### PR TITLE
fix(engine): composite ColorFilter.Mode over the image (per-pixel blend)

### DIFF
--- a/crates/flui-engine/src/wgpu/batches/images.rs
+++ b/crates/flui-engine/src/wgpu/batches/images.rs
@@ -113,10 +113,34 @@ impl DrawBatcher {
 
     /// Record an image draw by uploading (or retrieving from cache) its RGBA
     /// pixels into the texture cache, then pushing a `cached_images` entry.
+    ///
+    /// Keys the cache on the image's `Arc` pointer identity (O(1), no hashing).
+    /// This is safe for real images, whose allocation is content-stable for the
+    /// lifetime of the `Arc`. **Short-lived temporaries (e.g. CPU-filtered
+    /// images) must NOT use this path** — their pointer is freed on drop and can
+    /// be reused by a different image, colliding in the cache; route those
+    /// through [`Self::draw_image_with_id`] with a content-derived key instead.
     pub(in super::super) fn draw_image(
         segment: &mut DrawSegment,
         state: &GpuStateStack,
         texture_cache: &mut TextureCache,
+        image: &Image,
+        dst_rect: Rect<Pixels>,
+    ) {
+        let texture_id = super::super::texture_cache::TextureId::from_ptr(image.data_ptr());
+        Self::draw_image_with_id(segment, state, texture_cache, texture_id, image, dst_rect);
+    }
+
+    /// Record an image draw under an explicit cache `texture_id`.
+    ///
+    /// Splits the keying decision out of [`Self::draw_image`] so callers that
+    /// generate transient pixel buffers (the CPU color-filter branches) can key
+    /// on a stable content hash rather than a soon-to-be-freed pointer.
+    fn draw_image_with_id(
+        segment: &mut DrawSegment,
+        state: &GpuStateStack,
+        texture_cache: &mut TextureCache,
+        texture_id: super::super::texture_cache::TextureId,
         image: &Image,
         dst_rect: Rect<Pixels>,
     ) {
@@ -125,8 +149,6 @@ impl DrawBatcher {
         let transformed_rect =
             Rect::from_ltrb(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
 
-        // Use Arc pointer identity for O(1) cache lookup instead of hashing all pixels.
-        let texture_id = super::super::texture_cache::TextureId::from_ptr(image.data_ptr());
         let data = image.data();
 
         // Load or get cached texture (small images are auto-packed into the atlas).
@@ -158,6 +180,34 @@ impl DrawBatcher {
                 tracing::error!("Failed to load image texture: {}", e);
             }
         }
+    }
+
+    /// Draw a freshly produced (CPU-filtered) RGBA buffer, keyed on a content
+    /// hash of its bytes.
+    ///
+    /// A filtered buffer is a short-lived temporary: its `Arc` allocation is
+    /// freed when this returns, so [`Self::draw_image`]'s pointer-identity key
+    /// could be reused by a later image and collide in the cache (the cache
+    /// returns a hit on key alone, never re-comparing bytes — see
+    /// `TextureCache::load_from_rgba`). Hashing the bytes is collision-free and
+    /// lets identical filtered output reuse its cached texture across frames.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "borrow-seam design: segment/state/texture_cache are disjoint WgpuPainter fields; \
+                  width/height/pixels/dst are the distinct filtered-image inputs"
+    )]
+    fn draw_filtered_pixels(
+        segment: &mut DrawSegment,
+        state: &GpuStateStack,
+        texture_cache: &mut TextureCache,
+        width: u32,
+        height: u32,
+        pixels: Vec<u8>,
+        dst: Rect<Pixels>,
+    ) {
+        let texture_id = super::super::texture_cache::TextureId::from_data(&pixels);
+        let filtered = Image::from_rgba8(width, height, pixels);
+        Self::draw_image_with_id(segment, state, texture_cache, texture_id, &filtered, dst);
     }
 
     /// Record a tiled image draw by delegating to `draw_image` for each tile.
@@ -463,8 +513,7 @@ impl DrawBatcher {
                     new_data.extend_from_slice(&[blended.r, blended.g, blended.b, blended.a]);
                 }
 
-                let filtered = Image::from_rgba8(w, h, new_data);
-                Self::draw_image(segment, state, texture_cache, &filtered, dst);
+                Self::draw_filtered_pixels(segment, state, texture_cache, w, h, new_data, dst);
 
                 tracing::debug!(
                     "draw_image_filtered: Mode filter baked per-pixel (color={color:?}, mode={blend_mode:?})"
@@ -508,8 +557,7 @@ impl DrawBatcher {
                     new_data.push((na * 255.0) as u8);
                 }
 
-                let filtered = Image::from_rgba8(w, h, new_data);
-                Self::draw_image(segment, state, texture_cache, &filtered, dst);
+                Self::draw_filtered_pixels(segment, state, texture_cache, w, h, new_data, dst);
 
                 tracing::debug!("draw_image_filtered: Matrix filter applied via CPU");
             }
@@ -533,8 +581,7 @@ impl DrawBatcher {
                     new_data.push(pixel[3]); // Alpha unchanged.
                 }
 
-                let filtered = Image::from_rgba8(w, h, new_data);
-                Self::draw_image(segment, state, texture_cache, &filtered, dst);
+                Self::draw_filtered_pixels(segment, state, texture_cache, w, h, new_data, dst);
 
                 tracing::debug!("draw_image_filtered: LinearToSrgbGamma applied via CPU");
             }
@@ -558,8 +605,7 @@ impl DrawBatcher {
                     new_data.push(pixel[3]); // Alpha unchanged.
                 }
 
-                let filtered = Image::from_rgba8(w, h, new_data);
-                Self::draw_image(segment, state, texture_cache, &filtered, dst);
+                Self::draw_filtered_pixels(segment, state, texture_cache, w, h, new_data, dst);
 
                 tracing::debug!("draw_image_filtered: SrgbToLinearGamma applied via CPU");
             }

--- a/crates/flui-engine/src/wgpu/batches/images.rs
+++ b/crates/flui-engine/src/wgpu/batches/images.rs
@@ -12,7 +12,7 @@
 //! | `texture`, `draw_texture`                    | `&ExternalTextureRegistry` |
 //! | `draw_image`, `draw_atlas`                   | `&mut TextureCache`      |
 //! | `draw_image_repeat`, `draw_image_nine_slice` | `&mut TextureCache` (delegate to `draw_image`) |
