### PR TITLE
feat(rendering,view)!: cycle 4 Wave 3b — close 4 P1 audit findings (R-11/15/16/18)

### DIFF
--- a/crates/flui-rendering/Cargo.toml
+++ b/crates/flui-rendering/Cargo.toml
@@ -35,3 +35,20 @@ mockall = "0.13"
 [features]
 default = []
 serde = ["dep:serde", "flui-types/serde"]
+
+# Cycle 4 R-18: gate `ScrollMetrics` trait + `FixedScrollMetrics` +
+# `FixedExtentMetrics` (~452 LOC at `src/constraints/scroll_metrics.rs`)
+# behind an off-by-default feature. The types had zero workspace
+# consumers; gating prevents the dead surface from being compiled into
+# every dependent build while keeping the code available for the
+# scrolling integration that will eventually land. Opt in via
+# `--features scrolling`.
+scrolling = []
+
+# Cycle 4 R-16: gate the delegate trait modules (~1,800 LOC across
+# `delegates/custom_painter.rs`, `flow.rs`, `multi_child_layout.rs`,
+# `single_child_layout.rs`, `sliver_grid.rs`, `custom_clipper.rs`)
+# behind an off-by-default feature. Each delegate trait has zero
+# production impls; gating removes the surface from default builds
+# without deleting it. Opt in via `--features experimental-delegates`.
+experimental-delegates = []

--- a/crates/flui-rendering/src/constraints/mod.rs
+++ b/crates/flui-rendering/src/constraints/mod.rs
@@ -83,6 +83,12 @@
 
 mod box_constraints;
 mod direction;
+// Cycle 4 R-18: scroll_metrics gated behind `scrolling` feature
+// (default off). The trait + 2 impls had zero workspace consumers
+// pre-cycle; gating prevents the dead surface from compiling into
+// every dependent build while keeping the code available for the
+// scrolling integration that will eventually land.
+#[cfg(feature = "scrolling")]
 mod scroll_metrics;
 mod sliver_constraints;
 mod sliver_geometry;
@@ -91,6 +97,7 @@ use std::fmt;
 
 pub use box_constraints::BoxConstraints;
 pub use direction::GrowthDirection;
+#[cfg(feature = "scrolling")]
 pub use scroll_metrics::{FixedExtentMetrics, FixedScrollMetrics, ScrollMetrics};
 pub use sliver_constraints::SliverConstraints;
 pub use sliver_geometry::SliverGeometry;
@@ -153,7 +160,10 @@ pub trait Constraints: Clone + PartialEq + fmt::Debug + Send + Sync + 'static {
 /// ```
 pub mod prelude {
     pub use super::{
-        BoxConstraints, Constraints, FixedExtentMetrics, FixedScrollMetrics, GrowthDirection,
-        ScrollMetrics, SliverConstraints, SliverGeometry,
+        BoxConstraints, Constraints, GrowthDirection, SliverConstraints, SliverGeometry,
     };
+    // Cycle 4 R-18: scroll-metrics types in the prelude only when
+    // the `scrolling` feature is enabled.
+    #[cfg(feature = "scrolling")]
+    pub use super::{FixedExtentMetrics, FixedScrollMetrics, ScrollMetrics};
 }

--- a/crates/flui-rendering/src/lib.rs
+++ b/crates/flui-rendering/src/lib.rs
@@ -55,6 +55,20 @@
 pub mod binding;
 pub mod constraints;
 pub mod context;
