### PR TITLE
feat: Drag + Scale + ForcePress impl OneSequence (U18 + U19 + U20)

### DIFF
--- a/crates/flui-interaction/src/recognizers/drag.rs
+++ b/crates/flui-interaction/src/recognizers/drag.rs
@@ -517,6 +517,40 @@ impl GestureRecognizer for DragGestureRecognizer {
     }
 }
 
+// =============================================================================
+// Canonical trait hierarchy adoption (U18)
+// =============================================================================
+//
+// Flutter parity: `monodrag.dart:81 sealed class DragGestureRecognizer
+// extends OneSequenceGestureRecognizer`. Drag is OneSequence (NOT
+// PrimaryPointer) — it tracks a single sequence but doesn't have the
+// pre-acceptance deadline semantics of PrimaryPointer recognizers.
+
+impl crate::recognizers::OneSequenceGestureRecognizer for DragGestureRecognizer {
+    fn tracked_pointers(&self) -> Vec<PointerId> {
+        self.state
+            .primary_pointer()
+            .map(|p| vec![p])
+            .unwrap_or_default()
+    }
+
+    fn resolve_pointer(&self, _pointer: PointerId, disposition: crate::arena::GestureDisposition) {
+        match disposition {
+            crate::arena::GestureDisposition::Accepted => {
+                // No-op — Drag callbacks fire from event handlers, not arena
+                // resolution. accept_gesture below mirrors.
+            }
+            crate::arena::GestureDisposition::Rejected => {
+                self.state.reject();
+            }
+        }
+    }
+
+    fn stop_tracking_pointer(&self, _pointer: PointerId) {
+        self.state.stop_tracking();
+    }
+}
+
 impl GestureArenaMember for DragGestureRecognizer {
     fn accept_gesture(&self, _pointer: PointerId) {
         // We won the arena - gesture is accepted

--- a/crates/flui-interaction/src/recognizers/force_press.rs
+++ b/crates/flui-interaction/src/recognizers/force_press.rs
@@ -503,6 +503,38 @@ impl GestureRecognizer for ForcePressGestureRecognizer {
     }
 }
 
+// =============================================================================
+// Canonical trait hierarchy adoption (U20)
+// =============================================================================
+//
+// Flutter parity: `force_press.dart:117 ForcePressGestureRecognizer extends
+// OneSequenceGestureRecognizer`.
+
+impl crate::recognizers::OneSequenceGestureRecognizer for ForcePressGestureRecognizer {
+    fn tracked_pointers(&self) -> Vec<PointerId> {
+        self.state
+            .primary_pointer()
+            .map(|p| vec![p])
+            .unwrap_or_default()
+    }
+
+    fn resolve_pointer(&self, _pointer: PointerId, disposition: crate::arena::GestureDisposition) {
+        match disposition {
+            crate::arena::GestureDisposition::Accepted => {
+                // No-op — ForcePress callbacks fire from event handlers
+                // (pressure threshold detection).
+            }
+            crate::arena::GestureDisposition::Rejected => {
+                self.state.reject();
+            }
+        }
+    }
+
+    fn stop_tracking_pointer(&self, _pointer: PointerId) {
+        self.state.stop_tracking();
+    }
+}
+
 impl GestureArenaMember for ForcePressGestureRecognizer {
     fn accept_gesture(&self, _pointer: PointerId) {
         // We won the arena - gesture is accepted

--- a/crates/flui-interaction/src/recognizers/scale.rs
+++ b/crates/flui-interaction/src/recognizers/scale.rs
@@ -624,6 +624,42 @@ impl GestureRecognizer for ScaleGestureRecognizer {
     }
 }
 
+// =============================================================================
+// Canonical trait hierarchy adoption (U19)
+// =============================================================================
+//
+// Flutter parity: `scale.dart:345 ScaleGestureRecognizer extends
+// OneSequenceGestureRecognizer`. Scale tracks multiple pointers (2+
+// for pinch) but resolves as a single sequence in the arena.
+
+impl crate::recognizers::OneSequenceGestureRecognizer for ScaleGestureRecognizer {
+    fn tracked_pointers(&self) -> Vec<PointerId> {
+        // Scale's RecognizerBase only tracks the primary pointer; richer
+        // multi-pointer tracking lives on ScaleGestureRecognizer's own
+        // internal state. Return what RecognizerBase knows for the canonical
+        // single-pointer arena protocol.
+        self.state
+            .primary_pointer()
+            .map(|p| vec![p])
+            .unwrap_or_default()
+    }
+
+    fn resolve_pointer(&self, _pointer: PointerId, disposition: crate::arena::GestureDisposition) {
+        match disposition {
+            crate::arena::GestureDisposition::Accepted => {
+                // No-op — Scale callbacks fire from event handlers.
+            }
+            crate::arena::GestureDisposition::Rejected => {
+                self.state.reject();
+            }
+        }
+    }
+
+    fn stop_tracking_pointer(&self, _pointer: PointerId) {
+        self.state.stop_tracking();
+    }
+}
+
 impl GestureArenaMember for ScaleGestureRecognizer {
     fn accept_gesture(&self, _pointer: PointerId) {
         // We won the arena - gesture is accepted


### PR DESCRIPTION
## Summary

Wave 4 continuation. Drag (U18) + Scale (U19) + ForcePress (U20) adopt canonical Flutter `OneSequenceGestureRecognizer` trait. Three concrete recognizers, three atomic commits, same shape pattern.

## Units landed

| Commit | Unit | Flutter parity | Description |
|---|---|---|---|
| `55033a98` | U18 Drag | `monodrag.dart:81` | sealed DragGestureRecognizer extends OneSequenceGestureRecognizer |
| `676f3950` | U19 Scale | `scale.dart:345` | Multi-pointer pinch; canonical single-arena sequence |
| `2f665bee` | U20 ForcePress | `force_press.dart:117` | Pressure-threshold detection in event handlers |

## Pattern

All three follow identical structure (from PR #91 Tap/LongPress establishment):
- `tracked_pointers()` returns RecognizerBase's primary-pointer Vec
- `resolve_pointer(Accepted)`: no-op (callbacks fire from event handlers)
- `resolve_pointer(Rejected)`: `state.reject()`
- `stop_tracking_pointer`: delegates to `state.stop_tracking()`

OneSequence-only (no PrimaryPointer impl) — these recognizers don't have pre-acceptance deadline semantics.

## Runtime behavior

No change. Trait impls expose existing recognizers через canonical Flutter hierarchy.

## Deferred (remaining Wave 4)

- U21 DoubleTap → GestureRecognizer base
- U22 MultiTap → GestureRecognizer base

(Both already impl GestureRecognizer directly per Flutter `multitap.dart` shape; "migration" is documentation/sealed-Layer cleanup only.)

## Verification at HEAD `2f665bee`

- `cargo build --workspace --all-targets`: ✅ clean
- `cargo clippy --workspace --all-targets -- -D warnings`: ✅ clean
- `cargo test -p flui-interaction --lib`: ✅ 247 passed
- `bash scripts/port-check.sh -v`: ✅ 7/7 clean

## Predecessor

PR [#91](https://github.com/vanyastaff/flui/pull/91) (`ae1bee0b` Tap + LongPress impl PrimaryPointer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)