### PR TITLE
feat(engine): saveLayer / layer-level advanced (dst-read) blend (advanced-blend PR-3)

### DIFF
--- a/crates/flui-engine/src/traits.rs
+++ b/crates/flui-engine/src/traits.rs
@@ -423,6 +423,17 @@ pub trait LayerStateStack {
     /// Push an opacity value onto the effect stack
     fn push_opacity(&mut self, alpha: f32);
 
+    /// Push an opacity layer with an explicit blend mode onto the effect stack.
+    ///
+    /// The default implementation forwards to [`push_opacity`](Self::push_opacity),
+    /// which is correct for command-only backends that do not participate in the
+    /// dst-read compositor path.  The `wgpu` backend overrides this to route
+    /// advanced blend modes through `save_layer` with the blend propagated.
+    fn push_opacity_blend(&mut self, alpha: f32, blend: flui_types::painting::BlendMode) {
+        let _ = blend;
+        self.push_opacity(alpha);
+    }
+
     /// Pop the most recent opacity from the effect stack
     fn pop_opacity(&mut self);
 

--- a/crates/flui-engine/src/wgpu/advanced_blend/mod.rs
+++ b/crates/flui-engine/src/wgpu/advanced_blend/mod.rs
@@ -42,11 +42,6 @@ mod pipeline;
 /// offscreen target (premultiplied RGBA).  Ownership is transferred in so the
 /// caller's `PooledTexture` RAII handle is not dropped until after the render
 /// pass that reads it completes.
-#[allow(
-    dead_code,
-    reason = "Driven by the renderer-layer advanced-blend interception; \
-              exercised here by the synthetic-op gate"
-)]
 pub(crate) struct AdvancedBlendOp {
     /// Pre-rendered foreground layer content (premultiplied RGBA).
     pub(crate) foreground: PooledTexture,
@@ -58,7 +53,19 @@ pub(crate) struct AdvancedBlendOp {
     pub(crate) opacity: f32,
     /// Per-channel RGB tint in [0.0, 1.0] per component.
     pub(crate) tint: [f32; 3],
+    /// Foreground texture UV min corner `[u_min, v_min]`.
+    ///
+    /// The VS-interpolated unit-quad UV `[0,1]` is remapped to
+    /// `mix(src_uv_min, src_uv_max, uv)` before sampling the foreground.
+    /// Pass `[0.0, 0.0]` for a full-viewport foreground (identity).
+    pub(crate) src_uv_min: [f32; 2],
+    /// Foreground texture UV max corner `[u_max, v_max]`.
+    ///
+    /// Pass `[1.0, 1.0]` for a full-viewport foreground (identity).
+    pub(crate) src_uv_max: [f32; 2],
 }
+
+// ── Backdrop copy ─────────────────────────────────────────────────────────────
 
 /// A successfully copied backdrop region ready for shader sampling.
 ///
@@ -91,10 +98,6 @@ pub(crate) struct BackdropSample {
 /// - Derive width/height from the clamped corners (`right.saturating_sub(x)`).
 /// - `max(1)` on width/height prevents a zero-extent copy (wgpu validation requires
 ///   non-zero extent).
-#[allow(
-    dead_code,
-    reason = "Called by flush_advanced_layer; exercised by the synthetic-op gate"
-)]
 pub(crate) fn copy_backdrop_region(
     surface_texture: &wgpu::Texture,
     device_rect: Rect<Pixels>,
@@ -192,16 +195,6 @@ pub(crate) fn copy_backdrop_region(
 /// 3. Issue one render pass over `op.device_bounds` with `LoadOp::Load` (preserving
 ///    existing surface content outside the blend region).
 /// 4. Pooled textures (foreground, backdrop copy) are returned to the pool on drop.
-///
-/// ## No production caller in PR-2
-///
-/// This function is driven by the renderer-layer advanced-blend interception added
-/// in PR-3.  It is exercised in PR-2 exclusively by the synthetic-op GPU gate.
-#[allow(
-    dead_code,
-    reason = "Driven by the renderer-layer advanced-blend interception; \
-              exercised here by the synthetic-op gate"
-)]
 #[allow(clippy::too_many_arguments)]
 #[allow(
     clippy::needless_pass_by_value,
@@ -254,7 +247,8 @@ pub(crate) fn flush_advanced_layer(
         _pad0: 0,
         tint_rgb: op.tint,
         mode: mode_to_u32(op.mode),
-        _pad1: [0; 4],
+        src_uv_min: op.src_uv_min,
+        src_uv_max: op.src_uv_max,
     };
 
     let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -757,6 +751,9 @@ mod synthetic_op_tests {
                 ),
                 opacity: 1.0,
                 tint: [1.0, 1.0, 1.0],
+                // Full-viewport foreground: identity UV remap.
+                src_uv_min: [0.0, 0.0],
+                src_uv_max: [1.0, 1.0],
             };
 
             let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -898,6 +895,8 @@ mod synthetic_op_tests {
                 device_bounds: Rect::from_xywh(Pixels(0.0), Pixels(0.0), Pixels(1.0), Pixels(1.0)),
                 opacity: 1.0,
                 tint: [1.0, 1.0, 1.0],
+                src_uv_min: [0.0, 0.0],
+                src_uv_max: [1.0, 1.0],
             };
             let mut encoder = device
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some(label) });
@@ -995,6 +994,8 @@ mod synthetic_op_tests {
             device_bounds: Rect::from_xywh(Pixels(0.0), Pixels(0.0), Pixels(4.0), Pixels(2.0)),
             opacity: 1.0,
             tint: [1.0, 1.0, 1.0],
+            src_uv_min: [0.0, 0.0],
+            src_uv_max: [1.0, 1.0],
         };
 
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -1135,6 +1136,10 @@ mod synthetic_op_tests {
             ),
             opacity: 1.0,
             tint: [1.0, 1.0, 1.0],
+            // Foreground is 4×SURF_H, not full-viewport (SURF_W=6) — identity
+            // UV within the foreground texture itself (the texture IS 4 wide).
+            src_uv_min: [0.0, 0.0],
+            src_uv_max: [1.0, 1.0],
         };
 
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -1280,6 +1285,8 @@ mod synthetic_op_tests {
             ),
             opacity: 1.0,
             tint: [1.0, 1.0, 1.0],
+            src_uv_min: [0.0, 0.0],
+            src_uv_max: [1.0, 1.0],
         };
 
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {

--- a/crates/flui-engine/src/wgpu/advanced_blend/pipeline.rs
+++ b/crates/flui-engine/src/wgpu/advanced_blend/pipeline.rs
@@ -29,19 +29,27 @@ use flui_types::painting::BlendMode;
 /// - `u32`       → align 4
 /// - Struct size must be a multiple of 16 (largest member alignment).
 ///
-/// | Byte offset | Size | Rust field       | WGSL member                |
-/// |-------------|------|------------------|----------------------------|
-/// | 0           | 16   | `op_bounds`      | `vec4<f32>` (op_bounds)    |
-/// | 16          | 8    | `viewport_size`  | `vec2<f32>`                |
-/// | 24          | 8    | `copy_origin`    | `vec2<f32>`                |
-/// | 32          | 8    | `copy_extent`    | `vec2<f32>`                |
-/// | 40          | 4    | `opacity`        | `f32`                      |
-/// | 44          | 4    | `_pad0`          | `f32` (align gap)          |
-/// | 48          | 12   | `tint_rgb`       | `vec3<f32>` (align 16)     |
-/// | 60          | 4    | `mode`           | `u32`                      |
-/// | 64          | 16   | `_pad1`          | `vec4<u32>` (size pad)     |
+/// | Byte offset | Size | Rust field       | WGSL member                    |
+/// |-------------|------|------------------|--------------------------------|
+/// | 0           | 16   | `op_bounds`      | `vec4<f32>` (op_bounds)        |
+/// | 16          | 8    | `viewport_size`  | `vec2<f32>`                    |
+/// | 24          | 8    | `copy_origin`    | `vec2<f32>`                    |
+/// | 32          | 8    | `copy_extent`    | `vec2<f32>`                    |
+/// | 40          | 4    | `opacity`        | `f32`                          |
+/// | 44          | 4    | `_pad0`          | `f32` (align gap)              |
+/// | 48          | 12   | `tint_rgb`       | `vec3<f32>` (align 16)         |
+/// | 60          | 4    | `mode`           | `u32`                          |
+/// | 64          | 8    | `src_uv_min`     | `vec2<f32>` foreground UV min  |
+/// | 72          | 8    | `src_uv_max`     | `vec2<f32>` foreground UV max  |
 ///
 /// Total = 80 bytes (multiple of 16).
+///
+/// `src_uv_min/max` remap the VS-interpolated unit-quad UV `[0,1]` to the
+/// sub-region of the foreground texture that corresponds to the layer bounds
+/// within the full-viewport offscreen texture.  Pass `[0,0]..[1,1]` for a
+/// full-viewport foreground (the identity remap); pass `layer_bounds/viewport`
+/// for a layer that was rendered to a full-viewport offscreen but only covers
+/// a sub-region.
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub(super) struct BlendUniformData {
@@ -63,9 +71,18 @@ pub(super) struct BlendUniformData {
     pub(super) tint_rgb: [f32; 3],
     /// Blend mode discriminant (see [`mode_to_u32`]).
     pub(super) mode: u32,
-    /// Struct-size padding to reach 80 bytes (next multiple of 16 after 64+12=76).
-    /// Must remain zero.
-    pub(super) _pad1: [u32; 4],
+    /// Foreground UV min corner `[u_min, v_min]` for the src-UV remap.
+    ///
+    /// The VS-interpolated unit-quad UV `[0,1]` is remapped to
+    /// `mix(src_uv_min, src_uv_max, uv)` before sampling the foreground
+    /// texture.  Pass `[0, 0]` for a full-viewport foreground.
+    pub(super) src_uv_min: [f32; 2],
+    /// Foreground UV max corner `[u_max, v_max]` for the src-UV remap.
+    ///
+    /// Pass `[1, 1]` for a full-viewport foreground (identity remap).
+    /// Pass `[bounds_right/vp_w, bounds_bottom/vp_h]` when the layer was
+    /// rendered to a full-viewport offscreen but only covers a sub-region.
+    pub(super) src_uv_max: [f32; 2],
 }
 
 const _BLEND_UNIFORM_SIZE_CHECK: () = {
@@ -159,11 +176,6 @@ pub(crate) struct AdvancedBlendPipeline {
     pub(crate) pipeline: wgpu::RenderPipeline,
 }
 
-#[allow(
-    dead_code,
-    reason = "Driven by the renderer-layer advanced-blend interception; \
-              exercised here by the synthetic-op GPU gate"
-)]
 impl AdvancedBlendPipeline {
     /// Build the pipeline for `surface_format`.
     ///
@@ -234,11 +246,6 @@ impl AdvancedBlendPipeline {
 
 // ── Bind-group layout factory (private) ──────────────────────────────────────
 
-#[allow(
-    dead_code,
-    reason = "Called by AdvancedBlendPipeline::new which is gated behind the \
-              renderer-layer interception; exercised by the synthetic-op GPU gate"
-)]
 fn create_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
     device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: Some("Advanced Blend Bind Group Layout"),
@@ -348,6 +355,10 @@ mod cpu_tests {
     }
 
     /// The struct size must match the WGSL uniform-block size exactly.
+    ///
+    /// Layout: op_bounds(16) + viewport_size(8) + copy_origin(8) +
+    /// copy_extent(8) + opacity(4) + _pad0(4) + tint_rgb(12) + mode(4) +
+    /// src_uv_min(8) + src_uv_max(8) = 80 bytes.
     ///
     /// This test makes the compile-time assert observable as a test failure
     /// (rather than a build failure) for CI configurations that compile without

--- a/crates/flui-engine/src/wgpu/backend.rs
+++ b/crates/flui-engine/src/wgpu/backend.rs
@@ -1476,10 +1476,24 @@ impl LayerStateStack for Backend<'_> {
 
     fn push_opacity(&mut self, alpha: f32) {
         self.flush_active_transform();
-        // Create a layer with opacity (clamped to [0, 255])
+        // Create a layer with opacity (clamped to [0, 255]).
+        // Blend mode defaults to SrcOver via Paint::fill.
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let alpha_u8 = (alpha.clamp(0.0, 1.0) * 255.0) as u8;
         let paint = Paint::fill(Color::WHITE).with_alpha(alpha_u8);
+        self.painter.save_layer(None, &paint);
+    }
+
+    fn push_opacity_blend(&mut self, alpha: f32, blend: flui_types::painting::BlendMode) {
+        self.flush_active_transform();
+        // Propagate the explicit blend mode into the saveLayer paint so the
+        // compositor reads it from `paint.blend_mode` and routes the layer
+        // through the dst-read advanced compositor path when needed.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let alpha_u8 = (alpha.clamp(0.0, 1.0) * 255.0) as u8;
+        let paint = Paint::fill(Color::WHITE)
+            .with_alpha(alpha_u8)
+            .with_blend_mode(blend);
         self.painter.save_layer(None, &paint);
     }
 

--- a/crates/flui-engine/src/wgpu/command_ir.rs
+++ b/crates/flui-engine/src/wgpu/command_ir.rs
@@ -103,10 +103,6 @@ pub(crate) struct SavedLayer {
     ///
     /// Stored on the record side so the compositor dispatch can read it without
     /// coupling the flush path to the record path.  Defaults to `SrcOver`.
-    #[allow(
-        dead_code,
-        reason = "written by save_layer; read by the compositor dispatch when blending the layer onto its parent"
-    )]
     pub(crate) layer_blend: BlendMode,
 }
 
