### PR TITLE
feat: PR-A1b1 — D-1 walk rewrite prep: ErasedConstraints/ErasedGeometry + RenderNode::layout_erased (U18)

### DIFF
--- a/crates/flui-rendering/src/error.rs
+++ b/crates/flui-rendering/src/error.rs
@@ -220,8 +220,14 @@ pub enum RenderError {
 
     /// Detected a layout cycle: a `RenderEntry::layout` call recursed
     /// (via `LayoutContext::layout_child`) back into a node whose layout
-    /// was still in flight on the same frame. Surfaces via the
-    /// `currently_laying_out` guard on `PipelineOwner<Layout>`.
+    /// was still in flight on the same frame.
+    ///
+    /// **Variant pre-added in D-block PR-A1b U18; cycle-detection wiring
+    /// lands in U21** (companion memo D6) as a `currently_laying_out`
+    /// `FxHashSet<RenderId>` guard on `PipelineOwner<Layout>` with a
+    /// RAII drop-guard for unwind safety. Currently no production code
+    /// constructs this variant — it is reserved so the error surface is
+    /// already stable when U21 wires the guard.
     #[error("layout cycle detected: node {0:?} re-entered while its own layout was in flight")]
     LayoutCycle(RenderId),
 }

--- a/crates/flui-rendering/src/error.rs
+++ b/crates/flui-rendering/src/error.rs
@@ -199,6 +199,31 @@ pub enum RenderError {
         /// Phase during which the panic occurred (e.g. `"layout"`).
         phase: &'static str,
     },
+
+    // ========================================================================
+    // D-block PR-A1b — protocol-erased dispatch
+    // ========================================================================
+    /// The protocol-erased constraints or geometry variant did not match
+    /// the node's protocol. Returned from
+    /// [`RenderNode::layout_erased`](crate::storage::RenderNode::layout_erased)
+    /// when a `Box(_)` constraint is handed to a `Sliver` node (or vice
+    /// versa). Indicates a bug in the pipeline-dispatch caller.
+    #[error(
+        "protocol mismatch in layout_erased: node is {node_protocol}, constraints are {constraints_protocol}"
+    )]
+    ProtocolMismatch {
+        /// Protocol of the node that received the call.
+        node_protocol: &'static str,
+        /// Protocol of the constraints actually passed.
+        constraints_protocol: &'static str,
+    },
+
+    /// Detected a layout cycle: a `RenderEntry::layout` call recursed
+    /// (via `LayoutContext::layout_child`) back into a node whose layout
+    /// was still in flight on the same frame. Surfaces via the
+    /// `currently_laying_out` guard on `PipelineOwner<Layout>`.
+    #[error("layout cycle detected: node {0:?} re-entered while its own layout was in flight")]
+    LayoutCycle(RenderId),
 }
 
 /// Result type alias for render operations.

--- a/crates/flui-rendering/src/storage/erased.rs
+++ b/crates/flui-rendering/src/storage/erased.rs
@@ -17,9 +17,18 @@
 //!
 //! Conversions are provided via `From`/`TryFrom` so callers that already
 //! hold a protocol-typed value can lift it into the erased enum cheaply
-//! (`ErasedConstraints::from(c)` for `c: BoxConstraints`), and
-//! pipeline-side recipients can downcast on the happy path with the
-//! `TryFrom` path returning the `ProtocolMismatch` error on mismatch.
+//! (`ErasedConstraints::from(c)` for `c: BoxConstraints`), and pipeline-side
+//! recipients can downcast on the happy path. The `TryFrom` impls return
+//! the local [`ErasedConstraintsMismatch`] / [`ErasedGeometryMismatch`]
+//! error types — narrow value-level signals tied to a specific conversion
+//! call site. `RenderNode::layout_erased` (which dispatches the erased
+//! constraints to the protocol-typed entry) uses the broader
+//! [`RenderError::ProtocolMismatch`](crate::error::RenderError::ProtocolMismatch)
+//! variant for its own return type instead — the two error surfaces are
+//! intentionally distinct because their callers have different recovery
+//! paths (a value-conversion mismatch is typically a caller bug worth
+//! `unwrap`-ing in tests, while a pipeline-dispatch mismatch flows through
+//! `RenderResult` alongside other render errors).
 
 use crate::constraints::{BoxConstraints, SliverConstraints, SliverGeometry};
 use flui_types::Size;

