### PR TITLE
fix: green --all-features clippy across the workspace (serde surface + gated-test repair)

### DIFF
--- a/crates/flui-devtools/src/hot_reload.rs
+++ b/crates/flui-devtools/src/hot_reload.rs
@@ -45,6 +45,9 @@ use notify::{
 };
 use parking_lot::RwLock;
 
+/// Callback invoked with the changed path when a watched file changes.
+type OnChangeCallback = Box<dyn Fn(&Path) + Send + Sync>;
+
 /// Hot reloader for watching file changes
 ///
 /// Monitors specified directories for file changes and triggers callbacks.
@@ -53,7 +56,7 @@ pub struct HotReloader {
     /// Paths being watched
     watched_paths: Arc<RwLock<Vec<PathBuf>>>,
     /// Callback function for file changes
-    on_change_callback: Arc<RwLock<Option<Box<dyn Fn(&Path) + Send + Sync>>>>,
+    on_change_callback: Arc<RwLock<Option<OnChangeCallback>>>,
     /// File watcher
     watcher: Arc<RwLock<Option<RecommendedWatcher>>>,
     /// Debounce duration (to avoid triggering multiple times)

--- a/crates/flui-devtools/src/timeline.rs
+++ b/crates/flui-devtools/src/timeline.rs
@@ -129,6 +129,7 @@ impl TimelineEvent {
 ///
 /// Automatically records the event duration when dropped.
 #[must_use = "EventGuard does nothing if not held"]
+#[derive(Debug)]
 pub struct EventGuard {
     timeline: Arc<Mutex<TimelineInner>>,
     event_index: usize,
@@ -144,6 +145,7 @@ impl Drop for EventGuard {
 }
 
 /// Internal timeline state
+#[derive(Debug)]
 struct TimelineInner {
     /// Timeline start time (for relative timestamps)
     start_time: Instant,
@@ -404,10 +406,7 @@ impl Timeline {
             std::collections::HashMap::new();
 
         for event in &events {
-            by_category
-                .entry(event.category)
-                .or_insert_with(Vec::new)
-                .push(event);
+            by_category.entry(event.category).or_default().push(event);
         }
 
         for (category, category_events) in by_category {
@@ -420,7 +419,7 @@ impl Timeline {
 
             // Show longest events
             let mut sorted = category_events.clone();
-            sorted.sort_by(|a, b| b.duration_micros.cmp(&a.duration_micros));
+            sorted.sort_by_key(|e| std::cmp::Reverse(e.duration_micros));
 
             println!("  Longest events:");
             for event in sorted.iter().take(3) {

--- a/crates/flui-engine/src/wgpu/atlas.rs
+++ b/crates/flui-engine/src/wgpu/atlas.rs
@@ -330,6 +330,10 @@ mod unit_tests {
 }
 
 #[cfg(all(test, feature = "enable-wgpu-tests"))]
+#[allow(
+    clippy::float_cmp,
+    reason = "tests assert exact expected values produced by exact arithmetic"
+)]
 mod tests {
     use super::*;
 

--- a/crates/flui-engine/src/wgpu/buffer_pool.rs
+++ b/crates/flui-engine/src/wgpu/buffer_pool.rs
@@ -336,6 +336,10 @@ pub struct BufferPoolStats {
 }
 
 #[cfg(all(test, feature = "enable-wgpu-tests"))]
+#[allow(
+    clippy::float_cmp,
+    reason = "tests assert exact expected values produced by exact arithmetic"
+)]
 mod tests {
     use super::*;
 

--- a/crates/flui-engine/src/wgpu/effects.rs
+++ b/crates/flui-engine/src/wgpu/effects.rs
@@ -370,6 +370,10 @@ impl ShadowInstance {
 // builder ceremony.
 
 #[cfg(all(test, feature = "enable-wgpu-tests"))]
+#[allow(
+    clippy::float_cmp,
+    reason = "tests assert exact expected values produced by exact arithmetic"
+)]
 mod tests {
     use super::*;
 

--- a/crates/flui-engine/src/wgpu/instancing.rs
+++ b/crates/flui-engine/src/wgpu/instancing.rs
@@ -645,7 +645,13 @@ impl<T> Default for InstanceBatch<T> {
 // NOTE: Tests temporarily disabled - need update for Pixels/DevicePixels
 // migration
 #[cfg(all(test, feature = "disabled-tests"))]
+#[allow(
+    clippy::float_cmp,
+    reason = "tests assert exact expected values produced by exact arithmetic"
+)]
 mod tests {
+    use flui_types::geometry::px;
+
     use super::*;
 
     #[test]
@@ -690,7 +696,7 @@ mod tests {
 
         // Add first instance
         let should_flush = batch.add(RectInstance::rect(
-            Rect::from_ltrb(0.0, 0.0, 100.0, 50.0),
+            Rect::from_ltrb(px(0.0), px(0.0), px(100.0), px(50.0)),
             Color::RED,
         ));
         assert!(!should_flush);
@@ -698,7 +704,7 @@ mod tests {
 
         // Add second instance (reaches max)
         let should_flush = batch.add(RectInstance::rect(
-            Rect::from_ltrb(10.0, 10.0, 110.0, 60.0),
+            Rect::from_ltrb(px(10.0), px(10.0), px(110.0), px(60.0)),
             Color::BLUE,
         ));
         assert!(should_flush);
@@ -711,7 +717,10 @@ mod tests {
 
     #[test]
     fn test_color_conversion() {
-        let instance = RectInstance::rect(Rect::from_ltrb(0.0, 0.0, 100.0, 100.0), Color::RED);
+        let instance = RectInstance::rect(
+            Rect::from_ltrb(px(0.0), px(0.0), px(100.0), px(100.0)),
+            Color::RED,
+        );
 
         // RED should be [1.0, 0.0, 0.0, 1.0] in normalized form
         assert_eq!(instance.color[0], 1.0); // R

--- a/crates/flui-engine/src/wgpu/offscreen.rs
+++ b/crates/flui-engine/src/wgpu/offscreen.rs
@@ -1404,6 +1404,10 @@ impl FullscreenVertex {
 }
 
 #[cfg(all(test, feature = "enable-wgpu-tests"))]
+#[allow(
+    clippy::float_cmp,
+    reason = "tests assert exact expected values produced by exact arithmetic"
+)]
 mod tests {
     use super::*;
 

--- a/crates/flui-engine/src/wgpu/renderer.rs
+++ b/crates/flui-engine/src/wgpu/renderer.rs
@@ -997,13 +997,16 @@ mod tests {
         assert_eq!(GpuCapabilities::vendor_name(0x106B), "Apple");
     }
 
-    #[tokio::test]
-    async fn test_offscreen_renderer() {
-        // This test may fail in CI without GPU
-        if let Ok(renderer) = Renderer::new_offscreen().await {
-            assert!(renderer.surface.is_none());
-            assert!(renderer.config.is_none());
-            assert!(!renderer.capabilities.adapter_name.is_empty());
-        }
+    #[test]
+    fn test_offscreen_renderer() {
+        // This test may fail in CI without GPU. Driven via `pollster` to match
+        // the rest of this crate's async tests (no tokio-macros dependency).
+        pollster::block_on(async {
+            if let Ok(renderer) = Renderer::new_offscreen().await {
+                assert!(renderer.surface.is_none());
+                assert!(renderer.config.is_none());
+                assert!(!renderer.capabilities.adapter_name.is_empty());
+            }
+        });
     }
 }

--- a/crates/flui-engine/src/wgpu/tessellator.rs
+++ b/crates/flui-engine/src/wgpu/tessellator.rs
@@ -1035,7 +1035,7 @@ mod tests {
         let paint = Paint::fill(Color::RED);
 
         // Create an RRect with different radii per corner
-        let rrect = RRect::from_rect_and_corners(
+        let rounded_rect = RRect::from_rect_and_corners(
             rect,
             Radius::circular(px(5.0)),  // top-left: small
             Radius::circular(px(15.0)), // top-right: medium
@@ -1043,7 +1043,7 @@ mod tests {
             Radius::circular(px(10.0)), // bottom-left: moderate
         );
 
-        let result = tessellator.tessellate_rrect(rrect, &paint);
+        let result = tessellator.tessellate_rrect(rounded_rect, &paint);
         assert!(result.is_ok());
 
         let (vertices, indices) = result.expect("tessellation should succeed");

--- a/crates/flui-engine/src/wgpu/texture_cache.rs
+++ b/crates/flui-engine/src/wgpu/texture_cache.rs
@@ -952,6 +952,10 @@ mod unit_tests {
 }
 
 #[cfg(all(test, feature = "enable-wgpu-tests"))]
+#[allow(
+    clippy::float_cmp,
+    reason = "tests assert exact expected values produced by exact arithmetic"
+)]
 mod tests {
     use super::*;
 

--- a/crates/flui-engine/src/wgpu/texture_pool.rs
+++ b/crates/flui-engine/src/wgpu/texture_pool.rs
@@ -354,6 +354,8 @@ pub struct PoolStats {
 
 #[cfg(all(test, feature = "enable-wgpu-tests"))]
 mod tests {
+    use flui_types::geometry::px;
+
     use super::*;
 
     /// Helper: create a wgpu device for testing (headless)
@@ -366,14 +368,12 @@ mod tests {
         }))
         .expect("Failed to find a suitable GPU adapter for testing");
 
-        let (device, _queue) = pollster::block_on(adapter.request_device(
-            &wgpu::DeviceDescriptor {
+        let (device, _queue) =
+            pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
                 label: Some("Test Device"),
                 ..Default::default()
-            },
-            None,
-        ))
-        .expect("Failed to create GPU device for testing");
+            }))
+            .expect("Failed to create GPU device for testing");
 
         Arc::new(device)
     }
@@ -391,7 +391,7 @@ mod tests {
 
     #[test]
     fn test_texture_desc_from_size() {
-        let size = Size::new(1920.0, 1080.0);
+        let size = Size::new(px(1920.0), px(1080.0));
         let desc = TextureDesc::from_size(size, wgpu::TextureFormat::Rgba8UnormSrgb);
         assert_eq!(desc.width, 1920);
         assert_eq!(desc.height, 1080);

--- a/crates/flui-foundation/src/id.rs
+++ b/crates/flui-foundation/src/id.rs
@@ -641,7 +641,7 @@ ids! {
 mod serde_impl {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    use super::*;
+    use super::{Id, Index, Marker, RawId};
 
     impl Serialize for RawId {
         fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {

--- a/crates/flui-geometry/src/corners.rs
+++ b/crates/flui-geometry/src/corners.rs
@@ -8,6 +8,7 @@
 ///
 /// Generic over type `T` to support various value types.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Corners<T = f32> {
     /// The top-left corner value.
     pub top_left: T,

--- a/crates/flui-geometry/src/edges.rs
+++ b/crates/flui-geometry/src/edges.rs
@@ -10,6 +10,7 @@ use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 ///
 /// Generic over type `T` to support various value types.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Edges<T = f32> {
     /// The top edge value.
     pub top: T,

--- a/crates/flui-geometry/src/point.rs
+++ b/crates/flui-geometry/src/point.rs
@@ -43,6 +43,7 @@ use super::{
 /// let normalized = Point::<Pixels>::new(px(0.5), px(0.75));
 /// ```
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Point<T: Unit = Pixels> {
     /// The x coordinate (horizontal position).
     pub x: T,

--- a/crates/flui-geometry/src/rrect.rs
+++ b/crates/flui-geometry/src/rrect.rs
@@ -9,6 +9,7 @@ use super::{
 
 /// A radius value with separate horizontal and vertical components.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct Radius<T: Unit> {
     /// Horizontal radius.

--- a/crates/flui-geometry/src/rsuperellipse.rs
+++ b/crates/flui-geometry/src/rsuperellipse.rs
@@ -15,6 +15,7 @@ use super::{Pixels, Radius, Rect, px};
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RSuperellipse {
     /// The bounding rectangle.
     rect: Rect<Pixels>,

--- a/crates/flui-geometry/src/size.rs
+++ b/crates/flui-geometry/src/size.rs
@@ -28,6 +28,7 @@ use super::{
 /// assert_eq!(ui_size.area(), 480_000.0);
 /// ```
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct Size<T: Unit = Pixels> {
     /// Width dimension.

--- a/crates/flui-geometry/src/units.rs
+++ b/crates/flui-geometry/src/units.rs
@@ -83,6 +83,7 @@ use super::traits::{NumericUnit, Unit};
 /// let _: Pixels = px(10.0) * px(2.0);
 /// ```
 #[derive(Copy, Clone, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct Pixels(pub f32);
 
@@ -610,6 +611,7 @@ impl<'a> Sum<&'a Pixels> for Pixels {
 /// Unlike [`Pixels`] which represents an absolute position or measurement,
 /// `PixelDelta` represents a signed change (offset, velocity, scroll distance).
 #[derive(Copy, Clone, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct PixelDelta(pub f32);
 
@@ -966,6 +968,7 @@ impl<'a> Sum<&'a PixelDelta> for PixelDelta {
 ///
 /// Uses i32 for precise integer pixel addressing on hardware.
 #[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct DevicePixels(pub i32);
 
@@ -1363,6 +1366,7 @@ impl std::str::FromStr for DevicePixels {
 /// Wraps an f32 value representing an angle in radians.
 /// Provides angular arithmetic, normalization, and degree conversions.
 #[derive(Copy, Clone, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct Radians(pub f32);
 

--- a/crates/flui-hot-reload/src/pipeline.rs
+++ b/crates/flui-hot-reload/src/pipeline.rs
@@ -114,8 +114,7 @@ impl PluginPipeline {
             let has_root = owner.root_id().is_some();
             let tree_len = owner.render_tree().len();
             log(&format!(
-                "mount complete: root_id={}, render_tree_len={}, size={}x{}",
-                has_root, tree_len, width, height
+                "mount complete: root_id={has_root}, render_tree_len={tree_len}, size={width}x{height}"
             ));
         }
 

--- a/crates/flui-platform/src/platforms/winit/window_requests.rs
+++ b/crates/flui-platform/src/platforms/winit/window_requests.rs
@@ -85,7 +85,7 @@ mod tests {
         let sender = queue.sender();
 
         // Create a request
-        let (response_tx, response_rx) = std::sync::mpsc::sync_channel(1);
+        let (response_tx, _response_rx) = std::sync::mpsc::sync_channel(1);
         let options = WindowOptions {
             title: "Test Window".to_string(),
             size: Size::new(px(800.0), px(600.0)),

--- a/crates/flui-rendering/src/delegates/custom_clipper.rs
+++ b/crates/flui-rendering/src/delegates/custom_clipper.rs
@@ -148,10 +148,10 @@ mod tests {
         let size = Size::new(px(100.0), px(200.0));
         let clip = clipper.get_clip(size);
 
-        assert_eq!(clip.left(), 0.0);
-        assert_eq!(clip.top(), 0.0);
-        assert_eq!(clip.right(), 100.0);
-        assert_eq!(clip.bottom(), 200.0);
+        assert_eq!(clip.left(), px(0.0));
+        assert_eq!(clip.top(), px(0.0));
+        assert_eq!(clip.right(), px(100.0));
+        assert_eq!(clip.bottom(), px(200.0));
     }
 
     #[test]
@@ -160,10 +160,10 @@ mod tests {
         let size = Size::new(px(100.0), px(200.0));
         let clip = clipper.get_clip(size);
 
-        assert_eq!(clip.left(), 10.0);
-        assert_eq!(clip.top(), 10.0);
-        assert_eq!(clip.right(), 90.0);
-        assert_eq!(clip.bottom(), 190.0);
+        assert_eq!(clip.left(), px(10.0));
+        assert_eq!(clip.top(), px(10.0));
+        assert_eq!(clip.right(), px(90.0));
+        assert_eq!(clip.bottom(), px(190.0));
     }
 
     #[test]

--- a/crates/flui-rendering/src/delegates/flow_delegate.rs
+++ b/crates/flui-rendering/src/delegates/flow_delegate.rs
@@ -270,8 +270,8 @@ mod tests {
         assert_eq!(size, Size::new(px(500.0), px(200.0)));
 
         let child_constraints = delegate.get_constraints_for_child(0, constraints);
-        assert_eq!(child_constraints.max_width, 100.0);
-        assert_eq!(child_constraints.max_height, 50.0);
+        assert_eq!(child_constraints.max_width, px(100.0));
+        assert_eq!(child_constraints.max_height, px(50.0));
     }
 
     #[test]

--- a/crates/flui-rendering/src/delegates/multi_child_layout_delegate.rs
+++ b/crates/flui-rendering/src/delegates/multi_child_layout_delegate.rs
@@ -227,12 +227,12 @@ mod tests {
         assert!(context.laid_out.contains_key("body"));
 
         let header_pos = context.positions.get("header").unwrap();
-        assert_eq!(header_pos.dx, 0.0);
-        assert_eq!(header_pos.dy, 0.0);
+        assert_eq!(header_pos.dx, px(0.0));
+        assert_eq!(header_pos.dy, px(0.0));
 
         let body_pos = context.positions.get("body").unwrap();
-        assert_eq!(body_pos.dx, 0.0);
-        assert_eq!(body_pos.dy, 60.0); // 50 (header height) + 10 (padding)
+        assert_eq!(body_pos.dx, px(0.0));
+        assert_eq!(body_pos.dy, px(60.0)); // 50 (header height) + 10 (padding)
     }
 
     #[test]

--- a/crates/flui-rendering/src/delegates/single_child_layout_delegate.rs
+++ b/crates/flui-rendering/src/delegates/single_child_layout_delegate.rs
@@ -208,13 +208,13 @@ mod tests {
         assert_eq!(size, Size::new(px(200.0), px(100.0)));
 
         let child_constraints = delegate.get_constraints_for_child(constraints);
-        assert_eq!(child_constraints.min_width, 0.0);
-        assert_eq!(child_constraints.min_height, 0.0);
+        assert_eq!(child_constraints.min_width, px(0.0));
+        assert_eq!(child_constraints.min_height, px(0.0));
 
         let child_size = Size::new(px(50.0), px(30.0));
         let position = delegate.get_position_for_child(size, child_size);
-        assert_eq!(position.dx, 75.0);
-        assert_eq!(position.dy, 35.0);
+        assert_eq!(position.dx, px(75.0));
+        assert_eq!(position.dy, px(35.0));
     }
 
     #[test]
@@ -223,8 +223,8 @@ mod tests {
         let constraints = BoxConstraints::new(px(0.0), px(200.0), px(0.0), px(200.0));
 
         let size = delegate.get_size(constraints);
-        assert_eq!(size.width, 200.0);
-        assert_eq!(size.height, 100.0);
+        assert_eq!(size.width, px(200.0));
+        assert_eq!(size.height, px(100.0));
     }
 
     #[test]
@@ -233,8 +233,8 @@ mod tests {
         let constraints = BoxConstraints::new(px(0.0), px(200.0), px(0.0), px(50.0));
 
         let size = delegate.get_size(constraints);
-        assert_eq!(size.width, 100.0);
-        assert_eq!(size.height, 50.0);
+        assert_eq!(size.width, px(100.0));
+        assert_eq!(size.height, px(50.0));
     }
 
     #[test]

--- a/crates/flui-types/src/painting/blend_mode.rs
+++ b/crates/flui-types/src/painting/blend_mode.rs
@@ -1,6 +1,7 @@
 //! Blend modes for compositing colors.
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BlendMode {
     /// Drop both the source and the destination, leaving nothing.
     ///

--- a/crates/flui-types/src/styling/color.rs
+++ b/crates/flui-types/src/styling/color.rs
@@ -3,6 +3,18 @@
 //! This module provides a comprehensive Color type with conversions between
 //! different color spaces (RGB, HSL, HSV), similar to Flutter's Color system.
 
+// `Color` is a plain RGBA quadruple of independent `u8` channels — every bit
+// pattern is a valid `Color`. The derived `Deserialize` therefore cannot
+// produce an instance that violates any invariant the `unsafe` SIMD helpers
+// rely on (they only read the four channels), so the lint's concern does not
+// apply here.
+#[cfg_attr(
+    feature = "serde",
+    allow(
+        clippy::unsafe_derive_deserialize,
+        reason = "Color has no field invariant; all u8 quadruples are valid"
+    )
+)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Color {
@@ -234,6 +246,10 @@ impl Color {
     }
 
     #[inline]
+    #[allow(
+        dead_code,
+        reason = "scalar fallback for `lerp`; unused when a SIMD path is compiled in (e.g. --features simd on x86_64), used on every other target"
+    )]
     fn lerp_scalar(a: Color, b: Color, t: f32) -> Color {
         let t = t.clamp(0.0, 1.0);
         let lerp_u8 = |a: u8, b: u8| (a as f32 + (b as f32 - a as f32) * t) as u8;
@@ -447,6 +463,10 @@ impl Color {
     }
 
     #[inline]
+    #[allow(
+        dead_code,
+        reason = "scalar fallback for `blend_over`; unused when a SIMD path is compiled in (e.g. --features simd on x86_64), used on every other target"
+    )]
     fn blend_over_scalar(&self, background: Color) -> Color {
         let alpha_src = self.a as f32 / 255.0;
         let alpha_dst = background.a as f32 / 255.0;

--- a/crates/flui-types/src/typography/text_spans.rs
+++ b/crates/flui-types/src/typography/text_spans.rs
@@ -43,63 +43,70 @@ pub trait InlineSpanTrait: std::fmt::Debug {
 ///
 /// Allows storing different types of inline spans (text, placeholders)
 /// in a uniform container.
-#[derive(Debug, Clone)]
-pub struct InlineSpan {
-    inner: Arc<dyn InlineSpanTrait + Send + Sync>,
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum InlineSpan {
+    /// A run of styled text (with its own child spans).
+    ///
+    /// Boxed because `TextSpan` is much larger than `PlaceholderSpan`; the
+    /// `Box` keeps `InlineSpan` small and sidesteps `clippy::large_enum_variant`.
+    Text(Box<TextSpan>),
+    /// An inline placeholder reserving space for an embedded box.
+    Placeholder(PlaceholderSpan),
 }
 
 impl InlineSpan {
-    /// Creates a new inline span from any type implementing `InlineSpanTrait`.
+    /// Creates an inline span from any type convertible into one — i.e.
+    /// [`TextSpan`] or [`PlaceholderSpan`], the closed set of span kinds.
     #[must_use]
     #[inline]
-    pub fn new<T: InlineSpanTrait + Send + Sync + 'static>(span: T) -> Self {
-        Self {
-            inner: Arc::new(span),
-        }
+    pub fn new(span: impl Into<InlineSpan>) -> Self {
+        span.into()
     }
 
-    /// Returns a reference to the trait object.
+    /// Returns this span as its [`InlineSpanTrait`] object for shared behavior.
     #[must_use]
     #[inline]
     pub fn as_trait(&self) -> &(dyn InlineSpanTrait + Send + Sync) {
-        &*self.inner
+        match self {
+            Self::Text(span) => span.as_ref(),
+            Self::Placeholder(span) => span,
+        }
     }
 
     /// Returns the style for this span, if any.
     #[must_use]
     #[inline]
     pub fn style(&self) -> Option<&TextStyle> {
-        self.inner.style()
+        self.as_trait().style()
     }
 
     /// Returns the plain text content.
     #[must_use]
     #[inline]
     pub fn to_plain_text(&self) -> String {
-        self.inner.to_plain_text()
+        self.as_trait().to_plain_text()
     }
 
     /// Returns true if this span has semantic labels.
     #[must_use]
     #[inline]
     pub fn has_semantics(&self) -> bool {
-        self.inner.has_semantics()
-    }
-}
-
-impl PartialEq for InlineSpan {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        // Compare by pointer equality for Arc (identity comparison)
-        // For deep comparison, use to_plain_text() or compare serialized forms
-        Arc::ptr_eq(&self.inner, &other.inner)
+        self.as_trait().has_semantics()
     }
 }
 
 impl From<TextSpan> for InlineSpan {
     #[inline]
     fn from(span: TextSpan) -> Self {
-        Self::new(span)
+        Self::Text(Box::new(span))
+    }
+}
+
+impl From<PlaceholderSpan> for InlineSpan {
+    #[inline]
+    fn from(span: PlaceholderSpan) -> Self {
+        Self::Placeholder(span)
     }
 }
 
@@ -108,7 +115,8 @@ impl From<TextSpan> for InlineSpan {
 /// Represents a portion of text with associated styling, child spans,
 /// and optional semantic labels and event handlers for accessibility
 /// and user interaction.
-#[derive(Default)]
+#[derive(Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextSpan {
     /// Text content.
     pub text: Option<String>,
@@ -122,9 +130,11 @@ pub struct TextSpan {
     pub mouse_cursor: Option<MouseCursor>,
     /// Tap callback handler.
     ///
-    /// `TextSpan` is intentionally not part of the serde surface (its
-    /// `TextStyle` is not serializable), so this callback carries no
-    /// `serde(skip)` attribute — there is no derive for it to attach to.
+    /// Skipped by serde: a live `Arc<dyn Fn>` callback cannot be serialized,
+    /// and a deserialized span legitimately carries no handler (it defaults to
+    /// `None`). This is the universal "callbacks don't survive serialization"
+    /// rule, not a loss of styling/text content.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub on_tap: Option<Arc<dyn Fn() + Send + Sync>>,
 }
 

--- a/crates/flui-types/src/typography/text_spans.rs
+++ b/crates/flui-types/src/typography/text_spans.rs
@@ -121,7 +121,10 @@ pub struct TextSpan {
     /// Mouse cursor when hovering.
     pub mouse_cursor: Option<MouseCursor>,
     /// Tap callback handler.
-    #[cfg_attr(feature = "serde", serde(skip))]
+    ///
+    /// `TextSpan` is intentionally not part of the serde surface (its
+    /// `TextStyle` is not serializable), so this callback carries no
+    /// `serde(skip)` attribute — there is no derive for it to attach to.
     pub on_tap: Option<Arc<dyn Fn() + Send + Sync>>,
 }
 

--- a/crates/flui-types/src/typography/text_style.rs
+++ b/crates/flui-types/src/typography/text_style.rs
@@ -196,6 +196,7 @@ impl StrutStyle {
 }
 
 #[derive(Default, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextStyle {
     /// Text color.
     pub color: Option<Color>,


### PR DESCRIPTION
## What

Makes `cargo clippy --workspace --all-targets --all-features -- -D warnings` pass (it failed before this PR). Independent of the in-flight ALT-2 element-tree work — pure `--all-features` hygiene.

Two classes of failure, each previously hidden behind the next crate's compile error in the dependency graph:

### 1. Incomplete `serde` feature surface
Generic geometry primitives and a few core types lacked the conditional serde derive their serde-deriving consumers needed (E0277), so every struct/enum embedding them failed to derive `Serialize`/`Deserialize` under `--features serde`.

- **flui-geometry**: `Point`, `Size`, `Radius`, `Corners`, `RSuperellipse`, `Edges`, and the unit newtypes `Pixels`/`PixelDelta`/`DevicePixels`/`Radians`.
- **flui-types**: `BlendMode`, `TextStyle`; justified `Color`'s `unsafe_derive_deserialize` (plain RGBA `u8` quadruple — no invariant the unsafe SIMD helpers rely on) and the scalar-fallback `dead_code`.
- **Display list serde, done right**: `DrawCommand`/`DisplayList` couldn't derive serde because `InlineSpan` was a trait object (`Arc<dyn InlineSpanTrait>`). `InlineSpanTrait` has exactly two impls (`TextSpan`, `PlaceholderSpan`) — a closed set — so `InlineSpan` is now a **closed enum** `{ Text(Box<TextSpan>), Placeholder(PlaceholderSpan) }` (drops the per-span `Arc`/vtable; `new(impl Into)` keeps all call sites; structural `PartialEq` safe — 0 call sites). `TextSpan` derives serde with the `on_tap` callback `serde(skip)`.
- **flui-foundation**: `serde_impl` wildcard import → explicit (`wildcard_imports`).

### 2. Drifted feature-gated test code
`--all-features` enables test modules off by default (`experimental-delegates`, `disabled-tests`, `enable-wgpu-tests`) whose code had drifted from current APIs and the lint bar (CI runs default features, so they were never built).

- **flui-rendering**: delegate tests asserted `Pixels` accessors against bare `f32` literals (the geometry unit-barrier forbids `PartialEq<f32>`) — wrapped expected values in `px(...)` (22 sites).
- **flui-engine**: `px(...)` wraps for `from_ltrb`/`Size::new` test args; `request_device` → wgpu-25 single-arg signature; `#[tokio::test]` → `pollster::block_on` (no tokio-macros dep); `rrect`→`rounded_rect` (`similar_names`); justified `float_cmp` on six exact-value test modules.
- **flui-platform**: unused channel receiver → `_response_rx`.
- **flui-hot-reload**: inline `format!` args.

## Verification
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean (was failing).
- `cargo clippy --workspace --all-targets -- -D warnings` (default) — clean.
- `cargo nextest run --workspace --test-threads 1` — 3560 passed, 0 failed.
- `cargo fmt --all -- --check` — clean.
- The display-list enum refactor is always-on (not serde-gated); default tests confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)