### PR TITLE
feat(filters): full ColorFilter through the producer path (consumer-chain T1)

### DIFF
--- a/.rust-studio/specs/gpu-filters-consumer-chain/spec.md
+++ b/.rust-studio/specs/gpu-filters-consumer-chain/spec.md
@@ -1,0 +1,110 @@
+<!-- Rust Code Studio — feature spec. Acceptance criteria are what /spec-verify checks. -->
+
+# Spec: GPU filters consumer chain (make engine filters reachable end-to-end)
+
+- **Status:** Draft   ·   **Slug:** `gpu-filters-consumer-chain`   ·   **Date:** `2026-06-22`   ·   **Owner:** `chief-architect`
+- **Predecessor:** `gpu-image-filters` (DONE — the engine producer; PRs #267-276). Governing decision: vault `adr-filter-consumer-chain`.
+
+## Problem
+
+The `gpu-image-filters` spec shipped a complete GPU **producer**: `ImageFilter::{Blur,Dilate,Erode,Compose}`
+on the bounds-growing `DrawItem::Filter` seam, `ColorFilter::{Mode,Gamma,Matrix}` on the bounds-preserving
+`LayerFilter` chain, the `ImageFilterLayer`/`ColorFilterLayer`/`BackdropFilterLayer` layer types, and the
+engine entry points (`push_image_filter`, `save_layer_with_image_filter`). **But nothing above the engine
+produces them** — they are reachable only by hand-building a `LayerTree` (as `examples/filter_demo.rs` does).
+The consumer chain is broken at every level above flui-layer:
+
+| Layer | Break (verified) |
+|---|---|
+| flui-view / widgets | No `ImageFiltered` / `ColorFiltered` / `BackdropFilter` widget exists. |
+| flui-rendering | No `RenderImageFiltered` / `RenderColorFiltered` / `RenderBackdropFilter`; `PaintEffectsCapability` has no filter hook; `paint_subtree` wraps only Opacity/Transform. |
+| flui-painting | `Paint` has no `image_filter`/`color_filter`; `DrawCommand::SaveLayer{bounds,paint,transform}` carries no filter. |
+| flui-layer | `ImageFilterLayer`/`ColorFilterLayer` exist + render, but have **zero producers**; `ColorFilterLayer` wraps a bare `ColorMatrix`, not the full `ColorFilter`. |
+| flui-engine | `push_color_filter(&ColorMatrix)` can't express `ColorFilter::Mode`/`Gamma` (which the engine implements); `LayerFilter::Mode`/`Gamma` are `cfg(test)`-only. |
+
+**Goal:** make the engine's filters reachable from the public widget API, improving the cross-crate
+architecture. **Breaking changes are allowed** (active dev, no external consumers) — used where the break is
+clean, not gratuitously.
+
+## Goals / Non-goals
+
+**Goals**
+- A user can apply a Gaussian blur / morphology / compose chain / color filter (Mode/Gamma/Matrix) to a
+  widget subtree via dedicated widgets, and it reaches GPU pixels end-to-end.
+- Complete the engine producer surface: full `ColorFilter` (not just `ColorMatrix`) through `push_color_filter`.
+- Each filter widget carries render-harness + readback/scene-snapshot tests (anti-MVP).
+
+**Non-goals**
+- ❌ `Paint.image_filter` / `Paint.color_filter` low-level route (Approach A) — rejected: bloats the
+  serialized `DrawCommand`/`Paint` trust boundary, breaks deterministic-replay goldens, forces per-draw
+  engine unpacking. Deferred to a future ADR only if a low-level (custom-painter `save_layer`) consumer appears.
+- ❌ New engine filter *kinds* — the producer is done; this spec only wires consumers.
+- ❌ gpui-style opacity-baking optimization — orthogonal (gpui has no general filters; ruled out as a model).
+
+## Approach (chief-architect ACCEPTABLE; Flutter-idiomatic route, verified vs `.flutter/`)
+
+**Dedicated widgets → proxy render-objects → existing layer-tree filter layers** — the exact structure of
+Flutter's `ImageFiltered`/`ColorFiltered`/`BackdropFilter` (`image_filter.dart`/`color_filter.dart`/
+`proxy_box.dart`), which flui already half-built (the layer types). `Paint`/`DrawCommand`/serialized wire
+format are **untouched**.
+
+- New render-objects (`Single` arity, always-composite + repaint-boundary — the flui analogue of Flutter's
+  `RenderProxyBox`): `RenderColorFiltered{filter: ColorFilter}` → `Layer::ColorFilter`;
+  `RenderImageFiltered{filter: ImageFilter}` → `Layer::ImageFilter`;
+  `RenderBackdropFilter{filter, blend_mode}` → `Layer::BackdropFilter`.
+- Seam mechanism: extend `PaintEffectsCapability` with filter hooks (default `None` → additive, non-breaking)
+  + one `paint_subtree` arm mirroring the Opacity arm. **Footgun (from advanced-blend memory):** the filter
+  arm must fire on the filter hook ALONE, independent of `paint_alpha` (the existing arm silently drops
+  `paint_layer_blend` unless `paint_alpha` is Some — the filter arm must NOT replicate that asymmetry).
+- Producer-completeness (breaking, internal only): `push_color_filter(&ColorMatrix)` → `&ColorFilter`;
+  promote `LayerFilter::Mode`/`Gamma` to production; widen `ColorFilterLayer` to carry `ColorFilter`.
+
+### Alternatives
+| Option | Why not |
+|---|---|
+| **A — `Paint.image_filter` + `DrawCommand::SaveLayer` filter field** | Bloats the serialized closed-enum trust boundary; breaks replay goldens; per-draw unpack. Matches only Flutter's low-level dart:ui surface, not the widget route apps use. Rejected. |
+| **gpui-style (effect-as-style-property + opacity stack)** | gpui has NO general image/color filters (opacity + box-shadow blur only — narrow code-editor scope). No abstraction to borrow for general filters. Ruled out. |
+
+## Public surface & semver impact
+Active-dev breaking allowed. Breaking edits are **internal trait/layer signatures only — zero serialized
+format change** (replay goldens stay valid): `push_color_filter(&ColorFilter)` (B1), `ColorFilterLayer`
+field widened to `ColorFilter` (B2). Additive: `PaintEffectsCapability` filter hooks (default None), new
+render-objects + widgets. `Paint`/`DrawCommand`/DisplayList wire format unchanged.
+
+## Pre-code maintainer verdict: **ACCEPTABLE**
+Filter-on-content owned by render-objects/widgets (compositing concept) producing layers (GPU-bridge concept);
+the `Paint`/`DrawCommand` trust boundary is not widened (one fact, one place — the typed filter enum flows,
+never duplicated into Paint). Maximal sibling reuse (engine seam + 3 layer types + `PaintEffectsCapability`/
+`paint_subtree`/`SceneComposer` + the `RenderOpacity` Single-arity template). Strict-maintainer risks pinned
+in acceptance below.
+
+## Acceptance criteria
+- [ ] **Full `ColorFilter` through the engine** — `push_color_filter` accepts `&ColorFilter` (Mode/Gamma/Matrix); `LayerFilter::Mode`/`Gamma` are production (not `cfg(test)`); `ColorFilterLayer` carries `ColorFilter`. *(GPU readback: Mode + Gamma reachable via the layer path; Matrix unchanged.)*
+- [ ] **Filter render seam** — `PaintEffectsCapability` gains filter hooks (default `None`); `paint_subtree` wraps the fragment in the filter layer when a hook returns `Some`, **firing independently of `paint_alpha`** (regression test for the no-silent-drop invariant). *(harness test that fails without the arm.)*
+- [ ] **`ColorFiltered` widget + `RenderColorFiltered`** — applies Mode/Matrix/Gamma to a subtree; always-composites; repaint-boundary. *(render-harness + GPU/scene-snapshot test across ALL THREE sub-modes — Matrix-only ≠ done.)*
+- [ ] **`ImageFiltered` widget + `RenderImageFiltered`** — applies Blur/Dilate/Erode/Compose to a subtree. *(harness + readback across the variants; off-origin content not clipped — reuse the grown-bounds lessons.)*
+- [ ] **`BackdropFilter` widget + `RenderBackdropFilter`** — blurs backdrop content under the existing renderer intercept (`supports_copy_src || intermediate_active` gate). *(harness + readback under the gate.)*
+- [ ] **End-to-end parity** — `examples/filter_demo` (and a new `color_filter_demo`) build via the **widget tree** (not a hand-built `LayerTree`), proving the chain closes public-API→pixels; each widget's edge behavior cross-checked vs `.flutter/` (anti-MVP).
+- [ ] **Repaint-boundary reuse** — a filter render-object reuses its layer on offset-only moves (Flutter `updateCompositedLayer` parity), not full repaint.
+- [ ] **Gates** — fmt; clippy both modes incl. `--features enable-wgpu-tests` `-D warnings`; nextest; doc `-D warnings`; port-check; the gpu-image-filters readback suite + deterministic-replay goldens stay green (serialized format untouched).
+
+## Risks & open questions
+- **Capability-hook alpha-asymmetry footgun** (`paint_subtree` drops `paint_layer_blend` without `paint_alpha`) — the filter arm must not replicate it; encode + regression-test. (vault `verify-guard-premise-before-debug-assert` / advanced-blend memory.)
+- **Repaint-boundary / always-composite** — if the filter RO doesn't report repaint-boundary, offset moves repaint instead of reusing the layer.
+- **Anti-MVP** — `ColorFiltered`'s three sub-modes each need coverage; shipping Matrix-only = MVP-as-parity.
+- **Backdrop ordering gate** — `RenderBackdropFilter` correct only under `supports_copy_src || intermediate_active` (already true for the existing path).
+- **Catalog CI guard** — every new `RenderBox` must appear in `RENDER_OBJECT_TYPES` with a `harness_*` test.
+
+## Slicing (dependency-ordered; each an independent `/dev-task` → review → local GPU-readback)
+- **T1 — Producer-completeness: full `ColorFilter` through the engine.** `[BREAK B1/B2]` `[SIGN-OFF: api-design-lead]` Widen `push_color_filter`→`&ColorFilter`; promote `LayerFilter::Mode/Gamma`; widen `ColorFilterLayer`→`ColorFilter`; update dispatch + `LayerRender for ColorFilterLayer`. GPU-readback Mode+Gamma via the layer path. *Engine+layer only — critical-path root, self-contained, immediate value.*
+- **T2 — Render seam: `PaintEffectsCapability` filter hooks + `paint_subtree` arm.** `[SIGN-OFF: chief-architect]` (hook shape + alpha-asymmetry footgun). Depends on T1.
+- **T3a — `RenderColorFiltered` + `ColorFiltered` widget** (Mode/Matrix/Gamma). Depends on T2.
+- **T3b — `RenderImageFiltered` + `ImageFiltered` widget** (Blur/Dilate/Erode/Compose). Depends on T2.
+- **T3c — `RenderBackdropFilter` + `BackdropFilter` widget** (under the backdrop gate). Depends on T2.
+  *(T3a/b/c parallel — disjoint render-objects/widgets sharing the T2 seam.)*
+- **T4 — End-to-end demos + `.flutter/` parity verification** (widget-tree-built `filter_demo`/`color_filter_demo`). Depends on T3a/b/c.
+
+## Links
+- Predecessor: `gpu-image-filters` spec + `verify-report.md`. Engine seam: `DrawItem::Filter`/`LayerFilter`, `layer_render.rs:447-477`, `traits.rs:441`, `command_ir.rs`.
+- Reference (read this design): `.flutter/` `lib/src/widgets/image_filter.dart`, `color_filter.dart`, `rendering/proxy_box.dart` (`RenderProxyBox`, `RenderBackdropFilter`). `.gpui/` ruled out (no general filters).
+- Vault: `adr-filter-consumer-chain`, `bounded-filter-intermediate-integer-grid-composite`, `occlusion-cull-was-unsound-in-back-to-front-order`, `flui-future-proof-over-yagni`.

