### PR TITLE
refactor(engine): introduce GpuReplay + re-home texture-batch flush family (T10b)

### DIFF
--- a/crates/flui-engine/src/wgpu/mod.rs
+++ b/crates/flui-engine/src/wgpu/mod.rs
@@ -123,6 +123,10 @@ pub(super) mod layer_compositor;
 pub(crate) mod pipelines;
 mod profiler;
 mod renderer;
+/// Texture-batch replay/submit component: owns the per-frame
+/// `texture_batch` scratch and the `flush_texture_batch*` family.
+/// Grows in T10c/d to own the full segment-flush and render loop.
+pub(super) mod replay;
 pub(crate) mod resources;
 /// Shader cache for offscreen pipelines (`OffscreenRenderer` mask /
 /// blur / morph). Cycle 4 E-7 dropped the module-level

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -25,6 +25,7 @@ use super::{
     layer_compositor::{LayerCompositor, RestoreOutcome},
     pipeline::PipelineKey,
     pipelines::PipelineSet,
+    replay::GpuReplay,
     resources::GpuResources,
     state_stack::GpuStateStack,
     text::TextRenderer,
@@ -74,11 +75,16 @@ pub struct WgpuPainter {
     /// Shared unit-quad index buffer (two triangles: 0,1,2 and 0,2,3).
     unit_quad_index_buffer: wgpu::Buffer,
 
-    /// Texture instance batch
-    texture_batch: super::instancing::InstanceBatch<super::instancing::TextureInstance>,
-
     /// Default texture sampler (linear filtering, clamp-to-edge).
     default_sampler: wgpu::Sampler,
+
+    // ===== Texture-batch replay/submit =====
+    /// Owns the per-frame texture-instance scratch batch and the
+    /// `flush_texture_batch*` GPU submit helpers.  Separated from the
+    /// painter so the replay path can be borrowed independently of the
+    /// other flush-side state.  Grows in T10c/d to own the full
+    /// segment-flush and render loop.
+    replay: GpuReplay,
 
     // ===== Record-side draw batcher =====
     /// Owns the tessellator, path cache, and superellipse cache — the three
@@ -207,8 +213,7 @@ impl WgpuPainter {
             usage: wgpu::BufferUsages::INDEX,
         });
 
-        // ===== Texture instance batch and default sampler =====
-        let texture_batch = super::instancing::InstanceBatch::new(1024);
+        // ===== Default sampler =====
         let default_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             label: Some("Default Texture Sampler"),
             address_mode_u: wgpu::AddressMode::ClampToEdge,
@@ -241,8 +246,8 @@ impl WgpuPainter {
             viewport_bind_group,
             unit_quad_buffer,
             unit_quad_index_buffer,
-            texture_batch,
             default_sampler,
+            replay: GpuReplay::new(),
             batcher: super::batches::DrawBatcher::new(),
             text_renderer,
             state: GpuStateStack::new(),
@@ -482,7 +487,7 @@ impl WgpuPainter {
                         p.bounds,
                         flui_types::styling::Color::WHITE,
                     );
-                    let _ = self.texture_batch.add(instance);
+                    let _ = self.replay.texture_batch.add(instance);
                     // Offscreen compositing is always full-viewport — no scissor.
                     //
                     // These are shader-mask / backdrop-blur results from
@@ -634,7 +639,7 @@ impl WgpuPainter {
                         p.bounds,
                         flui_types::styling::Color::WHITE,
                     );
-                    let _ = self.texture_batch.add(instance);
+                    let _ = self.replay.texture_batch.add(instance);
                     // Nested offscreen compositing — full-viewport, no scissor.
                     self.flush_texture_batch_premultiplied(
                         encoder,
@@ -687,7 +692,7 @@ impl WgpuPainter {
             [uv_left, uv_top, uv_right, uv_bottom],
             tint,
         );
-        let _ = self.texture_batch.add(instance);
+        let _ = self.replay.texture_batch.add(instance);
         // Opacity-layer composite onto main surface — full-viewport, no scissor.
         // Premultiplied: the offscreen texels are premultiplied (see above).
         self.flush_texture_batch_premultiplied(encoder, main_view, offscreen_view, None);
@@ -1303,15 +1308,15 @@ impl WgpuPainter {
         self.current_segment.sweep_grad_scissors.clear();
     }
 
-    /// Flush texture instance batch with given texture (straight-alpha blend).
+    /// Flush the texture instance batch with straight-alpha blending.
     ///
     /// Renders all batched textures in a single draw call using GPU instancing.
-    /// This is 50-100x faster than individual draw calls for image-heavy UIs.
+    /// This is 50–100× faster than individual draw calls for image-heavy UIs.
     ///
     /// This is the **straight-alpha** entry point used for normal decoded-image
     /// draws, whose samples carry straight (non-premultiplied) alpha. Offscreen
-    /// *layer* composites must instead use `flush_texture_batch_premultiplied`,
-    /// because their texels are premultiplied — see that method and
+    /// *layer* composites must instead use the premultiplied variant — see
+    /// `GpuReplay::flush_texture_batch_premultiplied` and
     /// `flush_opacity_layer`.
     ///
     /// `scissor` is the clip rect to apply for this draw call.  Pass `None` to
@@ -1330,20 +1335,28 @@ impl WgpuPainter {
         texture_view: &wgpu::TextureView,
         scissor: ScissorRect,
     ) {
-        self.flush_texture_batch_with_blend(encoder, view, texture_view, scissor, false);
+        self.replay.flush_texture_batch(
+            &self.device,
+            &self.queue,
+            &self.pipelines,
+            &self.viewport_bind_group,
+            &self.unit_quad_buffer,
+            &self.unit_quad_index_buffer,
+            &self.default_sampler,
+            &mut self.resources,
+            self.size,
+            encoder,
+            view,
+            texture_view,
+            scissor,
+        );
     }
 
-    /// Flush texture instance batch using **premultiplied** source-over blending.
+    /// Flush the texture instance batch using **premultiplied** source-over
+    /// blending.
     ///
-    /// Used to composite offscreen *layer* textures
-    /// (opacity / ColorFilter / ShaderMask / backdrop results). Those offscreens
-    /// are cleared transparent then drawn into with straight `ALPHA_BLENDING`,
-    /// which leaves their texels premultiplied (`rgb = straight_rgb * a`).
-    /// Compositing them with the straight pipeline would re-multiply rgb by
-    /// alpha, darkening translucent/AA content. This routes the batch through
-    /// [`super::pipelines::PipelineSet::instanced_texture_premul`] (src factor `One`) so the
-    /// composite is correct, with the per-channel `tint` carrying group opacity
-    /// and any ColorFilter chroma as `(C.r*O, C.g*O, C.b*O, O)`.
+    /// Thin forwarder to [`GpuReplay::flush_texture_batch_premultiplied`]; the
+    /// GPU plumbing fields stay on `WgpuPainter` until T10c/d.
     fn flush_texture_batch_premultiplied(
         &mut self,
         encoder: &mut wgpu::CommandEncoder,
@@ -1351,107 +1364,21 @@ impl WgpuPainter {
         texture_view: &wgpu::TextureView,
         scissor: ScissorRect,
     ) {
-        self.flush_texture_batch_with_blend(encoder, view, texture_view, scissor, true);
-    }
-
-    /// Shared body for [`Self::flush_texture_batch`] and
-    /// [`Self::flush_texture_batch_premultiplied`].
-    ///
-    /// `premultiplied` selects the blend pipeline: `false` =
-    /// straight-alpha (decoded images), `true` = premultiplied source-over
-    /// (offscreen-layer composites).
-    fn flush_texture_batch_with_blend(
-        &mut self,
-        encoder: &mut wgpu::CommandEncoder,
-        view: &wgpu::TextureView,
-        texture_view: &wgpu::TextureView,
-        scissor: ScissorRect,
-        premultiplied: bool,
-    ) {
-        if self.texture_batch.is_empty() {
-            return;
-        }
-
-        #[cfg(debug_assertions)]
-        tracing::trace!(
-            "WgpuPainter::flush_texture_batch: {} instances",
-            self.texture_batch.len()
-        );
-
-        // Create texture bind group for this batch
-        let texture_bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("Texture Instance Bind Group"),
-            layout: &self.pipelines.texture_bind_group_layout,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: wgpu::BindingResource::Sampler(&self.default_sampler),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: wgpu::BindingResource::TextureView(texture_view),
-                },
-            ],
-        });
-
-        // Upload instance buffer (using buffer pool for efficient zero-copy reuse)
-        let instance_buffer = self.resources.buffer_pool_mut().get_vertex_buffer(
+        self.replay.flush_texture_batch_premultiplied(
             &self.device,
             &self.queue,
-            "Texture Instance Buffer",
-            self.texture_batch.as_bytes(),
+            &self.pipelines,
+            &self.viewport_bind_group,
+            &self.unit_quad_buffer,
+            &self.unit_quad_index_buffer,
+            &self.default_sampler,
+            &mut self.resources,
+            self.size,
+            encoder,
+            view,
+            texture_view,
+            scissor,
         );
-
-        // Create render pass
-        let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: Some("Instanced Texture Render Pass"),
-            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                view,
-                resolve_target: None,
-                depth_slice: None,
-                ops: wgpu::Operations {
-                    load: wgpu::LoadOp::Load, // Don't clear - render on top
-                    store: wgpu::StoreOp::Store,
-                },
-            })],
-            depth_stencil_attachment: None,
-            timestamp_writes: None,
-            occlusion_query_set: None,
-            multiview_mask: None,
-        });
-
-        // Set pipeline and buffers. Offscreen-layer composites use the
-        // premultiplied pipeline; normal decoded-image draws use straight alpha.
-        // Selection logic is behavior-preserving (round-5c color-correctness fix).
-        let pipeline = if premultiplied {
-            &self.pipelines.instanced_texture_premul
-        } else {
-            &self.pipelines.instanced_texture
-        };
-        render_pass.set_pipeline(pipeline);
-        render_pass.set_bind_group(0, &self.viewport_bind_group, &[]);
-        render_pass.set_bind_group(1, &texture_bind_group, &[]);
-        render_pass.set_vertex_buffer(0, self.unit_quad_buffer.slice(..));
-        render_pass.set_vertex_buffer(1, instance_buffer.slice(..));
-        render_pass.set_index_buffer(
-            self.unit_quad_index_buffer.slice(..),
-            wgpu::IndexFormat::Uint16,
-        );
-
-        // Apply scissor rect, mirroring the rect/circle/arc instanced batch pattern.
-        if let Some((x, y, w, h)) = scissor {
-            render_pass.set_scissor_rect(x, y, w, h);
-        } else {
-            render_pass.set_scissor_rect(0, 0, self.size.0, self.size.1);
-        }
-
-        // Draw all instances in ONE draw call.
-        render_pass.draw_indexed(0..6, 0, 0..self.texture_batch.len() as u32);
-
-        drop(render_pass);
-
-        // Clear batch for next frame
-        self.texture_batch.clear();
     }
 
     fn flush_segment_cached_images(
@@ -1490,7 +1417,7 @@ impl WgpuPainter {
 
             active_scissor = scissor;
             if let Some(texture_view) = active_texture_view.as_ref()
-                && self.texture_batch.add(instance)
+                && self.replay.texture_batch.add(instance)
             {
                 self.flush_texture_batch(encoder, view, texture_view, active_scissor);
             }
@@ -1549,7 +1476,7 @@ impl WgpuPainter {
                 };
 
             // One instance → one batch-of-one → one draw call.
-            let _ = self.texture_batch.add(instance);
+            let _ = self.replay.texture_batch.add(instance);
             self.flush_texture_batch(encoder, view, &tex_view, scissor);
         }
     }

