### PR TITLE
Core.2 Sliver W3.2b-1: cross-protocol child layout (Box parent → leaf Sliver child)

### DIFF
--- a/crates/flui-rendering/src/context/layout.rs
+++ b/crates/flui-rendering/src/context/layout.rs
@@ -34,7 +34,7 @@ use flui_tree::Arity;
 use flui_types::{Pixels, Size, geometry::Offset};
 
 use crate::{
-    constraints::{BoxConstraints, Constraints},
+    constraints::{BoxConstraints, Constraints, SliverConstraints, SliverGeometry},
     parent_data::ParentData,
     protocol::{BoxLayout, LayoutCapability, LayoutContextApi, Protocol},
 };
@@ -333,6 +333,45 @@ where
     pub fn complete_matching_child(&mut self) {
         let size = self.child_geometry(0).cloned().unwrap_or(Size::ZERO);
         self.inner.complete_layout(size);
+    }
+}
+
+// ============================================================================
+// BOX CROSS-PROTOCOL EXTENSIONS
+// ============================================================================
+//
+// Separate impl block so the `BoxLayoutCtxErased` bound does not pollute
+// the shared-method-name impl above (which would cause E0034 ambiguity
+// between `BoxLayoutCtxErased::constraints` and
+// `LayoutContextApi::constraints`).
+
+impl<'ctx, A: Arity, PD: ParentData + Default> LayoutContext<'ctx, BoxProtocol, A, PD>
+where
+    <BoxLayout as LayoutCapability>::Context<'ctx, A, PD>:
+        crate::protocol::box_protocol::BoxLayoutCtxErased,
+{
+    /// Lays out a **sliver** child at `index` with the given
+    /// [`SliverConstraints`] and returns its [`SliverGeometry`].
+    ///
+    /// Delegates to
+    /// [`crate::protocol::box_protocol::BoxLayoutCtxErased::layout_sliver_child`]
+    /// on the underlying context. In Direct-storage contexts (leaf-only
+    /// layout, unit tests without a pipeline-wired sliver callback) the
+    /// underlying impl returns [`SliverGeometry::ZERO`]. In the production
+    /// pipeline-driven Proxy context the call drives
+    /// `layout_sliver_subtree_borrowed` on the pre-acquired sliver-child slot.
+    ///
+    /// `RenderViewport::perform_layout` (next PR) is the primary consumer.
+    pub fn layout_sliver_child(
+        &mut self,
+        index: usize,
+        constraints: SliverConstraints,
+    ) -> SliverGeometry {
+        crate::protocol::box_protocol::BoxLayoutCtxErased::layout_sliver_child(
+            &mut self.inner,
+            index,
+            constraints,
+        )
     }
 }
 

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -22,11 +22,11 @@ use parking_lot::Mutex;
 use rustc_hash::FxHashSet;
 
 use crate::{
-    constraints::BoxConstraints,
+    constraints::{BoxConstraints, SliverConstraints, SliverGeometry},
     context::{FragmentClip, FragmentOp, FragmentRecorder},
     protocol::{
         BoxProtocol, Protocol,
-        box_protocol::{BoxLayoutCtxErased, LayoutChildCallback},
+        box_protocol::{BoxLayoutCtxErased, LayoutChildCallback, SliverLayoutChildCallback},
     },
     storage::{RenderEntry, RenderNode, RenderTree},
 };
@@ -2203,6 +2203,7 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
     // is Sync too. So `&SubtreeBorrows: Send + Sync`, satisfying
     // `LayoutChildCallback: Send + Sync`.
     let borrows_for_cb: &SubtreeBorrows<'_> = borrows;
+    let descendant_error_for_sliver_cb = std::sync::Arc::clone(&descendant_error_flag);
     let cb_owned = move |child_id: RenderId, child_constraints: BoxConstraints| -> Size {
         // SAFETY: `borrows_for_cb` is alive (held by the outer
         // layout_dirty_root stack frame for the entire walk). The
@@ -2227,6 +2228,40 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
     };
     let cb_ref: LayoutChildCallback<'_> = &cb_owned;
 
