### PR TITLE
feat(engine): tessellated AA — SSAA-offscreen AA for arbitrary SrcOver paths (tessellated-AA PR-3)

### DIFF
--- a/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
+++ b/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
@@ -2222,6 +2222,511 @@ mod gpu_tests {
         );
     }
 
+    // ── P1–P4: SSAA path anti-aliasing (PR-3) ────────────────────────────────
+
+    // ── CPU oracle helpers for polygon tests ─────────────────────────────────
+
+    /// Half-plane inside-test for a single edge from `a` to `b`.
+    ///
+    /// Returns `true` when `p` is on the left side (positive cross-product)
+    /// of the directed edge `a→b`.  Used by `inside_triangle` / `inside_polygon`.
+    fn half_plane_inside(px: f32, py: f32, ax: f32, ay: f32, bx: f32, by: f32) -> bool {
+        (bx - ax) * (py - ay) - (by - ay) * (px - ax) >= 0.0
+    }
+
+    /// Analytic inside-test for a CW-oriented triangle (a, b, c) in device coords.
+    ///
+    /// Uses three half-plane tests.  The winding order must be consistent —
+    /// either all CCW or all CW — so that the signs agree.  The oracle
+    /// tests both orientations and accepts if either fires.
+    #[allow(clippy::too_many_arguments)]
+    fn inside_triangle(
+        px: f32,
+        py: f32,
+        ax: f32,
+        ay: f32,
+        bx: f32,
+        by: f32,
+        cx: f32,
+        cy: f32,
+    ) -> bool {
+        // Try CCW orientation.
+        let ccw = half_plane_inside(px, py, ax, ay, bx, by)
+            && half_plane_inside(px, py, bx, by, cx, cy)
+            && half_plane_inside(px, py, cx, cy, ax, ay);
+        // Try CW orientation (flip edge directions).
+        let cw = half_plane_inside(px, py, bx, by, ax, ay)
+            && half_plane_inside(px, py, cx, cy, bx, by)
+            && half_plane_inside(px, py, ax, ay, cx, cy);
+        ccw || cw
+    }
+
+    // ── P1: polygon fill boundary pixels have partial alpha (real SSAA AA) ────
+
+    /// P1: A SrcOver-filled triangle path must have partial-alpha pixels on its
+    /// boundary (analytic oracle says so) — proving SSAA produces real AA, not
+    /// binary hard-aliased output.
+    ///
+    /// ## Red→green proof
+    ///
+    /// Without the SSAA reroute, a tessellated triangle would be drawn with
+    /// `shape.wgsl` / `ALPHA_BLENDING` and no SDF distance field — producing
+    /// hard-aliased edges (every boundary pixel is either fully covered or not,
+    /// giving alpha ∈ {0, 255} at the edge).  With the SSAA reroute the
+    /// 2×-supersampled render resolves sub-pixel edge crossings and the boundary
+    /// band has partial alpha values.
+    ///
+    /// Test: render a ~70×50 triangle centered in the 128² surface.  The oracle
+    /// identifies boundary pixels (0 < coverage < 1).  After SSAA rendering all
+    /// of those pixels must carry partial alpha (> 5, < 250) — the strict
+    /// majority (>50%) guarantees the assertion cannot be vacuous.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index/coordinate arithmetic over a small fixed-size test surface"
+    )]
+    fn p1_ssaa_polygon_boundary_has_partial_alpha() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        // A triangle off-axis so its edges are not pixel-row/column aligned.
+        // Device-space vertices (centered in the 128² surface, intentionally
+        // non-axis-aligned so every edge produces boundary pixels).
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+        // Equilateral-ish triangle: apex top-center, base at bottom.
+        let ax = cx;
+        let ay = cy - 40.0;
+        let bx = cx + 35.0;
+        let by = cy + 25.0;
+        let dx = cx - 35.0;
+        let dy = cy + 25.0;
+
+        let mut path = flui_types::painting::path::Path::new();
+        path.move_to(flui_types::Point::new(Pixels(ax), Pixels(ay)));
+        path.line_to(flui_types::Point::new(Pixels(bx), Pixels(by)));
+        path.line_to(flui_types::Point::new(Pixels(dx), Pixels(dy)));
+        path.close();
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.draw_path(&path, &Paint::fill(Color::WHITE));
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("P1 SSAA Triangle Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Oracle: boundary pixels of the triangle.
+        let boundary =
+            boundary_pixel_indices(|px, py| inside_triangle(px, py, ax, ay, bx, by, dx, dy));
+
+        assert!(
+            boundary.len() >= 8,
+            "P1: fewer than 8 triangle boundary pixels found ({}) — \
+             oracle or path construction is wrong",
+            boundary.len()
+        );
+
+        // Count how many boundary pixels have partial alpha (SSAA produces
+        // partial coverage; hard-aliased rendering would give only 0/255).
+        let partial_count = boundary
+            .iter()
+            .filter(|(idx, _)| {
+                let a = pixels[*idx][3];
+                a > 5 && a < 250
+            })
+            .count();
+
+        let boundary_count = boundary.len();
+        let min_partial = (boundary_count as f32 * 0.5).ceil() as usize;
+
+        assert!(
+            partial_count >= min_partial,
+            "P1 FAILED: only {partial_count}/{boundary_count} triangle boundary pixels have \
+             partial alpha (expected ≥{min_partial} for SSAA AA). \
+             Hard-aliased rendering would give 0 partial pixels — SSAA reroute may be a no-op."
+        );
+
+        // Interior sanity: the centroid must be fully opaque.
+        let centroid_x = ((ax + bx + dx) / 3.0) as usize;
+        let centroid_y = ((ay + by + dy) / 3.0) as usize;
+        let centroid_idx = centroid_y * SURFACE_WIDTH as usize + centroid_x;
+        assert!(
+            pixels[centroid_idx][3] > 200,
+            "P1: triangle centroid must be opaque (got alpha={}); \
+             the SSAA tile may not be composited correctly",
+            pixels[centroid_idx][3]
+        );
+    }
+
+    // ── P2: fill rule (NonZero solid / EvenOdd hollow) both AA'd ─────────────
+
+    /// P2: A star polygon drawn with NonZero fill (solid) vs EvenOdd fill (hollow
+    /// center) must both produce partial-alpha pixels on their boundaries, proving
+    /// the SSAA reroute works for both fill rules.
+    ///
+    /// Additionally, the center of the star is sampled to discriminate fill rules:
+    /// - NonZero: center must be opaque (filled in by the non-zero winding).
+    /// - EvenOdd: center must be transparent (punched out by even crossings).
+    ///
+    /// This guards against the SSAA path ignoring the `PathFillType` carried by
+    /// the tessellated geometry (which lives in the `SsaaPathOp::segment`).
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index/coordinate arithmetic over a small fixed-size test surface"
+    )]
+    fn p2_ssaa_fill_rule_honored_nonzero_vs_evenodd() {
+        use flui_types::painting::PathFillType;
+
+        // Self-intersecting pentagram (★) centered at (cx, cy) with outer radius 40.
+        //
+        // A pentagram connects the 5 tips in skip-2 order: tip[0]→tip[2]→tip[4]→
+        // tip[1]→tip[3]→close.  The 5 diagonals cross through the center, creating
+        // a region with winding count +2 (NonZero → filled, EvenOdd → hole).
+        //
+        // The simple 10-vertex star polygon (alternating outer/inner radii) is
+        // NOT self-intersecting and therefore gives identical results under both
+        // fill rules — it cannot discriminate them.  The pentagram IS self-
+        // intersecting and IS the correct geometry for fill-rule discrimination.
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+        let outer_r = 40.0_f32;
+
+        // 5 tip positions, tip[i] at angle (i*72° - 90°).
+        let tips: Vec<(f32, f32)> = (0..5)
+            .map(|i| {
+                let angle = (i as f32 * 2.0 * PI / 5.0) - PI / 2.0;
+                (cx + outer_r * angle.cos(), cy + outer_r * angle.sin())
+            })
+            .collect();
+
+        // Skip-2 connection order: [0, 2, 4, 1, 3] → self-intersecting pentagram.
+        let pentagram_order = [0usize, 2, 4, 1, 3];
+
+        let build_star_path = |fill_type: PathFillType| {
+            let mut path = flui_types::painting::path::Path::with_fill_type(fill_type);
+            let (first_x, first_y) = tips[pentagram_order[0]];
+            path.move_to(flui_types::Point::new(Pixels(first_x), Pixels(first_y)));
+            for &idx in &pentagram_order[1..] {
+                let (x, y) = tips[idx];
+                path.line_to(flui_types::Point::new(Pixels(x), Pixels(y)));
+            }
+            path.close();
+            path
+        };
+
+        let (device, queue) = acquire_test_device_and_queue();
+
+        // Render NonZero star.
+        let (surface_nz, view_nz) = create_render_surface(&device);
+        clear_surface(&device, &queue, &view_nz);
+        {
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            painter.draw_path(
+                &build_star_path(PathFillType::NonZero),
+                &Paint::fill(Color::WHITE),
+            );
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("P2 NonZero Star Encoder"),
+            });
+            painter
+                .render(
+                    RenderTarget::sampleable(&view_nz, &surface_nz),
+                    &mut encoder,
+                )
+                .expect("painter.render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+        }
+
+        // Render EvenOdd star.
+        let (surface_eo, view_eo) = create_render_surface(&device);
+        clear_surface(&device, &queue, &view_eo);
+        {
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            painter.draw_path(
+                &build_star_path(PathFillType::EvenOdd),
+                &Paint::fill(Color::WHITE),
+            );
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("P2 EvenOdd Star Encoder"),
+            });
+            painter
+                .render(
+                    RenderTarget::sampleable(&view_eo, &surface_eo),
+                    &mut encoder,
+                )
+                .expect("painter.render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+        }
+
+        let pixels_nz = readback_pixels(&device, &queue, &surface_nz);
+        let pixels_eo = readback_pixels(&device, &queue, &surface_eo);
+
+        // Both renders must produce partial-alpha pixels in the outer boundary band
+        // (the 5 outer tips of the star) — proving SSAA is active for both fill rules.
+        for (label, pixels) in [("NonZero", &pixels_nz), ("EvenOdd", &pixels_eo)] {
+            let partial_outer = pixels
+                .iter()
+                .enumerate()
+                .filter(|(idx, p)| {
+                    let col = (idx % SURFACE_WIDTH as usize) as f32 + 0.5 - cx;
+                    let row = (idx / SURFACE_WIDTH as usize) as f32 + 0.5 - cy;
+                    let dist = (col * col + row * row).sqrt();
+                    // Only consider pixels in the outer tip boundary band.
+                    let in_outer_band = dist >= outer_r - 3.0 && dist <= outer_r + 3.0;
+                    in_outer_band && p[3] > 5 && p[3] < 250
+                })
+                .count();
+
+            assert!(
+                partial_outer >= 4,
+                "P2 {label}: fewer than 4 partial-alpha pixels in the outer boundary band \
+                 ({partial_outer}) — SSAA may not be active for this fill rule"
+            );
+        }
+
+        // Fill-rule discrimination: center of the star (at the exact center pixel).
+        // NonZero: winding number is +2 (all edges wind the same) → interior → opaque.
+        // EvenOdd: crossing count is 2 (even) → hole → transparent.
+        let center_idx = cy as usize * SURFACE_WIDTH as usize + cx as usize;
+        assert!(
+            pixels_nz[center_idx][3] > 150,
+            "P2: NonZero star center must be filled (got alpha={}); \
+             fill rule may not be flowing through the SSAA segment",
+            pixels_nz[center_idx][3]
+        );
+        assert!(
+            pixels_eo[center_idx][3] < 100,
+            "P2: EvenOdd star center must be transparent (got alpha={}); \
+             fill rule may not be flowing through the SSAA segment",
+            pixels_eo[center_idx][3]
+        );
+    }
+
+    // ── P3: SSAA scale-invariance — AA band stays ~1 device-px ───────────────
+
+    /// P3: A triangle path rendered at 1× world scale and at 4× world scale
+    /// must both produce comparable numbers of partial-alpha boundary pixels,
+    /// proving the SSAA box-downsample produces a ~1-device-px AA band
+    /// regardless of the local-space scale factor.
+    ///
+    /// ## Why this matters
+    ///
+    /// SSAA samples the 2× texture at sub-pixel positions and averages.  The AA
+    /// band width in device pixels is set by the 2× factor and is scale-
+    /// invariant (the 2× texture always captures 2 sub-pixels per output pixel
+    /// regardless of how large the shape is in local space).  At 4× canvas
+    /// scale the local-space triangle is 4× smaller to produce the same device
+    /// footprint, but the tile is still 2× the output resolution → same band.
+    ///
+    /// A hard-aliased fallback would produce binary (0/255) pixels at any scale
+    /// and would have zero partial-alpha pixels — this test would catch that.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index/coordinate arithmetic over a small fixed-size test surface"
+    )]
+    fn p3_ssaa_aa_band_scale_invariant() {
+        // Same device-space triangle at two scales.
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+
+        // Device triangle (same for both renders):
+        let ax = cx;
+        let ay = cy - 35.0;
+        let bx = cx + 30.0;
+        let by = cy + 20.0;
+        let dx = cx - 30.0;
+        let dy = cy + 20.0;
+
+        let render_triangle_at_scale = |scale: f32| -> Vec<[u8; 4]> {
+            let (device, queue) = acquire_test_device_and_queue();
+            let (surface, view) = create_render_surface(&device);
+            clear_surface(&device, &queue, &view);
+
+            // Shrink local coords by `scale` so the device footprint stays the same.
+            let lax = (ax - cx) / scale + cx;
+            let lay = (ay - cy) / scale + cy;
+            let lbx = (bx - cx) / scale + cx;
+            let lby = (by - cy) / scale + cy;
+            let ldx = (dx - cx) / scale + cx;
+            let ldy = (dy - cy) / scale + cy;
+
+            let mut path = flui_types::painting::path::Path::new();
+            path.move_to(flui_types::Point::new(Pixels(lax), Pixels(lay)));
+            path.line_to(flui_types::Point::new(Pixels(lbx), Pixels(lby)));
+            path.line_to(flui_types::Point::new(Pixels(ldx), Pixels(ldy)));
+            path.close();
+
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            // Apply the compensating world scale so device geometry = target triangle.
+            painter.translate(flui_types::Offset::new(Pixels(cx), Pixels(cy)));
+            painter.scale(scale, scale);
+            painter.translate(flui_types::Offset::new(Pixels(-cx), Pixels(-cy)));
+            painter.draw_path(&path, &Paint::fill(Color::WHITE));
+
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("P3 Scale Encoder"),
+            });
+            painter
+                .render(RenderTarget::sampleable(&view, &surface), &mut encoder)
+                .expect("painter.render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+
+            readback_pixels(&device, &queue, &surface)
+        };
+
+        let pixels_1x = render_triangle_at_scale(1.0);
+        let pixels_4x = render_triangle_at_scale(4.0);
+
+        // Count partial-alpha boundary pixels (the SSAA AA band).
+        let partial_1x = pixels_1x.iter().filter(|p| p[3] > 5 && p[3] < 250).count();
+        let partial_4x = pixels_4x.iter().filter(|p| p[3] > 5 && p[3] < 250).count();
+
+        assert!(
+            partial_1x > 0,
+            "P3: 1× render must have partial-alpha boundary pixels"
+        );
+        assert!(
+            partial_4x > 0,
+            "P3: 4× render must have partial-alpha boundary pixels — SSAA must produce AA at \
+             any canvas scale"
+        );
+
+        // The two band widths must be close: the device footprint is IDENTICAL at
+        // both scales (local coords are pre-shrunk by `scale`), so a scale-invariant
+        // SSAA band should yield near-identical partial-pixel counts — well within
+        // 2×. A hard-aliased renderer has zero partials; a band that collapses at
+        // high scale (e.g. a missing CTM update) pushes the ratio past 2×.
+        let ratio = if partial_1x > partial_4x {
+            partial_1x as f32 / partial_4x as f32
+        } else {
+            partial_4x as f32 / partial_1x as f32
+        };
+        assert!(
+            ratio < 2.0,
+            "P3: AA band width differs too much between 1× ({partial_1x} pixels) and \
+             4× ({partial_4x} pixels) — ratio {ratio:.1}×. SSAA should give ~1 device-px AA \
+             at any scale; a large ratio means the band is collapsing at high scale."
+        );
+    }
+
+    // ── P4: anti-MVP — SrcOver Fill path must emit ≥1 partial-alpha pixel ────
+
+    /// P4: A SrcOver-filled arbitrary path (the canonical SSAA target) must
+    /// emit at least one partial-alpha pixel on its geometric boundary —
+    /// proving the SSAA reroute actually executes the GPU path rather than
+    /// silently being a no-op or returning a stub opaque tile.
+    ///
+    /// ## Anti-MVP rationale (Definition of Done §anti-cheating)
+    ///
+    /// A minimum-viable implementation that tessellates the path and submits it
+    /// directly (bypassing SSAA) would pass P1–P3 only if the tessellated geometry
+    /// happens to be AA'd by some other mechanism.  P4 is a targeted falsification:
+    /// it checks the ONE property that a fake SSAA implementation without a real
+    /// 2× render cannot produce — partial alpha at the exact pixel positions the
+    /// oracle identifies as boundary, EVEN for a shape that is far from axis-aligned.
+    ///
+    /// A non-axis-aligned triangle rendered without SSAA or SDF produces hard edges
+    /// (boundary pixels are either 0 or 255) because `shape.wgsl` has no distance
+    /// field for tessellated geometry.  With SSAA the 2× offscreen capture resolves
+    /// sub-pixel coverage and the downsample produces genuine fractional alpha.
+    ///
+    /// Test structure: explicitly disabled oracle (we do NOT check oracle closeness
+    /// here — only existence of partial alpha), so it cannot degenerate to "check
+    /// nothing" even if the oracle boundary is small.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index/coordinate arithmetic over a small fixed-size test surface"
+    )]
+    fn p4_anti_mvp_srcover_fill_has_partial_alpha_at_boundary() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        // Deliberately non-axis-aligned irregular quadrilateral so that EVERY
+        // edge is diagonal and thus has fractional-coverage boundary pixels under
+        // 2× SSAA.  An axis-aligned rectangle edge falls on a pixel row/column and
+        // can produce zero partial pixels (all boundary pixels round to 0 or 255).
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+        // Irregular kite: four vertices, none axis-aligned relative to each other.
+        let v = [
+            (cx + 1.3, cy - 38.7), // near-top, slightly off-center
+            (cx + 42.2, cy + 5.5), // right
+            (cx - 2.7, cy + 33.1), // near-bottom
+            (cx - 38.4, cy - 9.2), // left
+        ];
+
+        let mut path = flui_types::painting::path::Path::new();
+        path.move_to(flui_types::Point::new(Pixels(v[0].0), Pixels(v[0].1)));
+        for &(x, y) in &v[1..] {
+            path.line_to(flui_types::Point::new(Pixels(x), Pixels(y)));
+        }
+        path.close();
+
+        // SrcOver fill — the ONLY variant that the SSAA reroute handles.
+        let paint = Paint::fill(Color::WHITE); // blend_mode defaults to SrcOver
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.draw_path(&path, &paint);
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("P4 Anti-MVP Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Count partial-alpha pixels anywhere on the surface.
+        // Any partial-alpha pixel is evidence of sub-pixel coverage resolution —
+        // it is impossible to produce with a hard-aliased (0/255) tessellated renderer.
+        let partial_count = pixels.iter().filter(|p| p[3] > 5 && p[3] < 250).count();
+
+        assert!(
+            partial_count >= 4,
+            "P4 FAILED: only {partial_count} partial-alpha pixels in the frame — the SSAA \
+             reroute appears to be a no-op or hard-aliased. A real 2× SSAA box-downsample \
+             MUST produce sub-pixel coverage (partial alpha) on EVERY non-axis-aligned edge."
+        );
+
+        // Also confirm the shape is actually rendered (interior is opaque, not blank).
+        let interior_col = cx as usize;
+        let interior_row = cy as usize;
+        let interior_idx = interior_row * SURFACE_WIDTH as usize + interior_col;
+        assert!(
+            pixels[interior_idx][3] > 200,
+            "P4: shape interior (cx, cy) must be opaque; got alpha={} — \
+             the SSAA composite path may be broken",
+            pixels[interior_idx][3]
+        );
+    }
+
     // ── A4: Angular edges are anti-aliased (partial alpha) ───────────────────
 
     /// A4: The two angular edges of a ~90° arc must show partial alpha (anti-