--- a/crates/flui-engine/src/traits.rs
+++ b/crates/flui-engine/src/traits.rs
@@ -437,8 +437,12 @@ pub trait LayerStateStack {
     /// Pop the most recent opacity from the effect stack
     fn pop_opacity(&mut self);
 
-    /// Push a color filter onto the effect stack
-    fn push_color_filter(&mut self, filter: &flui_types::painting::ColorMatrix);
+    /// Push a color filter onto the effect stack.
+    ///
+    /// Accepts the full [`flui_types::painting::ColorFilter`] enum — `Matrix`,
+    /// `Mode`, `LinearToSrgbGamma`, and `SrgbToLinearGamma` — so all engine
+    /// GPU passes are reachable from a single trait method.
+    fn push_color_filter(&mut self, filter: &flui_types::painting::ColorFilter);
 
     /// Pop the most recent color filter from the effect stack
     fn pop_color_filter(&mut self);

--- a/crates/flui-engine/src/wgpu/backend.rs
+++ b/crates/flui-engine/src/wgpu/backend.rs
@@ -15,7 +15,7 @@ use smallvec::SmallVec;
 use std::sync::Arc;
 
 use super::{
-    command_ir::{ImageFilterPass, ImageFilterSpec, LayerFilter, MorphOp},
+    command_ir::{GammaDirection, ImageFilterPass, ImageFilterSpec, LayerFilter, MorphOp},
     painter::WgpuPainter,
 };
 use crate::{
@@ -1511,33 +1511,78 @@ impl LayerStateStack for Backend<'_> {
         self.painter.restore_layer();
     }
 
-    fn push_color_filter(&mut self, filter: &flui_types::painting::ColorMatrix) {
+    fn push_color_filter(&mut self, filter: &flui_types::painting::ColorFilter) {
+        use flui_types::painting::ColorFilter;
+
         self.flush_active_transform();
 
-        // Identity fast-path: no-op layer keeps push/pop balanced.
-        // Exact f32 comparison is correct: `ColorMatrix::identity()` is
-        // built from bit-exact 0.0/1.0 literals, so a transitive equality
-        // check correctly skips the GPU pass without ULP slop.
-        let identity = flui_types::painting::ColorMatrix::identity();
-        #[expect(
-            clippy::float_cmp,
-            reason = "identity matrix is bit-exact (0.0/1.0 literals); exact comparison is correct"
-        )]
-        if filter.values == identity.values {
-            self.painter.save_layer(None, &Paint::fill(Color::WHITE));
-            tracing::trace!("push_color_filter: identity matrix — no-op layer");
-            return;
+        match filter {
+            ColorFilter::Matrix(m) => {
+                // Identity fast-path: no-op layer keeps push/pop balanced.
+                // Exact f32 comparison is correct: `ColorMatrix::identity()` is
+                // built from bit-exact 0.0/1.0 literals, so a transitive equality
+                // check correctly skips the GPU pass without ULP slop.
+                let identity = flui_types::painting::effects::ColorMatrix::identity();
+                #[expect(
+                    clippy::float_cmp,
+                    reason = "identity matrix is bit-exact (0.0/1.0 literals); exact comparison is correct"
+                )]
+                if m.values == identity.values {
+                    self.painter.save_layer(None, &Paint::fill(Color::WHITE));
+                    tracing::trace!("push_color_filter: identity matrix — no-op layer");
+                    return;
+                }
+                // Real color-matrix: open a filter layer.  The GPU shader applies the
+                // full 5×4 matrix per-pixel (unpremul → matrix → clamp → repremul).
+                self.painter
+                    .save_layer_with_filter(None, LayerFilter::ColorMatrix(m.values));
+                tracing::trace!(
+                    matrix = ?m.values,
+                    "push_color_filter: GPU color-matrix filter layer"
+                );
+            }
+            ColorFilter::Mode { color, blend_mode } => {
+                // Blend a solid filter color over each layer pixel via the
+                // Porter-Duff / W3C blend equation.  Unpremul → blend → clamp →
+                // repremul is applied by the GPU shader.
+                self.painter.save_layer_with_filter(
+                    None,
+                    LayerFilter::Mode {
+                        color: color.to_f32_array(),
+                        blend_mode: *blend_mode,
+                    },
+                );
+                tracing::trace!(
+                    ?color,
+                    ?blend_mode,
+                    "push_color_filter: GPU mode filter layer"
+                );
+            }
+            ColorFilter::LinearToSrgbGamma => {
+                // Linear-light → sRGB-encoded transfer per RGB channel; alpha
+                // passes through unchanged.
+                self.painter
+                    .save_layer_with_filter(None, LayerFilter::Gamma(GammaDirection::LinearToSrgb));
+                tracing::trace!("push_color_filter: GPU LinearToSrgb gamma filter layer");
+            }
+            ColorFilter::SrgbToLinearGamma => {
+                // sRGB-encoded → linear-light transfer per RGB channel; alpha
+                // passes through unchanged.
+                self.painter
+                    .save_layer_with_filter(None, LayerFilter::Gamma(GammaDirection::SrgbToLinear));
+                tracing::trace!("push_color_filter: GPU SrgbToLinear gamma filter layer");
+            }
+            // `ColorFilter` is `#[non_exhaustive]`; a wildcard arm is required by
+            // the compiler.  Open a balanced no-op layer so `pop_color_filter` has a
+            // matching restore, and warn once so unknown variants surface in logs.
+            _ => {
+                tracing::warn!(
+                    "push_color_filter: unknown ColorFilter variant (future extension?) \
+                     — falling back to no-op layer to keep push/pop balanced"
+                );
+                self.painter.save_layer(None, &Paint::fill(Color::WHITE));
+            }
         }
