### PR TITLE
fix(engine): single source of truth for W3C blend helpers + align clip_color epsilon

### DIFF
--- a/crates/flui-engine/CHANGELOG.md
+++ b/crates/flui-engine/CHANGELOG.md
@@ -54,6 +54,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Single source of truth for the W3C blend helpers + epsilon drift.** The
+  non-separable blend leaf helpers (`hard_light`/`lum`/`clip_color`/`set_lum`/
+  `sat`/`set_sat`) were duplicated across `mode.wgsl` and `advanced_blend.wgsl`,
+  and had drifted: `mode.wgsl`'s `clip_color` used `1e-7` where the CPU oracle
+  `Color::blend` + `advanced_blend.wgsl` use `f32::EPSILON`. Extracted them to one
+  `blend_helpers.wgsl`, prepended via `concat!(include_str!(…))` at both pipeline
+  sites, aligned the epsilon to the oracle. Adds a non-separable-on-translucent
+  GPU-vs-oracle test (MO8); the 433-test readback baseline is unchanged.
 - **~28 render-correctness bugs** surfaced by the wgpu-29 deep-audit rounds: sRGB
   encoding, group-opacity premultiplication, `ColorFilter` chroma, HiDPI offscreen
   (backdrop-filter + shader-mask resolved in device space), tessellation fill-rule /

--- a/crates/flui-engine/src/wgpu/advanced_blend/pipeline.rs
+++ b/crates/flui-engine/src/wgpu/advanced_blend/pipeline.rs
@@ -192,7 +192,18 @@ impl AdvancedBlendPipeline {
 
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Advanced Blend Shader"),
-            source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/advanced_blend.wgsl").into()),
+            // Prepend the shared leaf helpers (hard_light, lum, clip_color,
+            // set_lum, sat, set_sat) from blend_helpers.wgsl so naga sees one
+            // unified module.  A duplicate fn definition would cause a "redefined"
+            // error here, enforcing the single-source contract.
+            source: wgpu::ShaderSource::Wgsl(
+                concat!(
+                    include_str!("../shaders/blend_helpers.wgsl"),
+                    "\n\n",
+                    include_str!("../shaders/advanced_blend.wgsl"),
+                )
+                .into(),
+            ),
         });
 
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {

--- a/crates/flui-engine/src/wgpu/mode/pipeline.rs
+++ b/crates/flui-engine/src/wgpu/mode/pipeline.rs
@@ -147,7 +147,18 @@ impl ModePipeline {
 
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Mode Shader"),
-            source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/effects/mode.wgsl").into()),
+            // Prepend the shared leaf helpers (hard_light, lum, clip_color,
+            // set_lum, sat, set_sat) from blend_helpers.wgsl so naga sees one
+            // unified module.  A duplicate fn definition would cause a "redefined"
+            // error here, enforcing the single-source contract.
+            source: wgpu::ShaderSource::Wgsl(
+                concat!(
+                    include_str!("../shaders/blend_helpers.wgsl"),
+                    "\n\n",
+                    include_str!("../shaders/effects/mode.wgsl"),
+                )
+                .into(),
+            ),
         });
 
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {

--- a/crates/flui-engine/src/wgpu/mode_filter_tests.rs
+++ b/crates/flui-engine/src/wgpu/mode_filter_tests.rs
@@ -719,6 +719,113 @@ mod gpu_tests {
         );
     }
 
