### PR TITLE
feat(rendering): actual baseline layout and RenderBaseline (Wave 2)

### DIFF
--- a/crates/flui-rendering/src/context/layout.rs
+++ b/crates/flui-rendering/src/context/layout.rs
@@ -394,6 +394,20 @@ where
             index,
         )
     }
+
+    /// Distance from the top of child `index` to its first baseline of
+    /// `baseline` kind, after the child has been laid out in this walk.
+    pub fn child_distance_to_actual_baseline(
+        &self,
+        index: usize,
+        baseline: crate::traits::TextBaseline,
+    ) -> Option<f32> {
+        crate::protocol::box_protocol::BoxLayoutCtxErased::child_distance_to_actual_baseline(
+            &self.inner,
+            index,
+            baseline,
+        )
+    }
 }
 
 // ============================================================================

--- a/crates/flui-rendering/src/objects/baseline.rs
+++ b/crates/flui-rendering/src/objects/baseline.rs
@@ -1,0 +1,152 @@
+//! RenderBaseline — positions a child so its baseline sits at a fixed offset.
+//!
+//! Flutter parity: `shifted_box.dart` `RenderBaseline`.
+
+use flui_tree::Single;
+use flui_types::{Offset, Pixels, Point, Rect, Size};
+
+use crate::{
+    constraints::BoxConstraints,
+    context::{BoxDryBaselineCtx, BoxHitTestContext, BoxLayoutContext},
+    parent_data::BoxParentData,
+    traits::{
+        HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability, TextBaseline,
+    },
+};
+
+/// Positions its child so the child's [`TextBaseline`] sits at
+/// [`baseline_offset`](Self::baseline_offset) from the top of this box.
+#[derive(Debug, Clone)]
+pub struct RenderBaseline {
+    baseline: TextBaseline,
+    baseline_offset: Pixels,
+    size: Size,
+    has_child: bool,
+    child_offset: Offset,
+}
+
+impl RenderBaseline {
+    /// Creates a baseline container for `baseline` at `baseline_offset`.
+    pub fn new(baseline: TextBaseline, baseline_offset: Pixels) -> Self {
+        Self {
+            baseline,
+            baseline_offset,
+            size: Size::ZERO,
+            has_child: false,
+            child_offset: Offset::ZERO,
+        }
+    }
+
+    /// Which baseline kind to align.
+    pub fn baseline(&self) -> TextBaseline {
+        self.baseline
+    }
+
+    /// Distance from the top of this box to the aligned baseline.
+    pub fn baseline_offset(&self) -> Pixels {
+        self.baseline_offset
+    }
+
+    /// Sets the baseline kind. Caller marks layout dirty.
+    pub fn set_baseline(&mut self, baseline: TextBaseline) {
+        self.baseline = baseline;
+    }
+
+    /// Sets the baseline offset. Caller marks layout dirty.
+    pub fn set_baseline_offset(&mut self, offset: Pixels) {
+        self.baseline_offset = offset;
+    }
+}
+
+impl flui_foundation::Diagnosticable for RenderBaseline {
+    fn debug_fill_properties(&self, properties: &mut flui_foundation::DiagnosticsBuilder) {
+        properties.add_enum("baseline", self.baseline);
+        properties.add(
+            "baseline_offset",
+            format!("{:.0}px", self.baseline_offset.get()),
+        );
+    }
+}
+
+impl RenderBox for RenderBaseline {
+    type Arity = Single;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Single, BoxParentData>) {
+        let constraints = *ctx.constraints();
+
+        if ctx.child_count() == 0 {
+            self.has_child = false;
+            self.size = constraints.smallest();
+            ctx.complete_with_size(self.size);
+            return;
+        }
+
+        self.has_child = true;
+        let child_size = ctx.layout_child(0, constraints);
+
+        if let Some(distance) = ctx.child_distance_to_actual_baseline(0, self.baseline) {
+            self.child_offset =
+                Offset::new(Pixels::ZERO, self.baseline_offset - Pixels::new(distance));
+            self.size = Size::new(
+                child_size.width,
+                child_size.height - Pixels::new(distance) + self.baseline_offset,
+            );
+        } else {
+            self.child_offset = Offset::ZERO;
+            self.size = child_size;
+        }
+
+        ctx.position_child(0, self.child_offset);
+        self.size = constraints.constrain(self.size);
+        ctx.complete_with_size(self.size);
+    }
+
+    fn size(&self) -> &Size {
+        &self.size
+    }
+
+    fn size_mut(&mut self) -> &mut Size {
+        &mut self.size
+    }
+
+    fn compute_distance_to_actual_baseline(&self, baseline: TextBaseline) -> Option<f32> {
+        if baseline == self.baseline {
+            Some(self.baseline_offset.get())
+        } else {
+            None
+        }
+    }
+
+    fn compute_dry_baseline(
+        &self,
+        constraints: BoxConstraints,
+        baseline: TextBaseline,
+        ctx: &mut BoxDryBaselineCtx<'_>,
+    ) -> Option<f32> {
+        if baseline != self.baseline || ctx.child_count() == 0 {
+            return None;
+        }
+        ctx.child_dry_baseline(0, constraints, baseline)
+            .map(|_| self.baseline_offset.get())
+    }
+
+    fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Single, BoxParentData>) -> bool {
+        if !ctx.is_within_size(self.size.width, self.size.height) {
+            return false;
+        }
+        if self.has_child {
+            ctx.hit_test_child_at_layout_offset(0)
+        } else {
+            false
+        }
+    }
+
+    fn box_paint_bounds(&self) -> Rect {
+        Rect::from_origin_size(Point::ZERO, self.size)
+    }
+}
+
+impl PaintEffectsCapability for RenderBaseline {}
+impl SemanticsCapability for RenderBaseline {}
+impl HotReloadCapability for RenderBaseline {}