--- a/crates/flui-engine/src/wgpu/replay.rs
+++ b/crates/flui-engine/src/wgpu/replay.rs
@@ -1,0 +1,302 @@
+//! Texture-batch replay/submit component for `WgpuPainter`.
+//!
+//! `GpuReplay` owns the per-frame texture-instance scratch batch and the
+//! three flush helpers that submit it to the GPU.  This is the **skeleton** of
+//! the record/replay split introduced in T10:
+//!
+//! | T10 step | What moves                                                |
+//! |----------|-----------------------------------------------------------|
+//! | T10b (this) | `texture_batch` field + `flush_texture_batch*` family |
+//! | T10c     | Segment-flush helpers (`flush_segment*`)                  |
+//! | T10d     | Top-level `render()` / `flush_opacity_layer`              |
+//!
+//! ## Borrow-split strategy
+//!
+//! The GPU plumbing fields (`device`, `queue`, `pipelines`, `viewport_bind_group`,
+//! `unit_quad_buffer`, `unit_quad_index_buffer`, `default_sampler`) still live on
+//! `WgpuPainter` in T10b.  They are passed as borrowed parameters to each flush
+//! method so that `&mut GpuReplay` and `&WgpuPainter`-owned fields can coexist
+//! in the same call without `&mut self` on the painter.  T10c/d will move those
+//! fields here as the split progresses.
+//!
+//! ## Invariants
+//!
+//! - `texture_batch` is allocated once at construction time with a capacity of
+//!   1 024 instances.  It is cleared at the end of each flush, preserving the
+//!   allocated capacity across frames (no per-frame heap allocation).
+//! - Every `flush_texture_batch*` call leaves the batch empty on return.
+//! - Neither this module nor its callers bring in `flui_types::Matrix4` — the
+//!   C4 rule (port-check Trigger 19) keeps `Matrix4` out of the batches and
+//!   replay path.
+
+use std::sync::Arc;
+
+use super::{
+    command_ir::ScissorRect,
+    instancing::{InstanceBatch, TextureInstance},
+    pipelines::PipelineSet,
+    resources::GpuResources,
+};
+
+/// Owns the texture-instance scratch batch and the GPU flush helpers that
+/// submit it.
+///
+/// Created once per `WgpuPainter` via [`GpuReplay::new`] and stored as the
+/// `replay` field.  Callers accumulate instances with
+/// `replay.texture_batch.add(instance)` and submit the batch with one of the
+/// three flush methods, passing the GPU plumbing they need as borrowed
+/// parameters.
+// `wgpu::Device` / `wgpu::Queue` do not implement `Debug`.
+#[allow(missing_debug_implementations)]
+pub(super) struct GpuReplay {
+    /// Per-frame scratch batch for texture instances.
+    ///
+    /// Allocated once at construction time (1 024-instance capacity) and
+    /// cleared after each flush.  Accumulate with `.texture_batch.add(instance)`;
+    /// submit with one of the `flush_texture_batch*` methods.
+    pub(super) texture_batch: InstanceBatch<TextureInstance>,
+}
+
+// The flush methods temporarily accept GPU plumbing fields (device, queue,
+// pipelines, buffers, sampler, resources) as borrowed parameters because those
+// fields still live on `WgpuPainter` in T10b.  T10c/d will move them here,
+// eliminating the argument lists entirely.  The `too_many_arguments` lint is
+// suppressed for this transitional state only.
+//
+// `cast_possible_truncation` and `cast_sign_loss` are suppressed for the same
+// reason as in `painter.rs`: GPU rendering converts between numeric types
+// (pixel coords, buffer indices, instance counts) intentionally.
+#[allow(
+    clippy::too_many_arguments,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap
+)]
+impl GpuReplay {
+    /// Create a new [`GpuReplay`] with a pre-allocated texture-instance scratch
+    /// batch.
+    ///
+    /// Mirrors the `texture_batch` initialisation that previously lived in
+    /// `WgpuPainter::with_shared_device`.
+    pub(super) fn new() -> Self {
+        Self {
+            texture_batch: InstanceBatch::new(1024),
+        }
+    }
+
+    /// Flush the texture instance batch with straight-alpha blending.
+    ///
+    /// Renders all batched textures in a single draw call using GPU instancing.
+    /// This is 50–100× faster than individual draw calls for image-heavy UIs.
+    ///
+    /// This is the **straight-alpha** entry point used for normal decoded-image
+    /// draws, whose samples carry straight (non-premultiplied) alpha. Offscreen
+    /// *layer* composites must instead use
+    /// [`flush_texture_batch_premultiplied`](Self::flush_texture_batch_premultiplied),
+    /// because their texels are premultiplied — see that method and
+    /// `WgpuPainter::flush_opacity_layer`.
+    ///
+    /// `scissor` is the clip rect to apply for this draw call.  Pass `None` to
+    /// render unclipped (full viewport), matching the behaviour of the
+    /// rect/circle instanced batches when no scissor is active.
+    ///
+    /// # Arguments
+    /// * `device` - wgpu device
+    /// * `queue` - wgpu queue
+    /// * `pipelines` - pipeline collection (selects the straight-alpha pipeline)
+    /// * `viewport_bind_group` - group 0 viewport uniform bind group
+    /// * `unit_quad_buffer` - shared unit-quad vertex buffer
+    /// * `unit_quad_index_buffer` - shared unit-quad index buffer
+    /// * `default_sampler` - linear/clamp-to-edge sampler
+    /// * `resources` - GPU resource managers (buffer pool used for instance upload)
+    /// * `viewport_size` - current viewport `(width, height)` in physical pixels
+    /// * `encoder` - command encoder
+    /// * `view` - render target view
+    /// * `texture_view` - texture to use for all instances in this batch
+    /// * `scissor` - optional scissor rect `(x, y, w, h)` in physical pixels
+    pub(super) fn flush_texture_batch(
+        &mut self,
+        device: &Arc<wgpu::Device>,
+        queue: &Arc<wgpu::Queue>,
+        pipelines: &PipelineSet,
+        viewport_bind_group: &wgpu::BindGroup,
+        unit_quad_buffer: &wgpu::Buffer,
+        unit_quad_index_buffer: &wgpu::Buffer,
+        default_sampler: &wgpu::Sampler,
+        resources: &mut GpuResources,
+        viewport_size: (u32, u32),
+        encoder: &mut wgpu::CommandEncoder,
+        view: &wgpu::TextureView,
+        texture_view: &wgpu::TextureView,
+        scissor: ScissorRect,
+    ) {
+        self.flush_texture_batch_with_blend(
+            device,
+            queue,
+            pipelines,
+            viewport_bind_group,
+            unit_quad_buffer,
+            unit_quad_index_buffer,
+            default_sampler,
+            resources,
+            viewport_size,
+            encoder,
+            view,
+            texture_view,
+            scissor,
+            false,
+        );
+    }
+
+    /// Flush the texture instance batch using **premultiplied** source-over
+    /// blending.
+    ///
+    /// Used to composite offscreen *layer* textures (opacity / ColorFilter /
+    /// ShaderMask / backdrop results). Those offscreens are cleared transparent
+    /// then drawn into with straight `ALPHA_BLENDING`, which leaves their texels
+    /// premultiplied (`rgb = straight_rgb * a`). Compositing them with the
+    /// straight pipeline would re-multiply rgb by alpha, darkening translucent/AA
+    /// content. This routes the batch through
+    /// [`PipelineSet::instanced_texture_premul`] (src factor `One`) so the
+    /// composite is correct, with the per-channel `tint` carrying group opacity
+    /// and any ColorFilter chroma as `(C.r*O, C.g*O, C.b*O, O)`.
+    pub(super) fn flush_texture_batch_premultiplied(
+        &mut self,
+        device: &Arc<wgpu::Device>,
+        queue: &Arc<wgpu::Queue>,
+        pipelines: &PipelineSet,
+        viewport_bind_group: &wgpu::BindGroup,
+        unit_quad_buffer: &wgpu::Buffer,
+        unit_quad_index_buffer: &wgpu::Buffer,
+        default_sampler: &wgpu::Sampler,
+        resources: &mut GpuResources,
+        viewport_size: (u32, u32),
+        encoder: &mut wgpu::CommandEncoder,
+        view: &wgpu::TextureView,
+        texture_view: &wgpu::TextureView,
+        scissor: ScissorRect,
+    ) {
+        self.flush_texture_batch_with_blend(
+            device,
+            queue,
+            pipelines,
+            viewport_bind_group,
+            unit_quad_buffer,
+            unit_quad_index_buffer,
+            default_sampler,
+            resources,
+            viewport_size,
+            encoder,
+            view,
+            texture_view,
+            scissor,
+            true,
+        );
+    }
+
+    /// Shared body for [`Self::flush_texture_batch`] and
+    /// [`Self::flush_texture_batch_premultiplied`].
+    ///
+    /// `premultiplied` selects the blend pipeline: `false` =
+    /// straight-alpha (decoded images), `true` = premultiplied source-over
+    /// (offscreen-layer composites).
+    fn flush_texture_batch_with_blend(
+        &mut self,
+        device: &Arc<wgpu::Device>,
+        queue: &Arc<wgpu::Queue>,
+        pipelines: &PipelineSet,
+        viewport_bind_group: &wgpu::BindGroup,
+        unit_quad_buffer: &wgpu::Buffer,
+        unit_quad_index_buffer: &wgpu::Buffer,
+        default_sampler: &wgpu::Sampler,
+        resources: &mut GpuResources,
+        viewport_size: (u32, u32),
+        encoder: &mut wgpu::CommandEncoder,
+        view: &wgpu::TextureView,
+        texture_view: &wgpu::TextureView,
+        scissor: ScissorRect,
+        premultiplied: bool,
+    ) {
+        if self.texture_batch.is_empty() {
+            return;
+        }
+
+        #[cfg(debug_assertions)]
+        tracing::trace!(
+            "GpuReplay::flush_texture_batch: {} instances",
+            self.texture_batch.len()
+        );
+
+        // Create texture bind group for this batch
+        let texture_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Texture Instance Bind Group"),
+            layout: &pipelines.texture_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Sampler(default_sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(texture_view),
+                },
+            ],
+        });
+
+        // Upload instance buffer (using buffer pool for efficient zero-copy reuse)
+        let instance_buffer = resources.buffer_pool_mut().get_vertex_buffer(
+            device,
+            queue,
+            "Texture Instance Buffer",
+            self.texture_batch.as_bytes(),
+        );
+
+        // Create render pass
+        let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("Instanced Texture Render Pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view,
+                resolve_target: None,
+                depth_slice: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load, // Don't clear - render on top
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+
+        // Set pipeline and buffers. Offscreen-layer composites use the
+        // premultiplied pipeline; normal decoded-image draws use straight alpha.
+        // Selection logic is behavior-preserving (round-5c color-correctness fix).
+        let pipeline = if premultiplied {
+            &pipelines.instanced_texture_premul
+        } else {
+            &pipelines.instanced_texture
+        };
+        render_pass.set_pipeline(pipeline);
+        render_pass.set_bind_group(0, viewport_bind_group, &[]);
+        render_pass.set_bind_group(1, &texture_bind_group, &[]);
+        render_pass.set_vertex_buffer(0, unit_quad_buffer.slice(..));
+        render_pass.set_vertex_buffer(1, instance_buffer.slice(..));
+        render_pass.set_index_buffer(unit_quad_index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+
+        // Apply scissor rect, mirroring the rect/circle/arc instanced batch pattern.
+        if let Some((x, y, w, h)) = scissor {
+            render_pass.set_scissor_rect(x, y, w, h);
+        } else {
+            render_pass.set_scissor_rect(0, 0, viewport_size.0, viewport_size.1);
+        }
+
+        // Draw all instances in ONE draw call.
+        render_pass.draw_indexed(0..6, 0, 0..self.texture_batch.len() as u32);
+
+        drop(render_pass);
+
+        // Clear batch for next frame
+        self.texture_batch.clear();
+    }
+}


