### PR TITLE
refactor(rendering): RenderObject::perform_layout_raw -> Result<T, RenderError> (PR #141 #5 Option A follow-up)

### DIFF
--- a/crates/flui-rendering/src/error.rs
+++ b/crates/flui-rendering/src/error.rs
@@ -235,30 +235,35 @@ pub enum RenderError {
     ///
     /// Distinct from [`Poisoned`](Self::Poisoned): `Poisoned` covers
     /// unstructured panics surfaced through `catch_unwind` (genuine
-    /// runtime bugs, double-frees, etc.); `ContractViolation` covers
-    /// **specific, named** invariants the bridge / pipeline can detect
-    /// and report by name.
+    /// runtime bugs, double-frees, third-party `panic!` / `unwrap` in
+    /// user widget code); `ContractViolation` covers **specific, named**
+    /// invariants the bridge / pipeline can detect and report by name.
     ///
-    /// **D-block PR-A1b U19 review fix #5 (Option B):** introduced so
-    /// the `RenderObject<BoxProtocol>` blanket impl on
+    /// # History
+    ///
+    /// **D-block PR-A1b U19 review fix #5 (Option B, PR #141):**
+    /// introduced so the `RenderObject<BoxProtocol>` blanket impl on
     /// [`crate::traits::RenderBox`] can signal "user's
     /// [`RenderBox::perform_layout`](crate::traits::RenderBox::perform_layout)
     /// returned without calling `ctx.complete_with_size`" as a typed
-    /// error rather than an opaque panic. The bridge raises it via
-    /// `std::panic::panic_any(RenderError::ContractViolation { ... })`;
+    /// error rather than an opaque panic. The original landing used
+    /// `std::panic::panic_any(RenderError::ContractViolation { ... })`
+    /// caught by `catch_unwind` in
     /// [`RenderEntry::layout_leaf_only`](crate::storage::RenderEntry::layout_leaf_only)
-    /// downcasts the panic payload to recover the typed value and
-    /// returns it through `RenderResult` alongside other render errors.
+    /// and downcast back to the typed value — `panic_any` was the
+    /// minimum-disruption shape that preserved the existing
+    /// `perform_layout_raw` infallible signature.
     ///
-    /// `panic_any` (not plain `panic!`) is used so the payload survives
-    /// `catch_unwind` cleanly — `catch_unwind`'s `Box<dyn Any + Send>`
-    /// boxes it; the entry-layout handler downcasts to
-    /// `Box<RenderError>` and unwraps. Constitution Principle 6 reading:
-    /// the panic_any primitive is the structured-payload escape hatch
-    /// the standard library provides for exactly this catch-and-recover
-    /// shape; the alternative (full `Result<T, RenderError>` return on
-    /// `perform_layout_raw`) ripples through ~50 LOC across the trait
-    /// surface and is deferred to a dedicated typed-errors PR.
+    /// **Follow-up PR (this commit, Option A):** the
+    /// `perform_layout_raw` signature now returns
+    /// `RenderResult<ProtocolGeometry<P>>` so contract violations
+    /// propagate as typed `Err(...)` through `?` directly — no panic
+    /// primitive in the normal error path. The variant + constructor
+    /// stay; the only change is how the value reaches
+    /// `RenderEntry::layout_leaf_only` (via `Result` chain, not via
+    /// `panic_any` + downcast). `catch_unwind` in the entry is retained
+    /// only for genuine third-party panics from user widget code, which
+    /// continue to surface as `Poisoned`.
     #[error("contract violation in {render_object}: {what}")]
     ContractViolation {
         /// Static debug name of the render object that violated the contract.
@@ -341,15 +346,14 @@ impl RenderError {
 
     /// Creates a ContractViolation error.
     ///
-    /// **D-block PR-A1b U19 review fix #5:** raised by the
+    /// **D-block PR-A1b U19 review fix #5 (Option A follow-up):**
+    /// returned as `Err(...)` by the
     /// [`RenderObject<BoxProtocol>`](crate::traits::RenderObject)
     /// blanket impl when the user's
     /// [`RenderBox::perform_layout`](crate::traits::RenderBox::perform_layout)
-    /// returns without calling `ctx.complete_with_size`. The bridge
-    /// passes this through
-    /// `std::panic::panic_any(RenderError::ContractViolation { ... })`;
-    /// [`RenderEntry::layout_leaf_only`](crate::storage::RenderEntry::layout_leaf_only)
-    /// downcasts the catch_unwind payload to recover the typed value.
+    /// returns without calling `ctx.complete_with_size`. Propagates
+    /// through the `RenderResult<ProtocolGeometry<P>>` channel of
+    /// [`RenderEntry::layout_leaf_only`](crate::storage::RenderEntry::layout_leaf_only).
     pub fn contract_violation(render_object: &'static str, what: &'static str) -> Self {
         Self::ContractViolation {
             render_object,

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -1713,8 +1713,10 @@ mod tests {
             _ctx: &mut <crate::protocol::BoxProtocol as crate::protocol::Protocol>::LayoutCtxErased<
                 '_,
             >,
-        ) -> crate::protocol::ProtocolGeometry<crate::protocol::BoxProtocol> {
-            self.size
+        ) -> crate::error::RenderResult<
+            crate::protocol::ProtocolGeometry<crate::protocol::BoxProtocol>,
+        > {
+            Ok(self.size)
         }
 
         fn paint(&self, _context: &mut crate::context::CanvasContext, _offset: flui_types::Offset) {
@@ -1772,7 +1774,15 @@ mod tests {
             _ctx: &mut <crate::protocol::BoxProtocol as crate::protocol::Protocol>::LayoutCtxErased<
                 '_,
             >,
-        ) -> crate::protocol::ProtocolGeometry<crate::protocol::BoxProtocol> {
+        ) -> crate::error::RenderResult<
+            crate::protocol::ProtocolGeometry<crate::protocol::BoxProtocol>,
+        > {
+            // Intentional unstructured panic — exercises the catch_unwind →
+            // Poisoned path in `RenderEntry::layout_leaf_only`. After the
+            // Option A signature change, this panic is the ONE remaining
+            // way to produce `RenderError::Poisoned` (typed
+            // ContractViolation returns are reserved for bridge-detected
+            // contract violations that go through the `Result` chain).
             panic!("PanickingLayoutBox::perform_layout_raw -- intentional test panic");
         }
 

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -1778,11 +1778,14 @@ mod tests {
             crate::protocol::ProtocolGeometry<crate::protocol::BoxProtocol>,
         > {
             // Intentional unstructured panic — exercises the catch_unwind →
-            // Poisoned path in `RenderEntry::layout_leaf_only`. After the
-            // Option A signature change, this panic is the ONE remaining
-            // way to produce `RenderError::Poisoned` (typed
-            // ContractViolation returns are reserved for bridge-detected
-            // contract violations that go through the `Result` chain).
+            // Poisoned path in `RenderEntry::layout_leaf_only`. This test
+            // fixture is one explicit way to produce
+            // `RenderError::Poisoned`; in production any third-party
+            // panic in user widget code (`panic!`, `unwrap()`, assertion
+            // failure inside `RenderBox::perform_layout`) reaches the
+            // same path. Bridge-detected contract violations go through
+            // the typed `Result` chain instead and surface as
+            // `RenderError::ContractViolation`.
             panic!("PanickingLayoutBox::perform_layout_raw -- intentional test panic");
         }
 

--- a/crates/flui-rendering/src/storage/entry.rs
+++ b/crates/flui-rendering/src/storage/entry.rs
@@ -344,10 +344,12 @@ impl<P: Protocol> RenderEntry<P> {
         //   message for diagnostics.
         //
         // Flatten shape: `catch_unwind` returns
-        // `Result<Result<G, RenderError>, Box<dyn Any + Send>>`. We
-        // map the outer Err (panic payload) to Poisoned and the inner
-        // Ok carries through; `.and_then(|inner| inner)` collapses to
-        // `Result<G, RenderError>` for the closure return.
+        // `Result<Result<G, RenderError>, Box<dyn Any + Send>>`. The
+        // `match` below explicitly forwards `Ok(inner)` verbatim (the
+        // inner `Result<G, RenderError>` from `perform_layout_raw`
+        // becomes the closure's return) and maps `Err(panic_payload)`
+        // into `Err(RenderError::Poisoned)` after logging the payload
+        // message. Net: closure returns `Result<G, RenderError>`.
         let geometry = <P as crate::protocol::Protocol>::with_leaf_erased_ctx(
             constraints_for_ctx,
             |erased_ctx| {

--- a/crates/flui-rendering/src/storage/entry.rs
+++ b/crates/flui-rendering/src/storage/entry.rs
@@ -323,49 +323,62 @@ impl<P: Protocol> RenderEntry<P> {
         // `SliverLayoutCtx::new` on its own stack frame and lends an
         // erased `&mut dyn` view; the borrow expires when the FnOnce
         // closure returns, keeping the storage local to this call.
+        //
+        // # Error-handling shape (follow-up to PR #141 #5 Option A)
+        //
+        // `perform_layout_raw` now returns
+        // `RenderResult<ProtocolGeometry<P>>` — contract violations
+        // (e.g., bridge-detected missing `complete_with_size`) flow
+        // through the `Err(...)` channel of the inner Result; the
+        // `catch_unwind` boundary remains, but ONLY for genuine
+        // third-party panics (user widget calling `panic!` /
+        // `unwrap()` etc.), which still surface as
+        // `RenderError::Poisoned`.
+        //
+        // The two error classes are now distinct at the variant level:
+        // - `ContractViolation` — bridge or pipeline detected an
+        //   invariant violation it can name. Propagated as
+        //   `Result<_, _>` through `?`.
+        // - `Poisoned` — opaque panic payload caught by `catch_unwind`.
+        //   Cannot be named specifically; tracing logs the payload
+        //   message for diagnostics.
+        //
+        // Flatten shape: `catch_unwind` returns
+        // `Result<Result<G, RenderError>, Box<dyn Any + Send>>`. We
+        // map the outer Err (panic payload) to Poisoned and the inner
+        // Ok carries through; `.and_then(|inner| inner)` collapses to
+        // `Result<G, RenderError>` for the closure return.
         let geometry = <P as crate::protocol::Protocol>::with_leaf_erased_ctx(
             constraints_for_ctx,
             |erased_ctx| {
                 let unwind_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     render_object.perform_layout_raw(erased_ctx)
                 }));
-                unwind_result.map_err(|payload| {
-                    // **D-block PR-A1b U19 review fix #5 (Option B).**
-                    // Try structured `RenderError` payload first — the
-                    // `RenderObject<BoxProtocol>` blanket impl raises
-                    // `RenderError::ContractViolation` via
-                    // `std::panic::panic_any(...)` when the user's
-                    // `RenderBox::perform_layout` forgets to call
-                    // `ctx.complete_with_size(...)`. Recovering the
-                    // typed payload here means contract violations
-                    // surface as their own `RenderError` variant rather
-                    // than collapsing to `Poisoned` (which is reserved
-                    // for unstructured runtime panics).
-                    match payload.downcast::<crate::error::RenderError>() {
-                        Ok(typed) => *typed,
-                        Err(payload) => {
-                            // Review fix #6: forward the unstructured
-                            // panic message to tracing before discarding
-                            // the payload. Without this, panics that
-                            // pre-date the structured-payload path (or
-                            // arrive from third-party `panic!` calls in
-                            // user widgets) become opaque
-                            // `RenderError::Poisoned` errors with no
-                            // diagnostic detail.
-                            let msg = payload
-                                .downcast_ref::<String>()
-                                .map(String::as_str)
-                                .or_else(|| payload.downcast_ref::<&'static str>().copied())
-                                .unwrap_or("(non-string panic payload)");
-                            tracing::error!(
-                                render_object = debug_name,
-                                panic_msg = msg,
-                                "perform_layout panicked — surfacing as RenderError::Poisoned",
-                            );
-                            crate::error::RenderError::poisoned(debug_name, "layout")
-                        }
+                match unwind_result {
+                    // Inner Result propagates verbatim — Ok(geometry)
+                    // or Err(RenderError::ContractViolation { ... } /
+                    // any other typed error the bridge returns).
+                    Ok(inner) => inner,
+                    // Catch_unwind caught a panic — log the payload
+                    // message to tracing for diagnostics, then surface
+                    // as Poisoned. Distinct from ContractViolation:
+                    // panics are unstructured (third-party `panic!` /
+                    // `unwrap()` in user widget code), Poisoned is the
+                    // catch-all bucket for "we don't know more".
+                    Err(payload) => {
+                        let msg = payload
+                            .downcast_ref::<String>()
+                            .map(String::as_str)
+                            .or_else(|| payload.downcast_ref::<&'static str>().copied())
+                            .unwrap_or("(non-string panic payload)");
+                        tracing::error!(
+                            render_object = debug_name,
+                            panic_msg = msg,
+                            "perform_layout panicked — surfacing as RenderError::Poisoned",
+                        );
+                        Err(crate::error::RenderError::poisoned(debug_name, "layout"))
                     }
-                })
+                }
             },
         )?;
 

--- a/crates/flui-rendering/src/traits/render_box.rs
+++ b/crates/flui-rendering/src/traits/render_box.rs
@@ -383,46 +383,49 @@ where
     fn perform_layout_raw(
         &mut self,
         ctx: &mut <BoxProtocol as crate::protocol::Protocol>::LayoutCtxErased<'_>,
-    ) -> crate::protocol::ProtocolGeometry<BoxProtocol> {
+    ) -> crate::error::RenderResult<crate::protocol::ProtocolGeometry<BoxProtocol>> {
         // D-block PR-A1b U19 / memo D5 — the real bridge.
         //
-        // The pipeline / `RenderEntry::layout` hands us a `&mut dyn
-        // BoxLayoutCtxErased` (the GAT for `BoxProtocol` resolves to
-        // exactly this). We reconstruct a typed
+        // The pipeline / `RenderEntry::layout_leaf_only` hands us a
+        // `&mut dyn BoxLayoutCtxErased` (the GAT for `BoxProtocol`
+        // resolves to exactly this). We reconstruct a typed
         // `BoxLayoutCtx<T::Arity, T::ParentData>` via the `from_erased`
-        // ctor (Proxy storage that delegates child / completion ops back
-        // through the erased trait), wrap it in the ergonomic
-        // `BoxLayoutContext` so user widgets get
-        // `complete_with_size` etc., and call `T::perform_layout`.
+        // ctor (Proxy storage that delegates child / completion ops
+        // back through the erased trait), wrap it in the ergonomic
+        // `BoxLayoutContext` so user widgets get `complete_with_size`
+        // etc., and call `T::perform_layout`.
         //
         // The user's `perform_layout` body must call
         // `ctx.complete_with_size(...)` (or equivalent) to record the
         // computed size; we read it back from the inner BoxLayoutCtx
         // and return to the caller.
         //
-        // **Contract violation handling (review fix #5, Option B).**
+        // # Contract-violation handling (follow-up to PR #141 #5 Option A)
+        //
         // If `perform_layout` returns without calling
-        // `ctx.complete_with_size(...)`, we raise
-        // [`RenderError::ContractViolation`] via
-        // `std::panic::panic_any(...)` — the structured-payload form of
-        // `panic!` that survives `catch_unwind` cleanly. The
-        // catch_unwind handler in
-        // [`RenderEntry::layout`](crate::storage::RenderEntry::layout)
-        // downcasts the panic payload to recover the typed
-        // [`RenderError`] and returns it through `RenderResult`,
-        // distinct from `RenderError::Poisoned` (which covers
-        // unstructured runtime panics).
+        // `ctx.complete_with_size(...)`, we return
+        // [`RenderError::ContractViolation`] as `Err(...)` directly —
+        // no `panic_any`, no `catch_unwind` dance. The PR #141 review
+        // (finding #5) called out the previous panic_any path as a
+        // Constitution Principle 6 violation; this PR closes that
+        // technical debt by making the signature
+        // `RenderResult<ProtocolGeometry<P>>` so contract violations
+        // propagate as typed errors through `?`.
+        //
+        // `catch_unwind` in `RenderEntry::layout_leaf_only` is retained
+        // only for genuine third-party panics (panic! / unwrap in user
+        // widget code) which still surface as `RenderError::Poisoned`.
         let typed_inner =
             crate::protocol::BoxLayoutCtx::<T::Arity, T::ParentData>::from_erased(ctx);
         let mut layout_ctx =
             crate::context::BoxLayoutContext::<T::Arity, T::ParentData>::new(typed_inner);
         T::perform_layout(self, &mut layout_ctx);
-        layout_ctx.inner().geometry().copied().unwrap_or_else(|| {
-            std::panic::panic_any(crate::error::RenderError::contract_violation(
+        layout_ctx.inner().geometry().copied().ok_or_else(|| {
+            crate::error::RenderError::contract_violation(
                 self.debug_name(),
                 "RenderBox::perform_layout returned without calling \
                      ctx.complete_with_size(...)",
-            ))
+            )
         })
     }
 

--- a/crates/flui-rendering/src/traits/render_object.rs
+++ b/crates/flui-rendering/src/traits/render_object.rs
@@ -155,9 +155,10 @@ pub trait RenderObject<P: Protocol>:
 
     /// Performs layout with a protocol-erased layout context.
     ///
-    /// Called by `RenderEntry::layout()` (leaf path) and the pipeline's
-    /// `layout_dirty_root` (U20, parent+children disjoint-borrow path).
-    /// Returns the computed geometry.
+    /// Called by `RenderEntry::layout_leaf_only()` (leaf path) and the
+    /// pipeline's `layout_dirty_root` (U20, parent+children
+    /// disjoint-borrow path). Returns either the computed geometry on
+    /// success, or a typed [`RenderError`] on contract violation.
     ///
     /// **Users don't implement this directly.** Protocol traits like
     /// `RenderBox` provide blanket implementations that reconstruct a
@@ -165,24 +166,46 @@ pub trait RenderObject<P: Protocol>:
     /// erased context (via the in-crate `BoxLayoutCtx::from_erased`
     /// ctor) and call the typed [`RenderBox::perform_layout`] method.
     ///
-    /// **D-block PR-A1b U19 (companion memo D5):** the signature changed
-    /// from `fn perform_layout_raw(&mut self, constraints:
-    /// ProtocolConstraints<P>) -> ProtocolGeometry<P>` to the current
-    /// shape so the blanket impl can construct a typed
-    /// [`BoxLayoutCtx`] with children access — the prior signature
-    /// shipped a no-op returning `*self.size()` because the trait
-    /// surface didn't carry children. The
-    /// [`Protocol::LayoutCtxErased`] GAT resolves to the per-protocol
-    /// trait-object form: `dyn BoxLayoutCtxErased` for `BoxProtocol`,
-    /// `dyn SliverLayoutCtxErased` for `SliverProtocol`.
+    /// # Signature evolution
+    ///
+    /// 1. **Pre-U19** — `fn perform_layout_raw(&mut self, constraints:
+    ///    ProtocolConstraints<P>) -> ProtocolGeometry<P>`. Blanket impl
+    ///    shipped as a no-op returning `*self.size()` because the trait
+    ///    surface didn't carry children (companion memo D5).
+    ///
+    /// 2. **D-block PR-A1b U19 (PR #141)** — signature changed to
+    ///    `fn perform_layout_raw(&mut self, ctx: &mut <P as Protocol>::LayoutCtxErased<'_>) -> ProtocolGeometry<P>`
+    ///    so the blanket impl can construct a typed [`BoxLayoutCtx`]
+    ///    with children access. Contract-violation signalling went
+    ///    through `std::panic::panic_any(RenderError::ContractViolation)`
+    ///    caught by `catch_unwind` in `RenderEntry::layout_leaf_only` —
+    ///    `panic_any` was a niche escape hatch with hidden control flow.
+    ///
+    ///    The PR #141 review (finding #5) called this out as a
+    ///    Constitution Principle 6 violation — using panic primitives
+    ///    for an error condition the caller can structurally handle.
+    ///
+    /// 3. **Current shape (this PR, follow-up to #141 #5 Option A)** —
+    ///    signature returns `RenderResult<ProtocolGeometry<P>>` so
+    ///    contract violations propagate as typed `Err(RenderError::...)`
+    ///    directly through `?`. `panic_any` removed; `catch_unwind` in
+    ///    `RenderEntry::layout_leaf_only` retained only to wrap genuine
+    ///    runtime panics from third-party user widget code into
+    ///    [`RenderError::Poisoned`].
+    ///
+    /// The [`Protocol::LayoutCtxErased`] GAT resolves to the
+    /// per-protocol trait-object form: `dyn BoxLayoutCtxErased` for
+    /// `BoxProtocol`, `dyn SliverLayoutCtxErased` for `SliverProtocol`.
     ///
     /// [`BoxLayoutCtx`]: crate::protocol::BoxLayoutCtx
     /// [`RenderBox::perform_layout`]: crate::traits::RenderBox::perform_layout
     /// [`Protocol::LayoutCtxErased`]: crate::protocol::Protocol::LayoutCtxErased
+    /// [`RenderError`]: crate::error::RenderError
+    /// [`RenderError::Poisoned`]: crate::error::RenderError::Poisoned
     fn perform_layout_raw(
         &mut self,
         ctx: &mut <P as Protocol>::LayoutCtxErased<'_>,
-    ) -> ProtocolGeometry<P>;
+    ) -> crate::error::RenderResult<ProtocolGeometry<P>>;
 
     /// Paints this render object.
     ///

--- a/crates/flui-rendering/src/traits/render_sliver.rs
+++ b/crates/flui-rendering/src/traits/render_sliver.rs
@@ -346,36 +346,36 @@ where
     fn perform_layout_raw(
         &mut self,
         _ctx: &mut <SliverProtocol as crate::protocol::Protocol>::LayoutCtxErased<'_>,
-    ) -> crate::protocol::ProtocolGeometry<SliverProtocol> {
+    ) -> crate::error::RenderResult<crate::protocol::ProtocolGeometry<SliverProtocol>> {
         // D-block PR-A1b U19 / memo D5 — Sliver bridge is unimplemented.
         //
         // The Box bridge in `render_box.rs` reconstructs a typed
         // `BoxLayoutCtx` from the erased trait object and calls the
         // user's `RenderBox::perform_layout`. The analogous Sliver
         // bridge (reconstruct `SliverLayoutCtx` → call
-        // `RenderSliver::perform_layout`) is deferred to Core.2 alongside
-        // the rest of the sliver layout work — no sliver render objects
-        // are in the D-block test surface (companion memo §D5
-        // "Out of scope. Sliver bridge — analogous shape, lands as part
-        // of Core.2 sliver work").
+        // `RenderSliver::perform_layout`) is deferred to Core.2
+        // alongside the rest of the sliver layout work — no sliver
+        // render objects are in the D-block test surface (companion
+        // memo §D5 "Out of scope. Sliver bridge — analogous shape,
+        // lands as part of Core.2 sliver work").
         //
         // **Loud-fail rather than silent-return** (review fix #1): the
         // pre-fix body returned `*RenderSliver::geometry(self)` — a
         // silent no-op that papered over any accidental reach into the
-        // unbridged path. Production callers in D-block cannot reach
-        // this stub (no concrete `RenderSliver` impls exist in the
-        // workspace; the only sliver flow is the generic blanket impl
-        // here). The unimplemented! is caught by
-        // `RenderEntry::layout`'s `catch_unwind` and surfaces as
-        // `RenderError::Poisoned` with the offending render-object's
-        // debug name — making any accidental reach immediately visible
-        // rather than producing wrong-but-quiet layout results.
-        unimplemented!(
-            "Sliver bridge — RenderObject<SliverProtocol>::perform_layout_raw is \
-             Core.2 work and not reachable from D-block scope (memo D5). \
-             Offending RenderSliver: {}",
-            core::any::type_name::<T>()
-        )
+        // unbridged path.
+        //
+        // **Typed error rather than panic** (this PR, follow-up to
+        // #141 #5 Option A): pre-fix code called `unimplemented!`
+        // (which panics) and relied on `RenderEntry::layout_leaf_only`'s
+        // catch_unwind to convert to `RenderError::Poisoned`. With the
+        // new `Result<T, RenderError>` signature, we return
+        // `Err(RenderError::ContractViolation)` directly — typed
+        // propagation, no panic primitive in the normal error path.
+        Err(crate::error::RenderError::contract_violation(
+            core::any::type_name::<T>(),
+            "RenderObject<SliverProtocol>::perform_layout_raw is Core.2 \
+             work and not reachable from D-block scope (memo D5)",
+        ))
     }
 
     fn paint(&self, _context: &mut CanvasContext, _offset: Offset) {

--- a/crates/flui-rendering/src/view/render_view.rs
+++ b/crates/flui-rendering/src/view/render_view.rs
@@ -497,14 +497,19 @@ impl crate::protocol::RenderObject<crate::protocol::BoxProtocol> for RenderViewA
     fn perform_layout_raw(
         &mut self,
         _ctx: &mut <crate::protocol::BoxProtocol as crate::protocol::Protocol>::LayoutCtxErased<'_>,
-    ) -> crate::protocol::ProtocolGeometry<crate::protocol::BoxProtocol> {
+    ) -> crate::error::RenderResult<crate::protocol::ProtocolGeometry<crate::protocol::BoxProtocol>>
+    {
         // D-block PR-A1b U19 — RenderView is the root and manages its own
         // layout via the `perform_layout()` method on the embedded
         // `RenderView`. The erased ctx is unused — root layout is driven
         // by `configuration().preferred_size` rather than parent-supplied
         // constraints (Flutter parity, `.flutter/.../view.dart`).
+        //
+        // Follow-up to PR #141 #5 Option A: signature returns
+        // `RenderResult<Size>`. Root always succeeds (no contract
+        // surface to violate) so this is always `Ok(...)`.
         self.view.perform_layout();
-        self.view.size()
+        Ok(self.view.size())
     }
 
     fn paint(&self, context: &mut CanvasContext, offset: Offset) {

--- a/crates/flui-rendering/src/view/render_view.rs
+++ b/crates/flui-rendering/src/view/render_view.rs
@@ -506,8 +506,15 @@ impl crate::protocol::RenderObject<crate::protocol::BoxProtocol> for RenderViewA
         // constraints (Flutter parity, `.flutter/.../view.dart`).
         //
         // Follow-up to PR #141 #5 Option A: signature returns
-        // `RenderResult<Size>`. Root always succeeds (no contract
-        // surface to violate) so this is always `Ok(...)`.
+        // `RenderResult<Size>`. The adapter itself has no contract
+        // surface to violate — there is no `complete_with_size`
+        // analogue to forget — so it never returns a typed `Err`.
+        // `RenderView::perform_layout` can still trip its internal
+        // `assert!` invariants (e.g. missing `prepare_initial_frame`)
+        // which propagate as panics; those are caught upstream by
+        // `RenderEntry::layout_leaf_only`'s `catch_unwind` and surface
+        // as `RenderError::Poisoned` — same as any third-party panic
+        // from user widget code.
         self.view.perform_layout();
         Ok(self.view.size())
     }

--- a/crates/flui-rendering/tests/u19_bridge.rs
+++ b/crates/flui-rendering/tests/u19_bridge.rs
@@ -56,13 +56,17 @@ fn u19_leaf_bridge_returns_constrained_size() {
     let mut direct_ctx: BoxLayoutCtx<'_, Leaf, BoxParentData> = BoxLayoutCtx::new(constraints);
     let erased: &mut dyn BoxLayoutCtxErased = &mut direct_ctx;
 
+    // perform_layout_raw returns `RenderResult<Size>` (Option A
+    // follow-up to PR #141 #5); on the happy path we unwrap to assert
+    // the concrete Size.
     let size = <RenderColoredBox as RenderObject<BoxProtocol>>::perform_layout_raw(
         &mut obj,
         // GAT resolves `<BoxProtocol as Protocol>::LayoutCtxErased<'_>` to
         // `dyn BoxLayoutCtxErased + '_`; the coercion above gives us
         // exactly that.
         erased,
-    );
+    )
+    .expect("Leaf bridge happy path must succeed");
 
     assert_eq!(
         size,
@@ -84,7 +88,8 @@ fn u19_leaf_bridge_honours_loose_constraints() {
     let erased: &mut dyn BoxLayoutCtxErased = &mut direct_ctx;
 
     let size =
-        <RenderColoredBox as RenderObject<BoxProtocol>>::perform_layout_raw(&mut obj, erased);
+        <RenderColoredBox as RenderObject<BoxProtocol>>::perform_layout_raw(&mut obj, erased)
+            .expect("Leaf bridge happy path must succeed");
 
     assert_eq!(size, Size::new(px(80.0), px(40.0)));
 }
@@ -134,7 +139,8 @@ fn u19_single_bridge_pads_child_and_returns_total_size() {
 
     let erased: &mut dyn BoxLayoutCtxErased = &mut direct_ctx;
 
-    let size = <RenderPadding as RenderObject<BoxProtocol>>::perform_layout_raw(&mut obj, erased);
+    let size = <RenderPadding as RenderObject<BoxProtocol>>::perform_layout_raw(&mut obj, erased)
+        .expect("Single bridge happy path must succeed");
 
     assert_eq!(
         size,
@@ -229,7 +235,8 @@ fn u19_variable_bridge_walks_child_slice_with_typed_parent_data() {
 
     let erased: &mut dyn BoxLayoutCtxErased = &mut direct_ctx;
 
-    let size = <RenderFlex as RenderObject<BoxProtocol>>::perform_layout_raw(&mut obj, erased);
+    let size = <RenderFlex as RenderObject<BoxProtocol>>::perform_layout_raw(&mut obj, erased)
+        .expect("Variable bridge happy path must succeed");
 
     // Deterministic flex math (see test doc): both children flex with
     // factors 1:2, parent max_width=300, no inflexible/spacing.
@@ -285,39 +292,43 @@ fn u19_with_leaf_erased_ctx_matches_direct_bridge_call() {
     let mut obj = RenderColoredBox::green(60.0, 30.0);
     let constraints = BoxConstraints::tight(Size::new(px(60.0), px(30.0)));
 
-    // Mirror what RenderEntry::layout does.
+    // Mirror what RenderEntry::layout_leaf_only does.
+    // `with_leaf_erased_ctx` forwards the closure return, which is now
+    // `RenderResult<Size>`; unwrap on the happy path.
     let size = <BoxProtocol as Protocol>::with_leaf_erased_ctx(constraints, |erased| {
         <RenderColoredBox as RenderObject<BoxProtocol>>::perform_layout_raw(&mut obj, erased)
-    });
+    })
+    .expect("with_leaf_erased_ctx happy path must succeed");
 
     assert_eq!(size, Size::new(px(60.0), px(30.0)));
 }
 
 // ============================================================================
-// Bridge contract violation (review fix #4): a RenderBox::perform_layout
-// that forgets to call ctx.complete_with_size() must trip the bridge's
-// expect/panic, naming the offending render object.
+// Bridge contract violation (review fix #4 + follow-up #5 Option A): a
+// RenderBox::perform_layout that forgets to call ctx.complete_with_size()
+// must return Err(RenderError::ContractViolation) directly from the
+// bridge — no panic, no catch_unwind dance.
 // ============================================================================
 
 /// Plan U19 §407 contract: if `RenderBox::perform_layout` returns without
-/// calling `ctx.complete_with_size()`, the blanket bridge raises
-/// `RenderError::ContractViolation` via `std::panic::panic_any(...)`.
-/// `RenderEntry::layout`'s `catch_unwind` handler downcasts the panic
-/// payload to recover the typed value and returns it through
-/// `RenderResult` — distinct from `RenderError::Poisoned`, which is
-/// reserved for unstructured runtime panics.
+/// calling `ctx.complete_with_size()`, the blanket bridge returns
+/// `Err(RenderError::ContractViolation { ... })` directly through the
+/// `RenderResult<ProtocolGeometry<P>>` return channel — no
+/// `panic_any` / `catch_unwind` dance.
 ///
-/// This test:
-/// 1. Drives a deliberately-broken `ForgetfulBox` directly through the
-///    blanket `perform_layout_raw` and asserts the panic payload is a
-///    typed `RenderError::ContractViolation` carrying the render
-///    object's debug name and the contract description.
-/// 2. (See [`u19_contract_violation_surfaces_through_render_entry_layout`])
-///    Wraps the same fixture in a `RenderEntry<BoxProtocol>` and
-///    asserts the typed error round-trips out as `Err(RenderError::ContractViolation)`
-///    — verifying the entry-layout payload-downcast handler.
+/// This is the follow-up to PR #141 #5 (Option A): pre-fix the bridge
+/// used `std::panic::panic_any(RenderError::ContractViolation)` caught
+/// by `catch_unwind` in `RenderEntry::layout_leaf_only` and downcast
+/// back to typed RenderError. Now the same value flows through `Result`
+/// directly, removing the panic primitive from the normal error path.
+///
+/// This test drives `ForgetfulBox` directly through the blanket
+/// `perform_layout_raw` and asserts the returned `Err` carries
+/// `ContractViolation` with the render object's debug name + contract
+/// description. The entry-layout round-trip is covered by
+/// [`u19_contract_violation_surfaces_through_render_entry_layout`].
 #[test]
-fn u19_bridge_panics_on_missing_complete_with_size() {
+fn u19_bridge_returns_contract_violation_on_missing_complete_with_size() {
     use flui_foundation::Diagnosticable;
     use flui_rendering::{
         context::{BoxHitTestContext, BoxLayoutContext},
@@ -367,27 +378,13 @@ fn u19_bridge_panics_on_missing_complete_with_size() {
     let mut direct_ctx: BoxLayoutCtx<'_, Leaf, BoxParentData> = BoxLayoutCtx::new(constraints);
     let erased: &mut dyn BoxLayoutCtxErased = &mut direct_ctx;
 
-    // Panic propagates from the blanket impl's `panic_any`; assert via
-    // catch_unwind. AssertUnwindSafe is fine — we own all the borrowed
-    // state on this test stack frame.
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        <ForgetfulBox as RenderObject<BoxProtocol>>::perform_layout_raw(&mut obj, erased)
-    }));
+    // No catch_unwind needed — bridge returns Err directly.
+    let result = <ForgetfulBox as RenderObject<BoxProtocol>>::perform_layout_raw(&mut obj, erased);
 
-    let panic_payload =
-        result.expect_err("perform_layout that forgets complete_with_size must panic");
+    let err =
+        result.expect_err("perform_layout that forgets complete_with_size must return Err, not Ok");
 
-    // **Review fix #5 (Option B).** Payload is a typed `RenderError`
-    // (via `std::panic::panic_any(RenderError::ContractViolation { ... })`
-    // in the blanket impl), not an opaque string. Downcast to the typed
-    // value and assert variant + fields.
-    let typed_err = panic_payload
-        .downcast::<RenderError>()
-        .map(|boxed| *boxed)
-        .unwrap_or_else(|_| {
-            panic!("panic payload should be RenderError, got non-RenderError payload")
-        });
-    match typed_err {
+    match err {
         RenderError::ContractViolation {
             render_object,
             what,
@@ -522,7 +519,8 @@ fn u19_variable_bridge_handles_zero_children() {
         BoxLayoutCtx::with_layout_callback(constraints, &mut children, &child_ids, cb.as_ref());
 
     let erased: &mut dyn BoxLayoutCtxErased = &mut direct_ctx;
-    let size = <RenderFlex as RenderObject<BoxProtocol>>::perform_layout_raw(&mut obj, erased);
+    let size = <RenderFlex as RenderObject<BoxProtocol>>::perform_layout_raw(&mut obj, erased)
+        .expect("Zero-child Variable bridge happy path must succeed");
 
     assert_eq!(
         size,
@@ -567,7 +565,8 @@ fn u19_render_view_adapter_bridge_smoke() {
     let sentinel_constraints = BoxConstraints::tight(Size::new(px(999.0), px(999.0)));
     let size = <BoxProtocol as Protocol>::with_leaf_erased_ctx(sentinel_constraints, |erased| {
         <RenderViewAdapter as RenderObject<BoxProtocol>>::perform_layout_raw(&mut adapter, erased)
-    });
+    })
+    .expect("RenderViewAdapter root layout must always succeed");
 
     // Logical constraints from from_size(200×150, 1.0) are tight at
     // (200, 150). RenderView::perform_layout writes size =


### PR DESCRIPTION
## Summary

Closes the technical debt left by PR #141's Option B for finding #5 — swaps `RenderObject<P>::perform_layout_raw` from `ProtocolGeometry<P>` (infallible) to `RenderResult<ProtocolGeometry<P>>` (typed Result). Contract violations propagate as typed `Err(RenderError::ContractViolation { ... })` directly through `?`; no `panic_any` primitive in the normal error path.

## Background

PR #141 (D-block PR-A1b2, U19) introduced `RenderError::ContractViolation` to distinguish bridge-detected contract violations (user `RenderBox::perform_layout` returns without calling `ctx.complete_with_size`) from unstructured runtime panics (`RenderError::Poisoned`). The original landing used `std::panic::panic_any(RenderError::ContractViolation { ... })` caught by `catch_unwind` in `RenderEntry::layout_leaf_only` and downcast back to the typed `RenderError`.

Honest second-look concluded Option B was "good-enough not best":

- **`panic_any` IS panic primitive.** Constitution Principle 6 reading "no `panic!` — use thiserror" was satisfied semantically (typed `Err` surfaces) but not mechanically (panic primitive in normal error path).
- **`catch_unwind` runtime overhead** per layout call. Result-returning avoids it on the success path.
- **Hidden control flow.** `panic_any(...)` → `catch_unwind` → downcast is a three-layer dance vs `Result` + `?` direct propagation.
- **`panic_any` is std edge-case escape hatch** for FFI / thread-join / executor pools, not idiomatic application error path. Per std docs: "the message is wrapped in a `Box<'static + Any + Send>`, which can be accessed later using `PanicHookInfo::payload`" — for catch sites that need structured info, not for normal `Result` semantics.

This PR completes the literal-reading Principle 6 satisfaction.

## Trait signature change

```rust
// OLD (PR #141)
fn perform_layout_raw(
    &mut self,
    ctx: &mut <P as Protocol>::LayoutCtxErased<'_>,
) -> ProtocolGeometry<P>;

// NEW (this PR)
fn perform_layout_raw(
    &mut self,
    ctx: &mut <P as Protocol>::LayoutCtxErased<'_>,
) -> RenderResult<ProtocolGeometry<P>>;
```

## Ripples

| File | Change |
|------|--------|
| `crates/flui-rendering/src/traits/render_object.rs` | Trait signature change + 3-phase doc history (pre-U19 no-op → U19 panic_any → Option A Result) |
| `crates/flui-rendering/src/traits/render_box.rs` | Blanket impl bridge: `unwrap_or_else(\|\| panic_any(...))` → `ok_or_else(\|\| RenderError::contract_violation(...))`. No panic primitive in bridge body. |
| `crates/flui-rendering/src/traits/render_sliver.rs` | Sliver stub: `unimplemented!` panic → `Err(RenderError::ContractViolation { what: "Core.2 work" })`. Same loud-fail signal, typed propagation. |
| `crates/flui-rendering/src/view/render_view.rs` | `RenderViewAdapter::perform_layout_raw` body wraps return in `Ok(...)` (root layout always succeeds). |
| `crates/flui-rendering/src/pipeline/owner.rs` | `PanickingPaintBox` returns `Ok(self.size)`. `PanickingLayoutBox` keeps `panic!` — intentional unstructured panic exercises the catch_unwind → Poisoned path (the one remaining way to produce Poisoned after this PR). |
| `crates/flui-rendering/src/storage/entry.rs` | `RenderEntry::layout_leaf_only` flattens `Result<Result<G, RenderError>, panic_payload>`: `Ok(inner)` → propagate inner Result verbatim; `Err(payload)` → tracing::error! + Poisoned. Removes the previous `payload.downcast::<RenderError>()` dance — typed errors no longer travel through the panic payload channel. |
| `crates/flui-rendering/src/error.rs` | `RenderError::ContractViolation` variant doc + constructor doc rewritten — replaced panic_any rationale with Option A Result-chain explanation. |
| `crates/flui-rendering/tests/u19_bridge.rs` | 8 happy-path tests gained `.expect("... happy path must succeed")`. `u19_bridge_panics_on_missing_complete_with_size` renamed to `u19_bridge_returns_contract_violation_on_missing_complete_with_size` + rewritten: no `catch_unwind`, asserts on `Err(ContractViolation)` from direct bridge call. |

## Constitution Principle 6 compliance — full

This PR completes the literal-reading satisfaction. The bridge no longer uses any panic primitive in the normal error path. The remaining `catch_unwind` in `RenderEntry::layout_leaf_only` is purely defensive: catches third-party panics from user widget code (where `panic!` / `unwrap()` in user `perform_layout` would otherwise unwind through the framework). Those still surface as `RenderError::Poisoned` with panic-payload-message forwarded to tracing.

## Verification

- `cargo build --workspace` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p flui-rendering --lib` — **265 passed, 0 failed**
- `cargo test -p flui-rendering --test u19_bridge` — **9 passed, 0 failed** (1 test renamed + rewritten; 8 happy-path tests gained `.expect`)
- `bash scripts/port-check.sh -v` — **9/9 triggers green**
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` clean

## Pre-existing failures (NOT this PR, present on origin/main)

- `flui-app::bindings::renderer_binding::tests::test_semantics_enabled` — singleton-state test-isolation flake
- `flui-rendering` doctests `storage/flags.rs` — 23 failures from stale `flui_rendering::core::*` imports. Predates D-block.

## Refs

- PR #141 review-fix #5 (Option B that this completes): https://github.com/vanyastaff/flui/pull/141
- Constitution v2.4.0 Principle 6: "No `unwrap()`/`println!`/`dbg!` — Use `thiserror`/`anyhow` for errors, `tracing` for logging"
- *The Rust Programming Language* §9.2 ([Recoverable Errors with Result](https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html)): "Result is appropriate for recoverable errors"
- std::panic::panic_any docs ([linked](https://doc.rust-lang.org/std/panic/fn.panic_any.html)): structured-payload escape hatch via `Box<dyn Any + Send>`, not for normal error flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
