### PR TITLE
feat: Tap + LongPress impl PrimaryPointer trait hierarchy (U16 + U17)

### DIFF
--- a/crates/flui-interaction/src/recognizers/long_press.rs
+++ b/crates/flui-interaction/src/recognizers/long_press.rs
@@ -512,6 +512,61 @@ impl GestureRecognizer for LongPressGestureRecognizer {
     }
 }
 
+// =============================================================================
+// Canonical trait hierarchy adoption (U17)
+// =============================================================================
+//
+// Flutter parity: `long_press.dart:262 LongPressGestureRecognizer extends
+// PrimaryPointerGestureRecognizer`.
+
+impl crate::recognizers::OneSequenceGestureRecognizer for LongPressGestureRecognizer {
+    fn tracked_pointers(&self) -> Vec<PointerId> {
+        self.state
+            .primary_pointer()
+            .map(|p| vec![p])
+            .unwrap_or_default()
+    }
+
+    fn resolve_pointer(&self, _pointer: PointerId, disposition: crate::arena::GestureDisposition) {
+        match disposition {
+            crate::arena::GestureDisposition::Accepted => {
+                // No-op — long-press callbacks fire from timer/up handlers,
+                // not from arena resolution. accept_gesture below mirrors.
+            }
+            crate::arena::GestureDisposition::Rejected => {
+                self.state.reject();
+            }
+        }
+    }
+
+    fn stop_tracking_pointer(&self, _pointer: PointerId) {
+        self.state.stop_tracking();
+    }
+}
+
+impl crate::recognizers::PrimaryPointerGestureRecognizer for LongPressGestureRecognizer {
+    fn initial_position(&self) -> Option<Offset<Pixels>> {
+        self.state.initial_position()
+    }
+
+    fn deadline(&self) -> Option<std::time::Duration> {
+        // LongPress has a pre-acceptance deadline from settings.
+        Some(self.settings.lock().long_press_timeout())
+    }
+
+    fn did_exceed_deadline(&self) {
+        // LongPress accepts on deadline (opposite of default Reject) —
+        // Flutter parity at long_press.dart::didExceedDeadline calls
+        // resolve(GestureDisposition.accepted).
+        use crate::recognizers::OneSequenceGestureRecognizer;
+        self.resolve(crate::arena::GestureDisposition::Accepted);
+    }
+
+    fn handle_primary_pointer(&self, event: &PointerEvent) {
+        <Self as GestureRecognizer>::handle_event(self, event);
+    }
+}
+
 impl GestureArenaMember for LongPressGestureRecognizer {
     fn accept_gesture(&self, _pointer: PointerId) {
         // We won the arena - gesture is accepted

--- a/crates/flui-interaction/src/recognizers/one_sequence.rs
+++ b/crates/flui-interaction/src/recognizers/one_sequence.rs
@@ -13,8 +13,7 @@
 //! shaped, sealed canonical trait ready for the migration wave.
 
 use crate::{
-    arena::GestureDisposition, events::PointerEvent, ids::PointerId,
-    recognizers::recognizer::GestureRecognizer,
+    arena::GestureDisposition, ids::PointerId, recognizers::recognizer::GestureRecognizer,
     sealed::gesture_recognizer::Sealed as GestureRecognizerSealed,
 };
 
@@ -30,10 +29,9 @@ pub trait OneSequenceGestureRecognizer: GestureRecognizer + GestureRecognizerSea
     /// Flutter parity: `recognizer.dart:415 _trackedPointers: Set<int>`.
     fn tracked_pointers(&self) -> Vec<PointerId>;
 
-    /// Handle a single pointer event for one of the tracked pointers.
-    ///
-    /// Flutter parity: `recognizer.dart:445 @protected void handleEvent(PointerEvent event)`.
-    fn handle_event(&self, event: &PointerEvent);
+    // `handle_event` inherited from the supertrait `GestureRecognizer`; one
+    // concrete impl satisfies both contracts. Flutter parity:
+    // `recognizer.dart:445 @protected void handleEvent(PointerEvent event)`.
 
     /// Resolve this recognizer's arena entries with the given disposition.
     ///

--- a/crates/flui-interaction/src/recognizers/primary_pointer.rs
+++ b/crates/flui-interaction/src/recognizers/primary_pointer.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use flui_types::{Offset, geometry::Pixels};
 
 use crate::{
-    ids::PointerId, recognizers::one_sequence::OneSequenceGestureRecognizer,
+    recognizers::one_sequence::OneSequenceGestureRecognizer,
     sealed::gesture_recognizer::Sealed as GestureRecognizerSealed,
 };
 
@@ -27,9 +27,6 @@ use crate::{
 pub trait PrimaryPointerGestureRecognizer:
     OneSequenceGestureRecognizer + GestureRecognizerSealed
 {
-    /// The pointer ID currently being tracked as primary, if any.
-    fn primary_pointer(&self) -> Option<PointerId>;
-
     /// The position of the primary pointer at down event.
     fn initial_position(&self) -> Option<Offset<Pixels>>;
 

--- a/crates/flui-interaction/src/recognizers/tap.rs
+++ b/crates/flui-interaction/src/recognizers/tap.rs
@@ -401,6 +401,51 @@ impl GestureRecognizer for TapGestureRecognizer {
     }
 }
 
+// =============================================================================
+// Canonical trait hierarchy adoption (U16)
+// =============================================================================
+//
+// Flutter parity: `tap.dart:202 BaseTapGestureRecognizer extends
+// PrimaryPointerGestureRecognizer`. The PR #85 / U13 trait infrastructure
+// at one_sequence.rs + primary_pointer.rs is now implemented for Tap.
+
+impl crate::recognizers::OneSequenceGestureRecognizer for TapGestureRecognizer {
+    fn tracked_pointers(&self) -> Vec<PointerId> {
+        self.state
+            .primary_pointer()
+            .map(|p| vec![p])
+            .unwrap_or_default()
+    }
+
+    fn resolve_pointer(&self, _pointer: PointerId, disposition: crate::arena::GestureDisposition) {
+        match disposition {
+            crate::arena::GestureDisposition::Accepted => {
+                // Arena accepted us — same path as accept_gesture below.
+                *self.accepted.lock() = Some(true);
+            }
+            crate::arena::GestureDisposition::Rejected => {
+                self.state.reject();
+            }
+        }
+    }
+
+    fn stop_tracking_pointer(&self, _pointer: PointerId) {
+        self.state.stop_tracking();
+    }
+}
+
+impl crate::recognizers::PrimaryPointerGestureRecognizer for TapGestureRecognizer {
+    fn initial_position(&self) -> Option<Offset<Pixels>> {
+        self.state.initial_position()
+    }
+
+    fn handle_primary_pointer(&self, event: &PointerEvent) {
+        // Tap dispatches all primary-pointer events through handle_event;
+        // delegate via the supertrait method.
+        <Self as GestureRecognizer>::handle_event(self, event);
+    }
+}
+
 impl GestureArenaMember for TapGestureRecognizer {
     fn accept_gesture(&self, _pointer: PointerId) {
         // PR #87 review fix (P1): do NOT invoke user callbacks here. The

--- a/crates/flui-interaction/src/sealed.rs
+++ b/crates/flui-interaction/src/sealed.rs
@@ -179,6 +179,20 @@ pub mod hit_testable {
 /// [`CustomGestureRecognizer`].
 pub mod gesture_recognizer {
     pub trait Sealed {}
+
+    // Blanket impl: any CustomGestureRecognizer automatically gets Sealed
+    impl<T: super::CustomGestureRecognizer> Sealed for T {}
+
+    // Built-in gesture recognizers — same impl list as arena_member::Sealed
+    // below. Required so `impl OneSequenceGestureRecognizer for X`
+    // (which has `: Sealed` supertrait bound) compiles for these types.
+    impl Sealed for crate::recognizers::TapGestureRecognizer {}
+    impl Sealed for crate::recognizers::DoubleTapGestureRecognizer {}
+    impl Sealed for crate::recognizers::LongPressGestureRecognizer {}
+    impl Sealed for crate::recognizers::DragGestureRecognizer {}
+    impl Sealed for crate::recognizers::ScaleGestureRecognizer {}
+    impl Sealed for crate::recognizers::MultiTapGestureRecognizer {}
+    impl Sealed for crate::recognizers::ForcePressGestureRecognizer {}
 }
 
 /// Sealed trait for arena members.


### PR DESCRIPTION
## Summary

Wave 4 continuation. Tap (U16) + LongPress (U17) adopt the canonical Flutter `PrimaryPointerGestureRecognizer` / `OneSequenceGestureRecognizer` trait hierarchy landed as infrastructure in [#85](https://github.com/vanyastaff/flui/pull/85) U13.

## Units landed

| Commit | Unit | Description |
|---|---|---|
| `78cdb7cc` | infra | Trait infra prep — removed redundant handle_event/primary_pointer from OneSequence/PrimaryPointer (already required by GestureRecognizer supertrait, was causing ambiguous-method errors on concrete impls). Added `gesture_recognizer::Sealed` impl blocks for the 7 concrete recognizer types. |
| `a4158382` | U16 | Tap: impl OneSequenceGestureRecognizer + impl PrimaryPointerGestureRecognizer. Flutter parity tap.dart:202. Runtime behavior unchanged (PR #87 + #90 arena-gated callback firing preserved). |
| `98b61833` | U17 | LongPress: same trait pair adoption. Key distinction from Tap: `deadline()` returns `Some(settings.long_press_timeout())` + `did_exceed_deadline()` overrides default Reject with Accepted (Flutter parity long_press.dart::didExceedDeadline). |

## Architectural notes

- **No behavioral change** — trait impls are surface-level wiring exposing existing recognizers through the canonical Flutter trait hierarchy. Future generic gesture-handling code (e.g. flui-widgets when materialized) can target `dyn PrimaryPointerGestureRecognizer` without recognizer-specific knowledge.
- **Method disambiguation**: `handle_primary_pointer` delegates to base `GestureRecognizer::handle_event` via explicit supertrait path `<Self as GestureRecognizer>::handle_event(self, event)`.
- **Reusable pattern**: same shape applicable to remaining recognizer migrations (U18 Drag / U19 Scale / U20 ForcePress to OneSequence; U21 DoubleTap / U22 MultiTap to base GestureRecognizer direct).

## Deferred (remaining wave 4)

- U18 Drag → OneSequence (Flutter monodrag.dart:81)
- U19 Scale → OneSequence (Flutter scale.dart:345)
- U20 ForcePress → OneSequence (Flutter force_press.dart:117)
- U21 DoubleTap → GestureRecognizer base (Flutter multitap.dart)
- U22 MultiTap → GestureRecognizer base (Flutter multitap.dart)

## Verification at HEAD `98b61833`

- `cargo build --workspace --all-targets`: ✅ clean
- `cargo clippy --workspace --all-targets -- -D warnings`: ✅ clean
- `cargo test -p flui-interaction --lib`: ✅ 247 passed
- `bash scripts/port-check.sh -v`: ✅ 7/7 clean

## Predecessor

PR [#90](https://github.com/vanyastaff/flui/pull/90) (`1e45181d` PR #85-#89 review followups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)