### PR TITLE
chore(cargo): trim dev debuginfo (`debug = 1`) + opt-in `dbg` profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,7 +202,7 @@ CI runs on PR + push to main. Jobs (in dependency order):
 ## Important Config
 
 - **Toolchain:** pinned in `rust-toolchain.toml` to `1.96.0` with `rustfmt` + `clippy` components
-- **Cargo profiles:** dev `opt-level = 1` (faster runtime), deps `opt-level = 2`; release `lto = "thin"`, `codegen-units = 1`, `strip = "symbols"`
+- **Cargo profiles:** dev `opt-level = 1` (faster runtime) + `debug = 1` ("limited" — backtraces + debugger vars, no DWARF/CodeView type info, the bulk of `target/debug/deps` size), deps `opt-level = 2`; `dbg` profile (`inherits = "dev"`, `debug = "full"`) is the opt-in full-type-info build for a step-debugger; release `lto = "thin"`, `codegen-units = 1`, `strip = "symbols"`. Local disk: the `target/debug/incremental` cache (no size cap) is the largest consumer on a 28-crate wgpu workspace — sweep it periodically. CI sets `CARGO_INCREMENTAL=0` + `CARGO_PROFILE_DEV_DEBUG=line-tables-only` and reclaims ~25 GB of runner bloat before building.
 - **Build jobs:** 8 (set in `.cargo/config.toml`)
 - **Android examples** require `cargo-ndk` + Android NDK (not in workspace default-members)
 - **WASM examples** require `wasm-pack` (not in workspace default-members); use `just web-server` for the dev server

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,9 +282,23 @@ serde = [
 [profile.dev]
 opt-level = 1      # Some optimization for faster runtime
 incremental = true # Faster rebuilds
+# `debug = 1` ("limited") keeps file:line in panic backtraces AND variable/scope
+# info for a step-debugger, but drops the DWARF/CodeView *type* info that full
+# `debug = 2` (cargo's dev default) emits. On this wgpu/cosmic-text/lyon/naga
+# workspace that embedded type info is the bulk of the per-crate artifact size
+# in `target/debug/deps`. Same trade-off Zed/gpui ships as its default dev
+# profile. When you need complete type info in the debugger, build `--profile dbg`.
+debug = 1
 
 [profile.dev.package."*"]
 opt-level = 2 # Optimize dependencies (they don't change often)
+
+# Opt-in full-debuginfo profile. Inherits `dev` but restores `debug = 2` so a
+# step-debugger (RustRover / lldb / gdb) sees complete type info. Use sparingly —
+# it re-inflates `target/`: `cargo build --profile dbg`, `cargo test --profile dbg`.
+[profile.dbg]
+inherits = "dev"
+debug = "full"
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
## What

- `[profile.dev]`: add `debug = 1` ("limited"). Cargo's dev default is full `debug = 2`.
- Add `[profile.dbg]` (`inherits = "dev"`, `debug = "full"`) — opt-in full type info for a step-debugger: `cargo build --profile dbg`.
- Sync `AGENTS.md` profile + local-disk notes.

No crate source touched. Release profile unchanged.

## Why

The `target/` directory on a local 28-crate `wgpu`/`cosmic-text`/`lyon`/`naga` workspace grows into the tens of GB. Ground-truth breakdown of a local `target` (77.5 GB):

| Bucket | Size |
|---|---|
| `target/debug/incremental` (rebuild cache, uncapped) | ~51 GB |
| `target/debug/deps` (artifacts w/ embedded debuginfo) | ~21 GB |
| `.pdb` (suppressed on Windows by existing `/DEBUG:NONE`) | ~1 GB |

`debug = 1` attacks the **deps** bucket — it drops the DWARF/CodeView **type** info (the bulk of embedded debuginfo) while keeping:
- file:line in panic backtraces, and
- variable/scope info for a step-debugger.

This is the same default Zed/gpui ships (`debug = "limited"`), the closest same-sphere project (GPU-accelerated UI framework in Rust). It pairs the trimmed default with an opt-in full-debug profile — mirrored here as `[profile.dbg]`, so no debugging capability is lost (one flag restores full type info).

## Scope / reviewer notes

- **Local-only effect.** CI already trims debuginfo (`CARGO_PROFILE_DEV_DEBUG=line-tables-only` on the test job) and disables incremental (`CARGO_INCREMENTAL=0`). This change only affects the local default `cargo build` / `cargo test`.
- The dominant local consumer (incremental cache, ~51 GB) is **not** addressed by a profile knob — it's a pure rebuild cache with no size cap. Reclaiming it / sweeping it is left to the developer (deliberately, per discussion) and does not belong in the manifest.
- Verified: `cargo build --profile dbg -p flui-types` → `Finished 'dbg' profile [optimized + debuginfo]`; `cargo metadata` parses; `taplo fmt --check Cargo.toml` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
