### PR TITLE
refactor(engine): C4 grep (port-check trigger 19) + ADR-0006 + record-side docs (T9f)

### DIFF
--- a/crates/flui-engine/ARCHITECTURE.md
+++ b/crates/flui-engine/ARCHITECTURE.md
@@ -147,6 +147,74 @@ Per-frame `Arc::clone` removal (verdict's U7) and `Arc<Mutex<OffscreenRenderer>>
 
 ---
 
+## Record-side boundary (engine overhaul T7–T9)
+
+This section documents the decomposition of `WgpuPainter` performed in the engine-overhaul series (PRs #231–#232, T9 sub-PRs). The governing decision is recorded in [`docs/adr/ADR-0006-c-ir-record-replay-seam.md`](../../docs/adr/ADR-0006-c-ir-record-replay-seam.md).
+
+### WgpuPainter as thin coordinator
+
+`WgpuPainter` is the per-frame coordinator; it no longer owns logic, only state and delegation:
+
+| Field | Owner | Module |
+|---|---|---|
+| `state: GpuStateStack` | transform / scissor / rrect-clip / rsuperellipse stacks; Copy accessors; depth + `Drop` assert | [`src/wgpu/state_stack.rs`](src/wgpu/state_stack.rs) |
+| `compositor: LayerCompositor` | `SavedLayer` + `PendingOpacityLayer` + opacity stack | [`src/wgpu/layer_compositor.rs`](src/wgpu/layer_compositor.rs) |
+| `resources: GpuResources` | `TexturePool` / `BufferPool` / `TextureCache` / `ExternalTextureRegistry` | [`src/wgpu/resources.rs`](src/wgpu/resources.rs) |
+| `pipelines: PipelineSet` | 9 named `RenderPipeline` fields + `PipelineCache` (composition) | [`src/wgpu/pipelines.rs`](src/wgpu/pipelines.rs) |
+| `current_segment: DrawSegment`, `draw_order: Vec<DrawItem>` | Command IR — the record output | [`src/wgpu/command_ir.rs`](src/wgpu/command_ir.rs) |
+
+Record methods (per-primitive draw calls) are owned by `DrawBatcher` in `batches/`:
+
+| Sub-module | Primitive family |
+|---|---|
+| [`src/wgpu/batches/shapes.rs`](src/wgpu/batches/shapes.rs) | rect, rrect, circle, oval, drrect, arc, shadow, line |
+| [`src/wgpu/batches/gradients.rs`](src/wgpu/batches/gradients.rs) | linear gradient, radial gradient, sweep gradient, `dispatch_shader_rect` |
+| [`src/wgpu/batches/paths.rs`](src/wgpu/batches/paths.rs) | `draw_path`, `draw_vertices` |
+| [`src/wgpu/batches/images.rs`](src/wgpu/batches/images.rs) | `draw_image`, `draw_image_repeat`, `draw_image_nine_slice`, `draw_image_filtered`, `draw_atlas`, `draw_texture` |
+
+`text` / `rich_text` remain on `WgpuPainter` pending T11 (the text-vs-IR seam decision).
+
+### Borrow-seam contract
+
+Each `DrawBatcher` record method takes the narrowest set of disjoint borrowed parameters it needs — it never takes `&mut WgpuPainter`. The borrow-checker enforces the data-flow contract:
+
+```text
+fn draw_*(
+    segment: &mut DrawSegment,          // IR write target
+    state: &GpuStateStack,              // Copy accessors only — no borrow aliasing
+    // plus any of:
+    draw_order: &mut Vec<DrawItem>,     // for methods that emit multiple items
+    texture_cache: &mut TextureCache,   // image/atlas paths
+    resources: &ExternalTextureRegistry,
+    opacity: f32,                       // from compositor.current_opacity()
+)
+```
+
+`WgpuPainter::draw_*` methods are thin shims that field-split `self` and delegate to `DrawBatcher`.
+
+### C1 definition — module file size limit
+
+Each module file in `batches/` must stay **< 1 500 non-test LOC**. `/spec-verify` measures non-test LOC (i.e., lines outside `#[cfg(test)]` blocks and `mod tests { … }` sections). The same limit applies to `state_stack.rs`, `layer_compositor.rs`, `resources.rs`, and `pipelines.rs`.
+
+`WgpuPainter` (`painter.rs`) currently sits at ~2 700 non-test LOC after T9. It will drop below 1 500 at T10, when the replay/submit path (`render()` / `flush_segment` / `flush_*`) is extracted into a dedicated replay module.
+
+### C4 rule — Matrix4 must not appear in batches/ or pipelines.rs
+
+`GpuStateStack` stores transforms as `glam::Mat4`. The conversion to/from `flui_types::Matrix4` happens at exactly one structural edge:
+
+- `painter.rs::current_transform_matrix()` — Copy-accessor returning a `Matrix4` to callers outside the engine's wgpu module.
+- `backend.rs::with_transform` and the `render_*` methods — the `CommandRenderer` implementation that converts incoming `Matrix4` arguments into `glam::Mat4` before calling painter record methods.
+
+**`Matrix4` must not appear in `batches/` or `pipelines.rs`** — these modules work entirely in glam primitives. Port-check Trigger 19 (`scripts/port-check.sh`) enforces this with an `rg` grep on every CI run and locally via `just port-check`.
+
+If a record method receives per-sprite transforms (e.g., `draw_atlas`), the conversion to pixel-space origins (`Offset<Pixels>`) happens at the `painter.rs` call site before the batcher is invoked.
+
+### Replay side — pending T10
+
+The replay/submit path (`render()`, `flush_segment`, `flush_segment_*`) is still on `WgpuPainter` in the current state. At T10 this path will be extracted into a replay module (`replay.rs` or `renderer/`) that takes `&CommandIR` + `&mut GpuResources` + `&PipelineSet` and produces GPU draw calls. After T10, `WgpuPainter`'s role becomes: record entry point → thin coordinator → delegate to replay. The `painter.rs` non-test LOC will drop below 1 500 at that point.
+
+---
+
 ## Thread safety
 
 `flui-engine` runs on the render thread; wgpu handles its own thread-safety via `Arc<Device>` / `Arc<Queue>` (cheap ref-counted handles, not lock-protected). Per strategy clause "sync hot path, async at edges," neither the layer walk nor the per-command dispatch is multi-threaded; `Renderer::render_scene` is sync. Async only at `Renderer::new` and `Renderer::new_offscreen` (wgpu's `request_adapter` and `request_device` are async at the wgpu boundary).

--- a/crates/flui-engine/src/wgpu/batches/images.rs
+++ b/crates/flui-engine/src/wgpu/batches/images.rs
@@ -30,7 +30,7 @@
 
 use flui_painting::Paint;
 use flui_types::{
-    Point, Rect,
+    Offset, Point, Rect,
     geometry::{Pixels, px},
     painting::Image,
 };
@@ -570,13 +570,17 @@ impl DrawBatcher {
 
     /// Record a sprite atlas draw: loads the atlas image once, then pushes one
     /// `cached_images` entry per sprite with the sprite's UV sub-rect and tint.
+    ///
+    /// `sprite_origins` are the per-sprite translation offsets in pixel space,
+    /// already extracted from any transform matrices at the trait-boundary caller.
+    /// The batcher is glam-only; `Matrix4` must not appear on this side of the seam.
     pub(in super::super) fn draw_atlas(
         segment: &mut DrawSegment,
         state: &GpuStateStack,
         texture_cache: &mut TextureCache,
         image: &Image,
         sprites: &[Rect<Pixels>],
-        transforms: &[flui_types::Matrix4],
+        sprite_origins: &[Offset<Pixels>],
         colors: Option<&[flui_types::styling::Color]>,
     ) {
         #[cfg(debug_assertions)]
@@ -588,12 +592,12 @@ impl DrawBatcher {
         );
 
         // Validate input.
-        if sprites.len() != transforms.len() {
+        if sprites.len() != sprite_origins.len() {
             #[cfg(debug_assertions)]
             tracing::error!(
-                "DrawAtlas: sprite count ({}) doesn't match transform count ({})",
+                "DrawAtlas: sprite count ({}) doesn't match origin count ({})",
                 sprites.len(),
-                transforms.len()
+                sprite_origins.len()
             );
             return;
         }
@@ -623,8 +627,8 @@ impl DrawBatcher {
                 let image_height = image.height() as f32;
 
                 // Create texture instances for each sprite.
-                for (i, (sprite_rect, transform)) in
-                    sprites.iter().zip(transforms.iter()).enumerate()
+                for (i, (sprite_rect, origin)) in
+                    sprites.iter().zip(sprite_origins.iter()).enumerate()
                 {
                     // Get color tint for this sprite (default to white).
                     let tint = colors
@@ -640,14 +644,12 @@ impl DrawBatcher {
                         (sprite_rect.bottom() / image_height).0,
                     ];
 
-                    // Extract position from transform matrix.
-                    // Matrix4 is column-major: m[12] = x translation, m[13] = y translation.
-                    let dst_x = transform.m[12];
-                    let dst_y = transform.m[13];
-                    let dst_width = sprite_rect.width();
-                    let dst_height = sprite_rect.height();
-
-                    let dst_rect = Rect::from_xywh(px(dst_x), px(dst_y), dst_width, dst_height);
+                    let dst_rect = Rect::from_xywh(
+                        origin.dx,
+                        origin.dy,
+                        sprite_rect.width(),
+                        sprite_rect.height(),
+                    );
 
                     // Create texture instance and route through cached_images so it is
                     // flushed by flush_segment_cached_images (not the orphaned texture_batch).

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -1879,13 +1879,23 @@ impl WgpuPainter {
         transforms: &[flui_types::Matrix4],
         colors: Option<&[flui_types::styling::Color]>,
     ) {
+        // Convert Matrix4 transforms to pixel-space origins here, at the
+        // painter boundary, so the batcher stays Matrix4-free (C4 rule).
+        // Each transform is column-major; m[12] = x translation, m[13] = y.
+        let sprite_origins: Vec<Offset<Pixels>> = transforms
+            .iter()
+            .map(|t| Offset {
+                dx: px(t.m[12]),
+                dy: px(t.m[13]),
+            })
+            .collect();
         super::batches::DrawBatcher::draw_atlas(
             &mut self.current_segment,
             &self.state,
             self.resources.texture_cache_mut(),
             image,
             sprites,
-            transforms,
+            &sprite_origins,
             colors,
         );
     }

--- a/docs/PORT.md
+++ b/docs/PORT.md
@@ -201,6 +201,18 @@ Re-exports (`pub use foo::Bar`) do not trip the trigger — only literal `pub <k
 
 **Back-references:** [N-geom polish-pass research §III U1–U12](research/2026-05-24-flui-geometry-polish-pass-research.md), [ROADMAP-TRACKER N-geom block](ROADMAP-TRACKER.md).
 
+### 19. `Matrix4` in the DrawBatcher record side or `PipelineCache`/`PipelineBuilder`
+
+**C4 rule: the `Matrix4`↔glam conversion happens at the `Backend` trait boundary; the record and pipeline modules are glam-only.** `GpuStateStack` stores transforms as `glam::Mat4`. The single structural conversion edge is `current_transform_matrix()` in `painter.rs` (outbound, returning a `Matrix4` to `Backend`/`LayerStateStack`) and `Backend::with_transform` (inbound, converting an incoming `Matrix4` into the glam state). Every record method below that boundary — `batches/{shapes,gradients,paths,images}.rs` — and the pipeline-cache module (`pipelines.rs`) work entirely in glam primitives and pixel-typed geometry.
+
+Importing or accepting `flui_types::Matrix4` on the record/pipeline side leaks the flui-types coordinate abstraction into GPU plumbing, defeats the `GpuStateStack` encapsulation, and couples every record-method caller to both coordinate systems. The correct fix is always to extract the needed scalars (translation, scale) at the `painter.rs` or `backend.rs` call site and pass primitives down.
+
+**Scope:** `crates/flui-engine/src/wgpu/batches/` (all files) and `crates/flui-engine/src/wgpu/pipelines.rs`.
+
+**Allowlist:** none. Doc-comment lines (`//!`, `///`, `//`) are excluded (the rg filter strips them).
+
+**Back-references:** [`docs/adr/ADR-0006-c-ir-record-replay-seam.md`](adr/ADR-0006-c-ir-record-replay-seam.md) §Decision 4 (C4 rule); engine-overhaul spec `.rust-studio/specs/flui-engine-overhaul/spec.md` acceptance criterion C4; `crates/flui-engine/ARCHITECTURE.md` §Record-side boundary.
+
 ### Reactive lint promotion
 
 Triggers grow reactively. A new trigger is added to this list when an anti-pattern is caught in review; it does not pre-exist its first observation.
@@ -852,7 +864,7 @@ just port-check-verbose       # prints "ok" lines for each passing trigger + mar
 just port-markers             # per-file marker breakdown (TODO(port) / PERF(port) / PORT NOTE)
 ```
 
-The underlying script lives at [`scripts/port-check.sh`](../scripts/port-check.sh). It runs nine `rg` (ripgrep) passes total — refusal triggers 1–7 plus the FR-033 downcast grep and the FR-036 sanctioned-`dyn`-boundary registry (main pattern + type-alias closure) — and filters out doc-comment matches. The marker-budget scan is an additional non-blocking pass in `-v` and `-b` modes. The regexes are derived directly from the trigger entries in this document; when a trigger changes here, the script changes too.
+The underlying script lives at [`scripts/port-check.sh`](../scripts/port-check.sh). It runs one `rg` (ripgrep) pass per trigger — 19 refusal triggers plus the FR-033 downcast grep and the FR-036 sanctioned-`dyn`-boundary registry (main pattern + type-alias closure) — and filters out doc-comment matches. The marker-budget scan is an additional non-blocking pass in `-v` and `-b` modes. The regexes are derived directly from the trigger entries in this document; when a trigger changes here, the script changes too.
 
 The marker-budget report is a **non-blocking** addition: it counts `TODO(port)`, `PERF(port)`, and `PORT NOTE` occurrences across `crates/` and prints a per-crate summary. Markers are deliberate deferrals (Phase B work-queue), not violations — the script never fails on marker count.
 

--- a/docs/adr/ADR-0006-c-ir-record-replay-seam.md
+++ b/docs/adr/ADR-0006-c-ir-record-replay-seam.md
@@ -1,0 +1,116 @@
+# ADR-0006: C-IR record/replay seam — explicit Command-IR as data, wgpu stays concrete, record side lives in DrawBatcher
+
+*Establish an explicit record/replay Command-IR as data so the engine gains batching, retention, and parallel-encode capacity without a device/backend trait abstraction — keeping wgpu concrete and decomposing WgpuPainter into cohesive components with enforceable boundary rules.*
+
+---
+
+- **Status:** Accepted (record side shipped T7–T9; replay/submit split pending T10)
+- **Date:** 2026-06-17
+- **Deciders:** @vanyastaff
+- **Scope:** `crates/flui-engine` — `src/wgpu/batches/`, `src/wgpu/state_stack.rs`, `src/wgpu/layer_compositor.rs`, `src/wgpu/pipelines.rs`, `src/wgpu/painter.rs`, `src/wgpu/backend.rs`
+- **Spec reference:** `.rust-studio/specs/flui-engine-overhaul/spec.md` (C-IR approach, tasks 7–11)
+- **Supersedes:** `adr-flui-engine-decomposition.md` if it exists (that draft argued "no IR"; this ADR supersedes that position — the IR is explicit data, not a future option)
+
+---
+
+## Verdict
+
+**Target architecture (one paragraph).** The engine uses an explicit **record/replay Command-IR as data**: `Backend` visits the `flui_layer::Scene` and calls `WgpuPainter` record methods, which write into `DrawSegment` / `DrawItem` structs (the Command IR) in `command_ir.rs`. `DrawBatcher` owns the record methods — one file per primitive family (`batches/{shapes,gradients,paths,images}.rs`) — and accepts **disjoint borrowed parameters** (`&mut DrawSegment`, `&mut Vec<DrawItem>`, `&GpuStateStack`, `&mut GpuResources`, `opacity: f32`) so the borrow-checker enforces the data-flow contract without locks. Replay and GPU submission (`flush_segment`, `flush_*`, `render()`) remain on `WgpuPainter` pending T10. wgpu stays concrete — no device trait, no second backend. The engine is the only abstraction flui needs between `Scene` and GPU calls.
+
+---
+
+## Context
+
+### The problem: WgpuPainter was a god-object
+
+`WgpuPainter` at the start of this overhaul was ~6 410 lines and ~58 fields, mixing batch recording, save-layer state machines, gradient construction, text-rendering integration, and per-frame submission with no internal seams. Market research established that flui was the only serious renderer (vs Impeller, Vello, WebRender, Bevy, egui/epaint, GPUI) with no record/replay IR seam. The five wgpu-29 audit rounds had proven the behavior correct; the structure blocked maintainability, testability, and future capabilities.
+
+### What shipped (T7–T9)
+
+| Task | What landed | PR |
+|---|---|---|
+| T7 | `GpuStateStack` — owns the 4 paired transform/scissor/rrect-clip/rsuperellipse stacks; Copy accessors; glam-internal; single `Matrix4`↔glam conversion edge at `current_transform_matrix`; depth counter + `Drop` `debug_assert` | [#231](https://github.com/vanyastaff/flui/pull/231) |
+| T8 | `LayerCompositor` — owns `SavedLayer` + `PendingOpacityLayer` + `opacity_stack` + `current_opacity`; `save_layer(&mut GpuStateStack, …)` borrow-enforced; borrows `layer_texture_pool` from `GpuResources` | [#232](https://github.com/vanyastaff/flui/pull/232) |
+| T9a–e | `DrawBatcher` record-method relocation: ~3 000 LOC of per-primitive record methods relocated from `painter.rs` into `batches/{shapes,gradients,paths,images}.rs`; batcher sub-modules are `Matrix4`-free (C4 rule, Trigger 19) | this branch |
+
+### What remains (T10–T11)
+
+- **T10 replay/submit split:** move `render()`/`flush_segment`/`flush_*` into a replay submitter over `&CommandIR` + `&mut GpuResources` + `&PipelineSet`; `WgpuPainter` drops below 1 500 non-test LOC.
+- **T11 deterministic-replay test:** record an IR, replay to encoder A and encoder B, assert emitted command streams match; compile-time proof record holds no `&mut Device/Queue/Encoder`.
+
+---
+
+## Decision
+
+### 1. The IR is explicit data, not implicit
+
+`DrawSegment` / `DrawItem` are plain data structs in `command_ir.rs`. Record methods write into them; replay reads them. This is the pattern Impeller used when it deleted its retained EntityPass tree in 2024 ("DisplayList in, flat Command vector out"). The alternative — implicit batching inside `WgpuPainter` with no separation — was the status quo that made every refactor open the full 6 410-line file.
+
+### 2. wgpu stays concrete — no device trait
+
+A `dyn GpuBackend` / device-trait abstraction was explicitly considered and rejected. No second GPU backend exists or is planned. Static dispatch via the single concrete `Backend` impl is the only consumer. A second backend (Skia/Vello/software) would build against a concrete second impl when a real consumer arrives, not against a hypothetical trait today. This is the same decision that deleted `pub trait Painter` in the Mythos chain (Mapping decision §2 in `ARCHITECTURE.md`).
+
+### 3. Borrow-seam pattern — Copy accessors, disjoint borrowed parameters
+
+`GpuStateStack` exposes Copy accessors only — it never returns `&` to internal state, so a caller cannot hold a borrow across the `&mut DrawSegment` write. Each `DrawBatcher` record method takes the narrowest set of disjoint borrowed parameters it needs:
+
+```text
+fn draw_rect(
+    segment: &mut DrawSegment,
+    state: &GpuStateStack,          // Copy accessors only — no &-aliasing hazard
+    image: &Image,                  // (example — varies per method)
+    …
+)
+```
+
+`&mut GpuResources` (for `TextureCache` / `ExternalTextureRegistry`) and `opacity: f32` are passed explicitly where needed. No method takes `&mut WgpuPainter` — borrow-splitting enforces the seam.
+
+### 4. Matrix4 conversion at the trait boundary — C4 rule
+
+`GpuStateStack` stores transforms as `glam::Mat4` (glam is the GPU-math crate; it matches the GPU buffer layout directly). The conversion to/from `flui_types::Matrix4` happens at exactly one structural edge: `current_transform_matrix()` in `painter.rs` and the `with_transform` entry in `backend.rs`. The `batches/` submodules and `pipelines.rs` are `Matrix4`-free — enforced by port-check Trigger 19 (added in T9f). Leaking `Matrix4` into the record/pipeline side would require every GPU-path caller to drag in the flui-types coordinate type and would undo the glam-internal encapsulation that `GpuStateStack` establishes.
+
+### 5. text / rich_text stay painter-side — T9 deferred, T11 seam
+
+`draw_text` and `draw_rich_text` were not relocated to `DrawBatcher` in T9. Rationale: `TextRenderer` is a `glyphon`-owned field (`text_renderer: TextRenderer` on `WgpuPainter`) that holds a GPU glyph atlas — it is not a geometry asset that can be passed as a plain borrowed parameter without restructuring the atlas ownership. The text-vs-IR seam is deferred to T11, where the deterministic-replay proof will clarify whether text commands become IR-opaque handles or are recorded as shaped glyph data. Relocating text before that decision would re-open the record methods a second time.
+
+---
+
+## Alternatives considered
+
+| Option | Why rejected |
+|---|---|
+| `dyn GpuBackend` device trait | No second backend; premature; every refactor re-types 6 410 lines of audited behavior for a non-existent consumer |
+| Keep WgpuPainter as-is (ALT-2) | "No respected Rust renderer resembles it" — the god-object survives; no record/replay, no batching, no testable boundary |
+| Separate IR crate (`flui-command-ir`) | Over-splits before a second consumer exists; extractable cheaply once T11 lands |
+| immediates / push-constants for per-draw uniforms | Dropped: wgpu-28 renamed, default `max_immediate_size` = 64 B too tight for transform+paint, WebGPU-web pending; market uses instancing + dynamic-offset/storage |
+
+---
+
+## Consequences
+
+**Now (T9 shipped):**
+- `WgpuPainter` reduced from ~6 410 to ~2 700 non-test LOC (record methods relocated).
+- `batches/` is `Matrix4`-free and enforced by Trigger 19.
+- Borrow-seam is structurally enforced; no method takes `&mut WgpuPainter`.
+- Behavior preserved: the five-round wgpu-29 audit net is unchanged (T6 readback safety-net landed before T7).
+
+**After T10:**
+- `WgpuPainter` drops below 1 500 non-test LOC (C1 target met).
+- Replay is a separate function/type over `&CommandIR`; record and replay are callable independently.
+
+**After T11:**
+- Deterministic-replay test proves the IR separation is non-tautological.
+- Text-vs-IR seam decided; `text` / `rich_text` either join the IR or are documented as a bounded exception.
+
+---
+
+## References
+
+- Spec: `.rust-studio/specs/flui-engine-overhaul/spec.md` — C-IR approach, C4 acceptance criterion, tasks 7–11
+- `crates/flui-engine/ARCHITECTURE.md` — wgpu/Vulkan/Metal mapping, mapping decisions §1–6, record-side boundary section (T9f addition)
+- `crates/flui-engine/src/wgpu/state_stack.rs` — single `Matrix4`↔glam conversion edge (`current_transform_matrix`)
+- `crates/flui-engine/src/wgpu/backend.rs` — `with_transform` + `render_*` entry points; `Matrix4` lives here
+- `crates/flui-engine/src/wgpu/batches/` — record-method home; `Matrix4`-free by Trigger 19
+- `crates/flui-engine/src/wgpu/painter.rs` — thin coordinator; text/rich_text pending T11
+- Impeller precedent: DisplayList→flat Command vector, EntityPass tree deleted 2024 (`.flutter/` reference)
+- Port-check Trigger 19: `scripts/port-check.sh` lines 1202–1230; `docs/PORT.md` §19

--- a/scripts/port-check.sh
+++ b/scripts/port-check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/port-check.sh
 #
-# Verifies the 18 refusal triggers (1-18, with #9 numbered for FR-036)
+# Verifies the 19 refusal triggers (1-19, with #9 numbered for FR-036)
 # documented in docs/PORT.md against the workspace, plus the FR-033
 # sanctioned-dyn-boundary check. Exits non-zero on the first violation
 # outside the whitelist; prints the offending file:line and the trigger
@@ -10,7 +10,9 @@
 # added by the N-geom polish pass §U12 (unit-barrier escape-hatch guard).
 # Triggers #15/#16/#17/#18 added in core-0a adversarial-reaudit PR-4 §U5
 # (println!/eprintln!/dbg! ban, module-level allow(unsafe_code) ban,
-# reinvented debug_assert_* ban, key.rs new_unchecked ban).
+# reinvented debug_assert_* ban, key.rs new_unchecked ban). Trigger #19
+# added in engine overhaul T9f (C4: Matrix4 must not appear on the
+# record/pipeline side; convert at the Backend trait boundary).
 #
 # Additionally reports the inline port-marker budget (TODO(port),
 # PERF(port), PORT NOTE) — markers are deliberate Phase B deferrals, NOT
@@ -21,7 +23,7 @@
 # docs/PORT.md "## Verification" for usage and rationale.
 #
 # Usage:
-#   bash scripts/port-check.sh             # check all 17 triggers; silent on pass
+#   bash scripts/port-check.sh             # check all 19 triggers; silent on pass
 #   bash scripts/port-check.sh -v          # verbose: per-trigger pass + marker totals
 #   bash scripts/port-check.sh -b          # marker-budget mode (per-file breakdown)
 #   bash scripts/port-check.sh --verbose   # alias for -v
@@ -1200,6 +1202,38 @@ else
 fi
 
 # -----------------------------------------------------------------------------
+# Trigger 19 (engine overhaul T9f) — `Matrix4` in the DrawBatcher record
+# side or `PipelineCache`/`PipelineBuilder` (record/pipeline modules).
+#
+# C4 rule: `Matrix4`↔glam conversions must happen at the `Backend` trait
+# boundary (crates/flui-engine/src/wgpu/backend.rs). The hot record path
+# (`batches/`) and the pipeline-cache module (`pipelines.rs`) must be
+# glam-only; importing or accepting `Matrix4` there leaks the flui-types
+# coordinate type into the GPU plumbing layer and breaks the seam contract
+# established in the engine overhaul spec (T9/T10 split).
+#
+# Allowlist: none. The correct fix is always to extract the needed scalar
+# fields (translation, scale) at the caller in backend.rs / painter.rs and
+# pass primitives down.
+# -----------------------------------------------------------------------------
+trigger19_hits=$(rg --line-number --column '\bMatrix4\b' \
+    crates/flui-engine/src/wgpu/batches crates/flui-engine/src/wgpu/pipelines.rs 2>/dev/null \
+  | grep -Ev ':\s*(//!|///|//)' \
+  || true)
+
+if [[ -n "${trigger19_hits}" ]]; then
+  echo 'VIOLATION 19: Matrix4 in batches/ or pipelines.rs (record/pipeline side must be glam-only; convert at the trait boundary)'
+  echo "see ${trigger_doc} (trigger 19)"
+  echo "${trigger19_hits}"
+  echo ""
+  violations=$((violations + 1))
+else
+  if [[ "${verbose}" -eq 1 ]]; then
+    echo "ok    19: no Matrix4 in batches/ or pipelines.rs"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------------
 if [[ "${violations}" -gt 0 ]]; then
@@ -1208,7 +1242,7 @@ if [[ "${violations}" -gt 0 ]]; then
   exit 1
 fi
 
-echo "port-check: all 18 refusal triggers + FR-033 grep clean"
+echo "port-check: all 19 refusal triggers + FR-033 grep clean"
 
 # -----------------------------------------------------------------------------
 # Marker summary (verbose mode only). Non-blocking — markers are Phase B


### PR DESCRIPTION
## T9f — C4 enforcement + ADR-0006 + record-side docs (final sub-PR of T9)

Closes the T9 record-side decomposition. `text`/`rich_text` stay painter-side (their `text_renderer` is glyphon-owned, not a geometry asset — chief-architect call), so there is **no further record relocation** here.

### What this does
1. **port-check.sh Trigger 19 (C4):** asserts no `Matrix4` in `crates/flui-engine/src/wgpu/batches/` or `pipelines.rs` — the record/pipeline side is glam-only; the `Matrix4`↔glam conversion stays at the trait boundary. Mirrors triggers 17/18; all count references bumped to 19; `docs/PORT.md` entry added. Proven to fire on a planted `Matrix4`, then clean on removal.
2. **`draw_atlas` C4 fix (forced by trigger 19):** T9e had relocated `draw_atlas` into `batches/images.rs` carrying a `transforms: &[Matrix4]` parameter — so `batches/` was **not actually glam-only** (the T9e reviewers missed it; trigger 19 is exactly the guard that surfaces this). The *batcher* `draw_atlas` now takes pre-extracted `sprite_origins: &[Offset<Pixels>]`; the **public `WgpuPainter::draw_atlas` signature is unchanged** (`&[Matrix4]`, 0 semver) and its shim does the column-major `m[12]`/`m[13]` translation extraction. Byte-identical (`draw_atlas` was translation-only).
3. **ADR-0006** (`docs/adr/ADR-0006-c-ir-record-replay-seam.md`): the C-IR record/replay seam — IR-as-data decision, the `GpuStateStack`/`LayerCompositor`/`DrawBatcher` cuts (T7–T9), the Copy-accessor borrow-seam, and the text-stays-painter rationale.
4. **ARCHITECTURE.md:** record-side boundary table + C1 = per-file **<1500 NON-TEST LOC**.

### Gates
- clippy (both modes) / fmt / taplo / typos / doc — **green**.
- `bash scripts/port-check.sh` = **all 19 triggers + FR-033 clean**.
- **GPU-readback serial (local DX12): exit 0** — atlas tests pass (`draw_atlas` behavior preserved).
- **rust-reviewer**: COMPLETE — trigger 19 regex verified (fires on `Matrix4`/`flui_types::Matrix4`/`crate::…Matrix4`, suppresses doc-comments), `draw_atlas` byte-identity + 0 semver, ADR accuracy, scope tight.

### Notes / follow-ups flagged
- Pre-existing: `docs/PORT.md` lacks entries for triggers 15–18 (core-0a foundation triggers added without docs); the 14→19 gap is now more visible. Flagged for a separate doc-backfill (out of engine-overhaul scope).
- Pre-existing (from T9e): `ColorFilter::Mode` tint is occluded by an opaque image due to segment flush order — flagged separately with a `.flutter/` cross-check + a failing-today readback.

### Roadmap
**T9 record-side decomposition is now complete (T9a–f).** `painter.rs` 6410 → ~4600. Remaining: **T10** (replay/submit split — move `render()`/`flush_segment`/`flush_*` into a replay submitter over `&CommandIR + &mut GpuResources + &PipelineSet`; painter drops <1500; external-image draws need an opaque handle-id since `wgpu::TextureView` is non-PartialEq) + **T11** (deterministic-replay A/B test + two-level-IR doc). T4 deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)