### PR TITLE
feat(engine): tessellated AA — circle/oval affine-SDF reroute + fwidth AA-model fix (tessellated-AA PR-2)

### DIFF
--- a/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
+++ b/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
@@ -27,6 +27,38 @@
 /// Number of sub-samples per pixel axis for the analytic-coverage oracle.
 const ORACLE_GRID: usize = 8;
 
+/// Analytic inside-test for an axis-aligned circle centered at origin with
+/// the given radius.
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+fn inside_circle(px: f32, py: f32, radius: f32) -> bool {
+    px * px + py * py <= radius * radius
+}
+
+/// Analytic inside-test for an axis-aligned ellipse centered at origin with
+/// semi-axes `(rx, ry)`.
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+fn inside_ellipse(px: f32, py: f32, rx: f32, ry: f32) -> bool {
+    // Point is inside the ellipse iff (px/rx)² + (py/ry)² ≤ 1.
+    let nx = px / rx;
+    let ny = py / ry;
+    nx * nx + ny * ny <= 1.0
+}
+
+/// Analytic inside-test for a rotated ellipse centered at origin.
+///
+/// `angle_rad` is the CW rotation of the ellipse's major axis from the +X axis
+/// (screen-space Y-down convention). The test maps the query point into the
+/// ellipse's local frame and delegates to [`inside_ellipse`].
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+fn inside_rotated_ellipse(px: f32, py: f32, rx: f32, ry: f32, angle_rad: f32) -> bool {
+    // Inverse rotation: rotate the query point by -angle into the ellipse frame.
+    let cos_a = angle_rad.cos();
+    let sin_a = angle_rad.sin();
+    let local_x = cos_a * px + sin_a * py;
+    let local_y = -sin_a * px + cos_a * py;
+    inside_ellipse(local_x, local_y, rx, ry)
+}
+
 /// Analytic inside-test for an axis-aligned rect centered at origin with
 /// half-extents `(half_w, half_h)`.
 fn inside_rect(px: f32, py: f32, half_w: f32, half_h: f32) -> bool {
@@ -294,7 +326,8 @@ mod gpu_tests {
     use crate::wgpu::{painter::WgpuPainter, render_target::RenderTarget};
 
     use super::{
-        analytic_coverage, inside_rotated_rect, inside_rotated_rounded_rect, inside_rounded_rect,
+        analytic_coverage, inside_circle, inside_rotated_ellipse, inside_rotated_rect,
+        inside_rotated_rounded_rect, inside_rounded_rect,
     };
 
     // ── Harness constants ─────────────────────────────────────────────────────
@@ -908,6 +941,416 @@ mod gpu_tests {
     }
 
     // ── O5: Byte-identity — axis-aligned SrcOver rect and rrect ──────────────
+
+    // ── C1: Circle AA — fwidth model is radius-independent ───────────────────
+
+    /// C1: A filled SrcOver circle must have boundary pixels that match the
+    /// analytic-coverage oracle within `CALIBRATION_TOLERANCE_U8` at two radii
+    /// spanning a ~4× range: 12 px and 50 px (both fit the 128² test surface).
+    ///
+    /// ## Red→green proof
+    ///
+    /// The OLD `edge_softness = 0.02` (radius-relative) model produced an AA band
+    /// that scaled with the radius, so the two radii diverge sharply:
+    ///   - r=12: AA band = 0.02 * 12 * 2 = 0.48 px → sub-pixel → nearly aliased.
+    ///     The boundary would be mostly 0 or 255, failing the oracle (diff ≈ 127 >> 30).
+    ///   - r=50: AA band = 0.02 * 50 * 2 = 2 px → too wide; boundary pixels sit at
+    ///     coverages the box oracle does not expect.
+    ///
+    /// A single relative-softness value cannot satisfy the oracle at both radii —
+    /// that 4× span is the teeth. The NEW `fwidth`-based model gives ~1 device-px
+    /// AA at any radius, so both pass.
+    ///
+    /// Additionally, the test verifies that the interior is fully opaque and an
+    /// exterior point is transparent (C3 properties), consolidating three checks.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index/coordinate arithmetic over a small fixed-size test surface"
+    )]
+    fn c1_circle_aa_is_radius_independent() {
+        // We test one radius per isolated surface to keep the test self-contained
+        // and avoid shape overlap. Use r=12 and r=50 on the 128×128 surface (r=200
+        // would not fit, so we use r=50 for the large-radius case — the point of
+        // C1 is radius-independence which is covered by comparing r=12 vs r=50).
+        for radius in [12.0_f32, 50.0_f32] {
+            let (device, queue) = acquire_test_device_and_queue();
+            let (surface_texture, surface_view) = create_render_surface(&device);
+            clear_surface(&device, &queue, &surface_view);
+
+            let cx = SURFACE_WIDTH as f32 / 2.0;
+            let cy = SURFACE_HEIGHT as f32 / 2.0;
+
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            painter.circle(
+                flui_types::Point::new(
+                    flui_types::geometry::Pixels(cx),
+                    flui_types::geometry::Pixels(cy),
+                ),
+                radius,
+                &Paint::fill(Color::WHITE),
+            );
+
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("C1 Circle Encoder"),
+            });
+            painter
+                .render(
+                    RenderTarget::sampleable(&surface_view, &surface_texture),
+                    &mut encoder,
+                )
+                .expect("painter.render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+
+            let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+            let boundary = boundary_pixel_indices(|px, py| inside_circle(px - cx, py - cy, radius));
+
+            assert!(
+                boundary.len() >= 4,
+                "C1 r={radius}: fewer than 4 boundary pixels found ({}) — shape may be off-screen \
+                 or oracle broken",
+                boundary.len()
+            );
+
+            let mut failed_count = 0usize;
+            for (pixel_idx, oracle_coverage) in &boundary {
+                let readback_alpha = pixels[*pixel_idx][3];
+                let oracle_alpha = (oracle_coverage * 255.0).round() as u8;
+                let diff =
+                    (i16::from(readback_alpha) - i16::from(oracle_alpha)).unsigned_abs() as u8;
+                if diff > CALIBRATION_TOLERANCE_U8 {
+                    failed_count += 1;
+                }
+            }
+
+            let boundary_count = boundary.len();
+            let max_failures = (boundary_count as f32 * 0.05).ceil() as usize;
+            assert!(
+                failed_count <= max_failures,
+                "C1 FAILED at r={radius}: {failed_count}/{boundary_count} boundary pixels exceed \
+                 oracle tolerance {CALIBRATION_TOLERANCE_U8}. \
+                 The fwidth AA model must give ~1-device-px AA at all radii — \
+                 the old edge_softness=0.02 would fail this at r=12 and r=50."
+            );
+
+            // Interior must be opaque.
+            let interior_col = cx.round() as usize;
+            let interior_row = cy.round() as usize;
+            let interior_idx = interior_row * SURFACE_WIDTH as usize + interior_col;
+            assert!(
+                pixels[interior_idx][3] > 200,
+                "C1 r={radius}: interior pixel must be nearly opaque; got alpha={}",
+                pixels[interior_idx][3]
+            );
+
+            // Exterior (2 px beyond the edge) must be transparent.
+            let exterior_col = (cx + radius + 2.0).min(SURFACE_WIDTH as f32 - 1.0) as usize;
+            let exterior_row = cy.round() as usize;
+            let exterior_idx = exterior_row * SURFACE_WIDTH as usize + exterior_col;
+            assert!(
+                pixels[exterior_idx][3] < CALIBRATION_TOLERANCE_U8,
+                "C1 r={radius}: exterior pixel (2px beyond edge) must be transparent; \
+                 got alpha={} — fringe expansion may be leaking output",
+                pixels[exterior_idx][3]
+            );
+        }
+    }
+
+    // ── C2: Rotated ellipse — affine orientation correct ─────────────────────
+
+    /// C2: A 30° rotated ellipse (rx=35, ry=15) must have boundary pixels that
+    /// match the analytic rotated-ellipse oracle within tolerance.
+    ///
+    /// This proves:
+    /// 1. The affine encoding `M_world * diag(rx, ry)` produces a correctly
+    ///    oriented ellipse in device space.
+    /// 2. `fwidth` gives ~1-device-px AA even for an anisotropic ellipse under
+    ///    rotation (non-uniform scale in local space).
+    ///
+    /// If the oval routing incorrectly treats `rx`/`ry` as a uniform scale or
+    /// uses the wrong local→device mapping, the boundary will be in the wrong
+    /// position and the oracle match will fail.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index/coordinate arithmetic over a small fixed-size test surface"
+    )]
+    fn c2_rotated_ellipse_boundary_matches_oracle() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        let angle = PI / 6.0; // 30°
+        let rx = 35.0_f32;
+        let ry = 15.0_f32;
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+
+        // Draw an oval (axis-aligned in local space) under a 30° rotation.
+        // The bounding rect in local space is [cx-rx, cy-ry, cx+rx, cy+ry].
+        let local_rect = Rect::from_ltrb(
+            Pixels(cx - rx),
+            Pixels(cy - ry),
+            Pixels(cx + rx),
+            Pixels(cy + ry),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        // Rotate around the canvas center so the ellipse center stays at (cx, cy).
+        painter.translate(flui_types::Offset::new(Pixels(cx), Pixels(cy)));
+        painter.rotate(angle);
+        painter.translate(flui_types::Offset::new(Pixels(-cx), Pixels(-cy)));
+        painter.oval(local_rect, &Paint::fill(Color::WHITE));
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("C2 Rotated Ellipse Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Oracle: rotated ellipse centered at (cx, cy).
+        let boundary = boundary_pixel_indices(|px, py| {
+            inside_rotated_ellipse(px - cx, py - cy, rx, ry, angle)
+        });
+
+        assert!(
+            boundary.len() >= 8,
+            "C2: fewer than 8 boundary pixels found ({}) — shape may be off-screen or oracle broken",
+            boundary.len()
+        );
+
+        let mut failed_count = 0usize;
+        for (pixel_idx, oracle_coverage) in &boundary {
+            let readback_alpha = pixels[*pixel_idx][3];
+            let oracle_alpha = (oracle_coverage * 255.0).round() as u8;
+            let diff = (i16::from(readback_alpha) - i16::from(oracle_alpha)).unsigned_abs() as u8;
+            if diff > CALIBRATION_TOLERANCE_U8 {
+                failed_count += 1;
+            }
+        }
+
+        let boundary_count = boundary.len();
+        let max_failures = (boundary_count as f32 * 0.05).ceil() as usize;
+        assert!(
+            failed_count <= max_failures,
+            "C2 FAILED: {failed_count}/{boundary_count} rotated-ellipse boundary pixels exceed \
+             oracle tolerance {CALIBRATION_TOLERANCE_U8}. \
+             Affine orientation or fwidth AA on the ellipse is wrong."
+        );
+
+        // Interior pixel (ellipse center) must be opaque.
+        let interior_col = cx.round() as usize;
+        let interior_row = cy.round() as usize;
+        let interior_idx = interior_row * SURFACE_WIDTH as usize + interior_col;
+        assert!(
+            pixels[interior_idx][3] > 200,
+            "C2: interior pixel (ellipse center) must be nearly opaque; got alpha={}",
+            pixels[interior_idx][3]
+        );
+    }
+
+    // ── C3: Interior opaque + exterior transparent (fringe leaks nothing) ────
+
+    /// C3: For a filled SrcOver circle:
+    /// 1. Every pixel whose center is ≥2px inside the circle must be fully opaque
+    ///    (interior correctness).
+    /// 2. Every pixel whose center is ≥2px outside the circle must be transparent
+    ///    (fringe expansion must not leak any visible output beyond the AA band).
+    ///
+    /// This guards against the fringe quad expansion producing visible artifacts
+    /// outside the shape boundary.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index/coordinate arithmetic over a small fixed-size test surface"
+    )]
+    fn c3_circle_interior_opaque_exterior_transparent() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+        let radius = 40.0_f32;
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.circle(
+            flui_types::Point::new(
+                flui_types::geometry::Pixels(cx),
+                flui_types::geometry::Pixels(cy),
+            ),
+            radius,
+            &Paint::fill(Color::WHITE),
+        );
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("C3 Circle Interior/Exterior Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        let guard_px = 2.0_f32; // minimum inset/outset from the geometric edge
+
+        let mut interior_failures = 0usize;
+        let mut exterior_failures = 0usize;
+        let mut interior_total = 0usize;
+        let mut exterior_total = 0usize;
+
+        for row in 0..SURFACE_HEIGHT {
+            for col in 0..SURFACE_WIDTH {
+                let px = col as f32 + 0.5 - cx;
+                let py = row as f32 + 0.5 - cy;
+                let dist_from_edge = (px * px + py * py).sqrt() - radius;
+                let idx = row as usize * SURFACE_WIDTH as usize + col as usize;
+                let alpha = pixels[idx][3];
+
+                if dist_from_edge < -guard_px {
+                    // Clearly inside: must be opaque.
+                    interior_total += 1;
+                    if alpha < 200 {
+                        interior_failures += 1;
+                    }
+                } else if dist_from_edge > guard_px {
+                    // Clearly outside: must be transparent.
+                    exterior_total += 1;
+                    if alpha > CALIBRATION_TOLERANCE_U8 {
+                        exterior_failures += 1;
+                    }
+                }
+            }
+        }
+
+        assert!(
+            interior_total > 0,
+            "C3: no interior pixels found — circle may be too small or off-screen"
+        );
+        assert!(
+            exterior_total > 0,
+            "C3: no exterior pixels found — circle may fill the whole surface"
+        );
+
+        assert!(
+            interior_failures == 0,
+            "C3 FAILED: {interior_failures}/{interior_total} interior pixels (≥2px inside the \
+             circle edge) are not fully opaque — interior fill is wrong."
+        );
+        assert!(
+            exterior_failures == 0,
+            "C3 FAILED: {exterior_failures}/{exterior_total} exterior pixels (≥2px outside the \
+             circle edge) are not transparent — fringe expansion is leaking visible output."
+        );
+    }
+
+    // ── C4: Scaled circle center is not double-scaled (baked-path regression) ──
+
+    /// C4: Under a non-unit canvas scale, a circle's CENTER must land at the
+    /// transformed position — NOT at scale × position.
+    ///
+    /// Regression guard for the baked fast-path bug where the device center was
+    /// placed inside the local vector, so `M = diag(sx,sy)` scaled it a second
+    /// time. With `scale(2,2)` and a circle at local (32,32) r=10, the device
+    /// center is (64,64) and device radius 20. The bug rendered the center at
+    /// (128,128) — off this 128² surface — leaving (64,64) empty. C1–C3 use
+    /// identity scale and cannot catch this; production hits it on every HiDPI
+    /// (DPR>1) display, which pushes a root `scale(dpr)` into the painter CTM.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index/coordinate arithmetic over a small fixed-size test surface"
+    )]
+    fn c4_scaled_circle_center_not_double_scaled() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.scale(2.0, 2.0);
+        painter.circle(
+            flui_types::Point::new(
+                flui_types::geometry::Pixels(32.0),
+                flui_types::geometry::Pixels(32.0),
+            ),
+            10.0,
+            &Paint::fill(Color::WHITE),
+        );
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("C4 Scaled Circle Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Expected device geometry: center (64,64), radius 20.
+        let dcx = 64.0_f32;
+        let dcy = 64.0_f32;
+        let dradius = 20.0_f32;
+
+        // The center must be opaque. The double-scale bug placed it at (128,128)
+        // (off-surface), so (64,64) would be transparent → this assertion fails.
+        let center_idx = dcy as usize * SURFACE_WIDTH as usize + dcx as usize;
+        assert!(
+            pixels[center_idx][3] > 200,
+            "C4: scaled circle center must be opaque at device (64,64); got alpha={} — \
+             the baked path likely double-scaled the center (rendered it at scale × position)",
+            pixels[center_idx][3]
+        );
+
+        // The boundary at device center (64,64), radius 20 must match the oracle —
+        // proving both correct position AND correct (scaled) radius extent.
+        let boundary = boundary_pixel_indices(|px, py| inside_circle(px - dcx, py - dcy, dradius));
+        assert!(
+            boundary.len() >= 4,
+            "C4: fewer than 4 boundary pixels at the expected device position ({}) — \
+             the circle is not where the transform says it should be",
+            boundary.len()
+        );
+        let mut failed = 0usize;
+        for (pixel_idx, oracle_coverage) in &boundary {
+            let a = pixels[*pixel_idx][3];
+            let oracle_alpha = (oracle_coverage * 255.0).round() as u8;
+            let diff = (i16::from(a) - i16::from(oracle_alpha)).unsigned_abs() as u8;
+            if diff > CALIBRATION_TOLERANCE_U8 {
+                failed += 1;
+            }
+        }
+        let max_failures = (boundary.len() as f32 * 0.05).ceil() as usize;
+        assert!(
+            failed <= max_failures,
+            "C4 FAILED: {failed}/{} boundary pixels exceed tolerance at device radius 20 — \
+             the scaled circle's geometry/position is wrong",
+            boundary.len()
+        );
+    }
 
     /// O5: The axis-aligned SrcOver path is byte-identical to its pre-affine
     /// behavior.