--- a/crates/flui-engine/src/wgpu/batches/mod.rs
+++ b/crates/flui-engine/src/wgpu/batches/mod.rs
@@ -47,7 +47,7 @@ use flui_painting::BlendMode;
 use flui_types::{Rect, geometry::Pixels};
 
 use super::{
-    command_ir::{AdvancedShapeOp, DrawItem, DrawSegment, TessellatedBatch},
+    command_ir::{AdvancedShapeOp, DrawItem, DrawSegment, SsaaPathOp, TessellatedBatch},
     path_cache::PathCache,
     pipeline::PipelineKey,
     state_stack::GpuStateStack,
@@ -237,6 +237,59 @@ impl DrawBatcher {
         if key.blend_mode() != BlendMode::SrcOver {
             Self::finish_current_segment(segment, draw_order);
         }
+    }
+
+    /// Divert an arbitrary SrcOver path fill into a `DrawItem::SsaaPath` for
+    /// SSAA-based anti-aliasing.
+    ///
+    /// Called exclusively from `DrawBatcher::draw_path` (in `batches/paths.rs`)
+    /// when the path is a fill (`PaintStyle::Fill`) and the blend mode is
+    /// `SrcOver`.  Closed-form shapes (rect/rrect/circle/oval/arc, which route to
+    /// the instanced affine-SDF path) must **not** call this method.
+    ///
+    /// ## What this does
+    ///
+    /// 1. Seals the current `segment` so prior content flushes before the SSAA
+    ///    tile (Z-order correctness, same as the advanced-shape diversion).
+    /// 2. Builds an isolated `DrawSegment` containing only this path's geometry.
+    /// 3. Computes the device-space AABB of the already-transformed vertices.
+    /// 4. Pushes `DrawItem::SsaaPath(SsaaPathOp { segment, device_bounds })`.
+    ///
+    /// All GPU work (2× render + box downsample + composite) happens at replay
+    /// time in `GpuReplay::submit`.
+    pub(super) fn divert_path_to_ssaa(
+        segment: &mut DrawSegment,
+        draw_order: &mut Vec<DrawItem>,
+        state: &GpuStateStack,
+        vertices: &[Vertex],
+        indices: &[u32],
+    ) {
+        if indices.is_empty() {
+            return;
+        }
+
+        // Step 1: seal prior content so it appears below the SSAA tile.
+        Self::finish_current_segment(segment, draw_order);
+
+        // Step 2: compute the device-space AABB from the baked (transformed) vertices.
+        let device_bounds = vertices_aabb(vertices);
+
+        // Step 3: build an isolated DrawSegment for this path only.
+        let mut path_segment = DrawSegment::new();
+        path_segment.vertices.extend_from_slice(vertices);
+        path_segment.indices.extend(indices.iter().copied());
+        path_segment.current_pipeline_key = Some(PipelineKey::alpha_blend());
+        path_segment.tess_batches.push(TessellatedBatch {
+            pipeline_key: PipelineKey::alpha_blend(),
+            scissor: state.current_scissor(),
+            index_start: 0,
+            index_count: indices.len() as u32,
+        });
+
+        draw_order.push(DrawItem::SsaaPath(SsaaPathOp {
+            segment: path_segment,
+            device_bounds,
+        }));
     }
 
     /// Apply the current world transform to every vertex position in `vertices`

--- a/crates/flui-engine/src/wgpu/batches/paths.rs
+++ b/crates/flui-engine/src/wgpu/batches/paths.rs
@@ -1,6 +1,6 @@
 //! Path, vertices, line, and shadow record methods: draw_path, draw_vertices, line, draw_shadow.
 
-use flui_painting::{Paint, PaintStyle};
+use flui_painting::{BlendMode, Paint, PaintStyle};
 use flui_types::{
     Offset, Point,
     geometry::{Pixels, px},
@@ -220,6 +220,27 @@ impl DrawBatcher {
             return;
         }
 
+        // Determine whether this path fill should be SSAA-routed:
+        //   - Fill style (not stroke).
+        //   - SrcOver blend (non-SrcOver paths go to PR-4's path).
+        //   - Path AABB area ≥ SSAA_AREA_THRESHOLD_PX²: tiny paths (icon
+        //     sub-elements, micro-decorations) yield no visible AA benefit and
+        //     pay 5 render passes + 2 texture acquisitions for nothing.  Below
+        //     the threshold they join the batched tessellated draw call instead
+        //     (same quality as pre-PR-3 for those sizes), preserving the engine's
+        //     draw-batching design for the common small-path case.
+        //
+        // Closed-form shapes (rect/rrect/circle/oval/arc) never reach `draw_path`
+        // — they go through `batches/shapes.rs` → instanced SDF.  So any Fill
+        // arriving here IS an arbitrary path.
+        //
+        // The AABB is computed lazily (only when style==Fill && mode==SrcOver)
+        // so the check adds no cost to the stroke / non-SrcOver paths.
+        //
+        let is_srcover_fill = paint.style == PaintStyle::Fill
+            && paint.blend_mode == BlendMode::SrcOver
+            && path_aabb_area_device_px_sq(path, state) >= SSAA_AREA_THRESHOLD_PX_SQ;
+
         // Compute cache key from path geometry + paint tessellation parameters
         // + the quantized world scale (so a scale-1 entry is not reused at a
         // larger scale with scale-1 chord density).
@@ -232,7 +253,7 @@ impl DrawBatcher {
             max_scale,
         );
 
-        // Check cache for previously tessellated geometry
+        // Check cache for previously tessellated geometry.
         if let Some((positions, cached_indices)) = self.path_cache.get(path_hash) {
             // Reconstruct full Vertex data with current paint color.
             // The cache stores UNTRANSFORMED positions; bake the current transform now.
@@ -242,19 +263,26 @@ impl DrawBatcher {
                 .map(|&pos| Vertex::new(pos, rgba, [0.0, 0.0]))
                 .collect();
             let indices: Vec<u32> = cached_indices.to_vec();
-            // Bake current_transform into vertices: shape.wgsl has no model matrix.
-            Self::submit_transformed_geometry(
-                segment,
-                draw_order,
-                state,
-                vertices,
-                &indices,
-                pipeline::pipeline_key_from_paint(paint),
-            );
+
+            if is_srcover_fill {
+                Self::submit_transformed_and_divert_to_ssaa(
+                    segment, draw_order, state, vertices, &indices,
+                );
+            } else {
+                // Bake current_transform into vertices: shape.wgsl has no model matrix.
+                Self::submit_transformed_geometry(
+                    segment,
+                    draw_order,
+                    state,
+                    vertices,
+                    &indices,
+                    pipeline::pipeline_key_from_paint(paint),
+                );
+            }
             return;
         }
 
-        // Cache miss — tessellate and store
+        // Cache miss — tessellate and store.
         let result = if paint.style == PaintStyle::Fill {
             self.tessellator.tessellate_flui_path_fill(path, paint)
         } else {
@@ -270,20 +298,45 @@ impl DrawBatcher {
                 self.path_cache
                     .insert(path_hash, positions, indices.clone());
 
-                // Bake current_transform into vertices: shape.wgsl has no model matrix.
-                Self::submit_transformed_geometry(
-                    segment,
-                    draw_order,
-                    state,
-                    vertices,
-                    &indices,
-                    pipeline::pipeline_key_from_paint(paint),
-                );
+                if is_srcover_fill {
+                    Self::submit_transformed_and_divert_to_ssaa(
+                        segment, draw_order, state, vertices, &indices,
+                    );
+                } else {
+                    // Bake current_transform into vertices: shape.wgsl has no model matrix.
+                    Self::submit_transformed_geometry(
+                        segment,
+                        draw_order,
+                        state,
+                        vertices,
+                        &indices,
+                        pipeline::pipeline_key_from_paint(paint),
+                    );
+                }
             }
             Err(e) => {
                 tracing::warn!("Failed to tessellate path: {}", e);
             }
         }
+    }
+
+    /// Transform vertices by the current CTM, then divert to SSAA.
+    ///
+    /// Factored out of `draw_path` so the transform+divert sequence is identical
+    /// for cache-hit and cache-miss paths.
+    fn submit_transformed_and_divert_to_ssaa(
+        segment: &mut DrawSegment,
+        draw_order: &mut Vec<DrawItem>,
+        state: &GpuStateStack,
+        mut vertices: Vec<Vertex>,
+        indices: &[u32],
+    ) {
+        let transform = state.current_transform();
+        for v in &mut vertices {
+            let transformed = transform * glam::vec4(v.position[0], v.position[1], 0.0, 1.0);
+            v.position = [transformed.x, transformed.y];
+        }
+        Self::divert_path_to_ssaa(segment, draw_order, state, &vertices, indices);
     }
 
     /// Draw indexed triangle geometry with per-vertex color + uv.
@@ -381,6 +434,208 @@ impl DrawBatcher {
             gpu_vertices,
             &gpu_indices,
             pipeline::pipeline_key_from_paint(paint),
+        );
+    }
+}
+
+// ─── Module-level helpers ─────────────────────────────────────────────────────
+
+/// Minimum path AABB area (in device-pixel²) that qualifies for SSAA routing.
+///
+/// Paths whose bounding-box area is below this threshold are rendered via the
+/// normal batched tessellated draw call (shared GPU pass, zero offscreen
+/// overhead).  Paths at or above the threshold are routed to SSAA (5 render
+/// passes, 2 pooled-texture acquisitions) for proper sub-pixel AA on visible
+/// diagonal edges.
+///
+/// 256 px² ≈ 16 × 16 device pixels.  Empirically, paths smaller than this
+/// produce aliasing that is imperceptible at typical DPR and viewing distances;
+/// the SSAA cost is not justified.
+pub(in super::super) const SSAA_AREA_THRESHOLD_PX_SQ: f32 = 256.0;
+
+/// Compute the device-pixel² area of a path's axis-aligned bounding box,
+/// scaled by the current CTM (so the area reflects actual screen size).
+///
+/// Uses `path.compute_bounds()` — a pure computation over path commands with
+/// no tessellation.  The CTM scale is applied as `area × max_scale²` because
+/// the AABB in local space must be scaled to device pixels.
+///
+/// Used exclusively by `draw_path` to decide SSAA eligibility.
+fn path_aabb_area_device_px_sq(path: &Path, state: &GpuStateStack) -> f32 {
+    let local_bounds = path.compute_bounds();
+    let w = local_bounds.width().0.max(0.0);
+    let h = local_bounds.height().0.max(0.0);
+    // Scale each edge by max_scale to get device-pixel extent.
+    let scale = state.max_scale();
+    let device_w = w * scale;
+    let device_h = h * scale;
+    device_w * device_h
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod threshold_tests {
+    use flui_painting::{BlendMode, Paint, PaintStyle};
+    use flui_types::{geometry::px, painting::path::Path};
+
+    use super::{
+        super::super::{
+            command_ir::{DrawItem, DrawSegment},
+            state_stack::GpuStateStack,
+        },
+        DrawBatcher, SSAA_AREA_THRESHOLD_PX_SQ,
+    };
+
+    fn make_batcher() -> DrawBatcher {
+        DrawBatcher::new()
+    }
+
+    fn rect_path(w: f32, h: f32) -> Path {
+        use flui_types::Rect;
+        Path::rectangle(Rect::from_xywh(px(0.0), px(0.0), px(w), px(h)))
+    }
+
+    // ── T1: path below threshold → batched tessellated (no SsaaPath) ─────────
+
+    /// T1: A SrcOver fill path whose AABB area is BELOW `SSAA_AREA_THRESHOLD_PX_SQ`
+    /// must NOT produce `DrawItem::SsaaPath`.  It must join the batched tessellated
+    /// path (zero offscreen overhead).
+    ///
+    /// Without the threshold gate, every SrcOver fill — including a 1px dot —
+    /// issued 5 render passes, breaking the engine's draw-batching model.
+    ///
+    /// The path is a 15×15 square → area = 225 px² < 256 px² (threshold).
+    #[test]
+    fn small_path_below_threshold_does_not_produce_ssaa_path() {
+        let mut batcher = make_batcher();
+        let mut segment = DrawSegment::new();
+        let mut draw_order: Vec<DrawItem> = Vec::new();
+        let state = GpuStateStack::new_for_test(); // identity CTM, scale=1
+
+        let path = rect_path(15.0, 15.0); // area = 225 px² < 256 threshold
+        const { assert!(15.0_f32 * 15.0 < SSAA_AREA_THRESHOLD_PX_SQ) };
+
+        let paint = Paint {
+            style: PaintStyle::Fill,
+            blend_mode: BlendMode::SrcOver,
+            ..Default::default()
+        };
+
+        batcher.draw_path(&mut segment, &mut draw_order, &state, &path, &paint);
+
+        // No SsaaPath item must appear in draw_order.
+        let ssaa_count = draw_order
+            .iter()
+            .filter(|item| matches!(item, DrawItem::SsaaPath(_)))
+            .count();
+        assert_eq!(
+            ssaa_count, 0,
+            "15×15 path (below threshold) must not produce SsaaPath; \
+             got {ssaa_count} SsaaPath items"
+        );
+    }
+
+    // ── T2: path at or above threshold → SsaaPath ────────────────────────────
+
+    /// T2: A SrcOver fill path whose AABB area is AT OR ABOVE
+    /// `SSAA_AREA_THRESHOLD_PX_SQ` must produce `DrawItem::SsaaPath`.
+    ///
+    /// The path is a 17×17 square → area = 289 px² ≥ 256 px² (threshold).
+    ///
+    /// Without the threshold gate all paths produced SsaaPath unconditionally,
+    /// but with it, only sufficiently large paths do — this test ensures the
+    /// threshold is not accidentally over-conservative.
+    #[test]
+    fn large_path_at_or_above_threshold_produces_ssaa_path() {
+        let mut batcher = make_batcher();
+        let mut segment = DrawSegment::new();
+        let mut draw_order: Vec<DrawItem> = Vec::new();
+        let state = GpuStateStack::new_for_test(); // identity CTM, scale=1
+
+        let path = rect_path(17.0, 17.0); // area = 289 px² ≥ 256 threshold
+        const { assert!(17.0_f32 * 17.0 >= SSAA_AREA_THRESHOLD_PX_SQ) };
+
+        let paint = Paint {
+            style: PaintStyle::Fill,
+            blend_mode: BlendMode::SrcOver,
+            ..Default::default()
+        };
+
+        batcher.draw_path(&mut segment, &mut draw_order, &state, &path, &paint);
+
+        let ssaa_count = draw_order
+            .iter()
+            .filter(|item| matches!(item, DrawItem::SsaaPath(_)))
+            .count();
+        assert_eq!(
+            ssaa_count, 1,
+            "17×17 path (at threshold) must produce exactly one SsaaPath; \
+             got {ssaa_count}"
+        );
+    }
+
+    // ── T3: stroke path is never SSAA-routed ─────────────────────────────────
+
+    /// T3: A stroked path (PaintStyle::Stroke) must NEVER produce
+    /// `DrawItem::SsaaPath`, regardless of size.  SSAA is only for fills.
+    #[test]
+    fn stroke_path_never_produces_ssaa_path() {
+        let mut batcher = make_batcher();
+        let mut segment = DrawSegment::new();
+        let mut draw_order: Vec<DrawItem> = Vec::new();
+        let state = GpuStateStack::new_for_test();
+
+        // Large enough that it would be SSAA-routed if this were a fill.
+        let path = rect_path(100.0, 100.0);
+
+        let paint = Paint {
+            style: PaintStyle::Stroke,
+            blend_mode: BlendMode::SrcOver,
+            stroke_width: 2.0,
+            ..Default::default()
+        };
+
+        batcher.draw_path(&mut segment, &mut draw_order, &state, &path, &paint);
+
+        let ssaa_count = draw_order
+            .iter()
+            .filter(|item| matches!(item, DrawItem::SsaaPath(_)))
+            .count();
+        assert_eq!(
+            ssaa_count, 0,
+            "stroke path must never produce SsaaPath; got {ssaa_count}"
+        );
+    }
+
+    // ── T4: non-SrcOver fill is never SSAA-routed ────────────────────────────
+
+    /// T4: A non-SrcOver fill (e.g. SrcOut) must NEVER produce
+    /// `DrawItem::SsaaPath`.  SSAA is SrcOver-only in PR-3.
+    #[test]
+    fn non_srcover_fill_never_produces_ssaa_path() {
+        let mut batcher = make_batcher();
+        let mut segment = DrawSegment::new();
+        let mut draw_order: Vec<DrawItem> = Vec::new();
+        let state = GpuStateStack::new_for_test();
+
+        let path = rect_path(200.0, 200.0); // large — would SSAA if SrcOver
+
+        let paint = Paint {
+            style: PaintStyle::Fill,
+            blend_mode: BlendMode::SrcOut,
+            ..Default::default()
+        };
+
+        batcher.draw_path(&mut segment, &mut draw_order, &state, &path, &paint);
+
+        let ssaa_count = draw_order
+            .iter()
+            .filter(|item| matches!(item, DrawItem::SsaaPath(_)))
+            .count();
+        assert_eq!(
+            ssaa_count, 0,
+            "non-SrcOver fill must never produce SsaaPath; got {ssaa_count}"
         );
     }
 }

--- a/crates/flui-engine/src/wgpu/command_ir.rs
+++ b/crates/flui-engine/src/wgpu/command_ir.rs
@@ -282,10 +282,50 @@ pub(crate) struct AdvancedShapeOp {
     pub(crate) device_bounds: Rect<Pixels>,
 }
 
+// ─── SSAA-path op ────────────────────────────────────────────────────────────
+
+/// A single arbitrary-path fill (SrcOver) routed to the SSAA offscreen tile
+/// for anti-aliased compositing.
+///
+/// Created by `DrawBatcher::draw_path` (in `batches/paths.rs`) when an
+/// arbitrary path fill with SrcOver blend is recorded.  Instead of batching the
+/// tessellated geometry directly into the main `DrawSegment` (which renders
+/// aliased at `sample_count=1`), the geometry is isolated here and rendered at
+/// replay time into a 2× supersampled pooled offscreen, box-downsampled to a
+/// premultiplied 1× tile, and composited via the existing premultiplied texture
+/// path — giving smooth ~1-device-px AA on every edge.
+///
+/// ## Scope
+///
+/// Only arbitrary SrcOver path **fills** take this path.  Closed-form shapes
+/// (rect/rrect/circle/oval/arc) are rerouted to the instanced affine-SDF path
+/// (PR-1/PR-2/PR-2b) and must **not** reach this variant.  Non-SrcOver paths
+/// stay on the tessellated path (PR-4 will handle them).
+///
+/// ## T11 purity contract
+///
+/// `SsaaPathOp` derives `Clone` — it is handle-free (no `wgpu::*` fields),
+/// matching the [`AdvancedShapeOp`] invariant.  The embedded [`DrawSegment`]
+/// carries only CPU data.  All GPU work happens at replay time in
+/// `GpuReplay::submit`.
+#[derive(Clone)]
+pub(crate) struct SsaaPathOp {
+    /// Tessellated geometry for this path (vertices already baked to device
+    /// space; indices relative to a fresh segment starting at base 0).
+    pub(crate) segment: DrawSegment,
+    /// Device-space AABB of the path's coverage in device pixels.
+    ///
+    /// Used to size the SSAA tile: `ceil(device_bounds.width) × ceil(device_bounds.height)`,
+    /// clamped to `[1, viewport]`.  Computed as the AABB of
+    /// `segment.vertices[*].position` at record time.
+    pub(crate) device_bounds: Rect<Pixels>,
+}
+
 // ─── Draw item (top-level ordering enum) ─────────────────────────────────────
 
 /// An item in the draw order list: either a segment of batched commands,
-/// an offscreen texture to composite, an opacity layer, or an advanced shape.
+/// an offscreen texture to composite, an opacity layer, or an advanced shape,
+/// or an SSAA-supersampled path tile.
 // `PendingOffscreenTexture` (via `OffscreenTexture` variant) is not `Debug`
 // because `PooledTexture` wraps a `wgpu::Texture`.
 #[allow(missing_debug_implementations)]
@@ -303,6 +343,14 @@ pub(crate) enum DrawItem {
     /// `GpuReplay::submit` can render it to an offscreen foreground and call
     /// `flush_advanced_layer` for the backdrop-compositing pass.
     AdvancedShape(AdvancedShapeOp),
+    /// An arbitrary SrcOver path fill rendered via SSAA (2× supersample →
+    /// box-downsample → premultiplied tile composite).
+    ///
+    /// Isolated from the surrounding `DrawSegment` at record time so that
+    /// `GpuReplay::submit` can execute the 2× render + downsample + composite
+    /// sequence at replay time.  Z-order is the insertion position in
+    /// `draw_order` (R1 arm order).
+    SsaaPath(SsaaPathOp),
 }
 
 // ─── Opacity layer ────────────────────────────────────────────────────────────

--- a/crates/flui-engine/src/wgpu/mod.rs
+++ b/crates/flui-engine/src/wgpu/mod.rs
@@ -148,6 +148,10 @@ pub(crate) mod resources;
 /// method existed -- only `clear`.
 mod shader_compiler;
 mod shaders;
+/// SSAA (2× supersampled) path anti-aliasing: downsample pipeline and replay
+/// helper `GpuReplay::render_ssaa_path` / `GpuReplay::downsample_ssaa_tile`.
+/// Handles Fill + SrcOver arbitrary paths that were diverted by `draw_path`.
+pub(crate) mod ssaa;
 /// GPU draw-state stack: the four paired transform/scissor/SDF-clip stacks
 /// and their cached current values, extracted from `WgpuPainter` so they can
 /// be owned and delegated as a unit. Owned by `WgpuPainter` via the `state`

--- a/crates/flui-engine/src/wgpu/opacity_layer.rs
+++ b/crates/flui-engine/src/wgpu/opacity_layer.rs
@@ -1,6 +1,6 @@
 //! Offscreen-layer render helpers for opacity and compositing layers.
 //!
-//! This module provides two `GpuReplay` methods:
+//! This module provides three `GpuReplay` methods:
 //!
 //! - `GpuReplay::render_segment_to_offscreen` — renders a single
 //!   `DrawSegment` into a fresh pooled texture.  Used by the
@@ -14,6 +14,11 @@
 //!   `LoadOp::Clear(TRANSPARENT)` pass rather than delegating to
 //!   `render_segment_to_offscreen`; both paths use the identical
 //!   clear-then-`LoadOp::Load` sequence (R3).
+//!
+//! - `GpuReplay::flush_opacity_layer` — composite a rendered layer onto the
+//!   main surface, dispatching to the advanced-blend path or the premultiplied
+//!   SrcOver path as appropriate.  Moved here from `replay.rs` to keep that
+//!   file under the 1500-LOC spec limit.
 //!
 //! ## Invariants preserved from `flush_opacity_layer`
 //!
@@ -315,6 +320,26 @@ impl GpuReplay {
                         );
                     }
                 }