+    // Sliver child callback: invoked when the Box parent calls
+    // `ctx.layout_sliver_child(index, sliver_constraints)`.  Uses the
+    // same `borrows_for_cb` pool and `descendant_error_flag` as the box
+    // callback — no extra pre-acquisition needed since sliver children
+    // are already in the pre-acquired `SubtreeBorrows` set.
+    let sliver_cb_owned = move |child_id: RenderId,
+                                sliver_constraints: SliverConstraints|
+          -> SliverGeometry {
+        // SAFETY: `borrows_for_cb` is alive for the entire walk (held
+        // by the `layout_dirty_root` stack frame). The reborrow targets
+        // `child_id`'s slot — distinct from the Box parent's slot
+        // (tree acyclicity) and from any concurrently-active Box child
+        // slot (LayoutCycleGuard blocks re-entry). No two concurrent
+        // reborrows of the same NodePtr.
+        match unsafe {
+            layout_sliver_subtree_borrowed(borrows_for_cb, child_id, sliver_constraints)
+        } {
+            Ok(geometry) => geometry,
+            Err(err) => {
+                descendant_error_for_sliver_cb.store(true, std::sync::atomic::Ordering::Relaxed);
+                tracing::error!(
+                    parent = ?id,
+                    ?child_id,
+                    ?err,
+                    "layout_dirty_root: sliver descendant layout failed; \
+                         returning SliverGeometry::ZERO to caller's perform_layout. \
+                         Parent NEEDS_LAYOUT preserved for next-frame retry.",
+                );
+                SliverGeometry::ZERO
+            }
+        }
+    };
+    let sliver_cb_ref: SliverLayoutChildCallback<'_> = &sliver_cb_owned;
+
     // Construct the driver-side PARENT-DATA-ERASED context. The walk
     // cannot name the parent's ParentData type (it holds dyn nodes);
     // the typed blanket bridge reconstructs BoxLayoutCtx<T::Arity,
@@ -2240,6 +2275,7 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
         &mut child_states,
         &child_ids,
         cb_ref,
+        Some(sliver_cb_ref),
     );
     let erased: &mut dyn BoxLayoutCtxErased = &mut ctx;
 
@@ -2328,6 +2364,102 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
     }
 
     Ok(geometry)
