### PR TITLE
feat(engine): device-loss recovery + wgpu-29 audit improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,6 +1175,7 @@ name = "flui-engine"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "criterion",
  "flui-assets",
  "flui-foundation",
  "flui-layer",
@@ -1187,6 +1188,7 @@ dependencies = [
  "parking_lot",
  "pollster",
  "raw-window-handle",
+ "smallvec",
  "thiserror 2.0.18",
  "tracing",
  "wgpu",

--- a/crates/flui-app/src/app/binding.rs
+++ b/crates/flui-app/src/app/binding.rs
@@ -534,9 +534,20 @@ impl AppBinding {
                     self.frames_dropped.fetch_add(1, Ordering::Relaxed);
                     tracing::debug!("Surface lost, will retry next frame");
                 }
+                Err(EngineError::DeviceLost) => {
+                    // GPU device lost (TDR / driver crash / GPU switch). Recovery
+                    // requires rebuilding the entire GPU context asynchronously; it
+                    // is handled by the platform runner after `render_frame` returns.
+                    // `render_frame` itself has no async context and no raw window
+                    // handle, so it must not attempt recovery here.
+                    self.frames_dropped.fetch_add(1, Ordering::Relaxed);
+                    tracing::warn!(
+                        "GPU device lost — recovery will be attempted by the platform runner"
+                    );
+                }
                 Err(e) => {
                     self.frames_dropped.fetch_add(1, Ordering::Relaxed);
-                    tracing::error!("Render error: {:?}", e);
+                    tracing::error!(error = ?e, "Render error (non-recoverable this frame)");
                 }
             }
         }

--- a/crates/flui-app/src/app/direct.rs
+++ b/crates/flui-app/src/app/direct.rs
@@ -148,7 +148,19 @@ pub fn run_direct(
             if e.is_recoverable() {
                 tracing::warn!("Recoverable render error (will retry): {}", e);
             } else {
-                tracing::error!("Fatal render error: {}", e);
+                tracing::error!(error = ?e, "Fatal render error");
+            }
+        }
+
+        // GPU device-loss recovery: same logic as runner.rs frame callbacks.
+        if r.is_device_lost() {
+            match pollster::block_on(r.recover()) {
+                Ok(()) => {
+                    tracing::warn!("GPU device lost — recovered successfully");
+                }
+                Err(e) => {
+                    tracing::error!(error = ?e, "GPU device recovery failed; will retry next frame");
+                }
             }
         }
     }));

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -259,7 +259,12 @@ where
             match pollster::block_on(r.recover()) {
                 Ok(()) => {
                     tracing::warn!("GPU device lost — recovered successfully");
-                    AppBinding::instance().request_redraw();
+                    // `wake_frame` (not `request_redraw`) so an idle winit loop
+                    // actually queues a `RedrawRequested`: device loss is
+                    // detected on a quiescent loop, where only flipping the
+                    // `needs_redraw` flag would leave the recovered renderer
+                    // idle until the next external input/resize.
+                    AppBinding::instance().wake_frame();
                 }
                 Err(e) => {
                     // Driver may still be resetting. Log and let the next frame
@@ -529,7 +534,12 @@ where
             match pollster::block_on(r.recover()) {
                 Ok(()) => {
                     tracing::warn!("GPU device lost — recovered successfully");
-                    AppBinding::instance().request_redraw();
+                    // `wake_frame` (not `request_redraw`) so an idle winit loop
+                    // actually queues a `RedrawRequested`: device loss is
+                    // detected on a quiescent loop, where only flipping the
+                    // `needs_redraw` flag would leave the recovered renderer
+                    // idle until the next external input/resize.
+                    AppBinding::instance().wake_frame();
                 }
                 Err(e) => {
                     tracing::error!(error = ?e, "GPU device recovery failed; will retry next frame");
@@ -747,7 +757,10 @@ where
                 match result {
                     Ok(()) => {
                         tracing::warn!("GPU device lost — recovered successfully");
-                        AppBinding::instance().request_redraw();
+                        // `wake_frame` so the idle rAF loop is pumped — see the
+                        // native paths; flipping `needs_redraw` alone would leave
+                        // the recovered renderer idle until the next input event.
+                        AppBinding::instance().wake_frame();
                     }
                     Err(e) => {
                         tracing::error!(error = ?e, "GPU device recovery failed; will retry next frame");

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -249,6 +249,26 @@ where
         // Render frame via AppBinding
         let mut r = renderer_frame.lock();
         binding.render_frame(&mut r);
+
+        // GPU device-loss recovery: if the device was lost during this frame
+        // (detected by the wgpu callback that fired between render_frame calls),
+        // attempt a synchronous rebuild on the runner thread. `pollster` is
+        // already a dep and safe to use here — the desktop runner owns this
+        // synchronous callback, not an async executor.
+        if r.is_device_lost() {
+            match pollster::block_on(r.recover()) {
+                Ok(()) => {
+                    tracing::warn!("GPU device lost — recovered successfully");
+                    AppBinding::instance().request_redraw();
+                }
+                Err(e) => {
+                    // Driver may still be resetting. Log and let the next frame
+                    // retry; the device-lost flag remains set so recover() will
+                    // be tried again.
+                    tracing::error!(error = ?e, "GPU device recovery failed; will retry next frame");
+                }
+            }
+        }
     }));
 
     // 7. Register resize callback -> renderer.resize()
@@ -503,6 +523,19 @@ where
 
         let mut r = renderer_frame.lock();
         binding.render_frame(&mut r);
+
+        // GPU device-loss recovery (same logic as the desktop path).
+        if r.is_device_lost() {
+            match pollster::block_on(r.recover()) {
+                Ok(()) => {
+                    tracing::warn!("GPU device lost — recovered successfully");
+                    AppBinding::instance().request_redraw();
+                }
+                Err(e) => {
+                    tracing::error!(error = ?e, "GPU device recovery failed; will retry next frame");
+                }
+            }
+        }
     }));
 
     // 7. Register resize callback -> renderer.resize()
@@ -578,6 +611,8 @@ fn run_web<V>(root: V, config: AppConfig)
 where
     V: View + StatelessView + Clone + Send + Sync + 'static,
 {
+    use std::sync::Arc;
+
     use flui_engine::wgpu::Renderer;
     use flui_foundation::HasInstance;
     use flui_platform::{
@@ -585,6 +620,7 @@ where
         traits::{DispatchEventResult, LifecycleEvent, PlatformInput},
     };
     use flui_scheduler::Scheduler;
+    use parking_lot::Mutex;
 
     use crate::embedder::PlatformWindowHandle;
 
@@ -598,26 +634,37 @@ where
         .open_window(options)
         .expect("Failed to create canvas window");
 
-    // 2. Create GPU renderer via wasm-bindgen-futures (async on web)
+    // 2. Shared renderer slot — starts as None, filled async once the WebGPU
+    //    adapter is available. `Option` lets the frame callback skip frames that
+    //    arrive before the renderer is ready.
+    let renderer: Arc<Mutex<Option<Renderer>>> = Arc::new(Mutex::new(None));
+
     let phys_size = window.physical_size();
+    let renderer_init = Arc::clone(&renderer);
     let renderer_window = window.as_ref() as *const dyn flui_platform::PlatformWindow;
 
-    // SAFETY: On wasm32, everything is single-threaded, the pointer remains valid
-    // within the spawn_local closure. We must use spawn_local because wgpu surface
-    // creation is async on web (WebGPU adapter request).
+    // SAFETY: On wasm32, the runtime is single-threaded and cooperative.
+    // The raw pointer to the window is valid for the duration of
+    // `spawn_local` because `window` is alive in the enclosing scope, which
+    // is not dropped until `platform.run()` ends (after `spawn_local`
+    // completes). The pointer is cast back to a shared reference only inside
+    // the `async move` block, and no other task can alias or mutate the
+    // window concurrently on the single-threaded wasm executor.
+    #[allow(unsafe_code)]
     wasm_bindgen_futures::spawn_local(async move {
+        // SAFETY: See the block-level SAFETY comment above.
         let window_ref = unsafe { &*renderer_window };
         let handle = PlatformWindowHandle(window_ref);
-        let renderer = Renderer::new(&handle).await;
-        let mut renderer = match renderer {
+        let mut r = match Renderer::new(&handle).await {
             Ok(r) => r,
             Err(e) => {
                 tracing::error!("GPU init failed: {:?}", e);
                 return;
             }
         };
-        renderer.resize(phys_size.width.0 as u32, phys_size.height.0 as u32);
+        r.resize(phys_size.width.0 as u32, phys_size.height.0 as u32);
         tracing::info!("WebGPU renderer initialized");
+        *renderer_init.lock() = Some(r);
     });
 
     // 3. Mount root widget at the LOGICAL size; the paint root's DPR
@@ -647,6 +694,7 @@ where
     }));
 
     // 5. Register frame callback
+    let renderer_frame = Arc::clone(&renderer);
     window.on_request_frame(Box::new(move || {
         let binding = AppBinding::instance();
 
@@ -664,7 +712,49 @@ where
         let _frame_id = scheduler.handle_begin_frame(now);
         scheduler.handle_draw_frame();
 
-        // Note: renderer is initialized async, frames without a renderer are no-ops
+        // Renderer may not be ready yet (async init in flight). Skip this frame;
+        // the spawn_local will call request_redraw once the renderer is ready.
+        let mut slot = renderer_frame.lock();
+        let Some(r) = slot.as_mut() else {
+            return;
+        };
+
+        binding.render_frame(r);
+
+        // GPU device-loss recovery on wasm. `block_on` is unavailable, but
+        // wasm32 is single-threaded and `spawn_local` is the correct async
+        // dispatch. We drop the `slot` guard before spawning so the future can
+        // re-acquire the lock without deadlocking.
+        if r.is_device_lost() {
+            drop(slot); // release the lock before spawning the async recovery
+            let renderer_recover = Arc::clone(&renderer_frame);
+            wasm_bindgen_futures::spawn_local(async move {
+                // Take the renderer OUT of the slot so the lock is NOT held
+                // across `.await`. wasm32 is single-threaded: holding the
+                // `parking_lot::Mutex` guard across `recover().await` (which
+                // suspends in `request_adapter`/`request_device`) would let the
+                // next `on_request_frame` block forever on `lock()` — a hard
+                // hang. While recovery is in flight the slot is `None`, so frame
+                // callbacks skip rendering instead of blocking. A racing second
+                // spawn finds `None` here and returns — no double recovery.
+                let Some(mut renderer) = renderer_recover.lock().take() else {
+                    return;
+                };
+                let result = renderer.recover().await;
+                // Restore the renderer regardless of outcome; a failed recover
+                // leaves the device lost and the next frame re-detects + retries.
+                *renderer_recover.lock() = Some(renderer);
+                match result {
+                    Ok(()) => {
+                        tracing::warn!("GPU device lost — recovered successfully");
+                        AppBinding::instance().request_redraw();
+                    }
+                    Err(e) => {
+                        tracing::error!(error = ?e, "GPU device recovery failed; will retry next frame");
+                    }
+                }
+            });
+        }
     }));
 
     // 6. Lifecycle callbacks

--- a/crates/flui-engine/Cargo.toml
+++ b/crates/flui-engine/Cargo.toml
@@ -33,7 +33,6 @@ lyon-debugger = ["lyon/debugger"]
 
 # === Test Features ===
 enable-wgpu-tests = []
-disabled-tests = []
 
 [dependencies]
 flui-types = { path = "../flui-types" }
@@ -57,6 +56,7 @@ glam = { version = "0.33", features = ["serde", "bytemuck"] }
 # === Utilities ===
 pollster = { workspace = true }
 parking_lot = { workspace = true }
