### PR TITLE
refactor(interaction)!: merge FocusManagerInner into FocusManager singleton (U23 remaining)

### DIFF
--- a/crates/flui-interaction/README.md
+++ b/crates/flui-interaction/README.md
@@ -70,9 +70,9 @@ if FocusManager::global().has_focus(node_id) {
     // Handle keyboard input
 }
 
-// Tab traversal
-FocusManager::global().next_focus();  // Tab
-FocusManager::global().previous_focus();  // Shift+Tab
+// Tab traversal (defaults to root scope's reading-order policy)
+FocusManager::global().focus_next();      // Tab
+FocusManager::global().focus_previous();  // Shift+Tab
 ```
 
 ### Gesture Recognition

--- a/crates/flui-interaction/docs/ARCHITECTURE.md
+++ b/crates/flui-interaction/docs/ARCHITECTURE.md
@@ -163,25 +163,32 @@ pub fn dispatch(&self, event: &PointerEvent) -> EventPropagation {
 
 ### FocusManager
 
-Global singleton for keyboard focus:
+Global singleton for keyboard focus. Owns the focus-tree root and all
+focus invariants (primary focus, listeners, key handlers, active
+scope). U23 collapsed the prior dual-state design (singleton + private
+`FocusManagerInner`) into this single source of truth:
 
 ```rust
 pub struct FocusManager {
-    focused: RwLock<Option<FocusNodeId>>,
-    nodes: RwLock<HashMap<FocusNodeId, FocusNode>>,
-    scopes: RwLock<Vec<FocusScopeNode>>,
-    traversal_policy: RwLock<Box<dyn FocusTraversalPolicy>>,
+    root_scope: Arc<FocusScopeNode>,                  // Flutter parity
+    primary_focus: RwLock<Option<FocusNodeId>>,
+    listeners: RwLock<Vec<FocusChangeCallback>>,
+    key_handlers: RwLock<HashMap<FocusNodeId, KeyEventCallback>>,
+    global_key_handlers: RwLock<Vec<KeyEventCallback>>,
+    active_scope: RwLock<Option<Arc<FocusScopeNode>>>, // override; defaults to root
 }
 
 impl FocusManager {
     pub fn global() -> &'static FocusManager;
-    
+    pub fn root_scope(&self) -> &Arc<FocusScopeNode>;
+    pub fn active_scope(&self) -> Arc<FocusScopeNode>;
+
     pub fn request_focus(&self, node: FocusNodeId);
     pub fn unfocus(&self);
     pub fn has_focus(&self, node: FocusNodeId) -> bool;
-    
-    pub fn next_focus(&self);      // Tab
-    pub fn previous_focus(&self);  // Shift+Tab
+
+    pub fn focus_next(&self) -> bool;      // Tab
+    pub fn focus_previous(&self) -> bool;  // Shift+Tab
 }
 ```
 
@@ -200,16 +207,17 @@ pub struct FocusScopeNode {
 ### Traversal Policies
 
 ```rust
-pub trait FocusTraversalPolicy: Send + Sync {
-    fn find_first_focus(&self, scope: &FocusScopeNode) -> Option<FocusNodeId>;
-    fn find_next_focus(&self, current: FocusNodeId, direction: TraversalDirection) 
+pub trait FocusTraversalPolicy: Send + Sync + std::fmt::Debug {
+    fn find_first(&self, nodes: &[Arc<FocusNode>]) -> Option<FocusNodeId>;
+    fn find_last(&self, nodes: &[Arc<FocusNode>]) -> Option<FocusNodeId>;
+    fn find_next(&self, current: FocusNodeId, nodes: &[Arc<FocusNode>])
+        -> Option<FocusNodeId>;
+    fn find_previous(&self, current: FocusNodeId, nodes: &[Arc<FocusNode>])
         -> Option<FocusNodeId>;
 }
 
 // Built-in policies
-pub struct OrderedTraversalPolicy;   // Explicit order
-pub struct ReadingOrderPolicy;       // Top-left to bottom-right
-pub struct DirectionalFocusPolicy;   // Arrow key navigation
+pub struct ReadingOrderPolicy;       // Top-left to bottom-right (default)
 ```
 
 ## Gesture Arena

--- a/crates/flui-interaction/src/routing/focus.rs
+++ b/crates/flui-interaction/src/routing/focus.rs
@@ -1,16 +1,33 @@
 //! Keyboard focus management
 //!
-//! FocusManager is a global singleton that tracks which UI element has keyboard
-//! focus. Only one element can have focus at a time.
+//! [`FocusManager`] is a global singleton that fronts the entire focus
+//! tree machinery — it owns the [`FocusScopeNode`] root, tracks the
+//! primary-focused node, notifies focus-change listeners, and routes
+//! key events through the registered handlers.
+//!
+//! Audit Finding I-4 closure (U23): prior dual structure (`FocusManager`
+//! singleton + private `FocusManagerInner` Arc<inner> co-existing with
+//! independent `primary_focus` + listener state) collapsed into a single
+//! singleton owning every focus invariant. [`FocusNode`] / [`FocusScopeNode`]
+//! reach the manager via [`FocusManager::global`] instead of holding a
+//! `Weak<FocusManagerInner>`.
 //!
 //! # Type System Features
 //!
-//! - **Newtype pattern**: `FocusNodeId` uses `NonZeroU64` for niche
-//!   optimization
-//! - **Singleton pattern**: Global focus manager via `OnceLock`
-//! - **parking_lot**: High-performance read-write locks
-//! - **FocusScope integration**: Tab/Shift+Tab navigation via
-//!   `FocusScopeManager`
+//! - **Newtype pattern**: [`FocusNodeId`] uses `NonZeroU64` for niche
+//!   optimization (so `Option<FocusNodeId>` is the same 8 bytes).
+//! - **Singleton pattern**: Global focus manager via `OnceLock`.
+//! - **parking_lot**: High-performance read-write locks.
+//! - **TOCTOU-safe**: Primary-focus updates take a single write lock
+//!   so concurrent `request_focus` callers cannot interleave a stale
+//!   read with a competing write.
+//!
+//! # Flutter parity
+//!
+//! Mirrors [`widgets/focus_manager.dart`](https://api.flutter.dev/flutter/widgets/FocusManager-class.html)
+//! `FocusManager` — singular `_primaryFocus` + `rootScope` + listener
+//! `ChangeNotifier` semantics. FLUI's singleton replaces Flutter's
+//! `WidgetsBinding.focusManager` accessor.
 //!
 //! # Example
 //!
@@ -27,23 +44,22 @@
 //!     println!("We have focus!");
 //! }
 //!
-//! // Tab navigation (uses FocusScopeManager)
+//! // Tab navigation (uses the root scope's traversal policy)
 //! FocusManager::global().focus_next();
 //!
 //! // Release focus
 //! FocusManager::global().unfocus();
 //! ```
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, atomic::AtomicBool},
-};
+use std::{collections::HashMap, sync::Arc};
 
 use parking_lot::RwLock;
 
