### PR TITLE
refactor(engine)!: cycle 4 Wave 3c — split CommandRenderer trait (E-9); E-8 deferred

### DIFF
--- a/crates/flui-engine/src/lib.rs
+++ b/crates/flui-engine/src/lib.rs
@@ -104,7 +104,12 @@ pub use flui_layer::{
 };
 // Re-export Paint from flui_painting
 pub use flui_painting::Paint;
-pub use traits::CommandRenderer;
+// Cycle 4 E-9: CommandRenderer trait split into render-visitor
+// (CommandRenderer, ~34 methods) + layer-tree state-stack
+// (LayerStateStack, 13 methods). Backends that only emit
+// commands implement CommandRenderer only; compositors implement
+// both. See traits.rs E-9 commentary.
+pub use traits::{CommandRenderer, LayerStateStack};
 #[cfg(all(feature = "wgpu-backend", debug_assertions))]
 pub use wgpu::DebugBackend;
 // wgpu backend exports

--- a/crates/flui-engine/src/traits.rs
+++ b/crates/flui-engine/src/traits.rs
@@ -337,8 +337,67 @@ pub trait CommandRenderer {
     /// Restore canvas state and composite the saved layer
     fn restore_layer(&mut self, transform: &Matrix4);
 
-    // ===== Layer Tree Operations =====
+    // ===== Performance Overlay =====
 
+    /// Add a performance overlay to the scene
+    ///
+    /// This is the equivalent of Flutter's
+    /// `SceneBuilder.addPerformanceOverlay()`. Renders FPS counter and
+    /// frame timing statistics at the specified location.
+    ///
+    /// # Arguments
+    ///
+    /// * `options_mask` - Bitmask of `PerformanceOverlayOption` flags
+    /// * `bounds` - Rectangle where the overlay should be displayed
+    /// * `fps` - Current frames per second
+    /// * `frame_time_ms` - Average frame time in milliseconds
+    /// * `total_frames` - Total frames rendered
+    fn add_performance_overlay(
+        &mut self,
+        options_mask: u32,
+        bounds: Rect<Pixels>,
+        fps: f32,
+        frame_time_ms: f32,
+        total_frames: u64,
+    );
+}
+
+// ============================================================================
+// LAYER-STATE-STACK TRAIT (cycle 4 E-9 split)
+// ============================================================================
+
+/// Compositor hand-off interface for the flui-layer clip/transform/effect
+/// stacks.
+///
+/// Pre-cycle these 13 methods lived on [`CommandRenderer`] alongside the
+/// 34 per-command visitor methods. Cycle 4 E-9 split them into this
+/// dedicated trait because:
+///
+/// - The visitor methods (render_rect / render_text / ...) are the
+///   `DrawCommand` dispatch contract every backend implements -- a
+///   software fallback, a debug recorder, a Skia backend, all
+///   conceptually answer "given this draw command, produce these
+///   pixels".
+/// - The push/pop methods are flui-layer's clip-stack hand-off
+///   mechanism. They are framework-internal: the layer tree (see
+///   `crates/flui-engine/src/wgpu/layer_render.rs`) walks layers
+///   recursively, calling `push_clip_*` / `pop_clip` / `push_opacity`
+///   / etc. to mirror the layer-tree's nesting onto the painter's
+///   internal state stack.
+///
+/// Backends that ONLY emit commands (a `DebugBackend` recorder, a
+/// command-stream test fixture, a software fallback that does its
+/// own state tracking) implement only [`CommandRenderer`]. Backends
+/// that participate in flui-layer's clip-stack handshake -- the
+/// compositor route -- implement both. The trait split lets new
+/// command-only backends materialize without the 13-method overhead.
+///
+/// # Cycle 4 audit
+///
+/// See `docs/research/2026-05-22-flui-rendering-engine-audit.md`
+/// E-9. Same trait-split intuition as cycle 2 PR #100/U21
+/// SemanticsConfiguration split.
+pub trait LayerStateStack {
     /// Push a rectangular clip onto the clip stack
     fn push_clip_rect(&mut self, rect: &Rect<Pixels>, clip_behavior: flui_types::painting::Clip);
 
@@ -377,28 +436,4 @@ pub trait CommandRenderer {
 
     /// Pop the most recent image filter from the effect stack
     fn pop_image_filter(&mut self);
-
-    // ===== Performance Overlay =====
-
-    /// Add a performance overlay to the scene
-    ///
-    /// This is the equivalent of Flutter's
-    /// `SceneBuilder.addPerformanceOverlay()`. Renders FPS counter and
-    /// frame timing statistics at the specified location.
-    ///
-    /// # Arguments
-    ///
-    /// * `options_mask` - Bitmask of `PerformanceOverlayOption` flags
-    /// * `bounds` - Rectangle where the overlay should be displayed
-    /// * `fps` - Current frames per second
-    /// * `frame_time_ms` - Average frame time in milliseconds
-    /// * `total_frames` - Total frames rendered
-    fn add_performance_overlay(
-        &mut self,
-        options_mask: u32,
-        bounds: Rect<Pixels>,
-        fps: f32,
-        frame_time_ms: f32,
-        total_frames: u64,
-    );
 }

--- a/crates/flui-engine/src/wgpu/backend.rs
+++ b/crates/flui-engine/src/wgpu/backend.rs
@@ -14,7 +14,10 @@ use flui_types::{
 use std::sync::Arc;
 
 use super::painter::WgpuPainter;
-use crate::{commands::dispatch_command, traits::CommandRenderer};
+use crate::{
+    commands::dispatch_command,
+    traits::{CommandRenderer, LayerStateStack},
+};
 
 /// wgpu backend implementation of CommandRenderer.
 ///
@@ -1174,231 +1177,14 @@ impl CommandRenderer for Backend<'_> {
         self.painter.restore_layer();
     }
 
-    // ===== Layer Tree Operations =====
-
-    fn push_clip_rect(&mut self, rect: &Rect<Pixels>, _clip_behavior: flui_types::painting::Clip) {
-        self.painter.save();
-        self.painter.clip_rect(*rect);
-    }
-
-    fn push_clip_rrect(&mut self, rrect: &RRect, _clip_behavior: flui_types::painting::Clip) {
-        self.painter.save();
-        self.painter.clip_rrect(*rrect);
-    }
-
-    fn push_clip_path(&mut self, path: &Path, _clip_behavior: flui_types::painting::Clip) {
-        self.painter.save();
-        self.painter.clip_path(path);
-    }
-
-    fn pop_clip(&mut self) {
-        self.painter.restore();
-    }
-
-    fn push_offset(&mut self, offset: Offset<Pixels>) {
-        self.painter.save();
-        self.painter.translate(offset);
-    }
-
-    fn push_transform(&mut self, transform: &Matrix4) {
-        self.painter.save();
-
-        // Decompose and apply transform components
-        let transform_enum = Transform::from(*transform);
-        let (tx, ty, rotation, sx, sy) = transform_enum.decompose();
-
-        if tx != 0.0 || ty != 0.0 {
-            self.painter.translate(Offset::new(px(tx), px(ty)));
-        }
-        if rotation.abs() > f32::EPSILON {
-            self.painter.rotate(rotation);
-        }
-        if (sx - 1.0).abs() > f32::EPSILON || (sy - 1.0).abs() > f32::EPSILON {
-            self.painter.scale(sx, sy);
-        }
-    }
-
-    fn pop_transform(&mut self) {
-        self.painter.restore();
-    }
-
-    fn push_opacity(&mut self, alpha: f32) {
-        // Create a layer with opacity (clamped to [0, 255])
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let alpha_u8 = (alpha.clamp(0.0, 1.0) * 255.0) as u8;
-        let paint = Paint::fill(Color::WHITE).with_alpha(alpha_u8);
-        self.painter.save_layer(None, &paint);
-    }
-
-    fn pop_opacity(&mut self) {
-        self.painter.restore_layer();
-    }
-
-    fn push_color_filter(&mut self, filter: &flui_types::painting::ColorMatrix) {
-        // Check if the matrix is identity (no transformation needed)
-        let identity = flui_types::painting::ColorMatrix::identity();
-        // Exact f32 array comparison is intentional: ColorMatrix::identity()
-        // is built from bit-exact 0.0/1.0 literals, so a transitive equality
-        // check correctly fast-paths the no-op case without ULP slop.
-        #[expect(
-            clippy::float_cmp,
-            reason = "identity matrix is bit-exact (0.0/1.0 literals); exact comparison is correct"
-        )]
-        if filter.values == identity.values {
-            // Identity matrix: use a plain save so pop_color_filter stays balanced
-            self.painter.save_layer(None, &Paint::fill(Color::WHITE));
-            tracing::trace!("push_color_filter: identity matrix, no-op layer");
-            return;
-        }
-
-        // Pragmatic approximation: extract opacity and tint from the color matrix.
-        //
-        // A full GPU color matrix filter requires render-to-texture + post-processing
-        // which needs offscreen rendering infrastructure not yet available.
-        //
-        // Instead, we approximate the color matrix effect:
-        // 1. Alpha scaling from the matrix's alpha row (a3 = alpha scale factor)
-        // 2. Color tint by applying the matrix to white [1,1,1,1] to derive
-        //    the dominant output color, then using it as a Multiply blend layer.
-
-        // Extract alpha from matrix row 4 (indices 15-19): A' = a0*R + a1*G + a2*B + a3*A + a4
-        // For typical filters, a3 is the alpha scale and a4 is the alpha offset.
-        let alpha_scale = filter.values[18].clamp(0.0, 1.0); // a3
-        let alpha_offset = filter.values[19].clamp(0.0, 1.0); // a4
-        let effective_alpha = (alpha_scale + alpha_offset).clamp(0.0, 1.0);
-
-        // Apply the matrix to white to derive the tint color
-        let tinted = filter.apply([1.0, 1.0, 1.0, 1.0]);
-
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let tint_color = Color::rgba(
-            (tinted[0] * 255.0) as u8,
-            (tinted[1] * 255.0) as u8,
-            (tinted[2] * 255.0) as u8,
-            (effective_alpha * 255.0) as u8,
-        );
-
-        let paint = Paint::fill(tint_color);
-        self.painter.save_layer(None, &paint);
-
-        tracing::debug!(
-            "push_color_filter: approximation tint=({},{},{}) alpha={:.2}",
-            tint_color.r,
-            tint_color.g,
-            tint_color.b,
-            effective_alpha
-        );
-    }
-
-    fn pop_color_filter(&mut self) {
-        self.painter.restore_layer();
-    }
-
-    fn push_image_filter(&mut self, filter: &flui_painting::display_list::ImageFilter) {
-        use flui_painting::display_list::ImageFilter;
-
-        // Pragmatic approximation: full GPU image filters (blur, dilate, erode)
-        // require render-to-texture + compute shader post-processing which needs
-        // offscreen infrastructure not yet available. Instead, we use save_layer
-        // to isolate the filtered content for future GPU pass integration.
-        match filter {
-            ImageFilter::Blur { sigma_x, sigma_y } => {
-                // Capture content in a layer; actual Gaussian blur requires
-                // a two-pass separable compute shader on the layer texture.
-                let paint = Paint::fill(Color::WHITE);
-                self.painter.save_layer(None, &paint);
-                tracing::debug!(
-                    "push_image_filter(Blur): save_layer for blur sigma_x={:.2}, sigma_y={:.2} \
-                     (GPU blur not yet implemented)",
-                    sigma_x,
-                    sigma_y,
-                );
-            }
-            ImageFilter::Dilate { radius } => {
-                let paint = Paint::fill(Color::WHITE);
-                self.painter.save_layer(None, &paint);
-                tracing::debug!(
-                    "push_image_filter(Dilate): save_layer for dilate radius={:.2} \
-                     (GPU morphology not yet implemented)",
-                    radius,
-                );
-            }
-            ImageFilter::Erode { radius } => {
-                let paint = Paint::fill(Color::WHITE);
-                self.painter.save_layer(None, &paint);
-                tracing::debug!(
-                    "push_image_filter(Erode): save_layer for erode radius={:.2} \
-                     (GPU morphology not yet implemented)",
-                    radius,
-                );
-            }
-            ImageFilter::Matrix(matrix) => {
-                // Color matrix can be approximated the same way as push_color_filter.
-                // Extract tint and alpha from the matrix applied to white.
-                let alpha_scale = matrix.values[18].clamp(0.0, 1.0);
-                let alpha_offset = matrix.values[19].clamp(0.0, 1.0);
-                let effective_alpha = (alpha_scale + alpha_offset).clamp(0.0, 1.0);
-                let tinted = matrix.apply([1.0, 1.0, 1.0, 1.0]);
-
-                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                let tint_color = Color::rgba(
-                    (tinted[0] * 255.0) as u8,
-                    (tinted[1] * 255.0) as u8,
-                    (tinted[2] * 255.0) as u8,
-                    (effective_alpha * 255.0) as u8,
-                );
-                let paint = Paint::fill(tint_color);
-                self.painter.save_layer(None, &paint);
-                tracing::debug!(
-                    "push_image_filter(Matrix): approximation tint=({},{},{}) alpha={:.2}",
-                    tint_color.r,
-                    tint_color.g,
-                    tint_color.b,
-                    effective_alpha,
-                );
-            }
-            ImageFilter::ColorAdjust(adjustment) => {
-                // Color adjustments are approximated via an opacity layer.
-                let paint = Paint::fill(Color::WHITE);
-                self.painter.save_layer(None, &paint);
-                tracing::debug!(
-                    "push_image_filter(ColorAdjust): save_layer for {:?} \
-                     (GPU color adjust not yet implemented)",
-                    adjustment,
-                );
-            }
-            ImageFilter::Compose(filters) => {
-                // For composed filters, we save a single layer. In the future,
-                // each sub-filter would chain as successive compute passes.
-                let paint = Paint::fill(Color::WHITE);
-                self.painter.save_layer(None, &paint);
-                tracing::debug!(
-                    "push_image_filter(Compose): save_layer for {} chained filters \
-                     (GPU compose not yet implemented)",
-                    filters.len(),
-                );
-            }
-            #[cfg(debug_assertions)]
-            ImageFilter::OverflowIndicator {
-                overflow_h,
-                overflow_v,
-                ..
-            } => {
-                // Debug-only overflow visualization; save layer for balance.
-                let paint = Paint::fill(Color::WHITE);
-                self.painter.save_layer(None, &paint);
-                tracing::debug!(
-                    "push_image_filter(OverflowIndicator): h={:.1}, v={:.1}",
-                    overflow_h,
-                    overflow_v,
-                );
-            }
-        }
-    }
-
-    fn pop_image_filter(&mut self) {
-        self.painter.restore_layer();
-    }
+    // ===== Layer Tree Operations split out =====
+    //
+    // Cycle 4 E-9: push_clip_* / push_offset / push_transform /
+    // push_opacity / push_color_filter / push_image_filter + their
+    // corresponding pop_* moved to `impl LayerStateStack for Backend`
+    // (below). The visitor methods on this trait stay; the layer-tree
+    // state-stack methods live on the dedicated `LayerStateStack`
+    // trait. See traits.rs E-9 commentary.
 
     fn add_performance_overlay(
         &mut self,
@@ -1476,5 +1262,220 @@ impl CommandRenderer for Backend<'_> {
         );
 
         let _ = total_frames;
