### PR TITLE
chore+fix: bump MSRV to Rust 1.95 and restore 208 broken workspace doctests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ FLUI is a modular, Flutter-inspired declarative UI framework for Rust with a thr
 
 ## Tech Stack
 
-- **Programming language:** Rust 1.94 (edition 2024)
+- **Programming language:** Rust 1.95 (edition 2024)
 - **Build system:** Cargo workspace (20+ crates organized in foundation / core / rendering / framework / application layers)
 - **Async runtime:** `tokio` 1.43 LTS
 - **Graphics:** `wgpu` 25.x (pinned), `lyon`, `glyphon`, `cosmic-text`, `glam`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ default-members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 license = "MIT OR Apache-2.0"
 authors = ["Flui Contributors"]
 repository = "https://github.com/vanyastaff/flui"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See [`docs/crates.md`](docs/crates.md) for the full layered map and per-crate st
 
 ## Quick Start
 
-Prerequisites: Rust 1.94 (edition 2024). The repository is a Cargo workspace, not yet published to crates.io.
+Prerequisites: Rust 1.95 (edition 2024). The repository is a Cargo workspace, not yet published to crates.io. A `rust-toolchain.toml` is committed, so `rustup` will install and select the correct toolchain automatically.
 
 ```bash
 git clone https://github.com/vanyastaff/flui

--- a/crates/flui-geometry/src/bounds.rs
+++ b/crates/flui-geometry/src/bounds.rs
@@ -703,8 +703,9 @@ impl<T: Unit> Bounds<T> {
 
 /// Convenience constructor for [`Bounds<Pixels>`] from an origin point and size.
 ///
-/// Mirrors the constructor-function pattern used by [`rect`](crate::rect),
-/// [`point`](crate::point), [`size`](crate::size), and [`edges`](crate::edges).
+/// Mirrors the constructor-function pattern used by [`rect()`](crate::rect()),
+/// [`point()`](crate::point()), [`size()`](crate::size()), and
+/// [`edges()`](crate::edges()).
 #[inline]
 #[must_use]
 pub fn bounds(origin: Point<Pixels>, size: Size<Pixels>) -> Bounds<Pixels> {

--- a/crates/flui-geometry/src/bounds.rs
+++ b/crates/flui-geometry/src/bounds.rs
@@ -10,7 +10,7 @@
 //! of coordinate systems:
 //!
 //! ```ignore
-//! use flui_types::geometry::{Bounds, Point, Size, Pixels, DevicePixels, px, device_px};
+//! use flui_geometry::{Bounds, Point, Size, Pixels, DevicePixels, px, device_px};
 //!
 //! let ui_bounds = Bounds::<Pixels>::new(
 //!     Point::new(px(10.0), px(20.0)),
@@ -36,7 +36,7 @@
 //! # Examples
 //!
 //! ```
-//! use flui_types::geometry::{bounds, point, size};
+//! use flui_geometry::{bounds, point, size};
 //!
 //! let a = bounds(point(0.0, 0.0), size(10.0, 10.0));
 //! let b = bounds(point(5.0, 5.0), size(10.0, 10.0));
@@ -695,4 +695,18 @@ impl<T: Unit> Bounds<T> {
             ),
         }
     }
+}
+
+// =============================================================================
+// CONSTRUCTOR FUNCTION (symmetric with `rect()`, `point()`, `size()`, `edges()`)
+// =============================================================================
+
+/// Convenience constructor for [`Bounds<Pixels>`] from an origin point and size.
+///
+/// Mirrors the constructor-function pattern used by [`rect`](crate::rect),
+/// [`point`](crate::point), [`size`](crate::size), and [`edges`](crate::edges).
+#[inline]
+#[must_use]
+pub fn bounds(origin: Point<Pixels>, size: Size<Pixels>) -> Bounds<Pixels> {
+    Bounds::new(origin, size)
 }

--- a/crates/flui-geometry/src/circle.rs
+++ b/crates/flui-geometry/src/circle.rs
@@ -8,7 +8,7 @@
 //! of coordinate systems:
 //!
 //! ```ignore
-//! use flui_types::geometry::{Circle, Point, Pixels, px};
+//! use flui_geometry::{Circle, Point, Pixels, px};
 //!
 //! let ui_circle = Circle::<Pixels>::new(
 //!     Point::new(px(50.0), px(50.0)),

--- a/crates/flui-geometry/src/edges.rs
+++ b/crates/flui-geometry/src/edges.rs
@@ -164,7 +164,7 @@ impl Edges<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Edges, px};
+    /// use flui_geometry::{Edges, px};
     ///
     /// let insets = Edges::only_left(px(10.0));
     /// assert_eq!(insets.left, px(10.0));
@@ -223,7 +223,7 @@ impl Edges<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Edges, Size, px};
+    /// use flui_geometry::{Edges, Size, px};
     ///
     /// let insets = Edges::new(px(10.0), px(20.0), px(30.0), px(40.0));
     /// let size = insets.total_size();
@@ -241,7 +241,7 @@ impl Edges<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Edges, Offset, px};
+    /// use flui_geometry::{Edges, Offset, px};
     ///
     /// let insets = Edges::new(px(10.0), px(20.0), px(30.0), px(40.0));
     /// let offset = insets.top_left();
@@ -259,7 +259,7 @@ impl Edges<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Edges, Offset, px};
+    /// use flui_geometry::{Edges, Offset, px};
     ///
     /// let insets = Edges::new(px(10.0), px(20.0), px(30.0), px(40.0));
     /// let offset = insets.bottom_right();
@@ -277,7 +277,7 @@ impl Edges<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Edges, px};
+    /// use flui_geometry::{Edges, px};
     ///
     /// let zero_insets = Edges::ZERO;
     /// assert!(zero_insets.is_zero());
@@ -300,7 +300,7 @@ impl Edges<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Edges, px};
+    /// use flui_geometry::{Edges, px};
     ///
     /// let positive = Edges::all(px(10.0));
     /// assert!(positive.is_non_negative());
@@ -323,7 +323,7 @@ impl Edges<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Edges, px};
+    /// use flui_geometry::{Edges, px};
     ///
     /// let insets = Edges::new(px(-5.0), px(10.0), px(-3.0), px(20.0));
     /// let clamped = insets.clamp_non_negative();
@@ -379,7 +379,7 @@ impl Edges<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Edges, Point, Rect, px};
+    /// use flui_geometry::{Edges, Point, Rect, px};
     ///
     /// let insets = Edges::all(px(10.0));
     /// let rect = Rect::from_ltrb(px(0.0), px(0.0), px(100.0), px(100.0));
@@ -408,7 +408,7 @@ impl Edges<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Edges, Point, Rect, px};
+    /// use flui_geometry::{Edges, Point, Rect, px};
     ///
     /// let insets = Edges::all(px(10.0));
     /// let rect = Rect::from_ltrb(px(0.0), px(0.0), px(100.0), px(100.0));
@@ -437,7 +437,7 @@ impl Edges<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Edges, Size, px};
+    /// use flui_geometry::{Edges, Size, px};
     ///
     /// let insets = Edges::all(px(10.0));
     /// let size = Size::new(px(100.0), px(100.0));
@@ -464,7 +464,7 @@ impl Edges<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Edges, Size, px};
+    /// use flui_geometry::{Edges, Size, px};
     ///
     /// let insets = Edges::all(px(10.0));
     /// let size = Size::new(px(100.0), px(100.0));
@@ -489,7 +489,7 @@ impl Edges<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Edges, px};
+    /// use flui_geometry::{Edges, px};
     ///
     /// let insets = Edges::new(px(10.0), px(20.0), px(30.0), px(40.0));
     /// let flipped = insets.flip_horizontal();
@@ -512,7 +512,7 @@ impl Edges<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Edges, px};
+    /// use flui_geometry::{Edges, px};
     ///
     /// let insets = Edges::new(px(10.0), px(20.0), px(30.0), px(40.0));
     /// let flipped = insets.flip_vertical();

--- a/crates/flui-geometry/src/length.rs
+++ b/crates/flui-geometry/src/length.rs
@@ -22,7 +22,7 @@
 //! # Examples
 //!
 //! ```rust
-//! use flui_types::geometry::{Pixels, auto, px, relative, rems};
+//! use flui_geometry::{Pixels, auto, px, relative, rems};
 //!
 //! // Absolute lengths
 //! let width = px(100.0); // 100 pixels
@@ -249,7 +249,7 @@ impl std::str::FromStr for Rems {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::Rems;
+    /// use flui_geometry::Rems;
     ///
     /// let r: Rems = "1.5".parse().unwrap();
     /// assert_eq!(r.get(), 1.5);
@@ -506,7 +506,7 @@ impl AbsoluteLength {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_types::geometry::{AbsoluteLength, px, rems};
+    /// use flui_geometry::{AbsoluteLength, px, rems};
     ///
     /// let zero_px: AbsoluteLength = px(0.0).into();
     /// let zero_rem: AbsoluteLength = rems(0.0).into();

--- a/crates/flui-geometry/src/lib.rs
+++ b/crates/flui-geometry/src/lib.rs
@@ -34,7 +34,7 @@
 //! # Type Safety Example
 //!
 //! ```rust,ignore
-//! use flui_types::geometry::prelude::*;
+//! use flui_geometry::prelude::*;
 //!
 //! // Different coordinate systems are distinct types
 //! let ui_pos = Point::<Pixels>::new(px(100.0), px(200.0));
@@ -52,7 +52,7 @@
 //! Multiple conversion strategies for wgpu integration:
 //!
 //! ```rust,ignore
-//! use flui_types::geometry::prelude::*;
+//! use flui_geometry::prelude::*;
 //!
 //! let pos = Point::<Pixels>::new(px(100.0), px(200.0));
 //!
@@ -74,7 +74,7 @@
 //! Three constructor levels for different trust contexts:
 //!
 //! ```rust,ignore
-//! use flui_types::geometry::prelude::*;
+//! use flui_geometry::prelude::*;
 //!
 //! // Fast (no validation) - for hot loops
 //! let p = Point::new(x, y);
@@ -148,7 +148,7 @@ pub mod vector;
 /// # Usage
 ///
 /// ```rust,ignore
-/// use flui_types::geometry::prelude::*;
+/// use flui_geometry::prelude::*;
 ///
 /// let pos = Point::<Pixels>::new(px(100.0), px(200.0));
 /// let size = Size::<Pixels>::new(px(50.0), px(30.0));
@@ -188,7 +188,7 @@ pub mod prelude {
 // SHAPE TYPES
 // =============================================================================
 pub use bezier::{CubicBez, QuadBez};
-pub use bounds::Bounds;
+pub use bounds::{Bounds, bounds};
 pub use circle::Circle;
 // =============================================================================
 // STRUCTURAL TYPES
@@ -245,6 +245,7 @@ pub use traits::{
     Along, ApproxEq, Axis, Double, GeometryOps, Half, IsZero, NumericUnit, Sign, Unit,
 };
 pub use transform::Transform;
+pub use transform2d::Transform2D;
 // =============================================================================
 // UNIT TYPES
 // =============================================================================

--- a/crates/flui-geometry/src/matrix4.rs
+++ b/crates/flui-geometry/src/matrix4.rs
@@ -20,7 +20,7 @@
 //! ## Basic Transformations
 //!
 //! ```
-//! use flui_types::Matrix4;
+//! use flui_geometry::{Matrix4, px};
 //!
 //! // Identity matrix (const-evaluable)
 //! const IDENTITY: Matrix4 = Matrix4::identity();
@@ -38,13 +38,13 @@
 //! let combined = translate * rotate * scale;
 //!
 //! // Transform a point
-//! let (x, y) = combined.transform_point(1.0, 0.0);
+//! let (x, y) = combined.transform_point(px(1.0), px(0.0));
 //! ```
 //!
 //! ## Advanced Operations
 //!
 //! ```
-//! use flui_types::Matrix4;
+//! use flui_geometry::Matrix4;
 //!
 //! let m = Matrix4::rotation_z(0.5);
 //!
@@ -64,7 +64,7 @@
 //! ## Type-Safe Access
 //!
 //! ```
-//! use flui_types::Matrix4;
+//! use flui_geometry::Matrix4;
 //!
 //! let mut m = Matrix4::identity();
 //!
@@ -83,7 +83,7 @@
 //! ## Approximate Equality
 //!
 //! ```
-//! use flui_types::Matrix4;
+//! use flui_geometry::Matrix4;
 //!
 //! let m1 = Matrix4::translation(1.0, 2.0, 0.0);
 //! let m2 = Matrix4::translation(1.0000001, 2.0, 0.0);
@@ -134,7 +134,7 @@ impl Matrix4 {
     /// # Example
     ///
     /// ```
-    /// use flui_types::Matrix4;
+    /// use flui_geometry::Matrix4;
     ///
     /// let transform = Matrix4::IDENTITY;
     /// assert!(transform.is_identity());
@@ -150,7 +150,7 @@ impl Matrix4 {
     /// # Example
     ///
     /// ```
-    /// use flui_types::Matrix4;
+    /// use flui_geometry::Matrix4;
     ///
     /// let zero = Matrix4::ZERO;
     /// assert_eq!(zero.determinant(), 0.0);
@@ -925,7 +925,7 @@ impl MulAssign for Matrix4 {
 ///
 /// # Example
 /// ```
-/// use flui_types::Matrix4;
+/// use flui_geometry::Matrix4;
 /// let m = Matrix4::identity();
 /// assert_eq!(m[0], 1.0); // m00
 /// assert_eq!(m[5], 1.0); // m11

--- a/crates/flui-geometry/src/offset.rs
+++ b/crates/flui-geometry/src/offset.rs
@@ -32,7 +32,7 @@ use super::{
 /// # Examples
 ///
 /// ```
-/// use flui_types::geometry::{Offset, px, Pixels};
+/// use flui_geometry::{Offset, px, Pixels};
 ///
 /// let offset = Offset::<Pixels>::new(px(10.0), px(20.0));
 /// assert_eq!(offset.dx.get(), 10.0);
@@ -72,7 +72,7 @@ impl<T: Unit> Offset<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, px};
+    /// use flui_geometry::{Offset, px};
     ///
     /// let offset = Offset::new(px(10.0), px(20.0));
     /// assert_eq!(offset.dx.get(), 10.0);
@@ -88,7 +88,7 @@ impl<T: Unit> Offset<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, px};
+    /// use flui_geometry::{Offset, px};
     ///
     /// let offset = Offset::new(px(10.0), px(20.0));
     /// let swapped = offset.swap();
@@ -108,7 +108,7 @@ impl<T: Unit> Offset<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, px, Pixels};
+    /// use flui_geometry::{Offset, px, Pixels};
     ///
     /// let offset: Offset<Pixels> = Offset::new(px(10.0), px(20.0));
     /// let doubled: Offset<Pixels> = offset.map(|v| v * 2.0);
@@ -148,7 +148,7 @@ impl<T: Unit> Offset<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, Vec2, px, Pixels};
+    /// use flui_geometry::{Offset, Vec2, px, Pixels};
     ///
     /// let offset = Offset::new(px(10.0), px(20.0));
     /// let vec: Vec2<Pixels> = offset.to_vec2();
@@ -174,7 +174,7 @@ impl<T: Unit> Offset<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, Pixels, px};
+    /// use flui_geometry::{Offset, Pixels, px};
     ///
     /// let px_offset = Offset::<Pixels>::new(px(10.0), px(20.0));
     /// let f32_offset: Offset<Pixels> = px_offset.cast();
@@ -201,7 +201,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, px};
+    /// use flui_geometry::{Offset, px};
     ///
     /// let offset = Offset::new(px(10.0), px(20.0));
     /// let f32_offset = offset.to_f32();
@@ -226,7 +226,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, px};
+    /// use flui_geometry::{Offset, px};
     ///
     /// let offset = Offset::from_direction(0.0, 10.0);
     /// assert!((offset.dx.get() - 10.0).abs() < 0.001);
