### PR TITLE
refactor(interaction)!: widen PointerId to ui_events::pointer::PointerId (U9)

### DIFF
--- a/crates/flui-interaction/README.md
+++ b/crates/flui-interaction/README.md
@@ -331,12 +331,15 @@ let drag = GestureBuilder::drag(
 
 ## Type-Safe IDs
 
-Newtype pattern prevents mixing ID types:
+Newtype pattern prevents mixing ID types. `PointerId` is re-exported from
+the `ui-events` crate (W3C-compliant `NonZeroU64`); `FocusNodeId` and
+`HandlerId` are crate-local `NonZeroU64` newtypes.
 
 ```rust
 use flui_interaction::{PointerId, FocusNodeId, HandlerId};
 
-let pointer = PointerId::new(0);
+// Primary pointer convention (was: `PointerId::new(0)` pre-U9).
+let pointer = PointerId::PRIMARY;
 let focus = FocusNodeId::new(42);
 
 // fn process(id: PointerId) { ... }

--- a/crates/flui-interaction/src/arena.rs
+++ b/crates/flui-interaction/src/arena.rs
@@ -476,7 +476,7 @@ impl ArenaEntryData {
 /// use flui_interaction::arena::{GestureArena, GestureDisposition, PointerId};
 ///
 /// let arena = GestureArena::new();
-/// let pointer = PointerId::new(0);
+/// let pointer = PointerId::PRIMARY;
 ///
 /// // Add recognizers to arena - returns entry handle
 /// let tap_entry = arena.add(pointer, tap_recognizer);
@@ -859,7 +859,7 @@ impl GestureArena {
             }
 
             tracing::trace!(
-                pointer = pointer.get(),
+                ?pointer,
                 elapsed_ms = entry.elapsed().as_millis(),
                 member_count = entry.members.len(),
                 "Force resolving arena due to timeout"
@@ -974,7 +974,7 @@ mod tests {
     #[test]
     fn test_arena_single_member_wins() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
         let member = Arc::new(MockMember::new());
 
         let _entry = arena.add(pointer, member.clone());
@@ -987,7 +987,7 @@ mod tests {
     #[test]
     fn test_arena_entry_resolve_accepted() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member1 = Arc::new(MockMember::new());
         let member2 = Arc::new(MockMember::new());
@@ -1010,7 +1010,7 @@ mod tests {
     #[test]
     fn test_arena_entry_resolve_rejected() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member1 = Arc::new(MockMember::new());
         let member2 = Arc::new(MockMember::new());
@@ -1034,7 +1034,7 @@ mod tests {
     #[test]
     fn test_arena_resolve_with_winner() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member1 = Arc::new(MockMember::new());
         let member2 = Arc::new(MockMember::new());
@@ -1055,7 +1055,7 @@ mod tests {
     #[test]
     fn test_arena_hold_and_release() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
         let member = Arc::new(MockMember::new());
 
         arena.add(pointer, member.clone());
@@ -1075,7 +1075,7 @@ mod tests {
     #[test]
     fn test_arena_sweep() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
         let member = Arc::new(MockMember::new());
 
         arena.add(pointer, member.clone());
@@ -1093,7 +1093,7 @@ mod tests {
         let arena = GestureArena::new();
         assert!(arena.is_empty());
 
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
         let member = Arc::new(MockMember::new());
 
         arena.add(pointer, member);
@@ -1106,7 +1106,7 @@ mod tests {
     #[test]
     fn test_arena_member_count() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         assert_eq!(arena.member_count(pointer), 0);
 
@@ -1129,7 +1129,7 @@ mod tests {
     #[test]
     fn test_arena_resolve_team() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member1 = Arc::new(MockMember::new());
         let member2 = Arc::new(MockMember::new());
@@ -1154,7 +1154,7 @@ mod tests {
     #[test]
     fn test_arena_winners_empty_when_not_resolved() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         arena.add(pointer, Arc::new(MockMember::new()));
 
@@ -1174,7 +1174,7 @@ mod tests {
     #[test]
     fn test_arena_elapsed_returns_duration() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         // No arena yet
         assert!(arena.elapsed(pointer).is_none());
@@ -1190,7 +1190,7 @@ mod tests {
     #[test]
     fn test_arena_has_timed_out_false_initially() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         arena.add(pointer, Arc::new(MockMember::new()));
 
@@ -1202,7 +1202,7 @@ mod tests {
     #[test]
     fn test_arena_has_timed_out_with_zero_duration() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         arena.add(pointer, Arc::new(MockMember::new()));
 
@@ -1213,7 +1213,7 @@ mod tests {
     #[test]
     fn test_arena_has_timed_out_false_for_resolved() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member = Arc::new(MockMember::new());
         arena.add(pointer, member.clone());
@@ -1226,7 +1226,7 @@ mod tests {
     #[test]
     fn test_force_resolve_if_timed_out() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member = Arc::new(MockMember::new());
         arena.add(pointer, member.clone());
@@ -1242,7 +1242,7 @@ mod tests {
     #[test]
     fn test_force_resolve_first_member_wins() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member1 = Arc::new(MockMember::new());
         let member2 = Arc::new(MockMember::new());
@@ -1264,7 +1264,7 @@ mod tests {
     #[test]
     fn test_force_resolve_does_nothing_if_held() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member = Arc::new(MockMember::new());
         arena.add(pointer, member.clone());
@@ -1281,7 +1281,7 @@ mod tests {
     #[test]
     fn test_force_resolve_does_nothing_if_already_resolved() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member = Arc::new(MockMember::new());
         arena.add(pointer, member.clone());
@@ -1295,7 +1295,7 @@ mod tests {
     #[test]
     fn test_force_resolve_does_nothing_if_not_timed_out() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member = Arc::new(MockMember::new());
         arena.add(pointer, member.clone());
@@ -1311,9 +1311,9 @@ mod tests {
     fn test_resolve_timed_out_arenas() {
         let arena = GestureArena::new();
 
-        let pointer1 = PointerId::new(0);
-        let pointer2 = PointerId::new(1);
-        let pointer3 = PointerId::new(2);
+        let pointer1 = PointerId::PRIMARY;
+        let pointer2 = PointerId::new(2).expect("nonzero pointer id");
+        let pointer3 = PointerId::new(3).expect("nonzero pointer id");
 
         let member1 = Arc::new(MockMember::new());
         let member2 = Arc::new(MockMember::new());
@@ -1346,7 +1346,7 @@ mod tests {
     #[test]
     fn test_resolve_default_timed_out_arenas() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         arena.add(pointer, Arc::new(MockMember::new()));
 
@@ -1358,7 +1358,7 @@ mod tests {
     #[test]
     fn test_force_resolve_with_no_members() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         // Create empty arena entry by adding and then we test empty case
         // Note: We need to create an arena entry first
@@ -1372,7 +1372,7 @@ mod tests {
     #[test]
     fn test_force_resolve_if_default_timeout() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member = Arc::new(MockMember::new());
         arena.add(pointer, member.clone());
@@ -1390,7 +1390,7 @@ mod tests {
     #[test]
     fn test_eager_winner_wins_on_close() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member1 = Arc::new(MockMember::new());
         let member2 = Arc::new(MockMember::new());
@@ -1414,7 +1414,7 @@ mod tests {
     #[test]
     fn test_first_eager_winner_wins() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member1 = Arc::new(MockMember::new());
         let member2 = Arc::new(MockMember::new());
@@ -1435,7 +1435,7 @@ mod tests {
     #[test]
     fn test_accept_after_close_resolves_immediately() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member1 = Arc::new(MockMember::new());
         let member2 = Arc::new(MockMember::new());
@@ -1459,7 +1459,7 @@ mod tests {
     #[test]
     fn test_reject_removes_eager_winner() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member1 = Arc::new(MockMember::new());
         let member2 = Arc::new(MockMember::new());
@@ -1484,7 +1484,7 @@ mod tests {
     #[test]
     fn test_is_open_false_after_close() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member = Arc::new(MockMember::new());
         arena.add(pointer, member);
@@ -1501,7 +1501,7 @@ mod tests {
     #[test]
     fn test_sweep_deferred_when_held() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member = Arc::new(MockMember::new());
         arena.add(pointer, member.clone());
@@ -1520,7 +1520,7 @@ mod tests {
     #[test]
     fn test_sweep_immediate_when_not_held() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member = Arc::new(MockMember::new());
         arena.add(pointer, member.clone());
@@ -1534,7 +1534,7 @@ mod tests {
     #[test]
     fn test_pending_sweep_cleared_on_release() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member = Arc::new(MockMember::new());
         arena.add(pointer, member);
@@ -1551,7 +1551,7 @@ mod tests {
     #[test]
     fn test_release_closes_arena_if_open() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member = Arc::new(MockMember::new());
         arena.add(pointer, member.clone());
@@ -1575,7 +1575,7 @@ mod tests {
     #[test]
     fn test_entry_pointer_accessor() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(42);
+        let pointer = PointerId::new(43).expect("nonzero pointer id");
         let member = Arc::new(MockMember::new());
 
         let entry = arena.add(pointer, member);
@@ -1586,7 +1586,7 @@ mod tests {
     #[test]
     fn test_entry_member_accessor() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
         let member = Arc::new(MockMember::new());
         let member_dyn: Arc<dyn GestureArenaMember> = member.clone();
 
@@ -1598,7 +1598,7 @@ mod tests {
     #[test]
     fn test_entry_debug_impl() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(123);
+        let pointer = PointerId::new(124).expect("nonzero pointer id");
         let member = Arc::new(MockMember::new());
 
         let entry = arena.add(pointer, member);
@@ -1611,7 +1611,7 @@ mod tests {
     #[test]
     fn test_entry_resolve_multiple_times_is_safe() {
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member = Arc::new(MockMember::new());
         let entry = arena.add(pointer, member.clone());

--- a/crates/flui-interaction/src/binding.rs
+++ b/crates/flui-interaction/src/binding.rs
@@ -553,7 +553,7 @@ mod tests {
     #[test]
     fn test_hit_test_cache() {
         let binding = GestureBinding::new();
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let result = HitTestResult::new();
 
         binding.hit_tests.insert(pointer, result.clone());
@@ -570,15 +570,18 @@ mod tests {
     fn test_clear_all_hit_tests() {
         let binding = GestureBinding::new();
 
-        binding
-            .hit_tests
-            .insert(PointerId::new(1), HitTestResult::new());
-        binding
-            .hit_tests
-            .insert(PointerId::new(2), HitTestResult::new());
-        binding
-            .hit_tests
-            .insert(PointerId::new(3), HitTestResult::new());
+        binding.hit_tests.insert(
+            PointerId::new(2).expect("nonzero pointer id"),
+            HitTestResult::new(),
+        );
+        binding.hit_tests.insert(
+            PointerId::new(3).expect("nonzero pointer id"),
+            HitTestResult::new(),
+        );
+        binding.hit_tests.insert(
+            PointerId::new(4).expect("nonzero pointer id"),
+            HitTestResult::new(),
+        );
 
         assert_eq!(binding.active_pointer_count(), 3);
 

--- a/crates/flui-interaction/src/events.rs
+++ b/crates/flui-interaction/src/events.rs
@@ -235,15 +235,16 @@ impl PointerEventData {
             (Offset::ZERO, 0, PointerButtons::new())
         };
 
-        // Convert pointer ID: 0 for primary, hash for others
+        // Convert pointer ID into the legacy `device: i32` field.
+        // U9: ui_events PointerId carries `NonZeroU64`; clamp into the i32
+        // range used by the test-only `PointerEventData` compat surface.
+        // Primary pointer ⇒ 0 (preserves the pre-U9 mouse sentinel inside
+        // the testing layer); other pointers ⇒ low 31 bits of the
+        // NonZeroU64. Saturates on overflow (no platform produces
+        // pointer ids > i32::MAX in practice).
         let device = match info.pointer_id {
-            Some(id) if id.is_primary_pointer() => 0,
-            Some(id) => {
-                use std::hash::{Hash, Hasher};
-                let mut hasher = std::collections::hash_map::DefaultHasher::new();
-                id.hash(&mut hasher);
-                (hasher.finish() & 0x7FFFFFFF) as i32
-            }
+            Some(id) if id.is_primary_pointer() => 0_i32,
+            Some(id) => (id.get_inner().get() & 0x7FFF_FFFF) as i32,
             None => 0,
         };
 
@@ -329,23 +330,27 @@ impl InputEvent {
             InputEvent::DeviceAdded { device_id, .. } => Some(*device_id),
             InputEvent::DeviceRemoved { device_id } => Some(*device_id),
             InputEvent::Pointer(event) => {
-                // Extract pointer_id from the event
+                // Extract pointer_id from the event into the legacy
+                // `DeviceId = i32` surface. Primary pointer ⇒ 0;
+                // otherwise return the low 31 bits of the pointer id so
+                // that distinct pointers stay distinct DeviceIds.
+                //
+                // Pre-U9 this branch also folded `persistent_device_id`
+                // via `DefaultHasher` to produce a distinct DeviceId per
+                // physical device — that allocator-hitting hash ran on
+                // every hot-path event. Since `PersistentDeviceId`'s
+                // inner `NonZeroU64` is private and `pointer_id` already
+                // uniquely identifies the logical pointer for the legacy
+                // i32 surface, drop the hasher and lean on `pointer_id`
+                // directly. Callers needing physical-device stability
+                // should consume `PointerInfo::persistent_device_id`
+                // upstream rather than via this legacy DeviceId mapping.
                 let info = get_pointer_info(event)?;
-                // Use 0 for primary pointer, otherwise hash the persistent device ID
-                if info
-                    .pointer_id
-                    .map(|id| id.is_primary_pointer())
-                    .unwrap_or(true)
-                {
+                let id = info.pointer_id?;
+                if id.is_primary_pointer() {
                     Some(0)
-                } else if let Some(persistent_id) = info.persistent_device_id {
-                    // Use a simple hash of the persistent device ID
-                    use std::hash::{Hash, Hasher};
-                    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-                    persistent_id.hash(&mut hasher);
-                    Some((hasher.finish() & 0x7FFFFFFF) as DeviceId)
                 } else {
-                    Some(0)
+                    Some((id.get_inner().get() & 0x7FFF_FFFF) as DeviceId)
                 }
             }
             InputEvent::Keyboard(_) => None,
@@ -684,9 +689,20 @@ pub fn make_scroll_event(position: Offset<Pixels>, delta: Offset<Pixels>) -> Poi
 
 /// Extracts a stable `PointerId` from a `PointerEvent`.
 ///
-/// Returns `PointerId(0)` for the primary pointer, or a hashed ID for others.
-/// This is used by event routing, pointer routing, and raw input modules.
+/// Returns the event's `pointer_id` directly when present, falling back to
+/// [`PointerId::PRIMARY`] for events without a pointer id (e.g. virtual or
+/// uninitialised events). Used by event routing, pointer routing, and raw
+/// input modules as a single canonical extraction point.
+///
+/// Pre-U9 this fn allocated a fresh `DefaultHasher` on every event to fold
+/// the `NonZeroU64` id down into the local `PointerId(i32)`. After widening
+/// to `ui_events::pointer::PointerId` this is a zero-cost field load — the
+/// id is already in its canonical form.
+///
+/// Flutter parity: `gestures/binding.dart::_handlePointerEventImmediately`
+/// reads `event.pointer` directly with no transform.
 #[inline]
+#[must_use]
 pub fn extract_pointer_id(event: &PointerEvent) -> crate::ids::PointerId {
     let info = match event {
         PointerEvent::Down(e) => &e.pointer,
@@ -696,17 +712,7 @@ pub fn extract_pointer_id(event: &PointerEvent) -> crate::ids::PointerId {
         PointerEvent::Scroll(e) => &e.pointer,
         PointerEvent::Gesture(e) => &e.pointer,
     };
-    let raw_id = match info.pointer_id {
-        Some(p) if p.is_primary_pointer() => 0,
-        Some(p) => {
-            use std::hash::{Hash, Hasher};
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            p.hash(&mut hasher);
-            (hasher.finish() & 0x7FFFFFFF) as i32
-        }
-        None => 0,
-    };
-    crate::ids::PointerId::new(raw_id)
+    info.pointer_id.unwrap_or(crate::ids::PointerId::PRIMARY)
 }
 
 #[cfg(any(test, feature = "testing"))]

--- a/crates/flui-interaction/src/ids.rs
+++ b/crates/flui-interaction/src/ids.rs
@@ -1,100 +1,70 @@
-//! Type-safe identifiers using newtype pattern
+//! Type-safe identifiers used by the gesture/interaction subsystem.
 //!
-//! This module provides strongly-typed identifiers that prevent mixing up
-//! different ID types at compile time.
+//! # `PointerId` re-export
 //!
-//! # Features
+//! The canonical [`PointerId`] is **re-exported** from the `ui-events` crate
+//! (W3C-compliant pointer event types). Pre-U9 this crate carried a local
+//! `PointerId(i32)` newtype which:
 //!
-//! - **Type safety**: Cannot mix `PointerId` with `FocusNodeId`
-//! - **Zero-cost**: No runtime overhead (same size as underlying type)
-//! - **Niche optimization**: `Option<NonZeroId>` is same size as `Id`
-//! - **Debug/Display**: Nice formatting for debugging
+//! - Used `0` as the "mouse / primary pointer" sentinel.
+//! - Duplicated a per-event `DefaultHasher` allocation on every event in
+//!   `extract_pointer_id` to fit `ui_events::pointer::PointerId(NonZeroU64)`
+//!   back into a 32-bit `i32`.
+//! - Caused HashMap key collisions between two pointers that hashed to the
+//!   same 31-bit truncated value.
+//!
+//! Widening the local type to [`ui_events::pointer::PointerId`] (i.e.
+//! `NonZeroU64`) removes the lossy hash and aligns the gesture layer with
+//! the platform layer ([`flui-platform`](crate)) which already speaks
+//! `ui_events` directly.
+//!
+//! ## Constructor migration
+//!
+//! `ui_events::pointer::PointerId::new` is **fallible** — it returns
+//! `Option<PointerId>` because `0` is not a valid id (the inner type is
+//! `NonZeroU64`). Callers that previously wrote `PointerId::new(0)` must use
+//! [`PointerId::PRIMARY`] instead (the canonical primary pointer id, value
+//! `1`). Callers that previously wrote `PointerId::new(N)` for `N >= 1`
+//! should use `PointerId::new((N as u64) + 1).expect("nonzero pointer id")`
+//! — adding `1` keeps test pointers distinct from `PRIMARY`.
+//!
+//! Flutter parity: `gestures/events.dart::PointerEvent.pointer` is an
+//! unbounded `int`; `PointerId::PRIMARY` corresponds to Flutter's
+//! mouse/primary pointer convention.
+//!
+//! # Local IDs
+//!
+//! [`FocusNodeId`] and [`HandlerId`] remain local — they back their own
+//! crate-private slab/registry indexing and do not touch platform layers.
 //!
 //! # Example
 //!
 //! ```rust,ignore
 //! use flui_interaction::ids::{PointerId, FocusNodeId};
 //!
-//! let pointer = PointerId::new(1);
-//! let focus = FocusNodeId::new(42);
+//! // Primary pointer (was: `PointerId::new(0)` pre-U9).
+//! let mouse = PointerId::PRIMARY;
+//! // Second pointer in a multi-touch gesture.
+//! let touch1 = PointerId::new(2).expect("nonzero pointer id");
 //!
-//! // These are different types - cannot mix!
-//! // fn process(id: PointerId) { ... }
-//! // process(focus); // Compile error!
+//! assert_ne!(mouse, touch1);
+//!
+//! let focus = FocusNodeId::new(42);
+//! // PointerId and FocusNodeId are distinct types — cannot be mixed.
 //! ```
 
 use std::{fmt, num::NonZeroU64};
 
 // ============================================================================
-// PointerId - Identifier for pointer devices
+// PointerId — re-exported from ui-events (canonical W3C-compliant type)
 // ============================================================================
 
 /// Unique identifier for a pointer device (mouse, touch, stylus).
 ///
-/// Uses `i32` to match platform APIs (winit, etc.).
-///
-/// # Example
-///
-/// ```rust
-/// use flui_interaction::ids::PointerId;
-///
-/// let mouse = PointerId::new(0);
-/// let touch1 = PointerId::new(1);
-///
-/// assert_ne!(mouse, touch1);
-/// ```
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
-#[repr(transparent)]
-pub struct PointerId(i32);
-
-impl PointerId {
-    /// Creates a new pointer ID.
-    #[inline]
-    pub const fn new(id: i32) -> Self {
-        Self(id)
-    }
-
-    /// Returns the raw ID value.
-    #[inline]
-    pub const fn get(self) -> i32 {
-        self.0
-    }
-
-    /// Returns the raw ID value (alias for compatibility).
-    #[inline]
-    pub const fn raw(self) -> i32 {
-        self.0
-    }
-
-    /// Mouse pointer ID (typically 0).
-    pub const MOUSE: Self = Self(0);
-}
-
-impl fmt::Debug for PointerId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "PointerId({})", self.0)
-    }
-}
-
-impl fmt::Display for PointerId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "pointer:{}", self.0)
-    }
-}
-
-impl From<i32> for PointerId {
-    #[inline]
-    fn from(id: i32) -> Self {
-        Self::new(id)
-    }
-}
-
-impl From<PointerId> for i32 {
-    #[inline]
-    fn from(id: PointerId) -> Self {
-        id.0
-    }
-}
+/// Re-exported from [`ui_events::pointer::PointerId`]. See [the module
+/// documentation](self) for migration notes (the local pre-U9 `i32` newtype
+/// was widened to this `NonZeroU64`-backed type).
+pub use ui_events::pointer::PointerId;
 
 // ============================================================================
 // FocusNodeId - Identifier for focusable UI elements
