### PR TITLE
docs(research): semantic / a11y audit (2026-06)

### DIFF
--- a/docs/research/2026-06-09-flui-semantic-a11y-audit.md
+++ b/docs/research/2026-06-09-flui-semantic-a11y-audit.md
@@ -1,0 +1,75 @@
+# flui Semantic / A11y — Synthesis Audit (2026-06-09)
+
+Caveman synthesis. Three layers: (1) [[2026-06-09-flui-semantic-current-state]] what flui ships today, (2) [[2026-06-09-flutter-3-41-semantic-reference]] the Flutter 3.41.9 reference corpus in `.flutter/flutter-master/`, (3) [[2026-06-09-rust-a11y-ecosystem]] the Rust a11y crates & competitor landscape.
+
+**Bottom line**: flui-semantics crate is ~65% Flutter-port complete on the data side. **3 production-path warn-stubs** and **zero platform bridges** block end-to-end. The Rust ecosystem has converged on **AccessKit** as the IR standard (Slint/Xilem/egui/plushie-iced/AccessKit itself). Path forward = finish the 3 stubs + add AccessKit adapter layer + port `SemanticsConfiguration::absorb` to match Flutter's `:6790` reference. Web path stays manual ARIA (Flutter Web's PR #168653 is the production model — `SemanticRole` per-role + `SemanticBehavior` cross-cutting).
+
+## Snapshot table
+
+| Layer | Status | LOC | Coverage |
+|---|---|---:|---|
+| `flui-semantics` (types/binding/owner) | ACTIVE | 6 625 | ~65% (tree-data done, OS-API bridge missing) |
+| `run_semantics` pipeline integration | STUB (warn) | — | 0% (3 tracing::warn! stubs) |
+| Platform bridges (UIA/AT-SPI/NSA/TalkBack/VoiceOver/ARIA) | NONE | 0 | 0% |
+| `SemanticsConfiguration::absorb` Flutter-parity | DRIFT | — | 4 drift-points vs `semantics.dart:6790` |
+| AccessKit dep declared but unused | ZOMBIE | — | 0 source refs |
+| Flutter 3.41.9 reference corpus (`.flutter/flutter-master/`) | AVAILABLE | ~82 213 | 100% (the contract source) |
+| Unit tests in flui-semantics | 110 | — | intra-crate only, no parity/ dir |
+
+## Top-10 actions (ranked by leverage)
+
+| # | Action | Source | Rationale |
+|---|---|---|---|
+| 1 | Wire `run_semantics` → `SemanticsOwner::flush` | `flui-rendering/src/pipeline/owner.rs:2413-2501` | Removes critical stub. Most concentrated user-facing gap. |
+| 2 | Wire `perform_semantics_action` → `SemanticsActionHandler` | `flui-rendering/src/binding/mod.rs:382-396` | Action dispatch is the second half of the a11y round-trip. |
+| 3 | Revive `SemanticsBuilder` in custom_painter | `flui-rendering/src/delegates/custom_painter.rs:50-58` | Custom painters need a path to contribute semantics. |
+| 4 | Port `SemanticsConfiguration::absorb` from Flutter `:6790` | `semantics.dart:6790` | 4 drift-points: concat label/value/hint, `isBlockingUserActions` filter, role absorption, heading-level merge. |
+| 5 | Add `role` field to `SemanticsConfiguration` | `semantics.dart:5196` | Role enum exposed in flui but never stored at runtime config. |
+| 6 | `SemanticsTree: TreeRead<SemanticsId>+TreeNav<SemanticsId>` | `crates/flui-semantics/src/tree.rs:57` | Asymmetric vs `LayerTree`; per [[flui-tree-unified-interface-intent]]. |
+| 7 | Add `accesskit` 0.24 + `accesskit_consumer` 0.36 as deps | `flui-semantics/Cargo.toml:39` (currently 0.21 dead) | `accesskit_winit` 0.33 + platform adapters handle UIA/AT-SPI/NSA out of box. |
+| 8 | `SemanticsNode` → `accesskit::Node` mapping | one-shot | 1:1 role/label/value/description mapping. See [[2026-06-09-rust-a11y-ecosystem]]. |
+| 9 | `UpdateSemantics` + `DispatchSemanticsAction` callbacks | embedder ABI `embedder.h:298` | Reuse Flutter's per-platform contract. |
+| 10 | Manual `web-sys` ARIA path (model: Flutter PR #168653) | `engine/src/flutter/lib/web_ui/lib/src/engine/semantics/` | No accesskit web-adapter shipped; mirror Flutter's per-role split. |
+
+## Top-5 hidden gaps (Flutter has, flui doesn't)
+
+| Gap | Flutter ref | Why it matters |
+|---|---|---|
+| `SemanticsInputType` enum (6 values: none/text/url/phone/search/email) | `engine/src/flutter/lib/ui/semantics.dart:561` | Text input semantics completeness; hint for keyboard type. |
+| `SemanticsValidationResult` enum (None/Valid/Invalid) | `engine/src/flutter/lib/ui/semantics/semantics_node.h:116` | Form validation feedback to AT. |
+| Heading-level merge in `absorb` | `semantics.dart:6790` via `_mergeHeadingLevels` | Document outline (a11y tree view) breaks without it. |
+| `isBlockingUserActions` filter on absorb | `semantics.dart:6790` via `_kUnblockedUserActions` | Modal dialogs swallowing AT gestures. |
+| Traversal-parent vs parent (OverlayPortal graft) | `semantics.dart:2773` + `SemanticsConfiguration.traversalChildIdentifier` | Future overlay-portal semantic graft. Not blocking now. |
+
+## Competitor position (mid-2026)
+
+| Tier | Members | Common ground |
+|---|---|---|
+| Production a11y on all 6 desktop+mobile platforms | Flutter, Slint, plushie-iced, Qt, GTK | All converge on platform-native bridges (UIA/AT-SPI/NSA/ATK) |
+| Alpha/stub a11y | Xilem, egui (via accesskit path), Servo servoshell (web content) | AccessKit-backed, still landing per-platform polish |
+| Webview-inherited ARIA | Dioxus, Tauri, Dioxus-mobile | Inherit Chromium/Safari a11y tree; native-layer gaps |
+| No a11y | Makepad | Acknowledged gap, no bridge shipped |
+
+**flui's bet**: same as Slint/egui (AccessKit) but with Flutter-semantics compatibility. **Differentiation**: the Flutter-port contract (`SemanticsNode`/`SemanticsConfiguration`/`SemanticsRole`/`SemanticsFlag`/`SemanticsAction` types are already 65% parity — that's the asset to defend).
+
+## Risks
+
+1. **MSRV lock-in**: accesskit 0.24+ MSRV 1.85. If flui MSRV < 1.85 → pin `accesskit 0.21.x` (last pre-edition-2024). Check before dep bump.
+2. **`accesskit_ios` 0.1.0 immaturity** (May 2026 initial). For iOS path either: (a) wait for ≥0.5, (b) build raw UIAccessibility bindings (like `accessibility` 0.2.0 eiz, but stagnant).
+3. **Rich text + hypertext**: AccessKit adapters don't support. Flutter `Link`/`AttributedString` need workaround (text range + custom action).
+4. **WASM bin size**: `accesskit_winit` pulls winit X11/Wayland ~500KB+ → not viable on wasm. cfg: `accesskit` core only on wasm, ARIA via `web-sys` only.
+5. **Flutter Web iOS WebKit regression #179784** (Dec 2025, still open) — manual ARIA path inherits the bug. Not flui-specific.
+6. **Test harness cost**: parity with Flutter's `packages/flutter/test/semantics/` (8 files) + `widgets/semantics_*.dart` (~30 files) = ~1k+ unit tests once ported. Estimate: 2-3 PRs of work.
+
+## Cross-references
+
+- [[2026-06-09-flui-semantic-current-state]] — file:line map of existing flui semantics
+- [[2026-06-09-flutter-3-41-semantic-reference]] — file:line map of Flutter 3.41.9 reference corpus
+- [[2026-06-09-rust-a11y-ecosystem]] — Rust crates + competitor framework matrix
+- Internal: `docs/research/2026-05-22-flui-layer-semantics-audit.md` (the prior 25-finding audit, now superseded for the platform-bridge section)
+- Internal: `docs/research/2026-05-22-flui-rendering-engine-audit.md` (the 3-stub inventory)
+- Internal: `docs/research/2026-05-22-flutter-flui-gap-matrix.md` (~65% coverage note)
+- Internal: `docs/research/2026-05-22-rust-ui-ecosystem-lessons.md`
+- Memory: `[[no-quick-wins-vanyastaff]]` (the no-defer-with-excuse rule applies to all 3 stub fixes)
+- Memory: `[[flui-tree-unified-interface-intent]]` (TreeRead/TreeNav symmetry)
+- Memory: `[[fable5-models-and-flui-env]]` (model context for any future PR work)

