### PR TITLE
feat(view): live BuildContext during build via by-value element extraction (PR-K keystone)

### DIFF
--- a/crates/flui-view/src/context/element_build_context.rs
+++ b/crates/flui-view/src/context/element_build_context.rs
@@ -644,6 +644,299 @@ impl BuildContext for ElementBuildContext {
 }
 
 // ============================================================================
+// BuildCtx — borrowed, build-time BuildContext (PR-K)
+// ============================================================================
+
+/// A dependency a building element registered on an `InheritedElement`.
+///
+/// Recorded during `build()` while the tree is borrowed read-only (a
+/// [`BuildCtx`] holds `&ElementTree`), then applied by
+/// [`BuildOwner::build_scope`](crate::BuildOwner) — which holds `&mut tree`
+/// again once the built element is put back — onto the provider node's
+/// dependent set. Deferring the *write* keeps the build itself read-only
+/// while still recording within the same `build_scope` iteration, before
+/// the next dirty element is processed.
+pub(crate) struct DependentRecord {
+    /// The `InheritedElement` the dependent read from.
+    pub(crate) provider: ElementId,
+    /// The element that read it (and must rebuild when it changes).
+    pub(crate) dependent: ElementId,
+    /// The dependent's tree depth (for dirty-heap ordering).
+    pub(crate) depth: usize,
+}
+
+/// Build-time [`BuildContext`] backed by a live, borrowed read view of the
+/// real [`ElementTree`].
+///
+/// Replaces the empty process-shared dummy that made `depend_on` /
+/// `find_ancestor_*` / notification dispatch inert in production. The
+/// building element is extracted from the slab by value for the duration
+/// of its `build()`
+/// (see [`ElementNode::element`](crate::tree::ElementNode)), so this can
+/// hold a shared `&ElementTree` without aliasing: ancestor walks read every
+/// live node, and the in-flight node reads back as a hole via
+/// [`element_opt`](crate::tree::ElementNode::element_opt).
+///
+/// Inherited dependencies cannot be written here (the tree is read-only),
+/// so they are buffered into `dep_sink` and applied by `build_scope` after
+/// the element is restored. `mark_needs_build` during build is a
+/// Flutter-forbidden no-op.
+pub(crate) struct BuildCtx<'b> {
+    element_id: ElementId,
+    depth: usize,
+    tree: &'b ElementTree,
+    dep_sink: &'b parking_lot::Mutex<Vec<DependentRecord>>,
+}
+
+impl<'b> BuildCtx<'b> {
+    /// Construct a build-time context for `element_id` (at `depth`) over a
+    /// borrowed view of `tree`, buffering inherited dependencies into
+    /// `dep_sink`.
+    pub(crate) fn new(
+        element_id: ElementId,
+        depth: usize,
+        tree: &'b ElementTree,
+        dep_sink: &'b parking_lot::Mutex<Vec<DependentRecord>>,
+    ) -> Self {
+        Self {
+            element_id,
+            depth,
+            tree,
+            dep_sink,
+        }
+    }
+
+    /// Walk strict-ancestors (parent and up), invoking `predicate` on each
+    /// live ancestor element. The in-flight node (extracted during build)
+    /// is skipped via [`element_opt`](crate::tree::ElementNode::element_opt).
+    fn walk_strict_ancestors<R>(
+        &self,
+        mut predicate: impl FnMut(&dyn crate::view::ElementBase) -> std::ops::ControlFlow<R>,
+    ) -> Option<R> {
+        let mut current = self.element_id;
+        loop {
+            let parent_id = self.tree.get(current)?.parent()?;
+            if let Some(elem) = self.tree.get(parent_id)?.element_opt()
+                && let std::ops::ControlFlow::Break(result) = predicate(elem)
+            {
+                return Some(result);
+            }
+            current = parent_id;
+        }
+    }
+
+    /// Nearest strict-ancestor `ElementId` whose view type is `type_id` AND
+    /// which is an `InheritedElement`.
+    ///
+    /// Complexity: O(depth) average and worst case (bounded by tree depth;
+    /// the common `Theme`/`MediaQuery` lookup resolves within a few hops).
+    fn find_inherited_provider(&self, type_id: TypeId) -> Option<ElementId> {
+        let mut current = self.element_id;
+        loop {
+            let parent_id = self.tree.get(current)?.parent()?;
+            if self
+                .tree
+                .get(parent_id)?
+                .element_opt()
+                .is_some_and(|e| e.view_type_id() == type_id && e.as_inherited().is_some())
+            {
+                return Some(parent_id);
+            }
+            current = parent_id;
+        }
+    }
+}
+
+impl BuildContext for BuildCtx<'_> {
+    fn element_id(&self) -> ElementId {
+        self.element_id
+    }
+
+    fn depth(&self) -> usize {
+        self.depth
+    }
+
+    fn mounted(&self) -> bool {
+        true
+    }
+
+    fn is_building(&self) -> bool {
+        true
+    }
+
+    fn owner(&self) -> Option<&BuildOwner> {
+        None
+    }
+
+    fn depend_on_inherited(&self, type_id: TypeId, callback: &mut dyn FnMut(&dyn Any)) -> bool {
+        let Some(provider_id) = self.find_inherited_provider(type_id) else {
+            return false;
+        };
+        let Some(accessor) = self
+            .tree
+            .get(provider_id)
+            .and_then(super::super::tree::ElementNode::element_opt)
+            .and_then(crate::view::ElementBase::as_inherited)
+        else {
+            return false;
+        };
+        callback(accessor.view_as_any());
+        // Defer the dependent-record write to `build_scope` (tree is
+        // read-only here); see [`DependentRecord`].
+        self.dep_sink.lock().push(DependentRecord {
+            provider: provider_id,
+            dependent: self.element_id,
+            depth: self.depth,
+        });
+        true
+    }
+
+    fn get_inherited(&self, type_id: TypeId, callback: &mut dyn FnMut(&dyn Any)) -> bool {
+        let Some(provider_id) = self.find_inherited_provider(type_id) else {
+            return false;
+        };
+        let Some(accessor) = self
+            .tree
+            .get(provider_id)
+            .and_then(super::super::tree::ElementNode::element_opt)
+            .and_then(crate::view::ElementBase::as_inherited)
+        else {
+            return false;
+        };
+        callback(accessor.view_as_any());
+        true
+    }
+
+    fn find_ancestor_element(&self, type_id: TypeId) -> Option<ElementId> {
+        let mut current = self.element_id;
+        loop {
+            let parent_id = self.tree.get(current)?.parent()?;
+            if self
+                .tree
+                .get(parent_id)?
+                .element_opt()
+                .is_some_and(|e| e.view_type_id() == type_id)
+            {
+                return Some(parent_id);
+            }
+            current = parent_id;
+        }
+    }
+
+    fn find_ancestor_view(&self, type_id: TypeId, callback: &mut dyn FnMut(&dyn Any)) -> bool {
+        self.walk_strict_ancestors::<()>(|elem| {
+            if elem.view_type_id() == type_id
+                && let Some(view_any) = elem.view_as_any()
+            {
+                callback(view_any);
+                std::ops::ControlFlow::Break(())
+            } else {
+                std::ops::ControlFlow::Continue(())
+            }
+        })
+        .is_some()
+    }
+
+    fn find_ancestor_state(&self, type_id: TypeId, callback: &mut dyn FnMut(&dyn Any)) -> bool {
+        self.walk_strict_ancestors::<()>(|elem| {
+            if let Some(state_any) = elem.state_as_any()
+                && (*state_any).type_id() == type_id
+            {
+                callback(state_any);
+                std::ops::ControlFlow::Break(())
+            } else {
+                std::ops::ControlFlow::Continue(())
+            }
+        })
+        .is_some()
+    }
+
+    fn find_root_ancestor_state(
+        &self,
+        type_id: TypeId,
+        callback: &mut dyn FnMut(&dyn Any),
+    ) -> bool {
+        let mut root_most: Option<ElementId> = None;
+        let mut current = self.element_id;
+        while let Some(node) = self.tree.get(current) {
+            let Some(parent_id) = node.parent() else {
+                break;
+            };
+            if self
+                .tree
+                .get(parent_id)
+                .and_then(super::super::tree::ElementNode::element_opt)
+                .and_then(crate::view::ElementBase::state_as_any)
+                .is_some_and(|s| (*s).type_id() == type_id)
+            {
+                root_most = Some(parent_id);
+            }
+            current = parent_id;
+        }
+        let Some(matched) = root_most else {
+            return false;
+        };
+        let Some(state_any) = self
+            .tree
+            .get(matched)
+            .and_then(super::super::tree::ElementNode::element_opt)
+            .and_then(crate::view::ElementBase::state_as_any)
+        else {
+            return false;
+        };
+        callback(state_any);
+        true
+    }
+
+    fn find_render_object(&self) -> Option<RenderId> {
+        self.walk_strict_ancestors(|elem| match elem.render_id() {
+            Some(id) => std::ops::ControlFlow::Break(id),
+            None => std::ops::ControlFlow::Continue(()),
+        })
+    }
+
+    fn visit_ancestor_elements(&self, visitor: &mut dyn FnMut(ElementId) -> bool) {
+        let mut current = self.element_id;
+        while let Some(node) = self.tree.get(current) {
+            let Some(parent_id) = node.parent() else {
+                break;
+            };
+            if !visitor(parent_id) {
+                break;
+            }
+            current = parent_id;
+        }
+    }
+
+    fn visit_child_elements(&self, visitor: &mut dyn FnMut(ElementId)) {
+        if let Some(node) = self.tree.get(self.element_id) {
+            for &child_id in node.child_ids() {
+                visitor(child_id);
+            }
+        }
+    }
+
+    fn mark_needs_build(&self) {
+        tracing::warn!(
+            "BuildCtx::mark_needs_build called during build — no-op (Flutter forbids \
+             mark-dirty during the build of the same element)"
+        );
+    }
+
+    fn dispatch_notification(&self, notification: &dyn Notification) {
+        let notification_any: &dyn Any = notification;
+        let type_id = notification_any.type_id();
+        self.walk_strict_ancestors::<()>(|ancestor| {
+            if ancestor.on_notification(type_id, notification_any) {
+                std::ops::ControlFlow::Break(())
+            } else {
+                std::ops::ControlFlow::Continue(())
+            }
+        });
+    }
+}
+
+// ============================================================================
 // Builder for ElementBuildContext
 // ============================================================================
 

