### PR TITLE
fix(animation+interaction): post-merge audit — deadlocks, dead listeners, pinch routing, curve catalog

### DIFF
--- a/crates/flui-animation/CHANGELOG.md
+++ b/crates/flui-animation/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to `flui-animation` are documented here.
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning: per `docs/release.md` policy.
+
+## [Unreleased]
+
+### Added
+
+- `smoothing` module — frame-rate-independent followers Flutter does not ship:
+  `exp_decay` / `exp_decay_half_life` / `Smoothed` (Holmér exponential decay,
+  half-life parameterization) and `SmoothDamp` (critically damped spring
+  approximation with max-speed clamp and overshoot guard, Game Programming
+  Gems 4 ch. 1.10).
+- `OklabColorTween` — perceptually uniform color interpolation through Oklab
+  (Björn Ottosson 2020). Flutter's `Color.lerp` averages gamma-encoded sRGB
+  channels, so cross-hue transitions pass through dark gray midpoints.
+  Backed by `Color::to_oklab` / `from_oklab` / `lerp_oklab` in `flui-types`.
+- Curve catalog parity + extensions: the full Penner cubic set (`Ease`,
+  `EaseIn/Out/InOut{Quad,Cubic,Quart,Quint}`, `FastLinearToSlowEaseIn`,
+  `LinearToEaseOut`, `EaseInToLinear`, `SlowMiddle`), `ThreePointCubic` with
+  the Material 3 `EaseInOutCubicEmphasized` and `FastEaseInToSlowEaseOut`
+  constants, and the `Split` curve (track-finger-then-fling transitions).
+
+### Changed
+
+- `AnimationController::is_animating()` is now ticker-based (Flutter parity:
+  `AnimationController` overrides `isAnimating` with `ticker.isActive`).
+  Previously a stopped controller positioned at an interior value reported
+  itself as animating.
+- `TweenSequence::transform` documents its clamping semantics (saturates
+  overshoot, unlike plain `Tween` extrapolation).
+
+### Fixed
+
+- `TweenAnimation` never subscribed to its parent, so listeners on any tween
+  combinator silently never fired (`AnimatedBuilder`-class breakage).
+- `ProxyAnimation` status listeners were orphaned on the old parent after
+  `set_parent` and removal targeted the wrong parent; the proxy now owns its
+  status registry behind a migrating forwarder and fires on swap only when
+  the status actually changes.
+- `AnimationSwitch` (train-hop) left stale listener ids after a switch and
+  `dispose()` cleaned the wrong animation; listeners (value and status) are
+  rebound on every hop, and public status listeners are switch-owned with
+  stable ids.
+- `CurvedAnimation` locks the active curve to the run-entry direction
+  (Flutter `_curveDirection`), so `reverse()` mid-run no longer swaps curves
+  underneath the value; the capture is gated on a live run so a stopped
+  controller's interior `set_value` cannot pin the direction.
+- NaN canonicalization: Rust's `clamp` propagates NaN through the cubic
+  solver and the controller value; canonicalized at `Cubic` /
+  `ThreePointCubic` / `Split::transform` and `AnimationController::set_value`
+  (warn + lower bound).
+- `FrictionSimulation::through` rejects the zero-travel degenerate case with
+  the physical constraint instead of an opaque downstream drag panic.
+- `ThreePointCubic::new` asserts the midpoint lies strictly inside the unit
+  square (divisor safety); `const` constructions turn violations into
+  compile errors.

--- a/crates/flui-animation/README.md
+++ b/crates/flui-animation/README.md
@@ -534,3 +534,20 @@ Constructors validate parameters and panic on invalid input:
 | `TweenSequenceItem::new` | weight ≤ 0, weight is infinite |
 | `Interval::new` | begin/end outside [0,1], end < begin |
 | `Threshold::new` | threshold outside [0,1] |
+
+---
+
+## Beyond Flutter
+
+Capabilities this crate ships that Flutter's animation library does not, each
+implemented from the canonical published source:
+
+| Capability | Source | API |
+|---|---|---|
+| Frame-rate-independent smoothing (half-life exponential decay) | Holmér, "lerp smoothing is broken" | `smoothing::exp_decay`, `Smoothed` |
+| Critically damped follower with max-speed clamp | Unity `SmoothDamp` / Game Programming Gems 4 ch. 1.10 | `smoothing::SmoothDamp` |
+| Perceptually uniform color interpolation | Ottosson, Oklab (2020) | `OklabColorTween`, `Color::lerp_oklab` |
+| M3 emphasized easing + full Penner catalog | Material 3 / Penner | `Curves::EaseInOutCubicEmphasized`, `ThreePointCubic`, `Split` |
+| Interruptible springs with velocity-preserving retarget | analytic closed forms | `AnimatedValue`, `#[derive(Animatable)]` |
+
+See `examples/smoothing_follow.rs` and `examples/oklab_gradient.rs`.

--- a/crates/flui-animation/benches/animation_bench.rs
+++ b/crates/flui-animation/benches/animation_bench.rs
@@ -15,9 +15,10 @@ use std::time::Duration;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
+use flui_animation::smoothing::{SmoothDamp, exp_decay_half_life};
 use flui_animation::{
     Animatable, AnimatedValue, Animation, AnimationController, ColorTween, Curve, CurvedAnimation,
-    Curves, FloatTween, Simulation, SpringDescription, SpringSimulation, Tween,
+    Curves, FloatTween, OklabColorTween, Simulation, SpringDescription, SpringSimulation, Tween,
 };
 use flui_scheduler::Scheduler;
 use flui_types::geometry::{Offset, px};