--- a/crates/flui-engine/src/wgpu/batches/shapes.rs
+++ b/crates/flui-engine/src/wgpu/batches/shapes.rs
@@ -375,31 +375,60 @@ impl DrawBatcher {
             };
 
             // The instanced fast path renders with a hardcoded SrcOver pipeline;
-            // a non-SrcOver blend mode must route through the tessellated path.
-            if state.is_axis_aligned() && paint.blend_mode == BlendMode::SrcOver {
-                // Fast path: axis-aligned — use GPU instancing.
-                let transformed_center = state.apply_transform(center);
+            // non-SrcOver blend modes route through tessellation (aliased, until PR-4).
+            if paint.blend_mode == BlendMode::SrcOver {
                 let m = state.current_transform();
-                let sx = (m.x_axis.x * m.x_axis.x + m.x_axis.y * m.x_axis.y).sqrt();
-                let sy = (m.y_axis.x * m.y_axis.x + m.y_axis.y * m.y_axis.y).sqrt();
-
-                let instance = super::super::instancing::CircleInstance::new(
-                    transformed_center,
-                    radius,
-                    color,
-                    [sx, sy],
-                );
-                let _ = segment.circle_batch.add(instance);
-                DrawSegment::push_scissor_region(
-                    &mut segment.circle_scissors,
-                    state.current_scissor(),
-                );
+                if state.is_axis_aligned() {
+                    // Baked fast path: axis-aligned SrcOver — pre-bake the device-space
+                    // center and encode the per-axis scale as diag(sx, sy).  Output is
+                    // byte-identical to the pre-affine path.
+                    let transformed_center = state.apply_transform(center);
+                    let sx = (m.x_axis.x * m.x_axis.x + m.x_axis.y * m.x_axis.y).sqrt();
+                    let sy = (m.y_axis.x * m.y_axis.x + m.y_axis.y * m.y_axis.y).sqrt();
+                    let instance = super::super::instancing::CircleInstance::new(
+                        transformed_center,
+                        radius,
+                        color,
+                        [sx, sy],
+                    );
+                    let _ = segment.circle_batch.add(instance);
+                    DrawSegment::push_scissor_region(
+                        &mut segment.circle_scissors,
+                        state.current_scissor(),
+                    );
+                } else {
+                    // Affine instanced path: rotated/skewed SrcOver circle.
+                    //
+                    // Encode the circle as a unit sphere (radius=1, center=origin) with
+                    // the full affine M_world * r baked into the linear columns so the
+                    // vertex shader places the device-space circle correctly.
+                    // The fragment evaluates `length(unit_pos) - 1.0`; fwidth gives
+                    // ~1-device-px AA at any scale/rotation.
+                    let linear_cols = [
+                        m.x_axis.x * radius,
+                        m.x_axis.y * radius,
+                        m.y_axis.x * radius,
+                        m.y_axis.y * radius,
+                    ];
+                    // Translation: M_world * center_local + t_world.
+                    // center is already in local space (pre-transform coordinates).
+                    let tx = m.x_axis.x * center.x.0 + m.y_axis.x * center.y.0 + m.w_axis.x;
+                    let ty = m.x_axis.y * center.x.0 + m.y_axis.y * center.y.0 + m.w_axis.y;
+                    let instance = super::super::instancing::CircleInstance::with_affine_transform(
+                        linear_cols,
+                        color,
+                        [tx, ty],
+                    );
+                    let _ = segment.circle_batch.add(instance);
+                    DrawSegment::push_scissor_region(
+                        &mut segment.circle_scissors,
+                        state.current_scissor(),
+                    );
+                }
             } else {
-                // Slow path: rotation/shear or non-SrcOver — tessellate and bake.
+                // Slow path: non-SrcOver — tessellate and bake.
                 //
-                // Phase-A quality note: uses the tessellated path → aliased edges
-                // (no SDF AA), AABB scissor clip. SDF-quality blended circles are
-                // Phase B.
+                // Non-SrcOver stays tessellated (aliased) until the SSAA tile path (PR-3+).
                 let fill_paint = Paint {
                     color,
                     style: PaintStyle::Fill,
@@ -418,7 +447,7 @@ impl DrawBatcher {
                         );
                     }
                     Err(e) => {
-                        tracing::warn!("Failed to tessellate rotated circle: {}", e);
+                        tracing::warn!("Failed to tessellate circle: {}", e);
                     }
                 }
             }