@@ -261,12 +231,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_pointer_id() {
-        let id = PointerId::new(42);
-        assert_eq!(id.get(), 42);
-        assert_eq!(id.raw(), 42);
-        assert_eq!(format!("{:?}", id), "PointerId(42)");
-        assert_eq!(format!("{}", id), "pointer:42");
+    fn pointer_id_primary_matches_ui_events_primary() {
+        // The widened PointerId (re-exported from ui-events) carries
+        // PointerId::PRIMARY as its canonical "mouse / primary pointer"
+        // sentinel — replacing the pre-U9 `PointerId(0)` convention.
+        assert!(PointerId::PRIMARY.is_primary_pointer());
+        // PRIMARY is NonZeroU64::MIN (= 1).
+        assert_eq!(PointerId::PRIMARY.get_inner().get(), 1);
+    }
+
+    #[test]
+    fn pointer_id_new_distinct_from_primary() {
+        // New(2) — first non-primary pointer in the U9 mapping
+        // (old `PointerId::new(1)` → new `PointerId::new(2)`).
+        let p2 = PointerId::new(2).expect("nonzero pointer id");
+        assert_ne!(p2, PointerId::PRIMARY);
+        assert!(!p2.is_primary_pointer());
+    }
+
+    #[test]
+    fn pointer_id_new_zero_returns_none() {
+        // Sanity: u64=0 violates NonZeroU64, returns None.
+        assert!(PointerId::new(0).is_none());
     }
 
     #[test]
@@ -308,9 +294,9 @@ mod tests {
 
     #[test]
     fn test_pointer_id_equality() {
-        let a = PointerId::new(1);
-        let b = PointerId::new(1);
-        let c = PointerId::new(2);
+        let a = PointerId::new(1).expect("nonzero");
+        let b = PointerId::new(1).expect("nonzero");
+        let c = PointerId::new(2).expect("nonzero");
 
         assert_eq!(a, b);
         assert_ne!(a, c);
@@ -321,9 +307,9 @@ mod tests {
         use std::collections::HashSet;
 
         let mut set = HashSet::new();
-        set.insert(PointerId::new(1));
-        set.insert(PointerId::new(2));
-        set.insert(PointerId::new(1)); // duplicate
+        set.insert(PointerId::new(1).expect("nonzero"));
+        set.insert(PointerId::new(2).expect("nonzero"));
+        set.insert(PointerId::new(1).expect("nonzero")); // duplicate
 
         assert_eq!(set.len(), 2);
     }

--- a/crates/flui-interaction/src/lib.rs
+++ b/crates/flui-interaction/src/lib.rs
@@ -19,8 +19,10 @@
 //! - **Sealed traits**: `HitTestable` and `GestureArenaMember` cannot be
 //!   implemented outside this crate, allowing API evolution without breaking
 //!   changes
-//! - **Newtype pattern**: Type-safe IDs (`PointerId`, `FocusNodeId`,
-//!   `HandlerId`) prevent mixing up different ID types at compile time
+//! - **Canonical pointer id**: [`PointerId`] is re-exported from the
+//!   `ui-events` crate (`NonZeroU64`-backed). [`FocusNodeId`] and
+//!   [`HandlerId`] are crate-local `NonZeroU64` newtypes that prevent
+//!   mixing up different ID types at compile time
 //! - **Niche optimization**: `Option<FocusNodeId>` is the same size as
 //!   `FocusNodeId`
 //! - **Extension traits**: Add methods to `PointerEvent` without modifying the
@@ -84,7 +86,7 @@
 //! ```rust,ignore
 //! use flui_interaction::ids::{PointerId, FocusNodeId};
 //!
-//! let pointer = PointerId::new(0);
+//! let pointer = PointerId::PRIMARY;
 //! let focus = FocusNodeId::new(42);
 //!
 //! // These are different types - cannot mix!

--- a/crates/flui-interaction/src/processing/raw_input.rs
+++ b/crates/flui-interaction/src/processing/raw_input.rs
@@ -648,7 +648,7 @@ mod tests {
     fn test_pointer_position_query() {
         let handler = RawInputHandler::new();
 
-        assert!(handler.pointer_position(PointerId::new(0)).is_none());
+        assert!(handler.pointer_position(PointerId::PRIMARY).is_none());
 
         let down = make_down_event(
             Offset::new(Pixels(100.0), Pixels(200.0)),
@@ -656,7 +656,7 @@ mod tests {
         );
         handler.handle_event(&down);
 
-        let pos = handler.pointer_position(PointerId::new(0)).unwrap();
+        let pos = handler.pointer_position(PointerId::PRIMARY).unwrap();
         assert_eq!(pos, Offset::new(Pixels(100.0), Pixels(200.0)));
     }
 

--- a/crates/flui-interaction/src/processing/resampler.rs
+++ b/crates/flui-interaction/src/processing/resampler.rs
@@ -32,7 +32,7 @@
 //! use flui_interaction::ids::PointerId;
 //! use std::time::Duration;
 //!
-//! let mut resampler = PointerEventResampler::new(PointerId::new(0));
+//! let mut resampler = PointerEventResampler::new(PointerId::PRIMARY);
 //!
 //! // Add incoming events
 //! resampler.add_event(pointer_event);
@@ -150,7 +150,7 @@ impl PointerEventResampler {
             });
         } else {
             tracing::warn!(
-                pointer_id = inner.pointer_id.get(),
+                pointer_id = ?inner.pointer_id,
                 "Event queue full, dropping event"
             );
         }
@@ -299,17 +299,17 @@ mod tests {
 
     #[test]
     fn test_resampler_basic() {
-        let resampler = PointerEventResampler::new(PointerId::new(0));
+        let resampler = PointerEventResampler::new(PointerId::PRIMARY);
 
         assert!(!resampler.is_tracked());
         assert!(!resampler.is_down());
         assert!(!resampler.has_pending_events());
-        assert_eq!(resampler.pointer_id(), PointerId::new(0));
+        assert_eq!(resampler.pointer_id(), PointerId::PRIMARY);
     }
 
     #[test]
     fn test_add_event() {
-        let resampler = PointerEventResampler::new(PointerId::new(0));
+        let resampler = PointerEventResampler::new(PointerId::PRIMARY);
 
         let event = make_down_event(Offset::new(Pixels(10.0), Pixels(20.0)), PointerType::Mouse);
         resampler.add_event(event);
@@ -321,7 +321,7 @@ mod tests {
 
     #[test]
     fn test_sample_events() {
-        let resampler = PointerEventResampler::new(PointerId::new(0));
+        let resampler = PointerEventResampler::new(PointerId::PRIMARY);
 
         // Add down event
         let event = make_down_event(Offset::new(Pixels(10.0), Pixels(20.0)), PointerType::Mouse);
@@ -340,7 +340,7 @@ mod tests {
 
     #[test]
     fn test_stop_flushes_events() {
-        let resampler = PointerEventResampler::new(PointerId::new(0));
+        let resampler = PointerEventResampler::new(PointerId::PRIMARY);
 
         let down = make_down_event(Offset::new(Pixels(10.0), Pixels(20.0)), PointerType::Mouse);
         resampler.add_event(down);
@@ -360,7 +360,7 @@ mod tests {
 
     #[test]
     fn test_clear() {
-        let resampler = PointerEventResampler::new(PointerId::new(0));
+        let resampler = PointerEventResampler::new(PointerId::PRIMARY);
 
         let event = make_down_event(Offset::new(Pixels(10.0), Pixels(20.0)), PointerType::Mouse);
         resampler.add_event(event);

--- a/crates/flui-interaction/src/recognizers/double_tap.rs
+++ b/crates/flui-interaction/src/recognizers/double_tap.rs
@@ -467,7 +467,7 @@ mod tests {
                 *tapped_clone.lock() = true;
             });
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let position = Offset::new(px(100.0), px(100.0));
 
         // First tap
@@ -500,7 +500,7 @@ mod tests {
                 *tapped_clone.lock() = true;
             });
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let first_pos = Offset::new(px(100.0), px(100.0));
 
         // First tap
@@ -529,7 +529,7 @@ mod tests {
         let arena = GestureArena::new();
         let recognizer = DoubleTapGestureRecognizer::new(arena);
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let position = Offset::new(px(100.0), px(100.0));
 
         // First tap

--- a/crates/flui-interaction/src/recognizers/drag.rs
+++ b/crates/flui-interaction/src/recognizers/drag.rs
@@ -599,7 +599,7 @@ mod tests {
                 *updated_clone.lock() = true;
             });
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let start_pos = Offset::new(Pixels(100.0), Pixels(100.0));
 
         // Start tracking

--- a/crates/flui-interaction/src/recognizers/force_press.rs
+++ b/crates/flui-interaction/src/recognizers/force_press.rs
@@ -615,7 +615,7 @@ mod tests {
             *started_clone.lock() = true;
         });
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let position = Offset::new(Pixels(100.0), Pixels(100.0));
 
         // Start tracking
@@ -637,7 +637,7 @@ mod tests {
             *started_clone.lock() = true;
         });
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let position = Offset::new(Pixels(100.0), Pixels(100.0));
 
         // Start tracking
@@ -660,7 +660,7 @@ mod tests {
             *peaked_clone.lock() = true;
         });
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let position = Offset::new(Pixels(100.0), Pixels(100.0));
 
         // Start tracking
@@ -689,7 +689,7 @@ mod tests {
             *update_clone.lock() += 1;
         });
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let position = Offset::new(Pixels(100.0), Pixels(100.0));
 
         // Start tracking
@@ -715,7 +715,7 @@ mod tests {
             *ended_clone.lock() = true;
         });
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let position = Offset::new(Pixels(100.0), Pixels(100.0));
 
         // Start tracking

--- a/crates/flui-interaction/src/recognizers/long_press.rs
+++ b/crates/flui-interaction/src/recognizers/long_press.rs
@@ -626,7 +626,7 @@ mod tests {
                 *pressed_clone.lock() = true;
             });
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let position = Offset::new(Pixels(100.0), Pixels(100.0));
 
         // Start long press
@@ -662,7 +662,7 @@ mod tests {
                 *cancelled_clone.lock() = true;
             });
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let start_pos = Offset::new(Pixels(100.0), Pixels(100.0));
 
         // Start long press
@@ -692,7 +692,7 @@ mod tests {
                 *moved_clone.lock() = true;
             });
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let position = Offset::new(Pixels(100.0), Pixels(100.0));
 
         // Start long press

--- a/crates/flui-interaction/src/recognizers/multi_tap.rs
+++ b/crates/flui-interaction/src/recognizers/multi_tap.rs
@@ -527,8 +527,8 @@ mod tests {
                 *count_clone.lock() = details.pointer_count;
             });
 
