### PR TITLE
fix(engine): self-heal advanced-blend shapes/layers straddling a partial-damage scissor

### DIFF
--- a/crates/flui-engine/CHANGELOG.md
+++ b/crates/flui-engine/CHANGELOG.md
@@ -63,6 +63,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   top of opaque content (e.g. a filtered layer over an opaque background). (#276)
 - `ColorFilter::Mode` is now composited **over** the image as a per-pixel blend, fixing
   a flush-bucket-order bug where the tint drew under the opaque image. (#241)
+- **Advanced (dst-read) shapes/layers no longer leave stale pixels under partial damage.**
+  An advanced-blend shape, SSAA path, or `saveLayer` whose `device_bounds` straddle a
+  partial-damage scissor edge was clipped to the damage rect on its foreground but
+  blended over its full bounds with `LoadOp::Load` + no scissor — writing the prior
+  frame's backdrop in the out-of-damage slice (a damage-completeness gap: a dst-read
+  shape's true dirty region is its full bounds). The renderer now detects such a
+  straddle (`has_advanced_shape_straddling`) and schedules a full repaint on the next
+  frame (1-frame self-heal; partial damage is currently unused so the transient is
+  unobservable today).
 
 ### Performance
 

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -287,18 +287,33 @@ impl WgpuPainter {
         self.batcher.tessellator.set_max_scale(scale);
     }
 
-    /// Returns `true` if any `DrawItem::AdvancedShape` (or `DrawItem::SsaaPath`
-    /// with an advanced blend mode) in the current `draw_order` has a
-    /// `device_bounds` that STRADDLES the given `damage` rect.
+    /// Returns `true` if any surface-reading draw item in the current `draw_order`
+    /// has bounds that STRADDLE the given `damage` rect.
+    ///
+    /// The items covered are:
+    ///
+    /// - `DrawItem::AdvancedShape` — a single tessellated shape with an advanced
+    ///   (dst-read) blend mode.
+    /// - `DrawItem::SsaaPath` with `blend.is_advanced()` — an SSAA path routed
+    ///   through `flush_advanced_layer` at replay time.
+    /// - `DrawItem::OpacityLayer` with `blend.is_advanced()` — a `saveLayer` with
+    ///   an explicit advanced blend mode; composited via `flush_advanced_layer` with
+    ///   `LoadOp::Load` and no scissor, so its `bounds` rect is the full composite
+    ///   footprint written to the surface.
+    ///
+    /// `DrawItem::Filter` and `DrawItem::OffscreenTexture` are intentionally
+    /// excluded: they composite their offscreen via premultiplied SrcOver and never
+    /// read the surface backdrop, so they carry no stale-pixel hazard outside the
+    /// scissor.
     ///
     /// "Straddle" means the bounds intersect the damage rect AND are NOT fully
-    /// contained by it — i.e., part of the shape falls outside the scissored
-    /// region.  Shapes fully inside or fully outside do not straddle.
+    /// contained by it — i.e., part of the item falls outside the scissored
+    /// region.  Items fully inside or fully outside do not straddle.
     ///
     /// Called by `renderer.rs` after `render_layer_recursive` to decide whether
     /// to schedule a full repaint on the next frame (self-healing).  Not test-gated
     /// because it is a production helper; it is also covered by the dedicated
-    /// detector test in `shape_blend_tests.rs`.
+    /// detector tests in `shape_blend_tests.rs`.
     pub(crate) fn has_advanced_shape_straddling(
         &self,
         damage: flui_types::Rect<flui_types::geometry::Pixels>,
@@ -316,6 +331,20 @@ impl WgpuPainter {
                 op.blend.is_advanced()
                     && op.device_bounds.intersects(&damage)
                     && !damage.contains_rect(&op.device_bounds)
+            }
+            DrawItem::OpacityLayer(op) => {
+                // An advanced-blend saveLayer composites onto the surface via
+                // `flush_advanced_layer` with `LoadOp::Load` and no scissor, reading
+                // the full `op.bounds` region of the backdrop.  Any straddle of the
+                // damage rect means unscissored pixels outside the damage may be
+                // written with a stale-backdrop blend result.
+                //
+                // `DrawItem::Filter` and `DrawItem::OffscreenTexture` are excluded:
+                // they composite via premultiplied SrcOver from an offscreen texture
+                // and do not read the surface backdrop.
+                op.blend.is_advanced()
+                    && op.bounds.intersects(&damage)
+                    && !damage.contains_rect(&op.bounds)
             }
             _ => false,
         })

--- a/crates/flui-engine/src/wgpu/painter.rs
+++ b/crates/flui-engine/src/wgpu/painter.rs
@@ -287,6 +287,40 @@ impl WgpuPainter {
         self.batcher.tessellator.set_max_scale(scale);
     }
 
+    /// Returns `true` if any `DrawItem::AdvancedShape` (or `DrawItem::SsaaPath`
+    /// with an advanced blend mode) in the current `draw_order` has a
+    /// `device_bounds` that STRADDLES the given `damage` rect.
+    ///
+    /// "Straddle" means the bounds intersect the damage rect AND are NOT fully
+    /// contained by it — i.e., part of the shape falls outside the scissored
+    /// region.  Shapes fully inside or fully outside do not straddle.
+    ///
+    /// Called by `renderer.rs` after `render_layer_recursive` to decide whether
+    /// to schedule a full repaint on the next frame (self-healing).  Not test-gated
+    /// because it is a production helper; it is also covered by the dedicated
+    /// detector test in `shape_blend_tests.rs`.
+    pub(crate) fn has_advanced_shape_straddling(
+        &self,
+        damage: flui_types::Rect<flui_types::geometry::Pixels>,
+    ) -> bool {
+        use super::command_ir::DrawItem;
+        self.draw_order.iter().any(|item| match item {
+            DrawItem::AdvancedShape(op) => {
+                op.device_bounds.intersects(&damage) && !damage.contains_rect(&op.device_bounds)
+            }
+            DrawItem::SsaaPath(op) => {
+                // SsaaPath is routed through `flush_advanced_layer` when the blend
+                // is advanced (dst-read).  Only those paths are subject to the same
+                // stale-pixel hazard; tile-safe porter-duff SSAA paths do not read
+                // the backdrop so they cannot write stale pixels outside the scissor.
+                op.blend.is_advanced()
+                    && op.device_bounds.intersects(&damage)
+                    && !damage.contains_rect(&op.device_bounds)
+            }
+            _ => false,
+        })
+    }
+
     /// The composite `bounds` and backing texture pixel size of every pending
     /// [`DrawItem::OffscreenTexture`] in the draw order, in draw order. Used by
     /// the HiDPI shader-mask / backdrop regression tests to assert an offscreen

--- a/crates/flui-engine/src/wgpu/renderer.rs
+++ b/crates/flui-engine/src/wgpu/renderer.rs
@@ -219,6 +219,25 @@ pub struct Renderer {
     /// Controlled by [`Renderer::force_intermediate_for_testing`].
     #[cfg(test)]
     force_intermediate: bool,
+
+    /// When `true`, the NEXT call to `render_scene` will promote the
+    /// damage to a full repaint before any scissor logic runs.
+    ///
+    /// Set when the current frame detected a partial-damage scissor AND a
+    /// `DrawItem::AdvancedShape` (or SSAA-path with an advanced blend) whose
+    /// `device_bounds` straddle the damage edge.  Such items call
+    /// `flush_advanced_layer` with `LoadOp::Load` on the full `device_bounds`
+    /// with no scissor — if the foreground is restricted by the scissor,
+    /// the out-of-damage slice blends `transparent_fg` over the stale
+    /// prior-frame backdrop, writing stale pixels.
+    ///
+    /// Self-healing: the next frame is forced full, repainting the shape
+    /// over its true `device_bounds` without a scissor restriction.  The
+    /// transient is unobservable today because callers use full repaint
+    /// exclusively (see the `damage_rect()` call-site comment); a this-frame
+    /// re-record or a precomputed `Scene` bit would be the upgrade path once
+    /// partial damage becomes hot.
+    force_full_repaint_next_frame: bool,
 }
 
 // SAFETY: `Renderer` stores `Option<RawWindowHandle>` and
@@ -305,6 +324,7 @@ impl Renderer {
             gpu_profiler: stack.gpu_profiler,
             #[cfg(test)]
             force_intermediate: false,
+            force_full_repaint_next_frame: false,
         })
     }
 
