### PR TITLE
perf(engine): bucket BufferPool by capacity + LRU byte-budget eviction

### DIFF
--- a/crates/flui-engine/src/wgpu/buffer_pool.rs
+++ b/crates/flui-engine/src/wgpu/buffer_pool.rs
@@ -4,56 +4,71 @@
 //! Instead of creating a new GPU buffer every frame, buffers are pooled
 //! and reused across frames.
 //!
-//! # Performance Impact
+//! # Reuse model
 //!
-//! - **CPU overhead reduction:** 10-20% (eliminates allocation overhead)
-//! - **Memory efficiency:** Reuses buffers instead of creating new ones
-//! - **Driver overhead:** Reduces driver calls for buffer creation
+//! Buffers are bucketed by **capacity rounded up to a power of two** (floor
+//! [`MIN_BUCKET_BYTES`]). A request reuses any free buffer in its bucket, so
+//! geometry whose byte size fluctuates frame to frame (a growing/shrinking
+//! instance count) still reuses a buffer instead of forcing a fresh allocation
+//! on every size change — the old exact-size match defeated reuse for anything
+//! dynamic. The data is written at offset 0 and draws use explicit vertex/index
+//! counts (or sub-range slices), so a buffer larger than its payload renders
+//! identically; the unused tail is never read.
 //!
-//! # Architecture
+//! # Memory budget
 //!
-//! ```text
-//! Frame N:   Allocate buffer A → Use → Return to pool
-//! Frame N+1: Reuse buffer A (if size matches) → Use → Return to pool
-//! Frame N+2: Reuse buffer A (if size matches) → Use → Return to pool
-//! ```
+//! [`BufferPool::evict_over_budget`] drops least-recently-used **free** buffers
+//! once total capacity exceeds a byte budget, so a transient spike (one huge
+//! frame) does not pin VRAM forever. Call it once per frame at the end-of-frame
+//! seam (`WgpuPainter::end_frame_maintenance`), after the final submit: every
+//! buffer is then free, and dropping a `wgpu::Buffer` only schedules the GPU
+//! free once outstanding submissions finish (wgpu ref-counts the resource), so
+//! eviction never frees memory the in-flight frame still reads.
 //!
-//! # Usage
+//! # Reset vs eviction
 //!
-//! ```rust,ignore
-//! let mut pool = BufferPool::new();
-//!
-//! // Get buffer (creates or reuses)
-//! let buffer = pool.get_vertex_buffer(
-//!     &device,
-//!     "Instance Buffer",
-//!     &instance_data,
-//! );
-//!
-//! // Use buffer in render pass
-//! render_pass.set_vertex_buffer(1, buffer.slice(..));
-//!
-//! // Return buffer to pool for next frame (automatic on pool.reset())
-//! pool.reset();  // Call at end of frame
-//! ```
+//! [`BufferPool::reset`] (per `WgpuPainter::render`) only flips `in_use` flags so
+//! the next pass may reuse a buffer. Cross-pass reuse within a frame is sound
+//! because the engine submits per pass (each `render`'s `write_buffer`s attach
+//! to that pass's own submit, and submits are serialized) — so a reused buffer's
+//! prior read completes before its next write executes. Eviction is the separate
+//! per-frame budget pass.
 
-use wgpu::{
-    Buffer, BufferUsages, Device,
-    util::{BufferInitDescriptor, DeviceExt},
-};
+use wgpu::{Buffer, BufferDescriptor, BufferUsages, Device};
 
