### PR TITLE
test(filters): verify SceneBuilder filter producer path → pixels + demos (consumer-chain T2')

### DIFF
--- a/.rust-studio/specs/gpu-filters-consumer-chain/spec.md
+++ b/.rust-studio/specs/gpu-filters-consumer-chain/spec.md
@@ -2,7 +2,9 @@
 
 # Spec: GPU filters consumer chain (make engine filters reachable end-to-end)
 
-- **Status:** Draft   ·   **Slug:** `gpu-filters-consumer-chain`   ·   **Date:** `2026-06-22`   ·   **Owner:** `chief-architect`
+- **Status:** In progress (scoped to flui-painting + flui-layer **ceiling** — render/widget tasks deferred)   ·   **Slug:** `gpu-filters-consumer-chain`   ·   **Date:** `2026-06-22`   ·   **Owner:** `chief-architect`
+
+> **SCOPE CEILING (user, 2026-06-22):** consumer wiring reaches only up to **flui-painting + flui-layer** for now; flui-rendering (render-objects) + flui-view/widgets are DEFERRED. Architecture finding (chief-architect re-scope, vault `adr-filter-consumer-chain-painting-layer-ceiling`): **DisplayList and LayerTree are orthogonal/non-convertible** (no lowering; `SaveLayer`/`BackdropFilter` replay direct to GPU; Canvas can't reference `Layer` — dependency direction). So the painting-level filter entry that produces filter LAYERS is **`SceneBuilder`** (flui-layer), NOT `Canvas` — and `SceneBuilder`'s filter producers were already complete after T1. The in-scope deliverable is therefore verification (T2′), not new producer code.
 - **Predecessor:** `gpu-image-filters` (DONE — the engine producer; PRs #267-276). Governing decision: vault `adr-filter-consumer-chain`.
 
 ## Problem
@@ -19,8 +21,8 @@ The consumer chain is broken at every level above flui-layer:
 | flui-view / widgets | No `ImageFiltered` / `ColorFiltered` / `BackdropFilter` widget exists. |
 | flui-rendering | No `RenderImageFiltered` / `RenderColorFiltered` / `RenderBackdropFilter`; `PaintEffectsCapability` has no filter hook; `paint_subtree` wraps only Opacity/Transform. |
 | flui-painting | `Paint` has no `image_filter`/`color_filter`; `DrawCommand::SaveLayer{bounds,paint,transform}` carries no filter. |
-| flui-layer | `ImageFilterLayer`/`ColorFilterLayer` exist + render, but have **zero producers**; `ColorFilterLayer` wraps a bare `ColorMatrix`, not the full `ColorFilter`. |
-| flui-engine | `push_color_filter(&ColorMatrix)` can't express `ColorFilter::Mode`/`Gamma` (which the engine implements); `LayerFilter::Mode`/`Gamma` are `cfg(test)`-only. |
+| flui-layer | ~~`ColorFilterLayer` wraps a bare `ColorMatrix`~~ — **RESOLVED (T1):** carries full `ColorFilter`; `SceneBuilder::push_{color,image}_filter`/`push_blur`/`push_backdrop_filter` are the complete programmatic producers. |
+| flui-engine | ~~`push_color_filter(&ColorMatrix)` can't express Mode/Gamma; `LayerFilter::Mode`/`Gamma` `cfg(test)`-only~~ — **RESOLVED (T1):** `push_color_filter(&ColorFilter)` dispatches all variants; Mode/Gamma promoted to production. |
 
 **Goal:** make the engine's filters reachable from the public widget API, improving the cross-crate
 architecture. **Breaking changes are allowed** (active dev, no external consumers) — used where the break is
@@ -95,14 +97,15 @@ in acceptance below.
 - **Backdrop ordering gate** — `RenderBackdropFilter` correct only under `supports_copy_src || intermediate_active` (already true for the existing path).
 - **Catalog CI guard** — every new `RenderBox` must appear in `RENDER_OBJECT_TYPES` with a `harness_*` test.
 
-## Slicing (dependency-ordered; each an independent `/dev-task` → review → local GPU-readback)
-- **T1 — Producer-completeness: full `ColorFilter` through the engine.** `[BREAK B1/B2]` `[SIGN-OFF: api-design-lead]` Widen `push_color_filter`→`&ColorFilter`; promote `LayerFilter::Mode/Gamma`; widen `ColorFilterLayer`→`ColorFilter`; update dispatch + `LayerRender for ColorFilterLayer`. GPU-readback Mode+Gamma via the layer path. *Engine+layer only — critical-path root, self-contained, immediate value.*
-- **T2 — Render seam: `PaintEffectsCapability` filter hooks + `paint_subtree` arm.** `[SIGN-OFF: chief-architect]` (hook shape + alpha-asymmetry footgun). Depends on T1.
-- **T3a — `RenderColorFiltered` + `ColorFiltered` widget** (Mode/Matrix/Gamma). Depends on T2.
-- **T3b — `RenderImageFiltered` + `ImageFiltered` widget** (Blur/Dilate/Erode/Compose). Depends on T2.
-- **T3c — `RenderBackdropFilter` + `BackdropFilter` widget** (under the backdrop gate). Depends on T2.
-  *(T3a/b/c parallel — disjoint render-objects/widgets sharing the T2 seam.)*
-- **T4 — End-to-end demos + `.flutter/` parity verification** (widget-tree-built `filter_demo`/`color_filter_demo`). Depends on T3a/b/c.
+## Slicing
+**In scope (flui-painting + flui-layer ceiling):**
+- **T1 — Producer-completeness: full `ColorFilter` through the engine.** `[BREAK]` **DONE — PR #277** (`77d08231`). `push_color_filter(&ColorFilter)` + dispatch; `LayerFilter::Mode/Gamma` promoted; `ColorFilterLayer`→`ColorFilter` (+ `ColorMatrix: Copy`, `ColorFilter` `#[non_exhaustive]`, `Matrix(ColorMatrix)` wart fixed). Readback P1-P4 (Mode/Gamma/Matrix producer path). api-design-lead ACCEPTABLE; ce-kieran COMPLETE.
+- **T2′ — SceneBuilder filter verification + demos.** **DONE — this PR.** Port `examples/filter_demo` to `SceneBuilder::push_image_filter`; add `examples/color_filter_demo` (Mode/Gamma/Matrix via `push_color_filter`); GPU-readback SC1-SC5 proving the `SceneBuilder → LayerRender → Backend → WgpuPainter → GPU` filter path closes to pixels (honest scope: `render_scene` needs a swapchain → SC tests exercise the identical constituent path minus swapchain-acquire/present). Confirms the programmatic painting+layer producer API. *This is the whole in-scope painting+layer deliverable — the `SceneBuilder` producers were already complete after T1; no new Canvas/DrawCommand filter API (a Canvas filter would be the rejected Approach A — DisplayList⊥LayerTree).*
+
+**DEFERRED (above the ceiling — flui-rendering + flui-view; resume when the user lifts the ceiling):**
+- **T2 — Render seam:** `PaintEffectsCapability` filter hooks + `paint_subtree` arm (chief-architect sign-off: alpha-asymmetry footgun). [DEFERRED]
+- **T3a/b/c — `Render{Color,Image,Backdrop}Filtered` + `{ColorFiltered, ImageFiltered, BackdropFilter}` widgets** (the real app-facing consumer — lets widget code write `ImageFiltered(child: …)`). [DEFERRED]
+- **T4 — widget-tree-built demos + `.flutter/` parity.** [DEFERRED]
 
 ## Links
 - Predecessor: `gpu-image-filters` spec + `verify-report.md`. Engine seam: `DrawItem::Filter`/`LayerFilter`, `layer_render.rs:447-477`, `traits.rs:441`, `command_ir.rs`.

--- a/crates/flui-engine/src/wgpu/mod.rs
+++ b/crates/flui-engine/src/wgpu/mod.rs
@@ -274,6 +274,13 @@ mod compose_filter_tests;
 #[cfg(all(test, feature = "enable-wgpu-tests"))]
 mod color_filter_producer_tests;
 
+// scenebuilder_filter_chain_tests contains SC1-SC5 GPU readback acceptance tests
+// for T2′ of `gpu-filters-consumer-chain`: SceneBuilder→LayerTree→LayerRender→
+// Backend→GPU pixel closure for image-filter blur (SC1), Mode/Multiply (SC2),
+// LinearToSrgbGamma (SC3), SrgbToLinearGamma (SC4), and Matrix/grayscale (SC5).
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+mod scenebuilder_filter_chain_tests;
+
 // ============================================================================
 // PUBLIC API
 // ============================================================================

--- a/crates/flui-engine/src/wgpu/scenebuilder_filter_chain_tests.rs
+++ b/crates/flui-engine/src/wgpu/scenebuilder_filter_chain_tests.rs
@@ -1,0 +1,690 @@
+//! SceneBuilder filter-chain GPU readback gate — T2′ of `gpu-filters-consumer-chain`.
+//!
+//! ## Purpose
+//!
+//! These tests prove that the **SceneBuilder producer path** closes end-to-end
+//! to pixels for both image-filter (blur) and color-filter (Mode, Gamma, Matrix)
+//! operations:
+//!
+//! ```text
+//! SceneBuilder::push_{image,color}_filter
+//!   → LayerTree containing {ImageFilterLayer, ColorFilterLayer}
+//!   → LayerRender::render (same impl render_scene's render_layer_recursive calls)
+//!   → Backend::{push_image_filter, push_color_filter}
+//!   → WgpuPainter::save_layer_with_filter / save_layer_with_image_filter
+//!   → GPU shader → pixels → readback
+//! ```
+//!
+//! ## Relationship to existing tests
+//!
+//! `color_filter_producer_tests` (P1-P4) prove that `Backend::push_color_filter`
+//! dispatches correctly when called **directly**.  These SC tests (`SC1`-`SC5`)
+//! prove the same pixels appear when the call originates via
+//! `SceneBuilder → LayerTree → LayerRender` — i.e., the **additional layer of
+//! indirection** (SceneBuilder builds the tree; the tree walker calls
+//! `LayerRender::render`) does not break the signal.
+//!
+//! ## Honest scope statement
+//!
+//! `Renderer::render_scene` requires a live wgpu swapchain surface and **cannot
+//! run headlessly**.  These tests exercise the identical constituent operations
+//! via the same code path the real frame loop uses:
+//!
+//! 1. `SceneBuilder` builds the `LayerTree` (same as production).
+//! 2. A minimal recursive walk mirrors `render_layer_recursive` for the subset
+//!    of layer types used here (no `BackdropFilter`, no offscreen OffscreenRenderer).
+//! 3. `Backend` dispatches filter/canvas commands to `WgpuPainter`.
+//! 4. `WgpuPainter::render(RenderTarget::sampleable(...))` submits to the GPU.
+//! 5. GPU readback asserts oracle match.
+//!
+//! The only gap relative to `render_scene` is the swapchain acquire and surface
+//! present steps — both are infrastructure that contains no filter logic.
+//!
+//! ## Test inventory
+//!
+//! | # | Gate | Requirement |
+//! |---|------|-------------|
+//! | SC1 | GPU | SceneBuilder→blur→pixels: blurred region is softer than sharp region |
+//! | SC2 | GPU | SceneBuilder→Mode/Multiply→pixels: oracle match |
+//! | SC3 | GPU | SceneBuilder→LinearToSrgbGamma→pixels: oracle match |
+//! | SC4 | GPU | SceneBuilder→SrgbToLinearGamma→pixels: oracle match |
+//! | SC5 | GPU | SceneBuilder→Matrix/grayscale→pixels: oracle match |
+
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+mod gpu_tests {
+    use std::sync::Arc;
+
+    use flui_foundation::LayerId;
+    use flui_layer::{CanvasLayer, LayerTree, SceneBuilder};
+    use flui_painting::Paint;
+    use flui_types::{
+        Color, Offset, Pixels, Rect,
+        painting::{BlendMode, ColorFilter, ImageFilter},
+    };
+
+    use crate::wgpu::{
+        Backend, layer_render::LayerRender, painter::WgpuPainter, render_target::RenderTarget,
+    };
+
+    // ── Harness constants ─────────────────────────────────────────────────────
+
+    const SURFACE_WIDTH: u32 = 64;
+    const SURFACE_HEIGHT: u32 = 64;
+    const SURFACE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
+
+    // ── Harness helpers ───────────────────────────────────────────────────────
+
+    fn acquire_test_device_and_queue() -> (Arc<wgpu::Device>, Arc<wgpu::Queue>) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .expect("a GPU adapter must be available for scenebuilder_filter_chain_tests");
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("SceneBuilderFilterChain Test Device"),
+            ..Default::default()
+        }))
+        .expect("a GPU device must be available for scenebuilder_filter_chain_tests");
+        (Arc::new(device), Arc::new(queue))
+    }
+
+    fn create_render_surface(device: &wgpu::Device) -> (wgpu::Texture, wgpu::TextureView) {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("SceneBuilderFilterChain Test Surface"),
+            size: wgpu::Extent3d {
+                width: SURFACE_WIDTH,
+                height: SURFACE_HEIGHT,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: SURFACE_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        (texture, view)
+    }
+
+    fn clear_to_black(device: &wgpu::Device, queue: &wgpu::Queue, view: &wgpu::TextureView) {
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("SceneBuilderFilterChain Surface Clear"),
+        });
+        {
+            let _pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("SceneBuilderFilterChain Clear Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+        }
+        queue.submit(std::iter::once(encoder.finish()));
+    }
+
+    /// Read every pixel back as `[r, g, b, a]` u8 quads.
+    fn readback_all_pixels(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        texture: &wgpu::Texture,
+    ) -> Vec<[u8; 4]> {
+        let bytes_per_pixel = 4u32;
+        let unpadded_row_bytes = SURFACE_WIDTH * bytes_per_pixel;
+        let padded_row_bytes = unpadded_row_bytes.div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT)
+            * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let staging_size = u64::from(padded_row_bytes * SURFACE_HEIGHT);
+
+        let staging = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("SceneBuilderFilterChain Readback Staging"),
+            size: staging_size,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("SceneBuilderFilterChain Readback Encoder"),
+        });
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &staging,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_row_bytes),
+                    rows_per_image: Some(SURFACE_HEIGHT),
+                },
+            },
+            wgpu::Extent3d {
+                width: SURFACE_WIDTH,
+                height: SURFACE_HEIGHT,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit(std::iter::once(encoder.finish()));
+
+        staging.slice(..).map_async(wgpu::MapMode::Read, |_| {});
+        device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .expect("GPU readback poll must complete within wait timeout");
+
+        let raw = staging.slice(..).get_mapped_range();
+        let pixel_count = (SURFACE_WIDTH * SURFACE_HEIGHT) as usize;
+        let mut pixels = Vec::with_capacity(pixel_count);
+        for row_index in 0..SURFACE_HEIGHT {
+            let row_start = (row_index * padded_row_bytes) as usize;
+            for col_index in 0..SURFACE_WIDTH {
+                let byte_offset = row_start + col_index as usize * 4;
+                pixels.push([
+                    raw[byte_offset],
+                    raw[byte_offset + 1],
+                    raw[byte_offset + 2],
+                    raw[byte_offset + 3],
+                ]);
+            }
+        }
+        pixels
+    }
+
+    fn build_painter(device: Arc<wgpu::Device>, queue: Arc<wgpu::Queue>) -> WgpuPainter {
+        WgpuPainter::with_shared_device(
+            device,
+            queue,
+            SURFACE_FORMAT,
+            (SURFACE_WIDTH, SURFACE_HEIGHT),
+        )
+    }
+
+    fn full_surface_rect() -> Rect<Pixels> {
+        Rect::from_xywh(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(SURFACE_WIDTH as f32),
+            Pixels(SURFACE_HEIGHT as f32),
+        )
+    }
+
+    /// Assert every interior pixel (1-px border excluded to avoid SDF edge
+    /// artefacts) is within `tolerance` of `expected` in all 4 channels.
+    fn assert_interior_pixels_near(
+        label: &str,
+        pixels: &[[u8; 4]],
+        expected: [u8; 4],
+        tolerance: u8,
+    ) {
+        let width = SURFACE_WIDTH as usize;
+        let height = SURFACE_HEIGHT as usize;
+        for (pixel_index, &actual) in pixels.iter().enumerate() {
+            let row = pixel_index / width;
+            let col = pixel_index % width;
+            if row == 0 || row >= height - 1 || col == 0 || col >= width - 1 {
+                continue;
+            }
+            for channel in 0..4 {
+                let channel_diff = u8::try_from(
+                    (i16::from(actual[channel]) - i16::from(expected[channel])).unsigned_abs(),
+                )
+                .expect("diff of two u8 values always fits in u8");
+                assert!(
+                    channel_diff <= tolerance,
+                    "{label}: pixel {pixel_index} (row={row} col={col}) \
+                     channel {channel} — actual={a} expected={e} \
+                     diff={channel_diff} > tolerance {tolerance}",
+                    a = actual[channel],
+                    e = expected[channel],
+                );
+            }
+        }
+    }
+
+    // ── SceneBuilder layer-tree walk ──────────────────────────────────────────
+    //
+    // This mirrors `Renderer::render_layer_recursive` for the subset of layer
+    // types used in these tests (canvas leaves, image-filter containers, and
+    // color-filter containers).  Backdrop-filter special-casing is omitted
+    // because none of the test scenes use it.
+
+    fn walk_layer_tree(tree: &LayerTree, node_id: LayerId, backend: &mut Backend<'_>) {
+        let Some(layer) = tree.get_layer(node_id) else {
+            return;
+        };
+        layer.render(backend);
+
+        let children: Vec<LayerId> = tree.children(node_id).unwrap_or_default().to_vec();
+        for child_id in children {
+            walk_layer_tree(tree, child_id, backend);
+        }
+
+        // Re-borrow after children walk.
+        if let Some(layer) = tree.get_layer(node_id) {
+            layer.cleanup(backend);
+        }
+    }
+
+    /// Render a `LayerTree` built by `SceneBuilder` through `Backend` into
+    /// `surface_view`/`surface_tex`, then readback all pixels.
+    ///
+    /// This is the headless equivalent of the per-frame segment of
+    /// `Renderer::render_scene` that runs between surface acquire and present.
+    fn render_scenebuilder_tree_and_readback(
+        device: &Arc<wgpu::Device>,
+        queue: &Arc<wgpu::Queue>,
+        surface_tex: &wgpu::Texture,
+        surface_view: &wgpu::TextureView,
+        tree: &LayerTree,
+        root_id: Option<LayerId>,
+    ) -> Vec<[u8; 4]> {
+        let painter = build_painter(Arc::clone(device), Arc::clone(queue));
+        let mut backend = Backend::new(painter);
+
+        if let Some(root_id) = root_id {
+            walk_layer_tree(tree, root_id, &mut backend);
+        }
+
+        let mut painter = backend.into_painter();
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("SceneBuilderFilterChain Render Encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(surface_view, surface_tex),
+                &mut encoder,
+            )
+            .expect("SceneBuilder filter-chain render must succeed");
+        queue.submit(std::iter::once(encoder.finish()));
+        readback_all_pixels(device, queue, surface_tex)
+    }
+
+    // ── CPU oracle helpers (shared with color_filter_producer_tests) ──────────
+
+    /// Mode oracle: `Color::blend(filter_color, dst_straight, mode)` → premul u8.
+    fn mode_oracle(filter_color: Color, dst: Color, mode: BlendMode) -> [u8; 4] {
+        let blended = filter_color.blend(dst, mode);
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "values clamped to [0,1]*255 then rounded; truncation is safe"
+        )]
+        let to_premul = |ch: u8, alpha: u8| -> u8 {
+            ((f32::from(ch) / 255.0) * (f32::from(alpha) / 255.0) * 255.0).round() as u8
+        };
+        [
+            to_premul(blended.r, blended.a),
+            to_premul(blended.g, blended.a),
+            to_premul(blended.b, blended.a),
+            blended.a,
+        ]
+    }
+
+    fn linear_to_srgb_oracle(channel_linear: u8) -> u8 {
+        let linear = f32::from(channel_linear) / 255.0;
+        let srgb = if linear <= 0.003_130_8 {
+            linear * 12.92
+        } else {
+            1.055 * linear.powf(1.0 / 2.4) - 0.055
+        };
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "value clamped to [0,1]*255 then rounded; truncation is safe"
+        )]
+        let result = (srgb.clamp(0.0, 1.0) * 255.0).round() as u8;
+        result
+    }
+
+    fn srgb_to_linear_oracle(channel_srgb: u8) -> u8 {
+        let srgb = f32::from(channel_srgb) / 255.0;
+        let linear = if srgb <= 0.04045 {
+            srgb / 12.92
+        } else {
+            ((srgb + 0.055) / 1.055).powf(2.4)
+        };
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "value clamped to [0,1]*255 then rounded; truncation is safe"
+        )]
+        let result = (linear.clamp(0.0, 1.0) * 255.0).round() as u8;
+        result
+    }
+
+    // ── SC1: SceneBuilder → blur → pixels ─────────────────────────────────────
+
+    /// SC1: A `SceneBuilder::push_image_filter(Blur σ=4)` wrapping a solid-colour
+    /// canvas produces pixels that are measurably different from an unfiltered
+    /// solid fill — the blur decal-clamps at the surface edge, attenuating the
+    /// RGB values of corner pixels while the centre stays bright.
+    ///
+    /// **Proves:**
+    /// - `SceneBuilder::push_image_filter` builds an `ImageFilterLayer` in the tree.
+    /// - `LayerRender::render` on `ImageFilterLayer` calls `Backend::push_image_filter`.
+    /// - The blur shader fires and diffuses pixels, producing edge attenuation.
+    ///
+    /// **Discriminating assertions:**
+    /// 1. Centre pixel is near-white (RGB ≥ 200): the blur interior is bright — the
+    ///    filter ran and preserved most energy in the centre.
+    /// 2. Corner pixel RGB < centre pixel RGB: the blur decal-clamps at the surface
+    ///    boundary, losing energy at the corners.  A no-op (filter missing) would
+    ///    leave all corners at the full white (255,255,255,255), so corner < centre
+    ///    proves the blur fired.
+    ///
+    /// **Why not check alpha:** a full-surface white fill keeps alpha=255 everywhere
+    /// after blur (no transparent source pixels to import at the boundary from
+    /// _outside_ the logical surface); the energy attenuation shows in RGB.
+    #[test]
+    fn sc1_scenebuilder_blur_reaches_pixels() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_render_surface(&device);
+        clear_to_black(&device, &queue, &surface_view);
+
+        // Build scene: push_image_filter(Blur σ=4) → add_canvas(white fill) → pop.
+        let mut tree = LayerTree::new();
+        let root_id = {
+            let mut builder = SceneBuilder::new(&mut tree);
+            // Zero-offset root so the first push becomes the tree root.
+            builder.push_offset(Offset::ZERO);
+            builder.push_image_filter(ImageFilter::blur(4.0));
+            let mut content_canvas = CanvasLayer::new();
+            content_canvas
+                .canvas_mut()
+                .draw_rect(full_surface_rect(), &Paint::fill(Color::WHITE));
+            builder.add_canvas(content_canvas);
+            builder.pop().expect("blur filter pop must not underflow");
+            builder.pop().expect("root offset pop must not underflow");
+            builder.build()
+        };
+
+        let pixels = render_scenebuilder_tree_and_readback(
+            &device,
+            &queue,
+            &surface_tex,
+            &surface_view,
+            &tree,
+            root_id,
+        );
+
+        let width = SURFACE_WIDTH as usize;
+
+        // Assertion 1: centre pixel RGB must be near-white (blur interior is
+        // bright; the filter ran and preserved most energy at the centre).
+        let centre_index = (SURFACE_HEIGHT / 2) as usize * width + (SURFACE_WIDTH / 2) as usize;
+        let centre_pixel = pixels[centre_index];
+        assert!(
+            centre_pixel[0] >= 200,
+            "SC1: centre pixel R must be ≥ 200 after blur (interior stays bright); \
+             got {centre_pixel:?}",
+        );
+
+        // Assertion 2: corner pixel RGB must be noticeably dimmer than the centre.
+        // The Gaussian blur decal-clamps at the surface boundary: when the blur
+        // kernel samples beyond the edge it reads transparent/black, attenuating
+        // corner pixel values.  A no-op filter would leave corners at 255.
+        let top_left_pixel = pixels[0];
+        let corner_r = top_left_pixel[0];
+        let centre_r = centre_pixel[0];
+        assert!(
+            corner_r < centre_r,
+            "SC1: corner pixel R must be dimmer than centre after blur \
+             (decal-clamp edge attenuation proves the blur shader fired); \
+             corner_r={corner_r} centre_r={centre_r}",
+        );
+    }
+
+    // ── SC2: SceneBuilder → Mode/Multiply → pixels ───────────────────────────
+
+    /// SC2: `SceneBuilder::push_color_filter(Mode { Multiply, half-opacity-blue })`
+    /// wrapping a coral canvas produces pixels matching the Mode oracle.
+    ///
+    /// **Proves:**
+    /// - `SceneBuilder::push_color_filter` builds a `ColorFilterLayer` in the tree.
+    /// - `LayerRender::render` on `ColorFilterLayer` calls `Backend::push_color_filter`.
+    /// - The mode-filter GPU shader produces the correct Multiply result.
+    ///
+    /// **Red-before-green discriminator:** this would produce opaque coral (no
+    /// filter) if `push_color_filter` were a no-op or if the tree walk bypassed
+    /// `ColorFilterLayer::render`.
+    #[test]
+    fn sc2_scenebuilder_mode_filter_multiply_reaches_pixels() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_render_surface(&device);
+        clear_to_black(&device, &queue, &surface_view);
+
+        let layer_color = Color::rgba(180, 120, 40, 255);
+        let filter_color = Color::rgba(0, 0, 200, 128);
+        let filter = ColorFilter::mode(filter_color, BlendMode::Multiply);
+
+        let mut tree = LayerTree::new();
+        let root_id = {
+            let mut builder = SceneBuilder::new(&mut tree);
+            builder.push_offset(Offset::ZERO);
+            builder.push_color_filter(filter);
+            let mut canvas = CanvasLayer::new();
+            canvas
+                .canvas_mut()
+                .draw_rect(full_surface_rect(), &Paint::fill(layer_color));
+            builder.add_canvas(canvas);
+            builder.pop().expect("color filter pop must not underflow");
+            builder.pop().expect("root offset pop must not underflow");
+            builder.build()
+        };
+
+        let pixels = render_scenebuilder_tree_and_readback(
+            &device,
+            &queue,
+            &surface_tex,
+            &surface_view,
+            &tree,
+            root_id,
+        );
+
+        let expected = mode_oracle(filter_color, layer_color, BlendMode::Multiply);
+        assert_interior_pixels_near("SC2 SceneBuilder/Mode/Multiply", &pixels, expected, 3);
+    }
+
+    // ── SC3: SceneBuilder → LinearToSrgbGamma → pixels ───────────────────────
+
+    /// SC3: `SceneBuilder::push_color_filter(LinearToSrgbGamma)` wrapping a
+    /// mid-range canvas produces pixels matching the linear→sRGB oracle.
+    ///
+    /// **Proves:** the `LinearToSrgbGamma` arm of `ColorFilterLayer::render` /
+    /// `Backend::push_color_filter` fires the correct GPU gamma shader.
+    #[test]
+    fn sc3_scenebuilder_linear_to_srgb_gamma_reaches_pixels() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_render_surface(&device);
+        clear_to_black(&device, &queue, &surface_view);
+
+        let layer_color = Color::rgba(50, 100, 200, 255);
+        let filter = ColorFilter::LinearToSrgbGamma;
+
+        let mut tree = LayerTree::new();
+        let root_id = {
+            let mut builder = SceneBuilder::new(&mut tree);
+            builder.push_offset(Offset::ZERO);
+            builder.push_color_filter(filter);
+            let mut canvas = CanvasLayer::new();
+            canvas
+                .canvas_mut()
+                .draw_rect(full_surface_rect(), &Paint::fill(layer_color));
+            builder.add_canvas(canvas);
+            builder.pop().expect("color filter pop must not underflow");
+            builder.pop().expect("root offset pop must not underflow");
+            builder.build()
+        };
+
+        let pixels = render_scenebuilder_tree_and_readback(
+            &device,
+            &queue,
+            &surface_tex,
+            &surface_view,
+            &tree,
+            root_id,
+        );
+
+        // Opaque alpha: premul == straight.
+        let expected = [
+            linear_to_srgb_oracle(50),
+            linear_to_srgb_oracle(100),
+            linear_to_srgb_oracle(200),
+            255,
+        ];
+        assert_interior_pixels_near("SC3 SceneBuilder/LinearToSrgbGamma", &pixels, expected, 3);
+    }
+
+    // ── SC4: SceneBuilder → SrgbToLinearGamma → pixels ───────────────────────
+
+    /// SC4: `SceneBuilder::push_color_filter(SrgbToLinearGamma)` wrapping a
+    /// mid-range canvas produces pixels matching the sRGB→linear oracle.
+    #[test]
+    fn sc4_scenebuilder_srgb_to_linear_gamma_reaches_pixels() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_render_surface(&device);
+        clear_to_black(&device, &queue, &surface_view);
+
+        let layer_color = Color::rgba(180, 120, 60, 255);
+        let filter = ColorFilter::SrgbToLinearGamma;
+
+        let mut tree = LayerTree::new();
+        let root_id = {
+            let mut builder = SceneBuilder::new(&mut tree);
+            builder.push_offset(Offset::ZERO);
+            builder.push_color_filter(filter);
+            let mut canvas = CanvasLayer::new();
+            canvas
+                .canvas_mut()
+                .draw_rect(full_surface_rect(), &Paint::fill(layer_color));
+            builder.add_canvas(canvas);
+            builder.pop().expect("color filter pop must not underflow");
+            builder.pop().expect("root offset pop must not underflow");
+            builder.build()
+        };
+
+        let pixels = render_scenebuilder_tree_and_readback(
+            &device,
+            &queue,
+            &surface_tex,
+            &surface_view,
+            &tree,
+            root_id,
+        );
+
+        let expected = [
+            srgb_to_linear_oracle(180),
+            srgb_to_linear_oracle(120),
+            srgb_to_linear_oracle(60),
+            255,
+        ];
+        assert_interior_pixels_near("SC4 SceneBuilder/SrgbToLinearGamma", &pixels, expected, 3);
+    }
+
+    // ── SC5: SceneBuilder → Matrix/grayscale → pixels ────────────────────────
+
+    /// SC5: `SceneBuilder::push_color_filter(ColorFilter::grayscale())` wrapping
+    /// an opaque coral canvas converts the coloured input to luminance-weighted
+    /// grayscale.
+    ///
+    /// **Proves:** the `Matrix` arm of `ColorFilterLayer::render` /
+    /// `Backend::push_color_filter` fires the colour-matrix GPU shader via
+    /// `SceneBuilder`.
+    ///
+    /// **Discriminating:** a no-op would leave the coral pixel unchanged
+    /// (r≠g≠b); grayscale forces r==g==b.  We assert all three channels are
+    /// within tolerance of the luminance value and equal each other.
+    #[test]
+    fn sc5_scenebuilder_grayscale_matrix_reaches_pixels() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_tex, surface_view) = create_render_surface(&device);
+        clear_to_black(&device, &queue, &surface_view);
+
+        let layer_color = Color::rgba(180, 90, 40, 255);
+        let filter = ColorFilter::grayscale();
+
+        let mut tree = LayerTree::new();
+        let root_id = {
+            let mut builder = SceneBuilder::new(&mut tree);
+            builder.push_offset(Offset::ZERO);
+            builder.push_color_filter(filter);
+            let mut canvas = CanvasLayer::new();
+            canvas
+                .canvas_mut()
+                .draw_rect(full_surface_rect(), &Paint::fill(layer_color));
+            builder.add_canvas(canvas);
+            builder.pop().expect("color filter pop must not underflow");
+            builder.pop().expect("root offset pop must not underflow");
+            builder.build()
+        };
+
+        let pixels = render_scenebuilder_tree_and_readback(
+            &device,
+            &queue,
+            &surface_tex,
+            &surface_view,
+            &tree,
+            root_id,
+        );
+
+        // Luminance = 0.2126*R + 0.7152*G + 0.0722*B (ITU-R BT.709).
+        // For opaque input, premul == straight.
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "luminance in [0,1]*255; truncation is safe"
+        )]
+        let luminance = (0.2126 * f32::from(layer_color.r)
+            + 0.7152 * f32::from(layer_color.g)
+            + 0.0722 * f32::from(layer_color.b)) as u8;
+        let expected = [luminance, luminance, luminance, 255];
+
+        assert_interior_pixels_near(
+            "SC5 SceneBuilder/grayscale-Matrix",
+            &pixels,
+            expected,
+            4, // tolerance=4: grayscale matrix uses f32 shader math vs f32 CPU oracle
+        );
+
+        // Additional discriminator: all three RGB channels must be equal
+        // (confirming we produced gray, not a colorful miss).
+        let width = SURFACE_WIDTH as usize;
+        let height = SURFACE_HEIGHT as usize;
+        for (pixel_index, &px_rgba) in pixels.iter().enumerate() {
+            let row = pixel_index / width;
+            let col = pixel_index % width;
+            if row == 0 || row >= height - 1 || col == 0 || col >= width - 1 {
+                continue;
+            }
+            let r_g_diff =
+                u8::try_from((i16::from(px_rgba[0]) - i16::from(px_rgba[1])).unsigned_abs())
+                    .expect("diff of two u8 values always fits in u8");
+            assert!(
+                r_g_diff <= 4,
+                "SC5: R and G channels must be equal in grayscale output; \
+                 pixel {pixel_index} R={} G={} diff={}",
+                px_rgba[0],
+                px_rgba[1],
+                r_g_diff,
+            );
+        }
+    }
+}