-//! | `draw_image_filtered`                        | `&mut TextureCache` + `&mut Vec<DrawItem>` + `opacity: f32` (inner `rect`/`draw_image` calls) |
+//! | `draw_image_filtered`                        | `&mut TextureCache` (all branches CPU-recolor then delegate to `draw_image`) |
 //!
 //! # Invariants preserved
 //!
@@ -22,25 +22,25 @@
 //! - The `draw_image_repeat`/`draw_image_nine_slice` → `draw_image` delegation
 //!   produces identical per-tile/per-region calls; loop bounds and dst rects are
 //!   byte-identical to the painter originals.
-//! - `draw_image_filtered`'s branch selection (overlay/CPU-recolor vs rect path)
-//!   is unchanged; the inner `rect` call receives the same `opacity` the shim
-//!   reads once from `compositor.current_opacity()`.
+//! - `draw_image_filtered` bakes every filter (`Mode`, `Matrix`, gamma) into
+//!   the image on the CPU and routes the result through `draw_image`, so the
+//!   filtered pixels share the `cached_images` flush bucket and compositing of
+//!   a plain image draw. No separate overlay rect, so no `draw_order`/`opacity`
+//!   seam is needed.
 //! - `texture_batch` is **not touched** by any method here — it remains a
 //!   painter field for T10.
 
-use flui_painting::Paint;
 use flui_types::{
     Offset, Point, Rect,
     geometry::{Pixels, px},
     painting::Image,
+    styling::Color,
 };
 
 use super::{
     super::{
-        command_ir::{DrawItem, DrawSegment},
-        external_texture_registry::ExternalTextureRegistry,
-        state_stack::GpuStateStack,
-        texture_cache::TextureCache,
+        command_ir::DrawSegment, external_texture_registry::ExternalTextureRegistry,
+        state_stack::GpuStateStack, texture_cache::TextureCache,
     },
     DrawBatcher,
 };
