### PR TITLE
feat(engine): tessellated AA — non-SrcOver path/shape AA via SSAA tile (tessellated-AA PR-4)

### DIFF
--- a/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
+++ b/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
@@ -505,7 +505,7 @@ mod gpu_tests {
     use std::f32::consts::PI;
     use std::sync::Arc;
 
-    use flui_painting::Paint;
+    use flui_painting::{BlendMode, Paint};
     use flui_types::{
         Color, Rect,
         geometry::{Pixels, RRect, px},
@@ -2830,6 +2830,754 @@ mod gpu_tests {
             "A4 FAILED: only {interior_partial} interior partial-alpha pixels (device dist < \
              radius-2) — the angular sector edges are hard-aliased. The screen-space angular \
              SDF + fwidth must produce a smooth ~1px band along each diagonal edge."
+        );
+    }
+
+    // ── PD1: tile-safe non-SrcOver arbitrary path is SSAA-routed ────────────
+
+    /// PD1: A tile-safe non-SrcOver arbitrary path fill (Xor mode on a
+    /// transparent surface) must produce partial alpha at its boundary —
+    /// proving the PR-4 SSAA routing fires for tile-safe non-SrcOver fills.
+    ///
+    /// ## Blend-mode selection rationale
+    ///
+    /// `Xor` on a transparent destination is equivalent to `SrcOver` (both give
+    /// `src * 1 + 0 * (1-src_a) = src`), so the pixel output is identical to the
+    /// SrcOver SSAA path.  This makes Xor the ideal probe for routing: the SSAA
+    /// tile is rendered with the SrcOver pipeline (a known-correct path), and the
+    /// composite is also effectively SrcOver — so the test validates that Xor IS
+    /// routed through the SSAA tile without requiring a per-mode texture composite
+    /// pipeline (TODO T12, deferred).
+    ///
+    /// Other tile-safe modes (DstOut, DstOver, Plus) composite differently and
+    /// their correct pixel output requires TODO T12.
+    ///
+    /// ## Routing proof (what this test guards)
+    ///
+    /// If Xor is NOT routed through SSAA (stays tessellated, aliased), boundary
+    /// pixels are hard 0 or 255 — no partial alpha. SSAA produces genuine fractional
+    /// alpha at every non-axis-aligned edge. The same kite geometry as p4 is used.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index arithmetic over a small fixed-size test surface"
+    )]
+    fn pd1_tile_safe_non_srcover_path_has_partial_alpha_at_boundary() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        // Non-axis-aligned irregular kite — all edges are diagonal.
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+        let v = [
+            (cx + 1.3, cy - 38.7),
+            (cx + 42.2, cy + 5.5),
+            (cx - 2.7, cy + 33.1),
+            (cx - 38.4, cy - 9.2),
+        ];
+        let mut path = flui_types::painting::path::Path::new();
+        path.move_to(flui_types::Point::new(Pixels(v[0].0), Pixels(v[0].1)));
+        for &(x, y) in &v[1..] {
+            path.line_to(flui_types::Point::new(Pixels(x), Pixels(y)));
+        }
+        path.close();
+
+        // Xor on transparent background = SrcOver (same pixel output, different mode
+        // tag). Proves tile-safe routing fires without needing TODO T12 blend fix.
+        let paint = Paint::fill(Color::WHITE).with_blend_mode(BlendMode::Xor);
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.draw_path(&path, &paint);
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("PD1 Xor Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Partial alpha at the kite boundary proves SSAA ran: hard tessellation
+        // produces only 0 or 255. Xor on transparent = SrcOver so boundary alpha =
+        // sub-pixel coverage, same as p4.
+        let partial_count = pixels.iter().filter(|p| p[3] > 5 && p[3] < 250).count();
+
+        assert!(
+            partial_count >= 4,
+            "PD1 FAILED: only {partial_count} partial-alpha pixels — the Xor tile-safe \
+             SSAA reroute appears to be a no-op or hard-aliased. PR-4 must route tile-safe \
+             non-SrcOver fills through the SSAA tile."
+        );
+    }
+
+    // ── PD3: non-SrcOver basic shape is SSAA-routed ──────────────────────────
+
+    /// PD3: A non-SrcOver rrect fill (Xor on transparent background) must
+    /// produce partial alpha at its curved corner boundary — proving the
+    /// shapes batcher routes non-SrcOver fills through SSAA (PR-4).
+    ///
+    /// ## Blend-mode selection rationale (same as PD1)
+    ///
+    /// `Xor` on a transparent destination equals `SrcOver` pixel-output-wise,
+    /// so the composite step does not need the per-mode pipeline (TODO T12).
+    /// The test validates that the shapes SSAA routing fires and the rounded
+    /// corner pixels receive genuine sub-pixel coverage.
+    ///
+    /// Uses an unrotated rrect with 10 px corner radii — the curved corner
+    /// band is the best probe for SSAA sub-pixel coverage vs hard aliasing.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index arithmetic over a small fixed-size test surface"
+    )]
+    fn pd3_non_srcover_basic_shape_has_partial_alpha_at_boundary() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        // Large rrect (60×60) with 10 px corner radii — well above SSAA threshold.
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+        let rrect = RRect::from_rect_circular(
+            Rect::from_xywh(px(cx - 30.0), px(cy - 30.0), px(60.0), px(60.0)),
+            px(10.0),
+        );
+
+        // Xor on transparent = SrcOver; proves routing fires without TODO T12.
+        let paint = Paint::fill(Color::WHITE).with_blend_mode(BlendMode::Xor);
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.rrect(rrect, &paint);
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("PD3 Xor Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Partial alpha at the curved corners and straight edges proves SSAA ran.
+        let partial_count = pixels.iter().filter(|p| p[3] > 5 && p[3] < 250).count();
+
+        assert!(
+            partial_count >= 4,
+            "PD3 FAILED: only {partial_count} partial-alpha pixels — the Xor rrect fill \
+             appears hard-aliased. PR-4 must route non-SrcOver basic shapes through SSAA."
+        );
+    }
+
+    // ── PD2: tile-safe non-SrcOver produces visually distinct output over backdrop ──
+
+    /// PD2: A tile-safe non-SrcOver SSAA path composited over a non-transparent
+    /// backdrop must produce pixel output that is visibly distinct from SrcOver.
+    ///
+    /// ## Why this test is necessary (gap in PD1 / PD3)
+    ///
+    /// PD1 and PD3 use `Xor` on a *transparent* destination.  On a transparent
+    /// dst, `Xor` and `SrcOver` produce identical pixel output (both yield `src`),
+    /// so those tests cannot distinguish whether the correct `Xor` blend pipeline
+    /// (`blend_state_for(Xor)`) or the default SrcOver pipeline fires at composite
+    /// time.  PD2 forces a non-transparent backdrop so the two pipelines diverge.
+    ///
+    /// ## Blend mode and expected pixel values
+    ///
+    /// `DstOut` is tile-safe (`is_tile_safe_for_ssaa` = true).
+    /// wgpu blend: `(src_factor=Zero, dst_factor=OneMinusSrcAlpha)`.
+    ///
+    /// Setup:
+    ///   - Background: opaque green `(0, 255, 0, 255)` painted with SrcOver.
+    ///   - Foreground: large white circle (r=40) with `DstOut` blend.
+    ///
+    /// Interior pixel formula (src.alpha=1 at the center of the circle):
+    ///   out.alpha = 0 + (1 − 1.0) × dst.alpha = 0   → transparent
+    ///   out.rgb   = 0 + (1 − 1.0) × dst.rgb   = 0   → black (premul of transparent)
+    ///
+    /// Under SrcOver the same pixel would be white (255, 255, 255, 255).
+    /// Under DstOut the interior becomes transparent (alpha ≈ 0).
+    ///
+    /// ## Partial-alpha proof (SSAA ran)
+    ///
+    /// At the circle boundary the SSAA tile has partial alpha `a_tile ∈ (0,1)`.
+    /// DstOut composite gives `out.alpha = dst.alpha × (1 − a_tile)`.
+    /// With `dst.alpha = 1`: `out.alpha = 1 − a_tile ∈ (0, 1)`.
+    /// These pixels show partial alpha — proving SSAA ran AND the DstOut blend
+    /// pipeline was used (SrcOver would yield alpha = 1 at the same positions).
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index arithmetic over a small fixed-size test surface"
+    )]
+    fn pd2_tile_safe_non_srcover_over_opaque_backdrop_is_pixel_distinct_from_srcover() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+        let radius = 40.0_f32;
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+
+        // Step 1: paint an opaque green background covering the whole surface.
+        // This is SrcOver — it comes first in draw order so the DstOut circle
+        // composites onto the green backdrop.
+        let full_rect = Rect::from_xywh(
+            px(0.0),
+            px(0.0),
+            px(SURFACE_WIDTH as f32),
+            px(SURFACE_HEIGHT as f32),
+        );
+        let green = Color::rgba(0, 255, 0, 255);
+        painter.rect(full_rect, &Paint::fill(green));
+
+        // Step 2: paint a large white circle with DstOut blend (tile-safe, non-SrcOver).
+        // Radius 40 → bounding box area = 80×80 = 6400 px² >> SSAA_AREA_THRESHOLD_PX_SQ=256.
+        // The circle is placed slightly off-pixel-center to ensure non-axis-aligned
+        // edges and genuine partial-alpha boundary pixels from the SSAA downsample.
+        let center = flui_types::Point::new(px(cx + 0.5), px(cy + 0.5));
+        painter.circle(
+            center,
+            radius,
+            &Paint::fill(Color::WHITE).with_blend_mode(BlendMode::DstOut),
+        );
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("PD2 DstOut Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Assertion 1: interior pixel is near-transparent (DstOut erases backdrop).
+        // Center pixel must have alpha close to 0. Under SrcOver it would be 255.
+        let interior_idx = cy as usize * SURFACE_WIDTH as usize + cx as usize;
+        let interior_alpha = pixels[interior_idx][3];
+        assert!(
+            interior_alpha < 30,
+            "PD2 FAILED: interior alpha={interior_alpha}, expected near-0 (DstOut erases \
+             the opaque green backdrop). SrcOver or wrong pipeline would give alpha=255."
+        );
+
+        // Assertion 2: boundary pixels show partial alpha — SSAA ran.
+        // Pixels near the circle edge (dist ∈ [radius-2, radius+2]) that have
+        // partial alpha can ONLY exist if SSAA resolved sub-pixel coverage.
+        let mut boundary_partial = 0usize;
+        for row in 0..SURFACE_HEIGHT {
+            for col in 0..SURFACE_WIDTH {
+                let dx = col as f32 + 0.5 - (cx + 0.5);
+                let dy = row as f32 + 0.5 - (cy + 0.5);
+                let dist = (dx * dx + dy * dy).sqrt();
+                if (radius - 2.0..=radius + 2.0).contains(&dist) {
+                    let alpha = pixels[row as usize * SURFACE_WIDTH as usize + col as usize][3];
+                    // DstOut boundary: alpha = 1 − a_tile, so partial when a_tile ∈ (0,1).
+                    // Strictly between 10 and 245 to exclude hard 0/255 edges.
+                    if alpha > 10 && alpha < 245 {
+                        boundary_partial += 1;
+                    }
+                }
+            }
+        }
+        assert!(
+            boundary_partial >= 4,
+            "PD2 FAILED: only {boundary_partial} partial-alpha boundary pixels — SSAA \
+             must produce sub-pixel coverage at the circle boundary when DstOut is active."
+        );
+    }
+
+    // ── PD6: per-mode composite is the REQUESTED blend, not SrcOver ──────────
+
+    /// PD6: For several tile-safe non-SrcOver modes, compositing the SSAA tile
+    /// over an OPAQUE backdrop must match `Color::blend(src, backdrop, mode)` —
+    /// NOT SrcOver. This pins the per-mode composite pipeline selection
+    /// (`flush_texture_batch_premultiplied_with_mode` → `blend_state_for(mode)`),
+    /// which PD1/PD3/PD4 (Xor-on-transparent) cannot detect because Xor and
+    /// SrcOver are pixel-identical over a transparent dst. PD2 covers DstOut;
+    /// this covers Dst/DstOver/Xor over an opaque dst where each differs from
+    /// SrcOver. Together they pixel-verify the per-mode composite for 4 of the 6
+    /// non-SrcOver tile-safe modes; the dispatch is uniform (keyed by `mode`), so
+    /// the remaining two share the verified code path.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index arithmetic over a small fixed-size test surface"
+    )]
+    fn pd6_tile_safe_composite_matches_requested_blend_not_srcover() {
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+        let radius = 40.0_f32;
+        let backdrop = Color::rgba(220, 30, 30, 255); // opaque red
+        let src = Color::rgba(40, 90, 230, 255); // opaque blue (distinct channels)
+
+        for mode in [BlendMode::Dst, BlendMode::DstOver, BlendMode::Xor] {
+            let expected = src.blend(backdrop, mode);
+            let srcover = src.blend(backdrop, BlendMode::SrcOver);
+            // Teeth: the chosen setup must make this mode pixel-distinct from
+            // SrcOver, else a wrong (SrcOver) pipeline would pass.
+            assert_ne!(
+                (expected.r, expected.g, expected.b, expected.a),
+                (srcover.r, srcover.g, srcover.b, srcover.a),
+                "PD6 setup error: {mode:?} is not distinct from SrcOver on this backdrop"
+            );
+
+            let (device, queue) = acquire_test_device_and_queue();
+            let (surface_texture, surface_view) = create_render_surface(&device);
+            clear_surface(&device, &queue, &surface_view);
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+
+            painter.rect(
+                Rect::from_xywh(
+                    px(0.0),
+                    px(0.0),
+                    px(SURFACE_WIDTH as f32),
+                    px(SURFACE_HEIGHT as f32),
+                ),
+                &Paint::fill(backdrop),
+            );
+            painter.circle(
+                flui_types::Point::new(px(cx + 0.5), px(cy + 0.5)),
+                radius,
+                &Paint::fill(src).with_blend_mode(mode),
+            );
+
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("PD6 Encoder"),
+            });
+            painter
+                .render(
+                    RenderTarget::sampleable(&surface_view, &surface_texture),
+                    &mut encoder,
+                )
+                .expect("render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+            let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+            let interior = pixels[cy as usize * SURFACE_WIDTH as usize + cx as usize];
+            let tol = 8i16;
+            let near = |a: u8, b: u8| (i16::from(a) - i16::from(b)).abs() <= tol;
+            assert!(
+                near(interior[0], expected.r)
+                    && near(interior[1], expected.g)
+                    && near(interior[2], expected.b)
+                    && near(interior[3], expected.a),
+                "PD6 {mode:?}: interior {interior:?} != Color::blend oracle \
+                 [{},{},{},{}] (SrcOver would be [{},{},{},{}]) — the per-mode composite \
+                 selected the wrong blend pipeline",
+                expected.r,
+                expected.g,
+                expected.b,
+                expected.a,
+                srcover.r,
+                srcover.g,
+                srcover.b,
+                srcover.a,
+            );
+        }
+    }
+
+    // ── PD4: anti-MVP — all non-SrcOver shape producers emit partial alpha ────
+
+    /// PD4: Every non-SrcOver shape producer (rect, rrect, circle, oval, arc)
+    /// with a tile-safe blend mode on a large-enough geometry must emit at least
+    /// one partial-alpha boundary pixel — proving no producer is permanently
+    /// hard-aliased after PR-4.
+    ///
+    /// ## Anti-MVP rationale
+    ///
+    /// PD1 (path) and PD3 (rrect) cover only two shape types.  If the SSAA
+    /// routing in `DrawBatcher` is broken for one specific shape type
+    /// (e.g. the `rect` non-SrcOver branch falls through to tessellated), that
+    /// producer would silently regress to aliased output.  PD4 closes this gap by
+    /// requiring partial-alpha evidence from EVERY shape category.
+    ///
+    /// ## Shape placement
+    ///
+    /// All shapes are placed at fractional pixel offsets (e.g. center x = cx+0.3)
+    /// to ensure at least one edge is not pixel-grid-aligned.  A pixel-aligned
+    /// axis-aligned edge can produce zero partial-alpha pixels even with correct
+    /// SSAA (coverage is exactly 0 or 1 for grid-aligned edges); the fractional
+    /// offset guarantees a non-trivial SSAA result on every boundary.
+    ///
+    /// ## Blend mode
+    ///
+    /// `Xor` on a transparent destination: pixel-output-identical to SrcOver
+    /// (both give `src`), so this test validates SSAA routing fires without
+    /// requiring the per-mode composite pipeline (same rationale as PD1/PD3).
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index arithmetic over a small fixed-size test surface"
+    )]
+    fn pd4_all_non_srcover_shape_producers_emit_partial_alpha() {
+        // Helper: render `draw_fn` onto a fresh clear surface and count
+        // partial-alpha pixels (3 < alpha < 252).
+        let count_partial = |draw_fn: &dyn Fn(&mut WgpuPainter)| -> usize {
+            let (device, queue) = acquire_test_device_and_queue();
+            let (surface_texture, surface_view) = create_render_surface(&device);
+            clear_surface(&device, &queue, &surface_view);
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            draw_fn(&mut painter);
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("PD4 Encoder"),
+            });
+            painter
+                .render(
+                    RenderTarget::sampleable(&surface_view, &surface_texture),
+                    &mut encoder,
+                )
+                .expect("PD4 render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+            let pixels = readback_pixels(&device, &queue, &surface_texture);
+            pixels.iter().filter(|p| p[3] > 3 && p[3] < 252).count()
+        };
+
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+        // Fractional offset ensures no edge lands exactly on a pixel grid line.
+        let off = 0.3_f32;
+        let xor_paint = Paint::fill(Color::WHITE).with_blend_mode(BlendMode::Xor);
+
+        // ── Rect: 60×60 at fractional offset, Xor blend ──────────────────────
+        // Non-SrcOver rect falls into the tessellate+SSAA branch when
+        // `is_tile_safe_for_ssaa(Xor) = true` and area ≥ 256 px².
+        // 60×60 = 3600 >> 256.  Fractional offset forces non-aligned top/left edge.
+        {
+            let partial = count_partial(&|p: &mut WgpuPainter| {
+                p.rect(
+                    Rect::from_xywh(px(cx - 30.0 + off), px(cy - 30.0 + off), px(60.0), px(60.0)),
+                    &xor_paint,
+                );
+            });
+            assert!(
+                partial >= 1,
+                "PD4/rect FAILED: {partial} partial-alpha pixels — non-SrcOver rect \
+                 appears hard-aliased; expected SSAA routing to fire for Xor mode."
+            );
+        }
+
+        // ── RRect: 60×60 with 12px corner radius, Xor, fractional offset ─────
+        {
+            let partial = count_partial(&|p: &mut WgpuPainter| {
+                let r = RRect::from_rect_circular(
+                    Rect::from_xywh(px(cx - 30.0 + off), px(cy - 30.0 + off), px(60.0), px(60.0)),
+                    px(12.0),
+                );
+                p.rrect(r, &xor_paint);
+            });
+            assert!(
+                partial >= 4,
+                "PD4/rrect FAILED: {partial} partial-alpha pixels — non-SrcOver rrect \
+                 appears hard-aliased; curved corners must produce sub-pixel AA via SSAA."
+            );
+        }
+
+        // ── Circle: radius 40, Xor, fractional center ────────────────────────
+        // Diameter 80 → area = 80² = 6400 >> 256.
+        {
+            let partial = count_partial(&|p: &mut WgpuPainter| {
+                p.circle(
+                    flui_types::Point::new(px(cx + off), px(cy + off)),
+                    40.0,
+                    &xor_paint,
+                );
+            });
+            assert!(
+                partial >= 4,
+                "PD4/circle FAILED: {partial} partial-alpha pixels — non-SrcOver circle \
+                 appears hard-aliased; curved boundary must produce sub-pixel AA via SSAA."
+            );
+        }
+
+        // ── Oval: 80×60 at fractional offset, Xor ─────────────────────────────
+        // Area = 80×60 = 4800 >> 256.
+        {
+            let partial = count_partial(&|p: &mut WgpuPainter| {
+                p.oval(
+                    Rect::from_xywh(px(cx - 40.0 + off), px(cy - 30.0 + off), px(80.0), px(60.0)),
+                    &xor_paint,
+                );
+            });
+            assert!(
+                partial >= 4,
+                "PD4/oval FAILED: {partial} partial-alpha pixels — non-SrcOver oval \
+                 appears hard-aliased; curved ellipse boundary must produce sub-pixel AA via SSAA."
+            );
+        }
+
+        // ── Arc: 80px bounding box, 90° sweep at 45° start, Xor ─────────────
+        // Starting at 45° so both angular edges are diagonal (non-axis-aligned),
+        // guaranteeing partial-alpha pixels from the angular AA boundary.
+        // Bounding-box area = 80×80 = 6400 >> 256.
+        {
+            let partial = count_partial(&|p: &mut WgpuPainter| {
+                use std::f32::consts::FRAC_PI_4;
+                // use_center=true → pie sector; sweep 90° → two diagonal edges.
+                let arc_rect =
+                    Rect::from_xywh(px(cx - 40.0 + off), px(cy - 40.0 + off), px(80.0), px(80.0));
+                p.draw_arc(
+                    arc_rect,
+                    FRAC_PI_4,
+                    std::f32::consts::FRAC_PI_2,
+                    true,
+                    &xor_paint,
+                );
+            });
+            assert!(
+                partial >= 4,
+                "PD4/arc FAILED: {partial} partial-alpha pixels — non-SrcOver arc \
+                 appears hard-aliased; the diagonal radial/angular edges must produce \
+                 sub-pixel AA via SSAA."
+            );
+        }
+    }
+
+    // ── PD6: Xor over opaque backdrop — pipeline is NOT SrcOver ─────────────
+
+    /// PD6: `Xor` composited over an **opaque red backdrop** must produce
+    /// near-transparent interior pixels — NOT white as SrcOver would give.
+    ///
+    /// ## Why this test is necessary (gap in PD1 / PD3 / PD4)
+    ///
+    /// PD1, PD3, and the Xor sub-cases in PD4 all use `BlendMode::Xor` on a
+    /// **cleared (transparent)** destination.  On a transparent dst, Xor and
+    /// SrcOver produce identical pixel output:
+    ///
+    ///   Xor:    out = src×(1−dst_a) + dst×(1−src_a)
+    ///           at dst_a=0: out = src×1 + 0×(1−src_a) = src
+    ///   SrcOver: out = src + dst×(1−src_a) = src + 0 = src
+    ///
+    /// Those tests verify that SSAA routing fires, but they cannot detect if
+    /// the composite step incorrectly dispatches to the SrcOver pipeline instead
+    /// of the Xor pipeline.  PD6 forces an opaque backdrop so the two pipelines
+    /// diverge sharply:
+    ///
+    /// ## Expected pixel values
+    ///
+    /// Setup:
+    ///   - Background: opaque red `(255, 0, 0, 255)` painted with SrcOver.
+    ///   - Foreground: large white circle (r=40) with `Xor` blend.
+    ///
+    /// Xor formula at interior pixel (src = white premul = (1,1,1,1),
+    ///                                dst = red premul   = (1,0,0,1)):
+    ///
+    ///   src_factor = OneMinusDstAlpha = 1 − dst_a = 1 − 1 = 0
+    ///   dst_factor = OneMinusSrcAlpha = 1 − src_a = 1 − 1 = 0
+    ///
+    ///   out.rgb   = (1,1,1)×0 + (1,0,0)×0 = (0,0,0)
+    ///   out.alpha = 1×0        + 1×0       = 0          → transparent
+    ///
+    /// Under SrcOver the same pixel would be opaque white (255, 255, 255, 255).
+    /// This test asserts interior alpha < 30, which is impossible under SrcOver.
+    ///
+    /// ## Partial-alpha proof at the boundary
+    ///
+    /// At the circle boundary the SSAA tile has partial alpha `a_tile ∈ (0,1)`.
+    /// Xor composite:
+    ///   out.alpha = a_tile×(1−dst_a) + dst_a×(1−a_tile)
+    ///             = a_tile×0          + 1×(1−a_tile)
+    ///             = 1 − a_tile  ∈ (0, 1)   → partial alpha
+    ///
+    /// These partial-alpha boundary pixels also confirm SSAA ran.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index arithmetic over a small fixed-size test surface"
+    )]
+    fn pd6_xor_over_opaque_red_backdrop_is_not_srcover() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+        let radius = 40.0_f32;
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+
+        // Step 1: fill the entire surface with opaque red using SrcOver.
+        let full_rect = Rect::from_xywh(
+            px(0.0),
+            px(0.0),
+            px(SURFACE_WIDTH as f32),
+            px(SURFACE_HEIGHT as f32),
+        );
+        painter.rect(full_rect, &Paint::fill(Color::rgba(255, 0, 0, 255)));
+
+        // Step 2: draw a white circle (r=40, area >> SSAA threshold) with Xor blend.
+        // The circle is placed at a fractional offset to ensure non-axis-aligned
+        // edges, producing genuine partial-alpha pixels from the SSAA downsample.
+        painter.circle(
+            flui_types::Point::new(px(cx + 0.5), px(cy + 0.5)),
+            radius,
+            &Paint::fill(Color::WHITE).with_blend_mode(BlendMode::Xor),
+        );
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("PD6 Xor over Red Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Assertion 1: interior pixel is near-transparent (Xor zeros both src
+        // and dst when src_a=1 and dst_a=1). SrcOver would give alpha=255 (white).
+        let interior_idx = cy as usize * SURFACE_WIDTH as usize + cx as usize;
+        let interior_alpha = pixels[interior_idx][3];
+        assert!(
+            interior_alpha < 30,
+            "PD6 FAILED: interior alpha={interior_alpha}, expected near-0. \
+             Xor over an opaque backdrop zeros the output when both src_a=1 and \
+             dst_a=1.  SrcOver would produce alpha=255 (white).  If this fails, \
+             the SSAA composite step used the SrcOver pipeline instead of the Xor \
+             pipeline (flush_texture_batch_premultiplied_with_mode was not called \
+             with BlendMode::Xor, or is_tile_safe_for_ssaa incorrectly excluded Xor)."
+        );
+
+        // Assertion 2: exterior is still opaque red (Xor only touches the circle area).
+        // A point well outside the circle (2 px beyond the radius) must retain red.
+        let ext_col = (cx + radius + 2.0 + 0.5).min(SURFACE_WIDTH as f32 - 1.0) as usize;
+        let ext_row = cy as usize;
+        let ext_idx = ext_row * SURFACE_WIDTH as usize + ext_col;
+        assert!(
+            pixels[ext_idx][3] > 200,
+            "PD6: exterior pixel (outside circle) must remain opaque red; \
+             got alpha={} — Xor should not touch pixels outside the SSAA tile",
+            pixels[ext_idx][3]
+        );
+
+        // Assertion 3: boundary band shows partial alpha, proving SSAA ran.
+        // At dist ≈ radius, the SSAA tile has 0 < a_tile < 1, so
+        // Xor gives out.alpha = 1 − a_tile ∈ (0,1) — partial alpha.
+        let mut boundary_partial = 0usize;
+        for row in 0..SURFACE_HEIGHT {
+            for col in 0..SURFACE_WIDTH {
+                let dx = col as f32 + 0.5 - (cx + 0.5);
+                let dy = row as f32 + 0.5 - (cy + 0.5);
+                let dist = (dx * dx + dy * dy).sqrt();
+                if (radius - 2.0..=radius + 2.0).contains(&dist) {
+                    let alpha = pixels[row as usize * SURFACE_WIDTH as usize + col as usize][3];
+                    // 1−a_tile ∈ (10/255, 245/255) iff a_tile ∈ (10/255, 245/255).
+                    if alpha > 10 && alpha < 245 {
+                        boundary_partial += 1;
+                    }
+                }
+            }
+        }
+        assert!(
+            boundary_partial >= 4,
+            "PD6 FAILED: only {boundary_partial} partial-alpha boundary pixels — \
+             SSAA must produce sub-pixel coverage at the Xor circle boundary. \
+             This also confirms the Xor blend pipeline was used at composite time."
+        );
+    }
+
+    // ── PD5: Phase-B regression — SrcOver path still AA'd after PR-4 ─────────
+
+    /// PD5: A SrcOver arbitrary path fill must still produce partial alpha at
+    /// its boundary after PR-4 changes (regression guard: PR-4 must not break
+    /// the PR-3 SrcOver SSAA path).
+    ///
+    /// This is a Phase-B regression guard (the naming in the spec doc). It is
+    /// structurally equivalent to p4_anti_mvp_srcover_fill_has_partial_alpha_at_boundary
+    /// but documents its role as a regression gate specifically for PR-4.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixel index arithmetic over a small fixed-size test surface"
+    )]
+    fn pd5_srcover_path_still_has_partial_alpha_after_pr4() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        // Same kite as p4 — SrcOver, just verifying it still routes through SSAA.
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+        let v = [
+            (cx + 1.3, cy - 38.7),
+            (cx + 42.2, cy + 5.5),
+            (cx - 2.7, cy + 33.1),
+            (cx - 38.4, cy - 9.2),
+        ];
+        let mut path = flui_types::painting::path::Path::new();
+        path.move_to(flui_types::Point::new(Pixels(v[0].0), Pixels(v[0].1)));
+        for &(x, y) in &v[1..] {
+            path.line_to(flui_types::Point::new(Pixels(x), Pixels(y)));
+        }
+        path.close();
+
+        let paint = Paint::fill(Color::WHITE); // SrcOver default
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.draw_path(&path, &paint);
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("PD5 SrcOver Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        let partial_count = pixels.iter().filter(|p| p[3] > 5 && p[3] < 250).count();
+
+        assert!(
+            partial_count >= 4,
+            "PD5 FAILED: only {partial_count} partial-alpha pixels — the SrcOver SSAA path \
+             (PR-3) appears broken after PR-4 changes. The PR-4 routing must not regress \
+             the SrcOver SSAA path."
+        );
+
+        // Shape must be actually rendered (interior opaque).
+        let interior_col = cx as usize;
+        let interior_row = cy as usize;
+        let interior_idx = interior_row * SURFACE_WIDTH as usize + interior_col;
+        assert!(
+            pixels[interior_idx][3] > 200,
+            "PD5: shape interior must be opaque after PR-4; got alpha={}",
+            pixels[interior_idx][3]
         );
     }
 }

