### PR TITLE
Core.2 Sliver W3.10: add fill viewport

### DIFF
--- a/crates/flui-rendering/src/objects/mod.rs
+++ b/crates/flui-rendering/src/objects/mod.rs
@@ -55,6 +55,8 @@
 //! - [`RenderSliverFillRemaining`] /
 //!   [`RenderSliverFillRemainingAndOverscroll`] - Non-scroll fill remaining
 //!   variants that use Box child intrinsics (Core.2 W3.9)
+//! - [`RenderSliverFillViewport`] - Sizes each Box child to a viewport
+//!   fraction in the sliver main axis (Core.2 W3.10)
 //! - [`RenderViewport`] - Box viewport that drives Sliver children
 //!   (Core.2 W3.4a)
 //!
@@ -92,6 +94,7 @@ mod paragraph;
 mod repaint_boundary;
 mod sized_box;
 mod sliver_fill_remaining;
+mod sliver_fill_viewport;
 mod sliver_ignore_pointer;
 mod sliver_offstage;
 mod sliver_opacity;
@@ -129,6 +132,7 @@ pub use sliver_fill_remaining::{
     RenderSliverFillRemaining, RenderSliverFillRemainingAndOverscroll,
     RenderSliverFillRemainingWithScrollable,
 };
+pub use sliver_fill_viewport::RenderSliverFillViewport;
 pub use sliver_ignore_pointer::RenderSliverIgnorePointer;
 pub use sliver_offstage::RenderSliverOffstage;
 pub use sliver_opacity::RenderSliverOpacity;

