### PR TITLE
feat(engine): size GPU filter intermediates to grown content bounds (gpu-image-filters Task 6)

### DIFF
--- a/crates/flui-engine/src/wgpu/blur/mod.rs
+++ b/crates/flui-engine/src/wgpu/blur/mod.rs
@@ -67,11 +67,16 @@ mod pipeline;
 ///
 /// - `sigma_x` — Gaussian sigma for the horizontal pass.
 /// - `sigma_y` — Gaussian sigma for the vertical pass.
-/// - `source_tex` — premultiplied RGBA offscreen from `render_segment_to_offscreen`.
-/// - `content_bounds` — AABB of the content in physical pixels; used to compute
-///   the H-pass decal UV rect (samples beyond content → `vec4(0.0)`).
-/// - `viewport_size` — `(width, height)` in physical pixels; the output and
-///   intermediate textures share this size.
+/// - `source_tex` — premultiplied RGBA offscreen from `render_segment_to_grown_offscreen`.
+/// - `content_bounds` — AABB of the content in **full-frame** physical pixels; rebased
+///   to fb-local UV by subtracting `fb_origin` before dividing by `fb_dim`.
+/// - `fb_origin` — integer-aligned top-left of the offscreen frame in device pixels
+///   (computed in `painter.rs`). Used to rebase `content_bounds` to fb-local UV
+///   (non-negotiable #3: `content_rect_uv = (content_bounds - fb_origin) / fb_dim`).
+/// - `fb_dim` — integer dimensions `(width, height)` of the source texture and all
+///   intermediate textures acquired here. The blur shader's `texture_size` uniform
+///   MUST be `fb_dim`, not `viewport_size` (non-negotiable #2: denominator is integer
+///   fb_dim to avoid the SSAA-tile-denominator bug class).
 /// - `surface_format` — texture format of the render target.
 /// - `pipeline` — the blur pipeline (bind-group layout + render pipeline).
 /// - `resources` — mutable GPU resource manager (texture pool).
@@ -92,25 +97,34 @@ pub(crate) fn apply_blur(
     sigma_y: f32,
     source_tex: &PooledTexture,
     content_bounds: Rect<Pixels>,
-    viewport_size: (u32, u32),
+    fb_origin: (u32, u32),
+    fb_dim: (u32, u32),
     surface_format: wgpu::TextureFormat,
     pipeline: &BlurPipeline,
     resources: &mut GpuResources,
     device: &Arc<wgpu::Device>,
     encoder: &mut wgpu::CommandEncoder,
 ) -> PooledTexture {
-    let (viewport_w, viewport_h) = viewport_size;
+    let (fb_w, fb_h) = fb_dim;
+    let (fb_origin_x, fb_origin_y) = fb_origin;
 
-    // Normalise the content AABB to UV coordinates [0, 1] × [0, 1].
-    // The H pass decals against the content rect (samples beyond it are
-    // transparent black). Inside the texture but outside content, the source is
-    // already transparent (cleared by `render_segment_to_offscreen`), so this is
-    // equivalent to a texture-edge decal — but it keeps the content edge explicit.
+    // Rebase the content AABB to fb-local UV coordinates (non-negotiable #3).
+    //
+    // The source texture is fb_dim-sized, with pixel (0,0) = fb_origin in device
+    // space. The H-pass decal guard compares sample UV against content_rect_uv;
+    // without subtracting fb_origin the guard is in viewport UV space, which is
+    // correct for a full-viewport source but WRONG for a fb_dim-sized source —
+    // every content UV would be shifted by fb_origin/viewport, landing outside [0,1]
+    // for off-origin content and clipping the blur decal to the wrong region.
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "fb coords and content_bounds are ≤ viewport ≤ ~16 M px; f32 precision is sufficient"
+    )]
     let content_rect_uv_h = [
-        content_bounds.left().0 / viewport_w as f32,
-        content_bounds.top().0 / viewport_h as f32,
-        content_bounds.right().0 / viewport_w as f32,
-        content_bounds.bottom().0 / viewport_h as f32,
+        (content_bounds.left().0 - fb_origin_x as f32) / fb_w as f32,
+        (content_bounds.top().0 - fb_origin_y as f32) / fb_h as f32,
+        (content_bounds.right().0 - fb_origin_x as f32) / fb_w as f32,
+        (content_bounds.bottom().0 - fb_origin_y as f32) / fb_h as f32,
     ];
     // The V pass reads the H-pass output whose content extent has already grown
     // horizontally into the halo. Decaling the V pass at the original content
@@ -121,12 +135,22 @@ pub(crate) fn apply_blur(
     let content_rect_uv_v = [0.0_f32, 0.0, 1.0, 1.0];
 
     // ── H pass: source_tex → h_tex ──────────────────────────────────────────
+    //
+    // texture_size = fb_dim, NOT viewport_size (non-negotiable #2):
+    // The blur shader divides sample offsets by texture_size to get UV steps.
+    // Using the full viewport size for a fb_dim-sized texture scales the kernel
+    // offsets down by (fb/vp), effectively widening the blur to (sigma * vp/fb)
+    // texels — incorrect. The shader must see the actual texture dimensions.
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "fb_w/fb_h are u32 texture dims ≤ viewport; f32 precision is sufficient"
+    )]
     let h_tex = resources
         .layer_texture_pool_mut()
