### PR TITLE
build(engine): compose blend shaders via naga_oil #import (P0 of wgsl_bindgen adoption)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,17 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "codespan-reporting"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
@@ -896,6 +907,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dispatch"
@@ -1202,6 +1219,7 @@ dependencies = [
  "glyphon",
  "image",
  "lyon",
+ "naga_oil",
  "parking_lot",
  "pollster",
  "raw-window-handle",
@@ -2666,7 +2684,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
- "codespan-reporting",
+ "codespan-reporting 0.13.1",
  "half",
  "hashbrown 0.16.1",
  "hexf-parse",
@@ -2678,6 +2696,23 @@ dependencies = [
  "rustc-hash 1.1.0",
  "spirv",
  "thiserror 2.0.18",
+ "unicode-ident",
+]
+
+[[package]]
+name = "naga_oil"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "319f03062940ed85c03da020042618356bb8ca5263020322930883b05e30208e"
+dependencies = [
+ "codespan-reporting 0.12.0",
+ "data-encoding",
+ "indexmap",
+ "naga",
+ "regex",
+ "rustc-hash 1.1.0",
+ "thiserror 2.0.18",
+ "tracing",
  "unicode-ident",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,10 +114,14 @@ tracing-forest = { version = "0.3", features = ["smallvec"] }
 # GPU RENDERING (WGPU BACKEND) - Track latest stable (29.x).
 # Update policy: bump within the same minor on security/bug fixes; bump major after
 # verifying API migration on a dedicated branch (see docs/adr/ADR-0002).
-wgpu = { version = "29.0", default-features = false, features = ["wgsl"] }
+wgpu = { version = "29.0", default-features = false, features = ["wgsl", "naga-ir"] }
 # GPU profiling — optional, reused by flui-engine behind the `gpu-profiler` feature.
 # Pins wgpu ^29.0, consistent with the workspace pin above. Excluded from wasm32.
 wgpu-profiler = { version = "0.27", default-features = false }
+# Shader module composition — resolves #import directives in WGSL at build-time or
+# pipeline-init time.  Pins naga ^29, consistent with wgpu 29's naga dep.
+# Used by flui-engine to compose blend_helpers.wgsl into mode.wgsl / advanced_blend.wgsl.
+naga_oil = { version = "0.22", default-features = false }
 winit = "0.30.12"
 raw-window-handle = "0.6"
 pollster = "0.4"

--- a/crates/flui-engine/Cargo.toml
+++ b/crates/flui-engine/Cargo.toml
@@ -49,6 +49,9 @@ flui-assets = { path = "../flui-assets", optional = true }
 
 # === GPU Rendering (wgpu backend) ===
 wgpu = { workspace = true, default-features = false, optional = true }
+# Shader composition: resolves #import directives at pipeline-init time.
+# Only used in the wgpu backend; compile-time feature-gated via the wgpu-backend feature.
+naga_oil = { workspace = true }
 # `std` is required so `raw_window_handle::HandleError` impls `std::error::Error`
 # (the impl is `#[cfg(feature = "std")]` in raw-window-handle 0.6.2); that lets us
 # box a `HandleError` directly into `EngineError::SurfaceCreation` via the typed

--- a/crates/flui-engine/src/wgpu/advanced_blend/pipeline.rs
+++ b/crates/flui-engine/src/wgpu/advanced_blend/pipeline.rs
@@ -14,6 +14,8 @@ use std::mem;
 use bytemuck::{Pod, Zeroable};
 use flui_types::painting::BlendMode;
 
+use crate::wgpu::shader_composer::{ComposableSource, compose_wgsl_shader};
+
 // ── Uniform layout (mirrors `BlendUniforms` in advanced_blend.wgsl) ──────────
 
 /// GPU uniform buffer layout for the advanced-blend pass.
@@ -190,20 +192,26 @@ impl AdvancedBlendPipeline {
             immediate_size: 0,
         });
 
+        // Compose advanced_blend.wgsl by resolving its `#import blend_helpers` via naga_oil.
+        // The Composer registers blend_helpers.wgsl as a composable module, then
+        // produces a fully resolved naga::Module that wgpu accepts via ShaderSource::Naga.
+        // Panics are intentional here: a composition failure at pipeline-init is a
+        // programming error (bad WGSL or missing import), not a recoverable runtime
+        // condition — it matches the behaviour of the previous concat!/create_shader_module
+        // path which also panicked (wgpu panics on shader validation failure).
+        let composed_source = compose_wgsl_shader(
+            &[ComposableSource {
+                source: include_str!("../shaders/blend_helpers.wgsl"),
+                file_path: "shaders/blend_helpers.wgsl",
+            }],
+            include_str!("../shaders/advanced_blend.wgsl"),
+            "shaders/advanced_blend.wgsl",
+        )
+        .expect("blend_helpers.wgsl #import in advanced_blend.wgsl must resolve: check for WGSL syntax errors or a missing #define_import_path");
+
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Advanced Blend Shader"),
-            // Prepend the shared leaf helpers (hard_light, lum, clip_color,
-            // set_lum, sat, set_sat) from blend_helpers.wgsl so naga sees one
-            // unified module.  A duplicate fn definition would cause a "redefined"
-            // error here, enforcing the single-source contract.
-            source: wgpu::ShaderSource::Wgsl(
-                concat!(
-                    include_str!("../shaders/blend_helpers.wgsl"),
-                    "\n\n",
-                    include_str!("../shaders/advanced_blend.wgsl"),
-                )
-                .into(),
-            ),
+            source: composed_source,
         });
 
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {

--- a/crates/flui-engine/src/wgpu/mod.rs
+++ b/crates/flui-engine/src/wgpu/mod.rs
@@ -177,6 +177,12 @@ pub(crate) mod resources;
 /// suppression. The audit also mentioned `cached_count` but no such
 /// method existed -- only `clear`.
 mod shader_compiler;
+/// naga_oil shader composition helper: resolves `#import` directives
+/// in WGSL at pipeline-init time via [`shader_composer::compose_wgsl_shader`].
+/// Used by `mode/pipeline.rs` and `advanced_blend/pipeline.rs` to
+/// compose `blend_helpers.wgsl` into each entry shader, replacing the
+/// previous `concat!(include_str!(...))` approach.
+pub(crate) mod shader_composer;
 mod shaders;
 /// SSAA (2× supersampled) path anti-aliasing: downsample pipeline and replay
 /// helper `GpuReplay::render_ssaa_path` / `GpuReplay::downsample_ssaa_tile`.

--- a/crates/flui-engine/src/wgpu/mode/pipeline.rs
+++ b/crates/flui-engine/src/wgpu/mode/pipeline.rs
@@ -32,6 +32,8 @@ use std::mem;
 use bytemuck::{Pod, Zeroable};
 use flui_types::painting::BlendMode;
 
+use crate::wgpu::shader_composer::{ComposableSource, compose_wgsl_shader};
+
 // ── Uniform layout ────────────────────────────────────────────────────────────
 
 /// GPU uniform buffer layout for the ColorFilter::Mode blend pass.
@@ -145,20 +147,26 @@ impl ModePipeline {
             immediate_size: 0,
         });
 
