### PR TITLE
Core.2 Sliver W3.9: add fill remaining intrinsics

### DIFF
--- a/crates/flui-rendering/src/context/layout.rs
+++ b/crates/flui-rendering/src/context/layout.rs
@@ -37,6 +37,7 @@ use crate::{
     constraints::{BoxConstraints, Constraints, SliverConstraints, SliverGeometry},
     parent_data::ParentData,
     protocol::{BoxLayout, LayoutCapability, LayoutContextApi, Protocol},
+    storage::IntrinsicDimension,
 };
 
 // ============================================================================
@@ -417,6 +418,31 @@ where
             index,
             constraints,
         )
+    }
+
+    /// Queries a **Box** child intrinsic dimension from a Sliver parent.
+    pub fn box_child_intrinsic(
+        &mut self,
+        index: usize,
+        dimension: IntrinsicDimension,
+        extent: f32,
+    ) -> f32 {
+        crate::protocol::sliver_protocol::SliverLayoutCtxErased::box_child_intrinsic(
+            &mut self.inner,
+            index,
+            dimension,
+            extent,
+        )
+    }
+
+    /// Convenience wrapper for the child's maximum intrinsic height.
+    pub fn box_child_max_intrinsic_height(&mut self, index: usize, width: f32) -> f32 {
+        self.box_child_intrinsic(index, IntrinsicDimension::MaxHeight, width)
+    }
+
+    /// Convenience wrapper for the child's maximum intrinsic width.
+    pub fn box_child_max_intrinsic_width(&mut self, index: usize, height: f32) -> f32 {
+        self.box_child_intrinsic(index, IntrinsicDimension::MaxWidth, height)
     }
 }
 

--- a/crates/flui-rendering/src/objects/mod.rs
+++ b/crates/flui-rendering/src/objects/mod.rs
@@ -52,6 +52,9 @@
 //!   protocol geometry (Core.2 W3.3)
 //! - [`RenderSliverFillRemainingWithScrollable`] - Sizes one Box child to
 //!   the remaining viewport paint extent (Core.2 W3.8)
+//! - [`RenderSliverFillRemaining`] /
+//!   [`RenderSliverFillRemainingAndOverscroll`] - Non-scroll fill remaining
+//!   variants that use Box child intrinsics (Core.2 W3.9)
 //! - [`RenderViewport`] - Box viewport that drives Sliver children
 //!   (Core.2 W3.4a)
 //!
@@ -122,7 +125,10 @@ pub use padding::RenderPadding;
 pub use paragraph::RenderParagraph;
 pub use repaint_boundary::RenderRepaintBoundary;
 pub use sized_box::RenderSizedBox;
-pub use sliver_fill_remaining::RenderSliverFillRemainingWithScrollable;
+pub use sliver_fill_remaining::{
+    RenderSliverFillRemaining, RenderSliverFillRemainingAndOverscroll,
+    RenderSliverFillRemainingWithScrollable,
+};
 pub use sliver_ignore_pointer::RenderSliverIgnorePointer;
 pub use sliver_offstage::RenderSliverOffstage;
 pub use sliver_opacity::RenderSliverOpacity;

--- a/crates/flui-rendering/src/objects/sliver_fill_remaining.rs
+++ b/crates/flui-rendering/src/objects/sliver_fill_remaining.rs
@@ -10,7 +10,7 @@
 use flui_foundation::Diagnosticable;
 use flui_tree::Single;
 use flui_types::{
-    Offset,
+    Offset, Size,
     geometry::px,
     layout::{AxisDirection, AxisDirection::*},
 };
