### PR TITLE
L2 AA norm + SSAA perf/hygiene + smooth Win32 live-resize

### DIFF
--- a/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
+++ b/crates/flui-engine/src/wgpu/aa_oracle_tests.rs
@@ -3580,4 +3580,210 @@ mod gpu_tests {
             pixels[interior_idx][3]
         );
     }
+
+    // ── Q1: L2 gradient norm AA band-width tests ──────────────────────────────
+
+    /// Q1-a: Rotated-edge AA band width is ≤ ~1.1 device-px (L2 norm).
+    ///
+    /// Draws a 45°-rotated white rectangle that bisects the surface. The edge
+    /// normal is at 45°, so `fwidth` (L1) would give `|dpdx| + |dpdy|` ≈ √2
+    /// (for equal partial derivatives), widening the AA band to ~1.41 device-px.
+    /// `length(dpdx, dpdy)` (L2) gives exactly 1.0 for a unit SDF, so the band
+    /// stays ≤ ~1 device-px even at 45°.
+    ///
+    /// Measurement: scan the row through the rect center, count pixels with
+    /// alpha in (5, 250) → those are partial-coverage AA pixels. At 45°, one
+    /// device-px in the scan direction spans √2 in SDF space, so the L2 band
+    /// spans ≤ 1/√2 × 2 ≈ 1.41 scan pixels; in practice ≤ 2 scan pixels
+    /// (including rounding). L1 can span up to 3 scan pixels at 45°.
+    ///
+    /// ## Why this test MUST FAIL under L1:
+    /// With L1 (`fwidth`), the effective half-width is `(|0.5| + |0.5|) × 0.5 = 0.5`
+    /// in SDF units per device-px, widening smoothstep to span ~√2 device-px.
+    /// At 45° that means 2-3 boundary pixels in a scan perpendicular to the edge;
+    /// under L2 it is 1-2. The threshold `≤ 2` passes L2 and fails L1.
+    #[test]
+    fn q1a_rotated_edge_aa_band_width_is_within_l2_bound() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        // Draw a 90×10 white rect rotated 45°, centered in the frame.
+        // At 45° the vertical edges have a 45° normal, maximizing the L1 vs L2 difference.
+        let cx = SURFACE_WIDTH as f32 / 2.0; // 64.0
+        let cy = SURFACE_HEIGHT as f32 / 2.0; // 64.0
+        let half_w = 45.0_f32;
+        let half_h = 5.0_f32;
+
+        // Use an rrect with zero radius so the painter routes through the instanced
+        // affine-rect path (which uses the sdfToAlpha function we changed).
+        let angle_deg = 45.0_f32;
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+
+        // Build a rotated rect via the painter's transform API.
+        painter.save();
+        painter.translate(flui_types::Offset::new(Pixels(cx), Pixels(cy)));
+        painter.rotate(angle_deg.to_radians());
+        let rotated_rect = Rect::from_ltrb(
+            Pixels(-half_w),
+            Pixels(-half_h),
+            Pixels(half_w),
+            Pixels(half_h),
+        );
+        painter.rect(rotated_rect, &Paint::fill(Color::WHITE));
+        painter.restore();
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Q1a Rotated Edge Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Scan the center row (y = cy as usize = 64) and collect partial-alpha pixels.
+        // At 45° rotation the rect's long axis runs diagonally, but the center row
+        // crosses the rect interior. We look for the boundary band on the
+        // right "side" of the tilted rect — specifically, the band in the scan
+        // row that transitions from partial to interior.
+        //
+        // The short half-height (5px) means the rect's edge is ~5px from the center
+        // in the direction perpendicular to the long axis. At 45° this translates to
+        // ~3-4 pixels up/down and ~3-4 pixels left/right from center in screen space.
+        //
+        // Strategy: count all partial-alpha pixels in a 16-row band around the center
+        // that are on the upper-right boundary (col > cx, row < cy).
+        let band_row_begin = (cy as usize).saturating_sub(8);
+        let band_row_end = (cy as usize + 8).min(SURFACE_HEIGHT as usize);
+        let band_col_begin = cx as usize;
+        let band_col_end = (cx as usize + 16).min(SURFACE_WIDTH as usize);
+
+        let pixels_ref = &pixels;
+        let partial_in_band: Vec<u8> = (band_row_begin..band_row_end)
+            .flat_map(|row| {
+                (band_col_begin..band_col_end).filter_map(move |col| {
+                    let idx = row * SURFACE_WIDTH as usize + col;
+                    let a = pixels_ref[idx][3];
+                    if a > 5 && a < 250 { Some(a) } else { None }
+                })
+            })
+            .collect();
+
+        // There must be some AA pixels on the boundary (the rect exists).
+        assert!(
+            !partial_in_band.is_empty(),
+            "Q1a: no partial-alpha pixels found in the upper-right band — rect may not be rendered \
+             or the 45° rotation is off; partial count=0"
+        );
+
+        // Count total partial-alpha pixels in the whole frame.
+        //
+        // Under L2 (length(dpdx,dpdy)*0.5) the AA half-band is 0.5 device-px.
+        // Under L1 (fwidth*0.5) at 45° the half-band is (|0.5|+|0.5|)*0.5 = 0.707 px —
+        // √2 ≈ 41% wider.  For a 45° rect with ~200 px perimeter this produces
+        // measurably more partial-alpha pixels under L1 vs L2.
+        //
+        // Empirically verified on DX12/D3D12:
+        //   L2  → total_partial ≈ 142 (passes threshold ≤ 149)
+        //   L1  → total_partial ≈ 156 (FAILS threshold ≤ 149)
+        //
+        // The threshold 149 sits at the geometric midpoint, giving 7 px headroom
+        // on each side.  This MUST FAIL if sdfToAlpha reverts to fwidth(x)*0.5.
+        let total_partial: usize = pixels.iter().filter(|p| p[3] > 5 && p[3] < 250).count();
+        assert!(
+            total_partial <= 149,
+            "Q1a: total partial-alpha pixels across the 128×128 frame = {total_partial} — \
+             expected ≤ 149 (L2/length gives ≈142; L1/fwidth at 45° gives ≈156, failing here). \
+             If this assertion fires, check that sdfToAlpha in rect_instanced.wgsl uses \
+             length(vec2(dpdx(dist),dpdy(dist)))*0.5, NOT fwidth(dist)*0.5."
+        );
+    }
+
+    /// Q1-b: Axis-aligned straight edge — L2 and L1 are equivalent (guard test).
+    ///
+    /// On an axis-aligned edge one partial derivative is zero, so:
+    ///   L1: |dpdx| + |dpdy| = |∂/∂x| + 0 = |∂/∂x|
+    ///   L2: sqrt(dpdx² + dpdy²) = |∂/∂x|
+    /// The two norms are identical. This test verifies the AA band on a straight
+    /// horizontal/vertical edge is ≤ 2 pixels under both norms.
+    ///
+    /// If this test fails when Q1a passes, the `dpdx`/`dpdy` change introduced
+    /// a regression on axis-aligned edges.
+    #[test]
+    fn q1b_axis_aligned_edge_aa_band_is_within_expected_width() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_render_surface(&device);
+        clear_surface(&device, &queue, &surface_view);
+
+        // Draw a 60×40 axis-aligned white rect centered in the frame.
+        let cx = SURFACE_WIDTH as f32 / 2.0;
+        let cy = SURFACE_HEIGHT as f32 / 2.0;
+        let half_w = 30.0_f32;
+        let half_h = 20.0_f32;
+
+        let rect = Rect::from_ltrb(
+            Pixels(cx - half_w),
+            Pixels(cy - half_h),
+            Pixels(cx + half_w),
+            Pixels(cy + half_h),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.rect(rect, &Paint::fill(Color::WHITE));
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Q1b Axis-Aligned Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_texture);
+
+        // Scan the right edge of the rect (the column around cx + half_w = 94).
+        let edge_col = (cx + half_w) as usize; // ~94
+        let scan_row_start = (cy as usize).saturating_sub(5);
+        let scan_row_end = (cy as usize + 5).min(SURFACE_HEIGHT as usize);
+
+        // Count partial-alpha pixels in the edge column and its immediate neighbours.
+        let mut max_partial_per_row = 0usize;
+        for row in scan_row_start..scan_row_end {
+            let count = (edge_col.saturating_sub(1)
+                ..=(edge_col + 1).min(SURFACE_WIDTH as usize - 1))
+                .filter(|&col| {
+                    let idx = row * SURFACE_WIDTH as usize + col;
+                    let a = pixels[idx][3];
+                    a > 5 && a < 250
+                })
+                .count();
+            if count > max_partial_per_row {
+                max_partial_per_row = count;
+            }
+        }
+
+        // Interior must be opaque.
+        let interior_idx = cy as usize * SURFACE_WIDTH as usize + cx as usize;
+        assert!(
+            pixels[interior_idx][3] > 200,
+            "Q1b: interior must be opaque; got alpha={}",
+            pixels[interior_idx][3]
+        );
+
+        // Axis-aligned edge: ≤ 2 partial pixels in a 3-pixel horizontal scan.
+        assert!(
+            max_partial_per_row <= 2,
+            "Q1b: axis-aligned right edge has {max_partial_per_row} partial-alpha pixels in a \
+             3-wide scan — expected ≤ 2 (both L1 and L2 are identical on axis-aligned edges)"
+        );
+    }
 }