+        // Compose mode.wgsl by resolving its `#import blend_helpers` via naga_oil.
+        // The Composer registers blend_helpers.wgsl as a composable module, then
+        // produces a fully resolved naga::Module that wgpu accepts via ShaderSource::Naga.
+        // Panics are intentional here: a composition failure at pipeline-init is a
+        // programming error (bad WGSL or missing import), not a recoverable runtime
+        // condition — it matches the behaviour of the previous concat!/create_shader_module
+        // path which also panicked (wgpu panics on shader validation failure).
+        let composed_source = compose_wgsl_shader(
+            &[ComposableSource {
+                source: include_str!("../shaders/blend_helpers.wgsl"),
+                file_path: "shaders/blend_helpers.wgsl",
+            }],
+            include_str!("../shaders/effects/mode.wgsl"),
+            "shaders/effects/mode.wgsl",
+        )
+        .expect("blend_helpers.wgsl #import in mode.wgsl must resolve: check for WGSL syntax errors or a missing #define_import_path");
+
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Mode Shader"),
-            // Prepend the shared leaf helpers (hard_light, lum, clip_color,
-            // set_lum, sat, set_sat) from blend_helpers.wgsl so naga sees one
-            // unified module.  A duplicate fn definition would cause a "redefined"
-            // error here, enforcing the single-source contract.
-            source: wgpu::ShaderSource::Wgsl(
-                concat!(
-                    include_str!("../shaders/blend_helpers.wgsl"),
-                    "\n\n",
-                    include_str!("../shaders/effects/mode.wgsl"),
-                )
-                .into(),
-            ),
+            source: composed_source,
         });
 
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {

--- a/crates/flui-engine/src/wgpu/shader_composer.rs
+++ b/crates/flui-engine/src/wgpu/shader_composer.rs
@@ -1,0 +1,93 @@
+//! naga_oil shader composition helper.
+//!
+//! Provides `compose_wgsl_shader`, a thin wrapper over the naga_oil
+//! `Composer` that:
+//!
+//! 1. Registers one or more composable WGSL modules (e.g. `blend_helpers.wgsl`
+//!    marked with `#define_import_path blend_helpers`).
+//! 2. Composes a top-level WGSL source that carries `#import` directives into a
+//!    resolved `naga::Module`.
+//! 3. Returns that `naga::Module` wrapped in a `Cow::Owned` ready for
+//!    [`wgpu::ShaderSource::Naga`].
+//!
+//! ## Why `ShaderSource::Naga` and not WGSL re-emit?
+//!
+//! The `wgpu/naga-ir` feature (already enabled in the workspace `wgpu` dep)
+//! lets us hand the composed `naga::Module` directly to wgpu, skipping the
+//! naga → WGSL back-end round-trip.  That path has lower overhead (no string
+//! serialisation) and zero extra dependencies beyond naga_oil itself, which
+//! already pulls `naga ^29` matching wgpu 29's vendored naga.
+//!
+//! naga_oil's `Composer::make_naga_module` returns `naga::Module`, and
+//! `wgpu::ShaderSource::Naga` accepts `std::borrow::Cow<'static, naga::Module>`
+//! — so `Cow::Owned(module)` is the natural bridge.
+
+use std::borrow::Cow;
+
+use naga_oil::compose::{
+    ComposableModuleDescriptor, Composer, ComposerError, NagaModuleDescriptor, ShaderLanguage,
+    ShaderType,
+};
+
+/// A composable module source to register before composing the entry shader.
+///
+/// Pass one entry per `#define_import_path` module that the entry shader imports.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ComposableSource {
+    /// The WGSL source text (must contain a `#define_import_path` directive).
+    pub source: &'static str,
+    /// A short label used in error messages (e.g. `"blend_helpers.wgsl"`).
+    pub file_path: &'static str,
+}
+
+/// Compose a WGSL shader by resolving its `#import` directives via naga_oil.
+///
+/// # Arguments
+///
+/// * `composables` — slice of library modules to register (each must have a
+///   `#define_import_path <name>` at the top).  Modules are registered in
+///   order; a module may only import modules registered before it.
+/// * `entry_source` — the top-level WGSL source that contains `#import`
+///   directives referencing the composable modules.
+/// * `entry_file_path` — a label for the entry source, used in error messages
+///   (e.g. `"effects/mode.wgsl"`).
+///
+/// # Returns
+///
+/// A `wgpu::ShaderSource::Naga` containing the fully resolved `naga::Module`.
+///
+/// # Errors
+///
+/// Returns a boxed `ComposerError` if any import is missing, or if naga
+/// validation of the composed module fails.  The error is boxed because
+/// `ComposerError` is 240+ bytes — large enough to trigger
+/// `clippy::result_large_err` and cause stack-bloat at every call site.
+pub(crate) fn compose_wgsl_shader(
+    composables: &[ComposableSource],
+    entry_source: &'static str,
+    entry_file_path: &'static str,
+) -> Result<wgpu::ShaderSource<'static>, Box<ComposerError>> {
+    let mut composer = Composer::default();
+
+    for composable in composables {
+        composer
+            .add_composable_module(ComposableModuleDescriptor {
+                source: composable.source,
+                file_path: composable.file_path,
+                language: ShaderLanguage::Wgsl,
+                ..Default::default()
+            })
+            .map_err(Box::new)?;
+    }
+
+    let naga_module = composer
+        .make_naga_module(NagaModuleDescriptor {
+            source: entry_source,
+            file_path: entry_file_path,
+            shader_type: ShaderType::Wgsl,
+            ..Default::default()
+        })
+        .map_err(Box::new)?;
+
+    Ok(wgpu::ShaderSource::Naga(Cow::Owned(naga_module)))
+}

