### PR TITLE
feat(engine): tessellated AA — arc affine-SDF reroute + fwidth radial/angular AA (tessellated-AA PR-2b)

### DIFF
--- a/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
+++ b/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
@@ -59,6 +59,74 @@ fn inside_rotated_ellipse(px: f32, py: f32, rx: f32, ry: f32, angle_rad: f32) ->
     inside_ellipse(local_x, local_y, rx, ry)
 }
 
+/// Analytic inside-test for an arc sector centered at origin.
+///
+/// A point is inside the arc iff:
+///   1. Its distance from the origin is ≤ `radius` (inside the circle).
+///   2. Its angle falls within the swept sector.
+///
+/// `start_angle` and `sweep_angle` follow screen Y-down convention:
+///   - 0 = +X (right), π/2 = +Y (down), π = left.
+///   - Positive sweep = clockwise; negative = counter-clockwise.
+///
+/// For a `|sweep| ≥ 2π` input this degrades to the full circle test.
+fn inside_arc(px: f32, py: f32, radius: f32, start_angle: f32, sweep_angle: f32) -> bool {
+    // Radial guard.
+    if px * px + py * py > radius * radius {
+        return false;
+    }
+    // Full-circle shortcut.
+    if sweep_angle.abs() >= 2.0 * std::f32::consts::PI {
+        return true;
+    }
+    // Angle of the sample point in [-π, π].
+    let sample_angle = py.atan2(px);
+
+    // Normalise to a canonical [start, start + |sweep|] check.
+    // For negative sweep, swap start and end (test the CCW arc as a CW arc
+    // from `end` to `start`).
+    let (a0, pos_sweep) = if sweep_angle >= 0.0 {
+        (start_angle, sweep_angle)
+    } else {
+        (start_angle + sweep_angle, -sweep_angle)
+    };
+
+    // Wrap the sample angle into the range [a0, a0 + pos_sweep] using modular
+    // arithmetic so we can compare linearly.
+    let tau = 2.0 * std::f32::consts::PI;
+    // Bring sample into [a0, a0 + 2π).
+    let mut wrapped = sample_angle;
+    while wrapped < a0 {
+        wrapped += tau;
+    }
+    while wrapped >= a0 + tau {
+        wrapped -= tau;
+    }
+    wrapped < a0 + pos_sweep
+}
+
+/// Analytic inside-test for a rotated arc sector centered at origin.
+///
+/// `rotation_rad` is applied to the point (inverse of applying it to the arc),
+/// then delegates to [`inside_arc`] with the original `start_angle` / `sweep_angle`.
+/// This tests an arc that has been placed under a rotation transform.
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+fn inside_rotated_arc(
+    px: f32,
+    py: f32,
+    radius: f32,
+    start_angle: f32,
+    sweep_angle: f32,
+    rotation_rad: f32,
+) -> bool {
+    // Inverse-rotate the query point into the arc's local frame.
+    let cos_a = rotation_rad.cos();
+    let sin_a = rotation_rad.sin();
+    let local_x = cos_a * px + sin_a * py;
+    let local_y = -sin_a * px + cos_a * py;
+    inside_arc(local_x, local_y, radius, start_angle, sweep_angle)
+}
+
 /// Analytic inside-test for an axis-aligned rect centered at origin with
 /// half-extents `(half_w, half_h)`.
 fn inside_rect(px: f32, py: f32, half_w: f32, half_h: f32) -> bool {
@@ -238,6 +306,126 @@ mod oracle_unit_tests {
         );
     }
 
+    /// Arc oracle self-check: a pixel fully inside a 270° arc has coverage 1.0.
+    #[test]
+    fn oracle_arc_interior_coverage_is_one() {
+        use super::inside_arc;
+        // 270° arc (3π/2 sweep), radius 40. The arc covers 0 → 3π/2 (right→down→left).
+        // Sample at (-20, 0): angle = π, well into the middle of the arc and far from
+        // both angular edges. All 8×8 sub-samples land inside → coverage must be 1.0.
+        let coverage = analytic_coverage(-20.0, 0.0, |px, py| {
+            inside_arc(px, py, 40.0, 0.0, 3.0 * std::f32::consts::FRAC_PI_2)
+        });
+        #[allow(
+            clippy::float_cmp,
+            reason = "analytic oracle: all sub-samples inside → coverage exactly 1.0"
+        )]
+        {
+            assert_eq!(coverage, 1.0, "arc interior pixel must have full coverage");
+        }
+    }
+
+    /// Arc oracle self-check: a pixel fully outside (beyond radius) has coverage 0.0.
+    #[test]
+    fn oracle_arc_exterior_radial_coverage_is_zero() {
+        use super::inside_arc;
+        // Well outside the arc radially.
+        let coverage = analytic_coverage(60.0, 0.0, |px, py| {
+            inside_arc(px, py, 40.0, 0.0, std::f32::consts::FRAC_PI_2)
+        });
+        #[allow(
+            clippy::float_cmp,
+            reason = "analytic oracle: all sub-samples outside → coverage exactly 0.0"
+        )]
+        {
+            assert_eq!(coverage, 0.0, "arc exterior pixel must have zero coverage");
+        }
+    }
+
+    /// Arc oracle self-check: full-circle arc (|sweep| = 2π) covers all interior
+    /// points (coverage = 1.0 at the center), proving the full-circle shortcut
+    /// in `inside_arc` degrades correctly to a pure radial test.
+    #[test]
+    fn oracle_full_circle_arc_matches_circle() {
+        use super::inside_arc;
+        let r = 30.0_f32;
+        // Full-circle arc with 2π sweep — must behave exactly like a circle.
+        let arc_cov = analytic_coverage(0.0, 0.0, |px, py| {
+            inside_arc(px, py, r, 0.0, 2.0 * std::f32::consts::PI)
+        });
+        // The center pixel is fully inside the circle → coverage must be 1.0.
+        #[allow(
+            clippy::float_cmp,
+            reason = "analytic oracle: all sub-samples inside → coverage exactly 1.0"
+        )]
+        {
+            assert_eq!(
+                arc_cov, 1.0,
+                "full-circle arc (2π sweep) must have full coverage at the center"
+            );
+        }
+    }
+
+    /// Arc oracle self-check: a pixel on the RADIAL boundary of an arc has
+    /// partial coverage (the outer AA fringe is active).
+    #[test]
+    fn oracle_arc_radial_boundary_is_partial() {
+        use super::inside_arc;
+        // Sample right on the radial edge (radius=40, 90° sweep, pixel at (40,0)).
+        let coverage = analytic_coverage(40.0, 0.0, |px, py| {
+            inside_arc(px, py, 40.0, -0.1, std::f32::consts::FRAC_PI_2 + 0.2)
+        });
+        assert!(
+            coverage > 0.0 && coverage < 1.0,
+            "arc radial boundary pixel must have partial coverage; got {coverage}"
+        );
+    }
+
+    /// Arc oracle self-check: a pixel on the ANGULAR boundary of an arc has
+    /// partial coverage — the angular edge is anti-aliased.
+    #[test]
+    fn oracle_arc_angular_boundary_is_partial() {
+        use super::inside_arc;
+        // The angular edge of a 90° arc at start_angle=0 runs along the +X axis.
+        // Sample at pixel center (10, 0): the 8×8 sub-samples span
+        // y ∈ [-0.4375, +0.4375], so roughly half have y>0 (inside the [0,π/2]
+        // arc) and half have y<0 (below the start edge, outside). Coverage must
+        // be strictly between 0 and 1.
+        let coverage = analytic_coverage(10.0, 0.0, |px, py| {
+            // 90° arc (0 to π/2), radius 30. The angular boundary at angle=0 runs
+            // along the +X ray; a pixel centered at y=0 straddles it.
+            inside_arc(px, py, 30.0, 0.0, std::f32::consts::FRAC_PI_2)
+        });
+        // This pixel straddles the angular boundary — coverage must be partial.
+        assert!(
+            coverage > 0.0 && coverage < 1.0,
+            "arc angular boundary pixel must have partial coverage; got {coverage}"
+        );
+    }
+
+    /// CPU oracle: the ≤π / >π sector boundary (the seam where the GPU shader
+    /// flips `min(d_start,d_end)` → `max(...)`) is consistent — a point at angle
+    /// `start + 180.5°` is OUTSIDE a 180° arc but INSIDE a 181° arc. Guards the
+    /// modular-angle logic right at the half-plane intersection→union switch.
+    #[test]
+    fn oracle_arc_sweep_seam_at_180_degrees() {
+        use super::inside_arc;
+        use std::f32::consts::PI;
+        let r = 30.0_f32;
+        // A point at 180.5° from start=0, at radius 15 (well inside the disk).
+        let ang = (180.5_f32).to_radians();
+        let px = 15.0 * ang.cos();
+        let py = 15.0 * ang.sin();
+        assert!(
+            !inside_arc(px, py, r, 0.0, PI),
+            "point at 180.5° must be OUTSIDE a 180° arc"
+        );
+        assert!(
+            inside_arc(px, py, r, 0.0, (181.0_f32).to_radians()),
+            "point at 180.5° must be INSIDE a 181° arc"
+        );
+    }
+
     /// CPU coverage ramp for a 30° rotated rect is monotonically decreasing as
     /// we step outward across the boundary (inside → outside).
     ///