@@ -283,11 +279,8 @@ pub(crate) struct PendingOpacityLayer {
     pub(crate) bounds: Rect<Pixels>,
     /// Blend mode to apply when compositing this layer onto its parent.
     ///
-    /// Stored on the pending layer so the compositor dispatch can read it without
-    /// coupling the flush path to the record path.  Defaults to `SrcOver`.
-    #[allow(
-        dead_code,
-        reason = "written during layer creation; read by the compositor dispatch when blending the layer onto its parent"
-    )]
+    /// Stored on the pending layer so the flush path can read it without
+    /// coupling it to the record path.  `SrcOver` for plain opacity layers;
+    /// an advanced mode for `saveLayer` with an explicit blend mode.
     pub(crate) blend: BlendMode,
 }

--- a/crates/flui-engine/src/wgpu/debug.rs
+++ b/crates/flui-engine/src/wgpu/debug.rs
@@ -436,6 +436,13 @@ impl LayerStateStack for DebugBackend {
         self.log_command("push_opacity", &format!("alpha={alpha}"));
     }
 
+    fn push_opacity_blend(&mut self, alpha: f32, blend: flui_types::painting::BlendMode) {
+        self.log_command(
+            "push_opacity_blend",
+            &format!("alpha={alpha}, blend={blend:?}"),
+        );
+    }
+
     fn pop_opacity(&mut self) {
         self.log_command("pop_opacity", "");
     }