+                // ── SSAA-supersampled path nested inside a layer ───────────────
+                DrawItem::SsaaPath(mut op) => {
+                    // Composite the SSAA tile onto the layer's offscreen texture
+                    // at the correct Z position (R1 arm order).
+                    self.render_ssaa_path(
+                        &mut op,
+                        viewport_size,
+                        surface_format,
+                        device,
+                        queue,
+                        pipelines,
+                        resources,
+                        encoder,
+                        offscreen_view,
+                    );
+                    tracing::trace!(
+                        bounds = ?op.device_bounds,
+                        "GpuReplay: SSAA path tile composited onto layer offscreen"
+                    );
+                }
             }
         }
 
@@ -333,5 +358,221 @@ impl GpuReplay {
         }
 
         offscreen
+    }
+
+    // =========================================================================
+    // Opacity-layer composite (moved from replay.rs to honour the 1500-LOC limit)
+    // =========================================================================
+
+    /// Render an opacity layer's content to an offscreen texture and composite
+    /// the result onto `main_target` with group opacity.
+    ///
+    /// Correct group opacity: all children are rendered at full opacity into an
+    /// offscreen texture, then the entire texture is composited with the layer's
+    /// alpha. This avoids the incorrect per-primitive alpha that would result
+    /// from blending each child independently.
+    ///
+    /// ## R3 — LoadOp correctness
+    ///
+    /// - The offscreen clear pass uses `LoadOp::Clear(TRANSPARENT)` so only
+    ///   actually-drawn pixels contribute to the composite.
+    /// - All other render passes (flush_segment, flush_texture_batch) use
+    ///   `LoadOp::Load` — preserving prior content in the target.
+    ///   A Clear↔Load swap here would blank or ghost a layer.
+    ///
+    /// ## R2 — `texture_batch` invariant in recursion
+    ///
+    /// `&mut self` serializes the recursion.  Every `flush_texture_batch*`
+    /// call drains and clears `self.texture_batch` before returning, so a
+    /// depth-N+1 flush cannot leave instances that appear in the depth-N
+    /// composite.
+    #[allow(
+        clippy::too_many_arguments,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    pub(in crate::wgpu) fn flush_opacity_layer(
+        &mut self,
+        mut layer: PendingOpacityLayer,
+        viewport_size: (u32, u32),
+        surface_format: wgpu::TextureFormat,
+        device: &Arc<wgpu::Device>,
+        queue: &Arc<wgpu::Queue>,
+        pipelines: &mut PipelineSet,
+        resources: &mut GpuResources,
+        encoder: &mut wgpu::CommandEncoder,
+        main_target: RenderTarget<'_>,
+    ) {
+        // Zero-size viewports produce no visible pixels; skip GPU work entirely.
+        // The UV composite below divides by vp_w/vp_h, so proceeding would push
+        // inf/NaN into texture instances.  The pool clamps acquire to 1×1 but
+        // the resulting composite would be meaningless.
+        let (vp_w, vp_h) = viewport_size;
+        if vp_w == 0 || vp_h == 0 {
+            return;
+        }
+
+        let offscreen = self.render_layer_to_offscreen(
+            &mut layer,
+            viewport_size,
+            surface_format,
+            device,
+            queue,
+            pipelines,
+            resources,
+            encoder,
+        );
+
+        // ── Advanced-blend dispatch (DECISION 1 / CRITICAL GATE) ────────────
+        //
+        // `layer.blend.is_advanced()` is set when the layer carries a W3C
+        // advanced blend mode (Multiply, Screen, Overlay, …, Luminosity).
+        // Advanced blends require a backdrop read from the main surface — they
+        // MUST NOT go through the SrcOver premultiplied composite below, which
+        // would produce a white-over-dst tinted composite instead of the actual
+        // advanced blend.
+        //
+        // The COPY_SRC guard: `main_target.texture` is `Some` only when the
+        // surface was created with COPY_SRC usage.  Without it `copy_backdrop_region`
+        // cannot copy the backdrop, so we fall back to SrcOver + a one-shot warning.
+        if layer.blend.is_advanced() {
+            if let Some(surface_texture) = main_target.texture {
+                let o = layer.opacity.clamp(0.0, 1.0);
+                // UV remap: layer.bounds → [0,1] in viewport space.
+                #[allow(
+                    clippy::cast_precision_loss,
+                    reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
+                )]
+                let uv_left = layer.bounds.left().0 / vp_w as f32;
+                #[allow(
+                    clippy::cast_precision_loss,
+                    reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
+                )]
+                let uv_top = layer.bounds.top().0 / vp_h as f32;
+                #[allow(
+                    clippy::cast_precision_loss,
+                    reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
+                )]
+                let uv_right = layer.bounds.right().0 / vp_w as f32;
+                #[allow(
+                    clippy::cast_precision_loss,
+                    reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
+                )]
+                let uv_bottom = layer.bounds.bottom().0 / vp_h as f32;
+
+                let op = AdvancedBlendOp {
+                    foreground: offscreen,
+                    mode: layer.blend,
+                    device_bounds: layer.bounds,
+                    opacity: o,
+                    tint: layer.tint_rgb,
+                    src_uv_min: [uv_left, uv_top],
+                    src_uv_max: [uv_right, uv_bottom],
+                };
+                flush_advanced_layer(
+                    op,
+                    surface_texture,
+                    main_target.view,
+                    surface_format,
+                    viewport_size,
+                    &pipelines.advanced_blend,
+                    resources,
+                    device,
+                    encoder,
+                );
+                tracing::trace!(
+                    mode = ?layer.blend,
+                    opacity = layer.opacity,
+                    bounds = ?layer.bounds,
+                    "GpuReplay: composited advanced-blend opacity layer"
+                );
+                return;
+            }
+            // A `view_only` target has no sampleable backdrop; advanced modes
+            // degrade to SrcOver here (warn once).  Production producers pass a
+            // sampleable target — surface-with-COPY_SRC, the COPY_SRC-less
+            // intermediate, or a pooled offscreen — so this is only reached by
+            // genuinely view-only callers (benches/headless/ShaderMask-style).
+            tracing::warn!(
+                mode = ?layer.blend,
+                "Advanced blend layer reached a view_only target; \
+                 falling back to SrcOver compositing (caller must pass sampleable target)"
+            );
+        }
+
+        let offscreen_view = offscreen.view();
+
+        // Composite the premultiplied offscreen onto the main surface.
+        //
+        // The offscreen texel `T` is premultiplied: `T.rgb = straight_rgb * a`,
+        // `T.a = a`.  With group opacity `O` and ColorFilter chroma `C`
+        // (white = no-op), the correct result is premultiplied source-over of
+        // `T * (C.r*O, C.g*O, C.b*O, O)` — every premultiplied channel scaled
+        // by its tint, then OVER the destination.  The shader applies
+        // `tex * tint` and the premultiplied pipeline (src factor `One`)
+        // performs the OVER.
+        //
+        // - White tint, O<1  → tint (O,O,O,O): uniform group opacity (BUG 2 fix).
+        // - Chroma tint       → modulates hue while preserving premultiplication
+        //                       (BUG 3 fix).
+        let o = layer.opacity.clamp(0.0, 1.0);
+        let tint = [
+            layer.tint_rgb[0] * o,
+            layer.tint_rgb[1] * o,
+            layer.tint_rgb[2] * o,
+            o,
+        ];
+
+        // Use layer bounds as the destination rect; UV coordinates map the
+        // bounds region from the full-viewport texture.
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
+        )]
+        let uv_left = layer.bounds.left().0 / vp_w as f32;
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
+        )]
+        let uv_top = layer.bounds.top().0 / vp_h as f32;
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
+        )]
+        let uv_right = layer.bounds.right().0 / vp_w as f32;
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
+        )]
+        let uv_bottom = layer.bounds.bottom().0 / vp_h as f32;
+
+        let instance = super::instancing::TextureInstance::with_uv_tint_f32(
+            layer.bounds,
+            [uv_left, uv_top, uv_right, uv_bottom],
+            tint,
+        );
+        let _ = self.texture_batch.add(instance);
+        // Opacity-layer composite onto main surface — full-viewport, no scissor.
+        // Premultiplied: offscreen texels are premultiplied (see above).
+        // R2: flush_texture_batch_premultiplied drains + clears texture_batch.
+        self.flush_texture_batch_premultiplied(
+            device,
+            queue,
+            pipelines,
+            resources,
+            viewport_size,
+            encoder,
+            main_target.view,
+            offscreen_view,
+            None,
+        );
+
+        tracing::trace!(
+            opacity = layer.opacity,
+            bounds = ?layer.bounds,
+            "GpuReplay: composited opacity layer"
+        );
+
+        // offscreen texture returned to pool when `offscreen` is dropped here.
     }
 }

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -341,6 +341,11 @@ impl WgpuPainter {
             .drain(..)
             .filter_map(|item| match item {
                 DrawItem::Segment(seg) => Some(seg),
+                // SsaaPath carries the path's tessellated DrawSegment internally;
+                // surface it so the T11 deterministic-replay drain covers path
+                // geometry too (rather than silently omitting it if a future test
+                // scene adds a SrcOver arbitrary-path fill).
+                DrawItem::SsaaPath(op) => Some(op.segment),
                 DrawItem::OffscreenTexture(_)
                 | DrawItem::OpacityLayer(_)
                 | DrawItem::AdvancedShape(_) => None,

--- a/crates/flui-engine/src/wgpu/pipelines.rs
+++ b/crates/flui-engine/src/wgpu/pipelines.rs
@@ -53,7 +53,9 @@
 //! `&self.gradient_bind_group_layout`. The pattern mirrors
 //! [`super::resources::GpuResources`].
 
-use super::{advanced_blend::AdvancedBlendPipeline, pipeline::PipelineCache};
+use super::{
+    advanced_blend::AdvancedBlendPipeline, pipeline::PipelineCache, ssaa::SsaaDownsamplePipeline,
+};
 
 /// Device-scoped collection of all `wgpu::RenderPipeline`s used by [`super::painter::WgpuPainter`].
 ///
@@ -151,6 +153,13 @@ pub(crate) struct PipelineSet {
     /// Format-matched to `surface_format` at construction time; shared across
     /// every `flush_advanced_layer` call for this painter.
     pub(crate) advanced_blend: AdvancedBlendPipeline,
+
+    // ── SSAA box-downsample pipeline ─────────────────────────────────────────
+    /// 2×→1× box-filter downsample pipeline for SSAA path anti-aliasing.
+    ///
+    /// Used by `GpuReplay::render_ssaa_path` to box-average a 2× supersampled
+    /// offscreen tile into a premultiplied 1× tile before compositing.
+    pub(crate) ssaa_downsample: SsaaDownsamplePipeline,
 }
 
 impl PipelineSet {
@@ -244,6 +253,7 @@ impl PipelineSet {
         );
 
         let advanced_blend = AdvancedBlendPipeline::new(device, surface_format);
+        let ssaa_downsample = SsaaDownsamplePipeline::new(device, surface_format);
 
         Self {
             shape_cache,
@@ -261,6 +271,7 @@ impl PipelineSet {
             gradient_stops_buffer,
             gradient_bind_group: None,
             advanced_blend,
+            ssaa_downsample,
         }
     }
 

--- a/crates/flui-engine/src/wgpu/replay.rs
+++ b/crates/flui-engine/src/wgpu/replay.rs
@@ -56,7 +56,7 @@ use crate::error::EngineResult;
 
 use super::{
     advanced_blend::{AdvancedBlendOp, flush_advanced_layer},
-    command_ir::{DrawItem, DrawSegment, PendingOpacityLayer, ScissorRect},
+    command_ir::{DrawItem, DrawSegment, ScissorRect},
     instancing::{InstanceBatch, TextureInstance},
     pipeline::PipelineKey,
     pipelines::PipelineSet,
@@ -99,7 +99,11 @@ pub(super) struct GpuReplay {
     unit_quad_index_buffer: wgpu::Buffer,
 
     /// Default texture sampler (linear filtering, clamp-to-edge).
-    default_sampler: wgpu::Sampler,
+    ///
+    /// `pub(super)` so the sibling `ssaa` module's `impl GpuReplay` block can
+    /// reuse this sampler for the box-downsample bind group without adding a
+    /// second sampler field.  The `wgpu` module boundary is `super` here.
+    pub(super) default_sampler: wgpu::Sampler,
 
     // ── Per-frame texture-instance scratch batch (from T10b) ─────────────────
     /// Per-frame scratch batch for texture instances.
@@ -423,6 +427,30 @@ impl GpuReplay {
                         );
                     }
                 }
+                // ── SSAA-supersampled arbitrary path — PR-3 ────────────────
+                //
+                // Z-correctness: all prior draw_order items have been flushed
+                // before this arm executes (loop order), so the SSAA tile
+                // composites on top of prior content — correct SrcOver stacking.
+                //
+                // Surface stays sample_count=1; the 2× size is a normal texture.
+                DrawItem::SsaaPath(mut op) => {
+                    self.render_ssaa_path(
+                        &mut op,
+                        viewport_size,
+                        surface_format,
+                        device,
+                        queue,
+                        pipelines,
+                        resources,
+                        encoder,
+                        target.view,
+                    );
+                    tracing::trace!(
+                        bounds = ?op.device_bounds,
+                        "GpuReplay: SSAA path tile composited"
+                    );
+                }
             }
         }
 
@@ -430,206 +458,6 @@ impl GpuReplay {
         text_renderer.render(device, queue, target.view, encoder, viewport_size)?;
 
         Ok(())
-    }
-
-    // =========================================================================
-    // Opacity-layer recursion (T10d)
-    // =========================================================================
-
-    /// Render an opacity layer's content to an offscreen texture and composite
-    /// the result onto `main_view` with group opacity.
-    ///
-    /// Correct group opacity: all children are rendered at full opacity into an
-    /// offscreen texture, then the entire texture is composited with the layer's
-    /// alpha. This avoids the incorrect per-primitive alpha that would result
-    /// from blending each child independently.
-    ///
-    /// ## R3 — LoadOp correctness
-    ///
-    /// - The offscreen clear pass uses `LoadOp::Clear(TRANSPARENT)` so only
-    ///   actually-drawn pixels contribute to the composite.
-    /// - All other render passes (flush_segment, flush_texture_batch) use
-    ///   `LoadOp::Load` — preserving prior content in the target.
-    ///   A Clear↔Load swap here would blank or ghost a layer.
-    ///
-    /// ## R2 — `texture_batch` invariant in recursion
-    ///
-    /// `&mut self` serializes the recursion.  Every `flush_texture_batch*`
-    /// call drains and clears `self.texture_batch` before returning, so a
-    /// depth-N+1 flush cannot leave instances that appear in the depth-N
-    /// composite.
-    #[allow(
-        clippy::too_many_arguments,
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss
-    )]
-    pub(in crate::wgpu) fn flush_opacity_layer(
-        &mut self,
-        mut layer: PendingOpacityLayer,
-        viewport_size: (u32, u32),
-        surface_format: wgpu::TextureFormat,
-        device: &Arc<wgpu::Device>,
-        queue: &Arc<wgpu::Queue>,
-        pipelines: &mut PipelineSet,
-        resources: &mut GpuResources,
-        encoder: &mut wgpu::CommandEncoder,
-        main_target: RenderTarget<'_>,
-    ) {
-        // Zero-size viewports produce no visible pixels; skip GPU work entirely.
-        // The UV composite below divides by vp_w/vp_h, so proceeding would push
-        // inf/NaN into texture instances.  The pool clamps acquire to 1×1 but
-        // the resulting composite would be meaningless.
-        let (vp_w, vp_h) = viewport_size;
-        if vp_w == 0 || vp_h == 0 {
-            return;
-        }
-
-        let offscreen = self.render_layer_to_offscreen(
-            &mut layer,
-            viewport_size,
-            surface_format,
-            device,
-            queue,
-            pipelines,
-            resources,
-            encoder,
-        );
-
-        // ── Advanced-blend dispatch (DECISION 1 / CRITICAL GATE) ────────────
-        //
-        // `layer.blend.is_advanced()` is set when the layer carries a W3C
-        // advanced blend mode (Multiply, Screen, Overlay, …, Luminosity).
-        // Advanced blends require a backdrop read from the main surface — they
-        // MUST NOT go through the SrcOver premultiplied composite below, which
-        // would produce a white-over-dst tinted composite instead of the actual
-        // advanced blend.
-        //
-        // The COPY_SRC guard: `main_target.texture` is `Some` only when the
-        // surface was created with COPY_SRC usage.  Without it `copy_backdrop_region`
-        // cannot copy the backdrop, so we fall back to SrcOver + a one-shot warning.
-        if layer.blend.is_advanced() {
-            if let Some(surface_texture) = main_target.texture {
-                let o = layer.opacity.clamp(0.0, 1.0);
-                // UV remap: layer.bounds → [0,1] in viewport space.
-                #[allow(
-                    clippy::cast_precision_loss,
-                    reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
-                )]
-                let uv_left = layer.bounds.left().0 / vp_w as f32;
-                #[allow(
-                    clippy::cast_precision_loss,
-                    reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
-                )]
-                let uv_top = layer.bounds.top().0 / vp_h as f32;
-                #[allow(
-                    clippy::cast_precision_loss,
-                    reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
-                )]
-                let uv_right = layer.bounds.right().0 / vp_w as f32;
-                #[allow(
-                    clippy::cast_precision_loss,
-                    reason = "vp_w/vp_h are u32 viewport dims; precision loss at >16 M pixels is acceptable"
-                )]
-                let uv_bottom = layer.bounds.bottom().0 / vp_h as f32;
-
-                let op = AdvancedBlendOp {
-                    foreground: offscreen,
-                    mode: layer.blend,
-                    device_bounds: layer.bounds,
-                    opacity: o,
-                    tint: layer.tint_rgb,
-                    src_uv_min: [uv_left, uv_top],
-                    src_uv_max: [uv_right, uv_bottom],
-                };
-                flush_advanced_layer(
-                    op,
-                    surface_texture,
-                    main_target.view,
-                    surface_format,
-                    viewport_size,
-                    &pipelines.advanced_blend,
-                    resources,
-                    device,
-                    encoder,
-                );
-                tracing::trace!(
-                    mode = ?layer.blend,
-                    opacity = layer.opacity,
-                    bounds = ?layer.bounds,
-                    "GpuReplay: composited advanced-blend opacity layer"
-                );
-                return;
-            }
-            // A `view_only` target has no sampleable backdrop; advanced modes
-            // degrade to SrcOver here (warn once).  Production producers pass a
-            // sampleable target — surface-with-COPY_SRC, the COPY_SRC-less
-            // intermediate, or a pooled offscreen — so this is only reached by
-            // genuinely view-only callers (benches/headless/ShaderMask-style).
-            tracing::warn!(
-                mode = ?layer.blend,
-                "Advanced blend layer reached a view_only target; \
-                 falling back to SrcOver compositing (caller must pass sampleable target)"
-            );
-        }
-
-        let offscreen_view = offscreen.view();
-
-        // Composite the premultiplied offscreen onto the main surface.
-        //
-        // The offscreen texel `T` is premultiplied: `T.rgb = straight_rgb * a`,
-        // `T.a = a`.  With group opacity `O` and ColorFilter chroma `C`
-        // (white = no-op), the correct result is premultiplied source-over of
-        // `T * (C.r*O, C.g*O, C.b*O, O)` — every premultiplied channel scaled
-        // by its tint, then OVER the destination.  The shader applies
-        // `tex * tint` and the premultiplied pipeline (src factor `One`)
-        // performs the OVER.
-        //
-        // - White tint, O<1  → tint (O,O,O,O): uniform group opacity (BUG 2 fix).
-        // - Chroma tint       → modulates hue while preserving premultiplication
-        //                       (BUG 3 fix).
-        let o = layer.opacity.clamp(0.0, 1.0);
-        let tint = [
-            layer.tint_rgb[0] * o,
-            layer.tint_rgb[1] * o,
-            layer.tint_rgb[2] * o,
-            o,
-        ];
-
-        // Use layer bounds as the destination rect; UV coordinates map the
-        // bounds region from the full-viewport texture.
-        let uv_left = layer.bounds.left().0 / vp_w as f32;
-        let uv_top = layer.bounds.top().0 / vp_h as f32;
-        let uv_right = layer.bounds.right().0 / vp_w as f32;
-        let uv_bottom = layer.bounds.bottom().0 / vp_h as f32;
-
-        let instance = super::instancing::TextureInstance::with_uv_tint_f32(
-            layer.bounds,
-            [uv_left, uv_top, uv_right, uv_bottom],
-            tint,
-        );
-        let _ = self.texture_batch.add(instance);
-        // Opacity-layer composite onto main surface — full-viewport, no scissor.
-        // Premultiplied: offscreen texels are premultiplied (see above).
-        // R2: flush_texture_batch_premultiplied drains + clears texture_batch.
-        self.flush_texture_batch_premultiplied(
-            device,
-            queue,
-            pipelines,
-            resources,
-            viewport_size,
-            encoder,
-            main_target.view,
-            offscreen_view,
-            None,
-        );
-
-        tracing::trace!(
-            opacity = layer.opacity,
-            bounds = ?layer.bounds,
-            "GpuReplay: composited opacity layer"
-        );
-
-        // offscreen texture returned to pool when `offscreen` is dropped here.
     }
 
     /// Re-integrate offscreen draw content back into the parent draw order.

