### PR TITLE
feat(engine): advanced-blend dst-read shader + pipeline + driver (advanced-blend PR-2)

### DIFF
--- a/crates/flui-engine/src/wgpu/advanced_blend/mod.rs
+++ b/crates/flui-engine/src/wgpu/advanced_blend/mod.rs
@@ -1,0 +1,1342 @@
+//! Advanced-blend composite driver: backdrop copy + shader composite.
+//!
+//! This module provides two public entry points used by the render-layer
+//! advanced-blend interception (PR-3):
+//!
+//! - `copy_backdrop_region` — copies a device-space rect from the surface
+//!   texture into a pooled offscreen texture so the compositor shader can
+//!   sample it without racing the render target write.
+//!
+//! - `flush_advanced_layer` — runs the advanced-blend composite pass for one
+//!   `AdvancedBlendOp`: copies the backdrop, builds the bind group, and
+//!   executes one render pass over the op's device-space bounds.
+//!
+//! ## No production caller in PR-2
+//!
+//! `flush_advanced_layer` and `AdvancedBlendPipeline` have no production
+//! call site in this PR; the renderer-layer interception that drives them is
+//! wired in PR-3.  They ARE exercised by the synthetic-op GPU gate in this
+//! module's `#[cfg(all(test, feature = "enable-wgpu-tests"))]` section, which
+//! constitutes the authoritative correctness gate for the WGSL math.
+
+use bytemuck::cast_slice;
+use flui_types::{
+    geometry::{Pixels, Rect},
+    painting::BlendMode,
+};
+use wgpu::util::DeviceExt as _;
+
+pub(crate) use pipeline::AdvancedBlendPipeline;
+pub(crate) use pipeline::mode_to_u32;
+
+use super::{resources::GpuResources, texture_pool::PooledTexture};
+use pipeline::BlendUniformData;
+
+mod pipeline;
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+/// All inputs for one advanced-blend composite operation.
+///
+/// The `foreground` texture holds the layer's content pre-rendered into an
+/// offscreen target (premultiplied RGBA).  Ownership is transferred in so the
+/// caller's `PooledTexture` RAII handle is not dropped until after the render
+/// pass that reads it completes.
+#[allow(
+    dead_code,
+    reason = "Driven by the renderer-layer advanced-blend interception; \
+              exercised here by the synthetic-op gate"
+)]
+pub(crate) struct AdvancedBlendOp {
+    /// Pre-rendered foreground layer content (premultiplied RGBA).
+    pub(crate) foreground: PooledTexture,
+    /// The advanced blend mode to apply.
+    pub(crate) mode: BlendMode,
+    /// Device-space bounds of the foreground layer (origin + size in pixels).
+    pub(crate) device_bounds: Rect<Pixels>,
+    /// Group opacity in [0.0, 1.0].
+    pub(crate) opacity: f32,
+    /// Per-channel RGB tint in [0.0, 1.0] per component.
+    pub(crate) tint: [f32; 3],
+}
+
+/// A successfully copied backdrop region ready for shader sampling.
+///
+/// Holds the pooled texture containing the copy and the copy geometry needed
+/// to compute the backdrop UV in the fragment shader.
+pub(crate) struct BackdropSample {
+    /// Copy of the backdrop region (premultiplied RGBA).
+    pub(crate) texture: PooledTexture,
+    /// Origin of the copy rect in device pixels (rounded, clamped).
+    pub(crate) copy_origin: (u32, u32),
+    /// Extent of the copy rect in device pixels (≥ 1 × 1).
+    pub(crate) copy_extent: (u32, u32),
+}
+
+// ── Backdrop copy ─────────────────────────────────────────────────────────────
+
+/// Copy a device-space rectangle from `surface_texture` into a pooled offscreen
+/// texture so the advanced-blend shader can sample the backdrop without reading
+/// from the render target currently being written.
+///
+/// Returns `None` when the clamped device rect is entirely off-screen (zero
+/// area after clamping against the surface extent).
+///
+/// ## Clamp and round policy
+///
+/// Mirrors `renderer.rs:1384-1396` exactly:
+/// - Round each edge with `.round()` before truncation to avoid 1-pixel undersize
+///   on sub-pixel boundaries (DPR ≠ 1 or fractional-offset CTMs).
+/// - Clamp both edges to `[0, surface_extent]`.
+/// - Derive width/height from the clamped corners (`right.saturating_sub(x)`).
+/// - `max(1)` on width/height prevents a zero-extent copy (wgpu validation requires
+///   non-zero extent).
+#[allow(
+    dead_code,
+    reason = "Called by flush_advanced_layer; exercised by the synthetic-op gate"
+)]
+pub(crate) fn copy_backdrop_region(
+    surface_texture: &wgpu::Texture,
+    device_rect: Rect<Pixels>,
+    surface_format: wgpu::TextureFormat,
+    resources: &mut GpuResources,
+    encoder: &mut wgpu::CommandEncoder,
+) -> Option<BackdropSample> {
+    let surface_size = surface_texture.size();
+    let surface_w = surface_size.width;
+    let surface_h = surface_size.height;
+
+    // Round before truncate (mirrors renderer.rs policy).
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "clamped to [0, surface_wh] before cast; truncation is intentional"
+    )]
+    let x = device_rect.left().0.clamp(0.0, surface_w as f32).round() as u32;
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "clamped to [0, surface_wh] before cast; truncation is intentional"
+    )]
+    let y = device_rect.top().0.clamp(0.0, surface_h as f32).round() as u32;
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "clamped to [0, surface_wh] before cast; truncation is intentional"
+    )]
+    let right = device_rect.right().0.clamp(0.0, surface_w as f32).round() as u32;
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "clamped to [0, surface_wh] before cast; truncation is intentional"
+    )]
+    let bottom = device_rect.bottom().0.clamp(0.0, surface_h as f32).round() as u32;
+
+    // Entirely off-screen after clamping → no copy possible.
+    if right <= x || bottom <= y {
+        tracing::warn!(
+            bounds_l = device_rect.left().0,
+            bounds_t = device_rect.top().0,
+            bounds_r = device_rect.right().0,
+            bounds_b = device_rect.bottom().0,
+            surface_w,
+            surface_h,
+            "Advanced blend: clamped device region is empty (entirely off-screen); \
+             skipping backdrop copy"
+        );
+        return None;
+    }
+
+    let copy_w = right.saturating_sub(x).max(1);
+    let copy_h = bottom.saturating_sub(y).max(1);
+
+    // Acquire a pooled texture matching the copy extent and surface format.
+    let backdrop_copy = resources
+        .layer_texture_pool_mut()
+        .acquire(copy_w, copy_h, surface_format);
+
+    encoder.copy_texture_to_texture(
+        wgpu::TexelCopyTextureInfo {
+            texture: surface_texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d { x, y, z: 0 },
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyTextureInfo {
+            texture: backdrop_copy.texture(),
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::Extent3d {
+            width: copy_w,
+            height: copy_h,
+            depth_or_array_layers: 1,
+        },
+    );
+
+    Some(BackdropSample {
+        texture: backdrop_copy,
+        copy_origin: (x, y),
+        copy_extent: (copy_w, copy_h),
+    })
+}
+
+// ── Composite pass ────────────────────────────────────────────────────────────
+
+/// Execute the advanced-blend composite pass for `op` onto `surface_view`.
+///
+/// Steps:
+/// 1. Copy the backdrop region from `surface_texture` (via [`copy_backdrop_region`]).
+/// 2. Build the per-draw bind group (uniform + foreground + backdrop + sampler).
+/// 3. Issue one render pass over `op.device_bounds` with `LoadOp::Load` (preserving
+///    existing surface content outside the blend region).
+/// 4. Pooled textures (foreground, backdrop copy) are returned to the pool on drop.
+///
+/// ## No production caller in PR-2
+///
+/// This function is driven by the renderer-layer advanced-blend interception added
+/// in PR-3.  It is exercised in PR-2 exclusively by the synthetic-op GPU gate.
+#[allow(
+    dead_code,
+    reason = "Driven by the renderer-layer advanced-blend interception; \
+              exercised here by the synthetic-op gate"
+)]
+#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::needless_pass_by_value,
+    reason = "AdvancedBlendOp fields are moved into the GPU bind group and render pass; ownership is required"
+)]
+pub(crate) fn flush_advanced_layer(
+    op: AdvancedBlendOp,
+    surface_texture: &wgpu::Texture,
+    surface_view: &wgpu::TextureView,
+    surface_format: wgpu::TextureFormat,
+    viewport_size: (u32, u32),
+    pipeline: &AdvancedBlendPipeline,
+    resources: &mut GpuResources,
+    device: &wgpu::Device,
+    encoder: &mut wgpu::CommandEncoder,
+) {
+    // Step 1: copy backdrop region.
+    let Some(backdrop) = copy_backdrop_region(
+        surface_texture,
+        op.device_bounds,
+        surface_format,
+        resources,
+        encoder,
+    ) else {
+        // Off-screen or zero-area: nothing to composite.
+        tracing::debug!(
+            mode = ?op.mode,
+            bounds = ?op.device_bounds,
+            "Advanced blend: skipping off-screen layer"
+        );
+        return;
+    };
+
+    // Step 2: build the uniform buffer and bind group.
+    let (copy_origin_x, copy_origin_y) = backdrop.copy_origin;
+    let (copy_extent_w, copy_extent_h) = backdrop.copy_extent;
+    let (vp_w, vp_h) = viewport_size;
+
+    let uniforms = BlendUniformData {
+        op_bounds: [
+            op.device_bounds.left().0,
+            op.device_bounds.top().0,
+            op.device_bounds.width().0,
+            op.device_bounds.height().0,
+        ],
+        viewport_size: [vp_w as f32, vp_h as f32],
+        copy_origin: [copy_origin_x as f32, copy_origin_y as f32],
+        copy_extent: [copy_extent_w as f32, copy_extent_h as f32],
+        opacity: op.opacity,
+        _pad0: 0,
+        tint_rgb: op.tint,
+        mode: mode_to_u32(op.mode),
+        _pad1: [0; 4],
+    };
+
+    let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("Advanced Blend Uniform Buffer"),
+        contents: cast_slice(&[uniforms]),
+        usage: wgpu::BufferUsages::UNIFORM,
+    });
+
+    // Nearest + ClampToEdge sampler — no filtering: the backdrop copy and
+    // foreground are pixel-aligned; filtering would introduce colour error.
+    let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+        label: Some("Advanced Blend Nearest Sampler"),
+        address_mode_u: wgpu::AddressMode::ClampToEdge,
+        address_mode_v: wgpu::AddressMode::ClampToEdge,
+        address_mode_w: wgpu::AddressMode::ClampToEdge,
+        mag_filter: wgpu::FilterMode::Nearest,
+        min_filter: wgpu::FilterMode::Nearest,
+        mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+        ..Default::default()
+    });
+
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("Advanced Blend Bind Group"),
+        layout: &pipeline.bind_group_layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::TextureView(op.foreground.view()),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: wgpu::BindingResource::TextureView(backdrop.texture.view()),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: wgpu::BindingResource::Sampler(&sampler),
+            },
+        ],
+    });
+
+    // Step 3: render pass over op.device_bounds.
+    // LoadOp::Load preserves surface content outside the blend region.
+    {
+        let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("Advanced Blend Render Pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: surface_view,
+                resolve_target: None,
+                depth_slice: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+
+        render_pass.set_pipeline(&pipeline.pipeline);
+        render_pass.set_bind_group(0, &bind_group, &[]);
+        // 6 vertices synthesised in the VS from @builtin(vertex_index) — no vertex buffer.
+        render_pass.draw(0..6, 0..1);
+    }
+    // Step 4: pooled textures (op.foreground, backdrop.texture) return to the
+    // pool on drop at end of this scope — no explicit action needed.
+}
+
+// ── Synthetic-op GPU gate ─────────────────────────────────────────────────────
+//
+// This test module is the authoritative correctness gate for the WGSL math.
+// It exercises all 15 advanced modes with a non-flat backdrop (left/right halves
+// of distinct colours) and asserts that each pixel ≈ Color::blend(src, dst, mode)
+// within ±1/255 in gamma space.
+//
+// A 1-texel UV shift makes a boundary pixel sample the wrong half → fails.
+// A wrong blend formula → fails for the affected mode.
+// A SrcOver fallback → fails for any mode where SrcOver ≠ the advanced mode.
+
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+mod synthetic_op_tests {
+    use std::sync::Arc;
+
+    use flui_types::{
+        Color,
+        geometry::{Pixels, Rect},
+        painting::BlendMode,
+    };
+    use wgpu::util::DeviceExt as _;
+
+    use super::{AdvancedBlendOp, AdvancedBlendPipeline, flush_advanced_layer};
+    use crate::wgpu::{resources::GpuResources, texture_pool::TexturePool};
+
+    // ── GPU test harness ──────────────────────────────────────────────────────
+
+    fn request_device_and_queue() -> (Arc<wgpu::Device>, Arc<wgpu::Queue>) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .expect("a GPU adapter must be available on a GPU-enabled test host");
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("AdvancedBlend Synthetic Test Device"),
+            ..Default::default()
+        }))
+        .expect("GPU device creation succeeded when adapter was found");
+        (Arc::new(device), Arc::new(queue))
+    }
+
+    /// Format used for all synthetic-op textures.
+    const TEST_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
+
+    // Viewport / target dimensions.
+    const TARGET_W: u32 = 4;
+    const TARGET_H: u32 = 2;
+    // Left half: columns 0-1; right half: columns 2-3.
+
+    // ── Colour helpers ────────────────────────────────────────────────────────
+
+    fn color_to_premul_f32(c: Color) -> [f32; 4] {
+        let [red, green, blue, alpha] = c.to_f32_array();
+        [red * alpha, green * alpha, blue * alpha, alpha]
+    }
+
+    /// Fill a 2D texture (w × h) with a solid premultiplied colour.
+    fn create_solid_texture(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        w: u32,
+        h: u32,
+        format: wgpu::TextureFormat,
+        color_pm: [f32; 4],
+        usage_extra: wgpu::TextureUsages,
+    ) -> wgpu::Texture {
+        // Convert f32 premultiplied → u8 Rgba8Unorm bytes.
+        // Clamping [0,1] before rounding makes the truncation and sign-loss safe.
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "value clamped to [0,1] * 255 rounds into [0,255]; truncation and \
+                      sign-loss are intentional and provably safe"
+        )]
+        let f32_to_u8 = |v: f32| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
+
+        let mut texels: Vec<u8> = Vec::with_capacity((w * h * 4) as usize);
+        for _ in 0..(w * h) {
+            texels.push(f32_to_u8(color_pm[0]));
+            texels.push(f32_to_u8(color_pm[1]));
+            texels.push(f32_to_u8(color_pm[2]));
+            texels.push(f32_to_u8(color_pm[3]));
+        }
+        device.create_texture_with_data(
+            queue,
+            &wgpu::TextureDescriptor {
+                label: Some("Synthetic Solid Texture"),
+                size: wgpu::Extent3d {
+                    width: w,
+                    height: h,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING
+                    | wgpu::TextureUsages::COPY_DST
+                    | usage_extra,
+                view_formats: &[],
+            },
+            wgpu::util::TextureDataOrder::LayerMajor,
+            &texels,
+        )
+    }
+
+    /// Build a w×h surface texture with left-half = `left_pm` and right-half = `right_pm`.
+    #[allow(clippy::too_many_arguments)]
+    fn create_split_texture(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        w: u32,
+        h: u32,
+        format: wgpu::TextureFormat,
+        left_pm: [f32; 4],
+        right_pm: [f32; 4],
+        usage_extra: wgpu::TextureUsages,
+    ) -> wgpu::Texture {
+        // Clamping [0,1]*255 before truncation makes the cast provably safe.
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "value clamped to [0,1] * 255 rounds into [0,255]; safe"
+        )]
+        let f32_to_u8 = |v: f32| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
+
+        let mut texels: Vec<u8> = Vec::with_capacity((w * h * 4) as usize);
+        for _row in 0..h {
+            for col in 0..w {
+                let color_pm = if col < w / 2 { left_pm } else { right_pm };
+                texels.push(f32_to_u8(color_pm[0]));
+                texels.push(f32_to_u8(color_pm[1]));
+                texels.push(f32_to_u8(color_pm[2]));
+                texels.push(f32_to_u8(color_pm[3]));
+            }
+        }
+        device.create_texture_with_data(
+            queue,
+            &wgpu::TextureDescriptor {
+                label: Some("Synthetic Split Surface Texture"),
+                size: wgpu::Extent3d {
+                    width: w,
+                    height: h,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING
+                    | wgpu::TextureUsages::COPY_SRC
+                    | wgpu::TextureUsages::COPY_DST
+                    | usage_extra,
+                view_formats: &[],
+            },
+            wgpu::util::TextureDataOrder::LayerMajor,
+            &texels,
+        )
+    }
+
+    /// Read back all pixels from a texture via a staging buffer.
+    /// Returns RGBA bytes in row-major order.
+    fn readback_texture(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        texture: &wgpu::Texture,
+        w: u32,
+        h: u32,
+    ) -> Vec<[u8; 4]> {
+        // wgpu requires the row stride to be a multiple of COPY_BYTES_PER_ROW_ALIGNMENT (256).
+        let bytes_per_row_unaligned = w * 4;
+        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let bytes_per_row = bytes_per_row_unaligned.div_ceil(align) * align;
+        let buffer_size = u64::from(bytes_per_row * h);
+
+        let staging = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Readback Staging Buffer"),
+            size: buffer_size,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Readback Encoder"),
+        });
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &staging,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(bytes_per_row),
+                    rows_per_image: Some(h),
+                },
+            },
+            wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit(std::iter::once(encoder.finish()));
+
+        // Map and read.
+        let slice = staging.slice(..);
+        slice.map_async(wgpu::MapMode::Read, |_| {});
+        device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .expect("device poll must complete the readback copy");
+
+        let mapped = slice.get_mapped_range();
+        let raw = mapped.as_ref();
+
+        let mut pixels = Vec::with_capacity((w * h) as usize);
+        for row in 0..h {
+            let row_start = (row * bytes_per_row) as usize;
+            for col in 0..w {
+                let offset = row_start + (col as usize) * 4;
+                pixels.push([
+                    raw[offset],
+                    raw[offset + 1],
+                    raw[offset + 2],
+                    raw[offset + 3],
+                ]);
+            }
+        }
+        pixels
+    }
+
+    // ── Oracle ────────────────────────────────────────────────────────────────
+
+    /// CPU oracle: compute expected RGBA u8 for `Color::blend(src_straight, dst_straight, mode)`.
+    /// Returns RGBA in the same premultiplied encoding the GPU writes (Rgba8Unorm).
+    fn oracle_pixel(src_straight: Color, dst_straight: Color, mode: BlendMode) -> [u8; 4] {
+        let result = src_straight.blend(dst_straight, mode);
+        // Color::blend returns a straight Color (un-premultiplied); convert to premultiplied
+        // RGBA bytes for comparison with the GPU readback (which outputs premultiplied).
+        let [r, g, b, a] = result.to_f32_array();
+        // Clamping [0,1]*255 before truncation makes the cast provably safe.
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "value clamped to [0,1] * 255 rounds into [0,255]; safe"
+        )]
+        let f32_to_u8 = |v: f32| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
+        let r_pm = f32_to_u8(r * a);
+        let g_pm = f32_to_u8(g * a);
+        let b_pm = f32_to_u8(b * a);
+        let a_u8 = f32_to_u8(a);
+        [r_pm, g_pm, b_pm, a_u8]
+    }
+
+    /// Assert two RGBA u8 pixels are within `±tolerance` in every channel.
+    fn assert_pixel_close(label: &str, actual: [u8; 4], expected: [u8; 4], tolerance: u8) {
+        for ch in 0..4 {
+            let diff =
+                u8::try_from((i16::from(actual[ch]) - i16::from(expected[ch])).unsigned_abs())
+                    .expect("diff of two u8 values always fits in u8");
+            assert!(
+                diff <= tolerance,
+                "{label}: channel {ch} — actual {a}, expected {e}, diff {diff} > tolerance {tolerance}",
+                a = actual[ch],
+                e = expected[ch],
+            );
+        }
+    }
+
+    // ── Main synthetic-op test ────────────────────────────────────────────────
+
+    /// For each of the 15 advanced blend modes:
+    ///
+    /// 1. Build a `TARGET_W × TARGET_H` surface split left=D1, right=D2.
+    /// 2. Render a solid-colour foreground (src S) over it with `flush_advanced_layer`.
+    /// 3. Read back the result.
+    /// 4. Assert left pixels ≈ oracle(S, D1, mode) and right pixels ≈ oracle(S, D2, mode),
+    ///    within ±1/255.
+    ///
+    /// A 1-texel UV shift → boundary pixel samples wrong half → fails.
+    /// Wrong blend formula → fails on the affected mode.
+    /// SrcOver fallback → fails on any mode where Multiply ≠ SrcOver.
+    #[test]
+    fn all_15_advanced_modes_match_cpu_oracle_within_one_lsb() {
+        let (device, queue) = request_device_and_queue();
+
+        // OPAQUE colors: premul == straight (no quantization round-trip on u8↔f32 unpremul).
+        // With α=255 the composite formula collapses to exactly B(Cb,Cs), so GPU == oracle
+        // within ±1 LSB from pure f32 rounding.  This is STRICTER for formula correctness
+        // than semi-transparent inputs, not a mask.
+        let src_straight = Color::rgba(200, 120, 40, 255);
+        let dst_left_straight = Color::rgba(40, 60, 220, 255);
+        let dst_right_straight = Color::rgba(20, 180, 50, 255);
+
+        let src_pm = color_to_premul_f32(src_straight);
+        let dst_left_pm = color_to_premul_f32(dst_left_straight);
+        let dst_right_pm = color_to_premul_f32(dst_right_straight);
+
+        let advanced_modes = [
+            BlendMode::Multiply,
+            BlendMode::Screen,
+            BlendMode::Overlay,
+            BlendMode::Darken,
+            BlendMode::Lighten,
+            BlendMode::ColorDodge,
+            BlendMode::ColorBurn,
+            BlendMode::HardLight,
+            BlendMode::SoftLight,
+            BlendMode::Difference,
+            BlendMode::Exclusion,
+            BlendMode::Hue,
+            BlendMode::Saturation,
+            BlendMode::Color,
+            BlendMode::Luminosity,
+        ];
+
+        let pipeline = AdvancedBlendPipeline::new(&device, TEST_FORMAT);
+        let pool = TexturePool::new(Arc::clone(&device));
+        let mut resources = GpuResources::new(Arc::clone(&device), Arc::clone(&queue));
+
+        // Build the foreground pooled texture (solid src, full target size).
+        // The texture pool uses RENDER_ATTACHMENT | TEXTURE_BINDING | COPY_SRC | COPY_DST.
+        // We need COPY_DST for upload and TEXTURE_BINDING for shader sampling.
+        // Use create_solid_texture to upload; then we need it in a PooledTexture.
+        // Easiest: acquire a pooled texture, then submit a copy from a staging texture.
+
+        // Staging foreground texture (solid src_pm).
+        let fg_staging = create_solid_texture(
+            &device,
+            &queue,
+            TARGET_W,
+            TARGET_H,
+            TEST_FORMAT,
+            src_pm,
+            wgpu::TextureUsages::COPY_SRC,
+        );
+
+        // Acquire a pooled foreground texture.
+        let fg_pooled = pool.acquire(TARGET_W, TARGET_H, TEST_FORMAT);
+
+        // Copy staging → pooled.
+        {
+            let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("FG Upload Encoder"),
+            });
+            enc.copy_texture_to_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: &fg_staging,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::TexelCopyTextureInfo {
+                    texture: fg_pooled.texture(),
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::Extent3d {
+                    width: TARGET_W,
+                    height: TARGET_H,
+                    depth_or_array_layers: 1,
+                },
+            );
+            queue.submit(std::iter::once(enc.finish()));
+        }
+
+        for mode in advanced_modes {
+            // Build a fresh split surface for each mode (flush_advanced_layer modifies it).
+            let surface_texture = create_split_texture(
+                &device,
+                &queue,
+                TARGET_W,
+                TARGET_H,
+                TEST_FORMAT,
+                dst_left_pm,
+                dst_right_pm,
+                wgpu::TextureUsages::empty(),
+            );
+            let surface_view = surface_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+            // Build a fresh foreground pooled texture for each mode (consumed by op).
+            let fg_this_mode = pool.acquire(TARGET_W, TARGET_H, TEST_FORMAT);
+            {
+                let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("FG Per-Mode Upload Encoder"),
+                });
+                enc.copy_texture_to_texture(
+                    wgpu::TexelCopyTextureInfo {
+                        texture: &fg_staging,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    wgpu::TexelCopyTextureInfo {
+                        texture: fg_this_mode.texture(),
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    wgpu::Extent3d {
+                        width: TARGET_W,
+                        height: TARGET_H,
+                        depth_or_array_layers: 1,
+                    },
+                );
+                queue.submit(std::iter::once(enc.finish()));
+            }
+
+            let op = AdvancedBlendOp {
+                foreground: fg_this_mode,
+                mode,
+                device_bounds: Rect::from_xywh(
+                    Pixels(0.0),
+                    Pixels(0.0),
+                    Pixels(TARGET_W as f32),
+                    Pixels(TARGET_H as f32),
+                ),
+                opacity: 1.0,
+                tint: [1.0, 1.0, 1.0],
+            };
+
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Advanced Blend Test Encoder"),
+            });
+
+            flush_advanced_layer(
+                op,
+                &surface_texture,
+                &surface_view,
+                TEST_FORMAT,
+                (TARGET_W, TARGET_H),
+                &pipeline,
+                &mut resources,
+                &device,
+                &mut encoder,
+            );
+
+            queue.submit(std::iter::once(encoder.finish()));
+
+            // Read back result.
+            let pixels = readback_texture(&device, &queue, &surface_texture, TARGET_W, TARGET_H);
+
+            // Compute oracles.
+            let expected_left = oracle_pixel(src_straight, dst_left_straight, mode);
+            let expected_right = oracle_pixel(src_straight, dst_right_straight, mode);
+
+            // Tolerance: ±1 LSB (1/255) to absorb f32 rounding across premul/unpremul.
+            let tolerance = 1u8;
+            let mode_label = format!("{mode:?}");
+
+            // Check all left-half pixels (columns 0..TARGET_W/2).
+            for row in 0..TARGET_H {
+                for col in 0..(TARGET_W / 2) {
+                    let pixel = pixels[(row * TARGET_W + col) as usize];
+                    assert_pixel_close(
+                        &format!("{mode_label} left col={col} row={row}"),
+                        pixel,
+                        expected_left,
+                        tolerance,
+                    );
+                }
+            }
+
+            // Check all right-half pixels (columns TARGET_W/2..TARGET_W).
+            for row in 0..TARGET_H {
+                for col in (TARGET_W / 2)..TARGET_W {
+                    let pixel = pixels[(row * TARGET_W + col) as usize];
+                    assert_pixel_close(
+                        &format!("{mode_label} right col={col} row={row}"),
+                        pixel,
+                        expected_right,
+                        tolerance,
+                    );
+                }
+            }
+        }
+
+        // Drop fg_pooled after all modes — it was only used as the staging source.
+        drop(fg_pooled);
+    }
+
+    // ── Edge-case tests ───────────────────────────────────────────────────────
+
+    /// ColorDodge and ColorBurn GPU round-trip: WGSL divide-guard branches vs oracle.
+    ///
+    /// Uses OPAQUE inputs so the composite formula collapses to B(Cb,Cs) and the GPU
+    /// readback can be compared against `oracle_pixel` directly within ±1.
+    ///
+    /// Two boundary pairs are covered:
+    /// - (cs=1, cb=0): ColorDodge → cb=0 guard → B=0; ColorBurn → cs=1 guard → B=0.
+    /// - (cs=0, cb=1): ColorDodge → cb/(1-0)=1 → B=1; ColorBurn → cb=1 guard → B=1.
+    ///
+    /// Note on the prior CPU-only test: `Color::blend` returns the full W3C *composite*
+    /// result, not B alone.  For semi-transparent inputs the composite adds an
+    /// αs(1-αb)·Cs source-over term ≈ 0.176 even when B=0, so asserting `R≈0.0` on
+    /// the composite was incorrect.  The GPU round-trip with opaque inputs avoids that
+    /// confusion entirely.
+    #[test]
+    fn color_dodge_and_burn_boundary_inputs_match_cpu_oracle() {
+        let (device, queue) = request_device_and_queue();
+        let pipeline = AdvancedBlendPipeline::new(&device, TEST_FORMAT);
+        let pool = TexturePool::new(Arc::clone(&device));
+        let mut resources = GpuResources::new(Arc::clone(&device), Arc::clone(&queue));
+        let tolerance = 1u8;
+
+        // Helper: run one flush and read back the single-pixel result.
+        let mut run_blend = |src: Color, dst: Color, mode: BlendMode, label: &str| -> [u8; 4] {
+            let src_pm = color_to_premul_f32(src);
+            let dst_pm = color_to_premul_f32(dst);
+            let surface = create_solid_texture(
+                &device,
+                &queue,
+                1,
+                1,
+                TEST_FORMAT,
+                dst_pm,
+                wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            );
+            let surface_view = surface.create_view(&wgpu::TextureViewDescriptor::default());
+            let fg_staging = create_solid_texture(
+                &device,
+                &queue,
+                1,
+                1,
+                TEST_FORMAT,
+                src_pm,
+                wgpu::TextureUsages::COPY_SRC,
+            );
+            let fg_pooled = pool.acquire(1, 1, TEST_FORMAT);
+            {
+                let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("DodgeBurn Upload"),
+                });
+                enc.copy_texture_to_texture(
+                    wgpu::TexelCopyTextureInfo {
+                        texture: &fg_staging,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    wgpu::TexelCopyTextureInfo {
+                        texture: fg_pooled.texture(),
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    wgpu::Extent3d {
+                        width: 1,
+                        height: 1,
+                        depth_or_array_layers: 1,
+                    },
+                );
+                queue.submit(std::iter::once(enc.finish()));
+            }
+            let op = AdvancedBlendOp {
+                foreground: fg_pooled,
+                mode,
+                device_bounds: Rect::from_xywh(Pixels(0.0), Pixels(0.0), Pixels(1.0), Pixels(1.0)),
+                opacity: 1.0,
+                tint: [1.0, 1.0, 1.0],
+            };
+            let mut encoder = device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some(label) });
+            flush_advanced_layer(
+                op,
+                &surface,
+                &surface_view,
+                TEST_FORMAT,
+                (1, 1),
+                &pipeline,
+                &mut resources,
+                &device,
+                &mut encoder,
+            );
+            queue.submit(std::iter::once(encoder.finish()));
+            readback_texture(&device, &queue, &surface, 1, 1)[0]
+        };
+
+        // ── (cs=1, cb=0): white src over black dst ────────────────────────────
+        let src_white = Color::rgba(255, 255, 255, 255); // cs=1.0
+        let dst_black = Color::rgba(0, 0, 0, 255); // cb=0.0
+
+        // ColorDodge: cb<=0 guard → B=0 → composite with opaque inputs = 0.
+        let got_dodge_a = run_blend(src_white, dst_black, BlendMode::ColorDodge, "DodgeA");
+        let exp_dodge_a = oracle_pixel(src_white, dst_black, BlendMode::ColorDodge);
+        assert_pixel_close("ColorDodge cs=1 cb=0", got_dodge_a, exp_dodge_a, tolerance);
+
+        // ColorBurn: cs>=1 guard → B=0 → composite = 0.
+        let got_burn_a = run_blend(src_white, dst_black, BlendMode::ColorBurn, "BurnA");
+        let exp_burn_a = oracle_pixel(src_white, dst_black, BlendMode::ColorBurn);
+        assert_pixel_close("ColorBurn cs=1 cb=0", got_burn_a, exp_burn_a, tolerance);
+
+        // ── (cs=0, cb=1): black src over white dst ────────────────────────────
+        let src_black = Color::rgba(0, 0, 0, 255); // cs=0.0
+        let dst_white = Color::rgba(255, 255, 255, 255); // cb=1.0
+
+        // ColorDodge: cb/(1-cs) = cb/1 = cb; min(1,1)=1 → B=1 → composite = 1.
+        let got_dodge_b = run_blend(src_black, dst_white, BlendMode::ColorDodge, "DodgeB");
+        let exp_dodge_b = oracle_pixel(src_black, dst_white, BlendMode::ColorDodge);
+        assert_pixel_close("ColorDodge cs=0 cb=1", got_dodge_b, exp_dodge_b, tolerance);
+
+        // ColorBurn: cb>=1 guard → B=1 → composite = 1.
+        let got_burn_b = run_blend(src_black, dst_white, BlendMode::ColorBurn, "BurnB");
+        let exp_burn_b = oracle_pixel(src_black, dst_white, BlendMode::ColorBurn);
+        assert_pixel_close("ColorBurn cs=0 cb=1", got_burn_b, exp_burn_b, tolerance);
+    }
+
+    /// Fully transparent source over fully transparent backdrop → transparent output.
+    ///
+    /// out_a = 0 → the shader must return vec4(0) without NaN-propagation
+    /// from the division guards.
+    #[test]
+    fn transparent_source_over_transparent_backdrop_yields_transparent() {
+        let (device, queue) = request_device_and_queue();
+
+        let transparent_pm = [0.0f32; 4];
+        let surface_texture = create_split_texture(
+            &device,
+            &queue,
+            4,
+            2,
+            TEST_FORMAT,
+            transparent_pm,
+            transparent_pm,
+            wgpu::TextureUsages::empty(),
+        );
+        let surface_view = surface_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let pool = TexturePool::new(Arc::clone(&device));
+        let fg_transparent = pool.acquire(4, 2, TEST_FORMAT);
+        // Explicitly upload transparent (all-zero) pixels — do not rely on pool zero-init,
+        // which is an implementation detail not guaranteed by the pool contract.
+        let transparent_bytes = vec![0u8; (4 * 2 * 4) as usize]; // w=4, h=2, 4 bytes/pixel
+        queue.write_texture(
+            fg_transparent.texture().as_image_copy(),
+            &transparent_bytes,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(4 * 4),
+                rows_per_image: Some(2),
+            },
+            wgpu::Extent3d {
+                width: 4,
+                height: 2,
+                depth_or_array_layers: 1,
+            },
+        );
+
+        let pipeline = AdvancedBlendPipeline::new(&device, TEST_FORMAT);
+        let mut resources = GpuResources::new(Arc::clone(&device), Arc::clone(&queue));
+
+        let op = AdvancedBlendOp {
+            foreground: fg_transparent,
+            mode: BlendMode::Multiply, // any mode — out_a=0 must short-circuit
+            device_bounds: Rect::from_xywh(Pixels(0.0), Pixels(0.0), Pixels(4.0), Pixels(2.0)),
+            opacity: 1.0,
+            tint: [1.0, 1.0, 1.0],
+        };
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Transparent Test Encoder"),
+        });
+        flush_advanced_layer(
+            op,
+            &surface_texture,
+            &surface_view,
+            TEST_FORMAT,
+            (4, 2),
+            &pipeline,
+            &mut resources,
+            &device,
+            &mut encoder,
+        );
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_texture(&device, &queue, &surface_texture, 4, 2);
+        for (i, pixel) in pixels.iter().enumerate() {
+            assert_eq!(
+                *pixel,
+                [0, 0, 0, 0],
+                "transparent+transparent pixel {i} must be fully transparent, got {pixel:?}"
+            );
+        }
+    }
+
+    /// Backdrop UV correctness with a non-zero `copy_origin`.
+    ///
+    /// The surface is 6 × 2: left 2 columns = colour A, right 4 columns = colour B.
+    /// The foreground op covers columns 2-5 (x=2, width=4) — so `copy_origin=(2,0)`,
+    /// `copy_extent=(4,2)`.  Column 2 of the surface maps to texel 0 of the backdrop
+    /// copy; column 3 → texel 1, etc.
+    ///
+    /// With the correct UV formula `bd_uv = (frag_pos.xy - copy_origin) / copy_extent`,
+    /// every sampled backdrop texel = colour B.
+    ///
+    /// If `+0.5` is incorrectly added again after `frag_pos`, column 2
+    /// (frag_pos.x ≈ 2.5) would sample `(2.5-2+0.5)/4 = 0.25` instead of
+    /// `(2.5-2)/4 = 0.125` — the first texel of the copy still lands inside B,
+    /// so the test would pass despite the bug on a narrow region.  Therefore we
+    /// also include a case where the copy region starts mid-surface and the sub-pixel
+    /// alignment matters: `copy_origin=(1,0)`, op x=1.
+    ///
+    /// Both the column-1 and column-5 pixels are asserted against the oracle.
+    #[test]
+    fn backdrop_uv_is_correct_with_nonzero_copy_origin() {
+        // Surface: 6 wide × 2 tall.
+        // `create_split_texture` puts col < w/2 = left, col >= w/2 = right.
+        // For w=6: cols 0,1,2 = LEFT (red); cols 3,4,5 = RIGHT (blue).
+        //
+        // Op covers x=1, width=4 → surface columns 1,2,3,4 → copy_origin=(1,0),
+        // copy_extent=(4,2).  With the correct UV formula each covered surface column `c`
+        // samples its own original backdrop: col c's expected = oracle(src, surface_at_c).
+        //
+        // With an incorrect +0.5 on bd_uv the boundary between left and right shifts;
+        // a ±1-LSB assertion on the per-column oracle catches the offset.
+        //
+        // OPAQUE colors: no premul→u8→unpremul quantization error (α=255 keeps ±1 tight).
+        const SURF_W: u32 = 6;
+        const SURF_H: u32 = 2;
+
+        let (device, queue) = request_device_and_queue();
+
+        // Deliberately distinct opaque colors so a UV regression misassigns a column.
+        let color_left = Color::rgba(200, 20, 20, 255); // opaque red
+        let color_right = Color::rgba(20, 20, 200, 255); // opaque blue
+        let src_straight = Color::rgba(180, 100, 30, 255); // opaque orange
+
+        let left_pm = color_to_premul_f32(color_left);
+        let right_pm = color_to_premul_f32(color_right);
+        let src_pm = color_to_premul_f32(src_straight);
+
+        let surface_texture = create_split_texture(
+            &device,
+            &queue,
+            SURF_W,
+            SURF_H,
+            TEST_FORMAT,
+            left_pm,
+            right_pm,
+            wgpu::TextureUsages::empty(),
+        );
+        let surface_view = surface_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        // Foreground: solid orange, 4 × SURF_H.
+        // COPY_SRC is required because we copy FROM this texture into the pooled texture.
+        let fg_staging = create_solid_texture(
+            &device,
+            &queue,
+            4,
+            SURF_H,
+            TEST_FORMAT,
+            src_pm,
+            wgpu::TextureUsages::COPY_SRC,
+        );
+
+        let pool = TexturePool::new(Arc::clone(&device));
+        let fg_pooled = pool.acquire(4, SURF_H, TEST_FORMAT);
+        {
+            let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("NonZeroOrigin FG Upload"),
+            });
+            enc.copy_texture_to_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: &fg_staging,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::TexelCopyTextureInfo {
+                    texture: fg_pooled.texture(),
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::Extent3d {
+                    width: 4,
+                    height: SURF_H,
+                    depth_or_array_layers: 1,
+                },
+            );
+            queue.submit(std::iter::once(enc.finish()));
+        }
+
+        let pipeline = AdvancedBlendPipeline::new(&device, TEST_FORMAT);
+        let mut resources = GpuResources::new(Arc::clone(&device), Arc::clone(&queue));
+
+        let op = AdvancedBlendOp {
+            foreground: fg_pooled,
+            mode: BlendMode::Multiply,
+            device_bounds: Rect::from_xywh(
+                Pixels(1.0),
+                Pixels(0.0),
+                Pixels(4.0),
+                Pixels(SURF_H as f32),
+            ),
+            opacity: 1.0,
+            tint: [1.0, 1.0, 1.0],
+        };
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("NonZeroOrigin Blend Encoder"),
+        });
+        flush_advanced_layer(
+            op,
+            &surface_texture,
+            &surface_view,
+            TEST_FORMAT,
+            (SURF_W, SURF_H),
+            &pipeline,
+            &mut resources,
+            &device,
+            &mut encoder,
+        );
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_texture(&device, &queue, &surface_texture, SURF_W, SURF_H);
+        let tolerance = 1u8;
+
+        // Column 0: outside op bounds — must NOT be blended.
+        // With opaque colors the untouched pixel equals the original premul-u8 surface value,
+        // which ≠ Multiply(src, left) since src.r=180/255 < 1 (Multiply always darkens).
+        for row in 0..SURF_H {
+            let untouched = pixels[(row * SURF_W) as usize];
+            let would_be_blended = oracle_pixel(src_straight, color_left, BlendMode::Multiply);
+            assert_ne!(
+                untouched, would_be_blended,
+                "row={row}: col 0 is outside op bounds and must NOT be blended"
+            );
+        }
+
+        // Covered columns 1-4: each column samples its OWN original surface backdrop.
+        // create_split_texture: col < 3 → left, col >= 3 → right (w=6, w/2=3).
+        // col 1 → surface col 1 < 3 → backdrop = color_left (opaque red).
+        // col 2 → surface col 2 < 3 → backdrop = color_left.
+        // col 3 → surface col 3 >= 3 → backdrop = color_right (opaque blue).
+        // col 4 → surface col 4 >= 3 → backdrop = color_right.
+        let backdrop_at_col = |col: u32| {
+            if col < SURF_W / 2 {
+                color_left
+            } else {
+                color_right
+            }
+        };
+
+        for row in 0..SURF_H {
+            for col in 1..5u32 {
+                let expected =
+                    oracle_pixel(src_straight, backdrop_at_col(col), BlendMode::Multiply);
+                let pix = pixels[(row * SURF_W + col) as usize];
+                assert_pixel_close(
+                    &format!("NonZeroOrigin Multiply col={col} row={row}"),
+                    pix,
+                    expected,
+                    tolerance,
+                );
+            }
+        }
+    }
+
+    /// Semi-transparent composite: Screen mode with α<255 inputs.
+    ///
+    /// The opaque tests above verify blend-formula correctness but exercise only the
+    /// `αs=1, αb=1` path of the W3C composite equation.  This test uses semi-transparent
+    /// src (α=180) and dst (α=200) to exercise the full αs/αb composite arithmetic.
+    ///
+    /// Tolerance is ±2 (not ±1) to absorb the premul→u8→unpremul quantization error
+    /// that occurs when the GPU round-trips straight colors through premultiplied u8
+    /// textures before the blend function.  The oracle (`Color::blend`) operates on
+    /// pristine straight-channel values; at sub-255 alphas the u8 encode/decode
+    /// introduces up to ~1 LSB per channel before the blend, which propagates to ±2
+    /// in the output byte.
+    #[test]
+    fn translucent_composite_matches_oracle() {
+        let (device, queue) = request_device_and_queue();
+        let pipeline = AdvancedBlendPipeline::new(&device, TEST_FORMAT);
+        let pool = TexturePool::new(Arc::clone(&device));
+        let mut resources = GpuResources::new(Arc::clone(&device), Arc::clone(&queue));
+
+        // Semi-transparent inputs — the composite path where αs·αb terms are non-trivial.
+        let src_straight = Color::rgba(160, 80, 200, 180);
+        let dst_straight = Color::rgba(50, 180, 60, 200);
+        let src_pm = color_to_premul_f32(src_straight);
+        let dst_pm = color_to_premul_f32(dst_straight);
+
+        let surface = create_solid_texture(
+            &device,
+            &queue,
+            TARGET_W,
+            TARGET_H,
+            TEST_FORMAT,
+            dst_pm,
+            wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        );
+        let surface_view = surface.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let fg_staging = create_solid_texture(
+            &device,
+            &queue,
+            TARGET_W,
+            TARGET_H,
+            TEST_FORMAT,
+            src_pm,
+            wgpu::TextureUsages::COPY_SRC,
+        );
+        let fg_pooled = pool.acquire(TARGET_W, TARGET_H, TEST_FORMAT);
+        {
+            let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Translucent FG Upload"),
+            });
+            enc.copy_texture_to_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: &fg_staging,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::TexelCopyTextureInfo {
+                    texture: fg_pooled.texture(),
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::Extent3d {
+                    width: TARGET_W,
+                    height: TARGET_H,
+                    depth_or_array_layers: 1,
+                },
+            );
+            queue.submit(std::iter::once(enc.finish()));
+        }
+
+        let op = AdvancedBlendOp {
+            foreground: fg_pooled,
+            mode: BlendMode::Screen,
+            device_bounds: Rect::from_xywh(
+                Pixels(0.0),
+                Pixels(0.0),
+                Pixels(TARGET_W as f32),
+                Pixels(TARGET_H as f32),
+            ),
+            opacity: 1.0,
+            tint: [1.0, 1.0, 1.0],
+        };
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Translucent Screen Encoder"),
+        });
+        flush_advanced_layer(
+            op,
+            &surface,
+            &surface_view,
+            TEST_FORMAT,
+            (TARGET_W, TARGET_H),
+            &pipeline,
+            &mut resources,
+            &device,
+            &mut encoder,
+        );
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_texture(&device, &queue, &surface, TARGET_W, TARGET_H);
+        let expected = oracle_pixel(src_straight, dst_straight, BlendMode::Screen);
+        // ±2: absorbs the premul→u8→unpremul quantization of the GPU's premultiplied
+        // texture inputs, which the straight-color oracle does not model.
+        // Formula correctness (±1) is covered by the opaque tests above.
+        let tolerance = 2u8;
+        for (i, &pixel) in pixels.iter().enumerate() {
+            assert_pixel_close(
+                &format!("Screen translucent pixel {i}"),
+                pixel,
+                expected,
+                tolerance,
+            );
+        }
+    }
+
+    /// Non-separable Color mode with an achromatic (flat) backdrop (R=G=B).
+    ///
+    /// `set_sat` on a flat triple must return black (not NaN) because max==min.
+    #[test]
+    fn color_mode_with_achromatic_backdrop_does_not_nan() {
+        let src_straight = Color::rgba(200, 50, 100, 180); // colourful source
+        let dst_achromatic = Color::rgba(128, 128, 128, 200); // flat (R=G=B)
+
+        // CPU oracle must not panic (regression guard).
+        let result = src_straight.blend(dst_achromatic, BlendMode::Color);
+        let [r, g, b, _a] = result.to_f32_array();
+        // Result channels must be finite and in [0, 1].
+        assert!(
+            r.is_finite() && (0.0f32..=1.0).contains(&r),
+            "Color mode R NaN/OOB: {r}"
+        );
+        assert!(
+            g.is_finite() && (0.0f32..=1.0).contains(&g),
+            "Color mode G NaN/OOB: {g}"
+        );
+        assert!(
+            b.is_finite() && (0.0f32..=1.0).contains(&b),
+            "Color mode B NaN/OOB: {b}"
+        );
+    }
+}

