### PR TITLE
Core.2 Sliver W3.4a: add minimal render viewport

### DIFF
--- a/crates/flui-rendering/src/context/layout.rs
+++ b/crates/flui-rendering/src/context/layout.rs
@@ -373,6 +373,26 @@ where
             constraints,
         )
     }
+
+    /// Returns the last known sliver constraints and geometry for a sliver
+    /// child, when the production pipeline has cached them.
+    pub fn cached_sliver_child_layout(
+        &self,
+        index: usize,
+    ) -> Option<(SliverConstraints, SliverGeometry)> {
+        crate::protocol::box_protocol::BoxLayoutCtxErased::cached_sliver_child_layout(
+            &self.inner,
+            index,
+        )
+    }
+
+    /// Returns whether a sliver child is still marked as needing layout.
+    pub fn sliver_child_needs_layout(&self, index: usize) -> bool {
+        crate::protocol::box_protocol::BoxLayoutCtxErased::sliver_child_needs_layout(
+            &self.inner,
+            index,
+        )
+    }
 }
 
 // ============================================================================

--- a/crates/flui-rendering/src/objects/mod.rs
+++ b/crates/flui-rendering/src/objects/mod.rs
@@ -50,6 +50,8 @@
 //!   skipped paint, no hit-test) (Core.2 Wave 5a)
 //! - [`RenderSliverToBoxAdapter`] - Wraps one Box child in Sliver
 //!   protocol geometry (Core.2 W3.3)
+//! - [`RenderViewport`] - Box viewport that drives Sliver children
+//!   (Core.2 W3.4a)
 //!
 //! # Example
 //!
@@ -91,6 +93,7 @@ mod sliver_padding;
 mod sliver_to_box_adapter;
 mod stack;
 mod transform;
+mod viewport;
 
 pub use absorb_pointer::RenderAbsorbPointer;
 pub use aspect_ratio::{AspectRatio, RenderAspectRatio};
@@ -123,3 +126,4 @@ pub use sliver_padding::RenderSliverPadding;
 pub use sliver_to_box_adapter::RenderSliverToBoxAdapter;
 pub use stack::{PositionedSpec, RenderStack, StackFit};
 pub use transform::RenderTransform;
+pub use viewport::RenderViewport;

