### PR TITLE
feat(engine): GPU color-matrix filter (first GPU ImageFilter/ColorFilter)

### DIFF
--- a/crates/flui-engine/src/wgpu/backend.rs
+++ b/crates/flui-engine/src/wgpu/backend.rs
@@ -14,7 +14,7 @@ use smallvec::SmallVec;
 
 use std::sync::Arc;
 
-use super::painter::WgpuPainter;
+use super::{command_ir::LayerFilter, painter::WgpuPainter};
 use crate::{
     commands::dispatch_command,
     traits::{CommandRenderer, LayerStateStack},
@@ -1409,27 +1409,6 @@ impl CommandRenderer for Backend<'_> {
 // receiving trait differs. See `crates/flui-engine/src/traits.rs`
 // for the trait-split rationale.
 
-// ColorMatrix row-major layout: `[r0-r4, g0-g4, b0-b4, a0-a4]`.
-// Each row holds (R-coeff, G-coeff, B-coeff, A-coeff, offset) for one
-// output channel: `out = m0*R + m1*G + m2*B + m3*A + m4`.
-// The alpha row sits at indices 15-19; the alpha-out coefficient on
-// alpha-in (`a3`, alpha scaling) is index 18, the alpha offset (`a4`)
-// is index 19. Naming these out keeps the push_color_filter +
-// ImageFilter::Matrix call sites readable (PR #115 review fix).
-const COLOR_MATRIX_ALPHA_SCALE_IDX: usize = 18;
-const COLOR_MATRIX_ALPHA_OFFSET_IDX: usize = 19;
-
-/// Extract (alpha_scale, alpha_offset, effective_alpha) from a
-/// `ColorMatrix`'s alpha row. All three values are clamped to `[0, 1]`.
-/// Helper shared by `push_color_filter` and the
-/// `ImageFilter::Matrix` branch of `push_image_filter`.
-fn color_matrix_effective_alpha(values: &[f32; 20]) -> (f32, f32, f32) {
-    let alpha_scale = values[COLOR_MATRIX_ALPHA_SCALE_IDX].clamp(0.0, 1.0);
-    let alpha_offset = values[COLOR_MATRIX_ALPHA_OFFSET_IDX].clamp(0.0, 1.0);
-    let effective = (alpha_scale + alpha_offset).clamp(0.0, 1.0);
-    (alpha_scale, alpha_offset, effective)
-}
-
 impl LayerStateStack for Backend<'_> {
     // Cycle 4 wave 5 PR #117 review (Codex P1): every method on
     // this trait must call `self.flush_active_transform()` BEFORE
@@ -1531,44 +1510,30 @@ impl LayerStateStack for Backend<'_> {
 
     fn push_color_filter(&mut self, filter: &flui_types::painting::ColorMatrix) {
         self.flush_active_transform();
-        // Check if the matrix is identity (no transformation needed)
+
+        // Identity fast-path: no-op layer keeps push/pop balanced.
+        // Exact f32 comparison is correct: `ColorMatrix::identity()` is
+        // built from bit-exact 0.0/1.0 literals, so a transitive equality
+        // check correctly skips the GPU pass without ULP slop.
         let identity = flui_types::painting::ColorMatrix::identity();
-        // Exact f32 array comparison is intentional: ColorMatrix::identity()
-        // is built from bit-exact 0.0/1.0 literals, so a transitive equality
-        // check correctly fast-paths the no-op case without ULP slop.
         #[expect(
             clippy::float_cmp,
             reason = "identity matrix is bit-exact (0.0/1.0 literals); exact comparison is correct"
         )]
         if filter.values == identity.values {
-            // Identity matrix: use a plain save so pop_color_filter stays balanced
             self.painter.save_layer(None, &Paint::fill(Color::WHITE));
-            tracing::trace!("push_color_filter: identity matrix, no-op layer");
+            tracing::trace!("push_color_filter: identity matrix — no-op layer");
             return;
         }
 
-        // Pragmatic approximation: extract opacity and tint from the
-        // color matrix. The alpha-row coefficient layout
-        // (`a3` = scale, `a4` = offset) lives in
-        // `color_matrix_effective_alpha`; see the helper comment
-        // above for the row-major index mapping.
-        let (_alpha_scale, _alpha_offset, effective_alpha) =
-            color_matrix_effective_alpha(&filter.values);
-        let tinted = filter.apply([1.0, 1.0, 1.0, 1.0]);
-
-        // Pass the chroma explicitly. `save_layer` ignores its paint's RGB (a
-        // saveLayer paint's color is not a tint — opacity comes from alpha,
-        // chroma only from a ColorFilter), so the filter's RGB must go through
-        // the dedicated tint entry point or it would be dropped.
+        // Real color-matrix: open a filter layer.  The GPU shader applies the
+        // full 5×4 matrix per-pixel (unpremul → matrix → clamp → repremul),
+        // so no approximation is needed here.
         self.painter
-            .save_layer_with_tint(None, effective_alpha, [tinted[0], tinted[1], tinted[2]]);
-
-        tracing::debug!(
-            "push_color_filter: approximation tint=({:.3},{:.3},{:.3}) alpha={:.2}",
-            tinted[0],
-            tinted[1],
-            tinted[2],
-            effective_alpha
+            .save_layer_with_filter(None, LayerFilter::ColorMatrix(filter.values));
+        tracing::trace!(
+            matrix = ?filter.values,
+            "push_color_filter: GPU color-matrix filter layer"
         );
     }
 
@@ -1616,34 +1581,22 @@ impl LayerStateStack for Backend<'_> {
                 );
             }
             ImageFilter::Matrix(matrix) => {
-                let (_alpha_scale, _alpha_offset, effective_alpha) =
-                    color_matrix_effective_alpha(&matrix.values);
-                let tinted = matrix.apply([1.0, 1.0, 1.0, 1.0]);
-
-                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                let tint_color = Color::rgba(
-                    (tinted[0] * 255.0) as u8,
-                    (tinted[1] * 255.0) as u8,
-                    (tinted[2] * 255.0) as u8,
-                    (effective_alpha * 255.0) as u8,
-                );
-                let paint = Paint::fill(tint_color);
-                self.painter.save_layer(None, &paint);
-                tracing::debug!(
-                    "push_image_filter(Matrix): approximation tint=({},{},{}) alpha={:.2}",
-                    tint_color.r,
-                    tint_color.g,
-                    tint_color.b,
-                    effective_alpha,
+                // Full GPU color-matrix pass — no approximation.
+                self.painter
+                    .save_layer_with_filter(None, LayerFilter::ColorMatrix(matrix.values));
+                tracing::trace!(
+                    matrix = ?matrix.values,
+                    "push_image_filter(Matrix): GPU color-matrix filter layer"
                 );
             }
             ImageFilter::ColorAdjust(adjustment) => {
-                let paint = Paint::fill(Color::WHITE);
-                self.painter.save_layer(None, &paint);
-                tracing::debug!(
-                    "push_image_filter(ColorAdjust): save_layer for {:?} \
-                     (GPU color adjust not yet implemented)",
-                    adjustment,
+                // Promote to a color matrix so the same GPU pass handles it.
+                let matrix = adjustment.to_color_matrix();
+                self.painter
+                    .save_layer_with_filter(None, LayerFilter::ColorMatrix(matrix.values));
+                tracing::trace!(
+                    ?adjustment,
+                    "push_image_filter(ColorAdjust): GPU color-matrix filter layer"
                 );
             }
             ImageFilter::Compose(filters) => {

--- a/crates/flui-engine/src/wgpu/color_matrix/mod.rs
+++ b/crates/flui-engine/src/wgpu/color_matrix/mod.rs
@@ -2,15 +2,15 @@
 //! premultiplied layer offscreen, writing the filtered result into a 2nd
 //! pooled texture (ping-pong).
 //!
-//! The only public entry point is [`apply_color_matrix`], called by
-//! `GpuReplay::flush_opacity_layer` when a [`super::command_ir::LayerFilter::ColorMatrix`]
+//! The only public entry point is `apply_color_matrix`, called by
+//! `GpuReplay::flush_opacity_layer` when a `LayerFilter::ColorMatrix`
 //! is present on the pending layer.
 //!
 //! ## Correctness contract
 //!
 //! - The source texture is premultiplied RGBA.
 //! - The matrix operates on straight (un-premultiplied) RGBA — the WGSL shader
-//!   unpremultiplies, applies the matrix, clamps [0,1] per channel, and
+//!   unpremultiplies, applies the matrix, clamps to `[0, 1]` per channel, and
 //!   re-premultiplies before writing.  This is bit-identical to
 //!   [`flui_types::painting::ColorMatrix::apply`] on the straight color.
 //! - The output texture is rendered with `LoadOp::Clear(TRANSPARENT)` so

--- a/crates/flui-engine/src/wgpu/color_matrix/mod.rs
+++ b/crates/flui-engine/src/wgpu/color_matrix/mod.rs
@@ -1,0 +1,149 @@
+//! Per-pixel color-matrix filter pass: applies a 5×4 color matrix to a
+//! premultiplied layer offscreen, writing the filtered result into a 2nd
+//! pooled texture (ping-pong).
+//!
+//! The only public entry point is [`apply_color_matrix`], called by
+//! `GpuReplay::flush_opacity_layer` when a [`super::command_ir::LayerFilter::ColorMatrix`]
+//! is present on the pending layer.
+//!
+//! ## Correctness contract
+//!
+//! - The source texture is premultiplied RGBA.
+//! - The matrix operates on straight (un-premultiplied) RGBA — the WGSL shader
+//!   unpremultiplies, applies the matrix, clamps [0,1] per channel, and
+//!   re-premultiplies before writing.  This is bit-identical to
+//!   [`flui_types::painting::ColorMatrix::apply`] on the straight color.
+//! - The output texture is rendered with `LoadOp::Clear(TRANSPARENT)` so
+//!   pixels outside the viewport are transparent.
+//! - `BlendState::REPLACE` is used; the GPU must not re-blend the result.
+//!
+//! ## Ping-pong
+//!
+//! The source (`layer_tex`) is bound as a texture; the destination
+//! (`filtered_tex`) is the render attachment.  They are distinct pooled
+//! textures so there is no read/write aliasing.
+
+use std::sync::Arc;
+
+use bytemuck::cast_slice;
+use wgpu::util::DeviceExt as _;
+
+pub(crate) use pipeline::ColorMatrixPipeline;
+use pipeline::ColorMatrixUniform;
+
+use super::{resources::GpuResources, texture_pool::PooledTexture};
+
+mod pipeline;
+
+/// Apply a 5×4 color matrix to `source_tex`, writing filtered premultiplied
+/// RGBA into a freshly-acquired pooled texture returned to the caller.
+///
+/// The caller must composite (or otherwise use) the returned texture before
+/// dropping it.  Dropping without compositing is not a correctness error —
+/// the texture returns to the pool — but produces an invisible layer.
+///
+/// ## Parameters
+///
+/// - `matrix_values` — flat row-major `[f32; 20]` color matrix:
+///   `[r0..r3, off_r,  g0..g3, off_g,  b0..b3, off_b,  a0..a3, off_a]`.
+/// - `source_tex` — premultiplied RGBA offscreen from `render_layer_to_offscreen`.
+/// - `viewport_size` — `(width, height)` in physical pixels; the output
+///   texture is the same size as the source.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "GPU pass functions require device/queue/pipeline/encoder plus the operation inputs"
+)]
+pub(crate) fn apply_color_matrix(
+    matrix_values: [f32; 20],
+    source_tex: &PooledTexture,
+    viewport_size: (u32, u32),
+    surface_format: wgpu::TextureFormat,
+    pipeline: &ColorMatrixPipeline,
+    resources: &mut GpuResources,
+    device: &Arc<wgpu::Device>,
+    encoder: &mut wgpu::CommandEncoder,
+) -> PooledTexture {
+    let (vp_w, vp_h) = viewport_size;
+
+    // Acquire the destination (filtered) texture — same size and format as source.
+    let filtered_tex = resources
+        .layer_texture_pool_mut()
+        .acquire(vp_w, vp_h, surface_format);
+    let filtered_view = filtered_tex.view();
+
+    // Build the uniform buffer from the flat 20-element matrix.
+    // Per-filtered-layer-per-frame allocation is intentional: the buffer is tiny
+    // (80 bytes) and bind-group-layout identity requires the uniform to be freshly
+    // bound per draw.  Hoisting into the pipeline would couple the pipeline to a
+    // single matrix value and break multi-layer filtering.
+    let uniform = ColorMatrixUniform::from_values(matrix_values);
+    let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("Color Matrix Uniform Buffer"),
+        contents: cast_slice(&[uniform]),
+        usage: wgpu::BufferUsages::UNIFORM,
+    });
+
+    // Nearest + ClampToEdge sampler — per-draw allocation (same rationale as above).
+    // No filtering: source texels are pixel-aligned with the output; bilinear
+    // filtering would introduce color error.
+    let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+        label: Some("Color Matrix Nearest Sampler"),
+        address_mode_u: wgpu::AddressMode::ClampToEdge,
+        address_mode_v: wgpu::AddressMode::ClampToEdge,
+        address_mode_w: wgpu::AddressMode::ClampToEdge,
+        mag_filter: wgpu::FilterMode::Nearest,
+        min_filter: wgpu::FilterMode::Nearest,
+        mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+        ..Default::default()
+    });
+
+    // Per-draw bind group: uniform (0) + source texture (1) + sampler (2).
+    // Must be created against the same `pipeline.bind_group_layout` object.
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("Color Matrix Bind Group"),
+        layout: &pipeline.bind_group_layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::TextureView(source_tex.view()),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: wgpu::BindingResource::Sampler(&sampler),
+            },
+        ],
+    });
+
+    // Render pass: clear to TRANSPARENT then draw the full-viewport quad.
+    // LoadOp::Clear ensures pixels outside the source content are transparent,
+    // matching the R3 invariant for offscreen passes.
+    {
+        let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("Color Matrix Filter Pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: filtered_view,
+                resolve_target: None,
+                depth_slice: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+
+        render_pass.set_pipeline(&pipeline.pipeline);
+        render_pass.set_bind_group(0, &bind_group, &[]);
+        // 6 vertices synthesised in the VS — no vertex buffer.
+        render_pass.draw(0..6, 0..1);
+    }
+
+    filtered_tex
+}