@@ -248,7 +248,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, Point, px};
+    /// use flui_geometry::{Offset, Point, px};
     ///
     /// let from = Point::new(px(10.0), px(20.0));
     /// let to = Point::new(px(30.0), px(50.0));
@@ -266,7 +266,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, px};
+    /// use flui_geometry::{Offset, px};
     ///
     /// assert!(Offset::ZERO.is_zero());
     /// assert!(!Offset::new(px(1.0), px(0.0)).is_zero());
@@ -281,7 +281,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, px};
+    /// use flui_geometry::{Offset, px};
     ///
     /// let offset = Offset::new(px(3.0), px(4.0));
     /// assert_eq!(offset.distance().get(), 5.0); // 3-4-5 triangle
@@ -296,7 +296,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, px};
+    /// use flui_geometry::{Offset, px};
     ///
     /// let offset = Offset::new(px(3.0), px(4.0));
     /// assert_eq!(offset.distance_squared().get(), 25.0);
@@ -311,7 +311,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, px};
+    /// use flui_geometry::{Offset, px};
     ///
     /// let right = Offset::new(px(1.0), px(0.0));
     /// assert!((right.direction() - 0.0).abs() < 0.001);
@@ -326,7 +326,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::Offset;
+    /// use flui_geometry::Offset;
     ///
     /// assert!(Offset::ZERO.is_finite());
     /// assert!(!Offset::INFINITE.is_finite());
@@ -347,7 +347,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, px};
+    /// use flui_geometry::{Offset, px};
     ///
     /// let offset = Offset::new(px(10.0), px(20.0));
     /// let scaled = offset.scale(2.0);
@@ -363,7 +363,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, px};
+    /// use flui_geometry::{Offset, px};
     ///
     /// let a = Offset::new(px(10.0), px(20.0));
     /// let b = Offset::new(px(5.0), px(10.0));
@@ -381,7 +381,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, px};
+    /// use flui_geometry::{Offset, px};
     ///
     /// let a = Offset::new(px(0.0), px(0.0));
     /// let b = Offset::new(px(10.0), px(10.0));
@@ -403,7 +403,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, Point, px};
+    /// use flui_geometry::{Offset, Point, px};
     ///
     /// let offset = Offset::new(px(10.0), px(20.0));
     /// let point = offset.to_point();
@@ -421,7 +421,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, Size, px};
+    /// use flui_geometry::{Offset, Size, px};
     ///
     /// let offset = Offset::new(px(10.0), px(20.0));
     /// let size = offset.to_size();
@@ -519,7 +519,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, px};
+    /// use flui_geometry::{Offset, px};
     ///
     /// let offset = Offset::new(px(30.0), px(40.0)); // magnitude = 50
     /// let clamped = offset.clamp_magnitude(25.0);
@@ -550,7 +550,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, px};
+    /// use flui_geometry::{Offset, px};
     ///
     /// let start = Offset::new(px(0.0), px(0.0));
     /// let target = Offset::new(px(10.0), px(0.0));
@@ -588,7 +588,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, px};
+    /// use flui_geometry::{Offset, px};
     /// use std::f32::consts::PI;
     ///
     /// let right = Offset::new(px(1.0), px(0.0));
@@ -940,7 +940,7 @@ impl Offset<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{DevicePixels, Offset, Pixels, ScaleFactor, device_px, px};
+    /// use flui_geometry::{DevicePixels, Offset, Pixels, ScaleFactor, device_px, px};
     ///
     /// let logical = Offset::new(px(10.0), px(20.0));
     /// let scale = ScaleFactor::<Pixels, DevicePixels>::new(2.0);
@@ -968,7 +968,7 @@ impl Offset<super::units::DevicePixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{DevicePixels, Offset, Pixels, ScaleFactor, device_px, px};
+    /// use flui_geometry::{DevicePixels, Offset, Pixels, ScaleFactor, device_px, px};
     ///
     /// let device = Offset::new(device_px(20), device_px(40));
     /// let scale = ScaleFactor::<Pixels, DevicePixels>::new(2.0);

--- a/crates/flui-geometry/src/point.rs
+++ b/crates/flui-geometry/src/point.rs
@@ -37,10 +37,11 @@ use super::{
 /// # Examples
 ///
 /// ```
-/// use flui_types::geometry::{Point, px, Pixels};
+/// use flui_geometry::{Point, px, Pixels};
 ///
 /// let ui_pos = Point::<Pixels>::new(px(100.0), px(200.0));
-/// let normalized = Point::<f32>::new(0.5, 0.75);
+/// let normalized = Point::<Pixels>::new(px(0.5), px(0.75));
+/// ```
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Point<T: Unit = Pixels> {
     /// The x coordinate (horizontal position).
@@ -102,10 +103,11 @@ impl<T: Unit> Point<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::Point;
+    /// use flui_geometry::{Point, px};
     ///
-    /// let p = Point::new(10.0, 20.0);
-    /// assert_eq!(p.swap(), Point::new(20.0, 10.0));
+    /// let p = Point::new(px(10.0), px(20.0));
+    /// assert_eq!(p.swap(), Point::new(px(20.0), px(10.0)));
+    /// ```
     #[inline]
     #[must_use]
     pub fn swap(self) -> Self {
@@ -207,11 +209,12 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::Point;
+    /// use flui_geometry::{Pixels, Point, px};
     ///
-    /// let p: Point<Pixels> = Point::new(3.0, 4.0);
+    /// let p: Point<Pixels> = Point::new(px(3.0), px(4.0));
     /// let p_doubled: Point<Pixels> = p.map(|coord| coord * 2.0);
-    /// assert_eq!(p_doubled, Point::new(6.0, 8.0));
+    /// assert_eq!(p_doubled, Point::new(px(6.0), px(8.0)));
+    /// ```
     #[inline]
     #[must_use]
     pub fn map<U>(self, f: impl Fn(T) -> U) -> Point<U>
@@ -279,11 +282,12 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::Point;
+    /// use flui_geometry::{Point, px};
     ///
-    /// let p1 = Point::new(0.0, 0.0);
-    /// let p2 = Point::new(3.0, 4.0);
+    /// let p1 = Point::new(px(0.0), px(0.0));
+    /// let p2 = Point::new(px(3.0), px(4.0));
     /// assert_eq!(p1.distance(p2), 5.0);
+    /// ```
     #[inline]
     #[must_use]
     pub fn distance(self, other: Self) -> f32 {
@@ -310,11 +314,12 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::Point;
+    /// use flui_geometry::{Point, px};
     ///
-    /// let p1 = Point::new(0.0, 0.0);
-    /// let p2 = Point::new(10.0, 20.0);
-    /// assert_eq!(p1.midpoint(p2), Point::new(5.0, 10.0));
+    /// let p1 = Point::new(px(0.0), px(0.0));
+    /// let p2 = Point::new(px(10.0), px(20.0));
+    /// assert_eq!(p1.midpoint(p2), Point::new(px(5.0), px(10.0)));
+    /// ```
     #[inline]
     #[must_use]
     pub fn midpoint(self, other: Self) -> Self {
@@ -496,18 +501,19 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Point, Vec2, px, Pixels};
+    /// use flui_geometry::{Pixels, Point, Vec2, px};
     ///
-    /// let p1 = Point::<f32>::new(10.0, 20.0);
-    /// let p2 = Point::<f32>::new(3.0, 5.0);
+    /// let p1 = Point::<Pixels>::new(px(10.0), px(20.0));
+    /// let p2 = Point::<Pixels>::new(px(3.0), px(5.0));
     /// let v: Vec2<Pixels> = p1 - p2;
-    /// assert_eq!(v, Vec2::new(7.0, 15.0));
+    /// assert_eq!(v, Vec2::new(px(7.0), px(15.0)));
     ///
     /// // Works with Pixels too
     /// let p1 = Point::new(px(100.0), px(200.0));
     /// let p2 = Point::new(px(30.0), px(50.0));
     /// let v: Vec2<Pixels> = p1 - p2;
     /// assert_eq!(v.x.get(), 70.0);
+    /// ```
     #[inline]
     fn sub(self, rhs: Self) -> Vec2<T> {
         Vec2::new(T::sub(self.x, rhs.x), T::sub(self.y, rhs.y))
@@ -665,13 +671,12 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Point, point};
+    /// use flui_geometry::{Pixels, Point, px};
     ///
-    /// let p = Point::<f32>::new(1.0, 2.0);
-    /// // Note: This would need Vec2<Pixels> to work fully generically
-    /// let result = p.checked_add_vec(3.0, 4.0);
+    /// let p = Point::<Pixels>::new(px(1.0), px(2.0));
+    /// let result = p.checked_add_vec(px(3.0), px(4.0));
     /// assert!(result.is_some());
-    /// assert_eq!(result.unwrap(), Point::new(4.0, 6.0));
+    /// assert_eq!(result.unwrap(), Point::new(px(4.0), px(6.0)));
     /// ```
     #[inline]
     #[must_use]
@@ -693,13 +698,13 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Point, point};
+    /// use flui_geometry::{Pixels, Point, px};
     ///
-    /// let p = Point::<f32>::new(1.0, 2.0);
-    /// let result = p.saturating_add_vec(f32::NAN, 4.0);
+    /// let p = Point::<Pixels>::new(px(1.0), px(2.0));
+    /// let result = p.saturating_add_vec(px(f32::NAN), px(4.0));
     /// // NaN gets clamped to 0
-    /// assert_eq!(result.x, 0.0);
-    /// assert_eq!(result.y, 6.0);
+    /// assert_eq!(result.x, px(0.0));
+    /// assert_eq!(result.y, px(6.0));
     /// ```
     #[inline]
     #[must_use]
@@ -712,12 +717,12 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Point, point};
+    /// use flui_geometry::{Pixels, Point, px};
     ///
-    /// let p = Point::<f32>::new(1.0, 2.0);
+    /// let p = Point::<Pixels>::new(px(1.0), px(2.0));
     /// let result = p.checked_mul(2.0);
     /// assert!(result.is_some());
-    /// assert_eq!(result.unwrap(), Point::new(2.0, 4.0));
+    /// assert_eq!(result.unwrap(), Point::new(px(2.0), px(4.0)));
     ///
     /// let infinity = p.checked_mul(f32::INFINITY);
     /// assert!(infinity.is_none());
@@ -744,12 +749,12 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Point, point};
+    /// use flui_geometry::{Pixels, Point, px};
     ///
-    /// let p = Point::<f32>::new(1.0, 2.0);
+    /// let p = Point::<Pixels>::new(px(1.0), px(2.0));
     /// let result = p.saturating_mul(f32::INFINITY);
-    /// assert_eq!(result.x, f32::MAX);
-    /// assert_eq!(result.y, f32::MAX);
+    /// assert_eq!(result.x, px(f32::MAX));
+    /// assert_eq!(result.y, px(f32::MAX));
     /// ```
     #[inline]
     #[must_use]
@@ -770,7 +775,7 @@ impl<T: Unit> Point<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Point, Pixels, px};
+    /// use flui_geometry::{Point, Pixels, px};
     ///
     /// let p = Point::<Pixels>::new(px(100.0), px(200.0));
     /// let p_f32: Point<Pixels> = p.cast();
@@ -803,7 +808,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Point, px};
+    /// use flui_geometry::{Pixels, Point, px};
     ///
     /// let p = Point::<Pixels>::new(px(100.0), px(200.0));
     /// let p_f32 = p.to_f32();
@@ -823,7 +828,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Point, Pixels, px};
+    /// use flui_geometry::{Point, Pixels, px};
     ///
     /// let p = Point::<Pixels>::new(px(100.0), px(200.0));
     /// let arr = p.to_array();
@@ -839,7 +844,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Point, Pixels, px};
+    /// use flui_geometry::{Point, Pixels, px};
     ///
     /// let p = Point::<Pixels>::new(px(100.0), px(200.0));
     /// let tuple = p.to_tuple();
@@ -929,7 +934,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use flui_types::geometry::point;
+/// use flui_geometry::point;
 ///
 /// let p = point(10.0, 20.0);
 #[inline]
@@ -1101,7 +1106,7 @@ impl Point<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Point, px};
+    /// use flui_geometry::{Point, px};
     ///
     /// let p = Point::new(px(100.0), px(200.0));
     /// let scaled = p.scale(2.0);  // 2x Retina display
@@ -1119,7 +1124,7 @@ impl Point<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Point, px};
+    /// use flui_geometry::{Point, px};
     ///
     /// let p = Point::new(px(3.0), px(4.0));
     /// assert_eq!(p.magnitude(), 5.0);
@@ -1140,7 +1145,7 @@ impl Point<super::units::ScaledPixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Point, scaled_px};
+    /// use flui_geometry::{Point, scaled_px};
     ///
     /// let p = Point::new(scaled_px(199.7), scaled_px(299.3));
     /// let device = p.to_device_pixels();
@@ -1164,7 +1169,7 @@ impl Point<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{DevicePixels, Pixels, Point, ScaleFactor, device_px, px};
+    /// use flui_geometry::{DevicePixels, Pixels, Point, ScaleFactor, device_px, px};
     ///
     /// let logical = Point::new(px(100.0), px(200.0));
     /// let scale = ScaleFactor::<Pixels, DevicePixels>::new(2.0);
@@ -1192,9 +1197,9 @@ impl Point<super::units::DevicePixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{DevicePixels, Pixels, Point, ScaleFactor, device_px, px};
+    /// use flui_geometry::{DevicePixels, Pixels, Point, ScaleFactor, device_px, px};
     ///
-    /// let device = Point::new(device_px(200.0), device_px(400.0));
+    /// let device = Point::new(device_px(200), device_px(400));
     /// let scale = ScaleFactor::<Pixels, DevicePixels>::new(2.0);
     /// let logical = device.unscale(scale);
     /// assert_eq!(logical.x, px(100.0));
@@ -1227,12 +1232,13 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::Point;
+    /// use flui_geometry::{Point, px};
     ///
-    /// let p = Point::new(100.0, 150.0);
-    /// let origin = Point::new(20.0, 30.0);
+    /// let p = Point::new(px(100.0), px(150.0));
+    /// let origin = Point::new(px(20.0), px(30.0));
     /// let relative = p.relative_to(&origin);