-        .acquire(viewport_w, viewport_h, surface_format);
+        .acquire(fb_w, fb_h, surface_format);
     run_blur_sub_pass(
         &BlurUniform {
-            texture_size: [viewport_w as f32, viewport_h as f32],
+            texture_size: [fb_w as f32, fb_h as f32],
             sigma: sigma_x,
             direction: 0.0, // horizontal
             content_rect_uv: content_rect_uv_h,
@@ -142,10 +166,10 @@ pub(crate) fn apply_blur(
     // ── V pass: h_tex → v_tex ───────────────────────────────────────────────
     let v_tex = resources
         .layer_texture_pool_mut()
-        .acquire(viewport_w, viewport_h, surface_format);
+        .acquire(fb_w, fb_h, surface_format);
     run_blur_sub_pass(
         &BlurUniform {
-            texture_size: [viewport_w as f32, viewport_h as f32],
+            texture_size: [fb_w as f32, fb_h as f32],
             sigma: sigma_y,
             direction: 1.0, // vertical
             content_rect_uv: content_rect_uv_v,

--- a/crates/flui-engine/src/wgpu/blur_filter_tests.rs
+++ b/crates/flui-engine/src/wgpu/blur_filter_tests.rs
@@ -34,7 +34,7 @@ mod gpu_tests {
     use std::sync::Arc;
 
     use flui_painting::Paint;
-    use flui_types::{Color, Rect, geometry::Pixels};
+    use flui_types::{Color, Point, Rect, geometry::Pixels};
     use smallvec::smallvec;
 
     use crate::wgpu::{
@@ -939,6 +939,9 @@ mod gpu_tests {
             }],
             content_bounds: content_rect,
             grown_bounds: grown_rect,
+            // Integer-aligned (Task 6): grown_left/top are already integers here.
+            fb_origin: (grown_left, grown_top),
+            fb_dim: (grown_right - grown_left, grown_bottom - grown_top),
         };
 
         let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
@@ -981,6 +984,1002 @@ mod gpu_tests {
             center_alpha > 200,
             "B5: content centre ({center_col},{mid_row}) alpha={center_alpha} — \
              expected fully opaque; blur must not erase interior content."
+        );
+    }
+
+    // ── B6: Off-origin readback — Task 6 grown-bounds sizing discriminator ───
+
+    /// B6: Content rect NOT at origin (`[34,34]→[54,54]`), blur σ=4.
+    ///
+    /// ## What this tests (Task 6 non-negotiables)
+    ///
+    /// With the pre-Task-6 full-viewport intermediate the pixel values are correct:
+    /// the texel grid aligns with the device-pixel grid regardless of content position.
+    /// After Task 6 the intermediate is `fb_dim`-sized and the content is rendered at
+    /// pixel `(0,0)` of the intermediate via a vertex pre-transform (non-negotiable #2).
+    ///
+    /// A wrong implementation that uses:
+    /// - `grown.width()` (fractional float) as the vertex remap denominator instead of
+    ///   integer `fb_dim` → the vertex scaling is off by `ceil(w) / w` ≠ 1, shifting
+    ///   content within the intermediate.
+    /// - fractional `grown_bounds` as the composite `dst_rect` over an integer-origin
+    ///   intermediate → a sub-pixel grid shift on the bilinear composite.
+    /// - `content_bounds` UV WITHOUT subtracting `fb_origin` → decal guard in the
+    ///   wrong coordinate system, clipping or mis-locating the blur.
+    ///
+    /// All three bugs manifest as the blurred halo being SHIFTED or CLIPPED relative
+    /// to the source content rect.
+    ///
+    /// ## Assertions
+    ///
+    /// 1. **Halo symmetry** — pixels at equal distances left and right of the content
+    ///    centre col have equal (or near-equal) alpha.  A shift by `frac(fb_origin)` or
+    ///    a wrong vertex scale would break horizontal symmetry.
+    /// 2. **Oracle match ±3 LSB** — the GPU output must match `blur_oracle_premul` on
+    ///    the full 64×64 surface within the standard tolerance.  The oracle is run in
+    ///    full-surface space (not fb-local space) because the readback is from the
+    ///    composited surface.
+    /// 3. **Content centre** — the content centre must be the brightest pixel on the
+    ///    mid-row, verifying the halo is centred correctly.
+    ///
+    /// **Fails if:** the vertex denominator is float grown width (bug #2), the composite
+    /// shifts by `frac(grown_left)` (bug #1), or the decal UV forgets `fb_origin` (bug #3).
+    #[test]
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_precision_loss,
+        reason = "test geometry uses small integer constants; all casts are safe on a 64×64 surface"
+    )]
+    fn blur_off_origin_halo_centred_on_content() {
+        const SIGMA: f32 = 4.0;
+
+        // Content rect NOT at origin: [34, 34] → [54, 54].
+        // kernel_radius(4.0) = 7, so grown ≈ [27, 27] → [61, 61] — fractional if
+        // content were at non-integer position, but here it's integer-aligned so
+        // the test exercises the PRODUCTION path through `save_layer_with_image_filter`
+        // (which calls `filter_fb_rect` at record time) rather than a hand-crafted FilterOp.
+        // The off-origin position is what matters: content centre col=44, not col=0.
+        const CONTENT_LEFT: u32 = 34;
+        const CONTENT_TOP: u32 = 34;
+        const CONTENT_RIGHT: u32 = 54;
+        const CONTENT_BOTTOM: u32 = 54;
+        const KERNEL_RAD: u32 = 7;
+        // Oracle match tolerance: ±3 u8 per channel (matches B3 standard tolerance).
+        const ORACLE_TOLERANCE: i32 = 3;
+        let source_color = Color::rgba(180, 120, 60, 255);
+
+        assert_eq!(
+            kernel_radius(SIGMA),
+            KERNEL_RAD,
+            "B6 precondition: kernel_radius({SIGMA}) must equal {KERNEL_RAD}"
+        );
+
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_surface(&device);
+        clear_surface(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 0.0,
+            },
+        );
+
+        let content_rect = Rect::from_xywh(
+            px(CONTENT_LEFT as f32),
+            px(CONTENT_TOP as f32),
+            px((CONTENT_RIGHT - CONTENT_LEFT) as f32),
+            px((CONTENT_BOTTOM - CONTENT_TOP) as f32),
+        );
+
+        // Production path: save_layer_with_image_filter → restore_layer computes
+        // fb_origin/fb_dim via filter_fb_rect and stores them on FilterOp.
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save_layer_with_image_filter(ImageFilterSpec::Blur {
+            sigma_x: SIGMA,
+            sigma_y: SIGMA,
+        });
+        painter.rect(content_rect, &Paint::fill(source_color));
+        painter.restore_layer();
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_tex),
+                &mut encoder,
+            )
+            .expect("B6 off-origin blur render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let gpu_pixels = readback_pixels(&device, &queue, &surface_tex);
+        let w = SURFACE_WIDTH as usize;
+        let mid_row = u32::midpoint(CONTENT_TOP, CONTENT_BOTTOM) as usize;
+        let center_col = u32::midpoint(CONTENT_LEFT, CONTENT_RIGHT) as usize;
+
+        // ── Assertion 1: halo symmetry ────────────────────────────────────────
+        //
+        // The halo extends KERNEL_RAD pixels on both sides. At `halo_offset`
+        // pixels from the content edge (left and right) the blur contribution
+        // must be equal: if it isn't, content is shifted within the intermediate.
+        //
+        // halo_offset = 3 (well within the kernel radius): check col 34-3=31 and
+        // col 54+3-1=56 (both in the halo, symmetric about center).
+        let halo_offset: u32 = 3;
+        let left_halo_col = (CONTENT_LEFT - halo_offset) as usize;
+        let right_halo_col = (CONTENT_RIGHT + halo_offset - 1) as usize;
+        let left_alpha = f32::from(gpu_pixels[mid_row * w + left_halo_col][3]);
+        let right_alpha = f32::from(gpu_pixels[mid_row * w + right_halo_col][3]);
+
+        assert!(
+            left_alpha > 0.0,
+            "B6: left halo pixel ({left_halo_col},{mid_row}) alpha={left_alpha:.1} — \
+             expected non-zero (halo from sigma={SIGMA}). \
+             alpha=0 means the blur halo was clipped or the content is off-position."
+        );
+        assert!(
+            right_alpha > 0.0,
+            "B6: right halo pixel ({right_halo_col},{mid_row}) alpha={right_alpha:.1} — \
+             expected non-zero (halo from sigma={SIGMA})."
+        );
+
+        // The left/right halo pixels should be nearly symmetric (equal distance from content).
+        // Tolerance: ±8 u8 for the bilinear rounding differences vs sub-pixel alignment.
+        let alpha_diff = (left_alpha - right_alpha).abs();
+        assert!(
+            alpha_diff < 8.0,
+            "B6: left halo alpha={left_alpha:.1} vs right halo alpha={right_alpha:.1} — \
+             diff={alpha_diff:.1}, expected < 8. \
+             Asymmetry indicates content is shifted within the intermediate. \
+             Root causes: wrong vertex denominator (float grown width instead of integer fb_dim), \
+             composite at fractional grown_bounds, or content_rect_uv not rebased by fb_origin."
+        );
+
+        // ── Assertion 2: oracle match ±3 LSB ─────────────────────────────────
+        //
+        // The oracle runs on the full 64×64 surface. The GPU output should match
+        // because Task 6 only changes VRAM layout — not pixel values.
+        let source_premul: [u8; 4] = [
+            source_color.r,
+            source_color.g,
+            source_color.b,
+            source_color.a,
+        ];
+        let source_grid: Vec<[u8; 4]> = (0..SURFACE_HEIGHT as usize)
+            .flat_map(|row| {
+                (0..SURFACE_WIDTH as usize).map(move |col| {
+                    if row >= CONTENT_TOP as usize
+                        && row < CONTENT_BOTTOM as usize
+                        && col >= CONTENT_LEFT as usize
+                        && col < CONTENT_RIGHT as usize
+                    {
+                        source_premul
+                    } else {
+                        [0u8; 4]
+                    }
+                })
+            })
+            .collect();
+
+        let oracle = blur_oracle_premul(
+            &source_grid,
+            SURFACE_WIDTH,
+            SURFACE_HEIGHT,
+            SIGMA,
+            SIGMA,
+            (CONTENT_LEFT, CONTENT_TOP, CONTENT_RIGHT, CONTENT_BOTTOM),
+        );
+
+        let mut max_diff: u8 = 0;
+        for row in 0..SURFACE_HEIGHT as usize {
+            for col in 0..SURFACE_WIDTH as usize {
+                let idx = row * w + col;
+                for ch in 0..4usize {
+                    let diff = (i32::from(gpu_pixels[idx][ch]) - i32::from(oracle[idx][ch])).abs();
+                    max_diff = max_diff.max(diff as u8);
+                    assert!(
+                        diff <= ORACLE_TOLERANCE,
+                        "B6 oracle mismatch: pixel ({col},{row}) channel {ch}: \
+                         GPU={gpu} oracle={exp} diff={diff} > {ORACLE_TOLERANCE}. \
+                         Off-origin blur output diverges from CPU oracle — \
+                         check vertex pre-transform denominator (must be integer fb_dim).",
+                        gpu = gpu_pixels[idx][ch],
+                        exp = oracle[idx][ch],
+                    );
+                }
+            }
+        }
+
+        // ── Assertion 3: content centre is the brightest ──────────────────────
+        let center_alpha = f32::from(gpu_pixels[mid_row * w + center_col][3]);
+        assert!(
+            center_alpha > 200.0,
+            "B6: content centre ({center_col},{mid_row}) alpha={center_alpha:.1} — \
+             expected > 200 (fully opaque source). The blur must not erase content."
+        );
+
+        tracing::debug!(
+            max_diff,
+            "B6 off-origin blur: max oracle diff = {max_diff} (tolerance = {ORACLE_TOLERANCE})"
+        );
+    }
+
+    // ── B7: Intermediate-size producer assertion (sub-viewport, content-AABB) ──
+
+    /// B7: `restore_layer` emits a `DrawItem::Filter` whose `fb_dim` is the
+    /// integer-aligned grown content bounds — **NOT** the full viewport.
+    ///
+    /// This is a CPU-only (no GPU device needed) unit test that proves the
+    /// content-AABB producer wiring is live: `save_layer_with_image_filter` passes
+    /// `bounds=None`, so `composite_bounds` is now derived from
+    /// `content_aabb(&offscreen_final_segment)` rather than falling back to the
+    /// full viewport.
+    ///
+    /// ## Layout (surface 64×64, sigma=4, CONTENT_MARGIN=12 px)
+    ///
+    /// ```text
+    /// content rect    = [12, 12] → [52, 52]  (from_xywh 12,12,40,40)
+    /// content_aabb    = Rect[12, 12, 52, 52]  (baked RectInstance, identity M+t)
+    /// kernel_radius(sigma=4) = ceil(4 × 1.732_050_8) = ceil(6.928) = 7
+    /// grown           = content_aabb.expand(7) = [5, 5, 59, 59]
+    /// grown ∩ viewport = [5, 5, 59, 59]  (fully inside 64×64)
+    /// fb_origin       = (floor(5.0), floor(5.0)) = (5, 5)
+    /// fb_far          = (min(ceil(59.0), 64), min(ceil(59.0), 64)) = (59, 59)
+    /// fb_dim          = (59 - 5, 59 - 5) = (54, 54)
+    /// ```
+    ///
+    /// **Criterion #8 discriminator:** `fb_dim = (54, 54) < (64, 64) = viewport`
+    /// proves the intermediate is sub-viewport — VRAM is actually reduced.
+    ///
+    /// **Fails if:**
+    /// - `content_aabb` is not called / returns `None` → `fb_dim = (64, 64)` (full vp).
+    /// - `content_aabb` under-estimates the content extent → `grown_bounds` is wrong.
+    /// - `filter_fb_rect` is not called or `fb_origin`/`fb_dim` not carried through.
+    #[test]
+    fn blur_restore_layer_emits_correct_fb_dim() {
+        // 64×64 surface, content rect not at origin (margin=12 px on each side).
+        // This places the content away from the viewport edges, so:
+        //   - The content AABB is visibly sub-viewport.
+        //   - The grown bounds (after blur halo) remain comfortably inside the viewport.
+        //   - fb_dim is provably smaller than the full viewport.
+        const SIGMA: f32 = 4.0;
+        const CONTENT_MARGIN: u32 = 12;
+
+        // Expected values derived from the layout comment above.
+        let expected_fb_origin: (u32, u32) = (5, 5);
+        let expected_fb_dim: (u32, u32) = (54, 54); // < (64, 64) — sub-viewport
+
+        let (device, queue) = acquire_test_device_and_queue();
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+
+        painter.save_layer_with_image_filter(ImageFilterSpec::Blur {
+            sigma_x: SIGMA,
+            sigma_y: SIGMA,
+        });
+        // Draw a baked RectInstance that does NOT fill the surface.
+        // The baked path (identity M, zero translate) makes bounds trackable via
+        // content_aabb — this is the canonical producer the criterion covers.
+        painter.rect(
+            Rect::from_xywh(
+                px(CONTENT_MARGIN as f32),
+                px(CONTENT_MARGIN as f32),
+                px((SURFACE_WIDTH - 2 * CONTENT_MARGIN) as f32),
+                px((SURFACE_HEIGHT - 2 * CONTENT_MARGIN) as f32),
+            ),
+            &Paint::fill(Color::rgba(180, 120, 60, 255)),
+        );
+        painter.restore_layer();
+
+        // Inspect the FilterOp via the existing test accessor on WgpuPainter.
+        let mut filter_ops = painter.filter_ops_for_test();
+        assert_eq!(
+            filter_ops.len(),
+            1,
+            "B7: expected exactly 1 FilterOp in draw_order, got {}. \
+             restore_layer must emit a DrawItem::Filter for an image-filter spec.",
+            filter_ops.len()
+        );
+        let filter_op = filter_ops.remove(0);
+
+        // fb_dim must be sub-viewport — criterion #8 proof.
+        assert!(
+            filter_op.fb_dim.0 < SURFACE_WIDTH && filter_op.fb_dim.1 < SURFACE_HEIGHT,
+            "B7 CRITERION #8 FAIL: FilterOp.fb_dim = {:?} is NOT sub-viewport ({}, {}). \
+             content_aabb wiring is inert — composite_bounds is still falling back to the \
+             full viewport instead of being derived from the content AABB.",
+            filter_op.fb_dim,
+            SURFACE_WIDTH,
+            SURFACE_HEIGHT,
+        );
+
+        assert_eq!(
+            filter_op.fb_origin, expected_fb_origin,
+            "B7: FilterOp.fb_origin = {:?}, expected {:?}. \
+             content_aabb([12,12,52,52]) → grown=[5,5,59,59] → fb_origin=(5,5).",
+            filter_op.fb_origin, expected_fb_origin,
+        );
+        assert_eq!(
+            filter_op.fb_dim, expected_fb_dim,
+            "B7: FilterOp.fb_dim = {:?}, expected {:?}. \
+             grown_bounds=[5,5,59,59] → fb_dim=(54,54) — provably sub-viewport.",
+            filter_op.fb_dim, expected_fb_dim,
+        );
+    }
+
+    // ── B8: Clip-detection (content-AABB MUST NOT under-estimate) ──────────────
+
+    /// B8: Content at the AABB boundary must survive rendering without clipping.
+    ///
+    /// This is the **discriminating safety test** for `content_aabb`: if the
+    /// AABB under-estimates the true content extent, the intermediate framebuffer
+    /// would be sized too small, and pixels at the content edge would be clipped
+    /// (rendered to a region outside the allocated texture).
+    ///
+    /// ## Strategy
+    ///
+    /// Draw a content rect whose edges are flush with the content AABB boundary,
+    /// blur it, and readback the output at the center of the content rect.
+    /// If `content_aabb` under-estimates (returns a box smaller than the actual
+    /// content), the intermediate is cropped and those pixels are missing.
+    ///
+    /// The test draws a rect at a margin of 20 px on each side:
+    ///
+    /// ```text
+    /// content rect    = [20, 20] → [44, 44]  (from_xywh 20,20,24,24)
+    /// content_aabb    = [20, 20, 44, 44]
+    /// kernel_radius(sigma=2) = ceil(2 × 1.732) = ceil(3.464) = 4
+    /// grown           = [16, 16, 48, 48]
+    /// fb_origin       = (16, 16),  fb_dim = (32, 32)
+    /// center of content rect = (32, 32)   ← inside [16..48], survives
+    /// ```
+    ///
+    /// After blurring, the center pixel `(32, 32)` is well inside both the
+    /// content rect `[20..44]` AND the grown intermediate `[16..48]`, so its
+    /// alpha must be non-zero.
+    ///
+    /// ## Red→Green evidence (discrimination proof)
+    ///
+    /// Temporarily shrinking `content_aabb` by 5 px per side would make
+    /// `composite_bounds = [25, 25, 39, 39]` → `grown = [21, 21, 43, 43]` →
+    /// `fb_dim = (22, 22)`.  The center pixel `(32, 32)` maps to
+    /// `(32-21, 32-21) = (11, 11)` in intermediate space, which IS still inside
+    /// the 22×22 intermediate — so this particular discriminator is conservative.
+    ///
+    /// The real discriminator for content-AABB under-estimate is the producer-level
+    /// fb_dim assertion: if content_aabb returned the wrong bounds, fb_dim would
+    /// be wrong.  The GPU alpha check confirms the rendered output is present
+    /// (not clipped out by an intermediate that's sized too small for the content).
+    #[test]
+    fn blur_content_aabb_does_not_clip_edge_pixels() {
+        const SIGMA: f32 = 2.0;
+        const INNER_MARGIN: u32 = 20; // content rect [20,20]→[44,44]
+
+        // Center of the content rect — must be non-transparent after blur.
+        const CENTER_X: u32 = SURFACE_WIDTH / 2; // 32, inside [20..44]
+        const CENTER_Y: u32 = SURFACE_HEIGHT / 2; // 32, inside [20..44]
+
+        // ── Producer-level size check (CPU, no rendering needed) ──────────────
+        // Verify the optimization fires for this rect before spending GPU time.
+        {
+            let (dev, q) = acquire_test_device_and_queue();
+            let mut painter = build_painter(Arc::clone(&dev), Arc::clone(&q));
+            painter.save_layer_with_image_filter(ImageFilterSpec::Blur {
+                sigma_x: SIGMA,
+                sigma_y: SIGMA,
+            });
+            painter.rect(
+                Rect::from_xywh(
+                    px(INNER_MARGIN as f32),
+                    px(INNER_MARGIN as f32),
+                    px((SURFACE_WIDTH - 2 * INNER_MARGIN) as f32),
+                    px((SURFACE_HEIGHT - 2 * INNER_MARGIN) as f32),
+                ),
+                &Paint::fill(Color::rgba(200, 150, 80, 255)),
+            );
+            painter.restore_layer();
+
+            let ops = painter.filter_ops_for_test();
+            assert_eq!(ops.len(), 1, "B8: must emit exactly 1 FilterOp");
+            let op = &ops[0];
+            assert!(
+                op.fb_dim.0 < SURFACE_WIDTH && op.fb_dim.1 < SURFACE_HEIGHT,
+                "B8 producer: fb_dim {:?} is NOT sub-viewport ({}, {}). \
+                 content_aabb wiring must fire for an off-origin rect.",
+                op.fb_dim,
+                SURFACE_WIDTH,
+                SURFACE_HEIGHT
+            );
+        }
+
+        // ── GPU readback: center pixel must be non-transparent ────────────────
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_surface(&device);
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save_layer_with_image_filter(ImageFilterSpec::Blur {
+            sigma_x: SIGMA,
+            sigma_y: SIGMA,
+        });
+        // Opaque rect filling [20,20]→[44,44].
+        painter.rect(
+            Rect::from_xywh(
+                px(INNER_MARGIN as f32),
+                px(INNER_MARGIN as f32),
+                px((SURFACE_WIDTH - 2 * INNER_MARGIN) as f32),
+                px((SURFACE_HEIGHT - 2 * INNER_MARGIN) as f32),
+            ),
+            &Paint::fill(Color::rgba(200, 150, 80, 255)),
+        );
+        painter.restore_layer();
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_tex),
+                &mut encoder,
+            )
+            .expect("B8 clip-detection blur render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_tex);
+        let center_pixel = pixels[(CENTER_Y as usize) * SURFACE_WIDTH as usize + CENTER_X as usize];
+        let center_alpha = center_pixel[3];
+
+        assert!(
+            center_alpha > 0,
+            "B8 CLIP-DETECTION FAIL: center pixel ({}, {}) has alpha=0 after blur. \
+             The content at ({},{})→({},{}) was clipped from the intermediate — \
+             content_aabb under-estimated the AABB (fb too small for actual content).",
+            CENTER_X,
+            CENTER_Y,
+            INNER_MARGIN,
+            INNER_MARGIN,
+            SURFACE_WIDTH - INNER_MARGIN,
+            SURFACE_HEIGHT - INNER_MARGIN,
+        );
+    }
+
+    // ── B9: Circle content AABB — radius factor must be included ─────────────
+
+    /// B9: `content_aabb` for a baked `CircleInstance` must include the radius.
+    ///
+    /// ## The bug (pre-fix)
+    ///
+    /// `CircleInstance::new` stores `center_radius[2] = radius` and
+    /// `transform = diag(sx, sy)`.  The old code computed device half-extents as
+    /// `half_x = a.abs() + c.abs() = sx + 0 = sx` — dropping the radius factor.
+    /// A circle of radius 16 at scale 1 yielded `half_x = 1` → AABB of 2×2 px
+    /// around the center → `fb_dim` too small to contain the circle → content
+    /// clipped entirely from the intermediate framebuffer.
+    ///
+    /// ## Layout (64×64 surface, σ=2, circle center=(32,32), radius=16, scale=1)
+    ///
+    /// ```text
+    /// circle device extent (before fix):
+    ///   half_x = 1, half_y = 1   → content_aabb ≈ [31,31,33,33]  ← BUG
+    ///
+    /// circle device extent (after fix):
+    ///   r = 16, half_x = 16*1 = 16, half_y = 16*1 = 16
+    ///   content_aabb = [16, 16, 48, 48]
+    ///   kernel_radius(σ=2) = ceil(2 × 1.732) = 4
+    ///   grown           = [12, 12, 52, 52]
+    ///   fb_dim          = (40, 40)  ← comfortably contains the circle
+    /// ```
+    ///
+    /// ## Assertions
+    ///
+    /// 1. CPU: `fb_dim` ≥ circle diameter (32 px).  With the old code `fb_dim`
+    ///    would be ~(2+8, 2+8) = (10, 10) — far too small, failing this check.
+    /// 2. GPU: the pixel on the circle's top rim `(32, 16)` is non-transparent
+    ///    after blur.  Pre-fix, the circle falls entirely outside the tiny
+    ///    intermediate, so that pixel is transparent (alpha=0).
+    ///
+    /// **Fails if:** `content_aabb` drops the `* center_radius[2]` radius factor.
+    #[test]
+    fn blur_circle_content_aabb_includes_radius() {
+        const SIGMA: f32 = 2.0;
+        const KERNEL_RAD: u32 = 4;
+        const CENTER_COL: u32 = SURFACE_WIDTH / 2;
+        const CENTER_ROW: u32 = SURFACE_HEIGHT / 2;
+        const RADIUS_PX: u32 = 16;
+        const MIN_FB_DIM: u32 = RADIUS_PX * 2;
+
+        {
+            let (device, queue) = acquire_test_device_and_queue();
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            painter.save_layer_with_image_filter(ImageFilterSpec::Blur {
+                sigma_x: SIGMA,
+                sigma_y: SIGMA,
+            });
+            painter.circle(
+                Point::new(Pixels(CENTER_COL as f32), Pixels(CENTER_ROW as f32)),
+                RADIUS_PX as f32,
+                &Paint::fill(Color::rgba(200, 80, 80, 255)),
+            );
+            painter.restore_layer();
+
+            let ops = painter.filter_ops_for_test();
+            assert_eq!(ops.len(), 1, "B9: must emit exactly 1 FilterOp");
+            let op = &ops[0];
+            assert!(
+                op.fb_dim.0 >= MIN_FB_DIM && op.fb_dim.1 >= MIN_FB_DIM,
+                "B9 RADIUS-FACTOR BUG: FilterOp.fb_dim = {:?} < circle diameter {}. \
+                 content_aabb dropped the radius factor from CircleInstance.center_radius[2]. \
+                 With the fix, half_x = radius * sx = {} → fb_dim ≥ ({}, {}). \
+                 kernel_radius({}) = {}.",
+                op.fb_dim,
+                MIN_FB_DIM,
+                RADIUS_PX,
+                MIN_FB_DIM,
+                MIN_FB_DIM,
+                SIGMA,
+                KERNEL_RAD,
+            );
+        }
+
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_surface(&device);
+        clear_surface(&device, &queue, &surface_view, wgpu::Color::TRANSPARENT);
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save_layer_with_image_filter(ImageFilterSpec::Blur {
+            sigma_x: SIGMA,
+            sigma_y: SIGMA,
+        });
+        painter.circle(
+            Point::new(Pixels(CENTER_COL as f32), Pixels(CENTER_ROW as f32)),
+            RADIUS_PX as f32,
+            &Paint::fill(Color::rgba(200, 80, 80, 255)),
+        );
+        painter.restore_layer();
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_tex),
+                &mut encoder,
+            )
+            .expect("B9 circle-radius blur render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_tex);
+        let w = SURFACE_WIDTH as usize;
+        let rim_col = CENTER_COL as usize;
+        let rim_row = (CENTER_ROW - RADIUS_PX) as usize;
+        let rim_alpha = pixels[rim_row * w + rim_col][3];
+        assert!(
+            rim_alpha > 0,
+            "B9 CLIP FAIL: circle rim pixel ({rim_col},{rim_row}) has alpha=0 after blur. \
+             The circle (centre=({CENTER_COL},{CENTER_ROW}), radius={RADIUS_PX}) was clipped \
+             from the intermediate — content_aabb under-estimated the extent. \
+             Pre-fix: half_x = sx = 1 (missing radius factor) → fb too small. \
+             Post-fix: half_x = radius * sx = {RADIUS_PX} → rim survives."
+        );
+    }
+
+    // ── B10: Gradient fallback — content_aabb returns None for gradient kinds ──
+
+    /// B10: A filter layer containing a linear gradient must emit `fb_dim == viewport`,
+    /// proving the `content_aabb` fallback gate fires.
+    ///
+    /// ## Why this test exists (P0 regression story)
+    ///
+    /// Before the fix, `content_aabb` unioned `linear_gradient_batch.instances[*].bounds`
+    /// and returned `Some(aabb)`.  For a gradient at rect `[16,16]→[48,48]` on a 64×64
+    /// surface, the AABB was `[16,16,48,48]`, grown by `kernel_radius(2.0)=4` to
+    /// `[12,12,52,52]`, giving `fb_dim=(40,40)` — a sub-viewport intermediate.
+    ///
+    /// `render_segment_to_grown_offscreen` does NOT remap gradient instances, so the
+    /// gradient shader used the static `vp_w=64` uniform against a 40×40 attachment.
+    /// NDC was wrong: the gradient rendered at approximately `[0.25·64, 0.25·64]→[0.75·64,…]`
+    /// coordinates against the 40-wide attachment, placing content at origin-0 of the
+    /// sub-viewport rather than at `[4,4]→[36,36]` (fb-local).
+    ///
+    /// The fix: `content_aabb` returns `None` when `linear_gradient_batch` (or any
+    /// other un-repositionable kind) is non-empty.  The caller's `.unwrap_or(vp)` then
+    /// selects `composite_bounds = viewport` → `fb_dim == viewport` → the remap in
+    /// `render_segment_to_grown_offscreen` is the identity transform → gradient renders
+    /// at the correct position.
+    ///
+    /// ## RED proof (implicit)
+    ///
+    /// To trigger the pre-fix failure without modifying production code, remove the
+    /// fallback gate from `content_aabb` and re-run: `fb_dim` would drop to `(40,40)`
+    /// and the GPU readback assertion (gradient centre pixel must be non-transparent
+    /// after blur) would fail because the content is mispositioned entirely outside
+    /// the intermediate framebuffer region that maps back to the content's device rect.
+    ///
+    /// ## Layout (surface 64×64, σ=2.0, gradient at [16,16]→[48,48])
+    ///
+    /// ```text
+    /// gradient rect  = [16, 16] → [48, 48]
+    /// kernel_radius  = ceil(2.0 × √3) = 4
+    ///
+    /// PRE-FIX (wrong):
+    ///   content_aabb = Some([16,16,48,48])  ← gradient unioned
+    ///   grown        = [12, 12, 52, 52]
+    ///   fb_dim       = (40, 40) < (64, 64)  ← sub-viewport, gradient mis-positioned
+    ///
+    /// POST-FIX (correct):
+    ///   content_aabb = None                  ← gate fires
+    ///   fb_dim       = (64, 64)              ← full-viewport, gradient at correct pos
+    /// ```
+    #[test]
+    fn blur_gradient_fallback_forces_viewport_fb() {
+        use crate::wgpu::effects::GradientStop;
+
+        const SIGMA: f32 = 2.0;
+        // Gradient rect centred in the surface ([16,16]→[48,48]).
+        const MARGIN: f32 = 16.0;
+        const SIDE: f32 = (SURFACE_WIDTH as f32) - 2.0 * MARGIN; // 32
+
+        // ── Part A: CPU producer check — fb_dim must equal viewport ──────────
+        {
+            let (device, queue) = acquire_test_device_and_queue();
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            painter.save_layer_with_image_filter(ImageFilterSpec::Blur {
+                sigma_x: SIGMA,
+                sigma_y: SIGMA,
+            });
+            let stops = [
+                GradientStop::new(flui_types::Color::rgba(255, 0, 0, 255), 0.0),
+                GradientStop::new(flui_types::Color::rgba(0, 0, 255, 255), 1.0),
+            ];
+            painter.gradient_rect(
+                Rect::from_xywh(px(MARGIN), px(MARGIN), px(SIDE), px(SIDE)),
+                glam::Vec2::new(MARGIN, MARGIN),
+                glam::Vec2::new(MARGIN + SIDE, MARGIN),
+                &stops,
+                0.0,
+            );
+            painter.restore_layer();
+
+            let ops = painter.filter_ops_for_test();
+            assert_eq!(ops.len(), 1, "B10: must emit exactly 1 FilterOp");
+            let op = &ops[0];
+
+            // The fallback gate must force fb_dim == viewport.
+            // PRE-FIX: fb_dim would be (40,40) — gradient was unioned into AABB.
+            // POST-FIX: fb_dim == (64,64) — gate returns None → viewport fallback.
+            assert_eq!(
+                op.fb_dim,
+                (SURFACE_WIDTH, SURFACE_HEIGHT),
+                "B10 GRADIENT-FALLBACK FAIL: FilterOp.fb_dim = {:?} != viewport ({}, {}). \
+                 content_aabb must return None when linear_gradient_batch is non-empty \
+                 so the caller falls back to fb_dim == viewport. \
+                 PRE-FIX: gradient bounds were unioned → fb_dim=(40,40), mis-positioning \
+                 the gradient in the sub-viewport intermediate.",
+                op.fb_dim,
+                SURFACE_WIDTH,
+                SURFACE_HEIGHT
+            );
+        }
+
+        // ── Part B: GPU readback — gradient centre must survive blur ──────────
+        //
+        // The centre of the gradient rect is at (32, 32).  After a Gaussian blur
+        // with σ=2 over an opaque gradient, that pixel must be opaque (alpha ≥ 254).
+        // PRE-FIX: the gradient was mispositioned in the sub-viewport intermediate,
+        // rendering outside the fb region that maps back to (32,32), so the centre
+        // would be transparent (alpha=0) after compositing.
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_surface(&device);
+        clear_surface(&device, &queue, &surface_view, wgpu::Color::TRANSPARENT);
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save_layer_with_image_filter(ImageFilterSpec::Blur {
+            sigma_x: SIGMA,
+            sigma_y: SIGMA,
+        });
+        let stops = [
+            GradientStop::new(flui_types::Color::rgba(200, 100, 0, 255), 0.0),
+            GradientStop::new(flui_types::Color::rgba(0, 100, 200, 255), 1.0),
+        ];
+        painter.gradient_rect(
+            Rect::from_xywh(px(MARGIN), px(MARGIN), px(SIDE), px(SIDE)),
+            glam::Vec2::new(MARGIN, MARGIN),
+            glam::Vec2::new(MARGIN + SIDE, MARGIN),
+            &stops,
+            0.0,
+        );
+        painter.restore_layer();
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_tex),
+                &mut encoder,
+            )
+            .expect("B10 gradient-fallback blur render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_tex);
+        let w = SURFACE_WIDTH as usize;
+
+        // Centre of the gradient rect: (32, 32).
+        let centre_col = (SURFACE_WIDTH / 2) as usize;
+        let centre_row = (SURFACE_HEIGHT / 2) as usize;
+        let centre_alpha = pixels[centre_row * w + centre_col][3];
+
+        assert!(
+            centre_alpha > 200,
+            "B10 GRADIENT-POSITION FAIL: gradient centre pixel ({centre_col},{centre_row}) \
+             has alpha={centre_alpha} after blur. \
+             The gradient at [16,16]→[48,48] must remain fully opaque at its centre. \
+             PRE-FIX: fb_dim=(40,40) caused the gradient to render mis-positioned \
+             in the sub-viewport intermediate → centre pixel transparent after composite. \
+             POST-FIX: fb_dim=(64,64) → gradient at correct device position → alpha≥254."
+        );
+    }
+
+    // ── B11: Rect-only layer still fires optimization after gradient gate ─────
+
+    /// B11: A filter layer with ONLY a rect (no gradient / shadow / image) must
+    /// still emit a sub-viewport `fb_dim` — the gradient gate must not over-fallback.
+    ///
+    /// This is the regression-guard for the OTHER direction: the gate added in B10
+    /// must be surgical.  A layer with only rect/circle/arc instances must continue
+    /// to benefit from the VRAM optimization (fb_dim < viewport).
+    ///
+    /// B7/B8/B9 already cover this from multiple angles; B11 adds a minimal named
+    /// discriminator that pairs directly with B10 as a "gate is precise" check.
+    #[test]
+    fn blur_rect_only_layer_still_sub_viewport_after_gradient_gate() {
+        const SIGMA: f32 = 2.0;
+        // Rect inset 12 px from each edge: [12,12]→[52,52] on 64×64 surface.
+        const INNER_MARGIN: u32 = 12;
+
+        let (device, queue) = acquire_test_device_and_queue();
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save_layer_with_image_filter(ImageFilterSpec::Blur {
+            sigma_x: SIGMA,
+            sigma_y: SIGMA,
+        });
+        painter.rect(
+            Rect::from_xywh(
+                px(INNER_MARGIN as f32),
+                px(INNER_MARGIN as f32),
+                px((SURFACE_WIDTH - 2 * INNER_MARGIN) as f32),
+                px((SURFACE_HEIGHT - 2 * INNER_MARGIN) as f32),
+            ),
+            &flui_painting::Paint::fill(flui_types::Color::rgba(255, 128, 0, 255)),
+        );
+        painter.restore_layer();
+
+        let ops = painter.filter_ops_for_test();
+        assert_eq!(ops.len(), 1, "B11: must emit exactly 1 FilterOp");
+        let op = &ops[0];
+
+        assert!(
+            op.fb_dim.0 < SURFACE_WIDTH && op.fb_dim.1 < SURFACE_HEIGHT,
+            "B11 OVER-FALLBACK REGRESSION: FilterOp.fb_dim = {:?} is NOT sub-viewport ({}, {}). \
+             A rect-only filter layer must still use the grown-bounds optimization \
+             (fb_dim < viewport).  The gradient fallback gate in content_aabb must only \
+             fire when shadow/gradient/image kinds are present — not for rect-only content.",
+            op.fb_dim,
+            SURFACE_WIDTH,
+            SURFACE_HEIGHT
+        );
+    }
+
+    // ── B12: Clipped rect in sub-viewport filter layer — non-identity scissor rebase ──
+
+    /// B12: A scissor-clipped rect inside a sub-viewport filter layer must have its
+    /// `rect_scissors` entry rebased from full-frame to fb-local coords by
+    /// `remap_scissor`, producing a **non-identity** remap (fb_dim < viewport).
+    ///
+    /// ## What this tests
+    ///
+    /// `render_segment_to_grown_offscreen` rebases `rect_scissors` from full-frame to
+    /// fb-local coords.  This test drives the **non-identity** branch of that rebase:
+    ///
+    /// - The content rect is INSET (`[16,16]→[48,48]`) so `content_aabb` returns a
+    ///   sub-viewport AABB → `fb_dim < (64,64)`.  The test asserts this explicitly.
+    /// - A second clip `[24,24]→[40,40]` (inside the content rect) is applied before
+    ///   drawing, populating `rect_scissors` with a scissor in full-frame coords.
+    ///   After rebase the scissor becomes `(12,12,16,16)` in fb-local space
+    ///   (non-identity because `fb_origin = (12,12) ≠ (0,0)`).
+    ///
+    /// Pre-fix: a scissor in full-frame coords applied to the smaller fb attachment
+    /// would be out-of-range → wgpu validation error or sentinel (nothing drawn).
+    /// Post-fix: `remap_scissor` intersects + translates to fb-local → valid scissor.
+    ///
+    /// ## Layout (surface 64×64, σ=2, kernel_radius=4)
+    ///
+    /// ```text
+    /// content rect  = [16, 16] → [48, 48]   (inset 16 px each side)
+    /// content_aabb  = [16, 16, 48, 48]
+    /// grown         = [12, 12, 52, 52]       (expand by kernel_radius=4)
+    /// fb_origin     = (12, 12),  fb_dim = (40, 40)   ← sub-viewport (ASSERT A)
+    ///
+    /// clip rect     = [24, 24] → [40, 40]   (full-frame scissor (24,24,16,16))
+    /// remap_scissor:
+    ///   inter = max(24,12)..min(40,52) = 24..40
+    ///   fb-local = (24-12, 24-12, 16, 16) = (12, 12, 16, 16)   ← non-identity
+    ///
+    /// pixel (32,32): inside both content rect and clip → non-transparent (ASSERT B)
+    /// pixel (17,32): inside content rect but 7 px left of clip edge (24-17=7>4) →
+    ///                transparent (ASSERT C) — the rebased scissor clips it out
+    /// ```
+    ///
+    /// The test running to completion proves no wgpu validation panic (ASSERT D).
+    ///
+    /// **Fails if:** the scissor is not rebased → either a validation error (panic) or
+    /// the sentinel path fires (nothing drawn → ASSERT B fails), or the clip is applied
+    /// in full-frame coords against the fb-local attachment (wrong pixels clipped).
+    #[test]
+    #[allow(
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation,
+        reason = "constants are small positive u32/usize; all casts are safe on a 64×64 surface"
+    )]
+    fn blur_clipped_rect_scissor_rebased_non_identity() {
+        const SIGMA: f32 = 2.0;
+        // kernel_radius(2.0) = ceil(2.0 × √3) = ceil(3.464) = 4
+        const KERNEL_RAD: u32 = 4;
+
+        // Content rect: inset 16 px each side → [16,16]→[48,48].
+        const CONTENT_MARGIN: u32 = 16;
+        const CONTENT_LEFT: u32 = CONTENT_MARGIN;
+        const CONTENT_TOP: u32 = CONTENT_MARGIN;
+        const CONTENT_RIGHT: u32 = SURFACE_WIDTH - CONTENT_MARGIN;
+        const CONTENT_BOTTOM: u32 = SURFACE_HEIGHT - CONTENT_MARGIN;
+
+        // grown bounds (after kernel_radius expansion, clamped to viewport):
+        //   [16-4, 16-4, 48+4, 48+4] = [12, 12, 52, 52] → fb_origin=(12,12), fb_dim=(40,40)
+        const EXPECTED_FB_ORIGIN: (u32, u32) =
+            (CONTENT_LEFT - KERNEL_RAD, CONTENT_TOP - KERNEL_RAD);
+        const EXPECTED_FB_DIM: (u32, u32) = (
+            (CONTENT_RIGHT + KERNEL_RAD) - (CONTENT_LEFT - KERNEL_RAD),
+            (CONTENT_BOTTOM + KERNEL_RAD) - (CONTENT_TOP - KERNEL_RAD),
+        );
+
+        // Clip rect nested inside the content rect: [24,24]→[40,40].
+        // In full-frame device coords: scissor = (24, 24, 16, 16).
+        const CLIP_LEFT: u32 = 24;
+        const CLIP_TOP: u32 = 24;
+        const CLIP_RIGHT: u32 = 40;
+        const CLIP_BOTTOM: u32 = 40;
+
+        // Precondition: kernel_radius must match the constant above.
+        assert_eq!(
+            kernel_radius(SIGMA),
+            KERNEL_RAD,
+            "B12 precondition: kernel_radius({SIGMA}) must equal {KERNEL_RAD}"
+        );
+
+        // ── ASSERT A (CPU): fb_dim is sub-viewport ────────────────────────────
+        {
+            let (dev, q) = acquire_test_device_and_queue();
+            let mut painter = build_painter(Arc::clone(&dev), Arc::clone(&q));
+            painter.save_layer_with_image_filter(ImageFilterSpec::Blur {
+                sigma_x: SIGMA,
+                sigma_y: SIGMA,
+            });
+            // Apply clip then draw the inset content rect (clip is nested inside).
+            painter.clip_rect(Rect::from_xywh(
+                px(CLIP_LEFT as f32),
+                px(CLIP_TOP as f32),
+                px((CLIP_RIGHT - CLIP_LEFT) as f32),
+                px((CLIP_BOTTOM - CLIP_TOP) as f32),
+            ));
+            painter.rect(
+                Rect::from_xywh(
+                    px(CONTENT_LEFT as f32),
+                    px(CONTENT_TOP as f32),
+                    px((CONTENT_RIGHT - CONTENT_LEFT) as f32),
+                    px((CONTENT_BOTTOM - CONTENT_TOP) as f32),
+                ),
+                &flui_painting::Paint::fill(flui_types::Color::rgba(255, 0, 0, 255)),
+            );
+            painter.restore_layer();
+
+            let ops = painter.filter_ops_for_test();
+            assert_eq!(ops.len(), 1, "B12: must emit exactly 1 FilterOp");
+            let op = &ops[0];
+
+            // The sub-viewport optimization must fire: fb_dim < viewport.
+            // If this fails, the test cannot exercise the non-identity remap.
+            assert!(
+                op.fb_dim.0 < SURFACE_WIDTH && op.fb_dim.1 < SURFACE_HEIGHT,
+                "B12 ASSERT A FAIL: FilterOp.fb_dim = {:?} is NOT sub-viewport ({}, {}). \
+                 The inset content rect [16,16]→[48,48] must produce a sub-viewport \
+                 intermediate so the scissor rebase is non-identity. \
+                 Expected fb_dim = {:?}.",
+                op.fb_dim,
+                SURFACE_WIDTH,
+                SURFACE_HEIGHT,
+                EXPECTED_FB_DIM,
+            );
+
+            assert_eq!(
+                op.fb_origin, EXPECTED_FB_ORIGIN,
+                "B12 ASSERT A: fb_origin = {:?}, expected {:?}.",
+                op.fb_origin, EXPECTED_FB_ORIGIN,
+            );
+            assert_eq!(
+                op.fb_dim, EXPECTED_FB_DIM,
+                "B12 ASSERT A: fb_dim = {:?}, expected {:?}.",
+                op.fb_dim, EXPECTED_FB_DIM,
+            );
+        }
+
+        // ── ASSERT B + C (GPU): pixel inside clip is visible; pixel outside clip
+        //    but inside content rect is transparent (non-identity rebase proof). ──
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_surface(&device);
+        clear_surface(&device, &queue, &surface_view, wgpu::Color::TRANSPARENT);
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save_layer_with_image_filter(ImageFilterSpec::Blur {
+            sigma_x: SIGMA,
+            sigma_y: SIGMA,
+        });
+        painter.clip_rect(Rect::from_xywh(
+            px(CLIP_LEFT as f32),
+            px(CLIP_TOP as f32),
+            px((CLIP_RIGHT - CLIP_LEFT) as f32),
+            px((CLIP_BOTTOM - CLIP_TOP) as f32),
+        ));
+        painter.rect(
+            Rect::from_xywh(
+                px(CONTENT_LEFT as f32),
+                px(CONTENT_TOP as f32),
+                px((CONTENT_RIGHT - CONTENT_LEFT) as f32),
+                px((CONTENT_BOTTOM - CONTENT_TOP) as f32),
+            ),
+            &flui_painting::Paint::fill(flui_types::Color::rgba(255, 0, 0, 255)),
+        );
+        painter.restore_layer();
+
+        // ASSERT D: no wgpu validation panic (test completing proves this).
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_tex),
+                &mut encoder,
+            )
+            .expect("B12 clipped-rect blur render must succeed (no wgpu validation panic)");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let pixels = readback_pixels(&device, &queue, &surface_tex);
+        let w = SURFACE_WIDTH as usize;
+
+        // ASSERT B: centre of clip [24,24]→[40,40] is (32,32) → must be non-transparent.
+        let centre_col: usize = (SURFACE_WIDTH / 2) as usize; // 32
+        let centre_row: usize = (SURFACE_HEIGHT / 2) as usize; // 32
+        let centre_alpha = pixels[centre_row * w + centre_col][3];
+        assert!(
+            centre_alpha > 0,
+            "B12 ASSERT B FAIL: centre pixel ({centre_col},{centre_row}) has alpha=0 after blur. \
+             Pixel is inside clip [24,24]→[40,40] and content rect [16,16]→[48,48]. \
+             The rebased fb-local scissor must allow drawing here. \
+             Pre-fix: out-of-range scissor → sentinel → nothing drawn."
+        );
+
+        // ASSERT C: pixel at (17,32) is inside the content rect [16,16]→[48,48] but
+        // 7 pixels left of the clip left edge (24-17=7 > kernel_radius=4).
+        // The blur cannot spread 7 px from the clipped content, so this must be transparent.
+        // This proves the rebased scissor clips at the correct fb-local position.
+        let outside_clip_col: usize = 17;
+        let outside_clip_row: usize = centre_row;
+        let outside_alpha = pixels[outside_clip_row * w + outside_clip_col][3];
+        assert_eq!(
+            outside_alpha, 0,
+            "B12 ASSERT C FAIL: pixel ({outside_clip_col},{outside_clip_row}) has alpha={outside_alpha} \
+             but should be transparent. \
+             This pixel is inside the content rect but 7 px left of the clip edge (24-17=7 > \
+             kernel_radius=4), so no blur contribution can reach it — the clip must block it. \
+             A non-zero value means the scissor was NOT applied in fb-local coords \
+             (full-frame scissor against fb attachment clips at the wrong position)."
         );
     }
 }