+smallvec = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
@@ -93,6 +93,11 @@ wgpu = { workspace = true, default-features = false, features = [
 
 [dev-dependencies]
 pollster = { workspace = true }
+criterion = { workspace = true }
+
+[[bench]]
+name = "render_throughput"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/flui-engine/benches/render_throughput.rs
+++ b/crates/flui-engine/benches/render_throughput.rs
@@ -1,0 +1,225 @@
+// criterion_group!/criterion_main! generate public functions that have no docs;
+// missing_docs on a bench binary is noise (no external consumers of the items).
+#![allow(
+    missing_docs,
+    reason = "criterion macros generate undocumented public fns"
+)]
+//! End-to-end render-throughput benchmark for flui-engine.
+//!
+//! Measures the CPU-side cost of a representative frame through `WgpuPainter`:
+//!   - command encoding for ~50 rects
+//!   - a linear gradient with 4 colour stops
+//!   - a text label
+//!   - the full `painter.render()` call (GPU encode + submit)
+//!
+//! # GPU-availability guard
+//!
+//! Device creation is attempted once at startup. If no GPU is available
+//! (common in headless CI without a software rasteriser) the process prints
+//! a diagnostic and exits cleanly so the suite still "passes" in compile-only
+//! CI jobs (`cargo bench --no-run`). The bench runs only where a GPU exists.
+//!
+//! # Micro-benchmark scope note — DEFERRED
+//!
+//! The hottest CPU micro-functions touched by the Phase-1 perf work —
+//! `build_gradient_stops` and `RichTextCacheKey::new` — are `pub(crate)` /
+//! private and are not accessible from an external `benches/` crate. Widening
+//! their visibility solely to bench them would pollute the public API surface
+//! (api.md). They are therefore NOT benched here; this file reaches them
+//! indirectly via the public `WgpuPainter` draw API, which is the correct
+//! integration level for a baseline-regression bench. Micro-benches for those
+//! paths are a follow-up task.
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use flui_engine::WgpuPainter;
+use flui_painting::Paint;
+use flui_types::{Offset, geometry::px, painting::Shader, styling::Color};
+
+// ---------------------------------------------------------------------------
+// Platform backend selection (mirrors Renderer::select_backend)
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "windows")]
+const BACKENDS: wgpu::Backends = wgpu::Backends::DX12;
+#[cfg(target_os = "macos")]
+const BACKENDS: wgpu::Backends = wgpu::Backends::METAL;
+#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+const BACKENDS: wgpu::Backends = wgpu::Backends::VULKAN;
+
+// ---------------------------------------------------------------------------
+// GPU setup helper
+// ---------------------------------------------------------------------------
+
+/// Attempt to acquire a headless wgpu device and queue.
+///
+/// Returns `None` when no adapter is available (CI without GPU, etc.).
+fn try_create_gpu() -> Option<(Arc<wgpu::Device>, Arc<wgpu::Queue>)> {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: BACKENDS,
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
+        });
+
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter: false,
+            })
+            .await
+            .ok()?;
+
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("bench-device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::downlevel_defaults(),
+                memory_hints: wgpu::MemoryHints::Performance,
+                experimental_features: wgpu::ExperimentalFeatures::disabled(),
+                trace: wgpu::Trace::Off,
+            })
+            .await
+            .ok()?;
+
+        Some((Arc::new(device), Arc::new(queue)))
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Gradient stop colours
+//
+// `Color::rgb` is `const` so these can live in a static slice, avoiding
+// a heap allocation on every bench iteration. The gradient-stop SmallVec
+// in the painter is built from the `Vec` we pass to `simple_linear`, so the
+// allocation is once per `build_frame` call (not per criterion sample).
+// ---------------------------------------------------------------------------
+
+static GRADIENT_COLORS: &[Color] = &[
+    Color::rgb(255, 0, 0),
+    Color::rgb(255, 255, 0),
+    Color::rgb(0, 255, 0),
+    Color::rgb(0, 0, 255),
+];
+
+// ---------------------------------------------------------------------------
+// Frame builder
+// ---------------------------------------------------------------------------
+
+/// Issue a representative draw list into `painter`:
+///   - 50 solid-colour rects (exercises rect instance batching)
+///   - 1 linear gradient rect with 4 stops (exercises gradient-stop path)
+///   - 1 text call (exercises text cache key path)
+///
+/// All geometry fits inside an 800×600 viewport.
+fn build_frame(painter: &mut WgpuPainter) {
+    // 50 solid rects — 10 columns × 5 rows across the viewport.
+    // Colours vary per rect so the compiler cannot constant-fold the loop.
+    for i in 0_u32..50 {
+        let col = (i % 10) as f32;
+        let row = (i / 10) as f32;
+        let x = col * 80.0;
+        let y = row * 100.0;
+        let rect = flui_types::Rect::from_ltrb(px(x), px(y), px(x + 70.0), px(y + 90.0));
+        let hue = i as f32 / 50.0;
+        let color = Color::from_rgba_f32_array([hue, 0.5, 1.0 - hue, 1.0]);
+        let paint = Paint::fill(black_box(color));
+        painter.rect(black_box(rect), &paint);
+    }
+
+    // 1 linear gradient (4 colour stops — exercises SmallVec<GradientStop>)
+    let gradient_rect = flui_types::Rect::from_ltrb(px(0.0), px(500.0), px(800.0), px(600.0));
+    let gradient_paint = Paint::fill(Color::WHITE).with_shader(Shader::simple_linear(
+        Offset::new(px(0.0), px(500.0)),
+        Offset::new(px(800.0), px(600.0)),
+        GRADIENT_COLORS.to_vec(),
+    ));
+    painter.rect(black_box(gradient_rect), &gradient_paint);
+
+    // 1 text label (exercises text buffer + cache-key path)
+    let text_paint = Paint::fill(Color::WHITE);
+    painter.text(
+        black_box("Hello, flui bench!"),
+        flui_types::Point::new(px(10.0), px(480.0)),
+        24.0,
+        &text_paint,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark
+// ---------------------------------------------------------------------------
+
+fn render_throughput(c: &mut Criterion) {
+    let Some((device, queue)) = try_create_gpu() else {
+        println!("skipping render benches: no GPU available");
+        return;
+    };
+
+    // Rgba8UnormSrgb is universally supported for offscreen render targets.
+    let format = wgpu::TextureFormat::Rgba8UnormSrgb;
+    let (width, height) = (800_u32, 600_u32);
+
+    // Offscreen render target — created once, reused across all iterations.
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("bench-target"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+    // Build the painter once — shader compilation is a one-time cost that is
+    // NOT part of the benchmark; it runs before `bench_function` is called.
+    let mut painter = WgpuPainter::with_shared_device(
+        Arc::clone(&device),
+        Arc::clone(&queue),
+        format,
+        (width, height),
+    );
+
+    // Warm-up frame: ensures pipeline caches (path, text buffer, gradient-stop
+    // SmallVec) are in steady state before criterion starts measurement.
+    {
+        build_frame(&mut painter);
+        let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("bench-warmup"),
+        });
+        let _ = painter.render(&view, &mut enc);
+        queue.submit([enc.finish()]);
+        // wait_indefinitely() blocks until the most recent submission completes.
+        let _ = device.poll(wgpu::PollType::wait_indefinitely());
+    }
+
+    // Each iteration measures: fill draw-list → encode GPU commands → submit.
+    // `device.poll(wait_indefinitely())` ensures the GPU has consumed the
+    // commands so each measurement covers the full CPU-observable round-trip —
+    // which is what the Phase-1 allocation-reduction work optimised.
+    c.bench_function("painter_render_50rects_gradient_text", |b| {
+        b.iter(|| {
+            build_frame(&mut painter);
+            let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("bench-frame"),
+            });
+            let result = painter.render(&view, &mut enc);
+            queue.submit([enc.finish()]);
+            let _ = device.poll(wgpu::PollType::wait_indefinitely());
+            // black_box the result so the compiler cannot prove the render
+            // call is a no-op and eliminate it.
+            black_box(result)
+        });
+    });
+}
+
+criterion_group!(benches, render_throughput);
+criterion_main!(benches);

--- a/crates/flui-engine/src/commands.rs
+++ b/crates/flui-engine/src/commands.rs
@@ -369,7 +369,10 @@ where
     }
 }
 
-#[cfg(test)]
+// `DebugBackend` is only compiled under debug_assertions (it exists only for
+// testing and uses no GPU). The test must carry the same gate so it compiles
+// in release/bench profiles where `debug_assertions` is off.
+#[cfg(all(test, debug_assertions))]
 mod tests {
     //! Cycle 5 U10 regression: dispatching an `Arc<Paint>`-carrying
     //! `DrawCommand` reaches the backend identically to the pre-U10

--- a/crates/flui-engine/src/error.rs
+++ b/crates/flui-engine/src/error.rs
@@ -3,16 +3,6 @@
 //! This module provides backend-agnostic error types that can be used
 //! by any rendering backend (wgpu, skia, vello, software, etc.)
 //!
-//! # Naming (cycle 4 R-10)
-//!
-//! The canonical type is [`EngineError`]; `RenderError` is a deprecated
-//! alias kept for one cycle to ease the migration. Pre-cycle the type
-//! was named `RenderError`, which collided with
-//! `flui_rendering::RenderError` at every call site importing both
-//! crates. The engine-side error is about GPU / surface / pipeline /
-//! shader / wgpu — "engine" is the right namespace; "rendering" stays
-//! the pipeline-phase error in the sister crate.
-//!
 //! # Design Principles
 //!
 //! 1. **Backend-agnostic**: Core error variants don't depend on specific
@@ -289,28 +279,6 @@ impl EngineError {
 
 /// A Result type alias for engine operations.
 pub type EngineResult<T> = Result<T, EngineError>;
-
-// Cycle 4 R-10: deprecated aliases for one-cycle migration. The
-// pre-cycle names (`RenderError`, `RenderResult`) collided with
-// `flui_rendering::RenderError` / `RenderResult` at every call site
-// importing both crates. New code should use `EngineError` /
-// `EngineResult` directly.
-
-/// Deprecated alias for [`EngineError`] (renamed in cycle 4 R-10).
-#[deprecated(
-    since = "0.1.0",
-    note = "Renamed to `EngineError` to disambiguate from \
-            `flui_rendering::RenderError`. See cycle 4 audit R-10."
-)]
-pub type RenderError = EngineError;
-
-/// Deprecated alias for [`EngineResult`] (renamed in cycle 4 R-10).
-#[deprecated(
-    since = "0.1.0",
-    note = "Renamed to `EngineResult` to disambiguate from \
-            `flui_rendering::RenderResult`. See cycle 4 audit R-10."
-)]
-pub type RenderResult<T> = EngineResult<T>;
 
 #[cfg(test)]
 mod tests {

--- a/crates/flui-engine/src/lib.rs
+++ b/crates/flui-engine/src/lib.rs
@@ -64,6 +64,16 @@
 //! - `wgpu` (default) - wgpu GPU backend
 //! - Future: `skia`, `vello`, `software`
 
+// Compile-time guard: the `fragile-send-sync-non-atomic-wasm` wgpu feature
+// marks !Send types as Send+Sync, which is only sound when the wasm target has
+// no threads (no atomics target feature). Enabling atomics with this feature
+// is UB — catch it at compile time instead of silently producing data races.
+#[cfg(all(target_arch = "wasm32", target_feature = "atomics"))]
+compile_error!(
+    "fragile-send-sync-non-atomic-wasm is unsound with threads/atomics enabled \
+     — see flui-engine Cargo.toml [target.wasm32] note"
+);
+
 // ============================================================================
 // ABSTRACT LAYER (backend-agnostic)
 // ============================================================================
@@ -92,11 +102,6 @@ pub mod wgpu;
 // Abstract traits and errors
 pub use commands::{dispatch_command, dispatch_commands};
 pub use error::{EngineError, EngineResult};
-// Cycle 4 R-10: deprecated aliases re-exported for one-cycle
-// migration. Downstream consumers (flui-app) switch on their next
-// touch.
-#[allow(deprecated)]
-pub use error::{RenderError, RenderResult};
 // Re-export layer types from flui-layer
 pub use flui_layer::{
     CanvasLayer, Layer, LayerId, LayerTree, LinkRegistry, Scene, SceneBuilder, SceneCompositor,

--- a/crates/flui-engine/src/wgpu/atlas.rs
+++ b/crates/flui-engine/src/wgpu/atlas.rs
@@ -99,11 +99,6 @@ pub struct TextureAtlas {
     /// Atlas height
     height: u32,
 
-    /// Texture format (stored at construction; queried via the underlying
-    /// `wgpu::Texture` at runtime, not via this field).
-    #[allow(dead_code)]
-    format: TextureFormat,
-
     /// Current shelf Y position
     current_shelf_y: u32,
 
@@ -149,7 +144,6 @@ impl TextureAtlas {
             texture,
             width,
             height,
-            format,
             current_shelf_y: 0,
             current_shelf_height: 0,
             current_x: 0,

--- a/crates/flui-engine/src/wgpu/atlas.rs
+++ b/crates/flui-engine/src/wgpu/atlas.rs
@@ -201,6 +201,30 @@ impl TextureAtlas {
         }
     }
 
+    /// Reclaim the entire atlas: drop every entry and rewind the shelf cursor.
+    ///
+    /// The shelf packer is append-only — once `allocate` walks the cursor to the
+    /// bottom-right it can never reuse a freed slot, so a long-lived atlas
+    /// eventually fills with stale entries and `allocate` returns `None`
+    /// forever. `reset` is the freeing mechanism: it clears `entries` and
+    /// rewinds the cursor so the GPU texture (reused as-is) can be re-packed
+    /// from scratch.
+    ///
+    /// # Invalidates outstanding rects
+    ///
+    /// Every [`AtlasRect`] / `image_id` handed out by `allocate` before this
+    /// call is invalidated — the regions they point at will be overwritten by
+    /// future uploads. Callers that cache atlas UVs (e.g. `TextureCache`) MUST
+    /// drop those cached entries in the same step. Old pixels are not cleared;
+    /// they become garbage that the next `upload_image` overwrites.
+    pub fn reset(&mut self) {
+        self.entries.clear();
+        self.current_shelf_y = 0;
+        self.current_shelf_height = 0;
+        self.current_x = 0;
+        self.next_image_id = 1;
+    }
+
     /// Upload image data to the atlas
     ///
     /// # Arguments
@@ -362,5 +386,45 @@ mod tests {
     fn test_texture_atlas_exists() {
         // Compile-time check
         let _ = std::marker::PhantomData::<TextureAtlas>;
+    }
+
+    /// Headless GPU device for atlas allocation/reset tests.
+    fn test_device() -> Device {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .expect("a GPU adapter for atlas tests");
+        let (device, _queue) =
+            pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+                label: Some("Atlas Test Device"),
+                ..Default::default()
+            }))
+            .expect("a GPU device for atlas tests");
+        device
+    }
+
+    #[test]
+    fn reset_reclaims_a_full_atlas() {
+        let device = test_device();
+        // A 64x64 atlas fits exactly one 64x64 image, then is full.
+        let mut atlas = TextureAtlas::new(&device, 64, 64, TextureFormat::Rgba8UnormSrgb);
+
+        assert!(atlas.allocate(64, 64).is_some(), "first 64x64 must fit");
+        assert!(
+            atlas.allocate(1, 1).is_none(),
+            "atlas must report full — the shelf packer cannot reuse freed space"
+        );
+        assert_eq!(atlas.image_count(), 1);
+
+        atlas.reset();
+
+        assert_eq!(atlas.image_count(), 0, "reset drops all entries");
+        assert!(
+            atlas.allocate(64, 64).is_some(),
+            "reset must rewind the shelf cursor so the atlas is allocatable again"
+        );
     }
 }