--- a/crates/flui-engine/src/wgpu/advanced_blend/pipeline.rs
+++ b/crates/flui-engine/src/wgpu/advanced_blend/pipeline.rs
@@ -1,0 +1,393 @@
+//! Pipeline and mode-discriminant mapping for the advanced-blend composite pass.
+//!
+//! [`AdvancedBlendPipeline`] owns the single `wgpu::RenderPipeline` used by
+//! [`super::flush_advanced_layer`].  It is format-parametric so the same pipeline
+//! serves both the windowed surface format and any offscreen target format.
+//!
+//! [`mode_to_u32`] is the canonical mapping from the 15 advanced [`BlendMode`]
+//! variants to the `u32` discriminants the WGSL `switch` consumes.  Passing a
+//! non-advanced mode (Porter-Duff or Modulate) to `mode_to_u32` is a caller
+//! contract violation; the function panics with an invariant message.
+
+use std::mem;
+
+use bytemuck::{Pod, Zeroable};
+use flui_types::painting::BlendMode;
+
+// ── Uniform layout (mirrors `BlendUniforms` in advanced_blend.wgsl) ──────────
+
+/// GPU uniform buffer layout for the advanced-blend pass.
+///
+/// **Explicit `#[repr(C)]` layout — must match `BlendUniforms` in
+/// `advanced_blend.wgsl` byte-for-byte.**
+///
+/// WGSL uniform-block alignment rules (WGSL §13.4.1, WebGPU §3.13.3):
+/// - `vec4<f32>` → align 16
+/// - `vec2<f32>` → align 8
+/// - `f32`       → align 4
+/// - `vec3<f32>` → align **16** (not 12; the spec rounds vec3 up to vec4 alignment)
+/// - `u32`       → align 4
+/// - Struct size must be a multiple of 16 (largest member alignment).
+///
+/// | Byte offset | Size | Rust field       | WGSL member                |
+/// |-------------|------|------------------|----------------------------|
+/// | 0           | 16   | `op_bounds`      | `vec4<f32>` (op_bounds)    |
+/// | 16          | 8    | `viewport_size`  | `vec2<f32>`                |
+/// | 24          | 8    | `copy_origin`    | `vec2<f32>`                |
+/// | 32          | 8    | `copy_extent`    | `vec2<f32>`                |
+/// | 40          | 4    | `opacity`        | `f32`                      |
+/// | 44          | 4    | `_pad0`          | `f32` (align gap)          |
+/// | 48          | 12   | `tint_rgb`       | `vec3<f32>` (align 16)     |
+/// | 60          | 4    | `mode`           | `u32`                      |
+/// | 64          | 16   | `_pad1`          | `vec4<u32>` (size pad)     |
+///
+/// Total = 80 bytes (multiple of 16).
+#[derive(Debug, Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub(super) struct BlendUniformData {
+    /// Device-space bounds [x, y, width, height] in pixels.
+    pub(super) op_bounds: [f32; 4],
+    /// Viewport size [width, height] in pixels.
+    pub(super) viewport_size: [f32; 2],
+    /// Backdrop copy rect origin [x, y] in pixels.
+    pub(super) copy_origin: [f32; 2],
+    /// Backdrop copy rect extent [width, height] in pixels.
+    pub(super) copy_extent: [f32; 2],
+    /// Group opacity in [0, 1].
+    pub(super) opacity: f32,
+    /// Alignment gap: `tint_rgb` (`vec3<f32>`) requires 16-byte WGSL alignment,
+    /// so the 4 bytes between `opacity` (offset 40) and `tint_rgb` (offset 48)
+    /// must be padded.  Must remain zero.
+    pub(super) _pad0: u32,
+    /// Per-channel RGB tint applied premultiplied.
+    pub(super) tint_rgb: [f32; 3],
+    /// Blend mode discriminant (see [`mode_to_u32`]).
+    pub(super) mode: u32,
+    /// Struct-size padding to reach 80 bytes (next multiple of 16 after 64+12=76).
+    /// Must remain zero.
+    pub(super) _pad1: [u32; 4],
+}
+
+const _BLEND_UNIFORM_SIZE_CHECK: () = {
+    assert!(mem::size_of::<BlendUniformData>() == 80);
+};
+
+// ── Mode discriminant mapping ─────────────────────────────────────────────────
+
+/// Map an advanced [`BlendMode`] to the `u32` discriminant consumed by the
+/// WGSL `separable_blend` / `nonseparable_blend` switch statements.
+///
+/// ## Invariant
+///
+/// The caller **must** only pass one of the 15 advanced modes (Multiply through
+/// Luminosity).  Passing a Porter-Duff or Modulate mode is a contract violation:
+/// the function panics with a message naming the illegal mode, because those
+/// modes must be dispatched through the Porter-Duff / Modulate paths — not the
+/// advanced-blend shader.
+///
+/// The discriminant assignment (0–14) is an engine-internal contract shared
+/// only between this function and `advanced_blend.wgsl`.  It is NOT derived
+/// from `BlendMode`'s Rust enum discriminant.
+pub(crate) fn mode_to_u32(mode: BlendMode) -> u32 {
+    match mode {
+        // ── Separable modes (0–10) ────────────────────────────────────────
+        BlendMode::Multiply => 0,
+        BlendMode::Screen => 1,
+        BlendMode::Overlay => 2,
+        BlendMode::Darken => 3,
+        BlendMode::Lighten => 4,
+        BlendMode::ColorDodge => 5,
+        BlendMode::ColorBurn => 6,
+        BlendMode::HardLight => 7,
+        BlendMode::SoftLight => 8,
+        BlendMode::Difference => 9,
+        BlendMode::Exclusion => 10,
+        // ── Non-separable modes (11–14) ───────────────────────────────────
+        BlendMode::Hue => 11,
+        BlendMode::Saturation => 12,
+        BlendMode::Color => 13,
+        BlendMode::Luminosity => 14,
+        // ── Non-advanced (Porter-Duff + Modulate) modes: caller contract violation ──
+        //
+        // Listed exhaustively so adding a new BlendMode variant is a *compile error*,
+        // not a silent runtime panic.  A wildcard arm would compile fine and only
+        // panic at runtime — that defeats the static-exhaustiveness guarantee.
+        BlendMode::Clear
+        | BlendMode::Src
+        | BlendMode::Dst
+        | BlendMode::SrcOver
+        | BlendMode::DstOver
+        | BlendMode::SrcIn
+        | BlendMode::DstIn
+        | BlendMode::SrcOut
+        | BlendMode::DstOut
+        | BlendMode::SrcATop
+        | BlendMode::DstATop
+        | BlendMode::Xor
+        | BlendMode::Plus
+        | BlendMode::Modulate => unreachable!(
+            "mode_to_u32 called with non-advanced blend mode {:?}; \
+             Porter-Duff and Modulate modes must be dispatched through their \
+             own fixed-function paths, not the advanced-blend shader",
+            mode
+        ),
+    }
+}
+
+// ── Pipeline ──────────────────────────────────────────────────────────────────
+
+/// Bind-group layout and render pipeline for the advanced-blend composite pass.
+///
+/// ## Bind-group layout (group 0)
+///
+/// | Binding | Stage    | Type                    | Content                      |
+/// |---------|----------|-------------------------|------------------------------|
+/// | 0       | VS + FS  | Uniform buffer          | [`BlendUniformData`]         |
+/// | 1       | FS       | 2D float texture        | Foreground (premultiplied)   |
+/// | 2       | FS       | 2D float texture        | Backdrop copy (premultiplied)|
+/// | 3       | FS       | Non-filtering sampler   | Nearest + ClampToEdge        |
+///
+/// ## Blend state
+///
+/// `REPLACE` (no fixed-function blending): the fragment shader emits the full
+/// premultiplied composite directly; the GPU hardware must not re-blend it.
+pub(crate) struct AdvancedBlendPipeline {
+    /// Bind-group layout shared between pipeline construction and per-draw
+    /// bind-group creation in [`super::flush_advanced_layer`].
+    pub(crate) bind_group_layout: wgpu::BindGroupLayout,
+    /// The single render pipeline (format-parametric at construction time).
+    pub(crate) pipeline: wgpu::RenderPipeline,
+}
+
+#[allow(
+    dead_code,
+    reason = "Driven by the renderer-layer advanced-blend interception; \
+              exercised here by the synthetic-op GPU gate"
+)]
+impl AdvancedBlendPipeline {
+    /// Build the pipeline for `surface_format`.
+    ///
+    /// Compilation of the WGSL shader module happens here; a wgpu validation
+    /// error surfaces at this call site, which the synthetic-op GPU test
+    /// exercises before any production caller exists.
+    pub(crate) fn new(device: &wgpu::Device, surface_format: wgpu::TextureFormat) -> Self {
+        let bind_group_layout = create_bind_group_layout(device);
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("Advanced Blend Pipeline Layout"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Advanced Blend Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/advanced_blend.wgsl").into()),
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Advanced Blend Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                // No vertex buffers: the VS synthesises 6 vertices from
+                // `@builtin(vertex_index)`, forming a quad over `op_bounds`.
+                buffers: &[],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    // REPLACE: the shader emits the full premultiplied composite.
+                    // Fixed-function blending must not re-blend the result.
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview_mask: None,
+            cache: None,
+        });
+
+        Self {
+            bind_group_layout,
+            pipeline,
+        }
+    }
+}
+
+// ── Bind-group layout factory (private) ──────────────────────────────────────
+
+#[allow(
+    dead_code,
+    reason = "Called by AdvancedBlendPipeline::new which is gated behind the \
+              renderer-layer interception; exercised by the synthetic-op GPU gate"
+)]
+fn create_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
+    device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("Advanced Blend Bind Group Layout"),
+        entries: &[
+            // Binding 0: uniform buffer (VS + FS)
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(
+                        mem::size_of::<BlendUniformData>() as u64
+                    ),
+                },
+                count: None,
+            },
+            // Binding 1: foreground texture (FS) — non-filtering (Nearest sampler)
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                count: None,
+            },
+            // Binding 2: backdrop copy texture (FS) — non-filtering
+            wgpu::BindGroupLayoutEntry {
+                binding: 2,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                count: None,
+            },
+            // Binding 3: nearest-clamp sampler (FS)
+            wgpu::BindGroupLayoutEntry {
+                binding: 3,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
+                count: None,
+            },
+        ],
+    })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod cpu_tests {
+    use std::collections::HashSet;
+
+    use flui_types::painting::BlendMode;
+
+    use super::mode_to_u32;
+
+    /// All 15 advanced modes map to distinct `u32` values in `[0, 14]`.
+    ///
+    /// This is the runtime-observable exhaustiveness proof: if `mode_to_u32`
+    /// duplicates a discriminant this test fails before a GPU round-trip.
+    #[test]
+    fn mode_to_u32_produces_distinct_values_for_all_15_advanced_modes() {
+        let advanced_modes = [
+            BlendMode::Multiply,
+            BlendMode::Screen,
+            BlendMode::Overlay,
+            BlendMode::Darken,
+            BlendMode::Lighten,
+            BlendMode::ColorDodge,
+            BlendMode::ColorBurn,
+            BlendMode::HardLight,
+            BlendMode::SoftLight,
+            BlendMode::Difference,
+            BlendMode::Exclusion,
+            BlendMode::Hue,
+            BlendMode::Saturation,
+            BlendMode::Color,
+            BlendMode::Luminosity,
+        ];
+
+        let discriminants: Vec<u32> = advanced_modes.iter().map(|&m| mode_to_u32(m)).collect();
+
+        assert_eq!(
+            discriminants.len(),
+            15,
+            "expected exactly 15 advanced modes"
+        );
+
+        for (mode, &disc) in advanced_modes.iter().zip(discriminants.iter()) {
+            assert!(
+                disc <= 14,
+                "mode {mode:?} maps to discriminant {disc} which is out of range [0, 14]"
+            );
+        }
+
+        let mut seen = HashSet::new();
+        for (mode, &disc) in advanced_modes.iter().zip(discriminants.iter()) {
+            assert!(
+                seen.insert(disc),
+                "mode {mode:?} has duplicate discriminant {disc}"
+            );
+        }
+    }
+
+    /// The struct size must match the WGSL uniform-block size exactly.
+    ///
+    /// This test makes the compile-time assert observable as a test failure
+    /// (rather than a build failure) for CI configurations that compile without
+    /// the const-eval size check being evaluated.
+    #[test]
+    fn blend_uniform_data_size_is_80_bytes() {
+        assert_eq!(
+            std::mem::size_of::<super::BlendUniformData>(),
+            80,
+            "BlendUniformData must be 80 bytes to match the WGSL BlendUniforms struct"
+        );
+    }
+}
+
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+mod gpu_construction_tests {
+    use super::AdvancedBlendPipeline;
+
+    fn test_device() -> wgpu::Device {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .expect("a GPU adapter must be available on a GPU-enabled test host");
+        let (device, _queue) =
+            pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+                label: Some("AdvancedBlendPipeline Test Device"),
+                ..Default::default()
+            }))
+            .expect("GPU device creation succeeded when adapter was found");
+        device
+    }
+
+    /// `AdvancedBlendPipeline::new` completes without a wgpu validation error for
+    /// `Bgra8Unorm`, proving the WGSL parses and the bind-group layout is valid.
+    #[test]
+    fn pipeline_construction_succeeds_for_bgra8unorm() {
+        let device = test_device();
+        let _pipeline = AdvancedBlendPipeline::new(&device, wgpu::TextureFormat::Bgra8Unorm);
+    }
+}