--- a/docs/research/2026-06-09-flui-semantic-current-state.md
+++ b/docs/research/2026-06-09-flui-semantic-current-state.md
@@ -1,0 +1,144 @@
+# flui Semantic / A11y — Current State (2026-06-09)
+
+Caveman file:line map of what flui already has. Synthesized by `rust-studio:rust-scout` agent. Companion to [[2026-06-09-flui-semantic-a11y-audit]] (synthesis) and [[2026-06-09-flutter-3-41-semantic-reference]] (Flutter reference corpus).
+
+## Cargo dep: zombie `accesskit`
+
+`C:\Users\vanya\RustroverProjects\flui\crates\flui-semantics\Cargo.toml:39` — `accesskit = "0.21"`. **Zero source-file refs** in flui-semantics (grep returns nothing). Dead dep. Either use it or remove.
+
+## `flui-semantics` crate (6,625 LOC, 110 unit tests, 12 files)
+
+```
+crates/flui-semantics/src/
+  lib.rs              (1-180)  module docs + 5-tree architecture diagram + re-exports
+  action.rs           (21-260) SemanticsAction enum (28 variants) + 4 tests
+  binding.rs          (1-608)  SemanticsBinding, SemanticsHandle, AccessibilityFeatures, SemanticsActionEvent, SemanticsService
+                              + 10 tests
+  configuration.rs    (1-1058) SemanticsConfiguration (builder) + 9 tests
+  event.rs            (22-257) SemanticsEvent, SemanticsEventType + 6 tests
+  flags.rs            (16-217) SemanticsFlag (u64, 28 variants) + SemanticsFlags + 4 tests
+  node.rs             (52-470) SemanticsNode (parent/children/element_id/config/rect/transform/dirty) + 9 tests
+  owner.rs            (117-525) SemanticsOwner (tree + callback + flush) + 13 tests
+  properties.rs       (1-529)  CustomSemanticsAction, SemanticsProperties, AttributedString,
+                              SemanticsHintOverrides, SemanticsSortKey, SemanticsTag,
+                              StringAttribute, StringAttributeType, TextDirection + 6 tests
+  role.rs             (1-394)  SemanticsRole (30 variants), Assertiveness,
+                              AccessibilityFocusBlockType, DebugSemanticsDumpOrder + 13 tests
+  tree.rs             (57-565) SemanticsTree (Slab<SemanticsNode>) + 27 tests
+  update.rs           (1-201)  SemanticsNodeData, SemanticsTreeUpdate, SemanticsTreeUpdateBuilder + 4 tests
+```
+
+## Foundation integration
+
+- `C:\Users\vanya\RustroverProjects\flui\crates\flui-foundation\src\id.rs:647-651` — `pub type SemanticsId = Semantics;`
+- `C:\Users\vanya\RustroverProjects\flui\crates\flui-foundation\src\lib.rs:200,263` — re-exports
+- `C:\Users\vanya\RustroverProjects\flui\crates\flui-foundation\README.md:61,64,99,261` — SemanticsId documented in 5-tree family
+
+## Rendering pipeline integration
+
+- `crates/flui-rendering/src/lib.rs:84` — `pub use flui_semantics as semantics`
+- `crates/flui-rendering/src/lib.rs:153-155` — re-exports
+- `crates/flui-rendering/src/pipeline/phase.rs:148,154,168-171` — `pub struct Semantics` (PipelinePhase, sealed)
+- `crates/flui-rendering/src/pipeline/owner.rs:155-158` — `semantics_enabled: AtomicBool`
+- `crates/flui-rendering/src/pipeline/owner.rs:2050` — `pub fn into_semantics(self) -> PipelineOwner<Semantics>`
+- `crates/flui-rendering/src/pipeline/owner.rs:2413-2501` — **`run_semantics` STUB** (tracing::warn per node + clear dirty)
+- `crates/flui-rendering/src/pipeline/owner.rs:332-335` — `run_frame` wires `run_semantics`
+- `crates/flui-rendering/src/pipeline/owner.rs:154-156` — `debug_doing_semantics` flag
+- `crates/flui-rendering/src/pipeline/notifier.rs:35-111` — `on_semantics_owner_created`/`disposed` callbacks
+- `crates/flui-rendering/src/pipeline/dirty.rs:70` — `pub needs_semantics: Vec<DirtyNode>`
+- `crates/flui-rendering/src/storage/flags.rs:13,112,129,185-192,797,811` — `NEEDS_SEMANTICS` bit / `markNeedsSemanticsUpdate`
+- `crates/flui-rendering/src/traits/render_object.rs:80-92` — `pub trait SemanticsCapability { fn describe_semantics_configuration(...) }`
+- `crates/flui-rendering/src/traits/render_object.rs:149` — supertrait of `RenderObject<P>`
+- `crates/flui-rendering/src/traits/render_box.rs:381` — `+ SemanticsCapability` supertrait bound
+- `crates/flui-rendering/src/traits/render_sliver.rs:343` — `+ SemanticsCapability` supertrait bound
+- `crates/flui-rendering/src/objects/*.rs` — **22 concrete `impl SemanticsCapability for Render* {}` empty/zero-arg opt-outs** (absorb_pointer:141, aspect_ratio:329, center:166, clip:569, colored_box:106, constrained_box:205, fitted_box:336, flex:422, fractional_translation, fractionally_sized_box, ignore_pointer, limited_box, meta_data, offstage, opacity, padding, repaint_boundary, sized_box, sliver_*, stack, transform)
+- `crates/flui-rendering/src/delegates/custom_painter.rs:28-70` — `pub struct SemanticsBuilder` (inert shell, WARN_ONCE)
+- `crates/flui-rendering/src/delegates/custom_painter.rs:142-145` — `fn semantics_builder(&self) -> Option<SemanticsBuilder>`
+- `crates/flui-rendering/src/binding/mod.rs:78,357-397` — **Semantics Actions section; `perform_semantics_action` warn-stub**
+- `crates/flui-rendering/src/binding/mod.rs:452-484` — `pub fn debug_dump_semantics_tree` (placeholder text "Semantics not generated")
+
+## App integration
+
+- `crates/flui-app/src/bindings/mod.rs:10,19,42` — re-export `SemanticsBinding`
+- `crates/flui-app/src/bindings/renderer_binding.rs:51` — `use flui_semantics::{Assertiveness, SemanticsAction, SemanticsBinding}`
+- `crates/flui-app/src/bindings/renderer_binding.rs:242-256` — `set_semantics_enabled` → `SemanticsBinding::set_platform_semantics_enabled`
+- `crates/flui-app/src/bindings/renderer_binding.rs:259-263` — `announce()` → `SemanticsBinding::announce`
+- `crates/flui-app/src/bindings/renderer_binding.rs:279-281` — `semantics()` accessor
+- `crates/flui-app/src/debug/flags.rs:22,42,71,110,155,208` — `DebugFlags.show_semantics: AtomicBool`
+- `crates/flui-view/src/binding.rs:14,365-366,1128-1135` — `did_change_accessibility_features` observer + `handle_accessibility_features_changed`
+
+## Platform bridges — ZERO
+
+```
+crates/flui-platform/src/platforms/windows/    NO a11y refs (no UIA calls)
+crates/flui-platform/src/platforms/macos/      NO a11y refs (no NSAccessibility calls)
+crates/flui-platform/src/platforms/linux/      NO a11y refs (no AT-SPI calls)
+crates/flui-platform/src/platforms/android/    NO a11y refs (no TalkBack bridge)
+crates/flui-platform/src/platforms/ios/        NO a11y refs (no VoiceOver bridge)
+crates/flui-platform/src/platforms/web/        NO a11y refs (no ARIA)
+crates/flui-platform/src/traits/lifecycle.rs:4  only "lifecycle semantics" (i.e. naming, not accessibility)
+```
+
+No `windows` crate, no `atspi` crate, no `objc2-accessibility` crate, no `web_sys` for ARIA. Zero platform a11y dependencies anywhere in workspace.
+
+## Tests
+
+- 110 unit tests intra-crate (no `tests/` integration dir, no `parity/` test port of Flutter corpus)
+- Notable coverage: `tree.rs:538` (27 tests, the most), `owner.rs:407` (13 incl. `flush_when_disabled`), `role.rs:394` (13), `binding.rs:492,608` (10), `configuration.rs:1058` (9), `node.rs:328` (9 incl. `test_semantics_node_to_data`, `test_semantics_node_absorb`)
+
+## Internal docs / specs
+
+- `crates/flui-semantics/src/lib.rs:1-53` — module-level doc + 5-tree architecture diagram
+- `crates/flui-foundation/README.md:61,64,99,261` — SemanticsId
+- `docs/FOUNDATIONS.md:36,151,170,192,200` — semantics = L3, L1 architecture
+- `docs/architecture.md:24` — Layer 3 = `flui-painting, flui-layer, flui-semantics`
+- `docs/crates.md:32,40` — "flui-semantics ACTIVE: Accessibility tree"
+- `docs/ROADMAP.md:23` — semantics 7.9k Dart ~70% covered
+- `docs/ROADMAP.md:140` — references layer/semantics repair plan
+- `docs/ROADMAP-TRACKER.md:M3` — Layer/semantics repair plan in-progress
+- `docs/plans/2026-05-22-004-feat-layer-semantics-repair-plan.md` — 22 atomic commits / 7 waves
+- `docs/brainstorms/layer-semantics-repair-requirements.md`
+- `docs/research/2026-05-22-flui-layer-semantics-audit.md` — **25 findings (3 CRITICAL / 5 HIGH / 10 MEDIUM / 7 LOW)**
+- `docs/research/2026-05-22-flui-rendering-engine-audit.md:54,72,179,240-244,281-340,346-388` — 3 unimplemented!()s in semantics + 4 production-path gaps
+- `docs/research/2026-05-22-flutter-flui-gap-matrix.md:154-164` — ~65% coverage
+- `docs/STRATEGY.md:20` — 4 trees incl. Semantics
+- `AGENTS.md:33,157` — flui-semantics = "Core: accessibility (ACTIVE)" + ID offset pattern
+- `crates/flui-painting/README.md:900-927` — Semantics Integration section (doc only, no impl)
+- `crates/flui-rendering/flutter-rendering-hierarchy.md:56,89-93,218,572-573,623-624,720-895` — Flutter reference: `RenderSemantics*`, `SemanticsAnnotationsMixin`, `_RenderObjectSemantics`
+- `openspec/changes/core-0a-foundation-adversarial-reaudit/exploration.md:116` — SemanticsBinding as 5th BindingBase
+- `openspec/changes/core-0a-foundation-adversarial-reaudit/proposal.md:10,68,69,80,82,105,137,225` — Cross-cutting impact
+- `openspec/changes/core-0a-foundation-adversarial-reaudit/specs/foundation-flutter-parity/spec.md:147` — Variant "Semantics" column
+
+## Critical stubs inventory (production-path blockers)
+
+| # | File:line | Code | Impact |
+|---|---|---|---|
+| 1 | `crates/flui-rendering/src/pipeline/owner.rs:2413-2501` | `run_semantics` = `tracing::warn!` per node + clear dirty | Tree never flows to AT |
+| 2 | `crates/flui-rendering/src/binding/mod.rs:382-396` | `perform_semantics_action` = warn-stub, action no-op | AT input never reaches framework |
+| 3 | `crates/flui-rendering/src/delegates/custom_painter.rs:50-58` | `SemanticsBuilder` = inert shell with WARN_ONCE | Custom paint path can't contribute semantics |
+
+## `SemanticsConfiguration::absorb` drift vs Flutter `:6790`
+
+| Flutter behavior | flui behavior | Reference |
+|---|---|---|
+| Concat `label`/`value`/`hint` via `_concatAttributedString` | first-wins | `semantics.dart:6790` |
+| Filter `_actions` through `_kUnblockedUserActions` if `isBlockingUserActions` | not implemented | `semantics.dart:6790` |
+| Absorb `role` field | `role` field absent from `SemanticsConfiguration` | `semantics.dart:5196` |
+| Merge `headingLevel` via `_mergeHeadingLevels` | not implemented | `semantics.dart:6790` |
+
+## Symmetric / architectural gaps
+
+- `crates/flui-semantics/src/tree.rs:57` — `SemanticsTree` does NOT implement `TreeRead<SemanticsId>+TreeNav<SemanticsId>` (asymmetric vs `LayerTree` per [[flui-tree-unified-interface-intent]])
+- `crates/flui-semantics/src/node.rs:437` — `merge()` should be `absorb()` for Flutter naming consistency
+- `crates/flui-semantics/src/binding.rs:147-170` — `SemanticsBinding` has 4 `RwLock`s where `disable_animations` reads single bool; pack into `AtomicU8`
+- `crates/flui-semantics/src/owner.rs:131` — `updates_buffer` per-frame alloc (now amortized via clear+reuse; verify)
+- `crates/flui-semantics/src/tree.rs:391` — `iter_mut` zero callers outside `owner`
+- `crates/flui-semantics/src/node.rs:79` — `transform: Option<Matrix4>` now unified (post-U19); pre-U19 was `Option<[f32; 16]>`
+
+## SemanticsAction enum drift
+
+`crates/flui-semantics/src/action.rs:21-100` adds `Expand`/`Collapse`/`Unfocus` not in current Flutter — **wire-format risk** when serializing to embedder ABI.
+
+## `.flutter` symlink
+
+`C:\Users\vanya\RustroverProjects\flui\.flutter` is a **Cygwin symlink** (mtime 2026-05-24) → `C:\Users\vanya\RustroverProjects\.flutter\flutter-master\` (the actual Flutter 3.41.9 mirror, 184 MB, no git, mtime 2026-05-19). See [[2026-06-09-flutter-3-41-semantic-reference]].

--- a/docs/research/2026-06-09-flutter-3-41-semantic-reference.md
+++ b/docs/research/2026-06-09-flutter-3-41-semantic-reference.md
@@ -1,0 +1,238 @@
+# Flutter 3.41.9 Semantic / A11y — Reference Corpus (2026-06-09)
+
+Caveman file:line map of Flutter 3.41.9 in `.flutter/flutter-master/`. This is the contract source flui ports against. Companion to [[2026-06-09-flui-semantic-current-state]] (flui side) and [[2026-06-09-flui-semantic-a11y-a11y-audit]] (synthesis).
+
+## Where it lives
+
+- `C:\Users\vanya\RustroverProjects\flui\.flutter` = Cygwin symlink → `C:\Users\vanya\RustroverProjects\.flutter\flutter-master`
+- `flutter-master` = Flutter 3.41.9 master mirror, 184 MB, 15 881 files / 3 696 dirs, **no git, no .gitmodules**, mtime 2026-05-19
+- Engine hash: `ade10cafbad7dae826a7641a2cb759f8f8865f52` (per `bin/internal/flutter_packages.version`)
+- Pinned to `## Flutter 3.41 Changes` (CHANGELOG.md:33) → 3.41.9 latest
+
+## Total semantic/a11y corpus
+
+- ~202 files, ~82 213 LOC by filename
+- Dart 2 502 025 LOC total; C++/Obj-C++/Java ~720K LOC; framework+engine+embedder+tests
+
+## Framework Dart (the semantic contract)
+
+### `packages/flutter/lib/src/semantics/semantics.dart` (7 232 LOC) — the load-bearing file
+
+| Symbol | Line | Notes |
+|---|---:|---|
+| `class SemanticsTag` | :608 | |
+| `class SemanticsData with Diagnosticable` | :1048 | |
+| `class SemanticsHintOverrides extends DiagnosticableTree` | :1576 | |
+| `class SemanticsProperties extends DiagnosticableTree` | :1634 | |
+| **`class SemanticsNode with DiagnosticableTreeMixin`** | **:2773** | **definition**. 16-bit ID space (framework 0..2^16-1, engine gets upper 32 bits) |
+| `class SemanticsOwner extends ChangeNotifier` | :4842 | |
+| **`class SemanticsConfiguration`** | **:5196** | builder, flags, actions, absort, role, inputType, etc. |
+| `abstract class SemanticsSortKey` | :7004 | |
+| `class CustomSemanticsAction` | :736 | |
+
+### `SemanticsConfiguration.absorb` (THE merge contract, `semantics.dart:6790`)
+- Merges child config into parent when `!explicitChildNodes`
+- Recomputes `_actions` filtered through `_kUnblockedUserActions` if `isBlockingUserActions`
+- Merges `_flags`, attrib strings, sortKey, role, inputType, tooltip
+- Merges traversal ids
+- Merges scroll extent
+- Merges heading-level via `_mergeHeadingLevels`
+
+### `packages/flutter/lib/src/semantics/binding.dart` (279 LOC)
+- `:23` `mixin SemanticsBinding on BindingBase`
+- subscribes to `platformDispatcher.onSemanticsEnabledChanged` / `onSemanticsActionEvent` / `onAccessibilityFeaturesChanged`
+- owns `_handleSemanticsEnabledChanged`, exposes `addSemanticsEnabledListener`, `ensureSemantics`, `SemanticsHandle`
+
+### Other framework semantic files
+- `packages/flutter/lib/src/semantics/semantics_event.dart` (238 LOC) — `SemanticsEvent` + `AnnounceSemanticsEvent` + `TooltipSemanticsEvent` (the protocol sent to platform)
+- `packages/flutter/lib/src/semantics/semantics_service.dart` (104 LOC) — `SemanticsService.requestSemanticsEnabled` (legacy probe)
+- `packages/flutter/lib/src/semantics/debug.dart` (12 LOC) — `debugDisableSemantics` toggle
+- `packages/flutter/lib/semantics.dart` (24 LOC) — public re-export
+
+## Engine ui Dart (`dart:ui` surface)
+
+`engine/src/flutter/lib/ui/semantics.dart` (2 273 LOC) — the bitfield contracts.
+
+| Symbol | Line | Shape |
+|---|---:|---|
+| `class SemanticsAction` | :14 | **26 action bits** (`tap=1<<0` … `collapse=1<<25`): tap, longPress, scrollLeft/Right/Up/Down, increase, decrease, showOnScreen, moveCursorForwardByChar/BackByChar, setSelection, copy, cut, paste, didGain/LoseAccessibilityFocus, customAction, dismiss, moveCursorForwardByWord/BackByWord, setText, focus, scrollToOffset, expand, collapse. Max 1<<31 on web JS mode. |
+| **`enum SemanticsRole`** | **:361** | **32 values**: none, tab, tabBar, tabPanel, dialog, alertDialog, table, cell, row, columnHeader, dragHandle, spinButton, comboBox, menuBar, menu, menuItem, menuItemCheckbox, menuItemRadio, list, listItem, form, tooltip, loadingSpinner, progressBar, hotKey, radioGroup, status, alert, complementary, contentInfo, main, navigation, region. Trailing `region` at :555. |
+| `enum SemanticsInputType` | :561 | 6 values: none, text, url, phone, search, email. **MISSING IN flui** |
+| `class SemanticsFlag` | :588 | **31 flag bits** (`hasCheckedState=1<<0` … `isRequired=1<<30`). |
+
+## Engine C++ peers
+
+`engine/src/flutter/lib/ui/semantics/`:
+
+| File | LOC | Content |
+|---|---:|---|
+| `semantics_node.h` | 187 | `enum class SemanticsAction` (`:23`, mirrors dart 1:1) + `enum class SemanticsRole` (`:74`, 32 values) + `enum class SemanticsValidationResult` (`:116`, 3 values: None/Valid/Invalid) + `struct SemanticsNode` (`:122`) |
+| `semantics_flags.h` | — | `enum SemanticsTristate` (`:13`), `enum SemanticsCheckState` (`:18`), `struct SemanticsFlags` (`:25`), `class NativeSemanticsFlags : public RefCountedDartWrappable<…>` (`:54`) |
+| `semantics_update_builder.h/.cc` | 95+166 | `SemanticsUpdateBuilder::updateNode/applyRootNodeUpdate/...` |
+| `semantics_update.h/.cc` | 40+47 | batch wire format |
+| `string_attribute.h/.cc` | 88+59 | `StringAttribute` (LocaleStringAttribute, SpellOutStringAttribute) |
+| `custom_accessibility_action.h/.cc` | 36+13 | `CustomAccessibilityAction` peer |
+| `semantics_update_builder_unittests.cc` | 228 | Dart unit test runner surface |
+
+## Embedder ABI (C interface — the platform integration contract)
+
+`engine/src/flutter/shell/platform/embedder/embedder.h`:
+
+| Symbol | Line | Content |
+|---|---:|---|
+| `kFlutterAccessibilityFeatureDeterministicCursor = 1 << 10` | :115 | `FlutterAccessibilityFeature` enum, 10-bit feature bitmask |
+| `typedef enum { kFlutterSemanticsActionTap=1<<0 … kFlutterSemanticsActionCollapse=1<<25 }` | :122 | comment: "Must match the `SemanticsAction` enum in semantics.dart" |
+| **DEPRECATED `FlutterSemanticsFlag`** | **:189** | **31-bit enum, FROZEN** (lines 195–276) |
+| **CURRENT `FlutterSemanticsFlags` struct** | **:298** | **32 named uint32_t bit fields** + extras: `isMultiline`/`isReadOnly`/`isFocusable`/`isLink`/`isSlider`/`isKeyboardKey`/`isCheckStateMixed`/`hasExpandedState`/`isExpanded`/`hasSelectedState`/`hasRequiredState`/`isRequired` |
+| `FlutterSemanticsStringAttributes` typedef | :395 | |
+| **MIGRATION SEAM**: `FlutterSemanticsNode2` | **:1574** (`flags: FlutterSemanticsFlag`) + **:1743** (`flags2: FlutterSemanticsFlags*`) | **Dual field, old bitmask + new struct pointer** — this is the embedder pattern for the same surface in transition |
+| `kFlutterSemanticsNodeIdBatchEnd` | :1504 | batch sentinel |
+| `FlutterSemanticsNode` | :1637 | deprecated struct |
+| `FlutterSemanticsNode2` | :1753 | current |
+| `embedder_semantics_update.cc` | 426 | C++ side that calls embedder callback |
+| `embedder_a11y_unittests.cc` | 966 | embedder a11y tests |
+
+## Per-OS platform bridges
+
+| OS | File(s) | LOC |
+|---|---|---:|
+| **Android** (Java) | `engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java` + `AccessibilityStringBuilder.java` (109) + `AccessibilityViewEmbedder.java` (620) + `embedding/engine/systemchannels/AccessibilityChannel.java` (220) + `plugin/platform/AccessibilityEventsDelegate.java` (61) + `PlatformViewsAccessibilityDelegate.java` (39) | 4 441 |
+| **iOS** (Obj-C++) | `darwin/ios/.../accessibility_bridge.h` (114) + `accessibility_bridge.mm` (383) + `accessibility_bridge_ios.h` (48) + `accessibility_bridge_test.mm` (2 449) + `SemanticsObject.h` (239) + `SemanticsObject.mm` (976) + `SemanticsObject+UIFocusSystem.mm` (245) + `SemanticsObjectTest.mm` (1 420) + `FlutterSemanticsScrollView.{h,mm}` (52+123) + `TextInputSemanticsObject.{h,mm}` (23+501) | 6 573 |
+| **macOS** (Obj-C++) | `darwin/macos/.../AccessibilityBridgeMac.{h,mm}` (98+379) + `AccessibilityBridgeMacTest.mm` (319) + `FlutterTextInputSemanticsObject.{h,mm}` (106+226) + `FlutterTextInputSemanticsObjectTest.mm` (70) | 1 198 |
+| **Linux** (C++ GLib) | `linux/fl_accessibility_channel.{h,cc}` (62+194) + `fl_accessibility_handler.{h,cc}` (47+84) + `fl_accessibility_handler_test.cc` (233) | 620 |
+| **Windows** (C++) | `windows/accessibility_bridge_windows.{h,cc}` (82+212) + `accessibility_bridge_windows_unittests.cc` (406) + `accessibility_plugin.{h,cc}` (43+122) + `accessibility_plugin_unittests.cc` (156) | 1 021 |
+| **Fuchsia** (C++) | `fuchsia/flutter/accessibility_bridge.{h,cc}` (275+976) + `accessibility_bridge_unittest.cc` (1 175) | 2 426 |
+| **Common** (C++ header-only) | `shell/platform/common/accessibility_bridge.{h,cc}` (296+744) + `accessibility_bridge_unittests.cc` (639) + `test_accessibility_bridge.{h,cc}` (33+26) | 1 738 |
+| **Third-party** (Windows UIA base) | `third_party/accessibility/base/win/enum_variant.{h,cc,unittest.cc}` + `scoped_variant.{h,cc,unittest.cc}` + `variant_util.h` + `variant_vector.{h,cc,unittest.cc}` | UIA COM helpers |
+
+## Web — PR #168653 refactor (25 files, 6 537 LOC)
+
+`engine/src/flutter/lib/web_ui/lib/src/engine/semantics/` — production model for manual ARIA path.
+
+| Path | Purpose |
+|---|---|
+| `semantics.dart:632` | `abstract class SemanticRole` (per-role `apply()` to DOM) |
+| `semantics.dart:1147` | `abstract class SemanticBehavior` (cross-role `update()` to DOM) |
+| `semantics_helper.dart:69` | `abstract class SemanticsEnabler` |
+| `semantics_helper.dart:133` | `DesktopSemanticsEnabler` |
+| `semantics_helper.dart:235` | `MobileSemanticsEnabler` |
+
+### Per-role ARIAElement files (each `extends SemanticRole`)
+
+| File | Classes |
+|---|---|
+| `alert.dart` | `SemanticAlert`, `SemanticStatus` |
+| `checkable.dart` | `SemanticRadioGroup`, `SemanticCheckable` + `Checkable`/`Selectable` behaviors |
+| `disable.dart` | `CanDisable` |
+| `expandable.dart` | `Expandable` |
+| `focusable.dart` | `Focusable` |
+| `form.dart` | `SemanticForm` |
+| `header.dart` | `SemanticHeader` |
+| `heading.dart` | `SemanticHeading` |
+| `image.dart` | `SemanticImage` |
+| `incrementable.dart` | `SemanticIncrementable` |
+| `label_and_value.dart` | `LabelAndValue` (441-line behavior) |
+| `landmarks.dart` | `SemanticComplementary`, `SemanticContentInfo`, `SemanticMain`, `SemanticNavigation`, `SemanticRegion` |
+| `link.dart` | `SemanticLink` |
+| `list.dart` | `SemanticList`, `SemanticListItem` |
+| `live_region.dart` | `LiveRegion` |
+| `menus.dart` | `SemanticMenu`, `SemanticMenuBar`, `SemanticMenuItem`, `SemanticMenuItemCheckbox`, `SemanticMenuItemRadio` |
+| `platform_view.dart` | `SemanticPlatformView` |
+| `progress_bar.dart` | `SemanticsProgressBar`, `SemanticsLoadingSpinner` |
+| `requirable.dart` | `Requirable` |
+| `route.dart` | `SemanticRouteBase` → `SemanticRoute`, `SemanticDialog`, `SemanticAlertDialog` + `RouteName` behavior |
+| `scrollable.dart` | `SemanticScrollable` |
+| `table.dart` | `SemanticTable`, `SemanticCell`, `SemanticRow`, `SemanticColumnHeader` |
+| `tabs.dart` | `SemanticTab`, `SemanticTabPanel`, `SemanticTabList` |
+| `tappable.dart` | `SemanticButton` (role) + `Tappable` (behavior) |
+| `text_field.dart` | `SemanticTextField` + `SemanticsTextEditingStrategy` |
+
+### Web tests
+- `engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart` (6 537 LOC)
+- `semantics_tester.dart` (316 LOC) + 9 smaller: announcement, api, auto_enable, helper, multi_view, placeholder_enable, text, tappable, scrollable, selectable, text_field
+- Total web test corpus: ~9 300 LOC
+
+## flutter_test / flutter_driver / devicelab
+
+### Test infrastructure
+- `packages/flutter_test/lib/src/accessibility.dart` (825 LOC) — `AccessibilityGuideline` enum + `AccessibilityGuidelineViolation` + `AccessibilityController.evaluate(...)` (color contrast, tap-target size, label presence)
+- `packages/flutter_test/lib/src/controller.dart:65` — `class SemanticsController` (used by widget tests to dump/enable semantics)
+- `packages/flutter_test/lib/src/binding.dart` (3 256 LOC) — `AutomatedTestWidgetsFlutterBinding` with `_kSemanticsHandle` plumbing
+
+### flutter_test test files
+- `packages/flutter_test/test/accessibility_test.dart` (~30 KB)
+- `accessibility_window_test.dart`
+- `multi_view_accessibility_test.dart`
+- `pre_test_message_accessibility_test.dart`
+- `semantics_finder_test.dart`
+- `semantics_checker/pipeline_owner_semantics_handle_test.dart`
+- `semantics_checker/semantics_binding_semantics_handle_test.dart`
+- `test_fixes/.../semantics_controller.{dart,dart.expect}`
+- `fix_data/.../fix_semantics_controller.yaml`
+
+### packages/flutter/test/semantics/ (8 files)
+- `custom_semantics_action.dart`
+- `semantics_binding_set_semantics_tree_enabled.dart`
+- `semantics_binding_set_semantics_tree_enabled_1.dart`
+- `semantics_binding.dart`
+- `semantics_node_send_event.dart`
+- `semantics_owner.dart`
+- `semantics_service.dart`
+- `semantics_test.dart`
+- `semantics_update.dart`
+
+### packages/flutter/test/widgets/semantics_*.dart (~30 files)
+- `semantics_1..11_split_test.dart` (config absorb scenarios)
+- `semantics_checks.dart`
+- `semantics_child_configs_delegate.dart`
+- `semantics_clipping.dart`
+- `semantics_debugger.dart`
+- `semantics_event.dart`
+- `semantics_keep_alive_offstage.dart`
+- `semantics_merge.dart`
+- `semantics_refactor_regression.dart`
+- `semantics_role_checks.dart`
+- `semantics_tester.dart`
+- `semantics_tester_generate_test_semantics_expression.dart`
+- `semantics_traversal.dart`
+- `semantics_zero_surface_size.dart`
+- `scrollable_semantics.dart`
+- `scrollable_semantics_traversal_order.dart`
+- `sliver_semantics.dart`
+- `sliver_semantics_widget.dart`
+- `text_semantics.dart`
+- `gesture_detector_semantics.dart`
+- `implicit_semantics.dart`
+- `list_view_semantics.dart`
+- `accessibility_evaluations.dart`
+- `accessibility_evaluations_service_extension.dart`
+
+### dev/ — a11y test infra
+- `packages/flutter_driver/lib/src/common/semantics.dart` (46 LOC) — driver-side `SemanticsClient`
+- `dev/devicelab/lib/framework/talkback.dart` (82 LOC) — Android TalkBack test harness
+- `dev/integration_tests/android_semantics_testing/{lib,test}/` — semantic trees-on-device probe library
+- `dev/benchmarks/complex_layout/test_driver/semantics_perf/` — perf bench
+- `dev/benchmarks/macrobenchmarks/lib/src/web/bench_material_3_semantics.dart` — web a11y perf
+- `dev/devicelab/bin/tasks/{android_semantics_integration_test,complex_layout_semantics_perf,flutter_gallery__transition_perf_with_semantics}.dart`
+- `dev/a11y_assessments/test/accessibility_guideline_test.dart` — gallery-driven a11y audit
+- `dev/integration_tests/flutter_gallery/test/accessibility_test.dart` + `test_driver/transitions_perf_e2e_with_semantics.dart`
+
+## Docs (sparse on architecture)
+
+- `docs/platforms/desktop/windows/Accessibility-on-Windows.md` — Windows UIA integration doc
+- `docs/contributing/Contributor-access.md` — ACL for a11y
+- `dev/a11y_assessments/` — internal widget-by-widget a11y audits (concentrated, not architecture)
+- **NO `docs/semantics/*` index, NO top-level a11y architecture doc**
+
+## Version-specific notes (3.41)
+
+- ARIA refactor PR #168653 (May 2025) → in 3.27+ stable, fully landed by 3.41
+- 3.36 deprecated `focusable` in favor of `focused` (input focus vs accessibility focus)
+- 32-value `SemanticsRole` enum is stable since 3.27
+- Embedder migration seam (`flags` deprecated + `flags2` struct) is the current pattern
+
+## Known open issues (transcribed from research)
+
+- Flutter web iOS WebKit regression #179784 (Dec 2025, still open) — `ensureSemantics()` + `ListView.builder` 100×`SizedBox` causes severe scroll lag on iOS Safari; Android Chrome/Desktop unaffected
+- Android WebView delay #175465 (Sept 2025) — Android WebView doesn't propagate AT state until first user interaction
+- Web perf issue #150234 (Jun 2024 → Feb 2025) — fixed by PR #161195 from 2.6ms in 6ms frame → 0.3ms in 4ms frame (~5x)

