### PR TITLE
feat(engine): tessellated AA — rotated rect/rrect affine-SDF reroute + AA oracle (tessellated-AA PR-1)

### DIFF
--- a/.rust-studio/specs/tessellated-aa/SPEC.md
+++ b/.rust-studio/specs/tessellated-aa/SPEC.md
@@ -1,0 +1,120 @@
+# SPEC — Engine-wide anti-aliasing for tessellated geometry (flui-engine)
+
+Status: **APPROVED-PENDING** (design settled via design-panel + 2 adversarial reshapes + user scope decisions). Successor effort to Phase B (advanced dst-read blend, #251–257).
+
+## Problem
+
+SDF instanced primitives (axis-aligned rect/rrect/circle/arc, SrcOver) already AA in-shader
+via `fwidth`/`sdfToAlpha` (`shaders/common/sdf.wgsl:145`). Everything else routes to lyon
+tessellation and renders with **no AA at `sample_count: 1`** → aliased edges. This is a documented
+engine-wide "Phase-A quality limit" (`batches/shapes.rs:71,93,197,322`), not a Phase-B defect.
+
+The aliased-tessellated set: (a) rotated/skewed/transformed basic shapes (rect/rrect/circle/ellipse),
+(b) non-SrcOver basic shapes (Porter-Duff + advanced blend), (c) arbitrary paths / polygons / béziers /
+complex strokes.
+
+## Rejected approaches (with reasons — do not revisit without new facts)
+
+- **Surface MSAA** — regresses the just-shipped Phase B (single-sample surface backdrop-copy in
+  `advanced_blend/mod.rs`, single-sample pooled offscreen in `opacity_layer.rs`, REPLACE composite);
+  4× memory/bandwidth; redundant for SDF primitives that already AA via `fwidth`.
+- **Analytic feather-strip for fills** — lyon_tessellation 1.0.20 `FillVertex` has **no `normal()`**
+  (only `position()/sources()/as_endpoint_id()/interpolated_attributes()`), so the fringe would be a
+  contour stroke = premul double-blend; plus concave/self-intersect over-coverage. Wrong tool.
+- **Stencil-then-cover** — solves *GPU* winding resolution for raw paths; flui already CPU-triangulates
+  via lyon `FillTessellator` (watertight, winding-correct NonZero/EvenOdd, non-overlapping). The stencil
+  pass re-solves an already-solved problem; its own AA still came from an isolated MSAA offscreen. Both
+  adversarial reviewers independently converged on "supersample the existing triangulation instead".
+  Greenfield depth-stencil + pool rewrite for no benefit in a CPU-tessellation architecture.
+
+## Chosen architecture (two halves)
+
+### Half 1 — SDF-affine reroute (transformed basic shapes, SrcOver)
+
+Currently the instanced fast path is gated on `is_axis_aligned() && blend==SrcOver`
+(`batches/shapes.rs:75`) because the instance `transform` is `[scale_x, scale_y, tx, ty]` —
+scale+translate only, **no rotation/skew** (`rect_instanced.wgsl:26`). Extend the instance to a full
+2×3 affine; the vertex shader applies it; the fragment evaluates the SDF in **local space** via the
+inverse transform. `fwidth` stays correct (it measures screen-space derivative of the transformed
+distance → ~1-device-px AA even under skew/anisotropy). Reuse existing `sdRoundedBox`,
+`sdRoundedSuperellipse`, `sdEllipse`, `sdOrientedBox`. Reroute rotated/skewed SrcOver
+rect/rrect/circle/ellipse/arc from tessellation → instanced affine-SDF. **Exact analytic AA, cheap,
+covers the dominant real-world case (transformed cards/buttons), zero Phase-B coupling.**
+
+### Half 2 — SSAA offscreen tile (arbitrary paths + non-SrcOver basic shapes)
+
+For geometry with no closed-form SDF (custom paths, polygons, béziers, strokes) and for non-SrcOver
+basic shapes: render lyon's **existing** triangulation into an **isolated NxN supersampled** pooled
+offscreen (just a larger `{w,h}` texture — the pool already keys on `{w,h,format}`; **no multisampled
+texture, no stencil, no pool rewrite**), box-filter downsample (reuse the PR-6 `blit.wgsl` infra into a
+downsample variant), producing a resolved **premultiplied color tile**. Composite that tile via the
+**existing** `DrawItem::OffscreenTexture` (SrcOver/Porter-Duff) or `DrawItem::AdvancedShape`
+(advanced dst-read) seam at the correct Z. **Supersampling is unconditionally correct on all
+topologies** (convex/concave/self-intersecting/holes). Surface stays `sample_count: 1` → Phase-B-safe.
+
+## Routing decision tree (no producer left permanently aliased)
+
+| shape × transform × blend | route |
+|---|---|
+| basic shape, axis-aligned, SrcOver | existing instanced SDF (unchanged, byte-identical) |
+| basic shape, rotated/skewed, SrcOver | **NEW** instanced affine-SDF (half 1) |
+| basic shape, any transform, non-SrcOver (Porter-Duff/advanced) | **NEW** SSAA tile (half 2) → OffscreenTexture/AdvancedShape |
+| arbitrary path/polygon/stroke, SrcOver | **NEW** SSAA tile (half 2) → OffscreenTexture |
+| arbitrary path/polygon/stroke, non-SrcOver | **NEW** SSAA tile (half 2) → OffscreenTexture(blend)/AdvancedShape |
+
+Document any genuine exception (e.g. `Plus`/`Modulate`) explicitly; never silent.
+
+## The AA oracle (gating blocker — define BEFORE relying on it)
+
+A green render test that only checks "AA present" is vacuous (Phase-B lesson:
+adversarial-soundness-catches-vacuous-gates). Define two real oracles in PR-1 and **calibrate them
+against the existing SDF primitives** (which are known-correct AA) before using them to gate new code:
+
+1. **CPU analytic area-coverage** — for a known edge (45° line, circle arc) compute exact fractional
+   pixel coverage; assert rendered alpha within tolerance.
+2. **Tessellated-vs-SDF edge-consistency** — render the same circle/rect via the SDF path AND via the
+   new path; assert boundary pixels match within tolerance. This *is* the literal goal.
+
+Plus: interior byte-identity, monotonic coverage ramp across the boundary band, topology correctness
+(pentagram NonZero=solid vs EvenOdd=hole, both AA'd), anti-MVP "all tessellated producers emit ≥1
+partial-alpha boundary pixel".
+
+## PR sequence (each independently `just ci`-green; axis-aligned SrcOver byte-identical throughout)
+
+1. **PR-1** — AA oracle harness + calibration vs existing SDF; **instanced rect/rrect → full affine +
+   local-space SDF**; reroute rotated/skewed SrcOver rect/rrect. GPU-readback gated by oracle.
+2. **PR-2** — **instanced circle/ellipse/arc → affine**; reroute rotated SrcOver circle/ellipse/arc.
+3. **PR-3** — **SSAA infra** (pool NxN request + downsample blit + render-tess-to-SSAA-tile → premul
+   tile → `DrawItem::OffscreenTexture`); route SrcOver arbitrary paths/polygons. Edge-consistency +
+   pentagram NonZero/EvenOdd topology gates.
+4. **PR-4** — route **non-SrcOver basic shapes + Porter-Duff/advanced arbitrary paths** through the
+   SSAA tile (compose via OffscreenTexture blend / AdvancedShape). Anti-MVP all-producers guard;
+   document exceptions.
+5. **PR-5 (conditional)** — batching multiple paths into shared tiles; thin-shape (<1px) handling —
+   only if readback/profiling shows need.
+
+## Maintainer conditions (all must hold to claim done)
+
+1. Surface stays `sample_count: 1`; **no `resolve_target: Some` on the surface, no `DepthStencilState`
+   anywhere** (SSAA uses normal larger textures, not MSAA/stencil). CI grep guard.
+2. Existing axis-aligned SrcOver byte-identical (instanced path unchanged for that case; local GPU golden).
+3. AA oracle defined + calibrated against existing SDF in PR-1 before gating any new behavior.
+4. Tessellated-vs-SDF edge-consistency passes (rotated rect ~ axis rect; circle-via-path ~ circle-via-SDF).
+5. Topology: pentagram NonZero (solid) vs EvenOdd (hole) both correctly AA'd.
+6. No real producer permanently aliased (anti-MVP test); explicit documented exceptions only.
+7. Phase B untouched except additively (`advanced_blend/`, `opacity_layer.rs` core, `replay.rs`); Phase
+   B GPU-readback suite stays green.
+8. `fwidth` correctness under non-uniform scale verified (coverage-ramp at 1× and 8×).
+9. Every touched non-test file < 1500 LOC; split modules as needed (tessellator.rs already ~1520 incl tests).
+
+## Test / verification
+
+GPU-readback local DX12 only (`--features enable-wgpu-tests -- --test-threads 1`), not CI — naming the
+GPU, red→green (assertions fail without the change). `just ci` green per PR. Phase B suite green.
+Optional `examples/` AA demo (rotated shapes + a star path) for visual confirmation beyond unit pixels.
+
+## Review discipline (per PR)
+
+`rust-builder` (test-first) → `rust-reviewer` + **`ce-kieran`** (soundness, mandatory on this core) →
+**I run the GPU-readback serial on DX12 myself** (the only pixel gate; not in CI). Capture the durable
+decision to the Obsidian vault via `/remember` after the architecture lands.

--- a/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
+++ b/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
@@ -1,0 +1,1197 @@
+//! AA oracle harness: calibrated analytic-coverage reference + GPU acceptance
+//! gates for the affine-SDF instanced rect/rrect path.
+//!
+//! ## Design
+//!
+//! The oracle computes fractional pixel coverage by supersampling an analytic
+//! inside-test at 8×8 sub-pixel positions (`ORACLE_GRID = 8`). This gives a
+//! CPU reference accurate to within 1/(8×8) = ~1.6% of a pixel.
+//!
+//! The oracle is **calibrated against the existing axis-aligned SDF rrect**
+//! (which is known-correct AA) before being used to gate the new affine path.
+//!
+//! ## Test inventory
+//!
+//! | # | Description |
+//! |---|-------------|
+//! | O1 | Calibration — axis-aligned SDF rrect boundary matches oracle within tolerance |
+//! | O2 | Oracle has teeth — hard-aliased alpha map does NOT pass the same tolerance |
+//! | O3 | Rotated rect AA — boundary band monotonic and matches oracle (fails before reroute) |
+//! | O4 | Rotated rrect — correct size/orientation + AA (fixes AABB bug) |
+//! | O5 | Byte-identity — axis-aligned SrcOver rect and rrect readback identical after change |
+//! | O6 | fwidth scale-invariance — AA band stays ~1 device-px at 1× and 8× world scale |
+//! | O7 | Corner-radius mapping — only the top-left corner rounds when only `tl` is set |
+
+// ── CPU oracle (no GPU needed) ────────────────────────────────────────────────
+
+/// Number of sub-samples per pixel axis for the analytic-coverage oracle.
+const ORACLE_GRID: usize = 8;
+
+/// Analytic inside-test for an axis-aligned rect centered at origin with
+/// half-extents `(half_w, half_h)`.
+fn inside_rect(px: f32, py: f32, half_w: f32, half_h: f32) -> bool {
+    px.abs() <= half_w && py.abs() <= half_h
+}
+
+/// Analytic inside-test for a rounded rect centered at origin.
+/// Mirrors `sdRoundedBox` from `rect_instanced.wgsl`: negative SDF = inside.
+fn inside_rounded_rect(px: f32, py: f32, half_w: f32, half_h: f32, r: [f32; 4]) -> bool {
+    // Per-corner radius selection — mirrors the WGSL branchless `select` in
+    // `sdRoundedBox`. r = [tl, tr, br, bl]. (top, bottom) radii for the active
+    // horizontal side: right (px>0) → (tr=r[1], br=r[2]); left → (tl=r[0], bl=r[3]).
+    let r2 = if px > 0.0 { [r[1], r[2]] } else { [r[0], r[3]] };
+    let r3 = if py > 0.0 { r2[1] } else { r2[0] };
+
+    let qx = px.abs() - half_w + r3;
+    let qy = py.abs() - half_h + r3;
+
+    let dist = (qx.max(0.0).powi(2) + qy.max(0.0).powi(2)).sqrt() + qx.max(qy).min(0.0) - r3;
+    dist <= 0.0
+}
+
+/// Analytic inside-test for a rotated rect.
+///
+/// `angle_rad` rotates the shape CW (screen coordinates, Y-down). The test
+/// maps the query point into the shape's local frame and delegates to
+/// `inside_rect`.
+fn inside_rotated_rect(px: f32, py: f32, half_w: f32, half_h: f32, angle_rad: f32) -> bool {
+    // Inverse rotation: rotate the query point by -angle into local frame.
+    let cos_a = angle_rad.cos();
+    let sin_a = angle_rad.sin();
+    let local_x = cos_a * px + sin_a * py;
+    let local_y = -sin_a * px + cos_a * py;
+    inside_rect(local_x, local_y, half_w, half_h)
+}
+
+/// Analytic inside-test for a rotated rounded rect.
+///
+/// Only used in GPU readback tests gated on `enable-wgpu-tests`.
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+fn inside_rotated_rounded_rect(
+    px: f32,
+    py: f32,
+    half_w: f32,
+    half_h: f32,
+    r: [f32; 4],
+    angle_rad: f32,
+) -> bool {
+    let cos_a = angle_rad.cos();
+    let sin_a = angle_rad.sin();
+    let local_x = cos_a * px + sin_a * py;
+    let local_y = -sin_a * px + cos_a * py;
+    inside_rounded_rect(local_x, local_y, half_w, half_h, r)
+}
+
+/// Compute analytic fractional pixel coverage for a shape at pixel center
+/// `(pixel_x, pixel_y)`, by supersampling at `ORACLE_GRID × ORACLE_GRID`
+/// sub-positions within the pixel.
+///
+/// `inside_fn` returns `true` when the sample point is inside the shape.
+fn analytic_coverage(pixel_x: f32, pixel_y: f32, inside_fn: impl Fn(f32, f32) -> bool) -> f32 {
+    let n = ORACLE_GRID as f32;
+    let mut inside_count = 0u32;
+    for row in 0..ORACLE_GRID {
+        for col in 0..ORACLE_GRID {
+            // Sub-pixel offset within [-0.5, 0.5] × [-0.5, 0.5].
+            let dx = (col as f32 + 0.5) / n - 0.5;
+            let dy = (row as f32 + 0.5) / n - 0.5;
+            if inside_fn(pixel_x + dx, pixel_y + dy) {
+                inside_count += 1;
+            }
+        }
+    }
+    inside_count as f32 / (n * n)
+}
+
+// ── CPU-only (no GPU) oracle tests ────────────────────────────────────────────
+
+#[cfg(test)]
+mod oracle_unit_tests {
+    use super::*;
+
+    /// Oracle self-check: a pixel fully inside a rect must have coverage 1.0.
+    #[test]
+    fn oracle_interior_coverage_is_one() {
+        let coverage = analytic_coverage(0.0, 0.0, |px, py| inside_rect(px, py, 50.0, 25.0));
+        // All 8×8 sub-samples land inside the shape → sum/64 is exactly 1.0 (no float rounding).
+        #[allow(
+            clippy::float_cmp,
+            reason = "analytic oracle: all sub-samples inside → coverage is exactly 1.0"
+        )]
+        {
+            assert_eq!(coverage, 1.0, "interior pixel must have full coverage");
+        }
+    }
+
+    /// Oracle self-check: a pixel fully outside a rect must have coverage 0.0.
+    #[test]
+    fn oracle_exterior_coverage_is_zero() {
+        let coverage = analytic_coverage(60.0, 0.0, |px, py| inside_rect(px, py, 50.0, 25.0));
+        // All 8×8 sub-samples land outside the shape → sum/64 is exactly 0.0.
+        #[allow(
+            clippy::float_cmp,
+            reason = "analytic oracle: all sub-samples outside → coverage is exactly 0.0"
+        )]
+        {
+            assert_eq!(coverage, 0.0, "exterior pixel must have zero coverage");
+        }
+    }
+
+    /// Oracle self-check: a pixel on the 45° boundary of a rect has partial
+    /// coverage strictly between 0 and 1.
+    #[test]
+    fn oracle_boundary_coverage_is_partial() {
+        // Edge pixel at the right boundary of a 100×50 rect.
+        // Center at x=50 puts exactly half the pixel inside (for an infinitely
+        // thin edge), so ORACLE_GRID sub-samples give ≈0.5 coverage.
+        let coverage = analytic_coverage(50.0, 0.0, |px, py| inside_rect(px, py, 50.0, 25.0));
+        assert!(
+            coverage > 0.0 && coverage < 1.0,
+            "boundary pixel must have partial coverage; got {coverage}"
+        );
+    }
+
+    /// Oracle self-check: corner coverage of a rounded rect is strictly less
+    /// than 1.0 (the corner arc cuts into the pixel).
+    #[test]
+    fn oracle_rrect_corner_coverage_less_than_rect() {
+        let half_w = 50.0_f32;
+        let half_h = 25.0_f32;
+        let r = [10.0_f32; 4];
+        // Sample at the corner itself — rrect removes the sharp corner, so
+        // coverage should be lower than for a plain rect.
+        let sharp_corner_coverage =
+            analytic_coverage(half_w, half_h, |px, py| inside_rect(px, py, half_w, half_h));
+        let rounded_corner_coverage = analytic_coverage(half_w, half_h, |px, py| {
+            inside_rounded_rect(px, py, half_w, half_h, r)
+        });
+        assert!(
+            rounded_corner_coverage < sharp_corner_coverage,
+            "rounded rect corner coverage ({rounded_corner_coverage}) must be < \
+             rect coverage ({sharp_corner_coverage})"
+        );
+    }
+
+    /// Oracle has teeth: verifies that a synthetic hard-aliased alpha map (all
+    /// boundary pixels are either 0 or 1) does NOT pass a tolerance test
+    /// against the analytic oracle at a boundary pixel.
+    ///
+    /// This proves the calibration tolerance would catch hard-aliased output —
+    /// i.e., the oracle is non-vacuous.
+    #[test]
+    fn oracle_hard_aliased_map_fails_tolerance() {
+        // Oracle says this boundary pixel has partial coverage ≈ 0.5.
+        let oracle_coverage =
+            analytic_coverage(50.0, 0.0, |px, py| inside_rect(px, py, 50.0, 25.0));
+
+        // Hard-aliased value: pixel is either fully inside (1.0) or outside (0.0).
+        // At x=50 the pixel center is exactly on the edge → hard-aliased = 1 or 0.
+        // Either way it differs from oracle by ~0.5 * 255 ≈ 127.5 in alpha units.
+        let hard_aliased_alpha_high: f32 = 1.0; // pixel fully inside
+        let hard_aliased_alpha_low: f32 = 0.0; // pixel fully outside
+
+        // Tolerance used by the calibration test (O1): 30/255 ≈ 0.118.
+        let tolerance_f32 = 30.0_f32 / 255.0;
+
+        let diff_high = (hard_aliased_alpha_high - oracle_coverage).abs();
+        let diff_low = (hard_aliased_alpha_low - oracle_coverage).abs();
+
+        assert!(
+            diff_high > tolerance_f32,
+            "hard-aliased high alpha should FAIL the oracle tolerance; diff={diff_high:.3} tolerance={tolerance_f32:.3}"
+        );
+        assert!(
+            diff_low > tolerance_f32,
+            "hard-aliased low alpha should FAIL the oracle tolerance; diff={diff_low:.3} tolerance={tolerance_f32:.3}"
+        );
+    }
+
+    /// CPU coverage ramp for a 30° rotated rect is monotonically decreasing as
+    /// we step outward across the boundary (inside → outside).
+    ///
+    /// Tests the oracle's rotated-rect computation without any GPU involvement.
+    #[test]
+    fn oracle_rotated_rect_coverage_ramp_is_monotone() {
+        use std::f32::consts::PI;
+        let angle = PI / 6.0; // 30°
+        let half_w = 40.0_f32;
+        let half_h = 20.0_f32;
+
+        // Sample perpendicular to the right edge, stepping outward.
+        // The edge normal for a 30° rotated rect points in the direction
+        // (cos30, sin30). Step along that direction across the boundary.
+        let cos_a = angle.cos();
+        let sin_a = angle.sin();
+
+        // Step from 1px inside the edge to 1px outside.
+        let samples: Vec<f32> = (-4..=4)
+            .map(|step_i| {
+                let step = step_i as f32 * 0.4; // 0.4px per step
+                let cx = half_w * cos_a + step * cos_a;
+                let cy = half_w * sin_a + step * sin_a;
+                analytic_coverage(cx, cy, |px, py| {
+                    inside_rotated_rect(px, py, half_w, half_h, angle)
+                })
+            })
+            .collect();
+
+        // Verify the ramp crosses from ~1.0 to ~0.0 monotonically.
+        let mut any_decrease_seen = false;
+        for window in samples.windows(2) {
+            let prev = window[0];
+            let next = window[1];
+            if next < prev {
+                any_decrease_seen = true;
+            }
+            // Allow small non-monotone jitter from grid quantization (≤1 sample step).
+            let tolerance = 1.0 / (ORACLE_GRID * ORACLE_GRID) as f32;
+            assert!(
+                next <= prev + tolerance,
+                "coverage ramp must be non-increasing across boundary; \
+                 got {next:.3} after {prev:.3}"
+            );
+        }
+        assert!(
+            any_decrease_seen,
+            "coverage ramp must actually decrease somewhere — oracle may be broken"
+        );
+        // First sample (inside) must have high coverage; last (outside) low.
+        assert!(
+            *samples.first().unwrap() > 0.8,
+            "inside sample must have high coverage; got {}",
+            samples.first().unwrap()
+        );
+        assert!(
+            *samples.last().unwrap() < 0.2,
+            "outside sample must have low coverage; got {}",
+            samples.last().unwrap()
+        );
+    }
+}
+
+// ── GPU readback tests ─────────────────────────────────────────────────────────
+
+// All intentional: pixel-coordinate and alpha-value casts (f32 → u8 / usize)
+// are clamped or derived from fixed [0,1] oracle values; sign loss is impossible
+// (oracle returns non-negative; pixel coords are positive screen positions).
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "oracle alpha: f32 in [0,1]×255 → [0,255] fits u8; pixel coords are non-negative \
+              device-px — both casts are analytically safe"
+)]
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+mod gpu_tests {
+    use std::f32::consts::PI;
+    use std::sync::Arc;
+
+    use flui_painting::Paint;
+    use flui_types::{
+        Color, Rect,
+        geometry::{Pixels, RRect},
+    };
+
+    use crate::wgpu::{painter::WgpuPainter, render_target::RenderTarget};
+
+    use super::{
+        analytic_coverage, inside_rotated_rect, inside_rotated_rounded_rect, inside_rounded_rect,
+    };
+
+    // ── Harness constants ─────────────────────────────────────────────────────
+
+    // 128×128: large enough that a rotated rect boundary has many pixels to
+    // sample and small enough for fast DX12 readback. Matches the ≥64px
+    // minimum to avoid DX12 small-texture copy artifacts.
+    const SURFACE_WIDTH: u32 = 128;
+    const SURFACE_HEIGHT: u32 = 128;
+    const SURFACE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
+
+    // Calibrated tolerance: 30/255 ≈ 11.8% of the [0,255] alpha range.
+    //
+    // This tolerance is designed to:
+    // - PASS: fwidth-based SDF AA (actual vs oracle within ~10% due to the
+    //   smoothstep width equalling 1×fwidth ≈ 1 device-px, which rounds
+    //   slightly differently from 8×8 grid supersampling).
+    // - FAIL: hard-aliased edges (alpha ∈ {0, 255}; boundary oracle ≈ 128 →
+    //   diff ≈ 128 >> 30). The unit test O2 / `oracle_has_teeth` confirms this.
+    const CALIBRATION_TOLERANCE_U8: u8 = 30;
+
+    // ── Harness helpers ───────────────────────────────────────────────────────
+
+    fn acquire_test_device_and_queue() -> (Arc<wgpu::Device>, Arc<wgpu::Queue>) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .expect("a GPU adapter must be available for aa_oracle_tests");
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("AA Oracle Test Device"),
+            ..Default::default()
+        }))
+        .expect("a GPU device must be available for aa_oracle_tests");
+        (Arc::new(device), Arc::new(queue))
+    }
+
+    fn create_render_surface(device: &wgpu::Device) -> (wgpu::Texture, wgpu::TextureView) {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("AA Oracle Test Surface"),
+            size: wgpu::Extent3d {
+                width: SURFACE_WIDTH,
+                height: SURFACE_HEIGHT,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: SURFACE_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        (texture, view)
+    }
+
+    fn clear_surface(device: &wgpu::Device, queue: &wgpu::Queue, view: &wgpu::TextureView) {
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("AA Oracle Clear"),
+        });
+        {
+            let _pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("AA Oracle Clear Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+        }
+        queue.submit(std::iter::once(encoder.finish()));
+    }
+
+    /// Read all pixels from a texture and return RGBA bytes (row-major).
+    fn readback_pixels(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        texture: &wgpu::Texture,
+    ) -> Vec<[u8; 4]> {
+        let bytes_per_pixel = 4u32;
+        let unpadded_bytes_per_row = SURFACE_WIDTH * bytes_per_pixel;
+        let row_alignment = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let padded_bytes_per_row = unpadded_bytes_per_row.div_ceil(row_alignment) * row_alignment;
+        let staging_size = u64::from(padded_bytes_per_row * SURFACE_HEIGHT);
+
+        let staging = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("AA Oracle Readback Staging"),
+            size: staging_size,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("AA Oracle Readback Encoder"),
+        });
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &staging,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_bytes_per_row),
+                    rows_per_image: Some(SURFACE_HEIGHT),
+                },
+            },
+            wgpu::Extent3d {
+                width: SURFACE_WIDTH,
+                height: SURFACE_HEIGHT,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit(std::iter::once(encoder.finish()));
+
+        staging.slice(..).map_async(wgpu::MapMode::Read, |_| {});
+        device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .expect("GPU readback poll must complete");
+
+        let raw = staging.slice(..).get_mapped_range();
+        let mut pixels = Vec::with_capacity((SURFACE_WIDTH * SURFACE_HEIGHT) as usize);
+        for row in 0..SURFACE_HEIGHT {
+            let row_start = (row * padded_bytes_per_row) as usize;
+            for col in 0..SURFACE_WIDTH {
+                let byte_offset = row_start + col as usize * 4;
+                pixels.push([
+                    raw[byte_offset],
+                    raw[byte_offset + 1],
+                    raw[byte_offset + 2],
+                    raw[byte_offset + 3],
+                ]);
+            }
+        }
+        pixels
+    }
+
+    fn build_painter(device: Arc<wgpu::Device>, queue: Arc<wgpu::Queue>) -> WgpuPainter {
+        WgpuPainter::with_shared_device(
+            device,
+            queue,
+            SURFACE_FORMAT,
+            (SURFACE_WIDTH, SURFACE_HEIGHT),
+        )
+    }
+
+    /// Identify the boundary band of pixels: those that have partial coverage
+    /// according to the analytic oracle (0 < coverage < 1).
+    fn boundary_pixel_indices(inside_fn: impl Fn(f32, f32) -> bool) -> Vec<(usize, f32)> {
+        let mut boundary = Vec::new();
+        for row in 0..SURFACE_HEIGHT {
+            for col in 0..SURFACE_WIDTH {
+                // Pixel center in device coordinates.
+                let cx = col as f32 + 0.5;
+                let cy = row as f32 + 0.5;
+                let coverage = analytic_coverage(cx, cy, &inside_fn);
+                if coverage > 0.0 && coverage < 1.0 {
+                    let idx = row as usize * SURFACE_WIDTH as usize + col as usize;
+                    boundary.push((idx, coverage));
+                }
+            }
+        }
+        boundary
+    }
+
+    // ── O1: Calibration — existing SDF rrect matches oracle ──────────────────
+
+    /// O1: The existing axis-aligned SDF rrect (known-correct AA) must match
+    /// the analytic-coverage oracle within `CALIBRATION_TOLERANCE_U8` on every
+    /// boundary pixel.
+    ///
+    /// Calibrates the oracle against the known-correct baseline before using
+    /// it to gate the new affine path.
+    ///
+    /// Fails if the oracle itself is wrong, or if the existing SDF AA path
+    /// regresses (correctness guard for the pre-existing baseline).
+    #[test]
+    fn o1_calibration_axis_aligned_sdf_rrect_matches_oracle() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        // Draw a 60×40 opaque white rrect centered in the surface, with 8px radii.
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+        let half_w = 30.0_f32;
+        let half_h = 20.0_f32;
+        let radius = 8.0_f32;
+
+        let rrect = RRect::from_rect_circular(
+            Rect::from_ltrb(
+                Pixels(cx - half_w),
+                Pixels(cy - half_h),
+                Pixels(cx + half_w),
+                Pixels(cy + half_h),
+            ),
+            Pixels(radius),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.rrect(rrect, &Paint::fill(Color::WHITE));
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("O1 Calibration Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Find boundary pixels according to the oracle.
+        let radii_arr = [radius; 4];
+        let boundary = boundary_pixel_indices(|px, py| {
+            inside_rounded_rect(px - cx, py - cy, half_w, half_h, radii_arr)
+        });
+
+        assert!(
+            !boundary.is_empty(),
+            "O1: no boundary pixels found — oracle or shape parameters may be wrong"
+        );
+
+        let mut failed_count = 0usize;
+        for (pixel_idx, oracle_coverage) in &boundary {
+            let readback_alpha = pixels[*pixel_idx][3];
+            let oracle_alpha = (oracle_coverage * 255.0).round() as u8;
+            let diff = (i16::from(readback_alpha) - i16::from(oracle_alpha)).unsigned_abs();
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "diff of two u8-range values fits in u8"
+            )]
+            let diff_u8 = diff as u8;
+            if diff_u8 > CALIBRATION_TOLERANCE_U8 {
+                failed_count += 1;
+            }
+        }
+
+        // Allow up to 5% of boundary pixels to exceed tolerance (subpixel
+        // differences between fwidth-smoothstep and grid supersampling can
+        // diverge slightly at very thin corners).
+        let boundary_count = boundary.len();
+        let max_failures = (boundary_count as f32 * 0.05).ceil() as usize;
+        assert!(
+            failed_count <= max_failures,
+            "O1 calibration failed: {failed_count}/{boundary_count} boundary pixels exceed \
+             tolerance {CALIBRATION_TOLERANCE_U8}; max allowed = {max_failures}. \
+             Either the oracle or the existing SDF path has regressed."
+        );
+    }
+
+    // ── O2: Oracle has teeth (control test) ──────────────────────────────────
+
+    /// O2: A synthetic hard-aliased alpha map (boundary pixels = 0 or 255)
+    /// must NOT pass the calibration tolerance.
+    ///
+    /// Proves the oracle is non-vacuous: the tolerance chosen in O1 would catch
+    /// un-antialiased (hard-aliased) edges, not just accept anything.
+    ///
+    /// This is a CPU-only test — no GPU required.
+    #[test]
+    fn o2_oracle_hard_aliased_fails_calibration_tolerance() {
+        // Build a synthetic hard-aliased alpha map for an axis-aligned rect.
+        // Any pixel whose center is inside = 255, outside = 0.
+        let cx = 64.0_f32;
+        let cy = 64.0_f32;
+        let half_w = 30.0_f32;
+        let half_h = 20.0_f32;
+        let radii = [8.0_f32; 4];
+
+        let boundary = boundary_pixel_indices(|px, py| {
+            inside_rounded_rect(px - cx, py - cy, half_w, half_h, radii)
+        });
+
+        assert!(
+            !boundary.is_empty(),
+            "O2: no boundary pixels found — oracle shape parameters may be wrong"
+        );
+
+        // Synthetic hard-aliased: alpha = 255 if inside at pixel center, else 0.
+        let mut exceeded_count = 0usize;
+        for (pixel_idx, oracle_coverage) in &boundary {
+            let col = pixel_idx % SURFACE_WIDTH as usize;
+            let row = pixel_idx / SURFACE_WIDTH as usize;
+            let center_x = col as f32 + 0.5;
+            let center_y = row as f32 + 0.5;
+            let hard_aliased_alpha =
+                if inside_rounded_rect(center_x - cx, center_y - cy, half_w, half_h, radii) {
+                    255u8
+                } else {
+                    0u8
+                };
+            let oracle_alpha = (oracle_coverage * 255.0).round() as u8;
+            let diff = (i16::from(hard_aliased_alpha) - i16::from(oracle_alpha)).unsigned_abs();
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "diff of two u8-range values fits in u8"
+            )]
+            let diff_u8 = diff as u8;
+            if diff_u8 > CALIBRATION_TOLERANCE_U8 {
+                exceeded_count += 1;
+            }
+        }
+
+        // A hard-aliased edge should fail for the MAJORITY of boundary pixels.
+        let boundary_count = boundary.len();
+        let min_failures = (boundary_count as f32 * 0.5).ceil() as usize;
+        assert!(
+            exceeded_count >= min_failures,
+            "O2 teeth check FAILED: only {exceeded_count}/{boundary_count} pixels exceeded the \
+             tolerance — the oracle may be too lenient to catch hard-aliased edges"
+        );
+    }
+
+    // ── O3: Rotated rect AA (red→green gate) ─────────────────────────────────
+
+    /// O3: A 30° rotated SrcOver rect rendered via the new affine instanced path
+    /// must have boundary pixels with monotonic coverage and alpha within the
+    /// calibration tolerance of the analytic oracle.
+    ///
+    /// Before the reroute: the rotated rect fell through to tessellation →
+    /// hard-aliased edges → this test would fail at the oracle-match assertion
+    /// (the monotone check alone might pass since tessellated edges are binary).
+    ///
+    /// After the reroute: the affine SDF path produces smooth AA → passes.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index/coordinate arithmetic over a small fixed-size test surface"
+    )]
+    fn o3_rotated_rect_boundary_matches_oracle() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        let angle = PI / 6.0; // 30°
+        let half_w = 35.0_f32;
+        let half_h = 18.0_f32;
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+
+        // The rect in local space (centered at origin). The painter will rotate
+        // it by applying a rotation transform before drawing.
+        let local_rect = Rect::from_ltrb(
+            Pixels(-half_w),
+            Pixels(-half_h),
+            Pixels(half_w),
+            Pixels(half_h),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        // Translate to center, then rotate.
+        painter.translate(flui_types::Offset::new(Pixels(cx), Pixels(cy)));
+        painter.rotate(angle);
+        painter.rect(local_rect, &Paint::fill(Color::WHITE));
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("O3 Rotated Rect Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Oracle uses the same angle and half-extents, centered at (cx, cy).
+        let boundary = boundary_pixel_indices(|px, py| {
+            inside_rotated_rect(px - cx, py - cy, half_w, half_h, angle)
+        });
+
+        assert!(
+            boundary.len() >= 8,
+            "O3: fewer than 8 boundary pixels found ({}) — shape may be off-screen or oracle broken",
+            boundary.len()
+        );
+
+        // SDF rendering rounds sharp convex corners over the ~1px AA band: the
+        // distance field beyond a convex vertex is radial, so `sdBox` (radius 0)
+        // produces a rounded falloff at each corner. This is inherent to the
+        // SDF/fwidth AA model and is the SAME behavior as the existing
+        // axis-aligned SDF rect primitives. The 8×8 box-supersample oracle models
+        // a mathematically-sharp corner, so the two LEGITIMATELY diverge within
+        // ~AA-width of each corner vertex. We therefore validate EDGE AA against
+        // the oracle (the actual quality claim) and SEPARATELY assert the corners
+        // are anti-aliased (rounded), not hard-aliased — never silently skipped.
+        let (sin, cos) = angle.sin_cos();
+        let corners_dev: [(f32, f32); 4] = [
+            (-half_w, -half_h),
+            (half_w, -half_h),
+            (half_w, half_h),
+            (-half_w, half_h),
+        ]
+        .map(|(lx, ly)| (cx + lx * cos - ly * sin, cy + lx * sin + ly * cos));
+        // ~AA band (≈1px) + sub-pixel corner rounding, with margin.
+        let corner_radius_sq = 3.0_f32 * 3.0;
+        let near_corner = |px: f32, py: f32| {
+            corners_dev.iter().any(|(qx, qy)| {
+                let dx = px - qx;
+                let dy = py - qy;
+                dx * dx + dy * dy <= corner_radius_sq
+            })
+        };
+
+        let mut edge_failed = 0usize;
+        let mut edge_total = 0usize;
+        let mut corner_total = 0usize;
+        let mut corner_partial = 0usize; // corner pixels that are AA'd (partial alpha)
+        for (pixel_idx, oracle_coverage) in &boundary {
+            let col = (*pixel_idx % SURFACE_WIDTH as usize) as f32 + 0.5;
+            let row = (*pixel_idx / SURFACE_WIDTH as usize) as f32 + 0.5;
+            let readback_alpha = pixels[*pixel_idx][3];
+            if near_corner(col, row) {
+                corner_total += 1;
+                if readback_alpha > 0 && readback_alpha < 255 {
+                    corner_partial += 1;
+                }
+                continue;
+            }
+            edge_total += 1;
+            let oracle_alpha = (oracle_coverage * 255.0).round() as u8;
+            let diff = (i16::from(readback_alpha) - i16::from(oracle_alpha)).unsigned_abs() as u8;
+            if diff > CALIBRATION_TOLERANCE_U8 {
+                edge_failed += 1;
+            }
+        }
+
+        // Guard against the corner exclusion swallowing the boundary: corner-band
+        // pixels must remain a minority. If this trips, the exclusion radius is
+        // masking a real edge problem.
+        assert!(
+            corner_total * 2 < boundary.len(),
+            "O3: corner-band exclusion too large ({corner_total}/{} boundary) — \
+             would mask edge AA defects",
+            boundary.len()
+        );
+
+        let max_edge_failures = (edge_total as f32 * 0.05).ceil() as usize;
+        assert!(
+            edge_failed <= max_edge_failures,
+            "O3 FAILED: {edge_failed}/{edge_total} rotated-rect EDGE boundary pixels exceed \
+             oracle tolerance {CALIBRATION_TOLERANCE_U8} (corner-band excluded: {corner_total}). \
+             Edge AA does not match analytic coverage — affine reroute or fwidth AA is wrong."
+        );
+
+        // Corners must be SDF-rounded (anti-aliased), not hard-aliased: most
+        // corner-band pixels carry partial alpha. A hard-aliased renderer would
+        // have them all at 0/255.
+        assert!(
+            corner_total == 0 || corner_partial * 2 >= corner_total,
+            "O3 FAILED: only {corner_partial}/{corner_total} corner-band pixels are \
+             anti-aliased (partial alpha) — corners look hard-aliased, not SDF-rounded."
+        );
+
+        // Also assert that interior pixels are fully opaque.
+        // Sample a point 10px inside the rotated rect.
+        let interior_col = (cx + 0.0).round() as usize;
+        let interior_row = (cy + 0.0).round() as usize;
+        let interior_idx = interior_row * SURFACE_WIDTH as usize + interior_col;
+        assert!(
+            pixels[interior_idx][3] > 200,
+            "O3: interior pixel must be nearly opaque; got alpha={}",
+            pixels[interior_idx][3]
+        );
+    }
+
+    // ── O4: Rotated rrect — correct size + orientation + AA ──────────────────
+
+    /// O4: A 45° rotated SrcOver rrect must:
+    /// 1. Cover the correct device-space footprint (fixes the pre-existing AABB bug).
+    /// 2. Have boundary-band alpha matching the analytic oracle within tolerance.
+    ///
+    /// Pre-existing bug: a rotated SrcOver rrect was baked via 2-corner AABB
+    /// (`apply_transform(top_left)` + `apply_transform(bottom_right)`) without
+    /// checking `is_axis_aligned()` — producing an axis-aligned AABB with wrong
+    /// size and position. The affine instanced path fixes this by passing local
+    /// bounds + the full 2×3 affine to the GPU.
+    #[test]
+    fn o4_rotated_rrect_correct_size_orientation_and_aa() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        let angle = PI / 4.0; // 45°
+        let half_w = 30.0_f32;
+        let half_h = 15.0_f32;
+        let radius = 6.0_f32;
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+
+        let local_rrect = RRect::from_rect_circular(
+            Rect::from_ltrb(
+                Pixels(-half_w),
+                Pixels(-half_h),
+                Pixels(half_w),
+                Pixels(half_h),
+            ),
+            Pixels(radius),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.translate(flui_types::Offset::new(Pixels(cx), Pixels(cy)));
+        painter.rotate(angle);
+        painter.rrect(local_rrect, &Paint::fill(Color::WHITE));
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("O4 Rotated RRect Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        let radii_arr = [radius; 4];
+        let boundary = boundary_pixel_indices(|px, py| {
+            inside_rotated_rounded_rect(px - cx, py - cy, half_w, half_h, radii_arr, angle)
+        });
+
+        assert!(
+            boundary.len() >= 8,
+            "O4: fewer than 8 boundary pixels found ({}) — shape may be off-screen or oracle broken",
+            boundary.len()
+        );
+
+        // Assert AA: boundary pixels must match oracle.
+        let mut failed_count = 0usize;
+        for (pixel_idx, oracle_coverage) in &boundary {
+            let readback_alpha = pixels[*pixel_idx][3];
+            let oracle_alpha = (oracle_coverage * 255.0).round() as u8;
+            let diff = (i16::from(readback_alpha) - i16::from(oracle_alpha)).unsigned_abs();
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "diff of two u8-range values fits in u8"
+            )]
+            let diff_u8 = diff as u8;
+            if diff_u8 > CALIBRATION_TOLERANCE_U8 {
+                failed_count += 1;
+            }
+        }
+        let boundary_count = boundary.len();
+        let max_failures = (boundary_count as f32 * 0.05).ceil() as usize;
+        assert!(
+            failed_count <= max_failures,
+            "O4 FAILED: {failed_count}/{boundary_count} rotated-rrect boundary pixels exceed \
+             oracle tolerance {CALIBRATION_TOLERANCE_U8}"
+        );
+
+        // Assert size/orientation: a point that the AABB bug would have
+        // covered (but the rotated rrect does NOT cover) must be transparent.
+        // For a 45°-rotated 60×30 rect, the corners of the rect in device
+        // space are at ≈(±half_h*√2, 0) along the Y axis. A point well
+        // outside the rotated shape (in a corner of the AABB) must be blank.
+        // The AABB of the rotated rect is roughly [cx±half_w*√2, cy±half_w*√2]
+        // ≈ [cx±42, cy±42]. The corner at device (cx + half_w * 0.95, cy + 0.0)
+        // is inside the bounding box but outside the rotated shape.
+        let aabb_corner_col = (cx + half_w * 0.95).round() as usize;
+        let aabb_corner_row = cy.round() as usize;
+        if aabb_corner_col < SURFACE_WIDTH as usize && aabb_corner_row < SURFACE_HEIGHT as usize {
+            let aabb_idx = aabb_corner_row * SURFACE_WIDTH as usize + aabb_corner_col;
+            // For a 45° rotated rect the AABB corner contains only a corner sliver.
+            // Oracle says: is this point inside the rotated rrect?
+            let oracle_inside = inside_rotated_rounded_rect(
+                aabb_corner_col as f32 + 0.5 - cx,
+                aabb_corner_row as f32 + 0.5 - cy,
+                half_w,
+                half_h,
+                radii_arr,
+                angle,
+            );
+            if !oracle_inside {
+                assert!(
+                    pixels[aabb_idx][3] < CALIBRATION_TOLERANCE_U8,
+                    "O4: AABB-bug regression — pixel at ({aabb_corner_col}, {aabb_corner_row}) \
+                     should be outside the rotated rrect (oracle says so) but got alpha={}; \
+                     the pre-existing AABB bake bug may have returned",
+                    pixels[aabb_idx][3]
+                );
+            }
+        }
+    }
+
+    // ── O5: Byte-identity — axis-aligned SrcOver rect and rrect ──────────────
+
+    /// O5: The axis-aligned SrcOver path is byte-identical to its pre-affine
+    /// behavior.
+    ///
+    /// The ONLY change affecting the axis-aligned (baked-AABB) path is the ~1.5px
+    /// quad-fringe expansion in the vertex shader (the L1 `fwidth` AA norm is
+    /// unchanged). Its fringe fragments have SDF `dist > edge_width` → alpha 0, so
+    /// they contribute nothing. This test gates that property **directly**: every
+    /// pixel whose center is ≥1px outside the geometric shape must be the cleared
+    /// transparent value, proving the expansion leaked no output. It also gates
+    /// run-to-run determinism (two independent painters → identical pixels). Full
+    /// byte-identity vs `origin/main` is further corroborated by the unchanged
+    /// 294-test GPU suite, which asserts exact axis-aligned pixel values.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "pixel index → f32 device coordinate over a 128×128 test surface"
+    )]
+    fn o5_axis_aligned_src_over_rect_and_rrect_byte_identical() {
+        let (device, queue) = acquire_test_device_and_queue();
+
+        // ── Rect (sharp-cornered) ──
+        let (surface_a, view_a) = create_render_surface(&device);
+        let (surface_b, view_b) = create_render_surface(&device);
+        clear_surface(&device, &queue, &view_a);
+        clear_surface(&device, &queue, &view_b);
+
+        let flat_rect = Rect::from_ltrb(Pixels(20.0), Pixels(15.0), Pixels(108.0), Pixels(113.0));
+        let color = Color::rgba(180, 80, 40, 200);
+
+        for (surface, view) in [(&surface_a, &view_a), (&surface_b, &view_b)] {
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            painter.rect(flat_rect, &Paint::fill(color));
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("O5 Rect Identity Encoder"),
+            });
+            painter
+                .render(RenderTarget::sampleable(view, surface), &mut encoder)
+                .expect("render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+        }
+
+        let pixels_a = readback_pixels(&device, &queue, &surface_a);
+        let pixels_b = readback_pixels(&device, &queue, &surface_b);
+        for (idx, (a, b)) in pixels_a.iter().zip(pixels_b.iter()).enumerate() {
+            assert_eq!(
+                a, b,
+                "O5 rect: pixel {idx} differs ({a:?} vs {b:?}) — axis-aligned path must be deterministic"
+            );
+        }
+
+        // Byte-identity gate: the quad-fringe expansion must contribute NOTHING
+        // outside the geometric rect for an axis-aligned shape. Every pixel whose
+        // center is ≥1px beyond the rect bounds must equal the cleared transparent
+        // value — proving the only axis-aligned shader change (the expansion) added
+        // no visible output.
+        let (rl, rt, rr, rb) = (20.0_f32, 15.0, 108.0, 113.0);
+        for (idx, px) in pixels_a.iter().enumerate() {
+            let col = (idx % SURFACE_WIDTH as usize) as f32 + 0.5;
+            let row = (idx / SURFACE_WIDTH as usize) as f32 + 0.5;
+            let outside = col < rl - 1.0 || col > rr + 1.0 || row < rt - 1.0 || row > rb + 1.0;
+            assert!(
+                !outside || *px == [0, 0, 0, 0],
+                "O5: pixel at ({col},{row}) is ≥1px outside the axis-aligned rect but not \
+                 transparent ({px:?}) — quad-fringe expansion leaked output, breaking byte-identity"
+            );
+        }
+
+        // ── Rounded rect ──
+        let (surface_c, view_c) = create_render_surface(&device);
+        let (surface_d, view_d) = create_render_surface(&device);
+        clear_surface(&device, &queue, &view_c);
+        clear_surface(&device, &queue, &view_d);
+
+        let rounded_rect_shape = RRect::from_rect_circular(
+            Rect::from_ltrb(Pixels(20.0), Pixels(15.0), Pixels(108.0), Pixels(113.0)),
+            Pixels(8.0),
+        );
+
+        for (surface, view) in [(&surface_c, &view_c), (&surface_d, &view_d)] {
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            painter.rrect(rounded_rect_shape, &Paint::fill(color));
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("O5 RRect Identity Encoder"),
+            });
+            painter
+                .render(RenderTarget::sampleable(view, surface), &mut encoder)
+                .expect("render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+        }
+
+        let pixels_c = readback_pixels(&device, &queue, &surface_c);
+        let pixels_d = readback_pixels(&device, &queue, &surface_d);
+        for (idx, (c, d)) in pixels_c.iter().zip(pixels_d.iter()).enumerate() {
+            assert_eq!(
+                c, d,
+                "O5 rrect: pixel {idx} differs ({c:?} vs {d:?}) — axis-aligned path must be deterministic"
+            );
+        }
+    }
+
+    // ── O6: fwidth scale-invariance ───────────────────────────────────────────
+
+    /// O6: The AA band width (in device pixels) must stay approximately 1 device-px
+    /// when the same shape is rendered at 1× world scale and at 8× world scale.
+    ///
+    /// Verifies the fwidth correctness guarantee: `fwidth(dist)` measures the
+    /// screen-space derivative of the SDF distance, which equals the reciprocal
+    /// of the scale factor, keeping the AA band width constant in device pixels
+    /// regardless of world scale.
+    ///
+    /// Test strategy: render a rotated rect at 1× and 8× scale (the 8× shape is
+    /// 8× smaller in local units but the same device footprint). The number of
+    /// partial-alpha boundary pixels must be comparable (within a 3× factor).
+    /// A hard-aliased implementation would have zero partial-alpha pixels at 8×.
+    #[test]
+    fn o6_fwidth_aa_band_scale_invariant() {
+        let (device, queue) = acquire_test_device_and_queue();
+
+        // Render 1× scale: a 45°-rotated 60×30 rect, scaled at 1:1.
+        let (surface_1x, view_1x) = create_render_surface(&device);
+        clear_surface(&device, &queue, &view_1x);
+        {
+            let angle = PI / 4.0;
+            let half_w = 30.0_f32;
+            let half_h = 15.0_f32;
+            let cx = SURFACE_WIDTH as f32 / 2.0;
+            let cy = SURFACE_HEIGHT as f32 / 2.0;
+
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            painter.translate(flui_types::Offset::new(Pixels(cx), Pixels(cy)));
+            painter.rotate(angle);
+            painter.rect(
+                Rect::from_ltrb(
+                    Pixels(-half_w),
+                    Pixels(-half_h),
+                    Pixels(half_w),
+                    Pixels(half_h),
+                ),
+                &Paint::fill(Color::WHITE),
+            );
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("O6 1x Encoder"),
+            });
+            painter
+                .render(
+                    RenderTarget::sampleable(&view_1x, &surface_1x),
+                    &mut encoder,
+                )
+                .expect("render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+        }
+
+        // Render 8× scale: the rect is 8× smaller in local space but occupies
+        // the same device footprint (we scale the canvas by 8 and shrink local bounds).
+        let (surface_8x, view_8x) = create_render_surface(&device);
+        clear_surface(&device, &queue, &view_8x);
+        {
+            let angle = PI / 4.0;
+            // Local bounds shrunk by 8× to compensate the 8× canvas scale.
+            let local_half_w = 30.0_f32 / 8.0;
+            let local_half_h = 15.0_f32 / 8.0;
+            let cx = SURFACE_WIDTH as f32 / 2.0;
+            let cy = SURFACE_HEIGHT as f32 / 2.0;
+
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            painter.translate(flui_types::Offset::new(Pixels(cx), Pixels(cy)));
+            painter.scale(8.0, 8.0);
+            painter.rotate(angle);
+            painter.rect(
+                Rect::from_ltrb(
+                    Pixels(-local_half_w),
+                    Pixels(-local_half_h),
+                    Pixels(local_half_w),
+                    Pixels(local_half_h),
+                ),
+                &Paint::fill(Color::WHITE),
+            );
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("O6 8x Encoder"),
+            });
+            painter
+                .render(
+                    RenderTarget::sampleable(&view_8x, &surface_8x),
+                    &mut encoder,
+                )
+                .expect("render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+        }
+
+        let pixels_1x = readback_pixels(&device, &queue, &surface_1x);
+        let pixels_8x = readback_pixels(&device, &queue, &surface_8x);
+
+        // Count boundary (partial-alpha) pixels for each render.
+        let partial_1x = pixels_1x.iter().filter(|p| p[3] > 10 && p[3] < 245).count();
+        let partial_8x = pixels_8x.iter().filter(|p| p[3] > 10 && p[3] < 245).count();
+
+        assert!(
+            partial_1x > 0,
+            "O6: 1× render must have partial-alpha boundary pixels (AA must be active)"
+        );
+        assert!(
+            partial_8x > 0,
+            "O6: 8× render must have partial-alpha boundary pixels (fwidth must stay ~1px)"
+        );
+
+        // The band should be comparable within 3×.  A hard-aliased implementation
+        // at 8× scale would have very few (or zero) partial-alpha pixels.
+        let ratio = if partial_1x > partial_8x {
+            partial_1x as f32 / partial_8x as f32
+        } else {
+            partial_8x as f32 / partial_1x as f32
+        };
+        assert!(
+            ratio < 3.0,
+            "O6: AA band width differs too much between 1× ({partial_1x} pixels) and \
+             8× ({partial_8x} pixels) — ratio {ratio:.1}×. fwidth should keep the band ~1 \
+             device-px at any scale. A ratio > 3 suggests the AA is NOT scale-invariant."
+        );
+    }
+
+    // ── O7: Non-uniform corner radii map to the correct screen corners ────────
+
+    /// O7: A rrect with ONLY the top-left corner rounded must round the TOP-LEFT
+    /// screen corner and leave the other three sharp.
+    ///
+    /// Uniform-radii tests (O1/O4) cannot detect a corner-index transposition in
+    /// `sdRoundedBox`'s quadrant `select`; production rrects use distinct
+    /// per-corner radii, so this pins the `[tl,tr,br,bl]` → screen-corner mapping.
+    #[test]
+    #[allow(
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation,
+        reason = "fixed positive device-pixel coordinates on a 128² test surface"
+    )]
+    fn o7_non_uniform_corner_radii_map_to_correct_corners() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface, view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &view);
+
+        // 80×80 axis-aligned rrect, ONLY the top-left corner rounded (r=24);
+        // the other three corners are sharp.
+        let bounds = Rect::from_ltrb(Pixels(24.0), Pixels(24.0), Pixels(104.0), Pixels(104.0));
+        let rrect = RRect::new(
+            bounds,
+            flui_types::geometry::Radius::circular(Pixels(24.0)), // top-left
+            flui_types::geometry::Radius::ZERO,                   // top-right
+            flui_types::geometry::Radius::ZERO,                   // bottom-right
+            flui_types::geometry::Radius::ZERO,                   // bottom-left
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.rrect(rrect, &Paint::fill(Color::WHITE));
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("O7 Non-uniform RRect Encoder"),
+        });
+        painter
+            .render(RenderTarget::sampleable(&view, &surface), &mut encoder)
+            .expect("render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+        let pixels = readback_pixels(&device, &queue, &surface);
+
+        let alpha_at = |col: usize, row: usize| pixels[row * SURFACE_WIDTH as usize + col][3];
+
+        // ~3px diagonally inside each corner. For the 24px-rounded top-left the
+        // corner triangle is cut away (transparent); sharp corners stay opaque.
+        let inset = 3usize;
+        let tl = alpha_at(24 + inset, 24 + inset);
+        let tr = alpha_at(104 - inset, 24 + inset);
+        let br = alpha_at(104 - inset, 104 - inset);
+        let bl = alpha_at(24 + inset, 104 - inset);
+
+        assert!(
+            tl < 40,
+            "O7: top-left corner must be ROUNDED (transparent near the corner) — got alpha={tl}. \
+             corners (tl,tr,br,bl)=({tl},{tr},{br},{bl}). A different transparent corner means the \
+             [tl,tr,br,bl] → screen-corner mapping in sdRoundedBox is transposed."
+        );
+        for (name, a) in [("tr", tr), ("br", br), ("bl", bl)] {
+            assert!(
+                a > 215,
+                "O7: {name} corner must be SHARP (opaque near the corner) — got alpha={a}. \
+                 corners (tl,tr,br,bl)=({tl},{tr},{br},{bl})."
+            );
+        }
+    }
+}