@@ -163,16 +163,18 @@ impl RenderSliver for RenderSliverFillRemainingAndOverscroll {
             .max(0.0);
         let mut max_extent =
             (self.constraints.remaining_paint_extent - self.constraints.overlap.min(0.0)).max(0.0);
+        let mut child_main_extent = extent;
 
         if ctx.child_count() > 0 {
             let child_extent = child_max_intrinsic_main_extent(ctx, &self.constraints);
             extent = extent.max(child_extent);
             max_extent = max_extent.max(extent);
-            ctx.layout_box_child(
+            let child_size = ctx.layout_box_child(
                 0,
                 self.constraints
                     .as_box_constraints(extent, max_extent, None),
             );
+            child_main_extent = size_main_axis_extent(child_size, &self.constraints);
         }
 
         let painted_child_size = max_extent.min(self.constraints.remaining_paint_extent);
@@ -190,7 +192,10 @@ impl RenderSliver for RenderSliverFillRemainingAndOverscroll {
             ..SliverGeometry::ZERO
         };
         if ctx.child_count() > 0 {
-            ctx.position_child(0, child_paint_offset(&self.constraints, &geometry));
+            ctx.position_child(
+                0,
+                child_paint_offset_for_extent(&self.constraints, &geometry, child_main_extent),
+            );
         }
         self.geometry = geometry;
         ctx.complete(geometry);
@@ -348,7 +353,24 @@ fn child_max_intrinsic_main_extent(
 }
 
 #[inline]
+fn size_main_axis_extent(size: Size, constraints: &SliverConstraints) -> f32 {
+    match constraints.axis_direction.axis() {
+        flui_types::layout::Axis::Horizontal => size.width.get(),
+        flui_types::layout::Axis::Vertical => size.height.get(),
+    }
+}
+
+#[inline]
 fn child_paint_offset(constraints: &SliverConstraints, geometry: &SliverGeometry) -> Offset {
+    child_paint_offset_for_extent(constraints, geometry, geometry.scroll_extent)
+}
+
+#[inline]
+fn child_paint_offset_for_extent(
+    constraints: &SliverConstraints,
+    geometry: &SliverGeometry,
+    child_main_extent: f32,
+) -> Offset {
     match apply_growth_direction_to_axis_direction(
         constraints.axis_direction,
         constraints.growth_direction,
@@ -357,10 +379,10 @@ fn child_paint_offset(constraints: &SliverConstraints, geometry: &SliverGeometry
         LeftToRight => Offset::new(px(-constraints.scroll_offset), px(0.0)),
         BottomToTop => Offset::new(
             px(0.0),
-            px(geometry.paint_extent + constraints.scroll_offset - geometry.scroll_extent),
+            px(geometry.paint_extent + constraints.scroll_offset - child_main_extent),
         ),
         RightToLeft => Offset::new(
-            px(geometry.paint_extent + constraints.scroll_offset - geometry.scroll_extent),
+            px(geometry.paint_extent + constraints.scroll_offset - child_main_extent),
             px(0.0),
         ),
     }

--- a/crates/flui-rendering/src/objects/sliver_fill_remaining.rs
+++ b/crates/flui-rendering/src/objects/sliver_fill_remaining.rs
@@ -1,10 +1,11 @@
-//! `RenderSliverFillRemainingWithScrollable` — single Box child sliver that
-//! fills the remaining viewport paint extent.
+//! `SliverFillRemaining` render objects — single Box child slivers that fill
+//! remaining viewport space.
 //!
-//! This is the scroll-body variant of Flutter's `SliverFillRemaining`: it does
-//! not ask the Box child for intrinsic size, and therefore fits FLUI's current
-//! Sliver -> Box layout bridge without adding a new intrinsic query channel to
-//! `SliverLayoutContext`.
+//! The scroll-body variant sizes directly from paint extent. The non-scroll
+//! variants query the Box child's max intrinsic main-axis extent through the
+//! Sliver -> Box intrinsic bridge and mirror Flutter's
+//! `RenderSliverFillRemaining` / `RenderSliverFillRemainingAndOverscroll`
+//! geometry formulas.
 
 use flui_foundation::Diagnosticable;
 use flui_tree::Single;
@@ -20,6 +21,210 @@ use crate::{
     parent_data::SliverPhysicalParentData,
     traits::{HotReloadCapability, PaintEffectsCapability, RenderSliver, SemanticsCapability},
 };
+
+/// A Sliver-protocol adapter that sizes one non-scrollable Box child to fill
+/// the remaining viewport space, but expands to the child's intrinsic extent
+/// when the child is larger.
+#[derive(Debug, Clone)]
+pub struct RenderSliverFillRemaining {
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl RenderSliverFillRemaining {
+    /// Creates a non-scroll fill-remaining sliver with no laid-out geometry yet.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            constraints: empty_sliver_constraints(),
+            geometry: SliverGeometry::ZERO,
+        }
+    }
+}
+
+impl Default for RenderSliverFillRemaining {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Diagnosticable for RenderSliverFillRemaining {}
+impl PaintEffectsCapability for RenderSliverFillRemaining {}
+impl SemanticsCapability for RenderSliverFillRemaining {}
+impl HotReloadCapability for RenderSliverFillRemaining {}
+
+impl RenderSliver for RenderSliverFillRemaining {
+    type Arity = Single;
+    type ParentData = SliverPhysicalParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Single, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        let mut extent = (self.constraints.viewport_main_axis_extent
+            - self.constraints.preceding_scroll_extent)
+            .max(0.0);
+
+        if ctx.child_count() > 0 {
+            let child_extent = child_max_intrinsic_main_extent(ctx, &self.constraints);
+            extent = extent.max(child_extent);
+            ctx.layout_box_child(0, self.constraints.as_box_constraints(extent, extent, None));
+        }
+
+        let painted_child_size = self.calculate_paint_offset(&self.constraints, 0.0, extent);
+        let cache_extent = self.calculate_cache_offset(&self.constraints, 0.0, extent);
+        let geometry = SliverGeometry {
+            scroll_extent: extent,
+            paint_extent: painted_child_size,
+            layout_extent: painted_child_size,
+            max_paint_extent: painted_child_size,
+            cache_extent,
+            hit_test_extent: painted_child_size,
+            visible: painted_child_size > 0.0,
+            has_visual_overflow: extent > self.constraints.remaining_paint_extent
+                || self.constraints.scroll_offset > 0.0,
+            ..SliverGeometry::ZERO
+        };
+        if ctx.child_count() > 0 {
+            ctx.position_child(0, child_paint_offset(&self.constraints, &geometry));
+        }
+        self.geometry = geometry;
+        ctx.complete(geometry);
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn child_main_axis_position(
+        &self,
+        _child: &dyn crate::traits::RenderObject<crate::protocol::SliverProtocol>,
+    ) -> f32 {
+        -self.constraints.scroll_offset
+    }
+
+    fn paint(&self, ctx: &mut PaintCx<'_, Single>) {
+        if self.geometry.visible {
+            ctx.paint_child();
+        }
+    }
+
+    fn hit_test(&self, ctx: &mut SliverHitTestContext<'_, Single, Self::ParentData>) -> bool {
+        ctx.hit_test_child_at_layout_offset(0)
+    }
+}
+
+/// Non-scroll fill-remaining sliver that also includes overscroll in its
+/// maximum paint extent.
+#[derive(Debug, Clone)]
+pub struct RenderSliverFillRemainingAndOverscroll {
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl RenderSliverFillRemainingAndOverscroll {
+    /// Creates an overscroll-aware fill-remaining sliver.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            constraints: empty_sliver_constraints(),
+            geometry: SliverGeometry::ZERO,
+        }
+    }
+}
+
+impl Default for RenderSliverFillRemainingAndOverscroll {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Diagnosticable for RenderSliverFillRemainingAndOverscroll {}
+impl PaintEffectsCapability for RenderSliverFillRemainingAndOverscroll {}
+impl SemanticsCapability for RenderSliverFillRemainingAndOverscroll {}
+impl HotReloadCapability for RenderSliverFillRemainingAndOverscroll {}
+
+impl RenderSliver for RenderSliverFillRemainingAndOverscroll {
+    type Arity = Single;
+    type ParentData = SliverPhysicalParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Single, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        let mut extent = (self.constraints.viewport_main_axis_extent
+            - self.constraints.preceding_scroll_extent)
+            .max(0.0);
+        let mut max_extent =
+            (self.constraints.remaining_paint_extent - self.constraints.overlap.min(0.0)).max(0.0);
+
+        if ctx.child_count() > 0 {
+            let child_extent = child_max_intrinsic_main_extent(ctx, &self.constraints);
+            extent = extent.max(child_extent);
+            max_extent = max_extent.max(extent);
+            ctx.layout_box_child(
+                0,
+                self.constraints
+                    .as_box_constraints(extent, max_extent, None),
+            );
+        }
+
+        let painted_child_size = max_extent.min(self.constraints.remaining_paint_extent);
+        let cache_extent = self.calculate_cache_offset(&self.constraints, 0.0, extent);
+        let geometry = SliverGeometry {
+            scroll_extent: extent,
+            paint_extent: painted_child_size,
+            layout_extent: painted_child_size,
+            max_paint_extent: max_extent,
+            cache_extent,
+            hit_test_extent: painted_child_size,
+            visible: painted_child_size > 0.0,
+            has_visual_overflow: extent > self.constraints.remaining_paint_extent
+                || self.constraints.scroll_offset > 0.0,
+            ..SliverGeometry::ZERO
+        };
+        if ctx.child_count() > 0 {
+            ctx.position_child(0, child_paint_offset(&self.constraints, &geometry));
+        }
+        self.geometry = geometry;
+        ctx.complete(geometry);
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn child_main_axis_position(
+        &self,
+        _child: &dyn crate::traits::RenderObject<crate::protocol::SliverProtocol>,
+    ) -> f32 {
+        -self.constraints.scroll_offset
+    }
+
+    fn paint(&self, ctx: &mut PaintCx<'_, Single>) {
+        if self.geometry.visible {
+            ctx.paint_child();
+        }
+    }
+
+    fn hit_test(&self, ctx: &mut SliverHitTestContext<'_, Single, Self::ParentData>) -> bool {
+        ctx.hit_test_child_at_layout_offset(0)
+    }
+}
 
 /// A Sliver-protocol adapter that sizes one Box child to the remaining paint
 /// extent of the viewport.
@@ -37,25 +242,6 @@ impl RenderSliverFillRemainingWithScrollable {
         Self {
             constraints: empty_sliver_constraints(),
             geometry: SliverGeometry::ZERO,
-        }
-    }
-
-    #[inline]
-    fn child_paint_offset(constraints: &SliverConstraints, geometry: &SliverGeometry) -> Offset {
-        match apply_growth_direction_to_axis_direction(
-            constraints.axis_direction,
-            constraints.growth_direction,
-        ) {
-            TopToBottom => Offset::new(px(0.0), px(-constraints.scroll_offset)),
-            LeftToRight => Offset::new(px(-constraints.scroll_offset), px(0.0)),
-            BottomToTop => Offset::new(
-                px(0.0),
-                px(geometry.paint_extent + constraints.scroll_offset - geometry.scroll_extent),
-            ),
-            RightToLeft => Offset::new(
-                px(geometry.paint_extent + constraints.scroll_offset - geometry.scroll_extent),
-                px(0.0),
-            ),
         }
     }
 }
@@ -111,8 +297,7 @@ impl RenderSliver for RenderSliverFillRemainingWithScrollable {
             ..SliverGeometry::ZERO
         };
         if ctx.child_count() > 0 {
-            let child_paint_offset = Self::child_paint_offset(&self.constraints, &geometry);
-            ctx.position_child(0, child_paint_offset);
+            ctx.position_child(0, child_paint_offset(&self.constraints, &geometry));
         }
         self.geometry = geometry;
         ctx.complete(geometry);
@@ -145,6 +330,39 @@ impl RenderSliver for RenderSliverFillRemainingWithScrollable {
 
     fn hit_test(&self, ctx: &mut SliverHitTestContext<'_, Single, Self::ParentData>) -> bool {
         ctx.hit_test_child_at_layout_offset(0)
+    }
+}
+
+fn child_max_intrinsic_main_extent(
+    ctx: &mut SliverLayoutContext<'_, Single, SliverPhysicalParentData>,
+    constraints: &SliverConstraints,
+) -> f32 {
+    match constraints.axis_direction.axis() {
+        flui_types::layout::Axis::Horizontal => {
+            ctx.box_child_max_intrinsic_width(0, constraints.cross_axis_extent)
+        }
+        flui_types::layout::Axis::Vertical => {
+            ctx.box_child_max_intrinsic_height(0, constraints.cross_axis_extent)
+        }
+    }
+}
+
+#[inline]
+fn child_paint_offset(constraints: &SliverConstraints, geometry: &SliverGeometry) -> Offset {
+    match apply_growth_direction_to_axis_direction(
+        constraints.axis_direction,
+        constraints.growth_direction,
+    ) {
+        TopToBottom => Offset::new(px(0.0), px(-constraints.scroll_offset)),
+        LeftToRight => Offset::new(px(-constraints.scroll_offset), px(0.0)),
+        BottomToTop => Offset::new(
+            px(0.0),
+            px(geometry.paint_extent + constraints.scroll_offset - geometry.scroll_extent),
+        ),
+        RightToLeft => Offset::new(
+            px(geometry.paint_extent + constraints.scroll_offset - geometry.scroll_extent),
+            px(0.0),
+        ),
     }
 }
 

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -2631,6 +2631,107 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
     Ok(geometry)
 }
 
+/// Recursive Box intrinsic query over the pre-acquired layout subtree.
+///
+/// Used when a Sliver parent needs Flutter-style Box child intrinsics during
+/// layout. It shares the layout walk's [`SubtreeBorrows`] pool instead of
+/// re-entering `PipelineOwner`, preserving the same disjoint-slot discipline as
+/// `layout_subtree_borrowed`.
+unsafe fn box_intrinsic_query_borrowed<'tree>(
+    borrows: &SubtreeBorrows<'tree>,
+    id: RenderId,
+    dimension: crate::storage::IntrinsicDimension,
+    extent: f32,
+) -> crate::error::RenderResult<f32> {
+    ensure_stack(|| {
+        // SAFETY: forwarded from this wrapper; ensure_stack only changes stack
+        // placement, not borrow lifetimes or aliasing.
+        unsafe { box_intrinsic_query_borrowed_impl(borrows, id, dimension, extent) }
+    })
+}
+
+/// Body of [`box_intrinsic_query_borrowed`].
+///
+/// # Safety
+///
+/// Same contract as [`layout_subtree_borrowed`]: `borrows` must outlive this
+/// call and recursive child callbacks, and re-entry into an in-flight node is
+/// rejected by [`LayoutCycleGuard`] before any second mutable reborrow occurs.
+unsafe fn box_intrinsic_query_borrowed_impl<'tree>(
+    borrows: &SubtreeBorrows<'tree>,
+    id: RenderId,
+    dimension: crate::storage::IntrinsicDimension,
+    extent: f32,
+) -> crate::error::RenderResult<f32> {
+    let _cycle_guard = LayoutCycleGuard::enter(borrows, id)?;
+
+    let NodePtr(node_ptr) = match borrows.get(id) {
+        Some(np) => np,
+        None => return Err(crate::error::RenderError::NodeNotFound(id)),
+    };
+
+    // SAFETY: this is the only live reborrow of `id` in this intrinsic query
+    // frame. Recursive callbacks target child slots; cycle guard rejects
+    // attempts to revisit an in-flight ancestor.
+    let node_ref: &mut RenderNode = unsafe { &mut *node_ptr };
+    let node_protocol = node_ref.protocol_name();
+    let entry: &mut RenderEntry<BoxProtocol> = match node_ref.as_box_mut() {
+        Some(e) => e,
+        None => {
+            return Err(crate::error::RenderError::ProtocolMismatch {
+                node_protocol,
+                constraints_protocol: "box",
+            });
+        }
+    };
+
+    if let Some(hit) = entry
+        .state()
+        .layout_cache()
+        .peek_intrinsic(dimension, extent)
+    {
+        return Ok(hit);
+    }
+
+    let child_ids: Vec<RenderId> = entry.links().children().to_vec();
+    let mut child_err: Option<crate::error::RenderError> = None;
+    let value = {
+        let child_err = &mut child_err;
+        let mut child_query =
+            |index: usize, dim: crate::storage::IntrinsicDimension, ext: f32| -> f32 {
+                let Some(&child_id) = child_ids.get(index) else {
+                    child_err.get_or_insert(crate::error::RenderError::contract_violation(
+                        "sliver box child intrinsic query",
+                        "child index out of range for this node's children",
+                    ));
+                    return 0.0;
+                };
+                // SAFETY: the child query uses the same pre-acquired subtree
+                // and targets a child slot distinct from the current box node.
+                match unsafe { box_intrinsic_query_borrowed(borrows, child_id, dim, ext) } {
+                    Ok(value) => value,
+                    Err(err) => {
+                        child_err.get_or_insert(err);
+                        0.0
+                    }
+                }
+            };
+        entry
+            .render_object()
+            .intrinsic_raw(dimension, extent, child_ids.len(), &mut child_query)
+    };
+
+    if let Some(err) = child_err {
+        return Err(err);
+    }
+
+    entry
+        .state_mut()
+        .layout_cache_mut()
+        .insert_intrinsic(dimension, extent, value);
+    Ok(value)
+}
+
 // ============================================================================
 // Cross-protocol child layout: Box parent → Sliver child
 // ============================================================================