@@ -320,14 +508,14 @@ mod gpu_tests {
     use flui_painting::Paint;
     use flui_types::{
         Color, Rect,
-        geometry::{Pixels, RRect},
+        geometry::{Pixels, RRect, px},
     };
 
     use crate::wgpu::{painter::WgpuPainter, render_target::RenderTarget};
 
     use super::{
-        analytic_coverage, inside_circle, inside_rotated_ellipse, inside_rotated_rect,
-        inside_rotated_rounded_rect, inside_rounded_rect,
+        analytic_coverage, inside_arc, inside_circle, inside_rotated_arc, inside_rotated_ellipse,
+        inside_rotated_rect, inside_rotated_rounded_rect, inside_rounded_rect,
     };
 
     // ── Harness constants ─────────────────────────────────────────────────────
@@ -1636,5 +1824,507 @@ mod gpu_tests {
                  corners (tl,tr,br,bl)=({tl},{tr},{br},{bl})."
             );
         }
+    }
+
+    // ── A1: Arc radial AA is radius-independent ───────────────────────────────
+
+    /// A1: A filled SrcOver arc must have RADIAL boundary pixels that match the
+    /// analytic-coverage oracle within `CALIBRATION_TOLERANCE_U8` at two radii
+    /// spanning a ~4× range: 12 px and 50 px.
+    ///
+    /// ## Red→green proof
+    ///
+    /// The OLD `edge_softness = 0.02` (radius-relative) model produced an AA band
+    /// that scaled with the radius — the same bug class as the old circle shader:
+    ///   - r=12: AA band = 0.02*12*2 = 0.48 px → sub-pixel → nearly aliased.
+    ///   - r=50: AA band = 0.02*50*2 = 2 px → too wide.
+    ///
+    /// The NEW `fwidth(length(unit_pos) - 1.0)` model gives ~1 device-px AA at
+    /// any radius, so both pass the oracle.
+    ///
+    /// The arc used is a 270° sweep (wide arc) so most of the circle boundary
+    /// is present; the angular edges are kept away from the boundary sample pixels.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index/coordinate arithmetic over a small fixed-size test surface"
+    )]
+    fn a1_arc_radial_aa_is_radius_independent() {
+        for radius in [12.0_f32, 50.0_f32] {
+            let (device, queue) = acquire_test_device_and_queue();
+            let (surface_texture, surface_view) = create_render_surface(&device);
+            clear_surface(&device, &queue, &surface_view);
+
+            let cx = SURFACE_WIDTH as f32 / 2.0;
+            let cy = SURFACE_HEIGHT as f32 / 2.0;
+
+            // 270° arc starting at 0 (right), sweeping CW — large arc so the
+            // radial boundary has many boundary pixels.
+            let start = 0.0_f32;
+            let sweep = 3.0 * std::f32::consts::FRAC_PI_2; // 270°
+
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            let rect = Rect::from_xywh(
+                flui_types::geometry::Pixels(cx - radius),
+                flui_types::geometry::Pixels(cy - radius),
+                px(radius * 2.0),
+                px(radius * 2.0),
+            );
+            painter.draw_arc(rect, start, sweep, true, &Paint::fill(Color::WHITE));
+
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("A1 Arc Encoder"),
+            });
+            painter
+                .render(
+                    RenderTarget::sampleable(&surface_view, &surface_texture),
+                    &mut encoder,
+                )
+                .expect("painter.render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+
+            let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+            // Boundary pixels: only the RADIAL edge (exclude angular edge vicinity).
+            // The angular edges are at angle=0 (+X) and angle=3π/2 (+Y rotated back
+            // to 270° = −Y direction = pointing up). Exclude sectors near those edges.
+            // Angular exclusion: skip samples within ±10° of the angular cut edges.
+            let angular_exclusion_rad = 10.0_f32 * std::f32::consts::PI / 180.0;
+            let end_angle = start + sweep;
+            let boundary =
+                boundary_pixel_indices(|px, py| inside_arc(px - cx, py - cy, radius, start, sweep));
+
+            // Filter to radial-only boundary pixels (not near angular edges).
+            let radial_boundary: Vec<(usize, f32)> = boundary
+                .into_iter()
+                .filter(|(pixel_idx, _)| {
+                    let col = (*pixel_idx % SURFACE_WIDTH as usize) as f32 + 0.5 - cx;
+                    let row = (*pixel_idx / SURFACE_WIDTH as usize) as f32 + 0.5 - cy;
+                    // Skip pixels near angular edges.
+                    let sample_angle = row.atan2(col);
+                    let dist_to_start = angle_diff_abs(sample_angle, start);
+                    let dist_to_end = angle_diff_abs(sample_angle, end_angle);
+                    // Only keep pixels whose radial distance is close to the arc edge
+                    // (not near the angular cut).
+                    let r = (col * col + row * row).sqrt();
+                    let near_radial_edge = (r - radius).abs() < 2.0;
+                    near_radial_edge
+                        && dist_to_start > angular_exclusion_rad
+                        && dist_to_end > angular_exclusion_rad
+                })
+                .collect();
+
+            assert!(
+                radial_boundary.len() >= 4,
+                "A1 r={radius}: fewer than 4 radial boundary pixels ({}) — shape may be \
+                 off-screen or oracle broken",
+                radial_boundary.len()
+            );
+
+            let mut failed_count = 0usize;
+            for (pixel_idx, oracle_coverage) in &radial_boundary {
+                let readback_alpha = pixels[*pixel_idx][3];
+                let oracle_alpha = (oracle_coverage * 255.0).round() as u8;
+                let diff =
+                    (i16::from(readback_alpha) - i16::from(oracle_alpha)).unsigned_abs() as u8;
+                if diff > CALIBRATION_TOLERANCE_U8 {
+                    failed_count += 1;
+                }
+            }
+
+            let boundary_count = radial_boundary.len();
+            let max_failures = (boundary_count as f32 * 0.1).ceil() as usize;
+            assert!(
+                failed_count <= max_failures,
+                "A1 FAILED at r={radius}: {failed_count}/{boundary_count} radial boundary pixels \
+                 exceed tolerance {CALIBRATION_TOLERANCE_U8}. The fwidth radial AA must give ~1 \
+                 device-px AA at all radii — old edge_softness=0.02 would fail at r=12 and r=50."
+            );
+        }
+    }
+
+    /// Absolute angle difference wrapping to [0, π].
+    fn angle_diff_abs(a: f32, b: f32) -> f32 {
+        let tau = 2.0 * std::f32::consts::PI;
+        let raw = (a - b).abs() % tau;
+        if raw > std::f32::consts::PI {
+            tau - raw
+        } else {
+            raw
+        }
+    }
+
+    // ── A2: Rotated arc — affine orientation correct ──────────────────────────
+
+    /// A2: A 30° rotated arc must have boundary pixels that match the analytic
+    /// rotated-arc oracle within tolerance.
+    ///
+    /// Proves:
+    /// 1. The full-affine encoding produces a correctly oriented arc in device space.
+    /// 2. `fwidth` radial AA stays ~1 device-px even under rotation.
+    ///
+    /// If the arc routing incorrectly uses the old axis-aligned path (scale+translate
+    /// only), the boundary will be at the wrong position and this test will fail.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index/coordinate arithmetic over a small fixed-size test surface"
+    )]
+    fn a2_rotated_arc_boundary_matches_oracle() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        let angle = PI / 6.0; // 30° rotation applied to the canvas
+        let radius = 35.0_f32;
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+        let start = 0.0_f32;
+        let sweep = 3.0 * std::f32::consts::FRAC_PI_2; // 270°
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        // Translate to center, then rotate.
+        painter.translate(flui_types::Offset::new(
+            flui_types::geometry::Pixels(cx),
+            flui_types::geometry::Pixels(cy),
+        ));
+        painter.rotate(angle);
+        // The arc rect is centered at origin in local space.
+        let rect = Rect::from_xywh(
+            flui_types::geometry::Pixels(-radius),
+            flui_types::geometry::Pixels(-radius),
+            px(radius * 2.0),
+            px(radius * 2.0),
+        );
+        painter.draw_arc(rect, start, sweep, true, &Paint::fill(Color::WHITE));
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("A2 Rotated Arc Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Oracle: rotated arc centered at (cx, cy).
+        // The rotation transform applied to the canvas means the arc's own
+        // angles are unchanged in local space; from the device frame, the arc
+        // is rotated by `angle`. We use `inside_rotated_arc` which applies an
+        // inverse rotation to query points.
+        let angular_exclusion_rad = 15.0_f32 * std::f32::consts::PI / 180.0;
+        let end_angle = start + sweep;
+
+        // Boundary pixels near the radial edge (oracle).
+        let radial_boundary: Vec<(usize, f32)> = {
+            let all_boundary = boundary_pixel_indices(|px, py| {
+                inside_rotated_arc(px - cx, py - cy, radius, start, sweep, angle)
+            });
+            all_boundary
+                .into_iter()
+                .filter(|(pixel_idx, _)| {
+                    let col = (*pixel_idx % SURFACE_WIDTH as usize) as f32 + 0.5 - cx;
+                    let row = (*pixel_idx / SURFACE_WIDTH as usize) as f32 + 0.5 - cy;
+                    // Inverse-rotate to get local angle.
+                    let cos_a = angle.cos();
+                    let sin_a = angle.sin();
+                    let lx = cos_a * col + sin_a * row;
+                    let ly = -sin_a * col + cos_a * row;
+                    let local_r = (lx * lx + ly * ly).sqrt();
+                    let local_ang = ly.atan2(lx);
+                    let near_radial = (local_r - radius).abs() < 2.0;
+                    let dist_start = angle_diff_abs(local_ang, start);
+                    let dist_end = angle_diff_abs(local_ang, end_angle);
+                    near_radial
+                        && dist_start > angular_exclusion_rad
+                        && dist_end > angular_exclusion_rad
+                })
+                .collect()
+        };
+
+        assert!(
+            radial_boundary.len() >= 4,
+            "A2: fewer than 4 radial boundary pixels ({}) — shape may be off-screen or oracle broken",
+            radial_boundary.len()
+        );
+
+        let mut failed_count = 0usize;
+        for (pixel_idx, oracle_coverage) in &radial_boundary {
+            let readback_alpha = pixels[*pixel_idx][3];
+            let oracle_alpha = (oracle_coverage * 255.0).round() as u8;
+            let diff = (i16::from(readback_alpha) - i16::from(oracle_alpha)).unsigned_abs() as u8;
+            if diff > CALIBRATION_TOLERANCE_U8 {
+                failed_count += 1;
+            }
+        }
+
+        let boundary_count = radial_boundary.len();
+        let max_failures = (boundary_count as f32 * 0.1).ceil() as usize;
+        assert!(
+            failed_count <= max_failures,
+            "A2 FAILED: {failed_count}/{boundary_count} rotated-arc radial boundary pixels exceed \
+             oracle tolerance {CALIBRATION_TOLERANCE_U8}. Affine orientation or fwidth AA is wrong."
+        );
+
+        // Interior fill check: a 270° sector at radius 35 has a large solid
+        // interior. Count opaque pixels in the mid-radius band (excluding the AA
+        // bands at the radial + angular edges). The arc APEX is intentionally NOT
+        // sampled — a pie apex is only fractionally covered (≈ sweep/2π of the
+        // directions around it), so the exact center pixel is legitimately
+        // partial, not opaque. This check proves the sector is substantially
+        // filled (not hollow / mis-oriented).
+        let mut opaque_interior = 0usize;
+        for row in 0..SURFACE_HEIGHT {
+            for col in 0..SURFACE_WIDTH {
+                let dx = col as f32 + 0.5 - cx;
+                let dy = row as f32 + 0.5 - cy;
+                let dist = (dx * dx + dy * dy).sqrt();
+                if dist < 5.0 || dist > radius - 3.0 {
+                    continue; // skip near-apex and the radial boundary band
+                }
+                let idx = row as usize * SURFACE_WIDTH as usize + col as usize;
+                if pixels[idx][3] > 250 {
+                    opaque_interior += 1;
+                }
+            }
+        }
+        assert!(
+            opaque_interior >= 200,
+            "A2: rotated arc interior is not substantially filled — only {opaque_interior} \
+             opaque pixels in the mid-radius band; the sector fill may be hollow or mis-oriented"
+        );
+    }
+
+    // ── A3: Scaled arc center not double-scaled (PR-2 regression guard) ───────
+
+    /// A3: Under a non-unit canvas scale, an arc's CENTER must land at the
+    /// transformed position — NOT at scale × position.
+    ///
+    /// This is the exact PR-2 double-scale regression guard applied to arcs.
+    /// A circle with `scale(2,2)` at local (32,32) must appear at device (64,64)
+    /// with device radius 20. The old `center_radius.xy`-in-local bug would place
+    /// the center at (128,128) — off this 128² surface — leaving (64,64) empty.
+    ///
+    /// Note: C1–C3 use identity scale and cannot catch this; production hits it on
+    /// every HiDPI (DPR>1) display.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index/coordinate arithmetic over a small fixed-size test surface"
+    )]
+    fn a3_scaled_arc_center_not_double_scaled() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.scale(2.0, 2.0);
+        // Local arc: center at (32,32), radius=10. Under scale(2,2) the device
+        // center is (64,64) and device radius is 20.
+        let local_radius = 10.0_f32;
+        let rect = Rect::from_xywh(
+            flui_types::geometry::Pixels(32.0 - local_radius),
+            flui_types::geometry::Pixels(32.0 - local_radius),
+            px(local_radius * 2.0),
+            px(local_radius * 2.0),
+        );
+        painter.draw_arc(
+            rect,
+            0.0,
+            3.0 * std::f32::consts::FRAC_PI_2, // 270°
+            true,
+            &Paint::fill(Color::WHITE),
+        );
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("A3 Scaled Arc Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Expected device geometry: center (64,64), radius 20.
+        let dcx = 64.0_f32;
+        let dcy = 64.0_f32;
+        let dradius = 20.0_f32;
+
+        // The center must be opaque. The double-scale bug placed it at (128,128)
+        // (off-surface), so (64,64) would be transparent → this assertion fails.
+        let center_idx = dcy as usize * SURFACE_WIDTH as usize + dcx as usize;
+        assert!(
+            pixels[center_idx][3] > 200,
+            "A3: scaled arc center must be opaque at device (64,64); got alpha={} — \
+             the baked path likely double-scaled the center (rendered it at scale × position)",
+            pixels[center_idx][3]
+        );
+
+        // The boundary at device center (64,64), radius 20 must have boundary pixels
+        // — proving both correct position AND correct (scaled) radius extent.
+        let start = 0.0_f32;
+        let sweep = 3.0 * std::f32::consts::FRAC_PI_2;
+        let end_angle = start + sweep;
+        let angular_excl = 15.0_f32 * std::f32::consts::PI / 180.0;
+        let radial_boundary: Vec<(usize, f32)> = {
+            let all = boundary_pixel_indices(|px, py| {
+                inside_arc(px - dcx, py - dcy, dradius, start, sweep)
+            });
+            all.into_iter()
+                .filter(|(pixel_idx, _)| {
+                    let col = (*pixel_idx % SURFACE_WIDTH as usize) as f32 + 0.5 - dcx;
+                    let row = (*pixel_idx / SURFACE_WIDTH as usize) as f32 + 0.5 - dcy;
+                    let r = (col * col + row * row).sqrt();
+                    let ang = row.atan2(col);
+                    (r - dradius).abs() < 2.0
+                        && angle_diff_abs(ang, start) > angular_excl
+                        && angle_diff_abs(ang, end_angle) > angular_excl
+                })
+                .collect()
+        };
+
+        assert!(
+            radial_boundary.len() >= 4,
+            "A3: fewer than 4 radial boundary pixels at expected device position ({}) — \
+             the arc is not where the transform says it should be",
+            radial_boundary.len()
+        );
+
+        let mut failed = 0usize;
+        for (pixel_idx, oracle_coverage) in &radial_boundary {
+            let a = pixels[*pixel_idx][3];
+            let oracle_alpha = (oracle_coverage * 255.0).round() as u8;
+            let diff = (i16::from(a) - i16::from(oracle_alpha)).unsigned_abs() as u8;
+            if diff > CALIBRATION_TOLERANCE_U8 {
+                failed += 1;
+            }
+        }
+        let max_failures = (radial_boundary.len() as f32 * 0.1).ceil() as usize;
+        assert!(
+            failed <= max_failures,
+            "A3 FAILED: {failed}/{} radial boundary pixels exceed tolerance at device radius 20 — \
+             the scaled arc's geometry/position is wrong",
+            radial_boundary.len()
+        );
+    }
+
+    // ── A4: Angular edges are anti-aliased (partial alpha) ───────────────────
+
+    /// A4: The two angular edges of a ~90° arc must show partial alpha (anti-
+    /// aliased), not a hard step from 0 to 255.
+    ///
+    /// ## Red→green proof
+    ///
+    /// The OLD `angle_softness = 0.05` rad was a FIXED angular threshold: it
+    /// produced a smoothstep width that was ~0.05 rad ≈ 3° regardless of
+    /// resolution. At a radius of 40 px this width is 40 * 0.05 ≈ 2 pixels —
+    /// already incorrect (too wide at large radius, too narrow at small radius).
+    /// More critically, the old approach first computed a hard `in_arc` boolean
+    /// and then softened only the edges, so any pixel whose center angle fell
+    /// outside the sector got a hard `discard` before the softening.
+    ///
+    /// The NEW approach uses an angular half-plane SDF: `angular_sdf =
+    /// min(d_start, d_end)` for ≤180° sweeps, `max` for >180°. `fwidth` of
+    /// this distance gives ~1 device-px AA at any radius — the angular AA band
+    /// is as wide as the radial AA band, which is the correct behavior.
+    ///
+    /// Test: draw a 90° arc (radius=40) and scan pixels near the angular boundary
+    /// at start_angle=0 (the +X ray). The pixels immediately above and below the
+    /// start ray must have partial alpha — not 0 or 255.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index/coordinate arithmetic over a small fixed-size test surface"
+    )]
+    fn a4_arc_angular_edges_are_antialiased() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+        let radius = 40.0_f32;
+        // 90° arc, ROTATED 30° so its angular edges are DIAGONAL (not grid-aligned).
+        // A grid-aligned (axis) edge legitimately has no partial pixels — it falls
+        // on a pixel-row boundary so coverage is 0/1 between rows — so the angular
+        // AA can only be observed on a non-axis-aligned edge.
+        let start = 0.0_f32;
+        let sweep = std::f32::consts::FRAC_PI_2;
+        let rotation = PI / 6.0; // 30°
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.translate(flui_types::Offset::new(
+            flui_types::geometry::Pixels(cx),
+            flui_types::geometry::Pixels(cy),
+        ));
+        painter.rotate(rotation);
+        let rect = Rect::from_xywh(
+            flui_types::geometry::Pixels(-radius),
+            flui_types::geometry::Pixels(-radius),
+            px(radius * 2.0),
+            px(radius * 2.0),
+        );
+        painter.draw_arc(rect, start, sweep, true, &Paint::fill(Color::WHITE));
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("A4 Angular AA Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Count partial-alpha pixels along the two angular edges: a partial pixel
+        // in the annulus `5 <= dist < radius-2` can ONLY come from the angular-edge
+        // AA — the radial edge is excluded by the outer bound, and the APEX disk
+        // (`dist < 5`, where the pie tip is legitimately partial regardless of edge
+        // AA) is excluded by the inner bound so it cannot satisfy the count on its
+        // own. Rotation about the center preserves distance, so no inverse transform
+        // is needed. A hard-aliased angular edge produces ZERO such partials; smooth
+        // screen-space AA produces a ~1px band along each of the two diagonal edges.
+        let mut interior_partial = 0usize;
+        for row in 0..SURFACE_HEIGHT {
+            for col in 0..SURFACE_WIDTH {
+                let dx = col as f32 + 0.5 - cx;
+                let dy = row as f32 + 0.5 - cy;
+                let dist = (dx * dx + dy * dy).sqrt();
+                if dist < 5.0 || dist >= radius - 2.0 {
+                    continue; // skip the apex disk and the radial boundary band
+                }
+                let idx = row as usize * SURFACE_WIDTH as usize + col as usize;
+                let alpha = pixels[idx][3];
+                if alpha > 5 && alpha < 250 {
+                    interior_partial += 1;
+                }
+            }
+        }
+
+        assert!(
+            interior_partial >= 10,
+            "A4 FAILED: only {interior_partial} interior partial-alpha pixels (device dist < \
+             radius-2) — the angular sector edges are hard-aliased. The screen-space angular \
+             SDF + fwidth must produce a smooth ~1px band along each diagonal edge."
+        );
     }
 }

