### PR TITLE
Wave 0: render-pipeline + engine hygiene (clamp, short-circuit, paint/layout guards, wgpu diagnostics)

### DIFF
--- a/crates/flui-engine/src/wgpu/renderer.rs
+++ b/crates/flui-engine/src/wgpu/renderer.rs
@@ -253,6 +253,8 @@ impl Renderer {
             .await
             .map_err(EngineError::device_creation)?;
 
+        Self::install_device_diagnostics(&device);
+
         let device = Arc::new(device);
         let queue = Arc::new(queue);
 
@@ -353,6 +355,8 @@ impl Renderer {
             .await
             .map_err(EngineError::device_creation)?;
 
+        Self::install_device_diagnostics(&device);
+
         Ok(Self {
             instance,
             adapter,
@@ -419,6 +423,31 @@ impl Renderer {
             tracing::warn!("Unknown platform, using all available backends");
             wgpu::Backends::all()
         }
+    }
+
+    /// Installs diagnostic callbacks on a freshly created device.
+    ///
+    /// wgpu's default behaviour translates an uncaptured error (validation
+    /// bug, out-of-memory, internal GPU failure) into a thread panic, and a
+    /// lost device surfaces only as repeated surface failures with no cause.
+    /// Both callbacks route the fault through `tracing` so it is logged and
+    /// diagnosable instead of aborting the process or spinning the render
+    /// loop blind.
+    fn install_device_diagnostics(device: &wgpu::Device) {
+        device.on_uncaptured_error(Arc::new(|error: wgpu::Error| {
+            tracing::error!(
+                %error,
+                "wgpu uncaptured error (validation / out-of-memory / internal)",
+            );
+        }));
+        device.set_device_lost_callback(|reason, message| {
+            tracing::error!(
+                ?reason,
+                %message,
+                "wgpu device lost — the GPU context is gone; the renderer must \
+                 recreate the device to recover",
+            );
+        });
     }
 
     /// Required GPU features based on capabilities and adapter support

--- a/crates/flui-rendering/src/error.rs
+++ b/crates/flui-rendering/src/error.rs
@@ -203,18 +203,18 @@ pub enum RenderError {
     // ========================================================================
     // D-block PR-A1b — protocol-erased dispatch
     // ========================================================================
-    /// The protocol-erased constraints or geometry variant did not match
-    /// the node's protocol. Returned from
-    /// [`RenderNode::layout_leaf_erased`](crate::storage::RenderNode::layout_leaf_erased)
-    /// when a `Box(_)` constraint is handed to a `Sliver` node (or vice
-    /// versa). Indicates a bug in the pipeline-dispatch caller.
-    #[error(
-        "protocol mismatch in layout_erased: node is {node_protocol}, constraints are {constraints_protocol}"
-    )]
+    /// A pipeline walk reached a node whose protocol does not match the
+    /// protocol the walk expects. Returned by the layout walk (a `Box(_)`
+    /// constraint handed to a `Sliver` node or vice versa) and by the paint
+    /// walk (a sliver node reached by the box paint walk). Indicates a bug in
+    /// the pipeline-dispatch caller — the message is phase-agnostic because
+    /// more than one walk produces it.
+    #[error("protocol mismatch: node is {node_protocol}, walk expected {constraints_protocol}")]
     ProtocolMismatch {
         /// Protocol of the node that received the call.
         node_protocol: &'static str,
-        /// Protocol of the constraints actually passed.
+        /// Protocol the walk expected (e.g. `"Box"` for the box layout/paint
+        /// walks).
         constraints_protocol: &'static str,
     },
 

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -2276,21 +2276,10 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
     // On the Err path above, state is intentionally unmodified so
     // NEEDS_LAYOUT stays set for next-frame retry.
 
-    // D-block PR-A1 U20 — Debug geometry validation (Flutter parity).
-    // Objects must return finite sizes that satisfy their constraints.
-    debug_assert!(
-        geometry.is_finite(),
-        "{}: perform_layout returned non-finite size: {:?}",
-        debug_name,
-        geometry
-    );
-    debug_assert!(
-        constraints.is_satisfied_by(geometry),
-        "{}: perform_layout returned size {:?} that violates constraints {:?}",
-        debug_name,
-        geometry,
-        constraints
-    );
+    // Same protocol-generic geometry check the leaf commit runs
+    // (RenderEntry::layout_leaf_only) — Flutter's debugAssertDoesMeetConstraints:
+    // a finite size that satisfies the constraints. No-op for slivers.
+    <BoxProtocol as Protocol>::debug_assert_layout_output(&constraints, &geometry);
 
     entry.state_mut().set_geometry(geometry);
     entry.state_mut().set_constraints(constraints);
@@ -3989,5 +3978,89 @@ mod tests {
         let phantom = RenderId::new(99);
         owner.mark_needs_layout(phantom);
         assert!(owner.nodes_needing_layout().is_empty());
+    }
+
+    /// Leaf `RenderObject<BoxProtocol>` returning a fixed size regardless of
+    /// the constraints — used to drive the layout-output debug assertion on
+    /// the leaf commit path (`RenderEntry::layout_leaf_only`).
+    #[derive(Debug)]
+    struct FixedSizeLeaf {
+        size: flui_types::Size,
+    }
+
+    impl flui_foundation::Diagnosticable for FixedSizeLeaf {}
+    impl crate::traits::PaintEffectsCapability for FixedSizeLeaf {}
+    impl crate::traits::SemanticsCapability for FixedSizeLeaf {}
+    impl crate::traits::HotReloadCapability for FixedSizeLeaf {}
+
+    impl crate::protocol::RenderObject<crate::protocol::BoxProtocol> for FixedSizeLeaf {
+        fn perform_layout_raw(
+            &mut self,
+            _ctx: &mut <crate::protocol::BoxProtocol as crate::protocol::Protocol>::LayoutCtxErased<
+                '_,
+            >,
+        ) -> crate::error::RenderResult<
+            crate::protocol::ProtocolGeometry<crate::protocol::BoxProtocol>,
+        > {
+            Ok(self.size)
+        }
+
+        fn paint_raw(&self, _recorder: &mut crate::context::FragmentRecorder, _child_count: usize) {
+        }
+
+        fn hit_test_raw(
+            &self,
+            _position: crate::protocol::ProtocolPosition<crate::protocol::BoxProtocol>,
+            _child_count: usize,
+            _hit_child: &mut (
+                     dyn FnMut(
+                usize,
+                Option<crate::protocol::ProtocolPosition<crate::protocol::BoxProtocol>>,
+            ) -> bool
+                         + Send
+                         + Sync
+                 ),
+        ) -> bool {
+            false
+        }
+
+        fn geometry(&self) -> &crate::protocol::ProtocolGeometry<crate::protocol::BoxProtocol> {
+            &self.size
+        }
+
+        fn set_geometry(
+            &mut self,
+            geometry: crate::protocol::ProtocolGeometry<crate::protocol::BoxProtocol>,
+        ) {
+            self.size = geometry;
+        }
+
+        fn paint_bounds(&self) -> flui_types::Rect {
+            flui_types::Rect::from_origin_size(flui_types::Point::ZERO, self.size)
+        }
+    }
+
+    /// A leaf committing a size that violates the constraints it was laid out
+    /// under trips `Protocol::debug_assert_layout_output` (Flutter
+    /// `debugAssertDoesMeetConstraints`) on the leaf commit path — a node
+    /// returning 999×999 under tight 100×100 is a layout bug.
+    #[test]
+    #[should_panic(expected = "violates its constraints")]
+    fn leaf_committing_a_constraint_violating_size_trips_the_layout_assert() {
+        let mut owner = PipelineOwner::new();
+        let root = owner.insert(Box::new(FixedSizeLeaf {
+            size: flui_types::Size::new(
+                flui_types::geometry::px(999.0),
+                flui_types::geometry::px(999.0),
+            ),
+        })
+            as Box<dyn crate::traits::RenderObject<crate::protocol::BoxProtocol>>);
+        owner.set_root_id(Some(root));
+        owner.set_root_constraints(Some(BoxConstraints::tight(flui_types::Size::new(
+            flui_types::geometry::px(100.0),
+            flui_types::geometry::px(100.0),
+        ))));
+
+        let _ = owner.run_frame();
     }
 }

--- a/crates/flui-rendering/src/protocol/box_protocol.rs
+++ b/crates/flui-rendering/src/protocol/box_protocol.rs
@@ -125,6 +125,27 @@ impl Protocol for BoxProtocol {
         state.compute_relayout_boundary(true, false, has_parent);
     }
 
+    /// Flutter's `debugAssertDoesMeetConstraints` (`box.dart`): a node's own
+    /// committed size must be finite and satisfy the constraints it was laid
+    /// out under. A render object that needs to overflow passes modified
+    /// constraints down to its children — its own size still stays in range,
+    /// so this catches the silent-commit of an infinite or constraint-
+    /// violating size at the source.
+    fn debug_assert_layout_output(constraints: &BoxConstraints, geometry: &Size) {
+        debug_assert!(
+            geometry.width.get().is_finite() && geometry.height.get().is_finite(),
+            "layout produced a non-finite size {geometry:?} under {constraints:?}: a \
+             render object returned inf/NaN — constrain the result before returning it",
+        );
+        debug_assert!(
+            constraints.is_satisfied_by(*geometry),
+            "layout produced size {geometry:?} that violates its constraints \
+             {constraints:?}: a node's own size must satisfy the constraints it was \
+             given — pass modified constraints to children instead of overflowing the \
+             node's own size",
+        );
+    }
+
     /// D-block PR-A1b U19 — wraps the given `BoxConstraints` in a typed
     /// `BoxLayoutCtx::<Leaf, BoxParentData>::new(constraints)` (no
     /// children, no callback) and hands an erased `&mut dyn

--- a/crates/flui-rendering/src/protocol/protocol.rs
+++ b/crates/flui-rendering/src/protocol/protocol.rs
@@ -134,6 +134,24 @@ pub trait Protocol: Send + Sync + Debug + Clone + Copy + sealed::Sealed + 'stati
         let _ = (state, has_parent);
     }
 