-        let pointer1 = PointerId::new(1);
-        let pointer2 = PointerId::new(2);
+        let pointer1 = PointerId::new(2).expect("nonzero pointer id");
+        let pointer2 = PointerId::new(3).expect("nonzero pointer id");
 
         // Add two pointers
         recognizer.add_pointer(pointer1, Offset::new(Pixels(100.0), Pixels(100.0)));
@@ -565,9 +565,18 @@ mod tests {
             });
 
         // Add three pointers
-        recognizer.add_pointer(PointerId::new(1), Offset::new(Pixels(100.0), Pixels(100.0)));
-        recognizer.add_pointer(PointerId::new(2), Offset::new(Pixels(200.0), Pixels(100.0)));
-        recognizer.add_pointer(PointerId::new(3), Offset::new(Pixels(150.0), Pixels(200.0)));
+        recognizer.add_pointer(
+            PointerId::new(2).expect("nonzero pointer id"),
+            Offset::new(Pixels(100.0), Pixels(100.0)),
+        );
+        recognizer.add_pointer(
+            PointerId::new(3).expect("nonzero pointer id"),
+            Offset::new(Pixels(200.0), Pixels(100.0)),
+        );
+        recognizer.add_pointer(
+            PointerId::new(4).expect("nonzero pointer id"),
+            Offset::new(Pixels(150.0), Pixels(200.0)),
+        );
 
         // Verify waiting for up phase
         let state = recognizer.gesture_state.lock();
