### PR TITLE
fix: PR #95 + #97 review followups — Ticker restart + focus attachment correctness

### DIFF
--- a/crates/flui-animation/src/controller.rs
+++ b/crates/flui-animation/src/controller.rs
@@ -266,6 +266,12 @@ impl AnimationController {
 
         if let Some(ticker) = &mut inner.ticker {
             let controller = self.clone();
+            // Restart-safe: stop if already Active (PR #95 review fix — Ticker::start
+            // debug-asserts on Active state; AnimationController methods can be called
+            // repeatedly, so we must stop the previous run before starting a new one).
+            if ticker.state().can_tick() {
+                ticker.stop();
+            }
             ticker.start(move |_elapsed| {
                 controller.tick();
             });
@@ -314,6 +320,12 @@ impl AnimationController {
 
         if let Some(ticker) = &mut inner.ticker {
             let controller = self.clone();
+            // Restart-safe: stop if already Active (PR #95 review fix — Ticker::start
+            // debug-asserts on Active state; AnimationController methods can be called
+            // repeatedly, so we must stop the previous run before starting a new one).
+            if ticker.state().can_tick() {
+                ticker.stop();
+            }
             ticker.start(move |_elapsed| {
                 controller.tick();
             });
@@ -429,6 +441,12 @@ impl AnimationController {
 
         if let Some(ticker) = &mut inner.ticker {
             let notifier = Arc::clone(&self.notifier);
+            // Restart-safe: stop if already Active (PR #95 review fix — Ticker::start
+            // debug-asserts on Active state; AnimationController methods can be called
+            // repeatedly, so we must stop the previous run before starting a new one).
+            if ticker.state().can_tick() {
+                ticker.stop();
+            }
             ticker.start(move |_elapsed| {
                 notifier.notify_listeners();
             });
@@ -465,6 +483,12 @@ impl AnimationController {
         if let Some(ticker) = &mut inner.ticker {
             eprintln!("[DEBUG] AnimationController::repeat starting ticker");
             let controller = self.clone();
+            // Restart-safe: stop if already Active (PR #95 review fix — Ticker::start
+            // debug-asserts on Active state; AnimationController methods can be called
+            // repeatedly, so we must stop the previous run before starting a new one).
+            if ticker.state().can_tick() {
+                ticker.stop();
+            }
             ticker.start(move |_elapsed| {
                 controller.tick();
             });
@@ -567,6 +591,12 @@ impl AnimationController {
 
         if let Some(ticker) = &mut inner.ticker {
             let controller = self.clone();
+            // Restart-safe: stop if already Active (PR #95 review fix — Ticker::start
+            // debug-asserts on Active state; AnimationController methods can be called
+            // repeatedly, so we must stop the previous run before starting a new one).
+            if ticker.state().can_tick() {
+                ticker.stop();
+            }
             ticker.start(move |_elapsed| {
                 controller.tick();
             });
@@ -629,6 +659,12 @@ impl AnimationController {
 
         if let Some(ticker) = &mut inner.ticker {
             let controller = self.clone();
+            // Restart-safe: stop if already Active (PR #95 review fix — Ticker::start
+            // debug-asserts on Active state; AnimationController methods can be called
+            // repeatedly, so we must stop the previous run before starting a new one).
+            if ticker.state().can_tick() {
+                ticker.stop();
+            }
             ticker.start(move |_elapsed| {
                 controller.tick();
             });
@@ -671,6 +707,12 @@ impl AnimationController {
 
         if let Some(ticker) = &mut inner.ticker {
             let controller = self.clone();
+            // Restart-safe: stop if already Active (PR #95 review fix — Ticker::start
+            // debug-asserts on Active state; AnimationController methods can be called
+            // repeatedly, so we must stop the previous run before starting a new one).
+            if ticker.state().can_tick() {
+                ticker.stop();
+            }
             ticker.start(move |_elapsed| {
                 controller.tick();
             });

--- a/crates/flui-interaction/src/routing/focus_scope.rs
+++ b/crates/flui-interaction/src/routing/focus_scope.rs
@@ -288,7 +288,14 @@ impl FocusNode {
     /// This is `true` if any node in this subtree has primary focus.
     /// Reaches the [`crate::FocusManager`] singleton directly (no Weak
     /// upgrade dance) — singleton always live.
+    ///
+    /// PR #97 review fix: gated on `is_attached()` so detached nodes
+    /// (still holding a stale FocusManager.primary_focus ID после
+    /// `detach_child`) don't lie about having focus.
     pub fn has_focus(&self) -> bool {
+        if !self.is_attached() {
+            return false;
+        }
         let Some(focused_id) = crate::FocusManager::global().primary_focus() else {
             return false;
         };
@@ -296,7 +303,13 @@ impl FocusNode {
     }
 
     /// Returns whether this specific node has primary focus.
+    ///
+    /// PR #97 review fix: same is_attached() gate as `has_focus` to
+    /// avoid stale-focus reports for detached nodes.
     pub fn has_primary_focus(&self) -> bool {
+        if !self.is_attached() {
+            return false;
+        }
         crate::FocusManager::global().primary_focus() == Some(self.id)
     }
 
@@ -432,8 +445,35 @@ impl FocusNode {
             // Clear parent
             *child.parent.write() = None;
 
-            // Mark as detached
-            child.attached.store(false, AtomicOrdering::Release);
+            // PR #97 review fix: detach recursively so the entire removed
+            // subtree is marked detached, not just the direct child.
+            // Without this, descendants kept `attached == true` despite
+            // being unreachable from the root scope — making
+            // `request_focus` on those descendants succeed AND
+            // `has_focus`/`has_primary_focus` (with the new is_attached
+            // gate) return inconsistent results across the subtree.
+            Self::detach_subtree(&child);
+
+            // Clear FocusManager.primary_focus if the detached subtree
+            // owned the current focus — prevents stale focus state from
+            // outliving the tree node.
+            let focus_mgr = crate::FocusManager::global();
+            if let Some(focused_id) = focus_mgr.primary_focus()
+                && (child.id == focused_id || child.has_descendant(focused_id))
+            {
+                focus_mgr.unfocus();
+            }
+        }
+    }
+
+    /// Recursively mark a FocusNode and all its descendants as detached.
+    ///
+    /// Used by [`detach_child`] to ensure the entire removed subtree's
+    /// attached state matches reality после parent-link clearing.
+    fn detach_subtree(node: &Arc<FocusNode>) {
+        node.attached.store(false, AtomicOrdering::Release);
+        for grandchild in node.children.read().iter() {
+            Self::detach_subtree(grandchild);
         }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up fixes addressing reviewer findings (Codex P1 + Copilot inline) on PRs [#95](https://github.com/vanyastaff/flui/pull/95) (U15 + U24) and [#97](https://github.com/vanyastaff/flui/pull/97) (U23 FocusManager merger). 2 atomic commits, one per source PR.

## Fixes

| Commit | Source PR | Findings | Description |
|---|---|---|---|
| HEAD~1 | [#95](https://github.com/vanyastaff/flui/pull/95) | Codex P1 | AnimationController `ticker.start()` restart pattern. Post-U15 Ticker debug-asserts on Active (Flutter "started twice" parity); pre-fix code panicked in debug on `forward_from`/`reverse_from`/`animate_to`/`repeat`/`fling_with` re-entry. 7 callsites prepended с `if ticker.state().can_tick() { ticker.stop(); }`. Preserves ScheduledTicker restart semantics без dropping the debug-assert. |
| HEAD | [#97](https://github.com/vanyastaff/flui/pull/97) | Codex P1 + Copilot ×2 | Focus attachment correctness: (1) `has_focus`/`has_primary_focus` now gate on `is_attached()` — detached nodes no longer report stale primary focus; (2) `detach_child` now recursively marks the entire removed subtree via new `Self::detach_subtree` helper; (3) detach clears `FocusManager.primary_focus` if the detached subtree owned focus — global manager never points outside the tree. |

## Architectural notes

- **Ticker restart contract**: matches the workspace-wide PR #84 dispose-pattern discipline. `start()` is single-cycle; restart requires explicit `stop()` first. Animation framework owns the restart pattern internally so callers see the convenient `forward_from(value)` API while debug-assertions catch misuse.
- **Tree consistency invariant**: `attached: AtomicBool` now reflects "reachable from root scope" accurately. Three coupled fixes restore the invariant that no focus query returns truth that contradicts the tree shape.

## Verification at HEAD

- `cargo build --workspace --all-targets`: ✅ clean
- `cargo clippy --workspace --all-targets -- -D warnings`: ✅ clean
- `cargo test -p flui-interaction --lib`: ✅ 250 passed
- `bash scripts/port-check.sh -v`: ✅ 7/7 clean

## Predecessor

PR [#97](https://github.com/vanyastaff/flui/pull/97) (`3a247305` U23 FocusManager singleton merger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)