### PR TITLE
Core.2 Sliver W3.8: add fill remaining scrollable

### DIFF
--- a/crates/flui-rendering/src/objects/mod.rs
+++ b/crates/flui-rendering/src/objects/mod.rs
@@ -50,6 +50,8 @@
 //!   skipped paint, no hit-test) (Core.2 Wave 5a)
 //! - [`RenderSliverToBoxAdapter`] - Wraps one Box child in Sliver
 //!   protocol geometry (Core.2 W3.3)
+//! - [`RenderSliverFillRemainingWithScrollable`] - Sizes one Box child to
+//!   the remaining viewport paint extent (Core.2 W3.8)
 //! - [`RenderViewport`] - Box viewport that drives Sliver children
 //!   (Core.2 W3.4a)
 //!
@@ -86,6 +88,7 @@ mod padding;
 mod paragraph;
 mod repaint_boundary;
 mod sized_box;
+mod sliver_fill_remaining;
 mod sliver_ignore_pointer;
 mod sliver_offstage;
 mod sliver_opacity;
@@ -119,6 +122,7 @@ pub use padding::RenderPadding;
 pub use paragraph::RenderParagraph;
 pub use repaint_boundary::RenderRepaintBoundary;
 pub use sized_box::RenderSizedBox;
+pub use sliver_fill_remaining::RenderSliverFillRemainingWithScrollable;
 pub use sliver_ignore_pointer::RenderSliverIgnorePointer;
 pub use sliver_offstage::RenderSliverOffstage;
 pub use sliver_opacity::RenderSliverOpacity;