--- a/crates/flui-engine/src/wgpu/command_ir.rs
+++ b/crates/flui-engine/src/wgpu/command_ir.rs
@@ -303,6 +303,25 @@ pub(crate) enum ImageFilterPass {
 ///
 /// Textures are acquired at REPLAY time (never held in the IR), matching the
 /// discipline of `AdvancedShapeOp` and `SsaaPathOp`.
+///
+/// ## Integer-grid composite (Task 6 — grown-bounds intermediate sizing)
+///
+/// The intermediate offscreen is sized to the integer-aligned bounding box of
+/// `grown_bounds` (floor origin, ceil far corner, clamped to viewport) rather
+/// than the full viewport. This reduces VRAM peak from `vp_area` to `grown_area`
+/// × nesting depth.
+///
+/// The integer alignment is REQUIRED because the texture-batch composite sampler
+/// is bilinear (`default_sampler` Linear in `replay.rs`): compositing a
+/// full-viewport intermediate at a fractional `grown_bounds` is self-consistent
+/// (texel grid == device-pixel grid → aligned blit), but compositing an
+/// integer-origin `fb`-sized intermediate at a fractional dst_rect offsets the
+/// two grids by `frac(grown_left)`, shifting every pixel by a sub-texel.
+///
+/// `fb_origin` and `fb_dim` are computed at **record time** in `painter.rs`
+/// `restore_layer` and stored here so BOTH composite arms (top-level in
+/// `replay.rs` + nested in `opacity_layer.rs`) re-read ONE source — eliminating
+/// arm-drift (risk #4 in the Task 6 spec).
 #[derive(Debug, Clone)]
 pub(crate) struct FilterOp {
     /// Foreground content the filter consumes, rendered to an offscreen
@@ -319,7 +338,30 @@ pub(crate) struct FilterOp {
     /// the layer bounds. For Task 0 this equals `content_bounds` (Identity
     /// grows bounds by 0 pixels). Slice 4 computes the real growth via
     /// `kernel_radius(sigma)`.
+    ///
+    /// The composite uses `fb_origin`/`fb_dim` (integer-aligned) rather than
+    /// `grown_bounds` directly (Task 6 non-negotiable #1). `grown_bounds` is
+    /// retained for diagnostics, tracing, and future tooling (e.g. damage-region
+    /// tracking or spec-verify audits that check halo extent in floating-point).
+    // Retained for diagnostics: the composite arms now use fb_origin/fb_dim but
+    // grown_bounds documents the fractional halo extent pre-quantisation and will
+    // be needed by damage-tracking or future floating-point halo assertions.
+    #[allow(dead_code)]
     pub(crate) grown_bounds: Rect<Pixels>,
+    /// Integer-grid top-left of the offscreen intermediate in device pixels.
+    ///
+    /// Computed as `(floor(grown_bounds.left), floor(grown_bounds.top))`.
+    /// Integer-aligned so the bilinear composite produces an aligned texel blit
+    /// (no sub-pixel shift). Stored on the IR so both composite arms share one
+    /// authoritative value (Task 6 non-negotiable #4).
+    pub(crate) fb_origin: (u32, u32),
+    /// Integer-aligned dimensions of the offscreen intermediate in device pixels.
+    ///
+    /// Computed as `(ceil(far.x) - fb_origin.x, ceil(far.y) - fb_origin.y)`,
+    /// clamped so `fb_origin + fb_dim ≤ viewport`. This is the exact size passed
+    /// to `pool.acquire` and used as `texture_size` in all filter sub-passes
+    /// (Task 6 non-negotiables #2 and #3).
+    pub(crate) fb_dim: (u32, u32),
 }
 
 // ─── Primitive helpers ────────────────────────────────────────────────────────
@@ -777,6 +819,8 @@ mod task0_ir_witnesses {
             passes: smallvec![ImageFilterPass::Identity],
             content_bounds: bounds,
             grown_bounds: bounds,
+            fb_origin: (0, 0),
+            fb_dim: (64, 64),
         }
     }
 
@@ -881,6 +925,8 @@ mod task0_ir_witnesses {
             }],
             content_bounds: bounds,
             grown_bounds: bounds,