--- a/crates/flui-rendering/src/storage/erased.rs
+++ b/crates/flui-rendering/src/storage/erased.rs
@@ -1,0 +1,248 @@
+//! Protocol-erased constraint / geometry enums for the pipeline → entry
+//! dispatch seam.
+//!
+//! **D-block PR-A1b U18 (companion memo D4):** the pipeline operates on
+//! `&mut RenderNode` (a protocol-erased enum over `RenderEntry<BoxProtocol>`
+//! and `RenderEntry<SliverProtocol>`). `RenderEntry::layout` is generic
+//! over `P: Protocol` and takes protocol-typed `ProtocolConstraints<P>` /
+//! returns `ProtocolGeometry<P>`. Bridging the two ends requires an erased
+//! enum + per-variant dispatch through `RenderNode::layout_erased`.
+//!
+//! `ErasedConstraints` and `ErasedGeometry` carry the protocol-typed value
+//! inside an enum tag; `RenderNode::layout_erased` (added in U18 to
+//! `crates/flui-rendering/src/storage/node.rs`) pattern-matches and forwards
+//! to the appropriate `RenderEntry<P>::layout` call, returning
+//! `Err(RenderError::ProtocolMismatch)` if the constraint variant does not
+//! match the node's protocol.
+//!
+//! Conversions are provided via `From`/`TryFrom` so callers that already
+//! hold a protocol-typed value can lift it into the erased enum cheaply
+//! (`ErasedConstraints::from(c)` for `c: BoxConstraints`), and
+//! pipeline-side recipients can downcast on the happy path with the
+//! `TryFrom` path returning the `ProtocolMismatch` error on mismatch.
+
+use crate::constraints::{BoxConstraints, SliverConstraints, SliverGeometry};
+use flui_types::Size;
+
+// ============================================================================
+// ErasedConstraints
+// ============================================================================
+
+/// Protocol-erased constraints enum carrying either a `BoxConstraints` or a
+/// `SliverConstraints` payload.
+///
+/// Pattern-matched by [`RenderNode::layout_erased`](super::RenderNode::layout_erased);
+/// caller-side construction via `From<BoxConstraints>` / `From<SliverConstraints>`;
+/// callee-side downcast via `TryFrom`.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum ErasedConstraints {
+    /// Box-protocol constraints (`min_width`, `max_width`, `min_height`, `max_height`).
+    Box(BoxConstraints),
+    /// Sliver-protocol constraints (axis-direction-aware scroll layout).
+    Sliver(SliverConstraints),
+}
+
+impl From<BoxConstraints> for ErasedConstraints {
+    #[inline]
+    fn from(c: BoxConstraints) -> Self {
+        Self::Box(c)
+    }
+}
+
+impl From<SliverConstraints> for ErasedConstraints {
+    #[inline]
+    fn from(c: SliverConstraints) -> Self {
+        Self::Sliver(c)
+    }
+}
+
+impl TryFrom<ErasedConstraints> for BoxConstraints {
+    type Error = ErasedConstraintsMismatch;
+
+    #[inline]
+    fn try_from(value: ErasedConstraints) -> Result<Self, Self::Error> {
+        match value {
+            ErasedConstraints::Box(c) => Ok(c),
+            ErasedConstraints::Sliver(_) => Err(ErasedConstraintsMismatch {
+                expected: "Box",
+                got: "Sliver",
+            }),
+        }
+    }
+}
+
+impl TryFrom<ErasedConstraints> for SliverConstraints {
+    type Error = ErasedConstraintsMismatch;
+
+    #[inline]
+    fn try_from(value: ErasedConstraints) -> Result<Self, Self::Error> {
+        match value {
+            ErasedConstraints::Sliver(c) => Ok(c),
+            ErasedConstraints::Box(_) => Err(ErasedConstraintsMismatch {
+                expected: "Sliver",
+                got: "Box",
+            }),
+        }
+    }
+}
+
+// ============================================================================
+// ErasedGeometry
+// ============================================================================
+
+/// Protocol-erased geometry enum carrying either a box `Size` or a
+/// `SliverGeometry` payload.
+///
+/// Returned from [`RenderNode::layout_erased`](super::RenderNode::layout_erased);
+/// caller-side construction via `From<Size>` / `From<SliverGeometry>`;
+/// callee-side downcast via `TryFrom`.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum ErasedGeometry {
+    /// Box-protocol geometry (a 2D size).
+    Box(Size),
+    /// Sliver-protocol geometry (scroll-extent / paint-extent / etc.).
+    Sliver(SliverGeometry),
+}
+
+impl From<Size> for ErasedGeometry {
+    #[inline]
+    fn from(g: Size) -> Self {
+        Self::Box(g)
+    }
+}
+
+impl From<SliverGeometry> for ErasedGeometry {
+    #[inline]
+    fn from(g: SliverGeometry) -> Self {
+        Self::Sliver(g)
+    }
+}
+
+impl TryFrom<ErasedGeometry> for Size {
+    type Error = ErasedGeometryMismatch;
+
+    #[inline]
+    fn try_from(value: ErasedGeometry) -> Result<Self, Self::Error> {
+        match value {
+            ErasedGeometry::Box(g) => Ok(g),
+            ErasedGeometry::Sliver(_) => Err(ErasedGeometryMismatch {
+                expected: "Box",
+                got: "Sliver",
+            }),
+        }
+    }
+}
+
+impl TryFrom<ErasedGeometry> for SliverGeometry {
+    type Error = ErasedGeometryMismatch;
+
+    #[inline]
+    fn try_from(value: ErasedGeometry) -> Result<Self, Self::Error> {
+        match value {
+            ErasedGeometry::Sliver(g) => Ok(g),
+            ErasedGeometry::Box(_) => Err(ErasedGeometryMismatch {
+                expected: "Sliver",
+                got: "Box",
+            }),
+        }
+    }
+}
+
+// ============================================================================
+// Mismatch errors
+// ============================================================================
+
+/// Returned by `TryFrom<ErasedConstraints>` when the enum variant does not
+/// match the requested protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ErasedConstraintsMismatch {
+    /// Protocol name the caller asked for.
+    pub expected: &'static str,
+    /// Protocol name actually carried by the erased value.
+    pub got: &'static str,
+}
+
+impl core::fmt::Display for ErasedConstraintsMismatch {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "ErasedConstraints variant mismatch: expected {}, got {}",
+            self.expected, self.got
+        )
+    }
+}
+
+impl std::error::Error for ErasedConstraintsMismatch {}
+
+/// Returned by `TryFrom<ErasedGeometry>` when the enum variant does not
+/// match the requested protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ErasedGeometryMismatch {
+    /// Protocol name the caller asked for.
+    pub expected: &'static str,
+    /// Protocol name actually carried by the erased value.
+    pub got: &'static str,
+}
+
+impl core::fmt::Display for ErasedGeometryMismatch {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "ErasedGeometry variant mismatch: expected {}, got {}",
+            self.expected, self.got
+        )
+    }
+}
+
+impl std::error::Error for ErasedGeometryMismatch {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn erased_constraints_box_roundtrip() {
+        let c = BoxConstraints::tight(Size::new(
+            flui_types::geometry::px(50.0),
+            flui_types::geometry::px(30.0),
+        ));
+        let erased: ErasedConstraints = c.into();
+        let back: BoxConstraints = erased.try_into().expect("box round-trip");
+        assert_eq!(back, c);
+    }
+
+    #[test]
+    fn erased_constraints_box_to_sliver_is_mismatch() {
+        let c = BoxConstraints::loose(Size::new(
+            flui_types::geometry::px(100.0),
+            flui_types::geometry::px(100.0),
+        ));
+        let erased: ErasedConstraints = c.into();
+        let err = SliverConstraints::try_from(erased).expect_err("box→sliver mismatch");
+        assert_eq!(err.expected, "Sliver");
+        assert_eq!(err.got, "Box");
+    }
+
+    #[test]
+    fn erased_geometry_size_roundtrip() {
+        let g = Size::new(
+            flui_types::geometry::px(75.0),
+            flui_types::geometry::px(25.0),
+        );
+        let erased: ErasedGeometry = g.into();
+        let back: Size = erased.try_into().expect("size round-trip");
+        assert_eq!(back, g);
+    }
+
+    #[test]
+    fn erased_geometry_size_to_sliver_is_mismatch() {
+        let g = Size::new(
+            flui_types::geometry::px(10.0),
+            flui_types::geometry::px(10.0),
+        );
+        let erased: ErasedGeometry = g.into();
+        let err = SliverGeometry::try_from(erased).expect_err("size→sliver mismatch");
+        assert_eq!(err.expected, "Sliver");
+        assert_eq!(err.got, "Box");
+    }
+}