+    // ── MO8: Non-separable modes on translucent inputs ────────────────────────
+    //
+    // Regression lock for the single-source `blend_helpers.wgsl` epsilon fix.
+    //
+    // ## What this test covers
+    //
+    // All 4 non-separable modes (Hue, Saturation, Color, Luminosity) on a
+    // **translucent** filter-color input (alpha < 255) — a combination MO5
+    // (opaque Hue) and MO6 (translucent Luminosity only) did not cover. It
+    // locks the shared `blend_helpers.wgsl` non-separable math (`lum`, `sat`,
+    // `set_sat`, `set_lum`, `clip_color`) against the CPU oracle `Color::blend`
+    // per-pixel: any future drift in a shared helper shifts the GPU output
+    // relative to the oracle and fails this assertion.
+    //
+    // ## Epsilon note (what this test does NOT lock)
+    //
+    // The pre-fix `mode.wgsl` used `1e-7` in `clip_color` while the oracle and
+    // `advanced_blend.wgsl` use `f32::EPSILON` (1.1920929e-7). That drift is
+    // NOT regression-locked by a pixel test, and deliberately so: the epsilon
+    // guards (`abs(l-n) > eps` / `abs(x-l) > eps`) only matter when the OUTER
+    // `n < 0.0` / `x > 1.0` clamp branches fire, and even then the two epsilon
+    // values differ only across a ~2e-8-wide band — a sub-LSB effect no u8
+    // readback can distinguish. The epsilon is instead protected structurally
+    // by **single-sourcing**: `clip_color` now exists in exactly one place
+    // (`blend_helpers.wgsl`), verbatim-matched to the oracle, so the two copies
+    // can no longer diverge. (The clamp branches do not fire on the vector
+    // below — its channels stay in [0,1] — confirming the sub-LSB analysis.)
+    //
+    // ## Test vector design
+    //
+    // Filter (SRC): 70%-alpha warm grey-brown (r=180, g=170, b=165, a=178)
+    //   — translucent + low-saturation, exercising the `set_sat`/`set_lum`
+    //   path through `lum` and `clip_color` against a saturated backdrop.
+    //
+    // Backdrop (DST): opaque blue-green (r=30, g=120, b=100, a=255)
+    //   — high saturation, meaningful HSL interactions with the near-grey SRC.
+
+    /// MO8: All 4 non-separable modes (Hue/Saturation/Color/Luminosity) on a
+    /// translucent SRC, oracle-locked per-pixel.
+    ///
+    /// Regression lock for the shared `blend_helpers.wgsl` non-separable helper
+    /// math (`lum`/`sat`/`set_sat`/`set_lum`/`clip_color`) vs the CPU oracle —
+    /// NOT for the epsilon constant (sub-LSB; single-sourced — see the
+    /// module-level comment above).
+    #[test]
+    fn nonseparable_modes_translucent_match_oracle() {
+        let (device, queue) = acquire_test_device_and_queue();
+
+        // Translucent low-saturation SRC over a saturated opaque DST — drives the
+        // shared set_sat/set_lum/lum path for all four non-separable modes.
+        let filter_color = Color::rgba(180, 170, 165, 178);
+        // High-saturation opaque DST — provides non-trivial HSL interaction.
+        let layer_color = Color::rgba(30, 120, 100, 255);
+
+        let modes = [
+            (BlendMode::Hue, "MO8a Hue(near-grey-translucent, teal)"),
+            (
+                BlendMode::Saturation,
+                "MO8b Saturation(near-grey-translucent, teal)",
+            ),
+            (BlendMode::Color, "MO8c Color(near-grey-translucent, teal)"),
+            (
+                BlendMode::Luminosity,
+                "MO8d Luminosity(near-grey-translucent, teal)",
+            ),
+        ];
+
+        for (mode, label) in modes {
+            let (surface_tex, surface_view) = create_surface(&device);
+            clear_surface(
+                &device,
+                &queue,
+                &surface_view,
+                wgpu::Color {
+                    r: 0.0,
+                    g: 0.0,
+                    b: 0.0,
+                    a: 1.0,
+                },
+            );
+
+            let readback = render_with_mode_filter(
+                &device,
+                &queue,
+                &surface_tex,
+                &surface_view,
+                filter_color,
+                layer_color,
+                mode,
+            );
+
+            // Oracle (G1): same function as production blending.
+            let oracle = blend_mode_oracle(filter_color, layer_color, mode);
+
+            // Sanity: translucent SRC over opaque DST → output nearly opaque.
+            // α_out = SRC_a + DST_a·(1-SRC_a) = 178/255 + 1·(1-178/255) ≈ 1.0.
+            assert!(
+                oracle[3] > 240,
+                "{label}: oracle alpha should be ~255 for 70%-alpha SrcOver opaque, got {}",
+                oracle[3],
+            );
+
+            // GPU must match oracle within ±4 LSB (non-sep + translucent + HSL).
+            assert_interior_pixels_near(label, &readback, oracle, 4);
+        }
+    }
+
     // ── MO7: Pipeline construction test ───────────────────────────────────────
 
     /// MO7: `ModePipeline::new` must complete without a wgpu validation error.

