### PR TITLE
Core.2 Sliver W3.3: add sliver-to-box adapter

### DIFF
--- a/crates/flui-rendering/src/constraints/sliver_constraints.rs
+++ b/crates/flui-rendering/src/constraints/sliver_constraints.rs
@@ -8,9 +8,12 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use flui_types::layout::{Axis, AxisDirection};
+use flui_types::{
+    geometry::px,
+    layout::{Axis, AxisDirection},
+};
 
-use super::{Constraints, GrowthDirection};
+use super::{BoxConstraints, Constraints, GrowthDirection};
 use crate::view::ScrollDirection;
 
 /// Layout constraints for sliver (scrollable) content.
@@ -201,6 +204,36 @@ impl SliverConstraints {
     #[must_use]
     pub const fn axis(&self) -> Axis {
         self.axis_direction.axis()
+    }
+
+    /// Returns [`BoxConstraints`] that reflect this sliver constraint space.
+    ///
+    /// Mirrors Flutter's `SliverConstraints.asBoxConstraints`: the cross axis
+    /// is tight to either `cross_axis_extent` or this constraint's own
+    /// cross-axis extent, while the main axis uses `min_extent..max_extent`.
+    #[inline]
+    #[must_use]
+    pub fn as_box_constraints(
+        &self,
+        min_extent: f32,
+        max_extent: f32,
+        cross_axis_extent: Option<f32>,
+    ) -> BoxConstraints {
+        let cross_axis_extent = cross_axis_extent.unwrap_or(self.cross_axis_extent);
+        match self.axis() {
+            Axis::Horizontal => BoxConstraints::new(
+                px(min_extent),
+                px(max_extent),
+                px(cross_axis_extent),
+                px(cross_axis_extent),
+            ),
+            Axis::Vertical => BoxConstraints::new(
+                px(cross_axis_extent),
+                px(cross_axis_extent),
+                px(min_extent),
+                px(max_extent),
+            ),
+        }
     }
 
     /// Returns whether content is at or before the viewport start.

--- a/crates/flui-rendering/src/context/layout.rs
+++ b/crates/flui-rendering/src/context/layout.rs
@@ -190,7 +190,7 @@ where
 // BOX-SPECIFIC EXTENSIONS
 // ============================================================================
 
-use crate::protocol::BoxProtocol;
+use crate::protocol::{BoxProtocol, SliverProtocol};
 
 impl<'ctx, A: Arity, PD: ParentData + Default> LayoutContext<'ctx, BoxProtocol, A, PD>
 where
@@ -368,6 +368,31 @@ where
         constraints: SliverConstraints,
     ) -> SliverGeometry {
         crate::protocol::box_protocol::BoxLayoutCtxErased::layout_sliver_child(
+            &mut self.inner,
+            index,
+            constraints,
+        )
+    }
+}
+
+// ============================================================================
+// SLIVER CROSS-PROTOCOL EXTENSIONS
+// ============================================================================
+
+impl<'ctx, A: Arity, PD: ParentData + Default> LayoutContext<'ctx, SliverProtocol, A, PD>
+where
+    <crate::protocol::SliverLayout as LayoutCapability>::Context<'ctx, A, PD>:
+        crate::protocol::sliver_protocol::SliverLayoutCtxErased,
+{
+    /// Lays out a **Box** child at `index` with the given
+    /// [`BoxConstraints`] and returns its [`Size`].
+    ///
+    /// This is the reverse bridge of
+    /// [`Self::layout_sliver_child`]: Sliver render objects such as
+    /// `RenderSliverToBoxAdapter` can host Box children and still drive the
+    /// normal Box subtree layout walk through the pipeline.
+    pub fn layout_box_child(&mut self, index: usize, constraints: BoxConstraints) -> Size {
+        crate::protocol::sliver_protocol::SliverLayoutCtxErased::layout_box_child(
             &mut self.inner,
             index,
             constraints,

--- a/crates/flui-rendering/src/objects/mod.rs
+++ b/crates/flui-rendering/src/objects/mod.rs
@@ -48,6 +48,8 @@
 //!   subtree to siblings beneath in the viewport (Core.2 Wave 5a)
 //! - [`RenderSliverOffstage`] - Hides a sliver subtree (zero geometry,
 //!   skipped paint, no hit-test) (Core.2 Wave 5a)
+//! - [`RenderSliverToBoxAdapter`] - Wraps one Box child in Sliver
+//!   protocol geometry (Core.2 W3.3)
 //!
 //! # Example
 //!
@@ -86,6 +88,7 @@ mod sliver_ignore_pointer;
 mod sliver_offstage;
 mod sliver_opacity;
 mod sliver_padding;
+mod sliver_to_box_adapter;
 mod stack;
 mod transform;
 
@@ -117,5 +120,6 @@ pub use sliver_ignore_pointer::RenderSliverIgnorePointer;
 pub use sliver_offstage::RenderSliverOffstage;
 pub use sliver_opacity::RenderSliverOpacity;
 pub use sliver_padding::RenderSliverPadding;
+pub use sliver_to_box_adapter::RenderSliverToBoxAdapter;
 pub use stack::{PositionedSpec, RenderStack, StackFit};
 pub use transform::RenderTransform;

--- a/crates/flui-rendering/src/objects/sliver_to_box_adapter.rs
+++ b/crates/flui-rendering/src/objects/sliver_to_box_adapter.rs
@@ -1,0 +1,168 @@
+//! `RenderSliverToBoxAdapter` — Sliver wrapper for one Box child.
+//!
+//! Mirrors Flutter's `RenderSliverToBoxAdapter`: the Box child is laid out
+//! with tight cross-axis constraints derived from the sliver constraint space,
+//! then the child's main-axis size becomes the sliver scroll extent.
+
+use flui_foundation::Diagnosticable;
+use flui_tree::Single;
+use flui_types::{
+    Offset,
+    geometry::px,
+    layout::{AxisDirection, AxisDirection::*},
+};
+
+use crate::{
+    constraints::{GrowthDirection, SliverConstraints, SliverGeometry},
+    context::{PaintCx, SliverHitTestContext, SliverLayoutContext},
+    parent_data::SliverPhysicalParentData,
+    traits::{HotReloadCapability, PaintEffectsCapability, RenderSliver, SemanticsCapability},
+};
+
+/// A Sliver-protocol adapter that lays out one Box-protocol child.
+#[derive(Debug, Clone)]
+pub struct RenderSliverToBoxAdapter {
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl RenderSliverToBoxAdapter {
+    /// Creates an adapter with no laid-out geometry yet.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            constraints: empty_sliver_constraints(),
+            geometry: SliverGeometry::ZERO,
+        }
+    }
+
+    #[inline]
+    fn child_paint_offset(constraints: &SliverConstraints, geometry: &SliverGeometry) -> Offset {
+        match apply_growth_direction_to_axis_direction(
+            constraints.axis_direction,
+            constraints.growth_direction,
+        ) {
+            TopToBottom => Offset::new(px(0.0), px(-constraints.scroll_offset)),
+            LeftToRight => Offset::new(px(-constraints.scroll_offset), px(0.0)),
+            BottomToTop => Offset::new(
+                px(0.0),
+                px(geometry.paint_extent + constraints.scroll_offset - geometry.scroll_extent),
+            ),
+            RightToLeft => Offset::new(
+                px(geometry.paint_extent + constraints.scroll_offset - geometry.scroll_extent),
+                px(0.0),
+            ),
+        }
+    }
+}
+
+impl Default for RenderSliverToBoxAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Diagnosticable for RenderSliverToBoxAdapter {}
+impl PaintEffectsCapability for RenderSliverToBoxAdapter {}
+impl SemanticsCapability for RenderSliverToBoxAdapter {}
+impl HotReloadCapability for RenderSliverToBoxAdapter {}
+
+impl RenderSliver for RenderSliverToBoxAdapter {
+    type Arity = Single;
+    type ParentData = SliverPhysicalParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Single, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        if ctx.child_count() == 0 {
+            self.geometry = SliverGeometry::ZERO;
+            ctx.complete(self.geometry);
+            return;
+        }
+
+        let child_size = ctx.layout_box_child(
+            0,
+            self.constraints
+                .as_box_constraints(0.0, f32::INFINITY, None),
+        );
+        let child_extent = match self.constraints.axis_direction {
+            LeftToRight | RightToLeft => child_size.width.get(),
+            TopToBottom | BottomToTop => child_size.height.get(),
+        };
+        let painted_child_size = self.calculate_paint_offset(&self.constraints, 0.0, child_extent);
+        let cache_extent = self.calculate_cache_offset(&self.constraints, 0.0, child_extent);
+
+        let geometry = SliverGeometry {
+            scroll_extent: child_extent,
+            paint_extent: painted_child_size,
+            layout_extent: painted_child_size,
+            max_paint_extent: child_extent,
+            cache_extent,
+            hit_test_extent: painted_child_size,
+            visible: painted_child_size > 0.0,
+            has_visual_overflow: child_extent > self.constraints.remaining_paint_extent
+                || self.constraints.scroll_offset > 0.0,
+            ..SliverGeometry::ZERO
+        };
+        let child_paint_offset = Self::child_paint_offset(&self.constraints, &geometry);
+        ctx.position_child(0, child_paint_offset);
+        self.geometry = geometry;
+        ctx.complete(geometry);
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn child_main_axis_position(
+        &self,
+        _child: &dyn crate::traits::RenderObject<crate::protocol::SliverProtocol>,
+    ) -> f32 {
+        -self.constraints.scroll_offset
+    }
+
+    fn paint(&self, ctx: &mut PaintCx<'_, Single>) {
+        if self.geometry.visible {
+            ctx.paint_child();
+        }
+    }
+
+    fn hit_test(&self, ctx: &mut SliverHitTestContext<'_, Single, Self::ParentData>) -> bool {
+        ctx.hit_test_child_at_layout_offset(0)
+    }
+}
+
+const fn apply_growth_direction_to_axis_direction(
+    axis_direction: AxisDirection,
+    growth_direction: GrowthDirection,
+) -> AxisDirection {
+    match growth_direction {
+        GrowthDirection::Forward => axis_direction,
+        GrowthDirection::Reverse => axis_direction.opposite(),
+    }
+}
+
+const fn empty_sliver_constraints() -> SliverConstraints {
+    SliverConstraints {
+        axis_direction: TopToBottom,
+        growth_direction: GrowthDirection::Forward,
+        user_scroll_direction: crate::view::ScrollDirection::Idle,
+        scroll_offset: 0.0,
+        preceding_scroll_extent: 0.0,
+        overlap: 0.0,
+        remaining_paint_extent: 0.0,
+        cross_axis_extent: 0.0,
+        cross_axis_direction: LeftToRight,
+        viewport_main_axis_extent: 0.0,
+        remaining_cache_extent: 0.0,
+        cache_origin: 0.0,
+    }
+}

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -745,6 +745,26 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
         }
     }
 
