### PR TITLE
fix(rendering): box query forwarding, layout validation, and flex intrinsics

### DIFF
--- a/crates/flui-painting/src/text_painter/measure.rs
+++ b/crates/flui-painting/src/text_painter/measure.rs
@@ -283,6 +283,19 @@ impl TextPainter {
         let (metrics, _) = self.compute_layout_metrics(text, min_width, max_width);
         metrics.size
     }
+
+    /// Where the first baseline of the given kind would sit after a dry
+    /// layout under the width constraints, without touching
+    /// `layout_cache`.
+    #[must_use]
+    pub fn dry_baseline(&self, min_width: f32, max_width: f32, baseline: TextBaseline) -> Option<f32> {
+        let text = self.text.as_ref()?;
+        let (metrics, _) = self.compute_layout_metrics(text, min_width, max_width);
+        Some(match baseline {
+            TextBaseline::Alphabetic => metrics.alphabetic_baseline,
+            TextBaseline::Ideographic => metrics.ideographic_baseline,
+        })
+    }
 }
 
 /// Flattens an [`InlineSpan`] tree into per-run `(text, merged style)`

--- a/crates/flui-painting/src/text_painter/measure.rs
+++ b/crates/flui-painting/src/text_painter/measure.rs
@@ -288,7 +288,12 @@ impl TextPainter {
     /// layout under the width constraints, without touching
     /// `layout_cache`.
     #[must_use]
-    pub fn dry_baseline(&self, min_width: f32, max_width: f32, baseline: TextBaseline) -> Option<f32> {
+    pub fn dry_baseline(
+        &self,
+        min_width: f32,
+        max_width: f32,
+        baseline: TextBaseline,
+    ) -> Option<f32> {
         let text = self.text.as_ref()?;
         let (metrics, _) = self.compute_layout_metrics(text, min_width, max_width);
         Some(match baseline {

--- a/crates/flui-rendering/docs/TESTING.md
+++ b/crates/flui-rendering/docs/TESTING.md
@@ -34,7 +34,8 @@ TreeNode spec  →  RenderTester::mount  →  run_layout | run_frame
    [`sliver_node`](../src/testing/tree.rs), optional [`ParentDataSeed`](../src/testing/parent_data.rs),
    and [`TreeNode::label`](../src/testing/tree.rs).
 2. **Drive** the production pipeline at the depth you need.
-3. **Inspect** through the shared [`Probe`](../src/testing/inspect.rs) trait.
+3. **Inspect** through the shared [`Probe`](../src/testing/inspect.rs) trait and,
+   for proxy query contracts, [`BoxQueryRun`](../src/testing/queries.rs).
 4. **Animate** with multi-frame helpers on [`FrameRun`](../src/testing/harness.rs).
 
 Diagnostics dumps combine each render object's **user config** (via
@@ -76,8 +77,9 @@ use **snake_case**.
 | `update_paint::<T>(id, edit)` | Mutate + paint-dirty (no layout pass here) |
 | `mark_needs_paint(id)` | Paint-dirty only |
 | `relayout()` | Re-run layout after `update` |
+| [`BoxQueryRun`](../src/testing/queries.rs) | Intrinsics / dry layout / dry baseline (see below) |
 
-Implements [`Probe`](../src/testing/inspect.rs).
+Implements [`Probe`](../src/testing/inspect.rs) and [`BoxQueryRun`](../src/testing/queries.rs).
 
 ### `FrameRun`
 
@@ -99,7 +101,7 @@ Implements [`Probe`](../src/testing/inspect.rs).
 | `opacity_alpha()` | First opacity layer alpha, if any |
 | `has_picture_layer()` | Whether a picture layer exists |
 
-Implements [`Probe`](../src/testing/inspect.rs).
+Implements [`Probe`](../src/testing/inspect.rs) and [`BoxQueryRun`](../src/testing/queries.rs).
 
 ### `Probe` (shared inspection)
 
@@ -115,6 +117,46 @@ Implements [`Probe`](../src/testing/inspect.rs).
 | `property_f64(id, "name")` | Parsed numeric property |
 | `descendant_property("RenderFlex", "direction")` | Find by type name |
 | `dump()` | Printable tree (for failure messages) |
+
+### `BoxQueryRun` (intrinsics / dry probes)
+
+Implemented on both [`LayoutRun`](../src/testing/harness.rs) and
+[`FrameRun`](../src/testing/harness.rs). Queries use the production
+[`PipelineOwner`](../src/pipeline/owner.rs) memoization path — they do **not**
+require a prior layout pass, but you can call them after `run_layout` or
+`run_frame` to assert proxy forwarding contracts.
+
+| Method | Purpose |
+|--------|---------|
+| `intrinsic_dimension(id, dimension, extent)` | Raw intrinsic dispatch |
+| `min_intrinsic_width(id, height)` | `computeMinIntrinsicWidth` |
+| `max_intrinsic_width(id, height)` | `computeMaxIntrinsicWidth` |
+| `min_intrinsic_height(id, width)` | `computeMinIntrinsicHeight` |
+| `max_intrinsic_height(id, width)` | `computeMaxIntrinsicHeight` |
+| `dry_layout(id, constraints)` | Flutter `getDryLayout` |
+| `dry_baseline(id, constraints, baseline)` | Flutter `getDryBaseline` |
+
+```rust
+use flui_rendering::objects::{RenderColoredBox, RenderOpacity};
+use flui_rendering::testing::{BoxQueryRun, RenderTester, box_node};
+use flui_types::{Size, geometry::px};
+
+let constraints = flui_rendering::constraints::BoxConstraints::new(
+    px(0.0), px(200.0), px(0.0), px(200.0),
+);
+let mut run = RenderTester::mount(
+    box_node(RenderOpacity::opaque())
+        .child(box_node(RenderColoredBox::red(40.0, 40.0))),
+)
+.with_constraints(constraints)
+.run_layout();
+
+assert_eq!(run.min_intrinsic_width(run.root(), 100.0), 40.0);
+assert_eq!(
+    run.dry_layout(run.root(), constraints),
+    Size::new(px(40.0), px(40.0)),
+);
+```
 
 ### Assertion helpers ([`assertions`](../src/testing/assertions.rs))
 

--- a/crates/flui-rendering/src/context/intrinsics.rs
+++ b/crates/flui-rendering/src/context/intrinsics.rs
@@ -11,6 +11,75 @@ use flui_types::Size;
 
 use crate::constraints::BoxConstraints;
 use crate::storage::IntrinsicDimension;
+use crate::traits::TextBaseline;
+
+/// Child probe kinds issued during a dry-baseline computation.
+#[derive(Debug, Clone, Copy)]
+pub enum DryBaselineChildRequest {
+    /// Dry baseline under `constraints`.
+    Baseline(BoxConstraints, TextBaseline),
+    /// Dry layout size under `constraints`.
+    DryLayout(BoxConstraints),
+}
+
+/// Answers to [`DryBaselineChildRequest`].
+#[derive(Debug, Clone, Copy)]
+pub enum DryBaselineChildResponse {
+    /// Child dry-baseline result.
+    Baseline(Option<f32>),
+    /// Child dry-layout size.
+    DryLayout(Size),
+}
+
+/// Child-query channel for one dry-baseline computation.
+///
+/// Handed to [`RenderBox::compute_dry_baseline`]; baseline and dry-layout
+/// child probes share one driver callback so the slot map is borrowed once.
+pub struct BoxDryBaselineCtx<'a> {
+    child_count: usize,
+    query: &'a mut (dyn FnMut(usize, DryBaselineChildRequest) -> DryBaselineChildResponse
+             + Send
+             + Sync),
+}
+
+impl<'a> BoxDryBaselineCtx<'a> {
+    /// Wraps the driver's child dry-baseline callback.
+    pub(crate) fn new(
+        child_count: usize,
+        query: &'a mut (dyn FnMut(usize, DryBaselineChildRequest) -> DryBaselineChildResponse
+                 + Send
+                 + Sync),
+    ) -> Self {
+        Self { child_count, query }
+    }
+
+    /// Number of tree children.
+    #[must_use]
+    pub fn child_count(&self) -> usize {
+        self.child_count
+    }
+
+    /// The dry baseline the child would report under `constraints`.
+    pub fn child_dry_baseline(
+        &mut self,
+        index: usize,
+        constraints: BoxConstraints,
+        baseline: TextBaseline,
+    ) -> Option<f32> {
+        match (self.query)(index, DryBaselineChildRequest::Baseline(constraints, baseline)) {
+            DryBaselineChildResponse::Baseline(v) => v,
+            DryBaselineChildResponse::DryLayout(_) => None,
+        }
+    }
+
+    /// The size the child would take under `constraints`, without laying it out.
+    pub fn child_dry_layout(&mut self, index: usize, constraints: BoxConstraints) -> Size {
+        match (self.query)(index, DryBaselineChildRequest::DryLayout(constraints)) {
+            DryBaselineChildResponse::DryLayout(size) => size,
+            DryBaselineChildResponse::Baseline(_) => Size::ZERO,
+        }
+    }
+}
 
 /// Child-query channel for one intrinsic computation.
 ///
@@ -132,5 +201,22 @@ pub(crate) mod test_support {
             )
         };
         f(&mut BoxDryLayoutCtx::new(0, &mut deny))
+    }
+
+    /// Leaf context for `compute_dry_baseline` tests.
+    pub(crate) fn leaf_dry_baseline<R>(f: impl FnOnce(&mut BoxDryBaselineCtx<'_>) -> R) -> R {
+        let mut deny = |index: usize, request: DryBaselineChildRequest| -> DryBaselineChildResponse {
+            match request {
+                DryBaselineChildRequest::Baseline(constraints, baseline) => panic!(
+                    "leaf object dry-baselined child {index} ({constraints:?}, {baseline:?}) — \
+                 a childless compute_dry_baseline must not consult children"
+                ),
+                DryBaselineChildRequest::DryLayout(constraints) => panic!(
+                    "leaf object dry-laid out child {index} ({constraints:?}) during dry baseline — \
+                 a childless compute_dry_baseline must not consult children"
+                ),
+            }
+        };
+        f(&mut BoxDryBaselineCtx::new(0, &mut deny))
     }
 }

--- a/crates/flui-rendering/src/context/intrinsics.rs
+++ b/crates/flui-rendering/src/context/intrinsics.rs
@@ -86,6 +86,14 @@ impl<'a> BoxDryBaselineCtx<'a> {
     }
 }
 
+/// Driver callbacks for one intrinsic computation.
+pub struct IntrinsicChildChannel<'a> {
+    /// Memoized child intrinsic probes.
+    pub query: &'a mut (dyn FnMut(usize, IntrinsicDimension, f32) -> f32 + Send + Sync),
+    /// Flex factor for child `index` (`0` when inflexible or unknown).
+    pub flex: &'a mut (dyn FnMut(usize) -> i32 + Send + Sync),
+}
+
 /// Child-query channel for one intrinsic computation.
 ///
 /// Handed to [`RenderBox::compute_min_intrinsic_width`] and friends.