@@ -2747,6 +2848,7 @@ unsafe fn layout_sliver_subtree_borrowed_impl<'tree>(
         std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let descendant_error_for_cb = std::sync::Arc::clone(&descendant_error_flag);
     let descendant_error_for_box_cb = std::sync::Arc::clone(&descendant_error_flag);
+    let descendant_error_for_intrinsic_cb = std::sync::Arc::clone(&descendant_error_flag);
     let borrows_for_cb: &SubtreeBorrows<'_> = borrows;
 
     let cb_owned = move |child_id: RenderId,
@@ -2795,12 +2897,39 @@ unsafe fn layout_sliver_subtree_borrowed_impl<'tree>(
     };
     let box_cb_ref: crate::protocol::sliver_protocol::BoxChildLayoutCallback<'_> = &box_cb_owned;
 
+    let box_intrinsic_cb_owned = move |child_id: RenderId,
+                                       dimension: crate::storage::IntrinsicDimension,
+                                       extent: f32|
+          -> f32 {
+        // SAFETY: same subtree-borrow contract as the Sliver -> Box layout
+        // callback, but this read-only sizing query routes through the Box
+        // intrinsic bridge instead of perform_layout.
+        match unsafe { box_intrinsic_query_borrowed(borrows_for_cb, child_id, dimension, extent) } {
+            Ok(value) => value,
+            Err(err) => {
+                descendant_error_for_intrinsic_cb.store(true, std::sync::atomic::Ordering::Relaxed);
+                tracing::error!(
+                    parent = ?id,
+                    ?child_id,
+                    ?err,
+                    "layout_dirty_root: box intrinsic query failed from sliver parent; \
+                     returning 0.0 to caller's perform_layout. \
+                     Parent NEEDS_LAYOUT preserved for next-frame retry.",
+                );
+                0.0
+            }
+        }
+    };
+    let box_intrinsic_cb_ref: crate::protocol::sliver_protocol::BoxChildIntrinsicCallback<'_> =
+        &box_intrinsic_cb_owned;
+
     let mut ctx = crate::protocol::ErasedSliverLayoutCtx::new(
         constraints,
         &mut child_states,
         &child_ids,
         cb_ref,
         box_cb_ref,
+        box_intrinsic_cb_ref,
     );
     let erased: &mut dyn SliverLayoutCtxErased = &mut ctx;
 

