### PR TITLE
refactor(engine): RenderTarget seam + opacity_layer extraction + blend carriers (advanced-blend PR-1)

### DIFF
--- a/crates/flui-engine/benches/render_throughput.rs
+++ b/crates/flui-engine/benches/render_throughput.rs
@@ -195,7 +195,7 @@ fn render_throughput(c: &mut Criterion) {
         let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("bench-warmup"),
         });
-        let _ = painter.render(&view, &mut enc);
+        let _ = painter.render_to_view(&view, &mut enc);
         queue.submit([enc.finish()]);
         // wait_indefinitely() blocks until the most recent submission completes.
         let _ = device.poll(wgpu::PollType::wait_indefinitely());
@@ -211,7 +211,7 @@ fn render_throughput(c: &mut Criterion) {
             let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
                 label: Some("bench-frame"),
             });
-            let result = painter.render(&view, &mut enc);
+            let result = painter.render_to_view(&view, &mut enc);
             queue.submit([enc.finish()]);
             let _ = device.poll(wgpu::PollType::wait_indefinitely());
             // black_box the result so the compiler cannot prove the render

--- a/crates/flui-engine/src/wgpu/backend.rs
+++ b/crates/flui-engine/src/wgpu/backend.rs
@@ -734,8 +734,12 @@ impl CommandRenderer for Backend<'_> {
                     multiview_mask: None,
                 });
             }
-            // Render child batches to offscreen texture
-            if let Err(e) = temp_painter.render(child_tex.view(), &mut encoder) {
+            // Render child batches to offscreen texture.
+            // View-only: the shader-mask pipeline reads the texture via its own
+            // bind group (not via `RenderTarget::texture`), so no backdrop
+            // sampling back-reference is needed here.
+            let child_target = super::render_target::RenderTarget::view_only(child_tex.view());
+            if let Err(e) = temp_painter.render(child_target, &mut encoder) {
                 tracing::error!("Failed to render shader mask child content: {}", e);
             }
             queue.submit(std::iter::once(encoder.finish()));
@@ -1123,7 +1127,9 @@ impl CommandRenderer for Backend<'_> {
         let mut flush_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("DisplayList Backdrop Flush Encoder"),
         });
-        if let Err(e) = self.painter.render(surface_view, &mut flush_encoder) {
+        let flush_target =
+            super::render_target::RenderTarget::sampleable(surface_view, surface_texture);
+        if let Err(e) = self.painter.render(flush_target, &mut flush_encoder) {
             tracing::error!("DisplayList backdrop flush failed: {}", e);
         }
 

--- a/crates/flui-engine/src/wgpu/command_ir.rs
+++ b/crates/flui-engine/src/wgpu/command_ir.rs
@@ -9,7 +9,9 @@
 //! `painter.rs`.  These types are re-exported `pub(crate)` so `painter.rs`
 //! and future batcher/compositor modules can import from one place.
 
-use flui_types::{Rect, geometry::Pixels, painting::TextureId as ExternalTextureId};
+use flui_types::{
+    Rect, geometry::Pixels, painting::BlendMode, painting::TextureId as ExternalTextureId,
+};
 
 use super::{
     effects::GradientStop,
@@ -97,6 +99,15 @@ pub(crate) struct SavedLayer {
     pub(crate) layer_tint_rgb: [f32; 3],
     /// Bounds of the layer in screen space [x, y, w, h], or `None` for full viewport
     pub(crate) bounds: Option<[f32; 4]>,
+    /// Blend mode to apply when compositing this layer onto its parent.
+    ///
+    /// Stored on the record side so the compositor dispatch can read it without
+    /// coupling the flush path to the record path.  Defaults to `SrcOver`.
+    #[allow(
+        dead_code,
+        reason = "written by save_layer; read by the compositor dispatch when blending the layer onto its parent"
+    )]
+    pub(crate) layer_blend: BlendMode,
 }
 
 // ─── Draw segment ─────────────────────────────────────────────────────────────
@@ -270,4 +281,13 @@ pub(crate) struct PendingOpacityLayer {
     pub(crate) tint_rgb: [f32; 3],
     /// Compositing bounds in screen coordinates
     pub(crate) bounds: Rect<Pixels>,
+    /// Blend mode to apply when compositing this layer onto its parent.
+    ///
+    /// Stored on the pending layer so the compositor dispatch can read it without
+    /// coupling the flush path to the record path.  Defaults to `SrcOver`.
+    #[allow(
+        dead_code,
+        reason = "written during layer creation; read by the compositor dispatch when blending the layer onto its parent"
+    )]
+    pub(crate) blend: BlendMode,
 }

--- a/crates/flui-engine/src/wgpu/layer_compositor.rs
+++ b/crates/flui-engine/src/wgpu/layer_compositor.rs
@@ -197,6 +197,7 @@ impl LayerCompositor {
             layer_opacity,
             layer_tint_rgb,
             bounds,
+            layer_blend: flui_types::painting::BlendMode::SrcOver,
         };
         self.layer_stack.push(saved);
 

--- a/crates/flui-engine/src/wgpu/mod.rs
+++ b/crates/flui-engine/src/wgpu/mod.rs
@@ -120,8 +120,14 @@ mod pipeline;
 /// `layer_stack` extracted from `WgpuPainter`.  Owns the book-keeping half of
 /// `save_layer`/`restore_layer`; GPU emission lives in `GpuReplay`.
 pub(super) mod layer_compositor;
+/// Offscreen-layer render helper: extracted from `flush_opacity_layer` so the
+/// renderer driver can reuse the same routine for backdrop-read compositing.
+pub(super) mod opacity_layer;
 pub(crate) mod pipelines;
 mod profiler;
+/// Frame render-target descriptor: `view` + optional back-reference `texture`
+/// for dst-read blend passes.  Frame-scoped borrow, never stored in IR types.
+pub(crate) mod render_target;
 mod renderer;
 /// Replay/submit component: owns GPU plumbing fields, the per-frame
 /// `texture_batch` scratch, all six segment-flush phases, the top-level

