### PR TITLE
perf(engine): reuse uniform buffers across frames via a pooled allocator

### DIFF
--- a/crates/flui-engine/src/wgpu/advanced_blend/mod.rs
+++ b/crates/flui-engine/src/wgpu/advanced_blend/mod.rs
@@ -24,7 +24,6 @@ use flui_types::{
     geometry::{Pixels, Rect},
     painting::BlendMode,
 };
-use wgpu::util::DeviceExt as _;
 
 pub(crate) use pipeline::AdvancedBlendPipeline;
 pub(crate) use pipeline::mode_to_u32;
@@ -254,11 +253,7 @@ pub(crate) fn flush_advanced_layer(
         op.src_uv_max,
     );
 
-    let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-        label: Some("Advanced Blend Uniform Buffer"),
-        contents: cast_slice(&[uniforms]),
-        usage: wgpu::BufferUsages::UNIFORM,
-    });
+    let uniform_buffer = resources.uniform_pool_mut().alloc(cast_slice(&[uniforms]));
 
     // Nearest + ClampToEdge sampler — no filtering: the backdrop copy and
     // foreground are pixel-aligned; filtering would introduce colour error.
@@ -279,7 +274,7 @@ pub(crate) fn flush_advanced_layer(
         device,
         advanced_blend::WgpuBindGroup0Entries::new(advanced_blend::WgpuBindGroup0EntriesParams {
             blend: wgpu::BufferBinding {
-                buffer: &uniform_buffer,
+                buffer: uniform_buffer,
                 offset: 0,
                 size: None,
             },

--- a/crates/flui-engine/src/wgpu/blur/mod.rs
+++ b/crates/flui-engine/src/wgpu/blur/mod.rs
@@ -46,11 +46,10 @@ use std::sync::Arc;
 
 use bytemuck::cast_slice;
 use flui_types::{Rect, geometry::Pixels};
-use wgpu::util::DeviceExt as _;
 
 pub(crate) use pipeline::BlurPipeline;
 
-use super::{resources::GpuResources, texture_pool::PooledTexture};
+use super::{resources::GpuResources, texture_pool::PooledTexture, uniform_pool::UniformPool};
 
 mod generated;
 mod pipeline;
@@ -160,6 +159,7 @@ pub(crate) fn apply_blur(
         source_tex.view(),
         h_tex.view(),
         pipeline,
+        resources.uniform_pool_mut(),
         device,
         encoder,
         "Blur H Pass",
@@ -179,6 +179,7 @@ pub(crate) fn apply_blur(
         h_tex.view(),
         v_tex.view(),
         pipeline,
+        resources.uniform_pool_mut(),
         device,
         encoder,
         "Blur V Pass",
@@ -196,22 +197,23 @@ pub(crate) fn apply_blur(
 /// Writes into `dst_view` using `LoadOp::Clear(TRANSPARENT)` so pixels outside
 /// the viewport are transparent (R3 invariant). `REPLACE` blend prevents the
 /// GPU from re-blending the premultiplied output.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "GPU sub-pass needs the uniform, src/dst views, pipeline, pool, device, encoder, and label"
+)]
 fn run_blur_sub_pass(
     uniform: blur::BlurUniforms,
     src_view: &wgpu::TextureView,
     dst_view: &wgpu::TextureView,
     pipeline: &BlurPipeline,
+    uniform_pool: &mut UniformPool,
     device: &Arc<wgpu::Device>,
     encoder: &mut wgpu::CommandEncoder,
     pass_label: &str,
 ) {
-    // Per-pass uniform buffer (32 bytes — tiny allocation, new each pass so the
-    // bind-group can reference its own buffer without a dynamic-offset scheme).
-    let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-        label: Some(pass_label),
-        contents: cast_slice(&[uniform]),
-        usage: wgpu::BufferUsages::UNIFORM,
-    });
+    // Uniform (32 bytes) written into a frame-distinct buffer from the reusable
+    // pool — no per-pass allocation; each pass still binds its own buffer.
+    let uniform_buffer = uniform_pool.alloc(cast_slice(&[uniform]));
 
     // Linear-filter sampler: bilinear interpolation + ClampToEdge.
     // Bilinear is valid for Gaussian; the continuous kernel naturally composes
@@ -235,7 +237,7 @@ fn run_blur_sub_pass(
         device,
         blur::WgpuBindGroup0Entries::new(blur::WgpuBindGroup0EntriesParams {
             u: wgpu::BufferBinding {
-                buffer: &uniform_buffer,
+                buffer: uniform_buffer,
                 offset: 0,
                 size: None,
             },

--- a/crates/flui-engine/src/wgpu/color_matrix/mod.rs
+++ b/crates/flui-engine/src/wgpu/color_matrix/mod.rs
@@ -26,7 +26,6 @@
 use std::sync::Arc;
 
 use bytemuck::cast_slice;
-use wgpu::util::DeviceExt as _;
 
 pub(crate) use pipeline::ColorMatrixPipeline;
 use pipeline::color_matrix_uniform_from_values;
@@ -80,11 +79,7 @@ pub(crate) fn apply_color_matrix(
     // bound per draw.  Hoisting into the pipeline would couple the pipeline to a
     // single matrix value and break multi-layer filtering.
     let uniform = color_matrix_uniform_from_values(matrix_values);
-    let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-        label: Some("Color Matrix Uniform Buffer"),
-        contents: cast_slice(&[uniform]),
-        usage: wgpu::BufferUsages::UNIFORM,
-    });
+    let uniform_buffer = resources.uniform_pool_mut().alloc(cast_slice(&[uniform]));
 
     // Nearest + ClampToEdge sampler — per-draw allocation (same rationale as above).
     // No filtering: source texels are pixel-aligned with the output; bilinear
@@ -107,7 +102,7 @@ pub(crate) fn apply_color_matrix(
         device,
         color_matrix::WgpuBindGroup0Entries::new(color_matrix::WgpuBindGroup0EntriesParams {
             u: wgpu::BufferBinding {
-                buffer: &uniform_buffer,
+                buffer: uniform_buffer,
                 offset: 0,
                 size: None,
             },

--- a/crates/flui-engine/src/wgpu/gamma/mod.rs
+++ b/crates/flui-engine/src/wgpu/gamma/mod.rs
@@ -27,7 +27,6 @@
 use std::sync::Arc;
 
 use bytemuck::cast_slice;
-use wgpu::util::DeviceExt as _;
 
 pub(crate) use pipeline::GammaPipeline;
 use pipeline::gamma_direction_to_u32;
@@ -75,12 +74,9 @@ pub(crate) fn apply_gamma(
     let filtered_view = filtered_tex.view();
 
     // Build the uniform: direction flag; padding is zero-filled by the generated ctor.
+    // The reusable pool writes it into a frame-distinct buffer (no per-call alloc).
     let uniform = gamma::GammaUniforms::new(gamma_direction_to_u32(direction));
-    let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-        label: Some("Gamma Uniform Buffer"),
-        contents: cast_slice(&[uniform]),
-        usage: wgpu::BufferUsages::UNIFORM,
-    });
+    let uniform_buffer = resources.uniform_pool_mut().alloc(cast_slice(&[uniform]));
 
     // Nearest + ClampToEdge sampler — no filtering: source texels are pixel-aligned.
     let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
@@ -102,7 +98,7 @@ pub(crate) fn apply_gamma(
         device,
         gamma::WgpuBindGroup0Entries::new(gamma::WgpuBindGroup0EntriesParams {
             u: wgpu::BufferBinding {
-                buffer: &uniform_buffer,
+                buffer: uniform_buffer,
                 offset: 0,
                 size: None,
             },

--- a/crates/flui-engine/src/wgpu/mod.rs
+++ b/crates/flui-engine/src/wgpu/mod.rs
@@ -198,6 +198,7 @@ mod tessellator;
 mod text;
 pub mod texture_cache;
 mod texture_pool;
+mod uniform_pool;
 mod vertex;
 
 // ============================================================================

--- a/crates/flui-engine/src/wgpu/mode/mod.rs
+++ b/crates/flui-engine/src/wgpu/mode/mod.rs
@@ -28,7 +28,6 @@ use std::sync::Arc;
 
 use bytemuck::cast_slice;
 use flui_types::painting::BlendMode;
-use wgpu::util::DeviceExt as _;
 
 pub(crate) use pipeline::ModePipeline;
 use pipeline::blend_mode_to_u32;
@@ -82,11 +81,7 @@ pub(crate) fn apply_mode(
     // Build the uniform: filter color + blend mode index.  The generated
     // `ModeUniforms::new` zero-fills the WGSL alignment padding.
     let uniform = mode::ModeUniforms::new(filter_color, blend_mode_to_u32(blend_mode));
-    let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-        label: Some("Mode Uniform Buffer"),
-        contents: cast_slice(&[uniform]),
-        usage: wgpu::BufferUsages::UNIFORM,
-    });
+    let uniform_buffer = resources.uniform_pool_mut().alloc(cast_slice(&[uniform]));
 
     // Nearest + ClampToEdge sampler — no filtering: source texels are pixel-aligned.
     let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
@@ -106,7 +101,7 @@ pub(crate) fn apply_mode(
         device,
         mode::WgpuBindGroup0Entries::new(mode::WgpuBindGroup0EntriesParams {
             u: wgpu::BufferBinding {
-                buffer: &uniform_buffer,
+                buffer: uniform_buffer,
                 offset: 0,
                 size: None,
             },

--- a/crates/flui-engine/src/wgpu/morphology/mod.rs
+++ b/crates/flui-engine/src/wgpu/morphology/mod.rs
@@ -29,11 +29,13 @@ use std::sync::Arc;
 
 use bytemuck::cast_slice;
 use flui_types::{Rect, geometry::Pixels};
-use wgpu::util::DeviceExt as _;
 
 pub(crate) use pipeline::MorphologyPipeline;
 
-use super::{command_ir::MorphOp, resources::GpuResources, texture_pool::PooledTexture};
+use super::{
+    command_ir::MorphOp, resources::GpuResources, texture_pool::PooledTexture,
+    uniform_pool::UniformPool,
+};
 
 mod generated;
 mod pipeline;
@@ -143,6 +145,7 @@ pub(crate) fn apply_morphology(
         source_tex.view(),
         h_tex.view(),
         pipeline,
+        resources.uniform_pool_mut(),
         device,
         encoder,
         "Morphology H Pass",
@@ -163,6 +166,7 @@ pub(crate) fn apply_morphology(
         h_tex.view(),
         v_tex.view(),
         pipeline,
+        resources.uniform_pool_mut(),
         device,
         encoder,
         "Morphology V Pass",
@@ -180,22 +184,23 @@ pub(crate) fn apply_morphology(
 /// Writes into `dst_view` using `LoadOp::Clear(TRANSPARENT)` so pixels outside
 /// the viewport are transparent (R3 invariant). `REPLACE` blend prevents the
 /// GPU from re-blending the premultiplied output.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "GPU sub-pass needs the uniform, src/dst views, pipeline, pool, device, encoder, and label"
+)]
 fn run_morph_sub_pass(
     uniform: morphology::MorphUniforms,
     src_view: &wgpu::TextureView,
     dst_view: &wgpu::TextureView,
     pipeline: &MorphologyPipeline,
+    uniform_pool: &mut UniformPool,
     device: &Arc<wgpu::Device>,
     encoder: &mut wgpu::CommandEncoder,
     pass_label: &str,
 ) {
-    // Per-pass uniform buffer (48 bytes — tiny allocation, new each pass so the
-    // bind-group can reference its own buffer without a dynamic-offset scheme).
-    let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-        label: Some(pass_label),
-        contents: cast_slice(&[uniform]),
-        usage: wgpu::BufferUsages::UNIFORM,
-    });
+    // Uniform (48 bytes) written into a frame-distinct buffer from the reusable
+    // pool — no per-pass allocation; each pass still binds its own buffer.
+    let uniform_buffer = uniform_pool.alloc(cast_slice(&[uniform]));
 
     // Nearest-clamp sampler: source texels are pixel-aligned with the output;
     // bilinear filtering would introduce colour error between morphology steps.
@@ -217,7 +222,7 @@ fn run_morph_sub_pass(
         device,
         morphology::WgpuBindGroup0Entries::new(morphology::WgpuBindGroup0EntriesParams {
             u: wgpu::BufferBinding {
-                buffer: &uniform_buffer,
+                buffer: uniform_buffer,
                 offset: 0,
                 size: None,
             },

--- a/crates/flui-engine/src/wgpu/painter/mod.rs
+++ b/crates/flui-engine/src/wgpu/painter/mod.rs
@@ -611,6 +611,12 @@ impl WgpuPainter {
         // `TextRenderer::atlas_trim`.
         self.text_renderer.atlas_trim();
 
+        // Rewind the filter/composite uniform pool for next-frame reuse. Same
+        // once-per-frame seam: rewinding per `render` would alias a backdrop-
+        // flush uniform with a final-render uniform in the same frame. See
+        // `UniformPool::reset_frame`.
+        self.resources.uniform_pool_mut().reset_frame();
+
         let maint = self.resources.texture_cache_mut().end_frame_maintenance();
         if maint.evicted > 0 || maint.atlas_reset {
             tracing::debug!(

--- a/crates/flui-engine/src/wgpu/resources.rs
+++ b/crates/flui-engine/src/wgpu/resources.rs
@@ -34,7 +34,7 @@ use std::sync::Arc;
 
 use super::{
     buffer_pool::BufferPool, external_texture_registry::ExternalTextureRegistry,
-    texture_cache::TextureCache, texture_pool::TexturePool,
+    texture_cache::TextureCache, texture_pool::TexturePool, uniform_pool::UniformPool,
 };
 
 /// Single owner of the four GPU resource managers used by [`super::painter::WgpuPainter`].
@@ -68,6 +68,14 @@ pub(crate) struct GpuResources {
     /// Exposed via `WgpuPainter::external_texture_registry[_mut]` which
     /// delegate here.
     external_texture_registry: ExternalTextureRegistry,
+
+    /// Reusable uniform-buffer pool for the filter/composite passes.
+    ///
+    /// `reset_frame` must run **exactly once per frame** (after the final
+    /// submit) via `WgpuPainter::end_frame_maintenance` — NOT at the per-`render`
+    /// `buffer_pool` reset, which would alias a backdrop-flush uniform with a
+    /// final-render uniform in the same frame. See [`UniformPool`].
+    uniform_pool: UniformPool,
 }
 
 impl GpuResources {
@@ -79,6 +87,9 @@ impl GpuResources {
     /// `WgpuPainter::with_shared_device`.
     pub(crate) fn new(device: Arc<wgpu::Device>, queue: Arc<wgpu::Queue>) -> Self {
         let buffer_pool = BufferPool::new();
+        // Built before `texture_cache` consumes `queue` (and `layer_texture_pool`
+        // consumes `device`): the uniform pool keeps its own `Arc` clones.
+        let uniform_pool = UniformPool::new(device.clone(), queue.clone());
         let texture_cache = TextureCache::new(device.clone(), queue);
         let external_texture_registry = ExternalTextureRegistry::new(device.clone());
         let layer_texture_pool = TexturePool::with_capacity(device, 4);
@@ -88,6 +99,7 @@ impl GpuResources {
             texture_cache,
             layer_texture_pool,
             external_texture_registry,
+            uniform_pool,
         }
     }
 
@@ -124,6 +136,15 @@ impl GpuResources {
     /// acquire and return offscreen compositing textures.
     pub(crate) fn layer_texture_pool_mut(&mut self) -> &mut TexturePool {
         &mut self.layer_texture_pool
+    }
+
+    // -------------------------------------------------------------------------
+    // UniformPool accessor
+    // -------------------------------------------------------------------------
+
+    /// Exclusive reference to the reusable filter/composite uniform-buffer pool.
+    pub(crate) fn uniform_pool_mut(&mut self) -> &mut UniformPool {
+        &mut self.uniform_pool
     }
 
     // -------------------------------------------------------------------------

--- a/crates/flui-engine/src/wgpu/uniform_pool.rs
+++ b/crates/flui-engine/src/wgpu/uniform_pool.rs
@@ -1,0 +1,194 @@
+//! Reusable per-frame uniform-buffer pool for the filter/composite passes.
+//!
+//! Every GPU filter pass (gamma, blur, morphology, color_matrix, mode,
+//! advanced_blend) needs a small `#[repr(C)]` uniform block bound at group 0.
+//! Each pass used to `device.create_buffer_init` a fresh `wgpu::Buffer` on every
+//! invocation — one driver allocation + tracking object per pass, per frame, for
+//! a 16–80 byte payload.  This pool hands out **reusable** buffers instead,
+//! mirroring flui's existing persistent-uniform pattern (`resources.rs` viewport
+//! uniform; `offscreen/blur.rs` pre-allocated blur slots).
+//!
+//! ## The write-after-read hazard this design avoids
+//!
+//! `queue.write_buffer` writes are applied at submit time, *before* the command
+//! buffer executes.  If two passes in the **same submit** referenced one reused
+//! buffer that was `write_buffer`-rewritten between them, both would read the
+//! last write — silently wrong output.  The engine submits per pass-group
+//! (clear / each backdrop-filter flush / final render are separate submits), but
+//! a single submit (the final render) can hold many filter passes, and the
+//! backdrop-flush submits run earlier in the *same frame*.
+//!
+//! So the pool hands out a **distinct buffer per `alloc` call within a frame**
+//! (the cursor only rewinds on [`UniformPool::reset_frame`], called once
+//! per frame after the final submit).  No buffer is reused within a frame →
+//! no within-frame `write_buffer` collapse.  Across frames the same buffers are
+//! rewritten — the standard, wgpu-synchronised "update a persistent uniform each
+//! frame" pattern (the next frame's write is queued after the previous frame's
+//! submit, so the GPU read completes first).
+//!
+//! [`UniformPool::reset_frame`] therefore belongs at the **once-per-frame** seam
+//! (`WgpuPainter::end_frame_maintenance`), **not** the per-`render` buffer-pool
+//! reset — a per-`render` rewind would alias a backdrop-flush buffer with a
+//! final-render buffer in the same frame.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// One size class: reusable buffers all exactly `size` bytes, handed out in
+/// order and rewound by [`UniformPool::reset_frame`].
+#[derive(Default)]
+struct Bucket {
+    buffers: Vec<wgpu::Buffer>,
+    /// Index of the next buffer to hand out this frame.
+    next: usize,
+}
+
+/// Pool of reusable `UNIFORM | COPY_DST` buffers, bucketed by exact byte size.
+///
+/// Bucketing by exact size keeps every buffer's length equal to its uniform
+/// block's size, so a whole-buffer binding (`BufferBinding { offset: 0, size:
+/// None }`) still satisfies the generated layout's `min_binding_size` — no
+/// dynamic offsets, no 256-byte alignment math.
+pub(crate) struct UniformPool {
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+    buckets: HashMap<u64, Bucket>,
+    /// Cumulative count of buffers ever created — plateaus once a repeating
+    /// workload's buffers are all reused.  Used by tests to prove reuse.
+    total_created: u64,
+}
+
+impl UniformPool {
+    /// Create an empty pool.  Buffers are allocated lazily on first [`alloc`].
+    ///
+    /// [`alloc`]: Self::alloc
+    pub(crate) fn new(device: Arc<wgpu::Device>, queue: Arc<wgpu::Queue>) -> Self {
+        Self {
+            device,
+            queue,
+            buckets: HashMap::new(),
+            total_created: 0,
+        }
+    }
+
+    /// Write `data` into a reusable uniform buffer and return it for binding.
+    ///
+    /// Returns a buffer distinct from every other live `alloc` this frame, so
+    /// callers may bind several uniforms in one submit without aliasing.  The
+    /// returned borrow ends once the bind group is built, freeing the pool for
+    /// the next `alloc`.
+    pub(crate) fn alloc(&mut self, data: &[u8]) -> &wgpu::Buffer {
+        let size = data.len() as u64;
+        // Split the borrow into disjoint fields: `device`/`total_created` are held
+        // while `buckets` is borrowed mutably by `entry`. Buckets are keyed by
+        // exact size, so different filter types that share a size (blur+mode at
+        // 32 B, color_matrix+advanced_blend at 80 B) share a bucket — still safe,
+        // because the cursor advances per `alloc` regardless of caller, so every
+        // live uniform this frame gets a distinct buffer.
+        let device = &self.device;
+        let total_created = &mut self.total_created;
+        let bucket = self.buckets.entry(size).or_default();
+
+        if bucket.next == bucket.buffers.len() {
+            let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("Pooled Uniform Buffer"),
+                size,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+            bucket.buffers.push(buffer);
+            *total_created += 1;
+        }
+
+        let index = bucket.next;
+        bucket.next += 1;
+        self.queue.write_buffer(&bucket.buffers[index], 0, data);
+        &bucket.buffers[index]
+    }
+
+    /// Rewind every size class so the next frame reuses the same buffers.
+    ///
+    /// Call EXACTLY ONCE per frame, after the final submit — never between
+    /// passes or per `WgpuPainter::render` (see the module docs for the
+    /// within-frame aliasing hazard that would cause).
+    pub(crate) fn reset_frame(&mut self) {
+        for bucket in self.buckets.values_mut() {
+            bucket.next = 0;
+        }
+    }
+
+    /// Total uniform buffers ever allocated across all size classes.
+    ///
+    /// Plateaus once a steady-state workload's buffers are all reused — the
+    /// signal the per-frame reuse is working.  Test-only: the reuse contract is
+    /// observable but not part of the production API.
+    #[cfg(all(test, feature = "enable-wgpu-tests"))]
+    pub(crate) fn total_created(&self) -> u64 {
+        self.total_created
+    }
+}
+
+#[cfg(all(test, feature = "enable-wgpu-tests"))]
+mod tests {
+    use std::sync::Arc;
+
+    use super::UniformPool;
+
+    fn device_queue() -> (Arc<wgpu::Device>, Arc<wgpu::Queue>) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .expect("a GPU adapter must be available on a GPU-enabled test host");
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("UniformPool Test Device"),
+            ..Default::default()
+        }))
+        .expect("GPU device creation succeeded when adapter was found");
+        (Arc::new(device), Arc::new(queue))
+    }
+
+    /// The pool reuses buffers across frames and hands out distinct buffers
+    /// within a frame.
+    ///
+    /// Red→green: without [`UniformPool::reset_frame`] (or with broken reuse) the
+    /// second frame's allocations would create three more buffers — `total_created`
+    /// would be 6, not 3.  The within-frame counts also prove distinctness: two
+    /// 16-byte allocations in one frame create two buffers, never one reused.
+    #[test]
+    fn reuses_across_frames_and_distinct_within_frame() {
+        let (device, queue) = device_queue();
+        let mut pool = UniformPool::new(device, queue);
+
+        // Frame 1: two 16-byte + one 32-byte uniform.
+        pool.alloc(&[0u8; 16]);
+        pool.alloc(&[0u8; 32]);
+        pool.alloc(&[0u8; 16]);
+        assert_eq!(
+            pool.total_created(),
+            3,
+            "frame 1 must create one buffer per alloc (2× size-16 distinct + 1× size-32)"
+        );
+
+        // Frame 2: identical workload must reuse every buffer — zero new allocations.
+        pool.reset_frame();
+        pool.alloc(&[0u8; 16]);
+        pool.alloc(&[0u8; 32]);
+        pool.alloc(&[0u8; 16]);
+        assert_eq!(
+            pool.total_created(),
+            3,
+            "frame 2's identical workload must reuse all buffers (no new allocations)"
+        );
+
+        // Exceeding a size class's high-water mark grows it by exactly one.
+        pool.alloc(&[0u8; 16]); // 3rd size-16 this frame → one new buffer
+        assert_eq!(
+            pool.total_created(),
+            4,
+            "a third concurrent size-16 uniform must allocate exactly one more buffer"
+        );
+    }
+}


### PR DESCRIPTION
## What

Finding #2 from the wgpu-ecosystem scan (an in-house win, not a new crate). Every GPU filter/composite pass — gamma, blur, morphology, color_matrix, mode, advanced_blend — used to `device.create_buffer_init` a fresh `wgpu::Buffer` for its 16–80 byte uniform on **every invocation**: one driver allocation + tracking object per pass, per frame, whenever filtered content is drawn.

`UniformPool` (new `src/wgpu/uniform_pool.rs`) hands out **reusable** `UNIFORM | COPY_DST` buffers bucketed by exact byte size, written via `queue.write_buffer`. The 6 sites call `resources.uniform_pool_mut().alloc(...)`; `reset_frame` rewinds the cursor once per frame in `WgpuPainter::end_frame_maintenance`. Generalises flui's existing persistent-uniform patterns (viewport uniform; offscreen-blur slots).

## Correctness — the `write_buffer`-collapse hazard

`queue.write_buffer` is applied at submit time before the command buffer runs, so a reused buffer rewritten between two passes **in one submit** would collapse to the last write (silently wrong filter output). The pool hands out a **distinct buffer per `alloc` within a frame** (cursor only rewinds in `reset_frame`) → no within-frame reuse. `reset_frame` runs at the once-per-frame seam (after the final submit), **not** the per-`render` buffer-pool reset — which would alias a backdrop-flush uniform with a final-render uniform in the same frame. Cross-frame reuse is the standard wgpu-synchronised persistent-uniform pattern.

Bucketing by exact size keeps each buffer's length equal to its uniform block, so whole-buffer bindings still satisfy the generated layout's `min_binding_size` — no dynamic offsets, no 256-byte alignment math.

## Verification

- GPU readback suite (`--features enable-wgpu-tests --test-threads 1`): **454 passed / 0 failed** (was 453; +1 new pool reuse unit test). Filter + backdrop readback tests exercise the pooled path and stay **bit-identical** — empirical proof the 6 sites render identically and the cross-submit (backdrop+final) path is correct.
- New unit test: reuse-across-frames + within-frame distinctness + grow-by-one (red→green — without `reset_frame`, frame 2 would allocate 3 more buffers → `total_created` 6 ≠ 3).
- clippy (default + `enable-wgpu-tests`) `-D warnings`, `cargo fmt --check`, `cargo doc -D warnings`: clean.
- `ce-kieran` review: **SHIP** — all five reset-seam / within-frame-aliasing / borrow-soundness / size-bucket hazards traced clean for principled reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)