--- a/crates/flui-rendering/src/protocol/sliver_protocol.rs
+++ b/crates/flui-rendering/src/protocol/sliver_protocol.rs
@@ -21,6 +21,7 @@ use crate::{
         capabilities::{HitTestCapability, HitTestContextApi, LayoutCapability, LayoutContextApi},
         protocol::{Protocol, ProtocolCompatible, sealed},
     },
+    storage::IntrinsicDimension,
 };
 
 // ============================================================================
@@ -187,6 +188,11 @@ pub type SliverChildLayoutCallback<'a> =
 /// Callback type for cross-protocol box child layout driven by a Sliver parent.
 pub type BoxChildLayoutCallback<'a> = &'a (dyn Fn(RenderId, BoxConstraints) -> Size + Send + Sync);
 
+/// Callback type for cross-protocol box child intrinsic queries driven by a
+/// Sliver parent.
+pub type BoxChildIntrinsicCallback<'a> =
+    &'a (dyn Fn(RenderId, IntrinsicDimension, f32) -> f32 + Send + Sync);
+
 /// Dense per-child geometry cache used by Proxy storage.
 type ProxySliverChildGeometryCache = Vec<Option<SliverGeometry>>;
 
@@ -246,6 +252,7 @@ enum SliverLayoutCtxStorage<'ctx, P: ParentData + Default> {
         child_ids: Option<&'ctx [RenderId]>,
         layout_child_callback: Option<SliverChildLayoutCallback<'ctx>>,
         layout_box_child_callback: Option<BoxChildLayoutCallback<'ctx>>,
