### PR TITLE
Core2 W3.16 centralize sliver direction helpers

### DIFF
--- a/crates/flui-rendering/src/constraints/direction.rs
+++ b/crates/flui-rendering/src/constraints/direction.rs
@@ -4,6 +4,8 @@
 
 use std::fmt;
 
+use flui_types::layout::AxisDirection;
+
 /// Direction in which content grows within a scrollable area.
 ///
 /// Determines whether new content is added at the end (Forward) or
@@ -84,6 +86,19 @@ impl GrowthDirection {
         }
     }
 
+    /// Applies growth direction to an axis direction.
+    ///
+    /// Mirrors Flutter's `applyGrowthDirectionToAxisDirection`: forward growth
+    /// keeps the axis direction, while reverse growth uses its opposite.
+    #[inline]
+    #[must_use]
+    pub const fn apply_to_axis_direction(self, axis_direction: AxisDirection) -> AxisDirection {
+        match self {
+            GrowthDirection::Forward => axis_direction,
+            GrowthDirection::Reverse => axis_direction.opposite(),
+        }
+    }
+
     /// Returns the directional multiplier (+1 for Forward, -1 for Reverse).
     ///
     /// Useful for calculations that need to scale by direction.
@@ -158,6 +173,30 @@ mod tests {
 
         assert_eq!(GrowthDirection::Forward.apply_to_i32(10), 10);
         assert_eq!(GrowthDirection::Reverse.apply_to_i32(10), -10);
+    }
+
+    #[test]
+    fn test_apply_to_axis_direction() {
+        use flui_types::layout::AxisDirection::{
+            BottomToTop, LeftToRight, RightToLeft, TopToBottom,
+        };
+
+        assert_eq!(
+            GrowthDirection::Forward.apply_to_axis_direction(TopToBottom),
+            TopToBottom
+        );
+        assert_eq!(
+            GrowthDirection::Reverse.apply_to_axis_direction(TopToBottom),
+            BottomToTop
+        );
+        assert_eq!(
+            GrowthDirection::Forward.apply_to_axis_direction(LeftToRight),
+            LeftToRight
+        );
+        assert_eq!(
+            GrowthDirection::Reverse.apply_to_axis_direction(LeftToRight),
+            RightToLeft
+        );
     }
 
     #[test]

--- a/crates/flui-rendering/src/objects/sliver_fill_remaining.rs
+++ b/crates/flui-rendering/src/objects/sliver_fill_remaining.rs
@@ -9,11 +9,7 @@
 
 use flui_foundation::Diagnosticable;
 use flui_tree::Single;