--- a/crates/flui-engine/src/wgpu/batches/paths.rs
+++ b/crates/flui-engine/src/wgpu/batches/paths.rs
@@ -243,9 +243,10 @@ impl DrawBatcher {
         //
         // The AABB is computed lazily (only when style==Fill and the mode qualifies).
         let ssaa_blend: Option<BlendMode> = if paint.style == PaintStyle::Fill
-            && (pipeline::is_tile_safe_for_ssaa(paint.blend_mode) || paint.blend_mode.is_advanced())
-            && path_aabb_area_device_px_sq(path, state) >= SSAA_AREA_THRESHOLD_PX_SQ
-        {
+            && pipeline::ssaa_eligible_for(
+                paint.blend_mode,
+                path_aabb_area_device_px_sq(path, state),
+            ) {
             Some(paint.blend_mode)
         } else {
             None
@@ -458,36 +459,23 @@ impl DrawBatcher {
 
 // ─── Module-level helpers ─────────────────────────────────────────────────────
 
-/// Minimum path AABB area (in device-pixel²) that qualifies for SSAA routing.
-///
-/// Paths whose bounding-box area is below this threshold are rendered via the
-/// normal batched tessellated draw call (shared GPU pass, zero offscreen
-/// overhead).  Paths at or above the threshold are routed to SSAA (5 render
-/// passes, 2 pooled-texture acquisitions) for proper sub-pixel AA on visible
-/// diagonal edges.
-///
-/// 256 px² ≈ 16 × 16 device pixels.  Empirically, paths smaller than this
-/// produce aliasing that is imperceptible at typical DPR and viewing distances;
-/// the SSAA cost is not justified.
-pub(in super::super) const SSAA_AREA_THRESHOLD_PX_SQ: f32 = 256.0;
-
 /// Compute the device-pixel² area of a path's axis-aligned bounding box,
 /// scaled by the current CTM (so the area reflects actual screen size).
 ///
 /// Uses `path.compute_bounds()` — a pure computation over path commands with
-/// no tessellation.  The CTM scale is applied as `area × max_scale²` because
-/// the AABB in local space must be scaled to device pixels.
+/// no tessellation. The CTM area scale is applied via `state.area_scale()` (the
+/// absolute determinant of the 2D linear part of the CTM), which is correct for
+/// anisotropic transforms. Under uniform scale `s`, `area_scale() == s²`.
 ///
 /// Used exclusively by `draw_path` to decide SSAA eligibility.
 fn path_aabb_area_device_px_sq(path: &Path, state: &GpuStateStack) -> f32 {
     let local_bounds = path.compute_bounds();
     let w = local_bounds.width().0.max(0.0);
     let h = local_bounds.height().0.max(0.0);
-    // Scale each edge by max_scale to get device-pixel extent.
-    let scale = state.max_scale();
-    let device_w = w * scale;
-    let device_h = h * scale;
-    device_w * device_h
+    // area_scale() = |det(M_2d)| maps local area → device-pixel² area correctly
+    // under rotation, shear, and anisotropic scale. max_scale² overestimates for
+    // anisotropic scale (e.g. scale(0.5, 10) → max_scale²=100, area_scale=5).
+    w * h * state.area_scale()
 }
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────
@@ -500,9 +488,10 @@ mod threshold_tests {
     use super::{
         super::super::{
             command_ir::{DrawItem, DrawSegment},
+            pipeline::SSAA_AREA_THRESHOLD_PX_SQ,
             state_stack::GpuStateStack,
         },
-        DrawBatcher, SSAA_AREA_THRESHOLD_PX_SQ,
+        DrawBatcher,
     };
 
     fn make_batcher() -> DrawBatcher {

--- a/crates/flui-engine/src/wgpu/batches/shapes.rs
+++ b/crates/flui-engine/src/wgpu/batches/shapes.rs
@@ -153,11 +153,8 @@ impl DrawBatcher {
                 ];
                 let indices = [0u32, 1, 2, 0, 2, 3];
                 let mode = paint.blend_mode;
-                let scale = state.max_scale();
-                let device_area = rect.width().0 * scale * rect.height().0 * scale;
-                if (pipeline::is_tile_safe_for_ssaa(mode) || mode.is_advanced())
-                    && device_area >= super::paths::SSAA_AREA_THRESHOLD_PX_SQ
-                {
+                let device_area = rect.width().0 * rect.height().0 * state.area_scale();
+                if pipeline::ssaa_eligible_for(mode, device_area) {
                     // Vertices are already in device-pixel space (apply_transform was
                     // called above). Pass them directly to divert_path_to_ssaa.
                     Self::divert_path_to_ssaa(
@@ -248,14 +245,10 @@ impl DrawBatcher {
                 self.prime_tessellator_scale(state);
                 match self.tessellator.tessellate_rrect(rrect, &fill_paint) {
                     Ok((vertices, indices)) => {
-                        let scale = state.max_scale();
                         let device_area = rrect.bounding_rect().width().0
-                            * scale
                             * rrect.bounding_rect().height().0
-                            * scale;
-                        let ssaa_eligible = (pipeline::is_tile_safe_for_ssaa(mode)
-                            || mode.is_advanced())
-                            && device_area >= super::paths::SSAA_AREA_THRESHOLD_PX_SQ;
+                            * state.area_scale();
+                        let ssaa_eligible = pipeline::ssaa_eligible_for(mode, device_area);
                         if ssaa_eligible {
                             // Bake current transform into vertices before divert.
                             // `divert_path_to_ssaa` expects pre-transformed device-px coords.
@@ -485,12 +478,10 @@ impl DrawBatcher {
                     .tessellate_circle(center, radius, &fill_paint)
                 {
                     Ok((vertices, indices)) => {
-                        let scale = state.max_scale();
-                        let diameter = radius * 2.0 * scale;
-                        let device_area = diameter * diameter;
-                        let ssaa_eligible = (pipeline::is_tile_safe_for_ssaa(mode)
-                            || mode.is_advanced())
-                            && device_area >= super::paths::SSAA_AREA_THRESHOLD_PX_SQ;
+                        // Circle local-space AABB: (2r)×(2r) = 4r²; area_scale converts to device px².
+                        let local_area = (radius * 2.0) * (radius * 2.0);
+                        let device_area = local_area * state.area_scale();
+                        let ssaa_eligible = pipeline::ssaa_eligible_for(mode, device_area);
                         if ssaa_eligible {
                             let transform = state.current_transform();
                             let mut baked = vertices;
@@ -611,10 +602,8 @@ impl DrawBatcher {
                 self.tessellator
                     .tessellate_ellipse(center, radii, &fill_paint)
             {
-                let scale = state.max_scale();
-                let device_area = rect.width().0 * scale * rect.height().0 * scale;
-                let ssaa_eligible = (pipeline::is_tile_safe_for_ssaa(mode) || mode.is_advanced())
-                    && device_area >= super::paths::SSAA_AREA_THRESHOLD_PX_SQ;
+                let device_area = rect.width().0 * rect.height().0 * state.area_scale();
+                let ssaa_eligible = pipeline::ssaa_eligible_for(mode, device_area);
                 if ssaa_eligible {
                     let transform = state.current_transform();
                     let mut baked = vertices;
@@ -673,13 +662,11 @@ impl DrawBatcher {
                 // tessellated (aliased) path. (Without this, a SrcOver ring/border —
                 // a common UI element — would render aliased.)
                 let mode = paint.blend_mode;
-                let scale = state.max_scale();
-                let device_area = outer.width().0 * scale * outer.height().0 * scale;
-                if paint.style == PaintStyle::Fill
-                    && (mode == BlendMode::SrcOver
-                        || pipeline::is_tile_safe_for_ssaa(mode)
-                        || mode.is_advanced())
-                    && device_area >= super::paths::SSAA_AREA_THRESHOLD_PX_SQ
+                // `mode == BlendMode::SrcOver` prefix dropped: SrcOver is tile-safe by
+                // definition (`is_tile_safe_for_ssaa(SrcOver) == true`), so
+                // `ssaa_eligible_for` subsumes it.
+                let device_area = outer.width().0 * outer.height().0 * state.area_scale();
+                if paint.style == PaintStyle::Fill && pipeline::ssaa_eligible_for(mode, device_area)
                 {
                     Self::submit_transformed_and_divert_to_ssaa(
                         segment, draw_order, state, vertices, &indices, mode,
@@ -817,15 +804,14 @@ impl DrawBatcher {
                     &fill_paint,
                 ) {
                     Ok((vertices, indices)) => {
-                        let scale = state.max_scale();
                         // Arc bounding area ≈ rect area (conservative upper bound).
-                        let device_area = rect.width().0 * scale * rect.height().0 * scale;
-                        // Only route to SSAA for non-SrcOver modes; SrcOver arcs
-                        // that reach this branch (reflection fallback) are already
-                        // tessellated — a second SSAA path for them is not needed.
+                        let device_area = rect.width().0 * rect.height().0 * state.area_scale();
+                        // Only route to SSAA for non-SrcOver modes; SrcOver arcs that reach
+                        // this reflection-fallback branch are already tessellated — routing
+                        // them through SSAA again would be redundant. The `mode != SrcOver`
+                        // guard is load-bearing and must NOT be folded into ssaa_eligible_for.
                         let ssaa_eligible = mode != BlendMode::SrcOver
-                            && (pipeline::is_tile_safe_for_ssaa(mode) || mode.is_advanced())
-                            && device_area >= super::paths::SSAA_AREA_THRESHOLD_PX_SQ;
+                            && pipeline::ssaa_eligible_for(mode, device_area);
                         if ssaa_eligible {
                             let transform = state.current_transform();
                             let mut baked = vertices;

--- a/crates/flui-engine/src/wgpu/pipeline.rs
+++ b/crates/flui-engine/src/wgpu/pipeline.rs
@@ -222,6 +222,41 @@ pub fn is_tile_safe_for_ssaa(mode: BlendMode) -> bool {
     )
 }
 
+/// Minimum device-pixel² area a shape must have before SSAA is eligible.
+///
+/// A 16×16 px² shape (256 px²) is the crossover below which SSAA overhead
+/// (2× texture allocation + downsample pass) is not worth the quality gain.
+/// Shapes smaller than this fall back to the tessellated (SDF-AA) path.
+///
+/// Previously declared in `batches/paths.rs` (private to that module);
+/// centralised here so all batch modules share one constant.
+pub const SSAA_AREA_THRESHOLD_PX_SQ: f32 = 256.0;
+
+/// Returns `true` when SSAA tiling is both blend-safe and large enough to
+/// justify the 2× oversample overhead.
+///
+/// A shape is SSAA-eligible when:
+/// 1. `is_tile_safe_for_ssaa(mode)` — transparent padding in the tile cannot
+///    destroy destination pixels (no coverage-destructive Porter-Duff mode).
+/// 2. OR `mode.is_advanced()` — advanced (dst-read) modes are handled via
+///    the GPU compositor path which is inherently tile-aware.
+/// 3. AND `device_area >= SSAA_AREA_THRESHOLD_PX_SQ` — shape is large enough
+///    to amortise the tile's allocation and downsample cost.
+///
+/// ## Shape-specific prefix rules
+///
+/// Most shapes call this directly. Two shapes have additional prefix guards
+/// that must be evaluated BY THE CALLER:
+///
+/// - **arc** (`batches/shapes.rs`): must KEEP an outer `mode != BlendMode::SrcOver &&`
+///   guard — SrcOver arcs reach the non-SrcOver reflection-fallback branch and
+///   must stay on the tessellated path.
+/// - **drrect** (`batches/shapes.rs`): the `mode == BlendMode::SrcOver ||`
+///   prefix was dropped (it is subsumed by `is_tile_safe_for_ssaa(SrcOver)` == `true`).
+pub fn ssaa_eligible_for(mode: BlendMode, device_area: f32) -> bool {
+    (is_tile_safe_for_ssaa(mode) || mode.is_advanced()) && device_area >= SSAA_AREA_THRESHOLD_PX_SQ
+}
+
 /// Pipeline cache managing specialized pipeline variants
 ///
 /// Automatically creates and caches pipelines on-demand based on PipelineKey.
@@ -831,6 +866,97 @@ mod blend_logic {
                 k_trans.blend_mode(),
                 mode,
                 "{mode:?} translucent: key must carry the original advanced mode"
+            );
+        }
+    }
+
+    // =========================================================================
+    // H1: ssaa_eligible_for() behaviour tests
+    // =========================================================================
+
+    /// SrcOver at a large device area is eligible (tile-safe + above threshold).
+    #[test]
+    fn ssaa_eligible_for_srcover_large_area_is_true() {
+        assert!(
+            ssaa_eligible_for(BlendMode::SrcOver, 300.0),
+            "SrcOver at 300 px² must be SSAA-eligible"
+        );
+    }
+
+    /// Every destructive Porter-Duff mode is ineligible regardless of area.
+    ///
+    /// These modes zero the destination where the SSAA tile is transparent,
+    /// so routing them through the tile would corrupt pixels outside the shape.
+    #[test]
+    fn ssaa_eligible_for_destructive_modes_are_ineligible_at_max_area() {
+        for mode in [
+            BlendMode::Clear,
+            BlendMode::Src,
+            BlendMode::SrcIn,
+            BlendMode::DstIn,
+            BlendMode::SrcOut,
+            BlendMode::DstATop,
+            BlendMode::Modulate,
+        ] {
+            assert!(
+                !is_tile_safe_for_ssaa(mode),
+                "{mode:?} should NOT be tile-safe"
+            );
+            assert!(!mode.is_advanced(), "{mode:?} should NOT be advanced");
+            assert!(
+                !ssaa_eligible_for(mode, f32::MAX),
+                "{mode:?} must never be SSAA-eligible (destructive padding)"
+            );
+        }
+    }
+
+    /// Below-threshold area is always ineligible even for tile-safe modes.
+    #[test]
+    fn ssaa_eligible_for_srcover_below_threshold_is_false() {
+        assert!(
+            !ssaa_eligible_for(BlendMode::SrcOver, 255.9),
+            "SrcOver at 255.9 px² (below 256.0 threshold) must not be SSAA-eligible"
+        );
+    }
+
+    /// Pin the destructive set to Color::blend oracle: for every Porter-Duff mode,
+    /// `!is_tile_safe_for_ssaa(mode)` must agree with the color-blend oracle for
+    /// a canonical opaque dst. (Mirrors the existing `is_tile_safe_for_ssaa_agrees_with_color_blend`
+    /// check but scoped specifically to the destructive modes documented in H2.)
+    #[test]
+    fn destructive_modes_are_never_ssaa_eligible() {
+        use flui_types::Color;
+        let transparent = Color::TRANSPARENT;
+        let opaque_dst = Color::rgba(200, 80, 40, 255);
+
+        for mode in [
+            BlendMode::Clear,
+            BlendMode::Src,
+            BlendMode::SrcIn,
+            BlendMode::DstIn,
+            BlendMode::SrcOut,
+            BlendMode::DstATop,
+            BlendMode::Modulate,
+        ] {
+            // Oracle: transparent src changes dst → destructive → not tile-safe.
+            let transparent_src_changes_dst = transparent.blend(opaque_dst, mode) != opaque_dst;
+            assert!(
+                transparent_src_changes_dst,
+                "{mode:?}: Color::blend oracle says transparent src does NOT change dst \
+                 — this mode should be tile-safe, not in the destructive list"
+            );
+            // The H2 table: all three classifiers agree.
+            assert!(
+                !is_tile_safe_for_ssaa(mode),
+                "{mode:?}: is_tile_safe_for_ssaa should be false for a destructive mode"
+            );
+            assert!(
+                !mode.is_advanced(),
+                "{mode:?}: is_advanced should be false for a plain Porter-Duff mode"
+            );
+            assert!(
+                !ssaa_eligible_for(mode, f32::MAX),
+                "{mode:?}: ssaa_eligible_for must be false regardless of area"
             );
         }
     }

--- a/crates/flui-engine/src/wgpu/renderer.rs
+++ b/crates/flui-engine/src/wgpu/renderer.rs
@@ -331,8 +331,35 @@ impl Renderer {
         let backends = Self::select_backend();
         tracing::info!("Creating wgpu instance with backends: {:?}", backends);
 
+        // DX12 presentation system: route through DirectComposition
+        // (`CreateSwapChainForComposition` + an auto-created `IDCompositionVisual`)
+        // instead of the default `CreateSwapChainForHwnd` redirection-bitmap path.
+        //
+        // The HWND redirection bitmap + flip-model swapchain have no synchronization
+        // between the swapchain flip and the window-rect change during a live resize,
+        // so DWM stretches the in-flight back buffer to the new rect — the root cause
+        // of resize "wobble" (confirmed: not fixable via present_mode / frame_latency /
+        // DwmFlush / WM_SIZE timing — see winit#786, wgpu#2869, and the hardcoded
+        // `DXGI_SCALING_STRETCH` in wgpu-hal dx12). Compositing through a DComp visual
+        // lets DWM own the transform, which removes the stretch and gives smooth resize.
+        //
+        // Opt out with `FLUI_DX12_NO_DCOMP=1` (RenderDoc cannot capture a composition
+        // swapchain, so GPU-debugging the present path needs the plain HWND path).
+        let dx12_options = if std::env::var_os("FLUI_DX12_NO_DCOMP").is_some() {
+            tracing::debug!("DX12 DComp presentation disabled via FLUI_DX12_NO_DCOMP");
+            wgpu::Dx12BackendOptions::default()
+        } else {
+            wgpu::Dx12BackendOptions {
+                presentation_system: wgpu::Dx12SwapchainKind::DxgiFromVisual,
+                ..Default::default()
+            }
+        };
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends,
+            backend_options: wgpu::BackendOptions {
+                dx12: dx12_options,
+                ..Default::default()
+            },
             ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
 
@@ -415,7 +442,11 @@ impl Renderer {
             present_mode: Self::select_present_mode(&surface_caps),
             alpha_mode: wgpu::CompositeAlphaMode::Auto,
             view_formats: vec![],
-            desired_maximum_frame_latency: 2,
+            // 1 (not 2): during a live resize the displayed frame must track the
+            // window size as tightly as possible. A latency of 2 lets the present
+            // queue hold frames rendered for an older size, which the compositor
+            // then stretches to the current window → visible resize jitter.
+            desired_maximum_frame_latency: 1,
         };
         surface.configure(&device, &config);
 
@@ -874,7 +905,11 @@ impl Renderer {
 
     /// Select present mode based on capabilities
     fn select_present_mode(surface_caps: &wgpu::SurfaceCapabilities) -> wgpu::PresentMode {
-        // Prefer Mailbox (triple buffering, low latency) > Fifo (vsync)
+        // Prefer Mailbox (triple buffering, low latency) > Fifo (vsync).
+        // NB: neither cures live-resize wobble — Mailbox stretches the in-flight
+        // frame, Fifo blocks on vsync and ghosts a stale frame during the modal
+        // resize loop. The wobble is inherent flip-model DWM compositing; the only
+        // real fix is DXGI_SCALING_NONE, which wgpu 29 does not expose.
         if surface_caps
             .present_modes
             .contains(&wgpu::PresentMode::Mailbox)
@@ -1061,6 +1096,25 @@ impl Renderer {
         let view = output
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());
+
+        // Observability: the acquired swapchain texture must match the configured
+        // surface size, which is the size the geometry was laid out / the viewport
+        // uniform was written against. A divergence means a resize landed between
+        // `surface.configure` and `get_current_texture` (or the OS handed back a
+        // stale backbuffer) — the frame would then be presented stretched, which
+        // reads as resize "jitter". Warn (don't spam): only when they actually differ.
+        if let Some(config) = self.config.as_ref() {
+            let attachment = (output.texture.width(), output.texture.height());
+            let configured = (config.width, config.height);
+            if attachment != configured {
+                tracing::warn!(
+                    ?attachment,
+                    ?configured,
+                    "render_scene: swapchain texture size != configured surface size \
+                     (resize transient — frame will present stretched)"
+                );
+            }
+        }
 
         // Determine whether this frame should go through the intermediate-texture
         // path (COPY_SRC-less adapters, or forced in tests).

--- a/crates/flui-engine/src/wgpu/replay.rs
+++ b/crates/flui-engine/src/wgpu/replay.rs
@@ -1025,6 +1025,20 @@ impl GpuReplay {
         render_pass.set_index_buffer(index_buffer.slice(..), wgpu::IndexFormat::Uint32);
 
         let (full_w, full_h) = viewport_size;
+
+        // Pin the viewport to (full_w, full_h) so that NDC [-1,+1] always maps to
+        // exactly the requested viewport extent, regardless of the wgpu attachment
+        // size.  Without this explicit set, wgpu's default viewport equals the
+        // attachment dimensions — which diverges from full_w/full_h when rendering
+        // into an oversized pool-bucket texture (e.g. SSAA bucket-aligned tiles).
+        // Setting it explicitly is a no-op for the normal case where attachment ==
+        // viewport, but is load-bearing for SSAA bucket rendering.
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "full_w/full_h are small surface dimensions; f32 is sufficient"
+        )]
+        render_pass.set_viewport(0.0, 0.0, full_w as f32, full_h as f32, 0.0, 1.0);
+
         let mut active_key: Option<PipelineKey> = None;
         for batch in &segment.tess_batches {
             if active_key != Some(batch.pipeline_key) {

--- a/crates/flui-engine/src/wgpu/shaders/arc_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/arc_instanced.wgsl
@@ -26,14 +26,16 @@
 //   transform           = M_world * r     (col-major [a,b,c,d])
 //   transform_translate = M_world * center_local + t_world
 //
-// ## Radial AA (fwidth — radius-independent)
+// ## Radial AA (L2 screen-space gradient — radius-independent)
 //
 // Previous shader used `edge_softness = 0.02` (radius-RELATIVE — wrong).
-// New model: `d_r = length(unit_pos) - 1.0`, `aa_r = fwidth(d_r) * 0.5`.
-// `fwidth(d_r)` measures the screen-space derivative of the unit-circle SDF,
-// yielding ~1 device-px AA at ANY radius, rotation, or anisotropic scale.
+// New model: `d_r = length(unit_pos) - 1.0`,
+// `aa_r = length(vec2(dpdx(d_r), dpdy(d_r))) * 0.5`.
+// The L2 (Euclidean) gradient measures the screen-space derivative of the
+// unit-circle SDF, yielding ~1 device-px AA at ANY radius, rotation, or
+// anisotropic scale (L1/fwidth would overestimate diagonal edges by up to √2).
 //
-// ## Angular AA (screen-space fwidth — resolution-independent)
+// ## Angular AA (L2 screen-space gradient — resolution-independent)
 //
 // Previous shader used `angle_softness = 0.05` rad (fixed ~3° — wrong at any
 // but one radius). New model uses an SDF of the two radial half-planes that
@@ -66,7 +68,7 @@
 //
 // For negative sweep (counter-clockwise): flip sign of both d_start and d_end.
 //
-// `fwidth` of the resulting angular_sdf gives screen-space ~1 device-px AA
+// The L2 gradient of the resulting angular_sdf gives screen-space ~1 device-px AA
 // at the sector edges at ANY radius or scale.
 //
 // ## Outer-fringe quad expansion
@@ -77,8 +79,8 @@
 //
 // ## AA model improvement over previous arc shader
 //
-// - Radial: `edge_softness=0.02` (radius-relative) → `fwidth(dist)` (radius-independent).
-// - Angular: `angle_softness=0.05` rad (fixed ~3°) → `fwidth(angular_sdf)` (~1px device).
+// - Radial: `edge_softness=0.02` (radius-relative) → L2 `length(dpdx, dpdy)` (radius-independent).
+// - Angular: `angle_softness=0.05` rad (fixed ~3°) → L2 gradient of `angular_sdf` (~1px device).
 // - No fixed `angle_softness` threshold remains.
 // - The `in_arc` boolean + angular smoothstep is replaced by a signed-distance
 //   approach that computes continuous partial-alpha at the sector edges.
@@ -102,7 +104,7 @@ struct VertexOutput {
     @location(0) color: vec4<f32>,
     // Unit-disk coordinate: `unit_pos = expanded_unit_quad * 2 - 1`, scaled by
     // the fringe expansion. SDF evaluates `length(unit_pos) - 1.0`. Passed to
-    // the fragment so `fwidth` measures the screen-space derivative correctly.
+    // the fragment so the L2 gradient (dpdx/dpdy) measures the screen-space derivative correctly.
     @location(1) unit_pos: vec2<f32>,
     @location(2) start_angle: f32,
     @location(3) sweep_angle: f32,
@@ -185,15 +187,16 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let start    = in.start_angle;
     let sweep    = in.sweep_angle;
 
-    // ── Radial SDF (fwidth-based, radius-independent) ─────────────────────
+    // ── Radial SDF (L2-gradient, radius-independent) ──────────────────────
     //
     // Signed distance to the unit-circle edge:
     //   d < 0 → inside the circle
     //   d = 0 → on the edge
     //   d > 0 → outside
-    // `fwidth(d)` gives ~1 device-px AA at ANY radius, rotation, or scale.
+    // The L2 gradient of `d` gives ~1 device-px AA at ANY radius, rotation, or scale.
     let d_radial = length(unit_pos) - 1.0;
-    let aa_radial = fwidth(d_radial) * 0.5;
+    // L2 gradient magnitude: ~1-device-px AA at any angle/scale (no L1 overestimate).
+    let aa_radial = length(vec2<f32>(dpdx(d_radial), dpdy(d_radial))) * 0.5;
     let radial_alpha = 1.0 - smoothstep(-aa_radial, aa_radial, d_radial);
 
     // Discard pixels fully outside the circle (fringe expansion safety).
@@ -201,7 +204,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         discard;
     }
 
-    // ── Angular SDF (screen-space fwidth, sector half-planes) ────────────
+    // ── Angular SDF (L2 screen-space gradient, sector half-planes) ───────
     //
     // Full-circle shortcut: |sweep| ≥ 2π → no angular cut, pure circle.
     let tau = 6.28318530718; // 2π
@@ -262,8 +265,8 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         angular_sdf = max(d_start_hp, d_end_hp);
     }
 
-    // Screen-space AA width for the angular edge: ~1 device-px.
-    let aa_angular = fwidth(angular_sdf) * 0.5;
+    // Screen-space AA width for the angular edge: ~1 device-px via L2 gradient.
+    let aa_angular = length(vec2<f32>(dpdx(angular_sdf), dpdy(angular_sdf))) * 0.5;
     let angular_alpha = smoothstep(-aa_angular, aa_angular, angular_sdf);
 
     // Discard pixels fully outside the angular sector.

--- a/crates/flui-engine/src/wgpu/shaders/circle_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/circle_instanced.wgsl
@@ -22,9 +22,10 @@
 //   transform_translate = M_world * center_local + t_world
 //
 // The SDF fragment evaluates `length(unit_pos) - 1.0` (0 at the unit-circle
-// edge). `fwidth(dist)` measures the screen-space derivative of that local
-// distance, yielding ~1-device-px AA under ANY affine (rotation/shear/
-// anisotropic scale).
+// edge). The L2 screen-space gradient `length(vec2(dpdx(dist), dpdy(dist)))`
+// measures the derivative of that local distance, yielding ~1-device-px AA under
+// ANY affine (rotation/shear/anisotropic scale); L1/fwidth would overestimate
+// diagonal edges by up to √2.
 //
 // ## Baked fast path (axis-aligned SrcOver circles)
 //
@@ -44,7 +45,7 @@
 // ## AA quality fix
 //
 // Previous shader used `edge_softness = 0.02` (radius-RELATIVE): a 200px circle
-// got 4px AA; a 5px circle got 0.1px. The new `fwidth`-based model gives exactly
+// got 4px AA; a 5px circle got 0.1px. The new L2-gradient model gives exactly
 // ~1 device-px AA at ANY radius and any affine — the same model as rect_instanced.
 
 // Vertex input (shared unit quad: [0,0] to [1,1])
@@ -66,8 +67,8 @@ struct VertexOutput {
     @location(0) color: vec4<f32>,
     // Unit-circle coordinate passed from the vertex shader to the fragment.
     // For the unit-circle local shape: `unit_pos = (local_pos - center) / radius`.
-    // The SDF evaluates `length(unit_pos) - 1.0`; fwidth gives correct screen-space
-    // AA width regardless of the affine applied in the vertex shader.
+    // The SDF evaluates `length(unit_pos) - 1.0`; the L2 gradient (dpdx/dpdy) gives
+    // correct screen-space AA width regardless of the affine applied in the vertex shader.
     @location(1) unit_pos: vec2<f32>,
 }
 
@@ -162,7 +163,7 @@ fn vs_main(
 }
 
 // =============================================================================
-// Fragment Shader (SDF-based with screen-space fwidth AA)
+// Fragment Shader (SDF-based with L2 screen-space gradient AA)
 // =============================================================================
 
 @fragment
@@ -175,15 +176,18 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // `length(unit_pos) - 1.0` is the exact SDF of the unit circle in the
     // coordinate space passed from the vertex shader. Because the vertex shader
     // maps local→device via the full affine M (which is M_world * diag(rx,ry)),
-    // `fwidth(d)` measures the screen-space gradient of this distance, giving
-    // ~1 device-px AA at ANY radius, rotation, or anisotropic scale — correct
-    // for circles, rotated circles, and oriented ellipses.
+    // The L2 gradient `length(vec2(dpdx(d), dpdy(d)))` measures the screen-space
+    // gradient of this distance, giving ~1 device-px AA at ANY radius, rotation,
+    // or anisotropic scale — correct for circles, rotated circles, and oriented
+    // ellipses.
     let d = length(in.unit_pos) - 1.0;
 
-    // Adaptive AA: half-pixel-width in local SDF units, derived from fwidth.
+    // Adaptive AA: L2 gradient magnitude = sqrt(dpdx²+dpdy²), half width.
+    // L2 gives exactly ~1-device-px AA at any angle; L1/fwidth overestimates
+    // by up to √2 on ±45° diagonals, widening the band at rotated edges.
     // smoothstep maps [-aa, aa] → [1, 0]: fragments inside are fully opaque,
     // outside fully transparent, and the boundary band is anti-aliased.
-    let aa = fwidth(d) * 0.5;
+    let aa = length(vec2<f32>(dpdx(d), dpdy(d))) * 0.5;
     let alpha = 1.0 - smoothstep(-aa, aa, d);
 
     // Discard fully transparent pixels to reduce overdraw on expanded fringe.

--- a/crates/flui-engine/src/wgpu/shaders/common/sdf.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/common/sdf.wgsl
@@ -5,7 +5,7 @@
 //
 // SDF advantages:
 // - Branchless execution (no if/else in fragment shader)
-// - Adaptive antialiasing via fwidth()
+// - Adaptive antialiasing via L2 screen-space gradient (length(dpdx, dpdy))
 // - CSG operations (union, subtraction, intersection)
 // - Resolution-independent rendering
 //
@@ -142,15 +142,17 @@ fn sdEllipse(p: vec2<f32>, ab: vec2<f32>) -> f32 {
 // =============================================================================
 
 /// Convert SDF distance to alpha value with adaptive antialiasing
-/// Uses screen-space derivatives (fwidth) for resolution-independent AA
+/// Uses screen-space derivatives (L2: length(dpdx, dpdy)) for resolution-independent AA
 ///
 /// dist: signed distance from SDF function
 /// Returns: alpha value [0.0, 1.0] for blending
 fn sdfToAlpha(dist: f32) -> f32 {
-    // fwidth(dist) = abs(dFdx(dist)) + abs(dFdy(dist))
-    // This gives us the rate of change across the pixel, allowing
-    // adaptive antialiasing that works at any zoom level
-    let edge_width = fwidth(dist) * 0.5;
+    // L2 (Euclidean) gradient magnitude: length(∇dist) = sqrt(dpdx²+dpdy²).
+    // Compared to L1/fwidth (|dpdx|+|dpdy|), L2 is correct for isotropic 1-px
+    // AA at any orientation: on a ±45° diagonal L1 overestimates by √2 (~41%),
+    // giving a wider AA band on rounded corners under rotation/skew.
+    // Axis-aligned straight edges are numerically identical (one partial is 0).
+    let edge_width = length(vec2<f32>(dpdx(dist), dpdy(dist))) * 0.5;
 
     // smoothstep from -edge to +edge creates smooth transition
     return 1.0 - smoothstep(-edge_width, edge_width, dist);

--- a/crates/flui-engine/src/wgpu/shaders/effects/box_downsample.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/effects/box_downsample.wgsl
@@ -17,6 +17,16 @@
 // Averaging premultiplied values is correct: premultiplied colour is linear in
 // coverage, so the mean of four coverage-weighted colours equals the
 // coverage-weighted mean colour — no artefact at transparent edges.
+//
+// ## Bucketed pool support (crop_uv)
+//
+// When the 2× texture is acquired from a pool bucket that is LARGER than the
+// exact supersample dimensions (rounded up to the nearest 64px), the shader
+// must only sample the content region. `crop_uv` is `(supersample_w/bucket_w,
+// supersample_h/bucket_h)`. The quad always covers NDC [-1,1], but UVs are
+// scaled to [0, crop_uv] so only the actual content is read. When the bucket
+// exactly equals the supersample (no padding), crop_uv = (1, 1) and the shader
+// is identical to the original.
 
 struct VertexInput {
     @location(0) position: vec2<f32>,
@@ -28,23 +38,34 @@ struct VertexOutput {
     @location(0)       uv:       vec2<f32>,
 }
 
+// Crop-UV uniform: scale applied to vertex UV so that only the content region
+// of a pooled bucket texture is sampled. (1.0, 1.0) = no padding, full texture.
+struct CropUv {
+    uv: vec2<f32>,
+    _pad: vec2<f32>,
+}
+
 @group(0) @binding(0)
 var source_texture: texture_2d<f32>;
 
 @group(0) @binding(1)
 var linear_sampler: sampler;
 
+@group(0) @binding(2)
+var<uniform> crop: CropUv;
+
 @vertex
 fn vs_main(in: VertexInput) -> VertexOutput {
     var out: VertexOutput;
     out.position = vec4<f32>(in.position, 0.0, 1.0);
-    out.uv = in.uv;
+    // Scale UV into the content region of the (possibly oversized) bucket texture.
+    out.uv = in.uv * crop.uv;
     return out;
 }
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    // Source dimensions in texels.
+    // Source dimensions in texels (the full bucket, not the content region).
     let src_dim = vec2<f32>(textureDimensions(source_texture));
 
     // Half a sub-texel offset in UV space: sub-texel = 1/src_dim texels,

--- a/crates/flui-engine/src/wgpu/shaders/gradients/linear.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/gradients/linear.wgsl
@@ -70,8 +70,9 @@ fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
     return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r3;
 }
 
+/// L2 gradient magnitude for ~1-device-px AA on diagonal/rotated clip edges.
 fn sdfToAlpha(dist: f32) -> f32 {
-    let edge_width = fwidth(dist) * 0.5;
+    let edge_width = length(vec2<f32>(dpdx(dist), dpdy(dist))) * 0.5;
     return 1.0 - smoothstep(-edge_width, edge_width, dist);
 }
 
@@ -181,7 +182,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // Interpolate color from gradient stops
     var color = interpolateGradient(t, in.stop_count, in.stop_offset);
 
-    // Apply rounded corner alpha (fwidth must be called from uniform control flow)
+    // Apply rounded corner alpha (derivatives dpdx/dpdy must be called from uniform control flow)
     let alpha = sdfToAlpha(dist);
     color = vec4<f32>(color.rgb, color.a * alpha);
 

--- a/crates/flui-engine/src/wgpu/shaders/gradients/radial.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/gradients/radial.wgsl
@@ -68,8 +68,9 @@ fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
     return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r3;
 }
 
+/// L2 gradient magnitude for ~1-device-px AA on diagonal/rotated clip edges.
 fn sdfToAlpha(dist: f32) -> f32 {
-    let edge_width = fwidth(dist) * 0.5;
+    let edge_width = length(vec2<f32>(dpdx(dist), dpdy(dist))) * 0.5;
     return 1.0 - smoothstep(-edge_width, edge_width, dist);
 }
 
@@ -170,7 +171,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // Interpolate color from storage buffer
     var color = interpolateGradient(t, in.stop_count, in.stop_offset);
 
-    // Apply corner clipping (fwidth must be called from uniform control flow)
+    // Apply corner clipping (derivatives dpdx/dpdy must be called from uniform control flow)
     let alpha = sdfToAlpha(dist);
     color = vec4<f32>(color.rgb, color.a * alpha);
 

--- a/crates/flui-engine/src/wgpu/shaders/gradients/sweep.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/gradients/sweep.wgsl
@@ -68,8 +68,9 @@ fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
     return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r3;
 }
 
+/// L2 gradient magnitude for ~1-device-px AA on diagonal/rotated clip edges.
 fn sdfToAlpha(dist: f32) -> f32 {
-    let edge_width = fwidth(dist) * 0.5;
+    let edge_width = length(vec2<f32>(dpdx(dist), dpdy(dist))) * 0.5;
     return 1.0 - smoothstep(-edge_width, edge_width, dist);
 }
 
@@ -188,7 +189,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // Interpolate color from gradient stops
     var color = interpolateGradient(t, in.stop_count, in.stop_offset);
 
-    // Apply corner clipping (fwidth must be called from uniform control flow)
+    // Apply corner clipping (derivatives dpdx/dpdy must be called from uniform control flow)
     let alpha = sdfToAlpha(dist);
     color = vec4<f32>(color.rgb, color.a * alpha);
 

--- a/crates/flui-engine/src/wgpu/shaders/rect_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/rect_instanced.wgsl
@@ -15,9 +15,10 @@
 //   device    = M * local_pos + transform_translate.xy
 //
 // The SDF fragment evaluates distance in LOCAL space (via `uv` / `rect_size`);
-// `fwidth(dist)` measures the screen-space derivative of that local distance,
-// yielding ~1-device-px AA under ANY affine (rotation/skew/anisotropic scale)
-// with no fragment-shader change.
+// the L2 screen-space gradient `length(vec2(dpdx(dist), dpdy(dist)))` measures the
+// derivative of that local distance, yielding ~1-device-px AA under ANY affine
+// (rotation/skew/anisotropic scale) with no fragment-shader change; L1/fwidth
+// would overestimate diagonal edges by up to √2.
 //
 // For the baked-AABB fast path (axis-aligned SrcOver):
 //   transform           = [1, 0, 0, 1]   (identity 2×2)
@@ -26,7 +27,7 @@
 //
 // Performance:
 // - 30-40% faster fragment shader (branchless SDF)
-// - Adaptive antialiasing via fwidth() — correct at any zoom AND under rotation
+// - Adaptive antialiasing via L2 screen-space gradient — correct at any zoom AND under rotation
 // - SDF-based rounded rect clipping (no stencil buffer needed)
 
 // Vertex input (shared unit quad: [0,0] to [1,1])
@@ -114,10 +115,11 @@ fn sdRoundedSuperellipse(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
     return (n_norm - 1.0) * r3;
 }
 
-/// Convert SDF distance to alpha with adaptive antialiasing
+/// Convert SDF distance to alpha with adaptive antialiasing.
+/// Uses the L2 (Euclidean) gradient magnitude so a diagonal/rotated edge
+/// receives ~1-device-px AA exactly, not ~1.41× as with L1/fwidth.
 fn sdfToAlpha(dist: f32) -> f32 {
-    // fwidth gives us screen-space gradient for resolution-independent AA
-    let edge_width = fwidth(dist) * 0.5;
+    let edge_width = length(vec2<f32>(dpdx(dist), dpdy(dist))) * 0.5;
     return 1.0 - smoothstep(-edge_width, edge_width, dist);
 }
 
@@ -187,8 +189,8 @@ fn vs_main(
     // the SDF distance measured to the true rect regardless of quad expansion.
     out.uv = exp_pos;
     // rect_size = local width × height; the SDF evaluates distance in this space.
-    // Under any affine, fwidth(dist) correctly measures the screen-space
-    // derivative of the LOCAL distance → ~1 device-px AA band.
+    // Under any affine, the L2 gradient length(dpdx(dist), dpdy(dist)) correctly
+    // measures the screen-space derivative of the LOCAL distance → ~1 device-px AA band.
     out.rect_size = instance.bounds.zw;
     out.corner_radii = instance.corner_radii;
     // world_pos is the device-pixel position, used by the SDF clip test.
@@ -214,7 +216,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let dist = sdRoundedBox(p, in.rect_size * 0.5, in.corner_radii);
 
     // Convert distance to alpha with adaptive antialiasing
-    // fwidth() automatically adjusts AA based on zoom level and pixel density
+    // The L2 screen-space gradient automatically adjusts AA based on zoom level and pixel density
     let alpha = sdfToAlpha(dist);
 
     // --- SDF Clip Test ---

--- a/crates/flui-engine/src/wgpu/ssaa.rs
+++ b/crates/flui-engine/src/wgpu/ssaa.rs
@@ -45,6 +45,38 @@ use super::{
 
 // ─── Downsample pipeline ───────────────────────────────────────────────────────
 
+/// Alignment multiple for SSAA source-texture bucket dimensions.
+///
+/// Bucket dimensions are rounded UP to the next multiple of this value so that
+/// the texture pool can reuse the same allocation across tiles whose exact
+/// supersample sizes differ only by a few pixels. When the bucket equals the
+/// supersample exactly (no padding) `crop_uv` = (1, 1) and the shader output
+/// is bit-identical to the unbucketed path.
+///
+/// 64 was chosen as the minimum power-of-two that amortises pool fragmentation
+/// while keeping wasted texels below ~4× for typical (>16 px) tiles.
+const SSAA_BUCKET_ALIGNMENT: u32 = 64;
+
+/// Fullscreen quad for the 2×→1× downsample pass.
+///
+/// Two triangles covering NDC [-1,1]×[-1,1]. UV (0,0) = top-left, (1,1) =
+/// bottom-right (wgpu top-left origin). The vertex shader scales UV by
+/// `crop_uv` to address only the content region inside a bucket allocation.
+///
+/// Hoisted to a module-level const so the buffer is created ONCE in
+/// `SsaaDownsamplePipeline::new` and reused for every frame — avoid per-draw
+/// `create_buffer_init` (allocation + upload on every path AA draw call).
+#[rustfmt::skip]
+const SSAA_QUAD_VERTICES: &[f32] = &[
+    // position (x,y)   UV (u,v)
+    -1.0,  1.0,         0.0, 0.0, // top-left
+    -1.0, -1.0,         0.0, 1.0, // bottom-left
+     1.0, -1.0,         1.0, 1.0, // bottom-right
+    -1.0,  1.0,         0.0, 0.0, // top-left
+     1.0, -1.0,         1.0, 1.0, // bottom-right
+     1.0,  1.0,         1.0, 0.0, // top-right
+];
+
 /// Pipeline for the 2×→1× box-filter downsample pass used by SSAA path AA.
 ///
 /// The pipeline samples a 2× supersampled source texture (premultiplied RGBA)
@@ -58,8 +90,11 @@ use super::{
 pub(crate) struct SsaaDownsamplePipeline {
     /// Render pipeline for the 4-tap box downsample.
     pub(crate) pipeline: wgpu::RenderPipeline,
-    /// Bind group layout: binding 0 = source texture, binding 1 = linear sampler.
+    /// Bind group layout: binding 0 = source texture, binding 1 = linear sampler,
+    /// binding 2 = crop_uv uniform buffer.
     pub(crate) bind_group_layout: wgpu::BindGroupLayout,
+    /// Fullscreen quad vertex buffer, created once and reused every draw call.
+    pub(crate) quad_vertex_buffer: wgpu::Buffer,
 }
 
 impl SsaaDownsamplePipeline {
@@ -95,6 +130,18 @@ impl SsaaDownsamplePipeline {
                     binding: 1,
                     visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+                // binding 2: crop_uv uniform — scales vertex UVs to the content
+                // region of the (possibly padded) pool bucket texture.
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
                     count: None,
                 },
             ],
@@ -151,11 +198,42 @@ impl SsaaDownsamplePipeline {
             cache: None,
         });
 
+        // Create the fullscreen quad vertex buffer ONCE — reused for every
+        // SSAA downsample draw call within this pipeline's lifetime.
+        let quad_vertex_buffer = {
+            use wgpu::util::DeviceExt as _;
+            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("SSAA Downsample Quad VB"),
+                contents: bytemuck::cast_slice(SSAA_QUAD_VERTICES),
+                usage: wgpu::BufferUsages::VERTEX,
+            })
+        };
+
         Self {
             pipeline,
             bind_group_layout,
+            quad_vertex_buffer,
         }
     }
+}
+
+// ─── Pool-bucketing arithmetic ─────────────────────────────────────────────────
+
+/// Round `value` up to the next multiple of `alignment`.
+///
+/// `alignment` must be non-zero; panics in debug builds if it is.
+/// Saturating addition prevents overflow for extreme values (though pool
+/// dimensions are bounded by `max_tex_dim` before this function is called).
+///
+/// # Examples
+/// ```ignore
+/// assert_eq!(round_up_to_alignment(130, 64), 192);
+/// assert_eq!(round_up_to_alignment(128, 64), 128); // already aligned
+/// assert_eq!(round_up_to_alignment(1, 64), 64);
+/// ```
+fn round_up_to_alignment(value: u32, alignment: u32) -> u32 {
+    debug_assert!(alignment > 0, "alignment must be non-zero");
+    value.saturating_add(alignment - 1) / alignment * alignment
 }
 
 // ─── Replay helper ─────────────────────────────────────────────────────────────
@@ -298,18 +376,26 @@ impl GpuReplay {
             return;
         }
 
-        // ── Step 2: acquire a 2× pooled texture ───────────────────────────────
+        // ── Step 2: acquire a 2× pooled texture (bucketed) ───────────────────
         //
         // tile_w ≤ max_tile_half = max_tex_dim/2 (guaranteed by the fallback
         // above), so tile_w*2 ≤ max_tex_dim. No wgpu create_texture error.
         let supersample_w = tile_w * 2;
         let supersample_h = tile_h * 2;
 
-        let super_tex = resources.layer_texture_pool_mut().acquire(
-            supersample_w,
-            supersample_h,
-            surface_format,
-        );
+        // Pool bucketing: round supersample dims UP to the next multiple of
+        // SSAA_BUCKET_ALIGNMENT, capped at max_tex_dim.  This promotes texture
+        // reuse across paths with slightly different sizes (e.g. two tiles of
+        // 130×132 and 126×128 both acquire the 192×192 bucket rather than two
+        // distinct sizes).  When the bucket equals the supersample exactly,
+        // crop_uv = (1,1) and the shader output is bit-identical.
+        let bucket_w = round_up_to_alignment(supersample_w, SSAA_BUCKET_ALIGNMENT).min(max_tex_dim);
+        let bucket_h = round_up_to_alignment(supersample_h, SSAA_BUCKET_ALIGNMENT).min(max_tex_dim);
+
+        let super_tex =
+            resources
+                .layer_texture_pool_mut()
+                .acquire(bucket_w, bucket_h, surface_format);
         let super_view = super_tex.view();
 
         // ── Step 3: clear + render into the 2× tile ───────────────────────────
@@ -444,11 +530,14 @@ impl GpuReplay {
         );
 
         // ── Step 4: box-downsample 2× → 1× premultiplied tile ────────────────
+        //
+        // Pass the exact supersample dims (not the bucket) so the function can
+        // compute crop_uv = supersample/bucket correctly.
 
         let one_x_tile = self.downsample_ssaa_tile(
             &super_tex,
-            tile_w,
-            tile_h,
+            supersample_w,
+            supersample_h,
             surface_format,
             device,
             pipelines,
@@ -572,19 +661,37 @@ impl GpuReplay {
 
     /// Box-downsample a 2× pooled `source_texture` into a fresh 1× tile.
     ///
-    /// Returns the 1× [`PooledTexture`]; the caller is responsible for
-    /// compositing it before dropping.
+    /// ## Pool bucketing
+    ///
+    /// The `source_tex` was acquired at the exact supersample dimensions
+    /// `(supersample_w, supersample_h)`, but the pool may have returned a
+    /// larger bucket (next multiple of [`SSAA_BUCKET_ALIGNMENT`], capped at
+    /// the device max texture dimension). The `crop_uv` uniform
+    /// `(supersample_w/bucket_w, supersample_h/bucket_h)` scales vertex UVs
+    /// so only the content region is sampled.
+    ///
+    /// When the bucket equals the supersample (no padding, or exact multiple),
+    /// `crop_uv` = (1.0, 1.0) and the output is bit-identical to the
+    /// pre-bucketing path.
+    ///
+    /// Returns the 1× [`PooledTexture`]; the caller composites then drops it.
     fn downsample_ssaa_tile(
         &mut self,
         source_tex: &PooledTexture,
-        output_w: u32,
-        output_h: u32,
+        supersample_w: u32,
+        supersample_h: u32,
         output_format: wgpu::TextureFormat,
         device: &Arc<wgpu::Device>,
         pipelines: &PipelineSet,
         resources: &mut GpuResources,
         encoder: &mut wgpu::CommandEncoder,
     ) -> PooledTexture {
+        // ── Output (1×) dimensions ─────────────────────────────────────────
+        // The logical output is half the supersample size (which is always the
+        // original tile_w/tile_h from render_ssaa_path step 2).
+        let output_w = supersample_w / 2;
+        let output_h = supersample_h / 2;
+
         // Acquire the 1× output tile and clear it to transparent.
         let one_x_tile =
             resources
@@ -611,7 +718,41 @@ impl GpuReplay {
             });
         }
 
-        // Build the bind group: source 2× texture + linear sampler.
+        // ── crop_uv: ratio of content to bucket ────────────────────────────
+        //
+        // The source texture returned by the pool has bucket dimensions
+        // `(bucket_w, bucket_h)` — the actual allocated wgpu texture size.
+        // We can query these from the PooledTexture; for now we derive them
+        // from the supersample dimensions (which the caller passed): the pool
+        // always returns a texture ≥ (supersample_w, supersample_h), so we
+        // read the actual texture dimensions from the wgpu handle.
+        //
+        // SAFETY: `source_tex.texture()` is the live wgpu handle. Its width/
+        // height reflect the actual bucket the pool allocated.
+        let bucket_w = source_tex.width();
+        let bucket_h = source_tex.height();
+
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "bucket/supersample dims are small u32 values; f32 is sufficient for UV ratios"
+        )]
+        let crop_uv_x = supersample_w as f32 / bucket_w as f32;
+        #[allow(clippy::cast_precision_loss, reason = "same as above")]
+        let crop_uv_y = supersample_h as f32 / bucket_h as f32;
+
+        // crop_uv uniform: [x, y, pad, pad] — matches the WGSL struct layout.
+        let crop_uv_data: [f32; 4] = [crop_uv_x, crop_uv_y, 0.0, 0.0];
+
+        let crop_uv_buffer = {
+            use wgpu::util::DeviceExt as _;
+            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("SSAA Crop UV Uniform"),
+                contents: bytemuck::cast_slice(&crop_uv_data),
+                usage: wgpu::BufferUsages::UNIFORM,
+            })
+        };
+
+        // Build the bind group: source 2× texture + linear sampler + crop_uv.
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("SSAA Downsample Bind Group"),
             layout: &pipelines.ssaa_downsample.bind_group_layout,
@@ -625,32 +766,14 @@ impl GpuReplay {
                     // `default_sampler` uses Linear filtering — correct for the 4-tap box average.
                     resource: wgpu::BindingResource::Sampler(&self.default_sampler),
                 },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: crop_uv_buffer.as_entire_binding(),
+                },
             ],
         });
 
-        // Fullscreen quad in NDC: two triangles covering [-1,1] × [-1,1].
-        // UV (0,0) = top-left, (1,1) = bottom-right to match wgpu's top-left origin.
-        #[rustfmt::skip]
-        let quad_vertices: &[f32] = &[
-            // position (x,y)   UV (u,v)
-            -1.0,  1.0,         0.0, 0.0, // top-left
-            -1.0, -1.0,         0.0, 1.0, // bottom-left
-             1.0, -1.0,         1.0, 1.0, // bottom-right
-            -1.0,  1.0,         0.0, 0.0, // top-left
-             1.0, -1.0,         1.0, 1.0, // bottom-right
-             1.0,  1.0,         1.0, 0.0, // top-right
-        ];
-
-        let vertex_buffer = {
-            use wgpu::util::DeviceExt as _;
-            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("SSAA Downsample Quad VB"),
-                contents: bytemuck::cast_slice(quad_vertices),
-                usage: wgpu::BufferUsages::VERTEX,
-            })
-        };
-
-        // Run the downsample pass.
+        // Run the downsample pass using the cached quad vertex buffer.
         {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("SSAA Box Downsample Pass"),
@@ -671,7 +794,8 @@ impl GpuReplay {
 
             pass.set_pipeline(&pipelines.ssaa_downsample.pipeline);
             pass.set_bind_group(0, &bind_group, &[]);
-            pass.set_vertex_buffer(0, vertex_buffer.slice(..));
+            // Cached VB — no per-draw allocation.
+            pass.set_vertex_buffer(0, pipelines.ssaa_downsample.quad_vertex_buffer.slice(..));
             pass.draw(0..6, 0..1);
         }
 
@@ -1079,5 +1203,440 @@ mod unit_tests {
             (supersample_w, supersample_h, 1, 1),
             "scissor entirely outside tile must produce the fully-clipped sentinel; got {remapped:?}"
         );
+    }
+
+    // ── P2: round_up_to_alignment (pool bucket quantize) ────────────────────
+
+    /// P2-a: `round_up_to_alignment` correctly rounds up to multiples of 64.
+    ///
+    /// This is the arithmetic backing the SSAA tile bucket: a 2× supersample of
+    /// arbitrary size is rounded up to the next 64px multiple so the pool can
+    /// reuse the same allocation for nearby sizes.
+    #[test]
+    fn round_up_to_alignment_correctness() {
+        use super::round_up_to_alignment;
+
+        // Already-aligned value stays the same.
+        assert_eq!(
+            round_up_to_alignment(128, 64),
+            128,
+            "128 is already a multiple of 64"
+        );
+        // One over → next bucket.
+        assert_eq!(
+            round_up_to_alignment(129, 64),
+            192,
+            "129 rounds up to 192 (next 64-multiple)"
+        );
+        // Typical small tile: 130px → 192.
+        assert_eq!(round_up_to_alignment(130, 64), 192);
+        // Minimum case.
+        assert_eq!(round_up_to_alignment(1, 64), 64);
+        // Zero → 0 (aligned at any alignment).
+        assert_eq!(round_up_to_alignment(0, 64), 0);
+        // Exact multiple: 256 → 256.
+        assert_eq!(round_up_to_alignment(256, 64), 256);
+        // Just below a larger bucket: 191 → 192.
+        assert_eq!(round_up_to_alignment(191, 64), 192);
+        // Just at the boundary: 192 → 192.
+        assert_eq!(round_up_to_alignment(192, 64), 192);
+        // Cap via .min(max) is caller responsibility; test with a large dim.
+        let max_tex_dim: u32 = 8192;
+        let bucket = round_up_to_alignment(8000, 64).min(max_tex_dim);
+        assert_eq!(bucket, 8000_u32.div_ceil(64) * 64);
+    }
+
+    /// P2-b: when bucket > supersample, crop_uv is in (0, 1) exclusive.
+    ///
+    /// Structural arithmetic check: `supersample / bucket` must be < 1 when
+    /// the bucket is larger, ensuring the shader samples only the content region.
+    #[test]
+    fn crop_uv_is_less_than_one_when_bucket_is_larger() {
+        use super::round_up_to_alignment;
+
+        // A 130px supersample gets a 192px bucket.
+        let supersample = 130_u32;
+        let bucket = round_up_to_alignment(supersample, 64);
+        assert_eq!(bucket, 192, "130 → 192 bucket");
+
+        let crop_uv = supersample as f32 / bucket as f32;
+        assert!(
+            crop_uv > 0.0 && crop_uv < 1.0,
+            "crop_uv must be in (0, 1) when bucket > supersample; got {crop_uv}"
+        );
+        // Sanity: the shader must not over-sample beyond bucket_w.
+        let sampled_max = crop_uv * bucket as f32;
+        assert!(
+            (sampled_max - supersample as f32).abs() < 0.001,
+            "crop_uv × bucket_w must equal supersample_w; got {sampled_max}"
+        );
+    }
+
+    /// P2-c: when bucket == supersample (already aligned), crop_uv == 1.0.
+    #[test]
+    fn crop_uv_is_one_when_bucket_equals_supersample() {
+        use super::round_up_to_alignment;
+
+        let supersample = 128_u32; // already a multiple of 64
+        let bucket = round_up_to_alignment(supersample, 64);
+        assert_eq!(
+            bucket, supersample,
+            "128 is already aligned → bucket == supersample"
+        );
+
+        let crop_uv = supersample as f32 / bucket as f32;
+        assert!(
+            (crop_uv - 1.0).abs() < f32::EPSILON,
+            "crop_uv must be exactly 1.0 when bucket == supersample; got {crop_uv}"
+        );
+    }
+}
+
+// ─── GPU tests (require a real wgpu adapter) ─────────────────────────────────
+
+/// H2(b): The view-only fallback (advanced blend with `surface_texture = None`)
+/// composites the SSAA tile via SrcOver and must leave visible, AA'd pixels.
+///
+/// ## Failure mode if the fallback branch is deleted
+///
+/// Without the else-branch in `render_ssaa_path` (lines 599–624 of ssaa.rs),
+/// `one_x_tile` is dropped without being composited → the target remains
+/// transparent → `interior_alpha == 0` and `partial_count == 0`.  This test
+/// would then fire on the interior assertion, proving the branch is load-bearing.
+///
+/// ## What the test does
+///
+/// 1. Paints a triangle with `BlendMode::Multiply` (an advanced/dst-read mode).
+/// 2. Renders to `RenderTarget::view_only` — passes `surface_texture = None`
+///    to `render_ssaa_path`, triggering the warn + SrcOver fallback.
+/// 3. Reads back the pixels.
+/// 4. Asserts:
+///    - Interior pixel is opaque (tile was composited, not discarded).
+///    - ≥ 50% of triangle boundary pixels have partial alpha (SSAA AA present).
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+mod gpu_tests {
+    use std::sync::Arc;
+
+    use flui_painting::{BlendMode, Paint};
+    use flui_types::{Color, geometry::Pixels};
+
+    use crate::wgpu::{painter::WgpuPainter, render_target::RenderTarget};
+
+    // ── harness constants ─────────────────────────────────────────────────────
+
+    const SURFACE_W: u32 = 128;
+    const SURFACE_H: u32 = 128;
+    const SURFACE_FMT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
+
+    // ── harness helpers ───────────────────────────────────────────────────────
+
+    fn acquire_device_and_queue() -> (Arc<wgpu::Device>, Arc<wgpu::Queue>) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .expect("GPU adapter required for ssaa::gpu_tests");
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("SSAA GPU Test Device"),
+            ..Default::default()
+        }))
+        .expect("GPU device required for ssaa::gpu_tests");
+        (Arc::new(device), Arc::new(queue))
+    }
+
+    fn make_render_surface(device: &wgpu::Device) -> (wgpu::Texture, wgpu::TextureView) {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("SSAA GPU Test Surface"),
+            size: wgpu::Extent3d {
+                width: SURFACE_W,
+                height: SURFACE_H,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: SURFACE_FMT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        (texture, view)
+    }
+
+    fn clear_to_transparent(device: &wgpu::Device, queue: &wgpu::Queue, view: &wgpu::TextureView) {
+        let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("SSAA GPU Test Clear"),
+        });
+        {
+            let _pass = enc.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("SSAA GPU Test Clear Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+        }
+        queue.submit(std::iter::once(enc.finish()));
+    }
+
+    /// Read all SURFACE_W × SURFACE_H pixels, returning row-major RGBA bytes.
+    fn readback_rgba(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        texture: &wgpu::Texture,
+    ) -> Vec<[u8; 4]> {
+        let bytes_per_pixel = 4_u32;
+        let unpadded_row = SURFACE_W * bytes_per_pixel;
+        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let padded_row = unpadded_row.div_ceil(align) * align;
+        let staging_size = u64::from(padded_row * SURFACE_H);
+
+        let staging = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("SSAA GPU Test Readback"),
+            size: staging_size,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("SSAA GPU Test Readback Encoder"),
+        });
+        enc.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &staging,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_row),
+                    rows_per_image: Some(SURFACE_H),
+                },
+            },
+            wgpu::Extent3d {
+                width: SURFACE_W,
+                height: SURFACE_H,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit(std::iter::once(enc.finish()));
+
+        let slice = staging.slice(..);
+        slice.map_async(wgpu::MapMode::Read, |_| {});
+        device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .expect("GPU readback poll must complete within the test timeout");
+
+        let raw = slice.get_mapped_range();
+        let mut pixels = Vec::with_capacity((SURFACE_W * SURFACE_H) as usize);
+        for row in 0..SURFACE_H {
+            let row_start = (row * padded_row) as usize;
+            for col in 0..SURFACE_W {
+                let offset = row_start + col as usize * 4;
+                pixels.push([
+                    raw[offset],
+                    raw[offset + 1],
+                    raw[offset + 2],
+                    raw[offset + 3],
+                ]);
+            }
+        }
+        pixels
+    }
+
+    // ── H2(b): view-only fallback exercises the warn + SrcOver composite ──────
+
+    /// H2(b): `render_ssaa_path` view-only advanced-blend fallback composites
+    /// the SSAA tile via SrcOver and must produce opaque interior + AA boundary.
+    ///
+    /// This test FAILS if the `else` branch inside `render_ssaa_path`
+    /// (the `surface_texture.is_none()` path for advanced blends) is deleted:
+    /// without it `one_x_tile` is silently dropped and the target stays transparent.
+    #[test]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "small fixed-size test surface; pixel-coordinate arithmetic is safe"
+    )]
+    fn h2b_view_only_advanced_blend_fallback_composites_via_src_over() {
+        let (device, queue) = acquire_device_and_queue();
+        // Create a render surface: hold `surface_tex` for readback; derive `surface_view`
+        // for rendering.  `RenderTarget::view_only` omits the &Texture reference from the
+        // render-target struct — that is what triggers `surface_texture = None` inside
+        // `render_ssaa_path` — but the wgpu texture itself remains alive and readable.
+        let (surface_tex, surface_view) = make_render_surface(&device);
+        clear_to_transparent(&device, &queue, &surface_view);
+
+        // A 45° right triangle centered in the 128×128 surface.  Non-axis-aligned
+        // edges produce partial-alpha boundary pixels under SSAA.
+        let cx = SURFACE_W as f32 / 2.0;
+        let cy = SURFACE_H as f32 / 2.0;
+        let half_side = 36.0_f32;
+        let apex_x = cx;
+        let apex_y = cy - half_side;
+        let right_x = cx + half_side;
+        let right_y = cy + half_side;
+        let left_x = cx - half_side;
+        let left_y = cy + half_side;
+
+        let mut path = flui_types::painting::path::Path::new();
+        path.move_to(flui_types::Point::new(Pixels(apex_x), Pixels(apex_y)));
+        path.line_to(flui_types::Point::new(Pixels(right_x), Pixels(right_y)));
+        path.line_to(flui_types::Point::new(Pixels(left_x), Pixels(left_y)));
+        path.close();
+
+        // BlendMode::Multiply is an advanced (dst-read) blend mode.
+        // RenderTarget::view_only → `surface_texture = None` in render_ssaa_path →
+        // the warn + SrcOver fallback branch fires.
+        let mut painter = WgpuPainter::with_shared_device(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            SURFACE_FMT,
+            (SURFACE_W, SURFACE_H),
+        );
+        painter.draw_path(
+            &path,
+            &Paint::fill(Color::WHITE).with_blend_mode(BlendMode::Multiply),
+        );
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("H2b Fallback Encoder"),
+        });
+        painter
+            .render(RenderTarget::view_only(&surface_view), &mut encoder)
+            .expect("render must succeed even on a view-only target");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        // `surface_tex` was always alive; we can read it back directly.
+        let pixels = readback_rgba(&device, &queue, &surface_tex);
+
+        // ── Assert 1: interior pixel is opaque ───────────────────────────────
+        //
+        // ── Assert 1: interior pixel is opaque ───────────────────────────────
+        //
+        // If the fallback branch is deleted, one_x_tile is dropped without being
+        // composited → target stays fully transparent → interior_alpha == 0.
+        let centroid_x = ((apex_x + right_x + left_x) / 3.0) as usize;
+        let centroid_y = ((apex_y + right_y + left_y) / 3.0) as usize;
+        let interior_pixel_index = centroid_y * SURFACE_W as usize + centroid_x;
+        let interior_alpha = pixels[interior_pixel_index][3];
+        assert!(
+            interior_alpha > 200,
+            "H2b FAILED: triangle interior (centroid at ({centroid_x},{centroid_y})) \
+             has alpha={interior_alpha} — expected > 200. \
+             The view-only SrcOver fallback in render_ssaa_path did not composite \
+             the 1× SSAA tile (one_x_tile was dropped without drawing)."
+        );
+
+        // ── Assert 2: boundary pixels have SSAA partial alpha ────────────────
+        //
+        // Boundary pixels of a triangle rendered via SSAA must have partial alpha
+        // (0 < alpha < 255).  Hard-aliased rendering gives only 0 or 255.
+        // If the fallback composites to the wrong region or is a no-op, this fires.
+        //
+        // The boundary set below is the 4-neighbour GEOMETRIC boundary, ~2-3 px
+        // wide per edge, so it overcounts the ~1 px AA band — especially on the
+        // triangle's axis-aligned bottom edge. Measured ground truth on DX12: a
+        // correct SrcOver-fallback SSAA composite makes ~34% of these geometric-
+        // boundary pixels partial; a hard-aliased or wrong-region composite gives
+        // ~0%. The 25% floor cleanly separates the two with margin; the no-op case
+        // is already caught by Assert 1 (transparent interior).
+        let boundary_pixel_indices: Vec<usize> = (0..SURFACE_H)
+            .flat_map(|row| {
+                let row = row as usize;
+                (0..SURFACE_W as usize).filter_map(move |col| {
+                    // Pixel-center sample point in device coordinates.
+                    let sample_x = col as f32 + 0.5;
+                    let sample_y = row as f32 + 0.5;
+                    let center_inside = point_in_triangle(
+                        (sample_x, sample_y),
+                        (apex_x, apex_y),
+                        (right_x, right_y),
+                        (left_x, left_y),
+                    );
+                    // A boundary pixel has at least one cardinal neighbor with the
+                    // opposite inside/outside classification.
+                    let on_boundary = [
+                        (sample_x - 1.0, sample_y),
+                        (sample_x + 1.0, sample_y),
+                        (sample_x, sample_y - 1.0),
+                        (sample_x, sample_y + 1.0),
+                    ]
+                    .into_iter()
+                    .any(|(nx, ny)| {
+                        point_in_triangle(
+                            (nx, ny),
+                            (apex_x, apex_y),
+                            (right_x, right_y),
+                            (left_x, left_y),
+                        ) != center_inside
+                    });
+                    on_boundary.then_some(row * SURFACE_W as usize + col)
+                })
+            })
+            .collect();
+
+        assert!(
+            boundary_pixel_indices.len() >= 8,
+            "H2b: fewer than 8 boundary pixels found ({}) — oracle or path geometry is wrong",
+            boundary_pixel_indices.len()
+        );
+
+        let partial_boundary_count = boundary_pixel_indices
+            .iter()
+            .filter(|&&pixel_index| {
+                let alpha = pixels[pixel_index][3];
+                alpha > 5 && alpha < 250
+            })
+            .count();
+        let min_partial_required = (boundary_pixel_indices.len() as f32 * 0.25).ceil() as usize;
+
+        assert!(
+            partial_boundary_count >= min_partial_required,
+            "H2b FAILED: only {partial_boundary_count}/{} boundary pixels have partial \
+             alpha (expected ≥{min_partial_required}). \
+             Hard-aliased rendering gives ~0 partial pixels; a correct SSAA \
+             fallback gives ~34% of the (overcounted) geometric boundary. \
+             The fallback composite may be a no-op or compositing the wrong region.",
+            boundary_pixel_indices.len()
+        );
+    }
+
+    /// Return true if `(query_x, query_y)` is inside or on the edge of the
+    /// triangle `(ax,ay)-(bx,by)-(cx,cy)` using the sign-of-cross-product test.
+    fn point_in_triangle(query: (f32, f32), a: (f32, f32), b: (f32, f32), c: (f32, f32)) -> bool {
+        let (query_x, query_y) = query;
+        let (ax, ay) = a;
+        let (bx, by) = b;
+        let (cx, cy) = c;
+        let signed_area = |ox: f32, oy: f32, ex: f32, ey: f32| -> f32 {
+            (ex - ox) * (query_y - oy) - (ey - oy) * (query_x - ox)
+        };
+        let d0 = signed_area(ax, ay, bx, by);
+        let d1 = signed_area(bx, by, cx, cy);
+        let d2 = signed_area(cx, cy, ax, ay);
+        let has_neg = d0 < 0.0 || d1 < 0.0 || d2 < 0.0;
+        let has_pos = d0 > 0.0 || d1 > 0.0 || d2 > 0.0;
+        !(has_neg && has_pos)
     }
 }

--- a/crates/flui-engine/src/wgpu/state_stack.rs
+++ b/crates/flui-engine/src/wgpu/state_stack.rs
@@ -307,11 +307,30 @@ impl GpuStateStack {
     /// Mirrors Impeller `Matrix::GetMaxBasisLengthXY`: the larger of the two
     /// column-vector lengths of the upper-left 2×2. The tessellator uses this
     /// to budget curve-flattening tolerance at the correct magnification.
+    ///
+    /// **Do not use this for device-area thresholds.** Under anisotropic scale
+    /// (e.g. `scale(0.5, 10)`) `max_scale()` returns 10, squaring to 100,
+    /// while the true area scale is 5. Use [`Self::area_scale`] for area thresholds.
     pub(super) fn max_scale(&self) -> f32 {
         let m = self.current_transform;
         let col_x = (m.x_axis.x * m.x_axis.x + m.x_axis.y * m.x_axis.y).sqrt();
         let col_y = (m.y_axis.x * m.y_axis.x + m.y_axis.y * m.y_axis.y).sqrt();
         col_x.max(col_y)
+    }
+
+    /// Absolute determinant of the CTM's 2D linear part — the device-pixel² area
+    /// scale factor (`area_device = area_local × area_scale`).
+    ///
+    /// Mirrors Impeller `Matrix::GetDeterminant` (upper-left 2×2 only):
+    ///   `|det(M)| = |m.x_axis.x * m.y_axis.y − m.x_axis.y * m.y_axis.x|`
+    ///
+    /// This is rotation- and shear-invariant: a pure rotation has `|det|=1`;
+    /// `diag(sx, sy)` gives `|sx*sy|`. For device-area thresholds this is
+    /// more accurate than `max_scale²`, which overestimates under anisotropic
+    /// scale (e.g. `scale(0.5, 10)` → `area_scale=5`, `max_scale²=100`).
+    pub(super) fn area_scale(&self) -> f32 {
+        let m = self.current_transform;
+        (m.x_axis.x * m.y_axis.y - m.x_axis.y * m.y_axis.x).abs()
     }
 
     // =========================================================================
@@ -678,6 +697,82 @@ mod tests {
             "reset() must restore identity CTM"
         );
         assert_eq!(stack.depth(), 0, "reset() must clear all stacks");
+    }
+
+    // =========================================================================
+    // P1: area_scale() correctness
+    // =========================================================================
+
+    /// diag(sx, sy) → |sx * sy|.
+    ///
+    /// Confirms the determinant formula on a pure axis-aligned scale.
+    /// max_scale() returns `max(sx, sy)` = sy; squaring gives sy² ≠ sx*sy,
+    /// which is the overestimate this fix closes.
+    #[test]
+    fn area_scale_diagonal_equals_product_of_scales() {
+        let sx = 3.0_f32;
+        let sy = 7.0_f32;
+        let mut stack = identity_stack();
+        stack.scale(sx, sy);
+        let area = stack.area_scale();
+        assert!(
+            (area - sx * sy).abs() < 1e-5,
+            "area_scale() for diag({sx}, {sy}) should be {expected}, got {area}",
+            expected = sx * sy
+        );
+        // Document the overestimate max_scale² closes.
+        let max_s = stack.max_scale();
+        assert!(
+            (max_s - sy).abs() < 1e-5,
+            "max_scale() for diag({sx}, {sy}) should be {sy}, got {max_s}"
+        );
+        assert!(
+            max_s * max_s > area * 1.01,
+            "max_scale²={} should exceed area_scale={} for anisotropic scale",
+            max_s * max_s,
+            area
+        );
+    }
+
+    /// Pure 45° rotation → area_scale == 1.0 (rotation preserves area).
+    ///
+    /// `max_scale()` also returns 1.0 here, so this is a parity check.
+    #[test]
+    fn area_scale_pure_rotation_is_one() {
+        let angle = std::f32::consts::FRAC_PI_4; // 45°
+        let mut stack = identity_stack();
+        stack.rotate(angle);
+        let area = stack.area_scale();
+        assert!(
+            (area - 1.0).abs() < 1e-5,
+            "45° rotation must preserve area: area_scale={area}"
+        );
+    }
+
+    /// Anisotropic scale(0.5, 10) → area_scale == 5.0; max_scale == 10.0.
+    ///
+    /// This is the canonical case the fix closes: max_scale² = 100 (4× over),
+    /// while area_scale = 5 is the correct threshold multiplier.
+    #[test]
+    fn area_scale_anisotropic_closes_max_scale_overestimate() {
+        let mut stack = identity_stack();
+        stack.scale(0.5, 10.0);
+        let area = stack.area_scale();
+        let max_s = stack.max_scale();
+        assert!(
+            (area - 5.0).abs() < 1e-5,
+            "area_scale() for scale(0.5, 10) should be 5.0, got {area}"
+        );
+        assert!(
+            (max_s - 10.0).abs() < 1e-5,
+            "max_scale() for scale(0.5, 10) should be 10.0, got {max_s}"
+        );
+        // max_scale² = 100.0 vs area_scale = 5.0 — documents the 20× overestimate.
+        let overestimate_ratio = (max_s * max_s) / area;
+        assert!(
+            overestimate_ratio > 15.0,
+            "expected ≥15× overestimate for scale(0.5, 10), got {overestimate_ratio:.1}×"
+        );
     }
 
     /// Additional: save/restore round-trips the scissor correctly when it IS

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -311,14 +311,14 @@ impl WindowsPlatform {
                         // Skip rendering for minimized windows to save CPU/GPU resources
                         let should_skip = WindowsWindow::should_skip_render(hwnd);
                         if !should_skip {
-                            // Fill with solid black - required for Mica backdrop transparency
-                            // When app draws, this will be replaced with actual content
-                            let mut rect = RECT::default();
-                            if GetClientRect(hwnd, &mut rect).is_ok() {
-                                let black_brush = GetStockObject(BLACK_BRUSH);
-                                FillRect(hdc, &rect, HBRUSH(black_brush.0));
-                            }
-
+                            // No GDI painting here. This HWND carries a D3D12 flip-model
+                            // swapchain (wgpu-on-DX12 is always flip-model). Per Microsoft,
+                            // GDI and flip model cannot share an HWND: after the first
+                            // `Present1`, GDI updates to the window are dropped, and the
+                            // contention with the compositor produces visible jitter while
+                            // the window is being live-resized. The background comes from the
+                            // wgpu clear pass + the scene, not from a GDI fill (the old
+                            // FillRect was overwritten by the present in the same frame).
                             if let Some(ctx) = ctx {
                                 // Fire per-window on_request_frame callback
                                 ctx.callbacks.dispatch_request_frame();
@@ -405,35 +405,29 @@ impl WindowsPlatform {
                                 }
                             }
                             SIZE_RESTORED => {
-                                tracing::info!("📐 Window Restored: {}x{}", width, height);
-                                // Validate transition
-                                let candidate = WindowMode::Normal;
-                                if !prev_mode.can_transition_to(&candidate) {
-                                    tracing::warn!(
-                                        "⚠️  Invalid state transition: {:?} -> Normal (transition ignored)",
-                                        prev_mode
-                                    );
-                                    (prev_mode, None)
+                                // SIZE_RESTORED covers two cases: a genuine restore FROM
+                                // minimized/maximized (a real state change), and a plain
+                                // resize while already Normal (same state — NOT a transition).
+                                // `can_transition_to` rejects same-state by design, so it must
+                                // NOT gate this event: a normal-state resize is always a valid
+                                // `Resized`. Gating on it dropped the event (and the last_size
+                                // update) on every live-resize drag step.
+                                ctx.last_size.set(size);
+                                let event = if prev_mode.is_minimized() || prev_mode.is_maximized()
+                                {
+                                    tracing::info!("📐 Window Restored: {}x{}", width, height);
+                                    WindowEvent::Restored {
+                                        window_id: ctx.window_id,
+                                        size,
+                                    }
                                 } else {
-                                    ctx.last_size.set(size);
-
-                                    // Dispatch Restored event only when transitioning FROM
-                                    // minimized or maximized
-                                    let event =
-                                        if prev_mode.is_minimized() || prev_mode.is_maximized() {
-                                            Some(WindowEvent::Restored {
-                                                window_id: ctx.window_id,
-                                                size,
-                                            })
-                                        } else {
-                                            // Normal resize within normal state
-                                            Some(WindowEvent::Resized {
-                                                window_id: ctx.window_id,
-                                                size,
-                                            })
-                                        };
-                                    (candidate, event)
-                                }
+                                    tracing::debug!("📐 Window Resized: {}x{}", width, height);
+                                    WindowEvent::Resized {
+                                        window_id: ctx.window_id,
+                                        size,
+                                    }
+                                };
+                                (WindowMode::Normal, Some(event))
                             }
                             _ => {
                                 // Regular resize while in current state
@@ -473,6 +467,25 @@ impl WindowsPlatform {
                         // Dispatch event to global handlers if any
                         if let Some(event) = event {
                             ctx.dispatch_event(event);
+                        }
+
+                        // Render synchronously at the new size, in the same WM_SIZE
+                        // message that reconfigured the surface. Win32 does not post a
+                        // WM_PAINT for every WM_SIZE during the modal resize loop, so
+                        // without this the next rendered frame lags ≥1 step behind the
+                        // window size: the compositor stretches the stale frame and
+                        // fixed-position content appears to jitter while dragging the
+                        // border. `dispatch_resize` above already released the renderer
+                        // lock (its closure returned), so this re-locks cleanly; a
+                        // minimized window has nothing to present.
+                        if size_type != SIZE_MINIMIZED {
+                            // Render synchronously, in the same WM_SIZE message that
+                            // reconfigured the surface, so the new size is presented within
+                            // the modal resize loop instead of waiting for the next WM_PAINT
+                            // (which Windows does not reliably post per drag step).
+                            // `dispatch_resize` above already released the renderer lock, so
+                            // this re-locks cleanly; a minimized window has nothing to present.
+                            ctx.callbacks.dispatch_request_frame();
                         }
                     }
 

--- a/examples/aa_showcase.rs
+++ b/examples/aa_showcase.rs
@@ -1,0 +1,141 @@
+//! AA Showcase — visual check for the engine's anti-aliasing paths.
+//!
+//! Renders the primitives whose AA this engine computes, at angles that make the
+//! quality visible:
+//!   * rounded rects rotated 0° / 15° / 30° / 45° — the SDF-instanced affine path
+//!     (`rect_instanced.wgsl`). The L2 (`length(dpdx, dpdy)`) gradient gives a
+//!     ~1-device-px edge band at every angle; the old L1/`fwidth` band was up to
+//!     √2 (~1.41px) wider on the 45° edges.
+//!   * a circle and a rotated oval — `circle_instanced.wgsl`.
+//!   * a pie arc — `arc_instanced.wgsl` (radial + angular SDF edges).
+//!   * a self-intersecting 5-point star, filled — the SSAA-tile path
+//!     (`draw_path` → supersampled offscreen → box downsample), which is what the
+//!     pool-bucketing + `crop_uv` work touches.
+//!   * a rounded-rect ring (`draw_drrect`).
+//!
+//! White-on-dark so the boundary band is easy to inspect (zoom in on the 45° rect
+//! and the star tips). Run with: `cargo run --example aa_showcase`
+//! (or `just example aa_showcase`).
+
+use flui_app::{AppConfig, run_direct};
+
+fn main() -> anyhow::Result<()> {
+    run_direct(
+        AppConfig::new()
+            .with_title("FLUI — AA Showcase (L2 SDF + SSAA paths)")
+            .with_size(960, 640),
+        |builder, width, height| {
+            use flui_painting::Canvas;
+            use flui_types::{
+                Point, RRect, Rect,
+                geometry::{Pixels, px},
+                painting::{Paint, path::Path},
+                styling::Color,
+            };
+
+            let mut canvas = Canvas::new();
+
+            // Dark slate background so the AA edge band is visible against fills.
+            canvas.draw_rect(
+                Rect::from_ltrb(px(0.0), px(0.0), px(width), px(height)),
+                &Paint::fill(Color::rgb(24, 24, 37)),
+            );
+
+            let white = Paint::fill(Color::WHITE);
+
+            // ── Row 1: rounded rects rotated 0/15/30/45° (SDF-instanced affine) ──
+            // The 45° card is the clearest L2-vs-L1 tell: its edges should read as a
+            // single crisp ~1px ramp, not a fuzzy ~1.4px band.
+            let card_half_w = 60.0_f32;
+            let card_half_h = 38.0_f32;
+            let row1_y = 130.0_f32;
+            for (slot, angle_deg) in [0.0_f32, 15.0, 30.0, 45.0].into_iter().enumerate() {
+                let center_x = 140.0 + slot as f32 * 220.0;
+                canvas.save();
+                canvas.translate(center_x, row1_y);
+                canvas.rotate(angle_deg.to_radians());
+                let local = Rect::from_ltrb(
+                    px(-card_half_w),
+                    px(-card_half_h),
+                    px(card_half_w),
+                    px(card_half_h),
+                );
+                canvas.draw_rrect(RRect::from_rect_circular(local, Pixels(16.0)), &white);
+                canvas.restore();
+            }
+
+            // ── Row 2: circle, rotated oval, pie arc (circle/arc instanced) ──────
+            let row2_y = 340.0_f32;
+            canvas.draw_circle(Point::new(px(140.0), px(row2_y)), px(52.0), &white);
+
+            // Oval rotated 30° to exercise the affine ellipse path.
+            canvas.save();
+            canvas.translate(380.0, row2_y);
+            canvas.rotate(30.0_f32.to_radians());
+            canvas.draw_oval(
+                Rect::from_ltrb(px(-70.0), px(-40.0), px(70.0), px(40.0)),
+                &white,
+            );
+            canvas.restore();
+
+            // Pie arc: 270° sweep, filled to centre.
+            canvas.draw_arc(
+                Rect::from_ltrb(px(560.0), px(row2_y - 56.0), px(672.0), px(row2_y + 56.0)),
+                -45.0_f32.to_radians(),
+                270.0_f32.to_radians(),
+                true,
+                &white,
+            );
+
+            // Rounded-rect ring (drrect) — outer minus inner.
+            let ring_center_x = 840.0_f32;
+            let outer = RRect::from_rect_circular(
+                Rect::from_ltrb(
+                    px(ring_center_x - 56.0),
+                    px(row2_y - 56.0),
+                    px(ring_center_x + 56.0),
+                    px(row2_y + 56.0),
+                ),
+                Pixels(20.0),
+            );
+            let inner = RRect::from_rect_circular(
+                Rect::from_ltrb(
+                    px(ring_center_x - 32.0),
+                    px(row2_y - 32.0),
+                    px(ring_center_x + 32.0),
+                    px(row2_y + 32.0),
+                ),
+                Pixels(12.0),
+            );
+            canvas.draw_drrect(outer, inner, &white);
+
+            // ── Row 3: self-intersecting 5-point star (SSAA-tile fill path) ──────
+            let star_center = Point::new(px(width / 2.0), px(520.0));
+            let outer_radius = 80.0_f32;
+            let inner_radius = 32.0_f32;
+            let mut star = Path::new();
+            for tip in 0..10 {
+                let radius = if tip % 2 == 0 {
+                    outer_radius
+                } else {
+                    inner_radius
+                };
+                // Start at the top tip (-90°) and step every 36°.
+                let angle = (-90.0_f32 + tip as f32 * 36.0).to_radians();
+                let point = Point::new(
+                    px(star_center.x.0 + radius * angle.cos()),
+                    px(star_center.y.0 + radius * angle.sin()),
+                );
+                if tip == 0 {
+                    star.move_to(point);
+                } else {
+                    star.line_to(point);
+                }
+            }
+            star.close();
+            canvas.draw_path(&star, &white);
+
+            builder.add_picture(canvas.finish());
+        },
+    )
+}


### PR DESCRIPTION
## Summary

Closes the tessellated-AA deferred backlog (items 1–5) — the visible AA quality win plus the SSAA perf/hygiene debt — and, found while visually verifying it, fixes the Win32 live-resize **wobble** plus two real Win32 bugs.

## What changed

**Engine — AA quality & SSAA (`feat`+`perf` commits)**
- **Q1 — L1→L2 AA norm.** Replace `fwidth` (L1/Manhattan) with `length(vec2(dpdx,dpdy))` (L2/Euclidean) at all 8 SDF AA sites (5 `sdfToAlpha` copies + 3 inline circle/arc). L1 over-widens diagonal-edge AA by up to √2 (~1.41px); L2 gives an exact ~1px band at any angle. Axis-aligned straight edges stay byte-identical; only rounded corners change (≤1/255).
- **P1 — anisotropic SSAA threshold.** `GpuStateStack::area_scale()` = `|det|` of the CTM 2×2 (rotation/shear-invariant) replaces `max_scale²`, which overestimated device area under anisotropic scale and spuriously routed tiny shapes to the 5-pass SSAA tile. All 7 device-area sites updated; `max_scale` kept for tessellation tolerance.
- **H1 — `pipeline::ssaa_eligible_for(mode, area)`** consolidates the eligibility predicate (was reconstructed at 7 sites). Behavior-preserving: **arc keeps** its load-bearing `mode != SrcOver` prefix; **drrect drops** the redundant `mode == SrcOver` prefix (subsumed by `is_tile_safe_for_ssaa`).
- **P2 — SSAA tile-pool bucketing.** Quantize the 2× supersample texture to 64px buckets so odd per-path sizes stop evicting reusable full-viewport layer textures; a `crop_uv` uniform in `box_downsample.wgsl` keeps the box filter sampling only the content region; the downsample unit-quad VB is cached instead of re-created per call.
- **H2 — tests.** Table-driven guard over all 7 coverage-destructive Porter-Duff modes pinned to the `Color::blend` oracle; a real GPU view-only advanced-blend fallback test (replaces a vacuous placeholder).

**Platform — smooth Win32 live-resize (`fix` commit)**
- Root cause: the DX12 **flip-model swapchain on the HWND redirection bitmap** has no sync between the flip and the window-rect change during a live resize → DWM stretches the in-flight back buffer (the "wobble"). Not reachable from any `SurfaceConfiguration` knob (wgpu-hal hardcodes `DXGI_SCALING_STRETCH`).
- Fix: route DX12 through **DirectComposition** (`Dx12SwapchainKind::DxgiFromVisual`, [wgpu#7550](https://github.com/gfx-rs/wgpu/pull/7550), no fork) so DWM owns the transform. Default on; opt out with `FLUI_DX12_NO_DCOMP=1` (RenderDoc can't capture a composition swapchain). **Confirmed: eliminates the wobble.**
- Also: drop the GDI `FillRect(BLACK_BRUSH)` from `WM_PAINT` (GDI + flip-model can't share an HWND); render synchronously in the `WM_SIZE` modal loop; fix `SIZE_RESTORED` dropping the `Resized` event on a plain Normal→Normal resize; `desired_maximum_frame_latency` 2→1.

**Example:** [`examples/aa_showcase.rs`](examples/aa_showcase.rs) — rotated rrects/circle/oval/arc/ring + an SSAA star, for visual AA + resize verification.

## Verification

- `cargo fmt --check` ✓ · `cargo clippy --all-targets --features enable-wgpu-tests -- -D warnings` (engine + platform) ✓
- **DX12 GPU-readback: 351 passed / 0 failed / 7 ignored**; workspace CPU 2866 passed.
- **Q1 red→green proven**: reverting one shader to `fwidth` makes `aa_oracle_tests::q1a` fail (partial-alpha count 156 > 149); L2 passes (~142).

## Reviewer notes

- Q1 is **intentionally not byte-identical** at rounded corners (≤1/255) — the one approved divergence from the "axis-aligned byte-identical" maintainer condition.
- GPU-readback tests are local DX12 only (`--features enable-wgpu-tests`), not CI; flui-platform is excluded from CI, so the resize fix is verified manually (visually confirmed).
- The DComp resize fix is wgpu-config-level, no fork. Known residual per Firefox [bug 1191971](https://bugzilla.mozilla.org/show_bug.cgi?id=1191971): DComp gives "much smaller jiggle, not guaranteed mathematically perfect" — pixel-perfect would need `DXGI_SCALING_NONE` (below wgpu's API). Context: winit [#786](https://github.com/rust-windowing/winit/issues/786), wgpu [#2869](https://github.com/gfx-rs/wgpu/issues/2869).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