+        box_child_intrinsic_callback: Option<BoxChildIntrinsicCallback<'ctx>>,
     },
     /// Bridge path: wraps the erased context from the pipeline boundary.
     ///
@@ -275,6 +282,7 @@ impl<'ctx, A: Arity, P: ParentData + Default> SliverLayoutCtx<'ctx, A, P> {
                 child_ids: None,
                 layout_child_callback: None,
                 layout_box_child_callback: None,
+                box_child_intrinsic_callback: None,
             },
             _phantom: std::marker::PhantomData,
         }
@@ -293,6 +301,7 @@ impl<'ctx, A: Arity, P: ParentData + Default> SliverLayoutCtx<'ctx, A, P> {
                 child_ids: None,
                 layout_child_callback: None,
                 layout_box_child_callback: None,
+                box_child_intrinsic_callback: None,
             },
             _phantom: std::marker::PhantomData,
         }
@@ -305,6 +314,7 @@ impl<'ctx, A: Arity, P: ParentData + Default> SliverLayoutCtx<'ctx, A, P> {
         child_ids: &'ctx [RenderId],
         layout_child_callback: SliverChildLayoutCallback<'ctx>,
         layout_box_child_callback: Option<BoxChildLayoutCallback<'ctx>>,
+        box_child_intrinsic_callback: Option<BoxChildIntrinsicCallback<'ctx>>,
     ) -> Self {
         Self {
             storage: SliverLayoutCtxStorage::Direct {
@@ -314,6 +324,7 @@ impl<'ctx, A: Arity, P: ParentData + Default> SliverLayoutCtx<'ctx, A, P> {
                 child_ids: Some(child_ids),
                 layout_child_callback: Some(layout_child_callback),
                 layout_box_child_callback,
+                box_child_intrinsic_callback,
             },
             _phantom: std::marker::PhantomData,
         }
@@ -436,6 +447,33 @@ impl<'ctx, A: Arity, P: ParentData + Default> SliverLayoutCtx<'ctx, A, P> {
             }
             SliverLayoutCtxStorage::Proxy { erased, .. } => {
                 erased.layout_box_child(index, constraints)
+            }
+        }
+    }
+
+    /// Queries one Box-protocol child's intrinsic dimension.
+    pub fn box_child_intrinsic(
+        &mut self,
+        index: usize,
+        dimension: IntrinsicDimension,
+        extent: f32,
+    ) -> f32 {
+        match &mut self.storage {
+            SliverLayoutCtxStorage::Direct {
+                child_ids,
+                box_child_intrinsic_callback,
+                ..
+            } => {
+                if let (Some(child_ids), Some(callback)) =
+                    (*child_ids, box_child_intrinsic_callback.as_ref())
+                    && let Some(&child_id) = child_ids.get(index)
+                {
+                    return callback(child_id, dimension, extent);
+                }
+                0.0
+            }
+            SliverLayoutCtxStorage::Proxy { erased, .. } => {
+                erased.box_child_intrinsic(index, dimension, extent)
             }
         }
     }
