### PR TITLE
chore(engine): Cargo/lint hygiene batch (GLM audit #9 + theme 8)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,13 +129,19 @@ arboard = "3.4"
 # TODO: Re-enable "webp" feature when image-rs/image-webp#102 is fixed upstream
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif"] }
 
+# === Engine/geometry shared math dependencies ===
+# glam: SIMD GPU math used by flui-engine (serde+bytemuck features) and
+# flui-geometry (bytemuck+mint features). The workspace entry carries the common
+# base features; each crate adds its own extras via per-crate `features = [...]`.
+glam = { version = "0.33", features = ["bytemuck"] }
+# bytemuck: zero-copy Pod/Zeroable derives shared by flui-engine and flui-geometry.
+bytemuck = { version = "1.24", features = ["derive"] }
+
 # === Engine-specific dependencies (NOT in workspace) ===
 # These are ONLY used in flui-engine:
-# - glam (GPU math)
 # - glyphon, cosmic-text (text rendering)
 # - lyon (tessellation)
 # - guillotiere (texture atlas)
-# - bytemuck
 
 # CACHING - Used by flui_core and flui-assets
 moka = { version = "0.12", features = ["future"] }

--- a/crates/flui-engine/CHANGELOG.md
+++ b/crates/flui-engine/CHANGELOG.md
@@ -51,6 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ColorFilter`; `ColorFilter::Matrix` wraps the `ColorMatrix` newtype and `ColorFilter`
   is `#[non_exhaustive]`; `ColorMatrix` is now `Copy`. *(breaking — internal signatures
   only, no serialized-format change)* (#277)
+- **Hygiene:** `glam`/`bytemuck` pinned once in `[workspace.dependencies]`;
+  `GpuFrameProfile`/`PassTiming` are `#[non_exhaustive]` (future telemetry fields stay
+  additive); `wgpu-profiler` `compile_error!`-guarded on wasm32; `docs.rs` all-features
+  metadata + `readme`; `#[allow(unsafe_code)]` → `#[expect(…)]` in `buffer_pool`.
 
 ### Fixed
 

--- a/crates/flui-engine/Cargo.toml
+++ b/crates/flui-engine/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 description = "GPU-accelerated rendering engine for FLUI using wgpu"
 keywords = ["rendering", "gpu", "wgpu", "ui", "graphics"]
 categories = ["rendering::engine", "graphics", "gui"]
+readme = "README.md"
 
 [features]
 default = ["wgpu-backend", "images"]
@@ -50,13 +51,13 @@ flui-assets = { path = "../flui-assets", optional = true }
 wgpu = { workspace = true, default-features = false, optional = true }
 raw-window-handle = "0.6"
 glyphon = { version = "0.11", optional = true }
-bytemuck = { version = "1.24", features = ["derive"] }
+bytemuck = { workspace = true }
 
 # Vector graphics tessellation
 lyon = "1.0.16"
 
-# Math for GPU rendering
-glam = { version = "0.33", features = ["serde", "bytemuck"] }
+# Math for GPU rendering — workspace base has bytemuck; add serde here for GPU struct serialization
+glam = { workspace = true, features = ["serde"] }
 
 # === Utilities ===
 pollster = { workspace = true }
@@ -109,3 +110,7 @@ harness = false
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/flui-engine/src/lib.rs
+++ b/crates/flui-engine/src/lib.rs
@@ -74,6 +74,14 @@ compile_error!(
      — see flui-engine Cargo.toml [target.wasm32] note"
 );
 
+// wgpu-profiler 0.27 has no wasm32 support; reject the combination at compile
+// time so a downstream consumer cannot accidentally enable both.
+#[cfg(all(target_arch = "wasm32", feature = "gpu-profiler"))]
+compile_error!(
+    "the `gpu-profiler` feature (wgpu-profiler 0.27) is not supported on wasm32; \
+     build without it"
+);
+
 // ============================================================================
 // ABSTRACT LAYER (backend-agnostic)
 // ============================================================================

--- a/crates/flui-engine/src/wgpu/buffer_pool.rs
+++ b/crates/flui-engine/src/wgpu/buffer_pool.rs
@@ -219,7 +219,10 @@ impl BufferPool {
     /// - The two Vec fields are disjoint memory regions
     /// - The statistics counters are simple increment-only values
     /// - No reallocation of `vertex_buffers` occurs during the index buffer call
-    #[allow(unsafe_code)]
+    #[expect(
+        unsafe_code,
+        reason = "disjoint-field &mut borrow of vertex+index buffers via raw pointers; see SAFETY note"
+    )]
     pub fn get_vertex_and_index_buffers(
         &mut self,
         device: &Device,

--- a/crates/flui-engine/src/wgpu/profiler.rs
+++ b/crates/flui-engine/src/wgpu/profiler.rs
@@ -41,6 +41,7 @@ use flui_foundation::{Diagnosticable, DiagnosticsBuilder};
 ///
 /// Mapped from `wgpu_profiler::GpuTimerQueryResult`; stored in [`GpuFrameProfile`]
 /// after each completed frame. All times are in milliseconds.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PassTiming {
     /// Human-readable label matching the scope label passed to the profiler.
@@ -61,6 +62,7 @@ pub struct PassTiming {
 /// `gpu-profiler` feature) when a frame's queries have resolved. `None` means
 /// no frame has completed yet (the profiler needs `max_num_pending_frames`
 /// frames to warm up).
+#[non_exhaustive]
 #[derive(Debug, Clone, Default)]
 pub struct GpuFrameProfile {
     /// Per-pass timing records, in submission order.

--- a/crates/flui-geometry/Cargo.toml
+++ b/crates/flui-geometry/Cargo.toml
@@ -57,10 +57,11 @@ serde = { workspace = true, optional = true }
 # Linear-algebra backend (Option D, N-geom PR 2): glam provides SIMD-by-default
 # matrix/vector math + `bytemuck` Pod derives + the `mint` interop cascade.
 # Non-optional — Matrix4 (and, in later PR-2 steps, Vec2/Transform) delegate to it.
-glam = { version = "0.33", features = ["bytemuck", "mint"] }
+# Workspace base has bytemuck; add mint here for the interop cascade.
+glam = { workspace = true, features = ["mint"] }
 
 # Pod/Zeroable derives for zero-copy GPU upload (Matrix4 + future vertex structs).
-bytemuck = { version = "1", features = ["derive"] }
+bytemuck = { workspace = true }
 
 # kurbo: f64 Bézier/curve math for the painting layer. The bridge
 # (src/bridges/kurbo.rs) is gated behind `feature = "kurbo"` (PR 3, U8).


### PR DESCRIPTION
## What

A contained, no-behavior-change hygiene batch from the GLM 5.2 audit (#9 + theme 8). **Scout-verified** each item against current code first — **3 GLM findings were refuted as stale/intentional and excluded** (`deny.toml` wildcards = documented workspace policy; the `wgpu`-namespace re-exports = correct lib.rs↔wgpu/* layering; `DebugBackend` cfg-gating = already idiomatic). The `pub mod`→`pub(crate)` demotion is **deferred** pending api-design-lead (the modules carry documented forward-infra).

## Changes
- **`glam` + `bytemuck` → `[workspace.dependencies]`** (one pin); `flui-engine` + `flui-geometry` use `.workspace = true` with per-crate feature add-ons (engine `serde`, geometry `mint`). Resolved feature sets verified **unchanged** via `cargo tree` (no silent feature drop).
- **`GpuFrameProfile` + `PassTiming` → `#[non_exhaustive]`** (future telemetry fields stay additive; zero external constructors today).
- **`wgpu-profiler` `compile_error!`-guarded on wasm32** (mirrors the existing atomics guard; 0.27 has no wasm support).
- **`[package.metadata.docs.rs] all-features` + `readme = "README.md"`** on flui-engine (mirrors flui-geometry).
- **`#[allow(unsafe_code)]` → `#[expect(unsafe_code, reason=…)]`** in `buffer_pool` (self-cleans if the unsafe is ever removed).

## Verification (ground-truthed locally)
`cargo check -p flui-engine` (standalone default) + `cargo check --workspace --exclude flui-platform` + clippy both modes `-D warnings` + `cargo doc -D warnings` + `cargo test -p flui-engine --lib` (204/204) + fmt + typos + port-check = all clean. `cargo tree` confirms glam features intact (engine serde+bytemuck, geometry mint+bytemuck). Scope: only root `Cargo.toml`, the two crate `Cargo.toml`s, `lib.rs`, `buffer_pool.rs`, `profiler.rs` — no error.rs/text.rs/renderer.rs/flui-app (parallel error-model worktree untouched).

Part of systematically working the GLM audit backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)