### PR TITLE
docs(engine): wgsl_bindgen P3 review-polish comments (ce-kieran follow-up)

### DIFF
--- a/crates/flui-engine/build.rs
+++ b/crates/flui-engine/build.rs
@@ -199,7 +199,9 @@ const COMPOSED_SHADER_CONFIGS: &[ComposedShaderConfig] = &[
         },
         // BlendUniforms.tint_rgb is a `vec3<f32>` packed tight before `mode: u32`
         // — force [f32; 3] so the generated layout matches the WGSL (see the
-        // field doc above).
+        // field doc above).  The `BlendUniforms` regex is intentionally a
+        // substring match: it must also retype the generated `BlendUniformsInit`
+        // constructor-mirror struct's `tint_rgb` field to the same `[f32; 3]`.
         field_type_overrides: &[("BlendUniforms", "tint_rgb", "[f32; 3]")],
     },
 ];

--- a/crates/flui-engine/src/wgpu/advanced_blend/pipeline.rs
+++ b/crates/flui-engine/src/wgpu/advanced_blend/pipeline.rs
@@ -135,6 +135,12 @@ pub(crate) fn mode_to_u32(mode: BlendMode) -> u32 {
 /// | 2       | FS       | 2D float texture        | Backdrop copy (premultiplied)|
 /// | 3       | FS       | Non-filtering sampler   | Nearest + ClampToEdge        |
 ///
+/// The `Stage` column is the actual shader usage.  The generated
+/// `WgpuBindGroup0` layout marks every binding `VERTEX_FRAGMENT` (wgsl_bindgen
+/// does not derive per-stage visibility); this is wider than the former
+/// hand-written descriptor (bindings 1–3 were FRAGMENT-only) but permissive —
+/// wgpu accepts it and the GPU readback suite confirms bit-identical output.
+///
 /// ## Blend state
 ///
 /// `REPLACE` (no fixed-function blending): the fragment shader emits the full

--- a/crates/flui-engine/src/wgpu/mode/pipeline.rs
+++ b/crates/flui-engine/src/wgpu/mode/pipeline.rs
@@ -123,6 +123,12 @@ pub(crate) fn blend_mode_to_u32(mode: BlendMode) -> u32 {
 /// | 1       | FS    | 2D float texture      | Source layer (premultiplied) |
 /// | 2       | FS    | Non-filtering sampler | Nearest + ClampToEdge        |
 ///
+/// The `Stage` column is the actual shader usage.  The generated
+/// `WgpuBindGroup0` layout marks every binding `VERTEX_FRAGMENT` (wgsl_bindgen
+/// does not derive per-stage visibility); this is wider than the former
+/// hand-written FRAGMENT-only descriptor but permissive — wgpu accepts it and
+/// the GPU readback suite confirms bit-identical output.
+///
 /// ## Blend state
 ///
 /// `REPLACE` (no fixed-function blending): the fragment shader emits the full

--- a/crates/flui-engine/src/wgpu/shaders/effects/mode.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/effects/mode.wgsl
@@ -58,7 +58,8 @@
 //   u32        _pad[3]    → 12 bytes padding
 // Total: 32 bytes (multiple of 16 ✓).
 //
-// Rust side: `ModeUniform { color: [f32;4], blend_mode: u32, _pad: [u32;3] }` = 32 bytes.
+// Rust side: the generated `ModeUniforms { color: [f32;4], blend_mode: u32,
+// _pad0/_pad1/_pad2: u32 }` (wgsl_bindgen, see mode/generated.rs) = 32 bytes.
 struct ModeUniforms {
     /// Filter color in straight sRGB [r, g, b, a] (SRC for the blend).
     color: vec4<f32>,


### PR DESCRIPTION
Doc/comment-only follow-up to #300. These notes were written in response to the `ce-kieran` review of #300 but missed the commit snapshot (committed a stale staged index). **No code, no behavior change** — `git diff` is comments + doc-comments only.

- **build.rs**: note the `BlendUniforms` field-type-override regex is intentionally a substring match so it also retypes the generated `BlendUniformsInit` mirror struct.
- **mode/pipeline.rs** + **advanced_blend/pipeline.rs**: document that the generated `WgpuBindGroup0` marks every binding `VERTEX_FRAGMENT` (wgsl_bindgen doesn't derive per-stage visibility) — wider than the former FRAGMENT-only texture/sampler descriptors, but permissive and pixel-verified identical.
- **effects/mode.wgsl**: refresh the stale `Rust side: ModeUniform {…}` comment to reference the generated `ModeUniforms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)