### PR TITLE
Core2 W3.17 add fixed extent sliver list

### DIFF
--- a/crates/flui-rendering/src/objects/mod.rs
+++ b/crates/flui-rendering/src/objects/mod.rs
@@ -57,6 +57,8 @@
 //!   variants that use Box child intrinsics (Core.2 W3.9)
 //! - [`RenderSliverFillViewport`] - Sizes each Box child to a viewport
 //!   fraction in the sliver main axis (Core.2 W3.10)
+//! - [`RenderSliverFixedExtentList`] - Sizes each Box child to a fixed
+//!   main-axis extent (Core.2 W3.17)
 //! - [`RenderViewport`] - Box viewport that drives Sliver children
 //!   (Core.2 W3.4a)
 //!
@@ -95,6 +97,7 @@ mod repaint_boundary;
 mod sized_box;
 mod sliver_fill_remaining;
 mod sliver_fill_viewport;
+mod sliver_fixed_extent_list;
 mod sliver_ignore_pointer;
 mod sliver_offstage;
 mod sliver_opacity;
@@ -133,6 +136,7 @@ pub use sliver_fill_remaining::{
     RenderSliverFillRemainingWithScrollable,
 };
 pub use sliver_fill_viewport::RenderSliverFillViewport;
+pub use sliver_fixed_extent_list::RenderSliverFixedExtentList;
 pub use sliver_ignore_pointer::RenderSliverIgnorePointer;
 pub use sliver_offstage::RenderSliverOffstage;
 pub use sliver_opacity::RenderSliverOpacity;