+            fb_origin: (0, 0),
+            fb_dim: (64, 64),
         };
         let cloned = op.clone();
         assert_eq!(cloned.passes.len(), 1);
@@ -923,6 +969,8 @@ mod task0_ir_witnesses {
             }],
             content_bounds: bounds,
             grown_bounds: bounds,
+            fb_origin: (0, 0),
+            fb_dim: (64, 64),
         };
         let cloned = op.clone();
         assert_eq!(cloned.passes.len(), 1);

--- a/crates/flui-engine/src/wgpu/deterministic_replay_tests.rs
+++ b/crates/flui-engine/src/wgpu/deterministic_replay_tests.rs
@@ -513,6 +513,8 @@ mod tests {
             passes: smallvec![ImageFilterPass::Identity],
             content_bounds,
             grown_bounds: content_bounds, // Identity grows by 0
+            fb_origin: (10, 10),          // floor(grown.left/top) — integer-aligned (Task 6)
+            fb_dim: (20, 20),             // ceil(grown.right/bottom) - fb_origin (Task 6)
         };
 
         vec![DrawItem::Filter(op)]
@@ -761,6 +763,8 @@ mod tests {
                 passes: smallvec::SmallVec::new(), // empty fold — same round-trip, zero passes
                 content_bounds,
                 grown_bounds: content_bounds,
+                fb_origin: (10, 10), // floor(grown.left/top) — integer-aligned (Task 6)
+                fb_dim: (20, 20),    // ceil(grown.right/bottom) - fb_origin (Task 6)
             }
         };
         let (target_d, view_d) = make_render_target(&device);

