### PR TITLE
fix(engine): round-2 deep-audit — 6 render-correctness bugs

### DIFF
--- a/crates/flui-engine/src/wgpu/effects_pipeline.rs
+++ b/crates/flui-engine/src/wgpu/effects_pipeline.rs
@@ -25,10 +25,18 @@ pub fn create_gradient_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGro
     })
 }
 
+/// Maximum number of gradient stop slots in the GPU buffer.
+///
+/// Each gradient consumes up to 8 slots; this cap allows 100 gradients per
+/// frame. The three `*_gradient_rect` methods in `painter.rs` enforce this
+/// limit by dropping instances that would overflow it rather than writing
+/// past the end of the buffer.
+pub const MAX_GRADIENT_STOPS: usize = 8 * 100;
+
 /// Create gradient stops buffer with initial capacity
 pub fn create_gradient_stops_buffer(device: &wgpu::Device) -> wgpu::Buffer {
     // Max 8 stops per gradient, support up to 100 gradients per frame
-    let capacity = 8 * 100;
+    let capacity = MAX_GRADIENT_STOPS;
     let size = (capacity * std::mem::size_of::<GradientStop>()) as u64;
 
     device.create_buffer(&wgpu::BufferDescriptor {

--- a/crates/flui-engine/src/wgpu/offscreen.rs
+++ b/crates/flui-engine/src/wgpu/offscreen.rs
@@ -644,6 +644,49 @@ impl OffscreenRenderer {
     ///
     /// A new `PooledTexture` containing the blurred result at the original resolution.
     pub fn render_blur(&mut self, input: &PooledTexture, sigma: f32) -> PooledTexture {
+        // sigma ≤ 0 means "no blur" — copy the input through without running
+        // any Kawase passes. Without this guard sigma=0 would produce one
+        // downsample+upsample pass (iterations=1 from the clamp below), visibly
+        // blurring content that should be unchanged (e.g. backdrop_filter with
+        // sigma 0, identity image filters).
+        if sigma <= 0.0 {
+            tracing::trace!(
+                sigma,
+                width = input.width(),
+                height = input.height(),
+                "render_blur: sigma ≤ 0, copying input through without Kawase passes"
+            );
+            let out = self
+                .texture_pool
+                .acquire(input.width(), input.height(), self.surface_format);
+            let mut encoder = self
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("Blur Passthrough Encoder"),
+                });
+            encoder.copy_texture_to_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: input.texture(),
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::TexelCopyTextureInfo {
+                    texture: out.texture(),
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::Extent3d {
+                    width: input.width(),
+                    height: input.height(),
+                    depth_or_array_layers: 1,
+                },
+            );
+            self.queue.submit(std::iter::once(encoder.finish()));
+            return out;
+        }
+
         // `sigma` flows in from public APIs (BlurFilter constructors) that do
         // not clamp non-negative, so explicitly clamp to `[0, ∞)` in float
         // space before the `as u32` cast. The `.clamp(1, 5)` then bounds the

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -995,11 +995,10 @@ impl WgpuPainter {
     }
 
     /// Returns the current scissor rect for testing purposes.
-    #[cfg(test)]
-    #[allow(
-        dead_code,
-        reason = "used by GPU integration tests under `enable-wgpu-tests`"
-    )]
+    ///
+    /// Gated to match its sole consumer (`reset_frame_state_clears_damage_scissor`)
+    /// so it is never dead code in either build configuration.
+    #[cfg(all(test, feature = "enable-wgpu-tests"))]
     pub(crate) fn current_scissor_for_test(&self) -> Option<(u32, u32, u32, u32)> {
         self.current_scissor
     }
@@ -3937,12 +3936,19 @@ impl WgpuPainter {
         let stop_count = stops.len().min(8);
         let current_len = self.current_segment.current_gradient_stops.len();
         if current_len + stop_count > super::effects_pipeline::MAX_GRADIENT_STOPS {
-            tracing::warn!(
-                current_stops = current_len,
-                requested = stop_count,
-                limit = super::effects_pipeline::MAX_GRADIENT_STOPS,
-                "gradient_rect: gradient stop buffer full; dropping linear gradient instance"
-            );
+            // Logged once per process: a >MAX_GRADIENT_STOPS frame would
+            // otherwise spam this for every overflowing instance, every frame.
+            static WARNED: std::sync::atomic::AtomicBool =
+                std::sync::atomic::AtomicBool::new(false);
+            if !WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                tracing::warn!(
+                    current_stops = current_len,
+                    requested = stop_count,
+                    limit = super::effects_pipeline::MAX_GRADIENT_STOPS,
+                    "gradient_rect: gradient stop buffer full; dropping linear gradient \
+                     instance (logged once per process)"
+                );
+            }
             return;
         }
         let stop_offset = current_len as u32;
@@ -4010,12 +4016,17 @@ impl WgpuPainter {
         let stop_count = stops.len().min(8);
         let current_len = self.current_segment.current_gradient_stops.len();
         if current_len + stop_count > super::effects_pipeline::MAX_GRADIENT_STOPS {
-            tracing::warn!(
-                current_stops = current_len,
-                requested = stop_count,
-                limit = super::effects_pipeline::MAX_GRADIENT_STOPS,
-                "radial_gradient_rect: gradient stop buffer full; dropping radial gradient instance"
-            );
+            static WARNED: std::sync::atomic::AtomicBool =
+                std::sync::atomic::AtomicBool::new(false);
+            if !WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                tracing::warn!(
+                    current_stops = current_len,
+                    requested = stop_count,
+                    limit = super::effects_pipeline::MAX_GRADIENT_STOPS,
+                    "radial_gradient_rect: gradient stop buffer full; dropping radial \
+                     gradient instance (logged once per process)"
+                );
+            }
             return;
         }
         let stop_offset = current_len as u32;
@@ -4070,12 +4081,17 @@ impl WgpuPainter {
         let stop_count = stops.len().min(8);
         let current_len = self.current_segment.current_gradient_stops.len();
         if current_len + stop_count > super::effects_pipeline::MAX_GRADIENT_STOPS {
-            tracing::warn!(
-                current_stops = current_len,
-                requested = stop_count,
-                limit = super::effects_pipeline::MAX_GRADIENT_STOPS,
-                "sweep_gradient_rect: gradient stop buffer full; dropping sweep gradient instance"
-            );
+            static WARNED: std::sync::atomic::AtomicBool =
+                std::sync::atomic::AtomicBool::new(false);
+            if !WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                tracing::warn!(
+                    current_stops = current_len,
+                    requested = stop_count,
+                    limit = super::effects_pipeline::MAX_GRADIENT_STOPS,
+                    "sweep_gradient_rect: gradient stop buffer full; dropping sweep \
+                     gradient instance (logged once per process)"
+                );
+            }
             return;
         }
         let stop_offset = current_len as u32;
@@ -4152,12 +4168,56 @@ impl WgpuPainter {
 
 #[cfg(all(test, feature = "enable-wgpu-tests"))]
 mod tests {
+    use std::sync::Arc;
 
-    // Note: Full tests require wgpu device initialization
-    // These would be integration tests with headless rendering
+    use flui_types::{Point, Rect, Size, geometry::px};
 
+    use super::WgpuPainter;
+
+    /// Headless GPU device + queue for painter tests.
+    fn test_device_and_queue() -> (Arc<wgpu::Device>, Arc<wgpu::Queue>) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .expect("a GPU adapter for painter tests");
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("Painter Test Device"),
+            ..Default::default()
+        }))
+        .expect("a GPU device for painter tests");
+        (Arc::new(device), Arc::new(queue))
+    }
+
+    /// Regression for the damage-scissor leak: the painter is reused across
+    /// frames, so `reset_frame_state` MUST clear a per-frame scissor or it
+    /// would clip subsequent frames to a stale damage rect.
     #[test]