--- a/crates/flui-engine/src/wgpu/batches/mod.rs
+++ b/crates/flui-engine/src/wgpu/batches/mod.rs
@@ -239,13 +239,22 @@ impl DrawBatcher {
         }
     }
 
-    /// Divert an arbitrary SrcOver path fill into a `DrawItem::SsaaPath` for
-    /// SSAA-based anti-aliasing.
+    /// Divert a geometry fill into a `DrawItem::SsaaPath` for SSAA-based
+    /// anti-aliasing.
     ///
-    /// Called exclusively from `DrawBatcher::draw_path` (in `batches/paths.rs`)
-    /// when the path is a fill (`PaintStyle::Fill`) and the blend mode is
-    /// `SrcOver`.  Closed-form shapes (rect/rrect/circle/oval/arc, which route to
-    /// the instanced affine-SDF path) must **not** call this method.
+    /// Called from:
+    /// - `DrawBatcher::draw_path` (in `batches/paths.rs`) for arbitrary path fills
+    ///   whose blend mode is tile-safe or advanced.
+    /// - `batches/shapes.rs` non-SrcOver branches for rect/rrect/circle/oval/arc
+    ///   fills whose blend mode is tile-safe or advanced.
+    ///
+    /// Closed-form SrcOver shapes (rect/rrect/circle/oval/arc) route to the
+    /// instanced affine-SDF path and must **not** call this method.
+    ///
+    /// Coverage-destructive Porter-Duff modes (Clear, Src, SrcIn, DstIn, SrcOut,
+    /// DstATop, Modulate) must NOT call this method — they keep the tessellated
+    /// path so transparent tile padding does not destructively write to the
+    /// destination outside the geometry boundary.
     ///
     /// ## What this does
     ///
