### PR TITLE
ci: trim Windows matrix, split clippy job, bump checkout to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,27 +27,22 @@ env:
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────
-  # checks — fast gate. fmt + clippy + port-check + typos + Taplo.
-  # Every downstream job depends on this. Ubuntu only — pure source analysis.
+  # checks — fast source gate. fmt + port-check + typos + Taplo. No compile.
+  # Every downstream job (clippy, test, doc, bench-compile) depends on this, so
+  # a malformed PR fails in seconds before any workspace build starts.
+  # Ubuntu only — pure source analysis. clippy lives in its own parallel job.
   # ─────────────────────────────────────────────────────────────────────────
   checks:
-    name: checks (fmt, clippy, port-check, typos, taplo)
+    name: checks (fmt, port-check, typos, taplo)
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Install Rust stable + components
+      - name: Install Rust stable + rustfmt
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
-
-      - name: Cache cargo registry + target
-        uses: Swatinem/rust-cache@v2
-        with:
-          # Skip cache writes on merge-queue runs to avoid poisoning the cache
-          # with merge-commit artifacts (per xilem/tokio precedent).
-          save-if: ${{ github.event_name != 'merge_group' }}
+          components: rustfmt
 
       - name: Install CI tools (typos, taplo, ripgrep)
         uses: taiki-e/install-action@v2
@@ -70,6 +65,30 @@ jobs:
       - name: scripts/port-check.sh (7 institutional refusal triggers)
         run: bash scripts/port-check.sh -v
 
+  # ─────────────────────────────────────────────────────────────────────────
+  # clippy — workspace lint with -D warnings. Split out of `checks` so it runs
+  # in PARALLEL with test/doc/bench-compile instead of gating them: clippy
+  # compiles the whole workspace (minutes); the rest of `checks` is seconds.
+  # Gated on `checks` so a malformed PR fails cheap before this build starts.
+  # ─────────────────────────────────────────────────────────────────────────
+  clippy:
+    name: clippy
+    needs: checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust stable + clippy
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
       - name: cargo clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
@@ -84,11 +103,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # Windows temporarily dropped from the matrix: day-to-day development
+        # happens on Windows locally, so Windows regressions surface there
+        # first — paying the wgpu/PDB build cost in CI is redundant for now.
+        # Re-add `windows-latest` here (and in `bench-compile`) once the
+        # workspace stabilizes and cross-platform CI coverage is worth the time.
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -133,11 +157,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # Windows temporarily dropped — see the note in the `test` job.
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -167,7 +192,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## What

Three CI-hygiene changes to `.github/workflows/ci.yml`, no source/behavior changes:

1. **Drop `windows-latest` from the `test` and `bench-compile` matrices** -> ubuntu-only.
2. **Split `clippy` out of the `checks` gate into its own parallel job.**
3. **Bump `actions/checkout@v4` -> `@v6`** across all jobs.

## Why

- **Windows off (temporary):** day-to-day development happens on Windows locally, so Windows regressions surface there first. The wgpu/PDB build cost made the Windows runner dominate CI wall-clock (~13+ min on the build step) for coverage already exercised by hand. Matrix-of-one is kept so `${{ matrix.os }}` interpolations stay intact and re-adding Windows is a one-word change in both jobs. Inline comments document how/when to restore.
- **clippy split:** clippy compiles the whole workspace (minutes) while the rest of `checks` (fmt, taplo, typos, port-check) is seconds. Bundling forced `test`/`doc`/`bench-compile` to wait on clippy. Now clippy runs in parallel with them; critical path drops from `checks(+clippy) -> test` to `checks -> max(clippy, test, doc, bench)`. `checks` is now a pure source gate (no cargo cache, rustfmt-only, timeout 25->10) and still gates every downstream job.
- **checkout v6:** Node 20 is deprecated on GitHub runners (forced to Node 24 on 2026-06-16, removed 2026-09-16); checkout v6 runs on Node 24. Latest verified via `gh api` (v6.0.3, 2026-06-02).

## Reviewer notes

- Job name `checks` is intentionally preserved so existing branch-protection required-checks do not break. A **new** `clippy` required check now exists -- if branch protection lists required checks, add `clippy` there.
- Other actions were checked and left as-is (all current, none flagged by the Node 20 notice): `Swatinem/rust-cache@v2` (v2.9.1), `taiki-e/install-action@v2` (composite), `dtolnay/rust-toolchain@stable` (composite).
- `dependabot.yml` already tracks the `github-actions` ecosystem; the checkout v4 drift was unmerged Dependabot PRs, not a config gap.
- Trade-off: CI loses automatic Windows coverage. Known Windows-specific flakes (flui-app singleton-state, flui-platform STATUS_HEAP_CORRUPTION) are now caught only locally until the matrix is restored.

## Job graph after

```
checks (fmt+taplo+typos+port-check, ubuntu, no compile)
   |-- clippy          (ubuntu)
   |-- test            (ubuntu)
   |-- bench-compile   (ubuntu)
   |-- doc             (ubuntu)   all parallel
```

YAML validated; job graph confirmed via parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)