--- a/crates/flui-view/src/context/element_build_context.rs
+++ b/crates/flui-view/src/context/element_build_context.rs
@@ -780,14 +780,23 @@ impl BuildContext for BuildCtx<'_> {
         else {
             return false;
         };
-        callback(accessor.view_as_any());
-        // Defer the dependent-record write to `build_scope` (tree is
-        // read-only here); see [`DependentRecord`].
+        // Buffer the dependent BEFORE invoking the user callback. The tree is
+        // read-only here, so the write itself is deferred to the `build_scope`
+        // drain (see [`DependentRecord`]) — but it is *recorded* first, matching
+        // `ElementBuildContext::depend_on_inherited` and Flutter
+        // (`dependOnInheritedElement` calls `updateDependencies` before
+        // returning the widget). This matters on the error path: if the user
+        // `build()` panics after this `depend_on` (caught by `build_or_recover`,
+        // which substitutes an `ErrorView`), the element stays registered as a
+        // dependent, so a later inherited change reschedules it and it recovers.
+        // Recording only after the callback would drop the registration on that
+        // panic and strand the element on the `ErrorView`.
         self.dep_sink.lock().push(DependentRecord {
             provider: provider_id,
             dependent: self.element_id,
             depth: self.depth,
         });
+        callback(accessor.view_as_any());
         true
     }
 
@@ -909,6 +918,16 @@ impl BuildContext for BuildCtx<'_> {
     }
 
     fn visit_child_elements(&self, visitor: &mut dyn FnMut(ElementId)) {
+        // Forbidden during build: a `BuildCtx` is ALWAYS mid-build, and the
+        // node's `child_ids` here are the PRE-reconcile list — for an update
+        // build they may be removed or reordered moments later. Mirrors the
+        // guard on `ElementBuildContext::visit_child_elements` and Flutter's
+        // build-target check (`framework.dart` `_debugCheckOwnerBuildTargetExists`).
+        debug_assert!(
+            !self.is_building(),
+            "visit_child_elements cannot be called during build (a BuildCtx is always \
+             mid-build; its child_ids are the stale pre-reconcile list)"
+        );
         if let Some(node) = self.tree.get(self.element_id) {
             for &child_id in node.child_ids() {
                 visitor(child_id);
@@ -1160,5 +1179,20 @@ mod tests {
     fn test_context_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<ElementBuildContext>();
+    }
+
+    /// `BuildCtx` is the context handed to a live `build()`, so it is always
+    /// mid-build; `visit_child_elements` is forbidden during build (its
+    /// `child_ids` are the stale pre-reconcile list). The debug guard must
+    /// fire — mirroring `ElementBuildContext::visit_child_elements`.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "visit_child_elements cannot be called during build")]
+    fn build_ctx_forbids_visit_child_elements_during_build() {
+        let tree = ElementTree::new();
+        let dep_sink = parking_lot::Mutex::new(Vec::new());
+        // The guard fires before any tree access, so a sentinel id is fine.
+        let ctx = BuildCtx::new(ElementId::new(1), 0, &tree, &dep_sink);
+        ctx.visit_child_elements(&mut |_| {});
     }
 }

--- a/crates/flui-view/src/context/mod.rs
+++ b/crates/flui-view/src/context/mod.rs
@@ -10,3 +10,7 @@ mod element_build_context;
 
 pub use build_context::{BuildContext, BuildContextExt};
 pub use element_build_context::{ElementBuildContext, ElementBuildContextBuilder};
+// Build-time borrowed context + its deferred dependent-record (PR-K). Crate
+// -internal: constructed by the behaviors during `build_scope`, applied by
+// `BuildOwner`.
+pub(crate) use element_build_context::{BuildCtx, DependentRecord};

--- a/crates/flui-view/src/element/behavior.rs
+++ b/crates/flui-view/src/element/behavior.rs
@@ -13,13 +13,80 @@ use flui_rendering::{
 
 use super::{arity::ElementArity, generic::ElementCore};
 use crate::{
-    context::ElementBuildContext,
+    context::{BuildContext, BuildCtx, ElementBuildContext},
     element::RenderSlot,
     view::{
         AnimatedView, InheritedView, IntoView, ProxyView, RenderView, StatefulView, StatelessView,
         View, ViewState,
     },
 };
+
+/// The `BuildContext` a behavior hands to user `build()` / lifecycle code.
+///
+/// During a [`BuildOwner::build_scope`](crate::BuildOwner) drain the owner
+/// carries a [`BuildHandle`](crate::ElementOwner) — a borrowed live view of
+/// the real tree — so the variant resolves to [`BuildCtx`] and ancestor
+/// walks / `depend_on` hit real nodes (PR-K). Outside a drain (mount-time
+/// first build, unit tests that call a behavior directly) no handle is
+/// present and it falls back to the read-only minimal context, which returns
+/// `None`/`false` from every tree walk exactly as before.
+///
+/// Holding the concrete value in a local lets the caller hand out a
+/// `&dyn BuildContext` whose borrow outlives the user `build()` closure.
+enum BuildCtxChoice<'a> {
+    /// Live context over the borrowed real tree (inside `build_scope`).
+    Live(BuildCtx<'a>),
+    /// Read-only minimal fallback (outside `build_scope`).
+    Minimal(ElementBuildContext),
+}
+
+impl BuildCtxChoice<'_> {
+    /// Borrow the chosen context as the object-safe trait.
+    fn as_ctx(&self) -> &dyn BuildContext {
+        match self {
+            Self::Live(ctx) => ctx,
+            Self::Minimal(ctx) => ctx,
+        }
+    }
+}
+
+/// Pick the build context for `core`'s `build()` from `owner`.
+///
+/// `BuildHandle` is `Copy`, so reading `owner.build_view` lifts the borrowed
+/// tree/sink references (lifetime `'a`, tied to the data — not to this `&`
+/// borrow of `owner`) out cleanly; the returned `BuildCtxChoice<'a>` does not
+/// keep `owner` borrowed, so the caller can still pass `owner` on mutably.
+/// Falls back to the minimal context when there is no handle (out of a drain)
+/// or the element is not slab-stamped (`self_id == None`).
+fn make_build_ctx<'a, V, A>(
+    core: &ElementCore<V, A>,
+    owner: &crate::ElementOwner<'a>,
+) -> BuildCtxChoice<'a>
+where
+    V: Clone + Send + Sync + 'static,
+    A: ElementArity,
+{
+    // A build-time handle without a stamped `self_id` is a framework
+    // invariant violation, not an out-of-drain call: every slab-resident
+    // element is `set_self_id`-stamped at insert, and only slab ids reach
+    // `build_scope`. Surface it loudly instead of silently degrading to the
+    // inert context (which would resurrect the very dead-inherited-lookup
+    // divergence this wiring removes).
+    debug_assert!(
+        owner.build_view.is_none() || core.self_id().is_some(),
+        "ElementOwner::build_view set during build_scope but the element has no \
+         self_id — a slab-resident element must be set_self_id-stamped at insert"
+    );
+    match (owner.build_view, core.self_id()) {
+        (Some(handle), Some(element_id)) => BuildCtxChoice::Live(BuildCtx::new(
+            element_id,
+            core.depth(),
+            handle.tree,
+            handle.dep_sink,
+        )),
+        _ => BuildCtxChoice::Minimal(ElementBuildContext::new_minimal(core.depth())),
+    }
+}
 
 // ============================================================================
 // ElementBehavior Trait
@@ -147,7 +214,7 @@ where
     ///
     /// Default returns `None`; only `StatefulBehavior<V>` overrides this
     /// to hand out `&self.state as &dyn Any`. Used by
-    /// [`BuildContext::find_ancestor_state`](crate::BuildContext::find_ancestor_state) (plan §U11, R7) to surface
+    /// [`BuildContext::find_ancestor_state`] (plan §U11, R7) to surface
     /// the typed `ViewState` to the dispatch boundary without naming
     /// `V` at the object-safe trait surface.
     ///
@@ -165,7 +232,7 @@ where
     /// Default returns `None`; only `RenderBehavior<V>` overrides this
     /// (`AnimatedBehavior` composes `StatefulBehavior`, not `RenderBehavior`,
     /// so it keeps the default). Used by
-    /// [`BuildContext::find_render_object`](crate::BuildContext::find_render_object) (plan §U12, R9) to surface
+    /// [`BuildContext::find_render_object`] (plan §U12, R9) to surface
     /// the nearest ancestor's `RenderId` to the dispatch boundary.
     ///
     /// Flutter parity: `framework.dart:5160`
@@ -212,8 +279,18 @@ where
     /// suffices. [`StatefulBehavior`] overrides this to forward to
     /// `ViewState::did_change_dependencies`; [`AnimatedBehavior`]
     /// delegates to the composed `StatefulBehavior`. Plan §U14.
+    ///
+    /// The split-borrow `owner` handle is threaded through so the override
+    /// can resolve the same live build-time context (`BuildHandle`) the
+    /// rebuild uses, letting a user `did_change_dependencies` re-read the
+    /// changed inherited value against the real tree (PR-K).
     #[allow(unused_variables)]
-    fn did_change_dependencies(&mut self, core: &ElementCore<V, A>) {}
+    fn did_change_dependencies(
+        &mut self,
+        core: &ElementCore<V, A>,
+        owner: &mut crate::ElementOwner<'_>,
+    ) {
+    }
 }
 
 // ============================================================================