--- a/crates/flui-rendering/src/objects/sliver_fill_viewport.rs
+++ b/crates/flui-rendering/src/objects/sliver_fill_viewport.rs
@@ -1,0 +1,222 @@
+//! `RenderSliverFillViewport` — Box children with viewport-fraction extents.
+
+use flui_foundation::Diagnosticable;
+use flui_tree::Variable;
+use flui_types::{
+    Offset,
+    geometry::px,
+    layout::{Axis, AxisDirection::*},
+};
+
+use crate::{
+    constraints::{GrowthDirection, SliverConstraints, SliverGeometry},
+    context::{PaintCx, SliverHitTestContext, SliverLayoutContext},
+    parent_data::SliverPhysicalParentData,
+    traits::{HotReloadCapability, PaintEffectsCapability, RenderSliver, SemanticsCapability},
+};
+
+/// A sliver that sizes each direct Box child to a fraction of the viewport's
+/// main-axis extent.
+///
+/// This is the direct-child FLUI counterpart of Flutter's
+/// `RenderSliverFillViewport`. Lazy child creation remains deferred to the
+/// future multi-box-adaptor layer; attached children are laid out eagerly.
+#[derive(Debug, Clone)]
+pub struct RenderSliverFillViewport {
+    viewport_fraction: f32,
+    allow_implicit_scrolling: bool,
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+    child_count: usize,
+}
+
+impl RenderSliverFillViewport {
+    /// Creates a fill-viewport sliver.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `viewport_fraction <= 0.0`.
+    #[inline]
+    #[must_use]
+    pub fn new(viewport_fraction: f32) -> Self {
+        assert!(
+            viewport_fraction > 0.0,
+            "viewport_fraction must be greater than zero"
+        );
+        Self {
+            viewport_fraction,
+            allow_implicit_scrolling: true,
+            constraints: empty_sliver_constraints(),
+            geometry: SliverGeometry::ZERO,
+            child_count: 0,
+        }
+    }
+
+    /// Fraction of the viewport occupied by each child in the main axis.
+    #[inline]
+    #[must_use]
+    pub const fn viewport_fraction(&self) -> f32 {
+        self.viewport_fraction
+    }
+
+    /// Updates the viewport fraction.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `viewport_fraction <= 0.0`.
+    #[inline]
+    pub fn set_viewport_fraction(&mut self, viewport_fraction: f32) {
+        assert!(
+            viewport_fraction > 0.0,
+            "viewport_fraction must be greater than zero"
+        );
+        self.viewport_fraction = viewport_fraction;
+    }
+
+    /// Whether all children should be available to semantics even when outside
+    /// the visible viewport.
+    #[inline]
+    #[must_use]
+    pub const fn allow_implicit_scrolling(&self) -> bool {
+        self.allow_implicit_scrolling
+    }
+
+    /// Sets the implicit-scrolling semantics flag.
+    #[inline]
+    pub const fn set_allow_implicit_scrolling(&mut self, allow: bool) {
+        self.allow_implicit_scrolling = allow;
+    }
+
+    #[inline]
+    fn item_extent(&self) -> f32 {
+        (self.constraints.viewport_main_axis_extent * self.viewport_fraction).max(0.0)
+    }
+}
+
+impl Default for RenderSliverFillViewport {
+    fn default() -> Self {
+        Self::new(1.0)
+    }
+}
+
+impl Diagnosticable for RenderSliverFillViewport {}
+impl PaintEffectsCapability for RenderSliverFillViewport {}
+impl SemanticsCapability for RenderSliverFillViewport {}
+impl HotReloadCapability for RenderSliverFillViewport {}
+
+impl RenderSliver for RenderSliverFillViewport {
+    type Arity = Variable;
+    type ParentData = SliverPhysicalParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Variable, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        self.child_count = ctx.child_count();
+        let item_extent = self.item_extent();
+
+        for index in 0..self.child_count {
+            ctx.layout_box_child(
+                index,
+                self.constraints
+                    .as_box_constraints(item_extent, item_extent, None),
+            );
+        }
+
+        let scroll_extent = item_extent * self.child_count as f32;
+        let paint_extent = self.calculate_paint_offset(&self.constraints, 0.0, scroll_extent);
+        let cache_extent = self.calculate_cache_offset(&self.constraints, 0.0, scroll_extent);
+        let geometry = SliverGeometry {
+            scroll_extent,
+            paint_extent,
+            layout_extent: paint_extent,
+            max_paint_extent: scroll_extent,
+            cache_extent,
+            hit_test_extent: paint_extent,
+            visible: paint_extent > 0.0,
+            has_visual_overflow: scroll_extent > self.constraints.remaining_paint_extent
+                || self.constraints.scroll_offset > 0.0,
+            ..SliverGeometry::ZERO
+        };
+
+        for index in 0..self.child_count {
+            let layout_offset = item_extent * index as f32;
+            ctx.position_child(
+                index,
+                child_paint_offset(&self.constraints, &geometry, layout_offset, item_extent),
+            );
+        }
+
+        self.geometry = geometry;
+        ctx.complete(geometry);
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn paint(&self, ctx: &mut PaintCx<'_, Variable>) {
+        if self.geometry.visible {
+            ctx.paint_children();
+        }
+    }
+
+    fn hit_test(&self, ctx: &mut SliverHitTestContext<'_, Variable, Self::ParentData>) -> bool {
+        for index in (0..self.child_count).rev() {
+            if ctx.hit_test_child_at_layout_offset(index) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+fn child_paint_offset(
+    constraints: &SliverConstraints,
+    geometry: &SliverGeometry,
+    layout_offset: f32,
+    child_main_extent: f32,
+) -> Offset {
+    let child_main_axis_position = layout_offset - constraints.scroll_offset;
+    let main_axis_delta = if right_way_up(constraints) {
+        child_main_axis_position
+    } else {
+        geometry.paint_extent - child_main_extent - child_main_axis_position
+    };
+
+    match constraints.axis_direction.axis() {
+        Axis::Horizontal => Offset::new(px(main_axis_delta), px(0.0)),
+        Axis::Vertical => Offset::new(px(0.0), px(main_axis_delta)),
+    }
+}
+
+const fn right_way_up(constraints: &SliverConstraints) -> bool {
+    let reversed = constraints.axis_direction.is_reversed();
+    match constraints.growth_direction {
+        GrowthDirection::Forward => !reversed,
+        GrowthDirection::Reverse => reversed,
+    }
+}
+
+const fn empty_sliver_constraints() -> SliverConstraints {
+    SliverConstraints {
+        axis_direction: TopToBottom,
+        growth_direction: GrowthDirection::Forward,
+        user_scroll_direction: crate::view::ScrollDirection::Idle,
+        scroll_offset: 0.0,
+        preceding_scroll_extent: 0.0,
+        overlap: 0.0,
+        remaining_paint_extent: 0.0,
+        cross_axis_extent: 0.0,
+        cross_axis_direction: LeftToRight,
+        viewport_main_axis_extent: 0.0,
+        remaining_cache_extent: 0.0,
+        cache_origin: 0.0,
+    }
+}

--- a/crates/flui-rendering/tests/sliver_fill_viewport.rs
+++ b/crates/flui-rendering/tests/sliver_fill_viewport.rs
@@ -1,0 +1,339 @@
+//! `RenderSliverFillViewport` — direct Box children with viewport-sized extents.
+
+use flui_rendering::{
+    constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
+    context::{BoxHitTestContext, BoxLayoutContext},
+    hit_testing::HitTestResult,
+    objects::RenderSliverFillViewport,
+    parent_data::BoxParentData,
+    pipeline::PipelineOwner,
+    protocol::{BoxProtocol, SliverProtocol},
+    traits::{
+        HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, SemanticsCapability,
+    },
+    view::ScrollDirection,
+};
+use flui_tree::Leaf;
+use flui_types::{Offset, Rect, Size, geometry::px, layout::AxisDirection};
+
+type BoxedRenderObject = Box<dyn RenderObject<BoxProtocol>>;
+type BoxedSliverObject = Box<dyn RenderObject<SliverProtocol>>;
+
+fn vertical_constraints(scroll_offset: f32) -> SliverConstraints {
+    SliverConstraints {
+        axis_direction: AxisDirection::TopToBottom,
+        cross_axis_direction: AxisDirection::LeftToRight,
+        growth_direction: GrowthDirection::Forward,
+        user_scroll_direction: ScrollDirection::Idle,
+        scroll_offset,
+        preceding_scroll_extent: 0.0,
+        overlap: 0.0,
+        remaining_paint_extent: 100.0,
+        cross_axis_extent: 300.0,
+        viewport_main_axis_extent: 100.0,
+        remaining_cache_extent: 120.0,
+        cache_origin: -20.0,
+    }
+}
+
+fn horizontal_constraints(scroll_offset: f32) -> SliverConstraints {
+    SliverConstraints {
+        axis_direction: AxisDirection::LeftToRight,
+        cross_axis_direction: AxisDirection::TopToBottom,
+        growth_direction: GrowthDirection::Forward,
+        user_scroll_direction: ScrollDirection::Idle,
+        scroll_offset,
+        preceding_scroll_extent: 0.0,
+        overlap: 0.0,
+        remaining_paint_extent: 300.0,
+        cross_axis_extent: 100.0,
+        viewport_main_axis_extent: 300.0,
+        remaining_cache_extent: 320.0,
+        cache_origin: -20.0,
+    }
+}
+
+fn laid_out(
+    mut owner: PipelineOwner,
+    root: flui_foundation::RenderId,
+) -> PipelineOwner<flui_rendering::pipeline::phase::Layout> {
+    owner.set_root_id(Some(root));
+    owner.set_root_constraints(Some(BoxConstraints::tight(Size::new(px(300.0), px(100.0)))));
+    let mut owner = owner.into_layout();
+    owner.run_layout().expect("layout succeeds");
+    owner
+}
+
+fn sliver_geometry(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    id: flui_foundation::RenderId,
+) -> SliverGeometry {
+    owner
+        .render_tree()
+        .get(id)
+        .and_then(|node| node.as_sliver())
+        .and_then(|entry| entry.state().geometry())
+        .expect("sliver geometry is committed")
+}
+
+fn box_size(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    id: flui_foundation::RenderId,
+) -> Size {
+    owner
+        .render_tree()
+        .get(id)
+        .and_then(|node| node.as_box())
+        .and_then(|entry| entry.state().geometry())
+        .expect("box geometry is committed")
+}
+
+fn render_offset(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    id: flui_foundation::RenderId,
+) -> Offset {
+    owner
+        .render_tree()
+        .get(id)
+        .map(flui_rendering::storage::RenderNode::offset)
+        .expect("node exists")
+}
+
+fn hits(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    cross: f32,
+    main: f32,
+) -> Vec<flui_foundation::RenderId> {
+    let mut result = HitTestResult::new();
+    owner.hit_test(Offset::new(px(cross), px(main)), &mut result);
+    result.path().iter().map(|entry| entry.target).collect()
+}
+
+#[derive(Debug)]
+struct FixedHitBox {
+    desired: Size,
+    size: Size,
+}
+
+impl FixedHitBox {
+    fn new(width: f32, height: f32) -> Self {
+        Self {
+            desired: Size::new(px(width), px(height)),
+            size: Size::ZERO,
+        }
+    }
+}
+
+impl flui_foundation::Diagnosticable for FixedHitBox {}
+impl PaintEffectsCapability for FixedHitBox {}
+impl SemanticsCapability for FixedHitBox {}
+impl HotReloadCapability for FixedHitBox {}
+
+impl RenderBox for FixedHitBox {
+    type Arity = Leaf;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.size = ctx.constraints().constrain(self.desired);
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+
+    fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+        ctx.is_within_bounds(Rect::from_origin_size(flui_types::Point::ZERO, self.size))
+    }
+}
+
+#[derive(Debug)]
+struct SliverHost {
+    constraints: SliverConstraints,
+    size: Size,
+}
+
+impl flui_foundation::Diagnosticable for SliverHost {}
+impl PaintEffectsCapability for SliverHost {}
+impl SemanticsCapability for SliverHost {}
+impl HotReloadCapability for SliverHost {}
+
+impl RenderBox for SliverHost {
+    type Arity = flui_tree::Variable;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(
+        &mut self,
+        ctx: &mut BoxLayoutContext<'_, flui_tree::Variable, Self::ParentData>,
+    ) {
+        if ctx.child_count() > 0 {
+            let _ = ctx.layout_sliver_child(0, self.constraints);
+        }
+        self.size = ctx.constraints().biggest();
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+
+    fn hit_test(
+        &self,
+        ctx: &mut BoxHitTestContext<'_, flui_tree::Variable, Self::ParentData>,
+    ) -> bool {
+        ctx.hit_test_child_at_layout_offset(0)
+    }
+}
+
+fn fill_viewport_tree(
+    constraints: SliverConstraints,
+    viewport_fraction: f32,
+    child_count: usize,
+) -> (
+    PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    flui_foundation::RenderId,
+    flui_foundation::RenderId,
+    Vec<flui_foundation::RenderId>,
+) {
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(SliverHost {
+        constraints,
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let sliver_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(RenderSliverFillViewport::new(viewport_fraction)) as BoxedSliverObject,
+        )
+        .expect("fill viewport sliver");
+    let mut child_ids = Vec::with_capacity(child_count);
+    for _ in 0..child_count {
+        let child_id = owner
+            .render_tree_mut()
+            .insert_box_child(
+                sliver_id,
+                Box::new(FixedHitBox::new(1000.0, 1000.0)) as BoxedRenderObject,
+            )
+            .expect("box child");
+        child_ids.push(child_id);
+    }
+
+    (laid_out(owner, root_id), root_id, sliver_id, child_ids)
+}
+
+#[test]
+fn sliver_fill_viewport_sizes_children_to_viewport_fraction() {
+    let (owner, _root_id, sliver_id, child_ids) =
+        fill_viewport_tree(vertical_constraints(40.0), 0.5, 3);
+
+    let geometry = sliver_geometry(&owner, sliver_id);
+    assert_eq!(geometry.scroll_extent, 150.0);
+    assert_eq!(geometry.paint_extent, 100.0);
+    assert_eq!(geometry.layout_extent, 100.0);
+    assert_eq!(geometry.max_paint_extent, 150.0);
+    assert_eq!(geometry.hit_test_extent, 100.0);
+    assert_eq!(geometry.cache_extent, 120.0);
+    assert!(geometry.has_visual_overflow);
+
+    assert_eq!(
+        box_size(&owner, child_ids[0]),
+        Size::new(px(300.0), px(50.0))
+    );
+    assert_eq!(
+        box_size(&owner, child_ids[1]),
+        Size::new(px(300.0), px(50.0))
+    );
+    assert_eq!(
+        box_size(&owner, child_ids[2]),
+        Size::new(px(300.0), px(50.0))
+    );
+    assert_eq!(
+        render_offset(&owner, child_ids[0]),
+        Offset::new(px(0.0), px(-40.0)),
+    );
+    assert_eq!(
+        render_offset(&owner, child_ids[1]),
+        Offset::new(px(0.0), px(10.0)),
+    );
+    assert_eq!(
+        render_offset(&owner, child_ids[2]),
+        Offset::new(px(0.0), px(60.0)),
+    );
+}
+
+#[test]
+fn sliver_fill_viewport_hit_tests_visible_page_children() {
+    let (owner, root_id, sliver_id, child_ids) =
+        fill_viewport_tree(vertical_constraints(40.0), 0.5, 3);
+
+    assert_eq!(
+        hits(&owner, 10.0, 20.0),
+        vec![child_ids[1], sliver_id, root_id],
+        "global y=20 maps to child 1 after the 40px scroll offset",
+    );
+    assert_eq!(
+        hits(&owner, 10.0, 70.0),
+        vec![child_ids[2], sliver_id, root_id],
+        "global y=70 maps to child 2 after the 40px scroll offset",
+    );
+}
+
+#[test]
+fn sliver_fill_viewport_supports_horizontal_axis() {
+    let (owner, _root_id, _sliver_id, child_ids) =
+        fill_viewport_tree(horizontal_constraints(30.0), 0.25, 2);
+
+    assert_eq!(
+        box_size(&owner, child_ids[0]),
+        Size::new(px(75.0), px(100.0))
+    );
+    assert_eq!(
+        box_size(&owner, child_ids[1]),
+        Size::new(px(75.0), px(100.0))
+    );
+    assert_eq!(
+        render_offset(&owner, child_ids[0]),
+        Offset::new(px(-30.0), px(0.0)),
+    );
+    assert_eq!(
+        render_offset(&owner, child_ids[1]),
+        Offset::new(px(45.0), px(0.0)),
+    );
+}
+
+#[test]
+fn sliver_fill_viewport_reverse_axis_uses_right_way_up_offsets() {
+    let mut constraints = vertical_constraints(40.0);
+    constraints.axis_direction = AxisDirection::BottomToTop;
+    let (owner, root_id, sliver_id, child_ids) = fill_viewport_tree(constraints, 0.5, 3);
+
+    assert_eq!(
+        render_offset(&owner, child_ids[0]),
+        Offset::new(px(0.0), px(90.0)),
+    );
+    assert_eq!(
+        render_offset(&owner, child_ids[1]),
+        Offset::new(px(0.0), px(40.0)),
+    );
+    assert_eq!(
+        render_offset(&owner, child_ids[2]),
+        Offset::new(px(0.0), px(-10.0)),
+    );
+    assert_eq!(
+        hits(&owner, 10.0, 20.0),
+        vec![child_ids[2], sliver_id, root_id]
+    );
+    assert_eq!(
+        hits(&owner, 10.0, 70.0),
+        vec![child_ids[1], sliver_id, root_id]
+    );
+}


### PR DESCRIPTION
## Summary
- add eager direct-child RenderSliverFillViewport with viewportFraction sizing
- export the new sliver object from flui-rendering objects
- cover geometry, vertical/horizontal sizing, visible child hit-testing, and reverse-axis right-way-up offsets

## Validation
- cargo fmt --all -- --check
- cargo test -p flui-rendering --quiet
- cargo clippy -p flui-rendering --all-targets -- -D warnings