--- a/crates/flui-engine/src/wgpu/shaders/advanced_blend.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/advanced_blend.wgsl
@@ -139,10 +139,10 @@ fn vs_main(@builtin(vertex_index) vi: u32) -> VsOutput {
 // ── Blend helpers ─────────────────────────────────────────────────────────────
 //
 // The 6 shared leaf helpers (hard_light, lum, clip_color, set_lum, sat,
-// set_sat) are defined in `blend_helpers.wgsl` and prepended to this module
-// by `advanced_blend/pipeline.rs` via `concat!(include_str!(...))`.  naga
-// sees one unified module — any duplicate definition would cause a "redefined"
-// error at `create_shader_module`.
+// set_sat) are defined in `blend_helpers.wgsl` and resolved by naga_oil at
+// pipeline-init time via `compose_wgsl_shader` in `src/wgpu/mod.rs`.
+
+#import blend_helpers::{hard_light, lum, clip_color, set_lum, sat, set_sat}
 
 fn separable_blend(mode: u32, cb: f32, cs: f32) -> f32 {
     switch mode {

--- a/crates/flui-engine/src/wgpu/shaders/blend_helpers.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/blend_helpers.wgsl
@@ -3,13 +3,19 @@
 // Shared W3C Compositing and Blending Level 1 leaf helpers used by both
 // `effects/mode.wgsl` and `advanced_blend.wgsl`.
 //
+// ## Module composition (naga_oil)
+//
+// This file is a naga_oil composable module.  The `#define_import_path`
+// directive below registers the module name; consumers import it with:
+//   #import blend_helpers::{hard_light, lum, clip_color, set_lum, sat, set_sat}
+// Composition occurs at pipeline-init time via `compose_wgsl_shader` in
+// `src/wgpu/mod.rs`, which replaces the previous `concat!(include_str!(...))`.
+//
 // ## Single source of truth
 //
-// Both shaders concatenate this snippet at the top of their module (via
-// `concat!(include_str!("blend_helpers.wgsl"), "\n\n", include_str!("..."))`)
-// so naga sees one unified WGSL module.  Any duplicate fn definition would
-// cause a "redefined" error at `create_shader_module` — the concatenation
-// enforces that this file is the sole definition site.
+// These 6 helpers are imported (not copied) by each consumer shader.
+// Any duplicate fn definition would cause a naga_oil "redefined" error —
+// the import enforces that this file is the sole definition site.
 //
 // ## Correctness contract
 //
@@ -25,6 +31,8 @@
 // any mode-index switch) are NOT shared: `mode.wgsl` encodes modes 15-29 and
 // `advanced_blend.wgsl` encodes modes 0-14.  Only the leaf helpers below are
 // identical between the two shaders and belong here.
+
+#define_import_path blend_helpers
 
 // ── Leaf helpers (verbatim port of color.rs) ─────────────────────────────────
 

--- a/crates/flui-engine/src/wgpu/shaders/effects/mode.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/effects/mode.wgsl
@@ -102,14 +102,14 @@ fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
 // ─── Blend helpers ─────────────────────────────────────────────────────────────
 //
 // The 6 shared leaf helpers (hard_light, lum, clip_color, set_lum, sat,
-// set_sat) are defined in `blend_helpers.wgsl` and prepended to this module
-// by `mode/pipeline.rs` via `concat!(include_str!(...))`.  naga sees one
-// unified module — any duplicate definition would cause a "redefined" error
-// at `create_shader_module`.
+// set_sat) are defined in `blend_helpers.wgsl` and resolved by naga_oil at
+// pipeline-init time via `compose_wgsl_shader` in `src/wgpu/mod.rs`.
 //
 // All helpers mirror the corresponding private functions in
 // `flui_types::styling::color`.  SRC = filter color, DST = layer pixel.
 // Both operate on straight sRGB [0,1] values.
+
+#import blend_helpers::{hard_light, lum, clip_color, set_lum, sat, set_sat}
 
 /// W3C separable blend function B(cb, cs), one channel.
 /// cb = backdrop (DST straight), cs = source (SRC straight).


### PR DESCRIPTION
## What

`mode/pipeline.rs` and `advanced_blend/pipeline.rs` composed their shaders at runtime via `concat!(include_str!(blend_helpers), shader)` — a string splice naga sees as one module, but which build-time tooling (wgsl_bindgen) **cannot parse**. Replaced with proper **naga_oil `#import` composition**:

- `blend_helpers.wgsl` declares `#define_import_path blend_helpers`
- `effects/mode.wgsl` + `advanced_blend.wgsl` `#import blend_helpers::{hard_light, lum, clip_color, set_lum, sat, set_sat}`

Each shader is now a self-contained naga-oil module.

**This is P0 of the wgsl_bindgen adoption** (ADR `adr-wgsl-bindgen-pilot.md`) — the prerequisite that makes the composed shaders codegen-friendly. Net win on its own: retires the fragile runtime string-splice (whose only drift guard was naga's *"redefined fn"* error) for real module resolution.

## Implementation

- New `wgpu/shader_composer.rs`: `compose_wgsl_shader(composables, entry, path)` builds a `naga_oil::compose::Composer`, registers the composable module(s), returns `ShaderSource::Naga(Cow::Owned(module))`. **DRY** — both pipelines call it.
- Integration via the new **`wgpu/naga-ir`** feature (chosen over a naga WGSL re-emit: no string round-trip, no extra `naga` dep — naga_oil already pulls `naga ^29` matching wgpu 29's vendored naga).
- New dep `naga_oil = "0.22"` (targets naga 29 / wgpu 29; **MIT OR Apache-2.0** — already allow-listed, no deny.toml change).

## Behaviour-preserving

The composed module is semantically identical to the concat output. Proven by the full `enable-wgpu-tests` GPU readback: **445 passed, 0 failed**, including the 15-advanced-mode-vs-CPU-oracle and mode/blend readback tests that exercise the now-`#import`ed `blend_helpers` math.

## Gates (orchestrator-verified)

- `cargo check -p flui-engine` · `cargo check --workspace` ✅ · `clippy --all-targets -- -D warnings` (default + `enable-wgpu-tests`) ✅ · `cargo doc -D warnings` ✅ (fixed broken intra-doc links) · `cargo fmt --check` ✅
- **GPU readback: 445 passed, 0 failed** (bit-identical)

> ⚠️ `cargo deny check` reports two **pre-existing** advisories (`memmap2` RUSTSEC-2026-0186, `swash` yank) via `cosmic-text`/`winit` — present on `main` before this branch, unrelated to naga_oil. Tracked as a separate dep-hygiene follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)