--- a/crates/flui-engine/src/wgpu/batches/shapes.rs
+++ b/crates/flui-engine/src/wgpu/batches/shapes.rs
@@ -67,32 +67,61 @@ impl DrawBatcher {
             // (ALPHA_BLENDING) pipeline. Non-SrcOver blend modes must route
             // through the tessellated path, whose pipeline is selected per
             // `pipeline_key_from_paint` (Phase A fixed-function Porter-Duff).
-            //
-            // Phase-A quality limit: the tessellated path produces aliased edges
-            // at sample_count=1 (no SDF anti-aliasing) and the scissor clip is
-            // an AABB, not a pixel-perfect rounded shape. SDF-quality blended
-            // shapes are Phase B.
-            if state.is_axis_aligned() && paint.blend_mode == BlendMode::SrcOver {
-                // Fast path: GPU instancing for axis-aligned rects.
-                let top_left = state.apply_transform(Point::new(rect.left(), rect.top()));
-                let bottom_right = state.apply_transform(Point::new(rect.right(), rect.bottom()));
-                let transformed_rect =
-                    Rect::from_ltrb(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
-                let instance = state.apply_active_clip(
-                    super::super::instancing::RectInstance::rect(transformed_rect, color),
-                );
-                let _ = segment.rect_batch.add(instance);
-                DrawSegment::push_scissor_region(
-                    &mut segment.rect_scissors,
-                    state.current_scissor(),
-                );
+            if paint.blend_mode == BlendMode::SrcOver {
+                if state.is_axis_aligned() {
+                    // Baked-AABB fast path: axis-aligned SrcOver — bake the
+                    // transform into the bounds (scale+translate only) and use
+                    // the identity affine. Output is byte-identical to the
+                    // pre-affine instanced path.
+                    let top_left = state.apply_transform(Point::new(rect.left(), rect.top()));
+                    let bottom_right =
+                        state.apply_transform(Point::new(rect.right(), rect.bottom()));
+                    let device_rect =
+                        Rect::from_ltrb(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
+                    let instance = state.apply_active_clip(
+                        super::super::instancing::RectInstance::rect(device_rect, color),
+                    );
+                    let _ = segment.rect_batch.add(instance);
+                    DrawSegment::push_scissor_region(
+                        &mut segment.rect_scissors,
+                        state.current_scissor(),
+                    );
+                } else {
+                    // Affine instanced path: rotated/skewed SrcOver rect.
+                    //
+                    // Pass the local-space bounds and the full 2×3 affine to
+                    // the GPU. The vertex shader applies `device = M*local + t`;
+                    // the fragment SDF evaluates in local space — `fwidth(dist)`
+                    // then gives ~1-device-px AA under any affine.
+                    let m = state.current_transform();
+                    let linear_cols = [m.x_axis.x, m.x_axis.y, m.y_axis.x, m.y_axis.y];
+                    let translation = [m.w_axis.x, m.w_axis.y];
+                    let local_bounds =
+                        [rect.left().0, rect.top().0, rect.width().0, rect.height().0];
+                    let instance = state.apply_active_clip(
+                        super::super::instancing::RectInstance::with_affine_transform(
+                            local_bounds,
+                            color,
+                            [0.0; 4],
+                            linear_cols,
+                            translation,
+                        ),
+                    );
+                    let _ = segment.rect_batch.add(instance);
+                    // Scissor = the active damage/clip region, exactly as the
+                    // axis-aligned path. The shape is bounded by its own quad +
+                    // SDF; a per-shape AABB scissor is unnecessary and (because
+                    // the quad is expanded by a ~1.5px AA fringe) would clip the
+                    // outer fringe at the shape's extreme corners.
+                    DrawSegment::push_scissor_region(
+                        &mut segment.rect_scissors,
+                        state.current_scissor(),
+                    );
+                }
             } else {
-                // Slow path: tessellate rotated/skewed rects or any non-SrcOver
-                // blend mode as a transformed quad.
+                // Slow path: any non-SrcOver blend mode — tessellate and bake.
                 //
-                // Phase-A quality note: uses the tessellated path → aliased edges
-                // (no SDF AA), AABB scissor clip. SDF-quality blended rects are
-                // Phase B.
+                // Non-SrcOver stays tessellated until the SSAA tile path (PR-3+).
                 let tl = state.apply_transform(Point::new(rect.left(), rect.top()));
                 let tr = state.apply_transform(Point::new(rect.right(), rect.top()));
                 let br = state.apply_transform(Point::new(rect.right(), rect.bottom()));
@@ -191,16 +220,10 @@ impl DrawBatcher {
             };
 
             // The instanced fast path renders with a hardcoded SrcOver pipeline.
-            // A non-SrcOver blend mode must route through the tessellated path so
-            // the blend pipeline keyed by `pipeline_key_from_paint` is selected.
-            //
-            // Phase-A quality note: the tessellated fallback produces aliased edges
-            // (no SDF AA) and the scissor clip is an AABB, not the rounded shape.
-            // SDF-quality blended rounded rects are Phase B.
+            // A non-SrcOver blend mode must route through the tessellated path.
             if paint.blend_mode != BlendMode::SrcOver {
-                // Tessellate the filled rounded rect in local space, carry the
-                // opacity-adjusted color and the requested blend mode, then bake
-                // the transform via `submit_transformed_geometry`.
+                // Non-SrcOver rrect: tessellate and bake via `submit_transformed_geometry`.
+                // Stays tessellated (aliased) until the SSAA tile path (PR-3+).
                 let fill_paint = Paint::fill(color).with_blend_mode(paint.blend_mode);
                 self.prime_tessellator_scale(state);
                 match self.tessellator.tessellate_rrect(rrect, &fill_paint) {
@@ -217,25 +240,80 @@ impl DrawBatcher {
                 return;
             }
 
-            let top_left = state.apply_transform(Point::new(rrect.rect.left(), rrect.rect.top()));
-            let bottom_right =
-                state.apply_transform(Point::new(rrect.rect.right(), rrect.rect.bottom()));
-            let transformed_rect =
-                Rect::from_ltrb(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
+            // SrcOver rrect: split on axis-alignment.
+            // Per-corner max radius (x and y components of each corner's radii).
+            let radius_top_left = rrect.top_left.x.0.max(rrect.top_left.y.0);
+            let radius_top_right = rrect.top_right.x.0.max(rrect.top_right.y.0);
+            let radius_bottom_right = rrect.bottom_right.x.0.max(rrect.bottom_right.y.0);
+            let radius_bottom_left = rrect.bottom_left.x.0.max(rrect.bottom_left.y.0);
 
-            // GPU instancing for filled rounded rects.
-            let instance = state.apply_active_clip(
-                super::super::instancing::RectInstance::rounded_rect_corners(
-                    transformed_rect,
-                    color,
-                    rrect.top_left.x.0.max(rrect.top_left.y.0),
-                    rrect.top_right.x.0.max(rrect.top_right.y.0),
-                    rrect.bottom_right.x.0.max(rrect.bottom_right.y.0),
-                    rrect.bottom_left.x.0.max(rrect.bottom_left.y.0),
-                ),
-            );
-            let _ = segment.rect_batch.add(instance);
-            DrawSegment::push_scissor_region(&mut segment.rect_scissors, state.current_scissor());
+            if state.is_axis_aligned() {
+                // Baked-AABB fast path: transform the two diagonal corners to get
+                // the device-space AABB, then use identity affine.
+                // Fixes the pre-existing bug where `apply_transform` of only 2 corners
+                // produced a wrong AABB for a rotated rrect (now gated on axis-aligned).
+                let top_left =
+                    state.apply_transform(Point::new(rrect.rect.left(), rrect.rect.top()));
+                let bottom_right =
+                    state.apply_transform(Point::new(rrect.rect.right(), rrect.rect.bottom()));
+                let device_rect =
+                    Rect::from_ltrb(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
+
+                let instance = state.apply_active_clip(
+                    super::super::instancing::RectInstance::rounded_rect_corners(
+                        device_rect,
+                        color,
+                        radius_top_left,
+                        radius_top_right,
+                        radius_bottom_right,
+                        radius_bottom_left,
+                    ),
+                );
+                let _ = segment.rect_batch.add(instance);
+                DrawSegment::push_scissor_region(
+                    &mut segment.rect_scissors,
+                    state.current_scissor(),
+                );
+            } else {
+                // Affine instanced path: rotated/skewed SrcOver rrect.
+                //
+                // Local-space bounds + full 2×3 affine. The SDF evaluates in local
+                // space with per-corner radii; fwidth gives correct ~1px AA under
+                // rotation/skew. This also fixes the pre-existing bug: previously a
+                // rotated SrcOver rrect fell through to the 2-corner AABB bake,
+                // rendering as a wrong-size axis-aligned box.
+                let m = state.current_transform();
+                let linear_cols = [m.x_axis.x, m.x_axis.y, m.y_axis.x, m.y_axis.y];
+                let translation = [m.w_axis.x, m.w_axis.y];
+                let local_bounds = [
+                    rrect.rect.left().0,
+                    rrect.rect.top().0,
+                    rrect.rect.width().0,
+                    rrect.rect.height().0,
+                ];
+                let instance = state.apply_active_clip(
+                    super::super::instancing::RectInstance::with_affine_transform(
+                        local_bounds,
+                        color,
+                        [
+                            radius_top_left,
+                            radius_top_right,
+                            radius_bottom_right,
+                            radius_bottom_left,
+                        ],
+                        linear_cols,
+                        translation,
+                    ),
+                );
+                let _ = segment.rect_batch.add(instance);
+                // Scissor = the active damage/clip region (same as the axis-aligned
+                // path); the shape is bounded by its own quad + SDF, so a per-shape
+                // AABB scissor is unnecessary and would clip the AA fringe.
+                DrawSegment::push_scissor_region(
+                    &mut segment.rect_scissors,
+                    state.current_scissor(),
+                );
+            }
         } else {
             // Stroked rounded rect — tessellate (fallback).
             self.prime_tessellator_scale(state);

--- a/crates/flui-engine/src/wgpu/instancing.rs
+++ b/crates/flui-engine/src/wgpu/instancing.rs
@@ -33,25 +33,46 @@ use flui_types::{Point, Rect, geometry::Pixels, styling::Color};
 ///
 /// This is uploaded to GPU as an instance buffer. Each rectangle gets one
 /// instance. The GPU shader reads this data per-instance and transforms a
-/// shared quad.
+/// shared quad via a full 2×3 affine.
+///
+/// ## Affine representation
+///
+/// The vertex shader applies `device = M * local + t` where:
+/// - `M` is the 2×2 linear part stored column-major in `transform`:
+///   `[a, b, c, d]` → `mat2x2(a, b, c, d)` (x_col=(a,b), y_col=(c,d)).
+/// - `t` is the translation stored in `transform_translate.xy`.
+/// - `local` is the vertex position in local shape space (derived from
+///   `bounds` which holds `[x_local, y_local, width_local, height_local]`).
+///
+/// For the baked-AABB fast path (axis-aligned SrcOver rect/rrect), `M` is
+/// the identity matrix and `t` is zero, so `device = local + 0 = local` —
+/// byte-identical to the pre-affine instanced output.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Zeroable)]
 pub struct RectInstance {
-    /// Bounding box [x, y, width, height]
+    /// Local-space bounding box `[x, y, width, height]`.
+    ///
+    /// For the baked-AABB path this is already in device pixels (the CPU
+    /// baked the transform into the bounds before constructing the instance).
+    /// For the affine path this holds the untransformed local-space extent;
+    /// the vertex shader applies `transform` + `transform_translate` to map
+    /// it to device space.
     pub bounds: [f32; 4],
 
-    /// Color [r, g, b, a] in 0-1 range
+    /// Color `[r, g, b, a]` in linear 0–1 range.
     pub color: [f32; 4],
 
-    /// Corner radii [top_left, top_right, bottom_right, bottom_left]
+    /// Corner radii `[top_left, top_right, bottom_right, bottom_left]`.
     pub corner_radii: [f32; 4],
 
-    /// Transform matrix (simplified 2D: [scale_x, scale_y, translate_x,
-    /// translate_y]) Full matrix would be 16 floats, but for UI we only
-    /// need 2D affine
+    /// 2×2 linear part of the affine transform, column-major:
+    /// `[a, b, c, d]` → x-column `(a, b)`, y-column `(c, d)`.
+    ///
+    /// Identity: `[1, 0, 0, 1]`. For the baked-AABB path this is always
+    /// identity (the transform was pre-baked into `bounds`).
     pub transform: [f32; 4],
 
-    /// SDF clip rounded rectangle: [x, y, width, height, radius_tl, radius_tr, radius_br, radius_bl]
+    /// SDF clip rounded rectangle: `[x, y, width, height, radius_tl, radius_tr, radius_br, radius_bl]`.
     /// All zeros means no clip active. When non-zero, the fragment shader
     /// uses an SDF test to discard pixels outside this rounded rectangle.
     pub clip_rrect: [f32; 8],
@@ -70,19 +91,32 @@ pub struct RectInstance {
     /// instance attributes. Only the `.x` lane carries the kind; the other
     /// three lanes are padding.
     pub clip_kind: [u32; 4],
+
+    /// Translation part of the affine transform: `[tx, ty, 0, 0]`.
+    ///
+    /// The `.zw` lanes are padding for 16-byte vec4 alignment in the shader.
+    /// For the baked-AABB path this is always `[0, 0, 0, 0]`.
+    pub transform_translate: [f32; 4],
 }
 
 impl RectInstance {
-    /// Create a simple rectangular instance
+    /// Create a simple rectangular instance (baked-AABB fast path).
+    ///
+    /// `rect` must already be in device pixels (the caller bakes the current
+    /// transform into the bounds before calling this). The affine fields are
+    /// set to identity / zero so the vertex shader produces an identical result
+    /// to the pre-affine path.
     #[must_use]
     pub fn rect(rect: Rect<Pixels>, color: Color) -> Self {
         Self {
             bounds: [rect.left().0, rect.top().0, rect.width().0, rect.height().0],
             color: color.to_f32_array(),
             corner_radii: [0.0; 4],
-            transform: [1.0, 1.0, 0.0, 0.0], // Identity transform
+            // Identity 2×2: x-col=(1,0), y-col=(0,1).
+            transform: [1.0, 0.0, 0.0, 1.0],
             clip_rrect: [0.0; 8],
             clip_kind: [0; 4],
+            transform_translate: [0.0; 4],
         }
     }
 
@@ -90,7 +124,10 @@ impl RectInstance {
     // single_radius)` (uniform-corner shortcut). Zero callsites --
     // production paths use `rounded_rect_corners` (per-corner).
 
-    /// Create an instance with per-corner radii
+    /// Create an instance with per-corner radii (baked-AABB fast path).
+    ///
+    /// `rect` must already be in device pixels. The affine fields are identity /
+    /// zero — byte-identical to the pre-affine baked-AABB path.
     #[must_use]
     pub fn rounded_rect_corners(
         rect: Rect<Pixels>,
@@ -104,9 +141,44 @@ impl RectInstance {
             bounds: [rect.left().0, rect.top().0, rect.width().0, rect.height().0],
             color: color.to_f32_array(),
             corner_radii: [top_left, top_right, bottom_right, bottom_left],
-            transform: [1.0, 1.0, 0.0, 0.0],
+            // Identity 2×2: x-col=(1,0), y-col=(0,1).
+            transform: [1.0, 0.0, 0.0, 1.0],
             clip_rrect: [0.0; 8],
             clip_kind: [0; 4],
+            transform_translate: [0.0; 4],
+        }
+    }
+
+    /// Create an instance for a **rotated or skewed** rect/rrect (affine path).
+    ///
+    /// `local_bounds` is the untransformed local-space bounding box
+    /// `[x, y, width, height]`. The vertex shader applies the full affine
+    /// `device = M * local + t` where `M` is the 2×2 linear part from the
+    /// current transform and `t` is the translation.
+    ///
+    /// `linear_cols` is column-major `[a, b, c, d]`: x-column `(a, b)`,
+    /// y-column `(c, d)`. Use `glam::Mat4::x_axis`/`y_axis` to extract it.
+    ///
+    /// `translation` is `[tx, ty]` from the current device transform.
+    ///
+    /// Corner radii default to zero; call `.with_clip_rrect` /
+    /// `.with_clip_rsuperellipse` afterwards to attach an SDF clip.
+    #[must_use]
+    pub fn with_affine_transform(
+        local_bounds: [f32; 4],
+        color: Color,
+        corner_radii: [f32; 4],
+        linear_cols: [f32; 4],
+        translation: [f32; 2],
+    ) -> Self {
+        Self {
+            bounds: local_bounds,
+            color: color.to_f32_array(),
+            corner_radii,
+            transform: linear_cols,
+            clip_rrect: [0.0; 8],
+            clip_kind: [0; 4],
+            transform_translate: [translation[0], translation[1], 0.0, 0.0],
         }
     }
 
@@ -185,17 +257,21 @@ impl RectInstance {
     // -- audit text claimed zero callsites but missed the method-style
     // dispatch on `instance` (vs type-path `RectInstance::`).
 
-    /// Get wgpu vertex buffer layout for instance data
+    /// Get wgpu vertex buffer layout for instance data.
+    ///
+    /// Locations 2–8 are unchanged from the pre-affine layout. Location 9 is
+    /// the new `transform_translate` field appended at the end of the struct;
+    /// appending keeps all existing field offsets byte-identical.
     #[must_use]
     pub fn desc() -> wgpu::VertexBufferLayout<'static> {
         const ATTRIBUTES: &[wgpu::VertexAttribute] = &wgpu::vertex_attr_array![
-            // Bounds (location 2)
+            // Bounds [x, y, width, height] (location 2)
             2 => Float32x4,
-            // Color (location 3)
+            // Color [r, g, b, a] (location 3)
             3 => Float32x4,
-            // Corner radii (location 4)
+            // Corner radii [tl, tr, br, bl] (location 4)
             4 => Float32x4,
-            // Transform (location 5)
+            // 2×2 linear affine [a, b, c, d] column-major (location 5)
             5 => Float32x4,
             // Clip rrect part 1: [x, y, width, height] (location 6)
             6 => Float32x4,
@@ -203,6 +279,8 @@ impl RectInstance {
             7 => Float32x4,
             // Clip kind: [kind, _pad, _pad, _pad] (location 8) — 0=none, 1=rrect, 2=rsuperellipse
             8 => Uint32x4,
+            // Affine translation [tx, ty, 0, 0] (location 9)
+            9 => Float32x4,
         ];
 
         wgpu::VertexBufferLayout {
@@ -699,14 +777,15 @@ mod tests {
     #[test]
     fn test_rect_instance_size() {
         // RectInstance field layout (all #[repr(C)], tightly packed):
-        //   bounds:       [f32; 4]  = 16 bytes
-        //   color:        [f32; 4]  = 16 bytes
-        //   corner_radii: [f32; 4]  = 16 bytes
-        //   transform:    [f32; 4]  = 16 bytes
-        //   clip_rrect:   [f32; 8]  = 32 bytes
-        //   clip_kind:    [u32; 4]  = 16 bytes  ← added with squircle SDF
-        //   Total: 112 bytes
-        assert_eq!(std::mem::size_of::<RectInstance>(), 112);
+        //   bounds:              [f32; 4]  = 16 bytes
+        //   color:               [f32; 4]  = 16 bytes
+        //   corner_radii:        [f32; 4]  = 16 bytes
+        //   transform:           [f32; 4]  = 16 bytes  ← 2×2 linear affine
+        //   clip_rrect:          [f32; 8]  = 32 bytes
+        //   clip_kind:           [u32; 4]  = 16 bytes
+        //   transform_translate: [f32; 4]  = 16 bytes  ← appended for affine path
+        //   Total: 128 bytes
+        assert_eq!(std::mem::size_of::<RectInstance>(), 128);
     }
 
     #[test]
@@ -791,13 +870,81 @@ mod tests {
     fn test_rect_default_clip_is_no_clip() {
         // Plain rect: clip_rrect must be all-zeros and clip_kind must be 0
         // (no SDF clip active). The fragment shader reads clip_kind[0] == 0
-        // as "skip clip test".
+        // as "skip clip test". The affine fields must be identity / zero.
         let instance = RectInstance::rect(
             Rect::from_ltrb(px(0.0), px(0.0), px(50.0), px(50.0)),
             Color::RED,
         );
         assert_eq!(instance.clip_rrect, [0.0; 8]);
         assert_eq!(instance.clip_kind, [0u32; 4]);
+        // Identity 2×2 and zero translation — baked-AABB path.
+        assert_eq!(instance.transform, [1.0, 0.0, 0.0, 1.0]);
+        assert_eq!(instance.transform_translate, [0.0; 4]);
+    }
+
+    /// The baked-AABB `rect` and `rounded_rect_corners` constructors must
+    /// produce identity affine fields so the vertex shader yields
+    /// `device = identity*local + 0 = local` — byte-identical to the
+    /// pre-affine path.
+    #[test]
+    fn baked_aabb_constructors_have_identity_affine() {
+        let r = Rect::from_ltrb(px(10.0), px(20.0), px(110.0), px(70.0));
+        let plain = RectInstance::rect(r, Color::RED);
+        assert_eq!(plain.transform, [1.0, 0.0, 0.0, 1.0], "identity 2×2");
+        assert_eq!(plain.transform_translate, [0.0; 4], "zero translation");
+
+        let rounded = RectInstance::rounded_rect_corners(r, Color::RED, 4.0, 4.0, 4.0, 4.0);
+        assert_eq!(
+            rounded.transform,
+            [1.0, 0.0, 0.0, 1.0],
+            "identity 2×2 rrect"
+        );
+        assert_eq!(
+            rounded.transform_translate, [0.0; 4],
+            "zero translation rrect"
+        );
+    }
+
+    /// `with_affine_transform` must round-trip the caller's linear + translate
+    /// components into the corresponding GPU fields without mangling them.
+    #[test]
+    fn with_affine_transform_stores_linear_and_translate() {
+        // 30° rotation: cos30≈0.866, sin30=0.5
+        let cos30 = std::f32::consts::FRAC_PI_6.cos();
+        let sin30 = std::f32::consts::FRAC_PI_6.sin();
+        // Column-major: x-col=(cos,-sin), y-col=(sin,cos) for CCW rotation.
+        // But glam uses x_axis=(cos,sin), y_axis=(-sin,cos) for CW screen rotation;
+        // we just round-trip whatever the caller provides — the math is the
+        // shader's concern.
+        let linear = [cos30, sin30, -sin30, cos30];
+        let translation = [100.0_f32, 200.0_f32];
+        let local_bounds = [0.0_f32, 0.0, 80.0, 40.0];
+        let radii = [5.0_f32, 5.0, 5.0, 5.0];
+
+        let instance = RectInstance::with_affine_transform(
+            local_bounds,
+            Color::BLUE,
+            radii,
+            linear,
+            translation,
+        );
+
+        assert_eq!(instance.bounds, local_bounds);
+        assert_eq!(instance.corner_radii, radii);
+        assert_eq!(instance.transform, linear, "linear 2×2 stored verbatim");
+        assert_eq!(
+            instance.transform_translate[0], translation[0],
+            "tx stored in .x"
+        );
+        assert_eq!(
+            instance.transform_translate[1], translation[1],
+            "ty stored in .y"
+        );
+        assert_eq!(instance.transform_translate[2], 0.0, ".z padding is zero");
+        assert_eq!(instance.transform_translate[3], 0.0, ".w padding is zero");
+        // Default: no clip.
+        assert_eq!(instance.clip_kind, [0u32; 4]);
+        assert_eq!(instance.clip_rrect, [0.0; 8]);
     }
 
     #[test]

--- a/crates/flui-engine/src/wgpu/mod.rs
+++ b/crates/flui-engine/src/wgpu/mod.rs
@@ -169,6 +169,11 @@ pub(crate) mod layer_render;
 #[cfg(test)]
 mod sdf_smoke_test;
 
+// aa_oracle_tests contains both CPU unit tests (no GPU) and GPU readback tests.
+// Include whenever test compilation is active.
+#[cfg(test)]
+mod aa_oracle_tests;
+
 #[cfg(all(test, feature = "enable-wgpu-tests"))]
 mod deterministic_replay_tests;
 

--- a/crates/flui-engine/src/wgpu/sdf_smoke_test.rs
+++ b/crates/flui-engine/src/wgpu/sdf_smoke_test.rs
@@ -34,10 +34,12 @@
 /// (and the inlined copy in `shaders/rect_instanced.wgsl`).
 fn sd_rounded_box(p: [f32; 2], b: [f32; 2], r: [f32; 4]) -> f32 {
     // Per-corner radius selection (branchless equivalent of WGSL `select`)
+    // (top, bottom) radii for the active horizontal side — see WGSL sdRoundedBox:
+    //   right (p.x>0) → (tr=r[1], br=r[2]); left → (tl=r[0], bl=r[3]).
     let r2 = if p[0] > 0.0 {
-        [r[0], r[1]]
+        [r[1], r[2]]
     } else {
-        [r[3], r[2]]
+        [r[0], r[3]]
     };
     let r3 = if p[1] > 0.0 { r2[1] } else { r2[0] };
 
@@ -53,10 +55,12 @@ fn sd_rounded_box(p: [f32; 2], b: [f32; 2], r: [f32; 4]) -> f32 {
 /// Must stay in sync with [`shaders/common/sdf.wgsl::sdRoundedSuperellipse`]
 /// (and the inlined copy in `shaders/rect_instanced.wgsl`).
 fn sd_rounded_superellipse(p: [f32; 2], b: [f32; 2], r: [f32; 4]) -> f32 {
+    // (top, bottom) radii for the active horizontal side — see WGSL sdRoundedBox:
+    //   right (p.x>0) → (tr=r[1], br=r[2]); left → (tl=r[0], bl=r[3]).
     let r2 = if p[0] > 0.0 {
-        [r[0], r[1]]
+        [r[1], r[2]]
     } else {
-        [r[3], r[2]]
+        [r[0], r[3]]
     };
     let r3 = if p[1] > 0.0 { r2[1] } else { r2[0] };
 
@@ -168,5 +172,31 @@ fn sdf_degenerate_corner_radius_zero() {
         diff < 1e-3,
         "With r=0 the superellipse SDF must fall back to rect SDF: \
          rrect={d_rrect:.6}, superellipse={d_sup:.6}, diff={diff:.6}",
+    );
+}
+
+#[test]
+fn sdf_corner_radius_maps_to_correct_quadrant() {
+    // Pin the [tl, tr, br, bl] → screen-quadrant mapping (Y-down: p.x>0 = right,
+    // p.y>0 = bottom). With ONLY the top-left corner rounded, a point just inside
+    // the TOP-LEFT corner (p.x<0, p.y<0) must be cut away (SDF > 0), while the
+    // sharp BOTTOM-RIGHT corner (p.x>0, p.y>0) stays inside (SDF < 0). The pre-fix
+    // mapping rounded the bottom-right corner instead and would fail here — this
+    // is the CPU mirror of GPU test O7, giving this sync guard teeth against a
+    // corner-index transposition (the existing tests use uniform radii and cannot).
+    let b = [100.0_f32, 100.0];
+    let r = [80.0_f32, 0.0, 0.0, 0.0]; // top-left only
+
+    let top_left = sd_rounded_box([-95.0, -95.0], b, r);
+    let bottom_right = sd_rounded_box([95.0, 95.0], b, r);
+
+    assert!(
+        top_left > 0.0,
+        "top-left corner must be ROUNDED (point cut away → SDF > 0); got {top_left:.3}. \
+         A non-positive value means the [tl,tr,br,bl] → quadrant mapping is transposed."
+    );
+    assert!(
+        bottom_right < 0.0,
+        "bottom-right corner must be SHARP (point inside → SDF < 0); got {bottom_right:.3}."
     );
 }

--- a/crates/flui-engine/src/wgpu/shaders/common/sdf.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/common/sdf.wgsl
@@ -43,8 +43,11 @@ fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
     // - p.x < 0.0: left side (uses r.x or r.w)
     // - p.y > 0.0: bottom (uses r.z or r.w)
     // - p.y < 0.0: top (uses r.x or r.y)
-    let r2 = select(r.zw, r.xy, p.x > 0.0);  // Select left/right pair
-    let r3 = select(r2.y, r2.x, p.y > 0.0);  // Select top/bottom from pair
+    // r2 = (top, bottom) radii for the active horizontal side:
+    //   right (p.x>0) → (tr=r.y, br=r.z); left → (tl=r.x, bl=r.w).
+    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
+    // r3 = bottom (p.y>0) → r2.y; top → r2.x.
+    let r3 = select(r2.x, r2.y, p.y > 0.0);
 
     let q = abs(p) - b + vec2<f32>(r3);
     return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r3;
@@ -68,8 +71,9 @@ fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
 fn sdRoundedSuperellipse(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
     // Per-corner radius selection (identical branchless pattern to
     // sdRoundedBox).
-    let r2 = select(r.zw, r.xy, p.x > 0.0);
-    let r3 = select(r2.y, r2.x, p.y > 0.0);
+    // (top, bottom) radii for the active side — see sdRoundedBox.
+    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
+    let r3 = select(r2.x, r2.y, p.y > 0.0);
 
     // `q` is the corner-local distance vector: positive when outside the
     // inner (non-rounded) rect.

--- a/crates/flui-engine/src/wgpu/shaders/rect_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/rect_instanced.wgsl
@@ -1,17 +1,33 @@
-// Instanced rectangle shader for FLUI (SDF-based)
+// Instanced rectangle shader for FLUI (SDF-based, full-affine transform).
 //
 // Renders multiple rectangles in a single draw call using GPU instancing.
-// Each instance contains: bounds, color, corner radii, transform, and clip rrect.
+// Each instance carries: local bounds, color, corner radii, a full 2×3 affine
+// (2×2 linear + translation), and an optional SDF clip rrect.
 //
-// Performance improvements over previous version:
+// ## Affine transform design
+//
+// The vertex shader applies a full 2×3 affine in LOCAL space, enabling correct
+// SDF anti-aliasing for rotated and skewed rects without any fragment-shader
+// change:
+//
+//   local_pos = vertex.position * bounds.zw + bounds.xy
+//   M         = mat2x2(transform.xy, transform.zw)   // column-major 2×2
+//   device    = M * local_pos + transform_translate.xy
+//
+// The SDF fragment evaluates distance in LOCAL space (via `uv` / `rect_size`);
+// `fwidth(dist)` measures the screen-space derivative of that local distance,
+// yielding ~1-device-px AA under ANY affine (rotation/skew/anisotropic scale)
+// with no fragment-shader change.
+//
+// For the baked-AABB fast path (axis-aligned SrcOver):
+//   transform           = [1, 0, 0, 1]   (identity 2×2)
+//   transform_translate = [0, 0, 0, 0]
+//   device = identity * local + 0 = local  → byte-identical output.
+//
+// Performance:
 // - 30-40% faster fragment shader (branchless SDF)
-// - Adaptive antialiasing via fwidth() (perfect at any zoom level)
-// - CSG-ready (can combine with other SDFs)
+// - Adaptive antialiasing via fwidth() — correct at any zoom AND under rotation
 // - SDF-based rounded rect clipping (no stencil buffer needed)
-//
-// SDF Implementation:
-// Uses signed distance field for rounded corners, eliminating conditional
-// branches in the fragment shader for optimal GPU parallelism.
 
 // Vertex input (shared unit quad: [0,0] to [1,1])
 struct VertexInput {
@@ -20,13 +36,14 @@ struct VertexInput {
 
 // Instance input (per-rectangle data)
 struct InstanceInput {
-    @location(2) bounds: vec4<f32>,         // [x, y, width, height]
-    @location(3) color: vec4<f32>,          // [r, g, b, a] in 0-1 range
-    @location(4) corner_radii: vec4<f32>,   // [tl, tr, br, bl]
-    @location(5) transform: vec4<f32>,      // [scale_x, scale_y, translate_x, translate_y]
-    @location(6) clip_bounds: vec4<f32>,    // [x, y, width, height] of clip
-    @location(7) clip_radii: vec4<f32>,     // [tl, tr, br, bl] of clip
-    @location(8) clip_kind: vec4<u32>,      // [kind, _, _, _]: 0=none, 1=rrect, 2=rsuperellipse
+    @location(2) bounds: vec4<f32>,              // [x_local, y_local, width_local, height_local]
+    @location(3) color: vec4<f32>,               // [r, g, b, a] in 0-1 range
+    @location(4) corner_radii: vec4<f32>,        // [tl, tr, br, bl]
+    @location(5) transform: vec4<f32>,           // 2×2 linear affine col-major: [a, b, c, d]
+    @location(6) clip_bounds: vec4<f32>,         // [x, y, width, height] of clip
+    @location(7) clip_radii: vec4<f32>,          // [tl, tr, br, bl] of clip
+    @location(8) clip_kind: vec4<u32>,           // [kind, _, _, _]: 0=none, 1=rrect, 2=rsuperellipse
+    @location(9) transform_translate: vec4<f32>, // [tx, ty, 0, 0] — translation part of affine
 }
 
 // Vertex output / Fragment input
@@ -61,8 +78,11 @@ var<uniform> viewport: Viewport;
 /// r: corner radii [top-left, top-right, bottom-right, bottom-left]
 fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
     // Select radius based on quadrant (branchless!)
-    let r2 = select(r.zw, r.xy, p.x > 0.0);
-    let r3 = select(r2.y, r2.x, p.y > 0.0);
+    // r2 = (top, bottom) radii for the active horizontal side:
+    //   right (p.x>0) → (tr=r.y, br=r.z); left → (tl=r.x, bl=r.w).
+    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
+    // r3 = bottom (p.y>0) → r2.y; top → r2.x.
+    let r3 = select(r2.x, r2.y, p.y > 0.0);
 
     let q = abs(p) - b + vec2<f32>(r3);
     return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r3;
@@ -74,8 +94,9 @@ fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
 /// the existing `sdRoundedBox` inlining convention. See the common-library
 /// version for full prose.
 fn sdRoundedSuperellipse(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
-    let r2 = select(r.zw, r.xy, p.x > 0.0);
-    let r3 = select(r2.y, r2.x, p.y > 0.0);
+    // (top, bottom) radii for the active side — see sdRoundedBox.
+    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
+    let r3 = select(r2.x, r2.y, p.y > 0.0);
 
     let q = abs(p) - b + vec2<f32>(r3);
 
@@ -111,24 +132,67 @@ fn vs_main(
 ) -> VertexOutput {
     var out: VertexOutput;
 
-    // Transform unit quad [0-1] to rectangle bounds
-    let local_pos = vertex.position * instance.bounds.zw; // Scale by width/height
-    let world_pos = local_pos + instance.bounds.xy;        // Translate to position
+    // Map unit quad [0,0]–[1,1] to local shape space, EXPANDED outward by a
+    // ~1.5 device-px AA fringe.
+    //
+    // The SDF anti-aliases the edge over a ~1 device-px band that straddles the
+    // geometric boundary (inside AND outside). A quad sized to the exact rect
+    // only rasterizes fragments whose center is inside, so the OUTER half of the
+    // AA band is never shaded — invisible for axis-aligned edges (outer fringe
+    // pixels have dist > edge_width → alpha 0) but visibly truncating for
+    // diagonal/rotated edges, where an outside-center pixel can still be ~50%
+    // covered. Expanding the quad gives those fringe pixels fragments; the SDF
+    // distance is still measured to the TRUE rect (via `out.uv` below), so the
+    // shape is unchanged — only the previously-missing outer fringe is added.
+    //
+    // Margin is applied in LOCAL units = fringe_device / per-axis scale, so the
+    // fringe is ~1.5 device-px at any zoom/rotation. Column lengths of the 2×2
+    // give the local→device scale per axis.
+    let fringe_device = 1.5;
+    let col0_len = length(instance.transform.xy); // |x-column| → device x-scale
+    let col1_len = length(instance.transform.zw); // |y-column| → device y-scale
+    let size_safe = max(instance.bounds.zw, vec2<f32>(1e-6, 1e-6));
+    let margin_local = vec2<f32>(
+        fringe_device / max(col0_len, 1e-6),
+        fringe_device / max(col1_len, 1e-6),
+    );
+    // Expand the unit quad to [-e, 1+e] where e = margin_local / size.
+    let expand = margin_local / size_safe;
+    let exp_pos = vertex.position * (1.0 + 2.0 * expand) - expand;
+    let local_pos = exp_pos * instance.bounds.zw + instance.bounds.xy;
 
-    // Apply instance transform (for rotations, scaling, etc.)
-    let transformed_x = world_pos.x * instance.transform.x + instance.transform.z;
-    let transformed_y = world_pos.y * instance.transform.y + instance.transform.w;
+    // Apply the full 2×3 affine: device = M * local + t.
+    //
+    // transform = [a, b, c, d] is the 2×2 linear part column-major:
+    //   x-column = (a, b), y-column = (c, d).
+    // So: M * p = (a*p.x + c*p.y,  b*p.x + d*p.y).
+    //
+    // For the baked-AABB path: M=identity ([1,0,0,1]), t=[0,0] →
+    // device = local (byte-identical output).
+    let m = mat2x2<f32>(
+        instance.transform.xy,  // x-column (a, b)
+        instance.transform.zw,  // y-column (c, d)
+    );
+    let device_pos = m * local_pos + instance.transform_translate.xy;
 
-    // Convert to clip space [-1, 1]
-    let clip_x = (transformed_x / viewport.size.x) * 2.0 - 1.0;
-    let clip_y = 1.0 - (transformed_y / viewport.size.y) * 2.0; // Flip Y for screen coords
+    // Convert device pixels to clip space [-1, 1].
+    let clip_x = (device_pos.x / viewport.size.x) * 2.0 - 1.0;
+    let clip_y = 1.0 - (device_pos.y / viewport.size.y) * 2.0; // flip Y
 
     out.position = vec4<f32>(clip_x, clip_y, 0.0, 1.0);
     out.color = instance.color;
-    out.uv = vertex.position;  // UV coordinates [0-1]
+    // UV carries the EXPANDED normalized coordinate so that the fragment's
+    // `(uv - 0.5) * rect_size` recovers the TRUE centered local position even on
+    // the expanded fringe (uv ranges slightly outside [0,1] there). This keeps
+    // the SDF distance measured to the true rect regardless of quad expansion.
+    out.uv = exp_pos;
+    // rect_size = local width × height; the SDF evaluates distance in this space.
+    // Under any affine, fwidth(dist) correctly measures the screen-space
+    // derivative of the LOCAL distance → ~1 device-px AA band.
     out.rect_size = instance.bounds.zw;
     out.corner_radii = instance.corner_radii;
-    out.world_pos = vec2<f32>(transformed_x, transformed_y);
+    // world_pos is the device-pixel position, used by the SDF clip test.
+    out.world_pos = device_pos;
     out.clip_bounds = instance.clip_bounds;
     out.clip_radii = instance.clip_radii;
     out.clip_kind = instance.clip_kind.x;


### PR DESCRIPTION
## Tessellated AA — PR-1 of the engine-wide anti-aliasing series

First PR of the tessellated-AA effort (successor to Phase B advanced blend). Design + 6-PR plan: `.rust-studio/specs/tessellated-aa/SPEC.md`.

### What this PR does
Reroutes **rotated/skewed SrcOver rect & rrect** from the aliased tessellated path to the instanced SDF path, extended to a **full 2×3 affine** → exact `fwidth`-based AA. Axis-aligned SrcOver stays **byte-identical**.

- `RectInstance` carries a full 2×3 affine (2×2 linear `transform` + appended `transform_translate`); the vertex shader applies `device = M·local + t` and evaluates the SDF in local space (`fwidth` keeps ~1px AA under any affine).
- **Quad expanded ~1.5px** so the outer half of the AA band is rasterized — without it, diagonal edges were missing their outer fringe (the quad equalled the exact geometric rect, so out-of-edge fragments were never shaded). This was the load-bearing fix that made rotated-edge AA match analytic coverage.
- **AA oracle harness** (`aa_oracle_tests.rs`, O1–O7): a CPU supersampled analytic-coverage reference calibrated against the existing SDF AA, with O2 proving the tolerance has teeth; GPU-readback gates for rotated rect/rrect, byte-identity, scale-invariance, and corner-radius mapping. Local DX12 only (not CI).

### Two pre-existing bugs fixed in the rerouted path
- **Rotated rrect AABB bug**: a rotated SrcOver rrect baked a 2-corner AABB without an `is_axis_aligned()` check → rendered a wrong-size axis-aligned box. Now routed through the affine path.
- **Corner-radius scramble**: `sdRoundedBox`/`sdRoundedSuperellipse` quadrant `select` mapped `[tl,tr,br,bl]` to the **wrong screen corners** (the code contradicted its own comment) — invisible until non-uniform radii are used (which the new O7 test exercises). Fixed in both shader copies + the CPU oracle + the `sdf_smoke_test` sync transliteration (now with a non-uniform teeth test). Also corrects non-uniform SDF **clip** rrects.

### Out of scope (later PRs)
Circle/ellipse/arc reroute (PR-2), SSAA offscreen for arbitrary paths (PR-3), non-SrcOver/advanced path AA (PR-4). The L1→L2 AA-norm refinement (sharper diagonal AA, engine-wide) is deferred to its own PR since it changes all SDF-primitive output.

### Verification
- `clippy` (default **and** `--features enable-wgpu-tests`, `-D warnings`) clean · `fmt` · `doc` · `cargo test --lib` 150 passed
- **DX12 GPU-readback: 295 passed / 0 failed / 7 ignored** (incl. the full Phase B advanced-blend suite — no regression)
- Reviewed by `rust-reviewer` + `ce-kieran` (soundness); all findings addressed (L2 revert restoring byte-identity, O5 hardened to a real leak-free gate, sync-oracle desync fixed, scissor fringe-clip removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)