--- a/crates/flui-engine/src/wgpu/opacity_layer.rs
+++ b/crates/flui-engine/src/wgpu/opacity_layer.rs
@@ -1,0 +1,167 @@
+//! Offscreen-layer render helper for opacity and compositing layers.
+//!
+//! This module provides `GpuReplay::render_layer_to_offscreen`, extracted
+//! from the `flush_opacity_layer` body so the renderer driver can reuse the
+//! same routine for both standard opacity compositing and backdrop-read compositing.
+//!
+//! ## Invariants preserved from `flush_opacity_layer`
+//!
+//! - **R1** — arm order (Segment / OffscreenTexture / OpacityLayer) is
+//!   load-bearing; it is preserved verbatim.
+//! - **R2** — `texture_batch` drain: every `flush_texture_batch*` call drains
+//!   and clears `self.texture_batch` before returning so depth-N+1 content
+//!   cannot leak into depth-N.
+//! - **R3** — `LoadOp::Clear(TRANSPARENT)` on the offscreen pass; all inner
+//!   passes use `LoadOp::Load`.
+
+use std::sync::Arc;
+
+use super::{
+    command_ir::{DrawItem, PendingOpacityLayer},
+    pipelines::PipelineSet,
+    render_target::RenderTarget,
+    replay::GpuReplay,
+    resources::GpuResources,
+    texture_pool::PooledTexture,
+};
+
+#[allow(clippy::too_many_arguments)]
+impl GpuReplay {
+    /// Render a pending opacity layer's content to a pooled offscreen texture.
+    ///
+    /// Acquires an offscreen texture from the pool, clears it to transparent,
+    /// then flushes all items in `layer` (including the `final_segment`) to that
+    /// texture.  Returns the acquired [`PooledTexture`]; the caller is responsible
+    /// for compositing it onto the parent target and dropping it (which returns it
+    /// to the pool).
+    ///
+    /// ## Caller contract
+    ///
+    /// The caller (`flush_opacity_layer`) must composite the returned texture onto
+    /// the parent surface before dropping it.  Dropping without compositing is not
+    /// a correctness error — the texture simply returns to the pool — but would
+    /// produce a blank opacity layer.
+    ///
+    /// ## R3 — `LoadOp` correctness
+    ///
+    /// The offscreen clear pass uses `LoadOp::Clear(TRANSPARENT)` so only
+    /// actually-drawn pixels contribute to the composite.  All inner render
+    /// passes (inside `flush_segment`, `flush_texture_batch*`) use
+    /// `LoadOp::Load`, preserving prior offscreen content.
+    pub(in crate::wgpu) fn render_layer_to_offscreen(
+        &mut self,
+        layer: &mut PendingOpacityLayer,
+        viewport_size: (u32, u32),
+        surface_format: wgpu::TextureFormat,
+        device: &Arc<wgpu::Device>,
+        queue: &Arc<wgpu::Queue>,
+        pipelines: &mut PipelineSet,
+        resources: &mut GpuResources,
+        encoder: &mut wgpu::CommandEncoder,
+    ) -> PooledTexture {
+        let (vp_w, vp_h) = viewport_size;
+
+        // Acquire a pooled offscreen texture for the layer's content.
+        let offscreen = resources
+            .layer_texture_pool_mut()
+            .acquire(vp_w, vp_h, surface_format);
+        let offscreen_view = offscreen.view();
+
+        // R3: Clear the offscreen target to fully transparent BEFORE drawing
+        // any layer content.  LoadOp::Clear here; all subsequent passes use Load.
+        {
+            let _clear_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Opacity Layer Clear Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: offscreen_view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+            // Pass dropped immediately — just clearing.
+        }
+
+        // Flush all inner draw items to the offscreen texture.
+        // R1: arm order is preserved (Segment / OffscreenTexture / OpacityLayer).
+        let offscreen_target = RenderTarget::view_only(offscreen_view);
+        for item in layer.items.drain(..) {
+            match item {
+                DrawItem::Segment(mut seg) => {
+                    self.flush_segment(
+                        &mut seg,
+                        viewport_size,
+                        device,
+                        queue,
+                        pipelines,
+                        resources,
+                        encoder,
+                        offscreen_view,
+                    );
+                }
+                DrawItem::OffscreenTexture(p) => {
+                    // A nested OffscreenTexture (shader-mask / backdrop-blur
+                    // result) is itself premultiplied — composite with the
+                    // premultiplied pipeline and an identity tint so it is not
+                    // re-multiplied by its own alpha.
+                    let instance = super::instancing::TextureInstance::new(
+                        p.bounds,
+                        flui_types::styling::Color::WHITE,
+                    );
+                    let _ = self.texture_batch.add(instance);
+                    // R2: flush_texture_batch_premultiplied drains + clears
+                    // texture_batch before returning.
+                    self.flush_texture_batch_premultiplied(
+                        device,
+                        queue,
+                        pipelines,
+                        resources,
+                        viewport_size,
+                        encoder,
+                        offscreen_view,
+                        p.texture.view(),
+                        None,
+                    );
+                }
+                DrawItem::OpacityLayer(nested) => {
+                    // Recursively handle nested opacity layers.
+                    // R2: &mut self serializes access to texture_batch.
+                    self.flush_opacity_layer(
+                        nested,
+                        viewport_size,
+                        surface_format,
+                        device,
+                        queue,
+                        pipelines,
+                        resources,
+                        encoder,
+                        offscreen_target,
+                    );
+                }
+            }
+        }
+
+        // Flush the final segment (content drawn after the last draw-order item).
+        if !layer.final_segment.is_empty() {
+            self.flush_segment(
+                &mut layer.final_segment,
+                viewport_size,
+                device,
+                queue,
+                pipelines,
+                resources,
+                encoder,
+                offscreen_view,
+            );
+        }
+
+        offscreen
+    }
+}

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -355,7 +355,7 @@ impl WgpuPainter {
             &mut self.resources,
             &mut self.text_renderer,
             encoder,
-            view,
+            super::render_target::RenderTarget::view_only(view),
         )
     }
 