--- a/crates/flui-rendering/src/objects/viewport.rs
+++ b/crates/flui-rendering/src/objects/viewport.rs
@@ -1,0 +1,442 @@
+//! `RenderViewport` — Box render object that drives sliver children.
+//!
+//! This is the first Core.2 W3.4 slice: a forward, non-shrink-wrapping
+//! viewport with a bounded correction loop. It is intentionally smaller than
+//! Flutter's full `RenderViewport`: center/anchor reverse-side layout,
+//! shrink-wrap, `showOnScreen`, and lazy child creation stay out of this PR.
+
+use flui_foundation::Diagnosticable;
+use flui_tree::Variable;
+use flui_types::{
+    Offset, Point, Rect, Size,
+    geometry::px,
+    layout::{Axis, AxisDirection, AxisDirection::*},
+    painting::Clip,
+};
+
+use crate::{
+    constraints::{GrowthDirection, SliverConstraints, SliverGeometry},
+    context::{BoxHitTestContext, BoxLayoutContext, PaintCx},
+    parent_data::BoxParentData,
+    traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability},
+    view::{
+        CacheExtentStyle, ScrollDirection, ScrollableViewportOffset, SliverPaintOrder,
+        ViewportOffset,
+    },
+};
+
+const MAX_LAYOUT_CYCLES_PER_CHILD: usize = 10;
+const DEFAULT_CACHE_EXTENT: f32 = 250.0;
+
+/// A Box-protocol viewport that lays out Sliver-protocol children.
+#[derive(Debug)]
+pub struct RenderViewport<O = ScrollableViewportOffset> {
+    axis_direction: AxisDirection,
+    cross_axis_direction: AxisDirection,
+    offset: O,
+    cache_extent: f32,
+    cache_extent_style: CacheExtentStyle,
+    paint_order: SliverPaintOrder,
+    size: Size,
+    child_count: usize,
+    min_scroll_extent: f32,
+    max_scroll_extent: f32,
+    has_visual_overflow: bool,
+}
+
+impl RenderViewport<ScrollableViewportOffset> {
+    /// Creates a viewport with a zero scrollable offset.
+    #[inline]
+    #[must_use]
+    pub fn new(axis_direction: AxisDirection) -> Self {
+        Self::with_offset(
+            axis_direction,
+            default_cross_axis_direction(axis_direction),
+            ScrollableViewportOffset::zero(),
+        )
+    }
+}
+
+impl<O: ViewportOffset + 'static> RenderViewport<O> {
+    /// Creates a viewport with explicit axis directions and offset storage.
+    #[inline]
+    #[must_use]
+    pub fn with_offset(
+        axis_direction: AxisDirection,
+        cross_axis_direction: AxisDirection,
+        offset: O,
+    ) -> Self {
+        Self {
+            axis_direction,
+            cross_axis_direction,
+            offset,
+            cache_extent: DEFAULT_CACHE_EXTENT,
+            cache_extent_style: CacheExtentStyle::Pixel,
+            paint_order: SliverPaintOrder::FirstIsTop,
+            size: Size::ZERO,
+            child_count: 0,
+            min_scroll_extent: 0.0,
+            max_scroll_extent: 0.0,
+            has_visual_overflow: false,
+        }
+    }
+
+    /// Last laid-out viewport size.
+    #[inline]
+    #[must_use]
+    pub const fn size(&self) -> &Size {
+        &self.size
+    }
+
+    /// Returns the viewport offset object.
+    #[inline]
+    #[must_use]
+    pub const fn offset(&self) -> &O {
+        &self.offset
+    }
+
+    /// Mutable access to the viewport offset object.
+    #[inline]
+    #[must_use]
+    pub const fn offset_mut(&mut self) -> &mut O {
+        &mut self.offset
+    }
+
+    /// Sets the sliver paint order. Hit testing uses the opposite order.
+    #[inline]
+    pub const fn set_paint_order(&mut self, paint_order: SliverPaintOrder) {
+        self.paint_order = paint_order;
+    }
+
+    /// Sets the cache extent and interpretation mode.
+    #[inline]
+    pub const fn set_cache_extent(&mut self, cache_extent: f32, style: CacheExtentStyle) {
+        self.cache_extent = cache_extent;
+        self.cache_extent_style = style;
+    }
+
+    /// Last total scroll extent reported by the forward sliver sequence.
+    #[inline]
+    #[must_use]
+    pub const fn max_scroll_extent(&self) -> f32 {
+        self.max_scroll_extent
+    }
+
+    fn calculated_cache_extent(&self, main_axis_extent: f32) -> f32 {
+        match self.cache_extent_style {
+            CacheExtentStyle::Pixel => self.cache_extent.max(0.0),
+            CacheExtentStyle::Viewport => (self.cache_extent * main_axis_extent).max(0.0),
+        }
+    }
+
+    fn main_axis_extent(&self) -> f32 {
+        match self.axis_direction.axis() {
+            Axis::Horizontal => self.size.width.get(),
+            Axis::Vertical => self.size.height.get(),
+        }
+    }
+
+    fn cross_axis_extent(&self) -> f32 {
+        match self.axis_direction.axis() {
+            Axis::Horizontal => self.size.height.get(),
+            Axis::Vertical => self.size.width.get(),
+        }
+    }
+
+    fn attempt_layout(
+        &mut self,
+        ctx: &mut BoxLayoutContext<'_, Variable, BoxParentData>,
+        main_axis_extent: f32,
+        cross_axis_extent: f32,
+        corrected_offset: f32,
+    ) -> f32 {
+        self.min_scroll_extent = 0.0;
+        self.max_scroll_extent = 0.0;
+        self.has_visual_overflow = false;
+
+        let center_offset = -corrected_offset;
+        let cache_extent = self.calculated_cache_extent(main_axis_extent);
+        let full_cache_extent = main_axis_extent + 2.0 * cache_extent;
+        let center_cache_offset = center_offset + cache_extent;
+        let remaining_cache_extent =
+            (full_cache_extent - center_cache_offset).clamp(0.0, full_cache_extent);
+
+        self.layout_child_sequence(
+            ctx,
+            corrected_offset.max(0.0),
+            center_offset.min(0.0),
+            0.0,
+            main_axis_extent,
+            main_axis_extent,
+            cross_axis_extent,
+            GrowthDirection::Forward,
+            remaining_cache_extent,
+            center_offset.clamp(-cache_extent, 0.0),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn layout_child_sequence(
+        &mut self,
+        ctx: &mut BoxLayoutContext<'_, Variable, BoxParentData>,
+        mut scroll_offset: f32,
+        overlap: f32,
+        mut layout_offset: f32,
+        remaining_paint_extent: f32,
+        main_axis_extent: f32,
+        cross_axis_extent: f32,
+        growth_direction: GrowthDirection,
+        mut remaining_cache_extent: f32,
+        mut cache_origin: f32,
+    ) -> f32 {
+        let initial_layout_offset = layout_offset;
+        let adjusted_user_scroll_direction = apply_growth_direction_to_scroll_direction(
+            self.offset.user_scroll_direction(),
+            growth_direction,
+        );
+        let mut max_paint_offset = layout_offset + overlap;
+        let mut preceding_scroll_extent = 0.0;
+
+        for index in 0..ctx.child_count() {
+            let sliver_scroll_offset = if scroll_offset <= 0.0 {
+                0.0
+            } else {
+                scroll_offset
+            };
+            let corrected_cache_origin = cache_origin.max(-sliver_scroll_offset);
+            let cache_extent_correction = cache_origin - corrected_cache_origin;
+
+            let geometry = ctx.layout_sliver_child(
+                index,
+                SliverConstraints {
+                    axis_direction: self.axis_direction,
+                    growth_direction,
+                    user_scroll_direction: adjusted_user_scroll_direction,
+                    scroll_offset: sliver_scroll_offset,
+                    preceding_scroll_extent,
+                    overlap: max_paint_offset - layout_offset,
+                    remaining_paint_extent: (remaining_paint_extent - layout_offset
+                        + initial_layout_offset)
+                        .max(0.0),
+                    cross_axis_extent,
+                    cross_axis_direction: self.cross_axis_direction,
+                    viewport_main_axis_extent: main_axis_extent,
+                    remaining_cache_extent: (remaining_cache_extent + cache_extent_correction)
+                        .max(0.0),
+                    cache_origin: corrected_cache_origin,
+                },
+            );
+
+            if let Some(correction) = geometry.scroll_offset_correction {
+                return correction;
+            }
+
+            let effective_layout_offset = layout_offset + geometry.paint_origin;
+            let child_layout_offset = if geometry.visible || scroll_offset > 0.0 {
+                effective_layout_offset
+            } else {
+                -scroll_offset + initial_layout_offset
+            };
+            ctx.position_child(
+                index,
+                self.compute_absolute_paint_offset(
+                    child_layout_offset,
+                    growth_direction,
+                    geometry.paint_extent,
+                ),
+            );
+
+            max_paint_offset =
+                max_paint_offset.max(effective_layout_offset + geometry.paint_extent);
+            scroll_offset -= geometry.scroll_extent;
+            preceding_scroll_extent += geometry.scroll_extent;
+            layout_offset += geometry.layout_extent;
+
+            if geometry.cache_extent != 0.0 {
+                remaining_cache_extent -= geometry.cache_extent - cache_extent_correction;
+                cache_origin = (corrected_cache_origin + geometry.cache_extent).min(0.0);
+            }
+
+            self.update_out_of_band_data(growth_direction, geometry);
+        }
+
+        0.0
+    }
+
+    fn update_out_of_band_data(
+        &mut self,
+        growth_direction: GrowthDirection,
+        geometry: SliverGeometry,
+    ) {
+        match growth_direction {
+            GrowthDirection::Forward => {
+                self.max_scroll_extent += geometry.scroll_extent;
+            }
+            GrowthDirection::Reverse => {
+                self.min_scroll_extent -= geometry.scroll_extent;
+            }
+        }
+        if geometry.has_visual_overflow {
+            self.has_visual_overflow = true;
+        }
+    }
+
+    fn compute_absolute_paint_offset(
+        &self,
+        layout_offset: f32,
+        growth_direction: GrowthDirection,
+        paint_extent: f32,
+    ) -> Offset {
+        match apply_growth_direction_to_axis_direction(self.axis_direction, growth_direction) {
+            TopToBottom => Offset::new(px(0.0), px(layout_offset)),
+            BottomToTop => Offset::new(
+                px(0.0),
+                px(self.size.height.get() - layout_offset - paint_extent),
+            ),
+            LeftToRight => Offset::new(px(layout_offset), px(0.0)),
+            RightToLeft => Offset::new(
+                px(self.size.width.get() - layout_offset - paint_extent),
+                px(0.0),
+            ),
+        }
+    }
+
+    fn viewport_rect(&self) -> Rect {
+        Rect::from_origin_size(Point::ZERO, self.size)
+    }
+}
+
+impl Default for RenderViewport<ScrollableViewportOffset> {
+    fn default() -> Self {
+        Self::new(TopToBottom)
+    }
+}
+
+impl<O: ViewportOffset + 'static> Diagnosticable for RenderViewport<O> {}
+impl<O: ViewportOffset + 'static> PaintEffectsCapability for RenderViewport<O> {}
+impl<O: ViewportOffset + 'static> SemanticsCapability for RenderViewport<O> {}
+impl<O: ViewportOffset + 'static> HotReloadCapability for RenderViewport<O> {}
+
+impl<O: ViewportOffset + 'static> RenderBox for RenderViewport<O> {
+    type Arity = Variable;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Variable, Self::ParentData>) {
+        self.size = ctx.constraints().biggest();
+        let main_axis_extent = self.main_axis_extent();
+        let cross_axis_extent = self.cross_axis_extent();
+        self.child_count = ctx.child_count();
+        let _ = self.offset.apply_viewport_dimension(main_axis_extent);
+
+        if ctx.child_count() == 0 {
+            self.min_scroll_extent = 0.0;
+            self.max_scroll_extent = 0.0;
+            self.has_visual_overflow = false;
+            let _ = self.offset.apply_content_dimensions(0.0, 0.0);
+            ctx.complete_with_size(self.size);
+            return;
+        }
+
+        let max_layout_cycles = MAX_LAYOUT_CYCLES_PER_CHILD * ctx.child_count();
+        let mut accepted = false;
+        for _ in 0..max_layout_cycles {
+            let correction = self.attempt_layout(
+                ctx,
+                main_axis_extent,
+                cross_axis_extent,
+                self.offset.pixels(),
+            );
+            if correction != 0.0 {
+                self.offset.correct_by(correction);
+                continue;
+            }
+
+            if self
+                .offset
+                .apply_content_dimensions(0.0, (self.max_scroll_extent - main_axis_extent).max(0.0))
+            {
+                accepted = true;
+                break;
+            }
+        }
+        debug_assert!(
+            accepted,
+            "RenderViewport exceeded its bounded layout correction loop"
+        );
+
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+
+    fn paint(&self, ctx: &mut PaintCx<'_, Variable>) {
+        let paint_children = |ctx: &mut PaintCx<'_, Variable>| match self.paint_order {
+            SliverPaintOrder::FirstIsTop => ctx.paint_children_reverse(),
+            SliverPaintOrder::LastIsTop => ctx.paint_children(),
+        };
+
+        if self.has_visual_overflow {
+            ctx.with_clip_rect(self.viewport_rect(), Clip::HardEdge, paint_children);
+        } else {
+            paint_children(ctx);
+        }
+    }
+
+    fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Variable, Self::ParentData>) -> bool {
+        if !ctx.is_within_size(self.size.width, self.size.height) {
+            return false;
+        }
+
+        match self.paint_order {
+            SliverPaintOrder::FirstIsTop => {
+                for index in 0..self.child_count {
+                    if ctx.hit_test_child_at_layout_offset(index) {
+                        return true;
+                    }
+                }
+            }
+            SliverPaintOrder::LastIsTop => {
+                for index in (0..self.child_count).rev() {
+                    if ctx.hit_test_child_at_layout_offset(index) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        false
+    }
+}
+
+const fn default_cross_axis_direction(axis_direction: AxisDirection) -> AxisDirection {
+    match axis_direction {
+        TopToBottom | BottomToTop => LeftToRight,
+        LeftToRight | RightToLeft => TopToBottom,
+    }
+}
+
+const fn apply_growth_direction_to_axis_direction(
+    axis_direction: AxisDirection,
+    growth_direction: GrowthDirection,
+) -> AxisDirection {
+    match growth_direction {
+        GrowthDirection::Forward => axis_direction,
+        GrowthDirection::Reverse => axis_direction.opposite(),
+    }
+}
+
+fn apply_growth_direction_to_scroll_direction(
+    scroll_direction: ScrollDirection,
+    growth_direction: GrowthDirection,
+) -> ScrollDirection {
+    match growth_direction {
+        GrowthDirection::Forward => scroll_direction,
+        GrowthDirection::Reverse => scroll_direction.flip(),
+    }
+}

--- a/crates/flui-rendering/src/objects/viewport.rs
+++ b/crates/flui-rendering/src/objects/viewport.rs
@@ -205,27 +205,34 @@ impl<O: ViewportOffset + 'static> RenderViewport<O> {
             };
             let corrected_cache_origin = cache_origin.max(-sliver_scroll_offset);
             let cache_extent_correction = cache_origin - corrected_cache_origin;
+            let child_remaining_paint_extent =
+                (remaining_paint_extent - layout_offset + initial_layout_offset).max(0.0);
+            let child_remaining_cache_extent =
+                (remaining_cache_extent + cache_extent_correction).max(0.0);
+            let constraints = SliverConstraints {
+                axis_direction: self.axis_direction,
+                growth_direction,
+                user_scroll_direction: adjusted_user_scroll_direction,
+                scroll_offset: sliver_scroll_offset,
+                preceding_scroll_extent,
+                overlap: max_paint_offset - layout_offset,
+                remaining_paint_extent: child_remaining_paint_extent,
+                cross_axis_extent,
+                cross_axis_direction: self.cross_axis_direction,
+                viewport_main_axis_extent: main_axis_extent,
+                remaining_cache_extent: child_remaining_cache_extent,
+                cache_origin: corrected_cache_origin,
+            };
 
-            let geometry = ctx.layout_sliver_child(
-                index,
-                SliverConstraints {
-                    axis_direction: self.axis_direction,
-                    growth_direction,
-                    user_scroll_direction: adjusted_user_scroll_direction,
-                    scroll_offset: sliver_scroll_offset,
-                    preceding_scroll_extent,
-                    overlap: max_paint_offset - layout_offset,
-                    remaining_paint_extent: (remaining_paint_extent - layout_offset
-                        + initial_layout_offset)
-                        .max(0.0),
-                    cross_axis_extent,
-                    cross_axis_direction: self.cross_axis_direction,
-                    viewport_main_axis_extent: main_axis_extent,
-                    remaining_cache_extent: (remaining_cache_extent + cache_extent_correction)
-                        .max(0.0),
-                    cache_origin: corrected_cache_origin,
-                },
-            );
+            let geometry = if child_remaining_paint_extent <= f32::EPSILON
+                && child_remaining_cache_extent <= f32::EPSILON
+                && sliver_scroll_offset <= f32::EPSILON
+                && let Some(cached_geometry) = cached_clean_sliver_geometry(ctx, index, constraints)
+            {
+                cached_geometry
+            } else {
+                ctx.layout_sliver_child(index, constraints)
+            };
 
             if let Some(correction) = geometry.scroll_offset_correction {
                 return correction;
@@ -438,5 +445,21 @@ fn apply_growth_direction_to_scroll_direction(
     match growth_direction {
         GrowthDirection::Forward => scroll_direction,
         GrowthDirection::Reverse => scroll_direction.flip(),
+    }
+}
+
+fn cached_clean_sliver_geometry(
+    ctx: &BoxLayoutContext<'_, Variable, BoxParentData>,
+    index: usize,
+    constraints: SliverConstraints,
+) -> Option<SliverGeometry> {
+    if ctx.sliver_child_needs_layout(index) {
+        return None;
+    }
+    let (cached_constraints, cached_geometry) = ctx.cached_sliver_child_layout(index)?;
+    if cached_constraints == constraints && cached_geometry.scroll_offset_correction.is_none() {
+        Some(cached_geometry)
+    } else {
+        None
     }
 }

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -2362,6 +2362,11 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
             // Stacked / Tree Borrows.
             let child_node: &RenderNode = unsafe { &*child_ptr.0 };
             cs.offset = child_node.offset();
+            cs.needs_layout = child_node.needs_layout();
+            if let Some(sliver_entry) = child_node.as_sliver() {
+                cs.sliver_constraints = sliver_entry.state().constraints().copied();
+                cs.sliver_geometry = sliver_entry.state().geometry();
+            }
         }
     }
 