--- a/crates/flui-rendering/src/objects/flex.rs
+++ b/crates/flui-rendering/src/objects/flex.rs
@@ -7,7 +7,9 @@ use crate::{
     constraints::BoxConstraints,
     context::{BoxHitTestContext, BoxIntrinsicsCtx, BoxLayoutContext},
     parent_data::{FlexFit, FlexParentData},
-    traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability},
+    traits::{
+        HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability, TextBaseline,
+    },
 };
 
 /// Direction of the flex layout.
@@ -59,6 +61,8 @@ pub enum CrossAxisAlignment {
     Center,
     /// Children are stretched to fill the cross axis.
     Stretch,
+    /// Align children by their text baselines (horizontal flex only).
+    Baseline,
 }
 
 /// A render object that lays out children in a flex layout (row or column).
@@ -87,6 +91,8 @@ pub struct RenderFlex {
     main_axis_size: MainAxisSize,
     /// Cross axis alignment.
     cross_axis_alignment: CrossAxisAlignment,
+    /// Baseline kind used when [`CrossAxisAlignment::Baseline`] is selected.
+    text_baseline: TextBaseline,
     /// Spacing between children.
     spacing: f32,
     /// Size after layout.
@@ -102,6 +108,7 @@ impl Default for RenderFlex {
             main_axis_alignment: MainAxisAlignment::Start,
             main_axis_size: MainAxisSize::Max,
             cross_axis_alignment: CrossAxisAlignment::Start,
+            text_baseline: TextBaseline::Alphabetic,
             spacing: 0.0,
             size: Size::ZERO,
             child_count: 0,
@@ -146,6 +153,12 @@ impl RenderFlex {
     /// Sets the cross axis alignment.
     pub fn with_cross_axis_alignment(mut self, alignment: CrossAxisAlignment) -> Self {
         self.cross_axis_alignment = alignment;
+        self
+    }
+
+    /// Sets the text baseline used for [`CrossAxisAlignment::Baseline`].
+    pub fn with_text_baseline(mut self, baseline: TextBaseline) -> Self {
+        self.text_baseline = baseline;
         self
     }
 
@@ -260,6 +273,9 @@ impl flui_foundation::Diagnosticable for RenderFlex {
         properties.add_enum("main_axis_alignment", self.main_axis_alignment);
         properties.add_default_enum("main_axis_size", self.main_axis_size, MainAxisSize::Max);
         properties.add_enum("cross_axis_alignment", self.cross_axis_alignment);
+        if self.cross_axis_alignment == CrossAxisAlignment::Baseline {
+            properties.add_enum("text_baseline", self.text_baseline);
+        }
         properties.add_default_double("spacing", self.spacing, 0.0, Some("px"));
     }
 }
@@ -473,6 +489,24 @@ impl RenderBox for RenderFlex {
             }
         };
 
+        // Flutter flex.dart: baseline cross-axis alignment applies to rows only.
+        let max_baseline_distance = if self.direction == FlexDirection::Horizontal
+            && self.cross_axis_alignment == CrossAxisAlignment::Baseline
+        {
+            let mut max = None::<f32>;
+            for i in 0..child_count {
+                if let Some(d) = ctx.child_distance_to_actual_baseline(i, self.text_baseline) {
+                    max = Some(match max {
+                        Some(m) => m.max(d),
+                        None => d,
+                    });
+                }
+            }
+            max
+        } else {
+            None
+        };
+
         // Position each child and track offsets
 
         for (i, slot) in child_sizes.iter().enumerate().take(child_count) {
@@ -484,6 +518,15 @@ impl RenderBox for RenderFlex {
                 CrossAxisAlignment::End => cross_extent - self.cross_size(child_size),
                 CrossAxisAlignment::Center => (cross_extent - self.cross_size(child_size)) / 2.0,
                 CrossAxisAlignment::Stretch => Pixels::ZERO,
+                CrossAxisAlignment::Baseline => {
+                    if let Some(max_dist) = max_baseline_distance {
+                        ctx.child_distance_to_actual_baseline(i, self.text_baseline)
+                            .map(|child_dist| Pixels::new(max_dist - child_dist))
+                            .unwrap_or(Pixels::ZERO)
+                    } else {
+                        Pixels::ZERO
+                    }
+                }
             };
 
             let offset = self.offset(main_offset, cross_offset);

--- a/crates/flui-rendering/src/objects/mod.rs
+++ b/crates/flui-rendering/src/objects/mod.rs
@@ -76,6 +76,7 @@
 
 mod absorb_pointer;
 mod aspect_ratio;
+mod baseline;
 mod center;
 mod clip;
 mod colored_box;
@@ -109,6 +110,7 @@ mod viewport;
 
 pub use absorb_pointer::RenderAbsorbPointer;
 pub use aspect_ratio::{AspectRatio, RenderAspectRatio};
+pub use baseline::RenderBaseline;
 pub use center::RenderCenter;
 pub use clip::{
     ClipGeometry, CustomClipper, Oval, RenderClip, RenderClipOval, RenderClipPath, RenderClipRRect,

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -31,7 +31,10 @@ use crate::{
     context::{FragmentClip, FragmentOp, FragmentRecorder},
     protocol::{
         BoxProtocol, MainAxisPosition, Protocol, SliverProtocol,
-        box_protocol::{BoxLayoutCtxErased, LayoutChildCallback, SliverLayoutChildCallback},
+        box_protocol::{
+            ActualBaselineChildCallback, BoxLayoutCtxErased, LayoutChildCallback,
+            SliverLayoutChildCallback,
+        },
         sliver_protocol::{SliverChildLayoutCallback, SliverLayoutCtxErased},
     },
     storage::{RenderEntry, RenderNode, RenderTree},
@@ -2556,6 +2559,18 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
     };
     let cb_ref: LayoutChildCallback<'_> = &cb_owned;
 
+    let baseline_cb_owned = move |child_id: RenderId, baseline: crate::traits::TextBaseline| {
+        borrows_for_cb.get(child_id).and_then(|child_ptr| {
+            // SAFETY: shared reborrow of a distinct child slot after its
+            // layout completed in this walk; no concurrent &mut to the slot.
+            let child_node: &RenderNode = unsafe { &*child_ptr.0 };
+            child_node
+                .as_box()
+                .and_then(|entry| entry.render_object().actual_baseline_raw(baseline))
+        })
+    };
+    let baseline_cb_ref: ActualBaselineChildCallback<'_> = &baseline_cb_owned;
+
     // Sliver child callback: invoked when the Box parent calls
     // `ctx.layout_sliver_child(index, sliver_constraints)`.  Uses the
     // same `borrows_for_cb` pool and `descendant_error_flag` as the box
@@ -2603,6 +2618,7 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
         &mut child_states,
         &child_ids,
         cb_ref,
+        baseline_cb_ref,
         Some(sliver_cb_ref),
     );
     let erased: &mut dyn BoxLayoutCtxErased = &mut ctx;

--- a/crates/flui-rendering/src/protocol/box_protocol.rs
+++ b/crates/flui-rendering/src/protocol/box_protocol.rs
@@ -287,6 +287,14 @@ impl LayoutCapability for BoxLayout {
 pub type LayoutChildCallback<'a> =
     &'a (dyn Fn(flui_foundation::RenderId, BoxConstraints) -> Size + Send + Sync);
 
+/// Callback for reading a laid-out child's actual baseline distance.
+///
+/// Called after `layout_child` when a parent needs the post-layout baseline
+/// position (e.g. `RenderBaseline`, flex baseline cross-axis alignment).
+pub type ActualBaselineChildCallback<'a> = &'a (
+        dyn Fn(flui_foundation::RenderId, crate::traits::TextBaseline) -> Option<f32> + Send + Sync
+    );
+
 /// Callback type for cross-protocol sliver child layout driven by a Box parent.
 ///
 /// Called when a Box parent's `layout_sliver_child()` is invoked. The callback
@@ -515,6 +523,21 @@ impl<'ctx, A: Arity, P: ParentData + Default> BoxLayoutCtx<'ctx, A, P> {
         match &self.storage {
             BoxLayoutCtxStorage::Direct { geometry, .. }
             | BoxLayoutCtxStorage::Proxy { geometry, .. } => geometry.as_ref(),
+        }
+    }
+
+    /// Distance from the top of child `index` to its first baseline of
+    /// `baseline` kind, after the child has been laid out in this walk.
+    pub fn child_distance_to_actual_baseline(
+        &self,
+        index: usize,
+        baseline: crate::traits::TextBaseline,
+    ) -> Option<f32> {
+        match &self.storage {
+            BoxLayoutCtxStorage::Direct { .. } => None,
+            BoxLayoutCtxStorage::Proxy { erased, .. } => {
+                erased.child_distance_to_actual_baseline(index, baseline)
+            }
         }
     }
 }
@@ -789,6 +812,18 @@ pub trait BoxLayoutCtxErased: Send + Sync {
     /// and Proxy `complete_layout` mirror.
     fn complete_layout(&mut self, size: Size);
 
+    /// Distance from the top of child `index` to its first baseline of
+    /// `baseline` kind, after the child has been laid out in this walk.
+    ///
+    /// Default: `None` when the walk does not wire a baseline callback.
+    fn child_distance_to_actual_baseline(
+        &self,
+        _index: usize,
+        _baseline: crate::traits::TextBaseline,
+    ) -> Option<f32> {
+        None
+    }
+
     /// Reads child `index`'s parent data as `&dyn ParentData`. Returns
     /// `None` if `index` is out of bounds or the context wasn't
     /// constructed with children access.
@@ -918,6 +953,20 @@ impl<A: Arity, P: ParentData + Default> BoxLayoutCtxErased for BoxLayoutCtx<'_, 
     }
 
     #[inline]
+    fn child_distance_to_actual_baseline(
+        &self,
+        index: usize,
+        baseline: crate::traits::TextBaseline,
+    ) -> Option<f32> {
+        match &self.storage {
+            BoxLayoutCtxStorage::Direct { .. } => None,
+            BoxLayoutCtxStorage::Proxy { erased, .. } => {
+                erased.child_distance_to_actual_baseline(index, baseline)
+            }
+        }
+    }
+
+    #[inline]
     fn child_parent_data_dyn(&self, index: usize) -> Option<&dyn ParentData> {
         // Storage-aware: Direct returns own children's parent_data;
         // Proxy delegates back through the underlying erased ctx.
@@ -1022,6 +1071,7 @@ pub struct ErasedBoxLayoutCtx<'ctx> {
     children: &'ctx mut Vec<ErasedChildState>,
     child_ids: &'ctx [flui_foundation::RenderId],
     layout_child_callback: LayoutChildCallback<'ctx>,
+    actual_baseline_callback: ActualBaselineChildCallback<'ctx>,
     /// Optional callback for cross-protocol sliver child layout.
     ///
     /// `None` when no sliver children are present in this subtree walk.
@@ -1041,6 +1091,7 @@ impl<'ctx> ErasedBoxLayoutCtx<'ctx> {
         children: &'ctx mut Vec<ErasedChildState>,
         child_ids: &'ctx [flui_foundation::RenderId],
         layout_child_callback: LayoutChildCallback<'ctx>,
+        actual_baseline_callback: ActualBaselineChildCallback<'ctx>,
         sliver_layout_child_callback: Option<SliverLayoutChildCallback<'ctx>>,
     ) -> Self {
         Self {
@@ -1049,6 +1100,7 @@ impl<'ctx> ErasedBoxLayoutCtx<'ctx> {
             children,
             child_ids,
             layout_child_callback,
+            actual_baseline_callback,
             sliver_layout_child_callback,
         }
     }
@@ -1077,6 +1129,15 @@ impl BoxLayoutCtxErased for ErasedBoxLayoutCtx<'_> {
             slot.size = size;
         }
         size
+    }
+
+    fn child_distance_to_actual_baseline(
+        &self,
+        index: usize,
+        baseline: crate::traits::TextBaseline,
+    ) -> Option<f32> {
+        let &child_id = self.child_ids.get(index)?;
+        (self.actual_baseline_callback)(child_id, baseline)
     }
 
     fn layout_sliver_child(

--- a/crates/flui-rendering/src/traits/render_box.rs
+++ b/crates/flui-rendering/src/traits/render_box.rs
@@ -555,6 +555,10 @@ where
         T::compute_dry_baseline(self, constraints, baseline, &mut ctx)
     }
 
+    fn actual_baseline_raw(&self, baseline: crate::traits::TextBaseline) -> Option<f32> {
+        T::compute_distance_to_actual_baseline(self, baseline)
+    }
+
     fn geometry(&self) -> &crate::protocol::ProtocolGeometry<BoxProtocol> {
         self.size()
     }

--- a/crates/flui-rendering/src/traits/render_object.rs
+++ b/crates/flui-rendering/src/traits/render_object.rs
@@ -321,6 +321,16 @@ pub trait RenderObject<P: Protocol>:
         None
     }
 
+    /// Distance from the top of this box to its first baseline of `baseline`
+    /// kind, after layout. Used by containers (`RenderBaseline`, flex
+    /// baseline alignment) during `perform_layout`.
+    ///
+    /// Default: `None` (no baseline). Box objects override via
+    /// [`RenderBox::compute_distance_to_actual_baseline`].
+    fn actual_baseline_raw(&self, _baseline: crate::traits::TextBaseline) -> Option<f32> {
+        None
+    }
+
     // ========================================================================
     // Optimization Boundaries
     // ========================================================================

--- a/crates/flui-rendering/src/traits/render_object.rs
+++ b/crates/flui-rendering/src/traits/render_object.rs
@@ -326,7 +326,7 @@ pub trait RenderObject<P: Protocol>:
     /// baseline alignment) during `perform_layout`.
     ///
     /// Default: `None` (no baseline). Box objects override via
-    /// [`RenderBox::compute_distance_to_actual_baseline`].
+    /// [`RenderBox::compute_distance_to_actual_baseline`](crate::traits::RenderBox::compute_distance_to_actual_baseline).
     fn actual_baseline_raw(&self, _baseline: crate::traits::TextBaseline) -> Option<f32> {
         None
     }

--- a/crates/flui-rendering/src/traits/render_sliver.rs
+++ b/crates/flui-rendering/src/traits/render_sliver.rs
@@ -110,10 +110,11 @@ pub trait RenderSliver: flui_foundation::Diagnosticable + Send + Sync + 'static 
         0.0
     }
 