--- a/crates/flui-engine/src/wgpu/backend.rs
+++ b/crates/flui-engine/src/wgpu/backend.rs
@@ -10,6 +10,7 @@ use flui_types::{
     styling::Color,
     typography::TextStyle,
 };
+use smallvec::SmallVec;
 
 use std::sync::Arc;
 
@@ -18,6 +19,39 @@ use crate::{
     commands::dispatch_command,
     traits::{CommandRenderer, LayerStateStack},
 };
+
+/// Builds a gradient stop array from a color slice and optional explicit stop
+/// positions, with no heap allocation for the common case of ≤ 8 stops.
+///
+/// When `stop_positions` is `None`, stops are spaced evenly across [0, 1].
+/// The return type derefs to `&[GradientStop]`, satisfying every painter call site.
+fn build_gradient_stops(
+    colors: &[Color],
+    stop_positions: Option<&Vec<f32>>,
+) -> SmallVec<[super::effects::GradientStop; 8]> {
+    use super::effects::GradientStop;
+    if let Some(positions) = stop_positions {
+        colors
+            .iter()
+            .zip(positions.iter())
+            .map(|(color, pos)| GradientStop::new(*color, *pos))
+            .collect()
+    } else {
+        let count = colors.len();
+        colors
+            .iter()
+            .enumerate()
+            .map(|(i, color)| {
+                let pos = if count > 1 {
+                    i as f32 / (count - 1) as f32
+                } else {
+                    0.0
+                };
+                GradientStop::new(*color, pos)
+            })
+            .collect()
+    }
+}
 
 /// wgpu backend implementation of CommandRenderer.
 ///