+    }
+}
+
+// ============================================================================
+// LAYER-STATE-STACK IMPL (cycle 4 E-9 split)
+// ============================================================================
+//
+// The 13 push_/pop_ methods below moved out of the `impl CommandRenderer
+// for Backend` block in cycle 4 E-9 to live on the dedicated
+// `LayerStateStack` trait. Bodies + behavior unchanged; only the
+// receiving trait differs. See `crates/flui-engine/src/traits.rs`
+// for the trait-split rationale.
+
+impl LayerStateStack for Backend<'_> {
+    fn push_clip_rect(&mut self, rect: &Rect<Pixels>, _clip_behavior: flui_types::painting::Clip) {
+        self.painter.save();
+        self.painter.clip_rect(*rect);
+    }
+
+    fn push_clip_rrect(&mut self, rrect: &RRect, _clip_behavior: flui_types::painting::Clip) {
+        self.painter.save();
+        self.painter.clip_rrect(*rrect);
+    }
+
+    fn push_clip_path(&mut self, path: &Path, _clip_behavior: flui_types::painting::Clip) {
+        self.painter.save();
+        self.painter.clip_path(path);
+    }
+
+    fn pop_clip(&mut self) {
+        self.painter.restore();
+    }
+
+    fn push_offset(&mut self, offset: Offset<Pixels>) {
+        self.painter.save();
+        self.painter.translate(offset);
+    }
+
+    fn push_transform(&mut self, transform: &Matrix4) {
+        self.painter.save();
+
+        // Decompose and apply transform components
+        let transform_enum = Transform::from(*transform);
+        let (tx, ty, rotation, sx, sy) = transform_enum.decompose();
+
+        if tx != 0.0 || ty != 0.0 {
+            self.painter.translate(Offset::new(px(tx), px(ty)));
+        }
+        if rotation.abs() > f32::EPSILON {
+            self.painter.rotate(rotation);
+        }
+        if (sx - 1.0).abs() > f32::EPSILON || (sy - 1.0).abs() > f32::EPSILON {
+            self.painter.scale(sx, sy);
+        }
+    }
+
+    fn pop_transform(&mut self) {
+        self.painter.restore();
+    }
+
+    fn push_opacity(&mut self, alpha: f32) {
+        // Create a layer with opacity (clamped to [0, 255])
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let alpha_u8 = (alpha.clamp(0.0, 1.0) * 255.0) as u8;
+        let paint = Paint::fill(Color::WHITE).with_alpha(alpha_u8);
+        self.painter.save_layer(None, &paint);
+    }
+
+    fn pop_opacity(&mut self) {
+        self.painter.restore_layer();
+    }
+
+    fn push_color_filter(&mut self, filter: &flui_types::painting::ColorMatrix) {
+        // Check if the matrix is identity (no transformation needed)
+        let identity = flui_types::painting::ColorMatrix::identity();
+        // Exact f32 array comparison is intentional: ColorMatrix::identity()
+        // is built from bit-exact 0.0/1.0 literals, so a transitive equality
+        // check correctly fast-paths the no-op case without ULP slop.
+        #[expect(
+            clippy::float_cmp,
+            reason = "identity matrix is bit-exact (0.0/1.0 literals); exact comparison is correct"
+        )]
+        if filter.values == identity.values {
+            // Identity matrix: use a plain save so pop_color_filter stays balanced
+            self.painter.save_layer(None, &Paint::fill(Color::WHITE));
+            tracing::trace!("push_color_filter: identity matrix, no-op layer");
+            return;
+        }
+
+        // Pragmatic approximation: extract opacity and tint from the color matrix.
+        let alpha_scale = filter.values[18].clamp(0.0, 1.0);
+        let alpha_offset = filter.values[19].clamp(0.0, 1.0);
+        let effective_alpha = (alpha_scale + alpha_offset).clamp(0.0, 1.0);
+        let tinted = filter.apply([1.0, 1.0, 1.0, 1.0]);
+
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let tint_color = Color::rgba(
+            (tinted[0] * 255.0) as u8,
+            (tinted[1] * 255.0) as u8,
+            (tinted[2] * 255.0) as u8,
+            (effective_alpha * 255.0) as u8,
+        );
+
+        let paint = Paint::fill(tint_color);
+        self.painter.save_layer(None, &paint);
+
+        tracing::debug!(
+            "push_color_filter: approximation tint=({},{},{}) alpha={:.2}",
+            tint_color.r,
+            tint_color.g,
+            tint_color.b,
+            effective_alpha
+        );
+    }
+
+    fn pop_color_filter(&mut self) {
+        self.painter.restore_layer();
+    }
+
+    fn push_image_filter(&mut self, filter: &flui_painting::display_list::ImageFilter) {
+        use flui_painting::display_list::ImageFilter;
+
+        // Pragmatic approximation: full GPU image filters (blur, dilate, erode)
+        // require render-to-texture + compute shader post-processing which needs
+        // offscreen infrastructure not yet available. Instead, we use save_layer
+        // to isolate the filtered content for future GPU pass integration.
+        match filter {
+            ImageFilter::Blur { sigma_x, sigma_y } => {
+                let paint = Paint::fill(Color::WHITE);
+                self.painter.save_layer(None, &paint);
+                tracing::debug!(
+                    "push_image_filter(Blur): save_layer for blur sigma_x={:.2}, sigma_y={:.2} \
+                     (GPU blur not yet implemented)",
+                    sigma_x,
+                    sigma_y,
+                );
+            }
+            ImageFilter::Dilate { radius } => {
+                let paint = Paint::fill(Color::WHITE);
+                self.painter.save_layer(None, &paint);
+                tracing::debug!(
+                    "push_image_filter(Dilate): save_layer for dilate radius={:.2} \
+                     (GPU morphology not yet implemented)",
+                    radius,
+                );
+            }
+            ImageFilter::Erode { radius } => {
+                let paint = Paint::fill(Color::WHITE);
+                self.painter.save_layer(None, &paint);
+                tracing::debug!(
+                    "push_image_filter(Erode): save_layer for erode radius={:.2} \
+                     (GPU morphology not yet implemented)",
+                    radius,
+                );
+            }
+            ImageFilter::Matrix(matrix) => {
+                let alpha_scale = matrix.values[18].clamp(0.0, 1.0);
+                let alpha_offset = matrix.values[19].clamp(0.0, 1.0);
+                let effective_alpha = (alpha_scale + alpha_offset).clamp(0.0, 1.0);
+                let tinted = matrix.apply([1.0, 1.0, 1.0, 1.0]);
+
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                let tint_color = Color::rgba(
+                    (tinted[0] * 255.0) as u8,
+                    (tinted[1] * 255.0) as u8,
+                    (tinted[2] * 255.0) as u8,
+                    (effective_alpha * 255.0) as u8,
+                );
+                let paint = Paint::fill(tint_color);
+                self.painter.save_layer(None, &paint);
+                tracing::debug!(
+                    "push_image_filter(Matrix): approximation tint=({},{},{}) alpha={:.2}",
+                    tint_color.r,
+                    tint_color.g,
+                    tint_color.b,
+                    effective_alpha,
+                );
+            }
+            ImageFilter::ColorAdjust(adjustment) => {
+                let paint = Paint::fill(Color::WHITE);
+                self.painter.save_layer(None, &paint);
+                tracing::debug!(
+                    "push_image_filter(ColorAdjust): save_layer for {:?} \
+                     (GPU color adjust not yet implemented)",
+                    adjustment,
+                );
+            }
+            ImageFilter::Compose(filters) => {
+                let paint = Paint::fill(Color::WHITE);
+                self.painter.save_layer(None, &paint);
+                tracing::debug!(
+                    "push_image_filter(Compose): save_layer for {} chained filters \
+                     (GPU compose not yet implemented)",
+                    filters.len(),
+                );
+            }
+            #[cfg(debug_assertions)]
+            ImageFilter::OverflowIndicator {
+                overflow_h,
+                overflow_v,
+                ..
+            } => {
+                let paint = Paint::fill(Color::WHITE);
+                self.painter.save_layer(None, &paint);
+                tracing::debug!(
+                    "push_image_filter(OverflowIndicator): h={:.1}, v={:.1}",
+                    overflow_h,
+                    overflow_v,
+                );
+            }
+        }
+    }
+
+    fn pop_image_filter(&mut self) {
+        self.painter.restore_layer();
     }
 }

