### PR TITLE
PR-A1b3 — D-1 layout walk U20 layout_dirty_root + disjoint-borrow recursion

### DIFF
--- a/crates/flui-rendering/src/error.rs
+++ b/crates/flui-rendering/src/error.rs
@@ -234,20 +234,29 @@ pub enum RenderError {
     /// A pipeline-side disjoint-borrow walk requested a child slot
     /// outside the parent's child-id range.
     ///
-    /// **D-block PR-A1b3 U20 (companion memo D1):** returned from
-    /// [`PipelineOwner::layout_dirty_root`](crate::pipeline::PipelineOwner::layout_dirty_root)
-    /// when an off-by-one or stale-id condition would make
-    /// `RenderTree::get_parent_and_children_mut` reject the request.
+    /// **D-block PR-A1b3 U20 (companion memo D1):** reserved variant
+    /// for future defensive bounds checks at the pipeline-side
+    /// disjoint-borrow seam (e.g., when an off-by-one or stale-id
+    /// condition would make a `child_ids[index]` access panic).
     /// Indicates a pipeline-side bug (tree-link corruption, off-by-one
-    /// in the dirty-queue walk, etc.) rather than a user-widget defect;
-    /// surfaces as a typed error so the caller can drop the frame and
-    /// log the offending id without aborting the process.
+    /// in the dirty-queue walk, etc.) rather than a user-widget
+    /// defect; surfaces as a typed error so the caller can drop the
+    /// frame and log the offending parent / index without aborting
+    /// the process.
     ///
-    /// Currently no production code constructs this variant — it is
-    /// reserved alongside U20's disjoint-borrow primitive so the error
-    /// surface is stable when callers grow defensive checks. The U20
-    /// failure-path unit test exercises the variant through a synthetic
-    /// `child_ids` whose entry has been removed from the tree.
+    /// **No production construction site exists yet.** The current
+    /// [`PipelineOwner::layout_dirty_root`](crate::pipeline::PipelineOwner::layout_dirty_root)
+    /// walk iterates over a snapshotted `child_ids` (always in-bounds
+    /// by construction), so stale child-ids surface as
+    /// [`RenderError::NodeNotFound`](Self::NodeNotFound) (id missing
+    /// from tree) or
+    /// [`RenderError::ProtocolMismatch`](Self::ProtocolMismatch) (id
+    /// present but wrong protocol) downstream. Only the
+    /// [`Self::child_index_out_of_bounds`] constructor + round-trip
+    /// unit test cover this variant in the current diff. Future
+    /// defensive checks that grow on the disjoint-borrow primitive
+    /// will produce this variant; pre-adding it keeps the error
+    /// surface stable.
     #[error(
         "child index {index} out of bounds for parent {parent:?} (child_count = {child_count})"
     )]

--- a/crates/flui-rendering/src/error.rs
+++ b/crates/flui-rendering/src/error.rs
@@ -231,6 +231,35 @@ pub enum RenderError {
     #[error("layout cycle detected: node {0:?} re-entered while its own layout was in flight")]
     LayoutCycle(RenderId),
 
+    /// A pipeline-side disjoint-borrow walk requested a child slot
+    /// outside the parent's child-id range.
+    ///
+    /// **D-block PR-A1b3 U20 (companion memo D1):** returned from
+    /// [`PipelineOwner::layout_dirty_root`](crate::pipeline::PipelineOwner::layout_dirty_root)
+    /// when an off-by-one or stale-id condition would make
+    /// `RenderTree::get_parent_and_children_mut` reject the request.
+    /// Indicates a pipeline-side bug (tree-link corruption, off-by-one
+    /// in the dirty-queue walk, etc.) rather than a user-widget defect;
+    /// surfaces as a typed error so the caller can drop the frame and
+    /// log the offending id without aborting the process.
+    ///
+    /// Currently no production code constructs this variant — it is
+    /// reserved alongside U20's disjoint-borrow primitive so the error
+    /// surface is stable when callers grow defensive checks. The U20
+    /// failure-path unit test exercises the variant through a synthetic
+    /// `child_ids` whose entry has been removed from the tree.
+    #[error(
+        "child index {index} out of bounds for parent {parent:?} (child_count = {child_count})"
+    )]
+    ChildIndexOutOfBounds {
+        /// The parent `RenderId` whose child slice was indexed.
+        parent: RenderId,
+        /// The out-of-range index that was requested.
+        index: usize,
+        /// The actual number of children the parent has.
+        child_count: usize,
+    },
+
     /// A render object's `perform_layout` violated its layout contract.
     ///
     /// Distinct from [`Poisoned`](Self::Poisoned): `Poisoned` covers
@@ -368,6 +397,20 @@ impl RenderError {
             phase,
         }
     }
