### PR TITLE
Core.2 Sliver W3: complete sliver subtree traversal

### DIFF
--- a/crates/flui-rendering/src/objects/sliver_ignore_pointer.rs
+++ b/crates/flui-rendering/src/objects/sliver_ignore_pointer.rs
@@ -132,16 +132,8 @@ impl RenderSliver for RenderSliverIgnorePointer {
             return false;
         }
 
-        // Defer to the child via the generic per-child hit-test API.
-        // `SliverHitTestContext::hit_test_child(0, position)` is the
-        // generic [`HitTestContext`] forward — Sliver protocol does not
-        // yet expose an `_at_offset` variant (see
-        // `crates/flui-rendering/src/context/hit_test.rs`), so we
-        // forward the current main/cross axis position unchanged. The
-        // child is positioned by the viewport, not by this proxy, so
-        // the identity-position forwarding is correct.
-        let position = ctx.main_axis_position();
-        ctx.hit_test_child(0, position)
+        // Defer to the child at its committed sliver paint offset.
+        ctx.hit_test_child_at_layout_offset(0)
     }
 
     fn sliver_paint_bounds(&self) -> Rect {

--- a/crates/flui-rendering/src/objects/sliver_opacity.rs
+++ b/crates/flui-rendering/src/objects/sliver_opacity.rs
@@ -204,17 +204,13 @@ impl RenderSliver for RenderSliverOpacity {
 
     fn hit_test(
         &self,
-        _ctx: &mut SliverHitTestContext<'_, Single, SliverPhysicalParentData>,
+        ctx: &mut SliverHitTestContext<'_, Single, SliverPhysicalParentData>,
     ) -> bool {
         // Transparent — fully-transparent slivers still hit-test (Flutter
         // parity: `RenderSliverOpacity` does not gate hit-testing on
         // alpha, leaving that to `RenderSliverIgnorePointer`). The
-        // viewport drives child hit-testing directly; opacity adds no
-        // extra hit area.
-        //
-        // TODO(core.2): once `SliverHitTestContext` exposes
-        // `hit_test_child(0)` with offset translation, delegate here.
-        false
+        // opacity object adds no extra hit area.
+        ctx.hit_test_child_at_layout_offset(0)
     }
 
     fn sliver_paint_bounds(&self) -> Rect {

--- a/crates/flui-rendering/src/objects/sliver_padding.rs
+++ b/crates/flui-rendering/src/objects/sliver_padding.rs
@@ -354,7 +354,10 @@ impl RenderSliver for RenderSliverPadding {
 
         let (geometry, child_paint_offset) = self.padded_geometry(&constraints, &child_geometry);
 
-        // Set the child's paint offset within the padded box.
+        // Set the child's paint offset within the padded box. The
+        // layout walk commits this into the child's RenderState so
+        // later paint and hit-test phases use the same placement.
+        ctx.position_child(0, child_paint_offset);
         if let Some(pd) = ctx.child_parent_data_mut(0) {
             pd.paint_offset = child_paint_offset;
         }
@@ -377,23 +380,12 @@ impl RenderSliver for RenderSliverPadding {
 
     fn hit_test(
         &self,
-        _ctx: &mut SliverHitTestContext<'_, Single, SliverPhysicalParentData>,
+        ctx: &mut SliverHitTestContext<'_, Single, SliverPhysicalParentData>,
     ) -> bool {
-        // Sliver hit-testing currently has no per-child offset path
-        // exposed on the rich context (see
-        // `crates/flui-rendering/src/context/hit_test.rs`) — the
-        // viewport drives child-offset translation directly. Padding
-        // adds no hit area beyond what the child reports, so we
-        // delegate trivially: return false here (the viewport falls
-        // through to the next sliver) and rely on the child sliver's
-        // own `hit_test` once the rich Sliver hit-test API exposes
-        // child-offset translation.
-        //
-        // TODO(core.2): once `SliverHitTestContext` exposes
-        // `hit_test_child_at_offset(0, paint_offset)`, route through
-        // it here so the padded region itself is included in the hit
-        // region.
-        false
+        // Padding contributes no hit area of its own; it only forwards
+        // hits into the child after the pipeline subtracts the committed
+        // child paint offset.
+        ctx.hit_test_child_at_layout_offset(0)
     }
 
     fn sliver_paint_bounds(&self) -> Rect {

--- a/crates/flui-rendering/src/objects/sliver_padding.rs
+++ b/crates/flui-rendering/src/objects/sliver_padding.rs
@@ -1,7 +1,7 @@
 //! `RenderSliverPadding` — single-child sliver that pads its inner sliver on
 //! all four sides (main- and cross-axis), honouring the sliver layout
 //! protocol (scroll/paint/cache extents, scroll-offset correction passthrough,
-//! viewport overlap reset).
+//! viewport overlap reduction).
 //!
 //! # Flutter equivalence
 //!
@@ -165,9 +165,11 @@ impl RenderSliverPadding {
             from <= to,
             "cache_offset: from ({from}) must be <= to ({to})"
         );
-        let a = constraints.cache_origin;
-        let b = constraints.cache_origin + constraints.remaining_cache_extent;
-        (to.min(b) - from.max(a)).max(0.0)
+        let a = constraints.scroll_offset + constraints.cache_origin;
+        let b = constraints.scroll_offset + constraints.remaining_cache_extent;
+        (to.min(b) - from.max(a))
+            .max(0.0)
+            .min(constraints.remaining_cache_extent)
     }
 
     /// Computes the sliver child's constraints given the parent
@@ -178,7 +180,7 @@ impl RenderSliverPadding {
     /// - `scroll_offset` reduced by the leading padding (clamped to 0),
     /// - `cache_origin` extended by the leading padding (clamped to 0
     ///   on the high side — `cache_origin` is always <= 0),
-    /// - `overlap` reset to 0 (padding consumes any prior overlap),
+    /// - positive `overlap` reduced by the leading paint padding,
     /// - `remaining_paint_extent` reduced by the leading paint padding,
     /// - `remaining_cache_extent` reduced by the leading cache padding,
     /// - `cross_axis_extent` reduced by the total cross padding
@@ -192,7 +194,11 @@ impl RenderSliverPadding {
         let mut cc = *parent;
         cc.scroll_offset = (parent.scroll_offset - before).max(0.0);
         cc.cache_origin = (parent.cache_origin + before).min(0.0);
-        cc.overlap = 0.0;
+        cc.overlap = if parent.overlap > 0.0 {
+            (parent.overlap - before_pad_paint).max(0.0)
+        } else {
+            parent.overlap
+        };
         cc.remaining_paint_extent = parent.remaining_paint_extent - before_pad_paint;
         cc.remaining_cache_extent = parent.remaining_cache_extent - before_pad_cache;
         cc.cross_axis_extent = (parent.cross_axis_extent - cross).max(0.0);
@@ -263,8 +269,8 @@ impl RenderSliverPadding {
                 .cache_extent
                 .max(child_geometry.layout_extent + after_pad_cache))
         .min(parent.remaining_cache_extent);
-        let hit_test_extent = (main_pad_paint + child_geometry.hit_test_extent)
-            .max(before_pad_paint + child_geometry.paint_extent);
+        let hit_test_extent = (main_pad_paint + child_geometry.paint_extent)
+            .max(before_pad_paint + child_geometry.hit_test_extent);
 
         let geometry = SliverGeometry {
             paint_origin: child_geometry.paint_origin,
@@ -358,10 +364,6 @@ impl RenderSliver for RenderSliverPadding {
         // layout walk commits this into the child's RenderState so
         // later paint and hit-test phases use the same placement.
         ctx.position_child(0, child_paint_offset);
-        if let Some(pd) = ctx.child_parent_data_mut(0) {
-            pd.paint_offset = child_paint_offset;
-        }
-
         self.geometry = geometry;
         ctx.complete(geometry);
     }
@@ -553,6 +555,17 @@ mod tests {
     }
 
     #[test]
+    fn cache_offset_window_starts_at_scroll_offset_plus_cache_origin() {
+        let mut c = vertical_constraints(50.0, 50.0, 100.0, 300.0);
+        c.cache_origin = -20.0;
+
+        // Flutter's cache window is [scroll_offset + cache_origin,
+        // scroll_offset + remaining_cache_extent] = [30, 150]. The range
+        // [0, 40] overlaps only [30, 40] → 10.
+        assert_eq!(RenderSliverPadding::cache_offset(&c, 0.0, 40.0), 10.0);
+    }
+
+    #[test]
     fn resolve_picks_per_axis_padding_correctly() {
         let p = RenderSliverPadding::new(EdgeInsets {
             top: px(10.0),
@@ -608,6 +621,25 @@ mod tests {
         assert_eq!(cc.preceding_scroll_extent, 10.0);
         // Remaining paint reduced by leading paint padding (full 10 because scroll_offset=0).
         assert_eq!(cc.remaining_paint_extent, 200.0 - 10.0);
+    }
+
+    #[test]
+    fn child_constraints_reduce_positive_overlap_by_before_paint_padding() {
+        let p = RenderSliverPadding::new(EdgeInsets {
+            top: px(10.0),
+            right: px(0.0),
+            bottom: px(0.0),
+            left: px(0.0),
+        });
+        let mut parent = vertical_constraints(0.0, 200.0, 200.0, 300.0);
+        parent.overlap = 30.0;
+
+        let cc = p.child_constraints(&parent);
+
+        assert_eq!(
+            cc.overlap, 20.0,
+            "positive overlap is reduced by beforePaddingPaintExtent, not reset",
+        );
     }
 
     // ────────────────────────────────────────────────────────────────────────
@@ -666,6 +698,27 @@ mod tests {
         // paint_offset.y = before_pad_paint (10).
         assert_eq!(paint_offset.dx, px(0.0));
         assert_eq!(paint_offset.dy, px(10.0));
+    }
+
+    #[test]
+    fn padded_geometry_hit_test_extent_pairs_main_padding_with_paint_extent() {
+        let p = RenderSliverPadding::new(EdgeInsets {
+            top: px(10.0),
+            right: px(0.0),
+            bottom: px(20.0),
+            left: px(0.0),
+        });
+        let parent = vertical_constraints(0.0, 200.0, 200.0, 300.0);
+        let mut child = child_geom(100.0, 40.0, 40.0, 40.0);
+        child.hit_test_extent = 100.0;
+
+        let (geom, _paint_offset) = p.padded_geometry(&parent, &child);
+
+        assert_eq!(
+            geom.hit_test_extent, 110.0,
+            "Flutter formula: max(main_pad_paint + child.paint_extent, \
+             before_pad_paint + child.hit_test_extent)",
+        );
     }
 
     #[test]

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -2953,29 +2953,16 @@ impl PipelineOwner<PaintPhase> {
             return Ok(());
         };
 
-        // Type safety: reject non-Box protocols symmetrically with layout/intrinsics walks
-        let render_entry = match render_node.as_box() {
-            Some(entry) => entry,
-            None => {
-                return Err(crate::error::RenderError::ProtocolMismatch {
-                    node_protocol: render_node.protocol_name(),
-                    constraints_protocol: "Box",
-                });
-            }
-        };
-        let render_object = render_entry.render_object();
-        let is_repaint_boundary = render_object.is_repaint_boundary();
-        let alpha = render_object.paint_alpha();
-        let transform = render_object.paint_transform();
+        let is_repaint_boundary = render_node.is_repaint_boundary();
+        let alpha = render_node.paint_alpha();
+        let transform = render_node.paint_transform();
         let child_ids: Vec<RenderId> = render_node.children().to_vec();
 
         // Written unconditionally PRE-paint (Flutter object.dart:3560):
         // a node flipping boundary→non-boundary leaves exactly one
         // `WAS_REPAINT_BOUNDARY=true` trail for the next compositing
         // walk's lost-boundary branch.
-        if let Some(entry) = render_node.as_box() {
-            entry.state().set_was_repaint_boundary(is_repaint_boundary);
-        }
+        render_node.set_was_repaint_boundary(is_repaint_boundary);
 
         // Clear BEFORE paint so the post-paint check catches a paint
         // body that marks its own node dirty (paint-must-not-redirty).
@@ -2990,10 +2977,10 @@ impl PipelineOwner<PaintPhase> {
 
         // Record the node's fragment. paint_raw sees ONLY the recorder
         // (sans-IO): no tree access, no layer access, no recursion.
-        let debug_name = render_object.debug_name();
+        let debug_name = render_node.debug_name();
         let mut recorder = FragmentRecorder::new(origin, self.device_pixel_ratio);
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            render_object.paint_raw(&mut recorder, child_ids.len());
+            render_node.paint_raw(&mut recorder, child_ids.len());
         }))
         .map_err(|_| crate::error::RenderError::poisoned(debug_name, "paint"))?;
         let fragment = recorder.finish();
@@ -3071,8 +3058,7 @@ impl PipelineOwner<PaintPhase> {
                     let child_is_boundary = self
                         .render_tree
                         .get(child_id)
-                        .and_then(|n| n.as_box())
-                        .is_some_and(|entry| entry.render_object().is_repaint_boundary());
+                        .is_some_and(RenderNode::is_repaint_boundary);
 
                     if child_is_boundary {
                         // Boundary children rebase to ZERO under their

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -25,7 +25,7 @@ use crate::{
     constraints::{BoxConstraints, SliverConstraints, SliverGeometry},
     context::{FragmentClip, FragmentOp, FragmentRecorder},
     protocol::{
-        BoxProtocol, Protocol, SliverProtocol,
+        BoxProtocol, MainAxisPosition, Protocol, SliverProtocol,
         box_protocol::{BoxLayoutCtxErased, LayoutChildCallback, SliverLayoutChildCallback},
         sliver_protocol::{SliverChildLayoutCallback, SliverLayoutCtxErased},
     },
@@ -672,7 +672,10 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
             return false;
         };
         let Some(entry) = node.as_box() else {
-            // Sliver hit testing lands with the sliver walk (Core.2).
+            if node.as_sliver().is_some() {
+                let sliver_position = Self::sliver_hit_position_from_offset(node, position);
+                return self.hit_test_sliver_subtree(id, sliver_position, result);
+            }
             return false;
         };
         let children: Vec<RenderId> = node.children().to_vec();
@@ -698,6 +701,73 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
         if hit {
             // Leaf-first path: children pushed their entries during
             // the callback above; the ancestor follows.
+            result.add(crate::hit_testing::HitTestEntry::new(id));
+        }
+        hit
+    }
+
+    fn sliver_hit_position_from_offset(node: &RenderNode, position: Offset) -> MainAxisPosition {
+        let axis_direction = node
+            .as_sliver()
+            .and_then(|entry| entry.state().constraints())
+            .map(|constraints| constraints.axis_direction);
+
+        match axis_direction {
+            Some(
+                flui_types::layout::AxisDirection::LeftToRight
+                | flui_types::layout::AxisDirection::RightToLeft,
+            ) => MainAxisPosition::from_horizontal_offset(position),
+            _ => MainAxisPosition::from_vertical_offset(position),
+        }
+    }
+
+    fn hit_test_sliver_subtree(
+        &self,
+        id: RenderId,
+        position: MainAxisPosition,
+        result: &mut crate::hit_testing::HitTestResult,
+    ) -> bool
+    where
+        Phase: Sync,
+    {
+        ensure_stack(|| self.hit_test_sliver_subtree_impl(id, position, result))
+    }
+
+    fn hit_test_sliver_subtree_impl(
+        &self,
+        id: RenderId,
+        position: MainAxisPosition,
+        result: &mut crate::hit_testing::HitTestResult,
+    ) -> bool
+    where
+        Phase: Sync,
+    {
+        let Some(node) = self.render_tree.get(id) else {
+            return false;
+        };
+        let Some(entry) = node.as_sliver() else {
+            return false;
+        };
+        let children: Vec<RenderId> = node.children().to_vec();
+        let render_object = entry.render_object();
+
+        let mut hit_child = |index: usize, override_pos: Option<MainAxisPosition>| -> bool {
+            let Some(&child_id) = children.get(index) else {
+                return false;
+            };
+            let child_position = override_pos.unwrap_or(position);
+            let Some(child_node) = self.render_tree.get(child_id) else {
+                return false;
+            };
+            if child_node.as_sliver().is_some() {
+                self.hit_test_sliver_subtree(child_id, child_position, result)
+            } else {
+                false
+            }
+        };
+
+        let hit = render_object.hit_test_raw(position, children.len(), &mut hit_child);
+        if hit {
             result.add(crate::hit_testing::HitTestEntry::new(id));
         }
         hit

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -689,8 +689,7 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
                 let offset = self
                     .render_tree
                     .get(child_id)
-                    .and_then(|n| n.as_box())
-                    .map(|e| e.state().offset())
+                    .map(RenderNode::offset)
                     .unwrap_or(Offset::ZERO);
                 position - offset
             });
@@ -718,6 +717,31 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
                 | flui_types::layout::AxisDirection::RightToLeft,
             ) => MainAxisPosition::from_horizontal_offset(position),
             _ => MainAxisPosition::from_vertical_offset(position),
+        }
+    }
+
+    fn sliver_hit_position_minus_offset(
+        node: &RenderNode,
+        position: MainAxisPosition,
+        offset: Offset,
+    ) -> MainAxisPosition {
+        let axis_direction = node
+            .as_sliver()
+            .and_then(|entry| entry.state().constraints())
+            .map(|constraints| constraints.axis_direction);
+
+        match axis_direction {
+            Some(
+                flui_types::layout::AxisDirection::LeftToRight
+                | flui_types::layout::AxisDirection::RightToLeft,
+            ) => MainAxisPosition::new(
+                position.main_axis - offset.dx.get(),
+                position.cross_axis - offset.dy.get(),
+            ),
+            _ => MainAxisPosition::new(
+                position.main_axis - offset.dy.get(),
+                position.cross_axis - offset.dx.get(),
+            ),
         }
     }
 
@@ -755,11 +779,17 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
             let Some(&child_id) = children.get(index) else {
                 return false;
             };
-            let child_position = override_pos.unwrap_or(position);
             let Some(child_node) = self.render_tree.get(child_id) else {
                 return false;
             };
             if child_node.as_sliver().is_some() {
+                let child_position = override_pos.unwrap_or_else(|| {
+                    Self::sliver_hit_position_minus_offset(
+                        child_node,
+                        position,
+                        child_node.offset(),
+                    )
+                });
                 self.hit_test_sliver_subtree(child_id, child_position, result)
             } else {
                 false
@@ -2410,9 +2440,7 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
             // `entry`/`node_ref` cover only the parent's slot.
             // `set_offset` is an atomic store through `&self`.
             let child_node: &RenderNode = unsafe { &*child_ptr.0 };
-            if let Some(child_entry) = child_node.as_box() {
-                child_entry.state().set_offset(cs.offset);
-            }
+            child_node.set_offset(cs.offset);
         }
     }
 
@@ -2600,6 +2628,22 @@ unsafe fn layout_sliver_subtree_borrowed_impl<'tree>(
 
     entry.state_mut().set_geometry(geometry);
     entry.state_mut().set_constraints(constraints);
+
+    // Commit child paint offsets produced by sliver parents
+    // (`RenderSliverPadding` et al.) into the same parent-relative
+    // offset slot that paint / hit-test already consult. The
+    // `ErasedSliverChildState` vec is per-walk transient; without
+    // this commit, child placement dies with the layout stack frame.
+    for cs in &child_states {
+        if let Some(child_ptr) = borrows.get(cs.id) {
+            // SAFETY: shared reborrow of a DISTINCT child slot
+            // (parent != child by tree acyclicity). All recursive
+            // child borrows ended when perform_layout_raw returned;
+            // `entry` / `node_ref` cover only the parent's slot.
+            let child_node: &crate::storage::RenderNode = unsafe { &*child_ptr.0 };
+            child_node.set_offset(cs.offset);
+        }
+    }
 
     let has_parent = entry.links().parent().is_some();
     <SliverProtocol as Protocol>::bootstrap_relayout_boundary(entry.state(), has_parent);
@@ -3051,8 +3095,7 @@ impl PipelineOwner<PaintPhase> {
                     let child_offset = offset_override.unwrap_or_else(|| {
                         self.render_tree
                             .get(child_id)
-                            .and_then(|n| n.as_box())
-                            .map(|e| e.state().offset())
+                            .map(RenderNode::offset)
                             .unwrap_or(Offset::ZERO)
                     });
                     let child_is_boundary = self

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -25,8 +25,9 @@ use crate::{
     constraints::{BoxConstraints, SliverConstraints, SliverGeometry},
     context::{FragmentClip, FragmentOp, FragmentRecorder},
     protocol::{
-        BoxProtocol, Protocol,
+        BoxProtocol, Protocol, SliverProtocol,
         box_protocol::{BoxLayoutCtxErased, LayoutChildCallback, SliverLayoutChildCallback},
+        sliver_protocol::{SliverChildLayoutCallback, SliverLayoutCtxErased},
     },
     storage::{RenderEntry, RenderNode, RenderTree},
 };
@@ -2367,7 +2368,7 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
 }
 
 // ============================================================================
-// Cross-protocol child layout: Box parent → leaf Sliver child
+// Cross-protocol child layout: Box parent → Sliver child
 // ============================================================================
 //
 // `layout_sliver_subtree_borrowed` is the Sliver sibling of
@@ -2375,14 +2376,13 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
 // closure captured inside `layout_subtree_borrowed_impl`'s non-leaf path
 // when a Box parent calls `ctx.layout_sliver_child(index, constraints)`.
 //
-// Scope: LEAF sliver children only. Non-leaf sliver children are gated by
-// the arity check inside `RenderEntry::layout_leaf_only` (the Sliver
-// blanket returns `RenderError::ContractViolation` for non-leaf nodes).
+// Scope: sliver subtrees. Leaf nodes still delegate to
+// `RenderEntry::layout_leaf_only`; non-leaf slivers get an erased driver
+// context and may call `ctx.layout_child(...)` to lay out sliver children.
 //
 // The short-circuit clean-child optimisation from the Box path is omitted
-// here on purpose: leaf slivers always relayout because their constraints
-// change with scroll position on every frame. Omitting the check is
-// correct and saves a branch.
+// here on purpose: sliver constraints change with scroll position on every
+// frame. Omitting the check is correct and saves a branch.
 
 /// Stack-probe wrapper for [`layout_sliver_subtree_borrowed_impl`].
 ///
@@ -2445,7 +2445,7 @@ unsafe fn layout_sliver_subtree_borrowed_impl<'tree>(
     let node_ref: &mut crate::storage::RenderNode = unsafe { &mut *node_ptr };
 
     let node_protocol = node_ref.protocol_name();
-    let entry: &mut RenderEntry<crate::protocol::SliverProtocol> = match node_ref.as_sliver_mut() {
+    let entry: &mut RenderEntry<SliverProtocol> = match node_ref.as_sliver_mut() {
         Some(e) => e,
         None => {
             return Err(crate::error::RenderError::ProtocolMismatch {
@@ -2454,12 +2454,97 @@ unsafe fn layout_sliver_subtree_borrowed_impl<'tree>(
             });
         }
     };
+    let child_ids: Vec<RenderId> = entry.links().children().to_vec();
 
-    // Delegate to the generic leaf-only layout path.
-    // Non-leaf sliver nodes trigger `RenderError::ContractViolation`
-    // inside `layout_leaf_only` via the arity gate — the non-leaf
-    // sliver walk is out of scope for this change.
-    entry.layout_leaf_only(constraints)
+    if child_ids.is_empty() {
+        return entry.layout_leaf_only(constraints);
+    }
+
+    let mut child_states: Vec<crate::protocol::ErasedSliverChildState> = child_ids
+        .iter()
+        .map(|&cid| crate::protocol::ErasedSliverChildState::new(cid))
+        .collect();
+
+    let descendant_error_flag: std::sync::Arc<std::sync::atomic::AtomicBool> =
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let descendant_error_for_cb = std::sync::Arc::clone(&descendant_error_flag);
+    let borrows_for_cb: &SubtreeBorrows<'_> = borrows;
+
+    let cb_owned = move |child_id: RenderId,
+                         child_constraints: SliverConstraints|
+          -> SliverGeometry {
+        // SAFETY: `borrows_for_cb` is alive for the whole dirty-root
+        // walk, and this callback reborrows a child slot distinct from
+        // the current sliver node. `LayoutCycleGuard` rejects re-entry.
+        match unsafe { layout_sliver_subtree_borrowed(borrows_for_cb, child_id, child_constraints) }
+        {
+            Ok(geometry) => geometry,
+            Err(err) => {
+                descendant_error_for_cb.store(true, std::sync::atomic::Ordering::Relaxed);
+                tracing::error!(
+                    parent = ?id,
+                    ?child_id,
+                    ?err,
+                    "layout_dirty_root: sliver descendant layout failed; \
+                     returning SliverGeometry::ZERO to caller's perform_layout. \
+                     Parent NEEDS_LAYOUT preserved for next-frame retry.",
+                );
+                SliverGeometry::ZERO
+            }
+        }
+    };
+    let cb_ref: SliverChildLayoutCallback<'_> = &cb_owned;
+
+    let mut ctx = crate::protocol::ErasedSliverLayoutCtx::new(
+        constraints,
+        &mut child_states,
+        &child_ids,
+        cb_ref,
+    );
+    let erased: &mut dyn SliverLayoutCtxErased = &mut ctx;
+
+    let debug_name = entry.render_object().debug_name();
+    let render_object = entry.render_object_mut();
+    let unwind_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        render_object.perform_layout_raw(erased)
+    }));
+    let geometry = match unwind_result {
+        Ok(inner) => inner?,
+        Err(payload) => {
+            let msg = payload
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| payload.downcast_ref::<&'static str>().copied())
+                .unwrap_or("(non-string panic payload)");
+            tracing::error!(
+                render_object = debug_name,
+                panic_msg = msg,
+                "perform_layout panicked in non-leaf sliver path — surfacing as \
+                 RenderError::Poisoned",
+            );
+            return Err(crate::error::RenderError::poisoned(debug_name, "layout"));
+        }
+    };
+
+    <SliverProtocol as Protocol>::debug_assert_layout_output(&constraints, &geometry);
+
+    entry.state_mut().set_geometry(geometry);
+    entry.state_mut().set_constraints(constraints);
+
+    let has_parent = entry.links().parent().is_some();
+    <SliverProtocol as Protocol>::bootstrap_relayout_boundary(entry.state(), has_parent);
+
+    if !descendant_error_flag.load(std::sync::atomic::Ordering::Relaxed) {
+        entry.clear_needs_layout();
+    } else {
+        tracing::debug!(
+            parent = ?id,
+            "layout_dirty_root: a sliver descendant errored during this walk; \
+             keeping parent NEEDS_LAYOUT set for next-frame retry"
+        );
+    }
+
+    Ok(geometry)
 }
 
 // ============================================================================

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -772,6 +772,19 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
         let Some(entry) = node.as_sliver() else {
             return false;
         };
+        let Some(geometry) = entry.state().geometry() else {
+            return false;
+        };
+        let Some(constraints) = entry.state().constraints() else {
+            return false;
+        };
+        if position.main_axis < 0.0
+            || position.main_axis >= geometry.hit_test_extent
+            || position.cross_axis < 0.0
+            || position.cross_axis >= constraints.cross_axis_extent
+        {
+            return false;
+        }
         let children: Vec<RenderId> = node.children().to_vec();
         let render_object = entry.render_object();
 
@@ -2272,7 +2285,9 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
     // (Flutter parity: BoxParentData.offset persists until
     // positionChild overwrites it) — without the seed, the
     // post-layout commit below would silently reset unpositioned
-    // children to Offset::ZERO.
+    // children to Offset::ZERO. Box parents can now host both Box and
+    // Sliver children, so seed through RenderNode's protocol-generic
+    // offset view.
     for cs in &mut child_states {
         if let Some(child_ptr) = borrows.get(cs.id) {
             // SAFETY: shared reborrow of a DISTINCT child slot
@@ -2282,9 +2297,7 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
             // Distinct slot reborrows have independent tags under
             // Stacked / Tree Borrows.
             let child_node: &RenderNode = unsafe { &*child_ptr.0 };
-            if let Some(child_entry) = child_node.as_box() {
-                cs.offset = child_entry.state().offset();
-            }
+            cs.offset = child_node.offset();
         }
     }
 
@@ -2562,6 +2575,20 @@ unsafe fn layout_sliver_subtree_borrowed_impl<'tree>(
         .iter()
         .map(|&cid| crate::protocol::ErasedSliverChildState::new(cid))
         .collect();
+
+    // Seed child offsets from persisted RenderState so a sliver parent that
+    // does not call `position_child` on a later pass preserves its child's
+    // previous placement, matching the Box path's offset semantics.
+    for cs in &mut child_states {
+        if let Some(child_ptr) = borrows.get(cs.id) {
+            // SAFETY: shared reborrow of a DISTINCT child slot
+            // (parent != child by tree acyclicity). No recursive child
+            // borrow has run yet in this frame, and `node_ref` covers only
+            // the current sliver parent slot.
+            let child_node: &crate::storage::RenderNode = unsafe { &*child_ptr.0 };
+            cs.offset = child_node.offset();
+        }
+    }
 
     let descendant_error_flag: std::sync::Arc<std::sync::atomic::AtomicBool> =
         std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -3089,19 +3116,21 @@ impl PipelineOwner<PaintPhase> {
                         );
                         continue;
                     };
+                    let Some(child_node) = self.render_tree.get(child_id) else {
+                        continue;
+                    };
+                    if child_node
+                        .as_sliver()
+                        .and_then(|entry| entry.state().geometry())
+                        .is_some_and(|geometry| !geometry.visible)
+                    {
+                        continue;
+                    }
                     // Authoritative child position: RenderState.offset,
                     // committed by the layout walk; paint_child_at
                     // overrides it explicitly.
-                    let child_offset = offset_override.unwrap_or_else(|| {
-                        self.render_tree
-                            .get(child_id)
-                            .map(RenderNode::offset)
-                            .unwrap_or(Offset::ZERO)
-                    });
-                    let child_is_boundary = self
-                        .render_tree
-                        .get(child_id)
-                        .is_some_and(RenderNode::is_repaint_boundary);
+                    let child_offset = offset_override.unwrap_or_else(|| child_node.offset());
+                    let child_is_boundary = child_node.is_repaint_boundary();
 
                     if child_is_boundary {
                         // Boundary children rebase to ZERO under their

--- a/crates/flui-rendering/src/protocol/box_protocol.rs
+++ b/crates/flui-rendering/src/protocol/box_protocol.rs
@@ -723,9 +723,8 @@ pub trait BoxLayoutCtxErased: Send + Sync {
     /// Lays out a **sliver** child at `index` with the given
     /// [`SliverConstraints`]; returns the child's [`SliverGeometry`].
     ///
-    /// Only the **leaf** sliver path is supported here (non-leaf sliver
-    /// children gate to [`crate::error::RenderError::ContractViolation`]
-    /// inside `RenderEntry::layout_leaf_only` when the arity check fires).
+    /// The pipeline callback drives the sliver subtree walk, so both leaf
+    /// and child-bearing slivers can be laid out through this method.
     ///
     /// When no sliver callback is wired (e.g. a Direct-storage context
     /// constructed without one), returns [`SliverGeometry::ZERO`] — same

--- a/crates/flui-rendering/src/protocol/mod.rs
+++ b/crates/flui-rendering/src/protocol/mod.rs
@@ -137,15 +137,18 @@ pub use protocol::{
 // SLIVER PROTOCOL EXPORTS
 // ============================================================================
 pub use sliver_protocol::{
+    // Layout
+    ErasedSliverChildState,
+    ErasedSliverLayoutCtx,
     // Hit test
     MainAxisPosition,
+    SliverChildState,
     // Cache key
     SliverConstraintsCacheKey,
     SliverHitTest,
     SliverHitTestCtx,
     SliverHitTestEntry,
     SliverHitTestResult,
-    // Layout
     SliverLayout,
     SliverLayoutCtx,
     // Protocol

--- a/crates/flui-rendering/src/protocol/sliver_protocol.rs
+++ b/crates/flui-rendering/src/protocol/sliver_protocol.rs
@@ -6,6 +6,7 @@
 //! - [`SliverHitTest`]: Hit test capability (MainAxisPosition →
 //!   SliverHitTestResult)
 
+use flui_foundation::RenderId;
 use flui_tree::Arity;
 use flui_types::geometry::{Matrix4, Offset, Rect};
 
@@ -147,6 +148,42 @@ impl SliverConstraintsCacheKey {
     }
 }
 
+// ============================================================================
+// CHILD STATE
+// ============================================================================
+
+/// Per-child layout-time state held by [`SliverLayoutCtx`].
+#[derive(Debug)]
+pub struct SliverChildState<P: ParentData + Default> {
+    /// Render ID of this child.
+    pub id: RenderId,
+    /// Computed sliver geometry after layout.
+    pub geometry: SliverGeometry,
+    /// Position offset set by parent.
+    pub offset: Offset,
+    /// Parent data for this child.
+    pub parent_data: P,
+}
+
+impl<P: ParentData + Default> SliverChildState<P> {
+    /// Creates a new child state with default values.
+    pub fn new(id: RenderId) -> Self {
+        Self {
+            id,
+            geometry: SliverGeometry::ZERO,
+            offset: Offset::ZERO,
+            parent_data: P::default(),
+        }
+    }
+}
+
+/// Callback type for synchronous sliver child layout.
+pub type SliverChildLayoutCallback<'a> =
+    &'a (dyn Fn(RenderId, SliverConstraints) -> SliverGeometry + Send + Sync);
+
+/// Dense per-child geometry cache used by Proxy storage.
+type ProxySliverChildGeometryCache = Vec<Option<SliverGeometry>>;
+
 impl LayoutCapability for SliverLayout {
     type Constraints = SliverConstraints;
     type Geometry = SliverGeometry;
@@ -187,17 +224,21 @@ impl LayoutCapability for SliverLayout {
 ///    boundary and call `RenderSliver::perform_layout`. Completion writes
 ///    through to the underlying context so both the local cache and the
 ///    pipeline-side Direct ctx stay consistent.
-pub struct SliverLayoutCtx<'ctx, A: Arity, P: ParentData> {
-    storage: SliverLayoutCtxStorage<'ctx>,
+pub struct SliverLayoutCtx<'ctx, A: Arity, P: ParentData + Default> {
+    storage: SliverLayoutCtxStorage<'ctx, P>,
     _phantom: std::marker::PhantomData<(A, P)>,
 }
 
 /// Internal storage variants for [`SliverLayoutCtx`].
-enum SliverLayoutCtxStorage<'ctx> {
-    /// Production / pipeline path: owns constraints and geometry slot.
+enum SliverLayoutCtxStorage<'ctx, P: ParentData + Default> {
+    /// Production / pipeline path: owns constraints, geometry slot, and
+    /// optional child layout access.
     Direct {
         constraints: SliverConstraints,
         geometry: Option<SliverGeometry>,
+        children: Option<&'ctx mut Vec<SliverChildState<P>>>,
+        child_ids: Option<&'ctx [RenderId]>,
+        layout_child_callback: Option<SliverChildLayoutCallback<'ctx>>,
     },
     /// Bridge path: wraps the erased context from the pipeline boundary.
     ///
@@ -211,17 +252,57 @@ enum SliverLayoutCtxStorage<'ctx> {
     Proxy {
         constraints: SliverConstraints,
         geometry: Option<SliverGeometry>,
+        child_geometries: ProxySliverChildGeometryCache,
         erased: &'ctx mut dyn SliverLayoutCtxErased,
     },
 }
 
-impl<'ctx, A: Arity, P: ParentData> SliverLayoutCtx<'ctx, A, P> {
+impl<'ctx, A: Arity, P: ParentData + Default> SliverLayoutCtx<'ctx, A, P> {
     /// Creates a new sliver layout context with given constraints. Direct storage.
     pub fn new(constraints: SliverConstraints) -> Self {
         Self {
             storage: SliverLayoutCtxStorage::Direct {
                 constraints,
                 geometry: None,
+                children: None,
+                child_ids: None,
+                layout_child_callback: None,
+            },
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Creates a new sliver layout context with children access.
+    pub fn with_children(
+        constraints: SliverConstraints,
+        children: &'ctx mut Vec<SliverChildState<P>>,
+    ) -> Self {
+        Self {
+            storage: SliverLayoutCtxStorage::Direct {
+                constraints,
+                geometry: None,
+                children: Some(children),
+                child_ids: None,
+                layout_child_callback: None,
+            },
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Creates a new sliver layout context with synchronous child layout.
+    pub fn with_layout_callback(
+        constraints: SliverConstraints,
+        children: &'ctx mut Vec<SliverChildState<P>>,
+        child_ids: &'ctx [RenderId],
+        layout_child_callback: SliverChildLayoutCallback<'ctx>,
+    ) -> Self {
+        Self {
+            storage: SliverLayoutCtxStorage::Direct {
+                constraints,
+                geometry: None,
+                children: Some(children),
+                child_ids: Some(child_ids),
+                layout_child_callback: Some(layout_child_callback),
             },
             _phantom: std::marker::PhantomData,
         }
@@ -254,10 +335,24 @@ impl<'ctx, A: Arity, P: ParentData> SliverLayoutCtx<'ctx, A, P> {
     // PORT-CHECK-OK-DYN: protocol-layout-erasure (Core.2 W3.1 sliver leaf bridge)
     pub(crate) fn from_erased(erased: &'ctx mut dyn SliverLayoutCtxErased) -> Self {
         let constraints = erased.constraints();
+        debug_assert!(
+            match erased.parent_data_type_id() {
+                Some(id) => id == std::any::TypeId::of::<P>(),
+                None => true,
+            },
+            "SliverLayoutCtx::from_erased: ParentData type mismatch — \
+             underlying erased ctx reports TypeId={:?}, typed wrapper \
+             requested {:?} ({})",
+            erased.parent_data_type_id(),
+            std::any::TypeId::of::<P>(),
+            std::any::type_name::<P>(),
+        );
+        let child_count = erased.child_count();
         Self {
             storage: SliverLayoutCtxStorage::Proxy {
                 constraints,
                 geometry: None,
+                child_geometries: vec![None; child_count],
                 erased,
             },
             _phantom: std::marker::PhantomData,
@@ -313,7 +408,7 @@ impl<'ctx, A: Arity, P: ParentData> SliverLayoutCtx<'ctx, A, P> {
     }
 }
 
-impl<'ctx, A: Arity, P: ParentData> LayoutContextApi<'ctx, SliverLayout, A, P>
+impl<'ctx, A: Arity, P: ParentData + Default> LayoutContextApi<'ctx, SliverLayout, A, P>
     for SliverLayoutCtx<'ctx, A, P>
 {
     fn constraints(&self) -> &SliverConstraints {
@@ -349,27 +444,107 @@ impl<'ctx, A: Arity, P: ParentData> LayoutContextApi<'ctx, SliverLayout, A, P>
     }
 
     fn child_count(&self) -> usize {
-        0 // Leaf scope — child layout is Core.2 follow-on work
+        match &self.storage {
+            SliverLayoutCtxStorage::Direct { children, .. } => {
+                children.as_ref().map(|c| c.len()).unwrap_or(0)
+            }
+            SliverLayoutCtxStorage::Proxy { erased, .. } => erased.child_count(),
+        }
     }
 
-    fn layout_child(&mut self, _index: usize, _constraints: SliverConstraints) -> SliverGeometry {
-        SliverGeometry::ZERO // Leaf scope — child layout is Core.2 follow-on work
+    fn layout_child(&mut self, index: usize, constraints: SliverConstraints) -> SliverGeometry {
+        match &mut self.storage {
+            SliverLayoutCtxStorage::Direct {
+                children,
+                child_ids,
+                layout_child_callback,
+                ..
+            } => {
+                if let (Some(child_ids), Some(callback)) =
+                    (*child_ids, layout_child_callback.as_ref())
+                    && let Some(&child_id) = child_ids.get(index)
+                {
+                    let geometry = callback(child_id, constraints);
+                    if let Some(children) = children.as_mut()
+                        && let Some(child) = children.get_mut(index)
+                    {
+                        child.geometry = geometry;
+                    }
+                    return geometry;
+                }
+
+                if let Some(children) = children.as_ref()
+                    && let Some(child) = children.get(index)
+                {
+                    return child.geometry;
+                }
+                SliverGeometry::ZERO
+            }
+            SliverLayoutCtxStorage::Proxy {
+                erased,
+                child_geometries,
+                ..
+            } => {
+                let geometry = erased.layout_child(index, constraints);
+                if let Some(slot) = child_geometries.get_mut(index) {
+                    *slot = Some(geometry);
+                }
+                geometry
+            }
+        }
     }
 
-    fn position_child(&mut self, _index: usize, _offset: Offset) {
-        // Leaf scope — child positioning is Core.2 follow-on work
+    fn position_child(&mut self, index: usize, offset: Offset) {
+        match &mut self.storage {
+            SliverLayoutCtxStorage::Direct { children, .. } => {
+                if let Some(children) = children.as_mut()
+                    && let Some(child) = children.get_mut(index)
+                {
+                    child.offset = offset;
+                }
+            }
+            SliverLayoutCtxStorage::Proxy { erased, .. } => {
+                erased.position_child(index, offset);
+            }
+        }
     }
 
-    fn child_geometry(&self, _index: usize) -> Option<&SliverGeometry> {
-        None // Leaf scope — child layout is Core.2 follow-on work
+    fn child_geometry(&self, index: usize) -> Option<&SliverGeometry> {
+        match &self.storage {
+            SliverLayoutCtxStorage::Direct { children, .. } => children
+                .as_ref()
+                .and_then(|c| c.get(index))
+                .map(|child| &child.geometry),
+            SliverLayoutCtxStorage::Proxy {
+                child_geometries, ..
+            } => child_geometries.get(index).and_then(Option::as_ref),
+        }
     }
 
-    fn child_parent_data(&self, _index: usize) -> Option<&P> {
-        None // Leaf scope — child parent-data is Core.2 follow-on work
+    fn child_parent_data(&self, index: usize) -> Option<&P> {
+        match &self.storage {
+            SliverLayoutCtxStorage::Direct { children, .. } => children
+                .as_ref()
+                .and_then(|c| c.get(index))
+                .map(|child| &child.parent_data),
+            SliverLayoutCtxStorage::Proxy { erased, .. } => erased
+                .child_parent_data_dyn(index)
+                .and_then(|d| d.downcast_ref::<P>()),
+        }
     }
 
-    fn child_parent_data_mut(&mut self, _index: usize) -> Option<&mut P> {
-        None // Leaf scope — child parent-data is Core.2 follow-on work
+    fn child_parent_data_mut(&mut self, index: usize) -> Option<&mut P> {
+        match &mut self.storage {
+            SliverLayoutCtxStorage::Direct { children, .. } => children
+                .as_mut()
+                .and_then(|c| c.get_mut(index))
+                .map(|child| &mut child.parent_data),
+            SliverLayoutCtxStorage::Proxy { erased, .. } => erased
+                .child_parent_data_dyn_or_insert(index, &|| {
+                    Box::new(P::default()) as Box<dyn ParentData>
+                })
+                .and_then(|d| d.downcast_mut::<P>()),
+        }
     }
 }
 
@@ -383,13 +558,23 @@ impl<'ctx, A: Arity, P: ParentData> LayoutContextApi<'ctx, SliverLayout, A, P>
 /// at the `RenderObject<SliverProtocol>::perform_layout_raw` trait
 /// boundary.
 ///
-/// The trait surface is intentionally minimal for the leaf scope (Core.2
-/// W3.1): the leaf bridge only needs constraints readback and completion.
-/// Child-layout / parent-data operations are added in the follow-on Core.2
-/// child-walk wave.
+/// The trait surface mirrors the Box erased layout bridge: the pipeline
+/// owns parent-data-erased child slots, while the blanket impl rebuilds a
+/// typed `SliverLayoutCtx<T::Arity, T::ParentData>` and delegates child
+/// layout / parent-data access through this trait.
 pub trait SliverLayoutCtxErased: Send + Sync {
     /// Sliver constraints from parent.
     fn constraints(&self) -> SliverConstraints;
+
+    /// Number of children visible to this context.
+    fn child_count(&self) -> usize;
+
+    /// Performs synchronous layout on child at `index` with the given
+    /// constraints; returns the child's computed [`SliverGeometry`].
+    fn layout_child(&mut self, index: usize, constraints: SliverConstraints) -> SliverGeometry;
+
+    /// Records the paint offset for child at `index`.
+    fn position_child(&mut self, index: usize, offset: Offset);
 
     /// Records the layout result (parent's own geometry) on the context.
     ///
@@ -398,9 +583,30 @@ pub trait SliverLayoutCtxErased: Send + Sync {
     /// `Option<&SliverGeometry>`. The erased trait intentionally exposes
     /// only the write.
     fn complete_layout(&mut self, geometry: SliverGeometry);
+
+    /// Reads child `index`'s parent data as `&dyn ParentData`.
+    fn child_parent_data_dyn(&self, index: usize) -> Option<&dyn ParentData>;
+
+    /// Mutable counterpart to [`Self::child_parent_data_dyn`].
+    fn child_parent_data_dyn_mut(&mut self, index: usize) -> Option<&mut dyn ParentData>;
+
+    /// Mutable access to child `index`'s parent data, creating it when
+    /// the erased storage has no slot yet.
+    fn child_parent_data_dyn_or_insert(
+        &mut self,
+        index: usize,
+        _create: &dyn Fn() -> Box<dyn ParentData>,
+    ) -> Option<&mut dyn ParentData> {
+        self.child_parent_data_dyn_mut(index)
+    }
+
+    /// `TypeId` of the underlying parent-data type when known.
+    fn parent_data_type_id(&self) -> Option<std::any::TypeId> {
+        None
+    }
 }
 
-impl<A: Arity, P: ParentData> SliverLayoutCtxErased for SliverLayoutCtx<'_, A, P> {
+impl<A: Arity, P: ParentData + Default> SliverLayoutCtxErased for SliverLayoutCtx<'_, A, P> {
     #[inline]
     fn constraints(&self) -> SliverConstraints {
         // Both Direct and Proxy cache constraints as an owned `Copy` value.
@@ -409,10 +615,180 @@ impl<A: Arity, P: ParentData> SliverLayoutCtxErased for SliverLayoutCtx<'_, A, P
     }
 
     #[inline]
+    fn child_count(&self) -> usize {
+        <Self as LayoutContextApi<'_, SliverLayout, A, P>>::child_count(self)
+    }
+
+    #[inline]
+    fn layout_child(&mut self, index: usize, constraints: SliverConstraints) -> SliverGeometry {
+        <Self as LayoutContextApi<'_, SliverLayout, A, P>>::layout_child(self, index, constraints)
+    }
+
+    #[inline]
+    fn position_child(&mut self, index: usize, offset: Offset) {
+        <Self as LayoutContextApi<'_, SliverLayout, A, P>>::position_child(self, index, offset)
+    }
+
+    #[inline]
     fn complete_layout(&mut self, geometry: SliverGeometry) {
         // Delegates through `LayoutContextApi::complete_layout` so the
         // Proxy write-through path is exercised consistently.
         <Self as LayoutContextApi<'_, SliverLayout, A, P>>::complete_layout(self, geometry);
+    }
+
+    #[inline]
+    fn child_parent_data_dyn(&self, index: usize) -> Option<&dyn ParentData> {
+        match &self.storage {
+            SliverLayoutCtxStorage::Direct { children, .. } => children
+                .as_ref()
+                .and_then(|c| c.get(index))
+                .map(|child| &child.parent_data as &dyn ParentData),
+            SliverLayoutCtxStorage::Proxy { erased, .. } => erased.child_parent_data_dyn(index),
+        }
+    }
+
+    #[inline]
+    fn child_parent_data_dyn_mut(&mut self, index: usize) -> Option<&mut dyn ParentData> {
+        match &mut self.storage {
+            SliverLayoutCtxStorage::Direct { children, .. } => children
+                .as_mut()
+                .and_then(|c| c.get_mut(index))
+                .map(|child| &mut child.parent_data as &mut dyn ParentData),
+            SliverLayoutCtxStorage::Proxy { erased, .. } => erased.child_parent_data_dyn_mut(index),
+        }
+    }
+
+    #[inline]
+    fn parent_data_type_id(&self) -> Option<std::any::TypeId> {
+        match &self.storage {
+            SliverLayoutCtxStorage::Direct {
+                children: Some(_), ..
+            } => Some(std::any::TypeId::of::<P>()),
+            SliverLayoutCtxStorage::Direct { children: None, .. }
+            | SliverLayoutCtxStorage::Proxy { .. } => None,
+        }
+    }
+}
+
+// ============================================================================
+// ERASED DRIVER LAYOUT CONTEXT
+// ============================================================================
+
+/// Per-child layout state with parent-data-erased storage for the sliver
+/// production layout walk.
+#[derive(Debug)]
+pub struct ErasedSliverChildState {
+    /// Render ID of this child.
+    pub id: RenderId,
+    /// Computed sliver geometry after layout.
+    pub geometry: SliverGeometry,
+    /// Position offset set by parent.
+    pub offset: Offset,
+    /// Parent data, created on demand by the typed bridge.
+    pub parent_data: Option<Box<dyn ParentData>>,
+}
+
+impl ErasedSliverChildState {
+    /// Creates an empty child slot.
+    pub fn new(id: RenderId) -> Self {
+        Self {
+            id,
+            geometry: SliverGeometry::ZERO,
+            offset: Offset::ZERO,
+            parent_data: None,
+        }
+    }
+}
+
+/// Driver-native, parent-data-erased implementation of
+/// [`SliverLayoutCtxErased`] used by the sliver subtree walk.
+pub struct ErasedSliverLayoutCtx<'ctx> {
+    constraints: SliverConstraints,
+    geometry: Option<SliverGeometry>,
+    children: &'ctx mut Vec<ErasedSliverChildState>,
+    child_ids: &'ctx [RenderId],
+    layout_child_callback: SliverChildLayoutCallback<'ctx>,
+}
+
+impl<'ctx> ErasedSliverLayoutCtx<'ctx> {
+    /// Creates the walk-side context over pre-built child slots.
+    pub fn new(
+        constraints: SliverConstraints,
+        children: &'ctx mut Vec<ErasedSliverChildState>,
+        child_ids: &'ctx [RenderId],
+        layout_child_callback: SliverChildLayoutCallback<'ctx>,
+    ) -> Self {
+        Self {
+            constraints,
+            geometry: None,
+            children,
+            child_ids,
+            layout_child_callback,
+        }
+    }
+
+    /// The parent's completed geometry, when `complete_layout` ran.
+    pub fn geometry(&self) -> Option<&SliverGeometry> {
+        self.geometry.as_ref()
+    }
+}
+
+impl SliverLayoutCtxErased for ErasedSliverLayoutCtx<'_> {
+    fn constraints(&self) -> SliverConstraints {
+        self.constraints
+    }
+
+    fn child_count(&self) -> usize {
+        self.child_ids.len()
+    }
+
+    fn layout_child(&mut self, index: usize, constraints: SliverConstraints) -> SliverGeometry {
+        let Some(&child_id) = self.child_ids.get(index) else {
+            return SliverGeometry::ZERO;
+        };
+        let geometry = (self.layout_child_callback)(child_id, constraints);
+        if let Some(slot) = self.children.get_mut(index) {
+            slot.geometry = geometry;
+        }
+        geometry
+    }
+
+    fn position_child(&mut self, index: usize, offset: Offset) {
+        if let Some(slot) = self.children.get_mut(index) {
+            slot.offset = offset;
+        }
+    }
+
+    fn complete_layout(&mut self, geometry: SliverGeometry) {
+        self.geometry = Some(geometry);
+    }
+
+    fn child_parent_data_dyn(&self, index: usize) -> Option<&dyn ParentData> {
+        self.children
+            .get(index)
+            .and_then(|slot| slot.parent_data.as_deref())
+    }
+
+    fn child_parent_data_dyn_mut(&mut self, index: usize) -> Option<&mut dyn ParentData> {
+        self.children
+            .get_mut(index)
+            .and_then(|slot| slot.parent_data.as_deref_mut())
+    }
+
+    fn child_parent_data_dyn_or_insert(
+        &mut self,
+        index: usize,
+        create: &dyn Fn() -> Box<dyn ParentData>,
+    ) -> Option<&mut dyn ParentData> {
+        let slot = self.children.get_mut(index)?;
+        Some(slot.parent_data.get_or_insert_with(create).as_mut())
+    }
+
+    fn parent_data_type_id(&self) -> Option<std::any::TypeId> {
+        self.children
+            .iter()
+            .find_map(|slot| slot.parent_data.as_deref())
+            .map(|pd| pd.as_any().type_id())
     }
 }
 

--- a/crates/flui-rendering/src/protocol/sliver_protocol.rs
+++ b/crates/flui-rendering/src/protocol/sliver_protocol.rs
@@ -889,10 +889,15 @@ impl SliverHitTestEntry {
     }
 }
 
+/// Driver-supplied child recursion for the sliver hit-test walk.
+pub type SliverHitTestChildCallback<'a> =
+    &'a mut (dyn FnMut(usize, Option<MainAxisPosition>) -> bool + Send + Sync);
+
 /// Sliver hit test context implementation.
 pub struct SliverHitTestCtx<'ctx, A: Arity, P: ParentData> {
     position: MainAxisPosition,
     result: SliverHitTestResult,
+    child_callback: Option<SliverHitTestChildCallback<'ctx>>,
     _phantom: std::marker::PhantomData<(&'ctx (), A, P)>,
 }
 
@@ -902,6 +907,20 @@ impl<'ctx, A: Arity, P: ParentData> SliverHitTestCtx<'ctx, A, P> {
         Self {
             position,
             result: SliverHitTestResult::new(),
+            child_callback: None,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Creates a context wired to the pipeline driver's child recursion.
+    pub fn with_child_callback(
+        position: MainAxisPosition,
+        callback: SliverHitTestChildCallback<'ctx>,
+    ) -> Self {
+        Self {
+            position,
+            result: SliverHitTestResult::new(),
+            child_callback: Some(callback),
             _phantom: std::marker::PhantomData,
         }
     }
@@ -937,8 +956,18 @@ impl<'ctx, A: Arity, P: ParentData> HitTestContextApi<'ctx, SliverHitTest, A, P>
         self.position.main_axis >= 0.0 && self.position.main_axis <= bounds.height().get()
     }
 
-    fn hit_test_child(&mut self, _index: usize, _position: MainAxisPosition) -> bool {
-        false // Override in actual implementation
+    fn hit_test_child(&mut self, index: usize, position: MainAxisPosition) -> bool {
+        match self.child_callback.as_mut() {
+            Some(callback) => callback(index, Some(position)),
+            None => false,
+        }
+    }
+
+    fn hit_test_child_at_layout_offset(&mut self, index: usize) -> bool {
+        match self.child_callback.as_mut() {
+            Some(callback) => callback(index, None),
+            None => false,
+        }
     }
 
     fn push_transform(&mut self, _transform: Matrix4) {

--- a/crates/flui-rendering/src/storage/node.rs
+++ b/crates/flui-rendering/src/storage/node.rs
@@ -572,6 +572,24 @@ impl RenderNode {
         }
     }
 
+    /// Returns this node's parent-relative offset.
+    #[inline]
+    pub fn offset(&self) -> flui_types::Offset {
+        match self {
+            Self::Box(entry) => entry.state().offset(),
+            Self::Sliver(entry) => entry.state().offset(),
+        }
+    }
+
+    /// Sets this node's parent-relative offset.
+    #[inline]
+    pub fn set_offset(&self, offset: flui_types::Offset) {
+        match self {
+            Self::Box(entry) => entry.state().set_offset(offset),
+            Self::Sliver(entry) => entry.state().set_offset(offset),
+        }
+    }
+
     /// Returns the size for Box protocol nodes (None for Sliver nodes).
     pub fn size(&self) -> Option<flui_types::Size> {
         match self {

--- a/crates/flui-rendering/src/storage/node.rs
+++ b/crates/flui-rendering/src/storage/node.rs
@@ -536,6 +536,42 @@ impl RenderNode {
         }
     }
 
+    /// Stable debug name for the stored render object.
+    #[inline]
+    pub fn debug_name(&self) -> &'static str {
+        match self {
+            Self::Box(entry) => entry.render_object().debug_name(),
+            Self::Sliver(entry) => entry.render_object().debug_name(),
+        }
+    }
+
+    /// Optional paint opacity effect for this render object.
+    #[inline]
+    pub fn paint_alpha(&self) -> Option<u8> {
+        match self {
+            Self::Box(entry) => entry.render_object().paint_alpha(),
+            Self::Sliver(entry) => entry.render_object().paint_alpha(),
+        }
+    }
+
+    /// Optional paint transform effect for this render object.
+    #[inline]
+    pub fn paint_transform(&self) -> Option<flui_types::Matrix4> {
+        match self {
+            Self::Box(entry) => entry.render_object().paint_transform(),
+            Self::Sliver(entry) => entry.render_object().paint_transform(),
+        }
+    }
+
+    /// Records this node's paint fragment through the protocol blanket.
+    #[inline]
+    pub fn paint_raw(&self, recorder: &mut crate::context::FragmentRecorder, child_count: usize) {
+        match self {
+            Self::Box(entry) => entry.render_object().paint_raw(recorder, child_count),
+            Self::Sliver(entry) => entry.render_object().paint_raw(recorder, child_count),
+        }
+    }
+
     /// Returns the size for Box protocol nodes (None for Sliver nodes).
     pub fn size(&self) -> Option<flui_types::Size> {
         match self {

--- a/crates/flui-rendering/src/traits/render_sliver.rs
+++ b/crates/flui-rendering/src/traits/render_sliver.rs
@@ -150,11 +150,14 @@ pub trait RenderSliver: flui_foundation::Diagnosticable + Send + Sync + 'static 
         debug_assert!(from <= to);
         let remaining_cache_extent = constraints.remaining_cache_extent;
         let cache_origin = constraints.cache_origin;
+        let scroll_offset = constraints.scroll_offset;
 
-        let a = cache_origin;
-        let b = cache_origin + remaining_cache_extent;
+        let a = scroll_offset + cache_origin;
+        let b = scroll_offset + remaining_cache_extent;
 
-        (to.min(b) - from.max(a)).max(0.0)
+        (to.min(b) - from.max(a))
+            .max(0.0)
+            .min(remaining_cache_extent)
     }
 
     /// Returns the position of a child along the main axis.
@@ -470,6 +473,17 @@ mod tests {
         )
     }
 
+    fn vertical_cache_constraints(
+        scroll_offset: f32,
+        remaining_cache_extent: f32,
+        cache_origin: f32,
+    ) -> SliverConstraints {
+        let mut constraints = vertical_constraints(scroll_offset, 50.0);
+        constraints.remaining_cache_extent = remaining_cache_extent;
+        constraints.cache_origin = cache_origin;
+        constraints
+    }
+
     // ────────────────────────────────────────────────────────────────────────
     // Test double — completing leaf
     //
@@ -666,6 +680,19 @@ mod tests {
             (geom.paint_extent - 80.0).abs() < 1e-4,
             "paint_extent clamped to remaining_paint_extent=80, got {}",
             geom.paint_extent
+        );
+    }
+
+    #[test]
+    fn calculate_cache_offset_uses_scroll_offset_plus_cache_origin_window() {
+        let sliver = FixedHeightSliver::new(200.0);
+        let constraints = vertical_cache_constraints(50.0, 100.0, -20.0);
+
+        assert_eq!(
+            sliver.calculate_cache_offset(&constraints, 0.0, 40.0),
+            10.0,
+            "Flutter cache window is [scroll_offset + cache_origin, \
+             scroll_offset + remaining_cache_extent]",
         );
     }
 

--- a/crates/flui-rendering/src/traits/render_sliver.rs
+++ b/crates/flui-rendering/src/traits/render_sliver.rs
@@ -382,18 +382,20 @@ where
 
     fn hit_test_raw(
         &self,
-        _position: crate::protocol::ProtocolPosition<SliverProtocol>,
+        position: crate::protocol::ProtocolPosition<SliverProtocol>,
         _child_count: usize,
-        _hit_child: &mut (
+        hit_child: &mut (
                  dyn FnMut(usize, Option<crate::protocol::ProtocolPosition<SliverProtocol>>) -> bool
                      + Send
                      + Sync
              ),
     ) -> bool {
-        // Sliver hit testing lands with the sliver layout walk
-        // (Core.2); until then a sliver subtree reports a miss rather
-        // than a false hit.
-        false
+        let inner =
+            crate::protocol::SliverHitTestCtx::<T::Arity, T::ParentData>::with_child_callback(
+                position, hit_child,
+            );
+        let mut ctx = crate::context::SliverHitTestContext::new(inner);
+        T::hit_test(self, &mut ctx)
     }
 
     fn geometry(&self) -> &crate::protocol::ProtocolGeometry<SliverProtocol> {

--- a/crates/flui-rendering/src/traits/render_sliver.rs
+++ b/crates/flui-rendering/src/traits/render_sliver.rs
@@ -334,7 +334,7 @@ where
         &mut self,
         ctx: &mut <SliverProtocol as crate::protocol::Protocol>::LayoutCtxErased<'_>,
     ) -> crate::error::RenderResult<crate::protocol::ProtocolGeometry<SliverProtocol>> {
-        // Core.2 W3.1 — live leaf bridge, mirroring the Box analog in
+        // Core.2 W3 — live bridge, mirroring the Box analog in
         // `render_box.rs`.
         //
         // The pipeline hands us `&mut dyn SliverLayoutCtxErased`
@@ -355,26 +355,9 @@ where
         // we return `Err(RenderError::ContractViolation)` — typed
         // propagation, no panic.
         //
-        // Child layout operations are still leaf-scoped stubs (child
-        // count returns 0, `layout_child` returns `SliverGeometry::ZERO`);
-        // the full child-walk bridge is a follow-on Core.2 wave.
-        //
-        // Leaf-arity gate: the blanket installs for EVERY `T: RenderSliver`,
-        // but the reconstructed context cannot yet lay out children. A
-        // non-leaf sliver (e.g. `RenderSliverPadding`, arity `Single`) would
-        // read the stubbed child API and silently produce wrong geometry
-        // instead of failing. Until the child-walk bridge lands, restrict
-        // the live path to `Leaf` arity and preserve the loud
-        // `ContractViolation` for every other arity (`Arity: 'static`, so
-        // the identity check is exact and the only arity that passes is
-        // `flui_tree::Leaf`).
-        if core::any::TypeId::of::<T::Arity>() != core::any::TypeId::of::<flui_tree::Leaf>() {
-            return Err(crate::error::RenderError::contract_violation(
-                self.debug_name(),
-                "RenderSliver child layout is not yet wired: only Leaf-arity \
-                 slivers lay out through perform_layout_raw (Core.2 child-walk pending)",
-            ));
-        }
+        // Child layout operations delegate through `SliverLayoutCtxErased`,
+        // so non-leaf slivers such as `RenderSliverPadding` can synchronously
+        // lay out their sliver children during the pipeline walk.
         let typed_inner =
             crate::protocol::SliverLayoutCtx::<T::Arity, T::ParentData>::from_erased(ctx);
         let mut layout_ctx =
@@ -726,8 +709,8 @@ mod tests {
     }
 
     // ────────────────────────────────────────────────────────────────────────
-    // Test double — non-leaf (Single) arity: completes geometry, but the
-    // bridge must refuse it because the child-walk is not yet wired.
+    // Test double — non-leaf (Single) arity: completes geometry through
+    // the same erased bridge as leaf slivers.
     // ────────────────────────────────────────────────────────────────────────
 
     struct SingleAritySliver {
@@ -780,13 +763,10 @@ mod tests {
         }
     }
 
-    /// A non-`Leaf` sliver must hit the arity gate and return
-    /// `ContractViolation` — even though its `perform_layout` would complete —
-    /// because the child-walk bridge is not yet wired. This preserves the
-    /// pre-bridge loud-fail for `RenderSliverPadding` & friends (arity
-    /// `Single`) rather than silently dropping their child geometry.
+    /// A non-`Leaf` sliver that completes layout must now pass through the
+    /// bridge; child-aware slivers use the same path and call `layout_child`.
     #[test]
-    fn sliver_non_leaf_arity_is_gated_to_contract_violation() {
+    fn sliver_non_leaf_bridge_completing_succeeds() {
         let constraints = vertical_constraints(0.0, 600.0);
         let mut sliver = SingleAritySliver {
             constraints,
@@ -798,13 +778,8 @@ mod tests {
             sliver.perform_layout_raw(erased)
         });
 
-        assert!(
-            matches!(
-                result,
-                Err(crate::error::RenderError::ContractViolation { .. })
-            ),
-            "non-leaf sliver must be gated to ContractViolation until child-walk \
-             lands, got {result:?}",
-        );
+        let geom = result.expect("non-leaf sliver bridge must accept completed layout");
+        assert_eq!(geom.scroll_extent, 600.0);
+        assert_eq!(geom.paint_extent, 600.0);
     }
 }

--- a/crates/flui-rendering/tests/cross_protocol_layout.rs
+++ b/crates/flui-rendering/tests/cross_protocol_layout.rs
@@ -22,7 +22,7 @@ use flui_foundation::Diagnosticable;
 use flui_rendering::{
     constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
     context::{BoxLayoutContext, SliverHitTestContext, SliverLayoutContext},
-    objects::RenderColoredBox,
+    objects::{RenderColoredBox, RenderSliverPadding},
     parent_data::{BoxParentData, SliverParentData},
     pipeline::PipelineOwner,
     protocol::{BoxProtocol, SliverProtocol},
@@ -227,6 +227,85 @@ fn cross_protocol_box_parent_lays_out_leaf_sliver_child() {
     assert!(
         !parent_node.needs_layout(),
         "parent NEEDS_LAYOUT must be cleared after successful cross-protocol layout"
+    );
+}
+
+// ============================================================================
+// Test 1b — Positive: Box parent lays out a non-leaf Sliver child
+// ============================================================================
+
+/// Box parent with a `RenderSliverPadding` child drives the sliver non-leaf
+/// walk: the padding sliver must lay out its own leaf sliver child, compose
+/// the padded geometry, and return that geometry to the Box parent.
+///
+/// This is the next Core.2 step after W3.2b-1's leaf-only sliver bridge. On
+/// the leaf-only bridge this regresses to `SliverGeometry::ZERO` and leaves
+/// the Box parent dirty because `RenderSliverPadding` is gated as non-leaf.
+#[test]
+fn cross_protocol_box_parent_lays_out_sliver_padding_with_leaf_child() {
+    let sc = make_sliver_constraints();
+    let captured: Arc<Mutex<Option<SliverGeometry>>> = Arc::new(Mutex::new(None));
+
+    let parent_obj: Box<dyn RenderObject<BoxProtocol>> = Box::new(BoxWithSliverChild {
+        sliver_constraints: sc,
+        captured: Arc::clone(&captured),
+        size: Size::ZERO,
+    });
+    let padding_obj: Box<dyn RenderObject<SliverProtocol>> =
+        Box::new(RenderSliverPadding::symmetric(0.0, 10.0));
+    let leaf_obj: Box<dyn RenderObject<SliverProtocol>> = Box::new(StubLeafSliver::default());
+
+    let mut pipeline = fresh_layout_pipeline();
+    let parent_id = pipeline.render_tree_mut().insert_box(parent_obj);
+    let padding_id = pipeline
+        .render_tree_mut()
+        .insert_sliver_child(parent_id, padding_obj)
+        .expect("tree must accept RenderSliverPadding under a Box parent");
+    pipeline
+        .render_tree_mut()
+        .insert_sliver_child(padding_id, leaf_obj)
+        .expect("tree must accept a leaf Sliver child under RenderSliverPadding");
+
+    let box_constraints = BoxConstraints::new(px(0.0), px(800.0), px(0.0), px(600.0));
+    let result = pipeline.layout_dirty_root(parent_id, box_constraints);
+    assert!(
+        result.is_ok(),
+        "layout_dirty_root must succeed for Box parent -> SliverPadding -> leaf Sliver: {result:?}"
+    );
+
+    let geom = captured
+        .lock()
+        .unwrap()
+        .expect("perform_layout must have called layout_sliver_child");
+
+    assert_eq!(
+        geom.scroll_extent, 220.0,
+        "10px top + 10px bottom padding must add 20px to the leaf's 200px scroll extent"
+    );
+    assert_eq!(
+        geom.paint_extent, 220.0,
+        "remaining_paint_extent=400 gives enough room for 200px leaf + 20px padding"
+    );
+    assert_eq!(
+        geom.layout_extent, 220.0,
+        "layout extent should match the fully visible padded extent"
+    );
+
+    let parent_node = pipeline
+        .render_tree()
+        .get(parent_id)
+        .expect("parent must remain in the tree after layout");
+    assert!(
+        !parent_node.needs_layout(),
+        "parent NEEDS_LAYOUT must be cleared after successful non-leaf sliver layout"
+    );
+    let padding_node = pipeline
+        .render_tree()
+        .get(padding_id)
+        .expect("padding sliver must remain in the tree after layout");
+    assert!(
+        !padding_node.needs_layout(),
+        "RenderSliverPadding NEEDS_LAYOUT must be cleared after its child layout succeeds"
     );
 }
 

--- a/crates/flui-rendering/tests/hit_test_pipeline.rs
+++ b/crates/flui-rendering/tests/hit_test_pipeline.rs
@@ -12,19 +12,26 @@
 //!    matrix (the D8 hit-test-under-transform gate).
 
 use flui_rendering::{
-    constraints::BoxConstraints,
-    context::{BoxHitTestContext, BoxLayoutContext},
+    constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
+    context::{BoxHitTestContext, BoxLayoutContext, SliverHitTestContext, SliverLayoutContext},
     hit_testing::HitTestResult,
-    objects::{RenderColoredBox, RenderFlex, RenderPadding, RenderTransform},
-    parent_data::BoxParentData,
+    objects::{
+        RenderColoredBox, RenderFlex, RenderPadding, RenderSliverIgnorePointer, RenderTransform,
+    },
+    parent_data::{BoxParentData, SliverParentData},
     pipeline::PipelineOwner,
-    traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability},
+    protocol::{BoxProtocol, SliverProtocol},
+    traits::{
+        HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, RenderSliver,
+        SemanticsCapability,
+    },
+    view::ScrollDirection,
 };
-use flui_tree::Variable;
-use flui_types::{Offset, Size, geometry::px};
+use flui_tree::{Leaf, Variable};
+use flui_types::{Offset, Rect, Size, geometry::px, layout::AxisDirection};
 
-type BoxedRenderObject =
-    Box<dyn flui_rendering::traits::RenderObject<flui_rendering::protocol::BoxProtocol>>;
+type BoxedRenderObject = Box<dyn RenderObject<BoxProtocol>>;
+type BoxedSliverObject = Box<dyn RenderObject<SliverProtocol>>;
 
 /// Lays out the tree, then returns the laid-out owner for hit queries.
 fn laid_out(
@@ -239,5 +246,149 @@ fn flex_lays_out_and_hits_children_at_layout_offsets() {
         hits(&owner, 50.0, 10.0).first().copied(),
         Some(second),
         "(50,10) lands in the second flex child at its laid-out offset",
+    );
+}
+
+// ============================================================================
+// 5. Sliver subtree hit-testing through a Box host
+// ============================================================================
+
+fn sliver_hit_constraints() -> SliverConstraints {
+    SliverConstraints {
+        axis_direction: AxisDirection::TopToBottom,
+        cross_axis_direction: AxisDirection::LeftToRight,
+        growth_direction: GrowthDirection::Forward,
+        user_scroll_direction: ScrollDirection::Idle,
+        scroll_offset: 0.0,
+        preceding_scroll_extent: 0.0,
+        overlap: 0.0,
+        remaining_paint_extent: 200.0,
+        cross_axis_extent: 100.0,
+        viewport_main_axis_extent: 200.0,
+        remaining_cache_extent: 200.0,
+        cache_origin: 0.0,
+    }
+}
+
+#[derive(Debug)]
+struct SliverHitHost {
+    constraints: SliverConstraints,
+    size: Size,
+}
+
+impl flui_foundation::Diagnosticable for SliverHitHost {}
+impl PaintEffectsCapability for SliverHitHost {}
+impl SemanticsCapability for SliverHitHost {}
+impl HotReloadCapability for SliverHitHost {}
+
+impl RenderBox for SliverHitHost {
+    type Arity = Variable;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Variable, BoxParentData>) {
+        if ctx.child_count() > 0 {
+            let _ = ctx.layout_sliver_child(0, self.constraints);
+        }
+        self.size = ctx.constraints().biggest();
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+
+    fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Variable, BoxParentData>) -> bool {
+        ctx.hit_test_child(0, ctx.offset())
+    }
+}
+
+#[derive(Debug, Default)]
+struct HitLeafSliver {
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl flui_foundation::Diagnosticable for HitLeafSliver {}
+impl PaintEffectsCapability for HitLeafSliver {}
+impl SemanticsCapability for HitLeafSliver {}
+impl HotReloadCapability for HitLeafSliver {}
+
+impl RenderSliver for HitLeafSliver {
+    type Arity = Leaf;
+    type ParentData = SliverParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        let geometry = SliverGeometry {
+            scroll_extent: 80.0,
+            paint_extent: 80.0,
+            layout_extent: 80.0,
+            max_paint_extent: 80.0,
+            hit_test_extent: 80.0,
+            visible: true,
+            ..SliverGeometry::ZERO
+        };
+        self.geometry = geometry;
+        ctx.complete(geometry);
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn hit_test(&self, ctx: &mut SliverHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+        ctx.is_within_main_axis_range(0.0, self.geometry.hit_test_extent)
+            && ctx.is_within_cross_axis_range(0.0, self.constraints.cross_axis_extent)
+    }
+
+    fn sliver_paint_bounds(&self) -> Rect {
+        Rect::from_origin_size(flui_types::Point::ZERO, Size::new(px(100.0), px(80.0)))
+    }
+}
+
+#[test]
+fn box_host_hit_tests_sliver_proxy_subtree_leaf_first() {
+    let mut owner = PipelineOwner::new();
+    let host_id = owner.insert(Box::new(SliverHitHost {
+        constraints: sliver_hit_constraints(),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let proxy_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            host_id,
+            Box::new(RenderSliverIgnorePointer::new(false)) as BoxedSliverObject,
+        )
+        .expect("sliver proxy child");
+    let leaf_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            proxy_id,
+            Box::new(HitLeafSliver::default()) as BoxedSliverObject,
+        )
+        .expect("sliver leaf child");
+
+    let owner = laid_out(owner, host_id);
+
+    assert_eq!(
+        hits(&owner, 10.0, 10.0),
+        vec![leaf_id, proxy_id, host_id],
+        "hit path must cross Box -> SliverIgnorePointer -> leaf Sliver and remain leaf-first",
+    );
+    assert!(
+        hits(&owner, 10.0, 120.0).is_empty(),
+        "main-axis position beyond the leaf sliver's hit extent must miss",
     );
 }

--- a/crates/flui-rendering/tests/hit_test_pipeline.rs
+++ b/crates/flui-rendering/tests/hit_test_pipeline.rs
@@ -16,7 +16,8 @@ use flui_rendering::{
     context::{BoxHitTestContext, BoxLayoutContext, SliverHitTestContext, SliverLayoutContext},
     hit_testing::HitTestResult,
     objects::{
-        RenderColoredBox, RenderFlex, RenderPadding, RenderSliverIgnorePointer, RenderTransform,
+        RenderColoredBox, RenderFlex, RenderPadding, RenderSliverIgnorePointer,
+        RenderSliverOpacity, RenderSliverPadding, RenderTransform,
     },
     parent_data::{BoxParentData, SliverParentData},
     pipeline::PipelineOwner,
@@ -306,6 +307,44 @@ impl RenderBox for SliverHitHost {
     }
 }
 
+#[derive(Debug)]
+struct PositionedSliverHitHost {
+    constraints: SliverConstraints,
+    offset: Offset,
+    size: Size,
+}
+
+impl flui_foundation::Diagnosticable for PositionedSliverHitHost {}
+impl PaintEffectsCapability for PositionedSliverHitHost {}
+impl SemanticsCapability for PositionedSliverHitHost {}
+impl HotReloadCapability for PositionedSliverHitHost {}
+
+impl RenderBox for PositionedSliverHitHost {
+    type Arity = Variable;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Variable, BoxParentData>) {
+        if ctx.child_count() > 0 {
+            let _ = ctx.layout_sliver_child(0, self.constraints);
+            ctx.position_child(0, self.offset);
+        }
+        self.size = ctx.constraints().biggest();
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+
+    fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Variable, BoxParentData>) -> bool {
+        ctx.hit_test_child_at_layout_offset(0)
+    }
+}
+
 #[derive(Debug, Default)]
 struct HitLeafSliver {
     constraints: SliverConstraints,
@@ -390,5 +429,103 @@ fn box_host_hit_tests_sliver_proxy_subtree_leaf_first() {
     assert!(
         hits(&owner, 10.0, 120.0).is_empty(),
         "main-axis position beyond the leaf sliver's hit extent must miss",
+    );
+}
+
+#[test]
+fn box_parent_positions_sliver_child_for_hit_testing() {
+    let mut owner = PipelineOwner::new();
+    let host_id = owner.insert(Box::new(PositionedSliverHitHost {
+        constraints: sliver_hit_constraints(),
+        offset: Offset::new(px(0.0), px(20.0)),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let leaf_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            host_id,
+            Box::new(HitLeafSliver::default()) as BoxedSliverObject,
+        )
+        .expect("sliver leaf child");
+
+    let owner = laid_out(owner, host_id);
+
+    assert_eq!(
+        hits(&owner, 10.0, 90.0),
+        vec![leaf_id, host_id],
+        "Box parent position_child must commit offsets for Sliver children \
+         too: visual y=90 becomes sliver-local main=70",
+    );
+}
+
+#[test]
+fn box_host_hit_tests_transparent_sliver_opacity_child() {
+    let mut owner = PipelineOwner::new();
+    let host_id = owner.insert(Box::new(SliverHitHost {
+        constraints: sliver_hit_constraints(),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let opacity_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            host_id,
+            Box::new(RenderSliverOpacity::transparent()) as BoxedSliverObject,
+        )
+        .expect("sliver opacity child");
+    let leaf_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            opacity_id,
+            Box::new(HitLeafSliver::default()) as BoxedSliverObject,
+        )
+        .expect("sliver leaf child");
+
+    let owner = laid_out(owner, host_id);
+
+    assert_eq!(
+        hits(&owner, 10.0, 10.0),
+        vec![leaf_id, opacity_id, host_id],
+        "RenderSliverOpacity must not gate hit-testing on alpha; it \
+         transparently delegates to its child",
+    );
+}
+
+#[test]
+fn box_host_hit_tests_sliver_padding_child_at_paint_offset() {
+    let mut owner = PipelineOwner::new();
+    let host_id = owner.insert(Box::new(SliverHitHost {
+        constraints: sliver_hit_constraints(),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let padding_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            host_id,
+            Box::new(RenderSliverPadding::symmetric(7.0, 10.0)) as BoxedSliverObject,
+        )
+        .expect("sliver padding child");
+    let leaf_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            padding_id,
+            Box::new(HitLeafSliver::default()) as BoxedSliverObject,
+        )
+        .expect("sliver leaf child");
+
+    let owner = laid_out(owner, host_id);
+
+    assert_eq!(
+        hits(&owner, 10.0, 15.0),
+        vec![leaf_id, padding_id, host_id],
+        "the point is inside the child after subtracting the padding \
+         paint offset (cross=7, main=10)",
+    );
+    assert!(
+        hits(&owner, 10.0, 5.0).is_empty(),
+        "the leading main-axis padding itself is hit-transparent",
+    );
+    assert!(
+        hits(&owner, 3.0, 15.0).is_empty(),
+        "the leading cross-axis padding itself is hit-transparent",
     );
 }

--- a/crates/flui-rendering/tests/hit_test_pipeline.rs
+++ b/crates/flui-rendering/tests/hit_test_pipeline.rs
@@ -61,6 +61,17 @@ fn hits(
     result.path().iter().map(|e| e.target).collect()
 }
 
+fn render_offset(
+    owner: &flui_rendering::pipeline::PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    id: flui_foundation::RenderId,
+) -> Offset {
+    owner
+        .render_tree()
+        .get(id)
+        .map(flui_rendering::storage::RenderNode::offset)
+        .expect("node exists")
+}
+
 // ============================================================================
 // 1. Leaf-first recursion through a positioned child
 // ============================================================================
@@ -311,6 +322,7 @@ impl RenderBox for SliverHitHost {
 struct PositionedSliverHitHost {
     constraints: SliverConstraints,
     offset: Offset,
+    position_child: bool,
     size: Size,
 }
 
@@ -326,7 +338,9 @@ impl RenderBox for PositionedSliverHitHost {
     fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Variable, BoxParentData>) {
         if ctx.child_count() > 0 {
             let _ = ctx.layout_sliver_child(0, self.constraints);
-            ctx.position_child(0, self.offset);
+            if self.position_child {
+                ctx.position_child(0, self.offset);
+            }
         }
         self.size = ctx.constraints().biggest();
         ctx.complete_with_size(self.size);
@@ -341,6 +355,74 @@ impl RenderBox for PositionedSliverHitHost {
     }
 
     fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Variable, BoxParentData>) -> bool {
+        ctx.hit_test_child_at_layout_offset(0)
+    }
+}
+
+#[derive(Debug)]
+struct ConditionalOffsetSliverParent {
+    position_child: bool,
+    offset: Offset,
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl ConditionalOffsetSliverParent {
+    fn new(offset: Offset) -> Self {
+        Self {
+            position_child: true,
+            offset,
+            constraints: sliver_hit_constraints(),
+            geometry: SliverGeometry::ZERO,
+        }
+    }
+}
+
+impl flui_foundation::Diagnosticable for ConditionalOffsetSliverParent {}
+impl PaintEffectsCapability for ConditionalOffsetSliverParent {}
+impl SemanticsCapability for ConditionalOffsetSliverParent {}
+impl HotReloadCapability for ConditionalOffsetSliverParent {}
+
+impl RenderSliver for ConditionalOffsetSliverParent {
+    type Arity = flui_tree::Single;
+    type ParentData = SliverParentData;
+
+    fn perform_layout(
+        &mut self,
+        ctx: &mut SliverLayoutContext<'_, flui_tree::Single, Self::ParentData>,
+    ) {
+        self.constraints = *ctx.constraints();
+        let child_geometry = ctx.layout_child(0, self.constraints);
+        if self.position_child {
+            ctx.position_child(0, self.offset);
+        }
+        self.geometry = SliverGeometry {
+            hit_test_extent: 120.0,
+            paint_extent: 120.0,
+            layout_extent: 120.0,
+            max_paint_extent: 120.0,
+            visible: true,
+            ..child_geometry
+        };
+        ctx.complete(self.geometry);
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn hit_test(
+        &self,
+        ctx: &mut SliverHitTestContext<'_, flui_tree::Single, Self::ParentData>,
+    ) -> bool {
         ctx.hit_test_child_at_layout_offset(0)
     }
 }
@@ -397,6 +479,60 @@ impl RenderSliver for HitLeafSliver {
     }
 }
 
+#[derive(Debug)]
+struct OvereagerHitLeafSliver {
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl OvereagerHitLeafSliver {
+    fn new(paint_extent: f32, hit_test_extent: f32) -> Self {
+        Self {
+            constraints: sliver_hit_constraints(),
+            geometry: SliverGeometry {
+                scroll_extent: hit_test_extent.max(paint_extent),
+                paint_extent,
+                layout_extent: paint_extent,
+                max_paint_extent: paint_extent,
+                hit_test_extent,
+                visible: paint_extent > 0.0,
+                ..SliverGeometry::ZERO
+            },
+        }
+    }
+}
+
+impl flui_foundation::Diagnosticable for OvereagerHitLeafSliver {}
+impl PaintEffectsCapability for OvereagerHitLeafSliver {}
+impl SemanticsCapability for OvereagerHitLeafSliver {}
+impl HotReloadCapability for OvereagerHitLeafSliver {}
+
+impl RenderSliver for OvereagerHitLeafSliver {
+    type Arity = Leaf;
+    type ParentData = SliverParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        ctx.complete(self.geometry);
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn hit_test(&self, _ctx: &mut SliverHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+        true
+    }
+}
+
 #[test]
 fn box_host_hit_tests_sliver_proxy_subtree_leaf_first() {
     let mut owner = PipelineOwner::new();
@@ -433,11 +569,41 @@ fn box_host_hit_tests_sliver_proxy_subtree_leaf_first() {
 }
 
 #[test]
+fn sliver_hit_walk_gates_each_level_before_dispatch() {
+    let mut owner = PipelineOwner::new();
+    let host_id = owner.insert(Box::new(SliverHitHost {
+        constraints: sliver_hit_constraints(),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let leaf_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            host_id,
+            Box::new(OvereagerHitLeafSliver::new(40.0, 40.0)) as BoxedSliverObject,
+        )
+        .expect("sliver leaf child");
+
+    let owner = laid_out(owner, host_id);
+
+    assert_eq!(hits(&owner, 10.0, 10.0), vec![leaf_id, host_id]);
+    assert!(
+        hits(&owner, 10.0, 45.0).is_empty(),
+        "main-axis position outside geometry.hit_test_extent must miss \
+         before the object's hit_test override can claim it",
+    );
+    assert!(
+        hits(&owner, 120.0, 10.0).is_empty(),
+        "cross-axis position outside constraints.cross_axis_extent must miss",
+    );
+}
+
+#[test]
 fn box_parent_positions_sliver_child_for_hit_testing() {
     let mut owner = PipelineOwner::new();
     let host_id = owner.insert(Box::new(PositionedSliverHitHost {
         constraints: sliver_hit_constraints(),
         offset: Offset::new(px(0.0), px(20.0)),
+        position_child: true,
         size: Size::ZERO,
     }) as BoxedRenderObject);
     let leaf_id = owner
@@ -455,6 +621,112 @@ fn box_parent_positions_sliver_child_for_hit_testing() {
         vec![leaf_id, host_id],
         "Box parent position_child must commit offsets for Sliver children \
          too: visual y=90 becomes sliver-local main=70",
+    );
+}
+
+#[test]
+fn box_parent_preserves_unpositioned_sliver_child_offset_across_relayout() {
+    let mut owner = PipelineOwner::new();
+    let host_id = owner.insert(Box::new(PositionedSliverHitHost {
+        constraints: sliver_hit_constraints(),
+        offset: Offset::new(px(0.0), px(20.0)),
+        position_child: true,
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let leaf_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            host_id,
+            Box::new(HitLeafSliver::default()) as BoxedSliverObject,
+        )
+        .expect("sliver leaf child");
+
+    let owner = laid_out(owner, host_id);
+    assert_eq!(
+        render_offset(&owner, leaf_id),
+        Offset::new(px(0.0), px(20.0))
+    );
+
+    let mut owner = owner.into_idle();
+    {
+        let node = owner
+            .render_tree_mut()
+            .get_mut(host_id)
+            .expect("host in tree");
+        let entry = node.as_box_mut().expect("box entry");
+        let host = entry
+            .render_object_mut()
+            .as_any_mut()
+            .downcast_mut::<PositionedSliverHitHost>()
+            .expect("positioned host downcast");
+        host.position_child = false;
+    }
+    owner.mark_needs_layout(host_id);
+    let mut owner = owner.into_layout();
+    owner.run_layout().expect("relayout succeeds");
+
+    assert_eq!(
+        render_offset(&owner, leaf_id),
+        Offset::new(px(0.0), px(20.0)),
+        "a Box parent that lays out a Sliver child without re-positioning \
+         it must preserve the child's previous offset",
+    );
+}
+
+#[test]
+fn unpositioned_sliver_child_keeps_prior_offset_across_relayout() {
+    let mut owner = PipelineOwner::new();
+    let host_id = owner.insert(Box::new(SliverHitHost {
+        constraints: sliver_hit_constraints(),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let proxy_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            host_id,
+            Box::new(ConditionalOffsetSliverParent::new(Offset::new(
+                px(0.0),
+                px(20.0),
+            ))) as BoxedSliverObject,
+        )
+        .expect("sliver proxy child");
+    let leaf_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            proxy_id,
+            Box::new(HitLeafSliver::default()) as BoxedSliverObject,
+        )
+        .expect("sliver leaf child");
+
+    let owner = laid_out(owner, host_id);
+    assert_eq!(
+        render_offset(&owner, leaf_id),
+        Offset::new(px(0.0), px(20.0))
+    );
+
+    let mut owner = owner.into_idle();
+    {
+        let node = owner
+            .render_tree_mut()
+            .get_mut(proxy_id)
+            .expect("proxy in tree");
+        let entry = node.as_sliver_mut().expect("sliver entry");
+        let proxy = entry
+            .render_object_mut()
+            .as_any_mut()
+            .downcast_mut::<ConditionalOffsetSliverParent>()
+            .expect("conditional proxy downcast");
+        proxy.position_child = false;
+    }
+    owner.mark_needs_layout(host_id);
+    let mut owner = owner.into_layout();
+    owner.run_layout().expect("relayout succeeds");
+
+    assert_eq!(
+        render_offset(&owner, leaf_id),
+        Offset::new(px(0.0), px(20.0)),
+        "a sliver parent that does not call position_child on a later \
+         pass must preserve the child's previously committed offset",
     );
 }
 
@@ -487,6 +759,37 @@ fn box_host_hit_tests_transparent_sliver_opacity_child() {
         vec![leaf_id, opacity_id, host_id],
         "RenderSliverOpacity must not gate hit-testing on alpha; it \
          transparently delegates to its child",
+    );
+}
+
+#[test]
+fn sliver_padding_hit_test_extent_uses_child_hit_extent_without_after_padding() {
+    let mut owner = PipelineOwner::new();
+    let host_id = owner.insert(Box::new(SliverHitHost {
+        constraints: sliver_hit_constraints(),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let padding_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            host_id,
+            Box::new(RenderSliverPadding::symmetric(0.0, 10.0)) as BoxedSliverObject,
+        )
+        .expect("sliver padding child");
+    owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            padding_id,
+            Box::new(OvereagerHitLeafSliver::new(40.0, 100.0)) as BoxedSliverObject,
+        )
+        .expect("sliver leaf child");
+
+    let owner = laid_out(owner, host_id);
+
+    assert!(
+        hits(&owner, 10.0, 120.0).is_empty(),
+        "hit position beyond Flutter's padded hit-test extent must miss \
+         even if the child would otherwise claim it",
     );
 }
 

--- a/crates/flui-rendering/tests/paint_fragment_snapshot.rs
+++ b/crates/flui-rendering/tests/paint_fragment_snapshot.rs
@@ -19,19 +19,25 @@
 
 use flui_layer::{Layer, LayerTree};
 use flui_painting::DisplayListCore;
+use flui_painting::Paint;
 use flui_rendering::{
-    constraints::BoxConstraints,
-    context::{BoxHitTestContext, BoxLayoutContext},
+    constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
+    context::{BoxHitTestContext, BoxLayoutContext, SliverHitTestContext, SliverLayoutContext},
     objects::{RenderClipRect, RenderColoredBox, RenderPadding, RenderRepaintBoundary},
-    parent_data::BoxParentData,
+    parent_data::{BoxParentData, SliverParentData},
     pipeline::PipelineOwner,
-    traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability},
+    protocol::{BoxProtocol, SliverProtocol},
+    traits::{
+        HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, RenderSliver,
+        SemanticsCapability,
+    },
+    view::ScrollDirection,
 };
-use flui_tree::Variable;
-use flui_types::{Offset, Point, Rect, Size, geometry::px};
+use flui_tree::{Leaf, Variable};
+use flui_types::{Color, Offset, Point, Rect, Size, geometry::px, layout::AxisDirection};
 
-type BoxedRenderObject =
-    Box<dyn flui_rendering::traits::RenderObject<flui_rendering::protocol::BoxProtocol>>;
+type BoxedRenderObject = Box<dyn RenderObject<BoxProtocol>>;
+type BoxedSliverObject = Box<dyn RenderObject<SliverProtocol>>;
 
 /// Runs layout → compositing → paint and returns the produced layer
 /// tree.
@@ -255,5 +261,154 @@ fn clip_rect_object_brackets_child_in_clip_layer() {
         "RenderClipRect must produce a ClipRect LAYER covering the \
          child's picture — canvas clips are run-local and would never \
          reach the child",
+    );
+}
+
+// ============================================================================
+// 5. Box host paints a sliver subtree
+// ============================================================================
+
+fn sliver_paint_constraints() -> SliverConstraints {
+    SliverConstraints {
+        axis_direction: AxisDirection::TopToBottom,
+        cross_axis_direction: AxisDirection::LeftToRight,
+        growth_direction: GrowthDirection::Forward,
+        user_scroll_direction: ScrollDirection::Idle,
+        scroll_offset: 0.0,
+        preceding_scroll_extent: 0.0,
+        overlap: 0.0,
+        remaining_paint_extent: 200.0,
+        cross_axis_extent: 100.0,
+        viewport_main_axis_extent: 200.0,
+        remaining_cache_extent: 200.0,
+        cache_origin: 0.0,
+    }
+}
+
+#[derive(Debug)]
+struct SliverPaintHost {
+    constraints: SliverConstraints,
+    size: Size,
+}
+
+impl flui_foundation::Diagnosticable for SliverPaintHost {}
+impl PaintEffectsCapability for SliverPaintHost {}
+impl SemanticsCapability for SliverPaintHost {}
+impl HotReloadCapability for SliverPaintHost {}
+
+impl RenderBox for SliverPaintHost {
+    type Arity = Variable;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Variable, BoxParentData>) {
+        if ctx.child_count() > 0 {
+            let _ = ctx.layout_sliver_child(0, self.constraints);
+        }
+        self.size = ctx.constraints().biggest();
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+
+    fn hit_test(&self, _ctx: &mut BoxHitTestContext<'_, Variable, BoxParentData>) -> bool {
+        false
+    }
+}
+
+#[derive(Debug, Default)]
+struct PaintLeafSliver {
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl flui_foundation::Diagnosticable for PaintLeafSliver {}
+impl PaintEffectsCapability for PaintLeafSliver {}
+impl SemanticsCapability for PaintLeafSliver {}
+impl HotReloadCapability for PaintLeafSliver {}
+
+impl RenderSliver for PaintLeafSliver {
+    type Arity = Leaf;
+    type ParentData = SliverParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        let geometry = SliverGeometry {
+            scroll_extent: 80.0,
+            paint_extent: 80.0,
+            layout_extent: 80.0,
+            max_paint_extent: 80.0,
+            hit_test_extent: 80.0,
+            visible: true,
+            ..SliverGeometry::ZERO
+        };
+        self.geometry = geometry;
+        ctx.complete(geometry);
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn paint(&self, ctx: &mut flui_rendering::context::PaintCx<'_, Leaf>) {
+        let rect = Rect::from_origin_size(Point::ZERO, Size::new(px(100.0), px(80.0)));
+        ctx.canvas().draw_rect(rect, &Paint::fill(Color::RED));
+    }
+
+    fn hit_test(&self, _ctx: &mut SliverHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+        false
+    }
+
+    fn sliver_paint_bounds(&self) -> Rect {
+        Rect::from_origin_size(Point::ZERO, Size::new(px(100.0), px(80.0)))
+    }
+}
+
+#[test]
+fn box_host_splices_sliver_leaf_paint_into_picture() {
+    let mut owner = PipelineOwner::new();
+    let host_id = owner.insert(Box::new(SliverPaintHost {
+        constraints: sliver_paint_constraints(),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            host_id,
+            Box::new(PaintLeafSliver::default()) as BoxedSliverObject,
+        )
+        .expect("sliver child");
+
+    owner.set_root_id(Some(host_id));
+    owner.set_root_constraints(Some(BoxConstraints::new(
+        px(0.0),
+        px(200.0),
+        px(0.0),
+        px(200.0),
+    )));
+
+    let (tree, _owner) = paint_frame(owner);
+
+    assert_eq!(
+        structure(&tree),
+        vec![(0, "Offset"), (1, "Picture")],
+        "inline sliver paint should splice into the Box host's picture stream",
+    );
+    assert_eq!(
+        first_picture(&tree).bounds(),
+        Rect::from_origin_size(Point::ZERO, Size::new(px(100.0), px(80.0))),
     );
 }

--- a/crates/flui-rendering/tests/paint_fragment_snapshot.rs
+++ b/crates/flui-rendering/tests/paint_fragment_snapshot.rs
@@ -379,6 +379,58 @@ impl RenderSliver for PaintLeafSliver {
     }
 }
 
+#[derive(Debug, Default)]
+struct InvisiblePaintLeafSliver {
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl flui_foundation::Diagnosticable for InvisiblePaintLeafSliver {}
+impl PaintEffectsCapability for InvisiblePaintLeafSliver {}
+impl SemanticsCapability for InvisiblePaintLeafSliver {}
+impl HotReloadCapability for InvisiblePaintLeafSliver {}
+
+impl RenderSliver for InvisiblePaintLeafSliver {
+    type Arity = Leaf;
+    type ParentData = SliverParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        let geometry = SliverGeometry {
+            scroll_extent: 80.0,
+            paint_extent: 0.0,
+            layout_extent: 0.0,
+            max_paint_extent: 80.0,
+            hit_test_extent: 0.0,
+            visible: false,
+            ..SliverGeometry::ZERO
+        };
+        self.geometry = geometry;
+        ctx.complete(geometry);
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn paint(&self, ctx: &mut flui_rendering::context::PaintCx<'_, Leaf>) {
+        let rect = Rect::from_origin_size(Point::ZERO, Size::new(px(100.0), px(80.0)));
+        ctx.canvas().draw_rect(rect, &Paint::fill(Color::RED));
+    }
+
+    fn hit_test(&self, _ctx: &mut SliverHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+        false
+    }
+}
+
 #[test]
 fn box_host_splices_sliver_leaf_paint_into_picture() {
     let mut owner = PipelineOwner::new();
@@ -412,6 +464,46 @@ fn box_host_splices_sliver_leaf_paint_into_picture() {
     assert_eq!(
         first_picture(&tree).bounds(),
         Rect::from_origin_size(Point::ZERO, Size::new(px(100.0), px(80.0))),
+    );
+}
+
+#[test]
+fn box_host_skips_invisible_sliver_child_paint() {
+    let mut owner = PipelineOwner::new();
+    let host_id = owner.insert(Box::new(SliverPaintHost {
+        constraints: sliver_paint_constraints(),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let padding_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            host_id,
+            Box::new(RenderSliverPadding::symmetric(0.0, 10.0)) as BoxedSliverObject,
+        )
+        .expect("sliver padding child");
+    owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            padding_id,
+            Box::new(InvisiblePaintLeafSliver::default()) as BoxedSliverObject,
+        )
+        .expect("sliver leaf child");
+
+    owner.set_root_id(Some(host_id));
+    owner.set_root_constraints(Some(BoxConstraints::new(
+        px(0.0),
+        px(200.0),
+        px(0.0),
+        px(200.0),
+    )));
+
+    let (tree, _owner) = paint_frame(owner);
+
+    assert_eq!(
+        structure(&tree),
+        vec![(0, "Offset")],
+        "sliver children whose geometry.visible is false must not be spliced \
+         into the paint stream",
     );
 }
 

--- a/crates/flui-rendering/tests/paint_fragment_snapshot.rs
+++ b/crates/flui-rendering/tests/paint_fragment_snapshot.rs
@@ -23,7 +23,9 @@ use flui_painting::Paint;
 use flui_rendering::{
     constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
     context::{BoxHitTestContext, BoxLayoutContext, SliverHitTestContext, SliverLayoutContext},
-    objects::{RenderClipRect, RenderColoredBox, RenderPadding, RenderRepaintBoundary},
+    objects::{
+        RenderClipRect, RenderColoredBox, RenderPadding, RenderRepaintBoundary, RenderSliverPadding,
+    },
     parent_data::{BoxParentData, SliverParentData},
     pipeline::PipelineOwner,
     protocol::{BoxProtocol, SliverProtocol},
@@ -410,5 +412,45 @@ fn box_host_splices_sliver_leaf_paint_into_picture() {
     assert_eq!(
         first_picture(&tree).bounds(),
         Rect::from_origin_size(Point::ZERO, Size::new(px(100.0), px(80.0))),
+    );
+}
+
+#[test]
+fn box_host_splices_sliver_padding_child_at_paint_offset() {
+    let mut owner = PipelineOwner::new();
+    let host_id = owner.insert(Box::new(SliverPaintHost {
+        constraints: sliver_paint_constraints(),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let padding_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            host_id,
+            Box::new(RenderSliverPadding::symmetric(7.0, 10.0)) as BoxedSliverObject,
+        )
+        .expect("sliver padding child");
+    owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            padding_id,
+            Box::new(PaintLeafSliver::default()) as BoxedSliverObject,
+        )
+        .expect("sliver leaf child");
+
+    owner.set_root_id(Some(host_id));
+    owner.set_root_constraints(Some(BoxConstraints::new(
+        px(0.0),
+        px(200.0),
+        px(0.0),
+        px(200.0),
+    )));
+
+    let (tree, _owner) = paint_frame(owner);
+
+    assert_eq!(
+        first_picture(&tree).bounds(),
+        Rect::from_ltrb(px(7.0), px(10.0), px(107.0), px(90.0)),
+        "sliver child paint must be composed at the paint offset computed \
+         by RenderSliverPadding",
     );
 }


### PR DESCRIPTION
## Summary
- walk non-leaf Sliver subtrees from Box parents during layout
- wire Sliver hit-test recursion and leaf-first result ordering
- splice Sliver paint fragments into the Box-hosted picture stream
- commit Sliver child paint offsets so padding/opacity/positioned Sliver children hit-test and paint at the same location

## Why
Wave3 had Box -> leaf Sliver layout, but non-leaf Sliver proxies still lost child traversal across layout, hit-test, and paint. This closes that path for proxy Slivers such as padding, opacity, and ignore-pointer while keeping offsets in RenderState as the shared paint/hit-test source of truth.

## Validation
- cargo fmt --package flui-rendering -- --check
- cargo test -p flui-rendering --test hit_test_pipeline
- cargo test -p flui-rendering --test paint_fragment_snapshot
- cargo test -p flui-rendering
- cargo clippy -p flui-rendering --all-targets -- -D warnings