--- a/crates/flui-engine/src/wgpu/backend.rs
+++ b/crates/flui-engine/src/wgpu/backend.rs
@@ -1275,6 +1275,27 @@ impl CommandRenderer for Backend<'_> {
 // receiving trait differs. See `crates/flui-engine/src/traits.rs`
 // for the trait-split rationale.
 
+// ColorMatrix row-major layout: `[r0-r4, g0-g4, b0-b4, a0-a4]`.
+// Each row holds (R-coeff, G-coeff, B-coeff, A-coeff, offset) for one
+// output channel: `out = m0*R + m1*G + m2*B + m3*A + m4`.
+// The alpha row sits at indices 15-19; the alpha-out coefficient on
+// alpha-in (`a3`, alpha scaling) is index 18, the alpha offset (`a4`)
+// is index 19. Naming these out keeps the push_color_filter +
+// ImageFilter::Matrix call sites readable (PR #115 review fix).
+const COLOR_MATRIX_ALPHA_SCALE_IDX: usize = 18;
+const COLOR_MATRIX_ALPHA_OFFSET_IDX: usize = 19;
+
+/// Extract (alpha_scale, alpha_offset, effective_alpha) from a
+/// `ColorMatrix`'s alpha row. All three values are clamped to `[0, 1]`.
+/// Helper shared by `push_color_filter` and the
+/// `ImageFilter::Matrix` branch of `push_image_filter`.
+fn color_matrix_effective_alpha(values: &[f32; 20]) -> (f32, f32, f32) {
+    let alpha_scale = values[COLOR_MATRIX_ALPHA_SCALE_IDX].clamp(0.0, 1.0);
+    let alpha_offset = values[COLOR_MATRIX_ALPHA_OFFSET_IDX].clamp(0.0, 1.0);
+    let effective = (alpha_scale + alpha_offset).clamp(0.0, 1.0);
+    (alpha_scale, alpha_offset, effective)
+}
+
 impl LayerStateStack for Backend<'_> {
     fn push_clip_rect(&mut self, rect: &Rect<Pixels>, _clip_behavior: flui_types::painting::Clip) {
         self.painter.save();
@@ -1351,10 +1372,13 @@ impl LayerStateStack for Backend<'_> {
             return;
         }
 
