### PR TITLE
perf(flui-types): InlineSpan::Text behind Arc (O(1) clone) — addresses #165 review

### DIFF
--- a/crates/flui-types/Cargo.toml
+++ b/crates/flui-types/Cargo.toml
@@ -21,8 +21,12 @@ num-traits = "0.2"
 # Error handling
 thiserror = "2.0"
 
-# Serialization support (optional)
-serde = { workspace = true, optional = true }
+# Serialization support (optional).
+# `rc` enables `Serialize`/`Deserialize` for `Arc<T>` — needed by
+# `InlineSpan::Text(Arc<TextSpan>)`. Deserialization does not preserve Arc
+# sharing (each is rebuilt independently), which is fine: display-list
+# snapshots carry no cross-span aliasing to preserve.
+serde = { workspace = true, optional = true, features = ["rc"] }
 
 # Stack-allocated Vec for small collections (animation curves, color stops)
 smallvec = { workspace = true }

--- a/crates/flui-types/src/typography/text_spans.rs
+++ b/crates/flui-types/src/typography/text_spans.rs
@@ -48,9 +48,12 @@ pub trait InlineSpanTrait: std::fmt::Debug {
 pub enum InlineSpan {
     /// A run of styled text (with its own child spans).
     ///
-    /// Boxed because `TextSpan` is much larger than `PlaceholderSpan`; the
-    /// `Box` keeps `InlineSpan` small and sidesteps `clippy::large_enum_variant`.
-    Text(Box<TextSpan>),
+    /// `Arc`-wrapped so `InlineSpan::clone` is an O(1) refcount bump rather
+    /// than an O(N) deep copy of the span tree — display lists clone
+    /// `DrawCommand`s freely (compositing, `with_opacity`/transform ops), and
+    /// rich text can carry many child spans. The `Arc` indirection also keeps
+    /// the enum small (no `large_enum_variant`).
+    Text(Arc<TextSpan>),
     /// An inline placeholder reserving space for an embedded box.
     Placeholder(PlaceholderSpan),
 }
@@ -99,7 +102,7 @@ impl InlineSpan {
 impl From<TextSpan> for InlineSpan {
     #[inline]
     fn from(span: TextSpan) -> Self {
-        Self::Text(Box::new(span))
+        Self::Text(Arc::new(span))
     }
 }
 


### PR DESCRIPTION
Follow-up to #165, addressing the Copilot review finding on `InlineSpan`.

## Problem
#165 made `InlineSpan` a closed enum with `Text(Box<TextSpan>)`. `Box` makes `InlineSpan::clone` **deep-copy the whole span tree** (all child spans). But display lists clone `DrawCommand`s freely:
- compositing: `Canvas::append` → `DisplayList::clone`;
- per-command `with_opacity` / transform ops.

So for rich text this turned the previously O(1) clone (the pre-refactor `Arc<dyn InlineSpanTrait>` was a refcount bump) into an **O(N) deep copy** on a paint-path-adjacent operation — a regression for a framework whose headline win is no-jank rendering.

## Fix
`Text(Arc<TextSpan>)` — restores O(1) refcount-bump clone. Still a closed, serde-derivable enum; structural `PartialEq` (Arc compares by value); `from`/`as_trait`/`new` unchanged. Enables serde's `rc` feature so `Arc<TextSpan>` derives `Serialize`/`Deserialize` — display-list snapshots carry no cross-span Arc sharing to preserve, so the "no dedup on deserialize" caveat is irrelevant. The Arc also shrinks the variant (`large_enum_variant` moot).

## Verification
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` (default) — clean.
- `cargo nextest run -p flui-types -p flui-painting` — 704 passed.
- `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)