--- a/crates/flui-rendering/src/storage/mod.rs
+++ b/crates/flui-rendering/src/storage/mod.rs
@@ -60,6 +60,7 @@
 //! ```
 
 mod entry;
+mod erased;
 mod flags;
 mod links;
 mod node;
@@ -68,6 +69,9 @@ mod tree;
 
 // Public exports
 pub use entry::RenderEntry;
+pub use erased::{
+    ErasedConstraints, ErasedConstraintsMismatch, ErasedGeometry, ErasedGeometryMismatch,
+};
 pub use flags::{AtomicRenderFlags, RenderFlags};
 pub use links::NodeLinks;
 pub use node::RenderNode;

--- a/crates/flui-rendering/src/storage/node.rs
+++ b/crates/flui-rendering/src/storage/node.rs
@@ -306,6 +306,47 @@ impl RenderNode {
         }
     }
 
+    /// Protocol-erased layout dispatch: matches the inner `RenderEntry<P>`
+    /// against the supplied [`ErasedConstraints`](crate::storage::ErasedConstraints)
+    /// variant and forwards to `RenderEntry::<P>::layout(constraints)`,
+    /// returning the result as
+    /// [`ErasedGeometry`](crate::storage::ErasedGeometry).
+    ///
+    /// **D-block PR-A1b U18 (companion memo D4):** the pipeline operates on
+    /// protocol-erased `RenderNode`s, but `RenderEntry::layout` is generic
+    /// over `P: Protocol`. This method bridges the seam — variant mismatch
+    /// (e.g., `Box` constraints handed to a `Sliver` entry) returns
+    /// [`RenderError::ProtocolMismatch`](crate::error::RenderError::ProtocolMismatch).
+    ///
+    /// Pipeline-side callers (`PipelineOwner::layout_dirty_root`, U20) lift
+    /// the protocol-typed root constraints to `ErasedConstraints` via the
+    /// `From<BoxConstraints>` / `From<SliverConstraints>` impls before
+    /// invoking. Per-protocol-typed callers (the `RenderBox` bridge and
+    /// `RenderSliver` bridge in U19) downcast the returned geometry via
+    /// `TryFrom<ErasedGeometry>`.
+    pub fn layout_erased(
+        &mut self,
+        constraints: crate::storage::ErasedConstraints,
+    ) -> crate::error::RenderResult<crate::storage::ErasedGeometry> {
+        use crate::storage::ErasedConstraints;
+        match (self, constraints) {
+            (Self::Box(entry), ErasedConstraints::Box(c)) => entry.layout(c).map(Into::into),
+            (Self::Sliver(entry), ErasedConstraints::Sliver(c)) => entry.layout(c).map(Into::into),
+            (Self::Box(_), ErasedConstraints::Sliver(_)) => {
+                Err(crate::error::RenderError::ProtocolMismatch {
+                    node_protocol: "Box",
+                    constraints_protocol: "Sliver",
+                })
+            }
+            (Self::Sliver(_), ErasedConstraints::Box(_)) => {
+                Err(crate::error::RenderError::ProtocolMismatch {
+                    node_protocol: "Sliver",
+                    constraints_protocol: "Box",
+                })
+            }
+        }
+    }
+
     /// Returns true if this is a repaint boundary.
     pub fn is_repaint_boundary(&self) -> bool {
         match self {


### PR DESCRIPTION
## Summary

Fourth implementation PR in the Core.0 D-block sequence per [the D-block plan](docs/plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md). **Scope: U18 ONLY** — protocol-erased constraints/geometry enums + `RenderNode::layout_erased` dispatch method. Additive APIs; no behavior change; pipeline orchestration untouched.

**Why narrower than the original PR-A1b spec (U18-U31):** U19 (`RenderObject::perform_layout_raw` signature change + `RenderBox` bridge) needs careful architectural design work — the trait-surface change ripples to all impls, and the `LayoutCtxErased` shape is non-obvious under Rust's generic-context erasure constraints (`BoxLayoutContext` is generic over `Arity` + `ParentData`, complicating trait-object friendliness). Shipping U18 alone locks the dispatch enums as additive infrastructure; U19+ continues in the next PR with a fresh design pass.

| Unit | Commit | What |
|---|---|---|
| U18 | `1bbb924b` | `ErasedConstraints` / `ErasedGeometry` enums with `From` + `TryFrom` per protocol; `ErasedConstraintsMismatch` / `ErasedGeometryMismatch` error types; `RenderError::ProtocolMismatch` variant; `RenderError::LayoutCycle(RenderId)` variant (pre-add for U21); `RenderNode::layout_erased` dispatch method pattern-matching over the (node-variant, constraint-variant) cross-product |

## Per memo D9 file fences

PR-A1b U18 touchpoints (verified — no overlap with PR-A2 / PR-C-3):

- `crates/flui-rendering/src/storage/erased.rs` (NEW)
- `crates/flui-rendering/src/storage/mod.rs` (declare `mod erased;` + re-export 4 public types)
- `crates/flui-rendering/src/storage/node.rs` (`RenderNode::layout_erased` method)
- `crates/flui-rendering/src/error.rs` (`ProtocolMismatch` + `LayoutCycle` variants)

## Test plan

CI runs the standard workspace gate. Local pre-push gates exit 0:

- `cargo build --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p flui-rendering --lib` — 265 tests pass (261 prior + 4 new `storage::erased::tests::*` covering box-roundtrip / box-to-sliver-mismatch / size-roundtrip / size-to-sliver-mismatch)
- `cargo fmt --check`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `bash scripts/port-check.sh` — "all seven refusal triggers + FR-033 grep + trigger 9 (FR-036) clean"

## What's NOT in this PR (deferred to follow-up PRs)

Per plan U19-U31 — substantial walk-rewrite scope deferred:
- U19: `RenderObject::perform_layout_raw` signature change + `RenderBox` bridge (memo D5)
- U20: disjoint-borrow walk in `layout_dirty_root` (memo D1)
- U21: cycle detection via `currently_laying_out` (memo D6; error variant pre-added in this PR)
- U22: dirty-queue dedup symmetric across 4 queues (memo D7; needs_layout dedup added in PR-A1a review)
- U23: rewrite `layout_node_with_children` → `layout_dirty_root` in `run_layout`
- U24: cache-hit short-circuit in `RenderEntry::layout` (memo D2)
- U25: test fixture infrastructure (`tests/common/mod.rs` + `tests/pipeline/`)
- U26-U30: AE1-AE9 integration tests (`Padding → Center → ColoredBox` etc.)
- U31: PR-A1 receipts

## Next steps after merge

1. PR-A1b2: U19 (perform_layout_raw bridge) with carefully-designed `LayoutCtxErased` shape — likely requires per-protocol associated type on `Protocol` trait or GAT-based wrapper
2. PR-A1b3: U20-U24 (walk rewrite + cycle/dedup/cache-hit)
3. PR-A1b4: U25-U30 (test infrastructure + AE1-AE9 integration tests)
4. PR-A2: D-3+D-4 compositing+paint pipeline (U32-U40)
5. PR-C-3: refusal triggers install LAST per close-first

**Cumulative D-block progress: 4/5 PRs (3 merged + 1 no-op). This PR + PR-A1b2/3/4 sub-PRs + PR-A2 + PR-C-3 remain.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