--- a/crates/flui-rendering/src/objects/sliver_fixed_extent_list.rs
+++ b/crates/flui-rendering/src/objects/sliver_fixed_extent_list.rs
@@ -1,0 +1,201 @@
+//! `RenderSliverFixedExtentList` — Box children with one fixed main-axis extent.
+
+use flui_foundation::Diagnosticable;
+use flui_tree::Variable;
+use flui_types::{
+    Offset,
+    geometry::px,
+    layout::{Axis, AxisDirection::*},
+};
+
+use crate::{
+    constraints::{GrowthDirection, SliverConstraints, SliverGeometry},
+    context::{PaintCx, SliverHitTestContext, SliverLayoutContext},
+    parent_data::SliverPhysicalParentData,
+    traits::{HotReloadCapability, PaintEffectsCapability, RenderSliver, SemanticsCapability},
+};
+
+/// A sliver that lays out each direct Box child with the same main-axis extent.
+///
+/// This is the eager, attached-child FLUI counterpart of Flutter's
+/// `RenderSliverFixedExtentList`. Lazy child creation and garbage collection
+/// remain deferred to the future multi-box-adaptor layer; attached children are
+/// laid out eagerly with fixed extents.
+#[derive(Debug, Clone)]
+pub struct RenderSliverFixedExtentList {
+    item_extent: f32,
+    constraints: SliverConstraints,
+    geometry: SliverGeometry,
+    child_count: usize,
+}
+
+impl RenderSliverFixedExtentList {
+    /// Creates a fixed-extent sliver list.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `item_extent` is not finite or is less than or equal to
+    /// zero.
+    #[inline]
+    #[must_use]
+    pub fn new(item_extent: f32) -> Self {
+        assert!(
+            item_extent.is_finite() && item_extent > 0.0,
+            "item_extent must be finite and greater than zero"
+        );
+        Self {
+            item_extent,
+            constraints: empty_sliver_constraints(),
+            geometry: SliverGeometry::ZERO,
+            child_count: 0,
+        }
+    }
+
+    /// Main-axis extent assigned to each child.
+    #[inline]
+    #[must_use]
+    pub const fn item_extent(&self) -> f32 {
+        self.item_extent
+    }
+
+    /// Updates the main-axis extent assigned to each child.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `item_extent` is not finite or is less than or equal to
+    /// zero.
+    #[inline]
+    pub fn set_item_extent(&mut self, item_extent: f32) {
+        assert!(
+            item_extent.is_finite() && item_extent > 0.0,
+            "item_extent must be finite and greater than zero"
+        );
+        self.item_extent = item_extent;
+    }
+}
+
+impl Diagnosticable for RenderSliverFixedExtentList {}
+impl PaintEffectsCapability for RenderSliverFixedExtentList {}
+impl SemanticsCapability for RenderSliverFixedExtentList {}
+impl HotReloadCapability for RenderSliverFixedExtentList {}
+
+impl RenderSliver for RenderSliverFixedExtentList {
+    type Arity = Variable;
+    type ParentData = SliverPhysicalParentData;
+
+    fn perform_layout(&mut self, ctx: &mut SliverLayoutContext<'_, Variable, Self::ParentData>) {
+        self.constraints = *ctx.constraints();
+        self.child_count = ctx.child_count();
+
+        for index in 0..self.child_count {
+            ctx.layout_box_child(
+                index,
+                self.constraints
+                    .as_box_constraints(self.item_extent, self.item_extent, None),
+            );
+        }
+
+        let scroll_extent = self.item_extent * self.child_count as f32;
+        let paint_extent = self.calculate_paint_offset(&self.constraints, 0.0, scroll_extent);
+        let cache_extent = self.calculate_cache_offset(&self.constraints, 0.0, scroll_extent);
+        let geometry = SliverGeometry {
+            scroll_extent,
+            paint_extent,
+            layout_extent: paint_extent,
+            max_paint_extent: scroll_extent,
+            cache_extent,
+            hit_test_extent: paint_extent,
+            visible: paint_extent > 0.0,
+            has_visual_overflow: scroll_extent > self.constraints.remaining_paint_extent
+                || self.constraints.scroll_offset > 0.0,
+            ..SliverGeometry::ZERO
+        };
+
+        for index in 0..self.child_count {
+            let layout_offset = self.item_extent * index as f32;
+            ctx.position_child(
+                index,
+                child_paint_offset(
+                    &self.constraints,
+                    &geometry,
+                    layout_offset,
+                    self.item_extent,
+                ),
+            );
+        }
+
+        self.geometry = geometry;
+        ctx.complete(geometry);
+    }
+
+    fn geometry(&self) -> &SliverGeometry {
+        &self.geometry
+    }
+
+    fn constraints(&self) -> &SliverConstraints {
+        &self.constraints
+    }
+
+    fn set_geometry(&mut self, geometry: SliverGeometry) {
+        self.geometry = geometry;
+    }
+
+    fn paint(&self, ctx: &mut PaintCx<'_, Variable>) {
+        if self.geometry.visible {
+            ctx.paint_children();
+        }
+    }
+
+    fn hit_test(&self, ctx: &mut SliverHitTestContext<'_, Variable, Self::ParentData>) -> bool {
+        for index in (0..self.child_count).rev() {
+            if ctx.hit_test_child_at_layout_offset(index) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+fn child_paint_offset(
+    constraints: &SliverConstraints,
+    geometry: &SliverGeometry,
+    layout_offset: f32,
+    child_main_extent: f32,
+) -> Offset {
+    let child_main_axis_position = layout_offset - constraints.scroll_offset;
+    let main_axis_delta = if right_way_up(constraints) {
+        child_main_axis_position
+    } else {
+        geometry.paint_extent - child_main_extent - child_main_axis_position
+    };
+
+    match constraints.axis_direction.axis() {
+        Axis::Horizontal => Offset::new(px(main_axis_delta), px(0.0)),
+        Axis::Vertical => Offset::new(px(0.0), px(main_axis_delta)),
+    }
+}
+
+const fn right_way_up(constraints: &SliverConstraints) -> bool {
+    let reversed = constraints.axis_direction.is_reversed();
+    match constraints.growth_direction {
+        GrowthDirection::Forward => !reversed,
+        GrowthDirection::Reverse => reversed,
+    }
+}
+
+const fn empty_sliver_constraints() -> SliverConstraints {
+    SliverConstraints {
+        axis_direction: TopToBottom,
+        growth_direction: GrowthDirection::Forward,
+        user_scroll_direction: crate::view::ScrollDirection::Idle,
+        scroll_offset: 0.0,
+        preceding_scroll_extent: 0.0,
+        overlap: 0.0,
+        remaining_paint_extent: 0.0,
+        cross_axis_extent: 0.0,
+        cross_axis_direction: LeftToRight,
+        viewport_main_axis_extent: 0.0,
+        remaining_cache_extent: 0.0,
+        cache_origin: 0.0,
+    }
+}

--- a/crates/flui-rendering/tests/sliver_fixed_extent_list.rs
+++ b/crates/flui-rendering/tests/sliver_fixed_extent_list.rs
@@ -1,0 +1,329 @@
+//! `RenderSliverFixedExtentList` — direct Box children with a fixed main-axis extent.
+
+use flui_rendering::{
+    constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
+    context::{BoxHitTestContext, BoxLayoutContext},
+    hit_testing::HitTestResult,
+    objects::RenderSliverFixedExtentList,
+    parent_data::BoxParentData,
+    pipeline::PipelineOwner,
+    protocol::{BoxProtocol, SliverProtocol},
+    traits::{
+        HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, SemanticsCapability,
+    },
+    view::ScrollDirection,
+};
+use flui_tree::Leaf;
+use flui_types::{Offset, Rect, Size, geometry::px, layout::AxisDirection};
+
+type BoxedRenderObject = Box<dyn RenderObject<BoxProtocol>>;
+type BoxedSliverObject = Box<dyn RenderObject<SliverProtocol>>;
+
+fn vertical_constraints(scroll_offset: f32) -> SliverConstraints {
+    SliverConstraints {
+        axis_direction: AxisDirection::TopToBottom,
+        cross_axis_direction: AxisDirection::LeftToRight,
+        growth_direction: GrowthDirection::Forward,
+        user_scroll_direction: ScrollDirection::Idle,
+        scroll_offset,
+        preceding_scroll_extent: 0.0,
+        overlap: 0.0,
+        remaining_paint_extent: 100.0,
+        cross_axis_extent: 300.0,
+        viewport_main_axis_extent: 100.0,
+        remaining_cache_extent: 120.0,
+        cache_origin: -20.0,
+    }
+}
+
+fn horizontal_constraints(scroll_offset: f32) -> SliverConstraints {
+    SliverConstraints {
+        axis_direction: AxisDirection::LeftToRight,
+        cross_axis_direction: AxisDirection::TopToBottom,
+        growth_direction: GrowthDirection::Forward,
+        user_scroll_direction: ScrollDirection::Idle,
+        scroll_offset,
+        preceding_scroll_extent: 0.0,
+        overlap: 0.0,
+        remaining_paint_extent: 300.0,
+        cross_axis_extent: 100.0,
+        viewport_main_axis_extent: 300.0,
+        remaining_cache_extent: 320.0,
+        cache_origin: -20.0,
+    }
+}
+
+fn laid_out(
+    mut owner: PipelineOwner,
+    root: flui_foundation::RenderId,
+) -> PipelineOwner<flui_rendering::pipeline::phase::Layout> {
+    owner.set_root_id(Some(root));
+    owner.set_root_constraints(Some(BoxConstraints::tight(Size::new(px(300.0), px(100.0)))));
+    let mut owner = owner.into_layout();
+    owner.run_layout().expect("layout succeeds");
+    owner
+}
+
+fn sliver_geometry(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    id: flui_foundation::RenderId,
+) -> SliverGeometry {
+    owner
+        .render_tree()
+        .get(id)
+        .and_then(|node| node.as_sliver())
+        .and_then(|entry| entry.state().geometry())
+        .expect("sliver geometry is committed")
+}
+
+fn box_size(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    id: flui_foundation::RenderId,
+) -> Size {
+    owner
+        .render_tree()
+        .get(id)
+        .and_then(|node| node.as_box())
+        .and_then(|entry| entry.state().geometry())
+        .expect("box geometry is committed")
+}
+
+fn render_offset(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    id: flui_foundation::RenderId,
+) -> Offset {
+    owner
+        .render_tree()
+        .get(id)
+        .map(flui_rendering::storage::RenderNode::offset)
+        .expect("node exists")
+}
+
+fn hits(
+    owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    x: f32,
+    y: f32,
+) -> Vec<flui_foundation::RenderId> {
+    let mut result = HitTestResult::new();
+    owner.hit_test(Offset::new(px(x), px(y)), &mut result);
+    result.path().iter().map(|entry| entry.target).collect()
+}
+
+#[derive(Debug)]
+struct FixedHitBox {
+    desired: Size,
+    size: Size,
+}
+
+impl FixedHitBox {
+    fn new(width: f32, height: f32) -> Self {
+        Self {
+            desired: Size::new(px(width), px(height)),
+            size: Size::ZERO,
+        }
+    }
+}
+
+impl flui_foundation::Diagnosticable for FixedHitBox {}
+impl PaintEffectsCapability for FixedHitBox {}
+impl SemanticsCapability for FixedHitBox {}
+impl HotReloadCapability for FixedHitBox {}
+
+impl RenderBox for FixedHitBox {
+    type Arity = Leaf;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Leaf, Self::ParentData>) {
+        self.size = ctx.constraints().constrain(self.desired);
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+
+    fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Leaf, Self::ParentData>) -> bool {
+        ctx.is_within_bounds(Rect::from_origin_size(flui_types::Point::ZERO, self.size))
+    }
+}
+
+#[derive(Debug)]
+struct SliverHost {
+    constraints: SliverConstraints,
+    size: Size,
+}
+
+impl flui_foundation::Diagnosticable for SliverHost {}
+impl PaintEffectsCapability for SliverHost {}
+impl SemanticsCapability for SliverHost {}
+impl HotReloadCapability for SliverHost {}
+
+impl RenderBox for SliverHost {
+    type Arity = flui_tree::Variable;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(
+        &mut self,
+        ctx: &mut BoxLayoutContext<'_, flui_tree::Variable, Self::ParentData>,
+    ) {
+        if ctx.child_count() > 0 {
+            let _ = ctx.layout_sliver_child(0, self.constraints);
+        }
+        self.size = ctx.constraints().biggest();
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+
+    fn hit_test(
+        &self,
+        ctx: &mut BoxHitTestContext<'_, flui_tree::Variable, Self::ParentData>,
+    ) -> bool {
+        ctx.hit_test_child_at_layout_offset(0)
+    }
+}
+
+fn fixed_extent_tree(
+    constraints: SliverConstraints,
+    item_extent: f32,
+    child_count: usize,
+) -> (
+    PipelineOwner<flui_rendering::pipeline::phase::Layout>,
+    flui_foundation::RenderId,
+    flui_foundation::RenderId,
+    Vec<flui_foundation::RenderId>,
+) {
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(SliverHost {
+        constraints,
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    let sliver_id = owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            root_id,
+            Box::new(RenderSliverFixedExtentList::new(item_extent)) as BoxedSliverObject,
+        )
+        .expect("fixed extent sliver");
+    let mut child_ids = Vec::with_capacity(child_count);
+    for _ in 0..child_count {
+        let child_id = owner
+            .render_tree_mut()
+            .insert_box_child(
+                sliver_id,
+                Box::new(FixedHitBox::new(1000.0, 1000.0)) as BoxedRenderObject,
+            )
+            .expect("box child");
+        child_ids.push(child_id);
+    }
+
+    (laid_out(owner, root_id), root_id, sliver_id, child_ids)
+}
+
+#[test]
+fn sliver_fixed_extent_list_sizes_children_to_item_extent() {
+    let (owner, _root_id, sliver_id, child_ids) =
+        fixed_extent_tree(vertical_constraints(25.0), 30.0, 4);
+
+    let geometry = sliver_geometry(&owner, sliver_id);
+    assert_eq!(geometry.scroll_extent, 120.0);
+    assert_eq!(geometry.paint_extent, 95.0);
+    assert_eq!(geometry.layout_extent, 95.0);
+    assert_eq!(geometry.max_paint_extent, 120.0);
+    assert_eq!(geometry.hit_test_extent, 95.0);
+    assert_eq!(geometry.cache_extent, 115.0);
+    assert!(geometry.has_visual_overflow);
+
+    for &child_id in &child_ids {
+        assert_eq!(box_size(&owner, child_id), Size::new(px(300.0), px(30.0)));
+    }
+    assert_eq!(
+        render_offset(&owner, child_ids[0]),
+        Offset::new(px(0.0), px(-25.0)),
+    );
+    assert_eq!(
+        render_offset(&owner, child_ids[1]),
+        Offset::new(px(0.0), px(5.0)),
+    );
+    assert_eq!(
+        render_offset(&owner, child_ids[2]),
+        Offset::new(px(0.0), px(35.0)),
+    );
+    assert_eq!(
+        render_offset(&owner, child_ids[3]),
+        Offset::new(px(0.0), px(65.0)),
+    );
+}
+
+#[test]
+fn sliver_fixed_extent_list_hit_tests_visible_children() {
+    let (owner, root_id, sliver_id, child_ids) =
+        fixed_extent_tree(vertical_constraints(25.0), 30.0, 4);
+
+    assert_eq!(
+        hits(&owner, 10.0, 10.0),
+        vec![child_ids[1], sliver_id, root_id],
+        "global y=10 maps to child 1 after the 25px scroll offset",
+    );
+    assert_eq!(
+        hits(&owner, 10.0, 50.0),
+        vec![child_ids[2], sliver_id, root_id],
+        "global y=50 maps to child 2 after the 25px scroll offset",
+    );
+    assert!(
+        hits(&owner, 10.0, 110.0).is_empty(),
+        "per-level sliver gate rejects points beyond geometry.hit_test_extent",
+    );
+}
+
+#[test]
+fn sliver_fixed_extent_list_supports_horizontal_axis() {
+    let (owner, _root_id, _sliver_id, child_ids) =
+        fixed_extent_tree(horizontal_constraints(30.0), 80.0, 2);
+
+    for &child_id in &child_ids {
+        assert_eq!(box_size(&owner, child_id), Size::new(px(80.0), px(100.0)));
+    }
+    assert_eq!(
+        render_offset(&owner, child_ids[0]),
+        Offset::new(px(-30.0), px(0.0)),
+    );
+    assert_eq!(
+        render_offset(&owner, child_ids[1]),
+        Offset::new(px(50.0), px(0.0)),
+    );
+}
+
+#[test]
+fn sliver_fixed_extent_list_reverse_axis_uses_right_way_up_offsets() {
+    let mut constraints = vertical_constraints(25.0);
+    constraints.axis_direction = AxisDirection::BottomToTop;
+    let (owner, _root_id, _sliver_id, child_ids) = fixed_extent_tree(constraints, 30.0, 4);
+
+    assert_eq!(
+        render_offset(&owner, child_ids[0]),
+        Offset::new(px(0.0), px(90.0)),
+    );
+    assert_eq!(
+        render_offset(&owner, child_ids[1]),
+        Offset::new(px(0.0), px(60.0)),
+    );
+    assert_eq!(
+        render_offset(&owner, child_ids[2]),
+        Offset::new(px(0.0), px(30.0)),
+    );
+    assert_eq!(
+        render_offset(&owner, child_ids[3]),
+        Offset::new(px(0.0), px(0.0)),
+    );
+}

--- a/docs/research/widget-renderobject-map.md
+++ b/docs/research/widget-renderobject-map.md
@@ -130,7 +130,7 @@
 | `ShrinkWrappingViewport` | `RenderShrinkWrappingViewport` | Needed | Variable(Sliver) | Viewport that sizes to content |
 | `SliverList` | `RenderSliverList` | Needed | Variable(Box) | Lazy linear list of box children |
 | `SliverGrid` | `RenderSliverGrid` | Needed | Variable(Box) | Lazy 2D grid of box children |
-| `SliverFixedExtentList` | `RenderSliverFixedExtentList` | Needed | Variable(Box) | Fixed-height items (optimized layout) |
+| `SliverFixedExtentList` | `RenderSliverFixedExtentList` | **Exists** | Variable(Box) | Eager attached-child fixed extent; lazy adaptor pending |
 | `SliverFillViewport` | `RenderSliverFillViewport` | Needed | Variable(Box) | Each child fills viewport main-axis extent |
 | `SliverToBoxAdapter` | `RenderSliverToBoxAdapter` | Needed | Single(Box) | Wraps single box child in sliver protocol |
 | `SliverPadding` | `RenderSliverPadding` | **Exists** | Single(Sliver) | Pads a sliver child |


### PR DESCRIPTION
## Summary
- add RenderSliverFixedExtentList for eager attached Box children with fixed main-axis extents
- cover geometry, child sizing, committed paint offsets, hit testing, horizontal axis, and reverse-axis placement
- export the render object and update the widget/render-object map

## Verification
- cargo fmt --all -- --check
- cargo test -p flui-rendering
- cargo clippy -p flui-rendering --all-targets -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items