### PR TITLE
PR-A1 U23 — wire run_layout to layout_dirty_root

### DIFF
--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -477,9 +477,27 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
     /// Pass `None` to clear (e.g., when the binding wants to defer to
     /// a yet-unmounted root render object that supplies its own
     /// constraints via `RootRenderElement::mount`).
-    #[inline]
+    ///
+    /// # Auto-schedules root relayout (PR #148 review fix)
+    ///
+    /// When `Some(_)` is passed AND `root_id` is set AND the new
+    /// constraints differ from the prior value, this method also
+    /// calls [`Self::mark_needs_layout`] on the root id so the
+    /// next `run_layout` invocation picks up the change. This
+    /// avoids the silent-no-relayout footgun the prior shape had —
+    /// the binding no longer needs to call `mark_needs_layout`
+    /// separately after `set_root_constraints`.
+    ///
+    /// Setting to the SAME constraints value (or to `None`) does
+    /// NOT mark dirty — those cases either don't change the layout
+    /// result or are explicit clears that the caller manages
+    /// independently.
     pub fn set_root_constraints(&mut self, constraints: Option<BoxConstraints>) {
+        let changed = constraints.is_some() && constraints != self.root_constraints;
         self.root_constraints = constraints;
+        if changed && let Some(root_id) = self.root_id {
+            self.mark_needs_layout(root_id);
+        }
     }
 
     /// Returns a reference to the render tree.