-
-        // Real color-matrix: open a filter layer.  The GPU shader applies the
-        // full 5×4 matrix per-pixel (unpremul → matrix → clamp → repremul),
-        // so no approximation is needed here.
-        self.painter
-            .save_layer_with_filter(None, LayerFilter::ColorMatrix(filter.values));
-        tracing::trace!(
-            matrix = ?filter.values,
-            "push_color_filter: GPU color-matrix filter layer"
-        );
     }
 
     fn pop_color_filter(&mut self) {

--- a/crates/flui-engine/src/wgpu/batches/images.rs
+++ b/crates/flui-engine/src/wgpu/batches/images.rs
@@ -943,8 +943,11 @@ impl DrawBatcher {
             }
             ColorFilter::Matrix(matrix) => {
                 // Apply color matrix to image pixel data on CPU.
+                // `matrix` is `ColorMatrix` (a `[f32;20]` newtype); access
+                // the raw values through `matrix.values`.
                 // Matrix / gamma branches carry no per-pixel blend mode and
                 // always delegate with the paint's blend mode unchanged.
+                let m = &matrix.values;
                 let data = image.data();
                 let w = image.width();
                 let h = image.height();
@@ -956,24 +959,12 @@ impl DrawBatcher {
                     let b = f32::from(pixel[2]) / 255.0;
                     let a = f32::from(pixel[3]) / 255.0;
 
-                    let nr =
-                        (matrix[0] * r + matrix[1] * g + matrix[2] * b + matrix[3] * a + matrix[4])
-                            .clamp(0.0, 1.0);
-                    let ng =
-                        (matrix[5] * r + matrix[6] * g + matrix[7] * b + matrix[8] * a + matrix[9])
-                            .clamp(0.0, 1.0);
-                    let nb = (matrix[10] * r
-                        + matrix[11] * g
-                        + matrix[12] * b
-                        + matrix[13] * a
-                        + matrix[14])
-                        .clamp(0.0, 1.0);
-                    let na = (matrix[15] * r
-                        + matrix[16] * g
-                        + matrix[17] * b
-                        + matrix[18] * a
-                        + matrix[19])
-                        .clamp(0.0, 1.0);
+                    let nr = (m[0] * r + m[1] * g + m[2] * b + m[3] * a + m[4]).clamp(0.0, 1.0);
+                    let ng = (m[5] * r + m[6] * g + m[7] * b + m[8] * a + m[9]).clamp(0.0, 1.0);
+                    let nb =
+                        (m[10] * r + m[11] * g + m[12] * b + m[13] * a + m[14]).clamp(0.0, 1.0);
+                    let na =
+                        (m[15] * r + m[16] * g + m[17] * b + m[18] * a + m[19]).clamp(0.0, 1.0);
 
                     new_data.push((nr * 255.0) as u8);
                     new_data.push((ng * 255.0) as u8);
@@ -1062,6 +1053,24 @@ impl DrawBatcher {
                 );
 
                 tracing::debug!("draw_image_filtered: SrgbToLinearGamma applied via CPU");
+            }
+            // `ColorFilter` is `#[non_exhaustive]`; this arm handles any future
+            // variants added after this site was compiled.  The image is drawn
+            // unfiltered with `paint_blend_mode` so nothing is silently dropped.
+            _ => {
+                tracing::warn!(
+                    "draw_image_filtered: unknown ColorFilter variant \
+                     — drawing image unfiltered"
+                );
+                Self::draw_image(
+                    segment,
+                    draw_order,
+                    state,
+                    texture_cache,
+                    image,
+                    dst,
+                    paint_blend_mode,
+                );
             }
         }
     }