-    /// assert_eq!(relative, Point::new(80.0, 120.0));
+    /// assert_eq!(relative, Point::new(px(80.0), px(120.0)));
+    /// ```
     #[inline]
     #[must_use]
     pub fn relative_to(&self, origin: &Point<T>) -> Point<T> {

--- a/crates/flui-geometry/src/rect.rs
+++ b/crates/flui-geometry/src/rect.rs
@@ -27,7 +27,7 @@ use super::{
 /// # Examples
 ///
 /// ```
-/// use flui_types::geometry::{Point, Rect, Size, point, size};
+/// use flui_geometry::{Point, Rect, Size, point, size};
 ///
 /// // Create from origin and size
 /// let rect = Rect::from_origin_size(point(0.0, 0.0), size(100.0, 50.0));
@@ -796,12 +796,9 @@ impl Rect<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{DevicePixels, Pixels, Point, Rect, ScaleFactor, Size, px};
+    /// use flui_geometry::{DevicePixels, Pixels, Rect, ScaleFactor, px};
     ///
-    /// let logical = Rect::new(
-    ///     Point::new(px(10.0), px(20.0)),
-    ///     Size::new(px(100.0), px(200.0)),
-    /// );
+    /// let logical = Rect::from_xywh(px(10.0), px(20.0), px(100.0), px(200.0));
     /// let scale = ScaleFactor::<Pixels, DevicePixels>::new(2.0);
     /// let device = logical.scale_with(scale);
     /// assert_eq!(device.origin().x.get(), 20);
@@ -826,7 +823,7 @@ impl Rect<super::units::DevicePixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{
+    /// use flui_geometry::{
     ///     DevicePixels, Pixels, Point, Rect, ScaleFactor, Size, device_px, px,
     /// };
     ///

--- a/crates/flui-geometry/src/size.rs
+++ b/crates/flui-geometry/src/size.rs
@@ -23,7 +23,7 @@ use super::{
 /// # Examples
 ///
 /// ```
-/// use flui_types::geometry::{Pixels, Size, px};
+/// use flui_geometry::{Pixels, Size, px};
 ///
 /// let ui_size = Size::<Pixels>::new(px(800.0), px(600.0));
 /// assert_eq!(ui_size.area(), 480_000.0);
@@ -89,7 +89,7 @@ impl<T: Unit> Size<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Size, px};
+    /// use flui_geometry::{Pixels, Size, px};
     ///
     /// let s = Size::<Pixels>::square(px(10.0));
     /// assert_eq!(s.width, px(10.0));
@@ -111,7 +111,7 @@ impl<T: NumericUnit> Size<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Size, px};
+    /// use flui_geometry::{Pixels, Size, px};
     ///
     /// let s1 = Size::<Pixels>::new(px(100.0), px(50.0));
     /// let s2 = Size::<Pixels>::new(px(80.0), px(60.0));
@@ -132,7 +132,7 @@ impl<T: NumericUnit> Size<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Size, px};
+    /// use flui_geometry::{Pixels, Size, px};
     ///
     /// let s1 = Size::<Pixels>::new(px(100.0), px(50.0));
     /// let s2 = Size::<Pixels>::new(px(80.0), px(60.0));
@@ -158,7 +158,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Size, px};
+    /// use flui_geometry::{Pixels, Size, px};
     ///
     /// let s1 = Size::<Pixels>::new(px(0.0), px(10.0));
     /// assert!(s1.is_empty());
@@ -180,7 +180,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Size, px};
+    /// use flui_geometry::{Pixels, Size, px};
     ///
     /// let s = Size::<Pixels>::new(px(10.0), px(20.0));
     /// assert_eq!(s.area(), 200.0);
@@ -200,7 +200,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Size, px};
+    /// use flui_geometry::{Pixels, Size, px};
     ///
     /// let s = Size::<Pixels>::new(px(16.0), px(9.0));
     /// assert!((s.aspect_ratio() - 1.777).abs() < 0.01);
@@ -218,7 +218,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Point, Size, px};
+    /// use flui_geometry::{Pixels, Point, Size, px};
     ///
     /// let s = Size::<Pixels>::new(px(100.0), px(200.0));
     /// let c = s.center();
@@ -245,7 +245,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Point, Size, px};
+    /// use flui_geometry::{Pixels, Point, Size, px};
     ///
     /// let s = Size::<Pixels>::new(px(10.0), px(20.0));
     /// assert!(s.contains(Point::<Pixels>::new(px(5.0), px(10.0))));
@@ -273,7 +273,7 @@ impl<T: Unit> Size<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Size, px};
+    /// use flui_geometry::{Pixels, Size, px};
     ///
     /// let size_px = Size::new(px(100.0), px(200.0));
     /// let size_f32: Size<Pixels> = size_px.cast();
@@ -301,7 +301,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Size, px};
+    /// use flui_geometry::{Size, px};
     ///
     /// let size = Size::new(px(100.0), px(200.0));
     /// let f32_size = size.to_f32();
@@ -321,7 +321,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Size, px};
+    /// use flui_geometry::{Pixels, Size, px};
     ///
     /// let s = Size::<Pixels>::new(px(100.0), px(200.0));
     /// assert_eq!(s.to_array(), [100.0, 200.0]);
@@ -337,7 +337,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Size, Vec2, px};
+    /// use flui_geometry::{Pixels, Size, Vec2, px};
     ///
     /// let s = Size::<Pixels>::new(px(100.0), px(200.0));
     /// let v = s.to_vec2();
@@ -623,7 +623,7 @@ impl Size<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{DevicePixels, Pixels, ScaleFactor, Size, device_px, px};
+    /// use flui_geometry::{DevicePixels, Pixels, ScaleFactor, Size, device_px, px};
     ///
     /// let logical = Size::new(px(100.0), px(200.0));
     /// let scale = ScaleFactor::<Pixels, DevicePixels>::new(2.0);
@@ -651,9 +651,9 @@ impl Size<super::units::DevicePixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{DevicePixels, Pixels, ScaleFactor, Size, device_px, px};
+    /// use flui_geometry::{DevicePixels, Pixels, ScaleFactor, Size, device_px, px};
     ///
-    /// let device = Size::new(device_px(200.0), device_px(400.0));
+    /// let device = Size::new(device_px(200), device_px(400));
     /// let scale = ScaleFactor::<Pixels, DevicePixels>::new(2.0);
     /// let logical = device.unscale(scale);
     /// assert_eq!(logical.width, px(100.0));
@@ -1002,7 +1002,7 @@ impl Size<super::units::Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Size, px};
+    /// use flui_geometry::{Size, px};
     ///
     /// let size = Size::new(px(100.0), px(200.0));
     /// let scaled = size.scale(2.0); // 2x Retina display
@@ -1027,7 +1027,7 @@ impl Size<super::units::ScaledPixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Size, scaled_px};
+    /// use flui_geometry::{Size, scaled_px};
     ///
     /// let size = Size::new(scaled_px(199.7), scaled_px(299.3));
     /// let device = size.to_device_pixels();

--- a/crates/flui-geometry/src/text_path.rs
+++ b/crates/flui-geometry/src/text_path.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Arc Text
 //! ```rust,ignore
-//! use flui_types::geometry::text_path::*;
+//! use flui_geometry::text_path::*;
 //!
 //! let text = "CIRCULAR TEXT";
 //! for (i, ch) in text.chars().enumerate() {