+}
+
+// ============================================================================
+// Cross-protocol child layout: Box parent → leaf Sliver child
+// ============================================================================
+//
+// `layout_sliver_subtree_borrowed` is the Sliver sibling of
+// `layout_subtree_borrowed`. It is called from the `sliver_cb_owned`
+// closure captured inside `layout_subtree_borrowed_impl`'s non-leaf path
+// when a Box parent calls `ctx.layout_sliver_child(index, constraints)`.
+//
+// Scope: LEAF sliver children only. Non-leaf sliver children are gated by
+// the arity check inside `RenderEntry::layout_leaf_only` (the Sliver
+// blanket returns `RenderError::ContractViolation` for non-leaf nodes).
+//
+// The short-circuit clean-child optimisation from the Box path is omitted
+// here on purpose: leaf slivers always relayout because their constraints
+// change with scroll position on every frame. Omitting the check is
+// correct and saves a branch.
+
+/// Stack-probe wrapper for [`layout_sliver_subtree_borrowed_impl`].
+///
+/// # Safety
+///
+/// Same contract as [`layout_subtree_borrowed`]:
+/// 1. `borrows` must outlive every recursive invocation this helper
+///    triggers (it is held by the outer `layout_dirty_root` stack frame
+///    for the entire walk).
+/// 2. At any moment, no two concurrent reborrows of the SAME [`NodePtr`]
+///    exist. The `LayoutCycleGuard` enforces this by returning
+///    [`crate::error::RenderError::LayoutCycle`] on re-entry into a slot
+///    already in flight, preventing the otherwise-UB second Unique tag.
+unsafe fn layout_sliver_subtree_borrowed<'tree>(
+    borrows: &SubtreeBorrows<'tree>,
+    id: flui_foundation::RenderId,
+    constraints: SliverConstraints,
+) -> crate::error::RenderResult<SliverGeometry> {
+    ensure_stack(|| {
+        // SAFETY: identical contract, forwarded verbatim from this
+        // wrapper's own `# Safety` section; the stack-growth wrapper
+        // only relocates which memory the frames live in, never their
+        // borrow structure, lifetimes, or drop order.
+        unsafe { layout_sliver_subtree_borrowed_impl(borrows, id, constraints) }
+    })
+}
+
+/// Body of [`layout_sliver_subtree_borrowed`]; split out so every
+/// recursion level enters through the [`ensure_stack`] probe.
+///
+/// # Safety
+///
+/// Same contract as [`layout_sliver_subtree_borrowed`].
+unsafe fn layout_sliver_subtree_borrowed_impl<'tree>(
+    borrows: &SubtreeBorrows<'tree>,
+    id: flui_foundation::RenderId,
+    constraints: SliverConstraints,
+) -> crate::error::RenderResult<SliverGeometry> {
+    // U21 cycle guard: register `id` in currently_laying_out *before*
+    // any NodePtr reborrow. Same RAII discipline as the Box path —
+    // Drop runs on every exit including unwind so the set stays
+    // consistent across panics.
+    let _cycle_guard = LayoutCycleGuard::enter(borrows, id)?;
+
+    // Resolve id → NodePtr. Cross-thread access panics inside `get`.
+    let NodePtr(node_ptr) = match borrows.get(id) {
+        Some(np) => np,
+        None => return Err(crate::error::RenderError::NodeNotFound(id)),
+    };
+
+    // SAFETY: `node_ptr` aliases a `&mut RenderNode` that
+    // `SubtreeBorrows` holds disjointly from every other slot it
+    // covers. The reborrow below is the FIRST and ONLY reborrow of
+    // `id`'s slot in this call frame; no other live `&mut` to this
+    // slot exists — the Box parent's reborrow belongs to a DISTINCT
+    // slot (parent ≠ child by tree acyclicity), and the cycle guard
+    // above prevents re-entry into `id` from the same call stack.
+    // Distinct slot reborrows have independent Unique tags under
+    // Stacked / Tree Borrows — no aliasing.
+    let node_ref: &mut crate::storage::RenderNode = unsafe { &mut *node_ptr };
+
+    let node_protocol = node_ref.protocol_name();
+    let entry: &mut RenderEntry<crate::protocol::SliverProtocol> = match node_ref.as_sliver_mut() {
+        Some(e) => e,
+        None => {
+            return Err(crate::error::RenderError::ProtocolMismatch {
+                node_protocol,
+                constraints_protocol: "Sliver",
+            });
+        }
+    };
+
+    // Delegate to the generic leaf-only layout path.
+    // Non-leaf sliver nodes trigger `RenderError::ContractViolation`
+    // inside `layout_leaf_only` via the arity gate — the non-leaf
+    // sliver walk is out of scope for this change.
+    entry.layout_leaf_only(constraints)
 }
 
 // ============================================================================

--- a/crates/flui-rendering/src/protocol/box_protocol.rs
+++ b/crates/flui-rendering/src/protocol/box_protocol.rs
@@ -268,7 +268,7 @@ pub type LayoutChildCallback<'a> =
 /// Called when a Box parent's `layout_sliver_child()` is invoked. The callback
 /// receives the sliver child's [`flui_foundation::RenderId`] and
 /// [`SliverConstraints`], drives leaf layout on the child via the pre-acquired
-/// [`crate::pipeline::SubtreeBorrows`] pool, and returns the child's
+/// pipeline subtree-borrow pool, and returns the child's
 /// [`SliverGeometry`].
 ///
 /// Mirrors [`LayoutChildCallback`] in contract; distinct because the input and

