### PR TITLE
test(flui-view): serialize reconcile-event collector tests

### DIFF
--- a/crates/flui-view/src/tree/test_utils/reconcile_event_collector.rs
+++ b/crates/flui-view/src/tree/test_utils/reconcile_event_collector.rs
@@ -45,6 +45,12 @@
 //! `tracing::dispatcher::set_default()` (global) and gate the
 //! affected tests behind `#[serial_test::serial]`. Phase 1 ships the
 //! per-thread discipline (KTD-5).
+//!
+//! Even with per-thread dispatchers, tests installing a collector
+//! must be `#[serial_test::serial]`-gated: tracing-core's callsite
+//! interest cache is process-global, and concurrent dispatcher
+//! installs/drops race its rebuild — a freshly installed collector
+//! can then miss events, tripping the vacuous-pass guard.
 
 use std::sync::{Arc, Mutex};
 
@@ -305,7 +311,17 @@ mod tests {
         );
     }
 
+    // All five tests below install a per-thread dispatcher via
+    // `tracing::dispatcher::with_default`. Installing/dropping a
+    // dispatcher triggers tracing-core's global callsite
+    // interest-cache rebuild; under parallel test execution that
+    // rebuild races between threads and a freshly installed
+    // per-thread collector can miss events (observed as a
+    // vacuous-pass-guard failure in full-workspace runs). The module
+    // docs prescribe `#[serial_test::serial]` gating for exactly this
+    // hazard.
     #[test]
+    #[serial_test::serial]
     fn collector_captures_mount_event() {
         let events = with_collector(|| {
             emit_event(&ReconcileEvent::mount(
@@ -327,6 +343,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn collector_captures_all_five_kinds() {
         let events = with_collector(|| {
             let parent = ElementId::new(1);
@@ -361,6 +378,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn collector_ignores_other_targets() {
         let events = with_collector(|| {
             // Emission on a different target must NOT land in the
@@ -388,6 +406,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn collector_clear_resets_buffer() {
         let collector = ReconcileEventCollector::new();
         let subscriber = Registry::default().with(collector.layer());
@@ -411,6 +430,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn malformed_event_dropped_silently() {
         // Emit a partial event (missing required fields) on the
         // reconcile target. The collector's `build()` returns None,


### PR DESCRIPTION
## What

Gates all five `ReconcileEventCollector` unit tests in `crates/flui-view/src/tree/test_utils/reconcile_event_collector.rs` behind `#[serial_test::serial]`, and extends the module docs to record why per-thread dispatcher installation is affected.

## Why

The tests install per-thread tracing dispatchers via `tracing::dispatcher::with_default` + `Registry`. That looks isolated, but tracing-core's callsite interest cache is **process-global**: every dispatcher install/drop triggers a rebuild, and under parallel test execution those rebuilds race between threads — a freshly installed collector can miss events entirely.

Observed once in a full-workspace run as a vacuous-pass-guard failure (`191 passed; 1 failed`), passing in isolation and on rerun — the classic interest-cache race signature. The module docs (KTD-5 section) already anticipated this hazard and prescribed exactly this gating; this PR applies it and notes that the hazard covers per-thread installation too, not only the future global-dispatcher scenario.

## Notes for reviewers

- `serial_test = "3"` was already a dev-dependency of `flui-view` (used for GlobalKey registry tests) — no manifest changes.
- Tests only; zero production code changes. The diff is +20 lines: 5 attributes + 2 explanatory comments.
- The 5 collector tests now serialize against each other **and** against the existing `#[serial]` GlobalKey tests (same default serial_test key), which is harmless — all are microsecond-scale.

## Verification

- `cargo test -p flui-view --lib` × 6 consecutive runs: `192 passed; 0 failed` each time
- `cargo clippy -p flui-view --all-targets`: clean
- `cargo fmt -p flui-view --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)