-        // Pragmatic approximation: extract opacity and tint from the color matrix.
-        let alpha_scale = filter.values[18].clamp(0.0, 1.0);
-        let alpha_offset = filter.values[19].clamp(0.0, 1.0);
-        let effective_alpha = (alpha_scale + alpha_offset).clamp(0.0, 1.0);
+        // Pragmatic approximation: extract opacity and tint from the
+        // color matrix. The alpha-row coefficient layout
+        // (`a3` = scale, `a4` = offset) lives in
+        // `color_matrix_effective_alpha`; see the helper comment
+        // above for the row-major index mapping.
+        let (_alpha_scale, _alpha_offset, effective_alpha) =
+            color_matrix_effective_alpha(&filter.values);
         let tinted = filter.apply([1.0, 1.0, 1.0, 1.0]);
 
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -1418,9 +1442,8 @@ impl LayerStateStack for Backend<'_> {
                 );
             }
             ImageFilter::Matrix(matrix) => {
-                let alpha_scale = matrix.values[18].clamp(0.0, 1.0);
-                let alpha_offset = matrix.values[19].clamp(0.0, 1.0);
-                let effective_alpha = (alpha_scale + alpha_offset).clamp(0.0, 1.0);
+                let (_alpha_scale, _alpha_offset, effective_alpha) =
+                    color_matrix_effective_alpha(&matrix.values);
                 let tinted = matrix.apply([1.0, 1.0, 1.0, 1.0]);
 
                 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]