--- a/crates/flui-engine/src/wgpu/color_matrix/pipeline.rs
+++ b/crates/flui-engine/src/wgpu/color_matrix/pipeline.rs
@@ -1,0 +1,437 @@
+//! Pipeline and uniform layout for the per-pixel color-matrix filter pass.
+//!
+//! [`ColorMatrixPipeline`] owns the `wgpu::RenderPipeline` used by
+//! [`super::apply_color_matrix`].  It is format-parametric so the same pipeline
+//! serves both the windowed surface format and any pooled offscreen target format.
+//!
+//! ## Matrix upload format
+//!
+//! The CPU-side color matrix is stored row-major as `[f32; 20]`:
+//!
+//! ```text
+//!   [r0, r1, r2, r3, offset_r,   // row 0: R output weights + bias
+//!    g0, g1, g2, g3, offset_g,   // row 1: G output weights + bias
+//!    b0, b1, b2, b3, offset_b,   // row 2: B output weights + bias
+//!    a0, a1, a2, a3, offset_a]   // row 3: A output weights + bias
+//! ```
+//!
+//! `ColorMatrixUniform::from_values` splits this into a 4×4 weight matrix and a
+//! vec4 offset, uploaded as a single 80-byte uniform block.
+//!
+//! ## WGSL column-major layout — critical correctness note
+//!
+//! WGSL `mat4x4<f32>` is **column-major**: the first 16 floats in memory become
+//! column 0, column 1, column 2, column 3 of the matrix.  `mat * vec` in WGSL
+//! is the standard column-major product: `result[i] = dot(column_i, vec)`.
+//!
+//! We want `result[i] = dot(row_i_of_M, straight)` (the row dot-product).
+//! To achieve this we pack the **columns** of M into the four `[f32;4]` blocks
+//! so that WGSL's `u.m * straight` computes exactly the row dot-products:
+//!
+//! ```text
+//!   m[0] = [r0, g0, b0, a0]  (column 0 of M: first  weight of every row)
+//!   m[1] = [r1, g1, b1, a1]  (column 1 of M: second weight of every row)
+//!   m[2] = [r2, g2, b2, a2]  (column 2 of M: third  weight of every row)
+//!   m[3] = [r3, g3, b3, a3]  (column 3 of M: fourth weight of every row)
+//! ```
+//!
+//! WGSL then sees `result[i] = Σ_j column_j[i] * straight[j]
+//!                            = Σ_j M[i,j] * straight[j]`  ✓
+
+use std::mem;
+
+use bytemuck::{Pod, Zeroable};
+
+// ── Uniform layout (mirrors `ColorMatrixUniforms` in color_matrix.wgsl) ──────
+
+/// GPU uniform buffer layout for the color-matrix filter pass.
+///
+/// **Explicit `#[repr(C)]` layout — must match `ColorMatrixUniforms` in
+/// `color_matrix.wgsl` byte-for-byte.**
+///
+/// WGSL uniform-block alignment rules (WGSL §13.4.1, WebGPU §3.13.3):
+/// - `mat4x4<f32>` → align 16, size 64
+/// - `vec4<f32>`   → align 16, size 16
+///
+/// | Byte offset | Size | Rust field | WGSL member     |
+/// |-------------|------|------------|-----------------|
+/// | 0           | 64   | `m`        | `mat4x4<f32>`   |
+/// | 64          | 16   | `offset`   | `vec4<f32>`     |
+///
+/// Total = 80 bytes (multiple of 16 ✓).
+///
+/// `m[i]` is **column `i`** of the 4×4 weight matrix.  WGSL `mat4x4<f32>`
+/// is column-major, so `u.m * straight` computes `result[row] = dot(M_row, straight)`,
+/// the intended row-major matrix–vector product.  See crate-level doc comment for
+/// the full layout derivation.
+/// `offset[i]` is the additive bias for output channel `i` (R/G/B/A).
+#[derive(Debug, Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub(super) struct ColorMatrixUniform {
+    /// 4×4 weight matrix stored as its four COLUMNS.
+    ///
+    /// WGSL `mat4x4<f32>` reads consecutive floats as columns; storing column `i`
+    /// in `m[i]` makes `u.m` equal to M (not Mᵀ), so `u.m * straight` gives the
+    /// correct row dot-products.
+    pub(super) m: [[f32; 4]; 4],
+    /// Additive offset/bias for each output channel (R/G/B/A).
+    pub(super) offset: [f32; 4],
+}
+
+const _COLOR_MATRIX_UNIFORM_SIZE_CHECK: () = {
+    assert!(mem::size_of::<ColorMatrixUniform>() == 80);
+};
+
+impl ColorMatrixUniform {
+    /// Build a uniform from the flat `[f32; 20]` row-major color-matrix layout.
+    ///
+    /// Input layout: `[r0, r1, r2, r3, off_r,  g0..off_g,  b0..off_b,  a0..off_a]`.
+    ///
+    /// Each `m[i]` is stored as **column `i`** of the 4×4 weight matrix so that
+    /// WGSL's column-major `mat4x4<f32>` reads `u.m` as M (not Mᵀ).  The mapping:
+    ///
+    /// ```text
+    ///   m[0] = [r0, g0, b0, a0]  column 0: first  weight of every row
+    ///   m[1] = [r1, g1, b1, a1]  column 1: second weight of every row
+    ///   m[2] = [r2, g2, b2, a2]  column 2: third  weight of every row
+    ///   m[3] = [r3, g3, b3, a3]  column 3: fourth weight of every row
+    /// ```
+    pub(crate) fn from_values(values: [f32; 20]) -> Self {
+        Self {
+            m: [
+                // Column 0: the first RGBA weight of each output channel.
+                [values[0], values[5], values[10], values[15]],
+                // Column 1: the second RGBA weight of each output channel.
+                [values[1], values[6], values[11], values[16]],
+                // Column 2: the third RGBA weight of each output channel.
+                [values[2], values[7], values[12], values[17]],
+                // Column 3: the fourth RGBA weight of each output channel.
+                [values[3], values[8], values[13], values[18]],
+            ],
+            offset: [values[4], values[9], values[14], values[19]],
+        }
+    }
+}
+
+// ── Pipeline ──────────────────────────────────────────────────────────────────
+
+/// Bind-group layout and render pipeline for the color-matrix filter pass.
+///
+/// ## Bind-group layout (group 0)
+///
+/// | Binding | Stage | Type                  | Content                      |
+/// |---------|-------|-----------------------|------------------------------|
+/// | 0       | FS    | Uniform buffer        | [`ColorMatrixUniform`]       |
+/// | 1       | FS    | 2D float texture      | Source layer (premultiplied) |
+/// | 2       | FS    | Non-filtering sampler | Nearest + ClampToEdge        |
+///
+/// ## Blend state
+///
+/// `REPLACE` (no fixed-function blending): the fragment shader emits the full
+/// premultiplied filtered texel directly; the GPU hardware must not re-blend it.
+#[allow(missing_debug_implementations)]
+pub(crate) struct ColorMatrixPipeline {
+    /// Bind-group layout shared between pipeline construction and per-draw
+    /// bind-group creation in [`super::apply_color_matrix`].
+    pub(crate) bind_group_layout: wgpu::BindGroupLayout,
+    /// The single render pipeline (format-parametric at construction time).
+    pub(crate) pipeline: wgpu::RenderPipeline,
+}
+
+impl ColorMatrixPipeline {
+    /// Build the pipeline for `surface_format`.
+    ///
+    /// WGSL shader compilation happens here; a wgpu validation error surfaces
+    /// at this call site, which the GPU construction test exercises.
+    pub(crate) fn new(device: &wgpu::Device, surface_format: wgpu::TextureFormat) -> Self {
+        let bind_group_layout = create_bind_group_layout(device);
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("Color Matrix Pipeline Layout"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Color Matrix Shader"),
+            source: wgpu::ShaderSource::Wgsl(
+                include_str!("../shaders/effects/color_matrix.wgsl").into(),
+            ),
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Color Matrix Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                // No vertex buffers: the VS synthesises 6 vertices from
+                // `@builtin(vertex_index)`, forming a full-viewport quad.
+                buffers: &[],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    // REPLACE: the shader emits the full premultiplied result.
+                    // Fixed-function blending must not re-blend it.
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview_mask: None,
+            cache: None,
+        });
+
+        Self {
+            bind_group_layout,
+            pipeline,
+        }
+    }
+}
+
+// ── Bind-group layout factory (private) ──────────────────────────────────────
+
+fn create_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
+    device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("Color Matrix Bind Group Layout"),
+        entries: &[
+            // Binding 0: uniform buffer (FS)
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(
+                        mem::size_of::<ColorMatrixUniform>() as u64
+                    ),
+                },
+                count: None,
+            },
+            // Binding 1: source layer texture (FS) — non-filtering (Nearest)
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                count: None,
+            },
+            // Binding 2: nearest-clamp sampler (FS)
+            wgpu::BindGroupLayoutEntry {
+                binding: 2,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
+                count: None,
+            },
+        ],
+    })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+// `float_cmp` fires on `assert_eq!` of f32 arrays; these tests verify exact
+// bit-identity of literals stored and read back through a struct — no arithmetic,
+// so equality is bit-exact and the comparison is correct.
+#[allow(clippy::float_cmp)]
+mod cpu_tests {
+    use super::ColorMatrixUniform;
+
+    /// The struct size must match the WGSL uniform-block size exactly.
+    ///
+    /// Layout: m(64) + offset(16) = 80 bytes.
+    #[test]
+    fn color_matrix_uniform_size_is_80_bytes() {
+        assert_eq!(
+            std::mem::size_of::<ColorMatrixUniform>(),
+            80,
+            "ColorMatrixUniform must be 80 bytes to match the WGSL ColorMatrixUniforms struct"
+        );
+    }
+
+    /// `from_values` splits the flat 20-element layout correctly.
+    ///
+    /// The identity matrix in [f32;20] form:
+    /// ```text
+    ///   [1,0,0,0,0,  0,1,0,0,0,  0,0,1,0,0,  0,0,0,1,0]
+    /// ```
+    /// must produce `m[i] = column i of I₄` (= I₄ itself) and `offset = [0;4]`.
+    ///
+    /// For identity: column 0 = (1,0,0,0), column 1 = (0,1,0,0), etc.
+    #[test]
+    fn from_values_identity_matrix() {
+        #[rustfmt::skip]
+        let identity: [f32; 20] = [
+            1.0, 0.0, 0.0, 0.0, 0.0,  // R row: weight R=1, G=0, B=0, A=0, off=0
+            0.0, 1.0, 0.0, 0.0, 0.0,  // G row
+            0.0, 0.0, 1.0, 0.0, 0.0,  // B row
+            0.0, 0.0, 0.0, 1.0, 0.0,  // A row
+        ];
+        let u = ColorMatrixUniform::from_values(identity);
+        // m[i] is column i — for the identity, columns equal the standard basis.
+        assert_eq!(u.m[0], [1.0, 0.0, 0.0, 0.0], "column 0: (r0,g0,b0,a0)");
+        assert_eq!(u.m[1], [0.0, 1.0, 0.0, 0.0], "column 1: (r1,g1,b1,a1)");
+        assert_eq!(u.m[2], [0.0, 0.0, 1.0, 0.0], "column 2: (r2,g2,b2,a2)");
+        assert_eq!(u.m[3], [0.0, 0.0, 0.0, 1.0], "column 3: (r3,g3,b3,a3)");
+        assert_eq!(u.offset, [0.0, 0.0, 0.0, 0.0], "offset");
+    }
+
+    /// `from_values` extracts offsets from column 4 of each row.
+    #[test]
+    fn from_values_extracts_offset_correctly() {
+        #[rustfmt::skip]
+        let values: [f32; 20] = [
+            1.0, 0.0, 0.0, 0.0, 0.1,  // off_r = 0.1
+            0.0, 1.0, 0.0, 0.0, 0.2,  // off_g = 0.2
+            0.0, 0.0, 1.0, 0.0, 0.3,  // off_b = 0.3
+            0.0, 0.0, 0.0, 1.0, 0.4,  // off_a = 0.4
+        ];
+        let u = ColorMatrixUniform::from_values(values);
+        assert_eq!(
+            u.offset,
+            [0.1, 0.2, 0.3, 0.4],
+            "offsets from column 4 of each row"
+        );
+    }
+
+    /// `from_values` maps a swap-R/B matrix into the correct columns.
+    ///
+    /// The "swap R and B channels" matrix (used in the GPU readback tests):
+    /// ```text
+    ///   row 0 (R_out): [0,0,1,0,0]   R_out = B_in
+    ///   row 1 (G_out): [0,1,0,0,0]   G_out = G_in
+    ///   row 2 (B_out): [1,0,0,0,0]   B_out = R_in
+    ///   row 3 (A_out): [0,0,0,1,0]   A_out = A_in
+    /// ```
+    /// Columns of this matrix:
+    ///   column 0: (0,0,1,0) — the R-input weight for every output channel
+    ///   column 1: (0,1,0,0)
+    ///   column 2: (1,0,0,0)
+    ///   column 3: (0,0,0,1)
+    #[test]
+    fn from_values_swap_rb_matrix() {
+        #[rustfmt::skip]
+        let swap_rb: [f32; 20] = [
+            0.0, 0.0, 1.0, 0.0, 0.0,  // R_out = B_in
+            0.0, 1.0, 0.0, 0.0, 0.0,  // G_out = G_in
+            1.0, 0.0, 0.0, 0.0, 0.0,  // B_out = R_in
+            0.0, 0.0, 0.0, 1.0, 0.0,  // A_out = A_in
+        ];
+        let u = ColorMatrixUniform::from_values(swap_rb);
+        // m[i] is column i of the swap-R/B matrix.
+        assert_eq!(
+            u.m[0],
+            [0.0, 0.0, 1.0, 0.0],
+            "column 0: R-input weight per output row"
+        );
+        assert_eq!(
+            u.m[1],
+            [0.0, 1.0, 0.0, 0.0],
+            "column 1: G-input weight per output row"
+        );
+        assert_eq!(
+            u.m[2],
+            [1.0, 0.0, 0.0, 0.0],
+            "column 2: B-input weight per output row"
+        );
+        assert_eq!(
+            u.m[3],
+            [0.0, 0.0, 0.0, 1.0],
+            "column 3: A-input weight per output row"
+        );
+    }
+
+    /// Asymmetric matrix + offset: `from_values` → uniform → CPU oracle must agree.
+    ///
+    /// Uses a matrix with no symmetry so the transpose bug would produce wrong values.
+    /// Applies it to a non-trivial RGBA color and compares the uniform-computed result
+    /// with `ColorMatrix::apply`.
+    #[test]
+    fn from_values_asymmetric_matrix_with_offset_matches_apply() {
+        use flui_types::painting::ColorMatrix;
+        // Asymmetric 5×4 matrix: off-diagonal weights differ above/below diagonal.
+        #[rustfmt::skip]
+        let values: [f32; 20] = [
+            0.6, 0.2, 0.1, 0.0, 0.05,  // R_out
+            0.1, 0.7, 0.05, 0.0, 0.0,  // G_out
+            0.05, 0.1, 0.8, 0.0, 0.0,  // B_out
+            0.0, 0.0, 0.0, 1.0, 0.0,   // A_out
+        ];
+        let matrix = ColorMatrix::new(values);
+        let u = ColorMatrixUniform::from_values(values);
+
+        // Verify that applying the uniform reproduces ColorMatrix::apply for a
+        // straight-alpha input color — the CPU oracle for the shader's math.
+        let straight = [0.8_f32, 0.4, 0.2, 1.0]; // opaque warm orange
+        let cpu_result = matrix.apply(straight);
+
+        // Reproduce the uniform's dot-products: result[i] = Σ_j u.m[j][i] * straight[j]
+        // (column-major mat*vec: column j contributes column[j]*straight[j]).
+        let gpu_result: [f32; 4] = std::array::from_fn(|output_channel| {
+            (0..4)
+                .map(|input_channel| u.m[input_channel][output_channel] * straight[input_channel])
+                .sum::<f32>()
+                + u.offset[output_channel]
+        });
+
+        for ch in 0..4 {
+            assert!(
+                (gpu_result[ch] - cpu_result[ch]).abs() < 1e-5,
+                "channel {ch}: uniform-computed={} cpu-oracle={}",
+                gpu_result[ch],
+                cpu_result[ch]
+            );
+        }
+    }
+}
+
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+mod gpu_construction_tests {
+    use super::ColorMatrixPipeline;
+
+    fn test_device() -> wgpu::Device {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .expect("a GPU adapter must be available on a GPU-enabled test host");
+        let (device, _queue) =
+            pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+                label: Some("ColorMatrixPipeline Test Device"),
+                ..Default::default()
+            }))
+            .expect("GPU device creation succeeded when adapter was found");
+        device
+    }
+
+    /// `ColorMatrixPipeline::new` completes without a wgpu validation error for
+    /// `Rgba8Unorm`, proving the WGSL parses and the bind-group layout is valid.
+    #[test]
+    fn pipeline_construction_succeeds_for_rgba8unorm() {
+        let device = test_device();
+        let _pipeline = ColorMatrixPipeline::new(&device, wgpu::TextureFormat::Rgba8Unorm);
+    }
+}