--- a/crates/flui-engine/src/wgpu/shaders/effects/box_downsample.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/effects/box_downsample.wgsl
@@ -1,0 +1,62 @@
+// Box-filter 2×→1× downsample for SSAA path anti-aliasing.
+//
+// Reads a 2× supersampled source texture (premultiplied RGBA) and averages the
+// four texels that correspond to each output pixel.  Produces a premultiplied
+// tile that can be composited directly via the premultiplied texture pipeline.
+//
+// Sampling layout (2× → 1×):
+//   For an output pixel at UV (u, v), the four covered source texel centres are at:
+//     (u ∓ 0.5/src_w, v ∓ 0.5/src_h)   — the 2×2 source texels under this output pixel
+//
+// One output pixel spans 2/src_dim in UV (the source is 2× the output size), so the
+// four source-texel centres sit at ±(half the output-pixel UV span)/2 = ±0.5/src_dim
+// from the output-pixel centre. With linear filtering, sampling exactly at a source
+// texel centre returns that texel's value, so the four taps give the exact 2×2 box
+// average (ordered-grid 2× SSAA). The code below uses `0.5/src_dim` — matching this.
+//
+// Averaging premultiplied values is correct: premultiplied colour is linear in
+// coverage, so the mean of four coverage-weighted colours equals the
+// coverage-weighted mean colour — no artefact at transparent edges.
+
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+    @location(1) uv:       vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0)       uv:       vec2<f32>,
+}
+
+@group(0) @binding(0)
+var source_texture: texture_2d<f32>;
+
+@group(0) @binding(1)
+var linear_sampler: sampler;
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.position = vec4<f32>(in.position, 0.0, 1.0);
+    out.uv = in.uv;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    // Source dimensions in texels.
+    let src_dim = vec2<f32>(textureDimensions(source_texture));
+
+    // Half a sub-texel offset in UV space: sub-texel = 1/src_dim texels,
+    // so the tap offset to the sub-texel centre = 0.5 * (1/src_dim) = 0.5/src_dim.
+    let half_texel = 0.5 / src_dim;
+
+    // Four-tap box filter: sample the four sub-texels covering this output pixel.
+    let tl = textureSample(source_texture, linear_sampler, in.uv + vec2<f32>(-half_texel.x, -half_texel.y));
+    let tr = textureSample(source_texture, linear_sampler, in.uv + vec2<f32>( half_texel.x, -half_texel.y));
+    let bl = textureSample(source_texture, linear_sampler, in.uv + vec2<f32>(-half_texel.x,  half_texel.y));
+    let br = textureSample(source_texture, linear_sampler, in.uv + vec2<f32>( half_texel.x,  half_texel.y));
+
+    // Uniform 4-tap average.  Premultiplied averaging is linear-correct.
+    return (tl + tr + bl + br) * 0.25;
+}