@@ -1043,13 +1061,57 @@ impl PipelineOwner<Layout> {
             // Constraints come from cached state (post-frame-1) OR
             // the binding-set root_constraints (frame-1 root).
             for dirty_node in dirty_nodes {
+                // PR-A1 U23 P2 review fix (Copilot 3294417924): skip
+                // entries whose NEEDS_LAYOUT flag was already cleared
+                // earlier in this iteration. Common case: a parent's
+                // layout_child callback recursively lays out a child
+                // whose dirty-queue entry was queued separately
+                // (e.g., insert_child_render_object enqueues both).
+                // Re-laying out the child would be redundant +
+                // potentially side-effectful.
+                let already_clean = self
+                    .render_tree
+                    .get(dirty_node.id)
+                    .is_some_and(|n| !n.needs_layout());
+                if already_clean {
+                    tracing::trace!(
+                        id = ?dirty_node.id,
+                        "run_layout: skipping dirty-queue entry whose NEEDS_LAYOUT \
+                         was already cleared this iteration",
+                    );
+                    continue;
+                }
+
                 let Some(constraints) = self.cached_or_root_constraints(dirty_node.id) else {
+                    // PR-A1 U23 P2 review fix (Copilot 3294417942):
+                    // dropping the dirty entry here without recovery
+                    // strands the work. The two real cases this hits:
+                    //   1. Root id with root_constraints unset — the
+                    //      binding should have called
+                    //      set_root_constraints BEFORE run_frame.
+                    //      U23's set_root_constraints fix auto-marks
+                    //      root dirty when constraints land, so the
+                    //      next run_layout picks up the deferred
+                    //      work automatically.
+                    //   2. Non-root id with no cached constraints
+                    //      AND no parent-driven layout yet — the
+                    //      shallow-first dirty queue sort means the
+                    //      parent should have processed first; if
+                    //      it didn't (parent's perform_layout didn't
+                    //      call layout_child for this id), the entry
+                    //      is correctly dropped because the parent
+                    //      is the authority on child constraints.
+                    // Logged at warn so the diagnostic surfaces but
+                    // doesn't halt the pipeline.
                     tracing::warn!(
                         id = ?dirty_node.id,
-                        "run_layout: no cached state.constraints() AND id != root_id (or \
-                         root_constraints unset); skipping layout for this dirty entry. \
-                         Caller must either set_root_constraints OR mark the node's parent \
-                         dirty so the parent's layout propagates constraints."
+                        is_root = ?(self.root_id == Some(dirty_node.id)),
+                        "run_layout: no cached state.constraints() AND no \
+                         root_constraints (or id != root_id); skipping dirty entry. \
+                         Recovery: for root → call set_root_constraints (which \
+                         auto-marks the root dirty); for non-root → parent's \
+                         perform_layout must call ctx.layout_child(idx, c) for \
+                         this id first."
                     );
                     continue;
                 };

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -43,13 +43,6 @@ use super::{
 /// via [`PipelineOwner::new_with_capacity`].
 const DEFAULT_DIRTY_CHANNEL_CAPACITY: usize = 256;
 
-/// Maximum render-tree recursion depth during layout. Going deeper means
-/// the parent-child layout has cycled or the tree is pathologically
-/// deep. The pipeline aborts the offending subtree, surfaces
-/// [`RenderError::LayoutDepthExceeded`](crate::RenderError::LayoutDepthExceeded) via tracing, and continues with
-/// the next dirty root. Mythos Step 12 (2026-05-20).
-pub const LAYOUT_DEPTH_LIMIT: usize = 1024;
-
 // ============================================================================
 // Pipeline ID Counter
 // ============================================================================
@@ -140,6 +133,18 @@ pub struct PipelineOwner<Phase: PipelinePhase = Idle> {
     /// (same non-shrinking discipline as `dirty`).
     mid_layout_marks: DirtySets,
 
+    /// Constraints to pass to [`Self::layout_dirty_root`] when the
+    /// dirty entry is the tree root (`root_id`) and the root has no
+    /// cached `state.constraints()` yet (first frame).
+    ///
+    /// **D-block PR-A1 U23:** the binding layer (`flui-view` /
+    /// `flui-app` / `flui-hot-reload`) sets this once per
+    /// configuration via [`Self::set_root_constraints`] before the
+    /// first `run_frame` invocation. On subsequent frames the root's
+    /// cached constraints (post-layout) supersede this field; the
+    /// fallback only fires on the very first layout pass.
+    root_constraints: Option<BoxConstraints>,
+
     /// Whether we're currently doing layout.
     debug_doing_layout: bool,
 
@@ -216,6 +221,7 @@ impl PipelineOwner<Idle> {
             notifier: VisualUpdateNotifier::new(),
             dirty: DirtySets::new(),
             mid_layout_marks: DirtySets::new(),
+            root_constraints: None,
             debug_doing_layout: false,
             debug_doing_paint: false,
             debug_doing_semantics: false,
@@ -256,6 +262,7 @@ impl PipelineOwner<Idle> {
             notifier,
             dirty: DirtySets::new(),
             mid_layout_marks: DirtySets::new(),
+            root_constraints: None,
             debug_doing_layout: false,
             debug_doing_paint: false,
             debug_doing_semantics: false,
@@ -445,6 +452,34 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
     /// Sets the root render object ID.
     pub fn set_root_id(&mut self, id: Option<RenderId>) {
         self.root_id = id;
+    }
+
+    /// Returns the constraints to apply to the root render object on
+    /// the next layout pass (if no cached constraints yet).
+    ///
+    /// **D-block PR-A1 U23:** see [`Self::set_root_constraints`].
+    #[inline]
+    pub fn root_constraints(&self) -> Option<BoxConstraints> {
+        self.root_constraints
+    }
+
+    /// Sets the constraints to apply to the root render object on the
+    /// next layout pass when no cached constraints exist yet
+    /// (first-frame initialization).
+    ///
+    /// **D-block PR-A1 U23:** the binding layer (`flui-view` /
+    /// `flui-app` / `flui-hot-reload`) calls this once after
+    /// constructing the pipeline + before the first `run_frame`
+    /// invocation. On subsequent frames the root's cached
+    /// `state.constraints()` (post-layout) supersedes this field; the
+    /// fallback only fires on the very first layout pass.
+    ///
+    /// Pass `None` to clear (e.g., when the binding wants to defer to
+    /// a yet-unmounted root render object that supplies its own
+    /// constraints via `RootRenderElement::mount`).
+    #[inline]
+    pub fn set_root_constraints(&mut self, constraints: Option<BoxConstraints>) {
+        self.root_constraints = constraints;
     }
 
     /// Returns a reference to the render tree.
@@ -718,14 +753,13 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
                 };
                 // Idempotent flag set — the AtomicRenderFlags fetch-or is a
                 // no-op when the bit is already set. The walk does NOT
-                // short-circuit on "already marked"; the prior mark's
-                // dirty-queue entry may have been drained by `run_layout`
-                // without clearing the flag (the current run_layout still
-                // contains the `layout_node_with_children` no-op walk that
-                // doesn't invoke `RenderEntry::layout` — once PR-A1b lands
-                // the walk rewrite, layout clears `NEEDS_LAYOUT` and the
-                // walk could short-circuit, but the always-walk shape
-                // remains correct).
+                // short-circuit on "already marked": even with U23's
+                // `run_layout` → `layout_dirty_root` wiring (which
+                // clears NEEDS_LAYOUT after each successful layout via
+                // `layout_subtree_borrowed`), a stale flag can persist
+                // briefly between phases. Always-walking preserves
+                // correctness without depending on the precise clearing
+                // schedule; idempotence keeps it cheap.
                 node.mark_layout_flag();
                 let parent = node.links().parent();
                 let boundary = node.is_relayout_boundary() || parent.is_none();
@@ -983,7 +1017,9 @@ impl PipelineOwner<Layout> {
             self.debug_doing_layout = true;
 
             // Take the dirty nodes and replace with empty vec
-            // This allows new nodes to be added during layout
+            // This allows new nodes to be added during layout (routed
+            // to mid_layout_marks per U22; drained back at end of
+            // iteration below).
             let mut dirty_nodes = std::mem::take(&mut self.dirty.needs_layout);
 
             // Sort by depth (shallow first) - parents before children
@@ -998,21 +1034,30 @@ impl PipelineOwner<Layout> {
                     .collect::<Vec<_>>()
             );
 
-            // Process each dirty node
+            // Process each dirty node.
+            //
+            // **D-block PR-A1 U23:** layout_dirty_root replaces the
+            // legacy layout_node_with_children no-op recursion. Each
+            // dirty entry is laid out via the pre-acquired-subtree
+            // walk (U20.1) protected by LayoutCycleGuard (U21).
+            // Constraints come from cached state (post-frame-1) OR
+            // the binding-set root_constraints (frame-1 root).
             for dirty_node in dirty_nodes {
-                // Layout this node with synchronous child layout support.
-                // Depth starts at 0; recursion limit enforced inside.
-                //
-                // Mythos Step 12: layout_node_with_children returns
-                // RenderResult<()>. On error we restore
-                // debug_doing_layout and bail.
-                if let Err(e) = self.layout_node_with_children(dirty_node.id, 0) {
+                let Some(constraints) = self.cached_or_root_constraints(dirty_node.id) else {
+                    tracing::warn!(
+                        id = ?dirty_node.id,
+                        "run_layout: no cached state.constraints() AND id != root_id (or \
+                         root_constraints unset); skipping layout for this dirty entry. \
+                         Caller must either set_root_constraints OR mark the node's parent \
+                         dirty so the parent's layout propagates constraints."
+                    );
+                    continue;
+                };
+                if let Err(e) = self.layout_dirty_root(dirty_node.id, constraints) {
                     self.debug_doing_layout = false;
                     // PR-A1 U22 P1 review fix (Codex 3294365736): drain
                     // mid-phase marks back into `dirty` even on error
                     // path so they survive across phase invocations.
-                    // Without this, a panic / Err mid-iteration would
-                    // strand mid-phase marks indefinitely.
                     self.drain_mid_layout_marks();
                     return Err(e);
                 }
@@ -1022,121 +1067,42 @@ impl PipelineOwner<Layout> {
 
             // PR-A1 U22 P1 review fix (Codex 3294365736): drain
             // mid_layout_marks back into `dirty` so the outer while
-            // condition `!self.dirty.needs_layout.is_empty()` picks up
-            // marks that were routed to the side queue during this
-            // iteration's `debug_doing_layout = true` window. Without
-            // this drain, mid-phase marks accumulate in
-            // `mid_layout_marks` and are never processed.
+            // condition picks up marks routed to the side queue
+            // during this iteration's `debug_doing_layout = true`
+            // window.
             self.drain_mid_layout_marks();
         }
         Ok(())
     }
 
-    /// Lays out a single node with depth-first child layout.
+    /// Returns the constraints to apply when laying out `id` as a
+    /// dirty root.
     ///
-    /// This method follows Flutter's layout model:
-    /// 1. Propagate constraints to children
-    /// 2. Layout children first (depth-first) so their sizes are available
-    /// 3. Sync child sizes to parent's ChildState
-    /// 4. Layout parent using child sizes via `layout_child()` calls
+    /// **D-block PR-A1 U23:** sourced from (in priority order):
     ///
-    /// This ensures that when parent's `perform_layout` calls `layout_child()`,
-    /// the child's size is already cached and available.
-    fn layout_node_with_children(
-        &mut self,
-        render_id: RenderId,
-        depth: usize,
-    ) -> crate::error::RenderResult<()> {
-        // Mythos Step 12: bound recursion depth to detect infinite
-        // parent-child cycles. Going past LAYOUT_DEPTH_LIMIT surfaces
-        // RenderError::LayoutDepthExceeded; the caller (run_layout)
-        // propagates the error.
-        if depth > LAYOUT_DEPTH_LIMIT {
-            tracing::error!(
-                ?render_id,
-                "layout_node_with_children: depth limit exceeded ({})",
-                LAYOUT_DEPTH_LIMIT
-            );
-            return Err(crate::error::RenderError::layout_depth_exceeded(
-                LAYOUT_DEPTH_LIMIT,
-            ));
+    /// 1. The node's cached `state.constraints()` — set on the
+    ///    previous frame's successful layout. This is the common
+    ///    case for re-layout (constraints unchanged → cache hit
+    ///    fast path inside `layout_dirty_root`).
+    /// 2. The binding-set [`Self::root_constraints`] if `id` is the
+    ///    tree root (`root_id`). Used on the very first frame
+    ///    before any layout has cached its own constraints.
+    /// 3. Otherwise `None` — caller skips this dirty entry with a
+    ///    warning (no constraints available means the parent's
+    ///    perform_layout must propagate constraints first; the
+    ///    dirty queue's shallow-first ordering ensures parents are
+    ///    processed before children).
+    fn cached_or_root_constraints(&self, id: RenderId) -> Option<BoxConstraints> {
+        if let Some(node) = self.render_tree.get(id)
+            && let Some(entry) = node.as_box()
+            && let Some(cached) = entry.state().constraints()
+        {
+            return Some(*cached);
         }
-
-        // Check if node exists and needs layout
-        let needs_layout = {
-            if let Some(render_node) = self.render_tree.get(render_id) {
-                render_node.needs_layout()
-            } else {
-                return Ok(());
-            }
-        };
-
-        if !needs_layout {
-            return Ok(());
+        if self.root_id == Some(id) {
+            return self.root_constraints;
         }
-
-        tracing::trace!(
-            "layout_node_with_children: laying out node id={:?}",
-            render_id
-        );
-
-        // STEP 1: Get children IDs and propagate constraints
-        let children: Vec<RenderId> = {
-            if let Some(render_node) = self.render_tree.get(render_id) {
-                render_node.children().to_vec()
-            } else {
-                Vec::new()
-            }
-        };
-
-        // STEP 2: Layout children FIRST (depth-first)
-        // This ensures child sizes are available when parent's perform_layout runs.
-        //
-        // Cycle 4 R-13: the previous `propagate_constraints_to_child` and
-        // `sync_child_size_to_parent` calls bracketed each recursive child
-        // walk. Both were empty-body stubs (`fn ..(_) {}`) -- no constraints
-        // propagated, no sizes synced. Workspace audit:
-        //
-        //   - `RenderEntry::layout(constraints)` is the canonical per-node
-        //     layout entry point at `storage/entry.rs:252`. It accepts the
-        //     constraints as a parameter and is the only path that runs
-        //     `RenderObject::perform_layout_raw`.
-        //   - `layout_node_with_children` itself never calls
-        //     `entry.layout_leaf_only(...)` -- it only walks the tree
-        //     marking `needs_layout` checks and recursing. The actual
-        //     per-node layout happens nowhere in production today; the
-        //     only `entry.layout_leaf_only()` callsite in the file is
-        //     inside a `#[test]` block.
-        //
-        // So both stubs were dead code embedded in a larger half-implemented
-        // walk. They were called every layout pass at zero cost (empty body)
-        // but produced no behavior; deletion is strictly subtractive.
-        //
-        // The remaining `needs_layout()` walk preserves the depth-first
-        // recursion shape so that when the per-node layout call lands, the
-        // post-order traversal is already in place. The post-order ordering
-        // is what Flutter's `performLayout` relies on so child sizes are
-        // available when the parent's `performLayout` runs -- structurally
-        // correct even though no node-level layout call exists yet.
-        for child_id in &children {
-            let child_needs_layout = {
-                if let Some(child_node) = self.render_tree.get(*child_id) {
-                    child_node.needs_layout()
-                } else {
-                    false
-                }
-            };
-
-            if child_needs_layout {
-                // Recursively layout the child (depth-first), incrementing
-                // the recursion-depth counter so LAYOUT_DEPTH_LIMIT can
-                // catch infinite cycles. Errors propagate up the
-                // recursion via `?`.
-                self.layout_node_with_children(*child_id, depth + 1)?;
-            }
-        }
-
-        Ok(())
+        None
     }
 
     /// D-block PR-A1b3 U20 — production disjoint-borrow layout walk.
@@ -2292,6 +2258,7 @@ where
         notifier: from.notifier,
         dirty: from.dirty,
         mid_layout_marks: from.mid_layout_marks,
+        root_constraints: from.root_constraints,
         debug_doing_layout: from.debug_doing_layout,
         debug_doing_paint: from.debug_doing_paint,
         debug_doing_semantics: from.debug_doing_semantics,

--- a/crates/flui-rendering/tests/u23_run_layout_wiring.rs
+++ b/crates/flui-rendering/tests/u23_run_layout_wiring.rs
@@ -1,0 +1,189 @@
+//! D-block PR-A1 U23 — `run_layout` wiring to `layout_dirty_root`.
+//!
+//! Verifies the U23 rewrite: `PipelineOwner::run_layout` now calls
+//! `layout_dirty_root` per dirty entry (using cached / root
+//! constraints from `cached_or_root_constraints`) instead of the
+//! legacy `layout_node_with_children` no-op recursion. The result
+//! is that `run_layout` actually computes geometries — previously
+//! it walked the tree but invoked no per-node layout (audit-confirmed
+//! no-op stub before U23).
+//!
+//! Refs:
+//!   * docs/plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md §U23
+//!   * docs/research/2026-05-23-d-block-architecture-decision-memo.md §D1
+
+use flui_rendering::{
+    constraints::BoxConstraints,
+    objects::{RenderColoredBox, RenderPadding},
+    pipeline::PipelineOwner,
+    traits::RenderObject,
+};
+use flui_types::{Size, geometry::px};
+
+// ============================================================================
+// run_layout actually lays out via layout_dirty_root + root_constraints
+// ============================================================================
+
+/// PR-A1 U23 happy path: `run_layout` on a freshly-inserted
+/// Padding → ColoredBox tree (no cached state) uses
+/// `root_constraints` to drive the first layout pass.
+///
+/// Pre-U23: `run_layout` walked the dirty queue + recursed via
+/// `layout_node_with_children` which never invoked
+/// `perform_layout_raw` on anyone — geometries stayed at default
+/// (`Size::ZERO`). Test would have asserted `None` geometry.
+///
+/// Post-U23: `run_layout` calls `layout_dirty_root` per dirty entry,
+/// sourcing constraints from `root_constraints`. ColoredBox lays out
+/// to its preferred size; Padding wraps it.
+#[test]
+fn u23_run_layout_uses_root_constraints_to_drive_first_frame() {
+    let mut owner = PipelineOwner::new();
+    let padding_id = owner.insert(Box::new(RenderPadding::all(5.0))
+        as Box<dyn RenderObject<flui_rendering::protocol::BoxProtocol>>);
+    let _colored = owner
+        .insert_child_render_object(padding_id, Box::new(RenderColoredBox::red(40.0, 40.0)))
+        .expect("colored child insert");
+
+    owner.set_root_id(Some(padding_id));
+    // Bind root constraints: 0..200 × 0..200 loose.
+    owner.set_root_constraints(Some(BoxConstraints::new(
+        px(0.0),
+        px(200.0),
+        px(0.0),
+        px(200.0),
+    )));
+
+    // Transition to Layout phase and run.
+    let mut owner = owner.into_layout();
+    owner
+        .run_layout()
+        .expect("first-frame run_layout must succeed");
+
+    // ColoredBox(40×40) wrapped in Padding(5) → 50×50.
+    let padding_node = owner
+        .render_tree()
+        .get(padding_id)
+        .expect("padding still in tree");
+    assert_eq!(
+        padding_node.geometry_box(),
+        Some(Size::new(px(50.0), px(50.0))),
+        "post-run_layout Padding(5) wrapping ColoredBox(40×40) must \
+         have geometry 50×50 — verifies run_layout actually invokes \
+         per-node layout via layout_dirty_root (pre-U23 this was \
+         None / Size::ZERO)",
+    );
+    assert!(
+        !padding_node.needs_layout(),
+        "padding NEEDS_LAYOUT must be cleared after run_layout",
+    );
+}
+
+// ============================================================================
+// Frame 2 — cached constraints supersede root_constraints
+// ============================================================================
+
+/// After frame 1's successful layout, every node has cached
+/// `state.constraints()`. Frame 2 re-marks dirty + calls run_layout
+/// again. `cached_or_root_constraints` returns the cached value
+/// (not root_constraints) — verifies the priority order documented
+/// on the helper.
+#[test]
+fn u23_run_layout_uses_cached_constraints_on_frame_two() {
+    let mut owner = PipelineOwner::new();
+    let padding_id = owner.insert(Box::new(RenderPadding::all(2.0))
+        as Box<dyn RenderObject<flui_rendering::protocol::BoxProtocol>>);
+    let _colored = owner
+        .insert_child_render_object(padding_id, Box::new(RenderColoredBox::blue(60.0, 30.0)))
+        .expect("colored child insert");
+
+    owner.set_root_id(Some(padding_id));
+    owner.set_root_constraints(Some(BoxConstraints::new(
+        px(0.0),
+        px(300.0),
+        px(0.0),
+        px(300.0),
+    )));
+
+    // Frame 1.
+    let mut owner = owner.into_layout();
+    owner.run_layout().expect("frame 1");
+    let frame_1_size = owner
+        .render_tree()
+        .get(padding_id)
+        .and_then(|n| n.geometry_box());
+    assert_eq!(frame_1_size, Some(Size::new(px(64.0), px(34.0))));
+
+    // Clear root_constraints to prove frame 2 doesn't depend on it.
+    let mut owner = owner.into_idle();
+    owner.set_root_constraints(None);
+
+    // Mark dirty to trigger frame 2 re-layout.
+    owner.mark_needs_layout(padding_id);
+    let mut owner = owner.into_layout();
+    owner
+        .run_layout()
+        .expect("frame 2 must succeed using cached constraints");
+
+    let frame_2_size = owner
+        .render_tree()
+        .get(padding_id)
+        .and_then(|n| n.geometry_box());
+    assert_eq!(
+        frame_2_size, frame_1_size,
+        "frame 2 must produce the same geometry as frame 1 — \
+         cached_or_root_constraints picked up state.constraints() \
+         (root_constraints was cleared between frames)",
+    );
+}
+
+// ============================================================================
+// No constraints + non-root id — skip with warning, no Err
+// ============================================================================
+
+/// A dirty entry that's NOT the root AND has no cached constraints
+/// (impossible in practice — non-root nodes get constraints from
+/// their parent's perform_layout) skips with `tracing::warn!`. Test
+/// verifies `run_layout` returns `Ok(())` instead of erroring.
+#[test]
+fn u23_run_layout_skips_dirty_entry_with_no_constraints() {
+    let mut owner = PipelineOwner::new();
+    let padding_id = owner.insert(Box::new(RenderPadding::all(5.0))
+        as Box<dyn RenderObject<flui_rendering::protocol::BoxProtocol>>);
+    // Note: NOT set as root. NO root_constraints set.
+    // Dirty queue has padding_id (from insert) but cached_or_root_constraints
+    // returns None.
+
+    let mut owner = owner.into_layout();
+    owner.run_layout().expect(
+        "run_layout must not fail when a dirty entry has no constraints — \
+         skips with warning and continues",
+    );
+
+    // No geometry computed (skipped).
+    assert!(
+        owner
+            .render_tree()
+            .get(padding_id)
+            .and_then(|n| n.geometry_box())
+            .is_none(),
+        "skipped entry must NOT have geometry computed",
+    );
+}
+
+// ============================================================================
+// root_constraints get/set round-trip
+// ============================================================================
+
+#[test]
+fn u23_root_constraints_setter_round_trip() {
+    let mut owner = PipelineOwner::new();
+    assert_eq!(owner.root_constraints(), None);
+
+    let c = BoxConstraints::tight(Size::new(px(100.0), px(100.0)));
+    owner.set_root_constraints(Some(c));
+    assert_eq!(owner.root_constraints(), Some(c));
+
+    owner.set_root_constraints(None);
+    assert_eq!(owner.root_constraints(), None);
+}

--- a/crates/flui-rendering/tests/u23_run_layout_wiring.rs
+++ b/crates/flui-rendering/tests/u23_run_layout_wiring.rs
@@ -187,3 +187,98 @@ fn u23_root_constraints_setter_round_trip() {
     owner.set_root_constraints(None);
     assert_eq!(owner.root_constraints(), None);
 }
+
+// ============================================================================
+// PR-A1 U23 P2 review fixes — Copilot 3294417924/3294417942/3294417957
+// ============================================================================
+
+/// PR #148 Copilot review (comment_id=3294417957): setting
+/// `root_constraints` should auto-mark the root dirty so the next
+/// `run_layout` invocation picks up the change. Pre-fix the binding
+/// had to call `mark_needs_layout(root_id)` separately — silent
+/// no-relayout footgun.
+#[test]
+fn u23_set_root_constraints_auto_marks_root_dirty() {
+    let mut owner = PipelineOwner::new();
+    let padding_id = owner.insert(Box::new(RenderPadding::all(5.0))
+        as Box<dyn RenderObject<flui_rendering::protocol::BoxProtocol>>);
+    owner.set_root_id(Some(padding_id));
+    owner.clear_all_dirty_nodes();
+
+    assert!(!owner.has_dirty_nodes());
+
+    // Setting root_constraints to Some(_) auto-marks root dirty.
+    let c = BoxConstraints::tight(Size::new(px(100.0), px(100.0)));
+    owner.set_root_constraints(Some(c));
+    assert!(
+        owner.has_dirty_nodes(),
+        "set_root_constraints(Some(_)) must auto-mark root dirty for next run_layout",
+    );
+
+    // Idempotent: setting to the SAME value does not re-mark dirty.
+    owner.clear_all_dirty_nodes();
+    owner.set_root_constraints(Some(c));
+    assert!(
+        !owner.has_dirty_nodes(),
+        "set_root_constraints with same value must NOT re-mark dirty (idempotent)",
+    );
+
+    // Setting to None does NOT mark dirty (explicit clear).
+    owner.set_root_constraints(None);
+    assert!(
+        !owner.has_dirty_nodes(),
+        "set_root_constraints(None) must NOT mark dirty (explicit clear)",
+    );
+}
+
+/// PR #148 Copilot review (comment_id=3294417924): `run_layout` must
+/// skip dirty-queue entries whose `NEEDS_LAYOUT` flag was already
+/// cleared earlier in the iteration (e.g., parent's layout_child
+/// callback already laid out the child).
+///
+/// Verifies via insert_child_render_object which enqueues both parent
+/// and child. After run_layout:
+/// 1. Parent processed first (shallow-first sort) → layout_dirty_root
+///    invokes Padding's perform_layout → calls ctx.layout_child(0, c)
+///    for the child → child's needs_layout is cleared via
+///    layout_subtree_borrowed's success path.
+/// 2. Child's dirty entry was queued separately by insert_child;
+///    run_layout's iteration encounters it next; needs_layout()
+///    returns false → skipped.
+#[test]
+fn u23_run_layout_skips_already_cleaned_dirty_entries() {
+    let mut owner = PipelineOwner::new();
+    let padding_id = owner.insert(Box::new(RenderPadding::all(5.0))
+        as Box<dyn RenderObject<flui_rendering::protocol::BoxProtocol>>);
+    let _child_id = owner
+        .insert_child_render_object(padding_id, Box::new(RenderColoredBox::red(40.0, 40.0)))
+        .expect("child insert");
+
+    owner.set_root_id(Some(padding_id));
+    owner.set_root_constraints(Some(BoxConstraints::new(
+        px(0.0),
+        px(200.0),
+        px(0.0),
+        px(200.0),
+    )));
+
+    let mut owner = owner.into_layout();
+    // Pre-fix: both parent + child entries get layout_dirty_root invoked.
+    //   Parent's layout calls layout_child → recurses into child →
+    //   child laid out. Then run_layout dequeues child's separate
+    //   entry → layout_dirty_root invoked AGAIN on child → redundant
+    //   perform_layout invocation (potentially side-effectful).
+    // Post-fix: child's separate entry's needs_layout() = false →
+    //   skipped via trace log; no redundant invocation.
+    owner.run_layout().expect("run_layout must succeed");
+
+    // Both nodes laid out (geometry set).
+    let padding_geom = owner
+        .render_tree()
+        .get(padding_id)
+        .and_then(|n| n.geometry_box());
+    assert_eq!(padding_geom, Some(Size::new(px(50.0), px(50.0))));
+    // No way to count perform_layout invocations from integration test,
+    // but the skip path is exercised (covered by lib-scoped test if
+    // we wanted to assert the trace! event explicitly).
+}


### PR DESCRIPTION
# PR-A1 U23 — Wire `run_layout` to `layout_dirty_root`

Follow-up to [PR #147](https://github.com/vanyastaff/flui/pull/147) (U22 dirty-queue dedup). Implements U23 per plan + memo D1. **`run_layout` now actually computes geometries** — the legacy `layout_node_with_children` was a no-op recursion that walked the dirty tree without invoking per-node layout (audit-confirmed pre-U23).

## What this PR adds

1. **`root_constraints: Option<BoxConstraints>` field** + `set_root_constraints`/`root_constraints` accessor. Binding layer sets this once per configuration before first `run_frame`.

2. **`cached_or_root_constraints(id)` helper**:
   - Cached `state.constraints()` if present (common case post-frame-1)
   - `root_constraints` if `id` is root and cached is `None` (first frame)
   - `None` otherwise (skip with warning — parent must propagate constraints first)

3. **`run_layout` rewrite** — outer `while` loop iterates `dirty_nodes` (shallow-first sort retained); for each entry calls `layout_dirty_root` with resolved constraints. `Err` propagates with `mid_layout_marks` drain for next-frame retry. Missing-constraints entries skip with `tracing::warn!` rather than failing.

## Deletions

- **`layout_node_with_children`** (110 lines) — legacy no-op recursion that walked the tree but invoked no per-node layout. Replaced by `layout_dirty_root` per memo D1.
- **`LAYOUT_DEPTH_LIMIT` constant** — depth protection now via `LayoutCycleGuard` (U21) which detects re-entry instead of capping arbitrary depth.
- **Stale `layout_node_with_children` comment** in `mark_needs_layout`.

## Test scope

[`crates/flui-rendering/tests/u23_run_layout_wiring.rs`](crates/flui-rendering/tests/u23_run_layout_wiring.rs) — 4 new tests:

- `u23_run_layout_uses_root_constraints_to_drive_first_frame` — Padding(5)+ColoredBox(40x40) with `root_constraints` set produces 50x50. Pre-U23 would have stayed `None`/`Size::ZERO` (legacy walk no-op).
- `u23_run_layout_uses_cached_constraints_on_frame_two` — frame 1 caches constraints; frame 2 reuses cache even when `root_constraints` cleared between frames.
- `u23_run_layout_skips_dirty_entry_with_no_constraints` — dirty entry that's neither root nor cached skips with warning; `run_layout` returns `Ok`.
- `u23_root_constraints_setter_round_trip` — accessor smoke.

## Verification

```
cargo clippy --workspace --all-targets -- -D warnings             # clean
cargo test -p flui-rendering --lib                                # 281 passed
cargo test -p flui-rendering --test u20_layout_dirty_root         # 11 passed (no regression)
cargo test -p flui-rendering --test u21_layout_cycle              # 4 passed (no regression)
cargo test -p flui-rendering --test u22_dirty_dedup               # 8 passed (no regression)
cargo test -p flui-rendering --test u23_run_layout_wiring         # 4 passed (new)
RUSTDOCFLAGS=-D warnings cargo doc -p flui-rendering --no-deps    # clean
bash scripts/port-check.sh -v                                     # all 7 + FR-033 + FR-036 clean
```

## D-block PR-A1 status

| Unit | PR | Status |
|------|-----|--------|
| U14-U17 (prep) | #139 | merged |
| U18 (erasure enums) | #140 | merged |
| U19 (typed bridge) | #141 | merged |
| Option A (Result) | #143 | merged |
| U20 (disjoint walk) | #144 | merged |
| U20.1 (Miri-clean) | #145 | merged |
| U21 (cycle guard) | #146 | merged |
| U22 (dirty dedup) | #147 | merged |
| **U23 (run_layout wiring)** | **this PR** | — |
| U24-U31 (AE tests) | TBD | — |
| PR-A2 (D-3/D-4) | TBD | — |
| PR-C-3 (refusal triggers) | TBD | — |

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — internal rendering pipeline change. The binding layer needs to call `set_root_constraints` once before first `run_frame` (otherwise the root's first dirty entry skips with warning). Tests are the validation surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
