### PR TITLE
feat: PR-A1a — D-1 layout pipeline prep (OnceCell→Option + mark_needs_layout walk + boundary bootstrap, U14-U17)

### DIFF
--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -612,7 +612,7 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
     ///
     /// **D-block PR-A1 U15** (memo D3) — greenfield authoring of Flutter's
     /// `markNeedsLayout` walk (`.flutter/.../object.dart:2658-2700`). Walks
-    /// the parent chain via [`RenderNode::parent`] and at each step:
+    /// the parent chain via [`NodeLinks::parent`] and at each step:
     ///
     /// 1. If the node is already marked `NEEDS_LAYOUT`, stop — earlier
     ///    propagation already reached the boundary; no need to re-walk.
@@ -620,10 +620,14 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
     /// 3. If the node is a relayout boundary
     ///    ([`RenderNode::is_relayout_boundary`] — reads the per-instance
     ///    `IS_RELAYOUT_BOUNDARY` storage flag set by
-    ///    [`compute_relayout_boundary`](crate::storage::state::RenderState::compute_relayout_boundary))
+    ///    [`compute_relayout_boundary`](crate::storage::RenderState::compute_relayout_boundary))
     ///    OR has no parent (tree root), push this id onto
     ///    `dirty.needs_layout` and return.
     /// 4. Otherwise, recurse to the parent.
+    ///
+    /// [`NodeLinks::parent`]: crate::storage::NodeLinks::parent
+    /// [`RenderNode::mark_layout_flag`]: crate::storage::RenderNode::mark_layout_flag
+    /// [`RenderNode::is_relayout_boundary`]: crate::storage::RenderNode::is_relayout_boundary
     ///
     /// The walk is idempotent — a stale call on an already-marked subtree
     /// short-circuits at step 1 without re-pushing the boundary. Missing

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -606,6 +606,73 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
         self.dirty.needs_layout.push(DirtyNode::new(node_id, depth));
     }
 
+    /// Marks a node as needing layout, propagating the `NEEDS_LAYOUT` flag
+    /// up the ancestor chain and pushing the **relayout boundary** onto
+    /// `dirty.needs_layout` for the next `run_layout` pass.
+    ///
+    /// **D-block PR-A1 U15** (memo D3) — greenfield authoring of Flutter's
+    /// `markNeedsLayout` walk (`.flutter/.../object.dart:2658-2700`). Walks
+    /// the parent chain via [`RenderNode::parent`] and at each step:
+    ///
+    /// 1. If the node is already marked `NEEDS_LAYOUT`, stop — earlier
+    ///    propagation already reached the boundary; no need to re-walk.
+    /// 2. Otherwise, set the flag via [`RenderNode::mark_layout_flag`].
+    /// 3. If the node is a relayout boundary
+    ///    ([`RenderNode::is_relayout_boundary`] — reads the per-instance
+    ///    `IS_RELAYOUT_BOUNDARY` storage flag set by
+    ///    [`compute_relayout_boundary`](crate::storage::state::RenderState::compute_relayout_boundary))
+    ///    OR has no parent (tree root), push this id onto
+    ///    `dirty.needs_layout` and return.
+    /// 4. Otherwise, recurse to the parent.
+    ///
+    /// The walk is idempotent — a stale call on an already-marked subtree
+    /// short-circuits at step 1 without re-pushing the boundary. Missing
+    /// `RenderId`s (post-removal stale references) are silent no-ops; the
+    /// walk simply terminates at the missing-lookup step.
+    ///
+    /// This method supersedes the direct `add_node_needing_layout` call
+    /// pattern in `flui-view::element::behavior_commons::mark_render_needs_layout_and_paint`
+    /// (migrated in D-block PR-A1 U16). Direct `add_node_needing_layout`
+    /// remains as the low-level primitive for callers that have already
+    /// computed the correct boundary id (e.g. testing surfaces).
+    ///
+    /// **Bootstrap dependency (U17):** the relayout-boundary flag is set
+    /// per-instance only after [`RenderEntry::layout`](crate::storage::RenderEntry::layout)
+    /// has run once. Pre-bootstrap (no layout has executed yet) every node
+    /// reports `is_relayout_boundary() == false` and propagation runs to
+    /// root — which is the correct fallback (root is always an implicit
+    /// boundary in Flutter).
+    pub fn mark_needs_layout(&mut self, id: RenderId) {
+        let mut current = id;
+        loop {
+            // Snapshot the per-node decision under a short-lived borrow so
+            // we can release before stepping to the parent in the recursion.
+            let step = {
+                let Some(node) = self.render_tree.get_mut(current) else {
+                    // Stale reference (e.g. node removed mid-frame). Stop.
+                    return;
+                };
+                if node.needs_layout() {
+                    // Earlier propagation already reached the boundary.
+                    return;
+                }
+                node.mark_layout_flag();
+                let parent = node.links().parent();
+                let boundary = node.is_relayout_boundary() || parent.is_none();
+                let depth = node.depth() as usize;
+                (boundary, depth, parent)
+            };
+            let (is_boundary, depth, parent) = step;
+            if is_boundary {
+                self.dirty.needs_layout.push(DirtyNode::new(current, depth));
+                return;
+            }
+            // SAFETY: `parent.is_none()` is folded into `is_boundary` above,
+            // so reaching this branch guarantees `Some(_)`.
+            current = parent.unwrap();
+        }
+    }
+
     /// Adds a node to the paint dirty list.
     ///
     /// # Arguments
@@ -1824,5 +1891,146 @@ mod tests {
             name.contains("PanickingPaintBox"),
             "debug_name() should resolve to the concrete type via vtable; got `{name}`"
         );
