### PR TITLE
Wave 1 core: RenderImage intrinsics, width/height/scale, fit-independent sizing

### DIFF
--- a/crates/flui-rendering/src/constraints/box_constraints.rs
+++ b/crates/flui-rendering/src/constraints/box_constraints.rs
@@ -167,6 +167,39 @@ impl BoxConstraints {
         }
     }
 
+    /// Creates constraints that tighten each dimension to its value only when
+    /// that value is finite, leaving infinite dimensions unconstrained.
+    ///
+    /// Mirrors Flutter's `BoxConstraints.tightForFinite` (`box.dart`), used by
+    /// intrinsic-dimension probes that pass `f32::INFINITY` for the axis they
+    /// are not constraining.
+    #[inline]
+    #[must_use]
+    pub fn tight_for_finite(width: Pixels, height: Pixels) -> Self {
+        Self {
+            min_width: if width.is_finite() {
+                width
+            } else {
+                Pixels::ZERO
+            },
+            max_width: if width.is_finite() {
+                width
+            } else {
+                Pixels::INFINITY
+            },
+            min_height: if height.is_finite() {
+                height
+            } else {
+                Pixels::ZERO
+            },
+            max_height: if height.is_finite() {
+                height
+            } else {
+                Pixels::INFINITY
+            },
+        }
+    }
+
     // ============================================================================
     // NORMALIZATION FOR CACHING
     // ============================================================================