--- a/crates/flui-engine/src/wgpu/color_filter_producer_tests.rs
+++ b/crates/flui-engine/src/wgpu/color_filter_producer_tests.rs
@@ -1,0 +1,631 @@
+//! Producer-path GPU readback acceptance gate for T1 of `gpu-filters-consumer-chain`.
+//!
+//! ## Purpose
+//!
+//! These tests prove that `ColorFilter::Mode{...}` and `ColorFilter::LinearToSrgbGamma`
+//! are correctly routed through the **layer producer path**:
+//!
+//! ```text
+//! ColorFilterLayer::render
+//!   → Backend::push_color_filter(&ColorFilter::Mode/LinearToSrgbGamma/...)
+//!   → WgpuPainter::save_layer_with_filter(LayerFilter::Mode{...} / LayerFilter::Gamma(...))
+//!   → GPU mode/gamma filter shader
+//! ```
+//!
+//! Before T1, `Backend::push_color_filter` only accepted `&ColorMatrix`; the
+//! `LayerFilter::Mode` and `LayerFilter::Gamma` variants had no production caller
+//! (only `#[cfg(test)]`-gated uses).  These tests would have **failed to compile**
+//! on `main` because the old trait signature did not accept `&ColorFilter`.
+//! They turn RED→GREEN exactly at T1.
+//!
+//! ## Test inventory
+//!
+//! | # | Gate | Requirement |
+//! |---|------|-------------|
+//! | P1 | GPU | Mode filter via producer path: oracle match (Multiply) |
+//! | P2 | GPU | LinearToSrgbGamma via producer path: oracle match |
+//! | P3 | GPU | SrgbToLinearGamma via producer path: oracle match |
+//! | P4 | GPU | Matrix filter via producer path: matches direct-painter path byte-for-byte |
+//!
+//! ## Oracle discipline
+//!
+//! P1: calls `Color::blend(filter_color, dst_pixel, mode)` — the same function
+//! the mode-filter shader mirrors.
+//! P2/P3: applies the standard sRGB/linear transfer formula per channel (alpha unchanged).
+//! P4: redundant compared to `color_matrix_filter_tests` but proves the producer path
+//! for Matrix too.
+
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+mod gpu_tests {
+    use std::sync::Arc;
+
+    use flui_painting::Paint;
+    use flui_types::{
+        Color, Rect,
+        geometry::{Matrix4, Pixels},
+        painting::{BlendMode, ColorFilter},
+    };
+
+    use crate::{
+        traits::{CommandRenderer, LayerStateStack},
+        wgpu::{Backend, painter::WgpuPainter, render_target::RenderTarget},
+    };
+
+    // ── Harness constants ─────────────────────────────────────────────────────
+
+    const SURFACE_WIDTH: u32 = 64;
+    const SURFACE_HEIGHT: u32 = 64;
+    const SURFACE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
+
+    // ── Harness helpers ───────────────────────────────────────────────────────
+
+    fn acquire_test_device_and_queue() -> (Arc<wgpu::Device>, Arc<wgpu::Queue>) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .expect("a GPU adapter must be available for color_filter_producer_tests");
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("ColorFilterProducer Test Device"),
+            ..Default::default()
+        }))
+        .expect("a GPU device must be available for color_filter_producer_tests");
+        (Arc::new(device), Arc::new(queue))
+    }
+
+    fn create_surface(device: &wgpu::Device) -> (wgpu::Texture, wgpu::TextureView) {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("ColorFilterProducer Test Surface"),
+            size: wgpu::Extent3d {
+                width: SURFACE_WIDTH,
+                height: SURFACE_HEIGHT,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: SURFACE_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        (texture, view)
+    }
+
+    fn clear_surface(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        view: &wgpu::TextureView,
+        color: wgpu::Color,
+    ) {
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("ColorFilterProducer Surface Clear"),
+        });
+        {
+            let _pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("ColorFilterProducer Clear Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(color),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+        }
+        queue.submit(std::iter::once(encoder.finish()));
+    }
+
+    /// Read all pixels back from `texture` as `[r, g, b, a]` u8 quads.
+    fn readback_pixels(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        texture: &wgpu::Texture,
+    ) -> Vec<[u8; 4]> {
+        let bytes_per_pixel = 4u32;
+        let unpadded_row_bytes = SURFACE_WIDTH * bytes_per_pixel;
+        let row_alignment = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let padded_row_bytes = unpadded_row_bytes.div_ceil(row_alignment) * row_alignment;
+        let staging_size = u64::from(padded_row_bytes * SURFACE_HEIGHT);
+
+        let staging = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("ColorFilterProducer Readback Staging"),
+            size: staging_size,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("ColorFilterProducer Readback Encoder"),
+        });
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &staging,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_row_bytes),
+                    rows_per_image: Some(SURFACE_HEIGHT),
+                },
+            },
+            wgpu::Extent3d {
+                width: SURFACE_WIDTH,
+                height: SURFACE_HEIGHT,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit(std::iter::once(encoder.finish()));
+
+        staging.slice(..).map_async(wgpu::MapMode::Read, |_| {});
+        device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .expect("GPU readback poll must complete within wait timeout");
+
+        let raw_bytes = staging.slice(..).get_mapped_range();
+        let pixel_count = (SURFACE_WIDTH * SURFACE_HEIGHT) as usize;
+        let mut pixels = Vec::with_capacity(pixel_count);
+        for row_index in 0..SURFACE_HEIGHT {
+            let row_start = (row_index * padded_row_bytes) as usize;
+            for col_index in 0..SURFACE_WIDTH {
+                let byte_offset = row_start + col_index as usize * 4;
+                pixels.push([
+                    raw_bytes[byte_offset],
+                    raw_bytes[byte_offset + 1],
+                    raw_bytes[byte_offset + 2],
+                    raw_bytes[byte_offset + 3],
+                ]);
+            }
+        }
+        pixels
+    }
+
+    fn build_painter(device: Arc<wgpu::Device>, queue: Arc<wgpu::Queue>) -> WgpuPainter {
+        WgpuPainter::with_shared_device(
+            device,
+            queue,
+            SURFACE_FORMAT,
+            (SURFACE_WIDTH, SURFACE_HEIGHT),
+        )
+    }
+
+    fn full_surface_bounds() -> Rect<Pixels> {
+        Rect::from_xywh(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(SURFACE_WIDTH as f32),
+            Pixels(SURFACE_HEIGHT as f32),
+        )
+    }
+
+    /// Assert every interior pixel (skip 1-pixel border to avoid SDF fwidth edge
+    /// artefacts) is within `tolerance` of `expected` in all 4 channels.
+    fn assert_interior_pixels_near(
+        label: &str,
+        readback: &[[u8; 4]],
+        expected: [u8; 4],
+        tolerance: u8,
+    ) {
+        let width = SURFACE_WIDTH as usize;
+        let height = SURFACE_HEIGHT as usize;
+        for (pixel_index, &actual) in readback.iter().enumerate() {
+            let row = pixel_index / width;
+            let col = pixel_index % width;
+            // Skip the 1-pixel border.
+            if row == 0 || row >= height - 1 || col == 0 || col >= width - 1 {
+                continue;
+            }
+            for channel_index in 0..4 {
+                let channel_diff = u8::try_from(
+                    (i16::from(actual[channel_index]) - i16::from(expected[channel_index]))
+                        .unsigned_abs(),
+                )
+                .expect("diff of two u8 values always fits in u8");
+                assert!(
+                    channel_diff <= tolerance,
+                    "{label}: pixel {pixel_index} (row={row} col={col}) \
+                     channel {channel_index} — actual={a} expected={e} \
+                     diff={channel_diff} > tolerance {tolerance}",
+                    a = actual[channel_index],
+                    e = expected[channel_index],
+                );
+            }
+        }
+    }
+
+    /// Render using the **producer path**: `Backend::push_color_filter(&ColorFilter)`,
+    /// draw a rect via `render_rect`, `Backend::pop_color_filter`, submit, readback.
+    ///
+    /// This is the code path exercised by `ColorFilterLayer::render` in production.
+    /// Using `Backend` directly instead of `WgpuPainter::save_layer_with_filter`
+    /// is the distinguishing property: it proves `Backend::push_color_filter`
+    /// dispatches the right `LayerFilter` variant for each `ColorFilter` arm.
+    ///
+    /// Draw calls go through `CommandRenderer::render_rect` (which is what real
+    /// display-list dispatch does); `WgpuPainter::rect` is a painter-internal
+    /// method not exposed on `Backend`.
+    fn render_via_producer_path(
+        device: &Arc<wgpu::Device>,
+        queue: &Arc<wgpu::Queue>,
+        surface_tex: &wgpu::Texture,
+        surface_view: &wgpu::TextureView,
+        filter: ColorFilter,
+        layer_color: Color,
+    ) -> Vec<[u8; 4]> {
+        let bounds = full_surface_bounds();
+        let painter = build_painter(Arc::clone(device), Arc::clone(queue));
+        let mut backend = Backend::new(painter);
+
+        // The same call that `ColorFilterLayer::render` issues (via LayerStateStack).
+        backend.push_color_filter(&filter);
+        // Draw a full-surface rect via CommandRenderer (the display-list dispatch path).
+        backend.render_rect(bounds, &Paint::fill(layer_color), &Matrix4::IDENTITY);
+        // The same call that `ColorFilterLayer::cleanup` issues.
+        backend.pop_color_filter();
+
+        // Extract the painter and submit.
+        let mut painter = backend.into_painter();
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("ColorFilterProducer Render Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(surface_view, surface_tex),
+                &mut encoder,
+            )
+            .expect("producer-path filter render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+        readback_pixels(device, queue, surface_tex)
+    }
+
+    // ── CPU oracle helpers ────────────────────────────────────────────────────
+
+    /// Mode oracle: mirrors the mode-filter GPU shader.
+    /// Inputs are straight-alpha; output is premultiplied u8.
+    fn mode_filter_oracle(filter_color: Color, dst_straight: Color, mode: BlendMode) -> [u8; 4] {
+        // filter_color = SRC; dst_straight = DST (straight-alpha input from layer).
+        let blended = filter_color.blend(dst_straight, mode);
+        // `blended` is straight-alpha; convert to premultiplied u8.
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "values clamped to [0,1]*255 then rounded; truncation is safe"
+        )]
+        let to_premul_u8 = |channel: u8, alpha: u8| -> u8 {
+            let straight = f32::from(channel) / 255.0;
+            let a = f32::from(alpha) / 255.0;
+            (straight * a * 255.0).round() as u8
+        };
+        let out_a = blended.a;
+        [
+            to_premul_u8(blended.r, out_a),
+            to_premul_u8(blended.g, out_a),
+            to_premul_u8(blended.b, out_a),
+            out_a,
+        ]
+    }
+
+    /// LinearToSrgb oracle: linear → sRGB per channel; alpha unchanged.
+    /// Input is straight-alpha opaque; output is premultiplied u8 (== straight for
+    /// opaque alpha).
+    fn linear_to_srgb_oracle(linear_channel: u8) -> u8 {
+        let linear = f32::from(linear_channel) / 255.0;
+        let srgb = if linear <= 0.003_130_8 {
+            linear * 12.92
+        } else {
+            1.055 * linear.powf(1.0 / 2.4) - 0.055
+        };
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "value clamped to [0,1]*255 then rounded; truncation is safe"
+        )]
+        let result = (srgb.clamp(0.0, 1.0) * 255.0).round() as u8;
+        result
+    }
+
+    /// SrgbToLinear oracle: sRGB → linear per channel; alpha unchanged.
+    fn srgb_to_linear_oracle(srgb_channel: u8) -> u8 {
+        let srgb = f32::from(srgb_channel) / 255.0;
+        let linear = if srgb <= 0.04045 {
+            srgb / 12.92
+        } else {
+            ((srgb + 0.055) / 1.055).powf(2.4)
+        };
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "value clamped to [0,1]*255 then rounded; truncation is safe"
+        )]
+        let result = (linear.clamp(0.0, 1.0) * 255.0).round() as u8;
+        result
+    }
+
+    // ── P1: Mode filter via producer path ─────────────────────────────────────
+
+    /// P1: `ColorFilter::Mode { Multiply, half-opacity red }` dispatched through
+    /// `Backend::push_color_filter` produces the same GPU output as the
+    /// mode-oracle for the same input color.
+    ///
+    /// **Proves:**
+    /// - `Backend::push_color_filter` now accepts `&ColorFilter` (not just `&ColorMatrix`).
+    /// - The `ColorFilter::Mode` arm correctly translates to `LayerFilter::Mode`.
+    /// - `color.to_f32_array()` produces the right channel order for the GPU shader.
+    ///
+    /// **Fails if:** `push_color_filter` ignores Mode (no-op layer), dispatches the
+    /// wrong blend mode, or scrambles the color channels.
+    ///
+    /// **Red-before-green:** on `main`, this test would not compile because the old
+    /// trait signature was `&ColorMatrix`, not `&ColorFilter`.
+    #[test]
+    fn p1_mode_filter_multiply_via_producer_path() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_surface(&device);
+        clear_surface(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 1.0,
+            },
+        );
+
+        // Opaque red-green layer pixel; half-opacity blue filter color.
+        let layer_color = Color::rgba(180, 120, 40, 255);
+        let filter_color = Color::rgba(0, 0, 200, 128);
+        let filter = ColorFilter::mode(filter_color, BlendMode::Multiply);
+
+        let readback = render_via_producer_path(
+            &device,
+            &queue,
+            &surface_tex,
+            &surface_view,
+            filter,
+            layer_color,
+        );
+
+        // Oracle: mode filter blends filter_color (SRC) onto layer_color (DST).
+        // For opaque input the layer pixel IS the straight-alpha value.
+        let expected = mode_filter_oracle(filter_color, layer_color, BlendMode::Multiply);
+
+        assert_interior_pixels_near("P1 Mode/Multiply producer path", &readback, expected, 3);
+    }
+
+    // ── P2: LinearToSrgbGamma via producer path ───────────────────────────────
+
+    /// P2: `ColorFilter::LinearToSrgbGamma` dispatched through
+    /// `Backend::push_color_filter` applies the linear→sRGB transfer per channel.
+    ///
+    /// **Proves:**
+    /// - The `LinearToSrgbGamma` arm correctly translates to
+    ///   `LayerFilter::Gamma(GammaDirection::LinearToSrgb)`.
+    /// - The gamma shader applies the standard IEC 61966-2-1 transfer.
+    ///
+    /// **Discriminating:** the chosen `layer_color = rgba(50, 100, 200, 255)` has
+    /// mid-range channel values where the nonlinear part of the IEC formula applies.
+    /// A no-op (identity) would output `(50, 100, 200)` in straight-alpha space,
+    /// while the oracle outputs significantly different values, so a wrong/missing
+    /// dispatch is caught.
+    ///
+    /// **Red-before-green:** on `main`, the old `push_color_filter(&ColorMatrix)`
+    /// signature could not accept `&ColorFilter::LinearToSrgbGamma`.
+    #[test]
+    fn p2_linear_to_srgb_gamma_via_producer_path() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_surface(&device);
+        clear_surface(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 1.0,
+            },
+        );
+
+        // Choose a color where linear→sRGB is non-trivially different from identity.
+        // At channel value 50/255 ≈ 0.196 (above the 0.003_130_8 threshold):
+        //   sRGB = 1.055 * 0.196^(1/2.4) - 0.055 ≈ 0.471, i.e. ~120/255.
+        let layer_color = Color::rgba(50, 100, 200, 255);
+        let filter = ColorFilter::LinearToSrgbGamma;
+
+        let readback = render_via_producer_path(
+            &device,
+            &queue,
+            &surface_tex,
+            &surface_view,
+            filter,
+            layer_color,
+        );
+
+        // GPU output is premultiplied; since alpha=255 (opaque), premul == straight.
+        let expected = [
+            linear_to_srgb_oracle(50),
+            linear_to_srgb_oracle(100),
+            linear_to_srgb_oracle(200),
+            255,
+        ];
+
+        assert_interior_pixels_near("P2 LinearToSrgbGamma producer path", &readback, expected, 3);
+    }
+
+    // ── P3: SrgbToLinearGamma via producer path ───────────────────────────────
+
+    /// P3: `ColorFilter::SrgbToLinearGamma` dispatched through
+    /// `Backend::push_color_filter` applies the sRGB→linear transfer per channel.
+    ///
+    /// **Proves:**
+    /// - The `SrgbToLinearGamma` arm correctly translates to
+    ///   `LayerFilter::Gamma(GammaDirection::SrgbToLinear)`.
+    ///
+    /// **Discriminating:** `layer_color = rgba(180, 120, 60, 255)` — each channel
+    /// is above the 0.04045 threshold, so the nonlinear formula fires and the oracle
+    /// differs meaningfully from the input.
+    #[test]
+    fn p3_srgb_to_linear_gamma_via_producer_path() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_surface(&device);
+        clear_surface(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 1.0,
+            },
+        );
+
+        let layer_color = Color::rgba(180, 120, 60, 255);
+        let filter = ColorFilter::SrgbToLinearGamma;
+
+        let readback = render_via_producer_path(
+            &device,
+            &queue,
+            &surface_tex,
+            &surface_view,
+            filter,
+            layer_color,
+        );
+
+        // GPU output is premultiplied; opaque alpha → premul == straight.
+        let expected = [
+            srgb_to_linear_oracle(180),
+            srgb_to_linear_oracle(120),
+            srgb_to_linear_oracle(60),
+            255,
+        ];
+
+        assert_interior_pixels_near("P3 SrgbToLinearGamma producer path", &readback, expected, 3);
+    }
+
+    // ── P4: Matrix filter via producer path matches direct-painter path ───────
+
+    /// P4: `ColorFilter::Matrix(grayscale)` through `Backend::push_color_filter`
+    /// produces output byte-identical (tolerance=2) to the same filter applied
+    /// via `WgpuPainter::save_layer_with_filter(LayerFilter::ColorMatrix(...))`.
+    ///
+    /// **Proves:**
+    /// - The `ColorFilter::Matrix` arm correctly translates to `LayerFilter::ColorMatrix`.
+    /// - The `ColorMatrix::values` field is passed through correctly.
+    ///
+    /// **Note:** This is redundant with `color_matrix_filter_tests` for the GPU shader
+    /// correctness, but it closes the loop on the producer-path dispatch for the
+    /// Matrix variant — confirming the `m.values` extraction works end-to-end.
+    #[test]
+    fn p4_matrix_filter_via_producer_path_matches_direct_painter() {
+        use flui_types::painting::effects::ColorMatrix;
+
+        use crate::wgpu::command_ir::LayerFilter;
+
+        let (device, queue) = acquire_test_device_and_queue();
+        let (producer_tex, producer_view) = create_surface(&device);
+        let (direct_tex, direct_view) = create_surface(&device);
+
+        let black = wgpu::Color {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        };
+        clear_surface(&device, &queue, &producer_view, black);
+        clear_surface(&device, &queue, &direct_view, black);
+
+        let layer_color = Color::rgba(180, 90, 40, 255);
+        let grayscale = ColorMatrix::grayscale();
+        let bounds = full_surface_bounds();
+
+        // Producer path: Backend::push_color_filter(&ColorFilter::Matrix(grayscale)).
+        {
+            let painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            let mut backend = Backend::new(painter);
+            backend.push_color_filter(&ColorFilter::Matrix(grayscale));
+            backend.render_rect(bounds, &Paint::fill(layer_color), &Matrix4::IDENTITY);
+            backend.pop_color_filter();
+            let mut painter = backend.into_painter();
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("P4 Producer Encoder"),
+            });
+            painter
+                .render(
+                    RenderTarget::sampleable(&producer_view, &producer_tex),
+                    &mut encoder,
+                )
+                .expect("P4 producer render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+        }
+
+        // Direct path: WgpuPainter::save_layer_with_filter(LayerFilter::ColorMatrix(grayscale.values)).
+        {
+            let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+            painter.save_layer_with_filter(None, LayerFilter::ColorMatrix(grayscale.values));
+            painter.rect(bounds, &Paint::fill(layer_color));
+            painter.restore_layer();
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("P4 Direct Encoder"),
+            });
+            painter
+                .render(
+                    RenderTarget::sampleable(&direct_view, &direct_tex),
+                    &mut encoder,
+                )
+                .expect("P4 direct render must succeed");
+            queue.submit(std::iter::once(encoder.finish()));
+        }
+
+        let producer_pixels = readback_pixels(&device, &queue, &producer_tex);
+        let direct_pixels = readback_pixels(&device, &queue, &direct_tex);
+
+        // Both paths must produce byte-identical output for every interior pixel.
+        let width = SURFACE_WIDTH as usize;
+        let height = SURFACE_HEIGHT as usize;
+        for (pixel_index, (&prod, &direct)) in
+            producer_pixels.iter().zip(direct_pixels.iter()).enumerate()
+        {
+            let row = pixel_index / width;
+            let col = pixel_index % width;
+            if row == 0 || row >= height - 1 || col == 0 || col >= width - 1 {
+                continue;
+            }
+            for channel_index in 0..4 {
+                let diff = u8::try_from(
+                    (i16::from(prod[channel_index]) - i16::from(direct[channel_index]))
+                        .unsigned_abs(),
+                )
+                .expect("diff of two u8 values always fits in u8");
+                assert!(
+                    diff <= 2,
+                    "P4 Matrix/Grayscale producer vs direct: pixel {pixel_index} \
+                     (row={row} col={col}) channel {channel_index} — \
+                     producer={p} direct={d} diff={diff} > tolerance 2",
+                    p = prod[channel_index],
+                    d = direct[channel_index],
+                );
+            }
+        }
+    }
+}