@@ -688,8 +722,6 @@ impl CommandRenderer for Backend<'_> {
         shader: &flui_painting::Shader,
         transform: &Matrix4,
     ) {
-        use super::effects::GradientStop;
-
         self.with_transform(transform, |painter| {
             match shader {
                 flui_painting::Shader::LinearGradient {
@@ -703,30 +735,7 @@ impl CommandRenderer for Backend<'_> {
                         return;
                     }
 
-                    // Convert colors and stops to GradientStop array
-                    let gradient_stops: Vec<GradientStop> = if let Some(stop_positions) = stops {
-                        colors
-                            .iter()
-                            .zip(stop_positions.iter())
-                            .map(|(color, pos)| GradientStop::new(*color, *pos))
-                            .collect()
-                    } else {
-                        // Default evenly spaced stops
-                        let count = colors.len();
-                        colors
-                            .iter()
-                            .enumerate()
-                            .map(|(i, color)| {
-                                let pos = if count > 1 {
-                                    i as f32 / (count - 1) as f32
-                                } else {
-                                    0.0
-                                };
-                                GradientStop::new(*color, pos)
-                            })
-                            .collect()
-                    };
-
+                    let gradient_stops = build_gradient_stops(colors, stops.as_ref());
                     painter.gradient_rect(
                         rect,
                         glam::Vec2::new(from.dx.0, from.dy.0),
@@ -746,30 +755,7 @@ impl CommandRenderer for Backend<'_> {
                         return;
                     }
 
-                    // Convert colors and stops to GradientStop array
-                    let gradient_stops: Vec<GradientStop> = if let Some(stop_positions) = stops {
-                        colors
-                            .iter()
-                            .zip(stop_positions.iter())
-                            .map(|(color, pos)| GradientStop::new(*color, *pos))
-                            .collect()
-                    } else {
-                        // Default evenly spaced stops
-                        let count = colors.len();
-                        colors
-                            .iter()
-                            .enumerate()
-                            .map(|(i, color)| {
-                                let pos = if count > 1 {
-                                    i as f32 / (count - 1) as f32
-                                } else {
-                                    0.0
-                                };
-                                GradientStop::new(*color, pos)
-                            })
-                            .collect()
-                    };
-
+                    let gradient_stops = build_gradient_stops(colors, stops.as_ref());
                     painter.radial_gradient_rect(
                         rect,
                         glam::Vec2::new(center.dx.0, center.dy.0),
@@ -790,29 +776,7 @@ impl CommandRenderer for Backend<'_> {
                         return;
                     }
 
-                    // Convert colors and stops to GradientStop array
-                    let gradient_stops: Vec<GradientStop> = if let Some(stop_positions) = stops {
-                        colors
-                            .iter()
-                            .zip(stop_positions.iter())
-                            .map(|(color, pos)| GradientStop::new(*color, *pos))
-                            .collect()
-                    } else {
-                        let count = colors.len();
-                        colors
-                            .iter()
-                            .enumerate()
-                            .map(|(i, color)| {
-                                let pos = if count > 1 {
-                                    i as f32 / (count - 1) as f32
-                                } else {
-                                    0.0
-                                };
-                                GradientStop::new(*color, pos)
-                            })
-                            .collect()
-                    };
-
+                    let gradient_stops = build_gradient_stops(colors, stops.as_ref());
                     painter.sweep_gradient_rect(
                         rect,
                         glam::Vec2::new(center.dx.0, center.dy.0),
@@ -837,8 +801,6 @@ impl CommandRenderer for Backend<'_> {
         shader: &flui_painting::Shader,
         transform: &Matrix4,
     ) {
-        use super::effects::GradientStop;
-
         self.with_transform(transform, |painter| {
             // Get average corner radius
             let corner_radius =
@@ -857,30 +819,7 @@ impl CommandRenderer for Backend<'_> {
                         return;
                     }
 
-                    // Convert colors and stops to GradientStop array
-                    let gradient_stops: Vec<GradientStop> = if let Some(stop_positions) = stops {
-                        colors
-                            .iter()
-                            .zip(stop_positions.iter())
-                            .map(|(color, pos)| GradientStop::new(*color, *pos))
-                            .collect()
-                    } else {
-                        // Default evenly spaced stops
-                        let count = colors.len();
-                        colors
-                            .iter()
-                            .enumerate()
-                            .map(|(i, color)| {
-                                let pos = if count > 1 {
-                                    i as f32 / (count - 1) as f32
-                                } else {
-                                    0.0
-                                };
-                                GradientStop::new(*color, pos)
-                            })
-                            .collect()
-                    };
-
+                    let gradient_stops = build_gradient_stops(colors, stops.as_ref());
                     painter.gradient_rect(
                         rrect.rect,
                         glam::Vec2::new(from.dx.0, from.dy.0),
@@ -900,30 +839,7 @@ impl CommandRenderer for Backend<'_> {
                         return;
                     }
 
-                    // Convert colors and stops to GradientStop array
-                    let gradient_stops: Vec<GradientStop> = if let Some(stop_positions) = stops {
-                        colors
-                            .iter()
-                            .zip(stop_positions.iter())
-                            .map(|(color, pos)| GradientStop::new(*color, *pos))
-                            .collect()
-                    } else {
-                        // Default evenly spaced stops
-                        let count = colors.len();
-                        colors
-                            .iter()
-                            .enumerate()
-                            .map(|(i, color)| {
-                                let pos = if count > 1 {
-                                    i as f32 / (count - 1) as f32
-                                } else {
-                                    0.0
-                                };
-                                GradientStop::new(*color, pos)
-                            })
-                            .collect()
-                    };
-
+                    let gradient_stops = build_gradient_stops(colors, stops.as_ref());
                     painter.radial_gradient_rect(
                         rrect.rect,
                         glam::Vec2::new(center.dx.0, center.dy.0),
@@ -944,28 +860,7 @@ impl CommandRenderer for Backend<'_> {
                         return;
                     }
 
-                    let gradient_stops: Vec<GradientStop> = if let Some(stop_positions) = stops {
-                        colors
-                            .iter()
-                            .zip(stop_positions.iter())
-                            .map(|(color, pos)| GradientStop::new(*color, *pos))
-                            .collect()
-                    } else {
-                        let count = colors.len();
-                        colors
-                            .iter()
-                            .enumerate()
-                            .map(|(i, color)| {
-                                let pos = if count > 1 {
-                                    i as f32 / (count - 1) as f32
-                                } else {
-                                    0.0
-                                };
-                                GradientStop::new(*color, pos)
-                            })
-                            .collect()
-                    };
-
+                    let gradient_stops = build_gradient_stops(colors, stops.as_ref());
                     painter.sweep_gradient_rect(
                         rrect.rect,
                         glam::Vec2::new(center.dx.0, center.dy.0),

--- a/crates/flui-engine/src/wgpu/buffer_pool.rs
+++ b/crates/flui-engine/src/wgpu/buffer_pool.rs
@@ -47,8 +47,6 @@ struct PooledBuffer {
     buffer: Buffer,
     size: usize,
     in_use: bool,
-    #[allow(dead_code)]
-    usage: BufferUsages,
 }
 
 /// GPU buffer pool for efficient buffer reuse
@@ -201,7 +199,6 @@ impl BufferPool {
             buffer,
             size,
             in_use: true,
-            usage,
         });
 
         // Safe: We just pushed, so pool[index] exists
@@ -233,8 +230,12 @@ impl BufferPool {
         index_contents: &[u8],
     ) -> (&Buffer, &Buffer) {
         // We must call get_buffer_internal twice with disjoint borrows.
-        // Since vertex_buffers and index_buffers are separate fields,
-        // we split the borrow manually.
+        // `vertex_buffers` and `index_buffers` are separate Vec fields, so
+        // lending &mut to each simultaneously is safe at the value level.
+        // The `allocations`/`reuses` counters are shared between the two calls
+        // via raw pointers; each `unsafe { &mut *ptr }` expression lives only
+        // for the duration of one call argument list, so no two `&mut` aliases
+        // to the same counter are simultaneously live.
         let allocations = &raw mut self.allocations;
         let reuses = &raw mut self.reuses;
 
@@ -245,14 +246,16 @@ impl BufferPool {
             vertex_contents,
             BufferUsages::VERTEX | BufferUsages::COPY_DST,
             &mut self.vertex_buffers,
-            // SAFETY: allocations/reuses are only used for statistics counting.
-            // The two calls never alias the same Vec, and the counters are
-            // simple increments with no observable side effects between calls.
+            // SAFETY: `allocations` is a valid, aligned, initialised `usize` owned by
+            // `self`. This `&mut` is the only live reference to it at this point —
+            // `reuses` is a separate field and the borrow ends before the next call.
             unsafe { &mut *allocations },
+            // SAFETY: `reuses` is a valid, aligned, initialised `usize` owned by
+            // `self`, distinct from `allocations`. This `&mut` ends at the call site.
             unsafe { &mut *reuses },
         );
 
-        // Convert to raw pointer to release the mutable borrow on vertex_buffers
+        // Convert to raw pointer to release the mutable borrow on vertex_buffers.
         let vertex_ptr = std::ptr::from_ref::<Buffer>(vertex_buf);
 
         let index_buf = Self::get_buffer_internal(
@@ -262,13 +265,18 @@ impl BufferPool {
             index_contents,
             BufferUsages::INDEX | BufferUsages::COPY_DST,
             &mut self.index_buffers,
+            // SAFETY: the previous call's `&mut *allocations` borrow has ended
+            // (it was a temporary for the function call above). This is the only
+            // live `&mut` to `allocations` at this point.
             unsafe { &mut *allocations },
+            // SAFETY: same reasoning as above for `reuses`.
             unsafe { &mut *reuses },
         );
 
-        // SAFETY: vertex_ptr points into self.vertex_buffers which is not
-        // modified by the index buffer call (separate Vec). The buffer
-        // reference is valid for the lifetime of &mut self.
+        // SAFETY: valid because the index-buffer call mutates only `index_buffers`;
+        // it never pushes to / reallocates `vertex_buffers`, so `vertex_ptr` stays
+        // in-bounds of a live allocation and its borrow tag is not invalidated by
+        // the disjoint `index_buffers`/counter borrows.
         let vertex_ref = unsafe { &*vertex_ptr };
 
         (vertex_ref, index_buf)

--- a/crates/flui-engine/src/wgpu/instancing.rs
+++ b/crates/flui-engine/src/wgpu/instancing.rs
@@ -642,9 +642,7 @@ impl<T> Default for InstanceBatch<T> {
     }
 }
 
-// NOTE: Tests temporarily disabled - need update for Pixels/DevicePixels
-// migration
-#[cfg(all(test, feature = "disabled-tests"))]
+#[cfg(test)]
 #[allow(
     clippy::float_cmp,
     reason = "tests assert exact expected values produced by exact arithmetic"
@@ -656,12 +654,15 @@ mod tests {
 
     #[test]
     fn test_rect_instance_size() {
-        // Verify struct is tightly packed for GPU
-        // 16 original floats + 8 clip_rrect floats = 24 floats = 96 bytes
-        assert_eq!(
-            std::mem::size_of::<RectInstance>(),
-            24 * 4 // 24 floats = 96 bytes
-        );
+        // RectInstance field layout (all #[repr(C)], tightly packed):
+        //   bounds:       [f32; 4]  = 16 bytes
+        //   color:        [f32; 4]  = 16 bytes
+        //   corner_radii: [f32; 4]  = 16 bytes
+        //   transform:    [f32; 4]  = 16 bytes
+        //   clip_rrect:   [f32; 8]  = 32 bytes
+        //   clip_kind:    [u32; 4]  = 16 bytes  ← added with squircle SDF
+        //   Total: 112 bytes
+        assert_eq!(std::mem::size_of::<RectInstance>(), 112);
     }
 
     #[test]
@@ -727,5 +728,110 @@ mod tests {
         assert_eq!(instance.color[1], 0.0); // G
         assert_eq!(instance.color[2], 0.0); // B
         assert_eq!(instance.color[3], 1.0); // A
+    }
+
+    #[test]
+    fn test_rect_bounds_mapping() {
+        // `rect` maps Rect fields to [left, top, width, height] — not ltrb.
+        let instance = RectInstance::rect(
+            Rect::from_ltrb(px(10.0), px(20.0), px(110.0), px(70.0)),
+            Color::RED,
+        );
+        assert_eq!(instance.bounds[0], 10.0); // x = left
+        assert_eq!(instance.bounds[1], 20.0); // y = top
+        assert_eq!(instance.bounds[2], 100.0); // width = right − left
+        assert_eq!(instance.bounds[3], 50.0); // height = bottom − top
+    }
+
+    #[test]
+    fn test_rect_default_clip_is_no_clip() {
+        // Plain rect: clip_rrect must be all-zeros and clip_kind must be 0
+        // (no SDF clip active). The fragment shader reads clip_kind[0] == 0
+        // as "skip clip test".
+        let instance = RectInstance::rect(
+            Rect::from_ltrb(px(0.0), px(0.0), px(50.0), px(50.0)),
+            Color::RED,
+        );
+        assert_eq!(instance.clip_rrect, [0.0; 8]);
+        assert_eq!(instance.clip_kind, [0u32; 4]);
+    }
+
+    #[test]
+    fn test_with_clip_rrect_sets_kind_one() {
+        // Non-zero clip_rrect must set clip_kind[0] = 1 (sdRoundedBox).
+        let clip: [f32; 8] = [5.0, 5.0, 90.0, 40.0, 4.0, 4.0, 4.0, 4.0];
+        let instance = RectInstance::rect(
+            Rect::from_ltrb(px(0.0), px(0.0), px(100.0), px(50.0)),
+            Color::RED,
+        )
+        .with_clip_rrect(clip);
+        assert_eq!(instance.clip_rrect, clip);
+        assert_eq!(instance.clip_kind[0], 1u32);
+        // Padding lanes must be zero.
+        assert_eq!(instance.clip_kind[1], 0u32);
+        assert_eq!(instance.clip_kind[2], 0u32);
+        assert_eq!(instance.clip_kind[3], 0u32);
+    }
+
+    #[test]
+    fn test_with_clip_rrect_all_zeros_keeps_no_clip() {
+        // Passing the all-zeros sentinel must leave clip_kind == 0.
+        let instance = RectInstance::rect(
+            Rect::from_ltrb(px(0.0), px(0.0), px(100.0), px(50.0)),
+            Color::RED,
+        )
+        .with_clip_rrect([0.0; 8]);
+        assert_eq!(instance.clip_kind, [0u32; 4]);
+    }
+
+    #[test]
+    fn test_with_clip_rsuperellipse_sets_kind_two() {
+        // Non-zero squircle clip must set clip_kind[0] = 2.
+        let se: [f32; 12] = [
+            0.0, 0.0, 100.0, 50.0, 8.0, 10.0, 8.0, 10.0, 8.0, 10.0, 8.0, 10.0,
+        ];
+        let instance = RectInstance::rect(
+            Rect::from_ltrb(px(0.0), px(0.0), px(100.0), px(50.0)),
+            Color::RED,
+        )
+        .with_clip_rsuperellipse(se);
+        assert_eq!(instance.clip_kind[0], 2u32);
+        // Averaged corner radii: avg(8,10) = 9.0 for each corner.
+        assert_eq!(instance.clip_rrect[4], 9.0);
+        assert_eq!(instance.clip_rrect[5], 9.0);
+        assert_eq!(instance.clip_rrect[6], 9.0);
+        assert_eq!(instance.clip_rrect[7], 9.0);
+    }
+
+    #[test]
+    fn test_gradient_instance_sizes() {
+        // LinearGradientInstance:
+        //   bounds[4]=16  gradient_start[2]=8  gradient_end[2]=8
+        //   corner_radii[4]=16  stop_count(u32)=4  stop_offset(u32)=4  padding[2u32]=8
+        //   Total: 64 bytes
+        assert_eq!(std::mem::size_of::<LinearGradientInstance>(), 64);
+
+        // RadialGradientInstance:
+        //   bounds[4]=16  center[2]=8  radius(f32)=4  padding1(f32)=4
+        //   corner_radii[4]=16  stop_count(u32)=4  stop_offset(u32)=4  padding2[2u32]=8
+        //   Total: 64 bytes
+        assert_eq!(std::mem::size_of::<RadialGradientInstance>(), 64);
+
+        // SweepGradientInstance:
+        //   bounds[4]=16  center[2]=8  angles[2]=8
+        //   corner_radii[4]=16  stop_count(u32)=4  stop_offset(u32)=4  padding[2u32]=8
+        //   Total: 64 bytes
+        assert_eq!(std::mem::size_of::<SweepGradientInstance>(), 64);
+    }
+
+    #[test]
+    fn test_circle_instance_field_values() {
+        use flui_types::{Point, geometry::Pixels};
+        let center = Point::new(flui_types::geometry::Pixels(50.0), Pixels(75.0));
+        let instance = CircleInstance::new(center, 20.0, Color::RED);
+        assert_eq!(instance.center_radius[0], 50.0); // x
+        assert_eq!(instance.center_radius[1], 75.0); // y
+        assert_eq!(instance.center_radius[2], 20.0); // radius
+        assert_eq!(instance.center_radius[3], 0.0); // padding
     }
 }

--- a/crates/flui-engine/src/wgpu/mod.rs
+++ b/crates/flui-engine/src/wgpu/mod.rs
@@ -97,11 +97,10 @@ pub mod occlusion;
 mod offscreen;
 mod painter;
 pub mod path_cache;
-/// Pipeline key types + descriptors consumed by `painter.rs`'s pipeline cache.
-/// `#[allow(dead_code)]` retained because the `PipelineKey::from_color` /
-/// related constructors are not yet wired into painter.rs's pipeline
-/// construction. Per-item audit tracked in ARCHITECTURE.md.
-#[allow(dead_code)]
+/// Pipeline key types and cache consumed by `painter.rs`. Live items:
+/// `PipelineKey` (opaque/alpha-blend factory methods + bitfield queries),
+/// `PipelineCache` (get_or_create, viewport_bind_group_layout), and
+/// `pipeline_key_from_paint`. Unused constants/methods/cache helpers deleted.
 mod pipeline;
 // Cycle 4 E-6: parallel `pipelines.rs` module (with its own
 // `PipelineCache` + `PipelineBuilder` structs, name-colliding with
@@ -181,25 +180,6 @@ pub use debug::DebugBackend;
 pub use layer_render::LayerRender;
 pub use painter::WgpuPainter;
 
-// Cycle 4 PR #112 review fix: deprecated migration shim for
-// `PipelineBuilder`, which was re-exported from the deleted
-// `pipelines.rs` (plural) module pre-cycle. Workspace grep showed
-// zero consumers; if a downstream consumer DID import the name,
-// they hit a `#[deprecated]` warning rather than an unresolved-symbol
-// error. The shim resolves to the unit type so any method call on it
-// will fail compilation immediately -- the type's role was to host
-// builder methods that no longer exist. One-cycle migration window
-// before the alias goes away in cycle 5.
-/// Deprecated migration shim — see cycle 4 E-6 / PR #112 review.
-#[deprecated(
-    since = "0.1.0",
-    note = "`PipelineBuilder` (from the deleted `wgpu::pipelines` \
-            module) had zero workspace consumers and was removed in \
-            cycle 4 E-6. There is no replacement; pipeline construction \
-            goes through `pipeline::PipelineCache` (singular) directly. \
-            This deprecated alias will be removed in cycle 5."
-)]
-pub type PipelineBuilder = ();
 // Renderer (the one and only externally-consumed wgpu/* type)
 pub use renderer::Renderer;
 // Font loading utilities (external via lib.rs re-export at crate root)

--- a/crates/flui-engine/src/wgpu/multi_draw.rs
+++ b/crates/flui-engine/src/wgpu/multi_draw.rs
@@ -118,7 +118,11 @@ impl MultiDrawBatcher {
         self.total_instances += instance_count as usize;
     }
 
-    /// Get statistics
+    /// Get statistics (debug-only telemetry).
+    ///
+    /// The sole consumer logs at `debug_assertions`, so the method is gated to
+    /// match — avoiding a dead-code warning in release/bench builds.
+    #[cfg(debug_assertions)]
     pub fn stats(&self) -> MultiDrawStats {
         MultiDrawStats {
             active_draws: self.active_draws,
@@ -133,7 +137,8 @@ impl Default for MultiDrawBatcher {
     }
 }
 
-/// Multi-draw statistics
+/// Multi-draw statistics (debug-only telemetry).
+#[cfg(debug_assertions)]
 #[derive(Debug, Clone, Copy)]
 pub struct MultiDrawStats {
     /// Number of draw commands in current batch

--- a/crates/flui-engine/src/wgpu/offscreen.rs
+++ b/crates/flui-engine/src/wgpu/offscreen.rs
@@ -1409,7 +1409,11 @@ impl FullscreenVertex {
         ]
     }
 
-    // TODO: Add wgpu::VertexBufferLayout when integrated
+    // Vertex buffer layout descriptor for this type, for use when
+    // `FullscreenVertex` is bound as a vertex buffer in a render pipeline.
+    // Uncomment and implement when `OffscreenRenderer` grows a wired-up
+    // vertex-based fullscreen pass (current path uses hard-coded clip-space
+    // triangles via a storage buffer).
     // pub fn buffer_layout() -> wgpu::VertexBufferLayout<'static> { ... }
 }
 

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -1089,13 +1089,13 @@ impl WgpuPainter {
         self.buffer_pool.reset();
 
         // ===== Frame-boundary texture cache maintenance =====
-        self.texture_cache.reset_use_counters();
-        let shrunk = self.texture_cache.shrink();
-        let evicted = self.texture_cache.evict_over_budget();
-        if shrunk > 0 || evicted > 0 {
+        // One encapsulated pass (evict + atlas-reclaim, THEN reset counters) so
+        // the ordering can't regress into wiping the cache every frame.
+        let maint = self.texture_cache.end_frame_maintenance();
+        if maint.evicted > 0 || maint.atlas_reset {
             tracing::debug!(
-                shrunk,
-                evicted,
+                evicted = maint.evicted,
+                atlas_reset = maint.atlas_reset,
                 memory_bytes = self.texture_cache.memory_bytes(),
                 "Texture cache maintenance"
             );

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -1088,9 +1088,24 @@ impl WgpuPainter {
         // ===== Reset buffer pool for next frame =====
         self.buffer_pool.reset();
 
-        // ===== Frame-boundary texture cache maintenance =====
-        // One encapsulated pass (evict + atlas-reclaim, THEN reset counters) so
-        // the ordering can't regress into wiping the cache every frame.
+        // NOTE: texture-cache maintenance is intentionally NOT done here.
+        // `render` runs multiple times per frame — each backdrop-filter flush
+        // (backend.rs / renderer.rs) plus the final flush — on the SAME cache.
+        // Resetting use-counters here would mis-classify textures used in an
+        // earlier pass as unused and evict / atlas-reset them mid-frame. The
+        // Renderer calls `end_frame_maintenance` exactly once per frame instead.
+
+        Ok(())
+    }
+
+    /// Run end-of-frame texture-cache maintenance: evict over-budget textures,
+    /// reclaim a full atlas that holds stale entries, then reset use-counters.
+    ///
+    /// Call EXACTLY ONCE per frame, after the final [`Self::render`] flush.
+    /// `render` must not do this itself — it runs once per pass (backdrop-filter
+    /// flushes invoke it mid-frame), so per-call maintenance would reset
+    /// use-counters between passes and drop textures still in use this frame.
+    pub fn end_frame_maintenance(&mut self) {
         let maint = self.texture_cache.end_frame_maintenance();
         if maint.evicted > 0 || maint.atlas_reset {
             tracing::debug!(
@@ -1100,8 +1115,6 @@ impl WgpuPainter {
                 "Texture cache maintenance"
             );
         }
-
-        Ok(())
     }
 
     /// Flush a single draw segment by temporarily swapping it into current_segment

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -2400,7 +2400,6 @@ impl WgpuPainter {
                         );
                     }
                     Err(e) => {
-                        #[cfg(debug_assertions)]
                         tracing::error!("Failed to tessellate stroked arc: {}", e);
                     }
                 }
@@ -2427,7 +2426,6 @@ impl WgpuPainter {
                 );
             }
             Err(e) => {
-                #[cfg(debug_assertions)]
                 tracing::error!("Failed to tessellate DRRect: {}", e);
             }
         }
@@ -2459,7 +2457,6 @@ impl WgpuPainter {
                 );
             }
             Err(e) => {
-                #[cfg(debug_assertions)]
                 tracing::error!("WgpuPainter::line: Tessellation failed - {}", e);
             }
         }
@@ -2502,8 +2499,13 @@ impl WgpuPainter {
             "WgpuPainter::rich_text"
         );
         let transformed_position = self.apply_transform(position);
-        self.text_renderer
-            .add_rich_text(runs, transformed_position, base_font_size, base_color, wrap_width);
+        self.text_renderer.add_rich_text(
+            runs,
+            transformed_position,
+            base_font_size,
+            base_color,
+            wrap_width,
+        );
     }
 
     pub fn texture(&mut self, texture_id: TextureId, dst_rect: Rect<Pixels>) {
@@ -3077,7 +3079,6 @@ impl WgpuPainter {
                     self.add_tessellated(vertices, &indices);
                 }
                 Err(e) => {
-                    #[cfg(debug_assertions)]
                     tracing::error!("Failed to tessellate shadow path: {}", e);
                 }
             }
@@ -3255,7 +3256,6 @@ impl WgpuPainter {
                 }
             }
             Err(e) => {
-                #[cfg(debug_assertions)]
                 tracing::error!("Failed to load atlas texture: {}", e);
             }
         }