@@ -397,9 +397,9 @@ impl WgpuPainter {
     /// * `encoder` - Command encoder
     #[tracing::instrument(level = "trace", skip_all)]
     #[must_use = "errors must be propagated or handled"]
-    pub fn render(
+    pub(crate) fn render(
         &mut self,
-        view: &wgpu::TextureView,
+        target: super::render_target::RenderTarget<'_>,
         encoder: &mut wgpu::CommandEncoder,
     ) -> crate::error::EngineResult<()> {
         // Advance batcher cache frame counters and evict stale entries.
@@ -441,7 +441,7 @@ impl WgpuPainter {
             &mut self.resources,
             &mut self.text_renderer,
             encoder,
-            view,
+            target,
         )?;
 
         // Reset buffer pool for next frame.
@@ -457,10 +457,26 @@ impl WgpuPainter {
         Ok(())
     }
 
+    /// Convenience wrapper: render to a plain `TextureView` with no backdrop
+    /// sampling back-reference (write-only target).
+    ///
+    /// Use this for benchmarks and callers that do not own a backing
+    /// `wgpu::Texture` to supply.  Internal callers should prefer
+    /// `WgpuPainter::render` directly so they can pass a sampleable
+    /// `RenderTarget` when available.
+    #[must_use = "errors must be propagated or handled"]
+    pub fn render_to_view(
+        &mut self,
+        view: &wgpu::TextureView,
+        encoder: &mut wgpu::CommandEncoder,
+    ) -> crate::error::EngineResult<()> {
+        self.render(super::render_target::RenderTarget::view_only(view), encoder)
+    }
+
     /// Run end-of-frame texture-cache maintenance: evict over-budget textures,
     /// reclaim a full atlas that holds stale entries, then reset use-counters.
     ///
-    /// Call EXACTLY ONCE per frame, after the final [`Self::render`] flush.
+    /// Call EXACTLY ONCE per frame, after the final `WgpuPainter::render` flush.
     /// `render` must not do this itself — it runs once per pass (backdrop-filter
     /// flushes invoke it mid-frame), so per-call maintenance would reset
     /// use-counters between passes and drop textures still in use this frame.
@@ -1255,6 +1271,7 @@ impl WgpuPainter {
                         opacity: layer_opacity,
                         tint_rgb,
                         bounds: composite_bounds,
+                        blend: flui_types::painting::BlendMode::SrcOver,
                     }));
 
                 tracing::trace!(
@@ -1930,7 +1947,7 @@ mod tests {
 
         draw(&mut painter);
         painter
-            .render(&target_view, &mut encoder)
+            .render_to_view(&target_view, &mut encoder)
             .expect("painter.render must succeed for readback");
 
         // Copy the target into a CPU-readable buffer. `bytes_per_row` must be a
@@ -2050,7 +2067,7 @@ mod tests {
 
         draw(&mut painter);
         painter
-            .render(&target_view, &mut encoder)
+            .render_to_view(&target_view, &mut encoder)
             .expect("painter.render must succeed for readback");
 
         let bytes_per_pixel = 4u32;
@@ -2464,7 +2481,7 @@ mod tests {
             });
         }
         painter
-            .render(&target_view, &mut encoder)
+            .render_to_view(&target_view, &mut encoder)
             .expect("painter.render must succeed");
 
         let bytes_per_pixel = 4u32;
@@ -4084,7 +4101,7 @@ mod tests {
             });
         }
         painter
-            .render(&target_view, &mut encoder)
+            .render_to_view(&target_view, &mut encoder)
             .expect("painter.render must succeed");
 
         // Readback.
@@ -4282,5 +4299,75 @@ mod tests {
              even when a preceding external-texture draw was skipped). \
              R={br_r}, G={br_g}. If R<200, the frame was aborted instead of skip+continue."
         );
+    }
+
+    /// Regression: `flush_opacity_layer` must silently no-op when viewport is zero-sized.
+    ///
+    /// The UV composite inside `flush_opacity_layer` divides by `vp_w` and `vp_h` to
+    /// compute texture coordinates.  Before the guard was restored, submitting an
+    /// `OpacityLayer` at viewport (0, 0) would push `inf`/`NaN` into the texture
+    /// instance buffer.  The guard restores the original behavior: zero GPU work,
+    /// zero mutations.
+    ///
+    /// This test verifies that submitting a scene containing an `OpacityLayer` with a
+    /// zero-size viewport neither panics nor produces a GPU error.
+    #[test]
+    fn opacity_layer_zero_viewport_is_noop() {
+        use flui_painting::Paint;
+
+        let (device, queue) = test_device_and_queue();
+        let format = wgpu::TextureFormat::Rgba8Unorm;
+
+        // Construct a painter with viewport (0, 0).
+        let mut painter = WgpuPainter::with_shared_device(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            format,
+            (0, 0),
+        );
+
+        // Draw inside a save_layer so a PendingOpacityLayer is enqueued.
+        // Use a semi-transparent paint so opacity < 1 (group-opacity layer).
+        painter.save_layer(None, &Paint::fill(flui_types::Color::rgba(255, 0, 0, 128)));
+        painter.rect(
+            flui_types::Rect::from_xywh(px(0.0), px(0.0), px(1.0), px(1.0)),
+            &Paint::fill(flui_types::Color::RED),
+        );
+        painter.restore();
+
+        // A 1×1 texture to serve as the render target (smallest valid view).
+        let target_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("zero-vp test target"),
+            size: wgpu::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let target_view = target_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("zero-vp test encoder"),
+        });
+
+        // Must not panic. The zero-viewport guard fires before any GPU commands
+        // are recorded for the OpacityLayer, so the encoder submission is also safe.
+        painter
+            .render_to_view(&target_view, &mut encoder)
+            .expect("render on zero viewport must succeed without panic");
+
+        queue.submit(std::iter::once(encoder.finish()));
+        device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .expect("device poll must complete after zero-viewport render");
     }
 }