+// Cycle 4 R-16: delegates gated behind `experimental-delegates`
+// (default off). The 6 delegate trait modules (~1,800 LOC at
+// `delegates/{custom_painter, flow_delegate, multi_child_layout_delegate,
+// single_child_layout_delegate, sliver_grid_delegate,
+// custom_clipper}.rs`) had zero production impls -- only test mocks.
+// The 2026-05-20 audit flagged at MEDIUM with the verdict "wait for
+// companion render-objects"; 18 months later those render-objects
+// still don't exist. Gating removes the dead surface from default
+// builds + prelude while preserving the design work behind a feature
+// flag. Opt in via `--features experimental-delegates` when the
+// companion render-objects (RenderCustomPaint, RenderFlow,
+// RenderCustomMultiChildLayoutBox, RenderSliverGrid, RenderCustomClip,
+// RenderSingleChildLayoutBox) land.
+#[cfg(feature = "experimental-delegates")]
 pub mod delegates;
 pub mod error;
 pub mod hit_testing;
@@ -129,13 +143,6 @@ pub mod prelude {
             RendererBinding, debug_dump_layer_tree, debug_dump_pipeline_owner_tree,
             debug_dump_render_tree, debug_dump_semantics_tree,
         },
-        delegates::{
-            AspectRatioDelegate, CenterLayoutDelegate, CustomClipper, CustomPainter, FlowDelegate,
-            FlowPaintingContext, MultiChildLayoutContext, MultiChildLayoutDelegate, RectClipper,
-            SemanticsBuilder, SingleChildLayoutDelegate, SliverGridDelegate,
-            SliverGridDelegateWithFixedCrossAxisCount, SliverGridDelegateWithMaxCrossAxisExtent,
-            SliverGridLayout,
-        },
         parent_data::{
             BoxParentData, ContainerBoxParentData, FlexFit, FlexParentData, ParentData,
             SliverGridParentData, SliverMultiBoxAdaptorParentData, SliverParentData,
@@ -153,6 +160,16 @@ pub mod prelude {
             RenderView, RevealedOffset, ScrollDirection, ScrollableViewportOffset,
             SliverPaintOrder, ViewConfiguration, ViewportOffset,
         },
+    };
+    // Cycle 4 R-16: delegates surface only when
+    // `experimental-delegates` is enabled (default off).
+    #[cfg(feature = "experimental-delegates")]
+    pub use crate::delegates::{
+        AspectRatioDelegate, CenterLayoutDelegate, CustomClipper, CustomPainter, FlowDelegate,
+        FlowPaintingContext, MultiChildLayoutContext, MultiChildLayoutDelegate, RectClipper,
+        SemanticsBuilder, SingleChildLayoutDelegate, SliverGridDelegate,
+        SliverGridDelegateWithFixedCrossAxisCount, SliverGridDelegateWithMaxCrossAxisExtent,
+        SliverGridLayout,
     };
 }
 

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -1007,61 +1007,109 @@ impl PipelineOwner<PaintPhase> {
     pub fn run_paint(&mut self) -> crate::error::RenderResult<()> {
         tracing::debug!("run_paint: {} nodes", self.dirty.needs_paint.len());
 
-        // Process own dirty nodes if any
-        if !self.dirty.needs_paint.is_empty() {
-            self.debug_doing_paint = true;
-
-            // Take dirty nodes and replace with empty vec
-            let dirty_nodes = std::mem::take(&mut self.dirty.needs_paint);
-
-            // Sort by depth (deep first) - children before parents
-            // Flutter: dirtyNodes.sort((a, b) => b.depth - a.depth)
-            // Note: We don't need to sort for now since we paint from root
-
-            // Clear needs_paint flags for all dirty nodes
-            for dirty_node in &dirty_nodes {
-                if let Some(render_node) = self.render_tree.get(dirty_node.id) {
-                    render_node.clear_needs_paint();
-                }
-            }
-
-            // Paint render tree recursively starting from root.
-            // Each parent paints itself, then paints children with accumulated offset.
-            //
-            // Mythos Step 12: paint_node_recursive returns RenderResult<()>;
-            // a panicking render object surfaces as Err(Poisoned). We must
-            // restore debug_doing_paint before `?`-propagating so the
-            // owner's debug invariants stay consistent on the error path.
-            if let Some(root_id) = self.root_id
-                && let Some(root_node) = self.render_tree.get(root_id)
-            {
-                let paint_bounds = root_node.paint_bounds();
-                tracing::debug!("run_paint: painting root with bounds {:?}", paint_bounds);
-
-                // Create CanvasContext
-                let mut context = CanvasContext::new(paint_bounds);
-
-                // Paint recursively from root with offset accumulation
-                let paint_result = self.paint_node_recursive(&mut context, root_id, Offset::ZERO);
-
-                match paint_result {
-                    Ok(()) => {
-                        // Store the resulting layer tree
-                        self.last_layer_tree = Some(context.into_layer_tree());
-                        tracing::debug!(
-                            "run_paint: layer tree has {} layers",
-                            self.last_layer_tree.as_ref().map(|t| t.len()).unwrap_or(0)
-                        );
-                    }
-                    Err(e) => {
-                        self.debug_doing_paint = false;
-                        return Err(e);
-                    }
-                }
-            }
-
-            self.debug_doing_paint = false;
+        if self.dirty.needs_paint.is_empty() {
+            return Ok(());
         }
+
+        self.debug_doing_paint = true;
+
+        // Cycle 4 R-15: pre-fix this method
+        //   1. drained `dirty.needs_paint` via `std::mem::take` (capacity-
+        //      dropping),
+        //   2. did NOT sort the dirty list by depth (comment said
+        //      "we don't need to sort since we paint from root"),
+        //   3. cleared every dirty node's `needs_paint` flag in a
+        //      separate loop BEFORE the paint walk,
+        //   4. painted via root descent (`paint_node_recursive`),
+        //   5. silently dropped any dirty node not reached by the
+        //      descent (its flag was already cleared, its paint command
+        //      never recorded).
+        //
+        // Audit R-15 flagged steps 2/3/5 as a half-impl: Flutter's
+        // `flushPaint` sorts dirty deep-first AND paints each node
+        // (paint clears the flag, no separate pass). Dropping paints
+        // for unreached nodes is silent bug-bait for any future
+        // multi-root or detached-subtree design.
+        //
+        // Post-fix:
+        //   1. Sort dirty deep-first (Reverse depth) so repaint-
+        //      boundary subtrees process before their ancestors when
+        //      the per-node dirty-driven paint path lands.
+        //   2. Walk via root descent (unchanged).
+        //   3. `paint_node_recursive` clears `needs_paint` per node it
+        //      visits (folded into the recursion).
+        //   4. After the walk, scan the dirty list for nodes whose
+        //      flag is still set -- those are the unreached cases.
+        //   5. Emit `tracing::warn!` for each unreached dirty node,
+        //      then clear (so the dirty list doesn't accumulate
+        //      across frames).
+
+        self.dirty
+            .needs_paint
+            .sort_unstable_by_key(|n| std::cmp::Reverse(n.depth));
+
+        // Paint render tree recursively starting from root.
+        // Each parent paints itself, then paints children with
+        // accumulated offset.
+        //
+        // Mythos Step 12: paint_node_recursive returns RenderResult<()>;
+        // a panicking render object surfaces as Err(Poisoned). We must
+        // restore debug_doing_paint before `?`-propagating so the
+        // owner's debug invariants stay consistent on the error path.
+        if let Some(root_id) = self.root_id
+            && let Some(root_node) = self.render_tree.get(root_id)
+        {
+            let paint_bounds = root_node.paint_bounds();
+            tracing::debug!("run_paint: painting root with bounds {:?}", paint_bounds);
+
+            // Create CanvasContext
+            let mut context = CanvasContext::new(paint_bounds);
+
+            // Paint recursively from root with offset accumulation.
+            // `paint_node_recursive` clears `needs_paint` on every
+            // node it visits (R-15 fold), so the dirty-list scan
+            // below only fires for the unreached cases.
+            let paint_result = self.paint_node_recursive(&mut context, root_id, Offset::ZERO);
+
+            match paint_result {
+                Ok(()) => {
+                    // Store the resulting layer tree
+                    self.last_layer_tree = Some(context.into_layer_tree());
+                    tracing::debug!(
+                        "run_paint: layer tree has {} layers",
+                        self.last_layer_tree.as_ref().map(|t| t.len()).unwrap_or(0)
+                    );
+                }
+                Err(e) => {
+                    self.debug_doing_paint = false;
+                    return Err(e);
+                }
+            }
+        }
+
+        // R-15: dirty-list residue scan. Any node still flagged
+        // needs_paint AFTER the root descent is the unreached case
+        // the pre-fix loop silently swallowed. Warn + clear so the
+        // bug is visible AND the dirty list doesn't accumulate
+        // across frames.
+        for dirty_node in &self.dirty.needs_paint {
+            if let Some(render_node) = self.render_tree.get(dirty_node.id)
+                && render_node.needs_paint()
+            {
+                tracing::warn!(
+                    id = ?dirty_node.id,
+                    depth = dirty_node.depth,
+                    "run_paint: dirty node not reached by root descent (multi-root \
+                     or detached subtree?); paint dropped, flag cleared"
+                );
+                render_node.clear_needs_paint();
+            }
+        }
+        // `clear()` retains capacity per cycle 4 R-1/R-4 PR #109
+        // review feedback (preserve Vec backing across frames).
+        self.dirty.needs_paint.clear();
+
+        self.debug_doing_paint = false;
         Ok(())
     }
 
@@ -1132,6 +1180,15 @@ impl PipelineOwner<PaintPhase> {
                     render_object.paint(context, offset);
                 }))
                 .map_err(|_| crate::error::RenderError::poisoned(debug_name, "paint"))?;
