### PR TITLE
fix(flui-platform): rebuild macOS backend against current platform contracts

### DIFF
--- a/crates/flui-platform/Cargo.toml
+++ b/crates/flui-platform/Cargo.toml
@@ -147,9 +147,7 @@ x11 = []
 [lints.rust]
 # objc 0.2 macros expand `cfg(feature = "cargo-clippy")` probes (macOS backend);
 # declare the value so `unexpected_cfgs` stays quiet under the clippy driver.
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(feature, values("cargo-clippy"))',
-] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/crates/flui-platform/Cargo.toml
+++ b/crates/flui-platform/Cargo.toml
@@ -144,6 +144,13 @@ web = []
 wayland = []
 x11 = []
 
+[lints.rust]
+# objc 0.2 macros expand `cfg(feature = "cargo-clippy")` probes (macOS backend);
+# declare the value so `unexpected_cfgs` stays quiet under the clippy driver.
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("cargo-clippy"))',
+] }
+
 [dev-dependencies]
 tracing-subscriber = { workspace = true }
 

--- a/crates/flui-platform/src/platforms/macos/clipboard.rs
+++ b/crates/flui-platform/src/platforms/macos/clipboard.rs
@@ -4,11 +4,10 @@
 //! Thread-safe wrapper with proper Objective-C object lifetime management.
 
 use cocoa::{
-    appkit::NSPasteboard,
     base::{id, nil},
-    foundation::{NSArray, NSString},
+    foundation::NSString,
 };
-use objc::runtime::Object;
+use objc::{class, msg_send, sel, sel_impl};
 use parking_lot::Mutex;
 
 use crate::traits::Clipboard;
@@ -22,11 +21,21 @@ pub struct MacOSClipboard {
     pasteboard: Mutex<id>,
 }
 
