### PR TITLE
fix(engine): HiDPI offscreen — backdrop-filter + shader-mask in device space (round-5c)

### DIFF
--- a/crates/flui-engine/src/wgpu/backend.rs
+++ b/crates/flui-engine/src/wgpu/backend.rs
@@ -5,7 +5,7 @@
 
 use flui_painting::{BlendMode, DisplayListCore, Paint, PointMode};
 use flui_types::{
-    geometry::{Matrix4, Offset, Pixels, Point, RRect, Rect, Transform, px},
+    geometry::{Matrix4, Offset, Pixels, Point, RRect, Rect, Size, Transform, px},
     painting::{Image, Path},
     styling::Color,
     typography::TextStyle,
@@ -625,10 +625,31 @@ impl CommandRenderer for Backend<'_> {
     ) {
         // Try GPU shader mask pipeline
         if let Some(offscreen_arc) = self.offscreen.clone() {
+            // The live device-pixel ratio rides in the painter's current
+            // transform: the `RenderView` root pushes `scale(dpr)` and the paint
+            // walk accumulates it into the CTM. The `_transform` argument is
+            // identity on the paint path, so it is NOT the DPR source — read the
+            // active CTM here, before `reset_frame_state` below clears it.
+            //
+            // Sizing the offscreen child/result textures from the logical
+            // `bounds` would allocate the masked layer at half resolution on a
+            // 2x display and composite it at half coordinates / quarter area
+            // (Flutter/Impeller `ShaderMaskLayer::Paint` runs the child + masked
+            // saveLayer under the accumulated device matrix, so the offscreen is
+            // device-resolution and composited in device space).
+            let transform = self.painter.current_transform_matrix();
+            let dpr_scale = self.painter.current_max_scale().max(1.0);
+
+            // Device-resolution offscreen dimensions: logical extent × DPR.
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-            let width = bounds.width().0.max(1.0) as u32;
+            let dev_width = (bounds.width().0 * dpr_scale).round().max(1.0) as u32;
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-            let height = bounds.height().0.max(1.0) as u32;
+            let dev_height = (bounds.height().0 * dpr_scale).round().max(1.0) as u32;
+
+            // Composite rect in device space — mirrors Path B (backdrop filter):
+            // map the logical bounds through the CTM rather than scaling by DPR
+            // alone, so any translation in the CTM is honored too.
+            let device_bounds = transform.transform_rect(&bounds);
 
             // Step 1: Get GPU resources from offscreen renderer
             let (device, queue, format, child_tex) = {
@@ -636,7 +657,9 @@ impl CommandRenderer for Backend<'_> {
                 let device = Arc::clone(offscreen.device());
                 let queue = Arc::clone(offscreen.queue());
                 let format = offscreen.surface_format();
-                let child_tex = offscreen.texture_pool().acquire(width, height, format);
+                let child_tex = offscreen
+                    .texture_pool()
+                    .acquire(dev_width, dev_height, format);
                 (device, queue, format, child_tex)
             };
             // Lock released here
@@ -644,7 +667,14 @@ impl CommandRenderer for Backend<'_> {
             // Step 2: Get or create cached offscreen painter (avoids per-call allocation)
             // Ensure the cache is populated (creates or resizes as needed), then take
             // it out temporarily so we can wrap it in a Backend for command dispatch.
-            let _ = self.get_or_create_offscreen_painter(&device, &queue, format, (width, height));
+            // The cached painter's render target is the device-sized child texture,
+            // so it must be sized at device resolution too.
+            let _ = self.get_or_create_offscreen_painter(
+                &device,
+                &queue,
+                format,
+                (dev_width, dev_height),
+            );
             let mut temp_painter = self
                 .offscreen_painter
                 .take()
@@ -657,6 +687,13 @@ impl CommandRenderer for Backend<'_> {
                 // causing the second ShaderMask's child content to be silently
                 // clipped to the prior mask's scissor region.
                 temp_painter.reset_frame_state();
+                // After reset the CTM is identity. The child DisplayList carries
+                // logical coordinates, so scale by the DPR to bake it into the
+                // device-sized offscreen — without this the child renders into
+                // the top-left logical quadrant of the device texture.
+                if (dpr_scale - 1.0).abs() > f32::EPSILON {
+                    temp_painter.scale(dpr_scale, dpr_scale);
+                }
                 let mut temp_backend = Backend::new(temp_painter);
                 for command in child.commands() {
                     dispatch_command(command, &mut temp_backend);
@@ -696,22 +733,36 @@ impl CommandRenderer for Backend<'_> {
             // Put the cached painter back for reuse
             self.offscreen_painter = Some(temp_painter);
 
-            // Step 5: Apply shader mask via GPU pipeline
+            // Step 5: Apply shader mask via GPU pipeline. The result texture is
+            // sized at device resolution; `bounds` stays logical so the shader's
+            // gradient-endpoint normalization (scale-invariant) lands correctly.
+            let result_size = Size::new(Pixels(dev_width as f32), Pixels(dev_height as f32));
             let masked_texture = {
                 let mut offscreen = offscreen_arc.lock();
-                let result =
-                    offscreen.render_masked(bounds, shader, blend_mode, child_tex.texture());
+                let result = offscreen.render_masked(
+                    bounds,
+                    result_size,
+                    shader,
+                    blend_mode,
+                    child_tex.texture(),
+                );
                 result.into_texture()
             };
 
-            // Step 6: Queue masked result for compositing on main target
-            self.painter.queue_offscreen_result(masked_texture, bounds);
+            // Step 6: Queue masked result for compositing on main target at the
+            // device-space rect (logical `bounds` would composite at half
+            // scale/position on a HiDPI frame).
+            self.painter
+                .queue_offscreen_result(masked_texture, device_bounds);
 
             tracing::debug!(
-                "ShaderMask GPU pipeline complete: bounds={:?}, child_size={}x{}",
+                "ShaderMask GPU pipeline complete: bounds={:?}, device_bounds={:?}, \
+                 dpr_scale={}, child_size={}x{}",
                 bounds,
-                width,
-                height
+                device_bounds,
+                dpr_scale,
+                dev_width,
+                dev_height
             );
             return;
         }
@@ -1565,5 +1616,208 @@ impl LayerStateStack for Backend<'_> {
     fn pop_image_filter(&mut self) {
         self.flush_active_transform();
         self.painter.restore_layer();
+    }
+}
+
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+mod tests {
+    use super::*;
+    use crate::traits::CommandRenderer;
+
+    /// Acquire a real device/queue. Returns `None` when no GPU adapter exists
+    /// (CI without a GPU), so the test skips gracefully.
+    fn test_device_and_queue() -> Option<(Arc<wgpu::Device>, Arc<wgpu::Queue>)> {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .ok()?;
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("ShaderMask HiDPI Test Device"),
+            ..Default::default()
+        }))
+        .ok()?;
+        Some((Arc::new(device), Arc::new(queue)))
+    }
+
+    /// BUG 2 (HiDPI shader mask): the offscreen child/result textures must be
+    /// allocated at DEVICE resolution (`bounds * dpr`) and the masked result
+    /// composited at the device-space rect, sourcing the DPR from the live
+    /// painter CTM (not the identity `_transform` paint-path argument).
+    ///
+    /// Under a `scale(2)` CTM a `ShaderMask` over logical bounds (0,0,100,100)
+    /// must allocate a 200x200 offscreen and composite at device (0,0,200,200).
+    /// Red before the fix: 100x100 offscreen composited at (0,0,100,100)
+    /// (half resolution, quarter area).
+    #[test]
+    fn shader_mask_offscreen_is_device_sized_under_dpr() {
+        use super::super::offscreen::OffscreenRenderer;
+        use super::super::painter::WgpuPainter;
+
+        let Some((device, queue)) = test_device_and_queue() else {
+            return; // No GPU here; skip gracefully.
+        };
+
+        let format = wgpu::TextureFormat::Bgra8Unorm;
+
+        let offscreen = Arc::new(parking_lot::Mutex::new(OffscreenRenderer::new(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            format,
+        )));
+        let painter = WgpuPainter::with_shared_device(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            format,
+            (800, 800),
+        );
+        let mut backend = Backend::with_offscreen(painter, Arc::clone(&offscreen));
+
+        // Simulate the `RenderView` DPR root transform on the live CTM.
+        backend.painter_mut().scale(2.0, 2.0);
+
+        // Child display list: a single 100x100 rect, built via the public Canvas.
+        let mut canvas = flui_painting::Canvas::new();
+        canvas.draw_rect(
+            Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0)),
+            &Paint::fill(Color::WHITE),
+        );
+        let child = canvas.finish();
+
+        let shader = flui_painting::Shader::solid(Color::WHITE);
+        let bounds = Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0));
+
+        // `_transform` is identity on the paint path — the DPR comes from the CTM.
+        backend.render_shader_mask(
+            &child,
+            &shader,
+            bounds,
+            BlendMode::SrcOver,
+            &Matrix4::IDENTITY,
+        );
+
+        let results = backend.painter().offscreen_results_for_test();
+        assert_eq!(
+            results.len(),
+            1,
+            "shader mask must queue exactly one offscreen composite"
+        );
+        let (composite_rect, tex_w, tex_h) = results[0];
+
+        // Result texture allocated at device resolution.
+        assert_eq!(
+            (tex_w, tex_h),
+            (200, 200),
+            "shader-mask offscreen must be device-sized (200x200) under DPR=2; \
+             got {tex_w}x{tex_h} (100x100 means the CTM scale was dropped)"
+        );
+
+        // Composited at the device-space rect (0,0,200,200).
+        assert!(
+            composite_rect.left().0.abs() < 0.5
+                && composite_rect.top().0.abs() < 0.5
+                && (composite_rect.right().0 - 200.0).abs() < 0.5
+                && (composite_rect.bottom().0 - 200.0).abs() < 0.5,
+            "shader-mask composite rect must span device (0,0,200,200) under DPR=2; \
+             got {composite_rect:?}"
+        );
+    }
+
+    /// Locks the gradient-uniform / device-sizing split under HiDPI.
+    ///
+    /// `render_masked` receives `child_bounds` in LOGICAL pixels (for gradient
+    /// normalization) but `result_size` in DEVICE pixels. A regression that passes
+    /// device-sized bounds as `child_bounds` would misplace gradient stop positions;
+    /// a regression that passes logical size as `result_size` would under-allocate.
+    ///
+    /// This test uses a LINEAR-GRADIENT shader (not solid) to exercise the
+    /// gradient-uniform branch. Under DPR=2 over logical bounds (0,0,100,100):
+    /// - result texture must be 200×200 (device-sized)
+    /// - composite rect must cover device (0,0,200,200)
+    /// - the dispatch must not panic (gradient uniforms stay in logical space)
+    ///
+    /// Red before the fix: result texture is 100×100 (logical size fed as
+    /// `result_size`) and composite rect is (0,0,100,100).
+    #[test]
+    fn shader_mask_gradient_is_device_sized_under_dpr() {
+        use super::super::offscreen::OffscreenRenderer;
+        use super::super::painter::WgpuPainter;
+        use flui_types::painting::TileMode;
+
+        let Some((device, queue)) = test_device_and_queue() else {
+            return; // No GPU here; skip gracefully.
+        };
+
+        let format = wgpu::TextureFormat::Bgra8Unorm;
+
+        let offscreen = Arc::new(parking_lot::Mutex::new(OffscreenRenderer::new(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            format,
+        )));
+        let painter = WgpuPainter::with_shared_device(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            format,
+            (800, 800),
+        );
+        let mut backend = Backend::with_offscreen(painter, Arc::clone(&offscreen));
+
+        // Simulate DPR=2 on the live CTM.
+        backend.painter_mut().scale(2.0, 2.0);
+
+        // Child display list: a white rect matching the logical mask bounds.
+        let mut canvas = flui_painting::Canvas::new();
+        let bounds = Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0));
+        canvas.draw_rect(bounds, &Paint::fill(Color::WHITE));
+        let child = canvas.finish();
+
+        // Linear gradient: black-to-white left-to-right across the logical bounds.
+        // `to_mask_uniform_data` normalizes endpoints as (endpoint - origin) / extent;
+        // both endpoints and `child_bounds` are logical, so normalization is correct.
+        let shader = flui_painting::Shader::linear_gradient(
+            Offset::new(px(0.0), px(0.0)),
+            Offset::new(px(100.0), px(0.0)),
+            vec![Color::BLACK, Color::WHITE],
+            None,
+            TileMode::Clamp,
+        );
+
+        backend.render_shader_mask(
+            &child,
+            &shader,
+            bounds,
+            BlendMode::SrcOver,
+            &Matrix4::IDENTITY,
+        );
+
+        let results = backend.painter().offscreen_results_for_test();
+        assert_eq!(
+            results.len(),
+            1,
+            "gradient shader mask must queue exactly one offscreen composite"
+        );
+        let (composite_rect, tex_w, tex_h) = results[0];
+
+        // Result texture must be device-sized: 200×200 under DPR=2.
+        assert_eq!(
+            (tex_w, tex_h),
+            (200, 200),
+            "gradient shader-mask offscreen must be device-sized (200×200) under DPR=2; \
+             got {tex_w}×{tex_h} — logical sizing means the CTM scale was ignored for \
+             result_size"
+        );
+
+        // Composite must cover device (0,0,200,200).
+        assert!(
+            composite_rect.left().0.abs() < 0.5
+                && composite_rect.top().0.abs() < 0.5
+                && (composite_rect.right().0 - 200.0).abs() < 0.5
+                && (composite_rect.bottom().0 - 200.0).abs() < 0.5,
+            "gradient shader-mask composite rect must be (0,0,200,200) under DPR=2; \
+             got {composite_rect:?}"
+        );
     }
 }