--- a/crates/flui-rendering/src/protocol/box_protocol.rs
+++ b/crates/flui-rendering/src/protocol/box_protocol.rs
@@ -736,6 +736,20 @@ pub trait BoxLayoutCtxErased: Send + Sync {
         constraints: SliverConstraints,
     ) -> SliverGeometry;
 
+    /// Returns the last known sliver constraints and geometry for child
+    /// `index`, when this context is backed by pipeline storage.
+    fn cached_sliver_child_layout(
+        &self,
+        _index: usize,
+    ) -> Option<(SliverConstraints, SliverGeometry)> {
+        None
+    }
+
+    /// Returns whether sliver child `index` is currently marked dirty.
+    fn sliver_child_needs_layout(&self, _index: usize) -> bool {
+        true
+    }
+
     /// Records the paint offset for child at `index`.
     fn position_child(&mut self, index: usize, offset: Offset);
 
@@ -851,6 +865,25 @@ impl<A: Arity, P: ParentData + Default> BoxLayoutCtxErased for BoxLayoutCtx<'_, 
     }
 
     #[inline]
+    fn cached_sliver_child_layout(
+        &self,
+        index: usize,
+    ) -> Option<(SliverConstraints, SliverGeometry)> {
+        match &self.storage {
+            BoxLayoutCtxStorage::Direct { .. } => None,
+            BoxLayoutCtxStorage::Proxy { erased, .. } => erased.cached_sliver_child_layout(index),
+        }
+    }
+
+    #[inline]
+    fn sliver_child_needs_layout(&self, index: usize) -> bool {
+        match &self.storage {
+            BoxLayoutCtxStorage::Direct { .. } => true,
+            BoxLayoutCtxStorage::Proxy { erased, .. } => erased.sliver_child_needs_layout(index),
+        }
+    }
+
+    #[inline]
     fn position_child(&mut self, index: usize, offset: Offset) {
         <Self as LayoutContextApi<'_, BoxLayout, A, P>>::position_child(self, index, offset)
     }