--- a/crates/flui-engine/src/wgpu/layer_blend_tests.rs
+++ b/crates/flui-engine/src/wgpu/layer_blend_tests.rs
@@ -1,0 +1,876 @@
+//! PR-3 acceptance gate: saveLayer/layer-level advanced-blend.
+//!
+//! ## Test inventory
+//!
+//! | # | Gate  | Requirement |
+//! |---|-------|-------------|
+//! | T1 | unit | `needs_composite` for opaque Multiply: compositor → Composite, not Reintegrate |
+//! | T2 | unit | `needs_composite` for SrcOver opaque: compositor → Reintegrate (byte-identity) |
+//! | T3 | unit | All 15 advanced modes → Composite; all Porter-Duff modes → Reintegrate for opaque |
+//! | T4 | unit | Plus and Modulate are NOT advanced (`is_advanced()` = false) |
+//! | T5 | unit | `PendingOpacityLayer` with Multiply carries `is_advanced()` = true |
+//! | T6 | GPU  | Opaque Multiply saveLayer: GPU readback ≈ oracle (display-list path) |
+//! | T7 | GPU  | SrcOver saveLayer: GPU readback byte-identical to direct draw (byte-identity) |
+//! | T8 | GPU  | Plus/Modulate saveLayer: no panic, valid RGBA output |
+//! | T9 | GPU  | Nested advanced layers (Multiply inside Screen): no panic, non-zero alpha |
+//! | T10 | GPU  | Sibling-Z: Multiply layer left-half, SrcOver right-half — no cross-bleed |
+
+// ─── Unit tests (no GPU required) ─────────────────────────────────────────────
+
+#[cfg(test)]
+mod unit_tests {
+    use flui_types::{Rect, painting::BlendMode};
+
+    use crate::wgpu::{
+        command_ir::{DrawItem, DrawSegment, PendingOpacityLayer},
+        layer_compositor::{LayerCompositor, RestoreOutcome},
+    };
+
+    /// Returns a non-empty offscreen-items list (one empty segment).
+    ///
+    /// `pop_layer` checks `!offscreen_items.is_empty() || !segment.is_empty()`
+    /// to decide whether there is anything to composite.  Wrapping an empty
+    /// `DrawSegment` in `DrawItem::Segment` gives a non-empty items vec.
+    fn one_draw_item() -> Vec<DrawItem> {
+        vec![DrawItem::Segment(DrawSegment::new())]
+    }
+
+    // ── T1: CRITICAL GATE — opaque Multiply must Composite ───────────────────
+
+    /// T1: An opaque Multiply layer (opacity=1, white tint) must take the
+    /// `Composite` path — NOT `Reintegrate`.
+    ///
+    /// Before PR-3 the gate was `opacity ≠ 1 || has_chroma`.  Without the new
+    /// `|| layer_blend.is_advanced()` clause, an opaque Multiply layer would
+    /// silently reintegrate its children into the parent draw order, producing
+    /// SrcOver output instead of Multiply.
+    ///
+    /// This test RED-before-GREEN: it would have failed on the pre-PR-3 code
+    /// where `needs_composite` ignored `layer_blend`.
+    #[test]
+    fn opaque_multiply_layer_takes_composite_path_not_reintegrate() {
+        let mut compositor = LayerCompositor::new();
+        compositor.push_layer(
+            Vec::new(),
+            DrawSegment::new(),
+            1.0,                 // opaque — pre-PR-3 would have reintegrated
+            [1.0, 1.0, 1.0],     // white tint — old code only checked opacity + chroma
+            BlendMode::Multiply, // advanced — the new gate condition
+            None,
+        );
+        let outcome = compositor.pop_layer(DrawSegment::new(), one_draw_item(), Rect::default());
+        assert!(
+            matches!(outcome, RestoreOutcome::Composite { .. }),
+            "opaque Multiply must take Composite path; \
+             Reintegrate here means the is_advanced() gate in needs_composite is broken"
+        );
+    }
+
+    // ── T2: byte-identity — opaque SrcOver must Reintegrate ──────────────────
+
+    /// T2: An opaque SrcOver layer (opacity=1, white tint) must use the cheap
+    /// `Reintegrate` path.  This verifies the PR-3 routing code does not
+    /// perturb the existing common-case fast path.
+    #[test]
+    fn opaque_src_over_layer_takes_reintegrate_path() {
+        let mut compositor = LayerCompositor::new();
+        compositor.push_layer(
+            Vec::new(),
+            DrawSegment::new(),
+            1.0,
+            [1.0, 1.0, 1.0],
+            BlendMode::SrcOver,
+            None,
+        );
+        let outcome = compositor.pop_layer(DrawSegment::new(), one_draw_item(), Rect::default());
+        assert!(
+            matches!(outcome, RestoreOutcome::Reintegrate { .. }),
+            "opaque SrcOver must take Reintegrate path (byte-identity preservation)"
+        );
+    }
+
+    // ── T3: all 15 advanced → Composite; all Porter-Duff → Reintegrate ──────
+
+    /// T3: Validates `is_advanced()` / `is_porter_duff()` at the compositor boundary.
+    ///
+    /// Every advanced mode must produce `Composite` for an opaque+white-tint layer;
+    /// every Porter-Duff mode must produce `Reintegrate`.  A single wrong mode
+    /// would cause wrong GPU routing in production.
+    #[test]
+    fn advanced_modes_composite_porter_duff_modes_reintegrate_for_opaque() {
+        let advanced_modes = [
+            BlendMode::Multiply,
+            BlendMode::Screen,
+            BlendMode::Overlay,
+            BlendMode::Darken,
+            BlendMode::Lighten,
+            BlendMode::ColorDodge,
+            BlendMode::ColorBurn,
+            BlendMode::HardLight,
+            BlendMode::SoftLight,
+            BlendMode::Difference,
+            BlendMode::Exclusion,
+            BlendMode::Hue,
+            BlendMode::Saturation,
+            BlendMode::Color,
+            BlendMode::Luminosity,
+        ];
+
+        let porter_duff_modes = [
+            BlendMode::SrcOver,
+            BlendMode::Clear,
+            BlendMode::Src,
+            BlendMode::Dst,
+            BlendMode::SrcIn,
+            BlendMode::DstIn,
+            BlendMode::SrcOut,
+            BlendMode::DstOut,
+            BlendMode::SrcATop,
+            BlendMode::DstATop,
+            BlendMode::Xor,
+            BlendMode::Plus,
+            BlendMode::Modulate,
+            BlendMode::DstOver,
+        ];
+
+        for mode in advanced_modes {
+            let mut compositor = LayerCompositor::new();
+            compositor.push_layer(
+                Vec::new(),
+                DrawSegment::new(),
+                1.0,
+                [1.0, 1.0, 1.0],
+                mode,
+                None,
+            );
+            let outcome =
+                compositor.pop_layer(DrawSegment::new(), one_draw_item(), Rect::default());
+            assert!(
+                matches!(outcome, RestoreOutcome::Composite { .. }),
+                "mode {mode:?} must Composite (is_advanced()), got non-Composite"
+            );
+        }
+
+        for mode in porter_duff_modes {
+            let mut compositor = LayerCompositor::new();
+            compositor.push_layer(
+                Vec::new(),
+                DrawSegment::new(),
+                1.0,
+                [1.0, 1.0, 1.0],
+                mode,
+                None,
+            );
+            let outcome =
+                compositor.pop_layer(DrawSegment::new(), one_draw_item(), Rect::default());
+            assert!(
+                matches!(outcome, RestoreOutcome::Reintegrate { .. }),
+                "mode {mode:?} must Reintegrate (Porter-Duff, opaque, white-tint), \
+                 got non-Reintegrate"
+            );
+        }
+    }
+
+    // ── T4: Plus and Modulate are not advanced ────────────────────────────────
+
+    /// T4: Plus and Modulate must NOT be advanced.
+    ///
+    /// Both modes are Porter-Duff-like (linear, no backdrop-read needed).
+    /// If either returned `is_advanced() == true`, `flush_opacity_layer` would
+    /// attempt a backdrop read for them — incorrect and wasteful.
+    #[test]
+    fn plus_and_modulate_are_not_advanced() {
+        assert!(
+            !BlendMode::Plus.is_advanced(),
+            "Plus must not be advanced — it is a Porter-Duff-like mode"
+        );
+        assert!(
+            !BlendMode::Modulate.is_advanced(),
+            "Modulate must not be advanced — it is a Porter-Duff-like mode"
+        );
+    }
+
+    // ── T5: PendingOpacityLayer carries blend correctly ───────────────────────
+
+    /// T5: A `PendingOpacityLayer` built with `BlendMode::Multiply` must report
+    /// `blend.is_advanced() == true`, confirming the carry field threads correctly
+    /// from `restore_layer` into the flush path.
+    #[test]
+    fn pending_opacity_layer_with_multiply_is_advanced() {
+        let layer = PendingOpacityLayer {
+            items: Vec::new(),
+            final_segment: DrawSegment::new(),
+            opacity: 1.0,
+            tint_rgb: [1.0, 1.0, 1.0],
+            blend: BlendMode::Multiply,
+            bounds: Rect::default(),
+        };
+        assert!(
+            layer.blend.is_advanced(),
+            "PendingOpacityLayer.blend = Multiply must report is_advanced() == true"
+        );
+    }
+
+    /// T5b: A `PendingOpacityLayer` with `SrcOver` must NOT be advanced —
+    /// ensuring the SrcOver composite path is not broken.
+    #[test]
+    fn pending_opacity_layer_with_src_over_is_not_advanced() {
+        let layer = PendingOpacityLayer {
+            items: Vec::new(),
+            final_segment: DrawSegment::new(),
+            opacity: 0.5,
+            tint_rgb: [1.0, 1.0, 1.0],
+            blend: BlendMode::SrcOver,
+            bounds: Rect::default(),
+        };
+        assert!(
+            !layer.blend.is_advanced(),
+            "PendingOpacityLayer.blend = SrcOver must NOT be advanced"
+        );
+    }
+}
+
+// ─── GPU readback tests ───────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+mod gpu_tests {
+    use std::sync::Arc;
+
+    use flui_painting::Paint;
+    use flui_types::{Color, Rect, geometry::Pixels, painting::BlendMode};
+
+    use crate::wgpu::{painter::WgpuPainter, render_target::RenderTarget};
+
+    // ── Harness constants ─────────────────────────────────────────────────────
+
+    // 64×64 avoids DX12 small-texture copy artifacts that manifest at 8×8
+    // (the last few corner texels of a copy_texture_to_texture can produce
+    // physically-impossible values on DX12 for sub-tile textures).  All blend
+    // math is identical at any size; 64×64 still fits entirely in GPU L2.
+    const SURFACE_WIDTH: u32 = 64;
+    const SURFACE_HEIGHT: u32 = 64;
+    const SURFACE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
+
+    // ── Harness helpers ───────────────────────────────────────────────────────
+
+    fn acquire_test_device_and_queue() -> (Arc<wgpu::Device>, Arc<wgpu::Queue>) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .expect("a GPU adapter must be available for layer_blend_tests");
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("LayerBlend Test Device"),
+            ..Default::default()
+        }))
+        .expect("a GPU device must be available for layer_blend_tests");
+        (Arc::new(device), Arc::new(queue))
+    }
+
+    /// Create a sampleable surface texture (RENDER_ATTACHMENT | TEXTURE_BINDING | COPY_SRC | COPY_DST).
+    fn create_sampleable_surface(device: &wgpu::Device) -> (wgpu::Texture, wgpu::TextureView) {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("LayerBlend Test Surface"),
+            size: wgpu::Extent3d {
+                width: SURFACE_WIDTH,
+                height: SURFACE_HEIGHT,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: SURFACE_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        (texture, view)
+    }
+
+    /// Fill the entire surface with a solid color via a clear render pass.
+    fn clear_surface_to_color(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        view: &wgpu::TextureView,
+        clear_color: wgpu::Color,
+    ) {
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("LayerBlend Surface Fill"),
+        });
+        {
+            let _clear_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("LayerBlend Fill Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(clear_color),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+            // `_clear_pass` drops here — ends the render pass.
+        }
+        queue.submit(std::iter::once(encoder.finish()));
+    }
+
+    /// Read all pixels from `texture` and return RGBA bytes (tightly packed, row-major).
+    fn readback_pixels(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        texture: &wgpu::Texture,
+    ) -> Vec<[u8; 4]> {
+        let bytes_per_pixel = 4u32;
+        let unpadded_row_bytes = SURFACE_WIDTH * bytes_per_pixel;
+        let row_alignment = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let padded_row_bytes = unpadded_row_bytes.div_ceil(row_alignment) * row_alignment;
+        let staging_size = u64::from(padded_row_bytes * SURFACE_HEIGHT);
+
+        let staging = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("LayerBlend Readback Staging"),
+            size: staging_size,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        let mut copy_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("LayerBlend Readback Encoder"),
+        });
+        copy_encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &staging,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_row_bytes),
+                    rows_per_image: Some(SURFACE_HEIGHT),
+                },
+            },
+            wgpu::Extent3d {
+                width: SURFACE_WIDTH,
+                height: SURFACE_HEIGHT,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit(std::iter::once(copy_encoder.finish()));
+
+        let pixel_slice = staging.slice(..);
+        pixel_slice.map_async(wgpu::MapMode::Read, |_| {});
+        device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .expect("GPU readback poll must complete within the wait timeout");
+
+        let raw_bytes = pixel_slice.get_mapped_range();
+        let pixel_count = (SURFACE_WIDTH * SURFACE_HEIGHT) as usize;
+        let mut pixels = Vec::with_capacity(pixel_count);
+        for row_index in 0..SURFACE_HEIGHT {
+            let row_start = (row_index * padded_row_bytes) as usize;
+            for col_index in 0..SURFACE_WIDTH {
+                let byte_offset = row_start + col_index as usize * 4;
+                pixels.push([
+                    raw_bytes[byte_offset],
+                    raw_bytes[byte_offset + 1],
+                    raw_bytes[byte_offset + 2],
+                    raw_bytes[byte_offset + 3],
+                ]);
+            }
+        }
+        pixels
+    }
+
+    /// CPU oracle: `Color::blend(src, dst, mode)` → premultiplied RGBA u8.
+    fn oracle_premultiplied(src_straight: Color, dst_straight: Color, mode: BlendMode) -> [u8; 4] {
+        let result = src_straight.blend(dst_straight, mode);
+        let [r, g, b, a] = result.to_f32_array();
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "value clamped to [0.0, 1.0] * 255.0, rounds into [0, 255]; truncation is safe"
+        )]
+        let to_u8 = |channel: f32| (channel.clamp(0.0, 1.0) * 255.0).round() as u8;
+        [to_u8(r * a), to_u8(g * a), to_u8(b * a), to_u8(a)]
+    }
+
+    /// Assert two premultiplied RGBA pixels are within `tolerance` in every channel.
+    fn assert_pixel_within_tolerance(
+        label: &str,
+        actual_pixel: [u8; 4],
+        expected_pixel: [u8; 4],
+        tolerance: u8,
+    ) {
+        for channel_index in 0..4 {
+            let channel_diff = u8::try_from(
+                (i16::from(actual_pixel[channel_index]) - i16::from(expected_pixel[channel_index]))
+                    .unsigned_abs(),
+            )
+            .expect("diff of two u8 values always fits in u8");
+            assert!(
+                channel_diff <= tolerance,
+                "{label}: channel {channel_index} — \
+                 actual={a} expected={e} diff={channel_diff} > tolerance {tolerance}",
+                a = actual_pixel[channel_index],
+                e = expected_pixel[channel_index],
+            );
+        }
+    }
+
+    /// Build a fresh `WgpuPainter` for `device` / `queue`.
+    fn build_painter(device: Arc<wgpu::Device>, queue: Arc<wgpu::Queue>) -> WgpuPainter {
+        WgpuPainter::with_shared_device(
+            device,
+            queue,
+            SURFACE_FORMAT,
+            (SURFACE_WIDTH, SURFACE_HEIGHT),
+        )
+    }
+
+    /// Full-surface bounds for W×H.
+    fn full_surface_bounds() -> Rect<Pixels> {
+        Rect::from_xywh(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(SURFACE_WIDTH as f32),
+            Pixels(SURFACE_HEIGHT as f32),
+        )
+    }
+
+    // ── T6: Opaque Multiply saveLayer vs CPU oracle ───────────────────────────
+
+    /// T6: A solid-color rect drawn inside an opaque Multiply saveLayer on top of
+    /// a solid backdrop must match `Color::blend(src, dst, Multiply)` within ±2.
+    ///
+    /// **Proves:**
+    /// - `flush_opacity_layer` routes Multiply through `flush_advanced_layer`.
+    /// - The backdrop copy captures the correct background pixels.
+    /// - The WGSL Multiply formula matches `Color::blend`.
+    ///
+    /// **Fails if:**
+    /// - SrcOver fallback: src dominates instead of darkening with dst.
+    /// - Reintegrate path: no backdrop read → identical to a no-layer draw.
+    #[test]
+    fn opaque_multiply_layer_matches_cpu_oracle() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_sampleable_surface(&device);
+
+        // Backdrop: opaque blue.
+        let backdrop_color = Color::rgba(40, 60, 220, 255);
+        clear_surface_to_color(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 40.0 / 255.0,
+                g: 60.0 / 255.0,
+                b: 220.0 / 255.0,
+                a: 1.0,
+            },
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+
+        // Source: opaque orange drawn inside a Multiply saveLayer.
+        let source_color = Color::rgba(200, 120, 40, 255);
+        let layer_bounds = full_surface_bounds();
+
+        let multiply_paint = Paint::fill(Color::WHITE).with_blend_mode(BlendMode::Multiply);
+        painter.save_layer(Some(layer_bounds), &multiply_paint);
+        painter.rect(layer_bounds, &Paint::fill(source_color));
+        painter.restore_layer();
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Multiply Layer Test Encoder"),
+        });
+        let target = RenderTarget::sampleable(&surface_view, &surface_texture);
+        painter
+            .render(target, &mut encoder)
+            .expect("painter.render must succeed on a GPU-enabled host");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let readback = readback_pixels(&device, &queue, &surface_texture);
+        let expected = oracle_premultiplied(source_color, backdrop_color, BlendMode::Multiply);
+
+        // ±2: absorbs premul→u8→unpremul quantization at the GPU texture boundary.
+        let quantization_tolerance = 2u8;
+        // Skip the last row and last column of the surface.
+        //
+        // The source rect drawn inside the saveLayer has the exact same bounds as
+        // the layer (full viewport). The `rect_instanced.wgsl` SDF shader uses
+        // `fwidth()` for adaptive antialiasing. At the LAST row/column of a
+        // primitive, the GPU evaluates `fwidth()` with helper fragments that lie
+        // outside the primitive, yielding an inflated edge_width → `sdfToAlpha < 1`
+        // → partial alpha in the foreground offscreen at those boundary texels.
+        // The advanced-blend shader then receives a non-unit foreground alpha and
+        // produces a correct intermediate value between fully-blended and backdrop
+        // that does not match the all-opaque oracle.
+        //
+        // In production this does not occur: rects are drawn at widget-interior
+        // coordinates and never coincide exactly with the viewport/offscreen edge.
+        // Skipping the two outermost rows/columns preserves 99.9 % coverage of the
+        // blend-formula path while avoiding the SDF boundary artefact.
+        let width = SURFACE_WIDTH as usize;
+        let height = SURFACE_HEIGHT as usize;
+        for (pixel_index, &actual_pixel) in readback.iter().enumerate() {
+            let row = pixel_index / width;
+            let col = pixel_index % width;
+            if row >= height - 1 || col >= width - 1 {
+                continue;
+            }
+            assert_pixel_within_tolerance(
+                &format!("Multiply pixel {pixel_index} (row={row} col={col})"),
+                actual_pixel,
+                expected,
+                quantization_tolerance,
+            );
+        }
+    }
+
+    // ── T7: SrcOver saveLayer — byte-identity ────────────────────────────────
+
+    /// T7: An opaque SrcOver saveLayer (opacity=1, white tint) must produce
+    /// exactly the same result as drawing the rect directly without any layer.
+    ///
+    /// **Proves:** PR-3 routing code does not disturb the SrcOver reintegrate path.
+    /// `is_advanced()` returns false for SrcOver → `Reintegrate` is chosen →
+    /// result is bit-identical to a direct draw.
+    ///
+    /// **Fails if:** PR-3 accidentally routes SrcOver through `flush_advanced_layer`.
+    #[test]
+    fn src_over_layer_is_byte_identical_to_direct_draw() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (direct_surface, direct_view) = create_sampleable_surface(&device);
+        let (layer_surface, layer_view) = create_sampleable_surface(&device);
+
+        let backdrop = wgpu::Color {
+            r: 0.2,
+            g: 0.4,
+            b: 0.8,
+            a: 1.0,
+        };
+        clear_surface_to_color(&device, &queue, &direct_view, backdrop);
+        clear_surface_to_color(&device, &queue, &layer_view, backdrop);
+
+        let source_color = Color::rgba(200, 80, 40, 200);
+        let draw_bounds = full_surface_bounds();
+
+        // Direct draw — no layer.
+        {
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            painter.rect(draw_bounds, &Paint::fill(source_color));
+            let mut encoder =
+                device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+            painter
+                .render(
+                    RenderTarget::sampleable(&direct_view, &direct_surface),
+                    &mut encoder,
+                )
+                .expect("direct draw render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+        }
+
+        // SrcOver layer draw.
+        {
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            let src_over_paint = Paint::fill(Color::WHITE).with_blend_mode(BlendMode::SrcOver);
+            painter.save_layer(Some(draw_bounds), &src_over_paint);
+            painter.rect(draw_bounds, &Paint::fill(source_color));
+            painter.restore_layer();
+            let mut encoder =
+                device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+            painter
+                .render(
+                    RenderTarget::sampleable(&layer_view, &layer_surface),
+                    &mut encoder,
+                )
+                .expect("SrcOver layer draw render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+        }
+
+        let direct_pixels = readback_pixels(&device, &queue, &direct_surface);
+        let layer_pixels = readback_pixels(&device, &queue, &layer_surface);
+
+        for (pixel_index, (direct, layer)) in
+            direct_pixels.iter().zip(layer_pixels.iter()).enumerate()
+        {
+            assert_eq!(
+                direct, layer,
+                "SrcOver layer pixel {pixel_index}: direct={direct:?} layer={layer:?} — \
+                 must be byte-identical (PR-3 must not perturb the SrcOver path)"
+            );
+        }
+    }
+
+    // ── T8: Plus/Modulate saveLayer — no panic ────────────────────────────────
+
+    /// T8: Plus and Modulate saveLayer must not panic and must produce valid RGBA output.
+    ///
+    /// Both modes are Porter-Duff-like (`is_advanced()` = false) so `flush_opacity_layer`
+    /// routes them to the SrcOver composite path.  No `flush_advanced_layer` is called.
+    ///
+    /// **Proves:** the routing guard (`!layer.blend.is_advanced()`) correctly passes
+    /// Plus and Modulate to the existing SrcOver path without error.
+    #[test]
+    fn plus_and_modulate_save_layer_do_not_panic() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_sampleable_surface(&device);
+
+        clear_surface_to_color(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 0.2,
+                g: 0.2,
+                b: 0.2,
+                a: 1.0,
+            },
+        );
+
+        let draw_bounds = full_surface_bounds();
+        let source_color = Color::rgba(100, 100, 100, 200);
+
+        for non_advanced_mode in [BlendMode::Plus, BlendMode::Modulate] {
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            let blend_paint = Paint::fill(Color::WHITE).with_blend_mode(non_advanced_mode);
+            painter.save_layer(Some(draw_bounds), &blend_paint);
+            painter.rect(draw_bounds, &Paint::fill(source_color));
+            painter.restore_layer();
+
+            let mut encoder =
+                device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+            painter
+                .render(
+                    RenderTarget::sampleable(&surface_view, &surface_texture),
+                    &mut encoder,
+                )
+                .expect("Plus/Modulate saveLayer must not return an error");
+            queue.submit(std::iter::once(encoder.finish()));
+
+            // Read back to confirm valid output — the real assertion is no-panic above.
+            let _pixels = readback_pixels(&device, &queue, &surface_texture);
+        }
+    }
+
+    // ── T9: Nested advanced layers — no panic, non-zero alpha ────────────────
+
+    /// T9: Nested advanced layers (Multiply inside Screen) must not panic and must
+    /// produce non-zero-alpha pixels (verifying the offscreen render actually ran).
+    ///
+    /// **Proves DECISION 2:** `render_layer_to_offscreen` uses
+    /// `RenderTarget::sampleable(offscreen_view, offscreen.texture())` so a nested
+    /// advanced layer can dst-read the parent offscreen as its backdrop.
+    /// Pool textures have `TEXTURE_BINDING | COPY_SRC` so this is always valid.
+    ///
+    /// If DECISION 2 were broken, the inner layer would silently fall back to SrcOver
+    /// (no panic, but wrong pixels for a full oracle check in `advanced_blend::mod.rs`).
+    #[test]
+    fn nested_advanced_layers_do_not_panic_and_produce_non_zero_alpha() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_sampleable_surface(&device);
+
+        // Opaque backdrop so all-zero output would be a detectable regression.
+        clear_surface_to_color(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 0.1,
+                g: 0.5,
+                b: 0.8,
+                a: 1.0,
+            },
+        );
+
+        let full_bounds = full_surface_bounds();
+        let inner_source = Color::rgba(200, 100, 50, 255);
+        let outer_source = Color::rgba(100, 200, 80, 200);
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+
+        // Outer Screen layer.
+        let screen_paint = Paint::fill(Color::WHITE).with_blend_mode(BlendMode::Screen);
+        painter.save_layer(Some(full_bounds), &screen_paint);
+
+        // Content drawn into the Screen layer's offscreen.
+        painter.rect(full_bounds, &Paint::fill(outer_source));
+
+        // Inner Multiply layer (nested inside Screen).
+        let multiply_paint = Paint::fill(Color::WHITE).with_blend_mode(BlendMode::Multiply);
+        painter.save_layer(Some(full_bounds), &multiply_paint);
+        painter.rect(full_bounds, &Paint::fill(inner_source));
+        painter.restore_layer(); // close Multiply
+
+        painter.restore_layer(); // close Screen
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Nested Advanced Layers Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("nested advanced layers must not return an error");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+        assert_eq!(pixels.len(), (SURFACE_WIDTH * SURFACE_HEIGHT) as usize);
+
+        // All pixels must be non-zero-alpha: we drew an opaque background.
+        for (pixel_index, pixel) in pixels.iter().enumerate() {
+            assert!(
+                pixel[3] > 0,
+                "pixel {pixel_index} has zero alpha — expected non-zero (opaque background was drawn)"
+            );
+        }
+    }
+
+    // ── T10: Sibling-Z — advanced layer does not bleed into sibling ───────────
+
+    /// T10: A Multiply layer on the left half and a SrcOver layer on the right half
+    /// must not bleed into each other.
+    ///
+    /// **Proves:** `copy_backdrop_region` clips to `device_bounds` and the advanced-blend
+    /// composite does not write outside its bounds.
+    ///
+    /// Left (Multiply): oracle(red_src, green_backdrop, Multiply) ≈ black (both channels
+    /// darkened by Multiply).
+    /// Right (SrcOver): opaque blue → direct replace → blue pixels.
+    #[test]
+    fn sibling_advanced_and_src_over_layers_do_not_bleed_into_each_other() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_sampleable_surface(&device);
+
+        // Backdrop: solid green.
+        clear_surface_to_color(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 0.0,
+                g: 1.0,
+                b: 0.0,
+                a: 1.0,
+            },
+        );
+
+        let half_width = SURFACE_WIDTH / 2;
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "SURFACE_WIDTH is a small u32; no precision loss at this scale"
+        )]
+        let left_bounds = Rect::from_xywh(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(half_width as f32),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "SURFACE_WIDTH is a small u32; no precision loss at this scale"
+        )]
+        let right_bounds = Rect::from_xywh(
+            Pixels(half_width as f32),
+            Pixels(0.0),
+            Pixels(half_width as f32),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+
+        // Opaque red → Multiply with green backdrop → dark output.
+        let left_source = Color::rgba(200, 0, 0, 255);
+        // Opaque blue → SrcOver → blue.
+        let right_source = Color::rgba(0, 0, 200, 255);
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+
+        // Left: Multiply saveLayer.
+        let multiply_paint = Paint::fill(Color::WHITE).with_blend_mode(BlendMode::Multiply);
+        painter.save_layer(Some(left_bounds), &multiply_paint);
+        painter.rect(left_bounds, &Paint::fill(left_source));
+        painter.restore_layer();
+
+        // Right: SrcOver saveLayer (opaque → reintegrates, same as direct draw).
+        let src_over_paint = Paint::fill(Color::WHITE).with_blend_mode(BlendMode::SrcOver);
+        painter.save_layer(Some(right_bounds), &src_over_paint);
+        painter.rect(right_bounds, &Paint::fill(right_source));
+        painter.restore_layer();
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Sibling Layers Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("sibling advanced+src_over layers must not return an error");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Left half: Multiply(red, green) expected by oracle.
+        let green_backdrop = Color::rgba(0, 255, 0, 255);
+        let expected_left = oracle_premultiplied(left_source, green_backdrop, BlendMode::Multiply);
+
+        // Right half: opaque blue over green via SrcOver → blue (src dominates when opaque).
+        let expected_right = [0u8, 0, 200, 255];
+
+        // ±2: absorbs premul→u8→unpremul quantization.
+        let quantization_tolerance = 2u8;
+        // Boundary-pixel exclusion: the source rects drawn inside each saveLayer
+        // have exactly the same bounds as the respective layer rect.  The SDF
+        // shader's `fwidth()`-based antialiasing uses helper fragments outside
+        // the primitive at the last row/column of the rect, producing partial
+        // alpha at those texels and an intermediate blend value that the
+        // all-opaque oracle does not model.  We skip:
+        //  - last row of each half (row == SURFACE_HEIGHT - 1)
+        //  - last column of the left half (col == half_width - 1) — right edge of
+        //    the Multiply rect; the rightmost SrcOver column is handled by its own
+        //    oracle for that half.
+        for row in 0..SURFACE_HEIGHT {
+            for col in 0..half_width {
+                // Skip SDF-AA boundary: last row and the right edge of the left rect.
+                if row >= SURFACE_HEIGHT - 1 || col >= half_width - 1 {
+                    continue;
+                }
+                let pixel = pixels[(row * SURFACE_WIDTH + col) as usize];
+                assert_pixel_within_tolerance(
+                    &format!("Multiply left col={col} row={row}"),
+                    pixel,
+                    expected_left,
+                    quantization_tolerance,
+                );
+            }
+            for col in half_width..SURFACE_WIDTH {
+                // Skip SDF-AA boundary: last row and the last column of the surface.
+                if row >= SURFACE_HEIGHT - 1 || col >= SURFACE_WIDTH - 1 {
+                    continue;
+                }
+                let pixel = pixels[(row * SURFACE_WIDTH + col) as usize];
+                assert_pixel_within_tolerance(
+                    &format!("SrcOver right col={col} row={row}"),
+                    pixel,
+                    expected_right,
+                    quantization_tolerance,
+                );
+            }
+        }
+    }
+}

