### PR TITLE
refactor: cycle 4 opening — non_exhaustive on rendering+engine public error enums

### DIFF
--- a/crates/flui-engine/src/wgpu/tessellator.rs
+++ b/crates/flui-engine/src/wgpu/tessellator.rs
@@ -21,7 +21,10 @@ use thiserror::Error;
 use super::vertex::Vertex;
 
 /// Errors that can occur during tessellation
+///
+/// Cycle 4: `#[non_exhaustive]` future-compat marker.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum TessellationError {
     #[error("Fill tessellation failed: {0}")]
     FillFailed(String),

--- a/crates/flui-rendering/src/error.rs
+++ b/crates/flui-rendering/src/error.rs
@@ -7,7 +7,13 @@ use flui_foundation::RenderId;
 use thiserror::Error;
 
 /// Errors that can occur during rendering operations.
+///
+/// Cycle 4: `#[non_exhaustive]` future-compat marker. Matches the
+/// workspace 2026 quality bar — public error enums in foundation /
+/// tree / painting / engine all carry the attribute (cycle 3 I-11
+/// added it on `DiagnosticLevel` / `DiagnosticsTreeStyle`).
 #[derive(Error, Debug, Clone)]
+#[non_exhaustive]
 pub enum RenderError {
     // ========================================================================
     // Attachment Errors

--- a/crates/flui-rendering/src/pipeline/handle.rs
+++ b/crates/flui-rendering/src/pipeline/handle.rs
@@ -61,7 +61,10 @@ pub struct DirtyRequest {
 // ---------------------------------------------------------------------------
 
 /// Errors returned by [`PipelineOwnerHandle::request_mark_dirty`].
+///
+/// Cycle 4: `#[non_exhaustive]` future-compat marker.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum SendError {
     /// The channel is full; the producer must back off.
     #[error("dirty channel full ({capacity} capacity); back off and retry")]


### PR DESCRIPTION
# refactor: cycle 4 opening — `#[non_exhaustive]` on rendering+engine public error enums

Cycle 4 opening commit. Closes 3 missing `#[non_exhaustive]` markers on public error enums in `flui-rendering` and `flui-engine`. Matches cycle 3 I-11 precedent on `DiagnosticLevel` / `DiagnosticsTreeStyle`.

## Closes

- `flui-rendering::RenderError` — ~20 variants; new pipeline phase errors can land without SemVer break
- `flui-rendering::SendError` — 2 variants (ChannelFull, OwnerGone); future back-pressure modes possible
- `flui-engine::TessellationError` — 2 variants (FillFailed, StrokeFailed); new lyon error categories possible

## Cycle 4 status

Full Mythos audit blocked by sustained 529 API overload (two architect dispatches failed mid-flight). Pre-existing audit `docs/research/2026-05-20-mythos-audit-render-paint-layer-engine.md` predates cycles 2/3 — most flagged findings already closed by intervening PRs (#82 ClipContext, #83 SUPERELLIPSE_CACHE, #103 TreeWrite cascade, #105 zombie mega-delete). Inline verification confirmed:

- `RenderDirtyPropagation` — already `pub(crate)` (closed)
- `IntrinsicProtocol` / `BaselineProtocol` — already cleaned (closed)
- `SUPERELLIPSE_CACHE` unbounded — closed by PR #83
- RenderView 180+ commented lines — already deleted (only 10 left)
- `RendererBinding` — has flui-app consumers (false positive)
- Delegate traits (`CustomClipper`, `CustomPainter`, `FlowDelegate`, etc.) — kept as user extension points despite 0 internal impls

This PR ships the obviously-correct non_exhaustive polish that didn't need architect's deep analysis. Full cycle 4 audit PR will land when architect dispatch unblocked.

## Verification

- `cargo build --workspace --all-targets` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test -p flui-rendering --lib` 318/318 ✅
- `cargo test -p flui-engine --lib` 59/59 ✅
- `bash scripts/port-check.sh -v` all 7 institutional refusal triggers clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