@@ -576,9 +585,18 @@ mod tests {
         drop(state);
 
         // Release all pointers
-        recognizer.handle_pointer_up(PointerId::new(1), PointerType::Touch);
-        recognizer.handle_pointer_up(PointerId::new(2), PointerType::Touch);
-        recognizer.handle_pointer_up(PointerId::new(3), PointerType::Touch);
+        recognizer.handle_pointer_up(
+            PointerId::new(2).expect("nonzero pointer id"),
+            PointerType::Touch,
+        );
+        recognizer.handle_pointer_up(
+            PointerId::new(3).expect("nonzero pointer id"),
+            PointerType::Touch,
+        );
+        recognizer.handle_pointer_up(
+            PointerId::new(4).expect("nonzero pointer id"),
+            PointerType::Touch,
+        );
 
         // Should have called callback
         assert!(*tapped.lock());
@@ -597,12 +615,24 @@ mod tests {
             });
 
         // Add two pointers at (0, 0) and (100, 0)
-        recognizer.add_pointer(PointerId::new(1), Offset::new(Pixels(0.0), Pixels(0.0)));
-        recognizer.add_pointer(PointerId::new(2), Offset::new(Pixels(100.0), Pixels(0.0)));
+        recognizer.add_pointer(
+            PointerId::new(2).expect("nonzero pointer id"),
+            Offset::new(Pixels(0.0), Pixels(0.0)),
+        );
+        recognizer.add_pointer(
+            PointerId::new(3).expect("nonzero pointer id"),
+            Offset::new(Pixels(100.0), Pixels(0.0)),
+        );
 
         // Release both