@@ -927,6 +960,12 @@ pub struct ErasedChildState {
     pub size: Size,
     /// Position offset set by parent.
     pub offset: Offset,
+    /// Last constraints used to lay out this child when it is a sliver.
+    pub sliver_constraints: Option<SliverConstraints>,
+    /// Last geometry produced by this child when it is a sliver.
+    pub sliver_geometry: Option<SliverGeometry>,
+    /// Whether the child still needs layout in the backing render tree.
+    pub needs_layout: bool,
     /// Parent data, created on demand by the typed bridge.
     pub parent_data: Option<Box<dyn ParentData>>,
 }
@@ -938,6 +977,9 @@ impl ErasedChildState {
             id,
             size: Size::ZERO,
             offset: Offset::ZERO,
+            sliver_constraints: None,
+            sliver_geometry: None,
+            needs_layout: true,
             parent_data: None,
         }
     }
@@ -1021,10 +1063,31 @@ impl BoxLayoutCtxErased for ErasedBoxLayoutCtx<'_> {
         let Some(&child_id) = self.child_ids.get(index) else {
             return SliverGeometry::ZERO;
         };
-        match self.sliver_layout_child_callback {
+        let geometry = match self.sliver_layout_child_callback {
             Some(cb) => (cb)(child_id, constraints),
             None => SliverGeometry::ZERO,
+        };
+        if let Some(slot) = self.children.get_mut(index) {
+            slot.sliver_constraints = Some(constraints);
+            slot.sliver_geometry = Some(geometry);
+            slot.needs_layout = false;
         }
+        geometry
+    }
+
+    fn cached_sliver_child_layout(
+        &self,
+        index: usize,
+    ) -> Option<(SliverConstraints, SliverGeometry)> {
+        let slot = self.children.get(index)?;
+        Some((slot.sliver_constraints?, slot.sliver_geometry?))
+    }
+
+    fn sliver_child_needs_layout(&self, index: usize) -> bool {
+        self.children
+            .get(index)
+            .map(|slot| slot.needs_layout)
+            .unwrap_or(true)
     }
 
     fn position_child(&mut self, index: usize, offset: Offset) {

--- a/crates/flui-rendering/tests/render_viewport.rs
+++ b/crates/flui-rendering/tests/render_viewport.rs
@@ -1,5 +1,10 @@
 //! Core.2 W3.4a: minimal `RenderViewport` driver for sliver children.
 
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
 use flui_foundation::Diagnosticable;
 use flui_rendering::{
     constraints::{BoxConstraints, SliverConstraints, SliverGeometry},
@@ -205,6 +210,70 @@ impl RenderSliver for CorrectingSliver {
     }
 }
 
+#[derive(Debug)]
+struct CountingSliver {
+    scroll_extent: f32,
+    layouts: Arc<AtomicUsize>,
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl CountingSliver {
+    fn new(scroll_extent: f32, layouts: Arc<AtomicUsize>) -> Self {
+        Self {
+            scroll_extent,
+            layouts,
+            constraints: SliverConstraints::default(),
+            geometry: SliverGeometry::ZERO,
+        }
+    }
+}
+
+impl Diagnosticable for CountingSliver {}
+impl PaintEffectsCapability for CountingSliver {}
+impl SemanticsCapability for CountingSliver {}
+impl HotReloadCapability for CountingSliver {}
+
+impl RenderSliver for CountingSliver {
+    type Arity = Leaf;
+    type ParentData = SliverParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.layouts.fetch_add(1, Ordering::SeqCst);
+        self.constraints = *ctx.constraints();
+        let paint_extent = self.calculate_paint_offset(&self.constraints, 0.0, self.scroll_extent);
+        let cache_extent = self.calculate_cache_offset(&self.constraints, 0.0, self.scroll_extent);
+        self.geometry = SliverGeometry {
+            scroll_extent: self.scroll_extent,
+            paint_extent,
+            layout_extent: paint_extent,
+            max_paint_extent: self.scroll_extent,
+            hit_test_extent: paint_extent,
+            cache_extent,
+            visible: paint_extent > 0.0,
+            has_visual_overflow: self.constraints.scroll_offset > 0.0,
+            ..SliverGeometry::ZERO
+        };
+        ctx.complete(self.geometry);
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn hit_test(&self, _ctx: &mut SliverHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+        false
+    }
+}
+
 #[test]
 fn viewport_lays_out_forward_slivers_and_applies_content_dimensions() {
     let viewport = RenderViewport::with_offset(
@@ -359,5 +428,74 @@ fn viewport_hit_tests_in_opposite_paint_order() {
         hits(&owner, 10.0, 10.0),
         vec![first_id, root_id],
         "FirstIsTop paints earlier children on top, so hit testing must visit them first",
+    );
+}
+
+#[test]
+fn viewport_reuses_clean_cached_tail_extents_after_cache_window() {
+    let viewport = RenderViewport::with_offset(
+        AxisDirection::TopToBottom,
+        AxisDirection::LeftToRight,
+        ScrollableViewportOffset::zero(),
+    );
+
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(viewport));
+    let layout_counts = (0..8)
+        .map(|_| Arc::new(AtomicUsize::new(0)))
+        .collect::<Vec<_>>();
+
+    for counter in &layout_counts {
+        owner
+            .render_tree_mut()
+            .insert_sliver_child(
+                root_id,
+                Box::new(CountingSliver::new(100.0, Arc::clone(counter))) as BoxedSliverObject,
+            )
+            .expect("counting sliver");
+    }
+
+    let owner = laid_out(owner, root_id);
+    assert!(
+        layout_counts
+            .iter()
+            .all(|counter| counter.load(Ordering::SeqCst) == 1),
+        "first layout seeds geometry for every direct sliver child",
+    );
+
+    let mut owner = owner.into_idle();
+    owner.mark_needs_layout(root_id);
+    let mut owner = owner.into_layout();
+    owner.run_layout().expect("second layout succeeds");
+
+    assert!(
+        layout_counts
+            .iter()
+            .take(4)
+            .all(|counter| counter.load(Ordering::SeqCst) == 2),
+        "second layout still drives the visible/cache window",
+    );
+    assert!(
+        layout_counts
+            .iter()
+            .skip(4)
+            .all(|counter| counter.load(Ordering::SeqCst) == 1),
+        "clean slivers after the cache window should reuse cached scroll extents",
+    );
+
+    let viewport = owner
+        .render_tree()
+        .get(root_id)
+        .and_then(|node| node.as_box())
+        .and_then(|entry| {
+            entry
+                .render_object()
+                .downcast_ref::<RenderViewport<ScrollableViewportOffset>>()
+        })
+        .expect("root is RenderViewport");
+    assert_eq!(
+        viewport.offset().max_scroll_extent(),
+        700.0,
+        "reusing cached tail extents must preserve the full scroll range",
     );
 }

--- a/crates/flui-rendering/tests/render_viewport.rs
+++ b/crates/flui-rendering/tests/render_viewport.rs
@@ -1,0 +1,363 @@
+//! Core.2 W3.4a: minimal `RenderViewport` driver for sliver children.
+
+use flui_foundation::Diagnosticable;
+use flui_rendering::{
+    constraints::{BoxConstraints, SliverConstraints, SliverGeometry},
+    context::{SliverHitTestContext, SliverLayoutContext},
+    hit_testing::HitTestResult,
+    objects::RenderViewport,
+    parent_data::SliverParentData,
+    pipeline::PipelineOwner,
+    protocol::SliverProtocol,
+    traits::{
+        HotReloadCapability, PaintEffectsCapability, RenderObject, RenderSliver,
+        SemanticsCapability,
+    },
+    view::{ScrollableViewportOffset, SliverPaintOrder, ViewportOffset},
+};
+use flui_tree::Leaf;
+use flui_types::{Offset, Point, Rect, Size, geometry::px, layout::AxisDirection};
+
+type BoxedSliverObject = Box<dyn RenderObject<SliverProtocol>>;
+
+fn laid_out(
+    mut owner: PipelineOwner,
+    root: flui_foundation::RenderId,
+) -> PipelineOwner<flui_rendering::pipeline::phase::Layout> {
+    owner.set_root_id(Some(root));
+    owner.set_root_constraints(Some(BoxConstraints::tight(Size::new(px(100.0), px(100.0)))));
+    let mut owner = owner.into_layout();
+    owner.run_layout().expect("layout succeeds");
+    owner
+}
+
+fn render_offset(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    id: flui_foundation::RenderId,
+) -> Offset {
+    owner
+        .render_tree()
+        .get(id)
+        .map(flui_rendering::storage::RenderNode::offset)
+        .expect("node exists")
+}
+
+fn hits(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    cross: f32,
+    main: f32,
+) -> Vec<flui_foundation::RenderId> {
+    let mut result = HitTestResult::new();
+    owner.hit_test(Offset::new(px(cross), px(main)), &mut result);
+    result.path().iter().map(|entry| entry.target).collect()
+}
+
+#[derive(Debug)]
+struct FixedSliver {
+    scroll_extent: f32,
+    paint_extent: f32,
+    layout_extent: Option<f32>,
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl FixedSliver {
+    fn new(scroll_extent: f32) -> Self {
+        Self {
+            scroll_extent,
+            paint_extent: scroll_extent,
+            layout_extent: None,
+            constraints: SliverConstraints::default(),
+            geometry: SliverGeometry::ZERO,
+        }
+    }
+
+    fn with_extents(scroll_extent: f32, paint_extent: f32, layout_extent: f32) -> Self {
+        Self {
+            scroll_extent,
+            paint_extent,
+            layout_extent: Some(layout_extent),
+            constraints: SliverConstraints::default(),
+            geometry: SliverGeometry::ZERO,
+        }
+    }
+}
+
+impl Diagnosticable for FixedSliver {}
+impl PaintEffectsCapability for FixedSliver {}
+impl SemanticsCapability for FixedSliver {}
+impl HotReloadCapability for FixedSliver {}
+
+impl RenderSliver for FixedSliver {
+    type Arity = Leaf;
+    type ParentData = SliverParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        let paint_extent = self.calculate_paint_offset(&self.constraints, 0.0, self.paint_extent);
+        let layout_extent = self.layout_extent.unwrap_or(paint_extent);
+        let cache_extent = self.calculate_cache_offset(&self.constraints, 0.0, self.paint_extent);
+        self.geometry = SliverGeometry {
+            scroll_extent: self.scroll_extent,
+            paint_extent,
+            layout_extent,
+            max_paint_extent: self.paint_extent,
+            hit_test_extent: paint_extent,
+            cache_extent,
+            visible: paint_extent > 0.0,
+            has_visual_overflow: self.scroll_extent > self.constraints.remaining_paint_extent
+                || self.constraints.scroll_offset > 0.0,
+            ..SliverGeometry::ZERO
+        };
+        ctx.complete(self.geometry);
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn hit_test(&self, ctx: &mut SliverHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+        self.hit_test_self(ctx.main_axis(), ctx.cross_axis())
+    }
+
+    fn hit_test_self(&self, main: f32, cross: f32) -> bool {
+        cross >= 0.0 && cross < self.constraints.cross_axis_extent && main >= 0.0
+    }
+
+    fn sliver_paint_bounds(&self) -> Rect {
+        Rect::from_origin_size(
+            Point::ZERO,
+            Size::new(px(100.0), px(self.geometry.paint_extent)),
+        )
+    }
+}
+
+#[derive(Debug)]
+struct CorrectingSliver {
+    correction: f32,
+    corrected: bool,
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl CorrectingSliver {
+    fn new(correction: f32) -> Self {
+        Self {
+            correction,
+            corrected: false,
+            constraints: SliverConstraints::default(),
+            geometry: SliverGeometry::ZERO,
+        }
+    }
+}
+
+impl Diagnosticable for CorrectingSliver {}
+impl PaintEffectsCapability for CorrectingSliver {}
+impl SemanticsCapability for CorrectingSliver {}
+impl HotReloadCapability for CorrectingSliver {}
+
+impl RenderSliver for CorrectingSliver {
+    type Arity = Leaf;
+    type ParentData = SliverParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        if !self.corrected {
+            self.corrected = true;
+            self.geometry = SliverGeometry::scroll_offset_correction(self.correction);
+        } else {
+            self.geometry = SliverGeometry {
+                scroll_extent: 80.0,
+                paint_extent: 80.0,
+                layout_extent: 80.0,
+                max_paint_extent: 80.0,
+                hit_test_extent: 80.0,
+                cache_extent: 80.0,
+                visible: true,
+                ..SliverGeometry::ZERO
+            };
+        }
+        ctx.complete(self.geometry);
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn hit_test(&self, _ctx: &mut SliverHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+        false
+    }
+}
+
+#[test]
+fn viewport_lays_out_forward_slivers_and_applies_content_dimensions() {
+    let viewport = RenderViewport::with_offset(
+        AxisDirection::TopToBottom,
+        AxisDirection::LeftToRight,
+        ScrollableViewportOffset::new(40.0),
+    );
+
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(viewport));
+    let first_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(FixedSliver::new(70.0)) as BoxedSliverObject,
+        )
+        .expect("first sliver");
+    let second_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(FixedSliver::new(90.0)) as BoxedSliverObject,
+        )
+        .expect("second sliver");
+
+    let owner = laid_out(owner, root_id);
+    let viewport = owner
+        .render_tree()
+        .get(root_id)
+        .and_then(|node| node.as_box())
+        .and_then(|entry| {
+            entry
+                .render_object()
+                .downcast_ref::<RenderViewport<ScrollableViewportOffset>>()
+        })
+        .expect("root is RenderViewport");
+
+    assert_eq!(viewport.size(), &Size::new(px(100.0), px(100.0)));
+    assert_eq!(viewport.offset().viewport_dimension(), 100.0);
+    assert_eq!(viewport.offset().max_scroll_extent(), 60.0);
+    assert_eq!(viewport.offset().pixels(), 40.0);
+    assert_eq!(
+        render_offset(&owner, first_id),
+        Offset::new(px(0.0), px(0.0)),
+        "first forward sliver paints at the viewport origin when scroll_offset is consumed by constraints",
+    );
+    assert_eq!(
+        render_offset(&owner, second_id),
+        Offset::new(px(0.0), px(30.0)),
+        "second sliver advances by first.layout_extent after the first sliver consumes 40px of scroll",
+    );
+}
+
+#[test]
+fn viewport_retries_after_child_scroll_offset_correction() {
+    let viewport = RenderViewport::with_offset(
+        AxisDirection::TopToBottom,
+        AxisDirection::LeftToRight,
+        ScrollableViewportOffset::new(20.0),
+    );
+
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(viewport));
+    owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(CorrectingSliver::new(-20.0)) as BoxedSliverObject,
+        )
+        .expect("correcting sliver");
+
+    let owner = laid_out(owner, root_id);
+    let viewport = owner
+        .render_tree()
+        .get(root_id)
+        .and_then(|node| node.as_box())
+        .and_then(|entry| {
+            entry
+                .render_object()
+                .downcast_ref::<RenderViewport<ScrollableViewportOffset>>()
+        })
+        .expect("root is RenderViewport");
+
+    assert_eq!(
+        viewport.offset().pixels(),
+        0.0,
+        "child correction must be applied through ViewportOffset::correct_by and layout retried",
+    );
+}
+
+#[test]
+fn viewport_hit_tests_in_opposite_paint_order() {
+    let mut viewport = RenderViewport::with_offset(
+        AxisDirection::TopToBottom,
+        AxisDirection::LeftToRight,
+        ScrollableViewportOffset::zero(),
+    );
+    viewport.set_paint_order(SliverPaintOrder::LastIsTop);
+
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(viewport));
+    let _first_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(FixedSliver::with_extents(0.0, 100.0, 0.0)) as BoxedSliverObject,
+        )
+        .expect("first sliver");
+    let second_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(FixedSliver::with_extents(0.0, 100.0, 0.0)) as BoxedSliverObject,
+        )
+        .expect("second sliver");
+
+    let owner = laid_out(owner, root_id);
+
+    assert_eq!(
+        hits(&owner, 10.0, 10.0),
+        vec![second_id, root_id],
+        "LastIsTop paints later children on top, so hit testing must visit them first",
+    );
+
+    let mut viewport = RenderViewport::with_offset(
+        AxisDirection::TopToBottom,
+        AxisDirection::LeftToRight,
+        ScrollableViewportOffset::zero(),
+    );
+    viewport.set_paint_order(SliverPaintOrder::FirstIsTop);
+
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(viewport));
+    let first_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(FixedSliver::with_extents(0.0, 100.0, 0.0)) as BoxedSliverObject,
+        )
+        .expect("first sliver");
+    let _second_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(FixedSliver::with_extents(0.0, 100.0, 0.0)) as BoxedSliverObject,
+        )
+        .expect("second sliver");
+
+    let owner = laid_out(owner, root_id);
+
+    assert_eq!(
+        hits(&owner, 10.0, 10.0),
+        vec![first_id, root_id],
+        "FirstIsTop paints earlier children on top, so hit testing must visit them first",
+    );
+}


### PR DESCRIPTION
## Summary
- add `RenderViewport` as a Box/Variable driver for Sliver children
- port forward `layoutChildSequence` math with a bounded correction loop and `ViewportOffset` content dimensions
- cover forward layout offsets, scroll correction retry, and hit-test order opposite paint order

## Test Plan
- `cargo fmt --package flui-rendering -- --check`
- `cargo test -p flui-rendering --test render_viewport --quiet`
- `cargo clippy -p flui-rendering --all-targets -- -D warnings`
- `cargo test -p flui-rendering --quiet`
- `bash scripts/port-check.sh -v`