### PR TITLE
fix(rendering): Wave 3.1 sliver direction matrix and padding semantics

### DIFF
--- a/crates/flui-rendering/src/constraints/direction.rs
+++ b/crates/flui-rendering/src/constraints/direction.rs
@@ -131,6 +131,44 @@ impl fmt::Display for GrowthDirection {
     }
 }
 
+/// Applies growth direction to the user scroll direction.
+///
+/// Mirrors Flutter's composition inside `RenderViewport.layoutChildSequence`:
+/// reverse growth flips the scroll direction; forward growth preserves it.
+#[inline]
+#[must_use]
+pub fn apply_growth_direction_to_scroll_direction(
+    scroll_direction: crate::view::ScrollDirection,
+    growth_direction: GrowthDirection,
+) -> crate::view::ScrollDirection {
+    use crate::view::ScrollDirection;
+
+    match growth_direction {
+        GrowthDirection::Forward => scroll_direction,
+        GrowthDirection::Reverse => match scroll_direction {
+            ScrollDirection::Idle => ScrollDirection::Idle,
+            ScrollDirection::Forward => ScrollDirection::Reverse,
+            ScrollDirection::Reverse => ScrollDirection::Forward,
+        },
+    }
+}
+
+/// Whether sliver content is laid out in the "right way up" reading direction.
+///
+/// Mirrors Flutter's `RenderSliverHelpers.rightWayUp`.
+#[inline]
+#[must_use]
+pub const fn right_way_up(
+    axis_direction: AxisDirection,
+    growth_direction: GrowthDirection,
+) -> bool {
+    let reversed = axis_direction.is_reversed();
+    match growth_direction {
+        GrowthDirection::Forward => !reversed,
+        GrowthDirection::Reverse => reversed,
+    }
+}
+
 // ============================================================================
 // TESTS
 // ============================================================================