@@ -97,15 +105,21 @@ impl<'a> BoxDryBaselineCtx<'a> {
 pub struct BoxIntrinsicsCtx<'a> {
     child_count: usize,
     query: &'a mut (dyn FnMut(usize, IntrinsicDimension, f32) -> f32 + Send + Sync),
+    flex: &'a mut (dyn FnMut(usize) -> i32 + Send + Sync),
 }
 
 impl<'a> BoxIntrinsicsCtx<'a> {
-    /// Wraps the driver's child-query callback.
+    /// Wraps the driver's child-query and flex-factor callbacks.
     pub(crate) fn new(
         child_count: usize,
         query: &'a mut (dyn FnMut(usize, IntrinsicDimension, f32) -> f32 + Send + Sync),
+        flex: &'a mut (dyn FnMut(usize) -> i32 + Send + Sync),
     ) -> Self {
-        Self { child_count, query }
+        Self {
+            child_count,
+            query,
+            flex,
+        }
     }
 
     /// Number of tree children.
@@ -142,6 +156,11 @@ impl<'a> BoxIntrinsicsCtx<'a> {
     /// The child's maximum intrinsic height for the given width.
     pub fn child_max_intrinsic_height(&mut self, index: usize, width: f32) -> f32 {
         self.child_intrinsic(index, IntrinsicDimension::MaxHeight, width)
+    }
+
+    /// Flex factor for child `index` (`0` when inflexible or unknown).
+    pub fn child_flex(&mut self, index: usize) -> i32 {
+        (self.flex)(index).max(0)
     }
 }
 
@@ -187,13 +206,23 @@ pub(crate) mod test_support {
     /// childless objects: any child query is a contract violation and
     /// panics with the probe's coordinates.
     pub(crate) fn leaf_intrinsics<R>(f: impl FnOnce(&mut BoxIntrinsicsCtx<'_>) -> R) -> R {
-        let mut deny = |index: usize, dim: IntrinsicDimension, extent: f32| -> f32 {
+        let mut deny_query = |index: usize, dim: IntrinsicDimension, extent: f32| -> f32 {
             panic!(
                 "leaf object queried child {index} ({dim:?} @ {extent}) — \
                  a childless compute_* must not consult children"
             )
         };
-        f(&mut BoxIntrinsicsCtx::new(0, &mut deny))
+        let mut deny_flex = |index: usize| -> i32 {
+            panic!(
+                "leaf object queried flex for child {index} — \
+                 a childless compute_* must not consult children"
+            )
+        };
+        let mut channel = IntrinsicChildChannel {
+            query: &mut deny_query,
+            flex: &mut deny_flex,
+        };
+        f(&mut BoxIntrinsicsCtx::new(0, channel.query, channel.flex))
     }
 
     /// Leaf context for `compute_dry_layout` tests; mirrors

--- a/crates/flui-rendering/src/context/intrinsics.rs
+++ b/crates/flui-rendering/src/context/intrinsics.rs
@@ -37,18 +37,20 @@ pub enum DryBaselineChildResponse {
 /// child probes share one driver callback so the slot map is borrowed once.
 pub struct BoxDryBaselineCtx<'a> {
     child_count: usize,
-    query: &'a mut (dyn FnMut(usize, DryBaselineChildRequest) -> DryBaselineChildResponse
-             + Send
-             + Sync),
+    query: &'a mut (
+                dyn FnMut(usize, DryBaselineChildRequest) -> DryBaselineChildResponse + Send + Sync
+            ),
 }
 
 impl<'a> BoxDryBaselineCtx<'a> {
     /// Wraps the driver's child dry-baseline callback.
     pub(crate) fn new(
         child_count: usize,
-        query: &'a mut (dyn FnMut(usize, DryBaselineChildRequest) -> DryBaselineChildResponse
-                 + Send
-                 + Sync),
+        query: &'a mut (
+                    dyn FnMut(usize, DryBaselineChildRequest) -> DryBaselineChildResponse
+                        + Send
+                        + Sync
+                ),
     ) -> Self {
         Self { child_count, query }
     }
@@ -66,7 +68,10 @@ impl<'a> BoxDryBaselineCtx<'a> {
         constraints: BoxConstraints,
         baseline: TextBaseline,
     ) -> Option<f32> {
-        match (self.query)(index, DryBaselineChildRequest::Baseline(constraints, baseline)) {
+        match (self.query)(
+            index,
+            DryBaselineChildRequest::Baseline(constraints, baseline),
+        ) {
             DryBaselineChildResponse::Baseline(v) => v,
             DryBaselineChildResponse::DryLayout(_) => None,
         }
@@ -205,7 +210,9 @@ pub(crate) mod test_support {
 
     /// Leaf context for `compute_dry_baseline` tests.
     pub(crate) fn leaf_dry_baseline<R>(f: impl FnOnce(&mut BoxDryBaselineCtx<'_>) -> R) -> R {
-        let mut deny = |index: usize, request: DryBaselineChildRequest| -> DryBaselineChildResponse {
+        let mut deny = |index: usize,
+                        request: DryBaselineChildRequest|
+         -> DryBaselineChildResponse {
             match request {
                 DryBaselineChildRequest::Baseline(constraints, baseline) => panic!(
                     "leaf object dry-baselined child {index} ({constraints:?}, {baseline:?}) — \

--- a/crates/flui-rendering/src/context/intrinsics.rs
+++ b/crates/flui-rendering/src/context/intrinsics.rs
@@ -218,7 +218,7 @@ pub(crate) mod test_support {
                  a childless compute_* must not consult children"
             )
         };
-        let mut channel = IntrinsicChildChannel {
+        let channel = IntrinsicChildChannel {
             query: &mut deny_query,
             flex: &mut deny_flex,
         };

--- a/crates/flui-rendering/src/context/intrinsics.rs
+++ b/crates/flui-rendering/src/context/intrinsics.rs
@@ -33,7 +33,7 @@ pub enum DryBaselineChildResponse {
 
 /// Child-query channel for one dry-baseline computation.
 ///
-/// Handed to [`RenderBox::compute_dry_baseline`]; baseline and dry-layout
+/// Handed to [`crate::traits::RenderBox::compute_dry_baseline`]; baseline and dry-layout
 /// child probes share one driver callback so the slot map is borrowed once.
 pub struct BoxDryBaselineCtx<'a> {
     child_count: usize,

--- a/crates/flui-rendering/src/context/mod.rs
+++ b/crates/flui-rendering/src/context/mod.rs
@@ -61,7 +61,7 @@ pub use hit_test::HitTestContext;
 pub(crate) use intrinsics::test_support as intrinsics_test_support;
 pub use intrinsics::{
     BoxDryBaselineCtx, BoxDryLayoutCtx, BoxIntrinsicsCtx, DryBaselineChildRequest,
-    DryBaselineChildResponse,
+    DryBaselineChildResponse, IntrinsicChildChannel,
 };
 pub use layout::LayoutContext;
 pub(crate) use paint_cx::{FragmentClip, FragmentOp};

--- a/crates/flui-rendering/src/context/mod.rs
+++ b/crates/flui-rendering/src/context/mod.rs
@@ -53,12 +53,16 @@ mod hit_test;
 mod intrinsics;
 mod layout;
 mod paint_cx;
+pub mod proxy_queries;
 
 pub use flui_painting::{Canvas, DisplayList, Paint, PaintStyle};
 pub use hit_test::HitTestContext;
 #[cfg(test)]
 pub(crate) use intrinsics::test_support as intrinsics_test_support;
-pub use intrinsics::{BoxDryLayoutCtx, BoxIntrinsicsCtx};
+pub use intrinsics::{
+    BoxDryBaselineCtx, BoxDryLayoutCtx, BoxIntrinsicsCtx, DryBaselineChildRequest,
+    DryBaselineChildResponse,
+};
 pub use layout::LayoutContext;
 pub(crate) use paint_cx::{FragmentClip, FragmentOp};
 pub use paint_cx::{FragmentRecorder, PaintCx, PaintFragment};

--- a/crates/flui-rendering/src/context/proxy_queries.rs
+++ b/crates/flui-rendering/src/context/proxy_queries.rs
@@ -140,7 +140,9 @@ macro_rules! forward_single_child_box_queries {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::intrinsics::test_support::{leaf_dry_baseline, leaf_dry_layout, leaf_intrinsics};
+    use crate::context::intrinsics::test_support::{
+        leaf_dry_baseline, leaf_dry_layout, leaf_intrinsics,
+    };
 
     #[test]
     fn leaf_helpers_reject_child_queries() {

--- a/crates/flui-rendering/src/context/proxy_queries.rs
+++ b/crates/flui-rendering/src/context/proxy_queries.rs
@@ -1,0 +1,177 @@
+//! Shared helpers for single-child proxy boxes that pass layout queries
+//! through to their child unchanged (Flutter `RenderProxyBoxMixin` parity).
+
+use flui_types::Size;
+
+use crate::constraints::BoxConstraints;
+use crate::traits::TextBaseline;
+
+use super::{BoxDryBaselineCtx, BoxDryLayoutCtx, BoxIntrinsicsCtx};
+
+/// Minimum intrinsic width: child answer, or `0.0` when childless.
+#[inline]
+pub fn forward_min_intrinsic_width(ctx: &mut BoxIntrinsicsCtx<'_>, height: f32) -> f32 {
+    if ctx.child_count() == 0 {
+        0.0
+    } else {
+        ctx.child_min_intrinsic_width(0, height)
+    }
+}
+
+/// Maximum intrinsic width: child answer, or `0.0` when childless.
+#[inline]
+pub fn forward_max_intrinsic_width(ctx: &mut BoxIntrinsicsCtx<'_>, height: f32) -> f32 {
+    if ctx.child_count() == 0 {
+        0.0
+    } else {
+        ctx.child_max_intrinsic_width(0, height)
+    }
+}
+
+/// Minimum intrinsic height: child answer, or `0.0` when childless.
+#[inline]
+pub fn forward_min_intrinsic_height(ctx: &mut BoxIntrinsicsCtx<'_>, width: f32) -> f32 {
+    if ctx.child_count() == 0 {
+        0.0
+    } else {
+        ctx.child_min_intrinsic_height(0, width)
+    }
+}
+
+/// Maximum intrinsic height: child answer, or `0.0` when childless.
+#[inline]
+pub fn forward_max_intrinsic_height(ctx: &mut BoxIntrinsicsCtx<'_>, width: f32) -> f32 {
+    if ctx.child_count() == 0 {
+        0.0
+    } else {
+        ctx.child_max_intrinsic_height(0, width)
+    }
+}
+
+/// Dry layout: child size under the same constraints, or `smallest()` when
+/// childless (matches transparent proxy `perform_layout` with no child).
+#[inline]
+pub fn forward_dry_layout(constraints: BoxConstraints, ctx: &mut BoxDryLayoutCtx<'_>) -> Size {
+    if ctx.child_count() == 0 {
+        constraints.smallest()
+    } else {
+        ctx.child_dry_layout(0, constraints)
+    }
+}
+
+/// Dry baseline: child answer under the same constraints, or `None` when
+/// childless.
+#[inline]
+pub fn forward_dry_baseline(
+    constraints: BoxConstraints,
+    baseline: TextBaseline,
+    ctx: &mut BoxDryBaselineCtx<'_>,
+) -> Option<f32> {
+    if ctx.child_count() == 0 {
+        None
+    } else {
+        ctx.child_dry_baseline(0, constraints, baseline)
+    }
+}
+
+/// Expands the four intrinsic overrides for a pure single-child passthrough proxy.
+#[macro_export]
+macro_rules! forward_single_child_intrinsics {
+    () => {
+        fn compute_min_intrinsic_width(
+            &self,
+            height: f32,
+            ctx: &mut $crate::context::BoxIntrinsicsCtx<'_>,
+        ) -> f32 {
+            $crate::context::proxy_queries::forward_min_intrinsic_width(ctx, height)
+        }
+
+        fn compute_max_intrinsic_width(
+            &self,
+            height: f32,
+            ctx: &mut $crate::context::BoxIntrinsicsCtx<'_>,
+        ) -> f32 {
+            $crate::context::proxy_queries::forward_max_intrinsic_width(ctx, height)
+        }
+
+        fn compute_min_intrinsic_height(
+            &self,
+            width: f32,
+            ctx: &mut $crate::context::BoxIntrinsicsCtx<'_>,
+        ) -> f32 {
+            $crate::context::proxy_queries::forward_min_intrinsic_height(ctx, width)
+        }
+
+        fn compute_max_intrinsic_height(
+            &self,
+            width: f32,
+            ctx: &mut $crate::context::BoxIntrinsicsCtx<'_>,
+        ) -> f32 {
+            $crate::context::proxy_queries::forward_max_intrinsic_height(ctx, width)
+        }
+    };
+}
+
+/// Expands the six query overrides for a pure single-child passthrough proxy.
+#[macro_export]
+macro_rules! forward_single_child_box_queries {
+    () => {
+        $crate::forward_single_child_intrinsics!();
+
+        fn compute_dry_layout(
+            &self,
+            constraints: $crate::constraints::BoxConstraints,
+            ctx: &mut $crate::context::BoxDryLayoutCtx<'_>,
+        ) -> flui_types::Size {
+            $crate::context::proxy_queries::forward_dry_layout(constraints, ctx)
+        }
+
+        fn compute_dry_baseline(
+            &self,
+            constraints: $crate::constraints::BoxConstraints,
+            baseline: $crate::traits::TextBaseline,
+            ctx: &mut $crate::context::BoxDryBaselineCtx<'_>,
+        ) -> Option<f32> {
+            $crate::context::proxy_queries::forward_dry_baseline(constraints, baseline, ctx)
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::intrinsics::test_support::{leaf_dry_baseline, leaf_dry_layout, leaf_intrinsics};
+
+    #[test]
+    fn leaf_helpers_reject_child_queries() {
+        let w = leaf_intrinsics(|ctx| forward_min_intrinsic_width(ctx, 100.0));
+        assert_eq!(w, 0.0);
+
+        let size = leaf_dry_layout(|ctx| {
+            forward_dry_layout(
+                BoxConstraints::new(
+                    flui_types::geometry::px(0.0),
+                    flui_types::geometry::px(100.0),
+                    flui_types::geometry::px(0.0),
+                    flui_types::geometry::px(100.0),
+                ),
+                ctx,
+            )
+        });
+        assert_eq!(size, Size::ZERO);
+
+        let baseline = leaf_dry_baseline(|ctx| {
+            forward_dry_baseline(
+                BoxConstraints::new(
+                    flui_types::geometry::px(0.0),
+                    flui_types::geometry::px(100.0),
+                    flui_types::geometry::px(0.0),
+                    flui_types::geometry::px(100.0),
+                ),
+                TextBaseline::Alphabetic,
+                ctx,
+            )
+        });
+        assert!(baseline.is_none());
+    }
+}

--- a/crates/flui-rendering/src/objects/absorb_pointer.rs
+++ b/crates/flui-rendering/src/objects/absorb_pointer.rs
@@ -107,6 +107,8 @@ impl RenderBox for RenderAbsorbPointer {
         &mut self.size
     }
 
+    crate::forward_single_child_box_queries!();
+
     // paint: default pass-through (splices the child in order).
 
     fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Single, BoxParentData>) -> bool {

--- a/crates/flui-rendering/src/objects/aspect_ratio.rs
+++ b/crates/flui-rendering/src/objects/aspect_ratio.rs
@@ -360,6 +360,19 @@ impl RenderBox for RenderAspectRatio {
         // (proxy_box.dart `RenderAspectRatio.computeDryLayout`).
         self.apply_aspect_ratio(constraints)
     }
+
+    fn compute_dry_baseline(
+        &self,
+        constraints: BoxConstraints,
+        baseline: crate::traits::TextBaseline,
+        ctx: &mut crate::context::BoxDryBaselineCtx<'_>,
+    ) -> Option<f32> {
+        if ctx.child_count() == 0 {
+            return None;
+        }
+        let tight = BoxConstraints::tight(self.apply_aspect_ratio(constraints));
+        ctx.child_dry_baseline(0, tight, baseline)
+    }
 }
 
 // Mythos Step 11: explicit (default) capability opt-outs.

--- a/crates/flui-rendering/src/objects/center.rs
+++ b/crates/flui-rendering/src/objects/center.rs
@@ -4,9 +4,10 @@ use flui_tree::Single;
 use flui_types::{Offset, Point, Rect, Size};
 
 use crate::{
+    constraints::BoxConstraints,
     context::{BoxHitTestContext, BoxLayoutContext},
     parent_data::BoxParentData,
-    traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability},
+    traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability, TextBaseline},
 };
 
 /// A render object that centers its child within the available space.
@@ -62,6 +63,20 @@ impl RenderCenter {
     /// Returns the height factor.
     pub fn height_factor(&self) -> Option<f32> {
         self.height_factor
+    }
+
+    fn dry_size(&self, constraints: &BoxConstraints, child_size: Size) -> Size {
+        let width = if let Some(factor) = self.width_factor {
+            child_size.width * factor
+        } else {
+            constraints.max_width
+        };
+        let height = if let Some(factor) = self.height_factor {
+            child_size.height * factor
+        } else {
+            constraints.max_height
+        };
+        constraints.constrain(Size::new(width, height))
     }
 }
 
@@ -141,6 +156,83 @@ impl RenderBox for RenderCenter {
 
     fn size_mut(&mut self) -> &mut Size {
         &mut self.size
+    }
+
+    fn compute_min_intrinsic_width(
+        &self,
+        height: f32,
+        ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        if ctx.child_count() == 0 {
+            return 0.0;
+        }
+        let w_factor = self.width_factor.unwrap_or(1.0);
+        ctx.child_min_intrinsic_width(0, height) * w_factor
+    }
+
+    fn compute_max_intrinsic_width(
+        &self,
+        height: f32,
+        ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        if ctx.child_count() == 0 {
+            return 0.0;
+        }
+        let w_factor = self.width_factor.unwrap_or(1.0);
+        ctx.child_max_intrinsic_width(0, height) * w_factor
+    }
+
+    fn compute_min_intrinsic_height(
+        &self,
+        width: f32,
+        ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        if ctx.child_count() == 0 {
+            return 0.0;
+        }
+        let h_factor = self.height_factor.unwrap_or(1.0);
+        ctx.child_min_intrinsic_height(0, width) * h_factor
+    }
+
+    fn compute_max_intrinsic_height(
+        &self,
+        width: f32,
+        ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        if ctx.child_count() == 0 {
+            return 0.0;
+        }
+        let h_factor = self.height_factor.unwrap_or(1.0);
+        ctx.child_max_intrinsic_height(0, width) * h_factor
+    }
+
+    fn compute_dry_layout(
+        &self,
+        constraints: BoxConstraints,
+        ctx: &mut crate::context::BoxDryLayoutCtx<'_>,
+    ) -> Size {
+        if ctx.child_count() == 0 {
+            return constraints.biggest();
+        }
+        let child_size = ctx.child_dry_layout(0, constraints.loosen());
+        self.dry_size(&constraints, child_size)
+    }
+
+    fn compute_dry_baseline(
+        &self,
+        constraints: BoxConstraints,
+        baseline: TextBaseline,
+        ctx: &mut crate::context::BoxDryBaselineCtx<'_>,
+    ) -> Option<f32> {
+        if ctx.child_count() == 0 {
+            return None;
+        }
+        let child_constraints = constraints.loosen();
+        let child_baseline = ctx.child_dry_baseline(0, child_constraints, baseline)?;
+        let child_size = ctx.child_dry_layout(0, child_constraints);
+        let size = self.dry_size(&constraints, child_size);
+        let free_h = size.height.get() - child_size.height.get();
+        Some(child_baseline + free_h * 0.5)
     }
 
     // paint() uses default no-op - Center just positions children

--- a/crates/flui-rendering/src/objects/center.rs
+++ b/crates/flui-rendering/src/objects/center.rs
@@ -7,7 +7,9 @@ use crate::{
     constraints::BoxConstraints,
     context::{BoxHitTestContext, BoxLayoutContext},
     parent_data::BoxParentData,
-    traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability, TextBaseline},
+    traits::{
+        HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability, TextBaseline,
+    },
 };
 
 /// A render object that centers its child within the available space.

--- a/crates/flui-rendering/src/objects/clip.rs
+++ b/crates/flui-rendering/src/objects/clip.rs
@@ -533,6 +533,8 @@ impl<S: ClipGeometry> RenderBox for RenderClip<S> {
         &mut self.size
     }
 
+    crate::forward_single_child_box_queries!();
+
     fn paint(&self, ctx: &mut crate::context::PaintCx<'_, Single>) {
         // The clip is a LAYER scope so it covers the child subtree —
         // canvas clips are run-local in the fragment paint model and

--- a/crates/flui-rendering/src/objects/colored_box.rs
+++ b/crates/flui-rendering/src/objects/colored_box.rs
@@ -5,6 +5,7 @@ use flui_tree::Leaf;
 use flui_types::{Color, Point, Rect, Size, geometry::px};
 
 use crate::{
+    constraints::BoxConstraints,
     context::BoxLayoutContext,
     parent_data::BoxParentData,
     traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability},
@@ -97,6 +98,46 @@ impl RenderBox for RenderColoredBox {
     }
     fn size_mut(&mut self) -> &mut Size {
         &mut self.size
+    }
+
+    fn compute_min_intrinsic_width(
+        &self,
+        _height: f32,
+        _ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        self.preferred_size.width.get()
+    }
+
+    fn compute_max_intrinsic_width(
+        &self,
+        _height: f32,
+        _ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        self.preferred_size.width.get()
+    }
+
+    fn compute_min_intrinsic_height(
+        &self,
+        _width: f32,
+        _ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        self.preferred_size.height.get()
+    }
+
+    fn compute_max_intrinsic_height(
+        &self,
+        _width: f32,
+        _ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        self.preferred_size.height.get()
+    }
+
+    fn compute_dry_layout(
+        &self,
+        constraints: BoxConstraints,
+        _ctx: &mut crate::context::BoxDryLayoutCtx<'_>,
+    ) -> Size {
+        constraints.constrain(self.preferred_size)
     }
 
     fn paint(&self, ctx: &mut crate::context::PaintCx<'_, Leaf>) {

--- a/crates/flui-rendering/src/objects/constrained_box.rs
+++ b/crates/flui-rendering/src/objects/constrained_box.rs
@@ -274,6 +274,20 @@ impl RenderBox for RenderConstrainedBox {
             combined.constrain(Size::ZERO)
         }
     }
+
+    fn compute_dry_baseline(
+        &self,
+        constraints: BoxConstraints,
+        baseline: crate::traits::TextBaseline,
+        ctx: &mut crate::context::BoxDryBaselineCtx<'_>,
+    ) -> Option<f32> {
+        let combined = self.additional_constraints.enforce(&constraints);
+        if ctx.child_count() > 0 {
+            ctx.child_dry_baseline(0, combined, baseline)
+        } else {
+            None
+        }
+    }
 }
 
 // Mythos Step 11: explicit (default) capability opt-outs.

--- a/crates/flui-rendering/src/objects/decorated_box.rs
+++ b/crates/flui-rendering/src/objects/decorated_box.rs
@@ -119,6 +119,8 @@ impl RenderBox for RenderDecoratedBox {
         &mut self.size
     }
 
+    crate::forward_single_child_box_queries!();
+
     fn paint(&self, ctx: &mut PaintCx<'_, Single>) {
         let rect = self.paint_rect();
         if self.position == DecorationPosition::Background {

--- a/crates/flui-rendering/src/objects/fitted_box.rs
+++ b/crates/flui-rendering/src/objects/fitted_box.rs
@@ -44,7 +44,7 @@ use crate::{
     constraints::BoxConstraints,
     context::{BoxHitTestContext, BoxLayoutContext},
     parent_data::BoxParentData,
-    traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability},
+    traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability, TextBaseline},
 };
 
 /// A render object that scales its child to fit its own box.
@@ -295,6 +295,51 @@ impl RenderBox for RenderFittedBox {
 
     fn size_mut(&mut self) -> &mut Size {
         &mut self.size
+    }
+
+    crate::forward_single_child_intrinsics!();
+
+    fn compute_dry_layout(
+        &self,
+        constraints: BoxConstraints,
+        ctx: &mut crate::context::BoxDryLayoutCtx<'_>,
+    ) -> Size {
+        if ctx.child_count() == 0 {
+            return constraints.smallest();
+        }
+        let child_size = ctx.child_dry_layout(0, BoxConstraints::UNCONSTRAINED);
+        if child_size.width <= px(0.0) || child_size.height <= px(0.0) {
+            return constraints.smallest();
+        }
+        match self.fit {
+            BoxFit::ScaleDown => {
+                let loosened = constraints.loosen();
+                constraints.constrain(
+                    loosened.constrain_size_and_attempt_to_preserve_aspect_ratio(child_size),
+                )
+            }
+            BoxFit::Contain
+            | BoxFit::Cover
+            | BoxFit::Fill
+            | BoxFit::FitHeight
+            | BoxFit::FitWidth
+            | BoxFit::None => {
+                constraints.constrain_size_and_attempt_to_preserve_aspect_ratio(child_size)
+            }
+        }
+    }
+
+    fn compute_dry_baseline(
+        &self,
+        _constraints: BoxConstraints,
+        baseline: TextBaseline,
+        ctx: &mut crate::context::BoxDryBaselineCtx<'_>,
+    ) -> Option<f32> {
+        if ctx.child_count() == 0 {
+            None
+        } else {
+            ctx.child_dry_baseline(0, BoxConstraints::UNCONSTRAINED, baseline)
+        }
     }
 
     fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Single, BoxParentData>) -> bool {

--- a/crates/flui-rendering/src/objects/fitted_box.rs
+++ b/crates/flui-rendering/src/objects/fitted_box.rs
@@ -44,7 +44,9 @@ use crate::{
     constraints::BoxConstraints,
     context::{BoxHitTestContext, BoxLayoutContext},
     parent_data::BoxParentData,
-    traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability, TextBaseline},
+    traits::{
+        HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability, TextBaseline,
+    },
 };
 
 /// A render object that scales its child to fit its own box.

--- a/crates/flui-rendering/src/objects/flex.rs
+++ b/crates/flui-rendering/src/objects/flex.rs
@@ -235,7 +235,7 @@ impl RenderFlex {
         max_flex_fraction * total_flex as f32 + inflexible_space
     }
 
-    /// Folds child intrinsics along the cross axis (max for rows, sum for columns).
+    /// Folds child intrinsics along the cross axis (max of child cross sizes).
     fn intrinsic_cross(
         &self,
         ctx: &mut BoxIntrinsicsCtx<'_>,
@@ -246,22 +246,11 @@ impl RenderFlex {
         if child_count == 0 {
             return 0.0;
         }
-        match self.direction {
-            FlexDirection::Horizontal => {
-                let mut max = 0.0f32;
-                for i in 0..child_count {
-                    max = max.max(child_cross(ctx, i, main_extent));
-                }
-                max
-            }
-            FlexDirection::Vertical => {
-                let mut sum = 0.0f32;
-                for i in 0..child_count {
-                    sum += child_cross(ctx, i, main_extent);
-                }
-                sum + self.spacing * (child_count.saturating_sub(1)) as f32
-            }
+        let mut max = 0.0f32;
+        for i in 0..child_count {
+            max = max.max(child_cross(ctx, i, main_extent));
         }
+        max
     }
 }
 

--- a/crates/flui-rendering/src/objects/flex.rs
+++ b/crates/flui-rendering/src/objects/flex.rs
@@ -5,7 +5,7 @@ use flui_types::{Offset, Pixels, Point, Rect, Size, geometry::px};
 
 use crate::{
     constraints::BoxConstraints,
-    context::{BoxHitTestContext, BoxLayoutContext},
+    context::{BoxHitTestContext, BoxIntrinsicsCtx, BoxLayoutContext},
     parent_data::{FlexFit, FlexParentData},
     traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability},
 };
@@ -199,6 +199,65 @@ impl RenderFlex {
         match self.direction {
             FlexDirection::Horizontal => Size::new(main, cross),
             FlexDirection::Vertical => Size::new(cross, main),
+        }
+    }
+
+    /// Folds child intrinsics along the main axis (sum + spacing).
+    fn intrinsic_main(
+        &self,
+        ctx: &mut BoxIntrinsicsCtx<'_>,
+        cross_extent: f32,
+        mut child_main: impl FnMut(&mut BoxIntrinsicsCtx<'_>, usize, f32) -> f32,
+    ) -> f32 {
+        let child_count = ctx.child_count();
+        if child_count == 0 {
+            return 0.0;
+        }
+        let spacing_total = self.spacing * (child_count.saturating_sub(1)) as f32;
+        match self.direction {
+            FlexDirection::Horizontal => {
+                let mut sum = 0.0f32;
+                for i in 0..child_count {
+                    sum += child_main(ctx, i, cross_extent);
+                }
+                sum + spacing_total
+            }
+            FlexDirection::Vertical => {
+                let mut max = 0.0f32;
+                for i in 0..child_count {
+                    max = max.max(child_main(ctx, i, cross_extent));
+                }
+                max
+            }
+        }
+    }
+
+    /// Folds child intrinsics along the cross axis (max, or sum for columns).
+    fn intrinsic_cross(
+        &self,
+        ctx: &mut BoxIntrinsicsCtx<'_>,
+        main_extent: f32,
+        mut child_cross: impl FnMut(&mut BoxIntrinsicsCtx<'_>, usize, f32) -> f32,
+    ) -> f32 {
+        let child_count = ctx.child_count();
+        if child_count == 0 {
+            return 0.0;
+        }
+        match self.direction {
+            FlexDirection::Horizontal => {
+                let mut max = 0.0f32;
+                for i in 0..child_count {
+                    max = max.max(child_cross(ctx, i, main_extent));
+                }
+                max
+            }
+            FlexDirection::Vertical => {
+                let mut sum = 0.0f32;
+                for i in 0..child_count {
+                    sum += child_cross(ctx, i, main_extent);
+                }
+                sum + self.spacing * (child_count.saturating_sub(1)) as f32
+            }
         }
     }
 }
@@ -450,6 +509,30 @@ impl RenderBox for RenderFlex {
 
     fn size_mut(&mut self) -> &mut Size {
         &mut self.size
+    }
+
+    fn compute_min_intrinsic_width(&self, height: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        self.intrinsic_main(ctx, height, |ctx, i, extent| {
+            ctx.child_min_intrinsic_width(i, extent)
+        })
+    }
+
+    fn compute_max_intrinsic_width(&self, height: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        self.intrinsic_main(ctx, height, |ctx, i, extent| {
+            ctx.child_max_intrinsic_width(i, extent)
+        })
+    }
+
+    fn compute_min_intrinsic_height(&self, width: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        self.intrinsic_cross(ctx, width, |ctx, i, extent| {
+            ctx.child_min_intrinsic_height(i, extent)
+        })
+    }
+
+    fn compute_max_intrinsic_height(&self, width: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        self.intrinsic_cross(ctx, width, |ctx, i, extent| {
+            ctx.child_max_intrinsic_height(i, extent)
+        })
     }
 
     // paint() uses default no-op - Flex just positions children

--- a/crates/flui-rendering/src/objects/flex.rs
+++ b/crates/flui-rendering/src/objects/flex.rs
@@ -202,37 +202,40 @@ impl RenderFlex {
         }
     }
 
-    /// Folds child intrinsics along the main axis (sum + spacing).
-    fn intrinsic_main(
+    /// Flutter `RenderFlex._getIntrinsicSize` main-axis branch
+    /// (`flex.dart:716-733`): flex children contribute via the largest
+    /// per-flex-unit size; inflexible children sum directly.
+    fn fold_main_axis_intrinsics(
         &self,
         ctx: &mut BoxIntrinsicsCtx<'_>,
         cross_extent: f32,
-        mut child_main: impl FnMut(&mut BoxIntrinsicsCtx<'_>, usize, f32) -> f32,
+        mut child_size: impl FnMut(&mut BoxIntrinsicsCtx<'_>, usize, f32) -> f32,
     ) -> f32 {
         let child_count = ctx.child_count();
         if child_count == 0 {
             return 0.0;
         }
+
         let spacing_total = self.spacing * (child_count.saturating_sub(1)) as f32;
-        match self.direction {
-            FlexDirection::Horizontal => {
-                let mut sum = 0.0f32;
-                for i in 0..child_count {
-                    sum += child_main(ctx, i, cross_extent);
-                }
-                sum + spacing_total
-            }
-            FlexDirection::Vertical => {
-                let mut max = 0.0f32;
-                for i in 0..child_count {
-                    max = max.max(child_main(ctx, i, cross_extent));
-                }
-                max
+        let mut total_flex = 0i32;
+        let mut inflexible_space = spacing_total;
+        let mut max_flex_fraction = 0.0f32;
+
+        for i in 0..child_count {
+            let flex = ctx.child_flex(i);
+            total_flex += flex;
+            if flex > 0 {
+                let size = child_size(ctx, i, cross_extent);
+                max_flex_fraction = max_flex_fraction.max(size / flex as f32);
+            } else {
+                inflexible_space += child_size(ctx, i, cross_extent);
             }
         }
+
+        max_flex_fraction * total_flex as f32 + inflexible_space
     }
 
-    /// Folds child intrinsics along the cross axis (max, or sum for columns).
+    /// Folds child intrinsics along the cross axis (max for rows, sum for columns).
     fn intrinsic_cross(
         &self,
         ctx: &mut BoxIntrinsicsCtx<'_>,
@@ -512,27 +515,51 @@ impl RenderBox for RenderFlex {
     }
 
     fn compute_min_intrinsic_width(&self, height: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
-        self.intrinsic_main(ctx, height, |ctx, i, extent| {
-            ctx.child_min_intrinsic_width(i, extent)
-        })
+        match self.direction {
+            FlexDirection::Horizontal => {
+                self.fold_main_axis_intrinsics(ctx, height, |ctx, i, e| {
+                    ctx.child_min_intrinsic_width(i, e)
+                })
+            }
+            FlexDirection::Vertical => {
+                self.intrinsic_cross(ctx, height, |ctx, i, e| ctx.child_min_intrinsic_width(i, e))
+            }
+        }
     }
 
     fn compute_max_intrinsic_width(&self, height: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
-        self.intrinsic_main(ctx, height, |ctx, i, extent| {
-            ctx.child_max_intrinsic_width(i, extent)
-        })
+        match self.direction {
+            FlexDirection::Horizontal => {
+                self.fold_main_axis_intrinsics(ctx, height, |ctx, i, e| {
+                    ctx.child_max_intrinsic_width(i, e)
+                })
+            }
+            FlexDirection::Vertical => {
+                self.intrinsic_cross(ctx, height, |ctx, i, e| ctx.child_max_intrinsic_width(i, e))
+            }
+        }
     }
 
     fn compute_min_intrinsic_height(&self, width: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
-        self.intrinsic_cross(ctx, width, |ctx, i, extent| {
-            ctx.child_min_intrinsic_height(i, extent)
-        })
+        match self.direction {
+            FlexDirection::Vertical => self.fold_main_axis_intrinsics(ctx, width, |ctx, i, e| {
+                ctx.child_min_intrinsic_height(i, e)
+            }),
+            FlexDirection::Horizontal => {
+                self.intrinsic_cross(ctx, width, |ctx, i, e| ctx.child_min_intrinsic_height(i, e))
+            }
+        }
     }
 
     fn compute_max_intrinsic_height(&self, width: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
-        self.intrinsic_cross(ctx, width, |ctx, i, extent| {
-            ctx.child_max_intrinsic_height(i, extent)
-        })
+        match self.direction {
+            FlexDirection::Vertical => self.fold_main_axis_intrinsics(ctx, width, |ctx, i, e| {
+                ctx.child_max_intrinsic_height(i, e)
+            }),
+            FlexDirection::Horizontal => {
+                self.intrinsic_cross(ctx, width, |ctx, i, e| ctx.child_max_intrinsic_height(i, e))
+            }
+        }
     }
 
     // paint() uses default no-op - Flex just positions children

--- a/crates/flui-rendering/src/objects/fractional_translation.rs
+++ b/crates/flui-rendering/src/objects/fractional_translation.rs
@@ -193,6 +193,8 @@ impl RenderBox for RenderFractionalTranslation {
         &mut self.size
     }
 
+    crate::forward_single_child_box_queries!();
+
     fn paint(&self, ctx: &mut crate::context::PaintCx<'_, Single>) {
         if !self.has_child {
             return;

--- a/crates/flui-rendering/src/objects/fractionally_sized_box.rs
+++ b/crates/flui-rendering/src/objects/fractionally_sized_box.rs
@@ -424,6 +424,23 @@ impl RenderBox for RenderFractionallySizedBox {
         );
         result / self.height_factor_or_one()
     }
+
+    fn compute_dry_baseline(
+        &self,
+        constraints: BoxConstraints,
+        baseline: crate::traits::TextBaseline,
+        ctx: &mut crate::context::BoxDryBaselineCtx<'_>,
+    ) -> Option<f32> {
+        if ctx.child_count() == 0 {
+            return None;
+        }
+        let child_constraints = self.child_constraints(constraints);
+        let child_baseline = ctx.child_dry_baseline(0, child_constraints, baseline)?;
+        let child_size = ctx.child_dry_layout(0, child_constraints);
+        let size = constraints.constrain(child_size);
+        let offset = self.align_child(size, child_size);
+        Some(child_baseline + offset.dy.get())
+    }
 }
 
 // Mythos Step 11: explicit (default) capability opt-outs.

--- a/crates/flui-rendering/src/objects/ignore_pointer.rs
+++ b/crates/flui-rendering/src/objects/ignore_pointer.rs
@@ -105,6 +105,8 @@ impl RenderBox for RenderIgnorePointer {
         &mut self.size
     }
 
+    crate::forward_single_child_box_queries!();
+
     // paint: default pass-through (splices the child in order).
 
     fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Single, BoxParentData>) -> bool {

--- a/crates/flui-rendering/src/objects/limited_box.rs
+++ b/crates/flui-rendering/src/objects/limited_box.rs
@@ -222,6 +222,8 @@ impl RenderBox for RenderLimitedBox {
         Rect::from_origin_size(Point::ZERO, self.size)
     }
 
+    crate::forward_single_child_intrinsics!();
+
     fn compute_dry_layout(
         &self,
         constraints: BoxConstraints,
@@ -237,6 +239,15 @@ impl RenderBox for RenderLimitedBox {
         } else {
             constraints.constrain(Size::new(limited.min_width, limited.min_height))
         }
+    }
+
+    fn compute_dry_baseline(
+        &self,
+        constraints: BoxConstraints,
+        baseline: crate::traits::TextBaseline,
+        ctx: &mut crate::context::BoxDryBaselineCtx<'_>,
+    ) -> Option<f32> {
+        crate::context::proxy_queries::forward_dry_baseline(constraints, baseline, ctx)
     }
 }
 

--- a/crates/flui-rendering/src/objects/meta_data.rs
+++ b/crates/flui-rendering/src/objects/meta_data.rs
@@ -194,6 +194,8 @@ impl RenderBox for RenderMetaData {
         &mut self.size
     }
 
+    crate::forward_single_child_box_queries!();
+
     // paint: default pass-through (splices the child in order).
 
     fn hit_test_behavior(&self) -> HitTestBehavior {

--- a/crates/flui-rendering/src/objects/offstage.rs
+++ b/crates/flui-rendering/src/objects/offstage.rs
@@ -22,8 +22,12 @@ use flui_types::{Offset, Point, Rect, Size};
 use crate::{
     constraints::BoxConstraints,
     context::{BoxHitTestContext, BoxLayoutContext},
+    context::proxy_queries::{
+        forward_dry_baseline, forward_dry_layout, forward_max_intrinsic_height,
+        forward_max_intrinsic_width, forward_min_intrinsic_height, forward_min_intrinsic_width,
+    },
     parent_data::BoxParentData,
-    traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability},
+    traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability, TextBaseline},
 };
 
 /// A render object that, when `offstage` is true, collapses to zero
@@ -129,6 +133,79 @@ impl RenderBox for RenderOffstage {
 
     fn size_mut(&mut self) -> &mut Size {
         &mut self.size
+    }
+
+    fn compute_min_intrinsic_width(
+        &self,
+        height: f32,
+        ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        if self.offstage {
+            0.0
+        } else {
+            forward_min_intrinsic_width(ctx, height)
+        }
+    }
+
+    fn compute_max_intrinsic_width(
+        &self,
+        height: f32,
+        ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        if self.offstage {
+            0.0
+        } else {
+            forward_max_intrinsic_width(ctx, height)
+        }
+    }
+
+    fn compute_min_intrinsic_height(
+        &self,
+        width: f32,
+        ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        if self.offstage {
+            0.0
+        } else {
+            forward_min_intrinsic_height(ctx, width)
+        }
+    }
+
+    fn compute_max_intrinsic_height(
+        &self,
+        width: f32,
+        ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        if self.offstage {
+            0.0
+        } else {
+            forward_max_intrinsic_height(ctx, width)
+        }
+    }
+
+    fn compute_dry_layout(
+        &self,
+        constraints: BoxConstraints,
+        ctx: &mut crate::context::BoxDryLayoutCtx<'_>,
+    ) -> Size {
+        if self.offstage {
+            Size::ZERO
+        } else {
+            forward_dry_layout(constraints, ctx)
+        }
+    }
+
+    fn compute_dry_baseline(
+        &self,
+        constraints: BoxConstraints,
+        baseline: TextBaseline,
+        ctx: &mut crate::context::BoxDryBaselineCtx<'_>,
+    ) -> Option<f32> {
+        if self.offstage {
+            None
+        } else {
+            forward_dry_baseline(constraints, baseline, ctx)
+        }
     }
 
     fn paint(&self, ctx: &mut crate::context::PaintCx<'_, Single>) {

--- a/crates/flui-rendering/src/objects/offstage.rs
+++ b/crates/flui-rendering/src/objects/offstage.rs
@@ -21,13 +21,15 @@ use flui_types::{Offset, Point, Rect, Size};
 
 use crate::{
     constraints::BoxConstraints,
-    context::{BoxHitTestContext, BoxLayoutContext},
     context::proxy_queries::{
         forward_dry_baseline, forward_dry_layout, forward_max_intrinsic_height,
         forward_max_intrinsic_width, forward_min_intrinsic_height, forward_min_intrinsic_width,
     },
+    context::{BoxHitTestContext, BoxLayoutContext},
     parent_data::BoxParentData,
-    traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability, TextBaseline},
+    traits::{
+        HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability, TextBaseline,
+    },
 };
 
 /// A render object that, when `offstage` is true, collapses to zero

--- a/crates/flui-rendering/src/objects/opacity.rs
+++ b/crates/flui-rendering/src/objects/opacity.rs
@@ -166,6 +166,8 @@ impl RenderBox for RenderOpacity {
         &mut self.size
     }
 
+    crate::forward_single_child_box_queries!();
+
     // paint() uses default no-op - opacity is applied via paint_alpha()
 
     fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Single, BoxParentData>) -> bool {

--- a/crates/flui-rendering/src/objects/padding.rs
+++ b/crates/flui-rendering/src/objects/padding.rs
@@ -126,24 +126,96 @@ impl RenderBox for RenderPadding {
         &mut self.size
     }
 
+    fn compute_min_intrinsic_width(
+        &self,
+        height: f32,
+        ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        let deflated_height = (height - self.padding.vertical_total().get()).max(0.0);
+        if ctx.child_count() == 0 {
+            return self.padding.horizontal_total().get();
+        }
+        ctx.child_min_intrinsic_width(0, deflated_height) + self.padding.horizontal_total().get()
+    }
+
+    fn compute_max_intrinsic_width(
+        &self,
+        height: f32,
+        ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        let deflated_height = (height - self.padding.vertical_total().get()).max(0.0);
+        if ctx.child_count() == 0 {
+            return self.padding.horizontal_total().get();
+        }
+        ctx.child_max_intrinsic_width(0, deflated_height) + self.padding.horizontal_total().get()
+    }
+
+    fn compute_min_intrinsic_height(
+        &self,
+        width: f32,
+        ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        let deflated_width = (width - self.padding.horizontal_total().get()).max(0.0);
+        if ctx.child_count() == 0 {
+            return self.padding.vertical_total().get();
+        }
+        ctx.child_min_intrinsic_height(0, deflated_width) + self.padding.vertical_total().get()
+    }
+
+    fn compute_max_intrinsic_height(
+        &self,
+        width: f32,
+        ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        let deflated_width = (width - self.padding.horizontal_total().get()).max(0.0);
+        if ctx.child_count() == 0 {
+            return self.padding.vertical_total().get();
+        }
+        ctx.child_max_intrinsic_height(0, deflated_width) + self.padding.vertical_total().get()
+    }
+
+    fn compute_dry_layout(
+        &self,
+        constraints: BoxConstraints,
+        ctx: &mut crate::context::BoxDryLayoutCtx<'_>,
+    ) -> Size {
+        if ctx.child_count() == 0 {
+            return constraints.constrain(Size::new(
+                self.padding.horizontal_total(),
+                self.padding.vertical_total(),
+            ));
+        }
+        let child_constraints = self.deflate_constraints(&constraints);
+        let child_size = ctx.child_dry_layout(0, child_constraints);
+        constraints.constrain(Size::new(
+            child_size.width + self.padding.horizontal_total(),
+            child_size.height + self.padding.vertical_total(),
+        ))
+    }
+
+    fn compute_dry_baseline(
+        &self,
+        constraints: BoxConstraints,
+        baseline: crate::traits::TextBaseline,
+        ctx: &mut crate::context::BoxDryBaselineCtx<'_>,
+    ) -> Option<f32> {
+        if ctx.child_count() == 0 {
+            return None;
+        }
+        let child_constraints = self.deflate_constraints(&constraints);
+        let child_baseline = ctx.child_dry_baseline(0, child_constraints, baseline)?;
+        Some(child_baseline + self.padding.top.get())
+    }
+
     // paint() uses default no-op - Padding just positions children
 
     fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Single, BoxParentData>) -> bool {
-        // First check if we're in bounds
         if !ctx.is_within_size(self.size.width, self.size.height) {
             return false;
         }
 
-        // Then test child at its offset, recording the offset in the transform stack
         if self.has_child {
-            ctx.push_offset(self.child_offset);
-            let child_position = Offset::new(
-                ctx.position().dx - self.child_offset.dx,
-                ctx.position().dy - self.child_offset.dy,
-            );
-            let hit = ctx.hit_test_child(0, child_position);
-            ctx.pop_transform();
-            hit
+            ctx.hit_test_child_at_layout_offset(0)
         } else {
             false
         }

--- a/crates/flui-rendering/src/objects/paragraph.rs
+++ b/crates/flui-rendering/src/objects/paragraph.rs
@@ -260,7 +260,9 @@ mod tests {
     use flui_types::{geometry::px, typography::TextSpan};
 
     use super::*;
-    use crate::context::intrinsics_test_support::{leaf_dry_baseline, leaf_dry_layout, leaf_intrinsics};
+    use crate::context::intrinsics_test_support::{
+        leaf_dry_baseline, leaf_dry_layout, leaf_intrinsics,
+    };
 
     fn para(text: &str) -> RenderParagraph {
         RenderParagraph::new(TextSpan::new(text), TextDirection::Ltr)
@@ -320,9 +322,8 @@ mod tests {
     fn dry_baseline_is_available_without_layout() {
         let p = para("hello");
         let constraints = BoxConstraints::new(px(0.0), px(200.0), px(0.0), px(200.0));
-        let dry = leaf_dry_baseline(|c| {
-            p.compute_dry_baseline(constraints, TextBaseline::Alphabetic, c)
-        });
+        let dry =
+            leaf_dry_baseline(|c| p.compute_dry_baseline(constraints, TextBaseline::Alphabetic, c));
         assert!(
             dry.is_some_and(|baseline| baseline > 0.0),
             "text dry baseline must be computable before perform_layout",

--- a/crates/flui-rendering/src/objects/paragraph.rs
+++ b/crates/flui-rendering/src/objects/paragraph.rs
@@ -22,7 +22,7 @@ use flui_types::{
 
 use crate::{
     constraints::BoxConstraints,
-    context::{BoxDryLayoutCtx, BoxIntrinsicsCtx, BoxLayoutContext, PaintCx},
+    context::{BoxDryBaselineCtx, BoxDryLayoutCtx, BoxIntrinsicsCtx, BoxLayoutContext, PaintCx},
     parent_data::BoxParentData,
     traits::{
         HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability, TextBaseline,
@@ -180,6 +180,21 @@ impl RenderBox for RenderParagraph {
         constraints.constrain(text_size)
     }
 
+    fn compute_dry_baseline(
+        &self,
+        constraints: BoxConstraints,
+        baseline: TextBaseline,
+        _ctx: &mut BoxDryBaselineCtx<'_>,
+    ) -> Option<f32> {
+        let max_width = self.layout_max_width(&constraints);
+        let painter_baseline = match baseline {
+            TextBaseline::Alphabetic => PainterBaseline::Alphabetic,
+            TextBaseline::Ideographic => PainterBaseline::Ideographic,
+        };
+        self.painter
+            .dry_baseline(constraints.min_width.get(), max_width, painter_baseline)
+    }
+
     // Width intrinsics ignore the height extent (text width does not depend on
     // available height); height intrinsics lay the text out at the given width.
 
@@ -245,7 +260,7 @@ mod tests {
     use flui_types::{geometry::px, typography::TextSpan};
 
     use super::*;
-    use crate::context::intrinsics_test_support::{leaf_dry_layout, leaf_intrinsics};
+    use crate::context::intrinsics_test_support::{leaf_dry_baseline, leaf_dry_layout, leaf_intrinsics};
 
     fn para(text: &str) -> RenderParagraph {
         RenderParagraph::new(TextSpan::new(text), TextDirection::Ltr)
@@ -298,6 +313,19 @@ mod tests {
             "wrapped width {:?} cannot exceed the single-line width {:?}",
             narrow.width,
             wide.width,
+        );
+    }
+
+    #[test]
+    fn dry_baseline_is_available_without_layout() {
+        let p = para("hello");
+        let constraints = BoxConstraints::new(px(0.0), px(200.0), px(0.0), px(200.0));
+        let dry = leaf_dry_baseline(|c| {
+            p.compute_dry_baseline(constraints, TextBaseline::Alphabetic, c)
+        });
+        assert!(
+            dry.is_some_and(|baseline| baseline > 0.0),
+            "text dry baseline must be computable before perform_layout",
         );
     }
 

--- a/crates/flui-rendering/src/objects/repaint_boundary.rs
+++ b/crates/flui-rendering/src/objects/repaint_boundary.rs
@@ -176,7 +176,8 @@ impl crate::protocol::RenderObject<crate::protocol::BoxProtocol> for RenderRepai
                  dyn FnMut(
             usize,
             crate::protocol::ProtocolConstraints<crate::protocol::BoxProtocol>,
-        ) -> crate::protocol::ProtocolGeometry<crate::protocol::BoxProtocol>
+        )
+            -> crate::protocol::ProtocolGeometry<crate::protocol::BoxProtocol>
                      + Send
                      + Sync
              ),

--- a/crates/flui-rendering/src/objects/repaint_boundary.rs
+++ b/crates/flui-rendering/src/objects/repaint_boundary.rs
@@ -152,6 +152,69 @@ impl crate::protocol::RenderObject<crate::protocol::BoxProtocol> for RenderRepai
         child_count > 0 && hit_child(0, None)
     }
 
+    fn intrinsic_raw(
+        &self,
+        dimension: crate::storage::IntrinsicDimension,
+        extent: f32,
+        child_count: usize,
+        child_query: &mut (
+                 dyn FnMut(usize, crate::storage::IntrinsicDimension, f32) -> f32 + Send + Sync
+             ),
+    ) -> f32 {
+        if child_count == 0 {
+            0.0
+        } else {
+            child_query(0, dimension, extent)
+        }
+    }
+
+    fn dry_layout_raw(
+        &self,
+        constraints: crate::protocol::ProtocolConstraints<crate::protocol::BoxProtocol>,
+        child_count: usize,
+        child_dry: &mut (
+                 dyn FnMut(
+            usize,
+            crate::protocol::ProtocolConstraints<crate::protocol::BoxProtocol>,
+        ) -> crate::protocol::ProtocolGeometry<crate::protocol::BoxProtocol>
+                     + Send
+                     + Sync
+             ),
+    ) -> crate::protocol::ProtocolGeometry<crate::protocol::BoxProtocol> {
+        if child_count == 0 {
+            constraints.smallest()
+        } else {
+            child_dry(0, constraints)
+        }
+    }
+
+    fn dry_baseline_raw(
+        &self,
+        constraints: crate::protocol::ProtocolConstraints<crate::protocol::BoxProtocol>,
+        baseline: crate::traits::TextBaseline,
+        child_count: usize,
+        child_query: &mut (
+                 dyn FnMut(
+            usize,
+            crate::context::DryBaselineChildRequest,
+        ) -> crate::context::DryBaselineChildResponse
+                     + Send
+                     + Sync
+             ),
+    ) -> Option<f32> {
+        if child_count == 0 {
+            None
+        } else {
+            match child_query(
+                0,
+                crate::context::DryBaselineChildRequest::Baseline(constraints, baseline),
+            ) {
+                crate::context::DryBaselineChildResponse::Baseline(v) => v,
+                crate::context::DryBaselineChildResponse::DryLayout(_) => None,
+            }
+        }
+    }
+
     // === Optimization boundaries (the KEY overrides) ========================
 
     fn is_repaint_boundary(&self) -> bool {

--- a/crates/flui-rendering/src/objects/repaint_boundary.rs
+++ b/crates/flui-rendering/src/objects/repaint_boundary.rs
@@ -160,6 +160,7 @@ impl crate::protocol::RenderObject<crate::protocol::BoxProtocol> for RenderRepai
         child_query: &mut (
                  dyn FnMut(usize, crate::storage::IntrinsicDimension, f32) -> f32 + Send + Sync
              ),
+        _child_flex: &mut (dyn FnMut(usize) -> i32 + Send + Sync),
     ) -> f32 {
         if child_count == 0 {
             0.0

--- a/crates/flui-rendering/src/objects/sized_box.rs
+++ b/crates/flui-rendering/src/objects/sized_box.rs
@@ -4,6 +4,7 @@ use flui_tree::Leaf;
 use flui_types::{Pixels, Point, Rect, Size};
 
 use crate::{
+    constraints::BoxConstraints,
     context::BoxLayoutContext,
     parent_data::BoxParentData,
     traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability},
@@ -77,6 +78,18 @@ impl RenderSizedBox {
     pub fn height(&self) -> Option<Pixels> {
         self.height
     }
+
+    fn resolved_size(&self, constraints: &BoxConstraints) -> Size {
+        let width = self
+            .width
+            .map(|w| w.clamp(constraints.min_width, constraints.max_width))
+            .unwrap_or(constraints.max_width);
+        let height = self
+            .height
+            .map(|h| h.clamp(constraints.min_height, constraints.max_height))
+            .unwrap_or(constraints.max_height);
+        Size::new(width, height)
+    }
 }
 
 impl flui_foundation::Diagnosticable for RenderSizedBox {
@@ -113,6 +126,46 @@ impl RenderBox for RenderSizedBox {
 
     fn size_mut(&mut self) -> &mut Size {
         &mut self.size
+    }
+
+    fn compute_min_intrinsic_width(
+        &self,
+        _height: f32,
+        _ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        self.width.map(|w| w.get()).unwrap_or(0.0)
+    }
+
+    fn compute_max_intrinsic_width(
+        &self,
+        _height: f32,
+        _ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        self.width.map(|w| w.get()).unwrap_or(0.0)
+    }
+
+    fn compute_min_intrinsic_height(
+        &self,
+        _width: f32,
+        _ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        self.height.map(|h| h.get()).unwrap_or(0.0)
+    }
+
+    fn compute_max_intrinsic_height(
+        &self,
+        _width: f32,
+        _ctx: &mut crate::context::BoxIntrinsicsCtx<'_>,
+    ) -> f32 {
+        self.height.map(|h| h.get()).unwrap_or(0.0)
+    }
+
+    fn compute_dry_layout(
+        &self,
+        constraints: BoxConstraints,
+        _ctx: &mut crate::context::BoxDryLayoutCtx<'_>,
+    ) -> Size {
+        self.resolved_size(&constraints)
     }
 
     // paint() uses default no-op - SizedBox only affects layout

--- a/crates/flui-rendering/src/objects/stack.rs
+++ b/crates/flui-rendering/src/objects/stack.rs
@@ -45,7 +45,7 @@ use flui_types::{Alignment, Offset, Pixels, Point, Rect, Size, painting::Clip};
 
 use crate::{
     constraints::BoxConstraints,
-    context::{BoxHitTestContext, BoxLayoutContext},
+    context::{BoxHitTestContext, BoxIntrinsicsCtx, BoxLayoutContext},
     parent_data::StackParentData,
     traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability},
 };
@@ -308,6 +308,23 @@ impl RenderStack {
             || (offset.dx + child_size.width).get() > stack_size.width.get()
             || (offset.dy + child_size.height).get() > stack_size.height.get()
     }
+
+    /// Flutter stack.dart: each intrinsic dimension is the max of the children.
+    fn max_child_intrinsic(
+        ctx: &mut BoxIntrinsicsCtx<'_>,
+        extent: f32,
+        mut query: impl FnMut(&mut BoxIntrinsicsCtx<'_>, usize, f32) -> f32,
+    ) -> f32 {
+        let child_count = ctx.child_count();
+        if child_count == 0 {
+            return 0.0;
+        }
+        let mut max = 0.0f32;
+        for i in 0..child_count {
+            max = max.max(query(ctx, i, extent));
+        }
+        max
+    }
 }
 
 impl Default for RenderStack {
@@ -442,6 +459,30 @@ impl RenderBox for RenderStack {
 
     fn size_mut(&mut self) -> &mut Size {
         &mut self.size
+    }
+
+    fn compute_min_intrinsic_width(&self, height: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        Self::max_child_intrinsic(ctx, height, |ctx, i, extent| {
+            ctx.child_min_intrinsic_width(i, extent)
+        })
+    }
+
+    fn compute_max_intrinsic_width(&self, height: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        Self::max_child_intrinsic(ctx, height, |ctx, i, extent| {
+            ctx.child_max_intrinsic_width(i, extent)
+        })
+    }
+
+    fn compute_min_intrinsic_height(&self, width: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        Self::max_child_intrinsic(ctx, width, |ctx, i, extent| {
+            ctx.child_min_intrinsic_height(i, extent)
+        })
+    }
+
+    fn compute_max_intrinsic_height(&self, width: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        Self::max_child_intrinsic(ctx, width, |ctx, i, extent| {
+            ctx.child_max_intrinsic_height(i, extent)
+        })
     }
 
     fn paint(&self, ctx: &mut crate::context::PaintCx<'_, Variable>) {

--- a/crates/flui-rendering/src/objects/transform.rs
+++ b/crates/flui-rendering/src/objects/transform.rs
@@ -203,6 +203,8 @@ impl RenderBox for RenderTransform {
         &mut self.size
     }
 
+    crate::forward_single_child_box_queries!();
+
     // paint() uses default no-op - transform is applied via paint_transform()
 
     fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Single, BoxParentData>) -> bool {

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -1405,9 +1405,19 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
         dimension: crate::storage::IntrinsicDimension,
         extent: f32,
     ) -> crate::error::RenderResult<f32> {
+        #[cfg(any(test, feature = "testing"))]
         let parent_data_seeds = self.parent_data_seeds.clone();
         let mut slots = self.acquire_query_slots(id)?;
-        intrinsic_query(&mut slots, id, dimension, extent, &parent_data_seeds)
+        intrinsic_query(
+            &mut slots,
+            id,
+            dimension,
+            extent,
+            #[cfg(any(test, feature = "testing"))]
+            &parent_data_seeds,
+            #[cfg(not(any(test, feature = "testing")))]
+            &(),
+        )
     }
 
     /// The size a box subtree WOULD take under `constraints`, memoized
@@ -2770,7 +2780,14 @@ unsafe fn box_intrinsic_query_borrowed_impl<'tree>(
                 }
             };
         let mut child_flex = |index: usize| -> i32 {
-            child_flex_from_seeds(&borrows.parent_data_seeds, &child_ids, index)
+            child_flex_from_seeds(
+                #[cfg(any(test, feature = "testing"))]
+                &borrows.parent_data_seeds,
+                #[cfg(not(any(test, feature = "testing")))]
+                &(),
+                &child_ids,
+                index,
+            )
         };
         entry.render_object().intrinsic_raw(
             dimension,
@@ -3801,6 +3818,7 @@ struct QuerySlot<'a> {
     children: Vec<RenderId>,
 }
 
+#[cfg(any(test, feature = "testing"))]
 fn flex_factor_from_seed(seed: &ParentDataSeed) -> i32 {
     match seed {
         ParentDataSeed::Flex(data) => data.flex.unwrap_or(0).max(0),
@@ -3809,15 +3827,24 @@ fn flex_factor_from_seed(seed: &ParentDataSeed) -> i32 {
 }
 
 fn child_flex_from_seeds(
-    parent_data_seeds: &FxHashMap<RenderId, ParentDataSeed>,
+    #[cfg(any(test, feature = "testing"))] parent_data_seeds: &FxHashMap<RenderId, ParentDataSeed>,
+    #[cfg(not(any(test, feature = "testing")))] _parent_data_seeds: &(),
     children: &[RenderId],
     index: usize,
 ) -> i32 {
-    children
-        .get(index)
-        .and_then(|child_id| parent_data_seeds.get(child_id))
-        .map(flex_factor_from_seed)
-        .unwrap_or(0)
+    #[cfg(any(test, feature = "testing"))]
+    {
+        children
+            .get(index)
+            .and_then(|child_id| parent_data_seeds.get(child_id))
+            .map(flex_factor_from_seed)
+            .unwrap_or(0)
+    }
+    #[cfg(not(any(test, feature = "testing")))]
+    {
+        let _ = (children, index);
+        0
+    }
 }
 
 /// Recursive memoized intrinsic query over the take-out slot map.
@@ -3832,9 +3859,16 @@ fn intrinsic_query(
     id: RenderId,
     dimension: crate::storage::IntrinsicDimension,
     extent: f32,
-    parent_data_seeds: &FxHashMap<RenderId, ParentDataSeed>,
+    #[cfg(any(test, feature = "testing"))] parent_data_seeds: &FxHashMap<RenderId, ParentDataSeed>,
+    #[cfg(not(any(test, feature = "testing")))] parent_data_seeds: &(),
 ) -> crate::error::RenderResult<f32> {
-    ensure_stack(|| intrinsic_query_impl(slots, id, dimension, extent, parent_data_seeds))
+    ensure_stack(|| intrinsic_query_impl(
+        slots,
+        id,
+        dimension,
+        extent,
+        parent_data_seeds,
+    ))
 }
 
 /// Body of [`intrinsic_query`]; split out so every recursion level
@@ -3844,7 +3878,8 @@ fn intrinsic_query_impl(
     id: RenderId,
     dimension: crate::storage::IntrinsicDimension,
     extent: f32,
-    parent_data_seeds: &FxHashMap<RenderId, ParentDataSeed>,
+    #[cfg(any(test, feature = "testing"))] parent_data_seeds: &FxHashMap<RenderId, ParentDataSeed>,
+    #[cfg(not(any(test, feature = "testing")))] parent_data_seeds: &(),
 ) -> crate::error::RenderResult<f32> {
     let Some(slot) = slots.get_mut(&id) else {
         return Err(crate::error::RenderError::NodeNotFound(id));
@@ -3898,7 +3933,11 @@ fn intrinsic_query_impl(
                     }
                 };
             let mut child_flex = |index: usize| -> i32 {
-                child_flex_from_seeds(parent_data_seeds, &children, index)
+                child_flex_from_seeds(
+                    parent_data_seeds,
+                    &children,
+                    index,
+                )
             };
             entry.render_object().intrinsic_raw(
                 dimension,

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -3862,13 +3862,7 @@ fn intrinsic_query(
     #[cfg(any(test, feature = "testing"))] parent_data_seeds: &FxHashMap<RenderId, ParentDataSeed>,
     #[cfg(not(any(test, feature = "testing")))] parent_data_seeds: &(),
 ) -> crate::error::RenderResult<f32> {
-    ensure_stack(|| intrinsic_query_impl(
-        slots,
-        id,
-        dimension,
-        extent,
-        parent_data_seeds,
-    ))
+    ensure_stack(|| intrinsic_query_impl(slots, id, dimension, extent, parent_data_seeds))
 }
 
 /// Body of [`intrinsic_query`]; split out so every recursion level
@@ -3933,11 +3927,7 @@ fn intrinsic_query_impl(
                     }
                 };
             let mut child_flex = |index: usize| -> i32 {
-                child_flex_from_seeds(
-                    parent_data_seeds,
-                    &children,
-                    index,
-                )
+                child_flex_from_seeds(parent_data_seeds, &children, index)
             };
             entry.render_object().intrinsic_raw(
                 dimension,

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -718,22 +718,36 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
             if child_node.as_sliver().is_some() {
                 // Explicit positions are already child-local; the layout-offset
                 // fallback starts from the child's physical paint offset.
-                let child_position = match override_pos {
-                    Some(position) => Self::sliver_hit_position_from_offset(child_node, position),
+                return match override_pos {
+                    Some(position) => {
+                        let child_position =
+                            Self::sliver_hit_position_from_offset(child_node, position);
+                        self.hit_test_sliver_subtree(child_id, child_position, result)
+                    }
                     None => {
                         if !Self::sliver_child_is_visible(child_node) {
                             return false;
                         }
-                        Self::sliver_hit_position_from_paint_offset(
-                            child_node,
-                            position - child_node.offset(),
-                        )
+                        let child_offset = child_node.offset();
+                        result.with_paint_offset(child_offset, |result| {
+                            let child_position = Self::sliver_hit_position_from_paint_offset(
+                                child_node,
+                                position - child_offset,
+                            );
+                            self.hit_test_sliver_subtree(child_id, child_position, result)
+                        })
                     }
                 };
-                return self.hit_test_sliver_subtree(child_id, child_position, result);
             }
-            let child_position = override_pos.unwrap_or_else(|| position - child_node.offset());
-            self.hit_test_subtree(child_id, child_position, result)
+            match override_pos {
+                Some(child_position) => self.hit_test_subtree(child_id, child_position, result),
+                None => {
+                    let child_offset = child_node.offset();
+                    result.with_paint_offset(child_offset, |result| {
+                        self.hit_test_subtree(child_id, position - child_offset, result)
+                    })
+                }
+            }
         };
 
         let hit = render_object.hit_test_raw(position, children.len(), &mut hit_child);
@@ -1424,30 +1438,8 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
         constraints: crate::constraints::BoxConstraints,
         baseline: crate::traits::TextBaseline,
     ) -> crate::error::RenderResult<Option<f32>> {
-        let Some(node) = self.render_tree.get_mut(id) else {
-            return Err(crate::error::RenderError::NodeNotFound(id));
-        };
-        let Some(entry) = node.as_box_mut() else {
-            return Err(crate::error::RenderError::ProtocolMismatch {
-                node_protocol: "sliver",
-                constraints_protocol: "box",
-            });
-        };
-        if let Some(hit) = entry
-            .state()
-            .layout_cache()
-            .peek_dry_baseline(constraints, baseline)
-        {
-            return Ok(hit);
-        }
-        let value = entry
-            .render_object()
-            .dry_baseline_raw(constraints, baseline);
-        entry
-            .state_mut()
-            .layout_cache_mut()
-            .insert_dry_baseline(constraints, baseline, value);
-        Ok(value)
+        let mut slots = self.acquire_query_slots(id)?;
+        dry_baseline_query(&mut slots, id, constraints, baseline)
     }
 
     /// Acquires the take-out borrow map for a memoizing query walk:
@@ -3414,6 +3406,14 @@ impl PipelineOwner<PaintPhase> {
             return Ok(());
         }
 
+        // Flutter object.dart:3497 — a node that still needs layout must
+        // not paint stale geometry. Layout runs before paint in the
+        // pipeline, so this guards descendant-error and partial-frame
+        // paths where a poisoned layout left the flag set.
+        if render_node.needs_layout() {
+            return Ok(());
+        }
+
         // Record the node's fragment. paint_raw sees ONLY the recorder
         // (sans-IO): no tree access, no layer access, no recursion.
         let debug_name = render_node.debug_name();
@@ -3969,6 +3969,117 @@ fn dry_layout_query_impl(
     result
 }
 
+/// Recursive memoized dry-baseline query; same skeleton as
+/// [`dry_layout_query`] with `(constraints, baseline → Option<f32>)`
+/// payloads.
+fn dry_baseline_query(
+    slots: &mut rustc_hash::FxHashMap<RenderId, QuerySlot<'_>>,
+    id: RenderId,
+    constraints: crate::constraints::BoxConstraints,
+    baseline: crate::traits::TextBaseline,
+) -> crate::error::RenderResult<Option<f32>> {
+    ensure_stack(|| dry_baseline_query_impl(slots, id, constraints, baseline))
+}
+
+/// Body of [`dry_baseline_query`]; split out so every recursion level
+/// enters through the [`ensure_stack`] probe.
+fn dry_baseline_query_impl(
+    slots: &mut rustc_hash::FxHashMap<RenderId, QuerySlot<'_>>,
+    id: RenderId,
+    constraints: crate::constraints::BoxConstraints,
+    baseline: crate::traits::TextBaseline,
+) -> crate::error::RenderResult<Option<f32>> {
+    let Some(slot) = slots.get_mut(&id) else {
+        return Err(crate::error::RenderError::NodeNotFound(id));
+    };
+    let Some(node) = slot.node.take() else {
+        debug_assert!(
+            false,
+            "dry-baseline query re-entered node {id:?} mid-computation — cyclic child links"
+        );
+        return Ok(None);
+    };
+    let children = slot.children.clone();
+
+    let result = (|| {
+        let Some(entry) = node.as_box_mut() else {
+            return Err(crate::error::RenderError::ProtocolMismatch {
+                node_protocol: "sliver",
+                constraints_protocol: "box",
+            });
+        };
+        if let Some(hit) = entry
+            .state()
+            .layout_cache()
+            .peek_dry_baseline(constraints, baseline)
+        {
+            return Ok(hit);
+        }
+        let mut child_err: Option<crate::error::RenderError> = None;
+        let value = {
+            let child_err = &mut child_err;
+            let mut child_query = |index: usize,
+                                   request: crate::context::DryBaselineChildRequest|
+             -> crate::context::DryBaselineChildResponse {
+                use crate::context::{DryBaselineChildRequest, DryBaselineChildResponse};
+                let Some(&child_id) = children.get(index) else {
+                    child_err.get_or_insert(crate::error::RenderError::contract_violation(
+                        "dry-baseline child query",
+                        "child index out of range for this node's children",
+                    ));
+                    return match request {
+                        DryBaselineChildRequest::Baseline(_, _) => {
+                            DryBaselineChildResponse::Baseline(None)
+                        }
+                        DryBaselineChildRequest::DryLayout(_) => {
+                            DryBaselineChildResponse::DryLayout(flui_types::Size::ZERO)
+                        }
+                    };
+                };
+                match request {
+                    DryBaselineChildRequest::Baseline(c, b) => {
+                        match dry_baseline_query(slots, child_id, c, b) {
+                            Ok(v) => DryBaselineChildResponse::Baseline(v),
+                            Err(err) => {
+                                child_err.get_or_insert(err);
+                                DryBaselineChildResponse::Baseline(None)
+                            }
+                        }
+                    }
+                    DryBaselineChildRequest::DryLayout(c) => {
+                        match dry_layout_query(slots, child_id, c) {
+                            Ok(v) => DryBaselineChildResponse::DryLayout(v),
+                            Err(err) => {
+                                child_err.get_or_insert(err);
+                                DryBaselineChildResponse::DryLayout(flui_types::Size::ZERO)
+                            }
+                        }
+                    }
+                }
+            };
+            entry.render_object().dry_baseline_raw(
+                constraints,
+                baseline,
+                children.len(),
+                &mut child_query,
+            )
+        };
+        if let Some(err) = child_err {
+            return Err(err);
+        }
+        entry
+            .state_mut()
+            .layout_cache_mut()
+            .insert_dry_baseline(constraints, baseline, value);
+        Ok(value)
+    })();
+
+    if let Some(slot) = slots.get_mut(&id) {
+        slot.node = Some(node);
+    }
+    result
+}
+
 // ============================================================================
 // Diagnostics dump (Diagnosticable-backed)
 // ============================================================================
@@ -4421,7 +4532,9 @@ mod tests {
     /// The owner must remain usable for a subsequent frame.
     #[test]
     fn test_run_frame_catches_paint_panic() {
+        use crate::constraints::BoxConstraints;
         use crate::error::RenderError;
+        use flui_types::geometry::px;
 
         // Silence the default panic hook for the duration of this test
         // so cargo test output isn't polluted by the intentional panic.
@@ -4432,6 +4545,16 @@ mod tests {
         let root_id = owner.insert(Box::new(PanickingPaintBox::new())
             as Box<dyn crate::traits::RenderObject<crate::protocol::BoxProtocol>>);
         owner.set_root_id(Some(root_id));
+        // Root layout needs binding constraints on the first frame; without
+        // them run_layout skips the dirty entry, NEEDS_LAYOUT stays set, and
+        // the paint guard (Flutter object.dart:3497) correctly skips paint —
+        // which would make this test miss the intentional paint panic.
+        owner.set_root_constraints(Some(BoxConstraints::new(
+            px(0.0),
+            px(200.0),
+            px(0.0),
+            px(200.0),
+        )));
 
         let (owner, result) = owner.run_frame();
 

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -4937,12 +4937,12 @@ mod tests {
     }
 
     /// A leaf committing a size that violates the constraints it was laid out
-    /// under trips `Protocol::debug_assert_layout_output` (Flutter
-    /// `debugAssertDoesMeetConstraints`) on the leaf commit path — a node
-    /// returning 999×999 under tight 100×100 is a layout bug.
+    /// under surfaces `RenderError::InvalidGeometry` on the leaf commit path —
+    /// a node returning 999×999 under tight 100×100 is a layout bug.
     #[test]
-    #[should_panic(expected = "violates its constraints")]
-    fn leaf_committing_a_constraint_violating_size_trips_the_layout_assert() {
+    fn leaf_committing_a_constraint_violating_size_returns_invalid_geometry() {
+        use crate::error::RenderError;
+
         let mut owner = PipelineOwner::new();
         let root = owner.insert(Box::new(FixedSizeLeaf {
             size: flui_types::Size::new(
@@ -4957,6 +4957,12 @@ mod tests {
             flui_types::geometry::px(100.0),
         ))));
 
-        let _ = owner.run_frame();
+        let (_, result) = owner.run_frame();
+        match result {
+            Err(RenderError::InvalidGeometry { reason, .. }) => {
+                assert!(reason.contains("does not satisfy"));
+            }
+            other => panic!("expected InvalidGeometry, got {other:?}"),
+        }
     }
 }

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -1405,8 +1405,9 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
         dimension: crate::storage::IntrinsicDimension,
         extent: f32,
     ) -> crate::error::RenderResult<f32> {
+        let parent_data_seeds = self.parent_data_seeds.clone();
         let mut slots = self.acquire_query_slots(id)?;
-        intrinsic_query(&mut slots, id, dimension, extent)
+        intrinsic_query(&mut slots, id, dimension, extent, &parent_data_seeds)
     }
 
     /// The size a box subtree WOULD take under `constraints`, memoized
@@ -2768,9 +2769,16 @@ unsafe fn box_intrinsic_query_borrowed_impl<'tree>(
                     }
                 }
             };
-        entry
-            .render_object()
-            .intrinsic_raw(dimension, extent, child_ids.len(), &mut child_query)
+        let mut child_flex = |index: usize| -> i32 {
+            child_flex_from_seeds(&borrows.parent_data_seeds, &child_ids, index)
+        };
+        entry.render_object().intrinsic_raw(
+            dimension,
+            extent,
+            child_ids.len(),
+            &mut child_query,
+            &mut child_flex,
+        )
     };
 
     if let Some(err) = child_err {
@@ -3793,6 +3801,25 @@ struct QuerySlot<'a> {
     children: Vec<RenderId>,
 }
 
+fn flex_factor_from_seed(seed: &ParentDataSeed) -> i32 {
+    match seed {
+        ParentDataSeed::Flex(data) => data.flex.unwrap_or(0).max(0),
+        _ => 0,
+    }
+}
+
+fn child_flex_from_seeds(
+    parent_data_seeds: &FxHashMap<RenderId, ParentDataSeed>,
+    children: &[RenderId],
+    index: usize,
+) -> i32 {
+    children
+        .get(index)
+        .and_then(|child_id| parent_data_seeds.get(child_id))
+        .map(flex_factor_from_seed)
+        .unwrap_or(0)
+}
+
 /// Recursive memoized intrinsic query over the take-out slot map.
 ///
 /// Per node: cache peek → on miss, run the object's `intrinsic_raw`
@@ -3805,8 +3832,9 @@ fn intrinsic_query(
     id: RenderId,
     dimension: crate::storage::IntrinsicDimension,
     extent: f32,
+    parent_data_seeds: &FxHashMap<RenderId, ParentDataSeed>,
 ) -> crate::error::RenderResult<f32> {
-    ensure_stack(|| intrinsic_query_impl(slots, id, dimension, extent))
+    ensure_stack(|| intrinsic_query_impl(slots, id, dimension, extent, parent_data_seeds))
 }
 
 /// Body of [`intrinsic_query`]; split out so every recursion level
@@ -3816,6 +3844,7 @@ fn intrinsic_query_impl(
     id: RenderId,
     dimension: crate::storage::IntrinsicDimension,
     extent: f32,
+    parent_data_seeds: &FxHashMap<RenderId, ParentDataSeed>,
 ) -> crate::error::RenderResult<f32> {
     let Some(slot) = slots.get_mut(&id) else {
         return Err(crate::error::RenderError::NodeNotFound(id));
@@ -3860,7 +3889,7 @@ fn intrinsic_query_impl(
                         ));
                         return 0.0;
                     };
-                    match intrinsic_query(slots, child_id, dim, ext) {
+                    match intrinsic_query(slots, child_id, dim, ext, parent_data_seeds) {
                         Ok(v) => v,
                         Err(err) => {
                             child_err.get_or_insert(err);
@@ -3868,9 +3897,16 @@ fn intrinsic_query_impl(
                         }
                     }
                 };
-            entry
-                .render_object()
-                .intrinsic_raw(dimension, extent, children.len(), &mut child_query)
+            let mut child_flex = |index: usize| -> i32 {
+                child_flex_from_seeds(parent_data_seeds, &children, index)
+            };
+            entry.render_object().intrinsic_raw(
+                dimension,
+                extent,
+                children.len(),
+                &mut child_query,
+                &mut child_flex,
+            )
         };
         if let Some(err) = child_err {
             return Err(err);

--- a/crates/flui-rendering/src/protocol/box_protocol.rs
+++ b/crates/flui-rendering/src/protocol/box_protocol.rs
@@ -146,6 +146,30 @@ impl Protocol for BoxProtocol {
         );
     }
 
+    /// Runtime counterpart to [`Self::debug_assert_layout_output`] — surfaces
+    /// Flutter's `debugAssertDoesMeetConstraints` as
+    /// [`RenderError::InvalidGeometry`](crate::error::RenderError::InvalidGeometry)
+    /// so bad sizes fail the frame instead of committing silently.
+    fn validate_layout_output(
+        render_object: &'static str,
+        constraints: &BoxConstraints,
+        geometry: &Size,
+    ) -> crate::error::RenderResult<()> {
+        if !geometry.width.get().is_finite() || !geometry.height.get().is_finite() {
+            return Err(crate::error::RenderError::invalid_geometry(
+                render_object,
+                "non-finite width or height",
+            ));
+        }
+        if !constraints.is_satisfied_by(*geometry) {
+            return Err(crate::error::RenderError::invalid_geometry(
+                render_object,
+                "size does not satisfy layout constraints",
+            ));
+        }
+        Ok(())
+    }
+
     /// D-block PR-A1b U19 — wraps the given `BoxConstraints` in a typed
     /// `BoxLayoutCtx::<Leaf, BoxParentData>::new(constraints)` (no
     /// children, no callback) and hands an erased `&mut dyn
@@ -1381,6 +1405,31 @@ mod tests {
     #[test]
     fn test_box_protocol_name() {
         assert_eq!(BoxProtocol::name(), "box");
+    }
+
+    #[test]
+    fn validate_layout_output_rejects_non_finite_and_oversized_geometry() {
+        use crate::error::RenderError;
+
+        let constraints = BoxConstraints::new(px(0.0), px(100.0), px(0.0), px(100.0));
+        let ok = Size::new(px(40.0), px(40.0));
+        BoxProtocol::validate_layout_output("TestBox", &constraints, &ok).expect("valid size");
+
+        let bad = Size::new(px(f32::INFINITY), px(40.0));
+        match BoxProtocol::validate_layout_output("TestBox", &constraints, &bad) {
+            Err(RenderError::InvalidGeometry { reason, .. }) => {
+                assert!(reason.contains("non-finite"));
+            }
+            other => panic!("expected InvalidGeometry, got {other:?}"),
+        }
+
+        let oversize = Size::new(px(200.0), px(40.0));
+        match BoxProtocol::validate_layout_output("TestBox", &constraints, &oversize) {
+            Err(RenderError::InvalidGeometry { reason, .. }) => {
+                assert!(reason.contains("does not satisfy"));
+            }
+            other => panic!("expected InvalidGeometry, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/flui-rendering/src/testing/mod.rs
+++ b/crates/flui-rendering/src/testing/mod.rs
@@ -66,8 +66,8 @@ pub use assertions::{
 };
 pub use harness::{FrameRun, LayoutRun, RenderTester};
 pub use inspect::Probe;
-pub use queries::BoxQueryRun;
 pub use parent_data::ParentDataSeed;
+pub use queries::BoxQueryRun;
 pub use report::FrameReport;
 pub use tree::{
     RenderLabelRegistry, TreeNode, box_node, box_node_boxed, sliver_node, sliver_node_boxed,

--- a/crates/flui-rendering/src/testing/mod.rs
+++ b/crates/flui-rendering/src/testing/mod.rs
@@ -21,7 +21,8 @@
 //!    - [`RenderTester::run_frame`] -> [`FrameRun`] (full frame: layer
 //!      structure, picture bounds, [`FrameReport`], repeated `pump`).
 //! 3. Inspect via the shared [`Probe`] trait (`offset`, `box_geometry`,
-//!    `sliver_geometry`, `hit`, `id`).
+//!    `sliver_geometry`, `hit`, `id`) and, for proxy/leaf query contracts,
+//!    [`BoxQueryRun`] (`min_intrinsic_width`, `dry_layout`, `dry_baseline`, …).
 //! 4. Drive multi-frame / animation scenarios on [`FrameRun`]:
 //!    [`FrameRun::advance_layout`] / [`FrameRun::advance_paint`] (mutate +
 //!    one frame), [`FrameRun::simulate`] (tick loop + pump per step),
@@ -54,6 +55,7 @@ pub mod assertions;
 mod harness;
 pub mod inspect;
 pub mod parent_data;
+pub mod queries;
 mod report;
 pub mod sliver;
 pub mod tree;
@@ -64,6 +66,7 @@ pub use assertions::{
 };
 pub use harness::{FrameRun, LayoutRun, RenderTester};
 pub use inspect::Probe;
+pub use queries::BoxQueryRun;
 pub use parent_data::ParentDataSeed;
 pub use report::FrameReport;
 pub use tree::{

--- a/crates/flui-rendering/src/testing/queries.rs
+++ b/crates/flui-rendering/src/testing/queries.rs
@@ -1,0 +1,105 @@
+//! Box intrinsics, dry layout, and dry baseline queries on harness runs.
+//!
+//! Wraps [`PipelineOwner::box_intrinsic_dimension`], [`PipelineOwner::box_dry_layout`],
+//! and [`PipelineOwner::box_dry_baseline`] with panic-on-error ergonomics for tests.
+//! Queries do not require a committed layout pass — mount the tree and call the
+//! helpers on a [`LayoutRun`] or [`FrameRun`] directly.
+//!
+//! [`PipelineOwner::box_intrinsic_dimension`]: crate::pipeline::PipelineOwner::box_intrinsic_dimension
+//! [`PipelineOwner::box_dry_layout`]: crate::pipeline::PipelineOwner::box_dry_layout
+//! [`PipelineOwner::box_dry_baseline`]: crate::pipeline::PipelineOwner::box_dry_baseline
+//! [`LayoutRun`]: super::harness::LayoutRun
+//! [`FrameRun`]: super::harness::FrameRun
+
+use crate::constraints::BoxConstraints;
+use crate::pipeline::{PipelineOwner, PipelinePhase};
+use crate::storage::IntrinsicDimension;
+use crate::traits::TextBaseline;
+use flui_foundation::RenderId;
+use flui_types::Size;
+
+use super::harness::{FrameRun, LayoutRun};
+
+/// Box query helpers for harness runs that own a mutable [`PipelineOwner`].
+///
+/// Implemented for [`LayoutRun`] and [`FrameRun`]. Methods panic on stale ids,
+/// protocol mismatches, or other query failures — the same contract as other
+/// harness inspection helpers.
+pub trait BoxQueryRun {
+    /// Pipeline phase held by the run.
+    type Phase: PipelinePhase + Sync;
+
+    /// Mutable access to the backing owner (used by default method bodies).
+    fn pipeline_mut(&mut self) -> &mut PipelineOwner<Self::Phase>;
+
+    /// Flutter `computeMinIntrinsicWidth` / `computeMaxIntrinsicWidth` /
+    /// `computeMinIntrinsicHeight` / `computeMaxIntrinsicHeight` dispatch.
+    fn intrinsic_dimension(
+        &mut self,
+        id: RenderId,
+        dimension: IntrinsicDimension,
+        extent: f32,
+    ) -> f32 {
+        self.pipeline_mut()
+            .box_intrinsic_dimension(id, dimension, extent)
+            .unwrap_or_else(|e| panic!("intrinsic query failed for {id:?}: {e}"))
+    }
+
+    /// Minimum width the subtree would prefer at the given height extent.
+    fn min_intrinsic_width(&mut self, id: RenderId, height: f32) -> f32 {
+        self.intrinsic_dimension(id, IntrinsicDimension::MinWidth, height)
+    }
+
+    /// Maximum width the subtree would prefer at the given height extent.
+    fn max_intrinsic_width(&mut self, id: RenderId, height: f32) -> f32 {
+        self.intrinsic_dimension(id, IntrinsicDimension::MaxWidth, height)
+    }
+
+    /// Minimum height the subtree would prefer at the given width extent.
+    fn min_intrinsic_height(&mut self, id: RenderId, width: f32) -> f32 {
+        self.intrinsic_dimension(id, IntrinsicDimension::MinHeight, width)
+    }
+
+    /// Maximum height the subtree would prefer at the given width extent.
+    fn max_intrinsic_height(&mut self, id: RenderId, width: f32) -> f32 {
+        self.intrinsic_dimension(id, IntrinsicDimension::MaxHeight, width)
+    }
+
+    /// Size the subtree would take under `constraints` without mutating layout
+    /// state — Flutter's `getDryLayout`.
+    fn dry_layout(&mut self, id: RenderId, constraints: BoxConstraints) -> Size {
+        self.pipeline_mut()
+            .box_dry_layout(id, constraints)
+            .unwrap_or_else(|e| panic!("dry layout query failed for {id:?}: {e}"))
+    }
+
+    /// Baseline distance from the top edge under `constraints` without laying
+    /// out — Flutter's `getDryBaseline`. `None` means the subtree reports no
+    /// baseline for that axis/constraints pair (a valid, cacheable answer).
+    fn dry_baseline(
+        &mut self,
+        id: RenderId,
+        constraints: BoxConstraints,
+        baseline: TextBaseline,
+    ) -> Option<f32> {
+        self.pipeline_mut()
+            .box_dry_baseline(id, constraints, baseline)
+            .unwrap_or_else(|e| panic!("dry baseline query failed for {id:?}: {e}"))
+    }
+}
+
+impl BoxQueryRun for LayoutRun {
+    type Phase = crate::pipeline::Layout;
+
+    fn pipeline_mut(&mut self) -> &mut PipelineOwner<Self::Phase> {
+        self.owner_mut()
+    }
+}
+
+impl BoxQueryRun for FrameRun {
+    type Phase = crate::pipeline::Idle;
+
+    fn pipeline_mut(&mut self) -> &mut PipelineOwner<Self::Phase> {
+        self.owner_mut()
+    }
+}

--- a/crates/flui-rendering/src/testing/tests.rs
+++ b/crates/flui-rendering/src/testing/tests.rs
@@ -15,7 +15,7 @@ use crate::{
         RenderSliverFixedExtentList, RenderStack, RenderViewport,
     },
     parent_data::{FlexParentData, StackParentData},
-    testing::{Probe, RenderTester, box_node, sliver_node},
+    testing::{BoxQueryRun, Probe, RenderTester, box_node, sliver_node},
 };
 
 /// Loose `0..=200 x 0..=200` constraints: children settle at their natural
@@ -398,4 +398,39 @@ fn unknown_label_resolves_to_none() {
         .with_size(Size::new(px(50.0), px(50.0)))
         .run_layout();
     assert!(run.try_id("missing").is_none());
+}
+
+// ============================================================================
+// Box query helpers
+// ============================================================================
+
+#[test]
+fn layout_run_box_queries_match_pipeline() {
+    let constraints = loose_200();
+    let mut run = RenderTester::mount(
+        box_node(RenderOpacity::opaque())
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(constraints)
+    .run_layout();
+
+    assert_eq!(run.min_intrinsic_width(run.root(), 100.0), 40.0);
+    assert_eq!(
+        run.dry_layout(run.root(), constraints),
+        Size::new(px(40.0), px(40.0))
+    );
+}
+
+#[test]
+fn frame_run_box_queries_work_after_paint() {
+    let constraints = loose_200();
+    let mut run = RenderTester::mount(
+        box_node(RenderPadding::all(5.0))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(constraints)
+    .run_frame();
+
+    assert_eq!(run.min_intrinsic_width(run.root(), 100.0), 50.0);
+    assert!(run.painted());
 }

--- a/crates/flui-rendering/src/traits/render_box.rs
+++ b/crates/flui-rendering/src/traits/render_box.rs
@@ -291,11 +291,12 @@ pub trait RenderBox: RenderObject<BoxProtocol> + flui_foundation::Diagnosticable
     /// first baseline WOULD sit after a layout with these constraints.
     /// Memoized per `(constraints, baseline)` by the pipeline
     /// (`PipelineOwner::box_dry_baseline`); the cached entry includes a
-    /// computed `None`.
+    /// computed `None`. Children are probed through `ctx`.
     fn compute_dry_baseline(
         &self,
         _constraints: BoxConstraints,
         _baseline: TextBaseline,
+        _ctx: &mut crate::context::BoxDryBaselineCtx<'_>,
     ) -> Option<f32> {
         None
     }
@@ -539,8 +540,18 @@ where
         &self,
         constraints: crate::protocol::ProtocolConstraints<BoxProtocol>,
         baseline: crate::traits::TextBaseline,
+        child_count: usize,
+        child_query: &mut (
+                 dyn FnMut(
+            usize,
+            crate::context::DryBaselineChildRequest,
+        ) -> crate::context::DryBaselineChildResponse
+                     + Send
+                     + Sync
+             ),
     ) -> Option<f32> {
-        T::compute_dry_baseline(self, constraints, baseline)
+        let mut ctx = crate::context::BoxDryBaselineCtx::new(child_count, child_query);
+        T::compute_dry_baseline(self, constraints, baseline, &mut ctx)
     }
 
     fn geometry(&self) -> &crate::protocol::ProtocolGeometry<BoxProtocol> {

--- a/crates/flui-rendering/src/traits/render_box.rs
+++ b/crates/flui-rendering/src/traits/render_box.rs
@@ -504,13 +504,14 @@ where
         child_query: &mut (
                  dyn FnMut(usize, crate::storage::IntrinsicDimension, f32) -> f32 + Send + Sync
              ),
+        child_flex: &mut (dyn FnMut(usize) -> i32 + Send + Sync),
     ) -> f32 {
         // The intrinsics bridge: wrap the driver's memoizing child
         // recursion in the typed ctx and dispatch the dimension to the
         // matching typed compute_* — same shape as the paint/hit
         // bridges, no GAT erasure needed.
         use crate::storage::IntrinsicDimension as Dim;
-        let mut ctx = crate::context::BoxIntrinsicsCtx::new(child_count, child_query);
+        let mut ctx = crate::context::BoxIntrinsicsCtx::new(child_count, child_query, child_flex);
         match dimension {
             Dim::MinWidth => T::compute_min_intrinsic_width(self, extent, &mut ctx),
             Dim::MaxWidth => T::compute_max_intrinsic_width(self, extent, &mut ctx),

--- a/crates/flui-rendering/src/traits/render_object.rs
+++ b/crates/flui-rendering/src/traits/render_object.rs
@@ -271,6 +271,7 @@ pub trait RenderObject<P: Protocol>:
         _child_query: &mut (
                  dyn FnMut(usize, crate::storage::IntrinsicDimension, f32) -> f32 + Send + Sync
              ),
+        _child_flex: &mut (dyn FnMut(usize) -> i32 + Send + Sync),
     ) -> f32 {
         0.0
     }

--- a/crates/flui-rendering/src/traits/render_object.rs
+++ b/crates/flui-rendering/src/traits/render_object.rs
@@ -301,14 +301,21 @@ pub trait RenderObject<P: Protocol>:
     /// constraints. `None` means "this box has no baseline".
     ///
     /// Container objects that derive their baseline from a child need a
-    /// child-query channel like the other walks; none of the current
-    /// box objects report baselines yet, so the channel is added
-    /// together with the first text-bearing render object rather than
-    /// speculatively here.
+    /// child-query channel like the other memoized walks; the driver
+    /// memoizes every level in the per-node layout cache.
     fn dry_baseline_raw(
         &self,
         _constraints: ProtocolConstraints<P>,
         _baseline: crate::traits::TextBaseline,
+        _child_count: usize,
+        _child_query: &mut (
+                 dyn FnMut(
+            usize,
+            crate::context::DryBaselineChildRequest,
+        ) -> crate::context::DryBaselineChildResponse
+                     + Send
+                     + Sync
+             ),
     ) -> Option<f32> {
         None
     }

--- a/crates/flui-rendering/tests/deep_tree_stack.rs
+++ b/crates/flui-rendering/tests/deep_tree_stack.rs
@@ -176,11 +176,10 @@ fn deep_chain_survives_intrinsic_and_dry_layout_queries() {
         "intrinsic answer must be a real number, got {width}",
     );
 
-    // The leaf's DEFAULT dry layout is `constraints.smallest()` (only
-    // the child-forwarding containers implement dry queries so far),
-    // so the answer is 0×0 — what matters here is that the
-    // child-forwarding recursion reached it through 2500 levels
-    // without exhausting the stack.
+    // ConstrainedBox forwards dry layout through the chain; the leaf
+    // ColoredBox reports its preferred 40×40 under loose constraints.
+    // What matters here is that child-forwarding recursion reaches the
+    // leaf through 2500 levels without exhausting the stack.
     let size = owner
         .box_dry_layout(
             root,
@@ -189,7 +188,7 @@ fn deep_chain_survives_intrinsic_and_dry_layout_queries() {
         .expect("deep dry-layout query must not error");
     assert_eq!(
         size,
-        Size::new(px(0.0), px(0.0)),
-        "the chain forwards the leaf's default dry answer unchanged",
+        Size::new(px(40.0), px(40.0)),
+        "the chain must forward the leaf's dry layout answer unchanged",
     );
 }

--- a/crates/flui-rendering/tests/hit_test_pipeline.rs
+++ b/crates/flui-rendering/tests/hit_test_pipeline.rs
@@ -9,11 +9,13 @@
 //!    parents no longer mirror offsets in their own fields
 //!    (`hit_test_child_at_layout_offset`, Flex's `Vec<Offset>` is gone);
 //! 3. a transform parent hit-tests through the INVERSE of its paint
-//!    matrix (the D8 hit-test-under-transform gate).
+//!    matrix; child descent records paint offsets on the result
+//!    transform stack for gesture dispatch.
 
 use flui_rendering::{
     constraints::{BoxConstraints, GrowthDirection, SliverConstraints, SliverGeometry},
     context::{BoxHitTestContext, BoxLayoutContext, SliverHitTestContext, SliverLayoutContext},
+    hit_testing::HitTestResult,
     objects::{
         RenderColoredBox, RenderFlex, RenderPadding, RenderSliverIgnorePointer,
         RenderSliverOpacity, RenderSliverPadding, RenderTransform,
@@ -29,7 +31,7 @@ use flui_rendering::{
     view::ScrollDirection,
 };
 use flui_tree::{Leaf, Variable};
-use flui_types::{Offset, Rect, Size, geometry::px, layout::AxisDirection};
+use flui_types::{Matrix4, Offset, Rect, Size, geometry::px, layout::AxisDirection};
 
 type BoxedRenderObject = Box<dyn RenderObject<BoxProtocol>>;
 type BoxedSliverObject = Box<dyn RenderObject<SliverProtocol>>;
@@ -207,6 +209,43 @@ fn transform_child_hits_through_inverse_matrix() {
     assert!(
         hits(&owner, 90.0, 90.0).is_empty(),
         "outside the inverse-mapped child bounds → miss",
+    );
+}
+
+#[test]
+fn hit_entry_records_child_paint_offset_transform() {
+    let mut owner = PipelineOwner::new();
+    let padding_id = owner.insert(Box::new(RenderPadding::all(5.0)) as BoxedRenderObject);
+    let child_id = owner
+        .insert_child_render_object(padding_id, Box::new(RenderColoredBox::red(40.0, 40.0)))
+        .expect("child insert");
+    let owner = laid_out(owner, padding_id);
+
+    let mut result = HitTestResult::new();
+    owner.hit_test(Offset::new(px(20.0), px(20.0)), &mut result);
+
+    let child_entry = result
+        .path()
+        .iter()
+        .find(|entry| entry.target == child_id)
+        .expect("child must be in hit path");
+
+    let transform = child_entry
+        .transform
+        .expect("hit entry must capture the result transform stack");
+    assert_ne!(
+        transform,
+        Matrix4::identity(),
+        "laid-out child offset must contribute a non-identity transform",
+    );
+
+    let inverse = transform
+        .try_inverse()
+        .expect("paint-offset transform must be invertible");
+    let (local_x, local_y) = inverse.transform_point(px(20.0), px(20.0));
+    assert!(
+        (local_x.get() - 15.0).abs() < 0.01 && (local_y.get() - 15.0).abs() < 0.01,
+        "inverse transform must map global (20,20) to child-local (15,15) through 5px padding",
     );
 }
 

--- a/crates/flui-rendering/tests/intrinsics_cache.rs
+++ b/crates/flui-rendering/tests/intrinsics_cache.rs
@@ -398,3 +398,149 @@ fn dry_layout_flows_through_real_objects_and_memoizes() {
         .expect("dry layout new key");
     assert_eq!(f.dry_runs.load(Ordering::Relaxed), 2);
 }
+
+// ============================================================================
+// 5. Dry baseline: child-aware through real objects + memoized
+// ============================================================================
+
+#[test]
+fn dry_baseline_flows_through_padding_and_memoizes() {
+    use flui_rendering::{
+        objects::{RenderPadding, RenderParagraph},
+        traits::TextBaseline,
+    };
+    use flui_types::typography::{TextDirection, TextSpan};
+
+    let mut owner = PipelineOwner::new();
+    let padding_id = owner.insert(Box::new(RenderPadding::all(8.0)) as BoxedRenderObject);
+    let text_id = owner
+        .insert_child_render_object(
+            padding_id,
+            Box::new(RenderParagraph::new(
+                TextSpan::new("hello"),
+                TextDirection::Ltr,
+            )) as BoxedRenderObject,
+        )
+        .expect("text child");
+
+    let constraints = BoxConstraints::new(px(0.0), px(200.0), px(0.0), px(200.0));
+    let leaf_baseline = owner
+        .box_dry_baseline(text_id, constraints, TextBaseline::Alphabetic)
+        .expect("leaf dry baseline")
+        .expect("text reports a baseline");
+    let padded_baseline = owner
+        .box_dry_baseline(padding_id, constraints, TextBaseline::Alphabetic)
+        .expect("padding dry baseline")
+        .expect("padding forwards child baseline");
+
+    assert!(
+        (padded_baseline - (leaf_baseline + 8.0)).abs() < 0.01,
+        "padding must add top inset to the child's dry baseline",
+    );
+
+    let cached = owner
+        .box_dry_baseline(padding_id, constraints, TextBaseline::Alphabetic)
+        .expect("cached dry baseline");
+    assert_eq!(cached, Some(padded_baseline), "dry baseline must memoize");
+}
+
+// ============================================================================
+// 6. Passthrough proxy: intrinsics + dry layout forward unchanged
+// ============================================================================
+
+#[test]
+fn passthrough_proxy_forwards_intrinsics_and_dry_layout() {
+    use flui_rendering::objects::RenderOpacity;
+
+    let intrinsic_runs = Arc::new(AtomicUsize::new(0));
+    let dry_runs = Arc::new(AtomicUsize::new(0));
+
+    let mut owner = PipelineOwner::new();
+    let proxy_id = owner.insert(Box::new(RenderOpacity::opaque()) as BoxedRenderObject);
+    let _leaf_id = owner
+        .insert_child_render_object(
+            proxy_id,
+            Box::new(CountingLeaf::new(
+                Arc::clone(&intrinsic_runs),
+                Arc::clone(&dry_runs),
+            )),
+        )
+        .expect("leaf under opacity");
+
+    let constraints = BoxConstraints::new(px(0.0), px(200.0), px(0.0), px(200.0));
+
+    let width = owner
+        .box_intrinsic_dimension(proxy_id, IntrinsicDimension::MinWidth, 100.0)
+        .expect("proxy intrinsic width");
+    assert_eq!(width, 40.0, "opacity must forward child min intrinsic width");
+    assert_eq!(intrinsic_runs.load(Ordering::Relaxed), 1);
+
+    let size = owner
+        .box_dry_layout(proxy_id, constraints)
+        .expect("proxy dry layout");
+    assert_eq!(
+        size,
+        Size::new(px(40.0), px(40.0)),
+        "opacity must forward child dry layout"
+    );
+    assert_eq!(dry_runs.load(Ordering::Relaxed), 1);
+
+    // Memoized re-query should not re-hit the leaf.
+    owner
+        .box_intrinsic_dimension(proxy_id, IntrinsicDimension::MinWidth, 100.0)
+        .expect("cached intrinsic");
+    owner.box_dry_layout(proxy_id, constraints).expect("cached dry");
+    assert_eq!(intrinsic_runs.load(Ordering::Relaxed), 1);
+    assert_eq!(dry_runs.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn padding_forwards_intrinsics_with_insets() {
+    use flui_rendering::objects::RenderPadding;
+
+    let intrinsic_runs = Arc::new(AtomicUsize::new(0));
+    let dry_runs = Arc::new(AtomicUsize::new(0));
+
+    let mut owner = PipelineOwner::new();
+    let padding_id = owner.insert(Box::new(RenderPadding::all(10.0)) as BoxedRenderObject);
+    owner
+        .insert_child_render_object(
+            padding_id,
+            Box::new(CountingLeaf::new(
+                Arc::clone(&intrinsic_runs),
+                Arc::clone(&dry_runs),
+            )),
+        )
+        .expect("leaf under padding");
+
+    let width = owner
+        .box_intrinsic_dimension(padding_id, IntrinsicDimension::MinWidth, 100.0)
+        .expect("padding min width");
+    assert_eq!(
+        width, 60.0,
+        "padding must add horizontal insets to the child's 40px min width"
+    );
+}
+
+#[test]
+fn sized_box_reports_fixed_intrinsics_and_dry_layout() {
+    use flui_rendering::objects::RenderSizedBox;
+
+    let mut owner = PipelineOwner::new();
+    let sized_id = owner.insert(
+        Box::new(RenderSizedBox::fixed(px(80.0), px(30.0))) as BoxedRenderObject,
+    );
+
+    let width = owner
+        .box_intrinsic_dimension(sized_id, IntrinsicDimension::MinWidth, 0.0)
+        .expect("sized min width");
+    assert_eq!(width, 80.0);
+
+    let size = owner
+        .box_dry_layout(
+            sized_id,
+            BoxConstraints::new(px(0.0), px(200.0), px(0.0), px(200.0)),
+        )
+        .expect("sized dry layout");
+    assert_eq!(size, Size::new(px(80.0), px(30.0)));
+}

--- a/crates/flui-rendering/tests/intrinsics_cache.rs
+++ b/crates/flui-rendering/tests/intrinsics_cache.rs
@@ -472,7 +472,10 @@ fn passthrough_proxy_forwards_intrinsics_and_dry_layout() {
     let width = owner
         .box_intrinsic_dimension(proxy_id, IntrinsicDimension::MinWidth, 100.0)
         .expect("proxy intrinsic width");
-    assert_eq!(width, 40.0, "opacity must forward child min intrinsic width");
+    assert_eq!(
+        width, 40.0,
+        "opacity must forward child min intrinsic width"
+    );
     assert_eq!(intrinsic_runs.load(Ordering::Relaxed), 1);
 
     let size = owner
@@ -489,7 +492,9 @@ fn passthrough_proxy_forwards_intrinsics_and_dry_layout() {
     owner
         .box_intrinsic_dimension(proxy_id, IntrinsicDimension::MinWidth, 100.0)
         .expect("cached intrinsic");
-    owner.box_dry_layout(proxy_id, constraints).expect("cached dry");
+    owner
+        .box_dry_layout(proxy_id, constraints)
+        .expect("cached dry");
     assert_eq!(intrinsic_runs.load(Ordering::Relaxed), 1);
     assert_eq!(dry_runs.load(Ordering::Relaxed), 1);
 }
@@ -527,9 +532,8 @@ fn sized_box_reports_fixed_intrinsics_and_dry_layout() {
     use flui_rendering::objects::RenderSizedBox;
 
     let mut owner = PipelineOwner::new();
-    let sized_id = owner.insert(
-        Box::new(RenderSizedBox::fixed(px(80.0), px(30.0))) as BoxedRenderObject,
-    );
+    let sized_id =
+        owner.insert(Box::new(RenderSizedBox::fixed(px(80.0), px(30.0))) as BoxedRenderObject);
 
     let width = owner
         .box_intrinsic_dimension(sized_id, IntrinsicDimension::MinWidth, 0.0)

--- a/crates/flui-rendering/tests/render_object_harness.rs
+++ b/crates/flui-rendering/tests/render_object_harness.rs
@@ -4,45 +4,45 @@
 //!
 //! # Coverage map (one row per exported render type)
 //!
-//! | Type | Harness test(s) | Layout | Hit-test | Paint | Diagnostics |
-//! |------|-----------------|--------|----------|-------|-------------|
-//! | `RenderSizedBox` | `harness_sized_box_*` | yes | — | — | yes |
-//! | `RenderColoredBox` | `harness_colored_box_*` | yes | yes | yes | yes |
-//! | `RenderImage` | `harness_image_*` | yes | — | yes | yes |
-//! | `RenderParagraph` | `harness_paragraph_*` | yes | — | yes | yes |
-//! | `RenderPadding` | `harness_padding_*` | yes | — | — | yes |
-//! | `RenderCenter` | `harness_center_*` | yes | — | — | yes |
-//! | `RenderAspectRatio` | `harness_aspect_ratio_*` | yes | — | — | yes |
-//! | `RenderConstrainedBox` | `harness_constrained_box_*` | yes | — | — | yes |
-//! | `RenderLimitedBox` | `harness_limited_box_*` | yes | — | — | yes |
-//! | `RenderOffstage` | `harness_offstage_*` | yes | yes | — | yes |
-//! | `RenderOpacity` | `harness_opacity_*` | yes | — | yes | yes |
-//! | `RenderTransform` | `harness_transform_*` | yes | — | yes | yes |
-//! | `RenderFittedBox` | `harness_fitted_box_*` | yes | — | — | yes |
-//! | `RenderFractionallySizedBox` | `harness_fractionally_sized_box_*` | yes | — | — | yes |
-//! | `RenderFractionalTranslation` | `harness_fractional_translation_*` | yes | — | — | yes |
-//! | `RenderDecoratedBox` | `harness_decorated_box_*` | yes | — | yes | yes |
-//! | `RenderClipRect` | `harness_clip_rect_*` | yes | — | — | yes |
-//! | `RenderClipRRect` | `harness_clip_rrect_*` | yes | — | — | yes |
-//! | `RenderClipOval` | `harness_clip_oval_*` | yes | — | — | yes |
-//! | `RenderClipPath` | `harness_clip_path_*` | yes | — | — | yes |
-//! | `RenderRepaintBoundary` | `harness_repaint_boundary_*` | yes | — | yes | yes |
-//! | `RenderMetaData` | `harness_metadata_*` | yes | — | — | yes |
-//! | `RenderFlex` | `harness_flex_*` | yes | — | — | yes |
-//! | `RenderStack` | `harness_stack_*` | yes | yes | — | yes |
-//! | `RenderAbsorbPointer` | `harness_absorb_pointer_*` | yes | yes | — | yes |
-//! | `RenderIgnorePointer` | `harness_ignore_pointer_*` | yes | yes | — | yes |
-//! | `RenderSliverFixedExtentList` | `harness_sliver_fixed_extent_list_*` | yes | — | — | yes |
-//! | `RenderSliverPadding` | `harness_sliver_padding_*` | yes | — | — | yes |
-//! | `RenderSliverToBoxAdapter` | `harness_sliver_to_box_adapter_*` | yes | — | — | yes |
-//! | `RenderSliverFillViewport` | `harness_sliver_fill_viewport_*` | yes | — | — | yes |
-//! | `RenderSliverFillRemaining` | `harness_sliver_fill_remaining_*` | yes | — | — | yes |
-//! | `RenderSliverFillRemainingAndOverscroll` | `harness_sliver_fill_remaining_and_overscroll_*` | yes | — | — | yes |
-//! | `RenderSliverFillRemainingWithScrollable` | `harness_sliver_fill_remaining_with_scrollable_*` | yes | — | — | yes |
-//! | `RenderSliverIgnorePointer` | `harness_sliver_ignore_pointer_*` | yes | yes | — | yes |
-//! | `RenderSliverOffstage` | `harness_sliver_offstage_*` | yes | — | — | yes |
-//! | `RenderSliverOpacity` | `harness_sliver_opacity_*` | yes | — | yes | yes |
-//! | `RenderViewport` | `harness_viewport_*` | yes | — | — | yes |
+//! | Type | Harness test(s) | Layout | Hit-test | Paint | Diagnostics | Queries |
+//! |------|-----------------|--------|----------|-------|-------------|---------|
+//! | `RenderSizedBox` | `harness_sized_box_*` | yes | — | — | yes | queries |
+//! | `RenderColoredBox` | `harness_colored_box_*` | yes | yes | yes | yes | — |
+//! | `RenderImage` | `harness_image_*` | yes | — | yes | yes | — |
+//! | `RenderParagraph` | `harness_paragraph_*` | yes | — | yes | yes | — |
+//! | `RenderPadding` | `harness_padding_*` | yes | — | — | yes | queries |
+//! | `RenderCenter` | `harness_center_*` | yes | — | — | yes | — |
+//! | `RenderAspectRatio` | `harness_aspect_ratio_*` | yes | — | — | yes | — |
+//! | `RenderConstrainedBox` | `harness_constrained_box_*` | yes | — | — | yes | — |
+//! | `RenderLimitedBox` | `harness_limited_box_*` | yes | — | — | yes | — |
+//! | `RenderOffstage` | `harness_offstage_*` | yes | yes | — | yes | — |
+//! | `RenderOpacity` | `harness_opacity_*` | yes | — | yes | yes | queries |
+//! | `RenderTransform` | `harness_transform_*` | yes | — | yes | yes | — |
+//! | `RenderFittedBox` | `harness_fitted_box_*` | yes | — | — | yes | — |
+//! | `RenderFractionallySizedBox` | `harness_fractionally_sized_box_*` | yes | — | — | yes | — |
+//! | `RenderFractionalTranslation` | `harness_fractional_translation_*` | yes | — | — | yes | — |
+//! | `RenderDecoratedBox` | `harness_decorated_box_*` | yes | — | yes | yes | — |
+//! | `RenderClipRect` | `harness_clip_rect_*` | yes | — | — | yes | — |
+//! | `RenderClipRRect` | `harness_clip_rrect_*` | yes | — | — | yes | — |
+//! | `RenderClipOval` | `harness_clip_oval_*` | yes | — | — | yes | — |
+//! | `RenderClipPath` | `harness_clip_path_*` | yes | — | — | yes | — |
+//! | `RenderRepaintBoundary` | `harness_repaint_boundary_*` | yes | — | yes | yes | — |
+//! | `RenderMetaData` | `harness_metadata_*` | yes | — | — | yes | — |
+//! | `RenderFlex` | `harness_flex_*` | yes | — | — | yes | — |
+//! | `RenderStack` | `harness_stack_*` | yes | yes | — | yes | — |
+//! | `RenderAbsorbPointer` | `harness_absorb_pointer_*` | yes | yes | — | yes | — |
+//! | `RenderIgnorePointer` | `harness_ignore_pointer_*` | yes | yes | — | yes | — |
+//! | `RenderSliverFixedExtentList` | `harness_sliver_fixed_extent_list_*` | yes | — | — | yes | — |
+//! | `RenderSliverPadding` | `harness_sliver_padding_*` | yes | — | — | yes | — |
+//! | `RenderSliverToBoxAdapter` | `harness_sliver_to_box_adapter_*` | yes | — | — | yes | — |
+//! | `RenderSliverFillViewport` | `harness_sliver_fill_viewport_*` | yes | — | — | yes | — |
+//! | `RenderSliverFillRemaining` | `harness_sliver_fill_remaining_*` | yes | — | — | yes | — |
+//! | `RenderSliverFillRemainingAndOverscroll` | `harness_sliver_fill_remaining_and_overscroll_*` | yes | — | — | yes | — |
+//! | `RenderSliverFillRemainingWithScrollable` | `harness_sliver_fill_remaining_with_scrollable_*` | yes | — | — | yes | — |
+//! | `RenderSliverIgnorePointer` | `harness_sliver_ignore_pointer_*` | yes | yes | — | yes | — |
+//! | `RenderSliverOffstage` | `harness_sliver_offstage_*` | yes | — | — | yes | — |
+//! | `RenderSliverOpacity` | `harness_sliver_opacity_*` | yes | — | yes | yes | — |
+//! | `RenderViewport` | `harness_viewport_*` | yes | — | — | yes | — |
 //!
 //! [`catalog_covers_every_render_object_name`] guards the table: every row's
 //! type string must appear in this file so a missing harness test fails CI.
@@ -52,8 +52,8 @@ use flui_rendering::{
     objects::*,
     parent_data::StackParentData,
     testing::{
-        Probe, RenderTester, TreeNode, assert_descendant_properties, assert_has_committed_geometry,
-        assert_has_committed_size, box_node, sliver_node,
+        BoxQueryRun, Probe, RenderTester, TreeNode, assert_descendant_properties,
+        assert_has_committed_geometry, assert_has_committed_size, box_node, sliver_node,
     },
 };
 use flui_types::{
@@ -165,6 +165,20 @@ fn harness_sized_box_width_only_leaves_height_loose() {
 }
 
 #[test]
+fn harness_sized_box_reports_fixed_queries() {
+    let constraints = loose(200.0);
+    let mut run = RenderTester::mount(box_node(RenderSizedBox::fixed(px(80.0), px(30.0))))
+        .with_constraints(constraints)
+        .run_layout();
+
+    assert_eq!(run.min_intrinsic_width(run.root(), 0.0), 80.0);
+    assert_eq!(
+        run.dry_layout(run.root(), constraints),
+        Size::new(px(80.0), px(30.0))
+    );
+}
+
+#[test]
 fn harness_colored_box_self_describes_and_paints() {
     let run = RenderTester::mount(box_node(RenderColoredBox::red(50.0, 50.0)))
         .with_size(Size::new(px(100.0), px(100.0)))
@@ -270,6 +284,23 @@ fn harness_padding_deflates_child_offset() {
     assert!(
         run.descendant_property("RenderPadding", "padding")
             .is_some()
+    );
+}
+
+#[test]
+fn harness_padding_forwards_intrinsics_with_insets() {
+    let mut run = RenderTester::mount(
+        box_node(RenderPadding::all(10.0))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    let padding = run.root();
+    assert_eq!(
+        run.min_intrinsic_width(padding, 100.0),
+        60.0,
+        "padding must add horizontal insets to the child's 40px min width"
     );
 }
 
@@ -454,6 +485,30 @@ fn harness_opacity_passes_child_geometry() {
     assert_eq!(
         run.descendant_property_f64("RenderOpacity", "opacity"),
         Some(0.5)
+    );
+}
+
+#[test]
+fn harness_opacity_forwards_box_queries() {
+    let constraints = loose(200.0);
+    let mut run = RenderTester::mount(
+        box_node(RenderOpacity::opaque())
+            .label("proxy")
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(constraints)
+    .run_layout();
+
+    let proxy = run.id("proxy");
+    assert_eq!(
+        run.min_intrinsic_width(proxy, 100.0),
+        40.0,
+        "opacity must forward child min intrinsic width"
+    );
+    assert_eq!(
+        run.dry_layout(proxy, constraints),
+        Size::new(px(40.0), px(40.0)),
+        "opacity must forward child dry layout"
     );
 }
 

--- a/crates/flui-rendering/tests/render_object_harness.rs
+++ b/crates/flui-rendering/tests/render_object_harness.rs
@@ -50,7 +50,7 @@
 use flui_rendering::{
     constraints::BoxConstraints,
     objects::*,
-    parent_data::StackParentData,
+    parent_data::{FlexParentData, StackParentData},
     testing::{
         BoxQueryRun, Probe, RenderTester, TreeNode, assert_descendant_properties,
         assert_has_committed_geometry, assert_has_committed_size, box_node, sliver_node,
@@ -849,6 +849,27 @@ fn harness_flex_row_sums_child_min_intrinsic_widths() {
 
     assert_eq!(run.min_intrinsic_width(run.root(), 100.0), 80.0);
     assert_eq!(run.max_intrinsic_height(run.root(), 200.0), 20.0);
+}
+
+#[test]
+fn harness_flex_row_weights_flexible_child_min_intrinsic_width() {
+    let mut run = RenderTester::mount(
+        box_node(RenderFlex::row())
+            .child(
+                box_node(RenderColoredBox::red(100.0, 20.0))
+                    .with_flex_parent_data(FlexParentData::flexible(1))
+                    .label("flex"),
+            )
+            .child(box_node(RenderColoredBox::green(40.0, 20.0)).label("fixed")),
+    )
+    .with_size(Size::new(px(200.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(
+        run.min_intrinsic_width(run.root(), 100.0),
+        140.0,
+        "flex child min 100 at flex 1 plus fixed 40",
+    );
 }
 
 #[test]

--- a/crates/flui-rendering/tests/render_object_harness.rs
+++ b/crates/flui-rendering/tests/render_object_harness.rs
@@ -28,8 +28,8 @@
 //! | `RenderClipPath` | `harness_clip_path_*` | yes | — | — | yes | — |
 //! | `RenderRepaintBoundary` | `harness_repaint_boundary_*` | yes | — | yes | yes | — |
 //! | `RenderMetaData` | `harness_metadata_*` | yes | — | — | yes | — |
-//! | `RenderFlex` | `harness_flex_*` | yes | — | — | yes | — |
-//! | `RenderStack` | `harness_stack_*` | yes | yes | — | yes | — |
+//! | `RenderFlex` | `harness_flex_*` | yes | — | — | yes | queries |
+//! | `RenderStack` | `harness_stack_*` | yes | yes | — | yes | queries |
 //! | `RenderAbsorbPointer` | `harness_absorb_pointer_*` | yes | yes | — | yes | — |
 //! | `RenderIgnorePointer` | `harness_ignore_pointer_*` | yes | yes | — | yes | — |
 //! | `RenderSliverFixedExtentList` | `harness_sliver_fixed_extent_list_*` | yes | — | — | yes | — |
@@ -838,6 +838,20 @@ fn harness_flex_row_positions_children_on_main_axis() {
 }
 
 #[test]
+fn harness_flex_row_sums_child_min_intrinsic_widths() {
+    let mut run = RenderTester::mount(
+        box_node(RenderFlex::row())
+            .child(box_node(RenderColoredBox::red(30.0, 20.0)).label("a"))
+            .child(box_node(RenderColoredBox::green(50.0, 20.0)).label("b")),
+    )
+    .with_size(Size::new(px(200.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.min_intrinsic_width(run.root(), 100.0), 80.0);
+    assert_eq!(run.max_intrinsic_height(run.root(), 200.0), 20.0);
+}
+
+#[test]
 fn harness_flex_column_stacks_children_vertically() {
     let run = RenderTester::mount(
         box_node(RenderFlex::column())
@@ -854,6 +868,20 @@ fn harness_flex_column_stacks_children_vertically() {
             .as_deref(),
         Some("Vertical"),
     );
+}
+
+#[test]
+fn harness_stack_max_child_intrinsic_width() {
+    let mut run = RenderTester::mount(
+        box_node(RenderStack::new())
+            .child(box_node(RenderColoredBox::red(30.0, 20.0)).label("a"))
+            .child(box_node(RenderColoredBox::green(50.0, 25.0)).label("b")),
+    )
+    .with_size(Size::new(px(200.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(run.min_intrinsic_width(run.root(), 100.0), 50.0);
+    assert_eq!(run.max_intrinsic_height(run.root(), 200.0), 25.0);
 }
 
 #[test]

--- a/crates/flui-rendering/tests/render_object_harness.rs
+++ b/crates/flui-rendering/tests/render_object_harness.rs
@@ -892,6 +892,24 @@ fn harness_flex_column_stacks_children_vertically() {
 }
 
 #[test]
+fn harness_flex_column_max_child_intrinsic_width() {
+    let mut run = RenderTester::mount(
+        box_node(RenderFlex::column())
+            .child(box_node(RenderColoredBox::red(30.0, 20.0)).label("a"))
+            .child(box_node(RenderColoredBox::green(50.0, 20.0)).label("b")),
+    )
+    .with_size(Size::new(px(200.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(
+        run.min_intrinsic_width(run.root(), 100.0),
+        50.0,
+        "column cross-axis width is max child width, not sum",
+    );
+    assert_eq!(run.max_intrinsic_width(run.root(), 100.0), 50.0);
+}
+
+#[test]
 fn harness_stack_max_child_intrinsic_width() {
     let mut run = RenderTester::mount(
         box_node(RenderStack::new())

--- a/crates/flui-rendering/tests/u35_paint_dirty_flag_discipline.rs
+++ b/crates/flui-rendering/tests/u35_paint_dirty_flag_discipline.rs
@@ -11,6 +11,8 @@
 //!   * crates/flui-rendering/src/pipeline/owner.rs — `run_paint`,
 //!     `paint_node_recursive`
 
+use flui_foundation::LayerId;
+use flui_layer::{Layer, LayerTree};
 use flui_rendering::{
     constraints::BoxConstraints,
     objects::{RenderColoredBox, RenderPadding, RenderRepaintBoundary},
@@ -261,5 +263,65 @@ fn u35_unpainted_unreached_nodes_still_clear_flag() {
     assert!(
         !owner.render_tree().get(root_id).unwrap().needs_paint(),
         "root needs_paint must be cleared after paint (painted by root descent)",
+    );
+}
+
+fn layer_tree_has_picture(tree: &LayerTree) -> bool {
+    fn walk(tree: &LayerTree, id: LayerId) -> bool {
+        let Some(node) = tree.get(id) else {
+            return false;
+        };
+        matches!(node.layer(), Layer::Picture(_))
+            || node.children().iter().any(|&child| walk(tree, child))
+    }
+    tree.root().is_some_and(|root| walk(tree, root))
+}
+
+#[test]
+fn paint_skips_node_that_still_needs_layout() {
+    let mut owner = PipelineOwner::new();
+    let root_id = owner.insert(Box::new(RenderPadding::all(0.0))
+        as Box<dyn RenderObject<flui_rendering::protocol::BoxProtocol>>);
+    let child_id = owner
+        .insert_child_render_object(root_id, Box::new(RenderColoredBox::red(40.0, 40.0)))
+        .expect("child insert");
+
+    owner.set_root_id(Some(root_id));
+    owner.set_root_constraints(Some(BoxConstraints::new(
+        px(0.0),
+        px(200.0),
+        px(0.0),
+        px(200.0),
+    )));
+
+    let mut owner = owner.into_layout();
+    owner.run_layout().expect("layout");
+    let mut owner = owner.into_compositing();
+    owner.run_compositing().expect("compositing");
+    let mut owner = owner.into_paint();
+    owner.run_paint().expect("paint");
+
+    assert!(
+        owner.layer_tree().is_some_and(layer_tree_has_picture),
+        "first paint must record child picture ops",
+    );
+
+    let root_depth = owner.render_tree().depth(root_id).unwrap_or(0) as usize;
+    let mut owner = owner.into_idle();
+    owner
+        .render_tree()
+        .get(child_id)
+        .expect("child")
+        .mark_layout_flag();
+    owner.add_node_needing_paint(root_id, root_depth);
+
+    let owner = owner.into_layout();
+    let owner = owner.into_compositing();
+    let mut owner = owner.into_paint();
+    owner.run_paint().expect("repaint with stale child layout");
+
+    assert!(
+        !owner.layer_tree().is_some_and(layer_tree_has_picture),
+        "needs_layout node must not paint stale geometry",
     );
 }


### PR DESCRIPTION
## Summary

- Forward box intrinsics, dry layout, and dry baseline through single-child proxy boxes so U9 memoization returns correct values for wrappers (opacity, padding, transform, clip, etc.).
- Extend the render harness with `BoxQueryRun` query helpers, catalog coverage, and updated `TESTING.md`; add paint guard when layout is still dirty.
- Validate committed box geometry at runtime (`InvalidGeometry` for non-finite or constraint-violating sizes) and add multi-child intrinsics for `RenderFlex` / `RenderStack`, including Flutter-style flex-weighted main-axis sizing.

## Test plan

- [x] `cargo test -p flui-rendering --features testing`
- [ ] CI green on PR
- [ ] Spot-check harness query tests (`harness_opacity_forwards_box_queries`, `harness_flex_row_weights_flexible_child_min_intrinsic_width`)