--- a/crates/flui-engine/src/wgpu/path_cache.rs
+++ b/crates/flui-engine/src/wgpu/path_cache.rs
@@ -102,7 +102,7 @@ impl PathCache {
     ///
     /// Entries not accessed within the last `EVICTION_THRESHOLD` (120) frames are
     /// removed.  Call this once per frame (typically at the start of
-    /// [`WgpuPainter::render`](super::painter::WgpuPainter::render)).
+    /// `WgpuPainter::render`).
     pub fn advance_frame(&mut self) {
         self.current_frame += 1;
 

--- a/crates/flui-engine/src/wgpu/pipeline.rs
+++ b/crates/flui-engine/src/wgpu/pipeline.rs
@@ -483,6 +483,112 @@ mod blend_logic {
             "different blend modes must hash to different pipeline keys"
         );
     }
+
+    /// Golden lock for the current routing of `pipeline_key_from_paint`.
+    ///
+    /// Asserts the exact key produced for each blend mode so any change to the
+    /// routing is forced to produce a diff here — accidental regressions surface
+    /// as a test failure rather than a silent render change.
+    ///
+    /// ## SrcOver / Porter-Duff record
+    ///
+    /// - `SrcOver` + opaque source → opaque key (no blend stage).
+    /// - `SrcOver` + translucent source → alpha-blend key (`SrcOver` mode).
+    /// - Every other Porter-Duff mode → alpha-blend key keyed to that mode.
+    ///
+    /// ## Advanced-mode record (current: warn-fallback to SrcOver)
+    ///
+    /// All 15 advanced modes currently fall back to the SrcOver heuristic
+    /// (opaque → opaque key, translucent → alpha-blend SrcOver key).  When
+    /// the advanced-blend key is introduced, the routing changes and this
+    /// test must be updated to match.
+    #[test]
+    fn pipeline_key_routing_golden() {
+        let opaque = flui_types::Color::rgb(200, 100, 50); // a == 255
+        let translucent = flui_types::Color::rgba(200, 100, 50, 128);
+
+        // ── SrcOver ─────────────────────────────────────────────────────────
+        let k = pipeline_key_from_paint(&Paint::fill(opaque).with_blend_mode(BlendMode::SrcOver));
+        assert!(!k.is_alpha_blended(), "SrcOver + opaque → opaque key");
+        assert_eq!(k.blend_mode(), BlendMode::SrcOver);
+
+        let k =
+            pipeline_key_from_paint(&Paint::fill(translucent).with_blend_mode(BlendMode::SrcOver));
+        assert!(k.is_alpha_blended(), "SrcOver + translucent → blend key");
+        assert_eq!(k.blend_mode(), BlendMode::SrcOver);
+
+        // ── Porter-Duff modes (all 13 non-SrcOver) ──────────────────────────
+        for mode in [
+            BlendMode::Clear,
+            BlendMode::Src,
+            BlendMode::Dst,
+            BlendMode::DstOver,
+            BlendMode::SrcIn,
+            BlendMode::DstIn,
+            BlendMode::SrcOut,
+            BlendMode::DstOut,
+            BlendMode::SrcATop,
+            BlendMode::DstATop,
+            BlendMode::Xor,
+            BlendMode::Plus,
+            BlendMode::Modulate,
+        ] {
+            let k = pipeline_key_from_paint(&Paint::fill(opaque).with_blend_mode(mode));
+            assert!(
+                k.is_alpha_blended(),
+                "{mode:?}: Porter-Duff must always use the blend stage"
+            );
+            assert_eq!(
+                k.blend_mode(),
+                mode,
+                "{mode:?}: key must encode the exact mode"
+            );
+        }
+
+        // ── Advanced modes (current fallback: SrcOver-heuristic) ────────────
+        // Opaque source → opaque key; translucent source → alpha-blend SrcOver.
+        // When the advanced-blend key is introduced these assertions must be
+        // updated to match the new dedicated key.
+        for mode in [
+            BlendMode::Screen,
+            BlendMode::Overlay,
+            BlendMode::Darken,
+            BlendMode::Lighten,
+            BlendMode::ColorDodge,
+            BlendMode::ColorBurn,
+            BlendMode::HardLight,
+            BlendMode::SoftLight,
+            BlendMode::Difference,
+            BlendMode::Exclusion,
+            BlendMode::Multiply,
+            BlendMode::Hue,
+            BlendMode::Saturation,
+            BlendMode::Color,
+            BlendMode::Luminosity,
+        ] {
+            let k_opaque = pipeline_key_from_paint(&Paint::fill(opaque).with_blend_mode(mode));
+            assert!(
+                !k_opaque.is_alpha_blended(),
+                "{mode:?} opaque fallback: current routing produces opaque key"
+            );
+            assert_eq!(
+                k_opaque.blend_mode(),
+                BlendMode::SrcOver,
+                "{mode:?} opaque fallback: mode must be SrcOver"
+            );
+
+            let k_trans = pipeline_key_from_paint(&Paint::fill(translucent).with_blend_mode(mode));
+            assert!(
+                k_trans.is_alpha_blended(),
+                "{mode:?} translucent fallback: current routing produces blend key"
+            );
+            assert_eq!(
+                k_trans.blend_mode(),
+                BlendMode::SrcOver,
+                "{mode:?} translucent fallback: mode must be SrcOver"
+            );
+        }
+    }
 }
 
 #[cfg(all(test, feature = "enable-wgpu-tests"))]