--- a/crates/flui-engine/src/wgpu/mod.rs
+++ b/crates/flui-engine/src/wgpu/mod.rs
@@ -56,6 +56,10 @@
 // CORE MODULES
 // ============================================================================
 
+/// Advanced dst-read blend composite driver: backdrop copy, pipeline, and
+/// `flush_advanced_layer`.  No production caller exists yet (wired in PR-3);
+/// the synthetic-op GPU gate in this module is the authoritative WGSL gate.
+pub(crate) mod advanced_blend;
 mod atlas;
 mod backend;
 /// Record-side draw accumulation helpers: `DrawBatcher` owns the tessellator,

--- a/crates/flui-engine/src/wgpu/shaders/advanced_blend.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/advanced_blend.wgsl
@@ -1,0 +1,340 @@
+// Advanced blend-mode composite shader.
+//
+// Implements the W3C Compositing and Blending Level 1 separable and
+// non-separable blend functions for all 15 advanced modes.  The math is
+// a verbatim port of `Color::blend` in `flui-types/src/styling/color.rs`
+// (lines 913–1149); any divergence is a correctness bug — the CPU oracle is
+// the canonical definition.
+//
+// ## Pipeline contract
+//
+// - VS: generates a unit quad over `op_bounds` (device-space pixels) and
+//   converts to clip space using `viewport_size`.  No vertex buffer is bound;
+//   vertices are synthesised from `@builtin(vertex_index)`.
+// - FS group 0:
+//     binding 0 — `BlendUniforms` uniform
+//     binding 1 — foreground texture (premultiplied RGBA f32)
+//     binding 2 — backdrop copy texture (premultiplied RGBA f32)
+//     binding 3 — nearest-clamp sampler
+//
+// ## Gamma space
+//
+// No `pow(2.2)` linearisation anywhere.  The textures store byte-channel
+// values divided by 255 (i.e. the same encoding `Color::blend` uses).
+// Introducing gamma linearisation here would diverge from the CPU oracle.
+//
+// ## Premultiplied flow
+//
+// Both input textures arrive premultiplied.  The fragment shader
+// un-premultiplies to straight Cs/Cb before calling the blend function,
+// then re-composites according to the W3C formula, and outputs premultiplied
+// RGBA.  The pipeline blend state is REPLACE (the shader owns the full
+// composite); no GPU fixed-function blending occurs.
+
+// ── Uniforms ─────────────────────────────────────────────────────────────────
+
+struct BlendUniforms {
+    // Device-space pixel rectangle for the foreground layer: [x, y, w, h].
+    // offset 0, size 16.
+    op_bounds:    vec4<f32>,
+    // Viewport size in device pixels [w, h] for clip-space conversion.
+    // offset 16, size 8.
+    viewport_size: vec2<f32>,
+    // Origin of the backdrop copy rect in device pixels [x, y].
+    // offset 24, size 8.
+    copy_origin:  vec2<f32>,
+    // Extent of the backdrop copy rect in device pixels [w, h].
+    // offset 32, size 8.
+    copy_extent:  vec2<f32>,
+    // Group opacity pre-applied into the source sample.
+    // offset 40, size 4.
+    opacity:      f32,
+    // Alignment gap: tint_rgb (vec3<f32>) requires 16-byte alignment,
+    // so bytes 44-47 are padding. offset 44, size 4.
+    _pad0:        f32,
+    // Per-channel tint RGB pre-applied into the source sample (matches
+    // `flush_opacity_layer` tint folding: tint = (tint_rgb * opacity, opacity)).
+    // offset 48, size 12.
+    tint_rgb:     vec3<f32>,
+    // Blend mode discriminant; see `mode_to_u32` in pipeline.rs.
+    // offset 60, size 4.
+    mode:         u32,
+    // Struct-size padding to 80 bytes (multiple of 16). offset 64, size 16.
+    _pad1:        vec4<u32>,
+}
+
+@group(0) @binding(0)
+var<uniform> blend: BlendUniforms;
+
+@group(0) @binding(1)
+var foreground_tex: texture_2d<f32>;
+
+@group(0) @binding(2)
+var backdrop_tex:   texture_2d<f32>;
+
+@group(0) @binding(3)
+var nearest_sampler: sampler;
+
+// ── Vertex shader ─────────────────────────────────────────────────────────────
+//
+// Synthesises 6 vertices (2 triangles, CCW) from `vertex_index` 0-5 that form
+// a quad covering `op_bounds` in device space, then converts to clip space.
+// No vertex buffer is bound; this avoids a CPU upload per draw.
+
+struct VsOutput {
+    // In the vertex shader this holds clip-space position; the rasteriser
+    // converts it so that in the fragment shader @builtin(position) delivers
+    // `frag_coord` — fragment-centre device pixel coordinates (col+0.5, row+0.5).
+    @builtin(position) frag_pos: vec4<f32>,
+    // Foreground texture UV in [0,1] within `op_bounds`.
+    @location(0)       src_uv:   vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VsOutput {
+    // Unit-quad corners for the 2-triangle strip (CCW winding).
+    // Indices map: 0→TL, 1→TR, 2→BL, 3→TR, 4→BR, 5→BL
+    let corners = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), // TL
+        vec2<f32>(1.0, 0.0), // TR
+        vec2<f32>(0.0, 1.0), // BL
+        vec2<f32>(1.0, 0.0), // TR
+        vec2<f32>(1.0, 1.0), // BR
+        vec2<f32>(0.0, 1.0), // BL
+    );
+    let uv = corners[vi];
+
+    let bx = blend.op_bounds.x;
+    let by = blend.op_bounds.y;
+    let bw = blend.op_bounds.z;
+    let bh = blend.op_bounds.w;
+
+    // Device pixel position.
+    let px = bx + uv.x * bw;
+    let py = by + uv.y * bh;
+
+    // Clip space: x in [-1,1], y flipped (screen Y grows down, clip Y up).
+    let clip_x = (px / blend.viewport_size.x) * 2.0 - 1.0;
+    let clip_y = 1.0 - (py / blend.viewport_size.y) * 2.0;
+
+    var out: VsOutput;
+    out.frag_pos = vec4<f32>(clip_x, clip_y, 0.0, 1.0);
+    out.src_uv   = uv;
+    return out;
+}
+
+// ── Blend helpers (verbatim port of color.rs separable/nonseparable) ──────────
+
+fn hard_light(cb: f32, cs: f32) -> f32 {
+    if cs <= 0.5 {
+        return 2.0 * cb * cs;
+    }
+    return 1.0 - 2.0 * (1.0 - cb) * (1.0 - cs);
+}
+
+fn separable_blend(mode: u32, cb: f32, cs: f32) -> f32 {
+    switch mode {
+        // Multiply  (mode 0)
+        case 0u: { return cb * cs; }
+        // Screen    (mode 1)
+        case 1u: { return cb + cs - cb * cs; }
+        // Overlay   (mode 2): overlay(cb,cs) == hard_light(cs,cb)
+        case 2u: { return hard_light(cs, cb); }
+        // Darken    (mode 3)
+        case 3u: { return min(cb, cs); }
+        // Lighten   (mode 4)
+        case 4u: { return max(cb, cs); }
+        // ColorDodge (mode 5) — exact branch order from color.rs:1040-1047
+        case 5u: {
+            if cb <= 0.0 { return 0.0; }
+            if cs >= 1.0 { return 1.0; }
+            return min(cb / (1.0 - cs), 1.0);
+        }
+        // ColorBurn (mode 6) — exact branch order from color.rs:1049-1056
+        case 6u: {
+            if cb >= 1.0 { return 1.0; }
+            if cs <= 0.0 { return 0.0; }
+            return 1.0 - min((1.0 - cb) / cs, 1.0);
+        }
+        // HardLight (mode 7)
+        case 7u: { return hard_light(cb, cs); }
+        // SoftLight (mode 8) — verbatim from color.rs:1059-1069
+        case 8u: {
+            if cs <= 0.5 {
+                return cb - (1.0 - 2.0 * cs) * cb * (1.0 - cb);
+            }
+            var d: f32;
+            if cb <= 0.25 {
+                d = ((16.0 * cb - 12.0) * cb + 4.0) * cb;
+            } else {
+                d = sqrt(cb);
+            }
+            return cb + (2.0 * cs - 1.0) * (d - cb);
+        }
+        // Difference (mode 9)
+        case 9u: { return abs(cb - cs); }
+        // Exclusion  (mode 10)
+        case 10u: { return cb + cs - 2.0 * cb * cs; }
+        default: { return cs; }
+    }
+}
+
+// Luminosity of an RGB triple (W3C Lum).
+fn lum(c: vec3<f32>) -> f32 {
+    return 0.3 * c.r + 0.59 * c.g + 0.11 * c.b;
+}
+
+// Clip an RGB triple back into [0,1] preserving luminosity (W3C ClipColor).
+// The epsilon guards avoid 0/0 when all channels are equal.
+fn clip_color(c: vec3<f32>) -> vec3<f32> {
+    let l = lum(c);
+    let n = min(min(c.r, c.g), c.b);
+    let x = max(max(c.r, c.g), c.b);
+    var out = c;
+    if n < 0.0 && abs(l - n) > 1.1920929e-7 {
+        out = l + (out - l) * l / (l - n);
+    }
+    if x > 1.0 && abs(x - l) > 1.1920929e-7 {
+        out = l + (out - l) * (1.0 - l) / (x - l);
+    }
+    return out;
+}
+
+// Shift an RGB triple to target luminosity (W3C SetLum).
+fn set_lum(c: vec3<f32>, target_lum: f32) -> vec3<f32> {
+    let d = target_lum - lum(c);
+    return clip_color(c + d);
+}
+
+// Saturation: max channel minus min channel (W3C Sat).
+fn sat(c: vec3<f32>) -> f32 {
+    return max(max(c.r, c.g), c.b) - min(min(c.r, c.g), c.b);
+}
+
+// Rescale RGB triple to target saturation keeping relative channel order
+// (W3C SetSat).  A flat triple (max == min) collapses to black.
+//
+// WGSL has no sort; we implement the sort-by-magnitude manually.
+// The triple has 6 orderings; we enumerate them as the index triple
+// (i_min, i_mid, i_max) by comparing all three pairs exactly once.
+fn set_sat(c: vec3<f32>, target_sat: f32) -> vec3<f32> {
+    // Extract channels into indexed array for permutation.
+    var ch = array<f32, 3>(c.r, c.g, c.b);
+
+    // Bubble-sort 3 elements ascending: O(3 comparisons), stable.
+    var tmp: f32;
+    if ch[0] > ch[1] { tmp = ch[0]; ch[0] = ch[1]; ch[1] = tmp; }
+    if ch[1] > ch[2] { tmp = ch[1]; ch[1] = ch[2]; ch[2] = tmp; }
+    if ch[0] > ch[1] { tmp = ch[0]; ch[0] = ch[1]; ch[1] = tmp; }
+    // ch[0]=min, ch[1]=mid, ch[2]=max — but these are VALUES not original indices.
+    // We need to map back to (r,g,b); find which original index maps where.
+    let c_min = ch[0];
+    let c_mid = ch[1];
+    let c_max = ch[2];
+
+    var out_ch = array<f32, 3>(0.0, 0.0, 0.0);
+    if c_max > c_min {
+        // Determine original index for each sorted slot.
+        // Priority: if two channels are equal we still assign each to a distinct slot.
+        // We use the same lexicographic tie-break as Rust's total_cmp on f32.
+        for (var slot = 0u; slot < 3u; slot++) {
+            let cv = array<f32, 3>(c.r, c.g, c.b)[slot];
+            // Assign to min/mid/max slot based on sorted value.
+            if cv == c_min {
+                out_ch[slot] = 0.0;
+            } else if cv == c_max {
+                out_ch[slot] = target_sat;
+            } else {
+                out_ch[slot] = (cv - c_min) * target_sat / (c_max - c_min);
+            }
+        }
+    }
+    // If c_max == c_min: all channels equal → out_ch stays 0 (flat/achromatic → black).
+    return vec3<f32>(out_ch[0], out_ch[1], out_ch[2]);
+}
+
+// Non-separable blend for Hue/Saturation/Color/Luminosity modes.
+// mode discriminants: 11=Hue, 12=Saturation, 13=Color, 14=Luminosity.
+fn nonseparable_blend(mode: u32, cb: vec3<f32>, cs: vec3<f32>) -> vec3<f32> {
+    switch mode {
+        // Hue: hue of source, sat+lum of backdrop
+        case 11u: { return set_lum(set_sat(cs, sat(cb)), lum(cb)); }
+        // Saturation: sat of source, hue+lum of backdrop
+        case 12u: { return set_lum(set_sat(cb, sat(cs)), lum(cb)); }
+        // Color: hue+sat of source, lum of backdrop
+        case 13u: { return set_lum(cs, lum(cb)); }
+        // Luminosity: lum of source, hue+sat of backdrop
+        case 14u: { return set_lum(cb, lum(cs)); }
+        default: { return cs; }
+    }
+}
+
+// ── Fragment shader ───────────────────────────────────────────────────────────
+
+@fragment
+fn fs_main(in: VsOutput) -> @location(0) vec4<f32> {
+    // ── Sample foreground (premultiplied) ──────────────────────────────────
+    let fg_pm = textureSample(foreground_tex, nearest_sampler, in.src_uv);
+
+    // Apply opacity + tint into the premultiplied source, matching the
+    // flush_opacity_layer folding: tint = (tint_rgb * opacity, opacity).
+    // Per replay.rs:496-502: src_pm_adjusted = fg_pm * vec4(tint_rgb, 1) * opacity
+    let fg_pm_adjusted = vec4<f32>(
+        fg_pm.rgb * blend.tint_rgb * blend.opacity,
+        fg_pm.a   * blend.opacity,
+    );
+
+    // ── Sample backdrop copy (premultiplied) ───────────────────────────────
+    //
+    // frag_pos.xy carries frag_coord: the fragment centre in device pixels,
+    // i.e. (col+0.5, row+0.5).  The backdrop copy starts at copy_origin and
+    // spans copy_extent pixels.  For surface column `col`:
+    //   texel index in copy = col - copy_origin.x
+    //   uv = ((col - copy_origin.x) + 0.5) / copy_extent.x
+    //       = (frag_pos.x - copy_origin.x) / copy_extent.x
+    //
+    // No additional +0.5: frag_coord already carries the half-texel offset.
+    let bd_uv = (in.frag_pos.xy - blend.copy_origin) / blend.copy_extent;
+    let bd_pm = textureSample(backdrop_tex, nearest_sampler, bd_uv);
+
+    // ── Un-premultiply both to straight Cs / Cb ────────────────────────────
+    let as_ = fg_pm_adjusted.a;   // source alpha
+    let ab  = bd_pm.a;            // backdrop alpha
+
+    // Guard against division by zero: straight = premul / alpha, or 0 if alpha=0.
+    let cs = select(fg_pm_adjusted.rgb / as_, vec3<f32>(0.0), as_ <= 0.0);
+    let cb = select(bd_pm.rgb / ab,          vec3<f32>(0.0), ab  <= 0.0);
+
+    // ── Blend function B(Cb, Cs) ───────────────────────────────────────────
+    var blended: vec3<f32>;
+    let m = blend.mode;
+    if m >= 11u {
+        // Non-separable: Hue/Saturation/Color/Luminosity
+        blended = nonseparable_blend(m, cb, cs);
+    } else {
+        // Separable: applied per channel
+        blended = vec3<f32>(
+            separable_blend(m, cb.r, cs.r),
+            separable_blend(m, cb.g, cs.g),
+            separable_blend(m, cb.b, cs.b),
+        );
+    }
+
+    // ── W3C composite (color.rs:934-942) ──────────────────────────────────
+    //
+    // co = αs·(1-αb)·Cs + αs·αb·B(Cb,Cs) + (1-αs)·αb·Cb  (premultiplied)
+    // αo = αs + αb·(1-αs)
+    let out_rgb_pm = as_ * (1.0 - ab) * cs
+                   + as_ * ab         * blended
+                   + (1.0 - as_) * ab * cb;
+    let out_a = as_ + ab * (1.0 - as_);
+
+    // ── out_a <= 0 → transparent (color.rs:945) ───────────────────────────
+    if out_a <= 0.0 {
+        return vec4<f32>(0.0);
+    }
+
+    // Output premultiplied.
+    return vec4<f32>(clamp(out_rgb_pm, vec3<f32>(0.0), vec3<f32>(1.0)),
+                     clamp(out_a, 0.0, 1.0));
+}