--- a/crates/flui-rendering/src/objects/sliver_fill_remaining.rs
+++ b/crates/flui-rendering/src/objects/sliver_fill_remaining.rs
@@ -1,0 +1,176 @@
+//! `RenderSliverFillRemainingWithScrollable` — single Box child sliver that
+//! fills the remaining viewport paint extent.
+//!
+//! This is the scroll-body variant of Flutter's `SliverFillRemaining`: it does
+//! not ask the Box child for intrinsic size, and therefore fits FLUI's current
+//! Sliver -> Box layout bridge without adding a new intrinsic query channel to
+//! `SliverLayoutContext`.
+
+use flui_foundation::Diagnosticable;
+use flui_tree::Single;
+use flui_types::{
+    Offset,
+    geometry::px,
+    layout::{AxisDirection, AxisDirection::*},
+};
+
+use crate::{
+    constraints::{GrowthDirection, SliverConstraints, SliverGeometry},
+    context::{PaintCx, SliverHitTestContext, SliverLayoutContext},
+    parent_data::SliverPhysicalParentData,
+    traits::{HotReloadCapability, PaintEffectsCapability, RenderSliver, SemanticsCapability},
+};
+
+/// A Sliver-protocol adapter that sizes one Box child to the remaining paint
+/// extent of the viewport.
+#[derive(Debug, Clone)]
+pub struct RenderSliverFillRemainingWithScrollable {
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl RenderSliverFillRemainingWithScrollable {
+    /// Creates a fill-remaining sliver with no laid-out geometry yet.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            constraints: empty_sliver_constraints(),
+            geometry: SliverGeometry::ZERO,
+        }
+    }
+
+    #[inline]
+    fn child_paint_offset(constraints: &SliverConstraints, geometry: &SliverGeometry) -> Offset {
+        match apply_growth_direction_to_axis_direction(
+            constraints.axis_direction,
+            constraints.growth_direction,
+        ) {
+            TopToBottom => Offset::new(px(0.0), px(-constraints.scroll_offset)),
+            LeftToRight => Offset::new(px(-constraints.scroll_offset), px(0.0)),
+            BottomToTop => Offset::new(
+                px(0.0),
+                px(geometry.paint_extent + constraints.scroll_offset - geometry.scroll_extent),
+            ),
+            RightToLeft => Offset::new(
+                px(geometry.paint_extent + constraints.scroll_offset - geometry.scroll_extent),
+                px(0.0),
+            ),
+        }
+    }
+}
+
+impl Default for RenderSliverFillRemainingWithScrollable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Diagnosticable for RenderSliverFillRemainingWithScrollable {}
+impl PaintEffectsCapability for RenderSliverFillRemainingWithScrollable {}
+impl SemanticsCapability for RenderSliverFillRemainingWithScrollable {}
+impl HotReloadCapability for RenderSliverFillRemainingWithScrollable {}
+
+impl RenderSliver for RenderSliverFillRemainingWithScrollable {
+    type Arity = Single;
+    type ParentData = SliverPhysicalParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Single, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        let extent = self.constraints.remaining_paint_extent - self.constraints.overlap.min(0.0);
+        let cache_extent = self.calculate_cache_offset(
+            &self.constraints,
+            0.0,
+            self.constraints.viewport_main_axis_extent,
+        );
+
+        if ctx.child_count() > 0 {
+            let max_extent = if extent == 0.0 && cache_extent > 0.0 {
+                cache_extent
+            } else {
+                extent
+            };
+            ctx.layout_box_child(
+                0,
+                self.constraints
+                    .as_box_constraints(extent, max_extent, None),
+            );
+        }
+
+        let painted_child_size = self.calculate_paint_offset(&self.constraints, 0.0, extent);
+        let geometry = SliverGeometry {
+            scroll_extent: self.constraints.viewport_main_axis_extent,
+            paint_extent: painted_child_size,
+            layout_extent: painted_child_size,
+            max_paint_extent: painted_child_size,
+            cache_extent,
+            hit_test_extent: painted_child_size,
+            visible: painted_child_size > 0.0,
+            has_visual_overflow: extent > self.constraints.remaining_paint_extent
+                || self.constraints.scroll_offset > 0.0,
+            ..SliverGeometry::ZERO
+        };
+        if ctx.child_count() > 0 {
+            let child_paint_offset = Self::child_paint_offset(&self.constraints, &geometry);
+            ctx.position_child(0, child_paint_offset);
+        }
+        self.geometry = geometry;
+        ctx.complete(geometry);
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn child_main_axis_position(
+        &self,
+        _child: &dyn crate::traits::RenderObject<crate::protocol::SliverProtocol>,
+    ) -> f32 {
+        -self.constraints.scroll_offset
+    }
+
+    fn paint(&self, ctx: &mut PaintCx<'_, Single>) {
+        if self.geometry.visible {
+            ctx.paint_child();
+        }
+    }
+
+    fn hit_test(&self, ctx: &mut SliverHitTestContext<'_, Single, Self::ParentData>) -> bool {
+        ctx.hit_test_child_at_layout_offset(0)
+    }
+}
+
+const fn apply_growth_direction_to_axis_direction(
+    axis_direction: AxisDirection,
+    growth_direction: GrowthDirection,
+) -> AxisDirection {
+    match growth_direction {
+        GrowthDirection::Forward => axis_direction,
+        GrowthDirection::Reverse => axis_direction.opposite(),
+    }
+}
+
+const fn empty_sliver_constraints() -> SliverConstraints {
+    SliverConstraints {
+        axis_direction: TopToBottom,
+        growth_direction: GrowthDirection::Forward,
+        user_scroll_direction: crate::view::ScrollDirection::Idle,
+        scroll_offset: 0.0,
+        preceding_scroll_extent: 0.0,
+        overlap: 0.0,
+        remaining_paint_extent: 0.0,
+        cross_axis_extent: 0.0,
+        cross_axis_direction: LeftToRight,
+        viewport_main_axis_extent: 0.0,
+        remaining_cache_extent: 0.0,
+        cache_origin: 0.0,
+    }
+}