--- a/crates/flui-engine/src/wgpu/pipeline.rs
+++ b/crates/flui-engine/src/wgpu/pipeline.rs
@@ -27,11 +27,8 @@ pub struct PipelineKey {
 impl PipelineKey {
     // Feature flags
     const ALPHA_BLEND: u32 = 1 << 0; // Requires alpha blending
-    const TEXTURED: u32 = 1 << 1; // Uses textures
     const MSAA_4X: u32 = 1 << 2; // 4x MSAA enabled
     const MSAA_8X: u32 = 1 << 3; // 8x MSAA enabled
-    const HDR: u32 = 1 << 4; // HDR color space
-    const PREMUL_ALPHA: u32 = 1 << 5; // Premultiplied alpha
 
     /// Create opaque pipeline key (no blending, fastest)
     pub fn opaque() -> Self {
@@ -45,57 +42,9 @@ impl PipelineKey {
         }
     }
 
-    /// Create textured pipeline key
-    pub fn textured() -> Self {
-        Self {
-            bits: Self::TEXTURED,
-        }
-    }
-
-    /// Enable alpha blending
-    pub fn with_alpha_blend(mut self) -> Self {
-        self.bits |= Self::ALPHA_BLEND;
-        self
-    }
-
-    /// Enable texturing
-    pub fn with_textured(mut self) -> Self {
-        self.bits |= Self::TEXTURED;
-        self
-    }
-
-    /// Enable 4x MSAA
-    pub fn with_msaa_4x(mut self) -> Self {
-        self.bits |= Self::MSAA_4X;
-        self
-    }
-
-    /// Enable 8x MSAA
-    pub fn with_msaa_8x(mut self) -> Self {
-        self.bits |= Self::MSAA_8X;
-        self
-    }
-
-    /// Enable HDR
-    pub fn with_hdr(mut self) -> Self {
-        self.bits |= Self::HDR;
-        self
-    }
-
-    /// Enable premultiplied alpha
-    pub fn with_premul_alpha(mut self) -> Self {
-        self.bits |= Self::PREMUL_ALPHA;
-        self
-    }
-
     /// Check if pipeline requires alpha blending
     pub fn is_alpha_blended(self) -> bool {
         self.bits & Self::ALPHA_BLEND != 0
-    }
-
-    /// Check if pipeline uses textures
-    pub fn is_textured(self) -> bool {
-        self.bits & Self::TEXTURED != 0
     }
 
     /// Get MSAA sample count
@@ -160,14 +109,14 @@ impl PipelineCache {
     /// Returns cached pipeline if available, otherwise creates and caches new
     /// one.
     pub fn get_or_create(&mut self, device: &wgpu::Device, key: PipelineKey) -> &RenderPipeline {
-        // Check if pipeline exists
+        // `entry` needs `&mut self.cache`; `create_pipeline` needs `&self.shader` /
+        // `self.format` / `self.viewport_bind_group_layout` — disjoint fields.
+        // We pre-create on miss, then insert, to keep one logical lookup on hit.
         if !self.cache.contains_key(&key) {
-            // Create and insert new pipeline
             let pipeline = self.create_pipeline(device, key);
             self.cache.insert(key, pipeline);
         }
-
-        // Return cached pipeline (guaranteed to exist now)
+        // Safety: just inserted above on miss path.
         &self.cache[&key]
     }
 
@@ -233,16 +182,6 @@ impl PipelineCache {
         })
     }
 
-    /// Get number of cached pipelines
-    pub fn cached_count(&self) -> usize {
-        self.cache.len()
-    }
-
-    /// Clear the cache (useful for resource cleanup)
-    pub fn clear(&mut self) {
-        self.cache.clear();
-    }
-
     /// Get a reference to the viewport bind group layout
     ///
     /// This is needed to create bind groups that are compatible with pipelines
@@ -273,7 +212,6 @@ mod tests {
     fn test_pipeline_key_opaque() {
         let key = PipelineKey::opaque();
         assert!(!key.is_alpha_blended());
-        assert!(!key.is_textured());
         assert_eq!(key.msaa_samples(), 1);
     }
 
@@ -281,36 +219,13 @@ mod tests {
     fn test_pipeline_key_alpha_blend() {
         let key = PipelineKey::alpha_blend();
         assert!(key.is_alpha_blended());
-        assert!(!key.is_textured());
         assert_eq!(key.msaa_samples(), 1);
     }
 
     #[test]
-    fn test_pipeline_key_builder() {
-        let key = PipelineKey::opaque().with_alpha_blend().with_msaa_4x();
-
-        assert!(key.is_alpha_blended());
-        assert_eq!(key.msaa_samples(), 4);
-    }
-
-    #[test]
-    fn test_pipeline_key_msaa() {
-        let key_4x = PipelineKey::opaque().with_msaa_4x();
-        assert_eq!(key_4x.msaa_samples(), 4);
-
-        let key_8x = PipelineKey::opaque().with_msaa_8x();
-        assert_eq!(key_8x.msaa_samples(), 8);
-
-        // 8x overrides 4x
-        let key_both = PipelineKey::opaque().with_msaa_4x().with_msaa_8x();
-        assert_eq!(key_both.msaa_samples(), 8);
-    }
-
-    #[test]
-    fn test_pipeline_key_equality() {
-        let key1 = PipelineKey::alpha_blend().with_msaa_4x();
-        let key2 = PipelineKey::opaque().with_alpha_blend().with_msaa_4x();
-
-        assert_eq!(key1, key2);
+    fn test_pipeline_key_msaa_samples_default() {
+        // opaque() has no MSAA bits set → 1 sample
+        let key = PipelineKey::opaque();
+        assert_eq!(key.msaa_samples(), 1);
     }
 }

--- a/crates/flui-engine/src/wgpu/renderer.rs
+++ b/crates/flui-engine/src/wgpu/renderer.rs
@@ -129,6 +129,24 @@ struct RenderContext {
     supports_copy_src: bool,
 }
 
+/// Bundled GPU stack rebuilt by `new` (windowed path) and `recover`.
+///
+/// All fields are moved into `Renderer` after construction — this struct is
+/// a local bundle, not a long-lived allocation.
+struct WindowedGpuStack {
+    instance: wgpu::Instance,
+    adapter: wgpu::Adapter,
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+    surface: wgpu::Surface<'static>,
+    config: wgpu::SurfaceConfiguration,
+    capabilities: GpuCapabilities,
+    painter: super::painter::WgpuPainter,
+    offscreen: Arc<parking_lot::Mutex<super::offscreen::OffscreenRenderer>>,
+    supports_copy_src: bool,
+    device_lost: Arc<std::sync::atomic::AtomicBool>,
+}
+
 /// Cross-platform GPU renderer
 pub struct Renderer {
     // `instance` and `adapter` are kept alive for the lifetime of the renderer
@@ -155,7 +173,36 @@ pub struct Renderer {
     damage_tracker: flui_layer::damage::DamageTracker,
     /// Tracks opaque regions to skip fully-occluded layers during traversal
     occlusion: OcclusionTracker,
+    /// Raw window handle stored for self-contained device recovery.
+    ///
+    /// SAFETY: The stored handles are reused by `recover()` to rebuild the wgpu
+    /// surface after a GPU device loss. They remain valid for the same reason the
+    /// existing `wgpu::Surface<'static>` is sound — the window (owned by
+    /// flui-app's `App`) outlives the `Renderer`. `None` for offscreen renderers.
+    raw_window_handle: Option<raw_window_handle::RawWindowHandle>,
+    /// Raw display handle stored alongside `raw_window_handle` for recovery.
+    /// `None` for offscreen renderers.
+    raw_display_handle: Option<raw_window_handle::RawDisplayHandle>,
 }
+
+// SAFETY: `Renderer` stores `Option<RawWindowHandle>` and
+// `Option<RawDisplayHandle>`, which contain `NonNull<c_void>` on some
+// platforms (e.g. `UiKitWindowHandle`) and are therefore `!Send` by default.
+// The handles are:
+//   1. Extracted once at construction from the live window (or `None` for
+//      offscreen renderers).
+//   2. Read only inside `recover(&mut self)`, which requires exclusive access —
+//      no two threads can call `recover` concurrently on the same `Renderer`.
+//   3. Never sent to another thread while they are being dereferenced; the
+//      dereferencing happens only inside the `unsafe` block in
+//      `build_windowed_gpu_stack`, which runs in the same logical context as the
+//      caller holding `&mut self`.
+// This is the same Send posture that wgpu itself uses for its internal raw-handle
+// wrappers: the window pointer is accessed exclusively and never aliased across
+// threads. The owning window (flui-app's `App`) is alive for the lifetime of the
+// `Renderer`, satisfying the validity requirement.
+#[allow(unsafe_code)]
+unsafe impl Send for Renderer {}
 
 impl Renderer {
     /// Create a new renderer with automatic backend selection
@@ -181,49 +228,90 @@ impl Renderer {
     where
         W: raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle,
     {
-        // Select backend based on platform
-        let backends = Self::select_backend();
+        // Extract raw handles before calling the GPU stack builder.
+        // `window_handle()` and `display_handle()` are safe trait methods; no
+        // unsafe is required here. The stored raw handles are later reused by
+        // `recover()` to rebuild the surface; they remain valid for the same
+        // reason the `wgpu::Surface<'static>` is sound — the window (owned by
+        // flui-app's `App`) outlives the `Renderer`.
+        //
+        // wgpu 29.x multi-monitor fix: explicitly extract raw handles to work
+        // around DisplayHandle lifetime issues on multi-display systems.
+        let window_handle = window
+            .window_handle()
+            .map_err(|e| EngineError::surface_creation(std::io::Error::other(e.to_string())))?;
+        let display_handle = window
+            .display_handle()
+            .map_err(|e| EngineError::surface_creation(std::io::Error::other(e.to_string())))?;
+        let (raw_window_handle, raw_display_handle) =
+            (window_handle.as_raw(), Some(display_handle.as_raw()));
 
+        let (w, h) = (800u32, 600u32); // Will be updated on first resize
+        let stack =
+            Self::build_windowed_gpu_stack(raw_window_handle, raw_display_handle, w, h).await?;
+
+        Ok(Self {
+            instance: stack.instance,
+            adapter: stack.adapter,
+            device: stack.device,
+            queue: stack.queue,
+            surface: Some(stack.surface),
+            config: Some(stack.config),
+            capabilities: stack.capabilities,
+            painter: Some(stack.painter),
+            offscreen: Some(stack.offscreen),
+            supports_copy_src: stack.supports_copy_src,
+            device_lost: stack.device_lost,
+            damage_tracker: flui_layer::damage::DamageTracker::new(),
+            occlusion: OcclusionTracker::new(),
+            raw_window_handle: Some(raw_window_handle),
+            raw_display_handle,
+        })
+    }
+
+    /// Build the full windowed GPU stack from raw handles.
+    ///
+    /// Factored out of `new` so `recover` can call it without re-extracting
+    /// the window handles. Called once at construction and again on device loss.
+    ///
+    /// # Errors
+    ///
+    /// Adapter or device creation can fail (e.g. driver still resetting after
+    /// a TDR). Returns the underlying [`EngineError`]; the caller may retry on
+    /// the next frame.
+    async fn build_windowed_gpu_stack(
+        raw_window_handle: raw_window_handle::RawWindowHandle,
+        raw_display_handle: Option<raw_window_handle::RawDisplayHandle>,
+        width: u32,
+        height: u32,
+    ) -> EngineResult<WindowedGpuStack> {
+        let backends = Self::select_backend();
         tracing::info!("Creating wgpu instance with backends: {:?}", backends);
 
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends,
-            flags: wgpu::InstanceFlags::default(),
             ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
 
-        // Create surface — requires unsafe: wgpu surface creation from raw window
-        // handle.
+        // Create surface from stored raw handles.
         //
-        // SAFETY: the caller (typically flui-app) guarantees the window handle
-        // remains valid for the lifetime of the returned `Renderer` (and thus the
-        // `wgpu::Surface<'static>` it holds). This invariant is honoured by
-        // flui-app's `App` which owns the winit window for the application's
-        // lifetime. Both `SurfaceTargetUnsafe::from_window` and
-        // `Instance::create_surface_unsafe` carry this requirement; we audit it
-        // here once for the combined block.
+        // SAFETY: The raw handles were captured from the live window at
+        // construction time (see `Renderer::new`) and remain valid while the
+        // window is alive. Both `SurfaceTargetUnsafe::RawHandle` and
+        // `Instance::create_surface_unsafe` require the handles to stay valid
+        // for the lifetime of the resulting `Surface<'static>`; that invariant
+        // is upheld because flui-app's `App` owns the window for its lifetime.
         #[allow(unsafe_code)]
         let surface = unsafe {
-            // wgpu 29.x multi-monitor fix: explicitly extract raw handles to work
-            // around DisplayHandle lifetime issues on multi-display systems.
-            let window_handle = window
-                .window_handle()
-                .map_err(|e| EngineError::surface_creation(std::io::Error::other(e.to_string())))?;
-            let display_handle = window
-                .display_handle()
-                .map_err(|e| EngineError::surface_creation(std::io::Error::other(e.to_string())))?;
-
-            // Create surface target with explicit raw handles to avoid lifetime issues
             let surface_target = wgpu::SurfaceTargetUnsafe::RawHandle {
-                raw_display_handle: Some(display_handle.as_raw()),
-                raw_window_handle: window_handle.as_raw(),
+                raw_display_handle,
+                raw_window_handle,
             };
             instance
                 .create_surface_unsafe(surface_target)
                 .map_err(EngineError::surface_creation)?
         };
 
-        // Request adapter
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::HighPerformance,
@@ -233,9 +321,7 @@ impl Renderer {
             .await
             .map_err(EngineError::adapter_request)?;
 
-        // Detect capabilities
         let capabilities = GpuCapabilities::detect(&adapter);
-
         tracing::info!(
             "Selected GPU: {} ({}), Backend: {:?}",
             capabilities.adapter_name,
@@ -243,13 +329,13 @@ impl Renderer {
             capabilities.backend
         );
 
-        // Request device and queue
         let (device, queue) = adapter
             .request_device(&wgpu::DeviceDescriptor {
                 label: Some("FLUI GPU Device"),
                 required_features: Self::required_features(&capabilities),
                 required_limits: Self::required_limits(&capabilities),
-                memory_hints: wgpu::MemoryHints::default(),
+                // Desktop UI: trade VRAM for faster per-frame GPU allocations.
+                memory_hints: wgpu::MemoryHints::Performance,
                 experimental_features: wgpu::ExperimentalFeatures::disabled(),
                 trace: wgpu::Trace::Off,
             })
@@ -262,11 +348,9 @@ impl Renderer {
         let device = Arc::new(device);
         let queue = Arc::new(queue);
 
-        // Configure surface
         let surface_caps = surface.get_capabilities(&adapter);
         let surface_format = Self::select_surface_format(&surface_caps, &capabilities);
 
-        // Check if the surface supports COPY_SRC (needed for backdrop blur)
         let supports_copy_src = surface_caps.usages.contains(wgpu::TextureUsages::COPY_SRC);
         if !supports_copy_src {
             tracing::warn!(
@@ -283,17 +367,15 @@ impl Renderer {
         let config = wgpu::SurfaceConfiguration {
             usage: surface_usage,
             format: surface_format,
-            width: 800, // Will be updated on resize
-            height: 600,
+            width,
+            height,
             present_mode: Self::select_present_mode(&surface_caps),
             alpha_mode: wgpu::CompositeAlphaMode::Auto,
             view_formats: vec![],
             desired_maximum_frame_latency: 2,
         };
-
         surface.configure(&device, &config);
 
-        // Create painter for GPU rendering
         let painter = super::painter::WgpuPainter::with_shared_device(
             Arc::clone(&device),
             Arc::clone(&queue),
@@ -301,28 +383,25 @@ impl Renderer {
             (config.width, config.height),
         );
 
-        // Create offscreen renderer for shader mask / backdrop filter effects
         let offscreen = super::offscreen::OffscreenRenderer::new(
             Arc::clone(&device),
             Arc::clone(&queue),
             surface_format,
         );
-        let offscreen = Some(Arc::new(parking_lot::Mutex::new(offscreen)));
+        let offscreen = Arc::new(parking_lot::Mutex::new(offscreen));
 
-        Ok(Self {
+        Ok(WindowedGpuStack {
             instance,
             adapter,
             device,
             queue,
-            surface: Some(surface),
-            config: Some(config),
+            surface,
+            config,
             capabilities,
-            painter: Some(painter),
+            painter,
             offscreen,
             supports_copy_src,
             device_lost,
-            damage_tracker: flui_layer::damage::DamageTracker::new(),
-            occlusion: OcclusionTracker::new(),
         })
     }
 
@@ -353,7 +432,8 @@ impl Renderer {
                 label: Some("FLUI Offscreen Device"),
                 required_features: Self::required_features(&capabilities),
                 required_limits: Self::required_limits(&capabilities),
-                memory_hints: wgpu::MemoryHints::default(),
+                // Desktop UI: trade VRAM for faster per-frame GPU allocations.
+                memory_hints: wgpu::MemoryHints::Performance,
                 experimental_features: wgpu::ExperimentalFeatures::disabled(),
                 trace: wgpu::Trace::Off,
             })
@@ -377,7 +457,120 @@ impl Renderer {
             device_lost,
             damage_tracker: flui_layer::damage::DamageTracker::new(),
             occlusion: OcclusionTracker::new(),
+            raw_window_handle: None,
+            raw_display_handle: None,
         })
+    }
+
+    /// Returns `true` if the GPU device has been lost.
+    ///
+    /// After a TDR, driver crash, or GPU hardware failure the device-lost
+    /// callback fires and sets this flag. The caller (runner frame loop)
+    /// should call [`recover()`](Self::recover) to rebuild the GPU context.
+    #[must_use]
+    pub fn is_device_lost(&self) -> bool {
+        self.device_lost.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Rebuild the GPU device and surface after a device-lost event.
+    ///
+    /// On the **windowed** path (`raw_window_handle` is `Some`) this rebuilds
+    /// the entire GPU stack (instance → adapter → device → surface → painter →
+    /// offscreen) and swaps the new pieces into `self`. The recovered surface
+    /// is configured at the **current** surface size captured from `self.config`
+    /// (falling back to 800×600), so the window keeps its correct dimensions
+    /// without a separate resize call.
+    ///
+    /// On the **offscreen** path (`raw_window_handle` is `None`) only the
+    /// device/queue are replaced; surface, painter, and offscreen are left as
+    /// `None`.
+    ///
+    /// On success the device-lost flag is cleared (the fresh device starts
+    /// healthy). On failure the underlying [`EngineError`] is returned — the
+    /// driver may still be resetting; the runner should retry on the next frame.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError::AdapterRequest`] or [`EngineError::DeviceCreation`]
+    /// when the driver is still resetting or the adapter is no longer available.
+    /// Returns [`EngineError::SurfaceCreation`] if the surface cannot be
+    /// recreated from the stored raw handles (very unlikely while the window is
+    /// alive).
+    #[tracing::instrument(level = "warn", skip(self))]
+    pub async fn recover(&mut self) -> EngineResult<()> {
+        if let Some(raw_window) = self.raw_window_handle {
+            // Capture current dimensions before rebuild so the recovered
+            // surface matches the live window size instead of defaulting to
+            // 800×600.
+            let (width, height) = self
+                .config
+                .as_ref()
+                .map_or((800u32, 600u32), |c| (c.width, c.height));
+
+            let stack =
+                Self::build_windowed_gpu_stack(raw_window, self.raw_display_handle, width, height)
+                    .await?;
+
+            self.instance = stack.instance;
+            self.adapter = stack.adapter;
+            self.device = stack.device;
+            self.queue = stack.queue;
+            self.surface = Some(stack.surface);
+            self.config = Some(stack.config);
+            self.capabilities = stack.capabilities;
+            self.painter = Some(stack.painter);
+            self.offscreen = Some(stack.offscreen);
+            self.supports_copy_src = stack.supports_copy_src;
+            // Replace with a fresh flag — the new device starts healthy.
+            self.device_lost = stack.device_lost;
+            // Force a full repaint so the first recovered frame is complete.
+            self.damage_tracker.mark_full_repaint();
+        } else {
+            // Offscreen path: rebuild device/queue only.
+            let backends = Self::select_backend();
+            let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+                backends,
+                ..wgpu::InstanceDescriptor::new_without_display_handle()
+            });
+            let adapter = instance
+                .request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::HighPerformance,
+                    compatible_surface: None,
+                    force_fallback_adapter: false,
+                })
+                .await
+                .map_err(EngineError::adapter_request)?;
+            let capabilities = GpuCapabilities::detect(&adapter);
+            let (device, queue) = adapter
+                .request_device(&wgpu::DeviceDescriptor {
+                    label: Some("FLUI Offscreen Device"),
+                    required_features: Self::required_features(&capabilities),
+                    required_limits: Self::required_limits(&capabilities),
+                    memory_hints: wgpu::MemoryHints::Performance,
+                    experimental_features: wgpu::ExperimentalFeatures::disabled(),
+                    trace: wgpu::Trace::Off,
+                })
+                .await
+                .map_err(EngineError::device_creation)?;
+
+            let fresh_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            Self::install_device_diagnostics(&device, Arc::clone(&fresh_flag));
+
+            self.instance = instance;
+            self.adapter = adapter;
+            self.device = Arc::new(device);
+            self.queue = Arc::new(queue);
+            self.capabilities = capabilities;
+            self.device_lost = fresh_flag;
+        }
+
+        tracing::info!(
+            width = self.config.as_ref().map_or(0, |c| c.width),
+            height = self.config.as_ref().map_or(0, |c| c.height),
+            "GPU device recovered successfully"
+        );
+
+        Ok(())
     }
 
     /// Select appropriate backend for the current platform
@@ -520,8 +713,14 @@ impl Renderer {
             }
         }
 
-        // Fallback to first available format
-        surface_caps.formats[0]
+        // Fallback: some drivers report zero formats (e.g. headless CI).
+        // Default to a universally supported sRGB format rather than panicking.
+        if let Some(fmt) = surface_caps.formats.first().copied() {
+            fmt
+        } else {
+            tracing::error!("surface reported zero formats; defaulting to Bgra8UnormSrgb");
+            wgpu::TextureFormat::Bgra8UnormSrgb
+        }
     }
 
     /// Select present mode based on capabilities
@@ -631,11 +830,11 @@ impl Renderer {
     pub fn render_scene(&mut self, scene: &flui_layer::Scene) -> Result<(), EngineError> {
         use super::backend::Backend;
 
-        // TODO: Fine-grained damage tracking from widget state changes.
-        // Currently, the application layer must call `mark_dirty()` or
-        // `mark_full_repaint()` explicitly (e.g., after any input event).
-        // When the widget layer (flui-view) is re-enabled, widgets should
-        // call `mark_dirty(bounds)` on state change for per-region tracking.
+        // Fine-grained damage tracking is the caller's responsibility: the
+        // application layer calls `mark_dirty()` / `mark_full_repaint()` after
+        // input events or state changes. When flui-view is wired up, widgets
+        // will call `mark_dirty(bounds)` on state change; until then, callers
+        // use `mark_full_repaint()` to force a frame.
 
         // Check if we need to render at all
         if !self.damage_tracker.has_damage() && !self.damage_tracker.needs_full_repaint() {
@@ -880,8 +1079,9 @@ impl Renderer {
         // Normal path: render → children → cleanup
         layer.render(backend);
 
-        let children: Vec<_> = node.children().to_vec();
-        for child_id in children {
+        // Borrow children as a slice of Copy values; re-borrow `tree` inside the
+        // call is shared and does not conflict with this shared borrow of `node`.
+        for &child_id in node.children() {
             Self::render_layer_recursive(
                 tree,
                 child_id,
@@ -948,8 +1148,7 @@ impl Renderer {
             tracing::warn!(
                 "Backdrop filter type not supported for GPU blur, rendering children only"
             );
-            let children: Vec<_> = node.children().to_vec();
-            for child_id in children {
+            for &child_id in node.children() {
                 Self::render_layer_recursive(
                     tree,
                     child_id,
@@ -1026,8 +1225,7 @@ impl Renderer {
         }
 
         // 5. Render children on top of the blurred backdrop
-        let children: Vec<_> = node.children().to_vec();
-        for child_id in children {
+        for &child_id in node.children() {
             Self::render_layer_recursive(
                 tree,
                 child_id,
@@ -1084,6 +1282,81 @@ mod tests {
                 assert!(renderer.config.is_none());
                 assert!(!renderer.capabilities.adapter_name.is_empty());
             }
+        });
+    }
+
+    /// Verify that `recover()` on an offscreen renderer:
+    ///   1. Starts with `is_device_lost() == false`.
+    ///   2. Reports `true` after the flag is set manually.
+    ///   3. Returns to `false` after `recover()` (fresh device = fresh flag).
+    ///   4. The recovered device is functional (buffer creation + empty submit).
+    ///
+    /// # Limitation
+    ///
+    /// wgpu has no public API to force a real device loss programmatically, so
+    /// we simulate the flag being set by the driver callback by storing directly
+    /// into the `Arc<AtomicBool>`. The windowed surface-rebuild path (raw handle
+    /// → surface → adapter → device) cannot be unit-tested without a real window
+    /// and a real GPU loss event; it is covered by compilation + code review only.
+    #[test]
+    fn offscreen_recover_clears_device_lost_flag() {
+        pollster::block_on(async {
+            let mut renderer = match Renderer::new_offscreen().await {
+                Ok(r) => r,
+                Err(_) => {
+                    // No GPU in this environment (common in CI); skip gracefully.
+                    return;
+                }
+            };
+
+            // Precondition: flag starts clear on a healthy device.
+            assert!(
+                !renderer.is_device_lost(),
+                "device_lost must be false on a freshly created offscreen renderer"
+            );
+
+            // Simulate the device-lost callback firing (wgpu sets this flag when
+            // a real loss occurs; we set it directly because wgpu exposes no API
+            // to force a device loss in tests).
+            renderer
+                .device_lost
+                .store(true, std::sync::atomic::Ordering::Release);
+            assert!(
+                renderer.is_device_lost(),
+                "flag must read true after simulated device loss"
+            );
+
+            // Recover — this builds a fresh device with a fresh flag.
+            match renderer.recover().await {
+                Ok(()) => {}
+                Err(_) => {
+                    // recover() can fail when the adapter is unavailable (e.g.
+                    // software rasterizer CI). That's expected; the important
+                    // property is that the flag is reset on *success*.
+                    return;
+                }
+            }
+
+            // Post-condition: fresh device, fresh flag.
+            assert!(
+                !renderer.is_device_lost(),
+                "is_device_lost() must be false after a successful recover()"
+            );
+
+            // Verify the recovered device is functional: create a tiny buffer and
+            // submit an empty command encoder without panicking.
+            let _buf = renderer.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("recovery-probe"),
+                size: 16,
+                usage: wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+            let encoder = renderer
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("recovery-probe-encoder"),
+                });
+            renderer.queue.submit(std::iter::once(encoder.finish()));
         });
     }
 }

--- a/crates/flui-engine/src/wgpu/renderer.rs
+++ b/crates/flui-engine/src/wgpu/renderer.rs
@@ -1003,6 +1003,12 @@ impl Renderer {
             }
             self.queue.submit(std::iter::once(final_encoder.finish()));
 
+            // Frame boundary: run texture-cache maintenance ONCE, after the
+            // final flush. `painter.render` runs per-pass (backdrop-filter
+            // flushes call it mid-frame), so maintenance lives here — not inside
+            // `render` — to avoid resetting use-counters between passes.
+            painter.end_frame_maintenance();
+
             // Return painter to Renderer for reuse
             self.painter = Some(painter);
         }
@@ -1301,12 +1307,9 @@ mod tests {
     #[test]
     fn offscreen_recover_clears_device_lost_flag() {
         pollster::block_on(async {
-            let mut renderer = match Renderer::new_offscreen().await {
-                Ok(r) => r,
-                Err(_) => {
-                    // No GPU in this environment (common in CI); skip gracefully.
-                    return;
-                }
+            let Ok(mut renderer) = Renderer::new_offscreen().await else {
+                // No GPU in this environment (common in CI); skip gracefully.
+                return;
             };
 
             // Precondition: flag starts clear on a healthy device.

--- a/crates/flui-engine/src/wgpu/text.rs
+++ b/crates/flui-engine/src/wgpu/text.rs
@@ -537,47 +537,49 @@ impl TextRenderer {
         );
 
         let key = RichTextCacheKey::new(runs, base_font_size, base_color);
-        match self.rich_cache.entry(key.clone()) {
-            Entry::Occupied(mut e) => {
-                e.get_mut().last_used_frame = self.current_frame;
-                self.cache_hits += 1;
-            }
-            Entry::Vacant(e) => {
-                let line_height = base_font_size * 1.2;
-                let mut buffer = Buffer::new(
-                    &mut self.font_system,
-                    Metrics::new(base_font_size, line_height),
-                );
-                // Use wrap_width from the layout constraint so glyphon
-                // respects the same line-breaking as cosmic-text.
-                // None = unbounded (no wrapping); Some(w) = wrap at w pixels.
-                let buffer_width = wrap_width.unwrap_or(f32::MAX);
-                buffer.set_size(&mut self.font_system, Some(buffer_width), None);
 
-                // Build per-run AttrsOwned; the iterator borrows from the vec
-                // of owned values, satisfying set_rich_text's lifetime.
-                let owned_attrs: Vec<AttrsOwned> = runs
-                    .iter()
-                    .map(|(_, style)| style_to_attrs_owned(style.as_ref(), base_color))
-                    .collect();
+        // Borrow `key` on hit to avoid an allocation; move it into the map on miss.
+        if let Some(entry) = self.rich_cache.get_mut(&key) {
+            entry.last_used_frame = self.current_frame;
+            self.cache_hits += 1;
+        } else {
+            let line_height = base_font_size * 1.2;
+            let mut buffer = Buffer::new(
+                &mut self.font_system,
+                Metrics::new(base_font_size, line_height),
+            );
+            // Use wrap_width from the layout constraint so glyphon
+            // respects the same line-breaking as cosmic-text.
+            // None = unbounded (no wrapping); Some(w) = wrap at w pixels.
+            let buffer_width = wrap_width.unwrap_or(f32::MAX);
+            buffer.set_size(&mut self.font_system, Some(buffer_width), None);
 
-                buffer.set_rich_text(
-                    &mut self.font_system,
-                    runs.iter()
-                        .zip(owned_attrs.iter())
-                        .map(|((text, _), attrs)| (text.as_str(), attrs.as_attrs())),
-                    &Attrs::new(),
-                    Shaping::Advanced,
-                    None,
-                );
-                buffer.shape_until_scroll(&mut self.font_system, false);
+            // Build per-run AttrsOwned; the iterator borrows from the vec
+            // of owned values, satisfying set_rich_text's lifetime.
+            let owned_attrs: Vec<AttrsOwned> = runs
+                .iter()
+                .map(|(_, style)| style_to_attrs_owned(style.as_ref(), base_color))
+                .collect();
 
-                e.insert(CachedBuffer {
+            buffer.set_rich_text(
+                &mut self.font_system,
+                runs.iter()
+                    .zip(owned_attrs.iter())
+                    .map(|((text, _), attrs)| (text.as_str(), attrs.as_attrs())),
+                &Attrs::new(),
+                Shaping::Advanced,
+                None,
+            );
+            buffer.shape_until_scroll(&mut self.font_system, false);
+
+            self.rich_cache.insert(
+                key.clone(),
+                CachedBuffer {
                     buffer,
                     last_used_frame: self.current_frame,
-                });
-                self.cache_misses += 1;
-            }
+                },
+            );
+            self.cache_misses += 1;
         }
 
         let default_color =

--- a/crates/flui-engine/src/wgpu/texture_cache.rs
+++ b/crates/flui-engine/src/wgpu/texture_cache.rs
@@ -1102,23 +1102,35 @@ mod tests {
         let mut cache = TextureCache::new(device, queue);
         let id = TextureId::from_name("retained");
         // 4x4 RGBA — far under the default 100 MB budget.
+        // 4x4 <= ATLAS_MAX_DIMENSION -> atlas-backed path.
         cache
             .load_from_rgba(id.clone(), 4, 4, &[0u8; 4 * 4 * 4])
             .expect("rgba upload");
-        // A frame draws it (record_use -> use_count > 0).
+        // 300x300 > ATLAS_MAX_DIMENSION -> standalone path. The per-frame wipe
+        // removed atlas AND standalone entries alike, so cover both here.
+        let big = TextureId::from_name("retained_standalone");
+        cache
+            .load_from_rgba(big.clone(), 300, 300, &vec![0u8; 300 * 300 * 4])
+            .expect("rgba upload");
+        // A frame draws both (record_use -> use_count > 0).
         assert!(cache.get(&id).is_some());
+        assert!(cache.get(&big).is_some());
 
         cache.end_frame_maintenance();
         assert!(
             cache.contains(&id),
-            "a texture used this frame must survive frame maintenance"
+            "an atlas-backed texture used this frame must survive frame maintenance"
+        );
+        assert!(
+            cache.contains(&big),
+            "a standalone texture used this frame must survive frame maintenance"
         );
 
-        // A second, idle frame under budget also retains it for reuse.
+        // A second, idle frame under budget also retains them for reuse.
         cache.end_frame_maintenance();
         assert!(
-            cache.contains(&id),
-            "under budget, a cached texture persists across idle frames"
+            cache.contains(&id) && cache.contains(&big),
+            "under budget, cached textures persist across idle frames"
         );
     }
 }

--- a/crates/flui-engine/src/wgpu/texture_cache.rs
+++ b/crates/flui-engine/src/wgpu/texture_cache.rs
@@ -185,6 +185,15 @@ pub struct TextureCacheStats {
     pub atlas_utilization: f32,
 }
 
+/// Outcome of one frame-boundary [`TextureCache::end_frame_maintenance`] pass.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FrameMaintenance {
+    /// Number of standalone textures evicted to stay within the memory budget.
+    pub evicted: usize,
+    /// `true` when the shared atlas was reclaimed this frame.
+    pub atlas_reset: bool,
+}
+
 /// GPU Texture Cache
 ///
 /// Manages texture loading, caching, and reuse for optimal performance.
@@ -226,6 +235,10 @@ pub struct TextureCache {
     /// Images with both dimensions <= `ATLAS_MAX_DIMENSION` are packed here.
     /// When the atlas is full, allocation falls back to standalone textures.
     atlas: super::atlas::TextureAtlas,
+    /// Set when an atlas allocation fails (the shelf packer is full). Read at
+    /// the frame boundary by [`Self::end_frame_maintenance`] to decide whether
+    /// to reclaim the atlas; cleared once the atlas is reset.
+    atlas_full: bool,
 }
 
 impl TextureCache {
@@ -268,6 +281,7 @@ impl TextureCache {
             queue,
             max_memory_bytes: 100 * 1024 * 1024, // 100 MB default
             atlas,
+            atlas_full: false,
         }
     }
 
@@ -446,7 +460,10 @@ impl TextureCache {
 
                         return Ok(entry.insert(cached_texture));
                     }
-                    // Atlas full — fall through to standalone texture
+                    // Atlas full — fall through to standalone texture, and flag
+                    // the atlas for frame-boundary reclamation (see
+                    // `end_frame_maintenance`).
+                    self.atlas_full = true;
                     tracing::debug!(
                         width,
                         height,
@@ -670,12 +687,66 @@ impl TextureCache {
         before - self.textures.len()
     }
 
-    /// Reset use counters (call at frame start)
+    /// Reset use counters.
     ///
-    /// Sets all use_count to 0 so unused textures can be detected.
+    /// Sets all `use_count` to 0 so the next frame can detect unused textures.
+    /// Run at the END of frame maintenance, after eviction has read this
+    /// frame's counts — see [`Self::end_frame_maintenance`].
     pub fn reset_use_counters(&mut self) {
         for texture in self.textures.values_mut() {
             texture.use_count = 0;
+        }
+    }
+
+    /// Reclaim the shared atlas if it filled up and holds stale entries.
+    ///
+    /// The shelf packer never frees individual slots, so once it fills, every
+    /// subsequent small image falls back to a standalone texture and loses
+    /// atlas batching for the rest of the session. When that has happened AND
+    /// at least one atlas-backed entry went unused this frame (a stale slot to
+    /// reclaim), drop ALL atlas entries and reset the packer; the still-live
+    /// ones re-pack from their source image on the next frame (a one-frame
+    /// standalone blip, then back in the atlas).
+    ///
+    /// Skips the reset when every atlas entry was used this frame — the working
+    /// set genuinely exceeds the atlas, so a reset would immediately refill and
+    /// thrash. Returns `true` when the atlas was reset.
+    ///
+    /// Must run before [`Self::reset_use_counters`] so per-entry `use_count`
+    /// still reflects this frame.
+    fn maybe_reset_atlas(&mut self) -> bool {
+        if !self.atlas_full {
+            return false;
+        }
+        let has_stale = self
+            .textures
+            .values()
+            .any(|t| t.is_atlas_entry() && t.use_count == 0);
+        if !has_stale {
+            // Working set fills the atlas; resetting now would only thrash.
+            return false;
+        }
+        self.textures.retain(|_, t| !t.is_atlas_entry());
+        self.atlas.reset();
+        self.atlas_full = false;
+        true
+    }
+
+    /// Frame-boundary cache maintenance — call once per frame AFTER rendering.
+    ///
+    /// Order is load-bearing: stale-atlas detection and budget eviction read
+    /// this frame's `use_count`s, THEN the counters reset for the next frame. A
+    /// previous call site reset the counters FIRST and then removed every
+    /// `use_count == 0` entry, which wiped the entire cache every frame and
+    /// defeated cross-frame reuse. Encapsulating the sequence here keeps callers
+    /// from reintroducing that ordering bug.
+    pub fn end_frame_maintenance(&mut self) -> FrameMaintenance {
+        let atlas_reset = self.maybe_reset_atlas();
+        let evicted = self.evict_over_budget();
+        self.reset_use_counters();
+        FrameMaintenance {
+            evicted,
+            atlas_reset,
         }
     }
 
@@ -1000,5 +1071,54 @@ mod tests {
 
         assert_eq!(stats.cached_textures, 0);
         assert_eq!(stats.hit_rate, 0.0);
+    }
+
+    /// Headless GPU device + queue for cache tests.
+    fn test_device_and_queue() -> (std::sync::Arc<wgpu::Device>, std::sync::Arc<wgpu::Queue>) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .expect("a GPU adapter for texture-cache tests");
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("TextureCache Test Device"),
+            ..Default::default()
+        }))
+        .expect("a GPU device for texture-cache tests");
+        (std::sync::Arc::new(device), std::sync::Arc::new(queue))
+    }
+
+    /// Regression: frame maintenance must RETAIN textures used this frame.
+    ///
+    /// The previous call site reset the use-counters and THEN removed every
+    /// zero-count entry, wiping the entire cache every frame. `end_frame_main`
+    /// now evicts (budget-gated) before resetting, so an under-budget cache
+    /// keeps its entries for cross-frame reuse.
+    #[test]
+    fn end_frame_maintenance_retains_used_texture() {
+        let (device, queue) = test_device_and_queue();
+        let mut cache = TextureCache::new(device, queue);
+        let id = TextureId::from_name("retained");
+        // 4x4 RGBA — far under the default 100 MB budget.
+        cache
+            .load_from_rgba(id.clone(), 4, 4, &[0u8; 4 * 4 * 4])
+            .expect("rgba upload");
+        // A frame draws it (record_use -> use_count > 0).
+        assert!(cache.get(&id).is_some());
+
+        cache.end_frame_maintenance();
+        assert!(
+            cache.contains(&id),
+            "a texture used this frame must survive frame maintenance"
+        );
+
+        // A second, idle frame under budget also retains it for reuse.
+        cache.end_frame_maintenance();
+        assert!(
+            cache.contains(&id),
+            "under budget, a cached texture persists across idle frames"
+        );
     }
 }


### PR DESCRIPTION
Audit + improvement pass on `flui-engine` after the Rust 1.96 / wgpu 29 / glyphon 0.11 bump. Three commits: a feature + cleanup pass, two texture/atlas cache bug fixes, and a review fix.

## What changed

### Device-loss recovery (cross-crate) — `ce8d7a73`
The engine surfaced `EngineError::DeviceLost`, but `flui-app` swallowed it → after a real GPU loss (TDR / driver update / GPU switch) the app logged forever and never rebuilt the device.
- `Renderer` stores `Copy` `RawWindowHandle`/`RawDisplayHandle` so `recover()` rebuilds the GPU stack self-contained (no window arg); `new()`/`recover()` share an extracted `build_windowed_gpu_stack`. Adds `is_device_lost()` + `recover()`.
- `flui-app` runner (desktop/android/wasm) + `direct.rs` detect `is_device_lost()` and recover (`block_on` native, `spawn_local` wasm); `binding.rs` no longer swallows `DeviceLost`. wasm recovery takes the renderer out of the `Arc<Mutex<Option<_>>>` slot before `.await` to avoid a single-thread deadlock.

### wgpu-29 correctness + fossil/perf cleanup — `ce8d7a73`
- panic-guard on an empty surface-format list; `MemoryHints::Performance`; remove redundant `InstanceFlags`.
- delete deprecated `RenderError`/`RenderResult` aliases + `PipelineBuilder=()` shim; prune dead `PipelineKey` API + fix a pipeline-cache double-lookup.
- re-enable the silently-disabled instancing tests (drop the `disabled-tests` feature), fix the layout assertion (96→112B; `clip_kind` was added after the test was muted).
- painter: log tessellation/texture errors in release too (were `#[cfg(debug_assertions)]`-gated → swallowed); gate `multi_draw` debug-only telemetry.
- perf: children `.to_vec()`→direct iteration ×3; gradient stops `Vec`→`SmallVec<[_;8]>` via one helper ×6; drop a per-call rich-text cache-key clone.
- soundness: `buffer_pool` SAFETY comments name their load-bearing invariants; wasm `compile_error!` guard enforcing the no-atomics `Send` contract.
- criterion `benches/render_throughput.rs` (GPU-gated, baseline for future perf work).

### Texture/atlas cache fixes — `3b911f8d`
- **Per-frame wipe:** the painter ran `reset_use_counters()` → `shrink()`, which removed every entry every frame (zero cross-frame reuse, re-upload each frame). Encapsulated in `TextureCache::end_frame_maintenance()` (evict/reclaim **before** reset); dropped the over-aggressive per-frame `shrink`.
- **Atlas never freed slots:** the shelf packer is append-only, so once full every small image permanently fell back to a standalone texture. Added `TextureAtlas::reset()` + `maybe_reset_atlas()` (reclaim when full **and** stale entries exist; anti-thrash guard when the working set exceeds the atlas).

### Review fix — `9e5641b2`
A `ce-kieran-rust-reviewer` pass found that `WgpuPainter::render` runs **multiple times per frame** on the same cache (each backdrop-filter flush + the final flush), so the maintenance-inside-`render` reset use-counters mid-frame.
- Moved maintenance to `WgpuPainter::end_frame_maintenance`, called **once** in `render_scene` after the final flush (true frame boundary); `render` is now a pure per-pass flush.
- Strengthened the regression test to cover both the atlas and standalone cache paths.
- Closed a gate gap the reviewer surfaced: the clippy gate ran without `--features enable-wgpu-tests`, so GPU-only test code was never linted (fixed a `manual_let_else`).

## Reviewer note
`unsafe impl Send for Renderer` was added to store the thread-affine `RawWindowHandle` (`!Send`) behind winit's `Send + 'static` callback bound. Sound under flui's single-UI-thread invariant (handles are never dereferenced off-thread); flagged here for awareness.

## Gates (verified)
`clippy --all-targets -D warnings` **with and without** `--features enable-wgpu-tests` · `check --release` 0 warnings · nextest 78/78 · GPU suite 126/126 (run serially — GPU tests flake in parallel due to DX12 driver contention, a pre-existing pattern CI already guards with `--test-threads 1`) · `cargo bench --no-run` · `cargo check --target wasm32-unknown-unknown` · `cargo doc`.

## Notes for the reviewer
- The windowed real-loss recovery path is **review-only** — wgpu has no public API to force a device loss; the offscreen path is unit-tested (`offscreen_recover_clears_device_lost_flag`).
- Deferred P2s (with rationale): wgpu `PipelineCache` is Vulkan-only (no-op on DX12/Metal); `texture_pool` exact-size match; `buffer_pool` O(n) reuse scan; occlusion-query GPU culling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)