### PR TITLE
Core.2 Sliver W3.5c: fix sliver child hit offsets

### DIFF
--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -765,28 +765,51 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
         MainAxisPosition::new(main_axis, cross_axis)
     }
 
-    fn sliver_hit_position_minus_offset(
-        node: &RenderNode,
+    fn sliver_hit_position_minus_paint_offset(
+        parent_constraints: &SliverConstraints,
+        parent_geometry: &SliverGeometry,
+        child_node: &RenderNode,
         position: MainAxisPosition,
         offset: Offset,
     ) -> MainAxisPosition {
-        let axis_direction = node
-            .as_sliver()
-            .and_then(|entry| entry.state().constraints())
-            .map(|constraints| constraints.axis_direction);
+        let Some(child_entry) = child_node.as_sliver() else {
+            return position;
+        };
+        let Some(child_constraints) = child_entry.state().constraints() else {
+            return position;
+        };
+        let Some(child_geometry) = child_entry.state().geometry() else {
+            return position;
+        };
 
-        match axis_direction {
-            Some(
-                flui_types::layout::AxisDirection::LeftToRight
-                | flui_types::layout::AxisDirection::RightToLeft,
-            ) => MainAxisPosition::new(
-                position.main_axis - offset.dx.get(),
-                position.cross_axis - offset.dy.get(),
-            ),
-            _ => MainAxisPosition::new(
-                position.main_axis - offset.dy.get(),
-                position.cross_axis - offset.dx.get(),
-            ),
+        let (offset_main, offset_cross) = match child_constraints.axis_direction {
+            flui_types::layout::AxisDirection::LeftToRight
+            | flui_types::layout::AxisDirection::RightToLeft => (offset.dx.get(), offset.dy.get()),
+            flui_types::layout::AxisDirection::TopToBottom
+            | flui_types::layout::AxisDirection::BottomToTop => (offset.dy.get(), offset.dx.get()),
+        };
+        let parent_physical_main =
+            if Self::effective_sliver_axis_direction(parent_constraints).is_reversed() {
+                parent_geometry.paint_extent - position.main_axis
+            } else {
+                position.main_axis
+            };
+        let child_physical_main = parent_physical_main - offset_main;
+        let child_main = if Self::effective_sliver_axis_direction(child_constraints).is_reversed() {
+            child_geometry.paint_extent - child_physical_main
+        } else {
+            child_physical_main
+        };
+
+        MainAxisPosition::new(child_main, position.cross_axis - offset_cross)
+    }
+
+    fn effective_sliver_axis_direction(
+        constraints: &SliverConstraints,
+    ) -> flui_types::layout::AxisDirection {
+        match constraints.growth_direction {
+            crate::constraints::GrowthDirection::Forward => constraints.axis_direction,
+            crate::constraints::GrowthDirection::Reverse => constraints.axis_direction.opposite(),
         }
     }
 
@@ -893,13 +916,18 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
                 return false;
             };
             if child_node.as_sliver().is_some() {
-                let child_position = override_pos.unwrap_or_else(|| {
-                    Self::sliver_hit_position_minus_offset(
+                // Explicit positions are already in child sliver coordinates.
+                // The layout-offset fallback starts from physical paint data.
+                let child_position = match override_pos {
+                    Some(position) => position,
+                    None => Self::sliver_hit_position_minus_paint_offset(
+                        constraints,
+                        &geometry,
                         child_node,
                         position,
                         child_node.offset(),
-                    )
-                });
+                    ),
+                };
                 self.hit_test_sliver_subtree(child_id, child_position, result)
             } else if let Some(child_entry) = child_node.as_box() {
                 let Some(child_size) = child_entry.state().geometry() else {

--- a/crates/flui-rendering/tests/hit_test_pipeline.rs
+++ b/crates/flui-rendering/tests/hit_test_pipeline.rs
@@ -282,6 +282,13 @@ fn sliver_hit_constraints() -> SliverConstraints {
     }
 }
 
+fn reverse_growth_sliver_hit_constraints() -> SliverConstraints {
+    SliverConstraints {
+        growth_direction: GrowthDirection::Reverse,
+        ..sliver_hit_constraints()
+    }
+}
+
 #[derive(Debug)]
 struct SliverHitHost {
     constraints: SliverConstraints,
@@ -476,6 +483,69 @@ impl RenderSliver for HitLeafSliver {
 
     fn sliver_paint_bounds(&self) -> Rect {
         Rect::from_origin_size(flui_types::Point::ZERO, Size::new(px(100.0), px(80.0)))
+    }
+}
+
+#[derive(Debug)]
+struct MainAxisBandSliver {
+    hit_start: f32,
+    hit_end: f32,
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl MainAxisBandSliver {
+    fn new(hit_start: f32, hit_end: f32) -> Self {
+        Self {
+            hit_start,
+            hit_end,
+            constraints: SliverConstraints::default(),
+            geometry: SliverGeometry::ZERO,
+        }
+    }
+}
+
+impl flui_foundation::Diagnosticable for MainAxisBandSliver {}
+impl PaintEffectsCapability for MainAxisBandSliver {}
+impl SemanticsCapability for MainAxisBandSliver {}
+impl HotReloadCapability for MainAxisBandSliver {}
+
+impl RenderSliver for MainAxisBandSliver {
+    type Arity = Leaf;
+    type ParentData = SliverParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        let geometry = SliverGeometry {
+            scroll_extent: 80.0,
+            paint_extent: 80.0,
+            layout_extent: 80.0,
+            max_paint_extent: 80.0,
+            hit_test_extent: 80.0,
+            visible: true,
+            ..SliverGeometry::ZERO
+        };
+        self.geometry = geometry;
+        ctx.complete(geometry);
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn hit_test_self(&self, main: f32, cross: f32) -> bool {
+        main >= self.hit_start
+            && main < self.hit_end
+            && cross >= 0.0
+            && cross < self.constraints.cross_axis_extent
     }
 }
 
@@ -803,6 +873,51 @@ fn unpositioned_sliver_child_keeps_prior_offset_across_relayout() {
         Offset::new(px(0.0), px(20.0)),
         "a sliver parent that does not call position_child on a later \
          pass must preserve the child's previously committed offset",
+    );
+}
+
+#[test]
+fn reverse_growth_sliver_parent_converts_child_paint_offset_for_hit_testing() {
+    let mut owner = PipelineOwner::new();
+    let host_id = owner.insert(Box::new(PositionedSliverHitHost {
+        constraints: reverse_growth_sliver_hit_constraints(),
+        offset: Offset::ZERO,
+        position_child: true,
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let parent_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            host_id,
+            Box::new(ConditionalOffsetSliverParent::new(Offset::new(
+                px(0.0),
+                px(10.0),
+            ))) as BoxedSliverObject,
+        )
+        .expect("reverse-growth sliver parent");
+    let leaf_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            parent_id,
+            Box::new(MainAxisBandSliver::new(0.0, 15.0)) as BoxedSliverObject,
+        )
+        .expect("band sliver leaf");
+
+    let owner = laid_out(owner, host_id);
+    assert_eq!(
+        render_offset(&owner, leaf_id),
+        Offset::new(px(0.0), px(10.0)),
+        "fixture sanity: parent positioned the child 10px from the physical top",
+    );
+    assert_eq!(
+        hits(&owner, 10.0, 80.0),
+        vec![leaf_id, parent_id, host_id],
+        "reverse-growth parent main=40 maps through physical y=80 and child \
+         offset=10 to child main=10, inside the leading hit band",
+    );
+    assert!(
+        hits(&owner, 10.0, 60.0).is_empty(),
+        "box y=60 maps to child main=30 and must miss the leading hit band",
     );
 }
 


### PR DESCRIPTION
## Summary
- Convert sliver child layout-offset hit positions through parent physical paint coordinates before entering the child sliver.
- Preserve explicit sliver child hit positions as already child-local.
- Add a reverse-growth sliver-parent regression that distinguishes physical paint offsets from sliver main-axis coordinates.

## Test Plan
- cargo fmt --package flui-rendering -- --check
- cargo clippy -p flui-rendering --all-targets -- -D warnings
- cargo test -p flui-rendering --quiet
- bash scripts/port-check.sh -v