@@ -441,27 +470,108 @@ impl DrawBatcher {
     }
 
     /// Record a filled or stroked oval (ellipse).
+    ///
+    /// SrcOver filled ovals are routed through the affine instanced circle path:
+    /// an ellipse with semi-axes `(rx, ry)` is a unit circle scaled by `diag(rx, ry)`
+    /// in local space, so the combined affine is `M_world * diag(rx, ry)` — exactly
+    /// what `CircleInstance::with_affine_transform` encodes. The fragment evaluates
+    /// `length(unit_pos) - 1.0` on the resulting oriented ellipse; `fwidth` gives
+    /// ~1-device-px AA for circles and moderate-aspect ellipses. (At extreme aspect
+    /// ratios the unit-circle SDF is not the true Euclidean distance to the ellipse,
+    /// so the AA band at the thin tips is slightly wider than 1px — same limitation
+    /// as `rect_instanced`; acceptable for UI shapes.)
+    ///
+    /// Non-SrcOver and stroked ovals remain tessellated (aliased) until PR-4.
+    ///
+    /// Paint-order note: like all instanced shapes (rect, circle), an instanced
+    /// oval flushes in the engine's fixed bucket order, NOT strict painter order
+    /// relative to overlapping *tessellated* SrcOver geometry in the same segment.
+    /// This is a pre-existing engine characteristic (bucket order ≠ draw order),
+    /// now extended consistently to ovals/rotated circles for the AA win; true
+    /// painter-order compositing is a separate, engine-wide concern.
     pub(in super::super) fn oval(
         &mut self,
         segment: &mut DrawSegment,
         draw_order: &mut Vec<DrawItem>,
         state: &GpuStateStack,
+        opacity: f32,
         rect: Rect<Pixels>,
         paint: &Paint,
     ) {
         let center = rect.center();
-        let radii = Point::new(rect.width() / 2.0, rect.height() / 2.0);
+        let rx = (rect.width() / 2.0).0;
+        let ry = (rect.height() / 2.0).0;
 
-        self.prime_tessellator_scale(state);
-        if let Ok((vertices, indices)) = self.tessellator.tessellate_ellipse(center, radii, paint) {
-            Self::submit_transformed_geometry(
-                segment,
-                draw_order,
-                state,
-                vertices,
-                &indices,
-                pipeline::pipeline_key_from_paint(paint),
+        // Fold the compositor layer opacity into the color (the instanced pipeline
+        // has no opacity uniform), mirroring `rect`/`rrect`/`circle`.
+        let color = if opacity < 1.0 {
+            let alpha = (f32::from(paint.color.a) * opacity) as u8;
+            flui_types::Color::rgba(paint.color.r, paint.color.g, paint.color.b, alpha)
+        } else {
+            paint.color
+        };
+
+        if paint.style == PaintStyle::Fill && paint.blend_mode == BlendMode::SrcOver {
+            // Instanced affine SDF path: encode the ellipse as a unit circle under
+            // M_world * diag(rx, ry).  Works for both axis-aligned and rotated ovals.
+            let m = state.current_transform();
+
+            // Combined linear: M_w * diag(rx, ry).
+            // x-col of M_w scaled by rx; y-col of M_w scaled by ry.
+            let linear_cols = [
+                m.x_axis.x * rx,
+                m.x_axis.y * rx,
+                m.y_axis.x * ry,
+                m.y_axis.y * ry,
+            ];
+            // Translation: M_w * center_local + t_w.
+            let cx = center.x.0;
+            let cy = center.y.0;
+            let tx = m.x_axis.x * cx + m.y_axis.x * cy + m.w_axis.x;
+            let ty = m.x_axis.y * cx + m.y_axis.y * cy + m.w_axis.y;
+
+            let instance = super::super::instancing::CircleInstance::with_affine_transform(
+                linear_cols,
+                color,
+                [tx, ty],
             );
+            let _ = segment.circle_batch.add(instance);
+            DrawSegment::push_scissor_region(&mut segment.circle_scissors, state.current_scissor());
+        } else if paint.style == PaintStyle::Fill {
+            // Non-SrcOver fill — tessellate (aliased until the SSAA tile path, PR-4),
+            // carrying the opacity-folded color + the requested blend mode.
+            let fill_paint = Paint::fill(color).with_blend_mode(paint.blend_mode);
+            let radii = Point::new(rect.width() / 2.0, rect.height() / 2.0);
+            self.prime_tessellator_scale(state);
+            if let Ok((vertices, indices)) =
+                self.tessellator
+                    .tessellate_ellipse(center, radii, &fill_paint)
+            {
+                Self::submit_transformed_geometry(
+                    segment,
+                    draw_order,
+                    state,
+                    vertices,
+                    &indices,
+                    pipeline::pipeline_key_from_paint(&fill_paint),
+                );
+            }
+        } else {
+            // Stroked oval — tessellate (fallback), unchanged.
+            let radii = Point::new(rect.width() / 2.0, rect.height() / 2.0);
+            self.prime_tessellator_scale(state);
+            if let Ok((vertices, indices)) =
+                self.tessellator.tessellate_ellipse(center, radii, paint)
+            {
+                Self::submit_transformed_geometry(
+                    segment,
+                    draw_order,
+                    state,
+                    vertices,
+                    &indices,
+                    pipeline::pipeline_key_from_paint(paint),
+                );
+            }
         }
     }
 

--- a/crates/flui-engine/src/wgpu/instancing.rs
+++ b/crates/flui-engine/src/wgpu/instancing.rs
@@ -291,34 +291,124 @@ impl RectInstance {
     }
 }
 
-/// Instance data for a circle
+/// Instance data for a circle or ellipse rendered via the affine instanced SDF path.
+///
+/// ## Layout and affine design
+///
+/// Mirrors [`RectInstance`]: the vertex shader applies `device = M * local + t` where:
+/// - `M` is the 2×2 linear part stored column-major in `transform`:
+///   `[a, b, c, d]` → x-column `(a, b)`, y-column `(c, d)`.
+/// - `t` is the translation stored in `transform_translate.xy`.
+/// - `local` is `unit_pos * radius + [cx, cy]`, where `unit_pos ∈ [-1,1]²`
+///   and `[cx, cy]` is the local-space center from `center_radius.xy`.
+///
+/// ## Baked fast path (axis-aligned SrcOver circles)
+///
+/// [`CircleInstance::new`] produces `transform = diag(sx, sy)`,
+/// `transform_translate = [cx_dev, cy_dev, 0, 0]`, and `center_radius = [0, 0, r, 0]`.
+/// The vertex shader computes `local = unit_pos * radius` (origin-centered) then
+/// `device = diag(sx,sy)*local + center_dev`. The device center lives in the
+/// translation so the scale never multiplies it — matching the pre-affine path,
+/// which added `center` directly and scaled only `normalized_pos * radius`.
+/// (Putting the center inside `local` would double-scale it under any non-unit
+/// CTM scale, e.g. HiDPI DPR>1.)
+///
+/// ## Affine path (rotated circles, ellipses, ovals under a general transform)
+///
+/// [`CircleInstance::with_affine_transform`] uses `center_radius = [0,0,1,0]`
+/// (unit circle at origin). `transform` encodes `M_world * diag(rx, ry)`:
+///   - circle of radius `r` at center `c` under `M_w + t_w`:
+///     `linear = [M_w.a*r, M_w.b*r, M_w.c*r, M_w.d*r]`,
+///     `translate = M_w * c + t_w`.
+///   - ellipse with semi-axes `(rx, ry)`:
+///     `linear = [M_w.a*rx, M_w.b*rx, M_w.c*ry, M_w.d*ry]`.
+///
+/// The SDF fragment evaluates `length(unit_pos) - 1.0`, which is 0 at the unit-circle
+/// edge; `fwidth` gives ~1-device-px AA at any radius, scale, or rotation.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Zeroable)]
 pub struct CircleInstance {
-    /// Center point [x, y] and radius [radius, _padding]
+    /// Radius in `.z`; `.xy` is unused (the center lives in `transform_translate`).
+    ///
+    /// Baked fast path: `[0, 0, radius, 0]`.
+    /// Affine path: `[0, 0, 1, 0]` (radius folded into `transform`).
     pub center_radius: [f32; 4],
 
-    /// Color [r, g, b, a] in 0-1 range
+    /// Color `[r, g, b, a]` in linear 0–1 range.
     pub color: [f32; 4],
 
-    /// Transform (for ellipses: scale_x, scale_y)
+    /// 2×2 linear part of the affine transform, column-major:
+    /// `[a, b, c, d]` → x-column `(a, b)`, y-column `(c, d)`.
+    ///
+    /// Baked fast path: `diag(sx, sy)` (per-axis canvas scale).
+    /// Affine path: `M_world * diag(rx, ry)`.
     pub transform: [f32; 4],
+
+    /// Translation part of the affine transform: `[tx, ty, 0, 0]` = the device
+    /// center. Added AFTER `M` in the shader, so the linear part never scales it.
+    ///
+    /// Baked fast path: `[cx_dev, cy_dev, 0, 0]`.
+    /// Affine path: device-space center = `M_w * center_local + t_w`.
+    /// The `.zw` lanes are padding for 16-byte vec4 alignment.
+    pub transform_translate: [f32; 4],
 }
 
 impl CircleInstance {
-    /// Create a circle instance.
+    /// Create a circle instance (baked fast path).
     ///
-    /// `scale_xy` is the per-axis scale `[sx, sy]` extracted from the current
-    /// transform matrix.  Pass `[1.0, 1.0]` for identity / uniform scale.
-    /// The circle shader computes the bounding-quad half-extent as
-    /// `radius * scale_xy`, so non-unit values correctly handle a zoomed
-    /// or non-uniformly scaled canvas.
+    /// `center` must already be in device pixels (the caller applies the
+    /// current transform). The affine encodes axis-aligned scale as
+    /// `diag(sx, sy)` and carries the device center in the translation, so the
+    /// vertex shader produces `device = diag(sx,sy) * (unit * radius) + center_dev`
+    /// — the scale never multiplies the center (matches the pre-affine path).
+    ///
+    /// `scale_xy` is `[sx, sy]` extracted from the current transform matrix.
+    /// Pass `[1.0, 1.0]` for identity / uniform scale.
     #[must_use]
     pub fn new(center: Point<Pixels>, radius: f32, color: Color, scale_xy: [f32; 2]) -> Self {
         Self {
-            center_radius: [center.x.0, center.y.0, radius, 0.0],
+            // `center` is already in device pixels. It is carried in
+            // `transform_translate` (added AFTER M in the shader) so the scale in
+            // M = diag(sx,sy) never multiplies it — the local shape is the
+            // origin-centered unit circle scaled by `radius`. center_radius.xy is
+            // unused; only .z (radius) is read.
+            center_radius: [0.0, 0.0, radius, 0.0],
             color: color.to_f32_array(),
-            transform: [scale_xy[0], scale_xy[1], 0.0, 0.0],
+            // Baked scale: identity rotation, per-axis scale as diag(sx, sy).
+            // x-col = (sx, 0), y-col = (0, sy).
+            transform: [scale_xy[0], 0.0, 0.0, scale_xy[1]],
+            transform_translate: [center.x.0, center.y.0, 0.0, 0.0],
+        }
+    }
+
+    /// Create a circle or ellipse instance for the full-affine SDF path.
+    ///
+    /// Use this for any SrcOver circle/ellipse that needs rotation, shear,
+    /// or non-uniform scale (rotated circles, oriented ellipses, ovals under
+    /// a general world transform).
+    ///
+    /// The unit circle at origin is the canonical local shape: `center_radius =
+    /// [0, 0, 1, 0]`. The vertex shader applies `device = M * unit_pos + t` and
+    /// passes `unit_pos` to the fragment, which evaluates `length(unit_pos) - 1.0`
+    /// as the signed distance — correct for any affine (fwidth gives ~1-device-px AA).
+    ///
+    /// `linear_cols` encodes `M_world * diag(rx, ry)` column-major `[a, b, c, d]`:
+    ///   - circle radius `r` under `M_w`: `[M_w.a*r, M_w.b*r, M_w.c*r, M_w.d*r]`
+    ///   - ellipse `(rx, ry)` under `M_w`: `[M_w.a*rx, M_w.b*rx, M_w.c*ry, M_w.d*ry]`
+    ///
+    /// `translation` is `[tx, ty]` = `M_w * center_local + t_w` in device pixels.
+    #[must_use]
+    pub fn with_affine_transform(
+        linear_cols: [f32; 4],
+        color: Color,
+        translation: [f32; 2],
+    ) -> Self {
+        Self {
+            // Unit circle at local origin; the affine encodes radius + world transform.
+            center_radius: [0.0, 0.0, 1.0, 0.0],
+            color: color.to_f32_array(),
+            transform: linear_cols,
+            transform_translate: [translation[0], translation[1], 0.0, 0.0],
         }
     }
 
@@ -327,16 +417,22 @@ impl CircleInstance {
     // `CircleInstance::new` with scale_xy. When per-axis radii independent of
     // the canvas scale are needed it relands with a concrete first consumer.
 
-    /// Get wgpu vertex buffer layout for instance data
+    /// Get wgpu vertex buffer layout for instance data.
+    ///
+    /// Locations 2–4 are unchanged from the pre-PR-2 layout. Location 5 is the
+    /// new `transform_translate` field appended at the end of the struct;
+    /// appending keeps all existing field offsets byte-identical.
     #[must_use]
     pub fn desc() -> wgpu::VertexBufferLayout<'static> {
         const ATTRIBUTES: &[wgpu::VertexAttribute] = &wgpu::vertex_attr_array![
-            // Center + radius (location 2)
+            // Center + radius [cx, cy, radius, _] (location 2)
             2 => Float32x4,
-            // Color (location 3)
+            // Color [r, g, b, a] (location 3)
             3 => Float32x4,
-            // Transform (location 4)
+            // 2×2 linear affine [a, b, c, d] column-major (location 4)
             4 => Float32x4,
+            // Affine translation [tx, ty, 0, 0] (location 5)
+            5 => Float32x4,
         ];
 
         wgpu::VertexBufferLayout {
@@ -790,10 +886,13 @@ mod tests {
 
     #[test]
     fn test_circle_instance_size() {
-        assert_eq!(
-            std::mem::size_of::<CircleInstance>(),
-            12 * 4 // 12 floats = 48 bytes
-        );
+        // CircleInstance field layout (all #[repr(C)], tightly packed):
+        //   center_radius:       [f32; 4]  = 16 bytes
+        //   color:               [f32; 4]  = 16 bytes
+        //   transform:           [f32; 4]  = 16 bytes  ← 2×2 linear affine
+        //   transform_translate: [f32; 4]  = 16 bytes  ← appended for affine path
+        //   Total: 64 bytes
+        assert_eq!(std::mem::size_of::<CircleInstance>(), 64);
     }
 
     #[test]
@@ -1020,29 +1119,67 @@ mod tests {
         use flui_types::{Point, geometry::Pixels};
         let center = Point::new(flui_types::geometry::Pixels(50.0), Pixels(75.0));
         let instance = CircleInstance::new(center, 20.0, Color::RED, [1.0, 1.0]);
-        assert_eq!(instance.center_radius[0], 50.0); // x
-        assert_eq!(instance.center_radius[1], 75.0); // y
+        // The device center lives in `transform_translate` (added AFTER M in the
+        // shader) so M = diag(sx,sy) never double-scales it. `center_radius.xy`
+        // is unused; `.z` is the radius. (Unit-level guard for the baked-path
+        // double-scale bug — see GPU test C4.)
+        assert_eq!(instance.center_radius[0], 0.0); // unused
+        assert_eq!(instance.center_radius[1], 0.0); // unused
         assert_eq!(instance.center_radius[2], 20.0); // radius
         assert_eq!(instance.center_radius[3], 0.0); // padding
+        assert_eq!(instance.transform_translate[0], 50.0); // device center x
+        assert_eq!(instance.transform_translate[1], 75.0); // device center y
     }
 
-    /// Regression: CircleInstance::new must propagate scale_xy into the
-    /// transform field so the circle shader sizes the bounding quad correctly.
-    /// Before the fix, transform was always [1.0, 1.0, 0.0, 0.0] regardless
-    /// of the canvas scale, causing scaled circles to render at wrong size.
+    /// `CircleInstance::new` must encode scale_xy as `diag(sx, sy)` in the 2×2
+    /// transform field so the vertex shader computes the correct bounding-quad
+    /// size, and carry the device center in `transform_translate` (so M never
+    /// scales it). A non-origin center proves the center → translate mapping.
     #[test]
     fn circle_instance_scale_propagates_to_transform() {
         use flui_types::{Point, geometry::Pixels};
-        let center = Point::new(Pixels(0.0), Pixels(0.0));
+        let center = Point::new(Pixels(12.0), Pixels(34.0));
         let identity = CircleInstance::new(center, 10.0, Color::RED, [1.0, 1.0]);
-        assert_eq!(identity.transform[0], 1.0, "identity sx");
-        assert_eq!(identity.transform[1], 1.0, "identity sy");
+        // diag(1,1): x-col=(1,0), y-col=(0,1)
+        assert_eq!(identity.transform, [1.0, 0.0, 0.0, 1.0], "identity diag");
+        // Center carried in the translation (NOT scaled by M).
+        assert_eq!(identity.transform_translate[0], 12.0, "tx = center x");
+        assert_eq!(identity.transform_translate[1], 34.0, "ty = center y");
 
         let scaled = CircleInstance::new(center, 10.0, Color::RED, [2.5, 3.0]);
-        assert_eq!(scaled.transform[0], 2.5, "scaled sx");
-        assert_eq!(scaled.transform[1], 3.0, "scaled sy");
-        assert_eq!(scaled.transform[2], 0.0, "translate_x always 0");
-        assert_eq!(scaled.transform[3], 0.0, "translate_y always 0");
+        // diag(2.5, 3.0): x-col=(2.5,0), y-col=(0,3.0)
+        assert_eq!(scaled.transform, [2.5, 0.0, 0.0, 3.0], "scaled diag");
+        // Center is still the raw device center — diag(sx,sy) must NOT multiply it.
+        assert_eq!(scaled.transform_translate[0], 12.0, "tx unscaled by sx");
+        assert_eq!(scaled.transform_translate[1], 34.0, "ty unscaled by sy");
+    }
+
+    /// `CircleInstance::with_affine_transform` must store a unit circle at origin
+    /// and round-trip the caller's linear + translate without mangling.
+    #[test]
+    fn circle_with_affine_transform_stores_unit_circle_and_affine() {
+        // 30° rotation × radius 20 for a circle: col-major M_w*r.
+        let cos30 = std::f32::consts::FRAC_PI_6.cos();
+        let sin30 = std::f32::consts::FRAC_PI_6.sin();
+        let r = 20.0_f32;
+        // CW screen rotation: x-col=(cos,-sin)*r, y-col=(sin,cos)*r (col-major [a,b,c,d]).
+        let linear = [cos30 * r, -sin30 * r, sin30 * r, cos30 * r];
+        let translation = [64.0_f32, 64.0_f32];
+
+        let instance = CircleInstance::with_affine_transform(linear, Color::BLUE, translation);
+
+        // center_radius must be the unit circle at origin.
+        assert_eq!(instance.center_radius[0], 0.0, "cx=0");
+        assert_eq!(instance.center_radius[1], 0.0, "cy=0");
+        assert_eq!(instance.center_radius[2], 1.0, "radius=1 (unit circle)");
+        assert_eq!(instance.center_radius[3], 0.0, "padding");
+        // Linear stored verbatim.
+        assert_eq!(instance.transform, linear, "linear 2×2 round-trip");
+        // Translation stored in xy; zw are padding.
+        assert_eq!(instance.transform_translate[0], 64.0, "tx");
+        assert_eq!(instance.transform_translate[1], 64.0, "ty");
+        assert_eq!(instance.transform_translate[2], 0.0, "pad.z");
+        assert_eq!(instance.transform_translate[3], 0.0, "pad.w");
     }
 
     /// Regression: ArcInstance::new must propagate scale_xy into the transform

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -727,10 +727,12 @@ impl WgpuPainter {
         #[cfg(debug_assertions)]
         tracing::trace!("WgpuPainter::oval: rect={:?}, paint={:?}", rect, paint);
 
+        let opacity = self.compositor.current_opacity();
         self.batcher.oval(
             &mut self.current_segment,
             &mut self.draw_order,
             &self.state,
+            opacity,
             rect,
             paint,
         );

--- a/crates/flui-engine/src/wgpu/shaders/circle_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/circle_instanced.wgsl
@@ -1,28 +1,74 @@
-// Instanced circle shader for FLUI
+// Instanced circle / ellipse shader for FLUI (SDF-based, full-affine transform).
 //
-// Renders multiple circles in a single draw call using GPU instancing.
-// Each instance contains: center, radius, color, and transform (for ellipses).
+// Renders circles and ellipses in a single draw call via GPU instancing.
+// Each instance carries: a local center + radius (unit circle for the affine path),
+// color, a full 2×3 affine (2×2 linear + translation), enabling correct SDF AA
+// for rotated and scaled circles/ellipses without any fragment-shader change.
 //
-// Performance: 100 circles = 1 draw call (vs 100 without instancing)
+// ## Affine transform design
+//
+// The vertex shader applies a full 2×3 affine to an ORIGIN-CENTERED unit circle:
+//
+//   local_pos  = unit_pos * radius                  // unit_pos ∈ [-1,1]², origin-centered
+//   M          = mat2x2(transform.xy, transform.zw) // column-major 2×2
+//   device     = M * local_pos + transform_translate.xy
+//
+// The device CENTER lives in `transform_translate` (added after M), so M never
+// scales it. center_radius.z is the radius; center_radius.xy is unused.
+//
+// For the affine path (circles/ellipses under rotation/shear):
+//   center_radius = [0, 0, 1, 0]  (unit circle, radius folded into M)
+//   transform     = M_world * diag(rx, ry)
+//   transform_translate = M_world * center_local + t_world
+//
+// The SDF fragment evaluates `length(unit_pos) - 1.0` (0 at the unit-circle
+// edge). `fwidth(dist)` measures the screen-space derivative of that local
+// distance, yielding ~1-device-px AA under ANY affine (rotation/shear/
+// anisotropic scale).
+//
+// ## Baked fast path (axis-aligned SrcOver circles)
+//
+//   center_radius       = [0, 0, radius, 0]   (xy unused; center is in translate)
+//   transform           = diag(sx, sy)        (per-axis canvas scale)
+//   transform_translate = [cx_dev, cy_dev, 0, 0]   (device-space center)
+//   → device = diag(sx,sy) * (unit * radius) + center_dev
+//   → scaled radius extent about the device center (matches the pre-affine path,
+//     which added center directly and scaled only the radius displacement).
+//
+// ## AA fringe quad expansion
+//
+// The quad is expanded ~1.5 device-px outward so the outer AA fringe rasterizes.
+// Margin is computed in LOCAL units = 1.5 / column_length (mirroring rect_instanced).
+// The SDF distance is still measured to the true unit circle regardless of expansion.
+//
+// ## AA quality fix
+//
+// Previous shader used `edge_softness = 0.02` (radius-RELATIVE): a 200px circle
+// got 4px AA; a 5px circle got 0.1px. The new `fwidth`-based model gives exactly
+// ~1 device-px AA at ANY radius and any affine — the same model as rect_instanced.
 
 // Vertex input (shared unit quad: [0,0] to [1,1])
 struct VertexInput {
     @location(0) position: vec2<f32>,  // Quad corner [0 to 1]
 }
 
-// Instance input (per-circle data)
+// Instance input (per-circle / per-ellipse data)
 struct InstanceInput {
-    @location(2) center_radius: vec4<f32>,  // [x, y, radius, _padding]
-    @location(3) color: vec4<f32>,          // [r, g, b, a] in 0-1 range
-    @location(4) transform: vec4<f32>,      // [scale_x, scale_y, translate_x, translate_y]
+    @location(2) center_radius: vec4<f32>,      // [cx, cy, radius, _padding]
+    @location(3) color: vec4<f32>,              // [r, g, b, a] in 0-1 range
+    @location(4) transform: vec4<f32>,          // 2×2 linear affine col-major: [a, b, c, d]
+    @location(5) transform_translate: vec4<f32>,// [tx, ty, 0, 0] — translation part
 }
 
 // Vertex output / Fragment input
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) color: vec4<f32>,
-    @location(1) local_pos: vec2<f32>,      // Position relative to circle center [-1 to 1]
-    @location(2) radius: f32,               // Circle radius (for anti-aliasing)
+    // Unit-circle coordinate passed from the vertex shader to the fragment.
+    // For the unit-circle local shape: `unit_pos = (local_pos - center) / radius`.
+    // The SDF evaluates `length(unit_pos) - 1.0`; fwidth gives correct screen-space
+    // AA width regardless of the affine applied in the vertex shader.
+    @location(1) unit_pos: vec2<f32>,
 }
 
 // Viewport uniform (for screen-space to clip-space conversion)
@@ -34,6 +80,10 @@ struct Viewport {
 @group(0) @binding(0)
 var<uniform> viewport: Viewport;
 
+// =============================================================================
+// Vertex Shader
+// =============================================================================
+
 @vertex
 fn vs_main(
     vertex: VertexInput,
@@ -41,48 +91,105 @@ fn vs_main(
 ) -> VertexOutput {
     var out: VertexOutput;
 
-    let center = instance.center_radius.xy;
     let radius = instance.center_radius.z;
 
-    // Convert unit quad [0,1] to [-1,1] range for local position
-    let normalized_pos = vertex.position * 2.0 - 1.0;
-
-    // Transform to circle bounding box in world space
-    // Apply instance transform for ellipses (scale_x, scale_y)
-    let scaled_pos = normalized_pos * vec2<f32>(
-        radius * instance.transform.x,
-        radius * instance.transform.y
+    // Map unit quad [0,0]–[1,1] to the unit-circle local space [-1,1]²,
+    // EXPANDED outward by a ~1.5 device-px AA fringe.
+    //
+    // The unit quad maps to [-1, 1] × [-1, 1] in the un-expanded case:
+    //   unit_pos = vertex.position * 2.0 - 1.0
+    //
+    // The SDF anti-aliases the edge over a ~1 device-px band that straddles the
+    // geometric boundary (inside AND outside). Expanding the quad gives fringe
+    // pixels fragments for the outer half of the AA band — essential for diagonal
+    // and rotated edges. The SDF distance is still measured to the true unit
+    // circle regardless of expansion.
+    //
+    // Margin in LOCAL units = 1.5 / (radius * column_length), so the fringe is
+    // ~1.5 device-px at any zoom/rotation/scale. Column lengths of the 2×2 give
+    // the local→device scale per axis (|M * e_x| = |col0|, |M * e_y| = |col1|).
+    // The `radius` factor converts from unit-circle local space to world-local space.
+    let fringe_device = 1.5;
+    let col0_len = length(instance.transform.xy); // |x-column| → device scale of local-x
+    let col1_len = length(instance.transform.zw); // |y-column| → device scale of local-y
+    // margin_unit: how much to expand the unit-circle quad in unit-circle coordinates.
+    // fringe_device / (radius * col_len) = fringe_dev_px / dev_px_per_unit.
+    let r_safe = max(radius, 1e-6);
+    let margin_unit = vec2<f32>(
+        fringe_device / max(col0_len * r_safe, 1e-6),
+        fringe_device / max(col1_len * r_safe, 1e-6),
     );
+    // Expand the [-1,1] quad to [-(1+e), 1+e].
+    let base_unit = vertex.position * 2.0 - 1.0; // [-1, 1]
+    let exp_unit  = base_unit * (1.0 + margin_unit); // [-(1+e), 1+e]
 
-    let world_pos = center + scaled_pos + instance.transform.zw; // Add translation
+    // Local-space position: the expanded unit coord scaled by radius, ORIGIN-
+    // centered. The device CENTER is carried entirely in `transform_translate`
+    // (added AFTER M below), so it is never scaled by M. Putting the center
+    // inside `local` here would let M scale it — the baked-path double-scale bug
+    // (a circle on a scaled/HiDPI CTM rendered its center at scale × position).
+    let local_pos = exp_unit * r_safe;
 
-    // Convert to clip space [-1, 1]
-    let clip_x = (world_pos.x / viewport.size.x) * 2.0 - 1.0;
-    let clip_y = 1.0 - (world_pos.y / viewport.size.y) * 2.0; // Flip Y for screen coords
+    // Apply the full 2×3 affine: device = M * local + t.
+    //
+    // transform = [a, b, c, d] is the 2×2 linear part column-major:
+    //   x-column = (a, b), y-column = (c, d).
+    // So: M * p = (a*p.x + c*p.y,  b*p.x + d*p.y).
+    //
+    // Baked fast path: M = diag(sx, sy), local = unit*radius, t = center_dev
+    //   → device = diag(sx,sy)*(unit*r) + center_dev — scaled radius extent about
+    //     the device center (matches the pre-affine circle path exactly).
+    // Affine path: M = M_world*diag(rx,ry), radius = 1, t = M_world*center + t_world
+    //   → device = oriented ellipse about the device center.
+    let m = mat2x2<f32>(
+        instance.transform.xy,  // x-column (a, b)
+        instance.transform.zw,  // y-column (c, d)
+    );
+    let device_pos = m * local_pos + instance.transform_translate.xy;
+
+    // Convert device pixels to clip space [-1, 1].
+    let clip_x = (device_pos.x / viewport.size.x) * 2.0 - 1.0;
+    let clip_y = 1.0 - (device_pos.y / viewport.size.y) * 2.0; // flip Y
 
     out.position = vec4<f32>(clip_x, clip_y, 0.0, 1.0);
     out.color = instance.color;
-    out.local_pos = normalized_pos; // [-1 to 1] range for fragment shader
-    out.radius = radius;
+    // Pass the EXPANDED unit coord to the fragment so the SDF evaluates
+    // `length(unit_pos) - 1.0` relative to the true unit-circle edge,
+    // even on the expanded fringe (exp_unit ranges slightly outside [-1,1] there).
+    out.unit_pos = exp_unit;
 
     return out;
 }
 
+// =============================================================================
+// Fragment Shader (SDF-based with screen-space fwidth AA)
+// =============================================================================
+
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    // Calculate distance from circle center
-    let dist = length(in.local_pos);
+    // Signed distance to the unit-circle edge:
+    //   d < 0 → inside the circle
+    //   d = 0 → exactly on the edge
+    //   d > 0 → outside the circle
+    //
+    // `length(unit_pos) - 1.0` is the exact SDF of the unit circle in the
+    // coordinate space passed from the vertex shader. Because the vertex shader
+    // maps local→device via the full affine M (which is M_world * diag(rx,ry)),
+    // `fwidth(d)` measures the screen-space gradient of this distance, giving
+    // ~1 device-px AA at ANY radius, rotation, or anisotropic scale — correct
+    // for circles, rotated circles, and oriented ellipses.
+    let d = length(in.unit_pos) - 1.0;
 
-    // Circle edge at distance = 1.0 (unit circle in local space)
-    // Smooth anti-aliasing using smoothstep
-    let edge_softness = 0.02; // 2% of radius for smooth edge
-    let alpha = 1.0 - smoothstep(1.0 - edge_softness, 1.0 + edge_softness, dist);
+    // Adaptive AA: half-pixel-width in local SDF units, derived from fwidth.
+    // smoothstep maps [-aa, aa] → [1, 0]: fragments inside are fully opaque,
+    // outside fully transparent, and the boundary band is anti-aliased.
+    let aa = fwidth(d) * 0.5;
+    let alpha = 1.0 - smoothstep(-aa, aa, d);
 
-    // Discard pixels outside circle (optional, but improves overdraw)
-    if (alpha < 0.01) {
+    // Discard fully transparent pixels to reduce overdraw on expanded fringe.
+    if (alpha < 0.001) {
         discard;
     }
 
-    // Multiply alpha with color alpha
     return vec4<f32>(in.color.rgb, in.color.a * alpha);
 }


### PR DESCRIPTION
## Tessellated AA — PR-2 (circle + oval)

Second PR of the engine-wide AA series (after [#258](https://github.com/vanyastaff/flui/pull/258)). Spec: `.rust-studio/specs/tessellated-aa/SPEC.md`.

### What this PR does
Reroutes SrcOver **circle + oval (ellipse)** through the instanced circle path extended to a **full 2×3 affine**, and replaces the radius-relative AA softness with **screen-space `fwidth` AA**. Rotated circles and oriented ellipses now anti-alias correctly, and AA width is ~1 device-px at any radius.

- `CircleInstance` carries a full 2×2 linear (`transform`) + appended `transform_translate`. The device **center** lives in the translation; radius + world transform fold into M → `device = M·unit + center_dev`.
- `circle_instanced.wgsl`: vertex applies the affine to an origin-centered unit circle + ~1.5px quad-fringe expansion; fragment uses `d = length(unit_pos)-1`, `aa = fwidth(d)*0.5` — radius- and affine-independent AA. This replaces `edge_softness = 0.02`, a quality bug that gave a 200px circle 4px AA and a 5px circle 0.1px.
- `oval()` routes SrcOver fills through `M_world·diag(rx,ry)`, and now **threads compositor opacity** into the color (it was silently ignored) like rect/rrect/circle.
- AA oracle tests **C1** (radius-independence at 12 & 50px), **C2** (rotated-ellipse orientation), **C3** (no fringe leak), **C4** (scaled-circle center not double-scaled).

### A BLOCKER caught in review (and fixed)
The first cut put the device center *inside* the local vector, so `M = diag(sx,sy)` scaled it twice — **every circle on a scaled / HiDPI (DPR>1) CTM rendered its center at scale × position**. The fix moves the center into the translation (added after M). **C4** is the regression gate — it fails without the fix and is masked at identity scale (where C1–C3 run). Both adversarial reviewers (`ce-kieran` + `rust-reviewer`) flagged it independently.

### Scope / deferrals
- **Arc** deferred (its radial + angular AA is more involved) — its shader/path is untouched.
- **Non-SrcOver** circle/oval stays tessellated (PR-4).
- Byte-identity is intentionally **not** claimed for circles — the AA model improved (verified by the unchanged Phase B + PR-1 GPU suites passing).
- Z-order: instanced ovals/rotated-circles follow the engine's existing bucket order (documented), consistent with how rects/circles already behave.

### Verification
- `clippy` (default **and** `--features enable-wgpu-tests`, `-D warnings`) clean · `fmt` · `doc` · `cargo test --lib` 151
- **DX12 GPU-readback: 301 passed / 0 failed / 7 ignored** (incl. the full Phase B advanced-blend + PR-1 suites — no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)