+    fn box_hit_offset_from_sliver_position(
+        constraints: &SliverConstraints,
+        position: MainAxisPosition,
+        offset: Offset,
+    ) -> Offset {
+        let absolute = match constraints.axis_direction {
+            flui_types::layout::AxisDirection::LeftToRight
+            | flui_types::layout::AxisDirection::RightToLeft => Offset::new(
+                flui_types::geometry::px(position.main_axis),
+                flui_types::geometry::px(position.cross_axis),
+            ),
+            flui_types::layout::AxisDirection::TopToBottom
+            | flui_types::layout::AxisDirection::BottomToTop => Offset::new(
+                flui_types::geometry::px(position.cross_axis),
+                flui_types::geometry::px(position.main_axis),
+            ),
+        };
+        absolute - offset
+    }
+
     fn hit_test_sliver_subtree(
         &self,
         id: RenderId,
@@ -804,6 +824,13 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
                     )
                 });
                 self.hit_test_sliver_subtree(child_id, child_position, result)
+            } else if child_node.as_box().is_some() {
+                let child_position = Self::box_hit_offset_from_sliver_position(
+                    constraints,
+                    override_pos.unwrap_or(position),
+                    child_node.offset(),
+                );
+                self.hit_test_subtree(child_id, child_position, result)
             } else {
                 false
             }