--- a/crates/flui-engine/src/wgpu/shaders/advanced_blend.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/advanced_blend.wgsl
@@ -136,14 +136,13 @@ fn vs_main(@builtin(vertex_index) vi: u32) -> VsOutput {
     return out;
 }
 
-// ── Blend helpers (verbatim port of color.rs separable/nonseparable) ──────────
-
-fn hard_light(cb: f32, cs: f32) -> f32 {
-    if cs <= 0.5 {
-        return 2.0 * cb * cs;
-    }
-    return 1.0 - 2.0 * (1.0 - cb) * (1.0 - cs);
-}
+// ── Blend helpers ─────────────────────────────────────────────────────────────
+//
+// The 6 shared leaf helpers (hard_light, lum, clip_color, set_lum, sat,
+// set_sat) are defined in `blend_helpers.wgsl` and prepended to this module
+// by `advanced_blend/pipeline.rs` via `concat!(include_str!(...))`.  naga
+// sees one unified module — any duplicate definition would cause a "redefined"
+// error at `create_shader_module`.
 
 fn separable_blend(mode: u32, cb: f32, cs: f32) -> f32 {
     switch mode {
@@ -190,80 +189,6 @@ fn separable_blend(mode: u32, cb: f32, cs: f32) -> f32 {
         case 10u: { return cb + cs - 2.0 * cb * cs; }
         default: { return cs; }
     }
-}
-
-// Luminosity of an RGB triple (W3C Lum).
-fn lum(c: vec3<f32>) -> f32 {
-    return 0.3 * c.r + 0.59 * c.g + 0.11 * c.b;
-}
-
-// Clip an RGB triple back into [0,1] preserving luminosity (W3C ClipColor).
-// The epsilon guards avoid 0/0 when all channels are equal.
-fn clip_color(c: vec3<f32>) -> vec3<f32> {
-    let l = lum(c);
-    let n = min(min(c.r, c.g), c.b);
-    let x = max(max(c.r, c.g), c.b);
-    var out = c;
-    if n < 0.0 && abs(l - n) > 1.1920929e-7 {
-        out = l + (out - l) * l / (l - n);
-    }
-    if x > 1.0 && abs(x - l) > 1.1920929e-7 {
-        out = l + (out - l) * (1.0 - l) / (x - l);
-    }
-    return out;
-}
-
-// Shift an RGB triple to target luminosity (W3C SetLum).
-fn set_lum(c: vec3<f32>, target_lum: f32) -> vec3<f32> {
-    let d = target_lum - lum(c);
-    return clip_color(c + d);
-}
-
-// Saturation: max channel minus min channel (W3C Sat).
-fn sat(c: vec3<f32>) -> f32 {
-    return max(max(c.r, c.g), c.b) - min(min(c.r, c.g), c.b);
-}
-
-// Rescale RGB triple to target saturation keeping relative channel order
-// (W3C SetSat).  A flat triple (max == min) collapses to black.
-//
-// WGSL has no sort; we implement the sort-by-magnitude manually.
-// The triple has 6 orderings; we enumerate them as the index triple
-// (i_min, i_mid, i_max) by comparing all three pairs exactly once.
-fn set_sat(c: vec3<f32>, target_sat: f32) -> vec3<f32> {
-    // Extract channels into indexed array for permutation.
-    var ch = array<f32, 3>(c.r, c.g, c.b);
-
-    // Bubble-sort 3 elements ascending: O(3 comparisons), stable.
-    var tmp: f32;
-    if ch[0] > ch[1] { tmp = ch[0]; ch[0] = ch[1]; ch[1] = tmp; }
-    if ch[1] > ch[2] { tmp = ch[1]; ch[1] = ch[2]; ch[2] = tmp; }
-    if ch[0] > ch[1] { tmp = ch[0]; ch[0] = ch[1]; ch[1] = tmp; }
-    // ch[0]=min, ch[1]=mid, ch[2]=max — but these are VALUES not original indices.
-    // We need to map back to (r,g,b); find which original index maps where.
-    let c_min = ch[0];
-    let c_mid = ch[1];
-    let c_max = ch[2];
-
-    var out_ch = array<f32, 3>(0.0, 0.0, 0.0);
-    if c_max > c_min {
-        // Determine original index for each sorted slot.
-        // Priority: if two channels are equal we still assign each to a distinct slot.
-        // We use the same lexicographic tie-break as Rust's total_cmp on f32.
-        for (var slot = 0u; slot < 3u; slot++) {
-            let cv = array<f32, 3>(c.r, c.g, c.b)[slot];
-            // Assign to min/mid/max slot based on sorted value.
-            if cv == c_min {
-                out_ch[slot] = 0.0;
-            } else if cv == c_max {
-                out_ch[slot] = target_sat;
-            } else {
-                out_ch[slot] = (cv - c_min) * target_sat / (c_max - c_min);
-            }
-        }
-    }
-    // If c_max == c_min: all channels equal → out_ch stays 0 (flat/achromatic → black).
-    return vec3<f32>(out_ch[0], out_ch[1], out_ch[2]);
 }
 
 // Non-separable blend for Hue/Saturation/Color/Luminosity modes.

--- a/crates/flui-engine/src/wgpu/shaders/blend_helpers.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/blend_helpers.wgsl
@@ -1,0 +1,117 @@
+// blend_helpers.wgsl
+//
+// Shared W3C Compositing and Blending Level 1 leaf helpers used by both
+// `effects/mode.wgsl` and `advanced_blend.wgsl`.
+//
+// ## Single source of truth
+//
+// Both shaders concatenate this snippet at the top of their module (via
+// `concat!(include_str!("blend_helpers.wgsl"), "\n\n", include_str!("..."))`)
+// so naga sees one unified WGSL module.  Any duplicate fn definition would
+// cause a "redefined" error at `create_shader_module` — the concatenation
+// enforces that this file is the sole definition site.
+//
+// ## Correctness contract
+//
+// These helpers are a verbatim port of the corresponding private functions in
+// `flui-types/src/styling/color.rs` (lines 1112-1184).  Any divergence from
+// that CPU oracle is a correctness bug.  The epsilon `1.1920929e-7` is the
+// exact decimal representation of `f32::EPSILON` (2^-23 ≈ 1.1920929e-7) —
+// the same value the oracle uses in `clip_color`.
+//
+// ## What is NOT in this file
+//
+// Per-shader dispatch functions (`separable_blend` / `nonseparable_blend` and
+// any mode-index switch) are NOT shared: `mode.wgsl` encodes modes 15-29 and
+// `advanced_blend.wgsl` encodes modes 0-14.  Only the leaf helpers below are
+// identical between the two shaders and belong here.
+
+// ── Leaf helpers (verbatim port of color.rs) ─────────────────────────────────
+
+/// W3C `HardLight(cb, cs)`: multiply for a dark source, screen for a light one.
+/// Also the kernel of Overlay with arguments swapped.
+/// Mirrors `hard_light` in `flui-types/src/styling/color.rs:1114`.
+fn hard_light(cb: f32, cs: f32) -> f32 {
+    if cs <= 0.5 {
+        return 2.0 * cb * cs;
+    }
+    return 1.0 - 2.0 * (1.0 - cb) * (1.0 - cs);
+}
+
+/// Luminosity of an RGB triple (W3C `Lum`).
+/// Mirrors `lum` in `flui-types/src/styling/color.rs:1136`.
+fn lum(c: vec3<f32>) -> f32 {
+    return 0.3 * c.r + 0.59 * c.g + 0.11 * c.b;
+}
+
+/// Clip an RGB triple back into `[0, 1]` while preserving luminosity (W3C `ClipColor`).
+/// The epsilon `1.1920929e-7` = `f32::EPSILON` guards avoid 0/0 when all channels
+/// are equal (degenerate flat triple has nothing to scale).
+/// Mirrors `clip_color` in `flui-types/src/styling/color.rs:1143`.
+fn clip_color(c: vec3<f32>) -> vec3<f32> {
+    let l = lum(c);
+    let n = min(min(c.r, c.g), c.b);
+    let x = max(max(c.r, c.g), c.b);
+    var out = c;
+    if n < 0.0 && abs(l - n) > 1.1920929e-7 {
+        out = l + (out - l) * l / (l - n);
+    }
+    if x > 1.0 && abs(x - l) > 1.1920929e-7 {
+        out = l + (out - l) * (1.0 - l) / (x - l);
+    }
+    return out;
+}
+
+/// Shift an RGB triple to the target luminosity `l` (W3C `SetLum`).
+/// Mirrors `set_lum` in `flui-types/src/styling/color.rs:1162`.
+fn set_lum(c: vec3<f32>, target_lum: f32) -> vec3<f32> {
+    let d = target_lum - lum(c);
+    return clip_color(c + d);
+}
+
+/// Saturation of an RGB triple (W3C `Sat`): max channel minus min channel.
+/// Mirrors `sat` in `flui-types/src/styling/color.rs:1168`.
+fn sat(c: vec3<f32>) -> f32 {
+    return max(max(c.r, c.g), c.b) - min(min(c.r, c.g), c.b);
+}
+
+/// Rescale an RGB triple to the target saturation `s` (W3C `SetSat`), keeping
+/// the relative channel ordering.  A flat triple (max == min) collapses to black.
+///
+/// Implementation: bubble-sort the 3 channels to find min/mid/max values, then
+/// map each original channel back to its sorted slot using value equality.
+/// Algorithmically equivalent to the `idx.sort_by` approach in
+/// `flui-types/src/styling/color.rs:1174`.
+///
+/// WGSL has no sort primitive; this uses 3 swap comparisons (O(3), stable).
+fn set_sat(c: vec3<f32>, target_sat: f32) -> vec3<f32> {
+    // Extract channels into indexed array for permutation.
+    var ch = array<f32, 3>(c.r, c.g, c.b);
+
+    // Bubble-sort 3 elements ascending: O(3 comparisons), stable.
+    var tmp: f32;
+    if ch[0] > ch[1] { tmp = ch[0]; ch[0] = ch[1]; ch[1] = tmp; }
+    if ch[1] > ch[2] { tmp = ch[1]; ch[1] = ch[2]; ch[2] = tmp; }
+    if ch[0] > ch[1] { tmp = ch[0]; ch[0] = ch[1]; ch[1] = tmp; }
+    // ch[0]=min, ch[1]=mid, ch[2]=max — values only; original index unknown here.
+    let c_min = ch[0];
+    let c_mid = ch[1];
+    let c_max = ch[2];
+
+    var out_ch = array<f32, 3>(0.0, 0.0, 0.0);
+    if c_max > c_min {
+        // Map each original channel back to its sorted role by value comparison.
+        for (var slot = 0u; slot < 3u; slot++) {
+            let cv = array<f32, 3>(c.r, c.g, c.b)[slot];
+            if cv == c_min {
+                out_ch[slot] = 0.0;
+            } else if cv == c_max {
+                out_ch[slot] = target_sat;
+            } else {
+                out_ch[slot] = (cv - c_min) * target_sat / (c_max - c_min);
+            }
+        }
+    }
+    // If c_max == c_min: all channels equal → out_ch stays 0 (achromatic → black).
+    return vec3<f32>(out_ch[0], out_ch[1], out_ch[2]);
+}

--- a/crates/flui-engine/src/wgpu/shaders/effects/mode.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/effects/mode.wgsl
@@ -101,18 +101,15 @@ fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
 
 // ─── Blend helpers ─────────────────────────────────────────────────────────────
 //
+// The 6 shared leaf helpers (hard_light, lum, clip_color, set_lum, sat,
+// set_sat) are defined in `blend_helpers.wgsl` and prepended to this module
+// by `mode/pipeline.rs` via `concat!(include_str!(...))`.  naga sees one
+// unified module — any duplicate definition would cause a "redefined" error
+// at `create_shader_module`.
+//
 // All helpers mirror the corresponding private functions in
 // `flui_types::styling::color`.  SRC = filter color, DST = layer pixel.
 // Both operate on straight sRGB [0,1] values.
-
-/// W3C `HardLight(cb, cs)`: cs is source (SRC), cb is backdrop (DST).
-fn hard_light(cb: f32, cs: f32) -> f32 {
-    if cs <= 0.5 {
-        return 2.0 * cb * cs;
-    } else {
-        return 1.0 - 2.0 * (1.0 - cb) * (1.0 - cs);
-    }
-}
 
 /// W3C separable blend function B(cb, cs), one channel.
 /// cb = backdrop (DST straight), cs = source (SRC straight).
@@ -162,82 +159,6 @@ fn separable_blend(mode: u32, cb: f32, cs: f32) -> f32 {
     if mode == 25u { return cb * cs; }
     // Fallback (should not be reached for advanced modes)
     return cs;
-}
-
-// ─── Non-separable HSL blend helpers ──────────────────────────────────────────
-//
-// Mirrors `lum`, `sat`, `set_sat`, `set_lum`, `clip_color`, `nonseparable_blend`
-// from `flui_types::styling::color`.
-
-fn lum(c: vec3<f32>) -> f32 {
-    return 0.3 * c.x + 0.59 * c.y + 0.11 * c.z;
-}
-
-fn clip_color(c: vec3<f32>) -> vec3<f32> {
-    let l = lum(c);
-    let n = min(min(c.x, c.y), c.z);
-    let x = max(max(c.x, c.y), c.z);
-    var out = c;
-    if n < 0.0 && abs(l - n) > 1e-7 {
-        out = l + (out - l) * l / (l - n);
-    }
-    if x > 1.0 && abs(x - l) > 1e-7 {
-        out = l + (out - l) * (1.0 - l) / (x - l);
-    }
-    return out;
-}
-
-fn set_lum(c: vec3<f32>, l: f32) -> vec3<f32> {
-    let d = l - lum(c);
-    return clip_color(c + d);
-}
-
-fn sat(c: vec3<f32>) -> f32 {
-    return max(max(c.x, c.y), c.z) - min(min(c.x, c.y), c.z);
-}
-
-/// Rescale an RGB triple to target saturation `s`, preserving relative channel order.
-/// Mirrors `set_sat` in `flui_types::styling::color`.
-fn set_sat(c: vec3<f32>, s: f32) -> vec3<f32> {
-    // Find min/mid/max channel indices and values.
-    // We handle all 6 orderings explicitly to avoid indexing with a dynamic integer.
-    var c_min: f32;
-    var c_mid: f32;
-    var c_max: f32;
-    var idx_min: u32;
-    var idx_mid: u32;
-    var idx_max: u32;
-
-    let cx = c.x;
-    let cy = c.y;
-    let cz = c.z;
-
-    // Sort 3 values to find min/mid/max with their indices.
-    if cx <= cy && cx <= cz {
-        idx_min = 0u;
-        c_min   = cx;
-        if cy <= cz { idx_mid = 1u; c_mid = cy; idx_max = 2u; c_max = cz; }
-        else        { idx_mid = 2u; c_mid = cz; idx_max = 1u; c_max = cy; }
-    } else if cy <= cx && cy <= cz {
-        idx_min = 1u;
-        c_min   = cy;
-        if cx <= cz { idx_mid = 0u; c_mid = cx; idx_max = 2u; c_max = cz; }
-        else        { idx_mid = 2u; c_mid = cz; idx_max = 0u; c_max = cx; }
-    } else {
-        idx_min = 2u;
-        c_min   = cz;
-        if cx <= cy { idx_mid = 0u; c_mid = cx; idx_max = 1u; c_max = cy; }
-        else        { idx_mid = 1u; c_mid = cy; idx_max = 0u; c_max = cx; }
-    }
-
-    var out = vec3<f32>(0.0);
-    if c_max > c_min {
-        let mid_val = (c_mid - c_min) * s / (c_max - c_min);
-        // Write mid and max channels; min stays 0.
-        out = select(out, vec3<f32>(mid_val), vec3<bool>(idx_mid == 0u, idx_mid == 1u, idx_mid == 2u));
-        out = select(out, vec3<f32>(s),       vec3<bool>(idx_max == 0u, idx_max == 1u, idx_max == 2u));
-    }
-    return out;
 }
 
 /// W3C non-separable blend (Hue/Saturation/Color/Luminosity).


### PR DESCRIPTION
## What

The W3C non-separable blend leaf helpers (`hard_light`/`lum`/`clip_color`/`set_lum`/`sat`/`set_sat`) were **duplicated verbatim** across `mode.wgsl` and `advanced_blend.wgsl`, and the duplication had let them **drift**: `mode.wgsl`'s `clip_color` used `1e-7` where the CPU oracle `Color::blend` + `advanced_blend.wgsl` use `f32::EPSILON` (1.1920929e-7) — a "verbatim port" contract violation (GLM audit #4, independently confirmed).

## Fix

- Extract the 6 leaf helpers into one **`shaders/blend_helpers.wgsl`** (epsilon aligned to the oracle), delete the inline copies from both shaders, prepend via `concat!(include_str!(blend_helpers), "\n\n", include_str!(shader))` at the two pipeline sites. Per-shader dispatch (`separable_blend`/`nonseparable_blend`, different mode-index encodings) stays inline.
- `set_sat` unified on `advanced_blend`'s impl — **ce-kieran proved it behaviorally equivalent to the oracle across the full domain** (exhaustive tie-grid + 200k fuzz, algebraic reason), and the full readback confirms zero pixel shift in either shader.
- Adds **MO8** (`nonseparable_modes_translucent_match_oracle`): the 4 non-separable modes on a translucent SRC vs `Color::blend` — closing a coverage gap (MO5 opaque-only, MO6 Luminosity-only) and locking the shared helper math. The epsilon itself is **sub-LSB** and is protected structurally by single-sourcing, not by a pixel test — documented honestly in the test (ce-kieran caught + I corrected an earlier overclaim that MO8 "locks the epsilon").

## Verification (ground-truthed locally)

`cargo check -p flui-engine` (standalone default) + clippy both modes `-D warnings` + `cargo doc -D warnings` + fmt + typos + port-check = 0. **readback 434/0** (433 baseline incl. all mode/advanced_blend/layer_blend + MO8). Scope: only the 6 shader/pipeline/test files (no error.rs/renderer.rs — a parallel worktree owns error-model). Soundness: ce-kieran **COMPLETE** (set_sat equivalence proven against the oracle source, not just the green suite).

GLM-audit item #4. Follow-up (tiny, tracked): a CPU unit test for `set_sat` tie-handling in `color.rs` to self-document the value-vs-index invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)