+    /// Debug-only check that a freshly computed layout result is well-formed:
+    /// a finite geometry that satisfies the constraints it was laid out under.
+    ///
+    /// Called at every layout-commit site (leaf and container paths). The
+    /// default is a no-op — sliver geometry validation is deferred to Core.2.
+    /// `BoxProtocol` overrides it with Flutter's `debugAssertDoesMeetConstraints`
+    /// (`box.dart`): a node's own size must be finite and within its
+    /// constraints. The `debug_assert!` bodies compile out in release builds,
+    /// leaving the override an empty call the optimizer can drop.
+    fn debug_assert_layout_output(
+        constraints: &<Self::Layout as LayoutCapability>::Constraints,
+        geometry: &<Self::Layout as LayoutCapability>::Geometry,
+    ) where
+        Self: Sized,
+    {
+        let _ = (constraints, geometry);
+    }
+
     /// Constructs a leaf-mode (no children, no layout callback) erased
     /// layout context from protocol-typed constraints, then invokes `f`
     /// with a `&mut Self::LayoutCtxErased<'_>` referencing it.

--- a/crates/flui-rendering/src/storage/entry.rs
+++ b/crates/flui-rendering/src/storage/entry.rs
@@ -386,6 +386,7 @@ impl<P: Protocol> RenderEntry<P> {
 
         // Update state -- only on the success path. On panic, state remains
         // untouched and NEEDS_LAYOUT stays set so a retry is possible.
+        <P as crate::protocol::Protocol>::debug_assert_layout_output(&constraints, &geometry);
         self.state.set_geometry(geometry.clone());
         self.state.set_constraints(constraints);
 


### PR DESCRIPTION
## What

Wave 0 hygiene from the post-#177 RenderObject readiness audit. **Rebased onto current `main`: PR #179 ("Wave 1 RenderImage") independently landed most of the original W0 set** (tighten-clamp, clean-child layout short-circuit, paint sliver guard, child-boundary guard, inline layout asserts). This branch is therefore slimmed to the three pieces that are genuinely net-new over #179.

| Commit | Fix |
|--------|-----|
| `55927ce1` | **wgpu device diagnostics.** wgpu turns an uncaptured error (validation / OOM / internal) into a thread panic by default, and a lost device surfaced only as repeated surface failures with no cause. Register `on_uncaptured_error` + `set_device_lost_callback` (wgpu 29) on every created device via a shared `install_device_diagnostics`, routing both faults through `tracing::error`. Applied at both production device sites (surface + offscreen). |
| `6079ac0d` | **Protocol-generic layout-output assertion.** #179 debug-asserts finite + in-constraints geometry inline in the container walk, but the **leaf** commit path (`RenderEntry::layout_leaf_only`) had no such check — a leaf returning an infinite or constraint-violating size committed silently. Lift the check into `Protocol::debug_assert_layout_output` (Box: finite + `is_satisfied_by`; Sliver: no-op, Core.2) and call it at **both** commit sites, so the leaf path is covered and the two paths share one release-compiled-out mechanism. |
| `48622716` | **Phase-agnostic `ProtocolMismatch` message.** The paint walk now returns `ProtocolMismatch` on a sliver too, but the Display hard-coded "in layout_erased". Reword to "protocol mismatch: node is X, walk expected Y". |

## Tests

- `leaf_committing_a_constraint_violating_size_trips_the_layout_assert` (`should_panic`): a leaf returning 999×999 under tight 100×100 trips the new leaf-path assert.

## Gates

clippy `--workspace --all-targets -D warnings` 0 · `fmt --all --check` clean · `cargo doc -D warnings` 0 · miri clean on the layout/paint walks · flui-rendering 481 lib + integration green · flui-view/flui-app green · flui-engine 107/107 GPU (DX12).

## Copilot review

All three inline findings (`ProtocolMismatch` message, `install_device_diagnostics` doc, `debug_assert_layout_output` doc) are addressed in the commits above.

## Follow-ups (own PRs, not skipped)

- **Hit-test transform consolidation** (audit W0 item 4): the production hit walk records bare entries with no transform/local position; three parallel hit-test stacks exist (dead R-24 in `box_protocol.rs`, dead `MatrixTransformPart`, canonical in `flui-interaction`); the gesture dispatcher ignores `entry.transform`. Cross-crate consolidation with real design choices — its own PR.
- **Device-loss recovery** (device recreation): this PR adds observability only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