@@ -2593,6 +2620,7 @@ unsafe fn layout_sliver_subtree_borrowed_impl<'tree>(
     let descendant_error_flag: std::sync::Arc<std::sync::atomic::AtomicBool> =
         std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let descendant_error_for_cb = std::sync::Arc::clone(&descendant_error_flag);
+    let descendant_error_for_box_cb = std::sync::Arc::clone(&descendant_error_flag);
     let borrows_for_cb: &SubtreeBorrows<'_> = borrows;
 
     let cb_owned = move |child_id: RenderId,
@@ -2620,11 +2648,33 @@ unsafe fn layout_sliver_subtree_borrowed_impl<'tree>(
     };
     let cb_ref: SliverChildLayoutCallback<'_> = &cb_owned;
 
+    let box_cb_owned = move |child_id: RenderId, child_constraints: BoxConstraints| -> Size {
+        // SAFETY: same subtree-borrow contract as the sliver child callback,
+        // but routed through the Box layout walk for Sliver -> Box adapters.
+        match unsafe { layout_subtree_borrowed(borrows_for_cb, child_id, child_constraints) } {
+            Ok(size) => size,
+            Err(err) => {
+                descendant_error_for_box_cb.store(true, std::sync::atomic::Ordering::Relaxed);
+                tracing::error!(
+                    parent = ?id,
+                    ?child_id,
+                    ?err,
+                    "layout_dirty_root: box descendant layout failed from sliver parent; \
+                     returning Size::ZERO to caller's perform_layout. \
+                     Parent NEEDS_LAYOUT preserved for next-frame retry.",
+                );
+                Size::ZERO
+            }
+        }
+    };
+    let box_cb_ref: crate::protocol::sliver_protocol::BoxChildLayoutCallback<'_> = &box_cb_owned;
+
     let mut ctx = crate::protocol::ErasedSliverLayoutCtx::new(
         constraints,
         &mut child_states,
         &child_ids,
         cb_ref,
+        box_cb_ref,
     );
     let erased: &mut dyn SliverLayoutCtxErased = &mut ctx;
 

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -747,22 +747,54 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
 
     fn box_hit_offset_from_sliver_position(
         constraints: &SliverConstraints,
+        geometry: &SliverGeometry,
+        child_size: Size,
         position: MainAxisPosition,
         offset: Offset,
     ) -> Offset {
-        let absolute = match constraints.axis_direction {
+        let reversed = matches!(
+            constraints.axis_direction,
+            flui_types::layout::AxisDirection::RightToLeft
+                | flui_types::layout::AxisDirection::BottomToTop
+        );
+        let right_way_up = match constraints.growth_direction {
+            crate::constraints::GrowthDirection::Forward => !reversed,
+            crate::constraints::GrowthDirection::Reverse => reversed,
+        };
+
+        let (paint_main, paint_cross, child_main_extent) = match constraints.axis_direction {
+            flui_types::layout::AxisDirection::LeftToRight
+            | flui_types::layout::AxisDirection::RightToLeft => {
+                (offset.dx.get(), offset.dy.get(), child_size.width.get())
+            }
+            flui_types::layout::AxisDirection::TopToBottom
+            | flui_types::layout::AxisDirection::BottomToTop => {
+                (offset.dy.get(), offset.dx.get(), child_size.height.get())
+            }
+        };
+        let child_main_axis_position = if right_way_up {
+            paint_main
+        } else {
+            geometry.paint_extent - child_main_extent - paint_main
+        };
+        let mut local_main = position.main_axis - child_main_axis_position;
+        if !right_way_up {
+            local_main = child_main_extent - local_main;
+        }
+        let local_cross = position.cross_axis - paint_cross;
+
+        match constraints.axis_direction {
             flui_types::layout::AxisDirection::LeftToRight
             | flui_types::layout::AxisDirection::RightToLeft => Offset::new(
-                flui_types::geometry::px(position.main_axis),
-                flui_types::geometry::px(position.cross_axis),
+                flui_types::geometry::px(local_main),
+                flui_types::geometry::px(local_cross),
             ),
             flui_types::layout::AxisDirection::TopToBottom
             | flui_types::layout::AxisDirection::BottomToTop => Offset::new(
-                flui_types::geometry::px(position.cross_axis),
-                flui_types::geometry::px(position.main_axis),
+                flui_types::geometry::px(local_cross),
+                flui_types::geometry::px(local_main),
             ),
-        };
-        absolute - offset
+        }
     }
 
     fn hit_test_sliver_subtree(
@@ -824,9 +856,14 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
                     )
                 });
                 self.hit_test_sliver_subtree(child_id, child_position, result)
