### PR TITLE
feat: testing feature-gate (U29) — testing/ submodule + compat layer behind Cargo feature

### DIFF
--- a/crates/flui-interaction/Cargo.toml
+++ b/crates/flui-interaction/Cargo.toml
@@ -44,5 +44,12 @@ tokio = { workspace = true, features = ["full"] }
 [features]
 default = []
 
+# Gates the `testing/` submodule (gesture recording, replay, builders)
+# plus `PointerEventData` / `PointerEventKind` / `make_*_event` compat
+# helpers from `events.rs`. Off by default — opt in via dev-dependencies
+# or downstream `flui-interaction = { features = ["testing"] }`.
+# Auto-enabled in test builds via `cfg(any(test, feature = "testing"))`.
+testing = []
+
 # Serialization support (if needed in the future)
 serde = ["flui-types/serde"]

--- a/crates/flui-interaction/src/events.rs
+++ b/crates/flui-interaction/src/events.rs
@@ -124,13 +124,22 @@ pub enum Event {
 }
 
 // ============================================================================
-// Compatibility PointerEventData struct
+// Compatibility PointerEventData struct (testing-only)
 // ============================================================================
+//
+// U29: PointerEventData + PointerEventKind + make_*_event helpers are
+// gated behind `#[cfg(any(test, feature = "testing"))]`. Pre-U29 they
+// shipped in release binaries; only the testing/ submodule and the
+// in-crate test modules consume them. Gating eliminates the legacy
+// compat surface from release builds without forcing call-site
+// migration in the testing module.
 
-/// Base pointer event data for gesture recognition.
+/// Base pointer event data for gesture recognition (test-only).
 ///
 /// This struct provides compatibility with legacy gesture recognizers
-/// while wrapping W3C-compliant ui-events underneath.
+/// while wrapping W3C-compliant ui-events underneath. Available only
+/// under `#[cfg(any(test, feature = "testing"))]`.
+#[cfg(any(test, feature = "testing"))]
 #[derive(Debug, Clone)]
 pub struct PointerEventData {
     /// Position in global coordinates
@@ -149,6 +158,7 @@ pub struct PointerEventData {
     pub time_stamp: u64,
 }
 
+#[cfg(any(test, feature = "testing"))]
 impl PointerEventData {
     /// Create new pointer event data
     pub fn new(position: Offset<Pixels>, device_kind: PointerType) -> Self {
@@ -509,10 +519,16 @@ impl From<&PointerScrollEvent> for ScrollEventData {
 }
 
 // ============================================================================
-// Test helper functions
+// Test helper functions — gated behind `testing` feature
 // ============================================================================
+//
+// U29: these `make_*_event` helpers + `PointerEventData` / `PointerEventKind`
+// only compile in test builds or when the `testing` Cargo feature is
+// active. Removes ~480 LOC of legacy compat construction surface from
+// release binaries.
 
 /// Create a PointerEvent::Down for testing
+#[cfg(any(test, feature = "testing"))]
 pub fn make_down_event(position: Offset<Pixels>, pointer_type: PointerType) -> PointerEvent {
     use ui_events::pointer::{
         ContactGeometry, PointerButtonEvent, PointerOrientation, PointerState,
@@ -546,6 +562,7 @@ pub fn make_down_event(position: Offset<Pixels>, pointer_type: PointerType) -> P
     })
 }
 
+#[cfg(any(test, feature = "testing"))]
 /// Create a PointerEvent::Up for testing
 pub fn make_up_event(position: Offset<Pixels>, pointer_type: PointerType) -> PointerEvent {
     use ui_events::pointer::{
@@ -580,6 +597,7 @@ pub fn make_up_event(position: Offset<Pixels>, pointer_type: PointerType) -> Poi
     })
 }
 
+#[cfg(any(test, feature = "testing"))]
 /// Create a PointerEvent::Move for testing
 pub fn make_move_event(position: Offset<Pixels>, pointer_type: PointerType) -> PointerEvent {
     use ui_events::pointer::{ContactGeometry, PointerOrientation, PointerState, PointerUpdate};
@@ -613,6 +631,7 @@ pub fn make_move_event(position: Offset<Pixels>, pointer_type: PointerType) -> P
     })
 }
 