-    /// Computes the portion of this sliver that is visible in the viewport.
+    /// Computes how much of the `[from, to]` range lies inside the viewport
+    /// paint window `[scroll_offset, scroll_offset + remaining_paint_extent]`.
     ///
-    /// Given a `from` and `to` range in the sliver's coordinate space,
-    /// this returns the offset at which the visible portion begins.
+    /// Returns the **extent** (length) of the visible intersection, not a
+    /// coordinate offset — matching Flutter's `calculatePaintOffset` naming.
     ///
     /// # Arguments
     ///
@@ -753,6 +754,30 @@ mod tests {
             10.0,
             "Flutter cache window is [scroll_offset + cache_origin, \
             scroll_offset + remaining_cache_extent]",
+        );
+    }
+
+    /// Regression: audit scroll=1000 / origin=-250 / remaining=1100 → window
+    /// [750, 2100], not the pre-fix [cache_origin, cache_origin+remaining].
+    #[test]
+    fn calculate_cache_offset_non_zero_scroll_uses_flutter_window() {
+        let sliver = FixedHeightSliver::new(200.0);
+        let constraints = vertical_cache_constraints(1000.0, 1100.0, -250.0);
+
+        assert_eq!(
+            sliver.calculate_cache_offset(&constraints, 700.0, 800.0),
+            50.0,
+            "intersection of [700,800] with [750,2100]",
+        );
+        assert_eq!(
+            sliver.calculate_cache_offset(&constraints, 750.0, 2100.0),
+            1100.0,
+            "full window clamped to remaining_cache_extent",
+        );
+        assert_eq!(
+            sliver.calculate_cache_offset(&constraints, 0.0, 500.0),
+            0.0,
+            "range entirely before cache window",
         );
     }
 