-/// Buffer pool entry
-struct PooledBuffer {
-    buffer: Buffer,
-    size: usize,
-    in_use: bool,
+/// Floor for bucket capacity. Requests below this round up to it, so tiny
+/// uniform-sized payloads don't each spawn their own bucket.
+const MIN_BUCKET_BYTES: usize = 256;
+
+/// Default capacity budget for [`BufferPool::evict_over_budget`].
+///
+/// Generous enough that steady-state UI frames never evict; eviction reclaims
+/// only the bloat left by a transient large frame. Tunable.
+pub const DEFAULT_BUDGET_BYTES: usize = 64 * 1024 * 1024;
+
+/// Round a byte size up to its pooling bucket: `next_power_of_two`, floored at
+/// [`MIN_BUCKET_BYTES`]. For payloads at or above the floor this bounds waste at
+/// < 2×; smaller payloads round up to the 256-byte floor. Collapsing fluctuating
+/// sizes onto a shared bucket lets them reuse one buffer.
+fn bucket_capacity(size: usize) -> usize {
+    size.max(MIN_BUCKET_BYTES).next_power_of_two()
 }
 
-/// GPU buffer pool for efficient buffer reuse
+/// Buffer pool entry. `capacity` is the buffer's actual byte length (the bucket
+/// size), which is what reuse matches on and what eviction accounts.
+struct PooledBuffer {
+    buffer: Buffer,
+    capacity: usize,
+    in_use: bool,
+    /// Recency clock value at the last acquire — drives LRU eviction.
+    last_used_frame: u64,
+}
+
+/// GPU buffer pool for efficient buffer reuse.
 ///
-/// Maintains separate pools for different buffer types (vertex, index,
-/// uniform). Buffers are matched by size - if requested size matches pooled
-/// buffer size, the buffer is reused. Otherwise, a new buffer is created.
+/// Maintains separate pools for vertex, index, and uniform buffers. Buffers are
+/// matched by power-of-two capacity bucket; over-budget free buffers are evicted
+/// LRU-first by [`evict_over_budget`](BufferPool::evict_over_budget).
 #[derive(Default)]
 pub struct BufferPool {
     vertex_buffers: Vec<PooledBuffer>,
@@ -63,6 +78,11 @@ pub struct BufferPool {
     // Statistics
     allocations: usize,
     reuses: usize,
+
+    /// Monotonic recency clock, advanced once per frame by `evict_over_budget`.
+    /// Each acquire stamps its entry with the current value; eviction drops the
+    /// smallest (oldest) first.
+    current_frame: u64,
 }
 
 impl BufferPool {
@@ -73,8 +93,8 @@ impl BufferPool {
 
     /// Get or create a vertex buffer
     ///
-    /// If a vertex buffer of the same size is available in the pool, it will be
-    /// reused. Otherwise, a new buffer will be created.
+    /// Reuses a free buffer from the request's capacity bucket if available,
+    /// else allocates a fresh bucket-sized buffer.
     ///
     /// # Arguments
     /// * `device` - WGPU device
@@ -100,6 +120,7 @@ impl BufferPool {
             &mut self.vertex_buffers,
             &mut self.allocations,
             &mut self.reuses,
+            self.current_frame,
         )
     }
 
@@ -107,17 +128,18 @@ impl BufferPool {
     // standalone entry points deleted -- zero workspace callers. The
     // joint `get_vertex_and_index_buffers` (below) is the live index-
     // buffer path (split-borrow to dodge the borrow checker), and
-    // uniform buffers don't go through this pool at all (pipeline
-    // construction creates them once via `device.create_buffer`).
+    // uniform buffers don't go through this pool at all (the filter
+    // passes use the dedicated `UniformPool`; pipeline construction
+    // creates its uniforms once via `device.create_buffer`).
     // `index_buffers` / `uniform_buffers` Vec fields stay because
-    // `BufferPool::reset` (the per-frame "mark all buffers free"
-    // pass on line 277) drains all three pools, and the joint
-    // accessor writes into `index_buffers` directly. PR #117 review
-    // fix: prior comment said `BufferPool::shrink` was the
-    // load-bearer; that method was also deleted in this wave, so
-    // `reset` is the actual reason these fields survive.
+    // `BufferPool::reset` / `evict_over_budget` drain all three pools,
+    // and the joint accessor writes into `index_buffers` directly.
 
-    /// Internal: Get or create a buffer from specific pool
+    /// Internal: Get or create a buffer from a specific pool.
+    ///
+    /// `current_frame` is the recency-clock value stamped onto the acquired
+    /// entry (taken by value, so the split-borrow accessor can hand it to both
+    /// calls without an extra borrow).
     #[allow(clippy::too_many_arguments)]
     fn get_buffer_internal<'a>(
         device: &Device,
@@ -128,77 +150,76 @@ impl BufferPool {
         pool: &'a mut Vec<PooledBuffer>,
         allocations: &mut usize,
         reuses: &mut usize,
+        current_frame: u64,
     ) -> &'a Buffer {
-        let size = contents.len();
+        // wgpu's `write_buffer` requires the payload length be a multiple of
+        // COPY_BUFFER_ALIGNMENT (4). All pooled payloads are `bytemuck`-cast
+        // `#[repr(C)]` vertices/instances or `Uint32` indices, so this always
+        // holds; assert it loudly here rather than surfacing as an opaque wgpu
+        // validation error at submit.
+        debug_assert!(
+            contents.len().is_multiple_of(4),
+            "pooled buffer payload length {} must be 4-byte aligned (wgpu COPY_BUFFER_ALIGNMENT)",
+            contents.len()
+        );
 
-        // Try to find available buffer with matching size
+        let capacity = bucket_capacity(contents.len());
+
+        // Reuse a free buffer from the same capacity bucket.
         let reuse_index = pool
             .iter()
-            .position(|entry| !entry.in_use && entry.size == size);
+            .position(|entry| !entry.in_use && entry.capacity == capacity);
 
         if let Some(index) = reuse_index {
-            // Reuse buffer with zero-copy update
             let entry = &mut pool[index];
             entry.in_use = true;
+            entry.last_used_frame = current_frame;
             *reuses += 1;
 
-            #[cfg(debug_assertions)]
-            {
-                let total = *allocations + *reuses;
-                let reuse_rate = if total == 0 {
-                    0.0
-                } else {
-                    *reuses as f32 / total as f32
-                };
-                tracing::trace!(
-                    "BufferPool: Reusing buffer with zero-copy (size={}, reuse_rate={:.1}%)",
-                    size,
-                    reuse_rate * 100.0
-                );
-            }
-
-            // Zero-copy buffer update via queue.write_buffer
-            // This is MUCH faster than recreating the buffer!
-            // Benefits:
-            // - No GPU buffer allocation overhead
-            // - No driver synchronization overhead
-            // - Direct DMA transfer to existing GPU memory
+            // Zero-copy update of the existing GPU allocation. The payload is
+            // written at offset 0; the bucket-sized tail (if `contents` is
+            // smaller than `capacity`) is left untouched and never read, because
+            // draws use explicit vertex/index counts or sub-range slices.
             queue.write_buffer(&entry.buffer, 0, contents);
 
             return &pool[index].buffer;
         }
 
-        // No matching buffer found - create new one
+        // No free buffer in this bucket — allocate one at the bucket capacity.
         *allocations += 1;
 
         #[cfg(debug_assertions)]
         {
             let total = *allocations + *reuses;
+            #[allow(clippy::cast_precision_loss)]
             let reuse_rate = if total == 0 {
                 0.0
             } else {
                 *reuses as f32 / total as f32
             };
-            let pool_len = pool.len();
             tracing::trace!(
-                "BufferPool: Creating new buffer (size={}, pool_size={}, reuse_rate={:.1}%)",
-                size,
-                pool_len + 1,
+                "BufferPool: new buffer (payload={}, capacity={}, pool_size={}, reuse_rate={:.1}%)",
+                contents.len(),
+                capacity,
+                pool.len() + 1,
                 reuse_rate * 100.0
             );
         }
 
-        let buffer = device.create_buffer_init(&BufferInitDescriptor {
+        let buffer = device.create_buffer(&BufferDescriptor {
             label: Some(label),
-            contents,
+            size: capacity as u64,
             usage,
+            mapped_at_creation: false,
         });
+        queue.write_buffer(&buffer, 0, contents);
 
         let index = pool.len();
         pool.push(PooledBuffer {
             buffer,
-            size,
+            capacity,
             in_use: true,
+            last_used_frame: current_frame,
         });
 
         // Safe: We just pushed, so pool[index] exists
@@ -238,9 +259,11 @@ impl BufferPool {
         // The `allocations`/`reuses` counters are shared between the two calls
         // via raw pointers; each `unsafe { &mut *ptr }` expression lives only
         // for the duration of one call argument list, so no two `&mut` aliases
-        // to the same counter are simultaneously live.
+        // to the same counter are simultaneously live. `current_frame` is copied
+        // by value into each call, so it needs no borrow.
         let allocations = &raw mut self.allocations;
         let reuses = &raw mut self.reuses;
+        let current_frame = self.current_frame;
 
         let vertex_buf = Self::get_buffer_internal(
             device,
@@ -256,6 +279,7 @@ impl BufferPool {
             // SAFETY: `reuses` is a valid, aligned, initialised `usize` owned by
             // `self`, distinct from `allocations`. This `&mut` ends at the call site.
             unsafe { &mut *reuses },
+            current_frame,
         );
 
         // Convert to raw pointer to release the mutable borrow on vertex_buffers.
@@ -274,6 +298,7 @@ impl BufferPool {
             unsafe { &mut *allocations },
             // SAFETY: same reasoning as above for `reuses`.
             unsafe { &mut *reuses },
+            current_frame,
         );
 
         // SAFETY: valid because the index-buffer call mutates only `index_buffers`;
@@ -285,12 +310,12 @@ impl BufferPool {
         (vertex_ref, index_buf)
     }
 
-    /// Reset pool for next frame
+    /// Reset pool for next pass/frame.
     ///
-    /// Call this at the end of each frame to mark all buffers as available
-    /// for reuse in the next frame.
+    /// Marks all buffers available for reuse. Called per `WgpuPainter::render`
+    /// (which runs multiple times per frame); only flips `in_use` flags and frees
+    /// nothing — see [`evict_over_budget`](Self::evict_over_budget) for reclaim.
     pub fn reset(&mut self) {
-        // Mark all buffers as available
         for entry in &mut self.vertex_buffers {
             entry.in_use = false;
         }
@@ -302,6 +327,58 @@ impl BufferPool {
         }
     }
 
+    /// Drop least-recently-used free buffers until total capacity ≤ `budget_bytes`,
+    /// then advance the recency clock for the next frame.
+    ///
+    /// Call EXACTLY ONCE per frame, at the end-of-frame seam after the final
+    /// submit (`WgpuPainter::end_frame_maintenance`). At that point every buffer
+    /// is free, and dropping a `wgpu::Buffer` only schedules the GPU free once
+    /// outstanding submissions finish, so this never reclaims memory the in-flight
+    /// frame still reads. Only `!in_use` buffers are ever dropped.
+    pub fn evict_over_budget(&mut self, budget_bytes: usize) {
+        while self.total_capacity_bytes() > budget_bytes {
+            // Find the oldest free entry across all three pools.
+            let mut oldest: Option<(BufferKind, usize, u64)> = None;
+            for (kind, pool) in [
+                (BufferKind::Vertex, &self.vertex_buffers),
+                (BufferKind::Index, &self.index_buffers),
+                (BufferKind::Uniform, &self.uniform_buffers),
+            ] {
+                for (index, entry) in pool.iter().enumerate() {
+                    if entry.in_use {
+                        continue;
+                    }
+                    if oldest.is_none_or(|(_, _, frame)| entry.last_used_frame < frame) {
+                        oldest = Some((kind, index, entry.last_used_frame));
+                    }
+                }
+            }
+
+            match oldest {
+                // Dropping the entry drops its `wgpu::Buffer` (deferred GPU free).
+                Some((BufferKind::Vertex, index, _)) => {
+                    self.vertex_buffers.swap_remove(index);
+                }
+                Some((BufferKind::Index, index, _)) => {
+                    self.index_buffers.swap_remove(index);
+                }
+                Some((BufferKind::Uniform, index, _)) => {
+                    self.uniform_buffers.swap_remove(index);
+                }
+                // No free buffer left to drop — everything is in use this frame.
+                None => break,
+            }
+        }
+
+        self.current_frame = self.current_frame.wrapping_add(1);
+    }
+
+    /// Total byte capacity held across all three pools (live + free).
+    pub fn total_capacity_bytes(&self) -> usize {
+        let sum = |pool: &[PooledBuffer]| pool.iter().map(|entry| entry.capacity).sum::<usize>();
+        sum(&self.vertex_buffers) + sum(&self.index_buffers) + sum(&self.uniform_buffers)
+    }
+
     /// Get reuse rate (0.0 to 1.0)
     ///
     /// 1.0 = 100% reuse (perfect)
@@ -311,32 +388,26 @@ impl BufferPool {
         if total == 0 {
             0.0
         } else {
-            self.reuses as f32 / total as f32
+            #[allow(clippy::cast_precision_loss)]
+            let rate = self.reuses as f32 / total as f32;
+            rate
         }
     }
 
     /// Get statistics for the painter's per-frame log line.
-    ///
-    /// Cycle 4 wave 5 E-10: trimmed from a 6-field struct
-    /// (`vertex_buffers`/`index_buffers`/`uniform_buffers`/
-    /// `allocations`/`reuses`/`reuse_rate`) to a single field. The
-    /// other 5 were set on construction but read by zero callers
-    /// in the workspace; the painter's per-frame log line only
-    /// surfaces the cache-hit ratio.
     pub fn stats(&self) -> BufferPoolStats {
         BufferPoolStats {
             reuse_rate: self.reuse_rate(),
         }
     }
+}
 
-    // Cycle 4 wave 5 E-10: `BufferPool::shrink` deleted. Workspace
-    // grep showed zero callers; the only `shrink()` callsites in
-    // flui-engine live on `TextureCache::shrink` (a different
-    // method). Buffer pools grow with batch size and there's no
-    // tear-down path that calls `.shrink()` -- the eventual
-    // budget-watching tool (separate cleanup wave) can reintroduce
-    // it if needed. The per-pool `retain(|e| e.in_use)` body is
-    // trivial to rewrite when that lands.
+/// Which sub-pool an entry lives in — used by eviction to remove from the right Vec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BufferKind {
+    Vertex,
+    Index,
+    Uniform,
 }
 
 /// Buffer pool statistics surfaced to the painter's per-frame log.
@@ -352,25 +423,112 @@ pub struct BufferPoolStats {
     reason = "tests assert exact expected values produced by exact arithmetic"
 )]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+
+    fn device_queue() -> (Arc<wgpu::Device>, Arc<wgpu::Queue>) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .expect("a GPU adapter must be available on a GPU-enabled test host");
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("BufferPool Test Device"),
+            ..Default::default()
+        }))
+        .expect("GPU device creation succeeded when adapter was found");
+        (Arc::new(device), Arc::new(queue))
+    }
 
     #[test]
     fn test_buffer_pool_size() {
-        // BufferPool should be small
+        // BufferPool should stay small (header only; buffers live behind Vecs).
         assert!(std::mem::size_of::<BufferPool>() <= 128);
     }
 
-    // Cycle 4 wave 5 PR #117 review fix: prior `test_buffer_pool_stats`
-    // asserted on 5 BufferPoolStats fields (`vertex_buffers`,
-    // `index_buffers`, `uniform_buffers`, `allocations`, `reuses`)
-    // that the E-10 trim deleted. The fresh shape exposes only
-    // `reuse_rate`; an empty pool's reuse rate is 0.0 (no allocs +
-    // no reuses → `0 / 0` short-circuits to 0.0 per `reuse_rate()`'s
-    // `total == 0` branch).
     #[test]
     fn test_buffer_pool_stats_empty_pool_zero_reuse_rate() {
         let pool = BufferPool::new();
         let stats = pool.stats();
         assert_eq!(stats.reuse_rate, 0.0);
+    }
+
+    /// Grow-to-fit: two payloads of DIFFERENT byte sizes that share a capacity
+    /// bucket reuse one buffer across frames.
+    ///
+    /// Red→green vs the old exact-size match: 300 and 400 bytes both bucket to
+    /// 512, so frame 2 reuses frame 1's buffer → reuse_rate 0.5. Exact-size
+    /// matching would miss (300 ≠ 400) → two allocations, reuse_rate 0.0.
+    #[test]
+    fn grow_to_fit_reuses_across_fluctuating_size() {
+        let (device, queue) = device_queue();
+        let mut pool = BufferPool::new();
+
+        pool.get_vertex_buffer(&device, &queue, "f1", &[0u8; 300]); // miss → bucket 512
+        pool.reset();
+        pool.get_vertex_buffer(&device, &queue, "f2", &[0u8; 400]); // hit → same bucket 512
+
+        assert_eq!(
+            pool.reuse_rate(),
+            0.5,
+            "a 400-byte payload must reuse the 300-byte payload's 512-byte bucket"
+        );
+    }
+
+    /// A payload exceeding its bucket's prior high-water mark crosses into the
+    /// next power-of-two bucket and allocates fresh (no false reuse).
+    #[test]
+    fn distinct_buckets_do_not_alias() {
+        let (device, queue) = device_queue();
+        let mut pool = BufferPool::new();
+
+        pool.get_vertex_buffer(&device, &queue, "small", &[0u8; 300]); // bucket 512
+        pool.reset();
+        pool.get_vertex_buffer(&device, &queue, "large", &[0u8; 600]); // bucket 1024 → miss
+
+        assert_eq!(
+            pool.reuse_rate(),
+            0.0,
+            "a 600-byte payload (bucket 1024) must not reuse a 512-byte buffer"
+        );
+    }
+
+    /// Eviction drops least-recently-used free buffers until under budget.
+    ///
+    /// Three distinct buckets allocated across three frames (so each has a
+    /// distinct recency stamp and none reuses another): 512 + 1024 + 2048 =
+    /// 3584 bytes. Red→green: without `evict_over_budget` the pool keeps all
+    /// three; with a 2048-byte budget the two oldest (512, then 1024) are
+    /// dropped LRU-first, leaving the newest 2048.
+    #[test]
+    fn evict_over_budget_drops_lru_free_buffers() {
+        let (device, queue) = device_queue();
+        let mut pool = BufferPool::new();
+
+        pool.get_vertex_buffer(&device, &queue, "oldest", &[0u8; 300]); // bucket 512, frame 0
+        pool.reset();
+        pool.evict_over_budget(usize::MAX); // no eviction; advances the clock
+        pool.get_vertex_buffer(&device, &queue, "middle", &[0u8; 600]); // bucket 1024, frame 1
+        pool.reset();
+        pool.evict_over_budget(usize::MAX);
+        pool.get_vertex_buffer(&device, &queue, "newest", &[0u8; 1200]); // bucket 2048, frame 2
+        pool.reset();
+
+        assert_eq!(
+            pool.total_capacity_bytes(),
+            512 + 1024 + 2048,
+            "three distinct buckets before eviction"
+        );
+
+        // Budget fits only the newest bucket → the two oldest are evicted.
+        pool.evict_over_budget(2048);
+        assert_eq!(
+            pool.total_capacity_bytes(),
+            2048,
+            "eviction must drop the 512 and 1024 buckets LRU-first, keeping the newest 2048"
+        );
     }
 }