--- a/crates/flui-engine/src/wgpu/color_matrix_filter_tests.rs
+++ b/crates/flui-engine/src/wgpu/color_matrix_filter_tests.rs
@@ -1,0 +1,751 @@
+//! GPU readback acceptance gate for the color-matrix filter pass.
+//!
+//! ## Test inventory
+//!
+//! | # | Gate | Requirement |
+//! |---|------|-------------|
+//! | F1 | GPU | Identity matrix: output equals unfiltered source |
+//! | F2 | GPU | Swap-R↔B matrix: opaque red input → premul blue output |
+//! | F3 | GPU | Identity on translucent: 50% alpha survives filter correctly |
+//! | F4 | GPU | Asymmetric matrix (saturation=0) on mixed color: all channels equal (gray) — catches transpose bug |
+//! | F5 | GPU | Brightness(+0.3) on translucent green: oracle match catches premul skip |
+//! | F6 | GPU | Filter layer nested in opacity-0.5 layer: output alpha ≈ 128 (inherits parent opacity) |
+//!
+//! All tests use `enable-wgpu-tests` feature-gate and follow the same harness
+//! pattern as `layer_blend_tests`.  The 64×64 surface avoids DX12 small-texture
+//! copy artefacts (see `layer_blend_tests.rs` for the rationale).
+
+// ─── GPU readback tests ───────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+mod gpu_tests {
+    use std::sync::Arc;
+
+    use flui_painting::Paint;
+    use flui_types::{Color, Rect, geometry::Pixels, painting::ColorMatrix};
+
+    use crate::wgpu::{command_ir::LayerFilter, painter::WgpuPainter, render_target::RenderTarget};
+
+    // ── Harness constants ─────────────────────────────────────────────────────
+
+    const SURFACE_WIDTH: u32 = 64;
+    const SURFACE_HEIGHT: u32 = 64;
+    const SURFACE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
+
+    // ── Harness helpers ───────────────────────────────────────────────────────
+
+    fn acquire_test_device_and_queue() -> (Arc<wgpu::Device>, Arc<wgpu::Queue>) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .expect("a GPU adapter must be available for color_matrix_filter_tests");
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("ColorMatrixFilter Test Device"),
+            ..Default::default()
+        }))
+        .expect("a GPU device must be available for color_matrix_filter_tests");
+        (Arc::new(device), Arc::new(queue))
+    }
+
+    fn create_surface(device: &wgpu::Device) -> (wgpu::Texture, wgpu::TextureView) {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("ColorMatrixFilter Test Surface"),
+            size: wgpu::Extent3d {
+                width: SURFACE_WIDTH,
+                height: SURFACE_HEIGHT,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: SURFACE_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        (texture, view)
+    }
+
+    fn clear_surface(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        view: &wgpu::TextureView,
+        color: wgpu::Color,
+    ) {
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("ColorMatrixFilter Surface Clear"),
+        });
+        {
+            let _pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("ColorMatrixFilter Clear Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(color),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+        }
+        queue.submit(std::iter::once(encoder.finish()));
+    }
+
+    /// Read all pixels back from `texture` as `[r, g, b, a]` u8 quads.
+    fn readback_pixels(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        texture: &wgpu::Texture,
+    ) -> Vec<[u8; 4]> {
+        let bytes_per_pixel = 4u32;
+        let unpadded_row_bytes = SURFACE_WIDTH * bytes_per_pixel;
+        let row_alignment = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let padded_row_bytes = unpadded_row_bytes.div_ceil(row_alignment) * row_alignment;
+        let staging_size = u64::from(padded_row_bytes * SURFACE_HEIGHT);
+
+        let staging = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("ColorMatrixFilter Readback Staging"),
+            size: staging_size,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("ColorMatrixFilter Readback Encoder"),
+        });
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &staging,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_row_bytes),
+                    rows_per_image: Some(SURFACE_HEIGHT),
+                },
+            },
+            wgpu::Extent3d {
+                width: SURFACE_WIDTH,
+                height: SURFACE_HEIGHT,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit(std::iter::once(encoder.finish()));
+
+        staging.slice(..).map_async(wgpu::MapMode::Read, |_| {});
+        device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .expect("GPU readback poll must complete within wait timeout");
+
+        let raw_bytes = staging.slice(..).get_mapped_range();
+        let pixel_count = (SURFACE_WIDTH * SURFACE_HEIGHT) as usize;
+        let mut pixels = Vec::with_capacity(pixel_count);
+        for row_index in 0..SURFACE_HEIGHT {
+            let row_start = (row_index * padded_row_bytes) as usize;
+            for col_index in 0..SURFACE_WIDTH {
+                let byte_offset = row_start + col_index as usize * 4;
+                pixels.push([
+                    raw_bytes[byte_offset],
+                    raw_bytes[byte_offset + 1],
+                    raw_bytes[byte_offset + 2],
+                    raw_bytes[byte_offset + 3],
+                ]);
+            }
+        }
+        pixels
+    }
+
+    fn build_painter(device: Arc<wgpu::Device>, queue: Arc<wgpu::Queue>) -> WgpuPainter {
+        WgpuPainter::with_shared_device(
+            device,
+            queue,
+            SURFACE_FORMAT,
+            (SURFACE_WIDTH, SURFACE_HEIGHT),
+        )
+    }
+
+    fn full_surface_bounds() -> Rect<Pixels> {
+        Rect::from_xywh(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(SURFACE_WIDTH as f32),
+            Pixels(SURFACE_HEIGHT as f32),
+        )
+    }
+
+    /// Assert every interior pixel (skip 1-pixel border to avoid SDF fwidth edge
+    /// artefacts) is within `tolerance` of `expected` in all 4 channels.
+    fn assert_interior_pixels_near(
+        label: &str,
+        readback: &[[u8; 4]],
+        expected: [u8; 4],
+        tolerance: u8,
+    ) {
+        let width = SURFACE_WIDTH as usize;
+        let height = SURFACE_HEIGHT as usize;
+        for (pixel_index, &actual) in readback.iter().enumerate() {
+            let row = pixel_index / width;
+            let col = pixel_index % width;
+            // Skip the 1-pixel border: SDF fwidth uses helper fragments outside
+            // the primitive at the viewport edge, yielding partial alpha there.
+            if row == 0 || row >= height - 1 || col == 0 || col >= width - 1 {
+                continue;
+            }
+            for channel_index in 0..4 {
+                let channel_diff = u8::try_from(
+                    (i16::from(actual[channel_index]) - i16::from(expected[channel_index]))
+                        .unsigned_abs(),
+                )
+                .expect("diff of two u8 values always fits in u8");
+                assert!(
+                    channel_diff <= tolerance,
+                    "{label}: pixel {pixel_index} (row={row} col={col}) \
+                     channel {channel_index} — actual={a} expected={e} \
+                     diff={channel_diff} > tolerance {tolerance}",
+                    a = actual[channel_index],
+                    e = expected[channel_index],
+                );
+            }
+        }
+    }
+
+    // ── CPU oracle helpers ────────────────────────────────────────────────────
+
+    /// Apply `matrix` to a straight-alpha RGBA color and return the expected
+    /// premultiplied `[r, g, b, a]` u8 quad, matching the shader's math:
+    ///
+    /// 1. Treat input as straight-alpha (opaque input → straight == itself).
+    /// 2. `output = M * straight + offset`, clamped component-wise to `[0, 1]`.
+    /// 3. Re-premultiply: `(r*a, g*a, b*a, a)` in the `[0,1]` domain.
+    /// 4. Quantise to u8 via `round(x * 255)`.
+    fn color_matrix_oracle(matrix: &ColorMatrix, straight_rgba: [f32; 4]) -> [u8; 4] {
+        let v = &matrix.values;
+        let [sr, sg, sb, sa] = straight_rgba;
+        // The 5×4 matrix: row i = [v[5i], v[5i+1], v[5i+2], v[5i+3], v[5i+4]]
+        // Output_i = row_i · [sr, sg, sb, sa, 1]
+        let out_r = (v[0] * sr + v[1] * sg + v[2] * sb + v[3] * sa + v[4]).clamp(0.0, 1.0);
+        let out_g = (v[5] * sr + v[6] * sg + v[7] * sb + v[8] * sa + v[9]).clamp(0.0, 1.0);
+        let out_b = (v[10] * sr + v[11] * sg + v[12] * sb + v[13] * sa + v[14]).clamp(0.0, 1.0);
+        let out_a = (v[15] * sr + v[16] * sg + v[17] * sb + v[18] * sa + v[19]).clamp(0.0, 1.0);
+        // Re-premultiply.
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "values clamped to [0,1]*255 then rounded; truncation is safe"
+        )]
+        let to_u8 = |x: f32| (x * 255.0).round() as u8;
+        [
+            to_u8(out_r * out_a),
+            to_u8(out_g * out_a),
+            to_u8(out_b * out_a),
+            to_u8(out_a),
+        ]
+    }
+
+    // ── F1: Identity matrix — output byte-identical to unfiltered ────────────
+
+    /// F1: An identity color-matrix filter must produce output bit-identical to
+    /// drawing the same rect without any filter.
+    ///
+    /// **Proves:**
+    /// - The filter pass runs (it must read and write to the ping-pong texture).
+    /// - Identity `m * straight + 0 = straight`, so no channels are mutated.
+    /// - `needs_composite` gate is set for filter layers even when opacity=1.
+    ///
+    /// **Fails if:** the filter pass is silently skipped (reintegrate fast-path
+    /// wrongly fires when `filter.is_some()`).
+    #[test]
+    fn identity_filter_produces_same_output_as_no_filter() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (no_filter_tex, no_filter_view) = create_surface(&device);
+        let (identity_filter_tex, identity_filter_view) = create_surface(&device);
+
+        let black = wgpu::Color {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        };
+        clear_surface(&device, &queue, &no_filter_view, black);
+        clear_surface(&device, &queue, &identity_filter_view, black);
+
+        let source_color = Color::rgba(180, 90, 40, 255);
+        let bounds = full_surface_bounds();
+
+        // Without filter.
+        {
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            painter.rect(bounds, &Paint::fill(source_color));
+            let mut encoder =
+                device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+            painter
+                .render(
+                    RenderTarget::sampleable(&no_filter_view, &no_filter_tex),
+                    &mut encoder,
+                )
+                .expect("no-filter render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+        }
+
+        // With identity filter.
+        {
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            let identity = ColorMatrix::identity();
+            painter.save_layer_with_filter(None, LayerFilter::ColorMatrix(identity.values));
+            painter.rect(bounds, &Paint::fill(source_color));
+            painter.restore_layer();
+            let mut encoder =
+                device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+            painter
+                .render(
+                    RenderTarget::sampleable(&identity_filter_view, &identity_filter_tex),
+                    &mut encoder,
+                )
+                .expect("identity-filter render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+        }
+
+        let no_filter_pixels = readback_pixels(&device, &queue, &no_filter_tex);
+        let identity_pixels = readback_pixels(&device, &queue, &identity_filter_tex);
+
+        // Identity must be bit-exact — tolerance 0.  Both paths go through the
+        // same rect draw; the only difference is the identity filter pass.
+        // ±1 for u8 quantisation mismatch when the premul round-trip at the
+        // offscreen boundary moves a texel by half an LSB.
+        let quantization_tolerance = 1u8;
+        let width = SURFACE_WIDTH as usize;
+        let height = SURFACE_HEIGHT as usize;
+        for (pixel_index, (&nf, &id)) in no_filter_pixels
+            .iter()
+            .zip(identity_pixels.iter())
+            .enumerate()
+        {
+            let row = pixel_index / width;
+            let col = pixel_index % width;
+            if row == 0 || row >= height - 1 || col == 0 || col >= width - 1 {
+                continue;
+            }
+            for channel_index in 0..4 {
+                let channel_diff = u8::try_from(
+                    (i16::from(nf[channel_index]) - i16::from(id[channel_index])).unsigned_abs(),
+                )
+                .expect("diff of two u8 values always fits in u8");
+                assert!(
+                    channel_diff <= quantization_tolerance,
+                    "F1: pixel {pixel_index} channel {channel_index} — \
+                     no_filter={a} identity_filter={b} \
+                     diff={channel_diff} > tolerance {quantization_tolerance}",
+                    a = nf[channel_index],
+                    b = id[channel_index],
+                );
+            }
+        }
+    }
+
+    // ── F2: Swap-R↔B matrix — opaque red → premul blue ───────────────────────
+
+    /// F2: A channel-swap matrix (R↔B, pass-through G and A) applied to an
+    /// opaque red layer must produce opaque blue output.
+    ///
+    /// **Proves:**
+    /// - Per-pixel unpremultiply → matrix → clamp → repremultiply is correct.
+    /// - The `from_values` row/column mapping correctly sends red-channel weight
+    ///   to the blue output and vice versa.
+    /// - Straight-alpha and premultiplied-alpha roundtrip is numerically correct
+    ///   for opaque inputs (alpha=1 → premul==straight; no division hazard).
+    ///
+    /// **Fails if:** the WGSL mat4x4 column-major vs Rust row-major mapping is
+    /// wrong (all four off-diagonal entries would be swapped, producing wrong
+    /// channels — e.g. leaving red unchanged instead of swapping to blue).
+    #[test]
+    fn swap_rb_matrix_converts_red_to_blue() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_surface(&device);
+
+        clear_surface(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 1.0,
+            },
+        );
+
+        // Source: opaque red.
+        let source_color = Color::rgba(200, 0, 0, 255);
+
+        // Swap-R↔B matrix: row-major 5×4 layout.
+        //   R_out = B_in  →  row 0 = [0, 0, 1, 0, 0]
+        //   G_out = G_in  →  row 1 = [0, 1, 0, 0, 0]
+        //   B_out = R_in  →  row 2 = [1, 0, 0, 0, 0]
+        //   A_out = A_in  →  row 3 = [0, 0, 0, 1, 0]
+        #[rustfmt::skip]
+        let swap_rb = ColorMatrix {
+            values: [
+                0.0, 0.0, 1.0, 0.0,   0.0,   // R_out = B_in
+                0.0, 1.0, 0.0, 0.0,   0.0,   // G_out = G_in
+                1.0, 0.0, 0.0, 0.0,   0.0,   // B_out = R_in
+                0.0, 0.0, 0.0, 1.0,   0.0,   // A_out = A_in
+            ],
+        };
+
+        let bounds = full_surface_bounds();
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save_layer_with_filter(None, LayerFilter::ColorMatrix(swap_rb.values));
+        painter.rect(bounds, &Paint::fill(source_color));
+        painter.restore_layer();
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_tex),
+                &mut encoder,
+            )
+            .expect("swap-R↔B filter render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let readback = readback_pixels(&device, &queue, &surface_tex);
+
+        // Oracle: apply the CPU swap-R↔B matrix to the straight-alpha source.
+        let expected = color_matrix_oracle(&swap_rb, [200.0 / 255.0, 0.0, 0.0, 1.0]);
+
+        // ±2: GPU u8 quantization at offscreen boundary.
+        assert_interior_pixels_near("F2 swap-R↔B", &readback, expected, 2);
+    }
+
+    // ── F3: Translucent premul roundtrip ─────────────────────────────────────
+
+    /// F3: An identity matrix applied to a 50%-alpha source must preserve
+    /// both the color channels and the alpha, proving the unpremultiply →
+    /// (identity) matrix → clamp → repremultiply cycle is numerically stable
+    /// for translucent inputs.
+    ///
+    /// **Proves:**
+    /// - Divide-by-alpha guard in the shader handles `alpha ≠ 1` without NaN or
+    ///   division by zero.
+    /// - For `alpha = 0.5`, `straight = premul / 0.5` is exact in f32 for the
+    ///   tested colors; identity matrix leaves straight unchanged; re-premul gives
+    ///   back the original premul value within quantisation.
+    ///
+    /// **Fails if:** the shader skips the unpremultiply step (straight≠premul for
+    /// alpha<1, so the matrix then operates on the wrong values and the output
+    /// color channels are scaled incorrectly).
+    #[test]
+    fn identity_filter_preserves_translucent_premul_value() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_surface(&device);
+
+        // Transparent black backdrop — so compositing only sees the layer.
+        clear_surface(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 0.0,
+            },
+        );
+
+        // Source: 50% alpha green — chosen so straight = (0, 1, 0, 0.5),
+        // premul = (0, 128, 0, 128) in u8.
+        let source_color = Color::rgba(0, 255, 0, 128);
+
+        let bounds = full_surface_bounds();
+        let identity = ColorMatrix::identity();
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save_layer_with_filter(None, LayerFilter::ColorMatrix(identity.values));
+        painter.rect(bounds, &Paint::fill(source_color));
+        painter.restore_layer();
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_tex),
+                &mut encoder,
+            )
+            .expect("translucent filter render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let readback = readback_pixels(&device, &queue, &surface_tex);
+
+        // Oracle: identity matrix on (0, 1, 0, 0.5) straight → same straight →
+        // repremul → (0 * 0.5, 1 * 0.5, 0 * 0.5, 0.5) = (0, 0.5, 0, 0.5)
+        // → u8: (0, 128, 0, 128).
+        let expected = color_matrix_oracle(&identity, [0.0, 1.0, 0.0, 128.0 / 255.0]);
+
+        // ±3: offscreen boundary premul quantization for translucent pixels
+        // incurs one extra rounding step vs. opaque paths.
+        assert_interior_pixels_near("F3 translucent premul", &readback, expected, 3);
+    }
+
+    // ── F4: Asymmetric matrix (catches the transpose bug) ─────────────────────
+
+    /// F4: `ColorMatrix::saturation(0.0)` (grayscale) applied to opaque red must
+    /// produce gray ≈ (45, 45, 45, 255), NOT greenish (54, 182, 18, 255).
+    ///
+    /// The saturation-0 matrix is severely asymmetric: off-diagonal weights differ
+    /// dramatically above and below the diagonal (luminance coefficients
+    /// 0.2126/0.7152/0.0722 are on the R-row, not the columns).
+    ///
+    /// **The transpose bug would produce:** applying the transposed matrix to red
+    /// (1,0,0,1) reads column 0 of the transposed matrix = row 0 of M.  With
+    /// saturation=0 the transposed column 0 = (0.2126, 0.2126, 0.2126, 0) which
+    /// happens to give the correct R value — but columns 1,2,3 are wrong:
+    /// column 1 = (0.7152, 0.7152, 0.7152, 0) → applies G-weight to every channel.
+    /// Since source G=0 and B=0, only R contributes; with Mᵀ: the output for red
+    /// would be (0.2126, 0.2126, 0.2126, 1) which is accidentally correct for this
+    /// specific input.
+    ///
+    /// Opaque green is NOT differentiating (saturation(0) sends it to gray under both
+    /// M and Mᵀ — column 1 of Mᵀ equals row 1 of M, the all-G-out row). The truly
+    /// differentiating input is a mixed color, e.g. warm orange (R=200, G=80, B=0):
+    ///
+    /// ```text
+    /// Correct    M·v:  R_out = 0.2126*R + 0.7152*G + 0.0722*B ≈ 0.391
+    ///                  → all channels equal → gray (0.391, 0.391, 0.391, 1)
+    /// Transposed Mᵀ·v: R_out = 0.2126*(R+G+B) ≈ 0.233, G_out = 0.7152*(R+G+B) ≈ 0.785
+    ///                  → NOT gray, channels diverge (proves the transpose)
+    /// ```
+    ///
+    /// **Fails if:** `from_values` packs rows instead of columns (transpose bug).
+    #[test]
+    fn saturation_zero_on_mixed_color_produces_gray() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_surface(&device);
+
+        clear_surface(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 1.0,
+            },
+        );
+
+        // Mixed warm color: R=200, G=80, B=0, A=255.
+        // With the correct matrix all RGB channels become equal (gray).
+        // With the transposed matrix G would be ~3x brighter than R and B —
+        // the assertion below catches that asymmetry.
+        let source_color = Color::rgba(200, 80, 0, 255);
+        let grayscale_matrix = ColorMatrix::saturation(0.0);
+
+        let bounds = full_surface_bounds();
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save_layer_with_filter(None, LayerFilter::ColorMatrix(grayscale_matrix.values));
+        painter.rect(bounds, &Paint::fill(source_color));
+        painter.restore_layer();
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_tex),
+                &mut encoder,
+            )
+            .expect("saturation-0 filter render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let readback = readback_pixels(&device, &queue, &surface_tex);
+
+        // CPU oracle: apply saturation(0) to the straight source.
+        let expected =
+            color_matrix_oracle(&grayscale_matrix, [200.0 / 255.0, 80.0 / 255.0, 0.0, 1.0]);
+
+        // The three RGB channels of the oracle must be equal (grayscale invariant).
+        assert_eq!(
+            expected[0], expected[1],
+            "oracle: grayscale must produce equal R and G channels"
+        );
+        assert_eq!(
+            expected[1], expected[2],
+            "oracle: grayscale must produce equal G and B channels"
+        );
+
+        // ±3: tolerates GPU u8 quantisation at the offscreen boundary.
+        assert_interior_pixels_near("F4 saturation(0) on warm color", &readback, expected, 3);
+    }
+
+    // ── F5: Non-identity matrix on translucent input ──────────────────────────
+
+    /// F5: `ColorMatrix::brightness(0.3)` applied to 50%-alpha green must produce
+    /// the oracle value, not one that skipped the unpremultiply step.
+    ///
+    /// **Proves (combined):**
+    /// - The unpremultiply → asymmetric-matrix → clamp → repremultiply cycle is
+    ///   correct for translucent inputs.
+    /// - The brightness matrix is NOT the identity, so this catches both the
+    ///   premul error and any uniform-packing error simultaneously.
+    ///
+    /// **What the premul bug would produce (skipping unpremultiply):**
+    /// Input premul = (0, 0.5, 0, 0.5).  Brightness adds +0.3 to each RGB channel.
+    /// If the shader operates on premul instead of straight:
+    ///   out = clamp((0,0.5,0,0.5) + (0.3,0.3,0.3,0)) = (0.3, 0.8, 0.3, 0.5)
+    ///   repremul G = 0.8 * 0.5 = 0.4.
+    /// Correct (operate on straight (0,1,0,0.5) then repremul):
+    ///   out_straight = (0.3, 1.3→clamp→1.0, 0.3, 0.5)
+    ///   repremul G = 1.0 * 0.5 = 0.5.
+    /// The two values differ by 0.1 → ~25 u8 units, well above tolerance.
+    ///
+    /// **Fails if:** the shader applies the matrix to the premultiplied value
+    /// instead of the straight-alpha value.
+    #[test]
+    fn brightness_filter_on_translucent_green_matches_oracle() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_surface(&device);
+
+        clear_surface(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 0.0,
+            },
+        );
+
+        // Source: 50% alpha green.  Premul = (0, 128, 0, 128) in u8.
+        let source_color = Color::rgba(0, 255, 0, 128);
+        let brightness_matrix = ColorMatrix::brightness(0.3);
+
+        let bounds = full_surface_bounds();
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save_layer_with_filter(None, LayerFilter::ColorMatrix(brightness_matrix.values));
+        painter.rect(bounds, &Paint::fill(source_color));
+        painter.restore_layer();
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_tex),
+                &mut encoder,
+            )
+            .expect("brightness-on-translucent render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let readback = readback_pixels(&device, &queue, &surface_tex);
+
+        // Oracle: brightness on straight (0, 1, 0, 0.5).
+        let expected = color_matrix_oracle(&brightness_matrix, [0.0, 1.0, 0.0, 128.0 / 255.0]);
+
+        // ±4: translucent offscreen + clamping introduces one extra quantisation step.
+        assert_interior_pixels_near(
+            "F5 brightness(+0.3) on translucent green",
+            &readback,
+            expected,
+            4,
+        );
+    }
+
+    // ── F6: Nested filter inside opacity layer (opacity semantics) ─────────────
+
+    /// F6: A filter layer nested inside an outer opacity-0.5 layer must composite
+    /// at the parent's opacity (0.5), not at 1.0.
+    ///
+    /// **Proves:** `save_layer_with_filter` calls `effective_layer_opacity(1.0)`
+    /// which multiplies 1.0 by the current ancestor opacity — correctly inheriting
+    /// the parent's opacity rather than overriding it.
+    ///
+    /// **Fails if:** the filter layer ignores the parent opacity and composites at
+    /// full opacity (output alpha would be ~255 instead of ~128 for opaque content).
+    #[test]
+    fn filter_layer_inherits_outer_opacity() {
+        use flui_types::painting::BlendMode;
+
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_surface(&device);
+
+        // Transparent black backdrop.
+        clear_surface(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 0.0,
+            },
+        );
+
+        // Draw: outer opacity-0.5 saveLayer → identity-filter saveLayer → opaque red rect.
+        let bounds = full_surface_bounds();
+        let source_color = Color::rgba(255, 0, 0, 255);
+        let identity = ColorMatrix::identity();
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        let outer_paint = Paint::fill(Color::WHITE)
+            .with_blend_mode(BlendMode::SrcOver)
+            .with_opacity(0.5);
+        painter.save_layer(Some(bounds), &outer_paint);
+        painter.save_layer_with_filter(None, LayerFilter::ColorMatrix(identity.values));
+        painter.rect(bounds, &Paint::fill(source_color));
+        painter.restore_layer(); // pop filter layer
+        painter.restore_layer(); // pop opacity layer
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_tex),
+                &mut encoder,
+            )
+            .expect("nested filter+opacity render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let readback = readback_pixels(&device, &queue, &surface_tex);
+
+        // The outer opacity layer composites at 0.5, so the output alpha should
+        // be approximately 128 (50% of 255).  If the filter layer ignores parent
+        // opacity, alpha would be ~255.
+        let width = SURFACE_WIDTH as usize;
+        let height = SURFACE_HEIGHT as usize;
+        for (pixel_index, &pixel) in readback.iter().enumerate() {
+            let row = pixel_index / width;
+            let col = pixel_index % width;
+            if row == 0 || row >= height - 1 || col == 0 || col >= width - 1 {
+                continue;
+            }
+            let alpha = pixel[3];
+            assert!(
+                alpha < 200,
+                "F6: pixel {pixel_index} alpha={alpha} — filter layer must \
+                 inherit outer opacity=0.5 (expected alpha ≈ 128, not full 255)"
+            );
+            assert!(
+                alpha > 50,
+                "F6: pixel {pixel_index} alpha={alpha} — expected alpha ≈ 128, not 0"
+            );
+        }
+    }
+}