@@ -34,6 +35,13 @@ fn tween_transform(c: &mut Criterion) {
     let col = ColorTween::new(Color::rgba(0, 0, 0, 255), Color::rgba(255, 128, 0, 255));
     group.bench_function("color", |b| {
         b.iter(|| black_box(col.transform(black_box(0.37))));
+    });
+
+    // Perceptual color path: prices the two Oklab conversions (powf/cbrt per
+    // channel) against the componentwise sRGB lerp above.
+    let oklab = OklabColorTween::new(Color::rgba(0, 0, 255, 255), Color::rgba(255, 255, 0, 255));
+    group.bench_function("color_oklab", |b| {
+        b.iter(|| black_box(oklab.transform(black_box(0.37))));
     });
 
     let off = Tween::new(
@@ -58,6 +66,36 @@ fn curve_eval(c: &mut Criterion) {
     });
     group.bench_function("elastic_out", |b| {
         b.iter(|| black_box(Curves::ElasticOut.transform(black_box(0.37))));
+    });
+    // Two cubic segments + rescale arithmetic: the M3 emphasized default.
+    group.bench_function("three_point_cubic_emphasized", |b| {
+        b.iter(|| black_box(Curves::EaseInOutCubicEmphasized.transform(black_box(0.37))));
+    });
+
+    group.finish();
+}
+
+fn smoothing_step(c: &mut Criterion) {
+    let mut group = c.benchmark_group("smoothing");
+
+    group.bench_function("exp_decay_half_life", |b| {
+        b.iter(|| {
+            black_box(exp_decay_half_life(
+                black_box(10.0),
+                black_box(100.0),
+                black_box(0.25),
+                black_box(1.0 / 120.0),
+            ))
+        });
+    });
+
+    let mut damp = SmoothDamp::new(0.2);
+    let mut pos = 0.0_f32;
+    group.bench_function("smooth_damp_step", |b| {
+        b.iter(|| {
+            pos = damp.step(black_box(pos), black_box(100.0), black_box(1.0 / 120.0));
+            black_box(pos)
+        });
     });
 
     group.finish();
@@ -121,6 +159,7 @@ criterion_group!(
     benches,
     tween_transform,
     curve_eval,
+    smoothing_step,
     spring_step,
     controller_tick
 );

--- a/crates/flui-animation/examples/oklab_gradient.rs
+++ b/crates/flui-animation/examples/oklab_gradient.rs
@@ -1,0 +1,52 @@
+//! Perceptual (Oklab) vs componentwise-sRGB color interpolation.
+//!
+//! Prints the blue→yellow transition both ways. The sRGB path dips through a
+//! dark gray midpoint (the classic "muddy gradient"); the Oklab path keeps
+//! perceived lightness steady — this is what `OklabColorTween` gives every
+//! color animation for free.
+//!
+//! Run with: `cargo run -p flui-animation --example oklab_gradient`
+
+use flui_animation::{Animatable, ColorTween, OklabColorTween};
+use flui_types::Color;
+
+fn brightness(c: Color) -> u16 {
+    u16::from(c.r) + u16::from(c.g) + u16::from(c.b)
+}
+
+fn main() {
+    println!("FLUI Oklab color tween example\n");
+
+    let blue = Color::rgb(0, 0, 255);
+    let yellow = Color::rgb(255, 255, 0);
+
+    let srgb = ColorTween::new(blue, yellow);
+    let oklab = OklabColorTween::new(blue, yellow);
+
+    println!("blue -> yellow, 11 steps:");
+    println!("    t     sRGB (r,g,b)  sum    Oklab (r,g,b)  sum");
+    for i in 0..=10 {
+        let t = i as f32 / 10.0;
+        let s = srgb.transform(t);
+        let o = oklab.transform(t);
+        println!(
+            "  {t:4.1}   ({:3},{:3},{:3})  {:4}   ({:3},{:3},{:3})  {:4}",
+            s.r,
+            s.g,
+            s.b,
+            brightness(s),
+            o.r,
+            o.g,
+            o.b,
+            brightness(o),
+        );
+    }
+
+    let s_mid = srgb.transform(0.5);
+    let o_mid = oklab.transform(0.5);
+    println!(
+        "\nMidpoint brightness: sRGB {} vs Oklab {} — the perceptual path never goes muddy.",
+        brightness(s_mid),
+        brightness(o_mid)
+    );
+}

--- a/crates/flui-animation/examples/smoothing_follow.rs
+++ b/crates/flui-animation/examples/smoothing_follow.rs
@@ -1,0 +1,68 @@
+//! Frame-rate-independent smoothing: `exp_decay` vs `SmoothDamp`.
+//!
+//! Simulates a "handle follows target" interaction at two different frame
+//! rates and shows that both followers land in the same place after the same
+//! wall-clock time — the property the naive `lerp(a, b, 0.1)`-per-frame
+//! pattern does NOT have.
+//!
+//! Run with: `cargo run -p flui-animation --example smoothing_follow`
+
+use flui_animation::smoothing::{SmoothDamp, Smoothed, exp_decay_half_life};
+
+fn main() {
+    println!("FLUI smoothing example\n");
+
+    // 1. The frame-rate trap: same "lerp factor" at different frame rates
+    //    diverges; exp_decay does not.
+    println!("1. One second of following target=100 from 0:");
+    for (label, fps) in [("30 fps", 30u32), ("120 fps", 120u32)] {
+        let dt = 1.0 / fps as f32;
+
+        // Broken pattern: x += (target - x) * 0.05 per FRAME.
+        let mut broken = 0.0_f32;
+        // Correct pattern: exponential decay with a 250 ms half-life.
+        let mut correct = 0.0_f32;
+        for _ in 0..fps {
+            broken += (100.0 - broken) * 0.05;
+            correct = exp_decay_half_life(correct, 100.0, 0.25, dt);
+        }
+        println!("   {label:>7}: per-frame lerp = {broken:6.2}   exp_decay = {correct:6.2}");
+    }
+    println!("   -> per-frame lerp depends on the frame count; exp_decay only on elapsed time.\n");
+
+    // 2. Smoothed: stateful wrapper for a moving target.
+    println!("2. Smoothed cursor with a retarget mid-flight (120 fps):");
+    let mut cursor = Smoothed::new(0.0, 0.1); // 100 ms half-life
+    cursor.set_target(80.0);
+    for frame in 0..36 {
+        if frame == 18 {
+            cursor.set_target(20.0); // user changed direction
+            println!("   -- retarget to 20 --");
+        }
+        let v = cursor.tick(1.0 / 120.0);
+        if frame % 6 == 5 {
+            println!(
+                "   t={:>4.0} ms  value={v:6.2}",
+                (frame + 1) as f32 * 1000.0 / 120.0
+            );
+        }
+    }
+    println!();
+
+    // 3. SmoothDamp: carries velocity, so motion is C1-continuous and never
+    //    overshoots — the right tool for camera/scroll-indicator follow.
+    println!("3. SmoothDamp follow with a max speed of 300 units/s:");
+    let mut damp = SmoothDamp::new(0.25).with_max_speed(300.0);
+    let mut pos = 0.0_f32;
+    for frame in 0..48 {
+        pos = damp.step(pos, 100.0, 1.0 / 120.0);
+        if frame % 12 == 11 {
+            println!(
+                "   t={:>4.0} ms  pos={pos:6.2}  velocity={:7.2}/s",
+                (frame + 1) as f32 * 1000.0 / 120.0,
+                damp.velocity()
+            );
+        }
+    }
+    println!("\nDone.");
+}

--- a/crates/flui-animation/src/animation.rs
+++ b/crates/flui-animation/src/animation.rs
@@ -129,7 +129,7 @@ pub(crate) struct ParentSubscription {
 }
 
 impl ParentSubscription {
-    fn new(teardown: impl FnMut() + Send + 'static) -> Arc<Self> {
+    pub(crate) fn new(teardown: impl FnMut() + Send + 'static) -> Arc<Self> {
         Arc::new(Self {
             teardown: parking_lot::Mutex::new(Some(Box::new(teardown))),
         })

--- a/crates/flui-animation/src/compound.rs
+++ b/crates/flui-animation/src/compound.rs
@@ -205,10 +205,13 @@ impl Animation<f32> for CompoundAnimation {
         self.apply_operator(first_value, next_value)
     }
 
+    /// The status of the **first** operand, regardless of operator.
+    ///
+    /// Intentional (Flutter `CompoundAnimation` parity): even when `Min`/`Max`
+    /// currently selects the second operand's value, `first` drives both
+    /// `status()` and the status listeners.
     #[inline]
     fn status(&self) -> AnimationStatus {
-        // Return the status of the first animation
-        // (both animations might have different statuses)
         self.first.status()
     }
 

--- a/crates/flui-animation/src/constant.rs
+++ b/crates/flui-animation/src/constant.rs
@@ -7,6 +7,11 @@ use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Counter for generating unique listener IDs (starts at 1, not 0).
+///
+/// These ids live in `ConstantAnimation`'s own namespace: they are only ever
+/// handed back to [`ConstantAnimation::remove_listener`]-style no-ops and are
+/// never valid for any `ChangeNotifier`-backed animation (which mints ids
+/// from its own counter).
 static LISTENER_ID_COUNTER: AtomicUsize = AtomicUsize::new(1);
 
 /// An animation that always returns the same value.

--- a/crates/flui-animation/src/controller.rs
+++ b/crates/flui-animation/src/controller.rs
@@ -798,7 +798,9 @@ impl AnimationController {
             return;
         }
 
-        // Cycle complete.
+        // Cycle complete. Provisional: this is the end of the *first* spanned
+        // cycle; the repeat-exhaustion branch below overwrites it with the
+        // last cycle's endpoint when several cycles retire in one frame.
         inner.value = inner.target_value;
 
         if inner.is_repeating {
@@ -896,8 +898,20 @@ impl AnimationController {
     }
 
     /// Set the value directly without animating; recomputes status and notifies.
+    ///
+    /// A `NaN` input is canonicalized to the lower bound: Rust's `clamp`
+    /// propagates `NaN`, which would otherwise poison every downstream
+    /// curve/tween evaluation for the rest of the controller's life.
     pub fn set_value(&self, value: f32) {
         let mut inner = self.inner.lock();
+        let value = if value.is_nan() {
+            tracing::warn!(
+                "set_value(NaN) canonicalized to lower bound; drive the controller with finite values"
+            );
+            inner.lower_bound
+        } else {
+            value
+        };
         inner.value = value.clamp(inner.lower_bound, inner.upper_bound);
         let status = inner.settled_status_keep_direction();
         inner.status = status;
@@ -1107,6 +1121,23 @@ impl Animation<f32> for AnimationController {
             .status_listeners
             .retain(|(listener_id, _)| *listener_id != id);
     }
+
+    /// Whether the controller is currently driving a run.
+    ///
+    /// Flutter parity: `AnimationController.isAnimating` is ticker-based
+    /// (`_ticker!.isActive`), not status-based. `set_value` at an interior
+    /// value reports a directional status (per `_internalSetValue`) while the
+    /// controller is stopped, so the trait's status-derived default would
+    /// wrongly report `true` there. A muted ticker still counts as animating,
+    /// matching `Ticker.isActive`.
+    #[inline]
+    fn is_animating(&self) -> bool {
+        self.inner
+            .lock()
+            .ticker
+            .as_ref()
+            .is_some_and(Ticker::is_running)
+    }
 }
 
 impl Listenable for AnimationController {
@@ -1173,6 +1204,40 @@ mod tests {
         let c = controller(100);
         c.forward().unwrap();
         assert_eq!(c.status(), AnimationStatus::Forward);
+        c.dispose();
+    }
+
+    #[test]
+    fn is_animating_is_ticker_based_not_status_based() {
+        let _serial = serial();
+        let c = controller(100);
+        // Flutter `_internalSetValue` parity: an interior set_value reports a
+        // directional status, but a stopped controller must not claim to be
+        // animating (Flutter's isAnimating is ticker-based).
+        c.set_value(0.5);
+        assert_eq!(c.status(), AnimationStatus::Forward);
+        assert!(!c.is_animating(), "stopped controller must not animate");
+
+        c.forward().unwrap();
+        assert!(c.is_animating(), "running controller must animate");
+
+        c.stop().unwrap();
+        assert!(!c.is_animating(), "stop() must end animating");
+        c.dispose();
+    }
+
+    #[test]
+    fn set_value_nan_is_canonicalized() {
+        let _serial = serial();
+        let c = controller(100);
+        c.set_value(0.5);
+        c.set_value(f32::NAN);
+        assert_eq!(
+            c.value(),
+            0.0,
+            "NaN must canonicalize to the lower bound, not poison the value"
+        );
+        assert_eq!(c.status(), AnimationStatus::Dismissed);
         c.dispose();
     }
 

--- a/crates/flui-animation/src/curve.rs
+++ b/crates/flui-animation/src/curve.rs
@@ -323,9 +323,171 @@ impl Cubic {
 
 impl Curve for Cubic {
     fn transform(&self, t: f32) -> f32 {
+        // Rust's `clamp` propagates NaN, which would silently NaN both the
+        // Newton loop and the bisection fallback; canonicalize to the left
+        // endpoint instead of poisoning every downstream animation value.
+        if t.is_nan() {
+            return 0.0;
+        }
         let t = t.clamp(0.0, 1.0);
         let s = self.solve_x(t);
         evaluate_cubic(s, 0.0, self.b, self.d, 1.0)
+    }
+}
+
+/// Two cubic bezier segments joined at a shared `midpoint`.
+///
+/// The curve passes through `(0,0)`, `midpoint`, and `(1,1)`; each half is a
+/// [`Cubic`] rescaled into its sub-rectangle. This is the building block for
+/// the Material 3 emphasized easing set.
+///
+/// Similar to Flutter's `ThreePointCubic`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ThreePointCubic {
+    /// First control point of the first segment (tangent at `(0, 0)`).
+    pub a1: (f32, f32),
+    /// Second control point of the first segment (tangent into `midpoint`).
+    pub b1: (f32, f32),
+    /// The shared point both segments pass through.
+    ///
+    /// `midpoint.0` must lie strictly inside `(0, 1)` — both segment widths
+    /// are used as divisors.
+    pub midpoint: (f32, f32),
+    /// First control point of the second segment (tangent out of `midpoint`).
+    pub a2: (f32, f32),
+    /// Second control point of the second segment (tangent at `(1, 1)`).
+    pub b2: (f32, f32),
+}
+
+impl ThreePointCubic {
+    /// Creates a three-point cubic from the control points of both segments.
+    ///
+    /// The two implied end points `(0,0)` and `(1,1)` are fixed and not
+    /// passed. See Flutter's `ThreePointCubic` for the geometry.
+    #[must_use]
+    pub const fn new(
+        a1: (f32, f32),
+        b1: (f32, f32),
+        midpoint: (f32, f32),
+        a2: (f32, f32),
+        b2: (f32, f32),
+    ) -> Self {
+        Self {
+            a1,
+            b1,
+            midpoint,
+            a2,
+            b2,
+        }
+    }
+}
+
+impl Curve for ThreePointCubic {
+    fn transform(&self, t: f32) -> f32 {
+        // NaN canonicalization mirrors `Cubic::transform`.
+        if t.is_nan() {
+            return 0.0;
+        }
+        let t = t.clamp(0.0, 1.0);
+        let (mx, my) = self.midpoint;
+        let first = t < mx;
+        let scale_x = if first { mx } else { 1.0 - mx };
+        let scale_y = if first { my } else { 1.0 - my };
+        let scaled_t = (t - if first { 0.0 } else { mx }) / scale_x;
+        if first {
+            Cubic::new(
+                self.a1.0 / scale_x,
+                self.a1.1 / scale_y,
+                self.b1.0 / scale_x,
+                self.b1.1 / scale_y,
+            )
+            .transform(scaled_t)
+                * scale_y
+        } else {
+            Cubic::new(
+                (self.a2.0 - mx) / scale_x,
+                (self.a2.1 - my) / scale_y,
+                (self.b2.0 - mx) / scale_x,
+                (self.b2.1 - my) / scale_y,
+            )
+            .transform(scaled_t)
+                * scale_y
+                + my
+        }
+    }
+}
+
+// ============================================================================
+// Split Curve
+// ============================================================================
+
+/// A curve that progresses according to `begin_curve` until `split`, then
+/// according to `end_curve`.
+///
+/// Useful when a widget must track the user's finger (linear) and then be
+/// flung with an easing curve after release: `split` is the animation
+/// progress at the moment of release.
+///
+/// Similar to Flutter's `Split`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Split<B: Curve = Linear, E: Curve = Cubic> {
+    /// The progress value separating the two curves. In `[0, 1]`.
+    pub split: f32,
+    /// The curve used before `split`.
+    pub begin_curve: B,
+    /// The curve used at and after `split`.
+    pub end_curve: E,
+}
+
+impl Split<Linear, Cubic> {
+    /// Creates a split curve with Flutter's defaults: linear before `split`,
+    /// `Curves::EaseOutCubic` after.
+    #[must_use]
+    pub fn new(split: f32) -> Self {
+        Self::with_curves(split, Linear, Curves::EaseOutCubic)
+    }
+}
+
+impl<B: Curve, E: Curve> Split<B, E> {
+    /// Creates a split curve with explicit segment curves.
+    #[must_use]
+    pub fn with_curves(split: f32, begin_curve: B, end_curve: E) -> Self {
+        assert!(
+            (0.0..=1.0).contains(&split),
+            "split must be in range [0.0, 1.0]"
+        );
+        Self {
+            split,
+            begin_curve,
+            end_curve,
+        }
+    }
+}
+
+impl<B: Curve, E: Curve> Curve for Split<B, E> {
+    #[allow(clippy::float_cmp)] // Intentional exact comparisons per the Flutter contract
+    fn transform(&self, t: f32) -> f32 {
+        if t.is_nan() {
+            return 0.0;
+        }
+        let t = t.clamp(0.0, 1.0);
+        if t == 0.0 || t == 1.0 {
+            return t;
+        }
+        if t == self.split {
+            return self.split;
+        }
+        if t < self.split {
+            // `t < split` implies `split > 0`, so the division is safe.
+            let progress = t / self.split;
+            self.split * self.begin_curve.transform(progress)
+        } else {
+            // `t > split` implies `split < 1`, so the division is safe.
+            let progress = (t - self.split) / (1.0 - self.split);
+            self.split + (1.0 - self.split) * self.end_curve.transform(progress)
+        }
     }
 }
 
@@ -856,6 +1018,74 @@ impl Curves {
 
     /// A curve where the rate of change starts fast and then decelerates.
     pub const Decelerate: DecelerateCurve = DecelerateCurve;
+
+    /// The CSS `ease` function: speeds up quickly, ends slowly.
+    pub const Ease: Cubic = Cubic::new(0.25, 0.1, 0.25, 1.0);
+
+    /// A quadratic ease-in (Penner `easeInQuad`).
+    pub const EaseInQuad: Cubic = Cubic::new(0.55, 0.085, 0.68, 0.53);
+
+    /// A cubic ease-in (Penner `easeInCubic`).
+    pub const EaseInCubic: Cubic = Cubic::new(0.55, 0.055, 0.675, 0.19);
+
+    /// A quartic ease-in (Penner `easeInQuart`).
+    pub const EaseInQuart: Cubic = Cubic::new(0.895, 0.03, 0.685, 0.22);
+
+    /// A quintic ease-in (Penner `easeInQuint`).
+    pub const EaseInQuint: Cubic = Cubic::new(0.755, 0.05, 0.855, 0.06);
+
+    /// A quadratic ease-out (Penner `easeOutQuad`).
+    pub const EaseOutQuad: Cubic = Cubic::new(0.25, 0.46, 0.45, 0.94);
+
+    /// A cubic ease-out (Penner `easeOutCubic`).
+    pub const EaseOutCubic: Cubic = Cubic::new(0.215, 0.61, 0.355, 1.0);
+
+    /// A quartic ease-out (Penner `easeOutQuart`).
+    pub const EaseOutQuart: Cubic = Cubic::new(0.165, 0.84, 0.44, 1.0);
+
+    /// A quintic ease-out (Penner `easeOutQuint`).
+    pub const EaseOutQuint: Cubic = Cubic::new(0.23, 1.0, 0.32, 1.0);
+
+    /// A quadratic ease-in-out (Penner `easeInOutQuad`).
+    pub const EaseInOutQuad: Cubic = Cubic::new(0.455, 0.03, 0.515, 0.955);
+
+    /// A quartic ease-in-out (Penner `easeInOutQuart`).
+    pub const EaseInOutQuart: Cubic = Cubic::new(0.77, 0.0, 0.175, 1.0);
+
+    /// A quintic ease-in-out (Penner `easeInOutQuint`).
+    pub const EaseInOutQuint: Cubic = Cubic::new(0.86, 0.0, 0.07, 1.0);
+
+    /// Starts nearly linear and ends with a strong ease-in; pairs with
+    /// `LinearToEaseOut` for enter/exit transitions.
+    pub const FastLinearToSlowEaseIn: Cubic = Cubic::new(0.18, 1.0, 0.04, 1.0);
+
+    /// Starts nearly linear and ends with an ease-out; the exit counterpart
+    /// of `FastLinearToSlowEaseIn`.
+    pub const LinearToEaseOut: Cubic = Cubic::new(0.35, 0.91, 0.33, 0.97);
+
+    /// Starts with an ease-in and ends nearly linear.
+    pub const EaseInToLinear: Cubic = Cubic::new(0.67, 0.03, 0.65, 0.09);
+
+    /// Fast at the edges, slow through the middle.
+    pub const SlowMiddle: Cubic = Cubic::new(0.15, 0.85, 0.85, 0.15);
+
+    /// Material 3 emphasized easing: the default M3 motion curve.
+    pub const EaseInOutCubicEmphasized: ThreePointCubic = ThreePointCubic::new(
+        (0.05, 0.0),
+        (0.133_333, 0.06),
+        (0.166_666, 0.4),
+        (0.208_333, 0.82),
+        (0.25, 1.0),
+    );
+
+    /// A strong ease-in followed by a long, gentle ease-out.
+    pub const FastEaseInToSlowEaseOut: ThreePointCubic = ThreePointCubic::new(
+        (0.056, 0.024),
+        (0.108, 0.308_5),
+        (0.198, 0.541),
+        (0.365_5, 1.0),
+        (0.546_5, 0.989),
+    );
 }
 
 #[cfg(test)]
@@ -1015,6 +1245,76 @@ mod tests {
         assert_eq!(Curves::Linear.transform(0.5), 0.5);
         assert!(Curves::EaseIn.transform(0.5) < 0.5);
         assert!(Curves::EaseOut.transform(0.5) > 0.5);
+    }
+
+    #[test]
+    fn cubic_nan_input_is_canonicalized() {
+        // Rust's clamp propagates NaN; the solver must not.
+        let c = Curves::EaseInOut;
+        assert_eq!(c.transform(f32::NAN), 0.0);
+        let tp = Curves::EaseInOutCubicEmphasized;
+        assert_eq!(tp.transform(f32::NAN), 0.0);
+        let split = Split::new(0.5);
+        assert_eq!(split.transform(f32::NAN), 0.0);
+    }
+
+    #[test]
+    fn penner_catalog_endpoints() {
+        // Every new cubic catalog entry must satisfy the Curve contract at
+        // the endpoints.
+        for c in [
+            Curves::Ease,
+            Curves::EaseInQuad,
+            Curves::EaseInCubic,
+            Curves::EaseInQuart,
+            Curves::EaseInQuint,
+            Curves::EaseOutQuad,
+            Curves::EaseOutCubic,
+            Curves::EaseOutQuart,
+            Curves::EaseOutQuint,
+            Curves::EaseInOutQuad,
+            Curves::EaseInOutQuart,
+            Curves::EaseInOutQuint,
+            Curves::FastLinearToSlowEaseIn,
+            Curves::LinearToEaseOut,
+            Curves::EaseInToLinear,
+            Curves::SlowMiddle,
+        ] {
+            assert!(c.transform(0.0).abs() < 1e-4, "{c:?} must start at 0");
+            assert!((c.transform(1.0) - 1.0).abs() < 1e-4, "{c:?} must end at 1");
+        }
+    }
+
+    #[test]
+    fn three_point_cubic_passes_through_midpoint() {
+        let c = Curves::EaseInOutCubicEmphasized;
+        assert!(c.transform(0.0).abs() < 1e-4);
+        assert!((c.transform(1.0) - 1.0).abs() < 1e-4);
+        // The curve must pass through its midpoint (M3 spec: (1/6, 0.4)).
+        assert!((c.transform(0.166_666) - 0.4).abs() < 1e-2);
+
+        let f = Curves::FastEaseInToSlowEaseOut;
+        assert!(f.transform(0.0).abs() < 1e-4);
+        assert!((f.transform(1.0) - 1.0).abs() < 1e-4);
+        assert!((f.transform(0.198) - 0.541).abs() < 1e-2);
+    }
+
+    #[test]
+    fn split_curve_contract() {
+        let split = Split::new(0.5);
+        // Endpoints and the split point itself are exact per the contract.
+        assert_eq!(split.transform(0.0), 0.0);
+        assert_eq!(split.transform(1.0), 1.0);
+        assert_eq!(split.transform(0.5), 0.5);
+        // Before the split the default begin curve is linear.
+        assert!((split.transform(0.25) - 0.25).abs() < 1e-6);
+        // After the split the ease-out segment runs ahead of linear.
+        assert!(split.transform(0.75) > 0.75);
+
+        // A custom begin curve is rescaled into [0, split].
+        let custom = Split::with_curves(0.5, Threshold::new(0.5), Linear);
+        assert_eq!(custom.transform(0.2), 0.0); // threshold not yet reached
+        assert_eq!(custom.transform(0.3), 0.5); // threshold crossed -> split*1.0
     }
 
     #[test]

--- a/crates/flui-animation/src/curve.rs
+++ b/crates/flui-animation/src/curve.rs
@@ -365,6 +365,15 @@ impl ThreePointCubic {
     ///
     /// The two implied end points `(0,0)` and `(1,1)` are fixed and not
     /// passed. See Flutter's `ThreePointCubic` for the geometry.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `midpoint` does not lie strictly inside the unit square:
+    /// both segment widths (`midpoint.0`, `1 - midpoint.0`) and heights
+    /// (`midpoint.1`, `1 - midpoint.1`) are used as divisors in
+    /// [`Curve::transform`], so a midpoint on the boundary (or NaN) would
+    /// silently evaluate to NaN/inf. For `const` constructions the panic is
+    /// a compile error.
     #[must_use]
     pub const fn new(
         a1: (f32, f32),
@@ -373,6 +382,11 @@ impl ThreePointCubic {
         a2: (f32, f32),
         b2: (f32, f32),
     ) -> Self {
+        assert!(
+            midpoint.0 > 0.0 && midpoint.0 < 1.0 && midpoint.1 > 0.0 && midpoint.1 < 1.0,
+            "ThreePointCubic midpoint must lie strictly inside the unit square: \
+             both segments are rescaled by its distance to each edge"
+        );
         Self {
             a1,
             b1,

--- a/crates/flui-animation/src/curved.rs
+++ b/crates/flui-animation/src/curved.rs
@@ -65,6 +65,7 @@ impl<C: Curve + Clone + Send + Sync> CurvedAnimation<C> {
 
         let curve_direction = Arc::new(Mutex::new(None));
         let weak_direction = Arc::downgrade(&curve_direction);
+        let weak_parent = Arc::downgrade(&parent);
         let status_id = parent.add_status_listener(Arc::new(move |status| {
             if let Some(direction) = weak_direction.upgrade() {
                 let mut direction = direction.lock();
@@ -73,7 +74,16 @@ impl<C: Curve + Clone + Send + Sync> CurvedAnimation<C> {
                     AnimationStatus::Dismissed | AnimationStatus::Completed => *direction = None,
                     // First running transition wins; mid-run flips keep it.
                     AnimationStatus::Forward | AnimationStatus::Reverse => {
-                        direction.get_or_insert(status);
+                        // Only capture from a LIVE run: a stopped controller's
+                        // set_value at an interior value also reports a
+                        // directional status (Flutter `_internalSetValue`),
+                        // and caching that would pin the wrong curve for the
+                        // next real run (e.g. position at 0.5, then
+                        // reverse()).
+                        let running = weak_parent.upgrade().is_some_and(|p| p.is_animating());
+                        if running {
+                            direction.get_or_insert(status);
+                        }
                     }
                 }
             }
@@ -293,6 +303,38 @@ mod tests {
         assert!(
             (reverse_run - expected).abs() < 1e-3,
             "a run entered in Reverse must use the reverse curve ({reverse_run} vs {expected})"
+        );
+
+        controller.dispose();
+    }
+
+    #[test]
+    fn interior_set_value_does_not_pin_curve_direction() {
+        // A stopped controller positioned mid-range reports a directional
+        // status (Flutter `_internalSetValue`); that must NOT be captured as
+        // the run direction, or a subsequent reverse() would run on the
+        // forward curve.
+        let scheduler = Arc::new(Scheduler::new());
+        let controller = Arc::new(AnimationController::new(
+            Duration::from_millis(100),
+            scheduler,
+        ));
+        let curved = CurvedAnimation::new(
+            controller.clone() as Arc<dyn Animation<f32>>,
+            Cubic::new(0.0, 0.0, 1.0, 1.0), // y(x) = x
+        )
+        .with_reverse_curve(Curves::EaseInQuint);
+
+        // Position while stopped: fires a Forward status with no live run.
+        controller.set_value(0.5);
+        // Now genuinely start in reverse: the reverse curve must apply.
+        let _ = controller.reverse();
+        let value = curved.value();
+        let expected = Curves::EaseInQuint.transform(0.5);
+        assert!(
+            (value - expected).abs() < 1e-3,
+            "a run entered in Reverse after an interior set_value must use \
+             the reverse curve ({value} vs {expected})"
         );
 
         controller.dispose();

--- a/crates/flui-animation/src/curved.rs
+++ b/crates/flui-animation/src/curved.rs
@@ -4,6 +4,7 @@ use crate::animation::{Animation, ParentSubscription, StatusCallback, link_paren
 use crate::curve::Curve;
 use crate::status::AnimationStatus;
 use flui_foundation::{ChangeNotifier, Listenable, ListenerCallback, ListenerId};
+use parking_lot::Mutex;
 use std::fmt;
 use std::sync::Arc;
 
@@ -36,8 +37,18 @@ pub struct CurvedAnimation<C: Curve + Clone + Send + Sync> {
     curve: C,
     reverse_curve: Option<C>,
     notifier: Arc<ChangeNotifier>,
+    /// The running direction captured at run start; `None` at rest.
+    ///
+    /// Flutter parity (`CurvedAnimation._curveDirection`): the active curve is
+    /// locked to the direction the run *entered* with, so flipping direction
+    /// mid-run does not swap curves underneath the value and cause a visual
+    /// discontinuity.
+    curve_direction: Arc<Mutex<Option<AnimationStatus>>>,
     /// Re-emits parent value changes to our listeners; removed on last drop.
     _parent_sub: Arc<ParentSubscription>,
+    /// Keeps `curve_direction` in sync with the parent's status transitions;
+    /// removed on last drop.
+    _status_sub: Arc<ParentSubscription>,
 }
 
 impl<C: Curve + Clone + Send + Sync> CurvedAnimation<C> {
@@ -52,12 +63,34 @@ impl<C: Curve + Clone + Send + Sync> CurvedAnimation<C> {
         let notifier = Arc::new(ChangeNotifier::new());
         let parent_sub = link_parent(&parent, &notifier);
 
+        let curve_direction = Arc::new(Mutex::new(None));
+        let weak_direction = Arc::downgrade(&curve_direction);
+        let status_id = parent.add_status_listener(Arc::new(move |status| {
+            if let Some(direction) = weak_direction.upgrade() {
+                let mut direction = direction.lock();
+                match status {
+                    // At rest the lock is released; the next run re-captures.
+                    AnimationStatus::Dismissed | AnimationStatus::Completed => *direction = None,
+                    // First running transition wins; mid-run flips keep it.
+                    AnimationStatus::Forward | AnimationStatus::Reverse => {
+                        direction.get_or_insert(status);
+                    }
+                }
+            }
+        }));
+        let status_parent = Arc::clone(&parent);
+        let status_sub = ParentSubscription::new(move || {
+            status_parent.remove_status_listener(status_id);
+        });
+
         Self {
             parent,
             curve,
             reverse_curve: None,
             notifier,
+            curve_direction,
             _parent_sub: parent_sub,
+            _status_sub: status_sub,
         }
     }
 
@@ -69,9 +102,15 @@ impl<C: Curve + Clone + Send + Sync> CurvedAnimation<C> {
     }
 
     /// Get the current curve being used (respects reverse).
+    ///
+    /// Uses the direction captured at run start when running (so a mid-run
+    /// direction flip keeps the entry curve), falling back to the parent's
+    /// instantaneous status at rest — Flutter's `_useForwardCurve`.
     #[inline]
     fn current_curve(&self) -> &C {
-        match self.parent.status() {
+        let captured: Option<AnimationStatus> = *self.curve_direction.lock();
+        let effective = captured.unwrap_or_else(|| self.parent.status());
+        match effective {
             AnimationStatus::Reverse => self.reverse_curve.as_ref().unwrap_or(&self.curve),
             _ => &self.curve,
         }
@@ -130,7 +169,7 @@ impl<C: Curve + Clone + Send + Sync + fmt::Debug + 'static> fmt::Debug for Curve
 mod tests {
     use super::*;
     use crate::AnimationController;
-    use crate::curve::Curves;
+    use crate::curve::{Cubic, Curves};
     use flui_scheduler::Scheduler;
     use std::time::Duration;
 
@@ -206,6 +245,54 @@ mod tests {
             hits.load(Ordering::SeqCst),
             2,
             "curved listener must re-emit each parent change"
+        );
+
+        controller.dispose();
+    }
+
+    #[test]
+    fn reverse_curve_locked_to_run_entry_direction() {
+        // Flutter `_curveDirection` parity: a run that entered Forward keeps
+        // the forward curve even if the parent's status flips to Reverse
+        // mid-run; the reverse curve only applies to a run entered in
+        // Reverse. Without the lock, a mid-run `reverse()` would swap curves
+        // underneath the value and cause a visual jump.
+        let scheduler = Arc::new(Scheduler::new());
+        let controller = Arc::new(AnimationController::new(
+            Duration::from_millis(100),
+            scheduler,
+        ));
+        // Forward curve is the identity cubic; the reverse curve is strongly
+        // sub-linear at t=0.5, so any curve swap is observable there.
+        let curved = CurvedAnimation::new(
+            controller.clone() as Arc<dyn Animation<f32>>,
+            Cubic::new(0.0, 0.0, 1.0, 1.0), // y(x) = x
+        )
+        .with_reverse_curve(Curves::EaseInQuint);
+
+        controller.set_value(0.5);
+        let _ = controller.forward();
+        let during_forward = curved.value();
+
+        // Flip direction mid-run: the captured Forward direction must keep
+        // the (≈linear) forward curve active.
+        let _ = controller.reverse();
+        let during_flip = curved.value();
+        assert!(
+            (during_forward - during_flip).abs() < 1e-3,
+            "mid-run direction flip must not swap curves (forward {during_forward} vs flipped {during_flip})"
+        );
+
+        // Settle the run, then start a fresh run in Reverse: now the reverse
+        // curve applies from the start.
+        controller.set_value(1.0); // Completed -> direction lock cleared
+        let _ = controller.reverse();
+        controller.set_value(0.5);
+        let reverse_run = curved.value();
+        let expected = Curves::EaseInQuint.transform(0.5);
+        assert!(
+            (reverse_run - expected).abs() < 1e-3,
+            "a run entered in Reverse must use the reverse curve ({reverse_run} vs {expected})"
         );
 
         controller.dispose();

--- a/crates/flui-animation/src/lib.rs
+++ b/crates/flui-animation/src/lib.rs
@@ -12,7 +12,15 @@
 //! - [`AnimationController`] - Primary animation driver (generates 0.0..1.0)
 //! - [`CurvedAnimation`] - Applies easing curves to animations
 //! - [`Curve`] - Easing curve trait with predefined curves in [`Curves`]
-//! - [`Tween`] - Maps animation values to any type T
+//!   (full Penner catalog, M3 [`ThreePointCubic`] emphasized set, [`Split`])
+//! - [`Tween`] - Maps animation values to any type T;
+//!   [`OklabColorTween`] interpolates colors perceptually (Oklab) instead of
+//!   componentwise sRGB
+//! - [`smoothing`] - Frame-rate-independent followers beyond Flutter:
+//!   [`exp_decay`]/[`Smoothed`] (half-life exponential decay) and
+//!   [`SmoothDamp`] (critically damped, max-speed-clamped)
+//! - [`AnimatedValue`] - Interruptible spring value with velocity-preserving
+//!   retargeting (`#[derive(Animatable)]` for custom types)
 //! - [`AnimationError`] - Error type for animation operations
 //!
 //! ## Persistent Object Pattern

--- a/crates/flui-animation/src/lib.rs
+++ b/crates/flui-animation/src/lib.rs
@@ -93,6 +93,7 @@ pub mod ext;
 pub mod proxy;
 pub mod reverse;
 pub mod simulation;
+pub mod smoothing;
 pub mod spring;
 pub mod switch;
 pub mod tween;
@@ -117,6 +118,7 @@ pub use simulation::{
     BoundedFrictionSimulation, ClampedSimulation, FrictionSimulation, GravitySimulation,
     ScrollSpringSimulation, Simulation, SpringDescription, SpringSimulation, SpringType, Tolerance,
 };
+pub use smoothing::{SmoothDamp, Smoothed, exp_decay, exp_decay_half_life};
 pub use spring::{AnimatedValue, TwoWayConverter};
 // `#[derive(Animatable)]` generates a `TwoWayConverter` impl. It shares the name
 // `Animatable` with the trait above but lives in the macro namespace (the serde
@@ -137,8 +139,8 @@ pub use status::{AnimationBehavior, AnimationStatus};
 pub use tween_types::{
     AlignmentTween, Animatable, AnimatableExt as TweenAnimatableExt, BorderRadiusTween,
     ChainedTween, ColorTween, ConstantTween, CurveExt, CurveTween, EdgeInsetsTween, FloatTween,
-    IntTween, Matrix4Tween, OffsetTween, RectTween, ReverseTween, SizeTween, StepTween, Tween,
-    TweenSequence, TweenSequenceItem,
+    IntTween, Matrix4Tween, OffsetTween, OklabColorTween, RectTween, ReverseTween, SizeTween,
+    StepTween, Tween, TweenSequence, TweenSequenceItem,
 };
 
 // Re-export scheduler types for convenience.

--- a/crates/flui-animation/src/lib.rs
+++ b/crates/flui-animation/src/lib.rs
@@ -131,7 +131,7 @@ pub use curve::{
     BounceInCurve, BounceInOutCurve, BounceOutCurve, CatmullRomCurve, CatmullRomSpline, Cubic,
     Curve, Curve2D, Curve2DSample, Curves, DecelerateCurve, ElasticInCurve, ElasticInOutCurve,
     ElasticOutCurve, FlippedCurve, Interval, Linear, ParametricCurve, ReverseCurve, SawTooth,
-    Threshold,
+    Split, ThreePointCubic, Threshold,
 };
 pub use status::{AnimationBehavior, AnimationStatus};
 pub use tween_types::{

--- a/crates/flui-animation/src/proxy.rs
+++ b/crates/flui-animation/src/proxy.rs
@@ -3,9 +3,45 @@
 use crate::animation::{Animation, ParentSubscription, StatusCallback, link_parent};
 use crate::status::AnimationStatus;
 use flui_foundation::{ChangeNotifier, Listenable, ListenerCallback, ListenerId};
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use std::fmt;
 use std::sync::Arc;
+
+/// Proxy-owned status-listener registry.
+///
+/// Status listeners must be owned by the proxy (not delegated to the current
+/// parent): after `set_parent`, listeners registered on the old parent would
+/// be orphaned there and `remove_status_listener` would target the new parent
+/// with a foreign id. A single forwarder per parent fans out to this registry
+/// and is migrated on every swap.
+struct StatusListeners {
+    listeners: Vec<(ListenerId, StatusCallback)>,
+    next_id: usize,
+}
+
+impl StatusListeners {
+    fn new() -> Self {
+        Self {
+            listeners: Vec::new(),
+            // Listener ids start at 1 so a zero id can never collide.
+            next_id: 1,
+        }
+    }
+}
+
+/// Snapshot-then-fire so user callbacks run without the registry lock held
+/// (a callback may re-enter add/remove_status_listener).
+fn fan_out_status(listeners: &Mutex<StatusListeners>, status: AnimationStatus) {
+    let snapshot: Vec<StatusCallback> = listeners
+        .lock()
+        .listeners
+        .iter()
+        .map(|(_, cb)| Arc::clone(cb))
+        .collect();
+    for cb in snapshot {
+        cb(status);
+    }
+}
 
 /// An animation that can be hot-swapped for another animation.
 ///
@@ -46,6 +82,32 @@ where
     /// Re-emits the current parent's value changes; swapped (old removed) on
     /// `set_parent`, removed entirely on the last clone's drop.
     parent_sub: Arc<RwLock<Arc<ParentSubscription>>>,
+    /// Proxy-owned status listeners; fed by a per-parent forwarder.
+    status_listeners: Arc<Mutex<StatusListeners>>,
+    /// Removes the status forwarder from the current parent; swapped on
+    /// `set_parent`, removed entirely on the last clone's drop.
+    status_sub: Arc<RwLock<Arc<ParentSubscription>>>,
+}
+
+/// Subscribe a status forwarder on `parent` that fans out to `listeners`.
+///
+/// Holds only a `Weak` to the registry so the subscription never keeps the
+/// proxy alive; returns the teardown handle that removes the forwarder.
+fn link_parent_status<T>(
+    parent: &Arc<dyn Animation<T>>,
+    listeners: &Arc<Mutex<StatusListeners>>,
+) -> Arc<ParentSubscription>
+where
+    T: Clone + Send + Sync + 'static,
+{
+    let weak = Arc::downgrade(listeners);
+    let id = parent.add_status_listener(Arc::new(move |status| {
+        if let Some(listeners) = weak.upgrade() {
+            fan_out_status(&listeners, status);
+        }
+    }));
+    let parent = Arc::clone(parent);
+    ParentSubscription::new(move || parent.remove_status_listener(id))
 }
 
 impl<T> ProxyAnimation<T>
@@ -61,10 +123,14 @@ where
     pub fn new(parent: Arc<dyn Animation<T>>) -> Self {
         let notifier = Arc::new(ChangeNotifier::new());
         let parent_sub = link_parent(&parent, &notifier);
+        let status_listeners = Arc::new(Mutex::new(StatusListeners::new()));
+        let status_sub = link_parent_status(&parent, &status_listeners);
         Self {
             parent: Arc::new(RwLock::new(parent)),
             notifier,
             parent_sub: Arc::new(RwLock::new(parent_sub)),
+            status_listeners,
+            status_sub: Arc::new(RwLock::new(status_sub)),
         }
     }
 
@@ -77,15 +143,25 @@ where
 
     /// Set a new parent animation.
     ///
-    /// This will cause all listeners to be notified of the change.
+    /// Value listeners are always notified (the value type has no equality
+    /// bound, so the proxy cannot compare old vs. new — Flutter only notifies
+    /// on change). Status listeners are notified only when the status actually
+    /// differs across the swap, matching Flutter's `ProxyAnimation.parent=`.
     pub fn set_parent(&self, new_parent: Arc<dyn Animation<T>>) {
+        let old_status = self.parent.read().status();
         // Subscribe to the new parent first, then swap; replacing the stored
-        // subscription drops the old one, which removes its listener from the
-        // previous parent.
+        // subscriptions drops the old ones, which removes the value listener
+        // and status forwarder from the previous parent.
         let new_sub = link_parent(&new_parent, &self.notifier);
+        let new_status_sub = link_parent_status(&new_parent, &self.status_listeners);
+        let new_status = new_parent.status();
         *self.parent.write() = new_parent;
         *self.parent_sub.write() = new_sub;
+        *self.status_sub.write() = new_status_sub;
         self.notifier.notify_listeners();
+        if new_status != old_status {
+            fan_out_status(&self.status_listeners, new_status);
+        }
     }
 }
 
@@ -104,11 +180,18 @@ where
     }
 
     fn add_status_listener(&self, callback: StatusCallback) -> ListenerId {
-        self.parent.read().add_status_listener(callback)
+        let mut reg = self.status_listeners.lock();
+        let id = ListenerId::new(reg.next_id);
+        reg.next_id += 1;
+        reg.listeners.push((id, callback));
+        id
     }
 
     fn remove_status_listener(&self, id: ListenerId) {
-        self.parent.read().remove_status_listener(id);
+        self.status_listeners
+            .lock()
+            .listeners
+            .retain(|(listener_id, _)| *listener_id != id);
     }
 }
 
@@ -146,6 +229,7 @@ mod tests {
     use super::*;
     use crate::AnimationController;
     use flui_scheduler::Scheduler;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     #[test]
@@ -191,5 +275,119 @@ mod tests {
         assert_eq!(proxy.status(), AnimationStatus::Forward);
 
         controller.dispose();
+    }
+
+    #[test]
+    fn status_listeners_survive_set_parent() {
+        // Status listeners registered on the proxy must keep firing after a
+        // hot-swap; previously they stayed registered on the old parent and
+        // never saw the new parent's transitions.
+        let scheduler = Arc::new(Scheduler::new());
+        let controller1 = Arc::new(AnimationController::new(
+            Duration::from_millis(100),
+            scheduler.clone(),
+        ));
+        let controller2 = Arc::new(AnimationController::new(
+            Duration::from_millis(100),
+            scheduler,
+        ));
+
+        let proxy = ProxyAnimation::new(controller1.clone() as Arc<dyn Animation<f32>>);
+
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits2 = Arc::clone(&hits);
+        let _id = proxy.add_status_listener(Arc::new(move |_status| {
+            hits2.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        // Both parents are Dismissed: the swap itself must NOT fire (status
+        // unchanged across the swap, Flutter parity).
+        proxy.set_parent(controller2.clone() as Arc<dyn Animation<f32>>);
+        assert_eq!(hits.load(Ordering::SeqCst), 0);
+
+        // A transition on the NEW parent must reach the proxy's listener.
+        let _ = controller2.forward();
+        assert!(
+            hits.load(Ordering::SeqCst) >= 1,
+            "status listener must follow the proxy to the new parent"
+        );
+
+        // A transition on the OLD parent must no longer reach it.
+        let before = hits.load(Ordering::SeqCst);
+        let _ = controller1.forward();
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            before,
+            "old parent must be unsubscribed after the swap"
+        );
+
+        controller1.dispose();
+        controller2.dispose();
+    }
+
+    #[test]
+    fn swap_with_status_change_fires_listeners() {
+        let scheduler = Arc::new(Scheduler::new());
+        let controller1 = Arc::new(AnimationController::new(
+            Duration::from_millis(100),
+            scheduler.clone(),
+        ));
+        let controller2 = Arc::new(AnimationController::new(
+            Duration::from_millis(100),
+            scheduler,
+        ));
+        controller2.set_value(1.0); // Completed
+
+        let proxy = ProxyAnimation::new(controller1.clone() as Arc<dyn Animation<f32>>);
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = Arc::clone(&seen);
+        let _id = proxy.add_status_listener(Arc::new(move |status| {
+            seen2.lock().push(status);
+        }));
+
+        // Dismissed -> Completed across the swap must fire once with the new
+        // status (Flutter `ProxyAnimation.parent=` parity).
+        proxy.set_parent(controller2.clone() as Arc<dyn Animation<f32>>);
+        assert_eq!(seen.lock().as_slice(), &[AnimationStatus::Completed]);
+
+        controller1.dispose();
+        controller2.dispose();
+    }
+
+    #[test]
+    fn remove_status_listener_after_swap() {
+        let scheduler = Arc::new(Scheduler::new());
+        let controller1 = Arc::new(AnimationController::new(
+            Duration::from_millis(100),
+            scheduler.clone(),
+        ));
+        let controller2 = Arc::new(AnimationController::new(
+            Duration::from_millis(100),
+            scheduler,
+        ));
+
+        let proxy = ProxyAnimation::new(controller1.clone() as Arc<dyn Animation<f32>>);
+
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits2 = Arc::clone(&hits);
+        let id = proxy.add_status_listener(Arc::new(move |_status| {
+            hits2.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        proxy.set_parent(controller2.clone() as Arc<dyn Animation<f32>>);
+        // The id was issued by the proxy, so removal must work regardless of
+        // which parent is current.
+        proxy.remove_status_listener(id);
+
+        let _ = controller2.forward();
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            0,
+            "removed status listener must not fire"
+        );
+
+        controller1.dispose();
+        controller2.dispose();
     }
 }

--- a/crates/flui-animation/src/simulation.rs
+++ b/crates/flui-animation/src/simulation.rs
@@ -604,6 +604,14 @@ impl FrictionSimulation {
         start_velocity: f32,
         end_velocity: f32,
     ) -> Self {
+        // Zero travel distance puts a 0 (or ±0-signed) denominator under the
+        // exponent and produces drag = e^±inf / NaN; fail with the physical
+        // constraint instead of the downstream "drag must be in (0,1)" panic.
+        assert!(
+            (start_position - end_position).abs() > f32::EPSILON,
+            "FrictionSimulation::through requires start_position != end_position: \
+             zero travel distance has no finite drag solution"
+        );
         // drag = e^((vStart - vEnd) / (xStart - xEnd))  (Flutter's `_dragFor`).
         let drag = std::f32::consts::E
             .powf((start_velocity - end_velocity) / (start_position - end_position));

--- a/crates/flui-animation/src/smoothing.rs
+++ b/crates/flui-animation/src/smoothing.rs
@@ -1,0 +1,336 @@
+//! Frame-rate-independent smoothing primitives.
+//!
+//! Two building blocks Flutter does not ship:
+//!
+//! - [`exp_decay`] / [`Smoothed`]: exponential decay toward a moving target,
+//!   parameterized by **half-life**. The classic `lerp(a, b, f)`-per-frame
+//!   pattern converges at a rate that depends on the frame count, not on
+//!   elapsed time — a 120 Hz device animates twice as fast as a 60 Hz one.
+//!   `b + (a - b) * exp(-λ·dt)` is the closed-form fix (Freya Holmér,
+//!   "lerp smoothing is broken", <https://www.youtube.com/watch?v=LSNQuFEDOyQ>).
+//! - [`SmoothDamp`]: critically-damped spring approximation with a maximum
+//!   speed clamp and overshoot guard, after Unity's `Mathf.SmoothDamp`
+//!   (Game Programming Gems 4, ch. 1.10). The workhorse for "camera follows
+//!   target" / "handle follows finger" motion that must never oscillate.
+//!
+//! Both are pure functions of `(state, target, dt)` — no allocation, no
+//! locking, usable from any tick path.
+
+/// Exponential decay from `current` toward `target` over `dt` seconds.
+///
+/// `lambda` is the decay rate in 1/seconds: the remaining distance shrinks by
+/// `e^-lambda` every second. Prefer [`exp_decay_half_life`] for a tunable in
+/// human units.
+///
+/// Frame-rate independent: two devices stepping with different `dt` sequences
+/// that sum to the same elapsed time land on the same value.
+#[inline]
+#[must_use]
+pub fn exp_decay(current: f32, target: f32, lambda: f32, dt: f32) -> f32 {
+    target + (current - target) * (-lambda * dt).exp()
+}
+
+/// [`exp_decay`] parameterized by **half-life**: the time (seconds) for the
+/// remaining distance to the target to halve.
+///
+/// `half_life <= 0` snaps to the target (interpreted as "no smoothing").
+#[inline]
+#[must_use]
+pub fn exp_decay_half_life(current: f32, target: f32, half_life: f32, dt: f32) -> f32 {
+    if half_life <= 0.0 {
+        return target;
+    }
+    exp_decay(current, target, core::f32::consts::LN_2 / half_life, dt)
+}
+
+/// A value that follows a (possibly moving) target with exponential decay.
+///
+/// Thin stateful wrapper over [`exp_decay_half_life`] for the common
+/// "smoothed cursor / smoothed scroll indicator" pattern:
+///
+/// ```
+/// use flui_animation::smoothing::Smoothed;
+///
+/// let mut s = Smoothed::new(0.0, 0.1); // 100 ms half-life
+/// s.set_target(10.0);
+/// s.tick(0.1);
+/// assert!((s.value() - 5.0).abs() < 1e-4); // one half-life -> half the gap
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Smoothed {
+    value: f32,
+    target: f32,
+    half_life: f32,
+}
+
+impl Smoothed {
+    /// Create at `value`, targeting itself (at rest), with the given
+    /// half-life in seconds.
+    #[must_use]
+    pub fn new(value: f32, half_life: f32) -> Self {
+        Self {
+            value,
+            target: value,
+            half_life,
+        }
+    }
+
+    /// Current smoothed value.
+    #[inline]
+    #[must_use]
+    pub fn value(&self) -> f32 {
+        self.value
+    }
+
+    /// Current target.
+    #[inline]
+    #[must_use]
+    pub fn target(&self) -> f32 {
+        self.target
+    }
+
+    /// Retarget without disturbing the current value (the decay follows).
+    #[inline]
+    pub fn set_target(&mut self, target: f32) {
+        self.target = target;
+    }
+
+    /// Change the half-life (seconds).
+    #[inline]
+    pub fn set_half_life(&mut self, half_life: f32) {
+        self.half_life = half_life;
+    }
+
+    /// Snap to a value and stop (target = value).
+    #[inline]
+    pub fn snap_to(&mut self, value: f32) {
+        self.value = value;
+        self.target = value;
+    }
+
+    /// Advance by `dt` seconds; returns the new value.
+    #[inline]
+    pub fn tick(&mut self, dt: f32) -> f32 {
+        self.value = exp_decay_half_life(self.value, self.target, self.half_life, dt);
+        self.value
+    }
+
+    /// Whether the value is within `tolerance` of the target.
+    #[inline]
+    #[must_use]
+    pub fn is_settled(&self, tolerance: f32) -> bool {
+        (self.value - self.target).abs() <= tolerance
+    }
+}
+
+/// Critically-damped spring follower with a maximum-speed clamp.
+///
+/// Port of Unity's `Mathf.SmoothDamp` (Game Programming Gems 4, ch. 1.10):
+/// reaches the target smoothly without overshoot, in roughly `smooth_time`
+/// seconds, never moving faster than `max_speed`. Unlike [`exp_decay`] it
+/// carries velocity state, so a retarget mid-flight is C¹-continuous (no
+/// kink in the motion).
+///
+/// The inner `e^-x` uses the GPG4 Padé-style polynomial
+/// `1/(1 + x + 0.48x² + 0.235x³)` — accurate for `x = 2·dt/smooth_time` in
+/// `[0, ~3]`; the max-speed clamp and overshoot guard bound the error
+/// outside that range.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SmoothDamp {
+    velocity: f32,
+    /// Approximate time (seconds) to reach the target. Smaller = stiffer.
+    pub smooth_time: f32,
+    /// Maximum speed in value-units/second. `f32::INFINITY` disables the clamp.
+    pub max_speed: f32,
+}
+
+impl SmoothDamp {
+    /// Create with the given smooth-time (seconds) and no speed limit.
+    #[must_use]
+    pub fn new(smooth_time: f32) -> Self {
+        Self {
+            velocity: 0.0,
+            smooth_time,
+            max_speed: f32::INFINITY,
+        }
+    }
+
+    /// Builder: cap the follow speed (value-units per second).
+    #[must_use]
+    pub fn with_max_speed(mut self, max_speed: f32) -> Self {
+        self.max_speed = max_speed;
+        self
+    }
+
+    /// Current velocity (value-units per second).
+    #[inline]
+    #[must_use]
+    pub fn velocity(&self) -> f32 {
+        self.velocity
+    }
+
+    /// Reset velocity to zero (e.g. after a hard snap).
+    #[inline]
+    pub fn reset(&mut self) {
+        self.velocity = 0.0;
+    }
+
+    /// Advance `current` toward `target` by `dt` seconds; returns the new
+    /// position. Velocity state is updated in place.
+    #[must_use]
+    pub fn step(&mut self, current: f32, target: f32, dt: f32) -> f32 {
+        // Guard degenerate inputs: a zero/negative smooth_time means "snap".
+        let smooth_time = self.smooth_time.max(0.0001);
+        let omega = 2.0 / smooth_time;
+        let x = omega * dt;
+        // GPG4 polynomial approximation of e^-x (see type docs).
+        let exp = 1.0 / (1.0 + x + 0.48 * x * x + 0.235 * x * x * x);
+
+        let mut change = current - target;
+        let original_target = target;
+
+        // Clamp maximum follow speed.
+        let max_change = self.max_speed * smooth_time;
+        if max_change.is_finite() {
+            change = change.clamp(-max_change, max_change);
+        }
+        let target = current - change;
+
+        let temp = (self.velocity + omega * change) * dt;
+        self.velocity = (self.velocity - omega * temp) * exp;
+        let mut output = target + (change + temp) * exp;
+
+        // Overshoot guard: the polynomial approximation can cross the target
+        // for large x; clamp to the target and zero the outward velocity.
+        if (original_target - current > 0.0) == (output > original_target) {
+            output = original_target;
+            self.velocity = (output - original_target) / dt;
+        }
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exp_decay_is_frame_rate_independent() {
+        // Same wall-clock time, different step counts -> same result.
+        let (start, target, half_life) = (0.0_f32, 100.0_f32, 0.25_f32);
+
+        let mut at_30fps = start;
+        for _ in 0..30 {
+            at_30fps = exp_decay_half_life(at_30fps, target, half_life, 1.0 / 30.0);
+        }
+
+        let mut at_120fps = start;
+        for _ in 0..120 {
+            at_120fps = exp_decay_half_life(at_120fps, target, half_life, 1.0 / 120.0);
+        }
+
+        assert!(
+            (at_30fps - at_120fps).abs() < 1e-3,
+            "30 fps ({at_30fps}) and 120 fps ({at_120fps}) must agree after 1 s"
+        );
+        // 1 s / 0.25 s half-life = 4 halvings: 100 * (1 - 1/16) = 93.75.
+        assert!((at_120fps - 93.75).abs() < 0.01);
+    }
+
+    #[test]
+    fn exp_decay_half_life_halves_per_half_life() {
+        let v = exp_decay_half_life(0.0, 10.0, 0.5, 0.5);
+        assert!((v - 5.0).abs() < 1e-4, "one half-life closes half the gap");
+        let v = exp_decay_half_life(v, 10.0, 0.5, 0.5);
+        assert!(
+            (v - 7.5).abs() < 1e-4,
+            "two half-lives close three quarters"
+        );
+    }
+
+    #[test]
+    fn zero_half_life_snaps() {
+        assert_eq!(exp_decay_half_life(3.0, 7.0, 0.0, 0.016), 7.0);
+    }
+
+    #[test]
+    fn smoothed_follows_moving_target() {
+        let mut s = Smoothed::new(0.0, 0.1);
+        s.set_target(10.0);
+        s.tick(0.1);
+        assert!((s.value() - 5.0).abs() < 1e-4);
+        // Retarget mid-flight: decay continues from the current value.
+        s.set_target(0.0);
+        s.tick(0.1);
+        assert!((s.value() - 2.5).abs() < 1e-4);
+        assert!(!s.is_settled(0.01));
+        s.snap_to(0.0);
+        assert!(s.is_settled(0.0));
+    }
+
+    #[test]
+    fn smooth_damp_converges_without_overshoot() {
+        let mut damp = SmoothDamp::new(0.2);
+        let mut pos = 0.0_f32;
+        let mut max_seen = 0.0_f32;
+        for _ in 0..240 {
+            pos = damp.step(pos, 100.0, 1.0 / 120.0);
+            max_seen = max_seen.max(pos);
+        }
+        assert!(
+            (pos - 100.0).abs() < 0.5,
+            "must converge near the target, got {pos}"
+        );
+        assert!(
+            max_seen <= 100.0 + 1e-3,
+            "critically damped follower must not overshoot, peaked at {max_seen}"
+        );
+    }
+
+    #[test]
+    fn smooth_damp_respects_max_speed() {
+        let mut damp = SmoothDamp::new(0.05).with_max_speed(50.0);
+        let mut pos = 0.0_f32;
+        let dt = 1.0 / 120.0;
+        let mut prev = pos;
+        for _ in 0..120 {
+            pos = damp.step(pos, 1000.0, dt);
+            let speed = (pos - prev) / dt;
+            assert!(
+                speed <= 50.0 * 1.05,
+                "instantaneous speed {speed} must stay near the 50/s cap"
+            );
+            prev = pos;
+        }
+    }
+
+    #[test]
+    fn smooth_damp_retarget_is_position_continuous() {
+        // A retarget mid-flight must not teleport: carried velocity keeps the
+        // motion C0-continuous and the first post-retarget step still moves
+        // in the OLD direction (momentum), unlike a stateless lerp which
+        // would immediately reverse.
+        let mut damp = SmoothDamp::new(0.15);
+        let mut pos = 0.0_f32;
+        let dt = 1.0 / 120.0;
+        for _ in 0..30 {
+            pos = damp.step(pos, 100.0, dt);
+        }
+        let v_before = damp.velocity();
+        assert!(v_before > 0.0, "approach run must carry forward velocity");
+
+        let pos_before = pos;
+        let pos_after = damp.step(pos, -100.0, dt);
+        let step = (pos_after - pos_before).abs();
+        assert!(
+            step <= v_before.abs() * dt * 2.0 + 1e-3,
+            "one step after a retarget must stay within the velocity envelope \
+             (moved {step} at velocity {v_before})"
+        );
+        assert!(
+            pos_after > pos_before - 1e-3,
+            "carried momentum must keep moving toward the old target for the \
+             first instant, not snap backwards"
+        );
+    }
+}

--- a/crates/flui-animation/src/status.rs
+++ b/crates/flui-animation/src/status.rs
@@ -94,9 +94,16 @@ impl AnimationStatus {
     }
 }
 
-/// Configures how an animation should behave when not in view.
+/// Configures how an animation should behave when animations are globally
+/// disabled (e.g. the platform's reduce-motion accessibility setting).
 ///
 /// Similar to Flutter's `AnimationBehavior`.
+///
+/// This is a policy carrier: `AnimationController` does not read it itself —
+/// the accessibility/bindings layer consults it when deciding whether to
+/// fast-forward (`Normal`) or run unchanged (`Preserve`) under a
+/// disable-animations setting, mirroring Flutter where `AnimationBehavior`
+/// only takes effect through `SemanticsBinding.disableAnimations`.
 ///
 /// # Examples
 ///

--- a/crates/flui-animation/src/switch.rs
+++ b/crates/flui-animation/src/switch.rs
@@ -176,10 +176,32 @@ impl AnimationSwitch {
         self.inner.lock().current.clone()
     }
 
+    /// Builds the status forwarder that re-emits the current animation's
+    /// status transitions through our notifier.
+    fn make_status_callback(
+        inner_weak: &std::sync::Weak<Mutex<AnimationSwitchInner>>,
+        notifier: &Arc<ChangeNotifier>,
+    ) -> StatusCallback {
+        let inner_weak = inner_weak.clone();
+        let notifier = Arc::clone(notifier);
+        Arc::new(move |status| {
+            if let Some(inner_arc) = inner_weak.upgrade() {
+                let mut inner = inner_arc.lock();
+                if inner.last_status != Some(status) {
+                    inner.last_status = Some(status);
+                    drop(inner);
+                    notifier.notify_listeners();
+                }
+            }
+        })
+    }
+
     /// Sets up listeners on the current and next animations.
     fn setup_listeners(&self) {
         let inner_weak = Arc::downgrade(&self.inner);
         let notifier = Arc::clone(&self.notifier);
+        let status_callback = Self::make_status_callback(&inner_weak, &notifier);
+        let status_callback_for_handler = Arc::clone(&status_callback);
 
         let value_handler = move || {
             if let Some(inner_arc) = inner_weak.upgrade() {
@@ -198,20 +220,40 @@ impl AnimationSwitch {
                     false
                 };
 
-                if should_switch {
-                    // Switch animations
-                    if let Some(next) = inner.next.take() {
-                        inner.current = next;
-                        inner.mode = None;
+                // On switch, rebind all listener bookkeeping so the ids stored
+                // in `inner` always describe live registrations on `current`:
+                //  - the old current's value + status listeners are removed
+                //    (it may be externally alive long after the hop);
+                //  - the promoted next's value listener becomes the current one;
+                //  - a fresh status listener is attached to the new current.
+                let mut callback = None;
+                let mut rebind = None;
+                if should_switch && let Some(next) = inner.next.take() {
+                    let old_current = std::mem::replace(&mut inner.current, Arc::clone(&next));
+                    inner.mode = None;
+                    let old_value_id = inner.current_listener_id.take();
+                    let old_status_id = inner.current_status_listener_id.take();
+                    inner.current_listener_id = inner.next_listener_id.take();
+                    callback.clone_from(&inner.on_switched);
+                    rebind = Some((old_current, old_value_id, old_status_id, next));
+                }
+                // Release the lock before touching other animations' listener
+                // registries or running user callbacks.
+                drop(inner);
 
-                        // Call on_switched callback
-                        if let Some(ref callback) = inner.on_switched {
-                            let callback = Arc::clone(callback);
-                            // Release lock before calling callback
-                            drop(inner);
-                            callback();
-                        }
+                if let Some((old_current, old_value_id, old_status_id, new_current)) = rebind {
+                    if let Some(id) = old_value_id {
+                        old_current.remove_listener(id);
                     }
+                    if let Some(id) = old_status_id {
+                        old_current.remove_status_listener(id);
+                    }
+                    let status_id =
+                        new_current.add_status_listener(Arc::clone(&status_callback_for_handler));
+                    inner_arc.lock().current_status_listener_id = Some(status_id);
+                }
+                if let Some(callback) = callback {
+                    callback();
                 }
 
                 // Notify listeners of value change
@@ -232,18 +274,6 @@ impl AnimationSwitch {
         }
 
         // Add status listener to current
-        let inner_weak = Arc::downgrade(&self.inner);
-        let notifier = Arc::clone(&self.notifier);
-        let status_callback: StatusCallback = Arc::new(move |status| {
-            if let Some(inner_arc) = inner_weak.upgrade() {
-                let mut inner = inner_arc.lock();
-                if inner.last_status != Some(status) {
-                    inner.last_status = Some(status);
-                    drop(inner);
-                    notifier.notify_listeners();
-                }
-            }
-        });
         inner.current_status_listener_id = Some(inner.current.add_status_listener(status_callback));
     }
 
@@ -360,6 +390,65 @@ mod tests {
 
         // Initially uses controller1
         assert_eq!(switch.value(), 0.8);
+
+        controller1.dispose();
+        controller2.dispose();
+    }
+
+    #[test]
+    fn switch_rebinds_listeners_to_new_current() {
+        use std::sync::atomic::AtomicUsize;
+
+        let scheduler = Arc::new(Scheduler::new());
+        let controller1 = create_controller(&scheduler, 0.8);
+        let controller2 = create_controller(&scheduler, 0.3);
+
+        let before1 = controller1.debug_value_listener_count();
+        let before2 = controller2.debug_value_listener_count();
+
+        let switch = AnimationSwitch::new(
+            controller1.clone() as Arc<dyn Animation<f32>>,
+            Some(controller2.clone() as Arc<dyn Animation<f32>>),
+        );
+        assert_eq!(controller1.debug_value_listener_count(), before1 + 1);
+        assert_eq!(controller2.debug_value_listener_count(), before2 + 1);
+
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits2 = Arc::clone(&hits);
+        let _id = switch.add_listener(Arc::new(move || {
+            hits2.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        // Drive controller1 below controller2's value -> hop to controller2.
+        controller1.set_value(0.2);
+        assert_eq!(switch.value(), 0.3, "switch must hop to next");
+
+        // The retired animation's listeners must be removed: further changes
+        // on controller1 must not re-notify the switch.
+        assert_eq!(
+            controller1.debug_value_listener_count(),
+            before1,
+            "old current's value listener must be removed after the hop"
+        );
+        let after_hop = hits.load(Ordering::SeqCst);
+        controller1.set_value(0.9);
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            after_hop,
+            "retired animation must not notify the switch"
+        );
+
+        // The new current still drives the switch.
+        controller2.set_value(0.6);
+        assert!(hits.load(Ordering::SeqCst) > after_hop);
+
+        // dispose() removes the (rebound) listeners from the new current.
+        switch.dispose();
+        assert_eq!(
+            controller2.debug_value_listener_count(),
+            before2,
+            "dispose must remove the rebound listener from the new current"
+        );
 
         controller1.dispose();
         controller2.dispose();

--- a/crates/flui-animation/src/switch.rs
+++ b/crates/flui-animation/src/switch.rs
@@ -85,6 +85,15 @@ struct AnimationSwitchInner {
     current_listener_id: Option<ListenerId>,
     next_listener_id: Option<ListenerId>,
     current_status_listener_id: Option<ListenerId>,
+    /// Switch-owned status listeners.
+    ///
+    /// Owned here (not delegated to `current`) because `current` changes on
+    /// a train-hop: an id minted by the old current would be removed against
+    /// the new one and orphan the callback on the retired animation. The
+    /// internal per-current forwarder fans out to this registry instead.
+    status_listeners: Vec<(ListenerId, StatusCallback)>,
+    /// Next id for `status_listeners` (starts at 1 so 0 never collides).
+    next_status_listener_id: usize,
 }
 
 impl AnimationSwitch {
@@ -142,6 +151,8 @@ impl AnimationSwitch {
             current_listener_id: None,
             next_listener_id: None,
             current_status_listener_id: None,
+            status_listeners: Vec::new(),
+            next_status_listener_id: 1,
         };
 
         let this = Self {
@@ -189,8 +200,18 @@ impl AnimationSwitch {
                 let mut inner = inner_arc.lock();
                 if inner.last_status != Some(status) {
                     inner.last_status = Some(status);
+                    // Snapshot-then-fire: user callbacks run without the
+                    // inner lock held (they may re-enter the switch).
+                    let callbacks: Vec<StatusCallback> = inner
+                        .status_listeners
+                        .iter()
+                        .map(|(_, cb)| Arc::clone(cb))
+                        .collect();
                     drop(inner);
                     notifier.notify_listeners();
+                    for callback in callbacks {
+                        callback(status);
+                    }
                 }
             }
         })
@@ -314,12 +335,23 @@ impl Animation<f32> for AnimationSwitch {
         self.inner.lock().current.status()
     }
 
+    /// Registers on the switch's own registry (NOT the current animation):
+    /// `current` changes on a train-hop, so a delegated id would later be
+    /// removed against the wrong animation. The internal per-current
+    /// forwarder re-emits the active animation's transitions here.
     fn add_status_listener(&self, callback: StatusCallback) -> ListenerId {
-        self.inner.lock().current.add_status_listener(callback)
+        let mut inner = self.inner.lock();
+        let id = ListenerId::new(inner.next_status_listener_id);
+        inner.next_status_listener_id += 1;
+        inner.status_listeners.push((id, callback));
+        id
     }
 
     fn remove_status_listener(&self, id: ListenerId) {
-        self.inner.lock().current.remove_status_listener(id);
+        self.inner
+            .lock()
+            .status_listeners
+            .retain(|(listener_id, _)| *listener_id != id);
     }
 }
 
@@ -448,6 +480,56 @@ mod tests {
             controller2.debug_value_listener_count(),
             before2,
             "dispose must remove the rebound listener from the new current"
+        );
+
+        controller1.dispose();
+        controller2.dispose();
+    }
+
+    #[test]
+    fn status_listeners_survive_the_hop() {
+        use std::sync::atomic::AtomicUsize;
+
+        // Status listener ids are minted by the switch itself; they must
+        // keep firing after a train-hop and stay removable by the same id
+        // (previously they were delegated to the pre-hop `current`).
+        let scheduler = Arc::new(Scheduler::new());
+        let controller1 = create_controller(&scheduler, 0.8);
+        let controller2 = create_controller(&scheduler, 0.3);
+
+        let switch = AnimationSwitch::new(
+            controller1.clone() as Arc<dyn Animation<f32>>,
+            Some(controller2.clone() as Arc<dyn Animation<f32>>),
+        );
+
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits2 = Arc::clone(&hits);
+        let id = switch.add_status_listener(Arc::new(move |_status| {
+            hits2.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        // Hop to controller2.
+        controller1.set_value(0.2);
+        assert_eq!(switch.value(), 0.3);
+
+        // A status transition on the NEW current must reach the listener.
+        // (set_value(1.0) -> Completed is guaranteed to differ from the
+        // interior Forward status, so the duplicate filter cannot eat it.)
+        let before = hits.load(Ordering::SeqCst);
+        controller2.set_value(1.0);
+        assert!(
+            hits.load(Ordering::SeqCst) > before,
+            "status listener must follow the switch to the new current"
+        );
+
+        // Removal by the switch-minted id must work after the hop.
+        switch.remove_status_listener(id);
+        let after_remove = hits.load(Ordering::SeqCst);
+        controller2.set_value(0.0); // Completed -> Dismissed transition
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            after_remove,
+            "removed status listener must not fire"
         );
 
         controller1.dispose();

--- a/crates/flui-animation/src/tween.rs
+++ b/crates/flui-animation/src/tween.rs
@@ -1,10 +1,9 @@
 //! `TweenAnimation` - maps f32 animations to any type T.
 
-use crate::animation::{Animation, StatusCallback};
+use crate::animation::{Animation, ParentSubscription, StatusCallback, link_parent};
 use crate::status::AnimationStatus;
 use crate::tween_types::Animatable;
 use flui_foundation::{ChangeNotifier, Listenable, ListenerCallback, ListenerId};
-use parking_lot::Mutex;
 use std::fmt;
 use std::sync::Arc;
 
@@ -48,7 +47,8 @@ where
     tween: A,
     parent: Arc<dyn Animation<f32>>,
     notifier: Arc<ChangeNotifier>,
-    _parent_listener_id: Arc<Mutex<Option<ListenerId>>>,
+    /// Re-emits parent value changes to our listeners; removed on last drop.
+    _parent_sub: Arc<ParentSubscription>,
     _phantom: std::marker::PhantomData<T>,
 }
 
@@ -66,12 +66,13 @@ where
     #[must_use]
     pub fn new(tween: A, parent: Arc<dyn Animation<f32>>) -> Self {
         let notifier = Arc::new(ChangeNotifier::new());
+        let parent_sub = link_parent(&parent, &notifier);
 
         Self {
             tween,
             parent,
             notifier,
-            _parent_listener_id: Arc::new(Mutex::new(None)),
+            _parent_sub: parent_sub,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -206,6 +207,66 @@ mod tests {
         controller.forward().unwrap();
         assert_eq!(animation.status(), AnimationStatus::Forward);
 
+        controller.dispose();
+    }
+
+    #[test]
+    fn tween_reemits_parent_value_changes() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Same class of regression as CurvedAnimation B2: a listener on a
+        // TweenAnimation must fire when the parent's value changes; previously
+        // the combinator never subscribed to its parent, so tween-driven
+        // rebuilds silently never happened.
+        let scheduler = Arc::new(Scheduler::new());
+        let controller = Arc::new(AnimationController::new(
+            Duration::from_millis(100),
+            scheduler,
+        ));
+        let tween = FloatTween::new(0.0, 100.0);
+        let animation = TweenAnimation::new(tween, controller.clone() as Arc<dyn Animation<f32>>);
+
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits2 = Arc::clone(&hits);
+        let _id = animation.add_listener(Arc::new(move || {
+            hits2.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        controller.set_value(0.5);
+        controller.set_value(0.7);
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            2,
+            "tween listener must re-emit each parent change"
+        );
+
+        controller.dispose();
+    }
+
+    #[test]
+    fn dropping_tween_removes_parent_subscription() {
+        let scheduler = Arc::new(Scheduler::new());
+        let controller = Arc::new(AnimationController::new(
+            Duration::from_millis(100),
+            scheduler,
+        ));
+        let before = controller.debug_value_listener_count();
+        {
+            let _animation = TweenAnimation::new(
+                FloatTween::new(0.0, 1.0),
+                controller.clone() as Arc<dyn Animation<f32>>,
+            );
+            assert_eq!(
+                controller.debug_value_listener_count(),
+                before + 1,
+                "constructing a tween combinator subscribes once to the parent"
+            );
+        }
+        assert_eq!(
+            controller.debug_value_listener_count(),
+            before,
+            "dropping the tween combinator removes its parent subscription"
+        );
         controller.dispose();
     }
 

--- a/crates/flui-animation/src/tween_types.rs
+++ b/crates/flui-animation/src/tween_types.rs
@@ -351,6 +351,10 @@ impl<T, A: Animatable<T>> TweenSequence<T, A> {
 }
 
 impl<T, A: Animatable<T>> Animatable<T> for TweenSequence<T, A> {
+    /// Unlike a plain [`Tween`], a sequence **clamps** `t` to `[0, 1]`:
+    /// overshoot (elastic/spring `t` outside the unit range) saturates at the
+    /// first/last item's endpoint rather than extrapolating, because there is
+    /// no meaningful item to attribute out-of-range progress to.
     fn transform(&self, t: f32) -> T {
         let t = t.clamp(0.0, 1.0);
 

--- a/crates/flui-animation/src/tween_types.rs
+++ b/crates/flui-animation/src/tween_types.rs
@@ -216,6 +216,60 @@ impl<T, A: Animatable<T>> Animatable<T> for ReverseTween<T, A> {
 /// Tween between two colors. Alias for `Tween<Color>`.
 pub type ColorTween = Tween<Color>;
 
+/// A color tween that interpolates through Oklab space (perceptually
+/// uniform) instead of componentwise sRGB.
+///
+/// Flutter has no equivalent: `Color.lerp` averages gamma-encoded channels,
+/// so cross-hue transitions pass through dark, gray midpoints (blue→yellow
+/// goes through mud). Interpolating in Oklab keeps perceived lightness and
+/// chroma steady across the whole transition.
+///
+/// Costs two color-space conversions per `transform` (`powf`/`cbrt` per
+/// channel); prefer [`ColorTween`] for near-identical endpoints or very hot
+/// paths. `t` is clamped to `[0, 1]` — extrapolating outside the segment in
+/// Oklab leaves the sRGB gamut almost immediately.
+///
+/// # Examples
+///
+/// ```
+/// use flui_animation::{Animatable, OklabColorTween};
+/// use flui_types::Color;
+///
+/// let tween = OklabColorTween::new(Color::rgb(0, 0, 255), Color::rgb(255, 255, 0));
+/// let perceptual_mid = tween.transform(0.5);
+/// let srgb_mid = Color::lerp(Color::rgb(0, 0, 255), Color::rgb(255, 255, 0), 0.5);
+/// // The perceptual path differs from the muddy componentwise-sRGB midpoint.
+/// assert_ne!(perceptual_mid, srgb_mid);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct OklabColorTween {
+    /// The color at the start of the animation.
+    pub begin: Color,
+    /// The color at the end of the animation.
+    pub end: Color,
+}
+
+impl OklabColorTween {
+    /// Creates a new perceptual color tween between `begin` and `end`.
+    #[must_use]
+    pub const fn new(begin: Color, end: Color) -> Self {
+        Self { begin, end }
+    }
+}
+
+impl Animatable<Color> for OklabColorTween {
+    fn transform(&self, t: f32) -> Color {
+        if t == 0.0 {
+            return self.begin;
+        }
+        if t == 1.0 {
+            return self.end;
+        }
+        Color::lerp_oklab(self.begin, self.end, t)
+    }
+}
+
 /// A tween that linearly interpolates between two sizes.
 ///
 /// Similar to Flutter's `SizeTween`.

--- a/crates/flui-interaction/CHANGELOG.md
+++ b/crates/flui-interaction/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning: per `docs/release.md` policy.
 
 ### Added
 
+- `ImpulseVelocityTracker` — Android's default fling-velocity strategy since 8.1 (AOSP `VelocityTracker.cpp` impulse model: kinetic-energy bookkeeping, from-rest boundary condition). Flutter ships least-squares only; impulse discounts stale samples on sharp deceleration, tracking the finger's final intent.
+- `OneEuroFilter` / `OneEuroFilter2D` — speed-adaptive low-pass for stylus/pointer smoothing (Casiez, Roussel & Vogel, CHI 2012) with the paper's recommended defaults (`min_cutoff=1.0`, `beta=0.007`, `d_cutoff=1.0`).
+- `GestureSettings::for_platform(TargetPlatform)` (runtime platform dispatch, Flutter `defaultTargetPlatform` model) + cfg-seeded `GestureSettings::native()`; `android_defaults()` (AOSP `ViewConfiguration`: 8 dp slop, 16 dp paging, 300 ms double-tap, 400 ms long-press, 50–8000 dp/s fling) and `ios_defaults()` (10 pt `allowableMovement`; extrapolated fields documented).
+- `DEFAULT_RESAMPLE_LOOKBACK` (38 ms) — Flutter's `samplingOffset` derivation, documented for callers driving `PointerEventResampler::sample`.
 - `EagerGestureRecognizer` — wins the arena on `add_pointer` (Flutter `eager.dart:42-68`). Use for `AndroidView` / `UiKitView` (HybridComposition) hit regions that must unconditionally absorb input.
 - `pub mod observability` with `GestureEvent` typed enum + `SPAN_RECOGNIZER` / `SPAN_ARENA` span-name constants + `pointer_event_kind` helper. `#[tracing::instrument]` on `RecognizerBase` and `GestureArena` hot paths; observability is now Definition-of-Done for any recogniser or arena change.
 - `MultiDragGestureRecognizer` — per-pointer drag with team / multiple handles (`multi_drag.rs`).
@@ -21,9 +25,21 @@ Versioning: per `docs/release.md` policy.
 - `TapGestureRecognizer` now routes Primary / Secondary / Tertiary (`PointerButton::Primary` / `Secondary` / `Auxiliary`) to per-button callback slots. `on_secondary_tap_down/up/cancel` and `on_tertiary_tap_down/up/cancel` added to `TapCallbacks`. Button mismatch on Up cancels the in-flight primary tap (Flutter `tap.dart::_checkUp`).
 - `VelocityTracker` gains `with_kind(PointerDeviceKind)` constructor + `get_fling_velocity` parity with Flutter. Legacy `velocity()` / `is_reliable()` shims kept for source compat.
 - `lsq_solver` factored into a reusable helper (regression math shared with `PointerEventResampler` and `VelocityTracker`).
-- drag recognisers split into `HorizontalDragGestureRecognizer` / `VerticalDragGestureRecognizer` / `PanGestureRecognizer` with `dragStartBehavior` and `multitouchDragStrategy` per-axis slop. `drag_variants` module added. Legacy `DragGestureRecognizer` is now an alias for the three-axis supertype.
+- drag recognisers split into `HorizontalDragGestureRecognizer` / `VerticalDragGestureRecognizer` / `PanGestureRecognizer` with `dragStartBehavior` and per-axis slop. `drag_variants` module added. Legacy `DragGestureRecognizer` is now an alias for the three-axis supertype.
+- `InputPredictor` maximum prediction horizon reduced 50 ms → 25 ms, aligned with Chromium's empirically validated `kMaxPredictionTime` (`ui/base/prediction/input_predictor.h`); longer horizons overshoot on direction changes.
+
+### Removed
+
+- **Breaking:** `MultitouchDragStrategy` (enum, `with_multitouch_drag_strategy`, `multitouch_drag_strategy`). The drag recognizer is a single-sequence state machine with no per-pointer map, so `AverageBoundaryPointers`/`SumAllPointers` were silent no-ops behind a public builder — a contract violation. The surface returns together with a real multi-pointer drag implementation.
 
 ### Fixed
+
+- **Deadlock:** `LongPressGestureRecognizer::handle_up` held the gesture-state lock across `stop_tracking()`; the arena sweep can synchronously reject the same recognizer, whose cancel path re-locks — guaranteed hang on lift-before-deadline with a competitor in the arena.
+- **Deadlock:** `GestureArenaTeam` dispatched member callbacks while holding the combiner lock (`resolve`/`accept_gesture`/`reject_gesture`); a rejected recognizer's cancel path re-enters the same combiner via the team's arena wrapper. Notifications are now computed under the lock and dispatched after the guard drops.
+- **Leak:** `GestureArenaTeam` held a strong `Arc` to itself (`self_ref`), a write-only reference cycle keeping every team alive for the process lifetime.
+- `ScaleGestureRecognizer` routed every Move/Up to the primary pointer, so the second finger never updated its own slot and two-finger pinch produced no scale updates. Events are now routed by the event's own pointer id (Flutter `scale.dart` parity).
+- `DoubleTapGestureRecognizer` inter-tap timeout now fires `on_double_tap_cancel` and releases the arena (Flutter `_reset → _checkCancel` parity); reset is atomic under one lock.
+- `PointerEventResampler` computed interpolated positions but never emitted the synthesized Move while still advancing `last_position`; it now emits per Flutter `resampler.dart`.
 
 - `LongPressGestureRecognizer::did_exceed_deadline` now calls `try_fire_timer` before resolving Accepted so `on_long_press_start` fires (was resolving without firing the start callback).
 - pre-existing bug sweep — `events.rs::make_down_event_for_id` is now `#[cfg(any(test, feature = "testing"))]`-gated (was the only `*_for_id` family member shipping test-only code into the release binary); rustdoc hard-gate (`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`) is green; `EagerGestureRecognizer` added to the crate-root `AssertSendSync` static-assertion block; `force_press.rs::with_start_pressure` / `with_peak_pressure` now `debug_assert!(Arc::strong_count == 1)` to document the builder-call-immediately-after-`Arc::new` contract; `processing::prediction::predict` and `processing::resampler` refactored from post-guard `.unwrap()` to `let-else`; `tap_and_drag.rs` replaces a production `expect` with a `let-else` + `tracing::warn!` recovery.

--- a/crates/flui-interaction/README.md
+++ b/crates/flui-interaction/README.md
@@ -398,3 +398,19 @@ All types are `Send + Sync`:
 - [docs/HIT_TESTING.md](docs/HIT_TESTING.md) — Hit testing guide
 - [docs/GESTURES.md](docs/GESTURES.md) — Gesture recognition details
 - [docs/INTEGRATION.md](docs/INTEGRATION.md) — Integration with other crates
+
+---
+
+## Beyond Flutter
+
+Input-processing capabilities Flutter does not ship, each implemented from
+the canonical published source:
+
+| Capability | Source | API |
+|---|---|---|
+| Impulse fling velocity (Android's default strategy since 8.1) | AOSP `VelocityTracker.cpp` | `processing::ImpulseVelocityTracker` |
+| Speed-adaptive pointer smoothing | 1€ filter, Casiez et al., CHI 2012 | `processing::OneEuroFilter`, `OneEuroFilter2D` |
+| Platform-faithful gesture presets with runtime dispatch | AOSP `ViewConfiguration` / `UIGestureRecognizer` | `GestureSettings::for_platform`, `native`, `android_defaults`, `ios_defaults` |
+| Evidence-capped pointer prediction (25 ms) | Chromium `input_predictor.h` | `processing::InputPredictor` |
+
+See `examples/pointer_filtering.rs`.

--- a/crates/flui-interaction/benches/velocity_tracker_bench.rs
+++ b/crates/flui-interaction/benches/velocity_tracker_bench.rs
@@ -21,7 +21,9 @@ use std::hint::black_box;
 use std::time::{Duration, Instant};
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use flui_interaction::processing::{IosFlingVelocityTracker, VelocityTracker};
+use flui_interaction::processing::{
+    ImpulseVelocityTracker, IosFlingVelocityTracker, OneEuroFilter2D, VelocityTracker,
+};
 use flui_types::geometry::{Offset, Pixels};
 use flui_types::gestures::PointerDeviceKind;
 
@@ -152,6 +154,42 @@ fn bench_ios_estimate(c: &mut Criterion) {
     });
 }
 
+/// Benchmark the AOSP impulse strategy on the same full 20-sample buffer as
+/// the LSQ bench, so the two strategies price against each other directly.
+fn bench_estimate_impulse(c: &mut Criterion) {
+    let samples = black_box(linear_swipe(20, 100, 1000.0));
+    c.bench_function("ImpulseVelocityTracker::estimate (20 samples)", |b| {
+        b.iter_batched(
+            || {
+                let mut tracker = ImpulseVelocityTracker::with_kind(PointerDeviceKind::Touch);
+                for (t, p) in &samples {
+                    tracker.add_position(*t, *p);
+                }
+                tracker
+            },
+            |tracker| black_box(tracker.get_velocity_estimate()),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+}
+
+/// Benchmark one One-Euro filter step — the per-pointer-move cost when the
+/// filter sits in the input path (must be well under the 100 ns slot-write
+/// budget class, it is pure arithmetic).
+fn bench_one_euro_step(c: &mut Criterion) {
+    let start = Instant::now();
+    let mut filter = OneEuroFilter2D::default();
+    let mut i = 0u32;
+    c.bench_function("OneEuroFilter2D::filter (per move)", |b| {
+        b.iter(|| {
+            i = i.wrapping_add(1);
+            let t = start + Duration::from_millis(8) * i;
+            let p = Offset::new(Pixels(i as f32 * 0.5), Pixels(50.0));
+            black_box(filter.filter(black_box(t), black_box(p)))
+        });
+    });
+}
+
 criterion_group!(
     velocity_benches,
     bench_estimate_lsq,
@@ -159,5 +197,7 @@ criterion_group!(
     bench_estimate_repeated,
     bench_add_position,
     bench_ios_estimate,
+    bench_estimate_impulse,
+    bench_one_euro_step,
 );
 criterion_main!(velocity_benches);

--- a/crates/flui-interaction/examples/pointer_filtering.rs
+++ b/crates/flui-interaction/examples/pointer_filtering.rs
@@ -1,0 +1,94 @@
+//! Pointer-input processing: One Euro filtering + impulse velocity tracking.
+//!
+//! Feeds a synthetic noisy drag-then-decelerate gesture through:
+//!
+//! 1. [`OneEuroFilter2D`] — speed-adaptive jitter removal (Casiez CHI 2012);
+//! 2. [`ImpulseVelocityTracker`] (Android's default fling strategy) next to
+//!    the least-squares [`VelocityTracker`] (Flutter's strategy), showing how
+//!    the impulse model discounts stale samples after a sharp deceleration.
+//!
+//! Run with: `cargo run -p flui-interaction --example pointer_filtering`
+
+use std::time::{Duration, Instant};
+
+use flui_interaction::processing::{ImpulseVelocityTracker, OneEuroFilter2D, VelocityTracker};
+use flui_types::geometry::{Offset, Pixels};
+
+fn main() {
+    println!("FLUI pointer filtering example\n");
+
+    // ------------------------------------------------------------------
+    // 1. One Euro Filter: jittery slow hover, then a fast stroke.
+    // ------------------------------------------------------------------
+    println!("1. One Euro Filter (slow jitter suppressed, fast motion tracked):");
+    let mut filter = OneEuroFilter2D::default();
+    let t0 = Instant::now();
+    let dt = Duration::from_millis(8); // ~120 Hz input
+
+    println!("   slow phase (true position 100, ±1 px sensor jitter):");
+    let mut t = t0;
+    for i in 0..24 {
+        let jitter = if i % 2 == 0 { 1.0 } else { -1.0 };
+        let raw = Offset::new(Pixels(100.0 + jitter), Pixels(50.0));
+        let smoothed = filter.filter(t, raw);
+        if i % 8 == 7 {
+            println!(
+                "     raw x={:7.2}  filtered x={:7.2}",
+                raw.dx.get(),
+                smoothed.dx.get()
+            );
+        }
+        t += dt;
+    }
+
+    println!("   fast phase (2000 px/s stroke — lag stays small):");
+    let mut x = 100.0_f32;
+    for i in 0..24 {
+        x += 2000.0 * dt.as_secs_f32();
+        let raw = Offset::new(Pixels(x), Pixels(50.0));
+        let smoothed = filter.filter(t, raw);
+        if i % 8 == 7 {
+            println!(
+                "     raw x={:7.2}  filtered x={:7.2}  (lag {:5.2} px)",
+                raw.dx.get(),
+                smoothed.dx.get(),
+                raw.dx.get() - smoothed.dx.get()
+            );
+        }
+        t += dt;
+    }
+
+    // ------------------------------------------------------------------
+    // 2. Impulse vs least-squares velocity on a decelerating release.
+    // ------------------------------------------------------------------
+    println!("\n2. Fling velocity after a sharp deceleration:");
+    println!("   gesture: 4 intervals at 2000 px/s, then 5 intervals at 200 px/s\n");
+
+    let mut impulse = ImpulseVelocityTracker::default();
+    let mut lsq = VelocityTracker::new();
+
+    let mut pos = 0.0_f32;
+    let mut t = Instant::now();
+    for _ in 0..4 {
+        impulse.add_position(t, Offset::new(Pixels(pos), Pixels(0.0)));
+        lsq.add_position(t, Offset::new(Pixels(pos), Pixels(0.0)));
+        pos += 20.0; // 20 px / 10 ms = 2000 px/s
+        t += Duration::from_millis(10);
+    }
+    for _ in 0..6 {
+        impulse.add_position(t, Offset::new(Pixels(pos), Pixels(0.0)));
+        lsq.add_position(t, Offset::new(Pixels(pos), Pixels(0.0)));
+        pos += 2.0; // 2 px / 10 ms = 200 px/s
+        t += Duration::from_millis(10);
+    }
+
+    let impulse_v = impulse.get_velocity().pixels_per_second.dx.get();
+    let lsq_v = lsq.get_velocity().pixels_per_second.dx.get();
+    println!("   impulse (Android default): {impulse_v:8.1} px/s");
+    println!("   least-squares (Flutter):   {lsq_v:8.1} px/s");
+    println!(
+        "\n   The impulse model weights each interval by the velocity CHANGE it\n   \
+         represents, so the release velocity tracks the finger's final intent\n   \
+         instead of averaging the whole window."
+    );
+}

--- a/crates/flui-interaction/src/arena/team.rs
+++ b/crates/flui-interaction/src/arena/team.rs
@@ -76,10 +76,19 @@ impl TeamEntry {
     /// - Accepted: The captain (or this member) wins on behalf of the team
     /// - Rejected: The member is removed from the team; if empty, team rejects
     pub fn resolve(&self, disposition: GestureDisposition) {
-        // Get the entry to resolve while holding the lock, then resolve outside
-        let entry_to_resolve = self.combiner.lock().resolve(&self.member, disposition);
+        // Compute state transitions under the lock; dispatch every member
+        // callback and the arena resolution AFTER the guard drops. A member's
+        // reject_gesture commonly re-enters this combiner (e.g. recognizer ->
+        // handle_cancel -> stop_tracking -> arena.sweep -> the team's wrapper),
+        // and parking_lot mutexes are non-reentrant.
+        let (to_reject, entry_to_resolve) = {
+            let mut combiner = self.combiner.lock();
+            combiner.resolve(&self.member, disposition)
+        };
 
-        // Resolve arena entry outside the lock to avoid deadlock
+        if let Some((member, pointer)) = to_reject {
+            member.reject_gesture(pointer);
+        }
         if let Some((entry, disp)) = entry_to_resolve {
             entry.resolve(disp);
         }
@@ -134,15 +143,21 @@ impl CombiningMember {
     }
 
     /// Resolve a member with the given disposition.
-    /// Returns an optional entry to resolve (to avoid holding lock during arena
-    /// call).
+    ///
+    /// Pure state transition: returns the member to reject and/or the arena
+    /// entry to resolve so the caller can dispatch both AFTER releasing the
+    /// combiner lock (member callbacks re-enter the combiner).
+    #[allow(clippy::type_complexity)] // local return plumbing, not public API
     fn resolve(
         &mut self,
         member: &Arc<dyn GestureArenaMember>,
         disposition: GestureDisposition,
-    ) -> Option<(GestureArenaEntry, GestureDisposition)> {
+    ) -> (
+        Option<(Arc<dyn GestureArenaMember>, PointerId)>,
+        Option<(GestureArenaEntry, GestureDisposition)>,
+    ) {
         if self.resolved {
-            return None;
+            return (None, None);
         }
 
         match disposition {
@@ -151,31 +166,40 @@ impl CombiningMember {
                 self.winner = Some(self.team.captain().unwrap_or_else(|| member.clone()));
 
                 // Return entry to resolve outside lock
-                self.entry
-                    .clone()
-                    .map(|e| (e, GestureDisposition::Accepted))
+                (
+                    None,
+                    self.entry
+                        .clone()
+                        .map(|e| (e, GestureDisposition::Accepted)),
+                )
             }
             GestureDisposition::Rejected => {
-                // Remove member from team
+                // Remove member from team; the caller notifies it outside the
+                // lock.
                 self.members.retain(|m| !Arc::ptr_eq(m, member));
-                member.reject_gesture(self.pointer);
+                let to_reject = Some((member.clone(), self.pointer));
 
                 // If no members left, reject the whole team
-                if self.members.is_empty() {
+                let entry = if self.members.is_empty() {
                     self.entry
                         .clone()
                         .map(|e| (e, GestureDisposition::Rejected))
                 } else {
                     None
-                }
+                };
+                (to_reject, entry)
             }
         }
     }
 
     /// Called when the team wins in the arena.
-    fn accept_gesture(&mut self) {
+    ///
+    /// Returns the member notifications to dispatch after the combiner lock
+    /// is released.
+    fn accept_gesture(&mut self) -> PendingTeamNotifications {
+        let mut pending = PendingTeamNotifications::new(self.pointer);
         if self.resolved {
-            return;
+            return pending;
         }
         self.resolved = true;
 
@@ -193,39 +217,77 @@ impl CombiningMember {
             .zip(captain.as_ref())
             .is_some_and(|(w, c)| Arc::ptr_eq(w, c));
 
-        // Notify all members - they all lose except if one of them is the winner
+        // Queue all member notifications - they all lose except the winner
         for member in &self.members {
             let is_winner = winner.as_ref().is_some_and(|w| Arc::ptr_eq(w, member));
             if is_winner {
-                member.accept_gesture(self.pointer);
+                pending.accepts.push(member.clone());
             } else {
-                member.reject_gesture(self.pointer);
+                pending.rejects.push(member.clone());
             }
         }
 
         // If winner is the captain (not in members), notify captain separately
-        if winner_is_captain && let Some(ref captain) = captain {
-            captain.accept_gesture(self.pointer);
+        if winner_is_captain && let Some(captain) = captain {
+            pending.accepts.push(captain);
         }
 
         // Remove from team's combiners
         self.team.remove_combiner(self.pointer);
+        pending
     }
 
     /// Called when the team loses in the arena.
-    fn reject_gesture(&mut self) {
+    ///
+    /// Returns the member notifications to dispatch after the combiner lock
+    /// is released.
+    fn reject_gesture(&mut self) -> PendingTeamNotifications {
+        let mut pending = PendingTeamNotifications::new(self.pointer);
         if self.resolved {
-            return;
+            return pending;
         }
         self.resolved = true;
 
-        // Reject all members
-        for member in &self.members {
-            member.reject_gesture(self.pointer);
-        }
+        // Queue rejection for all members
+        pending.rejects.extend(self.members.iter().cloned());
 
         // Remove from team's combiners
         self.team.remove_combiner(self.pointer);
+        pending
+    }
+}
+
+/// Member notifications computed under the combiner lock and dispatched after
+/// it is released.
+///
+/// Member callbacks routinely re-enter the combiner (a rejected recognizer's
+/// `handle_cancel` path sweeps the arena, which resolves this team's wrapper,
+/// which locks the same combiner); dispatching under the lock would deadlock
+/// on parking_lot's non-reentrant mutex.
+struct PendingTeamNotifications {
+    pointer: PointerId,
+    /// At most the winner and (separately) the captain.
+    accepts: SmallVec<[Arc<dyn GestureArenaMember>; 2]>,
+    rejects: SmallVec<[Arc<dyn GestureArenaMember>; 4]>,
+}
+
+impl PendingTeamNotifications {
+    fn new(pointer: PointerId) -> Self {
+        Self {
+            pointer,
+            accepts: SmallVec::new(),
+            rejects: SmallVec::new(),
+        }
+    }
+
+    /// Fire all queued notifications. Call WITHOUT the combiner lock held.
+    fn dispatch(self) {
+        for member in self.accepts {
+            member.accept_gesture(self.pointer);
+        }
+        for member in self.rejects {
+            member.reject_gesture(self.pointer);
+        }
     }
 }
 
@@ -243,11 +305,13 @@ impl crate::sealed::arena_member::Sealed for CombiningMemberWrapper {}
 
 impl GestureArenaMember for CombiningMemberWrapper {
     fn accept_gesture(&self, _pointer: PointerId) {
-        self.combiner.lock().accept_gesture();
+        let pending = self.combiner.lock().accept_gesture();
+        pending.dispatch();
     }
 
     fn reject_gesture(&self, _pointer: PointerId) {
-        self.combiner.lock().reject_gesture();
+        let pending = self.combiner.lock().reject_gesture();
+        pending.dispatch();
     }
 }
 
@@ -280,8 +344,6 @@ pub struct GestureArenaTeam {
     combiners: DashMap<PointerId, Arc<Mutex<CombiningMember>>>,
     /// Captain that wins on behalf of the team.
     captain: Mutex<Option<Arc<dyn GestureArenaMember>>>,
-    /// Self-reference for creating combiners.
-    self_ref: Mutex<Option<Arc<GestureArenaTeam>>>,
 }
 
 impl GestureArenaTeam {
@@ -289,13 +351,10 @@ impl GestureArenaTeam {
     ///
     /// When the team wins, the first member added wins.
     pub fn new() -> Arc<Self> {
-        let team = Arc::new(Self {
+        Arc::new(Self {
             combiners: DashMap::new(),
             captain: Mutex::new(None),
-            self_ref: Mutex::new(None),
-        });
-        *team.self_ref.lock() = Some(team.clone());
-        team
+        })
     }
 
     /// Create a new gesture arena team with a captain.
@@ -303,13 +362,10 @@ impl GestureArenaTeam {
     /// When any team member wins, the captain receives the gesture.
     /// This is useful for forwarding gestures (e.g., to native views).
     pub fn with_captain(captain: Arc<dyn GestureArenaMember>) -> Arc<Self> {
-        let team = Arc::new(Self {
+        Arc::new(Self {
             combiners: DashMap::new(),
             captain: Mutex::new(Some(captain)),
-            self_ref: Mutex::new(None),
-        });
-        *team.self_ref.lock() = Some(team.clone());
-        team
+        })
     }
 
     /// Get the team's captain (if any).
@@ -394,7 +450,6 @@ impl Default for GestureArenaTeam {
         Self {
             combiners: DashMap::new(),
             captain: Mutex::new(None),
-            self_ref: Mutex::new(None),
         }
     }
 }
@@ -457,6 +512,67 @@ mod tests {
         let team = GestureArenaTeam::new();
         assert!(team.is_empty());
         assert!(team.captain().is_none());
+    }
+
+    #[test]
+    fn team_is_dropped_when_last_handle_goes_away() {
+        // Regression: the team used to store a strong Arc to itself
+        // (`self_ref`), a reference cycle that kept every team alive for the
+        // process lifetime.
+        let team = GestureArenaTeam::new();
+        let weak = Arc::downgrade(&team);
+        drop(team);
+        assert!(
+            weak.upgrade().is_none(),
+            "GestureArenaTeam must not keep itself alive via a self-cycle"
+        );
+    }
+
+    #[test]
+    fn reentrant_resolve_from_reject_callback_does_not_deadlock() {
+        // Regression: CombiningMember::resolve used to fire
+        // member.reject_gesture while holding the combiner lock. A member
+        // whose rejection handler re-enters the team (here: resolving its own
+        // entry again, as a recognizer's cancel path does via arena.sweep)
+        // would self-deadlock on the non-reentrant mutex.
+        struct Reentrant {
+            entry: Mutex<Option<TeamEntry>>,
+            rejected: AtomicBool,
+        }
+        impl crate::sealed::arena_member::Sealed for Reentrant {}
+        impl GestureArenaMember for Reentrant {
+            fn accept_gesture(&self, _pointer: PointerId) {}
+            fn reject_gesture(&self, _pointer: PointerId) {
+                self.rejected.store(true, Ordering::SeqCst);
+                // Re-enter the same combiner from inside the callback. The
+                // guard must drop before resolve() so the nested second
+                // rejection callback can re-acquire OUR OWN entry mutex —
+                // the deadlock under test is the combiner's, not this one.
+                let taken = self.entry.lock().take();
+                if let Some(entry) = taken {
+                    entry.resolve(GestureDisposition::Rejected);
+                }
+            }
+        }
+
+        let arena = GestureArena::new();
+        let team = GestureArenaTeam::new();
+        let pointer = PointerId::new(7).expect("nonzero pointer id");
+
+        let reentrant = Arc::new(Reentrant {
+            entry: Mutex::new(None),
+            rejected: AtomicBool::new(false),
+        });
+        let other = MockMember::new(1);
+
+        let entry = team.add(pointer, reentrant.clone(), &arena);
+        let _other_entry = team.add(pointer, other.clone(), &arena);
+        *reentrant.entry.lock() = Some(team.add(pointer, reentrant.clone(), &arena));
+
+        // Rejecting the member fires reject_gesture, which re-enters the
+        // combiner; must complete without deadlocking.
+        entry.resolve(GestureDisposition::Rejected);
+        assert!(reentrant.rejected.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/crates/flui-interaction/src/processing/mod.rs
+++ b/crates/flui-interaction/src/processing/mod.rs
@@ -22,6 +22,7 @@
 //! ```
 
 mod lsq_solver;
+mod one_euro;
 mod prediction;
 mod raw_input;
 mod resampler;
@@ -31,10 +32,12 @@ mod velocity;
 // `lsq_solver` (LeastSquaresSolver / PolynomialFit / MAX_*) is crate-internal
 // numerical machinery shared by the velocity tracker; it is intentionally NOT
 // re-exported, so the public API is not pinned to the solver's internals.
+pub use one_euro::{OneEuroFilter, OneEuroFilter2D};
 pub use prediction::{InputPredictor, PredictedPosition, PredictionConfig};
 pub use raw_input::{InputMode, RawInputHandler, RawPointerEvent};
-pub use resampler::PointerEventResampler;
+pub use resampler::{DEFAULT_RESAMPLE_LOOKBACK, PointerEventResampler};
 pub use sampling_clock::{DEFAULT_SAMPLE_PERIOD, SamplingClock};
 pub use velocity::{
-    IosFlingVelocityTracker, MacosFlingVelocityTracker, Velocity, VelocityEstimate, VelocityTracker,
+    ImpulseVelocityTracker, IosFlingVelocityTracker, MacosFlingVelocityTracker, Velocity,
+    VelocityEstimate, VelocityTracker,
 };

--- a/crates/flui-interaction/src/processing/one_euro.rs
+++ b/crates/flui-interaction/src/processing/one_euro.rs
@@ -1,0 +1,256 @@
+//! One Euro Filter — adaptive low-pass filtering for noisy pointer input.
+//!
+//! Implements Casiez, Roussel & Vogel, *"1€ Filter: A Simple Speed-based
+//! Low-pass Filter for Noisy Input in Interactive Systems"*, CHI 2012
+//! (<https://gery.casiez.net/1euro/>). The filter adapts its cutoff to the
+//! signal's speed:
+//!
+//! ```text
+//! α(fc, Te) = 2π·fc·Te / (1 + 2π·fc·Te)
+//! fc        = mincutoff + β·|dx̂|
+//! ```
+//!
+//! - at low speeds a low cutoff suppresses jitter (stylus hover, slow drag);
+//! - at high speeds the cutoff rises with the filtered derivative, so fast
+//!   strokes track with minimal lag.
+//!
+//! This is the standard smoothing filter for stylus/ink, AR/VR pointing, and
+//! cursor stabilization. Neither Flutter nor any Rust UI framework ships
+//! one in its input pipeline.
+//!
+//! # Tuning (from the paper)
+//!
+//! 1. Set `beta = 0`, adjust `min_cutoff` until slow-motion jitter is gone.
+//! 2. Increase `beta` until fast motion lags acceptably little.
+//!
+//! Defaults here (`min_cutoff = 1.0 Hz`, `beta = 0.007`, `d_cutoff = 1.0 Hz`)
+//! are the paper's recommended starting point for 60–120 Hz pointer input.
+
+use std::time::Instant;
+
+use flui_types::geometry::{Offset, Pixels};
+
+/// Smoothing factor for a first-order low-pass at cutoff `fc` (Hz) and
+/// sampling period `te` (seconds).
+#[inline]
+fn smoothing_alpha(fc: f32, te: f32) -> f32 {
+    let r = 2.0 * core::f32::consts::PI * fc * te;
+    r / (1.0 + r)
+}
+
+/// One-dimensional 1€ filter.
+///
+/// Instantiate one per axis (the filter is scalar); see [`OneEuroFilter2D`]
+/// for the pointer-position convenience wrapper.
+#[derive(Debug, Clone, Copy)]
+pub struct OneEuroFilter {
+    /// Minimum cutoff frequency (Hz). Lower = less jitter, more lag at rest.
+    pub min_cutoff: f32,
+    /// Speed coefficient. Higher = less lag during fast motion.
+    pub beta: f32,
+    /// Cutoff for the derivative low-pass (Hz). Rarely tuned; 1 Hz default.
+    pub d_cutoff: f32,
+    /// Last filtered value (`x̂`).
+    x_prev: Option<f32>,
+    /// Last filtered derivative (`dx̂`), units/second.
+    dx_prev: f32,
+}
+
+impl Default for OneEuroFilter {
+    fn default() -> Self {
+        Self::new(1.0, 0.007, 1.0)
+    }
+}
+
+impl OneEuroFilter {
+    /// Create a filter with explicit parameters (see module docs for tuning).
+    #[must_use]
+    pub fn new(min_cutoff: f32, beta: f32, d_cutoff: f32) -> Self {
+        Self {
+            min_cutoff,
+            beta,
+            d_cutoff,
+            x_prev: None,
+            dx_prev: 0.0,
+        }
+    }
+
+    /// Reset the filter state (e.g. on pointer-down of a new stroke).
+    pub fn reset(&mut self) {
+        self.x_prev = None;
+        self.dx_prev = 0.0;
+    }
+
+    /// Filter a sample taken `te` seconds after the previous one.
+    ///
+    /// The first sample initializes the filter and is returned unchanged.
+    /// Non-positive `te` (duplicate timestamp) returns the previous filtered
+    /// value without state corruption.
+    pub fn filter(&mut self, x: f32, te: f32) -> f32 {
+        let Some(x_prev) = self.x_prev else {
+            self.x_prev = Some(x);
+            self.dx_prev = 0.0;
+            return x;
+        };
+        if te <= 0.0 {
+            return x_prev;
+        }
+
+        // Filtered derivative: raw slope against the PREVIOUS FILTERED value
+        // (per the paper — using the raw previous sample would re-amplify
+        // the very noise being removed).
+        let dx = (x - x_prev) / te;
+        let a_d = smoothing_alpha(self.d_cutoff, te);
+        let dx_hat = a_d * dx + (1.0 - a_d) * self.dx_prev;
+
+        // Speed-adaptive cutoff.
+        let fc = self.min_cutoff + self.beta * dx_hat.abs();
+        let a = smoothing_alpha(fc, te);
+        let x_hat = a * x + (1.0 - a) * x_prev;
+
+        self.x_prev = Some(x_hat);
+        self.dx_prev = dx_hat;
+        x_hat
+    }
+}
+
+/// Two-dimensional 1€ filter for pointer positions.
+///
+/// Owns an X and a Y [`OneEuroFilter`] plus the previous timestamp, so the
+/// caller only feeds `(time, position)` pairs:
+///
+/// ```
+/// use std::time::{Duration, Instant};
+///
+/// use flui_interaction::processing::OneEuroFilter2D;
+/// use flui_types::geometry::{Offset, Pixels};
+///
+/// let mut filter = OneEuroFilter2D::default();
+/// let t0 = Instant::now();
+/// let p0 = filter.filter(t0, Offset::new(Pixels(10.0), Pixels(10.0)));
+/// assert_eq!(p0.dx.get(), 10.0); // first sample passes through
+/// let _p1 = filter.filter(
+///     t0 + Duration::from_millis(8),
+///     Offset::new(Pixels(10.4), Pixels(9.8)), // sensor jitter
+/// );
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OneEuroFilter2D {
+    x: OneEuroFilter,
+    y: OneEuroFilter,
+    last_time: Option<Instant>,
+}
+
+impl OneEuroFilter2D {
+    /// Create with explicit parameters applied to both axes.
+    #[must_use]
+    pub fn new(min_cutoff: f32, beta: f32, d_cutoff: f32) -> Self {
+        Self {
+            x: OneEuroFilter::new(min_cutoff, beta, d_cutoff),
+            y: OneEuroFilter::new(min_cutoff, beta, d_cutoff),
+            last_time: None,
+        }
+    }
+
+    /// Reset both axes (new stroke).
+    pub fn reset(&mut self) {
+        self.x.reset();
+        self.y.reset();
+        self.last_time = None;
+    }
+
+    /// Filter a timestamped position sample.
+    pub fn filter(&mut self, time: Instant, position: Offset<Pixels>) -> Offset<Pixels> {
+        let te = self.last_time.map_or(0.0, |last| {
+            time.saturating_duration_since(last).as_secs_f32()
+        });
+        self.last_time = Some(time);
+        Offset::new(
+            Pixels(self.x.filter(position.dx.get(), te)),
+            Pixels(self.y.filter(position.dy.get(), te)),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn first_sample_passes_through() {
+        let mut f = OneEuroFilter::default();
+        assert_eq!(f.filter(42.0, 0.008), 42.0);
+    }
+
+    #[test]
+    fn static_jitter_is_suppressed() {
+        // Small oscillation around 100: the filtered output's wobble must be
+        // much smaller than the raw ±1 px jitter.
+        let mut f = OneEuroFilter::default();
+        let te = 1.0 / 120.0;
+        let _ = f.filter(100.0, te);
+        let mut min = f32::MAX;
+        let mut max = f32::MIN;
+        for i in 0..240 {
+            let noise = if i % 2 == 0 { 1.0 } else { -1.0 };
+            let out = f.filter(100.0 + noise, te);
+            if i > 60 {
+                min = min.min(out);
+                max = max.max(out);
+            }
+        }
+        let wobble = max - min;
+        assert!(
+            wobble < 0.4,
+            "±1 px alternating jitter must be attenuated, residual wobble {wobble}"
+        );
+    }
+
+    #[test]
+    fn fast_motion_tracks_with_bounded_lag() {
+        // A fast linear ramp (2000 px/s): the speed-adaptive cutoff must keep
+        // lag small relative to motion per-frame.
+        let mut f = OneEuroFilter::default();
+        let te = 1.0 / 120.0;
+        let mut x = 0.0_f32;
+        let mut out = 0.0_f32;
+        for _ in 0..120 {
+            x += 2000.0 * te;
+            out = f.filter(x, te);
+        }
+        let lag = x - out;
+        assert!(
+            lag < 2000.0 * te * 4.0,
+            "lag {lag} px must stay within a few frames of motion at speed"
+        );
+    }
+
+    #[test]
+    fn duplicate_timestamp_returns_previous() {
+        let mut f = OneEuroFilter::default();
+        let a = f.filter(10.0, 0.008);
+        let b = f.filter(999.0, 0.0);
+        assert_eq!(a, b, "zero-dt sample must not corrupt state");
+    }
+
+    #[test]
+    fn two_d_wrapper_filters_both_axes() {
+        let mut f = OneEuroFilter2D::default();
+        let t0 = Instant::now();
+        let p0 = f.filter(t0, Offset::new(Pixels(0.0), Pixels(0.0)));
+        assert_eq!(p0, Offset::new(Pixels(0.0), Pixels(0.0)));
+
+        // Jittery samples around (50, 50) settle near (50, 50).
+        let mut last = p0;
+        for i in 1..120 {
+            let jitter = if i % 2 == 0 { 0.8 } else { -0.8 };
+            last = f.filter(
+                t0 + Duration::from_millis(8 * i),
+                Offset::new(Pixels(50.0 + jitter), Pixels(50.0 - jitter)),
+            );
+        }
+        assert!((last.dx.get() - 50.0).abs() < 1.0);
+        assert!((last.dy.get() - 50.0).abs() < 1.0);
+    }
+}

--- a/crates/flui-interaction/src/processing/prediction.rs
+++ b/crates/flui-interaction/src/processing/prediction.rs
@@ -41,8 +41,13 @@ use super::velocity::{Velocity, VelocityTracker};
 // Constants
 // ============================================================================
 
-/// Maximum prediction time (50ms)
-const MAX_PREDICTION_TIME: Duration = Duration::from_millis(50);
+/// Maximum prediction time.
+///
+/// 25 ms is Chromium's empirically validated ceiling
+/// (`ui/base/prediction/input_predictor.h` `kMaxPredictionTime`): beyond it,
+/// prediction visibly overshoots on direction changes and jitters on noisy
+/// trajectories. Was 50 ms here before being aligned with that evidence.
+const MAX_PREDICTION_TIME: Duration = Duration::from_millis(25);
 
 /// Default prediction time (16ms - one frame at 60fps)
 const DEFAULT_PREDICTION_TIME: Duration = Duration::from_millis(16);
@@ -80,7 +85,9 @@ impl PredictionConfig {
     /// Create a config optimized for games (lower latency, less smoothing).
     pub fn for_games() -> Self {
         Self {
-            max_prediction_time: Duration::from_millis(32),
+            // Capped at the Chromium-validated 25 ms ceiling (was 32 ms):
+            // longer horizons overshoot on direction changes.
+            max_prediction_time: MAX_PREDICTION_TIME,
             use_acceleration: true,
             smoothing: 0.1,
         }

--- a/crates/flui-interaction/src/processing/resampler.rs
+++ b/crates/flui-interaction/src/processing/resampler.rs
@@ -228,7 +228,10 @@ impl PointerEventResampler {
             callback(event);
         }
 
-        // Interpolate if we have move events pending
+        // Interpolate if we have move events pending (Flutter parity:
+        // `resampler.dart _samplePointerPosition` synthesizes a Move at the
+        // interpolated position so recognisers advance smoothly between
+        // sensor samples instead of stalling until the next real event).
         if !inner.event_queue.is_empty()
             && inner.last_position.is_some()
             && let Some(next_event) = inner.event_queue.front()
@@ -250,14 +253,17 @@ impl PointerEventResampler {
 
                 // Only emit if position actually changed
                 if interpolated_pos != last_pos {
-                    // For interpolated events, we clone the original and update position
-                    // This is a simplified version - in production we'd create proper
-                    // interpolated PointerUpdate events
+                    // Synthesize the interpolated Move from the pending event:
+                    // same pointer/buttons/pressure state, position replaced.
+                    let mut interpolated = next_event.event.clone();
+                    if let PointerEvent::Move(update) = &mut interpolated {
+                        update.current.position = dpi::PhysicalPosition::new(
+                            f64::from(interpolated_pos.dx.get()),
+                            f64::from(interpolated_pos.dy.get()),
+                        );
+                    }
                     inner.last_position = Some(interpolated_pos);
-                    // Note: We skip emitting interpolated events for now since
-                    // creating new PointerUpdate requires complex state
-                    // copying. The resampler primarily
-                    // helps with timing alignment.
+                    callback(interpolated);
                 }
             }
         }
@@ -325,6 +331,64 @@ mod tests {
         assert!(!resampler.is_down());
         assert!(!resampler.has_pending_events());
         assert_eq!(resampler.pointer_id(), PointerId::PRIMARY);
+    }
+
+    #[test]
+    fn sample_emits_interpolated_move_between_pending_events() {
+        use crate::events::make_move_event_for_id;
+
+        // Regression: the interpolated position used to be computed (and
+        // last_position advanced) but the synthesized Move was never emitted,
+        // so recognisers stalled until the next real sensor event.
+        let resampler = PointerEventResampler::new(PointerId::PRIMARY);
+        resampler.start_tracking();
+
+        // First move is in the past relative to the sample time.
+        resampler.add_event(make_move_event_for_id(
+            PointerId::PRIMARY,
+            Offset::new(Pixels(0.0), Pixels(0.0)),
+            PointerType::Touch,
+        ));
+        std::thread::sleep(Duration::from_millis(3));
+        let sample_time = Instant::now();
+        std::thread::sleep(Duration::from_millis(3));
+        // Second move arrives after the sample time -> stays pending.
+        resampler.add_event(make_move_event_for_id(
+            PointerId::PRIMARY,
+            Offset::new(Pixels(100.0), Pixels(0.0)),
+            PointerType::Touch,
+        ));
+
+        let mut emitted: Vec<Offset<Pixels>> = Vec::new();
+        resampler.sample(
+            sample_time,
+            sample_time + Duration::from_millis(100),
+            |event| {
+                assert!(
+                    matches!(event, PointerEvent::Move(..)),
+                    "only Move events are expected in this scenario"
+                );
+                emitted.push(event.position());
+            },
+        );
+
+        // The real first move plus a synthesized interpolated move toward
+        // the pending event (the wide sample window clamps t to 1.0, so the
+        // interpolation lands on the pending position).
+        assert_eq!(
+            emitted.len(),
+            2,
+            "an interpolated Move must be emitted toward the pending event"
+        );
+        assert!(
+            (emitted[1].dx.get() - 100.0).abs() < 0.5,
+            "interpolated position must approach the pending event, got {:?}",
+            emitted[1]
+        );
+        assert!(
+            resampler.has_pending_events(),
+            "the future-timestamped event itself must remain queued"
+        );
     }
 
     #[test]

--- a/crates/flui-interaction/src/processing/resampler.rs
+++ b/crates/flui-interaction/src/processing/resampler.rs
@@ -58,6 +58,16 @@ use crate::{
     ids::PointerId,
 };
 
+/// Recommended lookback from the presentation/frame time to the resample
+/// target: `sample_time = frame_time - DEFAULT_RESAMPLE_LOOKBACK`.
+///
+/// 38 ms is Flutter's `GestureBinding.samplingOffset` default
+/// (`gestures/binding.dart`, `_defaultSamplingOffset = -38 ms`): two 60 Hz
+/// frames of worst-case input latency (33.3 ms) plus a 4.7 ms input-driver
+/// margin. On 120 Hz input/display pipelines a ~22 ms lookback is
+/// appropriate instead — pass your own offset to [`PointerEventResampler::sample`].
+pub const DEFAULT_RESAMPLE_LOOKBACK: Duration = Duration::from_millis(38);
+
 /// Maximum number of events to buffer (prevents unbounded memory growth)
 const MAX_BUFFERED_EVENTS: usize = 100;
 

--- a/crates/flui-interaction/src/processing/velocity.rs
+++ b/crates/flui-interaction/src/processing/velocity.rs
@@ -698,6 +698,225 @@ impl MacosFlingVelocityTracker {
     }
 }
 
+// ============================================================================
+// ImpulseVelocityTracker
+// ============================================================================
+
+/// Velocity tracker using Android's impulse strategy — the platform default
+/// since Android 8.1 (`ImpulseVelocityTrackerStrategy` in AOSP
+/// `frameworks/native/libs/input/VelocityTracker.cpp`).
+///
+/// Flutter does not ship this strategy at all; its pipeline is least-squares
+/// only. The impulse model treats the touch surface as a physical object the
+/// finger does work on, and recovers the release velocity from the
+/// accumulated kinetic energy:
+///
+/// ```text
+/// w   += (v_i − v(w)) · |v_i|        per sample interval, first interval ×0.5
+/// v(w) = sign(w) · √(2·|w|)
+/// ```
+///
+/// Compared to the quadratic least-squares fit, each interval's contribution
+/// is weighted by the velocity *change* it represents, so a sharp
+/// deceleration right before lift-off discounts older samples instead of
+/// being averaged away — flings track the finger's final intent, which is
+/// why AOSP made it the default. Use this tracker for Android-feel scroll
+/// and fling; use [`VelocityTracker`] (least-squares) for Flutter parity.
+///
+/// Sample window and stationary gates are shared with the other trackers
+/// (100 ms horizon, 40 ms assume-stopped).
+#[derive(Debug, Clone)]
+pub struct ImpulseVelocityTracker {
+    inner: VelocityTracker,
+}
+
+impl Default for ImpulseVelocityTracker {
+    fn default() -> Self {
+        Self::with_kind(PointerDeviceKind::Touch)
+    }
+}
+
+impl ImpulseVelocityTracker {
+    /// Construct an impulse tracker for the given pointer kind.
+    #[must_use]
+    pub fn with_kind(kind: PointerDeviceKind) -> Self {
+        Self {
+            inner: VelocityTracker::with_kind(kind),
+        }
+    }
+
+    /// Record a position.
+    pub fn add_position(&mut self, time: Instant, position: Offset<Pixels>) {
+        self.inner.add_position(time, position);
+    }
+
+    /// Reset all samples.
+    pub fn reset(&mut self) {
+        self.inner.reset();
+    }
+
+    /// The pointer kind this tracker is configured for.
+    #[inline]
+    pub fn kind(&self) -> PointerDeviceKind {
+        self.inner.kind()
+    }
+
+    /// AOSP: kinetic energy back to velocity, preserving direction.
+    /// `v = sign(w) · √2 · √|w|` (mass cancels).
+    #[inline]
+    fn kinetic_energy_to_velocity(work: f32) -> f32 {
+        core::f32::consts::SQRT_2 * work.abs().sqrt() * work.signum()
+    }
+
+    /// Impulse velocity over one axis. `positions`/`times` are chronological
+    /// (oldest first); both slices have the same length ≥ 2 and strictly
+    /// increasing times (enforced by the caller's sample walk).
+    fn impulse_axis(positions: &[f32], dts: &[f32]) -> f32 {
+        let mut work = 0.0_f32;
+        for i in 0..positions.len() - 1 {
+            let v_prev = Self::kinetic_energy_to_velocity(work);
+            let v_curr = (positions[i + 1] - positions[i]) / dts[i];
+            work += (v_curr - v_prev) * v_curr.abs();
+            if i == 0 {
+                // Boundary condition (AOSP "approach 2"): with no information
+                // before the window, assume the finger started from rest —
+                // halve the first interval's contribution.
+                work *= 0.5;
+            }
+        }
+        Self::kinetic_energy_to_velocity(work)
+    }
+
+    /// Velocity estimate via the impulse strategy.
+    ///
+    /// Returns `None` when no samples have been recorded; a zero estimate
+    /// when the pointer is stationary (40 ms without a sample) or fewer than
+    /// two samples fall inside the window.
+    pub fn get_velocity_estimate(&self) -> Option<VelocityEstimate> {
+        // Stationary gate, same contract as the other trackers.
+        if let Some(last) = self.inner.since_last_sample
+            && last.elapsed() >= ASSUME_POINTER_STOPPED
+        {
+            return Some(VelocityEstimate::new(
+                Offset::ZERO,
+                Offset::ZERO,
+                Duration::ZERO,
+                1.0,
+            ));
+        }
+
+        let newest = self.inner.samples[self.inner.index]?;
+
+        // Walk backwards through the window (100 ms horizon / 40 ms gap),
+        // collecting chronological samples for the impulse integration.
+        let mut chron: [Option<PointAtTime>; HISTORY_SIZE] = [None; HISTORY_SIZE];
+        let mut n = 0usize;
+        let mut cursor = self.inner.index;
+        let mut previous = newest;
+        for _ in 0..HISTORY_SIZE {
+            let Some(sample) = self.inner.samples[cursor] else {
+                break;
+            };
+            let age = newest.time.saturating_duration_since(sample.time);
+            let delta = previous.time.saturating_duration_since(sample.time);
+            if age > HORIZON || delta > ASSUME_POINTER_STOPPED {
+                break;
+            }
+            previous = sample;
+            chron[n] = Some(sample);
+            n += 1;
+            cursor = if cursor == 0 {
+                HISTORY_SIZE - 1
+            } else {
+                cursor - 1
+            };
+        }
+
+        let oldest = chron[n.saturating_sub(1)].unwrap_or(newest);
+        if n < 2 {
+            return Some(VelocityEstimate::new(
+                Offset::ZERO,
+                Offset::ZERO,
+                Duration::ZERO,
+                1.0,
+            ));
+        }
+
+        // Reverse into chronological order and strip zero-dt duplicates
+        // (the walk guarantees monotone times, but identical timestamps can
+        // occur on coarse clocks and would divide by zero).
+        let mut xs: [f32; HISTORY_SIZE] = [0.0; HISTORY_SIZE];
+        let mut ys: [f32; HISTORY_SIZE] = [0.0; HISTORY_SIZE];
+        let mut dts: [f32; HISTORY_SIZE] = [0.0; HISTORY_SIZE];
+        let mut m = 0usize;
+        let mut last_time: Option<Instant> = None;
+        for i in (0..n).rev() {
+            // Invariant: slots 0..n were written by the walk above.
+            let s = chron[i].expect("walk wrote chron[0..n]; i < n");
+            if let Some(prev_time) = last_time {
+                let dt = s.time.saturating_duration_since(prev_time).as_secs_f32();
+                if dt <= 0.0 {
+                    // Same-timestamp duplicate: keep the newer position only.
+                    xs[m - 1] = s.position.dx.get();
+                    ys[m - 1] = s.position.dy.get();
+                    continue;
+                }
+                dts[m - 1] = dt;
+            }
+            xs[m] = s.position.dx.get();
+            ys[m] = s.position.dy.get();
+            last_time = Some(s.time);
+            m += 1;
+        }
+        if m < 2 {
+            return Some(VelocityEstimate::new(
+                Offset::ZERO,
+                Offset::ZERO,
+                Duration::ZERO,
+                1.0,
+            ));
+        }
+
+        let vx = Self::impulse_axis(&xs[..m], &dts[..m - 1]);
+        let vy = Self::impulse_axis(&ys[..m], &dts[..m - 1]);
+
+        Some(VelocityEstimate::new(
+            newest.position - oldest.position,
+            Offset::new(Pixels(vx), Pixels(vy)),
+            newest.time.saturating_duration_since(oldest.time),
+            // The impulse model makes no fit-quality claim (AOSP reports the
+            // value unconditionally).
+            1.0,
+        ))
+    }
+
+    /// Velocity as a [`Velocity`].
+    pub fn get_velocity(&self) -> Velocity {
+        match self.get_velocity_estimate() {
+            Some(est) if est.pixels_per_second != Offset::ZERO => {
+                Velocity::new(est.pixels_per_second)
+            }
+            _ => Velocity::ZERO,
+        }
+    }
+
+    /// Velocity for fling detection. Same semantics as
+    /// [`VelocityTracker::get_fling_velocity`].
+    pub fn get_fling_velocity(&self, allow_slow: bool) -> Velocity {
+        let velocity = self.get_velocity();
+        if allow_slow {
+            return velocity;
+        }
+        const MIN_FLING_SPEED: f32 = 50.0;
+        if velocity.pixels_per_second.dx.get().abs() < MIN_FLING_SPEED
+            && velocity.pixels_per_second.dy.get().abs() < MIN_FLING_SPEED
+        {
+            return Velocity::ZERO;
+        }
+        velocity
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -719,6 +938,74 @@ mod tests {
                 (t, pos)
             })
             .collect()
+    }
+
+    #[test]
+    fn impulse_recovers_constant_velocity_exactly() {
+        // For uniform motion the impulse model is exact: the first interval
+        // contributes w = ½v², every later interval contributes zero, and
+        // v = √(2w) returns the original speed.
+        let mut tracker = ImpulseVelocityTracker::with_kind(PointerDeviceKind::Touch);
+        for (t, p) in linear_swipe_x(90, 10, 1000.0) {
+            tracker.add_position(t, p);
+        }
+        let v = tracker.get_velocity().pixels_per_second.dx.get();
+        assert!(
+            (v - 1000.0).abs() < 10.0,
+            "constant 1000 px/s must be recovered exactly, got {v}"
+        );
+    }
+
+    #[test]
+    fn impulse_preserves_direction() {
+        let mut tracker = ImpulseVelocityTracker::with_kind(PointerDeviceKind::Touch);
+        for (t, p) in linear_swipe_x(90, 10, -800.0) {
+            tracker.add_position(t, p);
+        }
+        let v = tracker.get_velocity().pixels_per_second.dx.get();
+        assert!(
+            (v + 800.0).abs() < 10.0,
+            "negative motion must produce negative velocity, got {v}"
+        );
+    }
+
+    #[test]
+    fn impulse_needs_two_samples() {
+        let tracker = ImpulseVelocityTracker::with_kind(PointerDeviceKind::Touch);
+        assert!(tracker.get_velocity_estimate().is_none());
+
+        let mut tracker = ImpulseVelocityTracker::with_kind(PointerDeviceKind::Touch);
+        tracker.add_position(Instant::now(), Offset::new(Pixels(5.0), Pixels(5.0)));
+        assert_eq!(tracker.get_velocity(), Velocity::ZERO);
+    }
+
+    #[test]
+    fn impulse_discounts_history_on_deceleration() {
+        // Fast motion followed by sharp deceleration: the estimate must land
+        // strictly below the initial speed (old samples are discounted by
+        // the energy bookkeeping), unlike a plain window average.
+        let mut tracker = ImpulseVelocityTracker::with_kind(PointerDeviceKind::Touch);
+        let start = Instant::now();
+        let mut x = 0.0_f32;
+        let mut t = start;
+        // 4 intervals at 2000 px/s.
+        for _ in 0..4 {
+            tracker.add_position(t, Offset::new(Pixels(x), Pixels(0.0)));
+            x += 20.0; // 20 px / 10 ms
+            t += Duration::from_millis(10);
+        }
+        // 5 intervals at 200 px/s.
+        for _ in 0..6 {
+            tracker.add_position(t, Offset::new(Pixels(x), Pixels(0.0)));
+            x += 2.0; // 2 px / 10 ms
+            t += Duration::from_millis(10);
+        }
+        let v = tracker.get_velocity().pixels_per_second.dx.get();
+        assert!(
+            v < 1900.0 && v > 200.0,
+            "deceleration must pull the estimate below the initial 2000 px/s \
+             and keep it above the terminal 200 px/s, got {v}"
+        );
     }
 
     #[test]

--- a/crates/flui-interaction/src/recognizers/double_tap.rs
+++ b/crates/flui-interaction/src/recognizers/double_tap.rs
@@ -277,10 +277,14 @@ impl DoubleTapGestureRecognizer {
                     callback(details);
                 }
 
-                // Reset and stop tracking
-                self.gesture_state.lock().phase = DoubleTapPhase::Ready;
-                self.gesture_state.lock().first_tap_position = None;
-                self.gesture_state.lock().first_tap_time = None;
+                // Reset and stop tracking (single lock scope: three separate
+                // lock() calls would let another thread observe partial state)
+                {
+                    let mut state = self.gesture_state.lock();
+                    state.phase = DoubleTapPhase::Ready;
+                    state.first_tap_position = None;
+                    state.first_tap_time = None;
+                }
                 self.state.stop_tracking();
             }
             _ => {}
@@ -332,10 +336,24 @@ impl DoubleTapGestureRecognizer {
         {
             let elapsed = Instant::now().duration_since(first_time);
             if elapsed > self.double_tap_timeout() {
-                // Timeout - reset to ready
+                // Timeout - reset to ready and cancel. Flutter parity:
+                // `DoubleTapGestureRecognizer` fires `onDoubleTapCancel` and
+                // releases its arena hold when the inter-tap window expires
+                // (`_reset` -> `_checkCancel`).
+                let position = state.first_tap_position.take().unwrap_or(Offset::ZERO);
+                let kind = state.device_kind.unwrap_or(PointerType::Touch);
                 state.phase = DoubleTapPhase::Ready;
-                state.first_tap_position = None;
                 state.first_tap_time = None;
+                drop(state); // Release lock before callback + arena release
+
+                if let Some(callback) = self.callbacks.lock().on_double_tap_cancel.clone() {
+                    callback(DoubleTapDetails {
+                        global_position: position,
+                        local_position: position,
+                        kind,
+                    });
+                }
+                self.state.reject();
                 return true;
             }
         }
@@ -487,6 +505,54 @@ mod tests {
 
         // Should have called callback
         assert!(*tapped.lock());
+    }
+
+    #[test]
+    fn timeout_fires_double_tap_cancel() {
+        // Flutter parity: when the inter-tap window expires after a completed
+        // first tap, `onDoubleTapCancel` must fire (previously the state was
+        // silently reset and the callback never ran).
+        let arena = GestureArena::new();
+        let cancelled = Arc::new(Mutex::new(false));
+        let cancelled_clone = cancelled.clone();
+
+        // Zero inter-tap window so check_timeout() expires immediately.
+        let settings = GestureSettings::new(
+            18.0,
+            36.0,
+            0.05,
+            100.0,
+            Duration::ZERO,
+            Duration::from_millis(500),
+            50.0,
+            8000.0,
+        );
+        let recognizer = DoubleTapGestureRecognizer::with_settings(arena, settings)
+            .with_on_double_tap_cancel(move |_details| {
+                *cancelled_clone.lock() = true;
+            });
+
+        let pointer = PointerId::new(2).expect("nonzero pointer id");
+        let position = Offset::new(px(100.0), px(100.0));
+
+        // Complete the first tap.
+        recognizer.add_pointer(pointer, position);
+        let up_event = make_up_event(position, PointerType::Touch);
+        recognizer.handle_event(&up_event);
+        assert_eq!(
+            recognizer.gesture_state.lock().phase,
+            DoubleTapPhase::WaitingForSecond
+        );
+
+        // Zero timeout: the window expires as soon as measurable time passes
+        // (the comparison is strict, so let the clock tick once).
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(recognizer.check_timeout(), "timeout must be reported");
+        assert!(
+            *cancelled.lock(),
+            "on_double_tap_cancel must fire when the inter-tap window expires"
+        );
+        assert_eq!(recognizer.gesture_state.lock().phase, DoubleTapPhase::Ready);
     }
 
     #[test]

--- a/crates/flui-interaction/src/recognizers/drag.rs
+++ b/crates/flui-interaction/src/recognizers/drag.rs
@@ -60,33 +60,6 @@ pub enum DragStartBehavior {
     Start,
 }
 
-/// Configures how a drag handles multiple active pointers on a multi-touch
-/// device.
-///
-/// Flutter parity: `gestures/recognizer.dart:64` `MultitouchDragStrategy`.
-///
-/// - [`LatestPointer`](Self::LatestPointer): only the most recently added
-///   pointer is tracked. When that pointer lifts, the next active pointer
-///   takes over. This is the Android default.
-/// - [`AverageBoundaryPointers`](Self::AverageBoundaryPointers): the average
-///   of the boundary pointers drives the delta. Typical iOS scroll behaviour.
-/// - [`SumAllPointers`](Self::SumAllPointers): the sum of all active pointer
-///   deltas. Two-finger scrolling moves twice as fast as one-finger.
-///
-/// Single-pointer drags are unaffected by this setting.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[non_exhaustive]
-pub enum MultitouchDragStrategy {
-    /// Only the most recently added pointer is tracked. Flutter default —
-    /// matches `DragGestureRecognizer.multitouchDragStrategy`.
-    #[default]
-    LatestPointer,
-    /// Average of the boundary (extremal) pointer deltas.
-    AverageBoundaryPointers,
-    /// Sum of all active pointer deltas.
-    SumAllPointers,
-}
-
 /// Details about drag down (pointer contact before drag starts)
 #[derive(Debug, Clone, PartialEq)]
 pub struct DragDownDetails {
@@ -192,12 +165,6 @@ pub struct DragGestureRecognizer {
     ///   position (Flutter default).
     start_behavior: DragStartBehavior,
 
-    /// Multi-touch aggregation policy.
-    ///
-    /// Single-pointer drags are unaffected; the policy only matters when
-    /// two or more pointers are active simultaneously.
-    multitouch_strategy: MultitouchDragStrategy,
-
     /// Callbacks
     callbacks: Arc<Mutex<DragCallbacks>>,
 
@@ -214,7 +181,6 @@ impl std::fmt::Debug for DragGestureRecognizer {
             .field("state", &self.state)
             .field("axis", &self.axis)
             .field("start_behavior", &self.start_behavior)
-            .field("multitouch_strategy", &self.multitouch_strategy)
             .field("drag_state", &*self.drag_state.lock())
             .field("settings", &self.settings.lock())
             .finish_non_exhaustive()
@@ -278,7 +244,6 @@ impl DragGestureRecognizer {
             state: RecognizerBase::new(arena),
             axis,
             start_behavior: DragStartBehavior::default(),
-            multitouch_strategy: MultitouchDragStrategy::default(),
             callbacks: Arc::new(Mutex::new(DragCallbacks::default())),
             drag_state: Arc::new(Mutex::new(DragState::default())),
             settings: Arc::new(Mutex::new(GestureSettings::default())),
@@ -295,7 +260,6 @@ impl DragGestureRecognizer {
             state: RecognizerBase::new(arena),
             axis,
             start_behavior: DragStartBehavior::default(),
-            multitouch_strategy: MultitouchDragStrategy::default(),
             callbacks: Arc::new(Mutex::new(DragCallbacks::default())),
             drag_state: Arc::new(Mutex::new(DragState::default())),
             settings: Arc::new(Mutex::new(settings)),
@@ -311,20 +275,6 @@ impl DragGestureRecognizer {
         // this is a cheap move, and it keeps the constructor pattern uniform.
         Arc::new(Self {
             start_behavior: behavior,
-            ..(*self).clone()
-        })
-    }
-
-    /// Configure the multi-touch aggregation policy.
-    ///
-    /// See [`MultitouchDragStrategy`] for the semantics. Default is
-    /// [`MultitouchDragStrategy::LatestPointer`].
-    pub fn with_multitouch_drag_strategy(
-        self: Arc<Self>,
-        strategy: MultitouchDragStrategy,
-    ) -> Arc<Self> {
-        Arc::new(Self {
-            multitouch_strategy: strategy,
             ..(*self).clone()
         })
     }
@@ -347,11 +297,6 @@ impl DragGestureRecognizer {
     /// Currently-configured [`DragStartBehavior`].
     pub fn drag_start_behavior(&self) -> DragStartBehavior {
         self.start_behavior
-    }
-
-    /// Currently-configured [`MultitouchDragStrategy`].
-    pub fn multitouch_drag_strategy(&self) -> MultitouchDragStrategy {
-        self.multitouch_strategy
     }
 
     /// Minimum drag distance for the current axis. Per-axis slop:
@@ -915,22 +860,6 @@ mod tests {
             make_move_event(Offset::new(Pixels(15.0), Pixels(50.0)), PointerType::Touch);
         recognizer.handle_event(&move_event2);
         assert!(*started.lock());
-    }
-
-    #[test]
-    fn multitouch_drag_strategy_default_is_latest() {
-        let arena = GestureArena::new();
-        let rec = DragGestureRecognizer::new(arena, DragAxis::Free);
-        assert_eq!(
-            rec.multitouch_drag_strategy(),
-            MultitouchDragStrategy::LatestPointer
-        );
-        // Builder overrides the default.
-        let rec2 = rec.with_multitouch_drag_strategy(MultitouchDragStrategy::SumAllPointers);
-        assert_eq!(
-            rec2.multitouch_drag_strategy(),
-            MultitouchDragStrategy::SumAllPointers
-        );
     }
 
     #[test]

--- a/crates/flui-interaction/src/recognizers/long_press.rs
+++ b/crates/flui-interaction/src/recognizers/long_press.rs
@@ -334,8 +334,13 @@ impl LongPressGestureRecognizer {
 
         match state.phase {
             LongPressPhase::Possible => {
-                // Pointer up before timer elapsed - just cancel silently
+                // Pointer up before timer elapsed - just cancel silently.
                 state.phase = LongPressPhase::Ready;
+                // Release the lock first: stop_tracking() sweeps the arena,
+                // which can synchronously reject THIS recognizer, and
+                // reject_gesture -> handle_cancel re-locks gesture_state
+                // (parking_lot is non-reentrant -> deadlock).
+                drop(state);
                 self.state.stop_tracking();
             }
             LongPressPhase::Started => {
@@ -677,6 +682,36 @@ mod tests {
             *rejected.lock(),
             "competing member should be rejected when the long-press deadline fires"
         );
+    }
+
+    #[test]
+    fn up_before_deadline_with_competitor_does_not_deadlock() {
+        // Regression: handle_up's Possible branch used to hold the
+        // gesture_state lock across stop_tracking(). stop_tracking sweeps the
+        // arena; when the sweep resolves in favor of an earlier member, THIS
+        // recognizer is rejected synchronously and handle_cancel re-locks
+        // gesture_state -> guaranteed self-deadlock on any lift-before-
+        // deadline interaction with a competitor.
+        struct Competitor;
+        impl crate::sealed::arena_member::Sealed for Competitor {}
+        impl crate::arena::GestureArenaMember for Competitor {
+            fn accept_gesture(&self, _pointer: PointerId) {}
+            fn reject_gesture(&self, _pointer: PointerId) {}
+        }
+
+        let arena = GestureArena::new();
+        let pointer = PointerId::new(3).expect("nonzero pointer id");
+        // Competitor joins FIRST so the sweep accepts it and rejects the
+        // long press.
+        arena.add(pointer, Arc::new(Competitor));
+
+        let recognizer = LongPressGestureRecognizer::new(arena.clone());
+        let position = Offset::new(Pixels(10.0), Pixels(10.0));
+        recognizer.add_pointer(pointer, position);
+
+        // Lift before the deadline: must complete without deadlocking.
+        recognizer.handle_up(position, PointerType::Touch);
+        assert_eq!(recognizer.primary_pointer(), None);
     }
 
     #[test]

--- a/crates/flui-interaction/src/recognizers/scale.rs
+++ b/crates/flui-interaction/src/recognizers/scale.rs
@@ -593,21 +593,21 @@ impl GestureRecognizer for ScaleGestureRecognizer {
         if !self.state.assert_not_disposed("handle_event") {
             return;
         }
+        // Route by the event's own pointer id (Flutter parity:
+        // `ScaleGestureRecognizer.handleEvent` keys `_pointerLocations` by
+        // `event.pointer`). Attributing a secondary finger's events to the
+        // primary pointer corrupts span and focal point and leaves two-finger
+        // pinch inert.
         match event {
             PointerEvent::Move(data) => {
-                // We need to figure out which pointer this is
-                // For now, assume it's the primary pointer
-                // In a real implementation, we'd track pointer IDs
-                if let Some(pointer) = self.state.primary_pointer() {
-                    let pos = data.current.position;
-                    let position = Offset::new(Pixels(pos.x as f32), Pixels(pos.y as f32));
-                    self.handle_pointer_move(pointer, position);
-                }
+                let pointer = crate::events::extract_pointer_id(event);
+                let pos = data.current.position;
+                let position = Offset::new(Pixels(pos.x as f32), Pixels(pos.y as f32));
+                self.handle_pointer_move(pointer, position);
             }
-            PointerEvent::Up(_data) => {
-                if let Some(pointer) = self.state.primary_pointer() {
-                    self.handle_pointer_up(pointer);
-                }
+            PointerEvent::Up(_) => {
+                let pointer = crate::events::extract_pointer_id(event);
+                self.handle_pointer_up(pointer);
             }
             PointerEvent::Cancel(_) => {
                 self.handle_cancel();
@@ -691,6 +691,71 @@ mod tests {
         let recognizer = ScaleGestureRecognizer::new(arena);
 
         assert_eq!(recognizer.primary_pointer(), None);
+    }
+
+    #[test]
+    fn two_finger_pinch_routes_events_per_pointer() {
+        use crate::events::{PointerType, make_move_event_for_id, make_up_event_for_id};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Regression: handle_event used to attribute every Move/Up to the
+        // primary pointer, so the second finger's movement never updated its
+        // own slot and pinch produced no scale updates.
+        let arena = GestureArena::new();
+        let updates = Arc::new(AtomicUsize::new(0));
+        let last_scale = Arc::new(Mutex::new(1.0_f32));
+        let updates2 = Arc::clone(&updates);
+        let last_scale2 = Arc::clone(&last_scale);
+        let recognizer = ScaleGestureRecognizer::new(arena).with_on_scale_update(move |details| {
+            updates2.fetch_add(1, Ordering::SeqCst);
+            *last_scale2.lock() = details.scale;
+        });
+
+        let finger1 = PointerId::new(2).expect("nonzero pointer id");
+        let finger2 = PointerId::new(3).expect("nonzero pointer id");
+        recognizer.add_pointer(finger1, Offset::new(Pixels(0.0), Pixels(0.0)));
+        recognizer.add_pointer(finger2, Offset::new(Pixels(100.0), Pixels(0.0)));
+
+        // Move ONLY the second finger outward through the public event path.
+        let move2 = make_move_event_for_id(
+            finger2,
+            Offset::new(Pixels(200.0), Pixels(0.0)),
+            PointerType::Touch,
+        );
+        recognizer.handle_event(&move2); // crosses the 5% slop -> Started
+        let move2b = make_move_event_for_id(
+            finger2,
+            Offset::new(Pixels(220.0), Pixels(0.0)),
+            PointerType::Touch,
+        );
+        recognizer.handle_event(&move2b);
+
+        assert!(
+            updates.load(Ordering::SeqCst) >= 1,
+            "second finger's movement must drive scale updates"
+        );
+        assert!(
+            (*last_scale.lock() - 2.2).abs() < 0.05,
+            "span 220/100 must be reported, got {}",
+            *last_scale.lock()
+        );
+
+        // Lifting the SECOND finger must remove its own slot.
+        let up2 = make_up_event_for_id(
+            finger2,
+            Offset::new(Pixels(220.0), Pixels(0.0)),
+            PointerType::Touch,
+        );
+        recognizer.handle_event(&up2);
+        assert_eq!(recognizer.gesture_state.lock().pointers.len(), 1);
+        assert!(
+            recognizer
+                .gesture_state
+                .lock()
+                .pointers
+                .contains_key(&finger1),
+            "the remaining slot must belong to the first finger"
+        );
     }
 
     #[test]

--- a/crates/flui-interaction/src/settings.rs
+++ b/crates/flui-interaction/src/settings.rs
@@ -22,6 +22,7 @@
 use std::time::Duration;
 
 use flui_types::geometry::Pixels;
+use flui_types::platform::TargetPlatform;
 use ui_events::pointer::PointerType;
 
 /// Default touch slop for touch devices (18 logical pixels).
@@ -208,6 +209,52 @@ impl GestureSettings {
             min_fling_velocity: DEFAULT_MIN_FLING_VELOCITY,
             max_fling_velocity: DEFAULT_MAX_FLING_VELOCITY,
         }
+    }
+
+    /// Platform-faithful settings for a **runtime** [`TargetPlatform`].
+    ///
+    /// This is the primary platform-adaptation entry point, mirroring
+    /// Flutter's `defaultTargetPlatform`: the platform is a *value*, not a
+    /// compile-time fact, because the compile target alone is wrong in
+    /// several real configurations —
+    ///
+    /// - **web/wasm**: one binary serves iOS Safari and Android Chrome; the
+    ///   feel must be chosen from the user agent at runtime;
+    /// - **tests**: widget tests exercise Android and iOS behavior on a
+    ///   desktop host (Flutter's `debugDefaultTargetPlatformOverride`);
+    /// - **ChromeOS / iPad-on-macOS**: the app's nominal platform and the
+    ///   input hardware disagree.
+    ///
+    /// Use [`Self::native`] when the compile target *is* the right answer
+    /// (a plain mobile/desktop build).
+    ///
+    /// Mapping: `Android`/`Fuchsia` → [`Self::android_defaults`] (Flutter
+    /// also treats Fuchsia as Android-like); `iOS` →
+    /// [`Self::ios_defaults`]; desktop and `Unknown` →
+    /// [`Self::touch_defaults`] (the universal Flutter `kTouchSlop = 18`
+    /// baseline — per-device precision is layered on top via
+    /// [`Self::for_device`]).
+    #[must_use]
+    pub fn for_platform(platform: TargetPlatform) -> Self {
+        match platform {
+            TargetPlatform::Android | TargetPlatform::Fuchsia => Self::android_defaults(),
+            TargetPlatform::iOS => Self::ios_defaults(),
+            // Desktop, Unknown, and any future `#[non_exhaustive]` variant:
+            // the universal Flutter baseline is the safe feel.
+            _ => Self::touch_defaults(),
+        }
+    }
+
+    /// Settings for the compile-time platform
+    /// ([`TargetPlatform::current()`], `cfg(target_os)`-seeded).
+    ///
+    /// Convenience over [`Self::for_platform`] for plain native builds.
+    /// Anything that can host more than one platform feel (web, tests,
+    /// embedders with platform override) must resolve a runtime
+    /// [`TargetPlatform`] and call [`Self::for_platform`] instead.
+    #[must_use]
+    pub fn native() -> Self {
+        Self::for_platform(TargetPlatform::current())
     }
 
     /// Native Android feel: values from AOSP `ViewConfiguration`
@@ -488,6 +535,50 @@ mod tests {
         let default = GestureSettings::default();
         let touch = GestureSettings::touch_defaults();
         assert_eq!(default, touch);
+    }
+
+    #[test]
+    fn for_platform_maps_every_variant() {
+        // Android-family feel.
+        assert_eq!(
+            GestureSettings::for_platform(TargetPlatform::Android),
+            GestureSettings::android_defaults()
+        );
+        assert_eq!(
+            GestureSettings::for_platform(TargetPlatform::Fuchsia),
+            GestureSettings::android_defaults()
+        );
+        // iOS feel.
+        assert_eq!(
+            GestureSettings::for_platform(TargetPlatform::iOS),
+            GestureSettings::ios_defaults()
+        );
+        // Desktop + Unknown fall back to the universal Flutter baseline.
+        for p in [
+            TargetPlatform::Linux,
+            TargetPlatform::MacOS,
+            TargetPlatform::Windows,
+            TargetPlatform::Unknown,
+        ] {
+            assert_eq!(
+                GestureSettings::for_platform(p),
+                GestureSettings::touch_defaults()
+            );
+        }
+        // The platform presets are actually distinct (8 dp vs 10 pt vs 18 px).
+        assert_eq!(GestureSettings::android_defaults().touch_slop(), 8.0);
+        assert_eq!(GestureSettings::ios_defaults().touch_slop(), 10.0);
+        assert_eq!(GestureSettings::touch_defaults().touch_slop(), 18.0);
+    }
+
+    #[test]
+    fn native_matches_compile_target() {
+        // `native()` is the cfg-seeded convenience: it must agree with the
+        // runtime dispatch for the compile-time platform.
+        assert_eq!(
+            GestureSettings::native(),
+            GestureSettings::for_platform(TargetPlatform::current())
+        );
     }
 
     #[test]

--- a/crates/flui-interaction/src/settings.rs
+++ b/crates/flui-interaction/src/settings.rs
@@ -210,6 +210,51 @@ impl GestureSettings {
         }
     }
 
+    /// Native Android feel: values from AOSP `ViewConfiguration`
+    /// (`frameworks/base/core/java/android/view/ViewConfiguration.java`),
+    /// in dp ≡ logical px.
+    ///
+    /// Differences from [`Self::touch_defaults`] (which mirrors Flutter's
+    /// `kTouchSlop = 18`): Android's native scroll-disambiguation slop is
+    /// **8 dp** — noticeably more eager to scroll — and the double-tap
+    /// window is 300 ms. Pan slop uses `PAGING_TOUCH_SLOP` (2× touch slop).
+    pub fn android_defaults() -> Self {
+        Self {
+            touch_slop: 8.0,
+            pan_slop: 16.0,
+            pan_slop_vertical: 16.0,
+            pan_slop_horizontal: 16.0,
+            scale_slop: DEFAULT_SCALE_SLOP,
+            double_tap_slop: 100.0,
+            double_tap_timeout: Duration::from_millis(300),
+            long_press_timeout: Duration::from_millis(400),
+            min_fling_velocity: 50.0,
+            max_fling_velocity: 8000.0,
+        }
+    }
+
+    /// Native iOS feel.
+    ///
+    /// `touch_slop` is `UIGestureRecognizer.allowableMovement`'s 10 pt
+    /// default — the only value Apple publishes. The remaining values are
+    /// extrapolated (Apple does not document `UIScrollView` internals):
+    /// pan slop 2× touch slop, Android-equivalent double-tap window, and the
+    /// conventional 500 ms long-press.
+    pub fn ios_defaults() -> Self {
+        Self {
+            touch_slop: 10.0,
+            pan_slop: 20.0,
+            pan_slop_vertical: 20.0,
+            pan_slop_horizontal: 20.0,
+            scale_slop: DEFAULT_SCALE_SLOP,
+            double_tap_slop: 100.0,
+            double_tap_timeout: Duration::from_millis(300),
+            long_press_timeout: Duration::from_millis(500),
+            min_fling_velocity: 50.0,
+            max_fling_velocity: 8000.0,
+        }
+    }
+
     /// Create settings optimized for pen/stylus input.
     ///
     /// Uses medium tolerance values.

--- a/crates/flui-types/src/lib.rs
+++ b/crates/flui-types/src/lib.rs
@@ -107,7 +107,7 @@ pub mod typography;
 // Re-exports for convenience - Most commonly used types
 pub use geometry::{EdgeInsets, Edges, Matrix4, Offset, Pixels, Point, RRect, Rect, Size};
 pub use layout::{Alignment, Axis};
-pub use styling::{Color, Color32};
+pub use styling::{Color, Color32, Oklab};
 
 /// Prelude module for convenient glob imports
 ///

--- a/crates/flui-types/src/styling/color.rs
+++ b/crates/flui-types/src/styling/color.rs
@@ -28,6 +28,26 @@ pub struct Color {
     pub a: u8,
 }
 
+/// A color in the Oklab perceptually uniform color space.
+///
+/// Produced by [`Color::to_oklab`]; consumed by [`Color::from_oklab`] and
+/// [`Color::lerp_oklab`]. `L` is perceived lightness in roughly `[0, 1]`;
+/// `a`/`b` are the green–red and blue–yellow opponent axes (small values,
+/// typically within `[-0.4, 0.4]` for sRGB colors).
+///
+/// Reference: Björn Ottosson, "A perceptual color space for image
+/// processing" (2020), <https://bottosson.github.io/posts/oklab/>.
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Oklab {
+    /// Perceived lightness.
+    pub l: f32,
+    /// Green–red opponent axis.
+    pub a: f32,
+    /// Blue–yellow opponent axis.
+    pub b: f32,
+}
+
 impl Color {
     // ===== Constructors =====
 
@@ -665,6 +685,105 @@ impl Color {
         }
     }
 
+    // ===== Perceptual (Oklab) interpolation =====
+
+    /// Convert to Oklab (perceptually uniform, Björn Ottosson 2020).
+    ///
+    /// Pipeline: sRGB → linear → LMS (M1) → cube root → Lab (M2). Exact
+    /// matrices from <https://bottosson.github.io/posts/oklab/>. Alpha is not
+    /// part of Oklab and is carried separately by the caller.
+    #[must_use]
+    pub fn to_oklab(self) -> Oklab {
+        #[inline]
+        fn srgb_to_linear(c: f32) -> f32 {
+            if c <= 0.04045 {
+                c / 12.92
+            } else {
+                ((c + 0.055) / 1.055).powf(2.4)
+            }
+        }
+        let r = srgb_to_linear(f32::from(self.r) / 255.0);
+        let g = srgb_to_linear(f32::from(self.g) / 255.0);
+        let b = srgb_to_linear(f32::from(self.b) / 255.0);
+
+        let l = 0.412_221_47 * r + 0.536_332_54 * g + 0.051_445_995 * b;
+        let m = 0.211_903_5 * r + 0.680_699_5 * g + 0.107_396_96 * b;
+        let s = 0.088_302_46 * r + 0.281_718_85 * g + 0.629_978_7 * b;
+
+        let l_ = l.cbrt();
+        let m_ = m.cbrt();
+        let s_ = s.cbrt();
+
+        Oklab {
+            l: 0.210_454_26 * l_ + 0.793_617_8 * m_ - 0.004_072_047 * s_,
+            a: 1.977_998_5 * l_ - 2.428_592_2 * m_ + 0.450_593_7 * s_,
+            b: 0.025_904_037 * l_ + 0.782_771_77 * m_ - 0.808_675_77 * s_,
+        }
+    }
+
+    /// Convert from Oklab back to sRGB, with the given alpha channel.
+    ///
+    /// Out-of-gamut results are clamped per channel (sufficient for
+    /// interpolation between two in-gamut endpoints; the Oklab segment
+    /// between two sRGB colors leaves the gamut only marginally).
+    #[must_use]
+    pub fn from_oklab(lab: Oklab, alpha: u8) -> Color {
+        #[inline]
+        fn linear_to_srgb(c: f32) -> f32 {
+            if c <= 0.003_130_8 {
+                12.92 * c
+            } else {
+                1.055 * c.powf(1.0 / 2.4) - 0.055
+            }
+        }
+        // `.round() as u8` saturates: clamping out-of-gamut channels.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)] // saturating by design
+        #[inline]
+        fn to_channel(c: f32) -> u8 {
+            (linear_to_srgb(c).clamp(0.0, 1.0) * 255.0).round() as u8
+        }
+
+        let l_ = lab.l + 0.396_337_78 * lab.a + 0.215_803_76 * lab.b;
+        let m_ = lab.l - 0.105_561_346 * lab.a - 0.063_854_17 * lab.b;
+        let s_ = lab.l - 0.089_484_18 * lab.a - 1.291_485_5 * lab.b;
+
+        let l = l_ * l_ * l_;
+        let m = m_ * m_ * m_;
+        let s = s_ * s_ * s_;
+
+        let r = 4.076_741_7 * l - 3.307_711_6 * m + 0.230_969_94 * s;
+        let g = -1.268_438 * l + 2.609_757_4 * m - 0.341_319_38 * s;
+        let b = -0.004_196_086_3 * l - 0.703_418_6 * m + 1.707_614_7 * s;
+
+        Color::rgba(to_channel(r), to_channel(g), to_channel(b), alpha)
+    }
+
+    /// Perceptually uniform interpolation through Oklab space.
+    ///
+    /// Componentwise sRGB lerp (what [`Color::lerp`] and Flutter's
+    /// `Color.lerp` compute) averages gamma-encoded values, so midpoints go
+    /// dark and gray — blue→yellow passes through mud. Interpolating L/a/b
+    /// linearly keeps lightness and chroma perceptually steady. Costs two
+    /// conversions per call (`powf`/`cbrt`); use [`Color::lerp`] when the
+    /// endpoints are close or the budget is tight.
+    ///
+    /// Alpha interpolates linearly, matching [`Color::lerp`].
+    #[must_use]
+    pub fn lerp_oklab(a: Color, b: Color, t: f32) -> Color {
+        let t = t.clamp(0.0, 1.0);
+        let la = a.to_oklab();
+        let lb = b.to_oklab();
+        let mixed = Oklab {
+            l: la.l + (lb.l - la.l) * t,
+            a: la.a + (lb.a - la.a) * t,
+            b: la.b + (lb.b - la.b) * t,
+        };
+        // Alpha is linear, same rounding contract as `lerp_scalar`.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)] // saturating by design
+        let alpha = (f32::from(a.a) + (f32::from(b.a) - f32::from(a.a)) * t).round() as u8;
+        Color::from_oklab(mixed, alpha)
+    }
+
     #[must_use]
     #[inline]
     pub fn lerp_multi_stop(stops: &[(Color, f32)], t: f32) -> Color {
@@ -879,6 +998,70 @@ mod tests {
         assert!(c1.approx_eq(&c2));
         assert!(c1.approx_eq(&c3));
         assert!(c1.approx_eq(&c4));
+    }
+
+    #[test]
+    fn oklab_roundtrip_preserves_color() {
+        // sRGB -> Oklab -> sRGB must come back within 1 channel unit
+        // (cbrt/powf rounding) for representative colors.
+        for color in [
+            Color::rgb(0, 0, 0),
+            Color::rgb(255, 255, 255),
+            Color::rgb(255, 0, 0),
+            Color::rgb(0, 255, 0),
+            Color::rgb(0, 0, 255),
+            Color::rgb(128, 64, 200),
+            Color::rgb(13, 250, 99),
+        ] {
+            let back = Color::from_oklab(color.to_oklab(), color.a);
+            assert!(
+                (i16::from(back.r) - i16::from(color.r)).abs() <= 1
+                    && (i16::from(back.g) - i16::from(color.g)).abs() <= 1
+                    && (i16::from(back.b) - i16::from(color.b)).abs() <= 1,
+                "roundtrip {color:?} -> {back:?} drifted more than 1 unit"
+            );
+        }
+    }
+
+    #[test]
+    fn oklab_white_has_unit_lightness() {
+        // Ottosson reference values: white = (L=1, a≈0, b≈0), black = (0,0,0).
+        let white = Color::rgb(255, 255, 255).to_oklab();
+        assert!((white.l - 1.0).abs() < 1e-2, "white L = {}", white.l);
+        assert!(white.a.abs() < 1e-2 && white.b.abs() < 1e-2);
+
+        let black = Color::rgb(0, 0, 0).to_oklab();
+        assert!(black.l.abs() < 1e-3);
+    }
+
+    #[test]
+    fn oklab_lerp_endpoints_and_midpoint() {
+        let blue = Color::rgb(0, 0, 255);
+        let yellow = Color::rgb(255, 255, 0);
+
+        // Endpoints round-trip through the conversion.
+        let at0 = Color::lerp_oklab(blue, yellow, 0.0);
+        let at1 = Color::lerp_oklab(blue, yellow, 1.0);
+        assert!((i16::from(at0.b) - 255).abs() <= 1 && i16::from(at0.r) <= 1);
+        assert!((i16::from(at1.r) - 255).abs() <= 1 && i16::from(at1.b) <= 1);
+
+        // The perceptual midpoint must be brighter than the muddy sRGB
+        // midpoint (128,128,128): Oklab preserves perceived lightness.
+        let mid = Color::lerp_oklab(blue, yellow, 0.5);
+        let srgb_mid = Color::lerp(blue, yellow, 0.5);
+        let sum = u16::from(mid.r) + u16::from(mid.g) + u16::from(mid.b);
+        let srgb_sum = u16::from(srgb_mid.r) + u16::from(srgb_mid.g) + u16::from(srgb_mid.b);
+        assert!(
+            sum > srgb_sum,
+            "Oklab midpoint {mid:?} must be brighter than sRGB midpoint {srgb_mid:?}"
+        );
+    }
+
+    #[test]
+    fn oklab_lerp_interpolates_alpha_linearly() {
+        let a = Color::rgba(255, 0, 0, 0);
+        let b = Color::rgba(255, 0, 0, 200);
+        assert_eq!(Color::lerp_oklab(a, b, 0.5).a, 100);
     }
 
     #[test]

--- a/crates/flui-types/src/styling/mod.rs
+++ b/crates/flui-types/src/styling/mod.rs
@@ -19,7 +19,7 @@ pub mod shadow;
 pub use border::{BorderPosition, BorderSide, BorderStyle};
 pub use border_radius::{BorderRadius, BorderRadiusDirectional, BorderRadiusExt};
 pub use box_border::{Border, BorderDirectional, BoxBorder};
-pub use color::{Color, ParseColorError};
+pub use color::{Color, Oklab, ParseColorError};
 pub use color32::Color32;
 pub use decoration::{
     BlendMode, BoxDecoration, BoxFit, ColorFilter, Decoration, DecorationImage, ImageRepeat,


### PR DESCRIPTION
## What

Full-crate quality audit of `flui-animation` (post-#169) and `flui-interaction` (post-#164) against the Flutter reference, with every verified finding fixed in the same pass. Two commits, one per crate.

## Why it matters

Three of the findings are production-blocking despite green suites: tween-driven rebuilds never fired, two-finger pinch was inert, and two lift/reject interleavings self-deadlocked the input thread. All were invisible to the existing tests because they only manifest through wiring paths (listener subscription, multi-pointer routing, arena re-entrancy) that the unit tests bypassed.

## flui-animation

**Correctness**
- `TweenAnimation` never subscribed to its parent — **listeners on any tween combinator silently never fired** (`AnimatedBuilder`-class breakage). Wired via `link_parent` like `CurvedAnimation`.
- `ProxyAnimation` status listeners were orphaned on the old parent after `set_parent`, and removal targeted the wrong parent. Proxy now owns its status registry behind a migrating forwarder; a swap fires only on actual status change (Flutter `ProxyAnimation.parent=` parity).
- `AnimationController::is_animating()` is now ticker-based (Flutter overrides `isAnimating`); a stopped controller at an interior value no longer claims to animate.
- `AnimationSwitch` (train-hop) left stale listener ids after a switch; `dispose()` cleaned the wrong animation. Listeners are rebound on every hop.
- `CurvedAnimation` locks the active curve to the run-entry direction (Flutter `_curveDirection`) — `reverse()` mid-run no longer swaps curves under the value (visual jump).
- NaN guards: Rust `clamp` propagates NaN through the cubic solver and controller value; canonicalized at `Cubic`/`ThreePointCubic`/`Split::transform` and `set_value` (warn + lower bound).
- `FrictionSimulation::through` zero-travel case now fails with the physical constraint, not an opaque drag panic.

**Parity additions**
- Full Penner cubic catalog (`Ease`, `EaseIn/Out/InOut{Quad,Cubic,Quart,Quint}`, `FastLinearToSlowEaseIn`, `LinearToEaseOut`, `EaseInToLinear`, `SlowMiddle`).
- `ThreePointCubic` + M3 `EaseInOutCubicEmphasized` and `FastEaseInToSlowEaseOut`.
- `Split` curve (track-finger-then-fling transitions).

## flui-interaction

**Deadlocks** (parking_lot is non-reentrant)
- `LongPress::handle_up` held `gesture_state` across `stop_tracking()` → arena sweep → self-rejection → re-lock. Guaranteed hang on lift-before-deadline with a competitor.
- `GestureArenaTeam` dispatched member callbacks under the combiner lock; a rejected recognizer's cancel path re-enters the same combiner via the team's arena wrapper. All three paths now collect-then-dispatch (`PendingTeamNotifications`).
- `GestureArenaTeam.self_ref` was a write-only strong `Arc` self-cycle — **every team leaked for the process lifetime**. Removed.

**Recognizers**
- `Scale::handle_event` attributed every Move/Up to the primary pointer — **two-finger pinch produced zero scale updates**. Now routed by the event's own pointer id (`scale.dart` parity); regression test drives a pinch through the public event path.
- `DoubleTap` inter-tap timeout now fires `on_double_tap_cancel` and releases the arena (Flutter `_reset → _checkCancel`).
- `PointerEventResampler` computed interpolated positions but never emitted the synthesized Move (stub) while still advancing `last_position`. Now emits per `resampler.dart`.

**Breaking**
- `MultitouchDragStrategy` removed: drag is a single-sequence recognizer with no per-pointer state, so two of three strategies were silent no-ops behind a public builder. Returns with a real multi-pointer drag.

## Verification

- `cargo test -p flui-animation`: 169 + 3 + 46 doc — green (+13 new regression tests)
- `cargo test -p flui-interaction`: 363 + 11 doc — green (+5 new regression tests)
- `cargo clippy --all-targets --all-features`: zero warnings, both crates
- `cargo fmt --check`: clean
- `scripts/port-check.sh`: all 18 refusal triggers + FR-033 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)