+    }
+
+    // ========================================================================
+    // D-block PR-A1 U15 — PipelineOwner::mark_needs_layout walk tests
+    // ========================================================================
+    //
+    // Verifies the Flutter `markNeedsLayout` shape ported in U15:
+    //   - propagation walks the ancestor chain
+    //   - flag is set on every visited node (NEEDS_LAYOUT)
+    //   - propagation stops at the first relayout boundary or root
+    //   - dirty.needs_layout receives exactly the boundary id
+    //   - re-marking an already-dirty node is a no-op
+    //   - stale RenderIds (post-removal) terminate the walk silently
+
+    /// Build a 3-level chain root → middle → leaf with `PanickingPaintBox`
+    /// mocks via the public `insert` / `insert_child_render_object` APIs,
+    /// then clear the dirty queue so tests can observe only post-clear
+    /// marks. Returns `(owner, root_id, middle_id, leaf_id)`.
+    fn build_three_level_chain() -> (PipelineOwner<Idle>, RenderId, RenderId, RenderId) {
+        let mut owner = PipelineOwner::new();
+        let root_id = owner.insert(Box::new(PanickingPaintBox::new())
+            as Box<dyn crate::traits::RenderObject<crate::protocol::BoxProtocol>>);
+        let middle_id = owner
+            .insert_child_render_object(
+                root_id,
+                Box::new(PanickingPaintBox::new())
+                    as Box<dyn crate::traits::RenderObject<crate::protocol::BoxProtocol>>,
+            )
+            .expect("middle should attach under root");
+        let leaf_id = owner
+            .insert_child_render_object(
+                middle_id,
+                Box::new(PanickingPaintBox::new())
+                    as Box<dyn crate::traits::RenderObject<crate::protocol::BoxProtocol>>,
+            )
+            .expect("leaf should attach under middle");
+        owner.clear_all_dirty_nodes();
+        for id in [root_id, middle_id, leaf_id] {
+            if let Some(node) = owner.render_tree.get_mut(id) {
+                match node {
+                    crate::storage::RenderNode::Box(entry) => {
+                        entry.state().clear_needs_layout();
+                    }
+                    crate::storage::RenderNode::Sliver(entry) => {
+                        entry.state().clear_needs_layout();
+                    }
+                }
+            }
+        }
+        (owner, root_id, middle_id, leaf_id)
+    }
+
+    /// Marking a leaf where no relayout boundary is set propagates the
+    /// `NEEDS_LAYOUT` flag up to root and pushes the root onto
+    /// `dirty.needs_layout` (root is the implicit boundary).
+    #[test]
+    fn mark_needs_layout_walks_to_root_when_no_boundary_set() {
+        let (mut owner, root_id, middle_id, leaf_id) = build_three_level_chain();
+        assert!(owner.nodes_needing_layout().is_empty());
+
+        owner.mark_needs_layout(leaf_id);
+
+        for (id, label) in [(leaf_id, "leaf"), (middle_id, "middle"), (root_id, "root")] {
+            let node = owner.render_tree.get(id).expect(label);
+            assert!(
+                node.needs_layout(),
+                "{label} should have NEEDS_LAYOUT set after walk",
+            );
+        }
+        let dirty = owner.nodes_needing_layout();
+        assert_eq!(
+            dirty.len(),
+            1,
+            "exactly one boundary should land on dirty queue, got {dirty:?}",
+        );
+        assert_eq!(dirty[0].id, root_id, "boundary should be the root id");
+    }
+
+    /// Re-marking an already-dirty node short-circuits at step 1 of the
+    /// walk — no second push, no flag toggle (flags are idempotent anyway).
+    #[test]
+    fn mark_needs_layout_is_idempotent_on_repeat() {
+        let (mut owner, _root_id, _middle_id, leaf_id) = build_three_level_chain();
+        owner.mark_needs_layout(leaf_id);
+        let first_dirty_len = owner.nodes_needing_layout().len();
+        owner.mark_needs_layout(leaf_id);
+        assert_eq!(
+            owner.nodes_needing_layout().len(),
+            first_dirty_len,
+            "second mark on already-dirty subtree must not re-push",
+        );
+    }
+
+    /// When an intermediate ancestor IS a relayout boundary, propagation
+    /// stops at that ancestor — the root above stays clean and the
+    /// boundary id (not root) is the one pushed to the dirty queue.
+    #[test]
+    fn mark_needs_layout_stops_at_intermediate_relayout_boundary() {
+        let (mut owner, root_id, middle_id, leaf_id) = build_three_level_chain();
+        // Promote `middle` to a relayout boundary via the storage flag (U17
+        // wires this from `RenderEntry::layout`'s post-set_constraints
+        // compute_relayout_boundary call; this test pre-bootstraps the
+        // flag directly to isolate U15 walk behaviour from U17 bootstrap).
+        if let Some(crate::storage::RenderNode::Box(entry)) = owner.render_tree.get_mut(middle_id) {
+            entry.state().set_relayout_boundary(true);
+        }
+
+        owner.mark_needs_layout(leaf_id);
+
+        assert!(
+            owner.render_tree.get(leaf_id).expect("leaf").needs_layout(),
+            "leaf should be marked",
+        );
+        assert!(
+            owner
+                .render_tree
+                .get(middle_id)
+                .expect("middle")
+                .needs_layout(),
+            "boundary itself should be marked",
+        );
+        assert!(
+            !owner.render_tree.get(root_id).expect("root").needs_layout(),
+            "root above the boundary stays clean",
+        );
+        let dirty = owner.nodes_needing_layout();
+        assert_eq!(dirty.len(), 1);
+        assert_eq!(
+            dirty[0].id, middle_id,
+            "dirty entry should be the boundary, not the root",
+        );
+    }
+
+    /// Marking a stale `RenderId` (post-removal) terminates the walk
+    /// silently with no dirty-queue mutation.
+    #[test]
+    fn mark_needs_layout_stale_id_is_silent_noop() {
+        let mut owner = PipelineOwner::new();
+        let phantom = RenderId::new(99);
+        owner.mark_needs_layout(phantom);
+        assert!(owner.nodes_needing_layout().is_empty());
     }
 }

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -656,10 +656,16 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
                     // Stale reference (e.g. node removed mid-frame). Stop.
                     return;
                 };
-                if node.needs_layout() {
-                    // Earlier propagation already reached the boundary.
-                    return;
-                }
+                // Idempotent flag set — the AtomicRenderFlags fetch-or is a
+                // no-op when the bit is already set. The walk does NOT
+                // short-circuit on "already marked"; the prior mark's
+                // dirty-queue entry may have been drained by `run_layout`
+                // without clearing the flag (the current run_layout still
+                // contains the `layout_node_with_children` no-op walk that
+                // doesn't invoke `RenderEntry::layout` — once PR-A1b lands
+                // the walk rewrite, layout clears `NEEDS_LAYOUT` and the
+                // walk could short-circuit, but the always-walk shape
+                // remains correct).
                 node.mark_layout_flag();
                 let parent = node.links().parent();
                 let boundary = node.is_relayout_boundary() || parent.is_none();
@@ -668,7 +674,16 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
             };
             let (is_boundary, depth, parent) = step;
             if is_boundary {
-                self.dirty.needs_layout.push(DirtyNode::new(current, depth));
+                // Codex P1 (PR #139 review): always enqueue the boundary
+                // for this invalidation, with a dedup check against the
+                // dirty queue so multiple marks-in-same-frame don't push
+                // duplicate entries. Pre-fix, the algorithm returned early
+                // on already-marked nodes WITHOUT pushing — which silently
+                // dropped subsequent invalidations once the broken pipeline
+                // had drained the dirty queue but not cleared the flag.
+                if !self.dirty.needs_layout.iter().any(|d| d.id == current) {
+                    self.dirty.needs_layout.push(DirtyNode::new(current, depth));
+                }
                 return;
             }
             // SAFETY: `parent.is_none()` is folded into `is_boundary` above,

--- a/crates/flui-rendering/src/protocol/box_protocol.rs
+++ b/crates/flui-rendering/src/protocol/box_protocol.rs
@@ -96,12 +96,28 @@ impl Protocol for BoxProtocol {
     }
 
     /// D-block PR-A1 U17 — override the default no-op with the actual