@@ -609,6 +647,14 @@ pub trait SliverLayoutCtxErased: Send + Sync {
     /// Performs synchronous Box layout on child at `index`.
     fn layout_box_child(&mut self, index: usize, constraints: BoxConstraints) -> Size;
 
+    /// Performs a synchronous Box intrinsic query on child at `index`.
+    fn box_child_intrinsic(
+        &mut self,
+        index: usize,
+        dimension: IntrinsicDimension,
+        extent: f32,
+    ) -> f32;
+
     /// Records the paint offset for child at `index`.
     fn position_child(&mut self, index: usize, offset: Offset);
 
@@ -663,6 +709,16 @@ impl<A: Arity, P: ParentData + Default> SliverLayoutCtxErased for SliverLayoutCt
     #[inline]
     fn layout_box_child(&mut self, index: usize, constraints: BoxConstraints) -> Size {
         SliverLayoutCtx::layout_box_child(self, index, constraints)
+    }
+
+    #[inline]
+    fn box_child_intrinsic(
+        &mut self,
+        index: usize,
+        dimension: IntrinsicDimension,
+        extent: f32,
+    ) -> f32 {
+        SliverLayoutCtx::box_child_intrinsic(self, index, dimension, extent)
     }
 
     #[inline]
@@ -750,6 +806,7 @@ pub struct ErasedSliverLayoutCtx<'ctx> {
     child_ids: &'ctx [RenderId],
     layout_child_callback: SliverChildLayoutCallback<'ctx>,
     layout_box_child_callback: BoxChildLayoutCallback<'ctx>,
+    box_child_intrinsic_callback: BoxChildIntrinsicCallback<'ctx>,
 }
 
 impl<'ctx> ErasedSliverLayoutCtx<'ctx> {
@@ -760,6 +817,7 @@ impl<'ctx> ErasedSliverLayoutCtx<'ctx> {
         child_ids: &'ctx [RenderId],
         layout_child_callback: SliverChildLayoutCallback<'ctx>,
         layout_box_child_callback: BoxChildLayoutCallback<'ctx>,
+        box_child_intrinsic_callback: BoxChildIntrinsicCallback<'ctx>,
     ) -> Self {
         Self {
             constraints,
@@ -768,6 +826,7 @@ impl<'ctx> ErasedSliverLayoutCtx<'ctx> {
             child_ids,
             layout_child_callback,
             layout_box_child_callback,
+            box_child_intrinsic_callback,
         }
     }
 
@@ -802,6 +861,18 @@ impl SliverLayoutCtxErased for ErasedSliverLayoutCtx<'_> {
             return Size::ZERO;
         };
         (self.layout_box_child_callback)(child_id, constraints)
+    }
+
+    fn box_child_intrinsic(
+        &mut self,
+        index: usize,
+        dimension: IntrinsicDimension,
+        extent: f32,
+    ) -> f32 {
+        let Some(&child_id) = self.child_ids.get(index) else {
+            return 0.0;
+        };
+        (self.box_child_intrinsic_callback)(child_id, dimension, extent)
     }
 
     fn position_child(&mut self, index: usize, offset: Offset) {

--- a/crates/flui-rendering/tests/sliver_fill_remaining.rs
+++ b/crates/flui-rendering/tests/sliver_fill_remaining.rs
@@ -151,6 +151,56 @@ impl RenderBox for FixedHitBox {
 }
 
 #[derive(Debug)]
+struct ExpandingHitBox {
+    intrinsic: Size,
+    size: Size,
+}
+
+impl ExpandingHitBox {
+    fn new(width: f32, height: f32) -> Self {
+        Self {
+            intrinsic: Size::new(px(width), px(height)),
+            size: Size::ZERO,
+        }
+    }
+}
+
+impl flui_foundation::Diagnosticable for ExpandingHitBox {}
+impl PaintEffectsCapability for ExpandingHitBox {}
+impl SemanticsCapability for ExpandingHitBox {}
+impl HotReloadCapability for ExpandingHitBox {}
+
+impl RenderBox for ExpandingHitBox {
+    type Arity = Leaf;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.size = ctx.constraints().biggest();
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+
+    fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+        ctx.is_within_bounds(Rect::from_origin_size(flui_types::Point::ZERO, self.size))
+    }
+
+    fn compute_max_intrinsic_width(&self, _height: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        self.intrinsic.width.get()
+    }
+
+    fn compute_max_intrinsic_height(&self, _width: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        self.intrinsic.height.get()
+    }
+}
+
+#[derive(Debug)]
 struct IntrinsicProbeSliver {
     constraints: SliverConstraints,
     geometry: SliverGeometry,
@@ -496,4 +546,42 @@ fn sliver_fill_remaining_overscroll_expands_max_paint_extent() {
     assert_eq!(geometry.max_paint_extent, 120.0);
     assert_eq!(geometry.hit_test_extent, 90.0);
     assert_eq!(geometry.cache_extent, 80.0);
+}
+
+#[test]
+fn sliver_fill_remaining_overscroll_reverse_axis_positions_actual_child_extent() {
+    let mut constraints = vertical_constraints(0.0, 20.0, 90.0, -30.0);
+    constraints.axis_direction = AxisDirection::BottomToTop;
+
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(SliverHost {
+        constraints,
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let sliver_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(RenderSliverFillRemainingAndOverscroll::new()) as BoxedSliverObject,
+        )
+        .expect("fill remaining overscroll sliver");
+    let child_id = owner
+        .render_tree_mut()
+        .insert_box_child(
+            sliver_id,
+            Box::new(ExpandingHitBox::new(300.0, 40.0)) as BoxedRenderObject,
+        )
+        .expect("box child");
+
+    let owner = laid_out(owner, root_id);
+    let geometry = sliver_geometry(&owner, sliver_id);
+
+    assert_eq!(box_size(&owner, child_id), Size::new(px(300.0), px(120.0)));
+    assert_eq!(geometry.scroll_extent, 80.0);
+    assert_eq!(geometry.paint_extent, 90.0);
+    assert_eq!(geometry.max_paint_extent, 120.0);
+    assert_eq!(
+        render_offset(&owner, child_id),
+        Offset::new(px(0.0), px(-30.0))
+    );
 }

--- a/crates/flui-rendering/tests/sliver_fill_remaining.rs
+++ b/crates/flui-rendering/tests/sliver_fill_remaining.rs
@@ -1,17 +1,22 @@
 use flui_rendering::{
     constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
-    context::{BoxHitTestContext, BoxLayoutContext},
+    context::{BoxHitTestContext, BoxIntrinsicsCtx, BoxLayoutContext, SliverLayoutContext},
     hit_testing::HitTestResult,
-    objects::RenderSliverFillRemainingWithScrollable,
-    parent_data::BoxParentData,
+    objects::{
+        RenderSliverFillRemaining, RenderSliverFillRemainingAndOverscroll,
+        RenderSliverFillRemainingWithScrollable,
+    },
+    parent_data::{BoxParentData, SliverPhysicalParentData},
     pipeline::PipelineOwner,
     protocol::{BoxProtocol, SliverProtocol},
+    storage::IntrinsicDimension,
     traits::{
-        HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, SemanticsCapability,
+        HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, RenderSliver,
+        SemanticsCapability,
     },
     view::ScrollDirection,
 };
-use flui_tree::Leaf;
+use flui_tree::{Leaf, Single};
 use flui_types::{Offset, Rect, Size, geometry::px, layout::AxisDirection};
 
 type BoxedRenderObject = Box<dyn RenderObject<BoxProtocol>>;
@@ -134,6 +139,79 @@ impl RenderBox for FixedHitBox {
 
     fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
         ctx.is_within_bounds(Rect::from_origin_size(flui_types::Point::ZERO, self.size))
+    }
+
+    fn compute_max_intrinsic_width(&self, _height: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        self.desired.width.get()
+    }
+
+    fn compute_max_intrinsic_height(&self, _width: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        self.desired.height.get()
+    }
+}
+
+#[derive(Debug)]
+struct IntrinsicProbeSliver {
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl Default for IntrinsicProbeSliver {
+    fn default() -> Self {
+        Self {
+            constraints: vertical_constraints(0.0, 0.0, 100.0, 0.0),
+            geometry: SliverGeometry::ZERO,
+        }
+    }
+}
+
+impl flui_foundation::Diagnosticable for IntrinsicProbeSliver {}
+impl PaintEffectsCapability for IntrinsicProbeSliver {}
+impl SemanticsCapability for IntrinsicProbeSliver {}
+impl HotReloadCapability for IntrinsicProbeSliver {}
+
+impl RenderSliver for IntrinsicProbeSliver {
+    type Arity = flui_tree::Single;
+    type ParentData = SliverPhysicalParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Single, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        let child_extent = ctx.box_child_intrinsic(
+            0,
+            IntrinsicDimension::MaxHeight,
+            self.constraints.cross_axis_extent,
+        );
+        if ctx.child_count() > 0 {
+            ctx.layout_box_child(
+                0,
+                self.constraints
+                    .as_box_constraints(child_extent, child_extent, None),
+            );
+        }
+        let paint_extent = self.calculate_paint_offset(&self.constraints, 0.0, child_extent);
+        self.geometry = SliverGeometry {
+            scroll_extent: child_extent,
+            paint_extent,
+            layout_extent: paint_extent,
+            max_paint_extent: paint_extent,
+            hit_test_extent: paint_extent,
+            cache_extent: self.calculate_cache_offset(&self.constraints, 0.0, child_extent),
+            visible: paint_extent > 0.0,
+            ..SliverGeometry::ZERO
+        };
+        ctx.complete(self.geometry);
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
     }
 }
 
@@ -290,4 +368,132 @@ fn sliver_fill_remaining_with_scrollable_keeps_zero_extent_child_in_cache_window
         hits(&owner, 10.0, 0.0).is_empty(),
         "zero hit_test_extent gates child hits even while cache keeps layout alive",
     );