--- a/docs/research/2026-06-09-flutter-3-41-semantic-reference.md
+++ b/docs/research/2026-06-09-flutter-3-41-semantic-reference.md
@@ -1,6 +1,6 @@
 # Flutter 3.41.9 Semantic / A11y — Reference Corpus (2026-06-09)
 
-Caveman file:line map of Flutter 3.41.9 in `.flutter/flutter-master/`. This is the contract source flui ports against. Companion to [[2026-06-09-flui-semantic-current-state]] (flui side) and [[2026-06-09-flui-semantic-a11y-a11y-audit]] (synthesis).
+Caveman file:line map of Flutter 3.41.9 in `.flutter/flutter-master/`. This is the contract source flui ports against. Companion to [[2026-06-09-flui-semantic-current-state]] (flui side) and [[2026-06-09-flui-semantic-a11y-audit]] (synthesis).
 
 ## Where it lives
 

--- a/docs/research/2026-06-09-flutter-3-41-semantic-reference.md
+++ b/docs/research/2026-06-09-flutter-3-41-semantic-reference.md
@@ -26,7 +26,7 @@ Caveman file:line map of Flutter 3.41.9 in `.flutter/flutter-master/`. This is t
 | `class SemanticsProperties extends DiagnosticableTree` | :1634 | |
 | **`class SemanticsNode with DiagnosticableTreeMixin`** | **:2773** | **definition**. 16-bit ID space (framework 0..2^16-1, engine gets upper 32 bits) |
 | `class SemanticsOwner extends ChangeNotifier` | :4842 | |