### PR DESCRIPTION
## T10b — GpuReplay skeleton + texture-batch flush family (second sub-PR of T10)

Second step of the replay/submit split. Introduces the **`GpuReplay`** component (`replay.rs`) — the eventual owner of the replay/GPU-emit path — as a skeleton, and moves the texture-batch flush family + the `texture_batch` scratch onto it. **Pure relocation, zero behavior change.**

### What this does
- New `replay.rs`: `pub(super) struct GpuReplay` owning `texture_batch` (moved off `WgpuPainter`) + `flush_texture_batch` / `flush_texture_batch_premultiplied` / `flush_texture_batch_with_blend`.
- The flush methods read GPU plumbing (`device`/`queue`/`pipelines`/`viewport_bind_group`/`unit_quad` buffers/`default_sampler`/`resources`/`size`) that still lives on the painter — taken as **borrowed params** for now (T10c moves those fields into `GpuReplay`). The `#[allow(too_many_arguments)]` documents this temporary borrow-split.
- Painter gains `replay: GpuReplay`; all `texture_batch` accumulate/inspect sites repoint to `self.replay.texture_batch`. The accumulate→flush→clear cycle is unchanged.
- Public `WgpuPainter::flush_texture_batch` kept as a thin forwarder (**0 semver**).

### Gates
- clippy (both modes) / fmt / taplo / typos / doc / port-check — **green**.
- **GPU-readback serial (local DX12): 216 passed / 0 failed / 7 ignored** (pure move — no test added/removed).
- **rust-reviewer**: COMPLETE — bodies byte-identical, `texture_batch` fully re-homed (no residual `self.texture_batch` on painter), disjoint-field borrow seam sound, public forwarder 0-semver. The one cosmetic trace-string drift (`WgpuPainter::`→`GpuReplay::`) fixed.

### Roadmap (remaining T10)
T10c (move the segment flushers + the viewport/quad/sampler fields into `GpuReplay`) · T10d (opacity recursion + the `render()` dispatch loop → `GpuReplay::submit`; **closes C1 painter <1500 non-test**; both reviewers, R1/R2/R3 interaction risks) · T10e (ADR-0006 + ARCHITECTURE + extend the Matrix4 grep to `replay.rs`). Then **T11** (deterministic-replay A/B test + two-level-IR doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)