### PR TITLE
refactor(engine): external-image IR handle-id, resolve at replay (T10a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # The full-workspace debug build of all lib+test targets (incl. the wgpu/
+      # glyphon/lyon/naga GPU stack and criterion/proptest/insta/trybuild dev-
+      # deps, with debug-assertions + debuginfo) exhausted the ~14 GB free on the
+      # default ubuntu runner — `rustc-LLVM ERROR: IO failure on output stream:
+      # No space left on device` mid-build (PRs #236/#242). Reclaim ~25 GB of
+      # preinstalled bloat we don't use BEFORE building. Linux-only guard so the
+      # step is a no-op if Windows/macOS rejoin the matrix.
+      - name: Free disk space (ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost || true
+          sudo docker image prune --all --force || true
+          df -h /
+
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 

--- a/crates/flui-engine/src/wgpu/batches/images.rs
+++ b/crates/flui-engine/src/wgpu/batches/images.rs
@@ -7,18 +7,20 @@
 //! These methods receive disjoint `WgpuPainter` fields as plain borrowed
 //! parameters; see `batches/mod.rs` for the seam contract.
 //!
-//! | Method(s)                                    | Resources borrow         |
-//! |----------------------------------------------|--------------------------|
-//! | `texture`, `draw_texture`                    | `&ExternalTextureRegistry` |
-//! | `draw_image`, `draw_atlas`                   | `&mut TextureCache`      |
-//! | `draw_image_repeat`, `draw_image_nine_slice` | `&mut TextureCache` (delegate to `draw_image`) |
-//! | `draw_image_filtered`                        | `&mut TextureCache` + `&mut Vec<DrawItem>` + `opacity: f32` (inner `rect`/`draw_image` calls) |
+//! | Method(s)                                    | Resources borrow                                  |
+//! |----------------------------------------------|---------------------------------------------------|
+//! | `texture`                                    | none — ID stored directly in IR                   |
+//! | `draw_texture`                               | `Option<(u32, u32)>` (width/height from registry, for src UV normalization only) |
+//! | `draw_image`, `draw_atlas`                   | `&mut TextureCache`                               |
+//! | `draw_image_repeat`, `draw_image_nine_slice` | `&mut TextureCache` (delegate to `draw_image`)    |
+//! | `draw_image_filtered`                        | `&mut TextureCache` + `&mut Vec<DrawItem>` + `opacity: f32` |
 //!
 //! # Invariants preserved
 //!
-//! - `cached_images` entries are `(TextureId, TextureInstance, ScissorRect)`;
-//!   `external_images` entries are `(wgpu::TextureView, TextureInstance,
-//!   ScissorRect)`.  Tuple layout and scissor-at-draw-time capture are unchanged.
+//! - `cached_images` entries are `(TextureId, TextureInstance, ScissorRect)`.
+//! - `external_images` entries are `(flui_types::painting::TextureId, TextureInstance,
+//!   ScissorRect)` — no `wgpu::TextureView` in the IR; resolution to a view
+//!   happens in `flush_segment_external_images` at replay time (T10a).
 //! - The `draw_image_repeat`/`draw_image_nine_slice` → `draw_image` delegation
 //!   produces identical per-tile/per-region calls; loop bounds and dst rects are
 //!   byte-identical to the painter originals.
@@ -38,7 +40,6 @@ use flui_types::{
 use super::{
     super::{
         command_ir::{DrawItem, DrawSegment},
-        external_texture_registry::ExternalTextureRegistry,
         state_stack::GpuStateStack,
         texture_cache::TextureCache,
     },
@@ -55,12 +56,14 @@ use super::{
 impl DrawBatcher {
     /// Record an external texture draw by ID into `external_images`.
     ///
-    /// Looks up the texture in `registry`; if not found, warns and returns
-    /// without recording anything (preserving the original painter behavior).
+    /// The `texture_id` is stored in the IR as-is; resolution to a
+    /// `wgpu::TextureView` happens at replay time in
+    /// `flush_segment_external_images`. A not-found ID at replay emits a
+    /// `tracing::warn!` and skips the draw — identical behavior to before,
+    /// now deferred to the correct side of the record/replay seam.
     pub(in super::super) fn texture(
         segment: &mut DrawSegment,
         state: &GpuStateStack,
-        registry: &ExternalTextureRegistry,
         texture_id: flui_types::painting::TextureId,
         dst_rect: Rect<Pixels>,
     ) {
@@ -70,27 +73,6 @@ impl DrawBatcher {
             texture_id,
             dst_rect
         );
-
-        // Look up texture in external texture registry and capture the view
-        // BEFORE building the instance so we can move `view` into the segment.
-        let view = if let Some(entry) = registry.get(texture_id) {
-            #[cfg(debug_assertions)]
-            tracing::trace!(
-                "DrawBatcher::texture: found {:?} ({}x{}, frame={})",
-                texture_id,
-                entry.width,
-                entry.height,
-                entry.frame_count
-            );
-            entry.view.clone()
-        } else {
-            #[cfg(debug_assertions)]
-            tracing::warn!(
-                "DrawBatcher::texture: texture {:?} not found in registry",
-                texture_id
-            );
-            return;
-        };
 
         // Apply transform to rect.
         let top_left = state.apply_transform(Point::new(dst_rect.left(), dst_rect.top()));
@@ -104,11 +86,12 @@ impl DrawBatcher {
             flui_types::Color::WHITE,
         );
 
-        // Route through per-segment external_images (flushed by flush_segment_external_images
-        // which calls flush_texture_batch per entry with the correct view bound).
+        // Store the ID in the IR. Resolution happens at replay time in
+        // flush_segment_external_images, which calls
+        // ExternalTextureRegistry::get(id) immediately before the GPU draw.
         segment
             .external_images
-            .push((view, instance, state.current_scissor()));
+            .push((texture_id, instance, state.current_scissor()));
     }
 
     /// Record an image draw by uploading (or retrieving from cache) its RGBA
@@ -672,19 +655,27 @@ impl DrawBatcher {
     /// optional source UV sub-rect, filter quality hint, and opacity.
     ///
     /// - `src` rect is normalized to the texture dimensions to produce UV
-    ///   coordinates; `None` means full texture (`[0,0,1,1]`).
+    ///   coordinates; `None` means full texture (`[0,0,1,1]`). When `src` is
+    ///   `Some`, the registry is consulted for dimensions at record time (only
+    ///   `width`/`height` — not the view). Dimensions do not change via
+    ///   [`super::super::external_texture_registry::ExternalTextureRegistry::update`],
+    ///   so this read is stable across `update()` calls.
     /// - `opacity` is baked into the tint color alpha.
     /// - `_filter_quality` is accepted for API compatibility but currently unused
     ///   (the sampler is determined at pipeline level, not per-draw).
+    ///
+    /// Resolution of the `texture_id` to a `wgpu::TextureView` happens at
+    /// replay time in `flush_segment_external_images`. A not-found ID at replay
+    /// emits a `tracing::warn!` and skips the draw.
     #[allow(
         clippy::too_many_arguments,
-        reason = "borrow-seam design: segment/state/registry are disjoint WgpuPainter fields; \
+        reason = "borrow-seam design: segment/state/src_uv_registry are disjoint parameters; \
                   src/filter_quality/opacity are distinct per-draw parameters with no natural grouping"
     )]
     pub(in super::super) fn draw_texture(
         segment: &mut DrawSegment,
         state: &GpuStateStack,
-        registry: &ExternalTextureRegistry,
+        src_uv_registry: Option<(u32, u32)>,
         texture_id: flui_types::painting::TextureId,
         dst: Rect<Pixels>,
         src: Option<Rect<Pixels>>,
@@ -700,63 +691,46 @@ impl DrawBatcher {
             opacity
         );
 
-        // Look up the external texture in the registry.
-        if let Some(entry) = registry.get(texture_id) {
-            // Calculate UV coordinates from source rect.
-            let src_uv = if let Some(src_rect) = src {
-                // Normalize to texture dimensions.
-                let tex_width = entry.width as f32;
-                let tex_height = entry.height as f32;
+        // Compute UV coordinates from the source rect.
+        //
+        // `src=None` → full texture `[0,0,1,1]` (no registry needed).
+        // `src=Some(rect)` → normalize using dimensions passed as `src_uv_registry`
+        // (`(width, height)` read by the painter shim from the registry at record
+        // time). Dimensions are stable across `update()` calls. If the texture
+        // wasn't registered at record time, `src_uv_registry` is `None` and we
+        // fall back to full UV; the replay-side not-found warn+skip will fire.
+        let src_uv = match (src, src_uv_registry) {
+            (Some(src_rect), Some((tex_width, tex_height))) => {
+                let w = tex_width as f32;
+                let h = tex_height as f32;
                 [
-                    (src_rect.left() / tex_width).0,
-                    (src_rect.top() / tex_height).0,
-                    (src_rect.right() / tex_width).0,
-                    (src_rect.bottom() / tex_height).0,
+                    (src_rect.left() / w).0,
+                    (src_rect.top() / h).0,
+                    (src_rect.right() / w).0,
+                    (src_rect.bottom() / h).0,
                 ]
-            } else {
-                // Full texture.
-                [0.0, 0.0, 1.0, 1.0]
-            };
+            }
+            // src=None or dimensions unavailable: full UV.
+            _ => [0.0, 0.0, 1.0, 1.0],
+        };
 
-            // Apply opacity via tint color alpha.
-            let tint = flui_types::styling::Color::rgba(255, 255, 255, (opacity * 255.0) as u8);
+        // Apply opacity via tint color alpha.
+        let tint = flui_types::styling::Color::rgba(255, 255, 255, (opacity * 255.0) as u8);
 
-            // Apply the current transform to dst corners (translation + scale; rotation
-            // collapses to AABB — same accepted limitation as `texture()` and `draw_image`).
-            let top_left = state.apply_transform(Point::new(dst.left(), dst.top()));
-            let bottom_right = state.apply_transform(Point::new(dst.right(), dst.bottom()));
-            let transformed_dst =
-                Rect::from_ltrb(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
+        // Apply the current transform to dst corners (translation + scale; rotation
+        // collapses to AABB — same accepted limitation as `texture()` and `draw_image`).
+        let top_left = state.apply_transform(Point::new(dst.left(), dst.top()));
+        let bottom_right = state.apply_transform(Point::new(dst.right(), dst.bottom()));
+        let transformed_dst =
+            Rect::from_ltrb(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
 
-            let instance =
-                super::super::instancing::TextureInstance::with_uv(transformed_dst, src_uv, tint);
-            // Clone the registry view so this segment owns it independently of
-            // the registry lifetime.
-            let view = entry.view.clone();
+        let instance =
+            super::super::instancing::TextureInstance::with_uv(transformed_dst, src_uv, tint);
 
-            #[cfg(debug_assertions)]
-            tracing::trace!(
-                "External texture {} found: {}x{}, frame={}",
-                texture_id.get(),
-                entry.width,
-                entry.height,
-                entry.frame_count
-            );
-
-            // Push into per-segment external_images; flushed in flush_segment
-            // via flush_segment_external_images which binds each view via
-            // flush_texture_batch — identical to the cached-image path.
-            segment
-                .external_images
-                .push((view, instance, state.current_scissor()));
-        } else {
-            // Texture not registered — warn and skip.  Rendering an invisible
-            // placeholder via `texture_batch` (the old code) would orphan the
-            // instance because texture_batch is never drained by flush_segment.
-            tracing::warn!(
-                "External texture {} not registered — skipping draw_texture",
-                texture_id.get()
-            );
-        }
+        // Push the ID into the IR. Resolution to a `wgpu::TextureView` happens
+        // at replay time in flush_segment_external_images.
+        segment
+            .external_images
+            .push((texture_id, instance, state.current_scissor()));
     }
 }

--- a/crates/flui-engine/src/wgpu/batches/images.rs
+++ b/crates/flui-engine/src/wgpu/batches/images.rs
@@ -40,11 +40,7 @@ use flui_types::{
 };
 
 use super::{
-    super::{
-        command_ir::DrawSegment,
-        state_stack::GpuStateStack,
-        texture_cache::TextureCache,
-    },
+    super::{command_ir::DrawSegment, state_stack::GpuStateStack, texture_cache::TextureCache},
     DrawBatcher,
 };
 

--- a/crates/flui-engine/src/wgpu/command_ir.rs
+++ b/crates/flui-engine/src/wgpu/command_ir.rs
@@ -9,7 +9,7 @@
 //! `painter.rs`.  These types are re-exported `pub(crate)` so `painter.rs`
 //! and future batcher/compositor modules can import from one place.
 
-use flui_types::{Rect, geometry::Pixels};
+use flui_types::{Rect, geometry::Pixels, painting::TextureId as ExternalTextureId};
 
 use super::{
     effects::GradientStop,
@@ -75,7 +75,8 @@ pub(crate) struct PendingOffscreenTexture {
 /// struct and a fresh segment begins. All subsequent drawing goes into the new
 /// segment. On `restore_layer`, the offscreen content is composited back onto
 /// the parent surface with the layer's opacity applied as a group.
-// `DrawSegment` contains `wgpu::TextureView` fields that are not `Debug`.
+// `saved_draw_order: Vec<DrawItem>` is not `Debug` because `DrawItem::OffscreenTexture`
+// wraps `PooledTexture` which wraps a non-`Debug` `wgpu::Texture`.
 #[allow(missing_debug_implementations)]
 pub(crate) struct SavedLayer {
     /// Previous draw order (restored on pop)
@@ -106,8 +107,7 @@ pub(crate) struct SavedLayer {
 /// a new one starts. This ensures that content drawn before the offscreen
 /// texture renders before it, and content drawn after renders after it,
 /// preserving correct Z-order.
-// `wgpu::TextureView` (inside `external_images`) is not `Debug`.
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 pub(crate) struct DrawSegment {
     /// Rectangle instance batch
     pub(crate) rect_batch: InstanceBatch<RectInstance>,
@@ -152,13 +152,18 @@ pub(crate) struct DrawSegment {
     pub(crate) cached_images: Vec<(TextureId, TextureInstance, ScissorRect)>,
     /// External-texture draws queued for this segment.
     ///
-    /// Each entry carries the registry's `wgpu::TextureView` alongside the
-    /// instance data so `flush_segment_external_images` can bind each view
-    /// independently — identical to how `flush_segment_cached_images` binds
-    /// per-texture views for the atlas cache.
+    /// Each entry carries the `ExternalTextureId` (a `flui_types::painting::TextureId`)
+    /// so the IR is comparable by value and free of non-`PartialEq` wgpu handles.
+    /// Resolution from ID to `wgpu::TextureView` happens at replay time in
+    /// `flush_segment_external_images`, which calls
+    /// `ExternalTextureRegistry::get(id)` immediately before the draw call.
+    ///
+    /// This means a texture `update()`d between the `draw_texture`/`texture`
+    /// call and the frame flush resolves to the newer view — the latest-frame
+    /// semantics documented in [`super::external_texture_registry`].
     ///
     /// The third element is the scissor rect active at draw time.
-    pub(crate) external_images: Vec<(wgpu::TextureView, TextureInstance, ScissorRect)>,
+    pub(crate) external_images: Vec<(ExternalTextureId, TextureInstance, ScissorRect)>,
 }
 
 impl DrawSegment {
@@ -224,7 +229,8 @@ impl DrawSegment {
 
 /// An item in the draw order list: either a segment of batched commands,
 /// an offscreen texture to composite, or an opacity layer.
-// `DrawSegment` and `PendingOffscreenTexture` are not `Debug`.
+// `PendingOffscreenTexture` (via `OffscreenTexture` variant) is not `Debug`
+// because `PooledTexture` wraps a `wgpu::Texture`.
 #[allow(missing_debug_implementations)]
 pub(crate) enum DrawItem {
     /// A segment of instanced/tessellated/gradient draw commands.
@@ -244,7 +250,7 @@ pub(crate) enum DrawItem {
 /// During [`super::painter::WgpuPainter::render`], the contained segments are
 /// flushed to a pooled offscreen texture, then that texture is composited onto
 /// the main surface with the layer opacity applied as tint alpha.
-// `DrawSegment` (via `DrawItem`) is not `Debug`.
+// `DrawItem` (via the `OffscreenTexture` variant containing `PooledTexture`) is not `Debug`.
 #[allow(missing_debug_implementations)]
 pub(crate) struct PendingOpacityLayer {
     /// Draw items accumulated between save_layer and restore_layer

--- a/crates/flui-engine/src/wgpu/external_texture_registry.rs
+++ b/crates/flui-engine/src/wgpu/external_texture_registry.rs
@@ -219,9 +219,51 @@ impl ExternalTextureRegistry {
     /// Use this for dynamic textures like video frames where the texture
     /// dimensions stay the same but the content changes.
     ///
+    /// # Contract
+    ///
+    /// The new texture **must** have the same width and height as the one
+    /// originally passed to [`Self::register`].  UV coordinates for any
+    /// `draw_texture` call that supplies a `src` sub-rect are computed from
+    /// the dimensions recorded at register time; a differently-sized
+    /// replacement would cause incorrect UV sampling without producing a
+    /// compile- or runtime error.  Violating this contract is logged as a
+    /// warning and a `debug_assert` fires in debug builds.  The stored
+    /// dimensions are kept frozen (the original values), so repeated lookups
+    /// remain consistent with the recorded draw commands.
+    ///
     /// Returns `true` if the texture was updated, `false` if not found.
     pub fn update(&mut self, texture_id: TextureId, new_texture: Texture) -> bool {
         if let Some(entry) = self.textures.get_mut(&texture_id.get()) {
+            // Guard: dimensions must not change between register and update.
+            // UV coordinates for src sub-rects are frozen at record time using
+            // entry.width/height; a resize here would silently corrupt sampling.
+            let new_size = new_texture.size();
+            let (new_w, new_h) = (new_size.width, new_size.height);
+            if new_w != entry.width || new_h != entry.height {
+                tracing::warn!(
+                    id = texture_id.get(),
+                    old_width = entry.width,
+                    old_height = entry.height,
+                    new_width = new_w,
+                    new_height = new_h,
+                    "ExternalTextureRegistry::update called with a differently-sized \
+                     texture — dimensions are frozen at register time and cannot change. \
+                     Dynamic resize is unsupported; UV coordinates recorded before this \
+                     update will sample incorrectly. Stored dimensions are unchanged."
+                );
+                debug_assert_eq!(
+                    (new_w, new_h),
+                    (entry.width, entry.height),
+                    "ExternalTextureRegistry::update: texture {} size changed from {}x{} \
+                     to {}x{} — contract violation (dimensions must stay the same)",
+                    texture_id.get(),
+                    entry.width,
+                    entry.height,
+                    new_w,
+                    new_h,
+                );
+            }
+
             // Create new view for the new texture
             let view = new_texture.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/crates/flui-engine/src/wgpu/instancing.rs
+++ b/crates/flui-engine/src/wgpu/instancing.rs
@@ -622,6 +622,7 @@ impl ShadowInstance {
 /// Batch of instances ready for rendering
 ///
 /// Groups instances by type for efficient rendering.
+#[derive(Debug)]
 pub struct InstanceBatch<T> {
     /// Instance data
     pub instances: Vec<T>,

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -1501,11 +1501,14 @@ impl WgpuPainter {
         }
     }
 
-    /// Flush external-texture draws for the current segment.
+    /// Flush all external-texture draws recorded in the current segment.
     ///
-    /// Each entry in `external_images` carries the registry's `wgpu::TextureView`
-    /// that was cloned at draw time, so we bind it directly via
-    /// `flush_texture_batch` — no lookup against `texture_cache` needed.
+    /// Each entry carries a `flui_types::painting::TextureId` (stored at record
+    /// time).  Here, at replay time, we resolve each ID to a `wgpu::TextureView`
+    /// via the external texture registry.  If an ID is not found (texture was
+    /// unregistered between record and flush), a warning is emitted and the entry
+    /// is skipped — identical behavior to before, now on the correct replay side
+    /// of the record/replay seam.
     ///
     /// Because `wgpu::TextureView` is not `PartialEq`, instances are flushed
     /// individually (one draw call per instance) rather than trying to group
@@ -1521,16 +1524,31 @@ impl WgpuPainter {
         }
 
         // Drain into a local vec so we can call &mut self methods (flush_texture_batch
-        // takes &mut self) while iterating.
+        // takes &mut self) while iterating without holding a borrow on
+        // self.current_segment.
         let pending: Vec<(
-            wgpu::TextureView,
+            flui_types::painting::TextureId,
             super::instancing::TextureInstance,
             ScissorRect,
         )> = self.current_segment.external_images.drain(..).collect();
 
-        for (tex_view, instance, scissor) in pending {
+        for (texture_id, instance, scissor) in pending {
+            // Resolve the ID to a view at replay time.
+            // We cannot hold a borrow on self.resources and call self.flush_texture_batch
+            // (&mut self) simultaneously, so we clone the view here.  External textures
+            // are uncommon; this clone is not a hot-path concern.
+            let tex_view =
+                if let Some(entry) = self.resources.external_texture_registry().get(texture_id) {
+                    entry.view.clone()
+                } else {
+                    tracing::warn!(
+                        "External texture {} not found at flush time — skipping draw",
+                        texture_id.get()
+                    );
+                    continue;
+                };
+
             // One instance → one batch-of-one → one draw call.
-            // This is the safe default when view identity cannot be checked.
             let _ = self.texture_batch.add(instance);
             self.flush_texture_batch(encoder, view, &tex_view, scissor);
         }
@@ -1738,7 +1756,6 @@ impl WgpuPainter {
         super::batches::DrawBatcher::texture(
             &mut self.current_segment,
             &self.state,
-            self.resources.external_texture_registry(),
             texture_id,
             dst_rect,
         );
@@ -1908,10 +1925,19 @@ impl WgpuPainter {
         filter_quality: flui_types::painting::FilterQuality,
         opacity: f32,
     ) {
+        // Read dimensions only when a `src` sub-rect was supplied, so the
+        // batcher can normalize pixel coordinates to UV in [0,1].  The
+        // TextureView stays in the registry until replay time.
+        let src_dimensions = src.and_then(|_| {
+            self.resources
+                .external_texture_registry()
+                .get(texture_id)
+                .map(|entry| (entry.width, entry.height))
+        });
         super::batches::DrawBatcher::draw_texture(
             &mut self.current_segment,
             &self.state,
-            self.resources.external_texture_registry(),
+            src_dimensions,
             texture_id,
             dst,
             src,
@@ -4607,6 +4633,344 @@ mod tests {
             b <= 30,
             "B={b}: expected B ≈ 0 (RED-only tint, no blue contribution). \
              High B means a wrong color was used for the overlay. pixel={px_val:?}"
+        );
+    }
+
+    /// T10a: external-texture resolution happens at replay time, not record time.
+    ///
+    /// Register a solid-RED texture under ID 77, record `draw_texture`, then
+    /// call `update()` on the same ID replacing it with a solid-GREEN texture —
+    /// all BEFORE `render()`.  Assert the readback shows GREEN, not RED.
+    ///
+    /// This test FAILS before T10a (record-time resolution → RED survives the
+    /// update) and PASSES after (replay-time resolution → GREEN wins).
+    ///
+    /// Flutter reference: `Texture` widget and the engine's `ExternalTextureRegistry`
+    /// feed the platform's most-recently-uploaded frame to the rasterizer at
+    /// present time, not at the `drawImage` command time — any frame produced
+    /// between record and rasterize is presented (latest-frame semantics).
+    /// This test encodes that contract for the FLUI IR.
+    #[test]
+    fn external_texture_resolves_at_replay_not_record_time() {
+        const SIZE: u32 = 16;
+        let (device, queue) = test_device_and_queue();
+
+        // Helper: create a solid-color 1-channel RGBA Unorm texture.
+        let make_solid_texture =
+            |device: &wgpu::Device, queue: &wgpu::Queue, r: u8, g: u8, b: u8| -> wgpu::Texture {
+                let data: Vec<u8> = (0..SIZE * SIZE).flat_map(|_| [r, g, b, 0xFFu8]).collect();
+                let tex = device.create_texture(&wgpu::TextureDescriptor {
+                    label: Some("solid color test texture"),
+                    size: wgpu::Extent3d {
+                        width: SIZE,
+                        height: SIZE,
+                        depth_or_array_layers: 1,
+                    },
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: wgpu::TextureDimension::D2,
+                    format: wgpu::TextureFormat::Rgba8Unorm,
+                    usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                    view_formats: &[],
+                });
+                queue.write_texture(
+                    wgpu::TexelCopyTextureInfo {
+                        texture: &tex,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    &data,
+                    wgpu::TexelCopyBufferLayout {
+                        offset: 0,
+                        bytes_per_row: Some(4 * SIZE),
+                        rows_per_image: Some(SIZE),
+                    },
+                    wgpu::Extent3d {
+                        width: SIZE,
+                        height: SIZE,
+                        depth_or_array_layers: 1,
+                    },
+                );
+                tex
+            };
+
+        let tex_id = flui_types::painting::TextureId::new(77);
+
+        // Build a painter with a full-size UNorm render target.
+        let target = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("replay-timing readback target"),
+            size: wgpu::Extent3d {
+                width: SIZE,
+                height: SIZE,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: READBACK_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let target_view = target.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let mut painter = WgpuPainter::with_shared_device(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            READBACK_FORMAT,
+            (SIZE, SIZE),
+        );
+
+        // Step 1: register a solid-RED texture.
+        painter.external_texture_registry_mut().register(
+            tex_id,
+            make_solid_texture(&device, &queue, 0xFF, 0x00, 0x00),
+            SIZE,
+            SIZE,
+            true,  // dynamic
+            false, // nearest sampler
+        );
+
+        // Step 2: record draw_texture.  Under record-time resolution this would
+        // capture RED's TextureView into the IR.  Under replay-time resolution
+        // only the TextureId is stored.
+        painter.draw_texture(
+            tex_id,
+            Rect::from_xywh(px(0.0), px(0.0), px(SIZE as f32), px(SIZE as f32)),
+            None,
+            flui_types::painting::FilterQuality::None,
+            1.0,
+        );
+
+        // Step 3: update the same ID to a solid-GREEN texture BEFORE render().
+        // Under record-time resolution this update would be invisible (the old
+        // RED view was already cloned into the IR).  Under replay-time resolution
+        // the registry lookup at flush time picks up GREEN.
+        let updated = painter.external_texture_registry_mut().update(
+            tex_id,
+            make_solid_texture(&device, &queue, 0x00, 0xFF, 0x00),
+        );
+        assert!(updated, "update must return true when the ID is registered");
+
+        // Step 4: render.
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        {
+            let _clear = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("replay-timing clear"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &target_view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+        }
+        painter
+            .render(&target_view, &mut encoder)
+            .expect("painter.render must succeed");
+
+        // Readback.
+        let bytes_per_pixel = 4u32;
+        let unpadded = SIZE * bytes_per_pixel;
+        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let padded_bytes_per_row = unpadded.div_ceil(align) * align;
+        let readback_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("replay-timing readback buffer"),
+            size: u64::from(padded_bytes_per_row) * u64::from(SIZE),
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: &target,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &readback_buf,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_bytes_per_row),
+                    rows_per_image: Some(SIZE),
+                },
+            },
+            wgpu::Extent3d {
+                width: SIZE,
+                height: SIZE,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let slice = readback_buf.slice(..);
+        slice.map_async(wgpu::MapMode::Read, |r| {
+            r.expect("buffer mapping must succeed");
+        });
+        device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .expect("device poll must complete the readback copy");
+
+        let data = slice.get_mapped_range();
+        // Sample center pixel.
+        let center = (SIZE / 2) as usize;
+        let stride = padded_bytes_per_row as usize;
+        let off = center * stride + center * 4;
+        let pixel = [data[off], data[off + 1], data[off + 2], data[off + 3]];
+        drop(data);
+        readback_buf.unmap();
+
+        let (r, g, b) = (
+            i32::from(pixel[0]),
+            i32::from(pixel[1]),
+            i32::from(pixel[2]),
+        );
+        // Must be GREEN (updated texture), NOT RED (originally recorded texture).
+        // Failure here means resolution happened at record time (T10a regressed).
+        assert!(
+            g > 200 && r < 20,
+            "Center pixel = {pixel:?}: expected GREEN (G>200, R<20) to prove \
+             replay-time resolution (T10a). \
+             RED (R>200, G<20) means the TextureView was captured at record time \
+             and the update() was invisible — regression in T10a record/replay seam."
+        );
+        assert!(
+            b < 20,
+            "B = {b}, expected near-zero (solid GREEN texture, no blue). pixel = {pixel:?}"
+        );
+    }
+
+    /// T10a edge: unregistered external texture at replay time is warn-skipped, not rendered.
+    ///
+    /// Sequence:
+    /// 1. Register a solid-GREEN texture under ID 88.
+    /// 2. Record `draw_texture` filling the top-left quadrant (GREEN expected there).
+    /// 3. Record a solid-RED `rect` in the bottom-right quadrant as a "frame is alive" marker.
+    /// 4. Unregister ID 88 via `unregister()` — before `render()`.
+    /// 5. `render()`.
+    ///
+    /// Assert (a): top-left quadrant center is NOT GREEN — the missing texture was
+    /// skipped, leaving the black clear color.
+    /// Assert (b): bottom-right quadrant center IS RED — the skip did not abort the
+    /// frame; subsequent draws still executed.
+    ///
+    /// This locks the Flutter-aligned "removed external texture is not composited"
+    /// contract: unregistered platform textures must not leave stale pixels, and
+    /// a missing texture must not prevent the rest of the frame from rendering.
+    #[test]
+    fn external_texture_unregistered_at_replay_is_skipped() {
+        use flui_painting::Paint;
+
+        const SIZE: u32 = 32;
+        let half = SIZE / 2;
+
+        let (device, queue) = test_device_and_queue();
+        let tex_id = flui_types::painting::TextureId::new(88);
+
+        // Build a solid-GREEN texture (SIZE×SIZE).
+        let green_data: Vec<u8> = (0..SIZE * SIZE)
+            .flat_map(|_| [0x00u8, 0xFFu8, 0x00u8, 0xFFu8])
+            .collect();
+        let green_tex = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("unregistered-test green texture"),
+            size: wgpu::Extent3d {
+                width: SIZE,
+                height: SIZE,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &green_tex,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &green_data,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(4 * SIZE),
+                rows_per_image: Some(SIZE),
+            },
+            wgpu::Extent3d {
+                width: SIZE,
+                height: SIZE,
+                depth_or_array_layers: 1,
+            },
+        );
+
+        // Use render_to_rgba so the draw closure gets &mut WgpuPainter.
+        // We register, record, unregister, then draw the RED marker — all inside
+        // the closure, before render() is called by render_to_rgba.
+        let rgba = render_to_rgba(&device, &queue, SIZE, wgpu::Color::BLACK, |painter| {
+            // Step 1: register GREEN under ID 88.
+            painter.external_texture_registry_mut().register(
+                tex_id, green_tex, SIZE, SIZE, false, // static
+                true,  // linear filter
+            );
+
+            // Step 2: record draw_texture in the top-left quadrant.
+            painter.draw_texture(
+                tex_id,
+                Rect::from_xywh(px(0.0), px(0.0), px(half as f32), px(half as f32)),
+                None,
+                flui_types::painting::FilterQuality::None,
+                1.0,
+            );
+
+            // Step 3: unregister ID 88 BEFORE render() — the recorded draw must be skipped.
+            let removed = painter.external_texture_registry_mut().unregister(tex_id);
+            assert!(removed, "unregister must return true for a registered id");
+
+            // Step 4: record a solid-RED rect in the bottom-right quadrant as a
+            // "frame is alive" marker.  This must survive the external-texture skip.
+            painter.rect(
+                Rect::from_xywh(
+                    px(half as f32),
+                    px(half as f32),
+                    px(half as f32),
+                    px(half as f32),
+                ),
+                &Paint::fill(flui_types::Color::rgba(0xFF, 0x00, 0x00, 0xFF)),
+            );
+        });
+
+        // Assert (a): top-left quadrant center was NOT rendered (GREEN texture skipped →
+        // background black remains).
+        let tl = pixel_at(&rgba, SIZE, half / 2, half / 2);
+        let (tl_r, tl_g) = (i32::from(tl[0]), i32::from(tl[1]));
+        assert!(
+            tl_g < 20 && tl_r < 20,
+            "Top-left center pixel = {tl:?}: expected near-BLACK (unregistered external \
+             texture must be skipped, not composited). High G={tl_g} means the GREEN texture \
+             was rendered despite being unregistered before render() — T10a skip-on-missing contract broken."
+        );
+
+        // Assert (b): bottom-right quadrant center IS RED — the skip did not abort the frame.
+        let br = pixel_at(&rgba, SIZE, half + half / 2, half + half / 2);
+        let (br_r, br_g) = (i32::from(br[0]), i32::from(br[1]));
+        assert!(
+            br_r > 200 && br_g < 20,
+            "Bottom-right center pixel = {br:?}: expected RED (marker rect must render \
+             even when a preceding external-texture draw was skipped). \
+             R={br_r}, G={br_g}. If R<200, the frame was aborted instead of skip+continue."
         );
     }
 }


### PR DESCRIPTION
## T10a — external-image IR handle-id (first sub-PR of T10 replay/submit split)

T9 (record-side decomposition) is complete; T10 splits the replay/GPU-emit side off `WgpuPainter`. This first PR makes the Command-IR **comparable by value** — the prerequisite for T11's deterministic-replay A/B test — by removing the non-`PartialEq` `wgpu::TextureView` from the IR.

### What this does
- **`command_ir.rs`:** `DrawSegment.external_images` → `Vec<(TextureId, TextureInstance, ScissorRect)>` (reuses `flui_types::painting::TextureId`, `Copy+Eq+Hash` — no new id type). `DrawSegment` + `InstanceBatch<T>` gain `#[derive(Debug)]` (the `TextureView` was the only non-Debug field). `DrawItem`/`SavedLayer`/`PendingOpacityLayer` still can't (PooledTexture→non-Debug `wgpu::Texture`).
- **`batches/images.rs`:** `texture`/`draw_texture` stop resolving the registry at record time (push the `TextureId`). `draw_texture` still reads only `(width,height)` for src-rect UV (dims are frozen at register).
- **`painter.rs` `flush_segment_external_images`:** resolves `registry.get(id)` → view at **replay**, warn+skip on not-found.
- **`external_texture_registry.rs` `update()`:** warn + `debug_assert` if a caller updates an id to a different-sized texture — enforces the documented same-size contract that the record-UV/replay-view split now relies on.

### Behavior (user + chief-architect approved)
- **Static textures: byte-identical.**
- **Dynamic textures:** resolution now picks the newest registered view at replay — **matches Flutter** (`TextureBox.paint` pushes a `TextureLayer` carrying the id, resolved at composite time; verified against `.flutter/texture.dart`). An external texture unregistered before flush is now skipped (was: stale view) — the intended Flutter-aligned consequence.

### Gates
- clippy (both modes) / fmt / taplo / typos / doc / port-check (trigger 19 clean) — **green**.
- **GPU-readback serial (local DX12): 213 passed / 0 failed / 7 ignored.** Two new discriminating tests: `external_texture_resolves_at_replay_not_record_time` (update id mid-frame → newest wins) and `external_texture_unregistered_at_replay_is_skipped` (missing id skipped, rest of frame renders).
- **rust-reviewer + ce-kieran** (behavior-touching → both): COMPLETE after fixes (stale doc removed; `update()` size-contract guard added). Static byte-identity, replay-resolution soundness, borrow seam, and the Debug-derive cascade all verified; `.flutter/` parity confirmed.

### Roadmap (remaining T10)
T10b (introduce `GpuReplay` + move the texture-batch flush family + re-home `texture_batch`) · T10c (move the segment flushers + viewport/quad/sampler fields) · T10d (opacity recursion + the `render()` dispatch loop → `GpuReplay::submit`; **closes C1 painter <1500 non-test**) · T10e (ADR-0006 + ARCHITECTURE + extend the Matrix4 grep to `replay.rs`). Then **T11** (deterministic-replay A/B test + two-level-IR doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)