-    /// Flutter-parity `compute_relayout_boundary` call. `parent_uses_size`
-    /// and `sized_by_parent` are wired as `false` for now; full Flutter
-    /// parity for those parameters lands later in Core.2 alongside the
-    /// intrinsic-dimension protocol.
+    /// Flutter-parity `compute_relayout_boundary` call.
+    ///
+    /// `parent_uses_size = true` (conservative default per Copilot P1 review
+    /// on PR #139): with the Flutter formula
+    /// `is_boundary = !parent_uses_size || sized_by_parent || constraints.is_tight() || !has_parent`,
+    /// passing `parent_uses_size = false` would make `!false = true` ⇒ EVERY
+    /// non-root node defaults to a relayout boundary, immediately blocking
+    /// [`PipelineOwner::mark_needs_layout`](crate::pipeline::PipelineOwner::mark_needs_layout)
+    /// propagation at the leaf and breaking parents-depend-on-child-size
+    /// flows. The conservative `true` default makes boundary-ness depend on
+    /// the remaining three signals: tight constraints (always a boundary in
+    /// Flutter — parent is forcing a single valid size), root (no parent),
+    /// or `sized_by_parent` (constraints alone determine size). Non-tight
+    /// non-root non-sized-by-parent nodes correctly default to non-boundary,
+    /// preserving propagation.
+    ///
+    /// `sized_by_parent = false`: full Flutter parity for both parameters
+    /// requires per-render-object trait methods that report their layout
+    /// dependency shape; deferred to Core.2 alongside the intrinsic-
+    /// dimension protocol.
     fn bootstrap_relayout_boundary(state: &crate::storage::RenderState<Self>, has_parent: bool) {
-        state.compute_relayout_boundary(false, false, has_parent);
+        state.compute_relayout_boundary(true, false, has_parent);
     }
 }
 

--- a/crates/flui-rendering/src/protocol/box_protocol.rs
+++ b/crates/flui-rendering/src/protocol/box_protocol.rs
@@ -94,6 +94,15 @@ impl Protocol for BoxProtocol {
     fn name() -> &'static str {
         "box"
     }
+
+    /// D-block PR-A1 U17 — override the default no-op with the actual
+    /// Flutter-parity `compute_relayout_boundary` call. `parent_uses_size`
+    /// and `sized_by_parent` are wired as `false` for now; full Flutter
+    /// parity for those parameters lands later in Core.2 alongside the
+    /// intrinsic-dimension protocol.
+    fn bootstrap_relayout_boundary(state: &crate::storage::RenderState<Self>, has_parent: bool) {
+        state.compute_relayout_boundary(false, false, has_parent);
+    }
 }
 
 impl BidirectionalProtocol for BoxProtocol {}

--- a/crates/flui-rendering/src/protocol/protocol.rs
+++ b/crates/flui-rendering/src/protocol/protocol.rs
@@ -77,6 +77,31 @@ pub trait Protocol: Send + Sync + Debug + Clone + Copy + sealed::Sealed + 'stati
     fn validate_constraints(constraints: &<Self::Layout as LayoutCapability>::Constraints) -> bool {
         <Self::Layout as LayoutCapability>::validate_constraints(constraints)
     }
+
+    /// Bootstrap the per-instance `IS_RELAYOUT_BOUNDARY` storage flag after
+    /// a successful layout pass.
+    ///
+    /// Default implementation is a no-op (slivers don't use relayout-boundary
+    /// semantics today; that's deferred to Core.2). The `BoxProtocol`
+    /// override calls [`RenderState::<BoxProtocol>::compute_relayout_boundary`]
+    /// with `parent_uses_size = false` and `sized_by_parent = false` —
+    /// Flutter parity for those parameters lands later in Core.2 alongside
+    /// the intrinsic-dimension protocol.
+    ///
+    /// Added in D-block PR-A1 U17 (companion memo D3) so that
+    /// [`PipelineOwner::mark_needs_layout`] (U15) has a meaningful
+    /// `is_relayout_boundary` answer to read once nodes have laid out at
+    /// least once. Pre-bootstrap, all nodes report `false` and propagation
+    /// runs to root — the correct fallback (root is the implicit boundary).
+    ///
+    /// [`RenderState::<BoxProtocol>::compute_relayout_boundary`]: crate::storage::state::RenderState::compute_relayout_boundary
+    /// [`PipelineOwner::mark_needs_layout`]: crate::pipeline::owner::PipelineOwner::mark_needs_layout
+    fn bootstrap_relayout_boundary(state: &crate::storage::RenderState<Self>, has_parent: bool)
+    where
+        Self: Sized,
+    {
+        let _ = (state, has_parent);
+    }
 }
 
 // ============================================================================

--- a/crates/flui-rendering/src/protocol/protocol.rs
+++ b/crates/flui-rendering/src/protocol/protocol.rs
@@ -94,8 +94,8 @@ pub trait Protocol: Send + Sync + Debug + Clone + Copy + sealed::Sealed + 'stati
     /// least once. Pre-bootstrap, all nodes report `false` and propagation
     /// runs to root — the correct fallback (root is the implicit boundary).
     ///
-    /// [`RenderState::<BoxProtocol>::compute_relayout_boundary`]: crate::storage::state::RenderState::compute_relayout_boundary
-    /// [`PipelineOwner::mark_needs_layout`]: crate::pipeline::owner::PipelineOwner::mark_needs_layout
+    /// [`RenderState::<BoxProtocol>::compute_relayout_boundary`]: crate::storage::RenderState::compute_relayout_boundary
+    /// [`PipelineOwner::mark_needs_layout`]: crate::pipeline::PipelineOwner::mark_needs_layout
     fn bootstrap_relayout_boundary(state: &crate::storage::RenderState<Self>, has_parent: bool)
     where
         Self: Sized,

