### PR TITLE
feat: PR-C-3 — refusal trigger backfill #8/#10/#11/#12/#13 (U41-U47)

### DIFF
--- a/crates/flui-animation/src/ext.rs
+++ b/crates/flui-animation/src/ext.rs
@@ -40,7 +40,7 @@ use std::sync::Arc;
 ///
 /// assert_eq!(animation.value(), 0.0);
 /// ```
-pub trait AnimatableExt<T>: Animatable<T> + Clone + Send + Sync + 'static
+pub trait AnimatableExt<T>: Animatable<T> + Clone + Send + Sync + 'static // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 where
     T: Clone + Send + Sync + fmt::Debug + 'static,
 {

--- a/crates/flui-animation/src/simulation.rs
+++ b/crates/flui-animation/src/simulation.rs
@@ -28,7 +28,7 @@ use std::f32::consts::PI;
 /// Specifies maximum allowable magnitudes for distances and velocities
 /// to be considered at rest.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Tolerance {
+pub struct Tolerance { // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Maximum distance from target to be considered "at rest".
     pub distance: f32,
     /// Maximum velocity to be considered "at rest".
@@ -69,7 +69,7 @@ impl Default for Tolerance {
 /// - Position via [`x()`](Simulation::x)
 /// - Velocity via [`dx()`](Simulation::dx)
 /// - Completion state via [`is_done()`](Simulation::is_done)
-pub trait Simulation: Send + Sync {
+pub trait Simulation: Send + Sync { // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The position of the object at the given time.
     fn x(&self, time: f32) -> f32;
 
@@ -90,7 +90,7 @@ pub trait Simulation: Send + Sync {
 ///
 /// Used to configure [`SpringSimulation`].
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct SpringDescription {
+pub struct SpringDescription { // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The mass of the spring (m).
     pub mass: f32,
     /// The spring constant / stiffness (k).
@@ -201,7 +201,7 @@ impl SpringDescription {
 
 /// The type of spring behavior.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum SpringType {
+pub enum SpringType { // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// A spring that does not bounce and returns to rest in the shortest time.
     CriticallyDamped,
     /// A spring that bounces (oscillates) before settling.
@@ -214,7 +214,7 @@ pub enum SpringType {
 ///
 /// Models a particle attached to a spring following Hooke's law.
 #[derive(Debug, Clone)]
-pub struct SpringSimulation {
+pub struct SpringSimulation { // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     end_position: f32,
     solution: SpringSolution,
     tolerance: Tolerance,
@@ -458,7 +458,7 @@ fn near_zero(value: f32, threshold: f32) -> bool {
 
 /// A friction simulation that slows an object by a constant deceleration.
 #[derive(Debug, Clone)]
-pub struct FrictionSimulation {
+pub struct FrictionSimulation { // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     drag: f32,
     drag_log: f32,
     initial_position: f32,
@@ -551,7 +551,7 @@ impl Simulation for FrictionSimulation {
 
 /// A gravity simulation with constant acceleration.
 #[derive(Debug, Clone)]
-pub struct GravitySimulation {
+pub struct GravitySimulation { // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     acceleration: f32,
     initial_position: f32,
     initial_velocity: f32,

--- a/crates/flui-animation/src/tween_types.rs
+++ b/crates/flui-animation/src/tween_types.rs
@@ -846,7 +846,7 @@ where
 /// let curved = tween.with_curve(Curves::EaseIn);
 /// assert!(curved.transform(0.5) < 50.0);
 /// ```
-pub trait AnimatableExt<T>: Animatable<T> + Sized {
+pub trait AnimatableExt<T>: Animatable<T> + Sized { // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Returns a reversed version of this animatable.
     ///
     /// The reversed animatable transforms `t` to `1.0 - t` before passing

--- a/crates/flui-app/src/app/binding.rs
+++ b/crates/flui-app/src/app/binding.rs
@@ -158,11 +158,13 @@ impl AppBinding {
 
     /// Get read access to RendererBinding.
     pub fn renderer(&self) -> parking_lot::RwLockReadGuard<'_, RenderingFlutterBinding> {
+        // PORT-CHECK-OK-SP6: AppBinding renderer accessor; pre-existing SP-6
         self.renderer.read()
     }
 
     /// Get write access to RendererBinding.
     pub fn renderer_mut(&self) -> parking_lot::RwLockWriteGuard<'_, RenderingFlutterBinding> {
+        // PORT-CHECK-OK-SP6: AppBinding renderer_mut accessor; pre-existing SP-6
         self.renderer.write()
     }
 
@@ -199,11 +201,13 @@ impl AppBinding {
 
     /// Get read access to WidgetsBinding.
     pub fn widgets(&self) -> parking_lot::RwLockReadGuard<'_, WidgetsBinding> {
+        // PORT-CHECK-OK-SP6: AppBinding widgets accessor; pre-existing SP-6
         self.widgets.read()
     }
 
     /// Get write access to WidgetsBinding.
     pub fn widgets_mut(&self) -> parking_lot::RwLockWriteGuard<'_, WidgetsBinding> {
+        // PORT-CHECK-OK-SP6: AppBinding widgets_mut accessor; pre-existing SP-6
         self.widgets.write()
     }
 
@@ -263,6 +267,7 @@ impl AppBinding {
     /// This is used by RootRenderElement to insert RenderObjects into the tree.
     /// Elements need `Arc<RwLock<PipelineOwner>>` for concurrent access.
     pub fn render_pipeline_arc(&self) -> Arc<RwLock<flui_rendering::pipeline::PipelineOwner>> {
+        // PORT-CHECK-OK-SP6: AppBinding render_pipeline_arc accessor; pre-existing SP-6
         Arc::clone(&self.shared_pipeline_owner)
     }
 

--- a/crates/flui-app/src/app/config.rs
+++ b/crates/flui-app/src/app/config.rs
@@ -16,6 +16,7 @@ use flui_types::{Size, geometry::px};
 /// ```
 #[derive(Debug, Clone)]
 pub struct AppConfig {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Window title.
     pub title: String,
 

--- a/crates/flui-app/src/lib.rs
+++ b/crates/flui-app/src/lib.rs
@@ -37,9 +37,9 @@
 // Modules
 pub mod app;
 pub mod bindings;
-pub mod embedder;
-pub mod overlay;
-pub mod theme;
+pub mod embedder; // PORT-CHECK-OK-SP4: embedder API surface; binding entry for app integrators
+pub mod overlay; // PORT-CHECK-OK-SP4: overlay API surface; binding entry for app integrators
+pub mod theme; // PORT-CHECK-OK-SP4: theme API surface; binding entry for app integrators
 
 // Primary exports - Flutter naming
 // Legacy alias

--- a/crates/flui-assets/src/assets/font.rs
+++ b/crates/flui-assets/src/assets/font.rs
@@ -26,6 +26,7 @@ use crate::types::AssetKey;
 /// ```
 #[derive(Debug, Clone)]
 pub struct FontAsset {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Source path or identifier
     path: String,
 

--- a/crates/flui-assets/src/cache/mod.rs
+++ b/crates/flui-assets/src/cache/mod.rs
@@ -248,7 +248,7 @@ pub mod sealed {
     use super::*;
 
     /// Sealed trait to prevent external implementations of AssetCacheCore.
-    pub trait Sealed {}
+    pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
     impl<T: Asset> Sealed for AssetCache<T> {}
     impl<T: Asset> Sealed for &AssetCache<T> {}

--- a/crates/flui-assets/src/types/handle.rs
+++ b/crates/flui-assets/src/types/handle.rs
@@ -282,7 +282,7 @@ pub mod sealed {
     ///
     /// This ensures only types in this crate can implement AssetHandleCore,
     /// allowing us to add methods to AssetHandleExt without breaking changes.
-    pub trait Sealed {}
+    pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
     impl<T, K> Sealed for AssetHandle<T, K> {}
     impl<T, K> Sealed for &AssetHandle<T, K> {}

--- a/crates/flui-build/src/platform.rs
+++ b/crates/flui-build/src/platform.rs
@@ -8,7 +8,7 @@ use crate::error::{BuildError, BuildResult};
 /// allowing us to add methods to the trait in the future without
 /// breaking changes.
 pub(crate) mod private {
-    pub trait Sealed {}
+    pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 }
 
 /// Build context containing configuration and paths.
@@ -31,7 +31,7 @@ pub struct BuilderContext {
 
 /// Platform to build for
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Platform {
+pub enum Platform { // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Android platform with target architectures
     Android {
         /// Target architectures (e.g., "aarch64-linux-android")

--- a/crates/flui-cli/src/config.rs
+++ b/crates/flui-cli/src/config.rs
@@ -137,7 +137,7 @@ impl FluiConfig {
 
 /// Application metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AppConfig {
+pub struct AppConfig { // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Application name (used as crate name).
     pub name: String,
     /// Application version (semver).
@@ -235,7 +235,7 @@ pub struct FontFamily {
 
 /// Individual font asset.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct FontAsset {
+pub struct FontAsset { // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Path to font file.
     pub asset: String,
     /// Font weight (100-900).
@@ -386,7 +386,7 @@ impl Default for GlobalBuildConfig {
 
 /// `DevTools` configuration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DevToolsConfig {
+pub struct DevToolsConfig { // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Default port for `DevTools` server.
     #[serde(default = "default_devtools_port")]
     pub port: u16,

--- a/crates/flui-cli/src/error.rs
+++ b/crates/flui-cli/src/error.rs
@@ -346,7 +346,7 @@ impl CliError {
 ///         .context("Failed to read configuration file")
 /// }
 /// ```
-pub trait ResultExt<T> {
+pub trait ResultExt<T> { // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Add context to an error result.
     ///
     /// Converts any error into a `CliError::WithContext` with the given message.

--- a/crates/flui-cli/src/main.rs
+++ b/crates/flui-cli/src/main.rs
@@ -380,7 +380,7 @@ impl Template {
 
 /// Target platforms for FLUI applications.
 #[derive(Clone, Copy, ValueEnum, Debug, PartialEq, Eq, Hash)]
-pub enum Platform {
+pub enum Platform { // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Microsoft Windows
     Windows,
     /// Linux distributions

--- a/crates/flui-devtools/src/common.rs
+++ b/crates/flui-devtools/src/common.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 /// DevTools configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DevToolsConfig {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Enable performance profiling
     pub profiling_enabled: bool,
 

--- a/crates/flui-devtools/src/profiler.rs
+++ b/crates/flui-devtools/src/profiler.rs
@@ -56,6 +56,7 @@ use crate::common::DevToolsConfig;
 /// Frame rendering phase
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FramePhase {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Widget tree build phase
     Build,
     /// Layout computation phase

--- a/crates/flui-foundation/src/lib.rs
+++ b/crates/flui-foundation/src/lib.rs
@@ -135,7 +135,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Core modules - fundamental types with minimal dependencies
-pub mod assert;
+pub mod assert; // PORT-CHECK-OK-SP4: assert API surface; consumed via flui_foundation::assert! macro re-export
 pub mod binding;
 pub mod callbacks;
 pub mod consts;

--- a/crates/flui-geometry/src/length.rs
+++ b/crates/flui-geometry/src/length.rs
@@ -422,7 +422,7 @@ impl<'a> std::iter::Sum<&'a Rems> for Rems {
 /// Percentage value (0.0 = 0%, 1.0 = 100%).
 #[derive(Copy, Clone, Default, PartialEq)]
 #[repr(transparent)]
-pub struct Percentage(pub f32);
+pub struct Percentage(pub f32); // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
 impl Percentage {
     /// Zero percent.

--- a/crates/flui-geometry/src/lib.rs
+++ b/crates/flui-geometry/src/lib.rs
@@ -135,7 +135,7 @@ pub mod size;
 pub mod text_path;
 pub mod traits;
 pub mod transform;
-pub mod transform2d;
+pub mod transform2d; // PORT-CHECK-OK-SP4: transform2d API surface; consumed via flui_types::geometry re-export chain
 pub mod units;
 pub mod vector;
 

--- a/crates/flui-geometry/src/traits.rs
+++ b/crates/flui-geometry/src/traits.rs
@@ -17,6 +17,7 @@ use super::{DevicePixels, PixelDelta, Pixels, Radians, Rems, ScaledPixels};
 /// The two axes of a 2D cartesian coordinate system.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Axis {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The vertical axis (y, up and down).
     Vertical,
     /// The horizontal axis (x, left and right).

--- a/crates/flui-hot-reload/src/lib.rs
+++ b/crates/flui-hot-reload/src/lib.rs
@@ -83,7 +83,7 @@ pub use pipeline::PluginPipeline;
 
 // Dynamic library loading is not available on wasm32
 #[cfg(not(target_arch = "wasm32"))]
-pub mod dynlib;
+pub mod dynlib; // PORT-CHECK-OK-SP4: dynlib API surface; binding entry for hot-reload integrators
 
 #[cfg(not(target_arch = "wasm32"))]
 mod driver;

--- a/crates/flui-interaction/src/recognizers/drag.rs
+++ b/crates/flui-interaction/src/recognizers/drag.rs
@@ -29,6 +29,7 @@ use crate::{
 /// Drag axis constraint
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DragAxis {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Vertical drag only (up/down)
     Vertical,
     /// Horizontal drag only (left/right)
@@ -40,6 +41,7 @@ pub enum DragAxis {
 /// Details about drag down (pointer contact before drag starts)
 #[derive(Debug, Clone, PartialEq)]
 pub struct DragDownDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Global position where pointer contacted the screen
     pub global_position: Offset<Pixels>,
     /// Local position (relative to widget)
@@ -51,6 +53,7 @@ pub struct DragDownDetails {
 /// Details about drag start
 #[derive(Debug, Clone)]
 pub struct DragStartDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Global position where drag started
     pub global_position: Offset<Pixels>,
     /// Local position (relative to widget)
@@ -64,6 +67,7 @@ pub struct DragStartDetails {
 /// Details about drag update
 #[derive(Debug, Clone, PartialEq)]
 pub struct DragUpdateDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Current global position
     pub global_position: Offset<Pixels>,
     /// Current local position
@@ -79,6 +83,7 @@ pub struct DragUpdateDetails {
 /// Details about drag end
 #[derive(Debug, Clone, PartialEq)]
 pub struct DragEndDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Velocity at end of drag (pixels per second)
     pub velocity: Velocity,
     /// Final global position

--- a/crates/flui-interaction/src/recognizers/long_press.rs
+++ b/crates/flui-interaction/src/recognizers/long_press.rs
@@ -42,6 +42,7 @@ pub type LongPressCallback = Arc<dyn Fn(LongPressDetails) + Send + Sync>;
 /// Details about long press down (initial contact)
 #[derive(Debug, Clone, PartialEq)]
 pub struct LongPressDownDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Global position where pointer contacted screen
     pub global_position: Offset<Pixels>,
     /// Local position (relative to widget)
@@ -53,6 +54,7 @@ pub struct LongPressDownDetails {
 /// Details about long press start
 #[derive(Debug, Clone, PartialEq)]
 pub struct LongPressStartDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Global position where long press started
     pub global_position: Offset<Pixels>,
     /// Local position (relative to widget)

--- a/crates/flui-interaction/src/recognizers/scale.rs
+++ b/crates/flui-interaction/src/recognizers/scale.rs
@@ -34,6 +34,7 @@ pub type ScaleCancelCallback = Arc<dyn Fn() + Send + Sync>;
 /// Details about scale gesture start
 #[derive(Debug, Clone, PartialEq)]
 pub struct ScaleStartDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Focal point (center between pointers) in global coordinates
     pub focal_point: Offset<Pixels>,
     /// Focal point in local coordinates
@@ -45,6 +46,7 @@ pub struct ScaleStartDetails {
 /// Details about scale gesture update
 #[derive(Debug, Clone, PartialEq)]
 pub struct ScaleUpdateDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Focal point (center between pointers) in global coordinates
     pub focal_point: Offset<Pixels>,
     /// Focal point in local coordinates
@@ -64,6 +66,7 @@ pub struct ScaleUpdateDetails {
 /// Details about scale gesture end
 #[derive(Debug, Clone, PartialEq)]
 pub struct ScaleEndDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Final focal point
     pub focal_point: Offset<Pixels>,
     /// Final scale factor

--- a/crates/flui-interaction/src/sealed.rs
+++ b/crates/flui-interaction/src/sealed.rs
@@ -163,7 +163,7 @@ pub trait CustomHitTestable: Send + Sync {
 ///
 /// **Do not implement directly.** Instead, implement [`CustomHitTestable`].
 pub mod hit_testable {
-    pub trait Sealed {}
+    pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
     // Blanket impl: any CustomHitTestable automatically gets Sealed
     impl<T: super::CustomHitTestable> Sealed for T {}
@@ -178,7 +178,7 @@ pub mod hit_testable {
 /// **Do not implement directly.** Instead, implement
 /// [`CustomGestureRecognizer`].
 pub mod gesture_recognizer {
-    pub trait Sealed {}
+    pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
     // Blanket impl: any CustomGestureRecognizer automatically gets Sealed
     impl<T: super::CustomGestureRecognizer> Sealed for T {}
@@ -200,7 +200,7 @@ pub mod gesture_recognizer {
 /// **Do not implement directly.** Instead, implement
 /// [`CustomGestureRecognizer`].
 pub mod arena_member {
-    pub trait Sealed {}
+    pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
     // Blanket impl: any CustomGestureRecognizer automatically gets Sealed
     impl<T: super::CustomGestureRecognizer> Sealed for T {}
@@ -219,5 +219,5 @@ pub mod arena_member {
 ///
 /// This restricts which types can receive keyboard focus.
 pub mod focus_node {
-    pub trait Sealed {}
+    pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 }

--- a/crates/flui-interaction/src/traits.rs
+++ b/crates/flui-interaction/src/traits.rs
@@ -177,6 +177,7 @@ pub trait GestureRecognizerExt {
 /// Drag axis constraint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum DragAxis {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Vertical drag only (up/down).
     Vertical,
     /// Horizontal drag only (left/right).

--- a/crates/flui-painting/src/display_list/sealed.rs
+++ b/crates/flui-painting/src/display_list/sealed.rs
@@ -42,7 +42,7 @@ use crate::display_list::DisplayList;
 pub mod private {
     /// Sealed trait to prevent external implementations of
     /// `DisplayListCore`.
-    pub trait Sealed {}
+    pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 }
 
 /// Core `DisplayList` API providing fundamental access methods.

--- a/crates/flui-painting/src/text_painter/baseline.rs
+++ b/crates/flui-painting/src/text_painter/baseline.rs
@@ -24,6 +24,7 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TextBaseline {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The alphabetic baseline (bottom of letters like 'x').
     #[default]
     Alphabetic,

--- a/crates/flui-platform/src/lib.rs
+++ b/crates/flui-platform/src/lib.rs
@@ -156,7 +156,7 @@ pub mod platforms;
 pub mod shared;
 pub mod task;
 pub mod traits;
-pub mod window;
+pub mod window; // PORT-CHECK-OK-SP4: window API surface; binding entry for platform integrators
 
 // Re-export configuration types
 // ==================== Platform Detection ====================

--- a/crates/flui-platform/src/platforms/macos/platform.rs
+++ b/crates/flui-platform/src/platforms/macos/platform.rs
@@ -162,7 +162,7 @@ impl Platform for MacOSPlatform {
 
     fn capabilities(&self) -> &dyn PlatformCapabilities {
         // TODO: Return macOS capabilities
-        unimplemented!("macOS capabilities not yet implemented")
+        unimplemented!("macOS capabilities not yet implemented") // PORT-CHECK-OK-STUB: macOS platform-init deferred to Core.0 → Core.1 native-platform track (ROADMAP.md)
     }
 
     fn name(&self) -> &'static str {

--- a/crates/flui-platform/src/platforms/macos/window_manager.rs
+++ b/crates/flui-platform/src/platforms/macos/window_manager.rs
@@ -245,7 +245,7 @@ impl Default for WindowManager {
 
 /// Unique identifier for a window.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct WindowId(pub u64);
+pub struct WindowId(pub u64); // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
 impl WindowId {
     /// Create a new window ID (for testing).
@@ -324,6 +324,7 @@ pub struct WindowInfo {
 /// Options for creating a new window.
 #[derive(Debug, Clone)]
 pub struct WindowOptions {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Window title.
     pub title: String,
 

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -36,7 +36,7 @@ pub(super) struct WindowContext {
     /// Window ID for event dispatch
     pub window_id: WindowId,
     /// Reference to platform handlers (global)
-    pub handlers: Arc<Mutex<PlatformHandlers>>,
+    pub handlers: Arc<Mutex<PlatformHandlers>>, // PORT-CHECK-OK-SP6: WindowsPlatform handlers Arc<Mutex<>>; mirrors PlatformHandlers callback storage; pre-existing SP-6
     /// Per-window callbacks for event delivery
     pub callbacks: Arc<WindowCallbacks>,
     /// Scale factor for coordinate conversion

--- a/crates/flui-platform/src/shared/handlers.rs
+++ b/crates/flui-platform/src/shared/handlers.rs
@@ -137,34 +137,34 @@ pub struct WindowCallbacks {
     /// Called when an input event (pointer, keyboard) is delivered to this
     /// window. Returns `DispatchEventResult` indicating if the event was
     /// consumed.
-    pub on_input: Mutex<Option<Box<dyn FnMut(PlatformInput) -> DispatchEventResult + Send>>>,
+    pub on_input: Mutex<Option<Box<dyn FnMut(PlatformInput) -> DispatchEventResult + Send>>>, // PORT-CHECK-OK-SP6: PlatformHandlers callback storage; FR-029 #5 sanctioned; SP-6 lock-placement tracked
 
     /// Called when the platform requests a new frame to be rendered.
-    pub on_request_frame: Mutex<Option<Box<dyn FnMut() + Send>>>,
+    pub on_request_frame: Mutex<Option<Box<dyn FnMut() + Send>>>, // PORT-CHECK-OK-SP6: PlatformHandlers callback storage; FR-029 #5 sanctioned; SP-6 lock-placement tracked
 
     /// Called when the window is resized. Parameters: new size (logical), scale
     /// factor.
-    pub on_resize: Mutex<Option<Box<dyn FnMut(Size<Pixels>, f32) + Send>>>,
+    pub on_resize: Mutex<Option<Box<dyn FnMut(Size<Pixels>, f32) + Send>>>, // PORT-CHECK-OK-SP6: PlatformHandlers callback storage; FR-029 #5 sanctioned; SP-6 lock-placement tracked
 
     /// Called when the window is moved.
-    pub on_moved: Mutex<Option<Box<dyn FnMut() + Send>>>,
+    pub on_moved: Mutex<Option<Box<dyn FnMut() + Send>>>, // PORT-CHECK-OK-SP6: PlatformHandlers callback storage; FR-029 #5 sanctioned; SP-6 lock-placement tracked
 
     /// Called when the window is about to be destroyed. Only fires once
     /// (FnOnce).
-    pub on_close: Mutex<Option<Box<dyn FnOnce() + Send>>>,
+    pub on_close: Mutex<Option<Box<dyn FnOnce() + Send>>>, // PORT-CHECK-OK-SP6: PlatformHandlers callback storage; FR-029 #5 sanctioned; SP-6 lock-placement tracked
 
     /// Called to ask if the window should close. Return `false` to veto.
-    pub on_should_close: Mutex<Option<Box<dyn FnMut() -> bool + Send>>>,
+    pub on_should_close: Mutex<Option<Box<dyn FnMut() -> bool + Send>>>, // PORT-CHECK-OK-SP6: PlatformHandlers callback storage; FR-029 #5 sanctioned; SP-6 lock-placement tracked
 
     /// Called when the window gains or loses focus. Parameter: is_active.
-    pub on_active_status_change: Mutex<Option<Box<dyn FnMut(bool) + Send>>>,
+    pub on_active_status_change: Mutex<Option<Box<dyn FnMut(bool) + Send>>>, // PORT-CHECK-OK-SP6: PlatformHandlers callback storage; FR-029 #5 sanctioned; SP-6 lock-placement tracked
 
     /// Called when the mouse enters or leaves the window. Parameter:
     /// is_hovered.
-    pub on_hover_status_change: Mutex<Option<Box<dyn FnMut(bool) + Send>>>,
+    pub on_hover_status_change: Mutex<Option<Box<dyn FnMut(bool) + Send>>>, // PORT-CHECK-OK-SP6: PlatformHandlers callback storage; FR-029 #5 sanctioned; SP-6 lock-placement tracked
 
     /// Called when the system appearance (light/dark) changes.
-    pub on_appearance_changed: Mutex<Option<Box<dyn FnMut() + Send>>>,
+    pub on_appearance_changed: Mutex<Option<Box<dyn FnMut() + Send>>>, // PORT-CHECK-OK-SP6: PlatformHandlers callback storage; FR-029 #5 sanctioned; SP-6 lock-placement tracked
 }
 
 impl WindowCallbacks {

--- a/crates/flui-platform/src/task.rs
+++ b/crates/flui-platform/src/task.rs
@@ -28,6 +28,7 @@ use std::{
 /// dispatching (e.g., Windows ThreadPool, macOS GCD) is planned for post-MVP.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum Priority {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// High priority — UI-blocking operations, user input handling
     High,
     /// Medium priority — default for most operations
@@ -70,7 +71,7 @@ impl std::fmt::Display for TaskLabel {
 /// executor.spawn(async { log_analytics() }).detach();
 /// ```
 #[must_use = "tasks are cancelled when dropped; use `.detach()` to run in background"]
-pub struct Task<T>(TaskState<T>);
+pub struct Task<T>(TaskState<T>); // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
 enum TaskState<T> {
     /// Task completed synchronously — value available immediately

--- a/crates/flui-platform/src/traits/platform.rs
+++ b/crates/flui-platform/src/traits/platform.rs
@@ -18,6 +18,7 @@ use crate::{cursor::CursorStyle, task::Task};
 /// Window creation options
 #[derive(Debug, Clone)]
 pub struct WindowOptions {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Window title
     pub title: String,
     /// Initial window size (logical pixels)
@@ -133,7 +134,7 @@ impl WindowMode {
 
 /// Window identifier
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct WindowId(pub u64);
+pub struct WindowId(pub u64); // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
 /// Core platform abstraction trait
 ///

--- a/crates/flui-platform/src/window.rs
+++ b/crates/flui-platform/src/window.rs
@@ -205,7 +205,7 @@ pub trait Window {
 /// This ID is unique within the application and persists for the window's
 /// lifetime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct WindowId(pub u64);
+pub struct WindowId(pub u64); // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
 impl WindowId {
     /// Create a new window ID.

--- a/crates/flui-reactivity/src/error.rs
+++ b/crates/flui-reactivity/src/error.rs
@@ -150,7 +150,7 @@ pub enum RuntimeError {
 }
 
 /// Extension trait for Result types to provide additional context.
-pub trait ResultExt<T> {
+pub trait ResultExt<T> { // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Add context to an error.
     fn context(self, msg: impl Into<String>) -> Result<T>;
 

--- a/crates/flui-reactivity/src/lib.rs
+++ b/crates/flui-reactivity/src/lib.rs
@@ -79,7 +79,7 @@ pub mod owner;
 pub mod runtime;
 pub mod scheduler;
 pub mod signal;
-pub mod test_harness;
+pub mod test_harness; // PORT-CHECK-OK-SP4: test_harness API surface; testing-only consumer (still pub for downstream test suites)
 pub mod traits;
 
 // Async support (optional, enabled via "async" feature)

--- a/crates/flui-reactivity/src/runtime.rs
+++ b/crates/flui-reactivity/src/runtime.rs
@@ -80,7 +80,7 @@ impl std::fmt::Debug for SignalDataErased {
 /// Typed signal data (stored inside SignalDataErased).
 pub struct SignalData<T> {
     /// The actual value (thread-safe)
-    pub value: Arc<Mutex<T>>,
+    pub value: Arc<Mutex<T>>, // PORT-CHECK-OK-SP6: Signal value Mutex<T>; required by reactive RuntimeContext; pre-existing SP-6
 
     /// Subscribers that get notified on changes
     #[allow(dead_code)]

--- a/crates/flui-rendering/src/constraints/box_constraints.rs
+++ b/crates/flui-rendering/src/constraints/box_constraints.rs
@@ -39,6 +39,7 @@ use super::Constraints;
 /// Maps directly to Flutter's `BoxConstraints` class with identical semantics.
 #[derive(Clone, Copy, PartialEq)]
 pub struct BoxConstraints {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Minimum width that satisfies the constraints.
     pub min_width: Pixels,
     /// Maximum width that satisfies the constraints (may be infinite).

--- a/crates/flui-rendering/src/objects/flex.rs
+++ b/crates/flui-rendering/src/objects/flex.rs
@@ -23,6 +23,7 @@ pub enum FlexDirection {
 /// How children are aligned along the main axis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum MainAxisAlignment {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Children are placed at the start.
     #[default]
     Start,
@@ -41,6 +42,7 @@ pub enum MainAxisAlignment {
 /// How children are aligned along the cross axis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CrossAxisAlignment {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Children are aligned at the start.
     #[default]
     Start,

--- a/crates/flui-rendering/src/parent_data/box_variants.rs
+++ b/crates/flui-rendering/src/parent_data/box_variants.rs
@@ -103,6 +103,7 @@ pub struct FlexParentData {
 /// How flexible child should fit in allocated space.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FlexFit {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Child can be smaller than allocated space.
     Loose,
 

--- a/crates/flui-rendering/src/parent_data/table_text.rs
+++ b/crates/flui-rendering/src/parent_data/table_text.rs
@@ -32,6 +32,7 @@ pub struct TableCellParentData {
 /// Vertical alignment options for table cells.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TableCellVerticalAlignment {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Align to top of cell.
     Top,
 
@@ -139,6 +140,7 @@ pub struct TextParentData {
 /// Range of text in a paragraph (start and end character indices).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TextRange {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Start character index (inclusive).
     pub start: usize,
 

--- a/crates/flui-rendering/src/pipeline/phase.rs
+++ b/crates/flui-rendering/src/pipeline/phase.rs
@@ -99,7 +99,7 @@ use core::marker::PhantomData;
 // ---------------------------------------------------------------------------
 
 mod sealed {
-    pub trait Sealed {}
+    pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 }
 
 /// Phase marker trait, sealed so only this crate can name phases.

--- a/crates/flui-rendering/src/protocol/protocol.rs
+++ b/crates/flui-rendering/src/protocol/protocol.rs
@@ -20,7 +20,7 @@ use crate::parent_data::ParentData;
 /// Private module for sealed trait pattern.
 pub(crate) mod sealed {
     /// Sealed marker trait preventing external Protocol implementations.
-    pub trait Sealed {}
+    pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 }
 
 // ============================================================================

--- a/crates/flui-rendering/src/storage/tree.rs
+++ b/crates/flui-rendering/src/storage/tree.rs
@@ -97,6 +97,7 @@ impl RenderTree {
     /// Returns the pipeline owner.
     #[inline]
     pub fn owner(&self) -> Option<&Arc<RwLock<PipelineOwner>>> {
+        // PORT-CHECK-OK-SP6: RenderTree owner accessor; pre-existing SP-6
         self.owner.as_ref()
     }
 

--- a/crates/flui-rendering/src/traits/render_box.rs
+++ b/crates/flui-rendering/src/traits/render_box.rs
@@ -333,6 +333,7 @@ pub trait RenderBox: RenderObject<BoxProtocol> + flui_foundation::Diagnosticable
 /// Text baseline types for baseline alignment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TextBaseline {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The alphabetic baseline.
     Alphabetic,
     /// The ideographic baseline.

--- a/crates/flui-rendering/src/view/viewport.rs
+++ b/crates/flui-rendering/src/view/viewport.rs
@@ -15,6 +15,7 @@ use crate::{protocol::BoxProtocol, traits::RenderObject};
 /// The unit of measurement for a viewport's cache extent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum CacheExtentStyle {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Treat the cache extent as logical pixels.
     #[default]
     Pixel,

--- a/crates/flui-scheduler/src/duration.rs
+++ b/crates/flui-scheduler/src/duration.rs
@@ -582,7 +582,7 @@ impl fmt::Display for FrameDuration {
 /// Type-safe percentage wrapper (0.0 to 100.0)
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Percentage(f64);
+pub struct Percentage(f64); // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
 impl Percentage {
     /// Zero percent

--- a/crates/flui-scheduler/src/frame.rs
+++ b/crates/flui-scheduler/src/frame.rs
@@ -230,6 +230,7 @@ impl fmt::Display for SchedulerPhase {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(u8)]
 pub enum AppLifecycleState {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The application is visible and responding to user input.
     ///
     /// This is the default running state. Animations should run,
@@ -419,6 +420,7 @@ pub type LifecycleStateCallback = Box<dyn Fn(AppLifecycleState) + Send + Sync>;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(u8)]
 pub enum FramePhase {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Waiting for frame to start
     #[default]
     Idle = 0,

--- a/crates/flui-scheduler/src/scheduler.rs
+++ b/crates/flui-scheduler/src/scheduler.rs
@@ -941,6 +941,7 @@ impl Scheduler {
 
     /// Get frame budget reference
     pub fn budget(&self) -> parking_lot::MutexGuard<'_, FrameBudget> {
+        // PORT-CHECK-OK-SP6: FrameBudget guard accessor; required for atomic snapshot semantics; pre-existing SP-6
         self.frame.budget.lock()
     }
 

--- a/crates/flui-scheduler/src/task.rs
+++ b/crates/flui-scheduler/src/task.rs
@@ -44,6 +44,7 @@ fn next_task_id() -> TaskId {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(u8)]
 pub enum Priority {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Background/idle work (GC, telemetry). Flutter `priority.dart::idle` = 0.
     Idle = 0,
     /// Normal UI updates (widget rebuilds). FLUI-only — inserted between
@@ -162,6 +163,7 @@ pub use flui_foundation::TaskId;
 
 /// A scheduled task with priority
 pub struct Task {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     id: TaskId,
     priority: Priority,
     callback: Box<dyn FnOnce() + Send>,

--- a/crates/flui-semantics/src/properties.rs
+++ b/crates/flui-semantics/src/properties.rs
@@ -14,6 +14,7 @@ use crate::flags::SemanticsFlag;
 /// Text direction for semantics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TextDirection {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Right-to-left text.
     Rtl,
     /// Left-to-right text.

--- a/crates/flui-tree/src/arity/traits.rs
+++ b/crates/flui-tree/src/arity/traits.rs
@@ -55,7 +55,7 @@ pub trait Arity: sealed::Sealed + Send + Sync + Debug + Copy + Default + 'static
 pub(crate) mod sealed {
     use super::super::types::{AtLeast, Exact, Leaf, Never, Optional, Range, Variable};
 
-    pub trait Sealed {}
+    pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
     impl Sealed for Leaf {}
     impl Sealed for Optional {}

--- a/crates/flui-types/src/gestures/details.rs
+++ b/crates/flui-types/src/gestures/details.rs
@@ -86,6 +86,7 @@ impl TapUpDetails {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DragStartDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The time when the drag started
     pub source_time_stamp: Duration,
 
@@ -126,6 +127,7 @@ impl DragStartDetails {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DragDownDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The global position where the pointer contacted
     pub global_position: Offset<Pixels>,
 
@@ -147,6 +149,7 @@ impl DragDownDetails {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DragUpdateDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The time when the update occurred
     pub source_time_stamp: Duration,
 
@@ -195,6 +198,7 @@ impl DragUpdateDetails {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DragEndDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The velocity of the pointer when the drag ended
     pub velocity: Velocity,
 
@@ -227,6 +231,7 @@ impl DragEndDetails {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScaleStartDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The focal point of the pointers in contact with the screen
     pub focal_point: OffsetPair,
 
@@ -248,6 +253,7 @@ impl ScaleStartDetails {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScaleUpdateDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The focal point of the pointers in contact with the screen
     pub focal_point: OffsetPair,
 
@@ -311,6 +317,7 @@ impl ScaleUpdateDetails {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScaleEndDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The velocity of the gesture
     pub velocity: Velocity,
 
@@ -336,6 +343,7 @@ impl ScaleEndDetails {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LongPressDownDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The global position where the pointer contacted
     pub global_position: Offset<Pixels>,
 
@@ -368,6 +376,7 @@ impl LongPressDownDetails {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LongPressStartDetails {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The global position where the long press started
     pub global_position: Offset<Pixels>,
 

--- a/crates/flui-types/src/layout/alignment.rs
+++ b/crates/flui-types/src/layout/alignment.rs
@@ -35,6 +35,7 @@ impl MainAxisSize {
 #[derive(Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MainAxisAlignment {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     #[default]
     Start,
 
@@ -138,6 +139,7 @@ impl MainAxisAlignment {
 #[derive(Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CrossAxisAlignment {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     #[default]
     Start,
 
@@ -187,6 +189,7 @@ impl CrossAxisAlignment {
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Alignment {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Horizontal alignment: -1.0 = left, 0.0 = center, 1.0 = right
     pub x: f32,
 

--- a/crates/flui-types/src/layout/axis.rs
+++ b/crates/flui-types/src/layout/axis.rs
@@ -11,6 +11,7 @@ use crate::{Size, geometry::Pixels};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Axis {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The horizontal axis (left to right).
     #[default]
     Horizontal,

--- a/crates/flui-types/src/layout/baseline.rs
+++ b/crates/flui-types/src/layout/baseline.rs
@@ -3,6 +3,7 @@
 #[derive(Default, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TextBaseline {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     #[default]
     Alphabetic,
 

--- a/crates/flui-types/src/layout/constraints.rs
+++ b/crates/flui-types/src/layout/constraints.rs
@@ -35,6 +35,7 @@ use crate::geometry::{Pixels, Size};
 /// ```
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct BoxConstraints {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Minimum width
     pub min_width: Pixels,
     /// Maximum width

--- a/crates/flui-types/src/layout/flex.rs
+++ b/crates/flui-types/src/layout/flex.rs
@@ -3,6 +3,7 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FlexFit {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     #[default]
     Tight,
 

--- a/crates/flui-types/src/layout/table.rs
+++ b/crates/flui-types/src/layout/table.rs
@@ -40,6 +40,7 @@ impl Default for TableColumnWidth {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TableCellVerticalAlignment {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     #[default]
     Top,
 

--- a/crates/flui-types/src/layout/viewport.rs
+++ b/crates/flui-types/src/layout/viewport.rs
@@ -5,6 +5,7 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CacheExtentStyle {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     #[default]
     Pixel,
 

--- a/crates/flui-types/src/lib.rs
+++ b/crates/flui-types/src/lib.rs
@@ -93,8 +93,8 @@ pub use flui_geometry as geometry;
 pub mod gestures;
 pub mod layout;
 pub mod painting;
-pub mod physics;
-pub mod platform;
+pub mod physics; // PORT-CHECK-OK-SP4: physics types API surface; future consumer in flui-animation per ROADMAP
+pub mod platform; // PORT-CHECK-OK-SP4: platform types API surface; future consumer in flui-platform per ROADMAP
 pub mod styling;
 pub mod typography;
 

--- a/crates/flui-types/src/painting/alignment.rs
+++ b/crates/flui-types/src/painting/alignment.rs
@@ -41,6 +41,7 @@ use crate::geometry::{Offset, Pixels, Rect};
 #[non_exhaustive]
 #[must_use]
 pub struct Alignment {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Horizontal position. `-1.0` = left, `0.0` = center, `+1.0` = right.
     pub x: f32,
     /// Vertical position. `-1.0` = top, `0.0` = center, `+1.0` = bottom.

--- a/crates/flui-types/src/physics/friction.rs
+++ b/crates/flui-types/src/physics/friction.rs
@@ -6,6 +6,7 @@ use super::{Simulation, Tolerance};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FrictionSimulation {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The drag coefficient (higher = more friction)
     drag: f32,
 

--- a/crates/flui-types/src/physics/gravity.rs
+++ b/crates/flui-types/src/physics/gravity.rs
@@ -6,6 +6,7 @@ use super::{Simulation, Tolerance};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GravitySimulation {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The acceleration due to gravity (in pixels per second squared)
     acceleration: f32,
 

--- a/crates/flui-types/src/physics/mod.rs
+++ b/crates/flui-types/src/physics/mod.rs
@@ -41,6 +41,7 @@ pub use tolerance::Tolerance;
 /// let vel = sim.velocity(0.1);
 /// ```
 pub trait Simulation {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     #[must_use]
     fn position(&self, time: f32) -> f32;
 

--- a/crates/flui-types/src/physics/spring.rs
+++ b/crates/flui-types/src/physics/spring.rs
@@ -7,6 +7,7 @@ use super::{Simulation, Tolerance};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SpringType {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Critical damping - returns to rest as quickly as possible without
     /// oscillating
     Critical,
@@ -20,6 +21,7 @@ pub enum SpringType {
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SpringDescription {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The mass of the spring (must be positive)
     pub mass: f32,
 
@@ -139,6 +141,7 @@ impl SpringDescription {
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SpringSimulation {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The spring description
     spring: SpringDescription,
 

--- a/crates/flui-types/src/physics/tolerance.rs
+++ b/crates/flui-types/src/physics/tolerance.rs
@@ -6,6 +6,7 @@
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Tolerance {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The minimum distance between samples to consider them different
     ///
     /// Default: 0.001 (1/1000th of a pixel)

--- a/crates/flui-types/src/typography/text_alignment.rs
+++ b/crates/flui-types/src/typography/text_alignment.rs
@@ -80,6 +80,7 @@ pub use crate::layout::TextBaseline;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TextDirection {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     #[default]
     Ltr,
     /// Right-to-left text direction.

--- a/crates/flui-types/src/typography/text_metrics.rs
+++ b/crates/flui-types/src/typography/text_metrics.rs
@@ -67,6 +67,7 @@ impl Default for TextPosition {
 /// exclusive.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextRange {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// Start offset (inclusive).
     pub start: usize,
     /// End offset (exclusive).

--- a/crates/flui-view/src/binding.rs
+++ b/crates/flui-view/src/binding.rs
@@ -369,6 +369,7 @@ pub trait WidgetsBindingObserver: Send + Sync {
 /// Application lifecycle states.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AppLifecycleState {
+    // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// App is visible and responding to user input.
     Resumed,
     /// App is inactive (e.g., incoming call).
@@ -581,6 +582,7 @@ impl WidgetsBinding {
 
     /// Get the PipelineOwner if set.
     pub fn pipeline_owner(&self) -> Option<Arc<RwLock<PipelineOwner>>> {
+        // PORT-CHECK-OK-SP6: binding layer Arc<RwLock<PipelineOwner>> leak; consolidation tracked under architecture-correction-plan SP-6
         self.inner.read().pipeline_owner.clone()
     }
 

--- a/crates/flui-view/src/context/element_build_context.rs
+++ b/crates/flui-view/src/context/element_build_context.rs
@@ -136,11 +136,13 @@ impl ElementBuildContext {
 
     /// Get a reference to the tree.
     pub fn tree(&self) -> &Arc<RwLock<ElementTree>> {
+        // PORT-CHECK-OK-SP6: ElementBuildContext tree accessor; pre-existing SP-6
         &self.tree
     }
 
     /// Get a reference to the owner.
     pub fn build_owner(&self) -> &Arc<RwLock<BuildOwner>> {
+        // PORT-CHECK-OK-SP6: ElementBuildContext build_owner accessor; pre-existing SP-6
         &self.owner
     }
 

--- a/crates/flui-view/src/element/generic.rs
+++ b/crates/flui-view/src/element/generic.rs
@@ -629,6 +629,7 @@ where
 
     /// Get the PipelineOwner, if set.
     pub fn pipeline_owner(&self) -> Option<&Arc<RwLock<PipelineOwner>>> {
+        // PORT-CHECK-OK-SP6: ElementCore pipeline_owner accessor; pre-existing SP-6
         self.pipeline_owner.as_ref()
     }
 

--- a/crates/flui-view/src/lib.rs
+++ b/crates/flui-view/src/lib.rs
@@ -90,9 +90,9 @@ pub mod child;
 pub mod context;
 pub mod element;
 pub mod key;
-pub mod macros;
+pub mod macros; // PORT-CHECK-OK-SP4: macros consumed via #[macro_export] (no qualified path); intentional API surface
 pub mod owner;
-pub mod seq;
+pub mod seq; // PORT-CHECK-OK-SP4: seq/Children API surface; consumed via prelude re-exports
 pub mod tree;
 pub mod view;
 

--- a/crates/flui-view/src/owner/build_owner.rs
+++ b/crates/flui-view/src/owner/build_owner.rs
@@ -242,6 +242,7 @@ impl BuildOwner {
     /// — eliminates the per-build `Arc::new(RwLock::new(_))` allocation
     /// in the stateless/stateful build paths.
     pub fn shared_dummy_tree() -> Arc<RwLock<ElementTree>> {
+        // PORT-CHECK-OK-SP6: shared_dummy_tree test-harness accessor; pre-existing SP-6
         Arc::clone(SHARED_DUMMY_TREE.get_or_init(|| Arc::new(RwLock::new(ElementTree::new()))))
     }
 
@@ -250,6 +251,7 @@ impl BuildOwner {
     /// [`shared_dummy_tree`](Self::shared_dummy_tree) for the
     /// allocation-elimination rationale.
     pub fn shared_dummy_owner() -> Arc<RwLock<BuildOwner>> {
+        // PORT-CHECK-OK-SP6: shared_dummy_owner test-harness accessor; pre-existing SP-6
         Arc::clone(SHARED_DUMMY_OWNER.get_or_init(|| Arc::new(RwLock::new(BuildOwner::new()))))
     }
 

--- a/crates/flui-view/src/view/root.rs
+++ b/crates/flui-view/src/view/root.rs
@@ -128,6 +128,7 @@ impl<V: View + Clone + Send + Sync + 'static> RootRenderElement<V> {
 
     /// Get the PipelineOwner.
     pub fn pipeline_owner(&self) -> Option<&Arc<RwLock<PipelineOwner>>> {
+        // PORT-CHECK-OK-SP6: RootView pipeline_owner accessor; pre-existing SP-6; consolidation tracked
         self.pipeline_owner.as_ref()
     }
 

--- a/docs/PORT.md
+++ b/docs/PORT.md
@@ -123,29 +123,43 @@ The *funnel* signatures (`tree.rs::insert_box`, view → render `From` impls) ac
 
 **Back-references:** [architecture-correction-plan §SP-1](research/2026-05-22-architecture-correction-plan.md), [D-block plan §U41](plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md).
 
+### 9. Sanctioned `dyn`-boundary registry (FR-036)
+
+**FR-036 — every `Box<dyn …>` / `&dyn …` / `Arc<dyn …>` / `Rc<dyn …>` introduction (and every type alias of that shape) in the framework crates must either (a) name a sanctioned trait from the inline allowlist, (b) match a language-runtime exempt pattern (`Pin<Box<dyn Future>>`, `Box<dyn Iterator>`, `&dyn Fn*` callback parameters), or (c) carry an explicit `// PORT-CHECK-OK-DYN:` marker on the same line.** Phase 3.1 §U30 of the view/element core-contracts plan installs this trigger as the canonical FR-036 enforcement layer.
+
+**Allowlist marker:** `// PORT-CHECK-OK-DYN: <one-line justification>` on the same line as the `dyn`-introducing declaration. Multi-line declarations either keep the marker on the `Box<` line (matched by the scan) or refactor to a type alias that fits one line + carries its own marker.
+
+**Sanctioned trait allowlist** (categories per FR-029 #1-#5 + pre-existing framework surfaces): element-storage sub-traits (`ElementBase` / `ElementBehavior` / `StatelessElementBase` / `StatefulElementBase` / `ProxyElementBase` / `InheritedElementBase` / `RenderElementBase`), BoxedView (`View` / `BoxedView` / `ViewObject`), pipeline-owner type-erasure (`Any`), error / observer / animation / owned-callback chains (`Error` / `Listenable` / `Animation` / `WidgetsBindingObserver` / `Fn` / `FnMut` / `FnOnce`), protocol-layout erasure (`BoxLayoutCtxErased` / `SliverLayoutCtxErased` — D-block PR-A1b §U19 / memo D5), and pre-existing surfaces (`ViewKey` / `BuildContext` / `Notification` / `NotifiableElement` / `RenderObject` / `RenderObjectTrait`). Add a trait here when its `dyn` usage is widespread enough that per-site markers become noise; remove only after auditing that the trait's `dyn` surface is genuinely gone.
+
+**Scope:** framework crates (`crates/flui-view/src`, `crates/flui-foundation/src`, `crates/flui-tree/src`, `crates/flui-engine/src`, `crates/flui-rendering/src`, `crates/flui-interaction/src`).
+
+**Multi-line declaration handling:** the scan does NOT use `rg -U` multiline mode (mixing multi-line output blocks with line-oriented `grep -Ev` filters partial-filters multi-line matches → false positives and silent bypasses). The single-line scan catches rustfmt-formatted code (which collapses `Box<dyn Trait>` to one line whenever possible).
+
+**Back-references:** [specs/004-view-element-core/spec.md FR-036](../specs/004-view-element-core/spec.md), [Phase 3.1 §U30](plans/2026-05-22-005-feat-view-element-core-contracts-plan.md).
+
 ### 10. Parallel cross-crate type definitions
 
 **SP-3 — same identifier `pub struct` / `pub enum` / `pub trait` defined in 2+ distinct framework crates.** Either the same concept is implemented twice (consolidate) or two unrelated concepts collide on a single name (rename one).
 
 Re-exports (`pub use foo::Bar`) do not trip the trigger — only literal `pub <kind> <Name>` declarations are counted.
 
-**Allowlist marker:** `// PORT-CHECK-OK-SP3: <reason + tracking-issue>` on the same line as the `pub <kind> <Name>` declaration. Pre-existing parallel definitions in the current codebase are individually marked so future ADDITIONS are caught; the marker reason should point to a consolidation tracking issue.
+**Allowlist marker:** `// PORT-CHECK-OK-SP3: <reason + tracking-issue>`. The scan checks a ±2-line window around the `pub <kind> <Name>` declaration (preceding line + same line + 2 lines after), so the marker survives rustfmt moving a trailing same-line comment on block-opening decls (`pub enum Foo {`, `pub struct Bar {`) into the body as the first non-blank line. Place the marker on the same line for one-liner decls (`pub struct Foo(pub u32);`) or on the preceding line for block decls; both forms are accepted.
 
 **Scope:** framework crates (`crates/`), excluding tests + examples.
 
-**Regex:** `pub +(struct|enum|trait) +[A-Z][a-zA-Z0-9_]*` with crate-attribution via path, then duplicate detection across distinct crates.
+**Regex:** `pub +(struct|enum|trait) +[A-Z][a-zA-Z0-9_]*` with crate-attribution via path (backslash-normalized for Windows portability), then duplicate detection across distinct crates.
 
 **Back-references:** [architecture-correction-plan §SP-3](research/2026-05-22-architecture-correction-plan.md), [D-block plan §U42](plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md).
 
 ### 11. Speculative scaffolding: `pub mod` with zero workspace consumers
 
-**SP-4 — `pub mod <name>;` declared in `lib.rs` that is (a) not behind `#[cfg(feature = "unstable-*")]`, (b) not re-exported via `pub use [crate::]<name>::` in the same `lib.rs`, AND (c) not referenced as `<crate>::<name>` anywhere in the workspace outside the defining crate.** This catches speculative `pub mod` surfaces that publish API without consumers.
+**SP-4 — `pub mod <name>;` declared in `lib.rs` that is (a) not behind `#[cfg(feature = "unstable-*")]` on its preceding non-blank line, (b) not re-exported via `pub use [crate::]<name>::` in the same `lib.rs`, AND (c) not referenced as `<crate>::<name>` anywhere in the workspace outside the defining crate.** This catches speculative `pub mod` surfaces that publish API without consumers.
 
 **Allowlist marker:** `// PORT-CHECK-OK-SP4: <reason + tracking-issue>` on the same line as the `pub mod` declaration. Common reasons: macro export bypass (`#[macro_export]` items consumed via macro invocation not module path), future-consumer binding entry, intentional API surface for downstream integrators.
 
 **Limitations:** mechanical scan — catches lib.rs-level `pub mod`, NOT sub-module speculation (`mod foo { pub mod bar; }`). For deeper SP-4 audits see the manual verdicts in [architecture-correction-plan §SP-4](research/2026-05-22-architecture-correction-plan.md).
 
-**Back-references:** [architecture-correction-plan §SP-4](research/2026-05-22-architecture-correction-plan.md), [D-block plan §U43](plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md), `flui-tree-unified-interface-intent` memory.
+**Back-references:** [architecture-correction-plan §SP-4](research/2026-05-22-architecture-correction-plan.md), [D-block plan §U43](plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md), [view-tree-foundation audit "Post-audit correction"](research/2026-05-21-view-tree-foundation-audit.md) (zero-consumer flui-tree surface is deliberate unified-tree infrastructure, not a deletion signal).
 
 ### 12. Lock placement in public API
 
@@ -155,7 +169,7 @@ Re-exports (`pub use foo::Bar`) do not trip the trigger — only literal `pub <k
 * `pub fn foo() -> RwLockReadGuard<...>` / `RwLockWriteGuard<...>` / `MutexGuard<...>` / `RwLock<...>` / `Mutex<...>`
 * `pub field: (Arc<)?(parking_lot::)?(RwLock|Mutex)<...>`
 
-**Allowlist marker:** `// PORT-CHECK-OK-SP6: <reason + tracking-issue>` on the same line as the declaration. Pre-existing leaks in the binding / context / callback-storage layers are marked individually; the marker reason should point to the consolidation tracking issue.
+**Allowlist marker:** `// PORT-CHECK-OK-SP6: <reason + tracking-issue>`. Same ±2-line window logic as trigger 10 — the marker is accepted on the preceding line, the same line, or 2 lines after the declaration (rustfmt may move trailing same-line markers on block-opening signatures like `pub fn foo() -> RwLockReadGuard {` into the body). Pre-existing leaks in the binding / context / callback-storage layers are marked individually.
 
 **Back-references:** [architecture-correction-plan §SP-6](research/2026-05-22-architecture-correction-plan.md), [D-block plan §U44](plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md).
 

--- a/docs/PORT.md
+++ b/docs/PORT.md
@@ -85,6 +85,66 @@ The *funnel* signatures (`tree.rs::insert_box`, view → render `From` impls) ac
 
 **Regex:** `^\s+(pub\s+)?\w+\s*:\s*(Option<\s*)?Arc<\s*(parking_lot::)?(Mutex|RwLock)<\s*((super::)?(\w+::)*\w*(Renderer|Pool)\w*|wgpu::\w+)` constrained to `crates/flui-engine/src/wgpu/`, with file-glob exclusions for the three Friction-log-tracked sites listed above. Anchored to struct-field syntax (leading whitespace + optional `pub` + ident + `:`); inner alternation `((super::)?(\w+::)*\w*(Renderer|Pool)\w*|wgpu::\w+)` is grouped so `wgpu::*` matches only at the outer-type position. Catches both `Arc<...>` and `Option<Arc<...>>` field shapes. Tightened after Copilot review on PR #79.
 
+### 8. `unimplemented!()` / `todo!()` in production `fn` body
+
+**SP-1 — stubbed-but-called.** A function whose body panics on entry is an API that publishes a contract without honoring it. The trigger fires whenever `unimplemented!(` or `todo!(` appears outside test code.
+
+**Allowlist marker:** `// PORT-CHECK-OK-STUB: <reason + tracking-issue>` on the same line as the panic. The reason should name the tracking issue or follow-up doc so the stub doesn't become permanent.
+
+**Scope:** framework crates (`crates/`), excluding tests (`tests/`, `test*.rs`), examples, and the per-platform stub modules (`crates/flui-platform/src/platforms/{linux,ios,android}/`) which are tracked outside SP-1 under the platform-impl track in [`ROADMAP.md`](ROADMAP.md).
+
+**Regex:** `unimplemented!\s*\(|todo!\s*\(` with doc-comment and marker filters.
+
+**Back-references:** [architecture-correction-plan §SP-1](research/2026-05-22-architecture-correction-plan.md), [D-block plan §U41](plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md).
+
+### 10. Parallel cross-crate type definitions
+
+**SP-3 — same identifier `pub struct` / `pub enum` / `pub trait` defined in 2+ distinct framework crates.** Either the same concept is implemented twice (consolidate) or two unrelated concepts collide on a single name (rename one).
+
+Re-exports (`pub use foo::Bar`) do not trip the trigger — only literal `pub <kind> <Name>` declarations are counted.
+
+**Allowlist marker:** `// PORT-CHECK-OK-SP3: <reason + tracking-issue>` on the same line as the `pub <kind> <Name>` declaration. Pre-existing parallel definitions in the current codebase are individually marked so future ADDITIONS are caught; the marker reason should point to a consolidation tracking issue.
+
+**Scope:** framework crates (`crates/`), excluding tests + examples.
+
+**Regex:** `pub +(struct|enum|trait) +[A-Z][a-zA-Z0-9_]*` with crate-attribution via path, then duplicate detection across distinct crates.
+
+**Back-references:** [architecture-correction-plan §SP-3](research/2026-05-22-architecture-correction-plan.md), [D-block plan §U42](plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md).
+
+### 11. Speculative scaffolding: `pub mod` with zero workspace consumers
+
+**SP-4 — `pub mod <name>;` declared in `lib.rs` that is (a) not behind `#[cfg(feature = "unstable-*")]`, (b) not re-exported via `pub use [crate::]<name>::` in the same `lib.rs`, AND (c) not referenced as `<crate>::<name>` anywhere in the workspace outside the defining crate.** This catches speculative `pub mod` surfaces that publish API without consumers.
+
+**Allowlist marker:** `// PORT-CHECK-OK-SP4: <reason + tracking-issue>` on the same line as the `pub mod` declaration. Common reasons: macro export bypass (`#[macro_export]` items consumed via macro invocation not module path), future-consumer binding entry, intentional API surface for downstream integrators.
+
+**Limitations:** mechanical scan — catches lib.rs-level `pub mod`, NOT sub-module speculation (`mod foo { pub mod bar; }`). For deeper SP-4 audits see the manual verdicts in [architecture-correction-plan §SP-4](research/2026-05-22-architecture-correction-plan.md).
+
+**Back-references:** [architecture-correction-plan §SP-4](research/2026-05-22-architecture-correction-plan.md), [D-block plan §U43](plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md), `flui-tree-unified-interface-intent` memory.
+
+### 12. Lock placement in public API
+
+**SP-6 — `RwLock` / `Mutex` / `Arc<RwLock<...>>` in a `pub fn` return type OR a `pub` field of a trait/struct.** Lock types leak the framework's concurrency model across module boundaries; every caller has to reason about lock ordering / poisoning / re-entrancy. SP-6's verdict is that locks should live behind private fields; public APIs should expose immutable snapshots or scoped callbacks.
+
+**Patterns flagged:**
+* `pub fn foo() -> RwLockReadGuard<...>` / `RwLockWriteGuard<...>` / `MutexGuard<...>` / `RwLock<...>` / `Mutex<...>`
+* `pub field: (Arc<)?(parking_lot::)?(RwLock|Mutex)<...>`
+
+**Allowlist marker:** `// PORT-CHECK-OK-SP6: <reason + tracking-issue>` on the same line as the declaration. Pre-existing leaks in the binding / context / callback-storage layers are marked individually; the marker reason should point to the consolidation tracking issue.
+
+**Back-references:** [architecture-correction-plan §SP-6](research/2026-05-22-architecture-correction-plan.md), [D-block plan §U44](plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md).
+
+### 13. Constructor-time panics
+
+**SP-8 — `unwrap()` / `expect(` / `panic!(` / `assert!(` inside a public CONSTRUCTOR body (`pub fn new` / `pub fn from_*` / `pub fn try_*`).** Turns argument-validation bugs into process aborts at the public API surface. The SP-8 verdict is that public constructors should return `Result` or take pre-validated types.
+
+**Allowed:** `debug_assert!` (compiled out in release).
+
+**Mechanical scope (deliberately narrow — high precision, accepts false-negatives):** single-line constructor bodies of the shape `pub fn new(...) -> Self { ... .unwrap()/.expect()/panic!/assert! ... }` (inline body with one of the panic forms on the SAME line as the `pub fn (new|from_*|try_*)` signature). Multi-line constructor bodies are NOT inspected; rustc + clippy lints (`clippy::expect_used`, `clippy::unwrap_used`) cover that surface where opted in.
+
+**Allowlist marker:** `// PORT-CHECK-OK-SP8: <reason>` on the same line as the panic.
+
+**Back-references:** [architecture-correction-plan §SP-8](research/2026-05-22-architecture-correction-plan.md), [D-block plan §U45](plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md).
+
 ### Reactive lint promotion
 
 Triggers grow reactively. A new trigger is added to this list when an anti-pattern is caught in review; it does not pre-exist its first observation.

--- a/scripts/port-check.sh
+++ b/scripts/port-check.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 # scripts/port-check.sh
 #
-# Verifies the six refusal triggers documented in docs/PORT.md against
-# the workspace. Exits non-zero on the first violation outside the
-# whitelist; prints offending file:line and the trigger ID.
+# Verifies the 13 refusal triggers (1-13, with #9 numbered for FR-036)
+# documented in docs/PORT.md against the workspace. Exits non-zero on
+# the first violation outside the whitelist; prints offending file:line
+# and the trigger ID. Triggers #8/#10/#11/#12/#13 added in D-block
+# PR-C-3 §U41-U45 (architecture-correction-plan SP-1/SP-3/SP-4/SP-6/
+# SP-8).
 #
 # Cross-platform note: this script is bash. On Windows, run via Git Bash
 # or WSL. A PowerShell sibling is not provided in this iteration; see
 # docs/PORT.md "## Verification" for usage and rationale.
 #
 # Usage:
-#   bash scripts/port-check.sh        # check all six triggers
+#   bash scripts/port-check.sh        # check all 13 triggers
 #   bash scripts/port-check.sh -v     # verbose (print each check's pass line)
 
 set -euo pipefail
@@ -305,6 +308,369 @@ else
 fi
 
 # -----------------------------------------------------------------------------
+# Trigger 8 (D-block PR-C-3 §U41, architecture-correction-plan SP-1) —
+# stubbed-but-called functions.
+#
+# Greps for `unimplemented!(` / `todo!(` in production code (non-test).
+# These are SP-1 violations: a `fn` body that panics on entry is a
+# "stubbed-but-called" surface — it appears in the API but has no
+# implementation. Common shapes:
+#   - `fn foo() { unimplemented!() }`
+#   - `fn foo() -> T { todo!() }`
+#
+# Exclusions:
+#   - doc comments (`///`, `//!`, `//`)
+#   - `// PORT-CHECK-OK-STUB: <reason>` markers on the same line
+#   - `crates/flui-platform/src/platforms/{linux,ios,android}/`
+#     (platform-init stubs deferred to native-platform implementation
+#     work; tracked outside SP-1 — see `crates/flui-platform/ARCHITECTURE.md`
+#     and `docs/ROADMAP.md` Core.0 → Core.1 platform-impl track)
+#   - `#[cfg(test)]` / `tests/` files
+#   - example crates (each example exists to demonstrate, not ship as
+#     framework code; an example's `todo!()` is an EXAMPLE concern,
+#     not an SP-1 violation)
+#
+# Allowlist marker grammar (same convention as triggers 7 / 9):
+#   <something>  // PORT-CHECK-OK-STUB: <one-line justification + tracking issue>
+#
+# Tracking-issue requirement: every marker should reference a tracking
+# issue or follow-up doc so the stub doesn't become permanent. Per-site
+# audit during PR review enforces this.
+# -----------------------------------------------------------------------------
+trigger8_hits=$(rg --line-number --column \
+    -e 'unimplemented!\s*\(' \
+    -e 'todo!\s*\(' \
+    --type rust \
+    --glob '!**/tests/**' \
+    --glob '!**/test*.rs' \
+    --glob '!crates/flui-platform/src/platforms/linux/**' \
+    --glob '!crates/flui-platform/src/platforms/ios/**' \
+    --glob '!crates/flui-platform/src/platforms/android/**' \
+    crates/ 2>/dev/null \
+  | grep -Ev ':\s*(//!|///|//)' \
+  | grep -Ev '//\s*PORT-CHECK-OK-STUB:' \
+  || true)
+
+if [[ -n "${trigger8_hits}" ]]; then
+  echo 'VIOLATION 8: SP-1 stubbed-but-called (unimplemented!()/todo!() in production fn body)'
+  echo "see ${trigger_doc} (trigger 8)"
+  echo "${trigger8_hits}"
+  echo ""
+  violations=$((violations + 1))
+else
+  if [[ "${verbose}" -eq 1 ]]; then
+    echo "ok    8: SP-1 stubbed-but-called (unimplemented!()/todo!() in production)"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# Trigger 10 (D-block PR-C-3 §U42, architecture-correction-plan SP-3) —
+# parallel cross-crate type definitions.
+#
+# Collects every `pub struct` / `pub enum` / `pub trait` identifier
+# across the `crates/flui-*/src/` tree and flags any identifier defined
+# (not re-exported) in 2+ DISTINCT crates. Parallel definitions are an
+# SP-3 smell: either the same concept is implemented twice (consolidate)
+# or two unrelated concepts collide on a single name (rename one).
+#
+# Re-exports (`pub use foo::Bar`) do not match because the pattern
+# requires the `struct`/`enum`/`trait` keyword.
+#
+# Exclusions:
+#   - doc comments (`///`, `//!`, `//`)
+#   - tests (`tests/`, `test*.rs`, `#[cfg(test)]` files)
+#   - example crates (`examples/`)
+#   - `// PORT-CHECK-OK-SP3: <reason>` markers on the same line as
+#     the `pub <kind> Name` declaration sanction the duplicate.
+#
+# Allowlist marker grammar:
+#   pub struct Foo { ... }  // PORT-CHECK-OK-SP3: <reason + tracking-issue>
+#
+# Pre-existing parallel definitions in the current codebase are marked
+# individually so future ADDITIONS are caught; the marker reason should
+# point to a consolidation tracking issue so the duplicate doesn't
+# become permanent.
+# -----------------------------------------------------------------------------
+trigger10_defs_raw=$(rg --line-number --no-heading \
+    'pub +(struct|enum|trait) +[A-Z][a-zA-Z0-9_]*' \
+    --type rust \
+    --glob '!**/tests/**' \
+    --glob '!**/test*.rs' \
+    --glob '!examples/**' \
+    crates/ 2>/dev/null \
+  | grep -Ev ':\s*(//!|///|//)' \
+  || true)
+
+# Marker scan: a PORT-CHECK-OK-SP3 marker is sanctioning if it appears
+# on the same line OR on the preceding line OR on either of the next
+# 2 lines (rustfmt moves trailing same-line markers on block-opening
+# decls like `pub enum Foo {` into the block body as the first
+# non-blank line). For each candidate line, fetch the surrounding
+# ±2-line window and check if any line carries the marker.
+trigger10_defs=""
+while IFS= read -r raw_line; do
+  [[ -z "${raw_line}" ]] && continue
+  file_part=$(echo "${raw_line}" | awk -F':' '{print $1}')
+  line_part=$(echo "${raw_line}" | awk -F':' '{print $2}')
+  # Normalize backslash → forward slash for sed path arg.
+  file_norm=$(echo "${file_part}" | tr '\\' '/')
+  [[ -z "${file_norm}" || -z "${line_part}" ]] && continue
+  start=$(( line_part - 1 ))
+  [[ "${start}" -lt 1 ]] && start=1
+  end=$(( line_part + 2 ))
+  window=$(sed -n "${start},${end}p" "${file_norm}" 2>/dev/null || true)
+  if ! echo "${window}" | grep -q 'PORT-CHECK-OK-SP3:'; then
+    trigger10_defs="${trigger10_defs}${raw_line}
+"
+  fi
+done <<< "${trigger10_defs_raw}"
+
+# Build a tab-separated index: crate \t kind \t name \t full-line
+trigger10_index=$(echo "${trigger10_defs}" | awk -F':' '
+BEGIN { OFS = "\t" }
+{
+  n = split($1, parts, "/")
+  if (n < 2) next
+  crate = parts[2]
+  line = $0
+  pos = match(line, /pub +(struct|enum|trait) +[A-Z][a-zA-Z0-9_]*/)
+  if (pos == 0) next
+  matched = substr(line, pos, RLENGTH)
+  split(matched, w, /[ \t]+/)
+  print crate, w[2], w[3], line
+}')
+
+# Find (kind, name) pairs defined in 2+ distinct crates.
+trigger10_dupes=$(echo "${trigger10_index}" \
+  | awk -F'\t' 'NF>=3 {print $2 "\t" $3 "\t" $1}' \
+  | sort -u \
+  | awk -F'\t' '{print $1 "\t" $2}' \
+  | sort \
+  | uniq -d)
+
+if [[ -n "${trigger10_dupes}" ]]; then
+  trigger10_report=""
+  while IFS=$'\t' read -r kind name; do
+    [[ -z "${kind}" ]] && continue
+    trigger10_report="${trigger10_report}  ${kind} ${name}:
+$(echo "${trigger10_index}" | awk -F'\t' -v k="${kind}" -v n="${name}" '$2==k && $3==n {print "    " $4}')
+"
+  done <<< "${trigger10_dupes}"
+  echo 'VIOLATION 10: SP-3 parallel cross-crate type definitions'
+  echo "see ${trigger_doc} (trigger 10)"
+  echo "${trigger10_report}"
+  violations=$((violations + 1))
+else
+  if [[ "${verbose}" -eq 1 ]]; then
+    echo "ok    10: SP-3 parallel cross-crate type definitions"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# Trigger 11 (D-block PR-C-3 §U43, architecture-correction-plan SP-4) —
+# speculative scaffolding: `pub mod` family with zero production
+# consumers and not behind `cfg(feature = "unstable-*")`.
+#
+# Scans each crate's `lib.rs` for `pub mod <name>;` declarations.
+# For each declaration the trigger:
+#   1. Skips if the preceding non-blank line is `#[cfg(feature =
+#      "unstable-...")]` (intentional speculation behind a feature
+#      gate — sanctioned by SP-4 verdict).
+#   2. Skips if the same `lib.rs` has `pub use <name>::` re-exporting
+#      the module's items (explicit external API surface).
+#   3. Otherwise searches the rest of the workspace for `<crate>::<name>`
+#      or `use <crate>::<name>` references. If zero references outside
+#      the defining crate exist, flags the declaration.
+#
+# Allowlist marker grammar:
+#   pub mod foo;  // PORT-CHECK-OK-SP4: <reason + tracking-issue>
+#
+# Limitations: this is a mechanical scan and trades precision for
+# implementability. It catches the common "lib.rs declares pub mod with
+# no use sites" shape; it does NOT catch sub-module speculation
+# (`mod foo { pub mod bar; }`). For deeper SP-4 audits, see the manual
+# verdicts in architecture-correction-plan §SP-4 (table at line 451).
+# -----------------------------------------------------------------------------
+trigger11_lib_files=$(rg --files --type rust --glob '**/lib.rs' --glob '!**/tests/**' --glob '!examples/**' crates/ 2>/dev/null || true)
+trigger11_violations=""
+for libfile in ${trigger11_lib_files}; do
+  # Extract crate name from path: crates/flui-X/src/lib.rs → flui-X → flui_X
+  # Normalize backslash → forward slash for Windows portability so awk
+  # field splitting on `/` always returns `flui-X` in field 2.
+  libfile_norm=$(echo "${libfile}" | tr '\\' '/')
+  crate_dir=$(echo "${libfile_norm}" | awk -F'/' '{print $2}')
+  crate_underscore=$(echo "${crate_dir}" | tr '-' '_')
+
+  # Find every `pub mod NAME;` line in lib.rs (declaration form, not block form).
+  mod_lines=$(grep -nE '^[[:space:]]*pub[[:space:]]+mod[[:space:]]+[a-z_][a-z0-9_]*[[:space:]]*;' "${libfile}" 2>/dev/null || true)
+  while IFS= read -r mod_line; do
+    [[ -z "${mod_line}" ]] && continue
+    lineno=$(echo "${mod_line}" | awk -F':' '{print $1}')
+    content=$(echo "${mod_line}" | cut -d':' -f2-)
+
+    # Skip if marker present on the same line.
+    if echo "${content}" | grep -q 'PORT-CHECK-OK-SP4:'; then
+      continue
+    fi
+
+    # Extract mod name.
+    modname=$(echo "${content}" | sed -E 's/^[[:space:]]*pub[[:space:]]+mod[[:space:]]+([a-z_][a-z0-9_]*).*/\1/')
+    [[ -z "${modname}" ]] && continue
+
+    # Skip if previous non-blank line is `#[cfg(feature = "unstable-...")]`.
+    prev_lineno=$((lineno - 1))
+    prev_content=$(sed -n "${prev_lineno}p" "${libfile}")
+    if echo "${prev_content}" | grep -qE '#\[cfg\(feature[[:space:]]*=[[:space:]]*"unstable-'; then
+      continue
+    fi
+
+    # Skip if the same lib.rs re-exports items from the module
+    # (`pub use <modname>::...` or `pub use crate::<modname>::...` —
+    # explicit external API surface).
+    if grep -qE "^[[:space:]]*pub[[:space:]]+use[[:space:]]+(crate::)?${modname}::" "${libfile}"; then
+      continue
+    fi
+
+    # Workspace consumer search: look for `<crate>::<modname>` (qualified
+    # path) or `use <crate>::<modname>` (import) anywhere in the
+    # workspace OUTSIDE the defining crate. If zero matches → flag.
+    consumer_matches=$(rg --type rust --no-heading -l \
+        -e "${crate_underscore}::${modname}\\b" \
+        --glob "!crates/${crate_dir}/**" \
+        --glob '!**/tests/**' \
+        crates/ examples/ 2>/dev/null | head -1 || true)
+    if [[ -z "${consumer_matches}" ]]; then
+      trigger11_violations="${trigger11_violations}${libfile}:${lineno}:${content}
+"
+    fi
+  done <<< "${mod_lines}"
+done
+
+if [[ -n "${trigger11_violations}" ]]; then
+  echo 'VIOLATION 11: SP-4 speculative scaffolding (pub mod with zero workspace consumers, not feature-gated)'
+  echo "see ${trigger_doc} (trigger 11)"
+  echo "${trigger11_violations}"
+  echo ""
+  violations=$((violations + 1))
+else
+  if [[ "${verbose}" -eq 1 ]]; then
+    echo "ok    11: SP-4 speculative scaffolding (pub mod surfaces)"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# Trigger 12 (D-block PR-C-3 §U44, architecture-correction-plan SP-6) —
+# lock placement in public API.
+#
+# Lock types leak the framework's concurrency model across module
+# boundaries. A `pub fn -> RwLockReadGuard<...>` or `pub field:
+# Mutex<...>` forces every caller to reason about lock ordering /
+# poisoning / re-entrancy. SP-6's verdict is that locks should live
+# behind private fields; public APIs should expose immutable
+# snapshots or scoped callbacks.
+#
+# Patterns flagged:
+#   pub fn foo() -> RwLockReadGuard<...> | RwLockWriteGuard<...> |
+#                   MutexGuard<...> | RwLock<...> | Mutex<...>
+#   pub field: (Arc<)?(parking_lot::)?(RwLock|Mutex)<...>
+#
+# Allowlist marker grammar:
+#   <decl>  // PORT-CHECK-OK-SP6: <reason + tracking-issue>
+# -----------------------------------------------------------------------------
+trigger12_raw=$(rg --line-number --no-heading \
+    -e '^\s*pub fn .*-> .*(RwLock|Mutex|RwLockReadGuard|RwLockWriteGuard|MutexGuard)\b' \
+    -e '^\s*pub \w+ *: *(Arc<\s*)?(parking_lot::)?(RwLock|Mutex)<' \
+    --type rust \
+    --glob '!**/tests/**' \
+    --glob '!**/test*.rs' \
+    --glob '!examples/**' \
+    crates/ 2>/dev/null \
+  | grep -Ev ':\s*(//!|///|//)' \
+  || true)
+
+# Same ±2 line marker-scan window as trigger #10 — rustfmt may move
+# trailing same-line markers on `pub fn ... -> ... {` block-openings
+# into the function body.
+trigger12_hits=""
+while IFS= read -r raw_line; do
+  [[ -z "${raw_line}" ]] && continue
+  file_part=$(echo "${raw_line}" | awk -F':' '{print $1}')
+  line_part=$(echo "${raw_line}" | awk -F':' '{print $2}')
+  file_norm=$(echo "${file_part}" | tr '\\' '/')
+  [[ -z "${file_norm}" || -z "${line_part}" ]] && continue
+  start=$(( line_part - 1 ))
+  [[ "${start}" -lt 1 ]] && start=1
+  end=$(( line_part + 2 ))
+  window=$(sed -n "${start},${end}p" "${file_norm}" 2>/dev/null || true)
+  if ! echo "${window}" | grep -q 'PORT-CHECK-OK-SP6:'; then
+    trigger12_hits="${trigger12_hits}${raw_line}
+"
+  fi
+done <<< "${trigger12_raw}"
+
+if [[ -n "${trigger12_hits}" ]]; then
+  echo 'VIOLATION 12: SP-6 lock placement in public API'
+  echo "see ${trigger_doc} (trigger 12)"
+  echo "${trigger12_hits}"
+  echo ""
+  violations=$((violations + 1))
+else
+  if [[ "${verbose}" -eq 1 ]]; then
+    echo "ok    12: SP-6 lock placement in public API"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# Trigger 13 (D-block PR-C-3 §U45, architecture-correction-plan SP-8) —
+# constructor-time panics.
+#
+# `unwrap()` / `expect()` / `panic!(...)` / `assert!(...)` inside a
+# public CONSTRUCTOR (`pub fn new` / `pub fn from_*` / `pub fn try_*`)
+# turns argument-validation bugs into process aborts at the public
+# API surface. The SP-8 verdict is that public constructors should
+# return `Result` or take pre-validated types; `debug_assert!` is
+# allowed (compiled out in release).
+#
+# Mechanical scope (heuristic, deliberately narrow — catches the
+# clearest shapes, accepts false-negatives over false-positives):
+#   - single-line constructor bodies: `pub fn new(...) -> Self { ...
+#     .unwrap()/.expect()/panic!/assert! ... }`
+#   - inline body with one of the panic forms on the SAME line as the
+#     `pub fn (new|from_*|try_*)` signature.
+#
+# Multi-line constructor bodies are NOT inspected — that requires
+# real-AST traversal; rustc + clippy lints (`clippy::expect_used`,
+# `clippy::unwrap_used`) cover that surface where opted in.
+#
+# Allowlist marker grammar:
+#   pub fn new() -> Self { foo.unwrap() }  // PORT-CHECK-OK-SP8: <reason>
+# -----------------------------------------------------------------------------
+trigger13_hits=$(rg --line-number --no-heading \
+    'pub fn (new|from_[a-z_]+|try_[a-z_]+)\b[^{]*\{[^}]*(\.unwrap\(\)|\.expect\(|panic!\s*\(|assert!\s*\()' \
+    --type rust \
+    --glob '!**/tests/**' \
+    --glob '!**/test*.rs' \
+    --glob '!examples/**' \
+    --glob '!crates/flui-platform/src/platforms/**' \
+    crates/ 2>/dev/null \
+  | grep -Ev ':\s*(//!|///|//)' \
+  | grep -Ev 'debug_assert' \
+  | grep -Ev '//\s*PORT-CHECK-OK-SP8:' \
+  || true)
+
+if [[ -n "${trigger13_hits}" ]]; then
+  echo 'VIOLATION 13: SP-8 constructor-time panics (unwrap/expect/panic!/assert! in pub constructor body)'
+  echo "see ${trigger_doc} (trigger 13)"
+  echo "${trigger13_hits}"
+  echo ""
+  violations=$((violations + 1))
+else
+  if [[ "${verbose}" -eq 1 ]]; then
+    echo "ok    13: SP-8 constructor-time panics"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
 # Trigger 9 (FR-036, Phase 3.1 §U30) — sanctioned `dyn`-boundary registry.
 #
 # Greps every `Box<dyn …>`, reference `dyn …` (in any of the four reference
@@ -482,5 +848,5 @@ if [[ "${violations}" -gt 0 ]]; then
   exit 1
 fi
 
-echo "port-check: all seven refusal triggers + FR-033 grep + trigger 9 (FR-036) clean"
+echo "port-check: all 13 refusal triggers + FR-033 grep clean"
 exit 0

--- a/scripts/port-check.sh
+++ b/scripts/port-check.sh
@@ -445,7 +445,7 @@ fi
 # issue or follow-up doc so the stub doesn't become permanent. Per-site
 # audit during PR review enforces this.
 # -----------------------------------------------------------------------------
-trigger8_hits=$(rg --line-number --column \
+trigger8_raw=$(rg --line-number --column \
     -e 'unimplemented!\s*\(' \
     -e 'todo!\s*\(' \
     --type rust \
@@ -459,7 +459,34 @@ trigger8_hits=$(rg --line-number --column \
   | grep -Ev '//\s*PORT-CHECK-OK-STUB:' \
   || true)
 
-if [[ -n "${trigger8_hits}" ]]; then
+# **PR #151 Codex review #3295220689:** post-filter out matches inside
+# in-file `#[cfg(test)]` blocks (Rust convention: `#[cfg(test)] mod
+# tests { ... }` at end of source file). The path-glob exclusions
+# above only drop dedicated test files; in-file test modules slip
+# through and false-positive on test-only `todo!()` / `unimplemented!()`
+# scaffolding.
+#
+# Heuristic: scan the file from the top to the matched line for a
+# `#[cfg(test)]` attribute on its own line. If found, assume the match
+# is inside a test mod and drop. This accepts the false-negative of
+# a `cfg(test)` ancestor that doesn't actually enclose the match
+# (rare in practice; tests/ + test*.rs path-exclusion handles the
+# dedicated-test-file case).
+trigger8_hits=""
+while IFS= read -r match_line; do
+  [[ -z "${match_line}" ]] && continue
+  match_file=$(echo "${match_line}" | awk -F':' '{print $1}' | tr '\\' '/')
+  match_lineno=$(echo "${match_line}" | awk -F':' '{print $2}')
+  [[ -z "${match_file}" || -z "${match_lineno}" ]] && continue
+  if head -n "${match_lineno}" "${match_file}" 2>/dev/null \
+      | grep -qE '^[[:space:]]*#\[cfg\(test\)\][[:space:]]*$'; then
+    continue
+  fi
+  trigger8_hits="${trigger8_hits}${match_line}
+"
+done <<< "${trigger8_raw}"
+
+if [[ -n "${trigger8_hits// }" ]]; then
   echo 'VIOLATION 8: SP-1 stubbed-but-called (unimplemented!()/todo!() in production fn body)'
   echo "see ${trigger_doc} (trigger 8)"
   echo "${trigger8_hits}"
@@ -533,11 +560,17 @@ while IFS= read -r raw_line; do
   fi
 done <<< "${trigger10_defs_raw}"
 
-# Build a tab-separated index: crate \t kind \t name \t full-line
+# Build a tab-separated index: crate \t kind \t name \t full-line.
+# **PR #151 Copilot review #3295220014:** Windows rg output uses `\`
+# in paths; the awk `split($1, parts, "/")` then yields `n < 2` and
+# silently drops every entry, suppressing all SP-3 duplicate detection.
+# Normalize backslash → forward slash before splitting.
 trigger10_index=$(echo "${trigger10_defs}" | awk -F':' '
 BEGIN { OFS = "\t" }
 {
-  n = split($1, parts, "/")
+  fp = $1
+  gsub(/\\/, "/", fp)
+  n = split(fp, parts, "/")
   if (n < 2) next
   crate = parts[2]
   line = $0
@@ -626,8 +659,21 @@ for libfile in ${trigger11_lib_files}; do
     [[ -z "${modname}" ]] && continue
 
     # Skip if previous non-blank line is `#[cfg(feature = "unstable-...")]`.
+    # **PR #151 Copilot review #3295220020 + Codex #3295220690:** the
+    # comment promises "previous non-blank line" but pre-fix only
+    # checked `lineno - 1`, so a blank separator between the cfg
+    # attribute and `pub mod` would false-positive. Scan backward
+    # until a non-blank line is found.
     prev_lineno=$((lineno - 1))
-    prev_content=$(sed -n "${prev_lineno}p" "${libfile}")
+    prev_content=""
+    while [[ "${prev_lineno}" -gt 0 ]]; do
+      prev_content=$(sed -n "${prev_lineno}p" "${libfile}")
+      # Strip whitespace; if non-empty, this is our target line.
+      if [[ -n "${prev_content// }" ]]; then
+        break
+      fi
+      prev_lineno=$((prev_lineno - 1))
+    done
     if echo "${prev_content}" | grep -qE '#\[cfg\(feature[[:space:]]*=[[:space:]]*"unstable-'; then
       continue
     fi


### PR DESCRIPTION
## Summary

D-block PR-C-3 — install 5 new mechanical refusal triggers
(#8/#10/#11/#12/#13) in `scripts/port-check.sh`, document them in
`docs/PORT.md`, and add per-site allowlist markers for the
pre-existing instances the triggers surface.

Closes the D-block plan §U41-U47. With PR-A1 + PR-A2 already in main
(D-1/D-3/D-4 closed), PR-C-3 is the durable enforcement layer that
prevents regression of the SP-1/SP-3/SP-4/SP-6/SP-8 anti-patterns the
architecture-correction-plan identified.

## Triggers shipped

| # | U-ID | SP | Anti-pattern | Allowlist marker |
| - | ---- | -- | ------------ | ---------------- |
| 8  | U41 | SP-1 | `unimplemented!()` / `todo!()` in production fn body                 | `// PORT-CHECK-OK-STUB:` |
| 10 | U42 | SP-3 | Parallel cross-crate `pub struct/enum/trait` definitions             | `// PORT-CHECK-OK-SP3:`  |
| 11 | U43 | SP-4 | `pub mod` with zero workspace consumers, not feature-gated           | `// PORT-CHECK-OK-SP4:`  |
| 12 | U44 | SP-6 | `RwLock/Mutex/Arc<RwLock<...>>` in `pub fn` return / `pub` field     | `// PORT-CHECK-OK-SP6:`  |
| 13 | U45 | SP-8 | `.unwrap()/.expect()/panic!()/assert!()` in public constructor body  | `// PORT-CHECK-OK-SP8:`  |

## Commits

1. `feat(scripts): PR-C-3 — install 5 new refusal triggers in port-check.sh` (U41-U45 + U47)
2. `docs(port): PR-C-3 U46 — document 5 new refusal triggers in PORT.md`
3. `chore: PR-C-3 — allowlist markers for pre-existing SP-1/SP-3/SP-4/SP-6 sites`

## Allowlist marker counts

- **SP-1:** 1 marker (macOS platform stub awaiting native-platform impl).
- **SP-3:** 84 markers (42 pre-existing parallel definitions × 2 sites each — consolidation tracked separately).
- **SP-4:** 12 markers (binding entries, macro re-exports, future-consumer placeholders).
- **SP-6:** 24 markers (binding/context layer lock leaks, callback-storage fields).
- **SP-8:** 0 markers (narrow heuristic returns 0 violations on current code).

Total 121 markers across 76 framework-crate files. Each marker carries
a one-line reason or tracking pointer; future ADDITIONS of the same
pattern still fire the trigger.

## Verification

- `bash scripts/port-check.sh -v` — all 13 refusal triggers + FR-033 grep green.
- `cargo build --workspace` — green.
- `cargo test -p flui-rendering --lib --tests` — 281 lib + 18 integration tests pass.
- `cargo clippy --workspace --all-targets -- -D warnings` — green.
- `cargo fmt --all -- --check` — green.

## Implementation notes

- **Windows-portability fix in port-check.sh:** backslash → forward-slash normalization on file paths before `awk -F'/'` field splitting (Windows rg output uses backslash; awk would otherwise miscount fields).
- **Marker placement vs rustfmt:** for block-opening declarations (`pub enum Foo {`, `pub struct Bar {`, `pub fn baz() -> RwLockGuard {`), rustfmt may move a trailing same-line marker into the body. Triggers #10 and #12 scan a ±2-line window for the marker to survive this re-formatting.
- **Trigger #11 scope limitations:** mechanical scan catches lib.rs-level `pub mod` declarations, NOT sub-module speculation. For deeper SP-4 audits see manual verdicts in `architecture-correction-plan §SP-4`.
- **Trigger #13 scope is deliberately narrow:** matches single-line constructor bodies only. Multi-line constructor bodies are covered by rustc + `clippy::unwrap_used` where opted in.

## D-block status

**Core.0 D-block COMPLETE** with this PR:
- ✅ D-1 layout pipeline (PR-A1 U14-U23 — PR #139-148)
- ✅ D-3 compositing-bits walk (PR-A2 U32-U34 — PR #149)
- ✅ D-4 paint flag-clear (PR-A2 U35 — PR #149)
- ✅ C-track (PR-C-1 log + PR-C-2 geometry — PR #137/#138)
- ✅ PR-C-3 refusal trigger backfill (this PR)

U24-U31 + U37/U39/U40 AE tests deferred per execution strategy
(u20-u23 + u34 integration tests already cover the AE surface).

## References

- `docs/plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md` §U41-U47
- `docs/research/2026-05-22-architecture-correction-plan.md` §SP-1, §SP-3, §SP-4, §SP-6, §SP-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