-    fn test_transform_stack() {
-        // Would need headless wgpu device for proper testing
+    fn reset_frame_state_clears_damage_scissor() {
+        let (device, queue) = test_device_and_queue();
+        let mut painter = WgpuPainter::with_shared_device(
+            device,
+            queue,
+            wgpu::TextureFormat::Bgra8UnormSrgb,
+            (100, 100),
+        );
+
+        // Simulate the per-frame damage clip the Renderer applies (unpaired).
+        painter.clip_rect(Rect::from_origin_size(
+            Point::ZERO,
+            Size::new(px(50.0), px(50.0)),
+        ));
+        assert!(
+            painter.current_scissor_for_test().is_some(),
+            "clip_rect must set the current scissor"
+        );
+
+        painter.reset_frame_state();
+        assert!(
+            painter.current_scissor_for_test().is_none(),
+            "reset_frame_state must clear the scissor so it cannot leak into the next frame"
+        );
     }
 }

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -964,6 +964,46 @@ impl WgpuPainter {
         self.surface_format
     }
 
+    // ===== Frame Lifecycle =====
+
+    /// Reset all per-frame clip/transform/opacity/layer state to pristine values.
+    ///
+    /// Must be called at the **start** of every frame, before any damage scissor
+    /// or other per-frame setup, so that state from frame N is never visible in
+    /// frame N+1.
+    ///
+    /// Without this call the damage-scissor that was intersected into
+    /// `current_scissor` during a partial-damage frame leaks into the next
+    /// frame, causing full-repaint frames to silently clip to the previous
+    /// damage rect.
+    pub fn reset_frame_state(&mut self) {
+        self.current_scissor = None;
+        self.scissor_stack.clear();
+        self.current_rrect_clip = [0.0; 8];
+        self.rrect_clip_stack.clear();
+        self.current_rsuperellipse_clip = [0.0; 12];
+        self.rsuperellipse_clip_stack.clear();
+        self.current_opacity = 1.0;
+        self.opacity_stack.clear();
+        self.layer_stack.clear();
+        // Identity is the construction-time value (see `new()`: `let current_transform =
+        // glam::Mat4::IDENTITY`). Reset to the same initial value.
+        self.current_transform = glam::Mat4::IDENTITY;
+        self.transform_stack.clear();
+
+        tracing::trace!("WgpuPainter::reset_frame_state: per-frame state cleared");
+    }
+
+    /// Returns the current scissor rect for testing purposes.
+    #[cfg(test)]
+    #[allow(
+        dead_code,
+        reason = "used by GPU integration tests under `enable-wgpu-tests`"
+    )]
+    pub(crate) fn current_scissor_for_test(&self) -> Option<(u32, u32, u32, u32)> {
+        self.current_scissor
+    }
+
     // ===== Offscreen Compositing =====
 
     /// Queue an offscreen-rendered texture for compositing into the main render target.