+
+                // Cycle 4 R-15: clear the needs_paint flag now that
+                // this node has been painted. Pre-fix the flag was
+                // cleared in a separate up-front loop on `dirty.needs_paint`,
+                // which silently dropped paints for nodes not reachable
+                // from `root_id`. Folding the clear into the recursive
+                // visit ensures the flag-clear and the paint walk stay
+                // in lockstep -- Flutter's `flushPaint` model.
+                render_node.clear_needs_paint();
 
                 // For each child in the tree, get its offset from the render object
                 // The render object stores offsets via position_child during layout

--- a/crates/flui-view/src/lib.rs
+++ b/crates/flui-view/src/lib.rs
@@ -192,7 +192,7 @@ pub use owner::{BuildOwner, ElementOwner};
 pub use tree::{ElementNode, ElementTree, reconcile_children};
 pub use view::{
     BoxedElement, BoxedView, ElementBase, ElementExt, ErrorElement, ErrorView, ErrorViewBuilder,
-    FlutterError, InheritedElement, InheritedView, IntoElement, IntoView, ParentData,
+    FlutterError, InheritedElement, InheritedView, IntoElement, IntoView, ParentDataConfig,
     ParentDataElement, ParentDataView, ProxyElement, ProxyView, RenderElement, RenderView,
     RootRenderElement, RootRenderView, StatefulElement, StatefulView, StatelessElement,
     StatelessView, View, ViewExt, ViewState, clear_error_view_builder, set_error_view_builder,
@@ -228,8 +228,8 @@ pub mod prelude {
         owner::{BuildOwner, ElementOwner},
         tree::{ElementNode, ElementTree, reconcile_children},
         view::{
-            BoxedView, InheritedView, IntoView, ParentData, ParentDataView, ProxyView, RenderView,
-            StatefulView, StatelessView, View, ViewExt, ViewState,
+            BoxedView, InheritedView, IntoView, ParentDataConfig, ParentDataView, ProxyView,
+            RenderView, StatefulView, StatelessView, View, ViewExt, ViewState,
         },
     };
 }

