### PR TITLE
fix(flui-view): deep element chains no longer overflow the stack in unmount walks

### DIFF
--- a/crates/flui-view/src/owner/build_owner.rs
+++ b/crates/flui-view/src/owner/build_owner.rs
@@ -872,8 +872,9 @@ mod tests {
         assert_eq!(tree.len(), DEPTH);
 
         // Park the chain root in the inactive queue and finalize — the
-        // collection must reach all 20 000 descendants without
-        // exhausting the stack, then tear them down deepest-first.
+        // collection must reach all 20 000 chain nodes (the root plus
+        // its 19 999 descendants) without exhausting the stack, then
+        // tear them down deepest-first.
         owner.add_to_inactive(root_id, 0);
         owner.finalize_tree(&mut tree);
 

--- a/crates/flui-view/src/owner/build_owner.rs
+++ b/crates/flui-view/src/owner/build_owner.rs
@@ -481,7 +481,7 @@ impl BuildOwner {
             .sort_by_key(|entry| std::cmp::Reverse(entry.depth()));
 
         // Take ownership of inactive elements to avoid borrow conflicts.
-        // `mem::take` snapshots the queue before the recursive unmount so
+        // `mem::take` snapshots the queue before the unmount sweep so
         // mid-iteration `ElementOwner::push_inactive` calls (e.g. children
         // deactivating as a parent unmounts) land in the *next* frame's
         // queue rather than re-entering this drain — same snapshot-then-fire
@@ -521,24 +521,37 @@ impl BuildOwner {
         tracing::debug!("Finalize tree complete");
     }
 
-    /// Recursively collect all element IDs to unmount, parent before
-    /// children (pre-order).
+    /// Iteratively collect all element IDs to unmount, parent before
+    /// children (pre-order DFS, children in
+    /// [`ElementNode::child_ids`](crate::tree::ElementNode) slot order).
     ///
-    /// E3: children come from the slab-resident
-    /// [`ElementNode::child_ids`](crate::tree::ElementNode) list — the
-    /// single element graph — read through a fresh, immediately-dropped
-    /// `&ElementTree` borrow. `finalize_tree` reverses the collected order
-    /// so `remove_finalized` runs deepest-first.
+    /// E3: children come from the slab-resident `child_ids` list — the
+    /// single element graph. `finalize_tree` reverses the collected order
+    /// so `remove_finalized` runs deepest-first; pre-order guarantees a
+    /// parent always precedes every one of its descendants, so the
+    /// reversed sweep never frees a parent slot before its children.
+    ///
+    /// The walk is driven by an explicit `Vec` work-stack instead of
+    /// recursion: the element tree nests several times deeper than the
+    /// render tree, and a recursive shape overflowed the 1 MiB Windows
+    /// main-thread stack on deep chains (the failure class PR #177
+    /// closed for the render-tree walks). To preserve the recursive
+    /// shape's visit order on a LIFO stack, children are pushed in
+    /// reverse slot order so the leftmost child is popped next — same
+    /// discipline as `WidgetsBinding::collect_all_elements`.
+    ///
+    /// Complexity: O(n) time over the n reachable nodes, average and
+    /// worst case (each node pushed/popped exactly once); the work-stack
+    /// peaks at O(n) heap in the degenerate all-siblings case and O(tree
+    /// height) for a chain. Call-stack usage is constant.
     fn collect_elements_to_unmount(tree: &ElementTree, id: ElementId, result: &mut Vec<ElementId>) {
-        // Add this element
-        result.push(id);
-
-        // Collect children (owned snapshot so no slab borrow is held
-        // across the recursive call).
-        if let Some(node) = tree.get(id) {
-            let children: Vec<ElementId> = node.child_ids().to_vec();
-            for child_id in children {
-                Self::collect_elements_to_unmount(tree, child_id, result);
+        let mut stack: Vec<ElementId> = vec![id];
+        while let Some(id) = stack.pop() {
+            result.push(id);
+            // The `tree.get` shared borrow ends with the statement; the
+            // extend writes only into the local stack, never the slab.
+            if let Some(node) = tree.get(id) {
+                stack.extend(node.child_ids().iter().rev().copied());
             }
         }
     }
@@ -818,6 +831,57 @@ mod tests {
         // Second caller sees None — the entry was removed atomically.
         assert_eq!(owner.take_global_key_for_reparent(hash), None);
         assert_eq!(owner.element_for_global_key(hash), None);
+    }
+
+    /// Deep-tree stack-safety: `finalize_tree`'s subtree collection must
+    /// survive an element chain far deeper than the fixed OS stack would
+    /// allow with plain recursion. The element tree nests several times
+    /// deeper than the render tree (every render object is wrapped in
+    /// multiple composition views), so it hits the 1 MiB Windows
+    /// main-thread stack earlier — same failure class PR #177 closed in
+    /// flui-rendering. The collection frame is small, so the depth is
+    /// 20 000 (the small-frame sizing the flui-rendering
+    /// compositing-bits test established; 2 500 survived unprotected
+    /// there by luck).
+    ///
+    /// Ignored under miri: the interpreter cannot finish a 20 000-level
+    /// walk in reasonable time; the shallow finalize-path coverage in
+    /// this module exercises the same code natively.
+    #[test]
+    #[cfg_attr(miri, ignore = "20k-node walk too slow for the interpreter")]
+    fn finalize_tree_survives_deep_chain() {
+        const DEPTH: usize = 20_000;
+
+        let mut owner = BuildOwner::new();
+        let mut tree = ElementTree::new();
+
+        let view = TestView;
+        let root_id = tree.mount_root(&view, &mut owner.element_owner_mut());
+
+        // Build a root → c1 → c2 → … single-child chain. `insert` wires
+        // the child's parent edge; the parent's `child_ids` list (what
+        // the unmount collection walks) is stamped explicitly.
+        let mut parent_id = root_id;
+        for _ in 1..DEPTH {
+            let child_id = tree.insert(&view, parent_id, 0, &mut owner.element_owner_mut());
+            tree.get_mut(parent_id)
+                .expect("freshly inserted parent resolves")
+                .set_child_ids(vec![child_id]);
+            parent_id = child_id;
+        }
+        assert_eq!(tree.len(), DEPTH);
+
+        // Park the chain root in the inactive queue and finalize — the
+        // collection must reach all 20 000 descendants without
+        // exhausting the stack, then tear them down deepest-first.
+        owner.add_to_inactive(root_id, 0);
+        owner.finalize_tree(&mut tree);
+
+        assert_eq!(
+            tree.len(),
+            0,
+            "every chain node must be collected and unmounted"
+        );
     }
 
     /// `take_global_key_for_reparent` on an unknown hash returns

--- a/crates/flui-view/src/tree/id_reconcile.rs
+++ b/crates/flui-view/src/tree/id_reconcile.rs
@@ -438,24 +438,36 @@ fn remove_child(tree: &mut ElementTree, id: ElementId, owner: &mut crate::Elemen
 }
 
 /// Collect `id` and its whole subtree in pre-order (parent before
-/// children) through fresh, immediately-dropped `&ElementTree` borrows.
+/// children, children in `child_ids` slot order).
 ///
 /// The caller removes the collected ids in REVERSE (deepest-first) so no
-/// parent slot is freed before its children — mirrors
+/// parent slot is freed before its children — pre-order guarantees a
+/// parent always precedes every one of its descendants. Mirrors
 /// [`BuildOwner::finalize_tree`](crate::BuildOwner::finalize_tree) +
 /// `collect_elements_to_unmount`.
 ///
-/// Complexity: O(n) over the subtree size n (each node visited once); the
-/// recursion depth equals the subtree height.
+/// The walk is driven by an explicit `Vec` work-stack instead of
+/// recursion: the element tree nests several times deeper than the
+/// render tree, and a recursive shape overflowed the 1 MiB Windows
+/// main-thread stack on deep chains (the failure class PR #177 closed
+/// for the render-tree walks). To preserve the recursive shape's visit
+/// order on a LIFO stack, children are pushed in reverse slot order so
+/// the leftmost child is popped next — same discipline as
+/// `WidgetsBinding::collect_all_elements`.
+///
+/// Complexity: O(n) time over the subtree size n, average and worst case
+/// (each node pushed/popped exactly once); the work-stack peaks at O(n)
+/// heap in the degenerate all-siblings case and O(subtree height) for a
+/// chain. Call-stack usage is constant.
 fn collect_subtree_preorder(tree: &ElementTree, id: ElementId, out: &mut Vec<ElementId>) {
-    out.push(id);
-    // Owned snapshot so no slab borrow is held across the recursive call.
-    let children: Vec<ElementId> = match tree.get(id) {
-        Some(node) => node.child_ids().to_vec(),
-        None => return,
-    };
-    for child in children {
-        collect_subtree_preorder(tree, child, out);
+    let mut stack: Vec<ElementId> = vec![id];
+    while let Some(id) = stack.pop() {
+        out.push(id);
+        // The `tree.get` shared borrow ends with the statement; the
+        // extend writes only into the local stack, never the slab.
+        if let Some(node) = tree.get(id) {
+            stack.extend(node.child_ids().iter().rev().copied());
+        }
     }
 }
 
@@ -967,6 +979,53 @@ mod tests {
         assert!(tree.get(a).is_none(), "removed subtree top is gone");
         assert!(tree.get(a1).is_none(), "mid descendant is not orphaned");
         assert!(tree.get(a1a).is_none(), "leaf descendant is not orphaned");
+        assert_eq!(tree.len(), 1, "only the root remains — no slab leak");
+    }
+
+    /// Deep-tree stack-safety: the eager removal path's subtree
+    /// collection must survive an element chain far deeper than the
+    /// fixed OS stack would allow with plain recursion. The element tree
+    /// nests several times deeper than the render tree (every render
+    /// object is wrapped in multiple composition views), so it hits the
+    /// 1 MiB Windows main-thread stack earlier — same failure class
+    /// PR #177 closed in flui-rendering. The collection frame is small,
+    /// so the depth is 20 000 (the small-frame sizing the
+    /// flui-rendering compositing-bits test established; 2 500 survived
+    /// unprotected there by luck).
+    ///
+    /// The chain is built one generation at a time through the
+    /// production reconciler (it inserts a parent's DIRECT children
+    /// only), then torn down by reconciling the root to zero children —
+    /// the keyless top takes the eager path, which collects and frees
+    /// the whole 20 000-node subtree in one call.
+    ///
+    /// Ignored under miri: the interpreter cannot finish a 20 000-level
+    /// walk in reasonable time; `eager_remove_tears_down_whole_subtree`
+    /// exercises the same path natively at shallow depth.
+    #[test]
+    #[cfg_attr(miri, ignore = "20k-node walk too slow for the interpreter")]
+    fn eager_remove_survives_deep_chain() {
+        const DEPTH: usize = 20_000;
+
+        let (mut tree, mut owner, root) = fixture();
+
+        let mut parent = root;
+        for _ in 0..DEPTH {
+            reconcile_children_by_id(
+                &mut tree,
+                parent,
+                &plain_views(&[1]),
+                &mut owner.element_owner_mut(),
+            );
+            parent = tree.get(parent).expect("parent resolves").child_ids()[0];
+        }
+        assert_eq!(tree.len(), DEPTH + 1, "root + 20 000 chain nodes");
+
+        // Drop the chain top from the root's children → the eager
+        // removal must collect and free all 20 000 descendants without
+        // exhausting the stack.
+        reconcile_children_by_id(&mut tree, root, &[], &mut owner.element_owner_mut());
+
         assert_eq!(tree.len(), 1, "only the root remains — no slab leak");
     }
 


### PR DESCRIPTION
## What

Follow-up to #177, which made every recursive walk in `flui-rendering` stack-safe. The element/widget layer was not swept there — and the element tree nests several times deeper than the render tree (every render object is wrapped in multiple composition views), so it hits the 1 MiB Windows main-thread stack earlier.

A full sweep of `crates/flui-view` and `crates/flui-tree` found exactly **two** remaining recursive descents over the element tree, both purely structural (no user code on the path):

- `BuildOwner::collect_elements_to_unmount` — `finalize_tree`'s subtree collection
- `id_reconcile::collect_subtree_preorder` — the eager removal path's subtree collection

Both are rewritten iteratively with an explicit `Vec` work-stack, preserving the recursive shape's pre-order visit order by pushing children in reverse slot order — the same discipline `WidgetsBinding::collect_all_elements` already uses. The per-level child-ids `Vec` snapshot is gone too: with no recursive call for the borrow to outlive, the shared slab borrow ends within the `extend` statement.

## Why no `ensure_stack` probes here

PR #177's recipe reserves `stacker::maybe_grow` probes for *contractual* recursion (walks that re-enter through user code). The element layer has none:

- build/inflate is already an iterative dirty-heap drain — children are **scheduled** onto the heap, never built recursively from their parent;
- `flui-tree`'s `Descendants` iterator already runs on an explicit work-stack;
- the box reconciler permutes a single generation without descending;
- `ElementTree::remove`/`remove_finalized`/`insert` are single-node operations.

So no `stacker` dependency, no helper lift into `flui-foundation` — the two structural walks just become loops.

## Tests

Two 20 000-level deep-chain regression tests (the small-frame sizing the #177 round-3 lesson established). Both were **verified to crash with `STATUS_STACK_OVERFLOW` against the recursive shape before the rewrite** — a deep test only guards the regression if the depth genuinely overflows. Both pass in 0.01 s after it. They are `#[cfg_attr(miri, ignore)]` (a 20k-node walk is too slow for the interpreter); the shallow tests in the same modules cover the borrow discipline natively and pass under miri.

## Gates

- `cargo test --workspace` green
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt` clean
- `scripts/port-check.sh` — all 18 refusal triggers + FR-033 grep clean
- `RUSTDOCFLAGS="-D warnings" cargo doc` clean
- `cargo +nightly miri test` on both touched modules — 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)