@@ -3821,7 +3861,19 @@ impl WgpuPainter {
                     composite_bounds
                 );
             } else if has_offscreen_content {
-                // Opacity is ~1.0, no compositing needed — just merge content back
+                // Opacity is ~1.0, no compositing needed — merge content back.
+                // Finalize the parent's pre-save content into the draw order
+                // BEFORE re-integrating the offscreen items so that the parent
+                // content renders beneath the layer subtree (correct Z-order).
+                // Without this flush the parent segment sits in `current_segment`
+                // and is emitted last by `render()`, placing it on top of the
+                // layer — an inversion.  Mirror the mem::replace pattern used by
+                // the opacity < 1.0 branch above.
+                let parent_segment =
+                    std::mem::replace(&mut self.current_segment, DrawSegment::new());
+                if !parent_segment.is_empty() {
+                    self.draw_order.push(DrawItem::Segment(parent_segment));
+                }
                 self.reintegrate_offscreen_content(offscreen_segment, offscreen_order, 1.0);
             }
 
@@ -3883,7 +3935,17 @@ impl WgpuPainter {
 
         // Append gradient stops to global buffer (max 8 per gradient)
         let stop_count = stops.len().min(8);
-        let stop_offset = self.current_segment.current_gradient_stops.len() as u32;
+        let current_len = self.current_segment.current_gradient_stops.len();
+        if current_len + stop_count > super::effects_pipeline::MAX_GRADIENT_STOPS {
+            tracing::warn!(
+                current_stops = current_len,
+                requested = stop_count,
+                limit = super::effects_pipeline::MAX_GRADIENT_STOPS,
+                "gradient_rect: gradient stop buffer full; dropping linear gradient instance"
+            );
+            return;
+        }
+        let stop_offset = current_len as u32;
         self.current_segment
             .current_gradient_stops
             .extend_from_slice(&stops[..stop_count]);
@@ -3946,7 +4008,17 @@ impl WgpuPainter {
 
         // Append gradient stops to global buffer (max 8 per gradient)
         let stop_count = stops.len().min(8);
-        let stop_offset = self.current_segment.current_gradient_stops.len() as u32;
+        let current_len = self.current_segment.current_gradient_stops.len();
+        if current_len + stop_count > super::effects_pipeline::MAX_GRADIENT_STOPS {
+            tracing::warn!(
+                current_stops = current_len,
+                requested = stop_count,
+                limit = super::effects_pipeline::MAX_GRADIENT_STOPS,
+                "radial_gradient_rect: gradient stop buffer full; dropping radial gradient instance"
+            );
+            return;
+        }
+        let stop_offset = current_len as u32;
         self.current_segment
             .current_gradient_stops
             .extend_from_slice(&stops[..stop_count]);
@@ -3996,7 +4068,17 @@ impl WgpuPainter {
 
         // Append gradient stops to global buffer (max 8 per gradient)
         let stop_count = stops.len().min(8);
-        let stop_offset = self.current_segment.current_gradient_stops.len() as u32;
+        let current_len = self.current_segment.current_gradient_stops.len();
+        if current_len + stop_count > super::effects_pipeline::MAX_GRADIENT_STOPS {
+            tracing::warn!(
+                current_stops = current_len,
+                requested = stop_count,
+                limit = super::effects_pipeline::MAX_GRADIENT_STOPS,
+                "sweep_gradient_rect: gradient stop buffer full; dropping sweep gradient instance"
+            );
+            return;
+        }
+        let stop_offset = current_len as u32;
         self.current_segment
             .current_gradient_stops
             .extend_from_slice(&stops[..stop_count]);

--- a/crates/flui-engine/src/wgpu/renderer.rs
+++ b/crates/flui-engine/src/wgpu/renderer.rs
@@ -955,6 +955,11 @@ impl Renderer {
             // vs Flutter.
             backend.bind_surface(&view, &output.texture);
 
+            // Reset per-frame clip/transform/opacity/layer state so that
+            // partial-damage scissors from frame N cannot leak into frame N+1.
+            // This must happen BEFORE the damage clip_rect below.
+            backend.painter_mut().reset_frame_state();
+
             // Apply damage rect as scissor optimization: when only part of the
             // screen changed, limit GPU work to the damaged region.
             // `damage_rect()` returns `None` for full repaint (no scissor needed),

--- a/crates/flui-engine/src/wgpu/text.rs
+++ b/crates/flui-engine/src/wgpu/text.rs
@@ -59,10 +59,19 @@ pub(super) fn collect_styled_spans(
             && !text.is_empty()
         {
             let mut effective = merged.clone();
-            if let Some(style) = &mut effective
-                && let Some(size) = style.font_size
-            {
-                style.font_size = Some(size * f64::from(scale));
+            if let Some(style) = &mut effective {
+                // Scale font_size to device pixels.
+                if let Some(size) = style.font_size {
+                    style.font_size = Some(size * f64::from(scale));
+                }
+                // Scale letter_spacing by the same DPR factor so that
+                // `style_to_attrs_owned` can compute the EM ratio as
+                // `spacing / font_size` using consistent (device-px) units.
+                // Without this scaling, at DPR=2 a 2px spacing on a 16px
+                // font yields 2/32=0.0625 EM instead of the correct 0.125 EM.
+                if let Some(spacing) = style.letter_spacing {
+                    style.letter_spacing = Some(spacing * f64::from(scale));
+                }
             }
             out.push((text.clone(), effective));
         }
@@ -213,8 +222,15 @@ impl RichTextCacheKey {
     /// identically-worded but differently-styled spans collide and reuse the
     /// wrong shaped buffer: family, weight, style, font_size, color,
     /// letter_spacing, height (per-run `Metrics` line height), plus the
-    /// buffer-level `base_font_size` default.
-    fn new(runs: &[(String, Option<TextStyle>)], base_font_size: f32, base_color: Color) -> Self {
+    /// buffer-level `base_font_size` default and the `wrap_width` (which
+    /// controls line-breaking, so two identical runs at different wrap widths
+    /// must produce distinct shaped buffers).
+    fn new(
+        runs: &[(String, Option<TextStyle>)],
+        base_font_size: f32,
+        base_color: Color,
+        wrap_width: Option<f32>,
+    ) -> Self {
         // Variable-length strings (run text, font family) are length-prefixed
         // `<byte-len>:<bytes>` (netstring style) so the concatenation is
         // unambiguous even when the text itself contains the field separators —
@@ -230,6 +246,13 @@ impl RichTextCacheKey {
             u32::from_le_bytes([base_color.r, base_color.g, base_color.b, base_color.a]);
         let mut fingerprint = String::new();
         fingerprint.push_str(&base_font_size.to_bits().to_string());
+        fingerprint.push('\x03');
+        // Encode wrap_width: None → sentinel 0xFFFF_FFFF (never a valid f32
+        // bit pattern for a positive finite width); Some(w) → w.to_bits().
+        // Wrap width changes line-breaking, so two identical runs at different
+        // wrap widths must not collide.
+        let wrap_bits: u32 = wrap_width.map_or(0xFFFF_FFFF, f32::to_bits);
+        fingerprint.push_str(&wrap_bits.to_string());
         fingerprint.push('\x03');
         for (text, style) in runs {
             push_len_prefixed(&mut fingerprint, text);
@@ -536,7 +559,7 @@ impl TextRenderer {
             "TextRenderer::add_rich_text"
         );
 
-        let key = RichTextCacheKey::new(runs, base_font_size, base_color);
+        let key = RichTextCacheKey::new(runs, base_font_size, base_color, wrap_width);
 
         // Borrow `key` on hit to avoid an allocation; move it into the map on miss.
         if let Some(entry) = self.rich_cache.get_mut(&key) {
@@ -934,7 +957,7 @@ mod tests {
             ..Default::default()
         };
         let runs_of = |s: &TextStyle| vec![("text".to_string(), Some(s.clone()))];
-        let key = |s: &TextStyle| RichTextCacheKey::new(&runs_of(s), 14.0, Color::BLACK);
+        let key = |s: &TextStyle| RichTextCacheKey::new(&runs_of(s), 14.0, Color::BLACK, None);
         let baseline = key(&base);
 
         let with_spacing = TextStyle {
@@ -957,8 +980,8 @@ mod tests {
 
         // The buffer-level default size is part of the key too.
         assert_ne!(
-            RichTextCacheKey::new(&runs_of(&base), 14.0, Color::BLACK),
-            RichTextCacheKey::new(&runs_of(&base), 28.0, Color::BLACK),
+            RichTextCacheKey::new(&runs_of(&base), 14.0, Color::BLACK, None),
+            RichTextCacheKey::new(&runs_of(&base), 28.0, Color::BLACK, None),
             "base_font_size must be keyed",
         );
     }
@@ -974,10 +997,111 @@ mod tests {
         let one_run = vec![("a\u{0}b\u{1}c\u{2}".to_string(), None)];
         let two_runs = vec![("a".to_string(), None), ("b\u{1}c\u{2}".to_string(), None)];
         assert_ne!(
-            RichTextCacheKey::new(&one_run, 14.0, Color::BLACK),
-            RichTextCacheKey::new(&two_runs, 14.0, Color::BLACK),
+            RichTextCacheKey::new(&one_run, 14.0, Color::BLACK, None),
+            RichTextCacheKey::new(&two_runs, 14.0, Color::BLACK, None),
             "separator bytes in run text must not collide distinct run sequences",
         );
+    }
+
+    /// `collect_styled_spans` must scale `letter_spacing` by the same DPR
+    /// factor as `font_size` so that `style_to_attrs_owned` computes the
+    /// correct EM ratio at high device-pixel-ratio.
+    ///
+    /// Regression test for P1-3 (cross-crate): at DPR=2 a 16px/2px-spacing
+    /// run was producing 2/32=0.0625 EM instead of 2/16=0.125 EM because
+    /// `font_size` was scaled by DPR but `letter_spacing` was not.
+    #[test]
+    fn collect_styled_spans_scales_letter_spacing_with_dpr() {
+        use flui_types::typography::{TextSpan, TextStyle};
+
+        let style = TextStyle {
+            font_size: Some(16.0),
+            letter_spacing: Some(2.0),
+            ..Default::default()
+        };
+        let span = InlineSpan::Text(std::sync::Arc::new(
+            TextSpan::new("hello").with_style(style),
+        ));
+
+        // DPR = 1: no scaling, both values stay the same
+        let runs_1x = collect_styled_spans(&span, 1.0);
+        assert_eq!(runs_1x.len(), 1);
+        let s1 = runs_1x[0].1.as_ref().expect("style must be present");
+        #[allow(clippy::cast_possible_truncation)] // UI coordinate; f64 value ≤ 300 fits f32 exactly
+        let size_1x = s1.font_size.expect("font_size must be present") as f32;
+        #[allow(clippy::cast_possible_truncation)] // UI coordinate; spacing fits f32
+        let spacing_1x = s1.letter_spacing.expect("letter_spacing must be present") as f32;
+        let em_1x = spacing_1x / size_1x;
+        assert!(
+            (em_1x - 0.125_f32).abs() < 1e-5,
+            "DPR=1 EM ratio must be 2/16=0.125, got {em_1x}"
+        );
+
+        // DPR = 2: both font_size and letter_spacing must be scaled by 2
+        let runs_2x = collect_styled_spans(&span, 2.0);
+        assert_eq!(runs_2x.len(), 1);
+        let s2 = runs_2x[0].1.as_ref().expect("style must be present");
+        #[allow(clippy::cast_possible_truncation)] // UI coordinate; fits f32
+        let size_2x = s2.font_size.expect("font_size must be present") as f32;
+        #[allow(clippy::cast_possible_truncation)] // UI coordinate; fits f32
+        let spacing_2x = s2.letter_spacing.expect("letter_spacing must be present") as f32;
+        let em_2x = spacing_2x / size_2x;
+        assert!(
+            (size_2x - 32.0_f32).abs() < 1e-5,
+            "DPR=2 font_size must be 16×2=32, got {size_2x}"
+        );
+        assert!(
+            (spacing_2x - 4.0_f32).abs() < 1e-5,
+            "DPR=2 letter_spacing must be 2×2=4, got {spacing_2x}"
+        );
+        assert!(
+            (em_2x - 0.125_f32).abs() < 1e-5,
+            "DPR=2 EM ratio must equal DPR=1 ratio (4/32=0.125), got {em_2x}"
+        );
+    }
+
+    /// `wrap_width` must be part of the cache key: the same styled runs at
+    /// different wrap widths produce different line breaks, so they must not
+    /// share a shaped buffer.
+    ///
+    /// Regression test for P0-3: `add_rich_text` was building the key with
+    /// `RichTextCacheKey::new(runs, base_font_size, base_color)` — without
+    /// `wrap_width` — so `Some(200.0)` and `Some(400.0)` and `None` all
+    /// hashed to the same key and the first width's buffer was reused for
+    /// the others, producing wrong line breaks at high DPR.
+    #[test]
+    fn rich_cache_key_distinguishes_wrap_width() {
+        use flui_types::Color;
+
+        use super::RichTextCacheKey;
+
+        let runs = vec![("hello world".to_string(), None)];
+        let key = |w: Option<f32>| RichTextCacheKey::new(&runs, 14.0, Color::BLACK, w);
+
+        let narrow = key(Some(200.0));
+        let wide = key(Some(400.0));
+        let unbounded = key(None);
+
+        assert_ne!(
+            narrow, wide,
+            "different wrap widths must produce distinct keys"
+        );
+        assert_ne!(
+            narrow, unbounded,
+            "Some(w) and None must produce distinct keys"
+        );
+        assert_ne!(
+            wide, unbounded,
+            "Some(w) and None must produce distinct keys"
+        );
+
+        // Identical wrap_width must produce equal keys (idempotence).
+        assert_eq!(
+            key(Some(200.0)),
+            key(Some(200.0)),
+            "identical wrap_width must be stable"
+        );
+        assert_eq!(key(None), key(None), "None must be stable");
     }
 }
 

--- a/crates/flui-engine/src/wgpu/text.rs
+++ b/crates/flui-engine/src/wgpu/text.rs
@@ -1027,7 +1027,8 @@ mod tests {
         let runs_1x = collect_styled_spans(&span, 1.0);
         assert_eq!(runs_1x.len(), 1);
         let s1 = runs_1x[0].1.as_ref().expect("style must be present");
-        #[allow(clippy::cast_possible_truncation)] // UI coordinate; f64 value ≤ 300 fits f32 exactly
+        #[allow(clippy::cast_possible_truncation)]
+        // UI coordinate; f64 value ≤ 300 fits f32 exactly
         let size_1x = s1.font_size.expect("font_size must be present") as f32;
         #[allow(clippy::cast_possible_truncation)] // UI coordinate; spacing fits f32
         let spacing_1x = s1.letter_spacing.expect("letter_spacing must be present") as f32;

--- a/crates/flui-painting/src/text_painter/measure.rs
+++ b/crates/flui-painting/src/text_painter/measure.rs
@@ -360,10 +360,19 @@ pub(crate) fn collect_styled_spans(
             && !text.is_empty()
         {
             let mut effective = merged.clone();
-            if let Some(style) = &mut effective
-                && let Some(size) = style.font_size
-            {
-                style.font_size = Some(size * f64::from(scale));
+            if let Some(style) = &mut effective {
+                // Scale font_size to device pixels.
+                if let Some(size) = style.font_size {
+                    style.font_size = Some(size * f64::from(scale));
+                }
+                // Scale letter_spacing by the same DPR factor so that
+                // `from_spans` can compute the EM ratio as
+                // `spacing / font_size` using consistent (device-px) units.
+                // Without this scaling, at DPR=2 a 2px spacing on a 16px
+                // font yields 2/32=0.0625 EM instead of the correct 0.125 EM.
+                if let Some(spacing) = style.letter_spacing {
+                    style.letter_spacing = Some(spacing * f64::from(scale));
+                }
             }
             out.push((text.clone(), effective));
         }


### PR DESCRIPTION
A round-2 deep CORRECTNESS audit of `flui-engine` (the areas the first audit, #217, under-covered: the painter state machine, offscreen/effects, text shaping, tessellation/caches), run as a multi-agent fan-out with per-finding adversarial refutation. It surfaced 6 verified bugs — all genuine wrong-output / crash / cache-collision defects, not style.

## Bugs fixed

**P0 — gradient-stops GPU buffer overflow** (`painter.rs`, `effects_pipeline.rs`)
The stops buffer is fixed at `MAX_GRADIENT_STOPS = 800` but accumulation was unbounded; a frame with >100 gradients overflowed `write_buffer` (wgpu validation panic) and left `stop_offset` pointing past the buffer (garbage colors). Now a shared const bounds both the buffer and the per-segment accumulation, and any gradient instance that would exceed the cap is dropped (skipped, never half-pushed) with a once-per-process warn.

**P0 — `render_blur(sigma=0)` blurred instead of passing through** (`offscreen.rs`)
`((0/2).ceil()).clamp(1,5)` forced one Kawase pass at sigma 0, softening content that should be untouched. Now early-returns a full-extent `copy_texture_to_texture` passthrough for `sigma <= 0` (pool textures already carry `COPY_SRC | COPY_DST`).

**P0 — `wrap_width` missing from `RichTextCacheKey`** (`text.rs`)
The same runs+style at a different wrap width hit the cache and reused a buffer shaped with the wrong line breaks. `wrap_width` is now part of the key fingerprint. +regression test.

**P1 — damage scissor leaked across frames** (`renderer.rs`, `painter.rs`)
The per-frame damage `clip_rect` was unpaired and the reused painter never reset its scissor/clip/transform state, so a stale damage rect silently clipped later frames (and `clip_rect` intersects, so two partial frames compounded). Added `WgpuPainter::reset_frame_state()`, called at frame start before the damage clip. +GPU regression test.

**P1 — z-order inversion in `restore_layer`** (`painter.rs`)
The ~1.0-opacity branch reintegrated offscreen content without first finalizing the restored parent segment (the `<1.0` branch always did), so pre-save sibling content painted on top of a filtered layer (reachable via every image-filter / identity color-filter). Mirrored the segment flush before reintegrate.

**P1 — `letter_spacing` EM conversion used the DPR-prescaled font size** (`flui-engine/text.rs` + `flui-painting/text_painter/measure.rs`)
At DPR=2 a 2px spacing on a 16px font gave 2/32 EM instead of 2/16 → wrong glyph advances at high DPR. Both paint paths now scale `letter_spacing` by the same factor as `font_size`. +regression test. (`flui-painting/text_layout/layout.rs` uses unscaled sizes — already correct, left untouched; the audit's claim that it was also buggy was verified false against the code.)

## Review
ce-kieran adversarial review confirmed all 6 fixes correct; its two P2s were addressed in the second commit: the gradient-drop warn is now rate-limited (one-shot per process), and the `reset_frame_state` fix ships with a GPU regression test (replacing a dead test-only accessor with a real consumer).

## Gates (verified)
`clippy --all-targets -D warnings` **with and without** `--features enable-wgpu-tests` · `check --release` 0 warnings · nextest 268/268 (flui-engine + flui-painting) · GPU suite 128/128 (run serially — GPU tests flake in parallel on DX12 driver contention, a known pattern) · `cargo check --target wasm32-unknown-unknown` · `cargo doc`.

## Notes
- The pixel-level fixes (blur passthrough, z-order, damage scissor) are covered by review + unit/state tests; a full pixel-readback harness is out of scope. The cache-key and letter_spacing fixes have direct unit regression tests; reset_frame_state has a GPU state test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)