--- a/crates/flui-engine/src/wgpu/command_ir.rs
+++ b/crates/flui-engine/src/wgpu/command_ir.rs
@@ -39,11 +39,8 @@ use super::{
 /// the CPU oracle in the GPU readback tests, ensuring one authoritative home for
 /// the IEC 61966-2-1 piecewise formula.
 ///
-/// Under **Scope A** this type is constructed only from `cfg(test)` GPU readback
-/// tests (no production `push_color_filter` → `LayerFilter::Gamma` wiring yet).
-/// The `#[cfg_attr]` gates dead_code away in non-test builds only; under `cfg(test)`
-/// the lint stays live so regressions surface immediately.
-#[cfg_attr(not(test), allow(dead_code))]
+/// Constructed from the production `push_color_filter` path via
+/// `ColorFilter::LinearToSrgbGamma` / `ColorFilter::SrgbToLinearGamma`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum GammaDirection {
     /// sRGB → linear light: apply the electro-optical transfer function
@@ -93,13 +90,8 @@ pub(crate) enum LayerFilter {
     /// Mirrors [`flui_types::Color::blend`] (`self` = filter color = src,
     /// `dst` = layer pixel): the CPU oracle for the GPU readback tests.
     ///
-    /// Constructed only from `#[cfg(test)]` paths under **Scope A** (no
-    /// production `push_color_filter` → `LayerFilter::Mode` wiring yet).
-    // Scope A: no production producer of this variant yet — it is constructed
-    // only in `cfg(test)` GPU readback tests. The `apply_mode` function and
-    // `ModePipeline` that consume it are live (referenced in the fold arm),
-    // so only the *variant construction sites* need the dead_code gate.
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// Constructed from the production `push_color_filter` path via
+    /// `ColorFilter::Mode { color, blend_mode }`.
     Mode {
         /// Filter color in straight sRGB `[r, g, b, a]` (values in `[0, 1]`).
         color: [f32; 4],
@@ -118,9 +110,8 @@ pub(crate) enum LayerFilter {
     /// The GPU shader unpremultiplies, applies the transfer per R/G/B, clamps to
     /// `[0, 1]`, and repremultiplies; alpha is left unchanged.
     ///
-    /// Constructed only from `#[cfg(test)]` paths under **Scope A**.
-    // Scope A: same dead_code rationale as `Mode` above.
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// Constructed from the production `push_color_filter` path via
+    /// `ColorFilter::LinearToSrgbGamma` / `ColorFilter::SrgbToLinearGamma`.
     Gamma(GammaDirection),
 }
 

--- a/crates/flui-engine/src/wgpu/debug.rs
+++ b/crates/flui-engine/src/wgpu/debug.rs
@@ -447,7 +447,7 @@ impl LayerStateStack for DebugBackend {
         self.log_command("pop_opacity", "");
     }
 
-    fn push_color_filter(&mut self, filter: &flui_types::painting::ColorMatrix) {
+    fn push_color_filter(&mut self, filter: &flui_types::painting::ColorFilter) {
         self.log_command("push_color_filter", &format!("filter={filter:?}"));
     }
 

--- a/crates/flui-engine/src/wgpu/layer_render.rs
+++ b/crates/flui-engine/src/wgpu/layer_render.rs
@@ -449,7 +449,10 @@ impl<R: CommandRenderer + LayerStateStack + ?Sized> LayerRender<R> for ColorFilt
         if self.is_identity() {
             return;
         }
-        renderer.push_color_filter(self.color_filter());
+        // `color_filter()` returns `ColorFilter` by value (Copy); take a reference
+        // to match the `&ColorFilter` trait parameter.
+        let filter = self.color_filter();
+        renderer.push_color_filter(&filter);
     }
 
     fn cleanup(&self, renderer: &mut R) {
@@ -905,7 +908,7 @@ mod tests {
         fn pop_opacity(&mut self) {
             self.calls.push("pop_opacity".to_string());
         }
-        fn push_color_filter(&mut self, _filter: &flui_types::painting::ColorMatrix) {
+        fn push_color_filter(&mut self, _filter: &flui_types::painting::ColorFilter) {
             self.calls.push("push_color_filter".to_string());
         }
         fn pop_color_filter(&mut self) {

--- a/crates/flui-engine/src/wgpu/mod.rs
+++ b/crates/flui-engine/src/wgpu/mod.rs
@@ -267,6 +267,13 @@ mod blur_filter_tests;
 #[cfg(all(test, feature = "enable-wgpu-tests"))]
 mod compose_filter_tests;
 
+// color_filter_producer_tests contains P1-P4 GPU readback acceptance tests for
+// the T1 producer-path change: Backend::push_color_filter(&ColorFilter) dispatch
+// for Mode (P1), LinearToSrgbGamma (P2), SrgbToLinearGamma (P3), and Matrix (P4).
+// These tests would fail to compile on main (old &ColorMatrix signature).
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+mod color_filter_producer_tests;
+
 // ============================================================================
 // PUBLIC API
 // ============================================================================

--- a/crates/flui-layer/src/compositor/builder.rs
+++ b/crates/flui-layer/src/compositor/builder.rs
@@ -7,9 +7,7 @@
 use flui_foundation::LayerId;
 use flui_types::{
     geometry::{Pixels, RRect, Rect},
-    painting::{
-        effects::ColorMatrix, BlendMode, Clip, FilterQuality, ImageFilter, Path, Shader, TextureId,
-    },
+    painting::{BlendMode, Clip, ColorFilter, FilterQuality, ImageFilter, Path, Shader, TextureId},
     Matrix4,
 };
 
@@ -273,9 +271,9 @@ impl<'a> SceneBuilder<'a> {
     ///
     /// # Arguments
     ///
-    /// * `color_matrix` - The color matrix to apply
-    pub fn push_color_filter(&mut self, color_matrix: ColorMatrix) -> LayerId {
-        self.push_layer(Layer::ColorFilter(ColorFilterLayer::new(color_matrix)))
+    /// * `filter` - The [`ColorFilter`] to apply (`Matrix`, `Mode`, or `Gamma` variants)
+    pub fn push_color_filter(&mut self, filter: ColorFilter) -> LayerId {
+        self.push_layer(Layer::ColorFilter(ColorFilterLayer::new(filter)))
     }
 
     /// Pushes an image filter layer (blur, etc.).

--- a/crates/flui-layer/src/layer/color_filter.rs
+++ b/crates/flui-layer/src/layer/color_filter.rs
@@ -1,322 +1,220 @@
-//! ColorFilterLayer - Color transformation layer
+//! `ColorFilterLayer` — applies a [`ColorFilter`] to its children.
 //!
-//! This layer applies a color filter (5x4 color matrix) to its children.
 //! Corresponds to Flutter's `ColorFilterLayer`.
 
-use flui_types::painting::effects::ColorMatrix;
+use flui_types::painting::{effects::ColorMatrix, ColorFilter};
 
-/// Layer that applies a color filter to its children.
+/// Layer that applies a [`ColorFilter`] to its children.
 ///
-/// Color filters transform the color of every pixel rendered by children
-/// using a 5x4 color matrix. This enables effects like:
-/// - Grayscale conversion
-/// - Sepia tone
-/// - Brightness/contrast adjustment
-/// - Saturation adjustment
-/// - Hue rotation
-/// - Color inversion
+/// Color filters transform the color of every pixel rendered by children.
+/// The full [`ColorFilter`] enum is supported:
+///
+/// | Variant | Effect |
+/// |---|---|
+/// | [`ColorFilter::Matrix`] | 5×4 matrix in un-premultiplied RGBA |
+/// | [`ColorFilter::Mode`] | Porter-Duff / W3C blend of a solid color |
+/// | [`ColorFilter::LinearToSrgbGamma`] | linear → sRGB transfer per RGB channel |
+/// | [`ColorFilter::SrgbToLinearGamma`] | sRGB → linear transfer per RGB channel |
+///
+/// Use the constructors on [`ColorFilter`] directly to build the filter value:
+///
+/// ```rust
+/// use flui_layer::ColorFilterLayer;
+/// use flui_types::painting::{ColorFilter, BlendMode};
+/// use flui_types::styling::Color;
+/// use flui_types::painting::effects::ColorMatrix;
+///
+/// // Matrix-based filter (e.g. grayscale).
+/// let layer = ColorFilterLayer::new(ColorFilter::grayscale());
+///
+/// // Mode-based filter: tint with 50% opacity blue.
+/// let tint = ColorFilterLayer::new(
+///     ColorFilter::mode(Color::BLUE, BlendMode::SrcOver),
+/// );
+///
+/// // Identity (no transformation): equivalent to no filter layer.
+/// let identity = ColorFilterLayer::identity();
+/// ```
 ///
 /// # Performance
 ///
 /// Color filter layers require offscreen rendering and per-pixel computation.
-/// For simple color changes, consider using Paint colors directly.
-///
-/// # Architecture
-///
-/// ```text
-/// ColorFilterLayer
-///   │
-///   │ Render children to offscreen buffer
-///   │ Apply 5x4 color matrix to each pixel
-///   ▼
-/// Children rendered with color transformation
-/// ```
-///
-/// # Example
-///
-/// ```rust
-/// use flui_layer::ColorFilterLayer;
-///
-/// // Create grayscale filter
-/// let layer = ColorFilterLayer::grayscale();
-///
-/// // Create custom brightness adjustment
-/// let bright = ColorFilterLayer::brightness(0.2);
-/// ```
-#[derive(Debug, Clone, PartialEq)]
+/// `Matrix`-identity layers are short-circuited in the render impl — they
+/// emit a no-op `save_layer` rather than a full GPU pass.
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ColorFilterLayer {
-    /// The color transformation matrix
-    color_filter: ColorMatrix,
+    /// The color filter to apply to the layer's children.
+    color_filter: ColorFilter,
 }
 
 impl ColorFilterLayer {
-    /// Creates a new color filter layer with a custom matrix.
+    /// Creates a new color filter layer with the given [`ColorFilter`].
     #[inline]
-    pub fn new(color_filter: ColorMatrix) -> Self {
+    #[must_use]
+    pub const fn new(color_filter: ColorFilter) -> Self {
         Self { color_filter }
     }
 
-    /// Creates an identity color filter (no transformation).
+    /// Creates an identity filter layer (no color transformation).
+    ///
+    /// The render impl short-circuits identity layers to a no-op.
     #[inline]
+    #[must_use]
     pub fn identity() -> Self {
-        Self::new(ColorMatrix::identity())
+        Self::new(ColorFilter::Matrix(ColorMatrix::identity()))
     }
 
-    /// Creates a grayscale color filter.
+    /// Returns the [`ColorFilter`] this layer applies.
     ///
-    /// Converts colors to grayscale using luminance weights.
+    /// `ColorFilter` is `Copy`, so the value is returned by value at no cost.
     #[inline]
-    pub fn grayscale() -> Self {
-        Self::new(ColorMatrix::grayscale())
+    #[must_use]
+    pub const fn color_filter(&self) -> ColorFilter {
+        self.color_filter
     }
 
-    /// Creates a sepia tone color filter.
-    ///
-    /// Gives a warm, vintage look to images.
+    /// Replaces the active [`ColorFilter`].
     #[inline]
-    pub fn sepia() -> Self {
-        Self::new(ColorMatrix::sepia())
-    }
-
-    /// Creates a brightness adjustment filter.
-    ///
-    /// # Arguments
-    ///
-    /// * `amount` - Brightness adjustment (-1.0 to 1.0, 0.0 = no change)
-    #[inline]
-    pub fn brightness(amount: f32) -> Self {
-        Self::new(ColorMatrix::brightness(amount))
-    }
-
-    /// Creates a contrast adjustment filter.
-    ///
-    /// # Arguments
-    ///
-    /// * `amount` - Contrast multiplier (0.0 to 2.0, 1.0 = no change)
-    #[inline]
-    pub fn contrast(amount: f32) -> Self {
-        Self::new(ColorMatrix::contrast(amount))
-    }
-
-    /// Creates a saturation adjustment filter.
-    ///
-    /// # Arguments
-    ///
-    /// * `amount` - Saturation multiplier (0.0 = grayscale, 1.0 = no change,
-    ///   2.0 = double saturation)
-    #[inline]
-    pub fn saturation(amount: f32) -> Self {
-        Self::new(ColorMatrix::saturation(amount))
-    }
-
-    /// Creates a hue rotation filter.
-    ///
-    /// # Arguments
-    ///
-    /// * `degrees` - Hue rotation in degrees (0.0 to 360.0)
-    #[inline]
-    pub fn hue_rotate(degrees: f32) -> Self {
-        Self::new(ColorMatrix::hue_rotate(degrees))
-    }
-
-    /// Creates a color inversion filter.
-    ///
-    /// Inverts all color channels (like a photo negative).
-    #[inline]
-    pub fn invert() -> Self {
-        Self::new(ColorMatrix::invert())
-    }
-
-    /// Returns a reference to the color matrix.
-    #[inline]
-    pub fn color_filter(&self) -> &ColorMatrix {
-        &self.color_filter
-    }
-
-    /// Sets the color matrix.
-    #[inline]
-    pub fn set_color_filter(&mut self, color_filter: ColorMatrix) {
+    pub fn set_color_filter(&mut self, color_filter: ColorFilter) {
         self.color_filter = color_filter;
     }
 
-    /// Returns true if this is an identity matrix (no transformation).
+    /// Returns `true` if this layer applies no transformation.
+    ///
+    /// Only a `Matrix`-variant that equals the identity matrix is considered
+    /// identity.  `Mode` and `Gamma` variants are never identity — they always
+    /// affect pixel values.
     #[inline]
+    #[must_use]
     pub fn is_identity(&self) -> bool {
-        self.color_filter == ColorMatrix::identity()
-    }
-
-    /// Applies the color filter to a color.
-    ///
-    /// # Arguments
-    ///
-    /// * `color` - Input color as [r, g, b, a] where each component is 0.0-1.0
-    ///
-    /// # Returns
-    ///
-    /// Transformed color as [r, g, b, a]
-    #[inline]
-    pub fn apply(&self, color: [f32; 4]) -> [f32; 4] {
-        self.color_filter.apply(color)
-    }
-
-    /// Combines this filter with another.
-    ///
-    /// The result applies `other` first, then `self`.
-    #[inline]
-    pub fn then(&self, other: &ColorFilterLayer) -> ColorFilterLayer {
-        ColorFilterLayer::new(self.color_filter.multiply(&other.color_filter))
+        match self.color_filter {
+            ColorFilter::Matrix(m) => m == ColorMatrix::identity(),
+            _ => false,
+        }
     }
 }
 
 impl Default for ColorFilterLayer {
+    #[inline]
     fn default() -> Self {
         Self::identity()
     }
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::float_cmp,
-    reason = "tests compare exact f32 values they just set; ULP slop would mask real regressions"
-)]
 mod tests {
+    use flui_types::{
+        painting::{effects::ColorMatrix, BlendMode, ColorFilter},
+        styling::Color,
+    };
+
     use super::*;
 
-    #[test]
-    fn test_color_filter_layer_new() {
-        let matrix = ColorMatrix::grayscale();
-        let layer = ColorFilterLayer::new(matrix.clone());
+    // ── Construction ──────────────────────────────────────────────────────────
 
-        assert_eq!(layer.color_filter(), &matrix);
+    #[test]
+    fn new_stores_filter() {
+        let filter = ColorFilter::grayscale();
+        let layer = ColorFilterLayer::new(filter);
+        assert_eq!(layer.color_filter(), filter);
     }
 
     #[test]
-    fn test_color_filter_layer_identity() {
+    fn identity_is_matrix_identity() {
         let layer = ColorFilterLayer::identity();
-
         assert!(layer.is_identity());
-
-        // Identity should not change colors
-        let color = [0.5, 0.6, 0.7, 0.8];
-        let result = layer.apply(color);
-        for i in 0..4 {
-            assert!((result[i] - color[i]).abs() < 0.001);
-        }
+        assert!(matches!(layer.color_filter(), ColorFilter::Matrix(_)));
     }
 
     #[test]
-    fn test_color_filter_layer_grayscale() {
-        let layer = ColorFilterLayer::grayscale();
-
-        // Red should become gray
-        let red = [1.0, 0.0, 0.0, 1.0];
-        let result = layer.apply(red);
-
-        // All RGB channels should be equal (grayscale)
-        assert!((result[0] - result[1]).abs() < 0.001);
-        assert!((result[1] - result[2]).abs() < 0.001);
-        assert_eq!(result[3], 1.0); // Alpha unchanged
-    }
-
-    #[test]
-    fn test_color_filter_layer_sepia() {
-        let layer = ColorFilterLayer::sepia();
-
-        assert!(!layer.is_identity());
-    }
-
-    #[test]
-    fn test_color_filter_layer_brightness() {
-        let layer = ColorFilterLayer::brightness(0.2);
-
-        let gray = [0.5, 0.5, 0.5, 1.0];
-        let result = layer.apply(gray);
-
-        // Should be brighter
-        assert!(result[0] > gray[0]);
-        assert!(result[1] > gray[1]);
-        assert!(result[2] > gray[2]);
-    }
-
-    #[test]
-    fn test_color_filter_layer_contrast() {
-        let layer = ColorFilterLayer::contrast(1.5);
-
-        assert!(!layer.is_identity());
-    }
-
-    #[test]
-    fn test_color_filter_layer_saturation() {
-        // Zero saturation should give grayscale
-        let layer = ColorFilterLayer::saturation(0.0);
-
-        let red = [1.0, 0.0, 0.0, 1.0];
-        let result = layer.apply(red);
-
-        // Should be grayscale
-        assert!((result[0] - result[1]).abs() < 0.001);
-        assert!((result[1] - result[2]).abs() < 0.001);
-    }
-
-    #[test]
-    fn test_color_filter_layer_hue_rotate() {
-        let layer = ColorFilterLayer::hue_rotate(180.0);
-
-        assert!(!layer.is_identity());
-    }
-
-    #[test]
-    fn test_color_filter_layer_invert() {
-        let layer = ColorFilterLayer::invert();
-
-        let black = [0.0, 0.0, 0.0, 1.0];
-        let result = layer.apply(black);
-
-        // Black should become white
-        assert!((result[0] - 1.0).abs() < 0.001);
-        assert!((result[1] - 1.0).abs() < 0.001);
-        assert!((result[2] - 1.0).abs() < 0.001);
-    }
-
-    #[test]
-    fn test_color_filter_layer_set_color_filter() {
-        let mut layer = ColorFilterLayer::identity();
-
-        layer.set_color_filter(ColorMatrix::grayscale());
-        assert!(!layer.is_identity());
-    }
-
-    #[test]
-    fn test_color_filter_layer_then() {
-        let brightness = ColorFilterLayer::brightness(0.1);
-        let grayscale = ColorFilterLayer::grayscale();
-
-        let combined = grayscale.then(&brightness);
-
-        // Should not be identity
-        assert!(!combined.is_identity());
-    }
-
-    #[test]
-    fn test_color_filter_layer_default() {
+    fn default_is_identity() {
         let layer = ColorFilterLayer::default();
+        assert!(layer.is_identity());
+    }
 
+    // ── Copy + Clone ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn layer_is_copy() {
+        let a = ColorFilterLayer::new(ColorFilter::grayscale());
+        let b = a; // Copy
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn layer_is_clone() {
+        // `ColorFilterLayer: Copy`; route through a generic `&T` call so
+        // clippy's `clone_on_copy` lint doesn't fire.
+        fn clone_it<T: Clone>(v: &T) -> T {
+            v.clone()
+        }
+        let a = ColorFilterLayer::new(ColorFilter::grayscale());
+        let b = clone_it(&a);
+        assert_eq!(a, b);
+    }
+
+    // ── is_identity semantics ─────────────────────────────────────────────────
+
+    #[test]
+    fn matrix_identity_is_identity() {
+        let layer = ColorFilterLayer::new(ColorFilter::Matrix(ColorMatrix::identity()));
         assert!(layer.is_identity());
     }
 
     #[test]
-    fn test_color_filter_layer_clone() {
-        let layer = ColorFilterLayer::grayscale();
-        let cloned = layer.clone();
-
-        assert_eq!(layer, cloned);
+    fn non_identity_matrix_is_not_identity() {
+        let layer = ColorFilterLayer::new(ColorFilter::grayscale());
+        assert!(!layer.is_identity());
     }
 
     #[test]
-    fn test_color_filter_layer_send_sync() {
+    fn mode_filter_is_never_identity() {
+        let layer = ColorFilterLayer::new(ColorFilter::mode(Color::WHITE, BlendMode::SrcOver));
+        assert!(
+            !layer.is_identity(),
+            "Mode filter must not be classified as identity even with white+SrcOver"
+        );
+    }
+
+    #[test]
+    fn linear_to_srgb_gamma_is_never_identity() {
+        let layer = ColorFilterLayer::new(ColorFilter::LinearToSrgbGamma);
+        assert!(!layer.is_identity());
+    }
+
+    #[test]
+    fn srgb_to_linear_gamma_is_never_identity() {
+        let layer = ColorFilterLayer::new(ColorFilter::SrgbToLinearGamma);
+        assert!(!layer.is_identity());
+    }
+
+    // ── set_color_filter ──────────────────────────────────────────────────────
+
+    #[test]
+    fn set_color_filter_updates_field() {
+        let mut layer = ColorFilterLayer::identity();
+        assert!(layer.is_identity());
+
+        layer.set_color_filter(ColorFilter::grayscale());
+        assert!(!layer.is_identity());
+        assert_eq!(layer.color_filter(), ColorFilter::grayscale());
+    }
+
+    #[test]
+    fn set_mode_filter() {
+        let mut layer = ColorFilterLayer::identity();
+        let mode_filter = ColorFilter::mode(Color::RED, BlendMode::Multiply);
+        layer.set_color_filter(mode_filter);
+        assert_eq!(layer.color_filter(), mode_filter);
+        assert!(!layer.is_identity());
+    }
+
+    // ── Send + Sync ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn layer_is_send_and_sync() {
         fn assert_send<T: Send>() {}
         fn assert_sync<T: Sync>() {}
-
         assert_send::<ColorFilterLayer>();
         assert_sync::<ColorFilterLayer>();
     }

--- a/crates/flui-layer/src/lib.rs
+++ b/crates/flui-layer/src/lib.rs
@@ -274,7 +274,9 @@ mod tests {
 
         // Effect layers
         let _ = tree.insert(Layer::Opacity(OpacityLayer::new(0.5)));
-        let _ = tree.insert(Layer::ColorFilter(ColorFilterLayer::grayscale()));
+        let _ = tree.insert(Layer::ColorFilter(ColorFilterLayer::new(
+            flui_types::painting::ColorFilter::grayscale(),
+        )));
         let _ = tree.insert(Layer::ImageFilter(ImageFilterLayer::blur(5.0)));
 
         assert_eq!(tree.len(), 7);

--- a/crates/flui-types/src/painting/effects.rs
+++ b/crates/flui-types/src/painting/effects.rs
@@ -107,7 +107,7 @@ pub enum ColorAdjustment {
 ///     0.0, 0.0, 0.0, 1.0, 0.0,  // A
 /// ]);
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColorMatrix {
     /// Matrix values in row-major order: [r0-r4, g0-g4, b0-b4, a0-a4]
@@ -417,7 +417,7 @@ impl ColorAdjustment {
                 ColorMatrix::lerp_from_identity(&ColorMatrix::invert(), *t)
             }
             ColorAdjustment::Opacity(opacity) => ColorMatrix::opacity(*opacity),
-            ColorAdjustment::Matrix(matrix) => matrix.clone(),
+            ColorAdjustment::Matrix(matrix) => *matrix,
         }
     }
 }
@@ -954,7 +954,7 @@ mod tests {
     #[test]
     fn matrix_adjustment_roundtrips_values() {
         let original = ColorMatrix::grayscale();
-        let via_adjustment = ColorAdjustment::Matrix(original.clone()).to_color_matrix();
+        let via_adjustment = ColorAdjustment::Matrix(original).to_color_matrix();
         assert_eq!(original.values, via_adjustment.values);
     }
 

--- a/crates/flui-types/src/painting/image.rs
+++ b/crates/flui-types/src/painting/image.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::{
     geometry::{Pixels, Size, px},
-    painting::BlendMode,
+    painting::{BlendMode, effects::ColorMatrix},
     styling::Color,
 };
 
@@ -374,18 +374,31 @@ impl Default for ImageConfiguration {
 ///
 /// let filter = ColorFilter::mode(Color::RED, BlendMode::Multiply);
 /// ```
+/// A color filter to apply to an image or layer.
+///
+/// ## Copy semantics
+///
+/// `ColorFilter` is `Copy`: all variants are plain-old-data.  `Matrix`
+/// wraps `ColorMatrix` (a `[f32;20]` newtype) which also derives `Copy`.
+///
+/// ## Stability
+///
+/// `#[non_exhaustive]` is set because future variants (`Shader`, `Compose`)
+/// may be added without a semver-major bump.  Match with a wildcard arm:
+/// `_ => { /* handle unknown */ }`.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ColorFilter {
-    /// Apply a color blend mode.
+    /// Apply a Porter-Duff / W3C blend of a solid color over each pixel.
     Mode {
-        /// The color to blend with the image.
+        /// The solid filter color (SRC).
         color: Color,
-        /// The blend mode to use.
+        /// The blend equation to apply.
         blend_mode: BlendMode,
     },
 
-    /// Apply a 5x4 matrix transformation in the RGBA color space.
+    /// Apply a 5×4 row-major matrix transformation in un-premultiplied RGBA.
     ///
     /// The matrix is applied as follows:
     /// ```text
@@ -395,12 +408,20 @@ pub enum ColorFilter {
     /// | A' |   | a30 a31 a32 a33 a34 |   | A |
     /// | 1  |   |  0   0   0   0   1  |   | 1 |
     /// ```
-    Matrix([f32; 20]),
+    ///
+    /// All channels are clamped to `[0, 1]` after multiplication.
+    Matrix(ColorMatrix),
 
-    /// Apply a gamma curve when converting from linear to sRGB.
+    /// Apply the IEC 61966-2-1 transfer: linear light → sRGB-encoded.
+    ///
+    /// RGB channels are gamma-encoded per channel; alpha is passed through
+    /// unchanged.
     LinearToSrgbGamma,
 
-    /// Apply a gamma curve when converting from sRGB to linear.
+    /// Apply the IEC 61966-2-1 inverse transfer: sRGB-encoded → linear light.
+    ///
+    /// RGB channels are gamma-decoded per channel; alpha is passed through
+    /// unchanged.
     SrgbToLinearGamma,
 }
 
@@ -412,11 +433,15 @@ impl ColorFilter {
         ColorFilter::Mode { color, blend_mode }
     }
 
-    /// Creates a color filter that applies a matrix transformation.
+    /// Creates a color filter that applies a 5×4 matrix transformation.
+    ///
+    /// The `matrix` argument is the row-major `[f32; 20]` array (rows R/G/B/A,
+    /// each row has 4 multipliers then an additive offset).  Internally the
+    /// array is wrapped in [`ColorMatrix`] to keep the IR uniform.
     #[inline]
     #[must_use]
     pub const fn matrix(matrix: [f32; 20]) -> Self {
-        ColorFilter::Matrix(matrix)
+        ColorFilter::Matrix(ColorMatrix::new(matrix))
     }
 
     /// Creates a color filter that converts from linear to sRGB gamma.
@@ -438,32 +463,32 @@ impl ColorFilter {
     #[must_use]
     pub const fn grayscale() -> Self {
         #[allow(clippy::excessive_precision)]
-        ColorFilter::Matrix([
+        ColorFilter::Matrix(ColorMatrix::new([
             0.2126, 0.7152, 0.0722, 0.0, 0.0, // R = luminance
             0.2126, 0.7152, 0.0722, 0.0, 0.0, // G = luminance
             0.2126, 0.7152, 0.0722, 0.0, 0.0, // B = luminance
             0.0, 0.0, 0.0, 1.0, 0.0, // A = unchanged
-        ])
+        ]))
     }
 
     /// Creates a sepia tone color filter.
     #[inline]
     #[must_use]
     pub const fn sepia() -> Self {
-        ColorFilter::Matrix([
+        ColorFilter::Matrix(ColorMatrix::new([
             0.393, 0.769, 0.189, 0.0, 0.0, 0.349, 0.686, 0.168, 0.0, 0.0, 0.272, 0.534, 0.131, 0.0,
             0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
-        ])
+        ]))
     }
 
     /// Creates an inverted color filter.
     #[inline]
     #[must_use]
     pub const fn invert() -> Self {
-        ColorFilter::Matrix([
+        ColorFilter::Matrix(ColorMatrix::new([
             -1.0, 0.0, 0.0, 0.0, 255.0, 0.0, -1.0, 0.0, 0.0, 255.0, 0.0, 0.0, -1.0, 0.0, 255.0,
             0.0, 0.0, 0.0, 1.0, 0.0,
-        ])
+        ]))
     }
 }
 
@@ -614,11 +639,13 @@ mod tests {
 
     #[test]
     fn test_color_filter_matrix() {
-        let matrix = [0.0; 20];
-        let filter = ColorFilter::matrix(matrix);
+        use crate::painting::effects::ColorMatrix;
+
+        let raw = [0.0f32; 20];
+        let filter = ColorFilter::matrix(raw);
 
         match filter {
-            ColorFilter::Matrix(m) => assert_eq!(m, matrix),
+            ColorFilter::Matrix(m) => assert_eq!(m.values, raw),
             _ => panic!("Wrong variant"),
         }
     }


### PR DESCRIPTION
## Summary

**T1 of the `gpu-filters-consumer-chain` spec.** Makes the engine's already-implemented `ColorFilter::{Mode,Gamma,Matrix}` reachable via the layer producer path. Before T1, `push_color_filter` took only `&ColorMatrix`, so `Mode`/`Gamma` (whose GPU passes shipped in gpu-image-filters) had **no production producer** and were `cfg(test)`-gated dead code.

## Breaking — internal signatures only (zero serialized-format change)
Per api-design-lead verdict (`ACCEPTABLE` after reshape):
- `ColorMatrix` += `Copy` (additive); `ColorFilter::Matrix([f32;20])` → `Matrix(ColorMatrix)` (fix the newtype wart) + `#[non_exhaustive]` (future Shader/Custom variant).
- `CommandRenderer::push_color_filter(&ColorMatrix)` → `(&ColorFilter)`; `backend.rs` dispatches `ColorFilter` → `LayerFilter::{ColorMatrix (identity-guarded), Mode, Gamma}`; promote `LayerFilter::Mode/Gamma` + `GammaDirection` out of `cfg(test)`.
- `ColorFilterLayer` field `ColorMatrix` → `ColorFilter`; mirrored helpers (grayscale/sepia/…) deleted (they already live on `ColorFilter`); `color_filter()` by value (Copy); `is_identity()` Matrix-only (Mode/Gamma are real ops, never elided — Flutter-faithful).
- The `#[non_exhaustive]` match sites (`backend` push_color_filter, `images` draw_image_filtered) gain a wildcard that warn+degrades for **future** variants only; all four current variants stay explicitly matched (verified by ce-kieran).

`Paint`/`DrawCommand`/DisplayList wire format **untouched** → deterministic-replay goldens unaffected.

## Tests (GPU readback, `color_filter_producer_tests.rs`)
P1 Mode/Multiply · P2 LinearToSrgb · P3 SrgbToLinear via `Backend::push_color_filter(&ColorFilter)` (matched vs oracle) · P4 Matrix-via-producer byte-matches the direct painter path. **red→green:** P1-P4 cannot compile against the `&ColorMatrix` signature. **428 readback green** (424 baseline + 4); the gpu-image-filters suite (39 filter tests) unchanged.

## Verification (ground-truthed locally)
`cargo check` ×3 crates `--all-targets` = 0 · clippy no-feature + `--features enable-wgpu-tests` both `-D warnings` = 0 · `cargo doc -D warnings` (3 crates) = 0 · fmt/typos/port-check = 0 · workspace check = 0 · readback 428/0 · `cargo test -p flui-layer` 33/33.

Soundness reviewed (ce-kieran): **COMPLETE** — the `#[non_exhaustive]` wildcards don't swallow current variants, dispatch (incl. Mode color order vs the apply_mode consumer) is correct, producer tests are non-co-vacuous.

Also adds the `gpu-filters-consumer-chain` spec (Approach B; `.flutter`-verified; gpui ruled out — no general filters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)