-use flui_types::{
-    Offset, Size,
-    geometry::px,
-    layout::{AxisDirection, AxisDirection::*},
-};
+use flui_types::{Offset, Size, geometry::px, layout::AxisDirection::*};
 
 use crate::{
     constraints::{GrowthDirection, SliverConstraints, SliverGeometry},
@@ -371,10 +367,10 @@ fn child_paint_offset_for_extent(
     geometry: &SliverGeometry,
     child_main_extent: f32,
 ) -> Offset {
-    match apply_growth_direction_to_axis_direction(
-        constraints.axis_direction,
-        constraints.growth_direction,
-    ) {
+    match constraints
+        .growth_direction
+        .apply_to_axis_direction(constraints.axis_direction)
+    {
         TopToBottom => Offset::new(px(0.0), px(-constraints.scroll_offset)),
         LeftToRight => Offset::new(px(-constraints.scroll_offset), px(0.0)),
         BottomToTop => Offset::new(
@@ -385,16 +381,6 @@ fn child_paint_offset_for_extent(
             px(geometry.paint_extent + constraints.scroll_offset - child_main_extent),
             px(0.0),
         ),
-    }
-}
-
-const fn apply_growth_direction_to_axis_direction(
-    axis_direction: AxisDirection,
-    growth_direction: GrowthDirection,
-) -> AxisDirection {
-    match growth_direction {
-        GrowthDirection::Forward => axis_direction,
-        GrowthDirection::Reverse => axis_direction.opposite(),
     }
 }
 

--- a/crates/flui-rendering/src/objects/sliver_padding.rs
+++ b/crates/flui-rendering/src/objects/sliver_padding.rs
@@ -39,7 +39,7 @@ use flui_tree::Single;
 use flui_types::{Axis, EdgeInsets, Offset, Pixels, Rect, geometry::px, layout::AxisDirection};
 
 use crate::{
-    constraints::{GrowthDirection, SliverConstraints, SliverGeometry},
+    constraints::{SliverConstraints, SliverGeometry},
     context::{SliverHitTestContext, SliverLayoutContext},
     parent_data::SliverPhysicalParentData,
     traits::{HotReloadCapability, PaintEffectsCapability, RenderSliver, SemanticsCapability},
@@ -120,7 +120,8 @@ impl RenderSliverPadding {
     /// constraint-axis–oriented form.
     ///
     /// * `before` — main-axis padding nearest the zero scroll offset after
-    ///   applying [`GrowthDirection`] to the axis direction.
+    ///   applying [`GrowthDirection`](crate::constraints::GrowthDirection)
+    ///   to the axis direction.
     /// * `after` — the opposite main-axis padding.
     /// * `main_total` — `before + after`.
     /// * `cross_total` — total padding on the cross axis.
@@ -134,10 +135,10 @@ impl RenderSliverPadding {
             Axis::Vertical => self.padding.horizontal_total().get(),
             Axis::Horizontal => self.padding.vertical_total().get(),
         };
-        let (before, after) = match apply_growth_direction_to_axis_direction(
-            constraints.axis_direction,
-            constraints.growth_direction,
-        ) {
+        let (before, after) = match constraints
+            .growth_direction
+            .apply_to_axis_direction(constraints.axis_direction)
+        {
             AxisDirection::TopToBottom => (self.padding.top.get(), self.padding.bottom.get()),
             AxisDirection::BottomToTop => (self.padding.bottom.get(), self.padding.top.get()),
             AxisDirection::LeftToRight => (self.padding.left.get(), self.padding.right.get()),
@@ -288,10 +289,9 @@ impl RenderSliverPadding {
             scroll_offset_correction: None,
         };
 
-        let effective_axis_direction = apply_growth_direction_to_axis_direction(
-            parent.axis_direction,
-            parent.growth_direction,
-        );
+        let effective_axis_direction = parent
+            .growth_direction
+            .apply_to_axis_direction(parent.axis_direction);
         let calculated_offset = match effective_axis_direction {
             AxisDirection::BottomToTop => Self::paint_offset(
                 parent,
@@ -444,16 +444,6 @@ const fn empty_sliver_constraints() -> SliverConstraints {
         0.0, // remaining_cache_extent
         0.0, // cache_origin
     )
-}
-
-const fn apply_growth_direction_to_axis_direction(
-    axis_direction: AxisDirection,
-    growth_direction: GrowthDirection,
-) -> AxisDirection {
-    match growth_direction {
-        GrowthDirection::Forward => axis_direction,
-        GrowthDirection::Reverse => axis_direction.opposite(),
-    }
 }
 
 // ============================================================================

--- a/crates/flui-rendering/src/objects/sliver_to_box_adapter.rs
+++ b/crates/flui-rendering/src/objects/sliver_to_box_adapter.rs
@@ -6,11 +6,7 @@
 
 use flui_foundation::Diagnosticable;
 use flui_tree::Single;
-use flui_types::{
-    Offset,
-    geometry::px,
-    layout::{AxisDirection, AxisDirection::*},
-};
+use flui_types::{Offset, geometry::px, layout::AxisDirection::*};
 
 use crate::{
     constraints::{GrowthDirection, SliverConstraints, SliverGeometry},
@@ -39,10 +35,10 @@ impl RenderSliverToBoxAdapter {
 
     #[inline]
     fn child_paint_offset(constraints: &SliverConstraints, geometry: &SliverGeometry) -> Offset {
-        match apply_growth_direction_to_axis_direction(
-            constraints.axis_direction,
-            constraints.growth_direction,
-        ) {
+        match constraints
+            .growth_direction
+            .apply_to_axis_direction(constraints.axis_direction)
+        {
             TopToBottom => Offset::new(px(0.0), px(-constraints.scroll_offset)),
             LeftToRight => Offset::new(px(-constraints.scroll_offset), px(0.0)),
             BottomToTop => Offset::new(
@@ -137,16 +133,6 @@ impl RenderSliver for RenderSliverToBoxAdapter {
 
     fn hit_test(&self, ctx: &mut SliverHitTestContext<'_, Single, Self::ParentData>) -> bool {
         ctx.hit_test_child_at_layout_offset(0)
-    }
-}
-
-const fn apply_growth_direction_to_axis_direction(
-    axis_direction: AxisDirection,
-    growth_direction: GrowthDirection,
-) -> AxisDirection {
-    match growth_direction {
-        GrowthDirection::Forward => axis_direction,
-        GrowthDirection::Reverse => axis_direction.opposite(),
     }
 }
 

--- a/crates/flui-rendering/src/objects/viewport.rs
+++ b/crates/flui-rendering/src/objects/viewport.rs
@@ -343,7 +343,7 @@ impl<O: ViewportOffset + 'static> RenderViewport<O> {
         growth_direction: GrowthDirection,
         paint_extent: f32,
     ) -> Offset {
-        match apply_growth_direction_to_axis_direction(self.axis_direction, growth_direction) {
+        match growth_direction.apply_to_axis_direction(self.axis_direction) {
             TopToBottom => Offset::new(px(0.0), px(layout_offset)),
             BottomToTop => Offset::new(
                 px(0.0),
@@ -476,16 +476,6 @@ const fn default_cross_axis_direction(axis_direction: AxisDirection) -> AxisDire
     match axis_direction {
         TopToBottom | BottomToTop => LeftToRight,
         LeftToRight | RightToLeft => TopToBottom,
-    }
-}
-
-const fn apply_growth_direction_to_axis_direction(
-    axis_direction: AxisDirection,
-    growth_direction: GrowthDirection,
-) -> AxisDirection {
-    match growth_direction {
-        GrowthDirection::Forward => axis_direction,
-        GrowthDirection::Reverse => axis_direction.opposite(),
     }
 }
 

--- a/crates/flui-rendering/src/traits/render_sliver.rs
+++ b/crates/flui-rendering/src/traits/render_sliver.rs
@@ -4,7 +4,7 @@ use flui_tree::Arity;
 use flui_types::{Pixels, Rect, Size, geometry::px, prelude::AxisDirection};
 
 use crate::{
-    constraints::{GrowthDirection, SliverConstraints, SliverGeometry},
+    constraints::{SliverConstraints, SliverGeometry},
     context::{SliverHitTestContext, SliverLayoutContext},
     parent_data::ParentData,
     protocol::SliverProtocol,
@@ -252,10 +252,10 @@ pub trait RenderSliver: flui_foundation::Diagnosticable + Send + Sync + 'static 
     fn get_absolute_size_relative_to_origin(&self, paint_extent: f32) -> Size {
         let constraints = self.constraints();
 
-        match apply_growth_direction_to_axis_direction(
-            constraints.axis_direction,
-            constraints.growth_direction,
-        ) {
+        match constraints
+            .growth_direction
+            .apply_to_axis_direction(constraints.axis_direction)
+        {
             AxisDirection::TopToBottom => {
                 Size::new(px(constraints.cross_axis_extent), px(paint_extent))
             }
@@ -342,16 +342,6 @@ pub trait RenderSliver: flui_foundation::Diagnosticable + Send + Sync + 'static 
     /// Creates default parent data for a child.
     fn create_default_parent_data() -> Self::ParentData {
         Self::ParentData::default()
-    }
-}
-
-const fn apply_growth_direction_to_axis_direction(
-    axis_direction: AxisDirection,
-    growth_direction: GrowthDirection,
-) -> AxisDirection {
-    match growth_direction {
-        GrowthDirection::Forward => axis_direction,
-        GrowthDirection::Reverse => axis_direction.opposite(),
     }
 }
 


### PR DESCRIPTION
## Summary
- add GrowthDirection::apply_to_axis_direction as the shared sliver direction composition helper
- replace local apply_growth_direction_to_axis_direction copies in sliver adapters and viewport
- keep RenderSliver::child_main_axis_position non-fatal until current container slivers can expose complete child-position data

## Verification
- cargo fmt --all -- --check
- cargo test -p flui-rendering
- cargo clippy -p flui-rendering --all-targets -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items