@@ -256,7 +333,13 @@ where
         if !super::behavior_commons::should_build_with_trace(core, "StatelessBehavior") {
             return Vec::new();
         }
-        let ctx = ElementBuildContext::new_minimal(core.depth());
+        // Live tree-backed context inside a `build_scope` drain (PR-K),
+        // read-only minimal fallback otherwise. Held in a local so the
+        // `&dyn BuildContext` outlives the `catch_unwind` closure below; it
+        // borrows the tree/sink, not `owner`, so the mutable `owner` reborrow
+        // for `build_or_recover` is still free.
+        let ctx_choice = make_build_ctx(core, owner);
+        let ctx = ctx_choice.as_ctx();
         // The user `build()` is wrapped in `catch_unwind`: a panicking
         // build is caught and substituted with the registered
         // `ErrorView`. The catch covers ONLY the build expression — the
@@ -266,14 +349,14 @@ where
         let view = core.view().clone();
         let child_view =
             super::behavior_commons::build_or_recover(core, owner, "StatelessElement", move || {
-                // `view.build(&ctx)` returns `impl IntoView` that may
+                // `view.build(ctx)` returns `impl IntoView` that may
                 // capture closure-local borrows of `view`/`ctx` (Rust 2024
                 // RPITIT default). We consume the opaque value through
                 // `IntoView::into_view()` inside the closure body — the
                 // resulting `<R as IntoView>::View` is `'static`, and
                 // boxing it produces an owned `Box<dyn View>` with no
                 // escaping borrows for `catch_unwind` to return.
-                let opaque = view.build(&ctx);
+                let opaque = view.build(ctx);
                 Box::new(IntoView::into_view(opaque)) as Box<dyn View>
             });
         super::behavior_commons::single_child_views(core, child_view, "StatelessBehavior")
@@ -365,7 +448,7 @@ where
     }
 
     /// Expose the owned `ViewState` (`V::State`) as `&dyn Any` so
-    /// [`BuildContext::find_ancestor_state`](crate::BuildContext::find_ancestor_state) / `find_root_ancestor_state`
+    /// [`BuildContext::find_ancestor_state`] / `find_root_ancestor_state`
     /// (plan §U11, R7/R8) can downcast at the dispatch boundary.
     ///
     /// `V::State: 'static` is guaranteed by the [`ViewState`] trait
@@ -380,13 +463,19 @@ where
         core: &mut ElementCore<V, A>,
         owner: &mut crate::ElementOwner<'_>,
     ) -> Vec<Box<dyn View>> {
-        let ctx = ElementBuildContext::new_minimal(core.depth());
+        // Live tree-backed context inside a `build_scope` drain (PR-K), else
+        // the read-only minimal fallback. One context serves both the
+        // first-build `init_state` and the `build` below; it borrows the
+        // tree/sink, not `owner`/`self`, so the later mutable reborrows stay
+        // free.
+        let ctx_choice = make_build_ctx(core, owner);
+        let ctx = ctx_choice.as_ctx();
 
         // Initialize state on first build — must run before the
         // `should_build` guard so a freshly-mounted `StatefulView` calls
         // `init_state` exactly once even if the element is clean.
         if !self.initialized {
-            self.state.init_state(&ctx);
+            self.state.init_state(ctx);
             self.initialized = true;
         }
 
@@ -407,7 +496,7 @@ where
                 // RPITIT-capture rationale — consume the opaque
                 // `impl IntoView` inside the closure body to box an owned
                 // `Box<dyn View>` for the `catch_unwind` return.
-                let opaque = state.build(&view, &ctx);
+                let opaque = state.build(&view, ctx);
                 Box::new(IntoView::into_view(opaque)) as Box<dyn View>
             });
         super::behavior_commons::single_child_views(core, child_view, "StatefulBehavior")
@@ -449,20 +538,19 @@ where
     /// inactive lifecycles are skipped by the build-scope check itself,
     /// so we get the defensive-shape Flutter calls for free without a
     /// second guard here.
-    fn did_change_dependencies(&mut self, core: &ElementCore<V, A>) {
-        // The dummy `ElementBuildContext::new_minimal` is read-only:
-        // its tree is empty, so `find_ancestor_*`, `depend_on_inherited`,
-        // and friends return `None`/`false`. That matches Flutter — a
-        // user `did_change_dependencies` body that calls `depend_on`
-        // would re-walk the ancestor chain via this context. Cycle 5
-        // ships the cheap separable part of V-13 only (the cached
-        // dummy); the real ancestor-context threading is the deferred
-        // element-ownership unification (Cycle 6). For now, user code
-        // that needs the new inherited value during
-        // `did_change_dependencies` should read it from the cached
-        // state field captured by the previous build.
-        let ctx = ElementBuildContext::new_minimal(core.depth());
-        self.state.did_change_dependencies(&ctx);
+    fn did_change_dependencies(
+        &mut self,
+        core: &ElementCore<V, A>,
+        owner: &mut crate::ElementOwner<'_>,
+    ) {
+        // Live tree-backed context (PR-K) when fired from a `build_scope`
+        // drain — so a user `did_change_dependencies` that re-reads the
+        // changed inherited value via `depend_on` resolves against the real
+        // ancestor chain, matching Flutter (`framework.dart:5977-5982` runs
+        // the hook with the element's live `BuildContext`). Outside a drain
+        // (no handle) this degrades to the read-only minimal context.
+        let ctx_choice = make_build_ctx(core, owner);
+        self.state.did_change_dependencies(ctx_choice.as_ctx());
     }
 }
 
@@ -545,7 +633,7 @@ where
     }
 
     /// Expose the behavior's `RenderId` (set by `on_mount` once a
-    /// `PipelineOwner` is in scope) so [`BuildContext::find_render_object`](crate::BuildContext::find_render_object)
+    /// `PipelineOwner` is in scope) so [`BuildContext::find_render_object`]
     /// (plan §U12, R9) can surface it to the dispatch boundary.
     ///
     /// Returns `None` until `on_mount` has run with a PipelineOwner —
@@ -1026,10 +1114,15 @@ where
     /// Flutter parity (animated widgets in Flutter inherit the
     /// `StatefulElement._didChangeDependencies` flag-and-fire path).
     /// Plan §U14.
-    fn did_change_dependencies(&mut self, core: &ElementCore<V, A>) {
+    fn did_change_dependencies(
+        &mut self,
+        core: &ElementCore<V, A>,
+        owner: &mut crate::ElementOwner<'_>,
+    ) {
         <StatefulBehavior<V> as ElementBehavior<V, A>>::did_change_dependencies(
             &mut self.stateful,
             core,
+            owner,
         );
     }
 }

--- a/crates/flui-view/src/element/generic.rs
+++ b/crates/flui-view/src/element/generic.rs
@@ -182,6 +182,18 @@ where
         self.self_id = Some(id);
     }
 
+    /// This element's own `ElementId`, stamped at slab insertion via
+    /// [`Self::set_self_id`]. `None` for a hand-rolled element that bypassed
+    /// `ElementTree::insert` / `mount_root_*` (not slab-addressable).
+    ///
+    /// Read by the behaviors to anchor the live build-time
+    /// [`BuildCtx`](crate::context::BuildContext) ancestor walk at the real
+    /// node (PR-K); the in-flight element is extracted by value during build,
+    /// so this id addresses the now-empty slot the walk skips.
+    pub(crate) fn self_id(&self) -> Option<ElementId> {
+        self.self_id
+    }
+
     /// Push this element onto the dirty heap so
     /// [`BuildOwner::build_scope`](crate::BuildOwner) reaches it.
     ///
@@ -206,9 +218,9 @@ where
         }
     }
 
-    // NOTE: `self_id` is read directly via `self.self_id` inside
-    // `update_or_create_children` rather than through a getter; the
-    // single in-crate consumer doesn't justify the boilerplate.
+    // NOTE: `update_or_create_children` reads `self.self_id` directly;
+    // external consumers (the build-time `BuildCtx` anchor) go through
+    // [`Self::self_id`].
 
     // ========================================================================
     // Lifecycle Methods (eliminates ~40 lines of boilerplate per element)

--- a/crates/flui-view/src/element/unified.rs
+++ b/crates/flui-view/src/element/unified.rs
@@ -284,8 +284,8 @@ where
     // the scheduled rebuild alone is the right response.
     // ========================================================================
 
-    fn notify_dependency_change(&mut self) {
-        self.behavior.did_change_dependencies(&self.core);
+    fn notify_dependency_change(&mut self, owner: &mut crate::ElementOwner<'_>) {
+        self.behavior.did_change_dependencies(&self.core, owner);
     }
 
     // ========================================================================

--- a/crates/flui-view/src/owner/build_owner.rs
+++ b/crates/flui-view/src/owner/build_owner.rs
@@ -300,6 +300,9 @@ impl BuildOwner {
             inactive_elements: &mut self.inactive_elements,
             pending_dependency_changes: &mut self.pending_dependency_changes,
             on_build_scheduled: self.on_build_scheduled.as_deref(),
+            // Lifecycle paths (mount/unmount/update) get no live-tree view;
+            // only the `build_scope` drain sets `build_view`.
+            build_view: None,
         }
     }
 