--- a/crates/flui-engine/src/wgpu/command_ir.rs
+++ b/crates/flui-engine/src/wgpu/command_ir.rs
@@ -25,6 +25,34 @@ use super::{
     vertex::Vertex,
 };
 
+// ─── Layer filter ────────────────────────────────────────────────────────────
+
+/// A pixel-level filter applied to the rendered content of an offscreen layer
+/// before it is composited onto its parent surface.
+///
+/// The filter is applied during `flush_opacity_layer`, immediately after
+/// `render_layer_to_offscreen` completes, by a full-screen quad pass that reads
+/// the layer offscreen and writes into a separate pooled texture (ping-pong
+/// avoiding read/write aliasing).  The filtered texture is then forwarded into
+/// both composite arms in place of the raw offscreen.
+///
+/// ## Correctness invariant — premultiplied alpha
+///
+/// The layer offscreen is premultiplied RGBA.  The `ColorMatrix` variant stores
+/// values that operate on **straight** (un-premultiplied) RGBA, matching
+/// [`flui_types::painting::ColorMatrix::apply`].  The GPU shader MUST
+/// unpremultiply before the matrix, clamp each output channel to `[0, 1]`,
+/// and repremultiply before writing, producing the identical result the CPU oracle
+/// would return for each pixel.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum LayerFilter {
+    /// A 5×4 row-major color matrix applied per-pixel on un-premultiplied color.
+    ///
+    /// Layout mirrors [`flui_types::painting::ColorMatrix::values`]:
+    /// rows R/G/B/A × columns `[m0..m3, offset]`.
+    ColorMatrix([f32; 20]),
+}
+
 // ─── Primitive helpers ────────────────────────────────────────────────────────
 
 /// Scissor rect type (x, y, width, height) in physical pixels.
