### PR TITLE
refactor(engine): own OffscreenRenderer directly; Backend<'frame> borrows it (drop Arc<Mutex>)

### DIFF
--- a/crates/flui-engine/src/wgpu/backend.rs
+++ b/crates/flui-engine/src/wgpu/backend.rs
@@ -81,7 +81,7 @@ fn build_gradient_stops(
 #[allow(missing_debug_implementations)]
 pub struct Backend<'frame> {
     painter: WgpuPainter,
-    offscreen: Option<Arc<parking_lot::Mutex<super::offscreen::OffscreenRenderer>>>,
+    offscreen: Option<&'frame mut super::offscreen::OffscreenRenderer>,
     /// Cached offscreen painter reused across shader mask invocations.
     /// Lazily created on first use, resized when dimensions change.
     offscreen_painter: Option<WgpuPainter>,
@@ -153,7 +153,7 @@ impl<'frame> Backend<'frame> {
     /// Create a new Backend with the given painter and offscreen renderer.
     pub fn with_offscreen(
         painter: WgpuPainter,
-        offscreen: Arc<parking_lot::Mutex<super::offscreen::OffscreenRenderer>>,
+        offscreen: &'frame mut super::offscreen::OffscreenRenderer,
     ) -> Self {
         Self {
             painter,
@@ -185,11 +185,9 @@ impl<'frame> Backend<'frame> {
         self.surface_texture = Some(texture);
     }
 
-    /// Access the offscreen renderer (for shader mask, backdrop filter).
-    pub fn offscreen(
-        &self,
-    ) -> Option<&Arc<parking_lot::Mutex<super::offscreen::OffscreenRenderer>>> {
-        self.offscreen.as_ref()
+    /// Access the offscreen renderer mutably (for shader mask, backdrop filter).
+    pub fn offscreen_mut(&mut self) -> Option<&mut super::offscreen::OffscreenRenderer> {
+        self.offscreen.as_deref_mut()
     }
 
     /// Get a reference to the underlying painter.
@@ -204,7 +202,8 @@ impl<'frame> Backend<'frame> {
 
     /// Consume the renderer and return the underlying painter.
     ///
-    /// The offscreen `Arc` is dropped here; ref-counting keeps it alive in Renderer.
+    /// The borrowed offscreen reference is released here; `Renderer` retains
+    /// direct ownership of its `OffscreenRenderer`.
     ///
     /// Cycle 4 wave 5 E-13: flushes any active lazy-pop transform
     /// first so the returned painter is balanced -- callers reuse
@@ -650,7 +649,10 @@ impl CommandRenderer for Backend<'_> {
         self.flush_active_transform();
 
         // Try GPU shader mask pipeline
-        if let Some(offscreen_arc) = self.offscreen.clone() {
+        if self.offscreen.is_some() {
+            // SAFETY of subsequent `expect` calls: `is_some()` was true above; each
+            // `as_deref_mut()` is a separate sequential borrow that does not overlap
+            // with the painter borrows interleaved between them.
             // The live device-pixel ratio rides in the painter's current
             // transform: the `RenderView` root pushes `scale(dpr)` and the paint
             // walk accumulates it into the CTM. The `_transform` argument is
@@ -679,7 +681,10 @@ impl CommandRenderer for Backend<'_> {
 
             // Step 1: Get GPU resources from offscreen renderer
             let (device, queue, format, child_tex) = {
-                let offscreen = offscreen_arc.lock();
+                let offscreen = self
+                    .offscreen
+                    .as_deref_mut()
+                    .expect("checked is_some above");
                 let device = Arc::clone(offscreen.device());
                 let queue = Arc::clone(offscreen.queue());
                 let format = offscreen.surface_format();
@@ -688,7 +693,6 @@ impl CommandRenderer for Backend<'_> {
                     .acquire(dev_width, dev_height, format);
                 (device, queue, format, child_tex)
             };
-            // Lock released here
 
             // Step 2: Get or create cached offscreen painter (avoids per-call allocation)
             // Ensure the cache is populated (creates or resizes as needed), then take
@@ -773,7 +777,10 @@ impl CommandRenderer for Backend<'_> {
             // gradient-endpoint normalization (scale-invariant) lands correctly.
             let result_size = Size::new(Pixels(dev_width as f32), Pixels(dev_height as f32));
             let masked_texture = {
-                let mut offscreen = offscreen_arc.lock();
+                let offscreen = self
+                    .offscreen
+                    .as_deref_mut()
+                    .expect("checked is_some above");
                 let result = offscreen.render_masked(
                     bounds,
                     result_size,
@@ -1071,13 +1078,13 @@ impl CommandRenderer for Backend<'_> {
             }
         };
 
-        let Some(offscreen_arc) = self.offscreen.clone() else {
+        if self.offscreen.is_none() {
             tracing::warn!(
                 "Backdrop filter: no OffscreenRenderer in DisplayList path; passthrough"
             );
             passthrough(self);
             return;
-        };
+        }
 
         let (Some(surface_view), Some(surface_texture)) = (self.surface_view, self.surface_texture)
         else {
@@ -1090,10 +1097,13 @@ impl CommandRenderer for Backend<'_> {
             return;
         };
 
-        // Snapshot device/queue/format under a short lock; offscreen
-        // mutation happens later through `render_blur`.
+        // Snapshot device/queue/format from offscreen; mutation happens later
+        // via separate sequential borrows for `texture_pool` and `render_blur`.
         let (device, queue, format) = {
-            let off = offscreen_arc.lock();
+            let off = self
+                .offscreen
+                .as_deref_mut()
+                .expect("checked is_some above");
             (
                 Arc::clone(off.device()),
                 Arc::clone(off.queue()),
@@ -1167,10 +1177,12 @@ impl CommandRenderer for Backend<'_> {
         // blur-input. Acquired from offscreen's texture pool so the
         // allocation amortises across frames (Path A acquires the
         // same way).
-        let blur_input = {
-            let offscreen = offscreen_arc.lock();
-            offscreen.texture_pool().acquire(w, h, format)
-        };
+        let blur_input = self
+            .offscreen
+            .as_deref_mut()
+            .expect("checked is_some above")
+            .texture_pool()
+            .acquire(w, h, format);
 
         flush_encoder.copy_texture_to_texture(
             wgpu::TexelCopyTextureInfo {
@@ -1194,10 +1206,11 @@ impl CommandRenderer for Backend<'_> {
         queue.submit(std::iter::once(flush_encoder.finish()));
 
         // Stage 4: Dual Kawase blur on the offscreen renderer.
-        let blurred = {
-            let mut offscreen = offscreen_arc.lock();
-            offscreen.render_blur(&blur_input, sigma)
-        };
+        let blurred = self
+            .offscreen
+            .as_deref_mut()
+            .expect("checked is_some above")
+            .render_blur(&blur_input, sigma);
 
         // Stage 5: queue blurred result for compositing on next painter
         // flush. The blurred texture is laid down at the same
@@ -1825,18 +1838,14 @@ mod tests {
 
         let format = wgpu::TextureFormat::Bgra8Unorm;
 
-        let offscreen = Arc::new(parking_lot::Mutex::new(OffscreenRenderer::new(
-            Arc::clone(&device),
-            Arc::clone(&queue),
-            format,
-        )));
+        let mut offscreen = OffscreenRenderer::new(Arc::clone(&device), Arc::clone(&queue), format);
         let painter = WgpuPainter::with_shared_device(
             Arc::clone(&device),
             Arc::clone(&queue),
             format,
             (800, 800),
         );
-        let mut backend = Backend::with_offscreen(painter, Arc::clone(&offscreen));
+        let mut backend = Backend::with_offscreen(painter, &mut offscreen);
 
         // Simulate the `RenderView` DPR root transform on the live CTM.
         backend.painter_mut().scale(2.0, 2.0);
@@ -1915,18 +1924,14 @@ mod tests {
 
         let format = wgpu::TextureFormat::Bgra8Unorm;
 
-        let offscreen = Arc::new(parking_lot::Mutex::new(OffscreenRenderer::new(
-            Arc::clone(&device),
-            Arc::clone(&queue),
-            format,
-        )));
+        let mut offscreen = OffscreenRenderer::new(Arc::clone(&device), Arc::clone(&queue), format);
         let painter = WgpuPainter::with_shared_device(
             Arc::clone(&device),
             Arc::clone(&queue),
             format,
             (800, 800),
         );
-        let mut backend = Backend::with_offscreen(painter, Arc::clone(&offscreen));
+        let mut backend = Backend::with_offscreen(painter, &mut offscreen);
 
         // Simulate DPR=2 on the live CTM.
         backend.painter_mut().scale(2.0, 2.0);
@@ -2025,18 +2030,14 @@ mod tests {
 
         let format = wgpu::TextureFormat::Bgra8Unorm;
 
-        let offscreen = Arc::new(parking_lot::Mutex::new(OffscreenRenderer::new(
-            Arc::clone(&device),
-            Arc::clone(&queue),
-            format,
-        )));
+        let mut offscreen = OffscreenRenderer::new(Arc::clone(&device), Arc::clone(&queue), format);
         let painter = WgpuPainter::with_shared_device(
             Arc::clone(&device),
             Arc::clone(&queue),
             format,
             (800, 800),
         );
-        let mut backend = Backend::with_offscreen(painter, Arc::clone(&offscreen));
+        let mut backend = Backend::with_offscreen(painter, &mut offscreen);
 
         // Step 1: push the DPR root scale(2) into the main painter CTM — this
         // happens before any command dispatch in a real frame.
@@ -2136,18 +2137,14 @@ mod tests {
         let format = wgpu::TextureFormat::Rgba8Unorm;
         let bounds = Rect::from_xywh(Pixels(0.0), Pixels(0.0), Pixels(W as f32), Pixels(H as f32));
 
-        let offscreen = Arc::new(parking_lot::Mutex::new(OffscreenRenderer::new(
-            Arc::clone(&device),
-            Arc::clone(&queue),
-            format,
-        )));
+        let mut offscreen = OffscreenRenderer::new(Arc::clone(&device), Arc::clone(&queue), format);
         let painter = WgpuPainter::with_shared_device(
             Arc::clone(&device),
             Arc::clone(&queue),
             format,
             (W, H),
         );
-        let mut backend = Backend::with_offscreen(painter, Arc::clone(&offscreen));
+        let mut backend = Backend::with_offscreen(painter, &mut offscreen);
 
         // Build child display list:
         //   Step 1 — opaque blue rect (SrcOver): establishes child backdrop.

--- a/crates/flui-engine/src/wgpu/renderer.rs
+++ b/crates/flui-engine/src/wgpu/renderer.rs
@@ -166,7 +166,7 @@ struct WindowedGpuStack {
     config: wgpu::SurfaceConfiguration,
     capabilities: GpuCapabilities,
     painter: super::painter::WgpuPainter,
-    offscreen: Arc<parking_lot::Mutex<super::offscreen::OffscreenRenderer>>,
+    offscreen: super::offscreen::OffscreenRenderer,
     supports_copy_src: bool,
     device_lost: Arc<std::sync::atomic::AtomicBool>,
     #[cfg(feature = "gpu-profiler")]
@@ -189,7 +189,7 @@ pub struct Renderer {
     config: Option<wgpu::SurfaceConfiguration>,
     capabilities: GpuCapabilities,
     painter: Option<super::painter::WgpuPainter>,
-    offscreen: Option<Arc<parking_lot::Mutex<super::offscreen::OffscreenRenderer>>>,
+    offscreen: Option<super::offscreen::OffscreenRenderer>,
     /// Whether the surface supports COPY_SRC (for mid-frame texture copies)
     supports_copy_src: bool,
     /// Set by the device-lost callback; checked at frame start to trigger
@@ -478,7 +478,6 @@ impl Renderer {
             Arc::clone(&queue),
             surface_format,
         );
-        let offscreen = Arc::new(parking_lot::Mutex::new(offscreen));
 
         // Create the GPU profiler if the feature is enabled AND the adapter
         // exposes TIMESTAMP_QUERY. A creation failure is non-fatal — profiling
@@ -1177,16 +1176,16 @@ impl Renderer {
         // it satisfies every downstream usage without extra flags.
         let intermediate_texture_slot: Option<super::texture_pool::PooledTexture> =
             if intermediate_active {
-                if let Some(offscreen_arc) = self.offscreen.as_ref() {
+                if let Some(offscreen) = self.offscreen.as_mut() {
                     let (surface_w, surface_h) = self
                         .config
                         .as_ref()
                         .map_or((800u32, 600u32), |c| (c.width, c.height));
-                    Some(offscreen_arc.lock().texture_pool().acquire(
-                        surface_w,
-                        surface_h,
-                        surface_format,
-                    ))
+                    Some(
+                        offscreen
+                            .texture_pool()
+                            .acquire(surface_w, surface_h, surface_format),
+                    )
                 } else {
                     // No offscreen renderer — cannot allocate intermediate.
                     // Fall back gracefully (direct path, no advanced blend).
@@ -1286,8 +1285,8 @@ impl Renderer {
         if scene.has_content()
             && let Some(painter) = self.painter.take()
         {
-            let mut backend = if let Some(ref offscreen) = self.offscreen {
-                Backend::with_offscreen(painter, Arc::clone(offscreen))
+            let mut backend = if let Some(ref mut offscreen) = self.offscreen {
+                Backend::with_offscreen(painter, offscreen)
             } else {
                 Backend::new(painter)
             };
@@ -1439,12 +1438,10 @@ impl Renderer {
         // back to the pool when `intermediate_texture_slot` drops at the end of
         // this function.
         if effective_intermediate_active
-            && let (Some(offscreen_arc), Some(slot)) =
-                (self.offscreen.as_ref(), intermediate_texture_slot.as_ref())
+            && let (Some(offscreen), Some(slot)) =
+                (self.offscreen.as_mut(), intermediate_texture_slot.as_ref())
         {
-            offscreen_arc
-                .lock()
-                .blit_to_surface(slot.texture(), &view, surface_format);
+            offscreen.blit_to_surface(slot.texture(), &view, surface_format);
         }
 
         output.present();
@@ -1677,11 +1674,12 @@ impl Renderer {
             tracing::error!("Backdrop flush failed: {}", e);
         }
 
-        if let Some(offscreen_arc) = backend.offscreen().cloned() {
-            let blur_input = {
-                let offscreen = offscreen_arc.lock();
-                offscreen.texture_pool().acquire(w, h, ctx.surface_format)
-            };
+        if backend.offscreen_mut().is_some() {
+            let blur_input = backend
+                .offscreen_mut()
+                .expect("checked is_some above")
+                .texture_pool()
+                .acquire(w, h, ctx.surface_format);
 
             // 3. Copy the device-space region from the surface to the blur input.
             flush_encoder.copy_texture_to_texture(
@@ -1706,10 +1704,10 @@ impl Renderer {
             ctx.queue.submit(std::iter::once(flush_encoder.finish()));
 
             // 4. Apply Dual Kawase blur
-            let blurred = {
-                let mut offscreen = offscreen_arc.lock();
-                offscreen.render_blur(&blur_input, sigma)
-            };
+            let blurred = backend
+                .offscreen_mut()
+                .expect("checked is_some above")
+                .render_blur(&blur_input, sigma);
 
             // 5. Queue the blurred result for compositing at the CLAMPED device
             //    rect — the copy source origin is (x,y) and extent (w,h), so the
@@ -1935,11 +1933,7 @@ mod tests {
         });
         let surface_view = surface_texture.create_view(&wgpu::TextureViewDescriptor::default());
 
-        let offscreen = Arc::new(parking_lot::Mutex::new(OffscreenRenderer::new(
-            Arc::clone(&device),
-            Arc::clone(&queue),
-            format,
-        )));
+        let mut offscreen = OffscreenRenderer::new(Arc::clone(&device), Arc::clone(&queue), format);
 
         let painter = WgpuPainter::with_shared_device(
             Arc::clone(&device),
@@ -1947,7 +1941,7 @@ mod tests {
             format,
             (surface_w, surface_h),
         );
-        let mut backend = Backend::with_offscreen(painter, Arc::clone(&offscreen));
+        let mut backend = Backend::with_offscreen(painter, &mut offscreen);
 
         // Simulate the `RenderView` DPR root transform: scale(2) on the CTM.
         backend.painter_mut().scale(2.0, 2.0);
@@ -2058,18 +2052,14 @@ mod tests {
         });
         let surface_view = surface_texture.create_view(&wgpu::TextureViewDescriptor::default());
 
-        let offscreen = Arc::new(parking_lot::Mutex::new(OffscreenRenderer::new(
-            Arc::clone(&device),
-            Arc::clone(&queue),
-            format,
-        )));
+        let mut offscreen = OffscreenRenderer::new(Arc::clone(&device), Arc::clone(&queue), format);
         let painter = WgpuPainter::with_shared_device(
             Arc::clone(&device),
             Arc::clone(&queue),
             format,
             (surface_w, surface_h),
         );
-        let mut backend = Backend::with_offscreen(painter, Arc::clone(&offscreen));
+        let mut backend = Backend::with_offscreen(painter, &mut offscreen);
 
         // CTM: scale(2) then translate(+10,+10).
         // Maps (x,y) → (2x+20, 2y+20).
@@ -2199,18 +2189,14 @@ mod tests {
         });
         let surface_view = surface_texture.create_view(&wgpu::TextureViewDescriptor::default());
 
-        let offscreen = Arc::new(parking_lot::Mutex::new(OffscreenRenderer::new(
-            Arc::clone(&device),
-            Arc::clone(&queue),
-            format,
-        )));
+        let mut offscreen = OffscreenRenderer::new(Arc::clone(&device), Arc::clone(&queue), format);
         let painter = WgpuPainter::with_shared_device(
             Arc::clone(&device),
             Arc::clone(&queue),
             format,
             (surface_w, surface_h),
         );
-        let mut backend = Backend::with_offscreen(painter, Arc::clone(&offscreen));
+        let mut backend = Backend::with_offscreen(painter, &mut offscreen);
 
         // CTM is identity (scale=1, DPR=1): device coords == logical coords.
         // Backdrop at (350,350,200,200) — corners (350,350)→(550,550).
@@ -2939,18 +2925,14 @@ mod tests {
         });
         let surface_view = surface_texture.create_view(&wgpu::TextureViewDescriptor::default());
 
-        let offscreen = Arc::new(parking_lot::Mutex::new(OffscreenRenderer::new(
-            Arc::clone(&device),
-            Arc::clone(&queue),
-            format,
-        )));
+        let mut offscreen = OffscreenRenderer::new(Arc::clone(&device), Arc::clone(&queue), format);
         let painter = WgpuPainter::with_shared_device(
             Arc::clone(&device),
             Arc::clone(&queue),
             format,
             (surface_w, surface_h),
         );
-        let mut backend = Backend::with_offscreen(painter, Arc::clone(&offscreen));
+        let mut backend = Backend::with_offscreen(painter, &mut offscreen);
 
         let ctx = RenderContext {
             device: Arc::clone(&device),


### PR DESCRIPTION
## What

The **keystone** both audits (88-agent + GLM 5.2) converged on: replace the `Arc<parking_lot::Mutex<OffscreenRenderer>>` shared between `Renderer` and `Backend` with **direct ownership** on `Renderer` + a **borrowed `&'frame mut OffscreenRenderer`** on the (already-`'frame`-parameterised) `Backend`. The canonical *"Arc<Mutex<> over single-mutator data"* smell, gone.

## Why it's safe

The lock was **uncontended single-mutator**: `flui-engine` runs on one render thread and `Renderer::render_scene` is sync — no two threads ever touched the offscreen renderer. Removing it changes only **how** the borrow is expressed, not **what** happens.

| Site | Before | After |
|---|---|---|
| `Renderer.offscreen` / `WindowedGpuStack.offscreen` | `Option<Arc<parking_lot::Mutex<OffscreenRenderer>>>` | `Option<OffscreenRenderer>` |
| `Backend<'frame>.offscreen` | `Option<Arc<Mutex<…>>>` | `Option<&'frame mut OffscreenRenderer>` |
| `with_offscreen(painter, Arc<Mutex<…>>)` | clone the Arc | `&'frame mut OffscreenRenderer` |
| `offscreen()` Arc accessor | returns the Arc | `offscreen_mut() -> Option<&mut OffscreenRenderer>` |
| 9 × `offscreen_arc.lock()` | lock guard | direct `&mut` / `&` access |

**No `split_mut` needed** — every site touching both painter and offscreen already did so **sequentially** (painter released before each former lock), so NLL resolves the disjoint `&mut` borrows on non-overlapping scopes. No `unsafe` / `clone` / `RefCell` / `Box` introduced. `unsafe impl Send for Renderer` stays (raw window/display handles are `!Send`); `OffscreenRenderer: Send`, so direct ownership preserves `Renderer: Send`.

Scope: **2 files** (`renderer.rs`, `backend.rs`); `offscreen.rs` untouched. Net **−98 / +77**.

## Gates (all local, ground-truthed by the orchestrator — not just the builder's report)

- `cargo check -p flui-engine` (standalone) ✅ · `cargo check --workspace` ✅
- `cargo clippy --all-targets -- -D warnings` (default + `enable-wgpu-tests`) ✅
- `RUSTDOCFLAGS=-D warnings cargo doc` ✅ · `cargo fmt --check` ✅
- **GPU readback: 443 passed, 0 failed** — bit-identical, incl. the shader-mask + backdrop-filter paths that drive the offscreen renderer (behaviour-preserving proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)