@@ -363,37 +366,55 @@ impl BuildOwner {
             // per dependency-change-then-rebuild cycle.
             let needs_did_change = self.pending_dependency_changes.remove(&id);
 
-            // ── Phase 1: extract. Borrow the element from the slab, run
-            // its build half, capture owned child views, drop the borrow.
-            let new_views: Vec<Box<dyn View>> = {
+            // Guard (still holding only a brief `&mut node`): an
+            // inherited-dependency change marks an otherwise-clean dependent
+            // dirty so its build re-runs against the new value; then skip
+            // unless the element is both buildable (lifecycle) AND dirty. A
+            // clean element's build half returns an empty view list, and the
+            // phase-2 reconcile would then wrongly REMOVE all its children —
+            // so a clean entry must never reach reconcile.
+            {
                 let Some(node) = tree.get_mut(id) else {
                     // Stale / removed id — nothing to build.
                     continue;
                 };
-                // An inherited-dependency change marks the dependent dirty
-                // even when its own state is clean: the inherited value it
-                // reads changed, so its build MUST re-run.
-                // `InheritedBehavior::on_view_updated` cannot set the flag
-                // itself — it only has the dependent's id, not slab access —
-                // so the dirty mark is applied here, BEFORE the dirty guard,
-                // keyed off the `pending_dependency_changes` entry. Without
-                // this a clean dependent (dirty flag false after its first
-                // build) would be skipped by the guard below and never
-                // observe the change.
                 if needs_did_change {
                     node.element_mut().mark_needs_build();
                 }
-                // Skip unless the element is both buildable (lifecycle) AND
-                // actually dirty. A clean element's build half would return
-                // an empty view list, and the phase-2 reconcile would then
-                // wrongly REMOVE all its slab-resident children — so a clean
-                // entry must never reach the reconcile. A scheduled child is
-                // always dirty (`tree.update` / fresh insert set the flag),
-                // so this guard does not starve legitimate rebuilds.
                 if !node.element().lifecycle().can_build() || !node.element().is_dirty() {
                     continue;
                 }
+            }
 
+            // ── Phase 1: extract BY VALUE, build against a LIVE read view.
+            // Taking the element out of its slot frees the tree for a shared
+            // `&` borrow, so the element's `build()` can resolve InheritedView
+            // / ancestor lookups against the REAL tree (via the `BuildCtx`
+            // the behaviour builds from `ElementOwner::build_view`) — no empty
+            // dummy, and no deadlock against the `Arc<RwLock>` write lock the
+            // frame driver holds (the borrowed view sidesteps the lock).
+            // Inherited dependents are buffered (the tree is read-only here)
+            // and applied below once `&mut tree` is free again.
+            let Some(mut element) = tree.take_element(id) else {
+                continue;
+            };
+            let dep_sink: parking_lot::Mutex<Vec<crate::context::DependentRecord>> =
+                parking_lot::Mutex::new(Vec::new());
+
+            // Run the build half under `catch_unwind` so the extracted element
+            // is ALWAYS restored to its slot, even on an unwind. The user
+            // `build()` is already caught one level down (`build_or_recover`
+            // substitutes an `ErrorView`), but the other user hooks reachable
+            // in this window — `did_change_dependencies` (via
+            // `notify_dependency_change`) and `init_state` (inside
+            // `StatefulBehavior::build_into_views`) — are not. Without this
+            // guard a panic in either would drop `element` and leave a
+            // permanent `None` hole, turning every later
+            // `element()`/`element_mut()` access on this node into an
+            // `ELEMENT_PRESENT` panic. `AssertUnwindSafe` is sound because the
+            // sole cross-unwind invariant — the slot is whole again — is
+            // re-established by the unconditional `put_element` below.
+            let build_outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 let mut element_owner = super::ElementOwner {
                     global_keys: &mut self.global_keys,
                     dirty_elements: &mut self.dirty_elements,
@@ -401,17 +422,45 @@ impl BuildOwner {
                     inactive_elements: &mut self.inactive_elements,
                     pending_dependency_changes: &mut self.pending_dependency_changes,
                     on_build_scheduled: self.on_build_scheduled.as_deref(),
+                    build_view: Some(super::BuildHandle {
+                        tree: &*tree,
+                        dep_sink: &dep_sink,
+                    }),
                 };
                 if needs_did_change {
-                    node.element_mut().notify_dependency_change();
+                    element.notify_dependency_change(&mut element_owner);
                 }
-                node.element_mut().build_into_views(&mut element_owner)
-            }; // ← element borrow ENDS here.
+                element.build_into_views(&mut element_owner)
+            })); // `element_owner` + its `&*tree` borrow drop here.
 
