### PR TITLE
docs(engine): mark T10 replay/submit split shipped + extend C4 grep to replay.rs (T10e)

### DIFF
--- a/crates/flui-engine/ARCHITECTURE.md
+++ b/crates/flui-engine/ARCHITECTURE.md
@@ -147,13 +147,36 @@ Per-frame `Arc::clone` removal (verdict's U7) and `Arc<Mutex<OffscreenRenderer>>
 
 ---
 
-## Record-side boundary (engine overhaul T7–T9)
+## Record/replay boundary (engine overhaul T7–T10)
 
-This section documents the decomposition of `WgpuPainter` performed in the engine-overhaul series (PRs #231–#232, T9 sub-PRs). The governing decision is recorded in [`docs/adr/ADR-0006-c-ir-record-replay-seam.md`](../../docs/adr/ADR-0006-c-ir-record-replay-seam.md).
+This section documents the decomposition of `WgpuPainter` performed in the engine-overhaul series (PRs #231–#232, T9–T10 sub-PRs). The governing decision is recorded in [`docs/adr/ADR-0006-c-ir-record-replay-seam.md`](../../docs/adr/ADR-0006-c-ir-record-replay-seam.md).
+
+### Two-level picture
+
+```
+Backend (CommandRenderer)
+  │  visits flui_layer::Scene, converts Matrix4 → glam::Mat4 at the boundary
+  ▼
+WgpuPainter::draw_* (thin shims — field-split self → DrawBatcher)
+  │  record side: DrawBatcher builds the Command-IR
+  ▼
+DrawBatcher (batches/{shapes,gradients,paths,images}.rs)
+  │  writes DrawSegment / DrawItem structs — the Command IR
+  │  Matrix4-free; glam-only (C4 rule, Trigger 19)
+  ▼
+WgpuPainter::render() — record-finish + self.replay.submit(…)
+  │  replay side: GpuReplay consumes the Command-IR → GPU draw calls
+  ▼
+GpuReplay::submit (replay.rs)
+     owns 5 GPU-plumbing fields, texture-batch scratch,
+     6 segment-flush families, submit dispatch loop,
+     flush_opacity_layer recursion, reintegrate_offscreen_content
+     Matrix4-free; glam-only (C4 rule, Trigger 19)
+```
 
 ### WgpuPainter as thin coordinator
 
-`WgpuPainter` is the per-frame coordinator; it no longer owns logic, only state and delegation:
+`WgpuPainter` is the per-frame coordinator (1 432 non-test LOC post-T10; **C1 closed**): it holds state and delegates — no record logic, no replay logic:
 
 | Field | Owner | Module |
 |---|---|---|
@@ -162,6 +185,7 @@ This section documents the decomposition of `WgpuPainter` performed in the engin
 | `resources: GpuResources` | `TexturePool` / `BufferPool` / `TextureCache` / `ExternalTextureRegistry` | [`src/wgpu/resources.rs`](src/wgpu/resources.rs) |
 | `pipelines: PipelineSet` | 9 named `RenderPipeline` fields + `PipelineCache` (composition) | [`src/wgpu/pipelines.rs`](src/wgpu/pipelines.rs) |
 | `current_segment: DrawSegment`, `draw_order: Vec<DrawItem>` | Command IR — the record output | [`src/wgpu/command_ir.rs`](src/wgpu/command_ir.rs) |
+| `replay: GpuReplay` | GPU-emit/submit path — the replay side | [`src/wgpu/replay.rs`](src/wgpu/replay.rs) |
 
 Record methods (per-primitive draw calls) are owned by `DrawBatcher` in `batches/`:
 
@@ -171,6 +195,8 @@ Record methods (per-primitive draw calls) are owned by `DrawBatcher` in `batches
 | [`src/wgpu/batches/gradients.rs`](src/wgpu/batches/gradients.rs) | linear gradient, radial gradient, sweep gradient, `dispatch_shader_rect` |
 | [`src/wgpu/batches/paths.rs`](src/wgpu/batches/paths.rs) | `draw_path`, `draw_vertices` |
 | [`src/wgpu/batches/images.rs`](src/wgpu/batches/images.rs) | `draw_image`, `draw_image_repeat`, `draw_image_nine_slice`, `draw_image_filtered`, `draw_atlas`, `draw_texture` |
+
+`GpuReplay` (`replay.rs`) owns the replay/submit path: it holds the viewport_buffer, viewport_bind_group, two unit_quad buffers, the default_sampler, the texture_batch scratch, and the 6 segment-flush families (`flush_rect_batch`, `flush_circle_batch`, `flush_arc_batch`, `flush_path_batch`, `flush_image_batch`, `flush_gradient_batch`). `GpuReplay::submit` is the top-level dispatch loop that consumes `&DrawSegment` / `&[DrawItem]` and drives GPU encoding, including `flush_opacity_layer` recursion and `reintegrate_offscreen_content`.
 
 `text` / `rich_text` remain on `WgpuPainter` pending T11 (the text-vs-IR seam decision).
 
@@ -194,24 +220,24 @@ fn draw_*(
 
 ### C1 definition — module file size limit
 
-Each module file in `batches/` must stay **< 1 500 non-test LOC**. `/spec-verify` measures non-test LOC (i.e., lines outside `#[cfg(test)]` blocks and `mod tests { … }` sections). The same limit applies to `state_stack.rs`, `layer_compositor.rs`, `resources.rs`, and `pipelines.rs`.
+Each module file in `batches/` must stay **< 1 500 non-test LOC**. `/spec-verify` measures non-test LOC (i.e., lines outside `#[cfg(test)]` blocks and `mod tests { … }` sections). The same limit applies to `state_stack.rs`, `layer_compositor.rs`, `resources.rs`, `pipelines.rs`, and `replay.rs`.
 
-`WgpuPainter` (`painter.rs`) currently sits at ~2 700 non-test LOC after T9. It will drop below 1 500 at T10, when the replay/submit path (`render()` / `flush_segment` / `flush_*`) is extracted into a dedicated replay module.
+`WgpuPainter` (`painter.rs`) sits at **1 432 non-test LOC** after T10. **C1 is closed.** The replay/submit path (`render()` / `flush_segment` / `flush_*`) was extracted into `GpuReplay` (`replay.rs`) across T10b–T10d.
 
-### C4 rule — Matrix4 must not appear in batches/ or pipelines.rs
+### C4 rule — Matrix4 must not appear in batches/, pipelines.rs, or replay.rs
 
 `GpuStateStack` stores transforms as `glam::Mat4`. The conversion to/from `flui_types::Matrix4` happens at exactly one structural edge:
 
 - `painter.rs::current_transform_matrix()` — Copy-accessor returning a `Matrix4` to callers outside the engine's wgpu module.
 - `backend.rs::with_transform` and the `render_*` methods — the `CommandRenderer` implementation that converts incoming `Matrix4` arguments into `glam::Mat4` before calling painter record methods.
 
-**`Matrix4` must not appear in `batches/` or `pipelines.rs`** — these modules work entirely in glam primitives. Port-check Trigger 19 (`scripts/port-check.sh`) enforces this with an `rg` grep on every CI run and locally via `just port-check`.
+**`Matrix4` must not appear in `batches/`, `pipelines.rs`, or `replay.rs`** — these modules work entirely in glam primitives. Port-check Trigger 19 (`scripts/port-check.sh`) enforces this with an `rg` grep on every CI run and locally via `just port-check`. Trigger 19 was extended to cover `replay.rs` in T10e (the replay side must stay glam-only for the same reason as the record side: the `Matrix4`↔glam conversion must not migrate into the GPU-emit path).
 
 If a record method receives per-sprite transforms (e.g., `draw_atlas`), the conversion to pixel-space origins (`Offset<Pixels>`) happens at the `painter.rs` call site before the batcher is invoked.
 
-### Replay side — pending T10
+### Replay side — shipped T10
 
-The replay/submit path (`render()`, `flush_segment`, `flush_segment_*`) is still on `WgpuPainter` in the current state. At T10 this path will be extracted into a replay module (`replay.rs` or `renderer/`) that takes `&CommandIR` + `&mut GpuResources` + `&PipelineSet` and produces GPU draw calls. After T10, `WgpuPainter`'s role becomes: record entry point → thin coordinator → delegate to replay. The `painter.rs` non-test LOC will drop below 1 500 at that point.
+The replay/submit path (`render()`, `flush_segment`, `flush_segment_*`) was extracted into `GpuReplay` (`replay.rs`) across T10b–T10d. `GpuReplay` owns: 5 GPU-plumbing fields (viewport_buffer, viewport_bind_group, unit_quad×2, default_sampler), the texture_batch scratch, 6 segment-flush families, the `submit` dispatch loop, `flush_opacity_layer` recursion, and `reintegrate_offscreen_content`. `WgpuPainter::render()` is now: record-finish + `self.replay.submit(…)`. C1 is closed at 1 432 non-test LOC.
 
 ---
 

--- a/docs/PORT.md
+++ b/docs/PORT.md
@@ -249,17 +249,17 @@ Re-exports (`pub use foo::Bar`) do not trip the trigger — only literal `pub <k
 
 **Back-references:** [core-0a foundation adversarial reaudit §F2 / SC2](../openspec/changes/core-0a-foundation-adversarial-reaudit/proposal.md) (Rustonomicon §3.2 is the UB basis).
 
-### 19. `Matrix4` in the DrawBatcher record side or `PipelineCache`/`PipelineBuilder`
+### 19. `Matrix4` in the DrawBatcher record side, `PipelineCache`/`PipelineBuilder`, or `GpuReplay` replay side
 
-**C4 rule: the `Matrix4`↔glam conversion happens at the `Backend` trait boundary; the record and pipeline modules are glam-only.** `GpuStateStack` stores transforms as `glam::Mat4`. The single structural conversion edge is `current_transform_matrix()` in `painter.rs` (outbound, returning a `Matrix4` to `Backend`/`LayerStateStack`) and `Backend::with_transform` (inbound, converting an incoming `Matrix4` into the glam state). Every record method below that boundary — `batches/{shapes,gradients,paths,images}.rs` — and the pipeline-cache module (`pipelines.rs`) work entirely in glam primitives and pixel-typed geometry.
+**C4 rule: the `Matrix4`↔glam conversion happens at the `Backend` trait boundary; the record, pipeline, and replay modules are glam-only.** `GpuStateStack` stores transforms as `glam::Mat4`. The single structural conversion edge is `current_transform_matrix()` in `painter.rs` (outbound, returning a `Matrix4` to `Backend`/`LayerStateStack`) and `Backend::with_transform` (inbound, converting an incoming `Matrix4` into the glam state). Every record method below that boundary — `batches/{shapes,gradients,paths,images}.rs` — the pipeline-cache module (`pipelines.rs`), and the replay/submit module (`replay.rs`) work entirely in glam primitives and pixel-typed geometry.
 
-Importing or accepting `flui_types::Matrix4` on the record/pipeline side leaks the flui-types coordinate abstraction into GPU plumbing, defeats the `GpuStateStack` encapsulation, and couples every record-method caller to both coordinate systems. The correct fix is always to extract the needed scalars (translation, scale) at the `painter.rs` or `backend.rs` call site and pass primitives down.
+Importing or accepting `flui_types::Matrix4` on the record/pipeline/replay side leaks the flui-types coordinate abstraction into GPU plumbing, defeats the `GpuStateStack` encapsulation, and couples every record-method caller to both coordinate systems. The replay side must stay glam-only for the same reason: the `Matrix4`↔glam conversion must not migrate into the GPU-emit path. The correct fix is always to extract the needed scalars (translation, scale) at the `painter.rs` or `backend.rs` call site and pass primitives down.
 
-**Scope:** `crates/flui-engine/src/wgpu/batches/` (all files) and `crates/flui-engine/src/wgpu/pipelines.rs`.
+**Scope:** `crates/flui-engine/src/wgpu/batches/` (all files), `crates/flui-engine/src/wgpu/pipelines.rs`, and `crates/flui-engine/src/wgpu/replay.rs`. (Extended to `replay.rs` in T10e — the scope tracks the seam contract: wherever the record-IR is consumed, the glam-only rule applies.)
 
 **Allowlist:** none. Doc-comment lines (`//!`, `///`, `//`) are excluded (the rg filter strips them).
 
-**Back-references:** [`docs/adr/ADR-0006-c-ir-record-replay-seam.md`](adr/ADR-0006-c-ir-record-replay-seam.md) §Decision 4 (C4 rule); engine-overhaul spec `.rust-studio/specs/flui-engine-overhaul/spec.md` acceptance criterion C4; `crates/flui-engine/ARCHITECTURE.md` §Record-side boundary.
+**Back-references:** [`docs/adr/ADR-0006-c-ir-record-replay-seam.md`](adr/ADR-0006-c-ir-record-replay-seam.md) §Decision 4 (C4 rule); engine-overhaul spec `.rust-studio/specs/flui-engine-overhaul/spec.md` acceptance criterion C4; `crates/flui-engine/ARCHITECTURE.md` §Record/replay boundary.
 
 ### Reactive lint promotion
 

--- a/docs/adr/ADR-0006-c-ir-record-replay-seam.md
+++ b/docs/adr/ADR-0006-c-ir-record-replay-seam.md
@@ -4,10 +4,10 @@
 
 ---
 
-- **Status:** Accepted (record side shipped T7–T9; replay/submit split pending T10)
+- **Status:** Accepted (record/replay split fully shipped T7–T10; C1 closed — painter.rs = 1 432 non-test LOC; T11 deterministic-replay test remains)
 - **Date:** 2026-06-17
 - **Deciders:** @vanyastaff
-- **Scope:** `crates/flui-engine` — `src/wgpu/batches/`, `src/wgpu/state_stack.rs`, `src/wgpu/layer_compositor.rs`, `src/wgpu/pipelines.rs`, `src/wgpu/painter.rs`, `src/wgpu/backend.rs`
+- **Scope:** `crates/flui-engine` — `src/wgpu/batches/`, `src/wgpu/state_stack.rs`, `src/wgpu/layer_compositor.rs`, `src/wgpu/pipelines.rs`, `src/wgpu/painter.rs`, `src/wgpu/replay.rs`, `src/wgpu/backend.rs`
 - **Spec reference:** `.rust-studio/specs/flui-engine-overhaul/spec.md` (C-IR approach, tasks 7–11)
 - **Supersedes:** `adr-flui-engine-decomposition.md` if it exists (that draft argued "no IR"; this ADR supersedes that position — the IR is explicit data, not a future option)
 
@@ -15,7 +15,7 @@
 
 ## Verdict
 
-**Target architecture (one paragraph).** The engine uses an explicit **record/replay Command-IR as data**: `Backend` visits the `flui_layer::Scene` and calls `WgpuPainter` record methods, which write into `DrawSegment` / `DrawItem` structs (the Command IR) in `command_ir.rs`. `DrawBatcher` owns the record methods — one file per primitive family (`batches/{shapes,gradients,paths,images}.rs`) — and accepts **disjoint borrowed parameters** (`&mut DrawSegment`, `&mut Vec<DrawItem>`, `&GpuStateStack`, `&mut GpuResources`, `opacity: f32`) so the borrow-checker enforces the data-flow contract without locks. Replay and GPU submission (`flush_segment`, `flush_*`, `render()`) remain on `WgpuPainter` pending T10. wgpu stays concrete — no device trait, no second backend. The engine is the only abstraction flui needs between `Scene` and GPU calls.
+**Target architecture (one paragraph).** The engine uses an explicit **record/replay Command-IR as data**: `Backend` visits the `flui_layer::Scene` and calls `WgpuPainter` record methods, which write into `DrawSegment` / `DrawItem` structs (the Command IR) in `command_ir.rs`. `DrawBatcher` owns the record methods — one file per primitive family (`batches/{shapes,gradients,paths,images}.rs`) — and accepts **disjoint borrowed parameters** (`&mut DrawSegment`, `&mut Vec<DrawItem>`, `&GpuStateStack`, `&mut GpuResources`, `opacity: f32`) so the borrow-checker enforces the data-flow contract without locks. `GpuReplay` (`replay.rs`) owns the replay/submit path: it holds the 5 GPU-plumbing fields (viewport buffer, viewport bind group, unit quads, default sampler), the texture-batch scratch, the 6 segment-flush families, and the top-level `submit` dispatch loop plus `flush_opacity_layer` recursion and `reintegrate_offscreen_content`. `WgpuPainter` is a thin coordinator: record-finish + `self.replay.submit(...)`. wgpu stays concrete — no device trait, no second backend. The engine is the only abstraction flui needs between `Scene` and GPU calls.
 
 ---
 
@@ -25,18 +25,22 @@
 
 `WgpuPainter` at the start of this overhaul was ~6 410 lines and ~58 fields, mixing batch recording, save-layer state machines, gradient construction, text-rendering integration, and per-frame submission with no internal seams. Market research established that flui was the only serious renderer (vs Impeller, Vello, WebRender, Bevy, egui/epaint, GPUI) with no record/replay IR seam. The five wgpu-29 audit rounds had proven the behavior correct; the structure blocked maintainability, testability, and future capabilities.
 
-### What shipped (T7–T9)
+### What shipped (T7–T10)
 
 | Task | What landed | PR |
 |---|---|---|
 | T7 | `GpuStateStack` — owns the 4 paired transform/scissor/rrect-clip/rsuperellipse stacks; Copy accessors; glam-internal; single `Matrix4`↔glam conversion edge at `current_transform_matrix`; depth counter + `Drop` `debug_assert` | [#231](https://github.com/vanyastaff/flui/pull/231) |
 | T8 | `LayerCompositor` — owns `SavedLayer` + `PendingOpacityLayer` + `opacity_stack` + `current_opacity`; `save_layer(&mut GpuStateStack, …)` borrow-enforced; borrows `layer_texture_pool` from `GpuResources` | [#232](https://github.com/vanyastaff/flui/pull/232) |
-| T9a–e | `DrawBatcher` record-method relocation: ~3 000 LOC of per-primitive record methods relocated from `painter.rs` into `batches/{shapes,gradients,paths,images}.rs`; batcher sub-modules are `Matrix4`-free (C4 rule, Trigger 19) | this branch |
+| T9a–e | `DrawBatcher` record-method relocation: ~3 000 LOC of per-primitive record methods relocated from `painter.rs` into `batches/{shapes,gradients,paths,images}.rs`; batcher sub-modules are `Matrix4`-free (C4 rule, Trigger 19) | branch T9 |
+| T9f | Port-check Trigger 19 (C4 grep), ADR-0006, ARCHITECTURE.md record-side boundary section | branch T9 |
+| T10a | External-image IR handle: `TextureView`→`TextureId`; resolve at replay, not record | branch T10 |
+| T10b | `GpuReplay` introduced; texture_batch scratch + texture-batch flush family moved in | branch T10 |
+| T10c | 5 GPU-plumbing fields (viewport_buffer/bind_group, unit_quad×2, default_sampler) + 6 segment-flush families moved into `GpuReplay` | branch T10 |
+| T10d | `submit` dispatch loop + `flush_opacity_layer` recursion + `reintegrate_offscreen_content` moved into `GpuReplay::submit`; `WgpuPainter` drops to 1 432 non-test LOC — **C1 closed** | branch T10 |
 
-### What remains (T10–T11)
+### What remains (T11)
 
-- **T10 replay/submit split:** move `render()`/`flush_segment`/`flush_*` into a replay submitter over `&CommandIR` + `&mut GpuResources` + `&PipelineSet`; `WgpuPainter` drops below 1 500 non-test LOC.
-- **T11 deterministic-replay test:** record an IR, replay to encoder A and encoder B, assert emitted command streams match; compile-time proof record holds no `&mut Device/Queue/Encoder`.
+- **T11 deterministic-replay test:** record an IR, replay to encoder A and encoder B, assert emitted command streams match; compile-time proof record holds no `&mut Device/Queue/Encoder`. This is the remaining C5-gate item.
 
 ---
 
@@ -67,7 +71,7 @@ fn draw_rect(
 
 ### 4. Matrix4 conversion at the trait boundary — C4 rule
 
-`GpuStateStack` stores transforms as `glam::Mat4` (glam is the GPU-math crate; it matches the GPU buffer layout directly). The conversion to/from `flui_types::Matrix4` happens at exactly one structural edge: `current_transform_matrix()` in `painter.rs` and the `with_transform` entry in `backend.rs`. The `batches/` submodules and `pipelines.rs` are `Matrix4`-free — enforced by port-check Trigger 19 (added in T9f). Leaking `Matrix4` into the record/pipeline side would require every GPU-path caller to drag in the flui-types coordinate type and would undo the glam-internal encapsulation that `GpuStateStack` establishes.
+`GpuStateStack` stores transforms as `glam::Mat4` (glam is the GPU-math crate; it matches the GPU buffer layout directly). The conversion to/from `flui_types::Matrix4` happens at exactly one structural edge: `current_transform_matrix()` in `painter.rs` and the `with_transform` entry in `backend.rs`. The `batches/` submodules, `pipelines.rs`, and `replay.rs` are `Matrix4`-free — enforced by port-check Trigger 19 (added in T9f, extended to replay.rs in T10e). Leaking `Matrix4` into the record/pipeline/replay side would require every GPU-path caller to drag in the flui-types coordinate type and would undo the glam-internal encapsulation that `GpuStateStack` establishes.
 
 ### 5. text / rich_text stay painter-side — T9 deferred, T11 seam
 
@@ -88,18 +92,16 @@ fn draw_rect(
 
 ## Consequences
 
-**Now (T9 shipped):**
-- `WgpuPainter` reduced from ~6 410 to ~2 700 non-test LOC (record methods relocated).
-- `batches/` is `Matrix4`-free and enforced by Trigger 19.
-- Borrow-seam is structurally enforced; no method takes `&mut WgpuPainter`.
+**Now (T10 shipped — record/replay split complete):**
+- `WgpuPainter` reduced from ~6 410 to **1 432 non-test LOC** (record methods to `batches/`; replay path to `GpuReplay`). **C1 is closed.**
+- `GpuReplay` (`replay.rs`) owns the GPU-emit/submit path: 5 GPU-plumbing fields, texture-batch scratch, 6 segment-flush families, `submit` dispatch loop, `flush_opacity_layer` recursion, `reintegrate_offscreen_content`.
+- `WgpuPainter` is a thin coordinator: record-finish + `self.replay.submit(...)`. It no longer mixes record and replay concerns.
+- `batches/` and `replay.rs` are `Matrix4`-free, enforced by Trigger 19.
+- Borrow-seam is structurally enforced; no record method takes `&mut WgpuPainter`.
 - Behavior preserved: the five-round wgpu-29 audit net is unchanged (T6 readback safety-net landed before T7).
 
-**After T10:**
-- `WgpuPainter` drops below 1 500 non-test LOC (C1 target met).
-- Replay is a separate function/type over `&CommandIR`; record and replay are callable independently.
-
 **After T11:**
-- Deterministic-replay test proves the IR separation is non-tautological.
+- Deterministic-replay test proves the IR separation is non-tautological: record an IR, replay to encoder A and encoder B, assert emitted command streams match.
 - Text-vs-IR seam decided; `text` / `rich_text` either join the IR or are documented as a bounded exception.
 
 ---
@@ -111,6 +113,7 @@ fn draw_rect(
 - `crates/flui-engine/src/wgpu/state_stack.rs` — single `Matrix4`↔glam conversion edge (`current_transform_matrix`)
 - `crates/flui-engine/src/wgpu/backend.rs` — `with_transform` + `render_*` entry points; `Matrix4` lives here
 - `crates/flui-engine/src/wgpu/batches/` — record-method home; `Matrix4`-free by Trigger 19
-- `crates/flui-engine/src/wgpu/painter.rs` — thin coordinator; text/rich_text pending T11
+- `crates/flui-engine/src/wgpu/replay.rs` — replay/submit home; `Matrix4`-free by Trigger 19 (extended T10e)
+- `crates/flui-engine/src/wgpu/painter.rs` — thin coordinator (record-finish + replay.submit); text/rich_text pending T11
 - Impeller precedent: DisplayList→flat Command vector, EntityPass tree deleted 2024 (`.flutter/` reference)
-- Port-check Trigger 19: `scripts/port-check.sh` lines 1202–1230; `docs/PORT.md` §19
+- Port-check Trigger 19: `scripts/port-check.sh`; `docs/PORT.md` §19

--- a/scripts/port-check.sh
+++ b/scripts/port-check.sh
@@ -1202,34 +1202,40 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# Trigger 19 (engine overhaul T9f) — `Matrix4` in the DrawBatcher record
-# side or `PipelineCache`/`PipelineBuilder` (record/pipeline modules).
+# Trigger 19 (engine overhaul T9f; extended to replay.rs in T10e) —
+# `Matrix4` in the DrawBatcher record side, `PipelineCache`/`PipelineBuilder`
+# (record/pipeline modules), or `GpuReplay` (replay/submit module).
 #
 # C4 rule: `Matrix4`↔glam conversions must happen at the `Backend` trait
 # boundary (crates/flui-engine/src/wgpu/backend.rs). The hot record path
-# (`batches/`) and the pipeline-cache module (`pipelines.rs`) must be
-# glam-only; importing or accepting `Matrix4` there leaks the flui-types
-# coordinate type into the GPU plumbing layer and breaks the seam contract
-# established in the engine overhaul spec (T9/T10 split).
+# (`batches/`), the pipeline-cache module (`pipelines.rs`), and the
+# replay/submit module (`replay.rs`) must be glam-only; importing or
+# accepting `Matrix4` in any of these leaks the flui-types coordinate type
+# into the GPU plumbing layer and breaks the seam contract established in
+# the engine overhaul spec (T9/T10 split). The replay side must stay
+# glam-only for the same reason as the record side: the `Matrix4`↔glam
+# conversion must not migrate into the GPU-emit path.
 #
 # Allowlist: none. The correct fix is always to extract the needed scalar
 # fields (translation, scale) at the caller in backend.rs / painter.rs and
 # pass primitives down.
 # -----------------------------------------------------------------------------
 trigger19_hits=$(rg --line-number --column '\bMatrix4\b' \
-    crates/flui-engine/src/wgpu/batches crates/flui-engine/src/wgpu/pipelines.rs 2>/dev/null \
+    crates/flui-engine/src/wgpu/batches \
+    crates/flui-engine/src/wgpu/pipelines.rs \
+    crates/flui-engine/src/wgpu/replay.rs 2>/dev/null \
   | grep -Ev ':\s*(//!|///|//)' \
   || true)
 
 if [[ -n "${trigger19_hits}" ]]; then
-  echo 'VIOLATION 19: Matrix4 in batches/ or pipelines.rs (record/pipeline side must be glam-only; convert at the trait boundary)'
+  echo 'VIOLATION 19: Matrix4 in batches/, pipelines.rs, or replay.rs (record/pipeline/replay side must be glam-only; convert at the trait boundary)'
   echo "see ${trigger_doc} (trigger 19)"
   echo "${trigger19_hits}"
   echo ""
   violations=$((violations + 1))
 else
   if [[ "${verbose}" -eq 1 ]]; then
-    echo "ok    19: no Matrix4 in batches/ or pipelines.rs"
+    echo "ok    19: no Matrix4 in batches/, pipelines.rs, or replay.rs"
   fi
 fi
 


### PR DESCRIPTION
## T10e — close out the T10 replay/submit split (docs + C4 grep)

Final T10 sub-PR. The record→replay decomposition is structurally complete; only T11's deterministic-replay test remains of the C-IR program. **No production `.rs` change.**

### What this does
- **ADR-0006:** status flipped to "record/replay split shipped T7–T10"; records `GpuReplay` (`replay.rs`) as the replay-side owner and `WgpuPainter` as the thin coordinator (record-finish + `replay.submit`); **C1 closed** (painter.rs ~1432 non-test LOC, down from the 6410-line god-object). T11 named as the only remaining C5-gate item.
- **ARCHITECTURE.md:** record-side boundary section extended to the replay side — adds the `GpuReplay` component + a two-level record→replay picture; C1-closed; C4 scope now covers `replay.rs`.
- **port-check.sh Trigger 19 (C4):** the no-`Matrix4` grep now also covers `replay.rs` (the replay side stays glam-only; the `Matrix4`↔glam conversion lives only at the trait boundary). Verified it fires on a planted `Matrix4` in `replay.rs` then clean on removal. `docs/PORT.md §19` updated.

### Gates
- `port-check` (all 19 triggers + FR-033 clean) / typos / fmt / taplo / doc — **green**. No GPU-readback (zero behavior change).
- **rust-reviewer**: COMPLETE — Trigger 19 path extension + doc-comment exclusion correct; ADR/ARCHITECTURE accuracy (no overclaim, C1=1432 factual); exactly 4 files, no stray `replay.rs` change.

### What's left of the overhaul
**T11** — the C5 acceptance gate: a deterministic-replay A/B test (record an IR, replay to encoder A and B, assert the emitted command streams match — not IR==itself), a compile-time proof the record holds no `&mut Device/Queue/Encoder`, a negative test that replay doesn't mutate the IR, and the two-level-IR doc (Scene=`DisplayList`, Command=`CommandIR`). T4 (backend runtime override) remains deferred per the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)