--- a/crates/flui-engine/src/wgpu/debug.rs
+++ b/crates/flui-engine/src/wgpu/debug.rs
@@ -10,7 +10,7 @@ use flui_types::{
     typography::TextStyle,
 };
 
-use crate::traits::CommandRenderer;
+use crate::traits::{CommandRenderer, LayerStateStack};
 
 /// Debug backend that logs all commands to tracing.
 #[derive(Debug)]
@@ -367,8 +367,29 @@ impl CommandRenderer for DebugBackend {
         self.log_command("restore_layer", "");
     }
 
-    // ===== Layer Tree Operations =====
+    // Cycle 4 E-9: layer-tree push/pop methods moved to
+    // `impl LayerStateStack for DebugBackend` below.
 
+    fn add_performance_overlay(
+        &mut self,
+        options_mask: u32,
+        bounds: Rect<Pixels>,
+        fps: f32,
+        frame_time_ms: f32,
+        total_frames: u64,
+    ) {
+        self.log_command(
+            "add_performance_overlay",
+            &format!(
+                "options_mask={options_mask}, bounds={bounds:?}, fps={fps:.1}, frame_time={frame_time_ms:.2}ms, total_frames={total_frames}"
+            ),
+        );
+    }
+}
+
+// Cycle 4 E-9: layer-tree state-stack methods moved to dedicated
+// trait. Bodies + log-command output unchanged.
+impl LayerStateStack for DebugBackend {
     fn push_clip_rect(&mut self, rect: &Rect<Pixels>, clip_behavior: flui_types::painting::Clip) {
         self.log_command(
             "push_clip_rect",
@@ -432,21 +453,5 @@ impl CommandRenderer for DebugBackend {
 
     fn pop_image_filter(&mut self) {
         self.log_command("pop_image_filter", "");
-    }
-
-    fn add_performance_overlay(
-        &mut self,
-        options_mask: u32,
-        bounds: Rect<Pixels>,
-        fps: f32,
-        frame_time_ms: f32,
-        total_frames: u64,
-    ) {
-        self.log_command(
-            "add_performance_overlay",
-            &format!(
-                "options_mask={options_mask}, bounds={bounds:?}, fps={fps:.1}, frame_time={frame_time_ms:.2}ms, total_frames={total_frames}"
-            ),
-        );
     }
 }

--- a/crates/flui-engine/src/wgpu/layer_render.rs
+++ b/crates/flui-engine/src/wgpu/layer_render.rs
@@ -11,7 +11,10 @@ use flui_layer::{
 };
 use flui_painting::DisplayListCore;
 
-use crate::{commands::dispatch_commands, traits::CommandRenderer};
+use crate::{
+    commands::dispatch_commands,
+    traits::{CommandRenderer, LayerStateStack},
+};
 
 // ============================================================================
 // SUPERELLIPSE PATH GENERATION
@@ -46,7 +49,7 @@ use crate::{commands::dispatch_commands, traits::CommandRenderer};
 /// let layer = Layer::Canvas(CanvasLayer::new());
 /// layer.render(&mut backend);
 /// ```
-pub trait LayerRender<R: CommandRenderer + ?Sized> {
+pub trait LayerRender<R: CommandRenderer + LayerStateStack + ?Sized> {
     /// Render this layer using the provided command renderer.
     fn render(&self, renderer: &mut R);
 
@@ -57,7 +60,7 @@ pub trait LayerRender<R: CommandRenderer + ?Sized> {
     fn cleanup(&self, renderer: &mut R);
 }
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for Layer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for Layer {
     fn render(&self, renderer: &mut R) {
         match self {
             // Leaf layers
@@ -143,7 +146,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for Layer {
 // LEAF LAYERS
 // ============================================================================
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for CanvasLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for CanvasLayer {
     fn render(&self, renderer: &mut R) {
         dispatch_commands(self.display_list().commands(), renderer);
     }
@@ -153,7 +156,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for CanvasLayer {
     }
 }
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for PictureLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for PictureLayer {
     fn render(&self, renderer: &mut R) {
         dispatch_commands(self.picture().commands(), renderer);
     }
@@ -167,7 +170,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for PictureLayer {
 // CLIP LAYERS
 // ============================================================================
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for ClipRectLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for ClipRectLayer {
     fn render(&self, renderer: &mut R) {
         if !self.clips() {
             return;
@@ -183,7 +186,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for ClipRectLayer {
     }
 }
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for ClipRRectLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for ClipRRectLayer {
     fn render(&self, renderer: &mut R) {
         if !self.clips() {
             return;
@@ -199,7 +202,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for ClipRRectLayer {
     }
 }
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for ClipPathLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for ClipPathLayer {
     fn render(&self, renderer: &mut R) {
         if !self.clips() {
             return;
@@ -215,7 +218,9 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for ClipPathLayer {
     }
 }
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for flui_layer::ClipSuperellipseLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R>
+    for flui_layer::ClipSuperellipseLayer
+{
     fn render(&self, renderer: &mut R) {
         if !self.clips() {
             return;
@@ -371,7 +376,7 @@ pub(crate) fn generate_superellipse_path(
 // TRANSFORM LAYERS
 // ============================================================================
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for OffsetLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for OffsetLayer {
     fn render(&self, renderer: &mut R) {
         if self.is_zero() {
             return;
@@ -386,7 +391,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for OffsetLayer {
     }
 }
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for TransformLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for TransformLayer {
     fn render(&self, renderer: &mut R) {
         if self.is_identity() {
             return;
@@ -405,7 +410,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for TransformLayer {
 // EFFECT LAYERS
 // ============================================================================
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for OpacityLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for OpacityLayer {
     fn render(&self, renderer: &mut R) {
         if self.is_invisible() {
             return;
@@ -431,7 +436,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for OpacityLayer {
     }
 }
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for ColorFilterLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for ColorFilterLayer {
     fn render(&self, renderer: &mut R) {
         if self.is_identity() {
             return;
@@ -446,7 +451,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for ColorFilterLayer {
     }
 }
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for ImageFilterLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for ImageFilterLayer {
     fn render(&self, renderer: &mut R) {
         if self.has_offset() {
             renderer.push_offset(self.offset());
@@ -463,7 +468,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for ImageFilterLayer {
     }
 }
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for ShaderMaskLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for ShaderMaskLayer {
     fn render(&self, renderer: &mut R) {
         // Create a compositing layer bounded to the mask area.
         // Children will be rendered into this layer, then composited
@@ -485,7 +490,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for ShaderMaskLayer {
     }
 }
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for BackdropFilterLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for BackdropFilterLayer {
     fn render(&self, _renderer: &mut R) {
         // Backdrop blur is handled at the Renderer level in render_layer_recursive,
         // which has access to the surface texture for mid-frame flush + copy + blur.
@@ -502,7 +507,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for BackdropFilterLayer {
 // EXTERNAL CONTENT LAYERS
 // ============================================================================
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for TextureLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for TextureLayer {
     fn render(&self, renderer: &mut R) {
         if self.is_invisible() {
             return;
@@ -522,7 +527,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for TextureLayer {
     }
 }
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for PlatformViewLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for PlatformViewLayer {
     fn render(&self, _renderer: &mut R) {
         // Platform views are composited by the platform embedder
     }
@@ -536,7 +541,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for PlatformViewLayer {
 // LINKING LAYERS
 // ============================================================================
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for LeaderLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for LeaderLayer {
     fn render(&self, renderer: &mut R) {
         let offset = self.get_offset();
         if offset.dx.0 != 0.0 || offset.dy.0 != 0.0 {
@@ -552,7 +557,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for LeaderLayer {
     }
 }
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for FollowerLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for FollowerLayer {
     fn render(&self, _renderer: &mut R) {
         // Transform is calculated by the compositor
     }
@@ -566,7 +571,7 @@ impl<R: CommandRenderer + ?Sized> LayerRender<R> for FollowerLayer {
 // PERFORMANCE OVERLAY LAYER
 // ============================================================================
 
-impl<R: CommandRenderer + ?Sized> LayerRender<R> for PerformanceOverlayLayer {
+impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for PerformanceOverlayLayer {
     fn render(&self, renderer: &mut R) {
         renderer.add_performance_overlay(
             self.options_mask(),
@@ -845,7 +850,25 @@ mod tests {
             self.calls.push("restore_layer".to_string());
         }
 
-        // ===== Layer Tree Operations (recorded) =====
+        // Cycle 4 E-9: push/pop methods moved to impl LayerStateStack below.
+
+        // ===== Performance Overlay (recorded) =====
+        fn add_performance_overlay(
+            &mut self,
+            _options_mask: u32,
+            _bounds: Rect<Pixels>,
+            _fps: f32,
+            _frame_time_ms: f32,
+            _total_frames: u64,
+        ) {
+            self.calls.push("add_performance_overlay".to_string());
+        }
+    }
+
+    // Cycle 4 E-9: layer-tree state-stack impl split into a dedicated
+    // trait. MockRenderer records each push/pop as a string for the
+    // ordering assertions in the test suite.
+    impl LayerStateStack for MockRenderer {
         fn push_clip_rect(&mut self, _rect: &Rect<Pixels>, _clip_behavior: Clip) {
             self.calls.push("push_clip_rect".to_string());
         }
@@ -884,18 +907,6 @@ mod tests {
         }
         fn pop_image_filter(&mut self) {
             self.calls.push("pop_image_filter".to_string());
-        }
-
-        // ===== Performance Overlay (recorded) =====
-        fn add_performance_overlay(
-            &mut self,
-            _options_mask: u32,
-            _bounds: Rect<Pixels>,
-            _fps: f32,
-            _frame_time_ms: f32,
-            _total_frames: u64,
-        ) {
-            self.calls.push("add_performance_overlay".to_string());
         }
     }
 


### PR DESCRIPTION
# Cycle 4 Wave 3c — E-9 CommandRenderer trait split + E-8 deferred

1 atomic commit closing the last architectural P1 finding from
[`docs/research/2026-05-22-flui-rendering-engine-audit.md`](docs/research/2026-05-22-flui-rendering-engine-audit.md).
The companion E-8 finding (unwrap `OffscreenRenderer` from
`Arc<Mutex<>>`) was investigated and **deferred** — see below.

## E-9 closed: CommandRenderer trait split

Pre-cycle `CommandRenderer` had **47 methods** mixed across two
conceptual responsibilities:

1. **Visitor methods** (~34): per-`DrawCommand` dispatch surface
   (`render_rect`, `render_text`, `render_image`, `clip_rect`,
   `save_layer`, etc.). Every backend implements these — command-
   dispatch contract.
2. **Layer-tree state-stack methods** (13): push/pop helpers
   (`push_clip_*` / `pop_clip` / `push_offset` / `push_transform` /
   `pop_transform` / `push_opacity` / `pop_opacity` /
   `push_color_filter` / `pop_color_filter` / `push_image_filter` /
   `pop_image_filter`). Only compositor backends that participate
   in flui-layer's clip-stack handshake need them.

Pre-cycle a new debug-recorder / software-fallback / Skia backend
had to implement all 47 to be valid. The 13 push/pop are
framework-internal, not backend-swap concerns.

**Split:** new `pub trait LayerStateStack` in `traits.rs` carrying
the 13 methods. `LayerRender<R>` bound updated from
`R: CommandRenderer + ?Sized` to `R: CommandRenderer + LayerStateStack + ?Sized`.

Bodies + behavior unchanged; only the receiving trait differs.

## E-8 deferred — Arc<Mutex<OffscreenRenderer>> load-bearing

Audit estimated ±20 LOC for unwrapping the Arc<Mutex<>>. Investigation
showed the shape is structurally load-bearing for cross-borrow flows:

- `Renderer.offscreen: Arc<Mutex<OffscreenRenderer>>` (single-thread
  GPU type).
- Wave 2 E-2 made `Backend` share this Arc via `Backend::with_offscreen(painter, Arc::clone(offscreen))`.
- `handle_backdrop_filter` at `renderer.rs:908` calls
  `backend.offscreen().cloned()` then `offscreen_arc.lock()` for
  blur dispatch — needs offscreen access WHILE `&mut backend` is
  held by the layer recursion.

Unwrapping to `Option<OffscreenRenderer>` requires reshaping
`handle_backdrop_filter` to a different ownership model
(`Backend<'frame>` would grow another lifetime, or offscreen would
need to thread through every dispatch call). The audit's ±20 LOC
estimate underestimated by an order of magnitude — real fix is
its own audit item, deferred to a future cycle where the
backdrop-filter cross-borrow is reshaped first.

The single-thread overhead penalty (atomic CAS + Mutex lock) is
small on the hot path; the architectural-correctness penalty of
the Arc-share shape is zero (single thread today, ready for
multi-thread when needed).

## Verification

| Gate | Result |
|------|--------|
| `cargo build --workspace` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | zero warnings |
| `cargo test -p flui-engine --lib` | 59 passed |
| `bash scripts/port-check.sh -v` | 7/7 institutional refusal triggers clean |

## Breaking change

External crates implementing `CommandRenderer` for their own
backend type must now ALSO implement `LayerStateStack` if they
plan to be used by the layer-tree dispatcher (i.e. inside
`LayerRender<R>`). Command-only backends compile unchanged.

## Stat

```
$ git diff --shortstat origin/main..HEAD
5 files changed, 238 insertions(+), 181 deletions(-)
```

Net +57 LOC (trait-split machinery + docstrings + impl-block moves).

## Cycle 4 final status

After this PR merges:

- **P0** (14 total): 14 closed across Waves 1+2.
- **P1** (14 total): 12 closed (Waves 3a+3b+3c). 1 deferred (E-8 — see above). 1 N/A: R-11 was reclassified P1 and counted in W3b.
- **P2** (10) + **P3** (6): pending follow-up cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