--- a/crates/flui-rendering/tests/render_object_harness.rs
+++ b/crates/flui-rendering/tests/render_object_harness.rs
@@ -13,6 +13,7 @@
 //! | `RenderPadding` | `harness_padding_*` | yes | — | — | yes | queries |
 //! | `RenderCenter` | `harness_center_*` | yes | — | — | yes | — |
 //! | `RenderAspectRatio` | `harness_aspect_ratio_*` | yes | — | — | yes | — |
+//! | `RenderBaseline` | `harness_baseline_*` | yes | — | — | yes | queries |
 //! | `RenderConstrainedBox` | `harness_constrained_box_*` | yes | — | — | yes | — |
 //! | `RenderLimitedBox` | `harness_limited_box_*` | yes | — | — | yes | — |
 //! | `RenderOffstage` | `harness_offstage_*` | yes | yes | — | yes | — |
@@ -55,6 +56,7 @@ use flui_rendering::{
         BoxQueryRun, Probe, RenderTester, TreeNode, assert_descendant_properties,
         assert_has_committed_geometry, assert_has_committed_size, box_node, sliver_node,
     },
+    traits::TextBaseline,
 };
 use flui_types::{
     Alignment, Offset, Point, Rect, Size,
@@ -74,6 +76,7 @@ const RENDER_OBJECT_TYPES: &[&str] = &[
     "RenderPadding",
     "RenderCenter",
     "RenderAspectRatio",
+    "RenderBaseline",
     "RenderConstrainedBox",
     "RenderLimitedBox",
     "RenderOffstage",
@@ -338,6 +341,61 @@ fn harness_center_with_factors_shrinks_available_space() {
     assert!(
         run.descendant_property("RenderCenter", "height_factor")
             .is_some()
+    );
+}
+
+#[test]
+fn harness_baseline_positions_text_at_offset() {
+    let mut run = RenderTester::mount(
+        box_node(RenderBaseline::new(TextBaseline::Alphabetic, px(0.0))).child(
+            box_node(RenderParagraph::new(
+                TextSpan::new("Ag"),
+                TextDirection::Ltr,
+            ))
+            .label("text"),
+        ),
+    )
+    .with_size(Size::new(px(200.0), px(100.0)))
+    .run_layout();
+
+    let tree = run.diagnostics();
+    assert_has_committed_size(
+        tree.find_descendant("RenderBaseline")
+            .expect("RenderBaseline"),
+    );
+    assert_descendant_properties(&tree, "RenderBaseline", &["baseline"]);
+    let constraints = BoxConstraints::loose(Size::new(px(200.0), px(100.0)));
+    let baseline = run
+        .dry_baseline(run.root(), constraints, TextBaseline::Alphabetic)
+        .expect("paragraph reports a dry baseline");
+    assert_eq!(baseline, 0.0);
+}
+
+#[test]
+fn harness_flex_row_baseline_aligns_text_and_box() {
+    let run = RenderTester::mount(
+        box_node(
+            RenderFlex::row()
+                .with_cross_axis_alignment(CrossAxisAlignment::Baseline)
+                .with_text_baseline(TextBaseline::Alphabetic),
+        )
+        .child(
+            box_node(RenderParagraph::new(
+                TextSpan::new("Ag"),
+                TextDirection::Ltr,
+            ))
+            .label("text"),
+        )
+        .child(box_node(RenderColoredBox::red(20.0, 40.0)).label("box")),
+    )
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    let text_y = run.offset(run.id("text")).dy.get();
+    let box_y = run.offset(run.id("box")).dy.get();
+    assert!(
+        (text_y - box_y).abs() < 0.5,
+        "baseline row should align text and box on the same cross offset (text={text_y}, box={box_y})",
     );
 }
 


### PR DESCRIPTION
## Summary

- Add RenderBaseline render object with harness coverage for alphabetic baseline positioning.
- Wire **actual baseline** queries through box layout context (ActualBaselineChildCallback) so parents read post-layout baseline distances from laid-out children.
- Extend RenderFlex with CrossAxisAlignment::Baseline, 	ext_baseline, and row positioning via child_distance_to_actual_baseline.
- Add RenderObject::actual_baseline_raw() + RenderBox blanket impl delegating to compute_distance_to_actual_baseline.

Follows merged PR #208 (Wave 0 hygiene + dry baseline forwarding).

## Test plan

- [x] cargo test -p flui-rendering --test render_object_harness (76 tests, catalog guards pass)
- [x] cargo clippy -p flui-rendering --all-targets -- -D warnings
- [x] cargo fmt --package flui-rendering -- --check
- [ ] CI green on PR

## Wave 2 follow-ups (not in this PR)

- Canonical lui-types enums on RenderFlex (VerticalDirection, TextDirection)
- Actual baseline caching in layout cache
- Container default baseline helpers

Made with [Cursor](https://cursor.com)