-        recognizer.handle_pointer_up(PointerId::new(1), PointerType::Touch);
-        recognizer.handle_pointer_up(PointerId::new(2), PointerType::Touch);
+        recognizer.handle_pointer_up(
+            PointerId::new(2).expect("nonzero pointer id"),
+            PointerType::Touch,
+        );
+        recognizer.handle_pointer_up(
+            PointerId::new(3).expect("nonzero pointer id"),
+            PointerType::Touch,
+        );
 
         // Center should be at (50, 0)
         let center = *center_pos.lock();
@@ -622,9 +652,18 @@ mod tests {
             });
 
         // Add three pointers (one too many)
-        recognizer.add_pointer(PointerId::new(1), Offset::new(Pixels(100.0), Pixels(100.0)));
-        recognizer.add_pointer(PointerId::new(2), Offset::new(Pixels(200.0), Pixels(100.0)));
-        recognizer.add_pointer(PointerId::new(3), Offset::new(Pixels(150.0), Pixels(200.0)));
+        recognizer.add_pointer(
+            PointerId::new(2).expect("nonzero pointer id"),
+            Offset::new(Pixels(100.0), Pixels(100.0)),
+        );
+        recognizer.add_pointer(
+            PointerId::new(3).expect("nonzero pointer id"),
+            Offset::new(Pixels(200.0), Pixels(100.0)),
+        );
+        recognizer.add_pointer(
+            PointerId::new(4).expect("nonzero pointer id"),
+            Offset::new(Pixels(150.0), Pixels(200.0)),
+        );
 
         // Should have cancelled
         assert!(*cancelled.lock());