--- a/crates/flui-engine/src/wgpu/painter/mod.rs
+++ b/crates/flui-engine/src/wgpu/painter/mod.rs
@@ -617,6 +617,15 @@ impl WgpuPainter {
         // `UniformPool::reset_frame`.
         self.resources.uniform_pool_mut().reset_frame();
 
+        // Reclaim over-budget vertex/index buffers (LRU-first). Must run here,
+        // after the final submit, where every pooled buffer is free — dropping a
+        // `wgpu::Buffer` only schedules the GPU free once submissions finish, so
+        // this never reclaims memory the in-flight frame still reads. See
+        // `BufferPool::evict_over_budget`.
+        self.resources
+            .buffer_pool_mut()
+            .evict_over_budget(crate::wgpu::buffer_pool::DEFAULT_BUDGET_BYTES);
+
         let maint = self.resources.texture_cache_mut().end_frame_maintenance();
         if maint.evicted > 0 || maint.atlas_reset {
             tracing::debug!(


### PR DESCRIPTION
## What

Finding #3 from the wgpu-ecosystem scan (in-house, no new crate). The vertex/index `BufferPool` matched reuse by **exact byte size**, so geometry whose byte count fluctuates frame-to-frame (a changing instance count) forced a fresh allocation on every size change — and the pool only ever grew to its high-water mark (`shrink()` deleted, no budget), so one large frame pinned that VRAM forever.

- **Grow-to-fit reuse**: match by capacity bucket (`size.max(256).next_power_of_two()`). The miss path switched `create_buffer_init` → `create_buffer(size = capacity) + write_buffer` so the buffer can be bucket-sized. Payload written at offset 0; draws use explicit counts / sub-range slices, so a larger-than-payload buffer renders identically (tail never read).
- **LRU byte-budget eviction**: `evict_over_budget` drops least-recently-used **free** buffers once total capacity exceeds 64 MiB, once per frame in `WgpuPainter::end_frame_maintenance` after the final submit (all buffers free; dropping a `wgpu::Buffer` defers the GPU free until submissions finish — no use-after-free).

The per-`render` `reset()` is unchanged (cross-pass reuse stays sound — the engine submits per pass, submits serialized). The pre-existing `unsafe` split-borrow is preserved (added `current_frame` is a `Copy` value). A `debug_assert` documents wgpu's 4-byte payload-length invariant.

## Verification

- GPU readback suite (`--features enable-wgpu-tests --test-threads 1`): **457 passed / 0 failed** (was 454; +3 new buffer_pool tests). All geometry/filter/backdrop readback tests render **bit-identically** through the bucketed (larger) buffers + create_buffer→write_buffer path — empirical byte-identity proof.
- New unit tests: grow-to-fit reuse across fluctuating size (red→green vs exact match), distinct-buckets-don't-alias, eviction drops LRU free buffers.
- clippy (default + `enable-wgpu-tests`) `-D warnings`, `cargo fmt --check`, `cargo doc -D warnings`: clean.
- `ce-kieran` review: **SHIP** — larger-buffer correctness (no `.size()` dependence on pooled buffers), `create_buffer`/`write_buffer` + `COPY_DST`, eviction use-after-free, unsafe-block aliasing, and the `size_of` budget all traced clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)