### PR DESCRIPTION
**PR 2 of 6** of the advanced (dst-read) blend-modes feature. This lands the **GPU machine** for the 15 advanced modes (Screen/Overlay/Multiply/…/Hue/Saturation/Color/Luminosity) and proves it against the CPU oracle with a synthetic op. The engine can now *execute* advanced blend; real producers still warn-fallback to SrcOver (wired in PR-3..5). Existing rendering paths are **byte-identical**.

## What this PR adds
- **`shaders/advanced_blend.wgsl`** — a faithful WGSL port of `Color::blend` (the sole in-repo oracle; `.flutter/` has no Impeller). All 15 modes: separable + the 4 non-separable HSL via `set_lum`/`set_sat`/`clip_color`. **Gamma-space** (no linearization — matches `Color::blend` and flui's `Rgba8Unorm` compositor). `premul → unpremul → B(Cb,Cs) → W3C composite → premul`, with the `out_a<=0` guard and the **exact** ColorDodge/ColorBurn branch order + non-separable degenerate-triple guards. One pipeline, `mode` as a `u32` switch; **REPLACE** blend (the shader emits the full composite); backdrop sampled **Nearest+ClampToEdge** from a *separately copied* region (no read-after-write).
- **`advanced_blend/{mod,pipeline}.rs`** — `AdvancedBlendOp`, `BackdropSample`, `copy_backdrop_region` (clamp/round mirrors `handle_backdrop_filter`), the `flush_advanced_layer` driver, `AdvancedBlendPipeline`, and `mode_to_u32` (non-advanced variants listed **explicitly** so a new `BlendMode` is a compile error, not a runtime panic).
- No production caller yet — the driver is exercised by the synthetic-op gate; the `dead_code` allow is removed when PR-3 wires the renderer interception.

## Evidence
- `fmt` · `clippy --workspace --all-targets -D warnings` (+ `--features enable-wgpu-tests`) · nextest · `check --release` · wasm32 · doc · typos · taplo · port-check — all green.
- **GPU-readback (local DX12, `--features enable-wgpu-tests`): 230/0/7.** Synthetic-op asserts each of the 15 modes pixel-matches `Color::blend` ±1 over an **opaque** split dst (opaque isolates the `B` formulas: composite collapses to `B`, premul is u8-exact). Plus: ColorDodge/ColorBurn boundary GPU round-trip; non-zero `copy_origin` uv correctness (catches texel-offset regressions); translucent composite ±2 (the αs/αb path; ±2 absorbs the premul→u8→unpremul input quantization the straight-color oracle doesn't model); transparent `out_a=0` → transparent no-NaN; achromatic no-NaN.

## Review
`rust-reviewer` (spec/quality) + `ce-kieran` (soundness — line-by-line WGSL vs `Color::blend`). Both independently caught two real bugs before commit: a duplicated texel-center `+0.5` in the backdrop UV (`@builtin(position)` in a FS is already centered → full-texel shift; confirmed by a failing GPU readback) and a `mode_to_u32` wildcard that would let a new variant panic at runtime. Both fixed; the GPU readback then surfaced and drove fixes to the synthetic tests' own setup (opaque vs translucent oracle fidelity, `COPY_SRC`/`RENDER_ATTACHMENT` usage flags, a wrong dodge/burn expectation that confused the blend-function `B` with the composited result).

🤖 Generated with [Claude Code](https://claude.com/claude-code)