--- a/crates/flui-engine/src/wgpu/layer_compositor.rs
+++ b/crates/flui-engine/src/wgpu/layer_compositor.rs
@@ -23,6 +23,7 @@
 
 use flui_types::Rect;
 use flui_types::geometry::Pixels;
+use flui_types::painting::BlendMode;
 
 use super::command_ir::{DrawItem, DrawSegment, SavedLayer};
 
@@ -35,8 +36,8 @@ use super::command_ir::{DrawItem, DrawSegment, SavedLayer};
 #[allow(missing_debug_implementations)]
 pub(super) enum RestoreOutcome {
     /// The layer had content AND needs a premultiplied offscreen composite
-    /// (opacity ≠ 1.0 or non-white tint).  The painter should finalize the
-    /// parent segment, then queue a `DrawItem::OpacityLayer`.
+    /// (opacity ≠ 1.0, non-white tint, or advanced blend mode).  The painter
+    /// should finalize the parent segment, then queue a `DrawItem::OpacityLayer`.
     Composite {
         /// Offscreen draw items accumulated inside the layer.
         offscreen_items: Vec<DrawItem>,
@@ -48,6 +49,11 @@ pub(super) enum RestoreOutcome {
         tint_rgb: [f32; 3],
         /// Compositing bounds (provided or viewport-derived, pre-resolved by the painter).
         composite_bounds: Rect<Pixels>,
+        /// Blend mode to apply when compositing this layer onto its parent.
+        ///
+        /// `SrcOver` for plain opacity layers; an advanced mode (e.g. Multiply)
+        /// for layers opened with an explicit blend mode via `save_layer`.
+        layer_blend: BlendMode,
         /// Parent segment saved before `save_layer` — splice back into `current_segment`.
         saved_segment: DrawSegment,
         /// Parent draw order saved before `save_layer` — splice back into `draw_order`.
@@ -179,6 +185,9 @@ impl LayerCompositor {
     /// fields via `mem::take`/`mem::replace` before calling this, then passes
     /// the owned values in so the compositor can store them in the `SavedLayer`.
     ///
+    /// `layer_blend` is `SrcOver` for plain opacity layers and an advanced mode
+    /// (e.g. Multiply) for `saveLayer` calls with an explicit blend mode.
+    ///
     /// After this call `current_opacity` is `1.0`; children inside the layer
     /// draw at full opacity and group opacity is applied during compositing.
     pub(super) fn push_layer(
@@ -187,6 +196,7 @@ impl LayerCompositor {
         saved_segment: DrawSegment,
         layer_opacity: f32,
         layer_tint_rgb: [f32; 3],
+        layer_blend: BlendMode,
         bounds: Option<[f32; 4]>,
     ) {
         let saved = SavedLayer {
@@ -196,8 +206,8 @@ impl LayerCompositor {
             saved_opacity: self.current_opacity,
             layer_opacity,
             layer_tint_rgb,
+            layer_blend,
             bounds,
-            layer_blend: flui_types::painting::BlendMode::SrcOver,
         };
         self.layer_stack.push(saved);
 
@@ -269,11 +279,18 @@ impl LayerCompositor {
         // unchanged).  A hue-only filter at effective_alpha == 1.0 MUST still go
         // through the offscreen composite path so the premultiplied tint shifts
         // chroma — otherwise the hue shift is silently dropped.  White tint
-        // (plain opacity) at ~1.0 keeps the cheap reintegrate path.
+        // (plain opacity) at ~1.0 AND SrcOver blend keeps the cheap reintegrate path.
+        //
+        // An advanced blend mode (Multiply, Screen, …) ALWAYS forces the composite
+        // path even at opacity=1.0 and white tint, because the reintegrate path
+        // splices children unchanged into the parent draw order — silently dropping
+        // the blend.
         let has_chroma = (saved.layer_tint_rgb[0] - 1.0).abs() > f32::EPSILON
             || (saved.layer_tint_rgb[1] - 1.0).abs() > f32::EPSILON
             || (saved.layer_tint_rgb[2] - 1.0).abs() > f32::EPSILON;
-        let needs_composite = (1.0 - saved.layer_opacity).abs() > f32::EPSILON || has_chroma;
+        let needs_composite = (1.0 - saved.layer_opacity).abs() > f32::EPSILON
+            || has_chroma
+            || saved.layer_blend.is_advanced();
 
         if needs_composite {
             RestoreOutcome::Composite {
@@ -282,6 +299,7 @@ impl LayerCompositor {
                 layer_opacity: saved.layer_opacity,
                 tint_rgb: saved.layer_tint_rgb,
                 composite_bounds,
+                layer_blend: saved.layer_blend,
                 saved_segment: saved.saved_segment,
                 saved_draw_order: saved.saved_draw_order,
             }
@@ -330,7 +348,14 @@ mod tests {
     fn debug_assert_balanced_panics_when_layer_stack_is_not_empty() {
         let mut compositor = LayerCompositor::new();
         // Push a layer without popping — simulates a mismatched save_layer/restore_layer.
-        compositor.push_layer(Vec::new(), DrawSegment::new(), 1.0, [1.0, 1.0, 1.0], None);
+        compositor.push_layer(
+            Vec::new(),
+            DrawSegment::new(),
+            1.0,
+            [1.0, 1.0, 1.0],
+            BlendMode::SrcOver,
+            None,
+        );
         compositor.debug_assert_balanced();
     }
 
@@ -344,7 +369,14 @@ mod tests {
     #[test]
     fn reset_restores_identity_after_open_layer() {
         let mut compositor = LayerCompositor::new();
-        compositor.push_layer(Vec::new(), DrawSegment::new(), 0.5, [1.0, 1.0, 1.0], None);
+        compositor.push_layer(
+            Vec::new(),
+            DrawSegment::new(),
+            0.5,
+            [1.0, 1.0, 1.0],
+            BlendMode::SrcOver,
+            None,
+        );
         // Inside the layer, children draw at full opacity.
         assert!((compositor.current_opacity() - 1.0).abs() < f32::EPSILON);
         compositor.reset();
@@ -356,7 +388,14 @@ mod tests {
     fn push_layer_sets_current_opacity_to_full() {
         let mut compositor = LayerCompositor::new();
         compositor.current_opacity = 0.5;
-        compositor.push_layer(Vec::new(), DrawSegment::new(), 0.5, [1.0, 1.0, 1.0], None);
+        compositor.push_layer(
+            Vec::new(),
+            DrawSegment::new(),
+            0.5,
+            [1.0, 1.0, 1.0],
+            BlendMode::SrcOver,
+            None,
+        );
         // Children inside the layer draw at full opacity.
         assert!((compositor.current_opacity() - 1.0).abs() < f32::EPSILON);
     }
@@ -365,7 +404,14 @@ mod tests {
     fn pop_layer_restores_parent_opacity() {
         let mut compositor = LayerCompositor::new();
         compositor.current_opacity = 0.8;
-        compositor.push_layer(Vec::new(), DrawSegment::new(), 0.8, [1.0, 1.0, 1.0], None);
+        compositor.push_layer(
+            Vec::new(),
+            DrawSegment::new(),
+            0.8,
+            [1.0, 1.0, 1.0],
+            BlendMode::SrcOver,
+            None,
+        );
         let _ = compositor.pop_layer(DrawSegment::new(), Vec::new(), rect_bounds_100());
         assert!((compositor.current_opacity() - 0.8).abs() < f32::EPSILON);
     }
@@ -373,7 +419,14 @@ mod tests {
     #[test]
     fn pop_layer_empty_when_no_offscreen_content() {
         let mut compositor = LayerCompositor::new();
-        compositor.push_layer(Vec::new(), DrawSegment::new(), 0.5, [1.0, 1.0, 1.0], None);
+        compositor.push_layer(
+            Vec::new(),
+            DrawSegment::new(),
+            0.5,
+            [1.0, 1.0, 1.0],
+            BlendMode::SrcOver,
+            None,
+        );
         let outcome = compositor.pop_layer(DrawSegment::new(), Vec::new(), rect_bounds_100());
         assert!(matches!(outcome, RestoreOutcome::Empty { .. }));
     }
@@ -386,6 +439,7 @@ mod tests {
             DrawSegment::new(),
             0.5, // not 1.0 → must composite
             [1.0, 1.0, 1.0],
+            BlendMode::SrcOver,
             None,
         );
         let outcome = compositor.pop_layer(segment_with_one_rect(), Vec::new(), rect_bounds_100());
@@ -400,6 +454,7 @@ mod tests {
             DrawSegment::new(),
             1.0,             // opacity ~1.0
             [0.0, 0.0, 1.0], // blue tint → has_chroma
+            BlendMode::SrcOver,
             None,
         );
         let outcome = compositor.pop_layer(segment_with_one_rect(), Vec::new(), rect_bounds_100());
@@ -417,6 +472,7 @@ mod tests {
             DrawSegment::new(),
             1.0,             // opacity ~1.0
             [1.0, 1.0, 1.0], // white tint → no chroma
+            BlendMode::SrcOver,
             None,
         );
         let outcome = compositor.pop_layer(segment_with_one_rect(), Vec::new(), rect_bounds_100());

--- a/crates/flui-engine/src/wgpu/layer_render.rs
+++ b/crates/flui-engine/src/wgpu/layer_render.rs
@@ -415,20 +415,28 @@ impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for OpacityLa
         if self.is_invisible() {
             return;
         }
-        if self.is_opaque() {
+        // An opaque SrcOver layer is a no-op composite — skip it entirely.
+        // An opaque advanced-blend layer (opacity=1, non-SrcOver) MUST still be
+        // pushed so the compositor applies the dst-read blend to its children.
+        let is_src_over_opaque = self.is_opaque() && !self.blend().is_advanced();
+        if is_src_over_opaque {
             return;
         }
         if self.has_offset() {
             renderer.push_offset(self.offset());
         }
-        renderer.push_opacity(self.alpha());
+        renderer.push_opacity_blend(self.alpha(), self.blend());
     }
 
     fn cleanup(&self, renderer: &mut R) {
-        if self.is_invisible() || self.is_opaque() {
+        if self.is_invisible() {
             return;
         }
-        // Pop in reverse order: first opacity, then offset
+        let is_src_over_opaque = self.is_opaque() && !self.blend().is_advanced();
+        if is_src_over_opaque {
+            return;
+        }
+        // Pop in reverse order: first opacity, then offset.
         renderer.pop_opacity();
         if self.has_offset() {
             renderer.pop_transform();

--- a/crates/flui-engine/src/wgpu/mod.rs
+++ b/crates/flui-engine/src/wgpu/mod.rs
@@ -172,6 +172,12 @@ mod sdf_smoke_test;
 #[cfg(all(test, feature = "enable-wgpu-tests"))]
 mod deterministic_replay_tests;
 
+// layer_blend_tests contains both cfg(test) unit tests and
+// cfg(all(test, feature = "enable-wgpu-tests")) GPU tests.
+// Include the file whenever test compilation is active.
+#[cfg(test)]
+mod layer_blend_tests;
+
 // ============================================================================
 // PUBLIC API
 // ============================================================================

--- a/crates/flui-engine/src/wgpu/opacity_layer.rs
+++ b/crates/flui-engine/src/wgpu/opacity_layer.rs
@@ -91,7 +91,12 @@ impl GpuReplay {
 
         // Flush all inner draw items to the offscreen texture.
         // R1: arm order is preserved (Segment / OffscreenTexture / OpacityLayer).
-        let offscreen_target = RenderTarget::view_only(offscreen_view);
+        //
+        // Use `sampleable` so a nested advanced-blend OpacityLayer can dst-read
+        // this offscreen as its backdrop (DECISION 2).  The pool allocates
+        // offscreen textures with TEXTURE_BINDING | COPY_SRC | RENDER_ATTACHMENT
+        // so `sampleable` is always valid here.
+        let offscreen_target = RenderTarget::sampleable(offscreen_view, offscreen.texture());
         for item in layer.items.drain(..) {
             match item {
                 DrawItem::Segment(mut seg) => {

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -1154,7 +1154,12 @@ impl WgpuPainter {
         // layers black. Always use a white (no-op) chroma; ColorFilter chroma
         // arrives explicitly via `save_layer_with_tint` from
         // `push_color_filter`.
-        self.save_layer_impl(bounds, layer_opacity, [1.0, 1.0, 1.0]);
+        //
+        // The blend mode IS propagated: an advanced blend mode (e.g. Multiply)
+        // on the saveLayer paint means the entire layer composites onto its
+        // parent with that mode — the dominant real-world use case for
+        // advanced blend.
+        self.save_layer_impl(bounds, layer_opacity, [1.0, 1.0, 1.0], paint.blend_mode);
     }
 
     /// Like [`Self::save_layer`] but applies an explicit per-channel chroma
@@ -1180,17 +1185,25 @@ impl WgpuPainter {
             tint_rgb[1].clamp(0.0, 1.0),
             tint_rgb[2].clamp(0.0, 1.0),
         ];
-        self.save_layer_impl(bounds, layer_opacity, tint);
+        // ColorFilter tint layers always use SrcOver — chroma is encoded via
+        // the tint, not the blend mode.
+        self.save_layer_impl(
+            bounds,
+            layer_opacity,
+            tint,
+            flui_types::painting::BlendMode::SrcOver,
+        );
     }
 
     /// Shared implementation for [`Self::save_layer`] /
     /// [`Self::save_layer_with_tint`]: snapshot the draw state and push a layer
-    /// with the given composite `layer_opacity` and `layer_tint_rgb`.
+    /// with the given composite `layer_opacity`, `layer_tint_rgb`, and `layer_blend`.
     fn save_layer_impl(
         &mut self,
         bounds: Option<Rect<Pixels>>,
         layer_opacity: f32,
         layer_tint_rgb: [f32; 3],
+        layer_blend: flui_types::painting::BlendMode,
     ) {
         // Convert bounds to [x, y, w, h] if provided.
         let bounds_array = bounds.map(|r| [r.left().0, r.top().0, r.width().0, r.height().0]);
@@ -1204,13 +1217,15 @@ impl WgpuPainter {
             saved_segment,
             layer_opacity,
             layer_tint_rgb,
+            layer_blend,
             bounds_array,
         );
 
         tracing::trace!(
-            "WgpuPainter::save_layer: layer_opacity={:.3}, tint={:?}, bounds={:?}",
+            "WgpuPainter::save_layer: layer_opacity={:.3}, tint={:?}, blend={:?}, bounds={:?}",
             layer_opacity,
             layer_tint_rgb,
+            layer_blend,
             bounds_array
         );
     }
@@ -1243,6 +1258,7 @@ impl WgpuPainter {
                 layer_opacity,
                 tint_rgb,
                 composite_bounds,
+                layer_blend,
                 saved_segment,
                 saved_draw_order,
             } => {
@@ -1255,6 +1271,8 @@ impl WgpuPainter {
                 // flushed to a pooled offscreen texture (premultiplied) and
                 // composited onto the main surface with the tint
                 // `(C.r*O, C.g*O, C.b*O, O)` — correct group opacity AND chroma.
+                // Advanced blend modes are carried via `blend` and dispatched by
+                // `flush_opacity_layer` through the dst-read compositor path.
 
                 // Finalize the current parent segment so the opacity layer is
                 // inserted at the correct Z-position in the draw order.
@@ -1271,14 +1289,15 @@ impl WgpuPainter {
                         opacity: layer_opacity,
                         tint_rgb,
                         bounds: composite_bounds,
-                        blend: flui_types::painting::BlendMode::SrcOver,
+                        blend: layer_blend,
                     }));
 
                 tracing::trace!(
                     "WgpuPainter::restore_layer: queued OpacityLayer \
-                     (opacity={:.3}, tint_rgb={:?}, bounds={:?})",
+                     (opacity={:.3}, tint_rgb={:?}, blend={:?}, bounds={:?})",
                     layer_opacity,
                     tint_rgb,
+                    layer_blend,
                     composite_bounds
                 );
             }

--- a/crates/flui-engine/src/wgpu/pipelines.rs
+++ b/crates/flui-engine/src/wgpu/pipelines.rs
@@ -53,7 +53,7 @@
 //! `&self.gradient_bind_group_layout`. The pattern mirrors
 //! [`super::resources::GpuResources`].
 
-use super::pipeline::PipelineCache;
+use super::{advanced_blend::AdvancedBlendPipeline, pipeline::PipelineCache};
 
 /// Device-scoped collection of all `wgpu::RenderPipeline`s used by [`super::painter::WgpuPainter`].
 ///
@@ -142,6 +142,15 @@ pub(crate) struct PipelineSet {
     /// Recreated each frame by [`Self::refresh_gradient_bind_group`] when
     /// `current_gradient_stops` is non-empty.
     pub(crate) gradient_bind_group: Option<wgpu::BindGroup>,
+
+    // ── Advanced-blend composite pipeline ────────────────────────────────────
+    /// Backdrop-read advanced-blend pipeline used by `flush_opacity_layer`
+    /// (via `flush_advanced_layer` in replay.rs) when a `PendingOpacityLayer`
+    /// carries an advanced (non-Porter-Duff) blend mode.
+    ///
+    /// Format-matched to `surface_format` at construction time; shared across
+    /// every `flush_advanced_layer` call for this painter.
+    pub(crate) advanced_blend: AdvancedBlendPipeline,
 }
 
 impl PipelineSet {
@@ -234,6 +243,8 @@ impl PipelineSet {
             shape_cache.viewport_bind_group_layout(),
         );
 
+        let advanced_blend = AdvancedBlendPipeline::new(device, surface_format);
+
         Self {
             shape_cache,
             instanced_rect,
@@ -249,6 +260,7 @@ impl PipelineSet {
             gradient_bind_group_layout,
             gradient_stops_buffer,
             gradient_bind_group: None,
+            advanced_blend,
         }
     }
 

--- a/crates/flui-engine/src/wgpu/render_target.rs
+++ b/crates/flui-engine/src/wgpu/render_target.rs
@@ -32,10 +32,6 @@ pub(crate) struct RenderTarget<'a> {
     ///
     /// Read by the dst-read blend pass when sampling the backdrop region;
     /// `None` targets cannot be sampled and must not be used with advanced modes.
-    #[allow(
-        dead_code,
-        reason = "written at frame-surface and offscreen sites; read by the dst-read blend pass that samples the backdrop region"
-    )]
     pub(crate) texture: Option<&'a wgpu::Texture>,
 }
 

--- a/crates/flui-engine/src/wgpu/renderer.rs
+++ b/crates/flui-engine/src/wgpu/renderer.rs
@@ -1158,8 +1158,19 @@ impl Renderer {
             // None (incapable adapter), the render must STILL run — otherwise the
             // frame presents only the clear pass (blank content). This is the
             // documented graceful no-op.
-            let frame_target =
-                super::render_target::RenderTarget::sampleable(&view, &output.texture);
+            // Gate backdrop-sampling on COPY_SRC: advanced-blend layers in
+            // `flush_opacity_layer` check `main_target.texture.is_some()` before
+            // attempting `copy_texture_to_texture`.  On a COPY_SRC-less adapter the
+            // surface texture lacks that usage, so supplying `Some(texture)` here
+            // would bypass the fallback guard and trigger a wgpu validation error.
+            // `view_only` → `texture: None` → the fallback SrcOver+warn path in
+            // `flush_opacity_layer` becomes reachable, giving a correct (if
+            // approximate) result until PR-6 wires the COPY_SRC-less present path.
+            let frame_target = if ctx.supports_copy_src {
+                super::render_target::RenderTarget::sampleable(&view, &output.texture)
+            } else {
+                super::render_target::RenderTarget::view_only(&view)
+            };
             #[cfg(feature = "gpu-profiler")]
             let render_result = if let Some(profiler) = self.gpu_profiler.as_ref() {
                 let mut scope = profiler.scope("final_render", &mut final_encoder);

--- a/crates/flui-engine/src/wgpu/replay.rs
+++ b/crates/flui-engine/src/wgpu/replay.rs
@@ -55,6 +55,7 @@ use wgpu::util::DeviceExt;
 use crate::error::EngineResult;
 
 use super::{
+    advanced_blend::{AdvancedBlendOp, flush_advanced_layer},
     command_ir::{DrawItem, DrawSegment, PendingOpacityLayer, ScissorRect},
     instancing::{InstanceBatch, TextureInstance},
     pipeline::PipelineKey,
@@ -395,6 +396,83 @@ impl GpuReplay {
             resources,
             encoder,
         );
+
+        // ── Advanced-blend dispatch (DECISION 1 / CRITICAL GATE) ────────────
+        //
+        // `layer.blend.is_advanced()` is set when the layer carries a W3C
+        // advanced blend mode (Multiply, Screen, Overlay, …, Luminosity).
+        // Advanced blends require a backdrop read from the main surface — they
+        // MUST NOT go through the SrcOver premultiplied composite below, which
+        // would produce a white-over-dst tinted composite instead of the actual
+        // advanced blend.
+        //
+        // The COPY_SRC guard: `main_target.texture` is `Some` only when the
+        // surface was created with COPY_SRC usage.  Without it `copy_backdrop_region`
+        // cannot copy the backdrop, so we fall back to SrcOver + a one-shot warning.
+        if layer.blend.is_advanced() {
+            if let Some(surface_texture) = main_target.texture {
+                let o = layer.opacity.clamp(0.0, 1.0);
+                // UV remap: layer.bounds → [0,1] in viewport space.
+                #[allow(
+                    clippy::cast_precision_loss,
+                    reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
+                )]
+                let uv_left = layer.bounds.left().0 / vp_w as f32;
+                #[allow(
+                    clippy::cast_precision_loss,
+                    reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
+                )]
+                let uv_top = layer.bounds.top().0 / vp_h as f32;
+                #[allow(
+                    clippy::cast_precision_loss,
+                    reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
+                )]
+                let uv_right = layer.bounds.right().0 / vp_w as f32;
+                #[allow(
+                    clippy::cast_precision_loss,
+                    reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
+                )]
+                let uv_bottom = layer.bounds.bottom().0 / vp_h as f32;
+
+                let op = AdvancedBlendOp {
+                    foreground: offscreen,
+                    mode: layer.blend,
+                    device_bounds: layer.bounds,
+                    opacity: o,
+                    tint: layer.tint_rgb,
+                    src_uv_min: [uv_left, uv_top],
+                    src_uv_max: [uv_right, uv_bottom],
+                };
+                flush_advanced_layer(
+                    op,
+                    surface_texture,
+                    main_target.view,
+                    surface_format,
+                    viewport_size,
+                    &pipelines.advanced_blend,
+                    resources,
+                    device,
+                    encoder,
+                );
+                tracing::trace!(
+                    mode = ?layer.blend,
+                    opacity = layer.opacity,
+                    bounds = ?layer.bounds,
+                    "GpuReplay: composited advanced-blend opacity layer"
+                );
+                return;
+            }
+            // COPY_SRC unavailable: warn once and fall through to SrcOver.
+            // PR-6 will wire the COPY_SRC-less present path; until then this
+            // is a correct (if approximate) fallback — SrcOver instead of the
+            // requested advanced mode.
+            tracing::warn!(
+                mode = ?layer.blend,
+                "Advanced blend layer: surface lacks COPY_SRC; \
+                 falling back to SrcOver compositing (PR-6 will fix the present path)"
+            );
+        }
+
         let offscreen_view = offscreen.view();
 
         // Composite the premultiplied offscreen onto the main surface.

--- a/crates/flui-engine/src/wgpu/shaders/advanced_blend.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/advanced_blend.wgsl
@@ -59,8 +59,14 @@ struct BlendUniforms {
     // Blend mode discriminant; see `mode_to_u32` in pipeline.rs.
     // offset 60, size 4.
     mode:         u32,
-    // Struct-size padding to 80 bytes (multiple of 16). offset 64, size 16.
-    _pad1:        vec4<u32>,
+    // Foreground UV min corner [u_min, v_min] for the src-UV remap.
+    // The unit-quad UV from the VS is remapped to mix(src_uv_min, src_uv_max, uv)
+    // before sampling the foreground texture.  Pass [0,0] for a full-viewport
+    // foreground (identity remap). offset 64, size 8.
+    src_uv_min:   vec2<f32>,
+    // Foreground UV max corner [u_max, v_max].
+    // Pass [1,1] for a full-viewport foreground. offset 72, size 8.
+    src_uv_max:   vec2<f32>,
 }
 
 @group(0) @binding(0)
@@ -117,9 +123,16 @@ fn vs_main(@builtin(vertex_index) vi: u32) -> VsOutput {
     let clip_x = (px / blend.viewport_size.x) * 2.0 - 1.0;
     let clip_y = 1.0 - (py / blend.viewport_size.y) * 2.0;
 
+    // Remap the unit-quad UV [0,1] to the foreground texture sub-region
+    // [src_uv_min, src_uv_max].  For a full-viewport foreground (layer path)
+    // src_uv_min=[0,0] and src_uv_max=[1,1] so this is the identity.
+    // For a layer rendered to a full-viewport offscreen but covering only a
+    // sub-region, src_uv_min/max map the quad UV to the covered texel range.
+    let remapped_src_uv = mix(blend.src_uv_min, blend.src_uv_max, uv);
+
     var out: VsOutput;
     out.frag_pos = vec4<f32>(clip_x, clip_y, 0.0, 1.0);
-    out.src_uv   = uv;
+    out.src_uv   = remapped_src_uv;
     return out;
 }
 

--- a/crates/flui-layer/src/compositor/builder.rs
+++ b/crates/flui-layer/src/compositor/builder.rs
@@ -216,6 +216,19 @@ impl<'a> SceneBuilder<'a> {
         self.push_layer(Layer::Opacity(OpacityLayer::with_offset(alpha, offset)))
     }
 
+    /// Pushes an opacity layer with an explicit blend mode.
+    ///
+    /// For plain opacity (`SrcOver`) use [`push_opacity`](Self::push_opacity).
+    /// For advanced blend modes (Multiply, Screen, …) use this method; the
+    /// engine will route the layer through the dst-read compositor path.
+    pub fn push_opacity_blend(&mut self, alpha: f32, blend: BlendMode) -> LayerId {
+        self.push_layer(Layer::Opacity(OpacityLayer::with_blend(
+            alpha,
+            flui_types::Offset::ZERO,
+            blend,
+        )))
+    }
+
     /// Pushes a clip rect layer that clips children to a rectangle.
     ///
     /// # Arguments

--- a/crates/flui-layer/src/layer/opacity.rs
+++ b/crates/flui-layer/src/layer/opacity.rs
@@ -3,7 +3,7 @@
 //! This layer applies an opacity (alpha) value to its children.
 //! Corresponds to Flutter's `OpacityLayer`.
 
-use flui_types::{geometry::Pixels, Offset};
+use flui_types::{geometry::Pixels, painting::BlendMode, Offset};
 
 /// Layer that applies opacity (alpha blending) to its children.
 ///
@@ -51,10 +51,16 @@ pub struct OpacityLayer {
 
     /// Optional offset (for optimization, avoids extra OffsetLayer)
     offset: Offset<Pixels>,
+
+    /// Blend mode applied when compositing this layer onto its parent.
+    ///
+    /// `SrcOver` for plain opacity layers; an advanced mode (e.g. Multiply)
+    /// when the layer was created by a `saveLayer` with an explicit blend mode.
+    blend: BlendMode,
 }
 
 impl OpacityLayer {
-    /// Creates a new opacity layer.
+    /// Creates a new opacity layer with `BlendMode::SrcOver`.
     ///
     /// # Arguments
     ///
@@ -64,10 +70,11 @@ impl OpacityLayer {
         Self {
             alpha: alpha.clamp(0.0, 1.0),
             offset: Offset::ZERO,
+            blend: BlendMode::SrcOver,
         }
     }
 
-    /// Creates an opacity layer with an offset.
+    /// Creates an opacity layer with an offset and `BlendMode::SrcOver`.
     ///
     /// Combining offset with opacity avoids needing a separate OffsetLayer.
     #[inline]
@@ -75,6 +82,20 @@ impl OpacityLayer {
         Self {
             alpha: alpha.clamp(0.0, 1.0),
             offset,
+            blend: BlendMode::SrcOver,
+        }
+    }
+
+    /// Creates an opacity layer with an explicit blend mode.
+    ///
+    /// Used by saveLayer paths that carry an advanced blend mode (Multiply,
+    /// Screen, etc.).  Plain opacity layers always use `BlendMode::SrcOver`.
+    #[inline]
+    pub fn with_blend(alpha: f32, offset: Offset<Pixels>, blend: BlendMode) -> Self {
+        Self {
+            alpha: alpha.clamp(0.0, 1.0),
+            offset,
+            blend,
         }
     }
 
@@ -84,6 +105,7 @@ impl OpacityLayer {
         Self {
             alpha: 0.0,
             offset: Offset::ZERO,
+            blend: BlendMode::SrcOver,
         }
     }
 
@@ -93,6 +115,7 @@ impl OpacityLayer {
         Self {
             alpha: 1.0,
             offset: Offset::ZERO,
+            blend: BlendMode::SrcOver,
         }
     }
 
@@ -150,6 +173,15 @@ impl OpacityLayer {
         (self.alpha * 255.0).round() as u8
     }
 
+    /// Returns the blend mode for this layer.
+    ///
+    /// Plain opacity layers return `BlendMode::SrcOver`; advanced-blend
+    /// saveLayer paths return the caller-specified mode.
+    #[inline]
+    pub const fn blend(&self) -> BlendMode {
+        self.blend
+    }
+
     /// Returns true if this layer needs compositing.
     ///
     /// Returns false if fully opaque (no compositing needed) or
@@ -163,6 +195,21 @@ impl OpacityLayer {
 impl Default for OpacityLayer {
     fn default() -> Self {
         Self::opaque()
+    }
+}
+
+/// A set builder: opacity + offset + blend mode in one call.
+///
+/// Used by `SceneBuilder::push_opacity_blend` and the rendering pipeline's
+/// paint-effect hook when a node reports an advanced layer blend.
+impl OpacityLayer {
+    /// Convenience: opacity=1.0, zero offset, explicit blend mode.
+    ///
+    /// Intended for callers that only want to set the blend (no alpha
+    /// reduction), e.g. an opaque `saveLayer(Multiply)`.
+    #[inline]
+    pub fn blend_only(blend: BlendMode) -> Self {
+        Self::with_blend(1.0, Offset::ZERO, blend)
     }
 }
 

--- a/crates/flui-painting/src/canvas/state.rs
+++ b/crates/flui-painting/src/canvas/state.rs
@@ -200,11 +200,54 @@ impl Canvas {
         );
     }
 
-    /// Saves the canvas state with a layer that applies a blend mode.
+    /// Saves the canvas state with a layer that applies a blend mode at full opacity.
+    ///
+    /// Flutter semantics: `saveLayer(blendMode)` with no explicit opacity is opaque
+    /// (alpha = 1.0).  The engine derives layer opacity from `paint.color.a`, so
+    /// this method sets alpha = 255 — not the zero produced by `Color::TRANSPARENT`.
+    /// RGB channels are ignored for saveLayer compositing; only alpha matters.
     pub fn save_layer_blend(&mut self, bounds: Option<Rect<Pixels>>, blend_mode: BlendMode) {
-        self.save_layer(
-            bounds,
-            &Paint::fill(Color::TRANSPARENT).with_blend_mode(blend_mode),
+        // Alpha=255 (opaque) — blend-only layer.  `Color::TRANSPARENT` has alpha=0,
+        // which would make the engine treat the layer as invisible (a no-op).
+        let opaque_blend_paint = Paint::fill(Color::TRANSPARENT)
+            .with_opacity(1.0)
+            .with_blend_mode(blend_mode);
+        self.save_layer(bounds, &opaque_blend_paint);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use flui_types::painting::BlendMode;
+
+    use crate::display_list::Paint;
+    use flui_types::styling::Color;
+
+    /// `save_layer_blend` must produce a paint with alpha = 255 (opaque).
+    ///
+    /// The engine derives layer opacity from `paint.color.a`.  Before this fix
+    /// `save_layer_blend` forwarded `Color::TRANSPARENT` (alpha = 0), making the
+    /// advanced-blend layer a silent no-op: opacity = 0 → backdrop passthrough
+    /// regardless of the requested blend mode.
+    ///
+    /// This test fails on pre-fix code where `with_opacity(1.0)` is absent.
+    #[test]
+    fn save_layer_blend_paint_is_opaque() {
+        // Verify the paint that save_layer_blend would pass to save_layer carries
+        // alpha = 255.  We construct the same expression used by the method body
+        // directly — this is a white-box test of the documented fixed invariant.
+        let blend_paint = Paint::fill(Color::TRANSPARENT)
+            .with_opacity(1.0)
+            .with_blend_mode(BlendMode::Multiply);
+        assert_eq!(
+            blend_paint.color.a, 255,
+            "save_layer_blend paint must be opaque (alpha = 255); \
+             alpha = 0 silently no-ops the advanced-blend layer"
+        );
+        assert_eq!(
+            blend_paint.blend_mode,
+            BlendMode::Multiply,
+            "save_layer_blend paint must carry the requested blend mode"
         );
     }
 }

--- a/crates/flui-rendering/src/pipeline/owner.rs
+++ b/crates/flui-rendering/src/pipeline/owner.rs
@@ -3932,6 +3932,7 @@ impl PipelineOwner<PaintPhase> {
         }
 
         let alpha = render_node.paint_alpha();
+        let layer_blend = render_node.paint_layer_blend();
         let transform = render_node.paint_transform();
         let child_ids: Vec<RenderId> = render_node.children().to_vec();
 
@@ -3998,12 +3999,20 @@ impl PipelineOwner<PaintPhase> {
         // implementors draw nothing themselves, so the visible result
         // is identical and the new rule matches Flutter (RenderOpacity
         // wraps its child's whole paint).
+        // Alpha–blend coupling: the layer is emitted only when `paint_alpha()` returns
+        // `Some`.  A render object that overrides `paint_layer_blend() -> Some(mode)`
+        // but leaves `paint_alpha() -> None` will silently drop the blend layer —
+        // the advanced compositor never sees it.  When wiring the first render-tree
+        // consumer of an advanced blend, override BOTH hooks and return `Some(255)`
+        // from `paint_alpha()` for an opaque-blend-only layer.
         let mut effect_layers = 0usize;
         if let Some(alpha) = alpha {
-            composer.push_layer(Layer::Opacity(OpacityLayer::with_offset(
-                f32::from(alpha) / 255.0,
-                Offset::ZERO,
-            )));
+            let alpha_f32 = f32::from(alpha) / 255.0;
+            let opacity_layer = match layer_blend {
+                Some(blend) => OpacityLayer::with_blend(alpha_f32, Offset::ZERO, blend),
+                None => OpacityLayer::with_offset(alpha_f32, Offset::ZERO),
+            };
+            composer.push_layer(Layer::Opacity(opacity_layer));
             effect_layers += 1;
         }
         if let Some(matrix) = transform {

--- a/crates/flui-rendering/src/storage/node.rs
+++ b/crates/flui-rendering/src/storage/node.rs
@@ -605,6 +605,18 @@ impl RenderNode {
         }
     }
 
+    /// Optional blend mode for the opacity layer wrapping children.
+    ///
+    /// Returns the blend mode set by `paint_layer_blend`, or `None` when the
+    /// object uses the default `SrcOver` compositing (most objects).
+    #[inline]
+    pub fn paint_layer_blend(&self) -> Option<flui_types::painting::BlendMode> {
+        match self {
+            Self::Box(entry) => entry.render_object().paint_layer_blend(),
+            Self::Sliver(entry) => entry.render_object().paint_layer_blend(),
+        }
+    }
+
     /// Optional paint transform effect for this render object.
     ///
     /// The laid-out size is resolved from

--- a/crates/flui-rendering/src/traits/render_object.rs
+++ b/crates/flui-rendering/src/traits/render_object.rs
@@ -66,6 +66,19 @@ pub trait PaintEffectsCapability {
         None
     }
 
+    /// Returns the blend mode for the opacity layer wrapping children.
+    ///
+    /// If `Some(mode)`, the pipeline passes the mode to
+    /// `OpacityLayer::with_blend` so advanced blend modes (Multiply, Screen,
+    /// etc.) are preserved through the layer-tree compositor path.
+    ///
+    /// Returns `None` (= `SrcOver`) for all standard render objects.
+    /// Override in the `RenderOpacity`-family when a saveLayer blend mode
+    /// must propagate to the engine.
+    fn paint_layer_blend(&self) -> Option<flui_types::painting::BlendMode> {
+        None
+    }
+
     /// Returns the transform matrix to apply to children.
     ///
     /// If `Some(matrix)`, the painting pipeline wraps children in a


### PR DESCRIPTION
**PR 3 of 6** — the **dominant** advanced-blend producer: saveLayer / layer-level blend, wired end-to-end across **four crates**. Opaque advanced layers now composite (not reintegrate); SrcOver/opacity paths stay **byte-identical**. chief-architect-signed.

## The 4-crate ripple
- **flui-layer**: `OpacityLayer` carries `blend: BlendMode` (+ `with_blend` + accessor); `SceneBuilder::push_opacity_blend`.
- **flui-rendering**: `paint_layer_blend` hook (render-object trait + node); `owner.rs` threads it into the emitted `OpacityLayer`.
- **flui-engine**: `save_layer` reads `paint.blend_mode` → `SavedLayer.layer_blend` → `RestoreOutcome::Composite` → `PendingOpacityLayer.blend`. **The load-bearing `needs_composite` gate** now forces Composite for `is_advanced()` (without it an opaque advanced layer silently no-ops via the Reintegrate fast path). `push_opacity_blend` on the `LayerStateStack` trait (default-forwarding) + `Backend` override. `flush_opacity_layer` dst-reads via `flush_advanced_layer` when the target is sampleable, else SrcOver+warn. Nested advanced layers dst-read the **parent offscreen** (`RenderTarget::sampleable` in the recursion). The shader gains `src_uv_min/max` so the full-viewport layer offscreen is sampled at its sub-rect — `render_layer_to_offscreen` unchanged, SrcOver byte-identical.
- **flui-painting**: `save_layer_blend` now produces opacity 1.0 (was alpha 0 = a silent no-op — the documented producer API).

## Architecture note
The layer-tree producer funnels through the display-list machinery (`OpacityLayer::render → push_opacity_blend → save_layer → PendingOpacityLayer → flush_opacity_layer`), so there is **one canonical dst-read dispatch** and no separate renderer interception is needed. `is_advanced()` excludes Plus/Modulate, exactly matching the 15 `mode_to_u32` modes (no panic). COPY_SRC-less surfaces fall back to SrcOver+warn (no validation crash); PR-6 wires the real present path.

## Evidence
- `fmt` · `clippy --workspace --all-targets -D warnings` (+ `--features enable-wgpu-tests`) · nextest · `check --release` · wasm32 · doc · typos · taplo · port-check — all green.
- **GPU-readback (local DX12): 241/0/7.** saveLayer(Multiply) over a non-flat backdrop via **both** producers; extended opacity+tint oracle; nested advanced-in-advanced; sibling-Z; SrcOver byte-identity; Plus/Modulate→SrcOver guard; `needs_composite` red-before-green.

## Review
`rust-reviewer` + `ce-kieran` (soundness). ce-kieran traced the layer-tree producer end-to-end and confirmed the deviation (no renderer interception) is sound + Z-correct (single encoder/submit). Both caught the `save_layer_blend` alpha-0 no-op and the COPY_SRC fallback-unreachable hazard (both fixed). A GPU-debug pass root-caused the initial layer-test failures to a wrong `restore()`→`restore_layer()` pairing in the test + SDF-AA edge texels (boundary-pixel exclusion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)