--- a/crates/flui-engine/src/wgpu/render_target.rs
+++ b/crates/flui-engine/src/wgpu/render_target.rs
@@ -1,0 +1,66 @@
+//! `RenderTarget` — the write destination for one render pass.
+//!
+//! A `RenderTarget` bundles the mandatory `wgpu::TextureView` (the attachment
+//! written by every render pass) with an optional `wgpu::Texture` back-reference
+//! (needed when a future pass wants to sample the surface as a backdrop — the
+//! dst-read pattern required by advanced blend modes).
+//!
+//! ## Design constraints
+//!
+//! - Frame-scoped borrows: `RenderTarget<'a>` holds no ownership.  It is a
+//!   **parameter**, not a stored field; it must never appear in `DrawItem`,
+//!   `DrawSegment`, or any other IR type.
+//! - `Copy + Clone`: callers thread it through nested flush calls without extra
+//!   ceremony.
+//! - The `texture` field is `None` for write-only targets (readback helpers,
+//!   offscreen child paints) that are never sampled back.  Downstream passes
+//!   that require backdrop sampling must call `RenderTarget::sampleable`.
+
+/// The surface (or a pooled offscreen) the current pass writes to, plus an
+/// optional back-reference to the underlying [`wgpu::Texture`] for passes that
+/// need to sample it as a backdrop.
+///
+/// `RenderTarget<'a>` is a lightweight, frame-scoped parameter — it carries no
+/// ownership and must **not** be stored inside any IR type.
+#[derive(Clone, Copy)]
+pub(crate) struct RenderTarget<'a> {
+    /// The `TextureView` passed to `RenderPassColorAttachment::view`.
+    pub(crate) view: &'a wgpu::TextureView,
+    /// The backing `Texture`, present when a later pass is allowed to sample
+    /// this target as a backdrop (dst-read blend modes).  `None` for purely
+    /// write-only targets (readback helpers, offscreen child renders).
+    ///
+    /// Read by the dst-read blend pass when sampling the backdrop region;
+    /// `None` targets cannot be sampled and must not be used with advanced modes.
+    #[allow(
+        dead_code,
+        reason = "written at frame-surface and offscreen sites; read by the dst-read blend pass that samples the backdrop region"
+    )]
+    pub(crate) texture: Option<&'a wgpu::Texture>,
+}
+
+impl<'a> RenderTarget<'a> {
+    /// Construct a target that may be sampled back by a later pass.
+    ///
+    /// Use this for the frame surface and any offscreen texture whose
+    /// content a subsequent blend pass must read.
+    #[inline]
+    pub(crate) fn sampleable(view: &'a wgpu::TextureView, texture: &'a wgpu::Texture) -> Self {
+        Self {
+            view,
+            texture: Some(texture),
+        }
+    }
+
+    /// Construct a write-only target — no backdrop sampling allowed.
+    ///
+    /// Use this for readback helpers and offscreen child paints that
+    /// are never read back by a blend shader.
+    #[inline]
+    pub(crate) fn view_only(view: &'a wgpu::TextureView) -> Self {
+        Self {
+            view,
+            texture: None,
+        }
+    }
+}

--- a/crates/flui-engine/src/wgpu/renderer.rs
+++ b/crates/flui-engine/src/wgpu/renderer.rs
@@ -1158,16 +1158,18 @@ impl Renderer {
             // None (incapable adapter), the render must STILL run — otherwise the
             // frame presents only the clear pass (blank content). This is the
             // documented graceful no-op.
+            let frame_target =
+                super::render_target::RenderTarget::sampleable(&view, &output.texture);
             #[cfg(feature = "gpu-profiler")]
             let render_result = if let Some(profiler) = self.gpu_profiler.as_ref() {
                 let mut scope = profiler.scope("final_render", &mut final_encoder);
-                painter.render(&view, scope.recorder())
+                painter.render(frame_target, scope.recorder())
                 // scope drops here → end_query fires
             } else {
-                painter.render(&view, &mut final_encoder)
+                painter.render(frame_target, &mut final_encoder)
             };
             #[cfg(not(feature = "gpu-profiler"))]
-            let render_result = painter.render(&view, &mut final_encoder);
+            let render_result = painter.render(frame_target, &mut final_encoder);
             if let Err(e) = render_result {
                 tracing::error!("Painter render failed: {}", e);
             }
@@ -1437,9 +1439,11 @@ impl Renderer {
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                     label: Some("Backdrop Flush Encoder"),
                 });
+        let flush_target =
+            super::render_target::RenderTarget::sampleable(surface_view, surface_texture);
         if let Err(e) = backend
             .painter_mut()
-            .render(surface_view, &mut flush_encoder)
+            .render(flush_target, &mut flush_encoder)
         {
             tracing::error!("Backdrop flush failed: {}", e);
         }

--- a/crates/flui-engine/src/wgpu/replay.rs
+++ b/crates/flui-engine/src/wgpu/replay.rs
@@ -59,6 +59,7 @@ use super::{
     instancing::{InstanceBatch, TextureInstance},
     pipeline::PipelineKey,
     pipelines::PipelineSet,
+    render_target::RenderTarget,
     resources::GpuResources,
     text::TextRenderer,
 };
@@ -263,7 +264,7 @@ impl GpuReplay {
         resources: &mut GpuResources,
         text_renderer: &mut TextRenderer,
         encoder: &mut wgpu::CommandEncoder,
-        view: &wgpu::TextureView,
+        target: RenderTarget<'_>,
     ) -> EngineResult<()> {
         // R1: arm order (Segment / OffscreenTexture / OpacityLayer) is
         // load-bearing for z-ordering — do not reorder.
@@ -278,7 +279,7 @@ impl GpuReplay {
                         pipelines,
                         resources,
                         encoder,
-                        view,
+                        target.view,
                     );
                 }
                 DrawItem::OffscreenTexture(p) => {
@@ -304,7 +305,7 @@ impl GpuReplay {
                         resources,
                         viewport_size,
                         encoder,
-                        view,
+                        target.view,
                         p.texture.view(),
                         None,
                     );
@@ -320,14 +321,14 @@ impl GpuReplay {
                         pipelines,
                         resources,
                         encoder,
-                        view,
+                        target,
                     );
                 }
             }
         }
 
         // Text is always the global final phase — rendered on top of all geometry.