--- a/crates/flui-view/src/view/mod.rs
+++ b/crates/flui-view/src/view/mod.rs
@@ -35,7 +35,7 @@ pub use error::{
 };
 pub use inherited::InheritedView;
 pub use into_view::{BoxedElement, BoxedView, ElementExt, IntoElement, IntoView, ViewExt};
-pub use parent_data::{ParentData, ParentDataElement, ParentDataView};
+pub use parent_data::{ParentDataConfig, ParentDataElement, ParentDataView};
 pub use proxy::ProxyView;
 pub use render::RenderView;
 pub use root::{RootRenderElement, RootRenderView};

--- a/crates/flui-view/src/view/parent_data.rs
+++ b/crates/flui-view/src/view/parent_data.rs
@@ -61,14 +61,36 @@ use flui_foundation::ElementId;
 use super::view::{ElementBase, View};
 use crate::element::Lifecycle;
 
-/// Marker trait for types that can be used as ParentData.
+/// Marker trait for types that can be used as parent-data configuration.
 ///
-/// ParentData is attached to a child RenderObject and used by
-/// the parent during layout to position/configure the child.
-pub trait ParentData: Clone + Default + Send + Sync + 'static {}
+/// Implementing types describe the per-child configuration that a
+/// `ParentDataView` widget supplies to its parent RenderObject (e.g.
+/// `Flex`'s `flex` factor, `Stack`'s `top` / `left`). The parent reads
+/// the configuration during layout to position / size the child.
+///
+/// # Why the name
+///
+/// Cycle 4 R-11 renamed this trait from `ParentData` to
+/// `ParentDataConfig` so it no longer collides with
+/// `flui_rendering::ParentData` (the actual render-object storage
+/// trait carrying `Any` + downcasting). The two traits serve
+/// different concerns:
+///
+/// - `flui_view::ParentDataConfig` (this trait): marker for the
+///   widget-side **configuration value**, what a `ParentDataView`
+///   supplies (Flutter's `ParentDataWidget.applyParentData` payload).
+/// - `flui_rendering::ParentData`: the render-side **storage trait**
+///   that a `RenderObject` carries.
+///
+/// Same-name trait collision pre-cycle forced every workspace
+/// consumer importing both crates to fully-qualify or alias one of
+/// them. The rename matches Flutter's `ParentDataWidget` naming:
+/// the widget **configures** the parent-data; it is not itself the
+/// parent-data.
+pub trait ParentDataConfig: Clone + Default + Send + Sync + 'static {}
 
 // Implement for common types