+
+    /// Creates a [`ChildIndexOutOfBounds`](Self::ChildIndexOutOfBounds) error.
+    ///
+    /// **D-block PR-A1b3 U20 (companion memo D1):** used by the
+    /// pipeline-side disjoint-borrow walk to surface stale-id /
+    /// off-by-one conditions on the child-id slice as a typed error
+    /// instead of a panic or silent `Size::ZERO`.
+    pub fn child_index_out_of_bounds(parent: RenderId, index: usize, child_count: usize) -> Self {
+        Self::ChildIndexOutOfBounds {
+            parent,
+            index,
+            child_count,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -393,5 +436,30 @@ mod tests {
 
         let err = RenderError::compositing("invalid bit state");
         assert!(matches!(err, RenderError::CompositingError { .. }));
+    }
+
+    /// PR-A1b3 U20: `ChildIndexOutOfBounds` round-trips its parent / index
+    /// / child_count fields and renders the expected display string.
+    #[test]
+    fn test_child_index_out_of_bounds() {
+        let parent = RenderId::new(7);
+        let err = RenderError::child_index_out_of_bounds(parent, 4, 2);
+        match err {
+            RenderError::ChildIndexOutOfBounds {
+                parent: p,
+                index,
+                child_count,
+            } => {
+                assert_eq!(p, parent);
+                assert_eq!(index, 4);
+                assert_eq!(child_count, 2);
+            }
+            other => panic!("expected ChildIndexOutOfBounds, got {other:?}"),
+        }
+        let display = RenderError::child_index_out_of_bounds(parent, 4, 2).to_string();
+        assert!(
+            display.contains("child index 4") && display.contains("child_count = 2"),
+            "display string `{display}` should name the index and child_count",
+        );
     }
 }

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -993,6 +993,11 @@ impl PipelineOwner<Layout> {
 
     /// D-block PR-A1b3 U20 — production disjoint-borrow layout walk.
     ///
+    /// **⚠ STAGING-WINDOW API.** Public for U23's eventual `run_layout`
+    /// wiring + the U20 integration-test surface. Pre-U21/U23 callers
+    /// must respect the soundness & retry caveats below; this method is
+    /// `#[doc(hidden)]` until U23 promotes it.
+    ///
     /// Lays out the subtree rooted at `id` with the supplied
     /// `constraints`, running `RenderObject::perform_layout_raw` against a
     /// typed [`BoxLayoutCtx`] populated with the parent's direct children
@@ -1020,16 +1025,71 @@ impl PipelineOwner<Layout> {
     ///    constructs a Direct-storage `BoxLayoutCtx` via
     ///    [`BoxLayoutCtx::with_layout_callback`] with a closure that
     ///    re-enters [`layout_subtree_raw`] for each child, materialises
-    ///    the parent entry from the tree, and calls `perform_layout_raw`.
-    ///    The bridge in `traits/render_box.rs` reconstructs a typed
-    ///    `BoxLayoutCtx<T::Arity, T::ParentData>` (Proxy storage variant)
-    ///    and forwards to `RenderBox::perform_layout`. Synchronous
-    ///    `ctx.layout_child(i, c)` calls dispatch through the callback,
-    ///    recursing into the child's subtree.
-    /// 4. On success, updates `state.set_geometry` /
-    ///    `state.set_constraints`, bootstraps `IS_RELAYOUT_BOUNDARY`
-    ///    (mirroring [`RenderEntry::layout_leaf_only`]'s U17 path), and
-    ///    clears `NEEDS_LAYOUT`.
+    ///    the parent entry from the tree, and calls `perform_layout_raw`
+    ///    wrapped in [`std::panic::catch_unwind`] (so third-party panics
+    ///    surface as [`RenderError::Poisoned`] symmetric with the leaf
+    ///    path). The bridge in `traits/render_box.rs` reconstructs a
+    ///    typed `BoxLayoutCtx<T::Arity, T::ParentData>` (Proxy storage
+    ///    variant) and forwards to `RenderBox::perform_layout`.
+    ///    Synchronous `ctx.layout_child(i, c)` calls dispatch through
+    ///    the callback, recursing into the child's subtree.
+    /// 4. On success **AND when no descendant errored**, updates
+    ///    `state.set_geometry` / `state.set_constraints`, bootstraps
+    ///    `IS_RELAYOUT_BOUNDARY` (mirroring
+    ///    [`RenderEntry::layout_leaf_only`]'s U17 path), and clears
+    ///    `NEEDS_LAYOUT`. When a descendant errored mid-callback (see
+    ///    Error handling below), geometry + constraints are still
+    ///    recorded but `NEEDS_LAYOUT` stays set on the parent so the
+    ///    next dirty walk re-runs the subtree.
+    ///
+    /// # Error handling
+    ///
+    /// - **Leaf-path panics** in user `perform_layout` → caught by
+    ///   `layout_leaf_only`'s `catch_unwind`, returned as
+    ///   [`RenderError::Poisoned`].
+    /// - **Non-leaf-path panics** (review-fix PR-A1b3): wrapped in
+    ///   `catch_unwind` at stage 5 here, returned as the same
+    ///   [`RenderError::Poisoned`]. Symmetric with the leaf path.
+    /// - **Descendant `Err` returned through the callback** → tracking
+    ///   flag (`AtomicBool`) set; outer `perform_layout` still completes
+    ///   with `Size::ZERO` for that child; outer `Ok` is returned to the
+    ///   caller, BUT parent's `NEEDS_LAYOUT` is **not cleared** (review
+    ///   fix). Next-frame dirty walk re-runs the parent. This is a
+    ///   compromise: the [`LayoutChildCallback`] signature is `Fn(_) ->
+    ///   Size`, not `Fn(_) -> Result<Size, _>`, so callback failures
+    ///   can't propagate as typed `Err` through the parent's
+    ///   `perform_layout` body. The retry-via-NEEDS_LAYOUT path is the
+    ///   minimum-disruption shape that preserves the documented
+    ///   retry-next-frame semantics. Surfacing the typed error to the
+    ///   outer caller requires widening `LayoutChildCallback` to
+    ///   `Result`; that's an API-shape change deferred to Core.1.
+    /// - **Stale tree state** (id not in tree → `NodeNotFound`; id is
+    ///   present but wrong protocol → `ProtocolMismatch` — review fix
+    ///   to disambiguate; the diff's leaf + non-leaf stages both
+    ///   distinguish the two cases).
+    ///
+    /// # Soundness — KNOWN MIRI BLOCKER
+    ///
+    /// **The recursive raw-pointer reborrow pattern in
+    /// [`layout_subtree_raw`] holds an outer `&mut RenderEntry` borrow
+    /// live across `perform_layout_raw`, during which the synchronous
+    /// callback re-enters and synthesises a fresh `&mut RenderTree`
+    /// reborrow from the same `*mut RenderTree`. Under Stacked Borrows
+    /// / Tree Borrows this invalidates the outer borrow's tag**;
+    /// `cargo +nightly miri test -p flui-rendering --test
+    /// u20_layout_dirty_root` would flag the 2-level and 3-level happy
+    /// paths. Current rustc/LLVM does not miscompile but the pattern
+    /// is latently unsound.
+    ///
+    /// The architectural fix is to pre-acquire all subtree
+    /// `&mut RenderNode` borrows upfront via a new `RenderTree::get_subtree_mut`
+    /// primitive (or to drop the parent borrow before invoking
+    /// `perform_layout_raw` and re-acquire after), eliminating the
+    /// raw-pointer recursion entirely. This is **a blocker for U23's
+    /// `run_layout` wiring** — `run_layout` must not call
+    /// `layout_dirty_root` until the soundness fix lands. Tracked as
+    /// the U20.1 follow-up; do not promote this method to non-`#[doc(hidden)]`
+    /// before the fix.
     ///
     /// # ParentData scope (current limitation)
     ///
@@ -1045,21 +1105,23 @@ impl PipelineOwner<Layout> {
     /// `T::ParentData` dispatch lands as a Core.1 follow-up alongside the
     /// real `RenderFlex` slice integration.
     ///
-    /// # Cycle safety
+    /// # Cycle / depth safety
     ///
-    /// The current implementation has **no cycle guard** — a render
-    /// object whose `perform_layout` re-enters its own ancestor via
-    /// `layout_child` triggers unbounded recursion that overflows the
-    /// stack. The cycle guard is U21's job (companion memo D6):
-    /// `currently_laying_out: FxHashSet<RenderId>` with RAII drop-guard
-    /// detects re-entry and returns
+    /// The current implementation has **no cycle guard and no depth
+    /// limit** — a render object whose `perform_layout` re-enters its
+    /// own ancestor via `layout_child` triggers unbounded recursion
+    /// that overflows the stack; a self-cycle additionally produces
+    /// two `&mut RenderEntry` aliasing the same slab slot (hard UB,
+    /// not just stack overflow). The cycle guard is U21's job
+    /// (companion memo D6): `currently_laying_out:
+    /// FxHashSet<RenderId>` with RAII drop-guard detects re-entry and
+    /// returns
     /// [`RenderError::LayoutCycle`](crate::error::RenderError::LayoutCycle).
-    /// Until U21 lands the pipeline relies on `LAYOUT_DEPTH_LIMIT`
-    /// (1024) via the legacy `layout_node_with_children` path; the new
-    /// disjoint-borrow walk does not honour that limit and will overflow
-    /// before reaching it. **Do not wire `run_layout` to call
-    /// `layout_dirty_root` until U21 ships.** U23 performs the wiring
-    /// after U21.
+    /// Until U21 lands, callers must ensure the tree is acyclic. **Do
+    /// not wire `run_layout` to call `layout_dirty_root` until U21 +
+    /// the Miri soundness fix above both ship.** U23 performs the
+    /// wiring after both.
+    #[doc(hidden)]
     pub fn layout_dirty_root(
         &mut self,
         id: RenderId,
@@ -1073,7 +1135,8 @@ impl PipelineOwner<Layout> {
         // SAFETY: tree_ptr is valid and no outstanding borrows exist on
         // `self.render_tree` at this call site (the `&mut self` receiver
         // is the unique owner). See [`layout_subtree_raw`] for the
-        // recursive disjoint-slot discipline.
+        // recursive disjoint-slot discipline AND the known Stacked
+        // Borrows / Tree Borrows latent UB documented on this method.
         unsafe { layout_subtree_raw(tree_ptr, id, constraints) }
     }
 }
@@ -1182,10 +1245,25 @@ unsafe fn layout_subtree_raw(
         // RenderTree` is scoped to the `get_mut(...)` call and the
         // returned `&mut RenderEntry<BoxProtocol>` borrow keeps only
         // `id`'s slab slot live.
+        //
+        // Review fix: distinguish missing-from-tree (NodeNotFound) from
+        // present-but-wrong-protocol (ProtocolMismatch) — `as_box_mut`
+        // returning `None` previously collapsed both into NodeNotFound,
+        // masking the protocol-mismatch bug class.
         let entry: &mut RenderEntry<BoxProtocol> = unsafe {
-            match (*ptr).get_mut(id).and_then(|n| n.as_box_mut()) {
-                Some(e) => e,
+            let node = match (*ptr).get_mut(id) {
+                Some(n) => n,
                 None => return Err(crate::error::RenderError::NodeNotFound(id)),
+            };
+            let node_protocol = node.protocol_name();
+            match node.as_box_mut() {
+                Some(e) => e,
+                None => {
+                    return Err(crate::error::RenderError::ProtocolMismatch {
+                        node_protocol,
+                        constraints_protocol: "Box",
+                    });
+                }
             }
         };
         return entry.layout_leaf_only(constraints);
@@ -1197,36 +1275,35 @@ unsafe fn layout_subtree_raw(
     let mut child_states: Vec<ChildState<BoxParentData>> =
         child_ids.iter().map(|&cid| ChildState::new(cid)).collect();
 
+    // Review fix: descendant-error tracking flag. The recursive
+    // callback collapses descendant `RenderError` to `Size::ZERO` (the
+    // `LayoutChildCallback` signature is fixed at `Fn(_) -> Size` and
+    // can't widen to `Result` without API churn). Without this flag,
+    // stage 6 below would clear the parent's NEEDS_LAYOUT after a
+    // successful `perform_layout_raw` even when a descendant failed,
+    // leaving the parent CLEAN with stale geometry derived from a
+    // ZERO-sized child — and the dirty queue would not re-process the
+    // parent next frame because its flag is cleared. The flag lets
+    // stage 6 SKIP `clear_needs_layout` so the next dirty walk re-runs
+    // the parent (and transitively the descendant) to surface the
+    // genuine sizing.
+    //
+    // Shared via `Arc<AtomicBool>` because the closure is `Send + Sync`
+    // (inherited from `LayoutChildCallback`'s `Send + Sync` bound) and
+    // must own its handle to flip the flag; outer scope reads via the
+    // sibling Arc clone.
+    let descendant_error_flag: std::sync::Arc<std::sync::atomic::AtomicBool> =
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let descendant_error_for_cb = std::sync::Arc::clone(&descendant_error_flag);
+
     // Recursive callback. `tree_ptr` is captured by value (Copy); the
     // closure is `move` so it owns its copy. The callback fires
     // synchronously from inside `parent_entry.perform_layout_raw(...)`,
     // which is downstream of the parent_entry borrow taken in stage 4
     // below. Per the helper-level safety doc invariant 3, the parent
     // and child slots are distinct so the disjoint-borrow discipline
-    // holds across the recursion boundary.
-    //
-    // # Error suppression rationale
-    //
-    // The callback returns `Size`, not `Result<Size, _>` — the
-    // [`LayoutChildCallback`] type's signature is fixed by
-    // `BoxLayoutCtx::with_layout_callback`'s API and can't widen to
-    // `Result` without changing every call site. A recursive failure
-    // (NodeNotFound, ContractViolation in a descendant, panic surfaced
-    // as Poisoned) collapses to `Size::ZERO` here and the parent's
-    // `perform_layout` sees a zero-sized child, which typically
-    // propagates as a wrong-but-not-panicking layout. This matches
-    // Flutter's behaviour where a descendant `performLayout` failure
-    // sets the child's size to whatever the constraints happen to
-    // produce (often `constraints.smallest()`).
-    //
-    // The full-fidelity error path (surface descendant `RenderError` to
-    // the outer `layout_dirty_root` caller) requires widening the
-    // callback signature or threading an error sink — both are larger
-    // refactors and out of scope for U20. tracing::error! at the swallow
-    // site keeps the failure visible in logs; production scaffolding
-    // around `layout_dirty_root` (U23's `run_layout` wiring) will pick
-    // up Poisoned in subsequent frames via the dirty-queue retry path
-    // documented on `RenderEntry::layout_leaf_only`.
+    // holds across the recursion boundary (see the KNOWN MIRI BLOCKER
+    // note on `layout_dirty_root` for the latent UB caveat).
     let cb_owned = move |child_id: RenderId, child_constraints: BoxConstraints| -> Size {
         // SAFETY: see helper-level safety doc + the closure's own
         // doc above. The recursive call's borrows are on
@@ -1235,14 +1312,16 @@ unsafe fn layout_subtree_raw(
         match unsafe { layout_subtree_raw(tree_ptr, child_id, child_constraints) } {
             Ok(size) => size,
             Err(err) => {
+                // Set the flag so stage 6 preserves the parent's
+                // NEEDS_LAYOUT for next-frame retry.
+                descendant_error_for_cb.store(true, std::sync::atomic::Ordering::Relaxed);
                 tracing::error!(
                     parent = ?id,
                     ?child_id,
                     ?err,
                     "layout_dirty_root: descendant layout failed; \
                          returning Size::ZERO to caller's perform_layout. \
-                         U23's run_layout wiring will surface this via \
-                         dirty-queue retry next frame.",
+                         Parent NEEDS_LAYOUT preserved for next-frame retry.",
                 );
                 Size::ZERO
             }
@@ -1256,11 +1335,25 @@ unsafe fn layout_subtree_raw(
     // Stage 4 — materialise parent_entry borrow on `id`'s slot. This
     // is the single outstanding mutable borrow when the callback fires
     // in stage 5.
-    // SAFETY: see helper-level safety doc invariant 2+3.
+    // SAFETY: see helper-level safety doc invariant 2+3 AND the known
+    // soundness gap documented on `layout_dirty_root`.
+    //
+    // Review fix: split NodeNotFound vs ProtocolMismatch (same shape as
+    // the leaf-path acquisition above).
     let parent_entry: &mut RenderEntry<BoxProtocol> = unsafe {
-        match (*ptr).get_mut(id).and_then(|n| n.as_box_mut()) {
-            Some(e) => e,
+        let node = match (*ptr).get_mut(id) {
+            Some(n) => n,
             None => return Err(crate::error::RenderError::NodeNotFound(id)),
+        };
+        let node_protocol = node.protocol_name();
+        match node.as_box_mut() {
+            Some(e) => e,
+            None => {
+                return Err(crate::error::RenderError::ProtocolMismatch {
+                    node_protocol,
+                    constraints_protocol: "Box",
+                });
+            }
         }
     };
 
@@ -1270,6 +1363,14 @@ unsafe fn layout_subtree_raw(
     // `T::Arity` from the user's `RenderBox` impl regardless) and
     // `BoxParentData` (see ParentData scope limitation on
     // `layout_dirty_root`).
+    //
+    // Review fix: wrap `perform_layout_raw` in `catch_unwind` so a
+    // third-party panic from a non-leaf user widget surfaces as
+    // `RenderError::Poisoned` instead of unwinding out of
+    // `layout_dirty_root`. Symmetric with the leaf path in
+    // `RenderEntry::layout_leaf_only`. Pattern matches the leaf-path
+    // shape verbatim (capture `debug_name` before the &mut reborrow;
+    // downcast panic payload for tracing).
     let mut ctx = BoxLayoutCtx::<flui_tree::Variable, BoxParentData>::with_layout_callback(
         constraints,
         &mut child_states,
@@ -1278,15 +1379,35 @@ unsafe fn layout_subtree_raw(
     );
     let erased: &mut dyn BoxLayoutCtxErased = &mut ctx;
 
-    let geometry = parent_entry
-        .render_object_mut()
-        .perform_layout_raw(erased)?;
+    let debug_name = parent_entry.render_object().debug_name();
+    let render_object = parent_entry.render_object_mut();
+    let unwind_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        render_object.perform_layout_raw(erased)
+    }));
+    let geometry = match unwind_result {
+        Ok(inner) => inner?,
+        Err(payload) => {
+            let msg = payload
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| payload.downcast_ref::<&'static str>().copied())
+                .unwrap_or("(non-string panic payload)");
+            tracing::error!(
+                render_object = debug_name,
+                panic_msg = msg,
+                "perform_layout panicked in non-leaf path — surfacing as \
+                     RenderError::Poisoned (symmetric with leaf-path \
+                     layout_leaf_only catch_unwind discipline)",
+            );
+            return Err(crate::error::RenderError::poisoned(debug_name, "layout"));
+        }
+    };
 
     // Stage 6 — update state on the success path (mirrors
     // `RenderEntry::layout_leaf_only`'s post-perform_layout discipline).
-    // On the Err path above (propagated via `?`), state is intentionally
-    // unmodified so `NEEDS_LAYOUT` stays set and the pipeline can retry
-    // next frame.
+    // On the Err path above (propagated via `?` or returned from the
+    // catch_unwind arm), state is intentionally unmodified so
+    // `NEEDS_LAYOUT` stays set and the pipeline can retry next frame.
     parent_entry.state_mut().set_geometry(geometry);
     parent_entry.state_mut().set_constraints(constraints);
 
@@ -1295,7 +1416,19 @@ unsafe fn layout_subtree_raw(
     let has_parent = parent_entry.links().parent().is_some();
     <BoxProtocol as Protocol>::bootstrap_relayout_boundary(parent_entry.state(), has_parent);
 
-    parent_entry.clear_needs_layout();
+    // Review fix: only clear NEEDS_LAYOUT if the recursive callback
+    // didn't observe a descendant failure. If it did, we keep the flag
+    // set so the next dirty walk re-runs the subtree — preserves the
+    // documented retry-next-frame semantics.
+    if !descendant_error_flag.load(std::sync::atomic::Ordering::Relaxed) {
+        parent_entry.clear_needs_layout();
+    } else {
+        tracing::debug!(
+            parent = ?id,
+            "layout_dirty_root: a descendant errored during this walk; \
+                 keeping parent NEEDS_LAYOUT set for next-frame retry"
+        );
+    }
 
     Ok(geometry)
 }

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -1130,7 +1130,7 @@ impl PipelineOwner<Layout> {
         // Raw pointer to render_tree: stays valid for the duration of
         // this call because `&mut self` keeps `self.render_tree` alive.
         // The recursive helper's safety invariant covers downstream uses.
-        let tree_ptr = TreePtr(&raw mut self.render_tree);
+        let tree_ptr = TreePtr::new(&mut self.render_tree);
 
         // SAFETY: tree_ptr is valid and no outstanding borrows exist on
         // `self.render_tree` at this call site (the `&mut self` receiver
@@ -1145,7 +1145,8 @@ impl PipelineOwner<Layout> {
 // PR-A1b3 U20 — recursive disjoint-borrow layout helper
 // ============================================================================
 
-/// `Send + Sync` raw-pointer wrapper for `RenderTree`.
+/// `Send + Sync` raw-pointer wrapper for `RenderTree` carrying the
+/// owning thread's `ThreadId` for runtime affinity enforcement.
 ///
 /// **D-block PR-A1b3 U20:** the pipeline-side
 /// [`PipelineOwner::layout_dirty_root`] hands this wrapper to a layout
@@ -1155,22 +1156,76 @@ impl PipelineOwner<Layout> {
 /// bound), so a bare `*mut RenderTree` cannot be captured.
 ///
 /// The wrapper is `Copy` so the closure captures by value without
-/// `Arc` ceremony. The unsafe `Send + Sync` impls are sound because
-/// the raw pointer itself is just an address — the soundness obligation
-/// is on the *uses* of the pointer at call sites inside
-/// [`layout_subtree_raw`] (each use synthesises a transient
-/// `&mut RenderTree` whose lifetime ends before the next synthesis,
-/// matching the discipline of [`RenderTree::get_two_mut`] /
-/// [`RenderTree::get_parent_and_children_mut`]).
+/// `Arc` ceremony.
+///
+/// # Thread-affinity guard (PR #144 Copilot review fix)
+///
+/// Although the documented invariant is "callback fires synchronously
+/// from the pipeline thread", the `BoxLayoutCtxErased: Send + Sync`
+/// supertrait permits a user `perform_layout` body to spawn child
+/// layout calls onto another thread (e.g., via `std::thread::scope` or
+/// `rayon::scope`). Two threads simultaneously dereferencing
+/// `TreePtr.ptr` would race on `Slab` internals → data race / UB.
+///
+/// `TreePtr` therefore records the owning thread's `ThreadId` at
+/// construction and exposes [`Self::check_thread`] which the unsafe
+/// `*ptr` deref sites call before reborrowing. Mismatched-thread
+/// access panics with a clear diagnostic instead of corrupting the
+/// slab silently. The check is active in **all builds** (not gated
+/// behind `debug_assertions`) because data-race UB is undetectable
+/// after the fact; the runtime cost is one `ThreadId::eq` (cheap;
+/// effectively a `u64` compare).
+///
+/// The structural fix (remove `Send + Sync` from `BoxLayoutCtxErased`
+/// or refactor `layout_child` to dispatch via the pipeline thread only)
+/// is deferred to the same U20.1 follow-up as the recursive-reborrow
+/// soundness fix.
 #[derive(Clone, Copy)]
-struct TreePtr(*mut RenderTree);
+struct TreePtr {
+    ptr: *mut RenderTree,
+    owner_thread: std::thread::ThreadId,
+}
+
+impl TreePtr {
+    /// Constructs a `TreePtr` from an exclusive `&mut RenderTree` borrow.
+    /// Records the current thread's `ThreadId` as the owner; every
+    /// subsequent `*ptr` deref via [`Self::check_thread`] verifies the
+    /// caller is on the same thread.
+    fn new(tree: &mut RenderTree) -> Self {
+        Self {
+            ptr: tree as *mut _,
+            owner_thread: std::thread::current().id(),
+        }
+    }
+
+    /// Verifies the current thread matches the `TreePtr`'s owner thread.
+    /// Panics otherwise. Called before every `*ptr` deref in
+    /// [`layout_subtree_raw`] to fail loudly on cross-thread callback
+    /// invocation (see thread-affinity guard rationale on [`TreePtr`]).
+    #[inline]
+    fn check_thread(&self) {
+        let current = std::thread::current().id();
+        if current != self.owner_thread {
+            panic!(
+                "TreePtr accessed from non-owner thread: \
+                 owner = {:?}, current = {:?}. The U20 layout walk \
+                 requires the layout_child callback to fire on the \
+                 same thread as PipelineOwner::layout_dirty_root \
+                 (the pipeline phase holds &mut self synchronously). \
+                 User RenderBox::perform_layout body must not spawn \
+                 ctx.layout_child(...) calls to other threads — the \
+                 underlying RenderTree slab is not Sync.",
+                self.owner_thread, current,
+            );
+        }
+    }
+}
 
 // SAFETY: the raw pointer is just an address; the per-call-site
 // `&mut RenderTree` synthesised inside [`layout_subtree_raw`] is the load-
 // bearing borrow, and that borrow is scoped to a single statement at each
-// use site. No data races are possible because the pipeline phase holds
-// `&mut self` for the entire layout walk and the callback fires
-// synchronously from inside `perform_layout_raw` on the same thread.
+// use site. Cross-thread access is rejected by the runtime
+// [`TreePtr::check_thread`] guard called before every `*ptr` deref.
 unsafe impl Send for TreePtr {}
 // SAFETY: the same reasoning as `Send` — see above.
 unsafe impl Sync for TreePtr {}
@@ -1221,7 +1276,11 @@ unsafe fn layout_subtree_raw(
     id: RenderId,
     constraints: BoxConstraints,
 ) -> crate::error::RenderResult<Size> {
-    let TreePtr(ptr) = tree_ptr;
+    // Thread-affinity guard: panic loudly if a user perform_layout body
+    // dispatched the layout_child callback to a non-pipeline thread (see
+    // TreePtr::check_thread doc). Cheap: one ThreadId compare.
+    tree_ptr.check_thread();
+    let ptr = tree_ptr.ptr;
 
     // Stage 1 — snapshot child_ids. The `&RenderTree` borrow lives only
     // for the `to_vec` call; releasing it here means we never hold a

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -13,9 +13,18 @@ use std::{
 
 use flui_foundation::RenderId;
 use flui_layer::LayerTree;
-use flui_types::Offset;
+use flui_types::{Offset, Size};
 
-use crate::{context::CanvasContext, storage::RenderTree};
+use crate::{
+    constraints::BoxConstraints,
+    context::CanvasContext,
+    parent_data::BoxParentData,
+    protocol::{
+        BoxLayoutCtx, BoxProtocol, ChildState, Protocol,
+        box_protocol::{BoxLayoutCtxErased, LayoutChildCallback},
+    },
+    storage::{RenderEntry, RenderTree},
+};
 
 use super::{
     dirty::{DirtyNode, DirtySets},
@@ -981,6 +990,314 @@ impl PipelineOwner<Layout> {
 
         Ok(())
     }
+
+    /// D-block PR-A1b3 U20 — production disjoint-borrow layout walk.
+    ///
+    /// Lays out the subtree rooted at `id` with the supplied
+    /// `constraints`, running `RenderObject::perform_layout_raw` against a
+    /// typed [`BoxLayoutCtx`] populated with the parent's direct children
+    /// (companion memo D1). Returns the parent's computed `Size` on
+    /// success.
+    ///
+    /// Replaces the recursion shape of
+    /// [`Self::layout_node_with_children`] (which only walks the dirty
+    /// tree without invoking per-node layout — see the audit comment in
+    /// that method). The pipeline-side `run_layout` outer loop is rewired
+    /// to this method in U23.
+    ///
+    /// # Mechanism
+    ///
+    /// The walk is driven by [`layout_subtree_raw`] (private helper). Each
+    /// invocation:
+    ///
+    /// 1. Snapshots the node's `child_ids` from the tree.
+    /// 2. **Leaf path** (no children): routes through
+    ///    [`RenderEntry::layout_leaf_only`](crate::storage::RenderEntry::layout_leaf_only)
+    ///    which constructs a leaf-mode `BoxLayoutCtx` and invokes
+    ///    `perform_layout_raw` — same code path the U18/U19 leaf bridge
+    ///    tests cover.
+    /// 3. **Non-leaf path**: builds `Vec<ChildState<BoxParentData>>`,
+    ///    constructs a Direct-storage `BoxLayoutCtx` via
+    ///    [`BoxLayoutCtx::with_layout_callback`] with a closure that
+    ///    re-enters [`layout_subtree_raw`] for each child, materialises
+    ///    the parent entry from the tree, and calls `perform_layout_raw`.
+    ///    The bridge in `traits/render_box.rs` reconstructs a typed
+    ///    `BoxLayoutCtx<T::Arity, T::ParentData>` (Proxy storage variant)
+    ///    and forwards to `RenderBox::perform_layout`. Synchronous
+    ///    `ctx.layout_child(i, c)` calls dispatch through the callback,
+    ///    recursing into the child's subtree.
+    /// 4. On success, updates `state.set_geometry` /
+    ///    `state.set_constraints`, bootstraps `IS_RELAYOUT_BOUNDARY`
+    ///    (mirroring [`RenderEntry::layout_leaf_only`]'s U17 path), and
+    ///    clears `NEEDS_LAYOUT`.
+    ///
+    /// # ParentData scope (current limitation)
+    ///
+    /// The pipeline-side Direct `BoxLayoutCtx` is parameterised over
+    /// [`BoxParentData`], so widgets whose `T::ParentData` is the default
+    /// (`RenderPadding`, `RenderCenter`, `RenderColoredBox`,
+    /// `RenderOpacity`, `RenderTransform`, `RenderSizedBox`) drive
+    /// through correctly. Non-default parent-data types (e.g.,
+    /// `FlexParentData` on `RenderFlex`) trigger a
+    /// `BoxLayoutCtx::from_erased` debug-assert mismatch in debug builds
+    /// and silently fail to downcast in release builds. Pipeline-driven
+    /// flex layout is out of scope for D-block; per-render-object
+    /// `T::ParentData` dispatch lands as a Core.1 follow-up alongside the
+    /// real `RenderFlex` slice integration.
+    ///
+    /// # Cycle safety
+    ///
+    /// The current implementation has **no cycle guard** — a render
+    /// object whose `perform_layout` re-enters its own ancestor via
+    /// `layout_child` triggers unbounded recursion that overflows the
+    /// stack. The cycle guard is U21's job (companion memo D6):
+    /// `currently_laying_out: FxHashSet<RenderId>` with RAII drop-guard
+    /// detects re-entry and returns
+    /// [`RenderError::LayoutCycle`](crate::error::RenderError::LayoutCycle).
+    /// Until U21 lands the pipeline relies on `LAYOUT_DEPTH_LIMIT`
+    /// (1024) via the legacy `layout_node_with_children` path; the new
+    /// disjoint-borrow walk does not honour that limit and will overflow
+    /// before reaching it. **Do not wire `run_layout` to call
+    /// `layout_dirty_root` until U21 ships.** U23 performs the wiring
+    /// after U21.
+    pub fn layout_dirty_root(
+        &mut self,
+        id: RenderId,
+        constraints: BoxConstraints,
+    ) -> crate::error::RenderResult<Size> {
+        // Raw pointer to render_tree: stays valid for the duration of
+        // this call because `&mut self` keeps `self.render_tree` alive.
+        // The recursive helper's safety invariant covers downstream uses.
+        let tree_ptr = TreePtr(&raw mut self.render_tree);
+
+        // SAFETY: tree_ptr is valid and no outstanding borrows exist on
+        // `self.render_tree` at this call site (the `&mut self` receiver
+        // is the unique owner). See [`layout_subtree_raw`] for the
+        // recursive disjoint-slot discipline.
+        unsafe { layout_subtree_raw(tree_ptr, id, constraints) }
+    }
+}
+
+// ============================================================================
+// PR-A1b3 U20 — recursive disjoint-borrow layout helper
+// ============================================================================
+
+/// `Send + Sync` raw-pointer wrapper for `RenderTree`.
+///
+/// **D-block PR-A1b3 U20:** the pipeline-side
+/// [`PipelineOwner::layout_dirty_root`] hands this wrapper to a layout
+/// callback that re-enters [`layout_subtree_raw`] for each child. The
+/// callback type [`LayoutChildCallback`] requires `Send + Sync`
+/// (inherited from the [`BoxLayoutCtxErased`] supertrait auto-trait
+/// bound), so a bare `*mut RenderTree` cannot be captured.
+///
+/// The wrapper is `Copy` so the closure captures by value without
+/// `Arc` ceremony. The unsafe `Send + Sync` impls are sound because
+/// the raw pointer itself is just an address — the soundness obligation
+/// is on the *uses* of the pointer at call sites inside
+/// [`layout_subtree_raw`] (each use synthesises a transient
+/// `&mut RenderTree` whose lifetime ends before the next synthesis,
+/// matching the discipline of [`RenderTree::get_two_mut`] /
+/// [`RenderTree::get_parent_and_children_mut`]).
+#[derive(Clone, Copy)]
+struct TreePtr(*mut RenderTree);
+
+// SAFETY: the raw pointer is just an address; the per-call-site
+// `&mut RenderTree` synthesised inside [`layout_subtree_raw`] is the load-
+// bearing borrow, and that borrow is scoped to a single statement at each
+// use site. No data races are possible because the pipeline phase holds
+// `&mut self` for the entire layout walk and the callback fires
+// synchronously from inside `perform_layout_raw` on the same thread.
+unsafe impl Send for TreePtr {}
+// SAFETY: the same reasoning as `Send` — see above.
+unsafe impl Sync for TreePtr {}
+
+/// Recursive helper for [`PipelineOwner::layout_dirty_root`].
+///
+/// Drives the disjoint-borrow walk per companion memo D1 + plan §U20:
+/// at each level, snapshots `child_ids`, materialises the parent entry
+/// from the tree, builds a Direct-storage `BoxLayoutCtx` with a
+/// recursive `layout_child` callback, and invokes
+/// `perform_layout_raw`. The callback re-enters this helper for each
+/// child slot synchronously, threading the recursion through the
+/// trait-object bridge in `traits/render_box.rs`.
+///
+/// # Safety
+///
+/// Caller must guarantee:
+///
+/// 1. `tree_ptr.0` points to a valid `RenderTree` that lives for the
+///    entire duration of this call (transitively, the duration of every
+///    nested recursive call this helper triggers via the callback).
+///    [`PipelineOwner::layout_dirty_root`] satisfies this by deriving
+///    `tree_ptr` from `&mut self.render_tree` and only invoking the
+///    helper while holding `&mut self`.
+/// 2. No other `&RenderTree` / `&mut RenderTree` borrow exists at the
+///    *moment of each helper invocation*. Inside the helper the
+///    `&mut RenderTree` synthesised via `&mut *tree_ptr.0` is scoped to
+///    the single `get` / `get_mut` / `get_parent_and_children_mut` call
+///    that uses it — the resulting `&mut RenderEntry` / `&mut RenderNode`
+///    borrows the tree's slab slot only, releasing the `&mut Slab` parent
+///    borrow.
+/// 3. Distinct call levels of this helper hold borrows on *disjoint
+///    slab slots*. The outer call's parent-entry borrow is on `id`'s
+///    slot; the inner call (triggered by the callback) acquires its
+///    own parent-entry borrow on the child's slot. Tree structure
+///    (parent ≠ child in a well-formed tree) guarantees these are
+///    distinct. **Cycles in the parent-child graph would violate this
+///    invariant** — the cycle guard arrives in U21
+///    ([`RenderError::LayoutCycle`](crate::error::RenderError::LayoutCycle));
+///    until then this helper relies on tree construction being acyclic.
+///
+/// The disjoint-slot discipline mirrors the existing
+/// [`RenderTree::get_two_mut`] / [`RenderTree::get_parent_and_children_mut`]
+/// primitives — same `*mut slab::Slab<RenderNode>` reborrow pattern,
+/// extended across recursion levels.
+unsafe fn layout_subtree_raw(
+    tree_ptr: TreePtr,
+    id: RenderId,
+    constraints: BoxConstraints,
+) -> crate::error::RenderResult<Size> {
+    let TreePtr(ptr) = tree_ptr;
+
+    // Stage 1 — snapshot child_ids. The `&RenderTree` borrow lives only
+    // for the `to_vec` call; releasing it here means we never hold a
+    // shared borrow across the mutable acquisitions below.
+    // SAFETY: see helper-level safety doc invariant 1+2.
+    let child_ids: Vec<RenderId> = unsafe {
+        match (*ptr).get(id) {
+            Some(node) => node.children().to_vec(),
+            None => return Err(crate::error::RenderError::NodeNotFound(id)),
+        }
+    };
+
+    // Stage 2 — leaf path: delegate to layout_leaf_only, which already
+    // implements the full leaf-mode bridge (constraints → typed
+    // BoxLayoutCtx<Leaf> → perform_layout_raw → geometry, with the
+    // catch_unwind wrapper for Poisoned + state update + relayout-boundary
+    // bootstrap). The U18/U19 leaf bridge tests cover this path; we just
+    // forward.
+    if child_ids.is_empty() {
+        // SAFETY: see helper-level safety doc invariant 2. This `&mut
+        // RenderTree` is scoped to the `get_mut(...)` call and the
+        // returned `&mut RenderEntry<BoxProtocol>` borrow keeps only
+        // `id`'s slab slot live.
+        let entry: &mut RenderEntry<BoxProtocol> = unsafe {
+            match (*ptr).get_mut(id).and_then(|n| n.as_box_mut()) {
+                Some(e) => e,
+                None => return Err(crate::error::RenderError::NodeNotFound(id)),
+            }
+        };
+        return entry.layout_leaf_only(constraints);
+    }
+
+    // Stage 3 — non-leaf path: build callback closure + ChildState
+    // backing vec. ChildState carries BoxParentData per child (see the
+    // ParentData scope limitation on `layout_dirty_root`).
+    let mut child_states: Vec<ChildState<BoxParentData>> =
+        child_ids.iter().map(|&cid| ChildState::new(cid)).collect();
+
+    // Recursive callback. `tree_ptr` is captured by value (Copy); the
+    // closure is `move` so it owns its copy. The callback fires
+    // synchronously from inside `parent_entry.perform_layout_raw(...)`,
+    // which is downstream of the parent_entry borrow taken in stage 4
+    // below. Per the helper-level safety doc invariant 3, the parent
+    // and child slots are distinct so the disjoint-borrow discipline
+    // holds across the recursion boundary.
+    //
+    // # Error suppression rationale
+    //
+    // The callback returns `Size`, not `Result<Size, _>` — the
+    // [`LayoutChildCallback`] type's signature is fixed by
+    // `BoxLayoutCtx::with_layout_callback`'s API and can't widen to
+    // `Result` without changing every call site. A recursive failure
+    // (NodeNotFound, ContractViolation in a descendant, panic surfaced
+    // as Poisoned) collapses to `Size::ZERO` here and the parent's
+    // `perform_layout` sees a zero-sized child, which typically
+    // propagates as a wrong-but-not-panicking layout. This matches
+    // Flutter's behaviour where a descendant `performLayout` failure
+    // sets the child's size to whatever the constraints happen to
+    // produce (often `constraints.smallest()`).
+    //
+    // The full-fidelity error path (surface descendant `RenderError` to
+    // the outer `layout_dirty_root` caller) requires widening the
+    // callback signature or threading an error sink — both are larger
+    // refactors and out of scope for U20. tracing::error! at the swallow
+    // site keeps the failure visible in logs; production scaffolding
+    // around `layout_dirty_root` (U23's `run_layout` wiring) will pick
+    // up Poisoned in subsequent frames via the dirty-queue retry path
+    // documented on `RenderEntry::layout_leaf_only`.
+    let cb_owned = move |child_id: RenderId, child_constraints: BoxConstraints| -> Size {
+        // SAFETY: see helper-level safety doc + the closure's own
+        // doc above. The recursive call's borrows are on
+        // `child_id`'s slab slot (and its descendants), disjoint
+        // from the outer call's `id`-slot borrow.
+        match unsafe { layout_subtree_raw(tree_ptr, child_id, child_constraints) } {
+            Ok(size) => size,
+            Err(err) => {
+                tracing::error!(
+                    parent = ?id,
+                    ?child_id,
+                    ?err,
+                    "layout_dirty_root: descendant layout failed; \
+                         returning Size::ZERO to caller's perform_layout. \
+                         U23's run_layout wiring will surface this via \
+                         dirty-queue retry next frame.",
+                );
+                Size::ZERO
+            }
+        }
+    };
+    // Bind the closure to a name so we can take a stable `&dyn Fn`
+    // reference whose lifetime matches the BoxLayoutCtx 'ctx lifetime
+    // (both end at this function's return).
+    let cb_ref: LayoutChildCallback<'_> = &cb_owned;
+
+    // Stage 4 — materialise parent_entry borrow on `id`'s slot. This
+    // is the single outstanding mutable borrow when the callback fires
+    // in stage 5.
+    // SAFETY: see helper-level safety doc invariant 2+3.
+    let parent_entry: &mut RenderEntry<BoxProtocol> = unsafe {
+        match (*ptr).get_mut(id).and_then(|n| n.as_box_mut()) {
+            Some(e) => e,
+            None => return Err(crate::error::RenderError::NodeNotFound(id)),
+        }
+    };
+
+    // Stage 5 — construct pipeline-side Direct BoxLayoutCtx and invoke
+    // the trait-erased bridge. The pipeline-side ctx is parameterised
+    // over `Variable` arity (most permissive — the Proxy bridge picks
+    // `T::Arity` from the user's `RenderBox` impl regardless) and
+    // `BoxParentData` (see ParentData scope limitation on
+    // `layout_dirty_root`).
+    let mut ctx = BoxLayoutCtx::<flui_tree::Variable, BoxParentData>::with_layout_callback(
+        constraints,
+        &mut child_states,
+        &child_ids,
+        cb_ref,
+    );
+    let erased: &mut dyn BoxLayoutCtxErased = &mut ctx;
+
+    let geometry = parent_entry
+        .render_object_mut()
+        .perform_layout_raw(erased)?;
+
+    // Stage 6 — update state on the success path (mirrors
+    // `RenderEntry::layout_leaf_only`'s post-perform_layout discipline).
+    // On the Err path above (propagated via `?`), state is intentionally
+    // unmodified so `NEEDS_LAYOUT` stays set and the pipeline can retry
+    // next frame.
+    parent_entry.state_mut().set_geometry(geometry);
+    parent_entry.state_mut().set_constraints(constraints);
+
+    // Bootstrap relayout boundary (U17). For BoxProtocol this runs the
+    // Flutter formula; for SliverProtocol it's a no-op.
+    let has_parent = parent_entry.links().parent().is_some();
+    <BoxProtocol as Protocol>::bootstrap_relayout_boundary(parent_entry.state(), has_parent);
+
+    parent_entry.clear_needs_layout();
+
+    Ok(geometry)
 }
 
 // ============================================================================

--- a/crates/flui-rendering/tests/u20_layout_dirty_root.rs
+++ b/crates/flui-rendering/tests/u20_layout_dirty_root.rs
@@ -1,0 +1,346 @@
+//! D-block PR-A1b3 U20 — `PipelineOwner::layout_dirty_root` disjoint-borrow
+//! walk integration tests.
+//!
+//! These exercise the **production layout path** introduced in U20:
+//! [`PipelineOwner::layout_dirty_root`] drives `perform_layout_raw`
+//! against a Direct-storage [`BoxLayoutCtx`] populated with the
+//! parent's child IDs + a recursive [`layout_subtree_raw`] callback. The
+//! tests cover the 2-level happy path (parent + leaf child), the
+//! 3-level grandchild path (Padding → Center → ColoredBox), and the
+//! failure path (NodeNotFound on a stale root id).
+//!
+//! The full integration suite (`tests/pipeline/layout_pipeline_test.rs`
+//! per plan §U25/§U26) lands in PR-A1c; this file is the U20-local smoke
+//! verification.
+//!
+//! Refs:
+//!   * docs/plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md §U20
+//!   * docs/research/2026-05-23-d-block-architecture-decision-memo.md §D1
+//!   * PR #140 (U18 — protocol-erased dispatch)
+//!   * PR #141 (U19 — typed bridge)
+//!   * PR #143 (perform_layout_raw → Result)
+
+use flui_foundation::RenderId;
+use flui_rendering::{
+    constraints::BoxConstraints,
+    error::RenderError,
+    objects::{RenderCenter, RenderColoredBox, RenderPadding},
+    pipeline::PipelineOwner,
+    protocol::{BoxProtocol, RenderObject},
+};
+use flui_types::{Size, geometry::px};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Builds a fresh pipeline owner in the Layout phase. Tests construct
+/// the tree via `render_tree_mut` (phase-agnostic accessor) before
+/// invoking [`PipelineOwner::layout_dirty_root`].
+fn fresh_layout_pipeline() -> PipelineOwner<flui_rendering::pipeline::Layout> {
+    PipelineOwner::new().into_layout()
+}
+
+// ============================================================================
+// Happy path — 2-level tree: RenderPadding (parent) + RenderColoredBox (child)
+// ============================================================================
+
+/// Plan §U20 happy path: a 2-level tree (`Padding` wrapping a single
+/// `ColoredBox`) lays out correctly through `layout_dirty_root`. The
+/// padding deflates parent constraints by 20 (left=right=10) on each
+/// axis, the colored box sizes to its preferred (80×40) clipped to the
+/// deflated constraints, and the padding wraps it with the configured
+/// insets to produce a final 100×60 box.
+///
+/// This exercises the **non-leaf path** of `layout_subtree_raw`:
+/// pipeline builds the Direct `BoxLayoutCtx` with `child_ids =
+/// [colored_box_id]` and a recursive callback, the trait-erased bridge
+/// in `traits/render_box.rs` reconstructs the typed
+/// `BoxLayoutCtx<Single, BoxParentData>` for `RenderPadding`, and
+/// `RenderPadding::perform_layout` calls `ctx.layout_child(0,
+/// deflated)` which invokes the callback → recursive
+/// `layout_subtree_raw(colored_box_id, deflated)` → leaf path →
+/// `RenderEntry::layout_leaf_only` produces the child size.
+#[test]
+fn u20_two_level_padding_with_colored_box_child() {
+    let mut pipeline = fresh_layout_pipeline();
+
+    // Build tree: Padding(all=10) → ColoredBox(preferred 80×40).
+    let padding_id = pipeline
+        .render_tree_mut()
+        .insert_box(Box::new(RenderPadding::all(10.0)));
+    let _colored_box_id = pipeline
+        .render_tree_mut()
+        .insert_box_child(padding_id, Box::new(RenderColoredBox::red(80.0, 40.0)))
+        .expect("child insert must succeed");
+
+    // Parent constraints: loose 0..300 × 0..200 — leaves room for the
+    // 80+20=100 wide, 40+20=60 tall padded box.
+    let parent_constraints = BoxConstraints::new(px(0.0), px(300.0), px(0.0), px(200.0));
+
+    let size = pipeline
+        .layout_dirty_root(padding_id, parent_constraints)
+        .expect("2-level layout_dirty_root must succeed");
+
+    assert_eq!(
+        size,
+        Size::new(px(100.0), px(60.0)),
+        "Padding(10) wrapping ColoredBox(80×40) must produce (80+20)×(40+20) = 100×60",
+    );
+
+    // Padding state should be populated post-layout.
+    let padding_node = pipeline
+        .render_tree()
+        .get(padding_id)
+        .expect("padding node still in tree");
+    assert_eq!(
+        padding_node.geometry_box(),
+        Some(Size::new(px(100.0), px(60.0))),
+        "padding's stored geometry must match the returned size",
+    );
+    assert!(
+        !padding_node.needs_layout(),
+        "NEEDS_LAYOUT must be cleared after successful layout",
+    );
+}
+
+// ============================================================================
+// Happy path — 3-level grandchild propagation: Padding → Center → ColoredBox
+// ============================================================================
+
+/// Plan §U20 edge case: a 3-level tree (`Padding` → `Center` →
+/// `ColoredBox`) propagates layout correctly through the
+/// **recursive** callback path of `layout_subtree_raw`. Each recursion
+/// level builds its own Direct `BoxLayoutCtx`, invokes
+/// `perform_layout_raw` on the parent at that level, and the bridge's
+/// `ctx.layout_child(0, c)` dispatches through the closure to recurse
+/// one level deeper.
+///
+/// # Math
+///
+/// Parent constraints: 0..400 × 0..300.
+/// - `RenderPadding::all(20)` deflates to 0..360 × 0..260, passes to
+///   `RenderCenter` (which is `Single` arity).
+/// - `RenderCenter::perform_layout` calls `ctx.layout_single_child_loose()`
+///   — gives the child 0..360 × 0..260 (loose). Since `RenderColoredBox`
+///   constrains its preferred 60×30 to the loose constraints, the child
+///   takes its preferred 60×30.
+/// - `RenderCenter` expands to fill the loose constraints' max → 360×260.
+/// - `RenderPadding` adds 20+20 = 40 in each axis → 360+40=400, 260+40=300.
+#[test]
+fn u20_three_level_padding_center_colored_box_grandchild_propagation() {
+    let mut pipeline = fresh_layout_pipeline();
+
+    // Build tree: Padding(20) → Center → ColoredBox(60×30).
+    let padding_id = pipeline
+        .render_tree_mut()
+        .insert_box(Box::new(RenderPadding::all(20.0)));
+    let center_id = pipeline
+        .render_tree_mut()
+        .insert_box_child(padding_id, Box::new(RenderCenter::new()))
+        .expect("center insert must succeed");
+    let _colored_box_id = pipeline
+        .render_tree_mut()
+        .insert_box_child(center_id, Box::new(RenderColoredBox::blue(60.0, 30.0)))
+        .expect("colored box insert must succeed");
+
+    let parent_constraints = BoxConstraints::new(px(0.0), px(400.0), px(0.0), px(300.0));
+
+    let size = pipeline
+        .layout_dirty_root(padding_id, parent_constraints)
+        .expect("3-level layout_dirty_root must succeed");
+
+    assert_eq!(
+        size,
+        Size::new(px(400.0), px(300.0)),
+        "Padding(20) wrapping Center wrapping ColoredBox(60×30) under \
+         (0..400)×(0..300) must expand to 400×300 (Center fills the \
+         deflated 360×260 + Padding adds 40 each axis)",
+    );
+
+    // Walk back: every node should have geometry set and NEEDS_LAYOUT clear.
+    let padding_geom = pipeline
+        .render_tree()
+        .get(padding_id)
+        .and_then(|n| n.geometry_box());
+    let center_geom = pipeline
+        .render_tree()
+        .get(center_id)
+        .and_then(|n| n.geometry_box());
+
+    assert_eq!(padding_geom, Some(Size::new(px(400.0), px(300.0))));
+    assert_eq!(
+        center_geom,
+        Some(Size::new(px(360.0), px(260.0))),
+        "Center fills the loose constraints it received from Padding's \
+         deflation (max_width=360, max_height=260)",
+    );
+
+    assert!(
+        !pipeline
+            .render_tree()
+            .get(padding_id)
+            .unwrap()
+            .needs_layout(),
+        "padding NEEDS_LAYOUT must be cleared",
+    );
+    assert!(
+        !pipeline
+            .render_tree()
+            .get(center_id)
+            .unwrap()
+            .needs_layout(),
+        "center NEEDS_LAYOUT must be cleared after the recursive callback \
+         drove its layout_leaf_only path",
+    );
+}
+
+// ============================================================================
+// Failure path — stale root id surfaces RenderError::NodeNotFound
+// ============================================================================
+
+/// Plan §U20 failure path (adapted): `layout_dirty_root` invoked on a
+/// `RenderId` that doesn't exist in the tree returns
+/// `Err(RenderError::NodeNotFound)` rather than panicking.
+///
+/// The plan's literal phrasing names `ChildIndexOutOfBounds` for the
+/// "child slice access out of bounds" case, but the U20 implementation
+/// surfaces that condition via `NodeNotFound` instead: the callback
+/// iterates over the parent's snapshotted `child_ids` (always within
+/// bounds by construction), so a stale child-id surfaces as a
+/// downstream `get(child_id) -> None` in the recursive call — i.e.,
+/// `NodeNotFound`. `ChildIndexOutOfBounds` is reserved (see the variant
+/// constructor doc) for future defensive checks; this test covers the
+/// shape that the current implementation actually produces.
+#[test]
+fn u20_stale_root_id_returns_node_not_found() {
+    let mut pipeline = fresh_layout_pipeline();
+
+    let stale_id = RenderId::new(999); // never inserted
+
+    let result = pipeline.layout_dirty_root(
+        stale_id,
+        BoxConstraints::tight(Size::new(px(100.0), px(100.0))),
+    );
+
+    let err = result.expect_err("layout on a non-existent id must fail");
+    assert!(
+        matches!(err, RenderError::NodeNotFound(id) if id == stale_id),
+        "expected NodeNotFound({stale_id:?}), got {err:?}",
+    );
+}
+
+// ============================================================================
+// Smoke — leaf path: layout_dirty_root on a node with no children
+// delegates to RenderEntry::layout_leaf_only.
+// ============================================================================
+
+/// Sanity: when `id`'s child list is empty, `layout_dirty_root` should
+/// route through `RenderEntry::layout_leaf_only` and return the
+/// constraint-clamped size — same path the U18/U19 leaf bridge tests
+/// already cover, exercised here through the U20 entry point to prove
+/// the leaf branch is reachable from the new public API.
+#[test]
+fn u20_leaf_path_delegates_to_layout_leaf_only() {
+    let mut pipeline = fresh_layout_pipeline();
+
+    let leaf_id = pipeline
+        .render_tree_mut()
+        .insert_box(Box::new(RenderColoredBox::green(120.0, 50.0)));
+
+    let constraints = BoxConstraints::tight(Size::new(px(120.0), px(50.0)));
+    let size = pipeline
+        .layout_dirty_root(leaf_id, constraints)
+        .expect("leaf-only layout_dirty_root must succeed");
+
+    assert_eq!(size, Size::new(px(120.0), px(50.0)));
+
+    let geom = pipeline
+        .render_tree()
+        .get(leaf_id)
+        .and_then(|n| n.geometry_box());
+    assert_eq!(geom, Some(Size::new(px(120.0), px(50.0))));
+}
+
+// ============================================================================
+// Idempotence — re-running layout on a clean tree returns the same size
+// (interaction with U14's OnceCell→Option migration: no panic on frame 2).
+// ============================================================================
+
+/// Frame-2 regression smoke: U14 swapped `RenderState::set_constraints` /
+/// `set_geometry` from `OnceCell` (panic on re-set) to `Option` (replace
+/// on re-set). Two consecutive `layout_dirty_root` calls on the same
+/// tree must succeed without panic — the new walk goes through the same
+/// `set_*` path U14 fixed.
+///
+/// Covers the AE8 surface (frame-2 no panic) at the U20 entry point;
+/// the full AE8 integration test lands in U29.
+#[test]
+fn u20_double_layout_does_not_panic_on_frame_two() {
+    let mut pipeline = fresh_layout_pipeline();
+
+    let padding_id = pipeline
+        .render_tree_mut()
+        .insert_box(Box::new(RenderPadding::all(5.0)));
+    let _child_id = pipeline
+        .render_tree_mut()
+        .insert_box_child(padding_id, Box::new(RenderColoredBox::red(40.0, 40.0)))
+        .expect("child insert must succeed");
+
+    let c = BoxConstraints::new(px(0.0), px(200.0), px(0.0), px(200.0));
+
+    let size1 = pipeline
+        .layout_dirty_root(padding_id, c)
+        .expect("frame 1 must succeed");
+    let size2 = pipeline
+        .layout_dirty_root(padding_id, c)
+        .expect("frame 2 must succeed without OnceCell-style panic");
+
+    assert_eq!(
+        size1, size2,
+        "deterministic layout: frame 1 and frame 2 must agree",
+    );
+    assert_eq!(size1, Size::new(px(50.0), px(50.0)));
+}
+
+// ============================================================================
+// Manual RenderObject<BoxProtocol> impls (RenderViewAdapter): the U20 walk
+// still drives perform_layout_raw on them via the trait dispatch.
+// ============================================================================
+
+/// `RenderViewAdapter` carries a manual (non-blanket)
+/// `RenderObject<BoxProtocol>` impl that ignores the erased ctx and
+/// drives layout from its embedded `ViewConfiguration`. The U20 walk
+/// should still invoke `perform_layout_raw` on it correctly (the manual
+/// impl chooses to ignore the ctx — that's its prerogative — but the
+/// walk's dispatch shouldn't change behaviour).
+///
+/// Smoke check that the U20 pipeline-side ctx (Direct, no children) is
+/// accepted by the adapter's manual impl.
+#[test]
+fn u20_render_view_adapter_layout_smoke() {
+    use flui_rendering::view::{RenderView, RenderViewAdapter, ViewConfiguration};
+
+    let mut pipeline = fresh_layout_pipeline();
+
+    let config = ViewConfiguration::from_size(Size::new(px(320.0), px(240.0)), 1.0);
+    let mut view = RenderView::with_configuration(config);
+    view.prepare_initial_frame_without_owner();
+
+    let adapter: Box<dyn RenderObject<BoxProtocol>> = Box::new(RenderViewAdapter::new(view));
+    let view_id = pipeline.render_tree_mut().insert_box(adapter);
+
+    // Sentinel constraints — RenderViewAdapter ignores them and drives
+    // layout from its configuration (logical 320×240).
+    let sentinel = BoxConstraints::tight(Size::new(px(999.0), px(999.0)));
+    let size = pipeline
+        .layout_dirty_root(view_id, sentinel)
+        .expect("RenderViewAdapter layout_dirty_root must succeed");
+
+    assert_eq!(
+        size,
+        Size::new(px(320.0), px(240.0)),
+        "RenderViewAdapter must lay out from its embedded configuration, \
+         not from the sentinel constraints",
+    );
+}

--- a/crates/flui-rendering/tests/u20_layout_dirty_root.rs
+++ b/crates/flui-rendering/tests/u20_layout_dirty_root.rs
@@ -308,6 +308,278 @@ fn u20_double_layout_does_not_panic_on_frame_two() {
 // still drives perform_layout_raw on them via the trait dispatch.
 // ============================================================================
 
+// ============================================================================
+// Review-fix regression — non-leaf perform_layout panic surfaces as Poisoned
+// ============================================================================
+
+/// PR-A1b3 review fix: a panicking user widget at NON-LEAF position
+/// surfaces as `RenderError::Poisoned`, symmetric with the leaf path.
+/// Pre-fix the non-leaf branch invoked `perform_layout_raw` without
+/// `catch_unwind` — a panic would have unwound out of
+/// `layout_dirty_root` and terminated the rendering thread. With the
+/// fix, the non-leaf branch wraps `perform_layout_raw` in
+/// `catch_unwind(AssertUnwindSafe(...))` mirroring
+/// `RenderEntry::layout_leaf_only`'s discipline.
+#[test]
+fn u20_non_leaf_perform_layout_panic_surfaces_as_poisoned() {
+    use flui_foundation::Diagnosticable;
+    use flui_rendering::{
+        context::{BoxHitTestContext, BoxLayoutContext},
+        hit_testing::HitTestBehavior,
+        traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability},
+    };
+    use flui_tree::Single;
+    use flui_types::{Point, Rect};
+
+    /// A non-leaf user widget that panics inside `perform_layout`.
+    /// Single arity so it requires a child (i.e., goes through the
+    /// NON-leaf path of `layout_subtree_raw`).
+    #[derive(Debug, Default)]
+    struct PanickingNonLeaf {
+        size: Size,
+    }
+
+    impl Diagnosticable for PanickingNonLeaf {}
+    impl PaintEffectsCapability for PanickingNonLeaf {}
+    impl SemanticsCapability for PanickingNonLeaf {}
+    impl HotReloadCapability for PanickingNonLeaf {}
+
+    impl RenderBox for PanickingNonLeaf {
+        type Arity = Single;
+        type ParentData = flui_rendering::parent_data::BoxParentData;
+
+        fn perform_layout(&mut self, _ctx: &mut BoxLayoutContext<'_, Single, Self::ParentData>) {
+            panic!("PanickingNonLeaf intentionally panics");
+        }
+
+        fn size(&self) -> &Size {
+            &self.size
+        }
+        fn size_mut(&mut self) -> &mut Size {
+            &mut self.size
+        }
+        fn hit_test(&self, _ctx: &mut BoxHitTestContext<'_, Single, Self::ParentData>) -> bool {
+            false
+        }
+        fn hit_test_behavior(&self) -> HitTestBehavior {
+            HitTestBehavior::Opaque
+        }
+        fn box_paint_bounds(&self) -> Rect {
+            Rect::from_origin_size(Point::ZERO, self.size)
+        }
+    }
+
+    let mut pipeline = fresh_layout_pipeline();
+
+    // Parent (panics) with a benign child so the walk takes the non-leaf path.
+    let parent_obj: Box<dyn RenderObject<BoxProtocol>> = Box::new(PanickingNonLeaf::default());
+    let parent_id = pipeline.render_tree_mut().insert_box(parent_obj);
+    let _child_id = pipeline
+        .render_tree_mut()
+        .insert_box_child(parent_id, Box::new(RenderColoredBox::red(10.0, 10.0)))
+        .expect("child insert must succeed");
+
+    let constraints = BoxConstraints::tight(Size::new(px(100.0), px(100.0)));
+    let result = pipeline.layout_dirty_root(parent_id, constraints);
+
+    let err = result.expect_err("panicking non-leaf widget must return Err, not unwind");
+    match err {
+        RenderError::Poisoned {
+            render_object,
+            phase,
+        } => {
+            assert!(
+                render_object.contains("PanickingNonLeaf"),
+                "render_object name must identify the offending widget; got {render_object}",
+            );
+            assert_eq!(
+                phase, "layout",
+                "phase tag should identify the layout phase, got {phase}",
+            );
+        }
+        other => panic!(
+            "expected RenderError::Poisoned, got {other:?} — \
+                 non-leaf panic must surface symmetric with leaf path",
+        ),
+    }
+}
+
+// ============================================================================
+// Review-fix regression — descendant Err preserves parent NEEDS_LAYOUT
+// ============================================================================
+
+/// PR-A1b3 review fix: when the recursive callback observes a
+/// descendant `Err`, the outer parent's `NEEDS_LAYOUT` must STAY SET
+/// so the next dirty walk re-runs the subtree. Pre-fix the parent
+/// was unconditionally `clear_needs_layout`'d after a successful
+/// `perform_layout_raw`, leaving the parent CLEAN with stale geometry
+/// derived from the `Size::ZERO` returned by the swallowed-error
+/// callback.
+///
+/// Trigger: `RenderPadding` (Single arity, non-leaf) with a child id
+/// that points to a node which was inserted but then removed from the
+/// tree before the layout walk. The recursive callback's stage 1
+/// snapshot reads the stale id from `parent.children()`, then the
+/// stage 4 `(*ptr).get_mut(stale_id)` returns `None` →
+/// `RenderError::NodeNotFound`. Callback swallows to `Size::ZERO` +
+/// flips the `descendant_error_flag`. Padding's perform_layout
+/// completes (0+padding = small size); stage 6 skips
+/// `clear_needs_layout` per the flag.
+#[test]
+fn u20_descendant_err_preserves_parent_needs_layout() {
+    let mut pipeline = fresh_layout_pipeline();
+
+    // Build Padding → Child. Insert both, then REMOVE the child from
+    // the slab (without removing the link from Padding.children()) —
+    // simulates a torn tree state where parent.children() contains a
+    // stale id.
+    let padding_id = pipeline
+        .render_tree_mut()
+        .insert_box(Box::new(RenderPadding::all(5.0)));
+    let child_id = pipeline
+        .render_tree_mut()
+        .insert_box_child(padding_id, Box::new(RenderColoredBox::red(20.0, 20.0)))
+        .expect("child insert must succeed");
+
+    // Remove the child node from the slab WITHOUT updating the
+    // parent's children list — this synthesises the stale-id condition.
+    // (In production this shouldn't happen; the test deliberately
+    // constructs it.)
+    pipeline
+        .render_tree_mut()
+        .remove_shallow(child_id)
+        .expect("shallow remove must succeed");
+    // remove_shallow also strips the child from parent.children() per
+    // its impl, so we have to re-add it manually to simulate the stale
+    // link.
+    let padding_node = pipeline
+        .render_tree_mut()
+        .get_mut(padding_id)
+        .expect("padding node must exist");
+    padding_node.add_child(child_id);
+
+    let constraints = BoxConstraints::tight(Size::new(px(100.0), px(100.0)));
+    let result = pipeline.layout_dirty_root(padding_id, constraints);
+
+    // Outer call SUCCEEDS (Padding's perform_layout completes with
+    // child_size = Size::ZERO from the swallowed callback Err).
+    let size = result.expect("padding perform_layout completes even when child layout fails");
+    // Padding(all=5) wrapping a Size::ZERO child = 10×10; constrained
+    // to tight (100, 100) constraints clamps it back to 100×100. Either
+    // way, the test only cares about NEEDS_LAYOUT preservation; assert
+    // size is non-NaN as a sanity check.
+    assert!(size.width.get().is_finite() && size.height.get().is_finite());
+
+    // CRITICAL ASSERTION: padding's NEEDS_LAYOUT must STAY SET because
+    // the descendant errored during the walk (pre-fix this would have
+    // been cleared, leading to stale layout persisting indefinitely).
+    let padding_node = pipeline
+        .render_tree()
+        .get(padding_id)
+        .expect("padding node must still exist");
+    assert!(
+        padding_node.needs_layout(),
+        "padding NEEDS_LAYOUT must remain SET when a descendant errored \
+             during the walk, so the next dirty pass re-runs the subtree",
+    );
+}
+
+// ============================================================================
+// Review-fix regression — Sliver protocol mismatch surfaces as ProtocolMismatch
+// ============================================================================
+
+/// PR-A1b3 review fix: when `layout_dirty_root` is called on a
+/// `RenderId` whose node is a `SliverProtocol` entry (not `Box`), it
+/// surfaces as `RenderError::ProtocolMismatch` — NOT
+/// `RenderError::NodeNotFound`. Pre-fix the `.get_mut(id).and_then(|n|
+/// n.as_box_mut())` chain collapsed both cases into `NodeNotFound`,
+/// masking the protocol-mismatch bug class.
+#[test]
+fn u20_sliver_node_surfaces_as_protocol_mismatch() {
+    use flui_rendering::{
+        constraints::{SliverConstraints, SliverGeometry},
+        context::{SliverHitTestContext, SliverLayoutContext},
+        protocol::SliverProtocol,
+        traits::{HotReloadCapability, PaintEffectsCapability, RenderSliver, SemanticsCapability},
+    };
+    use flui_tree::Leaf;
+    use flui_types::{Point, Rect};
+
+    /// Minimal sliver render-object stub for the test fixture — never
+    /// laid out (the test triggers the protocol-mismatch error path
+    /// before reaching perform_layout).
+    #[derive(Debug, Default)]
+    struct StubSliver {
+        constraints: SliverConstraints,
+        geometry: SliverGeometry,
+    }
+
+    impl flui_foundation::Diagnosticable for StubSliver {}
+    impl PaintEffectsCapability for StubSliver {}
+    impl SemanticsCapability for StubSliver {}
+    impl HotReloadCapability for StubSliver {}
+
+    impl RenderSliver for StubSliver {
+        type Arity = Leaf;
+        type ParentData = flui_rendering::parent_data::SliverParentData;
+
+        fn perform_layout(&mut self, _ctx: &mut SliverLayoutContext<'_, Leaf, Self::ParentData>) {
+            // Never invoked in this test — protocol-mismatch error
+            // returns before perform_layout.
+        }
+
+        fn constraints(&self) -> &SliverConstraints {
+            &self.constraints
+        }
+
+        fn geometry(&self) -> &SliverGeometry {
+            &self.geometry
+        }
+
+        fn set_geometry(&mut self, geometry: SliverGeometry) {
+            self.geometry = geometry;
+        }
+
+        fn hit_test(&self, _ctx: &mut SliverHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+            false
+        }
+
+        fn sliver_paint_bounds(&self) -> Rect {
+            Rect::from_origin_size(Point::ZERO, Size::ZERO)
+        }
+    }
+
+    let mut pipeline = fresh_layout_pipeline();
+
+    let sliver_obj: Box<dyn flui_rendering::traits::RenderObject<SliverProtocol>> =
+        Box::new(StubSliver::default());
+    let sliver_id = pipeline.render_tree_mut().insert_sliver(sliver_obj);
+
+    let constraints = BoxConstraints::tight(Size::new(px(100.0), px(100.0)));
+    let result = pipeline.layout_dirty_root(sliver_id, constraints);
+
+    let err = result.expect_err("box layout on sliver node must fail");
+    match err {
+        RenderError::ProtocolMismatch {
+            node_protocol,
+            constraints_protocol,
+        } => {
+            assert_eq!(node_protocol, "Sliver", "node_protocol must name Sliver");
+            assert_eq!(
+                constraints_protocol, "Box",
+                "constraints_protocol must name Box (the layout entry point)",
+            );
+        }
+        // The leaf path was taken (sliver has no children), but the
+        // refactored stage 2 distinguishes NodeNotFound vs
+        // ProtocolMismatch.
+        other => panic!(
+            "expected RenderError::ProtocolMismatch, got {other:?} — \
+                 sliver id should not collapse to NodeNotFound",
+        ),
+    }
+}
+
 /// `RenderViewAdapter` carries a manual (non-blanket)
 /// `RenderObject<BoxProtocol>` impl that ignores the erased ctx and
 /// drives layout from its embedded `ViewConfiguration`. The U20 walk

--- a/crates/flui-rendering/tests/u20_layout_dirty_root.rs
+++ b/crates/flui-rendering/tests/u20_layout_dirty_root.rs
@@ -580,6 +580,54 @@ fn u20_sliver_node_surfaces_as_protocol_mismatch() {
     }
 }
 
+// ============================================================================
+// Bot-review fix — TreePtr same-thread invariant smoke
+// ============================================================================
+
+/// PR #144 Copilot review (comment_id=3294225417) fix: `TreePtr` carries
+/// the owning thread's `ThreadId` (set at construction in
+/// `layout_dirty_root`) and exposes `check_thread()` which the
+/// `layout_subtree_raw` entry calls before any unsafe `*ptr` deref. The
+/// guard panics with a documented diagnostic if a future caller smuggles
+/// `TreePtr` across threads via the `Send + Sync` auto-trait inherited
+/// from `BoxLayoutCtxErased`.
+///
+/// This test verifies the legitimate worker-thread case: a pipeline
+/// run inside `std::thread::spawn` still works because the `TreePtr`
+/// is constructed AND deref'd on the SAME (worker) thread per call.
+/// The pathological cross-thread case (TreePtr constructed on thread A,
+/// deref'd on thread B via a smuggled closure capture) cannot be
+/// exercised from integration tests because both `TreePtr` and the
+/// `BoxLayoutCtx::with_layout_callback` ctor are `pub(crate)` / private —
+/// the guard is a defensive layer for the closure-smuggle attack vector
+/// the Copilot review flagged, validated by code reading.
+#[test]
+fn u20_treeptr_worker_thread_pipeline_succeeds() {
+    let mut pipeline = fresh_layout_pipeline();
+    let padding_id = pipeline
+        .render_tree_mut()
+        .insert_box(Box::new(RenderPadding::all(5.0)));
+    let _child_id = pipeline
+        .render_tree_mut()
+        .insert_box_child(padding_id, Box::new(RenderColoredBox::red(40.0, 40.0)))
+        .expect("child insert must succeed");
+
+    let constraints = BoxConstraints::tight(Size::new(px(50.0), px(50.0)));
+
+    // Move pipeline into a worker thread, run layout there. TreePtr is
+    // constructed inside `layout_dirty_root` using the worker thread's
+    // id; subsequent `check_thread()` calls inside `layout_subtree_raw`
+    // are on the same worker thread; guard does NOT fire.
+    let join = std::thread::spawn(move || pipeline.layout_dirty_root(padding_id, constraints));
+
+    let result = join.join().expect("worker thread must not panic");
+    assert!(
+        result.is_ok(),
+        "single-threaded worker pipeline must succeed (TreePtr \
+         constructed AND deref'd on the same worker thread)",
+    );
+}
+
 /// `RenderViewAdapter` carries a manual (non-blanket)
 /// `RenderObject<BoxProtocol>` impl that ignores the erased ctx and
 /// drives layout from its embedded `ViewConfiguration`. The U20 walk


### PR DESCRIPTION
# PR-A1b3 / U20 — `PipelineOwner::layout_dirty_root` disjoint-borrow walk

Third sub-PR in the PR-A1b series (D-1 layout pipeline wiring). Follows [PR #139](https://github.com/vanyastaff/flui/pull/139) (PR-A1a — OnceCell→Option + mark_needs_layout walk), [PR #140](https://github.com/vanyastaff/flui/pull/140) (PR-A1b1 — protocol-erased dispatch), [PR #141](https://github.com/vanyastaff/flui/pull/141) (PR-A1b2 — typed bridge + Proxy ctx), and [PR #143](https://github.com/vanyastaff/flui/pull/143) (`perform_layout_raw` Result-returning signature).

## What this PR adds

`PipelineOwner::<Layout>::layout_dirty_root(id, constraints) -> RenderResult<Size>` — the production disjoint-borrow layout walk. Drives per-node `perform_layout_raw` against a Direct-storage `BoxLayoutCtx` populated with the parent's child IDs + a recursive `layout_subtree_raw` callback. Replaces the no-op recursion shape of `layout_node_with_children`.

Per plan §U20 + memo D1 ([`docs/plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md`](docs/plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md), [`docs/research/2026-05-23-d-block-architecture-decision-memo.md`](docs/research/2026-05-23-d-block-architecture-decision-memo.md)).

## Mechanism

Each `layout_subtree_raw` invocation:

1. Snapshots `child_ids` from the tree.
2. **Leaf path**: delegates to `RenderEntry::layout_leaf_only` (same U18/U19 leaf bridge code).
3. **Non-leaf path**: builds `Vec<ChildState<BoxParentData>>`, constructs `BoxLayoutCtx::with_layout_callback` with a recursive callback that re-enters `layout_subtree_raw` for each child slot, invokes `perform_layout_raw` wrapped in `std::panic::catch_unwind` (review fix — symmetric with leaf path).
4. On success **AND when no descendant errored**: updates `state.set_geometry` / `state.set_constraints`, bootstraps `IS_RELAYOUT_BOUNDARY`, clears `NEEDS_LAYOUT`. When a descendant errored mid-callback: state still recorded but `NEEDS_LAYOUT` stays SET for next-frame retry (review fix).

## Commits (atomic-per-unit shape)

| Commit | Summary |
|--------|---------|
| `4967a9c0` | U20a — add `RenderError::ChildIndexOutOfBounds` variant (reserved for future defensive checks) |
| `e9e697ff` | U20b — `PipelineOwner::layout_dirty_root` + `TreePtr` + `layout_subtree_raw` recursion helper |
| `e87dd3d7` | U20c — 6 integration tests (2-level, 3-level, leaf delegation, frame-2 idempotence, stale-id, RenderViewAdapter) |
| `026e3798` | Review fixes — `catch_unwind` on non-leaf; retain `NEEDS_LAYOUT` on descendant `Err`; distinguish `NodeNotFound` vs `ProtocolMismatch`; doc gating (`#[doc(hidden)]` + KNOWN MIRI BLOCKER note); 3 regression tests |

## Test scope

[`crates/flui-rendering/tests/u20_layout_dirty_root.rs`](crates/flui-rendering/tests/u20_layout_dirty_root.rs) — 9 tests:

- `u20_two_level_padding_with_colored_box_child` (plan happy path)
- `u20_three_level_padding_center_colored_box_grandchild_propagation` (plan edge case — recursive callback)
- `u20_stale_root_id_returns_node_not_found` (plan failure path)
- `u20_leaf_path_delegates_to_layout_leaf_only` (smoke)
- `u20_double_layout_does_not_panic_on_frame_two` (U14 OnceCell→Option regression smoke; AE8 surface)
- `u20_render_view_adapter_layout_smoke` (manual non-blanket `RenderObject<BoxProtocol>` impl smoke)
- `u20_non_leaf_perform_layout_panic_surfaces_as_poisoned` (review fix #1)
- `u20_descendant_err_preserves_parent_needs_layout` (review fix #2)
- `u20_sliver_node_surfaces_as_protocol_mismatch` (review fix #3)

## Known limitations — documented inline, blockers for U23 wiring

1. **KNOWN MIRI BLOCKER (latent UB)** — the recursive raw-pointer reborrow pattern in `layout_subtree_raw` holds an outer `&mut RenderEntry` borrow live across `perform_layout_raw`, during which the synchronous callback re-enters and synthesises a fresh `&mut RenderTree` from the same `*mut`. Stacked Borrows / Tree Borrows would flag this; `cargo +nightly miri test -p flui-rendering --test u20_layout_dirty_root` would fail. Current rustc/LLVM does not miscompile, but the pattern is latently unsound. **Architectural fix path**: pre-acquire all subtree `&mut RenderNode` borrows upfront via new `RenderTree::get_subtree_mut` primitive. **Blocker for U23's `run_layout` wiring** — this PR adds `#[doc(hidden)]` to keep the method un-promoted until the fix lands.

2. **No cycle guard / depth limit** — U21's job (`RenderError::LayoutCycle` variant already reserved). Until U21 lands, callers must ensure the tree is acyclic.

3. **ParentData scope** — pipeline-side `BoxLayoutCtx` is hardcoded to `BoxParentData`. Non-default ParentData types (`FlexParentData` on `RenderFlex`) trigger debug-assert in `BoxLayoutCtx::from_erased` in debug builds; silent wrong layout in release. Pipeline-driven flex is Core.1 follow-up.

4. **Descendant `Err` observability** — callback collapses descendant `RenderError` to `Size::ZERO`; tracing logs the failure; parent stays dirty for retry. Surfacing typed `Err` to the outer caller requires widening `LayoutChildCallback` to `Result` — Core.1 API-shape change.

## Code review (Tier 1)

15 findings across 5 finder angles (line-by-line / removed-behavior / cross-file / Rust-pitfall / wrapper-correctness). 3 confirmations via single-vote verifiers. Top 4 P0/P1/P2 findings addressed in commit `026e3798`; the remaining 11 either are documented inline on `layout_dirty_root` as known limitations (Miri UB, cycle guard, ParentData scope, `Err` observability) or are deferred to U23-wiring / Core.1 work as called out in the commit body.

## Verification

```
cargo build -p flui-rendering --lib                                           # clean
cargo clippy --workspace --all-targets -- -D warnings                          # clean
cargo test -p flui-rendering --lib                                             # 266 passed
cargo test -p flui-rendering --test u19_bridge                                 # 9 passed (no regression)
cargo test -p flui-rendering --test u20_layout_dirty_root                      # 9 passed
bash scripts/port-check.sh -v                                                  # all 7 triggers + FR-033 + FR-036 clean
```

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is internal rendering pipeline work; `layout_dirty_root` is `#[doc(hidden)]` and not yet wired into any production caller (U23 will wire `run_layout`). Tests are the validation surface.

## Known Residuals

None accepted via residual gate — this PR ran Tier 1 review only (concentrated diff, no sensitive surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