-use crate::{events::KeyEvent, ids::FocusNodeId, routing::focus_scope::FocusScopeNode};
-
-// Re-export FocusNodeId for convenience
+use crate::{
+    events::KeyEvent,
+    ids::FocusNodeId,
+    routing::focus_scope::{FocusNode, FocusScopeNode},
+};
 
 // ============================================================================
 // FocusChangeCallback
@@ -65,18 +81,29 @@ pub type KeyEventCallback = Arc<dyn Fn(&KeyEvent) -> bool + Send + Sync>;
 
 /// Global focus manager (singleton).
 ///
-/// Tracks which UI element currently has keyboard focus.
-/// Only one element can have focus at a time.
+/// Tracks which UI element currently has keyboard focus, owns the root
+/// [`FocusScopeNode`] of the focus tree, dispatches key events through
+/// per-node + global handlers, and notifies registered listeners on
+/// focus changes. Only one element can have focus at a time.
+///
+/// # Singleton ownership
+///
+/// `FocusManager::global()` returns a `&'static FocusManager` initialized
+/// once via [`OnceLock`]. On first access, [`Default`] eagerly creates the
+/// root [`FocusScopeNode`] so consumers can always reach
+/// [`FocusManager::root_scope`] without re-initialization.
 ///
 /// # Thread Safety
 ///
-/// FocusManager uses `parking_lot::RwLock` for efficient concurrent access.
-/// Reads (checking focus) are very fast and don't block each other.
+/// `FocusManager` uses `parking_lot::RwLock` for efficient concurrent
+/// reads. Primary-focus mutations take a single write lock to avoid
+/// read-then-write TOCTOU races against competing `request_focus`
+/// callers.
 ///
 /// # Niche Optimization
 ///
-/// `FocusNodeId` uses `NonZeroU64`, so `Option<FocusNodeId>` is the same size
-/// as `FocusNodeId` (8 bytes).
+/// `FocusNodeId` uses `NonZeroU64`, so `Option<FocusNodeId>` is the same
+/// size as `FocusNodeId` (8 bytes).
 ///
 /// # Example
 ///