--- a/crates/flui-engine/src/wgpu/morphology/mod.rs
+++ b/crates/flui-engine/src/wgpu/morphology/mod.rs
@@ -50,11 +50,14 @@ mod pipeline;
 /// - `radius` — kernel half-radius in physical pixels; the shader samples
 ///   `[-ceil(radius) ..= ceil(radius)]` texels in each direction.
 /// - `morph_op` — `Dilate` (max) or `Erode` (min).
-/// - `source_tex` — premultiplied RGBA offscreen from `render_segment_to_offscreen`.
-/// - `content_bounds` — the AABB of the actual content in physical pixels; used to
-///   compute the decal UV rect so the filter does not bleed beyond content edges.
-/// - `viewport_size` — `(width, height)` in physical pixels; the output and
-///   intermediate textures share this size.
+/// - `source_tex` — premultiplied RGBA offscreen from `render_segment_to_grown_offscreen`.
+/// - `content_bounds` — the AABB of the actual content in **full-frame** physical pixels;
+///   rebased to fb-local UV by subtracting `fb_origin` before dividing by `fb_dim`.
+/// - `fb_origin` — integer-aligned top-left of the offscreen frame in device pixels.
+///   Used to rebase `content_bounds` to fb-local UV (non-negotiable #3).
+/// - `fb_dim` — integer dimensions `(width, height)` of the source texture and all
+///   intermediate textures. The shader's `texture_size` uniform is set to `fb_dim`
+///   (non-negotiable #2: denominator is integer fb_dim, not viewport_size).
 /// - `surface_format` — texture format of the render target.
 /// - `pipeline` — the morphology pipeline (bind-group layout + render pipeline).
 /// - `resources` — mutable GPU resource manager (texture pool).
@@ -75,32 +78,38 @@ pub(crate) fn apply_morphology(
     morph_op: MorphOp,
     source_tex: &PooledTexture,
     content_bounds: Rect<Pixels>,
-    viewport_size: (u32, u32),
+    fb_origin: (u32, u32),
+    fb_dim: (u32, u32),
     surface_format: wgpu::TextureFormat,
     pipeline: &MorphologyPipeline,
     resources: &mut GpuResources,
     device: &Arc<wgpu::Device>,
     encoder: &mut wgpu::CommandEncoder,
 ) -> PooledTexture {
-    let (vp_w, vp_h) = viewport_size;
+    let (fb_w, fb_h) = fb_dim;
+    let (fb_origin_x, fb_origin_y) = fb_origin;
 
-    // Normalise the content AABB to UV coordinates [0, 1] × [0, 1].
-    // The H pass decals against the content rect (samples beyond it are
-    // transparent black). Inside the texture but outside content, the source is
-    // already transparent (cleared by `render_segment_to_offscreen`), so this is
-    // equivalent to a texture-edge decal — but it keeps the content edge explicit.
+    // Rebase the content AABB to fb-local UV coordinates (non-negotiable #3).
+    //
+    // The source texture is fb_dim-sized with pixel (0,0) = fb_origin in device space.
+    // The H-pass decal guard compares sample UV against content_rect_uv; without
+    // subtracting fb_origin the UV is in viewport space, which would be wrong for an
+    // off-origin grown-bounds texture (content UV would not fall in [0, fb_dim]).
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "fb coords and content_bounds are ≤ viewport ≤ ~16 M px; f32 precision is sufficient"
+    )]
     let content_rect_uv_h = [
-        content_bounds.left().0 / vp_w as f32,
-        content_bounds.top().0 / vp_h as f32,
-        content_bounds.right().0 / vp_w as f32,
-        content_bounds.bottom().0 / vp_h as f32,
+        (content_bounds.left().0 - fb_origin_x as f32) / fb_w as f32,
+        (content_bounds.top().0 - fb_origin_y as f32) / fb_h as f32,
+        (content_bounds.right().0 - fb_origin_x as f32) / fb_w as f32,
+        (content_bounds.bottom().0 - fb_origin_y as f32) / fb_h as f32,
     ];
     // The V pass reads the H-pass OUTPUT, whose content extent has already grown
     // (dilate) horizontally beyond `content_bounds` into the halo. Decaling the V
     // pass at the original content rect would clip that halo and drop diagonal /
     // corner growth, so the V pass decals only at the texture edge ([0,1]) — the
-    // H output is already transparent outside its (grown) content, so this is the
-    // correct read region. Matches Impeller's grown-target-per-pass decal.
+    // H output is already transparent outside its (grown) content.
     let content_rect_uv_v = [0.0_f32, 0.0, 1.0, 1.0];
 
     // Operation selector: 0.0 = dilate, 1.0 = erode.
@@ -110,12 +119,20 @@ pub(crate) fn apply_morphology(
     };
 
     // ── H pass: source_tex → h_tex ──────────────────────────────────────────
+    //
+    // texture_size = fb_dim (non-negotiable #2): the shader uses texture_size to
+    // convert kernel offsets to UV deltas. Using viewport_size for a smaller
+    // fb_dim texture over-shrinks the UV step → effectively widens the kernel.
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "fb_w/fb_h are u32 texture dims ≤ viewport; f32 precision is sufficient"
+    )]
     let h_tex = resources
         .layer_texture_pool_mut()