+#[cfg(any(test, feature = "testing"))]
 /// Create a PointerEvent::Cancel for testing
 pub fn make_cancel_event(pointer_type: PointerType) -> PointerEvent {
     PointerEvent::Cancel(PointerInfo {
@@ -690,6 +709,7 @@ pub fn extract_pointer_id(event: &PointerEvent) -> crate::ids::PointerId {
     crate::ids::PointerId::new(raw_id)
 }
 
+#[cfg(any(test, feature = "testing"))]
 /// Kind of pointer event for event construction
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PointerEventKind {
@@ -703,6 +723,7 @@ pub enum PointerEventKind {
     Cancel,
 }
 
+#[cfg(any(test, feature = "testing"))]
 /// Create a PointerEvent from PointerEventData
 pub fn make_pointer_event(kind: PointerEventKind, data: PointerEventData) -> PointerEvent {
     use ui_events::pointer::{

--- a/crates/flui-interaction/src/lib.rs
+++ b/crates/flui-interaction/src/lib.rs
@@ -154,9 +154,10 @@ pub mod timer;
 pub mod processing;
 
 // ============================================================================
-// Testing utilities
+// Testing utilities — gated behind `testing` Cargo feature (U29)
 // ============================================================================
 
+#[cfg(any(test, feature = "testing"))]
 pub mod testing;
 
 // ============================================================================
@@ -232,8 +233,9 @@ pub use settings::{
 pub use signal_resolver::{PointerSignalResolver, SignalPriority};
 pub use team::{GestureArenaTeam, TeamEntry};
 // ============================================================================
-// Re-exports: Testing Utilities
+// Re-exports: Testing Utilities (U29 feature-gated)
 // ============================================================================
+#[cfg(any(test, feature = "testing"))]
 pub use testing::{
     GestureBuilder, GesturePlayer, GestureRecorder, GestureRecording, ModifiersBuilder,
     RecordedEvent, RecordedEventType,
@@ -279,7 +281,8 @@ pub mod prelude {
     };
     // Extension traits for custom types
     pub use crate::sealed::{CustomGestureRecognizer, CustomHitTestable};
-    // Testing
+    // Testing (U29 feature-gated)
+    #[cfg(any(test, feature = "testing"))]
     pub use crate::testing::{GestureBuilder, GesturePlayer, GestureRecorder};
     // Traits
     pub use crate::traits::{


### PR DESCRIPTION
## Summary

Plan unit U29 closes audit finding (testing-only `PointerEventData` compat layer + ~1,099-LOC `testing/` submodule shipped in release binaries).

## Unit landed

| Commit | Unit | Description |
|---|---|---|
| HEAD | U29 | Cargo feature `testing = []` non-default. Gates testing/ module + PointerEventData / PointerEventKind / make_*_event compat helpers via `#[cfg(any(test, feature = "testing"))]`. Auto-enabled в test builds (`cfg(test)`); downstream opt-in via `features = ["testing"]`. |

## What's gated

- `pub mod testing;` (entire 1,099-LOC submodule: recording / replay / builders / GesturePlayer / GestureRecorder / GestureBuilder / RecordedEvent / ModifiersBuilder)
- `PointerEventData` struct + impl block at events.rs (~120 LOC)
- `PointerEventKind` enum
- `make_pointer_event(kind, data)` factory
- `make_down_event` / `make_up_event` / `make_move_event` / `make_cancel_event` helpers (~250 LOC)
- Top-level + prelude re-exports of all above

## Cargo

```toml
[features]
default = []
testing = []
```

Downstream crates opt in:
```toml
[dev-dependencies]
flui-interaction = { path = "...", features = ["testing"] }
```

## Verification at HEAD

- `cargo build -p flui-interaction --no-default-features`: ✅ clean (release surface)
- `cargo build -p flui-interaction --features testing`: ✅ clean (test surface)
- `cargo build --workspace --all-targets`: ✅ clean
- `cargo clippy --workspace --all-targets -- -D warnings`: ✅ clean
- `cargo test -p flui-interaction --lib`: ✅ 247 passed
- `bash scripts/port-check.sh -v`: ✅ 7/7 clean

## Predecessor

PR [#92](https://github.com/vanyastaff/flui/pull/92) (`ff98ff4b` Drag + Scale + ForcePress OneSequence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)