--- a/crates/flui-engine/src/wgpu/backend.rs
+++ b/crates/flui-engine/src/wgpu/backend.rs
@@ -623,6 +623,16 @@ impl CommandRenderer for Backend<'_> {
         blend_mode: BlendMode,
         _transform: &Matrix4,
     ) {
+        // Flush any deferred-coalesced transform from the prior command before
+        // reading the CTM. The Backend defers transforms lazily (see
+        // `with_transform` / `active_transform`); without this call
+        // `current_transform_matrix()` / `current_max_scale()` below would read
+        // the PRIOR command's unrelated transform and size/position the offscreen
+        // from stale state. Every other method that reads painter transform state
+        // calls `flush_active_transform()` first (push_opacity, push_color_filter,
+        // push_image_filter, all LayerStateStack impls); shader-mask must match.
+        self.flush_active_transform();
+
         // Try GPU shader mask pipeline
         if let Some(offscreen_arc) = self.offscreen.clone() {
             // The live device-pixel ratio rides in the painter's current
@@ -1818,6 +1828,119 @@ mod tests {
                 && (composite_rect.bottom().0 - 200.0).abs() < 0.5,
             "gradient shader-mask composite rect must be (0,0,200,200) under DPR=2; \
              got {composite_rect:?}"
+        );
+    }
+
+    /// Locks P2 #1: `render_shader_mask` must flush the backend's deferred
+    /// transform coalescing state before reading the painter CTM.
+    ///
+    /// The Backend's `with_transform` mechanism batches consecutive same-matrix
+    /// draw calls by leaving a `save()+apply` on the painter stack between calls,
+    /// clearing it lazily on the next transform change. If `render_shader_mask`
+    /// reads `current_transform_matrix()` / `current_max_scale()` WITHOUT first
+    /// calling `flush_active_transform()`, it reads the PRIOR command's transform
+    /// stacked on top of the DPR root, and sizes/positions the offscreen from
+    /// stale state.
+    ///
+    /// Scenario:
+    ///   1. Main painter CTM = scale(2) (DPR root, pushed by the test before
+    ///      any commands, simulating RenderView).
+    ///   2. `render_rect` is called with a non-identity per-command transform
+    ///      `scale(3, 3, 1)`. `with_transform` leaves `active_transform =
+    ///      Some(scale3)` on the stack (the painter's current transform matrix
+    ///      is now scale(2)*scale(3) = scale(6) in the lazy-save layer).
+    ///   3. `render_shader_mask` is called for bounds (0,0,100,100) under the
+    ///      DPR=2 root CTM (no additional per-mask transform, _transform=identity).
+    ///
+    ///   Without the flush: `current_max_scale()` returns ≈6.0 (scale(6) from
+    ///   the still-active rect transform), device_size ≈ 600, composite rect ≈
+    ///   (0,0,600,600).
+    ///   With the flush (fix): `flush_active_transform()` restores the lazy save,
+    ///   `current_max_scale()` returns ≈2.0 (the DPR root only), device_size =
+    ///   200, composite rect = (0,0,200,200).
+    ///
+    /// Red-before: tex 600×600, composite (0,0,600,600).
+    /// Green-after: tex 200×200, composite (0,0,200,200).
+    #[test]
+    fn shader_mask_uses_own_transform_not_prior_command() {
+        use super::super::offscreen::OffscreenRenderer;
+        use super::super::painter::WgpuPainter;
+
+        let Some((device, queue)) = test_device_and_queue() else {
+            return; // No GPU here; skip gracefully.
+        };
+
+        let format = wgpu::TextureFormat::Bgra8Unorm;
+
+        let offscreen = Arc::new(parking_lot::Mutex::new(OffscreenRenderer::new(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            format,
+        )));
+        let painter = WgpuPainter::with_shared_device(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            format,
+            (800, 800),
+        );
+        let mut backend = Backend::with_offscreen(painter, Arc::clone(&offscreen));
+
+        // Step 1: push the DPR root scale(2) into the main painter CTM — this
+        // happens before any command dispatch in a real frame.
+        backend.painter_mut().scale(2.0, 2.0);
+
+        // Step 2: dispatch a rect with a non-identity per-command transform. This
+        // calls `with_transform(scale3_matrix, …)` which leaves
+        // `active_transform = Some(scale3)` and the painter's CTM temporarily at
+        // scale(2)*scale(3) = scale(6).
+        let scale3_matrix = Matrix4::scaling(3.0, 3.0, 1.0);
+        let prior_rect_bounds = Rect::from_xywh(px(0.0), px(0.0), px(10.0), px(10.0));
+        backend.render_rect(prior_rect_bounds, &Paint::fill(Color::RED), &scale3_matrix);
+
+        // Step 3: build the ShaderMask child display list and issue the mask
+        // under the DPR=2 root CTM (_transform = identity, as on the paint path).
+        let mut canvas = flui_painting::Canvas::new();
+        let bounds = Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0));
+        canvas.draw_rect(bounds, &Paint::fill(Color::WHITE));
+        let child = canvas.finish();
+        let shader = flui_painting::Shader::solid(Color::WHITE);
+
+        backend.render_shader_mask(
+            &child,
+            &shader,
+            bounds,
+            BlendMode::SrcOver,
+            &Matrix4::IDENTITY,
+        );
+
+        let results = backend.painter().offscreen_results_for_test();
+        assert_eq!(
+            results.len(),
+            1,
+            "shader mask must queue exactly one offscreen composite"
+        );
+        let (composite_rect, tex_w, tex_h) = results[0];
+
+        // Must be sized at DPR=2 (200×200), NOT at scale(2)*scale(3)=scale(6)
+        // (600×600) which would be the result if the deferred transform was not
+        // flushed before reading the CTM.
+        assert_eq!(
+            (tex_w, tex_h),
+            (200, 200),
+            "shader-mask offscreen must be 200×200 (DPR=2 only); got {tex_w}×{tex_h} — \
+             600×600 indicates the prior rect's deferred scale(3) was not flushed \
+             before the mask read the CTM (stale active_transform leak)"
+        );
+
+        // Composite rect must also derive from the DPR=2 CTM, not scale(6).
+        assert!(
+            composite_rect.left().0.abs() < 0.5
+                && composite_rect.top().0.abs() < 0.5
+                && (composite_rect.right().0 - 200.0).abs() < 0.5
+                && (composite_rect.bottom().0 - 200.0).abs() < 0.5,
+            "shader-mask composite rect must be (0,0,200,200) under DPR=2; \
+             got {composite_rect:?} — (0,0,600,600) indicates stale prior-rect \
+             transform leaked into the mask CTM read"
         );
     }
 }

