### PR TITLE
Core2 W3.11 sliver geometry validation

### DIFF
--- a/crates/flui-rendering/src/constraints/sliver_geometry.rs
+++ b/crates/flui-rendering/src/constraints/sliver_geometry.rs
@@ -305,8 +305,8 @@ impl SliverGeometry {
     #[inline]
     #[must_use]
     pub fn validation_error(&self) -> Option<&'static str> {
-        if !self.scroll_extent.is_finite() {
-            return Some("scroll_extent is not finite");
+        if self.scroll_extent.is_nan() {
+            return Some("scroll_extent is NaN");
         }
         if !self.paint_extent.is_finite() {
             return Some("paint_extent is not finite");
@@ -317,8 +317,8 @@ impl SliverGeometry {
         if !self.layout_extent.is_finite() {
             return Some("layout_extent is not finite");
         }
-        if !self.max_paint_extent.is_finite() {
-            return Some("max_paint_extent is not finite");
+        if self.max_paint_extent.is_nan() {
+            return Some("max_paint_extent is NaN");
         }
         if !self.max_scroll_obstruction_extent.is_finite() {
             return Some("max_scroll_obstruction_extent is not finite");
@@ -570,5 +570,21 @@ mod tests {
             geometry.validation_error(),
             Some("paint_extent exceeds max_paint_extent")
         );
+    }
+
+    #[test]
+    fn validation_allows_infinite_scroll_and_max_paint_extents() {
+        let geometry = SliverGeometry {
+            scroll_extent: f32::INFINITY,
+            paint_extent: 100.0,
+            layout_extent: 100.0,
+            max_paint_extent: f32::INFINITY,
+            hit_test_extent: 100.0,
+            cache_extent: 120.0,
+            visible: true,
+            ..SliverGeometry::ZERO
+        };
+
+        assert_eq!(geometry.validation_error(), None);
     }
 }

--- a/crates/flui-rendering/src/constraints/sliver_geometry.rs
+++ b/crates/flui-rendering/src/constraints/sliver_geometry.rs
@@ -8,6 +8,8 @@ use std::{
     hash::{Hash, Hasher},
 };
 
+const PRECISION_ERROR_TOLERANCE: f32 = flui_foundation::EPSILON_F32;
+
 /// Layout output describing space occupied by a sliver.
 ///
 /// After a sliver performs layout, it returns geometry describing:
@@ -299,46 +301,90 @@ impl SliverGeometry {
     // VALIDATION
     // ============================================================================
 
+    /// Returns the first Flutter-compatible geometry invariant violation.
+    #[inline]
+    #[must_use]
+    pub fn validation_error(&self) -> Option<&'static str> {
+        if !self.scroll_extent.is_finite() {
+            return Some("scroll_extent is not finite");
+        }
+        if !self.paint_extent.is_finite() {
+            return Some("paint_extent is not finite");
+        }
+        if !self.paint_origin.is_finite() {
+            return Some("paint_origin is not finite");
+        }
+        if !self.layout_extent.is_finite() {
+            return Some("layout_extent is not finite");
+        }
+        if !self.max_paint_extent.is_finite() {
+            return Some("max_paint_extent is not finite");
+        }
+        if !self.max_scroll_obstruction_extent.is_finite() {
+            return Some("max_scroll_obstruction_extent is not finite");
+        }
+        if !self.hit_test_extent.is_finite() {
+            return Some("hit_test_extent is not finite");
+        }
+        if !self.cache_extent.is_finite() {
+            return Some("cache_extent is not finite");
+        }
+
+        if self.scroll_extent < 0.0 {
+            return Some("scroll_extent is negative");
+        }
+        if self.paint_extent < 0.0 {
+            return Some("paint_extent is negative");
+        }
+        if self.layout_extent < 0.0 {
+            return Some("layout_extent is negative");
+        }
+        if self.max_paint_extent < 0.0 {
+            return Some("max_paint_extent is negative");
+        }
+        if self.max_scroll_obstruction_extent < 0.0 {
+            return Some("max_scroll_obstruction_extent is negative");
+        }
+        if self.hit_test_extent < 0.0 {
+            return Some("hit_test_extent is negative");
+        }
+        if self.cache_extent < 0.0 {
+            return Some("cache_extent is negative");
+        }
+
+        if let Some(extent) = self.cross_axis_extent {
+            if !extent.is_finite() {
+                return Some("cross_axis_extent is not finite");
+            }
+            if extent < 0.0 {
+                return Some("cross_axis_extent is negative");
+            }
+        }
+
+        if self.layout_extent > self.paint_extent {
+            return Some("layout_extent exceeds paint_extent");
+        }
+        if self.paint_extent - self.max_paint_extent > PRECISION_ERROR_TOLERANCE {
+            return Some("paint_extent exceeds max_paint_extent");
+        }
+
+        if let Some(correction) = self.scroll_offset_correction {
+            if !correction.is_finite() {
+                return Some("scroll_offset_correction is not finite");
+            }
+            if correction == 0.0 {
+                return Some("scroll_offset_correction is zero");
+            }
+        }
+
+        None
+    }
+
     /// Validates geometry invariants in debug builds.
     #[cfg(debug_assertions)]
     pub fn debug_assert_valid(&self) {
-        debug_assert!(
-            self.scroll_extent >= 0.0,
-            "scroll_extent must be non-negative: {}",
-            self.scroll_extent
-        );
-
-        debug_assert!(
-            self.paint_extent >= 0.0,
-            "paint_extent must be non-negative: {}",
-            self.paint_extent
-        );
-
-        debug_assert!(
-            self.layout_extent >= 0.0,
-            "layout_extent must be non-negative: {}",
-            self.layout_extent
-        );
-
-        debug_assert!(
-            self.max_paint_extent >= self.paint_extent,
-            "max_paint_extent ({}) must be >= paint_extent ({})",
-            self.max_paint_extent,
-            self.paint_extent
-        );
-
-        debug_assert!(
-            self.cache_extent >= self.layout_extent,
-            "cache_extent ({}) must be >= layout_extent ({})",
-            self.cache_extent,
-            self.layout_extent
-        );
-
-        if let Some(correction) = self.scroll_offset_correction {
-            debug_assert!(
-                correction != 0.0,
-                "scroll_offset_correction must be non-zero if set"
-            );
+        if let Some(reason) = self.validation_error() {
+            debug_assert!(false, "SliverGeometry is not valid: {reason}: {self:?}");
         }
     }
 
@@ -481,5 +527,48 @@ mod tests {
     fn test_validation() {
         let valid = SliverGeometry::new(100.0, 50.0, 0.0);
         valid.debug_assert_valid(); // Should not panic
+    }
+
+    #[test]
+    fn validation_rejects_non_finite_and_negative_extents() {
+        let geometry = SliverGeometry {
+            hit_test_extent: -1.0,
+            ..SliverGeometry::new(100.0, 50.0, 0.0)
+        };
+        assert_eq!(
+            geometry.validation_error(),
+            Some("hit_test_extent is negative")
+        );
+
+        let geometry = SliverGeometry {
+            paint_origin: f32::NAN,
+            ..SliverGeometry::new(100.0, 50.0, 0.0)
+        };
+        assert_eq!(
+            geometry.validation_error(),
+            Some("paint_origin is not finite")
+        );
+    }
+
+    #[test]
+    fn validation_allows_precision_tolerance_for_max_paint_extent() {
+        let geometry = SliverGeometry {
+            paint_extent: 1.0,
+            layout_extent: 1.0,
+            max_paint_extent: 1.0 - flui_foundation::EPSILON_F32 / 2.0,
+            ..SliverGeometry::ZERO
+        };
+        assert_eq!(geometry.validation_error(), None);
+
+        let geometry = SliverGeometry {
+            paint_extent: 1.0,
+            layout_extent: 1.0,
+            max_paint_extent: 1.0 - flui_foundation::EPSILON_F32 * 2.0,
+            ..SliverGeometry::ZERO
+        };
+        assert_eq!(
+            geometry.validation_error(),
+            Some("paint_extent exceeds max_paint_extent")
+        );
     }
 }

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -2579,9 +2579,11 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
     // On the Err path above, state is intentionally unmodified so
     // NEEDS_LAYOUT stays set for next-frame retry.
 
-    // Same protocol-generic geometry check the leaf commit runs
-    // (RenderEntry::layout_leaf_only) — Flutter's debugAssertDoesMeetConstraints:
-    // a finite size that satisfies the constraints. No-op for slivers.
+    // Same protocol-generic geometry guards the leaf commit runs
+    // (RenderEntry::layout_leaf_only). Runtime validation happens before
+    // state commit; debug assertions then mirror Flutter's debug-only
+    // contract checks.
+    <BoxProtocol as Protocol>::validate_layout_output(debug_name, &constraints, &geometry)?;
     <BoxProtocol as Protocol>::debug_assert_layout_output(&constraints, &geometry);
 
     entry.state_mut().set_geometry(geometry);
@@ -2956,6 +2958,7 @@ unsafe fn layout_sliver_subtree_borrowed_impl<'tree>(
         }
     };
 
+    <SliverProtocol as Protocol>::validate_layout_output(debug_name, &constraints, &geometry)?;
     <SliverProtocol as Protocol>::debug_assert_layout_output(&constraints, &geometry);
 
     entry.state_mut().set_geometry(geometry);

--- a/crates/flui-rendering/src/protocol/protocol.rs
+++ b/crates/flui-rendering/src/protocol/protocol.rs
@@ -152,6 +152,25 @@ pub trait Protocol: Send + Sync + Debug + Clone + Copy + sealed::Sealed + 'stati
         let _ = (constraints, geometry);
     }
 
+    /// Runtime validation for a freshly computed layout result before it is
+    /// committed to [`RenderState`](crate::storage::RenderState).
+    ///
+    /// The default is a no-op. Protocols with recoverable geometry contracts
+    /// override this to surface
+    /// [`RenderError::InvalidGeometry`](crate::error::RenderError::InvalidGeometry)
+    /// while leaving the previous committed geometry intact.
+    fn validate_layout_output(
+        render_object: &'static str,
+        constraints: &<Self::Layout as LayoutCapability>::Constraints,
+        geometry: &<Self::Layout as LayoutCapability>::Geometry,
+    ) -> crate::error::RenderResult<()>
+    where
+        Self: Sized,
+    {
+        let _ = (render_object, constraints, geometry);
+        Ok(())
+    }
+
     /// Constructs a leaf-mode (no children, no layout callback) erased
     /// layout context from protocol-typed constraints, then invokes `f`
     /// with a `&mut Self::LayoutCtxErased<'_>` referencing it.

--- a/crates/flui-rendering/src/protocol/sliver_protocol.rs
+++ b/crates/flui-rendering/src/protocol/sliver_protocol.rs
@@ -54,6 +54,26 @@ impl Protocol for SliverProtocol {
         "sliver"
     }
 
+    fn debug_assert_layout_output(constraints: &SliverConstraints, geometry: &SliverGeometry) {
+        let _ = constraints;
+        geometry.debug_assert_valid();
+    }
+
+    fn validate_layout_output(
+        render_object: &'static str,
+        constraints: &SliverConstraints,
+        geometry: &SliverGeometry,
+    ) -> crate::error::RenderResult<()> {
+        let _ = constraints;
+        if let Some(reason) = geometry.validation_error() {
+            return Err(crate::error::RenderError::invalid_geometry(
+                render_object,
+                reason,
+            ));
+        }
+        Ok(())
+    }
+
     /// D-block PR-A1b U19 — Sliver counterpart to
     /// [`BoxProtocol::with_leaf_erased_ctx`](super::BoxProtocol::with_leaf_erased_ctx).
     /// Wraps the given `SliverConstraints` in a typed

--- a/crates/flui-rendering/src/storage/entry.rs
+++ b/crates/flui-rendering/src/storage/entry.rs
@@ -386,6 +386,11 @@ impl<P: Protocol> RenderEntry<P> {
 
         // Update state -- only on the success path. On panic, state remains
         // untouched and NEEDS_LAYOUT stays set so a retry is possible.
+        <P as crate::protocol::Protocol>::validate_layout_output(
+            debug_name,
+            &constraints,
+            &geometry,
+        )?;
         <P as crate::protocol::Protocol>::debug_assert_layout_output(&constraints, &geometry);
         self.state.set_geometry(geometry.clone());
         self.state.set_constraints(constraints);

--- a/crates/flui-rendering/tests/sliver_geometry_validation.rs
+++ b/crates/flui-rendering/tests/sliver_geometry_validation.rs
@@ -1,0 +1,242 @@
+//! Runtime validation for `SliverGeometry` layout results.
+
+use std::sync::{Arc, Mutex};
+
+use flui_foundation::Diagnosticable;
+use flui_rendering::{
+    constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
+    context::{BoxLayoutContext, SliverHitTestContext, SliverLayoutContext},
+    error::RenderError,
+    parent_data::{BoxParentData, SliverParentData},
+    pipeline::PipelineOwner,
+    protocol::{BoxProtocol, SliverProtocol},
+    traits::{
+        HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, RenderSliver,
+        SemanticsCapability,
+    },
+    view::ScrollDirection,
+};
+use flui_tree::{Leaf, Variable};
+use flui_types::{Point, Rect, Size, geometry::px, layout::AxisDirection};
+
+type BoxedRenderObject = Box<dyn RenderObject<BoxProtocol>>;
+type BoxedSliverObject = Box<dyn RenderObject<SliverProtocol>>;
+
+fn sliver_constraints() -> SliverConstraints {
+    SliverConstraints {
+        axis_direction: AxisDirection::TopToBottom,
+        cross_axis_direction: AxisDirection::LeftToRight,
+        growth_direction: GrowthDirection::Forward,
+        user_scroll_direction: ScrollDirection::Idle,
+        scroll_offset: 0.0,
+        preceding_scroll_extent: 0.0,
+        overlap: 0.0,
+        remaining_paint_extent: 100.0,
+        cross_axis_extent: 300.0,
+        viewport_main_axis_extent: 100.0,
+        remaining_cache_extent: 120.0,
+        cache_origin: -20.0,
+    }
+}
+
+fn invalid_layout_exceeds_paint_geometry() -> SliverGeometry {
+    SliverGeometry {
+        scroll_extent: 100.0,
+        paint_extent: 10.0,
+        layout_extent: 20.0,
+        max_paint_extent: 100.0,
+        hit_test_extent: 10.0,
+        cache_extent: 20.0,
+        visible: true,
+        ..SliverGeometry::ZERO
+    }
+}
+
+fn assert_invalid_geometry(err: RenderError, expected_reason: &'static str) {
+    match err {
+        RenderError::InvalidGeometry {
+            render_object: _,
+            reason,
+        } => assert_eq!(reason, expected_reason),
+        other => panic!("expected InvalidGeometry, got {other:?}"),
+    }
+}
+
+#[derive(Debug)]
+struct BadGeometrySliver {
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+}
+
+impl BadGeometrySliver {
+    fn new(geometry: SliverGeometry) -> Self {
+        Self {
+            constraints: SliverConstraints::default(),
+            geometry,
+        }
+    }
+}
+
+impl Diagnosticable for BadGeometrySliver {}
+impl PaintEffectsCapability for BadGeometrySliver {}
+impl SemanticsCapability for BadGeometrySliver {}
+impl HotReloadCapability for BadGeometrySliver {}
+
+impl RenderSliver for BadGeometrySliver {
+    type Arity = Leaf;
+    type ParentData = SliverParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        ctx.complete(self.geometry);
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn hit_test(&self, _ctx: &mut SliverHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+        false
+    }
+
+    fn sliver_paint_bounds(&self) -> Rect {
+        Rect::from_origin_size(Point::ZERO, Size::ZERO)
+    }
+}
+
+#[derive(Debug)]
+struct BoxWithSliverChild {
+    sliver_constraints: SliverConstraints,
+    captured: Arc<Mutex<Option<SliverGeometry>>>,
+    size: Size,
+}
+
+impl BoxWithSliverChild {
+    fn new(
+        sliver_constraints: SliverConstraints,
+        captured: Arc<Mutex<Option<SliverGeometry>>>,
+    ) -> Self {
+        Self {
+            sliver_constraints,
+            captured,
+            size: Size::ZERO,
+        }
+    }
+}
+
+impl Diagnosticable for BoxWithSliverChild {}
+impl PaintEffectsCapability for BoxWithSliverChild {}
+impl SemanticsCapability for BoxWithSliverChild {}
+impl HotReloadCapability for BoxWithSliverChild {}
+
+impl RenderBox for BoxWithSliverChild {
+    type Arity = Variable;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Variable, Self::ParentData>) {
+        let geometry = ctx.layout_sliver_child(0, self.sliver_constraints);
+        *self.captured.lock().unwrap() = Some(geometry);
+        self.size = ctx.constraints().biggest();
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+}
+
+#[test]
+fn sliver_leaf_layout_rejects_invalid_geometry_before_state_commit() {
+    let mut owner = PipelineOwner::new();
+    let sliver_id = owner
+        .render_tree_mut()
+        .insert_sliver(Box::new(BadGeometrySliver::new(
+            invalid_layout_exceeds_paint_geometry(),
+        )) as BoxedSliverObject);
+
+    let entry = owner
+        .render_tree_mut()
+        .get_mut(sliver_id)
+        .and_then(|node| node.as_sliver_mut())
+        .expect("sliver entry");
+    let err = entry
+        .layout_leaf_only(sliver_constraints())
+        .expect_err("invalid sliver geometry must fail layout");
+
+    assert_invalid_geometry(err, "layout_extent exceeds paint_extent");
+    assert!(
+        entry.state().geometry().is_none(),
+        "invalid geometry must not be committed to RenderState"
+    );
+    assert!(
+        entry.needs_layout(),
+        "failed sliver layout must stay dirty for retry"
+    );
+}
+
+#[test]
+fn sliver_descendant_invalid_geometry_returns_zero_and_keeps_parent_dirty() {
+    let captured: Arc<Mutex<Option<SliverGeometry>>> = Arc::new(Mutex::new(None));
+    let parent_obj: BoxedRenderObject = Box::new(BoxWithSliverChild::new(
+        sliver_constraints(),
+        Arc::clone(&captured),
+    ));
+    let sliver_obj: BoxedSliverObject = Box::new(BadGeometrySliver::new(
+        invalid_layout_exceeds_paint_geometry(),
+    ));
+
+    let mut pipeline = PipelineOwner::new().into_layout();
+    let parent_id = pipeline.render_tree_mut().insert_box(parent_obj);
+    let sliver_id = pipeline
+        .render_tree_mut()
+        .insert_sliver_child(parent_id, sliver_obj)
+        .expect("tree accepts sliver child");
+
+    pipeline
+        .layout_dirty_root(
+            parent_id,
+            BoxConstraints::new(px(0.0), px(800.0), px(0.0), px(600.0)),
+        )
+        .expect("parent layout still completes; descendant error is isolated");
+
+    assert_eq!(
+        captured.lock().unwrap().expect("parent saw child layout"),
+        SliverGeometry::ZERO,
+        "invalid descendant geometry must be replaced with ZERO for the parent"
+    );
+
+    let parent_node = pipeline
+        .render_tree()
+        .get(parent_id)
+        .expect("parent remains in tree");
+    assert!(
+        parent_node.needs_layout(),
+        "descendant InvalidGeometry must keep the parent dirty for retry"
+    );
+
+    let sliver_entry = pipeline
+        .render_tree()
+        .get(sliver_id)
+        .and_then(|node| node.as_sliver())
+        .expect("sliver entry remains in tree");
+    assert!(
+        sliver_entry.state().geometry().is_none(),
+        "invalid descendant geometry must not be committed"
+    );
+    assert!(
+        sliver_entry.needs_layout(),
+        "invalid descendant must stay dirty for retry"
+    );
+}


### PR DESCRIPTION
## Summary

- add Flutter-compatible runtime validation for SliverGeometry invariants
- reject invalid sliver geometry before RenderState commit in leaf and subtree layout paths
- add regression coverage for direct leaf layout and Box-to-Sliver descendant retry behavior

## Validation

- cargo fmt --all -- --check
- cargo test -p flui-rendering --quiet
- cargo clippy -p flui-rendering --all-targets -- -D warnings