-impl ParentData for () {}
+impl ParentDataConfig for () {}
 
 /// A View that provides parent data to its child RenderObject.
 ///
@@ -96,7 +118,12 @@ impl ParentData for () {}
 /// | TableCell | Table | row, column span |
 pub trait ParentDataView: Send + Sync + 'static + Sized {
     /// The type of parent data this View provides.
-    type ParentData: ParentData;
+    ///
+    /// Cycle 4 R-11: bound is `ParentDataConfig` (was `ParentData`,
+    /// renamed to disambiguate from `flui_rendering::ParentData`).
+    /// The associated-type name `ParentData` is kept because no
+    /// cross-crate collision can occur on associated-type names.
+    type ParentData: ParentDataConfig;
 
     /// Get the child View.
     fn child(&self) -> &dyn View;
@@ -306,7 +333,7 @@ mod tests {
         fit: bool,
     }
 
-    impl ParentData for TestParentData {}
+    impl ParentDataConfig for TestParentData {}
 
     // A dummy child view
     #[derive(Clone)]


### PR DESCRIPTION
# Cycle 4 Wave 3b — P1 rename + algorithm fix + feature gates (R-11/15/16/18)

4 atomic commits closing 4 of the remaining 7 P1 audit findings.
**Stacked on** [PR #112](https://github.com/vanyastaff/flui/pull/112)
(Wave 3a) — when #112 merges to main, rebase wave3b on top + retarget
(same flow as Wave 1→2 PR #109→#111).

Combined wave3a+wave3b branch diff vs main: **15 files changed,
+430 / −873** (~−443 LOC net).

## Wave 3b findings closed

| # | Finding | Theme | Commit |
|---|---------|-------|--------|
| R-11 | `flui_view::ParentData` trait collided with `flui_rendering::ParentData` | Rename → `ParentDataConfig` (Flutter `ParentDataWidget` parity) | `9c5dd95b` |
| R-15 | `run_paint` skipped depth sort + cleared flags in separate loop + silently dropped unreached dirty nodes | Sort deep-first + fold flag-clear into recursion + warn on residue | `7886e647` |
| R-18 | `ScrollMetrics` trait + 2 impls (~452 LOC) had zero workspace consumers | `#[cfg(feature = "scrolling")]` gate (default off) | `c69d6164` |
| R-16 | 6 delegate trait modules (~1,800 LOC) had zero production impls (18-month-old finding) | `#[cfg(feature = "experimental-delegates")]` gate (default off) | `f144e013` |

## Wave 3a findings already included (from #112)

| # | Commit |
|---|--------|
| R-19 | `2470fc5b` delete FixedViewportOffset unreachable listeners |
| E-6 | `acb82091` delete parallel `wgpu/pipelines.rs` |
| E-5 | `d4d3ed9c` delete 5 instancing helpers + drop module-level `#[allow(dead_code)]` |
| R-14 | `564e8135` delete 9 RenderView placeholder fields + writes |
| R-17 | `ac25cd99` `RenderError` `String` → `Box<str>` |
| E-7 | `ecd423ac` devtools-gate `ShaderCache::clear` + 5 dead uniform helpers |
| R-12 + R-13 | `6b7b5242` honest-doc `set_owner` + delete propagate/sync stubs |

## Verification

| Gate | Result |
|------|--------|
| `cargo build --workspace` (default features) | clean |
| `cargo build -p flui-rendering --features scrolling` | clean |
| `cargo build -p flui-rendering --features experimental-delegates` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | zero warnings |
| `cargo test -p flui-rendering --lib` (default) | 249 passed |
| `cargo test -p flui-rendering --lib --features scrolling` | 254 passed (+5 scroll_metrics) |
| `cargo test -p flui-rendering --lib --features experimental-delegates` | 271 passed (+22 delegate mocks) |
| `cargo test -p flui-view --lib` | 123 passed |
| `cargo test -p flui-engine --lib` | 59 passed |
| `cargo test -p flui-interaction --lib` | 250 passed |
| `bash scripts/port-check.sh -v` | 7/7 institutional refusal triggers clean |

## Breaking changes

- `9c5dd95b` (R-11): `pub use flui_view::ParentData` no longer
  resolves. External consumers migrate by switching the import to
  `flui_view::ParentDataConfig`. The associated-type
  `<MyView as ParentDataView>::ParentData` is unchanged.

## Cycle 4 status

After Wave 3b (this PR) merges:

- **P0** (14 total): 13 closed (Waves 1 + 2). R-11 was reclassified P1 → now closed in W3b-1.
- **P1** (14 total): 11 closed (Wave 3a + 3b). 3 remaining → Wave 3c (R-15 was P1 too — wait, already done here).
- Wait, recounting: Wave 3a closed 7 (R-12/13/14/17/19, E-5/6/7), Wave 3b closes 4 (R-11/15/16/18) = 11 closed. P1 remaining: E-8 (unwrap `Arc<Mutex<OffscreenRenderer>>`) + E-9 (split `CommandRenderer` trait). **2** remaining for Wave 3c.

## Remaining cycle 4

- **Wave 3c** (architectural): E-8 + E-9.
- **Wave 4** (P2/P3 cleanup): 10 P2 + 6 P3 mechanical items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