-        text_renderer.render(device, queue, view, encoder, viewport_size)?;
+        text_renderer.render(device, queue, target.view, encoder, viewport_size)?;
 
         Ok(())
     }
@@ -363,7 +364,7 @@ impl GpuReplay {
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss
     )]
-    fn flush_opacity_layer(
+    pub(in crate::wgpu) fn flush_opacity_layer(
         &mut self,
         mut layer: PendingOpacityLayer,
         viewport_size: (u32, u32),
@@ -373,112 +374,28 @@ impl GpuReplay {
         pipelines: &mut PipelineSet,
         resources: &mut GpuResources,
         encoder: &mut wgpu::CommandEncoder,
-        main_view: &wgpu::TextureView,
+        main_target: RenderTarget<'_>,
     ) {
+        // Zero-size viewports produce no visible pixels; skip GPU work entirely.
+        // The UV composite below divides by vp_w/vp_h, so proceeding would push
+        // inf/NaN into texture instances.  The pool clamps acquire to 1×1 but
+        // the resulting composite would be meaningless.
         let (vp_w, vp_h) = viewport_size;
         if vp_w == 0 || vp_h == 0 {
             return;
         }
 
-        // Acquire a pooled offscreen texture for the layer's content.
-        let offscreen = resources
-            .layer_texture_pool_mut()
-            .acquire(vp_w, vp_h, surface_format);
+        let offscreen = self.render_layer_to_offscreen(
+            &mut layer,
+            viewport_size,
+            surface_format,
+            device,
+            queue,
+            pipelines,
+            resources,
+            encoder,
+        );
         let offscreen_view = offscreen.view();
-
-        // R3: Clear the offscreen target to fully transparent BEFORE drawing
-        // any layer content.  LoadOp::Clear here; all subsequent passes use Load.
-        {
-            let _clear_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("Opacity Layer Clear Pass"),
-                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: offscreen_view,
-                    resolve_target: None,
-                    depth_slice: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                        store: wgpu::StoreOp::Store,
-                    },
-                })],
-                depth_stencil_attachment: None,
-                timestamp_writes: None,
-                occlusion_query_set: None,
-                multiview_mask: None,
-            });
-            // Pass dropped immediately — just clearing.
-        }
-
-        // Flush all inner draw items to the offscreen texture.
-        // R1: arm order is preserved (Segment / OffscreenTexture / OpacityLayer).
-        for item in layer.items.drain(..) {
-            match item {
-                DrawItem::Segment(mut seg) => {
-                    self.flush_segment(
-                        &mut seg,
-                        viewport_size,
-                        device,
-                        queue,
-                        pipelines,
-                        resources,
-                        encoder,
-                        offscreen_view,
-                    );
-                }
-                DrawItem::OffscreenTexture(p) => {
-                    // A nested OffscreenTexture (shader-mask / backdrop-blur
-                    // result) is itself premultiplied — composite with the
-                    // premultiplied pipeline and an identity tint so it is not
-                    // re-multiplied by its own alpha.
-                    let instance = super::instancing::TextureInstance::new(
-                        p.bounds,
-                        flui_types::styling::Color::WHITE,
-                    );
-                    let _ = self.texture_batch.add(instance);
-                    // R2: flush_texture_batch_premultiplied drains + clears
-                    // texture_batch before returning.
-                    self.flush_texture_batch_premultiplied(
-                        device,
-                        queue,
-                        pipelines,
-                        resources,
-                        viewport_size,
-                        encoder,
-                        offscreen_view,
-                        p.texture.view(),
-                        None,
-                    );
-                }
-                DrawItem::OpacityLayer(nested) => {
-                    // Recursively handle nested opacity layers.
-                    // R2: &mut self serializes access to texture_batch.
-                    self.flush_opacity_layer(
-                        nested,
-                        viewport_size,
-                        surface_format,
-                        device,
-                        queue,
-                        pipelines,
-                        resources,
-                        encoder,
-                        offscreen_view,
-                    );
-                }
-            }
-        }
-
-        // Flush the final segment (content drawn after the last draw-order item).
-        if !layer.final_segment.is_empty() {
-            self.flush_segment(
-                &mut layer.final_segment,
-                viewport_size,
-                device,
-                queue,
-                pipelines,
-                resources,
-                encoder,
-                offscreen_view,
-            );
-        }
 
         // Composite the premultiplied offscreen onto the main surface.
         //
@@ -524,7 +441,7 @@ impl GpuReplay {
             resources,
             viewport_size,
             encoder,
-            main_view,
+            main_target.view,
             offscreen_view,
             None,
         );