-            // ── Phase 2: apply. Reconcile the returned views against the
-            // node's slab-resident children with a fresh `&mut tree`.
-            // Newly inserted children are scheduled for build inside the
-            // reconciler so this same drain loop reaches them.
+            // Restore the element BEFORE anything else — the slot must be whole
+            // whether the build returned or unwound. With `&mut tree` free
+            // again we then apply the dependents buffered during the read-only
+            // build onto their provider nodes; recording in the SAME iteration
+            // (before the next dirty pop) preserves Flutter's
+            // record-before-notify ordering (`framework.dart:5086`).
+            tree.put_element(id, element);
+
+            let new_views: Vec<Box<dyn View>> = match build_outcome {
+                Ok(views) => views,
+                // Slot restored above; re-raise so the frame aborts exactly as
+                // it did before (no behavior change beyond keeping the slab
+                // consistent). Partial `dep_sink` records are intentionally
+                // dropped — the build did not complete.
+                Err(payload) => std::panic::resume_unwind(payload),
+            };
+            for record in dep_sink.into_inner() {
+                if let Some(node) = tree.get_mut(record.provider)
+                    && let Some(accessor) = node.element_mut().as_inherited_mut()
+                {
+                    accessor.record_dependent(record.dependent, record.depth);
+                }
+            }
+
+            // ── Phase 2: reconcile the returned views against the node's
+            // slab-resident children with a fresh `&mut tree`. Newly inserted
+            // children are scheduled inside the reconciler so this same drain
+            // loop reaches them.
             let mut element_owner = super::ElementOwner {
                 global_keys: &mut self.global_keys,
                 dirty_elements: &mut self.dirty_elements,
@@ -419,6 +468,7 @@ impl BuildOwner {
                 inactive_elements: &mut self.inactive_elements,
                 pending_dependency_changes: &mut self.pending_dependency_changes,
                 on_build_scheduled: self.on_build_scheduled.as_deref(),
+                build_view: None,
             };
             crate::tree::id_reconcile::reconcile_children_by_id(
                 tree,
@@ -497,7 +547,8 @@ impl BuildOwner {
 
         // Build the split-borrow handle once for the entire unmount sweep.
         // The handle survives `tree.get_mut` borrows because it points into
-        // disjoint `BuildOwner` fields.
+        // disjoint `BuildOwner` fields. No live build runs here, so the
+        // build-time tree handle is absent.
         let mut element_owner = super::ElementOwner {
             global_keys: &mut self.global_keys,
             dirty_elements: &mut self.dirty_elements,
@@ -505,6 +556,7 @@ impl BuildOwner {
             inactive_elements: &mut self.inactive_elements,
             pending_dependency_changes: &mut self.pending_dependency_changes,
             on_build_scheduled: self.on_build_scheduled.as_deref(),
+            build_view: None,
         };
 
         // Finalize all elements (deepest first - already sorted by collect order).

--- a/crates/flui-view/src/owner/element_owner.rs
+++ b/crates/flui-view/src/owner/element_owner.rs
@@ -42,6 +42,25 @@ use flui_foundation::ElementId;
 
 use super::build_owner::{DirtyElement, InactiveElement};
 
+/// Borrowed live-tree access carried by [`ElementOwner`] while a
+/// `build_scope` drain runs an element's `build()` (PR-K).
+///
+/// Lets a behavior construct a live
+/// [`BuildCtx`](crate::context::BuildCtx) — reading the real tree and
+/// buffering inherited dependents — WITHOUT changing the object-safe
+/// `build_into_views` signature: the handle rides on the `ElementOwner`
+/// that is already threaded into every build. `dep_sink` collects the
+/// dependents recorded during the read-only build; `build_scope` drains it
+/// onto the provider nodes once it holds `&mut tree` again.
+///
+/// Both references are `Copy`, so reading [`ElementOwner::build_view`] lifts
+/// them out by value without keeping the owner borrowed.
+#[derive(Clone, Copy)]
+pub(crate) struct BuildHandle<'a> {
+    pub(crate) tree: &'a crate::tree::ElementTree,
+    pub(crate) dep_sink: &'a parking_lot::Mutex<Vec<crate::context::DependentRecord>>,
+}
+
 /// Split-borrow handle into `BuildOwner` for `Element` lifecycle paths.
 ///
 /// Carries `&mut` references to the subset of `BuildOwner` fields a
@@ -63,9 +82,10 @@ use super::build_owner::{DirtyElement, InactiveElement};
 /// - `ElementTree::insert`
 /// - `ElementTree::remove`
 /// - `ElementTree::update`
+/// - `BuildOwner::build_scope` (carrying the live `BuildHandle`)
 ///
-/// Downstream units (U9–U14) layer on top by calling the registration
-/// methods below from `Element` lifecycle code paths.
+/// Downstream units layer on top by calling the registration methods below
+/// from `Element` lifecycle code paths.
 ///
 /// # Flutter equivalent
 ///
@@ -114,6 +134,12 @@ pub struct ElementOwner<'a> {
     /// Stored as a raw reference because `Box<dyn Fn>` is not `Copy`
     /// and we never mutate it through this handle.
     pub(crate) on_build_scheduled: Option<&'a (dyn Fn() + Send + Sync)>,
+
+    /// Live-tree access during a `build_scope` drain (PR-K). `Some` only
+    /// while an element's `build()` runs; `None` on every other lifecycle
+    /// path (mount / unmount / update / reconcile). The behavior reads it
+    /// to build a live [`BuildCtx`](crate::context::BuildCtx).
+    pub(crate) build_view: Option<BuildHandle<'a>>,
 }
 
 impl ElementOwner<'_> {

--- a/crates/flui-view/src/owner/mod.rs
+++ b/crates/flui-view/src/owner/mod.rs
@@ -12,3 +12,6 @@ mod element_owner;
 
 pub use build_owner::BuildOwner;
 pub use element_owner::ElementOwner;
+// Build-time live-tree handle carried on `ElementOwner` during a
+// `build_scope` drain (PR-K). Crate-internal.
+pub(crate) use element_owner::BuildHandle;

--- a/crates/flui-view/src/tree/element_tree.rs
+++ b/crates/flui-view/src/tree/element_tree.rs
@@ -18,7 +18,17 @@ use crate::view::{ElementBase, View};
 /// Contains the Element plus metadata for tree traversal.
 pub struct ElementNode {
     /// The actual Element.
-    pub(crate) element: Box<dyn ElementBase>,
+    ///
+    /// Normally `Some`. A `None` hole exists ONLY transiently inside
+    /// [`BuildOwner::build_scope`](crate::BuildOwner), between
+    /// [`ElementTree::take_element`] and [`ElementTree::put_element`], while
+    /// the element runs its own `build()` against a live read view of the
+    /// rest of the tree. By-value extraction is what lets the element be
+    /// `&mut`-borrowed AND hand the slab a `&` borrow at the same time
+    /// without aliasing. Outside that window every accessor assumes `Some`;
+    /// during it, ancestor walks read [`Self::element_opt`] (which returns
+    /// `None` for the hole rather than panicking).
+    pub(crate) element: Option<Box<dyn ElementBase>>,
     /// Parent Element ID (None for root).
     pub(crate) parent: Option<ElementId>,
     /// Depth in the tree (root = 0).
@@ -83,7 +93,7 @@ impl ElementNode {
     pub fn new(element: Box<dyn ElementBase>, parent: Option<ElementId>, slot: usize) -> Self {
         let depth = if parent.is_some() { 1 } else { 0 }; // Will be updated by tree
         Self {
-            element,
+            element: Some(element),
             parent,
             depth,
             slot,
@@ -93,14 +103,29 @@ impl ElementNode {
         }
     }
 
+    /// Message for the `expect` in the element accessors — the element is
+    /// absent only inside the `build_scope` take/put window.
+    const ELEMENT_PRESENT: &'static str =
+        "ElementNode::element accessed while extracted by build_scope (take/put window)";
+
     /// Get the Element.
     pub fn element(&self) -> &dyn ElementBase {
-        &*self.element
+        &**self.element.as_ref().expect(Self::ELEMENT_PRESENT)
     }
 
     /// Get the Element mutably.
     pub fn element_mut(&mut self) -> &mut dyn ElementBase {
-        &mut *self.element
+        &mut **self.element.as_mut().expect(Self::ELEMENT_PRESENT)
+    }
+
+    /// Get the Element, or `None` if it is currently extracted (the
+    /// transient `build_scope` hole — see [`Self::element`]).
+    ///
+    /// Build-time ancestor walks use this instead of [`Self::element`] so a
+    /// lookup that reaches the in-flight node returns a clean miss in every
+    /// build profile rather than panicking.
+    pub fn element_opt(&self) -> Option<&dyn ElementBase> {
+        self.element.as_deref()
     }
 
     /// Get the parent ElementId.
@@ -182,7 +207,7 @@ impl std::fmt::Debug for ElementNode {
             .field("parent", &self.parent)
             .field("depth", &self.depth)
             .field("slot", &self.slot)
-            .field("lifecycle", &self.element.lifecycle())
+            .field("lifecycle", &self.element.as_ref().map(|e| e.lifecycle()))
             .finish()
     }
 }
@@ -407,10 +432,10 @@ impl ElementTree {
         // Plan §U15: stamp the element with its own ElementId BEFORE
         // `mount` so the Variable-arity reconciler can read it back
         // when emitting ReconcileEvent's `parent` field.
-        self.nodes[slab_index].element.set_self_id(id);
+        self.nodes[slab_index].element_mut().set_self_id(id);
 
         // Mount the element (now it has PipelineOwner set)
-        self.nodes[slab_index].element.mount(None, 0, owner);
+        self.nodes[slab_index].element_mut().mount(None, 0, owner);
 
         // R13: register GlobalKey on mount. The root element's view is
         // queried here because the dispatch boundary at `Element::mount`
@@ -500,12 +525,12 @@ impl ElementTree {
         let id = self.alloc_id(slab_index);
 
         // Plan §U15: same self-id stamping as mount_root.
-        self.nodes[slab_index].element.set_self_id(id);
+        self.nodes[slab_index].element_mut().set_self_id(id);
 
         // Mount the element (PipelineOwner + parent RenderId already set,
         // so `RenderBehavior::on_mount` can create its RenderObject).
         self.nodes[slab_index]
-            .element
+            .element_mut()
             .mount(Some(parent), slot, owner);
 
         // R13: register the GlobalKey hash → id mapping.
@@ -554,6 +579,40 @@ impl ElementTree {
         self.resolve_index(id).is_some()
     }
 
+    /// Extract the element out of node `id`'s slot, leaving a transient
+    /// `None` hole (see [`ElementNode::element`]).
+    ///
+    /// Companion to [`Self::put_element`]:
+    /// [`BuildOwner::build_scope`](crate::BuildOwner) takes the element out
+    /// so it can run that element's own `build()` against a shared `&` view
+    /// of the rest of the slab without aliasing, then puts it back in the
+    /// same iteration. Returns `None` for a stale/absent id or an
+    /// already-empty slot (a re-entrant take is a framework bug).
+    #[allow(
+        dead_code,
+        reason = "consumed by the build-context wiring (PR-K wire-real)"
+    )]
+    pub(crate) fn take_element(&mut self, id: ElementId) -> Option<Box<dyn ElementBase>> {
+        let index = self.resolve_index(id)?;
+        self.nodes.get_mut(index)?.element.take()
+    }
+
+    /// Restore an element previously removed by [`Self::take_element`] into
+    /// node `id`'s slot. No-op for a stale/absent id (cannot happen on the
+    /// build path: the node is re-addressed by the same id taken moments
+    /// earlier).
+    #[allow(
+        dead_code,
+        reason = "consumed by the build-context wiring (PR-K wire-real)"
+    )]
+    pub(crate) fn put_element(&mut self, id: ElementId, element: Box<dyn ElementBase>) {
+        if let Some(index) = self.resolve_index(id)
+            && let Some(node) = self.nodes.get_mut(index)
+        {
+            node.element = Some(element);
+        }
+    }
+
     /// Remove an element from the tree.
     ///
     /// # Soft vs eager removal
@@ -597,7 +656,7 @@ impl ElementTree {
         // remount.
         if self.nodes[index].registered_global_key_hash.is_some() {
             let depth = self.nodes[index].depth;
-            self.nodes[index].element.deactivate();
+            self.nodes[index].element_mut().deactivate();
             owner.push_inactive(id, depth);
             // Detach from active tree but keep the slot alive.
             self.nodes[index].parent = None;
@@ -621,7 +680,7 @@ impl ElementTree {
         // `did_change_dependencies` flag (plan §U14) — the dependent
         // leaves the active tree before its rebuild ever runs.
         owner.clear_pending_dependency_change(id);
-        self.nodes[index].element.unmount(owner);
+        self.nodes[index].element_mut().unmount(owner);
 
         let node = self.nodes.remove(index);
         // Slot freed → bump its generation so any straggler id that still
@@ -662,7 +721,7 @@ impl ElementTree {
         // Drop any stale `did_change_dependencies` flag (plan §U14) —
         // the dependent leaves the tree before its rebuild ever runs.
         owner.clear_pending_dependency_change(id);
-        self.nodes[index].element.unmount(owner);
+        self.nodes[index].element_mut().unmount(owner);
 
         let node = self.nodes.remove(index);
         // Slot freed → bump its generation (ABA guard, see `remove`).
@@ -688,7 +747,7 @@ impl ElementTree {
     /// than relying on the caller having already filtered by it.
     pub fn update(&mut self, id: ElementId, view: &dyn View, owner: &mut crate::ElementOwner<'_>) {
         if let Some(node) = self.get_mut(id) {
-            node.element.update(view, owner);
+            node.element_mut().update(view, owner);
             node.set_key(view.key().map(ViewKey::clone_key));
         }
     }
@@ -696,21 +755,21 @@ impl ElementTree {
     /// Mark an element as needing rebuild.
     pub fn mark_needs_build(&mut self, id: ElementId) {
         if let Some(node) = self.get_mut(id) {
-            node.element.mark_needs_build();
+            node.element_mut().mark_needs_build();
         }
     }
 
     /// Deactivate an element (temporary removal).
     pub fn deactivate(&mut self, id: ElementId) {
         if let Some(node) = self.get_mut(id) {
-            node.element.deactivate();
+            node.element_mut().deactivate();
         }
     }
 
     /// Activate an element (re-insertion after deactivation).
     pub fn activate(&mut self, id: ElementId) {
         if let Some(node) = self.get_mut(id) {
-            node.element.activate();
+            node.element_mut().activate();
         }
     }
 
@@ -841,7 +900,7 @@ fn try_retake_inactive(
     node.depth = parent_depth + 1;
 
     // Re-activate the element. `Lifecycle::Inactive` → `Active`.
-    node.element.activate();
+    node.element_mut().activate();
 
     // Apply the NEW view configuration to the re-taken element. Without
     // this the element keeps the stale view config from before it was
@@ -851,7 +910,7 @@ fn try_retake_inactive(
     // skipped. Flutter's `_retakeInactiveElement` does the same in
     // `framework.dart:4581` (`element.update(newWidget)`) right after
     // activating.
-    node.element.update(view, owner);
+    node.element_mut().update(view, owner);
     // Plan §U7 / FR-022: re-clone the key from the new view value so
     // the stored key tracks the re-taken element's current
     // configuration — the deactivated element's old key may match

--- a/crates/flui-view/src/tree/element_tree.rs
+++ b/crates/flui-view/src/tree/element_tree.rs
@@ -109,11 +109,24 @@ impl ElementNode {
         "ElementNode::element accessed while extracted by build_scope (take/put window)";
 
     /// Get the Element.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the element is currently extracted — the transient hole
+    /// `build_scope` opens between `take_element` and `put_element` while it
+    /// builds the node by value. Any lookup that can run *during* a build
+    /// (every `BuildCtx` ancestor walk) must go through [`Self::element_opt`]
+    /// instead, so reaching the in-flight node is a clean miss, not a panic.
     pub fn element(&self) -> &dyn ElementBase {
         &**self.element.as_ref().expect(Self::ELEMENT_PRESENT)
     }
 
     /// Get the Element mutably.
+    ///
+    /// # Panics
+    ///
+    /// Panics on the same extracted-element hole as [`Self::element`] — see
+    /// its `# Panics` note.
     pub fn element_mut(&mut self) -> &mut dyn ElementBase {
         &mut **self.element.as_mut().expect(Self::ELEMENT_PRESENT)
     }

--- a/crates/flui-view/src/view/view.rs
+++ b/crates/flui-view/src/view/view.rs
@@ -399,7 +399,12 @@ pub trait ElementBase: Downcast + Send + Sync + 'static {
     /// to notify; the scheduled rebuild handles their reaction.
     /// `StatefulBehavior` and `AnimatedBehavior` override the
     /// behavior-side hook to forward to the state.
-    fn notify_dependency_change(&mut self) {}
+    ///
+    /// `owner` carries the split-borrow build handle so the typed hook can
+    /// resolve the same live tree-backed `BuildContext` the rebuild uses
+    /// (PR-K).
+    #[allow(unused_variables)]
+    fn notify_dependency_change(&mut self, owner: &mut crate::ElementOwner<'_>) {}
 
     // ========================================================================
     // Slot Management

--- a/crates/flui-view/tests/inherited_dependency.rs
+++ b/crates/flui-view/tests/inherited_dependency.rs
@@ -23,12 +23,13 @@
 //! non-recording read), and `framework.dart:6414`
 //! (`InheritedElement.notifyClients`).
 
-use std::sync::Arc;
+use std::{any::TypeId, sync::Arc};
 
+use flui_foundation::ElementId;
 use flui_view::{
-    BuildContext, BuildContextExt, BuildOwner, ElementBase, ElementBuildContext, ElementTree,
-    InheritedElement, IntoView, Lifecycle, StatelessBehavior, StatelessElement, StatelessView,
-    View, ViewExt, element::InheritedBehavior, view::InheritedView,
+    BuildContext, BuildContextExt, BuildOwner, ElementBase, ElementBuildContext, ElementOwner,
+    ElementTree, InheritedElement, IntoView, Lifecycle, StatelessBehavior, StatelessElement,
+    StatelessView, View, ViewExt, element::InheritedBehavior, view::InheritedView,
 };
 use parking_lot::RwLock;
 
@@ -82,6 +83,75 @@ impl InheritedView for ThemeProvider {
 impl View for ThemeProvider {
     fn create_element(&self) -> Box<dyn ElementBase> {
         Box::new(InheritedElement::new(self, InheritedBehavior::new(self)))
+    }
+}
+
+// ============================================================================
+// Shared terminal leaf — a build chain must bottom out, so probe/consumer
+// views return this leaf as their child instead of recursing on themselves.
+// `LeafElement::build_into_views` returns no children, so `build_scope`
+// terminates one hop below the deepest interesting node.
+// ============================================================================
+
+#[derive(Clone)]
+struct LeafView;
+
+impl View for LeafView {
+    fn create_element(&self) -> Box<dyn ElementBase> {
+        Box::new(LeafElement::new())
+    }
+}
+
+struct LeafElement {
+    depth: usize,
+    lifecycle: Lifecycle,
+}
+
+impl LeafElement {
+    fn new() -> Self {
+        Self {
+            depth: 0,
+            lifecycle: Lifecycle::Initial,
+        }
+    }
+}
+
+impl ElementBase for LeafElement {
+    fn view_type_id(&self) -> TypeId {
+        TypeId::of::<LeafView>()
+    }
+
+    fn depth(&self) -> usize {
+        self.depth
+    }
+
+    fn lifecycle(&self) -> Lifecycle {
+        self.lifecycle
+    }
+
+    fn mount(&mut self, _parent: Option<ElementId>, slot: usize, _owner: &mut ElementOwner<'_>) {
+        self.depth = slot;
+        self.lifecycle = Lifecycle::Active;
+    }
+
+    fn unmount(&mut self, _owner: &mut ElementOwner<'_>) {
+        self.lifecycle = Lifecycle::Defunct;
+    }
+
+    fn activate(&mut self) {
+        self.lifecycle = Lifecycle::Active;
+    }
+
+    fn deactivate(&mut self) {
+        self.lifecycle = Lifecycle::Inactive;
+    }
+
+    fn update(&mut self, _new_view: &dyn View, _owner: &mut ElementOwner<'_>) {}
+
+    fn mark_needs_build(&mut self) {}
+
+    fn build_into_views(&mut self, _owner: &mut ElementOwner<'_>) -> Vec<Box<dyn View>> {
+        Vec::new()
     }
 }
 
@@ -418,96 +488,19 @@ fn get_inherited_returns_none_when_no_ancestor() {
 // ============================================================================
 
 mod did_change_dependencies_on_inherited_update {
-    use std::{
-        any::TypeId,
-        sync::{Arc, Mutex},
-    };
+    use std::sync::{Arc, Mutex};
 
-    use flui_foundation::ElementId;
     use flui_view::{
-        BuildContext, BuildOwner, ElementBase, ElementOwner, ElementTree, IntoView, Lifecycle,
-        StatefulBehavior, StatefulElement, StatefulView, View, ViewExt, ViewState,
+        BuildContext, BuildOwner, ElementBase, ElementTree, IntoView, StatefulBehavior,
+        StatefulElement, StatefulView, View, ViewExt, ViewState,
     };
 
-    use super::{DummyChild, MyTheme};
+    use super::{DummyChild, LeafView, MyTheme};
 
     /// Shared probe recording lifecycle ordering. Each entry is one
     /// observed event tag ("dcd:N" for the Nth `did_change_dependencies`
     /// call, "build" for a `build` call).
     type Probe = Mutex<Vec<String>>;
-
-    // ========================================================================
-    // Terminal leaf — the build chain must terminate, so probe-stateful
-    // views and the stateless dependent both return this leaf as their
-    // child instead of self.
-    // ========================================================================
-
-    #[derive(Clone)]
-    struct LeafView;
-
-    impl View for LeafView {
-        fn create_element(&self) -> Box<dyn ElementBase> {
-            Box::new(LeafElement::new())
-        }
-    }
-
-    struct LeafElement {
-        depth: usize,
-        lifecycle: Lifecycle,
-    }
-
-    impl LeafElement {
-        fn new() -> Self {
-            Self {
-                depth: 0,
-                lifecycle: Lifecycle::Initial,
-            }
-        }
-    }
-
-    impl ElementBase for LeafElement {
-        fn view_type_id(&self) -> TypeId {
-            TypeId::of::<LeafView>()
-        }
-
-        fn depth(&self) -> usize {
-            self.depth
-        }
-
-        fn lifecycle(&self) -> Lifecycle {
-            self.lifecycle
-        }
-
-        fn mount(
-            &mut self,
-            _parent: Option<ElementId>,
-            slot: usize,
-            _owner: &mut ElementOwner<'_>,
-        ) {
-            self.depth = slot;
-            self.lifecycle = Lifecycle::Active;
-        }
-
-        fn unmount(&mut self, _owner: &mut ElementOwner<'_>) {
-            self.lifecycle = Lifecycle::Defunct;
-        }
-
-        fn activate(&mut self) {
-            self.lifecycle = Lifecycle::Active;
-        }
-
-        fn deactivate(&mut self) {
-            self.lifecycle = Lifecycle::Inactive;
-        }
-
-        fn update(&mut self, _new_view: &dyn View, _owner: &mut ElementOwner<'_>) {}
-
-        fn mark_needs_build(&mut self) {}
-
-        fn build_into_views(&mut self, _owner: &mut ElementOwner<'_>) -> Vec<Box<dyn View>> {
-            Vec::new()
-        }
-    }
 
     // ========================================================================
     // Stateful dependent that records `did_change_dependencies` + `build`
@@ -902,6 +895,419 @@ mod did_change_dependencies_on_inherited_update {
                 .has_pending_dependency_change(dep_id),
             "pending-flag must be cleared after build_scope drains it (even for stateless \
              dependents whose hook is a no-op)"
+        );
+    }
+
+    // ========================================================================
+    // Panic-safety: a panic in the typed `did_change_dependencies` hook (the
+    // `notify_dependency_change` branch of the build-scope take/put window)
+    // must restore the dependent's slab slot, not leave a `None` hole.
+    // ========================================================================
+
+    #[derive(Clone)]
+    struct PanicDcd;
+
+    struct PanicDcdState;
+
+    impl StatefulView for PanicDcd {
+        type State = PanicDcdState;
+
+        fn create_state(&self) -> Self::State {
+            PanicDcdState
+        }
+    }
+
+    impl ViewState<PanicDcd> for PanicDcdState {
+        fn did_change_dependencies(&mut self, _ctx: &dyn BuildContext) {
+            panic!("induced did_change_dependencies panic (build-window panic-safety test)");
+        }
+
+        fn build(&self, _view: &PanicDcd, _ctx: &dyn BuildContext) -> impl IntoView {
+            LeafView.boxed()
+        }
+    }
+
+    impl View for PanicDcd {
+        fn create_element(&self) -> Box<dyn ElementBase> {
+            Box::new(StatefulElement::new(self, StatefulBehavior::new(self)))
+        }
+    }
+
+    #[test]
+    fn did_change_dependencies_panic_leaves_the_slot_intact_not_a_hole() {
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        let mut tree = ElementTree::new();
+        let mut owner = BuildOwner::new();
+
+        let (provider_id, dep_id) =
+            mount_provider_and_record_dependency(&mut tree, &mut owner, 0x00FF_0000, &PanicDcd);
+
+        // Change the inherited value so the dependent is notified: scheduled +
+        // pending typed-hook. Its build window will fire the panicking hook.
+        let provider_v2 = super::ThemeProvider {
+            theme: MyTheme { color: 0x0000_FF00 },
+            child: DummyChild,
+        };
+        tree.update(provider_id, &provider_v2, &mut owner.element_owner_mut());
+
+        let outcome = catch_unwind(AssertUnwindSafe(|| owner.build_scope(&mut tree)));
+        assert!(
+            outcome.is_err(),
+            "the did_change_dependencies panic must propagate out of build_scope",
+        );
+
+        // The guard restored the dependent's slot before re-raising; without
+        // it this read would observe a `None` hole.
+        assert!(
+            tree.get(dep_id)
+                .expect("dependent node still present")
+                .element_opt()
+                .is_some(),
+            "a panic in did_change_dependencies must restore the dependent's slot, not hole it",
+        );
+    }
+}
+
+// ============================================================================
+// PR-K keystone: a consumer's REAL build() resolves an inherited value two
+// hops up through the LIVE element tree, and the dependency it records there
+// drives its rebuild when the value later changes.
+//
+// Before PR-K, `build_into_views` handed user `build()` an empty process-
+// shared dummy context, so `depend_on` inside a real build returned `None`
+// and recorded nothing — inherited data was unreachable from the very place
+// Flutter makes it reachable (`framework.dart:5081`). This module pins the
+// wired behavior end to end: read-during-build → record → notify-on-update.
+// ============================================================================
+
+mod live_inherited_during_build {
+    use std::sync::{Arc, Mutex};
+
+    use flui_foundation::ElementId;
+    use flui_view::{
+        BuildContext, BuildContextExt, BuildOwner, ElementBase, ElementTree, InheritedElement,
+        IntoView, StatelessBehavior, StatelessElement, StatelessView, View, ViewExt,
+        element::InheritedBehavior, view::InheritedView,
+    };
+
+    use super::{LeafView, MyTheme};
+
+    /// The single value the deepest consumer observed via `depend_on` during
+    /// its build. `None` until its `build()` runs; the captured `Option`
+    /// distinguishes "never built" from "built but saw no provider".
+    type ObservedColor = Arc<Mutex<Option<u32>>>;
+
+    /// depth 0 — the inherited provider. Its child is the `Middle` pass-
+    /// through (NOT the consumer directly), so the consumer sits two hops
+    /// below and the ancestor walk must traverse a real intermediate node.
+    #[derive(Clone)]
+    struct ThemeRoot {
+        theme: MyTheme,
+        child: Middle,
+    }
+
+    impl InheritedView for ThemeRoot {
+        type Data = MyTheme;
+
+        fn data(&self) -> &Self::Data {
+            &self.theme
+        }
+
+        fn child(&self) -> &dyn View {
+            &self.child
+        }
+
+        fn update_should_notify(&self, old: &Self) -> bool {
+            self.theme != old.theme
+        }
+    }
+
+    impl View for ThemeRoot {
+        fn create_element(&self) -> Box<dyn ElementBase> {
+            Box::new(InheritedElement::new(self, InheritedBehavior::new(self)))
+        }
+    }
+
+    /// depth 1 — a pure pass-through. It does NOT call `depend_on`, so the
+    /// provider's dependent set isolates the consumer's registration (proving
+    /// the recorded dependent is the deeper node, not the intermediate one).
+    #[derive(Clone)]
+    struct Middle {
+        observed: ObservedColor,
+    }
+
+    impl StatelessView for Middle {
+        fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+            Consumer {
+                observed: self.observed.clone(),
+            }
+            .boxed()
+        }
+    }
+
+    impl View for Middle {
+        fn create_element(&self) -> Box<dyn ElementBase> {
+            Box::new(StatelessElement::new(self, StatelessBehavior))
+        }
+    }
+
+    /// depth 2 — reads the inherited value DURING its real build and stores
+    /// the captured color into the shared sink.
+    #[derive(Clone)]
+    struct Consumer {
+        observed: ObservedColor,
+    }
+
+    impl StatelessView for Consumer {
+        fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+            // The crux: resolve `ThemeRoot` two hops up, against the live
+            // tree, from inside the actual build.
+            let color = ctx.depend_on::<ThemeRoot, u32>(|provider| provider.theme.color);
+            *self.observed.lock().unwrap() = color;
+            LeafView.boxed()
+        }
+    }
+
+    impl View for Consumer {
+        fn create_element(&self) -> Box<dyn ElementBase> {
+            Box::new(StatelessElement::new(self, StatelessBehavior))
+        }
+    }
+
+    /// Count the provider's recorded dependents through the concrete
+    /// `InheritedElement<ThemeRoot>` (the integration crate cannot reach
+    /// `ElementNode::child_ids`, so dependent identity is asserted via this
+    /// count plus the rebuild-on-update phase).
+    fn provider_dependent_count(tree: &ElementTree, provider_id: ElementId) -> usize {
+        tree.get(provider_id)
+            .expect("provider exists")
+            .element()
+            .downcast_ref::<InheritedElement<ThemeRoot>>()
+            .expect("root is InheritedElement<ThemeRoot>")
+            .dependents()
+            .len()
+    }
+
+    #[test]
+    fn consumer_reads_live_inherited_value_and_rebuilds_on_change() {
+        let mut tree = ElementTree::new();
+        let mut owner = BuildOwner::new();
+        let observed: ObservedColor = Arc::new(Mutex::new(None));
+
+        let root_v1 = ThemeRoot {
+            theme: MyTheme { color: 0x00C0_FFEE },
+            child: Middle {
+                observed: observed.clone(),
+            },
+        };
+
+        // Mount the provider and drive a full build: build_scope reconciles
+        // and builds the whole subtree (ThemeRoot -> Middle -> Consumer ->
+        // Leaf), so the consumer's real `build()` runs under a live context.
+        let root_id = tree.mount_root(&root_v1, &mut owner.element_owner_mut());
+        owner.schedule_build_for(root_id, 0);
+        owner.build_scope(&mut tree);
+
+        // CRUX — pre-PR-K this is `None` (empty dummy tree); now the consumer
+        // resolved the provider two ancestor hops up through the live tree.
+        assert_eq!(
+            *observed.lock().unwrap(),
+            Some(0x00C0_FFEE),
+            "Consumer::build must observe ThemeRoot's value via depend_on against the live tree",
+        );
+
+        // The deferred dep-sink drain recorded exactly one dependent (the
+        // consumer; Middle never called depend_on) on the provider node.
+        assert_eq!(
+            provider_dependent_count(&tree, root_id),
+            1,
+            "the consumer's depend_on must register it on the provider (recorded after build)",
+        );
+
+        // ── Phase 2: changing the inherited value must rebuild the recorded
+        // dependent, which re-reads the NEW value live.
+        observed.lock().unwrap().take();
+        let root_v2 = ThemeRoot {
+            theme: MyTheme { color: 0x00BA_DA55 },
+            child: Middle {
+                observed: observed.clone(),
+            },
+        };
+        tree.update(root_id, &root_v2, &mut owner.element_owner_mut());
+
+        assert_eq!(
+            owner.dirty_count(),
+            1,
+            "the recorded dependent (and only it) is scheduled when the inherited value changes",
+        );
+
+        owner.build_scope(&mut tree);
+        assert_eq!(
+            *observed.lock().unwrap(),
+            Some(0x00BA_DA55),
+            "the rebuilt consumer re-reads the updated inherited value through the live context",
+        );
+
+        // The rebuild re-ran `depend_on`, but recording is idempotent — the
+        // dependent set must still hold exactly one entry, not a duplicate.
+        assert_eq!(
+            provider_dependent_count(&tree, root_id),
+            1,
+            "re-recording on rebuild must dedup, not accumulate duplicate dependents",
+        );
+    }
+
+    /// An `Outer` consumer that reads the live value, then builds an `Inner`
+    /// consumer that ALSO reads it — stacked so a single provider ends up
+    /// with two distinct recorded dependents (the keystone test has one).
+    #[derive(Clone)]
+    struct OuterConsumer {
+        own: ObservedColor,
+        inner: ObservedColor,
+    }
+
+    impl StatelessView for OuterConsumer {
+        fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+            *self.own.lock().unwrap() = ctx.depend_on::<ThemeRoot, u32>(|p| p.theme.color);
+            Consumer {
+                observed: self.inner.clone(),
+            }
+            .boxed()
+        }
+    }
+
+    impl View for OuterConsumer {
+        fn create_element(&self) -> Box<dyn ElementBase> {
+            Box::new(StatelessElement::new(self, StatelessBehavior))
+        }
+    }
+
+    #[test]
+    fn multiple_consumers_each_read_live_and_are_recorded() {
+        let mut tree = ElementTree::new();
+        let mut owner = BuildOwner::new();
+        let outer: ObservedColor = Arc::new(Mutex::new(None));
+        let inner: ObservedColor = Arc::new(Mutex::new(None));
+
+        // Mount the provider; its own typed `child` is never built — we attach
+        // the stacked consumers directly under it (mirroring the AE1 setup),
+        // so the throwaway `Middle` child is inert.
+        let root = ThemeRoot {
+            theme: MyTheme { color: 0x00FACADE },
+            child: Middle {
+                observed: Arc::new(Mutex::new(None)),
+            },
+        };
+        let root_id = tree.mount_root(&root, &mut owner.element_owner_mut());
+
+        // ThemeRoot -> OuterConsumer(outer) -> Consumer(inner) -> Leaf: two
+        // consumers at different depths each `depend_on` the same provider.
+        let outer_id = tree.insert(
+            &OuterConsumer {
+                own: outer.clone(),
+                inner: inner.clone(),
+            },
+            root_id,
+            0,
+            &mut owner.element_owner_mut(),
+        );
+        owner.schedule_build_for(outer_id, 1);
+        owner.build_scope(&mut tree);
+
+        assert_eq!(
+            *outer.lock().unwrap(),
+            Some(0x00FACADE),
+            "outer consumer reads the live inherited value",
+        );
+        assert_eq!(
+            *inner.lock().unwrap(),
+            Some(0x00FACADE),
+            "inner consumer reads the live inherited value",
+        );
+        assert_eq!(
+            provider_dependent_count(&tree, root_id),
+            2,
+            "both consumers are recorded as distinct dependents of the provider",
+        );
+    }
+}
+
+// ============================================================================
+// Panic-safety of the build_scope take/put window.
+//
+// `build_scope` extracts each element BY VALUE for the duration of its build
+// and puts it back afterward. A panic in a user hook reachable inside that
+// window (`init_state` / `did_change_dependencies`) must NOT drop the element
+// and leave a permanent `None` hole — every later `element()` access on that
+// node would then panic with `ELEMENT_PRESENT`. A `catch_unwind` guard
+// restores the slot before re-raising. These tests pin that contract: without
+// the guard `element_opt()` returns `None` after the panic.
+// ============================================================================
+
+mod build_window_panic_restores_slot {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use flui_view::{
+        BuildContext, BuildOwner, ElementBase, ElementTree, IntoView, StatefulBehavior,
+        StatefulElement, StatefulView, View, ViewExt, ViewState,
+    };
+
+    use super::LeafView;
+
+    /// A stateful view whose `init_state` panics on first build.
+    #[derive(Clone)]
+    struct PanicOnInit;
+
+    struct PanicOnInitState;
+
+    impl StatefulView for PanicOnInit {
+        type State = PanicOnInitState;
+
+        fn create_state(&self) -> Self::State {
+            PanicOnInitState
+        }
+    }
+
+    impl ViewState<PanicOnInit> for PanicOnInitState {
+        fn init_state(&mut self, _ctx: &dyn BuildContext) {
+            panic!("induced init_state panic (build-window panic-safety test)");
+        }
+
+        fn build(&self, _view: &PanicOnInit, _ctx: &dyn BuildContext) -> impl IntoView {
+            LeafView.boxed()
+        }
+    }
+
+    impl View for PanicOnInit {
+        fn create_element(&self) -> Box<dyn ElementBase> {
+            Box::new(StatefulElement::new(self, StatefulBehavior::new(self)))
+        }
+    }
+
+    #[test]
+    fn init_state_panic_leaves_the_slot_intact_not_a_hole() {
+        let mut tree = ElementTree::new();
+        let mut owner = BuildOwner::new();
+
+        let root_id = tree.mount_root(&PanicOnInit, &mut owner.element_owner_mut());
+        owner.schedule_build_for(root_id, 0);
+
+        // The panic propagates (the guard re-raises after restoring) ...
+        let outcome = catch_unwind(AssertUnwindSafe(|| owner.build_scope(&mut tree)));
+        assert!(
+            outcome.is_err(),
+            "an init_state panic must propagate out of build_scope",
+        );
+
+        // ... but the extracted element is back in its slab slot. Before the
+        // take/put catch_unwind guard this was a permanent `None` hole.
+        assert!(
+            tree.get(root_id)
+                .expect("node still present")
+                .element_opt()
+                .is_some(),
+            "a panic in the build window must restore the slot, not leave a hole",
         );
     }
 }

--- a/crates/flui-view/tests/inherited_dependency.rs
+++ b/crates/flui-view/tests/inherited_dependency.rs
@@ -1231,6 +1231,62 @@ mod live_inherited_during_build {
             "both consumers are recorded as distinct dependents of the provider",
         );
     }
+
+    /// A consumer whose `depend_on` callback panics. `build_or_recover`
+    /// catches it and substitutes an `ErrorView`, so `build_scope` does not
+    /// panic — but the dependency must already be recorded.
+    #[derive(Clone)]
+    struct PanicInDependCallback;
+
+    impl StatelessView for PanicInDependCallback {
+        fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+            ctx.depend_on::<ThemeRoot, u32>(|_provider| {
+                panic!("induced panic inside the depend_on callback")
+            });
+            LeafView.boxed()
+        }
+    }
+
+    impl View for PanicInDependCallback {
+        fn create_element(&self) -> Box<dyn ElementBase> {
+            Box::new(StatelessElement::new(self, StatelessBehavior))
+        }
+    }
+
+    #[test]
+    fn panic_in_depend_callback_still_records_dependent_for_recovery() {
+        let mut tree = ElementTree::new();
+        let mut owner = BuildOwner::new();
+
+        let root = ThemeRoot {
+            theme: MyTheme { color: 0x00C0_FFEE },
+            child: Middle {
+                observed: Arc::new(Mutex::new(None)),
+            },
+        };
+        let root_id = tree.mount_root(&root, &mut owner.element_owner_mut());
+        let consumer_id = tree.insert(
+            &PanicInDependCallback,
+            root_id,
+            0,
+            &mut owner.element_owner_mut(),
+        );
+        owner.schedule_build_for(consumer_id, 1);
+
+        // The build panics inside the depend_on callback, but `build_or_recover`
+        // catches it and substitutes an ErrorView — build_scope must not panic.
+        owner.build_scope(&mut tree);
+
+        // Despite the panic, the consumer must be registered as a dependent so
+        // a later inherited change reschedules it (recovering it from the
+        // ErrorView). Recording the dependent only AFTER the callback would
+        // drop the registration on this panic and strand the element.
+        assert_eq!(
+            provider_dependent_count(&tree, root_id),
+            1,
+            "a depend_on before a panicking callback must still register the dependent",
+        );
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## What

The keystone of the flui-view leapfrog: a building element's `build()` now runs against a **live `BuildContext` over the real `ElementTree`**, restoring Flutter's `build(this)` semantics. Previously every user `build()` was handed an **empty process-shared dummy** (`new_minimal`), so `depend_on` / `find_ancestor_*` / inherited lookups inside a real build were silently inert (returned `None`) — a divergence from Flutter exactly where Flutter makes inherited data reachable.

## How (the mechanism)

`BuildOwner::build_scope` can't hand `build()` a `&ElementTree` while the element sits in the slab (the `&mut element` for `build_into_views` would alias `&tree`), and an `Arc<RwLock>` re-lock would deadlock the write lock the frame driver holds. So per dirty element:

1. **`take_element(id)`** — move the element out by value, leaving a `None` hole in its slot. This frees the tree for a shared `&` borrow.
2. **build against a live `BuildCtx<'b>`** (holds `&'b ElementTree`) carried on `ElementOwner::build_view` as a `Copy` `BuildHandle` — so behaviors build the live context with **no change to the object-safe `build_into_views` signature**. Ancestor walks read real nodes; the in-flight node reads back as a hole via `element_opt()`.
3. **`put_element(id, element)`** — restore, then drain inherited dependents (buffered into a `Mutex<Vec<DependentRecord>>` during the read-only build) onto their provider nodes — **same iteration**, preserving Flutter's record-before-notify ordering.
4. **reconcile** the returned child views with a fresh `&mut tree`.

`did_change_dependencies` / `init_state` also resolve the live tree. Outside a `build_scope` drain (tests / hand-rolled elements — the only non-`build_scope` `build_into_views` callers are `#[test]`) it falls back to the inert `new_minimal`.

### Panic-safety
The take/put window is guarded by `catch_unwind`: a panic in `init_state` / `did_change_dependencies` (the user hooks reachable in-window that `build_or_recover` does **not** already catch) restores the element to its slot before re-raising — no permanent `None` hole that would turn every later `element()` access into an `ELEMENT_PRESENT` panic.

## Tests (each verified failing-first)

- `consumer_reads_live_inherited_value_and_rebuilds_on_change` — depth-3 `ThemeRoot → Middle → Consumer`: the consumer's real `build()` resolves the inherited value **2 hops up through the live tree**, is recorded as a dependent, and **rebuilds on update** re-reading the new value. (`None → Some` without the wiring.)
- `multiple_consumers_each_read_live_and_are_recorded` — fan-out: two consumers at different depths, two distinct recorded dependents.
- `init_state_panic_leaves_the_slot_intact_not_a_hole` / `did_change_dependencies_panic_leaves_the_slot_intact_not_a_hole` — panic-safety regression (a `None` hole without the guard).

## Review & parity

Reviewed by **ce-kieran-rust-reviewer** + **harsh-critic** (keystone sign-off). Both confirmed the by-value extraction is sound (the element is moved out before `&*tree` is borrowed — no alias; `ElementOwner` exposes no mutable tree handle during build; self-dependency is structurally impossible — strict-ancestor walks only). The panic-safety gap they surfaced is **fixed in this PR**.

Cross-checked `.flutter/` `framework.dart`: `build() => state.build(this)` (live element as context), `performRebuild` fires `didChangeDependencies` before build with a once-consumed flag, `dependOnInheritedElement` records the dependent synchronously (flui defers the write to the same-iteration drain — observably equivalent). Ancestor-walk vs `_inheritedElements` hash-map is a pre-existing documented divergence.

## Gates

flui-view **438/438** nextest · `clippy -D warnings` · rustfmt · `rustdoc -D warnings` · port-check (exit 0) · workspace check — all clean.

Builds on PR-K part 1 (`65f18615`, the by-value extraction substrate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)