--- a/crates/flui-rendering/tests/sliver_fill_remaining.rs
+++ b/crates/flui-rendering/tests/sliver_fill_remaining.rs
@@ -1,0 +1,293 @@
+use flui_rendering::{
+    constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
+    context::{BoxHitTestContext, BoxLayoutContext},
+    hit_testing::HitTestResult,
+    objects::RenderSliverFillRemainingWithScrollable,
+    parent_data::BoxParentData,
+    pipeline::PipelineOwner,
+    protocol::{BoxProtocol, SliverProtocol},
+    traits::{
+        HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, SemanticsCapability,
+    },
+    view::ScrollDirection,
+};
+use flui_tree::Leaf;
+use flui_types::{Offset, Rect, Size, geometry::px, layout::AxisDirection};
+
+type BoxedRenderObject = Box<dyn RenderObject<BoxProtocol>>;
+type BoxedSliverObject = Box<dyn RenderObject<SliverProtocol>>;
+
+fn vertical_constraints(
+    scroll_offset: f32,
+    preceding_scroll_extent: f32,
+    remaining_paint_extent: f32,
+    overlap: f32,
+) -> SliverConstraints {
+    SliverConstraints {
+        axis_direction: AxisDirection::TopToBottom,
+        cross_axis_direction: AxisDirection::LeftToRight,
+        growth_direction: GrowthDirection::Forward,
+        user_scroll_direction: ScrollDirection::Idle,
+        scroll_offset,
+        preceding_scroll_extent,
+        overlap,
+        remaining_paint_extent,
+        cross_axis_extent: 300.0,
+        viewport_main_axis_extent: 100.0,
+        remaining_cache_extent: 120.0,
+        cache_origin: -20.0,
+    }
+}
+
+fn laid_out(
+    mut owner: PipelineOwner,
+    root: flui_foundation::RenderId,
+) -> PipelineOwner<flui_rendering::pipeline::phase::Layout> {
+    owner.set_root_id(Some(root));
+    owner.set_root_constraints(Some(BoxConstraints::tight(Size::new(px(300.0), px(100.0)))));
+    let mut owner = owner.into_layout();
+    owner.run_layout().expect("layout succeeds");
+    owner
+}
+
+fn sliver_geometry(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    id: flui_foundation::RenderId,
+) -> SliverGeometry {
+    owner
+        .render_tree()
+        .get(id)
+        .and_then(|node| node.as_sliver())
+        .and_then(|entry| entry.state().geometry())
+        .expect("sliver geometry is committed")
+}
+
+fn box_size(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    id: flui_foundation::RenderId,
+) -> Size {
+    owner
+        .render_tree()
+        .get(id)
+        .and_then(|node| node.as_box())
+        .and_then(|entry| entry.state().geometry())
+        .expect("box geometry is committed")
+}
+
+fn render_offset(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    id: flui_foundation::RenderId,
+) -> Offset {
+    owner
+        .render_tree()
+        .get(id)
+        .map(flui_rendering::storage::RenderNode::offset)
+        .expect("node exists")
+}
+
+fn hits(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    cross: f32,
+    main: f32,
+) -> Vec<flui_foundation::RenderId> {
+    let mut result = HitTestResult::new();
+    owner.hit_test(Offset::new(px(cross), px(main)), &mut result);
+    result.path().iter().map(|entry| entry.target).collect()
+}
+
+#[derive(Debug)]
+struct FixedHitBox {
+    desired: Size,
+    size: Size,
+}
+
+impl FixedHitBox {
+    fn new(width: f32, height: f32) -> Self {
+        Self {
+            desired: Size::new(px(width), px(height)),
+            size: Size::ZERO,
+        }
+    }
+}
+
+impl flui_foundation::Diagnosticable for FixedHitBox {}
+impl PaintEffectsCapability for FixedHitBox {}
+impl SemanticsCapability for FixedHitBox {}
+impl HotReloadCapability for FixedHitBox {}
+
+impl RenderBox for FixedHitBox {
+    type Arity = Leaf;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.size = ctx.constraints().constrain(self.desired);
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+
+    fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+        ctx.is_within_bounds(Rect::from_origin_size(flui_types::Point::ZERO, self.size))
+    }
+}
+
+#[derive(Debug)]
+struct SliverHost {
+    constraints: SliverConstraints,
+    size: Size,
+}
+
+impl flui_foundation::Diagnosticable for SliverHost {}
+impl PaintEffectsCapability for SliverHost {}
+impl SemanticsCapability for SliverHost {}
+impl HotReloadCapability for SliverHost {}
+
+impl RenderBox for SliverHost {
+    type Arity = flui_tree::Variable;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(
+        &mut self,
+        ctx: &mut BoxLayoutContext<'_, flui_tree::Variable, Self::ParentData>,
+    ) {
+        if ctx.child_count() > 0 {
+            let _ = ctx.layout_sliver_child(0, self.constraints);
+        }
+        self.size = ctx.constraints().biggest();
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+
+    fn hit_test(
+        &self,
+        ctx: &mut BoxHitTestContext<'_, flui_tree::Variable, Self::ParentData>,
+    ) -> bool {
+        ctx.hit_test_child(0, ctx.offset())
+    }
+}
+
+#[test]
+fn sliver_fill_remaining_with_scrollable_sizes_child_to_remaining_paint_extent() {
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(SliverHost {
+        constraints: vertical_constraints(0.0, 30.0, 70.0, 0.0),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let sliver_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(RenderSliverFillRemainingWithScrollable::new()) as BoxedSliverObject,
+        )
+        .expect("fill remaining sliver");
+    let child_id = owner
+        .render_tree_mut()
+        .insert_box_child(
+            sliver_id,
+            Box::new(FixedHitBox::new(50.0, 10.0)) as BoxedRenderObject,
+        )
+        .expect("box child");
+
+    let owner = laid_out(owner, root_id);
+    let geometry = sliver_geometry(&owner, sliver_id);
+
+    assert_eq!(box_size(&owner, child_id), Size::new(px(300.0), px(70.0)));
+    assert_eq!(geometry.scroll_extent, 100.0);
+    assert_eq!(geometry.paint_extent, 70.0);
+    assert_eq!(geometry.max_paint_extent, 70.0);
+    assert_eq!(geometry.hit_test_extent, 70.0);
+    assert_eq!(geometry.cache_extent, 100.0);
+    assert_eq!(render_offset(&owner, child_id), Offset::ZERO);
+    assert!(!geometry.has_visual_overflow);
+}
+
+#[test]
+fn sliver_fill_remaining_with_scrollable_includes_negative_overlap_in_child_extent() {
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(SliverHost {
+        constraints: vertical_constraints(0.0, 0.0, 80.0, -20.0),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let sliver_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(RenderSliverFillRemainingWithScrollable::new()) as BoxedSliverObject,
+        )
+        .expect("fill remaining sliver");
+    let child_id = owner
+        .render_tree_mut()
+        .insert_box_child(
+            sliver_id,
+            Box::new(FixedHitBox::new(50.0, 10.0)) as BoxedRenderObject,
+        )
+        .expect("box child");
+
+    let owner = laid_out(owner, root_id);
+    let geometry = sliver_geometry(&owner, sliver_id);
+
+    assert_eq!(box_size(&owner, child_id), Size::new(px(300.0), px(100.0)));
+    assert_eq!(geometry.scroll_extent, 100.0);
+    assert_eq!(geometry.paint_extent, 80.0);
+    assert_eq!(geometry.max_paint_extent, 80.0);
+    assert_eq!(geometry.hit_test_extent, 80.0);
+    assert!(
+        geometry.has_visual_overflow,
+        "extent includes 20px negative overlap and exceeds the remaining paint extent",
+    );
+}
+
+#[test]
+fn sliver_fill_remaining_with_scrollable_keeps_zero_extent_child_in_cache_window() {
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(SliverHost {
+        constraints: vertical_constraints(110.0, 100.0, 0.0, 0.0),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let sliver_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(RenderSliverFillRemainingWithScrollable::new()) as BoxedSliverObject,
+        )
+        .expect("fill remaining sliver");
+    let child_id = owner
+        .render_tree_mut()
+        .insert_box_child(
+            sliver_id,
+            Box::new(FixedHitBox::new(50.0, 10.0)) as BoxedRenderObject,
+        )
+        .expect("box child");
+
+    let owner = laid_out(owner, root_id);
+    let geometry = sliver_geometry(&owner, sliver_id);
+
+    assert_eq!(
+        box_size(&owner, child_id),
+        Size::new(px(300.0), px(10.0)),
+        "when visible extent is zero but cache extent is non-zero, Flutter uses cache extent as maxExtent",
+    );
+    assert_eq!(geometry.scroll_extent, 100.0);
+    assert_eq!(geometry.paint_extent, 0.0);
+    assert_eq!(geometry.max_paint_extent, 0.0);
+    assert_eq!(geometry.hit_test_extent, 0.0);
+    assert_eq!(geometry.cache_extent, 10.0);
+    assert!(geometry.has_visual_overflow);
+    assert!(
+        hits(&owner, 10.0, 0.0).is_empty(),
+        "zero hit_test_extent gates child hits even while cache keeps layout alive",
+    );
+}


### PR DESCRIPTION
## What changed
- Add `RenderSliverFillRemainingWithScrollable`, a single Box child sliver that fills the viewport's remaining paint extent.
- Export the new sliver object from `flui_rendering::objects`.
- Cover Flutter parity math for remaining paint extent, negative overlap, cache-window zero extent layout, geometry, child sizing, paint offset, and hit gating.

## Why
This advances the sliver family beyond viewport/proxy groundwork without entering lazy `MultiBoxAdaptor` machinery yet. The scroll-body variant does not require child intrinsic queries from `SliverLayoutContext`, so it fits the current cross-protocol layout bridge honestly.

## Validation
- `cargo test -p flui-rendering --test sliver_fill_remaining --quiet`
- `cargo test -p flui-rendering --test sliver_fill_remaining --test sliver_to_box_adapter --test render_viewport --quiet`
- `cargo test -p flui-rendering --quiet`
- `cargo fmt --all -- --check`
- `cargo clippy -p flui-rendering --all-targets -- -D warnings`