@@ -422,28 +422,21 @@ impl DrawBatcher {
 
     /// Record a color-filtered image draw.
     ///
-    /// The `Mode` branch draws the image then overlays a tinted rect; the rect
-    /// call requires `&mut draw_order` and `opacity` (same seam as
-    /// `WgpuPainter::rect`). The CPU-recolor branches (`Matrix`,
-    /// `LinearToSrgbGamma`, `SrgbToLinearGamma`) apply the filter on CPU and
-    /// delegate to `draw_image`.
-    #[allow(
-        clippy::too_many_arguments,
-        reason = "borrow-seam design: segment/draw_order/state/texture_cache/opacity are disjoint \
-                  WgpuPainter fields passed as separate borrows; merging them into a context struct \
-                  defeats the T9a borrow split"
-    )]
+    /// Every branch bakes the filter into the image pixels on the CPU and then
+    /// delegates to [`Self::draw_image`], so the filtered result lives in the
+    /// same `cached_images` flush bucket as a plain image draw — correct
+    /// z-order, scissor, and opacity for free. The `Mode` branch composites
+    /// each pixel as `blend_mode(src = color, dst = pixel)`, matching
+    /// `ui.ColorFilter.mode`; the `Matrix` / gamma branches apply their
+    /// per-pixel transform the same way.
     #[allow(
         clippy::many_single_char_names,
         reason = "w/h/r/g/b/a are idiomatic in CPU-side color-matrix pixel loops"
     )]
     pub(in super::super) fn draw_image_filtered(
-        &mut self,
         segment: &mut DrawSegment,
-        draw_order: &mut Vec<DrawItem>,
         state: &GpuStateStack,
         texture_cache: &mut TextureCache,
-        opacity: f32,
         image: &Image,
         dst: Rect<Pixels>,
         filter: flui_painting::display_list::ColorFilter,
@@ -451,25 +444,30 @@ impl DrawBatcher {
         use flui_painting::display_list::ColorFilter;
 
         match filter {
-            ColorFilter::Mode {
-                color,
-                blend_mode: _,
-            } => {
-                // Pragmatic v1: draw image then overlay a tinted rect.
-                // First draw the image normally.
-                Self::draw_image(segment, state, texture_cache, image, dst);
+            ColorFilter::Mode { color, blend_mode } => {
+                // `ColorFilter.mode(color, blend_mode)` composites each pixel as
+                // `blend_mode(src = color, dst = pixel)` before the layer merges
+                // with its background. Bake it per-pixel and draw the result —
+                // the same path as the Matrix / gamma branches below. (The old
+                // implementation overlaid a half-alpha rect, which the segment
+                // flush order draws *beneath* the image, so it was fully
+                // occluded for an opaque image and ignored the blend mode.)
+                let data = image.data();
+                let w = image.width();
+                let h = image.height();
+                let mut new_data = Vec::with_capacity(data.len());
 
-                // Then overlay with the tint color using a semi-transparent rect.
-                let tint_paint = Paint {
-                    color: color.with_alpha(color.a / 2),
-                    style: flui_painting::PaintStyle::Fill,
-                    ..Default::default()
-                };
-                self.rect(segment, draw_order, state, opacity, dst, &tint_paint);
+                for pixel in data.chunks_exact(4) {
+                    let dst_pixel = Color::rgba(pixel[0], pixel[1], pixel[2], pixel[3]);
+                    let blended = color.blend(dst_pixel, blend_mode);
+                    new_data.extend_from_slice(&[blended.r, blended.g, blended.b, blended.a]);
+                }
+
+                let filtered = Image::from_rgba8(w, h, new_data);
+                Self::draw_image(segment, state, texture_cache, &filtered, dst);
 
                 tracing::debug!(
-                    "draw_image_filtered: Mode filter applied as color overlay (color={:?})",
-                    color
+                    "draw_image_filtered: Mode filter baked per-pixel (color={color:?}, mode={blend_mode:?})"
                 );
             }
             ColorFilter::Matrix(matrix) => {

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -4712,4 +4712,71 @@ mod tests {
             "G={g}: expected G ≈ 0 (unchanged). pixel={px_val:?}"
         );
     }
+
+    /// Two filtered draws of the **same source image** with **different** color
+    /// filters in one frame must not alias in the texture cache.
+    ///
+    /// Each filter produces a short-lived temporary `Image`; filtered draws key
+    /// the cache on a hash of the produced bytes, not the temporary's pointer.
+    /// If they keyed on the pointer (as a plain `draw_image` does), the second
+    /// temporary — frequently reallocated at the just-freed address of the first
+    /// — would collide on key and the cache would return the first filter's
+    /// texture for the second draw (it hits on key alone, never re-comparing
+    /// bytes). Here a white source is modulated RED in the top half and BLUE in
+    /// the bottom half; a collision would paint the bottom half red.
+    #[test]
+    fn draw_image_filtered_distinct_filters_do_not_alias() {
+        use flui_painting::display_list::ColorFilter;
+        use flui_types::{painting::Image, styling::Color};
+
+        const SIZE: u32 = 16;
+        let (device, queue) = test_device_and_queue();
+
+        let white_pixels: Vec<u8> = (0..SIZE * SIZE)
+            .flat_map(|_| [255u8, 255, 255, 255])
+            .collect();
+        let white_image = Image::from_rgba8(SIZE, SIZE, white_pixels);
+
+        let modulate_red = ColorFilter::mode(
+            Color::rgba(255, 0, 0, 255),
+            flui_painting::BlendMode::Modulate,
+        );
+        let modulate_blue = ColorFilter::mode(
+            Color::rgba(0, 0, 255, 255),
+            flui_painting::BlendMode::Modulate,
+        );
+
+        let half = SIZE as f32 / 2.0;
+        let rgba = render_to_rgba(&device, &queue, SIZE, wgpu::Color::BLACK, |painter| {
+            // Two separate filtered draws → two short-lived temporaries, the
+            // second likely reusing the first's freed allocation address.
+            painter.draw_image_filtered(
+                &white_image,
+                Rect::from_xywh(px(0.0), px(0.0), px(SIZE as f32), px(half)),
+                modulate_red,
+            );
+            painter.draw_image_filtered(
+                &white_image,
+                Rect::from_xywh(px(0.0), px(half), px(SIZE as f32), px(half)),
+                modulate_blue,
+            );
+        });
+
+        let top = pixel_at(&rgba, SIZE, SIZE / 2, SIZE / 4);
+        let bottom = pixel_at(&rgba, SIZE, SIZE / 2, SIZE * 3 / 4);
+
+        // Top half: modulate RED → red.
+        assert!(
+            top[0] >= 200 && top[2] <= 40,
+            "top={top:?}: expected red (R≈255, B≈0) from modulate-RED"
+        );
+        // Bottom half: modulate BLUE → blue. A cache collision with the first
+        // (red) temporary would paint this red instead.
+        assert!(
+            bottom[2] >= 200 && bottom[0] <= 40,
+            "bottom={bottom:?}: expected blue (B≈255, R≈0) from modulate-BLUE. \
+             Red here means the second filtered draw aliased the first in the \
+             texture cache (pointer-identity key on a freed temporary)."
+        );
+    }
 }

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -1802,13 +1802,14 @@ impl WgpuPainter {
         dst: Rect<Pixels>,
         filter: flui_painting::display_list::ColorFilter,
     ) {
-        let opacity = self.compositor.current_opacity();
-        self.batcher.draw_image_filtered(
+        // Every filter branch bakes the color filter into the image pixels and
+        // routes the result through `draw_image`, so it shares the cached-image
+        // flush bucket (z-order, scissor, opacity) — no `draw_order`/`opacity`
+        // seam is needed.
+        super::batches::DrawBatcher::draw_image_filtered(
             &mut self.current_segment,
-            &mut self.draw_order,
             &self.state,
             self.resources.texture_cache_mut(),
-            opacity,
             image,
             dst,
             filter,
@@ -4519,62 +4520,53 @@ mod tests {
         );
     }
 
-    /// `draw_image_filtered` with `ColorFilter::Mode` must emit a half-alpha
-    /// tinted rect whose alpha is correctly threaded from the painter shim
-    /// through `DrawBatcher::draw_image_filtered` into the inner `rect` call.
+    /// `draw_image_filtered` with `ColorFilter::Mode` must tint an **opaque**
+    /// image — the tint has to composite *over* the image, not under it.
     ///
-    /// ## Flush-ordering note
+    /// This is the regression guard for the pre-T9 bug: the old `Mode` branch
+    /// drew the image into `cached_images` and a half-alpha tint rect into
+    /// `rect_batch`, but `flush_segment` flushes `rect_batch` *before*
+    /// `cached_images`, so an opaque image fully occluded the tint and the color
+    /// filter had no visible effect. The fix bakes `blend_mode(src = color,
+    /// dst = pixel)` into the image pixels (per `ui.ColorFilter.mode`), so the
+    /// tint is in the same flush bucket as the image.
     ///
-    /// The segment flush order is: instanced rect_batch → cached image batch.
-    /// With an **opaque** source image the image overwrites the tint rect
-    /// entirely; no useful readback is possible.  This test therefore uses a
-    /// **fully transparent** source image so the tint rect is visible through
-    /// the image layer, making the opacity-thread the sole variable under test.
+    /// ## Blend math (opaque GREEN image, BLACK background)
     ///
-    /// ## Blend math (transparent image, BLACK background)
+    /// Filter = `mode(rgba(255, 0, 0, 128), SrcOver)` over `rgba(0, 200, 0, 255)`:
+    /// `srcOver(src = red·0.5, dst = green)` ≈ `rgba(128, 100, 0, 255)`. Drawn
+    /// opaque on black it reads back ≈ `(128, 100, 0)`.
     ///
-    /// 1. Filter color = RED (255, 0, 0, 255). The Mode branch computes
-    ///    `tint_alpha = color.a / 2` (u8 integer division) = 127.
-    /// 2. With painter opacity = 1.0 (default, no push_opacity), the `rect`
-    ///    fill path uses `paint.color.a` unscaled = 127.
-    /// 3. The tint rect renders SrcOver on BLACK:
-    ///    `out_R = 255 × (127/255) + 0 × (128/255) ≈ 127`.
-    /// 4. The transparent image draws over that — no change (alpha=0).
+    /// | Scenario                                   | R    | G    |
+    /// |--------------------------------------------|------|------|
+    /// | Fixed (tint baked over image)              | ~128 | ~100 |
+    /// | Old bug (tint occluded under opaque image) | ~0   | ~200 |
     ///
-    /// Final pixel: R ≈ 127, G ≈ 0, B ≈ 0.
-    ///
-    /// ## Discriminating band: R in [80, 170]
-    ///
-    /// | Scenario                              | R    |
-    /// |---------------------------------------|------|
-    /// | Correct (opacity=1.0, alpha=127)      | ~127 |  ← in band
-    /// | opacity dropped to 0 (zero-thread)    | ~0   |  ← below band
-    /// | opacity doubled / alpha=255 (clamp)   | ~255 |  ← above band
-    /// | tint rect not emitted at all          | ~0   |  ← below band
-    ///
-    /// G and B must stay near 0 (pure red tint).
+    /// So `R` is raised well above 0 (tint applied) while `G` stays mid-range
+    /// (the image content survives). The old code fails the `R` assertion.
     #[test]
-    fn draw_image_filtered_mode_overlays_tint() {
+    fn draw_image_filtered_mode_tints_opaque_image() {
         use flui_painting::display_list::ColorFilter;
         use flui_types::{painting::Image, styling::Color};
 
-        const SIZE: u32 = 8;
+        const SIZE: u32 = 16;
         let (device, queue) = test_device_and_queue();
 
-        // Fully transparent source image: lets the tint rect show through the
-        // cached-image flush so the opacity thread is the discriminating variable.
-        let transparent_pixels: Vec<u8> = (0..SIZE * SIZE).flat_map(|_| [0u8, 0, 0, 0]).collect();
-        let transparent_image = Image::from_rgba8(SIZE, SIZE, transparent_pixels);
+        // Opaque GREEN source image — an opaque image is exactly what the old
+        // overlay path failed to tint (the tint rect was drawn underneath it).
+        let green_pixels: Vec<u8> = (0..SIZE * SIZE).flat_map(|_| [0u8, 200, 0, 255]).collect();
+        let green_image = Image::from_rgba8(SIZE, SIZE, green_pixels);
 
-        // Full-alpha RED filter color; `color.a / 2` (u8 integer div) = 127.
+        // Half-alpha RED tint via SrcOver — mixes with the image so both the
+        // tint (raised R) and the surviving image content (mid G) are visible.
         let red_filter = ColorFilter::mode(
-            Color::rgba(255, 0, 0, 255),
+            Color::rgba(255, 0, 0, 128),
             flui_painting::BlendMode::SrcOver,
         );
 
         let px_val = render_and_read_center(&device, &queue, SIZE, wgpu::Color::BLACK, |painter| {
             painter.draw_image_filtered(
-                &transparent_image,
+                &green_image,
                 Rect::from_xywh(px(0.0), px(0.0), px(SIZE as f32), px(SIZE as f32)),
                 red_filter,
             );
@@ -4586,27 +4578,138 @@ mod tests {
             i32::from(px_val[2]),
         );
 
-        // R must land in [80, 170]: half-alpha RED on BLACK ≈ 127.
-        // R ≈ 0 means tint rect was not emitted or opacity was zero-threaded.
-        // R ≈ 255 means opacity was over-multiplied (alpha saturated to 255).
+        // R raised to ~128: the tint composited over the image. R ≈ 0 means the
+        // tint was occluded under the opaque image (the original bug).
         assert!(
-            (80..=170).contains(&r),
-            "R={r}: expected R in [80, 170] (half-alpha RED SrcOver on BLACK ≈ 127). \
-             R ≈ 0 means the tint overlay was not emitted or opacity=0 was threaded. \
-             R ≈ 255 means opacity was over-multiplied (full-alpha tint). \
-             pixel={px_val:?}"
+            (90..=165).contains(&r),
+            "R={r}: expected R in [90, 165] (half-alpha RED over GREEN ≈ 128). \
+             R ≈ 0 means the tint was drawn under the opaque image and occluded \
+             (the pre-fix bug). pixel={px_val:?}"
         );
 
-        // G and B must stay near zero: pure RED tint, no other color contributor.
+        // G mid-range ~100: the underlying image content survives the tint.
         assert!(
-            g <= 30,
-            "G={g}: expected G ≈ 0 (RED-only tint, no green contribution). \
-             High G means a wrong color was used for the overlay. pixel={px_val:?}"
+            (55..=135).contains(&g),
+            "G={g}: expected G in [55, 135] (GREEN image showing through the \
+             half-alpha tint). G ≈ 200 means no tint was applied; G ≈ 0 means the \
+             image content was lost. pixel={px_val:?}"
+        );
+
+        // B near zero: neither the RED tint nor the GREEN image contributes blue.
+        assert!(
+            b <= 35,
+            "B={b}: expected B ≈ 0 (no blue contributor). pixel={px_val:?}"
+        );
+    }
+
+    /// `ColorFilter::Mode` must honor its `blend_mode`, not just composite a
+    /// fixed SrcOver tint. The old branch ignored `blend_mode` entirely.
+    ///
+    /// `mode(RED, Modulate)` over an opaque WHITE image multiplies per channel:
+    /// `red · white = red`. So a white image becomes pure red — green and blue
+    /// are driven to zero. The old code (which ignored the mode and drew an
+    /// occluded half-alpha overlay) leaves the white image untouched, so its
+    /// `G ≈ 255` fails the green assertion below.
+    #[test]
+    fn draw_image_filtered_mode_honors_blend_mode() {
+        use flui_painting::display_list::ColorFilter;
+        use flui_types::{painting::Image, styling::Color};
+
+        const SIZE: u32 = 16;
+        let (device, queue) = test_device_and_queue();
+
+        // Opaque WHITE source image.
+        let white_pixels: Vec<u8> = (0..SIZE * SIZE)
+            .flat_map(|_| [255u8, 255, 255, 255])
+            .collect();
+        let white_image = Image::from_rgba8(SIZE, SIZE, white_pixels);
+
+        let modulate_red = ColorFilter::mode(
+            Color::rgba(255, 0, 0, 255),
+            flui_painting::BlendMode::Modulate,
+        );
+
+        let px_val = render_and_read_center(&device, &queue, SIZE, wgpu::Color::BLACK, |painter| {
+            painter.draw_image_filtered(
+                &white_image,
+                Rect::from_xywh(px(0.0), px(0.0), px(SIZE as f32), px(SIZE as f32)),
+                modulate_red,
+            );
+        });
+
+        let (r, g, b) = (
+            i32::from(px_val[0]),
+            i32::from(px_val[1]),
+            i32::from(px_val[2]),
+        );
+
+        // Modulate(RED, WHITE) = RED.
+        assert!(
+            r >= 200,
+            "R={r}: expected R ≈ 255 (red·white = red). pixel={px_val:?}"
         );
         assert!(
-            b <= 30,
-            "B={b}: expected B ≈ 0 (RED-only tint, no blue contribution). \
-             High B means a wrong color was used for the overlay. pixel={px_val:?}"
+            g <= 40,
+            "G={g}: expected G ≈ 0 (modulate kills the white image's green). \
+             G ≈ 255 means blend_mode was ignored and the white image was left \
+             untinted. pixel={px_val:?}"
+        );
+        assert!(
+            b <= 40,
+            "B={b}: expected B ≈ 0 (modulate kills the white image's blue). \
+             pixel={px_val:?}"
+        );
+    }
+
+    /// `ColorFilter::Matrix` recolors the image on the CPU then routes through
+    /// `draw_image`. A red↔blue channel-swap matrix turns an opaque RED image
+    /// blue — covering the CPU-recolor delegation path the `Mode` branch now
+    /// shares.
+    #[test]
+    fn draw_image_filtered_matrix_swaps_channels() {
+        use flui_painting::display_list::ColorFilter;
+        use flui_types::painting::Image;
+
+        const SIZE: u32 = 16;
+        let (device, queue) = test_device_and_queue();
+
+        // Opaque RED source image.
+        let red_pixels: Vec<u8> = (0..SIZE * SIZE).flat_map(|_| [255u8, 0, 0, 255]).collect();
+        let red_image = Image::from_rgba8(SIZE, SIZE, red_pixels);
+
+        // 5×4 row-major matrix swapping R and B (R'=B, G'=G, B'=R, A'=A).
+        let swap_rb = ColorFilter::matrix([
+            0.0, 0.0, 1.0, 0.0, 0.0, // R' = B
+            0.0, 1.0, 0.0, 0.0, 0.0, // G' = G
+            1.0, 0.0, 0.0, 0.0, 0.0, // B' = R
+            0.0, 0.0, 0.0, 1.0, 0.0, // A' = A
+        ]);
+
+        let px_val = render_and_read_center(&device, &queue, SIZE, wgpu::Color::BLACK, |painter| {
+            painter.draw_image_filtered(
+                &red_image,
+                Rect::from_xywh(px(0.0), px(0.0), px(SIZE as f32), px(SIZE as f32)),
+                swap_rb,
+            );
+        });
+
+        let (r, g, b) = (
+            i32::from(px_val[0]),
+            i32::from(px_val[1]),
+            i32::from(px_val[2]),
+        );
+
+        assert!(
+            b >= 200,
+            "B={b}: expected B ≈ 255 (R swapped into B). pixel={px_val:?}"
+        );
+        assert!(
+            r <= 40,
+            "R={r}: expected R ≈ 0 (B=0 swapped into R). pixel={px_val:?}"
+        );
+        assert!(
+            g <= 40,
+            "G={g}: expected G ≈ 0 (unchanged). pixel={px_val:?}"
         );
     }
 }

--- a/crates/flui-types/src/styling/color.rs
+++ b/crates/flui-types/src/styling/color.rs
@@ -864,6 +864,96 @@ impl Color {
             .collect()
     }
 
+    /// Composites `self` (the **source**) over `dst` (the **destination**)
+    /// using `mode`, returning the straight-alpha result.
+    ///
+    /// This generalizes [`Color::blend_over`] (the [`SrcOver`] case) to the full
+    /// Porter-Duff operator set plus the W3C separable and non-separable blend
+    /// modes. It is the per-pixel function behind `ui.ColorFilter.mode(color,
+    /// mode)`, where the filter computes `mode(src = color, dst = each layer
+    /// pixel)` before the layer is merged with its background.
+    ///
+    /// Channels are treated as straight (un-premultiplied), sRGB-*encoded*
+    /// values normalized to `[0, 1]` — the same non-color-managed space
+    /// [`Color::blend_over`] and the GPU blend pipeline use, so the Porter-Duff
+    /// results agree with hardware blending.
+    ///
+    /// [`SrcOver`]: crate::painting::BlendMode::SrcOver
+    #[must_use]
+    pub fn blend(&self, dst: Color, mode: crate::painting::BlendMode) -> Color {
+        use crate::painting::BlendMode;
+
+        let [src_r, src_g, src_b, src_a] = self.to_f32_array();
+        let [dst_r, dst_g, dst_b, dst_a] = dst.to_f32_array();
+
+        // The output color is accumulated premultiplied, then un-premultiplied
+        // once at the end. (`src_pm`/`dst_pm` are used by the Modulate and
+        // Porter-Duff branches; the advanced branch reads straight channels.)
+        let src_pm = [src_r * src_a, src_g * src_a, src_b * src_a];
+        let dst_pm = [dst_r * dst_a, dst_g * dst_a, dst_b * dst_a];
+
+        let (out_r_pm, out_g_pm, out_b_pm, out_a) = if matches!(mode, BlendMode::Modulate) {
+            // Modulate is the component-wise product of the premultiplied colors
+            // (Skia `kModulate`): r = s * d on every channel.
+            (
+                src_pm[0] * dst_pm[0],
+                src_pm[1] * dst_pm[1],
+                src_pm[2] * dst_pm[2],
+                src_a * dst_a,
+            )
+        } else if let Some((fa, fb)) = porter_duff_factors(mode, src_a, dst_a) {
+            // Porter-Duff coverage blend: r = Fa * src_premul + Fb * dst_premul
+            // (and the same for alpha).
+            (
+                (src_pm[0] * fa + dst_pm[0] * fb).clamp(0.0, 1.0),
+                (src_pm[1] * fa + dst_pm[1] * fb).clamp(0.0, 1.0),
+                (src_pm[2] * fa + dst_pm[2] * fb).clamp(0.0, 1.0),
+                (src_a * fa + dst_a * fb).clamp(0.0, 1.0),
+            )
+        } else {
+            // Separable / non-separable blend modes composite source-over with a
+            // per-mode blend function B(Cb, Cs) (W3C Compositing and Blending
+            // Level 1, §10–11):
+            //   co = αs·(1-αb)·Cs + αs·αb·B(Cb,Cs) + (1-αs)·αb·Cb   (premultiplied)
+            //   αo = αs + αb·(1-αs)
+            let backdrop = [dst_r, dst_g, dst_b];
+            let source = [src_r, src_g, src_b];
+            let blended = if matches!(
+                mode,
+                BlendMode::Hue | BlendMode::Saturation | BlendMode::Color | BlendMode::Luminosity
+            ) {
+                nonseparable_blend(mode, backdrop, source)
+            } else {
+                [
+                    separable_blend(mode, backdrop[0], source[0]),
+                    separable_blend(mode, backdrop[1], source[1]),
+                    separable_blend(mode, backdrop[2], source[2]),
+                ]
+            };
+
+            let composite = |cs: f32, cb: f32, b: f32| {
+                src_a * (1.0 - dst_a) * cs + src_a * dst_a * b + (1.0 - src_a) * dst_a * cb
+            };
+            (
+                composite(source[0], backdrop[0], blended[0]),
+                composite(source[1], backdrop[1], blended[1]),
+                composite(source[2], backdrop[2], blended[2]),
+                src_a + dst_a * (1.0 - src_a),
+            )
+        };
+
+        if out_a <= 0.0 {
+            return Color::TRANSPARENT;
+        }
+        let unpremul = |channel_pm: f32| ((channel_pm / out_a).clamp(0.0, 1.0) * 255.0) as u8;
+        Color::rgba(
+            unpremul(out_r_pm),
+            unpremul(out_g_pm),
+            unpremul(out_b_pm),
+            (out_a.clamp(0.0, 1.0) * 255.0) as u8,
+        )
+    }
+
     // ===== Common color constants =====
 
     /// Fully transparent (alpha = 0).
@@ -903,6 +993,159 @@ impl Color {
     pub const DARK_GRAY: Color = Color::rgb(64, 64, 64);
 
     // Material Design colors will be added in future commits
+}
+
+// ===== Blend-mode evaluation helpers (used by `Color::blend`) =====
+
+/// Porter-Duff source/destination coverage factors `(Fa, Fb)` for `mode`, given
+/// source alpha `sa` and destination alpha `da`. The composited premultiplied
+/// result is `Fa·src + Fb·dst` for every channel (and for alpha).
+///
+/// Returns `None` for modes that are not a coverage-factor blend — `Modulate`
+/// (a component product) and the advanced separable/non-separable modes — which
+/// [`Color::blend`] dispatches down its other branches.
+fn porter_duff_factors(mode: crate::painting::BlendMode, sa: f32, da: f32) -> Option<(f32, f32)> {
+    use crate::painting::BlendMode;
+    Some(match mode {
+        BlendMode::Clear => (0.0, 0.0),
+        BlendMode::Src => (1.0, 0.0),
+        BlendMode::Dst => (0.0, 1.0),
+        BlendMode::SrcOver => (1.0, 1.0 - sa),
+        BlendMode::DstOver => (1.0 - da, 1.0),
+        BlendMode::SrcIn => (da, 0.0),
+        BlendMode::DstIn => (0.0, sa),
+        BlendMode::SrcOut => (1.0 - da, 0.0),
+        BlendMode::DstOut => (0.0, 1.0 - sa),
+        BlendMode::SrcATop => (da, 1.0 - sa),
+        BlendMode::DstATop => (1.0 - da, sa),
+        BlendMode::Xor => (1.0 - da, 1.0 - sa),
+        BlendMode::Plus => (1.0, 1.0),
+        _ => return None,
+    })
+}
+
+/// W3C separable blend function `B(cb, cs)` for one channel, where `cb` is the
+/// backdrop and `cs` the source (both straight, in `[0, 1]`). Only the separable
+/// advanced modes are defined here; the four non-separable HSL modes are handled
+/// by [`nonseparable_blend`], and Porter-Duff modes never reach this function.
+fn separable_blend(mode: crate::painting::BlendMode, cb: f32, cs: f32) -> f32 {
+    use crate::painting::BlendMode;
+    match mode {
+        BlendMode::Multiply => cb * cs,
+        BlendMode::Screen => cb + cs - cb * cs,
+        // overlay(cb, cs) == hardlight(cs, cb).
+        BlendMode::Overlay => hard_light(cs, cb),
+        BlendMode::Darken => cb.min(cs),
+        BlendMode::Lighten => cb.max(cs),
+        BlendMode::ColorDodge => {
+            if cb <= 0.0 {
+                0.0
+            } else if cs >= 1.0 {
+                1.0
+            } else {
+                (cb / (1.0 - cs)).min(1.0)
+            }
+        }
+        BlendMode::ColorBurn => {
+            if cb >= 1.0 {
+                1.0
+            } else if cs <= 0.0 {
+                0.0
+            } else {
+                1.0 - ((1.0 - cb) / cs).min(1.0)
+            }
+        }
+        BlendMode::HardLight => hard_light(cb, cs),
+        BlendMode::SoftLight => {
+            if cs <= 0.5 {
+                cb - (1.0 - 2.0 * cs) * cb * (1.0 - cb)
+            } else {
+                let d = if cb <= 0.25 {
+                    ((16.0 * cb - 12.0) * cb + 4.0) * cb
+                } else {
+                    cb.sqrt()
+                };
+                cb + (2.0 * cs - 1.0) * (d - cb)
+            }
+        }
+        BlendMode::Difference => (cb - cs).abs(),
+        BlendMode::Exclusion => cb + cs - 2.0 * cb * cs,
+        _ => cs,
+    }
+}
+
+/// W3C `HardLight(cb, cs)`: multiply for a dark source, screen for a light one.
+/// Also the kernel of `Overlay` with the arguments swapped.
+fn hard_light(cb: f32, cs: f32) -> f32 {
+    if cs <= 0.5 {
+        2.0 * cb * cs
+    } else {
+        1.0 - 2.0 * (1.0 - cb) * (1.0 - cs)
+    }
+}
+
+/// W3C non-separable blend (`Hue`, `Saturation`, `Color`, `Luminosity`) over the
+/// whole RGB triple; `cb` is the backdrop and `cs` the source.
+fn nonseparable_blend(mode: crate::painting::BlendMode, cb: [f32; 3], cs: [f32; 3]) -> [f32; 3] {
+    use crate::painting::BlendMode;
+    match mode {
+        BlendMode::Hue => set_lum(set_sat(cs, sat(cb)), lum(cb)),
+        BlendMode::Saturation => set_lum(set_sat(cb, sat(cs)), lum(cb)),
+        BlendMode::Color => set_lum(cs, lum(cb)),
+        BlendMode::Luminosity => set_lum(cb, lum(cs)),
+        _ => cs,
+    }
+}
+
+/// Luminosity of an RGB triple (W3C `Lum`).
+fn lum(c: [f32; 3]) -> f32 {
+    0.3 * c[0] + 0.59 * c[1] + 0.11 * c[2]
+}
+
+/// Clip an RGB triple back into `[0, 1]` while preserving its luminosity
+/// (W3C `ClipColor`). The epsilon guards avoid a `0/0` when all channels are
+/// equal (a degenerate triple has nothing to scale).
+fn clip_color(c: [f32; 3]) -> [f32; 3] {
+    let l = lum(c);
+    let n = c[0].min(c[1]).min(c[2]);
+    let x = c[0].max(c[1]).max(c[2]);
+    let mut out = c;
+    if n < 0.0 && (l - n).abs() > f32::EPSILON {
+        for ch in &mut out {
+            *ch = l + (*ch - l) * l / (l - n);
+        }
+    }
+    if x > 1.0 && (x - l).abs() > f32::EPSILON {
+        for ch in &mut out {
+            *ch = l + (*ch - l) * (1.0 - l) / (x - l);
+        }
+    }
+    out
+}
+
+/// Shift an RGB triple to the target luminosity `l` (W3C `SetLum`).
+fn set_lum(c: [f32; 3], l: f32) -> [f32; 3] {
+    let d = l - lum(c);
+    clip_color([c[0] + d, c[1] + d, c[2] + d])
+}
+
+/// Saturation of an RGB triple (W3C `Sat`): max channel minus min channel.
+fn sat(c: [f32; 3]) -> f32 {
+    c[0].max(c[1]).max(c[2]) - c[0].min(c[1]).min(c[2])
+}
+
+/// Rescale an RGB triple to the target saturation `s` (W3C `SetSat`), keeping
+/// the relative channel ordering. A flat triple (max == min) collapses to black.
+fn set_sat(c: [f32; 3], s: f32) -> [f32; 3] {
+    let mut idx = [0usize, 1, 2];
+    idx.sort_by(|&a, &b| c[a].total_cmp(&c[b]));
+    let (i_min, i_mid, i_max) = (idx[0], idx[1], idx[2]);
+    let mut out = [0.0f32; 3];
+    if c[i_max] > c[i_min] {
+        out[i_mid] = (c[i_mid] - c[i_min]) * s / (c[i_max] - c[i_min]);
+        out[i_max] = s;
+    }
+    out
 }
 
 impl Default for Color {
@@ -1009,6 +1252,129 @@ impl std::error::Error for ParseColorError {}
 mod tests {
     use super::*;
     use crate::geometry::ApproxEq;
+    use crate::painting::BlendMode;
+
+    /// Assert each RGBA channel of `actual` is within `tol` units of `expected`.
+    #[track_caller]
+    fn assert_blend_close(actual: Color, expected: Color, tol: i32) {
+        let diff = |a: u8, b: u8| (i32::from(a) - i32::from(b)).abs();
+        assert!(
+            diff(actual.r, expected.r) <= tol
+                && diff(actual.g, expected.g) <= tol
+                && diff(actual.b, expected.b) <= tol
+                && diff(actual.a, expected.a) <= tol,
+            "blend mismatch: actual={actual:?} expected={expected:?} tol={tol}"
+        );
+    }
+
+    #[test]
+    fn blend_srcover_matches_blend_over() {
+        // The general `blend` SrcOver path must agree with the dedicated
+        // (SIMD-accelerated) `blend_over` across opaque, transparent, and
+        // semi-transparent sources.
+        let backdrop = Color::rgba(20, 60, 120, 255);
+        for src in [
+            Color::rgba(255, 0, 0, 255),
+            Color::rgba(255, 0, 0, 0),
+            Color::rgba(0, 200, 50, 128),
+            Color::rgba(255, 255, 255, 64),
+        ] {
+            assert_blend_close(
+                src.blend(backdrop, BlendMode::SrcOver),
+                src.blend_over(backdrop),
+                2,
+            );
+        }
+    }
+
+    #[test]
+    fn blend_porter_duff_basics() {
+        let src = Color::rgba(255, 0, 0, 255);
+        let dst = Color::rgba(0, 0, 255, 255);
+        // Clear drops everything.
+        assert_blend_close(src.blend(dst, BlendMode::Clear), Color::TRANSPARENT, 0);
+        // Src keeps only the source; Dst keeps only the destination.
+        assert_blend_close(src.blend(dst, BlendMode::Src), src, 1);
+        assert_blend_close(src.blend(dst, BlendMode::Dst), dst, 1);
+        // SrcOver with an opaque source fully replaces the destination.
+        assert_blend_close(src.blend(dst, BlendMode::SrcOver), src, 1);
+    }
+
+    #[test]
+    fn blend_srcin_uses_destination_alpha() {
+        // SrcIn keeps the source color but clipped to the destination's alpha
+        // shape — the canonical icon-tint mode.
+        let red = Color::rgba(255, 0, 0, 255);
+        // Over an opaque destination → solid source color.
+        assert_blend_close(
+            red.blend(Color::rgba(0, 0, 255, 255), BlendMode::SrcIn),
+            red,
+            1,
+        );
+        // Over a fully transparent destination → nothing (alpha 0).
+        assert_blend_close(
+            red.blend(Color::rgba(0, 0, 255, 0), BlendMode::SrcIn),
+            Color::TRANSPARENT,
+            1,
+        );
+    }
+
+    #[test]
+    fn blend_modulate_white_is_identity() {
+        // Modulate (premultiplied component product) by white returns the
+        // destination unchanged; by black it returns black.
+        let dst = Color::rgba(100, 150, 200, 255);
+        assert_blend_close(Color::WHITE.blend(dst, BlendMode::Modulate), dst, 1);
+        assert_blend_close(
+            Color::BLACK.blend(dst, BlendMode::Modulate),
+            Color::rgba(0, 0, 0, 255),
+            1,
+        );
+    }
+
+    #[test]
+    fn blend_plus_saturates() {
+        // Plus is additive and clamps at the channel ceiling.
+        let result =
+            Color::rgba(200, 0, 0, 255).blend(Color::rgba(100, 0, 0, 255), BlendMode::Plus);
+        assert_blend_close(result, Color::rgba(255, 0, 0, 255), 1);
+    }
+
+    #[test]
+    fn blend_multiply_opaque_is_channel_product() {
+        // With opaque source and destination the separable composite reduces to
+        // B(cb, cs); for Multiply that is the per-channel product.
+        let result = Color::rgba(255, 128, 0, 255)
+            .blend(Color::rgba(128, 255, 255, 255), BlendMode::Multiply);
+        assert_blend_close(result, Color::rgba(128, 128, 0, 255), 2);
+    }
+
+    #[test]
+    fn blend_difference_opaque() {
+        // Difference = |cb - cs| per channel for opaque inputs.
+        let result =
+            Color::rgba(255, 0, 100, 255).blend(Color::rgba(0, 0, 200, 255), BlendMode::Difference);
+        // |0-255|=255, |0-0|=0, |200-100|=100.
+        assert_blend_close(result, Color::rgba(255, 0, 100, 255), 2);
+    }
+
+    #[test]
+    fn blend_luminosity_takes_source_luma_dest_chroma() {
+        // Luminosity keeps the destination hue/saturation but the source's luma.
+        // A grey source against a saturated destination yields a desaturated-
+        // toward-grey destination at the source's luminosity. Sanity-check that
+        // the output luminosity tracks the grey source rather than the dest.
+        let src = Color::rgba(128, 128, 128, 255);
+        let dst = Color::rgba(200, 50, 50, 255);
+        let result = src.blend(dst, BlendMode::Luminosity);
+        let result_lum =
+            0.3 * result.red_f32() + 0.59 * result.green_f32() + 0.11 * result.blue_f32();
+        // Source luma = 0.502; allow rounding slack.
+        assert!(
+            (result_lum - 0.502).abs() < 0.04,
+            "luminosity blend should adopt the source luma; got {result_lum} from {result:?}"
+        );
+    }
 
     #[test]
     fn test_approx_eq_identical() {


### PR DESCRIPTION
## Problem

`WgpuPainter::draw_image_filtered`'s `ColorFilter::Mode` branch drew the image into `cached_images`, then a half-alpha tint rect (`color.with_alpha(color.a / 2)`, SrcOver) into `rect_batch`. But `flush_segment` (`painter.rs` ~560-564) drains `rect_batch` **before** `cached_images`, so the tint drew **underneath** the image — fully occluded for an opaque image, giving the Mode color filter **zero visible effect**. The `color.a / 2` alpha was an invented approximation, and `blend_mode` was ignored entirely (`blend_mode: _`). The old `draw_image_filtered_mode_overlays_tint` test only passed because it used a fully transparent source image.

## Reference check (`.flutter/`)

`ui.ColorFilter.mode(color, blendMode)` (`painting.dart:4065-4085`) is a per-pixel function: it composites `blendMode(src = color, dst = each layer pixel)` **before** the layer merges with its background. It is *not* a half-alpha SrcOver overlay.

## Fix

Bake the filter into the image pixels on the CPU and route through `draw_image` — the same pattern the `Matrix`/gamma branches already use — so the filtered pixels share the image's flush bucket (correct z-order, scissor, opacity for free). Chosen over flush-reordering (can't express blend modes/alpha; would reshuffle every segment) and over a dedicated GPU pipeline (large new surface the in-flight T10 would have to migrate; the engine's color-filter answer is already CPU-recolor).

- **flui-types**: new `Color::blend(&self_as_src, dst, BlendMode) -> Color` generalizing `blend_over` (SrcOver) to all 28 modes — 13 Porter-Duff (premultiplied coefficient form + `Modulate` product), 11 W3C separable advanced, 4 non-separable HSL. Blends in straight sRGB-**encoded** `[0,1]` space (matching `blend_over` and the `Rgba8Unorm` targets) so Porter-Duff results agree with the GPU pipeline. 8 unit tests vs hand-computed oracles.
- **engine**: rewrite the `Mode` branch; drop the now-unused `draw_order`/`opacity` params (made `draw_image_filtered` an associated fn), remove the `Paint`/`DrawItem` imports, update the borrow-seam docs, and ripple the simplified call into the `painter.rs` shim.
- **tests**: replace the stale transparent-source characterization test with three discriminating GPU-readback tests (`enable-wgpu-tests`):
  - `draw_image_filtered_mode_tints_opaque_image` — opaque green + `Mode(RED·0.5, SrcOver)` → R raised to ~128 **and** G survives at ~100.
  - `draw_image_filtered_mode_honors_blend_mode` — opaque white + `Mode(RED, Modulate)` → red (proves `blend_mode` is read).
  - `draw_image_filtered_matrix_swaps_channels` — covers the shared Matrix CPU-recolor path (previously untested).

## red→green proof

Temporarily modeled the bug (Mode filter has no visible effect on an opaque image) and confirmed both Mode tests **fail** with the exact documented values — `[0,200,0]` (green, tint occluded) and `[255,255,255]` (white, blend_mode ignored) — then reverted.

## Verification (all green)

| Gate | Result |
|---|---|
| flui-types blend unit tests | 9 passed |
| flui-engine GPU-readback serial (`--test-threads 1`) | 213 passed / 0 failed |
| `cargo fmt --check` | clean |
| `clippy --all-targets -D warnings` (both crates, incl. GPU test code) | clean |
| `port-check.sh` | exit 0 |
| `cargo doc` (`RUSTDOCFLAGS=-D warnings`) | exit 0 |

T10 (replay/submit split) has not landed (latest is T9f #239), so no coordination was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)