--- a/crates/flui-rendering/src/protocol/box_protocol.rs
+++ b/crates/flui-rendering/src/protocol/box_protocol.rs
@@ -13,7 +13,7 @@ use flui_types::{
 };
 
 use crate::{
-    constraints::{BoxConstraints, Constraints},
+    constraints::{BoxConstraints, Constraints, SliverConstraints, SliverGeometry},
     parent_data::{BoxParentData, ParentData},
     protocol::{
         capabilities::{HitTestCapability, HitTestContextApi, LayoutCapability, LayoutContextApi},
@@ -262,6 +262,19 @@ impl LayoutCapability for BoxLayout {
 /// the RenderTree, and returns the child's size.
 pub type LayoutChildCallback<'a> =
     &'a (dyn Fn(flui_foundation::RenderId, BoxConstraints) -> Size + Send + Sync);
+
+/// Callback type for cross-protocol sliver child layout driven by a Box parent.
+///
+/// Called when a Box parent's `layout_sliver_child()` is invoked. The callback
+/// receives the sliver child's [`flui_foundation::RenderId`] and
+/// [`SliverConstraints`], drives leaf layout on the child via the pre-acquired
+/// [`crate::pipeline::SubtreeBorrows`] pool, and returns the child's
+/// [`SliverGeometry`].
+///
+/// Mirrors [`LayoutChildCallback`] in contract; distinct because the input and
+/// output types differ (sliver protocol vs. box protocol).
+pub type SliverLayoutChildCallback<'a> =
+    &'a (dyn Fn(flui_foundation::RenderId, SliverConstraints) -> SliverGeometry + Send + Sync);
 
 /// Per-child geometry storage owned by the typed wrapper when bridging
 /// from an erased context.
@@ -707,6 +720,23 @@ pub trait BoxLayoutCtxErased: Send + Sync {
     /// constraints; returns the child's computed `Size`.
     fn layout_child(&mut self, index: usize, constraints: BoxConstraints) -> Size;
 
+    /// Lays out a **sliver** child at `index` with the given
+    /// [`SliverConstraints`]; returns the child's [`SliverGeometry`].
+    ///
+    /// Only the **leaf** sliver path is supported here (non-leaf sliver
+    /// children gate to [`crate::error::RenderError::ContractViolation`]
+    /// inside `RenderEntry::layout_leaf_only` when the arity check fires).
+    ///
+    /// When no sliver callback is wired (e.g. a Direct-storage context
+    /// constructed without one), returns [`SliverGeometry::ZERO`] — same
+    /// conservative fallback as `layout_child` returning `Size::ZERO` on
+    /// the no-callback Direct path.
+    fn layout_sliver_child(
+        &mut self,
+        index: usize,
+        constraints: SliverConstraints,
+    ) -> SliverGeometry;
+
     /// Records the paint offset for child at `index`.
     fn position_child(&mut self, index: usize, offset: Offset);
 
@@ -799,6 +829,26 @@ impl<A: Arity, P: ParentData + Default> BoxLayoutCtxErased for BoxLayoutCtx<'_, 
     #[inline]
     fn layout_child(&mut self, index: usize, constraints: BoxConstraints) -> Size {
         <Self as LayoutContextApi<'_, BoxLayout, A, P>>::layout_child(self, index, constraints)
+    }
+
+    #[inline]
+    fn layout_sliver_child(
+        &mut self,
+        index: usize,
+        constraints: SliverConstraints,
+    ) -> SliverGeometry {
+        // Direct-storage `BoxLayoutCtx` does not carry a sliver callback
+        // (it is used by leaf-only paths and unit tests that never wire
+        // cross-protocol layout). Return `ZERO` — the same conservative
+        // fallback as `layout_child` returning `Size::ZERO` on the
+        // no-callback Direct path. Proxy storage delegates to the
+        // underlying erased ctx which IS wired by the pipeline.
+        match &mut self.storage {
+            BoxLayoutCtxStorage::Direct { .. } => SliverGeometry::ZERO,
+            BoxLayoutCtxStorage::Proxy { erased, .. } => {
+                erased.layout_sliver_child(index, constraints)
+            }
+        }
     }
 
     #[inline]
@@ -907,15 +957,26 @@ pub struct ErasedBoxLayoutCtx<'ctx> {
     children: &'ctx mut Vec<ErasedChildState>,
     child_ids: &'ctx [flui_foundation::RenderId],
     layout_child_callback: LayoutChildCallback<'ctx>,
+    /// Optional callback for cross-protocol sliver child layout.
+    ///
+    /// `None` when no sliver children are present in this subtree walk.
+    /// `layout_sliver_child` returns [`SliverGeometry::ZERO`] in that
+    /// case, matching the conservative fallback on the box path.
+    sliver_layout_child_callback: Option<SliverLayoutChildCallback<'ctx>>,
 }
 
 impl<'ctx> ErasedBoxLayoutCtx<'ctx> {
     /// Creates the walk-side context over pre-built child slots.
+    ///
+    /// `sliver_layout_child_callback` is `None` when the parent is known
+    /// to have no sliver children (avoids the allocation + closure
+    /// construction on the all-box common path).
     pub fn new(
         constraints: BoxConstraints,
         children: &'ctx mut Vec<ErasedChildState>,
         child_ids: &'ctx [flui_foundation::RenderId],
         layout_child_callback: LayoutChildCallback<'ctx>,
+        sliver_layout_child_callback: Option<SliverLayoutChildCallback<'ctx>>,
     ) -> Self {
         Self {
             constraints,
@@ -923,6 +984,7 @@ impl<'ctx> ErasedBoxLayoutCtx<'ctx> {
             children,
             child_ids,
             layout_child_callback,
+            sliver_layout_child_callback,
         }
     }
 
@@ -950,6 +1012,20 @@ impl BoxLayoutCtxErased for ErasedBoxLayoutCtx<'_> {
             slot.size = size;
         }
         size
+    }
+
+    fn layout_sliver_child(
+        &mut self,
+        index: usize,
+        constraints: SliverConstraints,
+    ) -> SliverGeometry {
+        let Some(&child_id) = self.child_ids.get(index) else {
+            return SliverGeometry::ZERO;
+        };
+        match self.sliver_layout_child_callback {
+            Some(cb) => (cb)(child_id, constraints),
+            None => SliverGeometry::ZERO,
+        }
     }
 
     fn position_child(&mut self, index: usize, offset: Offset) {

--- a/crates/flui-rendering/tests/cross_protocol_layout.rs
+++ b/crates/flui-rendering/tests/cross_protocol_layout.rs
@@ -1,0 +1,293 @@
+//! Cross-protocol child layout — Box parent lays out a leaf Sliver child.
+//!
+//! Core.2 W3.2b-1: verifies that a Box parent can call
+//! `ctx.layout_sliver_child(index, constraints)` to drive a Sliver child
+//! through the `layout_sliver_subtree_borrowed` pipeline path, and that
+//! calling that method when the indexed child is a Box-protocol node returns
+//! `SliverGeometry::ZERO` and keeps the parent marked dirty.
+//!
+//! Tests:
+//!   1. **Positive** — Box parent + leaf Sliver child → non-zero
+//!      [`SliverGeometry`] produced, parent `needs_layout` cleared.
+//!   2. **Negative** — Box parent calls `layout_sliver_child` on a Box child
+//!      (protocol mismatch) → `SliverGeometry::ZERO`, parent stays dirty.
+//!
+//! Refs:
+//!   * `crates/flui-rendering/src/pipeline/owner.rs` `layout_sliver_subtree_borrowed`
+//!   * `crates/flui-rendering/src/protocol/box_protocol.rs` `BoxLayoutCtxErased::layout_sliver_child`
+
+use std::sync::{Arc, Mutex};
+
+use flui_foundation::Diagnosticable;
+use flui_rendering::{
+    constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
+    context::{BoxLayoutContext, SliverHitTestContext, SliverLayoutContext},
+    objects::RenderColoredBox,
+    parent_data::{BoxParentData, SliverParentData},
+    pipeline::PipelineOwner,
+    protocol::{BoxProtocol, SliverProtocol},
+    traits::{
+        HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, RenderSliver,
+        SemanticsCapability,
+    },
+    view::ScrollDirection,
+};
+use flui_tree::{Leaf, Variable};
+use flui_types::{Point, Rect, Size, geometry::px, layout::AxisDirection};
+
+// ============================================================================
+// Shared fixtures
+// ============================================================================
+
+/// Pipeline owner in the Layout phase.
+fn fresh_layout_pipeline() -> PipelineOwner<flui_rendering::pipeline::Layout> {
+    PipelineOwner::new().into_layout()
+}
+
+/// A sliver constraints value representing a 600×300 vertical viewport
+/// at scroll offset 0 with 400 px of remaining paint extent.
+fn make_sliver_constraints() -> SliverConstraints {
+    SliverConstraints {
+        axis_direction: AxisDirection::TopToBottom,
+        cross_axis_direction: AxisDirection::LeftToRight,
+        growth_direction: GrowthDirection::Forward,
+        user_scroll_direction: ScrollDirection::Idle,
+        scroll_offset: 0.0,
+        preceding_scroll_extent: 0.0,
+        overlap: 0.0,
+        remaining_paint_extent: 400.0,
+        cross_axis_extent: 300.0,
+        viewport_main_axis_extent: 600.0,
+        remaining_cache_extent: 450.0,
+        cache_origin: 0.0,
+    }
+}
+
+// ============================================================================
+// StubLeafSliver — minimal leaf Sliver render object
+// ============================================================================
+
+/// Leaf sliver that reports a deterministic geometry: 200 px scroll extent,
+/// paint extent clamped to remaining paint extent. Used to confirm that the
+/// cross-protocol path actually calls into the sliver's `perform_layout`.
+#[derive(Debug, Default)]
+struct StubLeafSliver {
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl Diagnosticable for StubLeafSliver {}
+impl PaintEffectsCapability for StubLeafSliver {}
+impl SemanticsCapability for StubLeafSliver {}
+impl HotReloadCapability for StubLeafSliver {}
+
+impl RenderSliver for StubLeafSliver {
+    type Arity = Leaf;
+    type ParentData = SliverParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Leaf, Self::ParentData>) {
+        let paint = 200.0_f32.min(ctx.constraints().remaining_paint_extent);
+        let geom = SliverGeometry {
+            scroll_extent: 200.0,
+            paint_extent: paint,
+            layout_extent: paint,
+            max_paint_extent: 200.0,
+            hit_test_extent: paint,
+            visible: paint > 0.0,
+            ..SliverGeometry::ZERO
+        };
+        ctx.complete(geom);
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn hit_test(&self, _ctx: &mut SliverHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+        false
+    }
+
+    fn sliver_paint_bounds(&self) -> Rect {
+        Rect::from_origin_size(Point::ZERO, Size::ZERO)
+    }
+}
+
+// ============================================================================
+// BoxWithSliverChild — Box parent that drives a sliver child
+// ============================================================================
+
+/// `Variable`-arity Box render object that, during layout, calls
+/// `ctx.layout_sliver_child(0, sliver_constraints)` and records the
+/// returned [`SliverGeometry`] in a shared sink.
+///
+/// Completes with the biggest size allowed by the parent constraints so the
+/// pipeline succeeds and dirty-flag state is observable.
+struct BoxWithSliverChild {
+    sliver_constraints: SliverConstraints,
+    /// Records the `SliverGeometry` received from `layout_sliver_child`.
+    captured: Arc<Mutex<Option<SliverGeometry>>>,
+    size: Size,
+}
+
+impl std::fmt::Debug for BoxWithSliverChild {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BoxWithSliverChild").finish_non_exhaustive()
+    }
+}
+
+impl Diagnosticable for BoxWithSliverChild {}
+impl PaintEffectsCapability for BoxWithSliverChild {}
+impl SemanticsCapability for BoxWithSliverChild {}
+impl HotReloadCapability for BoxWithSliverChild {}
+
+impl RenderBox for BoxWithSliverChild {
+    type Arity = Variable;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Variable, BoxParentData>) {
+        let geom = ctx.layout_sliver_child(0, self.sliver_constraints);
+        *self.captured.lock().unwrap() = Some(geom);
+        ctx.complete_with_size(ctx.constraints().biggest());
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+}
+
+// ============================================================================
+// Test 1 — Positive: Box parent lays out a leaf Sliver child
+// ============================================================================
+
+/// Box parent with a leaf Sliver child drives `layout_sliver_subtree_borrowed`
+/// and receives the child's non-zero [`SliverGeometry`].
+///
+/// `layout_dirty_root` must return `Ok`, the captured geometry must have
+/// `scroll_extent = 200.0`, and the parent's `needs_layout` must be cleared.
+#[test]
+fn cross_protocol_box_parent_lays_out_leaf_sliver_child() {
+    let sc = make_sliver_constraints();
+    let captured: Arc<Mutex<Option<SliverGeometry>>> = Arc::new(Mutex::new(None));
+
+    let parent_obj: Box<dyn RenderObject<BoxProtocol>> = Box::new(BoxWithSliverChild {
+        sliver_constraints: sc,
+        captured: Arc::clone(&captured),
+        size: Size::ZERO,
+    });
+    let sliver_obj: Box<dyn RenderObject<SliverProtocol>> = Box::new(StubLeafSliver::default());
+
+    let mut pipeline = fresh_layout_pipeline();
+    let parent_id = pipeline.render_tree_mut().insert_box(parent_obj);
+    pipeline
+        .render_tree_mut()
+        .insert_sliver_child(parent_id, sliver_obj)
+        .expect("tree must accept a Sliver child under a Box parent");
+
+    let box_constraints = BoxConstraints::new(px(0.0), px(800.0), px(0.0), px(600.0));
+    let result = pipeline.layout_dirty_root(parent_id, box_constraints);
+    assert!(
+        result.is_ok(),
+        "layout_dirty_root must succeed for Box parent + leaf Sliver child: {result:?}"
+    );
+
+    let geom = captured
+        .lock()
+        .unwrap()
+        .expect("perform_layout must have called layout_sliver_child and stored the result");
+
+    assert_eq!(
+        geom.scroll_extent, 200.0,
+        "StubLeafSliver always reports scroll_extent=200.0; captured geometry must match"
+    );
+    assert!(
+        geom.paint_extent > 0.0,
+        "remaining_paint_extent=400.0 so StubLeafSliver's paint_extent (min(200,400)=200) must be >0"
+    );
+
+    let parent_node = pipeline
+        .render_tree()
+        .get(parent_id)
+        .expect("parent must remain in the tree after layout");
+    assert!(
+        !parent_node.needs_layout(),
+        "parent NEEDS_LAYOUT must be cleared after successful cross-protocol layout"
+    );
+}
+
+// ============================================================================
+// Test 2 — Negative: layout_sliver_child on a Box child returns ZERO + stays dirty
+// ============================================================================
+
+/// Calling `ctx.layout_sliver_child(0, ...)` when child 0 is a Box-protocol
+/// node triggers a `ProtocolMismatch` error in `layout_sliver_subtree_borrowed_impl`
+/// (`as_sliver_mut()` returns `None`).  The sliver callback sets the
+/// descendant-error flag → parent `NEEDS_LAYOUT` stays set for retry,
+/// and `SliverGeometry::ZERO` is returned to the parent's `perform_layout`.
+///
+/// Assertions:
+/// - `layout_dirty_root` returns `Ok` (parent's own geometry is produced).
+/// - The captured geometry equals `SliverGeometry::ZERO`.
+/// - Parent remains dirty (`needs_layout() == true`).
+#[test]
+fn cross_protocol_layout_sliver_child_on_box_child_returns_zero_and_keeps_dirty() {
+    let sc = make_sliver_constraints();
+    let captured: Arc<Mutex<Option<SliverGeometry>>> = Arc::new(Mutex::new(None));
+
+    let parent_obj: Box<dyn RenderObject<BoxProtocol>> = Box::new(BoxWithSliverChild {
+        sliver_constraints: sc,
+        captured: Arc::clone(&captured),
+        size: Size::ZERO,
+    });
+    // Deliberately insert a Box child, not a Sliver child.
+    let box_child: Box<dyn RenderObject<BoxProtocol>> = Box::new(RenderColoredBox::red(40.0, 40.0));
+
+    let mut pipeline = fresh_layout_pipeline();
+    let parent_id = pipeline.render_tree_mut().insert_box(parent_obj);
+    pipeline
+        .render_tree_mut()
+        .insert_box_child(parent_id, box_child)
+        .expect("tree must accept a Box child");
+
+    let box_constraints = BoxConstraints::new(px(0.0), px(800.0), px(0.0), px(600.0));
+
+    // The parent's perform_layout calls complete_with_size and returns Ok,
+    // so layout_dirty_root itself returns Ok.  Only the descendant-error flag
+    // prevents NEEDS_LAYOUT from being cleared.
+    let result = pipeline.layout_dirty_root(parent_id, box_constraints);
+    assert!(
+        result.is_ok(),
+        "layout_dirty_root must return Ok even when a descendant ProtocolMismatch occurs: {result:?}"
+    );
+
+    let geom = captured
+        .lock()
+        .unwrap()
+        .expect("perform_layout must have called layout_sliver_child");
+    assert_eq!(
+        geom,
+        SliverGeometry::ZERO,
+        "layout_sliver_child on a Box-protocol child must return SliverGeometry::ZERO"
+    );
+
+    let parent_node = pipeline
+        .render_tree()
+        .get(parent_id)
+        .expect("parent must remain in the tree after layout");
+    assert!(
+        parent_node.needs_layout(),
+        "parent NEEDS_LAYOUT must remain set after descendant ProtocolMismatch \
+         (descendant_error_flag keeps the dirty bit for next-frame retry)"
+    );
+}

--- a/crates/flui-rendering/tests/cross_protocol_layout.rs
+++ b/crates/flui-rendering/tests/cross_protocol_layout.rs
@@ -86,7 +86,8 @@ impl RenderSliver for StubLeafSliver {
     type ParentData = SliverParentData;
 
     fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Leaf, Self::ParentData>) {
-        let paint = 200.0_f32.min(ctx.constraints().remaining_paint_extent);
+        self.constraints = *ctx.constraints();
+        let paint = 200.0_f32.min(self.constraints.remaining_paint_extent);
         let geom = SliverGeometry {
             scroll_extent: 200.0,
             paint_extent: paint,
@@ -96,6 +97,9 @@ impl RenderSliver for StubLeafSliver {
             visible: paint > 0.0,
             ..SliverGeometry::ZERO
         };
+        // Keep the object's own fields in sync with the layout result so
+        // `constraints()` / `geometry()` honor the RenderSliver contract.
+        self.geometry = geom;
         ctx.complete(geom);
     }
 


### PR DESCRIPTION
## Core.2 Sliver — W3.2b-1: cross-protocol child layout (Box parent → leaf Sliver child)

Plumbing so a **Box render object can lay out a Sliver child**. This is the mechanism `RenderViewport` (next slice) needs to drive slivers from a box-rooted subtree the pipeline already executes. Scoped to a **leaf** sliver child; non-leaf sliver children remain gated to `ContractViolation` (their child-walk is a later slice). No `RenderViewport` object yet — only the mechanism + integration tests.

### Why this is the hard piece
`layout_subtree_borrowed` (the unsafe per-child layout driver) is hardcoded to Box: `BoxConstraints → Size`, `as_box_mut()` else `ProtocolMismatch`. A viewport's sliver child would hit `ProtocolMismatch`. This adds the parallel cross-protocol path.

### What changed
- **`owner.rs`**: `layout_sliver_subtree_borrowed` (+`_impl`) — a leaf-sliver sibling of the Box walk, mirroring the NodePtr-reborrow discipline **exactly** (`ensure_stack` → `LayoutCycleGuard::enter` before reborrow → single distinct-slot reborrow → `as_sliver_mut()` else `ProtocolMismatch` → delegate to `RenderEntry::layout_leaf_only`). A `sliver_cb_owned` closure in the non-leaf Box driver shares the same `borrows` pool and the **same** `descendant_error_flag` (a failed sliver child keeps the parent `NEEDS_LAYOUT` for next-frame retry).
- **`box_protocol.rs`**: `SliverLayoutChildCallback` type; `BoxLayoutCtxErased::layout_sliver_child(index, SliverConstraints) -> SliverGeometry`; `BoxLayoutCtx` impl (Direct without a sliver callback → `SliverGeometry::ZERO`; Proxy → delegate); `ErasedBoxLayoutCtx` gains the `sliver_layout_child_callback` (index-bounds-checked).
- **`context/layout.rs`**: `BoxLayoutContext::layout_sliver_child` forwarder (full-path trait dispatch to dodge `E0034`).

### Soundness
The cross-protocol reborrow preserves the exact invariant: distinct child slot, first-and-only reborrow, cycle guard (shared, id-based → catches cross-protocol cycles) registered before reborrow. `cargo +nightly miri test` clean over the new tests.

### Tests (`tests/cross_protocol_layout.rs`)
- `cross_protocol_box_parent_lays_out_leaf_sliver_child` — a Box parent builds `SliverConstraints` and lays out a leaf-sliver child through the real pipeline; child geometry is non-zero, parent cleared.
- `cross_protocol_layout_sliver_child_on_box_child_returns_zero_and_keeps_dirty` — calling `layout_sliver_child` on a Box child → `ProtocolMismatch`-driven `SliverGeometry::ZERO` + parent stays dirty.

### Gates
build clean · `cargo check --workspace` clean · nextest **602/602** · clippy `-D warnings` clean · fmt clean · **miri 2/2** clean.

### Next (W3.2b-2)
The `RenderViewport` render object itself (Box, builds `SliverConstraints` from its box size, calls `ctx.layout_sliver_child`, positions + paints the sliver child) + an e2e example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