--- a/examples/color_filter_demo.rs
+++ b/examples/color_filter_demo.rs
@@ -1,0 +1,352 @@
+//! Color Filter Demo - T1 ColorFilter live via SceneBuilder
+//!
+//! Demonstrates all three `ColorFilter` variants from T1 of the
+//! `gpu-filters-consumer-chain` spec, each applied via
+//! `SceneBuilder::push_color_filter`. The window shows five columns
+//! side-by-side, each containing the same coral rectangle:
+//!
+//! | Column | Filter |
+//! |--------|--------|
+//! | 1 | Unfiltered (reference) |
+//! | 2 | `ColorFilter::Mode { Multiply, cyan }` |
+//! | 3 | `ColorFilter::LinearToSrgbGamma` (linear → sRGB) |
+//! | 4 | `ColorFilter::SrgbToLinearGamma` (sRGB → linear) |
+//! | 5 | `ColorFilter::grayscale()` (Matrix variant) |
+//!
+//! This is the first live windowed demonstration of `ColorFilter::Mode` and
+//! `ColorFilter::LinearToSrgbGamma`/`SrgbToLinearGamma` reachable through
+//! the `SceneBuilder` → `Scene` → `render_scene` → GPU path.
+//!
+//! Run with: cargo run --example color_filter_demo
+
+use std::sync::{Arc, Mutex};
+
+use flui_engine::wgpu::Renderer;
+use flui_layer::{CanvasLayer, LayerTree, Scene, SceneBuilder};
+use flui_platform::{WindowOptions, current_platform, traits::PlatformWindow};
+use flui_types::{
+    Color, Offset,
+    geometry::{Rect, Size, px},
+    painting::{BlendMode, ColorFilter, Paint},
+};
+
+// ── Window-handle bridge (mirrors filter_demo.rs) ────────────────────────────
+
+struct PlatformWindowHandle {
+    window: Arc<dyn PlatformWindow>,
+}
+
+impl raw_window_handle::HasWindowHandle for PlatformWindowHandle {
+    fn window_handle(
+        &self,
+    ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
+        self.window.window_handle()
+    }
+}
+
+impl raw_window_handle::HasDisplayHandle for PlatformWindowHandle {
+    fn display_handle(
+        &self,
+    ) -> Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
+        self.window.display_handle()
+    }
+}
+
+// ── Color filter definitions ─────────────────────────────────────────────────
+
+/// Describes one column in the demo: a label (for tracing) and a `ColorFilter`
+/// to apply, or `None` for the unfiltered reference column.
+struct FilterColumn {
+    label: &'static str,
+    filter: Option<ColorFilter>,
+}
+
+fn demo_columns() -> [FilterColumn; 5] {
+    [
+        FilterColumn {
+            label: "unfiltered",
+            filter: None,
+        },
+        FilterColumn {
+            label: "Mode/Multiply cyan",
+            // Half-opacity cyan multiplied onto the layer content.
+            filter: Some(ColorFilter::mode(
+                Color::rgba(0, 200, 220, 200),
+                BlendMode::Multiply,
+            )),
+        },
+        FilterColumn {
+            label: "LinearToSrgbGamma",
+            filter: Some(ColorFilter::LinearToSrgbGamma),
+        },
+        FilterColumn {
+            label: "SrgbToLinearGamma",
+            filter: Some(ColorFilter::SrgbToLinearGamma),
+        },
+        FilterColumn {
+            label: "grayscale (Matrix)",
+            filter: Some(ColorFilter::grayscale()),
+        },
+    ]
+}
+
+// ── Scene construction ────────────────────────────────────────────────────────
+
+/// Builds the color-filter demo scene via `SceneBuilder`.
+///
+/// Layer tree (constructed via SceneBuilder push/pop):
+/// ```text
+/// OffsetLayer (zero, root)
+///   ├── CanvasLayer  (background)
+///   ├── CanvasLayer  (column 0: unfiltered shapes)
+///   ├── ColorFilterLayer(Mode/Multiply) — push_color_filter
+///   │     └── CanvasLayer (column 1 shapes)
+///   ├── ColorFilterLayer(LinearToSrgbGamma) — push_color_filter
+///   │     └── CanvasLayer (column 2 shapes)
+///   ├── ColorFilterLayer(SrgbToLinearGamma) — push_color_filter
+///   │     └── CanvasLayer (column 3 shapes)
+///   └── ColorFilterLayer(Matrix/grayscale) — push_color_filter
+///         └── CanvasLayer (column 4 shapes)
+/// ```
+///
+/// SceneBuilder API used:
+/// - `push_offset(Offset::ZERO)` — root container
+/// - `add_canvas(background_canvas)` — full-surface background leaf
+/// - For unfiltered column: `add_canvas(shapes_canvas)` leaf directly
+/// - For filtered columns: `push_color_filter(filter)` + `add_canvas(shapes_canvas)` + `pop()`
+/// - `pop()` — close root offset layer
+/// - `build()` — consume builder, returns root `LayerId`
+fn build_color_filter_scene(viewport_width: f32, viewport_height: f32) -> Scene {
+    let columns = demo_columns();
+    let column_count = columns.len() as f32;
+    let column_width = viewport_width / column_count;
+
+    let mut tree = LayerTree::new();
+
+    let root_id = {
+        let mut builder = SceneBuilder::new(&mut tree);
+
+        // Root offset layer.
+        builder.push_offset(Offset::ZERO);
+
+        // Background canvas: dark slate covering the entire viewport.
+        let mut background_canvas = CanvasLayer::new();
+        background_canvas.canvas_mut().draw_rect(
+            Rect::from_ltrb(px(0.0), px(0.0), px(viewport_width), px(viewport_height)),
+            &Paint::fill(Color::rgb(22, 28, 40)),
+        );
+        builder.add_canvas(background_canvas);
+
+        // One column per filter.
+        for (col_index, column_spec) in columns.iter().enumerate() {
+            let x_offset = col_index as f32 * column_width;
+
+            // Draw the content canvas for this column (shapes + divider).
+            let shapes_canvas = build_column_canvas(x_offset, column_width, viewport_height);
+
+            match &column_spec.filter {
+                None => {
+                    // Unfiltered reference: add directly as a leaf.
+                    builder.add_canvas(shapes_canvas);
+                }
+                Some(filter) => {
+                    // Filtered columns: push a ColorFilterLayer, add content, pop.
+                    builder.push_color_filter(*filter);
+                    builder.add_canvas(shapes_canvas);
+                    builder
+                        .pop()
+                        .expect("SceneBuilder stack must not underflow: color filter was pushed");
+                }
+            }
+
+            tracing::debug!(col = col_index, filter = column_spec.label, "column added");
+        }
+
+        // Close root offset layer.
+        builder
+            .pop()
+            .expect("SceneBuilder stack must not underflow: root offset was pushed");
+
+        builder.build()
+    };
+
+    tracing::info!(
+        columns = columns.len(),
+        "color filter demo scene built via SceneBuilder::push_color_filter"
+    );
+
+    Scene::new(
+        Size::new(px(viewport_width), px(viewport_height)),
+        tree,
+        root_id,
+        1,
+    )
+}
+
+/// Draws the demo shapes into a `CanvasLayer` for one column of the display.
+///
+/// Each column contains a coral rectangle, a teal rectangle, a white accent
+/// square, and a yellow strip — the same geometry as `filter_demo.rs` so the
+/// color-filter effect is visually comparable.
+fn build_column_canvas(x_offset: f32, column_width: f32, viewport_height: f32) -> CanvasLayer {
+    let mut canvas_layer = CanvasLayer::new();
+    let canvas = canvas_layer.canvas_mut();
+
+    let margin = 20.0;
+    let left = x_offset + margin;
+    let right = x_offset + column_width - margin;
+    let center_x = x_offset + column_width / 2.0;
+
+    // Thin column divider on the right edge.
+    canvas.draw_rect(
+        Rect::from_ltrb(
+            px(x_offset + column_width - 1.0),
+            px(0.0),
+            px(x_offset + column_width),
+            px(viewport_height),
+        ),
+        &Paint::fill(Color::rgb(60, 60, 60)),
+    );
+
+    // Large coral rectangle (primary subject).
+    canvas.draw_rect(
+        Rect::from_ltrb(
+            px(left),
+            px(50.0),
+            px(right),
+            px(viewport_height / 2.0 - 20.0),
+        ),
+        &Paint::fill(Color::rgb(220, 80, 60)),
+    );
+
+    // Overlapping teal rectangle.
+    canvas.draw_rect(
+        Rect::from_ltrb(
+            px(center_x - 50.0),
+            px(viewport_height / 2.0 - 50.0),
+            px(center_x + 50.0),
+            px(viewport_height - 60.0),
+        ),
+        &Paint::fill(Color::rgb(30, 180, 160)),
+    );
+
+    // Small white accent square.
+    canvas.draw_rect(
+        Rect::from_ltrb(
+            px(center_x - 20.0),
+            px(viewport_height / 2.0 - 20.0),
+            px(center_x + 20.0),
+            px(viewport_height / 2.0 + 20.0),
+        ),
+        &Paint::fill(Color::WHITE),
+    );
+
+    // Yellow strip at the bottom.
+    canvas.draw_rect(
+        Rect::from_ltrb(
+            px(left),
+            px(viewport_height - 50.0),
+            px(right),
+            px(viewport_height - 30.0),
+        ),
+        &Paint::fill(Color::rgb(255, 210, 0)),
+    );
+
+    canvas_layer
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+fn main() {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    tracing::info!(
+        "Color filter demo — T1 ColorFilter (Mode/Gamma/Matrix) via SceneBuilder::push_color_filter"
+    );
+
+    let platform = current_platform().expect("failed to initialize platform");
+    tracing::info!("platform: {}", platform.name());
+
+    let options = WindowOptions {
+        title: "FLUI Color Filter Demo — Mode / Gamma / Matrix (SceneBuilder API)".to_string(),
+        size: Size::new(px(1100.0), px(600.0)),
+        resizable: true,
+        visible: true,
+        decorated: true,
+        min_size: None,
+        max_size: None,
+    };
+
+    let window: Arc<dyn PlatformWindow> = Arc::from(
+        platform
+            .open_window(options)
+            .expect("failed to open window"),
+    );
+
+    tracing::info!(
+        physical_size = ?window.physical_size(),
+        scale_factor = window.scale_factor(),
+        "window created"
+    );
+
+    let handle = PlatformWindowHandle {
+        window: window.clone(),
+    };
+
+    let mut renderer =
+        pollster::block_on(Renderer::new(&handle)).expect("failed to create GPU renderer");
+
+    let physical = window.physical_size();
+    renderer.resize(physical.width.0 as u32, physical.height.0 as u32);
+
+    tracing::info!(
+        adapter = renderer.capabilities().adapter_name,
+        backend = ?renderer.capabilities().backend,
+        "GPU adapter selected"
+    );
+
+    let renderer = Arc::new(Mutex::new(renderer));
+
+    // Frame callback: rebuild and render the scene each frame.
+    let renderer_for_frame = Arc::clone(&renderer);
+    let window_for_frame = window.clone();
+    window.on_request_frame(Box::new(move || {
+        let size = window_for_frame.physical_size();
+        let viewport_width = size.width.0 as f32;
+        let viewport_height = size.height.0 as f32;
+
+        let scene = build_color_filter_scene(viewport_width, viewport_height);
+
+        let mut locked_renderer = renderer_for_frame.lock().unwrap();
+        if let Err(render_error) = locked_renderer.render_scene(&scene) {
+            tracing::error!(?render_error, "render_scene failed");
+        }
+    }));
+
+    // Resize callback: update the renderer's surface dimensions.
+    let renderer_for_resize = Arc::clone(&renderer);
+    window.on_resize(Box::new(move |new_size, scale_factor| {
+        let surface_width = (new_size.width.0 * scale_factor) as u32;
+        let surface_height = (new_size.height.0 * scale_factor) as u32;
+        renderer_for_resize
+            .lock()
+            .unwrap()
+            .resize(surface_width, surface_height);
+    }));
+
+    window.request_redraw();
+
+    tracing::info!(
+        "color filter demo ready — 5 columns: unfiltered | Mode/Multiply | LinearToSrgb | SrgbToLinear | Grayscale"
+    );
+
+    platform.run(Box::new(move || {
+        // Keep resources alive through the event loop.
+        let _window = &window;
+        let _renderer = &renderer;
+    }));
+
+    tracing::info!("color filter demo finished");
+}

--- a/examples/filter_demo.rs
+++ b/examples/filter_demo.rs
@@ -1,9 +1,9 @@
-//! Filter Demo - GPU Gaussian blur via ImageFilterLayer
+//! Filter Demo - GPU Gaussian blur via SceneBuilder + ImageFilterLayer
 //!
-//! Demonstrates the full image-filter rendering pipeline:
-//! CanvasLayer (content) → ImageFilterLayer → LayerRender::render →
-//! Backend::push_image_filter → save_layer_with_image_filter →
-//! DrawItem::Filter → GPU blur pass → Renderer::render_scene → pixels
+//! Demonstrates the full image-filter rendering pipeline via the programmatic
+//! SceneBuilder API:
+//! SceneBuilder::push_image_filter → add_canvas (content) → pop →
+//! Scene → Renderer::render_scene → GPU blur pass → pixels
 //!
 //! The window shows two copies of the same shapes side-by-side:
 //! - LEFT half: sharp / un-blurred (direct CanvasLayer child of root)
@@ -14,12 +14,12 @@
 use std::sync::{Arc, Mutex};
 
 use flui_engine::wgpu::Renderer;
-use flui_layer::{CanvasLayer, ImageFilterLayer, Layer, LayerTree, OffsetLayer, Scene};
+use flui_layer::{CanvasLayer, LayerTree, Scene, SceneBuilder};
 use flui_platform::{WindowOptions, current_platform, traits::PlatformWindow};
 use flui_types::{
+    Color, Offset,
     geometry::{Rect, Size, px},
-    painting::Paint,
-    styling::Color,
+    painting::{ImageFilter, Paint},
 };
 
 // ── Window-handle bridge (mirrors scene_render.rs) ───────────────────────────
@@ -47,71 +47,94 @@ impl raw_window_handle::HasDisplayHandle for PlatformWindowHandle {
 // ── Scene construction ────────────────────────────────────────────────────────
 
 /// Builds a scene demonstrating `ImageFilterLayer` Gaussian blur side-by-side
-/// with an un-blurred copy of the same shapes.
+/// with an un-blurred copy of the same shapes, using the `SceneBuilder` API.
 ///
-/// Layer tree structure:
+/// Layer tree structure (constructed via SceneBuilder push/pop):
 /// ```text
-/// OffsetLayer (zero, root container)
-///   ├── CanvasLayer  (background + LEFT un-blurred shapes)
-///   └── ImageFilterLayer (Blur σ_x=8, σ_y=8)
-///         └── CanvasLayer (RIGHT blurred shapes)
+/// OffsetLayer (zero, root — pushed first)
+///   ├── CanvasLayer  (background + LEFT un-blurred shapes — add_canvas leaf)
+///   └── ImageFilterLayer (Blur σ_x=8, σ_y=8 — push_image_filter)
+///         └── CanvasLayer (RIGHT blurred shapes — add_canvas leaf inside filter)
 /// ```
+///
+/// SceneBuilder API used:
+/// - `push_offset(Offset::ZERO)` — root container
+/// - `add_canvas(sharp_canvas)` — leaf inside the offset layer
+/// - `push_image_filter(ImageFilter::blur_xy(8.0, 8.0))` — filter container
+/// - `add_canvas(blurred_canvas)` — leaf inside the filter layer
+/// - `pop()` — close the filter layer
+/// - `pop()` — close the offset layer (root)
+/// - `build()` — consume the builder, returns root `LayerId`
 fn build_filter_scene(width: f32, height: f32) -> Scene {
     let half_width = width / 2.0;
 
     let mut tree = LayerTree::new();
 
-    // Root: zero-offset container so both children share one root id.
-    let root_id = tree.insert(Layer::from(OffsetLayer::zero()));
+    // ── SceneBuilder: construct the layer hierarchy via push/pop ─────────────
+    //
+    // The builder is scoped so `tree` is available after the borrow ends.
+    let root_id = {
+        let mut builder = SceneBuilder::new(&mut tree);
 
-    // ── LEFT: background + un-blurred shapes ─────────────────────────────────
-    let mut sharp_canvas = CanvasLayer::new();
-    {
-        let canvas = sharp_canvas.canvas_mut();
+        // Root: zero-offset container so both children share one root id.
+        builder.push_offset(Offset::ZERO);
 
-        // Full background (dark navy).
-        canvas.draw_rect(
-            Rect::from_ltrb(px(0.0), px(0.0), px(width), px(height)),
-            &Paint::fill(Color::rgb(18, 26, 42)),
-        );
+        // ── LEFT: background + un-blurred shapes ─────────────────────────────
+        let mut sharp_canvas = CanvasLayer::new();
+        {
+            let canvas = sharp_canvas.canvas_mut();
 
-        // Divider between left (sharp) and right (blurred) halves.
-        canvas.draw_rect(
-            Rect::from_ltrb(
-                px(half_width - 1.0),
-                px(0.0),
-                px(half_width + 1.0),
-                px(height),
-            ),
-            &Paint::fill(Color::rgb(80, 80, 80)),
-        );
+            // Full background (dark navy).
+            canvas.draw_rect(
+                Rect::from_ltrb(px(0.0), px(0.0), px(width), px(height)),
+                &Paint::fill(Color::rgb(18, 26, 42)),
+            );
 
-        // Un-blurred shapes on the left half.
-        draw_demo_shapes(canvas, 0.0, half_width, height);
-    }
-    let sharp_id = tree.insert(Layer::from(sharp_canvas));
-    tree.add_child(root_id, sharp_id);
+            // Divider between left (sharp) and right (blurred) halves.
+            canvas.draw_rect(
+                Rect::from_ltrb(
+                    px(half_width - 1.0),
+                    px(0.0),
+                    px(half_width + 1.0),
+                    px(height),
+                ),
+                &Paint::fill(Color::rgb(80, 80, 80)),
+            );
 
-    // ── RIGHT: blurred shapes wrapped in ImageFilterLayer ────────────────────
-    let mut blurred_canvas = CanvasLayer::new();
-    draw_demo_shapes(blurred_canvas.canvas_mut(), half_width, half_width, height);
-    let blurred_content_id = tree.insert(Layer::from(blurred_canvas));
+            // Un-blurred shapes on the left half.
+            draw_demo_shapes(canvas, 0.0, half_width, height);
+        }
+        // Leaf: added as a child of the current parent (the offset layer).
+        builder.add_canvas(sharp_canvas);
 
-    // ImageFilterLayer::blur_xy(sigma_x, sigma_y) — public convenience ctor.
-    let filter_layer = ImageFilterLayer::blur_xy(8.0, 8.0);
-    let filter_layer_id = tree.insert(Layer::from(filter_layer));
+        // ── RIGHT: blurred shapes wrapped in ImageFilterLayer ─────────────────
+        //
+        // SceneBuilder::push_image_filter pushes an ImageFilterLayer and makes
+        // it the current parent; add_canvas then attaches the content as its child.
+        builder.push_image_filter(ImageFilter::blur_directional(8.0, 8.0));
+        let mut blurred_canvas = CanvasLayer::new();
+        draw_demo_shapes(blurred_canvas.canvas_mut(), half_width, half_width, height);
+        builder.add_canvas(blurred_canvas);
+        // Close the ImageFilterLayer.
+        builder
+            .pop()
+            .expect("SceneBuilder stack must not underflow: blur filter was pushed");
 
-    // Wire: filter layer is a child of root, blurred canvas is its child.
-    tree.add_child(root_id, filter_layer_id);
-    tree.add_child(filter_layer_id, blurred_content_id);
+        // Close the root offset layer.
+        builder
+            .pop()
+            .expect("SceneBuilder stack must not underflow: root offset was pushed");
+
+        builder.build()
+    };
 
     tracing::info!(
-        sigma_x = 8.0,
-        sigma_y = 8.0,
-        "blurred shape via ImageFilterLayer(Blur σ=8)"
+        sigma_x = 8.0_f32,
+        sigma_y = 8.0_f32,
+        "blurred shape via SceneBuilder::push_image_filter(Blur σ=8)"
     );
 
-    Scene::new(Size::new(px(width), px(height)), tree, Some(root_id), 1)
+    Scene::new(Size::new(px(width), px(height)), tree, root_id, 1)
 }
 
 /// Draws the demo shape set into `canvas`, offset by `x_offset` px within a
@@ -157,12 +180,7 @@ fn draw_demo_shapes(
 
     // Yellow strip at the bottom.
     canvas.draw_rect(
-        Rect::from_ltrb(
-            px(left),
-            px(height - 55.0),
-            px(right),
-            px(height - 30.0),
-        ),
+        Rect::from_ltrb(px(left), px(height - 55.0), px(right), px(height - 30.0)),
         &Paint::fill(Color::rgb(255, 210, 0)),
     );
 }
@@ -174,13 +192,13 @@ fn main() {
         .with_max_level(tracing::Level::INFO)
         .init();
 
-    tracing::info!("Filter demo — GPU Gaussian blur via ImageFilterLayer");
+    tracing::info!("Filter demo — GPU Gaussian blur via SceneBuilder::push_image_filter");
 
     let platform = current_platform().expect("failed to initialize platform");
     tracing::info!("platform: {}", platform.name());
 
     let options = WindowOptions {
-        title: "FLUI Filter Demo — Gaussian Blur (ImageFilterLayer)".to_string(),
+        title: "FLUI Filter Demo — Gaussian Blur (SceneBuilder API)".to_string(),
         size: Size::new(px(900.0), px(600.0)),
         resizable: true,
         visible: true,
@@ -189,8 +207,11 @@ fn main() {
         max_size: None,
     };
 
-    let window: Arc<dyn PlatformWindow> =
-        Arc::from(platform.open_window(options).expect("failed to open window"));
+    let window: Arc<dyn PlatformWindow> = Arc::from(
+        platform
+            .open_window(options)
+            .expect("failed to open window"),
+    );
 
     tracing::info!(
         physical_size = ?window.physical_size(),


### PR DESCRIPTION
## Summary

**T2′ of `gpu-filters-consumer-chain`** — the in-scope deliverable at the **flui-painting + flui-layer ceiling** (render/widget consumers deferred per user scope). Verifies the programmatic painting+layer filter API closes end-to-end to pixels.

**Architecture finding** (chief-architect re-scope): `DisplayList` and `LayerTree` are **orthogonal / non-convertible** — no lowering exists; `SaveLayer`/`BackdropFilter` replay direct to GPU; `Canvas` can't reference `Layer` (dependency direction). So the painting-level entry that produces filter **layers** is **`SceneBuilder`** (flui-layer), NOT `Canvas` — a Canvas filter would be the rejected Approach A. The `SceneBuilder` producers were already complete after T1 (#277), so the in-scope work is **verification**, not new producer code.

## Changes
- **`examples/filter_demo.rs`** — ported from hand `tree.insert`/`add_child` to `SceneBuilder::push_image_filter` (proves the programmatic API closes to pixels).
- **`examples/color_filter_demo.rs`** (new) — Mode/Multiply + LinearToSrgb + SrgbToLinear + grayscale Matrix via `SceneBuilder::push_color_filter`, side by side with an unfiltered reference. First live demo of T1's Mode/Gamma.
- **`scenebuilder_filter_chain_tests.rs`** (new) — SC1-SC5 GPU readback through `SceneBuilder → LayerRender → Backend → WgpuPainter → GPU`. Independent oracles (`Color::blend`, IEC 61966-2-1 gamma, BT.709 luminance) + discriminators (blur centre>corner, grayscale R==G). **Honest scope:** `render_scene` needs a swapchain, so SC tests exercise the identical constituent path minus swapchain acquire/present (no filter logic there); the production layer walk has separate coverage (#276 + the live demo).

## Verification (ground-truthed locally)
`cargo check` (3 crates + both examples) = 0 · clippy no-feature + `--features enable-wgpu-tests` `-D warnings` = 0 · `cargo doc -D warnings` = 0 · fmt/typos/port-check = 0 · **readback 433/0** (428 T1 baseline + 5 SC; P1-P4 + 39 filter tests still green).

**Deferred (above the ceiling):** the app-facing widget consumer (`ImageFiltered`/`ColorFiltered`/`BackdropFilter` widgets + render-objects in flui-rendering + flui-view) — spec tasks T2/T3/T4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)