### PR TITLE
Core.2 Sliver W3.5b: fix reverse-axis viewport hits

### DIFF
--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -685,14 +685,22 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
             let Some(&child_id) = children.get(index) else {
                 return false;
             };
-            let child_position = override_pos.unwrap_or_else(|| {
-                let offset = self
-                    .render_tree
-                    .get(child_id)
-                    .map(RenderNode::offset)
-                    .unwrap_or(Offset::ZERO);
-                position - offset
-            });
+            let Some(child_node) = self.render_tree.get(child_id) else {
+                return false;
+            };
+            if child_node.as_sliver().is_some() {
+                // Explicit positions are already child-local; the layout-offset
+                // fallback starts from the child's physical paint offset.
+                let child_position = match override_pos {
+                    Some(position) => Self::sliver_hit_position_from_offset(child_node, position),
+                    None => Self::sliver_hit_position_from_paint_offset(
+                        child_node,
+                        position - child_node.offset(),
+                    ),
+                };
+                return self.hit_test_sliver_subtree(child_id, child_position, result);
+            }
+            let child_position = override_pos.unwrap_or_else(|| position - child_node.offset());
             self.hit_test_subtree(child_id, child_position, result)
         };
 
@@ -718,6 +726,43 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
             ) => MainAxisPosition::from_horizontal_offset(position),
             _ => MainAxisPosition::from_vertical_offset(position),
         }
+    }
+
+    fn sliver_hit_position_from_paint_offset(
+        node: &RenderNode,
+        position: Offset,
+    ) -> MainAxisPosition {
+        let Some(entry) = node.as_sliver() else {
+            return MainAxisPosition::from_vertical_offset(position);
+        };
+        let Some(constraints) = entry.state().constraints() else {
+            return MainAxisPosition::from_vertical_offset(position);
+        };
+
+        let (raw_main, cross_axis) = match constraints.axis_direction {
+            flui_types::layout::AxisDirection::LeftToRight
+            | flui_types::layout::AxisDirection::RightToLeft => {
+                (position.dx.get(), position.dy.get())
+            }
+            flui_types::layout::AxisDirection::TopToBottom
+            | flui_types::layout::AxisDirection::BottomToTop => {
+                (position.dy.get(), position.dx.get())
+            }
+        };
+        let effective_axis_direction = match constraints.growth_direction {
+            crate::constraints::GrowthDirection::Forward => constraints.axis_direction,
+            crate::constraints::GrowthDirection::Reverse => constraints.axis_direction.opposite(),
+        };
+        let main_axis = if effective_axis_direction.is_reversed() {
+            entry
+                .state()
+                .geometry()
+                .map_or(raw_main, |geometry| geometry.paint_extent - raw_main)
+        } else {
+            raw_main
+        };
+
+        MainAxisPosition::new(main_axis, cross_axis)
     }
 
     fn sliver_hit_position_minus_offset(

--- a/crates/flui-rendering/tests/render_viewport.rs
+++ b/crates/flui-rendering/tests/render_viewport.rs
@@ -146,6 +146,72 @@ impl RenderSliver for FixedSliver {
 }
 
 #[derive(Debug)]
+struct MainAxisBandSliver {
+    extent: f32,
+    hit_start: f32,
+    hit_end: f32,
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl MainAxisBandSliver {
+    fn new(extent: f32, hit_start: f32, hit_end: f32) -> Self {
+        Self {
+            extent,
+            hit_start,
+            hit_end,
+            constraints: SliverConstraints::default(),
+            geometry: SliverGeometry::ZERO,
+        }
+    }
+}
+
+impl Diagnosticable for MainAxisBandSliver {}
+impl PaintEffectsCapability for MainAxisBandSliver {}
+impl SemanticsCapability for MainAxisBandSliver {}
+impl HotReloadCapability for MainAxisBandSliver {}
+
+impl RenderSliver for MainAxisBandSliver {
+    type Arity = Leaf;
+    type ParentData = SliverParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        let paint_extent = self.calculate_paint_offset(&self.constraints, 0.0, self.extent);
+        self.geometry = SliverGeometry {
+            scroll_extent: self.extent,
+            paint_extent,
+            layout_extent: paint_extent,
+            max_paint_extent: self.extent,
+            hit_test_extent: paint_extent,
+            cache_extent: self.calculate_cache_offset(&self.constraints, 0.0, self.extent),
+            visible: paint_extent > 0.0,
+            ..SliverGeometry::ZERO
+        };
+        ctx.complete(self.geometry);
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn hit_test_self(&self, main: f32, cross: f32) -> bool {
+        main >= self.hit_start
+            && main < self.hit_end
+            && cross >= 0.0
+            && cross < self.constraints.cross_axis_extent
+    }
+}
+
+#[derive(Debug)]
 struct CorrectingSliver {
     correction: f32,
     corrected: bool,
@@ -428,6 +494,42 @@ fn viewport_hit_tests_in_opposite_paint_order() {
         hits(&owner, 10.0, 10.0),
         vec![first_id, root_id],
         "FirstIsTop paints earlier children on top, so hit testing must visit them first",
+    );
+}
+
+#[test]
+fn viewport_hit_test_flips_reverse_axis_into_sliver_main_axis() {
+    let viewport = RenderViewport::with_offset(
+        AxisDirection::BottomToTop,
+        AxisDirection::LeftToRight,
+        ScrollableViewportOffset::zero(),
+    );
+
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(viewport));
+    let sliver_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(MainAxisBandSliver::new(40.0, 0.0, 15.0)) as BoxedSliverObject,
+        )
+        .expect("reverse-axis sliver");
+
+    let owner = laid_out(owner, root_id);
+
+    assert_eq!(
+        render_offset(&owner, sliver_id),
+        Offset::new(px(0.0), px(60.0)),
+        "bottom-to-top viewport paints the first 40px sliver at the bottom edge",
+    );
+    assert_eq!(
+        hits(&owner, 10.0, 90.0),
+        vec![sliver_id, root_id],
+        "parent y=90 must map to sliver main=10, inside the leading hit band",
+    );
+    assert!(
+        hits(&owner, 10.0, 70.0).is_empty(),
+        "parent y=70 maps to sliver main=30 and must miss the leading hit band",
     );
 }
 


### PR DESCRIPTION
## Summary
- Fix Box-to-Sliver hit-test conversion for layout-offset hits under reversed effective axes.
- Preserve explicit child hit positions as already child-local.
- Add a bottom-to-top viewport regression test that distinguishes physical offset from sliver main-axis coordinates.

## Test Plan
- cargo fmt --package flui-rendering -- --check
- cargo clippy -p flui-rendering --all-targets -- -D warnings
- cargo test -p flui-rendering --quiet
- bash scripts/port-check.sh -v