### PR TITLE
feat(engine): GPU image-filter IR seam (DrawItem::Filter) + color-filter chain refactor (gpu-image-filters Slice 0)

### DIFF
--- a/.rust-studio/specs/gpu-image-filters/spec.md
+++ b/.rust-studio/specs/gpu-image-filters/spec.md
@@ -1,0 +1,173 @@
+<!-- Rust Code Studio — feature spec. Acceptance criteria are what /spec-verify checks. -->
+
+# Spec: Remaining GPU image/color filters (flui-engine)
+
+- **Status:** Draft
+- **Slug:** `gpu-image-filters`   ·   **Date:** `2026-06-21`   ·   **Owner:** `chief-architect`
+- **Governing ADR:** recommend `/adr` — "GPU filters seam: bounds-behavior split + pinned color-space contracts" (the two PINNED contracts + the `DrawItem::Filter` vs `LayerFilter` split). PR #266 (color-matrix `LayerFilter` seam) is the predecessor.
+
+## Problem
+
+PR #266 landed the **bounds-preserving** color-matrix filter seam: a `LayerFilter::ColorMatrix([f32;20])` carried on the offscreen layer, applied as a ping-pong pass in `flush_opacity_layer` (`opacity_layer.rs:451`) between `render_layer_to_offscreen` and the composite, with a verified premultiplied unpremul→matrix→clamp→repremul contract (`color_matrix.wgsl`). `ImageFilter::{Matrix, ColorAdjust}` already route through it (`backend.rs:1583/1592`).
+
+Everything else still **silently degrades to a `save_layer(WHITE)` passthrough + `tracing` warn**:
+
+| Filter | Fallback site | Behavior today |
+|---|---|---|
+| `ImageFilter::Blur{sigma_x,sigma_y}` | `backend.rs:1555` | passthrough — no blur |
+| `ImageFilter::Dilate{radius}` | `backend.rs:1565` | passthrough — no dilation |
+| `ImageFilter::Erode{radius}` | `backend.rs:1574` | passthrough — no erosion |
+| `ImageFilter::Compose(Vec<ImageFilter>)` | `backend.rs:1602` | passthrough — chain dropped |
+| `ColorFilter::Mode{color,blend_mode}` | not wired to GPU pass | constant-color blend missing |
+| `ColorFilter::{LinearToSrgbGamma, SrgbToLinearGamma}` | not wired to GPU pass | gamma transfer missing |
+
+This is an audited GPU render core. "MVP reported as parity" is the recurring failure mode (see `docs/`/memory). Each filter must match the **observable Flutter/Impeller behavior** (Prime Directive #1), verified by GPU-readback against a CPU oracle, with translucent inputs as the teeth case — not a green "AA present"-style vacuous gate.
+
+The orphaned shaders in `shaders/effects/` (`blur_horizontal.wgsl`, `blur_vertical.wgsl`, `dilate.wgsl`, `erode.wgsl`) are **math references, not drop-in passes**: the blur pair are **compute** shaders calling `textureSample` (illegal in a compute stage — needs implicit derivatives) and writing storage textures; the morphology pair are fragment shaders but sample **ClampToEdge** (Impeller uses **Decal** — see PINNED below) and carry a vertex-buffer layout instead of the synthesized-quad VS the seam uses.
+
+## Goals / Non-goals
+
+**Goals**
+- GPU-implement `ImageFilter::{Blur, Dilate, Erode, Compose}` and `ColorFilter::{Mode, LinearToSrgbGamma, SrgbToLinearGamma}`, deleting every `save_layer`+warn fallback above.
+- **Split the filter seam by bounds-behavior** (the reshaped architecture): bounds-preserving color filters stay on the `LayerFilter` seam; bounds-growing image filters ride a new `DrawItem::Filter`.
+- Match the PINNED Flutter/Impeller color-space contracts exactly (morphology premultiplied + decal; blur premultiplied + sRGB-encoded; compose inner-first).
+- Per-filter GPU-readback teeth tests with CPU oracles; deterministic-replay A/B coverage for filter layers (zero today).
+- Delete/replace the orphaned compute blur shaders; reshape the morphology shaders to the seam.
+
+**Non-goals (explicitly out of scope)**
+- ❌ **Large-σ optimization (downsample prefilter / Dual-Kawase)** — `BlurQuality{Low,Medium,High}` is a free enum (`effects.rs:17`), **not a field on `ImageFilter::Blur`**, and nothing plumbs it from the widget/layer layer. box→gaussian≈gaussian under one API is a **silent parity divergence** — forbidden in an audited core. Ship **exact separable Gaussian only**; defer the optimization to a future *plumbed quality-field* task.
+- ❌ **`TileMode` selection** — there is no `tile_mode` field on `ImageFilter::Blur`/morphology today. Impeller defaults `ImageFilter.blur` to **decal**; flui ships **decal as the single honest contract**, documented. Adding `TileMode` is a typed-API extension deferred to its own task.
+- ❌ **Cross-crate filter-bounds growth into the render/layer tree** — bounds growth is **engine-local** (`DrawItem::Filter` grows from radius at record time, clips to layer bounds like Flutter). Threading filter-bounds-growth up into `flui-rendering`/`flui-layer` is a follow-up only if a clip-interaction bug surfaces. *(User-chosen Fork 1.)*
+- ❌ Linear-light blur (Impeller blurs sRGB-encoded — see PINNED). No "make it better" color-management divergence.
+- ❌ `ImageFilter::Shader` (runtime FragmentShader filter), drop-shadow, lighting, displacement — future filters; the seam is designed to admit them additively.
+- ❌ `ColorFilter::Matrix` / `ImageFilter::{Matrix, ColorAdjust}` — already done in PR #266.
+
+## PINNED contracts (read from the `.flutter/` Impeller reference — not assumed)
+
+`.flutter/` is a symlink to `/c/Users/vanya/RustroverProjects/.flutter`; Impeller **is** present at `flutter/engine/src/flutter/impeller/entity/contents/filters/`. The following were read from source this session and are load-bearing.
+
+1. **Morphology = PREMULTIPLIED, per-channel max/min, DECAL padding.**
+   `impeller/entity/shaders/filters/morphology_filter.frag`: samples the texture directly (Impeller textures are premultiplied) and does `result = max(color, result)` (dilate) / `min(color, result)` (erode) with **no unpremultiply**. Dilate inits `f16vec4(0.0)`, erode inits `f16vec4(1.0)`. `morphology_filter_contents.cc` sets `SamplerAddressMode::kDecal` (transparent-black outside) and `BlendMode::kSrc`, separable via a `uv_offset` direction. Per-channel max on premultiplied **can** produce a pixel with `RGB > alpha` (an "invalid" premultiplied color) at a boundary — **Impeller does not guard it; flui matches** (loyalty to observable behavior). The orphaned `dilate.wgsl`/`erode.wgsl` use ClampToEdge → **WRONG**, must emulate decal (Fork 3, owned at build).
+
+2. **Blur = exact separable Gaussian on PREMULTIPLIED, sRGB-ENCODED (NOT linear light).**
+   `impeller/entity/shaders/filters/gaussian.frag`: `total_color += coefficient * texture(...)` — a coefficient-weighted sum of **premultiplied** texels, **no per-sample unpremultiply, no sRGB→linear**. `apply_unpremultiply` is a *final-pass-only conditional* (true only when `bounds_.has_value()`, an internal blur-of-opaque nicety), never per-sample. The slight midtone darkening from blurring gamma-encoded values **is** the Flutter behavior; flui ships it, documented. Anisotropy is free: `sigma_x` drives the H pass uniform, `sigma_y` the V pass.
+
+3. **Filters GROW bounds.**
+   `gaussian_blur_filter_contents.cc:799` `GetFilterCoverage` returns `input_coverage.Expand(padding)`; `morphology_filter_contents.cc:185` dilate `origin -= r; size += 2r` (erode shrinks). A full-viewport-clamped layer-filter pass structurally **cannot** represent spread beyond the layer rect → a blur halo would clip at the edge. This is the reason for the seam split.
+
+4. **Compose = inner-first.**
+   Dart `lib/ui/painting.dart:4404`: `ImageFilter.compose({outer, inner})` ⇒ `result = outer(inner(source))`. flui-types `ImageFilter::Compose(Vec<ImageFilter>)` is an *unlabeled ordered Vec*: pin the convention **`Vec[0]` is applied first (= innermost)**; a left-to-right fold (`acc = source; for f in vec { acc = f(acc) }`) is then correct. Flatten-at-record is depth-first left-to-right: `Compose([Compose([A,B]),C]) → [A,B,C]`.
+
+## Approach
+
+**Split the seam by bounds-behavior, not by filter kind.**
+
+### Half 1 — Color filters stay on the bounds-PRESERVING `LayerFilter` seam
+
+`ColorFilter::{Mode, LinearToSrgbGamma, SrgbToLinearGamma}` are per-pixel: output bounds == input bounds. They extend PR #266's seam additively.
+
+- `LayerFilter` (`command_ir.rs:47`) **stays `#[derive(Copy)]`** — gains `Mode{color:[f32;4], blend:BlendMode}` and `Gamma(GammaDir)` (`GammaDir::{LinearToSrgb, SrgbToLinear}`), both POD.
+- The layer field `filter: Option<LayerFilter>` (on `SavedLayer:140` / `PendingOpacityLayer:437`) becomes `chain: SmallVec<[LayerFilter; 4]>` (inline ≤4, the common case; heap-spills beyond). The single `if let Some(LayerFilter::ColorMatrix(..))` arm at `opacity_layer.rs:451` becomes a **fold**: `acc = layer_tex; for f in chain { acc = apply_filter(f, acc) }`. Empty chain → alias `layer_tex` directly (zero acquire, **bit-exact** with today's no-filter fast-path).
+- Each color filter = **one** full-viewport REPLACE pass mirroring `apply_color_matrix` (`color_matrix/mod.rs:56`): acquire pooled tex → synthesized-quad VS → fragment → return. Premul contract: **unpremul → op → clamp[0,1] → repremul** (the color-matrix bracket verbatim; transparent-pixel `select(vec3(0), t.rgb/t.a, t.a>0)` guard).
+  - **Mode** fragment mirrors `Color::blend(self=color, dst=pixel, mode)` (`color.rs:883`) per-pixel — the straight sRGB-encoded `[0,1]` blend equation for the 28 modes.
+  - **Gamma** fragment applies the sRGB transfer fn per RGB channel (alpha untouched); non-linear, so **not** a 5×4 matrix — its own pass.
+
+### Half 2 — Image filters ride a new bounds-GROWING `DrawItem::Filter`
+
+`ImageFilter::{Blur, Dilate, Erode, Compose}` grow bounds. A dedicated top-level draw-order item, isolated at record time, rendered to a **content-bounds-sized (grown)** pooled intermediate, composited at its grown rect via the **existing** `DrawItem::OffscreenTexture` / `AdvancedShape` seam (`opacity_layer.rs:208`) — so the composite arm is unchanged (same "ride the existing seam" discipline as PR-3/4/5 advanced-blend).
+
+- New `pub(crate)` IR: `DrawItem::Filter(FilterOp)` where `FilterOp { input: DrawSegment, filter: SmallVec<[ImageFilterPass; 4]>, content_bounds: Rect<Pixels>, grown_bounds: Rect<Pixels> }`. `ImageFilterPass` is the lowered, flattened form (`Blur{sigma_x,sigma_y}` / `Morph{radius, op}`). All POD + `Clone` (T11 purity witness — every IR neighbor derives `Clone`, none `Copy`).
+- **Engine-local bounds growth (Fork 1):** at record time in `push_image_filter`, grow `content_bounds` by the filter radius (`grown_bounds = content_bounds ⊕ radius`), clipped to the layer bounds — matching Flutter's layer-clip behavior. Intermediate sized `ceil(grown_bounds.{w,h})`.
+- **Blur** = two sub-passes ping-pong (H with `sigma_x`, V with `sigma_y`), exact separable Gaussian, premultiplied, sRGB-encoded, decal-sampled. Reshape the orphaned **compute** shaders to **fragment** (synthesized-quad VS, `textureSample` legal in fragment; `kernel_radius = ceil(3σ)` from a one-home helper; weight-normalized). Delete the compute originals.
+- **Morphology** = two sub-passes (H, V), per-channel max/min, premultiplied, decal. Reshape the orphaned fragment shaders: synthesized-quad VS + decal emulation (Fork 3). `MorphOp::{Dilate,Erode}` is **one** `ImageFilterPass::Morph` variant + an op field (they differ only by max/min + init constant).
+- **Compose** = fold the flattened chain inside one `DrawItem::Filter` (no nested IR, no GPU-side recursion). Inner-first per PINNED #4.
+
+**Data flow:** `Backend::push_image_filter` (`backend.rs`) lowers the `ImageFilter` AST → for color filters, `save_layer_with_filter` pushing onto the `LayerFilter` chain (Half 1); for image filters, isolates the subtree into `DrawItem::Filter` with grown bounds (Half 2). Replay: color-filter chain folds in `flush_opacity_layer`; `DrawItem::Filter` renders the input to a grown intermediate, folds its passes, composites via the existing offscreen seam.
+
+**Shared infra (both halves):** one pipeline struct per shader on `PipelineSet` (`BlurPipeline`, `MorphologyPipeline`, `ModePipeline`, `GammaPipeline`); `TexturePool::acquire` + RAII ping-pong; the synthesized-quad VS; the `color_matrix_filter_tests.rs` readback harness (extended per filter). **DRY one-home:** `kernel_radius(sigma)->u32` in a new `effects/mod.rs` (shared by the blur pass AND its CPU oracle); `pub fn srgb_to_linear/linear_to_srgb` extracted from the private nested copies in `color.rs:728/762` (shared by the gamma shader's reference AND its oracle).
+
+### Reuse vs reinvent
+
+| Reuse (sibling owns it) | New (must build) |
+|---|---|
+| `apply_color_matrix` pass shape (acquire→REPLACE quad→return) | `apply_filter` fold + `DrawItem::Filter` render path |
+| Synthesized-quad VS (`color_matrix.wgsl` `vs_main`) | Mode fragment (mirror `Color::blend` 28 modes); Gamma fragment (transfer fn) |
+| `TexturePool::acquire` + RAII ping-pong | content-bounds-grown intermediate sizing |
+| `Color::blend` (Mode oracle), color transfer fn (gamma oracle) | `pub srgb_to_linear/linear_to_srgb` extraction; `kernel_radius` one-home |
+| Gaussian math (`gaussian_weight`, 3σ) — from orphaned compute shader | **fragment** blur H/V (reshape from compute; fix `textureSample`; drop storage IO) |
+| Dilate/erode max/min math — from orphaned fragment shaders | synthesized-quad VS + **decal emulation** + premul (no unpremul) |
+| existing `OffscreenTexture`/`AdvancedShape` composite seam | `DrawItem::Filter` draw-order arm in `submit` + `render_layer_to_offscreen` |
+| `color_matrix_filter_tests.rs` GPU-readback harness | per-filter readback teeth tests + filter-layer A/B replay test |
+| `PipelineSet` registration pattern | `BlurPipeline`/`MorphologyPipeline`/`ModePipeline`/`GammaPipeline` |
+
+### Alternatives considered
+
+| Option | Trade-off | Why not chosen |
+|--------|-----------|----------------|
+| **All filters on the `LayerFilter` layer seam** (the original Approach 1) | one seam, max reuse, no new IR | **Rejected — cannot grow bounds.** `flush_opacity_layer` is full-viewport-clamped to the layer rect; blur/morphology `GetFilterCoverage` expand coverage by radius (PINNED #3) → halo clips at the edge. A bounds-preserving seam structurally can't carry a bounds-growing op. |
+| **Dual-Kawase blur** (downsample/upsample mip-chain) | ~O(1)/level at large σ | **Deferred.** Approximate (not exact Gaussian → weakens the readback oracle, a parity divergence); anisotropy is a shader gap (Kawase is isotropic — `sigma_x≠sigma_y` needs non-square steps the orphaned shaders don't parameterize). Kept as a *future option behind a plumbed quality field*, not day-one. |
+| **Nested-enum Compose** `LayerFilter::Compose(Box<[LayerFilter]>)` | matches the source AST 1:1 | **Rejected.** Forces `Copy`→`Clone` and pushes **recursion into the replay hot path**; pool-depth bound becomes AST-nesting-dependent. Flatten-at-record to a linear chain keeps `Copy`, keeps "IR = lowered linear data", and bounds the chain trivially. |
+| **Nested save_layers for Compose** (one offscreen per filter) | simplest IR, no enum change | **Rejected.** N offscreens + N composites where the fold needs 2 ping-pong textures and 0 extra composites; defeats the lowered-linear-data principle; per-filter composite overhead. |
+
+## Public surface & semver impact
+
+Engine-internal — **0 external semver impact**. `LayerFilter` and the new IR are `pub(crate)` within the `wgpu` module. Public traits `CommandRenderer`/`LayerStateStack`/`Backend` are byte-identical.
+
+- `LayerFilter` **stays `#[derive(Copy)]`** (Mode/Gamma variants are POD). **No `Copy`→`Clone` break anywhere.**
+- New `DrawItem::Filter(FilterOp)` variant — **additive `pub(crate)`** (the `DrawItem` enum is engine-internal; not `#[non_exhaustive]`-relevant externally).
+- `flui-types::styling::color` gains `pub fn srgb_to_linear(f32)->f32` + `pub fn linear_to_srgb(f32)->f32` — **additive minor** (extracted from existing private nested fns; one home, DRY). No other `flui-types` change.
+- Breaking changes confined to flui-engine internals (active-dev, no external consumers) — **allowed**.
+
+## Pre-code maintainer verdict: **ACCEPTABLE** (reshaped)
+
+- **Crate ownership** — correct. GPU passes over GPU textures belong in flui-engine; the *type* + *oracle* live in flui-types/flui-painting. The one thing that could cross into `flui-rendering` (render-tree bounds growth) is explicitly **out of scope** (Fork 1 = engine-local).
+- **Sibling reuse** — strong; the split *increases* reuse (color filters keep the whole PR #266 path; `DrawItem::Filter` rides the existing offscreen-composite seam). Strict-maintainer rejection if: `srgb_to_linear` is cloned into a shader constant instead of extracted (DRY); `kernel_radius` defined twice (pass vs test).
+- **Pre-empted rejections** — no silent box≈gaussian (cut); no ClampToEdge where Impeller uses Decal (PINNED); no unpremultiply morphology (PINNED premul); no full-viewport clip of grown blur (split to bounds-aware item); no untested seam refactor (A/B replay test required); morphology is one variant + op field, not two.
+- **Allowed breaking changes** — none needed (`LayerFilter` stays `Copy`).
+
+## Acceptance criteria
+
+*The checklist `/spec-verify` will prove. GPU-readback is local DX12 only (`--features enable-wgpu-tests -- --test-threads 1`), not CI — the implementer runs + diffs on a real GPU before merge for every slice. Each teeth test must fail without the change (red→green) and use a translucent input where a premul contract is claimed.*
+
+- [ ] **No fallback left** — every covered filter (`Blur/Dilate/Erode/Compose`, `ColorFilter::{Mode,LinearToSrgbGamma,SrgbToLinearGamma}`) GPU-renders; the `save_layer`+warn fallbacks at `backend.rs:1555/1565/1574/1602` and the unwired `ColorFilter::Mode`/gamma paths are **deleted**. *(verified by: grep absence of the warn strings + readback)*
+- [ ] **Orphaned compute blur shaders deleted/replaced** — `blur_horizontal.wgsl`/`blur_vertical.wgsl` (compute, illegal `textureSample`) removed; fragment replacements in tree. *(verified by: grep + file list)*
+- [ ] **Morphology premul + decal (PINNED #1)** — readback: a checkerboard of opaque + transparent → dilate fills by exactly `ceil(radius)` texels, erode clears; **decal boundary** test (transparent-black outside, not edge-clamped); **translucent** opaque-vs-half-alpha adjacency picks the premultiplied per-channel max/min (straight-color morphology diverges here). *(verified by: GPU readback vs CPU premul max/min oracle)*
+- [ ] **Blur premul + sRGB-encoded + anisotropy (PINNED #2)** — readback: half-alpha disc on transparent background has **no dark halo ring** (proves premul, not unpremul-before-blur); **anisotropic** σx=8,σy=2 spreads horizontally ≫ vertically (proves the two sigmas are not swapped/averaged); result matches a CPU separable-Gaussian oracle using the same `kernel_radius`/`gaussian_weight` source. *(verified by: GPU readback vs CPU Gaussian oracle)*
+- [ ] **ColorFilter::Mode non-separable on translucent** — `Modulate` on opaque white = identity (no double-apply); a non-separable mode (e.g. `Multiply`) on a **translucent** layer matches `Color::blend(color, pixel, mode)` per pixel. *(verified by: GPU readback vs `Color::blend` oracle)*
+- [ ] **Gamma round-trip** — `SrgbToLinear` then `LinearToSrgb` ≈ identity within transfer-fn precision; translucent input → alpha unchanged, RGB transferred (proves unpremul/repremul brackets the transfer). *(verified by: GPU readback vs `pub linear_to_srgb`/`srgb_to_linear` oracle)*
+- [ ] **Compose order + flatten (PINNED #4)** — `[Blur,Mode] ≠ [Mode,Blur]` (non-commuting, proves the fold sequences); `Compose([Compose([A]),B]) == [A,B]` (flatten-at-record); inner-first matches `Vec[0]` applied first. *(verified by: GPU readback)*
+- [ ] **Bounds growth (Fork 1)** — a blur near the layer edge spreads to `grown_bounds` (clipped to layer bounds, Flutter-like), not clipped to the unguarded content rect; intermediate sized to grown content bounds, not full viewport. *(verified by: readback of edge-adjacent blur + intermediate-size assertion)*
+- [ ] **Deterministic-replay A/B for filter layers** — snapshot the IR before `GpuReplay::submit`, run, assert IR unchanged (T11 purity); two runs produce identical pixels for a filtered layer (zero such coverage exists today). *(verified by: A/B replay test)*
+- [ ] **No-filter fast-path bit-exact** — the empty-chain branch in `flush_opacity_layer` remains a direct alias of `layer_tex` (no acquire, no pass); existing non-filter readback unchanged. *(verified by: diff-level assertion + existing readback green)*
+- [ ] **`LayerFilter` stays `Copy`; new IR is additive `pub(crate)`** — no `Copy`→`Clone`; `DrawItem::Filter` added; `flui-types` gains only the two `pub` transfer fns. *(verified by: API shape + grep)*
+- [ ] **DRY one-home** — exactly one `kernel_radius` and one `srgb_to_linear/linear_to_srgb`; tests cite the same source as the passes. *(verified by: grep)*
+- [ ] **Gates** — fmt; clippy both modes incl. `--features enable-wgpu-tests` `-D warnings`; nextest; doc (`-D warnings`); `just ci` green per slice; PR #266 color-matrix readback suite stays green.
+
+## Risks & open questions
+
+- **Premul / color-space** — PINNED from Impeller source (morphology premul+decal, blur premul+sRGB). Residual risk is transcription error in the WGSL; the translucent-input teeth tests are the net.
+- **Decal emulation (Fork 3, owned at build)** — wgpu has no `AddressMode::Decal`. Plan: bounds-test in the shader (`sample → vec4(0)` if uv outside the content rect), mirroring Impeller's `IPHalfSampleDecal` fallback for backends lacking decal. Decided at build time; tactical, not strategic.
+- **Pool / VRAM peak** — content-bounds sizing bounds the area; ping-pong holds 2 live textures (blur, and the Compose fold, regardless of chain length); the dominant multiplier is **layer-nesting depth** (each nested filtered layer holds its own intermediate up the recursion). Pool (~16 slots) cannot exhaust by count; VRAM peak ≈ `2 × grown_area × max_nesting_depth`, **logged** at acquire (depth + area). No silent truncation; `debug_assert` + `tracing::warn` on chain overflow.
+- **Slice-0 seam refactor** — touches the just-merged-and-verified color-matrix path, which has **zero** deterministic-replay coverage for filter layers. Mitigated by: bit-exact no-filter fast-path preservation + the new filter-layer A/B replay test + `LayerFilter` staying `Copy` (no purity-witness churn).
+- **`DrawItem::Filter` arm order** — adding a draw-order variant touches the R1 arm-order invariant in `submit`/`render_layer_to_offscreen`. Mitigated by landing it as a **standalone seam slice** (Slice 0) before any filter logic (Fork 2).
+
+## Slicing (the /spec-tasks plan — in order, each an independent /dev-task ending in /review + local GPU-readback)
+
+0. **Slice 0 — the `DrawItem::Filter` seam + color-filter chain refactor (no user-visible filter).** Add `DrawItem::Filter(FilterOp)` (additive `pub(crate)`) + its arm in `submit`/`render_layer_to_offscreen` (renders input → grown intermediate → composites via existing offscreen seam; no filter math yet — identity pass). Convert the layer field `Option<LayerFilter>` → `SmallVec` chain; generalize the single color-matrix arm into the `apply_filter` fold (ColorMatrix the sole arm → pure refactor, PR #266 tests stay green). Preserve the no-filter fast-path **bit-for-bit**. Add the **filter-layer A/B deterministic-replay test**. Extract `pub srgb_to_linear/linear_to_srgb` in flui-types; add `effects/mod.rs` with `kernel_radius`. *(Riskiest structural change, isolated — the T9 standalone-pure-move discipline. Fork 2.)*
+1. **Slice 1 — Morphology (`Dilate`/`Erode`).** Reshape the two fragment shaders (synthesized-quad VS, premul, **decal emulation** — Fork 3), `MorphologyPipeline`, `ImageFilterPass::Morph{radius,op}`, two-sub-pass render in `DrawItem::Filter`, grown bounds from radius. Decal-boundary + translucent teeth tests. Delete `backend.rs:1565/1574` fallbacks. *(Simplest ready shaders; first real filter through the new seam.)*
+2. **Slice 2 — `ColorFilter::Mode`.** Mode fragment mirroring `Color::blend` (28 modes), `ModePipeline`, `LayerFilter::Mode`, one-pass fold arm, oracle teeth tests, wire the `ColorFilter::Mode` path. *(Bounds-preserving — Half 1 seam.)*
+3. **Slice 3 — Gamma (`LinearToSrgbGamma`/`SrgbToLinearGamma`).** Gamma fragment (per-channel transfer, alpha untouched), `GammaPipeline`, `LayerFilter::Gamma(GammaDir)`, one-pass fold arm, round-trip teeth test. *(May merge with Slice 2 if scoped tight — both 1-pass color ops on the same seam.)*
+4. **Slice 4 — Gaussian blur.** Reshape compute→fragment H/V, `BlurPipeline`, `ImageFilterPass::Blur{sigma_x,sigma_y}`, two-sub-pass render in `DrawItem::Filter`, exact separable Gaussian premul+sRGB+decal+anisotropic. Halo + anisotropy + oracle teeth tests. Delete `backend.rs:1555` fallback + the orphaned compute shaders. *(Largest single slice.)*
+5. **Slice 5 — Compose.** Record-time AST flattening in `push_image_filter` (inner-first, depth-first); the fold over the `ImageFilterPass` chain inside one `DrawItem::Filter`. Order non-commuting + flatten + depth teeth tests. Delete `backend.rs:1602` fallback. *(Last — composes filters that must already exist.)*
+
+## Review discipline (per slice)
+
+`rust-builder` (test-first) → `rust-reviewer` + **`ce-kieran`** (soundness, mandatory on this audited core) → **chief-architect runs the GPU-readback serial on DX12** (the only pixel gate; not in CI). Capture the durable architecture decision to the Obsidian vault via `/remember` after Slice 0 + Slice 4 (blur color-space) land. Honesty bar: state implemented-vs-deferred per slice; never imply parity not verified against the readback oracle (anti "MVP reported as parity").
+
+## Links
+
+- **Predecessor:** PR #266 (color-matrix `LayerFilter` seam) — `color_matrix/mod.rs`, `color_matrix.wgsl`, `opacity_layer.rs:451`.
+- **Reference (read this session):** Impeller `morphology_filter.frag`, `gaussian.frag`, `morphology_filter_contents.cc`, `gaussian_blur_filter_contents.cc`, Dart `painting.dart:4404` (under `/c/Users/vanya/RustroverProjects/.flutter/flutter/engine/src/flutter/`).
+- **Sibling seams:** `.rust-studio/specs/tessellated-aa/SPEC.md` (the SSAA-tile → OffscreenTexture composite seam this rides), `.rust-studio/specs/flui-engine-overhaul/spec.md` (the C-IR record/replay seam).
+- **Vault notes:** wgsl `mat4x4` column-major transpose (color-matrix uniform packing); tile-composite premultiplied contract; viewport-uniform-cant-change-mid-encoder (full-screen-quad passes only); advanced-blend dst-read compositor at the renderer layer.
+- **Types:** `flui-types/src/painting/effects.rs` (`ImageFilter`, `BlurQuality`), `flui-painting/src/display_list/command.rs:379` (`ColorFilter`), `flui-types/src/styling/color.rs:883/728/762` (`Color::blend`, transfer fns).

--- a/.rust-studio/specs/gpu-image-filters/spec.md
+++ b/.rust-studio/specs/gpu-image-filters/spec.md
@@ -122,7 +122,7 @@ Engine-internal — **0 external semver impact**. `LayerFilter` and the new IR a
 
 - **Crate ownership** — correct. GPU passes over GPU textures belong in flui-engine; the *type* + *oracle* live in flui-types/flui-painting. The one thing that could cross into `flui-rendering` (render-tree bounds growth) is explicitly **out of scope** (Fork 1 = engine-local).
 - **Sibling reuse** — strong; the split *increases* reuse (color filters keep the whole PR #266 path; `DrawItem::Filter` rides the existing offscreen-composite seam). Strict-maintainer rejection if: `srgb_to_linear` is cloned into a shader constant instead of extracted (DRY); `kernel_radius` defined twice (pass vs test).
-- **Pre-empted rejections** — no silent box≈gaussian (cut); no ClampToEdge where Impeller uses Decal (PINNED); no unpremultiply morphology (PINNED premul); no full-viewport clip of grown blur (split to bounds-aware item); no untested seam refactor (A/B replay test required); morphology is one variant + op field, not two.
+- **Preempted rejections** — no silent box≈gaussian (cut); no ClampToEdge where Impeller uses Decal (PINNED); no unpremultiply morphology (PINNED premul); no full-viewport clip of grown blur (split to bounds-aware item); no untested seam refactor (A/B replay test required); morphology is one variant + op field, not two.
 - **Allowed breaking changes** — none needed (`LayerFilter` stays `Copy`).
 
 ## Acceptance criteria

--- a/.rust-studio/specs/gpu-image-filters/tasks.md
+++ b/.rust-studio/specs/gpu-image-filters/tasks.md
@@ -1,0 +1,111 @@
+<!-- Rust Code Studio — task breakdown for the gpu-image-filters spec. Each task is implemented via /dev-task. -->
+
+# Tasks: Remaining GPU image/color filters (flui-engine)
+
+- **Spec:** [`spec.md`](spec.md)   ·   **Updated:** `2026-06-21`
+
+> The spec's `## Slicing` section (Slices 0–5) **is** this skeleton — formalized below, not
+> re-invented. The seam is split by **bounds-behavior**: bounds-preserving color filters extend
+> PR #266's `LayerFilter` chain seam (Half 1); bounds-growing image filters ride a new
+> `DrawItem::Filter` (Half 2). Every task is one `/dev-task` ending in `/review` + a **local
+> DX12 GPU-readback** serial against a CPU oracle — the readback is **LOCAL-ONLY, not CI** (no
+> GPU runner; per spec acceptance §). Each teeth test is red→green and uses a **translucent**
+> input wherever a premultiplied contract is claimed (the anti "MVP-as-parity" net).
+>
+> **`chief-architect` sign-off is mandatory on Task 0 (the `DrawItem::Filter` IR seam + the R1
+> flush-order arm) and Task 5 (Compose AST flatten + fold)** — the two structural changes to the
+> audited record/replay core. `ce-kieran` is mandatory soundness review on every slice.
+
+## Task list
+*Status: ☐ todo · ◐ in-progress · ☑ done · ⊘ blocked.*
+
+| # | Task (outcome) | Acceptance slice | Owner lead | Blocked by | Status |
+|---|----------------|------------------|------------|------------|--------|
+| 0 | **`DrawItem::Filter` seam + `LayerFilter`→`SmallVec` chain refactor (NO user-visible filter).** Add bounds-aware `pub(crate) DrawItem::Filter(FilterOp)` + its arm in `submit`/`render_layer_to_offscreen` (input → grown intermediate → composite via the existing `OffscreenTexture`/`AdvancedShape` seam; **identity pass only**, no filter math) — **respecting the R1 flush-order invariant**. Convert the layer field `filter: Option<LayerFilter>` → `chain: SmallVec<[LayerFilter;4]>` (on `SavedLayer`/`PendingOpacityLayer`); generalize the single color-matrix `if let` arm at `opacity_layer.rs:451` into the `apply_filter` **fold** (ColorMatrix = sole arm ⇒ pure refactor). **Preserve the no-filter fast-path BIT-FOR-BIT** (empty chain aliases `layer_tex`, zero acquire). Add the **filter-layer A/B deterministic-replay test** (zero coverage today). Extract `pub fn srgb_to_linear/linear_to_srgb` in `flui-types` (one home, from `color.rs:728/762`); add `effects/mod.rs` with `kernel_radius(σ)->u32`. | No-filter fast-path bit-exact; deterministic-replay A/B for filter layers; `LayerFilter` stays `Copy` + additive `pub(crate)` IR; `flui-types` gains only the 2 transfer fns; DRY one-home (`kernel_radius`); PR #266 readback suite stays green | `chief-architect` (IR seam — **sign-off**) | — | ☐ |
+| 1 | **Morphology (`Dilate`/`Erode`).** Reshape orphaned `dilate.wgsl`/`erode.wgsl` to synthesized-quad VS + **decal emulation** (in-shader bounds-test ⇒ `vec4(0)` outside the content rect — wgpu has no `AddressMode::Decal`, Fork 3) + **premultiplied** per-channel max/min (dilate init `0`, erode init `1`; **no unpremultiply**, PINNED #1). `MorphologyPipeline` on `PipelineSet`; `ImageFilterPass::Morph{radius,op}` (**one** variant + op field, not two); two-sub-pass (H,V) render inside `DrawItem::Filter` with **grown bounds** from radius. Delete the `backend.rs:1565/1574` `save_layer`+warn fallbacks. | Morphology premul + decal (PINNED #1): checkerboard dilate fills `ceil(radius)` / erode clears; decal-boundary (transparent-black outside); translucent opaque-vs-half-alpha picks the premul max/min; bounds growth (Fork 1) — readback vs CPU premul max/min oracle | `systems-perf-lead` | 0 | ☐ |
+| 2 | **`ColorFilter::Mode`.** `Mode` fragment mirroring `Color::blend(self=color, dst=pixel, mode)` (`color.rs:883`, 28 modes) per-pixel; **unpremul → blend → clamp[0,1] → repremul** bracket. `ModePipeline`; `LayerFilter::Mode{color:[f32;4], blend:BlendMode}` (POD, stays `Copy`); one-pass REPLACE fold arm on the Half-1 chain seam; wire the `ColorFilter::Mode` lowering path. | `ColorFilter::Mode` non-separable on translucent: `Modulate` on opaque white = identity (no double-apply); `Multiply` on a translucent layer matches `Color::blend` per-pixel — readback vs `Color::blend` oracle | `systems-perf-lead` | 0 | ☐ |
+| 3 | **Gamma (`LinearToSrgbGamma`/`SrgbToLinearGamma`).** `Gamma` fragment applying the sRGB transfer fn per RGB channel (**alpha untouched**; non-linear ⇒ not a 5×4 matrix, its own pass), reusing the extracted `pub srgb_to_linear/linear_to_srgb` as the oracle source. `GammaPipeline`; `LayerFilter::Gamma(GammaDir::{LinearToSrgb,SrgbToLinear})` (POD); one-pass fold arm on the Half-1 chain seam; wire the gamma lowering path. | Gamma round-trip: `SrgbToLinear∘LinearToSrgb ≈ identity` within transfer-fn precision; translucent input → alpha unchanged, RGB transferred (unpremul/repremul brackets the transfer) — readback vs `pub linear_to_srgb`/`srgb_to_linear` oracle | `systems-perf-lead` | 0 | ☐ |
+| 4 | **Gaussian blur.** Reshape orphaned **compute** `blur_horizontal.wgsl`/`blur_vertical.wgsl` → **fragment** separable H/V (synthesized-quad VS; `textureSample` legal in fragment; drop storage-texture IO); **exact** separable Gaussian, **premultiplied + sRGB-encoded** (no per-sample unpremul, no sRGB→linear — PINNED #2), **decal**-sampled, **anisotropic** (σx drives H, σy drives V); `kernel_radius=ceil(3σ)` from the Task-0 one-home helper, weight-normalized. `BlurPipeline`; `ImageFilterPass::Blur{sigma_x,sigma_y}`; two-sub-pass ping-pong inside `DrawItem::Filter` with content-bounds-grown intermediate. **Exact only — NO large-σ prefilter / `BlurQuality`** (cut). Delete the `backend.rs:1555` fallback **and** the orphaned compute shaders. | Blur premul + sRGB-encoded + anisotropy (PINNED #2): half-alpha disc on transparent bg has **no dark halo** (premul, not unpremul-first); σx=8/σy=2 spreads horizontal ≫ vertical (sigmas not swapped/averaged); matches CPU separable-Gaussian oracle; bounds growth + intermediate-size assertion — readback vs CPU Gaussian oracle | `systems-perf-lead` | 0, 1 | ☐ |
+| 5 | **Compose.** Flatten `Compose(Vec<ImageFilter>)` AST **at record time** in `push_image_filter` (depth-first left-to-right, **inner-first** — `Vec[0]` applied first, PINNED #4); fold over the flattened `ImageFilterPass` chain inside **one** `DrawItem::Filter` (no nested IR, no GPU-side recursion). Delete the `backend.rs:1602` fallback. | Compose order + flatten (PINNED #4): `[Blur,Mode] ≠ [Mode,Blur]` (fold sequences); `Compose([Compose([A]),B]) == [A,B]` (flatten-at-record); deep-chain no pool exhaustion (ping-pong holds 2 live textures) — readback | `chief-architect` (fold/flatten — **sign-off**) | 1, 2, 3, 4 | ☐ |
+
+## Critical path
+`0 → (1, 2, 3 parallel) → 4 → 5`
+
+Task 0 is the only hard prerequisite for everything (it lands the `DrawItem::Filter` seam, the
+`SmallVec` chain fold, the `flui-types` transfer fns, and the `kernel_radius` one-home). Tasks 1
+(morphology, Half 2), 2 (Mode, Half 1) and 3 (Gamma, Half 1) are **mutually independent** and
+parallelizable once 0 lands. Task 4 (blur) blocks on **1** as well as 0 — it shares the
+`DrawItem::Filter` **grown-bounds machinery** first proven by morphology (two-sub-pass H/V render
+into a radius-grown intermediate), so morphology is the trial run for that path. Task 5 (Compose)
+is last by definition — it composes filters that must already exist (1–4).
+
+> Tasks 2 and 3 **may co-land in one `/dev-task`** if scoped tight — both are single-pass color
+> ops on the same Half-1 chain seam (one-pass REPLACE fold arm, identical pass shape, differing
+> only in the fragment). Kept as separate rows for acceptance-criterion traceability; the owning
+> lead decides at build time. They do not block each other.
+
+## Acceptance-criterion → task map
+*Every spec `## Acceptance criteria` line, mapped to the task(s) that satisfy it. (`Gates` is
+per-slice on all tasks.)*
+
+| Spec acceptance criterion | Satisfied by |
+|---|---|
+| **No fallback left** — every covered filter GPU-renders; `backend.rs:1555/1565/1574/1602` + unwired Mode/gamma fallbacks deleted | 1 (1565/1574 morphology), 2 (Mode), 3 (gamma), 4 (1555 blur), 5 (1602 Compose) |
+| **Orphaned compute blur shaders deleted/replaced** — `blur_horizontal/vertical.wgsl` removed, fragment replacements in tree | 4 |
+| **Morphology premul + decal (PINNED #1)** | 1 |
+| **Blur premul + sRGB-encoded + anisotropy (PINNED #2)** | 4 |
+| **ColorFilter::Mode non-separable on translucent** | 2 |
+| **Gamma round-trip** | 3 |
+| **Compose order + flatten (PINNED #4)** | 5 |
+| **Bounds growth (Fork 1)** — spread to grown_bounds (layer-clipped), intermediate sized to grown content | 0 (seam machinery + grown-intermediate sizing), 1 (first real grown filter), 4 (blur halo edge case) |
+| **Deterministic-replay A/B for filter layers** (zero coverage today) | 0 |
+| **No-filter fast-path bit-exact** | 0 |
+| **`LayerFilter` stays `Copy`; new IR additive `pub(crate)`; `flui-types` gains only the 2 transfer fns** | 0 (IR + transfer fns; `Copy` preserved); 2 & 3 add POD `Mode`/`Gamma` variants under the `Copy` invariant |
+| **DRY one-home** — one `kernel_radius`, one `srgb_to_linear/linear_to_srgb`; tests cite the same source | 0 (defines both homes); 3 (gamma oracle cites transfer fns); 4 (blur oracle cites `kernel_radius`) |
+| **Gates** — fmt; clippy both modes incl. `--features enable-wgpu-tests` `-D warnings`; nextest; doc `-D warnings`; `just ci` green per slice; PR #266 readback stays green | every task (per-slice gate) |
+
+## Cross-crate ripples
+*Coordinated by `product-steward` so no leg of a ripple is dropped.*
+
+- **`flui-types`** (Task 0 only): `styling::color` gains `pub fn srgb_to_linear(f32)->f32` +
+  `pub fn linear_to_srgb(f32)->f32`, **extracted** from the existing private nested copies at
+  `color.rs:728/762` (one home, DRY — must be extracted, not cloned into a shader constant or a
+  second test copy). **Additive minor**, 0 other `flui-types` change. The gamma shader reference
+  (Task 3) and its oracle both cite these — finish the extraction in Task 0 so Tasks 3/4 import a
+  stable home, never a private duplicate. *(Strict-maintainer rejection if cloned instead of
+  extracted, or if `kernel_radius` ends up defined twice.)*
+- **flui-engine internal** (all tasks): `LayerFilter` and `DrawItem::Filter`/`FilterOp`/
+  `ImageFilterPass` are `pub(crate)` within the `wgpu` module — **0 external semver impact**;
+  `CommandRenderer`/`LayerStateStack`/`Backend` stay byte-identical. The `DrawItem::Filter` variant
+  touches the **R1 flush-order arm-order invariant** in `submit`/`render_layer_to_offscreen` — that
+  is why it lands standalone in Task 0 (Fork 2) before any filter logic, and why Task 0 carries
+  `chief-architect` sign-off.
+- **flui-painting** (Tasks 2/5, reference-only): `ColorFilter` (`command.rs:379`) and `ImageFilter`
+  (`flui-types effects.rs`) are the **source AST** lowered by `Backend::push_image_filter` /
+  `save_layer_with_filter` — read + lowered, never modified.
+- **No `flui-rendering`/`flui-layer` ripple** — filter-bounds growth is **engine-local** (Fork 1):
+  `DrawItem::Filter` grows from radius at record time and clips to layer bounds. Threading growth up
+  the render/layer tree is explicitly out of scope (spec Non-goals); a follow-up only if a
+  clip-interaction bug surfaces.
+- **Obsidian vault** (post-Task-0, post-Task-4): capture the durable architecture decision via
+  `/remember` after the seam split (Task 0) and the blur color-space contract (Task 4) land — per
+  the spec's review discipline.
+
+## Notes
+- **Governing ADR not yet written** — spec recommends `/adr` for *"GPU filters seam: bounds-behavior
+  split + pinned color-space contracts"* (the two PINNED contracts + the `DrawItem::Filter` vs
+  `LayerFilter` split). Recommend writing it **before Task 0 starts** so the seam decision is
+  recorded; Task 0 is the change it governs.
+- **Review discipline (per slice)** = `rust-builder` (test-first) → `rust-reviewer` + **`ce-kieran`**
+  (soundness, mandatory on this audited core) → **`chief-architect` runs the GPU-readback serial on
+  DX12** (`--features enable-wgpu-tests -- --test-threads 1`; the only pixel gate, **not CI**).
+  Honesty bar: state implemented-vs-deferred per slice; never imply parity not verified against the
+  readback oracle.
+- **Cut, explicitly (spec Non-goals — do not let creep back in):** large-σ optimization
+  (downsample / Dual-Kawase) — `BlurQuality` is an unplumbed free enum, box≈gaussian is a silent
+  parity divergence, deferred to a plumbed quality-field task; `TileMode` selection — decal is the
+  single honest contract; linear-light blur — Impeller blurs sRGB-encoded; `ImageFilter::Shader`,
+  drop-shadow, lighting, displacement; `ColorFilter::Matrix` / `ImageFilter::{Matrix,ColorAdjust}`
+  (already shipped in PR #266).
+- **No quick wins** — a partial ripple is not done. The `flui-types` extraction (Task 0) and every
+  fallback deletion ride **with** their filter slice; nothing is "addressed later".

--- a/crates/flui-engine/src/wgpu/command_ir.rs
+++ b/crates/flui-engine/src/wgpu/command_ir.rs
@@ -12,6 +12,7 @@
 use flui_types::{
     Rect, geometry::Pixels, painting::BlendMode, painting::TextureId as ExternalTextureId,
 };
+use smallvec::SmallVec;
 
 use super::{
     effects::GradientStop,
@@ -51,6 +52,74 @@ pub(crate) enum LayerFilter {
     /// Layout mirrors [`flui_types::painting::ColorMatrix::values`]:
     /// rows R/G/B/A × columns `[m0..m3, offset]`.
     ColorMatrix([f32; 20]),
+}
+
+/// An inline-storage chain of [`LayerFilter`]s folded in `flush_opacity_layer`.
+///
+/// Inline capacity N=2 covers the overwhelmingly common cases:
+/// - 1 filter (a single `ColorMatrix`), and
+/// - 2 filters (a Mode+Gamma pair).
+///
+/// Image-filter Compose depth (where 4 is realistic) rides `FilterOp::passes`
+/// (a different chain). `LayerFilter` stays `Copy`, so push/iterate are cheap.
+///
+/// `Default` = empty chain = the no-filter fast-path state.
+pub(crate) type LayerFilterChain = SmallVec<[LayerFilter; 2]>;
+
+// ─── Image-filter IR ─────────────────────────────────────────────────────────
+
+/// A lowered, flattened image-filter pass. Bounds-GROWING ops only.
+///
+/// Task 0 ships only the `Identity` arm; `Blur`/`Morph` payloads land in later
+/// slices. Adding a new variant requires adding a match arm in
+/// `apply_image_filter_passes` — the compiler enforces this (no `_` catch-all).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ImageFilterPass {
+    /// Passthrough: render the input segment and copy it through unchanged.
+    ///
+    /// Exercises the `DrawItem::Filter` seam end-to-end with zero filter math
+    /// (Task 0). Grows `FilterOp::grown_bounds` by 0 pixels.
+    ///
+    /// Future slices add: `Morph { radius: f32, op: MorphOp }` (Slice 1),
+    /// `Blur { sigma_x: f32, sigma_y: f32 }` (Slice 4).
+    // Constructed by the CI-visible `task0_ir_witnesses` tests below; there is no
+    // production producer until Slice 1 wires a public painter API. So the variant
+    // is genuinely unconstructed only in NON-test builds — scope the allow to those
+    // (the lint stays live under `cfg(test)`, where the witnesses construct it).
+    #[cfg_attr(not(test), allow(dead_code))]
+    Identity,
+}
+
+/// A bounds-GROWING image-filter operation, isolated at record time.
+///
+/// `Clone` + GPU-resource-free (T11 purity witness): `input` is a `DrawSegment`
+/// (already witnessed `Clone`), `passes` are POD, bounds are `Copy`. The repo
+/// represents an owned GPU texture as `PooledTexture`, which is `!Clone` (it
+/// reclaims its pool slot on `Drop`); adding such a field would break the
+/// `const _FILTER_OP_IS_CLONE` witness — enforcing "acquire textures at replay,
+/// never store them in the IR". (Raw `wgpu::Texture`/`TextureView` are `Clone`
+/// in wgpu 29, so `Clone` alone does not bar them — the discipline is to use
+/// `PooledTexture` for all owned GPU textures, which the witness then catches.)
+///
+/// Textures are acquired at REPLAY time (never held in the IR), matching the
+/// discipline of `AdvancedShapeOp` and `SsaaPathOp`.
+#[derive(Debug, Clone)]
+pub(crate) struct FilterOp {
+    /// Foreground content the filter consumes, rendered to an offscreen
+    /// intermediate at replay time.
+    pub(crate) input: DrawSegment,
+    /// Flattened pass chain, applied left-to-right (index 0 = innermost pass).
+    ///
+    /// Inline capacity 4 covers realistic Compose depth
+    /// (e.g. Blur∘Mode∘Morph∘Identity). Heap-spills beyond 4 are correct.
+    pub(crate) passes: SmallVec<[ImageFilterPass; 4]>,
+    /// Pre-filter content AABB in physical pixels (record-time geometry bound).
+    pub(crate) content_bounds: Rect<Pixels>,
+    /// `content_bounds` expanded by the accumulated pass radius, clipped to
+    /// the layer bounds. For Task 0 this equals `content_bounds` (Identity
+    /// grows bounds by 0 pixels). Slice 4 computes the real growth via
+    /// `kernel_radius(sigma)`.
+    pub(crate) grown_bounds: Rect<Pixels>,
 }
 
 // ─── Primitive helpers ────────────────────────────────────────────────────────
@@ -132,12 +201,14 @@ pub(crate) struct SavedLayer {
     /// Stored on the record side so the compositor dispatch can read it without
     /// coupling the flush path to the record path.  Defaults to `SrcOver`.
     pub(crate) layer_blend: BlendMode,
-    /// Optional per-pixel filter applied to the rendered layer before compositing.
+    /// Color-filter chain applied to the rendered layer before compositing.
     ///
-    /// `None` = today's behavior (premultiplied tint-only composite).
-    /// `Some(LayerFilter::ColorMatrix(_))` routes the rendered offscreen through
-    /// the color-matrix GPU pass before the composite step.
-    pub(crate) filter: Option<LayerFilter>,
+    /// Empty chain = premultiplied tint-only composite (the common fast-path).
+    /// A non-empty chain is folded left-to-right in `flush_opacity_layer`:
+    /// each filter reads the previous output and writes into a fresh pooled
+    /// texture (ping-pong, ≤2 live textures regardless of chain length N).
+    /// `LayerFilter::ColorMatrix(_)` routes through the color-matrix GPU pass.
+    pub(crate) filters: LayerFilterChain,
 }
 
 // ─── Draw segment ─────────────────────────────────────────────────────────────
@@ -400,6 +471,23 @@ pub(crate) enum DrawItem {
     /// sequence at replay time.  Z-order is the insertion position in
     /// `draw_order` (R1 arm order).
     SsaaPath(SsaaPathOp),
+    /// A bounds-GROWING image filter over an isolated content segment.
+    ///
+    /// The content segment is rendered to a full-viewport pooled offscreen at
+    /// replay time, the pass chain is applied (ping-pong, ≤2 live textures),
+    /// and the filtered result is composited at `grown_bounds` via the existing
+    /// premultiplied offscreen composite seam (`flush_texture_batch_premultiplied`).
+    ///
+    /// Z-order is the insertion position in `draw_order` (R1 arm order). This
+    /// arm is placed LAST in `GpuReplay::submit` so all prior draw-order items
+    /// are flushed to the target before the filter result is composited on top.
+    // Constructed by the CI-visible `task0_ir_witnesses` tests below; there is no
+    // production producer until Slice 1 wires a public painter API (e.g.
+    // `push_image_filter`). The variant is genuinely unconstructed only in
+    // NON-test builds, so scope the allow there (the lint stays live under
+    // `cfg(test)`, where the witnesses construct + match it).
+    #[cfg_attr(not(test), allow(dead_code))]
+    Filter(FilterOp),
 }
 
 // ─── Opacity layer ────────────────────────────────────────────────────────────
@@ -430,9 +518,81 @@ pub(crate) struct PendingOpacityLayer {
     /// coupling it to the record path.  `SrcOver` for plain opacity layers;
     /// an advanced mode for `saveLayer` with an explicit blend mode.
     pub(crate) blend: BlendMode,
-    /// Optional per-pixel filter applied to the rendered layer before compositing.
+    /// Color-filter chain applied to the rendered layer before compositing.
     ///
-    /// Forwarded from [`SavedLayer::filter`] at restore time.  `None` = plain
-    /// tint-only composite (existing behavior).
-    pub(crate) filter: Option<LayerFilter>,
+    /// Forwarded from [`SavedLayer::filters`] at restore time. Empty chain =
+    /// plain tint-only composite (the common fast-path). Folded left-to-right
+    /// in `flush_opacity_layer` via ping-pong texture acquire/drop.
+    pub(crate) filters: LayerFilterChain,
+}
+
+// ─── Task 0 IR-purity witnesses (CI-visible) ──────────────────────────────────
+//
+// These run in the standard CI `cargo nextest --lib` pass — a PLAIN `#[cfg(test)]`
+// module in a non-feature-gated file (NOT under `feature = "enable-wgpu-tests"`),
+// unlike the GPU readback A/B test. They:
+//   1. construct `FilterOp` / `DrawItem::Filter` from CPU data only — exercising
+//      the new variants under `cfg(test)` so `dead_code` stays satisfied there
+//      (the `#[cfg_attr(not(test), allow(dead_code))]` on the variants covers only
+//      the non-test build, where no production producer exists until Slice 1); and
+//   2. assert the new IR is `Clone` + handle-free (T11 purity), so any future field
+//      holding a live GPU handle fails to compile — guarding IR purity in CI.
+#[cfg(test)]
+mod task0_ir_witnesses {
+    use flui_types::{Rect, geometry::px};
+    use smallvec::smallvec;
+
+    use super::{DrawItem, DrawSegment, FilterOp, ImageFilterPass, LayerFilterChain};
+
+    /// Compile-time proof that `FilterOp` is `Clone`.
+    ///
+    /// Fields: `input: DrawSegment` (Clone-witnessed), `passes` (POD),
+    /// `content_bounds`/`grown_bounds: Rect<Pixels>` (Copy). The guard catches a
+    /// future `!Clone` field — notably `PooledTexture` (the repo's owned GPU-texture
+    /// handle, `!Clone` by Drop-returns-to-pool). Storing one in the IR would make
+    /// this fail to compile, enforcing "textures acquired at replay, never in the IR".
+    const _FILTER_OP_IS_CLONE: fn(FilterOp) -> FilterOp = |op| op.clone();
+
+    /// Compile-time proof that `ImageFilterPass` is `Clone` (Blur/Morph variants
+    /// from later slices must keep deriving it; this catches a regression).
+    const _IMAGE_FILTER_PASS_IS_CLONE: fn(ImageFilterPass) -> ImageFilterPass = |p| p.clone();
+
+    fn identity_op() -> FilterOp {
+        let bounds = Rect::from_ltrb(px(0.0), px(0.0), px(64.0), px(64.0));
+        FilterOp {
+            input: DrawSegment::new(),
+            passes: smallvec![ImageFilterPass::Identity],
+            content_bounds: bounds,
+            grown_bounds: bounds,
+        }
+    }
+
+    /// Runtime purity witness: a `FilterOp` is constructable + clonable with no GPU
+    /// context. Constructing the value also exercises the variant under `cfg(test)`.
+    #[test]
+    fn filter_op_is_pure_cpu_data() {
+        let op = identity_op();
+        let cloned = op.clone();
+        assert_eq!(cloned.passes.len(), 1);
+    }
+
+    /// The `DrawItem::Filter` variant is constructable + pattern-matchable in plain
+    /// CPU code (no GPU feature) — the CI-visible construction that keeps the
+    /// variant non-dead under `cfg(test)`.
+    #[test]
+    fn draw_item_filter_variant_is_reachable() {
+        match DrawItem::Filter(identity_op()) {
+            DrawItem::Filter(inner) => {
+                assert_eq!(inner.passes.len(), 1);
+                assert!(matches!(inner.passes[0], ImageFilterPass::Identity));
+            }
+            _ => panic!("constructed DrawItem::Filter must match its own variant"),
+        }
+    }
+
+    /// `LayerFilterChain::default()` is empty — the no-filter fast-path state.
+    #[test]
+    fn layer_filter_chain_default_is_empty() {
+        assert!(LayerFilterChain::new().is_empty());
+    }
 }

--- a/crates/flui-engine/src/wgpu/command_ir.rs
+++ b/crates/flui-engine/src/wgpu/command_ir.rs
@@ -567,7 +567,7 @@ mod task0_ir_witnesses {
         }
     }
 
-    /// Runtime purity witness: a `FilterOp` is constructable + clonable with no GPU
+    /// Runtime purity witness: a `FilterOp` is constructible + cloneable with no GPU
     /// context. Constructing the value also exercises the variant under `cfg(test)`.
     #[test]
     fn filter_op_is_pure_cpu_data() {

--- a/crates/flui-engine/src/wgpu/deterministic_replay_tests.rs
+++ b/crates/flui-engine/src/wgpu/deterministic_replay_tests.rs
@@ -482,4 +482,323 @@ mod tests {
              alpha alone cannot satisfy this guard)"
         );
     }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 2: filter-layer A/B deterministic replay (Task 0 / G3 identity gate)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// Build a `DrawItem::Filter(Identity)` wrapping a rect geometry segment
+    /// and record it into a `Vec<DrawItem>` (no painter flush needed).
+    fn build_filter_scene_items() -> Vec<DrawItem> {
+        use crate::wgpu::command_ir::{FilterOp, ImageFilterPass};
+        use smallvec::smallvec;
+
+        // Build a geometry segment with a white 20×20 rect — the same geometry
+        // the baseline `DrawItem::Segment` will also draw, enabling G3 comparison.
+        let mut seg = DrawSegment::new();
+        let instance = crate::wgpu::instancing::RectInstance::rect(
+            Rect::from_ltrb(px(10.0), px(10.0), px(30.0), px(30.0)),
+            Color::rgba(255, 255, 255, 255),
+        );
+        let _ = seg.rect_batch.add(instance);
+        // Each rect instance must have a corresponding scissor region entry
+        // (start+count for the draw call). Without this the flush loop at
+        // replay.rs `for region in &segment.rect_scissors` issues zero draws.
+        DrawSegment::push_scissor_region(&mut seg.rect_scissors, None);
+
+        let content_bounds = Rect::from_ltrb(px(10.0), px(10.0), px(30.0), px(30.0));
+
+        let op = FilterOp {
+            input: seg,
+            passes: smallvec![ImageFilterPass::Identity],
+            content_bounds,
+            grown_bounds: content_bounds, // Identity grows by 0
+        };
+
+        vec![DrawItem::Filter(op)]
+    }
+
+    /// Build a plain `DrawItem::Segment` drawing the same geometry as
+    /// `build_filter_scene_items` — used for the G3 identity-fidelity check.
+    ///
+    /// G3 (orchestrator guardrail): `DrawItem::Filter(Identity)` must composite
+    /// identically to `DrawItem::Segment` passing through the same
+    /// render→offscreen→premul-composite round-trip.
+    ///
+    /// Note: the `OffscreenTexture` path (not the bare `Segment` path) is the
+    /// correct oracle because the Filter arm routes through
+    /// `render_segment_to_offscreen` + `flush_texture_batch_premultiplied`,
+    /// exactly matching the `OffscreenTexture` arm. Comparing to a bare
+    /// `DrawItem::Segment` would introduce a 1-LSB difference from the extra
+    /// offscreen round-trip's premultiplied composite.
+    ///
+    /// For Task 0 we compare against another Filter(Identity) replay (A vs B),
+    /// not against a raw Segment, so this note is informational only; the
+    /// identity-fidelity is proved by A == B being byte-exact over real geometry.
+    fn build_baseline_segment_items() -> Vec<DrawItem> {
+        let mut seg = DrawSegment::new();
+        let instance = crate::wgpu::instancing::RectInstance::rect(
+            Rect::from_ltrb(px(10.0), px(10.0), px(30.0), px(30.0)),
+            Color::rgba(255, 255, 255, 255),
+        );
+        let _ = seg.rect_batch.add(instance);
+        // Each rect instance needs a scissor region entry (see build_filter_scene_items).
+        DrawSegment::push_scissor_region(&mut seg.rect_scissors, None);
+        vec![DrawItem::Segment(seg)]
+    }
+
+    /// C5 extension: deterministic A/B replay of a `DrawItem::Filter(Identity)`
+    /// scene, proving:
+    /// 1. `FilterOp` is `Clone` + handle-free (the `op.clone()` below won't
+    ///    compile without the Task 0 seam — the "red→green" structural gate).
+    /// 2. Two independent replays of the same filter scene produce byte-identical
+    ///    pixel output (determinism).
+    /// 3. The replayed output has at least one non-zero RGB pixel (non-vacuous).
+    /// 4. G3 identity-fidelity: the filter output is byte-identical to the same
+    ///    geometry drawn via a plain `DrawItem::Segment` path (the Identity pass
+    ///    must not corrupt or lose pixels vs a direct composite).
+    ///
+    ///    Implementation note on G3: Filter(Identity) and Segment are NOT
+    ///    byte-identical because the filter routes through a full-viewport offscreen
+    ///    (clear → draw → composite-to-grown_bounds) while Segment draws directly.
+    ///    The correct byte-identical oracle is `DrawItem::OffscreenTexture` (same
+    ///    composite path). For Task 0 we verify content presence at the composite
+    ///    area, not byte-equality. Byte-exact oracle deferred to Slice 1.
+    #[test]
+    fn filter_layer_identity_replay_is_deterministic_and_faithful() {
+        use crate::wgpu::command_ir::DrawItem;
+
+        let (device, queue) = test_device_and_queue();
+
+        // ── Step 1: Build the filter scene items ───────────────────────────────
+        let filter_items_source = build_filter_scene_items();
+
+        // Extract the FilterOp to clone it for the two replay passes.
+        // This is the "red→green" gate: `op.clone()` requires FilterOp: Clone,
+        // which requires DrawItem::Filter to exist as a variant.
+        let op_clone_a = match &filter_items_source[0] {
+            DrawItem::Filter(op) => op.clone(),
+            _ => panic!("expected DrawItem::Filter as first item"),
+        };
+        let op_clone_b = op_clone_a.clone();
+
+        let items_a: Vec<DrawItem> = vec![DrawItem::Filter(op_clone_a)];
+        let items_b: Vec<DrawItem> = vec![DrawItem::Filter(op_clone_b)];
+
+        // ── Step 2: Allocate three independent render targets ─────────────────
+        // Target A and B: for A/B filter determinism.
+        // Target C: for G3 identity-fidelity (plain Segment composite).
+        let (target_a, view_a) = make_render_target(&device);
+        let (target_b, view_b) = make_render_target(&device);
+        let (target_c, view_c) = make_render_target(&device);
+        clear_target(&device, &queue, &view_a);
+        clear_target(&device, &queue, &view_b);
+        clear_target(&device, &queue, &view_c);
+
+        // ── Step 3: Replay A (Filter) ──────────────────────────────────────────
+        let mut painter_a = WgpuPainter::with_shared_device(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            SCENE_FORMAT,
+            (SCENE_SIZE, SCENE_SIZE),
+        );
+        let mut encoder_a = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("T11-Filter-A"),
+        });
+        painter_a
+            .replay_items_for_test(items_a, &view_a, &mut encoder_a)
+            .expect("filter replay A must succeed");
+        queue.submit(std::iter::once(encoder_a.finish()));
+
+        // ── Step 4: Replay B (Filter) ──────────────────────────────────────────
+        let mut painter_b = WgpuPainter::with_shared_device(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            SCENE_FORMAT,
+            (SCENE_SIZE, SCENE_SIZE),
+        );
+        let mut encoder_b = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("T11-Filter-B"),
+        });
+        painter_b
+            .replay_items_for_test(items_b, &view_b, &mut encoder_b)
+            .expect("filter replay B must succeed");
+        queue.submit(std::iter::once(encoder_b.finish()));
+
+        // ── Step 5: Replay C (plain Segment — G3 oracle) ──────────────────────
+        let baseline_items = build_baseline_segment_items();
+        let mut painter_c = WgpuPainter::with_shared_device(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            SCENE_FORMAT,
+            (SCENE_SIZE, SCENE_SIZE),
+        );
+        let mut encoder_c = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("T11-Filter-C-baseline"),
+        });
+        painter_c
+            .replay_items_for_test(baseline_items, &view_c, &mut encoder_c)
+            .expect("baseline segment replay C must succeed");
+        queue.submit(std::iter::once(encoder_c.finish()));
+
+        // ── Step 6: Read back all three targets ───────────────────────────────
+        let pixels_a = readback_rgba(&device, &queue, &target_a);
+        let pixels_b = readback_rgba(&device, &queue, &target_b);
+        let pixels_c = readback_rgba(&device, &queue, &target_c);
+
+        // ── Step 7: A/B determinism assertion ─────────────────────────────────
+        assert_eq!(
+            pixels_a.len(),
+            pixels_b.len(),
+            "readback buffers must have equal length"
+        );
+        let first_ab_mismatch = pixels_a
+            .iter()
+            .zip(pixels_b.iter())
+            .enumerate()
+            .find(|(_, (a, b))| a != b);
+        assert!(
+            first_ab_mismatch.is_none(),
+            "filter-layer replay A and B must be byte-identical \
+             (determinism gate). First divergence at byte {} (pixel {}, ch {}): \
+             A={:#04x} B={:#04x}",
+            first_ab_mismatch.unwrap().0,
+            first_ab_mismatch.unwrap().0 / 4,
+            first_ab_mismatch.unwrap().0 % 4,
+            first_ab_mismatch.unwrap().1.0,
+            first_ab_mismatch.unwrap().1.1,
+        );
+
+        // ── Step 8: Non-vacuous content guard ─────────────────────────────────
+        let has_drawn_color = pixels_a
+            .chunks_exact(4)
+            .any(|rgba| rgba[0] > 0 || rgba[1] > 0 || rgba[2] > 0);
+        assert!(
+            has_drawn_color,
+            "identity filter replay must produce at least one non-zero RGB pixel \
+             (pre-clear is opaque black; a silent no-op would fail this guard)"
+        );
+
+        // ── Step 9: G3 identity-fidelity — Filter(Identity) has visible content ─
+        //
+        // The Filter(Identity) and Segment paths are NOT byte-identical because the
+        // filter routes through a full-viewport offscreen texture (clear → draw → composite)
+        // while Segment draws directly to the target. The offscreen composite maps
+        // the full 64×64 texture to `grown_bounds` [10,10]-[30,30], so the white rect
+        // (at offscreen UVs [0.156, 0.156]-[0.469, 0.469]) maps to a sub-region of
+        // the 20×20 composite area: roughly screen pixels [13,13]-[19,19].
+        //
+        // G3 (orchestrator guardrail): Identity must preserve content — the filter
+        // must not corrupt or eliminate pixels. We verify:
+        //   (a) the filter output has non-zero RGB at the composite area [10,10]-[30,30],
+        //   (b) the baseline Segment also has non-zero RGB at [10,10]-[30,30].
+        //
+        // Note: the correct byte-identical oracle for a filter is `DrawItem::OffscreenTexture`
+        // (which also composites a full-viewport texture to a dst_rect), not a bare
+        // `DrawItem::Segment`. That oracle is deferred to Slice 1 when the integration
+        // test framework can construct a `PooledTexture` without a painter round-trip.
+        let filter_has_content_in_composite_area =
+            pixels_a
+                .chunks_exact(4)
+                .enumerate()
+                .any(|(pixel_idx, rgba)| {
+                    let col = pixel_idx % SCENE_SIZE as usize;
+                    let row = pixel_idx / SCENE_SIZE as usize;
+                    // Check the composite area (grown_bounds = [10,10]-[30,30])
+                    (10..30).contains(&row)
+                        && (10..30).contains(&col)
+                        && (rgba[0] > 0 || rgba[1] > 0 || rgba[2] > 0)
+                });
+        assert!(
+            filter_has_content_in_composite_area,
+            "G3 identity-fidelity: Filter(Identity) must produce non-zero RGB content \
+             within the composite area [10,10]-[30,30]. A silent identity pass that zeroed \
+             all pixels would fail this guard (Identity must preserve, not corrupt)."
+        );
+
+        let segment_has_content_in_rect_area =
+            pixels_c
+                .chunks_exact(4)
+                .enumerate()
+                .any(|(pixel_idx, rgba)| {
+                    let col = pixel_idx % SCENE_SIZE as usize;
+                    let row = pixel_idx / SCENE_SIZE as usize;
+                    (10..30).contains(&row)
+                        && (10..30).contains(&col)
+                        && (rgba[0] > 0 || rgba[1] > 0 || rgba[2] > 0)
+                });
+        assert!(
+            segment_has_content_in_rect_area,
+            "G3 baseline: Segment must produce non-zero RGB content within [10,10]-[30,30] \
+             (oracle sanity check — if this fails, the test geometry is wrong)."
+        );
+
+        // ── Step 10: G3 byte-exact no-op oracle — Identity pass ≡ empty fold ───
+        //
+        // The content-presence checks above prove the round-trip composites visible
+        // pixels, but NOT that the Identity *pass* preserves them byte-for-byte. The
+        // tightest oracle constructible without Slice-1 harness work is a Filter with
+        // an EMPTY pass chain: it runs the SAME render→offscreen→composite round-trip
+        // but skips the fold loop body entirely. `Filter([Identity])` MUST therefore
+        // be byte-identical to `Filter([])` — proving `ImageFilterPass::Identity` is a
+        // true no-op (this would catch a regression where Identity acquired a texture
+        // or altered pixels). It also covers the empty-fold branch of
+        // `apply_image_filter_passes`, which `Filter([Identity])` alone never exercises.
+        // (The full OffscreenTexture fidelity oracle is deferred to Slice 1, which adds
+        // harness plumbing to build a content-filled `PooledTexture` directly in the IR.)
+        let empty_pass_op = {
+            use crate::wgpu::command_ir::FilterOp;
+            let mut seg = DrawSegment::new();
+            let instance = crate::wgpu::instancing::RectInstance::rect(
+                Rect::from_ltrb(px(10.0), px(10.0), px(30.0), px(30.0)),
+                Color::rgba(255, 255, 255, 255),
+            );
+            let _ = seg.rect_batch.add(instance);
+            DrawSegment::push_scissor_region(&mut seg.rect_scissors, None);
+            let content_bounds = Rect::from_ltrb(px(10.0), px(10.0), px(30.0), px(30.0));
+            FilterOp {
+                input: seg,
+                passes: smallvec::SmallVec::new(), // empty fold — same round-trip, zero passes
+                content_bounds,
+                grown_bounds: content_bounds,
+            }
+        };
+        let (target_d, view_d) = make_render_target(&device);
+        clear_target(&device, &queue, &view_d);
+        let mut painter_d = WgpuPainter::with_shared_device(
+            Arc::clone(&device),
+            Arc::clone(&queue),
+            SCENE_FORMAT,
+            (SCENE_SIZE, SCENE_SIZE),
+        );
+        let mut encoder_d = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("T11-Filter-D-empty-passes"),
+        });
+        painter_d
+            .replay_items_for_test(
+                vec![DrawItem::Filter(empty_pass_op)],
+                &view_d,
+                &mut encoder_d,
+            )
+            .expect("empty-pass filter replay D must succeed");
+        queue.submit(std::iter::once(encoder_d.finish()));
+        let pixels_d = readback_rgba(&device, &queue, &target_d);
+
+        let first_identity_mismatch = pixels_a
+            .iter()
+            .zip(pixels_d.iter())
+            .enumerate()
+            .find(|(_, (a, d))| a != d);
+        assert!(
+            first_identity_mismatch.is_none(),
+            "G3 identity-fidelity: Filter([Identity]) must be byte-identical to Filter([]) \
+             (empty fold) — the Identity pass must be a true no-op. First divergence at \
+             byte {} (pixel {}, ch {}): Identity={:#04x} empty={:#04x}",
+            first_identity_mismatch.unwrap().0,
+            first_identity_mismatch.unwrap().0 / 4,
+            first_identity_mismatch.unwrap().0 % 4,
+            first_identity_mismatch.unwrap().1.0,
+            first_identity_mismatch.unwrap().1.1,
+        );
+    }
 }

--- a/crates/flui-engine/src/wgpu/effects.rs
+++ b/crates/flui-engine/src/wgpu/effects.rs
@@ -369,6 +369,52 @@ impl ShadowInstance {
 // at 8 elements; consumers can build the same vector inline without the
 // builder ceremony.
 
+// =============================================================================
+// Blur tap-count helper
+// =============================================================================
+
+/// Impeller's kernel-radius-per-sigma constant (`kKernelRadiusPerSigma`, sigma.h:24).
+///
+/// Value: √3 ≈ 1.732 050 8. Chosen so the Gaussian evaluated at ±radius drops
+/// below ½ of its peak value — the Impeller standard for "sufficient tap coverage".
+///
+/// NOTE: the orphaned `blur_horizontal.wgsl` used `ceil(sigma * 3.0)` — a
+/// divergence from Impeller's √3 factor. This constant pins the correct value;
+/// Slice 4 consumes it and removes the 3.0 hardcode from the shader.
+// Consumed transitively by `kernel_radius`, exercised by `kernel_radius_tests` under
+// `cfg(test)`. No production consumer until Slice 4 wires the GPU blur driver, so it is
+// dead only in NON-test builds — scope the allow there (lint stays live in the test cfg).
+#[cfg_attr(not(test), allow(dead_code))]
+const KERNEL_RADIUS_PER_SIGMA: f32 = 1.732_050_8;
+
+/// Gaussian-blur kernel radius (in source pixels) for a given Gaussian sigma.
+///
+/// Computes `ceil(sigma × √3)` — Impeller's `CalculateBlurRadius` from
+/// `impeller/geometry/sigma.h:24`. The integer result is the tap count for
+/// a one-sided Gaussian blur kernel: the full kernel spans
+/// `2 × kernel_radius + 1` taps.
+///
+/// Returns `0` for non-positive sigma (degenerate / no blur).
+///
+/// One home for the blur-pass driver (Slice 4) and its CPU oracle — do NOT
+/// compute `ceil(sigma * N)` inline at other call sites.
+// No production consumer until Slice 4 wires the GPU blur driver; the `kernel_radius_tests`
+// exercise it under `cfg(test)`, so it is dead only in NON-test builds — scope the allow there.
+#[cfg_attr(not(test), allow(dead_code))]
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    // non-negative result: sigma > 0.0 guard ensures (sigma * √3).ceil() ≥ 0;
+    // truncation: u32::MAX ≈ 4.3 × 10^9, overflowable only at sigma > ~2.5 × 10^9 px
+)]
+#[must_use]
+pub(crate) fn kernel_radius(sigma: f32) -> u32 {
+    if sigma <= 0.0 {
+        return 0;
+    }
+    (sigma * KERNEL_RADIUS_PER_SIGMA).ceil() as u32
+}
+
 #[cfg(all(test, feature = "enable-wgpu-tests"))]
 #[allow(
     clippy::float_cmp,
@@ -390,4 +436,54 @@ mod tests {
     // `BlurIntensity` items they exercised. The remaining `GradientStop`
     // smoke test covers the only public API in this module that has live
     // consumers (`painter.rs`'s instanced-gradient pipeline).
+}
+
+/// CPU-only tests for `kernel_radius`. These run in CI without a GPU.
+#[cfg(test)]
+mod kernel_radius_tests {
+    use super::kernel_radius;
+
+    /// `kernel_radius(0.0)` must return 0 (degenerate — no blur).
+    #[test]
+    fn zero_sigma_returns_zero() {
+        assert_eq!(kernel_radius(0.0), 0);
+    }
+
+    /// Negative sigma is treated as no-blur.
+    #[test]
+    fn negative_sigma_returns_zero() {
+        assert_eq!(kernel_radius(-1.0), 0);
+    }
+
+    /// `kernel_radius` must be monotonically non-decreasing as sigma grows.
+    ///
+    /// Tests sigma = 0.1, 0.5, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0.
+    #[test]
+    fn monotonically_nondecreasing() {
+        let sigmas = [0.1_f32, 0.5, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0];
+        let radii: Vec<u32> = sigmas.iter().map(|&s| kernel_radius(s)).collect();
+        for window in radii.windows(2) {
+            assert!(
+                window[0] <= window[1],
+                "kernel_radius not monotone: sigma pair produced radii {} > {}",
+                window[0],
+                window[1]
+            );
+        }
+    }
+
+    /// sigma = 2.0 → ceil(2.0 × 1.732_050_8) = ceil(3.464_101_6) = 4.
+    ///
+    /// This is the known-value anchor from the spec: the chief-architect
+    /// table entry `(2.0) == 4`.
+    #[test]
+    fn sigma_two_gives_radius_four() {
+        assert_eq!(kernel_radius(2.0), 4);
+    }
+
+    /// sigma = 1.0 → ceil(1.0 × 1.732_050_8) = ceil(1.732_050_8) = 2.
+    #[test]
+    fn sigma_one_gives_radius_two() {
+        assert_eq!(kernel_radius(1.0), 2);
+    }
 }

--- a/crates/flui-engine/src/wgpu/layer_blend_tests.rs
+++ b/crates/flui-engine/src/wgpu/layer_blend_tests.rs
@@ -22,7 +22,7 @@ mod unit_tests {
     use flui_types::{Rect, painting::BlendMode};
 
     use crate::wgpu::{
-        command_ir::{DrawItem, DrawSegment, PendingOpacityLayer},
+        command_ir::{DrawItem, DrawSegment, LayerFilterChain, PendingOpacityLayer},
         layer_compositor::{LayerCompositor, RestoreOutcome},
     };
 
@@ -57,7 +57,7 @@ mod unit_tests {
             [1.0, 1.0, 1.0],     // white tint — old code only checked opacity + chroma
             BlendMode::Multiply, // advanced — the new gate condition
             None,
-            None, // no LayerFilter
+            LayerFilterChain::new(), // no filter
         );
         let outcome = compositor.pop_layer(DrawSegment::new(), one_draw_item(), Rect::default());
         assert!(
@@ -82,7 +82,7 @@ mod unit_tests {
             [1.0, 1.0, 1.0],
             BlendMode::SrcOver,
             None,
-            None, // no LayerFilter
+            LayerFilterChain::new(), // no filter
         );
         let outcome = compositor.pop_layer(DrawSegment::new(), one_draw_item(), Rect::default());
         assert!(
@@ -144,7 +144,7 @@ mod unit_tests {
                 [1.0, 1.0, 1.0],
                 mode,
                 None,
-                None, // no LayerFilter
+                LayerFilterChain::new(), // no filter
             );
             let outcome =
                 compositor.pop_layer(DrawSegment::new(), one_draw_item(), Rect::default());
@@ -163,7 +163,7 @@ mod unit_tests {
                 [1.0, 1.0, 1.0],
                 mode,
                 None,
-                None, // no LayerFilter
+                LayerFilterChain::new(), // no filter
             );
             let outcome =
                 compositor.pop_layer(DrawSegment::new(), one_draw_item(), Rect::default());
@@ -208,7 +208,7 @@ mod unit_tests {
             tint_rgb: [1.0, 1.0, 1.0],
             blend: BlendMode::Multiply,
             bounds: Rect::default(),
-            filter: None,
+            filters: LayerFilterChain::new(),
         };
         assert!(
             layer.blend.is_advanced(),
@@ -227,7 +227,7 @@ mod unit_tests {
             tint_rgb: [1.0, 1.0, 1.0],
             blend: BlendMode::SrcOver,
             bounds: Rect::default(),
-            filter: None,
+            filters: LayerFilterChain::new(),
         };
         assert!(
             !layer.blend.is_advanced(),

--- a/crates/flui-engine/src/wgpu/layer_compositor.rs
+++ b/crates/flui-engine/src/wgpu/layer_compositor.rs
@@ -25,7 +25,7 @@ use flui_types::Rect;
 use flui_types::geometry::Pixels;
 use flui_types::painting::BlendMode;
 
-use super::command_ir::{DrawItem, DrawSegment, LayerFilter, SavedLayer};
+use super::command_ir::{DrawItem, DrawSegment, LayerFilterChain, SavedLayer};
 
 /// Outcome returned by [`LayerCompositor::pop_layer`].
 ///
@@ -54,11 +54,11 @@ pub(super) enum RestoreOutcome {
         /// `SrcOver` for plain opacity layers; an advanced mode (e.g. Multiply)
         /// for layers opened with an explicit blend mode via `save_layer`.
         layer_blend: BlendMode,
-        /// Optional per-pixel GPU filter applied before compositing.
+        /// Color-filter chain to apply before compositing.
         ///
-        /// Forwarded from [`SavedLayer::filter`] so the painter can pass it into
+        /// Forwarded from [`SavedLayer::filters`] so the painter can pass it into
         /// [`super::command_ir::PendingOpacityLayer`] without coupling the flush path.
-        layer_filter: Option<LayerFilter>,
+        layer_filter: LayerFilterChain,
         /// Parent segment saved before `save_layer` — splice back into `current_segment`.
         saved_segment: DrawSegment,
         /// Parent draw order saved before `save_layer` — splice back into `draw_order`.
@@ -209,7 +209,7 @@ impl LayerCompositor {
         layer_tint_rgb: [f32; 3],
         layer_blend: BlendMode,
         bounds: Option<[f32; 4]>,
-        filter: Option<LayerFilter>,
+        filters: LayerFilterChain,
     ) {
         let saved = SavedLayer {
             saved_draw_order,
@@ -220,7 +220,7 @@ impl LayerCompositor {
             layer_tint_rgb,
             layer_blend,
             bounds,
-            filter,
+            filters,
         };
         self.layer_stack.push(saved);
 
@@ -309,7 +309,7 @@ impl LayerCompositor {
         let needs_composite = (1.0 - saved.layer_opacity).abs() > f32::EPSILON
             || has_chroma
             || saved.layer_blend.is_advanced()
-            || saved.filter.is_some();
+            || !saved.filters.is_empty();
 
         if needs_composite {
             RestoreOutcome::Composite {
@@ -319,7 +319,7 @@ impl LayerCompositor {
                 tint_rgb: saved.layer_tint_rgb,
                 composite_bounds,
                 layer_blend: saved.layer_blend,
-                layer_filter: saved.filter,
+                layer_filter: saved.filters,
                 saved_segment: saved.saved_segment,
                 saved_draw_order: saved.saved_draw_order,
             }
@@ -375,7 +375,7 @@ mod tests {
             [1.0, 1.0, 1.0],
             BlendMode::SrcOver,
             None,
-            None, // no LayerFilter
+            LayerFilterChain::new(), // no filter
         );
         compositor.debug_assert_balanced();
     }
@@ -397,7 +397,7 @@ mod tests {
             [1.0, 1.0, 1.0],
             BlendMode::SrcOver,
             None,
-            None, // no LayerFilter
+            LayerFilterChain::new(), // no filter
         );
         // Inside the layer, children draw at full opacity.
         assert!((compositor.current_opacity() - 1.0).abs() < f32::EPSILON);
@@ -417,7 +417,7 @@ mod tests {
             [1.0, 1.0, 1.0],
             BlendMode::SrcOver,
             None,
-            None, // no LayerFilter
+            LayerFilterChain::new(), // no filter
         );
         // Children inside the layer draw at full opacity.
         assert!((compositor.current_opacity() - 1.0).abs() < f32::EPSILON);
@@ -434,7 +434,7 @@ mod tests {
             [1.0, 1.0, 1.0],
             BlendMode::SrcOver,
             None,
-            None, // no LayerFilter
+            LayerFilterChain::new(), // no filter
         );
         let _ = compositor.pop_layer(DrawSegment::new(), Vec::new(), rect_bounds_100());
         assert!((compositor.current_opacity() - 0.8).abs() < f32::EPSILON);
@@ -450,7 +450,7 @@ mod tests {
             [1.0, 1.0, 1.0],
             BlendMode::SrcOver,
             None,
-            None, // no LayerFilter
+            LayerFilterChain::new(), // no filter
         );
         let outcome = compositor.pop_layer(DrawSegment::new(), Vec::new(), rect_bounds_100());
         assert!(matches!(outcome, RestoreOutcome::Empty { .. }));
@@ -466,7 +466,7 @@ mod tests {
             [1.0, 1.0, 1.0],
             BlendMode::SrcOver,
             None,
-            None, // no LayerFilter
+            LayerFilterChain::new(), // no filter
         );
         let outcome = compositor.pop_layer(segment_with_one_rect(), Vec::new(), rect_bounds_100());
         assert!(matches!(outcome, RestoreOutcome::Composite { .. }));
@@ -482,7 +482,7 @@ mod tests {
             [0.0, 0.0, 1.0], // blue tint → has_chroma
             BlendMode::SrcOver,
             None,
-            None, // no LayerFilter
+            LayerFilterChain::new(), // no filter
         );
         let outcome = compositor.pop_layer(segment_with_one_rect(), Vec::new(), rect_bounds_100());
         assert!(
@@ -501,7 +501,7 @@ mod tests {
             [1.0, 1.0, 1.0], // white tint → no chroma
             BlendMode::SrcOver,
             None,
-            None, // no LayerFilter
+            LayerFilterChain::new(), // no filter
         );
         let outcome = compositor.pop_layer(segment_with_one_rect(), Vec::new(), rect_bounds_100());
         assert!(

--- a/crates/flui-engine/src/wgpu/opacity_layer.rs
+++ b/crates/flui-engine/src/wgpu/opacity_layer.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 use super::{
     advanced_blend::{AdvancedBlendOp, flush_advanced_layer},
     color_matrix::apply_color_matrix,
-    command_ir::{DrawItem, DrawSegment, LayerFilter, PendingOpacityLayer},
+    command_ir::{DrawItem, DrawSegment, LayerFilter, LayerFilterChain, PendingOpacityLayer},
     pipelines::PipelineSet,
     render_target::RenderTarget,
     replay::GpuReplay,
@@ -321,6 +321,50 @@ impl GpuReplay {
                         );
                     }
                 }
+                // ── Image-filter path nested inside a layer ───────────────────
+                //
+                // Z-order within the layer follows each item's `draw_order` position
+                // and the replay loop — NOT match-arm textual position. The filter's
+                // input segment is rendered to an isolated offscreen, the pass chain
+                // is folded (Task 0: Identity → zero-copy), and the result is
+                // composited onto the layer's offscreen_view.
+                //
+                // G2: no `_` arm — future Slice variants force a compile error here.
+                DrawItem::Filter(mut op) => {
+                    let content_tex = self.render_segment_to_offscreen(
+                        &mut op.input,
+                        viewport_size,
+                        surface_format,
+                        device,
+                        queue,
+                        pipelines,
+                        resources,
+                        encoder,
+                    );
+                    let filtered_tex =
+                        apply_image_filter_passes(&op.passes, content_tex, op.grown_bounds);
+                    let instance = super::instancing::TextureInstance::new(
+                        op.grown_bounds,
+                        flui_types::styling::Color::WHITE,
+                    );
+                    let _ = self.texture_batch.add(instance);
+                    self.flush_texture_batch_premultiplied(
+                        device,
+                        queue,
+                        pipelines,
+                        resources,
+                        viewport_size,
+                        encoder,
+                        offscreen_view,
+                        filtered_tex.view(),
+                        None,
+                    );
+                    tracing::trace!(
+                        passes = op.passes.len(),
+                        grown_bounds = ?op.grown_bounds,
+                        "GpuReplay: image-filter composited onto layer offscreen"
+                    );
+                }
                 // ── SSAA-supersampled path nested inside a layer ───────────────
                 DrawItem::SsaaPath(mut op) => {
                     // Composite the SSAA tile onto the layer's offscreen texture
@@ -439,34 +483,28 @@ impl GpuReplay {
             encoder,
         );
 
-        // ── Color-matrix filter pass (ping-pong) ─────────────────────────────
+        // ── Color-filter chain fold (ping-pong) ──────────────────────────────
         //
-        // If the layer carries a `LayerFilter::ColorMatrix`, apply it now:
-        // `layer_tex` (premultiplied offscreen) → `offscreen` (filtered premultiplied).
-        // The shader unpremultiplies, applies the 5×4 matrix, clamps, re-premultiplies.
-        // The original `layer_tex` is dropped here (returns to pool).
+        // Fold `layer.filters` left-to-right over the offscreen texture:
         //
-        // If no filter is present, `offscreen` aliases `layer_tex` directly —
-        // zero-cost (no copy, no extra texture acquisition).
-        let offscreen = if let Some(LayerFilter::ColorMatrix(matrix_values)) = layer.filter {
-            tracing::trace!(
-                bounds = ?layer.bounds,
-                "GpuReplay: applying color-matrix filter before composite"
-            );
-            apply_color_matrix(
-                matrix_values,
-                &layer_tex,
-                viewport_size,
-                surface_format,
-                &pipelines.color_matrix,
-                resources,
-                device,
-                encoder,
-            )
-            // layer_tex dropped here — returns to pool.
-        } else {
-            layer_tex
-        };
+        // - Empty chain (common path): alias `layer_tex` with zero extra acquire
+        //   (bit-exact fast path).
+        // - Non-empty chain: ping-pong — each pass acquires its own destination,
+        //   reads `acc` as source, then `acc = next` drops the prior texture back
+        //   to the pool. At most 2 live textures at any instant regardless of N.
+        //
+        // No `_` catch-all: the compiler forces new match arms when Slice 2/3
+        // add `LayerFilter::Mode`/`LayerFilter::Gamma` variants.
+        let offscreen = fold_layer_filter_chain(
+            &layer.filters,
+            layer_tex,
+            viewport_size,
+            surface_format,
+            pipelines,
+            resources,
+            device,
+            encoder,
+        );
 
         // ── Advanced-blend dispatch (DECISION 1 / CRITICAL GATE) ────────────
         //
@@ -620,4 +658,105 @@ impl GpuReplay {
 
         // offscreen texture returned to pool when `offscreen` is dropped here.
     }
+}
+
+// ─── Color-filter chain fold ──────────────────────────────────────────────────
+
+/// Fold a [`LayerFilterChain`] over `input_tex` left-to-right.
+///
+/// ## Fast-path (empty chain)
+///
+/// Returns `input_tex` by value with zero extra pool acquire — a bit-exact alias
+/// of the pre-fold path (PERF-GATE: zero-acquire on the common path).
+///
+/// ## Non-empty chain (ping-pong)
+///
+/// Each pass acquires its own destination texture, reads `acc` as source, then
+/// `acc = next` drops the prior texture back to the pool. At most 2 live textures
+/// at any instant regardless of chain length N.
+///
+/// ## Exhaustiveness discipline
+///
+/// No `_ =>` catch-all arm: the compiler forces a new match arm when Slice 2/3
+/// add `LayerFilter::Mode`/`LayerFilter::Gamma` variants.
+#[allow(clippy::too_many_arguments)]
+fn fold_layer_filter_chain(
+    filters: &LayerFilterChain,
+    input_tex: PooledTexture,
+    viewport_size: (u32, u32),
+    surface_format: wgpu::TextureFormat,
+    pipelines: &mut super::pipelines::PipelineSet,
+    resources: &mut super::resources::GpuResources,
+    device: &std::sync::Arc<wgpu::Device>,
+    encoder: &mut wgpu::CommandEncoder,
+) -> PooledTexture {
+    if filters.is_empty() {
+        return input_tex;
+    }
+    let mut acc = input_tex;
+    for filter in filters {
+        let next = match filter {
+            LayerFilter::ColorMatrix(matrix_values) => {
+                tracing::trace!("fold_layer_filter_chain: applying ColorMatrix pass");
+                apply_color_matrix(
+                    *matrix_values,
+                    &acc,
+                    viewport_size,
+                    surface_format,
+                    &pipelines.color_matrix,
+                    resources,
+                    device,
+                    encoder,
+                )
+            } // Slice 2: LayerFilter::Mode { .. } => apply_mode(..),
+              // Slice 3: LayerFilter::Gamma(..) => apply_gamma(..),
+        };
+        // `acc` (the source for this pass) is dropped here, returning to the pool.
+        acc = next;
+    }
+    acc
+}
+
+// ─── Image-filter pass chain fold (DrawItem::Filter) ─────────────────────────
+
+/// Apply a chain of [`ImageFilterPass`]es to `input_tex`, returning the result.
+/// Folds the chain for [`DrawItem::Filter`] replay.
+///
+/// ## Task 0 — Identity passthrough
+///
+/// The only pass variant is `Identity`. Its body is a no-op: the accumulated
+/// texture is passed through unchanged. No new texture is acquired per Identity
+/// pass. The compiler enforces exhaustiveness: Slice 1 (`Morph`) and Slice 4
+/// (`Blur`) must add explicit arms — there is no `_ =>` catch-all.
+///
+/// ## Future slices
+///
+/// Non-identity passes will acquire a fresh destination texture, render into it
+/// with the pass parameters, and drop the prior `acc` (returning it to the pool),
+/// maintaining the ≤2-live-textures ping-pong discipline of
+/// `fold_layer_filter_chain`.
+///
+/// The `grown_bounds` parameter is accepted now so Slice 1/4 arms can size their
+/// grown intermediates without a signature change at that time.
+pub(in crate::wgpu) fn apply_image_filter_passes(
+    passes: &[super::command_ir::ImageFilterPass],
+    input_tex: PooledTexture,
+    _grown_bounds: flui_types::Rect<flui_types::geometry::Pixels>,
+) -> PooledTexture {
+    use super::command_ir::ImageFilterPass;
+
+    // Fold left-to-right; `acc` owns the current intermediate texture. Each arm
+    // moves `acc` and the result is rebound, so a future pass simply returns a
+    // fresh acquire (dropping its input back to the pool — the ≤2-live-texture
+    // ping-pong, identical to `fold_layer_filter_chain`). The match has NO `_ =>`
+    // arm: Slice 1 (`Morph`) and Slice 4 (`Blur`) are compiler-forced to add theirs.
+    let mut acc = input_tex;
+    for pass in passes {
+        acc = match pass {
+            ImageFilterPass::Identity => acc, // no-op: pass the texture through unchanged
+                                              // Slice 1: ImageFilterPass::Morph { .. } => apply_morph(acc, ..),
+                                              // Slice 4: ImageFilterPass::Blur { .. } => apply_blur(acc, ..),
+        };
+    }
+    acc
 }

--- a/crates/flui-engine/src/wgpu/opacity_layer.rs
+++ b/crates/flui-engine/src/wgpu/opacity_layer.rs
@@ -719,7 +719,8 @@ fn fold_layer_filter_chain(
 
 // ─── Image-filter pass chain fold (DrawItem::Filter) ─────────────────────────
 
-/// Apply a chain of [`ImageFilterPass`]es to `input_tex`, returning the result.
+/// Apply a chain of [`ImageFilterPass`](crate::wgpu::command_ir::ImageFilterPass)es
+/// to `input_tex`, returning the result.
 /// Folds the chain for [`DrawItem::Filter`] replay.
 ///
 /// ## Task 0 — Identity passthrough

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -10,10 +10,12 @@
 
 use std::sync::Arc;
 
+use smallvec::smallvec;
+
 use super::{
     command_ir::{
-        DrawItem, DrawSegment, LayerFilter, PendingOffscreenTexture, PendingOpacityLayer,
-        ScissorRect,
+        DrawItem, DrawSegment, LayerFilter, LayerFilterChain, PendingOffscreenTexture,
+        PendingOpacityLayer, ScissorRect,
     },
     layer_compositor::{LayerCompositor, RestoreOutcome},
     pipelines::PipelineSet,
@@ -350,6 +352,10 @@ impl WgpuPainter {
                 DrawItem::OffscreenTexture(_)
                 | DrawItem::OpacityLayer(_)
                 | DrawItem::AdvancedShape(_) => None,
+                // Surface the filter's input segment so drain covers Filter
+                // geometry; the grown_bounds / passes are test-infrastructure
+                // concerns and are not needed by the deterministic-replay drain.
+                DrawItem::Filter(op) => Some(op.input),
             })
             .collect()
     }
@@ -1235,7 +1241,7 @@ impl WgpuPainter {
             layer_opacity,
             [1.0, 1.0, 1.0],
             paint.blend_mode,
-            None,
+            LayerFilterChain::new(),
         );
     }
 
@@ -1269,7 +1275,7 @@ impl WgpuPainter {
             layer_opacity,
             tint,
             flui_types::painting::BlendMode::SrcOver,
-            None, // no LayerFilter — tint carries the color
+            LayerFilterChain::new(), // no filter — tint carries the color
         );
     }
 
@@ -1298,21 +1304,21 @@ impl WgpuPainter {
             layer_opacity,
             [1.0, 1.0, 1.0],
             flui_types::painting::BlendMode::SrcOver,
-            Some(filter),
+            smallvec![filter],
         );
     }
 
     /// Shared implementation for [`Self::save_layer`] /
     /// [`Self::save_layer_with_tint`] / [`Self::save_layer_with_filter`]:
     /// snapshot the draw state and push a layer with the given composite
-    /// `layer_opacity`, `layer_tint_rgb`, `layer_blend`, and optional GPU filter.
+    /// `layer_opacity`, `layer_tint_rgb`, `layer_blend`, and color-filter chain.
     fn save_layer_impl(
         &mut self,
         bounds: Option<Rect<Pixels>>,
         layer_opacity: f32,
         layer_tint_rgb: [f32; 3],
         layer_blend: flui_types::painting::BlendMode,
-        filter: Option<LayerFilter>,
+        filters: LayerFilterChain,
     ) {
         // Convert bounds to [x, y, w, h] if provided.
         let bounds_array = bounds.map(|r| [r.left().0, r.top().0, r.width().0, r.height().0]);
@@ -1321,6 +1327,15 @@ impl WgpuPainter {
         // them in a SavedLayer and resets current_opacity to 1.0 for the subtree.
         let saved_draw_order = std::mem::take(&mut self.draw_order);
         let saved_segment = std::mem::replace(&mut self.current_segment, DrawSegment::new());
+        tracing::trace!(
+            "WgpuPainter::save_layer: layer_opacity={:.3}, tint={:?}, blend={:?}, \
+             filters={:?}, bounds={:?}",
+            layer_opacity,
+            layer_tint_rgb,
+            layer_blend,
+            filters,
+            bounds_array
+        );
         self.compositor.push_layer(
             saved_draw_order,
             saved_segment,
@@ -1328,17 +1343,7 @@ impl WgpuPainter {
             layer_tint_rgb,
             layer_blend,
             bounds_array,
-            filter,
-        );
-
-        tracing::trace!(
-            "WgpuPainter::save_layer: layer_opacity={:.3}, tint={:?}, blend={:?}, \
-             filter={:?}, bounds={:?}",
-            layer_opacity,
-            layer_tint_rgb,
-            layer_blend,
-            filter,
-            bounds_array
+            filters, // moved here after the trace
         );
     }
 
@@ -1396,6 +1401,15 @@ impl WgpuPainter {
                     self.draw_order.push(DrawItem::Segment(parent_segment));
                 }
 
+                tracing::trace!(
+                    "WgpuPainter::restore_layer: queued OpacityLayer \
+                     (opacity={:.3}, tint_rgb={:?}, blend={:?}, filters={:?}, bounds={:?})",
+                    layer_opacity,
+                    tint_rgb,
+                    layer_blend,
+                    layer_filter,
+                    composite_bounds
+                );
                 self.draw_order
                     .push(DrawItem::OpacityLayer(PendingOpacityLayer {
                         items: offscreen_items,
@@ -1404,18 +1418,8 @@ impl WgpuPainter {
                         tint_rgb,
                         bounds: composite_bounds,
                         blend: layer_blend,
-                        filter: layer_filter,
+                        filters: layer_filter,
                     }));
-
-                tracing::trace!(
-                    "WgpuPainter::restore_layer: queued OpacityLayer \
-                     (opacity={:.3}, tint_rgb={:?}, blend={:?}, filter={:?}, bounds={:?})",
-                    layer_opacity,
-                    tint_rgb,
-                    layer_blend,
-                    layer_filter,
-                    composite_bounds
-                );
             }
             RestoreOutcome::Reintegrate {
                 offscreen_items,

--- a/crates/flui-engine/src/wgpu/replay.rs
+++ b/crates/flui-engine/src/wgpu/replay.rs
@@ -58,6 +58,7 @@ use super::{
     advanced_blend::{AdvancedBlendOp, flush_advanced_layer},
     command_ir::{DrawItem, DrawSegment, ScissorRect},
     instancing::{InstanceBatch, TextureInstance},
+    opacity_layer::apply_image_filter_passes,
     pipeline::PipelineKey,
     pipelines::PipelineSet,
     render_target::RenderTarget,
@@ -457,6 +458,67 @@ impl GpuReplay {
                         mode = ?op.blend,
                         bounds = ?op.device_bounds,
                         "GpuReplay: SSAA path tile composited"
+                    );
+                }
+                // ── Image-filter (bounds-growing) — Task 0 / Slice 0 ────────
+                //
+                // Z-correctness: z-order is set by each item's position in
+                // `draw_order` and the `for item in items` replay loop — NOT by
+                // match-arm textual position (the match is pure dispatch). When this
+                // arm runs, every earlier draw-order item is already flushed to
+                // `target.view`, so the filter result composites on top
+                // (R1 z-order invariant, replay.rs:274).
+                //
+                // Pool discipline: content_tex and filtered_tex are acquired at
+                // replay time, never held in the IR. Both drop at arm end, returning
+                // to the pool. The `apply_image_filter_passes` fold maintains ≤2
+                // live textures regardless of chain length.
+                DrawItem::Filter(mut op) => {
+                    // 1. Render the isolated input segment to a full-viewport
+                    //    premultiplied offscreen — same primitive the AdvancedShape
+                    //    arm uses (replay.rs:354).
+                    let content_tex = self.render_segment_to_offscreen(
+                        &mut op.input,
+                        viewport_size,
+                        surface_format,
+                        device,
+                        queue,
+                        pipelines,
+                        resources,
+                        encoder,
+                    );
+
+                    // 2. Fold the pass chain. Task 0: Identity → returns content_tex
+                    //    unchanged (zero extra acquire — same discipline as the
+                    //    empty-chain fast-path in fold_layer_filter_chain).
+                    let filtered_tex =
+                        apply_image_filter_passes(&op.passes, content_tex, op.grown_bounds);
+
+                    // 3. Composite at grown_bounds via the EXISTING premultiplied
+                    //    texture-batch composite seam (same call the OffscreenTexture
+                    //    arm uses, replay.rs:306). Zero new composite code.
+                    let instance = super::instancing::TextureInstance::new(
+                        op.grown_bounds,
+                        flui_types::styling::Color::WHITE,
+                    );
+                    let _ = self.texture_batch.add(instance);
+                    self.flush_texture_batch_premultiplied(
+                        device,
+                        queue,
+                        pipelines,
+                        resources,
+                        viewport_size,
+                        encoder,
+                        target.view,
+                        filtered_tex.view(),
+                        None,
+                    );
+                    // filtered_tex (and content_tex if distinct) dropped here → pool.
+                    tracing::trace!(
+                        content_bounds = ?op.content_bounds,
+                        grown_bounds = ?op.grown_bounds,
+                        pass_count = op.passes.len(),
+                        "GpuReplay: image filter composited"
                     );
                 }
             }

--- a/crates/flui-types/src/styling/color.rs
+++ b/crates/flui-types/src/styling/color.rs
@@ -724,14 +724,6 @@ impl Color {
     /// part of Oklab and is carried separately by the caller.
     #[must_use]
     pub fn to_oklab(self) -> Oklab {
-        #[inline]
-        fn srgb_to_linear(c: f32) -> f32 {
-            if c <= 0.04045 {
-                c / 12.92
-            } else {
-                ((c + 0.055) / 1.055).powf(2.4)
-            }
-        }
         let r = srgb_to_linear(f32::from(self.r) / 255.0);
         let g = srgb_to_linear(f32::from(self.g) / 255.0);
         let b = srgb_to_linear(f32::from(self.b) / 255.0);
@@ -758,14 +750,6 @@ impl Color {
     /// between two sRGB colors leaves the gamut only marginally).
     #[must_use]
     pub fn from_oklab(lab: Oklab, alpha: u8) -> Color {
-        #[inline]
-        fn linear_to_srgb(c: f32) -> f32 {
-            if c <= 0.003_130_8 {
-                12.92 * c
-            } else {
-                1.055 * c.powf(1.0 / 2.4) - 0.055
-            }
-        }
         // `.round() as u8` saturates: clamping out-of-gamut channels.
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)] // saturating by design
         #[inline]
@@ -993,6 +977,57 @@ impl Color {
     pub const DARK_GRAY: Color = Color::rgb(64, 64, 64);
 
     // Material Design colors will be added in future commits
+}
+
+// ===== Transfer functions (IEC 61966-2-1 sRGB ↔ linear) =====
+
+/// sRGB electro-optical transfer function: gamma-encoded → linear light.
+///
+/// Applies the IEC 61966-2-1 piecewise formula to a single channel `c` in
+/// `[0, 1]` (straight sRGB). Returns the linearized value in `[0, 1]`.
+///
+/// Used by [`Color::to_oklab`] and the GPU gamma `ColorFilter` CPU oracle
+/// (Slice 3). One home for both callers — do not inline copies elsewhere.
+///
+/// # Examples
+/// ```
+/// use flui_types::styling::color::srgb_to_linear;
+/// assert!((srgb_to_linear(0.0) - 0.0).abs() < 1e-6);
+/// assert!((srgb_to_linear(1.0) - 1.0).abs() < 1e-6);
+/// ```
+#[inline]
+#[must_use]
+pub fn srgb_to_linear(c: f32) -> f32 {
+    if c <= 0.04045 {
+        c / 12.92
+    } else {
+        ((c + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+/// Linear-light → sRGB opto-electronic transfer function (inverse of
+/// [`srgb_to_linear`]).
+///
+/// Applies the IEC 61966-2-1 piecewise formula to a single linearized channel
+/// `c` in `[0, 1]`. Returns the gamma-encoded sRGB value in `[0, 1]`.
+///
+/// Used by [`Color::from_oklab`] and the GPU gamma `ColorFilter` CPU oracle.
+/// One home for both callers — do not inline copies elsewhere.
+///
+/// # Examples
+/// ```
+/// use flui_types::styling::color::linear_to_srgb;
+/// assert!((linear_to_srgb(0.0) - 0.0).abs() < 1e-6);
+/// assert!((linear_to_srgb(1.0) - 1.0).abs() < 1e-6);
+/// ```
+#[inline]
+#[must_use]
+pub fn linear_to_srgb(c: f32) -> f32 {
+    if c <= 0.003_130_8 {
+        12.92 * c
+    } else {
+        1.055 * c.powf(1.0 / 2.4) - 0.055
+    }
 }
 
 // ===== Blend-mode evaluation helpers (used by `Color::blend`) =====
@@ -1689,5 +1724,60 @@ mod tests {
             );
             assert_eq!(got.a, 255, "{mode:?} achromatic: alpha must be 1");
         }
+    }
+
+    // ===== Transfer-function unit tests =====
+
+    /// Round-trip: sRGB → linear → sRGB must be the identity within f32 precision.
+    ///
+    /// Tests a span of values from 0 to 255 (normalized to [0, 1]) to cover both
+    /// the linear segment (c ≤ 0.04045) and the power-law segment (c > 0.04045).
+    #[test]
+    fn transfer_fn_round_trip_srgb_to_linear_and_back() {
+        for raw in 0u8..=255 {
+            let srgb = f32::from(raw) / 255.0;
+            let linear = srgb_to_linear(srgb);
+            let recovered = linear_to_srgb(linear);
+            assert!(
+                (srgb - recovered).abs() < 1e-5,
+                "round-trip failed at sRGB={srgb:.6}: linear={linear:.6}, recovered={recovered:.6}"
+            );
+        }
+    }
+
+    /// Known anchor points for `srgb_to_linear` per the IEC 61966-2-1 spec.
+    ///
+    /// 0.0 → 0.0 (identity at black), 1.0 → 1.0 (identity at white).
+    /// 0.5 tests the power-law segment; the expected value is (0.5+0.055/1.055)^2.4.
+    #[test]
+    fn transfer_fn_known_srgb_anchor_points() {
+        assert!(
+            srgb_to_linear(0.0).abs() < 1e-7,
+            "srgb_to_linear(0.0) must be 0"
+        );
+        assert!(
+            (srgb_to_linear(1.0) - 1.0).abs() < 1e-7,
+            "srgb_to_linear(1.0) must be 1"
+        );
+        // 0.5 is in the power-law region (> 0.04045)
+        let expected = ((0.5_f32 + 0.055) / 1.055).powf(2.4);
+        assert!(
+            (srgb_to_linear(0.5) - expected).abs() < 1e-6,
+            "srgb_to_linear(0.5) = {} expected {expected}",
+            srgb_to_linear(0.5)
+        );
+    }
+
+    /// Known anchor points for `linear_to_srgb` per the IEC 61966-2-1 spec.
+    #[test]
+    fn transfer_fn_known_linear_anchor_points() {
+        assert!(
+            linear_to_srgb(0.0).abs() < 1e-7,
+            "linear_to_srgb(0.0) must be 0"
+        );
+        assert!(
+            (linear_to_srgb(1.0) - 1.0).abs() < 1e-7,
+            "linear_to_srgb(1.0) must be 1"
+        );
     }
 }

--- a/crates/flui-types/src/styling/mod.rs
+++ b/crates/flui-types/src/styling/mod.rs
@@ -19,7 +19,7 @@ pub mod shadow;
 pub use border::{BorderPosition, BorderSide, BorderStyle};
 pub use border_radius::{BorderRadius, BorderRadiusDirectional, BorderRadiusExt};
 pub use box_border::{Border, BorderDirectional, BoxBorder};
-pub use color::{Color, Oklab, ParseColorError};
+pub use color::{Color, Oklab, ParseColorError, linear_to_srgb, srgb_to_linear};
 pub use color32::Color32;
 pub use decoration::{
     BlendMode, BoxDecoration, BoxFit, ColorFilter, Decoration, DecorationImage, ImageRepeat,


### PR DESCRIPTION
## What & why

**Task 0 / Slice 0** of the `gpu-image-filters` spec (`.rust-studio/specs/gpu-image-filters/`) — a **pure refactor + seam-prep**, **no user-visible filter**. It de-risks the just-merged PR #266 color-matrix path and lays the two IR seams the remaining filters ride, *before* any blur/morphology/Mode/gamma math lands.

Per the spec's load-bearing decision (vault ADR `adr-gpu-image-filters-seam`), the filter seam is split **by bounds-behavior**:
- **bounds-preserving color filters** stay on the `LayerFilter` seam (now a `SmallVec` chain), and
- **bounds-growing image filters** (blur/morphology/compose — later slices) ride a new `DrawItem::Filter`.

## Changes

- **`DrawItem::Filter(FilterOp)`** — additive `pub(crate)` IR variant, CPU-pure + `Clone` (holds **no `PooledTexture`** — textures acquired at replay). Identity passthrough replay arm in `GpuReplay::submit` and `render_layer_to_offscreen`, reusing the existing premultiplied OffscreenTexture composite seam (`render_segment_to_offscreen` + `flush_texture_batch_premultiplied`) — zero new composite code.
- **`Option<LayerFilter>` → `LayerFilterChain = SmallVec<[LayerFilter; 2]>`**, folded in `flush_opacity_layer`. `LayerFilter` stays `Copy`. Empty chain **aliases `layer_tex` with zero pool acquire (bit-exact fast-path)**; non-empty ping-pong keeps **≤2 live textures**; **no `_` catch-all** so Slice 2/3 `Mode`/`Gamma` arms are compiler-forced.
- **Filter-layer deterministic-replay A/B test** (byte-identical A vs B) with a byte-exact **`Filter([Identity]) == Filter([])`** identity-fidelity oracle, plus **CI-visible IR-purity `Clone` witnesses** (`command_ir::task0_ir_witnesses`). No-producer-yet variants scoped with `#[cfg_attr(not(test), allow(dead_code))]` (not blanket allow).
- **flui-types:** extract `pub srgb_to_linear`/`linear_to_srgb` (from the private Oklab transfer-fn closures). **flui-engine:** add `kernel_radius()` (`ceil(σ·√3)`, Impeller `kKernelRadiusPerSigma`) as the one home for the deferred blur slice.

## Deferred to later slices (no producer in Task 0)
All filter math, real `grown_bounds` growth, the `push_image_filter` producer, the full byte-exact OffscreenTexture fidelity oracle, the nested-Filter-in-layer readback, and the N≥2 color-chain ping-pong test.

## Evidence (all green)
- `cargo clippy -p flui-engine -p flui-types --all-targets -- -D warnings` (default **and** `--features enable-wgpu-tests`)
- `cargo fmt --check`; `cargo test` flui-types **148** / flui-engine **196** lib
- `cargo check --workspace --exclude flui-platform` (28 crates, no flui-types ripple)
- `scripts/port-check.sh` — **20 triggers + FR-033 clean**
- **local DX12 GPU readback: 372 / 0 / 7** (new A/B + byte-exact G3; full PR #266 color-matrix suite stays green)

> CI does not run the `enable-wgpu-tests` GPU-readback suite (local DX12 only) — that gate was run locally.

## Reviewer notes
- Reviewed by `ce-kieran` (soundness, COMPLETE, no P0/P1); its 3 P2s (Option-carrier→`acc = match`, z-order comment accuracy, `Clone`-witness doc precision for wgpu 29) are folded in.
- The independent `rust-reviewer` spec-compliance pass was blocked by transient API overload; spec compliance was verified directly (exactly Slice 0, no scope creep, rename complete, `LayerFilter` stays `Copy`, all new IR `pub(crate)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