+// SAFETY: the stored pointer is the process-wide `generalPasteboard`
+// singleton (never deallocated); access is serialized through the Mutex, and
+// NSPasteboard's mutating selectors are documented as thread-safe.
+unsafe impl Send for MacOSClipboard {}
+// SAFETY: see `Send` above — the singleton pointer is immutable and all
+// pasteboard calls go through the Mutex.
+unsafe impl Sync for MacOSClipboard {}
+
 impl MacOSClipboard {
     /// Create a new clipboard instance
     ///
     /// Gets the general system pasteboard ([NSPasteboard generalPasteboard]).
     pub fn new() -> Self {
+        // SAFETY: `+[NSPasteboard generalPasteboard]` returns the process-wide
+        // singleton (or nil, which is checked); no lifetime obligations.
         unsafe {
             let pasteboard: id = msg_send![class!(NSPasteboard), generalPasteboard];
 
@@ -48,6 +57,8 @@ impl MacOSClipboard {
     /// Use this to detect if clipboard has changed without reading contents.
     #[allow(dead_code)]
     fn change_count(&self) -> i64 {
+        // SAFETY: the stored pointer is the live pasteboard singleton (or nil,
+        // which is checked); `changeCount` is a plain integer getter.
         unsafe {
             let pasteboard = *self.pasteboard.lock();
             if pasteboard == nil {
@@ -66,6 +77,9 @@ impl Default for MacOSClipboard {
 
 impl Clipboard for MacOSClipboard {
     fn read_text(&self) -> Option<String> {
+        // SAFETY: the stored pointer is the live pasteboard singleton (nil
+        // checked); returned NSStrings are autoreleased and their UTF8String
+        // buffers are copied into owned Strings before the pool drains.
         unsafe {
             let pasteboard = *self.pasteboard.lock();
             if pasteboard == nil {
@@ -116,6 +130,9 @@ impl Clipboard for MacOSClipboard {
     }
 
     fn write_text(&self, text: String) {
+        // SAFETY: the stored pointer is the live pasteboard singleton (nil
+        // checked); NSStrings are created from valid Rust strings and
+        // ownership passes to the pasteboard.
         unsafe {
             let pasteboard = *self.pasteboard.lock();
             if pasteboard == nil {
@@ -146,6 +163,9 @@ impl Clipboard for MacOSClipboard {
     }
 
     fn has_text(&self) -> bool {
+        // SAFETY: the stored pointer is the live pasteboard singleton (nil
+        // checked); `types`/`containsObject:` operate on autoreleased objects
+        // consumed before the pool drains.
         unsafe {
             let pasteboard = *self.pasteboard.lock();
             if pasteboard == nil {

--- a/crates/flui-platform/src/platforms/macos/display.rs
+++ b/crates/flui-platform/src/platforms/macos/display.rs
@@ -3,11 +3,11 @@
 use std::sync::Arc;
 
 use cocoa::{
-    appkit::NSScreen,
     base::{id, nil},
-    foundation::{NSArray, NSRect},
+    foundation::NSRect,
 };
 use flui_types::geometry::{Bounds, DevicePixels, Point, Size};
+use objc::{class, msg_send, sel, sel_impl};
 
 use crate::traits::{DisplayId, PlatformDisplay};
 
@@ -23,7 +23,15 @@ pub struct MacOSDisplay {
 
 impl MacOSDisplay {
     /// Create a MacOSDisplay from NSScreen
-    pub fn new(screen: id, is_primary: bool) -> Self {
+    ///
+    /// # Safety
+    ///
+    /// `screen` must be a valid, live `NSScreen*` for the duration of the
+    /// call.
+    pub unsafe fn new(screen: id, is_primary: bool) -> Self {
+        // SAFETY: caller guarantees `screen` is a live NSScreen*; all
+        // messages are documented NSScreen getters, and `deviceDescription`
+        // values are read before the autorelease pool drains.
         unsafe {
             // Get screen frame (full bounds including menu bar)
             let frame: NSRect = msg_send![screen, frame];
@@ -37,30 +45,30 @@ impl MacOSDisplay {
             // Get device description for display ID
             let description: id = msg_send![screen, deviceDescription];
             let display_id_key: id =
-                msg_send![class!(NSString), stringWithUTF8String: "NSScreenNumber".as_ptr()];
+                msg_send![class!(NSString), stringWithUTF8String: c"NSScreenNumber".as_ptr()];
             let display_id_value: id = msg_send![description, objectForKey: display_id_key];
             let display_id: u64 = msg_send![display_id_value, unsignedLongLongValue];
 
             // macOS coordinates are bottom-left origin, convert to top-left
             let bounds = Bounds {
                 origin: Point::new(
-                    flui_types::geometry::device_px(frame.origin.x as f32),
-                    flui_types::geometry::device_px(frame.origin.y as f32),
+                    flui_types::geometry::device_px(frame.origin.x.round() as i32),
+                    flui_types::geometry::device_px(frame.origin.y.round() as i32),
                 ),
                 size: Size::new(
-                    flui_types::geometry::device_px(frame.size.width as f32),
-                    flui_types::geometry::device_px(frame.size.height as f32),
+                    flui_types::geometry::device_px(frame.size.width.round() as i32),
+                    flui_types::geometry::device_px(frame.size.height.round() as i32),
                 ),
             };
 
             let usable_bounds = Bounds {
                 origin: Point::new(
-                    flui_types::geometry::device_px(visible_frame.origin.x as f32),
-                    flui_types::geometry::device_px(visible_frame.origin.y as f32),
+                    flui_types::geometry::device_px(visible_frame.origin.x.round() as i32),
+                    flui_types::geometry::device_px(visible_frame.origin.y.round() as i32),
                 ),
                 size: Size::new(
-                    flui_types::geometry::device_px(visible_frame.size.width as f32),
-                    flui_types::geometry::device_px(visible_frame.size.height as f32),
+                    flui_types::geometry::device_px(visible_frame.size.width.round() as i32),
+                    flui_types::geometry::device_px(visible_frame.size.height.round() as i32),
                 ),
             };
 
@@ -104,6 +112,8 @@ impl PlatformDisplay for MacOSDisplay {
 
 /// Enumerate all displays using NSScreen
 pub fn enumerate_displays() -> Vec<Arc<dyn PlatformDisplay>> {
+    // SAFETY: `+[NSScreen screens]` returns an autoreleased NSArray of live
+    // NSScreen objects; all elements are consumed before the pool drains.
     unsafe {
         let screens: id = msg_send![class!(NSScreen), screens];
         if screens == nil {

--- a/crates/flui-platform/src/platforms/macos/display.rs
+++ b/crates/flui-platform/src/platforms/macos/display.rs
@@ -49,26 +49,25 @@ impl MacOSDisplay {
             let display_id_value: id = msg_send![description, objectForKey: display_id_key];
             let display_id: u64 = msg_send![display_id_value, unsignedLongLongValue];
 
-            // macOS coordinates are bottom-left origin, convert to top-left
+            // NSScreen frames are in points (logical units, bottom-left
+            // origin); the PlatformDisplay contract wants device pixels, so
+            // scale by backingScaleFactor before converting.
+            let to_device =
+                |points: f64| flui_types::geometry::device_px((points * scale).round() as i32);
+
             let bounds = Bounds {
-                origin: Point::new(
-                    flui_types::geometry::device_px(frame.origin.x.round() as i32),
-                    flui_types::geometry::device_px(frame.origin.y.round() as i32),
-                ),
-                size: Size::new(
-                    flui_types::geometry::device_px(frame.size.width.round() as i32),
-                    flui_types::geometry::device_px(frame.size.height.round() as i32),
-                ),
+                origin: Point::new(to_device(frame.origin.x), to_device(frame.origin.y)),
+                size: Size::new(to_device(frame.size.width), to_device(frame.size.height)),
             };
 
             let usable_bounds = Bounds {
                 origin: Point::new(
-                    flui_types::geometry::device_px(visible_frame.origin.x.round() as i32),
-                    flui_types::geometry::device_px(visible_frame.origin.y.round() as i32),
+                    to_device(visible_frame.origin.x),
+                    to_device(visible_frame.origin.y),
                 ),
                 size: Size::new(
-                    flui_types::geometry::device_px(visible_frame.size.width.round() as i32),
-                    flui_types::geometry::device_px(visible_frame.size.height.round() as i32),
+                    to_device(visible_frame.size.width),
+                    to_device(visible_frame.size.height),
                 ),
             };
 

--- a/crates/flui-platform/src/platforms/macos/events.rs
+++ b/crates/flui-platform/src/platforms/macos/events.rs
@@ -1,4 +1,4 @@
-//! macOS event conversion utilities
+//! macOS event conversion to W3C ui-events (0.3 API)
 //!
 //! Converts NSEvent to platform-agnostic ui-events types.
 //!
@@ -11,30 +11,56 @@
 //!     ↓
 //! PlatformInput (ui-events wrapper)
 //!     ↓
-//! Platform handlers
+//! WindowCallbacks::dispatch_input
 //! ```
 //!
 //! # Key Mappings
 //!
-//! - NSEvent.characters → keyboard_types::Key
+//! - NSEvent.characters / keyCode → keyboard_types::Key
 //! - NSEventModifierFlags → keyboard_types::Modifiers
 //! - NSEventType → PointerEvent / KeyboardEvent
-//! - NSPoint → logical pixels (converted via backingScaleFactor)
+//! - NSPoint → logical pixels (NSEvent coordinates are already logical;
+//!   the Y axis is flipped from bottom-left to top-left origin)
+
+use std::{sync::LazyLock, time::Instant};
 
 use cocoa::{
-    appkit::{NSEvent, NSEventModifierFlags, NSEventType},
+    appkit::{NSEventModifierFlags, NSEventType},
     base::id,
     foundation::NSPoint,
 };
-use flui_types::geometry::{Offset, Pixels};
-use keyboard_types::{Key, Modifiers};
-use objc::{runtime::Object, *};
+use dpi::{PhysicalPosition, PhysicalSize};
+use keyboard_types::{Key, Modifiers, NamedKey};
+use objc::{class, msg_send, sel, sel_impl};
 use ui_events::{
+    ScrollDelta,
     keyboard::{Code, KeyState, KeyboardEvent, Location},
-    pointer::{PointerButton, PointerButtons, PointerEvent, PointerId, PointerType},
+    pointer::{
+        PointerButton, PointerButtonEvent, PointerButtons, PointerEvent, PointerId, PointerInfo,
+        PointerScrollEvent, PointerState, PointerType, PointerUpdate,
+    },
 };
 
-use crate::traits::input::PlatformInput;
+use crate::traits::PlatformInput;
+
+/// Process-start epoch for monotonic event timestamps.
+static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+/// Get monotonic timestamp in milliseconds since process start.
+#[inline]
+fn event_timestamp_ms() -> u64 {
+    PROCESS_START.elapsed().as_millis() as u64
+}
+
+/// Create a `PointerInfo` for the primary mouse pointer.
+#[inline]
+fn primary_mouse_info() -> PointerInfo {
+    PointerInfo {
+        pointer_id: Some(PointerId::PRIMARY),
+        pointer_type: PointerType::Mouse,
+        persistent_device_id: None,
+    }
+}
 
 // ============================================================================
 // NSEvent Conversion
@@ -42,8 +68,21 @@ use crate::traits::input::PlatformInput;
 
 /// Convert NSEvent to PlatformInput
 ///
+/// `view_height` is the receiving view's logical height, used to flip the
+/// Y axis from macOS bottom-left origin to the framework's top-left origin.
+///
 /// Returns None if the event type is not supported (e.g., gesture events)
-pub fn convert_ns_event(ns_event: id, scale_factor: f64) -> Option<PlatformInput> {
+///
+/// # Safety
+///
+/// `ns_event` must be a valid, live `NSEvent*` for the duration of the call.
+pub unsafe fn convert_ns_event(
+    ns_event: id,
+    scale_factor: f64,
+    view_height: f64,
+) -> Option<PlatformInput> {
+    // SAFETY: caller guarantees `ns_event` is a valid NSEvent*; all messages
+    // sent below are documented NSEvent selectors.
     unsafe {
         let event_type: NSEventType = msg_send![ns_event, type];
 
@@ -81,43 +120,74 @@ pub fn convert_ns_event(ns_event: id, scale_factor: f64) -> Option<PlatformInput
             }
 
             // Mouse button events
-            NSEventType::NSLeftMouseDown => {
-                convert_mouse_event(ns_event, scale_factor, PointerButton::Primary, true)
-            }
+            NSEventType::NSLeftMouseDown => convert_mouse_button(
+                ns_event,
+                scale_factor,
+                view_height,
+                PointerButton::Primary,
+                true,
+            ),
 
-            NSEventType::NSLeftMouseUp => {
-                convert_mouse_event(ns_event, scale_factor, PointerButton::Primary, false)
-            }
+            NSEventType::NSLeftMouseUp => convert_mouse_button(
+                ns_event,
+                scale_factor,
+                view_height,
+                PointerButton::Primary,
+                false,
+            ),
 
-            NSEventType::NSRightMouseDown => {
-                convert_mouse_event(ns_event, scale_factor, PointerButton::Secondary, true)
-            }
+            NSEventType::NSRightMouseDown => convert_mouse_button(
+                ns_event,
+                scale_factor,
+                view_height,
+                PointerButton::Secondary,
+                true,
+            ),
 
-            NSEventType::NSRightMouseUp => {
-                convert_mouse_event(ns_event, scale_factor, PointerButton::Secondary, false)
-            }
+            NSEventType::NSRightMouseUp => convert_mouse_button(
+                ns_event,
+                scale_factor,
+                view_height,
+                PointerButton::Secondary,
+                false,
+            ),
 
-            NSEventType::NSOtherMouseDown => {
-                convert_mouse_event(ns_event, scale_factor, PointerButton::Auxiliary, true)
-            }
+            NSEventType::NSOtherMouseDown => convert_mouse_button(
+                ns_event,
+                scale_factor,
+                view_height,
+                PointerButton::Auxiliary,
+                true,
+            ),
 
-            NSEventType::NSOtherMouseUp => {
-                convert_mouse_event(ns_event, scale_factor, PointerButton::Auxiliary, false)
-            }
+            NSEventType::NSOtherMouseUp => convert_mouse_button(
+                ns_event,
+                scale_factor,
+                view_height,
+                PointerButton::Auxiliary,
+                false,
+            ),
 
             // Mouse movement events
             NSEventType::NSMouseMoved
             | NSEventType::NSLeftMouseDragged
             | NSEventType::NSRightMouseDragged
-            | NSEventType::NSOtherMouseDragged => convert_mouse_move(ns_event, scale_factor),
+            | NSEventType::NSOtherMouseDragged => {
+                convert_mouse_move(ns_event, scale_factor, view_height)
+            }
 
             // Scroll events
-            NSEventType::NSScrollWheel => convert_scroll_event(ns_event, scale_factor),
+            NSEventType::NSScrollWheel => convert_scroll_event(ns_event, scale_factor, view_height),
 
-            // Mouse enter/exit
-            NSEventType::NSMouseEntered => convert_mouse_enter_exit(ns_event, scale_factor, true),
+            // Mouse enter/exit carry no useful position payload in the W3C
+            // model — Enter/Leave only identify the pointer.
+            NSEventType::NSMouseEntered => Some(PlatformInput::Pointer(PointerEvent::Enter(
+                primary_mouse_info(),
+            ))),
 
-            NSEventType::NSMouseExited => convert_mouse_enter_exit(ns_event, scale_factor, false),
+            NSEventType::NSMouseExited => Some(PlatformInput::Pointer(PointerEvent::Leave(
+                primary_mouse_info(),
+            ))),
 
             // Unsupported events
             _ => None,
@@ -131,246 +201,282 @@ pub fn convert_ns_event(ns_event: id, scale_factor: f64) -> Option<PlatformInput
 
 /// Extract key from NSEvent
 ///
-/// Uses NSEvent.characters to get the Unicode character
+/// Uses NSEvent.keyCode for special keys, NSEvent.characters otherwise
+///
+/// # Safety
+///
+/// `ns_event` must be a valid, live `NSEvent*` of a keyboard event.
 unsafe fn extract_key(ns_event: id) -> Key {
-    // Get characters string
-    let chars: id = msg_send![ns_event, characters];
-    if chars.is_null() {
-        return Key::Unidentified;
+    // SAFETY: caller guarantees `ns_event` is a valid NSEvent*; `characters`
+    // returns an autoreleased NSString whose UTF8String buffer is valid while
+    // the event is alive (we copy it into an owned String before returning).
+    unsafe {
+        // Check for special keys via key code first
+        let key_code: u16 = msg_send![ns_event, keyCode];
+        if let Some(special_key) = key_code_to_key(key_code) {
+            return special_key;
+        }
+
+        // Get characters string
+        let chars: id = msg_send![ns_event, characters];
+        if chars.is_null() {
+            return Key::Named(NamedKey::Unidentified);
+        }
+
+        // Convert NSString to Rust string
+        let chars_ptr: *const i8 = msg_send![chars, UTF8String];
+        if chars_ptr.is_null() {
+            return Key::Named(NamedKey::Unidentified);
+        }
+
+        let chars_str = std::ffi::CStr::from_ptr(chars_ptr as *const _)
+            .to_str()
+            .unwrap_or("");
+
+        if chars_str.is_empty() {
+            return Key::Named(NamedKey::Unidentified);
+        }
+
+        // Regular character key
+        Key::Character(chars_str.to_string())
     }
-
-    // Convert NSString to Rust string
-    let chars_ptr: *const i8 = msg_send![chars, UTF8String];
-    if chars_ptr.is_null() {
-        return Key::Unidentified;
-    }
-
-    let chars_str = std::ffi::CStr::from_ptr(chars_ptr as *const _)
-        .to_str()
-        .unwrap_or("");
-
-    if chars_str.is_empty() {
-        return Key::Unidentified;
-    }
-
-    // Check for special keys via key code
-    let key_code: u16 = msg_send![ns_event, keyCode];
-    if let Some(special_key) = key_code_to_key(key_code) {
-        return special_key;
-    }
-
-    // Regular character key
-    Key::Character(chars_str.to_string())
 }
 
 /// Extract modifiers from NSEvent
+///
+/// # Safety
+///
+/// `ns_event` must be a valid, live `NSEvent*`.
 unsafe fn extract_modifiers(ns_event: id) -> Modifiers {
-    let flags: NSEventModifierFlags = msg_send![ns_event, modifierFlags];
+    // SAFETY: caller guarantees `ns_event` is a valid NSEvent*;
+    // `modifierFlags` is a plain NSUInteger getter.
+    unsafe {
+        let flags: NSEventModifierFlags = msg_send![ns_event, modifierFlags];
 
-    let mut modifiers = Modifiers::empty();
+        let mut modifiers = Modifiers::empty();
 
-    if flags.contains(NSEventModifierFlags::NSShiftKeyMask) {
-        modifiers.insert(Modifiers::SHIFT);
-    }
-    if flags.contains(NSEventModifierFlags::NSControlKeyMask) {
-        modifiers.insert(Modifiers::CONTROL);
-    }
-    if flags.contains(NSEventModifierFlags::NSAlternateKeyMask) {
-        modifiers.insert(Modifiers::ALT);
-    }
-    if flags.contains(NSEventModifierFlags::NSCommandKeyMask) {
-        modifiers.insert(Modifiers::META); // Command = Meta
-    }
+        if flags.contains(NSEventModifierFlags::NSShiftKeyMask) {
+            modifiers.insert(Modifiers::SHIFT);
+        }
+        if flags.contains(NSEventModifierFlags::NSControlKeyMask) {
+            modifiers.insert(Modifiers::CONTROL);
+        }
+        if flags.contains(NSEventModifierFlags::NSAlternateKeyMask) {
+            modifiers.insert(Modifiers::ALT);
+        }
+        if flags.contains(NSEventModifierFlags::NSCommandKeyMask) {
+            modifiers.insert(Modifiers::META); // Command = Meta
+        }
 
-    modifiers
+        modifiers
+    }
 }
 
 /// Convert macOS key code to Key
 ///
 /// Reference: https://developer.apple.com/documentation/appkit/nsevent/1534513-keycode
 fn key_code_to_key(key_code: u16) -> Option<Key> {
-    match key_code {
+    let named = match key_code {
         // Arrow keys
-        123 => Some(Key::ArrowLeft),
-        124 => Some(Key::ArrowRight),
-        125 => Some(Key::ArrowDown),
-        126 => Some(Key::ArrowUp),
+        123 => NamedKey::ArrowLeft,
+        124 => NamedKey::ArrowRight,
+        125 => NamedKey::ArrowDown,
+        126 => NamedKey::ArrowUp,
 
         // Function keys
-        122 => Some(Key::F1),
-        120 => Some(Key::F2),
-        99 => Some(Key::F3),
-        118 => Some(Key::F4),
-        96 => Some(Key::F5),
-        97 => Some(Key::F6),
-        98 => Some(Key::F7),
-        100 => Some(Key::F8),
-        101 => Some(Key::F9),
-        109 => Some(Key::F10),
-        103 => Some(Key::F11),
-        111 => Some(Key::F12),
+        122 => NamedKey::F1,
+        120 => NamedKey::F2,
+        99 => NamedKey::F3,
+        118 => NamedKey::F4,
+        96 => NamedKey::F5,
+        97 => NamedKey::F6,
+        98 => NamedKey::F7,
+        100 => NamedKey::F8,
+        101 => NamedKey::F9,
+        109 => NamedKey::F10,
+        103 => NamedKey::F11,
+        111 => NamedKey::F12,
 
         // Special keys
-        36 => Some(Key::Enter),
-        48 => Some(Key::Tab),
-        51 => Some(Key::Backspace),
-        53 => Some(Key::Escape),
-        117 => Some(Key::Delete),
-        115 => Some(Key::Home),
-        119 => Some(Key::End),
-        116 => Some(Key::PageUp),
-        121 => Some(Key::PageDown),
+        36 => NamedKey::Enter,
+        48 => NamedKey::Tab,
+        51 => NamedKey::Backspace,
+        53 => NamedKey::Escape,
+        117 => NamedKey::Delete,
+        115 => NamedKey::Home,
+        119 => NamedKey::End,
+        116 => NamedKey::PageUp,
+        121 => NamedKey::PageDown,
 
         // Space
-        49 => Some(Key::Character(" ".to_string())),
+        49 => return Some(Key::Character(" ".to_string())),
 
-        _ => None,
-    }
+        _ => return None,
+    };
+    Some(Key::Named(named))
 }
 
 // ============================================================================
 // Mouse Event Conversion
 // ============================================================================
 
+/// Build a `PointerState` from an NSEvent's window-relative location.
+///
+/// # Safety
+///
+/// `ns_event` must be a valid, live `NSEvent*` of a mouse event.
+unsafe fn pointer_state(ns_event: id, scale_factor: f64, view_height: f64) -> PointerState {
+    // SAFETY: caller guarantees `ns_event` is a valid NSEvent*;
+    // `locationInWindow` is a plain NSPoint getter.
+    unsafe {
+        // NSEvent.locationInWindow is already in logical coordinates with a
+        // bottom-left origin; flip Y to the framework's top-left origin.
+        let location: NSPoint = msg_send![ns_event, locationInWindow];
+        let modifiers = extract_modifiers(ns_event);
+        let buttons = extract_mouse_buttons();
+
+        PointerState {
+            time: event_timestamp_ms(),
+            position: PhysicalPosition::new(location.x, view_height - location.y),
+            buttons,
+            modifiers,
+            count: 1,
+            contact_geometry: PhysicalSize::new(1.0, 1.0),
+            orientation: Default::default(),
+            pressure: 0.0,
+            tangential_pressure: 0.0,
+            scale_factor,
+        }
+    }
+}
+
 /// Convert mouse button event
-unsafe fn convert_mouse_event(
+///
+/// # Safety
+///
+/// `ns_event` must be a valid, live `NSEvent*` of a mouse-button event.
+unsafe fn convert_mouse_button(
     ns_event: id,
     scale_factor: f64,
+    view_height: f64,
     button: PointerButton,
     is_down: bool,
 ) -> Option<PlatformInput> {
-    let position = extract_mouse_position(ns_event, scale_factor);
-    let buttons = extract_mouse_buttons(ns_event);
-    let modifiers = extract_modifiers(ns_event);
+    // SAFETY: caller guarantees `ns_event` validity; forwarded to
+    // `pointer_state` under the same contract.
+    unsafe {
+        let mut state = pointer_state(ns_event, scale_factor, view_height);
+        state.pressure = if is_down { 0.5 } else { 0.0 };
 
-    let update = if is_down {
-        ui_events::pointer::PointerUpdate::Down { button }
-    } else {
-        ui_events::pointer::PointerUpdate::Up { button }
-    };
+        let button_event = PointerButtonEvent {
+            pointer: primary_mouse_info(),
+            state,
+            button: Some(button),
+        };
 
-    Some(PlatformInput::Pointer(PointerEvent {
-        pointer_id: PointerId(0), // macOS doesn't have multi-pointer tracking
-        pointer_type: PointerType::Mouse,
-        position,
-        buttons,
-        modifiers,
-        update,
-    }))
+        let event = if is_down {
+            PointerEvent::Down(button_event)
+        } else {
+            PointerEvent::Up(button_event)
+        };
+
+        Some(PlatformInput::Pointer(event))
+    }
 }
 
 /// Convert mouse movement event
-unsafe fn convert_mouse_move(ns_event: id, scale_factor: f64) -> Option<PlatformInput> {
-    let position = extract_mouse_position(ns_event, scale_factor);
-    let buttons = extract_mouse_buttons(ns_event);
-    let modifiers = extract_modifiers(ns_event);
+///
+/// # Safety
+///
+/// `ns_event` must be a valid, live `NSEvent*` of a mouse-move event.
+unsafe fn convert_mouse_move(
+    ns_event: id,
+    scale_factor: f64,
+    view_height: f64,
+) -> Option<PlatformInput> {
+    // SAFETY: caller guarantees `ns_event` validity; forwarded to
+    // `pointer_state` under the same contract.
+    unsafe {
+        let state = pointer_state(ns_event, scale_factor, view_height);
 
-    Some(PlatformInput::Pointer(PointerEvent {
-        pointer_id: PointerId(0),
-        pointer_type: PointerType::Mouse,
-        position,
-        buttons,
-        modifiers,
-        update: ui_events::pointer::PointerUpdate::Moved,
-    }))
+        Some(PlatformInput::Pointer(PointerEvent::Move(PointerUpdate {
+            pointer: primary_mouse_info(),
+            current: state,
+            coalesced: Vec::new(),
+            predicted: Vec::new(),
+        })))
+    }
 }
 
 /// Convert scroll wheel event
-unsafe fn convert_scroll_event(ns_event: id, scale_factor: f64) -> Option<PlatformInput> {
-    let position = extract_mouse_position(ns_event, scale_factor);
-    let buttons = extract_mouse_buttons(ns_event);
-    let modifiers = extract_modifiers(ns_event);
-
-    // Get scroll delta
-    let delta_x: f64 = msg_send![ns_event, scrollingDeltaX];
-    let delta_y: f64 = msg_send![ns_event, scrollingDeltaY];
-
-    // Check if precise scrolling (trackpad) or line scrolling (mouse wheel)
-    let has_precise_delta: bool = msg_send![ns_event, hasPreciseScrollingDeltas];
-
-    let delta = if has_precise_delta {
-        // Trackpad: use pixel delta
-        ui_events::ScrollDelta::Pixels {
-            x: delta_x as f32,
-            y: delta_y as f32,
-        }
-    } else {
-        // Mouse wheel: use line delta
-        ui_events::ScrollDelta::Lines {
-            x: delta_x as f32,
-            y: delta_y as f32,
-        }
-    };
-
-    Some(PlatformInput::Pointer(PointerEvent {
-        pointer_id: PointerId(0),
-        pointer_type: PointerType::Mouse,
-        position,
-        buttons,
-        modifiers,
-        update: ui_events::pointer::PointerUpdate::Scroll { delta },
-    }))
-}
-
-/// Convert mouse enter/exit event
-unsafe fn convert_mouse_enter_exit(
+///
+/// # Safety
+///
+/// `ns_event` must be a valid, live `NSEvent*` of a scroll-wheel event.
+unsafe fn convert_scroll_event(
     ns_event: id,
     scale_factor: f64,
-    is_enter: bool,
+    view_height: f64,
 ) -> Option<PlatformInput> {
-    let position = extract_mouse_position(ns_event, scale_factor);
-    let buttons = extract_mouse_buttons(ns_event);
-    let modifiers = extract_modifiers(ns_event);
+    // SAFETY: caller guarantees `ns_event` validity; `scrollingDeltaX/Y` and
+    // `hasPreciseScrollingDeltas` are documented NSEvent getters.
+    unsafe {
+        let state = pointer_state(ns_event, scale_factor, view_height);
 
-    let update = if is_enter {
-        ui_events::pointer::PointerUpdate::Entered
-    } else {
-        ui_events::pointer::PointerUpdate::Exited
-    };
+        // Get scroll delta
+        let delta_x: f64 = msg_send![ns_event, scrollingDeltaX];
+        let delta_y: f64 = msg_send![ns_event, scrollingDeltaY];
 
-    Some(PlatformInput::Pointer(PointerEvent {
-        pointer_id: PointerId(0),
-        pointer_type: PointerType::Mouse,
-        position,
-        buttons,
-        modifiers,
-        update,
-    }))
+        // Check if precise scrolling (trackpad) or line scrolling (mouse wheel)
+        let has_precise_delta: bool = msg_send![ns_event, hasPreciseScrollingDeltas];
+
+        let delta = if has_precise_delta {
+            // Trackpad: use pixel delta
+            ScrollDelta::PixelDelta(PhysicalPosition::new(delta_x, delta_y))
+        } else {
+            // Mouse wheel: use line delta
+            ScrollDelta::LineDelta(delta_x as f32, delta_y as f32)
+        };
+
+        Some(PlatformInput::Pointer(PointerEvent::Scroll(
+            PointerScrollEvent {
+                pointer: primary_mouse_info(),
+                state,
+                delta,
+            },
+        )))
+    }
 }
 
 // ============================================================================
 // Helper Functions
 // ============================================================================
 
-/// Extract mouse position from NSEvent and convert to logical pixels
+/// Extract global mouse button state via `NSEvent.pressedMouseButtons`
 ///
-/// macOS coordinates are bottom-left origin, need to flip Y
-unsafe fn extract_mouse_position(ns_event: id, scale_factor: f64) -> Offset<Pixels> {
-    // Get location in window
-    let location: NSPoint = msg_send![ns_event, locationInWindow];
+/// # Safety
+///
+/// Must be called with AppKit loaded (any process that created an NSEvent).
+unsafe fn extract_mouse_buttons() -> PointerButtons {
+    // SAFETY: `+[NSEvent pressedMouseButtons]` is a class method returning a
+    // plain NSUInteger bitmask; no object lifetime is involved.
+    unsafe {
+        let buttons_mask: u64 = msg_send![class!(NSEvent), pressedMouseButtons];
 
-    // Convert to logical pixels (NSPoint is already in logical coordinates)
-    // Note: Y coordinate is bottom-up in macOS, will be flipped by window context
-    Offset::new(Pixels(location.x as f32), Pixels(location.y as f32))
-}
+        let mut buttons = PointerButtons::default();
 
-/// Extract mouse button state from NSEvent
-unsafe fn extract_mouse_buttons(ns_event: id) -> PointerButtons {
-    let buttons_mask: i64 = msg_send![class!(NSEvent), pressedMouseButtons];
+        if (buttons_mask & 0x1) != 0 {
+            buttons.insert(PointerButton::Primary);
+        }
+        if (buttons_mask & 0x2) != 0 {
+            buttons.insert(PointerButton::Secondary);
+        }
+        if (buttons_mask & 0x4) != 0 {
+            buttons.insert(PointerButton::Auxiliary);
+        }
 
-    let mut buttons = PointerButtons::default();
-
-    if (buttons_mask & 0x1) != 0 {
-        buttons.insert(PointerButton::Primary);
+        buttons
     }
-    if (buttons_mask & 0x2) != 0 {
-        buttons.insert(PointerButton::Secondary);
-    }
-    if (buttons_mask & 0x4) != 0 {
-        buttons.insert(PointerButton::Auxiliary);
-    }
-
-    buttons
 }
 
 // ============================================================================
@@ -384,37 +490,25 @@ mod tests {
     #[test]
     fn test_key_code_mappings() {
         // Arrow keys
-        assert_eq!(key_code_to_key(123), Some(Key::ArrowLeft));
-        assert_eq!(key_code_to_key(124), Some(Key::ArrowRight));
-        assert_eq!(key_code_to_key(125), Some(Key::ArrowDown));
-        assert_eq!(key_code_to_key(126), Some(Key::ArrowUp));
+        assert_eq!(key_code_to_key(123), Some(Key::Named(NamedKey::ArrowLeft)));
+        assert_eq!(key_code_to_key(124), Some(Key::Named(NamedKey::ArrowRight)));
+        assert_eq!(key_code_to_key(125), Some(Key::Named(NamedKey::ArrowDown)));
+        assert_eq!(key_code_to_key(126), Some(Key::Named(NamedKey::ArrowUp)));
 
         // Function keys
-        assert_eq!(key_code_to_key(122), Some(Key::F1));
-        assert_eq!(key_code_to_key(111), Some(Key::F12));
+        assert_eq!(key_code_to_key(122), Some(Key::Named(NamedKey::F1)));
+        assert_eq!(key_code_to_key(111), Some(Key::Named(NamedKey::F12)));
 
         // Special keys
-        assert_eq!(key_code_to_key(36), Some(Key::Enter));
-        assert_eq!(key_code_to_key(48), Some(Key::Tab));
-        assert_eq!(key_code_to_key(51), Some(Key::Backspace));
-        assert_eq!(key_code_to_key(53), Some(Key::Escape));
+        assert_eq!(key_code_to_key(36), Some(Key::Named(NamedKey::Enter)));
+        assert_eq!(key_code_to_key(48), Some(Key::Named(NamedKey::Tab)));
+        assert_eq!(key_code_to_key(51), Some(Key::Named(NamedKey::Backspace)));
+        assert_eq!(key_code_to_key(53), Some(Key::Named(NamedKey::Escape)));
+
+        // Space maps to a character key
+        assert_eq!(key_code_to_key(49), Some(Key::Character(" ".to_string())));
 
         // Unknown key
         assert_eq!(key_code_to_key(999), None);
-    }
-
-    #[test]
-    fn test_position_conversion() {
-        // Position conversion is already in logical pixels in NSEvent
-        // This test just documents the expected behavior
-        let scale_1x = 1.0;
-        let scale_2x = 2.0;
-
-        // At 1x scale, coordinates are 1:1
-        // At 2x scale (Retina), NSEvent.locationInWindow is still in logical pixels
-        // No conversion needed (macOS does this automatically)
-
-        assert_eq!(scale_1x, 1.0);
-        assert_eq!(scale_2x, 2.0);
     }
 }

--- a/crates/flui-platform/src/platforms/macos/liquid_glass.rs
+++ b/crates/flui-platform/src/platforms/macos/liquid_glass.rs
@@ -4,19 +4,14 @@
 //! Tahoe 26. It provides rich, dynamic materials with depth, blur, and vibrancy
 //! effects.
 //!
+//! Implemented on top of `NSVisualEffectView` via raw `objc` messaging (the
+//! same Objective-C binding stack as the rest of this backend); the dedicated
+//! Liquid Glass API will be adopted once exposed by AppKit.
+//!
 //! # Reference
 //! - macOS Tahoe 26 (Released September 15, 2025)
 //! - FINAL macOS version supporting Intel Macs
 //! - Design System: https://developer.apple.com/design/human-interface-guidelines/materials
-
-#[cfg(target_os = "macos")]
-use objc2::rc::Retained;
-#[cfg(target_os = "macos")]
-use objc2_app_kit::{
-    NSView, NSVisualEffectBlendingMode, NSVisualEffectMaterial, NSVisualEffectView,
-};
-#[cfg(target_os = "macos")]
-use objc2_foundation::MainThreadMarker;
 
 /// Liquid Glass material variants introduced in macOS Tahoe 26
 ///
@@ -90,42 +85,39 @@ impl LiquidGlassMaterial {
         }
     }
 
-    /// Map to NSVisualEffectMaterial
+    /// Map to a raw `NSVisualEffectMaterial` value for `setMaterial:`.
     ///
-    /// Liquid Glass uses enhanced NSVisualEffectView with new materials
-    /// introduced in macOS Tahoe 26.
-    #[cfg(target_os = "macos")]
-    pub(crate) fn to_ns_material(self) -> NSVisualEffectMaterial {
+    /// Raw values per AppKit's `NSVisualEffectMaterial` enum:
+    /// `menu = 5`, `popover = 6`, `sidebar = 7`, `hudWindow = 13`,
+    /// `contentBackground = 18`.
+    ///
+    /// These mappings are approximations until the official Liquid Glass API
+    /// is exposed; macOS Tahoe 26 will provide dedicated materials.
+    pub(crate) fn to_ns_visual_effect_material(self) -> usize {
         match self {
-            // Note: These mappings are approximations until official Liquid Glass API is available
-            // In macOS Tahoe 26, Apple will provide dedicated LiquidGlass materials
-            LiquidGlassMaterial::Standard => NSVisualEffectMaterial::ContentBackground,
-            LiquidGlassMaterial::Prominent => NSVisualEffectMaterial::HUDWindow,
-            LiquidGlassMaterial::Sidebar => NSVisualEffectMaterial::Sidebar,
-            LiquidGlassMaterial::Menu => NSVisualEffectMaterial::Menu,
-            LiquidGlassMaterial::Popover => NSVisualEffectMaterial::Popover,
-            LiquidGlassMaterial::ControlCenter => NSVisualEffectMaterial::HUDWindow,
+            LiquidGlassMaterial::Standard => 18,      // contentBackground
+            LiquidGlassMaterial::Prominent => 13,     // hudWindow
+            LiquidGlassMaterial::Sidebar => 7,        // sidebar
+            LiquidGlassMaterial::Menu => 5,           // menu
+            LiquidGlassMaterial::Popover => 6,        // popover
+            LiquidGlassMaterial::ControlCenter => 13, // hudWindow
         }
     }
 
     /// Check if Liquid Glass is available on this system
     ///
     /// Liquid Glass requires macOS Tahoe 26 or later.
-    #[cfg(target_os = "macos")]
     pub fn is_available() -> bool {
         // Check macOS version
         if let Ok(version) = std::process::Command::new("sw_vers")
             .arg("-productVersion")
             .output()
+            && let Ok(version_str) = String::from_utf8(version.stdout)
+            // Parse version (e.g., "26.0.0" for Tahoe)
+            && let Some(major) = version_str.split('.').next()
+            && let Ok(major_version) = major.trim().parse::<u32>()
         {
-            if let Ok(version_str) = String::from_utf8(version.stdout) {
-                // Parse version (e.g., "26.0.0" for Tahoe)
-                if let Some(major) = version_str.split('.').next() {
-                    if let Ok(major_version) = major.trim().parse::<u32>() {
-                        return major_version >= 26; // Tahoe is macOS 26
-                    }
-                }
-            }
+            return major_version >= 26; // Tahoe is macOS 26
         }
         false
     }
@@ -150,6 +142,10 @@ pub struct LiquidGlassConfig {
 
     /// Vibrancy strength (0.0-1.0, default: 1.0)
     pub vibrancy: f32,
+
+    /// Extend the material under a transparent titlebar
+    /// (`NSFullSizeContentViewWindowMask` + `titlebarAppearsTransparent`)
+    pub transparent_titlebar: bool,
 }
 
 impl LiquidGlassConfig {
@@ -161,30 +157,49 @@ impl LiquidGlassConfig {
             tint: None,
             blending_mode: BlendingMode::BehindWindow,
             vibrancy: 1.0,
+            transparent_titlebar: false,
         }
     }
 
+    /// Create a configuration from a material with default settings
+    ///
+    /// Alias for [`LiquidGlassConfig::new`].
+    pub fn from_material(material: LiquidGlassMaterial) -> Self {
+        Self::new(material)
+    }
+
     /// Set custom blur radius
+    #[must_use]
     pub fn with_blur_radius(mut self, radius: f32) -> Self {
         self.blur_radius = Some(radius);
         self
     }
 
     /// Set custom tint color
+    #[must_use]
     pub fn with_tint(mut self, r: f32, g: f32, b: f32, a: f32) -> Self {
         self.tint = Some((r, g, b, a));
         self
     }
 
     /// Set blending mode
+    #[must_use]
     pub fn with_blending_mode(mut self, mode: BlendingMode) -> Self {
         self.blending_mode = mode;
         self
     }
 
     /// Set vibrancy strength
+    #[must_use]
     pub fn with_vibrancy(mut self, vibrancy: f32) -> Self {
         self.vibrancy = vibrancy.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Make the titlebar transparent so the material extends under it
+    #[must_use]
+    pub fn with_transparent_titlebar(mut self, transparent: bool) -> Self {
+        self.transparent_titlebar = transparent;
         self
     }
 
@@ -216,59 +231,16 @@ pub enum BlendingMode {
     WithinWindow,
 }
 
-#[cfg(target_os = "macos")]
 impl BlendingMode {
-    pub(crate) fn to_ns_blending_mode(self) -> NSVisualEffectBlendingMode {
+    /// Map to a raw `NSVisualEffectBlendingMode` value for `setBlendingMode:`.
+    ///
+    /// Raw values per AppKit: `behindWindow = 0`, `withinWindow = 1`.
+    pub(crate) fn to_ns_blending_mode(self) -> usize {
         match self {
-            BlendingMode::BehindWindow => NSVisualEffectBlendingMode::BehindWindow,
-            BlendingMode::WithinWindow => NSVisualEffectBlendingMode::WithinWindow,
+            BlendingMode::BehindWindow => 0,
+            BlendingMode::WithinWindow => 1,
         }
     }
-}
-
-/// Apply Liquid Glass material to an NSView
-///
-/// This creates an NSVisualEffectView with Liquid Glass configuration and adds
-/// it as a subview.
-///
-/// # Safety
-/// Must be called on the main thread.
-#[cfg(target_os = "macos")]
-pub unsafe fn apply_liquid_glass_to_view(
-    parent_view: &NSView,
-    config: &LiquidGlassConfig,
-    _mtm: MainThreadMarker,
-) -> Retained<NSVisualEffectView> {
-    // Create NSVisualEffectView
-    let effect_view = NSVisualEffectView::new(_mtm);
-
-    // Set material
-    effect_view.setMaterial(config.material.to_ns_material());
-
-    // Set blending mode
-    effect_view.setBlendingMode(config.blending_mode.to_ns_blending_mode());
-
-    // Set state (active for vibrancy)
-    effect_view.setState(objc2_app_kit::NSVisualEffectState::Active);
-
-    // Set appearance (auto - follows system theme)
-    effect_view.setAppearance(None);
-
-    // Match parent view frame
-    effect_view.setFrame(parent_view.frame());
-    effect_view.setAutoresizingMask(
-        objc2_app_kit::NSAutoresizingMaskOptions::NSViewWidthSizable
-            | objc2_app_kit::NSAutoresizingMaskOptions::NSViewHeightSizable,
-    );
-
-    // Add as subview (behind content)
-    parent_view.addSubview_positioned_relativeTo(
-        &effect_view,
-        objc2_app_kit::NSWindowOrderingMode::Below,
-        None,
-    );
-
-    effect_view
 }
 
 #[cfg(test)]
@@ -291,10 +263,10 @@ mod tests {
             assert!(blur > 0.0, "Blur radius must be positive");
 
             let (r, g, b, a) = material.default_tint();
-            assert!(r >= 0.0 && r <= 1.0);
-            assert!(g >= 0.0 && g <= 1.0);
-            assert!(b >= 0.0 && b <= 1.0);
-            assert!(a >= 0.0 && a <= 1.0);
+            assert!((0.0..=1.0).contains(&r));
+            assert!((0.0..=1.0).contains(&g));
+            assert!((0.0..=1.0).contains(&b));
+            assert!((0.0..=1.0).contains(&a));
         }
     }
 
@@ -316,6 +288,15 @@ mod tests {
         let config = LiquidGlassConfig::default();
         assert_eq!(config.material, LiquidGlassMaterial::Standard);
         assert_eq!(config.vibrancy, 1.0);
+        assert!(!config.transparent_titlebar);
+    }
+
+    #[test]
+    fn test_from_material_matches_new() {
+        let a = LiquidGlassConfig::from_material(LiquidGlassMaterial::Menu);
+        let b = LiquidGlassConfig::new(LiquidGlassMaterial::Menu);
+        assert_eq!(a.material, b.material);
+        assert_eq!(a.transparent_titlebar, b.transparent_titlebar);
     }
 
     #[test]
@@ -325,5 +306,16 @@ mod tests {
 
         let config = LiquidGlassConfig::default().with_vibrancy(-0.5);
         assert_eq!(config.vibrancy, 0.0);
+    }
+
+    #[test]
+    fn test_material_raw_values() {
+        assert_eq!(
+            LiquidGlassMaterial::Sidebar.to_ns_visual_effect_material(),
+            7
+        );
+        assert_eq!(LiquidGlassMaterial::Menu.to_ns_visual_effect_material(), 5);
+        assert_eq!(BlendingMode::BehindWindow.to_ns_blending_mode(), 0);
+        assert_eq!(BlendingMode::WithinWindow.to_ns_blending_mode(), 1);
     }
 }

--- a/crates/flui-platform/src/platforms/macos/mod.rs
+++ b/crates/flui-platform/src/platforms/macos/mod.rs
@@ -32,8 +32,10 @@
 //! }));
 //! ```
 
-#[macro_use]
-extern crate objc;
+// cocoa 0.26 deprecates its entire API surface in favor of the objc2 family;
+// this backend deliberately stays on the single cocoa/objc stack until a
+// dedicated objc2 migration replaces it wholesale.
+#![allow(deprecated)]
 
 mod clipboard;
 mod display;

--- a/crates/flui-platform/src/platforms/macos/platform.rs
+++ b/crates/flui-platform/src/platforms/macos/platform.rs
@@ -5,23 +5,24 @@ use std::{collections::HashMap, sync::Arc};
 use anyhow::{Context, Result};
 use cocoa::{
     appkit::{NSApp, NSApplication, NSApplicationActivationPolicyRegular},
-    base::{id, nil},
+    base::{YES, id, nil},
 };
-use objc::runtime::Object;
+use objc::{class, msg_send, sel, sel_impl};
 use parking_lot::Mutex;
 
+use super::{display, window::MacOSWindow};
 use crate::{
     config::WindowConfiguration,
     executor::{BackgroundExecutor, ForegroundExecutor},
     shared::PlatformHandlers,
-    traits::*,
+    traits::{
+        Clipboard, DesktopCapabilities, Platform, PlatformCapabilities, PlatformDisplay,
+        PlatformExecutor, PlatformWindow, WindowEvent, WindowId, WindowOptions,
+    },
 };
 
-mod display;
-mod window;
-
-pub use display::MacOSDisplay;
-pub use window::MacOSWindow;
+/// Capabilities descriptor shared by all macOS platform instances.
+static MACOS_CAPABILITIES: DesktopCapabilities = DesktopCapabilities;
 
 /// macOS platform state
 pub struct MacOSPlatform {
@@ -44,7 +45,13 @@ pub struct MacOSPlatform {
     config: WindowConfiguration,
 }
 
+// SAFETY: the NSApplication pointer is a process-wide singleton only messaged
+// from the main thread (AppKit convention); all other fields are
+// `Arc`/`Mutex`-protected. `Platform: Send + Sync` requires the wrapper to be
+// shareable.
 unsafe impl Send for MacOSPlatform {}
+// SAFETY: see `Send` above — interior mutability is Mutex-guarded and the raw
+// pointer is main-thread-affine by AppKit convention.
 unsafe impl Sync for MacOSPlatform {}
 
 impl MacOSPlatform {
@@ -55,6 +62,9 @@ impl MacOSPlatform {
 
     /// Create a new macOS platform with custom configuration
     pub fn with_config(config: WindowConfiguration) -> Result<Self> {
+        // SAFETY: must run on the main thread (the platform owns the event
+        // loop); `NSApp()` returns the shared application singleton which is
+        // nil-checked before use.
         unsafe {
             // Initialize NSApplication
             let app = NSApp();
@@ -98,25 +108,25 @@ impl Platform for MacOSPlatform {
     }
 
     fn run(self: Box<Self>, on_finish_launching: Box<dyn FnOnce()>) {
+        // SAFETY: runs on the main thread; `self.app` is the live
+        // NSApplication singleton.
         unsafe {
             // Call the launch callback
             on_finish_launching();
 
             // Activate the app (bring to foreground)
-            self.app.activateIgnoringOtherApps_(true);
+            self.app.activateIgnoringOtherApps_(YES);
 
-            // Set up event handling (custom sendEvent to intercept input)
-            // Note: For now, we rely on NSWindowDelegate for window events
-            // Input events can be handled via NSResponder chain or custom NSApplication
-            // subclass
-
-            // Run the NSApplication event loop
+            // Run the NSApplication event loop. Window lifecycle events are
+            // delivered via NSWindowDelegate; input events via the content
+            // view's NSResponder chain.
             tracing::info!("Starting NSApplication event loop");
             self.app.run();
         }
     }
 
     fn quit(&self) {
+        // SAFETY: `self.app` is the live NSApplication singleton.
         unsafe {
             tracing::info!("Requesting application quit");
             let _: () = msg_send![self.app, terminate: nil];
@@ -124,17 +134,14 @@ impl Platform for MacOSPlatform {
     }
 
     fn open_window(&self, options: WindowOptions) -> Result<Box<dyn PlatformWindow>> {
-        let window = MacOSWindow::new(
-            options,
-            Arc::clone(&self.windows),
-            Arc::clone(&self.handlers),
-            self.config.clone(),
-        )?;
+        let window = MacOSWindow::new(options, Arc::clone(&self.windows), self.config.clone())?;
 
         Ok(Box::new(window))
     }
 
     fn active_window(&self) -> Option<WindowId> {
+        // SAFETY: `self.app` is the live NSApplication singleton; `keyWindow`
+        // returns nil or a live NSWindow whose pointer value is used as an id.
         unsafe {
             let key_window: id = msg_send![self.app, keyWindow];
             if key_window != nil {
@@ -157,12 +164,11 @@ impl Platform for MacOSPlatform {
     }
 
     fn clipboard(&self) -> Arc<dyn Clipboard> {
-        Arc::new(crate::platforms::macos::MacOSClipboard::new())
+        Arc::new(super::MacOSClipboard::new())
     }
 
     fn capabilities(&self) -> &dyn PlatformCapabilities {
-        // TODO: Return macOS capabilities
-        unimplemented!("macOS capabilities not yet implemented") // PORT-CHECK-OK-STUB: macOS platform-init deferred to Core.0 → Core.1 native-platform track (ROADMAP.md)
+        &MACOS_CAPABILITIES
     }
 
     fn name(&self) -> &'static str {
@@ -180,9 +186,10 @@ impl Platform for MacOSPlatform {
     }
 
     fn app_path(&self) -> Result<std::path::PathBuf> {
+        // SAFETY: `mainBundle` returns the shared NSBundle singleton; both it
+        // and `bundlePath` are nil-checked, and the UTF8String buffer is
+        // copied into an owned PathBuf before the autorelease pool drains.
         unsafe {
-            use cocoa::foundation::NSBundle;
-
             let bundle: id = msg_send![class!(NSBundle), mainBundle];
             if bundle == nil {
                 return Err(anyhow::anyhow!("Failed to get main bundle"));
@@ -193,8 +200,10 @@ impl Platform for MacOSPlatform {
                 return Err(anyhow::anyhow!("Failed to get bundle path"));
             }
 
-            use cocoa::foundation::NSString;
-            let c_str = NSString::UTF8String(path);
+            let c_str: *const i8 = msg_send![path, UTF8String];
+            if c_str.is_null() {
+                return Err(anyhow::anyhow!("Bundle path has no UTF-8 representation"));
+            }
             let rust_str = std::ffi::CStr::from_ptr(c_str)
                 .to_str()
                 .context("Invalid UTF-8 in bundle path")?;

--- a/crates/flui-platform/src/platforms/macos/view.rs
+++ b/crates/flui-platform/src/platforms/macos/view.rs
@@ -97,6 +97,53 @@ extern "C" fn handle_input_event(this: &Object, _sel: Sel, event: id) {
     }
 }
 
+/// Dispatch a hover status change through the per-window callbacks.
+fn dispatch_hover_change(this: &Object, is_hovered: bool) {
+    // SAFETY: `this` is a live FLUIContentView (AppKit only invokes methods on
+    // live objects); `get_context`'s ivar contract holds for views created by
+    // `create_content_view`.
+    unsafe {
+        if let Some(ctx) = get_context(this)
+            && let Some(callbacks) = ctx.callbacks.upgrade()
+        {
+            callbacks.dispatch_hover_status_change(is_hovered);
+        }
+    }
+}
+
+/// mouseEntered: — report hover gained, then forward the pointer event.
+extern "C" fn mouse_entered(this: &Object, sel: Sel, event: id) {
+    dispatch_hover_change(this, true);
+    handle_input_event(this, sel, event);
+}
+
+/// mouseExited: — report hover lost, then forward the pointer event.
+extern "C" fn mouse_exited(this: &Object, sel: Sel, event: id) {
+    dispatch_hover_change(this, false);
+    handle_input_event(this, sel, event);
+}
+
+/// drawRect: — the platform asks for content; forward as a frame request.
+///
+/// `request_redraw()` marks the view dirty via `setNeedsDisplay:`; AppKit then
+/// calls this method on the next display pass, which is where the
+/// per-window `on_request_frame` contract fires (the macOS analogue of the
+/// Windows backend's WM_PAINT dispatch).
+extern "C" fn draw_rect(this: &Object, _sel: Sel, dirty_rect: NSRect) {
+    // SAFETY: `this` is a live FLUIContentView; the super `drawRect:` message
+    // is the documented NSView teardown of the dirty region.
+    unsafe {
+        if let Some(ctx) = get_context(this)
+            && let Some(callbacks) = ctx.callbacks.upgrade()
+        {
+            callbacks.dispatch_request_frame();
+        }
+
+        let superclass = class!(NSView);
+        let _: () = msg_send![super(this, superclass), drawRect: dirty_rect];
+    }
+}
+
 /// Get or create the FLUIContentView class
 fn get_or_create_view_class() -> &'static Class {
     use std::sync::Once;
@@ -252,20 +299,26 @@ fn get_or_create_view_class() -> &'static Class {
                 handle_input_event as extern "C" fn(&Object, Sel, id),
             );
 
-            // Mouse enter/exit
+            // Mouse enter/exit (hover status + pointer event)
             decl.add_method(
                 sel!(mouseEntered:),
-                handle_input_event as extern "C" fn(&Object, Sel, id),
+                mouse_entered as extern "C" fn(&Object, Sel, id),
             );
             decl.add_method(
                 sel!(mouseExited:),
-                handle_input_event as extern "C" fn(&Object, Sel, id),
+                mouse_exited as extern "C" fn(&Object, Sel, id),
             );
 
             // Scroll
             decl.add_method(
                 sel!(scrollWheel:),
                 handle_input_event as extern "C" fn(&Object, Sel, id),
+            );
+
+            // Drawing — drawRect: drives the on_request_frame contract
+            decl.add_method(
+                sel!(drawRect:),
+                draw_rect as extern "C" fn(&Object, Sel, NSRect),
             );
 
             // Lifecycle

--- a/crates/flui-platform/src/platforms/macos/view.rs
+++ b/crates/flui-platform/src/platforms/macos/view.rs
@@ -18,26 +18,25 @@
 //!     ↓
 //! convert_ns_event()
 //!     ↓
-//! dispatch_input_event()
-//!     ↓
-//! PlatformHandlers.on_input
+//! WindowCallbacks::dispatch_input
 //! ```
 
-use std::sync::{Arc, Weak};
+use std::sync::Weak;
 
 use cocoa::{
-    appkit::{NSEvent, NSView},
-    base::{BOOL, NO, YES, id, nil},
+    base::{BOOL, YES, id, nil},
     foundation::NSRect,
 };
 use objc::{
+    class,
     declare::ClassDecl,
+    msg_send,
     runtime::{Class, Object, Sel},
+    sel, sel_impl,
 };
-use parking_lot::Mutex;
 
 use super::events::convert_ns_event;
-use crate::{shared::PlatformHandlers, traits::input::PlatformInput};
+use crate::shared::WindowCallbacks;
 
 // ============================================================================
 // FLUIContentView Creation
@@ -50,17 +49,20 @@ use crate::{shared::PlatformHandlers, traits::input::PlatformInput};
 pub fn create_content_view(
     frame: NSRect,
     scale_factor: f64,
-    handlers: Weak<Mutex<PlatformHandlers>>,
+    callbacks: Weak<WindowCallbacks>,
 ) -> id {
+    // SAFETY: FLUIContentView is registered before alloc/init; the boxed
+    // ViewContext pointer is stored in the view's ivar and released in
+    // `dealloc`, so it lives exactly as long as the view.
     unsafe {
         let class = get_or_create_view_class();
         let view: id = msg_send![class, alloc];
         let view: id = msg_send![view, initWithFrame: frame];
 
-        // Store context (scale factor + handlers)
+        // Store context (scale factor + callbacks)
         let context = Box::into_raw(Box::new(ViewContext {
             scale_factor,
-            handlers,
+            callbacks,
         })) as *mut std::ffi::c_void;
         (*view).set_ivar("context_ptr", context);
 
@@ -71,12 +73,29 @@ pub fn create_content_view(
 /// Context stored in NSView ivar
 struct ViewContext {
     scale_factor: f64,
-    handlers: Weak<Mutex<PlatformHandlers>>,
+    callbacks: Weak<WindowCallbacks>,
 }
 
 // ============================================================================
 // NSView Class Definition
 // ============================================================================
+
+/// Handle an input NSEvent arriving at a FLUIContentView method.
+///
+/// Converts the event and dispatches it through the per-window callbacks.
+extern "C" fn handle_input_event(this: &Object, _sel: Sel, event: id) {
+    // SAFETY: `this` is a live FLUIContentView (AppKit only invokes methods on
+    // live objects); `event` is a valid NSEvent* for the duration of the call;
+    // `bounds` is a plain NSRect getter.
+    unsafe {
+        if let Some(ctx) = get_context(this) {
+            let bounds: NSRect = msg_send![this, bounds];
+            if let Some(input) = convert_ns_event(event, ctx.scale_factor, bounds.size.height) {
+                dispatch_input_event(ctx, input);
+            }
+        }
+    }
+}
 
 /// Get or create the FLUIContentView class
 fn get_or_create_view_class() -> &'static Class {
@@ -85,7 +104,8 @@ fn get_or_create_view_class() -> &'static Class {
 
     INIT.call_once(|| {
         let superclass = class!(NSView);
-        let mut decl = ClassDecl::new("FLUIContentView", superclass).unwrap();
+        let mut decl = ClassDecl::new("FLUIContentView", superclass)
+            .expect("FLUIContentView must be registered exactly once (guarded by Once)");
 
         // Add ivar to store context
         decl.add_ivar::<*mut std::ffi::c_void>("context_ptr");
@@ -95,191 +115,58 @@ fn get_or_create_view_class() -> &'static Class {
         // =================================================================
 
         // acceptsFirstResponder - Allow view to become first responder
-        unsafe extern "C" fn accepts_first_responder(_this: &Object, _sel: Sel) -> BOOL {
+        extern "C" fn accepts_first_responder(_this: &Object, _sel: Sel) -> BOOL {
             YES
         }
 
         // becomeFirstResponder
-        unsafe extern "C" fn become_first_responder(this: &Object, _sel: Sel) -> BOOL {
+        extern "C" fn become_first_responder(_this: &Object, _sel: Sel) -> BOOL {
             tracing::debug!("FLUIContentView became first responder");
             YES
         }
 
         // resignFirstResponder
-        unsafe extern "C" fn resign_first_responder(this: &Object, _sel: Sel) -> BOOL {
+        extern "C" fn resign_first_responder(_this: &Object, _sel: Sel) -> BOOL {
             tracing::debug!("FLUIContentView resigned first responder");
             YES
         }
 
-        // =================================================================
-        // Keyboard Events
-        // =================================================================
-
-        unsafe extern "C" fn key_down(this: &Object, _sel: Sel, event: id) {
-            if let Some(ctx) = get_context(this) {
-                if let Some(input) = convert_ns_event(event, ctx.scale_factor) {
-                    dispatch_input_event(&ctx, input);
-                }
-            }
-        }
-
-        unsafe extern "C" fn key_up(this: &Object, _sel: Sel, event: id) {
-            if let Some(ctx) = get_context(this) {
-                if let Some(input) = convert_ns_event(event, ctx.scale_factor) {
-                    dispatch_input_event(&ctx, input);
-                }
-            }
-        }
-
-        unsafe extern "C" fn flags_changed(this: &Object, _sel: Sel, event: id) {
-            // Modifier keys (Shift, Control, Alt, Command) changed
-            // For now, we handle modifiers in key events themselves
+        // flagsChanged: — modifier keys (Shift, Control, Alt, Command).
+        // Modifier state is carried on every converted event, so flag-only
+        // transitions are observed but not dispatched separately.
+        extern "C" fn flags_changed(_this: &Object, _sel: Sel, _event: id) {
             tracing::trace!("Modifier flags changed");
-        }
-
-        // =================================================================
-        // Mouse Events
-        // =================================================================
-
-        // Left mouse button
-        unsafe extern "C" fn mouse_down(this: &Object, _sel: Sel, event: id) {
-            if let Some(ctx) = get_context(this) {
-                if let Some(input) = convert_ns_event(event, ctx.scale_factor) {
-                    dispatch_input_event(&ctx, input);
-                }
-            }
-        }
-
-        unsafe extern "C" fn mouse_up(this: &Object, _sel: Sel, event: id) {
-            if let Some(ctx) = get_context(this) {
-                if let Some(input) = convert_ns_event(event, ctx.scale_factor) {
-                    dispatch_input_event(&ctx, input);
-                }
-            }
-        }
-
-        unsafe extern "C" fn mouse_moved(this: &Object, _sel: Sel, event: id) {
-            if let Some(ctx) = get_context(this) {
-                if let Some(input) = convert_ns_event(event, ctx.scale_factor) {
-                    dispatch_input_event(&ctx, input);
-                }
-            }
-        }
-
-        unsafe extern "C" fn mouse_dragged(this: &Object, _sel: Sel, event: id) {
-            if let Some(ctx) = get_context(this) {
-                if let Some(input) = convert_ns_event(event, ctx.scale_factor) {
-                    dispatch_input_event(&ctx, input);
-                }
-            }
-        }
-
-        // Right mouse button
-        unsafe extern "C" fn right_mouse_down(this: &Object, _sel: Sel, event: id) {
-            if let Some(ctx) = get_context(this) {
-                if let Some(input) = convert_ns_event(event, ctx.scale_factor) {
-                    dispatch_input_event(&ctx, input);
-                }
-            }
-        }
-
-        unsafe extern "C" fn right_mouse_up(this: &Object, _sel: Sel, event: id) {
-            if let Some(ctx) = get_context(this) {
-                if let Some(input) = convert_ns_event(event, ctx.scale_factor) {
-                    dispatch_input_event(&ctx, input);
-                }
-            }
-        }
-
-        unsafe extern "C" fn right_mouse_dragged(this: &Object, _sel: Sel, event: id) {
-            if let Some(ctx) = get_context(this) {
-                if let Some(input) = convert_ns_event(event, ctx.scale_factor) {
-                    dispatch_input_event(&ctx, input);
-                }
-            }
-        }
-
-        // Other mouse button (middle, etc.)
-        unsafe extern "C" fn other_mouse_down(this: &Object, _sel: Sel, event: id) {
-            if let Some(ctx) = get_context(this) {
-                if let Some(input) = convert_ns_event(event, ctx.scale_factor) {
-                    dispatch_input_event(&ctx, input);
-                }
-            }
-        }
-
-        unsafe extern "C" fn other_mouse_up(this: &Object, _sel: Sel, event: id) {
-            if let Some(ctx) = get_context(this) {
-                if let Some(input) = convert_ns_event(event, ctx.scale_factor) {
-                    dispatch_input_event(&ctx, input);
-                }
-            }
-        }
-
-        unsafe extern "C" fn other_mouse_dragged(this: &Object, _sel: Sel, event: id) {
-            if let Some(ctx) = get_context(this) {
-                if let Some(input) = convert_ns_event(event, ctx.scale_factor) {
-                    dispatch_input_event(&ctx, input);
-                }
-            }
-        }
-
-        // Mouse enter/exit
-        unsafe extern "C" fn mouse_entered(this: &Object, _sel: Sel, event: id) {
-            if let Some(ctx) = get_context(this) {
-                if let Some(input) = convert_ns_event(event, ctx.scale_factor) {
-                    dispatch_input_event(&ctx, input);
-                }
-            }
-        }
-
-        unsafe extern "C" fn mouse_exited(this: &Object, _sel: Sel, event: id) {
-            if let Some(ctx) = get_context(this) {
-                if let Some(input) = convert_ns_event(event, ctx.scale_factor) {
-                    dispatch_input_event(&ctx, input);
-                }
-            }
-        }
-
-        // =================================================================
-        // Scroll Events
-        // =================================================================
-
-        unsafe extern "C" fn scroll_wheel(this: &Object, _sel: Sel, event: id) {
-            if let Some(ctx) = get_context(this) {
-                if let Some(input) = convert_ns_event(event, ctx.scale_factor) {
-                    dispatch_input_event(&ctx, input);
-                }
-            }
         }
 
         // =================================================================
         // View Lifecycle
         // =================================================================
 
-        unsafe extern "C" fn dealloc(this: &Object, _sel: Sel) {
-            // Clean up context
-            let context_ptr: *mut std::ffi::c_void = *this.get_ivar("context_ptr");
-            if !context_ptr.is_null() {
-                let _context = Box::from_raw(context_ptr as *mut ViewContext);
-                // Drop context
-            }
+        extern "C" fn dealloc(this: &Object, _sel: Sel) {
+            // SAFETY: the ivar holds either null or a Box<ViewContext> leaked
+            // in `create_content_view`; reclaiming it here (exactly once, on
+            // dealloc) is the matching release. The super dealloc message is
+            // the mandatory NSObject teardown.
+            unsafe {
+                let context_ptr: *mut std::ffi::c_void = *this.get_ivar("context_ptr");
+                if !context_ptr.is_null() {
+                    drop(Box::from_raw(context_ptr as *mut ViewContext));
+                }
 
-            // Call super dealloc
-            let superclass = class!(NSView);
-            let dealloc: extern "C" fn(&Object, Sel) =
-                std::mem::transmute(msg_send![super(this, superclass), dealloc]);
+                let superclass = class!(NSView);
+                let _: () = msg_send![super(this, superclass), dealloc];
+            }
         }
 
         // =================================================================
         // View Drawing (Optional)
         // =================================================================
 
-        unsafe extern "C" fn is_opaque(_this: &Object, _sel: Sel) -> BOOL {
+        extern "C" fn is_opaque(_this: &Object, _sel: Sel) -> BOOL {
             YES // Our view is fully opaque
         }
 
-        unsafe extern "C" fn accepts_touch_events(_this: &Object, _sel: Sel) -> BOOL {
+        extern "C" fn accepts_touch_events(_this: &Object, _sel: Sel) -> BOOL {
             YES // Accept touch events for future trackpad gestures
         }
 
@@ -287,6 +174,9 @@ fn get_or_create_view_class() -> &'static Class {
         // Add Methods to Class
         // =================================================================
 
+        // SAFETY: every registered function pointer matches the Objective-C
+        // method signature of its selector (`&Object, Sel` plus the declared
+        // argument/return types), as required by `ClassDecl::add_method`.
         unsafe {
             // First responder
             decl.add_method(
@@ -303,8 +193,14 @@ fn get_or_create_view_class() -> &'static Class {
             );
 
             // Keyboard events
-            decl.add_method(sel!(keyDown:), key_down as extern "C" fn(&Object, Sel, id));
-            decl.add_method(sel!(keyUp:), key_up as extern "C" fn(&Object, Sel, id));
+            decl.add_method(
+                sel!(keyDown:),
+                handle_input_event as extern "C" fn(&Object, Sel, id),
+            );
+            decl.add_method(
+                sel!(keyUp:),
+                handle_input_event as extern "C" fn(&Object, Sel, id),
+            );
             decl.add_method(
                 sel!(flagsChanged:),
                 flags_changed as extern "C" fn(&Object, Sel, id),
@@ -313,60 +209,63 @@ fn get_or_create_view_class() -> &'static Class {
             // Left mouse
             decl.add_method(
                 sel!(mouseDown:),
-                mouse_down as extern "C" fn(&Object, Sel, id),
+                handle_input_event as extern "C" fn(&Object, Sel, id),
             );
-            decl.add_method(sel!(mouseUp:), mouse_up as extern "C" fn(&Object, Sel, id));
+            decl.add_method(
+                sel!(mouseUp:),
+                handle_input_event as extern "C" fn(&Object, Sel, id),
+            );
             decl.add_method(
                 sel!(mouseMoved:),
-                mouse_moved as extern "C" fn(&Object, Sel, id),
+                handle_input_event as extern "C" fn(&Object, Sel, id),
             );
             decl.add_method(
                 sel!(mouseDragged:),
-                mouse_dragged as extern "C" fn(&Object, Sel, id),
+                handle_input_event as extern "C" fn(&Object, Sel, id),
             );
 
             // Right mouse
             decl.add_method(
                 sel!(rightMouseDown:),
-                right_mouse_down as extern "C" fn(&Object, Sel, id),
+                handle_input_event as extern "C" fn(&Object, Sel, id),
             );
             decl.add_method(
                 sel!(rightMouseUp:),
-                right_mouse_up as extern "C" fn(&Object, Sel, id),
+                handle_input_event as extern "C" fn(&Object, Sel, id),
             );
             decl.add_method(
                 sel!(rightMouseDragged:),
-                right_mouse_dragged as extern "C" fn(&Object, Sel, id),
+                handle_input_event as extern "C" fn(&Object, Sel, id),
             );
 
             // Other mouse
             decl.add_method(
                 sel!(otherMouseDown:),
-                other_mouse_down as extern "C" fn(&Object, Sel, id),
+                handle_input_event as extern "C" fn(&Object, Sel, id),
             );
             decl.add_method(
                 sel!(otherMouseUp:),
-                other_mouse_up as extern "C" fn(&Object, Sel, id),
+                handle_input_event as extern "C" fn(&Object, Sel, id),
             );
             decl.add_method(
                 sel!(otherMouseDragged:),
-                other_mouse_dragged as extern "C" fn(&Object, Sel, id),
+                handle_input_event as extern "C" fn(&Object, Sel, id),
             );
 
             // Mouse enter/exit
             decl.add_method(
                 sel!(mouseEntered:),
-                mouse_entered as extern "C" fn(&Object, Sel, id),
+                handle_input_event as extern "C" fn(&Object, Sel, id),
             );
             decl.add_method(
                 sel!(mouseExited:),
-                mouse_exited as extern "C" fn(&Object, Sel, id),
+                handle_input_event as extern "C" fn(&Object, Sel, id),
             );
 
             // Scroll
             decl.add_method(
                 sel!(scrollWheel:),
-                scroll_wheel as extern "C" fn(&Object, Sel, id),
+                handle_input_event as extern "C" fn(&Object, Sel, id),
             );
 
             // Lifecycle
@@ -386,7 +285,7 @@ fn get_or_create_view_class() -> &'static Class {
         decl.register();
     });
 
-    Class::get("FLUIContentView").unwrap()
+    Class::get("FLUIContentView").expect("FLUIContentView was registered by the Once block above")
 }
 
 // ============================================================================
@@ -394,23 +293,30 @@ fn get_or_create_view_class() -> &'static Class {
 // ============================================================================
 
 /// Get view context from ivar
+///
+/// # Safety
+///
+/// `view` must be a live FLUIContentView whose `context_ptr` ivar is either
+/// null or points to a `ViewContext` owned by that view.
 unsafe fn get_context(view: &Object) -> Option<&ViewContext> {
-    let context_ptr: *mut std::ffi::c_void = *view.get_ivar("context_ptr");
-    if context_ptr.is_null() {
-        return None;
+    // SAFETY: per the function contract the ivar is null or a valid
+    // Box<ViewContext> pointer owned by the view; the returned shared
+    // reference cannot outlive the view method invocation that holds `view`.
+    unsafe {
+        let context_ptr: *mut std::ffi::c_void = *view.get_ivar("context_ptr");
+        if context_ptr.is_null() {
+            return None;
+        }
+        Some(&*(context_ptr as *const ViewContext))
     }
-    Some(&*(context_ptr as *const ViewContext))
 }
 
-/// Dispatch input event to platform handlers
-fn dispatch_input_event(ctx: &ViewContext, input: PlatformInput) {
-    if let Some(handlers) = ctx.handlers.upgrade() {
-        let handlers = handlers.lock();
-        if let Some(handler) = &handlers.on_input {
-            handler(input);
-        } else {
-            tracing::trace!("Input event received but no handler set: {:?}", input);
-        }
+/// Dispatch input event to the window's callbacks
+fn dispatch_input_event(ctx: &ViewContext, input: crate::traits::PlatformInput) {
+    if let Some(callbacks) = ctx.callbacks.upgrade() {
+        let _result = callbacks.dispatch_input(input);
+    } else {
+        tracing::trace!("Input event received after window callbacks were dropped");
     }
 }
 
@@ -420,8 +326,11 @@ fn dispatch_input_event(ctx: &ViewContext, input: PlatformInput) {
 
 /// Update view scale factor (called when window moves to different display)
 pub fn update_view_scale_factor(view: id, new_scale_factor: f64) {
+    // SAFETY: `view` is a live FLUIContentView (callers pass the window's
+    // content view); its ivar is null or a valid ViewContext owned by the
+    // view, and the mutation is confined to the main thread (AppKit calls).
     unsafe {
-        let context_ptr: *mut std::ffi::c_void = (*view).get_ivar("context_ptr");
+        let context_ptr: *mut std::ffi::c_void = *(*view).get_ivar("context_ptr");
         if !context_ptr.is_null() {
             let context = &mut *(context_ptr as *mut ViewContext);
             context.scale_factor = new_scale_factor;
@@ -430,19 +339,31 @@ pub fn update_view_scale_factor(view: id, new_scale_factor: f64) {
     }
 }
 
+/// `NSTrackingArea` option bits (cocoa 0.26 does not bind NSTrackingArea).
+///
+/// Raw values per AppKit's `NSTrackingAreaOptions`.
+mod tracking_area_options {
+    pub const MOUSE_ENTERED_AND_EXITED: u64 = 0x01;
+    pub const MOUSE_MOVED: u64 = 0x02;
+    pub const ACTIVE_IN_KEY_WINDOW: u64 = 0x20;
+    pub const IN_VISIBLE_RECT: u64 = 0x200;
+}
+
 /// Enable mouse tracking for mouse moved events
 pub fn enable_mouse_tracking(view: id) {
+    // SAFETY: `view` is a live NSView; NSTrackingArea is looked up via the
+    // runtime (the class always exists in AppKit), and `addTrackingArea:`
+    // retains the tracking area, so releasing our reference is handled by
+    // the view's lifetime.
     unsafe {
-        use cocoa::{appkit::NSTrackingArea, foundation::NSRect};
-
         // Get view bounds
         let bounds: NSRect = msg_send![view, bounds];
 
         // Create tracking area options
-        let options = cocoa::appkit::NSTrackingAreaOptions::NSTrackingMouseMoved
-            | cocoa::appkit::NSTrackingAreaOptions::NSTrackingActiveInKeyWindow
-            | cocoa::appkit::NSTrackingAreaOptions::NSTrackingMouseEnteredAndExited
-            | cocoa::appkit::NSTrackingAreaOptions::NSTrackingInVisibleRect;
+        let options: u64 = tracking_area_options::MOUSE_MOVED
+            | tracking_area_options::ACTIVE_IN_KEY_WINDOW
+            | tracking_area_options::MOUSE_ENTERED_AND_EXITED
+            | tracking_area_options::IN_VISIBLE_RECT;
 
         // Create tracking area
         let tracking_area: id = msg_send![class!(NSTrackingArea), alloc];

--- a/crates/flui-platform/src/platforms/macos/window.rs
+++ b/crates/flui-platform/src/platforms/macos/window.rs
@@ -329,12 +329,12 @@ impl PlatformWindow for MacOSWindow {
     fn resize(&self, size: Size<Pixels>) {
         // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
-            let frame: NSRect = msg_send![self.ns_window, frame];
-            let new_frame = NSRect::new(
-                frame.origin,
-                cocoa::foundation::NSSize::new(size.width.0 as f64, size.height.0 as f64),
-            );
-            let _: () = msg_send![self.ns_window, setFrame: new_frame display: YES];
+            // The stored size tracks the *content* area (see `handle_resize`
+            // using `contentRectForFrameRect:`), so resize the content, not
+            // the frame — on decorated windows a frame-sized `setFrame:`
+            // would shrink the content by the titlebar height.
+            let ns_size = cocoa::foundation::NSSize::new(size.width.0 as f64, size.height.0 as f64);
+            let _: () = msg_send![self.ns_window, setContentSize: ns_size];
 
             // Update state
             let mut state = self.state.lock();

--- a/crates/flui-platform/src/platforms/macos/window.rs
+++ b/crates/flui-platform/src/platforms/macos/window.rs
@@ -2,16 +2,19 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use cocoa::{
-    appkit::{NSBackingStoreType, NSWindow, NSWindowStyleMask},
+    appkit::{NSBackingStoreType, NSWindowStyleMask},
     base::{BOOL, NO, YES, id, nil},
     foundation::NSRect,
 };
 use flui_types::geometry::{Bounds, DevicePixels, Pixels, Point, Size};
 use objc::{
+    class,
     declare::ClassDecl,
+    msg_send,
     runtime::{Class, Object, Sel},
+    sel, sel_impl,
 };
 use parking_lot::Mutex;
 use raw_window_handle::{
@@ -20,7 +23,11 @@ use raw_window_handle::{
 };
 
 use super::view;
-use crate::{config::WindowConfiguration, shared::PlatformHandlers, traits::*};
+use crate::{
+    config::WindowConfiguration,
+    shared::WindowCallbacks,
+    traits::{DispatchEventResult, PlatformInput, PlatformWindow, WindowOptions},
+};
 
 /// macOS window wrapper around NSWindow
 pub struct MacOSWindow {
@@ -28,23 +35,29 @@ pub struct MacOSWindow {
     ns_window: id,
 
     /// Window state
-    state: Arc<Mutex<WindowState>>,
+    state: Arc<Mutex<MacOSWindowState>>,
 
     /// Reference to all windows
     windows_map: Arc<Mutex<HashMap<u64, Arc<MacOSWindow>>>>,
 
-    /// Platform handlers
-    handlers: Arc<Mutex<PlatformHandlers>>,
+    /// Per-window callbacks (input, resize, close, ...)
+    callbacks: Arc<WindowCallbacks>,
 
     /// Window configuration
     _config: WindowConfiguration,
 }
 
+// SAFETY: the NSWindow pointer is only messaged from the main thread (AppKit
+// delivers all delegate/view callbacks there); the remaining fields are
+// `Arc`/`Mutex`-protected. Sharing the wrapper across threads is required by
+// the `PlatformWindow: Send + Sync` contract.
 unsafe impl Send for MacOSWindow {}
+// SAFETY: see `Send` above — interior mutability is Mutex-guarded and the raw
+// pointer is main-thread-affine by AppKit convention.
 unsafe impl Sync for MacOSWindow {}
 
 /// Mutable window state
-struct WindowState {
+struct MacOSWindowState {
     /// Current window bounds (logical pixels)
     bounds: Bounds<Pixels>,
 
@@ -57,9 +70,11 @@ impl MacOSWindow {
     pub fn new(
         options: WindowOptions,
         windows_map: Arc<Mutex<HashMap<u64, Arc<MacOSWindow>>>>,
-        handlers: Arc<Mutex<PlatformHandlers>>,
         config: WindowConfiguration,
     ) -> Result<Arc<Self>> {
+        // SAFETY: must run on the main thread (enforced by the platform's
+        // event-loop ownership); all messaged objects are alive: the freshly
+        // allocated NSWindow is checked for nil before further use.
         unsafe {
             // Convert logical size to NSRect
             let frame = NSRect::new(
@@ -88,7 +103,7 @@ impl MacOSWindow {
                 initWithContentRect: frame
                 styleMask: style_mask
                 backing: NSBackingStoreType::NSBackingStoreBuffered
-                defer: false as i8
+                defer: NO
             ];
 
             if ns_window == nil {
@@ -99,6 +114,18 @@ impl MacOSWindow {
             let title = cocoa::foundation::NSString::alloc(nil);
             let title = cocoa::foundation::NSString::init_str(title, &options.title);
             let _: () = msg_send![ns_window, setTitle: title];
+
+            // Apply size constraints
+            if let Some(min) = options.min_size {
+                let ns_size =
+                    cocoa::foundation::NSSize::new(min.width.0 as f64, min.height.0 as f64);
+                let _: () = msg_send![ns_window, setMinSize: ns_size];
+            }
+            if let Some(max) = options.max_size {
+                let ns_size =
+                    cocoa::foundation::NSSize::new(max.width.0 as f64, max.height.0 as f64);
+                let _: () = msg_send![ns_window, setMaxSize: ns_size];
+            }
 
             // Get backing scale factor
             let scale: f64 = msg_send![ns_window, backingScaleFactor];
@@ -111,9 +138,11 @@ impl MacOSWindow {
             // Center window on screen
             let _: () = msg_send![ns_window, center];
 
+            let callbacks = Arc::new(WindowCallbacks::new());
+
             let window = Arc::new(Self {
                 ns_window,
-                state: Arc::new(Mutex::new(WindowState {
+                state: Arc::new(Mutex::new(MacOSWindowState {
                     bounds: Bounds {
                         origin: Point::new(
                             flui_types::geometry::px(frame.origin.x as f32),
@@ -124,12 +153,13 @@ impl MacOSWindow {
                     scale_factor: scale,
                 })),
                 windows_map: Arc::clone(&windows_map),
-                handlers: Arc::clone(&handlers),
+                callbacks,
                 _config: config,
             });
 
             // Create content view for input events
-            let content_view = view::create_content_view(frame, scale, Arc::downgrade(&handlers));
+            let content_view =
+                view::create_content_view(frame, scale, Arc::downgrade(&window.callbacks));
             let _: () = msg_send![ns_window, setContentView: content_view];
 
             // Enable mouse tracking for mouse moved events
@@ -162,16 +192,21 @@ impl MacOSWindow {
     pub fn ns_window(&self) -> id {
         self.ns_window
     }
+
+    /// Get the per-window callbacks registry
+    pub fn callbacks(&self) -> &Arc<WindowCallbacks> {
+        &self.callbacks
+    }
 }
 
 impl PlatformWindow for MacOSWindow {
     fn physical_size(&self) -> Size<DevicePixels> {
         let state = self.state.lock();
         let logical = state.bounds.size;
-        let scale = state.scale_factor;
+        let scale = state.scale_factor as f32;
         Size::new(
-            flui_types::geometry::device_px((logical.width.0 * scale as f32).round()),
-            flui_types::geometry::device_px((logical.height.0 * scale as f32).round()),
+            flui_types::geometry::device_px((logical.width.0 * scale).round() as i32),
+            flui_types::geometry::device_px((logical.height.0 * scale).round() as i32),
         )
     }
 
@@ -186,16 +221,19 @@ impl PlatformWindow for MacOSWindow {
     }
 
     fn request_redraw(&self) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`; the
+        // content view is nil-checked before messaging.
         unsafe {
             // Tell the window's content view to redraw
             let content_view: id = msg_send![self.ns_window, contentView];
             if content_view != nil {
-                let _: () = msg_send![content_view, setNeedsDisplay: true];
+                let _: () = msg_send![content_view, setNeedsDisplay: YES];
             }
         }
     }
 
     fn is_focused(&self) -> bool {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let is_key: bool = msg_send![self.ns_window, isKeyWindow];
             is_key
@@ -203,13 +241,39 @@ impl PlatformWindow for MacOSWindow {
     }
 
     fn is_visible(&self) -> bool {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let is_visible: bool = msg_send![self.ns_window, isVisible];
             is_visible
         }
     }
 
+    fn bounds(&self) -> Bounds<Pixels> {
+        self.state.lock().bounds
+    }
+
+    fn get_title(&self) -> String {
+        // SAFETY: `ns_window` is alive; `title` returns an autoreleased
+        // NSString whose UTF8String buffer is copied before returning.
+        unsafe {
+            let ns_title: id = msg_send![self.ns_window, title];
+            if ns_title == nil {
+                return String::new();
+            }
+            let c_str: *const i8 = msg_send![ns_title, UTF8String];
+            if c_str.is_null() {
+                String::new()
+            } else {
+                std::ffi::CStr::from_ptr(c_str)
+                    .to_string_lossy()
+                    .into_owned()
+            }
+        }
+    }
+
     fn set_title(&self, title: &str) {
+        // SAFETY: `ns_window` is alive; the NSString is created from a valid
+        // Rust string and ownership passes to the window.
         unsafe {
             let ns_title = cocoa::foundation::NSString::alloc(nil);
             let ns_title = cocoa::foundation::NSString::init_str(ns_title, title);
@@ -217,14 +281,60 @@ impl PlatformWindow for MacOSWindow {
         }
     }
 
-    fn set_size(&self, size: Size<Pixels>) {
+    fn activate(&self) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
+        unsafe {
+            let _: () = msg_send![self.ns_window, makeKeyAndOrderFront: nil];
+        }
+    }
+
+    fn minimize(&self) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
+        unsafe {
+            let _: () = msg_send![self.ns_window, miniaturize: nil];
+        }
+    }
+
+    fn maximize(&self) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
+        unsafe {
+            let is_zoomed: bool = msg_send![self.ns_window, isZoomed];
+            if !is_zoomed {
+                let _: () = msg_send![self.ns_window, zoom: nil];
+            }
+        }
+    }
+
+    fn restore(&self) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
+        unsafe {
+            let is_minimized: bool = msg_send![self.ns_window, isMiniaturized];
+            if is_minimized {
+                let _: () = msg_send![self.ns_window, deminiaturize: nil];
+            }
+            let is_zoomed: bool = msg_send![self.ns_window, isZoomed];
+            if is_zoomed {
+                let _: () = msg_send![self.ns_window, zoom: nil];
+            }
+        }
+    }
+
+    fn toggle_fullscreen(&self) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
+        unsafe {
+            let _: () = msg_send![self.ns_window, toggleFullScreen: nil];
+        }
+    }
+
+    fn resize(&self, size: Size<Pixels>) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let frame: NSRect = msg_send![self.ns_window, frame];
             let new_frame = NSRect::new(
                 frame.origin,
                 cocoa::foundation::NSSize::new(size.width.0 as f64, size.height.0 as f64),
             );
-            let _: () = msg_send![self.ns_window, setFrame: new_frame display: true];
+            let _: () = msg_send![self.ns_window, setFrame: new_frame display: YES];
 
             // Update state
             let mut state = self.state.lock();
@@ -233,9 +343,184 @@ impl PlatformWindow for MacOSWindow {
     }
 
     fn close(&self) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let _: () = msg_send![self.ns_window, close];
         }
+    }
+
+    // ==================== Callback Registration ====================
+
+    fn on_input(&self, callback: Box<dyn FnMut(PlatformInput) -> DispatchEventResult + Send>) {
+        *self.callbacks.on_input.lock() = Some(callback);
+    }
+
+    fn on_request_frame(&self, callback: Box<dyn FnMut() + Send>) {
+        *self.callbacks.on_request_frame.lock() = Some(callback);
+    }
+
+    fn on_resize(&self, callback: Box<dyn FnMut(Size<Pixels>, f32) + Send>) {
+        *self.callbacks.on_resize.lock() = Some(callback);
+    }
+
+    fn on_moved(&self, callback: Box<dyn FnMut() + Send>) {
+        *self.callbacks.on_moved.lock() = Some(callback);
+    }
+
+    fn on_close(&self, callback: Box<dyn FnOnce() + Send>) {
+        *self.callbacks.on_close.lock() = Some(callback);
+    }
+
+    fn on_should_close(&self, callback: Box<dyn FnMut() -> bool + Send>) {
+        *self.callbacks.on_should_close.lock() = Some(callback);
+    }
+
+    fn on_active_status_change(&self, callback: Box<dyn FnMut(bool) + Send>) {
+        *self.callbacks.on_active_status_change.lock() = Some(callback);
+    }
+
+    fn on_hover_status_change(&self, callback: Box<dyn FnMut(bool) + Send>) {
+        *self.callbacks.on_hover_status_change.lock() = Some(callback);
+    }
+
+    fn on_appearance_changed(&self, callback: Box<dyn FnMut() + Send>) {
+        *self.callbacks.on_appearance_changed.lock() = Some(callback);
+    }
+
+    fn window_handle(
+        &self,
+    ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
+        HasWindowHandle::window_handle(self)
+    }
+
+    fn display_handle(
+        &self,
+    ) -> Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
+        HasDisplayHandle::display_handle(self)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Delegating impl so `Arc<MacOSWindow>` can be boxed as a `PlatformWindow`
+/// (mirrors the Windows backend).
+impl PlatformWindow for Arc<MacOSWindow> {
+    fn physical_size(&self) -> Size<DevicePixels> {
+        self.as_ref().physical_size()
+    }
+
+    fn logical_size(&self) -> Size<Pixels> {
+        self.as_ref().logical_size()
+    }
+
+    fn scale_factor(&self) -> f64 {
+        PlatformWindow::scale_factor(self.as_ref())
+    }
+
+    fn request_redraw(&self) {
+        PlatformWindow::request_redraw(self.as_ref())
+    }
+
+    fn is_focused(&self) -> bool {
+        PlatformWindow::is_focused(self.as_ref())
+    }
+
+    fn is_visible(&self) -> bool {
+        PlatformWindow::is_visible(self.as_ref())
+    }
+
+    fn bounds(&self) -> Bounds<Pixels> {
+        PlatformWindow::bounds(self.as_ref())
+    }
+
+    fn get_title(&self) -> String {
+        PlatformWindow::get_title(self.as_ref())
+    }
+
+    fn set_title(&self, title: &str) {
+        PlatformWindow::set_title(self.as_ref(), title)
+    }
+
+    fn activate(&self) {
+        PlatformWindow::activate(self.as_ref())
+    }
+
+    fn minimize(&self) {
+        PlatformWindow::minimize(self.as_ref())
+    }
+
+    fn maximize(&self) {
+        PlatformWindow::maximize(self.as_ref())
+    }
+
+    fn restore(&self) {
+        PlatformWindow::restore(self.as_ref())
+    }
+
+    fn toggle_fullscreen(&self) {
+        PlatformWindow::toggle_fullscreen(self.as_ref())
+    }
+
+    fn resize(&self, size: Size<Pixels>) {
+        PlatformWindow::resize(self.as_ref(), size)
+    }
+
+    fn close(&self) {
+        PlatformWindow::close(self.as_ref())
+    }
+
+    fn on_input(&self, callback: Box<dyn FnMut(PlatformInput) -> DispatchEventResult + Send>) {
+        PlatformWindow::on_input(self.as_ref(), callback)
+    }
+
+    fn on_request_frame(&self, callback: Box<dyn FnMut() + Send>) {
+        PlatformWindow::on_request_frame(self.as_ref(), callback)
+    }
+
+    fn on_resize(&self, callback: Box<dyn FnMut(Size<Pixels>, f32) + Send>) {
+        PlatformWindow::on_resize(self.as_ref(), callback)
+    }
+
+    fn on_moved(&self, callback: Box<dyn FnMut() + Send>) {
+        PlatformWindow::on_moved(self.as_ref(), callback)
+    }
+
+    fn on_close(&self, callback: Box<dyn FnOnce() + Send>) {
+        PlatformWindow::on_close(self.as_ref(), callback)
+    }
+
+    fn on_should_close(&self, callback: Box<dyn FnMut() -> bool + Send>) {
+        PlatformWindow::on_should_close(self.as_ref(), callback)
+    }
+
+    fn on_active_status_change(&self, callback: Box<dyn FnMut(bool) + Send>) {
+        PlatformWindow::on_active_status_change(self.as_ref(), callback)
+    }
+
+    fn on_hover_status_change(&self, callback: Box<dyn FnMut(bool) + Send>) {
+        PlatformWindow::on_hover_status_change(self.as_ref(), callback)
+    }
+
+    fn on_appearance_changed(&self, callback: Box<dyn FnMut() + Send>) {
+        PlatformWindow::on_appearance_changed(self.as_ref(), callback)
+    }
+
+    fn window_handle(
+        &self,
+    ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
+        PlatformWindow::window_handle(self.as_ref())
+    }
+
+    fn display_handle(
+        &self,
+    ) -> Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
+        PlatformWindow::display_handle(self.as_ref())
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self.as_ref()
     }
 }
 
@@ -246,9 +531,17 @@ impl HasWindowHandle for MacOSWindow {
     ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
         use std::ptr::NonNull;
 
-        let ns_window = self.ns_window as *mut std::ffi::c_void;
-        let handle = AppKitWindowHandle::new(NonNull::new(ns_window).unwrap());
+        // raw-window-handle 0.6 AppKitWindowHandle expects the NSView, not
+        // the NSWindow.
+        // SAFETY: `ns_window` is alive for the lifetime of `self`; the
+        // returned handle borrows `self`, so the view outlives it.
+        let content_view: id = unsafe { msg_send![self.ns_window, contentView] };
+        let ns_view = NonNull::new(content_view as *mut std::ffi::c_void)
+            .ok_or(raw_window_handle::HandleError::Unavailable)?;
+        let handle = AppKitWindowHandle::new(ns_view);
 
+        // SAFETY: the handle is valid for the lifetime of `&self` (the view
+        // is retained by the window, which `self` keeps alive).
         Ok(unsafe { raw_window_handle::WindowHandle::borrow_raw(RawWindowHandle::AppKit(handle)) })
     }
 }
@@ -258,6 +551,7 @@ impl HasDisplayHandle for MacOSWindow {
         &self,
     ) -> Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
         let handle = AppKitDisplayHandle::new();
+        // SAFETY: AppKit display handles carry no pointer; always valid.
         Ok(unsafe {
             raw_window_handle::DisplayHandle::borrow_raw(RawDisplayHandle::AppKit(handle))
         })
@@ -270,7 +564,7 @@ impl Clone for MacOSWindow {
             ns_window: self.ns_window,
             state: Arc::clone(&self.state),
             windows_map: Arc::clone(&self.windows_map),
-            handlers: Arc::clone(&self.handlers),
+            callbacks: Arc::clone(&self.callbacks),
             _config: self._config.clone(),
         }
     }
@@ -286,8 +580,9 @@ impl Drop for MacOSWindow {
             let window_id = self.ns_window as u64;
             self.windows_map.lock().remove(&window_id);
 
+            // SAFETY: this is the last wrapper referencing the NSWindow we
+            // alloc-init'ed in `new`, so releasing our +1 retain is balanced.
             unsafe {
-                // Release NSWindow (will be deallocated by Cocoa)
                 let _: () = msg_send![self.ns_window, release];
             }
         }
@@ -309,25 +604,11 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn title(&self) -> String {
-        unsafe {
-            let ns_title: id = msg_send![self.ns_window, title];
-            let c_str: *const i8 = msg_send![ns_title, UTF8String];
-            if c_str.is_null() {
-                String::new()
-            } else {
-                std::ffi::CStr::from_ptr(c_str)
-                    .to_string_lossy()
-                    .into_owned()
-            }
-        }
+        PlatformWindow::get_title(self)
     }
 
     fn set_title(&mut self, title: &str) {
-        unsafe {
-            let ns_title = cocoa::foundation::NSString::alloc(nil);
-            let ns_title = cocoa::foundation::NSString::init_str(ns_title, title);
-            let _: () = msg_send![self.ns_window, setTitle: ns_title];
-        }
+        PlatformWindow::set_title(self, title)
     }
 
     fn position(&self) -> Point<Pixels> {
@@ -336,13 +617,14 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn set_position(&mut self, position: Point<Pixels>) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let frame: NSRect = msg_send![self.ns_window, frame];
             let new_frame = NSRect::new(
                 cocoa::foundation::NSPoint::new(position.x.0 as f64, position.y.0 as f64),
                 frame.size,
             );
-            let _: () = msg_send![self.ns_window, setFrame: new_frame display: true];
+            let _: () = msg_send![self.ns_window, setFrame: new_frame display: YES];
 
             // Update state
             let mut state = self.state.lock();
@@ -356,21 +638,11 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn set_size(&mut self, size: Size<Pixels>) {
-        unsafe {
-            let frame: NSRect = msg_send![self.ns_window, frame];
-            let new_frame = NSRect::new(
-                frame.origin,
-                cocoa::foundation::NSSize::new(size.width.0 as f64, size.height.0 as f64),
-            );
-            let _: () = msg_send![self.ns_window, setFrame: new_frame display: true];
-
-            // Update state
-            let mut state = self.state.lock();
-            state.bounds.size = size;
-        }
+        PlatformWindow::resize(self, size)
     }
 
     fn state(&self) -> WindowState {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let is_minimized: bool = msg_send![self.ns_window, isMiniaturized];
             let is_zoomed: bool = msg_send![self.ns_window, isZoomed];
@@ -389,6 +661,7 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn set_state(&mut self, state: WindowState) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             match state {
                 WindowState::Normal => {
@@ -439,13 +712,11 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn is_visible(&self) -> bool {
-        unsafe {
-            let is_visible: bool = msg_send![self.ns_window, isVisible];
-            is_visible
-        }
+        PlatformWindow::is_visible(self)
     }
 
     fn set_visible(&mut self, visible: bool) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             if visible {
                 let _: () = msg_send![self.ns_window, makeKeyAndOrderFront: nil];
@@ -456,6 +727,7 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn is_resizable(&self) -> bool {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let style_mask: cocoa::appkit::NSWindowStyleMask = msg_send![self.ns_window, styleMask];
             style_mask.contains(NSWindowStyleMask::NSResizableWindowMask)
@@ -463,6 +735,7 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn set_resizable(&mut self, resizable: bool) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let mut style_mask: cocoa::appkit::NSWindowStyleMask =
                 msg_send![self.ns_window, styleMask];
@@ -476,6 +749,7 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn is_minimizable(&self) -> bool {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let style_mask: cocoa::appkit::NSWindowStyleMask = msg_send![self.ns_window, styleMask];
             style_mask.contains(NSWindowStyleMask::NSMiniaturizableWindowMask)
@@ -483,6 +757,7 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn set_minimizable(&mut self, minimizable: bool) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let mut style_mask: cocoa::appkit::NSWindowStyleMask =
                 msg_send![self.ns_window, styleMask];
@@ -496,6 +771,7 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn is_closable(&self) -> bool {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let style_mask: cocoa::appkit::NSWindowStyleMask = msg_send![self.ns_window, styleMask];
             style_mask.contains(NSWindowStyleMask::NSClosableWindowMask)
@@ -503,6 +779,7 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn set_closable(&mut self, closable: bool) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let mut style_mask: cocoa::appkit::NSWindowStyleMask =
                 msg_send![self.ns_window, styleMask];
@@ -516,34 +793,23 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn focus(&mut self) {
-        unsafe {
-            let _: () = msg_send![self.ns_window, makeKeyAndOrderFront: nil];
-        }
+        PlatformWindow::activate(self)
     }
 
     fn is_focused(&self) -> bool {
-        unsafe {
-            let is_key: bool = msg_send![self.ns_window, isKeyWindow];
-            is_key
-        }
+        PlatformWindow::is_focused(self)
     }
 
     fn close(&mut self) {
-        unsafe {
-            let _: () = msg_send![self.ns_window, close];
-        }
+        PlatformWindow::close(self)
     }
 
     fn request_redraw(&mut self) {
-        unsafe {
-            let content_view: id = msg_send![self.ns_window, contentView];
-            if content_view != nil {
-                let _: () = msg_send![content_view, setNeedsDisplay: true];
-            }
-        }
+        PlatformWindow::request_redraw(self)
     }
 
     fn set_min_size(&mut self, size: Option<Size<Pixels>>) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             if let Some(size) = size {
                 let ns_size =
@@ -558,6 +824,7 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn set_max_size(&mut self, size: Option<Size<Pixels>>) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             if let Some(size) = size {
                 let ns_size =
@@ -577,6 +844,8 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn raw_window_handle(&self) -> CrossRawWindowHandle {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`; the
+        // returned raw pointers are opaque handles for GPU integration.
         unsafe {
             let content_view: id = msg_send![self.ns_window, contentView];
             CrossRawWindowHandle::MacOS {
@@ -584,18 +853,6 @@ impl WindowTrait for MacOSWindow {
                 ns_window: self.ns_window as *mut std::ffi::c_void,
             }
         }
-    }
-
-    fn window_handle(
-        &self,
-    ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
-        HasWindowHandle::window_handle(self)
-    }
-
-    fn display_handle(
-        &self,
-    ) -> Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
-        HasDisplayHandle::display_handle(self)
     }
 }
 
@@ -619,6 +876,8 @@ impl MacOSWindowExtTrait for MacOSWindow {
     }
 
     fn set_liquid_glass_config(&mut self, config: LiquidGlassConfig) {
+        // SAFETY: `ns_window` is alive; NSVisualEffectView is alloc-init'ed
+        // and ownership passes to the window via `setContentView:`.
         unsafe {
             // Apply vibrancy effect to window content view
             let content_view: id = msg_send![self.ns_window, contentView];
@@ -641,7 +900,7 @@ impl MacOSWindowExtTrait for MacOSWindow {
             let _: () = msg_send![effect_view, setMaterial: material_value];
 
             // Set blending mode (NSVisualEffectBlendingMode)
-            let blending_mode: usize = 0; // NSVisualEffectBlendingModeBehindWindow
+            let blending_mode: usize = config.blending_mode.to_ns_blending_mode();
             let _: () = msg_send![effect_view, setBlendingMode: blending_mode];
 
             // Set state (NSVisualEffectState)
@@ -670,15 +929,16 @@ impl MacOSWindowExtTrait for MacOSWindow {
     }
 
     fn clear_liquid_glass(&mut self) {
+        // SAFETY: `ns_window` is alive; the freshly created content view's
+        // ownership passes to the window via `setContentView:`.
         unsafe {
+            let frame: NSRect = msg_send![self.ns_window, frame];
+
             // Remove visual effect view and restore normal content view
             let content_view = view::create_content_view(
-                NSRect::new(
-                    cocoa::foundation::NSPoint::new(0.0, 0.0),
-                    cocoa::foundation::NSSize::new(800.0, 600.0),
-                ),
-                self.scale_factor() as f64,
-                Arc::downgrade(&self.handlers),
+                NSRect::new(cocoa::foundation::NSPoint::new(0.0, 0.0), frame.size),
+                PlatformWindow::scale_factor(self),
+                Arc::downgrade(&self.callbacks),
             );
 
             let _: () = msg_send![self.ns_window, setContentView: content_view];
@@ -691,31 +951,27 @@ impl MacOSWindowExtTrait for MacOSWindow {
     }
 
     fn enable_tiling(&mut self, config: TilingConfiguration) {
-        // Store tiling config for later use
-        // Note: Actual tiling API is only available in macOS 15+
-        // For now, we just log the configuration
+        // Native tiling API requires macOS 15+; until adopted, the
+        // configuration is recorded for observability only.
         tracing::info!(
             "Window tiling enabled: position={:?}, ratio={}, layout={:?}",
             config.primary_position,
             config.split_ratio,
             config.layout
         );
-
-        // TODO: When macOS 15 APIs are available, implement actual tiling
-        // This would use NSWindow's tiling-related properties
     }
 
     fn disable_tiling(&mut self) {
         tracing::info!("Window tiling disabled");
-        // TODO: Implement when macOS 15 APIs are available
     }
 
     fn is_tiling_enabled(&self) -> bool {
-        // TODO: Implement when macOS 15 APIs are available
+        // Native tiling API requires macOS 15+; not yet adopted.
         false
     }
 
     fn enable_tabbing(&mut self) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             // Enable automatic tabbing (macOS 10.12+)
             let tabbing_mode: isize = 1; // NSWindowTabbingModeAutomatic
@@ -726,6 +982,7 @@ impl MacOSWindowExtTrait for MacOSWindow {
     }
 
     fn disable_tabbing(&mut self) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let tabbing_mode: isize = 2; // NSWindowTabbingModeDisallowed
             let _: () = msg_send![self.ns_window, setTabbingMode: tabbing_mode];
@@ -735,10 +992,11 @@ impl MacOSWindowExtTrait for MacOSWindow {
     }
 
     fn add_tab_to_window(&mut self, other_window_id: u64) {
+        // SAFETY: `other_window_id` round-trips an NSWindow pointer that was
+        // handed out as a window id; nil is rejected before messaging.
         unsafe {
-            // Get the other window from the windows map
-            let other_window_ptr = other_window_id as *mut std::ffi::c_void;
-            let other_ns_window = other_window_ptr as id;
+            // Window ids are NSWindow pointers (see `WindowTrait::id`)
+            let other_ns_window = other_window_id as *mut Object;
 
             if other_ns_window != nil {
                 let _: () = msg_send![self.ns_window, addTabbedWindow:other_ns_window ordered:0]; // NSWindowAbove
@@ -750,6 +1008,7 @@ impl MacOSWindowExtTrait for MacOSWindow {
     }
 
     fn toggle_native_fullscreen(&mut self) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let _: () = msg_send![self.ns_window, toggleFullScreen: nil];
             tracing::debug!("Toggled native fullscreen");
@@ -757,6 +1016,7 @@ impl MacOSWindowExtTrait for MacOSWindow {
     }
 
     fn set_window_level(&mut self, level: MacOSWindowLevel) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let level_value = level.to_ns_value();
             let _: () = msg_send![self.ns_window, setLevel: level_value];
@@ -765,6 +1025,7 @@ impl MacOSWindowExtTrait for MacOSWindow {
     }
 
     fn window_level(&self) -> MacOSWindowLevel {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let level_value: isize = msg_send![self.ns_window, level];
             match level_value {
@@ -782,6 +1043,7 @@ impl MacOSWindowExtTrait for MacOSWindow {
     }
 
     fn set_collection_behavior(&mut self, behavior: MacOSCollectionBehavior) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let _: () = msg_send![self.ns_window, setCollectionBehavior: behavior.bits() as usize];
             tracing::debug!("Set collection behavior: {:?}", behavior);
@@ -789,13 +1051,16 @@ impl MacOSWindowExtTrait for MacOSWindow {
     }
 
     fn set_has_shadow(&mut self, has_shadow: bool) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
-            let _: () = msg_send![self.ns_window, setHasShadow: has_shadow as i8];
+            let value: BOOL = if has_shadow { YES } else { NO };
+            let _: () = msg_send![self.ns_window, setHasShadow: value];
             tracing::debug!("Set window shadow: {}", has_shadow);
         }
     }
 
     fn set_alpha(&mut self, alpha: f32) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let clamped_alpha = alpha.clamp(0.0, 1.0);
             let _: () = msg_send![self.ns_window, setAlphaValue: clamped_alpha as f64];
@@ -827,6 +1092,9 @@ use std::sync::Weak;
 
 /// Create a window delegate for lifecycle events
 fn create_window_delegate(window: Weak<MacOSWindow>) -> id {
+    // SAFETY: the delegate class is registered before alloc/init; the boxed
+    // Weak pointer stored in the ivar is reclaimed in the delegate's
+    // `dealloc`, so it lives exactly as long as the delegate.
     unsafe {
         // Get or create delegate class
         let class = get_or_create_delegate_class();
@@ -848,42 +1116,48 @@ fn get_or_create_delegate_class() -> &'static Class {
 
     INIT.call_once(|| {
         let superclass = class!(NSObject);
-        let mut decl = ClassDecl::new("FLUIWindowDelegate", superclass).unwrap();
+        let mut decl = ClassDecl::new("FLUIWindowDelegate", superclass)
+            .expect("FLUIWindowDelegate must be registered exactly once (guarded by Once)");
 
         // Add ivar to store window pointer
         decl.add_ivar::<*mut std::ffi::c_void>("window_ptr");
 
         // windowDidResize:
-        unsafe extern "C" fn window_did_resize(this: &Object, _sel: Sel, _notification: id) {
-            if let Some(window) = get_window_from_delegate(this) {
+        extern "C" fn window_did_resize(this: &Object, _sel: Sel, _notification: id) {
+            // SAFETY: AppKit invokes delegate methods on live delegate objects.
+            if let Some(window) = unsafe { get_window_from_delegate(this) } {
                 window.handle_resize();
             }
         }
 
         // windowDidMove:
-        unsafe extern "C" fn window_did_move(this: &Object, _sel: Sel, _notification: id) {
-            if let Some(window) = get_window_from_delegate(this) {
+        extern "C" fn window_did_move(this: &Object, _sel: Sel, _notification: id) {
+            // SAFETY: AppKit invokes delegate methods on live delegate objects.
+            if let Some(window) = unsafe { get_window_from_delegate(this) } {
                 window.handle_move();
             }
         }
 
         // windowDidBecomeKey:
-        unsafe extern "C" fn window_did_become_key(this: &Object, _sel: Sel, _notification: id) {
-            if let Some(window) = get_window_from_delegate(this) {
+        extern "C" fn window_did_become_key(this: &Object, _sel: Sel, _notification: id) {
+            // SAFETY: AppKit invokes delegate methods on live delegate objects.
+            if let Some(window) = unsafe { get_window_from_delegate(this) } {
                 window.handle_focus_gained();
             }
         }
 
         // windowDidResignKey:
-        unsafe extern "C" fn window_did_resign_key(this: &Object, _sel: Sel, _notification: id) {
-            if let Some(window) = get_window_from_delegate(this) {
+        extern "C" fn window_did_resign_key(this: &Object, _sel: Sel, _notification: id) {
+            // SAFETY: AppKit invokes delegate methods on live delegate objects.
+            if let Some(window) = unsafe { get_window_from_delegate(this) } {
                 window.handle_focus_lost();
             }
         }
 
         // windowShouldClose:
-        unsafe extern "C" fn window_should_close(this: &Object, _sel: Sel, _sender: id) -> BOOL {
-            if let Some(window) = get_window_from_delegate(this) {
+        extern "C" fn window_should_close(this: &Object, _sel: Sel, _sender: id) -> BOOL {
+            // SAFETY: AppKit invokes delegate methods on live delegate objects.
+            if let Some(window) = unsafe { get_window_from_delegate(this) } {
                 if window.handle_close_request() {
                     YES
                 } else {
@@ -895,31 +1169,53 @@ fn get_or_create_delegate_class() -> &'static Class {
         }
 
         // windowWillClose:
-        unsafe extern "C" fn window_will_close(this: &Object, _sel: Sel, _notification: id) {
-            if let Some(window) = get_window_from_delegate(this) {
+        extern "C" fn window_will_close(this: &Object, _sel: Sel, _notification: id) {
+            // SAFETY: AppKit invokes delegate methods on live delegate objects.
+            if let Some(window) = unsafe { get_window_from_delegate(this) } {
                 window.handle_close();
             }
         }
 
         // windowDidChangeBackingProperties: (Retina/DPI change)
-        unsafe extern "C" fn window_did_change_backing_properties(
+        extern "C" fn window_did_change_backing_properties(
             this: &Object,
             _sel: Sel,
             _notification: id,
         ) {
-            if let Some(window) = get_window_from_delegate(this) {
+            // SAFETY: AppKit invokes delegate methods on live delegate objects.
+            if let Some(window) = unsafe { get_window_from_delegate(this) } {
                 window.handle_backing_properties_changed();
             }
         }
 
         // windowDidChangeScreen: (moved to different monitor)
-        unsafe extern "C" fn window_did_change_screen(this: &Object, _sel: Sel, _notification: id) {
-            if let Some(window) = get_window_from_delegate(this) {
+        extern "C" fn window_did_change_screen(this: &Object, _sel: Sel, _notification: id) {
+            // SAFETY: AppKit invokes delegate methods on live delegate objects.
+            if let Some(window) = unsafe { get_window_from_delegate(this) } {
                 window.handle_screen_changed();
             }
         }
 
+        // dealloc — reclaim the boxed Weak<MacOSWindow>
+        extern "C" fn delegate_dealloc(this: &Object, _sel: Sel) {
+            // SAFETY: the ivar holds either null or a Box<Weak<MacOSWindow>>
+            // leaked in `create_window_delegate`; reclaiming it exactly once
+            // on dealloc is the matching release. The super dealloc message
+            // is the mandatory NSObject teardown.
+            unsafe {
+                let window_ptr: *mut std::ffi::c_void = *this.get_ivar("window_ptr");
+                if !window_ptr.is_null() {
+                    drop(Box::from_raw(window_ptr as *mut Weak<MacOSWindow>));
+                }
+                let superclass = class!(NSObject);
+                let _: () = msg_send![super(this, superclass), dealloc];
+            }
+        }
+
         // Add methods
+        // SAFETY: every registered function pointer matches the Objective-C
+        // method signature of its selector, as required by
+        // `ClassDecl::add_method`.
         unsafe {
             decl.add_method(
                 sel!(windowDidResize:),
@@ -953,22 +1249,36 @@ fn get_or_create_delegate_class() -> &'static Class {
                 sel!(windowDidChangeScreen:),
                 window_did_change_screen as extern "C" fn(&Object, Sel, id),
             );
+            decl.add_method(
+                sel!(dealloc),
+                delegate_dealloc as extern "C" fn(&Object, Sel),
+            );
         }
 
         decl.register();
     });
 
-    Class::get("FLUIWindowDelegate").unwrap()
+    Class::get("FLUIWindowDelegate")
+        .expect("FLUIWindowDelegate was registered by the Once block above")
 }
 
 /// Get window from delegate
+///
+/// # Safety
+///
+/// `delegate` must be a live FLUIWindowDelegate whose `window_ptr` ivar is
+/// either null or points to a `Weak<MacOSWindow>` owned by that delegate.
 unsafe fn get_window_from_delegate(delegate: &Object) -> Option<Arc<MacOSWindow>> {
-    let window_ptr: *mut std::ffi::c_void = *delegate.get_ivar("window_ptr");
-    let weak_ptr = window_ptr as *mut Weak<MacOSWindow>;
-    if weak_ptr.is_null() {
-        return None;
+    // SAFETY: per the function contract the ivar is null or a valid
+    // Box<Weak<MacOSWindow>> pointer owned by the delegate.
+    unsafe {
+        let window_ptr: *mut std::ffi::c_void = *delegate.get_ivar("window_ptr");
+        let weak_ptr = window_ptr as *mut Weak<MacOSWindow>;
+        if weak_ptr.is_null() {
+            return None;
+        }
+        (*weak_ptr).upgrade()
     }
-    (*weak_ptr).upgrade()
 }
 
 // ============================================================================
@@ -978,6 +1288,7 @@ unsafe fn get_window_from_delegate(delegate: &Object) -> Option<Arc<MacOSWindow>
 impl MacOSWindow {
     /// Handle window resize event
     fn handle_resize(&self) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let frame: NSRect = msg_send![self.ns_window, frame];
             let content_rect: NSRect = msg_send![self.ns_window, contentRectForFrameRect: frame];
@@ -988,16 +1299,14 @@ impl MacOSWindow {
             );
 
             // Update state
-            {
+            let scale = {
                 let mut state = self.state.lock();
                 state.bounds.size = new_size;
-            }
+                state.scale_factor
+            };
 
-            // Notify handlers
-            let handlers = self.handlers.lock();
-            if let Some(handler) = &handlers.on_resize {
-                handler(new_size);
-            }
+            // Notify per-window callbacks
+            self.callbacks.dispatch_resize(new_size, scale as f32);
 
             tracing::debug!(
                 "Window resized to {}x{}",
@@ -1009,6 +1318,7 @@ impl MacOSWindow {
 
     /// Handle window move event
     fn handle_move(&self) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`.
         unsafe {
             let frame: NSRect = msg_send![self.ns_window, frame];
 
@@ -1023,25 +1333,21 @@ impl MacOSWindow {
                 state.bounds.origin = new_origin;
             }
 
+            self.callbacks.dispatch_moved();
+
             tracing::debug!("Window moved to ({}, {})", new_origin.x.0, new_origin.y.0);
         }
     }
 
     /// Handle focus gained event
     fn handle_focus_gained(&self) {
-        let handlers = self.handlers.lock();
-        if let Some(handler) = &handlers.on_active {
-            handler();
-        }
+        self.callbacks.dispatch_active_status_change(true);
         tracing::debug!("Window gained focus");
     }
 
     /// Handle focus lost event
     fn handle_focus_lost(&self) {
-        let handlers = self.handlers.lock();
-        if let Some(handler) = &handlers.on_inactive {
-            handler();
-        }
+        self.callbacks.dispatch_active_status_change(false);
         tracing::debug!("Window lost focus");
     }
 
@@ -1049,49 +1355,52 @@ impl MacOSWindow {
     ///
     /// Returns true to allow close, false to prevent
     fn handle_close_request(&self) -> bool {
-        let handlers = self.handlers.lock();
-        if let Some(handler) = &handlers.should_close {
-            let should_close = handler();
-            tracing::debug!("Window close requested: {}", should_close);
-            should_close
-        } else {
-            true // Allow close by default
-        }
+        let should_close = self.callbacks.dispatch_should_close();
+        tracing::debug!("Window close requested: {}", should_close);
+        should_close
     }
 
     /// Handle window close event
     fn handle_close(&self) {
-        let handlers = self.handlers.lock();
-        if let Some(handler) = &handlers.on_close {
-            handler();
-        }
+        self.callbacks.dispatch_close();
         tracing::debug!("Window closed");
     }
 
     /// Handle backing properties changed (Retina/DPI change)
     fn handle_backing_properties_changed(&self) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`; the
+        // content view is nil-checked before use.
         unsafe {
             let new_scale: f64 = msg_send![self.ns_window, backingScaleFactor];
 
             // Update window state
-            {
+            let (changed, size) = {
                 let mut state = self.state.lock();
-                if (state.scale_factor - new_scale).abs() > 0.01 {
+                let changed = (state.scale_factor - new_scale).abs() > 0.01;
+                if changed {
                     state.scale_factor = new_scale;
                     tracing::info!("Window scale factor changed to {}", new_scale);
                 }
-            }
+                (changed, state.bounds.size)
+            };
 
             // Update content view scale factor
             let content_view: id = msg_send![self.ns_window, contentView];
             if content_view != nil {
                 view::update_view_scale_factor(content_view, new_scale);
             }
+
+            // A scale change invalidates layout: notify as a resize
+            if changed {
+                self.callbacks.dispatch_resize(size, new_scale as f32);
+            }
         }
     }
 
     /// Handle screen changed (moved to different monitor)
     fn handle_screen_changed(&self) {
+        // SAFETY: `ns_window` is alive for the lifetime of `self`; the
+        // screen object is nil-checked before messaging.
         unsafe {
             let screen: id = msg_send![self.ns_window, screen];
             if screen != nil {

--- a/crates/flui-platform/src/platforms/macos/window_manager.rs
+++ b/crates/flui-platform/src/platforms/macos/window_manager.rs
@@ -162,7 +162,7 @@ impl WindowManager {
     /// Calculate cascade position for a new window.
     ///
     /// Cascades windows in a staggered pattern (like macOS does by default).
-    pub fn calculate_cascade_position(&self, window_size: Size<Pixels>) -> Point<Pixels> {
+    pub fn calculate_cascade_position(&self, _window_size: Size<Pixels>) -> Point<Pixels> {
         let count = self.window_count();
         let cascade_offset = 28.0; // Standard macOS cascade offset
 
@@ -202,14 +202,13 @@ impl WindowManager {
 
     /// Remove window from its group.
     pub fn remove_from_group(&mut self, window_id: WindowId) -> bool {
-        if let Some(info) = self.windows.get_mut(&window_id) {
-            if let Some(group_id) = info.group {
-                if let Some(group) = self.groups.get_mut(&group_id) {
-                    group.retain(|&id| id != window_id);
-                    info.group = None;
-                    return true;
-                }
-            }
+        if let Some(info) = self.windows.get_mut(&window_id)
+            && let Some(group_id) = info.group
+            && let Some(group) = self.groups.get_mut(&group_id)
+        {
+            group.retain(|&id| id != window_id);
+            info.group = None;
+            return true;
         }
         false
     }

--- a/crates/flui-platform/src/platforms/macos/window_tiling.rs
+++ b/crates/flui-platform/src/platforms/macos/window_tiling.rs
@@ -115,25 +115,25 @@ impl TilingConfiguration {
 
         match self.layout {
             TilingLayout::SideBySide => {
-                let split_x = width * Pixels(self.split_ratio);
+                let split_x = width * self.split_ratio;
 
                 let (primary, secondary) = match self.primary_position {
                     TilePosition::Left => (
-                        Rect::from_origin_and_size(
+                        Rect::from_origin_size(
                             flui_types::geometry::Point::new(Pixels(0.0), Pixels(0.0)),
                             Size::new(split_x, height),
                         ),
-                        Rect::from_origin_and_size(
+                        Rect::from_origin_size(
                             flui_types::geometry::Point::new(split_x, Pixels(0.0)),
                             Size::new(width - split_x, height),
                         ),
                     ),
                     TilePosition::Right => (
-                        Rect::from_origin_and_size(
+                        Rect::from_origin_size(
                             flui_types::geometry::Point::new(width - split_x, Pixels(0.0)),
                             Size::new(split_x, height),
                         ),
-                        Rect::from_origin_and_size(
+                        Rect::from_origin_size(
                             flui_types::geometry::Point::new(Pixels(0.0), Pixels(0.0)),
                             Size::new(width - split_x, height),
                         ),
@@ -145,25 +145,25 @@ impl TilingConfiguration {
             }
 
             TilingLayout::TopBottom => {
-                let split_y = height * Pixels(self.split_ratio);
+                let split_y = height * self.split_ratio;
 
                 let (primary, secondary) = match self.primary_position {
                     TilePosition::Top => (
-                        Rect::from_origin_and_size(
+                        Rect::from_origin_size(
                             flui_types::geometry::Point::new(Pixels(0.0), Pixels(0.0)),
                             Size::new(width, split_y),
                         ),
-                        Rect::from_origin_and_size(
+                        Rect::from_origin_size(
                             flui_types::geometry::Point::new(Pixels(0.0), split_y),
                             Size::new(width, height - split_y),
                         ),
                     ),
                     TilePosition::Bottom => (
-                        Rect::from_origin_and_size(
+                        Rect::from_origin_size(
                             flui_types::geometry::Point::new(Pixels(0.0), height - split_y),
                             Size::new(width, split_y),
                         ),
-                        Rect::from_origin_and_size(
+                        Rect::from_origin_size(
                             flui_types::geometry::Point::new(Pixels(0.0), Pixels(0.0)),
                             Size::new(width, height - split_y),
                         ),
@@ -176,23 +176,23 @@ impl TilingConfiguration {
 
             TilingLayout::Quarters => {
                 // Split screen into 4 equal quadrants
-                let half_width = width * Pixels(0.5);
-                let half_height = height * Pixels(0.5);
+                let half_width = width * 0.5;
+                let half_height = height * 0.5;
 
                 let primary = match self.primary_position {
-                    TilePosition::TopLeft => Rect::from_origin_and_size(
+                    TilePosition::TopLeft => Rect::from_origin_size(
                         flui_types::geometry::Point::new(Pixels(0.0), Pixels(0.0)),
                         Size::new(half_width, half_height),
                     ),
-                    TilePosition::TopRight => Rect::from_origin_and_size(
+                    TilePosition::TopRight => Rect::from_origin_size(
                         flui_types::geometry::Point::new(half_width, Pixels(0.0)),
                         Size::new(half_width, half_height),
                     ),
-                    TilePosition::BottomLeft => Rect::from_origin_and_size(
+                    TilePosition::BottomLeft => Rect::from_origin_size(
                         flui_types::geometry::Point::new(Pixels(0.0), half_height),
                         Size::new(half_width, half_height),
                     ),
-                    TilePosition::BottomRight => Rect::from_origin_and_size(
+                    TilePosition::BottomRight => Rect::from_origin_size(
                         flui_types::geometry::Point::new(half_width, half_height),
                         Size::new(half_width, half_height),
                     ),
@@ -200,7 +200,7 @@ impl TilingConfiguration {
                 };
 
                 // Secondary takes the rest (3 quadrants)
-                let secondary = Rect::from_origin_and_size(
+                let secondary = Rect::from_origin_size(
                     flui_types::geometry::Point::new(Pixels(0.0), Pixels(0.0)),
                     screen_size,
                 );

--- a/crates/flui-platform/tests/display_enumeration.rs
+++ b/crates/flui-platform/tests/display_enumeration.rs
@@ -366,7 +366,7 @@ fn test_macos_nsscreen_enumeration() {
 
     // macOS should detect at least the primary display
     assert!(
-        displays.len() >= 1,
+        !displays.is_empty(),
         "macOS should have at least one display"
     );
 

--- a/crates/flui-types/src/styling/color.rs
+++ b/crates/flui-types/src/styling/color.rs
@@ -288,8 +288,15 @@ impl Color {
 
     #[inline]
     #[cfg(all(target_arch = "x86_64", not(target_family = "wasm")))]
-    #[allow(dead_code, unsafe_code)]
+    #[allow(
+        dead_code,
+        unsafe_code,
+        reason = "SIMD twin of `lerp_scalar`: compiled on every x86_64 build but only called when the `simd` feature selects it in `lerp`; SSE2 intrinsics require unsafe"
+    )]
     fn lerp_simd_sse(a: Color, b: Color, t: f32) -> Color {
+        // SAFETY: gated on `target_feature = "sse2"`, so the intrinsics are
+        // available; `_mm_storeu_ps` is an unaligned store into a live 4-f32
+        // stack array, in bounds by construction.
         #[cfg(target_feature = "sse2")]
         unsafe {
             use std::arch::x86_64::*;
@@ -321,7 +328,15 @@ impl Color {
 
     #[inline]
     #[cfg(all(target_arch = "aarch64", not(target_family = "wasm")))]
+    #[allow(
+        dead_code,
+        unsafe_code,
+        reason = "SIMD twin of `lerp_scalar`: compiled on every aarch64 build but only called when the `simd` feature selects it in `lerp`; NEON intrinsics require unsafe"
+    )]
     fn lerp_simd_neon(a: Color, b: Color, t: f32) -> Color {
+        // SAFETY: gated on `target_feature = "neon"`, so the intrinsics are
+        // available; `vld1q_f32`/`vst1q_f32` load/store 4 f32s from/into live
+        // f32-aligned stack arrays, in bounds by construction.
         #[cfg(target_feature = "neon")]
         unsafe {
             use std::arch::aarch64::*;
@@ -513,8 +528,15 @@ impl Color {
 
     #[inline]
     #[cfg(all(target_arch = "x86_64", not(target_family = "wasm")))]
-    #[allow(dead_code, unsafe_code)]
+    #[allow(
+        dead_code,
+        unsafe_code,
+        reason = "SIMD twin of `blend_over_scalar`: compiled on every x86_64 build but only called when the `simd` feature selects it in `blend_over`; SSE2 intrinsics require unsafe"
+    )]
     fn blend_over_simd_sse(&self, background: Color) -> Color {
+        // SAFETY: gated on `target_feature = "sse2"`, so the intrinsics are
+        // available; `_mm_storeu_ps` is an unaligned store into a live 4-f32
+        // stack array, in bounds by construction.
         #[cfg(target_feature = "sse2")]
         unsafe {
             use std::arch::x86_64::*;
@@ -567,7 +589,15 @@ impl Color {
 
     #[inline]
     #[cfg(all(target_arch = "aarch64", not(target_family = "wasm")))]
+    #[allow(
+        dead_code,
+        unsafe_code,
+        reason = "SIMD twin of `blend_over_scalar`: compiled on every aarch64 build but only called when the `simd` feature selects it in `blend_over`; NEON intrinsics require unsafe"
+    )]
     fn blend_over_simd_neon(&self, background: Color) -> Color {
+        // SAFETY: gated on `target_feature = "neon"`, so the intrinsics are
+        // available; `vld1q_f32`/`vst1q_f32` load/store 4 f32s from/into live
+        // f32-aligned stack arrays, in bounds by construction.
         #[cfg(target_feature = "neon")]
         unsafe {
             use std::arch::aarch64::*;


### PR DESCRIPTION
## What

Makes `cargo check -p flui-platform --target x86_64-apple-darwin` (and `aarch64-apple-darwin`) pass with **zero errors and zero warnings**, by rebuilding the bit-rotted macOS backend against the crate's current contracts. Also clears the 3 pre-existing `flui-types` warnings on aarch64 (dead NEON SIMD twins). No Windows platform code touched.

## Why

The macOS module is only compiled under `cfg(target_os = "macos")` and CI builds Ubuntu/Windows, so it rotted silently. The reported 5 issues turned out to be the tip: ~120 errors, because the backend was still written against pre-refactor APIs (callbacks on global `PlatformHandlers`, old `PlatformWindow` shape, pre-0.3 ui-events, missing cocoa bindings, unlisted `objc2` deps).

## Changes

**Reported issues**
- `platform.rs`: dropped `mod display;`/`mod window;` (E0583) → sibling-module imports
- `mod.rs`: dropped `#[macro_use] extern crate objc` (E0468) → per-file `use objc::{class, msg_send, sel, sel_impl}`
- `window.rs`: local state struct renamed to `MacOSWindowState` (E0255 vs `crate::window::WindowState`)
- `liquid_glass.rs`: ported off `objc2`/`objc2-app-kit` onto the cocoa/objc stack (decision: one ObjC binding stack per backend; no new deps); added `from_material` / `to_ns_visual_effect_material` / `transparent_titlebar` that `window.rs` already called
- `view.rs`: cocoa 0.26 doesn't bind `NSTrackingArea` → raw `NSTrackingAreaOptions` bits + runtime `class!` lookup

**Bit-rot repairs beyond the list**
- `events.rs`: NSEvent conversion rewritten for ui-events 0.3 (`PointerButtonEvent`/`PointerUpdate`/`PointerScrollEvent`, `Key::Named(NamedKey)`), mirroring the Windows converter; Y flipped from AppKit's bottom-left origin
- Per-window events now flow through `shared::WindowCallbacks` (take/restore dispatch); full current `PlatformWindow` impl incl. callback registration + delegating `impl PlatformWindow for Arc<MacOSWindow>` (Windows backend pattern)
- Delegate/view methods declared as safe `extern "C" fn` (E0605 fix); delegate `dealloc` added — frees the boxed `Weak` (plugged a leak)
- **Bug fix:** rwh 0.6 `AppKitWindowHandle` expects the **NSView**; old code passed the NSWindow (would break wgpu surface creation)
- **Bug fix:** `display.rs` passed a non-NUL-terminated `"NSScreenNumber".as_ptr()` to `stringWithUTF8String:` → C-string literal
- `platform.rs`: `capabilities()` returns a real `DesktopCapabilities` instead of `unimplemented!()`
- `clipboard.rs`: justified `Send`/`Sync` for the pasteboard singleton (E0277)
- `window_tiling.rs`: `Rect::from_origin_size` + `Pixels * f32`

**flui-types (second commit)**
- NEON SIMD twins (`lerp_simd_neon`, `blend_over_simd_neon`) were missing the `#[allow(dead_code, unsafe_code)]` their SSE siblings carry (symmetric defect — they're compiled on every aarch64 build but only called with `--features simd`). Added with `reason` strings, SSE allows upgraded likewise, SAFETY invariants on all four intrinsics blocks.

## Reviewer notes

- cocoa 0.26 deprecates its **entire** API in favour of objc2 → module-level `#![allow(deprecated)]` with rationale; a wholesale objc2 migration is a separate track
- objc 0.2 macros emit `cfg(feature = "cargo-clippy")` probes → declared via `[lints.rust] unexpected_cfgs` check-cfg in `flui-platform/Cargo.toml` (a module-level allow does not work for this lint)
- All unsafe blocks carry `// SAFETY:` invariants; unsafe fns have `# Safety` contracts
- Runtime behaviour on real macOS hardware is untested (no Mac in the loop); this PR restores compile-correctness and contract parity with the Windows backend

## Verification

- `cargo check -p flui-platform --target x86_64-apple-darwin` — 0 errors, 0 warnings
- `cargo clippy -p flui-platform --target {x86_64,aarch64}-apple-darwin --all-targets --all-features` — clean
- `cargo build --workspace` (Windows host) — green
- `cargo test -p flui-platform -- --test-threads 1` — 133 passed (headless t069 parallel flake is pre-existing, CI-guarded)
- `cargo check -p flui-types --target aarch64-apple-darwin` (default + `--features simd`) — 0 warnings; `cargo test -p flui-types` green with and without `simd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)