--- a/crates/flui-engine/src/wgpu/batches/shapes.rs
+++ b/crates/flui-engine/src/wgpu/batches/shapes.rs
@@ -605,20 +605,24 @@ impl DrawBatcher {
 
     /// Record a filled or stroked arc (pie-slice or arc segment).
     ///
-    /// # Instanced fast path
+    /// # Instanced path (PR-2b: full-affine reroute)
     ///
-    /// An axis-aligned, non-reflected, `SrcOver` filled arc is submitted as a
-    /// GPU `ArcInstance`. All other cases — rotation, shear, reflection (`det < 0`),
-    /// stroked arcs, or any non-`SrcOver` blend mode — fall through to the
-    /// tessellated path.
+    /// All SrcOver filled arcs — including rotated and skewed ones — are now
+    /// routed through the affine instanced SDF path, which uses:
+    ///   - fwidth-based radial AA (radius-independent ~1 device-px)
+    ///   - screen-space angular AA via half-plane SDFs (resolution-independent)
     ///
-    /// The **2-D determinant reflection guard** is preserved exactly:
-    /// `det = m.x_axis.x * m.y_axis.y − m.x_axis.y * m.y_axis.x`.
-    /// `det < 0` means the transform contains a reflection; the arc shader cannot
-    /// represent a reflected wedge, so tessellation is required even when the
-    /// transform is otherwise axis-aligned.
+    /// Reflection guard: `det < 0` means the transform contains a reflection,
+    /// which negates the sector direction in the shader (the angular half-planes
+    /// flip). Reflected arcs fall back to tessellation (PR-4 handles non-SrcOver).
     ///
-    /// `draw_arc` does not read opacity — no opacity baking is performed.
+    /// Non-SrcOver blend modes and stroked arcs remain tessellated (aliased)
+    /// until the SSAA tile path (PR-4).
+    ///
+    /// # Opacity
+    ///
+    /// Compositor layer opacity is folded into the color alpha before submission
+    /// (the instanced pipeline has no opacity uniform), mirroring `oval`/`circle`.
     #[allow(
         clippy::too_many_arguments,
         reason = "borrow-seam design: segment/draw_order/state are disjoint WgpuPainter fields \
@@ -629,6 +633,7 @@ impl DrawBatcher {
         segment: &mut DrawSegment,
         draw_order: &mut Vec<DrawItem>,
         state: &GpuStateStack,
+        opacity: f32,
         rect: Rect<Pixels>,
         start_angle: f32,
         sweep_angle: f32,
@@ -636,39 +641,54 @@ impl DrawBatcher {
         paint: &Paint,
     ) {
         let center = rect.center();
-        // Pixels / Pixels = f32 (dimensionless ratio)
-        let radius: f32 = (rect.width() + rect.height()) / px(4.0);
+        let rx = (rect.width() / 2.0).0;
+        let ry = (rect.height() / 2.0).0;
 
         if paint.style == PaintStyle::Fill {
-            // Filled arc (pie slice when use_center, arc segment when !use_center).
-            // Gate on axis-aligned transform: the arc instance shader only handles
-            // translation + axis-aligned scale; rotation/shear/reflection require
-            // tessellation.
-            //
-            // `is_axis_aligned` already rejects rotation and shear, but it also
-            // returns `true` for a reflection like `scale(-1, 1)` because the
-            // off-diagonal elements are still zero.  A reflection negates the wedge
-            // direction, which the instanced shader cannot represent.  Guard with the
-            // 2D determinant: det < 0 means the transform includes a reflection and
-            // the wedge would be drawn on the wrong side.
+            // Fold compositor layer opacity into the color alpha (the instanced
+            // pipeline has no opacity uniform), mirroring `rect`/`circle`/`oval`.
+            let color = if opacity < 1.0 {
+                let alpha = (f32::from(paint.color.a) * opacity) as u8;
+                flui_types::Color::rgba(paint.color.r, paint.color.g, paint.color.b, alpha)
+            } else {
+                paint.color
+            };
+
+            // Instanced affine SDF path conditions (else → tessellate, correct
+            // shape but aliased until PR-4):
+            // - SrcOver only — the instanced pipeline is hardcoded SrcOver; other
+            //   blend modes route through the tessellated Porter-Duff path.
+            // - `use_center` only — the SDF shader carves a PIE SECTOR through the
+            //   origin. A `use_center == false` arc is a circular SEGMENT (endpoints
+            //   joined by a straight chord, NOT through the center): a different
+            //   shape the shader does not model, so it must tessellate.
+            // - Non-reflected (`det >= 0`) — the angular sector is carved in local
+            //   space and mapped by M; the math handles reflection, but the
+            //   reflected path is untested, so we conservatively tessellate it.
             let m = state.current_transform();
             let det = m.x_axis.x * m.y_axis.y - m.x_axis.y * m.y_axis.x;
-            // The instanced fast path renders with a hardcoded SrcOver pipeline;
-            // a non-SrcOver blend mode must route through the tessellated path
-            // (which selects the blend pipeline via `pipeline_key_from_paint`).
-            if state.is_axis_aligned() && det >= 0.0 && paint.blend_mode == BlendMode::SrcOver {
-                // Fast path: GPU instancing for filled arcs.
-                let transformed_center = state.apply_transform(center);
-                let sx = (m.x_axis.x * m.x_axis.x + m.x_axis.y * m.x_axis.y).sqrt();
-                let sy = (m.y_axis.x * m.y_axis.x + m.y_axis.y * m.y_axis.y).sqrt();
-
-                let instance = super::super::instancing::ArcInstance::new(
-                    transformed_center,
-                    radius,
+            if paint.blend_mode == BlendMode::SrcOver && use_center && det >= 0.0 {
+                // Encode the arc as a unit circle under M_world * diag(rx, ry)
+                // (elliptical when rx != ry, mirroring `oval`). The center goes
+                // into transform_translate (never scaled by M). Angles parameterise
+                // the unit circle, so they map to Flutter's elliptical-arc angles.
+                let linear_cols = [
+                    m.x_axis.x * rx,
+                    m.x_axis.y * rx,
+                    m.y_axis.x * ry,
+                    m.y_axis.y * ry,
+                ];
+                // Translation: M_world * center_local + t_world.
+                let cx = center.x.0;
+                let cy = center.y.0;
+                let tx = m.x_axis.x * cx + m.y_axis.x * cy + m.w_axis.x;
+                let ty = m.x_axis.y * cx + m.y_axis.y * cy + m.w_axis.y;
+                let instance = super::super::instancing::ArcInstance::with_affine_transform(
+                    linear_cols,
                     start_angle,
                     sweep_angle,
-                    paint.color,
-                    [sx, sy],
+                    color,
+                    [tx, ty],
                 );
                 let _ = segment.arc_batch.add(instance);
                 DrawSegment::push_scissor_region(
@@ -676,23 +696,28 @@ impl DrawBatcher {
                     state.current_scissor(),
                 );
             } else {
-                // Slow path: rotation, shear, reflection, or non-SrcOver blend
-                // mode — tessellate in local space and bake the full transform
-                // into vertex positions.
+                // Slow path: non-pie (use_center=false segment), reflection, or
+                // non-SrcOver blend — tessellate in local space and bake the full
+                // transform into vertex positions.
                 //
-                // Phase-A quality note: uses the tessellated path → aliased edges
-                // (no SDF AA), AABB scissor clip. SDF-quality blended arcs are
-                // Phase B.
+                // Phase-A quality note: tessellated path → aliased edges.
+                // SDF-quality coverage for these lands in PR-4 (SSAA tile).
+                let fill_paint = Paint {
+                    color,
+                    style: PaintStyle::Fill,
+                    blend_mode: paint.blend_mode,
+                    ..Paint::default()
+                };
                 self.prime_tessellator_scale(state);
                 match self.tessellator.tessellate_arc(
                     rect,
                     start_angle,
                     sweep_angle,
                     use_center,
-                    paint,
+                    &fill_paint,
                 ) {
                     Ok((vertices, indices)) => {
-                        let key = pipeline::pipeline_key_from_paint(paint);
+                        let key = pipeline::pipeline_key_from_paint(&fill_paint);
                         Self::submit_transformed_geometry(
                             segment, draw_order, state, vertices, &indices, key,
                         );

--- a/crates/flui-engine/src/wgpu/instancing.rs
+++ b/crates/flui-engine/src/wgpu/instancing.rs
@@ -443,79 +443,128 @@ impl CircleInstance {
     }
 }
 
-/// Instance data for an arc (partial circle)
+/// Instance data for an arc (pie sector) rendered via the affine instanced SDF path.
 ///
-/// Used for progress indicators, pie charts, and other arc-based UI elements.
+/// ## Layout and affine design
+///
+/// Mirrors [`CircleInstance`]'s affine path: the vertex shader applies
+/// `device = M * local + t` where:
+/// - `M` is the 2×2 linear part stored column-major in `transform`:
+///   `[a, b, c, d]` → x-column `(a, b)`, y-column `(c, d)`.
+/// - `t` is the translation stored in `transform_translate.xy` — the device
+///   **center**, added AFTER M so the linear part never scales it (the PR-2
+///   double-scale fix applied to arcs).
+/// - `local` is `unit_pos` (origin-centered unit disk; the radius is folded into M).
+///
+/// ## Single (affine) path
+///
+/// Every SrcOver filled arc — axis-aligned or rotated — routes through
+/// [`ArcInstance::with_affine_transform`], which uses `center_radius = [0,0,1,0]`
+/// (unit circle at origin, radius folded into `transform`). `transform` encodes
+/// `M_world * r`:
+///   `linear = [M_w.a*r, M_w.b*r, M_w.c*r, M_w.d*r]`,
+///   `translate = M_w * center_local + t_w`.
+/// The axis-aligned case is just `M_world = diag(sx, sy)`, so a separate baked
+/// constructor is unnecessary.
+///
+/// The fragment evaluates `length(unit_pos) - 1.0` for radial AA and a
+/// screen-space angular SDF for the sector edges; `fwidth` gives ~1-device-px AA
+/// at any radius, scale, or rotation.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Zeroable)]
 pub struct ArcInstance {
-    /// Center point [x, y], radius, and padding [radius, _padding]
+    /// Always `[0, 0, 1, 0]`: unit circle at origin, radius folded into `transform`;
+    /// `.xy` unused (the center lives in `transform_translate`).
     pub center_radius: [f32; 4],
 
-    /// Angles in radians [start_angle, sweep_angle, _padding, _padding]
-    /// start_angle: where the arc begins (0 = right, π/2 = bottom, π = left,
-    /// 3π/2 = top) sweep_angle: how much to sweep (positive = clockwise,
-    /// negative = counter-clockwise)
+    /// Angles in radians `[start_angle, sweep_angle, 0, 0]`.
+    ///
+    /// `start_angle`: where the arc begins (0 = +X right, π/2 = +Y down, π = left).
+    /// `sweep_angle`: how much to sweep (positive = clockwise in screen Y-down space,
+    /// negative = counter-clockwise). A sweep of ±2π or larger means a full circle.
     pub angles: [f32; 4],
 
-    /// Color [r, g, b, a] in 0-1 range
+    /// Color `[r, g, b, a]` in linear 0–1 range.
     pub color: [f32; 4],
 
-    /// Transform (for elliptical arcs: scale_x, scale_y, translate_x,
-    /// translate_y)
+    /// 2×2 linear part of the affine transform, column-major:
+    /// `[a, b, c, d]` → x-column `(a, b)`, y-column `(c, d)`.
+    /// Encodes `M_world * r` (radius folded in); axis-aligned is `diag(sx, sy) * r`.
     pub transform: [f32; 4],
+
+    /// Translation: `[tx, ty, 0, 0]` = the device center `M_w * center_local + t_w`.
+    /// Added AFTER `M` in the shader, so the linear part never scales it.
+    /// The `.zw` lanes are padding for 16-byte vec4 alignment.
+    pub transform_translate: [f32; 4],
 }
 
 impl ArcInstance {
-    /// Create an arc instance.
+    // PR-2b: deleted `ArcInstance::new(center, radius, start, sweep, color, scale_xy)`
+    // (baked-AABB fast path for axis-aligned SrcOver arcs).
+    //
+    // All SrcOver filled arcs now route through `with_affine_transform` regardless
+    // of axis-alignment: the full-affine path is correct for both axis-aligned and
+    // rotated arcs. The old `new` constructor encoded `diag(sx,sy)` as the linear
+    // part and placed the pre-transformed center in `transform_translate` — the
+    // same semantics as `with_affine_transform` with `M_world = diag(sx,sy)` and
+    // `radius` folded separately. `with_affine_transform` handles this uniformly.
+    // Zero callers outside this crate; the unit test is updated below.
+
+    /// Create an arc instance for the full-affine SDF path.
     ///
-    /// `scale_xy` is the per-axis scale `[sx, sy]` extracted from the current
-    /// transform matrix.  Pass `[1.0, 1.0]` for identity / uniform scale.
-    /// The arc shader computes the bounding-quad half-extent as
-    /// `radius * scale_xy`, so non-unit values correctly handle a zoomed
-    /// or non-uniformly scaled canvas.
+    /// Use this for any SrcOver arc that needs rotation or non-uniform scale
+    /// (rotated arcs under a general world transform).
     ///
-    /// # Arguments
-    /// * `center` — Center point of the arc (already in transformed space)
-    /// * `radius` — Radius of the arc before scale is applied
-    /// * `start_angle` — Starting angle in radians (0 = right)
-    /// * `sweep_angle` — Sweep angle in radians (positive = clockwise)
-    /// * `color` — Arc color
-    /// * `scale_xy` — Per-axis canvas scale `[sx, sy]`
+    /// The unit circle at origin is the canonical local shape: `center_radius =
+    /// [0, 0, 1, 0]`. The vertex shader applies `device = M * unit_pos * 1 + t`
+    /// and passes `unit_pos` to the fragment, which evaluates the radial and
+    /// angular SDFs — correct for any affine (fwidth gives ~1-device-px AA).
+    ///
+    /// `linear_cols` encodes `M_world * r` column-major `[a, b, c, d]`:
+    ///   `linear = [M_w.a*r, M_w.b*r, M_w.c*r, M_w.d*r]`
+    ///
+    /// `translation` is `[tx, ty]` = `M_w * center_local + t_w` in device pixels.
     #[must_use]
-    pub fn new(
-        center: Point<Pixels>,
-        radius: f32,
+    pub fn with_affine_transform(
+        linear_cols: [f32; 4],
         start_angle: f32,
         sweep_angle: f32,
         color: Color,
-        scale_xy: [f32; 2],
+        translation: [f32; 2],
     ) -> Self {
         Self {
-            center_radius: [center.x.0, center.y.0, radius, 0.0],
+            // Unit circle at local origin; the affine encodes radius + world transform.
+            center_radius: [0.0, 0.0, 1.0, 0.0],
             angles: [start_angle, sweep_angle, 0.0, 0.0],
             color: color.to_f32_array(),
-            transform: [scale_xy[0], scale_xy[1], 0.0, 0.0],
+            transform: linear_cols,
+            transform_translate: [translation[0], translation[1], 0.0, 0.0],
         }
     }
 
-    // Cycle 4 E-5: deleted `ArcInstance::ellipse(center, radius_x,
-    // radius_y, start_angle, sweep_angle, color)`. Zero call sites —
-    // production paths use `ArcInstance::new` with scale_xy.
-    // Re-lands with a concrete consumer when needed.
+    // Cycle 4 E-5: deleted `ArcInstance::ellipse(...)` (zero call sites).
+    // Re-lands with a concrete consumer when needed. All SrcOver arcs now use
+    // `with_affine_transform`; an elliptical arc folds `M_world * diag(rx, ry)`
+    // into `linear_cols` (mirroring `oval`).
 
-    /// Get wgpu vertex buffer layout for instance data
+    /// Get wgpu vertex buffer layout for instance data.
+    ///
+    /// Locations 2–5 are unchanged from the pre-PR-2b layout. Location 6 is the
+    /// new `transform_translate` field appended at the end of the struct;
+    /// appending keeps all existing field offsets byte-identical.
     #[must_use]
     pub fn desc() -> wgpu::VertexBufferLayout<'static> {
         const ATTRIBUTES: &[wgpu::VertexAttribute] = &wgpu::vertex_attr_array![
-            // Center + radius (location 2)
+            // Center + radius [0, 0, radius, _] (location 2)
             2 => Float32x4,
-            // Angles (location 3)
+            // Angles [start, sweep, 0, 0] (location 3)
             3 => Float32x4,
-            // Color (location 4)
+            // Color [r, g, b, a] (location 4)
             4 => Float32x4,
-            // Transform (location 5)
+            // 2×2 linear affine [a, b, c, d] column-major (location 5)
             5 => Float32x4,
+            // Affine translation [tx, ty, 0, 0] (location 6)
+            6 => Float32x4,
         ];
 
         wgpu::VertexBufferLayout {
@@ -897,11 +946,14 @@ mod tests {
 
     #[test]
     fn test_arc_instance_size() {
-        // Verify struct is tightly packed for GPU
-        assert_eq!(
-            std::mem::size_of::<ArcInstance>(),
-            16 * 4 // 16 floats = 64 bytes
-        );
+        // ArcInstance field layout (all #[repr(C)], tightly packed):
+        //   center_radius:       [f32; 4]  = 16 bytes
+        //   angles:              [f32; 4]  = 16 bytes
+        //   color:               [f32; 4]  = 16 bytes
+        //   transform:           [f32; 4]  = 16 bytes  ← 2×2 linear affine
+        //   transform_translate: [f32; 4]  = 16 bytes  ← appended for affine path
+        //   Total: 80 bytes
+        assert_eq!(std::mem::size_of::<ArcInstance>(), 80);
     }
 
     #[test]
@@ -1182,21 +1234,92 @@ mod tests {
         assert_eq!(instance.transform_translate[3], 0.0, "pad.w");
     }
 
-    /// Regression: ArcInstance::new must propagate scale_xy into the transform
-    /// field so the arc shader sizes the bounding quad correctly.
-    /// Before the fix, transform was always [1.0, 1.0, 0.0, 0.0].
+    /// `ArcInstance::with_affine_transform` encodes the baked axis-aligned path
+    /// via `diag(sx*r, sy*r)` in the 2×2 transform field and carries the device
+    /// center in `transform_translate` (so M never double-scales it).
+    ///
+    /// The old `ArcInstance::new` baked-fast-path stored `[sx, sy, 0, 0]` in
+    /// `transform` (a flat 4-float encode). The PR-2b col-major layout
+    /// `[sx*r, 0, 0, sy*r]` = `diag(sx*r, sy*r)` is equivalent under identity
+    /// rotation and correctly composes with non-unit canvas scale + rotation.
     #[test]
     fn arc_instance_scale_propagates_to_transform() {
-        use flui_types::{Point, geometry::Pixels};
-        let center = Point::new(Pixels(0.0), Pixels(0.0));
-        let identity = ArcInstance::new(center, 10.0, 0.0, 1.0, Color::RED, [1.0, 1.0]);
-        assert_eq!(identity.transform[0], 1.0, "identity sx");
-        assert_eq!(identity.transform[1], 1.0, "identity sy");
+        // Simulate the shapes.rs baked-path encoding: axis-aligned scale(2,2),
+        // center at device (12,34), radius 10.
+        // Translation: M_world * center_local + t_world = diag(2,2)*[6,17]+[0,0] = [12,34].
+        // linear_cols = [sx*r, 0, 0, sy*r] = [2*10, 0, 0, 2*10] = [20, 0, 0, 20].
+        let sx = 2.0_f32;
+        let sy = 2.0_f32;
+        let r = 10.0_f32;
+        let tx = 12.0_f32;
+        let ty = 34.0_f32;
 
-        let scaled = ArcInstance::new(center, 10.0, 0.0, 1.0, Color::RED, [2.5, 3.0]);
-        assert_eq!(scaled.transform[0], 2.5, "scaled sx");
-        assert_eq!(scaled.transform[1], 3.0, "scaled sy");
-        assert_eq!(scaled.transform[2], 0.0, "translate_x always 0");
-        assert_eq!(scaled.transform[3], 0.0, "translate_y always 0");
+        let identity = ArcInstance::with_affine_transform(
+            [1.0 * r, 0.0, 0.0, 1.0 * r], // diag(1,1)*r = identity scale
+            0.0,
+            1.0,
+            Color::RED,
+            [tx, ty],
+        );
+        // diag(1*r,1*r): x-col=(r,0), y-col=(0,r)
+        assert_eq!(identity.transform, [r, 0.0, 0.0, r], "identity diag × r");
+        // Center carried in transform_translate (NOT scaled by M).
+        assert_eq!(identity.transform_translate[0], tx, "tx = center x");
+        assert_eq!(identity.transform_translate[1], ty, "ty = center y");
+        assert_eq!(identity.transform_translate[2], 0.0, "pad z");
+        assert_eq!(identity.transform_translate[3], 0.0, "pad w");
+        // center_radius.xy unused; .z is the unit-circle radius (1).
+        assert_eq!(identity.center_radius[0], 0.0, "cx unused");
+        assert_eq!(identity.center_radius[1], 0.0, "cy unused");
+        assert_eq!(identity.center_radius[2], 1.0, "unit radius");
+
+        let scaled = ArcInstance::with_affine_transform(
+            [sx * r, 0.0, 0.0, sy * r], // diag(sx,sy)*r
+            0.0,
+            1.0,
+            Color::RED,
+            [tx, ty],
+        );
+        // diag(sx*r, sy*r): x-col=(sx*r,0), y-col=(0,sy*r)
+        assert_eq!(scaled.transform, [sx * r, 0.0, 0.0, sy * r], "scaled diag");
+        // Center is still the raw device center — diag(sx*r,sy*r) must NOT scale it.
+        assert_eq!(scaled.transform_translate[0], tx, "tx unscaled by sx");
+        assert_eq!(scaled.transform_translate[1], ty, "ty unscaled by sy");
+    }
+
+    /// `ArcInstance::with_affine_transform` must store a unit circle at origin
+    /// and round-trip the caller's linear + translate without mangling.
+    #[test]
+    fn arc_with_affine_transform_stores_unit_circle_and_affine() {
+        let cos30 = std::f32::consts::FRAC_PI_6.cos();
+        let sin30 = std::f32::consts::FRAC_PI_6.sin();
+        let r = 20.0_f32;
+        // CW screen rotation × radius r: x-col=(cos,-sin)*r, y-col=(sin,cos)*r.
+        let linear = [cos30 * r, -sin30 * r, sin30 * r, cos30 * r];
+        let translation = [64.0_f32, 64.0_f32];
+
+        let instance = ArcInstance::with_affine_transform(
+            linear,
+            0.5,  // start_angle
+            1.57, // sweep_angle
+            Color::BLUE,
+            translation,
+        );
+
+        // center_radius must be the unit circle at origin.
+        assert_eq!(instance.center_radius[0], 0.0, "cx=0");
+        assert_eq!(instance.center_radius[1], 0.0, "cy=0");
+        assert_eq!(instance.center_radius[2], 1.0, "radius=1 (unit circle)");
+        assert_eq!(instance.center_radius[3], 0.0, "padding");
+        // Angles round-trip.
+        assert_eq!(instance.angles[0], 0.5, "start_angle");
+        assert_eq!(instance.angles[1], 1.57, "sweep_angle");
+        // Linear stored verbatim.
+        assert_eq!(instance.transform, linear, "linear 2×2 round-trip");
+        // Translation stored in xy; zw are padding.
+        assert_eq!(instance.transform_translate[0], 64.0, "tx");
+        assert_eq!(instance.transform_translate[1], 64.0, "ty");
+        assert_eq!(instance.transform_translate[2], 0.0, "pad.z");
+        assert_eq!(instance.transform_translate[3], 0.0, "pad.w");
     }
 }

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -756,10 +756,12 @@ impl WgpuPainter {
             paint
         );
 
+        let opacity = self.compositor.current_opacity();
         self.batcher.draw_arc(
             &mut self.current_segment,
             &mut self.draw_order,
             &self.state,
+            opacity,
             rect,
             start_angle,
             sweep_angle,

--- a/crates/flui-engine/src/wgpu/shaders/arc_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/arc_instanced.wgsl
@@ -1,41 +1,124 @@
-// Instanced arc shader for FLUI
+// Instanced arc shader for FLUI (SDF-based, full-affine transform).
 //
-// Renders multiple arcs (partial circles) in a single draw call using GPU instancing.
-// Each instance contains: center, radius, angles (start, sweep), color, and transform.
+// Renders arcs (pie-slice sectors of a unit circle) in a single draw call via
+// GPU instancing. Each instance carries: a 2×3 affine (2×2 linear + device
+// center in the translation), start/sweep angles, and color.
 //
-// Performance: 100 arcs = 1 draw call (vs 100 without instancing)
+// ## Affine transform design (mirrors circle_instanced.wgsl)
+//
+// The vertex shader applies a full 2×3 affine to an ORIGIN-CENTERED unit disk:
+//
+//   local_pos  = unit_pos * radius                  // unit_pos ∈ [-1,1]², origin-centered
+//   M          = mat2x2(transform.xy, transform.zw) // column-major 2×2
+//   device     = M * local_pos + transform_translate.xy
+//
+// The device CENTER lives in `transform_translate` (added after M), so M never
+// scales it — same contract as circle_instanced (the PR-2 double-scale fix).
+//
+// For the baked fast path (axis-aligned SrcOver arcs):
+//   center_radius       = [0, 0, radius, 0]
+//   transform           = diag(sx, sy)
+//   transform_translate = [cx_dev, cy_dev, 0, 0]
+//   → device = diag(sx,sy) * (unit*radius) + center_dev
+//
+// For the affine path (rotated SrcOver arcs):
+//   center_radius       = [0, 0, 1, 0]   (unit circle, radius folded into M)
+//   transform           = M_world * r     (col-major [a,b,c,d])
+//   transform_translate = M_world * center_local + t_world
+//
+// ## Radial AA (fwidth — radius-independent)
+//
+// Previous shader used `edge_softness = 0.02` (radius-RELATIVE — wrong).
+// New model: `d_r = length(unit_pos) - 1.0`, `aa_r = fwidth(d_r) * 0.5`.
+// `fwidth(d_r)` measures the screen-space derivative of the unit-circle SDF,
+// yielding ~1 device-px AA at ANY radius, rotation, or anisotropic scale.
+//
+// ## Angular AA (screen-space fwidth — resolution-independent)
+//
+// Previous shader used `angle_softness = 0.05` rad (fixed ~3° — wrong at any
+// but one radius). New model uses an SDF of the two radial half-planes that
+// bound the sector:
+//
+// The signed distance to each bounding half-plane is the 2D cross product of
+// the edge ray with the query point (positive on the swept/inside side):
+//
+//   start_dir = (cos(start), sin(start))   [the ray at the start edge]
+//   The inside of the sector is on the swept side of start_dir, where
+//   cross(start_dir, unit_pos) ≥ 0:
+//   d_start = cross(start_dir, unit_pos)
+//           = start_dir.x*unit_pos.y - start_dir.y*unit_pos.x
+//           = cos(start)*py - sin(start)*px
+//
+//   The sector ends at end_angle; the point must be on the opposite (right) side
+//   of end_dir to still be inside:
+//   d_end = -cross(end_dir, unit_pos) = sin(end)*px - cos(end)*py
+//
+// For a positive sweep (sweep > 0): inside = d_start ≥ 0 AND d_end ≥ 0
+//   → angular_sdf = min(d_start, d_end)   (intersection of two half-planes)
+//
+// For sweep ≥ 2π (full circle): no angular cut — degrade to purely radial.
+//
+// For a sweep > π (the arc is the MAJORITY half — MORE than a semicircle):
+//   The two half-planes' INTERSECTION is no longer the correct inside region;
+//   the inside is actually the UNION: angular_sdf = max(d_start, d_end).
+//   This is because for a 270° arc, a point at angle 180° is inside both the
+//   "swept side of start" and "swept side of end" individually, so max works.
+//
+// For negative sweep (counter-clockwise): flip sign of both d_start and d_end.
+//
+// `fwidth` of the resulting angular_sdf gives screen-space ~1 device-px AA
+// at the sector edges at ANY radius or scale.
+//
+// ## Outer-fringe quad expansion
+//
+// The quad is expanded ~1.5 device-px outward so the outer AA fringe rasterizes.
+// Margin is computed in LOCAL units = 1.5 / (radius * column_length) — same
+// formula as circle_instanced.
+//
+// ## AA model improvement over previous arc shader
+//
+// - Radial: `edge_softness=0.02` (radius-relative) → `fwidth(dist)` (radius-independent).
+// - Angular: `angle_softness=0.05` rad (fixed ~3°) → `fwidth(angular_sdf)` (~1px device).
+// - No fixed `angle_softness` threshold remains.
+// - The `in_arc` boolean + angular smoothstep is replaced by a signed-distance
+//   approach that computes continuous partial-alpha at the sector edges.
 
-// Vertex input (shared unit quad: [-1,-1] to [1,1])
+// ────────────────────────────────────────────────────────────────────────────
+
 struct VertexInput {
-    @location(0) position: vec2<f32>,  // Quad corner [-1 to 1]
+    @location(0) position: vec2<f32>,  // Quad corner [0 to 1]
 }
 
-// Instance input (per-arc data)
 struct InstanceInput {
-    @location(2) center_radius: vec4<f32>,  // [x, y, radius, _padding]
-    @location(3) angles: vec4<f32>,         // [start_angle, sweep_angle, _padding, _padding]
-    @location(4) color: vec4<f32>,          // [r, g, b, a] in 0-1 range
-    @location(5) transform: vec4<f32>,      // [scale_x, scale_y, translate_x, translate_y]
+    @location(2) center_radius: vec4<f32>,      // [0, 0, radius, 0]
+    @location(3) angles: vec4<f32>,             // [start_angle, sweep_angle, 0, 0]
+    @location(4) color: vec4<f32>,              // [r, g, b, a] in 0-1 range
+    @location(5) transform: vec4<f32>,          // 2×2 linear affine col-major: [a, b, c, d]
+    @location(6) transform_translate: vec4<f32>,// [tx, ty, 0, 0] — device center
 }
 
-// Vertex output / Fragment input
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) color: vec4<f32>,
-    @location(1) local_pos: vec2<f32>,      // Position relative to arc center [-1 to 1]
-    @location(2) radius: f32,               // Arc radius (for anti-aliasing)
-    @location(3) start_angle: f32,          // Start angle in radians
-    @location(4) sweep_angle: f32,          // Sweep angle in radians
+    // Unit-disk coordinate: `unit_pos = expanded_unit_quad * 2 - 1`, scaled by
+    // the fringe expansion. SDF evaluates `length(unit_pos) - 1.0`. Passed to
+    // the fragment so `fwidth` measures the screen-space derivative correctly.
+    @location(1) unit_pos: vec2<f32>,
+    @location(2) start_angle: f32,
+    @location(3) sweep_angle: f32,
 }
 
-// Viewport uniform (for screen-space to clip-space conversion)
 struct Viewport {
-    size: vec2<f32>,      // Viewport size in pixels
+    size: vec2<f32>,
     _padding: vec2<f32>,
 }
 
 @group(0) @binding(0)
 var<uniform> viewport: Viewport;
+
+// =============================================================================
+// Vertex Shader
+// =============================================================================
 
 @vertex
 fn vs_main(
@@ -44,123 +127,155 @@ fn vs_main(
 ) -> VertexOutput {
     var out: VertexOutput;
 
-    let center = instance.center_radius.xy;
     let radius = instance.center_radius.z;
 
-    // Convert unit quad [0,1] to [-1,1] range for arc SDF
-    let centered_pos = vertex.position * 2.0 - 1.0;
-
-    // Transform to arc bounding box
-    let local_pos = centered_pos * vec2<f32>(
-        radius * instance.transform.x,
-        radius * instance.transform.y
+    // Map the unit quad [0,0]–[1,1] to the unit-disk local space [-1,1]²,
+    // expanded outward by a ~1.5 device-px AA fringe — mirrors circle_instanced.
+    //
+    // Margin in LOCAL units = 1.5 / (radius * column_length), so the fringe
+    // stays ~1.5 device-px at any zoom / scale.
+    let fringe_device = 1.5;
+    let col0_len = length(instance.transform.xy); // |x-column|
+    let col1_len = length(instance.transform.zw); // |y-column|
+    let r_safe = max(radius, 1e-6);
+    let margin_unit = vec2<f32>(
+        fringe_device / max(col0_len * r_safe, 1e-6),
+        fringe_device / max(col1_len * r_safe, 1e-6),
     );
+    // Expand the [-1,1] quad to [-(1+e), 1+e].
+    let base_unit = vertex.position * 2.0 - 1.0; // [-1, 1]
+    let exp_unit  = base_unit * (1.0 + margin_unit); // [-(1+e), 1+e]
 
-    let world_pos = center + local_pos + instance.transform.zw;
+    // Local-space position: the expanded unit coord scaled by radius,
+    // ORIGIN-centered. The device CENTER is in `transform_translate` (added
+    // AFTER M below) so it is never scaled by M.
+    let local_pos = exp_unit * r_safe;
 
-    // Convert to clip space [-1, 1]
-    let clip_x = (world_pos.x / viewport.size.x) * 2.0 - 1.0;
-    let clip_y = 1.0 - (world_pos.y / viewport.size.y) * 2.0;
+    // Apply the full 2×3 affine: device = M * local + t.
+    // transform = [a, b, c, d] column-major: x-col=(a,b), y-col=(c,d).
+    let m = mat2x2<f32>(
+        instance.transform.xy,  // x-column (a, b)
+        instance.transform.zw,  // y-column (c, d)
+    );
+    let device_pos = m * local_pos + instance.transform_translate.xy;
+
+    // Convert device pixels to clip space [-1, 1].
+    let clip_x = (device_pos.x / viewport.size.x) * 2.0 - 1.0;
+    let clip_y = 1.0 - (device_pos.y / viewport.size.y) * 2.0; // flip Y
 
     out.position = vec4<f32>(clip_x, clip_y, 0.0, 1.0);
     out.color = instance.color;
-    out.local_pos = centered_pos; // [-1 to 1] range
-    out.radius = radius;
+    // Pass the EXPANDED unit coord to the fragment. The SDF evaluates
+    // `length(unit_pos) - 1.0` relative to the true unit-circle edge
+    // even on the expanded fringe.
+    out.unit_pos    = exp_unit;
     out.start_angle = instance.angles.x;
     out.sweep_angle = instance.angles.y;
 
     return out;
 }
 
+// =============================================================================
+// Fragment Shader
+// =============================================================================
+
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    // Calculate distance from arc center
-    let dist = length(in.local_pos);
+    let unit_pos = in.unit_pos;
+    let start    = in.start_angle;
+    let sweep    = in.sweep_angle;
 
-    // Arc edge at distance = 1.0 (unit circle in local space)
-    // Smooth anti-aliasing using smoothstep
-    let edge_softness = 0.02; // 2% of radius for smooth edge
-    var alpha = 1.0 - smoothstep(1.0 - edge_softness, 1.0 + edge_softness, dist);
+    // ── Radial SDF (fwidth-based, radius-independent) ─────────────────────
+    //
+    // Signed distance to the unit-circle edge:
+    //   d < 0 → inside the circle
+    //   d = 0 → on the edge
+    //   d > 0 → outside
+    // `fwidth(d)` gives ~1 device-px AA at ANY radius, rotation, or scale.
+    let d_radial = length(unit_pos) - 1.0;
+    let aa_radial = fwidth(d_radial) * 0.5;
+    let radial_alpha = 1.0 - smoothstep(-aa_radial, aa_radial, d_radial);
 
-    // Discard pixels outside circle radius
-    if (alpha < 0.01) {
+    // Discard pixels fully outside the circle (fringe expansion safety).
+    if radial_alpha < 0.001 {
         discard;
     }
 
-    // Calculate angle of current pixel
-    // atan2(y, x) returns angle from -π to π
-    // We need to convert local_pos to angle
-    let pixel_angle = atan2(in.local_pos.y, in.local_pos.x);
-
-    // Normalize angles to [0, 2π] range
-    let start = in.start_angle;
-    let sweep = in.sweep_angle;
-
-    // Handle angle wrapping
-    // Convert pixel angle to [0, 2π] range
-    var normalized_pixel = pixel_angle;
-    if (normalized_pixel < 0.0) {
-        normalized_pixel = normalized_pixel + 6.28318530718; // + 2π
+    // ── Angular SDF (screen-space fwidth, sector half-planes) ────────────
+    //
+    // Full-circle shortcut: |sweep| ≥ 2π → no angular cut, pure circle.
+    let tau = 6.28318530718; // 2π
+    let abs_sweep = abs(sweep);
+    if abs_sweep >= tau {
+        return vec4<f32>(in.color.rgb, in.color.a * radial_alpha);
     }
 
-    // Convert start angle to [0, 2π] range
-    var normalized_start = start;
-    if (normalized_start < 0.0) {
-        normalized_start = normalized_start + 6.28318530718;
+    // Angular SDF design (positive sweep, screen Y-down):
+    //
+    //   start_dir = (cos(start), sin(start))    [the ray at the start edge]
+    //   end_dir   = (cos(end), sin(end))         where end = start + sweep
+    //
+    // We want d_start ≥ 0 for points on the swept (inside) side of the start ray.
+    // Using the 2D cross product of start_dir with unit_pos:
+    //   cross(start_dir, P) = cos(start)*P.y - sin(start)*P.x
+    // Positive cross = P is to the LEFT of start_dir.
+    // For a positive-sweep (CW in screen coords) arc the inside is to the
+    // LEFT of start → d_start = cos(start)*P.y - sin(start)*P.x.
+    //
+    // For the end edge the inside is to the RIGHT:
+    //   d_end = -(cos(end)*P.y - sin(end)*P.x) = sin(end)*P.x - cos(end)*P.y
+    //
+    // For |sweep| ≤ π the inside is the INTERSECTION (both d ≥ 0):
+    //   angular_sdf = min(d_start, d_end)
+    //
+    // For |sweep| > π the inside is the UNION (at least one d ≥ 0):
+    //   angular_sdf = max(d_start, d_end)
+    //
+    // For negative sweep (CCW): flip both — equivalently negate unit_pos's
+    // angular frame. We handle this by swapping start/end when sweep < 0
+    // (equivalent to reflecting the problem into the positive-sweep case).
+    let end_angle = start + sweep;
+
+    // For negative sweep, treat as a positive-sweep arc from end→start.
+    var a0 = start;
+    var a1 = end_angle;
+    if sweep < 0.0 {
+        a0 = end_angle;
+        a1 = start;
     }
 
-    // Calculate end angle
-    var end_angle = normalized_start + sweep;
+    // Signed distances from each bounding half-plane.
+    // d0 ≥ 0 → point is on the swept side of the a0 edge.
+    // d1 ≥ 0 → point is on the swept side of the a1 edge.
+    let d_start_hp = cos(a0) * unit_pos.y - sin(a0) * unit_pos.x;
+    let d_end_hp   = sin(a1) * unit_pos.x - cos(a1) * unit_pos.y;
 
-    // Check if pixel is within arc sweep
-    var in_arc = false;
+    // Effective positive sweep angle (already normalized to ≥ 0 by the swap above).
+    let pos_sweep = abs_sweep;
 
-    if (sweep > 0.0) {
-        // Clockwise sweep
-        if (end_angle > 6.28318530718) {
-            // Arc wraps around 2π
-            in_arc = (normalized_pixel >= normalized_start) || (normalized_pixel <= (end_angle - 6.28318530718));
-        } else {
-            in_arc = (normalized_pixel >= normalized_start) && (normalized_pixel <= end_angle);
-        }
+    var angular_sdf: f32;
+    if pos_sweep <= 3.14159265358979 {
+        // ≤ 180°: sector is the INTERSECTION of both half-planes.
+        angular_sdf = min(d_start_hp, d_end_hp);
     } else {
-        // Counter-clockwise sweep
-        end_angle = normalized_start + sweep;
-        if (end_angle < 0.0) {
-            // Arc wraps around 0
-            in_arc = (normalized_pixel <= normalized_start) || (normalized_pixel >= (end_angle + 6.28318530718));
-        } else {
-            in_arc = (normalized_pixel <= normalized_start) && (normalized_pixel >= end_angle);
-        }
+        // > 180°: sector is the UNION (either half-plane suffices).
+        angular_sdf = max(d_start_hp, d_end_hp);
     }
 
-    // Discard pixels outside arc sweep with smooth edges
-    if (!in_arc) {
+    // Screen-space AA width for the angular edge: ~1 device-px.
+    let aa_angular = fwidth(angular_sdf) * 0.5;
+    let angular_alpha = smoothstep(-aa_angular, aa_angular, angular_sdf);
+
+    // Discard pixels fully outside the angular sector.
+    if angular_alpha < 0.001 {
         discard;
     }
 
-    // Apply smooth edge anti-aliasing to arc boundaries
-    let angle_softness = 0.05; // ~3 degrees
-    var edge_alpha = 1.0;
-
-    // Distance to start edge
-    var dist_to_start = abs(normalized_pixel - normalized_start);
-    if (dist_to_start > 3.14159265359) {
-        dist_to_start = 6.28318530718 - dist_to_start; // Handle wrap-around
+    // ── Combine ───────────────────────────────────────────────────────────
+    let alpha = radial_alpha * angular_alpha;
+    if alpha < 0.001 {
+        discard;
     }
 
-    // Distance to end edge
-    var dist_to_end = abs(normalized_pixel - end_angle);
-    if (dist_to_end > 3.14159265359) {
-        dist_to_end = 6.28318530718 - dist_to_end; // Handle wrap-around
-    }
-
-    // Smooth edges at arc start and end
-    let min_edge_dist = min(dist_to_start, dist_to_end);
-    if (min_edge_dist < angle_softness) {
-        edge_alpha = min_edge_dist / angle_softness;
-    }
-
-    // Multiply alpha with color alpha and edge alpha
-    return vec4<f32>(in.color.rgb, in.color.a * alpha * edge_alpha);
+    return vec4<f32>(in.color.rgb, in.color.a * alpha);
 }


### PR DESCRIPTION
## Tessellated AA — PR-2b (arc)

Completes the SDF-reroute family of the engine-wide AA series (after [#258](https://github.com/vanyastaff/flui/pull/258) rect/rrect, [#259](https://github.com/vanyastaff/flui/pull/259) circle/oval). Spec: `.rust-studio/specs/tessellated-aa/SPEC.md`.

### What this PR does
Reroutes SrcOver **pie-sector arcs** through the instanced arc path extended to a **full 2×3 affine**, with screen-space `fwidth` **radial** AA (replacing `edge_softness=0.02`) and a screen-space **angular** SDF (two sector half-planes; replacing the fixed `angle_softness=0.05` rad).

- `ArcInstance` carries a full 2×2 linear + appended `transform_translate` (device center, never inside the local vector — the PR-2 double-scale fix; **A3** guards it).
- `arc_instanced.wgsl`: origin-centered unit disk, `device = M·(unit·r)+center`; radial `d = length(unit_pos)-1` with `fwidth` AA; angular sector via half-plane SDFs — `min(d_start,d_end)` for `|sweep|≤π`, `max` for `>π`, full-circle skip at `|sweep|≥2π`, start/end swap for negative sweep. Angular AA = `fwidth(angular_sdf)` → ~1px at any radius.
- `draw_arc` threads compositor opacity (was ignored) and routes **only pie sectors** (`use_center`) through the instanced path; **chord segments** (`use_center=false`), **reflected**, and **non-SrcOver** arcs tessellate (correct shape, aliased until PR-4).
- **Elliptical arcs** fold `M_world·diag(rx,ry)` (mirroring `oval`) — a non-square rect no longer collapses to a mean-radius circle.
- Oracle tests **A1** (radial radius-independence), **A2** (rotated 270° orientation/fill), **A3** (scaled center not double-scaled), **A4** (rotated arc → interior angular-edge partials, apex disk excluded), + a CPU seam test at `sweep=π`.

### Review (rust-reviewer + ce-kieran)
The angular half-plane classification was **numerically verified** to match the CPU oracle across the full start/sweep range (the `>π` union is exact; no min/max-crease seam artifact). Two issues were **caught and fixed before commit**:
- A **doc-CI break** — stale `[ArcInstance::new]` intra-doc links to the deleted constructor would have failed `cargo doc -D warnings` (the gate I now run).
- The **`use_center=false` and elliptical-arc shape regressions** that the widened instanced gate exposed (pre-existing for axis-aligned; this PR routes both to tessellation / folds `diag(rx,ry)` so they render the correct shape).

### Scope / deferrals
Non-SrcOver, reflected, and `use_center=false` (chord-segment) arcs stay tessellated (correct shape, aliased) pending the SSAA path (PR-4). Byte-identity is intentionally **not** claimed for arcs (AA model improved).

### Verification
- `clippy` (default **and** `--features enable-wgpu-tests`, `-D warnings`) clean · `fmt` · `cargo doc -D warnings` · `cargo test --lib` 158
- **DX12 GPU-readback: 312 passed / 0 failed / 7 ignored** (incl. Phase B + PR-1/PR-2 suites — no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)