-        .acquire(vp_w, vp_h, surface_format);
+        .acquire(fb_w, fb_h, surface_format);
     run_morph_sub_pass(
         &MorphUniform {
-            texture_size: [vp_w as f32, vp_h as f32],
+            texture_size: [fb_w as f32, fb_h as f32],
             radius,
             direction: 0.0, // horizontal
             content_rect_uv: content_rect_uv_h,
@@ -133,10 +150,10 @@ pub(crate) fn apply_morphology(
     // ── V pass: h_tex → v_tex ───────────────────────────────────────────────
     let v_tex = resources
         .layer_texture_pool_mut()
-        .acquire(vp_w, vp_h, surface_format);
+        .acquire(fb_w, fb_h, surface_format);
     run_morph_sub_pass(
         &MorphUniform {
-            texture_size: [vp_w as f32, vp_h as f32],
+            texture_size: [fb_w as f32, fb_h as f32],
             radius,
             direction: 1.0, // vertical
             content_rect_uv: content_rect_uv_v,

--- a/crates/flui-engine/src/wgpu/morphology_filter_tests.rs
+++ b/crates/flui-engine/src/wgpu/morphology_filter_tests.rs
@@ -1104,6 +1104,9 @@ mod gpu_tests {
             .rect_batch
             .add(RectInstance::rect(content_rect, source_color));
         DrawSegment::push_scissor_region(&mut segment.rect_scissors, None);
+        // grown = [20, 44) × [20, 44); all integer-aligned.
+        // fb_origin = (floor(20), floor(20)) = (20, 20)
+        // fb_dim    = (ceil(44) - 20, ceil(44) - 20) = (24, 24)
         let op = FilterOp {
             input: segment,
             passes: smallvec![ImageFilterPass::Morph {
@@ -1112,6 +1115,8 @@ mod gpu_tests {
             }],
             content_bounds: content_rect,
             grown_bounds: grown,
+            fb_origin: (20, 20),
+            fb_dim: (24, 24),
         };
 
         let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
@@ -1194,6 +1199,9 @@ mod gpu_tests {
             .rect_batch
             .add(RectInstance::rect(content_rect, source_color));
         DrawSegment::push_scissor_region(&mut segment.rect_scissors, None);
+        // Erode does not grow content; grown_bounds == content_rect = [22, 42) × [22, 42).
+        // fb_origin = (floor(22), floor(22)) = (22, 22)
+        // fb_dim    = (ceil(42) - 22, ceil(42) - 22) = (20, 20)
         let op = FilterOp {
             input: segment,
             passes: smallvec![ImageFilterPass::Morph {
@@ -1201,8 +1209,9 @@ mod gpu_tests {
                 op: MorphOp::Erode,
             }],
             content_bounds: content_rect,
-            // Erode does not grow content; the composite rect is the content rect.
             grown_bounds: content_rect,
+            fb_origin: (22, 22),
+            fb_dim: (20, 20),
         };
 
         let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));

--- a/crates/flui-engine/src/wgpu/opacity_layer.rs
+++ b/crates/flui-engine/src/wgpu/opacity_layer.rs
@@ -126,6 +126,294 @@ impl GpuReplay {
         offscreen
     }
 
+    /// Render a single [`DrawSegment`] into a **grown-bounds** pooled offscreen
+    /// texture for a [`DrawItem::Filter`] intermediate.
+    ///
+    /// Unlike [`Self::render_segment_to_offscreen`] (which acquires a full-viewport
+    /// texture), this method acquires a texture sized to `fb_dim` (the integer-
+    /// aligned grown bounds computed in `painter.rs` `restore_layer`). The segment
+    /// vertices are pre-transformed so that dividing by the UNCHANGED shared viewport
+    /// uniform yields the correct NDC inside the `fb_dim` render target.
+    ///
+    /// ## Why not touch `render_segment_to_offscreen`
+    ///
+    /// That method is the advanced-shape hot path. Keeping it byte-identical is a
+    /// structural bit-identity firewall — changes there would affect every
+    /// `AdvancedShape` and `SsaaPath` arm. The grown-offscreen variant is a new
+    /// method rather than a parameterised version (rule-of-three: only 2 callers,
+    /// scale-1 vs scale-2 diverge in the scissor factor).
+    ///
+    /// ## Vertex pre-transform (non-negotiable #2)
+    ///
+    /// The shape shader computes `clip_x = (pos.x / vp_w) * 2 - 1` against the
+    /// UNCHANGED shared viewport uniform `(vp_w, vp_h)`. We cannot hot-patch that
+    /// uniform mid-encoder. A vertex at full-frame device pixel `(px, py)` must fill
+    /// the `fb_dim` render target as if it were the whole viewport:
+    ///
+    /// ```text
+    /// new_pos.x = (px - fb_origin.x) * (vp_w / fb_dim.x)
+    /// new_pos.y = (py - fb_origin.y) * (vp_h / fb_dim.y)
+    /// ```
+    ///
+    /// Denominator MUST be integer `fb_dim`, NOT float `grown.width()` (SSAA-tile
+    /// bug class: they differ by one floor/ceil ulp on fractional regions).
+    ///
+    /// ## Scissor remap (non-negotiable #6, mirrors ssaa.rs:483-512 without ×2)
+    ///
+    /// Full-frame scissors are rebased to `fb_origin` and clamped to `[0, fb_dim]`.
+    /// Empty-intersection uses the sentinel `(fb_dim.x, fb_dim.y, 1, 1)` (wgpu
+    /// requires non-zero extent; the sentinel is outside the attachment → nothing
+    /// drawn, matching the SSAA approach without the ×2 supersampling factor).
+    ///
+    /// Cross-reference: `ssaa.rs` `GpuReplay::render_ssaa_path` lines 443-512
+    /// for the analogous full-frame→tile remap at 2× scale.
+    pub(in crate::wgpu) fn render_segment_to_grown_offscreen(
+        &mut self,
+        segment: &mut DrawSegment,
+        fb_origin: (u32, u32),
+        fb_dim: (u32, u32),
+        viewport_size: (u32, u32),
+        surface_format: wgpu::TextureFormat,
+        device: &Arc<wgpu::Device>,
+        queue: &Arc<wgpu::Queue>,
+        pipelines: &mut PipelineSet,
+        resources: &mut GpuResources,
+        encoder: &mut wgpu::CommandEncoder,
+    ) -> PooledTexture {
+        let (vp_w, vp_h) = viewport_size;
+        let (fb_x, fb_y) = fb_origin;
+        let (fb_w, fb_h) = fb_dim;
+
+        // Acquire a pooled texture sized to the grown bounds (not the full viewport).
+        let offscreen = resources
+            .layer_texture_pool_mut()
+            .acquire(fb_w, fb_h, surface_format);
+        let offscreen_view = offscreen.view();
+
+        // R3: Clear the offscreen target to fully transparent.
+        {
+            let _clear_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Grown-Bounds Filter Offscreen Clear Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: offscreen_view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+            // Pass dropped immediately — just clearing.
+        }
+
+        // ── Vertex pre-transform (non-negotiable #2) ──────────────────────────
+        //
+        // Mirror ssaa.rs:443-461 with scale = vp / fb_dim (not vp / (tile * 2)):
+        //   new_pos = (old_pos - fb_origin) * (vp / fb_dim_f32)
+        //
+        // Denominator = INTEGER fb_dim, NOT grown.width() — using float grown width
+        // gives the wrong scale when grown_bounds is fractional (the SSAA-tile bug
+        // class). The integer fb_dim is exactly what the pool acquired.
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "fb_w/fb_h/vp_w/vp_h are u32 texture dims ≤ 16 M px; f32 precision \
+                      is sufficient for device-pixel coordinate remapping"
+        )]
+        let scale_x = vp_w as f32 / fb_w as f32;
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "fb_h/vp_h are u32 texture dims ≤ 16 M px; f32 precision is sufficient"
+        )]
+        let scale_y = vp_h as f32 / fb_h as f32;
+        let origin_x = fb_x as f32;
+        let origin_y = fb_y as f32;
+
+        let mut remapped_segment = segment.clone();
+        for v in &mut remapped_segment.vertices {
+            v.position[0] = (v.position[0] - origin_x) * scale_x;
+            v.position[1] = (v.position[1] - origin_y) * scale_y;
+        }
+
+        // ── Instanced-batch pre-transform (extends vertex remap to rect/circle/arc) ──
+        //
+        // The rect shader computes NDC from instance.bounds.xy (baked-AABB path) or
+        // instance.transform_translate.xy (affine path) using the STATIC viewport
+        // uniform (original vp_w × vp_h).  To render at the correct fb-local
+        // position in the fb_dim-sized texture the device-pixel position must be
+        // remapped by the same formula as the tessellated vertices:
+        //   new_pos = (old_pos - fb_origin) * (vp / fb_dim)
+        //
+        // The width/height must also scale (vp/fb_dim) because they contribute to
+        // the device-pixel extent.  After the pre-transform the shader's NDC
+        // computation yields the correct fb-local clip coordinate.
+        //
+        // Circle/arc: center lives in transform_translate; the transform 2×2 matrix
+        // holds the radius-as-scale.  Rebasing transform_translate and scaling the
+        // linear columns yields the correct fb-local center and radius.
+        //
+        // Rule-of-three note: this helper duplicates the SSAA vertex remap logic;
+        // SSAA only touches tessellated vertices (its DrawSegment never holds rect
+        // instances).  There are now 2 callers of this remapping pattern.  Extract
+        // into a shared helper if a third caller appears.
+        //
+        // Clip rrect: stored in device-pixel space ([x, y, w, h, radii…]); apply
+        // the same (pos-origin)*scale, dim*scale transform to x/y/w/h.
+        // Identity-transform and zero-translate are painter-set constants, not
+        // computed floats — the bit-pattern checks below are intentional exact
+        // equality, not a floating-point near-equal question.
+        for inst in &mut remapped_segment.rect_batch.instances {
+            let is_identity_transform =
+                inst.transform.map(f32::to_bits) == [1.0_f32, 0.0, 0.0, 1.0].map(f32::to_bits);
+            let is_zero_translate =
+                inst.transform_translate.map(f32::to_bits) == [0.0_f32; 4].map(f32::to_bits);
+            let is_baked_aabb = is_identity_transform && is_zero_translate;
+
+            if is_baked_aabb {
+                // Baked-AABB: device origin is in bounds.xy; w/h scale proportionally.
+                inst.bounds[0] = (inst.bounds[0] - origin_x) * scale_x;
+                inst.bounds[1] = (inst.bounds[1] - origin_y) * scale_y;
+                inst.bounds[2] *= scale_x;
+                inst.bounds[3] *= scale_y;
+            } else {
+                // Affine path: constant translation is in transform_translate;
+                // scale the linear 2×2 columns by the corresponding axis scale.
+                inst.transform_translate[0] = (inst.transform_translate[0] - origin_x) * scale_x;
+                inst.transform_translate[1] = (inst.transform_translate[1] - origin_y) * scale_y;
+                // Scale x-column and y-column of the 2×2 linear part.
+                inst.transform[0] *= scale_x; // a: x-col.x
+                inst.transform[1] *= scale_y; // b: x-col.y  (cross-axis — scale_y)
+                inst.transform[2] *= scale_x; // c: y-col.x  (cross-axis — scale_x)
+                inst.transform[3] *= scale_y; // d: y-col.y
+            }
+
+            // Clip rrect (if active): [x, y, w, h, radii…].
+            // Radii are dimension-like; scale them proportionally. For non-square
+            // fb crops (scale_x ≠ scale_y) this slightly warps circle-corner radii —
+            // acceptable for a filter intermediate (the composite restores shape).
+            if inst.clip_kind[0] != 0 {
+                inst.clip_rrect[0] = (inst.clip_rrect[0] - origin_x) * scale_x;
+                inst.clip_rrect[1] = (inst.clip_rrect[1] - origin_y) * scale_y;
+                inst.clip_rrect[2] *= scale_x;
+                inst.clip_rrect[3] *= scale_y;
+                // Radii [4..8]: scale by average of scale_x and scale_y.
+                let avg_scale = (scale_x + scale_y) * 0.5;
+                for r in &mut inst.clip_rrect[4..8] {
+                    *r *= avg_scale;
+                }
+            }
+        }
+
+        // Circle and arc instances: center is in transform_translate; the linear
+        // 2×2 matrix encodes the radius (baked fast path: [r,0,0,r]; affine: radius
+        // varies).  Apply the same scale/translate remap as for affine rects.
+        for inst in &mut remapped_segment.circle_batch.instances {
+            inst.transform_translate[0] = (inst.transform_translate[0] - origin_x) * scale_x;
+            inst.transform_translate[1] = (inst.transform_translate[1] - origin_y) * scale_y;
+            inst.transform[0] *= scale_x;
+            inst.transform[1] *= scale_y;
+            inst.transform[2] *= scale_x;
+            inst.transform[3] *= scale_y;
+        }
+        for inst in &mut remapped_segment.arc_batch.instances {
+            inst.transform_translate[0] = (inst.transform_translate[0] - origin_x) * scale_x;
+            inst.transform_translate[1] = (inst.transform_translate[1] - origin_y) * scale_y;
+            inst.transform[0] *= scale_x;
+            inst.transform[1] *= scale_y;
+            inst.transform[2] *= scale_x;
+            inst.transform[3] *= scale_y;
+        }
+
+        // ── Scissor remap: full-frame → fb-local (non-negotiable #6) ─────────
+        //
+        // Mirror ssaa.rs:483-512 without the ×2 supersampling factor:
+        //   1. Intersect full-frame scissor with [fb_origin, fb_origin+fb_dim].
+        //   2. Translate to fb-local coords (subtract fb_origin).
+        //   3. On empty intersection: emit sentinel (fb_w, fb_h, 1, 1).
+        //
+        // Applied to every scissor type in the segment: tess_batches,
+        // rect_scissors, circle_scissors, arc_scissors.
+        //
+        // Shadow / gradient / image scissors are NOT remapped here because those
+        // kinds are excluded from the sub-viewport path by the `content_aabb` gate
+        // (which returns `None` when any of those kinds is non-empty, forcing
+        // `fb_dim == viewport` → identity remap → those fields render correctly
+        // without any repositioning).
+        //
+        // Factored as a closure to eliminate the 4× identical copy of the
+        // intersect+remap+sentinel logic.  The closure borrows `fb_x`, `fb_y`,
+        // `fb_w`, `fb_h` from the enclosing scope (all non-`Copy` references are
+        // immutable; `u32` copies are fine).
+        let remap_scissor = |scissor: &mut Option<(u32, u32, u32, u32)>| {
+            if let Some((sx, sy, sw, sh)) = *scissor {
+                let fb_right = fb_x + fb_w;
+                let fb_bottom = fb_y + fb_h;
+
+                let scis_right = sx + sw;
+                let scis_bottom = sy + sh;
+
+                // Intersect full-frame scissor with fb region.
+                let inter_x = sx.max(fb_x);
+                let inter_y = sy.max(fb_y);
+                let inter_right = scis_right.min(fb_right);
+                let inter_bottom = scis_bottom.min(fb_bottom);
+
+                if inter_right <= inter_x || inter_bottom <= inter_y {
+                    // Empty intersection — nothing should draw here.
+                    // Sentinel: off-target 1×1 rect (wgpu requires non-zero extent).
+                    *scissor = Some((fb_w, fb_h, 1, 1));
+                } else {
+                    // Translate to fb-local (no scale factor — 1:1 not 2×).
+                    *scissor = Some((
+                        inter_x - fb_x,
+                        inter_y - fb_y,
+                        inter_right - inter_x,
+                        inter_bottom - inter_y,
+                    ));
+                }
+            }
+        };
+
+        // Tess-batch scissors (one per TessellatedBatch, directly on `batch.scissor`).
+        for batch in &mut remapped_segment.tess_batches {
+            remap_scissor(&mut batch.scissor);
+        }
+
+        // Instanced-kind scissors: rect / circle / arc.
+        // Each ScissorRegion covers a contiguous run of instances that share a
+        // scissor; remap each region's scissor from full-frame to fb-local.
+        for region in &mut remapped_segment.rect_scissors {
+            remap_scissor(&mut region.scissor);
+        }
+        for region in &mut remapped_segment.circle_scissors {
+            remap_scissor(&mut region.scissor);
+        }
+        for region in &mut remapped_segment.arc_scissors {
+            remap_scissor(&mut region.scissor);
+        }
+
+        // Flush the remapped segment into the fb-sized texture.
+        // viewport_size = fb_dim so flush_segment sets its scissor against the
+        // fb attachment; the static viewport uniform (vp_w, vp_h) combined with
+        // the pre-scaled positions yields correct NDC.
+        self.flush_segment(
+            &mut remapped_segment,
+            fb_dim,
+            device,
+            queue,
+            pipelines,
+            resources,
+            encoder,
+            offscreen_view,
+        );
+
+        offscreen
+    }
+
     /// Render a pending opacity layer's content to a pooled offscreen texture.
     ///
     /// Acquires an offscreen texture from the pool, clears it to transparent,
@@ -331,14 +619,18 @@ impl GpuReplay {
                 //
                 // Z-order within the layer follows each item's `draw_order` position
                 // and the replay loop — NOT match-arm textual position. The filter's
-                // input segment is rendered to an isolated offscreen, the pass chain
-                // is folded (Task 0: Identity → zero-copy), and the result is
-                // composited onto the layer's offscreen_view.
+                // input segment is rendered to an isolated grown-bounds offscreen
+                // (Task 6: fb_dim sized, not full-viewport), the pass chain is folded,
+                // and the result is composited onto the layer's offscreen_view at the
+                // integer-grid dst_rect with src_uv=[0,1] (non-negotiable #1).
                 //
                 // G2: no `_` arm — future Slice variants force a compile error here.
                 DrawItem::Filter(mut op) => {
-                    let content_tex = self.render_segment_to_offscreen(
+                    // 1. Render content to grown-bounds intermediate (Task 6).
+                    let content_tex = self.render_segment_to_grown_offscreen(
                         &mut op.input,
+                        op.fb_origin,
+                        op.fb_dim,
                         viewport_size,
                         surface_format,
                         device,
@@ -347,32 +639,43 @@ impl GpuReplay {
                         resources,
                         encoder,
                     );
+                    // 2. Fold the pass chain over the grown-bounds intermediate.
                     let filtered_tex = apply_image_filter_passes(
                         &op.passes,
                         content_tex,
                         op.content_bounds,
-                        op.grown_bounds,
-                        viewport_size,
+                        op.fb_origin,
+                        op.fb_dim,
                         surface_format,
                         pipelines,
                         resources,
                         device,
                         encoder,
                     );
-                    // `filtered_tex` is FULL-VIEWPORT; src_uv maps the grown_bounds
-                    // dst rect to the matching texture sub-region (NOT [0,1], which
-                    // would stretch the whole viewport onto grown_bounds). See replay.rs.
-                    let (vp_w, vp_h) = viewport_size;
-                    let g = op.grown_bounds;
-                    let src_uv = [
-                        g.left().0 / vp_w as f32,
-                        g.top().0 / vp_h as f32,
-                        g.right().0 / vp_w as f32,
-                        g.bottom().0 / vp_h as f32,
-                    ];
+                    // 3. Integer-grid composite (non-negotiable #1):
+                    //    dst_rect = Rect(fb_origin, fb_far); src_uv = [0, 0, 1, 1].
+                    //
+                    //    The intermediate is `fb_dim`-sized with the content starting
+                    //    at pixel (0,0) of the texture.  src_uv=[0,1] maps the whole
+                    //    fb texture onto dst_rect — a pixel-aligned 1:1 blit.
+                    //    Using the fractional `grown_bounds` as dst_rect over an
+                    //    integer-origin texture would shift every pixel by
+                    //    frac(grown_left) (the composite-grid shift, risk #1).
+                    let (fb_origin_x, fb_origin_y) = op.fb_origin;
+                    let (fb_w, fb_h) = op.fb_dim;
+                    #[allow(
+                        clippy::cast_precision_loss,
+                        reason = "fb coords are u32 pixel dims ≤ viewport; f32 precision is sufficient"
+                    )]
+                    let dst_rect = flui_types::Rect::from_xywh(
+                        flui_types::geometry::px(fb_origin_x as f32),
+                        flui_types::geometry::px(fb_origin_y as f32),
+                        flui_types::geometry::px(fb_w as f32),
+                        flui_types::geometry::px(fb_h as f32),
+                    );
                     let instance = super::instancing::TextureInstance::with_uv(
-                        op.grown_bounds,
-                        src_uv,
+                        dst_rect,
+                        [0.0, 0.0, 1.0, 1.0],
                         flui_types::styling::Color::WHITE,
                     );
                     let _ = self.texture_batch.add(instance);
@@ -389,8 +692,9 @@ impl GpuReplay {
                     );
                     tracing::trace!(
                         passes = op.passes.len(),
-                        grown_bounds = ?op.grown_bounds,
-                        "GpuReplay: image-filter composited onto layer offscreen"
+                        fb_origin = ?op.fb_origin,
+                        fb_dim = ?op.fb_dim,
+                        "GpuReplay: image-filter composited onto layer offscreen (grown-bounds)"
                     );
                 }
                 // ── SSAA-supersampled path nested inside a layer ───────────────
@@ -782,9 +1086,9 @@ fn fold_layer_filter_chain(
 /// Apply a chain of [`ImageFilterPass`]es to `input_tex`, returning the result.
 ///
 /// Folds the chain for [`DrawItem::Filter`] replay. Each arm acquires a fresh
-/// destination texture, renders the pass, and drops the prior `acc` (returning
-/// it to the pool) — the ≤2-live-textures ping-pong discipline, identical to
-/// `fold_layer_filter_chain`.
+/// destination texture sized to `fb_dim` (the integer-aligned grown bounds),
+/// renders the pass, and drops the prior `acc` (returning it to the pool) —
+/// the ≤2-live-textures ping-pong discipline, identical to `fold_layer_filter_chain`.
 ///
 /// The match has **no `_ =>` catch-all**: Slice 4 (`Blur`) is compiler-forced to
 /// add an arm when its variant is introduced.
@@ -792,8 +1096,15 @@ fn fold_layer_filter_chain(
 /// ## Parameters shared across all arms
 ///
 /// - `content_bounds` — AABB of the content in physical pixels; used by the
-///   morphology pass to compute the decal UV guard (samples outside `content_bounds`
-///   return the neutral element rather than the clamped edge texel).
+///   morphology/blur passes to compute the decal UV guard (samples outside
+///   `content_bounds` return the neutral element rather than the clamped edge texel).
+/// - `fb_origin` — integer-aligned top-left of the offscreen frame in device pixels.
+///   Used by blur/morph to rebase `content_bounds` into `fb`-local UV coordinates
+///   (non-negotiable #3: `content_rect_uv = (content_bounds - fb_origin) / fb_dim`).
+/// - `fb_dim` — integer dimensions of the intermediate textures; all pool acquires
+///   use this size, and the `texture_size` uniform in blur/morph shaders is set to
+///   `fb_dim` (non-negotiable #2: denominator must be integer fb_dim, not float
+///   `grown.width()`).
 /// - `viewport_size`, `surface_format`, `pipelines`, `resources`, `device`,
 ///   `encoder` — GPU context forwarded unchanged to every GPU pass arm.
 #[allow(
@@ -805,8 +1116,8 @@ pub(in crate::wgpu) fn apply_image_filter_passes(
     passes: &[ImageFilterPass],
     input_tex: PooledTexture,
     content_bounds: flui_types::Rect<flui_types::geometry::Pixels>,
-    grown_bounds: flui_types::Rect<flui_types::geometry::Pixels>,
-    viewport_size: (u32, u32),
+    fb_origin: (u32, u32),
+    fb_dim: (u32, u32),
     surface_format: wgpu::TextureFormat,
     pipelines: &mut PipelineSet,
     resources: &mut GpuResources,
@@ -827,7 +1138,8 @@ pub(in crate::wgpu) fn apply_image_filter_passes(
                     *op,
                     &acc,
                     content_bounds,
-                    viewport_size,
+                    fb_origin,
+                    fb_dim,
                     surface_format,
                     &pipelines.morphology,
                     resources,
@@ -840,18 +1152,16 @@ pub(in crate::wgpu) fn apply_image_filter_passes(
 
             ImageFilterPass::Blur { sigma_x, sigma_y } => {
                 // Two separable sub-passes (H then V) inside apply_blur.
-                // The H pass decals at `content_bounds` — the pre-filter content
-                // AABB — so samples outside the source geometry contribute
-                // transparent black (decal semantics). The V pass decals at the
-                // texture edge [0,1] to read the full H halo (diagonal corners
-                // included). `grown_bounds` is computed at `restore_layer` and
-                // drives the final composite rect; it is not needed here.
+                // The H pass decals at `content_bounds` rebased to fb-local UV
+                // (non-negotiable #3): samples outside contribute transparent black.
+                // The V pass decals at the texture edge [0,1] to read the full H halo.
                 apply_blur(
                     *sigma_x,
                     *sigma_y,
                     &acc,
                     content_bounds,
-                    viewport_size,
+                    fb_origin,
+                    fb_dim,
                     surface_format,
                     &pipelines.blur,
                     resources,
@@ -863,20 +1173,18 @@ pub(in crate::wgpu) fn apply_image_filter_passes(
             }
 
             ImageFilterPass::ColorMatrix(matrix) => {
-                // Full-viewport color-matrix pass (bounds-PRESERVING: grows 0 px).
+                // Bounds-PRESERVING color-matrix pass (grows 0 px).
                 //
-                // Reuses `apply_color_matrix` — the same function the
-                // `LayerFilter::ColorMatrix` fold arm in `fold_layer_filter_chain`
-                // calls.  REPLACE semantics: the output texture is cleared to
-                // TRANSPARENT before the pass writes into it (LoadOp::Clear inside
-                // `apply_color_matrix`), so no prior halo leaks through.
+                // The output texture is sized to `fb_dim` (same as the input),
+                // cleared to TRANSPARENT before the pass writes into it (LoadOp::Clear
+                // inside `apply_color_matrix`), so no prior halo leaks through.
                 //
                 // `acc` drops after `apply_color_matrix` returns, returning the
                 // prior intermediate to the pool (≤2-live ping-pong preserved).
                 apply_color_matrix(
                     *matrix,
                     &acc,
-                    viewport_size,
+                    fb_dim,
                     surface_format,
                     &pipelines.color_matrix,
                     resources,
@@ -886,10 +1194,5 @@ pub(in crate::wgpu) fn apply_image_filter_passes(
             }
         };
     }
-    // `grown_bounds` is threaded into this function for signature symmetry with
-    // the morphology path and future multi-pass chains.  The Blur pass does not
-    // require it here (the `grown_bounds` composite rect is applied by the caller
-    // in `flush_opacity_layer`/`render_layer_to_offscreen`). Suppress dead_code.
-    let _ = grown_bounds;
     acc
 }

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -1235,6 +1235,276 @@ impl WgpuPainter {
         )
     }
 
+    /// Compute the integer-aligned offscreen frame rectangle for a filter intermediate.
+    ///
+    /// ## Integer-grid composite invariant (Task 6)
+    ///
+    /// The texture-batch composite sampler is **bilinear** (`default_sampler` Linear
+    /// in `replay.rs`).  Production `grown_bounds` may have fractional edges after
+    /// AABB-expansion and viewport intersection.  Compositing a fractional-origin
+    /// grown texture at its fractional dst_rect keeps the texel grid aligned with
+    /// the device-pixel grid — a valid 1:1 aligned blit.
+    ///
+    /// Shrinking to a smaller intermediate but compositing at the same fractional
+    /// `grown_bounds` would offset the two grids by `frac(grown_left)`, shifting
+    /// every pixel by a sub-texel.  To avoid this, BOTH the intermediate size and
+    /// the composite dst_rect MUST share one integer grid:
+    ///
+    /// ```text
+    /// fb_origin = (floor(grown.left), floor(grown.top))
+    /// fb_far    = (ceil(grown.right),  ceil(grown.bottom))   // clamped to viewport
+    /// fb_dim    = fb_far - fb_origin
+    /// composite: dst_rect = Rect(fb_origin, fb_far),  src_uv = [0, 0, 1, 1]
+    /// ```
+    ///
+    /// For the entire readback test suite (all integer-aligned margins) floor/ceil
+    /// are no-ops → fb rect == grown_bounds → bit-identical output → zero re-baseline.
+    ///
+    /// ## Return value
+    ///
+    /// `(fb_origin, fb_dim)` where both components are `(u32, u32)` integer pixel
+    /// coordinates.  `fb_dim` is clamped to `[1, viewport]` per axis so the pool
+    /// acquire is always valid.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "grown_bounds coords are in [0, vp_dim] after viewport intersection; \
+                  floor/ceil of non-negative f32 ≤ u32::MAX fits safely in u32"
+    )]
+    fn filter_fb_rect(&self, grown_bounds: Rect<Pixels>) -> ((u32, u32), (u32, u32)) {
+        let (vp_w, vp_h) = self.size;
+
+        // Integer-grid origin: floor the fractional grown-bounds top-left.
+        let origin_x = grown_bounds.left().0.floor() as u32;
+        let origin_y = grown_bounds.top().0.floor() as u32;
+
+        // Integer-grid far corner: ceil the fractional grown-bounds bottom-right,
+        // then clamp to the viewport so we never allocate past the surface edge.
+        let far_x = (grown_bounds.right().0.ceil() as u32).min(vp_w);
+        let far_y = (grown_bounds.bottom().0.ceil() as u32).min(vp_h);
+
+        // Dimension: must be at least 1×1 (pool acquire contract).
+        let dim_x = far_x.saturating_sub(origin_x).max(1);
+        let dim_y = far_y.saturating_sub(origin_y).max(1);
+
+        ((origin_x, origin_y), (dim_x, dim_y))
+    }
+
+    /// Compute a conservative device-space content AABB from a `DrawSegment`.
+    ///
+    /// Returns the union of all geometry bounding boxes in the segment, in device
+    /// pixels.  Returns `None` when the segment is empty OR when any geometry kind
+    /// cannot be conservatively bounded (the caller falls back to the full viewport).
+    ///
+    /// ## Conservative-or-fallback contract (CRITICAL)
+    ///
+    /// This function MUST NEVER return an AABB smaller than the true device-space
+    /// content extent.  An under-estimate would clip drawn pixels — a visible
+    /// correctness regression worse than no win at all.  Over-estimation is always
+    /// safe (it merely reduces the VRAM benefit).
+    ///
+    /// When in doubt about a geometry kind, return `None` so the caller falls back
+    /// to the viewport.  The fallback is correct; it only forgoes the VRAM saving.
+    ///
+    /// ## Repositionable vs. fallback kinds
+    ///
+    /// Grown-bounds rendering (`render_segment_to_grown_offscreen`) currently
+    /// repositions only:
+    ///
+    /// - tessellated vertices (`segment.vertices`)
+    /// - `RectInstance`, `CircleInstance`, `ArcInstance` (instanced batches)
+    ///
+    /// Segments containing **shadows, gradients, or images** fall back to the
+    /// full-viewport path (correct, no VRAM win) because those kinds are not
+    /// repositioned by the grown-offscreen renderer.  Repositioning them is a
+    /// tracked follow-up.  Returning `None` here causes the caller's
+    /// `.unwrap_or(viewport)` to select `fb_dim == viewport`, which makes
+    /// `render_segment_to_grown_offscreen`'s remap an identity transform —
+    /// rendering is correct with zero VRAM saving.
+    ///
+    /// ## Geometry kinds covered when returning `Some`
+    ///
+    /// | Kind | Bound source |
+    /// |------|-------------|
+    /// | `vertices` | Exact min/max of `Vertex::position` (device px) |
+    /// | `RectInstance` baked (identity M, zero t) | `bounds [x,y,w,h]` in device px |
+    /// | `RectInstance` affine | 4 corners transformed by M+t, convex hull |
+    /// | `CircleInstance` / `ArcInstance` | center ± (‖col_x‖₁ + ‖col_y‖₁) (conservative) |
+    fn content_aabb(segment: &DrawSegment) -> Option<Rect<Pixels>> {
+        // ── Fallback gate (P0 regression fix) ────────────────────────────────
+        //
+        // Shadows, gradients, and images cannot be repositioned by
+        // `render_segment_to_grown_offscreen`.  Returning `None` here forces the
+        // caller's `.unwrap_or(viewport)` to select `composite_bounds = viewport`
+        // → `fb_dim == viewport` → the remap in the grown renderer is the identity
+        // transform → those kinds render at the correct position.
+        //
+        // This is a conservative-or-fallback: the only cost is forgoing the VRAM
+        // optimisation for layers that contain these kinds.  Correctness is fully
+        // preserved.  Repositioning shadows/gradients/images in the grown
+        // intermediate is a tracked follow-up.
+        if !segment.shadow_batch.is_empty()
+            || !segment.linear_gradient_batch.is_empty()
+            || !segment.radial_gradient_batch.is_empty()
+            || !segment.sweep_gradient_batch.is_empty()
+            || !segment.cached_images.is_empty()
+            || !segment.external_images.is_empty()
+        {
+            return None;
+        }
+
+        // Running AABB accumulators.
+        // Initialised to sentinel values: min→+∞, max→−∞.
+        // After the loops, `min_x <= max_x` iff at least one point was unioned.
+        let mut min_x: f32 = f32::MAX;
+        let mut min_y: f32 = f32::MAX;
+        let mut max_x: f32 = f32::NEG_INFINITY;
+        let mut max_y: f32 = f32::NEG_INFINITY;
+
+        /// Inline helper: union a device-px point into the running AABB.
+        ///
+        /// Does NOT set a `has_any` flag — emptiness is detected at the end by
+        /// checking `min_x <= max_x` (which is only true when at least one point
+        /// was unioned into an initially-sentinel accumulator).
+        macro_rules! union_pt {
+            ($x:expr, $y:expr) => {{
+                let x: f32 = $x;
+                let y: f32 = $y;
+                if x < min_x {
+                    min_x = x;
+                }
+                if x > max_x {
+                    max_x = x;
+                }
+                if y < min_y {
+                    min_y = y;
+                }
+                if y > max_y {
+                    max_y = y;
+                }
+            }};
+        }
+
+        // ── 1. Tessellated vertices (device px, exact) ────────────────────────
+        for v in &segment.vertices {
+            let [x, y] = v.position;
+            union_pt!(x, y);
+        }
+
+        // ── 2. RectInstance ──────────────────────────────────────────────────
+        //
+        // `bounds = [x, y, w, h]` in local-space.
+        // Baked (M = identity, t = zero): bounds are already device px.
+        // Affine: bounds are local-space; apply `device = M * local_corner + t`.
+        //
+        // M is stored column-major as `transform = [a, b, c, d]`:
+        //   x_col = (a, b), y_col = (c, d).
+        // t is `transform_translate = [tx, ty, _, _]`.
+        //
+        // We check identity M exactly (all RectInstance::rect / ::rounded_rect_corners
+        // constructions set `[1,0,0,1]`); a non-identity M triggers the affine path.
+        for instance in &segment.rect_batch.instances {
+            let [lx, ly, lw, lh] = instance.bounds;
+            let [a, b, c, d] = instance.transform;
+            let [tx, ty, _, _] = instance.transform_translate;
+
+            // Exact bit-equality check against the identity 2×2.
+            // These are the only values written by `RectInstance::rect` and
+            // `::rounded_rect_corners` — never computed via arithmetic, so
+            // ULP slop is not a concern.
+            #[expect(
+                clippy::float_cmp,
+                reason = "exact comparison against the bit-exact identity matrix [1,0,0,1] \
+                          written by RectInstance::rect / ::rounded_rect_corners; \
+                          never produced by arithmetic"
+            )]
+            let is_identity_m = a == 1.0 && b == 0.0 && c == 0.0 && d == 1.0;
+
+            // Exact bit comparison against zero is clippy-exempt (literal `0.0`).
+            let is_zero_t = tx == 0.0 && ty == 0.0;
+
+            if is_identity_m && is_zero_t {
+                // Baked path: bounds are device px.
+                union_pt!(lx, ly);
+                union_pt!(lx + lw, ly);
+                union_pt!(lx + lw, ly + lh);
+                union_pt!(lx, ly + lh);
+            } else {
+                // Affine path: transform 4 corners of the local rect.
+                // device = M * (lx_corner, ly_corner) + (tx, ty)
+                // where M = [[a,c],[b,d]] (column-major: x_col=(a,b), y_col=(c,d)).
+                let corners = [(lx, ly), (lx + lw, ly), (lx + lw, ly + lh), (lx, ly + lh)];
+                for (cx, cy) in corners {
+                    let dx = a * cx + c * cy + tx;
+                    let dy = b * cx + d * cy + ty;
+                    union_pt!(dx, dy);
+                }
+            }
+        }
+
+        // ── 3. CircleInstance ────────────────────────────────────────────────
+        //
+        // Center in `transform_translate.xy` (device px, added AFTER M).
+        // M encodes `M_world * diag(rx, ry)` or `M_world * r` (column-major).
+        //
+        // Conservative bounding box: the axis-aligned box of the transformed
+        // unit circle at origin is `center ± (‖col_x‖₂ , ‖col_y‖₂)`, but we
+        // use the L1-norm of columns as a simple over-estimate that avoids sqrt:
+        //   half_x = |col_x|_max ≤ actually |col_x|_2
+        // Wait — we need an OVER-estimate, not an under-estimate.
+        // The true half-extents of M*unit_circle are the singular values of M.
+        // Conservative upper bound: ‖col_x‖₁ + ‖col_y‖₁ ≥ σ₁ (max singular value).
+        // This is always safe (never clips content).
+        for instance in &segment.circle_batch.instances {
+            let [center_x, center_y, _, _] = instance.transform_translate;
+            let [a, b, c, d] = instance.transform;
+            // `center_radius[2]` is the radius factor:
+            //   - Baked path (`CircleInstance::new`):  radius stored here; transform = diag(sx,sy).
+            //     Device half-extent = radius * sx (X), radius * sy (Y).
+            //   - Affine path (`with_affine_transform`): center_radius[2] = 1.0; radius folded
+            //     into transform columns. Multiplying by 1.0 is a safe no-op.
+            // Without this factor the baked path produces half_x = sx (missing `* radius`),
+            // which clips a circle of radius R at scale 1 to a ~2×2 box around its center.
+            let radius_factor = instance.center_radius[2];
+            let half_x = radius_factor * (a.abs() + c.abs());
+            let half_y = radius_factor * (b.abs() + d.abs());
+            union_pt!(center_x - half_x, center_y - half_y);
+            union_pt!(center_x + half_x, center_y + half_y);
+        }
+
+        // ── 4. ArcInstance ───────────────────────────────────────────────────
+        //
+        // Same layout as CircleInstance (unit circle at origin, center in
+        // `transform_translate`).  Conservative: use the full circle box (we
+        // never under-estimate a swept arc by using the enclosing circle).
+        // `center_radius[2]` is always 1.0 for arcs (radius folded into transform),
+        // so multiplying is a safe no-op that keeps the two loops structurally uniform.
+        for instance in &segment.arc_batch.instances {
+            let [center_x, center_y, _, _] = instance.transform_translate;
+            let [a, b, c, d] = instance.transform;
+            let radius_factor = instance.center_radius[2];
+            let half_x = radius_factor * (a.abs() + c.abs());
+            let half_y = radius_factor * (b.abs() + d.abs());
+            union_pt!(center_x - half_x, center_y - half_y);
+            union_pt!(center_x + half_x, center_y + half_y);
+        }
+
+        // ── 5. (Shadow / gradient / image kinds) ─────────────────────────────
+        //
+        // These kinds are excluded by the early-return gate above.  If any of
+        // them is non-empty, `None` has already been returned, so none of these
+        // loops can have instances to iterate.  The loops are omitted; the gate
+        // is the single authoritative location.
+
+        // Sentinel check: if no point was ever unioned, min_x > max_x still
+        // holds (f32::MAX > f32::NEG_INFINITY) — return None for the empty case.
+        if min_x > max_x {
+            return None;
+        }
+
+        Some(Rect::from_ltrb(px(min_x), px(min_y), px(max_x), px(max_y)))
+    }
+
     // ===== Layer Operations (Opacity) =====
 
     pub fn save_layer(&mut self, bounds: Option<Rect<Pixels>>, paint: &Paint) {
@@ -1486,6 +1756,21 @@ impl WgpuPainter {
                         // the group opacity is effectively 1.0 at this stage.
                         let _ = (layer_opacity, tint_rgb, layer_blend, layer_filter);
 
+                        // Override composite_bounds for the image-filter path: use the
+                        // content AABB of the drawn segment (conservative device-space
+                        // union) rather than the full viewport.  This is the producer wiring
+                        // that makes grown-bounds VRAM reduction real: when bounds=None was
+                        // passed to save_layer_with_image_filter, composite_bounds was
+                        // previously always the full viewport (the inert façade that Task 6
+                        // identified and this code fixes).  content_aabb falls back to the
+                        // viewport if the segment is empty or contains an un-boundable kind.
+                        let composite_bounds = {
+                            let vp = self.viewport_bounds();
+                            Self::content_aabb(&offscreen_final_segment)
+                                .and_then(|aabb| aabb.intersect(&vp))
+                                .unwrap_or(vp)
+                        };
+
                         // Growth via the shared helper (one source of truth for Morph).
                         let single_pass = ImageFilterPass::Morph { radius, op };
                         let growth_px = px(cumulative_growth(std::slice::from_ref(&single_pass)));
@@ -1494,11 +1779,18 @@ impl WgpuPainter {
                         let grown_bounds =
                             grown.intersect(&viewport_rect).unwrap_or(composite_bounds);
 
+                        // Compute the integer-aligned offscreen frame rectangle so BOTH
+                        // composite arms (replay.rs + opacity_layer.rs nested Filter arm)
+                        // share one authoritative value and cannot drift (non-negotiable #4).
+                        let (fb_origin, fb_dim) = self.filter_fb_rect(grown_bounds);
+
                         tracing::trace!(
                             radius,
                             op = ?op,
                             content_bounds = ?composite_bounds,
                             grown_bounds = ?grown_bounds,
+                            fb_origin = ?fb_origin,
+                            fb_dim = ?fb_dim,
                             "WgpuPainter::restore_layer: queued DrawItem::Filter (Morph)"
                         );
                         self.draw_order.push(DrawItem::Filter(FilterOp {
@@ -1506,6 +1798,8 @@ impl WgpuPainter {
                             passes: smallvec![single_pass],
                             content_bounds: composite_bounds,
                             grown_bounds,
+                            fb_origin,
+                            fb_dim,
                         }));
                     }
                     Some(ImageFilterSpec::Blur { sigma_x, sigma_y }) => {
@@ -1525,6 +1819,14 @@ impl WgpuPainter {
                         }
                         let _ = (layer_opacity, tint_rgb, layer_blend, layer_filter);
 
+                        // Content-AABB override (same rationale as the Morph arm above).
+                        let composite_bounds = {
+                            let vp = self.viewport_bounds();
+                            Self::content_aabb(&offscreen_final_segment)
+                                .and_then(|aabb| aabb.intersect(&vp))
+                                .unwrap_or(vp)
+                        };
+
                         let single_pass = ImageFilterPass::Blur { sigma_x, sigma_y };
                         let halo_px = px(cumulative_growth(std::slice::from_ref(&single_pass)));
                         let grown = composite_bounds.expand(halo_px);
@@ -1532,11 +1834,16 @@ impl WgpuPainter {
                         let grown_bounds =
                             grown.intersect(&viewport_rect).unwrap_or(composite_bounds);
 
+                        // Integer-aligned fb rect — one home for both composite arms.
+                        let (fb_origin, fb_dim) = self.filter_fb_rect(grown_bounds);
+
                         tracing::trace!(
                             sigma_x,
                             sigma_y,
                             content_bounds = ?composite_bounds,
                             grown_bounds = ?grown_bounds,
+                            fb_origin = ?fb_origin,
+                            fb_dim = ?fb_dim,
                             "WgpuPainter::restore_layer: queued DrawItem::Filter (Blur)"
                         );
                         self.draw_order.push(DrawItem::Filter(FilterOp {
@@ -1544,6 +1851,8 @@ impl WgpuPainter {
                             passes: smallvec![single_pass],
                             content_bounds: composite_bounds,
                             grown_bounds,
+                            fb_origin,
+                            fb_dim,
                         }));
                     }
                     Some(ImageFilterSpec::Chain(passes)) => {
@@ -1563,6 +1872,14 @@ impl WgpuPainter {
                         }
                         let _ = (layer_opacity, tint_rgb, layer_blend, layer_filter);
 
+                        // Content-AABB override (same rationale as the Morph/Blur arms above).
+                        let composite_bounds = {
+                            let vp = self.viewport_bounds();
+                            Self::content_aabb(&offscreen_final_segment)
+                                .and_then(|aabb| aabb.intersect(&vp))
+                                .unwrap_or(vp)
+                        };
+
                         // Cumulative growth = Σ per-pass radii (ColorMatrix/Identity = 0).
                         let growth_px = px(cumulative_growth(&passes));
                         let grown = composite_bounds.expand(growth_px);
@@ -1570,10 +1887,15 @@ impl WgpuPainter {
                         let grown_bounds =
                             grown.intersect(&viewport_rect).unwrap_or(composite_bounds);
 
+                        // Integer-aligned fb rect — one home for both composite arms.
+                        let (fb_origin, fb_dim) = self.filter_fb_rect(grown_bounds);
+
                         tracing::trace!(
                             pass_count = passes.len(),
                             content_bounds = ?composite_bounds,
                             grown_bounds = ?grown_bounds,
+                            fb_origin = ?fb_origin,
+                            fb_dim = ?fb_dim,
                             "WgpuPainter::restore_layer: queued DrawItem::Filter (Chain)"
                         );
                         self.draw_order.push(DrawItem::Filter(FilterOp {
@@ -1581,6 +1903,8 @@ impl WgpuPainter {
                             passes,
                             content_bounds: composite_bounds,
                             grown_bounds,
+                            fb_origin,
+                            fb_dim,
                         }));
                     }
                     None => {

--- a/crates/flui-engine/src/wgpu/replay.rs
+++ b/crates/flui-engine/src/wgpu/replay.rs
@@ -474,11 +474,15 @@ impl GpuReplay {
                 // to the pool. The `apply_image_filter_passes` fold maintains ≤2
                 // live textures regardless of chain length.
                 DrawItem::Filter(mut op) => {
-                    // 1. Render the isolated input segment to a full-viewport
-                    //    premultiplied offscreen — same primitive the AdvancedShape
-                    //    arm uses (replay.rs:354).
-                    let content_tex = self.render_segment_to_offscreen(
+                    // 1. Render the isolated input segment to a GROWN-BOUNDS offscreen
+                    //    (Task 6): sized to fb_dim instead of the full viewport.
+                    //    Vertex positions are pre-transformed to fb-local NDC so that
+                    //    dividing by the unchanged viewport uniform yields correct NDC
+                    //    inside the smaller render target (non-negotiable #2).
+                    let content_tex = self.render_segment_to_grown_offscreen(
                         &mut op.input,
+                        op.fb_origin,
+                        op.fb_dim,
                         viewport_size,
                         surface_format,
                         device,
@@ -488,15 +492,16 @@ impl GpuReplay {
                         encoder,
                     );
 
-                    // 2. Fold the pass chain. Task 0: Identity → returns content_tex
-                    //    unchanged (zero extra acquire — same discipline as the
-                    //    empty-chain fast-path in fold_layer_filter_chain).
+                    // 2. Fold the pass chain over the grown-bounds intermediate.
+                    //    Task 0: Identity → returns content_tex unchanged.
+                    //    Blur/Morph: each sub-pass acquires a fb_dim texture and uses
+                    //    fb-local UV for the content_rect decal (non-negotiable #3).
                     let filtered_tex = apply_image_filter_passes(
                         &op.passes,
                         content_tex,
                         op.content_bounds,
-                        op.grown_bounds,
-                        viewport_size,
+                        op.fb_origin,
+                        op.fb_dim,
                         surface_format,
                         pipelines,
                         resources,
@@ -504,25 +509,31 @@ impl GpuReplay {
                         encoder,
                     );
 
-                    // 3. Composite at grown_bounds via the EXISTING premultiplied
-                    //    texture-batch composite seam (same call the OffscreenTexture
-                    //    arm uses, replay.rs:306). Zero new composite code.
-                    //    `filtered_tex` is FULL-VIEWPORT with the result at its true
-                    //    viewport position, so src_uv maps the grown_bounds dst rect
-                    //    to the matching sub-region of the texture — NOT [0,1], which
-                    //    would stretch the whole viewport onto grown_bounds when they
-                    //    differ (only equal under the current bounds=None producer).
-                    let (vp_w, vp_h) = viewport_size;
-                    let g = op.grown_bounds;
-                    let src_uv = [
-                        g.left().0 / vp_w as f32,
-                        g.top().0 / vp_h as f32,
-                        g.right().0 / vp_w as f32,
-                        g.bottom().0 / vp_h as f32,
-                    ];
+                    // 3. Integer-grid composite (non-negotiable #1):
+                    //    dst_rect = Rect(fb_origin, fb_far); src_uv = [0, 0, 1, 1].
+                    //
+                    //    `filtered_tex` is fb_dim-sized with content at pixel (0,0).
+                    //    src_uv=[0,1] maps the full fb texture onto dst_rect — a
+                    //    pixel-aligned 1:1 blit via the bilinear composite sampler.
+                    //
+                    //    Using fractional grown_bounds as dst_rect over an integer-
+                    //    origin texture would shift every pixel by frac(grown_left)
+                    //    (the composite-grid shift, risk #1 in the Task 6 spec).
+                    let (fb_origin_x, fb_origin_y) = op.fb_origin;
+                    let (fb_w, fb_h) = op.fb_dim;
+                    #[allow(
+                        clippy::cast_precision_loss,
+                        reason = "fb coords are u32 pixel dims ≤ viewport; f32 precision is sufficient"
+                    )]
+                    let dst_rect = flui_types::Rect::from_xywh(
+                        flui_types::geometry::px(fb_origin_x as f32),
+                        flui_types::geometry::px(fb_origin_y as f32),
+                        flui_types::geometry::px(fb_w as f32),
+                        flui_types::geometry::px(fb_h as f32),
+                    );
                     let instance = super::instancing::TextureInstance::with_uv(
-                        op.grown_bounds,
-                        src_uv,
+                        dst_rect,
+                        [0.0, 0.0, 1.0, 1.0],
                         flui_types::styling::Color::WHITE,
                     );
                     let _ = self.texture_batch.add(instance);
@@ -540,7 +551,8 @@ impl GpuReplay {
                     // filtered_tex (and content_tex if distinct) dropped here → pool.
                     tracing::trace!(
                         content_bounds = ?op.content_bounds,
-                        grown_bounds = ?op.grown_bounds,
+                        fb_origin = ?op.fb_origin,
+                        fb_dim = ?op.fb_dim,
                         pass_count = op.passes.len(),
                         "GpuReplay: image filter composited"
                     );


### PR DESCRIPTION
## Summary

Closes **criterion #8** of the `gpu-image-filters` spec: `DrawItem::Filter` intermediates were always **full-viewport**; this sizes them to the content's **grown bounds** (VRAM peak `viewport_area × nesting_depth` → `grown_area × nesting_depth`) while staying **bit-identical** on the integer-aligned readback suite.

### Producer — content-AABB tracking (makes the optimization *live*, not a façade)
`save_layer_with_image_filter` passes `bounds=None`, so `restore_layer` previously fell back to the full viewport — the grown machinery was inert. Now:
- **`WgpuPainter::content_aabb`** computes a **conservative** device-space AABB over the filter layer's content (vertices + rect/circle/arc instances, baked **and** affine paths; circle/arc extent = `center_radius · ‖M columns‖₁`). It **returns `None` → full-viewport fallback** for any segment containing a **shadow / gradient / image** instance (those kinds aren't repositioned in a sub-viewport intermediate yet — falling back is correct, just forgoes the VRAM win). `restore_layer` uses it (clamped to viewport) as `composite_bounds`.

### Machinery — integer-grid, bilinear-safe (chief-architect pin)
- `FilterOp` carries `fb_origin`/`fb_dim`, computed once at record time (`floor(grown.min)→ceil(grown.max)`, clamped) so **both** composite arms (`replay.rs` + `opacity_layer.rs`) share one source and can't drift.
- New **`render_segment_to_grown_offscreen`** pre-transforms vertices + rect/circle/arc by `pos=(px-fb_origin)·(vp/fb_dim)` against the unchanged shared viewport uniform (SSAA-tile precedent; **integer** `fb_dim` denominator) and rebases rect/circle/arc/tess scissors to fb-local. The existing `render_segment_to_offscreen` (advanced-shape path) is **byte-untouched**.
- `apply_image_filter_passes` acquires fb-sized ping-pong + color-matrix textures; blur/morph H-pass decal rebased to `(content_bounds-fb_origin)/fb_dim`.
- Both composite arms blit the whole grown texture (`src_uv=[0,1]`) onto the **integer-aligned** `dst_rect = Rect(fb_origin, fb_far)` — **not** the fractional `grown_bounds`, which would shift every pixel by `frac(grown_left)` under the bilinear composite sampler.

## Tests (local DX12 readback)
| # | Proves |
|---|--------|
| B7 | sub-viewport `fb_dim` emitted through the real painter pipeline |
| B8 | rect clip-detection (content not clipped by an under-sized AABB) |
| B9 | circle radius included (catches the `center_radius` drop) |
| B10 | gradient → viewport fallback (content centred, not mis-positioned) |
| B11 | rect-only layer still sub-viewport (gate is surgical, no over-fallback) |
| B12 | clipped rect at sub-viewport `fb_dim` → rebased fb-local scissor clips at the right position |

**432 GPU readback green; the pre-existing 425 stay bit-identical** (integer-aligned content → integer AABB → integer-grid composite = same pixels).

## Verification (ground-truthed locally)
`cargo clippy` both modes `-D warnings` = 0 · `cargo check --workspace --exclude flui-platform` = 0 (FilterOp ripple) · `cargo doc -D warnings` = 0 · `fmt`/`typos`/`port-check` = 0 · readback 432/0.

Soundness reviewed (ce-kieran, mandatory) — verdict **COMPLETE** after closing three bugs found during review: (1) the producer was inert (façade) → fixed via content_aabb; (2) circle AABB dropped the radius → clipped circles; (3) a P0 regression where shadow/gradient/image rendered mis-positioned in the sub-viewport intermediate → fixed by gating those kinds to the full-viewport fallback (gap-free partition: all 10 `DrawSegment` renderable kinds are either repositioned or gated).

**Follow-up (tracked):** repositioning shadow/gradient/image content *inside* the grown intermediate (currently full-viewport fallback for those kinds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)