--- a/crates/flui-interaction/src/recognizers/recognizer.rs
+++ b/crates/flui-interaction/src/recognizers/recognizer.rs
@@ -280,7 +280,7 @@ mod tests {
         let arena = GestureArena::new();
         let base = RecognizerBase::new(arena);
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let position = Offset::new(Pixels(100.0), Pixels(200.0));
 
         base.set_primary_pointer(Some(pointer));

--- a/crates/flui-interaction/src/recognizers/scale.rs
+++ b/crates/flui-interaction/src/recognizers/scale.rs
@@ -696,8 +696,14 @@ mod tests {
         let recognizer = ScaleGestureRecognizer::new(arena);
 
         let mut pointers = HashMap::new();
-        pointers.insert(PointerId::new(1), Offset::new(Pixels(0.0), Pixels(0.0)));
-        pointers.insert(PointerId::new(2), Offset::new(Pixels(100.0), Pixels(100.0)));
+        pointers.insert(
+            PointerId::new(2).expect("nonzero pointer id"),
+            Offset::new(Pixels(0.0), Pixels(0.0)),
+        );
+        pointers.insert(
+            PointerId::new(3).expect("nonzero pointer id"),
+            Offset::new(Pixels(100.0), Pixels(100.0)),
+        );
 
         let focal_point = recognizer.calculate_focal_point(&pointers);
 
@@ -712,8 +718,14 @@ mod tests {
         let recognizer = ScaleGestureRecognizer::new(arena);
 
         let mut pointers = HashMap::new();
-        pointers.insert(PointerId::new(1), Offset::new(Pixels(0.0), Pixels(0.0)));
-        pointers.insert(PointerId::new(2), Offset::new(Pixels(100.0), Pixels(0.0)));
+        pointers.insert(
+            PointerId::new(2).expect("nonzero pointer id"),
+            Offset::new(Pixels(0.0), Pixels(0.0)),
+        );
+        pointers.insert(
+            PointerId::new(3).expect("nonzero pointer id"),
+            Offset::new(Pixels(100.0), Pixels(0.0)),
+        );
 
         let (span, h_span, v_span) = recognizer.calculate_spans(&pointers);
 
@@ -729,8 +741,8 @@ mod tests {
         let arena = GestureArena::new();
         let recognizer = ScaleGestureRecognizer::new(arena);
 
-        let pointer1 = PointerId::new(1);
-        let pointer2 = PointerId::new(2);
+        let pointer1 = PointerId::new(2).expect("nonzero pointer id");
+        let pointer2 = PointerId::new(3).expect("nonzero pointer id");
 
         // Add two pointers 100px apart
         recognizer.add_pointer(pointer1, Offset::new(Pixels(0.0), Pixels(0.0)));

--- a/crates/flui-interaction/src/recognizers/tap.rs
+++ b/crates/flui-interaction/src/recognizers/tap.rs
@@ -502,7 +502,7 @@ mod tests {
             *tapped_clone.lock() = true;
         });
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let position = Offset::new(Pixels(100.0), Pixels(100.0));
 
         // Simulate tap: down -> up
@@ -530,7 +530,7 @@ mod tests {
                 *cancelled_clone.lock() = true;
             });
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let start_pos = Offset::new(Pixels(100.0), Pixels(100.0));
 
         // Start tap
@@ -558,7 +558,7 @@ mod tests {
             *tapped_clone.lock() = true;
         });
 
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
         let start_pos = Offset::new(Pixels(100.0), Pixels(100.0));
 
         // Start tap

--- a/crates/flui-interaction/src/routing/event_router.rs
+++ b/crates/flui-interaction/src/routing/event_router.rs
@@ -303,7 +303,7 @@ pub(crate) mod tests {
 
         // Add some state
         router.pointer_state.write().insert(
-            PointerId::new(0),
+            PointerId::PRIMARY,
             PointerStateTracking {
                 is_down: true,
                 last_position: Offset::new(Pixels(0.0), Pixels(0.0)),

--- a/crates/flui-interaction/src/routing/pointer_router.rs
+++ b/crates/flui-interaction/src/routing/pointer_router.rs
@@ -132,7 +132,7 @@ impl PointerRouter {
         let mut routes = self.routes.write();
         routes.entry(pointer).or_default().push(handler);
 
-        tracing::trace!(pointer = pointer.get(), "Added pointer route");
+        tracing::trace!(?pointer, "Added pointer route");
     }
 
     /// Remove a route handler for a specific pointer.
@@ -154,7 +154,7 @@ impl PointerRouter {
             }
 
             if removed {
-                tracing::trace!(pointer = pointer.get(), "Removed pointer route");
+                tracing::trace!(?pointer, "Removed pointer route");
             }
 
             removed
@@ -169,7 +169,7 @@ impl PointerRouter {
     pub fn remove_all_routes(&self, pointer: PointerId) {
         let mut routes = self.routes.write();
         if routes.remove(&pointer).is_some() {
-            tracing::trace!(pointer = pointer.get(), "Removed all routes for pointer");
+            tracing::trace!(?pointer, "Removed all routes for pointer");
         }
     }
 
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn test_add_route() {
         let router = PointerRouter::new();
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
 
         let handler = Arc::new(|_: &PointerEvent| {});
         router.add_route(pointer, handler);
@@ -326,7 +326,7 @@ mod tests {
     #[test]
     fn test_remove_route() {
         let router = PointerRouter::new();
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
 
         let handler: PointerRouteHandler = Arc::new(|_: &PointerEvent| {});
         router.add_route(pointer, handler.clone());
@@ -340,7 +340,7 @@ mod tests {
     #[test]
     fn test_multiple_handlers() {
         let router = PointerRouter::new();
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
 
         let handler1: PointerRouteHandler = Arc::new(|_: &PointerEvent| {});
         let handler2: PointerRouteHandler = Arc::new(|_: &PointerEvent| {});
@@ -357,7 +357,7 @@ mod tests {
     #[test]
     fn test_route_event() {
         let router = PointerRouter::new();
-        let pointer = PointerId::new(0); // PRIMARY pointer
+        let pointer = PointerId::PRIMARY; // PRIMARY pointer
 
         let call_count = Arc::new(AtomicUsize::new(0));
         let count_clone = call_count.clone();
@@ -377,7 +377,7 @@ mod tests {
     #[test]
     fn test_route_to_multiple_handlers() {
         let router = PointerRouter::new();
-        let pointer = PointerId::new(0); // PRIMARY pointer
+        let pointer = PointerId::PRIMARY; // PRIMARY pointer
 
         let call_count = Arc::new(AtomicUsize::new(0));
 
@@ -427,7 +427,7 @@ mod tests {
         // handlers first, then global handlers. Post-U25 (acab2929+) FLUI
         // matches this ordering — previously global fired first.
         let router = PointerRouter::new();
-        let pointer = PointerId::new(0); // PRIMARY pointer
+        let pointer = PointerId::PRIMARY; // PRIMARY pointer
 
         let order = Arc::new(Mutex::new(Vec::new()));
 
@@ -454,7 +454,7 @@ mod tests {
     #[test]
     fn test_remove_all_routes() {
         let router = PointerRouter::new();
-        let pointer = PointerId::new(1);
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
 
         let handler1 = Arc::new(|_: &PointerEvent| {});
         let handler2 = Arc::new(|_: &PointerEvent| {});
@@ -473,8 +473,11 @@ mod tests {
         let router = PointerRouter::new();
 
         let handler = Arc::new(|_: &PointerEvent| {});
-        router.add_route(PointerId::new(1), handler.clone());
-        router.add_route(PointerId::new(2), handler);
+        router.add_route(
+            PointerId::new(2).expect("nonzero pointer id"),
+            handler.clone(),
+        );
+        router.add_route(PointerId::new(3).expect("nonzero pointer id"), handler);
         router.add_global_handler(Arc::new(|_: &PointerEvent| {}));
 
         router.clear();
@@ -485,8 +488,8 @@ mod tests {
     #[test]
     fn test_wrong_pointer_not_called() {
         let router = PointerRouter::new();
-        let pointer1 = PointerId::new(1);
-        let pointer2 = PointerId::new(2);
+        let pointer1 = PointerId::new(2).expect("nonzero pointer id");
+        let pointer2 = PointerId::new(3).expect("nonzero pointer id");
 
         let called = Arc::new(AtomicUsize::new(0));
         let called_clone = called.clone();
@@ -519,7 +522,7 @@ mod tests {
     fn test_reentrancy_remove_self() {
         // Test that a handler can remove itself during dispatch
         let router = Arc::new(PointerRouter::new());
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let call_count = Arc::new(AtomicUsize::new(0));
         let count_clone = call_count.clone();
@@ -530,7 +533,7 @@ mod tests {
             // Remove self during dispatch - this should work without deadlock
             // Note: We can't easily remove self here because we don't have the handler Arc
             // But we can remove all routes which exercises the same code path
-            router_clone.remove_all_routes(PointerId::new(0));
+            router_clone.remove_all_routes(PointerId::PRIMARY);
         });
 
         router.add_route(pointer, handler);
@@ -546,7 +549,7 @@ mod tests {
     fn test_reentrancy_add_handler() {
         // Test that a handler can add new handlers during dispatch
         let router = Arc::new(PointerRouter::new());
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let second_called = Arc::new(AtomicUsize::new(0));
         let second_called_clone = second_called.clone();
@@ -558,7 +561,7 @@ mod tests {
             let new_handler: PointerRouteHandler = Arc::new(move |_: &PointerEvent| {
                 called.fetch_add(1, Ordering::Relaxed);
             });
-            router_clone.add_route(PointerId::new(0), new_handler);
+            router_clone.add_route(PointerId::PRIMARY, new_handler);
         });
 
         router.add_route(pointer, handler1);
@@ -579,7 +582,7 @@ mod tests {
     fn test_reentrancy_remove_other_handler() {
         // Test that a handler can remove another handler during dispatch
         let router = Arc::new(PointerRouter::new());
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let handler2_called = Arc::new(AtomicUsize::new(0));
         let handler2_called_clone = handler2_called.clone();
@@ -592,7 +595,7 @@ mod tests {
         let router_clone = router.clone();
         let handler1: PointerRouteHandler = Arc::new(move |_: &PointerEvent| {
             // Remove handler2 during dispatch
-            router_clone.remove_route(PointerId::new(0), &handler2_for_remove);
+            router_clone.remove_route(PointerId::PRIMARY, &handler2_for_remove);
         });
 
         // Add handler1 first, then handler2

--- a/crates/flui-interaction/src/signal_resolver.rs
+++ b/crates/flui-interaction/src/signal_resolver.rs
@@ -260,16 +260,16 @@ mod tests {
     #[test]
     fn test_resolver_creation() {
         let resolver = PointerSignalResolver::new();
-        assert_eq!(resolver.handler_count(PointerId::new(0)), 0);
+        assert_eq!(resolver.handler_count(PointerId::PRIMARY), 0);
     }
 
     #[test]
     fn test_register_handler() {
         let resolver = PointerSignalResolver::new();
 
-        let handler_id = resolver.register(PointerId::new(0), SignalPriority::Normal, |_| {});
+        let handler_id = resolver.register(PointerId::PRIMARY, SignalPriority::Normal, |_| {});
 
-        assert_eq!(resolver.handler_count(PointerId::new(0)), 1);
+        assert_eq!(resolver.handler_count(PointerId::PRIMARY), 1);
         assert!(handler_id.get() > 0);
     }
 
@@ -277,11 +277,11 @@ mod tests {
     fn test_unregister_handler() {
         let resolver = PointerSignalResolver::new();
 
-        let handler_id = resolver.register(PointerId::new(0), SignalPriority::Normal, |_| {});
-        assert_eq!(resolver.handler_count(PointerId::new(0)), 1);
+        let handler_id = resolver.register(PointerId::PRIMARY, SignalPriority::Normal, |_| {});
+        assert_eq!(resolver.handler_count(PointerId::PRIMARY), 1);
 
-        resolver.unregister(PointerId::new(0), handler_id);
-        assert_eq!(resolver.handler_count(PointerId::new(0)), 0);
+        resolver.unregister(PointerId::PRIMARY, handler_id);
+        assert_eq!(resolver.handler_count(PointerId::PRIMARY), 0);
     }
 
     #[test]
@@ -290,13 +290,13 @@ mod tests {
         let called = Arc::new(AtomicBool::new(false));
         let called_clone = called.clone();
 
-        resolver.register(PointerId::new(0), SignalPriority::Normal, move |_| {
+        resolver.register(PointerId::PRIMARY, SignalPriority::Normal, move |_| {
             called_clone.store(true, Ordering::Relaxed);
         });
 
         let event = crate::events::make_scroll_event(Offset::ZERO, Offset::new(px(0.0), px(10.0)));
 
-        resolver.resolve(PointerId::new(0), event);
+        resolver.resolve(PointerId::PRIMARY, event);
 
         assert!(called.load(Ordering::Relaxed));
     }
@@ -310,17 +310,17 @@ mod tests {
         let low_clone = low_called.clone();
         let high_clone = high_called.clone();
 
-        resolver.register(PointerId::new(0), SignalPriority::Low, move |_| {
+        resolver.register(PointerId::PRIMARY, SignalPriority::Low, move |_| {
             low_clone.store(true, Ordering::Relaxed);
         });
 
-        resolver.register(PointerId::new(0), SignalPriority::High, move |_| {
+        resolver.register(PointerId::PRIMARY, SignalPriority::High, move |_| {
             high_clone.store(true, Ordering::Relaxed);
         });
 
         let event = crate::events::make_scroll_event(Offset::ZERO, Offset::new(px(0.0), px(10.0)));
 
-        resolver.resolve(PointerId::new(0), event);
+        resolver.resolve(PointerId::PRIMARY, event);
 
         assert!(!low_called.load(Ordering::Relaxed));
         assert!(high_called.load(Ordering::Relaxed));
@@ -335,17 +335,17 @@ mod tests {
         let first_clone = first_called.clone();
         let second_clone = second_called.clone();
 
-        resolver.register(PointerId::new(0), SignalPriority::Normal, move |_| {
+        resolver.register(PointerId::PRIMARY, SignalPriority::Normal, move |_| {
             first_clone.fetch_add(1, Ordering::Relaxed);
         });
 
-        resolver.register(PointerId::new(0), SignalPriority::Normal, move |_| {
+        resolver.register(PointerId::PRIMARY, SignalPriority::Normal, move |_| {
             second_clone.fetch_add(1, Ordering::Relaxed);
         });
 
         let event = crate::events::make_scroll_event(Offset::ZERO, Offset::new(px(0.0), px(10.0)));
 
-        resolver.resolve(PointerId::new(0), event);
+        resolver.resolve(PointerId::PRIMARY, event);
 
         // Last registered (second) should win
         assert_eq!(first_called.load(Ordering::Relaxed), 0);
@@ -356,27 +356,34 @@ mod tests {
     fn test_clear() {
         let resolver = PointerSignalResolver::new();
 
-        resolver.register(PointerId::new(0), SignalPriority::Normal, |_| {});
-        resolver.register(PointerId::new(0), SignalPriority::Normal, |_| {});
+        resolver.register(PointerId::PRIMARY, SignalPriority::Normal, |_| {});
+        resolver.register(PointerId::PRIMARY, SignalPriority::Normal, |_| {});
 
-        assert_eq!(resolver.handler_count(PointerId::new(0)), 2);
+        assert_eq!(resolver.handler_count(PointerId::PRIMARY), 2);
 
-        resolver.clear(PointerId::new(0));
+        resolver.clear(PointerId::PRIMARY);
 
-        assert_eq!(resolver.handler_count(PointerId::new(0)), 0);
+        assert_eq!(resolver.handler_count(PointerId::PRIMARY), 0);
     }
 
     #[test]
     fn test_clear_all() {
         let resolver = PointerSignalResolver::new();
 
-        resolver.register(PointerId::new(0), SignalPriority::Normal, |_| {});
-        resolver.register(PointerId::new(1), SignalPriority::Normal, |_| {});
+        resolver.register(PointerId::PRIMARY, SignalPriority::Normal, |_| {});
+        resolver.register(
+            PointerId::new(2).expect("nonzero pointer id"),
+            SignalPriority::Normal,
+            |_| {},
+        );
 
         resolver.clear_all();
 
-        assert_eq!(resolver.handler_count(PointerId::new(0)), 0);
-        assert_eq!(resolver.handler_count(PointerId::new(1)), 0);
+        assert_eq!(resolver.handler_count(PointerId::PRIMARY), 0);
+        assert_eq!(
+            resolver.handler_count(PointerId::new(2).expect("nonzero pointer id")),
+            0
+        );
     }
 
     #[test]
@@ -385,13 +392,13 @@ mod tests {
         let called = Arc::new(AtomicBool::new(false));
         let called_clone = called.clone();
 
-        resolver.register(PointerId::new(0), SignalPriority::Normal, move |_| {
+        resolver.register(PointerId::PRIMARY, SignalPriority::Normal, move |_| {
             called_clone.store(true, Ordering::Relaxed);
         });
 
         let event = crate::events::make_scroll_event(Offset::ZERO, Offset::new(px(0.0), px(10.0)));
 
-        let accepted = resolver.resolve_and_accept(PointerId::new(0), event);
+        let accepted = resolver.resolve_and_accept(PointerId::PRIMARY, event);
 
         assert!(accepted);
         assert!(called.load(Ordering::Relaxed));

--- a/crates/flui-interaction/src/team.rs
+++ b/crates/flui-interaction/src/team.rs
@@ -484,7 +484,7 @@ mod tests {
     fn test_team_add_creates_combiner() {
         let team = GestureArenaTeam::new();
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
         let member = MockMember::new(1);
 
         assert!(!team.contains(pointer));
@@ -499,7 +499,7 @@ mod tests {
     fn test_team_first_member_wins() {
         let team = GestureArenaTeam::new();
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member1 = MockMember::new(1);
         let member2 = MockMember::new(2);
@@ -520,7 +520,7 @@ mod tests {
         let captain = MockMember::new(0);
         let team = GestureArenaTeam::with_captain(captain.clone());
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member1 = MockMember::new(1);
         let member2 = MockMember::new(2);
@@ -540,7 +540,7 @@ mod tests {
     fn test_team_member_reject_removes_from_team() {
         let team = GestureArenaTeam::new();
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member1 = MockMember::new(1);
         let member2 = MockMember::new(2);
@@ -558,7 +558,7 @@ mod tests {
     fn test_team_all_reject_rejects_arena() {
         let team = GestureArenaTeam::new();
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         let member1 = MockMember::new(1);
         let member2 = MockMember::new(2);
@@ -588,7 +588,7 @@ mod tests {
     fn test_team_entry_debug_impl() {
         let team = GestureArenaTeam::new();
         let arena = GestureArena::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
         let member = MockMember::new(1);
 
         let entry = team.add(pointer, member, &arena);
@@ -602,8 +602,8 @@ mod tests {
         let team = GestureArenaTeam::new();
         let arena = GestureArena::new();
 
-        let pointer1 = PointerId::new(0);
-        let pointer2 = PointerId::new(1);
+        let pointer1 = PointerId::PRIMARY;
+        let pointer2 = PointerId::new(2).expect("nonzero pointer id");
 
         let member1 = MockMember::new(1);
         let member2 = MockMember::new(2);

--- a/crates/flui-interaction/src/testing/recording.rs
+++ b/crates/flui-interaction/src/testing/recording.rs
@@ -11,9 +11,9 @@
 //!
 //! // Record a gesture
 //! let mut recorder = GestureRecorder::new();
-//! recorder.record_down(PointerId::new(0), Offset::new(Pixels(100.0), Pixels(100.0)));
-//! recorder.record_move(PointerId::new(0), Offset::new(Pixels(150.0), Pixels(100.0)));
-//! recorder.record_up(PointerId::new(0), Offset::new(Pixels(200.0), Pixels(100.0)));
+//! recorder.record_down(PointerId::PRIMARY, Offset::new(Pixels(100.0), Pixels(100.0)));
+//! recorder.record_move(PointerId::PRIMARY, Offset::new(Pixels(150.0), Pixels(100.0)));
+//! recorder.record_up(PointerId::PRIMARY, Offset::new(Pixels(200.0), Pixels(100.0)));
 //!
 //! // Save/export the recording
 //! let recording = recorder.finish();
@@ -125,7 +125,11 @@ impl RecordedEvent {
             position: self.position,
             local_position: self.position,
             device_kind: self.device_kind,
-            device: self.pointer.get(),
+            // U9: PointerEventData carries the legacy `device: i32` field;
+            // map PointerId (NonZeroU64) into the low 31 bits — primary
+            // pointer (PointerId(1)) lands on `1`, matching the test
+            // expectation that distinct pointer ids stay distinct devices.
+            device: (self.pointer.get_inner().get() & 0x7FFF_FFFF) as i32,
             buttons: if matches!(
                 self.event_type,
                 RecordedEventType::Down | RecordedEventType::Move
@@ -330,7 +334,7 @@ impl GestureRecorder {
 
         let mut recorded = RecordedEvent::new(
             time_offset,
-            PointerId::new(0), // Default to primary pointer
+            PointerId::PRIMARY, // Default to primary pointer
             event_type,
             position,
         )
@@ -459,7 +463,7 @@ impl GestureBuilder {
     /// Create a simple tap gesture
     pub fn tap(position: Offset<Pixels>) -> GestureRecording {
         let mut recording = GestureRecording::with_name("tap");
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         recording.push(RecordedEvent::new(
             Duration::ZERO,
@@ -480,7 +484,7 @@ impl GestureBuilder {
     /// Create a double tap gesture
     pub fn double_tap(position: Offset<Pixels>) -> GestureRecording {
         let mut recording = GestureRecording::with_name("double_tap");
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         // First tap
         recording.push(RecordedEvent::new(
@@ -516,7 +520,7 @@ impl GestureBuilder {
     /// Create a long press gesture
     pub fn long_press(position: Offset<Pixels>, duration_ms: u64) -> GestureRecording {
         let mut recording = GestureRecording::with_name("long_press");
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         recording.push(RecordedEvent::new(
             Duration::ZERO,
@@ -560,7 +564,7 @@ impl GestureBuilder {
         name: &str,
     ) -> GestureRecording {
         let mut recording = GestureRecording::with_name(name);
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
 
         // Down
         recording.push(RecordedEvent::new(
@@ -605,8 +609,8 @@ impl GestureBuilder {
         steps: usize,
     ) -> GestureRecording {
         let mut recording = GestureRecording::with_name("pinch");
-        let pointer1 = PointerId::new(0);
-        let pointer2 = PointerId::new(1);
+        let pointer1 = PointerId::PRIMARY;
+        let pointer2 = PointerId::new(2).expect("nonzero pointer id");
 
         let steps = steps.max(1);
 
@@ -688,7 +692,7 @@ mod tests {
     #[test]
     fn test_recorder_basic() {
         let mut recorder = GestureRecorder::new();
-        let pointer = PointerId::new(0);
+        let pointer = PointerId::PRIMARY;
         let pos = Offset::new(Pixels(100.0), Pixels(100.0));
 
         recorder.record_down(pointer, pos);
@@ -772,15 +776,18 @@ mod tests {
         assert_eq!(recording.len(), 14);
 
         // First two should be downs for different pointers
-        assert_eq!(recording.events[0].pointer, PointerId::new(0));
-        assert_eq!(recording.events[1].pointer, PointerId::new(1));
+        assert_eq!(recording.events[0].pointer, PointerId::PRIMARY);
+        assert_eq!(
+            recording.events[1].pointer,
+            PointerId::new(2).expect("nonzero pointer id")
+        );
     }
 
     #[test]
     fn test_recorded_event_with_pressure() {
         let event = RecordedEvent::new(
             Duration::ZERO,
-            PointerId::new(0),
+            PointerId::PRIMARY,
             RecordedEventType::Down,
             Offset::new(Pixels(0.0), Pixels(0.0)),
         )

--- a/crates/flui-interaction/src/traits.rs
+++ b/crates/flui-interaction/src/traits.rs
@@ -118,30 +118,11 @@ impl PointerEventExtTrait for PointerEvent {
     }
 
     fn pointer_id(&self) -> PointerId {
-        // Extract pointer ID from the event
-        let id = match self {
-            PointerEvent::Down(e) => e.pointer.pointer_id,
-            PointerEvent::Up(e) => e.pointer.pointer_id,
-            PointerEvent::Move(e) => e.pointer.pointer_id,
-            PointerEvent::Cancel(info) | PointerEvent::Enter(info) | PointerEvent::Leave(info) => {
-                info.pointer_id
-            }
-            PointerEvent::Scroll(e) => e.pointer.pointer_id,
-            PointerEvent::Gesture(e) => e.pointer.pointer_id,
-        };
-        // Use 0 for primary pointer, hash for others
-        let raw_id = match id {
-            Some(p) if p.is_primary_pointer() => 0,
-            Some(p) => {
-                // Use a simple hash based on memory representation
-                use std::hash::{Hash, Hasher};
-                let mut hasher = std::collections::hash_map::DefaultHasher::new();
-                p.hash(&mut hasher);
-                (hasher.finish() & 0x7FFFFFFF) as i32
-            }
-            None => 0,
-        };
-        PointerId::new(raw_id)
+        // U9: PointerId is `ui_events::pointer::PointerId(NonZeroU64)`.
+        // Delegate to the canonical extractor — zero-cost field load,
+        // no per-event hasher allocation. Matches Flutter
+        // `gestures/binding.dart` `event.pointer` semantics.
+        crate::events::extract_pointer_id(self)
     }
 
     fn is_down(&self) -> bool {


### PR DESCRIPTION
Closes plan unit **U9** of [docs/plans/2026-05-21-003-feat-input-frame-loop-repair-plan.md](docs/plans/2026-05-21-003-feat-input-frame-loop-repair-plan.md). Follows precedent of PRs #85 / #86 / #87 / #88 / #91 / #92 / #93 / #94 / #95 for the input + frame-loop repair series.

## Summary

Replaces the crate-local `PointerId(i32)` newtype with a re-export of [`ui_events::pointer::PointerId`](https://docs.rs/ui-events/0.3.0/ui_events/pointer/struct.PointerId.html) (`NonZeroU64`-backed). Removes the per-event `DefaultHasher` allocation that pre-U9 folded the canonical `NonZeroU64` id down into a lossy 31-bit `i32` every time an event crossed the gesture layer, while bringing the gesture layer's `PointerId` vocabulary into alignment with the platform layer (flui-platform), which already speaks ui_events directly.

## Migration

`ui_events::pointer::PointerId::new` is **fallible** — it returns `Option<PointerId>` because `0` is not a valid id (the inner type is `NonZeroU64`). Constructor call-sites migrate via two rules:

| Pre-U9                          | Post-U9                                                              |
|---------------------------------|----------------------------------------------------------------------|
| `PointerId::new(0)` (i32)        | `PointerId::PRIMARY` (canonical primary, inner `NonZeroU64::MIN` = 1) |
| `PointerId::new(N)` (i32, N ≥ 1) | `PointerId::new((N as u64) + 1).expect("nonzero pointer id")`         |

The `+1` shift keeps every previously-distinct test pointer distinct from `PRIMARY` — old `N=0` ↦ `PRIMARY=1`; old `N=1` ↦ new id `2`; old `N=2` ↦ new id `3` — so arena keying, route lookups, and recognizer FSMs preserve the identity / distinctness semantics they had pre-U9.

`PointerId::MOUSE` (= `0`) had zero call-sites and is deleted; callers should use `PointerId::PRIMARY` directly. The `Display` impl on the local `PointerId` is lost (no callers depended on the `pointer:N` format); `Debug` formatting is inherited from ui_events.

## Hot-path cleanup

- **`events::extract_pointer_id`** is now a zero-cost field load (`info.pointer_id.unwrap_or(PointerId::PRIMARY)`) — replaces a per-event `DefaultHasher` allocation that hashed every non-primary pointer down into a 31-bit `i32`.
  - Flutter parity: [`gestures/binding.dart::_handlePointerEventImmediately`](.flutter/flutter-master/packages/flutter/lib/src/gestures/binding.dart) reads `event.pointer` directly with no transform.
- **`traits::PointerEventExt::pointer_id`** delegates to the canonical extractor, removing a duplicated copy of the same hasher path.
- **`events::InputEvent::device_id`** drops its `DefaultHasher` branch on `persistent_device_id`; falls back to `pointer_id` (low 31 bits) for the legacy `DeviceId = i32` surface. `PersistentDeviceId`'s inner is private, so consumers needing physical-device stability should read `PointerInfo::persistent_device_id` upstream rather than via the legacy DeviceId mapping. `mouse_tracker::handle_event` calls `device_id()` per pointer event on the hot path; this branch removal eliminates the last per-event allocator hit in the extractor.
- **Testing-only `PointerEventData::from_pointer_event`** keeps the same conversion shape (primary ⇒ 0; other ⇒ low 31 bits) without the hasher.

## Tracing fields

Three `pointer_router` `trace!` calls and one `arena` `trace!` call read `.get()` on `PointerId` — switched to Debug field form (`?pointer`), which formats as `PointerId(N)` via the upstream Debug derive. `resampler`'s `pointer_id` `warn!` likewise switched to Debug form.

## Test conversions

`testing/recording.rs::to_pointer_event_data` maps the new PointerId into the legacy `device: i32` field via `(self.pointer.get_inner().get() & 0x7FFF_FFFF) as i32`. This keeps distinct pointer ids producing distinct device ids in the test playback path.

## File scope (22 modified)

- **`crates/flui-interaction/src/ids.rs`**: delete local `PointerId(i32)` newtype, replace with `pub use ui_events::pointer::PointerId`; rewrite module-level docs + tests for the new constructor + the `PRIMARY` constant.
- **`crates/flui-interaction/src/events.rs`**: hot-path `extract_pointer_id` simplification; `InputEvent::device_id` hasher-branch removal; `PointerEventData::from_pointer_event` primary-pointer mapping rewrite.
- **`crates/flui-interaction/src/traits.rs`**: `PointerEventExt::pointer_id` delegates to `extract_pointer_id`.
- **`crates/flui-interaction/src/lib.rs`**: doc comment + `PointerId` re-export header.
- **`crates/flui-interaction/src/{arena.rs, binding.rs, signal_resolver.rs, team.rs, testing/recording.rs, processing/{raw_input.rs, resampler.rs}, routing/{event_router.rs, pointer_router.rs}, recognizers/{tap.rs, long_press.rs, drag.rs, scale.rs, force_press.rs, double_tap.rs, multi_tap.rs, recognizer.rs}}`**: mechanical `PointerId::new(N)` → `PointerId::PRIMARY` / `.new(N+1)` sweep across ~165 call-sites.
- **`crates/flui-interaction/README.md`**: Type-Safe IDs section rewritten for the new constructor + PRIMARY convention.

Net delta: `-321` / `+370` LOC across 22 files (most of the addition is rewritten module docs + 2 new `ids.rs` tests covering `PRIMARY` semantics and `PointerId::new(0).is_none()`).

## Verification

- `cargo build --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p flui-interaction --lib` — **249 pass** (was 247 pre-U9; +2 new tests in `ids.rs`)
- `cargo test -p flui-interaction --lib --features testing` — **249 pass**
- `cargo build -p flui-interaction --no-default-features` — clean
- `cargo test --workspace --lib` — all crates green
- `bash scripts/port-check.sh -v` — **7 / 7** institutional refusal triggers clean

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)