--- a/crates/flui-engine/src/wgpu/ssaa.rs
+++ b/crates/flui-engine/src/wgpu/ssaa.rs
@@ -1,0 +1,973 @@
+//! SSAA (2× supersampled) path anti-aliasing pipeline and replay helpers.
+//!
+//! This module provides:
+//!
+//! - `SsaaDownsamplePipeline` — the `box_downsample.wgsl` render pipeline +
+//!   its bind-group layout.  Converts a 2× supersampled source tile into a
+//!   premultiplied 1× tile via a 4-tap box filter.
+//!
+//! - `GpuReplay::render_ssaa_path` — the replay-time implementation for
+//!   `DrawItem::SsaaPath` items.  Acquires a 2× pooled texture, renders the
+//!   path segment into it (clearing to transparent first), box-downsamples to
+//!   a 1× tile, and composites via the existing premultiplied texture batch path.
+//!
+//! ## Surface / sample-count invariant
+//!
+//! The SSAA tile is a plain normal (non-multisampled) texture, just twice the
+//! logical resolution.  `sample_count` stays 1 everywhere.  No stencil, no
+//! `resolve_target`.  This is safe for Phase B (advanced blend / opacity layers)
+//! which also uses `sample_count: 1` pooled textures.
+//!
+//! ## Premultiplied correctness
+//!
+//! `shape.wgsl` emits PREMULTIPLIED colour (`vec4(rgb*a, a)`, shape.wgsl:51-53),
+//! and the SrcOver tessellated pipeline uses `PREMULTIPLIED_ALPHA_BLENDING`
+//! (src factor `One`, pipeline.rs:133). The 2× tile starts clear-transparent, so
+//! the path accumulates premultiplied values over transparent. The box downsample
+//! averages premultiplied values, which is linear-correct (premultiplied colour is
+//! linear in coverage). The 1× tile is then composited via
+//! `flush_texture_batch_premultiplied` (src factor `One`) — no double-multiply.
+
+use std::sync::Arc;
+
+use flui_types::{Rect, geometry::Pixels};
+
+use super::{
+    command_ir::SsaaPathOp, pipelines::PipelineSet, replay::GpuReplay, resources::GpuResources,
+    texture_pool::PooledTexture,
+};
+
+// ─── Downsample pipeline ───────────────────────────────────────────────────────
+
+/// Pipeline for the 2×→1× box-filter downsample pass used by SSAA path AA.
+///
+/// The pipeline samples a 2× supersampled source texture (premultiplied RGBA)
+/// and averages the four sub-texels for each output pixel, producing a
+/// premultiplied 1× tile ready for compositing.
+///
+/// One `SsaaDownsamplePipeline` is created per `PipelineSet` (keyed to the
+/// surface format) and reused for every SSAA path in the frame.
+// wgpu handle types do not implement Debug.
+#[allow(missing_debug_implementations)]
+pub(crate) struct SsaaDownsamplePipeline {
+    /// Render pipeline for the 4-tap box downsample.
+    pub(crate) pipeline: wgpu::RenderPipeline,
+    /// Bind group layout: binding 0 = source texture, binding 1 = linear sampler.
+    pub(crate) bind_group_layout: wgpu::BindGroupLayout,
+}
+
+impl SsaaDownsamplePipeline {
+    /// Create the downsample pipeline for `output_format`.
+    ///
+    /// `output_format` is the target format of the 1× tile — always
+    /// `surface_format` so the tile is compatible with the premultiplied
+    /// texture compositor.
+    pub(crate) fn new(device: &wgpu::Device, output_format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("SSAA Box Downsample Shader"),
+            source: wgpu::ShaderSource::Wgsl(
+                include_str!("shaders/effects/box_downsample.wgsl").into(),
+            ),
+        });
+
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("SSAA Downsample Bind Group Layout"),
+            entries: &[
+                // binding 0: source 2× texture
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                // binding 1: linear sampler (for the 4-tap average)
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("SSAA Downsample Pipeline Layout"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("SSAA Box Downsample Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[wgpu::VertexBufferLayout {
+                    // Two f32 position + two f32 UV per vertex.
+                    array_stride: 4 * std::mem::size_of::<f32>() as u64,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x2],
+                }],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: output_format,
+                    // Premultiplied source-over: the downsampled tile is premultiplied;
+                    // compositing onto a pre-cleared transparent output uses src-factor One.
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview_mask: None,
+            cache: None,
+        });
+
+        Self {
+            pipeline,
+            bind_group_layout,
+        }
+    }
+}
+
+// ─── Replay helper ─────────────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+impl GpuReplay {
+    /// Replay a `DrawItem::SsaaPath`: render the path into a 2× tile,
+    /// box-downsample to a premultiplied 1× tile, then composite via the
+    /// premultiplied texture batch.
+    ///
+    /// ## Algorithm
+    ///
+    /// 1. Compute the integer device tile rect = `ceil(device_bounds)` clamped
+    ///    to `[1, viewport]`.
+    /// 2. Acquire a 2× pooled texture `(tile_w*2, tile_h*2)` from the layer pool.
+    /// 3. Render the path segment into the 2× tile:
+    ///    - Clear to transparent (`LoadOp::Clear`).
+    ///    - Translate vertices by `-tile_origin` so the tile maps to `[0, tile_size]`.
+    ///    - `flush_segment` with a `tile_size`-wide viewport (1× logical size) so
+    ///      the 1× geometry fills the full 2× texture → 2× supersampled.
+    /// 4. Acquire a 1× pooled texture `(tile_w, tile_h)`.  Clear to transparent.
+    ///    Run `SsaaDownsamplePipeline` to box-average the 2× → 1×.
+    /// 5. Push the 1× tile into `texture_batch` and composite via
+    ///    `flush_texture_batch_premultiplied` at `device_bounds` on the target.
+    ///
+    /// Both pooled textures are RAII (return to pool on drop).  The 2× tile is
+    /// dropped before the composite step; the 1× tile drops after the composite.
+    pub(in crate::wgpu) fn render_ssaa_path(
+        &mut self,
+        op: &mut SsaaPathOp,
+        viewport_size: (u32, u32),
+        surface_format: wgpu::TextureFormat,
+        device: &Arc<wgpu::Device>,
+        queue: &Arc<wgpu::Queue>,
+        pipelines: &mut PipelineSet,
+        resources: &mut GpuResources,
+        encoder: &mut wgpu::CommandEncoder,
+        target_view: &wgpu::TextureView,
+    ) {
+        let (vp_w, vp_h) = viewport_size;
+
+        // ── Step 1: integer tile rect, covering ceil(right)−floor(left) ──────
+        //
+        // Round each edge independently before deriving extent:
+        //
+        //   tile_x = floor(left)          (start of leftmost sub-pixel column)
+        //   tile_y = floor(top)
+        //   tile_w = ceil(right)−tile_x   (ensures tile covers [floor(l), ceil(r)])
+        //   tile_h = ceil(bottom)−tile_y
+        //
+        // Adding 1px fringe on each dimension provides the AA fringe budget that
+        // Skia/Impeller use, so the antialiasing gradient on the extreme edge is
+        // not truncated.
+        //
+        // Previous scheme `tile_w = ceil(width)` was WRONG:
+        //   left=5.6, right=25.4 → width=19.8 → tile_x=5, tile_w=ceil(19.8)=20
+        //   → tile right = 25, which is < right(25.4) → the rightmost 0.4 px
+        //   plus its AA fringe were hardware-clipped (HIGH finding).
+        //
+        // The max_tile_half cap ensures the 2× texture never exceeds the device
+        // max_texture_dimension_2d.  Tile dimensions are clamped to the viewport
+        // as before; the additional half-max cap handles the "vp≈max/2" crash
+        // scenario (HIGH finding — no-op .min(vp_w*2) was the only previous bound).
+        let max_tex_dim = device.limits().max_texture_dimension_2d;
+        // Half of max dim: the 2× texture must be ≤ max_tex_dim, so each tile
+        // side must be ≤ max_tex_dim/2.  Use saturating_div to avoid u32 overflow.
+        let max_tile_half = max_tex_dim.saturating_div(2).max(1);
+
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "device_bounds is non-negative device-pixel coordinates; \
+                      floor/ceil→u32 is analytically safe and clamped to [1,vp]"
+        )]
+        let tile_x = op.device_bounds.left().0.floor().max(0.0) as u32;
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "device_bounds is non-negative device-pixel coordinates"
+        )]
+        let tile_y = op.device_bounds.top().0.floor().max(0.0) as u32;
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "device_bounds right/bottom edges are non-negative; ceil is safe"
+        )]
+        let tile_right_edge = (op.device_bounds.right().0.ceil() as u32 + 1).min(vp_w); // +1px AA fringe
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "device_bounds right/bottom edges are non-negative; ceil is safe"
+        )]
+        let tile_bottom_edge = (op.device_bounds.bottom().0.ceil() as u32 + 1).min(vp_h); // +1px AA fringe
+
+        let tile_w = tile_right_edge.saturating_sub(tile_x).max(1);
+        let tile_h = tile_bottom_edge.saturating_sub(tile_y).max(1);
+
+        // No silent truncation: a path whose 2× tile would exceed the device's
+        // max texture dimension is rendered DIRECTLY onto the target (aliased but
+        // COMPLETE) rather than cropped into a clamped tile. Clamping the tile to
+        // `max_tile_half` (the previous behavior) hardware-clipped every vertex
+        // past the clamp, silently dropping the right/bottom of large path fills.
+        if tile_w > max_tile_half || tile_h > max_tile_half {
+            tracing::warn!(
+                tile_w,
+                tile_h,
+                max_tile_half,
+                "SSAA path exceeds max tile size; rendering aliased (complete, no AA) \
+                 to avoid silent truncation"
+            );
+            self.flush_segment(
+                &mut op.segment,
+                viewport_size,
+                device,
+                queue,
+                pipelines,
+                resources,
+                encoder,
+                target_view,
+            );
+            return;
+        }
+
+        // ── Step 2: acquire a 2× pooled texture ───────────────────────────────
+        //
+        // tile_w ≤ max_tile_half = max_tex_dim/2 (guaranteed by the fallback
+        // above), so tile_w*2 ≤ max_tex_dim. No wgpu create_texture error.
+        let supersample_w = tile_w * 2;
+        let supersample_h = tile_h * 2;
+
+        let super_tex = resources.layer_texture_pool_mut().acquire(
+            supersample_w,
+            supersample_h,
+            surface_format,
+        );
+        let super_view = super_tex.view();
+
+        // ── Step 3: clear + render into the 2× tile ───────────────────────────
+
+        // Clear to transparent (R3 invariant from opacity_layer.rs).
+        {
+            let _clear_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("SSAA Path 2x Clear Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: super_view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+        }
+
+        // Remap vertices from full-frame device-pixel space into the coordinate
+        // system the shape shader expects for the 2× tile render.
+        //
+        // The shape shader always computes:
+        //   clip_x = (pos.x / viewport.size.x) * 2.0 - 1.0
+        // where `viewport.size` is the value in `GpuReplay::viewport_buffer` —
+        // the full-frame size `(vp_w, vp_h)`.  We cannot change that uniform
+        // mid-encoder (`queue.write_buffer` takes effect at the next submit, not
+        // mid-encoder), so we must pre-transform the vertex positions so that
+        // dividing by `vp_w/vp_h` yields the correct NDC for the tile.
+        //
+        // Goal: a vertex at full-frame device pixel `(px, py)` should fill the
+        // 2× tile as if the tile were the whole viewport.  The tile-local
+        // coordinate is `(px - tile_x, py - tile_y)`.  We want:
+        //   (pos.x / vp_w) * 2 - 1  ==  ((px - tile_x) / tile_w) * 2 - 1
+        // Therefore: pos.x = (px - tile_x) * (vp_w / tile_w).
+        //
+        // `flush_segment` receives `viewport_size = (supersample_w, supersample_h)`
+        // so the scissor rect it sets covers the full 2× render target; wgpu
+        // clamps the scissor to the attachment dimensions automatically.
+        let tile_origin_x = tile_x as f32;
+        let tile_origin_y = tile_y as f32;
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "tile_w/tile_h are small u32 tile dims; f32 precision is \
+                      sufficient for device-pixel coordinate remapping"
+        )]
+        let scale_x = vp_w as f32 / tile_w as f32;
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "tile_h is a small u32 tile dim; f32 precision is sufficient"
+        )]
+        let scale_y = vp_h as f32 / tile_h as f32;
+
+        let mut remapped_segment = op.segment.clone();
+        for v in &mut remapped_segment.vertices {
+            v.position[0] = (v.position[0] - tile_origin_x) * scale_x;
+            v.position[1] = (v.position[1] - tile_origin_y) * scale_y;
+        }
+
+        // ── Scissor remap: full-frame → tile-local 2× space ─────────────────
+        //
+        // The `tess_batches` scissor was captured at record time in full-frame
+        // device-pixel coordinates (via `state.current_scissor()`).  We are
+        // now rendering into a 2× tile attachment whose top-left corresponds to
+        // `(tile_x, tile_y)` in full-frame space.  Applying the full-frame
+        // scissor verbatim against the tile attachment would clip to entirely
+        // the wrong region or fully clip the path (BLOCKER finding).
+        //
+        // Algorithm per batch:
+        //   1. Intersect the full-frame scissor with the tile rect.
+        //      If the intersection is empty → the entire tile is clipped →
+        //      set the batch's scissor to a zero-area rect (nothing drawn).
+        //   2. Translate the intersected rect to be tile-relative, then
+        //      scale both origin and extent by 2 (1× → 2× supersampled space).
+        //   3. Store the result back; `flush_tessellated_geometry` will apply it
+        //      against the (supersample_w × supersample_h) attachment.
+        //
+        // When the batch scissor is `None` (no clip), the geometry fills the
+        // entire tile — leave it as `None` so the full 2× attachment is covered.
+        for batch in &mut remapped_segment.tess_batches {
+            if let Some((sx, sy, sw, sh)) = batch.scissor {
+                // Tile rect in full-frame device pixels.
+                let tile_right = tile_x + tile_w;
+                let tile_bottom = tile_y + tile_h;
+
+                // Full-frame scissor right/bottom edges.
+                let scis_right = sx + sw;
+                let scis_bottom = sy + sh;
+
+                // Intersect: [max(left), max(top), min(right), min(bottom)].
+                let inter_x = sx.max(tile_x);
+                let inter_y = sy.max(tile_y);
+                let inter_right = scis_right.min(tile_right);
+                let inter_bottom = scis_bottom.min(tile_bottom);
+
+                if inter_right <= inter_x || inter_bottom <= inter_y {
+                    // Intersection is empty → tile is fully clipped → nothing
+                    // should be drawn.  Use a 1×1 off-target rect as a sentinel
+                    // (wgpu requires non-zero extent; clamping to attachment dims
+                    // means it will simply not intersect any drawn pixels).
+                    batch.scissor = Some((supersample_w, supersample_h, 1, 1));
+                } else {
+                    // Translate to tile-local coordinates and scale to 2× space.
+                    let local_x = (inter_x - tile_x) * 2;
+                    let local_y = (inter_y - tile_y) * 2;
+                    let local_w = (inter_right - inter_x) * 2;
+                    let local_h = (inter_bottom - inter_y) * 2;
+                    batch.scissor = Some((local_x, local_y, local_w, local_h));
+                }
+            }
+        }
+
+        // Flush the remapped segment into the 2× texture.
+        // `viewport_size = (supersample_w, supersample_h)` so the scissor covers
+        // the full 2× render target.  The shape shader's static viewport uniform
+        // `(vp_w, vp_h)` combined with the pre-scaled positions produces NDC that
+        // fills the tile, rendering it into the 2× texture → supersampled.
+        self.flush_segment(
+            &mut remapped_segment,
+            (supersample_w, supersample_h),
+            device,
+            queue,
+            pipelines,
+            resources,
+            encoder,
+            super_view,
+        );
+
+        // ── Step 4: box-downsample 2× → 1× premultiplied tile ────────────────
+
+        let one_x_tile = self.downsample_ssaa_tile(
+            &super_tex,
+            tile_w,
+            tile_h,
+            surface_format,
+            device,
+            pipelines,
+            resources,
+            encoder,
+        );
+
+        // 2× tile is no longer needed — drop it back to the pool now, before
+        // the composite pass, to minimise peak texture memory.
+        drop(super_tex);
+
+        // ── Step 5: composite the 1× tile onto the target ────────────────────
+
+        let composite_bounds = Rect::from_xywh(
+            Pixels(tile_x as f32),
+            Pixels(tile_y as f32),
+            Pixels(tile_w as f32),
+            Pixels(tile_h as f32),
+        );
+
+        let instance = super::instancing::TextureInstance::new(
+            composite_bounds,
+            flui_types::styling::Color::WHITE,
+        );
+        let _ = self.texture_batch.add(instance);
+
+        self.flush_texture_batch_premultiplied(
+            device,
+            queue,
+            pipelines,
+            resources,
+            viewport_size,
+            encoder,
+            target_view,
+            one_x_tile.view(),
+            None, // no scissor for tile composite
+        );
+
+        // 1× tile drops here → returns to pool (RAII).
+    }
+
+    /// Box-downsample a 2× pooled `source_texture` into a fresh 1× tile.
+    ///
+    /// Returns the 1× [`PooledTexture`]; the caller is responsible for
+    /// compositing it before dropping.
+    fn downsample_ssaa_tile(
+        &mut self,
+        source_tex: &PooledTexture,
+        output_w: u32,
+        output_h: u32,
+        output_format: wgpu::TextureFormat,
+        device: &Arc<wgpu::Device>,
+        pipelines: &PipelineSet,
+        resources: &mut GpuResources,
+        encoder: &mut wgpu::CommandEncoder,
+    ) -> PooledTexture {
+        // Acquire the 1× output tile and clear it to transparent.
+        let one_x_tile =
+            resources
+                .layer_texture_pool_mut()
+                .acquire(output_w, output_h, output_format);
+        let one_x_view = one_x_tile.view();
+
+        {
+            let _clear = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("SSAA Downsample 1x Clear Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: one_x_view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+        }
+
+        // Build the bind group: source 2× texture + linear sampler.
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("SSAA Downsample Bind Group"),
+            layout: &pipelines.ssaa_downsample.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(source_tex.view()),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    // `default_sampler` uses Linear filtering — correct for the 4-tap box average.
+                    resource: wgpu::BindingResource::Sampler(&self.default_sampler),
+                },
+            ],
+        });
+
+        // Fullscreen quad in NDC: two triangles covering [-1,1] × [-1,1].
+        // UV (0,0) = top-left, (1,1) = bottom-right to match wgpu's top-left origin.
+        #[rustfmt::skip]
+        let quad_vertices: &[f32] = &[
+            // position (x,y)   UV (u,v)
+            -1.0,  1.0,         0.0, 0.0, // top-left
+            -1.0, -1.0,         0.0, 1.0, // bottom-left
+             1.0, -1.0,         1.0, 1.0, // bottom-right
+            -1.0,  1.0,         0.0, 0.0, // top-left
+             1.0, -1.0,         1.0, 1.0, // bottom-right
+             1.0,  1.0,         1.0, 0.0, // top-right
+        ];
+
+        let vertex_buffer = {
+            use wgpu::util::DeviceExt as _;
+            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("SSAA Downsample Quad VB"),
+                contents: bytemuck::cast_slice(quad_vertices),
+                usage: wgpu::BufferUsages::VERTEX,
+            })
+        };
+
+        // Run the downsample pass.
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("SSAA Box Downsample Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: one_x_view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load, // preserve the clear-transparent baseline
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+
+            pass.set_pipeline(&pipelines.ssaa_downsample.pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.set_vertex_buffer(0, vertex_buffer.slice(..));
+            pass.draw(0..6, 0..1);
+        }
+
+        one_x_tile
+    }
+}
+
+// ─── unit tests (CPU-only) ────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod unit_tests {
+    use super::super::batches::DrawBatcher;
+    use super::super::command_ir::{DrawItem, DrawSegment};
+    use super::super::state_stack::GpuStateStack;
+    use super::super::{command_ir::SsaaPathOp, vertex::Vertex};
+    use flui_types::{Rect, geometry::Pixels};
+
+    fn make_vertex(x: f32, y: f32) -> Vertex {
+        Vertex {
+            position: [x, y],
+            color: [1.0, 0.0, 0.0, 1.0],
+            tex_coord: [0.0, 0.0],
+        }
+    }
+
+    // ── U1: SsaaPathOp is Clone (T11 purity witness) ─────────────────────────
+
+    /// U1: `SsaaPathOp` must implement `Clone` (T11 IR-purity contract).
+    ///
+    /// Derivability of `Clone` proves no GPU handle is embedded in the record IR.
+    #[test]
+    fn ssaa_path_op_is_clone() {
+        let mut seg = DrawSegment::new();
+        seg.vertices.push(make_vertex(0.0, 0.0));
+        seg.vertices.push(make_vertex(10.0, 0.0));
+        seg.vertices.push(make_vertex(5.0, 10.0));
+
+        let op = SsaaPathOp {
+            segment: seg,
+            device_bounds: Rect::from_xywh(Pixels(0.0), Pixels(0.0), Pixels(10.0), Pixels(10.0)),
+        };
+
+        let cloned = op.clone();
+        assert_eq!(
+            cloned.segment.vertices.len(),
+            3,
+            "cloned SsaaPathOp must have 3 vertices"
+        );
+        assert!(
+            (cloned.device_bounds.width().0 - 10.0).abs() < f32::EPSILON,
+            "cloned device_bounds width must be 10"
+        );
+    }
+
+    // ── U2: divert_path_to_ssaa produces DrawItem::SsaaPath ─────────────────
+
+    /// U2: `divert_path_to_ssaa` must push `DrawItem::SsaaPath` to draw_order.
+    #[test]
+    fn divert_path_to_ssaa_produces_ssaa_path_item() {
+        let mut segment = DrawSegment::new();
+        let mut draw_order: Vec<DrawItem> = Vec::new();
+        let state = GpuStateStack::new_for_test();
+
+        let vertices = vec![
+            make_vertex(0.0, 0.0),
+            make_vertex(10.0, 0.0),
+            make_vertex(5.0, 10.0),
+        ];
+        let indices = [0u32, 1, 2];
+
+        DrawBatcher::divert_path_to_ssaa(
+            &mut segment,
+            &mut draw_order,
+            &state,
+            &vertices,
+            &indices,
+        );
+
+        assert_eq!(draw_order.len(), 1, "one SsaaPath item must be pushed");
+        assert!(
+            matches!(draw_order[0], DrawItem::SsaaPath(_)),
+            "draw_order[0] must be SsaaPath"
+        );
+    }
+
+    // ── U3: divert seals prior content before pushing SsaaPath ──────────────
+
+    /// U3: Prior SrcOver content in the main segment must be sealed into a
+    /// `DrawItem::Segment` before the `DrawItem::SsaaPath` (Z-order correctness).
+    #[test]
+    fn divert_path_to_ssaa_seals_prior_content() {
+        use super::super::pipeline::PipelineKey;
+
+        let mut segment = DrawSegment::new();
+        let mut draw_order: Vec<DrawItem> = Vec::new();
+        let state = GpuStateStack::new_for_test();
+
+        // Add SrcOver content to the current segment.
+        DrawBatcher::add_tessellated_with_key(
+            &mut segment,
+            &mut draw_order,
+            &state,
+            vec![
+                make_vertex(0.0, 0.0),
+                make_vertex(10.0, 0.0),
+                make_vertex(5.0, 5.0),
+            ],
+            &[0, 1, 2],
+            PipelineKey::alpha_blend(),
+        );
+        assert!(draw_order.is_empty(), "SrcOver stays in segment");
+
+        // Divert a path to SSAA — must seal the prior content first.
+        DrawBatcher::divert_path_to_ssaa(
+            &mut segment,
+            &mut draw_order,
+            &state,
+            &[
+                make_vertex(5.0, 5.0),
+                make_vertex(15.0, 5.0),
+                make_vertex(10.0, 15.0),
+            ],
+            &[0, 1, 2],
+        );
+
+        assert_eq!(
+            draw_order.len(),
+            2,
+            "draw_order must have [Segment (sealed prior), SsaaPath]"
+        );
+        assert!(
+            matches!(draw_order[0], DrawItem::Segment(_)),
+            "draw_order[0] must be the sealed prior Segment"
+        );
+        assert!(
+            matches!(draw_order[1], DrawItem::SsaaPath(_)),
+            "draw_order[1] must be SsaaPath"
+        );
+    }
+
+    // ── U4: device_bounds AABB is correct ────────────────────────────────────
+
+    /// U4: The `device_bounds` in `SsaaPathOp` must be the AABB of the
+    /// input vertices.
+    #[test]
+    fn divert_path_to_ssaa_device_bounds_is_vertex_aabb() {
+        let mut segment = DrawSegment::new();
+        let mut draw_order: Vec<DrawItem> = Vec::new();
+        let state = GpuStateStack::new_for_test();
+
+        DrawBatcher::divert_path_to_ssaa(
+            &mut segment,
+            &mut draw_order,
+            &state,
+            &[
+                make_vertex(5.0, 10.0),
+                make_vertex(30.0, 10.0),
+                make_vertex(17.5, 40.0),
+            ],
+            &[0, 1, 2],
+        );
+
+        let DrawItem::SsaaPath(ref op) = draw_order[0] else {
+            panic!("expected SsaaPath");
+        };
+
+        assert!(
+            (op.device_bounds.left().0 - 5.0).abs() < 0.01,
+            "left must be 5.0; got {}",
+            op.device_bounds.left().0
+        );
+        assert!(
+            (op.device_bounds.top().0 - 10.0).abs() < 0.01,
+            "top must be 10.0; got {}",
+            op.device_bounds.top().0
+        );
+        assert!(
+            (op.device_bounds.right().0 - 30.0).abs() < 0.01,
+            "right must be 30.0; got {}",
+            op.device_bounds.right().0
+        );
+        assert!(
+            (op.device_bounds.bottom().0 - 40.0).abs() < 0.01,
+            "bottom must be 40.0; got {}",
+            op.device_bounds.bottom().0
+        );
+    }
+
+    // ── U5: empty indices produce no item ────────────────────────────────────
+
+    /// U5: `divert_path_to_ssaa` with empty indices must produce nothing.
+    #[test]
+    fn divert_path_to_ssaa_empty_indices_is_noop() {
+        let mut segment = DrawSegment::new();
+        let mut draw_order: Vec<DrawItem> = Vec::new();
+        let state = GpuStateStack::new_for_test();
+
+        DrawBatcher::divert_path_to_ssaa(
+            &mut segment,
+            &mut draw_order,
+            &state,
+            &[make_vertex(0.0, 0.0), make_vertex(10.0, 0.0)],
+            &[], // empty indices
+        );
+
+        assert!(
+            draw_order.is_empty(),
+            "empty indices must produce no draw item"
+        );
+    }
+
+    // ── U6: tile rect covers the full right/bottom sub-pixel edge ────────────
+
+    /// U6: `tile_x + tile_w` must be ≥ `ceil(right)`, and
+    /// `tile_y + tile_h` must be ≥ `ceil(bottom)`, for sub-pixel path bounds.
+    ///
+    /// The previous `tile_w = ceil(width)` scheme failed this:
+    ///   left=5.6, right=25.4 → width=19.8 → tile_x=5, tile_w=ceil(19.8)=20
+    ///   → right_edge=25 < ceil(right)=26  ← sub-pixel clip bug.
+    ///
+    /// The corrected scheme:
+    ///   tile_x = floor(left) = 5
+    ///   tile_w = ceil(right)+1 − tile_x = 27−5 = 22  (includes +1 AA fringe)
+    ///   → right_edge = 27 ≥ ceil(right)=26  ✓
+    ///
+    /// This test asserts the arithmetic directly against the formula used in
+    /// `render_ssaa_path` — it would have caught the pre-fix under-coverage.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    #[test]
+    fn tile_rect_covers_full_subpixel_right_and_bottom_edge() {
+        struct Case {
+            left: f32,
+            top: f32,
+            right: f32,
+            bottom: f32,
+            vp_w: u32,
+            vp_h: u32,
+        }
+
+        let cases = [
+            // Original bug: floor(left)=5, ceil(width=19.8)=20 → tile right=25 < ceil(right)=26.
+            Case {
+                left: 5.6,
+                top: 10.3,
+                right: 25.4,
+                bottom: 40.7,
+                vp_w: 1920,
+                vp_h: 1080,
+            },
+            // Integer bounds: no sub-pixel, must still cover.
+            Case {
+                left: 0.0,
+                top: 0.0,
+                right: 100.0,
+                bottom: 100.0,
+                vp_w: 800,
+                vp_h: 600,
+            },
+            // Near-zero width.
+            Case {
+                left: 10.1,
+                top: 10.1,
+                right: 10.9,
+                bottom: 10.9,
+                vp_w: 200,
+                vp_h: 200,
+            },
+        ];
+
+        for c in &cases {
+            let tile_x = c.left.floor().max(0.0) as u32;
+            let tile_y = c.top.floor().max(0.0) as u32;
+            // Corrected formula: ceil each edge, derive extent, add +1 AA fringe.
+            let tile_right_edge = ((c.right.ceil() as u32) + 1).min(c.vp_w);
+            let tile_bottom_edge = ((c.bottom.ceil() as u32) + 1).min(c.vp_h);
+            let tile_w = tile_right_edge.saturating_sub(tile_x).max(1);
+            let tile_h = tile_bottom_edge.saturating_sub(tile_y).max(1);
+
+            let tile_right = tile_x + tile_w;
+            let tile_bottom = tile_y + tile_h;
+
+            assert!(
+                tile_right >= c.right.ceil() as u32,
+                "tile right edge ({}) must cover ceil(right={})={}",
+                tile_right,
+                c.right,
+                c.right.ceil() as u32,
+            );
+            assert!(
+                tile_bottom >= c.bottom.ceil() as u32,
+                "tile bottom edge ({}) must cover ceil(bottom={})={}",
+                tile_bottom,
+                c.bottom,
+                c.bottom.ceil() as u32,
+            );
+        }
+    }
+
+    // ── U7: scissor remap translates to tile-local 2× space ─────────────────
+
+    /// U7: A full-frame scissor must be translated into tile-local 2× space
+    /// when `render_ssaa_path` remaps the vertex segment.
+    ///
+    /// Concrete: tile at (50, 50), size 100×100; full-frame scissor (60,70,40,30).
+    /// Expected tile-local 2× scissor:
+    ///   inter_x = max(60,50) = 60, inter_y = max(70,50) = 70
+    ///   inter_right = min(100,150) = 100, inter_bottom = min(100,150) = 100
+    ///   local_x = (60−50)*2 = 20, local_y = (70−50)*2 = 40
+    ///   local_w = (100−60)*2 = 80, local_h = (100−70)*2 = 60
+    ///
+    /// Without the fix: full-frame scissor (60,70,40,30) is applied verbatim
+    /// against the 200×200 tile attachment.  The tile starts at pixel (0,0)
+    /// in attachment space, so x=60 is far inside the tile but refers to the
+    /// wrong frame of reference → the clip rect covers the wrong region.
+    #[test]
+    fn scissor_remap_produces_correct_tile_local_coords() {
+        // Tile parameters (matching render_ssaa_path Step 1 output).
+        let tile_x: u32 = 50;
+        let tile_y: u32 = 50;
+        let tile_w: u32 = 100;
+        let tile_h: u32 = 100;
+        let supersample_w: u32 = tile_w * 2;
+        let supersample_h: u32 = tile_h * 2;
+
+        // Full-frame scissor from `state.current_scissor()` at record time.
+        let scissor: (u32, u32, u32, u32) = (60, 70, 40, 30);
+        let (sx, sy, sw, sh) = scissor;
+
+        // Remap (mirrors render_ssaa_path scissor-remap logic verbatim).
+        let tile_right = tile_x + tile_w;
+        let tile_bottom = tile_y + tile_h;
+        let scis_right = sx + sw;
+        let scis_bottom = sy + sh;
+
+        let inter_x = sx.max(tile_x);
+        let inter_y = sy.max(tile_y);
+        let inter_right = scis_right.min(tile_right);
+        let inter_bottom = scis_bottom.min(tile_bottom);
+
+        let remapped = if inter_right <= inter_x || inter_bottom <= inter_y {
+            (supersample_w, supersample_h, 1, 1) // sentinel: fully clipped
+        } else {
+            let local_x = (inter_x - tile_x) * 2;
+            let local_y = (inter_y - tile_y) * 2;
+            let local_w = (inter_right - inter_x) * 2;
+            let local_h = (inter_bottom - inter_y) * 2;
+            (local_x, local_y, local_w, local_h)
+        };
+
+        assert_eq!(
+            remapped,
+            (20, 40, 80, 60),
+            "tile-local 2× scissor must be (20, 40, 80, 60); got {remapped:?}"
+        );
+    }
+
+    // ── U7b: scissor entirely outside tile → fully-clipped sentinel ─────────
+
+    /// U7b: A full-frame scissor that does not intersect the tile must produce
+    /// the fully-clipped sentinel, not a garbage rect that accidentally covers
+    /// part of the tile.
+    ///
+    /// Without the fix this case is impossible to distinguish from correct
+    /// rendering — the full-frame scissor would be applied as-is and might
+    /// accidentally clip to a different but non-empty region.
+    #[test]
+    fn scissor_fully_outside_tile_produces_sentinel() {
+        let tile_x: u32 = 300;
+        let tile_y: u32 = 0;
+        let tile_w: u32 = 100;
+        let tile_h: u32 = 100;
+        let supersample_w: u32 = tile_w * 2;
+        let supersample_h: u32 = tile_h * 2;
+
+        // Scissor entirely to the LEFT of the tile (x∈[0..99], tile x∈[300..399]).
+        let (sx, sy, sw, sh): (u32, u32, u32, u32) = (0, 0, 100, 100);
+
+        let tile_right = tile_x + tile_w;
+        let tile_bottom = tile_y + tile_h;
+        let scis_right = sx + sw;
+        let scis_bottom = sy + sh;
+
+        let inter_x = sx.max(tile_x);
+        let inter_y = sy.max(tile_y);
+        let inter_right = scis_right.min(tile_right);
+        let inter_bottom = scis_bottom.min(tile_bottom);
+
+        let remapped = if inter_right <= inter_x || inter_bottom <= inter_y {
+            (supersample_w, supersample_h, 1, 1)
+        } else {
+            let local_x = (inter_x - tile_x) * 2;
+            let local_y = (inter_y - tile_y) * 2;
+            let local_w = (inter_right - inter_x) * 2;
+            let local_h = (inter_bottom - inter_y) * 2;
+            (local_x, local_y, local_w, local_h)
+        };
+
+        assert_eq!(
+            remapped,
+            (supersample_w, supersample_h, 1, 1),
+            "scissor entirely outside tile must produce the fully-clipped sentinel; got {remapped:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Tessellated AA — PR-3 (arbitrary paths via SSAA)

Half 2 of the engine-wide AA series (Half 1 = SDF-reroute for closed-form shapes, merged in [#258](https://github.com/vanyastaff/flui/pull/258)/[#259](https://github.com/vanyastaff/flui/pull/259)/[#260](https://github.com/vanyastaff/flui/pull/260)). Spec: `.rust-studio/specs/tessellated-aa/SPEC.md`.

### What this PR does
Anti-aliases **arbitrary SrcOver path/polygon fills** (custom `Path`, béziers, self-intersecting/holed) by **supersampling lyon's existing CPU triangulation**: render the path into an isolated **2× pooled offscreen**, **box-downsample** to a premultiplied 1× tile, composite via the premultiplied texture batch. Surface stays `sample_count: 1` (no MSAA, no stencil) — supersampling is unconditionally correct on all topologies. Closed-form shapes (already SDF-AA'd) and non-SrcOver paths (PR-4) are untouched.

- New `DrawItem::SsaaPath(SsaaPathOp{ segment, device_bounds })` — Clone, handle-free (T11-pure); mirrors `AdvancedShape` (carries the tessellated segment, rendered at replay, Z-correct via R1 arm order).
- `batches/{mod,paths}.rs`: SrcOver `Fill` paths divert to `SsaaPath` (seal prior segment + push), parallel to the advanced-blend diversion. Only `draw_path` fills reach it.
- New `wgpu/ssaa.rs`: `render_ssaa_path` (2× tile render with a full-frame-equivalent vertex remap — the viewport uniform can't change mid-encoder, so vertices are pre-scaled by `vp/tile`) + `downsample_ssaa_tile` + `SsaaDownsamplePipeline`; new `shaders/effects/box_downsample.wgsl` (4-tap `0.5/src_dim` box filter, premultiplied-correct).
- **No silent truncation**: a path whose 2× tile would exceed the device max texture dimension renders **directly onto the target** (aliased but COMPLETE) + `tracing::warn`, instead of cropping into a clamped tile.
- `replay.rs` 1556 → 1384 LOC: `flush_opacity_layer` relocated to `opacity_layer.rs` (behavior-preserving; satisfies the <1500 LOC cap — condition 9 sanctions splitting).
- Oracle tests **P1** (polygon boundary vs analytic coverage), **P2** (pentagram NonZero solid vs EvenOdd hole — self-intersecting topology), **P3** (scale-invariant AA band, 1× vs 4×, ≤2× ratio), **P4** (anti-MVP: SrcOver fill emits partial-alpha boundary).

### Process
Built via a **Workflow** (build → 2 adversarial review rounds → fix); the self-repair loop fixed 5 BLOCKER/HIGH (incl. the mid-encoder viewport bug + a non-self-intersecting pentagram). My integrator pass then fixed the residual findings: **silent-crop fallback**, **P3 teeth** (4×→2×), **T11 drain** now surfaces the `SsaaPath` segment (no silent omission), and 3 doc-accuracy corrections (premultiplied source pipeline, box-filter offset). The `flush_opacity_layer` move was verified clean (single definition, no duplicate).

### Scope / deferrals
Non-SrcOver + Porter-Duff/advanced arbitrary paths → PR-4. Perf follow-ups (noted): SSAA-tile pool size-bucketing to avoid evicting full-viewport layer textures; reuse the unit-quad buffer in the downsample. Byte-identity is intentionally **not** claimed for paths (they were aliased before). `painter.rs` (4474 LOC, pre-existing oversize) was touched only for a 1-line enum-exhaustiveness arm.

### Verification
- `clippy` (default **and** `--features enable-wgpu-tests`, `-D warnings`) clean · `fmt` · `cargo doc -D warnings` · `cargo test --lib` 170
- **DX12 GPU-readback: 328 passed / 0 failed / 7 ignored** (incl. the full Phase B + PR-1/2/2b suites — no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)