@@ -561,6 +581,7 @@ impl Renderer {
             gpu_profiler: None,
             #[cfg(test)]
             force_intermediate: false,
+            force_full_repaint_next_frame: false,
         })
     }
 
@@ -1035,6 +1056,19 @@ impl Renderer {
         // will call `mark_dirty(bounds)` on state change; until then, callers
         // use `mark_full_repaint()` to force a frame.
 
+        // If the previous frame detected a straddling advanced shape under partial
+        // damage, promote this frame to a full repaint so the shape is redrawn
+        // without scissor restriction, self-healing any stale out-of-damage pixels.
+        // Consumed here (set to false) so it does not propagate beyond one frame.
+        if self.force_full_repaint_next_frame {
+            self.force_full_repaint_next_frame = false;
+            self.damage_tracker.mark_full_repaint();
+            tracing::trace!(
+                "force_full_repaint_next_frame: promoting to full repaint \
+                 (advanced shape straddled partial damage last frame)"
+            );
+        }
+
         // Check if we need to render at all
         if !self.damage_tracker.has_damage() && !self.damage_tracker.needs_full_repaint() {
             // Nothing changed — skip this frame entirely
@@ -1270,10 +1304,17 @@ impl Renderer {
             // screen changed, limit GPU work to the damaged region.
             // `damage_rect()` returns `None` for full repaint (no scissor needed),
             // `Some(rect)` for partial damage.
-            if let Some(damage) = self.damage_tracker.damage_rect()
-                && damage.width().0 > 0.0
-                && damage.height().0 > 0.0
-            {
+            //
+            // We capture `partial_damage` separately: after `render_layer_recursive`
+            // populates `draw_order`, we check whether any advanced shape (or SSAA
+            // path with an advanced blend) straddles the damage edge.  If so, we
+            // schedule a full repaint next frame to self-heal stale pixels outside
+            // the damage rect that `flush_advanced_layer` may have written.
+            let partial_damage = self
+                .damage_tracker
+                .damage_rect()
+                .filter(|r| r.width().0 > 0.0 && r.height().0 > 0.0);
+            if let Some(damage) = partial_damage {
                 backend.painter_mut().clip_rect(damage);
                 tracing::trace!(
                     left = damage.left().0,
@@ -1297,6 +1338,31 @@ impl Renderer {
                     &ctx,
                     render_texture,
                     render_view,
+                );
+            }
+
+            // Damage-straddle self-healing: if a partial scissor was applied AND
+            // `draw_order` now contains an advanced shape whose `device_bounds`
+            // straddle the damage edge, schedule a full repaint for the next frame.
+            //
+            // Why next-frame and not this-frame: `render_layer_recursive` has
+            // already populated the draw commands with the scissored geometry; a
+            // this-frame re-record would require replaying the entire scene graph.
+            // Partial damage is currently unused (callers use `mark_full_repaint`),
+            // so the transient stale pixel is unobservable.  A precomputed Scene
+            // bit or a re-record is the future upgrade path if partial damage
+            // becomes a hot path.
+            if let Some(damage) = partial_damage
+                && backend.painter().has_advanced_shape_straddling(damage)
+            {
+                self.force_full_repaint_next_frame = true;
+                tracing::debug!(
+                    left = damage.left().0,
+                    top = damage.top().0,
+                    width = damage.width().0,
+                    height = damage.height().0,
+                    "Advanced shape straddles partial damage; \
+                     scheduling full repaint next frame"
                 );
             }
 

--- a/crates/flui-engine/src/wgpu/replay.rs
+++ b/crates/flui-engine/src/wgpu/replay.rs
@@ -341,14 +341,21 @@ impl GpuReplay {
                 // anti-aliasing — edges are aliased.  This is consistent with the
                 // Phase-A quality note in `batches/shapes.rs`.
                 //
-                // Damage-straddle correctness: `flush_advanced_layer` issues its
-                // render pass with `LoadOp::Load` and writes to `op.device_bounds`
-                // on the surface.  The damage scissor (if any) was applied to the
-                // shape's geometry at record time via the GpuStateStack, which
-                // affects the offscreen foreground tessellation.  Outside the
-                // damage region the foreground is transparent, so the blend pass
-                // effectively passes through backdrop pixels — no stale content
-                // is written.  This is correct for all straddling configurations.
+                // Damage-straddle hazard: `flush_advanced_layer` issues its render
+                // pass with `LoadOp::Load` and NO scissor, writing the blend result
+                // to the full `op.device_bounds` on the surface.  If a partial
+                // damage scissor was applied at record time, the foreground texture
+                // is transparent OUTSIDE the scissor; the blend pass then computes
+                // `blend(transparent_fg, stale_backdrop)` there, potentially
+                // preserving prior-frame stale pixels in the out-of-damage slice.
+                //
+                // Self-healing: `renderer.rs` detects straddling advanced shapes
+                // after `render_layer_recursive` and sets
+                // `force_full_repaint_next_frame`, so the NEXT frame repaints the
+                // full `device_bounds` without scissor restriction.  Acceptable
+                // because partial damage is currently unused (callers use
+                // `mark_full_repaint`); a this-frame re-record or a precomputed
+                // Scene bit is the future upgrade when partial damage becomes hot.
                 DrawItem::AdvancedShape(mut op) => {
                     if let Some(surface_texture) = target.texture {
                         // Render the shape into a full-viewport offscreen foreground.

--- a/crates/flui-engine/src/wgpu/shape_blend_tests.rs
+++ b/crates/flui-engine/src/wgpu/shape_blend_tests.rs
@@ -18,6 +18,9 @@
 //! | S11a | `has_advanced_shape_straddling`: straddling AdvancedShape → `true` |
 //! | S11b | `has_advanced_shape_straddling`: fully-contained AdvancedShape → `false` |
 //! | S11c | `has_advanced_shape_straddling`: SrcOver (Segment) straddling → `false` |
+//! | S11d | `has_advanced_shape_straddling`: advanced-blend OpacityLayer straddling → `true` |
+//! | S11e | `has_advanced_shape_straddling`: advanced-blend OpacityLayer fully contained → `false` |
+//! | S11f | `has_advanced_shape_straddling`: SrcOver OpacityLayer straddling → `false` |
 
 // ─── GPU readback tests ───────────────────────────────────────────────────────
 
@@ -863,6 +866,138 @@ mod gpu_tests {
         assert!(
             !painter.has_advanced_shape_straddling(damage),
             "S11c: a SrcOver shape must NOT be flagged as straddling (not an advanced blend)"
+        );
+    }
+
+    /// S11d: A `saveLayer` with an advanced blend mode (`DrawItem::OpacityLayer`
+    /// whose `blend.is_advanced()` is `true`) whose `bounds` STRADDLE the damage
+    /// rect must cause `has_advanced_shape_straddling` to return `true`.
+    ///
+    /// The layer composites via `flush_advanced_layer` with `LoadOp::Load` and NO
+    /// scissor, so any backdrop pixel within `op.bounds` but outside the damage
+    /// rect is written with a stale-backdrop blend result.  The detector must flag
+    /// this so `renderer.rs` can schedule the self-healing full repaint.
+    ///
+    /// This test is the **red→green discriminator** for the P2 completeness fix:
+    /// it FAILS before the `DrawItem::OpacityLayer` arm is added (the detector
+    /// returns `false` — the gap), and passes after.
+    #[test]
+    fn has_advanced_shape_straddling_detector_advanced_layer_straddle_returns_true() {
+        let (device, queue) = acquire_test_device_and_queue();
+
+        // Layer spans the full surface (0..64, 0..64); bounds=None defaults to viewport.
+        let full_bounds = full_surface_bounds();
+        let half_width = SURFACE_WIDTH as f32 / 2.0;
+        // Damage is the left half (0..32, 0..64) — the layer straddles the right edge.
+        let damage = Rect::from_ltrb(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(half_width),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        // Open a saveLayer with an advanced (Multiply) blend mode.  bounds=None
+        // resolves to the full viewport rect inside restore_layer, so op.bounds
+        // covers the entire 64×64 surface and straddles the left-half damage rect.
+        // A rect is drawn inside the layer so the compositor produces
+        // RestoreOutcome::Composite (not Empty) and emits DrawItem::OpacityLayer.
+        painter.save_layer(
+            None,
+            &Paint {
+                blend_mode: BlendMode::Multiply,
+                ..Default::default()
+            },
+        );
+        painter.rect(full_bounds, &Paint::fill(Color::rgba(100, 200, 50, 200)));
+        painter.restore_layer();
+
+        assert!(
+            painter.has_advanced_shape_straddling(damage),
+            "S11d: a full-surface advanced-blend saveLayer must straddle a left-half damage rect"
+        );
+    }
+
+    /// S11e: A `saveLayer` with an advanced blend mode whose `bounds` are FULLY
+    /// CONTAINED within the damage rect must cause
+    /// `has_advanced_shape_straddling` to return `false`.
+    ///
+    /// The scissor already covers the layer's entire composite footprint, so no
+    /// stale-backdrop pixel can be written outside the damage region.
+    #[test]
+    fn has_advanced_shape_straddling_detector_advanced_layer_contained_returns_false() {
+        let (device, queue) = acquire_test_device_and_queue();
+
+        // Layer is the LEFT QUARTER (0..16, 0..64) — fully inside the left-half damage.
+        let quarter_width = SURFACE_WIDTH as f32 / 4.0;
+        let layer_bounds = Rect::from_ltrb(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(quarter_width),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+        // Damage is the left half (0..32, 0..64) — fully contains the layer.
+        let half_width = SURFACE_WIDTH as f32 / 2.0;
+        let damage = Rect::from_ltrb(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(half_width),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        // Explicit bounds = left-quarter rect; explicit bounds are respected as-is
+        // (no viewport fallback) so op.bounds will be the quarter rect.
+        // A rect inside ensures RestoreOutcome::Composite (not Empty).
+        painter.save_layer(
+            Some(layer_bounds),
+            &Paint {
+                blend_mode: BlendMode::Multiply,
+                ..Default::default()
+            },
+        );
+        painter.rect(layer_bounds, &Paint::fill(Color::rgba(100, 200, 50, 200)));
+        painter.restore_layer();
+
+        assert!(
+            !painter.has_advanced_shape_straddling(damage),
+            "S11e: an advanced-blend saveLayer fully within the damage rect must NOT straddle"
+        );
+    }
+
+    /// S11f: A `saveLayer` with a plain SrcOver blend mode whose `bounds` straddle
+    /// the damage rect must cause `has_advanced_shape_straddling` to return `false`.
+    ///
+    /// SrcOver layers do not call `flush_advanced_layer` and therefore do not read
+    /// the surface backdrop — they cannot write stale-backdrop pixels outside the
+    /// scissor.  Only the `is_advanced()` gate on the `OpacityLayer` arm admits
+    /// the hazardous case.
+    #[test]
+    fn has_advanced_shape_straddling_detector_srcover_layer_straddle_returns_false() {
+        let (device, queue) = acquire_test_device_and_queue();
+
+        // Layer spans the full surface (0..64, 0..64).
+        let full_bounds = full_surface_bounds();
+        let half_width = SURFACE_WIDTH as f32 / 2.0;
+        let damage = Rect::from_ltrb(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(half_width),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        // SrcOver saveLayer at half opacity — the compositor emits DrawItem::OpacityLayer
+        // with blend=SrcOver (not advanced).  A rect inside ensures RestoreOutcome::Composite.
+        // The OpacityLayer arm in the detector gates on `op.blend.is_advanced()`, which is
+        // `false` for SrcOver, so the straddling check returns `false`.
+        painter.save_layer(None, &Paint::fill(Color::rgba(0, 0, 0, 128)));
+        painter.rect(full_bounds, &Paint::fill(Color::rgba(100, 200, 50, 200)));
+        painter.restore_layer();
+
+        assert!(
+            !painter.has_advanced_shape_straddling(damage),
+            "S11f: a SrcOver saveLayer must NOT be flagged as straddling (no backdrop read)"
         );
     }
 }

--- a/crates/flui-engine/src/wgpu/shape_blend_tests.rs
+++ b/crates/flui-engine/src/wgpu/shape_blend_tests.rs
@@ -12,9 +12,12 @@
 //! | S5 | `drawRect` with Multiply over non-flat dst ≈ oracle (interior ±2) |
 //! | S6 | `drawRRect` with Screen over non-flat dst ≈ oracle (interior ±2) |
 //! | S7 | Z-interleave: SrcOver content before AND after an advanced shape — order correct |
-//! | S8 | Damage-straddle: partial damage scissor + Multiply shape straddling its edge |
+//! | S8 | Foreground confined by `clip_rect`: scissored region blended, no right-half assertion |
 //! | S9 | SrcOver shape byte-identity: advanced branch NOT taken |
 //! | S10 | Plus/Modulate shapes: no panic, valid RGBA output (Segment path) |
+//! | S11a | `has_advanced_shape_straddling`: straddling AdvancedShape → `true` |
+//! | S11b | `has_advanced_shape_straddling`: fully-contained AdvancedShape → `false` |
+//! | S11c | `has_advanced_shape_straddling`: SrcOver (Segment) straddling → `false` |
 
 // ─── GPU readback tests ───────────────────────────────────────────────────────
 
@@ -523,31 +526,35 @@ mod gpu_tests {
         );
     }
 
-    // ── S8: Damage-straddle — partial damage + advanced shape ─────────────────
+    // ── S8: Scissor-respecting foreground — advanced shape inside clip_rect ──────
 
-    /// S8: An advanced shape that straddles a partial-damage rect boundary must
-    /// be composited correctly both inside and outside the damage rect.
+    /// S8: A `clip_rect` scissor applied to an advanced shape correctly confines
+    /// the foreground tessellation to the scissored region; the INSIDE (left half)
+    /// receives the correct `Multiply` blend result.
     ///
-    /// The damage-straddle is correct by design: `flush_advanced_layer` issues
-    /// its render pass with `LoadOp::Load` on the full surface (no scissor on
-    /// the blend pass).  The foreground texture is cleared to TRANSPARENT;
-    /// the tessellation scissor limits the foreground to the damage rect.
-    /// Outside the damage rect: foreground is transparent → backdrop passes
-    /// through → no stale content is written.  Inside: correct blend.
+    /// This is a UNIT test for the painter's record-time scissor: it proves that
+    /// foreground geometry for an advanced-blend shape is restricted by `clip_rect`.
+    /// The right half is NOT asserted — its pixel value depends on whether the
+    /// `flush_advanced_layer` backdrop copy wrote transparent-over-stale or fresh
+    /// content there, which is the HAZARD documented in the damage-straddle
+    /// correctness bug (`force_full_repaint_next_frame`).  Asserting the right half
+    /// would enshrine that hazard as a guarantee.
+    ///
+    /// What this test does NOT cover:
+    /// - The stale-pixel hazard when `device_bounds` straddles a partial damage edge.
+    ///   That is covered by the `has_advanced_shape_straddling_detector_*` tests
+    ///   (detector unit tests) and the `force_full_repaint_next_frame` field in
+    ///   `Renderer` (self-healing integration).
+    /// - Renderer-level damage tracking, which requires a full Renderer+surface setup.
     ///
     /// Setup:
-    /// - Backdrop: opaque red.
-    /// - Partial damage: left half only (x=0..32, full height).
-    /// - Multiply shape covering the full surface (straddles the damage edge).
+    /// - Backdrop: opaque red (cleared directly onto the surface).
+    /// - `clip_rect`: left half only (x=0..32, full height).
+    /// - Multiply shape covering the full surface.
     ///
-    /// Expected: left half blended, right half unchanged (red).
-    ///
-    /// Note: This test validates the design correctness; it does NOT test the
-    /// renderer's damage-tracker integration (which requires a full Renderer
-    /// setup with a surface).  Instead it simulates the partial-damage scissor
-    /// by drawing the Multiply shape inside a clip_rect call.
+    /// Assertion: left half (inside scissor) must be the `Multiply` blend result.
     #[test]
-    fn damage_straddle_advanced_shape_blended_correctly() {
+    fn advanced_shape_foreground_confined_by_clip_rect() {
         let (device, queue) = acquire_test_device_and_queue();
         let (surface_texture, surface_view) = create_sampleable_surface(&device);
 
@@ -569,13 +576,7 @@ mod gpu_tests {
         let full_bounds = full_surface_bounds();
         let half_width = SURFACE_WIDTH as f32 / 2.0;
 
-        // Simulate a partial damage scissor: clip to the left half, then draw a
-        // full-surface Multiply rect.  The tessellation will only emit geometry
-        // inside the scissor.  The advanced blend render pass runs without a
-        // scissor, so it writes to the full `device_bounds` AABB on the surface.
-        // Outside the damage (right half): foreground is transparent → backdrop
-        // red passes through → pixels remain red.
-        let damage_rect = Rect::from_ltrb(
+        let clip = Rect::from_ltrb(
             Pixels(0.0),
             Pixels(0.0),
             Pixels(half_width),
@@ -583,8 +584,10 @@ mod gpu_tests {
         );
 
         let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
-        // Apply the damage scissor (simulates what renderer.rs does with damage_rect).
-        painter.clip_rect(damage_rect);
+        // Apply scissor; the tessellation will only emit foreground geometry for
+        // the left half.  The advanced-blend pass reads the backdrop and composites
+        // the trimmed foreground.
+        painter.clip_rect(clip);
         painter.rect(
             full_bounds,
             &Paint {
@@ -596,7 +599,7 @@ mod gpu_tests {
         );
 
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("S8 Damage Straddle Encoder"),
+            label: Some("S8 Clip-rect foreground encoder"),
         });
         painter
             .render(
@@ -619,7 +622,8 @@ mod gpu_tests {
         )]
         let half_col = half_width as usize;
 
-        // Left half (inside scissor / damage): must be blended correctly.
+        // Left half (inside scissor): foreground was emitted here; the Multiply
+        // blend must have been applied correctly.
         for row in 1..(height - 1) {
             for col in 1..(half_col - 1) {
                 let idx = row * width + col;
@@ -631,28 +635,9 @@ mod gpu_tests {
                 );
             }
         }
-
-        // Right half (outside scissor / damage): must remain the original red.
-        // The blend pass should write transparent foreground there → backdrop
-        // passes through → red is preserved.
-        let expected_right = [
-            // premul of backdrop_color (opaque)
-            backdrop_color.r,
-            backdrop_color.g,
-            backdrop_color.b,
-            255,
-        ];
-        for row in 1..(height - 1) {
-            for col in (half_col + 1)..(width - 1) {
-                let idx = row * width + col;
-                assert_pixel_within_tolerance(
-                    &format!("S8 right(unchanged) row={row} col={col}"),
-                    pixels[idx],
-                    expected_right,
-                    tolerance,
-                );
-            }
-        }
+        // Right half is NOT asserted: its content depends on the backdrop-blend
+        // outcome for a transparent foreground, which is the stale-pixel hazard
+        // addressed by `force_full_repaint_next_frame` in `Renderer`.
     }
 
     // ── S9: SrcOver shape byte-identity ───────────────────────────────────────
@@ -765,5 +750,119 @@ mod gpu_tests {
                  (suggests draw silently produced nothing)"
             );
         }
+    }
+
+    // ── S11: Straddle detector — `has_advanced_shape_straddling` geometry ────────
+
+    /// S11a: An advanced shape (`DrawItem::AdvancedShape`) whose `device_bounds`
+    /// intersect the damage rect but are NOT fully contained by it (straddle) must
+    /// cause `has_advanced_shape_straddling` to return `true`.
+    ///
+    /// This is the primary discriminator test for the new production method.
+    /// It would not compile on `main` (the method is new) and it asserts real
+    /// straddle geometry — not a tautology.
+    #[test]
+    fn has_advanced_shape_straddling_detector_straddle_returns_true() {
+        let (device, queue) = acquire_test_device_and_queue();
+
+        // Shape spans the full surface (0..64, 0..64).
+        let full_bounds = full_surface_bounds();
+        // Damage is the left half (0..32, 0..64) — the shape straddles the right edge.
+        let half_width = SURFACE_WIDTH as f32 / 2.0;
+        let damage = Rect::from_ltrb(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(half_width),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        // Record a Multiply (advanced) rect that covers the full surface.
+        painter.rect(
+            full_bounds,
+            &Paint {
+                style: PaintStyle::Fill,
+                color: Color::rgba(100, 200, 50, 255),
+                blend_mode: BlendMode::Multiply,
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            painter.has_advanced_shape_straddling(damage),
+            "S11a: full-surface Multiply shape must straddle a left-half damage rect"
+        );
+    }
+
+    /// S11b: An advanced shape whose `device_bounds` are FULLY CONTAINED within
+    /// the damage rect must cause `has_advanced_shape_straddling` to return `false`.
+    ///
+    /// Fully-contained shapes cannot write stale pixels outside the damage: the
+    /// scissor already covers their entire extent.
+    #[test]
+    fn has_advanced_shape_straddling_detector_contained_returns_false() {
+        let (device, queue) = acquire_test_device_and_queue();
+
+        // Shape in the LEFT QUARTER (0..16, 0..64) — fully inside the left-half damage.
+        let quarter_width = SURFACE_WIDTH as f32 / 4.0;
+        let shape_bounds = Rect::from_ltrb(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(quarter_width),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+        // Damage is the left half (0..32, 0..64) — fully contains the shape.
+        let half_width = SURFACE_WIDTH as f32 / 2.0;
+        let damage = Rect::from_ltrb(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(half_width),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.rect(
+            shape_bounds,
+            &Paint {
+                style: PaintStyle::Fill,
+                color: Color::rgba(100, 200, 50, 255),
+                blend_mode: BlendMode::Multiply,
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            !painter.has_advanced_shape_straddling(damage),
+            "S11b: a shape fully within the damage rect must NOT be flagged as straddling"
+        );
+    }
+
+    /// S11c: A NON-advanced shape (SrcOver) whose `device_bounds` straddle the
+    /// damage rect must cause `has_advanced_shape_straddling` to return `false`.
+    ///
+    /// SrcOver shapes do not call `flush_advanced_layer` and therefore cannot
+    /// write stale pixels outside the scissor via the backdrop blend path.
+    #[test]
+    fn has_advanced_shape_straddling_detector_srcover_returns_false() {
+        let (device, queue) = acquire_test_device_and_queue();
+
+        // Full-surface SrcOver shape — straddles any sub-full damage rect.
+        let full_bounds = full_surface_bounds();
+        let half_width = SURFACE_WIDTH as f32 / 2.0;
+        let damage = Rect::from_ltrb(
+            Pixels(0.0),
+            Pixels(0.0),
+            Pixels(half_width),
+            Pixels(SURFACE_HEIGHT as f32),
+        );
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        // SrcOver (default) — this stays in a `DrawItem::Segment`, NOT AdvancedShape.
+        painter.rect(full_bounds, &Paint::fill(Color::rgba(100, 200, 50, 255)));
+
+        assert!(
+            !painter.has_advanced_shape_straddling(damage),
+            "S11c: a SrcOver shape must NOT be flagged as straddling (not an advanced blend)"
+        );
     }
 }


### PR DESCRIPTION
## What

A real damage-**completeness** bug: on PARTIAL damage, `clip_rect(damage)` clips an advanced (dst-read) shape/SSAA-path/`saveLayer`'s foreground to the damage rect, but `flush_advanced_layer` blends over the FULL `device_bounds` with `LoadOp::Load` + no scissor → the out-of-damage slice writes `blend(transparent, STALE prior-frame backdrop)`. A dst-read item's true dirty region is its full bounds; the partial damage rect under-covers it.

## Fix

After `render_layer_recursive`, if a partial-damage scissor was applied AND the recorded `draw_order` contains an advanced item whose `device_bounds` **straddle** the damage rect (intersect but not contained), set `Renderer.force_full_repaint_next_frame` → the next frame repaints fully and self-heals. Covers `DrawItem::AdvancedShape`, advanced `DrawItem::SsaaPath`, and advanced `DrawItem::OpacityLayer` (saveLayer); `Filter`/`OffscreenTexture` excluded (premultiplied SrcOver from their own offscreen — no surface dst-read).

1-frame self-heal (documented): partial damage is currently unused (callers use full repaint), so the transient is unobservable today; a this-frame re-record or a precomputed Scene "contains advanced blend" bit is the future upgrade if partial damage becomes hot.

## Also: a FALSE-GREEN test reshaped

ce-kieran found the existing `damage_straddle_advanced_shape_blended_correctly` (S8) **enshrined the bug** — it pre-painted the backdrop equal to the desired right-half so stale==intended, and its doc claimed the buggy behavior as a design guarantee. Reshaped to `advanced_shape_foreground_confined_by_clip_rect` asserting only the honest unit fact (foreground confined by the record-time scissor).

## Verification (ground-truthed locally)

- `cargo check -p flui-engine` (standalone default) + `--all-targets --features enable-wgpu-tests` + `cargo check --workspace --exclude flui-platform` = 0
- clippy both modes `-D warnings` = 0 · `cargo doc -D warnings` = 0 · fmt · typos · port-check = 0
- **readback** `cargo test -p flui-engine --features enable-wgpu-tests -- --test-threads 1` = **439 passed / 0 failed / 7 ignored** — detector tests S11a-f (shape/path/layer straddle→true, contained→false, SrcOver→false) + reshaped S8 green; all prior baselines green.

Design: chief-architect ACCEPTABLE (Option A — scout confirmed no cheap precomputed bit; per-frame DisplayList walk rejected; scissor-replay refactor rejected). Soundness: ce-kieran COMPLETE (flag-survival traced sound; predicate `is_advanced()` matches exactly the `flush_advanced_layer` set; detector tests non-vacuous).

First item of the post-audit "finish flui-engine" remaining-work list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)