--- a/crates/flui-rendering/src/storage/entry.rs
+++ b/crates/flui-rendering/src/storage/entry.rs
@@ -280,6 +280,17 @@ impl<P: Protocol> RenderEntry<P> {
         // untouched and NEEDS_LAYOUT stays set so a retry is possible.
         self.state.set_geometry(geometry.clone());
         self.state.set_constraints(constraints);
+
+        // D-block PR-A1 U17 — bootstrap the per-instance
+        // `IS_RELAYOUT_BOUNDARY` flag now that constraints are populated.
+        // For `BoxProtocol`, dispatches to `compute_relayout_boundary`
+        // (Flutter `!parent_uses_size || sized_by_parent || constraints.is_tight() || !has_parent`);
+        // for `SliverProtocol`, no-op (relayout-boundary semantics not used).
+        // Pre-bootstrap, `PipelineOwner::mark_needs_layout` (U15) treats
+        // every node as non-boundary and walks to root.
+        let has_parent = self.links.parent().is_some();
+        <P as crate::protocol::Protocol>::bootstrap_relayout_boundary(&self.state, has_parent);
+
         self.state.clear_needs_layout();
 
         Ok(geometry)

--- a/crates/flui-rendering/src/storage/node.rs
+++ b/crates/flui-rendering/src/storage/node.rs
@@ -289,7 +289,7 @@ impl RenderNode {
 
     /// Sets the `NEEDS_LAYOUT` flag on this node's state — **flag-only**, no
     /// propagation. Added in D-block PR-A1 U15 to support the
-    /// [`PipelineOwner::mark_needs_layout`](crate::pipeline::owner::PipelineOwner::mark_needs_layout)
+    /// [`PipelineOwner::mark_needs_layout`](crate::pipeline::PipelineOwner::mark_needs_layout)
     /// ancestor-walk: each step of the walk flips one node's flag, and the
     /// owner is responsible for the ancestor traversal and dirty-queue push
     /// at the boundary.
@@ -328,7 +328,7 @@ impl RenderNode {
     /// `entry.render_object().is_relayout_boundary()` for the rare callers
     /// that genuinely want the type-default.
     ///
-    /// [`RenderState::compute_relayout_boundary`]: crate::storage::state::RenderState::compute_relayout_boundary
+    /// [`RenderState::compute_relayout_boundary`]: crate::storage::RenderState::compute_relayout_boundary
     #[inline]
     pub fn is_relayout_boundary(&self) -> bool {
         match self {

--- a/crates/flui-rendering/src/storage/node.rs
+++ b/crates/flui-rendering/src/storage/node.rs
@@ -287,10 +287,24 @@ impl RenderNode {
         }
     }
 
-    // NOTE: mark_needs_layout() and mark_needs_paint() removed from RenderNode
-    // These methods require element_id and tree access for dirty propagation.
-    // They should be called through RenderTree or PipelineOwner instead.
-    // See similar note in entry.rs for details.
+    /// Sets the `NEEDS_LAYOUT` flag on this node's state — **flag-only**, no
+    /// propagation. Added in D-block PR-A1 U15 to support the
+    /// [`PipelineOwner::mark_needs_layout`](crate::pipeline::owner::PipelineOwner::mark_needs_layout)
+    /// ancestor-walk: each step of the walk flips one node's flag, and the
+    /// owner is responsible for the ancestor traversal and dirty-queue push
+    /// at the boundary.
+    ///
+    /// The previously-removed `RenderNode::mark_needs_layout()` did
+    /// propagation; the new owner-side walk supersedes it. Direct callers
+    /// should still use `PipelineOwner::mark_needs_layout` for correct
+    /// Flutter-parity boundary semantics.
+    #[inline]
+    pub fn mark_layout_flag(&self) {
+        match self {
+            Self::Box(entry) => entry.state().mark_needs_layout(),
+            Self::Sliver(entry) => entry.state().mark_needs_layout(),
+        }
+    }
 
     /// Returns true if this is a repaint boundary.
     pub fn is_repaint_boundary(&self) -> bool {
@@ -300,11 +314,26 @@ impl RenderNode {
         }
     }
 
-    /// Returns true if this is a relayout boundary.
+    /// Returns true if this node is a relayout boundary.
+    ///
+    /// **D-block PR-A1 U15**: reads the per-instance `IS_RELAYOUT_BOUNDARY`
+    /// storage flag (set by [`RenderState::compute_relayout_boundary`] during
+    /// layout per Flutter `!parentUsesSize || sizedByParent || constraints.isTight() || !hasParent`).
+    /// Prior behaviour returned the hardcoded `RenderObject::is_relayout_boundary()`
+    /// trait answer; that value was never consulted in production (zero
+    /// callers via grep) and reflected the type-level default rather than
+    /// runtime layout context.
+    ///
+    /// The trait-level static answer is still available via
+    /// `entry.render_object().is_relayout_boundary()` for the rare callers
+    /// that genuinely want the type-default.
+    ///
+    /// [`RenderState::compute_relayout_boundary`]: crate::storage::state::RenderState::compute_relayout_boundary
+    #[inline]
     pub fn is_relayout_boundary(&self) -> bool {
         match self {
-            Self::Box(entry) => entry.render_object().is_relayout_boundary(),
-            Self::Sliver(entry) => entry.render_object().is_relayout_boundary(),
+            Self::Box(entry) => entry.state().is_relayout_boundary(),
+            Self::Sliver(entry) => entry.state().is_relayout_boundary(),
         }
     }
 

--- a/crates/flui-rendering/src/storage/state/constraints.rs
+++ b/crates/flui-rendering/src/storage/state/constraints.rs
@@ -1,9 +1,17 @@
 //! Constraint cache validation methods for `RenderState<P>`.
 //!
-//! This file contains the write-once `OnceCell` constraint methods
-//! (`constraints`, `set_constraints`, `clear_constraints`, `has_constraints`).
-
-use once_cell::sync::OnceCell;
+//! This file contains the `Option<ProtocolConstraints<P>>`-backed constraint
+//! methods (`constraints`, `set_constraints`, `clear_constraints`,
+//! `has_constraints`).
+//!
+//! **D-block PR-A1 U14 migration (2026-05-23):** the prior `OnceCell`-backed
+//! `set_constraints` panicked on second invocation, which made any re-layout
+//! of the same node a crash. Flutter `.flutter/.../object.dart:2865`
+//! straight-assigns `_constraints = constraints` each layout pass; we mirror
+//! that semantics by holding constraints in `Option<T>` and replacing
+//! unconditionally inside `set_constraints`. Method now takes `&mut self`;
+//! the production caller (`RenderEntry::layout`) already holds `&mut self`
+//! on the entry so the borrow chain reaches the state mutably.
 
 use super::RenderState;
 use crate::protocol::{Protocol, ProtocolConstraints};
@@ -27,28 +35,34 @@ impl<P: Protocol> RenderState<P> {
     ///     }
     /// }
     /// ```
+    #[inline]
     pub fn constraints(&self) -> Option<&ProtocolConstraints<P>> {
-        self.constraints.get()
+        self.constraints.as_ref()
     }
 
-    /// Sets the constraints used for layout.
+    /// Sets (or replaces) the constraints used for layout.
     ///
-    /// Used for cache validation - if constraints haven't changed,
-    /// layout can be skipped (for sized-by-parent render objects).
-    pub fn set_constraints(&self, constraints: ProtocolConstraints<P>) {
-        if self.constraints.set(constraints).is_err() {
-            // Constraints already set - clear first!
-            panic!(
-                "Constraints already set! Call clear_constraints() before relayout. \
-                 This indicates a logic error in the layout code."
-            );
-        }
+    /// Idempotent — overwrites any prior value. Used for cache validation
+    /// against the next layout pass: if `constraints()` matches the incoming
+    /// constraints and the node is clean, the layout can be skipped.
+    ///
+    /// **D-block PR-A1 U14**: prior `OnceCell`-backed implementation panicked
+    /// on second invocation. Re-layout of the same node now mirrors Flutter's
+    /// straight-assignment semantics. See module-level doc for rationale.
+    #[inline]
+    pub fn set_constraints(&mut self, constraints: ProtocolConstraints<P>) {
+        self.constraints = Some(constraints);
     }
 
-    /// Clears the constraints to allow relayout.
+    /// Clears the constraints, signalling no prior layout has run.
+    ///
+    /// Equivalent to `set_constraints` with no value; useful as an explicit
+    /// reset before a forced re-layout in tests or eviction paths. Production
+    /// re-layout simply calls `set_constraints` with the new value — clearing
+    /// first is no longer required (the `OnceCell`-era invariant is gone).
     #[inline]
     pub fn clear_constraints(&mut self) {
-        self.constraints = OnceCell::new();
+        self.constraints = None;
     }
 
     /// Checks if constraints match the given value.
@@ -59,7 +73,7 @@ impl<P: Protocol> RenderState<P> {
         ProtocolConstraints<P>: PartialEq,
     {
         self.constraints
-            .get()
+            .as_ref()
             .map(|c| c == constraints)
             .unwrap_or(false)
     }

--- a/crates/flui-rendering/src/storage/state/flags.rs
+++ b/crates/flui-rendering/src/storage/state/flags.rs
@@ -57,6 +57,30 @@ impl<P: Protocol> RenderState<P> {
         self.flags.contains(RenderFlags::NEEDS_COMPOSITING)
     }
 
+    /// Marks the layout dirty flag.
+    ///
+    /// Sets `NEEDS_LAYOUT` on the underlying atomic flags. Idempotent —
+    /// re-marking an already-dirty node is a no-op at the atomic level.
+    ///
+    /// Lock-free, `O(1)`. Used by [`PipelineOwner::mark_needs_layout`]
+    /// (added in D-block PR-A1 U15) to walk the ancestor chain marking
+    /// each node up to the nearest relayout boundary.
+    ///
+    /// [`PipelineOwner::mark_needs_layout`]: crate::pipeline::owner::PipelineOwner::mark_needs_layout
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let state = BoxRenderState::new();
+    /// state.clear_needs_layout();
+    /// state.mark_needs_layout();
+    /// assert!(state.needs_layout());
+    /// ```
+    #[inline]
+    pub fn mark_needs_layout(&self) {
+        self.flags.mark_needs_layout();
+    }
+
     /// Clears the layout dirty flag.
     ///
     /// Call this after successfully completing layout.

--- a/crates/flui-rendering/src/storage/state/flags.rs
+++ b/crates/flui-rendering/src/storage/state/flags.rs
@@ -66,7 +66,7 @@ impl<P: Protocol> RenderState<P> {
     /// (added in D-block PR-A1 U15) to walk the ancestor chain marking
     /// each node up to the nearest relayout boundary.
     ///
-    /// [`PipelineOwner::mark_needs_layout`]: crate::pipeline::owner::PipelineOwner::mark_needs_layout
+    /// [`PipelineOwner::mark_needs_layout`]: crate::pipeline::PipelineOwner::mark_needs_layout
     ///
     /// # Example
     ///

--- a/crates/flui-rendering/src/storage/state/geometry.rs
+++ b/crates/flui-rendering/src/storage/state/geometry.rs
@@ -1,15 +1,21 @@
 //! Geometry storage and protocol-specific convenience methods.
 //!
 //! This file contains:
-//! - Generic write-once `OnceCell<ProtocolGeometry<P>>` accessors
-//!   (`geometry`, `set_geometry`, `clear_geometry`) on `RenderState<P>`
+//! - Generic `Option<ProtocolGeometry<P>>`-backed accessors (`geometry`,
+//!   `set_geometry`, `clear_geometry`) on `RenderState<P>`
 //! - Box protocol convenience methods (`compute_relayout_boundary`, `size`,
 //!   `set_size`, `has_size`) on `RenderState<BoxProtocol>`
 //! - Sliver protocol convenience methods (`scroll_extent`, `paint_extent`,
 //!   `layout_extent`, `max_paint_extent`, `set_sliver_geometry`) on
 //!   `RenderState<SliverProtocol>`
-
-use once_cell::sync::OnceCell;
+//!
+//! **D-block PR-A1 U14 migration (2026-05-23):** the prior `OnceCell`-backed
+//! `set_geometry` panicked on second invocation, which made frame-2 re-layout
+//! a crash. Flutter `.flutter/.../object.dart` straight-assigns `_size` each
+//! layout pass; we mirror that semantics via `Option<T>`. `set_geometry`,
+//! `set_size`, `set_sliver_geometry` now take `&mut self`; production callers
+//! (`RenderEntry::layout`, RenderBox/RenderSliver impls) already hold a mut
+//! state borrow.
 
 use super::RenderState;
 use crate::constraints::{Constraints, SliverGeometry};
@@ -40,60 +46,50 @@ impl<P: Protocol> RenderState<P> {
     ///     // Need to perform layout first
     /// }
     /// ```
+    #[inline]
     pub fn geometry(&self) -> Option<ProtocolGeometry<P>>
     where
         ProtocolGeometry<P>: Copy,
     {
-        self.geometry.get().copied()
+        self.geometry
     }
 
-    /// Sets the computed geometry after layout.
+    /// Sets (or replaces) the computed geometry after layout.
     ///
-    /// This should be called exactly once per layout pass. If geometry
-    /// already exists, this will panic (use `clear_geometry()` first if
-    /// you need to relayout).
+    /// Idempotent — overwrites any prior value. Flutter `_size = size`
+    /// straight-assignment semantics.
     ///
-    /// # Performance
-    ///
-    /// - First call: One atomic CAS operation
-    /// - Subsequent calls: Panic (by design, to catch bugs)
+    /// **D-block PR-A1 U14**: prior `OnceCell`-backed implementation panicked
+    /// on second invocation, which made re-layout a crash. See module-level
+    /// doc for rationale.
     ///
     /// # Example
     ///
     /// ```rust,ignore
     /// let size = compute_size(constraints);
-    /// state.set_geometry(size); // Write once
-    ///
-    /// // Later reads are zero-cost
-    /// let cached = state.geometry().unwrap();
+    /// state.set_geometry(size); // first layout pass
+    /// state.set_geometry(new_size); // re-layout (no panic)
     /// ```
-    pub fn set_geometry(&self, geometry: ProtocolGeometry<P>) {
-        if self.geometry.set(geometry).is_err() {
-            // Geometry already set - this is a bug!
-            // You must call clear_geometry() before relayout
-            panic!(
-                "Geometry already set! Call clear_geometry() before relayout. \
-                 This indicates a logic error in the layout code."
-            );
-        }
+    #[inline]
+    pub fn set_geometry(&mut self, geometry: ProtocolGeometry<P>) {
+        self.geometry = Some(geometry);
     }
 
-    /// Clears the geometry to allow relayout.
+    /// Clears the geometry, signalling no prior layout has run.
     ///
-    /// Must be called before `set_geometry()` if geometry already exists.
-    /// Production callers typically invoke this immediately before
-    /// registering the element with `PipelineOwner::add_node_needing_layout`.
+    /// Equivalent to `set_geometry` with no value; production re-layout no
+    /// longer requires an explicit clear (the `OnceCell`-era invariant is
+    /// gone). Useful in tests and eviction paths.
     ///
     /// # Example
     ///
     /// ```rust,ignore
-    /// // Force relayout — pair with PipelineOwner registration.
+    /// // Reset state — useful in tests
     /// state.clear_geometry();
-    /// pipeline_owner.add_node_needing_layout(element_id);
     /// ```
     #[inline]
     pub fn clear_geometry(&mut self) {
-        self.geometry = OnceCell::new();
+        self.geometry = None;
     }
 }
 
@@ -212,13 +208,16 @@ impl RenderState<BoxProtocol> {
 
     /// Convenience method for setting size (box protocol).
     ///
+    /// **D-block PR-A1 U14**: signature changed to `&mut self` alongside
+    /// `set_geometry` migration.
+    ///
     /// # Example
     ///
     /// ```rust,ignore
     /// state.set_size(Size::new(100.0, 50.0));
     /// ```
     #[inline]
-    pub fn set_size(&self, size: flui_types::Size) {
+    pub fn set_size(&mut self, size: flui_types::Size) {
         self.set_geometry(size);
     }
 
@@ -286,6 +285,9 @@ impl RenderState<SliverProtocol> {
 
     /// Sets sliver geometry (convenience wrapper for `set_geometry()`).
     ///
+    /// **D-block PR-A1 U14**: signature changed to `&mut self` alongside
+    /// `set_geometry` migration.
+    ///
     /// # Example
     ///
     /// ```rust,ignore
@@ -297,7 +299,7 @@ impl RenderState<SliverProtocol> {
     /// state.set_sliver_geometry(geom);
     /// ```
     #[inline]
-    pub fn set_sliver_geometry(&self, geometry: SliverGeometry) {
+    pub fn set_sliver_geometry(&mut self, geometry: SliverGeometry) {
         self.set_geometry(geometry);
     }
 }

--- a/crates/flui-rendering/src/storage/state/mod.rs
+++ b/crates/flui-rendering/src/storage/state/mod.rs
@@ -2,24 +2,35 @@
 //!
 //! This module provides lock-free state storage for render objects:
 //! - Atomic flags for lock-free dirty tracking
-//! - Write-once geometry and constraints using `OnceCell`
+//! - Mutable geometry and constraints (`Option<T>`, mutated each layout
+//!   pass via `&mut self` accessors)
 //! - Atomic offset updates for paint positioning
 //! - Boundary accessors (relayout/repaint) for pipeline-owner registration
 //!
+//! **D-block PR-A1 U14 migration (2026-05-23):** geometry and constraints
+//! previously used `OnceCell` for write-once semantics; the resulting
+//! panic-on-second-set crashed any re-layout. Migrated to `Option<T>` so
+//! re-layout overwrites unconditionally, mirroring Flutter
+//! `.flutter/.../object.dart:2865` `_size = size` straight assignment.
+//! `set_constraints`/`set_geometry`/`set_size`/`set_sliver_geometry` now
+//! take `&mut self`; production callers (`RenderEntry::layout` and the
+//! RenderBox/RenderSliver helpers) already hold a mut state borrow.
+//!
 //! Production dirty marking does **not** live here. It is driven by
-//! `PipelineOwner::add_node_needing_layout / add_node_needing_paint` invoked
-//! from `flui-view` and `flui-hot-reload`. The boundary-aware propagation
-//! methods that previously hung off `RenderState<P>` were removed in U3 of
-//! the flui-rendering Phase 1 zombie cleanup as unreachable code; the
-//! `RenderDirtyPropagation` trait that PR #81 U3 preserved as a "cost-cheap
-//! option" was deleted in cycle 4 R-5 because its `ElementId` typing did not
-//! match the crate's `RenderId` key — see the `propagation` submodule's
-//! module-level docstring for the rationale and the audit trail
-//! (`docs/research/2026-05-22-flui-rendering-engine-audit.md`).
+//! [`PipelineOwner::mark_needs_layout`](crate::pipeline::PipelineOwner::mark_needs_layout)
+//! (D-block PR-A1 U15 — Flutter `markNeedsLayout` walk) invoked from
+//! `flui-view::element::behavior_commons::mark_render_needs_layout_and_paint`.
+//! The boundary-aware propagation methods that previously hung off
+//! `RenderState<P>` were removed in U3 of the flui-rendering Phase 1 zombie
+//! cleanup as unreachable code; the `RenderDirtyPropagation` trait that
+//! PR #81 U3 preserved as a "cost-cheap option" was deleted in cycle 4 R-5
+//! because its `ElementId` typing did not match the crate's `RenderId` key —
+//! see the `propagation` submodule's module-level docstring for the audit
+//! trail (`docs/research/2026-05-22-flui-rendering-engine-audit.md`).
 //!
 //! # Design Philosophy
 //!
-//! - **Lock-free when possible**: Atomic operations for hot paths
+//! - **Lock-free when possible**: Atomic operations for hot paths (flags + offset)
 //! - **Cache-friendly**: Optimized memory layout for performance
 //! - **Zero-cost abstractions**: No overhead for unused features
 //!
@@ -27,9 +38,9 @@
 //!
 //! ```text
 //! RenderState<P>
-//!  ├── flags: AtomicRenderFlags (lock-free, always accessible)
-//!  ├── geometry: OnceCell<ProtocolGeometry<P>> (write-once, read-many)
-//!  ├── constraints: OnceCell<ProtocolConstraints<P>> (write-once, read-many)
+//!  ├── flags: AtomicRenderFlags (lock-free, &self mutation)
+//!  ├── geometry: Option<ProtocolGeometry<P>> (&mut self set/clear; Flutter parity)
+//!  ├── constraints: Option<ProtocolConstraints<P>> (&mut self set/clear)
 //!  └── offset: AtomicOffset (lock-free atomic updates)
 //! ```
 //!
@@ -42,12 +53,17 @@
 //! - Write: Single atomic fetch_or/fetch_and (≈1-5ns)
 //! - No blocking, no context switches
 //!
-//! ## Write-Once Geometry/Constraints
+//! ## Mutable Geometry/Constraints
 //!
-//! Uses `OnceCell` for write-once, read-many pattern:
-//! - First layout: One atomic CAS to initialize
-//! - Subsequent reads: Zero-cost (just a pointer load)
-//! - Relayout: Clear and reinitialize (rare operation)
+//! Plain `Option<T>` fields mutated via `&mut self`:
+//! - Set: Direct field assignment (≈1ns)
+//! - Read: Direct field load (zero-cost via `Copy` types)
+//! - Re-layout: Idempotent overwrite — no clear-before-set required
+//!
+//! Thread-safety on these fields is enforced by Rust's borrow checker:
+//! pipeline layout is single-threaded by contract (the contract a render
+//! pass holds `&mut RenderEntry<P>` exclusively for its node, so the inner
+//! `&mut RenderState<P>` access is statically race-free).
 //!
 //! # Examples
 //!
@@ -56,7 +72,7 @@
 //! ```rust,ignore
 //! use flui_rendering::core::{BoxRenderState, RenderFlags};
 //!
-//! let state = BoxRenderState::new();
+//! let mut state = BoxRenderState::new();
 //!
 //! // Lock-free flag checks (hot path)
 //! if state.needs_layout() {
@@ -64,10 +80,10 @@
 //!     state.clear_needs_layout();
 //! }
 //!
-//! // Write geometry once after layout
+//! // Write geometry idempotently after layout
 //! state.set_geometry(computed_size);
 //!
-//! // Read geometry many times during paint (zero-cost)
+//! // Read geometry many times during paint (Copy, zero-cost)
 //! let size = state.geometry();
 //! ```
 

--- a/crates/flui-rendering/src/storage/state/mod.rs
+++ b/crates/flui-rendering/src/storage/state/mod.rs
@@ -73,7 +73,9 @@
 
 use std::marker::PhantomData;
 
-use once_cell::sync::OnceCell;
+// NOTE: `OnceCell` was previously imported here for `geometry`/`constraints`
+// write-once semantics; D-block PR-A1 U14 migrated both fields to `Option<T>`
+// so the import is no longer needed.
 
 use crate::protocol::{
     BoxProtocol, Protocol, ProtocolConstraints, ProtocolGeometry, SliverProtocol,
@@ -162,16 +164,21 @@ pub struct RenderState<P: Protocol> {
     /// For BoxProtocol: Size
     /// For SliverProtocol: SliverGeometry
     ///
-    /// Write-once per layout pass, read many times during paint.
-    geometry: OnceCell<ProtocolGeometry<P>>,
+    /// Mutated each layout pass via [`set_geometry`](Self::set_geometry).
+    /// Migrated from `OnceCell` to `Option` in D-block PR-A1 U14 — re-layout
+    /// must be idempotent (frame-2 panic fix per memo D2; Flutter `_size`
+    /// is straight-assigned each layout at `.flutter/.../object.dart:2865`).
+    geometry: Option<ProtocolGeometry<P>>,
 
     /// Last constraints used for layout.
     ///
     /// For BoxProtocol: BoxConstraints
     /// For SliverProtocol: SliverConstraints
     ///
-    /// Used for cache validation and optimization.
-    constraints: OnceCell<ProtocolConstraints<P>>,
+    /// Used for cache validation and the relayout-boundary short-circuit.
+    /// Migrated from `OnceCell` to `Option` in D-block PR-A1 U14 alongside
+    /// `geometry`; see field doc above for rationale.
+    constraints: Option<ProtocolConstraints<P>>,
 
     /// Offset relative to parent (atomic for lock-free updates).
     ///
@@ -205,8 +212,8 @@ impl<P: Protocol> RenderState<P> {
     pub fn new() -> Self {
         Self {
             flags: AtomicRenderFlags::new(RenderFlags::NEEDS_LAYOUT | RenderFlags::NEEDS_PAINT),
-            geometry: OnceCell::new(),
-            constraints: OnceCell::new(),
+            geometry: None,
+            constraints: None,
             offset: AtomicOffset::new(flui_types::Offset::ZERO),
             _phantom: PhantomData,
         }
@@ -227,8 +234,8 @@ impl<P: Protocol> RenderState<P> {
     pub fn with_flags(flags: RenderFlags) -> Self {
         Self {
             flags: AtomicRenderFlags::new(flags),
-            geometry: OnceCell::new(),
-            constraints: OnceCell::new(),
+            geometry: None,
+            constraints: None,
             offset: AtomicOffset::new(flui_types::Offset::ZERO),
             _phantom: PhantomData,
         }
@@ -249,24 +256,8 @@ where
     fn clone(&self) -> Self {
         Self {
             flags: AtomicRenderFlags::new(self.flags.load()),
-            geometry: self
-                .geometry
-                .get()
-                .cloned()
-                .map_or_else(OnceCell::new, |g| {
-                    let cell = OnceCell::new();
-                    let _ = cell.set(g);
-                    cell
-                }),
-            constraints: self
-                .constraints
-                .get()
-                .cloned()
-                .map_or_else(OnceCell::new, |c| {
-                    let cell = OnceCell::new();
-                    let _ = cell.set(c);
-                    cell
-                }),
+            geometry: self.geometry.clone(),
+            constraints: self.constraints.clone(),
             offset: AtomicOffset::new(self.offset.load()),
             _phantom: PhantomData,
         }

--- a/crates/flui-rendering/src/storage/state/tests.rs
+++ b/crates/flui-rendering/src/storage/state/tests.rs
@@ -100,3 +100,62 @@ fn test_boundary_flags() {
     assert!(!state.is_relayout_boundary());
     assert!(state.is_repaint_boundary());
 }
+
+/// Copilot P1 regression test (PR #139): a non-root node with loose
+/// (non-tight) constraints and `sized_by_parent = false` must NOT default
+/// to a relayout boundary. Pre-fix the U17 bootstrap passed
+/// `parent_uses_size = false` which made `!parent_uses_size = true`,
+/// flipping every Box node into a boundary and silently blocking
+/// `PipelineOwner::mark_needs_layout` propagation at the leaf.
+#[test]
+fn compute_relayout_boundary_non_tight_non_root_is_not_boundary_by_default() {
+    use crate::constraints::BoxConstraints;
+    use flui_types::Size;
+
+    let mut state = BoxRenderState::new();
+    // Loose constraints (not tight) — typical layout-from-parent case.
+    let loose = BoxConstraints::loose(Size::new(px(200.0), px(100.0)));
+    state.set_constraints(loose);
+
+    // Bootstrap as if running under the U17 wiring with the BoxProtocol
+    // override: parent_uses_size=true (conservative), sized_by_parent=false,
+    // has_parent=true (non-root).
+    state.compute_relayout_boundary(true, false, true);
+
+    assert!(
+        !state.is_relayout_boundary(),
+        "non-tight, non-root, non-sized-by-parent node MUST default to non-boundary so mark_needs_layout propagates up to a real boundary",
+    );
+}
+
+/// Companion test: tight constraints still mark as boundary (Flutter parity:
+/// when parent forces a single valid size, the node can re-layout in
+/// isolation).
+#[test]
+fn compute_relayout_boundary_tight_constraints_is_boundary() {
+    use crate::constraints::BoxConstraints;
+    use flui_types::Size;
+
+    let mut state = BoxRenderState::new();
+    let tight = BoxConstraints::tight(Size::new(px(50.0), px(50.0)));
+    state.set_constraints(tight);
+
+    state.compute_relayout_boundary(true, false, true);
+
+    assert!(
+        state.is_relayout_boundary(),
+        "tight constraints mean parent forces a single valid size — node is a boundary",
+    );
+}
+
+/// Companion test: root (no parent) is always a boundary regardless of
+/// other signals — propagation cannot escape the root.
+#[test]
+fn compute_relayout_boundary_root_is_always_boundary() {
+    let state = BoxRenderState::new();
+    state.compute_relayout_boundary(true, false, /* has_parent = */ false);
+    assert!(
+        state.is_relayout_boundary(),
+        "root must always be a boundary"
+    );
+}

--- a/crates/flui-rendering/src/storage/state/tests.rs
+++ b/crates/flui-rendering/src/storage/state/tests.rs
@@ -48,20 +48,25 @@ fn render_state_sliver_fits_budget() {
 }
 
 #[test]
-fn test_geometry_write_once() {
-    let state = BoxRenderState::new();
+fn test_geometry_set_is_idempotent() {
+    // D-block PR-A1 U14: previously `set_geometry` panicked on second
+    // invocation (OnceCell-backed). Re-layout now overwrites cleanly
+    // mirroring Flutter `_size = size` straight assignment.
+    let mut state = BoxRenderState::new();
     let size1 = flui_types::Size::new(px(100.0), px(50.0));
     let size2 = flui_types::Size::new(px(200.0), px(100.0));
 
-    // First set succeeds
+    // First set establishes geometry.
     state.set_geometry(size1);
     assert_eq!(state.geometry(), Some(size1));
 
-    // Second set panics
-    let result = std::panic::catch_unwind(|| {
-        state.set_geometry(size2);
-    });
-    assert!(result.is_err());
+    // Second set overwrites with no panic — re-layout safe.
+    state.set_geometry(size2);
+    assert_eq!(state.geometry(), Some(size2));
+
+    // Clear resets to None.
+    state.clear_geometry();
+    assert_eq!(state.geometry(), None);
 }
 
 #[test]

--- a/crates/flui-view/src/element/behavior_commons.rs
+++ b/crates/flui-view/src/element/behavior_commons.rs
@@ -239,13 +239,20 @@ pub(crate) fn mark_render_needs_layout_and_paint<V, A>(
         && let Some(pipeline_owner) = core.pipeline_owner()
     {
         let mut owner = pipeline_owner.write();
-        let tree_depth = owner.render_tree().depth(render_id).unwrap_or(0);
 
-        owner.add_node_needing_layout(render_id, tree_depth as usize);
+        // D-block PR-A1 U16: migrate from direct add_node_needing_layout to
+        // PipelineOwner::mark_needs_layout (new in U15) so the layout-side
+        // mark propagates up to the nearest relayout boundary per Flutter
+        // markNeedsLayout semantics. Paint side stays on the direct primitive
+        // — Flutter's markNeedsPaint is its own walk with different boundary
+        // semantics (repaint vs relayout boundary) and is out of D-block
+        // scope (Core.2 paint catalog work).
+        let tree_depth = owner.render_tree().depth(render_id).unwrap_or(0);
+        owner.mark_needs_layout(render_id);
         owner.add_node_needing_paint(render_id, tree_depth as usize);
 
         tracing::debug!(
-            "{}::on_update marked render_id={:?} dirty",
+            "{}::on_update marked render_id={:?} dirty (layout via mark_needs_layout walk, paint direct)",
             behavior_name,
             render_id
         );


### PR DESCRIPTION
## Summary

Third implementation PR in the Core.0 D-block sequence per [the D-block plan](docs/plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md). **PR-A1a prep work** (U14-U17) — additive changes that eliminate the frame-2 re-layout panic, author Flutter's `markNeedsLayout` propagation walk, migrate the production caller, and bootstrap the per-instance `IS_RELAYOUT_BOUNDARY` flag. Pipeline orchestration semantics (`run_layout` walk shape) unchanged in this PR — that lands in **PR-A1b** (U18-U31).

> **Discovery before PR-A1 work:** PR-B-gate AND PR-B-followup are both **no-op** — PR #100 (commit `be73d2e6`) + PR #101 + PR #103 already shipped the FULL layer/semantics repair plan U1-U24 before D-block planning began. The D-block sequence reduces from 7 PRs to 5: PR-C-1 ✅, PR-C-2 ✅, **PR-A1a (this) + PR-A1b (next)**, PR-A2, PR-C-3. PR-B work skipped. See memory entry `flui-d-block-pr-b-skipped` for evidence and process lesson.

| Unit | Commit | What |
|---|---|---|
| U14 | `9a738c1a` | `RenderState::set_constraints` + `set_geometry` `OnceCell` → `Option` (frame-2 panic fix per memo D2; Flutter `_size = size` straight assignment) |
| U15 | `16ff8e12` | `PipelineOwner::mark_needs_layout(id)` propagation walk — greenfield port of Flutter `markNeedsLayout` (`.flutter/.../object.dart:2658-2700`); state-flag `mark_needs_layout` accessor; `RenderNode::is_relayout_boundary` rewritten to read storage flag instead of trait answer |
| U16 | `c18dd623` | Migrate sole production caller (`flui-view::element::behavior_commons::mark_render_needs_layout_and_paint`) from direct `add_node_needing_layout` to the new walk |
| U17 | `923fa940` | Bootstrap `IS_RELAYOUT_BOUNDARY` flag via new `Protocol::bootstrap_relayout_boundary` trait method (Box-only override calls `compute_relayout_boundary`; Sliver default no-op); wired into `RenderEntry::layout` success path |

## What's NOT in this PR (deferred to PR-A1b)

- `layout_node_with_children` walk rewrite to invoke `entry.layout` per-node (memo D1 disjoint-borrow architecture)
- `RenderNode::layout_erased` + `ErasedConstraints`/`ErasedGeometry` enums (memo D4)
- `RenderObject::perform_layout_raw` signature change + `RenderBox` bridge (memo D5)
- Layout cycle detection (memo D6)
- Dirty-queue dedup (memo D7)
- Cache-hit short-circuit
- 3-level Padding/Center/ColoredBox integration test infrastructure

Pipeline orchestration semantics (`run_layout` actually invoking per-node layout) require all of the above and would balloon this PR past review tolerance. PR-A1a is pure prep — additive APIs and ONE caller migration; pipeline behavior unchanged.

## Per-unit green build

Each commit is a self-contained green build:

- **U14**: `cargo build --workspace` + `cargo clippy --workspace --all-targets -- -D warnings` + `cargo test -p flui-rendering --lib` all exit 0; 254 tests pass (incl. new idempotent test replacing the pre-migration write-once-panic test)
- **U15**: same gate; 258 tests pass (254 + 4 new `mark_needs_layout_*` walk tests)
- **U16**: same gate; 167 flui-view tests pass
- **U17**: same gate; 258 flui-rendering tests pass; `bash scripts/port-check.sh` reports "all seven refusal triggers + FR-033 grep + trigger 9 (FR-036) clean"

## Per memo D9 file fences

PR-A1a touchpoints (verified — no overlap with PR-A1b / PR-A2 / PR-C-3):

- `crates/flui-rendering/src/storage/state/{mod,constraints,geometry,flags,tests}.rs` (Option migration + new mark_needs_layout state accessor)
- `crates/flui-rendering/src/storage/{entry,node}.rs` (boundary bootstrap + state-flag-aware is_relayout_boundary + flag-only mark accessor)
- `crates/flui-rendering/src/protocol/{protocol,box_protocol}.rs` (Protocol::bootstrap_relayout_boundary trait method + Box override)
- `crates/flui-rendering/src/pipeline/owner.rs` (PipelineOwner::mark_needs_layout walk + 4 new unit tests)
- `crates/flui-view/src/element/behavior_commons.rs` (caller migration)

## Test plan

CI runs the standard workspace gate: `fmt`, `clippy`, `port-check`, `typos`, `taplo`, `test (ubuntu-latest)`, `test (windows-latest)`, `doc`. Local pre-push gates listed above.

New `pipeline::owner::tests::mark_needs_layout_*` tests cover:
- `_walks_to_root_when_no_boundary_set`: 3-level chain, all 3 NEEDS_LAYOUT set, dirty queue contains root only
- `_is_idempotent_on_repeat`: second mark on already-dirty subtree no-ops
- `_stops_at_intermediate_relayout_boundary`: pre-bootstrap middle as boundary, assert root stays clean
- `_stale_id_is_silent_noop`: missing-id walk terminates without dirty-queue mutation

## Next steps after merge

1. Open PR-A1b: `layout_node_with_children` walk rewrite (U18-U31) per memo D1/D4/D5/D6/D7 + 3-level integration test gates (R4/R5/R6 + AE8/AE9 from brainstorm)
2. Then PR-A2 (D-3+D-4 compositing+paint pipeline)
3. Finally PR-C-3 (refusal triggers install — close-first per PR #134 precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