@@ -176,27 +214,89 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_to_axis_direction() {
+    fn test_apply_to_axis_direction_all_pairs() {
         use flui_types::layout::AxisDirection::{
             BottomToTop, LeftToRight, RightToLeft, TopToBottom,
         };
 
+        let cases = [
+            (TopToBottom, GrowthDirection::Forward, TopToBottom),
+            (TopToBottom, GrowthDirection::Reverse, BottomToTop),
+            (BottomToTop, GrowthDirection::Forward, BottomToTop),
+            (BottomToTop, GrowthDirection::Reverse, TopToBottom),
+            (LeftToRight, GrowthDirection::Forward, LeftToRight),
+            (LeftToRight, GrowthDirection::Reverse, RightToLeft),
+            (RightToLeft, GrowthDirection::Forward, RightToLeft),
+            (RightToLeft, GrowthDirection::Reverse, LeftToRight),
+        ];
+
+        for (axis, growth, expected) in cases {
+            assert_eq!(
+                growth.apply_to_axis_direction(axis),
+                expected,
+                "axis={axis:?}, growth={growth:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_apply_growth_direction_to_scroll_direction() {
+        use crate::view::ScrollDirection;
+
         assert_eq!(
-            GrowthDirection::Forward.apply_to_axis_direction(TopToBottom),
-            TopToBottom
+            apply_growth_direction_to_scroll_direction(
+                ScrollDirection::Forward,
+                GrowthDirection::Forward
+            ),
+            ScrollDirection::Forward,
         );
         assert_eq!(
-            GrowthDirection::Reverse.apply_to_axis_direction(TopToBottom),
-            BottomToTop
+            apply_growth_direction_to_scroll_direction(
+                ScrollDirection::Forward,
+                GrowthDirection::Reverse
+            ),
+            ScrollDirection::Reverse,
         );
         assert_eq!(
-            GrowthDirection::Forward.apply_to_axis_direction(LeftToRight),
-            LeftToRight
+            apply_growth_direction_to_scroll_direction(
+                ScrollDirection::Reverse,
+                GrowthDirection::Reverse
+            ),
+            ScrollDirection::Forward,
         );
         assert_eq!(
-            GrowthDirection::Reverse.apply_to_axis_direction(LeftToRight),
-            RightToLeft
+            apply_growth_direction_to_scroll_direction(
+                ScrollDirection::Idle,
+                GrowthDirection::Reverse
+            ),
+            ScrollDirection::Idle,
         );
+    }
+
+    #[test]
+    fn test_right_way_up_all_pairs() {
+        use flui_types::layout::AxisDirection::{
+            BottomToTop, LeftToRight, RightToLeft, TopToBottom,
+        };
+
+        let cases = [
+            (TopToBottom, GrowthDirection::Forward, true),
+            (TopToBottom, GrowthDirection::Reverse, false),
+            (BottomToTop, GrowthDirection::Forward, false),
+            (BottomToTop, GrowthDirection::Reverse, true),
+            (LeftToRight, GrowthDirection::Forward, true),
+            (LeftToRight, GrowthDirection::Reverse, false),
+            (RightToLeft, GrowthDirection::Forward, false),
+            (RightToLeft, GrowthDirection::Reverse, true),
+        ];
+
+        for (axis, growth, expected) in cases {
+            assert_eq!(
+                right_way_up(axis, growth),
+                expected,
+                "axis={axis:?}, growth={growth:?}",
+            );
+        }
     }
 
     #[test]

--- a/crates/flui-rendering/src/constraints/mod.rs
+++ b/crates/flui-rendering/src/constraints/mod.rs
@@ -96,7 +96,7 @@ mod sliver_geometry;
 use std::fmt;
 
 pub use box_constraints::BoxConstraints;
-pub use direction::GrowthDirection;
+pub use direction::{GrowthDirection, apply_growth_direction_to_scroll_direction, right_way_up};
 #[cfg(feature = "scrolling")]
 pub use scroll_metrics::{FixedExtentMetrics, FixedScrollMetrics, ScrollMetrics};
 pub use sliver_constraints::SliverConstraints;

--- a/crates/flui-rendering/src/objects/sliver_fill_viewport.rs
+++ b/crates/flui-rendering/src/objects/sliver_fill_viewport.rs
@@ -188,7 +188,10 @@ fn child_paint_offset(
     child_main_extent: f32,
 ) -> Offset {
     let child_main_axis_position = layout_offset - constraints.scroll_offset;
-    let main_axis_delta = if right_way_up(constraints) {
+    let main_axis_delta = if crate::constraints::right_way_up(
+        constraints.axis_direction,
+        constraints.growth_direction,
+    ) {
         child_main_axis_position
     } else {
         geometry.paint_extent - child_main_extent - child_main_axis_position
@@ -197,14 +200,6 @@ fn child_paint_offset(
     match constraints.axis_direction.axis() {
         Axis::Horizontal => Offset::new(px(main_axis_delta), px(0.0)),
         Axis::Vertical => Offset::new(px(0.0), px(main_axis_delta)),
-    }
-}
-
-const fn right_way_up(constraints: &SliverConstraints) -> bool {
-    let reversed = constraints.axis_direction.is_reversed();
-    match constraints.growth_direction {
-        GrowthDirection::Forward => !reversed,
-        GrowthDirection::Reverse => reversed,
     }
 }
 

--- a/crates/flui-rendering/src/objects/sliver_fixed_extent_list.rs
+++ b/crates/flui-rendering/src/objects/sliver_fixed_extent_list.rs
@@ -167,7 +167,10 @@ fn child_paint_offset(
     child_main_extent: f32,
 ) -> Offset {
     let child_main_axis_position = layout_offset - constraints.scroll_offset;
-    let main_axis_delta = if right_way_up(constraints) {
+    let main_axis_delta = if crate::constraints::right_way_up(
+        constraints.axis_direction,
+        constraints.growth_direction,
+    ) {
         child_main_axis_position
     } else {
         geometry.paint_extent - child_main_extent - child_main_axis_position
@@ -176,14 +179,6 @@ fn child_paint_offset(
     match constraints.axis_direction.axis() {
         Axis::Horizontal => Offset::new(px(main_axis_delta), px(0.0)),
         Axis::Vertical => Offset::new(px(0.0), px(main_axis_delta)),
-    }
-}
-
-const fn right_way_up(constraints: &SliverConstraints) -> bool {
-    let reversed = constraints.axis_direction.is_reversed();
-    match constraints.growth_direction {
-        GrowthDirection::Forward => !reversed,
-        GrowthDirection::Reverse => reversed,
     }
 }
 

--- a/crates/flui-rendering/src/objects/sliver_padding.rs
+++ b/crates/flui-rendering/src/objects/sliver_padding.rs
@@ -391,13 +391,39 @@ impl RenderSliver for RenderSliverPadding {
         self.geometry = geometry;
     }
 
+    fn child_main_axis_position(
+        &self,
+        _child: &dyn crate::traits::RenderObject<crate::protocol::SliverProtocol>,
+    ) -> f32 {
+        let (before, _, _, _) = self.resolve(&self.constraints);
+        Self::paint_offset(&self.constraints, 0.0, before)
+    }
+
+    fn child_cross_axis_position(
+        &self,
+        _child: &dyn crate::traits::RenderObject<crate::protocol::SliverProtocol>,
+    ) -> f32 {
+        match self.constraints.axis() {
+            Axis::Vertical => self.padding.left.get(),
+            Axis::Horizontal => self.padding.top.get(),
+        }
+    }
+
+    fn child_scroll_offset(
+        &self,
+        _child: &dyn crate::traits::RenderObject<crate::protocol::SliverProtocol>,
+    ) -> Option<f32> {
+        let (before, _, _, _) = self.resolve(&self.constraints);
+        Some(before)
+    }
+
     fn hit_test(
         &self,
         ctx: &mut SliverHitTestContext<'_, Single, SliverPhysicalParentData>,
     ) -> bool {
-        // Padding contributes no hit area of its own; it only forwards
-        // hits into the child after the pipeline subtracts the committed
-        // child paint offset.
+        if self.geometry.hit_test_extent <= 0.0 {
+            return false;
+        }
         ctx.hit_test_child_at_layout_offset(0)
     }
 
@@ -830,6 +856,95 @@ mod tests {
         // paint_offset.y = cross_before (top = 7).
         assert_eq!(paint_offset.dx, px(10.0));
         assert_eq!(paint_offset.dy, px(7.0));
+    }
+
+    #[test]
+    fn padded_geometry_with_partially_scrolled_leading_padding() {
+        let p = RenderSliverPadding::new(EdgeInsets {
+            top: px(10.0),
+            right: px(0.0),
+            bottom: px(20.0),
+            left: px(0.0),
+        });
+        let parent = vertical_constraints(5.0, 200.0, 200.0, 300.0);
+        let child = child_geom(100.0, 80.0, 80.0, 80.0);
+
+        let (geom, paint_offset) = p.padded_geometry(&parent, &child);
+
+        assert_eq!(geom.paint_extent, 105.0);
+        assert_eq!(geom.layout_extent, 105.0);
+        assert_eq!(paint_offset.dy, px(5.0));
+        assert_eq!(paint_offset.dx, px(0.0));
+    }
+
+    #[test]
+    fn padded_geometry_reverse_growth_child_paint_offset() {
+        let p = RenderSliverPadding::new(EdgeInsets {
+            top: px(10.0),
+            right: px(0.0),
+            bottom: px(20.0),
+            left: px(0.0),
+        });
+        let mut parent = vertical_constraints(0.0, 200.0, 200.0, 300.0);
+        parent.growth_direction = GrowthDirection::Reverse;
+        let child = child_geom(100.0, 80.0, 80.0, 80.0);
+
+        let (_geom, paint_offset) = p.padded_geometry(&parent, &child);
+
+        // Reverse vertical growth uses bottom padding as leading; child is
+        // positioned from the trailing end of the padded scroll extent.
+        assert_eq!(paint_offset.dy, px(10.0));
+    }
+
+    #[test]
+    fn empty_geometry_with_scrolled_leading_padding() {
+        let p = RenderSliverPadding::symmetric(0.0, 15.0);
+        let parent = vertical_constraints(5.0, 200.0, 200.0, 300.0);
+        let geom = p.empty_geometry(&parent);
+
+        assert_eq!(geom.scroll_extent, 30.0);
+        assert_eq!(geom.paint_extent, 25.0);
+        assert_eq!(geom.hit_test_extent, 25.0);
+    }
+
+    #[test]
+    fn child_constraints_negative_overlap_passthrough() {
+        let p = RenderSliverPadding::new(EdgeInsets {
+            top: px(10.0),
+            right: px(0.0),
+            bottom: px(0.0),
+            left: px(0.0),
+        });
+        let mut parent = vertical_constraints(0.0, 200.0, 200.0, 300.0);
+        parent.overlap = -12.0;
+
+        let cc = p.child_constraints(&parent);
+
+        assert_eq!(cc.overlap, -12.0);
+    }
+
+    #[test]
+    fn child_position_helpers_use_leading_padding() {
+        let p = RenderSliverPadding::new(EdgeInsets {
+            top: px(10.0),
+            right: px(0.0),
+            bottom: px(20.0),
+            left: px(3.0),
+        });
+        let constraints = vertical_constraints(5.0, 200.0, 200.0, 300.0);
+        let (before, _, _, _) = p.resolve(&constraints);
+
+        assert_eq!(
+            RenderSliverPadding::paint_offset(&constraints, 0.0, before),
+            5.0,
+            "child main-axis position matches visible leading padding",
+        );
+        assert_eq!(before, 10.0, "child scroll offset uses leading padding");
+        assert_eq!(
+            p.padding.left.get(),
+            3.0,
+            "cross-axis position uses left inset"
+        );
     }
 
     // ────────────────────────────────────────────────────────────────────────

--- a/crates/flui-rendering/src/objects/viewport.rs
+++ b/crates/flui-rendering/src/objects/viewport.rs
@@ -19,10 +19,7 @@ use crate::{
     context::{BoxHitTestContext, BoxLayoutContext, PaintCx},
     parent_data::BoxParentData,
     traits::{HotReloadCapability, PaintEffectsCapability, RenderBox, SemanticsCapability},
-    view::{
-        CacheExtentStyle, ScrollDirection, ScrollableViewportOffset, SliverPaintOrder,
-        ViewportOffset,
-    },
+    view::{CacheExtentStyle, ScrollableViewportOffset, SliverPaintOrder, ViewportOffset},
 };
 
 const MAX_LAYOUT_CYCLES_PER_CHILD: usize = 10;
@@ -236,10 +233,11 @@ impl<O: ViewportOffset + 'static> RenderViewport<O> {
         mut cache_origin: f32,
     ) -> f32 {
         let initial_layout_offset = layout_offset;
-        let adjusted_user_scroll_direction = apply_growth_direction_to_scroll_direction(
-            self.offset.user_scroll_direction(),
-            growth_direction,
-        );
+        let adjusted_user_scroll_direction =
+            crate::constraints::apply_growth_direction_to_scroll_direction(
+                self.offset.user_scroll_direction(),
+                growth_direction,
+            );
         let mut max_paint_offset = layout_offset + overlap;
         let mut preceding_scroll_extent = 0.0;
 
@@ -485,16 +483,6 @@ const fn default_cross_axis_direction(axis_direction: AxisDirection) -> AxisDire
     match axis_direction {
         TopToBottom | BottomToTop => LeftToRight,
         LeftToRight | RightToLeft => TopToBottom,
-    }
-}
-
-fn apply_growth_direction_to_scroll_direction(
-    scroll_direction: ScrollDirection,
-    growth_direction: GrowthDirection,
-) -> ScrollDirection {
-    match growth_direction {
-        GrowthDirection::Forward => scroll_direction,
-        GrowthDirection::Reverse => scroll_direction.flip(),
     }
 }
 

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -843,29 +843,27 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
             flui_types::layout::AxisDirection::TopToBottom
             | flui_types::layout::AxisDirection::BottomToTop => (offset.dy.get(), offset.dx.get()),
         };
-        let parent_physical_main =
-            if Self::effective_sliver_axis_direction(parent_constraints).is_reversed() {
-                parent_geometry.paint_extent - position.main_axis
-            } else {
-                position.main_axis
-            };
+        let parent_physical_main = if parent_constraints
+            .growth_direction
+            .apply_to_axis_direction(parent_constraints.axis_direction)
+            .is_reversed()
+        {
+            parent_geometry.paint_extent - position.main_axis
+        } else {
+            position.main_axis
+        };
         let child_physical_main = parent_physical_main - offset_main;
-        let child_main = if Self::effective_sliver_axis_direction(child_constraints).is_reversed() {
+        let child_main = if child_constraints
+            .growth_direction
+            .apply_to_axis_direction(child_constraints.axis_direction)
+            .is_reversed()
+        {
             child_geometry.paint_extent - child_physical_main
         } else {
             child_physical_main
         };
 
         MainAxisPosition::new(child_main, position.cross_axis - offset_cross)
-    }
-
-    fn effective_sliver_axis_direction(
-        constraints: &SliverConstraints,
-    ) -> flui_types::layout::AxisDirection {
-        match constraints.growth_direction {
-            crate::constraints::GrowthDirection::Forward => constraints.axis_direction,
-            crate::constraints::GrowthDirection::Reverse => constraints.axis_direction.opposite(),
-        }
     }
 
     fn box_hit_offset_from_sliver_position(
@@ -875,15 +873,10 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
         position: MainAxisPosition,
         offset: Offset,
     ) -> Offset {
-        let reversed = matches!(
+        let right_way_up = crate::constraints::right_way_up(
             constraints.axis_direction,
-            flui_types::layout::AxisDirection::RightToLeft
-                | flui_types::layout::AxisDirection::BottomToTop
+            constraints.growth_direction,
         );
-        let right_way_up = match constraints.growth_direction {
-            crate::constraints::GrowthDirection::Forward => !reversed,
-            crate::constraints::GrowthDirection::Reverse => reversed,
-        };
 
         let (paint_main, paint_cross, child_main_extent) = match constraints.axis_direction {
             flui_types::layout::AxisDirection::LeftToRight

--- a/crates/flui-rendering/tests/hit_test_pipeline.rs
+++ b/crates/flui-rendering/tests/hit_test_pipeline.rs
@@ -1018,6 +1018,31 @@ fn sliver_padding_hit_test_extent_uses_child_hit_extent_without_after_padding() 
 }
 
 #[test]
+fn sliver_padding_skips_hit_test_when_hit_test_extent_zero() {
+    let mut owner = PipelineOwner::new();
+    let mut constraints = sliver_hit_constraints();
+    constraints.scroll_offset = 500.0;
+    let host_id = owner.insert(Box::new(SliverHitHost {
+        constraints,
+        size: Size::ZERO,
+    }) as BoxedRenderObject);
+    owner
+        .render_tree_mut()
+        .insert_sliver_child(
+            host_id,
+            Box::new(RenderSliverPadding::symmetric(0.0, 10.0)) as BoxedSliverObject,
+        )
+        .expect("padding without child");
+
+    let owner = laid_out(owner, host_id);
+
+    assert!(
+        hits(&owner, 10.0, 10.0).is_empty(),
+        "padding with zero hit_test_extent must not forward hits to a missing child",
+    );
+}
+
+#[test]
 fn box_host_hit_tests_sliver_padding_child_at_paint_offset() {
     let mut owner = PipelineOwner::new();
     let host_id = owner.insert(Box::new(SliverHitHost {

--- a/crates/flui-rendering/tests/render_object_harness.rs
+++ b/crates/flui-rendering/tests/render_object_harness.rs
@@ -59,7 +59,7 @@ use flui_rendering::{
     traits::TextBaseline,
 };
 use flui_types::{
-    Alignment, Offset, Point, Rect, Size,
+    Alignment, EdgeInsets, Offset, Point, Rect, Size,
     geometry::px,
     layout::{AxisDirection, BoxFit, StackFit},
     painting::Clip,
@@ -115,6 +115,18 @@ fn loose(max: f32) -> BoxConstraints {
 
 fn viewport(sliver: TreeNode) -> TreeNode {
     viewport_multi([sliver])
+}
+
+fn viewport_with_scroll(offset: f32, sliver: TreeNode) -> TreeNode {
+    use flui_rendering::view::ScrollableViewportOffset;
+
+    box_node(RenderViewport::with_offset(
+        AxisDirection::TopToBottom,
+        AxisDirection::LeftToRight,
+        ScrollableViewportOffset::new(offset),
+    ))
+    .label("viewport")
+    .child(sliver)
 }
 
 fn viewport_multi(slivers: impl IntoIterator<Item = TreeNode>) -> TreeNode {
@@ -1148,6 +1160,40 @@ fn harness_sliver_padding_insets_geometry() {
     assert_has_committed_geometry(
         tree.find_descendant("RenderSliverPadding")
             .expect("padding"),
+    );
+}
+
+#[test]
+fn harness_sliver_padding_scrolled_viewport_applies_leading_padding() {
+    let run = RenderTester::mount(viewport_with_scroll(
+        5.0,
+        sliver_node(RenderSliverPadding::new(EdgeInsets {
+            top: px(10.0),
+            right: px(0.0),
+            bottom: px(20.0),
+            left: px(0.0),
+        }))
+        .label("pad")
+        .child(
+            sliver_node(RenderSliverToBoxAdapter::new())
+                .label("adapter")
+                .child(box_node(RenderSizedBox::fixed(px(300.0), px(80.0))).label("box")),
+        ),
+    ))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    let pad = run.sliver_geometry(run.id("pad"));
+    assert_eq!(pad.scroll_extent, 110.0);
+    assert_eq!(
+        pad.paint_extent, 100.0,
+        "paint extent is clamped to the 100px viewport main axis",
+    );
+    assert_eq!(run.offset(run.id("adapter")).dy, px(5.0));
+    assert_has_committed_geometry(
+        run.diagnostics()
+            .find_descendant("RenderSliverToBoxAdapter")
+            .expect("adapter"),
     );
 }
 

--- a/crates/flui-rendering/tests/sliver_direction_matrix.rs
+++ b/crates/flui-rendering/tests/sliver_direction_matrix.rs
@@ -1,0 +1,186 @@
+//! Pure-math regression matrix for sliver direction composition (Wave 3.1).
+//!
+//! Covers 4 axis directions × 2 growth directions × 3 concerns:
+//! effective axis, paint/sign sizing, and scroll-direction composition.
+
+use flui_rendering::{
+    constraints::{GrowthDirection, apply_growth_direction_to_scroll_direction, right_way_up},
+    traits::RenderSliver,
+    view::ScrollDirection,
+};
+use flui_types::{Size, geometry::px, layout::AxisDirection::*};
+
+struct DirectionProbe {
+    constraints: flui_rendering::constraints::SliverConstraints,
+}
+
+impl std::fmt::Debug for DirectionProbe {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DirectionProbe").finish_non_exhaustive()
+    }
+}
+
+impl DirectionProbe {
+    fn new(axis_direction: flui_types::layout::AxisDirection, growth: GrowthDirection) -> Self {
+        use flui_rendering::constraints::SliverConstraints;
+        use flui_rendering::view::ScrollDirection;
+
+        let cross_axis_direction = match axis_direction {
+            TopToBottom | BottomToTop => LeftToRight,
+            LeftToRight | RightToLeft => TopToBottom,
+        };
+
+        Self {
+            constraints: SliverConstraints::new(
+                axis_direction,
+                growth,
+                ScrollDirection::Idle,
+                0.0,
+                0.0,
+                0.0,
+                100.0,
+                40.0,
+                cross_axis_direction,
+                100.0,
+                100.0,
+                0.0,
+            ),
+        }
+    }
+}
+
+impl RenderSliver for DirectionProbe {
+    type Arity = flui_tree::Leaf;
+    type ParentData = flui_rendering::parent_data::SliverParentData;
+
+    fn perform_layout(
+        &mut self,
+        ctx: &mut flui_rendering::context::SliverLayoutContext<'_, Self::Arity, Self::ParentData>,
+    ) {
+        let _ = ctx;
+    }
+
+    fn geometry(&self) -> &flui_rendering::constraints::SliverGeometry {
+        static ZERO: flui_rendering::constraints::SliverGeometry =
+            flui_rendering::constraints::SliverGeometry::ZERO;
+        &ZERO
+    }
+
+    fn constraints(&self) -> &flui_rendering::constraints::SliverConstraints {
+        &self.constraints
+    }
+
+    fn set_geometry(&mut self, _: flui_rendering::constraints::SliverGeometry) {}
+
+    fn hit_test(
+        &self,
+        _: &mut flui_rendering::context::SliverHitTestContext<'_, Self::Arity, Self::ParentData>,
+    ) -> bool {
+        false
+    }
+}
+
+impl flui_foundation::Diagnosticable for DirectionProbe {}
+impl flui_rendering::traits::PaintEffectsCapability for DirectionProbe {}
+impl flui_rendering::traits::SemanticsCapability for DirectionProbe {}
+impl flui_rendering::traits::HotReloadCapability for DirectionProbe {}
+
+#[test]
+fn sliver_direction_matrix_eight_by_three() {
+    let cases = [
+        (
+            TopToBottom,
+            GrowthDirection::Forward,
+            TopToBottom,
+            Size::new(px(40.0), px(25.0)),
+            true,
+        ),
+        (
+            TopToBottom,
+            GrowthDirection::Reverse,
+            BottomToTop,
+            Size::new(px(40.0), px(-25.0)),
+            false,
+        ),
+        (
+            BottomToTop,
+            GrowthDirection::Forward,
+            BottomToTop,
+            Size::new(px(40.0), px(-25.0)),
+            false,
+        ),
+        (
+            BottomToTop,
+            GrowthDirection::Reverse,
+            TopToBottom,
+            Size::new(px(40.0), px(25.0)),
+            true,
+        ),
+        (
+            LeftToRight,
+            GrowthDirection::Forward,
+            LeftToRight,
+            Size::new(px(25.0), px(40.0)),
+            true,
+        ),
+        (
+            LeftToRight,
+            GrowthDirection::Reverse,
+            RightToLeft,
+            Size::new(px(-25.0), px(40.0)),
+            false,
+        ),
+        (
+            RightToLeft,
+            GrowthDirection::Forward,
+            RightToLeft,
+            Size::new(px(-25.0), px(40.0)),
+            false,
+        ),
+        (
+            RightToLeft,
+            GrowthDirection::Reverse,
+            LeftToRight,
+            Size::new(px(25.0), px(40.0)),
+            true,
+        ),
+    ];
+
+    for (axis, growth, expected_axis, expected_size, expected_right_way_up) in cases {
+        let probe = DirectionProbe::new(axis, growth);
+
+        assert_eq!(
+            growth.apply_to_axis_direction(axis),
+            expected_axis,
+            "effective axis: axis={axis:?}, growth={growth:?}",
+        );
+        assert_eq!(
+            probe.get_absolute_size_relative_to_origin(25.0),
+            expected_size,
+            "absolute size: axis={axis:?}, growth={growth:?}",
+        );
+        assert_eq!(
+            right_way_up(axis, growth),
+            expected_right_way_up,
+            "right_way_up: axis={axis:?}, growth={growth:?}",
+        );
+        assert_eq!(
+            apply_growth_direction_to_scroll_direction(ScrollDirection::Forward, growth),
+            if growth.is_reverse() {
+                ScrollDirection::Reverse
+            } else {
+                ScrollDirection::Forward
+            },
+            "scroll direction from Forward user scroll: axis={axis:?}, growth={growth:?}",
+        );
+        assert_eq!(
+            apply_growth_direction_to_scroll_direction(ScrollDirection::Reverse, growth),
+            if growth.is_reverse() {
+                ScrollDirection::Forward
+            } else {
+                ScrollDirection::Reverse
+            },
+            "scroll direction from Reverse user scroll: axis={axis:?}, growth={growth:?}",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Centralize sliver direction composition in constraints/direction.rs: pply_growth_direction_to_scroll_direction, ight_way_up, and dedupe call sites in viewport, owner, and sliver list objects.
- Add 	ests/sliver_direction_matrix.rs — 8 axis×growth cases × effective axis, paint sign, scroll-direction, and ight_way_up.
- Harden RenderSliverPadding: scrolled/reverse/empty/overlap unit tests, child-position trait overrides, hit-test gate on hit_test_extent > 0.
- Integration: harness_sliver_padding_scrolled_viewport_applies_leading_padding (viewport scroll → padding → adapter → box).

## Test plan

- [x] cargo test -p flui-rendering --test sliver_direction_matrix
- [x] cargo test -p flui-rendering (full suite)
- [x] cargo clippy -p flui-rendering --all-targets -- -D warnings
- [x] cargo doc -p flui-rendering --no-deps
- [ ] CI green on PR

## Wave 3.2 follow-ups

- Viewport reverse-growth layout matrix (8 cases)
- Full hit coordinate matrix for reverse × BTT/LTR/RTL
- RenderSliverHelpers (hitTestBoxChild, sBoxConstraints)
- Viewport correction loop / pplyContentDimensions

Made with [Cursor](https://cursor.com)