@@ -104,6 +132,12 @@ pub(crate) struct SavedLayer {
     /// Stored on the record side so the compositor dispatch can read it without
     /// coupling the flush path to the record path.  Defaults to `SrcOver`.
     pub(crate) layer_blend: BlendMode,
+    /// Optional per-pixel filter applied to the rendered layer before compositing.
+    ///
+    /// `None` = today's behavior (premultiplied tint-only composite).
+    /// `Some(LayerFilter::ColorMatrix(_))` routes the rendered offscreen through
+    /// the color-matrix GPU pass before the composite step.
+    pub(crate) filter: Option<LayerFilter>,
 }
 
 // ─── Draw segment ─────────────────────────────────────────────────────────────
@@ -396,4 +430,9 @@ pub(crate) struct PendingOpacityLayer {
     /// coupling it to the record path.  `SrcOver` for plain opacity layers;
     /// an advanced mode for `saveLayer` with an explicit blend mode.
     pub(crate) blend: BlendMode,
+    /// Optional per-pixel filter applied to the rendered layer before compositing.
+    ///
+    /// Forwarded from [`SavedLayer::filter`] at restore time.  `None` = plain
+    /// tint-only composite (existing behavior).
+    pub(crate) filter: Option<LayerFilter>,
 }

--- a/crates/flui-engine/src/wgpu/layer_blend_tests.rs
+++ b/crates/flui-engine/src/wgpu/layer_blend_tests.rs
@@ -57,6 +57,7 @@ mod unit_tests {
             [1.0, 1.0, 1.0],     // white tint — old code only checked opacity + chroma
             BlendMode::Multiply, // advanced — the new gate condition
             None,
+            None, // no LayerFilter
         );
         let outcome = compositor.pop_layer(DrawSegment::new(), one_draw_item(), Rect::default());
         assert!(
@@ -81,6 +82,7 @@ mod unit_tests {
             [1.0, 1.0, 1.0],
             BlendMode::SrcOver,
             None,
+            None, // no LayerFilter
         );
         let outcome = compositor.pop_layer(DrawSegment::new(), one_draw_item(), Rect::default());
         assert!(
@@ -142,6 +144,7 @@ mod unit_tests {
                 [1.0, 1.0, 1.0],
                 mode,
                 None,
+                None, // no LayerFilter
             );
             let outcome =
                 compositor.pop_layer(DrawSegment::new(), one_draw_item(), Rect::default());
@@ -160,6 +163,7 @@ mod unit_tests {
                 [1.0, 1.0, 1.0],
                 mode,
                 None,
+                None, // no LayerFilter
             );
             let outcome =
                 compositor.pop_layer(DrawSegment::new(), one_draw_item(), Rect::default());
@@ -204,6 +208,7 @@ mod unit_tests {
             tint_rgb: [1.0, 1.0, 1.0],
             blend: BlendMode::Multiply,
             bounds: Rect::default(),
+            filter: None,
         };
         assert!(
             layer.blend.is_advanced(),
@@ -222,6 +227,7 @@ mod unit_tests {
             tint_rgb: [1.0, 1.0, 1.0],
             blend: BlendMode::SrcOver,
             bounds: Rect::default(),
+            filter: None,
         };
         assert!(
             !layer.blend.is_advanced(),

--- a/crates/flui-engine/src/wgpu/layer_compositor.rs
+++ b/crates/flui-engine/src/wgpu/layer_compositor.rs
@@ -25,7 +25,7 @@ use flui_types::Rect;
 use flui_types::geometry::Pixels;
 use flui_types::painting::BlendMode;
 
-use super::command_ir::{DrawItem, DrawSegment, SavedLayer};
+use super::command_ir::{DrawItem, DrawSegment, LayerFilter, SavedLayer};
 
 /// Outcome returned by [`LayerCompositor::pop_layer`].
 ///
@@ -54,6 +54,11 @@ pub(super) enum RestoreOutcome {
         /// `SrcOver` for plain opacity layers; an advanced mode (e.g. Multiply)
         /// for layers opened with an explicit blend mode via `save_layer`.
         layer_blend: BlendMode,
+        /// Optional per-pixel GPU filter applied before compositing.
+        ///
+        /// Forwarded from [`SavedLayer::filter`] so the painter can pass it into
+        /// [`super::command_ir::PendingOpacityLayer`] without coupling the flush path.
+        layer_filter: Option<LayerFilter>,
         /// Parent segment saved before `save_layer` — splice back into `current_segment`.
         saved_segment: DrawSegment,
         /// Parent draw order saved before `save_layer` — splice back into `draw_order`.
@@ -190,6 +195,12 @@ impl LayerCompositor {
     ///
     /// After this call `current_opacity` is `1.0`; children inside the layer
     /// draw at full opacity and group opacity is applied during compositing.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "all arguments are load-bearing: draw-order snapshot, opacity, tint, blend, \
+                  bounds, and filter must all be stored on the SavedLayer; the alternative \
+                  (a builder struct) adds complexity without a semantic boundary"
+    )]
     pub(super) fn push_layer(
         &mut self,
         saved_draw_order: Vec<DrawItem>,
@@ -198,6 +209,7 @@ impl LayerCompositor {
         layer_tint_rgb: [f32; 3],
         layer_blend: BlendMode,
         bounds: Option<[f32; 4]>,
+        filter: Option<LayerFilter>,
     ) {
         let saved = SavedLayer {
             saved_draw_order,
@@ -208,6 +220,7 @@ impl LayerCompositor {
             layer_tint_rgb,
             layer_blend,
             bounds,
+            filter,
         };
         self.layer_stack.push(saved);
 
@@ -285,12 +298,18 @@ impl LayerCompositor {
         // path even at opacity=1.0 and white tint, because the reintegrate path
         // splices children unchanged into the parent draw order — silently dropping
         // the blend.
+        //
+        // A LayerFilter ALWAYS forces the composite path: the filter must run on
+        // the rendered offscreen before pixels reach the parent, which the
+        // reintegrate path cannot do (it inserts content directly into the parent
+        // draw order without an offscreen round-trip).
         let has_chroma = (saved.layer_tint_rgb[0] - 1.0).abs() > f32::EPSILON
             || (saved.layer_tint_rgb[1] - 1.0).abs() > f32::EPSILON
             || (saved.layer_tint_rgb[2] - 1.0).abs() > f32::EPSILON;
         let needs_composite = (1.0 - saved.layer_opacity).abs() > f32::EPSILON
             || has_chroma
-            || saved.layer_blend.is_advanced();
+            || saved.layer_blend.is_advanced()
+            || saved.filter.is_some();
 
         if needs_composite {
             RestoreOutcome::Composite {
@@ -300,6 +319,7 @@ impl LayerCompositor {
                 tint_rgb: saved.layer_tint_rgb,
                 composite_bounds,
                 layer_blend: saved.layer_blend,
+                layer_filter: saved.filter,
                 saved_segment: saved.saved_segment,
                 saved_draw_order: saved.saved_draw_order,
             }
@@ -355,6 +375,7 @@ mod tests {
             [1.0, 1.0, 1.0],
             BlendMode::SrcOver,
             None,
+            None, // no LayerFilter
         );
         compositor.debug_assert_balanced();
     }
@@ -376,6 +397,7 @@ mod tests {
             [1.0, 1.0, 1.0],
             BlendMode::SrcOver,
             None,
+            None, // no LayerFilter
         );
         // Inside the layer, children draw at full opacity.
         assert!((compositor.current_opacity() - 1.0).abs() < f32::EPSILON);
@@ -395,6 +417,7 @@ mod tests {
             [1.0, 1.0, 1.0],
             BlendMode::SrcOver,
             None,
+            None, // no LayerFilter
         );
         // Children inside the layer draw at full opacity.
         assert!((compositor.current_opacity() - 1.0).abs() < f32::EPSILON);
@@ -411,6 +434,7 @@ mod tests {
             [1.0, 1.0, 1.0],
             BlendMode::SrcOver,
             None,
+            None, // no LayerFilter
         );
         let _ = compositor.pop_layer(DrawSegment::new(), Vec::new(), rect_bounds_100());
         assert!((compositor.current_opacity() - 0.8).abs() < f32::EPSILON);
@@ -426,6 +450,7 @@ mod tests {
             [1.0, 1.0, 1.0],
             BlendMode::SrcOver,
             None,
+            None, // no LayerFilter
         );
         let outcome = compositor.pop_layer(DrawSegment::new(), Vec::new(), rect_bounds_100());
         assert!(matches!(outcome, RestoreOutcome::Empty { .. }));
@@ -441,6 +466,7 @@ mod tests {
             [1.0, 1.0, 1.0],
             BlendMode::SrcOver,
             None,
+            None, // no LayerFilter
         );
         let outcome = compositor.pop_layer(segment_with_one_rect(), Vec::new(), rect_bounds_100());
         assert!(matches!(outcome, RestoreOutcome::Composite { .. }));
@@ -456,6 +482,7 @@ mod tests {
             [0.0, 0.0, 1.0], // blue tint → has_chroma
             BlendMode::SrcOver,
             None,
+            None, // no LayerFilter
         );
         let outcome = compositor.pop_layer(segment_with_one_rect(), Vec::new(), rect_bounds_100());
         assert!(
@@ -474,6 +501,7 @@ mod tests {
             [1.0, 1.0, 1.0], // white tint → no chroma
             BlendMode::SrcOver,
             None,
+            None, // no LayerFilter
         );
         let outcome = compositor.pop_layer(segment_with_one_rect(), Vec::new(), rect_bounds_100());
         assert!(

--- a/crates/flui-engine/src/wgpu/mod.rs
+++ b/crates/flui-engine/src/wgpu/mod.rs
@@ -67,6 +67,12 @@ mod backend;
 /// from the flush-side state during draw recording.
 mod batches;
 mod buffer_pool;
+/// Per-pixel 5×4 color-matrix filter pass: [`color_matrix::apply_color_matrix`]
+/// applies a [`command_ir::LayerFilter::ColorMatrix`] to a premultiplied layer
+/// offscreen via ping-pong into a 2nd pooled texture, then returns the filtered
+/// texture for compositing.  [`color_matrix::ColorMatrixPipeline`] owns the
+/// pipeline and bind-group layout.
+pub(crate) mod color_matrix;
 /// Command IR data types: `DrawSegment`, `DrawItem`, `SavedLayer`,
 /// `PendingOpacityLayer`, `PendingOffscreenTexture`, and their helpers
 /// (`ScissorRect`, `ScissorRegion`, `TessellatedBatch`). Moved here from
@@ -198,6 +204,11 @@ mod shape_blend_tests;
 // PR-5 unit tests (G1-G6) are inline in batches/mod.rs.
 #[cfg(all(test, feature = "enable-wgpu-tests"))]
 mod gradient_image_blend_tests;
+
+// color_matrix_filter_tests contains F1-F3 GPU readback tests for the
+// color-matrix filter pass (identity, swap-R↔B, translucent premul roundtrip).
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+mod color_matrix_filter_tests;
 
 // ============================================================================
 // PUBLIC API

--- a/crates/flui-engine/src/wgpu/opacity_layer.rs
+++ b/crates/flui-engine/src/wgpu/opacity_layer.rs
@@ -34,7 +34,8 @@ use std::sync::Arc;
 
 use super::{
     advanced_blend::{AdvancedBlendOp, flush_advanced_layer},
-    command_ir::{DrawItem, DrawSegment, PendingOpacityLayer},
+    color_matrix::apply_color_matrix,
+    command_ir::{DrawItem, DrawSegment, LayerFilter, PendingOpacityLayer},
     pipelines::PipelineSet,
     render_target::RenderTarget,
     replay::GpuReplay,
@@ -427,7 +428,7 @@ impl GpuReplay {
             return;
         }
 
-        let offscreen = self.render_layer_to_offscreen(
+        let layer_tex = self.render_layer_to_offscreen(
             &mut layer,
             viewport_size,
             surface_format,
@@ -437,6 +438,35 @@ impl GpuReplay {
             resources,
             encoder,
         );
+
+        // ── Color-matrix filter pass (ping-pong) ─────────────────────────────
+        //
+        // If the layer carries a `LayerFilter::ColorMatrix`, apply it now:
+        // `layer_tex` (premultiplied offscreen) → `offscreen` (filtered premultiplied).
+        // The shader unpremultiplies, applies the 5×4 matrix, clamps, re-premultiplies.
+        // The original `layer_tex` is dropped here (returns to pool).
+        //
+        // If no filter is present, `offscreen` aliases `layer_tex` directly —
+        // zero-cost (no copy, no extra texture acquisition).
+        let offscreen = if let Some(LayerFilter::ColorMatrix(matrix_values)) = layer.filter {
+            tracing::trace!(
+                bounds = ?layer.bounds,
+                "GpuReplay: applying color-matrix filter before composite"
+            );
+            apply_color_matrix(
+                matrix_values,
+                &layer_tex,
+                viewport_size,
+                surface_format,
+                &pipelines.color_matrix,
+                resources,
+                device,
+                encoder,
+            )
+            // layer_tex dropped here — returns to pool.
+        } else {
+            layer_tex
+        };
 
         // ── Advanced-blend dispatch (DECISION 1 / CRITICAL GATE) ────────────
         //

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -12,7 +12,8 @@ use std::sync::Arc;
 
 use super::{
     command_ir::{
-        DrawItem, DrawSegment, PendingOffscreenTexture, PendingOpacityLayer, ScissorRect,
+        DrawItem, DrawSegment, LayerFilter, PendingOffscreenTexture, PendingOpacityLayer,
+        ScissorRect,
     },
     layer_compositor::{LayerCompositor, RestoreOutcome},
     pipelines::PipelineSet,
@@ -1229,7 +1230,13 @@ impl WgpuPainter {
         // on the saveLayer paint means the entire layer composites onto its
         // parent with that mode — the dominant real-world use case for
         // advanced blend.
-        self.save_layer_impl(bounds, layer_opacity, [1.0, 1.0, 1.0], paint.blend_mode);
+        self.save_layer_impl(
+            bounds,
+            layer_opacity,
+            [1.0, 1.0, 1.0],
+            paint.blend_mode,
+            None,
+        );
     }
 
     /// Like [`Self::save_layer`] but applies an explicit per-channel chroma
@@ -1262,18 +1269,50 @@ impl WgpuPainter {
             layer_opacity,
             tint,
             flui_types::painting::BlendMode::SrcOver,
+            None, // no LayerFilter — tint carries the color
+        );
+    }
+
+    /// Like [`Self::save_layer`] but routes the layer through a per-pixel GPU
+    /// filter (currently only [`LayerFilter::ColorMatrix`]) before compositing.
+    ///
+    /// The filter is applied AFTER `render_layer_to_offscreen` and BEFORE the
+    /// composite step, so it receives the fully-rendered premultiplied offscreen
+    /// and emits a filtered premultiplied texture.  Opacity and blend mode carry
+    /// through normally.
+    ///
+    /// Used by `push_color_filter` and the `Matrix`/`ColorAdjust` branches of
+    /// `push_image_filter` in `backend.rs`.
+    pub(crate) fn save_layer_with_filter(
+        &mut self,
+        bounds: Option<Rect<Pixels>>,
+        filter: LayerFilter,
+    ) {
+        // Filter layers composite with white tint and SrcOver.  `effective_layer_opacity(1.0)`
+        // multiplies 1.0 by the current ancestor opacity, so a filter layer nested inside an
+        // outer opacity layer correctly inherits that opacity — matching Flutter semantics where
+        // a color-filter saveLayer respects the parent's opacity.
+        let layer_opacity = self.compositor.effective_layer_opacity(1.0);
+        self.save_layer_impl(
+            bounds,
+            layer_opacity,
+            [1.0, 1.0, 1.0],
+            flui_types::painting::BlendMode::SrcOver,
+            Some(filter),
         );
     }
 
     /// Shared implementation for [`Self::save_layer`] /
-    /// [`Self::save_layer_with_tint`]: snapshot the draw state and push a layer
-    /// with the given composite `layer_opacity`, `layer_tint_rgb`, and `layer_blend`.
+    /// [`Self::save_layer_with_tint`] / [`Self::save_layer_with_filter`]:
+    /// snapshot the draw state and push a layer with the given composite
+    /// `layer_opacity`, `layer_tint_rgb`, `layer_blend`, and optional GPU filter.
     fn save_layer_impl(
         &mut self,
         bounds: Option<Rect<Pixels>>,
         layer_opacity: f32,
         layer_tint_rgb: [f32; 3],
         layer_blend: flui_types::painting::BlendMode,
+        filter: Option<LayerFilter>,
     ) {
         // Convert bounds to [x, y, w, h] if provided.
         let bounds_array = bounds.map(|r| [r.left().0, r.top().0, r.width().0, r.height().0]);
@@ -1289,13 +1328,16 @@ impl WgpuPainter {
             layer_tint_rgb,
             layer_blend,
             bounds_array,
+            filter,
         );
 
         tracing::trace!(
-            "WgpuPainter::save_layer: layer_opacity={:.3}, tint={:?}, blend={:?}, bounds={:?}",
+            "WgpuPainter::save_layer: layer_opacity={:.3}, tint={:?}, blend={:?}, \
+             filter={:?}, bounds={:?}",
             layer_opacity,
             layer_tint_rgb,
             layer_blend,
+            filter,
             bounds_array
         );
     }
@@ -1329,6 +1371,7 @@ impl WgpuPainter {
                 tint_rgb,
                 composite_bounds,
                 layer_blend,
+                layer_filter,
                 saved_segment,
                 saved_draw_order,
             } => {
@@ -1343,6 +1386,7 @@ impl WgpuPainter {
                 // `(C.r*O, C.g*O, C.b*O, O)` — correct group opacity AND chroma.
                 // Advanced blend modes are carried via `blend` and dispatched by
                 // `flush_opacity_layer` through the dst-read compositor path.
+                // `filter` carries the color-matrix GPU pass when set.
 
                 // Finalize the current parent segment so the opacity layer is
                 // inserted at the correct Z-position in the draw order.
@@ -1360,14 +1404,16 @@ impl WgpuPainter {
                         tint_rgb,
                         bounds: composite_bounds,
                         blend: layer_blend,
+                        filter: layer_filter,
                     }));
 
                 tracing::trace!(
                     "WgpuPainter::restore_layer: queued OpacityLayer \
-                     (opacity={:.3}, tint_rgb={:?}, blend={:?}, bounds={:?})",
+                     (opacity={:.3}, tint_rgb={:?}, blend={:?}, filter={:?}, bounds={:?})",
                     layer_opacity,
                     tint_rgb,
                     layer_blend,
+                    layer_filter,
                     composite_bounds
                 );
             }

--- a/crates/flui-engine/src/wgpu/pipelines.rs
+++ b/crates/flui-engine/src/wgpu/pipelines.rs
@@ -59,6 +59,7 @@ use flui_types::painting::BlendMode;
 
 use super::{
     advanced_blend::AdvancedBlendPipeline,
+    color_matrix::ColorMatrixPipeline,
     pipeline::{PipelineCache, blend_state_for},
     ssaa::SsaaDownsamplePipeline,
 };
@@ -159,6 +160,14 @@ pub(crate) struct PipelineSet {
     /// Format-matched to `surface_format` at construction time; shared across
     /// every `flush_advanced_layer` call for this painter.
     pub(crate) advanced_blend: AdvancedBlendPipeline,
+
+    // ── Color-matrix filter pipeline ─────────────────────────────────────────
+    /// Per-pixel 5×4 color-matrix filter pipeline used by `flush_opacity_layer`
+    /// when a `PendingOpacityLayer` carries a `LayerFilter::ColorMatrix`.
+    ///
+    /// Format-matched to `surface_format` at construction time; shared across
+    /// every `apply_color_matrix` call for this painter.
+    pub(crate) color_matrix: ColorMatrixPipeline,
 
     // ── SSAA box-downsample pipeline ─────────────────────────────────────────
     /// 2×→1× box-filter downsample pipeline for SSAA path anti-aliasing.
@@ -281,6 +290,7 @@ impl PipelineSet {
         );
 
         let advanced_blend = AdvancedBlendPipeline::new(device, surface_format);
+        let color_matrix = ColorMatrixPipeline::new(device, surface_format);
         let ssaa_downsample = SsaaDownsamplePipeline::new(device, surface_format);
 
         // ── SSAA tile composite: shared layout + lazy pipeline cache ──────────
@@ -314,6 +324,7 @@ impl PipelineSet {
             gradient_stops_buffer,
             gradient_bind_group: None,
             advanced_blend,
+            color_matrix,
             ssaa_downsample,
             ssaa_tile_composite_layout,
             ssaa_tile_surface_format: surface_format,

--- a/crates/flui-engine/src/wgpu/shaders/effects/color_matrix.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/effects/color_matrix.wgsl
@@ -1,0 +1,117 @@
+// color_matrix.wgsl
+//
+// Per-pixel 5×4 color-matrix filter applied to a premultiplied layer offscreen.
+//
+// ## Correctness contract
+//
+// The layer texture is premultiplied RGBA.  The color-matrix spec (CSS Filter
+// Effects §10.2, `ColorMatrix::apply` in flui-types) operates on **straight**
+// (un-premultiplied) RGBA.  This shader therefore:
+//
+//   1. Samples the source texel `t` (premultiplied RGBA).
+//   2. Un-premultiplies: straight = t.rgb / t.a  (guard: if t.a == 0 → vec3(0)).
+//   3. Applies the 5×4 color matrix on straight RGBA:
+//        out.r = dot(M_row0, vec4(r,g,b,a)) + offset.r
+//        out.g = dot(M_row1, vec4(r,g,b,a)) + offset.g
+//        out.b = dot(M_row2, vec4(r,g,b,a)) + offset.b
+//        out.a = dot(M_row3, vec4(r,g,b,a)) + offset.a
+//      (u.m is uploaded as the columns of M so that `u.m * straight` computes
+//       the row dot-products via WGSL's column-major mat*vec.)
+//   4. Clamps every output channel to [0, 1].
+//   5. Re-premultiplies: out.rgb *= out.a
+//   6. Emits with BlendState::REPLACE (no fixed-function blending).
+//
+// This sequence is bit-identical to `ColorMatrix::apply` on the straight color.
+//
+// ## Bind-group layout (group 0)
+//
+// | Binding | Stage | Type                  | Content                      |
+// |---------|-------|-----------------------|------------------------------|
+// | 0       | FS    | Uniform buffer        | `ColorMatrixUniforms`        |
+// | 1       | FS    | 2D float texture      | Source layer (premultiplied) |
+// | 2       | FS    | Non-filtering sampler | Nearest + ClampToEdge        |
+//
+// ## Vertex stage
+//
+// No vertex buffer.  The VS synthesises 6 vertices from @builtin(vertex_index)
+// covering the full viewport ([0,0]→[1,1] NDC quad, two triangles).
+
+// ─── Uniforms ────────────────────────────────────────────────────────────────
+
+// WGSL uniform-block layout (§13.4.1 / WebGPU §3.13.3):
+//   mat4x4<f32>  →  64 bytes (align 16)
+//   vec4<f32>    →  16 bytes (align 16)
+// Total: 80 bytes (multiple of 16 ✓).
+//
+// Rust side: `ColorMatrixUniform { m: [[f32;4];4], offset: [f32;4] }` = 80 bytes.
+// `m[i]` is COLUMN i of the weight matrix M (see `ColorMatrixUniform::from_values`).
+// Because WGSL `mat4x4<f32>` is column-major, the Rust `[[f32;4];4]` blocks are
+// read as columns.  Packing column i of M into m[i] means WGSL's `u.m` equals M,
+// and `u.m * straight` computes the correct row dot-products.
+struct ColorMatrixUniforms {
+    /// Columns 0..3 of the 4×4 weight matrix M.
+    /// WGSL reads each [f32;4] block as a column, so u.m == M.
+    m: mat4x4<f32>,
+    /// Additive bias for each output channel (R/G/B/A).
+    offset: vec4<f32>,
+}
+
+@group(0) @binding(0)
+var<uniform> u: ColorMatrixUniforms;
+
+@group(0) @binding(1)
+var src_texture: texture_2d<f32>;
+
+@group(0) @binding(2)
+var src_sampler: sampler;
+
+// ─── Vertex stage ─────────────────────────────────────────────────────────────
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0)       uv:       vec2<f32>,
+}
+
+// Full-viewport quad: 6 vertices from vertex_index, two CCW triangles.
+// Covers NDC [(-1,-1)..(1,1)] with UV [(0,0)..(1,1)].
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
+    // Triangle 0: verts 0,1,2  Triangle 1: verts 3,4,5
+    let xs = array<f32,6>(-1.0,  1.0, -1.0,  1.0,  1.0, -1.0);
+    let ys = array<f32,6>(-1.0, -1.0,  1.0, -1.0,  1.0,  1.0);
+    let us = array<f32,6>( 0.0,  1.0,  0.0,  1.0,  1.0,  0.0);
+    let vs = array<f32,6>( 1.0,  1.0,  0.0,  1.0,  0.0,  0.0);
+
+    var out: VertexOutput;
+    out.position = vec4<f32>(xs[vi], ys[vi], 0.0, 1.0);
+    out.uv       = vec2<f32>(us[vi], vs[vi]);
+    return out;
+}
+
+// ─── Fragment stage ───────────────────────────────────────────────────────────
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    // Step 1 — sample the premultiplied source texel.
+    let t: vec4<f32> = textureSample(src_texture, src_sampler, in.uv);
+
+    // Step 2 — un-premultiply (divide-by-zero guard: if α=0 the RGB is black).
+    let straight_rgb: vec3<f32> = select(vec3<f32>(0.0), t.rgb / t.a, t.a > 0.0);
+    let straight: vec4<f32> = vec4<f32>(straight_rgb, t.a);
+
+    // Step 3 — apply the 5×4 matrix on straight RGBA.
+    //   u.m is mat4x4<f32> whose column i was packed with column i of M on the
+    //   Rust side (see ColorMatrixUniform::from_values).  WGSL column-major
+    //   mat*vec: (u.m * straight)[i] = Σ_j u.m[j][i] * straight[j]
+    //                                = Σ_j M[i,j] * straight[j]   ✓ (row dot-product)
+    let out_straight: vec4<f32> = u.m * straight + u.offset;
+
+    // Step 4 — clamp every output channel to [0, 1].
+    let clamped: vec4<f32> = clamp(out_straight, vec4<f32>(0.0), vec4<f32>(1.0));
+
+    // Step 5 — re-premultiply: rgb *= a.
+    let out_rgb: vec3<f32> = clamped.rgb * clamped.a;
+
+    // Step 6 — emit premultiplied RGBA (BlendState::REPLACE, no HW blending).
+    return vec4<f32>(out_rgb, clamped.a);
+}

--- a/crates/flui-types/src/painting/effects.rs
+++ b/crates/flui-types/src/painting/effects.rs
@@ -279,6 +279,38 @@ impl ColorMatrix {
         ])
     }
 
+    /// Create a matrix that scales only the alpha channel by `opacity`.
+    ///
+    /// RGB rows are identity; alpha row is `[0, 0, 0, opacity, 0]`.
+    /// Used to lower a layer's group opacity via the color-matrix GPU pass
+    /// without touching hue or saturation.
+    #[inline]
+    pub fn opacity(opacity: f32) -> Self {
+        Self::new([
+            1.0, 0.0, 0.0, 0.0, 0.0, // R
+            0.0, 1.0, 0.0, 0.0, 0.0, // G
+            0.0, 0.0, 1.0, 0.0, 0.0, // B
+            0.0, 0.0, 0.0, opacity, 0.0, // A
+        ])
+    }
+
+    /// Linearly interpolate between the identity matrix and `other` by `t ∈ [0, 1]`.
+    ///
+    /// `t = 0` → identity; `t = 1` → `other`.  Values are not clamped;
+    /// callers supplying a `t` outside `[0, 1]` get extrapolation.
+    ///
+    /// Used by `ColorAdjustment::to_color_matrix` for the strength-parameterised
+    /// Grayscale/Sepia/Invert variants.
+    #[inline]
+    pub fn lerp_from_identity(other: &ColorMatrix, t: f32) -> Self {
+        let identity = ColorMatrix::identity();
+        let mut values = [0.0f32; 20];
+        for (i, v) in values.iter_mut().enumerate() {
+            *v = identity.values[i] + (other.values[i] - identity.values[i]) * t;
+        }
+        Self::new(values)
+    }
+
     /// Apply this color matrix to a color.
     ///
     /// # Arguments
@@ -348,6 +380,45 @@ impl Default for ColorMatrix {
     #[inline]
     fn default() -> Self {
         Self::identity()
+    }
+}
+
+impl ColorAdjustment {
+    /// Convert this high-level color adjustment to an equivalent [`ColorMatrix`].
+    ///
+    /// The returned matrix is applied to straight (un-premultiplied) RGBA in `[0, 1]`,
+    /// identical to the GPU color-matrix pass.  CPU callers can use
+    /// [`ColorMatrix::apply`] as the oracle for verifying GPU output.
+    ///
+    /// ## Variant mapping
+    ///
+    /// | Variant | Matrix constructor |
+    /// |---------|-------------------|
+    /// | `Brightness(a)` | `ColorMatrix::brightness(a)` |
+    /// | `Contrast(a)` | `ColorMatrix::contrast(a)` |
+    /// | `Saturation(a)` | `ColorMatrix::saturation(a)` |
+    /// | `HueRotate(deg)` | `ColorMatrix::hue_rotate(deg)` |
+    /// | `Grayscale(t)` | `lerp_from_identity(grayscale, t)` |
+    /// | `Sepia(t)` | `lerp_from_identity(sepia, t)` |
+    /// | `Invert(t)` | `lerp_from_identity(invert, t)` |
+    /// | `Opacity(o)` | `ColorMatrix::opacity(o)` |
+    /// | `Matrix(m)` | `m` verbatim |
+    pub fn to_color_matrix(&self) -> ColorMatrix {
+        match self {
+            ColorAdjustment::Brightness(amount) => ColorMatrix::brightness(*amount),
+            ColorAdjustment::Contrast(amount) => ColorMatrix::contrast(*amount),
+            ColorAdjustment::Saturation(amount) => ColorMatrix::saturation(*amount),
+            ColorAdjustment::HueRotate(degrees) => ColorMatrix::hue_rotate(*degrees),
+            ColorAdjustment::Grayscale(t) => {
+                ColorMatrix::lerp_from_identity(&ColorMatrix::grayscale(), *t)
+            }
+            ColorAdjustment::Sepia(t) => ColorMatrix::lerp_from_identity(&ColorMatrix::sepia(), *t),
+            ColorAdjustment::Invert(t) => {
+                ColorMatrix::lerp_from_identity(&ColorMatrix::invert(), *t)
+            }
+            ColorAdjustment::Opacity(opacity) => ColorMatrix::opacity(*opacity),
+            ColorAdjustment::Matrix(matrix) => matrix.clone(),
+        }
     }
 }
 
@@ -684,5 +755,223 @@ mod tests {
         assert_eq!(options.cap, StrokeCap::Round);
         assert_eq!(options.join, StrokeJoin::Round);
         assert!(options.dash_pattern.is_some());
+    }
+
+    // ── ColorMatrix new helpers ─────────────────────────────────────────────
+
+    /// `ColorMatrix::opacity(o)` only scales the alpha channel; RGB is passthrough.
+    #[test]
+    fn opacity_matrix_scales_alpha_only() {
+        let m = ColorMatrix::opacity(0.5);
+        let input = [0.8, 0.6, 0.4, 1.0];
+        let output = m.apply(input);
+        // RGB must be unchanged.
+        assert!((output[0] - 0.8).abs() < 1e-6, "R unchanged");
+        assert!((output[1] - 0.6).abs() < 1e-6, "G unchanged");
+        assert!((output[2] - 0.4).abs() < 1e-6, "B unchanged");
+        // Alpha halved.
+        assert!((output[3] - 0.5).abs() < 1e-6, "A halved");
+    }
+
+    /// `lerp_from_identity(m, 0.0)` == identity applied to any colour.
+    #[test]
+    fn lerp_from_identity_at_zero_is_identity() {
+        let grayscale = ColorMatrix::grayscale();
+        let lerped = ColorMatrix::lerp_from_identity(&grayscale, 0.0);
+        let color = [0.3, 0.5, 0.9, 0.7];
+        let result = lerped.apply(color);
+        for i in 0..4 {
+            assert!(
+                (result[i] - color[i]).abs() < 1e-5,
+                "channel {i}: expected {}, got {}",
+                color[i],
+                result[i]
+            );
+        }
+    }
+
+    /// `lerp_from_identity(m, 1.0)` == `m` applied to any colour.
+    #[test]
+    fn lerp_from_identity_at_one_equals_full_matrix() {
+        let grayscale = ColorMatrix::grayscale();
+        let lerped = ColorMatrix::lerp_from_identity(&grayscale, 1.0);
+        let color = [1.0, 0.0, 0.0, 1.0]; // red
+        let direct = grayscale.apply(color);
+        let via_lerp = lerped.apply(color);
+        for i in 0..4 {
+            assert!(
+                (via_lerp[i] - direct[i]).abs() < 1e-5,
+                "channel {i}: lerp(1)={} vs direct={}",
+                via_lerp[i],
+                direct[i]
+            );
+        }
+    }
+
+    // ── ColorAdjustment::to_color_matrix ──────────────────────────────────────
+
+    /// Every `ColorAdjustment` variant produces a `ColorMatrix` that materially
+    /// transforms the expected input color in the expected direction.
+    ///
+    /// These are behavioral assertions, not just "no panic" smoke tests.
+    #[test]
+    fn color_adjustment_to_color_matrix_all_variants_have_correct_effect() {
+        // Saturation(0) = grayscale: opaque red → uniform gray ≈ (0.2126, …, 1.0).
+        {
+            let m = ColorAdjustment::Saturation(0.0).to_color_matrix();
+            let out = m.apply([1.0, 0.0, 0.0, 1.0]);
+            assert!(
+                (out[0] - 0.2126).abs() < 1e-4,
+                "Saturation(0) on red: R ≈ 0.2126, got {:.6}",
+                out[0]
+            );
+            assert!(
+                (out[0] - out[1]).abs() < 1e-4 && (out[1] - out[2]).abs() < 1e-4,
+                "Saturation(0) on red must produce equal RGB channels (gray)"
+            );
+            assert!((out[3] - 1.0).abs() < 1e-6, "alpha unchanged");
+        }
+
+        // HueRotate(90) on red must not leave R unchanged (it rotates the hue).
+        {
+            let m = ColorAdjustment::HueRotate(90.0).to_color_matrix();
+            let out = m.apply([1.0, 0.0, 0.0, 1.0]);
+            assert!(
+                (out[0] - 1.0).abs() > 0.01,
+                "HueRotate(90) on red: R must change, got {:.6}",
+                out[0]
+            );
+            assert!((out[3] - 1.0).abs() < 1e-6, "alpha unchanged");
+        }
+
+        // Sepia(1.0) on mid-gray (0.5,0.5,0.5): produces warm brownish tint (R > G > B).
+        // Avoids white input where sepia R and G rows sum > 1 and get clamped.
+        {
+            let m = ColorAdjustment::Sepia(1.0).to_color_matrix();
+            let out = m.apply([0.5, 0.5, 0.5, 1.0]);
+            // Sepia on mid-gray: R ≈ 0.675, G ≈ 0.601, B ≈ 0.469.
+            // Sepia warm-tint ordering must hold: R > G > B.
+            assert!(
+                out[0] > out[1] && out[1] > out[2],
+                "Sepia(1) on mid-gray: must produce warm tint R>G>B, got R={:.3} G={:.3} B={:.3}",
+                out[0],
+                out[1],
+                out[2]
+            );
+            // Verify channels are not equal (sepia is non-identity and asymmetric).
+            assert!(
+                (out[0] - out[2]).abs() > 0.1,
+                "Sepia(1): R and B must differ significantly (brown tint), got R={:.3} B={:.3}",
+                out[0],
+                out[2]
+            );
+            assert!((out[3] - 1.0).abs() < 1e-6, "alpha unchanged");
+        }
+
+        // Brightness(+0.3) on mid-gray must increase all channels.
+        {
+            let m = ColorAdjustment::Brightness(0.3).to_color_matrix();
+            let input = [0.5, 0.5, 0.5, 1.0];
+            let out = m.apply(input);
+            assert!(out[0] > input[0], "Brightness(+0.3): R must increase");
+            assert!(out[1] > input[1], "Brightness(+0.3): G must increase");
+            assert!(out[2] > input[2], "Brightness(+0.3): B must increase");
+            assert!((out[3] - 1.0).abs() < 1e-6, "alpha unchanged");
+        }
+
+        // Contrast(2.0) on mid-gray (0.5) must move channels away from 0.5.
+        {
+            let m = ColorAdjustment::Contrast(2.0).to_color_matrix();
+            let input = [0.3, 0.5, 0.7, 1.0];
+            let out = m.apply(input);
+            // Contrast > 1: values below 0.5 decrease, above 0.5 increase.
+            assert!(out[0] < input[0], "Contrast(2) on 0.3: R must decrease");
+            assert!(out[2] > input[2], "Contrast(2) on 0.7: B must increase");
+            assert!((out[3] - 1.0).abs() < 1e-6, "alpha unchanged");
+        }
+
+        // Remaining variants: confirm no panic and alpha is preserved.
+        for (label, variant) in [
+            ("Grayscale(0.5)", ColorAdjustment::Grayscale(0.5)),
+            ("Invert(0.3)", ColorAdjustment::Invert(0.3)),
+            ("Opacity(0.6)", ColorAdjustment::Opacity(0.6)),
+            (
+                "Matrix(identity)",
+                ColorAdjustment::Matrix(ColorMatrix::identity()),
+            ),
+        ] {
+            let m = variant.to_color_matrix();
+            let out = m.apply([0.5, 0.5, 0.5, 1.0]);
+            assert!(
+                out.iter().all(|v| v.is_finite()),
+                "{label}: output must be finite"
+            );
+        }
+    }
+
+    /// `Grayscale(1.0)` must produce the same matrix as `ColorMatrix::grayscale()`.
+    #[test]
+    fn grayscale_full_strength_matches_grayscale_constructor() {
+        let via_adjustment = ColorAdjustment::Grayscale(1.0).to_color_matrix();
+        let direct = ColorMatrix::grayscale();
+        for i in 0..20 {
+            assert!(
+                (via_adjustment.values[i] - direct.values[i]).abs() < 1e-6,
+                "index {i}: via_adjustment={} vs direct={}",
+                via_adjustment.values[i],
+                direct.values[i]
+            );
+        }
+    }
+
+    /// `Grayscale(0.0)` must produce the identity matrix (no effect).
+    #[test]
+    fn grayscale_zero_strength_is_identity() {
+        let via_adjustment = ColorAdjustment::Grayscale(0.0).to_color_matrix();
+        let identity = ColorMatrix::identity();
+        for i in 0..20 {
+            assert!(
+                (via_adjustment.values[i] - identity.values[i]).abs() < 1e-6,
+                "index {i}: expected identity {}, got {}",
+                identity.values[i],
+                via_adjustment.values[i]
+            );
+        }
+    }
+
+    /// `Opacity(0.5)` applied to a fully opaque red halves the alpha.
+    #[test]
+    fn opacity_adjustment_halves_alpha() {
+        let m = ColorAdjustment::Opacity(0.5).to_color_matrix();
+        let out = m.apply([1.0, 0.0, 0.0, 1.0]);
+        assert!((out[0] - 1.0).abs() < 1e-6, "R unchanged");
+        assert!((out[1] - 0.0).abs() < 1e-6, "G unchanged");
+        assert!((out[2] - 0.0).abs() < 1e-6, "B unchanged");
+        assert!((out[3] - 0.5).abs() < 1e-6, "A halved to 0.5");
+    }
+
+    /// `Matrix(m)` round-trips the matrix unchanged.
+    #[test]
+    fn matrix_adjustment_roundtrips_values() {
+        let original = ColorMatrix::grayscale();
+        let via_adjustment = ColorAdjustment::Matrix(original.clone()).to_color_matrix();
+        assert_eq!(original.values, via_adjustment.values);
+    }
+
+    /// `Invert(0.5)` applied to a color is a linear blend between identity and full invert.
+    #[test]
+    fn invert_half_is_halfway_between_identity_and_full_invert() {
+        let half = ColorAdjustment::Invert(0.5).to_color_matrix();
+        let identity_out = ColorMatrix::identity().apply([0.8, 0.4, 0.2, 1.0]);
+        let invert_out = ColorMatrix::invert().apply([0.8, 0.4, 0.2, 1.0]);
+        let half_out = half.apply([0.8, 0.4, 0.2, 1.0]);
+        for i in 0..4 {
+            let expected_mid = f32::midpoint(identity_out[i], invert_out[i]);
+            assert!(
+                (half_out[i] - expected_mid).abs() < 1e-5,
+                "channel {i}: expected mid {expected_mid:.6}, got {:.6}",
+                half_out[i]
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

First real **GPU ImageFilter/ColorFilter**: a per-pixel 5×4 **color-matrix pass** on a layer's rendered offscreen, replacing the previous flat-tint approximation. Covers `ColorFilter::Matrix`, `ImageFilter::Matrix`, and `ImageFilter::ColorAdjust` (all 9 adjustment variants lower to a matrix at record time). Establishes the offscreen→post-process→composite seam the remaining filters will extend.

**Out of scope** (separate `/spec` — different cost class; orphaned shaders already exist): Blur, Dilate, Erode, Compose, `ColorFilter::Mode`/Gamma — these keep their existing `save_layer` fallback.

## What changed

- **flui-types:** `ColorAdjustment::to_color_matrix()` lowers every variant to a `ColorMatrix` (+ `ColorMatrix::opacity`, lerp helper), value-asserting unit tests per variant.
- **IR:** extensible `LayerFilter::ColorMatrix([f32;20])` on `SavedLayer`/`PendingOpacityLayer` (`Copy` plain data — deterministic-replay witness untouched); `needs_composite |= filter.is_some()` so a matrix filter at opacity=1/white/SrcOver isn't dropped by the reintegrate fast-path.
- **Pass:** ping-pong in `flush_opacity_layer` (render children → matrix pass → existing composite); full-screen quad from `@builtin(vertex_index)` (no viewport-uniform mutation).
- **Premul contract:** the layer offscreen is premultiplied, `ColorMatrix::apply` is straight-alpha + clamps [0,1]; the shader does **unpremul → M·c + offset → clamp → repremul → REPLACE**, byte-matching the CPU oracle.
- **Uniform packing:** the 5×4 row-major matrix is uploaded **column-major** (`m[i]` = column i) because WGSL `mat4x4` reads contiguous floats as columns — so `u.m * v` is the correct row dot-product, not the transpose.
- **backend:** `push_color_filter` / `push_image_filter(Matrix|ColorAdjust)` record the matrix via a new `save_layer_with_filter`; old tint approximation deleted.

## Verification

- `cargo fmt --check` ✓ · `cargo clippy --all-targets --features enable-wgpu-tests -- -D warnings` (flui-types + flui-engine) ✓
- **DX12 GPU-readback: 363 passed / 0 failed / 7 ignored**; workspace CPU green.
- **Red→green proven** for the column/row transpose: `saturation_zero_on_mixed_color_produces_gray` fails under row-packing (chan0 60 vs 100) and passes under column-packing.

## Reviewer notes

- Review caught a real BLOCKER the initial green suite missed: a **transposed matrix** on the GPU (WGSL column-major vs Rust row-major). The original tests used matrices that are symmetric under transpose (identity, R↔B swap) and so were blind to it; the suite now includes an **asymmetric** matrix (`saturation(0)` → gray) and a **non-identity-on-translucent** test (the premul-contract teeth).
- The pass adds one pooled texture + one full-screen pass **per filtered layer only** (`filter.is_some()`-gated); `#[tracing::instrument]` on the pass.
- Blur/morphology/compose are a follow-up `/spec` (the `LayerFilter` enum extends additively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