--- a/crates/flui-engine/src/wgpu/offscreen.rs
+++ b/crates/flui-engine/src/wgpu/offscreen.rs
@@ -287,10 +287,19 @@ impl OffscreenRenderer {
     ///
     /// # Arguments
     ///
-    /// * `child_bounds` - Bounding rectangle of child content
+    /// * `child_bounds` - Bounding rectangle of child content, in **logical**
+    ///   pixels. Used only to normalize the shader's gradient endpoints into the
+    ///   0..1 range (`(endpoint - origin) / extent`); that normalization is
+    ///   scale-invariant, so the shader's endpoints and these bounds must share
+    ///   one coordinate space (both logical) for the gradient to land correctly.
+    /// * `result_size` - Size of the masked result texture, in **device**
+    ///   pixels (`child_bounds` extent × device-pixel-ratio). The fullscreen
+    ///   quad covers the whole result regardless of its pixel dimensions, so
+    ///   sizing it at device resolution keeps a HiDPI masked layer crisp instead
+    ///   of allocating it at half resolution and upscaling on composite.
     /// * `shader` - Shader (gradient, solid, etc.)
     /// * `blend_mode` - Blend mode for compositing
-    /// * `child_texture` - Pre-rendered child content texture
+    /// * `child_texture` - Pre-rendered child content texture (device-sized)
     ///
     /// # Returns
     ///
@@ -306,6 +315,7 @@ impl OffscreenRenderer {
     pub fn render_masked(
         &mut self,
         child_bounds: Rect<Pixels>,
+        result_size: Size<Pixels>,
         shader: &Shader,
         blend_mode: BlendMode,
         child_texture: &wgpu::Texture,
@@ -314,16 +324,17 @@ impl OffscreenRenderer {
         let shader_type = ShaderType::from_shader(shader);
 
         tracing::trace!(
-            "Rendering shader mask: {:?}, bounds: {:?}",
+            "Rendering shader mask: {:?}, bounds: {:?}, result_size: {:?}",
             shader_type,
-            child_bounds
+            child_bounds,
+            result_size
         );
 
-        // Acquire offscreen texture for masked result
-        let size = Size::new(child_bounds.width(), child_bounds.height());
+        // Acquire offscreen texture for masked result, sized at device
+        // resolution so a HiDPI mask is not allocated at half resolution.
         let texture = self
             .texture_pool
-            .acquire_from_size(size, self.surface_format);
+            .acquire_from_size(result_size, self.surface_format);
 
         // Ensure pipeline exists (Arc allows using after mutable borrow ends)
         let _ = self.get_or_create_pipeline(shader_type);
@@ -433,8 +444,8 @@ impl OffscreenRenderer {
         tracing::trace!(
             "Shader mask rendering complete: {:?}, size: {}x{}",
             shader_type,
-            size.width,
-            size.height
+            result_size.width,
+            result_size.height
         );
 
         MaskedRenderResult {

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -1149,6 +1149,26 @@ impl WgpuPainter {
         self.tessellator.set_max_scale(scale);
     }
 
+    /// The composite `bounds` and backing texture pixel size of every pending
+    /// [`DrawItem::OffscreenTexture`] in the draw order, in draw order. Used by
+    /// the HiDPI shader-mask / backdrop regression tests to assert an offscreen
+    /// result is allocated at device resolution (`extent * dpr`) and composited
+    /// at the device-space rect (`bounds * dpr`), not the logical rect.
+    ///
+    /// Returns `(bounds, texture_width, texture_height)`.
+    #[cfg(all(test, feature = "enable-wgpu-tests"))]
+    pub(crate) fn offscreen_results_for_test(&self) -> Vec<(Rect<Pixels>, u32, u32)> {
+        self.draw_order
+            .iter()
+            .filter_map(|item| match item {
+                DrawItem::OffscreenTexture(p) => {
+                    Some((p.bounds, p.texture.width(), p.texture.height()))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
     // ===== Offscreen Compositing =====
 
     /// Queue an offscreen-rendered texture for compositing into the main render target.
@@ -1634,11 +1654,38 @@ impl WgpuPainter {
     /// device-space chord-error budget by this so curves are subdivided finely
     /// enough at the magnification they will be baked and drawn at — see
     /// [`Tessellator::set_max_scale`](super::tessellator::Tessellator::set_max_scale).
-    fn current_max_scale(&self) -> f32 {
+    ///
+    /// Also consulted by `Backend::render_shader_mask` to size the shader-mask
+    /// offscreen at device resolution: on a HiDPI frame the live device-pixel
+    /// ratio rides in the painter CTM (the `RenderView` root pushes
+    /// `scale(dpr)`), so the offscreen child/result textures must be allocated
+    /// `bounds * dpr` to avoid rendering the masked layer at half resolution.
+    pub(crate) fn current_max_scale(&self) -> f32 {
         let m = self.current_transform;
         let col_x = (m.x_axis.x * m.x_axis.x + m.x_axis.y * m.x_axis.y).sqrt();
         let col_y = (m.y_axis.x * m.y_axis.x + m.y_axis.y * m.y_axis.y).sqrt();
         col_x.max(col_y)
+    }
+
+    /// The accumulated current transform (CTM) as a [`flui_types::Matrix4`].
+    ///
+    /// The painter stores its CTM as a `glam::Mat4`; both `glam::Mat4` and
+    /// `Matrix4` are column-major `[f32; 16]`, so this is a direct reinterpret
+    /// of the 16 floats.
+    ///
+    /// Consumed by `Renderer::handle_backdrop_filter` (layer-tree "Path A") to
+    /// map a layer's local-space `bounds` into device space before sampling /
+    /// compositing. The layer walk pushes the `RenderView` root `scale(dpr)`
+    /// (and every intervening `TransformLayer`/`OffsetLayer`) onto this CTM via
+    /// `push_transform`/`push_offset`, so reading it here is the same source of
+    /// truth the display-list backdrop path ("Path B") receives as its
+    /// `transform` argument.
+    pub(crate) fn current_transform_matrix(&self) -> flui_types::Matrix4 {
+        let c = self.current_transform.to_cols_array();
+        flui_types::Matrix4::new(
+            c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7], c[8], c[9], c[10], c[11], c[12], c[13],
+            c[14], c[15],
+        )
     }
 
     /// Prime the tessellator with the current world scale so its curve-flattening

--- a/crates/flui-engine/src/wgpu/renderer.rs
+++ b/crates/flui-engine/src/wgpu/renderer.rs
@@ -1165,6 +1165,7 @@ impl Renderer {
         surface_view: &wgpu::TextureView,
         occlusion: &mut OcclusionTracker,
     ) {
+        use flui_types::geometry::{Pixels, Rect};
         use flui_types::painting::ImageFilter;
 
         let bounds = bf_layer.bounds();
@@ -1305,13 +1306,22 @@ impl Renderer {
                 offscreen.render_blur(&blur_input, sigma)
             };
 
-            // 5. Queue the blurred result for compositing at the same
-            //    device-space rect it was sampled from — using `bounds`
-            //    (logical) here would lay the blur down at half scale/position
-            //    on a HiDPI frame.
+            // 5. Queue the blurred result for compositing at the CLAMPED device
+            //    rect — the copy source origin is (x,y) and extent (w,h), so the
+            //    composite rect must match exactly. `device_rect` is unclamped
+            //    (may extend outside the surface for a backdrop crossing the edge),
+            //    meaning the smaller blurred texture would be stretched/misaligned
+            //    across the larger unclamped rect. Build the composite rect from
+            //    the same clamped u32 values used for the copy.
+            let clamped_composite_rect = Rect::from_xywh(
+                Pixels(x as f32),
+                Pixels(y as f32),
+                Pixels(w as f32),
+                Pixels(h as f32),
+            );
             backend
                 .painter_mut()
-                .queue_offscreen_result(blurred, device_rect);
+                .queue_offscreen_result(blurred, clamped_composite_rect);
         } else {
             // No offscreen renderer available — just submit the flush
             ctx.queue.submit(std::iter::once(flush_encoder.finish()));
@@ -1728,6 +1738,157 @@ mod tests {
         assert!(
             (composite_rect.height().0 - 400.0).abs() < 0.5,
             "composite rect height must be ~400.0; got {:.2}",
+            composite_rect.height().0
+        );
+    }
+
+    /// Locks P2 #2: `handle_backdrop_filter` must composite the blurred texture
+    /// at the CLAMPED device rect, not the unclamped `device_rect`.
+    ///
+    /// When a backdrop layer extends beyond the window boundary, the copy source
+    /// and blur texture are sized at the CLAMPED extent (the portion that fits
+    /// on screen). Before this fix, `queue_offscreen_result` received the
+    /// unclamped `device_rect` — the blurred texture (w×h) would be stretched
+    /// or misaligned across the larger rect that extends off-screen.
+    ///
+    /// Scenario: surface = 400×400, CTM = identity (DPR=1 for simplicity —
+    /// device coords == logical coords). Backdrop layer at logical
+    /// (350, 350, 200, 200) i.e. corners (350,350)→(550,550).
+    /// Clamped: x=350, y=350, right=400, bottom=400 → w=50, h=50.
+    ///
+    /// Red-before: composite rect is (350,350,200,200) — the unclamped device
+    ///   rect width/height (200,200 from the layer bounds), not the clamped (50,50).
+    /// Green-after: composite rect is (350,350,50,50) — matches copy origin/extent.
+    #[test]
+    fn backdrop_filter_path_a_composites_clamped_rect_when_partially_offscreen() {
+        use super::super::backend::Backend;
+        use super::super::offscreen::OffscreenRenderer;
+        use super::super::painter::WgpuPainter;
+        use flui_layer::{BackdropFilterLayer, Layer, LayerTree};
+        use flui_types::{
+            geometry::{Rect, px},
+            painting::ImageFilter,
+        };
+
+        let Some((device, queue)) = test_device_and_queue() else {
+            return;
+        };
+
+        let format = wgpu::TextureFormat::Bgra8Unorm;
+
+        // Small surface so the layer extends off the right/bottom edge.
+        let surface_w = 400u32;
+        let surface_h = 400u32;
+
+        let surface_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Backdrop Clamp Test Surface"),
+            size: wgpu::Extent3d {
+                width: surface_w,
+                height: surface_h,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let surface_view = surface_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let offscreen = Arc::new(parking_lot::Mutex::new(OffscreenRenderer::new(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            format,
+        )));
+        let painter = WgpuPainter::with_shared_device(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            format,
+            (surface_w, surface_h),
+        );
+        let mut backend = Backend::with_offscreen(painter, Arc::clone(&offscreen));
+
+        // CTM is identity (scale=1, DPR=1): device coords == logical coords.
+        // Backdrop at (350,350,200,200) — corners (350,350)→(550,550).
+        // Clamped to 400×400 surface: x=350,y=350,right=400,bottom=400 →
+        // w=50, h=50.
+        let mut tree = LayerTree::new();
+        let logical_bounds = Rect::from_xywh(px(350.0), px(350.0), px(200.0), px(200.0));
+        let bf = BackdropFilterLayer::new(
+            ImageFilter::blur(5.0),
+            flui_types::painting::BlendMode::SrcOver,
+            logical_bounds,
+        );
+        let id = tree.insert(Layer::BackdropFilter(bf));
+        tree.set_root(Some(id));
+        let node = tree.get(id).expect("inserted backdrop node");
+        let Layer::BackdropFilter(bf_layer) = node.layer() else {
+            unreachable!("inserted a BackdropFilter layer");
+        };
+
+        let ctx = RenderContext {
+            device: Arc::clone(&device),
+            queue: Arc::clone(&queue),
+            surface_format: format,
+            supports_copy_src: true,
+        };
+        let mut occlusion = OcclusionTracker::new();
+
+        Renderer::handle_backdrop_filter(
+            bf_layer,
+            node,
+            &tree,
+            &mut backend,
+            &ctx,
+            &surface_texture,
+            &surface_view,
+            &mut occlusion,
+        );
+
+        let results = backend.painter().offscreen_results_for_test();
+        assert_eq!(
+            results.len(),
+            1,
+            "backdrop must queue exactly one offscreen composite"
+        );
+        let (composite_rect, tex_w, tex_h) = results[0];
+
+        // Blur texture must be the CLAMPED size, not the full logical size.
+        assert_eq!(
+            (tex_w, tex_h),
+            (50, 50),
+            "blur texture must be clamped size 50×50; got {tex_w}×{tex_h} — \
+             200×200 indicates the copy was sourced at the unclamped region"
+        );
+
+        // Composite rect origin must match the clamped origin (350,350) and
+        // extent must be the clamped size (50,50), NOT the unclamped (200,200).
+        // Before the fix, width/height would be 200 (device_rect was passed
+        // to queue_offscreen_result instead of clamped_composite_rect).
+        assert!(
+            (composite_rect.left().0 - 350.0).abs() < 0.5,
+            "composite rect left must be ~350.0 (clamped origin); got {:.2}",
+            composite_rect.left().0
+        );
+        assert!(
+            (composite_rect.top().0 - 350.0).abs() < 0.5,
+            "composite rect top must be ~350.0 (clamped origin); got {:.2}",
+            composite_rect.top().0
+        );
+        assert!(
+            (composite_rect.width().0 - 50.0).abs() < 0.5,
+            "composite rect width must be ~50.0 (clamped extent); got {:.2} — \
+             200.0 indicates the unclamped device_rect was passed to \
+             queue_offscreen_result (blurred texture would be stretched)",
+            composite_rect.width().0
+        );
+        assert!(
+            (composite_rect.height().0 - 50.0).abs() < 0.5,
+            "composite rect height must be ~50.0 (clamped extent); got {:.2}",
             composite_rect.height().0
         );
     }

--- a/crates/flui-engine/src/wgpu/renderer.rs
+++ b/crates/flui-engine/src/wgpu/renderer.rs
@@ -1191,6 +1191,73 @@ impl Renderer {
             return;
         };
 
+        // 2. Map the layer's local-space `bounds` to a device-space rect before
+        //    sampling/compositing. `bf_layer.bounds()` is in logical pixels; the
+        //    surface texture and the composite viewport are in physical pixels.
+        //    The accumulated layer-walk CTM — which carries the `RenderView`
+        //    root `scale(dpr)` plus every intervening transform/offset layer —
+        //    lives in the painter's `current_transform` at this point (the walk
+        //    pushes it via `push_transform`/`push_offset`). Reading it here is
+        //    the layer-tree equivalent of the `transform` argument the
+        //    display-list backdrop path ("Path B", `Backend::render_backdrop_filter`)
+        //    receives. Without this mapping a backdrop at logical (100,100,200,200)
+        //    sampled device region (100,100,200,200) on a 2x display — wrong
+        //    source pixels, half size, half position.
+        let transform = backend.painter().current_transform_matrix();
+        let device_rect = transform.transform_rect(&bounds);
+
+        // Clamp the device rect against the surface extent. Path A previously
+        // only lower-clamped (`max(0.0)`/`max(1.0)`); a backdrop partially
+        // off-screen (negative origin or extent beyond the frame) would feed
+        // `copy_texture_to_texture` an out-of-range region and trip wgpu
+        // validation at submit time, dropping the frame. Mirror Path B: clamp
+        // both edges, derive extents from the clamped corners.
+        let surface_extent = surface_texture.size();
+        let surface_w = surface_extent.width;
+        let surface_h = surface_extent.height;
+
+        // Use `.round()` before truncation to match the shader-mask path and avoid
+        // a 1-device-pixel undersize on sub-pixel boundaries (e.g. DPR=1.5 or
+        // fractional-offset CTMs). Keep ≥ 0 via the prior `clamp`.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let x = device_rect.left().0.clamp(0.0, surface_w as f32).round() as u32;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let y = device_rect.top().0.clamp(0.0, surface_h as f32).round() as u32;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let right = device_rect.right().0.clamp(0.0, surface_w as f32).round() as u32;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let bottom = device_rect.bottom().0.clamp(0.0, surface_h as f32).round() as u32;
+        let w = right.saturating_sub(x).max(1);
+        let h = bottom.saturating_sub(y).max(1);
+
+        // If the clamped region is empty the backdrop is entirely off-screen.
+        // `copy_texture_to_texture` requires non-zero extents — fall through to
+        // child rendering (no GPU blur) instead of tripping validation.
+        if right <= x || bottom <= y {
+            tracing::warn!(
+                bounds_l = bounds.left().0,
+                bounds_t = bounds.top().0,
+                bounds_r = bounds.right().0,
+                bounds_b = bounds.bottom().0,
+                surface_w,
+                surface_h,
+                "Backdrop filter (Path A): clamped device region is empty (entirely off-screen); \
+                 rendering children only"
+            );
+            for &child_id in node.children() {
+                Self::render_layer_recursive(
+                    tree,
+                    child_id,
+                    backend,
+                    ctx,
+                    surface_texture,
+                    surface_view,
+                    occlusion,
+                );
+            }
+            return;
+        }
+
         // 1. Flush current painter batches to the surface so pixels are available
         let mut flush_encoder =
             ctx.device
@@ -1204,18 +1271,13 @@ impl Renderer {
             tracing::error!("Backdrop flush failed: {}", e);
         }
 
-        // 2. Copy region from surface to offscreen texture for blur input
-        let x = bounds.left().0.max(0.0) as u32;
-        let y = bounds.top().0.max(0.0) as u32;
-        let w = bounds.width().0.max(1.0) as u32;
-        let h = bounds.height().0.max(1.0) as u32;
-
         if let Some(offscreen_arc) = backend.offscreen().cloned() {
             let blur_input = {
                 let offscreen = offscreen_arc.lock();
                 offscreen.texture_pool().acquire(w, h, ctx.surface_format)
             };
 
+            // 3. Copy the device-space region from the surface to the blur input.
             flush_encoder.copy_texture_to_texture(
                 wgpu::TexelCopyTextureInfo {
                     texture: surface_texture,
@@ -1237,16 +1299,19 @@ impl Renderer {
             );
             ctx.queue.submit(std::iter::once(flush_encoder.finish()));
 
-            // 3. Apply Dual Kawase blur
+            // 4. Apply Dual Kawase blur
             let blurred = {
                 let mut offscreen = offscreen_arc.lock();
                 offscreen.render_blur(&blur_input, sigma)
             };
 
-            // 4. Queue blurred result for compositing
+            // 5. Queue the blurred result for compositing at the same
+            //    device-space rect it was sampled from — using `bounds`
+            //    (logical) here would lay the blur down at half scale/position
+            //    on a HiDPI frame.
             backend
                 .painter_mut()
-                .queue_offscreen_result(blurred, bounds);
+                .queue_offscreen_result(blurred, device_rect);
         } else {
             // No offscreen renderer available — just submit the flush
             ctx.queue.submit(std::iter::once(flush_encoder.finish()));
@@ -1384,5 +1449,286 @@ mod tests {
                 });
             renderer.queue.submit(std::iter::once(encoder.finish()));
         });
+    }
+
+    /// Acquire a real device/queue for the HiDPI backdrop regression below.
+    /// Returns `None` when no GPU adapter is available (CI without a GPU).
+    fn test_device_and_queue() -> Option<(Arc<wgpu::Device>, Arc<wgpu::Queue>)> {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .ok()?;
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("Backdrop HiDPI Test Device"),
+            ..Default::default()
+        }))
+        .ok()?;
+        Some((Arc::new(device), Arc::new(queue)))
+    }
+
+    /// BUG 1 (HiDPI backdrop "Path A"): the layer-tree backdrop path must map
+    /// the layer's logical `bounds` through the accumulated CTM (which carries
+    /// the `RenderView` `scale(dpr)`) before sampling/compositing. Under a
+    /// `scale(2)` CTM a backdrop at logical (100,100,200,200) must sample and
+    /// composite the device rect (200,200,400,400), not the logical rect.
+    ///
+    /// Drives the real `Renderer::handle_backdrop_filter` (not a reimpl) with a
+    /// synthetic surface texture and asserts the queued offscreen composite rect
+    /// is the device rect. Red before the fix (logical (100,100,200,200)).
+    #[test]
+    fn backdrop_filter_path_a_composites_at_device_rect_under_dpr() {
+        use super::super::backend::Backend;
+        use super::super::offscreen::OffscreenRenderer;
+        use super::super::painter::WgpuPainter;
+        use flui_layer::{BackdropFilterLayer, Layer, LayerTree};
+        use flui_types::{
+            geometry::{Rect, px},
+            painting::ImageFilter,
+        };
+
+        let Some((device, queue)) = test_device_and_queue() else {
+            // No GPU in this environment; skip gracefully (matches the other
+            // GPU tests in this module).
+            return;
+        };
+
+        // Surface format used for the synthetic surface + offscreen pool. A
+        // UNorm format with COPY_SRC|COPY_DST|RENDER_ATTACHMENT|TEXTURE_BINDING
+        // is what the real surface uses (see `Renderer::new`).
+        let format = wgpu::TextureFormat::Bgra8Unorm;
+        let surface_w = 800u32;
+        let surface_h = 800u32;
+
+        let surface_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Backdrop HiDPI Test Surface"),
+            size: wgpu::Extent3d {
+                width: surface_w,
+                height: surface_h,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let surface_view = surface_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let offscreen = Arc::new(parking_lot::Mutex::new(OffscreenRenderer::new(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            format,
+        )));
+
+        let painter = WgpuPainter::with_shared_device(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            format,
+            (surface_w, surface_h),
+        );
+        let mut backend = Backend::with_offscreen(painter, Arc::clone(&offscreen));
+
+        // Simulate the `RenderView` DPR root transform: scale(2) on the CTM.
+        backend.painter_mut().scale(2.0, 2.0);
+
+        // Build a one-node layer tree: a leaf BackdropFilter with no children.
+        let mut tree = LayerTree::new();
+        let logical_bounds = Rect::from_xywh(px(100.0), px(100.0), px(200.0), px(200.0));
+        let bf = BackdropFilterLayer::new(
+            ImageFilter::blur(5.0),
+            flui_types::painting::BlendMode::SrcOver,
+            logical_bounds,
+        );
+        let id = tree.insert(Layer::BackdropFilter(bf));
+        tree.set_root(Some(id));
+        let node = tree.get(id).expect("inserted backdrop node");
+        let Layer::BackdropFilter(bf_layer) = node.layer() else {
+            unreachable!("inserted a BackdropFilter layer");
+        };
+
+        let ctx = RenderContext {
+            device: Arc::clone(&device),
+            queue: Arc::clone(&queue),
+            surface_format: format,
+            supports_copy_src: true,
+        };
+        let mut occlusion = OcclusionTracker::new();
+
+        Renderer::handle_backdrop_filter(
+            bf_layer,
+            node,
+            &tree,
+            &mut backend,
+            &ctx,
+            &surface_texture,
+            &surface_view,
+            &mut occlusion,
+        );
+
+        // The blurred backdrop must be queued for compositing at the DEVICE
+        // rect — logical bounds (x=100, y=100, w=200, h=200) under scale(2)
+        // maps to (x=200, y=200, w=400, h=400), i.e. corners (200,200)→(600,600).
+        // The bug would leave the logical rect (corners (100,100)→(300,300)).
+        let results = backend.painter().offscreen_results_for_test();
+        assert_eq!(
+            results.len(),
+            1,
+            "backdrop must queue exactly one offscreen composite"
+        );
+        let (composite_rect, _tw, _th) = results[0];
+        assert!(
+            (composite_rect.left().0 - 200.0).abs() < 0.5
+                && (composite_rect.top().0 - 200.0).abs() < 0.5
+                && (composite_rect.width().0 - 400.0).abs() < 0.5
+                && (composite_rect.height().0 - 400.0).abs() < 0.5,
+            "backdrop composite rect must be the device rect (x=200,y=200,w=400,h=400) \
+             under DPR=2; got {composite_rect:?} (logical (x=100,y=100,w=200,h=200) means \
+             the DPR transform was dropped)"
+        );
+    }
+
+    /// Locks that `handle_backdrop_filter` honours CTM TRANSLATION, not just
+    /// scale. Pure-scale(2) is sufficient to catch the "dropped DPR" bug but
+    /// insufficient to catch "translation eaten by the CTM reader".
+    ///
+    /// CTM: scale(2) THEN translate(+10, +10) (post-multiply order).
+    /// The accumulated matrix maps (x,y) → (2x+20, 2y+20).
+    /// Logical bounds (100,100)→(300,300) device-map to (220,220)→(620,620):
+    ///   left  = 2*100 + 20 = 220
+    ///   top   = 2*100 + 20 = 220
+    ///   right = 2*300 + 20 = 620  →  width  = 400
+    ///   bottom= 2*300 + 20 = 620  →  height = 400
+    ///
+    /// A regression that drops the translation but keeps the scale would give
+    /// (200,200,400,400) with the position wrong at (200,200) instead of (220,220).
+    #[test]
+    fn backdrop_filter_path_a_honors_translation_under_dpr() {
+        use super::super::backend::Backend;
+        use super::super::offscreen::OffscreenRenderer;
+        use super::super::painter::WgpuPainter;
+        use flui_layer::{BackdropFilterLayer, Layer, LayerTree};
+        use flui_types::{
+            geometry::{Offset, Rect, px},
+            painting::ImageFilter,
+        };
+
+        let Some((device, queue)) = test_device_and_queue() else {
+            return;
+        };
+
+        let format = wgpu::TextureFormat::Bgra8Unorm;
+        let surface_w = 1000u32;
+        let surface_h = 1000u32;
+
+        let surface_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Backdrop Translation Test Surface"),
+            size: wgpu::Extent3d {
+                width: surface_w,
+                height: surface_h,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let surface_view = surface_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let offscreen = Arc::new(parking_lot::Mutex::new(OffscreenRenderer::new(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            format,
+        )));
+        let painter = WgpuPainter::with_shared_device(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            format,
+            (surface_w, surface_h),
+        );
+        let mut backend = Backend::with_offscreen(painter, Arc::clone(&offscreen));
+
+        // CTM: scale(2) then translate(+10,+10).
+        // Maps (x,y) → (2x+20, 2y+20).
+        backend.painter_mut().scale(2.0, 2.0);
+        backend
+            .painter_mut()
+            .translate(Offset::new(px(10.0), px(10.0)));
+
+        let mut tree = LayerTree::new();
+        let logical_bounds = Rect::from_xywh(px(100.0), px(100.0), px(200.0), px(200.0));
+        let bf = BackdropFilterLayer::new(
+            ImageFilter::blur(5.0),
+            flui_types::painting::BlendMode::SrcOver,
+            logical_bounds,
+        );
+        let id = tree.insert(Layer::BackdropFilter(bf));
+        tree.set_root(Some(id));
+        let node = tree.get(id).expect("inserted backdrop node");
+        let Layer::BackdropFilter(bf_layer) = node.layer() else {
+            unreachable!("inserted a BackdropFilter layer");
+        };
+
+        let ctx = RenderContext {
+            device: Arc::clone(&device),
+            queue: Arc::clone(&queue),
+            surface_format: format,
+            supports_copy_src: true,
+        };
+        let mut occlusion = OcclusionTracker::new();
+
+        Renderer::handle_backdrop_filter(
+            bf_layer,
+            node,
+            &tree,
+            &mut backend,
+            &ctx,
+            &surface_texture,
+            &surface_view,
+            &mut occlusion,
+        );
+
+        let results = backend.painter().offscreen_results_for_test();
+        assert_eq!(
+            results.len(),
+            1,
+            "backdrop must queue exactly one offscreen composite"
+        );
+        let (composite_rect, _tw, _th) = results[0];
+
+        // Expected device rect corners: (220,220)→(620,620); w=h=400.
+        // A translation-drop regression gives (200,200) position (not 220).
+        assert!(
+            (composite_rect.left().0 - 220.0).abs() < 0.5,
+            "composite rect left must be ~220.0 (2*100+20); got {:.2} \
+             (translation was likely dropped from CTM)",
+            composite_rect.left().0
+        );
+        assert!(
+            (composite_rect.top().0 - 220.0).abs() < 0.5,
+            "composite rect top must be ~220.0 (2*100+20); got {:.2}",
+            composite_rect.top().0
+        );
+        assert!(
+            (composite_rect.width().0 - 400.0).abs() < 0.5,
+            "composite rect width must be ~400.0; got {:.2}",
+            composite_rect.width().0
+        );
+        assert!(
+            (composite_rect.height().0 - 400.0).abs() < 0.5,
+            "composite rect height must be ~400.0; got {:.2}",
+            composite_rect.height().0
+        );
     }
 }


### PR DESCRIPTION
Round-5 deep-audit, part C (HiDPI offscreen) — the two complex, interrelated fixes deferred from 5b for focused review. Both verified against Impeller; adversarial review returned **COMPLETE (0 P0/P1/P2)**.

## Bugs fixed

Both share a root cause: an offscreen pass used **logical**-pixel bounds while the device surface + composite viewport are **physical** pixels; the DPR lives in the painter's `current_transform` (root `TransformLayer = scale(dpr)`). Invisible at DPR=1, wrong on every HiDPI frame. The in-tree reference is `render_backdrop_filter` ("Path B"), which already does `transform.transform_rect(&bounds)`; these mirror it.

| # | Sev | Bug | Fix |
|---|-----|-----|-----|
| 1 | P1 | **backdrop-filter Path A** (live layer-tree path) copied the surface region + composited at logical bounds → blur sampled wrong region, half-size/half-position on HiDPI | read accumulated CTM via new `current_transform_matrix()`, apply `transform_rect` to BOTH the `copy_texture_to_texture` source AND the composite rect; add the missing upper clamp vs surface extent |
| 2 | P1 | **shader-mask** sized offscreen child/result from logical bounds + `reset_frame_state` dropped the CTM → mask at half-resolution, quarter-area on HiDPI | capture `dpr_scale` + CTM before reset; size offscreen at `bounds*dpr_scale`; `scale(dpr_scale)` the child render; composite at `transform_rect(bounds)`. Gradient-uniform keeps logical `child_bounds` (normalized endpoints vs fullscreen-quad UV — resolution-independent); only allocation/composite go device-space |

P3: backdrop device-rect sizing now `.round()` (was truncating `as u32`) — matches the shader-mask path; sub-pixel CTM origins no longer 1px-undersize.

## Tests (GPU, feature `enable-wgpu-tests`, `--test-threads 1`)
Each drives the **real** production function and asserts device-space results that fail on pre-fix code:
- `backdrop_filter_path_a_composites_at_device_rect_under_dpr` — scale(2): logical (100,100,200,200) → device (200,200,400,400)
- `backdrop_filter_path_a_honors_translation_under_dpr` — scale(2)∘translate(10,10) → (220,220,400,400) (locks CTM **translation** handling, not just scale)
- `shader_mask_offscreen_is_device_sized_under_dpr` — solid mask: offscreen 100×100 → 200×200
- `shader_mask_gradient_is_device_sized_under_dpr` — **gradient** mask at DPR=2 (locks the gradient-uniform split end-to-end)

The last two lock-in tests were added to cover exactly the two points (translation, gradient) the reviewer could only hand-verify.

## Gates (ground-truthed locally)
clippy dev + `--features enable-wgpu-tests` (`-D warnings`), fmt, doc (`-D warnings`), lib **89/89**, GPU serial **156/156**, release 0-warn.

## Known residuals (P3, documented)
Non-uniform scale / rotation in the offscreen CTM uses `max_basis_length` for sizing (exact placement via `transform_rect`; rotation in the offscreen interior is a pre-existing gap). Nonzero-bounds-origin child offset is a pre-existing gap. Neither regressed here.

This completes the round-5 deep audit (5a color/compositing #221, 5b tessellation/robustness #222, 5c HiDPI offscreen). The one remaining audit finding — `Paint.blendMode` ignored for shape draws — is deferred as a feature (needs a premultiplied pipeline + advanced-mode dst-read strategy), not a point fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)