### PR TITLE
feat(interaction)!: recognizer use-after-dispose debug asserts

### DIFF
--- a/crates/flui-interaction/src/recognizers/double_tap.rs
+++ b/crates/flui-interaction/src/recognizers/double_tap.rs
@@ -362,6 +362,9 @@ impl DoubleTapGestureRecognizer {
 
 impl GestureRecognizer for DoubleTapGestureRecognizer {
     fn add_pointer(&self, pointer: PointerId, position: Offset<Pixels>) {
+        if !self.state.assert_not_disposed("add_pointer") {
+            return;
+        }
         // Start tracking this pointer
         let recognizer = Arc::new(self.clone());
         self.state.start_tracking(pointer, position, &recognizer);
@@ -371,6 +374,9 @@ impl GestureRecognizer for DoubleTapGestureRecognizer {
     }
 
     fn handle_event(&self, event: &PointerEvent) {
+        if !self.state.assert_not_disposed("handle_event") {
+            return;
+        }
         // Only process if we're tracking a pointer
         if self.state.primary_pointer().is_none() {
             return;

--- a/crates/flui-interaction/src/recognizers/drag.rs
+++ b/crates/flui-interaction/src/recognizers/drag.rs
@@ -468,6 +468,9 @@ impl DragGestureRecognizer {
 
 impl GestureRecognizer for DragGestureRecognizer {
     fn add_pointer(&self, pointer: PointerId, position: Offset<Pixels>) {
+        if !self.state.assert_not_disposed("add_pointer") {
+            return;
+        }
         // Start tracking this pointer
         let recognizer = Arc::new(self.clone());
         self.state.start_tracking(pointer, position, &recognizer);
@@ -477,6 +480,9 @@ impl GestureRecognizer for DragGestureRecognizer {
     }
 
     fn handle_event(&self, event: &PointerEvent) {
+        if !self.state.assert_not_disposed("handle_event") {
+            return;
+        }
         // Only process if we're tracking a pointer
         if self.state.primary_pointer().is_none() {
             return;

--- a/crates/flui-interaction/src/recognizers/force_press.rs
+++ b/crates/flui-interaction/src/recognizers/force_press.rs
@@ -451,12 +451,18 @@ impl ForcePressGestureRecognizer {
 
 impl GestureRecognizer for ForcePressGestureRecognizer {
     fn add_pointer(&self, pointer: PointerId, position: Offset<Pixels>) {
+        if !self.state.assert_not_disposed("add_pointer") {
+            return;
+        }
         // Start tracking this pointer
         let recognizer = Arc::new(self.clone());
         self.state.start_tracking(pointer, position, &recognizer);
     }
 
     fn handle_event(&self, event: &PointerEvent) {
+        if !self.state.assert_not_disposed("handle_event") {
+            return;
+        }
         // Only process if we're tracking a pointer
         if self.state.primary_pointer().is_none() {
             return;

--- a/crates/flui-interaction/src/recognizers/long_press.rs
+++ b/crates/flui-interaction/src/recognizers/long_press.rs
@@ -456,6 +456,9 @@ impl LongPressGestureRecognizer {
 
 impl GestureRecognizer for LongPressGestureRecognizer {
     fn add_pointer(&self, pointer: PointerId, position: Offset<Pixels>) {
+        if !self.state.assert_not_disposed("add_pointer") {
+            return;
+        }
         // Start tracking this pointer
         let recognizer = Arc::new(self.clone());
         self.state.start_tracking(pointer, position, &recognizer);
@@ -465,6 +468,9 @@ impl GestureRecognizer for LongPressGestureRecognizer {
     }
 
     fn handle_event(&self, event: &PointerEvent) {
+        if !self.state.assert_not_disposed("handle_event") {
+            return;
+        }
         // Only process if we're tracking a pointer
         if self.state.primary_pointer().is_none() {
             return;

--- a/crates/flui-interaction/src/recognizers/multi_tap.rs
+++ b/crates/flui-interaction/src/recognizers/multi_tap.rs
@@ -423,6 +423,9 @@ impl MultiTapGestureRecognizer {
 
 impl GestureRecognizer for MultiTapGestureRecognizer {
     fn add_pointer(&self, pointer: PointerId, position: Offset<Pixels>) {
+        if !self.state.assert_not_disposed("add_pointer") {
+            return;
+        }
         // For the first pointer, track with arena
         if self.gesture_state.lock().pointers.is_empty() {
             let recognizer = Arc::new(self.clone());
@@ -433,6 +436,9 @@ impl GestureRecognizer for MultiTapGestureRecognizer {
     }
 
     fn handle_event(&self, event: &PointerEvent) {
+        if !self.state.assert_not_disposed("handle_event") {
+            return;
+        }
         match event {
             PointerEvent::Move(data) => {
                 // In a real implementation, we'd need to know which pointer this is

--- a/crates/flui-interaction/src/recognizers/recognizer.rs
+++ b/crates/flui-interaction/src/recognizers/recognizer.rs
@@ -123,6 +123,28 @@ impl RecognizerBase {
         *self.disposed.lock() = true;
     }
 
+    /// Debug-assert that the recognizer has not been disposed.
+    ///
+    /// Adopts the PR #84 `ChangeNotifier::dispose` lifecycle pattern at
+    /// [`crates/flui-foundation/src/notifier.rs`](../../crates/flui-foundation/src/notifier.rs)
+    /// — use-after-dispose triggers a `debug_assert!` panic in debug
+    /// builds + `tracing::warn!` + no-op semantics in release.
+    ///
+    /// Returns `true` if the recognizer is still live (call sites should
+    /// proceed); `false` if disposed (call sites should early-return).
+    #[inline]
+    pub fn assert_not_disposed(&self, op: &'static str) -> bool {
+        if self.is_disposed() {
+            debug_assert!(
+                false,
+                "Recognizer::{op} called after dispose (use-after-dispose)"
+            );
+            tracing::warn!(op, "Recognizer used after dispose");
+            return false;
+        }
+        true
+    }
+
     /// Start tracking a pointer
     ///
     /// Sets this as the primary pointer and stores initial position.

--- a/crates/flui-interaction/src/recognizers/scale.rs
+++ b/crates/flui-interaction/src/recognizers/scale.rs
@@ -574,6 +574,9 @@ impl ScaleGestureRecognizer {
 
 impl GestureRecognizer for ScaleGestureRecognizer {
     fn add_pointer(&self, pointer: PointerId, position: Offset<Pixels>) {
+        if !self.state.assert_not_disposed("add_pointer") {
+            return;
+        }
         // For the first pointer, track with arena
         if self.gesture_state.lock().pointers.is_empty() {
             let recognizer = Arc::new(self.clone());
@@ -584,6 +587,9 @@ impl GestureRecognizer for ScaleGestureRecognizer {
     }
 
     fn handle_event(&self, event: &PointerEvent) {
+        if !self.state.assert_not_disposed("handle_event") {
+            return;
+        }
         match event {
             PointerEvent::Move(data) => {
                 // We need to figure out which pointer this is

--- a/crates/flui-interaction/src/recognizers/tap.rs
+++ b/crates/flui-interaction/src/recognizers/tap.rs
@@ -334,6 +334,9 @@ impl TapGestureRecognizer {
 
 impl GestureRecognizer for TapGestureRecognizer {
     fn add_pointer(&self, pointer: PointerId, position: Offset<Pixels>) {
+        if !self.state.assert_not_disposed("add_pointer") {
+            return;
+        }
         // Reset accepted flag + pending_up for the new sequence (PR #87
         // review fix — flags from a prior gesture must not bleed into
         // the new one).
@@ -349,6 +352,9 @@ impl GestureRecognizer for TapGestureRecognizer {
     }
 
     fn handle_event(&self, event: &PointerEvent) {
+        if !self.state.assert_not_disposed("handle_event") {
+            return;
+        }
         // Only process if we're tracking a pointer
         if self.state.primary_pointer().is_none() {
             return;


### PR DESCRIPTION
## Summary

Audit-adjacent follow-up. Adopts the PR #84 `ChangeNotifier::dispose` use-after-dispose assertion pattern uniformly across all 7 concrete gesture recognizers' public entry points (add_pointer + handle_event = 14 sites).

## Changes

- **New** `RecognizerBase::assert_not_disposed(op: &'static str) -> bool` helper. Debug-assert + tracing::warn! + early-return false когда disposed.
- **Wired** на add_pointer + handle_event entry points в Tap / DoubleTap / LongPress / Drag / MultiTap / Scale / ForcePress.

## Aligns with workspace-wide pattern

Same lifecycle hygiene template now in:
- `ChangeNotifier::dispose` (PR #84 `eb95c2f2`)
- `Ticker::dispose` (PR #85 U10 `7d93611d`)
- `FocusManager::dispose` (post-PR #88 — set_active_scope warn-once via similar AtomicBool latch)
- Recognizer (this PR) — 14 entry-point sites

Use-after-dispose now produces:
- Debug builds: `debug_assert!` panic + recognizer context via op name
- Release builds: `tracing::warn!` + early-return no-op (no UB, diagnostic via tracing subscriber)

## Verification at HEAD

- `cargo build --workspace --all-targets`: ✅ clean
- `cargo clippy --workspace --all-targets -- -D warnings`: ✅ clean
- `cargo test -p flui-interaction --lib`: ✅ 247 passed
- `bash scripts/port-check.sh -v`: ✅ 7/7 clean

## Predecessor

PR [#93](https://github.com/vanyastaff/flui/pull/93) (`1b10b19b` U29 testing feature-gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)