@@ -97,8 +124,16 @@ pub type KeyEventCallback = Arc<dyn Fn(&KeyEvent) -> bool + Send + Sync>;
 /// FocusManager::global().unfocus();
 /// ```
 pub struct FocusManager {
-    /// Currently focused element (if any).
-    focused: RwLock<Option<FocusNodeId>>,
+    /// Root scope of the focus tree.
+    ///
+    /// Owned directly by the singleton (Flutter parity:
+    /// `FocusManager.rootScope`). Constructed eagerly in [`Default`] so
+    /// the root scope is always present — no Option dance, no
+    /// lazy-construction race.
+    root_scope: Arc<FocusScopeNode>,
+
+    /// Currently focused element (if any) — Flutter's `_primaryFocus`.
+    primary_focus: RwLock<Option<FocusNodeId>>,
 
     /// Listeners for focus changes.
     listeners: RwLock<Vec<FocusChangeCallback>>,
@@ -109,23 +144,18 @@ pub struct FocusManager {
     /// Global key event handlers (called for all key events).
     global_key_handlers: RwLock<Vec<KeyEventCallback>>,
 
-    /// Active focus scope used for Tab navigation traversal.
-    ///
-    /// Set via [`FocusManager::set_active_scope`] from the app binding at
-    /// init. When None, [`focus_next`] / [`focus_previous`] return false
-    /// (no traversal possible — app didn't wire a scope). Closes audit
-    /// Finding I-4 (Tab navigation public API was `tracing::warn!` stub).
+    /// Override scope used for Tab navigation traversal. When `None`
+    /// (the default), [`focus_next`] / [`focus_previous`] use
+    /// [`root_scope`]. App code can set this to a sub-scope to scope
+    /// traversal (matches Flutter modal-route scope semantics).
     active_scope: RwLock<Option<Arc<FocusScopeNode>>>,
-
-    /// Latches first missing-active-scope warn so repeated Tab presses
-    /// don't spam logs. PR #88 review fix.
-    missing_scope_warned: AtomicBool,
 }
 
 impl std::fmt::Debug for FocusManager {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FocusManager")
-            .field("focused", &*self.focused.read())
+            .field("primary_focus", &*self.primary_focus.read())
+            .field("root_scope_id", &self.root_scope.id())
             .field("listener_count", &self.listeners.read().len())
             .finish()
     }
@@ -133,13 +163,19 @@ impl std::fmt::Debug for FocusManager {
 
 impl Default for FocusManager {
     fn default() -> Self {
+        let root_scope = FocusScopeNode::with_debug_label("Root Focus Scope");
+        // Root scope is attached by definition — it has no parent
+        // because it IS the tree root. Mark attached so child-attach
+        // recursion treats it as live (audit parity with Flutter's
+        // root-scope-always-attached invariant).
+        FocusNode::mark_root_attached(root_scope.as_focus_node());
         Self {
-            focused: RwLock::new(None),
+            root_scope,
+            primary_focus: RwLock::new(None),
             listeners: RwLock::new(Vec::new()),
             key_handlers: RwLock::new(HashMap::new()),
             global_key_handlers: RwLock::new(Vec::new()),
             active_scope: RwLock::new(None),
-            missing_scope_warned: AtomicBool::new(false),
         }
     }
 }
@@ -147,60 +183,60 @@ impl Default for FocusManager {
 impl FocusManager {
     /// Get the global focus manager instance.
     ///
-    /// This is a singleton - the same instance is returned every time.
+    /// This is a singleton — the same instance is returned every time.
+    /// On first access the root [`FocusScopeNode`] is constructed.
     pub fn global() -> &'static FocusManager {
         static INSTANCE: std::sync::OnceLock<FocusManager> = std::sync::OnceLock::new();
         INSTANCE.get_or_init(FocusManager::default)
     }
 
-    /// Set the active focus scope used for Tab navigation traversal.
+    /// Returns the root focus scope.
     ///
-    /// Call this from the app binding when constructing the focus tree
-    /// (usually at app init). [`focus_next`] / [`focus_previous`] delegate
-    /// to the active scope's `focus_next_in_scope` /
-    /// `focus_previous_in_scope`.
-    pub fn set_active_scope(&self, scope: Option<Arc<FocusScopeNode>>) {
-        *self.active_scope.write() = scope;
-        // Reset the warn-latch so re-clearing the scope after wiring
-        // produces a fresh diagnostic.
-        self.missing_scope_warned
-            .store(false, std::sync::atomic::Ordering::Release);
+    /// Flutter parity: `FocusManager.rootScope`. Always present —
+    /// constructed eagerly in [`Default`]. Use this as the parent
+    /// when attaching focus nodes to the tree.
+    #[inline]
+    pub fn root_scope(&self) -> &Arc<FocusScopeNode> {
+        &self.root_scope
     }
 
-    /// Returns the currently active focus scope, if any.
-    pub fn active_scope(&self) -> Option<Arc<FocusScopeNode>> {
-        self.active_scope.read().clone()
+    /// Override the active scope for Tab navigation. Pass `None` to
+    /// fall back to the [`root_scope`].
+    ///
+    /// Useful for modal dialogs that need traversal scoped to dialog
+    /// descendants. Flutter equivalent: pushing a scope onto the
+    /// modal-route history.
+    pub fn set_active_scope(&self, scope: Option<Arc<FocusScopeNode>>) {
+        *self.active_scope.write() = scope;
+    }
+
+    /// Returns the active focus scope used for traversal. Defaults to
+    /// [`root_scope`] when no override is set.
+    pub fn active_scope(&self) -> Arc<FocusScopeNode> {
+        self.active_scope
+            .read()
+            .clone()
+            .unwrap_or_else(|| self.root_scope.clone())
     }
 
     /// Create a new focus manager (for testing).
     ///
     /// Normally you should use `global()` instead.
     #[cfg(test)]
-    fn new() -> Self {
+    pub(crate) fn new_for_test() -> Self {
         Self::default()
     }
 
-    /// Helper: warn-once for missing active scope. PR #88 review fix —
-    /// the prior `tracing::warn!` fired on every Tab press, spamming
-    /// logs on key-repeat.
-    fn warn_missing_scope(&self, op: &'static str) {
-        if !self
-            .missing_scope_warned
-            .swap(true, std::sync::atomic::Ordering::AcqRel)
-        {
-            tracing::warn!(
-                op,
-                "FocusManager::{op}: no active focus scope set — call \
-                 FocusManager::set_active_scope at app init to enable \
-                 Tab/Shift+Tab navigation",
-            );
-        }
-    }
-
-    /// Request focus for a node.
+    /// Request focus for a node. If another node had focus, it loses
+    /// focus. Focus-change listeners are notified.
     ///
-    /// If another node had focus, it loses focus.
-    /// Focus change listeners are notified.
+    /// Uses a single-write-lock TOCTOU-safe update so concurrent
+    /// callers cannot interleave a stale read with a competing write
+    /// — earlier dual-state design read with a separate read lock
+    /// before writing, allowing races.
+    ///
+    /// Records the new focus in the node's enclosing scope's history
+    /// (Flutter parity: `FocusScopeNode._focusedChild` history).
     ///
     /// # Example
     ///
@@ -209,30 +245,54 @@ impl FocusManager {
     /// FocusManager::global().request_focus(text_field);
     /// ```
     pub fn request_focus(&self, node_id: FocusNodeId) {
-        let previous = *self.focused.read();
+        self.set_primary_focus(Some(node_id));
+    }
 
-        if previous == Some(node_id) {
-            return; // Already focused
-        }
-
-        *self.focused.write() = Some(node_id);
+    /// Internal: single-write-lock primary-focus update + scope
+    /// history record + listener notification. Carries the
+    /// TOCTOU-safe pattern migrated from the prior
+    /// `FocusManagerInner::set_primary_focus`.
+    fn set_primary_focus(&self, node_id: Option<FocusNodeId>) {
+        // Single write lock: atomically read previous and write new
+        // (avoids TOCTOU race against concurrent request_focus calls).
+        let previous = {
+            let mut focus = self.primary_focus.write();
+            let previous = *focus;
+            if previous == node_id {
+                return;
+            }
+            *focus = node_id;
+            previous
+        };
 
         tracing::trace!(
             previous = ?previous.map(|id| id.get()),
-            new = node_id.get(),
+            new = ?node_id.map(|id| id.get()),
             "Focus changed"
         );
 
-        // Notify listeners
-        self.notify_listeners(previous, Some(node_id));
+        // Record in enclosing scope's history when focusing a node
+        // (mirrors Flutter `_setAsFocusedChildForScope`).
+        if let Some(id) = node_id
+            && let Some(node) = self.find_node(id)
+            && let Some(scope) = node.enclosing_scope()
+        {
+            scope.record_focus(id);
+        }
+
+        self.notify_listeners(previous, node_id);
     }
 
     /// Get the currently focused node (if any).
-    ///
-    /// Returns `None` if no element has focus.
     #[inline]
     pub fn focused(&self) -> Option<FocusNodeId> {
-        *self.focused.read()
+        *self.primary_focus.read()
+    }
+
+    /// Alias for [`focused`] — matches Flutter's `primaryFocus` getter.
+    #[inline]
+    pub fn primary_focus(&self) -> Option<FocusNodeId> {
+        *self.primary_focus.read()
     }
 
     /// Check if a specific node has focus.
@@ -246,7 +306,7 @@ impl FocusManager {
     /// ```
     #[inline]
     pub fn has_focus(&self, node_id: FocusNodeId) -> bool {
-        *self.focused.read() == Some(node_id)
+        *self.primary_focus.read() == Some(node_id)
     }
 
     /// Clear focus (no element focused).
@@ -256,23 +316,12 @@ impl FocusManager {
     /// - Window loses focus
     /// - Focused element is removed
     pub fn unfocus(&self) {
-        let previous = *self.focused.read();
-
-        if previous.is_none() {
-            return; // Already unfocused
-        }
-
-        *self.focused.write() = None;
-        tracing::trace!("Focus cleared");
-
-        // Notify listeners
-        self.notify_listeners(previous, None);
+        self.set_primary_focus(None);
     }
 
     /// Add a listener for focus changes.
     ///
-    /// Returns a callback that can be stored and used to check the current
-    /// focus. The listener is called whenever focus changes.
+    /// The listener is called whenever focus changes.
     ///
     /// # Example
     ///
@@ -285,72 +334,76 @@ impl FocusManager {
         self.listeners.write().push(callback);
     }
 
-    /// Remove all listeners.
-    ///
-    /// Useful for cleanup during shutdown.
+    /// Remove all listeners. Useful for cleanup during shutdown.
     pub fn clear_listeners(&self) {
         self.listeners.write().clear();
     }
 
     /// Notify all listeners of a focus change.
     fn notify_listeners(&self, previous: Option<FocusNodeId>, new: Option<FocusNodeId>) {
-        let listeners = self.listeners.read();
-        for listener in listeners.iter() {
+        // Clone the listener Vec so listener invocations can call
+        // `add_listener` / `clear_listeners` without deadlocking on
+        // our read lock (Flutter ChangeNotifier reentrancy semantics).
+        let listeners = self.listeners.read().clone();
+        for listener in &listeners {
             listener(previous, new);
         }
     }
 
-    /// Transfer focus to the next focusable element via the active scope's
-    /// traversal policy (Tab key).
+    /// Locate a focus node by ID by descending from the root scope.
     ///
-    /// Requires [`FocusManager::set_active_scope`] to have been called from
-    /// the app binding. Returns `true` if focus advanced, `false` if no
-    /// active scope is set, no element is currently focused, or the
-    /// traversal policy returned None.
+    /// Returns `None` if the node is not attached to the tree.
+    /// O(N) over tree nodes — used during focus-change history
+    /// recording (not on the per-event hot path).
+    pub(crate) fn find_node(&self, id: FocusNodeId) -> Option<Arc<FocusNode>> {
+        let root = self.root_scope.as_focus_node();
+        if root.id() == id {
+            return Some(root.clone());
+        }
+        root.descendants().find(|node| node.id() == id)
+    }
+
+    /// Transfer focus to the next focusable element via the active
+    /// scope's traversal policy (Tab key). The active scope defaults
+    /// to [`root_scope`] when no override is set via
+    /// [`set_active_scope`].
+    ///
+    /// Returns `true` if focus advanced, `false` if no element is
+    /// currently focused or the traversal policy returned `None`.
     pub fn focus_next(&self) -> bool {
-        let Some(current) = *self.focused.read() else {
+        let Some(current) = *self.primary_focus.read() else {
             tracing::trace!("focus_next: no element currently focused");
             return false;
         };
-        let Some(scope) = self.active_scope() else {
-            self.warn_missing_scope("focus_next");
-            return false;
-        };
+        let scope = self.active_scope();
         let Some(next_id) = scope.next_focusable_id(current) else {
             return false;
         };
-        // PR #88 review fix: route through request_focus so the singleton's
-        // focused field + listeners + key-routing surface stay in sync
-        // with the FocusScopeNode tree.
-        self.request_focus(next_id);
+        self.set_primary_focus(Some(next_id));
         true
     }
 
-    /// Transfer focus to the previous focusable element via the active
-    /// scope's traversal policy (Shift+Tab).
+    /// Transfer focus to the previous focusable element via the
+    /// active scope's traversal policy (Shift+Tab).
     ///
-    /// See [`focus_next`] for behavior contract — same singleton-sync fix
-    /// applied here.
+    /// See [`focus_next`] for behavior contract.
     pub fn focus_previous(&self) -> bool {
-        let Some(current) = *self.focused.read() else {
+        let Some(current) = *self.primary_focus.read() else {
             tracing::trace!("focus_previous: no element currently focused");
             return false;
         };
-        let Some(scope) = self.active_scope() else {
-            self.warn_missing_scope("focus_previous");
-            return false;
-        };
+        let scope = self.active_scope();
         let Some(prev_id) = scope.previous_focusable_id(current) else {
             return false;
         };
-        self.request_focus(prev_id);
+        self.set_primary_focus(Some(prev_id));
         true
     }
 
     /// Check if any element has focus.
     #[inline]
     pub fn is_focused(&self) -> bool {
-        self.focused.read().is_some()
+        self.primary_focus.read().is_some()
     }
 
     // ========================================================================
@@ -409,7 +462,7 @@ impl FocusManager {
     /// Dispatch a key event to the appropriate handler(s).
     ///
     /// Event routing order:
-    /// 1. Global handlers (in order added) - stop if any returns `true`
+    /// 1. Global handlers (in order added) — stop if any returns `true`
     /// 2. Focused node's handler (if any)
     ///
     /// Returns `true` if the event was handled.
@@ -423,19 +476,18 @@ impl FocusManager {
     /// }
     /// ```
     pub fn dispatch_key_event(&self, event: &KeyEvent) -> bool {
-        // First, try global handlers
-        {
-            let global_handlers = self.global_key_handlers.read();
-            for handler in global_handlers.iter() {
-                if handler(event) {
-                    tracing::trace!("Key event handled by global handler");
-                    return true;
-                }
+        // First, try global handlers — clone so the handler can mutate
+        // the global handler list without deadlocking.
+        let global_handlers = self.global_key_handlers.read().clone();
+        for handler in &global_handlers {
+            if handler(event) {
+                tracing::trace!("Key event handled by global handler");
+                return true;
             }
         }
 
         // Then, try focused node's handler
-        let focused = *self.focused.read();
+        let focused = *self.primary_focus.read();
         if let Some(node_id) = focused
             && let Some(handler) = self.key_handlers.read().get(&node_id).cloned()
             && handler(event)
@@ -468,8 +520,21 @@ mod tests {
     }
 
     #[test]
+    fn test_focus_manager_has_root_scope() {
+        let manager = FocusManager::new_for_test();
+        // Root scope is always present and attached.
+        assert!(manager.root_scope().as_focus_node().is_attached());
+        // Active scope falls back to root scope.
+        assert_eq!(
+            manager.active_scope().id(),
+            manager.root_scope().id(),
+            "active_scope should default to root_scope"
+        );
+    }
+
+    #[test]
     fn test_request_focus() {
-        let manager = FocusManager::new();
+        let manager = FocusManager::new_for_test();
         let node1 = FocusNodeId::new(1);
         let node2 = FocusNodeId::new(2);
 
@@ -493,7 +558,7 @@ mod tests {
 
     #[test]
     fn test_unfocus() {
-        let manager = FocusManager::new();
+        let manager = FocusManager::new_for_test();
         let node = FocusNodeId::new(42);
 
         // Give focus
@@ -509,7 +574,7 @@ mod tests {
 
     #[test]
     fn test_has_focus() {
-        let manager = FocusManager::new();
+        let manager = FocusManager::new_for_test();
         let node1 = FocusNodeId::new(1);
         let node2 = FocusNodeId::new(2);
 
@@ -543,7 +608,7 @@ mod tests {
     fn test_focus_listener() {
         use std::sync::atomic::{AtomicBool, Ordering};
 
-        let manager = FocusManager::new();
+        let manager = FocusManager::new_for_test();
         let called = Arc::new(AtomicBool::new(false));
         let called_clone = called.clone();
 
@@ -561,7 +626,7 @@ mod tests {
     fn test_request_same_focus_no_change() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
-        let manager = FocusManager::new();
+        let manager = FocusManager::new_for_test();
         let call_count = Arc::new(AtomicUsize::new(0));
         let count_clone = call_count.clone();
 
@@ -584,7 +649,7 @@ mod tests {
     fn test_clear_listeners() {
         use std::sync::atomic::{AtomicBool, Ordering};
 
-        let manager = FocusManager::new();
+        let manager = FocusManager::new_for_test();
         let called = Arc::new(AtomicBool::new(false));
         let called_clone = called.clone();
 
@@ -605,7 +670,7 @@ mod tests {
     fn test_register_key_handler() {
         use std::sync::atomic::{AtomicBool, Ordering};
 
-        let manager = FocusManager::new();
+        let manager = FocusManager::new_for_test();
         let node = FocusNodeId::new(1);
 
         assert!(!manager.has_key_handler(node));
@@ -634,7 +699,7 @@ mod tests {
 
         use crate::{events::keyboard::Code, testing::input::KeyEventBuilder};
 
-        let manager = FocusManager::new();
+        let manager = FocusManager::new_for_test();
         let node = FocusNodeId::new(1);
 
         let handled = Arc::new(AtomicBool::new(false));
@@ -666,7 +731,7 @@ mod tests {
 
         use crate::{events::keyboard::Code, testing::input::KeyEventBuilder};
 
-        let manager = FocusManager::new();
+        let manager = FocusManager::new_for_test();
         let node = FocusNodeId::new(1);
 
         let handled = Arc::new(AtomicBool::new(false));
@@ -695,7 +760,7 @@ mod tests {
 
         use crate::{events::keyboard::Code, testing::input::KeyEventBuilder};
 
-        let manager = FocusManager::new();
+        let manager = FocusManager::new_for_test();
 
         let global_handled = Arc::new(AtomicBool::new(false));
         let global_clone = global_handled.clone();
@@ -719,7 +784,7 @@ mod tests {
 
         use crate::{events::keyboard::Code, testing::input::KeyEventBuilder};
 
-        let manager = FocusManager::new();
+        let manager = FocusManager::new_for_test();
         let node = FocusNodeId::new(1);
 
         let global_called = Arc::new(AtomicBool::new(false));
@@ -759,7 +824,7 @@ mod tests {
 
         use crate::{events::keyboard::Code, testing::input::KeyEventBuilder};
 
-        let manager = FocusManager::new();
+        let manager = FocusManager::new_for_test();
         let node = FocusNodeId::new(1);
 
         let global_called = Arc::new(AtomicBool::new(false));
@@ -798,7 +863,7 @@ mod tests {
 
         use crate::{events::keyboard::Code, testing::input::KeyEventBuilder};
 
-        let manager = FocusManager::new();
+        let manager = FocusManager::new_for_test();
 
         let called = Arc::new(AtomicBool::new(false));
         let called_clone = called.clone();

--- a/crates/flui-interaction/src/routing/focus_scope.rs
+++ b/crates/flui-interaction/src/routing/focus_scope.rs
@@ -6,7 +6,6 @@
 //! - [`FocusNode`] - A node in the focus tree that can receive keyboard focus
 //! - [`FocusScopeNode`] - A special FocusNode that groups descendants and
 //!   tracks focus history
-//! - [`FocusAttachment`] - RAII handle for attaching FocusNode to the tree
 //! - [`FocusTraversalPolicy`] - Determines Tab/Shift+Tab navigation order
 //!
 //! # Flutter Architecture
@@ -28,7 +27,16 @@
 //! - `FocusScopeNode` restricts traversal and remembers focus history
 //! - `hasFocus` = any descendant has focus, `hasPrimaryFocus` = this node has
 //!   focus
-//! - Nodes must be attached via `FocusAttachment` lifecycle
+//!
+//! # Singleton manager (U23 / I-4 closure)
+//!
+//! Prior incarnations of this module held a `manager:
+//! RwLock<Option<Weak<FocusManagerInner>>>` reference on each
+//! [`FocusNode`], plus a private `FocusManagerInner` Arc-based dual
+//! state living alongside the public [`crate::FocusManager`] singleton.
+//! U23 collapses that into a single singleton: focus nodes reach the
+//! manager via [`crate::FocusManager::global`] without any weak-ref
+//! dance — the singleton is always live and globally reachable.
 //!
 //! # Example
 //!
@@ -36,18 +44,14 @@
 //! use flui_interaction::routing::{FocusNode, FocusScopeNode, FocusManager};
 //!
 //! // Create a focusable node
-//! let mut node = FocusNode::new()
-//!     .with_debug_label("my_button")
-//!     .on_key(|event| { /* handle key */ false });
+//! let node = FocusNode::new_with_debug_label("my_button");
+//! node.set_on_key_event(Arc::new(|event| { /* handle key */ false }));
 //!
-//! // Attach to tree (typically in widget's mount)
-//! let attachment = node.attach(parent_scope);
+//! // Attach to root scope
+//! FocusManager::global().root_scope().attach_node(&node);
 //!
 //! // Request focus
 //! node.request_focus();
-//!
-//! // Detach when widget unmounts
-//! drop(attachment);
 //! ```
 //!
 //! # References
@@ -126,20 +130,12 @@ pub enum KeyEventResult {
 /// | `nextFocus()` | `next_focus()` | Move to next focusable |
 /// | `previousFocus()` | `previous_focus()` | Move to previous focusable |
 ///
-/// # Example
+/// # Manager access
 ///
-/// ```rust,ignore
-/// let node = FocusNode::new()
-///     .with_debug_label("my_button")
-///     .can_request_focus(true)
-///     .on_key(|event| {
-///         if event.logical_key == Key::Enter {
-///             activate_button();
-///             return true;
-///         }
-///         false
-///     });
-/// ```
+/// Focus nodes no longer hold a `Weak<FocusManagerInner>` — they reach
+/// the [`crate::FocusManager`] singleton via [`crate::FocusManager::global`]
+/// directly. The [`is_attached`] flag still gates focus operations so
+/// nodes that haven't been mounted into the tree behave as no-ops.
 pub struct FocusNode {
     /// Unique identifier for this node.
     id: FocusNodeId,
@@ -170,9 +166,6 @@ pub struct FocusNode {
 
     /// Whether this node is attached to the focus tree.
     attached: AtomicBool,
-
-    /// The manager this node belongs to (set on attach).
-    manager: RwLock<Option<Weak<FocusManagerInner>>>,
 }
 
 impl FocusNode {
@@ -189,7 +182,6 @@ impl FocusNode {
             on_key_event: RwLock::new(None),
             rect: RwLock::new(Rect::ZERO),
             attached: AtomicBool::new(false),
-            manager: RwLock::new(None),
         })
     }
 
@@ -206,7 +198,6 @@ impl FocusNode {
             on_key_event: RwLock::new(None),
             rect: RwLock::new(Rect::ZERO),
             attached: AtomicBool::new(false),
-            manager: RwLock::new(None),
         })
     }
 
@@ -295,22 +286,18 @@ impl FocusNode {
     /// Returns whether this node has focus (this node or any descendant).
     ///
     /// This is `true` if any node in this subtree has primary focus.
+    /// Reaches the [`crate::FocusManager`] singleton directly (no Weak
+    /// upgrade dance) — singleton always live.
     pub fn has_focus(&self) -> bool {
-        if let Some(manager) = self.manager.read().as_ref().and_then(|w| w.upgrade())
-            && let Some(focused_id) = manager.primary_focus()
-        {
-            // Check if focused node is this node or a descendant
-            return self.id == focused_id || self.has_descendant(focused_id);
-        }
-        false
+        let Some(focused_id) = crate::FocusManager::global().primary_focus() else {
+            return false;
+        };
+        self.id == focused_id || self.has_descendant(focused_id)
     }
 
     /// Returns whether this specific node has primary focus.
     pub fn has_primary_focus(&self) -> bool {
-        if let Some(manager) = self.manager.read().as_ref().and_then(|w| w.upgrade()) {
-            return manager.primary_focus() == Some(self.id);
-        }
-        false
+        crate::FocusManager::global().primary_focus() == Some(self.id)
     }
 
     /// Checks if a node with the given ID is a descendant of this node.
@@ -348,14 +335,14 @@ impl FocusNode {
     }
 
     /// Requests primary focus for this node.
+    ///
+    /// No-op when the node cannot request focus or is not attached to
+    /// the focus tree.
     pub fn request_focus(self: &Arc<Self>) {
         if !self.can_request_focus() || !self.is_attached() {
             return;
         }
-
-        if let Some(manager) = self.manager.read().as_ref().and_then(|w| w.upgrade()) {
-            manager.set_primary_focus(Some(self.id));
-        }
+        crate::FocusManager::global().request_focus(self.id);
     }
 
     /// Removes focus from this node.
@@ -363,10 +350,7 @@ impl FocusNode {
         if !self.has_primary_focus() {
             return;
         }
-
-        if let Some(manager) = self.manager.read().as_ref().and_then(|w| w.upgrade()) {
-            manager.set_primary_focus(None);
-        }
+        crate::FocusManager::global().unfocus();
     }
 
     /// Moves focus to the next focusable node.
@@ -420,14 +404,20 @@ impl FocusNode {
     // Internal methods
     // ========================================================================
 
+    /// Mark the root node as attached. Used by [`crate::FocusManager`]
+    /// during default construction — the root scope has no parent so
+    /// the normal `attach_child` path doesn't run for it.
+    pub(crate) fn mark_root_attached(node: &Arc<FocusNode>) {
+        node.attached.store(true, AtomicOrdering::Release);
+    }
+
     fn attach_child(self: &Arc<Self>, child: &Arc<FocusNode>) {
         // Set parent
         *child.parent.write() = Some(Arc::downgrade(self));
 
-        // Copy manager reference
-        *child.manager.write() = self.manager.read().clone();
-
-        // Mark as attached
+        // Mark as attached — the singleton manager is always reachable
+        // via FocusManager::global, so no per-node manager reference
+        // needs to be propagated.
         child.attached.store(true, AtomicOrdering::Release);
 
         // Add to children
@@ -441,9 +431,6 @@ impl FocusNode {
 
             // Clear parent
             *child.parent.write() = None;
-
-            // Clear manager
-            *child.manager.write() = None;
 
             // Mark as detached
             child.attached.store(false, AtomicOrdering::Release);
@@ -464,7 +451,6 @@ impl Default for FocusNode {
             on_key_event: RwLock::new(None),
             rect: RwLock::new(Rect::ZERO),
             attached: AtomicBool::new(false),
-            manager: RwLock::new(None),
         }
     }
 }
@@ -540,9 +526,8 @@ impl Iterator for DescendantIterator {
 ///
 /// ```rust,ignore
 /// // Create a dialog scope
-/// let dialog_scope = FocusScopeNode::new()
-///     .with_debug_label("dialog")
-///     .autofocus(true);
+/// let dialog_scope = FocusScopeNode::with_debug_label("dialog");
+/// dialog_scope.set_autofocus(true);
 ///
 /// // Add children
 /// dialog_scope.attach_node(&text_field);
@@ -550,7 +535,7 @@ impl Iterator for DescendantIterator {
 /// dialog_scope.attach_node(&cancel_button);
 ///
 /// // Later: focus returns to last focused child
-/// dialog_scope.request_focus();
+/// dialog_scope.set_first_focus();
 /// ```
 pub struct FocusScopeNode {
     /// The underlying focus node.
@@ -649,22 +634,20 @@ impl FocusScopeNode {
         self.focus_history.lock().retain(|id| *id != node_id);
     }
 
-    /// Sets focus to the first focusable child.
+    /// Sets focus to the first focusable child via the singleton.
     pub fn set_first_focus(self: &Arc<Self>) {
         let nodes = self.collect_focusable_nodes();
-        if let Some(first) = nodes.first()
-            && let Some(manager) = self.inner.manager.read().as_ref().and_then(|w| w.upgrade())
-        {
-            manager.set_primary_focus(Some(first.id()));
+        if let Some(first) = nodes.first() {
+            crate::FocusManager::global().request_focus(first.id());
         }
     }
 
     /// Compute the next focusable node ID per the scope's traversal
     /// policy without mutating any focus state.
     ///
-    /// Returns `None` if no next focusable exists. Use this instead of
-    /// [`focus_next_in_scope`] when the caller (e.g. the singleton
-    /// [`crate::FocusManager`]) needs to update its own focused state.
+    /// Returns `None` if no next focusable exists. Use this when the
+    /// caller (e.g. the [`crate::FocusManager`] singleton's
+    /// `focus_next`) needs to update its own focused state.
     pub fn next_focusable_id(&self, current: FocusNodeId) -> Option<FocusNodeId> {
         let nodes = self.collect_focusable_nodes();
         let policy = self.traversal_policy.read().clone();
@@ -679,16 +662,14 @@ impl FocusScopeNode {
         policy.find_previous(current, &nodes)
     }
 
-    /// Focuses the next node in this scope.
+    /// Focuses the next node in this scope. Returns `true` when focus
+    /// advanced.
     pub fn focus_next_in_scope(&self, current: FocusNodeId) -> bool {
         let Some(next_id) = self.next_focusable_id(current) else {
             return false;
         };
-        if let Some(manager) = self.inner.manager.read().as_ref().and_then(|w| w.upgrade()) {
-            manager.set_primary_focus(Some(next_id));
-            return true;
-        }
-        false
+        crate::FocusManager::global().request_focus(next_id);
+        true
     }
 
     /// Focuses the previous node in this scope.
@@ -696,11 +677,8 @@ impl FocusScopeNode {
         let Some(prev_id) = self.previous_focusable_id(current) else {
             return false;
         };
-        if let Some(manager) = self.inner.manager.read().as_ref().and_then(|w| w.upgrade()) {
-            manager.set_primary_focus(Some(prev_id));
-            return true;
-        }
-        false
+        crate::FocusManager::global().request_focus(prev_id);
+        true
     }
 
     /// Records that a node received focus.
@@ -845,100 +823,6 @@ impl ReadingOrderPolicy {
 }
 
 // ============================================================================
-// FocusManagerInner (internal state)
-// ============================================================================
-
-/// Internal state for focus management.
-pub(crate) struct FocusManagerInner {
-    /// Root scope.
-    root_scope: Arc<FocusScopeNode>,
-
-    /// Currently focused node ID.
-    primary_focus: RwLock<Option<FocusNodeId>>,
-
-    /// Focus change listeners.
-    #[allow(clippy::type_complexity)]
-    listeners: RwLock<Vec<Arc<dyn Fn(Option<FocusNodeId>, Option<FocusNodeId>) + Send + Sync>>>,
-}
-
-#[allow(dead_code)] // Future public API for focus management
-impl FocusManagerInner {
-    pub fn new() -> Arc<Self> {
-        let root_scope = FocusScopeNode::with_debug_label("Root Focus Scope");
-
-        let manager = Arc::new(Self {
-            root_scope: root_scope.clone(),
-            primary_focus: RwLock::new(None),
-            listeners: RwLock::new(Vec::new()),
-        });
-
-        // Set manager reference in root scope
-        *root_scope.inner.manager.write() = Some(Arc::downgrade(&manager));
-        root_scope
-            .inner
-            .attached
-            .store(true, AtomicOrdering::Release);
-
-        manager
-    }
-
-    pub fn root_scope(&self) -> &Arc<FocusScopeNode> {
-        &self.root_scope
-    }
-
-    pub fn primary_focus(&self) -> Option<FocusNodeId> {
-        *self.primary_focus.read()
-    }
-
-    pub fn set_primary_focus(&self, node_id: Option<FocusNodeId>) {
-        // Single write lock to atomically read previous and write new (avoids TOCTOU
-        // race)
-        let previous = {
-            let mut focus = self.primary_focus.write();
-            let previous = *focus;
-            if previous == node_id {
-                return;
-            }
-            *focus = node_id;
-            previous
-        };
-
-        // Record in enclosing scope's history
-        if let Some(id) = node_id
-            && let Some(node) = self.find_node(id)
-            && let Some(scope) = node.enclosing_scope()
-        {
-            scope.record_focus(id);
-        }
-
-        // Notify listeners
-        let listeners = self.listeners.read().clone();
-        for listener in listeners {
-            listener(previous, node_id);
-        }
-    }
-
-    pub fn add_listener(
-        &self,
-        callback: Arc<dyn Fn(Option<FocusNodeId>, Option<FocusNodeId>) + Send + Sync>,
-    ) {
-        self.listeners.write().push(callback);
-    }
-
-    fn find_node(&self, id: FocusNodeId) -> Option<Arc<FocusNode>> {
-        // Search from root
-        if self.root_scope.inner.id() == id {
-            return Some(self.root_scope.inner.clone());
-        }
-
-        self.root_scope
-            .inner
-            .descendants()
-            .find(|node| node.id() == id)
-    }
-}
-
-// ============================================================================
 // Tests
 // ============================================================================
 
@@ -979,14 +863,16 @@ mod tests {
 
         assert_eq!(scope.as_focus_node().children().len(), 1);
         assert!(node.parent().is_some());
+        // After attach the child is marked attached.
+        assert!(node.is_attached());
     }
 
     #[test]
-    fn test_focus_manager_inner() {
-        let manager = FocusManagerInner::new();
-
-        assert!(manager.primary_focus().is_none());
+    fn test_focus_manager_owns_root_scope() {
+        // The singleton's root scope is constructed eagerly and attached.
+        let manager = crate::FocusManager::new_for_test();
         assert!(manager.root_scope().as_focus_node().is_attached());
+        assert!(manager.primary_focus().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## U23 — FocusManager singleton unification

Closes audit Finding **I-4** (Two FocusManager implementations + half-implemented Tab navigation).
Closes plan **Unit U23** ([2026-05-21-003-feat-input-frame-loop-repair-plan.md](docs/plans/2026-05-21-003-feat-input-frame-loop-repair-plan.md)).

Predecessor: [PR #96](https://github.com/vanyastaff/flui/pull/96) (PointerId widening to ui_events).

## Problem

Audit Part I Finding I-4 documented two parallel focus management implementations:

1. **`FocusManager`** (`focus.rs`) — public singleton via `OnceLock`, flat-state: `focused: RwLock<Option<FocusNodeId>>` + listeners + key handlers + an `active_scope: RwLock<Option<Arc<FocusScopeNode>>>` override (added in PR #88).
2. **`FocusManagerInner`** (`focus_scope.rs`) — private `pub(crate)` Arc-based dual state: `root_scope: Arc<FocusScopeNode>` + separate `primary_focus: RwLock<Option<FocusNodeId>>` + separate listener list.

Each `FocusNode` held a `manager: RwLock<Option<Weak<FocusManagerInner>>>` weak-ref. `FocusScopeNode::focus_next_in_scope` updated `FocusManagerInner::set_primary_focus` but **not** `FocusManager.focused` — the two states drifted. PR #88 review fix (`#90`) routed `FocusManager::focus_next` through `request_focus` to bridge them, but the underlying dual structure remained.

## What this PR does

Single architectural commit (`542d07ec`) collapsing the dual structure into a single source of truth.

### FocusManager singleton now owns everything

```rust
pub struct FocusManager {
    root_scope: Arc<FocusScopeNode>,                  // Flutter parity (rootScope)
    primary_focus: RwLock<Option<FocusNodeId>>,
    listeners: RwLock<Vec<FocusChangeCallback>>,
    key_handlers: RwLock<HashMap<FocusNodeId, KeyEventCallback>>,
    global_key_handlers: RwLock<Vec<KeyEventCallback>>,
    active_scope: RwLock<Option<Arc<FocusScopeNode>>>, // override; defaults to root
}
```

`root_scope` is constructed eagerly in `Default` (matches Flutter's `FocusManager.rootScope` non-null invariant). `FocusNode::mark_root_attached` pub(crate) helper sets the attached flag on the root since it has no parent and never goes through `attach_child`.

### FocusNode loses the weak-ref dance

`FocusNode` no longer carries `manager: RwLock<Option<Weak<FocusManagerInner>>>`. `has_focus` / `has_primary_focus` / `request_focus` / `unfocus` reach `FocusManager::global()` directly — singleton is always live and globally reachable, no weak-ref upgrade needed.

```rust
// before
if let Some(manager) = self.manager.read().as_ref().and_then(|w| w.upgrade()) {
    manager.set_primary_focus(Some(self.id));
}
// after
crate::FocusManager::global().request_focus(self.id);
```

### TOCTOU-safe primary focus updates

Prior `FocusManager::request_focus` had a TOCTOU race:

```rust
let previous = *self.focused.read();    // read lock 1
*self.focused.write() = Some(node_id);  // write lock 2 — competing request_focus can interleave
```

The new `set_primary_focus` carries the single-write-lock pattern migrated from `FocusManagerInner::set_primary_focus` (matches Flutter `FocusManager._applyFocusChange`):

```rust
let previous = {
    let mut focus = self.primary_focus.write();
    let previous = *focus;
    if previous == node_id { return; }
    *focus = node_id;
    previous
};
```

### active_scope as override

`active_scope` keeps Flutter modal-route scope-push semantics: `None` means 'use `root_scope`'. `focus_next` / `focus_previous` use `self.active_scope()` which falls back to `root_scope` when no override is set. The `missing_scope_warned` warn-latch from PR #88 is gone — there is no missing-scope path anymore.

### FocusScopeNode delegates to singleton

`focus_next_in_scope` / `focus_previous_in_scope` / `set_first_focus` route through `FocusManager::global().request_focus(id)` instead of the now-deleted `FocusManagerInner::set_primary_focus`. Same Flutter semantics — focus mutations always go through the singleton.

### Deleted

- `FocusManagerInner` struct (88 LOC) — entirely removed
- `FocusNode::manager: RwLock<Option<Weak<FocusManagerInner>>>` field
- `FocusManager::missing_scope_warned: AtomicBool` + `warn_missing_scope` helper
- `test_focus_manager_inner` replaced by `test_focus_manager_owns_root_scope` guarding the same root-attached invariant against the new singleton

## Flutter parity

Mirrors [`widgets/focus_manager.dart:1636`](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/widgets/focus_manager.dart):

```dart
class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
  FocusManager() {
    rootScope._manager = this;     // FLUI: mark_root_attached
  }
  final FocusScopeNode rootScope = FocusScopeNode(debugLabel: 'Root Focus Scope');
  FocusNode? get primaryFocus => _primaryFocus;
  FocusNode? _primaryFocus;
}
```

Listener notification clones the Vec under read lock before invoking each callback (Flutter `ChangeNotifier` reentrancy semantics — listeners may add/remove other listeners without deadlock).

## Verification

All gates green:

| Gate | Result |
|------|--------|
| `cargo build --workspace --all-targets` | clean (only pre-existing example name collisions) |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test -p flui-interaction --lib` | **250 passed** (baseline post-U9 was 249 + 1 new `test_focus_manager_owns_root_scope`) |
| `scripts/port-check.sh -v` | all 7 institutional refusal triggers clean |

## Net delta

**305 inserted, 346 deleted (-41 LOC)** — proper restructuring, not additive scaffolding. The dual-state design and per-node weak-ref machinery contributed real complexity that the singleton merger removes.

## Files

- `crates/flui-interaction/src/routing/focus.rs` — FocusManager owns root_scope, TOCTOU-safe set_primary_focus, active_scope override-with-root-fallback
- `crates/flui-interaction/src/routing/focus_scope.rs` — FocusNode loses manager weak-ref, FocusScopeNode delegates to singleton, FocusManagerInner deleted
- `crates/flui-interaction/README.md` — fix `next_focus`/`previous_focus` → `focus_next`/`focus_previous` (existing API rename from PR #88)
- `crates/flui-interaction/docs/ARCHITECTURE.md` — refresh FocusManager struct sketch + traversal policy trait signature (drop stale `OrderedTraversalPolicy` / `DirectionalFocusPolicy` from pre-U4)

## Plan progress

- U10, U11, U12 — landed (Ticker / Recognizer / FocusManager dispose pattern)
- U13, U16, U17, U18, U19, U20 — landed (PrimaryPointer + OneSequence trait infrastructure + Tap/LongPress/Drag/Scale/ForcePress migrations)
- U15, U24 — landed PR #95 (Ticker absorbs ScheduledTicker)
- U9 — landed PR #96 (PointerId widening)
- **U23 — closes here**

🤖 Generated with [Claude Code](https://claude.com/claude-code)