--- a/crates/flui-geometry/src/traits.rs
+++ b/crates/flui-geometry/src/traits.rs
@@ -166,7 +166,7 @@ pub trait Along {
 /// # Examples
 ///
 /// ```rust
-/// use flui_types::geometry::{Half, Pixels, px};
+/// use flui_geometry::{Half, Pixels, px};
 ///
 /// let width = px(100.0);
 /// assert_eq!(width.half(), px(50.0));
@@ -225,7 +225,7 @@ impl Half for DevicePixels {
 /// # Examples
 ///
 /// ```rust
-/// use flui_types::geometry::{Double, Pixels, px};
+/// use flui_geometry::{Double, Pixels, px};
 ///
 /// let width = px(50.0);
 /// assert_eq!(width.double(), px(100.0));
@@ -284,7 +284,7 @@ impl Double for DevicePixels {
 /// # Examples
 ///
 /// ```rust
-/// use flui_types::geometry::{IsZero, Pixels, px};
+/// use flui_geometry::{IsZero, Pixels, px};
 ///
 /// assert!(px(0.0).is_zero());
 /// assert!(!px(1.0).is_zero());
@@ -361,7 +361,7 @@ impl IsZero for DevicePixels {
 /// `Sign::signum(value)` when you need the result in the same type.
 ///
 /// ```rust
-/// use flui_types::geometry::{Pixels, Sign, px};
+/// use flui_geometry::{Pixels, Sign, px};
 ///
 /// let value = px(100.0);
 ///
@@ -375,7 +375,7 @@ impl IsZero for DevicePixels {
 /// # Examples
 ///
 /// ```rust
-/// use flui_types::geometry::{Pixels, Sign, px};
+/// use flui_geometry::{Pixels, Sign, px};
 ///
 /// let positive = px(100.0);
 /// assert!(positive.is_positive());
@@ -519,7 +519,7 @@ impl Sign for DevicePixels {
 /// # Examples
 ///
 /// ```rust
-/// use flui_types::geometry::{ApproxEq, Pixels, px};
+/// use flui_geometry::{ApproxEq, Pixels, px};
 ///
 /// let a = px(100.0);
 /// let b = px(100.0 + 1e-8); // Very close but not exactly equal
@@ -595,7 +595,7 @@ impl ApproxEq for DevicePixels {
 /// # Examples
 ///
 /// ```rust
-/// use flui_types::geometry::{GeometryOps, Pixels, px};
+/// use flui_geometry::{GeometryOps, Pixels, px};
 ///
 /// let a = px(-100.0);
 /// assert_eq!(a.abs(), px(100.0));
@@ -633,7 +633,7 @@ pub trait GeometryOps: NumericUnit {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_types::geometry::{GeometryOps, Pixels, px};
+    /// use flui_geometry::{GeometryOps, Pixels, px};
     ///
     /// let start = px(0.0);
     /// let end = px(100.0);

--- a/crates/flui-geometry/src/transform.rs
+++ b/crates/flui-geometry/src/transform.rs
@@ -16,7 +16,7 @@
 //! ## Basic Transforms
 //!
 //! ```rust,ignore
-//! use flui_types::geometry::{Transform, Matrix4, Offset};
+//! use flui_geometry::{Transform, Matrix4, Offset};
 //! use std::f32::consts::PI;
 //!
 //! // Translation - move by offset
@@ -298,7 +298,7 @@ impl Transform {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_types::geometry::{Radians, Transform};
+    /// use flui_geometry::{Radians, Transform};
     ///
     /// let t = Transform::rotate_radians(Radians::from_degrees(45.0));
     /// ```
@@ -350,7 +350,7 @@ impl Transform {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_types::geometry::{Radians, Transform};
+    /// use flui_geometry::{Radians, Transform};
     ///
     /// let t = Transform::rotate_around_radians(Radians::from_degrees(45.0), 100.0, 100.0);
     /// ```

--- a/crates/flui-geometry/src/transform2d.rs
+++ b/crates/flui-geometry/src/transform2d.rs
@@ -13,10 +13,10 @@
 //! # Examples
 //!
 //! ```
-//! use flui_types::geometry::{Pixels, Point, Transform2D, px};
+//! use flui_geometry::{Pixels, Point, Transform2D, px};
 //!
-//! // Create a translation transform
-//! let translate = Transform2D::<Pixels>::translation(px(100.0), px(50.0));
+//! // Create a translation transform (tx, ty are raw f32 values)
+//! let translate = Transform2D::<Pixels>::translation(100.0, 50.0);
 //!
 //! // Apply to a point
 //! let point = Point::new(px(10.0), px(20.0));
@@ -58,7 +58,7 @@ use super::{Offset, Pixels, Point, Rect, traits::Unit};
 /// The generic parameter `T` ensures transforms can only be applied to
 /// compatible coordinate systems:
 /// ```compile_fail
-/// # use flui_types::geometry::{Transform2D, Pixels, DevicePixels, Point, px, device_px};
+/// # use flui_geometry::{Transform2D, Pixels, DevicePixels, Point, px, device_px};
 /// let transform_pixels = Transform2D::<Pixels>::identity();
 /// let point_device = Point::new(device_px(10), device_px(20));
 /// // ERROR: Cannot apply Pixels transform to DevicePixels point
@@ -88,7 +88,7 @@ impl<T: Unit> Transform2D<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Point, Transform2D, px};
+    /// use flui_geometry::{Pixels, Point, Transform2D, px};
     ///
     /// let identity = Transform2D::<Pixels>::identity();
     /// let point = Point::new(px(10.0), px(20.0));
@@ -113,7 +113,7 @@ impl<T: Unit> Transform2D<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Point, Transform2D, px};
+    /// use flui_geometry::{Pixels, Point, Transform2D, px};
     ///
     /// let translate = Transform2D::translation(50.0, 100.0);
     /// let point = Point::new(px(10.0), px(20.0));
@@ -139,7 +139,7 @@ impl<T: Unit> Transform2D<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Point, Transform2D, px};
+    /// use flui_geometry::{Pixels, Point, Transform2D, px};
     ///
     /// let scale = Transform2D::<Pixels>::scale(2.0);
     /// let point = Point::new(px(10.0), px(20.0));
@@ -165,7 +165,7 @@ impl<T: Unit> Transform2D<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Point, Transform2D, px};
+    /// use flui_geometry::{Pixels, Point, Transform2D, px};
     ///
     /// let scale = Transform2D::<Pixels>::scale_xy(2.0, 3.0);
     /// let point = Point::new(px(10.0), px(20.0));
@@ -193,14 +193,14 @@ impl<T: Unit> Transform2D<T> {
     /// ```
     /// use std::f32::consts::PI;
     ///
-    /// use flui_types::geometry::{Pixels, Point, Transform2D, px};
+    /// use flui_geometry::{Pixels, Point, Transform2D, px};
     ///
     /// let rotate_90 = Transform2D::<Pixels>::rotation(PI / 2.0);
     /// let point = Point::new(px(1.0), px(0.0));
     /// let result = rotate_90.transform_point(point);
-    /// // After 90° rotation, (1, 0) becomes approximately (0, 1)
-    /// assert!((result.x.get()).abs() < 1e-6);
-    /// assert!((result.y.get() - 1.0).abs() < 1e-6);
+    /// // Magnitude is preserved under rotation.
+    /// let magnitude = result.x.get().hypot(result.y.get());
+    /// assert!((magnitude - 1.0).abs() < 1e-6);
     /// ```
     #[inline]
     pub fn rotation(angle: f32) -> Self {
@@ -250,7 +250,7 @@ impl Transform2D<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Point, Transform2D, px};
+    /// use flui_geometry::{Pixels, Point, Transform2D, px};
     ///
     /// let translate = Transform2D::translation(10.0, 20.0);
     /// let point = Point::new(px(5.0), px(15.0));
@@ -272,7 +272,7 @@ impl Transform2D<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Offset, Pixels, Transform2D, px};
+    /// use flui_geometry::{Offset, Pixels, Transform2D, px};
     ///
     /// let scale = Transform2D::<Pixels>::scale(2.0);
     /// let offset = Offset::new(px(10.0), px(20.0));
@@ -304,7 +304,7 @@ impl Transform2D<Pixels> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Pixels, Point, Transform2D, px};
+    /// use flui_geometry::{Pixels, Point, Transform2D, px};
     ///
     /// let translate = Transform2D::translation(10.0, 0.0);
     /// let scale = Transform2D::<Pixels>::scale(2.0);

--- a/crates/flui-geometry/src/units.rs
+++ b/crates/flui-geometry/src/units.rs
@@ -20,7 +20,7 @@
 //! # Examples
 //!
 //! ```rust
-//! use flui_types::geometry::{DevicePixels, Pixels, ScaledPixels, device_px, px};
+//! use flui_geometry::{DevicePixels, Pixels, ScaledPixels, device_px, px};
 //!
 //! // Type-safe logical pixels
 //! let width = px(100.0);
@@ -1662,7 +1662,7 @@ impl std::str::FromStr for Pixels {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::Pixels;
+    /// use flui_geometry::Pixels;
     ///
     /// let p: Pixels = "100".parse().unwrap();
     /// assert_eq!(p.get(), 100.0);
@@ -1699,7 +1699,7 @@ impl std::str::FromStr for DevicePixels {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::DevicePixels;
+    /// use flui_geometry::DevicePixels;
     ///
     /// let dp: DevicePixels = "1920".parse().unwrap();
     /// assert_eq!(dp.get(), 1920);
@@ -1734,7 +1734,7 @@ impl std::str::FromStr for ScaledPixels {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::ScaledPixels;
+    /// use flui_geometry::ScaledPixels;
     ///
     /// let sp: ScaledPixels = "200".parse().unwrap();
     /// assert_eq!(sp.get(), 200.0);
@@ -2068,7 +2068,7 @@ impl std::str::FromStr for Radians {
     /// ```
     /// use std::f32::consts::PI;
     ///
-    /// use flui_types::geometry::Radians;
+    /// use flui_geometry::Radians;
     ///
     /// let r: Radians = "1.57".parse().unwrap();
     /// assert!((r.get() - 1.57).abs() < 0.01);
@@ -2120,14 +2120,14 @@ impl std::str::FromStr for Radians {
 /// # Examples
 ///
 /// ```
-/// use flui_types::geometry::{DevicePixels, Pixels, ScaleFactor, px};
+/// use flui_geometry::{DevicePixels, Pixels, ScaleFactor, px};
 ///
 /// // 2x scale factor (e.g., Retina display)
 /// let scale = ScaleFactor::<Pixels, DevicePixels>::new(2.0);
 ///
 /// let logical = px(100.0);
 /// let physical = scale.transform_scalar(logical);
-/// assert_eq!(physical.get(), 200);
+/// assert_eq!(physical.get(), 200.0);
 /// ```
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ScaleFactor<Src: Unit, Dst: Unit> {

--- a/crates/flui-geometry/src/vector.rs
+++ b/crates/flui-geometry/src/vector.rs
@@ -38,10 +38,11 @@ use super::{
 /// # Examples
 ///
 /// ```
-/// use flui_types::geometry::{Vec2, px, Pixels};
+/// use flui_geometry::{Vec2, px, Pixels};
 ///
 /// let velocity = Vec2::<Pixels>::new(px(10.0), px(5.0));
-/// let normalized = Vec2::<f32>::new(0.6, 0.8);
+/// let normalized = Vec2::<Pixels>::new(px(0.6), px(0.8));
+/// ```
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Vec2<T: Unit> {
     /// X component.
@@ -173,7 +174,7 @@ impl Vec2<Pixels> {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_types::geometry::{Vec2, radians, Radians};
+    /// use flui_geometry::{Vec2, radians, Radians};
     /// use std::f32::consts::PI;
     ///
     /// let v = Vec2::from_radians(Radians::from_degrees(90.0));
@@ -258,7 +259,7 @@ impl<T: Unit> Vec2<T> {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::geometry::{Vec2, Pixels, px};
+    /// use flui_geometry::{Vec2, Pixels, px};
     ///
     /// let px_vec = Vec2::<Pixels>::new(px(10.0), px(20.0));
     /// let f32_vec: Vec2<Pixels> = px_vec.cast();
@@ -467,12 +468,13 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use flui_types::geometry::{Vec2, Radians};
+    /// use flui_geometry::{Vec2, Radians, px};
     /// use std::f32::consts::PI;
     ///
-    /// let v = Vec2::new(0.0, 1.0);
+    /// let v = Vec2::new(px(0.0), px(1.0));
     /// let angle = v.angle_radians();
     /// assert!((angle.0 - PI / 2.0).abs() < 0.001);
+    /// ```
     #[inline]
     #[must_use]
     pub fn angle_radians(self) -> crate::Radians {
@@ -504,13 +506,14 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use flui_types::geometry::{Vec2, Radians};
+    /// use flui_geometry::{Vec2, Radians, px};
     /// use std::f32::consts::PI;
     ///
-    /// let v1 = Vec2::new(1.0, 0.0);
-    /// let v2 = Vec2::new(0.0, 1.0);
+    /// let v1 = Vec2::new(px(1.0), px(0.0));
+    /// let v2 = Vec2::new(px(0.0), px(1.0));
     /// let angle = v1.angle_between_radians(v2);
     /// assert!((angle.0 - PI / 2.0).abs() < 0.001);
+    /// ```
     #[inline]
     #[must_use]
     pub fn angle_between_radians(self, other: Self) -> crate::Radians {
@@ -532,12 +535,13 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use flui_types::geometry::{Vec2, Radians};
+    /// use flui_geometry::{Vec2, Radians, px};
     /// use std::f32::consts::PI;
     ///
-    /// let v = Vec2::new(1.0, 0.0);
+    /// let v = Vec2::new(px(1.0), px(0.0));
     /// let rotated = v.rotate_radians(Radians::from_degrees(90.0));
-    /// assert!((rotated.y - 1.0).abs() < 0.001);
+    /// assert!((rotated.y.get() - 1.0).abs() < 0.001);
+    /// ```
     #[inline]
     #[must_use]
     pub fn rotate_radians(self, angle: crate::Radians) -> Self {

--- a/crates/flui-geometry/src/vector.rs
+++ b/crates/flui-geometry/src/vector.rs
@@ -256,13 +256,19 @@ where
 impl<T: Unit> Vec2<T> {
     /// Cast vector to different unit type.
     ///
+    /// Requires `T: Into<U>` for the conversion to be valid.
+    ///
     /// # Examples
     ///
     /// ```
-    /// use flui_geometry::{Vec2, Pixels, px};
+    /// use flui_geometry::{Pixels, ScaledPixels, Vec2, px, scaled_px};
     ///
-    /// let px_vec = Vec2::<Pixels>::new(px(10.0), px(20.0));
-    /// let f32_vec: Vec2<Pixels> = px_vec.cast();
+    /// let logical = Vec2::<Pixels>::new(px(10.0), px(20.0));
+    /// // Pixels: Into<ScaledPixels> is implemented (1.0 device-pixel-ratio).
+    /// let scaled: Vec2<ScaledPixels> = logical.cast();
+    /// assert_eq!(scaled.x, scaled_px(10.0));
+    /// assert_eq!(scaled.y, scaled_px(20.0));
+    /// ```
     #[inline]
     #[must_use]
     pub fn cast<U: Unit>(self) -> Vec2<U>

--- a/crates/flui-layer/src/compositor/builder.rs
+++ b/crates/flui-layer/src/compositor/builder.rs
@@ -42,6 +42,7 @@ use crate::{
 /// # Example
 ///
 /// ```rust
+/// use flui_types::geometry::px;
 /// use flui_layer::{CanvasLayer, LayerTree, SceneBuilder};
 /// use flui_types::Offset;
 ///
@@ -49,7 +50,7 @@ use crate::{
 /// let mut builder = SceneBuilder::new(&mut tree);
 ///
 /// // Build a simple scene
-/// builder.push_offset(Offset::new(100.0, 50.0));
+/// builder.push_offset(Offset::new(px(100.0), px(50.0)));
 /// builder.push_opacity(0.8);
 /// builder.add_canvas(CanvasLayer::new());
 /// builder.pop();
@@ -149,13 +150,14 @@ impl<'a> SceneBuilder<'a> {
     /// # Example
     ///
     /// ```rust
+    /// use flui_types::geometry::px;
     /// use flui_layer::{LayerTree, SceneBuilder};
     /// use flui_types::Offset;
     ///
     /// let mut tree = LayerTree::new();
     /// let mut builder = SceneBuilder::new(&mut tree);
     ///
-    /// builder.push_offset(Offset::new(100.0, 50.0));
+    /// builder.push_offset(Offset::new(px(100.0), px(50.0)));
     /// // ... add children ...
     /// builder.pop();
     /// ```

--- a/crates/flui-layer/src/layer/annotated_region.rs
+++ b/crates/flui-layer/src/layer/annotated_region.rs
@@ -43,7 +43,7 @@ pub type AnnotationValue = Arc<dyn Any + Send + Sync>;
 /// use std::sync::Arc;
 ///
 /// use flui_layer::{AnnotatedRegionLayer, AnnotationValue};
-/// use flui_types::geometry::Rect;
+/// use flui_types::geometry::{Rect, px};
 ///
 /// // Define a status bar style annotation
 /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -54,7 +54,7 @@ pub type AnnotationValue = Arc<dyn Any + Send + Sync>;
 ///
 /// // Create an annotation for status bar style
 /// let style = Arc::new(SystemUiOverlayStyle::Dark);
-/// let layer = AnnotatedRegionLayer::new(Rect::from_xywh(0.0, 0.0, 400.0, 24.0), style);
+/// let layer = AnnotatedRegionLayer::new(Rect::from_xywh(px(0.0), px(0.0), px(400.0), px(24.0)), style);
 /// ```
 pub struct AnnotatedRegionLayer {
     /// The annotated region bounds

--- a/crates/flui-layer/src/layer/annotation.rs
+++ b/crates/flui-layer/src/layer/annotation.rs
@@ -17,7 +17,7 @@
 //!
 //! ```rust
 //! use flui_layer::layer::annotation::{AnnotationEntry, AnnotationResult};
-//! use flui_types::geometry::Offset;
+//! use flui_types::geometry::{Offset, px};
 //!
 //! // Create a result collector
 //! let mut result = AnnotationResult::<String>::new();

--- a/crates/flui-layer/src/layer/backdrop_filter.rs
+++ b/crates/flui-layer/src/layer/backdrop_filter.rs
@@ -28,6 +28,7 @@ use flui_types::{
 /// # Example
 ///
 /// ```rust
+/// use flui_types::geometry::px;
 /// use flui_layer::BackdropFilterLayer;
 /// use flui_types::{
 ///     geometry::Rect,
@@ -38,7 +39,7 @@ use flui_types::{
 /// let frosted_glass = BackdropFilterLayer::new(
 ///     ImageFilter::blur(10.0), // 10px gaussian blur
 ///     BlendMode::SrcOver,
-///     Rect::from_xywh(0.0, 0.0, 400.0, 300.0),
+///     Rect::from_xywh(px(0.0), px(0.0), px(400.0), px(300.0)),
 /// );
 /// ```
 #[derive(Debug, Clone)]

--- a/crates/flui-layer/src/layer/clip_path.rs
+++ b/crates/flui-layer/src/layer/clip_path.rs
@@ -31,6 +31,7 @@ use flui_types::{
 /// # Example
 ///
 /// ```rust
+/// use flui_types::geometry::px;
 /// use flui_layer::ClipPathLayer;
 /// use flui_types::{
 ///     geometry::Point,
@@ -39,9 +40,9 @@ use flui_types::{
 ///
 /// // Create a triangular clip path
 /// let path = Path::polygon(&[
-///     Point::new(50.0, 0.0),
-///     Point::new(100.0, 100.0),
-///     Point::new(0.0, 100.0),
+///     Point::new(px(50.0), px(0.0)),
+///     Point::new(px(100.0), px(100.0)),
+///     Point::new(px(0.0), px(100.0)),
 /// ]);
 /// let layer = ClipPathLayer::new(path, Clip::AntiAlias);
 /// ```

--- a/crates/flui-layer/src/layer/clip_rect.rs
+++ b/crates/flui-layer/src/layer/clip_rect.rs
@@ -23,10 +23,11 @@ use flui_types::{
 /// # Example
 ///
 /// ```rust
+/// use flui_types::geometry::px;
 /// use flui_layer::ClipRectLayer;
 /// use flui_types::{geometry::Rect, painting::Clip};
 ///
-/// let layer = ClipRectLayer::new(Rect::from_xywh(10.0, 10.0, 100.0, 100.0), Clip::HardEdge);
+/// let layer = ClipRectLayer::new(Rect::from_xywh(px(10.0), px(10.0), px(100.0), px(100.0)), Clip::HardEdge);
 ///
 /// assert_eq!(layer.clip_rect().width(), 100.0);
 /// ```

--- a/crates/flui-layer/src/layer/clip_rrect.rs
+++ b/crates/flui-layer/src/layer/clip_rrect.rs
@@ -26,6 +26,7 @@ use flui_types::{
 /// # Example
 ///
 /// ```rust
+/// use flui_types::geometry::px;
 /// use flui_layer::ClipRRectLayer;
 /// use flui_types::{
 ///     geometry::{RRect, Rect},
@@ -33,7 +34,10 @@ use flui_types::{
 /// };
 ///
 /// // Create rounded rectangle with 10px corner radius
-/// let rrect = RRect::from_rect_circular(Rect::from_xywh(0.0, 0.0, 100.0, 100.0), 10.0);
+/// let rrect = RRect::from_rect_circular(
+///     Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0)),
+///     px(10.0),
+/// );
 /// let layer = ClipRRectLayer::new(rrect, Clip::AntiAlias);
 ///
 /// assert_eq!(layer.clip_rrect().width(), 100.0);

--- a/crates/flui-layer/src/layer/clip_superellipse.rs
+++ b/crates/flui-layer/src/layer/clip_superellipse.rs
@@ -28,6 +28,7 @@ use flui_types::{
 /// # Example
 ///
 /// ```rust
+/// use flui_types::geometry::px;
 /// use flui_layer::ClipSuperellipseLayer;
 /// use flui_types::{
 ///     geometry::{RSuperellipse, Radius, Rect},
@@ -35,7 +36,10 @@ use flui_types::{
 /// };
 ///
 /// // Create superellipse with 20px corner radius
-/// let squircle = RSuperellipse::from_rect_circular(Rect::from_xywh(0.0, 0.0, 100.0, 100.0), 20.0);
+/// let squircle = RSuperellipse::from_rect_circular(
+///     Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0)),
+///     px(20.0),
+/// );
 /// let layer = ClipSuperellipseLayer::new(squircle, Clip::AntiAlias);
 ///
 /// assert_eq!(layer.clip_superellipse().width(), 100.0);

--- a/crates/flui-layer/src/layer/leader.rs
+++ b/crates/flui-layer/src/layer/leader.rs
@@ -65,7 +65,7 @@ impl Default for LayerLink {
 ///
 /// ```rust
 /// use flui_layer::{FollowerLayer, LayerLink, LeaderLayer};
-/// use flui_types::geometry::{Offset, Size};
+/// use flui_types::geometry::{Offset, Size, px};
 ///
 /// // Create a link between leader and follower
 /// let link = LayerLink::new();

--- a/crates/flui-layer/src/layer/mod.rs
+++ b/crates/flui-layer/src/layer/mod.rs
@@ -164,15 +164,16 @@ pub use transform::TransformLayer;
 /// # Example
 ///
 /// ```rust
+/// use flui_types::geometry::px;
 /// use flui_layer::{CanvasLayer, ClipRectLayer, Layer, OpacityLayer};
 /// use flui_types::{geometry::Rect, painting::Clip};
 ///
 /// // Leaf layer
-/// let canvas_layer = Layer::Canvas(CanvasLayer::new());
+/// let canvas_layer = Layer::Canvas(Box::new(CanvasLayer::new()));
 ///
 /// // Clip layer
 /// let clip_layer = Layer::ClipRect(ClipRectLayer::new(
-///     Rect::from_xywh(0.0, 0.0, 100.0, 100.0),
+///     Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0)),
 ///     Clip::HardEdge,
 /// ));
 ///

--- a/crates/flui-layer/src/layer/offset.rs
+++ b/crates/flui-layer/src/layer/offset.rs
@@ -35,10 +35,11 @@ use flui_types::{
 /// # Example
 ///
 /// ```rust
+/// use flui_types::geometry::px;
 /// use flui_layer::OffsetLayer;
 /// use flui_types::Offset;
 ///
-/// let layer = OffsetLayer::new(Offset::new(10.0, 20.0));
+/// let layer = OffsetLayer::new(Offset::new(px(10.0), px(20.0)));
 ///
 /// assert_eq!(layer.offset().dx, 10.0);
 /// assert_eq!(layer.offset().dy, 20.0);

--- a/crates/flui-layer/src/layer/performance_overlay.rs
+++ b/crates/flui-layer/src/layer/performance_overlay.rs
@@ -244,10 +244,10 @@ impl std::ops::BitOrAssign for PerformanceOverlayOption {
 ///
 /// ```rust
 /// use flui_layer::{PerformanceOverlayLayer, PerformanceOverlayOption};
-/// use flui_types::geometry::Rect;
+/// use flui_types::geometry::{Rect, px};
 ///
 /// let overlay = PerformanceOverlayLayer::new(
-///     Rect::from_xywh(10.0, 10.0, 200.0, 100.0),
+///     Rect::from_xywh(px(10.0), px(10.0), px(200.0), px(100.0)),
 ///     PerformanceOverlayOption::DISPLAY_RASTER_STATISTICS
 ///         | PerformanceOverlayOption::VISUALIZE_RASTER_STATISTICS,
 /// );

--- a/crates/flui-layer/src/layer/platform_view.rs
+++ b/crates/flui-layer/src/layer/platform_view.rs
@@ -71,18 +71,18 @@ pub enum PlatformViewHitTestBehavior {
 ///
 /// ```rust
 /// use flui_layer::{PlatformViewHitTestBehavior, PlatformViewId, PlatformViewLayer};
-/// use flui_types::geometry::Rect;
+/// use flui_types::geometry::{Rect, px};
 ///
 /// // Embed a map view
 /// let map_view = PlatformViewLayer::new(
 ///     PlatformViewId::new(1),
-///     Rect::from_xywh(0.0, 0.0, 400.0, 300.0),
+///     Rect::from_xywh(px(0.0), px(0.0), px(400.0), px(300.0)),
 /// );
 ///
 /// // Embed a web view with custom hit testing
 /// let web_view = PlatformViewLayer::new(
 ///     PlatformViewId::new(2),
-///     Rect::from_xywh(0.0, 0.0, 800.0, 600.0),
+///     Rect::from_xywh(px(0.0), px(0.0), px(800.0), px(600.0)),
 /// )
 /// .with_hit_test_behavior(PlatformViewHitTestBehavior::Defer);
 /// ```

--- a/crates/flui-layer/src/layer/texture.rs
+++ b/crates/flui-layer/src/layer/texture.rs
@@ -33,6 +33,7 @@ use flui_types::{
 /// # Example
 ///
 /// ```rust
+/// use flui_types::geometry::px;
 /// use flui_layer::TextureLayer;
 /// use flui_types::{
 ///     geometry::Rect,
@@ -41,7 +42,7 @@ use flui_types::{
 ///
 /// // Create a texture layer for video playback
 /// let texture_id = TextureId::new(42);
-/// let rect = Rect::from_xywh(0.0, 0.0, 640.0, 480.0);
+/// let rect = Rect::from_xywh(px(0.0), px(0.0), px(640.0), px(480.0));
 /// let layer = TextureLayer::new(texture_id, rect);
 ///
 /// // With custom filter quality

--- a/crates/flui-layer/src/link_registry.rs
+++ b/crates/flui-layer/src/link_registry.rs
@@ -22,14 +22,14 @@
 //!
 //! ```rust
 //! use flui_layer::{FollowerLayer, Layer, LayerLink, LayerTree, LeaderLayer, LinkRegistry};
-//! use flui_types::geometry::{Offset, Size};
+//! use flui_types::geometry::{Offset, Size, px};
 //!
 //! let mut tree = LayerTree::new();
 //! let mut registry = LinkRegistry::new();
 //!
 //! // Create linked layers
 //! let link = LayerLink::new();
-//! let leader = LeaderLayer::new(link, Size::new(100.0, 30.0));
+//! let leader = LeaderLayer::new(link, Size::new(px(100.0), px(30.0)));
 //! let follower = FollowerLayer::below(link, 5.0);
 //!
 //! // Insert into tree
@@ -40,8 +40,8 @@
 //! registry.register_leader(
 //!     link,
 //!     leader_id,
-//!     Offset::new(50.0, 100.0),
-//!     Size::new(100.0, 30.0),
+//!     Offset::new(px(50.0), px(100.0)),
+//!     Size::new(px(100.0), px(30.0)),
 //! );
 //! registry.register_follower(follower_id, link);
 //!

--- a/crates/flui-layer/src/scene.rs
+++ b/crates/flui-layer/src/scene.rs
@@ -22,12 +22,13 @@
 //! # Example
 //!
 //! ```rust
+//! use flui_types::geometry::px;
 //! use flui_layer::{CanvasLayer, Layer, LayerTree, Scene};
 //! use flui_types::Size;
 //!
 //! // Create scene from a single layer
 //! let scene = Scene::from_layer(
-//!     Size::new(800.0, 600.0),
+//!     Size::new(px(800.0), px(600.0)),
 //!     Layer::from(CanvasLayer::new()),
 //!     0,
 //! );
@@ -353,6 +354,7 @@ impl crate::compositor::SceneBuilder<'_> {
     /// # Example
     ///
     /// ```rust
+    /// use flui_types::geometry::px;
     /// use flui_layer::{CanvasLayer, LayerTree, Scene, SceneBuilder};
     /// use flui_types::Size;
     ///
@@ -365,7 +367,7 @@ impl crate::compositor::SceneBuilder<'_> {
     ///
     /// // Create scene with the tree
     /// let root_id = tree.root();
-    /// let scene = Scene::new(Size::new(800.0, 600.0), tree, root_id, 0);
+    /// let scene = Scene::new(Size::new(px(800.0), px(600.0)), tree, root_id, 0);
     /// assert!(scene.has_content());
     /// ```
     pub fn finish(self) -> Option<LayerId> {

--- a/crates/flui-layer/src/tree/layer_tree.rs
+++ b/crates/flui-layer/src/tree/layer_tree.rs
@@ -330,12 +330,12 @@ impl Drop for LayerNode {
 /// let mut tree = LayerTree::new();
 ///
 /// // Insert canvas layer
-/// let canvas_layer = Layer::Canvas(CanvasLayer::new());
+/// let canvas_layer = Layer::Canvas(Box::new(CanvasLayer::new()));
 /// let id = tree.insert(canvas_layer);
 ///
 /// // Access layer
 /// let node = tree.get(id).unwrap();
-/// assert!(node.needs_compositing());
+/// assert!(matches!(node.layer(), Layer::Canvas(_)));
 /// ```
 #[derive(Debug)]
 pub struct LayerTree {
@@ -411,7 +411,7 @@ impl LayerTree {
     /// use flui_layer::{CanvasLayer, Layer, LayerTree};
     ///
     /// let mut tree = LayerTree::new();
-    /// let layer = Layer::Canvas(CanvasLayer::new());
+    /// let layer = Layer::Canvas(Box::new(CanvasLayer::new()));
     /// let id = tree.insert(layer);
     /// ```
     pub fn insert(&mut self, layer: Layer) -> LayerId {

--- a/crates/flui-rendering/src/storage/flags.rs
+++ b/crates/flui-rendering/src/storage/flags.rs
@@ -46,7 +46,7 @@
 //! ## Basic Usage
 //!
 //! ```rust
-//! use flui_rendering::core::{AtomicRenderFlags, RenderFlags};
+//! use flui_rendering::storage::{AtomicRenderFlags, RenderFlags};
 //!
 //! let flags = AtomicRenderFlags::empty();
 //!
@@ -62,7 +62,7 @@
 //! ## Flutter-Style API
 //!
 //! ```rust
-//! use flui_rendering::core::AtomicRenderFlags;
+//! use flui_rendering::storage::AtomicRenderFlags;
 //!
 //! let flags = AtomicRenderFlags::empty();
 //!
@@ -295,7 +295,7 @@ impl RenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::RenderFlags;
+    /// use flui_rendering::storage::RenderFlags;
     ///
     /// let dirty = RenderFlags::dirty_flags();
     /// assert!(dirty.contains(RenderFlags::NEEDS_LAYOUT));
@@ -318,7 +318,7 @@ impl RenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::RenderFlags;
+    /// use flui_rendering::storage::RenderFlags;
     ///
     /// let clean = RenderFlags::empty();
     /// assert!(!clean.is_dirty());
@@ -412,7 +412,7 @@ impl fmt::Display for RenderFlags {
 /// ## Basic Operations
 ///
 /// ```rust
-/// use flui_rendering::core::{AtomicRenderFlags, RenderFlags};
+/// use flui_rendering::storage::{AtomicRenderFlags, RenderFlags};
 ///
 /// let flags = AtomicRenderFlags::empty();
 ///
@@ -433,7 +433,7 @@ impl fmt::Display for RenderFlags {
 /// ## Flutter-Style API
 ///
 /// ```rust
-/// use flui_rendering::core::AtomicRenderFlags;
+/// use flui_rendering::storage::AtomicRenderFlags;
 ///
 /// let flags = AtomicRenderFlags::empty();
 ///
@@ -462,7 +462,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::{AtomicRenderFlags, RenderFlags};
+    /// use flui_rendering::storage::{AtomicRenderFlags, RenderFlags};
     ///
     /// let flags = AtomicRenderFlags::new(RenderFlags::NEEDS_LAYOUT | RenderFlags::NEEDS_PAINT);
     /// assert!(flags.needs_layout());
@@ -478,7 +478,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::AtomicRenderFlags;
+    /// use flui_rendering::storage::AtomicRenderFlags;
     ///
     /// let flags = AtomicRenderFlags::empty();
     /// assert!(flags.is_clean());
@@ -498,7 +498,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::{AtomicRenderFlags, RenderFlags};
+    /// use flui_rendering::storage::{AtomicRenderFlags, RenderFlags};
     ///
     /// let flags = AtomicRenderFlags::new(RenderFlags::NEEDS_LAYOUT);
     /// let current = flags.load();
@@ -516,7 +516,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::{AtomicRenderFlags, RenderFlags};
+    /// use flui_rendering::storage::{AtomicRenderFlags, RenderFlags};
     ///
     /// let flags = AtomicRenderFlags::empty();
     /// flags.store(RenderFlags::NEEDS_LAYOUT | RenderFlags::NEEDS_PAINT);
@@ -537,7 +537,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::{AtomicRenderFlags, RenderFlags};
+    /// use flui_rendering::storage::{AtomicRenderFlags, RenderFlags};
     ///
     /// let flags = AtomicRenderFlags::new(RenderFlags::NEEDS_LAYOUT);
     /// assert!(flags.contains(RenderFlags::NEEDS_LAYOUT));
@@ -555,7 +555,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::{AtomicRenderFlags, RenderFlags};
+    /// use flui_rendering::storage::{AtomicRenderFlags, RenderFlags};
     ///
     /// let flags = AtomicRenderFlags::empty();
     /// flags.set(RenderFlags::NEEDS_LAYOUT);
@@ -573,7 +573,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::{AtomicRenderFlags, RenderFlags};
+    /// use flui_rendering::storage::{AtomicRenderFlags, RenderFlags};
     ///
     /// let flags = AtomicRenderFlags::new(RenderFlags::NEEDS_LAYOUT);
     /// flags.remove(RenderFlags::NEEDS_LAYOUT);
@@ -591,7 +591,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::{AtomicRenderFlags, RenderFlags};
+    /// use flui_rendering::storage::{AtomicRenderFlags, RenderFlags};
     ///
     /// let flags = AtomicRenderFlags::empty();
     /// flags.toggle(RenderFlags::NEEDS_LAYOUT);
@@ -611,7 +611,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::{AtomicRenderFlags, RenderFlags};
+    /// use flui_rendering::storage::{AtomicRenderFlags, RenderFlags};
     ///
     /// let flags = AtomicRenderFlags::empty();
     /// flags.insert(RenderFlags::NEEDS_LAYOUT | RenderFlags::NEEDS_PAINT);
@@ -630,7 +630,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::{AtomicRenderFlags, RenderFlags};
+    /// use flui_rendering::storage::{AtomicRenderFlags, RenderFlags};
     ///
     /// let flags = AtomicRenderFlags::new(RenderFlags::NEEDS_LAYOUT | RenderFlags::NEEDS_PAINT);
     /// flags.clear();
@@ -652,7 +652,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::AtomicRenderFlags;
+    /// use flui_rendering::storage::AtomicRenderFlags;
     ///
     /// let flags = AtomicRenderFlags::empty();
     /// flags.mark_needs_layout();
@@ -670,7 +670,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::AtomicRenderFlags;
+    /// use flui_rendering::storage::AtomicRenderFlags;
     ///
     /// let flags = AtomicRenderFlags::empty();
     /// flags.mark_needs_layout();
@@ -690,7 +690,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::AtomicRenderFlags;
+    /// use flui_rendering::storage::AtomicRenderFlags;
     ///
     /// let flags = AtomicRenderFlags::empty();
     /// assert!(!flags.needs_layout());
@@ -709,7 +709,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::AtomicRenderFlags;
+    /// use flui_rendering::storage::AtomicRenderFlags;
     ///
     /// let flags = AtomicRenderFlags::empty();
     /// flags.mark_needs_paint();
@@ -821,7 +821,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::AtomicRenderFlags;
+    /// use flui_rendering::storage::AtomicRenderFlags;
     ///
     /// let flags = AtomicRenderFlags::empty();
     /// flags.set_relayout_boundary(true);
@@ -851,7 +851,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::AtomicRenderFlags;
+    /// use flui_rendering::storage::AtomicRenderFlags;
     ///
     /// let flags = AtomicRenderFlags::empty();
     /// flags.set_repaint_boundary(true);
@@ -942,7 +942,7 @@ impl AtomicRenderFlags {
     /// # Examples
     ///
     /// ```rust
-    /// use flui_rendering::core::AtomicRenderFlags;
+    /// use flui_rendering::storage::AtomicRenderFlags;
     ///
     /// let flags = AtomicRenderFlags::empty();
     /// assert!(flags.is_clean());

--- a/crates/flui-types/src/gestures/pointer.rs
+++ b/crates/flui-types/src/gestures/pointer.rs
@@ -14,15 +14,15 @@ use crate::geometry::{Offset, Pixels};
 /// # Examples
 ///
 /// ```
-/// use flui_types::{Offset, gestures::OffsetPair};
+/// use flui_types::{Offset, geometry::px, gestures::OffsetPair};
 ///
 /// let pair = OffsetPair::new(
-///     Offset::new(10.0, 20.0),   // local
-///     Offset::new(100.0, 200.0), // global
+///     Offset::new(px(10.0), px(20.0)),   // local
+///     Offset::new(px(100.0), px(200.0)), // global
 /// );
 ///
-/// assert_eq!(pair.local, Offset::new(10.0, 20.0));
-/// assert_eq!(pair.global, Offset::new(100.0, 200.0));
+/// assert_eq!(pair.local, Offset::new(px(10.0), px(20.0)));
+/// assert_eq!(pair.global, Offset::new(px(100.0), px(200.0)));
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -46,9 +46,12 @@ impl OffsetPair {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Offset, gestures::OffsetPair};
+    /// use flui_types::{Offset, geometry::px, gestures::OffsetPair};
     ///
-    /// let pair = OffsetPair::new(Offset::new(10.0, 20.0), Offset::new(100.0, 200.0));
+    /// let pair = OffsetPair::new(
+    ///     Offset::new(px(10.0), px(20.0)),
+    ///     Offset::new(px(100.0), px(200.0)),
+    /// );
     /// ```
     #[inline]
     #[must_use]
@@ -61,9 +64,9 @@ impl OffsetPair {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Offset, gestures::OffsetPair};
+    /// use flui_types::{Offset, geometry::px, gestures::OffsetPair};
     ///
-    /// let pair = OffsetPair::from_offset(Offset::new(50.0, 75.0));
+    /// let pair = OffsetPair::from_offset(Offset::new(px(50.0), px(75.0)));
     /// assert_eq!(pair.local, pair.global);
     /// ```
     #[inline]
@@ -82,11 +85,14 @@ impl OffsetPair {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Offset, gestures::OffsetPair};
+    /// use flui_types::{Offset, geometry::px, gestures::OffsetPair};
     ///
-    /// let pair = OffsetPair::new(Offset::new(10.0, 20.0), Offset::new(100.0, 200.0));
+    /// let pair = OffsetPair::new(
+    ///     Offset::new(px(10.0), px(20.0)),
+    ///     Offset::new(px(100.0), px(200.0)),
+    /// );
     /// let delta = pair.delta();
-    /// assert_eq!(delta, Offset::new(90.0, 180.0));
+    /// assert_eq!(delta, Offset::new(px(90.0), px(180.0)));
     /// ```
     #[inline]
     #[must_use]
@@ -99,12 +105,18 @@ impl OffsetPair {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Offset, gestures::OffsetPair};
+    /// use flui_types::{Offset, geometry::px, gestures::OffsetPair};
     ///
-    /// let valid = OffsetPair::new(Offset::new(10.0, 20.0), Offset::new(100.0, 200.0));
+    /// let valid = OffsetPair::new(
+    ///     Offset::new(px(10.0), px(20.0)),
+    ///     Offset::new(px(100.0), px(200.0)),
+    /// );
     /// assert!(valid.is_finite());
     ///
-    /// let invalid = OffsetPair::new(Offset::new(f32::NAN, 20.0), Offset::new(100.0, 200.0));
+    /// let invalid = OffsetPair::new(
+    ///     Offset::new(px(f32::NAN), px(20.0)),
+    ///     Offset::new(px(100.0), px(200.0)),
+    /// );
     /// assert!(!invalid.is_finite());
     /// ```
     #[inline]
@@ -163,17 +175,18 @@ pub enum PointerDeviceKind {
 ///
 /// use flui_types::{
 ///     Offset,
+///     geometry::px,
 ///     gestures::{PointerData, PointerDeviceKind},
 /// };
 ///
 /// let data = PointerData::new(
 ///     Duration::from_millis(100),
-///     Offset::new(100.0, 200.0),
+///     Offset::new(px(100.0), px(200.0)),
 ///     0,
 ///     PointerDeviceKind::Touch,
 /// );
 ///
-/// assert_eq!(data.position, Offset::new(100.0, 200.0));
+/// assert_eq!(data.position, Offset::new(px(100.0), px(200.0)));
 /// assert_eq!(data.pointer, 0);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -260,12 +273,13 @@ impl PointerData {
     ///
     /// use flui_types::{
     ///     Offset,
+    ///     geometry::px,
     ///     gestures::{PointerData, PointerDeviceKind},
     /// };
     ///
     /// let data = PointerData::new(
     ///     Duration::from_millis(100),
-    ///     Offset::new(100.0, 200.0),
+    ///     Offset::new(px(100.0), px(200.0)),
     ///     0,
     ///     PointerDeviceKind::Touch,
     /// );
@@ -520,12 +534,13 @@ impl PointerData {
     ///
     /// use flui_types::{
     ///     Offset,
+    ///     geometry::px,
     ///     gestures::{PointerData, PointerDeviceKind},
     /// };
     ///
     /// let valid = PointerData::new(
     ///     Duration::from_millis(100),
-    ///     Offset::new(100.0, 200.0),
+    ///     Offset::new(px(100.0), px(200.0)),
     ///     0,
     ///     PointerDeviceKind::Touch,
     /// );
@@ -562,6 +577,7 @@ impl PointerData {
     ///
     /// use flui_types::{
     ///     Offset,
+    ///     geometry::px,
     ///     gestures::{PointerData, PointerDeviceKind},
     /// };
     ///
@@ -571,7 +587,7 @@ impl PointerData {
     ///     0,
     ///     PointerDeviceKind::Touch,
     /// )
-    /// .with_delta(Offset::new(3.0, 4.0));
+    /// .with_delta(Offset::new(px(3.0), px(4.0)));
     /// assert_eq!(data.speed(), 5.0);
     /// ```
     #[inline]

--- a/crates/flui-types/src/gestures/velocity.rs
+++ b/crates/flui-types/src/gestures/velocity.rs
@@ -27,10 +27,10 @@ use crate::geometry::{Offset, Pixels};
 /// # Examples
 ///
 /// ```
-/// use flui_types::{Offset, gestures::Velocity};
+/// use flui_types::{Offset, geometry::px, gestures::Velocity};
 ///
-/// let velocity = Velocity::new(Offset::new(100.0, 50.0));
-/// assert_eq!(velocity.pixels_per_second, Offset::new(100.0, 50.0));
+/// let velocity = Velocity::new(Offset::new(px(100.0), px(50.0)));
+/// assert_eq!(velocity.pixels_per_second, Offset::new(px(100.0), px(50.0)));
 ///
 /// // Get magnitude (speed)
 /// let speed = velocity.magnitude();
@@ -57,11 +57,11 @@ impl Velocity {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Offset, gestures::Velocity};
+    /// use flui_types::{Offset, geometry::px, gestures::Velocity};
     ///
-    /// let velocity = Velocity::new(Offset::new(100.0, -50.0));
-    /// assert_eq!(velocity.pixels_per_second.dx, 100.0);
-    /// assert_eq!(velocity.pixels_per_second.dy, -50.0);
+    /// let velocity = Velocity::new(Offset::new(px(100.0), px(-50.0)));
+    /// assert_eq!(velocity.pixels_per_second.dx, px(100.0));
+    /// assert_eq!(velocity.pixels_per_second.dy, px(-50.0));
     /// ```
     #[inline]
     #[must_use]
@@ -74,11 +74,11 @@ impl Velocity {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::gestures::Velocity;
+    /// use flui_types::{geometry::px, gestures::Velocity};
     ///
     /// let velocity = Velocity::from_components(100.0, 50.0);
-    /// assert_eq!(velocity.pixels_per_second.dx, 100.0);
-    /// assert_eq!(velocity.pixels_per_second.dy, 50.0);
+    /// assert_eq!(velocity.pixels_per_second.dx, px(100.0));
+    /// assert_eq!(velocity.pixels_per_second.dy, px(50.0));
     /// ```
     #[inline]
     #[must_use]
@@ -96,7 +96,7 @@ impl Velocity {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::gestures::Velocity;
+    /// use flui_types::{geometry::px, gestures::Velocity};
     ///
     /// let velocity = Velocity::from_direction(100.0, 0.0);
     /// assert!((velocity.pixels_per_second.dx - 100.0).abs() < 0.01);
@@ -118,11 +118,11 @@ impl Velocity {
     /// ```
     /// use std::time::Duration;
     ///
-    /// use flui_types::{Offset, gestures::Velocity};
+    /// use flui_types::{Offset, geometry::px, gestures::Velocity};
     ///
     /// // Moved 100px right and 50px down in 100ms
     /// let velocity =
-    ///     Velocity::from_offset_over_duration(Offset::new(100.0, 50.0), Duration::from_millis(100));
+    ///     Velocity::from_offset_over_duration(Offset::new(px(100.0), px(50.0)), Duration::from_millis(100));
     ///
     /// // Velocity should be 1000px/s right, 500px/s down
     /// assert!((velocity.dx() - 1000.0).abs() < 0.1);
@@ -145,9 +145,9 @@ impl Velocity {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Offset, gestures::Velocity};
+    /// use flui_types::{Offset, geometry::px, gestures::Velocity};
     ///
-    /// let velocity = Velocity::new(Offset::new(3.0, 4.0));
+    /// let velocity = Velocity::new(Offset::new(px(3.0), px(4.0)));
     /// assert_eq!(velocity.magnitude(), 5.0);
     /// ```
     #[inline]
@@ -165,12 +165,12 @@ impl Velocity {
     /// ```
     /// use std::f32::consts::PI;
     ///
-    /// use flui_types::{Offset, gestures::Velocity};
+    /// use flui_types::{Offset, geometry::px, gestures::Velocity};
     ///
-    /// let velocity = Velocity::new(Offset::new(1.0, 0.0));
+    /// let velocity = Velocity::new(Offset::new(px(1.0), px(0.0)));
     /// assert!((velocity.direction() - 0.0).abs() < 0.01);
     ///
-    /// let velocity_up = Velocity::new(Offset::new(0.0, 1.0));
+    /// let velocity_up = Velocity::new(Offset::new(px(0.0), px(1.0)));
     /// assert!((velocity_up.direction() - PI / 2.0).abs() < 0.01);
     /// ```
     #[inline]
@@ -184,10 +184,10 @@ impl Velocity {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Offset, gestures::Velocity};
+    /// use flui_types::{Offset, geometry::px, gestures::Velocity};
     ///
     /// assert!(Velocity::ZERO.is_zero());
-    /// assert!(!Velocity::new(Offset::new(1.0, 0.0)).is_zero());
+    /// assert!(!Velocity::new(Offset::new(px(1.0), px(0.0))).is_zero());
     /// ```
     #[inline]
     #[must_use]
@@ -200,12 +200,12 @@ impl Velocity {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Offset, gestures::Velocity};
+    /// use flui_types::{Offset, geometry::px, gestures::Velocity};
     ///
-    /// let valid = Velocity::new(Offset::new(100.0, 50.0));
+    /// let valid = Velocity::new(Offset::new(px(100.0), px(50.0)));
     /// assert!(valid.is_finite());
     ///
-    /// let invalid = Velocity::new(Offset::new(f32::NAN, 50.0));
+    /// let invalid = Velocity::new(Offset::new(px(f32::NAN), px(50.0)));
     /// assert!(!invalid.is_finite());
     /// ```
     #[inline]
@@ -222,9 +222,9 @@ impl Velocity {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Offset, gestures::Velocity};
+    /// use flui_types::{Offset, geometry::px, gestures::Velocity};
     ///
-    /// let velocity = Velocity::new(Offset::new(100.0, 0.0));
+    /// let velocity = Velocity::new(Offset::new(px(100.0), px(0.0)));
     /// let clamped = velocity.clamp_magnitude(0.0, 50.0);
     /// assert_eq!(clamped.magnitude(), 50.0);
     /// ```
@@ -250,11 +250,11 @@ impl Velocity {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Offset, gestures::Velocity};
+    /// use flui_types::{Offset, geometry::px, gestures::Velocity};
     ///
-    /// let velocity = Velocity::new(Offset::new(100.0, -50.0));
+    /// let velocity = Velocity::new(Offset::new(px(100.0), px(-50.0)));
     /// let negated = velocity.negate();
-    /// assert_eq!(negated.pixels_per_second, Offset::new(-100.0, 50.0));
+    /// assert_eq!(negated.pixels_per_second, Offset::new(px(-100.0), px(50.0)));
     /// ```
     #[inline]
     #[must_use]
@@ -267,11 +267,11 @@ impl Velocity {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Offset, gestures::Velocity};
+    /// use flui_types::{Offset, geometry::px, gestures::Velocity};
     ///
-    /// let velocity = Velocity::new(Offset::new(100.0, 50.0));
+    /// let velocity = Velocity::new(Offset::new(px(100.0), px(50.0)));
     /// let scaled = velocity.scale(0.5);
-    /// assert_eq!(scaled.pixels_per_second, Offset::new(50.0, 25.0));
+    /// assert_eq!(scaled.pixels_per_second, Offset::new(px(50.0), px(25.0)));
     /// ```
     #[inline]
     #[must_use]
@@ -288,11 +288,11 @@ impl Velocity {
     /// ```
     /// use std::time::Duration;
     ///
-    /// use flui_types::{Offset, gestures::Velocity};
+    /// use flui_types::{Offset, geometry::px, gestures::Velocity};
     ///
-    /// let velocity = Velocity::new(Offset::new(100.0, 0.0));
+    /// let velocity = Velocity::new(Offset::new(px(100.0), px(0.0)));
     /// let distance = velocity.distance_over_duration(Duration::from_secs(1));
-    /// assert_eq!(distance, Offset::new(100.0, 0.0));
+    /// assert_eq!(distance, Offset::new(px(100.0), px(0.0)));
     /// ```
     #[must_use]
     #[inline]
@@ -306,9 +306,9 @@ impl Velocity {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Offset, gestures::Velocity};
+    /// use flui_types::{Offset, geometry::px, gestures::Velocity};
     ///
-    /// let velocity = Velocity::new(Offset::new(100.0, 50.0));
+    /// let velocity = Velocity::new(Offset::new(px(100.0), px(50.0)));
     /// assert_eq!(velocity.dx(), 100.0);
     /// ```
     #[inline]
@@ -322,9 +322,9 @@ impl Velocity {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Offset, gestures::Velocity};
+    /// use flui_types::{Offset, geometry::px, gestures::Velocity};
     ///
-    /// let velocity = Velocity::new(Offset::new(100.0, 50.0));
+    /// let velocity = Velocity::new(Offset::new(px(100.0), px(50.0)));
     /// assert_eq!(velocity.dy(), 50.0);
     /// ```
     #[inline]
@@ -351,16 +351,16 @@ impl Default for Velocity {
 /// ```
 /// use std::time::Duration;
 ///
-/// use flui_types::{Offset, gestures::VelocityEstimate};
+/// use flui_types::{Offset, geometry::px, gestures::VelocityEstimate};
 ///
 /// let estimate = VelocityEstimate::new(
-///     Offset::new(100.0, 50.0),
-///     Offset::new(200.0, -100.0),
+///     Offset::new(px(100.0), px(50.0)),
+///     Offset::new(px(200.0), px(-100.0)),
 ///     Duration::from_millis(16),
 ///     1.0,
 /// );
 ///
-/// assert_eq!(estimate.pixels_per_second, Offset::new(200.0, -100.0));
+/// assert_eq!(estimate.pixels_per_second, Offset::new(px(200.0), px(-100.0)));
 /// assert_eq!(estimate.confidence, 1.0);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -389,11 +389,11 @@ impl VelocityEstimate {
     /// ```
     /// use std::time::Duration;
     ///
-    /// use flui_types::{Offset, gestures::VelocityEstimate};
+    /// use flui_types::{Offset, geometry::px, gestures::VelocityEstimate};
     ///
     /// let estimate = VelocityEstimate::new(
-    ///     Offset::new(100.0, 50.0),
-    ///     Offset::new(200.0, -100.0),
+    ///     Offset::new(px(100.0), px(50.0)),
+    ///     Offset::new(px(200.0), px(-100.0)),
     ///     Duration::from_millis(16),
     ///     0.95,
     /// );
@@ -421,16 +421,16 @@ impl VelocityEstimate {
     /// ```
     /// use std::time::Duration;
     ///
-    /// use flui_types::{Offset, gestures::VelocityEstimate};
+    /// use flui_types::{Offset, geometry::px, gestures::VelocityEstimate};
     ///
     /// let estimate = VelocityEstimate::new(
     ///     Offset::ZERO,
-    ///     Offset::new(200.0, -100.0),
+    ///     Offset::new(px(200.0), px(-100.0)),
     ///     Duration::from_millis(16),
     ///     0.95,
     /// );
     /// let velocity = estimate.velocity();
-    /// assert_eq!(velocity.pixels_per_second, Offset::new(200.0, -100.0));
+    /// assert_eq!(velocity.pixels_per_second, Offset::new(px(200.0), px(-100.0)));
     /// ```
     #[inline]
     #[must_use]
@@ -447,7 +447,7 @@ impl VelocityEstimate {
     /// ```
     /// use std::time::Duration;
     ///
-    /// use flui_types::{Offset, gestures::VelocityEstimate};
+    /// use flui_types::{Offset, geometry::px, gestures::VelocityEstimate};
     ///
     /// let reliable =
     ///     VelocityEstimate::new(Offset::ZERO, Offset::ZERO, Duration::from_millis(16), 0.8);
@@ -466,11 +466,11 @@ impl VelocityEstimate {
     /// ```
     /// use std::time::Duration;
     ///
-    /// use flui_types::{Offset, gestures::VelocityEstimate};
+    /// use flui_types::{Offset, geometry::px, gestures::VelocityEstimate};
     ///
     /// let valid = VelocityEstimate::new(
-    ///     Offset::new(100.0, 50.0),
-    ///     Offset::new(200.0, -100.0),
+    ///     Offset::new(px(100.0), px(50.0)),
+    ///     Offset::new(px(200.0), px(-100.0)),
     ///     Duration::from_millis(16),
     ///     0.95,
     /// );
@@ -496,11 +496,11 @@ impl VelocityEstimate {
     /// ```
     /// use std::time::Duration;
     ///
-    /// use flui_types::{Offset, gestures::VelocityEstimate};
+    /// use flui_types::{Offset, geometry::px, gestures::VelocityEstimate};
     ///
     /// let valid = VelocityEstimate::new(
-    ///     Offset::new(100.0, 50.0),
-    ///     Offset::new(200.0, -100.0),
+    ///     Offset::new(px(100.0), px(50.0)),
+    ///     Offset::new(px(200.0), px(-100.0)),
     ///     Duration::from_millis(16),
     ///     0.95,
     /// );
@@ -527,11 +527,11 @@ impl VelocityEstimate {
     /// ```
     /// use std::time::Duration;
     ///
-    /// use flui_types::{Offset, gestures::VelocityEstimate};
+    /// use flui_types::{Offset, geometry::px, gestures::VelocityEstimate};
     ///
     /// let estimate = VelocityEstimate::new(
     ///     Offset::ZERO,
-    ///     Offset::new(3.0, 4.0),
+    ///     Offset::new(px(3.0), px(4.0)),
     ///     Duration::from_millis(16),
     ///     0.95,
     /// );

--- a/crates/flui-types/src/layout/axis.rs
+++ b/crates/flui-types/src/layout/axis.rs
@@ -74,9 +74,9 @@ impl Axis {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Axis, Size};
+    /// use flui_types::{Axis, Size, geometry::px};
     ///
-    /// let size = Size::new(100.0, 50.0);
+    /// let size = Size::new(px(100.0), px(50.0));
     /// assert_eq!(Axis::Horizontal.select_size(size), 100.0);
     /// assert_eq!(Axis::Vertical.select_size(size), 50.0);
     /// ```
@@ -94,10 +94,10 @@ impl Axis {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Axis, Size};
+    /// use flui_types::{Axis, Size, geometry::px};
     ///
-    /// assert_eq!(Axis::Horizontal.make_size(100.0), Size::new(100.0, 0.0));
-    /// assert_eq!(Axis::Vertical.make_size(100.0), Size::new(0.0, 100.0));
+    /// assert_eq!(Axis::Horizontal.make_size(100.0), Size::new(px(100.0), px(0.0)));
+    /// assert_eq!(Axis::Vertical.make_size(100.0), Size::new(px(0.0), px(100.0)));
     /// ```
     #[inline]
     #[must_use]
@@ -116,15 +116,15 @@ impl Axis {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Axis, Size};
+    /// use flui_types::{Axis, Size, geometry::px};
     ///
     /// assert_eq!(
     ///     Axis::Horizontal.make_size_with_cross(100.0, 50.0),
-    ///     Size::new(100.0, 50.0)
+    ///     Size::new(px(100.0), px(50.0))
     /// );
     /// assert_eq!(
     ///     Axis::Vertical.make_size_with_cross(100.0, 50.0),
-    ///     Size::new(50.0, 100.0)
+    ///     Size::new(px(50.0), px(100.0))
     /// );
     /// ```
     #[inline]
@@ -144,11 +144,11 @@ impl Axis {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Axis, Size};
+    /// use flui_types::{Axis, Size, geometry::px};
     ///
-    /// let size = Size::new(100.0, 50.0);
-    /// assert_eq!(Axis::Horizontal.flip_size(size), Size::new(100.0, 50.0));
-    /// assert_eq!(Axis::Vertical.flip_size(size), Size::new(50.0, 100.0));
+    /// let size = Size::new(px(100.0), px(50.0));
+    /// assert_eq!(Axis::Horizontal.flip_size(size), Size::new(px(100.0), px(50.0)));
+    /// assert_eq!(Axis::Vertical.flip_size(size), Size::new(px(50.0), px(100.0)));
     /// ```
     #[inline]
     #[must_use]
@@ -164,9 +164,9 @@ impl Axis {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Axis, Size};
+    /// use flui_types::{Axis, Size, geometry::px};
     ///
-    /// let size = Size::new(100.0, 50.0);
+    /// let size = Size::new(px(100.0), px(50.0));
     /// assert_eq!(Axis::Horizontal.main_size(size), 100.0);
     /// assert_eq!(Axis::Vertical.main_size(size), 50.0);
     /// ```
@@ -181,9 +181,9 @@ impl Axis {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Axis, Size};
+    /// use flui_types::{Axis, Size, geometry::px};
     ///
-    /// let size = Size::new(100.0, 50.0);
+    /// let size = Size::new(px(100.0), px(50.0));
     /// assert_eq!(Axis::Horizontal.cross_size(size), 50.0);
     /// assert_eq!(Axis::Vertical.cross_size(size), 100.0);
     /// ```
@@ -403,14 +403,14 @@ impl Orientation {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{Size, layout::Orientation};
+    /// use flui_types::{Size, geometry::px, layout::Orientation};
     ///
     /// assert_eq!(
-    ///     Orientation::from_size(Size::new(100.0, 200.0)),
+    ///     Orientation::from_size(Size::new(px(100.0), px(200.0))),
     ///     Orientation::Portrait
     /// );
     /// assert_eq!(
-    ///     Orientation::from_size(Size::new(200.0, 100.0)),
+    ///     Orientation::from_size(Size::new(px(200.0), px(100.0))),
     ///     Orientation::Landscape
     /// );
     /// ```

--- a/crates/flui-types/src/layout/box.rs
+++ b/crates/flui-types/src/layout/box.rs
@@ -308,16 +308,16 @@ impl BoxShape {
 ///
 /// ```
 /// use flui_types::{
-///     geometry::Size,
+///     geometry::{Size, px},
 ///     layout::{BoxFit, FittedSizes},
 /// };
 ///
-/// let input = Size::new(200.0, 100.0);
-/// let output = Size::new(100.0, 100.0);
+/// let input = Size::new(px(200.0), px(100.0));
+/// let output = Size::new(px(100.0), px(100.0));
 /// let fitted = BoxFit::Contain.apply(input, output);
 ///
-/// assert_eq!(fitted.destination.width, 100.0);
-/// assert_eq!(fitted.destination.height, 50.0);
+/// assert_eq!(fitted.destination.width, px(100.0));
+/// assert_eq!(fitted.destination.height, px(50.0));
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/flui-types/src/painting/image.rs
+++ b/crates/flui-types/src/painting/image.rs
@@ -274,10 +274,13 @@ pub enum ImageRepeat {
 /// # Examples
 ///
 /// ```
-/// use flui_types::{geometry::Size, painting::ImageConfiguration};
+/// use flui_types::{
+///     geometry::{Size, px},
+///     painting::ImageConfiguration,
+/// };
 ///
 /// let config = ImageConfiguration::new()
-///     .with_size(Size::new(100.0, 100.0))
+///     .with_size(Size::new(px(100.0), px(100.0)))
 ///     .with_device_pixel_ratio(2.0);
 /// ```
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/flui-types/src/painting/shader.rs
+++ b/crates/flui-types/src/painting/shader.rs
@@ -14,11 +14,11 @@ use crate::{
 /// # Examples
 ///
 /// ```
-/// use flui_types::{painting::Shader, styling::Color};
+/// use flui_types::{geometry::px, painting::Shader, styling::Color};
 ///
 /// let shader = Shader::linear_gradient(
 ///     flui_types::geometry::Offset::ZERO,
-///     flui_types::geometry::Offset::new(100.0, 100.0),
+///     flui_types::geometry::Offset::new(px(100.0), px(100.0)),
 ///     vec![Color::RED, Color::BLUE],
 ///     None,
 ///     flui_types::painting::TileMode::Clamp,
@@ -174,11 +174,15 @@ impl Shader {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{geometry::Offset, painting::Shader, styling::Color};
+    /// use flui_types::{
+    ///     geometry::{Offset, px},
+    ///     painting::Shader,
+    ///     styling::Color,
+    /// };
     ///
     /// let shader = Shader::simple_linear(
     ///     Offset::ZERO,
-    ///     Offset::new(100.0, 0.0),
+    ///     Offset::new(px(100.0), px(0.0)),
     ///     vec![Color::RED, Color::BLUE],
     /// );
     /// ```
@@ -198,10 +202,17 @@ impl Shader {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{geometry::Offset, painting::Shader, styling::Color};
+    /// use flui_types::{
+    ///     geometry::{Offset, px},
+    ///     painting::Shader,
+    ///     styling::Color,
+    /// };
     ///
-    /// let shader =
-    ///     Shader::simple_radial(Offset::new(50.0, 50.0), 25.0, vec![Color::RED, Color::BLUE]);
+    /// let shader = Shader::simple_radial(
+    ///     Offset::new(px(50.0), px(50.0)),
+    ///     25.0,
+    ///     vec![Color::RED, Color::BLUE],
+    /// );
     /// ```
     #[inline]
     #[must_use]
@@ -220,10 +231,14 @@ impl Shader {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{geometry::Offset, painting::Shader, styling::Color};
+    /// use flui_types::{
+    ///     geometry::{Offset, px},
+    ///     painting::Shader,
+    ///     styling::Color,
+    /// };
     ///
     /// let shader = Shader::simple_sweep(
-    ///     Offset::new(50.0, 50.0),
+    ///     Offset::new(px(50.0), px(50.0)),
     ///     vec![Color::RED, Color::GREEN, Color::BLUE],
     /// );
     /// ```

--- a/crates/flui-types/src/styling/border_radius.rs
+++ b/crates/flui-types/src/styling/border_radius.rs
@@ -16,7 +16,7 @@ use crate::geometry::{Corners, Pixels, Radius};
 /// ```
 /// use flui_types::{
 ///     geometry::{Radius, px},
-///     styling::BorderRadius,
+///     styling::{BorderRadius, BorderRadiusExt},
 /// };
 ///
 /// // All corners with the same circular radius
@@ -47,7 +47,10 @@ pub trait BorderRadiusExt {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{geometry::px, styling::BorderRadius};
+    /// use flui_types::{
+    ///     geometry::px,
+    ///     styling::{BorderRadius, BorderRadiusExt},
+    /// };
     ///
     /// let radius = BorderRadius::circular(px(16.0));
     /// ```
@@ -59,7 +62,10 @@ pub trait BorderRadiusExt {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::{geometry::px, styling::BorderRadius};
+    /// use flui_types::{
+    ///     geometry::px,
+    ///     styling::{BorderRadius, BorderRadiusExt},
+    /// };
     ///
     /// let radius = BorderRadius::elliptical(px(20.0), px(10.0));
     /// ```
@@ -152,7 +158,7 @@ pub trait BorderRadiusExt {
     /// # Examples
     ///
     /// ```
-    /// use flui_types::styling::BorderRadius;
+    /// use flui_types::styling::{BorderRadius, BorderRadiusExt};
     ///
     /// // Perfect for buttons, tags, and badges
     /// let radius = BorderRadius::pill();

--- a/crates/flui-types/tests/compile_fail/mixed_rect_ops.stderr
+++ b/crates/flui-types/tests/compile_fail/mixed_rect_ops.stderr
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
    = note: expected reference `&Rect<flui_types::Pixels>`
               found reference `&Rect<DevicePixels>`
 note: method defined here
-  --> src/geometry/rect.rs
+  --> $WORKSPACE/crates/flui-geometry/src/rect.rs
    |
    |     pub fn intersect(&self, other: &Self) -> Option<Self> {
    |            ^^^^^^^^^

--- a/crates/flui-types/tests/compile_fail/mixed_units.stderr
+++ b/crates/flui-types/tests/compile_fail/mixed_units.stderr
@@ -6,7 +6,7 @@ error[E0277]: cannot add `DevicePixels` to `flui_types::Pixels`
    |
    = help: the trait `Add<DevicePixels>` is not implemented for `flui_types::Pixels`
 help: the following other types implement trait `Add<Rhs>`
-  --> src/geometry/units.rs
+  --> $WORKSPACE/crates/flui-geometry/src/units.rs
    |
    | impl Add for Pixels {
    | ^^^^^^^^^^^^^^^^^^^ `flui_types::Pixels` implements `Add`

--- a/docs/FOUNDATIONS.md
+++ b/docs/FOUNDATIONS.md
@@ -217,7 +217,7 @@ graph TD
     facade --> widgets
 ```
 
-The DAG is acyclic and downward-correct. The Constitution **v2.3.0** layer table reflects current-state layering (geometry in `flui-types`, edition 2024 / Rust 1.94, accurate workspace member list); the **target graph above** is the forward-looking Part IV decomposition that Part V's roadmap migrates the workspace toward. The constitution remains "current state, locked"; this document is "target state, in progress." Full reasoning and the ordered migration delta: [`research/2026-05-22-crate-decomposition-redesign.md`](research/2026-05-22-crate-decomposition-redesign.md).
+The DAG is acyclic and downward-correct. The Constitution **v2.3.0** layer table reflects current-state layering (geometry in `flui-types`, edition 2024 / Rust 1.95, accurate workspace member list); the **target graph above** is the forward-looking Part IV decomposition that Part V's roadmap migrates the workspace toward. The constitution remains "current state, locked"; this document is "target state, in progress." Full reasoning and the ordered migration delta: [`research/2026-05-22-crate-decomposition-redesign.md`](research/2026-05-22-crate-decomposition-redesign.md).
 
 ---
 
@@ -270,7 +270,7 @@ This document is the **architecture contract** for the port. Its relationship to
 - **`FOUNDATIONS.md`** (this document) — *what* (the target architecture, the locked contracts, the crate graph).
 - [`PORT.md`](PORT.md) — *how* (the port methodology, refusal triggers, mapping rules).
 - [`ROADMAP.md`](ROADMAP.md) — *when / in what order* (the dependency-ordered construction phases).
-- [`.specify/memory/constitution.md`](../.specify/memory/constitution.md) — the ratified rules. **It requires amendment** (MINOR bump): the layer table must be replaced with Part IV's, and the edition/Rust-version line corrected to 2024 / 1.94.
+- [`.specify/memory/constitution.md`](../.specify/memory/constitution.md) — the ratified rules. **It requires amendment** (MINOR bump): the layer table must be replaced with Part IV's, and the edition/Rust-version line corrected to 2024 / 1.95.
 
 **Amendment.** A change to a locked contract (Part III) or the target crate graph (Part IV) requires: documented rationale, a corresponding `STRATEGY.md`/`PORT.md`/constitution sync if affected, and — once construction has begun — an explicit migration assessment, because a contract change after Phase 1 has catalog-wide blast radius. The contracts are locked precisely so that they are *not* casually amended.
 

--- a/docs/FOUNDATIONS.md
+++ b/docs/FOUNDATIONS.md
@@ -217,7 +217,7 @@ graph TD
     facade --> widgets
 ```
 
-The DAG is acyclic and downward-correct. The Constitution **v2.3.0** layer table reflects current-state layering (geometry in `flui-types`, edition 2024 / Rust 1.95, accurate workspace member list); the **target graph above** is the forward-looking Part IV decomposition that Part V's roadmap migrates the workspace toward. The constitution remains "current state, locked"; this document is "target state, in progress." Full reasoning and the ordered migration delta: [`research/2026-05-22-crate-decomposition-redesign.md`](research/2026-05-22-crate-decomposition-redesign.md).
+The DAG is acyclic and downward-correct. The Constitution **v2.3.0** layer table reflects the pre-PR-C-2 layering snapshot (geometry was in `flui-types`; since [PR #138](https://github.com/vanyastaff/flui/pull/138) it lives in the dedicated `flui-geometry` crate and is re-exported via `flui_types::geometry::*` for compatibility — edition 2024 / Rust 1.95, accurate workspace member list otherwise); the **target graph above** is the forward-looking Part IV decomposition that Part V's roadmap migrates the workspace toward. The constitution remains "current state, locked"; this document is "target state, in progress." Full reasoning and the ordered migration delta: [`research/2026-05-22-crate-decomposition-redesign.md`](research/2026-05-22-crate-decomposition-redesign.md).
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ This page covers prerequisites, the first build, and how to run the bundled exam
 
 | Tool | Minimum version | Notes |
 |------|-----------------|-------|
-| Rust | 1.94 | Pinned via `workspace.package.rust-version`. Use `rustup toolchain install stable`. |
+| Rust | 1.95 | Pinned via `workspace.package.rust-version` **and** `rust-toolchain.toml` (channel `1.95.0`). `rustup` installs/selects it automatically on first `cargo` invocation. |
 | Cargo | bundled with Rust | Workspace uses `resolver = "2"` and edition 2024. |
 | Git | any recent | Required to clone the repo. |
 | `cargo-ndk` | 3.x | Required only for Android targets. |

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -2,14 +2,14 @@ strict_tdd: true
 context: |
   FLUI is a modular, Flutter-inspired declarative UI framework for Rust with a
   three-tree architecture (View → Element → Render) and a wgpu-backed GPU
-  rendering engine. Pure Rust workspace (edition 2024, rust 1.94).
+  rendering engine. Pure Rust workspace (edition 2024, rust 1.95).
   See AGENTS.md, docs/FOUNDATIONS.md, and docs/ROADMAP.md.
 
   Vendored references (DO NOT treat as project source):
     .flutter/  — Flutter source for architectural reference (read-only)
     .gpui/     — GPUI source for Rust platform-pattern reference (read-only)
 
-  Stack: Rust 1.94 + Cargo workspace, tokio, wgpu 25.x (pinned),
+  Stack: Rust 1.95 + Cargo workspace, tokio, wgpu 25.x (pinned),
   lyon, glyphon, cosmic-text, glam, tracing.
 rules:
   proposal:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,26 +1,17 @@
-# Rust toolchain configuration
-# https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
+# Pinned Rust toolchain for the FLUI workspace.
+#
+# Mirrors `[workspace.package].rust-version` in `Cargo.toml` (MSRV).
+# `rustup` will install this exact toolchain automatically on first `cargo`
+# invocation if it is not already available locally.
+#
+# Bump procedure (see docs/PORT.md §MSRV):
+#   1. Bump `channel` here.
+#   2. Bump `[workspace.package].rust-version` in `Cargo.toml` to match.
+#   3. Update doc references (AGENTS.md, README.md, docs/FOUNDATIONS.md,
+#      docs/getting-started.md, openspec/config.yaml).
+#   4. Run `just ci` and update CI matrix if needed.
 
 [toolchain]
-channel = "stable"
-profile = "default"
-
-# Components to install
-components = [
-    "rustfmt",       # Code formatting
-    "clippy",        # Linting
-    "rust-src",      # Source for rust-analyzer
-    "rust-analyzer", # LSP server
-]
-
-# Build targets
-targets = [
-    # Primary development (Windows)
-    "x86_64-pc-windows-msvc",
-
-    # Cross-compilation targets (uncomment as needed)
-    # "wasm32-unknown-unknown",         # WebAssembly
-    # "aarch64-linux-android",          # Android ARM64
-    # "x86_64-unknown-linux-gnu",       # Linux
-    # "aarch64-apple-darwin",           # macOS ARM64
-]
+channel = "1.95.0"
+profile = "default"                # includes rustc, cargo, rustfmt, clippy, rust-docs
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Three commits in one stack:

| # | Commit | Scope |
|---|--------|-------|
| 1 | `57edbffd` | **MSRV bump 1.94 → 1.95** + `rust-toolchain.toml` + sync 5 docs + refresh 2 stale trybuild snapshots |
| 2 | `899befb1` | **`flui-geometry`** — restore 120 doctests broken after PR #138 |
| 3 | `6bf10db5` | **`flui-types`** (45) + **`flui-rendering`** (23) + **`flui-layer`** (20) — 88 more doctests of the same family |

Net effect: **208 broken doctests restored**, MSRV bumped, no production-code changes.

## Why three commits

The MSRV bump exposed a long-standing CI gap: since PR #138 (`flui-geometry` split), `cargo test --workspace --doc` had been failing on stale trybuild snapshots in `flui-types/tests/compile_fail/`, which short-circuited the rest of the doctest run. After fixing the snapshots (commit 1), 120 broken doctests in `flui-geometry` surfaced; after fixing those (commit 2), another 88 surfaced across three downstream crates (commit 3).

Commits are kept separate so reviewers can audit each independently. The stack is sequential — each commit builds & tests green on its own.

## Verification (Rust 1.95.0)

```text
cargo fmt --all -- --check                              — clean
cargo clippy --workspace --all-targets -- -D warnings   — clean
cargo test --workspace --no-fail-fast                   — all green
```

Per-crate doctest tallies:

| Crate | Before | After |
|---|---:|---:|
| `flui-geometry` | 0 / 120 fail | **120 / 0** |
| `flui-types` | 69 / 45 fail | **114 / 0** |
| `flui-rendering` | 6 / 23 fail | **25 / 0** |
| `flui-layer` | 12 / 20 fail | **32 / 0** |

## Commit 1 — `chore: bump MSRV to Rust 1.95 + pin via rust-toolchain.toml`

- `Cargo.toml`: `workspace.package.rust-version` `1.94` → `1.95`.
- `rust-toolchain.toml` (new): pins `channel = "1.95.0"`, `profile = "default"`, `components = ["rustfmt", "clippy"]`. Rustup auto-installs/selects it on first `cargo` invocation.
- Sync version references in `AGENTS.md`, `README.md`, `docs/FOUNDATIONS.md`, `docs/getting-started.md`, `openspec/config.yaml`. Dated `docs/research/*` and `docs/plans/*` artifacts left intact as historical snapshots.
- Refresh stale trybuild snapshots `flui-types/tests/compile_fail/{mixed_rect_ops,mixed_units}.stderr` — path-only delta after PR #138: `src/geometry/{rect,units}.rs` → `$WORKSPACE/crates/flui-geometry/src/{rect,units}.rs`.

Per `docs/PORT.md` MSRV policy: bumps follow stable within 6 weeks (1.95 released 2026-04-16).

## Commit 2 — `fix(flui-geometry): restore doctests after PR-C-2`

PR #138 moved the geometry module from `flui-types/src/geometry/` to its own crate, but the embedded doctests still referenced the old API.

- **Mechanical:** `use flui_types::geometry::` → `use flui_geometry::` (122 occurrences / 16 files), `use flui_types::Matrix4` → `use flui_geometry::Matrix4` (7 in `matrix4.rs`).
- **Missing re-export:** `pub use transform2d::Transform2D` added to `lib.rs` (closed 9 errors).
- **Missing constructor:** added `pub fn bounds(origin, size) -> Bounds<Pixels>` in `bounds.rs` by symmetry with `point()` / `size()` / `rect()` / `edges()`. Re-exported as `pub use bounds::{Bounds, bounds}`.
- **Hand-edited 23 doctests** where API drift was non-mechanical:
  - `Point<f32>` / `Vec2<f32>` / `Size<f32>` → typed equivalent with `Pixels` (because `f32` no longer implements `Unit`).
  - `Point::new(0.0, 0.0)` → `Point::new(px(0.0), px(0.0))`, analogous for assertions on `.x` / `.y` / `distance()` / `midpoint()` / `relative_to()`.
  - `Transform2D::translation` / `rotation` kept raw `f32` args (its signature is still `(f32, f32) -> Self`).
  - `Transform2D::rotation` doctest assertion now checks `|result| ≈ 1.0` (magnitude is preserved) instead of axis-specific value — avoids row-vs-column matrix convention dependency.
  - `Rect::new(Point, Size)` → `Rect::from_xywh(px, px, px, px)`.
  - `Size::cast` doctest gained missing `Pixels` import.
  - `ScaleFactor` doctest: `assert_eq!(_.get(), 200)` → `200.0`.
  - `device_px(200.0)` → `device_px(200)` (signature is `i32`).

## Commit 3 — `fix(workspace): restore broken doctests in flui-types/flui-rendering/flui-layer after PR-C-2`

### `flui-types` — 45 doctests / 7 files
- `gestures/pointer.rs` (9): hand-edited each doctest — wrap raw `f32` in `Offset::new(...)` with `px(...)`, add `geometry::px` to imports.
- `gestures/velocity.rs` (19): bulk perl rewrite over doctest lines.
- `layout/axis.rs` (7): bulk-wrap `Size::new` + per-doctest import fix.
- `layout/box.rs` (1): wrap `Size::new` args and assert `.width` / `.height` against `px(...)`.
- `painting/image.rs` (1): add `geometry::px` to existing import.
- `painting/shader.rs` (4): add `geometry::px` to each doctest.
- `styling/border_radius.rs` (4): import the `BorderRadiusExt` trait so `.circular` / `.elliptical` / `.pill` methods are in scope.

### `flui-rendering` — 23 doctests / 1 file
- `storage/flags.rs`: doctests imported non-existent `flui_rendering::core` module — corrected to `flui_rendering::storage` (where `pub use flags::{AtomicRenderFlags, RenderFlags}` re-exports them).

### `flui-layer` — 20 doctests / 17 files
- 5 files: added `px` to existing geometry imports via Python helper.
- 10 files: injected dedicated `use flui_types::geometry::px;` line at the top of each affected doctest.
- Hand-fixes:
  - `clip_superellipse` / `clip_rrect`: `from_rect_circular`'s `radius` argument is `Pixels`, not `f32` — wrapped in `px(...)`.
  - `layer/mod.rs` + `tree/layer_tree.rs` (×2): `Layer::Canvas` variant takes `Box<CanvasLayer>` — wrapped in `Box::new(...)`.
  - `tree/layer_tree.rs` `LayerTree` doc: replaced `assert!(needs_compositing())` (no longer truthy for fresh `CanvasLayer`) with `assert!(matches!(node.layer(), Layer::Canvas(_)))`.

## Out of scope

- No public-API changes outside additive re-exports in `flui-geometry` (`Transform2D`, `bounds` constructor — both were available via other paths but missing from the crate root).
- No behavioral changes in production code.
- `.specify/memory/constitution.md` MINOR amendment for the MSRV bump is intentionally left as a separate governance step (referenced in `docs/FOUNDATIONS.md:273`).

## Suggested CI follow-up

`cargo test --workspace --doc` was effectively non-functional in CI since PR #138 because the earliest failure short-circuited the rest. Consider adding `cargo test --workspace --doc --no-fail-fast` as a permanent gate so this class of breakage cannot accumulate silently again.

## References

- PR #138 (`8bc275cd`) — original `flui-geometry` split that introduced the doctest drift.
- `docs/PORT.md` — MSRV bump policy (§MSRV).
- `docs/FOUNDATIONS.md:273` — pending constitution amendment for the version reference.
