### PR TITLE
ci: trim test-job debuginfo + measure post-build disk (complements #242 reclaim)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,16 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
+    # Complements the `Free disk space` reclaim below by shrinking the build
+    # itself. DWARF is the single largest contributor to debug-target size; the
+    # full workspace (~28 crates + the wgpu/glyphon/lyon/naga stack + dev-deps)
+    # built with full debuginfo is what crept toward the runner's disk ceiling
+    # (PRs #236/#242). `line-tables-only` drops the bulk of DWARF while keeping
+    # file:line in panic backtraces, so CI failures stay diagnosable. Scoped to
+    # this job's env so local `cargo test` debuginfo is unaffected.
+    env:
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@v6
 
@@ -126,7 +136,7 @@ jobs:
         run: |
           df -h /
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-            /opt/hostedtoolcache/CodeQL /usr/local/share/boost || true
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /usr/local/share/boost || true
           sudo docker image prune --all --force || true
           df -h /
 
@@ -148,6 +158,13 @@ jobs:
 
       - name: cargo build --workspace
         run: cargo build --workspace --all-targets
+
+      # Confirm the heavy compile (disk peak) left headroom — the reclaim above
+      # measures only around itself, not after the build. If this trends toward
+      # 0, raise the runner or trim further targets.
+      - name: Disk usage after build (ubuntu)
+        if: runner.os == 'Linux'
+        run: df -h /
 
       # `--test-threads=1` guards the documented pre-existing flui-app
       # singleton-state flake (CLAUDE.md). flui-platform tests are excluded


### PR DESCRIPTION
## Context

This PR originally carried the full disk-exhaustion fix for the `test` job (`No space left on device` on `ubuntu-latest`, PRs [#236](https://github.com/vanyastaff/flui/pull/236) / [#242](https://github.com/vanyastaff/flui/pull/242)). In the meantime **[#242](https://github.com/vanyastaff/flui/pull/242) landed its own `Free disk space (ubuntu)` reclaim step on the same job**, so this PR has been rebased onto current `main` and **reduced to the complementary, non-duplicative parts** — attacking the disk ceiling from the *build-footprint* side rather than the *free-space* side, plus measurement.

## Changes (all additive; `.github/workflows/ci.yml` only)

1. **Trim debuginfo** — `CARGO_PROFILE_DEV_DEBUG` / `CARGO_PROFILE_TEST_DEBUG = line-tables-only` on the job `env`. DWARF is the single largest contributor to debug-target size; this drops the bulk of it while **keeping `file:line` in panic backtraces** so CI failures stay diagnosable. Complements #242's reclaim — less to build means more headroom as the workspace (~28 crates and growing) expands. Scoped to the job's `env`, so local `cargo test` debuginfo is unaffected.
2. **Top up the reclaim** — add `/usr/local/.ghcup` to #242's existing `rm -rf` list. That is where `ghcup` installs GHC on current `ubuntu-latest` images (~5 GB); the list previously only had `/opt/ghc`, which is often empty on those runners.
3. **Measure the peak** — `df -h /` after `cargo build` (the disk peak). #242's reclaim brackets only itself with `df`; this confirms headroom survived the heavy compile.

## Test semantics: unchanged

Same crates (`--workspace --exclude flui-platform --lib`), same `--test-threads 1`, same exclusions. Only debuginfo level (no effect on results), one extra reclaim path, and a diagnostic `df`. **No crate source touched.**

## Verification

- ✅ YAML parses; rebased cleanly onto `main` (incl. #242) — `mergeStateStatus: CLEAN`, no duplicate reclaim step.
- ✅ Cargo accepts `line-tables-only` from the env var on the pinned 1.96 toolchain (`cargo check -p flui-types` builds clean — an invalid value would fail config parsing and break CI).
- ✅ `typos` (the `checks` job) passes on the edited file.
- ⏳ Disk measurement runs only on the `ubuntu-latest` runner (dev machine is Windows). The `df -h` after build will show the headroom in this PR's `test` job log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