@@ -334,36 +367,52 @@ impl BoxConstraints {
     /// Flutter equivalent: `BoxConstraints.constrainSizeAndAttemptToPreserveAspectRatio`
     #[must_use]
     pub fn constrain_size_and_attempt_to_preserve_aspect_ratio(&self, size: Size) -> Size {
-        // Zero size: return as-is
-        if size.width.get() == 0.0 || size.height.get() == 0.0 {
-            return Size::new(
-                self.constrain_width(size.width),
-                self.constrain_height(size.height),
-            );
+        // Tight constraints fix the size outright (Flutter `box.dart`).
+        if self.is_tight() {
+            return self.smallest();
         }
 
-        // Aspect ratio of the natural size
-        let aspect_ratio = size.width.get() / size.height.get();
+        let mut width = size.width.get();
+        let mut height = size.height.get();
 
-        // Start by constraining to the absolute limits
-        let mut w = self.constrain_width(size.width);
-        let mut h = self.constrain_height(size.height);
-
-        // If the constrained size doesn't match the aspect ratio, adjust
-        // one dimension to restore it. Pick the dimension with more room.
-        let constrained_ratio = w.get() / h.get();
-
-        if constrained_ratio > aspect_ratio {
-            // Width is too large; scale down to maintain aspect ratio
-            w = Pixels::new(h.get() * aspect_ratio);
-            w = self.constrain_width(w);
-        } else if constrained_ratio < aspect_ratio {
-            // Height is too large; scale down to maintain aspect ratio
-            h = Pixels::new(w.get() / aspect_ratio);
-            h = self.constrain_height(h);
+        // A degenerate aspect source has no ratio to preserve — just constrain.
+        if width <= 0.0 || height <= 0.0 {
+            return self.constrain(size);
         }
 
-        Size::new(w, h)
+        let aspect_ratio = width / height;
+        let min_w = self.min_width.get();
+        let max_w = self.max_width.get();
+        let min_h = self.min_height.get();
+        let max_h = self.max_height.get();
+
+        // Adjust each out-of-range dimension and bring the OTHER dimension along
+        // to keep the ratio. Order (max then min, width then height) and the
+        // re-derivation of the partner dimension match Flutter's
+        // `constrainSizeAndAttemptToPreserveAspectRatio` exactly — the previous
+        // flui version clamped a dimension up to its min and then "scaled down"
+        // the same dimension, which got re-clamped and never grew its partner.
+        if width > max_w {
+            width = max_w;
+            height = width / aspect_ratio;
+        }
+        if height > max_h {
+            height = max_h;
+            width = height * aspect_ratio;
+        }
+        if width < min_w {
+            width = min_w;
+            height = width / aspect_ratio;
+        }
+        if height < min_h {
+            height = min_h;
+            width = height * aspect_ratio;
+        }
+
+        Size::new(
+            self.constrain_width(Pixels::new(width)),
+            self.constrain_height(Pixels::new(height)),
+        )
     }
 
     // ============================================================================

--- a/crates/flui-rendering/src/objects/image.rs
+++ b/crates/flui-rendering/src/objects/image.rs
@@ -94,11 +94,27 @@ pub struct RenderImage {
     /// load). When `None`, the object still lays out via `intrinsic_size`
     /// but paints nothing.
     image: Option<Image>,
-    /// Natural (intrinsic) size of the image.
+    /// Natural (intrinsic) size of the image, in image pixels. Divided by
+    /// [`scale`](Self::scale) to obtain the logical aspect source. flui keeps
+    /// this stored (Flutter derives it live from the image) so a not-yet-loaded
+    /// image can still reserve layout space — a superset of Flutter, which
+    /// returns `constraints.smallest` while the image is null.
     intrinsic_size: Size,
-    /// How to fit the image into available space.
+    /// Optional forced logical width. Folded into the constraints during
+    /// sizing (Flutter `RenderImage.width`); `None` means derive from the
+    /// image aspect.
+    width: Option<Pixels>,
+    /// Optional forced logical height (Flutter `RenderImage.height`).
+    height: Option<Pixels>,
+    /// Number of image pixels per logical pixel (Flutter `RenderImage.scale`).
+    /// The intrinsic size is divided by this to get the logical aspect source,
+    /// so a 2x asset renders at half its pixel dimensions.
+    scale: f32,
+    /// How to fit the image into available space. Affects paint only (where
+    /// the image is fitted into the laid-out box), not the box size — matching
+    /// Flutter, whose `_sizeForConstraints` never reads `fit`.
     fit: ImageFit,
-    /// How to align the image within the box.
+    /// How to align the image within the box. Paint-only, like `fit`.
     alignment: ImageAlignment,
     /// Cached layout size (set by perform_layout).
     size: Size,
@@ -111,6 +127,9 @@ impl RenderImage {
         Self {
             image: None,
             intrinsic_size,
+            width: None,
+            height: None,
+            scale: 1.0,
             fit,
             alignment,
             size: Size::ZERO,
@@ -125,6 +144,9 @@ impl RenderImage {
         Self {
             image: Some(image),
             intrinsic_size,
+            width: None,
+            height: None,
+            scale: 1.0,
             fit,
             alignment,
             size: Size::ZERO,
@@ -134,6 +156,21 @@ impl RenderImage {
     /// Returns the current image source, if any.
     pub fn image(&self) -> Option<&Image> {
         self.image.as_ref()
+    }
+
+    /// Returns the forced logical width, if set.
+    pub fn width(&self) -> Option<Pixels> {
+        self.width
+    }
+
+    /// Returns the forced logical height, if set.
+    pub fn height(&self) -> Option<Pixels> {
+        self.height
+    }
+
+    /// Returns the image-pixels-per-logical-pixel scale.
+    pub fn scale(&self) -> f32 {
+        self.scale
     }
 
     /// Sets the image source and updates the intrinsic size from its
@@ -163,6 +200,28 @@ impl RenderImage {
     pub fn set_alignment(&mut self, alignment: ImageAlignment) {
         self.alignment = alignment;
         // Caller responsible for marking repaint dirty
+    }
+
+    /// Sets the forced logical width (`None` to derive from the image aspect).
+    pub fn set_width(&mut self, width: Option<Pixels>) {
+        self.width = width;
+        // Caller responsible for marking the node layout-dirty.
+    }
+
+    /// Sets the forced logical height (`None` to derive from the image aspect).
+    pub fn set_height(&mut self, height: Option<Pixels>) {
+        self.height = height;
+        // Caller responsible for marking the node layout-dirty.
+    }
+
+    /// Sets the image-pixels-per-logical-pixel scale. A non-finite or
+    /// non-positive value is rejected (the previous scale is kept) because it
+    /// would make the logical aspect source NaN or zero.
+    pub fn set_scale(&mut self, scale: f32) {
+        if scale.is_finite() && scale > 0.0 {
+            self.scale = scale;
+        }
+        // Caller responsible for marking the node layout-dirty.
     }
 
     /// Computes the destination rectangle for the image content within the
@@ -223,48 +282,34 @@ impl RenderImage {
         ))
     }
 
-    /// Computes the size of the image given the fit mode and constraints.
+    /// Computes the box size for the given constraints — a direct port of
+    /// Flutter's `RenderImage._sizeForConstraints` (`image.dart`).
+    ///
+    /// The box size is **independent of [`fit`](ImageFit)**: the explicit
+    /// `width`/`height` are folded into the constraints, then the box takes the
+    /// largest size that fits while preserving the image's aspect ratio
+    /// (intrinsic size divided by `scale`). `fit` only governs where the image
+    /// is drawn inside this box, in [`Self::paint_rect_in`].
+    ///
+    /// The logical aspect source is `intrinsic_size / scale`; when it is
+    /// degenerate (zero in either dimension) the box falls back to the
+    /// constraints' smallest size, mirroring Flutter's null-image branch.
     ///
     /// Public so that callers can reproduce layout sizing without driving a
     /// full layout pass (tests, demos).
     pub fn compute_size(&self, constraints: &BoxConstraints) -> Size {
-        match self.fit {
-            ImageFit::Fill => {
-                // Fill the maximum box allowed by constraints.
-                constraints.biggest()
-            }
-            ImageFit::Contain => {
-                // Fit entirely within the box, preserving aspect ratio
-                constraints.constrain_size_and_attempt_to_preserve_aspect_ratio(self.intrinsic_size)
-            }
-            ImageFit::Cover => {
-                // Cover the entire box, preserving aspect ratio
-                // (image may be cropped)
-                let constrained = constraints
-                    .constrain_size_and_attempt_to_preserve_aspect_ratio(self.intrinsic_size);
-                // Ensure at least minimum dimensions are met
-                Size::new(
-                    constrained.width.max(constraints.min_width),
-                    constrained.height.max(constraints.min_height),
-                )
-            }
-            ImageFit::ScaleDown => {
-                // Like Contain, but never enlarge
-                let unconstrained = BoxConstraints {
-                    min_width: Pixels::ZERO,
-                    max_width: self.intrinsic_size.width,
-                    min_height: Pixels::ZERO,
-                    max_height: self.intrinsic_size.height,
-                };
-                let size = unconstrained
-                    .constrain_size_and_attempt_to_preserve_aspect_ratio(self.intrinsic_size);
-                constraints.constrain(size)
-            }
-            ImageFit::None => {
-                // Show at natural size, clamped to constraints
-                constraints.constrain(self.intrinsic_size)
-            }
+        // Fold the explicit width/height into the constraints so all three are
+        // treated uniformly (Flutter: tightFor(width, height).enforce(...)).
+        let folded = BoxConstraints::tight_for(self.width, self.height).enforce(constraints);
+
+        let aspect = Size::new(
+            Pixels::new(self.intrinsic_size.width.get() / self.scale),
+            Pixels::new(self.intrinsic_size.height.get() / self.scale),
+        );
+        if aspect.width.get() <= 0.0 || aspect.height.get() <= 0.0 {
+            return folded.smallest();
         }
+        folded.constrain_size_and_attempt_to_preserve_aspect_ratio(aspect)
     }
 }
 
@@ -302,6 +347,80 @@ impl RenderBox for RenderImage {
         if let Some(dst) = self.compute_paint_rect() {
             ctx.canvas().draw_image(image.clone(), dst, None);
         }
+    }
+
+    // Intrinsics mirror Flutter `RenderImage` (`image.dart`): the size the box
+    // would take with the cross-axis extent tightened. With no forced
+    // width/height the min-intrinsics report 0 (the image can scale to nothing),
+    // while max-intrinsics always report the aspect-preserved extent. A leaf,
+    // so the `_ctx` child channel is unused.
+
+    fn compute_min_intrinsic_width(
+        &self,
+        height: f32,
+        _ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        if self.width.is_none() && self.height.is_none() {
+            return 0.0;
+        }
+        self.compute_size(&BoxConstraints::tight_for_finite(
+            Pixels::INFINITY,
+            Pixels::new(height),
+        ))
+        .width
+        .get()
+    }
+
+    fn compute_max_intrinsic_width(
+        &self,
+        height: f32,
+        _ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        self.compute_size(&BoxConstraints::tight_for_finite(
+            Pixels::INFINITY,
+            Pixels::new(height),
+        ))
+        .width
+        .get()
+    }
+
+    fn compute_min_intrinsic_height(
+        &self,
+        width: f32,
+        _ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        if self.width.is_none() && self.height.is_none() {
+            return 0.0;
+        }
+        self.compute_size(&BoxConstraints::tight_for_finite(
+            Pixels::new(width),
+            Pixels::INFINITY,
+        ))
+        .height
+        .get()
+    }
+
+    fn compute_max_intrinsic_height(
+        &self,
+        width: f32,
+        _ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        self.compute_size(&BoxConstraints::tight_for_finite(
+            Pixels::new(width),
+            Pixels::INFINITY,
+        ))
+        .height
+        .get()
+    }
+
+    /// Dry layout is the exact box size `perform_layout` commits — both go
+    /// through `compute_size` (Flutter `computeDryLayout == _sizeForConstraints`).
+    fn compute_dry_layout(
+        &self,
+        constraints: BoxConstraints,
+        _ctx: &mut crate::context::BoxDryLayoutCtx<'_>,
+    ) -> Size {
+        self.compute_size(&constraints)
     }
 }
 
@@ -595,5 +714,114 @@ mod tests {
         assert_eq!(dst.origin().y, Pixels::ZERO);
         assert_eq!(dst.size().width, px(120.0));
         assert_eq!(dst.size().height, px(80.0));
+    }
+
+    // ===== width / height / scale folding + intrinsics + dry layout =====
+
+    use crate::context::intrinsics_test_support::{leaf_dry_layout, leaf_intrinsics};
+
+    #[test]
+    fn forced_width_tightens_box_and_preserves_aspect() {
+        // 1:1 intrinsic, forced logical width 40, otherwise unconstrained → 40x40.
+        let mut img = RenderImage::new(
+            Size::new(px(4.0), px(4.0)),
+            ImageFit::Contain,
+            ImageAlignment::Center,
+        );
+        img.set_width(Some(px(40.0)));
+        assert_eq!(
+            img.compute_size(&BoxConstraints::UNCONSTRAINED),
+            Size::new(px(40.0), px(40.0)),
+        );
+    }
+
+    #[test]
+    fn scale_divides_the_aspect_source() {
+        // 200x100 intrinsic at scale 2 → logical aspect source 100x50.
+        let mut img = RenderImage::new(
+            Size::new(px(200.0), px(100.0)),
+            ImageFit::Fill,
+            ImageAlignment::Center,
+        );
+        img.set_scale(2.0);
+        assert_eq!(
+            img.compute_size(&BoxConstraints::UNCONSTRAINED),
+            Size::new(px(100.0), px(50.0)),
+        );
+    }
+
+    #[test]
+    fn box_size_is_independent_of_fit() {
+        // Flutter `_sizeForConstraints` never reads `fit`: every fit mode under
+        // the same constraints + intrinsic must produce the same box.
+        let constraints = BoxConstraints {
+            min_width: Pixels::ZERO,
+            max_width: px(80.0),
+            min_height: Pixels::ZERO,
+            max_height: px(80.0),
+        };
+        let intrinsic = Size::new(px(200.0), px(100.0)); // 2:1 → 80x40 in an 80² box
+        for fit in [
+            ImageFit::Fill,
+            ImageFit::Contain,
+            ImageFit::Cover,
+            ImageFit::ScaleDown,
+            ImageFit::None,
+        ] {
+            let img = RenderImage::new(intrinsic, fit, ImageAlignment::Center);
+            assert_eq!(
+                img.compute_size(&constraints),
+                Size::new(px(80.0), px(40.0)),
+                "fit {fit:?} must not affect the box size",
+            );
+        }
+    }
+
+    #[test]
+    fn intrinsics_report_aspect_extent() {
+        let img = RenderImage::new(
+            Size::new(px(200.0), px(100.0)),
+            ImageFit::Contain,
+            ImageAlignment::Center,
+        );
+        // Max-intrinsics under an unbounded cross extent = the aspect source.
+        assert_eq!(
+            leaf_intrinsics(|c| img.compute_max_intrinsic_width(f32::INFINITY, c)),
+            200.0,
+        );
+        assert_eq!(
+            leaf_intrinsics(|c| img.compute_max_intrinsic_height(f32::INFINITY, c)),
+            100.0,
+        );
+        // Min-intrinsics are 0 with no forced width/height (the image can scale
+        // down to nothing).
+        assert_eq!(
+            leaf_intrinsics(|c| img.compute_min_intrinsic_width(f32::INFINITY, c)),
+            0.0,
+        );
+        assert_eq!(
+            leaf_intrinsics(|c| img.compute_min_intrinsic_height(f32::INFINITY, c)),
+            0.0,
+        );
+    }
+
+    #[test]
+    fn forced_width_drives_min_intrinsic_and_dry_layout_matches_layout() {
+        let mut img = RenderImage::new(
+            Size::new(px(200.0), px(100.0)),
+            ImageFit::Contain,
+            ImageAlignment::Center,
+        );
+        img.set_width(Some(px(80.0)));
+        // A forced width makes the min-intrinsic-width report it (80).
+        assert_eq!(
+            leaf_intrinsics(|c| img.compute_min_intrinsic_width(f32::INFINITY, c)),
+            80.0,
+        );
+        // Dry layout equals the size perform_layout commits for the same constraints.
+        let constraints = BoxConstraints::UNCONSTRAINED;
+        let dry = leaf_dry_layout(|c| img.compute_dry_layout(constraints, c));
+        assert_eq!(dry, img.compute_size(&constraints));
+        assert_eq!(dry, Size::new(px(80.0), px(40.0)));
     }
 }

--- a/crates/flui-rendering/src/objects/image.rs
+++ b/crates/flui-rendering/src/objects/image.rs
@@ -246,8 +246,13 @@ impl RenderImage {
     /// Returns `None` when the intrinsic size is degenerate (zero in either
     /// dimension), in which case there is nothing to paint.
     pub fn paint_rect_in(&self, box_size: Size) -> Option<Rect> {
-        let iw = self.intrinsic_size.width.get();
-        let ih = self.intrinsic_size.height.get();
+        // Logical image size (Flutter `ImageInfo.scale`): the fit math operates
+        // on the same `intrinsic / scale` dimensions the box was laid out
+        // against, so a high-DPI asset paints at its logical size — without the
+        // divide, `ImageFit::None`/`ScaleDown` would draw a 2x asset at its full
+        // pixel size and overflow its laid-out box.
+        let iw = self.intrinsic_size.width.get() / self.scale;
+        let ih = self.intrinsic_size.height.get() / self.scale;
         if iw <= 0.0 || ih <= 0.0 {
             return None;
         }
@@ -299,8 +304,11 @@ impl RenderImage {
     /// full layout pass (tests, demos).
     pub fn compute_size(&self, constraints: &BoxConstraints) -> Size {
         // Fold the explicit width/height into the constraints so all three are
-        // treated uniformly (Flutter: tightFor(width, height).enforce(...)).
-        let folded = BoxConstraints::tight_for(self.width, self.height).enforce(constraints);
+        // treated uniformly (Flutter `tightFor(w, h).enforce(constraints)`).
+        // `tighten` clamps each forced dimension INTO the parent's range, so a
+        // forced size outside the parent's min/max can never commit a size that
+        // violates the incoming constraints.
+        let folded = constraints.tighten(self.width, self.height);
 
         let aspect = Size::new(
             Pixels::new(self.intrinsic_size.width.get() / self.scale),
@@ -823,5 +831,50 @@ mod tests {
         let dry = leaf_dry_layout(|c| img.compute_dry_layout(constraints, c));
         assert_eq!(dry, img.compute_size(&constraints));
         assert_eq!(dry, Size::new(px(80.0), px(40.0)));
+    }
+
+    #[test]
+    fn forced_width_below_parent_minimum_respects_the_parent() {
+        // Forced width 40, but the parent demands min_width 50: the committed
+        // size must not drop below the parent's minimum.
+        let mut img = RenderImage::new(
+            Size::new(px(4.0), px(4.0)),
+            ImageFit::Contain,
+            ImageAlignment::Center,
+        );
+        img.set_width(Some(px(40.0)));
+        let constraints = BoxConstraints {
+            min_width: px(50.0),
+            max_width: px(200.0),
+            min_height: Pixels::ZERO,
+            max_height: px(200.0),
+        };
+        let size = img.compute_size(&constraints);
+        assert!(
+            size.width >= px(50.0),
+            "forced width {} must not violate the parent minimum 50",
+            size.width.get(),
+        );
+        assert!(
+            constraints.is_satisfied_by(size),
+            "size {size:?} must satisfy parent"
+        );
+    }
+
+    #[test]
+    fn scale_shrinks_the_painted_size() {
+        // 200x100 asset at scale 2 → logical 100x50. In an oversized box,
+        // ImageFit::None paints at the logical size, not the raw pixel size.
+        let mut img = RenderImage::new(
+            Size::new(px(200.0), px(100.0)),
+            ImageFit::None,
+            ImageAlignment::TopLeft,
+        );
+        img.set_scale(2.0);
+        let rect = img
+            .paint_rect_in(Size::new(px(400.0), px(400.0)))
+            .expect("paint rect");
+        assert_eq!(rect.size().width, px(100.0));
+        assert_eq!(rect.size().height, px(50.0));
     }
 }


### PR DESCRIPTION
## What

Closes the load-bearing RenderImage gaps surfaced by an against-the-reference audit of #179's Wave 1 RenderImage (which shipped a working MVP but ~1/3 of the Flutter `image.dart` contract). Verdict was: happy path renders real pixels and is well-tested, but **intrinsics, the `width`/`height`/`scale` sizing fields, and fit-independent sizing were missing**.

| Commit | Change |
|--------|--------|
| `39e6fe95` | **Fix `constrain_size_and_attempt_to_preserve_aspect_ratio`** + add `tight_for_finite`. The aspect helper diverged from Flutter: it clamped a dimension up to its min, then "scaled down" the *same* dimension (re-clamped) and never grew its partner — a 4×4 source forced to width 40 returned 40×4 instead of 40×40. Ported Flutter's `box.dart` algorithm verbatim (tight → smallest; adjust each out-of-range dim max-then-min, width-then-height, re-deriving the partner). RenderImage is the only caller, so the corrected sizing is contained. |
| `bda1bfbb` | **RenderImage `width`/`height`/`scale` + fit-independent sizing + intrinsics + dry layout.** Sizing now ports `_sizeForConstraints` verbatim: fold `width`/`height` into the constraints via `tightFor().enforce()`, then aspect-preserve `intrinsic_size / scale`. The box size is now **independent of `fit`** (Flutter never reads `fit` in sizing) — `fit` governs paint only. Implement the four `computeMin/MaxIntrinsicWidth/Height` methods and `compute_dry_layout`. |

`hitTestSelf` is already covered by `RenderBox`'s default size-bounds `hit_test`. Setter-driven invalidation stays caller-driven per flui's arena convention (render objects hold no owner back-ref — verified against `RenderColoredBox` et al., not a gap).

## Tests

Six new tests in `image.rs`: forced-width/height fold, scale, **fit-independence of box size** (proves the divergence fix), the four intrinsics via the leaf-intrinsics test harness, and `dry_layout == compute_size`. The 16 existing sizing/paint tests still pass (their constraint/intrinsic combos coincide under the fit-independent model).

## Gates

flui-rendering 486 lib green · clippy `-D warnings` 0 · fmt clean · `cargo doc -D warnings` 0 · miri clean on the intrinsics/dry walks · flui-view/flui-app green · `image_demo` example compiles.

## Still tail debt (own follow-up, tracked)

Paint fidelity beyond the rect — `repeat`, `centerSlice` (nine-patch), `color`/`colorBlendMode`, `opacity`, `filterQuality`, `flipHorizontally`, `invertColors`, `isAntiAlias`, and `fitWidth`/`fitHeight` — plus `AlignmentGeometry` and image-clone/dispose lifecycle. The engine already has `draw_image_repeat`/`nine_slice`/`filtered`; wiring them is additive and does not block Wave 2 (RenderParagraph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