-            } else if child_node.as_box().is_some() {
+            } else if let Some(child_entry) = child_node.as_box() {
+                let Some(child_size) = child_entry.state().geometry() else {
+                    return false;
+                };
                 let child_position = Self::box_hit_offset_from_sliver_position(
                     constraints,
+                    &geometry,
+                    child_size,
                     override_pos.unwrap_or(position),
                     child_node.offset(),
                 );

--- a/crates/flui-rendering/src/protocol/sliver_protocol.rs
+++ b/crates/flui-rendering/src/protocol/sliver_protocol.rs
@@ -8,10 +8,13 @@
 
 use flui_foundation::RenderId;
 use flui_tree::Arity;
-use flui_types::geometry::{Matrix4, Offset, Rect};
+use flui_types::{
+    Size,
+    geometry::{Matrix4, Offset, Rect},
+};
 
 use crate::{
-    constraints::{Constraints, SliverConstraints, SliverGeometry},
+    constraints::{BoxConstraints, Constraints, SliverConstraints, SliverGeometry},
     parent_data::{ParentData, SliverParentData},
     protocol::{
         box_protocol::BoxProtocol,
@@ -181,6 +184,9 @@ impl<P: ParentData + Default> SliverChildState<P> {
 pub type SliverChildLayoutCallback<'a> =
     &'a (dyn Fn(RenderId, SliverConstraints) -> SliverGeometry + Send + Sync);
 
+/// Callback type for cross-protocol box child layout driven by a Sliver parent.
+pub type BoxChildLayoutCallback<'a> = &'a (dyn Fn(RenderId, BoxConstraints) -> Size + Send + Sync);
+
 /// Dense per-child geometry cache used by Proxy storage.
 type ProxySliverChildGeometryCache = Vec<Option<SliverGeometry>>;
 
@@ -239,6 +245,7 @@ enum SliverLayoutCtxStorage<'ctx, P: ParentData + Default> {
         children: Option<&'ctx mut Vec<SliverChildState<P>>>,
         child_ids: Option<&'ctx [RenderId]>,
         layout_child_callback: Option<SliverChildLayoutCallback<'ctx>>,
+        layout_box_child_callback: Option<BoxChildLayoutCallback<'ctx>>,
     },
     /// Bridge path: wraps the erased context from the pipeline boundary.
     ///
@@ -267,6 +274,7 @@ impl<'ctx, A: Arity, P: ParentData + Default> SliverLayoutCtx<'ctx, A, P> {
                 children: None,
                 child_ids: None,
                 layout_child_callback: None,
+                layout_box_child_callback: None,
             },
             _phantom: std::marker::PhantomData,
         }
@@ -284,6 +292,7 @@ impl<'ctx, A: Arity, P: ParentData + Default> SliverLayoutCtx<'ctx, A, P> {
                 children: Some(children),
                 child_ids: None,
                 layout_child_callback: None,
+                layout_box_child_callback: None,
             },
             _phantom: std::marker::PhantomData,
         }
@@ -295,6 +304,7 @@ impl<'ctx, A: Arity, P: ParentData + Default> SliverLayoutCtx<'ctx, A, P> {
         children: &'ctx mut Vec<SliverChildState<P>>,
         child_ids: &'ctx [RenderId],
         layout_child_callback: SliverChildLayoutCallback<'ctx>,
+        layout_box_child_callback: Option<BoxChildLayoutCallback<'ctx>>,
     ) -> Self {
         Self {
             storage: SliverLayoutCtxStorage::Direct {
@@ -303,6 +313,7 @@ impl<'ctx, A: Arity, P: ParentData + Default> SliverLayoutCtx<'ctx, A, P> {
                 children: Some(children),
                 child_ids: Some(child_ids),
                 layout_child_callback: Some(layout_child_callback),
+                layout_box_child_callback,
             },
             _phantom: std::marker::PhantomData,
         }
@@ -404,6 +415,28 @@ impl<'ctx, A: Arity, P: ParentData + Default> SliverLayoutCtx<'ctx, A, P> {
         match &self.storage {
             SliverLayoutCtxStorage::Direct { constraints, .. }
             | SliverLayoutCtxStorage::Proxy { constraints, .. } => constraints.cross_axis_extent,
+        }
+    }
+
+    /// Lays out a Box-protocol child of this Sliver parent.
+    pub fn layout_box_child(&mut self, index: usize, constraints: BoxConstraints) -> Size {
+        match &mut self.storage {
+            SliverLayoutCtxStorage::Direct {
+                child_ids,
+                layout_box_child_callback,
+                ..
+            } => {
+                if let (Some(child_ids), Some(callback)) =
+                    (*child_ids, layout_box_child_callback.as_ref())
+                    && let Some(&child_id) = child_ids.get(index)
+                {
+                    return callback(child_id, constraints);
+                }
+                Size::ZERO
+            }
+            SliverLayoutCtxStorage::Proxy { erased, .. } => {
+                erased.layout_box_child(index, constraints)
+            }
         }
     }
 }
@@ -573,6 +606,9 @@ pub trait SliverLayoutCtxErased: Send + Sync {
     /// constraints; returns the child's computed [`SliverGeometry`].
     fn layout_child(&mut self, index: usize, constraints: SliverConstraints) -> SliverGeometry;
 
+    /// Performs synchronous Box layout on child at `index`.
+    fn layout_box_child(&mut self, index: usize, constraints: BoxConstraints) -> Size;
+
     /// Records the paint offset for child at `index`.
     fn position_child(&mut self, index: usize, offset: Offset);
 
@@ -622,6 +658,11 @@ impl<A: Arity, P: ParentData + Default> SliverLayoutCtxErased for SliverLayoutCt
     #[inline]
     fn layout_child(&mut self, index: usize, constraints: SliverConstraints) -> SliverGeometry {
         <Self as LayoutContextApi<'_, SliverLayout, A, P>>::layout_child(self, index, constraints)
+    }
+
+    #[inline]
+    fn layout_box_child(&mut self, index: usize, constraints: BoxConstraints) -> Size {
+        SliverLayoutCtx::layout_box_child(self, index, constraints)
     }
 
     #[inline]
@@ -708,6 +749,7 @@ pub struct ErasedSliverLayoutCtx<'ctx> {
     children: &'ctx mut Vec<ErasedSliverChildState>,
     child_ids: &'ctx [RenderId],
     layout_child_callback: SliverChildLayoutCallback<'ctx>,
+    layout_box_child_callback: BoxChildLayoutCallback<'ctx>,
 }
 
 impl<'ctx> ErasedSliverLayoutCtx<'ctx> {
@@ -717,6 +759,7 @@ impl<'ctx> ErasedSliverLayoutCtx<'ctx> {
         children: &'ctx mut Vec<ErasedSliverChildState>,
         child_ids: &'ctx [RenderId],
         layout_child_callback: SliverChildLayoutCallback<'ctx>,
+        layout_box_child_callback: BoxChildLayoutCallback<'ctx>,
     ) -> Self {
         Self {
             constraints,
@@ -724,6 +767,7 @@ impl<'ctx> ErasedSliverLayoutCtx<'ctx> {
             children,
             child_ids,
             layout_child_callback,
+            layout_box_child_callback,
         }
     }
 
@@ -751,6 +795,13 @@ impl SliverLayoutCtxErased for ErasedSliverLayoutCtx<'_> {
             slot.geometry = geometry;
         }
         geometry
+    }
+
+    fn layout_box_child(&mut self, index: usize, constraints: BoxConstraints) -> Size {
+        let Some(&child_id) = self.child_ids.get(index) else {
+            return Size::ZERO;
+        };
+        (self.layout_box_child_callback)(child_id, constraints)
     }
 
     fn position_child(&mut self, index: usize, offset: Offset) {

--- a/crates/flui-rendering/tests/paint_fragment_snapshot.rs
+++ b/crates/flui-rendering/tests/paint_fragment_snapshot.rs
@@ -24,7 +24,8 @@ use flui_rendering::{
     constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
     context::{BoxHitTestContext, BoxLayoutContext, SliverHitTestContext, SliverLayoutContext},
     objects::{
-        RenderClipRect, RenderColoredBox, RenderPadding, RenderRepaintBoundary, RenderSliverPadding,
+        RenderClipRect, RenderColoredBox, RenderPadding, RenderRepaintBoundary,
+        RenderSliverPadding, RenderSliverToBoxAdapter,
     },
     parent_data::{BoxParentData, SliverParentData},
     pipeline::PipelineOwner,
@@ -464,6 +465,49 @@ fn box_host_splices_sliver_leaf_paint_into_picture() {
     assert_eq!(
         first_picture(&tree).bounds(),
         Rect::from_origin_size(Point::ZERO, Size::new(px(100.0), px(80.0))),
+    );
+}
+
+#[test]
+fn box_host_splices_sliver_to_box_adapter_child_at_paint_offset() {
+    let mut constraints = sliver_paint_constraints();
+    constraints.scroll_offset = 40.0;
+
+    let mut owner = PipelineOwner::new();
+    let host_id = owner.insert(Box::new(SliverPaintHost {
+        constraints,
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let adapter_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            host_id,
+            Box::new(RenderSliverToBoxAdapter::new()) as BoxedSliverObject,
+        )
+        .expect("sliver adapter child");
+    owner
+        .render_tree_mut()
+        .insert_box_child(
+            adapter_id,
+            Box::new(RenderColoredBox::red(100.0, 80.0)) as BoxedRenderObject,
+        )
+        .expect("box child");
+
+    owner.set_root_id(Some(host_id));
+    owner.set_root_constraints(Some(BoxConstraints::new(
+        px(0.0),
+        px(200.0),
+        px(0.0),
+        px(200.0),
+    )));
+
+    let (tree, _owner) = paint_frame(owner);
+
+    assert_eq!(
+        first_picture(&tree).bounds(),
+        Rect::from_ltrb(px(0.0), px(-40.0), px(100.0), px(40.0)),
+        "RenderSliverToBoxAdapter paint must compose its Box child at \
+         the same -scroll_offset paint offset committed during layout",
     );
 }
 

--- a/crates/flui-rendering/tests/sliver_to_box_adapter.rs
+++ b/crates/flui-rendering/tests/sliver_to_box_adapter.rs
@@ -132,9 +132,86 @@ impl RenderBox for FixedHitBox {
 }
 
 #[derive(Debug)]
+struct VerticalBandHitBox {
+    size: Size,
+}
+
+impl VerticalBandHitBox {
+    fn new() -> Self {
+        Self { size: Size::ZERO }
+    }
+}
+
+impl flui_foundation::Diagnosticable for VerticalBandHitBox {}
+impl PaintEffectsCapability for VerticalBandHitBox {}
+impl SemanticsCapability for VerticalBandHitBox {}
+impl HotReloadCapability for VerticalBandHitBox {}
+
+impl RenderBox for VerticalBandHitBox {
+    type Arity = Leaf;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.size = ctx.constraints().constrain(Size::new(px(300.0), px(180.0)));
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+
+    fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+        let local = ctx.offset();
+        local.dx >= px(0.0)
+            && local.dx < self.size.width
+            && local.dy >= px(120.0)
+            && local.dy < px(140.0)
+    }
+}
+
+#[derive(Debug)]
 struct SliverHost {
     constraints: SliverConstraints,
     size: Size,
+}
+
+#[test]
+fn sliver_to_box_adapter_reverse_growth_hit_tests_box_child_right_way_up() {
+    let mut constraints = vertical_constraints(40.0);
+    constraints.growth_direction = GrowthDirection::Reverse;
+
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(SliverHost {
+        constraints,
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let adapter_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(RenderSliverToBoxAdapter::new()) as BoxedSliverObject,
+        )
+        .expect("sliver adapter child");
+    let child_id = owner
+        .render_tree_mut()
+        .insert_box_child(
+            adapter_id,
+            Box::new(VerticalBandHitBox::new()) as BoxedRenderObject,
+        )
+        .expect("box child under sliver adapter");
+
+    let owner = laid_out(owner, root_id);
+
+    assert_eq!(
+        hits(&owner, 10.0, 10.0),
+        vec![child_id, adapter_id, root_id],
+        "reverse growth must mirror Flutter RenderSliverHelpers::hitTestBoxChild: \
+         main=10 maps to child-local y=130, not y=50",
+    );
 }
 
 impl flui_foundation::Diagnosticable for SliverHost {}

--- a/crates/flui-rendering/tests/sliver_to_box_adapter.rs
+++ b/crates/flui-rendering/tests/sliver_to_box_adapter.rs
@@ -1,0 +1,263 @@
+//! Cross-protocol child layout — Sliver parent lays out a Box child.
+//!
+//! Core.2 W3.3: verifies the reverse bridge of PR #187/#188. A
+//! `RenderSliverToBoxAdapter` is a Sliver-protocol parent with a
+//! Box-protocol child. It must:
+//!
+//! 1. derive tight-cross-axis `BoxConstraints` from `SliverConstraints`;
+//! 2. lay out the Box child through the pipeline's Sliver -> Box callback;
+//! 3. compose Flutter-parity sliver geometry from the child's main-axis size;
+//! 4. commit the child's paint offset so hit-test/paint use the same source.
+
+use flui_rendering::{
+    constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
+    context::{BoxHitTestContext, BoxLayoutContext},
+    hit_testing::HitTestResult,
+    objects::RenderSliverToBoxAdapter,
+    parent_data::BoxParentData,
+    pipeline::PipelineOwner,
+    protocol::{BoxProtocol, SliverProtocol},
+    traits::{
+        HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, SemanticsCapability,
+    },
+    view::ScrollDirection,
+};
+use flui_tree::Leaf;
+use flui_types::{Offset, Rect, Size, geometry::px, layout::AxisDirection};
+
+type BoxedRenderObject = Box<dyn RenderObject<BoxProtocol>>;
+type BoxedSliverObject = Box<dyn RenderObject<SliverProtocol>>;
+
+fn vertical_constraints(scroll_offset: f32) -> SliverConstraints {
+    SliverConstraints {
+        axis_direction: AxisDirection::TopToBottom,
+        cross_axis_direction: AxisDirection::LeftToRight,
+        growth_direction: GrowthDirection::Forward,
+        user_scroll_direction: ScrollDirection::Idle,
+        scroll_offset,
+        preceding_scroll_extent: 0.0,
+        overlap: 0.0,
+        remaining_paint_extent: 100.0,
+        cross_axis_extent: 300.0,
+        viewport_main_axis_extent: 100.0,
+        remaining_cache_extent: 120.0,
+        cache_origin: -20.0,
+    }
+}
+
+fn laid_out(
+    mut owner: PipelineOwner,
+    root: flui_foundation::RenderId,
+) -> PipelineOwner<flui_rendering::pipeline::phase::Layout> {
+    owner.set_root_id(Some(root));
+    owner.set_root_constraints(Some(BoxConstraints::tight(Size::new(px(300.0), px(100.0)))));
+    let mut owner = owner.into_layout();
+    owner.run_layout().expect("layout succeeds");
+    owner
+}
+
+fn sliver_geometry(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    id: flui_foundation::RenderId,
+) -> SliverGeometry {
+    owner
+        .render_tree()
+        .get(id)
+        .and_then(|node| node.as_sliver())
+        .and_then(|entry| entry.state().geometry())
+        .expect("sliver geometry is committed")
+}
+
+fn render_offset(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    id: flui_foundation::RenderId,
+) -> Offset {
+    owner
+        .render_tree()
+        .get(id)
+        .map(flui_rendering::storage::RenderNode::offset)
+        .expect("node exists")
+}
+
+fn hits(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    cross: f32,
+    main: f32,
+) -> Vec<flui_foundation::RenderId> {
+    let mut result = HitTestResult::new();
+    owner.hit_test(Offset::new(px(cross), px(main)), &mut result);
+    result.path().iter().map(|entry| entry.target).collect()
+}
+
+#[derive(Debug)]
+struct FixedHitBox {
+    desired: Size,
+    size: Size,
+}
+
+impl FixedHitBox {
+    fn new(width: f32, height: f32) -> Self {
+        Self {
+            desired: Size::new(px(width), px(height)),
+            size: Size::ZERO,
+        }
+    }
+}
+
+impl flui_foundation::Diagnosticable for FixedHitBox {}
+impl PaintEffectsCapability for FixedHitBox {}
+impl SemanticsCapability for FixedHitBox {}
+impl HotReloadCapability for FixedHitBox {}
+
+impl RenderBox for FixedHitBox {
+    type Arity = Leaf;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.size = ctx.constraints().constrain(self.desired);
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+
+    fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+        ctx.is_within_bounds(Rect::from_origin_size(flui_types::Point::ZERO, self.size))
+    }
+}
+
+#[derive(Debug)]
+struct SliverHost {
+    constraints: SliverConstraints,
+    size: Size,
+}
+
+impl flui_foundation::Diagnosticable for SliverHost {}
+impl PaintEffectsCapability for SliverHost {}
+impl SemanticsCapability for SliverHost {}
+impl HotReloadCapability for SliverHost {}
+
+impl RenderBox for SliverHost {
+    type Arity = flui_tree::Variable;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(
+        &mut self,
+        ctx: &mut BoxLayoutContext<'_, flui_tree::Variable, Self::ParentData>,
+    ) {
+        if ctx.child_count() > 0 {
+            let _ = ctx.layout_sliver_child(0, self.constraints);
+        }
+        self.size = ctx.constraints().biggest();
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+
+    fn hit_test(
+        &self,
+        ctx: &mut BoxHitTestContext<'_, flui_tree::Variable, Self::ParentData>,
+    ) -> bool {
+        ctx.hit_test_child(0, ctx.offset())
+    }
+}
+
+#[test]
+fn sliver_constraints_as_box_constraints_tightens_cross_axis_vertically() {
+    let constraints = vertical_constraints(0.0);
+
+    let box_constraints = constraints.as_box_constraints(0.0, f32::INFINITY, None);
+
+    assert_eq!(box_constraints.min_width, px(300.0));
+    assert_eq!(box_constraints.max_width, px(300.0));
+    assert_eq!(box_constraints.min_height, px(0.0));
+    assert_eq!(box_constraints.max_height, px(f32::INFINITY));
+}
+
+#[test]
+fn sliver_to_box_adapter_lays_out_box_child_and_commits_geometry() {
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(SliverHost {
+        constraints: vertical_constraints(40.0),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let adapter_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(RenderSliverToBoxAdapter::new()) as BoxedSliverObject,
+        )
+        .expect("sliver adapter child");
+    let child_id = owner
+        .render_tree_mut()
+        .insert_box_child(
+            adapter_id,
+            Box::new(FixedHitBox::new(50.0, 180.0)) as BoxedRenderObject,
+        )
+        .expect("box child under sliver adapter");
+
+    let owner = laid_out(owner, root_id);
+
+    let geometry = sliver_geometry(&owner, adapter_id);
+    assert_eq!(geometry.scroll_extent, 180.0);
+    assert_eq!(geometry.paint_extent, 100.0);
+    assert_eq!(geometry.cache_extent, 120.0);
+    assert_eq!(geometry.max_paint_extent, 180.0);
+    assert_eq!(geometry.hit_test_extent, 100.0);
+    assert!(
+        geometry.has_visual_overflow,
+        "child extends beyond remaining paint extent and scroll_offset > 0",
+    );
+    assert_eq!(
+        render_offset(&owner, child_id),
+        Offset::new(px(0.0), px(-40.0)),
+        "forward vertical adapter positions the Box child at -scroll_offset",
+    );
+}
+
+#[test]
+fn sliver_to_box_adapter_hit_tests_box_child_leaf_first() {
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(SliverHost {
+        constraints: vertical_constraints(40.0),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let adapter_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(RenderSliverToBoxAdapter::new()) as BoxedSliverObject,
+        )
+        .expect("sliver adapter child");
+    let child_id = owner
+        .render_tree_mut()
+        .insert_box_child(
+            adapter_id,
+            Box::new(FixedHitBox::new(50.0, 180.0)) as BoxedRenderObject,
+        )
+        .expect("box child under sliver adapter");
+
+    let owner = laid_out(owner, root_id);
+
+    assert_eq!(
+        hits(&owner, 10.0, 10.0),
+        vec![child_id, adapter_id, root_id],
+        "global main=10 maps to child-local y=50 through the committed \
+         -scroll_offset paint offset",
+    );
+    assert!(
+        hits(&owner, 10.0, 120.0).is_empty(),
+        "per-level sliver gate rejects points beyond geometry.hit_test_extent",
+    );
+}


### PR DESCRIPTION
## Summary
- add Flutter-parity `SliverConstraints::as_box_constraints`
- wire Sliver -> Box child layout through the erased sliver layout context and pipeline subtree walk
- add `RenderSliverToBoxAdapter` with geometry, committed paint offsets, paint, and hit-test behavior
- cover layout, hit-test, and paint-offset snapshots for Box children hosted by Slivers

## Validation
- cargo fmt --package flui-rendering -- --check
- cargo test -p flui-rendering --test sliver_to_box_adapter
- cargo test -p flui-rendering --test paint_fragment_snapshot
- cargo test -p flui-rendering --test cross_protocol_layout
- cargo test -p flui-rendering --test hit_test_pipeline
- cargo test -p flui-rendering --lib
- cargo test -p flui-rendering
- cargo clippy -p flui-rendering --all-targets -- -D warnings