-| **`class SemanticsConfiguration`** | **:5196** | builder, flags, actions, absort, role, inputType, etc. |
+| **`class SemanticsConfiguration`** | **:5196** | builder, flags, actions, absorb, role, inputType, etc. |
 | `abstract class SemanticsSortKey` | :7004 | |
 | `class CustomSemanticsAction` | :736 | |
 

--- a/docs/research/2026-06-09-rust-a11y-ecosystem.md
+++ b/docs/research/2026-06-09-rust-a11y-ecosystem.md
@@ -1,0 +1,217 @@
+# Rust A11y Ecosystem + Competitor Framework Matrix (2026-06-09)
+
+Caveman research-mode synthesis. Companion to [[2026-06-09-flui-semantic-current-state]] (flui side) and [[2026-06-09-flutter-3-41-semantic-reference]] (Flutter reference). Triggers: which Rust crates to use for flui's platform bridges + how the competitor Rust UI frameworks handle a11y in mid-2026.
+
+## Bottom line
+
+**Industry standard IR = AccessKit** (Linebender / Matt Campbell + Arnold Loubriat). 19M lifetime downloads. Schema based on Chromium a11y, **push `TreeUpdate` model**, stable `NodeId`. Used in production by **Slint** (merged 2023), **egui** (via accesskit_winit path), **plushie-iced** (vendored fork, v0.8.4 May 2026), **Servo servoshell** (merged Jun 2025, web content a11y tree Apr 2026). Recommended path for flui.
+
+**Web adapter does NOT exist** in AccessKit (planned). For flui-wasm target: manual `web-sys` ARIA, model = Flutter Web PR #168653 (`SemanticRole` per-role + `SemanticBehavior` cross-cutting).
+
+## 1. AccessKit ecosystem (the standard)
+
+Repo: <https://github.com/AccessKit/accesskit>. Workspace. MIT OR Apache-2.0 (BSD-3-Clause для chromium-derived частей). MSRV 1.85 на всех crates с мая 2026 (edition 2024 prep per v0.33.0 changelog).
+
+**Architecture**: provider (app/toolkit) pushes `TreeUpdate` → consumer (adapter) holds the tree, diffs, translates to platform API. Only the adapter holds the full tree in memory → suitable for immediate-mode GUI.
+
+| Crate | Ver (2026-06) | Platform | Role | Downloads (lifetime) | Maintained | MSRV |
+|---|---|---|---|---:|---|---|
+| `accesskit` | 0.24.0 (2026-02-01) | cross | core: schema `Tree`/`Node`/`Role`/`TreeUpdate`/affine, provider-side | 19M | YES (active) | 1.85 |
+| `accesskit_consumer` | 0.36.0 | cross | platform-agnostic consumer: `Tree`+`ChangeHandler`+`common_filter` (hashbrown only, no OS deps) | 11.8M | YES | 1.85 |
+| `accesskit_winit` | 0.33.0 (2026-05-11) | cross | auto-select adapter под winit, default: `accesskit_unix+async-io+rwh_06+winit/{x11,wayland}` | 13.7M | YES | 1.85 |
+| `accesskit_windows` | 0.33.0 | Windows | UI Automation (UIA), MSAA legacy НЕ support, native UIA tree | 8.5M | YES | 1.85 |
+| `accesskit_macos` | 0.26.1 | macOS | NSAccessibility (AppKit) | 8.2M | YES | 1.85 |
+| `accesskit_unix` | 0.21.1 | Linux/BSD | AT-SPI2 через `zbus` | 8.2M | YES | 1.85 |
+| `accesskit_android` | 0.7.3 | Android | Java-based Android accessibility API (JNI) | (young) | YES (active hardening) | 1.85 |
+| `accesskit_ios` | 0.1.0 | iOS | UIAccessibility (UIKit), initial release | — | YES (initial, May 2026) | 1.85 |
+| `accesskit-c` | bundled | cross | FFI, cbindgen, есть Win32 + SDL пример | — | YES | 1.85 |
+| `accesskit` (Python) | bundled | cross | PyO3 bindings, Pygame пример | — | YES | n/a |
+| **web-adapter** | **—** | **—** | **PLANNED, не released** | — | — | — |
+
+**8 releases** с 2026-01-03 по 2026-05-11.
+
+**Gaps**:
+- Web-adapter (canvas-rendered UIs → ARIA) — planned, not shipped
+- Rich text + hypertext support — not yet
+
+Source: <https://github.com/AccessKit/accesskit/releases>, <https://docs.rs/crate/accesskit_consumer/latest>
+
+## 2. `atspi` ecosystem (odilia-app)
+
+Repo: <https://github.com/odilia-app/atspi>. License: Apache-2.0 OR MIT. MSRV 1.77.2. Pure-Rust, async, `#![deny(unsafe_code)]`, `#![deny(clippy::all, clippy::pedantic)]`, **type-validation против AT-SPI2 spec через `zbus-lockstep`**.
+
+| Crate | Ver (2026-06) | Role |
+|---|---|---|
+| `atspi` (meta) | 0.30.0 (2026-05-06) | re-exports; default = `proxies+connection+p2p+wrappers` |
+| `atspi-common` | 0.14.0 | types: `Event`, `State`, `Role` enums |
+| `atspi-connection` | 0.14.0 | `AccessibilityConnection` — receive-side event stream, `p2p` feature = peer-to-peer (bus bypass) |
+| `atspi-proxies` | 0.14.0 | auto-generated D-Bus proxies (zbus) для query/send |
+
+**Features**: `proxies`, `connection`, `p2p`, `wrappers` (categorized `Event` enum + `event_stream`), `tokio` (zbus/tokio), `tracing`. Async runtime: tokio/smol/async-std; НЕ glomio.
+
+**Use case для flui**: НЕ адаптер, это **client-side** binding (для screen reader'а, типа Odilia). Если flui = provider — используй `accesskit_unix` (он уже зовёт `atspi` под капотом).
+
+Downloads: `atspi` 8.6M, `atspi-proxies`/`atspi-common` 7.8M, `atspi-connection` 7.2M.
+
+## 3. Windows UIA
+
+**Нет отдельного mature UIA-only crate для приложений.** Доступные варианты:
+- `windows` crate (microsoft/windows-rs) — Windows API bindings, содержит UIA COM interfaces. Comprehensive, official. Используется `accesskit_windows` под капотом.
+- `uiautomation` crate (VivoM/pythonista) — high-level UIA wrapper (community).
+- `accesskit_windows` — recommended path.
+
+**MSAA (legacy)**: deprecated с Windows 7. UIA полностью его заменяет. Не нужно поддерживать отдельно.
+
+## 4. macOS NSAccessibility
+
+- `accesskit_macos` 0.26.1 — recommended.
+- Альтернатива (если AccessKit schema не подходит): `accessibility` 0.2.0 + `accessibility-sys` 0.2.0 (eiz) — direct NSAccessibility bindings, MIT/Apache-2.0. Сырые FFI, 42.9K downloads. **Stagnant** (last update 2025-03). Подходит если хочешь свой адаптер.
+- `core-foundation` 0.10.1 (servo) + `cocoa` 0.26.1 (servo) — 322M / 25M downloads. Используются `accesskit_macos` под капотом.
+
+## 5. Web (wasm-bindgen) — ARIA
+
+`accesskit-c` exists, but **web-adapter not released**. Варианты:
+- `web-sys` 0.3.x + `wasm-bindgen` 0.2.x + ARIA attributes напрямую через DOM (`Element.set_attribute("aria-label", ...)` и т.п.). Low-level, без tree management.
+- `accessibility-rs` 0.1.7 (a11ywatch/j-mendez) — runtime **WCAG audit engine** для HTML (markup5ever+taffy+selectors+spider). 99.5K downloads. **Не** provider-side accessibility tree, а static/dynamic auditor. MIT/Apache-2.0. Полезен для CI gate.
+- `rsx-a11y` 0.x (CHildebrandt, 2026-02) — clippy-style lint для ARIA в `view!`/`rsx!`/`html!` макросах (Yew/Leptos/Dioxus), 36 правил WAI-ARIA 1.2. License MIT. **Не** provider tree, static analysis на source.
+
+**Web adapter status (2026)**: ждать. Для flui-wasm target реальный путь = manual ARIA через `web-sys` (как Flutter web engine сейчас и делает через canvas+`SemanticsNode.toAria()`).
+
+## 6. Orca / AT client tools (testing harness)
+
+| OS | Tool | Notes |
+|---|---|---|
+| **Linux** | `accerciser` (GNOME a11y explorer, GTK3), `atspi-inspect` (CLI) | Orca — consumer, не devtool |
+| **Windows** | **Accessibility Insights** (MS, recommended), `Inspect.exe` (Win SDK), `UI Automation Verify` (UIAVerify) | Все читают UIA tree. AccProbe — Adobe legacy, 2014, НЕ рекомендуется |
+| **macOS** | **Xcode Accessibility Inspector** (Xcode → Open Developer Tool) | Читает NSAccessibility tree |
+| **Web** | Chrome DevTools → Elements → Accessibility pane, **Axe DevTools** (Deque), Lighthouse | |
+| **Cross-platform Rust** | `a11y-rust-gui-inspector` (nicolegordon, 2025-Q1) | proof-of-concept, `accesskit_consumer::Tree`. Toy state. |
+
+## 7. UI framework integrations — competitor matrix
+
+| Framework | Status | PR/Issue | Source |
+|---|---|---|---|
+| **Slint** | MERGED (winit backend), tested Windows Narrator + macOS VoiceOver | PR #2865 (2023-06), PR #3833 (2023-11) | github.com/slint-ui/slint |
+| **Iced** | Draft PR #1849 open с 2023-05; System76/COSMIC fork (pop-os/iced) carries работающий a11y; milestone 0.15 | PR #1849, Issue #552 (34 👍) | github.com/iced-rs/iced |
+| **Druid** | PAUSED. Matt Campbell's `accesskit` branch existed (Windows-only, no text editing), work stopped because maintainers moved to Xilem. | Issue #2088 (2021) | github.com/linebender/druid |
+| **Xilem** | Planned via glazier layer. No merged PR as of 2026-06. | — | github.com/linebender/glazier |
+| **Tauri** | Winit-based → `accesskit_winit` auto-wire possible; не документировано в Tauri core. Community a11y tracking via webview (Chromium) — основной путь a11y для Tauri. | — | — |
+| **egui** | Indirect: `egui-winit` → `accesskit_winit`. Per `accesskit_winit` changelog был bugfix "reduce winit version requirement to match egui". Not first-class. | — | — |
+| **Egui / Masonry** | Masonry (Druid-precursor Xilem widget layer) — `accesskit` branch существует, не merged. | — | — |
+
+**Вывод**: **Slint = единственный production Rust UI framework с merged+tested accesskit**. COSMIC (System76 pop-os iced fork) = production usage через свой fork, не mainline. Plus **plushie-iced** (vendored fork v0.8.4) is the closest second.
+
+## 8. Framework × platform × a11y-depth comparison table
+
+| Framework | iOS | Android | Web | Windows (UIA) | macOS (NSA) | Linux (AT-SPI) | Notes |
+|---|---|---|---|---|---|---|---|
+| **Flutter** | VoiceOver full | TalkBack full | ARIA opt-in (perf) | UIA full | VoiceOver full | Orca full (AT-SPI2) | Engine owns tree; embedder bridges. iOS WebKit perf regression #179784 still open. |
+| **Druid** | n/a | n/a | n/a | PoC branch only | n/a | n/a | Maintenance mode, focus → Xilem. |
+| **Xilem** | alpha (a11y basic) | alpha | web backend only | alpha (via Masonry+AccessKit) | alpha | alpha | Alpha, MSRV 1.92, AccessKit v0.32.x. |
+| **egui** | limited | limited | limited | AccessKit (stable path) | AccessKit | AccessKit | Recommended real-world Rust a11y path; default in 2026 trajectory. |
+| **iced (upstream)** | none | none | none | blocked (winit fork conflict) | blocked | PR #3281 closed Mar 26 | maintainer working on it. |
+| **plushie-iced (fork)** | none | none | none | full | full | full (AT-SPI2) | Vendored fork v0.8.4; production-ready a11y. |
+| **Slint** | basic (accesskit_ios v0.1.0) | basic (accesskit_android v0.7.3) | canvas (no AccessKit web yet) | UIA (Narrator/NVDA) | NSA (VoiceOver) | Orca (AT-SPI) merged 2023+ | `accessible-*` properties, AccessKit stable. |
+| **Makepad** | none | none | none | none | none | none | Backbone in system, no screen-reader bridge. |
+| **Dioxus** | WebView a11y (promise) | WebView a11y | ARIA (web) | WebView a11y (Chromium) | WebView a11y (WKWebView) | WebView a11y (WebKitGTK) | No native layer shipped на 2026. |
+| **Tauri** | WKWebView a11y | Android WebView a11y | WebView2/WebKit a11y (native) | WebView2 + #12901 NVDA bug (frameless) | WKWebView | WebKitGTK | Inherits webview a11y; Tauri-specific overlay bugs. |
+| **Servo (servoshell)** | n/a | n/a | WIP (PR #42338 merged Apr 26) | AccessKit (servoshell UI only) | AccessKit (servoshell UI only) | AccessKit+ORCA confirmed working | Web content a11y tree landing 2026. |
+| **Qt (reference)** | UIAccessibilityTraits | TalkBack | Qt WebEngine/Chromium | UIA full | NSA full | AT-SPI full (D-Bus) | Reference impl; QAccessible 3-layer. |
+| **GTK (reference)** | n/a | n/a | n/a | n/a | n/a | AT-SPI2 full | Reference impl; ATK → at-spi2-atk → D-Bus. |
+
+## 9. zbus vs atspi для AT-SPI2
+
+- `zbus` 5.x — general D-Bus binding, sync+async, code-gen из introspection XML. Not a11y-specific.
+- `atspi` = **typed** AT-SPI2 wrapper поверх zbus. `atspi-lockstep` валидирует types против spec. Pure async (tokio/smol/async-std). Правильный выбор для a11y client.
+- Если provider = `accesskit_unix` — zbus transitive dep, but flui не пишет D-Bus напрямую, `accesskit_unix` это делает.
+
+## 10. Bin size impact (wasm)
+
+Точных цифр не публиковали. Rough estimates (по dep tree):
+- `accesskit` core + `accesskit_consumer` ≈ 50-80 KB wasm (через wasm-bindgen, stripped)
+- `accesskit_winit` подтягивает winit (X11/wayland бэкенды) → ~500KB+ на wasm = **НЕПРИГОДНО** для wasm target. Нужен условный cfg: `accesskit` core only, адаптеры platform-specific.
+- `atspi` подтягивает zbus + tokio → **НЕ** для wasm. Только на native Linux build.
+- `web-sys` (для ARIA) = самый дешёвый путь для wasm: 0 extra bytes runtime, ARIA = string attributes на DOM.
+
+## 11. Web a11y path — Flutter PR #168653 as model
+
+Flutter Web's `engine/src/flutter/lib/web_ui/lib/src/engine/semantics/` is the production model for canvas-rendered → ARIA. Architecture:
+- `abstract class SemanticRole` — per-role DOM `apply()`
+- `abstract class SemanticBehavior` — cross-cutting DOM `update()` (`Focusable`/`Tappable`/`LabelAndValue`/`Expandable`/`LiveRegion`/`Requirable`/`CanDisable`/`RouteName`/`Checkable`/`Selectable`)
+- `SemanticsEnabler` (`:69`) → `DesktopSemanticsEnabler` (`:133`) / `MobileSemanticsEnabler` (`:235`)
+
+**Rules to follow** (from PR #168653, applied to Rust):
+- `label` = short name → `aria-label`
+- `description` = long description (hint/tooltip) → `aria-description` (with `aria-describedby` fallback через hidden span)
+- `value` = current value (slider/progress) → `aria-valuenow` (numeric) или `aria-valuetext` (text), only for non-incrementable
+- **DO NOT** concatenate everything into a single `aria-label`
+- Use `aria-live` `polite`/`assertive` host elements for live announcements
+- `liveMessageDuration=300ms` workaround for VoiceOver trailing ` ` bug
+
+**Architecture port** (Rust):
+- `enum SemanticRole { Button, Tab, TabList, TabPanel, ... }` (32 values, mirror Flutter)
+- `trait SemanticBehavior { fn apply(&self, node: &SemanticsNode, dom: &Dom) -> Result<()>; }`
+- `impl SemanticRole for ButtonRole { fn apply() { /* emit <button> + aria-* attrs */ } }`
+- Behaviors composed: `Button + Tappable + LabelAndValue + Focusable + CanDisable`
+
+## 12. Recommendation matrix for flui
+
+| Target | Primary path | Backup |
+|---|---|---|
+| **Windows** (native) | `accesskit_winit` → `accesskit_windows` (UIA) | direct `windows` crate UIA COM |
+| **macOS** (native) | `accesskit_winit` → `accesskit_macos` (NSAccessibility) | `accessibility` 0.2.0 (eiz, stagnant) |
+| **Linux/X11** (native) | `accesskit_winit` → `accesskit_unix` (AT-SPI2 zbus) | direct `atspi` 0.30 (provider-side, but type validation benefits) |
+| **Linux/Wayland** | `accesskit_winit` → `accesskit_unix` (same) | — |
+| **Android** | `accesskit_android` 0.7.3 (young, active) | wait or `accesskit_winit` doesn't apply (no winit on Android) |
+| **iOS** | **WAIT** — `accesskit_ios` 0.1.0 initial, May 2026 | direct `accessibility` 0.2.0 eiz (stagnant) |
+| **Web/WASM** | `web-sys` + ARIA (model: Flutter PR #168653) | wait AccessKit web-adapter |
+| **Embedded** | none — `accesskit_winit` brings winit dead weight | none |
+
+**Single dep recipe (native cross-platform)**:
+```toml
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+accesskit = "0.24"
+accesskit_consumer = "0.36"
+accesskit_winit = "0.33"  # auto-selects accesskit_<platform> per OS
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-sys = "0.3"
+wasm-bindgen = "0.2"
+```
+
+## 13. Open PRs reference (potentially useful for flui PR-planning)
+
+- egui AccessKit (PR #2294)
+- Slint initial AccessKit (PR #2865)
+- Servo servoshell (PR #37519, merged Jun 2025)
+- Servo web contents tree (PR #42338, merged Apr 2026)
+- Dioxus `inert` (PR #5476, merged Apr 2026)
+- Flutter ARIA refactor (PR #168653, May 2025)
+- iced AccessKit (PR #3281, closed Mar 2026, maintainer working on it)
+
+## 14. Caveats
+
+- **Rich text + hypertext НЕ поддержан** в AccessKit adapters. Flutter `SemanticsNode.textDirection` + `Link` semantics node → НЕ map-ится чисто. Workaround: mark as text range with hyperlink action.
+- **MSRV 1.85** жёсткий (2025-02 release). Если flui MSRV < 1.85 — pin на `accesskit 0.21.x` (последний pre-edition-2024). Currently flui workspace MSRV must be checked before dep bump.
+- **`accesskit_ios` 0.1.0** — initial, API может поменяться. Avoid как primary path пока не 0.5+.
+- **`accesskit_android` 0.7.3** — young, active hardening. Selected state, range info, URL property, scrolling fixes Feb 2026.
+- **MSAA legacy** (pre-Windows 7) — deprecated. UIA replaces entirely. Don't support.
+- **Test harness**: `accesskit_consumer::Tree` lets flui write unit tests for tree diffing without OS dep. Pair with `accerciser`/`Accessibility Insights` for end-to-end smoke.
+
+## Sources
+
+- [AccessKit GitHub](https://github.com/AccessKit/accesskit)
+- [accesskit_winit v0.32.2 release](https://github.com/AccessKit/accesskit/releases/tag/accesskit_winit-v0.32.2)
+- [accesskit_consumer docs.rs](https://docs.rs/crate/accesskit_consumer/latest)
+- [odilia-app/atspi](https://github.com/odilia-app/atspi)
+- [atspi 0.30.0](https://crates.io/crates/atspi)
+- [Slint #2865 Initial AccessKit support](https://github.com/slint-ui/slint/pull/2865)
+- [Slint #3833](https://github.com/slint-ui/slint/pull/3833)
+- [Iced #1849](https://github.com/iced-rs/iced/pull/1849)
+- [Druid #2088](https://github.com/linebender/druid/issues/2088)
+- [plushie-iced](https://crates.io/crates/plushie-iced)
+- [accessibility-rs](https://crates.io/crates/accessibility-rs)
+- [rsx-a11y](https://docs.rs/rsx-a11y/latest/rsx_a11y/)
+- [a11y-rust-gui-inspector](https://github.com/nicolegordon/a11y-rust-gui-inspector)
+- [DeepWiki AccessKit](https://deepwiki.com/AccessKit/accesskit)
+- [Qt QAccessible](https://doc.qt.io/qt-6/accessible.html)


### PR DESCRIPTION
## Summary

Four-file semantic / accessibility research synthesis grounded in the
`\.flutter/flutter-master` Flutter 3.41.9 mirror and the mid-2026 Rust
a11y ecosystem snapshot.

## What's in

| File | Purpose |
|---|---|
| `2026-06-09-flui-semantic-a11y-audit.md` | Synthesis: top-10 actions, hidden gaps, competitor position, risks |
| `2026-06-09-flui-semantic-current-state.md` | file:line map of `flui-semantics` (6,625 LOC, 110 tests) + 3 warn-stubs + Cargo zombie |
| `2026-06-09-flutter-3-41-semantic-reference.md` | Full Flutter 3.41.9 contract (Dart + engine C++ + embedder ABI + 5 platform bridges + Web PR #168653 + test corpus) |
| `2026-06-09-rust-a11y-ecosystem.md` | AccessKit 0.24/0.33 ecosystem + atspi 0.30 + competitor matrix + web path model |

## Key findings

1. `flui-semantics` ~65% Flutter-port on the data side; 3 production-path `tracing::warn!` stubs block end-to-end
   - `run_semantics` at `pipeline/owner.rs:2413-2501`
   - `perform_semantics_action` at `binding/mod.rs:382-396`
   - `SemanticsBuilder` at `delegates/custom_painter.rs:50-58`
2. **Zero platform bridges**; `accesskit = "0.21"` declared in `flui-semantics/Cargo.toml:39` but zero source-file refs (dead dep)
3. `SemanticsConfiguration::absorb` has 4 drift-points vs Flutter `semantics.dart:6790` (concat label/value/hint, `isBlockingUserActions` filter, role absorption, heading-level merge)
4. `SemanticsTree` does NOT implement `TreeRead<SemanticsId>+TreeNav<SemanticsId>` (asymmetric vs `LayerTree`)
5. Missing types from `engine/src/flutter/lib/ui/semantics.dart`: `SemanticsInputType` (6 values), `SemanticsValidationResult` (3 values)

## Recommended path (top-3)

1. Wire the 3 warn-stubs (one PR, ~3-5 commits)
2. Port `SemanticsConfiguration::absorb` from Flutter `semantics.dart:6790` (one PR, 1-2 commits)
3. Add `accesskit` 0.24 + `accesskit_consumer` 0.36 + `accesskit_winit` 0.33 as `flui-semantics` deps; `SemanticsNode` → `accesskit::Node` mapping; `UpdateSemantics` + `DispatchSemanticsAction` callbacks (one PR per platform)

Web path stays manual `web-sys` ARIA, model = Flutter Web PR #168653 (`SemanticRole` per-role + `SemanticBehavior` cross-cutting, split `aria-label`/`aria-description`/`aria-valuenow`).

## Test plan

- [x] Pure documentation, no code change
- [x] No new deps
- [x] No behavior change
- [x] No markers, ports, or doc gates affected
- [x] No `cargo check`/`cargo test` required

## Out of scope

- Code changes (separate PR chain)
- `accesskit` dep bump (MSRV 1.85 — needs workspace MSRV check first)
- `SemanticsInputType`/`SemanticsValidationResult` additions
- Per-platform bridge implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)