+}
+
+#[test]
+fn sliver_layout_context_queries_box_child_intrinsics() {
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(SliverHost {
+        constraints: vertical_constraints(0.0, 0.0, 100.0, 0.0),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let sliver_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(IntrinsicProbeSliver::default()) as BoxedSliverObject,
+        )
+        .expect("probe sliver");
+    let child_id = owner
+        .render_tree_mut()
+        .insert_box_child(
+            sliver_id,
+            Box::new(FixedHitBox::new(300.0, 140.0)) as BoxedRenderObject,
+        )
+        .expect("box child");
+
+    let owner = laid_out(owner, root_id);
+    let geometry = sliver_geometry(&owner, sliver_id);
+
+    assert_eq!(box_size(&owner, child_id), Size::new(px(300.0), px(140.0)));
+    assert_eq!(geometry.scroll_extent, 140.0);
+    assert_eq!(geometry.paint_extent, 100.0);
+}
+
+#[test]
+fn sliver_fill_remaining_uses_child_intrinsic_when_larger_than_remaining_viewport() {
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(SliverHost {
+        constraints: vertical_constraints(0.0, 30.0, 70.0, 0.0),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let sliver_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(RenderSliverFillRemaining::new()) as BoxedSliverObject,
+        )
+        .expect("fill remaining sliver");
+    let child_id = owner
+        .render_tree_mut()
+        .insert_box_child(
+            sliver_id,
+            Box::new(FixedHitBox::new(300.0, 120.0)) as BoxedRenderObject,
+        )
+        .expect("box child");
+
+    let owner = laid_out(owner, root_id);
+    let geometry = sliver_geometry(&owner, sliver_id);
+
+    assert_eq!(box_size(&owner, child_id), Size::new(px(300.0), px(120.0)));
+    assert_eq!(geometry.scroll_extent, 120.0);
+    assert_eq!(geometry.paint_extent, 70.0);
+    assert_eq!(geometry.max_paint_extent, 70.0);
+    assert_eq!(geometry.hit_test_extent, 70.0);
+    assert_eq!(geometry.cache_extent, 120.0);
+}
+
+#[test]
+fn sliver_fill_remaining_uses_viewport_remainder_when_child_is_smaller() {
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(SliverHost {
+        constraints: vertical_constraints(0.0, 30.0, 70.0, 0.0),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let sliver_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(RenderSliverFillRemaining::new()) as BoxedSliverObject,
+        )
+        .expect("fill remaining sliver");
+    let child_id = owner
+        .render_tree_mut()
+        .insert_box_child(
+            sliver_id,
+            Box::new(FixedHitBox::new(300.0, 20.0)) as BoxedRenderObject,
+        )
+        .expect("box child");
+
+    let owner = laid_out(owner, root_id);
+    let geometry = sliver_geometry(&owner, sliver_id);
+
+    assert_eq!(box_size(&owner, child_id), Size::new(px(300.0), px(70.0)));
+    assert_eq!(geometry.scroll_extent, 70.0);
+    assert_eq!(geometry.paint_extent, 70.0);
+    assert_eq!(geometry.max_paint_extent, 70.0);
+    assert_eq!(geometry.hit_test_extent, 70.0);
+}
+
+#[test]
+fn sliver_fill_remaining_overscroll_expands_max_paint_extent() {
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(SliverHost {
+        constraints: vertical_constraints(0.0, 20.0, 90.0, -30.0),
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let sliver_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(RenderSliverFillRemainingAndOverscroll::new()) as BoxedSliverObject,
+        )
+        .expect("fill remaining overscroll sliver");
+    let child_id = owner
+        .render_tree_mut()
+        .insert_box_child(
+            sliver_id,
+            Box::new(FixedHitBox::new(300.0, 40.0)) as BoxedRenderObject,
+        )
+        .expect("box child");
+
+    let owner = laid_out(owner, root_id);
+    let geometry = sliver_geometry(&owner, sliver_id);
+
+    assert_eq!(box_size(&owner, child_id), Size::new(px(300.0), px(80.0)));
+    assert_eq!(geometry.scroll_extent, 80.0);
+    assert_eq!(geometry.paint_extent, 90.0);
+    assert_eq!(geometry.max_paint_extent, 120.0);
+    assert_eq!(geometry.hit_test_extent, 90.0);
+    assert_eq!(geometry.cache_extent, 80.0);
 }


### PR DESCRIPTION
## Summary
- add a Sliver -> Box intrinsic callback through SliverLayoutContext
- add non-scroll RenderSliverFillRemaining and overscroll RenderSliverFillRemainingAndOverscroll
- cover intrinsic bridge, larger/smaller child sizing, and overscroll max paint extent

## Validation
- cargo fmt --all -- --check
- cargo test -p flui-rendering --quiet
- cargo clippy -p flui-rendering --all-targets -- -D warnings