### PR TITLE
feat(rendering): headless render-object test harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ flui/
 | Architecture | `docs/architecture.md` | Three-tree pipeline + layered DAG overview (current state) |
 | Crates Map | `docs/crates.md` | Per-layer crate inventory and status |
 | Testing | `docs/testing.md` | Build / test / clippy / fmt commands and coverage targets |
+| Render harness | `crates/flui-rendering/docs/TESTING.md` | `RenderTester` / `Probe` API, catalog rules, multi-frame helpers |
 | Contributing | `docs/contributing.md` | Workflow, commits, agent conventions |
 | Crate architecture notes | `crates/<crate>/ARCHITECTURE.md` | Per-crate architecture (e.g. `flui-foundation/ARCHITECTURE.md`) |
 | Plans | `docs/plans/` | Dated planning notes per workstream |
@@ -164,3 +165,97 @@ Run `just` (no argument) for the full grouped recipe list. Raw `cargo` commands 
 - **Test the edge, not just the happy path.** Any rendering fix should include regression tests for non-zero scroll/overlap/cache offsets, invisible or fully scrolled-out children, differing paint vs hit-test extents, relayout without repositioning, and cross-protocol Box/Sliver paths when relevant.
 - **Verify before commit or PR update.** For `flui-rendering` work, run targeted tests for the changed behavior, then `cargo fmt --package flui-rendering -- --check`, `cargo test -p flui-rendering`, and `cargo clippy -p flui-rendering --all-targets -- -D warnings` unless the user explicitly asks for a lighter pass.
 - **Be skeptical of broad fixes.** When expanding a commit path or shared pipeline behavior, check every protocol that now flows through it and seed/commit persistent state symmetrically so one protocol is not reset by another.
+
+## Render-Object Testing Checklist
+
+When adding or materially changing a **`RenderBox`** or **`RenderSliver`** in `flui-rendering`, land harness coverage in the same PR. Do not rely on GPU demos or manual inspection — use the headless pipeline via `flui_rendering::testing` (see [`crates/flui-rendering/docs/TESTING.md`](crates/flui-rendering/docs/TESTING.md)).
+
+### 1. Register the type (CI will fail if skipped)
+
+Every concrete type exported from `crates/flui-rendering/src/objects/mod.rs` must appear in the harness catalog:
+
+| Step | File | Action |
+|------|------|--------|
+| Export | `objects/mod.rs` | `pub use …::RenderYourType` |
+| Catalog list | `tests/render_object_harness.rs` | Add `"RenderYourType"` to `RENDER_OBJECT_TYPES` (keep sorted) |
+| Coverage table | same file, module doc | Add a row: harness test name(s), Layout / Hit-test / Paint / Diagnostics |
+| Harness test | same file | Add `#[test] fn harness_your_type_…()` that **uses the type name** inside the test body |
+
+Two guards run in CI:
+
+- `catalog_covers_every_render_object_name` — each `RENDER_OBJECT_TYPES` entry must appear in at least one `#[test] fn harness_*` block.
+- `render_object_types_match_exports` — `RENDER_OBJECT_TYPES` must match `pub use` exports in `objects/mod.rs` (generic `RenderClip` is excluded; concrete clip variants are not).
+
+### 2. Build the smallest meaningful tree
+
+```rust
+use flui_rendering::objects::*;
+use flui_rendering::testing::{RenderTester, Probe, box_node, sliver_node};
+
+// Box object — root or nested under a sized host
+RenderTester::mount(box_node(RenderYourType::new(…)).label("node"))
+    .with_size(Size::new(px(100.0), px(100.0)))
+    .run_layout(); // or .run_frame() when paint/layers matter
+
+// Sliver object — always under a Box viewport root (never a sliver root)
+RenderTester::mount(
+    box_node(RenderViewport::new(AxisDirection::TopToBottom))
+        .child(sliver_node(RenderYourSliver::new(…)).label("sliver")),
+)
+.with_size(Size::new(px(300.0), px(100.0)))
+.run_layout();
+```
+
+- **Box root** for box-only objects; **viewport host** for every sliver.
+- Use `.label("…")` on nodes you assert via `run.id("…")`.
+- Stack / flex children need parent metadata: `TreeNode::with_stack_parent_data` or `with_flex_parent_data` (see [`parent_data.rs`](crates/flui-rendering/src/testing/parent_data.rs)).
+
+### 3. Assert by capability (not every object needs every column)
+
+| Capability | When required | Typical assertions |
+|------------|---------------|-------------------|
+| **Layout** | Always | `run.box_geometry(id)`, `run.offset(id)`, `run.sliver_geometry(id)`; `assert_has_committed_size` / `assert_has_committed_geometry` |
+| **Diagnostics** | Always | `impl Diagnosticable` with **snake_case** property names; `assert_descendant_properties(&run.diagnostics(), "RenderYourType", &[…])`; use `run.property_f64` / `descendant_property_f64` for numeric fields (unit suffixes like `25px` are parsed) |
+| **Hit-test** | Pointer-blocking or positioned semantics | `run.hit(x, y)`, `run.hit_first(x, y)` — include a negative case (miss / pass-through) |
+| **Paint** | `perform_paint`, opacity, transform, decoration, picture layers | `.run_frame()` or `advance_paint`; `run.structure()`, `run.picture_bounds()`, `run.opacity_alpha()`, `run.has_picture_layer()` |
+| **Multi-frame** | Animated or dirty-state behavior | `run.update::<T>`, `run.update_paint::<T>`, `advance_layout`, `simulate` + `AnimationController` (see `tests/harness_animation.rs`) |
+
+Pick **at least one** `harness_<snake_name>_…` test per type. Split into multiple tests when layout vs paint vs hit-test need different tree shapes.
+
+### 4. Diagnostics contract
+
+- Object config: `debug_fill_properties` on the render type (`Diagnosticable`).
+- Runtime state: pipeline adds committed fields (`paint_offset`, `size`, sliver `geometry`, etc.) — do not duplicate scroll offset as bare `offset` on viewports (`scroll_offset` is the config field).
+- Property names are **snake_case** everywhere (render objects, layer tree, harness assertions).
+- Avoid duplicate type names in one diagnostics tree; `find_descendant_unique` is used by `Probe::descendant_property*`.
+
+### 5. Edge cases (regression tests beyond happy path)
+
+Add extra tests when the Flutter port has non-obvious behavior:
+
+- Non-zero scroll / cache / overlap offsets on viewport + sliver chains
+- Invisible or fully scrolled-out children (zero geometry, no paint, no hit)
+- Paint extent vs hit-test extent divergence (e.g. `RenderFractionalTranslation` without hit transform)
+- Relayout without repositioning; paint-only mutation without layout (`update_paint` + `pump`)
+- Cross-protocol paths (box child under sliver adapter, multiple slivers in one viewport)
+
+Check `.flutter/` for the reference behavior before asserting.
+
+### 6. Local verification (before PR)
+
+```bash
+cargo test -p flui-rendering --test render_object_harness
+cargo test -p flui-rendering --test harness_animation   # if animation/multi-frame touched
+cargo test -p flui-rendering
+cargo fmt --package flui-rendering -- --check
+cargo clippy -p flui-rendering --all-targets -- -D warnings
+bash scripts/port-check.sh -v   # no duplicate cross-crate test helper names; testing modules gated
+```
+
+### 7. Naming conventions
+
+| Item | Pattern | Example |
+|------|---------|---------|
+| Harness test fn | `harness_<snake_case>_…` | `harness_sliver_fixed_extent_list_geometry` |
+| Type string in diagnostics | Rust struct name | `"RenderSliverFixedExtentList"` |
+| Label registry | `LayerLabelRegistry` (layer), `RenderLabelRegistry` (render) — do not reintroduce a shared `IdRegistry` name across crates |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,7 @@ name = "flui-layer"
 version = "0.1.0"
 dependencies = [
  "flui-foundation",
+ "flui-layer",
  "flui-painting",
  "flui-tree",
  "flui-types",
@@ -1285,6 +1286,7 @@ version = "0.1.0"
 dependencies = [
  "cosmic-text",
  "flui-foundation",
+ "flui-painting",
  "flui-types",
  "parking_lot",
  "serde",
@@ -1348,6 +1350,7 @@ dependencies = [
  "flui-interaction",
  "flui-layer",
  "flui-painting",
+ "flui-rendering",
  "flui-scheduler",
  "flui-semantics",
  "flui-tree",

--- a/crates/flui-foundation/docs/README.md
+++ b/crates/flui-foundation/docs/README.md
@@ -1,0 +1,12 @@
+# flui_foundation documentation
+
+## Testing / diagnostics
+
+| Document | Topic |
+|----------|-------|
+| **[TESTING.md](./TESTING.md)** | `DiagnosticsNode` query API and `DiagnosticsBuilder` helpers for harness assertions |
+
+## Related
+
+- [flui-rendering/docs/TESTING.md](../../flui-rendering/docs/TESTING.md) — render harness using diagnostics
+- [docs/testing.md](../../../docs/testing.md) — workspace testing guide

--- a/crates/flui-foundation/docs/TESTING.md
+++ b/crates/flui-foundation/docs/TESTING.md
@@ -1,0 +1,103 @@
+# Diagnostics for test assertions (`flui_foundation::debug`)
+
+`flui_foundation` does not ship a `testing` feature module. Instead it provides the
+**diagnostics substrate** every rendering-stack harness uses for structured
+assertions: typed property builders on render objects, tree-shaped
+[`DiagnosticsNode`](../src/debug.rs) output, and query helpers that avoid
+substring-matching `dump()` strings.
+
+All render / layer / display-list harnesses implement or consume
+[`Diagnosticable`](../src/debug.rs).
+
+## Where this fits
+
+```text
+RenderObject::debug_fill_properties  →  user config (color, padding, …)
+PipelineOwner / harness              →  + committed offset / size / geometry
+Probe::diagnostics()               →  DiagnosticsNode tree
+assert_properties / property()     →  structured CI assertions
+```
+
+Property names use **snake_case** (Rust idiom, not Dart camelCase).
+
+## `DiagnosticsNode` — query API
+
+Built by `Diagnosticable::to_diagnostics_node()` and harness tree walks.
+
+| Method | Purpose |
+|--------|---------|
+| `name()` | Node type label (e.g. `"RenderPadding"`) |
+| `get_property("field")` | First property value as `&str` |
+| `get_property_f64("field")` | Parsed `f64`, if parseable |
+| `find_child("name")` | Direct child by name |
+| `find_descendant("RenderColoredBox")` | Depth-first search by node name |
+| `properties()` | All properties on this node |
+| `to_string()` / `to_string_deep_at_level(level)` | Rendered dump (debug only) |
+
+### Example — structured assertion
+
+```rust
+use flui_foundation::DiagnosticsNode;
+
+let tree: DiagnosticsNode = run.diagnostics();
+let leaf = tree.find_descendant("RenderColoredBox").expect("leaf");
+assert_eq!(leaf.get_property("color"), Some("[1.0, 0.0, 0.0, 1.0]"));
+```
+
+Via [`flui_rendering::testing::Probe`](../../flui-rendering/docs/TESTING.md):
+
+```rust
+assert_eq!(
+    run.property(child_id, "color").as_deref(),
+    Some("[1.0, 0.0, 0.0, 1.0]"),
+);
+assert_eq!(
+    run.descendant_property("RenderFlex", "direction").as_deref(),
+    Some("Horizontal"),
+);
+```
+
+## `DiagnosticsBuilder` — authoring API
+
+Render objects implement `debug_fill_properties` with typed helpers (defaults
+hidden automatically, kinds format cleanly in dumps).
+
+| Method | Purpose |
+|--------|---------|
+| `add(name, value)` | Generic display property |
+| `add_flag(name, value, if_true)` | Boolean, hidden when false |
+| `add_enum(name, value, default)` | Enum / direction labels |
+| `add_double` / `add_default_double` | Float with optional unit; hide at default |
+| `add_int` | Integer with optional unit |
+| `add_size` | `width x height` |
+| `add_color` | RGBA display |
+| `add_optional` | Skip when `None` |
+
+### Example — render object self-description
+
+```rust
+impl Diagnosticable for RenderPadding {
+    fn debug_fill_properties(&self, properties: &mut DiagnosticsBuilder) {
+        properties.add("padding", format!("{:?}", self.padding()));
+    }
+}
+```
+
+Prefer typed helpers over raw `format!("{:?}")` when a property has a default
+or a known kind (`add_default_double` for opacity defaulting to `1.0`, etc.).
+
+## Harness assertion helpers
+
+[`flui_rendering::testing::assertions`](../../flui-rendering/src/testing/assertions.rs)
+wrap common `DiagnosticsNode` checks:
+
+- `assert_properties(node, &["color", "padding"])`
+- `assert_descendant_properties(&tree, "RenderFlex", &["direction"])`
+- `assert_has_committed_size(node)` — runtime `size` from pipeline
+- `assert_has_committed_geometry(node)` — runtime sliver `geometry`
+
+## See also
+
+- Render harness: [`flui-rendering/docs/TESTING.md`](../../flui-rendering/docs/TESTING.md)
+- Layer harness diagnostics: [`flui-layer/docs/TESTING.md`](../../flui-layer/docs/TESTING.md)
+- Workspace overview: [`docs/testing.md`](../../../docs/testing.md)

--- a/crates/flui-foundation/src/debug.rs
+++ b/crates/flui-foundation/src/debug.rs
@@ -481,25 +481,42 @@ impl DiagnosticsProperty {
     /// Format the property as a string with given style
     #[must_use]
     pub fn format_with_style(&self, style: DiagnosticsTreeStyle) -> String {
-        match style {
-            DiagnosticsTreeStyle::SingleLine => {
+        if self.is_hidden() {
+            return String::new();
+        }
+
+        match &self.kind {
+            DiagnosticsPropertyKind::Flag => {
                 if self.show_name {
                     if self.show_separator {
                         format!("{}: {}", self.name, self.value)
                     } else {
-                        format!("{} {}", self.name, self.value)
+                        self.name.clone()
                     }
                 } else {
                     self.value.clone()
                 }
             }
-            _ => {
-                if self.show_name {
-                    format!("{}: {}", self.name, self.value)
-                } else {
-                    self.value.clone()
+            _ => match style {
+                DiagnosticsTreeStyle::SingleLine => {
+                    if self.show_name {
+                        if self.show_separator {
+                            format!("{}: {}", self.name, self.value)
+                        } else {
+                            format!("{} {}", self.name, self.value)
+                        }
+                    } else {
+                        self.value.clone()
+                    }
                 }
-            }
+                _ => {
+                    if self.show_name {
+                        format!("{}: {}", self.name, self.value)
+                    } else {
+                        self.value.clone()
+                    }
+                }
+            },
         }
     }
 }
@@ -602,6 +619,46 @@ impl DiagnosticsNode {
         &mut self.children
     }
 
+    /// Returns the value of the first property named `name`, if present.
+    ///
+    /// Convenience for structured assertions over a diagnostics tree
+    /// (instead of substring-matching the rendered dump).
+    #[must_use]
+    pub fn get_property(&self, name: &str) -> Option<&str> {
+        self.properties
+            .iter()
+            .find(|property| property.name() == name)
+            .map(DiagnosticsProperty::value)
+    }
+
+    /// Returns the first child node named `name`, if present.
+    #[must_use]
+    pub fn find_child(&self, name: &str) -> Option<&Self> {
+        self.children
+            .iter()
+            .find(|child| child.name() == Some(name))
+    }
+
+    /// Returns the first descendant node named `name` (depth-first), if present.
+    #[must_use]
+    pub fn find_descendant(&self, name: &str) -> Option<&Self> {
+        if self.name.as_deref() == Some(name) {
+            return Some(self);
+        }
+        for child in &self.children {
+            if let Some(found) = child.find_descendant(name) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    /// Parses the named property as `f64`, if present and parseable.
+    #[must_use]
+    pub fn get_property_f64(&self, name: &str) -> Option<f64> {
+        self.get_property(name)?.parse().ok()
+    }
+
     /// Returns the diagnostic level
     #[must_use]
     #[inline]
@@ -628,6 +685,13 @@ impl DiagnosticsNode {
     #[inline]
     pub const fn has_children(&self) -> bool {
         !self.children.is_empty()
+    }
+
+    /// Checks if this node should be displayed at the given minimum level.
+    #[must_use]
+    #[inline]
+    pub const fn is_visible_at_level(&self, min_level: DiagnosticLevel) -> bool {
+        self.level as u8 >= min_level as u8
     }
 
     /// Add a property
@@ -729,10 +793,21 @@ impl DiagnosticsNode {
         self
     }
 
-    /// Convert to a deep string representation
+    /// Convert to a deep string representation (all non-hidden properties).
     #[must_use]
     pub fn format_deep(&self, indent: usize) -> String {
+        self.format_deep_filtered(indent, DiagnosticLevel::Hidden)
+    }
+
+    /// Convert to a deep string representation, omitting properties and nodes
+    /// below `min_level` and properties equal to their default value.
+    #[must_use]
+    pub fn format_deep_filtered(&self, indent: usize, min_level: DiagnosticLevel) -> String {
         use std::fmt::Write;
+
+        if !self.is_visible_at_level(min_level) {
+            return String::new();
+        }
 
         let mut result = String::new();
         let prefix = "  ".repeat(indent);
@@ -742,17 +817,32 @@ impl DiagnosticsNode {
         }
 
         for prop in &self.properties {
-            if !prop.is_hidden() {
-                let formatted = prop.format_with_style(self.style);
+            if prop.is_hidden() || !prop.is_visible_at_level(min_level) {
+                continue;
+            }
+            let formatted = prop.format_with_style(self.style);
+            if !formatted.is_empty() {
                 let _ = writeln!(result, "{prefix}  {formatted}");
             }
         }
 
         for child in &self.children {
-            result.push_str(&child.format_deep(indent + 1));
+            result.push_str(&child.format_deep_filtered(indent + 1, min_level));
         }
 
         result
+    }
+
+    /// Renders the full tree from the root (same as [`fmt::Display`]).
+    #[must_use]
+    pub fn to_string_deep(&self) -> String {
+        self.format_deep(0)
+    }
+
+    /// Renders the tree, omitting diagnostics below `min_level`.
+    #[must_use]
+    pub fn to_string_deep_at_level(&self, min_level: DiagnosticLevel) -> String {
+        self.format_deep_filtered(0, min_level)
     }
 }
 
@@ -868,12 +958,128 @@ impl DiagnosticsBuilder {
         self
     }
 
-    /// Add a flag property (bool).
+    /// Add a flag property (bool). Omitted when `value` is false.
+    ///
+    /// Uses [`DiagnosticsPropertyKind::Flag`] so tree renderers can format the
+    /// property without a redundant `true` suffix.
     pub fn add_flag(&mut self, name: impl Into<String>, value: bool, if_true: &str) -> &mut Self {
         if value {
-            self.properties
-                .push(DiagnosticsProperty::new(name, if_true));
+            self.properties.push(
+                DiagnosticsProperty::new(name, if_true).with_kind(DiagnosticsPropertyKind::Flag),
+            );
         }
+        self
+    }
+
+    /// Add a property that is hidden when equal to `default`.
+    pub fn add_default(
+        &mut self,
+        name: impl Into<String>,
+        value: impl fmt::Display,
+        default: impl Into<String>,
+    ) -> &mut Self {
+        self.properties
+            .push(DiagnosticsProperty::new(name, value).with_default(default.into()));
+        self
+    }
+
+    /// Add an enum-like property (`Debug` formatted) with [`DiagnosticsPropertyKind::Enum`].
+    pub fn add_enum(&mut self, name: impl Into<String>, value: impl fmt::Debug) -> &mut Self {
+        self.properties.push(
+            DiagnosticsProperty::new(name, format!("{value:?}"))
+                .with_kind(DiagnosticsPropertyKind::Enum { description: None }),
+        );
+        self
+    }
+
+    /// Add an enum property hidden when it equals `default`.
+    pub fn add_default_enum<T: fmt::Debug>(
+        &mut self,
+        name: impl Into<String>,
+        value: T,
+        default: T,
+    ) -> &mut Self {
+        self.properties.push(
+            DiagnosticsProperty::new(name, format!("{value:?}"))
+                .with_default(format!("{default:?}"))
+                .with_kind(DiagnosticsPropertyKind::Enum { description: None }),
+        );
+        self
+    }
+
+    /// Add a floating-point property with an optional unit suffix.
+    pub fn add_double(
+        &mut self,
+        name: impl Into<String>,
+        value: f32,
+        unit: Option<&'static str>,
+    ) -> &mut Self {
+        self.properties.push(
+            DiagnosticsProperty::new(name, format_double(value, unit)).with_kind(
+                DiagnosticsPropertyKind::Double {
+                    unit: unit.map(std::borrow::Cow::Borrowed),
+                },
+            ),
+        );
+        self
+    }
+
+    /// Add a floating-point property hidden when equal to `default`.
+    pub fn add_default_double(
+        &mut self,
+        name: impl Into<String>,
+        value: f32,
+        default: f32,
+        unit: Option<&'static str>,
+    ) -> &mut Self {
+        self.properties.push(
+            DiagnosticsProperty::new(name, format_double(value, unit))
+                .with_default(format_double(default, unit))
+                .with_kind(DiagnosticsPropertyKind::Double {
+                    unit: unit.map(std::borrow::Cow::Borrowed),
+                }),
+        );
+        self
+    }
+
+    /// Add an integer property with an optional unit suffix.
+    pub fn add_int(
+        &mut self,
+        name: impl Into<String>,
+        value: i64,
+        unit: Option<&'static str>,
+    ) -> &mut Self {
+        let formatted = match unit {
+            Some(u) => format!("{value}{u}"),
+            None => format!("{value}"),
+        };
+        self.properties
+            .push(DiagnosticsProperty::new(name, formatted).with_kind(
+                DiagnosticsPropertyKind::Int {
+                    unit: unit.map(std::borrow::Cow::Borrowed),
+                },
+            ));
+        self
+    }
+
+    /// Add a size property (`width x height`).
+    pub fn add_size(
+        &mut self,
+        name: impl Into<String>,
+        width: impl fmt::Display,
+        height: impl fmt::Display,
+    ) -> &mut Self {
+        self.properties.push(
+            DiagnosticsProperty::new(name, format!("{width} x {height}"))
+                .with_kind(DiagnosticsPropertyKind::Size),
+        );
+        self
+    }
+
+    /// Add a color property (RGBA display).
+    pub fn add_color(&mut self, name: impl Into<String>, value: impl fmt::Display) -> &mut Self {
+        self.properties
+            .push(DiagnosticsProperty::new(name, value).with_kind(DiagnosticsPropertyKind::Color));
         self
     }
 
@@ -907,6 +1113,14 @@ impl DiagnosticsBuilder {
     #[must_use]
     pub fn build(self) -> Vec<DiagnosticsProperty> {
         self.properties
+    }
+}
+
+#[inline]
+fn format_double(value: f32, unit: Option<&str>) -> String {
+    match unit {
+        Some(u) => format!("{value}{u}"),
+        None => format!("{value}"),
     }
 }
 
@@ -1180,6 +1394,67 @@ mod tests {
             "type_name should be short (no module path), got: {:?}",
             node.name()
         );
+    }
+
+    #[test]
+    fn test_diagnostics_builder_typed_helpers() {
+        let mut builder = DiagnosticsBuilder::new();
+        builder.add_enum("direction", "Horizontal");
+        builder.add_default("spacing", 0, "0");
+        builder.add_default_double("opacity", 1.0, 1.0, None);
+        builder.add_default_double("gap", 8.0, 0.0, Some("px"));
+        builder.add_size("size", 100, 50);
+        builder.add_flag("visible", true, "visible");
+
+        let props = builder.build();
+        assert_eq!(props.len(), 6);
+        assert_eq!(
+            props[0].kind(),
+            &DiagnosticsPropertyKind::Enum { description: None }
+        );
+        assert!(props[1].is_hidden());
+        assert!(props[2].is_hidden());
+        assert!(!props[3].is_hidden());
+        assert_eq!(props[4].kind(), &DiagnosticsPropertyKind::Size);
+        assert_eq!(props[5].kind(), &DiagnosticsPropertyKind::Flag);
+    }
+
+    #[test]
+    fn test_diagnostics_node_find_descendant() {
+        let tree = DiagnosticsNode::new("Root").child(
+            DiagnosticsNode::new("RenderFlex")
+                .property("direction", "Horizontal")
+                .child(DiagnosticsNode::new("RenderPadding")),
+        );
+
+        let flex = tree.find_descendant("RenderFlex").expect("flex");
+        assert_eq!(flex.get_property("direction"), Some("Horizontal"));
+        assert!(tree.find_descendant("RenderPadding").is_some());
+        assert!(tree.find_descendant("Missing").is_none());
+    }
+
+    #[test]
+    fn test_diagnostics_node_format_deep_filtered() {
+        let node = DiagnosticsNode::new("Box")
+            .property("opacity", 1.0)
+            .with_property(
+                DiagnosticsProperty::new("debug_only", "trace").with_level(DiagnosticLevel::Debug),
+            );
+
+        let full = node.format_deep(0);
+        assert!(full.contains("opacity"));
+        assert!(full.contains("debug_only"));
+
+        let info_only = node.to_string_deep_at_level(DiagnosticLevel::Info);
+        assert!(info_only.contains("opacity"));
+        assert!(!info_only.contains("debug_only"));
+    }
+
+    #[test]
+    fn test_diagnostics_node_get_property_f64() {
+        let node = DiagnosticsNode::new("Box").property("opacity", "0.5");
+        assert_eq!(node.get_property_f64("opacity"), Some(0.5));
+        assert_eq!(node.get_property_f64("missing"), None);
     }
 
     #[test]

--- a/crates/flui-foundation/src/debug.rs
+++ b/crates/flui-foundation/src/debug.rs
@@ -448,6 +448,16 @@ impl DiagnosticsProperty {
         self
     }
 
+    /// Omit the `name: value` separator (builder pattern).
+    ///
+    /// Used by [`DiagnosticsPropertyKind::Flag`] so true flags render as the
+    /// property name only.
+    #[must_use]
+    pub const fn without_separator(mut self) -> Self {
+        self.show_separator = false;
+        self
+    }
+
     /// Set a default value (builder pattern)
     #[must_use]
     pub fn with_default(mut self, default: impl Into<String>) -> Self {
@@ -519,6 +529,45 @@ impl DiagnosticsProperty {
             },
         }
     }
+}
+
+/// Failure modes for [`DiagnosticsNode::find_descendant_unique`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DescendantLookupError {
+    /// No descendant matched the requested name.
+    NotFound,
+    /// More than one descendant matched the requested name.
+    Ambiguous,
+}
+
+impl std::error::Error for DescendantLookupError {}
+
+impl fmt::Display for DescendantLookupError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound => f.write_str("diagnostics descendant not found"),
+            Self::Ambiguous => f.write_str("diagnostics descendant name is ambiguous"),
+        }
+    }
+}
+
+fn walk_descendant<'a>(
+    node: &'a DiagnosticsNode,
+    name: &str,
+    found: &mut Option<&'a DiagnosticsNode>,
+) -> bool {
+    if node.name.as_deref() == Some(name) {
+        if found.is_some() {
+            return true;
+        }
+        *found = Some(node);
+    }
+    for child in &node.children {
+        if walk_descendant(child, name, found) {
+            return true;
+        }
+    }
+    false
 }
 
 impl fmt::Display for DiagnosticsProperty {
@@ -642,21 +691,40 @@ impl DiagnosticsNode {
     /// Returns the first descendant node named `name` (depth-first), if present.
     #[must_use]
     pub fn find_descendant(&self, name: &str) -> Option<&Self> {
-        if self.name.as_deref() == Some(name) {
-            return Some(self);
+        self.find_descendant_unique(name).ok()
+    }
+
+    /// Returns the sole descendant named `name` (depth-first).
+    ///
+    /// # Errors
+    ///
+    /// - [`DescendantLookupError::NotFound`] when no node matches `name`.
+    /// - [`DescendantLookupError::Ambiguous`] when more than one node matches.
+    pub fn find_descendant_unique(&self, name: &str) -> Result<&Self, DescendantLookupError> {
+        let mut found: Option<&DiagnosticsNode> = None;
+        if walk_descendant(self, name, &mut found) {
+            Err(DescendantLookupError::Ambiguous)
+        } else {
+            found.ok_or(DescendantLookupError::NotFound)
         }
-        for child in &self.children {
-            if let Some(found) = child.find_descendant(name) {
-                return Some(found);
-            }
-        }
-        None
+    }
+
+    /// Returns the named property record, if present.
+    #[must_use]
+    pub fn find_property(&self, name: &str) -> Option<&DiagnosticsProperty> {
+        self.properties
+            .iter()
+            .find(|property| property.name() == name)
     }
 
     /// Parses the named property as `f64`, if present and parseable.
+    ///
+    /// Respects [`DiagnosticsPropertyKind::Double`] / [`DiagnosticsPropertyKind::Int`]
+    /// unit suffixes (e.g. `"25px"` → `25.0`).
     #[must_use]
     pub fn get_property_f64(&self, name: &str) -> Option<f64> {
-        self.get_property(name)?.parse().ok()
+        self.find_property(name)
+            .and_then(parse_numeric_property_value)
     }
 
     /// Returns the diagnostic level
@@ -965,7 +1033,9 @@ impl DiagnosticsBuilder {
     pub fn add_flag(&mut self, name: impl Into<String>, value: bool, if_true: &str) -> &mut Self {
         if value {
             self.properties.push(
-                DiagnosticsProperty::new(name, if_true).with_kind(DiagnosticsPropertyKind::Flag),
+                DiagnosticsProperty::new(name, if_true)
+                    .with_kind(DiagnosticsPropertyKind::Flag)
+                    .without_separator(),
             );
         }
         self
@@ -1122,6 +1192,22 @@ fn format_double(value: f32, unit: Option<&str>) -> String {
         Some(u) => format!("{value}{u}"),
         None => format!("{value}"),
     }
+}
+
+/// Parses a numeric diagnostics property, stripping a typed unit suffix when
+/// present.
+fn parse_numeric_property_value(property: &DiagnosticsProperty) -> Option<f64> {
+    let raw = property.value();
+    let numeric = match property.kind() {
+        DiagnosticsPropertyKind::Double { unit } | DiagnosticsPropertyKind::Int { unit } => {
+            match unit {
+                Some(suffix) if raw.ends_with(suffix.as_ref()) => &raw[..raw.len() - suffix.len()],
+                _ => raw,
+            }
+        }
+        _ => raw,
+    };
+    numeric.trim().parse().ok()
 }
 
 #[cfg(test)]
@@ -1455,6 +1541,27 @@ mod tests {
         let node = DiagnosticsNode::new("Box").property("opacity", "0.5");
         assert_eq!(node.get_property_f64("opacity"), Some(0.5));
         assert_eq!(node.get_property_f64("missing"), None);
+    }
+
+    #[test]
+    fn test_diagnostics_node_get_property_f64_strips_unit_suffix() {
+        let mut builder = DiagnosticsBuilder::new();
+        builder.add_double("item_extent", 25.0, Some("px"));
+        let [property] = builder.build().try_into().ok().unwrap();
+        let node = DiagnosticsNode::new("RenderSliverFixedExtentList").with_property(property);
+        assert_eq!(node.get_property_f64("item_extent"), Some(25.0));
+    }
+
+    #[test]
+    fn test_diagnostics_node_find_descendant_unique_rejects_ambiguous() {
+        let tree = DiagnosticsNode::new("Root")
+            .child(DiagnosticsNode::new("RenderPadding"))
+            .child(DiagnosticsNode::new("RenderPadding"));
+        assert_eq!(
+            tree.find_descendant_unique("RenderPadding"),
+            Err(DescendantLookupError::Ambiguous),
+        );
+        assert!(tree.find_descendant("RenderPadding").is_none());
     }
 
     #[test]

--- a/crates/flui-layer/Cargo.toml
+++ b/crates/flui-layer/Cargo.toml
@@ -11,6 +11,12 @@ categories = ["gui", "graphics", "rendering"]
 [features]
 default = []
 
+# testing: opt-in layer-tree test harness (`crate::testing`) — declarative
+# LayerTree builder + structural/bounds inspection + a Diagnosticable-backed
+# tree dump. Off by default; enabled for this crate's own dev targets via the
+# self dev-dependency below, and forwarded by downstream crates that want it.
+testing = []
+
 [dependencies]
 # Foundation - canonical ID types
 flui-foundation = { path = "../flui-foundation" }
@@ -34,4 +40,6 @@ tracing = "0.1"
 thiserror = { workspace = true }
 
 [dev-dependencies]
-# For tests
+# Self dev-dependency that turns the off-by-default `testing` feature on for
+# this crate's own integration tests, so `tests/*.rs` can reach the harness.
+flui-layer = { path = ".", features = ["testing"] }

--- a/crates/flui-layer/docs/README.md
+++ b/crates/flui-layer/docs/README.md
@@ -1,0 +1,12 @@
+# flui_layer documentation
+
+## Testing
+
+| Document | Topic |
+|----------|-------|
+| **[TESTING.md](./TESTING.md)** | `LayerTester`, `layer` spec builder, `inspect` walkers |
+
+## Related
+
+- [flui-rendering/docs/TESTING.md](../../flui-rendering/docs/TESTING.md) — render-object harness (consumes layer walkers)
+- [docs/testing.md](../../../docs/testing.md) — workspace testing guide

--- a/crates/flui-layer/docs/TESTING.md
+++ b/crates/flui-layer/docs/TESTING.md
@@ -1,0 +1,120 @@
+# Layer-tree test harness (`flui_layer::testing`)
+
+Declarative construction and structural inspection of [`LayerTree`](../src/layer_tree.rs)
+for unit tests and for [`flui-rendering`](../../flui-rendering/docs/TESTING.md)'s
+render harness (which re-exports the walkers as `inspect::layer_structure`, etc.).
+
+## Enabling
+
+| Consumer | How to enable |
+|----------|----------------|
+| This crate's own tests | `cfg(test)` |
+| Downstream crates | `flui-layer = { features = ["testing"] }` |
+| `flui-rendering` with `testing` | Forwarded automatically |
+
+```bash
+cargo test -p flui-layer
+```
+
+## Design
+
+```text
+LayerSpec  →  LayerTester::mount  →  structure / bounds / diagnostics
+     ↑
+  layer(OffsetLayer::…).child(…).label("canvas")
+```
+
+The free functions in [`inspect`](../src/testing/inspect.rs) are the **single
+source of truth** for layer-tree walks. `flui-rendering` does not duplicate them.
+
+## Core API
+
+### Tree builder ([`spec`](../src/testing/spec.rs))
+
+| Item | Role |
+|------|------|
+| `layer(value)` | Start a spec from any `Into<Layer>` (`OffsetLayer`, `PictureLayer`, …) |
+| `LayerSpec::label("name")` | Register label for `tester.id("name")` |
+| `LayerSpec::child` / `children` | Nesting |
+| `mount(tree, spec)` | Low-level insert + wire children (used by `LayerTester`) |
+| `IdRegistry` | Label → `LayerId` map |
+
+### `LayerTester` ([`tester`](../src/testing/tester.rs))
+
+| Method | Purpose |
+|--------|---------|
+| `mount(spec)` | Build a fresh `LayerTree` from a spec |
+| `root()` | Root `LayerId` |
+| `tree()` / `tree_mut()` | Underlying `LayerTree` |
+| `id("label")` / `try_id` | Resolve labeled layer |
+| `kind(id)` | Short kind name (`"Picture"`, `"Opacity"`, …) |
+| `structure()` | Pre-order kind names |
+| `structure_with_depth()` | Kinds paired with depth from root |
+| `first_picture_bounds()` | First `Picture` layer bounds |
+| `diagnostics()` | `Diagnosticable`-backed hierarchy |
+| `dump()` | Printable diagnostics string |
+
+### Free inspect functions ([`inspect`](../src/testing/inspect.rs))
+
+Use these directly when you already hold a `LayerTree` (e.g. from
+`FrameRun::layer_tree()` in the render harness).
+
+| Function | Returns |
+|----------|---------|
+| `layer_kind(layer)` | `&'static str` kind name |
+| `structure(tree)` | `Vec<&'static str>` pre-order kinds |
+| `structure_with_depth(tree)` | `Vec<(usize, &'static str)>` |
+| `first_picture_bounds(tree)` | `Option<Rect>` |
+| `first_opacity_alpha(tree)` | `Option<f32>` — first `Opacity` layer |
+| `has_picture_layer(tree)` | `bool` |
+| `diagnostics_tree(tree)` | `Option<DiagnosticsNode>` |
+
+## Examples
+
+### Build and inspect structure
+
+```rust
+use flui_layer::testing::{LayerTester, layer};
+use flui_layer::{CanvasLayer, OffsetLayer};
+use flui_types::geometry::px;
+
+let probe = LayerTester::mount(
+    layer(OffsetLayer::new(flui_types::Offset::new(px(5.0), px(5.0))))
+        .child(layer(CanvasLayer::new()).label("canvas")),
+);
+
+assert_eq!(probe.structure(), vec!["Offset", "Canvas"]);
+assert_eq!(probe.kind(probe.id("canvas")), "Canvas");
+```
+
+### Walk a tree from the render harness
+
+```rust
+use flui_layer::testing::inspect;
+
+let tree = run.layer_tree().expect("frame painted");
+assert_eq!(inspect::structure(tree), vec!["Offset", "Picture"]);
+assert!(inspect::has_picture_layer(tree));
+```
+
+### Opacity layer checks (animation tests)
+
+```rust
+use flui_layer::testing::inspect;
+
+let alpha = inspect::first_opacity_alpha(tree);
+// None when fully opaque (Flutter parity: no OpacityLayer at alpha 255)
+// Some(0.5) when semi-transparent
+```
+
+### Diagnostics dump
+
+```rust
+let dump = probe.dump();
+assert!(dump.contains("Offset"));
+```
+
+## See also
+
+- Render harness (uses these walkers): [`flui-rendering/docs/TESTING.md`](../../flui-rendering/docs/TESTING.md)
+- Workspace overview: [`docs/testing.md`](../../../docs/testing.md)

--- a/crates/flui-layer/docs/TESTING.md
+++ b/crates/flui-layer/docs/TESTING.md
@@ -37,7 +37,7 @@ source of truth** for layer-tree walks. `flui-rendering` does not duplicate them
 | `LayerSpec::label("name")` | Register label for `tester.id("name")` |
 | `LayerSpec::child` / `children` | Nesting |
 | `mount(tree, spec)` | Low-level insert + wire children (used by `LayerTester`) |
-| `IdRegistry` | Label → `LayerId` map |
+| `LayerLabelRegistry` | Label → `LayerId` map |
 
 ### `LayerTester` ([`tester`](../src/testing/tester.rs))
 

--- a/crates/flui-layer/src/layer/mod.rs
+++ b/crates/flui-layer/src/layer/mod.rs
@@ -425,7 +425,7 @@ impl Diagnosticable for Layer {
             }
             _ => {}
         }
-        properties.add_flag("needsCompositing", self.needs_compositing(), "true");
+        properties.add_flag("needs_compositing", self.needs_compositing(), "true");
     }
 }
 

--- a/crates/flui-layer/src/layer/mod.rs
+++ b/crates/flui-layer/src/layer/mod.rs
@@ -108,6 +108,9 @@ pub use clip_rect::ClipRectLayer;
 pub use clip_rrect::ClipRRectLayer;
 pub use clip_superellipse::ClipSuperellipseLayer;
 pub use color_filter::ColorFilterLayer;
+use flui_foundation::{Diagnosticable, DiagnosticsBuilder, DiagnosticsNode};
+// `DisplayListCore` brings `len()` on the picture's display list into scope.
+use flui_painting::DisplayListCore;
 use flui_types::geometry::{Pixels, Rect};
 pub use follower::FollowerLayer;
 pub use image_filter::ImageFilterLayer;
@@ -360,6 +363,69 @@ impl Layer {
             // All other layers are conservatively treated as non-opaque
             _ => false,
         }
+    }
+
+    /// Returns the short variant name of this layer (e.g. `"Picture"`,
+    /// `"ClipRect"`). Used for diagnostics and structural test snapshots.
+    #[must_use]
+    pub const fn kind_name(&self) -> &'static str {
+        match self {
+            Layer::Canvas(_) => "Canvas",
+            Layer::Picture(_) => "Picture",
+            Layer::Texture(_) => "Texture",
+            Layer::PlatformView(_) => "PlatformView",
+            Layer::PerformanceOverlay(_) => "PerformanceOverlay",
+            Layer::ClipRect(_) => "ClipRect",
+            Layer::ClipRRect(_) => "ClipRRect",
+            Layer::ClipPath(_) => "ClipPath",
+            Layer::ClipSuperellipse(_) => "ClipSuperellipse",
+            Layer::Offset(_) => "Offset",
+            Layer::Transform(_) => "Transform",
+            Layer::Opacity(_) => "Opacity",
+            Layer::ColorFilter(_) => "ColorFilter",
+            Layer::ImageFilter(_) => "ImageFilter",
+            Layer::ShaderMask(_) => "ShaderMask",
+            Layer::BackdropFilter(_) => "BackdropFilter",
+            Layer::Leader(_) => "Leader",
+            Layer::Follower(_) => "Follower",
+            Layer::AnnotatedRegion(_) => "AnnotatedRegion",
+        }
+    }
+}
+
+impl Diagnosticable for Layer {
+    fn to_diagnostics_node(&self) -> DiagnosticsNode {
+        let mut node = DiagnosticsNode::new(self.kind_name());
+        let mut builder = DiagnosticsBuilder::new();
+        self.debug_fill_properties(&mut builder);
+        *node.properties_mut() = builder.build();
+        node
+    }
+
+    fn debug_fill_properties(&self, properties: &mut DiagnosticsBuilder) {
+        if let Some(bounds) = self.bounds() {
+            properties.add("bounds", format!("{bounds:?}"));
+        }
+        match self {
+            Layer::Offset(layer) => {
+                properties.add("offset", format!("{:?}", layer.offset()));
+            }
+            Layer::Transform(layer) => {
+                properties.add("transform", format!("{:?}", layer.transform()));
+            }
+            Layer::Opacity(layer) => {
+                properties.add("alpha", layer.alpha());
+                properties.add("offset", format!("{:?}", layer.offset()));
+            }
+            Layer::ClipRect(layer) => {
+                properties.add("clip_rect", format!("{:?}", layer.clip_rect()));
+            }
+            Layer::Picture(layer) => {
+                properties.add("commands", layer.picture().len());
+            }
+            _ => {}
+        }
+        properties.add_flag("needsCompositing", self.needs_compositing(), "true");
     }
 }
 

--- a/crates/flui-layer/src/lib.rs
+++ b/crates/flui-layer/src/lib.rs
@@ -100,6 +100,12 @@ mod link_registry;
 mod scene;
 
 pub mod layer;
+// Layer-tree test harness. Compiled only for this crate's own tests
+// (`cfg(test)`) or when a consumer enables the `testing` feature. Provides a
+// declarative `LayerTree` builder, structural/bounds inspection, and a
+// `Diagnosticable`-backed tree dump. See [`testing`] for the overview.
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;
 pub mod tree;
 
 pub use error::{LayerError, LayerResult};

--- a/crates/flui-layer/src/testing/inspect.rs
+++ b/crates/flui-layer/src/testing/inspect.rs
@@ -1,0 +1,108 @@
+//! Structural and diagnostic inspection of a [`LayerTree`].
+//!
+//! These free functions are the single source of truth for layer-tree
+//! introspection — `flui-rendering`'s render harness re-uses them rather than
+//! reimplementing the walk.
+
+use flui_foundation::{Diagnosticable, DiagnosticsNode, LayerId};
+use flui_painting::DisplayListCore;
+use flui_types::Rect;
+
+use crate::{Layer, LayerTree};
+
+/// Returns the short kind name of a layer (e.g. `"Picture"`).
+#[must_use]
+pub fn layer_kind(layer: &Layer) -> &'static str {
+    layer.kind_name()
+}
+
+/// Returns the layer kinds in pre-order (parent before children) as a flat
+/// list.
+#[must_use]
+pub fn structure(tree: &LayerTree) -> Vec<&'static str> {
+    structure_with_depth(tree)
+        .into_iter()
+        .map(|(_, kind)| kind)
+        .collect()
+}
+
+/// Returns the layer kinds in pre-order, each paired with its depth from the
+/// root (root = 0).
+#[must_use]
+pub fn structure_with_depth(tree: &LayerTree) -> Vec<(usize, &'static str)> {
+    fn walk(tree: &LayerTree, id: LayerId, depth: usize, out: &mut Vec<(usize, &'static str)>) {
+        let Some(node) = tree.get(id) else {
+            return;
+        };
+        out.push((depth, node.layer().kind_name()));
+        for &child in node.children() {
+            walk(tree, child, depth + 1, out);
+        }
+    }
+
+    let mut out = Vec::new();
+    if let Some(root) = tree.root() {
+        walk(tree, root, 0, &mut out);
+    }
+    out
+}
+
+/// Returns the bounds of the first `Picture` layer found in pre-order, or
+/// `None` if the tree contains no picture.
+#[must_use]
+pub fn first_picture_bounds(tree: &LayerTree) -> Option<Rect> {
+    fn find(tree: &LayerTree, id: LayerId) -> Option<Rect> {
+        let node = tree.get(id)?;
+        if let Layer::Picture(picture) = node.layer() {
+            return Some(picture.picture().bounds());
+        }
+        node.children().iter().find_map(|&child| find(tree, child))
+    }
+    find(tree, tree.root()?)
+}
+
+/// Builds a [`DiagnosticsNode`] tree mirroring the layer hierarchy: each
+/// node self-describes via [`Diagnosticable::to_diagnostics_node`] and the
+/// tree links supply the parent/child structure.
+#[must_use]
+pub fn diagnostics_tree(tree: &LayerTree) -> Option<DiagnosticsNode> {
+    fn subtree(tree: &LayerTree, id: LayerId) -> Option<DiagnosticsNode> {
+        let node = tree.get(id)?;
+        let mut diagnostics = node.to_diagnostics_node();
+        for &child in node.children() {
+            if let Some(child_diagnostics) = subtree(tree, child) {
+                diagnostics.add_child(child_diagnostics);
+            }
+        }
+        Some(diagnostics)
+    }
+    subtree(tree, tree.root()?)
+}
+
+/// Returns the alpha of the first [`Layer::Opacity`] node in pre-order, or
+/// `None` if the tree contains no opacity layer (fully-opaque subtrees paint
+/// directly per Flutter parity).
+#[must_use]
+pub fn first_opacity_alpha(tree: &LayerTree) -> Option<f32> {
+    fn find(tree: &LayerTree, id: LayerId) -> Option<f32> {
+        let node = tree.get(id)?;
+        if let Layer::Opacity(opacity) = node.layer() {
+            return Some(opacity.alpha());
+        }
+        node.children().iter().find_map(|&child| find(tree, child))
+    }
+    find(tree, tree.root()?)
+}
+
+/// Returns whether the tree contains any [`Layer::Picture`] node in pre-order.
+#[must_use]
+pub fn has_picture_layer(tree: &LayerTree) -> bool {
+    fn find(tree: &LayerTree, id: LayerId) -> bool {
+        let Some(node) = tree.get(id) else {
+            return false;
+        };
+        matches!(node.layer(), Layer::Picture(_))
+            || node.children().iter().any(|&child| find(tree, child))
+    }
+    tree.root().is_some_and(|root| find(tree, root))
+}

--- a/crates/flui-layer/src/testing/mod.rs
+++ b/crates/flui-layer/src/testing/mod.rs
@@ -1,0 +1,39 @@
+//! Layer-tree test harness.
+//!
+//! Full API reference and examples: `crates/flui-layer/docs/TESTING.md`.
+//!
+//! Compiled only for this crate's own tests (`cfg(test)`) or when a consumer
+//! enables the `testing` feature. Provides:
+//!
+//! - a declarative [`LayerTree`](crate::LayerTree) builder ([`layer`],
+//!   [`LayerSpec`]);
+//! - a [`LayerTester`] wrapper with structural / bounds / diagnostics
+//!   inspection (mirrors `flui_rendering::testing::RenderTester`);
+//! - free [`inspect`] functions (`structure`, `first_picture_bounds`,
+//!   `diagnostics_tree`) that are the single source of truth `flui-rendering`
+//!   re-uses.
+//!
+//! # Example
+//!
+//! ```
+//! use flui_layer::testing::{LayerTester, layer};
+//! use flui_layer::{CanvasLayer, OffsetLayer};
+//! use flui_types::geometry::px;
+//!
+//! let probe = LayerTester::mount(
+//!     layer(OffsetLayer::new(flui_types::Offset::new(px(5.0), px(5.0))))
+//!         .child(layer(CanvasLayer::new()).label("canvas")),
+//! );
+//! assert_eq!(probe.structure(), vec!["Offset", "Canvas"]);
+//! assert_eq!(probe.kind(probe.id("canvas")), "Canvas");
+//! ```
+
+pub mod inspect;
+mod spec;
+mod tester;
+
+pub use spec::{layer, mount, IdRegistry, LayerSpec};
+pub use tester::LayerTester;
+
+#[cfg(test)]
+mod tests;

--- a/crates/flui-layer/src/testing/mod.rs
+++ b/crates/flui-layer/src/testing/mod.rs
@@ -32,7 +32,7 @@ pub mod inspect;
 mod spec;
 mod tester;
 
-pub use spec::{layer, mount, IdRegistry, LayerSpec};
+pub use spec::{layer, mount, LayerLabelRegistry, LayerSpec};
 pub use tester::LayerTester;
 
 #[cfg(test)]

--- a/crates/flui-layer/src/testing/spec.rs
+++ b/crates/flui-layer/src/testing/spec.rs
@@ -1,0 +1,98 @@
+//! Declarative `LayerTree` construction.
+//!
+//! A [`LayerSpec`] describes a layer plus its children and an optional label;
+//! [`mount`] inserts the spec into a [`LayerTree`], wiring parent/child links
+//! and setting the root, and returns a label -> [`LayerId`] registry.
+
+use std::collections::HashMap;
+
+use flui_foundation::LayerId;
+
+use crate::{Layer, LayerTree};
+
+/// A node in a declarative layer-tree spec.
+///
+/// Build one with [`layer`], nest children with [`child`](LayerSpec::child) /
+/// [`children`](LayerSpec::children), and tag it with
+/// [`label`](LayerSpec::label) for lookup after mounting.
+pub struct LayerSpec {
+    layer: Layer,
+    label: Option<&'static str>,
+    children: Vec<LayerSpec>,
+}
+
+/// Creates a [`LayerSpec`] from any value convertible into a [`Layer`]
+/// (e.g. `CanvasLayer`, `OffsetLayer`, or a `Layer` directly).
+pub fn layer(layer: impl Into<Layer>) -> LayerSpec {
+    LayerSpec {
+        layer: layer.into(),
+        label: None,
+        children: Vec::new(),
+    }
+}
+
+impl LayerSpec {
+    /// Tags this node with a label for post-mount lookup.
+    #[must_use]
+    pub fn label(mut self, label: &'static str) -> Self {
+        self.label = Some(label);
+        self
+    }
+
+    /// Appends a single child spec.
+    #[must_use]
+    pub fn child(mut self, child: LayerSpec) -> Self {
+        self.children.push(child);
+        self
+    }
+
+    /// Appends every child spec from an iterator.
+    #[must_use]
+    pub fn children(mut self, children: impl IntoIterator<Item = LayerSpec>) -> Self {
+        self.children.extend(children);
+        self
+    }
+}
+
+/// Maps `&'static str` labels to the `LayerId`s minted while mounting a spec.
+#[derive(Debug, Default, Clone)]
+pub struct IdRegistry {
+    by_label: HashMap<&'static str, LayerId>,
+}
+
+impl IdRegistry {
+    fn record(&mut self, label: &'static str, id: LayerId) {
+        let previous = self.by_label.insert(label, id);
+        assert!(
+            previous.is_none(),
+            "duplicate layer label in test tree: {label:?}"
+        );
+    }
+
+    /// Returns the id for `label`, if one was registered.
+    #[must_use]
+    pub fn get(&self, label: &str) -> Option<LayerId> {
+        self.by_label.get(label).copied()
+    }
+}
+
+/// Inserts `spec` into `tree`, wires children, sets the root, and returns the
+/// root id plus the label registry.
+pub fn mount(tree: &mut LayerTree, spec: LayerSpec) -> (LayerId, IdRegistry) {
+    let mut registry = IdRegistry::default();
+    let root = mount_node(tree, spec, &mut registry);
+    tree.set_root(Some(root));
+    (root, registry)
+}
+
+fn mount_node(tree: &mut LayerTree, spec: LayerSpec, registry: &mut IdRegistry) -> LayerId {
+    let id = tree.insert(spec.layer);
+    if let Some(label) = spec.label {
+        registry.record(label, id);
+    }
+    for child in spec.children {
+        let child_id = mount_node(tree, child, registry);
+        tree.add_child(id, child_id);
+    }
+    id
+}

--- a/crates/flui-layer/src/testing/spec.rs
+++ b/crates/flui-layer/src/testing/spec.rs
@@ -56,11 +56,11 @@ impl LayerSpec {
 
 /// Maps `&'static str` labels to the `LayerId`s minted while mounting a spec.
 #[derive(Debug, Default, Clone)]
-pub struct IdRegistry {
+pub struct LayerLabelRegistry {
     by_label: HashMap<&'static str, LayerId>,
 }
 
-impl IdRegistry {
+impl LayerLabelRegistry {
     fn record(&mut self, label: &'static str, id: LayerId) {
         let previous = self.by_label.insert(label, id);
         assert!(
@@ -78,14 +78,14 @@ impl IdRegistry {
 
 /// Inserts `spec` into `tree`, wires children, sets the root, and returns the
 /// root id plus the label registry.
-pub fn mount(tree: &mut LayerTree, spec: LayerSpec) -> (LayerId, IdRegistry) {
-    let mut registry = IdRegistry::default();
+pub fn mount(tree: &mut LayerTree, spec: LayerSpec) -> (LayerId, LayerLabelRegistry) {
+    let mut registry = LayerLabelRegistry::default();
     let root = mount_node(tree, spec, &mut registry);
     tree.set_root(Some(root));
     (root, registry)
 }
 
-fn mount_node(tree: &mut LayerTree, spec: LayerSpec, registry: &mut IdRegistry) -> LayerId {
+fn mount_node(tree: &mut LayerTree, spec: LayerSpec, registry: &mut LayerLabelRegistry) -> LayerId {
     let id = tree.insert(spec.layer);
     if let Some(label) = spec.label {
         registry.record(label, id);

--- a/crates/flui-layer/src/testing/tester.rs
+++ b/crates/flui-layer/src/testing/tester.rs
@@ -8,7 +8,7 @@ use flui_types::Rect;
 use crate::{
     testing::{
         inspect,
-        spec::{self, IdRegistry, LayerSpec},
+        spec::{self, LayerLabelRegistry, LayerSpec},
     },
     LayerTree,
 };
@@ -17,7 +17,7 @@ use crate::{
 pub struct LayerTester {
     tree: LayerTree,
     root: LayerId,
-    registry: IdRegistry,
+    registry: LayerLabelRegistry,
 }
 
 impl LayerTester {

--- a/crates/flui-layer/src/testing/tester.rs
+++ b/crates/flui-layer/src/testing/tester.rs
@@ -1,0 +1,107 @@
+//! `LayerTester` — an ergonomic wrapper that mounts a [`LayerSpec`] and
+//! exposes the inspection surface. Named to mirror
+//! `flui_rendering::testing::RenderTester`.
+
+use flui_foundation::{DiagnosticsNode, LayerId};
+use flui_types::Rect;
+
+use crate::{
+    testing::{
+        inspect,
+        spec::{self, IdRegistry, LayerSpec},
+    },
+    LayerTree,
+};
+
+/// A mounted layer tree plus its label registry, ready to inspect.
+pub struct LayerTester {
+    tree: LayerTree,
+    root: LayerId,
+    registry: IdRegistry,
+}
+
+impl LayerTester {
+    /// Mounts a [`LayerSpec`] into a fresh [`LayerTree`].
+    #[must_use]
+    pub fn mount(spec: LayerSpec) -> Self {
+        let mut tree = LayerTree::new();
+        let (root, registry) = spec::mount(&mut tree, spec);
+        Self {
+            tree,
+            root,
+            registry,
+        }
+    }
+
+    /// The root layer id.
+    #[must_use]
+    pub fn root(&self) -> LayerId {
+        self.root
+    }
+
+    /// The underlying layer tree.
+    #[must_use]
+    pub fn tree(&self) -> &LayerTree {
+        &self.tree
+    }
+
+    /// Mutable access to the underlying layer tree (mutate between checks).
+    pub fn tree_mut(&mut self) -> &mut LayerTree {
+        &mut self.tree
+    }
+
+    /// Resolves a label to its id, panicking if it was never registered.
+    #[must_use]
+    pub fn id(&self, label: &str) -> LayerId {
+        self.try_id(label)
+            .unwrap_or_else(|| panic!("no layer labeled {label:?} in the test tree"))
+    }
+
+    /// Resolves a label to its id, or `None` if unknown.
+    #[must_use]
+    pub fn try_id(&self, label: &str) -> Option<LayerId> {
+        self.registry.get(label)
+    }
+
+    /// The kind name of the layer at `id`.
+    #[must_use]
+    pub fn kind(&self, id: LayerId) -> &'static str {
+        self.tree
+            .get(id)
+            .expect("layer id must be live")
+            .layer()
+            .kind_name()
+    }
+
+    /// The layer kinds in pre-order.
+    #[must_use]
+    pub fn structure(&self) -> Vec<&'static str> {
+        inspect::structure(&self.tree)
+    }
+
+    /// The layer kinds in pre-order with depth.
+    #[must_use]
+    pub fn structure_with_depth(&self) -> Vec<(usize, &'static str)> {
+        inspect::structure_with_depth(&self.tree)
+    }
+
+    /// The bounds of the first picture layer, if any.
+    #[must_use]
+    pub fn first_picture_bounds(&self) -> Option<Rect> {
+        inspect::first_picture_bounds(&self.tree)
+    }
+
+    /// A `Diagnosticable`-backed diagnostics tree mirroring the hierarchy.
+    #[must_use]
+    pub fn diagnostics(&self) -> Option<DiagnosticsNode> {
+        inspect::diagnostics_tree(&self.tree)
+    }
+
+    /// A printable, indented dump of the diagnostics tree.
+    #[must_use]
+    pub fn dump(&self) -> String {
+        self.diagnostics()
+            .map(|node| node.to_string())
+            .unwrap_or_default()
+    }
+}

--- a/crates/flui-layer/src/testing/tests.rs
+++ b/crates/flui-layer/src/testing/tests.rs
@@ -1,0 +1,80 @@
+//! Self-tests for the layer-tree harness.
+
+use flui_painting::{Canvas, Paint};
+use flui_types::{geometry::px, styling::Color, Offset, Rect};
+
+use crate::{
+    testing::{inspect, layer, LayerTester},
+    CanvasLayer, OffsetLayer, PictureLayer,
+};
+
+fn picture_0_0_40_40() -> PictureLayer {
+    let mut canvas = Canvas::new();
+    canvas.draw_rect(
+        Rect::from_ltrb(px(0.0), px(0.0), px(40.0), px(40.0)),
+        &Paint::fill(Color::RED),
+    );
+    PictureLayer::new(canvas.finish())
+}
+
+#[test]
+fn structure_label_and_kind() {
+    let probe = LayerTester::mount(
+        layer(OffsetLayer::new(Offset::new(px(5.0), px(5.0))))
+            .child(layer(CanvasLayer::new()).label("canvas")),
+    );
+
+    assert_eq!(probe.structure(), vec!["Offset", "Canvas"]);
+    assert_eq!(probe.kind(probe.id("canvas")), "Canvas");
+    assert_eq!(probe.kind(probe.root()), "Offset");
+}
+
+#[test]
+fn structure_with_depth_nests() {
+    let probe = LayerTester::mount(
+        layer(OffsetLayer::new(Offset::ZERO))
+            .child(layer(OffsetLayer::new(Offset::ZERO)).child(layer(CanvasLayer::new()))),
+    );
+
+    assert_eq!(
+        probe.structure_with_depth(),
+        vec![(0, "Offset"), (1, "Offset"), (2, "Canvas")],
+    );
+}
+
+#[test]
+fn first_picture_bounds_reads_record_time_bounds() {
+    let probe =
+        LayerTester::mount(layer(OffsetLayer::new(Offset::ZERO)).child(layer(picture_0_0_40_40())));
+
+    assert_eq!(
+        probe.first_picture_bounds(),
+        Some(Rect::from_ltrb(px(0.0), px(0.0), px(40.0), px(40.0))),
+    );
+}
+
+#[test]
+fn diagnostics_dump_names_each_layer_and_carries_properties() {
+    let probe = LayerTester::mount(
+        layer(OffsetLayer::new(Offset::new(px(5.0), px(5.0)))).child(layer(picture_0_0_40_40())),
+    );
+
+    let tree = probe.diagnostics().expect("diagnostics tree");
+    assert_eq!(tree.name(), Some("Offset"), "root names the Offset layer");
+    let picture = tree
+        .find_child("Picture")
+        .expect("the offset layer has a picture child");
+    // The Picture self-describes its record-time bounds.
+    assert!(
+        picture.get_property("bounds").is_some(),
+        "picture must carry a bounds property",
+    );
+}
+
+#[test]
+fn inspect_free_fns_match_probe() {
+    let probe =
+        LayerTester::mount(layer(OffsetLayer::new(Offset::ZERO)).child(layer(CanvasLayer::new())));
+    assert_eq!(inspect::structure(probe.tree()), probe.structure());
+    assert!(inspect::diagnostics_tree(probe.tree()).is_some());
+}

--- a/crates/flui-layer/src/tree/layer_tree.rs
+++ b/crates/flui-layer/src/tree/layer_tree.rs
@@ -5,7 +5,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use flui_foundation::{ElementId, LayerId};
+use flui_foundation::{Diagnosticable, ElementId, LayerId};
 use flui_types::{geometry::Pixels, Offset};
 use slab::Slab;
 
@@ -65,6 +65,21 @@ pub struct LayerNode {
     /// have not yet been pushed). Cleared by the engine after a successful
     /// scene build. Mirrors Flutter `layer.dart` `_needsAddToScene`.
     needs_add_to_scene: AtomicBool,
+}
+
+impl Diagnosticable for LayerNode {
+    /// Names the node by its layer kind and merges the layer's own
+    /// properties with node-level metadata (parent offset, element id).
+    fn to_diagnostics_node(&self) -> flui_foundation::DiagnosticsNode {
+        let mut node = self.layer.to_diagnostics_node();
+        if let Some(offset) = self.offset {
+            node = node.property("nodeOffset", format!("{offset:?}"));
+        }
+        if let Some(element_id) = self.element_id {
+            node = node.property("elementId", format!("{element_id:?}"));
+        }
+        node
+    }
 }
 
 impl LayerNode {

--- a/crates/flui-layer/src/tree/layer_tree.rs
+++ b/crates/flui-layer/src/tree/layer_tree.rs
@@ -73,10 +73,10 @@ impl Diagnosticable for LayerNode {
     fn to_diagnostics_node(&self) -> flui_foundation::DiagnosticsNode {
         let mut node = self.layer.to_diagnostics_node();
         if let Some(offset) = self.offset {
-            node = node.property("nodeOffset", format!("{offset:?}"));
+            node = node.property("node_offset", format!("{offset:?}"));
         }
         if let Some(element_id) = self.element_id {
-            node = node.property("elementId", format!("{element_id:?}"));
+            node = node.property("element_id", format!("{element_id:?}"));
         }
         node
     }

--- a/crates/flui-layer/tests/scene_builder.rs
+++ b/crates/flui-layer/tests/scene_builder.rs
@@ -57,6 +57,13 @@ fn test_scene_builder_push_pop() {
     let children = tree.children(offset_id).unwrap();
     assert_eq!(children.len(), 1);
     assert_eq!(children[0], opacity_id);
+
+    // Cross-check the same structure through the shared inspection walker
+    // (dogfoods `testing::inspect::structure` on a SceneBuilder-built tree).
+    assert_eq!(
+        flui_layer::testing::inspect::structure(&tree),
+        vec!["Offset", "Opacity"],
+    );
 }
 
 #[test]

--- a/crates/flui-painting/Cargo.toml
+++ b/crates/flui-painting/Cargo.toml
@@ -24,9 +24,17 @@ parking_lot = { workspace = true }
 cosmic-text = { version = "0.18" }
 
 [dev-dependencies]
+# Self dev-dependency that turns the off-by-default `testing` feature on for
+# this crate's own integration tests, so `tests/*.rs` can reach the harness.
+flui-painting = { path = ".", features = ["testing"] }
 
 [features]
 serde = ["dep:serde", "flui-types/serde"]
+
+# testing: opt-in painting test harness (`crate::testing`) — a `record`
+# builder for `DisplayList`s plus diagnostics helpers. Off by default;
+# enabled for this crate's dev targets via the self dev-dependency above.
+testing = []
 
 [lints]
 workspace = true

--- a/crates/flui-painting/docs/README.md
+++ b/crates/flui-painting/docs/README.md
@@ -19,6 +19,7 @@ Welcome to the `flui_painting` documentation! This directory contains comprehens
 ### For Contributors
 
 - **[Contributing Guide](../CONTRIBUTING.md)** - How to contribute to the project
+- **[Test Harness (`testing` feature)](./TESTING.md)** - `record`, display-list inspection, examples
 
 ## Overview
 

--- a/crates/flui-painting/docs/TESTING.md
+++ b/crates/flui-painting/docs/TESTING.md
@@ -1,0 +1,88 @@
+# Painting test harness (`flui_painting::testing`)
+
+Record [`DisplayList`](../src/display_list/mod.rs) commands without
+`Canvas::new()` / `finish()` boilerplate, then inspect command count, bounds,
+and diagnostics.
+
+Use this when testing **paint recording in isolation** (a single render object's
+`paint` method, a custom painter, or display-list utilities). For full render-tree
+integration, prefer [`flui-rendering::testing`](../../flui-rendering/docs/TESTING.md).
+
+## Enabling
+
+| Consumer | How to enable |
+|----------|----------------|
+| This crate's own tests | `cfg(test)` |
+| Downstream crates | `flui-painting = { features = ["testing"] }` |
+
+```bash
+cargo test -p flui-painting
+cargo test -p flui-painting --test display_list_unit
+```
+
+## Design
+
+```text
+record(|canvas| { … })  →  DisplayList  →  command_count / bounds / diagnostics
+```
+
+The harness wraps the canonical record-now pattern: one closure, one finished list.
+
+## Core API
+
+All functions live in [`testing/mod.rs`](../src/testing/mod.rs).
+
+| Function | Returns | Purpose |
+|----------|---------|---------|
+| `record(f)` | `DisplayList` | `Canvas::new()` → run `f` → `finish()` |
+| `command_count(list)` | `usize` | Number of recorded commands |
+| `bounds(list)` | `Rect` | Record-time bounds |
+| `diagnostics(list)` | `DiagnosticsNode` | `Diagnosticable` snapshot |
+| `dump(list)` | `String` | Indented printable dump |
+
+## Examples
+
+### Record a filled rect
+
+```rust
+use flui_painting::testing::{record, command_count, bounds};
+use flui_painting::Paint;
+use flui_types::{Rect, geometry::px, styling::Color};
+
+let list = record(|canvas| {
+    canvas.draw_rect(
+        Rect::from_ltrb(px(0.0), px(0.0), px(40.0), px(40.0)),
+        &Paint::fill(Color::RED),
+    );
+});
+
+assert_eq!(command_count(&list), 1);
+assert_eq!(
+    bounds(&list),
+    Rect::from_ltrb(px(0.0), px(0.0), px(40.0), px(40.0)),
+);
+```
+
+### Structured diagnostics (no substring matching)
+
+```rust
+use flui_painting::testing::{record, diagnostics};
+
+let list = record(|canvas| { /* draw */ });
+let node = diagnostics(&list);
+assert_eq!(node.name(), Some("DisplayList"));
+assert_eq!(node.get_property("commands"), Some("1"));
+```
+
+### Empty recording
+
+```rust
+let list = record(|_canvas| {});
+assert_eq!(command_count(&list), 0);
+```
+
+## See also
+
+- Crate architecture: [`ARCHITECTURE.md`](./ARCHITECTURE.md)
+- Render-object harness (end-to-end paint): [`flui-rendering/docs/TESTING.md`](../../flui-rendering/docs/TESTING.md)
+- Workspace overview: [`docs/testing.md`](../../../docs/testing.md)

--- a/crates/flui-painting/src/display_list/mod.rs
+++ b/crates/flui-painting/src/display_list/mod.rs
@@ -34,6 +34,7 @@
 
 use std::ops::{Index, IndexMut};
 
+use flui_foundation::{Diagnosticable, DiagnosticsBuilder};
 use flui_types::geometry::{Matrix4, Pixels, Rect};
 
 pub mod command;
@@ -72,6 +73,13 @@ pub struct DisplayList {
 
     /// Cached bounds of all drawing.
     pub(crate) bounds: Rect<Pixels>,
+}
+
+impl Diagnosticable for DisplayList {
+    fn debug_fill_properties(&self, properties: &mut DiagnosticsBuilder) {
+        properties.add("commands", self.commands.len());
+        properties.add("bounds", format!("{:?}", self.bounds));
+    }
 }
 
 impl DisplayList {

--- a/crates/flui-painting/src/lib.rs
+++ b/crates/flui-painting/src/lib.rs
@@ -173,6 +173,13 @@ pub mod error;
 pub mod text_layout;
 pub mod text_painter;
 
+// Painting test harness. Compiled only for this crate's own tests
+// (`cfg(test)`) or when a consumer enables the `testing` feature. Provides a
+// `record` builder for `DisplayList`s plus diagnostics helpers. See
+// [`testing`] for the overview.
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;
+
 // ===== Facade Pattern: Public Re-exports =====
 //
 // Re-export all public types at the crate root for convenient access.

--- a/crates/flui-painting/src/testing/mod.rs
+++ b/crates/flui-painting/src/testing/mod.rs
@@ -1,0 +1,111 @@
+//! Painting test harness.
+//!
+//! Full API reference and examples: `crates/flui-painting/docs/TESTING.md`.
+//!
+//! Compiled only for this crate's own tests (`cfg(test)`) or when a consumer
+//! enables the `testing` feature. Removes the `Canvas::new()` / `finish()`
+//! boilerplate from tests and exposes `Diagnosticable`-backed inspection of a
+//! recorded [`DisplayList`].
+//!
+//! # Example
+//!
+//! ```
+//! use flui_painting::testing::{record, command_count};
+//! use flui_painting::Paint;
+//! use flui_types::{Rect, geometry::px, styling::Color};
+//!
+//! let list = record(|canvas| {
+//!     canvas.draw_rect(
+//!         Rect::from_ltrb(px(0.0), px(0.0), px(40.0), px(40.0)),
+//!         &Paint::fill(Color::RED),
+//!     );
+//! });
+//! assert_eq!(command_count(&list), 1);
+//! ```
+
+use flui_foundation::{Diagnosticable, DiagnosticsNode};
+use flui_types::Rect;
+
+use crate::{Canvas, DisplayList, DisplayListCore};
+
+/// Records drawing commands into a fresh [`DisplayList`].
+///
+/// Runs `f` against a new [`Canvas`] and finishes it — the canonical
+/// record-now pattern, without the `Canvas::new()` / `finish()` boilerplate.
+pub fn record(f: impl FnOnce(&mut Canvas)) -> DisplayList {
+    let mut canvas = Canvas::new();
+    f(&mut canvas);
+    canvas.finish()
+}
+
+/// The number of recorded commands.
+#[must_use]
+pub fn command_count(list: &DisplayList) -> usize {
+    list.len()
+}
+
+/// The record-time bounds of the display list.
+#[must_use]
+pub fn bounds(list: &DisplayList) -> Rect {
+    list.bounds()
+}
+
+/// A diagnostics node describing the display list (command count + bounds).
+#[must_use]
+pub fn diagnostics(list: &DisplayList) -> DiagnosticsNode {
+    list.to_diagnostics_node()
+}
+
+/// A printable, indented dump of the display list's diagnostics.
+#[must_use]
+pub fn dump(list: &DisplayList) -> String {
+    diagnostics(list).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use flui_types::{Rect, geometry::px, styling::Color};
+
+    use super::{bounds, command_count, diagnostics, record};
+    use crate::Paint;
+
+    #[test]
+    fn record_captures_commands_and_bounds() {
+        let list = record(|canvas| {
+            canvas.draw_rect(
+                Rect::from_ltrb(px(0.0), px(0.0), px(40.0), px(40.0)),
+                &Paint::fill(Color::RED),
+            );
+        });
+
+        assert_eq!(command_count(&list), 1);
+        assert_eq!(
+            bounds(&list),
+            Rect::from_ltrb(px(0.0), px(0.0), px(40.0), px(40.0))
+        );
+    }
+
+    #[test]
+    fn diagnostics_dump_names_the_list_and_carries_properties() {
+        let list = record(|canvas| {
+            canvas.draw_rect(
+                Rect::from_ltrb(px(0.0), px(0.0), px(10.0), px(10.0)),
+                &Paint::fill(Color::BLUE),
+            );
+        });
+
+        let node = diagnostics(&list);
+        assert_eq!(node.name(), Some("DisplayList"), "names the list");
+        assert_eq!(
+            node.get_property("commands"),
+            Some("1"),
+            "carries the command count",
+        );
+    }
+
+    #[test]
+    fn empty_record_has_zero_commands() {
+        let list = record(|_canvas| {});
+        assert_eq!(command_count(&list), 0);
+    }
+}

--- a/crates/flui-painting/tests/display_list_unit.rs
+++ b/crates/flui-painting/tests/display_list_unit.rs
@@ -57,19 +57,18 @@ fn test_display_list_apply_transform_via_canvas() {
 
 #[test]
 fn test_display_list_command_iteration() {
-    use flui_painting::Canvas;
+    // Dogfoods the `testing::record` builder (no manual Canvas::new/finish).
+    let dl = flui_painting::testing::record(|canvas| {
+        canvas.draw_rect(
+            Rect::from_ltrb(px(0.0), px(0.0), px(50.0), px(50.0)),
+            &Paint::default(),
+        );
+        canvas.draw_rect(
+            Rect::from_ltrb(px(50.0), px(50.0), px(100.0), px(100.0)),
+            &Paint::default(),
+        );
+    });
 
-    let mut canvas = Canvas::new();
-    canvas.draw_rect(
-        Rect::from_ltrb(px(0.0), px(0.0), px(50.0), px(50.0)),
-        &Paint::default(),
-    );
-    canvas.draw_rect(
-        Rect::from_ltrb(px(50.0), px(50.0), px(100.0), px(100.0)),
-        &Paint::default(),
-    );
-
-    let dl = canvas.finish();
     let count = dl.commands().count();
     assert_eq!(count, 2);
 

--- a/crates/flui-rendering/Cargo.toml
+++ b/crates/flui-rendering/Cargo.toml
@@ -45,18 +45,43 @@ harness = false
 name = "paint"
 harness = false
 
+# Headless render-object inspection runner. Gated on `testing` so the
+# example only builds when the harness module is compiled in. Run with
+# `cargo run -p flui-rendering --example render_inspector --features testing`.
+[[example]]
+name = "render_inspector"
+required-features = ["testing"]
+
 [dev-dependencies]
 criterion.workspace = true
 # Animation -> render-pipeline integration scenarios (tests only; no
 # production dependency between the layers).
 flui-animation = { path = "../flui-animation" }
 flui-scheduler = { path = "../flui-scheduler" }
+# Self dev-dependency that turns the off-by-default `testing` feature on
+# for this crate's own integration tests (`tests/*.rs`), benches, and
+# examples. Unit tests reach the harness via `cfg(test)`; the separate
+# integration-test/bench/example crates link the normally-built library,
+# so the feature must be flipped on for the dev build graph. This is the
+# standard Cargo pattern for shipping a feature-gated test-support module
+# without making it part of normal/release builds.
+flui-rendering = { path = ".", features = ["testing"] }
 
 [features]
 default = []
 # serde: no direct serde derives in this crate; forwards to flui-types/serde
 # so downstream consumers enabling this feature get geometry/type serde impls.
 serde = ["flui-types/serde"]
+
+# testing: opt-in render-object test harness (`crate::testing`). Builds a
+# real `PipelineOwner` tree from a declarative spec, drives the production
+# layout/frame pipeline, and exposes a protocol-agnostic inspection surface
+# (Box + Sliver). Off by default so it never lands in normal/release builds;
+# enabled automatically for this crate's own dev targets via the self
+# dev-dependency above. Downstream crates (e.g. flui-app) opt in explicitly.
+# Forwards to `flui-layer/testing` so the layer-tree walkers (`structure`,
+# `first_picture_bounds`, diagnostics dump) are reused rather than duplicated.
+testing = ["flui-layer/testing"]
 
 # Cycle 4 R-18: gate `ScrollMetrics` trait + `FixedScrollMetrics` +
 # `FixedExtentMetrics` (~452 LOC at `src/constraints/scroll_metrics.rs`)

--- a/crates/flui-rendering/benches/helpers.rs
+++ b/crates/flui-rendering/benches/helpers.rs
@@ -12,14 +12,25 @@ use flui_rendering::{
     constraints::BoxConstraints,
     objects::{RenderColoredBox, RenderFlex, RenderPadding},
     pipeline::{Compositing, Layout, PaintPhase, PipelineOwner},
-    protocol::BoxProtocol,
-    traits::RenderObject,
+    testing::{TreeNode, box_node, tree},
 };
 use flui_types::{Size, geometry::px};
 
 /// Tight 200×200 root constraint used across all bench tree shapes.
 pub fn root_constraints() -> BoxConstraints {
     BoxConstraints::tight(Size::new(px(200.0), px(200.0)))
+}
+
+/// Mounts a `TreeNode` spec into a fresh owner with the shared root
+/// constraints and returns it in the `Layout` phase, ready for `run_layout`.
+/// Construction goes through the same `flui_rendering::testing` builder the
+/// integration tests use, so benches measure the genuine production contract.
+fn mount_layout(spec: TreeNode) -> PipelineOwner<Layout> {
+    let mut owner = PipelineOwner::new();
+    let (root_id, _registry) = tree::mount(&mut owner, spec);
+    owner.set_root_id(Some(root_id));
+    owner.set_root_constraints(Some(root_constraints()));
+    owner.into_layout()
 }
 
 // ============================================================================
@@ -31,17 +42,10 @@ pub fn root_constraints() -> BoxConstraints {
 ///
 /// Measures the cost of one root-layout pass across `n` same-depth children.
 pub fn build_flat(n: usize) -> PipelineOwner<Layout> {
-    let mut owner = PipelineOwner::new();
-    let root_id = owner.insert(Box::new(RenderFlex::row()) as Box<dyn RenderObject<BoxProtocol>>);
-    owner.set_root_id(Some(root_id));
-    owner.set_root_constraints(Some(root_constraints()));
-
-    for _ in 0..n {
-        owner
-            .insert_child_render_object(root_id, Box::new(RenderColoredBox::red(1.0, 1.0)))
-            .expect("child insert must succeed: parent id was just inserted and is valid");
-    }
-    owner.into_layout()
+    mount_layout(
+        box_node(RenderFlex::row())
+            .children((0..n).map(|_| box_node(RenderColoredBox::red(1.0, 1.0)))),
+    )
 }
 
 // ============================================================================
@@ -54,58 +58,15 @@ pub fn build_flat(n: usize) -> PipelineOwner<Layout> {
 /// Measures the cost of a layout pass that must recurse `depth` levels deep.
 /// Padding=0 keeps arithmetic trivial so the bench reflects traversal cost.
 ///
-/// Construction strategy (API constraint): `insert_child_render_object`
-/// creates a *new* node as child — it cannot adopt an existing node. We
-/// therefore build top-down: insert the root padding first, then at each step
-/// insert the next level as a child of the previous level. The final level
-/// inserts the leaf `ColoredBox`.
+/// The spec is built leaf-first and wrapped `depth` times, so `depth == 0`
+/// degenerates to a bare leaf and `depth == k` yields `k` padding wrappers
+/// around one `ColoredBox`.
 pub fn build_deep(depth: usize) -> PipelineOwner<Layout> {
-    let mut owner = PipelineOwner::new();
-
-    if depth == 0 {
-        // Degenerate: single leaf, no wrappers.
-        let root_id =
-            owner.insert(
-                Box::new(RenderColoredBox::red(1.0, 1.0)) as Box<dyn RenderObject<BoxProtocol>>
-            );
-        owner.set_root_id(Some(root_id));
-        owner.set_root_constraints(Some(root_constraints()));
-        return owner.into_layout();
+    let mut node = box_node(RenderColoredBox::red(1.0, 1.0));
+    for _ in 0..depth {
+        node = box_node(RenderPadding::all(0.0)).child(node);
     }
-
-    // Insert the first (top) padding as root.
-    let root_id =
-        owner.insert(Box::new(RenderPadding::all(0.0)) as Box<dyn RenderObject<BoxProtocol>>);
-    owner.set_root_id(Some(root_id));
-    owner.set_root_constraints(Some(root_constraints()));
-
-    let mut current = root_id;
-
-    // Add `depth - 1` intermediate padding nodes after the root padding, then
-    // one ColoredBox leaf — `depth` padding wrappers total. When depth==1 the
-    // range is empty and we fall straight through to the leaf insert below.
-    //
-    // Invariant: `current` is always a Padding node that was just inserted and
-    // has no children yet, so every insert_child_render_object call succeeds.
-    for _ in 1..depth {
-        let next = owner
-            .insert_child_render_object(current, Box::new(RenderPadding::all(0.0)))
-            .expect(
-                "chain insert must succeed: current is a valid padding node just inserted \
-                 and has no children yet",
-            );
-        current = next;
-    }
-
-    // Always insert one ColoredBox leaf as child of the deepest padding.
-    owner
-        .insert_child_render_object(current, Box::new(RenderColoredBox::red(1.0, 1.0)))
-        .expect(
-            "leaf insert must succeed: current is a valid padding node just inserted \
-             and has no children yet",
-        );
-
-    owner.into_layout()
+    mount_layout(node)
 }
 
 // ============================================================================

--- a/crates/flui-rendering/docs/README.md
+++ b/crates/flui-rendering/docs/README.md
@@ -1,0 +1,28 @@
+# flui_rendering documentation
+
+Crate-local guides for the render pipeline, protocols, and test harness.
+
+## System guides
+
+| Document | Topic |
+|----------|-------|
+| [PROTOCOL_ARCHITECTURE.md](./PROTOCOL_ARCHITECTURE.md) | Box / Sliver protocols and capability traits |
+| [LAYOUT_SYSTEM.md](./LAYOUT_SYSTEM.md) | Layout pipeline and constraints |
+| [PAINT_SYSTEM.md](./PAINT_SYSTEM.md) | Paint and compositing |
+| [HIT_TEST_SYSTEM.md](./HIT_TEST_SYSTEM.md) | Hit testing |
+| [ROADMAP.md](./ROADMAP.md) | Crate-level construction notes |
+
+## Testing
+
+| Document | Topic |
+|----------|-------|
+| **[TESTING.md](./TESTING.md)** | `RenderTester` harness — API, multi-frame animation, examples |
+| [render_inspector example](../examples/render_inspector.rs) | Runnable headless inspector |
+| [render_object_harness.rs](../tests/render_object_harness.rs) | CI catalog of all render types |
+
+## Related harness docs
+
+- [flui-layer/docs/TESTING.md](../../flui-layer/docs/TESTING.md) — layer-tree builders and walkers
+- [flui-painting/docs/TESTING.md](../../flui-painting/docs/TESTING.md) — display-list recording
+- [flui-foundation/docs/TESTING.md](../../flui-foundation/docs/TESTING.md) — diagnostics for assertions
+- [Workspace testing guide](../../../docs/testing.md) — CI commands and conventions

--- a/crates/flui-rendering/docs/TESTING.md
+++ b/crates/flui-rendering/docs/TESTING.md
@@ -72,7 +72,7 @@ use **snake_case**.
 |--------|---------|
 | `root()` | Root `RenderId` |
 | `owner()` / `owner_mut()` | Escape hatch to `PipelineOwner<Layout>` |
-| `update::<T>(id, edit)` | Mutate + `mark_needs_layout` |
+| `update::<T>(id, edit)` | Mutate + `mark_needs_layout` (Box or Sliver) |
 | `update_paint::<T>(id, edit)` | Mutate + paint-dirty (no layout pass here) |
 | `mark_needs_paint(id)` | Paint-dirty only |
 | `relayout()` | Re-run layout after `update` |
@@ -91,7 +91,7 @@ Implements [`Probe`](../src/testing/inspect.rs).
 | `report()` / `pump()` | `FrameReport` snapshot; run another frame |
 | `pump_frames(n)` | `n` consecutive frames, collect reports |
 | `pump_idle_frames(n)` | Skip `n` settled frames (panics if anything paints) |
-| `update::<T>(id, edit)` | Layout mutation |
+| `update::<T>(id, edit)` | Layout mutation (Box or Sliver) |
 | `update_paint::<T>(id, edit)` | Paint mutation (+ compositing bits refresh) |
 | `advance_layout::<T>(id, edit)` | `update` + `pump` |
 | `advance_paint::<T>(id, edit)` | `update_paint` + `pump` |

--- a/crates/flui-rendering/docs/TESTING.md
+++ b/crates/flui-rendering/docs/TESTING.md
@@ -1,0 +1,244 @@
+# Render-object test harness (`flui_rendering::testing`)
+
+Headless integration testing for `RenderBox` and `RenderSliver` types through the
+**real** [`PipelineOwner`](../src/pipeline/owner.rs) pipeline — no mocks, no GPU,
+no window.
+
+## Enabling
+
+The module is **off by default** so it never lands in release builds.
+
+| Consumer | How to enable |
+|----------|----------------|
+| This crate's own tests / benches / examples | Automatic via the self `dev-dependency` with `features = ["testing"]` |
+| Downstream crates | `flui-rendering = { features = ["testing"] }` |
+| `render_inspector` example | `cargo run -p flui-rendering --example render_inspector --features testing` |
+
+```bash
+cargo test -p flui-rendering
+cargo test -p flui-rendering --test render_object_harness
+cargo test -p flui-rendering --test harness_animation
+```
+
+## Design
+
+```text
+TreeNode spec  →  RenderTester::mount  →  run_layout | run_frame
+                                              ↓
+                                         LayoutRun | FrameRun
+                                              ↓
+                                         Probe (offset, hit, diagnostics, …)
+```
+
+1. **Describe** a tree with [`box_node`](../src/testing/tree.rs) /
+   [`sliver_node`](../src/testing/tree.rs), optional [`ParentDataSeed`](../src/testing/parent_data.rs),
+   and [`TreeNode::label`](../src/testing/tree.rs).
+2. **Drive** the production pipeline at the depth you need.
+3. **Inspect** through the shared [`Probe`](../src/testing/inspect.rs) trait.
+4. **Animate** with multi-frame helpers on [`FrameRun`](../src/testing/harness.rs).
+
+Diagnostics dumps combine each render object's **user config** (via
+[`Diagnosticable`](../src/traits/mod.rs)) with **committed runtime** fields
+(`offset`, `size`, sliver `geometry`) layered on by the pipeline. Property names
+use **snake_case**.
+
+## Core API
+
+### Tree builders
+
+| Item | Role |
+|------|------|
+| `box_node(obj)` | Box-protocol render object node |
+| `sliver_node(obj)` | Sliver-protocol render object node |
+| `TreeNode::child` / `children` | Nesting |
+| `TreeNode::label("name")` | Register label for `run.id("name")` |
+| `TreeNode::with_parent_data_seed` | Stack / flex / sliver parent metadata |
+| `TreeNode::with_stack_parent_data` | Shorthand for stack positioning |
+| `TreeNode::with_flex_parent_data` | Shorthand for flex factors |
+
+### `RenderTester`
+
+| Method | Returns | Purpose |
+|--------|---------|---------|
+| `mount(spec)` | `Self` | Configure from a `TreeNode` |
+| `with_constraints(c)` | `Self` | Root box constraints |
+| `with_size(size)` | `Self` | Tight root size |
+| `run_layout()` | `LayoutRun` | Layout phase only (geometry / offsets) |
+| `run_frame()` | `FrameRun` | Full frame (layout → compositing → paint) |
+
+### `LayoutRun`
+
+| Method | Purpose |
+|--------|---------|
+| `root()` | Root `RenderId` |
+| `owner()` / `owner_mut()` | Escape hatch to `PipelineOwner<Layout>` |
+| `update::<T>(id, edit)` | Mutate + `mark_needs_layout` |
+| `update_paint::<T>(id, edit)` | Mutate + paint-dirty (no layout pass here) |
+| `mark_needs_paint(id)` | Paint-dirty only |
+| `relayout()` | Re-run layout after `update` |
+
+Implements [`Probe`](../src/testing/inspect.rs).
+
+### `FrameRun`
+
+| Method | Purpose |
+|--------|---------|
+| `painted()` | Whether the last frame produced a layer tree |
+| `is_clean()` | No dirty nodes remain |
+| `layer_tree()` | Last `LayerTree`, if any |
+| `structure()` | Layer kind names (pre-order) |
+| `picture_bounds()` | First picture layer bounds |
+| `report()` / `pump()` | `FrameReport` snapshot; run another frame |
+| `pump_frames(n)` | `n` consecutive frames, collect reports |
+| `pump_idle_frames(n)` | Skip `n` settled frames (panics if anything paints) |
+| `update::<T>(id, edit)` | Layout mutation |
+| `update_paint::<T>(id, edit)` | Paint mutation (+ compositing bits refresh) |
+| `advance_layout::<T>(id, edit)` | `update` + `pump` |
+| `advance_paint::<T>(id, edit)` | `update_paint` + `pump` |
+| `simulate(ticks, \|t, run\| …)` | Per-tick callback then auto-`pump` |
+| `opacity_alpha()` | First opacity layer alpha, if any |
+| `has_picture_layer()` | Whether a picture layer exists |
+
+Implements [`Probe`](../src/testing/inspect.rs).
+
+### `Probe` (shared inspection)
+
+| Method | Purpose |
+|--------|---------|
+| `id("label")` / `try_id` | Resolve labeled node |
+| `offset(id)` | Committed paint offset |
+| `box_geometry(id)` | Committed box size |
+| `sliver_geometry(id)` | Committed sliver geometry |
+| `hit(x, y)` / `hit_first` | Hit-test path (leaf-first) |
+| `diagnostics()` | Full render-tree diagnostics tree |
+| `property(id, "name")` | Structured property lookup |
+| `property_f64(id, "name")` | Parsed numeric property |
+| `descendant_property("RenderFlex", "direction")` | Find by type name |
+| `dump()` | Printable tree (for failure messages) |
+
+### Assertion helpers ([`assertions`](../src/testing/assertions.rs))
+
+| Function | Purpose |
+|----------|---------|
+| `assert_properties(node, &[&str])` | Required config property names |
+| `assert_descendant_properties(tree, type_name, required)` | Descendant config contract |
+| `assert_has_committed_size(node)` | Runtime `size` present |
+| `assert_has_committed_geometry(node)` | Runtime sliver `geometry` present |
+
+### `FrameReport`
+
+Snapshot returned by `pump` / `advance_*` / `simulate`: `painted`, `structure`
+(with depth), `picture_bounds`, `dirty`. Implements `Display` for examples and
+[`render_inspector`](../examples/render_inspector.rs).
+
+## Examples
+
+### Single frame — layout + paint
+
+```rust
+use flui_rendering::objects::{RenderColoredBox, RenderPadding};
+use flui_rendering::testing::{RenderTester, Probe, box_node};
+use flui_types::{Offset, Size, geometry::px};
+
+let run = RenderTester::mount(
+    box_node(RenderPadding::all(5.0))
+        .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+)
+.with_size(Size::new(px(200.0), px(200.0)))
+.run_frame();
+
+let child = run.id("child");
+assert_eq!(run.offset(child), Offset::new(px(5.0), px(5.0)));
+assert_eq!(run.structure(), vec!["Offset", "Picture"]);
+assert!(run.painted());
+```
+
+### Layout only
+
+```rust
+let run = RenderTester::mount(/* … */).run_layout();
+assert_eq!(run.box_geometry(run.root()), Size::new(px(200.0), px(200.0)));
+```
+
+### Stack positioned child (`ParentDataSeed`)
+
+```rust
+use flui_rendering::parent_data::StackParentData;
+use flui_rendering::objects::{RenderColoredBox, RenderStack};
+use flui_rendering::testing::{RenderTester, Probe, box_node};
+
+let run = RenderTester::mount(
+    box_node(RenderStack::new())
+        .child(box_node(RenderColoredBox::red(80.0, 80.0)).label("base"))
+        .child(
+            box_node(RenderColoredBox::green(20.0, 20.0))
+                .with_stack_parent_data(StackParentData::new().with_top(12.0).with_left(18.0))
+                .label("positioned"),
+        ),
+)
+.with_size(Size::new(px(120.0), px(120.0)))
+.run_layout();
+
+assert_eq!(run.hit_first(25.0, 20.0), Some(run.id("positioned")));
+```
+
+### Multi-frame layout animation
+
+```rust
+let mut run = RenderTester::mount(/* padding + child */).run_frame();
+let pad = run.root();
+let child = run.id("child");
+
+run.simulate([0.0, 0.5, 1.0], |t, run| {
+    let padding = 5.0 + 50.0 * t as f32;
+    run.update::<RenderPadding>(pad, |p| {
+        p.set_padding(EdgeInsets::all(px(padding)));
+    });
+});
+assert_eq!(run.offset(child), Offset::new(px(55.0), px(55.0)));
+```
+
+### Paint-only (color / opacity)
+
+```rust
+// Color — assert via diagnostics config
+run.advance_paint::<RenderColoredBox>(leaf, |b| {
+    b.set_color([0.0, 1.0, 0.0, 1.0]);
+});
+assert_eq!(
+    run.property(leaf, "color").as_deref(),
+    Some("[0.0, 1.0, 0.0, 1.0]"),
+);
+
+// Opacity — assert via layer tree
+run.advance_paint::<RenderOpacity>(fade, |o| o.set_opacity(0.5));
+assert!(run.structure().contains(&"Opacity"));
+assert!((run.opacity_alpha().unwrap() - 0.5).abs() < 0.01);
+```
+
+### `AnimationController` integration
+
+See [`tests/harness_animation.rs`](../tests/harness_animation.rs): call
+`ctrl.tick_at(t)` then `run.advance_layout` and assert `offset` /
+`picture_bounds` each frame. Finish with `run.pump_idle_frames(2)` to prove
+the pipeline settles.
+
+### CI catalog
+
+[`tests/render_object_harness.rs`](../tests/render_object_harness.rs) mounts every
+exported `RenderBox` / `RenderSliver` type. `catalog_covers_every_render_object_name`
+fails CI if a new render object lacks harness coverage.
+
+## Cross-crate dependencies
+
+| Crate | Re-use |
+|-------|--------|
+| [`flui_layer::testing`](../../flui-layer/docs/TESTING.md) | Layer-tree walkers (`structure`, `first_picture_bounds`, `first_opacity_alpha`) |
+| [`flui_foundation`](../../flui-foundation/docs/TESTING.md) | `DiagnosticsNode` query API for structured assertions |
+| [`flui_painting::testing`](../../flui-painting/docs/TESTING.md) | Display-list recording when testing paint in isolation |
+
+## See also
+
+- Workspace overview: [`docs/testing.md`](../../../docs/testing.md)
+- Example binary: [`examples/render_inspector.rs`](../examples/render_inspector.rs)
+- Production animation tests: [`tests/animation_pipeline.rs`](../tests/animation_pipeline.rs)

--- a/crates/flui-rendering/examples/render_inspector.rs
+++ b/crates/flui-rendering/examples/render_inspector.rs
@@ -1,0 +1,102 @@
+//! Headless render-object inspector.
+//!
+//! Builds a few representative trees with the `flui-rendering` test harness,
+//! drives them through the real pipeline at both run depths, and prints what
+//! came out — no window, no GPU. This is the "run them and see they work"
+//! surface for the harness.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run -p flui-rendering --example render_inspector --features testing
+//! ```
+//!
+//! `println!` is used deliberately: this is a dev-only example binary, not
+//! shipped library code (the harness itself never writes to stdout — it only
+//! returns reports and values).
+
+use flui_rendering::{
+    objects::{
+        RenderColoredBox, RenderFlex, RenderPadding, RenderSliverFixedExtentList, RenderViewport,
+    },
+    testing::{Probe, RenderTester, box_node, sliver_node},
+};
+use flui_types::{Size, geometry::px, layout::AxisDirection};
+
+fn header(title: &str) {
+    println!("\n========== {title} ==========");
+}
+
+fn main() {
+    box_full_frame();
+    box_layout_only();
+    sliver_layout_only();
+}
+
+/// Box tree driven through a full frame: layer structure + picture bounds.
+fn box_full_frame() {
+    header("Box / run_frame: flex row of three colored boxes");
+
+    let run = RenderTester::mount(
+        box_node(RenderFlex::row())
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("red"))
+            .child(box_node(RenderColoredBox::green(60.0, 40.0)).label("green"))
+            .child(box_node(RenderColoredBox::blue(20.0, 40.0)).label("blue")),
+    )
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_frame();
+
+    println!("{}", run.report());
+    for label in ["red", "green", "blue"] {
+        let id = run.id(label);
+        println!(
+            "  {label:<6} offset={:?} size={:?}",
+            run.offset(id),
+            run.box_geometry(id),
+        );
+    }
+    println!("\n-- diagnostics tree --\n{}", run.dump());
+}
+
+/// Box tree inspected at the layout phase only — geometry without a frame.
+fn box_layout_only() {
+    header("Box / run_layout: nested padding, geometry without a frame");
+
+    let run = RenderTester::mount(
+        box_node(RenderPadding::all(8.0))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("inner")),
+    )
+    .with_size(Size::new(px(200.0), px(200.0)))
+    .run_layout();
+
+    let inner = run.id("inner");
+    println!("  root   size={:?}", run.box_geometry(run.root()));
+    println!(
+        "  inner  offset={:?} size={:?}",
+        run.offset(inner),
+        run.box_geometry(inner),
+    );
+}
+
+/// Sliver tree inspected at the layout phase: committed sliver geometry.
+fn sliver_layout_only() {
+    header("Sliver / run_layout: fixed-extent list under a viewport");
+
+    let run = RenderTester::mount(
+        box_node(RenderViewport::new(AxisDirection::TopToBottom)).child(
+            sliver_node(RenderSliverFixedExtentList::new(30.0))
+                .label("list")
+                .child(box_node(RenderColoredBox::red(300.0, 1000.0)))
+                .child(box_node(RenderColoredBox::green(300.0, 1000.0)))
+                .child(box_node(RenderColoredBox::blue(300.0, 1000.0))),
+        ),
+    )
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    let list = run.id("list");
+    let geometry = run.sliver_geometry(list);
+    println!("  list scroll_extent = {}", geometry.scroll_extent);
+    println!("  list paint_extent  = {}", geometry.paint_extent);
+    println!("  list offset        = {:?}", run.offset(list));
+}

--- a/crates/flui-rendering/src/binding/mod.rs
+++ b/crates/flui-rendering/src/binding/mod.rs
@@ -476,9 +476,17 @@ pub fn debug_dump_semantics_tree<B: RendererBinding + ?Sized>(
 }
 
 /// Prints a textual representation of the pipeline owner tree.
+///
+/// When the owner has a root, this renders the `Diagnosticable`-backed
+/// diagnostics tree (each render object self-describes its properties, with
+/// committed geometry/offset layered on); otherwise it falls back to the
+/// owner's `Debug` representation.
 pub fn debug_dump_pipeline_owner_tree<B: RendererBinding + ?Sized>(binding: &B) -> String {
     let owner = binding.root_pipeline_owner().read();
-    format!("{:?}", *owner)
+    match owner.debug_diagnostics_tree() {
+        Some(tree) => tree.to_string(),
+        None => format!("{:?}", *owner),
+    }
 }
 
 // ============================================================================

--- a/crates/flui-rendering/src/lib.rs
+++ b/crates/flui-rendering/src/lib.rs
@@ -84,6 +84,13 @@ pub mod protocol;
 pub use flui_semantics as semantics;
 pub mod objects;
 pub mod storage;
+// Render-object test harness. Compiled only for this crate's own tests
+// (`cfg(test)`) or when a consumer enables the `testing` feature. Builds
+// real `PipelineOwner` trees through the production pipeline and exposes a
+// protocol-agnostic inspection surface for Box and Sliver render objects.
+// See [`testing`] for the module overview.
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;
 pub mod traits;
 pub mod view;
 

--- a/crates/flui-rendering/src/objects/absorb_pointer.rs
+++ b/crates/flui-rendering/src/objects/absorb_pointer.rs
@@ -77,9 +77,7 @@ impl Default for RenderAbsorbPointer {
 
 impl flui_foundation::Diagnosticable for RenderAbsorbPointer {
     fn debug_fill_properties(&self, builder: &mut flui_foundation::DiagnosticsBuilder) {
-        builder.add("absorbing", self.absorbing);
-        builder.add("size", format!("{:?}", self.size));
-        builder.add("has_child", self.has_child);
+        builder.add_flag("absorbing", self.absorbing, "absorbing");
     }
 }
 
@@ -189,11 +187,9 @@ mod tests {
             .iter()
             .map(|p| p.name().to_string())
             .collect();
-        for required in ["absorbing", "size", "has_child"] {
-            assert!(
-                names.iter().any(|n| n == required),
-                "missing diagnostic field: {required}"
-            );
-        }
+        assert!(
+            names.iter().any(|n| n == "absorbing"),
+            "missing diagnostic field: absorbing"
+        );
     }
 }

--- a/crates/flui-rendering/src/objects/aspect_ratio.rs
+++ b/crates/flui-rendering/src/objects/aspect_ratio.rs
@@ -234,8 +234,7 @@ impl RenderAspectRatio {
 
 impl flui_foundation::Diagnosticable for RenderAspectRatio {
     fn debug_fill_properties(&self, builder: &mut flui_foundation::DiagnosticsBuilder) {
-        builder.add("aspect_ratio", format!("{}", self.aspect_ratio.value()));
-        builder.add("size", format!("{:?}", self.size));
+        builder.add_double("aspect_ratio", self.aspect_ratio.value(), None);
     }
 }
 

--- a/crates/flui-rendering/src/objects/center.rs
+++ b/crates/flui-rendering/src/objects/center.rs
@@ -67,10 +67,11 @@ impl RenderCenter {
 
 impl flui_foundation::Diagnosticable for RenderCenter {
     fn debug_fill_properties(&self, builder: &mut flui_foundation::DiagnosticsBuilder) {
-        builder.add("size", format!("{:?}", self.size));
-        builder.add("width_factor", format!("{:?}", self.width_factor));
-        builder.add("height_factor", format!("{:?}", self.height_factor));
-        builder.add("has_child", self.has_child);
+        builder.add_optional("width_factor", self.width_factor.map(|f| format!("{f:?}")));
+        builder.add_optional(
+            "height_factor",
+            self.height_factor.map(|f| format!("{f:?}")),
+        );
     }
 }
 

--- a/crates/flui-rendering/src/objects/clip.rs
+++ b/crates/flui-rendering/src/objects/clip.rs
@@ -137,6 +137,13 @@ mod sealed {
 /// private), preserves engine-level dispatch invariants, and lets the
 /// compiler monomorphise the clip-emission path per shape.
 pub trait ClipGeometry: sealed::Sealed + Clone + fmt::Debug + Send + Sync + 'static {
+    /// Flutter-parity diagnostics label (`RenderClipRect`, `RenderClipRRect`, …).
+    ///
+    /// Generic `RenderClip<S>` would otherwise surface as
+    /// `RenderClip<Rect<Pixels>>` via `type_name`, which breaks structured
+    /// tree queries in the render harness.
+    const DIAGNOSTIC_NAME: &'static str;
+
     /// Returns the default clip for a render box of `size` whose origin
     /// is at `(0, 0)` in local coordinates.
     fn default_for_size(size: Size) -> Self;
@@ -166,6 +173,8 @@ pub trait ClipGeometry: sealed::Sealed + Clone + fmt::Debug + Send + Sync + 'sta
 // ---- Rect ------------------------------------------------------------------
 
 impl ClipGeometry for Rect<Pixels> {
+    const DIAGNOSTIC_NAME: &'static str = "RenderClipRect";
+
     fn default_for_size(size: Size) -> Self {
         Rect::from_origin_size(Point::ZERO, size)
     }
@@ -187,6 +196,8 @@ impl ClipGeometry for Rect<Pixels> {
 // ---- RRect -----------------------------------------------------------------
 
 impl ClipGeometry for RRect {
+    const DIAGNOSTIC_NAME: &'static str = "RenderClipRRect";
+
     fn default_for_size(size: Size) -> Self {
         RRect::from_rect(Rect::from_origin_size(Point::ZERO, size))
     }
@@ -266,6 +277,8 @@ impl ClipGeometry for RRect {
 // ---- Oval ------------------------------------------------------------------
 
 impl ClipGeometry for Oval {
+    const DIAGNOSTIC_NAME: &'static str = "RenderClipOval";
+
     fn default_for_size(size: Size) -> Self {
         Oval::from_size(size)
     }
@@ -294,6 +307,8 @@ impl ClipGeometry for Oval {
 // ---- Path ------------------------------------------------------------------
 
 impl ClipGeometry for Path {
+    const DIAGNOSTIC_NAME: &'static str = "RenderClipPath";
+
     fn default_for_size(size: Size) -> Self {
         // A path-shaped default is the rectangle outline of `size`.
         let mut p = Path::new();
@@ -472,11 +487,21 @@ impl<S: ClipGeometry> Default for RenderClip<S> {
 }
 
 impl<S: ClipGeometry> flui_foundation::Diagnosticable for RenderClip<S> {
+    fn to_diagnostics_node(&self) -> flui_foundation::DiagnosticsNode {
+        let mut node = flui_foundation::DiagnosticsNode::new(S::DIAGNOSTIC_NAME);
+        let mut builder = flui_foundation::DiagnosticsBuilder::new();
+        self.debug_fill_properties(&mut builder);
+        *node.properties_mut() = builder.build();
+        node
+    }
+
     fn debug_fill_properties(&self, builder: &mut flui_foundation::DiagnosticsBuilder) {
-        builder.add("clip_behavior", format!("{:?}", self.clip_behavior));
-        builder.add("custom_clipper", self.clipper.is_some());
-        builder.add("size", format!("{:?}", self.size));
-        builder.add("has_child", self.has_child);
+        builder.add_enum("clip_behavior", self.clip_behavior);
+        builder.add_flag(
+            "custom_clipper",
+            self.clipper.is_some(),
+            "has custom clipper",
+        );
     }
 }
 
@@ -740,7 +765,28 @@ mod tests {
             .map(|p| p.name().to_string())
             .collect();
         assert!(names.iter().any(|n| n == "clip_behavior"));
-        assert!(names.iter().any(|n| n == "custom_clipper"));
-        assert!(names.iter().any(|n| n == "size"));
+        assert!(!names.iter().any(|n| n == "custom_clipper"));
+    }
+
+    #[test]
+    fn to_diagnostics_node_uses_flutter_parity_alias_names() {
+        use flui_foundation::Diagnosticable;
+
+        assert_eq!(
+            RenderClipRect::anti_alias().to_diagnostics_node().name(),
+            Some("RenderClipRect")
+        );
+        assert_eq!(
+            RenderClipRRect::anti_alias().to_diagnostics_node().name(),
+            Some("RenderClipRRect")
+        );
+        assert_eq!(
+            RenderClipOval::anti_alias().to_diagnostics_node().name(),
+            Some("RenderClipOval")
+        );
+        assert_eq!(
+            RenderClipPath::anti_alias().to_diagnostics_node().name(),
+            Some("RenderClipPath")
+        );
     }
 }

--- a/crates/flui-rendering/src/objects/colored_box.rs
+++ b/crates/flui-rendering/src/objects/colored_box.rs
@@ -70,7 +70,13 @@ impl RenderColoredBox {
     }
 }
 
-impl flui_foundation::Diagnosticable for RenderColoredBox {}
+impl flui_foundation::Diagnosticable for RenderColoredBox {
+    fn debug_fill_properties(&self, properties: &mut flui_foundation::DiagnosticsBuilder) {
+        // `color` is the defining config; the committed `size` is layered on
+        // by the test harness from `RenderState`, so it is not repeated here.
+        properties.add_color("color", format!("{:?}", self.color));
+    }
+}
 impl RenderBox for RenderColoredBox {
     type Arity = Leaf;
     type ParentData = BoxParentData;

--- a/crates/flui-rendering/src/objects/constrained_box.rs
+++ b/crates/flui-rendering/src/objects/constrained_box.rs
@@ -103,12 +103,7 @@ impl RenderConstrainedBox {
 
 impl flui_foundation::Diagnosticable for RenderConstrainedBox {
     fn debug_fill_properties(&self, builder: &mut flui_foundation::DiagnosticsBuilder) {
-        builder.add(
-            "additional_constraints",
-            format!("{:?}", self.additional_constraints),
-        );
-        builder.add("size", format!("{:?}", self.size));
-        builder.add("has_child", self.has_child);
+        builder.add_enum("additional_constraints", self.additional_constraints);
     }
 }
 
@@ -393,7 +388,5 @@ mod tests {
             .map(|p| p.name().to_string())
             .collect();
         assert!(names.iter().any(|n| n == "additional_constraints"));
-        assert!(names.iter().any(|n| n == "size"));
-        assert!(names.iter().any(|n| n == "has_child"));
     }
 }

--- a/crates/flui-rendering/src/objects/decorated_box.rs
+++ b/crates/flui-rendering/src/objects/decorated_box.rs
@@ -87,7 +87,12 @@ impl RenderDecoratedBox {
     }
 }
 
-impl flui_foundation::Diagnosticable for RenderDecoratedBox {}
+impl flui_foundation::Diagnosticable for RenderDecoratedBox {
+    fn debug_fill_properties(&self, properties: &mut flui_foundation::DiagnosticsBuilder) {
+        properties.add_enum("decoration", self.decoration.clone());
+        properties.add_default_enum("position", self.position, DecorationPosition::Background);
+    }
+}
 
 impl RenderBox for RenderDecoratedBox {
     type Arity = Single;

--- a/crates/flui-rendering/src/objects/fitted_box.rs
+++ b/crates/flui-rendering/src/objects/fitted_box.rs
@@ -210,16 +210,12 @@ impl Default for RenderFittedBox {
 
 impl flui_foundation::Diagnosticable for RenderFittedBox {
     fn debug_fill_properties(&self, builder: &mut flui_foundation::DiagnosticsBuilder) {
-        builder.add("fit", format!("{:?}", self.fit));
+        builder.add_enum("fit", self.fit);
         builder.add(
             "alignment",
             format!("({}, {})", self.alignment.x, self.alignment.y),
         );
-        builder.add("clip_behavior", format!("{:?}", self.clip_behavior));
-        builder.add("size", format!("{:?}", self.size));
-        builder.add("scale", format!("({}, {})", self.scale_x, self.scale_y));
-        builder.add("has_visual_overflow", self.has_visual_overflow);
-        builder.add("has_child", self.has_child);
+        builder.add_enum("clip_behavior", self.clip_behavior);
     }
 }
 
@@ -482,15 +478,7 @@ mod tests {
             .iter()
             .map(|p| p.name().to_string())
             .collect();
-        for required in [
-            "fit",
-            "alignment",
-            "clip_behavior",
-            "size",
-            "scale",
-            "has_visual_overflow",
-            "has_child",
-        ] {
+        for required in ["fit", "alignment", "clip_behavior"] {
             assert!(
                 names.iter().any(|n| n == required),
                 "missing diagnostic field: {required}"

--- a/crates/flui-rendering/src/objects/flex.rs
+++ b/crates/flui-rendering/src/objects/flex.rs
@@ -203,7 +203,15 @@ impl RenderFlex {
     }
 }
 
-impl flui_foundation::Diagnosticable for RenderFlex {}
+impl flui_foundation::Diagnosticable for RenderFlex {
+    fn debug_fill_properties(&self, properties: &mut flui_foundation::DiagnosticsBuilder) {
+        properties.add_enum("direction", self.direction);
+        properties.add_enum("main_axis_alignment", self.main_axis_alignment);
+        properties.add_default_enum("main_axis_size", self.main_axis_size, MainAxisSize::Max);
+        properties.add_enum("cross_axis_alignment", self.cross_axis_alignment);
+        properties.add_default_double("spacing", self.spacing, 0.0, Some("px"));
+    }
+}
 impl RenderBox for RenderFlex {
     type Arity = Variable;
     type ParentData = FlexParentData;

--- a/crates/flui-rendering/src/objects/fractional_translation.rs
+++ b/crates/flui-rendering/src/objects/fractional_translation.rs
@@ -159,9 +159,11 @@ impl flui_foundation::Diagnosticable for RenderFractionalTranslation {
             "translation",
             format!("({}, {})", self.translation.dx, self.translation.dy),
         );
-        builder.add("transform_hit_tests", self.transform_hit_tests);
-        builder.add("size", format!("{:?}", self.size));
-        builder.add("has_child", self.has_child);
+        builder.add_flag(
+            "transform_hit_tests",
+            self.transform_hit_tests,
+            "transform hit tests",
+        );
     }
 }
 
@@ -327,7 +329,7 @@ mod tests {
             .iter()
             .map(|p| p.name().to_string())
             .collect();
-        for required in ["translation", "transform_hit_tests", "size", "has_child"] {
+        for required in ["translation", "transform_hit_tests"] {
             assert!(
                 names.iter().any(|n| n == required),
                 "missing diagnostic field: {required}"

--- a/crates/flui-rendering/src/objects/fractionally_sized_box.rs
+++ b/crates/flui-rendering/src/objects/fractionally_sized_box.rs
@@ -285,7 +285,6 @@ impl flui_foundation::Diagnosticable for RenderFractionallySizedBox {
             "alignment",
             format!("({}, {})", self.alignment.x, self.alignment.y),
         );
-        builder.add("size", format!("{:?}", self.size));
     }
 }
 

--- a/crates/flui-rendering/src/objects/ignore_pointer.rs
+++ b/crates/flui-rendering/src/objects/ignore_pointer.rs
@@ -75,9 +75,7 @@ impl Default for RenderIgnorePointer {
 
 impl flui_foundation::Diagnosticable for RenderIgnorePointer {
     fn debug_fill_properties(&self, builder: &mut flui_foundation::DiagnosticsBuilder) {
-        builder.add("ignoring", self.ignoring);
-        builder.add("size", format!("{:?}", self.size));
-        builder.add("has_child", self.has_child);
+        builder.add_flag("ignoring", self.ignoring, "ignoring");
     }
 }
 
@@ -184,11 +182,9 @@ mod tests {
             .iter()
             .map(|p| p.name().to_string())
             .collect();
-        for required in ["ignoring", "size", "has_child"] {
-            assert!(
-                names.iter().any(|n| n == required),
-                "missing diagnostic field: {required}"
-            );
-        }
+        assert!(
+            names.iter().any(|n| n == "ignoring"),
+            "missing diagnostic field: ignoring"
+        );
     }
 }

--- a/crates/flui-rendering/src/objects/image.rs
+++ b/crates/flui-rendering/src/objects/image.rs
@@ -321,7 +321,34 @@ impl RenderImage {
     }
 }
 
-impl Diagnosticable for RenderImage {}
+impl Diagnosticable for RenderImage {
+    fn debug_fill_properties(&self, properties: &mut flui_foundation::DiagnosticsBuilder) {
+        properties.add(
+            "image",
+            if self.image.is_some() {
+                "loaded"
+            } else {
+                "none"
+            },
+        );
+        properties.add("intrinsic_size", format!("{:?}", self.intrinsic_size));
+        properties.add(
+            "width",
+            self.width
+                .map(|w| format!("{w:?}"))
+                .unwrap_or_else(|| "unset".to_string()),
+        );
+        properties.add(
+            "height",
+            self.height
+                .map(|h| format!("{h:?}"))
+                .unwrap_or_else(|| "unset".to_string()),
+        );
+        properties.add_default_double("scale", self.scale, 1.0, None);
+        properties.add_enum("fit", self.fit);
+        properties.add_enum("alignment", self.alignment);
+    }
+}
 
 impl RenderBox for RenderImage {
     type Arity = Leaf;

--- a/crates/flui-rendering/src/objects/limited_box.rs
+++ b/crates/flui-rendering/src/objects/limited_box.rs
@@ -172,7 +172,6 @@ impl flui_foundation::Diagnosticable for RenderLimitedBox {
                 .map(|v| format!("{}", v.get()))
                 .unwrap_or_else(|| "unset".to_string()),
         );
-        builder.add("size", format!("{:?}", self.size));
     }
 }
 

--- a/crates/flui-rendering/src/objects/meta_data.rs
+++ b/crates/flui-rendering/src/objects/meta_data.rs
@@ -163,10 +163,8 @@ impl fmt::Debug for RenderMetaData {
 
 impl flui_foundation::Diagnosticable for RenderMetaData {
     fn debug_fill_properties(&self, builder: &mut flui_foundation::DiagnosticsBuilder) {
-        builder.add("has_metadata", self.metadata.is_some());
-        builder.add("behavior", format!("{:?}", self.behavior));
-        builder.add("size", format!("{:?}", self.size));
-        builder.add("has_child", self.has_child);
+        builder.add_flag("has_metadata", self.metadata.is_some(), "has metadata");
+        builder.add_enum("behavior", self.behavior);
     }
 }
 
@@ -337,7 +335,7 @@ mod tests {
             .iter()
             .map(|p| p.name().to_string())
             .collect();
-        for required in ["has_metadata", "behavior", "size", "has_child"] {
+        for required in ["has_metadata", "behavior"] {
             assert!(
                 names.iter().any(|n| n == required),
                 "missing diagnostic field: {required}"

--- a/crates/flui-rendering/src/objects/offstage.rs
+++ b/crates/flui-rendering/src/objects/offstage.rs
@@ -84,9 +84,7 @@ impl Default for RenderOffstage {
 
 impl flui_foundation::Diagnosticable for RenderOffstage {
     fn debug_fill_properties(&self, builder: &mut flui_foundation::DiagnosticsBuilder) {
-        builder.add("offstage", self.offstage);
-        builder.add("size", format!("{:?}", self.size));
-        builder.add("has_child", self.has_child);
+        builder.add_flag("offstage", self.offstage, "offstage");
     }
 }
 
@@ -207,7 +205,7 @@ mod tests {
     #[test]
     fn debug_fill_properties_lists_state() {
         use flui_foundation::{Diagnosticable, DiagnosticsBuilder};
-        let node = RenderOffstage::visible();
+        let node = RenderOffstage::hidden();
         let mut builder = DiagnosticsBuilder::new();
         node.debug_fill_properties(&mut builder);
         let names: Vec<String> = builder
@@ -215,12 +213,10 @@ mod tests {
             .iter()
             .map(|p| p.name().to_string())
             .collect();
-        for required in ["offstage", "size", "has_child"] {
-            assert!(
-                names.iter().any(|n| n == required),
-                "missing diagnostic field: {required}"
-            );
-        }
+        assert!(
+            names.iter().any(|n| n == "offstage"),
+            "missing diagnostic field: offstage"
+        );
     }
 
     #[test]

--- a/crates/flui-rendering/src/objects/opacity.rs
+++ b/crates/flui-rendering/src/objects/opacity.rs
@@ -125,7 +125,16 @@ impl Default for RenderOpacity {
     }
 }
 
-impl flui_foundation::Diagnosticable for RenderOpacity {}
+impl flui_foundation::Diagnosticable for RenderOpacity {
+    fn debug_fill_properties(&self, properties: &mut flui_foundation::DiagnosticsBuilder) {
+        properties.add_default_double("opacity", self.opacity, 1.0, None);
+        properties.add_flag(
+            "always_needs_compositing",
+            self.always_needs_compositing,
+            "always needs compositing",
+        );
+    }
+}
 impl RenderBox for RenderOpacity {
     type Arity = Single;
     type ParentData = BoxParentData;

--- a/crates/flui-rendering/src/objects/padding.rs
+++ b/crates/flui-rendering/src/objects/padding.rs
@@ -76,7 +76,11 @@ impl RenderPadding {
     }
 }
 
-impl flui_foundation::Diagnosticable for RenderPadding {}
+impl flui_foundation::Diagnosticable for RenderPadding {
+    fn debug_fill_properties(&self, properties: &mut flui_foundation::DiagnosticsBuilder) {
+        properties.add_enum("padding", self.padding);
+    }
+}
 impl RenderBox for RenderPadding {
     type Arity = Single;
     type ParentData = BoxParentData;

--- a/crates/flui-rendering/src/objects/paragraph.rs
+++ b/crates/flui-rendering/src/objects/paragraph.rs
@@ -125,7 +125,33 @@ impl RenderParagraph {
     }
 }
 
-impl Diagnosticable for RenderParagraph {}
+impl Diagnosticable for RenderParagraph {
+    fn debug_fill_properties(&self, properties: &mut flui_foundation::DiagnosticsBuilder) {
+        properties.add_enum("text_align", self.painter.text_align());
+        properties.add(
+            "text_direction",
+            self.painter
+                .text_direction()
+                .map(|d| format!("{d:?}"))
+                .unwrap_or_else(|| "unset".to_string()),
+        );
+        properties.add_flag("soft_wrap", self.soft_wrap, "soft wrap");
+        properties.add(
+            "max_lines",
+            self.painter
+                .max_lines()
+                .map(|n| n.to_string())
+                .unwrap_or_else(|| "unlimited".to_string()),
+        );
+        properties.add(
+            "ellipsis",
+            self.painter
+                .ellipsis()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+        );
+    }
+}
 
 impl RenderBox for RenderParagraph {
     type Arity = Leaf;

--- a/crates/flui-rendering/src/objects/sized_box.rs
+++ b/crates/flui-rendering/src/objects/sized_box.rs
@@ -79,7 +79,12 @@ impl RenderSizedBox {
     }
 }
 
-impl flui_foundation::Diagnosticable for RenderSizedBox {}
+impl flui_foundation::Diagnosticable for RenderSizedBox {
+    fn debug_fill_properties(&self, properties: &mut flui_foundation::DiagnosticsBuilder) {
+        properties.add_optional("width", self.width.map(|w| format!("{w:?}")));
+        properties.add_optional("height", self.height.map(|h| format!("{h:?}")));
+    }
+}
 impl RenderBox for RenderSizedBox {
     type Arity = Leaf;
     type ParentData = BoxParentData;

--- a/crates/flui-rendering/src/objects/sliver_fill_remaining.rs
+++ b/crates/flui-rendering/src/objects/sliver_fill_remaining.rs
@@ -45,6 +45,8 @@ impl Default for RenderSliverFillRemaining {
     }
 }
 
+// Geometry-only fill: no configurable fields. Committed geometry is layered
+// onto the diagnostics node by the tree walk.
 impl Diagnosticable for RenderSliverFillRemaining {}
 impl PaintEffectsCapability for RenderSliverFillRemaining {}
 impl SemanticsCapability for RenderSliverFillRemaining {}
@@ -143,6 +145,7 @@ impl Default for RenderSliverFillRemainingAndOverscroll {
     }
 }
 
+// Geometry-only fill: no configurable fields (see above).
 impl Diagnosticable for RenderSliverFillRemainingAndOverscroll {}
 impl PaintEffectsCapability for RenderSliverFillRemainingAndOverscroll {}
 impl SemanticsCapability for RenderSliverFillRemainingAndOverscroll {}
@@ -253,6 +256,7 @@ impl Default for RenderSliverFillRemainingWithScrollable {
     }
 }
 
+// Geometry-only fill: no configurable fields (see above).
 impl Diagnosticable for RenderSliverFillRemainingWithScrollable {}
 impl PaintEffectsCapability for RenderSliverFillRemainingWithScrollable {}
 impl SemanticsCapability for RenderSliverFillRemainingWithScrollable {}

--- a/crates/flui-rendering/src/objects/sliver_fill_viewport.rs
+++ b/crates/flui-rendering/src/objects/sliver_fill_viewport.rs
@@ -99,7 +99,11 @@ impl Default for RenderSliverFillViewport {
     }
 }
 
-impl Diagnosticable for RenderSliverFillViewport {}
+impl Diagnosticable for RenderSliverFillViewport {
+    fn debug_fill_properties(&self, properties: &mut flui_foundation::DiagnosticsBuilder) {
+        properties.add_double("viewport_fraction", self.viewport_fraction, None);
+    }
+}
 impl PaintEffectsCapability for RenderSliverFillViewport {}
 impl SemanticsCapability for RenderSliverFillViewport {}
 impl HotReloadCapability for RenderSliverFillViewport {}

--- a/crates/flui-rendering/src/objects/sliver_fixed_extent_list.rs
+++ b/crates/flui-rendering/src/objects/sliver_fixed_extent_list.rs
@@ -74,7 +74,11 @@ impl RenderSliverFixedExtentList {
     }
 }
 
-impl Diagnosticable for RenderSliverFixedExtentList {}
+impl Diagnosticable for RenderSliverFixedExtentList {
+    fn debug_fill_properties(&self, properties: &mut flui_foundation::DiagnosticsBuilder) {
+        properties.add_double("item_extent", self.item_extent, Some("px"));
+    }
+}
 impl PaintEffectsCapability for RenderSliverFixedExtentList {}
 impl SemanticsCapability for RenderSliverFixedExtentList {}
 impl HotReloadCapability for RenderSliverFixedExtentList {}

--- a/crates/flui-rendering/src/objects/sliver_ignore_pointer.rs
+++ b/crates/flui-rendering/src/objects/sliver_ignore_pointer.rs
@@ -85,8 +85,7 @@ impl Default for RenderSliverIgnorePointer {
 
 impl flui_foundation::Diagnosticable for RenderSliverIgnorePointer {
     fn debug_fill_properties(&self, builder: &mut flui_foundation::DiagnosticsBuilder) {
-        builder.add("ignoring", self.ignoring);
-        builder.add("geometry", format!("{:?}", self.geometry));
+        builder.add_flag("ignoring", self.ignoring, "ignoring");
     }
 }
 
@@ -220,11 +219,9 @@ mod tests {
             .iter()
             .map(|p| p.name().to_string())
             .collect();
-        for required in ["ignoring", "geometry"] {
-            assert!(
-                names.iter().any(|n| n == required),
-                "missing diagnostic field: {required}"
-            );
-        }
+        assert!(
+            names.iter().any(|n| n == "ignoring"),
+            "missing diagnostic field: ignoring"
+        );
     }
 }

--- a/crates/flui-rendering/src/objects/sliver_offstage.rs
+++ b/crates/flui-rendering/src/objects/sliver_offstage.rs
@@ -104,8 +104,7 @@ impl Default for RenderSliverOffstage {
 
 impl flui_foundation::Diagnosticable for RenderSliverOffstage {
     fn debug_fill_properties(&self, builder: &mut flui_foundation::DiagnosticsBuilder) {
-        builder.add("offstage", self.offstage);
-        builder.add("geometry", format!("{:?}", self.geometry));
+        builder.add_flag("offstage", self.offstage, "offstage");
     }
 }
 
@@ -264,11 +263,9 @@ mod tests {
             .iter()
             .map(|p| p.name().to_string())
             .collect();
-        for required in ["offstage", "geometry"] {
-            assert!(
-                names.iter().any(|n| n == required),
-                "missing diagnostic field: {required}"
-            );
-        }
+        assert!(
+            names.iter().any(|n| n == "offstage"),
+            "missing diagnostic field: offstage"
+        );
     }
 }

--- a/crates/flui-rendering/src/objects/sliver_opacity.rs
+++ b/crates/flui-rendering/src/objects/sliver_opacity.rs
@@ -161,10 +161,12 @@ impl Default for RenderSliverOpacity {
 
 impl flui_foundation::Diagnosticable for RenderSliverOpacity {
     fn debug_fill_properties(&self, builder: &mut flui_foundation::DiagnosticsBuilder) {
-        builder.add("opacity", self.opacity);
-        builder.add("alpha", self.alpha);
-        builder.add("always_needs_compositing", self.always_needs_compositing);
-        builder.add("needs_compositing", self.needs_compositing());
+        builder.add_default_double("opacity", self.opacity, 1.0, None);
+        builder.add_flag(
+            "always_needs_compositing",
+            self.always_needs_compositing,
+            "always needs compositing",
+        );
     }
 }
 
@@ -351,16 +353,9 @@ mod tests {
             .iter()
             .map(|p| p.name().to_string())
             .collect();
-        for required in [
-            "opacity",
-            "alpha",
-            "always_needs_compositing",
-            "needs_compositing",
-        ] {
-            assert!(
-                names.iter().any(|n| n == required),
-                "missing diagnostic field: {required}"
-            );
-        }
+        assert!(
+            names.iter().any(|n| n == "opacity"),
+            "missing diagnostic field: opacity"
+        );
     }
 }

--- a/crates/flui-rendering/src/objects/sliver_padding.rs
+++ b/crates/flui-rendering/src/objects/sliver_padding.rs
@@ -333,14 +333,7 @@ impl Default for RenderSliverPadding {
 
 impl flui_foundation::Diagnosticable for RenderSliverPadding {
     fn debug_fill_properties(&self, builder: &mut flui_foundation::DiagnosticsBuilder) {
-        builder.add(
-            "padding",
-            format!(
-                "EdgeInsets(top={}, right={}, bottom={}, left={})",
-                self.padding.top, self.padding.right, self.padding.bottom, self.padding.left,
-            ),
-        );
-        builder.add("geometry", format!("{:?}", self.geometry));
+        builder.add_enum("padding", self.padding);
     }
 }
 
@@ -854,11 +847,9 @@ mod tests {
             .iter()
             .map(|p| p.name().to_string())
             .collect();
-        for required in ["padding", "geometry"] {
-            assert!(
-                names.iter().any(|n| n == required),
-                "missing diagnostic field: {required}"
-            );
-        }
+        assert!(
+            names.iter().any(|n| n == "padding"),
+            "missing diagnostic field: padding"
+        );
     }
 }

--- a/crates/flui-rendering/src/objects/sliver_to_box_adapter.rs
+++ b/crates/flui-rendering/src/objects/sliver_to_box_adapter.rs
@@ -59,6 +59,8 @@ impl Default for RenderSliverToBoxAdapter {
     }
 }
 
+// Geometry-only adapter: no configurable fields to surface. The committed
+// sliver geometry is layered onto the diagnostics node by the tree walk.
 impl Diagnosticable for RenderSliverToBoxAdapter {}
 impl PaintEffectsCapability for RenderSliverToBoxAdapter {}
 impl SemanticsCapability for RenderSliverToBoxAdapter {}

--- a/crates/flui-rendering/src/objects/stack.rs
+++ b/crates/flui-rendering/src/objects/stack.rs
@@ -318,15 +318,12 @@ impl Default for RenderStack {
 
 impl flui_foundation::Diagnosticable for RenderStack {
     fn debug_fill_properties(&self, builder: &mut flui_foundation::DiagnosticsBuilder) {
-        builder.add("fit", format!("{:?}", self.fit));
         builder.add(
             "alignment",
             format!("({}, {})", self.alignment.x, self.alignment.y),
         );
-        builder.add("clip_behavior", format!("{:?}", self.clip_behavior));
-        builder.add("size", format!("{:?}", self.size));
-        builder.add("has_visual_overflow", self.has_visual_overflow);
-        builder.add("child_count", self.child_count);
+        builder.add_enum("fit", self.fit);
+        builder.add_enum("clip_behavior", self.clip_behavior);
     }
 }
 
@@ -709,14 +706,7 @@ mod tests {
             .iter()
             .map(|p| p.name().to_string())
             .collect();
-        for required in [
-            "fit",
-            "alignment",
-            "clip_behavior",
-            "size",
-            "has_visual_overflow",
-            "child_count",
-        ] {
+        for required in ["alignment", "fit", "clip_behavior"] {
             assert!(
                 names.iter().any(|n| n == required),
                 "missing diagnostic field: {required}"

--- a/crates/flui-rendering/src/objects/transform.rs
+++ b/crates/flui-rendering/src/objects/transform.rs
@@ -166,7 +166,13 @@ impl Default for RenderTransform {
     }
 }
 
-impl flui_foundation::Diagnosticable for RenderTransform {}
+impl flui_foundation::Diagnosticable for RenderTransform {
+    fn debug_fill_properties(&self, properties: &mut flui_foundation::DiagnosticsBuilder) {
+        properties.add("transform", format!("{:?}", self.transform));
+        properties.add_enum("alignment", self.alignment);
+        properties.add_optional("origin", self.origin.map(|o| format!("{o:?}")));
+    }
+}
 impl RenderBox for RenderTransform {
     type Arity = Single;
     type ParentData = BoxParentData;

--- a/crates/flui-rendering/src/objects/viewport.rs
+++ b/crates/flui-rendering/src/objects/viewport.rs
@@ -368,7 +368,16 @@ impl Default for RenderViewport<ScrollableViewportOffset> {
     }
 }
 
-impl<O: ViewportOffset + 'static> Diagnosticable for RenderViewport<O> {}
+impl<O: ViewportOffset + 'static> Diagnosticable for RenderViewport<O> {
+    fn debug_fill_properties(&self, properties: &mut flui_foundation::DiagnosticsBuilder) {
+        properties.add_enum("axis_direction", self.axis_direction);
+        properties.add_enum("cross_axis_direction", self.cross_axis_direction);
+        properties.add_double("offset", self.offset.pixels(), Some("px"));
+        properties.add_double("cache_extent", self.cache_extent, Some("px"));
+        properties.add_enum("cache_extent_style", self.cache_extent_style);
+        properties.add_enum("paint_order", self.paint_order);
+    }
+}
 impl<O: ViewportOffset + 'static> PaintEffectsCapability for RenderViewport<O> {}
 impl<O: ViewportOffset + 'static> SemanticsCapability for RenderViewport<O> {}
 impl<O: ViewportOffset + 'static> HotReloadCapability for RenderViewport<O> {}

--- a/crates/flui-rendering/src/objects/viewport.rs
+++ b/crates/flui-rendering/src/objects/viewport.rs
@@ -372,7 +372,7 @@ impl<O: ViewportOffset + 'static> Diagnosticable for RenderViewport<O> {
     fn debug_fill_properties(&self, properties: &mut flui_foundation::DiagnosticsBuilder) {
         properties.add_enum("axis_direction", self.axis_direction);
         properties.add_enum("cross_axis_direction", self.cross_axis_direction);
-        properties.add_double("offset", self.offset.pixels(), Some("px"));
+        properties.add_double("scroll_offset", self.offset.pixels(), Some("px"));
         properties.add_double("cache_extent", self.cache_extent, Some("px"));
         properties.add_enum("cache_extent_style", self.cache_extent_style);
         properties.add_enum("paint_order", self.paint_order);

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -19,7 +19,9 @@ use flui_layer::{
 use flui_painting::DisplayList;
 use flui_types::{Offset, Size};
 use parking_lot::Mutex;
-use rustc_hash::{FxHashMap, FxHashSet};
+#[cfg(any(test, feature = "testing"))]
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 
 #[cfg(any(test, feature = "testing"))]
 use crate::testing::parent_data::ParentDataSeed;
@@ -262,6 +264,8 @@ impl PipelineOwner<Idle> {
 
     /// Records harness parent metadata for `child_id`, cloned into the
     /// transient child slots before each layout walk.
+    ///
+    /// A second call for the same `child_id` replaces the previous seed.
     #[cfg(any(test, feature = "testing"))]
     pub fn seed_parent_data(&mut self, child_id: RenderId, seed: ParentDataSeed) {
         self.parent_data_seeds.insert(child_id, seed);
@@ -3975,14 +3979,14 @@ fn dry_layout_query_impl(
 fn node_diagnostics(node: &RenderNode) -> DiagnosticsNode {
     if let Some(entry) = node.as_box() {
         let mut diagnostics = entry.render_object().to_diagnostics_node();
-        diagnostics = diagnostics.property("offset", format!("{:?}", node.offset()));
+        diagnostics = diagnostics.property("paint_offset", format!("{:?}", node.offset()));
         if let Some(size) = entry.state().geometry() {
             diagnostics = diagnostics.property("size", format!("{size:?}"));
         }
         diagnostics
     } else if let Some(entry) = node.as_sliver() {
         let mut diagnostics = entry.render_object().to_diagnostics_node();
-        diagnostics = diagnostics.property("offset", format!("{:?}", node.offset()));
+        diagnostics = diagnostics.property("paint_offset", format!("{:?}", node.offset()));
         if let Some(geometry) = entry.state().geometry() {
             diagnostics = diagnostics.property("geometry", format!("{geometry:?}"));
         }

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -11,7 +11,7 @@ use std::{
     sync::atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
-use flui_foundation::{LayerId, RenderId};
+use flui_foundation::{DiagnosticsNode, LayerId, RenderId};
 use flui_layer::{
     ClipPathLayer, ClipRRectLayer, ClipRectLayer, Layer, LayerTree, OffsetLayer, OpacityLayer,
     PictureLayer, TransformLayer,
@@ -19,7 +19,10 @@ use flui_layer::{
 use flui_painting::DisplayList;
 use flui_types::{Offset, Size};
 use parking_lot::Mutex;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+#[cfg(any(test, feature = "testing"))]
+use crate::testing::parent_data::ParentDataSeed;
 
 use crate::{
     constraints::{BoxConstraints, SliverConstraints, SliverGeometry},
@@ -179,6 +182,15 @@ pub struct PipelineOwner<Phase: PipelinePhase = Idle> {
     /// `dirty` by `drain_pending_dirty` at phase boundaries.
     dirty_rx: crossbeam_channel::Receiver<DirtyRequest>,
 
+    /// Harness-only parent-data presets keyed by child [`RenderId`].
+    ///
+    /// Cloned into per-walk [`ErasedChildState`] / [`ErasedSliverChildState`]
+    /// slots before layout so headless tests can express widget-level
+    /// configuration (stack positioning, flex factors, future animation
+    /// parent slots) without an element tree.
+    #[cfg(any(test, feature = "testing"))]
+    parent_data_seeds: FxHashMap<RenderId, ParentDataSeed>,
+
     /// Phantom marker for the typestate phase. Always zero-sized.
     /// See `crates/flui-rendering/src/pipeline/phase.rs`.
     _phase: PhantomData<Phase>,
@@ -242,8 +254,17 @@ impl PipelineOwner<Idle> {
             device_pixel_ratio: 1.0,
             handle,
             dirty_rx,
+            #[cfg(any(test, feature = "testing"))]
+            parent_data_seeds: FxHashMap::default(),
             _phase: PhantomData,
         }
+    }
+
+    /// Records harness parent metadata for `child_id`, cloned into the
+    /// transient child slots before each layout walk.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn seed_parent_data(&mut self, child_id: RenderId, seed: ParentDataSeed) {
+        self.parent_data_seeds.insert(child_id, seed);
     }
 
     /// Creates a new pipeline owner with callbacks in the [`Idle`] phase.
@@ -288,6 +309,8 @@ impl PipelineOwner<Idle> {
             device_pixel_ratio: 1.0,
             handle,
             dirty_rx,
+            #[cfg(any(test, feature = "testing"))]
+            parent_data_seeds: FxHashMap::default(),
             _phase: PhantomData,
         }
     }
@@ -2042,7 +2065,12 @@ impl PipelineOwner<Layout> {
         // &mut RenderNode borrows just acquired) so the recursive walk
         // can reborrow one slot at a time without re-entering the
         // tree's slab borrow.
-        let borrows = SubtreeBorrows::new(&subtree_ids, node_refs);
+        let borrows = SubtreeBorrows::new(
+            &subtree_ids,
+            node_refs,
+            #[cfg(any(test, feature = "testing"))]
+            &self.parent_data_seeds,
+        );
 
         // Step 4: recursive walk via index-into-pre-acquired-pool. No
         // &mut RenderTree appears inside the callback chain — only
@@ -2122,6 +2150,8 @@ unsafe impl Sync for NodePtr {}
 /// Cheap: one `ThreadId::eq` per lookup.
 struct SubtreeBorrows<'tree> {
     by_id: std::collections::HashMap<RenderId, NodePtr>,
+    #[cfg(any(test, feature = "testing"))]
+    parent_data_seeds: FxHashMap<RenderId, ParentDataSeed>,
     /// Set of ids whose layout is currently in flight at some recursion
     /// level above the current call. Insert on layout entry, remove on
     /// drop (RAII via [`LayoutCycleGuard`]). Re-entry on a member id
@@ -2150,7 +2180,11 @@ impl<'tree> SubtreeBorrows<'tree> {
     /// satisfy this — currently the only caller is
     /// [`PipelineOwner::layout_dirty_root`] which feeds the two
     /// methods' outputs directly to this ctor.
-    fn new(ids: &[RenderId], refs: Vec<&'tree mut RenderNode>) -> Self {
+    fn new(
+        ids: &[RenderId],
+        refs: Vec<&'tree mut RenderNode>,
+        #[cfg(any(test, feature = "testing"))] all_seeds: &FxHashMap<RenderId, ParentDataSeed>,
+    ) -> Self {
         debug_assert_eq!(
             ids.len(),
             refs.len(),
@@ -2162,8 +2196,15 @@ impl<'tree> SubtreeBorrows<'tree> {
         for (&id, r) in ids.iter().zip(refs) {
             by_id.insert(id, NodePtr(r as *mut RenderNode));
         }
+        #[cfg(any(test, feature = "testing"))]
+        let parent_data_seeds = ids
+            .iter()
+            .filter_map(|id| all_seeds.get(id).map(|seed| (*id, seed.clone())))
+            .collect();
         Self {
             by_id,
+            #[cfg(any(test, feature = "testing"))]
+            parent_data_seeds,
             // Pre-sized to subtree size — at most `ids.len()` entries
             // can be in-flight concurrently (the recursive walk
             // descends linearly through one path at a time).
@@ -2173,6 +2214,17 @@ impl<'tree> SubtreeBorrows<'tree> {
             )),
             owner_thread,
             _lifetime: std::marker::PhantomData,
+        }
+    }
+
+    #[cfg(any(test, feature = "testing"))]
+    fn seed_child_parent_data(
+        &self,
+        child_id: RenderId,
+        slot: &mut Option<Box<dyn crate::parent_data::ParentData>>,
+    ) {
+        if let Some(seed) = self.parent_data_seeds.get(&child_id) {
+            *slot = Some(seed.to_box());
         }
     }
 
@@ -2452,6 +2504,8 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
                 cs.sliver_geometry = sliver_entry.state().geometry();
             }
         }
+        #[cfg(any(test, feature = "testing"))]
+        borrows.seed_child_parent_data(cs.id, &mut cs.parent_data);
     }
 
     // Descendant-error tracking flag. Closure flips to `true` on any
@@ -2844,6 +2898,8 @@ unsafe fn layout_sliver_subtree_borrowed_impl<'tree>(
             let child_node: &crate::storage::RenderNode = unsafe { &*child_ptr.0 };
             cs.offset = child_node.offset();
         }
+        #[cfg(any(test, feature = "testing"))]
+        borrows.seed_child_parent_data(cs.id, &mut cs.parent_data);
     }
 
     let descendant_error_flag: std::sync::Arc<std::sync::atomic::AtomicBool> =
@@ -3713,6 +3769,8 @@ where
         device_pixel_ratio: from.device_pixel_ratio,
         handle: from.handle,
         dirty_rx: from.dirty_rx,
+        #[cfg(any(test, feature = "testing"))]
+        parent_data_seeds: from.parent_data_seeds,
         _phase: PhantomData,
     }
 }
@@ -3905,6 +3963,64 @@ fn dry_layout_query_impl(
         slot.node = Some(node);
     }
     result
+}
+
+// ============================================================================
+// Diagnostics dump (Diagnosticable-backed)
+// ============================================================================
+
+/// Builds a [`DiagnosticsNode`] for a single render node: the render object
+/// self-describes its own properties, and the committed geometry/offset is
+/// layered on from `RenderState`.
+fn node_diagnostics(node: &RenderNode) -> DiagnosticsNode {
+    if let Some(entry) = node.as_box() {
+        let mut diagnostics = entry.render_object().to_diagnostics_node();
+        diagnostics = diagnostics.property("offset", format!("{:?}", node.offset()));
+        if let Some(size) = entry.state().geometry() {
+            diagnostics = diagnostics.property("size", format!("{size:?}"));
+        }
+        diagnostics
+    } else if let Some(entry) = node.as_sliver() {
+        let mut diagnostics = entry.render_object().to_diagnostics_node();
+        diagnostics = diagnostics.property("offset", format!("{:?}", node.offset()));
+        if let Some(geometry) = entry.state().geometry() {
+            diagnostics = diagnostics.property("geometry", format!("{geometry:?}"));
+        }
+        diagnostics
+    } else {
+        DiagnosticsNode::new("<unknown>")
+    }
+}
+
+impl<Phase: PipelinePhase> PipelineOwner<Phase> {
+    /// Returns a [`DiagnosticsNode`] tree mirroring the render hierarchy
+    /// rooted at [`root_id`](Self::root_id), or `None` if no root is set.
+    ///
+    /// Each node self-describes via its render object's
+    /// [`Diagnosticable`](flui_foundation::Diagnosticable) impl, with the
+    /// committed geometry/offset layered on. This is the
+    /// `Diagnosticable`-backed counterpart to a plain `{:?}` dump and the
+    /// basis for [`debug_dump_pipeline_owner_tree`](crate::binding::debug_dump_pipeline_owner_tree).
+    pub fn debug_diagnostics_tree(&self) -> Option<DiagnosticsNode> {
+        self.debug_diagnostics_subtree(self.root_id?)
+    }
+
+    /// Returns the [`DiagnosticsNode`] for a single node `id` (no children),
+    /// or `None` if the id is not live.
+    pub fn debug_node_diagnostics(&self, id: RenderId) -> Option<DiagnosticsNode> {
+        Some(node_diagnostics(self.render_tree.get(id)?))
+    }
+
+    fn debug_diagnostics_subtree(&self, id: RenderId) -> Option<DiagnosticsNode> {
+        let node = self.render_tree.get(id)?;
+        let mut diagnostics = node_diagnostics(node);
+        for &child in node.children() {
+            if let Some(child_diagnostics) = self.debug_diagnostics_subtree(child) {
+                diagnostics.add_child(child_diagnostics);
+            }
+        }
+        Some(diagnostics)
+    }
 }
 
 // ============================================================================

--- a/crates/flui-rendering/src/testing/assertions.rs
+++ b/crates/flui-rendering/src/testing/assertions.rs
@@ -1,0 +1,49 @@
+//! Structured assertion helpers for diagnostics-backed harness tests.
+//!
+//! Prefer these over substring-matching [`crate::testing::Probe::dump`] output
+//! so CI can pin render-object contracts without visual inspection.
+
+use flui_foundation::DiagnosticsNode;
+
+/// Asserts that `node` exposes every property name in `required`.
+#[track_caller]
+pub fn assert_properties(node: &DiagnosticsNode, required: &[&str]) {
+    let names: Vec<&str> = node.properties().iter().map(|p| p.name()).collect();
+    for &req in required {
+        assert!(
+            names.contains(&req),
+            "missing property {req:?} on {:?}; have {names:?}",
+            node.name(),
+        );
+    }
+}
+
+/// Asserts that a descendant typed `type_name` exists and has `required` config
+/// properties on its self-description node (before counting runtime fields).
+#[track_caller]
+pub fn assert_descendant_properties(tree: &DiagnosticsNode, type_name: &str, required: &[&str]) {
+    let node = tree
+        .find_descendant(type_name)
+        .unwrap_or_else(|| panic!("no descendant named {type_name:?} in diagnostics tree"));
+    assert_properties(node, required);
+}
+
+/// Asserts the pipeline layered committed box geometry onto the node.
+#[track_caller]
+pub fn assert_has_committed_size(node: &DiagnosticsNode) {
+    assert!(
+        node.get_property("size").is_some(),
+        "expected committed size on {:?}",
+        node.name(),
+    );
+}
+
+/// Asserts the pipeline layered committed sliver geometry onto the node.
+#[track_caller]
+pub fn assert_has_committed_geometry(node: &DiagnosticsNode) {
+    assert!(
+        node.get_property("geometry").is_some(),
+        "expected committed geometry on {:?}",
+        node.name(),
+    );
+}

--- a/crates/flui-rendering/src/testing/harness.rs
+++ b/crates/flui-rendering/src/testing/harness.rs
@@ -1,0 +1,466 @@
+//! The symmetric render-object test harness.
+//!
+//! [`RenderTester`] is a small config (a [`TreeNode`] spec plus root
+//! constraints) that builds a real [`PipelineOwner`] and drives it to one
+//! of two depths, chosen by symmetric verbs that mirror the pipeline's own
+//! methods:
+//!
+//! - [`run_layout`](RenderTester::run_layout) -> [`LayoutRun`]: stops at the
+//!   `Layout` phase, for inspecting committed geometry/offsets without a
+//!   full frame (Box and Sliver alike);
+//! - [`run_frame`](RenderTester::run_frame) -> [`FrameRun`]: a full frame
+//!   (layout -> compositing -> paint), adding layer-tree structure, picture
+//!   bounds, dirty-state checks, and multi-frame helpers ([`pump`](FrameRun::pump),
+//!   [`pump_frames`](FrameRun::pump_frames), [`advance_layout`](FrameRun::advance_layout),
+//!   [`advance_paint`](FrameRun::advance_paint), [`simulate`](FrameRun::simulate)).
+//!
+//! Both run results implement [`Probe`], so Box and Sliver are inspected
+//! through the identical surface. They are two types only because the
+//! typestate forbids one live struct from holding both a `<Layout>` and an
+//! `<Idle>` owner.
+
+use flui_foundation::RenderId;
+use flui_layer::LayerTree;
+use flui_types::{Rect, Size, geometry::px};
+
+use crate::{
+    constraints::BoxConstraints,
+    pipeline::{Idle, Layout, PipelineOwner},
+    testing::{
+        inspect::{self, Probe},
+        report::FrameReport,
+        tree::{self, IdRegistry, TreeNode},
+    },
+};
+
+/// Default root constraints when a test does not specify any: a loose
+/// `0..=800 x 0..=600` box, large enough that most trees lay out at their
+/// natural size.
+fn default_constraints() -> BoxConstraints {
+    BoxConstraints::new(px(0.0), px(800.0), px(0.0), px(600.0))
+}
+
+/// Depth of `id` in the render tree (root = 0), for paint-dirty enqueue.
+fn node_depth<P: crate::pipeline::PipelinePhase>(owner: &PipelineOwner<P>, id: RenderId) -> usize {
+    owner.render_tree().depth(id).unwrap_or(0) as usize
+}
+
+/// Marks `id` for repaint: compositing bits (layer structure may change when
+/// paint effects like opacity cross the fully-opaque threshold) then paint.
+fn mark_needs_paint<P: crate::pipeline::PipelinePhase>(owner: &mut PipelineOwner<P>, id: RenderId) {
+    let depth = node_depth(owner, id);
+    owner.add_node_needing_compositing_bits_update(id, depth);
+    owner.add_node_needing_paint(id, depth);
+}
+
+/// Downcasts the Box render object at `id` to `T` and runs `edit`.
+fn edit_box_object<T: 'static, P: crate::pipeline::PipelinePhase>(
+    owner: &mut PipelineOwner<P>,
+    id: RenderId,
+    edit: impl FnOnce(&mut T),
+) {
+    let entry = owner
+        .render_tree_mut()
+        .get_mut(id)
+        .expect("update: render id must be live")
+        .as_box_mut()
+        .expect("update: node must be a Box render object");
+    let object = entry
+        .render_object_mut()
+        .as_any_mut()
+        .downcast_mut::<T>()
+        .expect("update: render object is not of the requested type");
+    edit(object);
+}
+
+/// A configured-but-not-yet-run render-object test.
+///
+/// Build it with [`mount`](RenderTester::mount), optionally set the root
+/// constraints, then pick a run depth.
+pub struct RenderTester {
+    spec: TreeNode,
+    constraints: Option<BoxConstraints>,
+}
+
+impl RenderTester {
+    /// Configures a test from a [`TreeNode`] spec (the root must be a Box
+    /// node — see [`crate::testing::tree::mount`]).
+    #[must_use]
+    pub fn mount(spec: TreeNode) -> Self {
+        Self {
+            spec,
+            constraints: None,
+        }
+    }
+
+    /// Sets the root constraints applied on the first layout pass.
+    #[must_use]
+    pub fn with_constraints(mut self, constraints: BoxConstraints) -> Self {
+        self.constraints = Some(constraints);
+        self
+    }
+
+    /// Sets tight root constraints forcing the root to exactly `size`.
+    #[must_use]
+    pub fn with_size(mut self, size: Size) -> Self {
+        self.constraints = Some(BoxConstraints::tight(size));
+        self
+    }
+
+    /// Builds the owner, mounts the spec, and seeds the root + constraints.
+    fn build(self) -> (PipelineOwner<Idle>, RenderId, IdRegistry) {
+        let mut owner = PipelineOwner::new();
+        let (root_id, registry) = tree::mount(&mut owner, self.spec);
+        owner.set_root_id(Some(root_id));
+        owner.set_root_constraints(Some(self.constraints.unwrap_or_else(default_constraints)));
+        (owner, root_id, registry)
+    }
+
+    /// Drives the tree through layout only, returning a [`LayoutRun`].
+    #[must_use]
+    pub fn run_layout(self) -> LayoutRun {
+        let (owner, root_id, registry) = self.build();
+        let mut owner = owner.into_layout();
+        owner
+            .run_layout()
+            .expect("run_layout must succeed for a well-formed test tree");
+        LayoutRun {
+            owner,
+            root_id,
+            registry,
+        }
+    }
+
+    /// Drives the tree through a full frame, returning a [`FrameRun`].
+    #[must_use]
+    pub fn run_frame(self) -> FrameRun {
+        let (owner, root_id, registry) = self.build();
+        let (owner, result) = owner.run_frame();
+        let layer_tree = result.expect("run_frame must succeed for a well-formed test tree");
+        FrameRun {
+            owner,
+            root_id,
+            registry,
+            layer_tree,
+        }
+    }
+}
+
+/// The result of a [`RenderTester::run_layout`]: a pipeline parked in the
+/// `Layout` phase with committed geometry/offsets ready to inspect.
+pub struct LayoutRun {
+    owner: PipelineOwner<Layout>,
+    root_id: RenderId,
+    registry: IdRegistry,
+}
+
+impl LayoutRun {
+    /// The root node's id.
+    #[must_use]
+    pub fn root(&self) -> RenderId {
+        self.root_id
+    }
+
+    /// The underlying pipeline owner (escape hatch for advanced inspection).
+    #[must_use]
+    pub fn owner(&self) -> &PipelineOwner<Layout> {
+        &self.owner
+    }
+
+    /// Mutable access to the underlying pipeline owner.
+    pub fn owner_mut(&mut self) -> &mut PipelineOwner<Layout> {
+        &mut self.owner
+    }
+
+    /// Downcasts the Box render object at `id` to `T`, runs `edit`, and marks
+    /// the node layout-dirty. Pair with [`relayout`](LayoutRun::relayout) to
+    /// re-run layout and observe the new geometry — the layout-only analog of
+    /// [`FrameRun::update`] + [`FrameRun::pump`].
+    ///
+    /// Panics if the id is stale, is not a Box node, or is not a `T`.
+    pub fn update<T: 'static>(&mut self, id: RenderId, edit: impl FnOnce(&mut T)) {
+        edit_box_object(&mut self.owner, id, edit);
+        self.owner.mark_needs_layout(id);
+    }
+
+    /// Downcasts the Box render object at `id` to `T`, runs `edit`, and marks
+    /// the node paint-dirty (opacity, color, transform, … — no layout pass).
+    ///
+    /// Pair with a full [`FrameRun`] if the change must be painted; layout-only
+    /// runs do not execute the paint phase.
+    ///
+    /// Panics if the id is stale, is not a Box node, or is not a `T`.
+    pub fn update_paint<T: 'static>(&mut self, id: RenderId, edit: impl FnOnce(&mut T)) {
+        edit_box_object(&mut self.owner, id, edit);
+        mark_needs_paint(&mut self.owner, id);
+    }
+
+    /// Marks `id` paint-dirty without mutating its render object.
+    pub fn mark_needs_paint(&mut self, id: RenderId) {
+        mark_needs_paint(&mut self.owner, id);
+    }
+
+    /// Re-runs the layout phase, committing fresh geometry/offsets for any
+    /// nodes marked dirty since the previous pass.
+    pub fn relayout(&mut self) {
+        self.owner
+            .run_layout()
+            .expect("relayout must succeed for a well-formed test tree");
+    }
+}
+
+impl Probe for LayoutRun {
+    type Phase = Layout;
+
+    fn pipeline(&self) -> &PipelineOwner<Layout> {
+        &self.owner
+    }
+
+    fn registry(&self) -> &IdRegistry {
+        &self.registry
+    }
+}
+
+/// The result of a [`RenderTester::run_frame`]: a pipeline returned to
+/// `Idle` plus the layer tree the frame produced.
+pub struct FrameRun {
+    owner: PipelineOwner<Idle>,
+    root_id: RenderId,
+    registry: IdRegistry,
+    layer_tree: Option<LayerTree>,
+}
+
+impl FrameRun {
+    /// The root node's id.
+    #[must_use]
+    pub fn root(&self) -> RenderId {
+        self.root_id
+    }
+
+    /// Whether the most recent frame produced a layer tree.
+    #[must_use]
+    pub fn painted(&self) -> bool {
+        self.layer_tree.is_some()
+    }
+
+    /// Whether the pipeline has no dirty nodes left after the frame.
+    #[must_use]
+    pub fn is_clean(&self) -> bool {
+        !self.owner.has_dirty_nodes()
+    }
+
+    /// The layer tree from the most recent frame, if any.
+    #[must_use]
+    pub fn layer_tree(&self) -> Option<&LayerTree> {
+        self.layer_tree.as_ref()
+    }
+
+    /// The composited layer kinds in pre-order (empty if nothing painted).
+    #[must_use]
+    pub fn structure(&self) -> Vec<&'static str> {
+        self.layer_tree
+            .as_ref()
+            .map(inspect::layer_structure)
+            .unwrap_or_default()
+    }
+
+    /// The bounds of the first picture layer, if any.
+    #[must_use]
+    pub fn picture_bounds(&self) -> Option<Rect> {
+        self.layer_tree
+            .as_ref()
+            .and_then(inspect::first_picture_bounds)
+    }
+
+    /// A [`FrameReport`] snapshot of the most recent frame.
+    #[must_use]
+    pub fn report(&self) -> FrameReport {
+        FrameReport {
+            painted: self.painted(),
+            structure: self
+                .layer_tree
+                .as_ref()
+                .map(inspect::layer_structure_with_depth)
+                .unwrap_or_default(),
+            picture_bounds: self.picture_bounds(),
+            dirty: self.owner.has_dirty_nodes(),
+        }
+    }
+
+    /// Runs another frame (after mutating the tree via
+    /// [`owner_mut`](FrameRun::owner_mut)) and returns its report.
+    ///
+    /// A frame with no dirty work produces no layer tree, mirroring the
+    /// production idle-frame behavior.
+    pub fn pump(&mut self) -> FrameReport {
+        let owner = std::mem::take(&mut self.owner);
+        let (owner, result) = owner.run_frame();
+        self.owner = owner;
+        self.layer_tree = result.expect("pump frame must succeed for a well-formed test tree");
+        self.report()
+    }
+
+    /// Runs `count` consecutive frames with no mutations between them.
+    ///
+    /// Returns one [`FrameReport`] per frame. Idle frames (no dirty work)
+    /// produce `painted: false`, mirroring production.
+    pub fn pump_frames(&mut self, count: usize) -> Vec<FrameReport> {
+        (0..count).map(|_| self.pump()).collect()
+    }
+
+    /// Runs `count` idle frames and panics if any frame paints or leaves the
+    /// pipeline dirty — the strict helper for "skip N settled frames" checks.
+    pub fn pump_idle_frames(&mut self, count: usize) {
+        for (i, report) in self.pump_frames(count).into_iter().enumerate() {
+            assert!(
+                !report.painted,
+                "idle frame {i} must not paint (no dirty work)",
+            );
+            assert!(
+                !report.dirty,
+                "idle frame {i} must leave the pipeline clean",
+            );
+        }
+    }
+
+    /// Layout mutation plus one frame — shorthand for
+    /// [`update`](FrameRun::update) + [`pump`](FrameRun::pump).
+    pub fn advance_layout<T: 'static>(
+        &mut self,
+        id: RenderId,
+        edit: impl FnOnce(&mut T),
+    ) -> FrameReport {
+        self.update(id, edit);
+        self.pump()
+    }
+
+    /// Paint-only mutation plus one frame — shorthand for
+    /// [`update_paint`](FrameRun::update_paint) + [`pump`](FrameRun::pump).
+    pub fn advance_paint<T: 'static>(
+        &mut self,
+        id: RenderId,
+        edit: impl FnOnce(&mut T),
+    ) -> FrameReport {
+        self.update_paint(id, edit);
+        self.pump()
+    }
+
+    /// Simulates a multi-frame animation on deterministic simulated time.
+    ///
+    /// For each `t` in `ticks`, calls `on_tick(t, self)` so the caller can
+    /// advance a controller and mutate the tree (`update`, `update_paint`, …),
+    /// then pumps exactly one frame. Returns one report per tick.
+    ///
+    /// ```
+    /// # use flui_rendering::objects::{RenderColoredBox, RenderPadding};
+    /// # use flui_rendering::testing::{RenderTester, Probe, box_node};
+    /// # use flui_types::{EdgeInsets, Offset, geometry::px};
+    /// let mut run = RenderTester::mount(
+    ///     box_node(RenderPadding::all(5.0))
+    ///         .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    /// )
+    /// .run_frame();
+    /// let child = run.id("child");
+    /// let pad = run.root();
+    /// run.simulate([0.0, 0.5, 1.0], |t, run| {
+    ///     let padding = 5.0 + 50.0 * t as f32;
+    ///     run.update::<RenderPadding>(pad, |p| {
+    ///         p.set_padding(EdgeInsets::all(px(padding)));
+    ///     });
+    /// });
+    /// assert_eq!(run.offset(child), Offset::new(px(55.0), px(55.0)));
+    /// ```
+    pub fn simulate<I, F>(&mut self, ticks: I, mut on_tick: F) -> Vec<FrameReport>
+    where
+        I: IntoIterator<Item = f64>,
+        F: FnMut(f64, &mut Self),
+    {
+        let mut reports = Vec::new();
+        for t in ticks {
+            on_tick(t, self);
+            reports.push(self.pump());
+        }
+        reports
+    }
+
+    /// Alpha of the first opacity layer in the most recent frame, if any.
+    #[must_use]
+    pub fn opacity_alpha(&self) -> Option<f32> {
+        self.layer_tree
+            .as_ref()
+            .and_then(inspect::first_opacity_alpha)
+    }
+
+    /// Whether the most recent frame's layer tree contains a picture layer.
+    #[must_use]
+    pub fn has_picture_layer(&self) -> bool {
+        self.layer_tree
+            .as_ref()
+            .is_some_and(inspect::has_picture_layer)
+    }
+
+    /// The underlying pipeline owner (escape hatch for advanced inspection).
+    #[must_use]
+    pub fn owner(&self) -> &PipelineOwner<Idle> {
+        &self.owner
+    }
+
+    /// Mutable access to the underlying pipeline owner — mutate the tree
+    /// here between [`pump`](FrameRun::pump) calls.
+    pub fn owner_mut(&mut self) -> &mut PipelineOwner<Idle> {
+        &mut self.owner
+    }
+
+    /// Downcasts the Box render object at `id` to `T`, runs `edit`, and marks
+    /// the node layout-dirty — the multi-frame mutate-then-[`pump`](FrameRun::pump)
+    /// flow in one call, collapsing the
+    /// `get_mut → as_box_mut → render_object_mut → as_any_mut → downcast_mut`
+    /// dance.
+    ///
+    /// Panics if the id is stale, is not a Box node, or is not a `T`.
+    ///
+    /// ```
+    /// # use flui_rendering::objects::{RenderColoredBox, RenderPadding};
+    /// # use flui_rendering::testing::{RenderTester, Probe, box_node};
+    /// # use flui_types::{EdgeInsets, Offset, geometry::px};
+    /// let mut run = RenderTester::mount(
+    ///     box_node(RenderPadding::all(5.0))
+    ///         .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    /// )
+    /// .run_frame();
+    /// let pad = run.root();
+    /// run.update::<RenderPadding>(pad, |p| p.set_padding(EdgeInsets::all(px(20.0))));
+    /// run.pump();
+    /// assert_eq!(run.offset(run.id("child")), Offset::new(px(20.0), px(20.0)));
+    /// ```
+    pub fn update<T: 'static>(&mut self, id: RenderId, edit: impl FnOnce(&mut T)) {
+        edit_box_object(&mut self.owner, id, edit);
+        self.owner.mark_needs_layout(id);
+    }
+
+    /// Downcasts the Box render object at `id` to `T`, runs `edit`, and marks
+    /// the node paint-dirty. Pair with [`pump`](FrameRun::pump).
+    ///
+    /// Panics if the id is stale, is not a Box node, or is not a `T`.
+    pub fn update_paint<T: 'static>(&mut self, id: RenderId, edit: impl FnOnce(&mut T)) {
+        edit_box_object(&mut self.owner, id, edit);
+        mark_needs_paint(&mut self.owner, id);
+    }
+
+    /// Marks `id` paint-dirty without mutating its render object.
+    pub fn mark_needs_paint(&mut self, id: RenderId) {
+        mark_needs_paint(&mut self.owner, id);
+    }
+}
+
+impl Probe for FrameRun {
+    type Phase = Idle;
+
+    fn pipeline(&self) -> &PipelineOwner<Idle> {
+        &self.owner
+    }
+
+    fn registry(&self) -> &IdRegistry {
+        &self.registry
+    }
+}

--- a/crates/flui-rendering/src/testing/harness.rs
+++ b/crates/flui-rendering/src/testing/harness.rs
@@ -26,10 +26,11 @@ use flui_types::{Rect, Size, geometry::px};
 use crate::{
     constraints::BoxConstraints,
     pipeline::{Idle, Layout, PipelineOwner},
+    storage::RenderNode,
     testing::{
         inspect::{self, Probe},
         report::FrameReport,
-        tree::{self, IdRegistry, TreeNode},
+        tree::{self, RenderLabelRegistry, TreeNode},
     },
 };
 
@@ -53,24 +54,35 @@ fn mark_needs_paint<P: crate::pipeline::PipelinePhase>(owner: &mut PipelineOwner
     owner.add_node_needing_paint(id, depth);
 }
 
-/// Downcasts the Box render object at `id` to `T` and runs `edit`.
-fn edit_box_object<T: 'static, P: crate::pipeline::PipelinePhase>(
+/// Downcasts the render object at `id` to `T` and runs `edit`.
+///
+/// Dispatches on the node's Box/Sliver protocol; `T` must match the concrete
+/// type stored at `id`.
+fn edit_object<T: 'static, P: crate::pipeline::PipelinePhase>(
     owner: &mut PipelineOwner<P>,
     id: RenderId,
     edit: impl FnOnce(&mut T),
 ) {
-    let entry = owner
+    let node = owner
         .render_tree_mut()
         .get_mut(id)
-        .expect("update: render id must be live")
-        .as_box_mut()
-        .expect("update: node must be a Box render object");
-    let object = entry
-        .render_object_mut()
-        .as_any_mut()
-        .downcast_mut::<T>()
-        .expect("update: render object is not of the requested type");
-    edit(object);
+        .expect("update: render id must be live");
+    match node {
+        RenderNode::Box(entry) => edit(
+            entry
+                .render_object_mut()
+                .as_any_mut()
+                .downcast_mut::<T>()
+                .expect("update: render object is not of the requested type"),
+        ),
+        RenderNode::Sliver(entry) => edit(
+            entry
+                .render_object_mut()
+                .as_any_mut()
+                .downcast_mut::<T>()
+                .expect("update: render object is not of the requested type"),
+        ),
+    }
 }
 
 /// A configured-but-not-yet-run render-object test.
@@ -108,7 +120,7 @@ impl RenderTester {
     }
 
     /// Builds the owner, mounts the spec, and seeds the root + constraints.
-    fn build(self) -> (PipelineOwner<Idle>, RenderId, IdRegistry) {
+    fn build(self) -> (PipelineOwner<Idle>, RenderId, RenderLabelRegistry) {
         let mut owner = PipelineOwner::new();
         let (root_id, registry) = tree::mount(&mut owner, self.spec);
         owner.set_root_id(Some(root_id));
@@ -151,7 +163,7 @@ impl RenderTester {
 pub struct LayoutRun {
     owner: PipelineOwner<Layout>,
     root_id: RenderId,
-    registry: IdRegistry,
+    registry: RenderLabelRegistry,
 }
 
 impl LayoutRun {
@@ -172,26 +184,28 @@ impl LayoutRun {
         &mut self.owner
     }
 
-    /// Downcasts the Box render object at `id` to `T`, runs `edit`, and marks
-    /// the node layout-dirty. Pair with [`relayout`](LayoutRun::relayout) to
-    /// re-run layout and observe the new geometry — the layout-only analog of
+    /// Downcasts the render object at `id` to `T`, runs `edit`, and marks the
+    /// node layout-dirty. Pair with [`relayout`](LayoutRun::relayout) to re-run
+    /// layout and observe the new geometry — the layout-only analog of
     /// [`FrameRun::update`] + [`FrameRun::pump`].
     ///
-    /// Panics if the id is stale, is not a Box node, or is not a `T`.
+    /// Works for Box and Sliver nodes; `T` must match the concrete type at `id`.
+    ///
+    /// Panics if the id is stale or is not a `T`.
     pub fn update<T: 'static>(&mut self, id: RenderId, edit: impl FnOnce(&mut T)) {
-        edit_box_object(&mut self.owner, id, edit);
+        edit_object(&mut self.owner, id, edit);
         self.owner.mark_needs_layout(id);
     }
 
-    /// Downcasts the Box render object at `id` to `T`, runs `edit`, and marks
-    /// the node paint-dirty (opacity, color, transform, … — no layout pass).
+    /// Downcasts the render object at `id` to `T`, runs `edit`, and marks the
+    /// node paint-dirty (opacity, color, transform, … — no layout pass).
     ///
     /// Pair with a full [`FrameRun`] if the change must be painted; layout-only
     /// runs do not execute the paint phase.
     ///
-    /// Panics if the id is stale, is not a Box node, or is not a `T`.
+    /// Panics if the id is stale or is not a `T`.
     pub fn update_paint<T: 'static>(&mut self, id: RenderId, edit: impl FnOnce(&mut T)) {
-        edit_box_object(&mut self.owner, id, edit);
+        edit_object(&mut self.owner, id, edit);
         mark_needs_paint(&mut self.owner, id);
     }
 
@@ -216,7 +230,7 @@ impl Probe for LayoutRun {
         &self.owner
     }
 
-    fn registry(&self) -> &IdRegistry {
+    fn registry(&self) -> &RenderLabelRegistry {
         &self.registry
     }
 }
@@ -226,7 +240,7 @@ impl Probe for LayoutRun {
 pub struct FrameRun {
     owner: PipelineOwner<Idle>,
     root_id: RenderId,
-    registry: IdRegistry,
+    registry: RenderLabelRegistry,
     layer_tree: Option<LayerTree>,
 }
 
@@ -411,13 +425,13 @@ impl FrameRun {
         &mut self.owner
     }
 
-    /// Downcasts the Box render object at `id` to `T`, runs `edit`, and marks
-    /// the node layout-dirty — the multi-frame mutate-then-[`pump`](FrameRun::pump)
-    /// flow in one call, collapsing the
-    /// `get_mut → as_box_mut → render_object_mut → as_any_mut → downcast_mut`
-    /// dance.
+    /// Downcasts the render object at `id` to `T`, runs `edit`, and marks the
+    /// node layout-dirty — the multi-frame mutate-then-[`pump`](FrameRun::pump)
+    /// flow in one call.
     ///
-    /// Panics if the id is stale, is not a Box node, or is not a `T`.
+    /// Works for Box and Sliver nodes; `T` must match the concrete type at `id`.
+    ///
+    /// Panics if the id is stale or is not a `T`.
     ///
     /// ```
     /// # use flui_rendering::objects::{RenderColoredBox, RenderPadding};
@@ -434,16 +448,16 @@ impl FrameRun {
     /// assert_eq!(run.offset(run.id("child")), Offset::new(px(20.0), px(20.0)));
     /// ```
     pub fn update<T: 'static>(&mut self, id: RenderId, edit: impl FnOnce(&mut T)) {
-        edit_box_object(&mut self.owner, id, edit);
+        edit_object(&mut self.owner, id, edit);
         self.owner.mark_needs_layout(id);
     }
 
-    /// Downcasts the Box render object at `id` to `T`, runs `edit`, and marks
-    /// the node paint-dirty. Pair with [`pump`](FrameRun::pump).
+    /// Downcasts the render object at `id` to `T`, runs `edit`, and marks the
+    /// node paint-dirty. Pair with [`pump`](FrameRun::pump).
     ///
-    /// Panics if the id is stale, is not a Box node, or is not a `T`.
+    /// Panics if the id is stale or is not a `T`.
     pub fn update_paint<T: 'static>(&mut self, id: RenderId, edit: impl FnOnce(&mut T)) {
-        edit_box_object(&mut self.owner, id, edit);
+        edit_object(&mut self.owner, id, edit);
         mark_needs_paint(&mut self.owner, id);
     }
 
@@ -460,7 +474,7 @@ impl Probe for FrameRun {
         &self.owner
     }
 
-    fn registry(&self) -> &IdRegistry {
+    fn registry(&self) -> &RenderLabelRegistry {
         &self.registry
     }
 }

--- a/crates/flui-rendering/src/testing/inspect.rs
+++ b/crates/flui-rendering/src/testing/inspect.rs
@@ -20,7 +20,7 @@ use crate::{
     hit_testing::HitTestResult,
     pipeline::{PipelineOwner, PipelinePhase},
     storage::RenderNode,
-    testing::tree::IdRegistry,
+    testing::tree::RenderLabelRegistry,
 };
 
 // The layer-tree walkers live in `flui_layer` (the crate that owns
@@ -95,7 +95,7 @@ pub fn render_diagnostics<P: PipelinePhase>(owner: &PipelineOwner<P>) -> Diagnos
 /// and of how far the pipeline was driven.
 ///
 /// Implementors supply the underlying [`PipelineOwner`] and the label
-/// [`IdRegistry`]; the provided methods do the rest. Box trees read
+/// [`RenderLabelRegistry`]; the provided methods do the rest. Box trees read
 /// [`box_geometry`](Probe::box_geometry); Sliver trees read
 /// [`sliver_geometry`](Probe::sliver_geometry); everything else is common.
 pub trait Probe {
@@ -106,7 +106,7 @@ pub trait Probe {
     fn pipeline(&self) -> &PipelineOwner<Self::Phase>;
 
     /// The label -> id registry built while mounting the tree.
-    fn registry(&self) -> &IdRegistry;
+    fn registry(&self) -> &RenderLabelRegistry;
 
     /// A diagnostics tree mirroring the render hierarchy, with each node's
     /// own properties plus committed geometry/offset.
@@ -134,7 +134,8 @@ pub trait Probe {
     /// type name (e.g. `"RenderColoredBox"`, `"RenderFlex"`).
     fn descendant_property(&self, type_name: &str, property: &str) -> Option<String> {
         self.diagnostics()
-            .find_descendant(type_name)?
+            .find_descendant_unique(type_name)
+            .ok()?
             .get_property(property)
             .map(str::to_owned)
     }
@@ -142,7 +143,8 @@ pub trait Probe {
     /// Parses a numeric property on the first descendant matched by `type_name`.
     fn descendant_property_f64(&self, type_name: &str, property: &str) -> Option<f64> {
         self.diagnostics()
-            .find_descendant(type_name)?
+            .find_descendant_unique(type_name)
+            .ok()?
             .get_property_f64(property)
     }
 

--- a/crates/flui-rendering/src/testing/inspect.rs
+++ b/crates/flui-rendering/src/testing/inspect.rs
@@ -1,0 +1,202 @@
+//! Protocol-agnostic inspection of a laid-out / painted render tree.
+//!
+//! Two layers live here:
+//!
+//! - free functions generic over the pipeline phase
+//!   ([`render_offset`], [`box_geometry`], [`sliver_geometry`],
+//!   [`hit_path`]) plus [`LayerTree`] walkers ([`layer_structure`],
+//!   [`layer_structure_with_depth`], [`first_picture_bounds`]). These are
+//!   the bodies previously duplicated across the integration tests.
+//! - the [`Probe`] trait, an ergonomic wrapper the run results
+//!   ([`crate::testing::LayoutRun`] / [`crate::testing::FrameRun`])
+//!   implement so Box and Sliver are inspected identically regardless of
+//!   how far the pipeline was driven.
+
+use flui_foundation::{DiagnosticsNode, RenderId};
+use flui_types::{Offset, Size, geometry::px};
+
+use crate::{
+    constraints::SliverGeometry,
+    hit_testing::HitTestResult,
+    pipeline::{PipelineOwner, PipelinePhase},
+    storage::RenderNode,
+    testing::tree::IdRegistry,
+};
+
+// The layer-tree walkers live in `flui_layer` (the crate that owns
+// `LayerTree`), the architecturally correct home. Re-exported here under
+// their historical names so the render harness and the migrated tests keep
+// using `inspect::layer_structure` / `inspect::first_picture_bounds`.
+pub use flui_layer::testing::inspect::{
+    first_opacity_alpha, first_picture_bounds, has_picture_layer, layer_kind,
+    structure as layer_structure, structure_with_depth as layer_structure_with_depth,
+};
+
+// ============================================================================
+// Phase-generic render-tree readers
+// ============================================================================
+
+/// Returns the committed paint offset of `id`, or `None` if no such node
+/// exists.
+pub fn render_offset<P: PipelinePhase>(owner: &PipelineOwner<P>, id: RenderId) -> Option<Offset> {
+    owner.render_tree().get(id).map(RenderNode::offset)
+}
+
+/// Returns the committed Box geometry (size) of `id`, or `None` if the node
+/// is missing, is not a Box node, or has not been laid out yet.
+pub fn box_geometry<P: PipelinePhase>(owner: &PipelineOwner<P>, id: RenderId) -> Option<Size> {
+    owner.render_tree().get(id)?.as_box()?.state().geometry()
+}
+
+/// Returns the committed Sliver geometry of `id`, or `None` if the node is
+/// missing, is not a Sliver node, or has not been laid out yet.
+pub fn sliver_geometry<P: PipelinePhase>(
+    owner: &PipelineOwner<P>,
+    id: RenderId,
+) -> Option<SliverGeometry> {
+    owner.render_tree().get(id)?.as_sliver()?.state().geometry()
+}
+
+/// Hit-tests at root-local `(x, y)` (logical pixels) and returns the
+/// leaf-first path of hit `RenderId`s.
+pub fn hit_path<P: PipelinePhase + Sync>(
+    owner: &PipelineOwner<P>,
+    x: f32,
+    y: f32,
+) -> Vec<RenderId> {
+    let mut result = HitTestResult::new();
+    owner.hit_test(Offset::new(px(x), px(y)), &mut result);
+    result.path().iter().map(|entry| entry.target).collect()
+}
+
+// ============================================================================
+// Render-tree diagnostics dump
+// ============================================================================
+
+/// Builds a [`DiagnosticsNode`] tree mirroring the render hierarchy. Each
+/// node self-describes via the render object's
+/// [`Diagnosticable`](flui_foundation::Diagnosticable) impl (color, padding,
+/// direction, ...); the committed geometry/offset is layered on, and the tree
+/// links supply the parent/child structure.
+///
+/// Delegates to [`PipelineOwner::debug_diagnostics_tree`] so the harness and
+/// the production debug dump share one walk.
+pub fn render_diagnostics<P: PipelinePhase>(owner: &PipelineOwner<P>) -> DiagnosticsNode {
+    owner
+        .debug_diagnostics_tree()
+        .unwrap_or_else(|| DiagnosticsNode::new("<no root>"))
+}
+
+// ============================================================================
+// Probe: the ergonomic inspection surface shared by both run results
+// ============================================================================
+
+/// Inspection surface shared by every run result, independent of protocol
+/// and of how far the pipeline was driven.
+///
+/// Implementors supply the underlying [`PipelineOwner`] and the label
+/// [`IdRegistry`]; the provided methods do the rest. Box trees read
+/// [`box_geometry`](Probe::box_geometry); Sliver trees read
+/// [`sliver_geometry`](Probe::sliver_geometry); everything else is common.
+pub trait Probe {
+    /// The pipeline phase the implementor holds its owner in.
+    type Phase: PipelinePhase + Sync;
+
+    /// The live pipeline owner backing the inspection.
+    fn pipeline(&self) -> &PipelineOwner<Self::Phase>;
+
+    /// The label -> id registry built while mounting the tree.
+    fn registry(&self) -> &IdRegistry;
+
+    /// A diagnostics tree mirroring the render hierarchy, with each node's
+    /// own properties plus committed geometry/offset.
+    fn diagnostics(&self) -> DiagnosticsNode {
+        render_diagnostics(self.pipeline())
+    }
+
+    /// The value of diagnostics property `name` on node `id` (e.g.
+    /// `property(child, "color")`), for structured assertions that don't
+    /// rely on substring-matching the dump.
+    fn property(&self, id: RenderId, name: &str) -> Option<String> {
+        self.pipeline()
+            .debug_node_diagnostics(id)
+            .and_then(|node| node.get_property(name).map(str::to_owned))
+    }
+
+    /// Parses a numeric diagnostics property on `id`, if present.
+    fn property_f64(&self, id: RenderId, name: &str) -> Option<f64> {
+        self.pipeline()
+            .debug_node_diagnostics(id)
+            .and_then(|node| node.get_property_f64(name))
+    }
+
+    /// Returns the first descendant's property value matched by render-object
+    /// type name (e.g. `"RenderColoredBox"`, `"RenderFlex"`).
+    fn descendant_property(&self, type_name: &str, property: &str) -> Option<String> {
+        self.diagnostics()
+            .find_descendant(type_name)?
+            .get_property(property)
+            .map(str::to_owned)
+    }
+
+    /// Parses a numeric property on the first descendant matched by `type_name`.
+    fn descendant_property_f64(&self, type_name: &str, property: &str) -> Option<f64> {
+        self.diagnostics()
+            .find_descendant(type_name)?
+            .get_property_f64(property)
+    }
+
+    /// A printable, indented dump of the render-tree diagnostics — what a
+    /// failing assertion should print to show *why*.
+    fn dump(&self) -> String {
+        self.diagnostics().to_string()
+    }
+
+    /// Resolves a node label to its `RenderId`, panicking if the label was
+    /// never registered (a test-authoring error).
+    fn id(&self, label: &str) -> RenderId {
+        self.try_id(label)
+            .unwrap_or_else(|| panic!("no render node labeled {label:?} in the test tree"))
+    }
+
+    /// Resolves a node label to its `RenderId`, or `None` if unknown.
+    fn try_id(&self, label: &str) -> Option<RenderId> {
+        self.registry().get(label)
+    }
+
+    /// The committed paint offset of `id`.
+    fn offset(&self, id: RenderId) -> Offset {
+        render_offset(self.pipeline(), id).expect("node must exist in the render tree")
+    }
+
+    /// The committed Box geometry (size) of `id`.
+    fn box_geometry(&self, id: RenderId) -> Size {
+        box_geometry(self.pipeline(), id).expect("node must be a laid-out Box node")
+    }
+
+    /// The committed Box geometry (size) of `id`, or `None`.
+    fn try_box_geometry(&self, id: RenderId) -> Option<Size> {
+        box_geometry(self.pipeline(), id)
+    }
+
+    /// The committed Sliver geometry of `id`.
+    fn sliver_geometry(&self, id: RenderId) -> SliverGeometry {
+        sliver_geometry(self.pipeline(), id).expect("node must be a laid-out Sliver node")
+    }
+
+    /// The committed Sliver geometry of `id`, or `None`.
+    fn try_sliver_geometry(&self, id: RenderId) -> Option<SliverGeometry> {
+        sliver_geometry(self.pipeline(), id)
+    }
+
+    /// Hit-tests at root-local `(x, y)` (logical pixels), returning the
+    /// leaf-first path of hit `RenderId`s.
+    fn hit(&self, x: f32, y: f32) -> Vec<RenderId> {
+        hit_path(self.pipeline(), x, y)
+    }
+
+    /// The first hit `RenderId` at `(x, y)`, if anything was hit.
+    fn hit_first(&self, x: f32, y: f32) -> Option<RenderId> {
+        self.hit(x, y).first().copied()
+    }
+}

--- a/crates/flui-rendering/src/testing/mod.rs
+++ b/crates/flui-rendering/src/testing/mod.rs
@@ -1,0 +1,72 @@
+//! Render-object test harness — build real trees, drive the production
+//! pipeline, inspect the result.
+//!
+//! Full API reference and examples: `crates/flui-rendering/docs/TESTING.md`.
+//!
+//! This module is compiled only for this crate's own tests (`cfg(test)`) or
+//! when a consumer enables the `testing` feature. It exists so render
+//! objects can be exercised through the **real** [`PipelineOwner`] pipeline
+//! (not mocks), with one ergonomic, protocol-agnostic surface.
+//!
+//! # Shape
+//!
+//! 1. Describe a tree with [`box_node`] / [`sliver_node`], nesting children,
+//!    tagging nodes with [`TreeNode::label`], and optionally attaching
+//!    [`ParentDataSeed`] presets (stack positioning, flex factors, …) via
+//!    [`TreeNode::with_parent_data_seed`].
+//! 2. Hand it to [`RenderTester::mount`] and pick a run depth — both apply
+//!    equally to Box and Sliver:
+//!    - [`RenderTester::run_layout`] -> [`LayoutRun`] (geometry/offsets,
+//!      no frame);
+//!    - [`RenderTester::run_frame`] -> [`FrameRun`] (full frame: layer
+//!      structure, picture bounds, [`FrameReport`], repeated `pump`).
+//! 3. Inspect via the shared [`Probe`] trait (`offset`, `box_geometry`,
+//!    `sliver_geometry`, `hit`, `id`).
+//! 4. Drive multi-frame / animation scenarios on [`FrameRun`]:
+//!    [`FrameRun::advance_layout`] / [`FrameRun::advance_paint`] (mutate +
+//!    one frame), [`FrameRun::simulate`] (tick loop + pump per step),
+//!    [`FrameRun::pump_frames`] / [`FrameRun::pump_idle_frames`] (skip settled
+//!    frames). Paint-only changes use [`FrameRun::update_paint`]; layout
+//!    changes use [`FrameRun::update`].
+//!
+//! [`PipelineOwner`]: crate::pipeline::PipelineOwner
+//!
+//! # Example
+//!
+//! ```
+//! use flui_rendering::objects::{RenderColoredBox, RenderPadding};
+//! use flui_rendering::testing::{RenderTester, Probe, box_node};
+//! use flui_types::{Offset, Size, geometry::px};
+//!
+//! let run = RenderTester::mount(
+//!     box_node(RenderPadding::all(5.0))
+//!         .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+//! )
+//! .with_size(Size::new(px(200.0), px(200.0)))
+//! .run_frame();
+//!
+//! let child = run.id("child");
+//! assert_eq!(run.offset(child), Offset::new(px(5.0), px(5.0)));
+//! assert!(run.painted());
+//! ```
+
+pub mod assertions;
+mod harness;
+pub mod inspect;
+pub mod parent_data;
+mod report;
+pub mod sliver;
+pub mod tree;
+
+pub use assertions::{
+    assert_descendant_properties, assert_has_committed_geometry, assert_has_committed_size,
+    assert_properties,
+};
+pub use harness::{FrameRun, LayoutRun, RenderTester};
+pub use inspect::Probe;
+pub use parent_data::ParentDataSeed;
+pub use report::FrameReport;
+pub use tree::{IdRegistry, TreeNode, box_node, box_node_boxed, sliver_node, sliver_node_boxed};
+
+#[cfg(test)]
+mod tests;

--- a/crates/flui-rendering/src/testing/mod.rs
+++ b/crates/flui-rendering/src/testing/mod.rs
@@ -26,8 +26,8 @@
 //!    [`FrameRun::advance_layout`] / [`FrameRun::advance_paint`] (mutate +
 //!    one frame), [`FrameRun::simulate`] (tick loop + pump per step),
 //!    [`FrameRun::pump_frames`] / [`FrameRun::pump_idle_frames`] (skip settled
-//!    frames). Paint-only changes use [`FrameRun::update_paint`]; layout
-//!    changes use [`FrameRun::update`].
+//!    frames). Layout changes use [`FrameRun::update`]; paint-only changes use
+//!    [`FrameRun::update_paint`] (Box and Sliver alike).
 //!
 //! [`PipelineOwner`]: crate::pipeline::PipelineOwner
 //!
@@ -66,7 +66,9 @@ pub use harness::{FrameRun, LayoutRun, RenderTester};
 pub use inspect::Probe;
 pub use parent_data::ParentDataSeed;
 pub use report::FrameReport;
-pub use tree::{IdRegistry, TreeNode, box_node, box_node_boxed, sliver_node, sliver_node_boxed};
+pub use tree::{
+    RenderLabelRegistry, TreeNode, box_node, box_node_boxed, sliver_node, sliver_node_boxed,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/flui-rendering/src/testing/parent_data.rs
+++ b/crates/flui-rendering/src/testing/parent_data.rs
@@ -1,0 +1,46 @@
+//! Cloneable parent-data presets for the render-object test harness.
+//!
+//! Production layout creates per-walk [`ErasedChildState`] slots with
+//! `parent_data: None` and lazily inserts `ParentData::default()` on the
+//! first mutable access. Widget configuration that lives on the child's
+//! parent data (stack positioning, flex factors, future animation parent
+//! slots) is normally applied by the element layer before layout; headless
+//! harness tests mount render objects directly, so [`ParentDataSeed`] bridges
+//! that gap by cloning a typed preset into the pipeline before each layout
+//! walk.
+//!
+//! Attach a seed to a [`TreeNode`](super::tree::TreeNode) via
+//! [`TreeNode::with_parent_data_seed`](super::tree::TreeNode::with_parent_data_seed)
+//! (or the `with_stack_parent_data` / `with_flex_parent_data` helpers).
+
+use crate::parent_data::{
+    BoxParentData, FlexParentData, ParentData, SliverPhysicalParentData, StackParentData,
+};
+
+/// A harness-side clone of the parent metadata a widget would normally
+/// write onto its child before layout.
+#[derive(Debug, Clone)]
+pub enum ParentDataSeed {
+    /// [`StackParentData`] for [`RenderStack`](crate::objects::RenderStack) children.
+    Stack(StackParentData),
+    /// [`FlexParentData`] for [`RenderFlex`](crate::objects::RenderFlex) children.
+    Flex(FlexParentData),
+    /// Default box offset slot (rarely needed — most parents use
+    /// [`StackParentData`] / [`FlexParentData`] instead).
+    Box(BoxParentData),
+    /// [`SliverPhysicalParentData`] for single-child sliver adapters.
+    SliverPhysical(SliverPhysicalParentData),
+}
+
+impl ParentDataSeed {
+    /// Materializes the seed into the erased slot the layout walk expects.
+    #[must_use]
+    pub fn to_box(&self) -> Box<dyn ParentData> {
+        match self {
+            Self::Stack(data) => Box::new(data.clone()),
+            Self::Flex(data) => Box::new(data.clone()),
+            Self::Box(data) => Box::new(data.clone()),
+            Self::SliverPhysical(data) => Box::new(data.clone()),
+        }
+    }
+}

--- a/crates/flui-rendering/src/testing/report.rs
+++ b/crates/flui-rendering/src/testing/report.rs
@@ -1,0 +1,53 @@
+//! A human-readable summary of a painted frame.
+//!
+//! [`FrameReport`] is what [`crate::testing::FrameRun::report`] /
+//! [`crate::testing::FrameRun::pump`] return. It is pure data plus a
+//! [`Display`](std::fmt::Display) impl so callers (e.g. the
+//! `render_inspector` example) can print it; the harness itself never
+//! writes to stdout.
+
+use std::fmt;
+
+use flui_types::Rect;
+
+/// A snapshot of the observable output of one frame.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FrameReport {
+    /// Whether the frame produced a layer tree (a clean idle frame produces
+    /// none).
+    pub painted: bool,
+    /// The composited layer kinds in pre-order, each with its depth from the
+    /// root.
+    pub structure: Vec<(usize, &'static str)>,
+    /// The bounds of the first picture layer, if any.
+    pub picture_bounds: Option<Rect>,
+    /// Whether the pipeline still has dirty nodes after the frame (a healthy
+    /// settled frame leaves none).
+    pub dirty: bool,
+}
+
+impl fmt::Display for FrameReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "painted: {}", self.painted)?;
+        writeln!(f, "dirty:   {}", self.dirty)?;
+        match self.picture_bounds {
+            Some(bounds) => writeln!(f, "picture: {bounds:?}")?,
+            None => writeln!(f, "picture: <none>")?,
+        }
+        if self.structure.is_empty() {
+            write!(f, "layers:  <none>")?;
+        } else {
+            writeln!(f, "layers:")?;
+            for (i, (depth, kind)) in self.structure.iter().enumerate() {
+                let indent = "  ".repeat(*depth);
+                let newline = if i + 1 == self.structure.len() {
+                    ""
+                } else {
+                    "\n"
+                };
+                write!(f, "  {indent}{kind}{newline}")?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/flui-rendering/src/testing/sliver.rs
+++ b/crates/flui-rendering/src/testing/sliver.rs
@@ -1,0 +1,129 @@
+//! Ergonomic [`SliverConstraints`] construction for tests.
+//!
+//! [`SliverConstraints`] is a wide plain-data struct; building one by hand
+//! is noisy and was duplicated as `vertical_constraints` /
+//! `horizontal_constraints` helpers across the sliver tests. This module
+//! offers a small builder that starts from a sensible viewport and lets a
+//! test override only the fields it cares about.
+//!
+//! The axis pair is derived for you: [`vertical`] scrolls top-to-bottom
+//! with a left-to-right cross axis, [`horizontal`] scrolls left-to-right
+//! with a top-to-bottom cross axis.
+
+use flui_types::layout::AxisDirection;
+
+use crate::{constraints::SliverConstraints, view::ScrollDirection};
+
+/// A chainable builder for [`SliverConstraints`].
+///
+/// Construct one with [`vertical`] or [`horizontal`], override extents with
+/// the setters, then call [`build`](SliverConstraintsBuilder::build).
+#[derive(Debug, Clone, Copy)]
+pub struct SliverConstraintsBuilder {
+    inner: SliverConstraints,
+}
+
+impl SliverConstraintsBuilder {
+    /// Sets the scroll offset.
+    #[must_use]
+    pub fn scroll_offset(mut self, value: f32) -> Self {
+        self.inner.scroll_offset = value;
+        self
+    }
+
+    /// Sets the remaining paint extent (viewport space available to paint).
+    #[must_use]
+    pub fn remaining_paint_extent(mut self, value: f32) -> Self {
+        self.inner.remaining_paint_extent = value;
+        self
+    }
+
+    /// Sets the cross-axis extent.
+    #[must_use]
+    pub fn cross_axis_extent(mut self, value: f32) -> Self {
+        self.inner.cross_axis_extent = value;
+        self
+    }
+
+    /// Sets the total viewport main-axis extent.
+    #[must_use]
+    pub fn viewport_main_axis_extent(mut self, value: f32) -> Self {
+        self.inner.viewport_main_axis_extent = value;
+        self
+    }
+
+    /// Sets the remaining cache extent.
+    #[must_use]
+    pub fn remaining_cache_extent(mut self, value: f32) -> Self {
+        self.inner.remaining_cache_extent = value;
+        self
+    }
+
+    /// Sets the cache origin (typically negative).
+    #[must_use]
+    pub fn cache_origin(mut self, value: f32) -> Self {
+        self.inner.cache_origin = value;
+        self
+    }
+
+    /// Sets the overlap with the preceding sliver.
+    #[must_use]
+    pub fn overlap(mut self, value: f32) -> Self {
+        self.inner.overlap = value;
+        self
+    }
+
+    /// Sets the scroll extent already consumed by preceding slivers.
+    #[must_use]
+    pub fn preceding_scroll_extent(mut self, value: f32) -> Self {
+        self.inner.preceding_scroll_extent = value;
+        self
+    }
+
+    /// Sets the user scroll direction.
+    #[must_use]
+    pub fn user_scroll_direction(mut self, value: ScrollDirection) -> Self {
+        self.inner.user_scroll_direction = value;
+        self
+    }
+
+    /// Finalizes the builder into [`SliverConstraints`].
+    #[must_use]
+    pub fn build(self) -> SliverConstraints {
+        self.inner
+    }
+}
+
+impl From<SliverConstraintsBuilder> for SliverConstraints {
+    fn from(builder: SliverConstraintsBuilder) -> Self {
+        builder.build()
+    }
+}
+
+/// A vertically-scrolling sliver constraint builder (main axis
+/// top-to-bottom, cross axis left-to-right), starting from
+/// [`SliverConstraints::default`].
+#[must_use]
+pub fn vertical() -> SliverConstraintsBuilder {
+    SliverConstraintsBuilder {
+        inner: SliverConstraints {
+            axis_direction: AxisDirection::TopToBottom,
+            cross_axis_direction: AxisDirection::LeftToRight,
+            ..SliverConstraints::default()
+        },
+    }
+}
+
+/// A horizontally-scrolling sliver constraint builder (main axis
+/// left-to-right, cross axis top-to-bottom), starting from
+/// [`SliverConstraints::default`].
+#[must_use]
+pub fn horizontal() -> SliverConstraintsBuilder {
+    SliverConstraintsBuilder {
+        inner: SliverConstraints {
+            axis_direction: AxisDirection::LeftToRight,
+            cross_axis_direction: AxisDirection::TopToBottom,
+            ..SliverConstraints::default()
+        },
+    }
+}

--- a/crates/flui-rendering/src/testing/tests.rs
+++ b/crates/flui-rendering/src/testing/tests.rs
@@ -1,0 +1,401 @@
+//! Self-tests for the test harness itself.
+//!
+//! Covers the full matrix — both protocols (Box, Sliver) crossed with both
+//! run depths (`run_layout`, `run_frame`) — so the harness is proven against
+//! known-good built-in render objects before any other test relies on it.
+//! Assertions mirror values already validated in `tests/pipeline_scenarios.rs`,
+//! `tests/layout_offset_commit.rs`, and `tests/sliver_fixed_extent_list.rs`.
+
+use flui_types::{EdgeInsets, Offset, Rect, Size, geometry::px, layout::AxisDirection};
+
+use crate::{
+    constraints::BoxConstraints,
+    objects::{
+        RenderColoredBox, RenderFlex, RenderOpacity, RenderPadding, RenderRepaintBoundary,
+        RenderSliverFixedExtentList, RenderStack, RenderViewport,
+    },
+    parent_data::{FlexParentData, StackParentData},
+    testing::{Probe, RenderTester, box_node, sliver_node},
+};
+
+/// Loose `0..=200 x 0..=200` constraints: children settle at their natural
+/// size rather than being forced to fill (the box-pipeline test default).
+fn loose_200() -> BoxConstraints {
+    BoxConstraints::new(px(0.0), px(200.0), px(0.0), px(200.0))
+}
+
+// ============================================================================
+// Box x run_frame
+// ============================================================================
+
+#[test]
+fn box_run_frame_padding_offsets_and_single_picture() {
+    let run = RenderTester::mount(
+        box_node(RenderPadding::all(5.0))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose_200())
+    .run_frame();
+
+    assert!(run.painted(), "first frame must paint");
+    assert!(run.is_clean(), "no dirty residue after a settled frame");
+
+    let child = run.id("child");
+    assert_eq!(run.offset(child), Offset::new(px(5.0), px(5.0)));
+    assert_eq!(run.box_geometry(child), Size::new(px(40.0), px(40.0)));
+    assert_eq!(run.structure(), vec!["Offset", "Picture"]);
+    assert_eq!(
+        run.picture_bounds(),
+        Some(Rect::from_ltrb(px(5.0), px(5.0), px(45.0), px(45.0))),
+    );
+}
+
+#[test]
+fn box_run_frame_flex_row_lays_children_along_main_axis() {
+    let run = RenderTester::mount(
+        box_node(RenderFlex::row())
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("red"))
+            .child(box_node(RenderColoredBox::green(60.0, 40.0)).label("green"))
+            .child(box_node(RenderColoredBox::blue(20.0, 40.0)).label("blue")),
+    )
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_frame();
+
+    assert_eq!(run.offset(run.id("red")), Offset::new(px(0.0), px(0.0)));
+    assert_eq!(run.offset(run.id("green")), Offset::new(px(40.0), px(0.0)));
+    assert_eq!(run.offset(run.id("blue")), Offset::new(px(100.0), px(0.0)));
+}
+
+#[test]
+fn box_run_layout_stack_positioned_child_respects_parent_data_seed() {
+    let run = RenderTester::mount(
+        box_node(RenderStack::new())
+            .child(box_node(RenderColoredBox::red(80.0, 80.0)).label("base"))
+            .child(
+                box_node(RenderColoredBox::green(20.0, 20.0))
+                    .with_stack_parent_data(StackParentData::new().with_top(12.0).with_left(18.0))
+                    .label("positioned"),
+            ),
+    )
+    .with_size(Size::new(px(120.0), px(120.0)))
+    .run_layout();
+
+    assert_eq!(
+        run.offset(run.id("positioned")),
+        Offset::new(px(18.0), px(12.0))
+    );
+    assert_eq!(run.hit_first(25.0, 20.0), Some(run.id("positioned")));
+}
+
+#[test]
+fn box_run_layout_flex_child_honors_flex_parent_data_seed() {
+    let run = RenderTester::mount(
+        box_node(RenderFlex::row())
+            .child(box_node(RenderColoredBox::red(40.0, 20.0)).label("fixed"))
+            .child(
+                box_node(RenderColoredBox::green(10.0, 20.0))
+                    .with_flex_parent_data(FlexParentData::flexible(1))
+                    .label("flex"),
+            ),
+    )
+    .with_size(Size::new(px(200.0), px(60.0)))
+    .run_layout();
+
+    assert_eq!(run.box_geometry(run.id("flex")).width, px(160.0));
+    assert_eq!(run.offset(run.id("flex")), Offset::new(px(40.0), px(0.0)));
+}
+
+#[test]
+fn box_run_frame_repaint_boundary_splits_subtree() {
+    let run = RenderTester::mount(box_node(RenderPadding::all(5.0)).child(
+        box_node(RenderRepaintBoundary::new()).child(box_node(RenderColoredBox::red(40.0, 40.0))),
+    ))
+    .with_constraints(loose_200())
+    .run_frame();
+
+    assert_eq!(
+        run.structure(),
+        vec!["Offset", "Offset", "Picture"],
+        "the boundary subtree splits under its own OffsetLayer",
+    );
+}
+
+#[test]
+fn box_run_frame_clean_frame_after_settle_produces_no_tree() {
+    let mut run = RenderTester::mount(box_node(RenderColoredBox::red(40.0, 40.0)))
+        .with_size(Size::new(px(100.0), px(100.0)))
+        .run_frame();
+
+    assert!(run.painted(), "frame 1 paints");
+
+    let report = run.pump();
+    assert!(
+        !report.painted,
+        "a frame with no dirty work must produce no layer tree",
+    );
+    assert!(run.is_clean());
+}
+
+#[test]
+fn box_run_frame_hit_path_routes_to_child() {
+    let run = RenderTester::mount(
+        box_node(RenderPadding::all(5.0))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose_200())
+    .run_frame();
+
+    let child = run.id("child");
+    assert_eq!(run.hit_first(10.0, 10.0), Some(child));
+    assert!(
+        run.hit(2.0, 2.0).is_empty(),
+        "the padding border (outside the child) misses",
+    );
+}
+
+#[test]
+fn render_dump_carries_object_properties_and_geometry() {
+    let run = RenderTester::mount(
+        box_node(RenderPadding::all(5.0))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose_200())
+    .run_frame();
+
+    let dump = run.dump();
+    assert!(dump.contains("RenderPadding"), "names the padding: {dump}");
+    assert!(dump.contains("RenderColoredBox"), "names the leaf: {dump}");
+    assert!(
+        dump.contains("padding"),
+        "padding self-describes its insets: {dump}"
+    );
+    assert!(
+        dump.contains("color"),
+        "leaf self-describes its color: {dump}"
+    );
+    assert!(
+        dump.contains("size"),
+        "committed size is layered on: {dump}"
+    );
+}
+
+#[test]
+fn structured_diagnostics_queries() {
+    let run = RenderTester::mount(
+        box_node(RenderFlex::row()).child(box_node(RenderColoredBox::red(40.0, 40.0)).label("red")),
+    )
+    .with_constraints(loose_200())
+    .run_frame();
+
+    // Per-node property lookup (no substring matching on the dump).
+    assert_eq!(
+        run.property(run.root(), "direction").as_deref(),
+        Some("Horizontal"),
+    );
+    assert_eq!(
+        run.property(run.id("red"), "color").as_deref(),
+        Some("[1.0, 0.0, 0.0, 1.0]"),
+    );
+
+    // Depth-first tree navigation (works regardless of nesting depth).
+    let tree = run.diagnostics();
+    let leaf = tree
+        .find_descendant("RenderColoredBox")
+        .expect("tree has a colored leaf");
+    assert_eq!(leaf.get_property("color"), Some("[1.0, 0.0, 0.0, 1.0]"));
+
+    assert_eq!(
+        run.descendant_property("RenderFlex", "direction")
+            .as_deref(),
+        Some("Horizontal"),
+    );
+    assert_eq!(
+        run.descendant_property("RenderColoredBox", "color")
+            .as_deref(),
+        Some("[1.0, 0.0, 0.0, 1.0]"),
+    );
+}
+
+#[test]
+fn pump_idle_frames_skips_settled_frames() {
+    let mut run = RenderTester::mount(box_node(RenderColoredBox::red(40.0, 40.0)))
+        .with_size(Size::new(px(100.0), px(100.0)))
+        .run_frame();
+
+    run.pump_idle_frames(3);
+}
+
+#[test]
+fn simulate_advances_layout_across_ticks() {
+    let mut run = RenderTester::mount(
+        box_node(RenderPadding::all(5.0))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose_200())
+    .run_frame();
+
+    let child = run.id("child");
+    let pad = run.root();
+    let reports = run.simulate([0.25, 0.5, 1.0], |t, run| {
+        let padding = 5.0 + 50.0 * t as f32;
+        run.update::<RenderPadding>(pad, |p| {
+            p.set_padding(EdgeInsets::all(px(padding)));
+        });
+    });
+
+    assert_eq!(reports.len(), 3);
+    assert!(reports.iter().all(|r| r.painted));
+    assert_eq!(run.offset(child), Offset::new(px(55.0), px(55.0)));
+    assert_eq!(
+        run.picture_bounds(),
+        Some(Rect::from_ltrb(px(55.0), px(55.0), px(95.0), px(95.0))),
+    );
+}
+
+#[test]
+fn advance_paint_changes_color_without_layout() {
+    let mut run = RenderTester::mount(box_node(RenderColoredBox::red(40.0, 40.0)).label("leaf"))
+        .with_size(Size::new(px(100.0), px(100.0)))
+        .run_frame();
+
+    let leaf = run.id("leaf");
+    let report = run.advance_paint::<RenderColoredBox>(leaf, |box_| {
+        box_.set_color([0.0, 1.0, 0.0, 1.0]);
+    });
+
+    assert!(report.painted);
+    assert_eq!(
+        run.property(leaf, "color").as_deref(),
+        Some("[0.0, 1.0, 0.0, 1.0]"),
+    );
+}
+
+#[test]
+fn advance_paint_opacity_tracks_layer_alpha() {
+    let mut run = RenderTester::mount(
+        box_node(RenderOpacity::new(1.0))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_size(Size::new(px(100.0), px(100.0)))
+    .run_frame();
+
+    let fade = run.root();
+    let report = run.advance_paint::<RenderOpacity>(fade, |o| o.set_opacity(0.5));
+    assert!(report.painted, "opacity change must repaint: {report}");
+    assert!(
+        run.structure().contains(&"Opacity"),
+        "semi-opaque subtree must pay for an OpacityLayer: {:?}",
+        run.structure(),
+    );
+    assert!(
+        (run.opacity_alpha().expect("opacity layer present") - 0.5).abs() < 0.01,
+        "opacity layer alpha must track the animated value",
+    );
+    assert!(run.has_picture_layer());
+}
+
+#[test]
+fn update_then_pump_relayouts() {
+    let mut run = RenderTester::mount(
+        box_node(RenderPadding::all(5.0))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose_200())
+    .run_frame();
+
+    let child = run.id("child");
+    assert_eq!(run.offset(child), Offset::new(px(5.0), px(5.0)));
+
+    run.update::<RenderPadding>(run.root(), |padding| {
+        padding.set_padding(EdgeInsets::all(px(20.0)));
+    });
+    run.pump();
+
+    assert_eq!(run.offset(child), Offset::new(px(20.0), px(20.0)));
+}
+
+// ============================================================================
+// Box x run_layout
+// ============================================================================
+
+#[test]
+fn box_run_layout_commits_geometry_without_a_frame() {
+    let run = RenderTester::mount(
+        box_node(RenderPadding::all(8.0))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("inner")),
+    )
+    .with_size(Size::new(px(200.0), px(200.0)))
+    .run_layout();
+
+    assert_eq!(
+        run.box_geometry(run.root()),
+        Size::new(px(200.0), px(200.0))
+    );
+
+    let inner = run.id("inner");
+    assert_eq!(run.offset(inner), Offset::new(px(8.0), px(8.0)));
+    assert_eq!(run.box_geometry(inner), Size::new(px(184.0), px(184.0)));
+}
+
+// ============================================================================
+// Sliver x run_layout
+// ============================================================================
+
+#[test]
+fn sliver_run_layout_fixed_extent_list_geometry_and_child_sizes() {
+    let run = RenderTester::mount(
+        box_node(RenderViewport::new(AxisDirection::TopToBottom)).child(
+            sliver_node(RenderSliverFixedExtentList::new(30.0))
+                .label("list")
+                .child(box_node(RenderColoredBox::red(300.0, 1000.0)).label("item0"))
+                .child(box_node(RenderColoredBox::green(300.0, 1000.0)))
+                .child(box_node(RenderColoredBox::blue(300.0, 1000.0))),
+        ),
+    )
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    let geometry = run.sliver_geometry(run.id("list"));
+    assert_eq!(geometry.scroll_extent, 90.0, "3 items x 30px main extent");
+
+    // Each box child is sized to the cross extent x the item extent.
+    assert_eq!(
+        run.box_geometry(run.id("item0")),
+        Size::new(px(300.0), px(30.0))
+    );
+}
+
+// ============================================================================
+// Sliver x run_frame (smoke)
+// ============================================================================
+
+#[test]
+fn sliver_run_frame_viewport_paints() {
+    let run = RenderTester::mount(
+        box_node(RenderViewport::new(AxisDirection::TopToBottom)).child(
+            sliver_node(RenderSliverFixedExtentList::new(30.0))
+                .child(box_node(RenderColoredBox::red(300.0, 1000.0)))
+                .child(box_node(RenderColoredBox::green(300.0, 1000.0))),
+        ),
+    )
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_frame();
+
+    assert!(
+        run.painted(),
+        "a viewport-rooted sliver tree paints a frame"
+    );
+    assert!(run.is_clean(), "no dirty residue after the frame settles");
+}
+
+// ============================================================================
+// Label registry
+// ============================================================================
+
+#[test]
+fn unknown_label_resolves_to_none() {
+    let run = RenderTester::mount(box_node(RenderColoredBox::red(10.0, 10.0)))
+        .with_size(Size::new(px(50.0), px(50.0)))
+        .run_layout();
+    assert!(run.try_id("missing").is_none());
+}

--- a/crates/flui-rendering/src/testing/tree.rs
+++ b/crates/flui-rendering/src/testing/tree.rs
@@ -1,0 +1,220 @@
+//! Declarative render-tree specification shared by both protocols.
+//!
+//! A [`TreeNode`] is a protocol-tagged spec: it carries either a
+//! [`BoxProtocol`] or a [`SliverProtocol`] render object, an optional
+//! `&'static str` label, and an ordered list of child specs. [`mount`]
+//! walks the spec top-down and inserts every node into a live
+//! [`PipelineOwner`], dispatching to the correct insertion API by the
+//! *child's* protocol:
+//!
+//! - Box child -> [`PipelineOwner::insert_child_render_object`] (full dirty
+//!   tracking, the same path the box pipeline tests use);
+//! - Sliver child -> [`crate::storage::RenderTree::insert_sliver_child`]
+//!   (the path the sliver tests use; the root layout pass cascades into
+//!   the sliver subtree).
+//!
+//! The tree root must be a Box render object — the layout pass drives the
+//! root via [`BoxConstraints`](crate::constraints::BoxConstraints), and
+//! slivers are laid out by a Box viewport/host parent, never as a bare
+//! root.
+
+use std::collections::HashMap;
+
+use flui_foundation::RenderId;
+
+use crate::{
+    parent_data::{FlexParentData, StackParentData},
+    pipeline::{Idle, PipelineOwner},
+    protocol::{BoxProtocol, SliverProtocol},
+    testing::parent_data::ParentDataSeed,
+    traits::RenderObject,
+};
+
+/// The render-object payload carried by a [`TreeNode`], tagged by protocol.
+enum NodePayload {
+    /// A Box-protocol render object.
+    Box(Box<dyn RenderObject<BoxProtocol>>),
+    /// A Sliver-protocol render object.
+    Sliver(Box<dyn RenderObject<SliverProtocol>>),
+}
+
+/// A single node in a declarative render-tree spec.
+///
+/// Build one with [`box_node`] or [`sliver_node`], attach children with
+/// [`child`](TreeNode::child) / [`children`](TreeNode::children), and tag a
+/// node with [`label`](TreeNode::label) so it can be looked up by name
+/// after mounting (see [`crate::testing::Probe::id`]).
+pub struct TreeNode {
+    payload: NodePayload,
+    label: Option<&'static str>,
+    /// Parent metadata the child's layout parent reads during
+    /// `perform_layout` (stack positioning, flex factor, …).
+    parent_data_seed: Option<ParentDataSeed>,
+    children: Vec<TreeNode>,
+}
+
+/// Creates a Box-protocol node from any concrete `RenderBox`-derived render
+/// object.
+pub fn box_node<R>(render_object: R) -> TreeNode
+where
+    R: RenderObject<BoxProtocol> + 'static,
+{
+    box_node_boxed(Box::new(render_object))
+}
+
+/// Creates a Box-protocol node from an already-boxed trait object.
+///
+/// Use this when the render object is only available as a
+/// `Box<dyn RenderObject<BoxProtocol>>` (e.g. produced by a factory).
+pub fn box_node_boxed(render_object: Box<dyn RenderObject<BoxProtocol>>) -> TreeNode {
+    TreeNode {
+        payload: NodePayload::Box(render_object),
+        label: None,
+        parent_data_seed: None,
+        children: Vec::new(),
+    }
+}
+
+/// Creates a Sliver-protocol node from any concrete `RenderSliver`-derived
+/// render object.
+pub fn sliver_node<R>(render_object: R) -> TreeNode
+where
+    R: RenderObject<SliverProtocol> + 'static,
+{
+    sliver_node_boxed(Box::new(render_object))
+}
+
+/// Creates a Sliver-protocol node from an already-boxed trait object.
+pub fn sliver_node_boxed(render_object: Box<dyn RenderObject<SliverProtocol>>) -> TreeNode {
+    TreeNode {
+        payload: NodePayload::Sliver(render_object),
+        label: None,
+        parent_data_seed: None,
+        children: Vec::new(),
+    }
+}
+
+impl TreeNode {
+    /// Tags this node with a label so it can be resolved to its `RenderId`
+    /// after mounting via [`crate::testing::Probe::id`].
+    #[must_use]
+    pub fn label(mut self, label: &'static str) -> Self {
+        self.label = Some(label);
+        self
+    }
+
+    /// Appends a single child spec.
+    #[must_use]
+    pub fn child(mut self, child: TreeNode) -> Self {
+        self.children.push(child);
+        self
+    }
+
+    /// Appends every child spec from an iterator.
+    #[must_use]
+    pub fn children(mut self, children: impl IntoIterator<Item = TreeNode>) -> Self {
+        self.children.extend(children);
+        self
+    }
+
+    /// Attaches a [`ParentDataSeed`] cloned into the pipeline before each
+    /// layout walk so parents that read child parent data (stack, flex, …)
+    /// see widget-level configuration in headless tests.
+    #[must_use]
+    pub fn with_parent_data_seed(mut self, seed: ParentDataSeed) -> Self {
+        self.parent_data_seed = Some(seed);
+        self
+    }
+
+    /// Convenience wrapper for [`StackParentData`] on [`RenderStack`] children.
+    #[must_use]
+    pub fn with_stack_parent_data(self, data: StackParentData) -> Self {
+        self.with_parent_data_seed(ParentDataSeed::Stack(data))
+    }
+
+    /// Convenience wrapper for [`FlexParentData`] on [`RenderFlex`] children.
+    #[must_use]
+    pub fn with_flex_parent_data(self, data: FlexParentData) -> Self {
+        self.with_parent_data_seed(ParentDataSeed::Flex(data))
+    }
+}
+
+/// Maps `&'static str` labels to the `RenderId`s minted while mounting a
+/// [`TreeNode`] spec.
+///
+/// Produced by [`mount`] and carried by the run results so assertions can
+/// reference nodes by name instead of threading raw ids around.
+#[derive(Debug, Default, Clone)]
+pub struct IdRegistry {
+    by_label: HashMap<&'static str, RenderId>,
+}
+
+impl IdRegistry {
+    /// Records a label -> id mapping, panicking on a duplicate label (a
+    /// duplicate is a test-authoring bug, not a runtime condition).
+    fn record(&mut self, label: &'static str, id: RenderId) {
+        if self.by_label.insert(label, id).is_some() {
+            panic!("duplicate node label in test tree: {label:?}");
+        }
+    }
+
+    /// Returns the id for `label`, if one was registered.
+    #[must_use]
+    pub fn get(&self, label: &str) -> Option<RenderId> {
+        self.by_label.get(label).copied()
+    }
+}
+
+/// Inserts a [`TreeNode`] spec into `owner`, returning the root id and the
+/// label registry.
+///
+/// The root must be a Box node; a Sliver root panics with a clear message.
+pub fn mount(owner: &mut PipelineOwner<Idle>, spec: TreeNode) -> (RenderId, IdRegistry) {
+    let mut registry = IdRegistry::default();
+    let root_id = match spec.payload {
+        NodePayload::Box(render_object) => owner.insert(render_object),
+        NodePayload::Sliver(_) => panic!(
+            "the root of a test tree must be a Box render object; slivers are driven \
+             by a Box viewport/host root (mount a `box_node(..)` and nest the sliver under it)"
+        ),
+    };
+    if let Some(label) = spec.label {
+        registry.record(label, root_id);
+    }
+    if let Some(seed) = spec.parent_data_seed {
+        owner.seed_parent_data(root_id, seed);
+    }
+    for child in spec.children {
+        mount_child(owner, root_id, child, &mut registry);
+    }
+    (root_id, registry)
+}
+
+/// Recursively inserts `spec` as a child of `parent_id`.
+fn mount_child(
+    owner: &mut PipelineOwner<Idle>,
+    parent_id: RenderId,
+    spec: TreeNode,
+    registry: &mut IdRegistry,
+) {
+    let id = match spec.payload {
+        NodePayload::Box(render_object) => owner
+            .insert_child_render_object(parent_id, render_object)
+            .expect("Box child insert must succeed: the parent id was just inserted and is valid"),
+        NodePayload::Sliver(render_object) => owner
+            .render_tree_mut()
+            .insert_sliver_child(parent_id, render_object)
+            .expect(
+                "Sliver child insert must succeed: the parent id was just inserted and is valid",
+            ),
+    };
+    if let Some(label) = spec.label {
+        registry.record(label, id);
+    }
+    if let Some(seed) = spec.parent_data_seed {
+        owner.seed_parent_data(id, seed);
+    }
+    for child in spec.children {
+        mount_child(owner, id, child, registry);
+    }
+}

--- a/crates/flui-rendering/src/testing/tree.rs
+++ b/crates/flui-rendering/src/testing/tree.rs
@@ -145,11 +145,11 @@ impl TreeNode {
 /// Produced by [`mount`] and carried by the run results so assertions can
 /// reference nodes by name instead of threading raw ids around.
 #[derive(Debug, Default, Clone)]
-pub struct IdRegistry {
+pub struct RenderLabelRegistry {
     by_label: HashMap<&'static str, RenderId>,
 }
 
-impl IdRegistry {
+impl RenderLabelRegistry {
     /// Records a label -> id mapping, panicking on a duplicate label (a
     /// duplicate is a test-authoring bug, not a runtime condition).
     fn record(&mut self, label: &'static str, id: RenderId) {
@@ -169,8 +169,8 @@ impl IdRegistry {
 /// label registry.
 ///
 /// The root must be a Box node; a Sliver root panics with a clear message.
-pub fn mount(owner: &mut PipelineOwner<Idle>, spec: TreeNode) -> (RenderId, IdRegistry) {
-    let mut registry = IdRegistry::default();
+pub fn mount(owner: &mut PipelineOwner<Idle>, spec: TreeNode) -> (RenderId, RenderLabelRegistry) {
+    let mut registry = RenderLabelRegistry::default();
     let root_id = match spec.payload {
         NodePayload::Box(render_object) => owner.insert(render_object),
         NodePayload::Sliver(_) => panic!(
@@ -195,7 +195,7 @@ fn mount_child(
     owner: &mut PipelineOwner<Idle>,
     parent_id: RenderId,
     spec: TreeNode,
-    registry: &mut IdRegistry,
+    registry: &mut RenderLabelRegistry,
 ) {
     let id = match spec.payload {
         NodePayload::Box(render_object) => owner

--- a/crates/flui-rendering/tests/animation_pipeline.rs
+++ b/crates/flui-rendering/tests/animation_pipeline.rs
@@ -23,12 +23,12 @@ use std::time::Duration;
 
 use flui_animation::{Animation, AnimationController};
 use flui_layer::{Layer, LayerTree};
-use flui_painting::DisplayListCore;
 use flui_rendering::{
     constraints::BoxConstraints,
     hit_testing::HitTestResult,
     objects::{RenderColoredBox, RenderOpacity, RenderPadding, RenderTransform},
     pipeline::PipelineOwner,
+    testing::inspect,
 };
 use flui_scheduler::Scheduler;
 use flui_types::{EdgeInsets, Matrix4, Offset, Size, geometry::px};
@@ -46,12 +46,7 @@ fn frame(owner: PipelineOwner) -> (PipelineOwner, Option<LayerTree>) {
 }
 
 fn state_offset(owner: &PipelineOwner, id: flui_foundation::RenderId) -> Offset {
-    owner
-        .render_tree()
-        .get(id)
-        .and_then(|n| n.as_box())
-        .map(|e| e.state().offset())
-        .expect("node state")
+    inspect::render_offset(owner, id).expect("node state")
 }
 
 fn set_padding(owner: &mut PipelineOwner, id: flui_foundation::RenderId, value: f32) {
@@ -110,16 +105,7 @@ fn animated_padding_tracks_controller_value_across_frames() {
             "frame {i}: committed offset must equal the animated padding",
         );
         // The picture's bounds track the animated origin exactly.
-        let bounds = {
-            fn find(tree: &LayerTree, id: flui_foundation::LayerId) -> Option<flui_types::Rect> {
-                let node = tree.get(id)?;
-                if let Layer::Picture(p) = node.layer() {
-                    return Some(p.picture().bounds());
-                }
-                node.children().iter().find_map(|&c| find(tree, c))
-            }
-            find(&tree, tree.root().expect("root")).expect("picture")
-        };
+        let bounds = inspect::first_picture_bounds(&tree).expect("picture");
         assert_eq!(
             bounds,
             flui_types::Rect::from_ltrb(

--- a/crates/flui-rendering/tests/harness_animation.rs
+++ b/crates/flui-rendering/tests/harness_animation.rs
@@ -1,0 +1,71 @@
+//! AnimationController-driven scenarios through the render harness.
+//!
+//! Mirrors `animation_pipeline.rs` but uses [`RenderTester`] /
+//! [`FrameRun::advance_layout`] instead of hand-rolled `PipelineOwner` wiring.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use flui_animation::{Animation, AnimationController};
+use flui_rendering::{
+    constraints::BoxConstraints,
+    objects::{RenderColoredBox, RenderPadding},
+    testing::{Probe, RenderTester, box_node},
+};
+use flui_scheduler::Scheduler;
+use flui_types::{EdgeInsets, Offset, Rect, geometry::px};
+
+fn controller() -> AnimationController {
+    AnimationController::new(Duration::from_secs(1), Arc::new(Scheduler::new()))
+}
+
+#[test]
+fn harness_advance_layout_follows_animation_controller() {
+    let mut run = RenderTester::mount(
+        box_node(RenderPadding::all(5.0))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(BoxConstraints::new(px(0.0), px(300.0), px(0.0), px(300.0)))
+    .run_frame();
+
+    let ctrl = controller();
+    ctrl.forward().expect("forward");
+
+    let child = run.id("child");
+    let pad = run.root();
+
+    for (i, t) in [0.0f64, 0.25, 0.5, 0.75, 1.0].iter().enumerate() {
+        ctrl.tick_at(*t);
+        let padding = 5.0 + 50.0 * ctrl.value();
+        let report = run.advance_layout::<RenderPadding>(pad, |p| {
+            p.set_padding(EdgeInsets::all(px(padding)));
+        });
+        assert!(report.painted, "animation frame {i} must paint");
+
+        assert_eq!(
+            run.offset(child),
+            Offset::new(px(padding), px(padding)),
+            "frame {i}: committed offset must equal animated padding",
+        );
+        let bounds = run
+            .picture_bounds()
+            .expect("animated frame must paint a picture");
+        assert_eq!(
+            bounds,
+            Rect::from_ltrb(
+                px(padding),
+                px(padding),
+                px(padding + 40.0),
+                px(padding + 40.0),
+            ),
+            "frame {i}: picture bounds must track the animated origin",
+        );
+    }
+
+    assert!(
+        ctrl.value() >= 1.0 - f32::EPSILON,
+        "controller reached its upper bound",
+    );
+
+    run.pump_idle_frames(2);
+}

--- a/crates/flui-rendering/tests/hit_test_pipeline.rs
+++ b/crates/flui-rendering/tests/hit_test_pipeline.rs
@@ -14,7 +14,6 @@
 use flui_rendering::{
     constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
     context::{BoxHitTestContext, BoxLayoutContext, SliverHitTestContext, SliverLayoutContext},
-    hit_testing::HitTestResult,
     objects::{
         RenderColoredBox, RenderFlex, RenderPadding, RenderSliverIgnorePointer,
         RenderSliverOpacity, RenderSliverPadding, RenderTransform,
@@ -22,6 +21,7 @@ use flui_rendering::{
     parent_data::{BoxParentData, SliverParentData},
     pipeline::PipelineOwner,
     protocol::{BoxProtocol, SliverProtocol},
+    testing::inspect,
     traits::{
         HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, RenderSliver,
         SemanticsCapability,
@@ -56,20 +56,14 @@ fn hits(
     x: f32,
     y: f32,
 ) -> Vec<flui_foundation::RenderId> {
-    let mut result = HitTestResult::new();
-    owner.hit_test(Offset::new(px(x), px(y)), &mut result);
-    result.path().iter().map(|e| e.target).collect()
+    inspect::hit_path(owner, x, y)
 }
 
 fn render_offset(
     owner: &flui_rendering::pipeline::PipelineOwner<flui_rendering::pipeline::phase::Layout>,
     id: flui_foundation::RenderId,
 ) -> Offset {
-    owner
-        .render_tree()
-        .get(id)
-        .map(flui_rendering::storage::RenderNode::offset)
-        .expect("node exists")
+    inspect::render_offset(owner, id).expect("node exists")
 }
 
 // ============================================================================

--- a/crates/flui-rendering/tests/layout_offset_commit.rs
+++ b/crates/flui-rendering/tests/layout_offset_commit.rs
@@ -2,16 +2,15 @@
 //!
 //! The layout walk builds a transient `Vec<ChildState>` per parent; the
 //! offsets `perform_layout` writes via `ctx.position_child` historically
-//! died with that stack frame (`RenderState::set_offset` had zero
-//! production callers). Paint and hit-test read `RenderState.offset` as
-//! the authoritative child position, so without the commit every child
+//! died with that stack frame. Paint and hit-test read `RenderState.offset`
+//! as the authoritative child position, so without the commit every child
 //! would render at the parent origin.
 //!
-//! These tests pin the commit contract:
+//! These tests pin the commit contract, expressed via the
+//! `flui_rendering::testing` harness at `run_layout` depth (Box, layout-only):
 //! 1. positioned offsets are persisted after `run_layout`;
-//! 2. re-layout overwrites with fresh positions;
-//! 3. a child the parent does NOT position keeps its prior offset
-//!    (seed-from-state semantics, Flutter `BoxParentData.offset` parity).
+//! 2. re-layout overwrites with fresh positions (`update` + `relayout`);
+//! 3. a child the parent does NOT position keeps its prior offset.
 //!
 //! Refs:
 //!   * docs/research/2026-06-10-rendering-design-amendments.md §D9.1
@@ -21,25 +20,15 @@ use flui_rendering::{
     context::{BoxHitTestContext, BoxLayoutContext},
     objects::{RenderColoredBox, RenderPadding},
     parent_data::BoxParentData,
-    pipeline::PipelineOwner,
+    testing::{Probe, RenderTester, box_node},
     traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability},
 };
 use flui_tree::Variable;
-use flui_types::{Offset, Size, geometry::px};
+use flui_types::{EdgeInsets, Offset, Size, geometry::px};
 
-/// Reads the committed offset off a node's persistent `RenderState`.
-fn state_offset(
-    owner: &flui_rendering::pipeline::PipelineOwner<flui_rendering::pipeline::phase::Layout>,
-    id: flui_foundation::RenderId,
-) -> Offset {
-    owner
-        .render_tree()
-        .get(id)
-        .expect("node must be in tree")
-        .as_box()
-        .expect("node must be Box-protocol")
-        .state()
-        .offset()
+/// Loose `0..=200 x 0..=200` root constraints shared by every scenario.
+fn constraints() -> BoxConstraints {
+    BoxConstraints::new(px(0.0), px(200.0), px(0.0), px(200.0))
 }
 
 // ============================================================================
@@ -48,33 +37,22 @@ fn state_offset(
 
 #[test]
 fn run_layout_commits_positioned_offsets_to_render_state() {
-    let mut owner = PipelineOwner::new();
-    let padding_id = owner.insert(Box::new(RenderPadding::all(5.0))
-        as Box<
-            dyn flui_rendering::traits::RenderObject<flui_rendering::protocol::BoxProtocol>,
-        >);
-    let child_id = owner
-        .insert_child_render_object(padding_id, Box::new(RenderColoredBox::red(40.0, 40.0)))
-        .expect("colored child insert");
-
-    owner.set_root_id(Some(padding_id));
-    owner.set_root_constraints(Some(BoxConstraints::new(
-        px(0.0),
-        px(200.0),
-        px(0.0),
-        px(200.0),
-    )));
-
-    let mut owner = owner.into_layout();
-    owner.run_layout().expect("first-frame run_layout");
+    let run = RenderTester::mount(
+        box_node(RenderPadding::all(5.0))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(constraints())
+    .run_layout();
 
     assert_eq!(
-        state_offset(&owner, child_id),
+        run.offset(run.id("child")),
         Offset::new(px(5.0), px(5.0)),
-        "Padding(5) positions its child at (5,5) via position_child; \
-         the layout walk must commit that offset into the child's \
-         RenderState.offset, not drop it with the transient ChildState vec",
+        "Padding(5) positions its child at (5,5) via position_child; the \
+         layout walk must commit that offset into RenderState.offset, not \
+         drop it with the transient ChildState vec",
     );
+    // The padding self-describes its insets through the layout pass.
+    assert!(run.property(run.root(), "padding").is_some());
 }
 
 // ============================================================================
@@ -83,53 +61,27 @@ fn run_layout_commits_positioned_offsets_to_render_state() {
 
 #[test]
 fn relayout_overwrites_committed_offset() {
-    let mut owner = PipelineOwner::new();
-    let padding_id = owner.insert(Box::new(RenderPadding::all(5.0))
-        as Box<
-            dyn flui_rendering::traits::RenderObject<flui_rendering::protocol::BoxProtocol>,
-        >);
-    let child_id = owner
-        .insert_child_render_object(padding_id, Box::new(RenderColoredBox::blue(40.0, 40.0)))
-        .expect("colored child insert");
+    let mut run = RenderTester::mount(
+        box_node(RenderPadding::all(5.0))
+            .child(box_node(RenderColoredBox::blue(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(constraints())
+    .run_layout();
+    let pad = run.root();
+    let child = run.id("child");
 
-    owner.set_root_id(Some(padding_id));
-    owner.set_root_constraints(Some(BoxConstraints::new(
-        px(0.0),
-        px(200.0),
-        px(0.0),
-        px(200.0),
-    )));
+    assert_eq!(run.offset(child), Offset::new(px(5.0), px(5.0)));
 
-    let mut owner = owner.into_layout();
-    owner.run_layout().expect("frame 1");
-    assert_eq!(
-        state_offset(&owner, child_id),
-        Offset::new(px(5.0), px(5.0))
-    );
-
-    // Change padding → re-position on frame 2.
-    let mut owner = owner.into_idle();
-    {
-        let node = owner
-            .render_tree_mut()
-            .get_mut(padding_id)
-            .expect("padding in tree");
-        let entry = node.as_box_mut().expect("box entry");
-        let padding = entry
-            .render_object_mut()
-            .as_any_mut()
-            .downcast_mut::<RenderPadding>()
-            .expect("padding downcast");
-        padding.set_padding(flui_types::EdgeInsets::all(px(9.0)));
-    }
-    owner.mark_needs_layout(padding_id);
-    let mut owner = owner.into_layout();
-    owner.run_layout().expect("frame 2");
+    // Change padding → re-position on the next layout pass.
+    run.update::<RenderPadding>(pad, |padding| {
+        padding.set_padding(EdgeInsets::all(px(9.0)));
+    });
+    run.relayout();
 
     assert_eq!(
-        state_offset(&owner, child_id),
+        run.offset(child),
         Offset::new(px(9.0), px(9.0)),
-        "frame 2 re-position must overwrite the previously committed offset",
+        "re-position must overwrite the previously committed offset",
     );
 }
 
@@ -189,35 +141,20 @@ impl RenderBox for PositionFirstChildOnly {
 
 #[test]
 fn unpositioned_child_keeps_prior_offset_across_relayout() {
-    let mut owner = PipelineOwner::new();
-    let parent_id = owner.insert(Box::new(PositionFirstChildOnly::new())
-        as Box<
-            dyn flui_rendering::traits::RenderObject<flui_rendering::protocol::BoxProtocol>,
-        >);
-    let positioned_id = owner
-        .insert_child_render_object(parent_id, Box::new(RenderColoredBox::red(10.0, 10.0)))
-        .expect("child 0 insert");
-    let unpositioned_id = owner
-        .insert_child_render_object(parent_id, Box::new(RenderColoredBox::blue(10.0, 10.0)))
-        .expect("child 1 insert");
+    let mut run = RenderTester::mount(
+        box_node(PositionFirstChildOnly::new())
+            .child(box_node(RenderColoredBox::red(10.0, 10.0)).label("positioned"))
+            .child(box_node(RenderColoredBox::blue(10.0, 10.0)).label("unpositioned")),
+    )
+    .with_constraints(constraints())
+    .run_layout();
+    let parent = run.root();
+    let positioned = run.id("positioned");
+    let unpositioned = run.id("unpositioned");
 
-    owner.set_root_id(Some(parent_id));
-    owner.set_root_constraints(Some(BoxConstraints::new(
-        px(0.0),
-        px(200.0),
-        px(0.0),
-        px(200.0),
-    )));
-
-    let mut owner = owner.into_layout();
-    owner.run_layout().expect("frame 1");
-
+    assert_eq!(run.offset(positioned), Offset::new(px(7.0), px(3.0)));
     assert_eq!(
-        state_offset(&owner, positioned_id),
-        Offset::new(px(7.0), px(3.0))
-    );
-    assert_eq!(
-        state_offset(&owner, unpositioned_id),
+        run.offset(unpositioned),
         Offset::ZERO,
         "never-positioned child starts at the default zero offset",
     );
@@ -225,27 +162,24 @@ fn unpositioned_child_keeps_prior_offset_across_relayout() {
     // Simulate an out-of-band offset write (e.g. a future compositor
     // adjustment), then re-layout. The parent still does not position
     // child 1, so the seed must carry the prior value through.
-    let mut owner = owner.into_idle();
-    owner
+    run.owner()
         .render_tree()
-        .get(unpositioned_id)
+        .get(unpositioned)
         .expect("child 1 in tree")
         .as_box()
         .expect("box entry")
         .state()
         .set_offset(Offset::new(px(11.0), px(13.0)));
-
-    owner.mark_needs_layout(parent_id);
-    let mut owner = owner.into_layout();
-    owner.run_layout().expect("frame 2");
+    run.owner_mut().mark_needs_layout(parent);
+    run.relayout();
 
     assert_eq!(
-        state_offset(&owner, positioned_id),
+        run.offset(positioned),
         Offset::new(px(7.0), px(3.0)),
         "positioned child is re-positioned every layout",
     );
     assert_eq!(
-        state_offset(&owner, unpositioned_id),
+        run.offset(unpositioned),
         Offset::new(px(11.0), px(13.0)),
         "unpositioned child must keep its prior RenderState.offset: the \
          per-walk ChildState is seeded from state, so skipping \

--- a/crates/flui-rendering/tests/paint_fragment_snapshot.rs
+++ b/crates/flui-rendering/tests/paint_fragment_snapshot.rs
@@ -30,6 +30,7 @@ use flui_rendering::{
     parent_data::{BoxParentData, SliverParentData},
     pipeline::PipelineOwner,
     protocol::{BoxProtocol, SliverProtocol},
+    testing::inspect,
     traits::{
         HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, RenderSliver,
         SemanticsCapability,
@@ -62,36 +63,10 @@ fn paint_frame(
     (tree, owner)
 }
 
-/// Collects `(depth, variant-name)` pairs in DFS order — the
-/// structural snapshot.
+/// Collects `(depth, variant-name)` pairs in DFS order — the structural
+/// snapshot. Delegates to the shared inspection surface.
 fn structure(tree: &LayerTree) -> Vec<(usize, &'static str)> {
-    fn walk(
-        tree: &LayerTree,
-        id: flui_foundation::LayerId,
-        depth: usize,
-        out: &mut Vec<(usize, &'static str)>,
-    ) {
-        let node = tree.get(id).expect("walk only visits live ids");
-        let name = match node.layer() {
-            Layer::Offset(_) => "Offset",
-            Layer::Picture(_) => "Picture",
-            Layer::ClipRect(_) => "ClipRect",
-            Layer::ClipRRect(_) => "ClipRRect",
-            Layer::ClipPath(_) => "ClipPath",
-            Layer::Opacity(_) => "Opacity",
-            Layer::Transform(_) => "Transform",
-            _ => "Other",
-        };
-        out.push((depth, name));
-        for &child in node.children() {
-            walk(tree, child, depth + 1, out);
-        }
-    }
-    let mut out = Vec::new();
-    if let Some(root) = tree.root() {
-        walk(tree, root, 0, &mut out);
-    }
-    out
+    inspect::layer_structure_with_depth(tree)
 }
 
 /// First picture's display list in DFS order.

--- a/crates/flui-rendering/tests/pipeline_scenarios.rs
+++ b/crates/flui-rendering/tests/pipeline_scenarios.rs
@@ -1,89 +1,43 @@
 //! Render-object foundation under realistic multi-frame scenarios.
 //!
-//! Each scenario drives the REAL `run_frame` orchestration (layout →
-//! compositing → paint) the bindings use in production, then asserts
-//! on observable outputs: committed `RenderState` offsets, layer-tree
-//! structure, picture bounds, hit paths, and dirty-queue hygiene.
+//! Each scenario drives the REAL frame pipeline (layout → compositing →
+//! paint) the bindings use in production, then asserts on observable
+//! outputs: committed offsets, layer-tree structure, picture bounds, hit
+//! paths, dirty-queue hygiene, and — via the `Diagnosticable`-backed
+//! diagnostics — the render objects' self-described configuration.
+//!
+//! These scenarios are expressed with the `flui_rendering::testing` harness
+//! (`RenderTester` / `FrameRun` / `Probe`): declarative tree specs, symmetric
+//! `run_frame`, `update` + `pump` for multi-frame mutation, and structured
+//! property queries. The advanced layer-internal checks (transform matrices,
+//! clip shapes, offset layers) still walk the produced `LayerTree` directly.
 //!
 //! Scenarios:
-//! 1. deep nesting — offsets accumulate through a 50-deep padding
-//!    chain and a single merged picture comes out;
-//! 2. mixed tree — flex + padding + transform + clip in one frame:
-//!    structure, bounds, and per-region hits;
-//! 3. invalidation round-trips — paint-only frame, then a
-//!    layout-changing frame, across three frames;
-//! 4. idle stability — frames after a clean one produce NO output
-//!    (no spurious repaints from leftover dirty state);
-//! 5. removal churn — remove + reinsert under one parent: stale ids
-//!    miss, queues stay clean, the new subtree paints;
-//! 6. repaint-boundary subtree — the boundary's OffsetLayer split
-//!    survives re-frames and carries the laid-out offset.
+//! 1. deep nesting — offsets accumulate through a 50-deep padding chain and
+//!    a single merged picture comes out;
+//! 2. mixed tree — flex + padding + transform + clip in one frame;
+//! 3. invalidation round-trips — paint-only then layout-changing frames;
+//! 4. idle stability — frames after a clean one produce NO output;
+//! 5. removal churn — remove + reinsert under one parent;
+//! 6. repaint-boundary subtree — the boundary's OffsetLayer split survives
+//!    re-frames;
+//! 7. edge cases — zero sizes and empty containers;
+//! 8. churn stress — 20 remove+reinsert cycles.
 
 use flui_layer::{Layer, LayerTree};
-use flui_painting::DisplayListCore;
 use flui_rendering::{
     constraints::BoxConstraints,
-    hit_testing::HitTestResult,
     objects::{
-        RenderColoredBox, RenderFlex, RenderPadding, RenderRepaintBoundary, RenderTransform,
+        RenderClipRect, RenderColoredBox, RenderFlex, RenderPadding, RenderRepaintBoundary,
+        RenderTransform,
     },
-    pipeline::PipelineOwner,
+    testing::{Probe, RenderTester, box_node},
 };
 use flui_types::{EdgeInsets, Matrix4, Offset, Point, Rect, Size, geometry::px};
 
-type BoxedRenderObject =
-    Box<dyn flui_rendering::traits::RenderObject<flui_rendering::protocol::BoxProtocol>>;
-
-fn frame(owner: PipelineOwner) -> (PipelineOwner, Option<LayerTree>) {
-    let (owner, result) = owner.run_frame();
-    (owner, result.expect("frame must not error"))
-}
-
-fn structure(tree: &LayerTree) -> Vec<&'static str> {
-    fn walk(tree: &LayerTree, id: flui_foundation::LayerId, out: &mut Vec<&'static str>) {
-        let node = tree.get(id).expect("live layer id");
-        out.push(match node.layer() {
-            Layer::Offset(_) => "Offset",
-            Layer::Picture(_) => "Picture",
-            Layer::ClipRect(_) => "ClipRect",
-            Layer::Transform(_) => "Transform",
-            _ => "Other",
-        });
-        for &c in node.children() {
-            walk(tree, c, out);
-        }
-    }
-    let mut out = Vec::new();
-    if let Some(root) = tree.root() {
-        walk(tree, root, &mut out);
-    }
-    out
-}
-
-fn first_picture_bounds(tree: &LayerTree) -> flui_types::Rect {
-    fn find(tree: &LayerTree, id: flui_foundation::LayerId) -> Option<flui_types::Rect> {
-        let node = tree.get(id)?;
-        if let Layer::Picture(p) = node.layer() {
-            return Some(p.picture().bounds());
-        }
-        node.children().iter().find_map(|&c| find(tree, c))
-    }
-    find(tree, tree.root().expect("root")).expect("picture present")
-}
-
-fn state_offset(owner: &PipelineOwner, id: flui_foundation::RenderId) -> Offset {
-    owner
-        .render_tree()
-        .get(id)
-        .and_then(|n| n.as_box())
-        .map(|e| e.state().offset())
-        .expect("node state")
-}
-
-fn hits(owner: &PipelineOwner, x: f32, y: f32) -> Vec<flui_foundation::RenderId> {
-    let mut result = HitTestResult::new();
-    owner.hit_test(Offset::new(px(x), px(y)), &mut result);
-    result.path().iter().map(|e| e.target).collect()
+/// Loose `0..=hi x 0..=hi` constraints (children settle at natural size).
+fn loose(width: f32, height: f32) -> BoxConstraints {
+    BoxConstraints::new(px(0.0), px(width), px(0.0), px(height))
 }
 
 // ============================================================================
@@ -92,53 +46,48 @@ fn hits(owner: &PipelineOwner, x: f32, y: f32) -> Vec<flui_foundation::RenderId>
 
 #[test]
 fn deep_padding_chain_accumulates_offsets_and_merges_one_picture() {
-    let mut owner = PipelineOwner::new();
-    let root = owner.insert(Box::new(RenderPadding::all(1.0)) as BoxedRenderObject);
-    let mut parent = root;
-    for _ in 0..49 {
-        parent = owner
-            .insert_child_render_object(parent, Box::new(RenderPadding::all(1.0)))
-            .expect("padding link");
+    // Build leaf-first, then wrap in 50 padding(1px) layers.
+    let mut spec = box_node(RenderColoredBox::red(10.0, 10.0)).label("leaf");
+    for _ in 0..50 {
+        spec = box_node(RenderPadding::all(1.0)).child(spec);
     }
-    let leaf = owner
-        .insert_child_render_object(parent, Box::new(RenderColoredBox::red(10.0, 10.0)))
-        .expect("leaf");
+    let run = RenderTester::mount(spec)
+        .with_constraints(loose(500.0, 500.0))
+        .run_frame();
 
-    owner.set_root_id(Some(root));
-    owner.set_root_constraints(Some(BoxConstraints::new(
-        px(0.0),
-        px(500.0),
-        px(0.0),
-        px(500.0),
-    )));
+    let leaf = run.id("leaf");
+    let root = run.root();
 
-    let (owner, tree) = frame(owner);
-    let tree = tree.expect("first frame paints");
-
-    // Every padding contributes (1,1) to ITS child — each link's
-    // committed RenderState offset is exactly (1,1)...
-    assert_eq!(state_offset(&owner, leaf), Offset::new(px(1.0), px(1.0)));
+    // Every padding contributes (1,1) to ITS child — the leaf's committed
+    // offset relative to its parent is exactly (1,1)...
+    assert_eq!(run.offset(leaf), Offset::new(px(1.0), px(1.0)));
     // ...and the picture's ABSOLUTE bounds carry the full 50-deep
     // accumulation: the leaf draws at (50,50)..(60,60).
     assert_eq!(
-        first_picture_bounds(&tree),
-        flui_types::Rect::from_ltrb(px(50.0), px(50.0), px(60.0), px(60.0)),
+        run.picture_bounds(),
+        Some(Rect::from_ltrb(px(50.0), px(50.0), px(60.0), px(60.0))),
         "accumulated origins must be baked through the whole chain",
     );
     assert_eq!(
-        structure(&tree),
+        run.structure(),
         vec!["Offset", "Picture"],
         "51 inline nodes still merge into ONE picture",
     );
 
     // Hit straight through all 50 levels, leaf-first path of 51 ids.
-    let path = hits(&owner, 55.0, 55.0);
+    let path = run.hit(55.0, 55.0);
     assert_eq!(path.len(), 51);
     assert_eq!(path[0], leaf, "leaf-first");
     assert_eq!(path[50], root, "root last");
     assert!(
-        hits(&owner, 5.0, 5.0).is_empty(),
+        run.hit(5.0, 5.0).is_empty(),
         "the border region (inside paddings, outside the box) misses",
+    );
+
+    // The leaf self-describes its color through the full pipeline.
+    assert_eq!(
+        run.property(leaf, "color").as_deref(),
+        Some("[1.0, 0.0, 0.0, 1.0]"),
     );
 }
 
@@ -148,53 +97,43 @@ fn deep_padding_chain_accumulates_offsets_and_merges_one_picture() {
 
 #[test]
 fn mixed_flex_padding_transform_clip_frame() {
-    let mut owner = PipelineOwner::new();
     // row[ padding(5){red 40}, transform(scale2){blue 20}, clip{green 40} ]
-    let row = owner.insert(Box::new(RenderFlex::row()) as BoxedRenderObject);
-    let pad = owner
-        .insert_child_render_object(row, Box::new(RenderPadding::all(5.0)))
-        .expect("pad");
-    let red = owner
-        .insert_child_render_object(pad, Box::new(RenderColoredBox::red(40.0, 40.0)))
-        .expect("red");
-    let scaler = owner
-        .insert_child_render_object(row, Box::new(RenderTransform::scale(2.0, 2.0)))
-        .expect("scaler");
-    let blue = owner
-        .insert_child_render_object(scaler, Box::new(RenderColoredBox::blue(20.0, 20.0)))
-        .expect("blue");
-    let clip = owner
-        .insert_child_render_object(
-            row,
-            Box::new(flui_rendering::objects::RenderClipRect::hard_edge()),
-        )
-        .expect("clip");
-    let green = owner
-        .insert_child_render_object(clip, Box::new(RenderColoredBox::green(40.0, 40.0)))
-        .expect("green");
+    let run = RenderTester::mount(
+        box_node(RenderFlex::row())
+            .child(
+                box_node(RenderPadding::all(5.0))
+                    .label("pad")
+                    .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("red")),
+            )
+            .child(
+                box_node(RenderTransform::scale(2.0, 2.0))
+                    .label("scaler")
+                    .child(box_node(RenderColoredBox::blue(20.0, 20.0)).label("blue")),
+            )
+            .child(
+                box_node(RenderClipRect::hard_edge())
+                    .label("clip")
+                    .child(box_node(RenderColoredBox::green(40.0, 40.0)).label("green")),
+            ),
+    )
+    .with_constraints(loose(300.0, 100.0))
+    .run_frame();
 
-    owner.set_root_id(Some(row));
-    owner.set_root_constraints(Some(BoxConstraints::new(
-        px(0.0),
-        px(300.0),
-        px(0.0),
-        px(100.0),
-    )));
+    let pad = run.id("pad");
+    let red = run.id("red");
+    let scaler = run.id("scaler");
+    let blue = run.id("blue");
+    let clip = run.id("clip");
+    let green = run.id("green");
 
-    let (owner, tree) = frame(owner);
-    let tree = tree.expect("frame paints");
+    // Row children sit at main-axis offsets 0 / 50 / 70.
+    assert_eq!(run.offset(pad), Offset::new(px(0.0), px(0.0)));
+    assert_eq!(run.offset(scaler), Offset::new(px(50.0), px(0.0)));
+    assert_eq!(run.offset(clip), Offset::new(px(70.0), px(0.0)));
 
-    // Row children sit at main-axis offsets 0 / 50 / 70
-    // (padding 40+10 wide, transform reports child size 20, clip 40).
-    assert_eq!(state_offset(&owner, pad), Offset::new(px(0.0), px(0.0)));
-    assert_eq!(state_offset(&owner, scaler), Offset::new(px(50.0), px(0.0)));
-    assert_eq!(state_offset(&owner, clip), Offset::new(px(70.0), px(0.0)));
-
-    // Layer splits happen exactly where semantics demand them: the
-    // transform's effect hook wraps ITS subtree in a TransformLayer,
-    // the clip scope brackets green — everything else merges.
+    // Layer splits happen exactly where semantics demand them.
     assert_eq!(
-        structure(&tree),
+        run.structure(),
         vec![
             "Offset",
             "Picture",
@@ -206,13 +145,11 @@ fn mixed_flex_padding_transform_clip_frame() {
         "inline draws merge; Transform and ClipRect split the stream",
     );
 
-    // Effect/clip layers must anchor at the NODE origin, not the layer
-    // origin: descendant runs carry the accumulated origin baked into
-    // their canvas transforms, so the composer conjugates the local
-    // matrix by the origin (Flutter pushTransform: T(o)·M·T(−o)) and
-    // shifts clip shapes (Flutter pushClipRect: clipRect.shift(offset)).
-    // A raw local matrix/shape here would pivot/cut at the row's (0,0).
-    let local = owner
+    // Effect/clip layers anchor at the NODE origin (Flutter pushTransform:
+    // T(o)·M·T(−o); pushClipRect: clipRect.shift(offset)).
+    let tree = run.layer_tree().expect("frame paints");
+    let local = run
+        .owner()
         .render_tree()
         .get(scaler)
         .expect("scaler node")
@@ -237,14 +174,13 @@ fn mixed_flex_padding_transform_clip_frame() {
             }
         }
         let mut out = Vec::new();
-        walk(&tree, tree.root().expect("root"), &mut out);
+        walk(tree, tree.root().expect("root"), &mut out);
         out
     };
     assert_eq!(
         transform_matrices,
         vec![expected],
-        "the scaler's TransformLayer must carry the origin-conjugated \
-         matrix (pivot at the node origin x=50, not the row origin)",
+        "the scaler's TransformLayer must carry the origin-conjugated matrix",
     );
     let clip_rects: Vec<Rect> = {
         fn walk(tree: &LayerTree, id: flui_foundation::LayerId, out: &mut Vec<Rect>) {
@@ -257,7 +193,7 @@ fn mixed_flex_padding_transform_clip_frame() {
             }
         }
         let mut out = Vec::new();
-        walk(&tree, tree.root().expect("root"), &mut out);
+        walk(tree, tree.root().expect("root"), &mut out);
         out
     };
     assert_eq!(
@@ -266,20 +202,36 @@ fn mixed_flex_padding_transform_clip_frame() {
             Point::new(px(70.0), px(0.0)),
             Size::new(px(40.0), px(40.0)),
         )],
-        "the clip shape recorded in node-local coordinates must be \
-         shifted by the node origin to match the origin-baked runs",
+        "the clip shape must be shifted by the node origin",
     );
 
-    // Region hits. The scaled blue's VISUAL extent is 50..90 (its
-    // 20-wide geometry under scale 2) and overlaps the clip at 70..110
-    // — in the overlap the LATER sibling (green) wins, topmost-first.
-    assert_eq!(hits(&owner, 20.0, 20.0).first().copied(), Some(red));
-    // (60,10): inverse-mapped blue-local (5,5), left of green's start.
-    assert_eq!(hits(&owner, 60.0, 10.0).first().copied(), Some(blue));
-    // (80,20): inside BOTH blue's visual extent and green — z-order
-    // gives the later sibling the hit.
-    assert_eq!(hits(&owner, 80.0, 20.0).first().copied(), Some(green));
-    assert_eq!(hits(&owner, 100.0, 20.0).first().copied(), Some(green));
+    // Region hits. Scaled blue's visual extent is 50..90 and overlaps the
+    // clip at 70..110 — in the overlap the later sibling (green) wins.
+    assert_eq!(run.hit(20.0, 20.0).first().copied(), Some(red));
+    assert_eq!(run.hit(60.0, 10.0).first().copied(), Some(blue));
+    assert_eq!(run.hit(80.0, 20.0).first().copied(), Some(green));
+    assert_eq!(run.hit(100.0, 20.0).first().copied(), Some(green));
+
+    // Self-description: the scaler reports its (local) transform and the
+    // padding its insets — config the geometry assertions don't cover.
+    assert!(
+        run.property(scaler, "transform").is_some(),
+        "the transform node self-describes its matrix",
+    );
+    assert!(
+        run.property(pad, "padding").is_some(),
+        "the padding node self-describes its insets",
+    );
+    assert_eq!(
+        run.descendant_property("RenderFlex", "direction")
+            .as_deref(),
+        Some("Horizontal"),
+    );
+    assert!(
+        run.descendant_property("RenderPadding", "padding")
+            .is_some(),
+        "padding self-describes its insets",
+    );
 }
 
 // ============================================================================
@@ -288,52 +240,36 @@ fn mixed_flex_padding_transform_clip_frame() {
 
 #[test]
 fn paint_only_then_layout_invalidations_round_trip() {
-    let mut owner = PipelineOwner::new();
-    let pad = owner.insert(Box::new(RenderPadding::all(5.0)) as BoxedRenderObject);
-    let child = owner
-        .insert_child_render_object(pad, Box::new(RenderColoredBox::red(40.0, 40.0)))
-        .expect("child");
-    owner.set_root_id(Some(pad));
-    owner.set_root_constraints(Some(BoxConstraints::new(
-        px(0.0),
-        px(200.0),
-        px(0.0),
-        px(200.0),
-    )));
-
-    // Frame 1: full.
-    let (mut owner, tree) = frame(owner);
-    assert!(tree.is_some());
+    let mut run = RenderTester::mount(
+        box_node(RenderPadding::all(5.0))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0, 200.0))
+    .run_frame();
+    let pad = run.root();
+    let child = run.id("child");
+    assert!(run.painted(), "frame 1 paints");
 
     // Frame 2: paint-only invalidation — no layout change, fresh tree.
-    owner.add_node_needing_paint(child, 1);
-    let (mut owner, tree2) = frame(owner);
-    let tree2 = tree2.expect("paint-only frame repaints");
+    run.owner_mut().add_node_needing_paint(child, 1);
+    let report = run.pump();
+    assert!(report.painted, "paint-only frame repaints");
     assert_eq!(
-        first_picture_bounds(&tree2),
-        flui_types::Rect::from_ltrb(px(5.0), px(5.0), px(45.0), px(45.0)),
+        run.picture_bounds(),
+        Some(Rect::from_ltrb(px(5.0), px(5.0), px(45.0), px(45.0))),
         "geometry unchanged on a paint-only frame",
     );
 
     // Frame 3: layout invalidation — padding grows, offsets move.
-    {
-        let tree_mut = owner.render_tree_mut();
-        let node = tree_mut.get_mut(pad).expect("pad");
-        let entry = node.as_box_mut().expect("box");
-        entry
-            .render_object_mut()
-            .as_any_mut()
-            .downcast_mut::<RenderPadding>()
-            .expect("padding")
-            .set_padding(EdgeInsets::all(px(20.0)));
-    }
-    owner.mark_needs_layout(pad);
-    let (owner, tree3) = frame(owner);
-    let tree3 = tree3.expect("layout frame repaints");
-    assert_eq!(state_offset(&owner, child), Offset::new(px(20.0), px(20.0)));
+    run.update::<RenderPadding>(pad, |padding| {
+        padding.set_padding(EdgeInsets::all(px(20.0)));
+    });
+    let report = run.pump();
+    assert!(report.painted, "layout frame repaints");
+    assert_eq!(run.offset(child), Offset::new(px(20.0), px(20.0)));
     assert_eq!(
-        first_picture_bounds(&tree3),
-        flui_types::Rect::from_ltrb(px(20.0), px(20.0), px(60.0), px(60.0)),
+        run.picture_bounds(),
+        Some(Rect::from_ltrb(px(20.0), px(20.0), px(60.0), px(60.0))),
         "relayout must repaint at the NEW offsets",
     );
 }
@@ -344,24 +280,20 @@ fn paint_only_then_layout_invalidations_round_trip() {
 
 #[test]
 fn clean_frames_after_first_produce_no_layer_tree() {
-    let mut owner = PipelineOwner::new();
-    let root = owner.insert(Box::new(RenderColoredBox::red(40.0, 40.0)) as BoxedRenderObject);
-    owner.set_root_id(Some(root));
-    owner.set_root_constraints(Some(BoxConstraints::tight(Size::new(px(100.0), px(100.0)))));
-
-    let (mut owner, first) = frame(owner);
-    assert!(first.is_some(), "frame 1 paints");
+    let mut run = RenderTester::mount(box_node(RenderColoredBox::red(40.0, 40.0)))
+        .with_size(Size::new(px(100.0), px(100.0)))
+        .run_frame();
+    assert!(run.painted(), "frame 1 paints");
 
     for n in 2..=5 {
-        let (next_owner, tree) = frame(owner);
-        owner = next_owner;
+        let report = run.pump();
         assert!(
-            tree.is_none(),
+            !report.painted,
             "frame {n} has no dirty work and must produce no output — \
              leftover dirty state here means an idle app burns frames",
         );
     }
-    assert!(!owner.has_dirty_nodes());
+    assert!(run.is_clean());
 }
 
 // ============================================================================
@@ -370,51 +302,41 @@ fn clean_frames_after_first_produce_no_layer_tree() {
 
 #[test]
 fn remove_and_reinsert_child_keeps_pipeline_clean() {
-    let mut owner = PipelineOwner::new();
-    let pad = owner.insert(Box::new(RenderPadding::all(5.0)) as BoxedRenderObject);
-    let first_child = owner
-        .insert_child_render_object(pad, Box::new(RenderColoredBox::red(40.0, 40.0)))
-        .expect("first child");
-    owner.set_root_id(Some(pad));
-    owner.set_root_constraints(Some(BoxConstraints::new(
-        px(0.0),
-        px(200.0),
-        px(0.0),
-        px(200.0),
-    )));
-
-    let (mut owner, _) = frame(owner);
+    let mut run = RenderTester::mount(
+        box_node(RenderPadding::all(5.0))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("first")),
+    )
+    .with_constraints(loose(200.0, 200.0))
+    .run_frame();
+    let pad = run.root();
+    let first_child = run.id("first");
 
     // Remove the child, reinsert a different one (slot reuse).
-    let removed = owner.remove_render_object(first_child);
-    assert_eq!(removed, 1);
-    let second_child = owner
+    assert_eq!(run.owner_mut().remove_render_object(first_child), 1);
+    let second_child = run
+        .owner_mut()
         .insert_child_render_object(pad, Box::new(RenderColoredBox::blue(60.0, 60.0)))
         .expect("second child");
-    owner.mark_needs_layout(pad);
-
-    let (owner, tree) = frame(owner);
-    let tree = tree.expect("churn frame paints");
+    run.owner_mut().mark_needs_layout(pad);
+    let report = run.pump();
+    assert!(report.painted, "churn frame paints");
 
     assert!(
-        owner.render_tree().get(first_child).is_none(),
+        run.owner().render_tree().get(first_child).is_none(),
         "the stale id must not resolve to the reused slot (ABA guard)",
     );
+    assert_eq!(run.offset(second_child), Offset::new(px(5.0), px(5.0)));
     assert_eq!(
-        state_offset(&owner, second_child),
-        Offset::new(px(5.0), px(5.0))
-    );
-    assert_eq!(
-        first_picture_bounds(&tree),
-        flui_types::Rect::from_ltrb(px(5.0), px(5.0), px(65.0), px(65.0)),
+        run.picture_bounds(),
+        Some(Rect::from_ltrb(px(5.0), px(5.0), px(65.0), px(65.0))),
         "the NEW child paints at the padded origin",
     );
     assert_eq!(
-        hits(&owner, 30.0, 30.0).first().copied(),
+        run.hit(30.0, 30.0).first().copied(),
         Some(second_child),
         "hits route to the new child, never the stale id",
     );
-    assert!(!owner.has_dirty_nodes(), "queues drain fully after churn");
+    assert!(run.is_clean(), "queues drain fully after churn");
 }
 
 // ============================================================================
@@ -423,55 +345,36 @@ fn remove_and_reinsert_child_keeps_pipeline_clean() {
 
 #[test]
 fn repaint_boundary_split_survives_relayout_frames() {
-    let mut owner = PipelineOwner::new();
-    let pad = owner.insert(Box::new(RenderPadding::all(5.0)) as BoxedRenderObject);
-    let boundary = owner
-        .insert_child_render_object(pad, Box::new(RenderRepaintBoundary::new()))
-        .expect("boundary");
-    let leaf = owner
-        .insert_child_render_object(boundary, Box::new(RenderColoredBox::red(40.0, 40.0)))
-        .expect("leaf");
-    owner.set_root_id(Some(pad));
-    owner.set_root_constraints(Some(BoxConstraints::new(
-        px(0.0),
-        px(200.0),
-        px(0.0),
-        px(200.0),
-    )));
-
-    let (mut owner, tree1) = frame(owner);
-    let tree1 = tree1.expect("frame 1");
+    let mut run = RenderTester::mount(
+        box_node(RenderPadding::all(5.0)).child(
+            box_node(RenderRepaintBoundary::new())
+                .label("boundary")
+                .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("leaf")),
+        ),
+    )
+    .with_constraints(loose(200.0, 200.0))
+    .run_frame();
+    let pad = run.root();
+    let leaf = run.id("leaf");
     assert_eq!(
-        structure(&tree1),
+        run.structure(),
         vec!["Offset", "Offset", "Picture"],
         "the boundary subtree splits under its own OffsetLayer",
     );
 
     // Move the boundary by growing the padding; re-frame.
-    {
-        let tree_mut = owner.render_tree_mut();
-        let entry = tree_mut
-            .get_mut(pad)
-            .expect("pad")
-            .as_box_mut()
-            .expect("box");
-        entry
-            .render_object_mut()
-            .as_any_mut()
-            .downcast_mut::<RenderPadding>()
-            .expect("padding")
-            .set_padding(EdgeInsets::all(px(30.0)));
-    }
-    owner.mark_needs_layout(pad);
-    let (owner, tree2) = frame(owner);
-    let tree2 = tree2.expect("frame 2");
+    run.update::<RenderPadding>(pad, |padding| {
+        padding.set_padding(EdgeInsets::all(px(30.0)));
+    });
+    run.pump();
 
-    assert_eq!(structure(&tree2), vec!["Offset", "Offset", "Picture"]);
-    // The boundary's OffsetLayer carries the NEW accumulated offset;
-    // the picture inside stays rebased at zero.
-    let root_id = tree2.root().expect("root");
-    let boundary_layer_id = tree2.get(root_id).expect("root node").children()[0];
-    let boundary_node = tree2.get(boundary_layer_id).expect("boundary node");
+    assert_eq!(run.structure(), vec!["Offset", "Offset", "Picture"]);
+    // The boundary's OffsetLayer carries the NEW accumulated offset; the
+    // picture inside stays rebased at zero.
+    let tree = run.layer_tree().expect("frame 2");
+    let root_id = tree.root().expect("root");
+    let boundary_layer_id = tree.get(root_id).expect("root node").children()[0];
+    let boundary_node = tree.get(boundary_layer_id).expect("boundary node");
     let Layer::Offset(offset_layer) = boundary_node.layer() else {
         panic!("boundary layer must be an OffsetLayer");
     };
@@ -481,11 +384,11 @@ fn repaint_boundary_split_survives_relayout_frames() {
         "an offset-only move shows up as the layer's offset",
     );
     assert_eq!(
-        first_picture_bounds(&tree2),
-        flui_types::Rect::from_ltrb(px(0.0), px(0.0), px(40.0), px(40.0)),
+        run.picture_bounds(),
+        Some(Rect::from_ltrb(px(0.0), px(0.0), px(40.0), px(40.0))),
         "boundary-subtree coordinates stay rebased to zero",
     );
-    assert_eq!(state_offset(&owner, leaf), Offset::new(px(0.0), px(0.0)));
+    assert_eq!(run.offset(leaf), Offset::new(px(0.0), px(0.0)));
 }
 
 // ============================================================================
@@ -494,47 +397,32 @@ fn repaint_boundary_split_survives_relayout_frames() {
 
 #[test]
 fn zero_size_children_and_empty_containers_survive_the_pipeline() {
-    let mut owner = PipelineOwner::new();
-    let row = owner.insert(Box::new(RenderFlex::row()) as BoxedRenderObject);
-    // A zero-size child, an empty nested row, and a normal child.
-    let zero = owner
-        .insert_child_render_object(row, Box::new(RenderColoredBox::red(0.0, 0.0)))
-        .expect("zero child");
-    let empty_row = owner
-        .insert_child_render_object(row, Box::new(RenderFlex::row()))
-        .expect("empty row");
-    let normal = owner
-        .insert_child_render_object(row, Box::new(RenderColoredBox::blue(40.0, 40.0)))
-        .expect("normal child");
+    let run = RenderTester::mount(
+        box_node(RenderFlex::row())
+            .child(box_node(RenderColoredBox::red(0.0, 0.0)).label("zero"))
+            .child(box_node(RenderFlex::row()).label("empty_row"))
+            .child(box_node(RenderColoredBox::blue(40.0, 40.0)).label("normal")),
+    )
+    .with_constraints(loose(200.0, 100.0))
+    .run_frame();
 
-    owner.set_root_id(Some(row));
-    owner.set_root_constraints(Some(BoxConstraints::new(
-        px(0.0),
-        px(200.0),
-        px(0.0),
-        px(100.0),
-    )));
+    let zero = run.id("zero");
+    let empty_row = run.id("empty_row");
+    let normal = run.id("normal");
 
-    let (owner, tree) = frame(owner);
-    let tree = tree.expect("frame paints despite degenerate children");
-
-    // Zero-size and empty contribute nothing to main extent: the
-    // normal child sits at x = 0 + 0 + 0 = 0.
-    assert_eq!(state_offset(&owner, zero), Offset::new(px(0.0), px(0.0)));
-    assert_eq!(
-        state_offset(&owner, empty_row),
-        Offset::new(px(0.0), px(0.0))
-    );
-    assert_eq!(state_offset(&owner, normal), Offset::new(px(0.0), px(0.0)));
+    // Zero-size and empty contribute nothing to the main extent.
+    assert_eq!(run.offset(zero), Offset::new(px(0.0), px(0.0)));
+    assert_eq!(run.offset(empty_row), Offset::new(px(0.0), px(0.0)));
+    assert_eq!(run.offset(normal), Offset::new(px(0.0), px(0.0)));
 
     // Only the normal child draws; degenerate nodes add no commands.
     assert_eq!(
-        first_picture_bounds(&tree),
-        flui_types::Rect::from_ltrb(px(0.0), px(0.0), px(40.0), px(40.0)),
+        run.picture_bounds(),
+        Some(Rect::from_ltrb(px(0.0), px(0.0), px(40.0), px(40.0))),
     );
     // A zero-area child never claims a hit.
-    assert_eq!(hits(&owner, 10.0, 10.0).first().copied(), Some(normal));
-    assert!(!owner.has_dirty_nodes());
+    assert_eq!(run.hit(10.0, 10.0).first().copied(), Some(normal));
+    assert!(run.is_clean());
 }
 
 // ============================================================================
@@ -543,47 +431,44 @@ fn zero_size_children_and_empty_containers_survive_the_pipeline() {
 
 #[test]
 fn repeated_churn_cycles_stay_clean_and_generations_protect_every_round() {
-    let mut owner = PipelineOwner::new();
-    let pad = owner.insert(Box::new(RenderPadding::all(5.0)) as BoxedRenderObject);
-    owner.set_root_id(Some(pad));
-    owner.set_root_constraints(Some(BoxConstraints::new(
-        px(0.0),
-        px(200.0),
-        px(0.0),
-        px(200.0),
-    )));
+    let mut run = RenderTester::mount(
+        box_node(RenderPadding::all(5.0))
+            .child(box_node(RenderColoredBox::red(10.0, 10.0)).label("initial")),
+    )
+    .with_constraints(loose(200.0, 200.0))
+    .run_frame();
+    let pad = run.root();
+    let mut current = run.id("initial");
+    assert!(run.painted(), "initial frame paints");
 
     let mut stale_ids = Vec::new();
-    let mut current = owner
-        .insert_child_render_object(pad, Box::new(RenderColoredBox::red(10.0, 10.0)))
-        .expect("initial child");
-
     for round in 0..20u32 {
-        let (next_owner, tree) = frame(owner);
-        owner = next_owner;
-        assert!(tree.is_some(), "round {round}: churn frame must paint");
-
-        assert_eq!(owner.remove_render_object(current), 1, "round {round}");
+        assert_eq!(
+            run.owner_mut().remove_render_object(current),
+            1,
+            "round {round}"
+        );
         stale_ids.push(current);
         let side = 10.0 + round as f32;
-        current = owner
+        current = run
+            .owner_mut()
             .insert_child_render_object(pad, Box::new(RenderColoredBox::blue(side, side)))
             .expect("reinserted child");
-        owner.mark_needs_layout(pad);
+        run.owner_mut().mark_needs_layout(pad);
+        let report = run.pump();
+        assert!(report.painted, "round {round}: churn frame must paint");
     }
 
-    let (owner, tree) = frame(owner);
-    assert!(tree.is_some(), "final frame paints");
-    assert!(!owner.has_dirty_nodes(), "no residue after 20 churn rounds");
+    assert!(run.is_clean(), "no residue after 20 churn rounds");
 
-    // EVERY historical id must stay dead — slot reuse never
-    // resurrects an old handle, no matter how many generations passed.
+    // EVERY historical id must stay dead — slot reuse never resurrects an
+    // old handle, no matter how many generations passed.
     for (i, stale) in stale_ids.iter().enumerate() {
         assert!(
-            owner.render_tree().get(*stale).is_none(),
+            run.owner().render_tree().get(*stale).is_none(),
             "stale id from round {i} must not resolve",
         );
     }
-    assert!(owner.render_tree().get(current).is_some());
-    assert_eq!(hits(&owner, 20.0, 20.0).first().copied(), Some(current));
+    assert!(run.owner().render_tree().get(current).is_some());
+    assert_eq!(run.hit(20.0, 20.0).first().copied(), Some(current));
 }

--- a/crates/flui-rendering/tests/render_object_harness.rs
+++ b/crates/flui-rendering/tests/render_object_harness.rs
@@ -41,7 +41,7 @@
 //! | `RenderSliverFillRemainingWithScrollable` | `harness_sliver_fill_remaining_with_scrollable_*` | yes | — | — | yes |
 //! | `RenderSliverIgnorePointer` | `harness_sliver_ignore_pointer_*` | yes | yes | — | yes |
 //! | `RenderSliverOffstage` | `harness_sliver_offstage_*` | yes | — | — | yes |
-//! | `RenderSliverOpacity` | `harness_sliver_opacity_*` | yes | — | — | yes |
+//! | `RenderSliverOpacity` | `harness_sliver_opacity_*` | yes | — | yes | yes |
 //! | `RenderViewport` | `harness_viewport_*` | yes | — | — | yes |
 //!
 //! [`catalog_covers_every_render_object_name`] guards the table: every row's
@@ -1135,6 +1135,38 @@ fn harness_sliver_offstage_visible_reports_child_geometry() {
 }
 
 #[test]
+fn harness_sliver_opacity_repaints_on_paint_mutation() {
+    let mut run = RenderTester::mount(viewport(
+        sliver_node(RenderSliverOpacity::new(1.0))
+            .label("opacity")
+            .child(
+                sliver_node(RenderSliverFixedExtentList::new(30.0))
+                    .child(box_node(RenderColoredBox::red(300.0, 1000.0))),
+            ),
+    ))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_frame();
+
+    let opacity = run.id("opacity");
+    let report = run.advance_paint::<RenderSliverOpacity>(opacity, |o| {
+        o.set_opacity(0.5);
+    });
+    assert!(
+        report.painted,
+        "sliver opacity change must repaint: {report}"
+    );
+    assert!(
+        run.structure().contains(&"Opacity"),
+        "semi-opaque sliver must pay for an OpacityLayer: {:?}",
+        run.structure(),
+    );
+    assert!(
+        (run.opacity_alpha().expect("opacity layer present") - 0.5).abs() < 0.01,
+        "opacity layer alpha must track the animated value",
+    );
+}
+
+#[test]
 fn harness_sliver_opacity_passes_geometry() {
     let run = RenderTester::mount(viewport(
         sliver_node(RenderSliverOpacity::new(0.5))
@@ -1166,7 +1198,7 @@ fn harness_viewport_self_describes() {
     assert_descendant_properties(
         &run.diagnostics(),
         "RenderViewport",
-        &["axis_direction", "offset", "cache_extent"],
+        &["axis_direction", "scroll_offset", "cache_extent"],
     );
 }
 
@@ -1195,11 +1227,48 @@ fn harness_viewport_stacks_two_slivers() {
 fn catalog_covers_every_render_object_name() {
     let source = include_str!("render_object_harness.rs");
     for &type_name in RENDER_OBJECT_TYPES {
-        let hits = source.matches(type_name).count();
+        let covered = source
+            .split("#[test]")
+            .skip(1)
+            .any(|chunk| chunk.contains("fn harness_") && chunk.contains(type_name));
         assert!(
-            hits >= 3,
-            "{type_name} must appear in the module doc, RENDER_OBJECT_TYPES, and at least one \
-             harness test (found {hits} references)",
+            covered,
+            "{type_name} must appear in at least one `#[test] fn harness_*` block",
         );
     }
+}
+
+#[test]
+fn render_object_types_match_exports() {
+    let objects_mod = include_str!("../src/objects/mod.rs");
+    let mut exported: Vec<&str> = Vec::new();
+    let mut in_pub_use = false;
+    for line in objects_mod.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("pub use ") {
+            in_pub_use = true;
+        }
+        if in_pub_use {
+            for word in trimmed.split(|c: char| !c.is_alphanumeric() && c != '_') {
+                if word.starts_with("Render") {
+                    exported.push(word);
+                }
+            }
+            if trimmed.ends_with(';') {
+                in_pub_use = false;
+            }
+        }
+    }
+    exported.sort_unstable();
+    exported.dedup();
+    // Generic clip family root — harness catalog targets the concrete variants.
+    exported.retain(|name| *name != "RenderClip");
+
+    let mut catalog: Vec<&str> = RENDER_OBJECT_TYPES.to_vec();
+    catalog.sort_unstable();
+
+    assert_eq!(
+        catalog, exported,
+        "RENDER_OBJECT_TYPES must match `pub use` exports in objects/mod.rs",
+    );
 }

--- a/crates/flui-rendering/tests/render_object_harness.rs
+++ b/crates/flui-rendering/tests/render_object_harness.rs
@@ -1,0 +1,1205 @@
+//! Render-object harness catalog — every concrete render type is exercised
+//! through [`RenderTester`] + [`Probe`] so CI can pin layout, hit-test, and
+//! diagnostics contracts without visual inspection.
+//!
+//! # Coverage map (one row per exported render type)
+//!
+//! | Type | Harness test(s) | Layout | Hit-test | Paint | Diagnostics |
+//! |------|-----------------|--------|----------|-------|-------------|
+//! | `RenderSizedBox` | `harness_sized_box_*` | yes | — | — | yes |
+//! | `RenderColoredBox` | `harness_colored_box_*` | yes | yes | yes | yes |
+//! | `RenderImage` | `harness_image_*` | yes | — | yes | yes |
+//! | `RenderParagraph` | `harness_paragraph_*` | yes | — | yes | yes |
+//! | `RenderPadding` | `harness_padding_*` | yes | — | — | yes |
+//! | `RenderCenter` | `harness_center_*` | yes | — | — | yes |
+//! | `RenderAspectRatio` | `harness_aspect_ratio_*` | yes | — | — | yes |
+//! | `RenderConstrainedBox` | `harness_constrained_box_*` | yes | — | — | yes |
+//! | `RenderLimitedBox` | `harness_limited_box_*` | yes | — | — | yes |
+//! | `RenderOffstage` | `harness_offstage_*` | yes | yes | — | yes |
+//! | `RenderOpacity` | `harness_opacity_*` | yes | — | yes | yes |
+//! | `RenderTransform` | `harness_transform_*` | yes | — | yes | yes |
+//! | `RenderFittedBox` | `harness_fitted_box_*` | yes | — | — | yes |
+//! | `RenderFractionallySizedBox` | `harness_fractionally_sized_box_*` | yes | — | — | yes |
+//! | `RenderFractionalTranslation` | `harness_fractional_translation_*` | yes | — | — | yes |
+//! | `RenderDecoratedBox` | `harness_decorated_box_*` | yes | — | yes | yes |
+//! | `RenderClipRect` | `harness_clip_rect_*` | yes | — | — | yes |
+//! | `RenderClipRRect` | `harness_clip_rrect_*` | yes | — | — | yes |
+//! | `RenderClipOval` | `harness_clip_oval_*` | yes | — | — | yes |
+//! | `RenderClipPath` | `harness_clip_path_*` | yes | — | — | yes |
+//! | `RenderRepaintBoundary` | `harness_repaint_boundary_*` | yes | — | yes | yes |
+//! | `RenderMetaData` | `harness_metadata_*` | yes | — | — | yes |
+//! | `RenderFlex` | `harness_flex_*` | yes | — | — | yes |
+//! | `RenderStack` | `harness_stack_*` | yes | yes | — | yes |
+//! | `RenderAbsorbPointer` | `harness_absorb_pointer_*` | yes | yes | — | yes |
+//! | `RenderIgnorePointer` | `harness_ignore_pointer_*` | yes | yes | — | yes |
+//! | `RenderSliverFixedExtentList` | `harness_sliver_fixed_extent_list_*` | yes | — | — | yes |
+//! | `RenderSliverPadding` | `harness_sliver_padding_*` | yes | — | — | yes |
+//! | `RenderSliverToBoxAdapter` | `harness_sliver_to_box_adapter_*` | yes | — | — | yes |
+//! | `RenderSliverFillViewport` | `harness_sliver_fill_viewport_*` | yes | — | — | yes |
+//! | `RenderSliverFillRemaining` | `harness_sliver_fill_remaining_*` | yes | — | — | yes |
+//! | `RenderSliverFillRemainingAndOverscroll` | `harness_sliver_fill_remaining_and_overscroll_*` | yes | — | — | yes |
+//! | `RenderSliverFillRemainingWithScrollable` | `harness_sliver_fill_remaining_with_scrollable_*` | yes | — | — | yes |
+//! | `RenderSliverIgnorePointer` | `harness_sliver_ignore_pointer_*` | yes | yes | — | yes |
+//! | `RenderSliverOffstage` | `harness_sliver_offstage_*` | yes | — | — | yes |
+//! | `RenderSliverOpacity` | `harness_sliver_opacity_*` | yes | — | — | yes |
+//! | `RenderViewport` | `harness_viewport_*` | yes | — | — | yes |
+//!
+//! [`catalog_covers_every_render_object_name`] guards the table: every row's
+//! type string must appear in this file so a missing harness test fails CI.
+
+use flui_rendering::{
+    constraints::BoxConstraints,
+    objects::*,
+    parent_data::StackParentData,
+    testing::{
+        Probe, RenderTester, TreeNode, assert_descendant_properties, assert_has_committed_geometry,
+        assert_has_committed_size, box_node, sliver_node,
+    },
+};
+use flui_types::{
+    Alignment, Offset, Point, Rect, Size,
+    geometry::px,
+    layout::{AxisDirection, BoxFit, StackFit},
+    painting::Clip,
+    styling::{BoxDecoration, Color},
+    typography::{TextDirection, TextSpan},
+};
+
+/// Every concrete render-object type exported from `flui_rendering::objects`.
+const RENDER_OBJECT_TYPES: &[&str] = &[
+    "RenderSizedBox",
+    "RenderColoredBox",
+    "RenderImage",
+    "RenderParagraph",
+    "RenderPadding",
+    "RenderCenter",
+    "RenderAspectRatio",
+    "RenderConstrainedBox",
+    "RenderLimitedBox",
+    "RenderOffstage",
+    "RenderOpacity",
+    "RenderTransform",
+    "RenderFittedBox",
+    "RenderFractionallySizedBox",
+    "RenderFractionalTranslation",
+    "RenderDecoratedBox",
+    "RenderClipRect",
+    "RenderClipRRect",
+    "RenderClipOval",
+    "RenderClipPath",
+    "RenderRepaintBoundary",
+    "RenderMetaData",
+    "RenderFlex",
+    "RenderStack",
+    "RenderAbsorbPointer",
+    "RenderIgnorePointer",
+    "RenderSliverFixedExtentList",
+    "RenderSliverPadding",
+    "RenderSliverToBoxAdapter",
+    "RenderSliverFillViewport",
+    "RenderSliverFillRemaining",
+    "RenderSliverFillRemainingAndOverscroll",
+    "RenderSliverFillRemainingWithScrollable",
+    "RenderSliverIgnorePointer",
+    "RenderSliverOffstage",
+    "RenderSliverOpacity",
+    "RenderViewport",
+];
+
+fn loose(max: f32) -> BoxConstraints {
+    BoxConstraints::new(px(0.0), px(max), px(0.0), px(max))
+}
+
+fn viewport(sliver: TreeNode) -> TreeNode {
+    viewport_multi([sliver])
+}
+
+fn viewport_multi(slivers: impl IntoIterator<Item = TreeNode>) -> TreeNode {
+    let mut node = box_node(RenderViewport::new(AxisDirection::TopToBottom)).label("viewport");
+    for sliver in slivers {
+        node = node.child(sliver);
+    }
+    node
+}
+
+// ============================================================================
+// Leaf box objects
+// ============================================================================
+
+#[test]
+fn harness_sized_box_forces_dimensions() {
+    let run = RenderTester::mount(box_node(RenderSizedBox::fixed(px(80.0), px(60.0))))
+        .with_constraints(loose(200.0))
+        .run_layout();
+
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(80.0), px(60.0)));
+    assert_descendant_properties(&run.diagnostics(), "RenderSizedBox", &["width", "height"]);
+}
+
+#[test]
+fn harness_sized_box_expand_fills_parent() {
+    let run = RenderTester::mount(box_node(RenderSizedBox::expand()))
+        .with_size(Size::new(px(120.0), px(80.0)))
+        .run_layout();
+
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(120.0), px(80.0)));
+}
+
+#[test]
+fn harness_sized_box_shrink_collapses() {
+    let run = RenderTester::mount(box_node(RenderSizedBox::shrink()))
+        .with_constraints(loose(200.0))
+        .run_layout();
+
+    assert_eq!(run.box_geometry(run.root()), Size::ZERO);
+}
+
+#[test]
+fn harness_sized_box_width_only_leaves_height_loose() {
+    let run = RenderTester::mount(box_node(RenderSizedBox::new(Some(px(60.0)), None)))
+        .with_constraints(BoxConstraints::new(px(0.0), px(200.0), px(0.0), px(100.0)))
+        .run_layout();
+
+    assert_eq!(run.box_geometry(run.root()).width, px(60.0));
+    assert_eq!(run.box_geometry(run.root()).height, px(100.0));
+}
+
+#[test]
+fn harness_colored_box_self_describes_and_paints() {
+    let run = RenderTester::mount(box_node(RenderColoredBox::red(50.0, 50.0)))
+        .with_size(Size::new(px(100.0), px(100.0)))
+        .run_frame();
+
+    assert!(run.painted());
+    assert_eq!(
+        run.descendant_property("RenderColoredBox", "color")
+            .as_deref(),
+        Some("[1.0, 0.0, 0.0, 1.0]"),
+    );
+    let tree = run.diagnostics();
+    assert_has_committed_size(
+        tree.find_descendant("RenderColoredBox")
+            .expect("colored box"),
+    );
+}
+
+#[test]
+fn harness_colored_box_hit_test_within_bounds() {
+    let run = RenderTester::mount(box_node(RenderColoredBox::red(40.0, 40.0)))
+        .with_constraints(loose(200.0))
+        .run_frame();
+
+    assert_eq!(run.hit_first(20.0, 20.0), Some(run.root()));
+    assert!(run.hit(50.0, 50.0).is_empty());
+}
+
+#[test]
+fn harness_image_placeholder_lays_out_from_intrinsic_size() {
+    let run = RenderTester::mount(box_node(RenderImage::new(
+        Size::new(px(100.0), px(50.0)),
+        ImageFit::Contain,
+        ImageAlignment::Center,
+    )))
+    .with_size(Size::new(px(200.0), px(200.0)))
+    .run_layout();
+
+    assert!(run.box_geometry(run.root()).width.get() > 0.0);
+    assert_descendant_properties(
+        &run.diagnostics(),
+        "RenderImage",
+        &["intrinsic_size", "scale", "fit", "alignment"],
+    );
+}
+
+#[test]
+fn harness_image_paints_placeholder_frame() {
+    let run = RenderTester::mount(box_node(RenderImage::new(
+        Size::new(px(50.0), px(50.0)),
+        ImageFit::Cover,
+        ImageAlignment::Center,
+    )))
+    .with_size(Size::new(px(100.0), px(100.0)))
+    .run_frame();
+
+    assert!(run.painted());
+}
+
+#[test]
+fn harness_paragraph_lays_out_text() {
+    let run = RenderTester::mount(box_node(RenderParagraph::new(
+        TextSpan::new("hello harness"),
+        TextDirection::Ltr,
+    )))
+    .with_size(Size::new(px(200.0), px(100.0)))
+    .run_layout();
+
+    assert!(run.box_geometry(run.root()).height.get() > 0.0);
+    assert_descendant_properties(
+        &run.diagnostics(),
+        "RenderParagraph",
+        &["text_align", "text_direction"],
+    );
+}
+
+#[test]
+fn harness_paragraph_paints_text_frame() {
+    let run = RenderTester::mount(box_node(RenderParagraph::new(
+        TextSpan::new("paint me"),
+        TextDirection::Ltr,
+    )))
+    .with_size(Size::new(px(200.0), px(100.0)))
+    .run_frame();
+
+    assert!(run.painted());
+}
+
+// ============================================================================
+// Single-child box proxies
+// ============================================================================
+
+#[test]
+fn harness_padding_deflates_child_offset() {
+    let run = RenderTester::mount(
+        box_node(RenderPadding::all(12.0))
+            .child(box_node(RenderColoredBox::red(30.0, 30.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert_eq!(run.offset(run.id("child")), Offset::new(px(12.0), px(12.0)));
+    assert!(
+        run.descendant_property("RenderPadding", "padding")
+            .is_some()
+    );
+}
+
+#[test]
+fn harness_center_centers_child() {
+    let run = RenderTester::mount(
+        box_node(RenderCenter::new())
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_size(Size::new(px(100.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.offset(run.id("child")), Offset::new(px(30.0), px(30.0)));
+    assert!(run.diagnostics().find_descendant("RenderCenter").is_some());
+}
+
+#[test]
+fn harness_center_with_factors_shrinks_available_space() {
+    let run = RenderTester::mount(
+        box_node(
+            RenderCenter::new()
+                .with_width_factor(0.5)
+                .with_height_factor(0.5),
+        )
+        .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(20.0), px(20.0)));
+    assert!(
+        run.descendant_property("RenderCenter", "width_factor")
+            .is_some()
+    );
+    assert!(
+        run.descendant_property("RenderCenter", "height_factor")
+            .is_some()
+    );
+}
+
+#[test]
+fn harness_aspect_ratio_enforces_ratio() {
+    // Loose constraints let `_apply_aspect_ratio` honour the ratio; tight
+    // constraints return `constraints.smallest()` unchanged (Flutter parity).
+    let run = RenderTester::mount(
+        box_node(RenderAspectRatio::new(AspectRatio::new_unchecked(2.0)))
+            .child(box_node(RenderColoredBox::red(10.0, 10.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    let size = run.box_geometry(run.root());
+    assert!((size.width.get() / size.height.get() - 2.0).abs() < 0.01);
+    assert_eq!(
+        run.descendant_property_f64("RenderAspectRatio", "aspect_ratio"),
+        Some(2.0)
+    );
+}
+
+#[test]
+fn harness_aspect_ratio_tight_constraints_use_smallest_size() {
+    let run = RenderTester::mount(
+        box_node(RenderAspectRatio::new(AspectRatio::new_unchecked(2.0)))
+            .child(box_node(RenderColoredBox::red(10.0, 10.0)).label("child")),
+    )
+    .with_size(Size::new(px(200.0), px(200.0)))
+    .run_layout();
+
+    assert_eq!(
+        run.box_geometry(run.root()),
+        Size::new(px(200.0), px(200.0))
+    );
+}
+
+#[test]
+fn harness_constrained_box_enforces_minimums() {
+    let extra = BoxConstraints::new(px(100.0), px(f32::INFINITY), px(100.0), px(f32::INFINITY));
+    let run = RenderTester::mount(
+        box_node(RenderConstrainedBox::new(extra))
+            .child(box_node(RenderColoredBox::red(10.0, 10.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    let child = run.box_geometry(run.id("child"));
+    assert!(child.width.get() >= 100.0);
+    assert!(child.height.get() >= 100.0);
+    assert_descendant_properties(
+        &run.diagnostics(),
+        "RenderConstrainedBox",
+        &["additional_constraints"],
+    );
+}
+
+#[test]
+fn harness_limited_box_caps_unbounded_width_in_row() {
+    let run = RenderTester::mount(
+        box_node(RenderFlex::row()).child(
+            box_node(RenderLimitedBox::width(px(60.0)))
+                .child(box_node(RenderColoredBox::green(200.0, 20.0)).label("child")),
+        ),
+    )
+    .with_size(Size::new(px(200.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.box_geometry(run.id("child")).width, px(60.0));
+}
+
+#[test]
+fn harness_limited_box_self_describes_and_caps_unbounded_height() {
+    let run = RenderTester::mount(
+        box_node(RenderLimitedBox::height(px(40.0)))
+            .child(box_node(RenderColoredBox::green(200.0, 200.0)).label("child")),
+    )
+    .with_constraints(BoxConstraints::new(
+        px(0.0),
+        px(200.0),
+        px(0.0),
+        px(f32::INFINITY),
+    ))
+    .run_layout();
+
+    assert_eq!(run.box_geometry(run.id("child")).height, px(40.0));
+    assert_descendant_properties(
+        &run.diagnostics(),
+        "RenderLimitedBox",
+        &["max_width", "max_height"],
+    );
+}
+
+#[test]
+fn harness_offstage_hidden_collapses_and_misses_hits() {
+    let run = RenderTester::mount(
+        box_node(RenderOffstage::hidden())
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert_eq!(run.box_geometry(run.root()), Size::ZERO);
+    assert!(run.hit(10.0, 10.0).is_empty());
+    assert!(
+        run.descendant_property("RenderOffstage", "offstage")
+            .is_some()
+    );
+}
+
+#[test]
+fn harness_offstage_visible_passes_child_size() {
+    let run = RenderTester::mount(
+        box_node(RenderOffstage::visible())
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(40.0), px(40.0)));
+}
+
+#[test]
+fn harness_offstage_visible_hit_test_reaches_child() {
+    let run = RenderTester::mount(
+        box_node(RenderOffstage::visible())
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_frame();
+
+    assert_eq!(run.hit_first(20.0, 20.0), Some(run.id("child")));
+}
+
+#[test]
+fn harness_opacity_passes_child_geometry() {
+    let run = RenderTester::mount(
+        box_node(RenderOpacity::new(0.5))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(40.0), px(40.0)));
+    assert_eq!(
+        run.descendant_property_f64("RenderOpacity", "opacity"),
+        Some(0.5)
+    );
+}
+
+#[test]
+fn harness_opacity_paints_with_alpha_layer() {
+    let run = RenderTester::mount(
+        box_node(RenderOpacity::new(0.5))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_frame();
+
+    assert!(run.painted());
+    assert!(run.structure().contains(&"Opacity"));
+}
+
+#[test]
+fn harness_transform_passes_layout_and_self_describes() {
+    let run = RenderTester::mount(
+        box_node(RenderTransform::uniform_scale(2.0))
+            .child(box_node(RenderColoredBox::red(20.0, 20.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(20.0), px(20.0)));
+    assert!(
+        run.descendant_property("RenderTransform", "transform")
+            .is_some()
+    );
+}
+
+#[test]
+fn harness_transform_paints_with_transform_layer() {
+    let run = RenderTester::mount(
+        box_node(RenderTransform::uniform_scale(2.0))
+            .child(box_node(RenderColoredBox::red(20.0, 20.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_frame();
+
+    assert!(run.painted());
+    assert!(run.structure().contains(&"Transform"));
+}
+
+#[test]
+fn harness_fitted_box_sizes_to_parent() {
+    let run = RenderTester::mount(
+        box_node(RenderFittedBox::new(
+            BoxFit::Contain,
+            Alignment::CENTER,
+            Clip::None,
+        ))
+        .child(box_node(RenderColoredBox::red(100.0, 100.0)).label("child")),
+    )
+    .with_size(Size::new(px(50.0), px(50.0)))
+    .run_layout();
+
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(50.0), px(50.0)));
+    assert_descendant_properties(
+        &run.diagnostics(),
+        "RenderFittedBox",
+        &["fit", "clip_behavior"],
+    );
+}
+
+#[test]
+fn harness_fractionally_sized_box_applies_width_factor() {
+    let run = RenderTester::mount(
+        box_node(RenderFractionallySizedBox::new().with_width_factor(FractionFactor::HALF))
+            .child(box_node(RenderColoredBox::red(10.0, 10.0)).label("child")),
+    )
+    .with_size(Size::new(px(200.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.box_geometry(run.id("child")).width, px(100.0));
+}
+
+#[test]
+fn harness_fractionally_sized_box_height_factor_and_diagnostics() {
+    let run = RenderTester::mount(
+        box_node(
+            RenderFractionallySizedBox::new()
+                .with_height_factor(FractionFactor::HALF)
+                .with_alignment(Alignment::BOTTOM_RIGHT),
+        )
+        .child(box_node(RenderColoredBox::red(10.0, 10.0)).label("child")),
+    )
+    .with_size(Size::new(px(200.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.box_geometry(run.id("child")).height, px(50.0));
+    assert_descendant_properties(
+        &run.diagnostics(),
+        "RenderFractionallySizedBox",
+        &["width_factor", "height_factor", "alignment"],
+    );
+}
+
+#[test]
+fn harness_fractional_translation_passes_child_size() {
+    let run = RenderTester::mount(
+        box_node(RenderFractionalTranslation::translated(
+            TranslationFraction::new(-0.5, 0.0),
+        ))
+        .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(40.0), px(40.0)));
+    assert_descendant_properties(
+        &run.diagnostics(),
+        "RenderFractionalTranslation",
+        &["translation", "transform_hit_tests"],
+    );
+}
+
+#[test]
+fn harness_fractional_translation_without_hit_transform_uses_layout_bounds() {
+    let run = RenderTester::mount(
+        box_node(RenderFractionalTranslation::new(
+            TranslationFraction::new(-0.5, 0.0),
+            false,
+        ))
+        .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_frame();
+
+    assert_eq!(run.hit_first(20.0, 20.0), Some(run.id("child")));
+    assert!(
+        run.descendant_property("RenderFractionalTranslation", "transform_hit_tests")
+            .is_none(),
+        "false transform_hit_tests flags are omitted from diagnostics",
+    );
+}
+
+#[test]
+fn harness_decorated_box_wraps_child() {
+    let run = RenderTester::mount(
+        box_node(RenderDecoratedBox::new(BoxDecoration::with_color(
+            Color::RED,
+        )))
+        .child(box_node(RenderColoredBox::blue(40.0, 40.0)).label("child")),
+    )
+    .with_size(Size::new(px(100.0), px(100.0)))
+    .run_frame();
+
+    assert!(run.painted());
+    assert_descendant_properties(&run.diagnostics(), "RenderDecoratedBox", &["decoration"]);
+}
+
+#[test]
+fn harness_decorated_box_layout_wraps_child_geometry() {
+    let run = RenderTester::mount(
+        box_node(RenderDecoratedBox::new(BoxDecoration::with_color(
+            Color::BLUE,
+        )))
+        .child(box_node(RenderColoredBox::red(30.0, 30.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert_eq!(
+        run.box_geometry(run.id("child")),
+        Size::new(px(30.0), px(30.0))
+    );
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(30.0), px(30.0)));
+}
+
+#[test]
+fn harness_clip_rect_self_describes() {
+    let run = RenderTester::mount(
+        box_node(RenderClipRect::new(Clip::HardEdge))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert_descendant_properties(&run.diagnostics(), "RenderClipRect", &["clip_behavior"]);
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(40.0), px(40.0)));
+}
+
+#[test]
+fn harness_clip_rect_custom_clipper_flag() {
+    let run = RenderTester::mount(
+        box_node(
+            RenderClipRect::anti_alias()
+                .with_clipper(|size| Rect::from_origin_size(Point::ZERO, size)),
+        )
+        .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert!(
+        run.descendant_property("RenderClipRect", "custom_clipper")
+            .is_some()
+    );
+}
+
+#[test]
+fn harness_clip_rrect_wraps_child() {
+    let run = RenderTester::mount(
+        box_node(RenderClipRRect::new(Clip::AntiAlias))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert_descendant_properties(&run.diagnostics(), "RenderClipRRect", &["clip_behavior"]);
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(40.0), px(40.0)));
+}
+
+#[test]
+fn harness_clip_oval_wraps_child() {
+    let run = RenderTester::mount(
+        box_node(RenderClipOval::new(Clip::AntiAlias))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert_descendant_properties(&run.diagnostics(), "RenderClipOval", &["clip_behavior"]);
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(40.0), px(40.0)));
+}
+
+#[test]
+fn harness_clip_path_wraps_child() {
+    let run = RenderTester::mount(
+        box_node(RenderClipPath::new(Clip::AntiAlias))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert_descendant_properties(&run.diagnostics(), "RenderClipPath", &["clip_behavior"]);
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(40.0), px(40.0)));
+}
+
+#[test]
+fn harness_repaint_boundary_splits_layer_tree() {
+    let run = RenderTester::mount(
+        box_node(RenderRepaintBoundary::new())
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_frame();
+
+    assert_eq!(run.structure(), vec!["Offset", "Picture"]);
+}
+
+#[test]
+fn harness_repaint_boundary_committed_size() {
+    let run = RenderTester::mount(
+        box_node(RenderRepaintBoundary::new())
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    let tree = run.diagnostics();
+    assert_has_committed_size(
+        tree.find_descendant("RenderRepaintBoundary")
+            .expect("boundary"),
+    );
+}
+
+#[test]
+fn harness_metadata_with_payload() {
+    let run = RenderTester::mount(
+        box_node(RenderMetaData::new().with_metadata(42u32))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(40.0), px(40.0)));
+    assert_descendant_properties(
+        &run.diagnostics(),
+        "RenderMetaData",
+        &["has_metadata", "behavior"],
+    );
+}
+
+#[test]
+fn harness_metadata_without_payload_omits_has_metadata_flag() {
+    let run = RenderTester::mount(
+        box_node(RenderMetaData::new())
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert!(
+        run.descendant_property("RenderMetaData", "has_metadata")
+            .is_none()
+    );
+    assert!(
+        run.descendant_property("RenderMetaData", "behavior")
+            .is_some()
+    );
+}
+
+// ============================================================================
+// Multi-child box objects
+// ============================================================================
+
+#[test]
+fn harness_flex_row_positions_children_on_main_axis() {
+    let run = RenderTester::mount(
+        box_node(RenderFlex::row())
+            .child(box_node(RenderColoredBox::red(30.0, 20.0)).label("a"))
+            .child(box_node(RenderColoredBox::green(50.0, 20.0)).label("b")),
+    )
+    .with_size(Size::new(px(200.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.offset(run.id("a")), Offset::ZERO);
+    assert_eq!(run.offset(run.id("b")), Offset::new(px(30.0), px(0.0)));
+    assert_eq!(
+        run.descendant_property("RenderFlex", "direction")
+            .as_deref(),
+        Some("Horizontal"),
+    );
+}
+
+#[test]
+fn harness_flex_column_stacks_children_vertically() {
+    let run = RenderTester::mount(
+        box_node(RenderFlex::column())
+            .child(box_node(RenderColoredBox::red(30.0, 20.0)).label("a"))
+            .child(box_node(RenderColoredBox::green(30.0, 25.0)).label("b")),
+    )
+    .with_size(Size::new(px(200.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.offset(run.id("a")), Offset::ZERO);
+    assert_eq!(run.offset(run.id("b")), Offset::new(px(0.0), px(20.0)));
+    assert_eq!(
+        run.descendant_property("RenderFlex", "direction")
+            .as_deref(),
+        Some("Vertical"),
+    );
+}
+
+#[test]
+fn harness_stack_hit_tests_top_child_first() {
+    let run = RenderTester::mount(
+        box_node(RenderStack::new())
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("bottom"))
+            .child(box_node(RenderColoredBox::green(40.0, 40.0)).label("top")),
+    )
+    .with_size(Size::new(px(100.0), px(100.0)))
+    .run_frame();
+
+    assert_eq!(run.hit_first(20.0, 20.0), Some(run.id("top")));
+    assert_descendant_properties(&run.diagnostics(), "RenderStack", &["fit", "clip_behavior"]);
+}
+
+#[test]
+fn harness_stack_expand_fit_stretches_non_positioned_child() {
+    let run = RenderTester::mount(
+        box_node(RenderStack::new().with_fit(StackFit::Expand))
+            .child(box_node(RenderColoredBox::red(10.0, 10.0)).label("child")),
+    )
+    .with_size(Size::new(px(100.0), px(80.0)))
+    .run_layout();
+
+    assert_eq!(
+        run.box_geometry(run.id("child")),
+        Size::new(px(100.0), px(80.0))
+    );
+}
+
+#[test]
+fn harness_stack_positioned_child_layout_and_hit_test() {
+    let run = RenderTester::mount(
+        box_node(RenderStack::new())
+            .child(box_node(RenderColoredBox::red(60.0, 60.0)).label("base"))
+            .child(
+                box_node(RenderColoredBox::green(20.0, 20.0))
+                    .with_stack_parent_data(StackParentData::new().with_top(8.0).with_left(16.0))
+                    .label("badge"),
+            ),
+    )
+    .with_size(Size::new(px(100.0), px(100.0)))
+    .run_frame();
+
+    assert_eq!(run.offset(run.id("badge")), Offset::new(px(16.0), px(8.0)));
+    assert_eq!(run.hit_first(20.0, 12.0), Some(run.id("badge")));
+    assert_eq!(run.hit_first(5.0, 5.0), Some(run.id("base")));
+}
+
+// ============================================================================
+// Pointer semantics
+// ============================================================================
+
+#[test]
+fn harness_absorb_pointer_self_describes() {
+    let run = RenderTester::mount(
+        box_node(RenderAbsorbPointer::new(true))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert!(
+        run.descendant_property("RenderAbsorbPointer", "absorbing")
+            .is_some()
+    );
+}
+
+#[test]
+fn harness_ignore_pointer_self_describes() {
+    let run = RenderTester::mount(
+        box_node(RenderIgnorePointer::new(true))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert!(
+        run.descendant_property("RenderIgnorePointer", "ignoring")
+            .is_some()
+    );
+}
+
+#[test]
+fn harness_absorb_pointer_blocks_child_hits() {
+    let run = RenderTester::mount(
+        box_node(RenderStack::new())
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("below"))
+            .child(
+                box_node(RenderAbsorbPointer::new(true))
+                    .child(box_node(RenderColoredBox::green(40.0, 40.0)).label("inner"))
+                    .label("absorb"),
+            ),
+    )
+    .with_size(Size::new(px(100.0), px(100.0)))
+    .run_frame();
+
+    let path = run.hit(20.0, 20.0);
+    assert!(path.contains(&run.id("absorb")));
+    assert!(!path.contains(&run.id("inner")));
+}
+
+#[test]
+fn harness_ignore_pointer_lets_hits_pass_to_sibling_below() {
+    let run = RenderTester::mount(
+        box_node(RenderStack::new())
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("below"))
+            .child(
+                box_node(RenderIgnorePointer::new(true))
+                    .child(box_node(RenderColoredBox::green(40.0, 40.0)).label("inner"))
+                    .label("ignore"),
+            ),
+    )
+    .with_size(Size::new(px(100.0), px(100.0)))
+    .run_frame();
+
+    assert_eq!(run.hit_first(20.0, 20.0), Some(run.id("below")));
+}
+
+// ============================================================================
+// Sliver objects (via viewport host)
+// ============================================================================
+
+#[test]
+fn harness_sliver_fixed_extent_list_geometry() {
+    let run = RenderTester::mount(viewport(
+        sliver_node(RenderSliverFixedExtentList::new(25.0))
+            .label("list")
+            .child(box_node(RenderColoredBox::red(300.0, 1000.0)).label("item0"))
+            .child(box_node(RenderColoredBox::green(300.0, 1000.0))),
+    ))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.sliver_geometry(run.id("list")).scroll_extent, 50.0);
+    assert_eq!(run.box_geometry(run.id("item0")).height, px(25.0));
+    assert_descendant_properties(
+        &run.diagnostics(),
+        "RenderSliverFixedExtentList",
+        &["item_extent"],
+    );
+    let tree = run.diagnostics();
+    let sliver = tree.find_descendant("RenderSliverFixedExtentList").unwrap();
+    assert_has_committed_geometry(sliver);
+}
+
+#[test]
+fn harness_sliver_padding_insets_geometry() {
+    let run = RenderTester::mount(viewport(
+        sliver_node(RenderSliverPadding::symmetric(10.0, 0.0))
+            .label("pad")
+            .child(
+                sliver_node(RenderSliverFixedExtentList::new(20.0))
+                    .child(box_node(RenderColoredBox::red(300.0, 1000.0))),
+            ),
+    ))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    assert!(
+        run.descendant_property("RenderSliverPadding", "padding")
+            .is_some()
+    );
+    assert!(run.sliver_geometry(run.id("pad")).scroll_extent > 0.0);
+    let tree = run.diagnostics();
+    assert_has_committed_geometry(
+        tree.find_descendant("RenderSliverPadding")
+            .expect("padding"),
+    );
+}
+
+#[test]
+fn harness_sliver_to_box_adapter_scroll_extent_matches_child() {
+    let run = RenderTester::mount(viewport(
+        sliver_node(RenderSliverToBoxAdapter::new())
+            .label("adapter")
+            .child(box_node(RenderSizedBox::fixed(px(300.0), px(42.0))).label("box")),
+    ))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.sliver_geometry(run.id("adapter")).scroll_extent, 42.0);
+    let tree = run.diagnostics();
+    assert_has_committed_geometry(
+        tree.find_descendant("RenderSliverToBoxAdapter")
+            .expect("adapter"),
+    );
+}
+
+#[test]
+fn harness_sliver_fill_viewport_fraction() {
+    let run = RenderTester::mount(viewport(
+        sliver_node(RenderSliverFillViewport::new(0.5))
+            .label("fill")
+            .child(box_node(RenderColoredBox::red(300.0, 1000.0)).label("page")),
+    ))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.sliver_geometry(run.id("fill")).scroll_extent, 50.0);
+    assert_eq!(run.box_geometry(run.id("page")).height, px(50.0));
+    assert_descendant_properties(
+        &run.diagnostics(),
+        "RenderSliverFillViewport",
+        &["viewport_fraction"],
+    );
+}
+
+#[test]
+fn harness_sliver_fill_remaining_uses_viewport_remainder() {
+    let run = RenderTester::mount(viewport(
+        sliver_node(RenderSliverFillRemaining::new())
+            .label("fill")
+            .child(box_node(RenderColoredBox::red(300.0, 10.0)).label("child")),
+    ))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.sliver_geometry(run.id("fill")).scroll_extent, 100.0);
+    let tree = run.diagnostics();
+    let node = tree.find_descendant("RenderSliverFillRemaining").unwrap();
+    assert_has_committed_geometry(node);
+}
+
+#[test]
+fn harness_sliver_fill_remaining_and_overscroll_fills_viewport() {
+    let run = RenderTester::mount(viewport(
+        sliver_node(RenderSliverFillRemainingAndOverscroll::new())
+            .label("fill")
+            .child(box_node(RenderColoredBox::red(300.0, 10.0)).label("child")),
+    ))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.sliver_geometry(run.id("fill")).scroll_extent, 100.0);
+    assert_eq!(run.box_geometry(run.id("child")).height, px(100.0));
+    let tree = run.diagnostics();
+    let node = tree
+        .find_descendant("RenderSliverFillRemainingAndOverscroll")
+        .unwrap();
+    assert_has_committed_geometry(node);
+}
+
+#[test]
+fn harness_sliver_fill_remaining_with_scrollable_reports_full_scroll_extent() {
+    let run = RenderTester::mount(viewport(
+        sliver_node(RenderSliverFillRemainingWithScrollable::new())
+            .label("fill")
+            .child(box_node(RenderColoredBox::red(300.0, 10.0)).label("child")),
+    ))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.sliver_geometry(run.id("fill")).scroll_extent, 100.0);
+    assert_eq!(run.box_geometry(run.id("child")).height, px(100.0));
+    let tree = run.diagnostics();
+    let node = tree
+        .find_descendant("RenderSliverFillRemainingWithScrollable")
+        .unwrap();
+    assert_has_committed_geometry(node);
+}
+
+#[test]
+fn harness_sliver_ignore_pointer_blocks_hits_when_active() {
+    let run = RenderTester::mount(viewport(
+        sliver_node(RenderSliverIgnorePointer::new(true))
+            .label("ignore")
+            .child(
+                sliver_node(RenderSliverFixedExtentList::new(30.0))
+                    .child(box_node(RenderColoredBox::red(300.0, 1000.0)).label("item")),
+            ),
+    ))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_frame();
+
+    assert!(run.hit(20.0, 20.0).is_empty());
+    assert!(
+        run.descendant_property("RenderSliverIgnorePointer", "ignoring")
+            .is_some()
+    );
+}
+
+#[test]
+fn harness_sliver_ignore_pointer_passes_hits_when_inactive() {
+    let run = RenderTester::mount(viewport(
+        sliver_node(RenderSliverIgnorePointer::new(false))
+            .label("ignore")
+            .child(
+                sliver_node(RenderSliverFixedExtentList::new(30.0))
+                    .child(box_node(RenderColoredBox::red(300.0, 1000.0)).label("item")),
+            ),
+    ))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_frame();
+
+    assert_eq!(run.hit_first(20.0, 20.0), Some(run.id("item")));
+}
+
+#[test]
+fn harness_sliver_offstage_hidden_reports_zero_geometry() {
+    let run = RenderTester::mount(viewport(
+        sliver_node(RenderSliverOffstage::hidden())
+            .label("off")
+            .child(
+                sliver_node(RenderSliverFixedExtentList::new(30.0))
+                    .child(box_node(RenderColoredBox::red(300.0, 1000.0))),
+            ),
+    ))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.sliver_geometry(run.id("off")).scroll_extent, 0.0);
+    assert!(
+        run.descendant_property("RenderSliverOffstage", "offstage")
+            .is_some()
+    );
+}
+
+#[test]
+fn harness_sliver_offstage_visible_reports_child_geometry() {
+    let run = RenderTester::mount(viewport(
+        sliver_node(RenderSliverOffstage::visible())
+            .label("off")
+            .child(
+                sliver_node(RenderSliverFixedExtentList::new(30.0))
+                    .child(box_node(RenderColoredBox::red(300.0, 1000.0)).label("item")),
+            ),
+    ))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.sliver_geometry(run.id("off")).scroll_extent, 30.0);
+}
+
+#[test]
+fn harness_sliver_opacity_passes_geometry() {
+    let run = RenderTester::mount(viewport(
+        sliver_node(RenderSliverOpacity::new(0.5))
+            .label("opacity")
+            .child(
+                sliver_node(RenderSliverFixedExtentList::new(30.0))
+                    .child(box_node(RenderColoredBox::red(300.0, 1000.0))),
+            ),
+    ))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.sliver_geometry(run.id("opacity")).scroll_extent, 30.0);
+    assert_eq!(
+        run.descendant_property_f64("RenderSliverOpacity", "opacity"),
+        Some(0.5)
+    );
+}
+
+#[test]
+fn harness_viewport_self_describes() {
+    let run = RenderTester::mount(viewport(
+        sliver_node(RenderSliverFixedExtentList::new(20.0))
+            .child(box_node(RenderColoredBox::red(300.0, 1000.0))),
+    ))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    assert_descendant_properties(
+        &run.diagnostics(),
+        "RenderViewport",
+        &["axis_direction", "offset", "cache_extent"],
+    );
+}
+
+#[test]
+fn harness_viewport_stacks_two_slivers() {
+    let run = RenderTester::mount(viewport_multi([
+        sliver_node(RenderSliverFixedExtentList::new(20.0))
+            .label("header")
+            .child(box_node(RenderColoredBox::red(300.0, 1000.0))),
+        sliver_node(RenderSliverFillRemaining::new())
+            .label("body")
+            .child(box_node(RenderColoredBox::green(300.0, 10.0)).label("fill_child")),
+    ]))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.sliver_geometry(run.id("header")).scroll_extent, 20.0);
+    assert_eq!(run.sliver_geometry(run.id("body")).scroll_extent, 80.0);
+}
+
+// ============================================================================
+// Catalog guard — every exported render type must be exercised above
+// ============================================================================
+
+#[test]
+fn catalog_covers_every_render_object_name() {
+    let source = include_str!("render_object_harness.rs");
+    for &type_name in RENDER_OBJECT_TYPES {
+        let hits = source.matches(type_name).count();
+        assert!(
+            hits >= 3,
+            "{type_name} must appear in the module doc, RENDER_OBJECT_TYPES, and at least one \
+             harness test (found {hits} references)",
+        );
+    }
+}

--- a/crates/flui-rendering/tests/render_viewport.rs
+++ b/crates/flui-rendering/tests/render_viewport.rs
@@ -9,11 +9,11 @@ use flui_foundation::Diagnosticable;
 use flui_rendering::{
     constraints::{BoxConstraints, SliverConstraints, SliverGeometry},
     context::{SliverHitTestContext, SliverLayoutContext},
-    hit_testing::HitTestResult,
     objects::RenderViewport,
     parent_data::SliverParentData,
     pipeline::PipelineOwner,
     protocol::SliverProtocol,
+    testing::inspect,
     traits::{
         HotReloadCapability, PaintEffectsCapability, RenderObject, RenderSliver,
         SemanticsCapability,
@@ -40,11 +40,7 @@ fn render_offset(
     owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
     id: flui_foundation::RenderId,
 ) -> Offset {
-    owner
-        .render_tree()
-        .get(id)
-        .map(flui_rendering::storage::RenderNode::offset)
-        .expect("node exists")
+    inspect::render_offset(owner, id).expect("node exists")
 }
 
 fn hits(
@@ -60,9 +56,7 @@ fn hits_at(
     x: f32,
     y: f32,
 ) -> Vec<flui_foundation::RenderId> {
-    let mut result = HitTestResult::new();
-    owner.hit_test(Offset::new(px(x), px(y)), &mut result);
-    result.path().iter().map(|entry| entry.target).collect()
+    inspect::hit_path(owner, x, y)
 }
 
 const fn test_cross_axis_direction(axis_direction: AxisDirection) -> AxisDirection {

--- a/crates/flui-rendering/tests/sliver_fill_remaining.rs
+++ b/crates/flui-rendering/tests/sliver_fill_remaining.rs
@@ -1,7 +1,6 @@
 use flui_rendering::{
-    constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
+    constraints::{BoxConstraints, SliverConstraints, SliverGeometry},
     context::{BoxHitTestContext, BoxIntrinsicsCtx, BoxLayoutContext, SliverLayoutContext},
-    hit_testing::HitTestResult,
     objects::{
         RenderSliverFillRemaining, RenderSliverFillRemainingAndOverscroll,
         RenderSliverFillRemainingWithScrollable,
@@ -10,11 +9,11 @@ use flui_rendering::{
     pipeline::PipelineOwner,
     protocol::{BoxProtocol, SliverProtocol},
     storage::IntrinsicDimension,
+    testing::{inspect, sliver as sliver_presets},
     traits::{
         HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, RenderSliver,
         SemanticsCapability,
     },
-    view::ScrollDirection,
 };
 use flui_tree::{Leaf, Single};
 use flui_types::{Offset, Rect, Size, geometry::px, layout::AxisDirection};
@@ -28,20 +27,16 @@ fn vertical_constraints(
     remaining_paint_extent: f32,
     overlap: f32,
 ) -> SliverConstraints {
-    SliverConstraints {
-        axis_direction: AxisDirection::TopToBottom,
-        cross_axis_direction: AxisDirection::LeftToRight,
-        growth_direction: GrowthDirection::Forward,
-        user_scroll_direction: ScrollDirection::Idle,
-        scroll_offset,
-        preceding_scroll_extent,
-        overlap,
-        remaining_paint_extent,
-        cross_axis_extent: 300.0,
-        viewport_main_axis_extent: 100.0,
-        remaining_cache_extent: 120.0,
-        cache_origin: -20.0,
-    }
+    sliver_presets::vertical()
+        .scroll_offset(scroll_offset)
+        .preceding_scroll_extent(preceding_scroll_extent)
+        .overlap(overlap)
+        .remaining_paint_extent(remaining_paint_extent)
+        .cross_axis_extent(300.0)
+        .viewport_main_axis_extent(100.0)
+        .remaining_cache_extent(120.0)
+        .cache_origin(-20.0)
+        .build()
 }
 
 fn laid_out(
@@ -59,35 +54,21 @@ fn sliver_geometry(
     owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
     id: flui_foundation::RenderId,
 ) -> SliverGeometry {
-    owner
-        .render_tree()
-        .get(id)
-        .and_then(|node| node.as_sliver())
-        .and_then(|entry| entry.state().geometry())
-        .expect("sliver geometry is committed")
+    inspect::sliver_geometry(owner, id).expect("sliver geometry is committed")
 }
 
 fn box_size(
     owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
     id: flui_foundation::RenderId,
 ) -> Size {
-    owner
-        .render_tree()
-        .get(id)
-        .and_then(|node| node.as_box())
-        .and_then(|entry| entry.state().geometry())
-        .expect("box geometry is committed")
+    inspect::box_geometry(owner, id).expect("box geometry is committed")
 }
 
 fn render_offset(
     owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
     id: flui_foundation::RenderId,
 ) -> Offset {
-    owner
-        .render_tree()
-        .get(id)
-        .map(flui_rendering::storage::RenderNode::offset)
-        .expect("node exists")
+    inspect::render_offset(owner, id).expect("node exists")
 }
 
 fn hits(
@@ -95,9 +76,7 @@ fn hits(
     cross: f32,
     main: f32,
 ) -> Vec<flui_foundation::RenderId> {
-    let mut result = HitTestResult::new();
-    owner.hit_test(Offset::new(px(cross), px(main)), &mut result);
-    result.path().iter().map(|entry| entry.target).collect()
+    inspect::hit_path(owner, cross, main)
 }
 
 #[derive(Debug)]

--- a/crates/flui-rendering/tests/sliver_fill_viewport.rs
+++ b/crates/flui-rendering/tests/sliver_fill_viewport.rs
@@ -1,17 +1,16 @@
 //! `RenderSliverFillViewport` — direct Box children with viewport-sized extents.
 
 use flui_rendering::{
-    constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
+    constraints::{BoxConstraints, SliverConstraints, SliverGeometry},
     context::{BoxHitTestContext, BoxLayoutContext},
-    hit_testing::HitTestResult,
     objects::RenderSliverFillViewport,
     parent_data::BoxParentData,
     pipeline::PipelineOwner,
     protocol::{BoxProtocol, SliverProtocol},
+    testing::{inspect, sliver as sliver_presets},
     traits::{
         HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, SemanticsCapability,
     },
-    view::ScrollDirection,
 };
 use flui_tree::Leaf;
 use flui_types::{Offset, Rect, Size, geometry::px, layout::AxisDirection};
@@ -20,37 +19,25 @@ type BoxedRenderObject = Box<dyn RenderObject<BoxProtocol>>;
 type BoxedSliverObject = Box<dyn RenderObject<SliverProtocol>>;
 
 fn vertical_constraints(scroll_offset: f32) -> SliverConstraints {
-    SliverConstraints {
-        axis_direction: AxisDirection::TopToBottom,
-        cross_axis_direction: AxisDirection::LeftToRight,
-        growth_direction: GrowthDirection::Forward,
-        user_scroll_direction: ScrollDirection::Idle,
-        scroll_offset,
-        preceding_scroll_extent: 0.0,
-        overlap: 0.0,
-        remaining_paint_extent: 100.0,
-        cross_axis_extent: 300.0,
-        viewport_main_axis_extent: 100.0,
-        remaining_cache_extent: 120.0,
-        cache_origin: -20.0,
-    }
+    sliver_presets::vertical()
+        .scroll_offset(scroll_offset)
+        .remaining_paint_extent(100.0)
+        .cross_axis_extent(300.0)
+        .viewport_main_axis_extent(100.0)
+        .remaining_cache_extent(120.0)
+        .cache_origin(-20.0)
+        .build()
 }
 
 fn horizontal_constraints(scroll_offset: f32) -> SliverConstraints {
-    SliverConstraints {
-        axis_direction: AxisDirection::LeftToRight,
-        cross_axis_direction: AxisDirection::TopToBottom,
-        growth_direction: GrowthDirection::Forward,
-        user_scroll_direction: ScrollDirection::Idle,
-        scroll_offset,
-        preceding_scroll_extent: 0.0,
-        overlap: 0.0,
-        remaining_paint_extent: 300.0,
-        cross_axis_extent: 100.0,
-        viewport_main_axis_extent: 300.0,
-        remaining_cache_extent: 320.0,
-        cache_origin: -20.0,
-    }
+    sliver_presets::horizontal()
+        .scroll_offset(scroll_offset)
+        .remaining_paint_extent(300.0)
+        .cross_axis_extent(100.0)
+        .viewport_main_axis_extent(300.0)
+        .remaining_cache_extent(320.0)
+        .cache_origin(-20.0)
+        .build()
 }
 
 fn laid_out(
@@ -68,35 +55,21 @@ fn sliver_geometry(
     owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
     id: flui_foundation::RenderId,
 ) -> SliverGeometry {
-    owner
-        .render_tree()
-        .get(id)
-        .and_then(|node| node.as_sliver())
-        .and_then(|entry| entry.state().geometry())
-        .expect("sliver geometry is committed")
+    inspect::sliver_geometry(owner, id).expect("sliver geometry is committed")
 }
 
 fn box_size(
     owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
     id: flui_foundation::RenderId,
 ) -> Size {
-    owner
-        .render_tree()
-        .get(id)
-        .and_then(|node| node.as_box())
-        .and_then(|entry| entry.state().geometry())
-        .expect("box geometry is committed")
+    inspect::box_geometry(owner, id).expect("box geometry is committed")
 }
 
 fn render_offset(
     owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
     id: flui_foundation::RenderId,
 ) -> Offset {
-    owner
-        .render_tree()
-        .get(id)
-        .map(flui_rendering::storage::RenderNode::offset)
-        .expect("node exists")
+    inspect::render_offset(owner, id).expect("node exists")
 }
 
 fn hits(
@@ -104,9 +77,7 @@ fn hits(
     cross: f32,
     main: f32,
 ) -> Vec<flui_foundation::RenderId> {
-    let mut result = HitTestResult::new();
-    owner.hit_test(Offset::new(px(cross), px(main)), &mut result);
-    result.path().iter().map(|entry| entry.target).collect()
+    inspect::hit_path(owner, cross, main)
 }
 
 #[derive(Debug)]

--- a/crates/flui-rendering/tests/sliver_fixed_extent_list.rs
+++ b/crates/flui-rendering/tests/sliver_fixed_extent_list.rs
@@ -1,17 +1,16 @@
 //! `RenderSliverFixedExtentList` — direct Box children with a fixed main-axis extent.
 
 use flui_rendering::{
-    constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
+    constraints::{BoxConstraints, SliverConstraints, SliverGeometry},
     context::{BoxHitTestContext, BoxLayoutContext},
-    hit_testing::HitTestResult,
     objects::RenderSliverFixedExtentList,
     parent_data::BoxParentData,
     pipeline::PipelineOwner,
     protocol::{BoxProtocol, SliverProtocol},
+    testing::{inspect, sliver as sliver_presets},
     traits::{
         HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, SemanticsCapability,
     },
-    view::ScrollDirection,
 };
 use flui_tree::Leaf;
 use flui_types::{Offset, Rect, Size, geometry::px, layout::AxisDirection};
@@ -20,37 +19,25 @@ type BoxedRenderObject = Box<dyn RenderObject<BoxProtocol>>;
 type BoxedSliverObject = Box<dyn RenderObject<SliverProtocol>>;
 
 fn vertical_constraints(scroll_offset: f32) -> SliverConstraints {
-    SliverConstraints {
-        axis_direction: AxisDirection::TopToBottom,
-        cross_axis_direction: AxisDirection::LeftToRight,
-        growth_direction: GrowthDirection::Forward,
-        user_scroll_direction: ScrollDirection::Idle,
-        scroll_offset,
-        preceding_scroll_extent: 0.0,
-        overlap: 0.0,
-        remaining_paint_extent: 100.0,
-        cross_axis_extent: 300.0,
-        viewport_main_axis_extent: 100.0,
-        remaining_cache_extent: 120.0,
-        cache_origin: -20.0,
-    }
+    sliver_presets::vertical()
+        .scroll_offset(scroll_offset)
+        .remaining_paint_extent(100.0)
+        .cross_axis_extent(300.0)
+        .viewport_main_axis_extent(100.0)
+        .remaining_cache_extent(120.0)
+        .cache_origin(-20.0)
+        .build()
 }
 
 fn horizontal_constraints(scroll_offset: f32) -> SliverConstraints {
-    SliverConstraints {
-        axis_direction: AxisDirection::LeftToRight,
-        cross_axis_direction: AxisDirection::TopToBottom,
-        growth_direction: GrowthDirection::Forward,
-        user_scroll_direction: ScrollDirection::Idle,
-        scroll_offset,
-        preceding_scroll_extent: 0.0,
-        overlap: 0.0,
-        remaining_paint_extent: 300.0,
-        cross_axis_extent: 100.0,
-        viewport_main_axis_extent: 300.0,
-        remaining_cache_extent: 320.0,
-        cache_origin: -20.0,
-    }
+    sliver_presets::horizontal()
+        .scroll_offset(scroll_offset)
+        .remaining_paint_extent(300.0)
+        .cross_axis_extent(100.0)
+        .viewport_main_axis_extent(300.0)
+        .remaining_cache_extent(320.0)
+        .cache_origin(-20.0)
+        .build()
 }
 
 fn laid_out(
@@ -68,35 +55,21 @@ fn sliver_geometry(
     owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
     id: flui_foundation::RenderId,
 ) -> SliverGeometry {
-    owner
-        .render_tree()
-        .get(id)
-        .and_then(|node| node.as_sliver())
-        .and_then(|entry| entry.state().geometry())
-        .expect("sliver geometry is committed")
+    inspect::sliver_geometry(owner, id).expect("sliver geometry is committed")
 }
 
 fn box_size(
     owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
     id: flui_foundation::RenderId,
 ) -> Size {
-    owner
-        .render_tree()
-        .get(id)
-        .and_then(|node| node.as_box())
-        .and_then(|entry| entry.state().geometry())
-        .expect("box geometry is committed")
+    inspect::box_geometry(owner, id).expect("box geometry is committed")
 }
 
 fn render_offset(
     owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
     id: flui_foundation::RenderId,
 ) -> Offset {
-    owner
-        .render_tree()
-        .get(id)
-        .map(flui_rendering::storage::RenderNode::offset)
-        .expect("node exists")
+    inspect::render_offset(owner, id).expect("node exists")
 }
 
 fn hits(
@@ -104,9 +77,7 @@ fn hits(
     x: f32,
     y: f32,
 ) -> Vec<flui_foundation::RenderId> {
-    let mut result = HitTestResult::new();
-    owner.hit_test(Offset::new(px(x), px(y)), &mut result);
-    result.path().iter().map(|entry| entry.target).collect()
+    inspect::hit_path(owner, x, y)
 }
 
 #[derive(Debug)]
@@ -243,6 +214,21 @@ fn sliver_fixed_extent_list_sizes_children_to_item_extent() {
     assert_eq!(geometry.hit_test_extent, 95.0);
     assert_eq!(geometry.cache_extent, 115.0);
     assert!(geometry.has_visual_overflow);
+
+    // The Diagnosticable-backed dump surfaces the sliver's committed
+    // geometry (cross-protocol: sliver nodes carry a `geometry` property,
+    // box nodes carry `size`). Exercises `PipelineOwner::debug_diagnostics_tree`
+    // and the foundation `DiagnosticsNode` query getters.
+    let diagnostics = owner
+        .debug_diagnostics_tree()
+        .expect("laid-out tree has a diagnostics root");
+    let sliver = diagnostics
+        .find_descendant("RenderSliverFixedExtentList")
+        .expect("the host's sliver child appears in the diagnostics tree");
+    assert!(
+        sliver.get_property("geometry").is_some(),
+        "the sliver self-reports its committed geometry in the dump",
+    );
 
     for &child_id in &child_ids {
         assert_eq!(box_size(&owner, child_id), Size::new(px(300.0), px(30.0)));

--- a/crates/flui-rendering/tests/sliver_to_box_adapter.rs
+++ b/crates/flui-rendering/tests/sliver_to_box_adapter.rs
@@ -12,37 +12,30 @@
 use flui_rendering::{
     constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
     context::{BoxHitTestContext, BoxLayoutContext},
-    hit_testing::HitTestResult,
     objects::RenderSliverToBoxAdapter,
     parent_data::BoxParentData,
     pipeline::PipelineOwner,
     protocol::{BoxProtocol, SliverProtocol},
+    testing::{inspect, sliver as sliver_presets},
     traits::{
         HotReloadCapability, PaintEffectsCapability, RenderBox, RenderObject, SemanticsCapability,
     },
-    view::ScrollDirection,
 };
 use flui_tree::Leaf;
-use flui_types::{Offset, Rect, Size, geometry::px, layout::AxisDirection};
+use flui_types::{Offset, Rect, Size, geometry::px};
 
 type BoxedRenderObject = Box<dyn RenderObject<BoxProtocol>>;
 type BoxedSliverObject = Box<dyn RenderObject<SliverProtocol>>;
 
 fn vertical_constraints(scroll_offset: f32) -> SliverConstraints {
-    SliverConstraints {
-        axis_direction: AxisDirection::TopToBottom,
-        cross_axis_direction: AxisDirection::LeftToRight,
-        growth_direction: GrowthDirection::Forward,
-        user_scroll_direction: ScrollDirection::Idle,
-        scroll_offset,
-        preceding_scroll_extent: 0.0,
-        overlap: 0.0,
-        remaining_paint_extent: 100.0,
-        cross_axis_extent: 300.0,
-        viewport_main_axis_extent: 100.0,
-        remaining_cache_extent: 120.0,
-        cache_origin: -20.0,
-    }
+    sliver_presets::vertical()
+        .scroll_offset(scroll_offset)
+        .remaining_paint_extent(100.0)
+        .cross_axis_extent(300.0)
+        .viewport_main_axis_extent(100.0)
+        .remaining_cache_extent(120.0)
+        .cache_origin(-20.0)
+        .build()
 }
 
 fn laid_out(
@@ -60,23 +53,14 @@ fn sliver_geometry(
     owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
     id: flui_foundation::RenderId,
 ) -> SliverGeometry {
-    owner
-        .render_tree()
-        .get(id)
-        .and_then(|node| node.as_sliver())
-        .and_then(|entry| entry.state().geometry())
-        .expect("sliver geometry is committed")
+    inspect::sliver_geometry(owner, id).expect("sliver geometry is committed")
 }
 
 fn render_offset(
     owner: &PipelineOwner<flui_rendering::pipeline::phase::Layout>,
     id: flui_foundation::RenderId,
 ) -> Offset {
-    owner
-        .render_tree()
-        .get(id)
-        .map(flui_rendering::storage::RenderNode::offset)
-        .expect("node exists")
+    inspect::render_offset(owner, id).expect("node exists")
 }
 
 fn hits(
@@ -84,9 +68,7 @@ fn hits(
     cross: f32,
     main: f32,
 ) -> Vec<flui_foundation::RenderId> {
-    let mut result = HitTestResult::new();
-    owner.hit_test(Offset::new(px(cross), px(main)), &mut result);
-    result.path().iter().map(|entry| entry.target).collect()
+    inspect::hit_path(owner, cross, main)
 }
 
 #[derive(Debug)]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -135,6 +135,92 @@ The constitution requires `///` doc comments on every public item and `//!` over
 - **Visual regression tests** (planned) will use snapshot-based comparison against the headless backend.
 - **No mocking frameworks.** Use trait-based test doubles. The `HeadlessPlatform` backend is the canonical test surface for platform-dependent code.
 
+## Test Harnesses (`testing` feature)
+
+The rendering stack ships opt-in test harnesses (off by default so they never
+land in normal/release builds). Each crate enables `testing` for its own
+tests/benches/examples via a self dev-dependency; downstream crates opt in with
+`features = ["testing"]`.
+
+**Per-crate guides (API reference + examples):**
+
+| Crate | Doc | Entry point |
+|-------|-----|-------------|
+| `flui-rendering` | [crates/flui-rendering/docs/TESTING.md](../crates/flui-rendering/docs/TESTING.md) | `RenderTester`, `Probe`, `box_node` / `sliver_node`, multi-frame `FrameRun` |
+| `flui-layer` | [crates/flui-layer/docs/TESTING.md](../crates/flui-layer/docs/TESTING.md) | `LayerTester`, `layer`, `inspect::structure` |
+| `flui-painting` | [crates/flui-painting/docs/TESTING.md](../crates/flui-painting/docs/TESTING.md) | `record`, `command_count`, `bounds`, `diagnostics` |
+| `flui-foundation` | [crates/flui-foundation/docs/TESTING.md](../crates/flui-foundation/docs/TESTING.md) | `DiagnosticsNode` / `DiagnosticsBuilder` for structured assertions (no `testing` module) |
+
+| Crate | What it gives you |
+|-------|-------------------|
+| `flui-painting` | Builds a `DisplayList` without `Canvas::new()` / `finish()` boilerplate. |
+| `flui-layer` | Declarative `LayerTree` builder and layer walkers reused by `flui-rendering`. |
+| `flui-rendering` | Real `PipelineOwner` trees (Box + Sliver), layout/frame depths, animation helpers. |
+| `flui-foundation` | Diagnostics substrate: `find_descendant`, `get_property`, typed property builders. |
+
+Diagnostics dumps are backed by `flui_foundation::Diagnosticable`: every node
+self-describes its own **user-config** properties (a `RenderFlex`'s
+`main_axis_alignment`, a `RenderPadding`'s `padding`), while `PipelineOwner`
+adds committed **runtime** fields (`offset`, `size`, sliver `geometry`) when
+building the tree. Property names use **snake_case** (Rust idiom, not Dart
+camelCase). Prefer typed builder helpers (`add_enum`, `add_default_double`,
+`add_flag`, `add_size`) over raw `format!("{:?}")` strings — defaults are
+hidden automatically and kinds format cleanly in dumps.
+
+Structured assertions should use `Probe::property` / `property_f64` /
+`descendant_property` (or `DiagnosticsNode::get_property` /
+`find_descendant`) instead of substring-matching `Probe::dump()`. Use
+`to_string_deep_at_level(DiagnosticLevel::Info)` when fine-grained debug
+properties should be omitted.
+
+A `Probe::dump()` is what a failing assertion should print to show *why*.
+
+```bash
+cargo run -p flui-rendering --example render_inspector --features testing
+cargo test -p flui-rendering --test render_object_harness
+```
+
+### Render-object harness catalog
+
+`crates/flui-rendering/tests/render_object_harness.rs` is the CI-facing
+catalog: every concrete `RenderBox` / `RenderSliver` type is mounted
+through `RenderTester`, laid out (or painted when hit-test / layer
+structure matters), and asserted via `Probe` + structured diagnostics
+queries. The file header lists a per-type coverage map; `RENDER_OBJECT_TYPES`
+is the manifest of all 37 exported render types; and
+`catalog_covers_every_render_object_name` fails CI if any type is missing
+from the harness file. Add a harness test when landing a new render object
+so layout, hit-test, and config/runtime diagnostics stay pinned without
+visual inspection.
+
+Parent metadata that widgets normally write before layout (stack
+positioning, flex factors, future animation parent slots) can be expressed
+in harness trees via [`ParentDataSeed`](../../crates/flui-rendering/src/testing/parent_data.rs)
+on [`TreeNode::with_parent_data_seed`](../../crates/flui-rendering/src/testing/tree.rs).
+The pipeline clones each seed into the per-walk child slots before
+`perform_layout` runs.
+
+### Multi-frame and animation testing
+
+After `.run_frame()`, [`FrameRun`](../../crates/flui-rendering/src/testing/harness.rs)
+supports deterministic multi-frame scenarios (no wall clock):
+
+| Method | Use when |
+|--------|----------|
+| `update` + `pump` | Layout changed (padding, size, position) |
+| `update_paint` + `pump` | Paint-only change (color, opacity) |
+| `advance_layout` / `advance_paint` | Shorthand: mutate + one frame |
+| `simulate(ticks, \|t, run\| …)` | Tick loop: mutate in closure, auto-pump each step |
+| `pump_frames(n)` | Skip `n` frames (idle frames produce no layer tree) |
+| `pump_idle_frames(n)` | Strict: panic if any skipped frame paints or stays dirty |
+
+Pair with `AnimationController::tick_at(t)` inside `simulate` for
+production-faithful animation tests. Assert per frame via `Probe` (`offset`,
+`box_geometry`, `picture_bounds`, `property`) and layer helpers
+(`opacity_alpha`, `has_picture_layer`). See
+`crates/flui-rendering/tests/harness_animation.rs` and
+`crates/flui-rendering/tests/animation_pipeline.rs`.
+
 ## CI Expectations
 
 The same three quality gates run in CI on every PR:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -207,7 +207,7 @@ supports deterministic multi-frame scenarios (no wall clock):
 
 | Method | Use when |
 |--------|----------|
-| `update` + `pump` | Layout changed (padding, size, position) |
+| `update` + `pump` | Layout changed (padding, size, sliver extent) |
 | `update_paint` + `pump` | Paint-only change (color, opacity) |
 | `advance_layout` / `advance_paint` | Shorthand: mutate + one frame |
 | `simulate(ticks, \|t, run\| …)` | Tick loop: mutate in closure, auto-pump each step |

--- a/scripts/port-check.sh
+++ b/scripts/port-check.sh
@@ -678,7 +678,7 @@ for libfile in ${trigger11_lib_files}; do
       fi
       prev_lineno=$((prev_lineno - 1))
     done
-    if echo "${prev_content}" | grep -qE '#\[cfg\(feature[[:space:]]*=[[:space:]]*"unstable-'; then
+    if echo "${prev_content}" | grep -qE '#\[cfg\([^)]*feature[[:space:]]*=[[:space:]]*"(unstable-|testing)"'; then
       continue
     fi
 


### PR DESCRIPTION
## Summary

- Add opt-in `testing` modules to `flui-rendering`, `flui-layer`, and `flui-painting` so render objects are exercised through the real `PipelineOwner` pipeline (layout, compositing, paint, hit-test) without GPU or a window.
- Introduce `RenderTester` / `Probe` with declarative `box_node` / `sliver_node` trees, `ParentDataSeed` for stack/flex parent metadata, structured diagnostics assertions, and multi-frame helpers (`advance_layout`, `advance_paint`, `simulate`, `pump_idle_frames`).
- Extend `flui_foundation` diagnostics (`find_descendant`, typed `DiagnosticsBuilder` helpers) and migrate render-object diagnostic property names to snake_case.
- Add CI catalog `render_object_harness.rs` (all 37 exported render types + guard test), `harness_animation.rs`, `render_inspector` example, and per-crate `docs/TESTING.md` guides.

## Test plan

- [x] `cargo test -p flui-rendering`
- [x] `cargo test -p flui-rendering --test render_object_harness`
- [x] `cargo test -p flui-rendering --test harness_animation`
- [x] `cargo test -p flui-layer`
- [x] `cargo test -p flui-painting`
- [x] `cargo clippy -p flui-rendering -p flui-layer --all-targets -- -D warnings`
- [ ] CI green on PR