@@ -253,16 +262,17 @@ impl DrawBatcher {
     ///    tile (Z-order correctness, same as the advanced-shape diversion).
     /// 2. Builds an isolated `DrawSegment` containing only this path's geometry.
     /// 3. Computes the device-space AABB of the already-transformed vertices.
-    /// 4. Pushes `DrawItem::SsaaPath(SsaaPathOp { segment, device_bounds })`.
+    /// 4. Pushes `DrawItem::SsaaPath(SsaaPathOp { segment, device_bounds, blend })`.
     ///
     /// All GPU work (2× render + box downsample + composite) happens at replay
-    /// time in `GpuReplay::submit`.
+    /// time in `GpuReplay::render_ssaa_path`.
     pub(super) fn divert_path_to_ssaa(
         segment: &mut DrawSegment,
         draw_order: &mut Vec<DrawItem>,
         state: &GpuStateStack,
         vertices: &[Vertex],
         indices: &[u32],
+        blend: BlendMode,
     ) {
         if indices.is_empty() {
             return;
@@ -275,6 +285,9 @@ impl DrawBatcher {
         let device_bounds = vertices_aabb(vertices);
 
         // Step 3: build an isolated DrawSegment for this path only.
+        // The internal pipeline is always SrcOver (alpha-blend): the geometry is
+        // rendered into a transparent offscreen tile.  The SSAA blend mode is stored
+        // in `SsaaPathOp::blend` and applied at composite time, not at raster time.
         let mut path_segment = DrawSegment::new();
         path_segment.vertices.extend_from_slice(vertices);
         path_segment.indices.extend(indices.iter().copied());
@@ -289,6 +302,7 @@ impl DrawBatcher {
         draw_order.push(DrawItem::SsaaPath(SsaaPathOp {
             segment: path_segment,
             device_bounds,
+            blend,
         }));
     }
 

--- a/crates/flui-engine/src/wgpu/batches/paths.rs
+++ b/crates/flui-engine/src/wgpu/batches/paths.rs
@@ -220,26 +220,36 @@ impl DrawBatcher {
             return;
         }
 
-        // Determine whether this path fill should be SSAA-routed:
-        //   - Fill style (not stroke).
-        //   - SrcOver blend (non-SrcOver paths go to PR-4's path).
-        //   - Path AABB area ≥ SSAA_AREA_THRESHOLD_PX²: tiny paths (icon
-        //     sub-elements, micro-decorations) yield no visible AA benefit and
-        //     pay 5 render passes + 2 texture acquisitions for nothing.  Below
-        //     the threshold they join the batched tessellated draw call instead
-        //     (same quality as pre-PR-3 for those sizes), preserving the engine's
-        //     draw-batching design for the common small-path case.
+        // Determine whether this path fill should be SSAA-routed.
         //
         // Closed-form shapes (rect/rrect/circle/oval/arc) never reach `draw_path`
         // — they go through `batches/shapes.rs` → instanced SDF.  So any Fill
         // arriving here IS an arbitrary path.
         //
-        // The AABB is computed lazily (only when style==Fill && mode==SrcOver)
-        // so the check adds no cost to the stroke / non-SrcOver paths.
+        // SSAA eligibility (PR-3 + PR-4):
+        //   1. Fill style (not stroke).
+        //   2. The blend mode must be either:
+        //      - tile-safe (SrcOver, Dst, DstOver, DstOut, SrcATop, Xor, Plus):
+        //        transparent SSAA padding is a no-op → composite with fixed-function
+        //        premul blend at `blend_state_for(mode)`.
+        //      - advanced (is_advanced()): dst-reading separable/non-separable modes
+        //        → composite via `flush_advanced_layer` with the 1× tile as foreground.
+        //      Coverage-destructive modes (Clear, Src, SrcIn, DstIn, SrcOut, DstATop,
+        //      Modulate) are kept on the tessellated (aliased) path: routing them
+        //      through the SSAA tile would destroy destination pixels in the
+        //      transparent tile border, corrupting content outside the shape boundary.
+        //   3. Path AABB area ≥ SSAA_AREA_THRESHOLD_PX²: tiny paths yield no
+        //      visible AA benefit and pay 5 render passes + 2 texture acquisitions.
         //
-        let is_srcover_fill = paint.style == PaintStyle::Fill
-            && paint.blend_mode == BlendMode::SrcOver
-            && path_aabb_area_device_px_sq(path, state) >= SSAA_AREA_THRESHOLD_PX_SQ;
+        // The AABB is computed lazily (only when style==Fill and the mode qualifies).
+        let ssaa_blend: Option<BlendMode> = if paint.style == PaintStyle::Fill
+            && (pipeline::is_tile_safe_for_ssaa(paint.blend_mode) || paint.blend_mode.is_advanced())
+            && path_aabb_area_device_px_sq(path, state) >= SSAA_AREA_THRESHOLD_PX_SQ
+        {
+            Some(paint.blend_mode)
+        } else {
+            None
+        };
 
         // Compute cache key from path geometry + paint tessellation parameters
         // + the quantized world scale (so a scale-1 entry is not reused at a
@@ -264,9 +274,9 @@ impl DrawBatcher {
                 .collect();
             let indices: Vec<u32> = cached_indices.to_vec();
 
-            if is_srcover_fill {
+            if let Some(blend) = ssaa_blend {
                 Self::submit_transformed_and_divert_to_ssaa(
-                    segment, draw_order, state, vertices, &indices,
+                    segment, draw_order, state, vertices, &indices, blend,
                 );
             } else {
                 // Bake current_transform into vertices: shape.wgsl has no model matrix.
@@ -298,9 +308,9 @@ impl DrawBatcher {
                 self.path_cache
                     .insert(path_hash, positions, indices.clone());
 
-                if is_srcover_fill {
+                if let Some(blend) = ssaa_blend {
                     Self::submit_transformed_and_divert_to_ssaa(
-                        segment, draw_order, state, vertices, &indices,
+                        segment, draw_order, state, vertices, &indices, blend,
                     );
                 } else {
                     // Bake current_transform into vertices: shape.wgsl has no model matrix.
@@ -324,19 +334,27 @@ impl DrawBatcher {
     ///
     /// Factored out of `draw_path` so the transform+divert sequence is identical
     /// for cache-hit and cache-miss paths.
-    fn submit_transformed_and_divert_to_ssaa(
+    ///
+    /// `blend` is forwarded to `SsaaPathOp` and determines how the 1× tile is
+    /// composited at replay time: tile-safe → `flush_texture_batch_premultiplied`
+    /// with `blend_state_for(blend)`; advanced → `flush_advanced_layer`.
+    ///
+    /// `pub(super)` so the sibling `shapes` module (e.g. `draw_drrect`) can reuse
+    /// the identical transform+divert sequence for tessellated fills.
+    pub(super) fn submit_transformed_and_divert_to_ssaa(
         segment: &mut DrawSegment,
         draw_order: &mut Vec<DrawItem>,
         state: &GpuStateStack,
         mut vertices: Vec<Vertex>,
         indices: &[u32],
+        blend: BlendMode,
     ) {
         let transform = state.current_transform();
         for v in &mut vertices {
             let transformed = transform * glam::vec4(v.position[0], v.position[1], 0.0, 1.0);
             v.position = [transformed.x, transformed.y];
         }
-        Self::divert_path_to_ssaa(segment, draw_order, state, &vertices, indices);
+        Self::divert_path_to_ssaa(segment, draw_order, state, &vertices, indices, blend);
     }
 
     /// Draw indexed triangle geometry with per-vertex color + uv.
@@ -610,10 +628,13 @@ mod threshold_tests {
 
     // ── T4: non-SrcOver fill is never SSAA-routed ────────────────────────────
 
-    /// T4: A non-SrcOver fill (e.g. SrcOut) must NEVER produce
-    /// `DrawItem::SsaaPath`.  SSAA is SrcOver-only in PR-3.
+    /// T4: A coverage-destructive fill (e.g. SrcOut) must NEVER produce
+    /// `DrawItem::SsaaPath`.  SrcOut has `dst_factor=Zero` — compositing a
+    /// transparent SSAA tile would zero out destination pixels outside the shape,
+    /// corrupting content.  PR-4 routes only tile-safe and advanced modes to SSAA;
+    /// coverage-destructive modes remain on the tessellated (aliased) path.
     #[test]
-    fn non_srcover_fill_never_produces_ssaa_path() {
+    fn coverage_destructive_fill_never_produces_ssaa_path() {
         let mut batcher = make_batcher();
         let mut segment = DrawSegment::new();
         let mut draw_order: Vec<DrawItem> = Vec::new();
@@ -635,7 +656,49 @@ mod threshold_tests {
             .count();
         assert_eq!(
             ssaa_count, 0,
-            "non-SrcOver fill must never produce SsaaPath; got {ssaa_count}"
+            "coverage-destructive SrcOut fill must never produce SsaaPath; got {ssaa_count}"
         );
+    }
+
+    // ── T5: tile-safe non-SrcOver fill is SSAA-routed ────────────────────────
+
+    /// T5: A tile-safe non-SrcOver fill (e.g. DstOut) on a large path MUST
+    /// produce `DrawItem::SsaaPath` (PR-4).  `DstOut` has `dst_factor=OneMinusSrcAlpha`
+    /// — transparent SSAA padding (src_a=0 → factor=1) leaves dst unchanged, so
+    /// compositing the SSAA tile is safe.
+    #[test]
+    fn tile_safe_non_srcover_large_fill_produces_ssaa_path() {
+        let mut batcher = make_batcher();
+        let mut segment = DrawSegment::new();
+        let mut draw_order: Vec<DrawItem> = Vec::new();
+        let state = GpuStateStack::new_for_test();
+
+        let path = rect_path(200.0, 200.0); // well above threshold
+
+        let paint = Paint {
+            style: PaintStyle::Fill,
+            blend_mode: BlendMode::DstOut, // tile-safe
+            ..Default::default()
+        };
+
+        batcher.draw_path(&mut segment, &mut draw_order, &state, &path, &paint);
+
+        let ssaa_count = draw_order
+            .iter()
+            .filter(|item| matches!(item, DrawItem::SsaaPath(_)))
+            .count();
+        assert_eq!(
+            ssaa_count, 1,
+            "tile-safe DstOut fill must produce exactly one SsaaPath; got {ssaa_count}"
+        );
+
+        // Verify the recorded blend mode is DstOut, not coerced to SrcOver.
+        if let Some(DrawItem::SsaaPath(op)) = draw_order.first() {
+            assert_eq!(
+                op.blend,
+                BlendMode::DstOut,
+                "SsaaPathOp.blend must preserve DstOut, not coerce to SrcOver"
+            );
+        }
     }
 }

--- a/crates/flui-engine/src/wgpu/batches/shapes.rs
+++ b/crates/flui-engine/src/wgpu/batches/shapes.rs
@@ -119,9 +119,11 @@ impl DrawBatcher {
                     );
                 }
             } else {
-                // Slow path: any non-SrcOver blend mode — tessellate and bake.
+                // Slow path: any non-SrcOver blend mode.
                 //
-                // Non-SrcOver stays tessellated until the SSAA tile path (PR-3+).
+                // PR-4 routing: tile-safe and advanced modes → SSAA tile (AA'd);
+                // coverage-destructive modes → tessellated (aliased, correct).
+                // See `pipeline::is_tile_safe_for_ssaa` for the mode table.
                 let tl = state.apply_transform(Point::new(rect.left(), rect.top()));
                 let tr = state.apply_transform(Point::new(rect.right(), rect.top()));
                 let br = state.apply_transform(Point::new(rect.right(), rect.bottom()));
@@ -150,14 +152,30 @@ impl DrawBatcher {
                     },
                 ];
                 let indices = [0u32, 1, 2, 0, 2, 3];
-                Self::add_tessellated_with_key(
-                    segment,
-                    draw_order,
-                    state,
-                    vertices,
-                    &indices,
-                    pipeline::pipeline_key_from_paint(paint),
-                );
+                let mode = paint.blend_mode;
+                let scale = state.max_scale();
+                let device_area = rect.width().0 * scale * rect.height().0 * scale;
+                if (pipeline::is_tile_safe_for_ssaa(mode) || mode.is_advanced())
+                    && device_area >= super::paths::SSAA_AREA_THRESHOLD_PX_SQ
+                {
+                    // Vertices are already in device-pixel space (apply_transform was
+                    // called above). Pass them directly to divert_path_to_ssaa.
+                    Self::divert_path_to_ssaa(
+                        segment, draw_order, state, &vertices, &indices, mode,
+                    );
+                } else {
+                    // Coverage-destructive modes or sub-threshold rects: tessellated path.
+                    // Coverage-destructive: Clear/Src/SrcIn/DstIn/SrcOut/DstATop/Modulate
+                    // — routing through SSAA tile would zero dst pixels in the tile border.
+                    Self::add_tessellated_with_key(
+                        segment,
+                        draw_order,
+                        state,
+                        vertices,
+                        &indices,
+                        pipeline::pipeline_key_from_paint(paint),
+                    );
+                }
             }
         } else {
             // Stroked rect — tessellate (less common, fallback path).
@@ -222,16 +240,43 @@ impl DrawBatcher {
             // The instanced fast path renders with a hardcoded SrcOver pipeline.
             // A non-SrcOver blend mode must route through the tessellated path.
             if paint.blend_mode != BlendMode::SrcOver {
-                // Non-SrcOver rrect: tessellate and bake via `submit_transformed_geometry`.
-                // Stays tessellated (aliased) until the SSAA tile path (PR-3+).
-                let fill_paint = Paint::fill(color).with_blend_mode(paint.blend_mode);
+                // Non-SrcOver rrect (PR-4 routing):
+                // - tile-safe or advanced + above area threshold → SSAA tile (AA'd)
+                // - coverage-destructive or sub-threshold → tessellated (aliased, correct)
+                let mode = paint.blend_mode;
+                let fill_paint = Paint::fill(color).with_blend_mode(mode);
                 self.prime_tessellator_scale(state);
                 match self.tessellator.tessellate_rrect(rrect, &fill_paint) {
                     Ok((vertices, indices)) => {
-                        let key = pipeline::pipeline_key_from_paint(&fill_paint);
-                        Self::submit_transformed_geometry(
-                            segment, draw_order, state, vertices, &indices, key,
-                        );
+                        let scale = state.max_scale();
+                        let device_area = rrect.bounding_rect().width().0
+                            * scale
+                            * rrect.bounding_rect().height().0
+                            * scale;
+                        let ssaa_eligible = (pipeline::is_tile_safe_for_ssaa(mode)
+                            || mode.is_advanced())
+                            && device_area >= super::paths::SSAA_AREA_THRESHOLD_PX_SQ;
+                        if ssaa_eligible {
+                            // Bake current transform into vertices before divert.
+                            // `divert_path_to_ssaa` expects pre-transformed device-px coords.
+                            let transform = state.current_transform();
+                            let mut baked = vertices;
+                            for v in &mut baked {
+                                let p =
+                                    transform * glam::vec4(v.position[0], v.position[1], 0.0, 1.0);
+                                v.position = [p.x, p.y];
+                            }
+                            Self::divert_path_to_ssaa(
+                                segment, draw_order, state, &baked, &indices, mode,
+                            );
+                        } else {
+                            // Coverage-destructive or sub-threshold: tessellated path.
+                            // `submit_transformed_geometry` applies the CTM itself.
+                            let key = pipeline::pipeline_key_from_paint(&fill_paint);
+                            Self::submit_transformed_geometry(
+                                segment, draw_order, state, vertices, &indices, key,
+                            );
+                        }
                     }
                     Err(e) => {
                         tracing::warn!("Failed to tessellate blended rrect: {}", e);
@@ -426,13 +471,12 @@ impl DrawBatcher {
                     );
                 }
             } else {
-                // Slow path: non-SrcOver — tessellate and bake.
-                //
-                // Non-SrcOver stays tessellated (aliased) until the SSAA tile path (PR-3+).
+                // Slow path: non-SrcOver — tessellate and maybe divert to SSAA (PR-4).
+                let mode = paint.blend_mode;
                 let fill_paint = Paint {
                     color,
                     style: PaintStyle::Fill,
-                    blend_mode: paint.blend_mode,
+                    blend_mode: mode,
                     ..Paint::default()
                 };
                 self.prime_tessellator_scale(state);
@@ -441,10 +485,29 @@ impl DrawBatcher {
                     .tessellate_circle(center, radius, &fill_paint)
                 {
                     Ok((vertices, indices)) => {
-                        let key = pipeline::pipeline_key_from_paint(&fill_paint);
-                        Self::submit_transformed_geometry(
-                            segment, draw_order, state, vertices, &indices, key,
-                        );
+                        let scale = state.max_scale();
+                        let diameter = radius * 2.0 * scale;
+                        let device_area = diameter * diameter;
+                        let ssaa_eligible = (pipeline::is_tile_safe_for_ssaa(mode)
+                            || mode.is_advanced())
+                            && device_area >= super::paths::SSAA_AREA_THRESHOLD_PX_SQ;
+                        if ssaa_eligible {
+                            let transform = state.current_transform();
+                            let mut baked = vertices;
+                            for v in &mut baked {
+                                let p =
+                                    transform * glam::vec4(v.position[0], v.position[1], 0.0, 1.0);
+                                v.position = [p.x, p.y];
+                            }
+                            Self::divert_path_to_ssaa(
+                                segment, draw_order, state, &baked, &indices, mode,
+                            );
+                        } else {
+                            let key = pipeline::pipeline_key_from_paint(&fill_paint);
+                            Self::submit_transformed_geometry(
+                                segment, draw_order, state, vertices, &indices, key,
+                            );
+                        }
                     }
                     Err(e) => {
                         tracing::warn!("Failed to tessellate circle: {}", e);
@@ -538,23 +601,38 @@ impl DrawBatcher {
             let _ = segment.circle_batch.add(instance);
             DrawSegment::push_scissor_region(&mut segment.circle_scissors, state.current_scissor());
         } else if paint.style == PaintStyle::Fill {
-            // Non-SrcOver fill — tessellate (aliased until the SSAA tile path, PR-4),
-            // carrying the opacity-folded color + the requested blend mode.
-            let fill_paint = Paint::fill(color).with_blend_mode(paint.blend_mode);
+            // Non-SrcOver fill — PR-4: tile-safe and advanced modes → SSAA (AA'd);
+            // coverage-destructive modes → tessellated (aliased, correct).
+            let mode = paint.blend_mode;
+            let fill_paint = Paint::fill(color).with_blend_mode(mode);
             let radii = Point::new(rect.width() / 2.0, rect.height() / 2.0);
             self.prime_tessellator_scale(state);
             if let Ok((vertices, indices)) =
                 self.tessellator
                     .tessellate_ellipse(center, radii, &fill_paint)
             {
-                Self::submit_transformed_geometry(
-                    segment,
-                    draw_order,
-                    state,
-                    vertices,
-                    &indices,
-                    pipeline::pipeline_key_from_paint(&fill_paint),
-                );
+                let scale = state.max_scale();
+                let device_area = rect.width().0 * scale * rect.height().0 * scale;
+                let ssaa_eligible = (pipeline::is_tile_safe_for_ssaa(mode) || mode.is_advanced())
+                    && device_area >= super::paths::SSAA_AREA_THRESHOLD_PX_SQ;
+                if ssaa_eligible {
+                    let transform = state.current_transform();
+                    let mut baked = vertices;
+                    for v in &mut baked {
+                        let p = transform * glam::vec4(v.position[0], v.position[1], 0.0, 1.0);
+                        v.position = [p.x, p.y];
+                    }
+                    Self::divert_path_to_ssaa(segment, draw_order, state, &baked, &indices, mode);
+                } else {
+                    Self::submit_transformed_geometry(
+                        segment,
+                        draw_order,
+                        state,
+                        vertices,
+                        &indices,
+                        pipeline::pipeline_key_from_paint(&fill_paint),
+                    );
+                }
             }
         } else {
             // Stroked oval — tessellate (fallback), unchanged.
@@ -588,14 +666,34 @@ impl DrawBatcher {
         self.prime_tessellator_scale(state);
         match self.tessellator.tessellate_drrect(&outer, &inner, paint) {
             Ok((vertices, indices)) => {
-                Self::submit_transformed_geometry(
-                    segment,
-                    draw_order,
-                    state,
-                    vertices,
-                    &indices,
-                    pipeline::pipeline_key_from_paint(paint),
-                );
+                // drrect is a compound (outer minus inner) tessellated fill with no
+                // closed-form SDF, so — like arbitrary paths (PR-3) — SrcOver +
+                // tile-safe + advanced FILLS route to the SSAA tile for AA;
+                // coverage-destructive modes and strokes keep the coverage-correct
+                // tessellated (aliased) path. (Without this, a SrcOver ring/border —
+                // a common UI element — would render aliased.)
+                let mode = paint.blend_mode;
+                let scale = state.max_scale();
+                let device_area = outer.width().0 * scale * outer.height().0 * scale;
+                if paint.style == PaintStyle::Fill
+                    && (mode == BlendMode::SrcOver
+                        || pipeline::is_tile_safe_for_ssaa(mode)
+                        || mode.is_advanced())
+                    && device_area >= super::paths::SSAA_AREA_THRESHOLD_PX_SQ
+                {
+                    Self::submit_transformed_and_divert_to_ssaa(
+                        segment, draw_order, state, vertices, &indices, mode,
+                    );
+                } else {
+                    Self::submit_transformed_geometry(
+                        segment,
+                        draw_order,
+                        state,
+                        vertices,
+                        &indices,
+                        pipeline::pipeline_key_from_paint(paint),
+                    );
+                }
             }
             Err(e) => {
                 tracing::error!("Failed to tessellate DRRect: {}", e);
@@ -700,12 +798,14 @@ impl DrawBatcher {
                 // non-SrcOver blend — tessellate in local space and bake the full
                 // transform into vertex positions.
                 //
-                // Phase-A quality note: tessellated path → aliased edges.
-                // SDF-quality coverage for these lands in PR-4 (SSAA tile).
+                // PR-4: tile-safe and advanced modes → SSAA (AA'd edges).
+                // Coverage-destructive modes + use_center=false + reflections remain
+                // tessellated (aliased).
+                let mode = paint.blend_mode;
                 let fill_paint = Paint {
                     color,
                     style: PaintStyle::Fill,
-                    blend_mode: paint.blend_mode,
+                    blend_mode: mode,
                     ..Paint::default()
                 };
                 self.prime_tessellator_scale(state);
@@ -717,10 +817,32 @@ impl DrawBatcher {
                     &fill_paint,
                 ) {
                     Ok((vertices, indices)) => {
-                        let key = pipeline::pipeline_key_from_paint(&fill_paint);
-                        Self::submit_transformed_geometry(
-                            segment, draw_order, state, vertices, &indices, key,
-                        );
+                        let scale = state.max_scale();
+                        // Arc bounding area ≈ rect area (conservative upper bound).
+                        let device_area = rect.width().0 * scale * rect.height().0 * scale;
+                        // Only route to SSAA for non-SrcOver modes; SrcOver arcs
+                        // that reach this branch (reflection fallback) are already
+                        // tessellated — a second SSAA path for them is not needed.
+                        let ssaa_eligible = mode != BlendMode::SrcOver
+                            && (pipeline::is_tile_safe_for_ssaa(mode) || mode.is_advanced())
+                            && device_area >= super::paths::SSAA_AREA_THRESHOLD_PX_SQ;
+                        if ssaa_eligible {
+                            let transform = state.current_transform();
+                            let mut baked = vertices;
+                            for v in &mut baked {
+                                let p =
+                                    transform * glam::vec4(v.position[0], v.position[1], 0.0, 1.0);
+                                v.position = [p.x, p.y];
+                            }
+                            Self::divert_path_to_ssaa(
+                                segment, draw_order, state, &baked, &indices, mode,
+                            );
+                        } else {
+                            let key = pipeline::pipeline_key_from_paint(&fill_paint);
+                            Self::submit_transformed_geometry(
+                                segment, draw_order, state, vertices, &indices, key,
+                            );
+                        }
                     }
                     Err(e) => {
                         tracing::error!("Failed to tessellate filled arc: {}", e);

--- a/crates/flui-engine/src/wgpu/command_ir.rs
+++ b/crates/flui-engine/src/wgpu/command_ir.rs
@@ -284,30 +284,39 @@ pub(crate) struct AdvancedShapeOp {
 
 // ─── SSAA-path op ────────────────────────────────────────────────────────────
 
-/// A single arbitrary-path fill (SrcOver) routed to the SSAA offscreen tile
-/// for anti-aliased compositing.
+/// A single geometry fill routed to the SSAA offscreen tile for anti-aliased
+/// compositing.
 ///
-/// Created by `DrawBatcher::draw_path` (in `batches/paths.rs`) when an
-/// arbitrary path fill with SrcOver blend is recorded.  Instead of batching the
-/// tessellated geometry directly into the main `DrawSegment` (which renders
-/// aliased at `sample_count=1`), the geometry is isolated here and rendered at
-/// replay time into a 2× supersampled pooled offscreen, box-downsampled to a
-/// premultiplied 1× tile, and composited via the existing premultiplied texture
-/// path — giving smooth ~1-device-px AA on every edge.
+/// Created by:
+/// - `DrawBatcher::draw_path` (in `batches/paths.rs`) for arbitrary path fills
+///   (SrcOver, tile-safe Porter-Duff, and advanced blend modes).
+/// - `batches/shapes.rs` non-SrcOver branches for rect/rrect/circle/oval/arc fills
+///   when the blend mode is tile-safe or advanced.
 ///
-/// ## Scope
+/// Instead of batching the tessellated geometry directly into the main
+/// `DrawSegment` (which renders aliased at `sample_count=1`), the geometry is
+/// isolated here and rendered at replay time into a 2× supersampled pooled
+/// offscreen, box-downsampled to a premultiplied 1× tile, and composited via
+/// one of three paths depending on `blend`:
 ///
-/// Only arbitrary SrcOver path **fills** take this path.  Closed-form shapes
-/// (rect/rrect/circle/oval/arc) are rerouted to the instanced affine-SDF path
-/// (PR-1/PR-2/PR-2b) and must **not** reach this variant.  Non-SrcOver paths
-/// stay on the tessellated path (PR-4 will handle them).
+/// - **SrcOver / tile-safe Porter-Duff** (`is_tile_safe_for_ssaa(blend)` = true):
+///   premultiplied texture composite with `blend_state_for(blend)` fixed-function
+///   blend.  Transparent-padding pixels are a no-op on the destination.
+/// - **Advanced (dst-read)** (`blend.is_advanced()` = true):
+///   `flush_advanced_layer` with the 1× tile as the foreground texture.
+///   W3C composite with correct coverage.
+/// - **Coverage-destructive Porter-Duff** (all other non-advanced modes):
+///   NOT routed here — these keep the existing tessellated (aliased) path because
+///   the transparent tile padding would destructively modify the destination
+///   outside the geometry boundary.  See the coverage-destructive exception list
+///   in `batches/shapes.rs` and `batches/paths.rs`.
 ///
 /// ## T11 purity contract
 ///
 /// `SsaaPathOp` derives `Clone` — it is handle-free (no `wgpu::*` fields),
-/// matching the [`AdvancedShapeOp`] invariant.  The embedded [`DrawSegment`]
-/// carries only CPU data.  All GPU work happens at replay time in
-/// `GpuReplay::submit`.
+/// matching the [`AdvancedShapeOp`] invariant.  `BlendMode` is `Copy`.
+/// The embedded [`DrawSegment`] carries only CPU data.  All GPU work happens at
+/// replay time in `GpuReplay::submit`.
 #[derive(Clone)]
 pub(crate) struct SsaaPathOp {
     /// Tessellated geometry for this path (vertices already baked to device
@@ -319,6 +328,12 @@ pub(crate) struct SsaaPathOp {
     /// clamped to `[1, viewport]`.  Computed as the AABB of
     /// `segment.vertices[*].position` at record time.
     pub(crate) device_bounds: Rect<Pixels>,
+    /// Blend mode to use when compositing the SSAA 1× tile onto the surface.
+    ///
+    /// Determines the composite strategy in `GpuReplay::render_ssaa_path`:
+    /// tile-safe → fixed-function premul blend; advanced → `flush_advanced_layer`.
+    /// Coverage-destructive modes never reach this struct (they stay tessellated).
+    pub(crate) blend: BlendMode,
 }
 
 // ─── Draw item (top-level ordering enum) ─────────────────────────────────────

--- a/crates/flui-engine/src/wgpu/opacity_layer.rs
+++ b/crates/flui-engine/src/wgpu/opacity_layer.rs
@@ -324,6 +324,19 @@ impl GpuReplay {
                 DrawItem::SsaaPath(mut op) => {
                     // Composite the SSAA tile onto the layer's offscreen texture
                     // at the correct Z position (R1 arm order).
+                    //
+                    // Pass `offscreen_target.texture` (a pool texture with
+                    // COPY_SRC | TEXTURE_BINDING — DECISION 2) so that advanced
+                    // (dst-read) blend modes on SSAA paths nested inside a layer
+                    // can dst-read the offscreen as their backdrop.  This mirrors
+                    // the AdvancedShape arm above (lines 246-301) which also passes
+                    // `offscreen_target.texture` for the same reason.
+                    //
+                    // The SSAA 1× tile is a SEPARATE pooled texture from the
+                    // offscreen, so there is no read/write aliasing: the backdrop
+                    // copy reads from `offscreen_target.texture` while the SSAA
+                    // tile is written to the same offscreen via `offscreen_view`
+                    // only AFTER the copy completes (sequential encoder commands).
                     self.render_ssaa_path(
                         &mut op,
                         viewport_size,
@@ -334,8 +347,10 @@ impl GpuReplay {
                         resources,
                         encoder,
                         offscreen_view,
+                        offscreen_target.texture, // sampleable pool texture for advanced dst-read
                     );
                     tracing::trace!(
+                        mode = ?op.blend,
                         bounds = ?op.device_bounds,
                         "GpuReplay: SSAA path tile composited onto layer offscreen"
                     );

--- a/crates/flui-engine/src/wgpu/pipeline.rs
+++ b/crates/flui-engine/src/wgpu/pipeline.rs
@@ -161,6 +161,67 @@ pub fn blend_state_for(mode: BlendMode) -> wgpu::BlendState {
     }
 }
 
+/// Classify a blend mode as "tile-safe" for SSAA compositing.
+///
+/// A mode is tile-safe iff compositing a **transparent-source** tile (src alpha=0,
+/// src color=0) onto any destination leaves the destination unchanged:
+///
+///   `blend(transparent_src, dst, mode) == dst`   for ALL dst values.
+///
+/// Derivation from `blend_state_for` with src=(0,0,0,0):
+///
+/// | Mode      | src-factor × 0 + dst-factor × dst | tile-safe? |
+/// |-----------|-----------------------------------|-----------|
+/// | SrcOver   | 0 + (1-0)·dst = dst               | ✓         |
+/// | Dst       | 0 + 1·dst = dst                   | ✓         |
+/// | DstOver   | 0 + 1·dst = dst                   | ✓         |
+/// | DstOut    | 0 + (1-0)·dst = dst               | ✓         |
+/// | SrcATop   | 0 + (1-0)·dst = dst               | ✓         |
+/// | Xor       | 0 + (1-0)·dst = dst               | ✓         |
+/// | Plus      | 0 + 1·dst = dst                   | ✓         |
+/// | Clear     | 0 + 0·dst = 0                     | ✗ (kills dst) |
+/// | Src       | 0 + 0·dst = 0                     | ✗         |
+/// | SrcIn     | dst_a·0 + 0·dst = 0               | ✗         |
+/// | DstIn     | 0 + src_a(=0)·dst = 0             | ✗         |
+/// | SrcOut    | (1-dst_a)·0 + 0·dst = 0           | ✗         |
+/// | DstATop   | dst_a·0 + src_a(=0)·dst = 0       | ✗         |
+/// | Modulate  | dst·0 + dst·src_a(=0) = 0         | ✗         |
+///
+/// (Rows where a dst-factor depends on `src_a` — DstIn, DstATop, Modulate —
+/// vanish only *because* `src_a = 0` here; they are state-dependent factors, not
+/// the constant `Zero`. `is_tile_safe_for_ssaa_agrees_with_color_blend` pins the
+/// whole partition to `Color::blend` so this hand-derivation can't drift.)
+///
+/// Advanced (dst-read) modes are NOT tile-safe by this definition, but they are
+/// handled separately via `flush_advanced_layer` (not fixed-function blend).
+/// Use `blend.is_advanced()` to detect them before calling this function.
+///
+/// ## Coverage-destructive exception set
+///
+/// The following modes are NOT tile-safe and NOT advanced (Porter-Duff modes
+/// that destroy the destination where the SSAA tile is transparent):
+///
+///   Clear, Src, SrcIn, DstIn, SrcOut, DstATop, Modulate
+///
+/// These modes KEEP the existing tessellated (aliased) render path for fills.
+/// This is an explicit, justified exception: routing them through the SSAA tile
+/// would apply the blend to the transparent padding, incorrectly writing zeros
+/// to destination pixels outside the shape's geometric boundary.
+/// The aliased result is COMPLETE and CORRECT in coverage region — only the
+/// 1px edge band is aliased, which is the same quality as the pre-PR-3 engine.
+pub fn is_tile_safe_for_ssaa(mode: BlendMode) -> bool {
+    matches!(
+        mode,
+        BlendMode::SrcOver
+            | BlendMode::Dst
+            | BlendMode::DstOver
+            | BlendMode::DstOut
+            | BlendMode::SrcATop
+            | BlendMode::Xor
+            | BlendMode::Plus
+    )
+}
+
 /// Pipeline cache managing specialized pipeline variants
 ///
 /// Automatically creates and caches pipelines on-demand based on PipelineKey.
@@ -386,6 +447,53 @@ mod blend_logic {
         assert_eq!(key.blend_mode(), BlendMode::SrcOver);
     }
 
+    /// The SSAA tile-safe gate must agree with the canonical blend evaluator
+    /// `Color::blend`: a Porter-Duff mode is tile-safe iff compositing a fully
+    /// TRANSPARENT source leaves the destination unchanged for every dst (so the
+    /// SSAA tile's transparent padding cannot corrupt dst outside the shape).
+    /// This ties the hand-written `matches!` list to the source of truth, so a
+    /// future mode or a `blend_state_for` change cannot silently desync them and
+    /// route a coverage-destructive mode through the tile.
+    #[test]
+    fn is_tile_safe_for_ssaa_agrees_with_color_blend() {
+        use flui_types::Color;
+        let transparent = Color::TRANSPARENT;
+        let dsts = [
+            Color::rgba(200, 80, 40, 255),
+            Color::rgba(30, 150, 220, 128),
+            Color::rgba(255, 255, 255, 60),
+        ];
+        // Every Porter-Duff (non-advanced) mode. Advanced modes are routed via
+        // `flush_advanced_layer`, not this gate, so they are out of scope here.
+        for mode in [
+            BlendMode::Clear,
+            BlendMode::Src,
+            BlendMode::Dst,
+            BlendMode::SrcOver,
+            BlendMode::DstOver,
+            BlendMode::SrcIn,
+            BlendMode::DstIn,
+            BlendMode::SrcOut,
+            BlendMode::DstOut,
+            BlendMode::SrcATop,
+            BlendMode::DstATop,
+            BlendMode::Xor,
+            BlendMode::Plus,
+            BlendMode::Modulate,
+        ] {
+            let transparent_src_is_noop =
+                dsts.iter().all(|&dst| transparent.blend(dst, mode) == dst);
+            assert_eq!(
+                is_tile_safe_for_ssaa(mode),
+                transparent_src_is_noop,
+                "{mode:?}: is_tile_safe_for_ssaa()={} but (transparent-src is a no-op)={} — \
+                 the SSAA tile-safe classification desynced from Color::blend",
+                is_tile_safe_for_ssaa(mode),
+                transparent_src_is_noop,
+            );
+        }
+    }
+
     #[test]
     fn porter_duff_modes_select_their_own_pipeline() {
         // Even an opaque source must take the blend stage for non-SrcOver modes
@@ -510,6 +618,114 @@ mod blend_logic {
             k_plus, k_clear,
             "different blend modes must hash to different pipeline keys"
         );
+    }
+
+    /// Exhaustive oracle cross-check: `is_tile_safe_for_ssaa` must agree with
+    /// the derivation from `blend_state_for` for every Porter-Duff mode.
+    ///
+    /// A mode is tile-safe iff compositing a fully-transparent source tile
+    /// (src = (0, 0, 0, 0)) leaves the destination unchanged for ALL dst:
+    ///
+    ///   out = src_factor × src_color + dst_factor × dst_color
+    ///       = src_factor × 0         + dst_factor × dst_color
+    ///       = dst_factor × dst_color
+    ///
+    /// The destination is preserved when `dst_factor` evaluates to `One` (or any
+    /// expression that equals 1 when src_alpha = 0): `One`,
+    /// `OneMinusSrcAlpha` (= 1 − 0 = 1), and `OneMinusDstAlpha` (= 1 − dst_a,
+    /// which is NOT necessarily 1 — so DstATop/Modulate/SrcIn/DstIn/SrcOut are
+    /// dst_alpha-dependent and may zero out dst for opaque destinations).
+    ///
+    /// This test evaluates the classification by substituting src = (0,0,0,0):
+    ///
+    /// | Mode      | color dst_factor         | a=0 ⟹ dst_factor=?  | tile-safe |
+    /// |-----------|--------------------------|----------------------|-----------|
+    /// | SrcOver   | OneMinusSrcAlpha (1-0=1) | 1                    | ✓         |
+    /// | Dst       | One                      | 1                    | ✓         |
+    /// | DstOver   | One                      | 1                    | ✓         |
+    /// | DstOut    | OneMinusSrcAlpha (1-0=1) | 1                    | ✓         |
+    /// | SrcATop   | OneMinusSrcAlpha (1-0=1) | 1                    | ✓         |
+    /// | Xor       | OneMinusSrcAlpha (1-0=1) | 1                    | ✓         |
+    /// | Plus      | One                      | 1                    | ✓         |
+    /// | Clear     | Zero                     | 0                    | ✗         |
+    /// | Src       | Zero                     | 0                    | ✗         |
+    /// | SrcIn     | Zero (DstAlpha×0=0)      | 0                    | ✗         |
+    /// | DstIn     | SrcAlpha (=0)            | 0                    | ✗         |
+    /// | SrcOut    | Zero                     | 0                    | ✗         |
+    /// | DstATop   | SrcAlpha (=0)            | 0                    | ✗         |
+    /// | Modulate  | Zero (Dst×0=0) / DstAlpha×0 | 0               | ✗         |
+    ///
+    /// Any future addition or reclassification of a Porter-Duff mode will
+    /// break this test, forcing a deliberate review of the safety gate.
+    #[test]
+    fn is_tile_safe_for_ssaa_matches_blend_state_for_all_porter_duff_modes() {
+        use wgpu::BlendFactor;
+
+        /// Evaluate `dst_factor` at src_alpha = 0, dst_alpha = arbitrary.
+        ///
+        /// Returns `None` when the factor depends on `dst_alpha` (and thus
+        /// `is_tile_safe` cannot be determined by src_alpha alone for all dst);
+        /// returns `Some(is_one)` when the factor is unconditionally 1 (safe)
+        /// or unconditionally 0 (destructive) at src_alpha = 0.
+        fn dst_factor_is_one_at_zero_src(factor: BlendFactor) -> Option<bool> {
+            match factor {
+                // `One` = always 1; `OneMinusSrcAlpha` = 1 − 0 = 1.
+                // Both unconditionally preserve dst at src_alpha = 0.
+                BlendFactor::One | BlendFactor::OneMinusSrcAlpha => Some(true),
+                // `Zero` = always 0; `SrcAlpha` = 0 at src_alpha = 0.
+                // Both unconditionally zero dst at src_alpha = 0.
+                BlendFactor::Zero | BlendFactor::SrcAlpha => Some(false),
+                // `OneMinusDstAlpha`, `DstAlpha`, `Dst`, and any other factor
+                // depend on the destination value, so tile-safety cannot be
+                // determined from src_alpha alone — classified as dst-dependent.
+                _ => None,
+            }
+        }
+
+        /// Compute whether `blend_state_for(mode)` at src=(0,0,0,0) preserves
+        /// the destination — i.e., both color and alpha dst_factor evaluate to 1.
+        fn tile_safe_from_blend_state(mode: BlendMode) -> bool {
+            let state = blend_state_for(mode);
+            // Both color and alpha dst_factor must evaluate to 1 unconditionally
+            // when src_alpha = 0. If either factor depends on dst_alpha (returns
+            // None), the mode is NOT guaranteed to be tile-safe for all dst.
+            matches!(
+                (
+                    dst_factor_is_one_at_zero_src(state.color.dst_factor),
+                    dst_factor_is_one_at_zero_src(state.alpha.dst_factor),
+                ),
+                (Some(true), Some(true))
+            )
+        }
+
+        let porter_duff_modes = [
+            BlendMode::Clear,
+            BlendMode::Src,
+            BlendMode::SrcOver,
+            BlendMode::Dst,
+            BlendMode::DstOver,
+            BlendMode::SrcIn,
+            BlendMode::DstIn,
+            BlendMode::SrcOut,
+            BlendMode::DstOut,
+            BlendMode::SrcATop,
+            BlendMode::DstATop,
+            BlendMode::Xor,
+            BlendMode::Plus,
+            BlendMode::Modulate,
+        ];
+
+        for mode in porter_duff_modes {
+            let expected = tile_safe_from_blend_state(mode);
+            let actual = is_tile_safe_for_ssaa(mode);
+            assert_eq!(
+                actual, expected,
+                "is_tile_safe_for_ssaa({mode:?}) = {actual} but \
+                 blend_state_for derivation says it should be {expected}. \
+                 Either the safety gate or the blend-state table is wrong — \
+                 update both together to keep them in sync."
+            );
+        }
     }
 
     /// Golden lock for the current routing of `pipeline_key_from_paint`.

--- a/crates/flui-engine/src/wgpu/pipelines.rs
+++ b/crates/flui-engine/src/wgpu/pipelines.rs
@@ -53,8 +53,14 @@
 //! `&self.gradient_bind_group_layout`. The pattern mirrors
 //! [`super::resources::GpuResources`].
 
+use std::collections::HashMap;
+
+use flui_types::painting::BlendMode;
+
 use super::{
-    advanced_blend::AdvancedBlendPipeline, pipeline::PipelineCache, ssaa::SsaaDownsamplePipeline,
+    advanced_blend::AdvancedBlendPipeline,
+    pipeline::{PipelineCache, blend_state_for},
+    ssaa::SsaaDownsamplePipeline,
 };
 
 /// Device-scoped collection of all `wgpu::RenderPipeline`s used by [`super::painter::WgpuPainter`].
@@ -160,6 +166,28 @@ pub(crate) struct PipelineSet {
     /// Used by `GpuReplay::render_ssaa_path` to box-average a 2× supersampled
     /// offscreen tile into a premultiplied 1× tile before compositing.
     pub(crate) ssaa_downsample: SsaaDownsamplePipeline,
+
+    // ── SSAA tile composite pipeline cache ───────────────────────────────────
+    //
+    // Holds per-blend-mode premultiplied texture composite pipelines used by
+    // `GpuReplay::render_ssaa_path` when the SSAA tile must be composited with
+    // a tile-safe non-SrcOver mode (e.g. Plus, DstOver, Xor, DstOut).
+    //
+    // SrcOver uses `instanced_texture_premul` (pre-baked); other tile-safe
+    // modes are created on first use and cached here.  Only 6 variants exist.
+    /// Shared layout for the SSAA tile composite pipelines.
+    ///
+    /// Stored at construction so that on-demand pipeline creation in
+    /// [`Self::ensure_ssaa_tile_composite`] does not need to recreate it.
+    ssaa_tile_composite_layout: wgpu::PipelineLayout,
+
+    /// Surface format stored for on-demand composite pipeline creation.
+    ssaa_tile_surface_format: wgpu::TextureFormat,
+
+    /// Cache of premultiplied SSAA tile composite pipelines keyed by blend mode.
+    ///
+    /// Populated lazily on the first encounter of each tile-safe non-SrcOver mode.
+    ssaa_tile_composite_cache: HashMap<BlendMode, wgpu::RenderPipeline>,
 }
 
 impl PipelineSet {
@@ -255,6 +283,21 @@ impl PipelineSet {
         let advanced_blend = AdvancedBlendPipeline::new(device, surface_format);
         let ssaa_downsample = SsaaDownsamplePipeline::new(device, surface_format);
 
+        // ── SSAA tile composite: shared layout + lazy pipeline cache ──────────
+        //
+        // The layout is identical to `texture_pipeline_layout` (same bind groups),
+        // but we store it separately so we can create new per-blend-mode pipelines
+        // later without holding the temporary `texture_pipeline_layout` borrow.
+        let ssaa_tile_composite_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("SSAA Tile Composite Pipeline Layout"),
+                bind_group_layouts: &[
+                    Some(shape_cache.viewport_bind_group_layout()),
+                    Some(&texture_bind_group_layout),
+                ],
+                immediate_size: 0,
+            });
+
         Self {
             shape_cache,
             instanced_rect,
@@ -272,6 +315,9 @@ impl PipelineSet {
             gradient_bind_group: None,
             advanced_blend,
             ssaa_downsample,
+            ssaa_tile_composite_layout,
+            ssaa_tile_surface_format: surface_format,
+            ssaa_tile_composite_cache: HashMap::new(),
         }
     }
 
@@ -323,6 +369,76 @@ impl PipelineSet {
                 resource: self.gradient_stops_buffer.as_entire_binding(),
             }],
         }));
+    }
+
+    // ── SSAA tile composite pipeline cache ────────────────────────────────────
+
+    /// Ensure the premultiplied composite pipeline for `mode` is in the cache.
+    ///
+    /// For `SrcOver`, this is a no-op: the pre-baked `instanced_texture_premul`
+    /// is always available.  For other tile-safe modes the pipeline is created
+    /// on first call and stored in `ssaa_tile_composite_cache`.
+    ///
+    /// This is intentionally separate from [`Self::ssaa_tile_composite_for`] so
+    /// that callers can split the `&mut self` (creation) and `&self` (lookup)
+    /// borrows at a statement boundary, avoiding a borrow-checker conflict when
+    /// `flush_texture_batch_premultiplied_with_mode` also needs `&self` fields
+    /// such as `texture_bind_group_layout` in the same expression.
+    ///
+    /// # Panics (debug)
+    ///
+    /// Debug-panics if `mode` is not tile-safe. Coverage-destructive and advanced
+    /// modes must never reach the SSAA tile composite path.
+    pub(crate) fn ensure_ssaa_tile_composite(&mut self, device: &wgpu::Device, mode: BlendMode) {
+        debug_assert!(
+            super::pipeline::is_tile_safe_for_ssaa(mode),
+            "ensure_ssaa_tile_composite called for non-tile-safe mode {mode:?}; \
+             advanced modes must use flush_advanced_layer, coverage-destructive \
+             modes must stay on the tessellated path",
+        );
+
+        if mode == BlendMode::SrcOver {
+            // SrcOver is served by the pre-baked `instanced_texture_premul`;
+            // no cache entry is needed.
+            return;
+        }
+
+        // `HashMap::entry` does a single lookup on both miss and hit paths.
+        self.ssaa_tile_composite_cache
+            .entry(mode)
+            .or_insert_with(|| {
+                let blend_state = blend_state_for(mode);
+                create_instanced_texture_with_blend_state(
+                    device,
+                    self.ssaa_tile_surface_format,
+                    &self.ssaa_tile_composite_layout,
+                    blend_state,
+                )
+            });
+    }
+
+    /// Return the premultiplied composite pipeline for `mode`.
+    ///
+    /// For `SrcOver`, returns `instanced_texture_premul` directly. For other
+    /// modes, returns the pipeline previously inserted by
+    /// [`Self::ensure_ssaa_tile_composite`].
+    ///
+    /// # Panics (debug)
+    ///
+    /// Debug-panics if `mode` is not `SrcOver` and the cache entry is missing.
+    /// Call `ensure_ssaa_tile_composite` before calling this method.
+    pub(crate) fn ssaa_tile_composite_for(&self, mode: BlendMode) -> &wgpu::RenderPipeline {
+        if mode == BlendMode::SrcOver {
+            return &self.instanced_texture_premul;
+        }
+        self.ssaa_tile_composite_cache
+            .get(&mode)
+            .unwrap_or_else(|| {
+                panic!(
+                    "ssaa_tile_composite_for: no cached pipeline for {mode:?}; \
+                 call ensure_ssaa_tile_composite first"
+                )
+            })
     }
 }
 
@@ -603,6 +719,58 @@ fn create_instanced_texture_premul_pipeline(
                 // premultiplied-alpha texel correctly. This is the defining
                 // distinction from `create_instanced_texture_pipeline`.
                 blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        }),
+        primitive: instanced_quad_primitive_state(),
+        depth_stencil: None,
+        multisample: single_sample_multisample_state(),
+        multiview_mask: None,
+        cache: None,
+    })
+}
+
+/// Creates a premultiplied-source texture composite pipeline with an arbitrary
+/// `blend_state`.
+///
+/// Used by [`PipelineSet::ensure_ssaa_tile_composite`] to build
+/// per-blend-mode variants for SSAA 1× tile compositing.  The SSAA tile is
+/// always premultiplied (box-downsample averages premultiplied values), so the
+/// shader is the same as `TEXTURE_INSTANCED`; only the wgpu `blend_state`
+/// changes.
+///
+/// `blend_state` must be appropriate for premultiplied source — callers should
+/// derive it from [`super::pipeline::blend_state_for`] using the desired
+/// [`flui_types::painting::BlendMode`].
+fn create_instanced_texture_with_blend_state(
+    device: &wgpu::Device,
+    surface_format: wgpu::TextureFormat,
+    layout: &wgpu::PipelineLayout,
+    blend_state: wgpu::BlendState,
+) -> wgpu::RenderPipeline {
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("SSAA Tile Composite Shader"),
+        source: wgpu::ShaderSource::Wgsl(super::shaders::TEXTURE_INSTANCED.into()),
+    });
+    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("SSAA Tile Composite Pipeline"),
+        layout: Some(layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: Some("vs_main"),
+            buffers: &[
+                unit_quad_vertex_buffer_layout(),
+                super::instancing::TextureInstance::desc(),
+            ],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: Some("fs_main"),
+            targets: &[Some(wgpu::ColorTargetState {
+                format: surface_format,
+                blend: Some(blend_state),
                 write_mask: wgpu::ColorWrites::ALL,
             })],
             compilation_options: wgpu::PipelineCompilationOptions::default(),

--- a/crates/flui-engine/src/wgpu/replay.rs
+++ b/crates/flui-engine/src/wgpu/replay.rs
@@ -427,13 +427,19 @@ impl GpuReplay {
                         );
                     }
                 }
-                // ── SSAA-supersampled arbitrary path — PR-3 ────────────────
+                // ── SSAA-supersampled path — PR-3 (SrcOver) / PR-4 (all modes) ──
                 //
                 // Z-correctness: all prior draw_order items have been flushed
                 // before this arm executes (loop order), so the SSAA tile
-                // composites on top of prior content — correct SrcOver stacking.
+                // composites on top of prior content — correct stacking for all
+                // blend modes.
                 //
-                // Surface stays sample_count=1; the 2× size is a normal texture.
+                // Surface stays sample_count=1; the 2× texture is a normal texture.
+                //
+                // Advanced-blend composite (PR-4): `target.texture` is the sampleable
+                // surface required by flush_advanced_layer for the backdrop copy.
+                // View-only targets pass `None` → advanced falls back to SrcOver
+                // (same fallback as AdvancedShape; warns once in that case).
                 DrawItem::SsaaPath(mut op) => {
                     self.render_ssaa_path(
                         &mut op,
@@ -445,8 +451,10 @@ impl GpuReplay {
                         resources,
                         encoder,
                         target.view,
+                        target.texture,
                     );
                     tracing::trace!(
+                        mode = ?op.blend,
                         bounds = ?op.device_bounds,
                         "GpuReplay: SSAA path tile composited"
                     );
@@ -1360,6 +1368,112 @@ impl GpuReplay {
         } else {
             &pipelines.instanced_texture
         };
+        render_pass.set_pipeline(pipeline);
+        render_pass.set_bind_group(0, &self.viewport_bind_group, &[]);
+        render_pass.set_bind_group(1, &texture_bind_group, &[]);
+        render_pass.set_vertex_buffer(0, self.unit_quad_buffer.slice(..));
+        render_pass.set_vertex_buffer(1, instance_buffer.slice(..));
+        render_pass.set_index_buffer(
+            self.unit_quad_index_buffer.slice(..),
+            wgpu::IndexFormat::Uint16,
+        );
+
+        let (full_w, full_h) = viewport_size;
+        if let Some((x, y, w, h)) = scissor {
+            render_pass.set_scissor_rect(x, y, w, h);
+        } else {
+            render_pass.set_scissor_rect(0, 0, full_w, full_h);
+        }
+
+        render_pass.draw_indexed(0..6, 0, 0..self.texture_batch.len() as u32);
+        drop(render_pass);
+        self.texture_batch.clear();
+    }
+
+    /// Flush the texture instance batch with the **exact blend mode** specified.
+    ///
+    /// Unlike [`Self::flush_texture_batch_premultiplied`] (which always uses the
+    /// SrcOver premultiplied pipeline), this method uses
+    /// [`PipelineSet::ensure_ssaa_tile_composite`] /
+    /// [`PipelineSet::ssaa_tile_composite_for`] to obtain a pipeline whose
+    /// `wgpu::BlendState` matches `mode` exactly.
+    ///
+    /// Used by [`Self::render_ssaa_path`] to composite the
+    /// SSAA 1× tile with the correct blend mode. The source texel is
+    /// premultiplied (box-downsample output), so `src_factor = One` is correct
+    /// for all tile-safe variants.
+    ///
+    /// Takes `pipelines: &mut PipelineSet` because lazy pipeline creation may
+    /// be needed on the first call for a given mode.
+    pub(in crate::wgpu) fn flush_texture_batch_premultiplied_with_mode(
+        &mut self,
+        mode: flui_types::painting::BlendMode,
+        device: &Arc<wgpu::Device>,
+        queue: &Arc<wgpu::Queue>,
+        pipelines: &mut PipelineSet,
+        resources: &mut GpuResources,
+        viewport_size: (u32, u32),
+        encoder: &mut wgpu::CommandEncoder,
+        view: &wgpu::TextureView,
+        texture_view: &wgpu::TextureView,
+        scissor: ScissorRect,
+    ) {
+        if self.texture_batch.is_empty() {
+            return;
+        }
+
+        #[cfg(debug_assertions)]
+        tracing::trace!(
+            ?mode,
+            "GpuReplay::flush_texture_batch_premultiplied_with_mode: {} instances",
+            self.texture_batch.len()
+        );
+
+        // Ensure the per-mode pipeline is in the cache. The `&mut` borrow of
+        // `pipelines` ends at the semicolon; subsequent accesses are `&`.
+        pipelines.ensure_ssaa_tile_composite(device, mode);
+
+        // Both of these are now `&pipelines` (shared) borrows — no conflict.
+        let pipeline = pipelines.ssaa_tile_composite_for(mode);
+        let texture_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("SSAA Tile Composite Bind Group"),
+            layout: &pipelines.texture_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Sampler(&self.default_sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(texture_view),
+                },
+            ],
+        });
+
+        let instance_buffer = resources.buffer_pool_mut().get_vertex_buffer(
+            device,
+            queue,
+            "SSAA Tile Composite Instance Buffer",
+            self.texture_batch.as_bytes(),
+        );
+
+        let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("SSAA Tile Composite Render Pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view,
+                resolve_target: None,
+                depth_slice: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+
         render_pass.set_pipeline(pipeline);
         render_pass.set_bind_group(0, &self.viewport_bind_group, &[]);
         render_pass.set_bind_group(1, &texture_bind_group, &[]);

--- a/crates/flui-engine/src/wgpu/ssaa.rs
+++ b/crates/flui-engine/src/wgpu/ssaa.rs
@@ -26,14 +26,20 @@
 //! the path accumulates premultiplied values over transparent. The box downsample
 //! averages premultiplied values, which is linear-correct (premultiplied colour is
 //! linear in coverage). The 1× tile is then composited via
-//! `flush_texture_batch_premultiplied` (src factor `One`) — no double-multiply.
+//! `flush_texture_batch_premultiplied_with_mode` using the exact blend factors
+//! for `op.blend` (src factor `One` for all tile-safe premultiplied modes).
 
 use std::sync::Arc;
 
 use flui_types::{Rect, geometry::Pixels};
 
 use super::{
-    command_ir::SsaaPathOp, pipelines::PipelineSet, replay::GpuReplay, resources::GpuResources,
+    advanced_blend::{AdvancedBlendOp, flush_advanced_layer},
+    command_ir::SsaaPathOp,
+    pipeline::is_tile_safe_for_ssaa,
+    pipelines::PipelineSet,
+    replay::GpuReplay,
+    resources::GpuResources,
     texture_pool::PooledTexture,
 };
 
@@ -157,8 +163,25 @@ impl SsaaDownsamplePipeline {
 #[allow(clippy::too_many_arguments)]
 impl GpuReplay {
     /// Replay a `DrawItem::SsaaPath`: render the path into a 2× tile,
-    /// box-downsample to a premultiplied 1× tile, then composite via the
-    /// premultiplied texture batch.
+    /// box-downsample to a premultiplied 1× tile, then composite onto the target.
+    ///
+    /// ## Composite step (Step 5) — PR-4 blend routing
+    ///
+    /// After producing the AA'd 1× tile, the composite is selected by `op.blend`:
+    ///
+    /// - **tile-safe** (`is_tile_safe_for_ssaa(op.blend)` = true): composite via
+    ///   `flush_texture_batch_premultiplied` with `blend_state_for(op.blend)`.
+    ///   Transparent SSAA padding is a no-op for these modes (dst preserved).
+    ///   This is an extension over PR-3 (SrcOver-only); now handles Dst, DstOver,
+    ///   DstOut, SrcATop, Xor, Plus as well.
+    ///
+    /// - **advanced** (`op.blend.is_advanced()` = true): composite via
+    ///   `flush_advanced_layer` with the 1× tile as foreground.  Requires a
+    ///   sampleable `surface_texture`; falls back to tile-safe SrcOver if absent.
+    ///
+    /// Coverage-destructive modes (Clear, Src, SrcIn, DstIn, SrcOut, DstATop,
+    /// Modulate) never reach `render_ssaa_path` — they are kept on the tessellated
+    /// (aliased) path in the record-side batchers.
     ///
     /// ## Algorithm
     ///
@@ -172,8 +195,7 @@ impl GpuReplay {
     ///      the 1× geometry fills the full 2× texture → 2× supersampled.
     /// 4. Acquire a 1× pooled texture `(tile_w, tile_h)`.  Clear to transparent.
     ///    Run `SsaaDownsamplePipeline` to box-average the 2× → 1×.
-    /// 5. Push the 1× tile into `texture_batch` and composite via
-    ///    `flush_texture_batch_premultiplied` at `device_bounds` on the target.
+    /// 5. Composite the 1× tile using the routing above.
     ///
     /// Both pooled textures are RAII (return to pool on drop).  The 2× tile is
     /// dropped before the composite step; the 1× tile drops after the composite.
@@ -188,6 +210,9 @@ impl GpuReplay {
         resources: &mut GpuResources,
         encoder: &mut wgpu::CommandEncoder,
         target_view: &wgpu::TextureView,
+        // Surface texture for advanced (dst-read) blend composite.
+        // Pass `None` for view-only targets (advanced falls back to SrcOver).
+        surface_texture: Option<&wgpu::Texture>,
     ) {
         let (vp_w, vp_h) = viewport_size;
 
@@ -436,6 +461,11 @@ impl GpuReplay {
         drop(super_tex);
 
         // ── Step 5: composite the 1× tile onto the target ────────────────────
+        //
+        // PR-4 blend routing (see function doc):
+        //   - tile-safe → fixed-function premul blend (SrcOver pipeline for now)
+        //   - advanced   → flush_advanced_layer (dst-read W3C composite)
+        //   - SrcOver (PR-3 baseline) → tile-safe path
 
         let composite_bounds = Rect::from_xywh(
             Pixels(tile_x as f32),
@@ -444,25 +474,100 @@ impl GpuReplay {
             Pixels(tile_h as f32),
         );
 
-        let instance = super::instancing::TextureInstance::new(
-            composite_bounds,
-            flui_types::styling::Color::WHITE,
-        );
-        let _ = self.texture_batch.add(instance);
-
-        self.flush_texture_batch_premultiplied(
-            device,
-            queue,
-            pipelines,
-            resources,
-            viewport_size,
-            encoder,
-            target_view,
-            one_x_tile.view(),
-            None, // no scissor for tile composite
-        );
-
-        // 1× tile drops here → returns to pool (RAII).
+        if op.blend.is_advanced() {
+            // Advanced (dst-read) composite: route through flush_advanced_layer,
+            // same as AdvancedShape. The 1× SSAA tile is the AA'd foreground.
+            if let Some(surf_tex) = surface_texture {
+                let blend_op = AdvancedBlendOp {
+                    foreground: one_x_tile,
+                    mode: op.blend,
+                    device_bounds: composite_bounds,
+                    opacity: 1.0,
+                    tint: [1.0, 1.0, 1.0],
+                    // 1× tile exactly covers composite_bounds; UV is identity.
+                    src_uv_min: [0.0, 0.0],
+                    src_uv_max: [1.0, 1.0],
+                };
+                flush_advanced_layer(
+                    blend_op,
+                    surf_tex,
+                    target_view,
+                    surface_format,
+                    viewport_size,
+                    &pipelines.advanced_blend,
+                    resources,
+                    device,
+                    encoder,
+                );
+                tracing::trace!(
+                    mode = ?op.blend,
+                    bounds = ?composite_bounds,
+                    "GpuReplay: SSAA path tile → advanced composite"
+                );
+                // one_x_tile was moved into AdvancedBlendOp.foreground;
+                // it returns to pool when AdvancedBlendOp is dropped inside
+                // flush_advanced_layer.
+            } else {
+                // View-only target has no sampleable backdrop; fall back to SrcOver.
+                // Same fallback as AdvancedShape in replay.rs.
+                tracing::warn!(
+                    mode = ?op.blend,
+                    "SSAA path advanced blend reached a view_only target; \
+                     falling back to SrcOver (caller must pass sampleable target)"
+                );
+                let instance = super::instancing::TextureInstance::new(
+                    composite_bounds,
+                    flui_types::styling::Color::WHITE,
+                );
+                let _ = self.texture_batch.add(instance);
+                self.flush_texture_batch_premultiplied(
+                    device,
+                    queue,
+                    pipelines,
+                    resources,
+                    viewport_size,
+                    encoder,
+                    target_view,
+                    one_x_tile.view(),
+                    None,
+                );
+                // one_x_tile drops here → returns to pool.
+            }
+        } else {
+            // Tile-safe: fixed-function premul composite with the exact blend mode.
+            //
+            // All tile-safe modes satisfy: blend(transparent_src, dst) == dst,
+            // so the SSAA tile's transparent border pixels do not corrupt dst.
+            //
+            // `flush_texture_batch_premultiplied_with_mode` selects (or lazily
+            // creates) a pipeline whose `wgpu::BlendState` matches `op.blend`
+            // exactly, so DstOut, Plus, DstOver, Xor, SrcATop, Dst, and SrcOver
+            // all composite the 1× tile with their correct factors.
+            debug_assert!(
+                is_tile_safe_for_ssaa(op.blend),
+                "non-advanced, non-tile-safe mode {:?} reached SSAA tile composite — \
+                 coverage-destructive modes must stay on the tessellated path",
+                op.blend
+            );
+            let instance = super::instancing::TextureInstance::new(
+                composite_bounds,
+                flui_types::styling::Color::WHITE,
+            );
+            let _ = self.texture_batch.add(instance);
+            self.flush_texture_batch_premultiplied_with_mode(
+                op.blend,
+                device,
+                queue,
+                pipelines,
+                resources,
+                viewport_size,
+                encoder,
+                target_view,
+                one_x_tile.view(),
+                None, // no scissor — tile exactly covers composite_bounds
+            );
+            // one_x_tile drops here → returns to pool (RAII).
+        }
     }
 
     /// Box-downsample a 2× pooled `source_texture` into a fresh 1× tile.
@@ -607,6 +712,7 @@ mod unit_tests {
         let op = SsaaPathOp {
             segment: seg,
             device_bounds: Rect::from_xywh(Pixels(0.0), Pixels(0.0), Pixels(10.0), Pixels(10.0)),
+            blend: flui_types::painting::BlendMode::SrcOver,
         };
 
         let cloned = op.clone();
@@ -643,6 +749,7 @@ mod unit_tests {
             &state,
             &vertices,
             &indices,
+            flui_types::painting::BlendMode::SrcOver,
         );
 
         assert_eq!(draw_order.len(), 1, "one SsaaPath item must be pushed");
@@ -690,6 +797,7 @@ mod unit_tests {
                 make_vertex(10.0, 15.0),
             ],
             &[0, 1, 2],
+            flui_types::painting::BlendMode::SrcOver,
         );
 
         assert_eq!(
@@ -727,6 +835,7 @@ mod unit_tests {
                 make_vertex(17.5, 40.0),
             ],
             &[0, 1, 2],
+            flui_types::painting::BlendMode::SrcOver,
         );
 
         let DrawItem::SsaaPath(ref op) = draw_order[0] else {
@@ -770,6 +879,7 @@ mod unit_tests {
             &state,
             &[make_vertex(0.0, 0.0), make_vertex(10.0, 0.0)],
             &[], // empty indices
+            flui_types::painting::BlendMode::SrcOver,
         );
 
         assert!(


### PR DESCRIPTION
## Tessellated AA — PR-4 (non-SrcOver) — FINAL PR of the series

Completes the engine-wide tessellated-AA effort. Routes **non-SrcOver tessellated geometry** (arbitrary paths + the non-SrcOver branches of rect/rrect/circle/oval/arc, and drrect fills) through the SSAA tile, composited per blend mode. SrcOver closed-form shapes (SDF — [#258](https://github.com/vanyastaff/flui/pull/258)/[#259](https://github.com/vanyastaff/flui/pull/259)/[#260](https://github.com/vanyastaff/flui/pull/260)) and SrcOver paths ([#262](https://github.com/vanyastaff/flui/pull/262)) are unchanged.

### Mode classification (the coverage-safety crux)
The SSAA tile is a bbox with transparent padding, so a blend that doesn't vanish at src-alpha-0 would corrupt the padding. Modes are partitioned:
- **tile-safe Porter-Duff** (SrcOver, Dst, DstOver, DstOut, SrcATop, Xor, Plus — `blend(transparent_src, dst) == dst`): SSAA tile composited with the mode's fixed-function `blend_state_for` (per-mode premultiplied texture pipeline).
- **advanced / dst-read** (Multiply/Screen/…): the 1× SSAA tile is fed as the `foreground` of `flush_advanced_layer` (reuses Phase B; AA'd + coverage-correct).
- **coverage-destructive Porter-Duff** (Clear, Src, SrcIn, DstIn, SrcOut, DstATop, Modulate): kept on the coverage-correct tessellated (aliased) path — an explicit **documented exception** (a tile would zero dst outside the shape).

### Key changes
- `SsaaPathOp` gains `blend: BlendMode` (Copy/Clone, T11-pure); `render_ssaa_path` branches on it.
- `is_tile_safe_for_ssaa` classifier, **pinned to the source of truth by two unit tests** (vs `blend_state_for` factors AND vs `Color::blend`) so a future mode/factor change can't silently desync.
- `flush_texture_batch_premultiplied_with_mode` + a lazily-cached per-mode tile composite pipeline (≤6 non-SrcOver pipelines).
- **drrect**: SrcOver + tile-safe + advanced ring fills now route to SSAA (was aliased — a common UI border/ring); destructive/stroke keep tessellated.

### Process
Built via a Workflow (build → 2 adversarial review rounds → fix); the self-repair loop fixed a mid-encoder viewport interaction + a non-self-intersecting pentagram. My integrator pass added: the exhaustive `is_tile_safe` classification test, a multi-mode (Dst/DstOver/Xor) per-mode-composite-vs-`Color::blend` GPU test (PD2/pd6_xor already distinctly cover DstOut/Xor), the **drrect routing** (closing an aliased-producer gap), and doc corrections.

### Anti-MVP / scope
PD4 asserts every non-SrcOver shape producer emits partial-alpha; the coverage-destructive set is the only documented aliased exception. Phase B untouched except the additive tile-foreground call site. Byte-identity not claimed for non-SrcOver (they were aliased before).

**Residual LOW hardening (deferred, documented):** SSAA area-threshold uses `max_scale` (perf over-route under anisotropic scale); a shared `ssaa_eligible_for` helper; a table-driven destructive-mode routing guard; an advanced view-only-fallback test (the fallback matches the Phase B AdvancedShape graceful-degrade pattern — sampleable in the surface + layer paths).

### Verification
- `clippy` (default **and** `--features enable-wgpu-tests`, `-D warnings`) clean · `fmt` · `cargo doc -D warnings` · `cargo test --lib` 173
- **DX12 GPU-readback: 338 passed / 0 failed / 7 ignored** (incl. the full Phase B + PR-1/2/2b/3 suites — no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)