@@ -579,7 +496,7 @@ impl GpuReplay {
     /// 3. `flush_tessellated_geometry`    — lyon tessellated paths / vertices
     /// 4. `flush_segment_cached_images`   — texture-cache images
     /// 5. `flush_segment_external_images` — external (registered) textures
-    pub(super) fn flush_segment(
+    pub(in crate::wgpu) fn flush_segment(
         &mut self,
         segment: &mut DrawSegment,
         viewport_size: (u32, u32),
@@ -1301,7 +1218,7 @@ impl GpuReplay {
     ///
     /// `scissor` is the clip rect to apply.  Pass `None` for full-viewport
     /// (unclipped), matching the rect/circle instanced batches.
-    pub(super) fn flush_texture_batch(
+    pub(in crate::wgpu) fn flush_texture_batch(
         &mut self,
         device: &Arc<wgpu::Device>,
         queue: &Arc<wgpu::Queue>,
@@ -1337,7 +1254,7 @@ impl GpuReplay {
     /// Routes through `PipelineSet::instanced_texture_premul` (src factor
     /// `One`); the per-channel tint carries group opacity and any ColorFilter
     /// chroma as `(C.r*O, C.g*O, C.b*O, O)`.
-    pub(super) fn flush_texture_batch_premultiplied(
+    pub(in crate::wgpu) fn flush_texture_batch_premultiplied(
         &mut self,
         device: &Arc<wgpu::Device>,
         queue: &Arc<wgpu::Queue>,

--- a/crates/flui-layer/src/layer/opacity.rs
+++ b/crates/flui-layer/src/layer/opacity.rs
@@ -78,7 +78,7 @@ impl OpacityLayer {
         }
     }
 
-    /// Creates a fully transparent layer.
+    /// Creates a fully transparent layer with `BlendMode::SrcOver`.
     #[inline]
     pub const fn transparent() -> Self {
         Self {
@@ -87,7 +87,7 @@ impl OpacityLayer {
         }
     }
 
-    /// Creates a fully opaque layer.
+    /// Creates a fully opaque layer with `BlendMode::SrcOver`.
     #[inline]
     pub const fn opaque() -> Self {
         Self {

--- a/crates/flui-types/src/styling/color.rs
+++ b/crates/flui-types/src/styling/color.rs
@@ -1559,4 +1559,135 @@ mod tests {
         // Verify default epsilon is 1/255
         assert!((Color::DEFAULT_EPSILON - 1.0 / 255.0).abs() < 1e-10);
     }
+
+    /// Characterization golden for `Color::blend` advanced modes.
+    ///
+    /// Locks the per-pixel output of every advanced (non-Porter-Duff) blend
+    /// mode at representative inputs so the WGSL port (PR-2) has a frozen CPU
+    /// oracle to compare against.  These assertions pass against the EXISTING
+    /// implementation — they must NOT be changed to match a buggy edit.
+    ///
+    /// If an assertion fails after a refactor, the formula changed: verify the
+    /// W3C Compositing and Blending Level 1 spec (§10–11) and fix the code,
+    /// not this test.
+    ///
+    /// ## Inputs
+    ///
+    /// - `WHITE` = `rgb(255,255,255)` — straight, fully opaque (sa=1, cs=1).
+    /// - `BLACK` = `rgb(0,0,0)`       — straight, fully opaque (da=1, cb=0).
+    /// - `MID`   = `rgb(128,128,128)` — achromatic mid-gray, fully opaque.
+    ///
+    /// For fully opaque src + dst (`sa=da=1`) the composite formula collapses
+    /// to `output = B(cb, cs)` (alpha=1), so results are easy to verify by
+    /// hand against the W3C blend function table.
+    #[test]
+    fn blend_advanced_modes_golden() {
+        use crate::painting::BlendMode;
+
+        let white = Color::WHITE; // rgb(255,255,255), a=255
+        let black = Color::BLACK; // rgb(0,0,0),       a=255
+        let mid = Color::GRAY; // rgb(128,128,128),  a=255
+
+        // Helper: assert blend output matches expected RGBA bytes.
+        let check = |src: Color, dst: Color, mode: BlendMode, expected: Color| {
+            let got = src.blend(dst, mode);
+            assert_eq!(
+                got, expected,
+                "blend({src:?}, {dst:?}, {mode:?}) = {got:?}, expected {expected:?}"
+            );
+        };
+
+        // ── Multiply ─────────────────────────────────────────────────────────
+        // B(cb, cs) = cb * cs.
+        // white src (cs=1) + black dst (cb=0): 0*1=0 → black.
+        // white src + white dst: 1*1=1 → white.
+        check(white, black, BlendMode::Multiply, black);
+        check(white, white, BlendMode::Multiply, white);
+
+        // ── Screen ───────────────────────────────────────────────────────────
+        // B(cb, cs) = cb + cs - cb*cs.
+        // white src + black dst: 0+1-0=1 → white.
+        // white src + white dst: 1+1-1=1 → white.
+        check(white, black, BlendMode::Screen, white);
+        check(white, white, BlendMode::Screen, white);
+
+        // ── Overlay ──────────────────────────────────────────────────────────
+        // overlay(cb, cs) = HardLight(cs, cb)  [note the swap].
+        // white src (cs=1), black dst (cb=0):
+        //   HardLight(cb=cs=1, cs=cb=0): cs_hl=0 ≤ 0.5 → 2·cb_hl·cs_hl = 2·1·0 = 0 → black.
+        check(white, black, BlendMode::Overlay, black);
+        // black src (cs=0), white dst (cb=1):
+        //   HardLight(cb_hl=0, cs_hl=1): cs_hl=1 > 0.5 → 1−2·(1−0)·(1−1) = 1 → white.
+        check(black, white, BlendMode::Overlay, white);
+
+        // ── Darken ───────────────────────────────────────────────────────────
+        // B = min(cb, cs). white+black → min(0,1)=0 → black.
+        check(white, black, BlendMode::Darken, black);
+        check(black, white, BlendMode::Darken, black);
+
+        // ── Lighten ──────────────────────────────────────────────────────────
+        // B = max(cb, cs). white+black → max(0,1)=1 → white.
+        check(white, black, BlendMode::Lighten, white);
+        check(black, white, BlendMode::Lighten, white);
+
+        // ── HardLight ────────────────────────────────────────────────────────
+        // hardlight(cb, cs): cs>0.5 → 1-2*(1-cb)*(1-cs).
+        // white(cs=1)+black(cb=0): cs>0.5 → 1-2*(1-0)*(1-1)=1 → white.
+        check(white, black, BlendMode::HardLight, white);
+
+        // ── SoftLight ────────────────────────────────────────────────────────
+        // cs=1(>0.5), cb=0(<=0.25): d=((16*0-12)*0+4)*0=0; result=0+(2*1-1)*(0-0)=0 → black.
+        check(white, black, BlendMode::SoftLight, black);
+
+        // ── Difference ───────────────────────────────────────────────────────
+        // B = |cb - cs|. white+black → |0-1|=1 → white.
+        check(white, black, BlendMode::Difference, white);
+        check(black, white, BlendMode::Difference, white);
+
+        // ── Exclusion ────────────────────────────────────────────────────────
+        // B = cb + cs - 2*cb*cs. white+black → 0+1-0=1 → white.
+        check(white, black, BlendMode::Exclusion, white);
+
+        // ── ColorDodge ───────────────────────────────────────────────────────
+        // cb=0 → B=0 (edge: source cannot dodge a zero-luminosity backdrop).
+        check(white, black, BlendMode::ColorDodge, black);
+        // cb=1, cs=1 → cs>=1 → B=1 → white (edge: fully lit backdrop, any source).
+        check(white, white, BlendMode::ColorDodge, white);
+
+        // ── ColorBurn ────────────────────────────────────────────────────────
+        // cb≥1 guard fires first regardless of cs → B=1 → white.
+        // cs=1(white), cb=1(white): cb≥1 → white.
+        check(white, white, BlendMode::ColorBurn, white);
+        // cs=0(black src), cb=1(white dst): cb≥1 fires first → white.
+        // (Note: cs≤0 → B=0 only applies when cb < 1; with cb=1 the cb≥1 guard wins.)
+        check(black, white, BlendMode::ColorBurn, white);
+        // cs=1(white), cb=0(black dst): cb<1, cs>0 → 1−((1−0)/1).min(1) = 1−1 = 0 → black.
+        check(white, black, BlendMode::ColorBurn, black);
+
+        // ── Non-separable: achromatic flat-triple (src==dst==mid-gray) ───────
+        // When src and dst are achromatic and equal, all four HSL blend modes
+        // must preserve the input: Hue/Saturation/Color/Luminosity all collapse
+        // to set_lum(cb_or_cs, lum_of_same) = same color.
+        for mode in [
+            BlendMode::Hue,
+            BlendMode::Saturation,
+            BlendMode::Color,
+            BlendMode::Luminosity,
+        ] {
+            let got = mid.blend(mid, mode);
+            assert_eq!(
+                got.r, mid.r,
+                "{mode:?} achromatic: r channel must be preserved"
+            );
+            assert_eq!(
+                got.g, mid.g,
+                "{mode:?} achromatic: g channel must be preserved"
+            );
+            assert_eq!(
+                got.b, mid.b,
+                "{mode:?} achromatic: b channel must be preserved"
+            );
+            assert_eq!(got.a, 255, "{mode:?} achromatic: alpha must be 1");
+        }
+    }
 }

--- a/examples/painting_demo/src/lib.rs
+++ b/examples/painting_demo/src/lib.rs
@@ -134,7 +134,7 @@ pub async fn main() {
         });
     }
 
-    if let Err(e) = painter.render(&view, &mut encoder) {
+    if let Err(e) = painter.render_to_view(&view, &mut encoder) {
         web_sys::console::error_1(&format!("Painter render error: {e}").into());
     }
 


### PR DESCRIPTION
**PR 1 of 6** of the advanced (dst-read) blend-modes feature for `flui-engine`. The 15 advanced
modes (Screen/Overlay/Multiply/…/Hue/Saturation/Color/Luminosity) currently fall back to SrcOver
with a `warn!`; this series wires them end-to-end across all four real producer paths (display-list
saveLayer, layer-tree OpacityLayer, shape, image/gradient) via one dst-read compositor at the
renderer layer. This PR lays the seam — **byte-identical, no rendering change.**

## What this PR does
- **`RenderTarget { view, texture: Option<&Texture> }`** (new `render_target.rs`) threaded through
  `WgpuPainter::render` / `GpuReplay::submit` / `flush_opacity_layer`. The surface `wgpu::Texture`
  (needed for `copy_texture_to_texture` dst-read) is only available at the renderer layer; this
  bundles it so later PRs can sample the backdrop. Inner `flush_segment` + batch flushers keep
  `&TextureView` — they only write, never sample. `texture: None` is the honest offscreen-recursion
  case (no backdrop), never a transitional shim.
- **Extract `render_layer_to_offscreen`** out of `flush_opacity_layer` into new `opacity_layer.rs`
  (`replay.rs` 1462 → 1371, back under the 1500 C1 cap; the renderer dst-read driver reuses it). The
  zero-viewport early-return guard is preserved.
- **Additive blend carriers** (default `SrcOver`, not yet consumed): `OpacityLayer.blend`,
  `PendingOpacityLayer.blend`, `SavedLayer.layer_blend`.
- **Tests:** `pipeline_key` routing golden (SrcOver + Porter-Duff keys stable); a `Color::blend`
  characterization golden locking the 15 advanced-mode W3C formulas as the WGSL port oracle for
  PR-2; a zero-viewport opacity no-op regression test.

## Evidence
- `fmt` · `clippy --workspace --all-targets -D warnings` (+ `--features enable-wgpu-tests`) · nextest
  · `check --release` · `check --target wasm32-unknown-unknown` (incl. `flui-painting-demo`) · doc
  (`-D warnings --document-private-items`) · typos · taplo · port-check — all green.
- **GPU-readback serial (DX12, local):** 220/0/7 byte-identical vs `main` + the new zero-viewport
  test. (This suite is local-only; no CI GPU runner.)

## Review
Reviewed by `rust-reviewer` (spec + quality) and `ce-kieran` (soundness on the audited compositing
core). Two blockers found and fixed before commit: a dropped zero-viewport guard during the
extraction (byte-identity regression invisible to the capable-host readback) and a missed
`render`→`render_to_view` call site in the wasm `painting_demo` example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)