### PR TITLE
Production lazy-sliver wiring: ListView.builder builds children in a real window

### DIFF
--- a/crates/flui-app/Cargo.toml
+++ b/crates/flui-app/Cargo.toml
@@ -63,3 +63,7 @@ android-activity = { version = "0.6", features = ["native-activity"] }
 # construct synthetic pointer events via `events::make_*_event`. Feature
 # unification keeps these helpers out of the release `flui-app` binary.
 flui-interaction = { path = "../flui-interaction", features = ["testing"] }
+# Enable flui-rendering's `testing` feature in test builds so wiring tests can
+# seed pending child-build requests via `push_pending_child_request_for_test`.
+# Same dev-only feature-unification pattern; helper stays out of release builds.
+flui-rendering = { path = "../flui-rendering", features = ["testing"] }

--- a/crates/flui-app/src/app/binding.rs
+++ b/crates/flui-app/src/app/binding.rs
@@ -458,6 +458,20 @@ impl AppBinding {
             }
         };
 
+        // Production↔headless convergence point: service lazy-sliver child
+        // requests accumulated by `run_frame`'s layout pass. This is the
+        // production equivalent of `HeadlessBinding::pump_frame` step 6.
+        // Lock order: `widgets` (brief write for the split-borrow) → `pipeline`
+        // (brief write inside `service_child_requests` to drain the two pending
+        // Vecs). The `run_frame` pipeline write-guard above is fully released
+        // before this call — no nested write. Future gap-#2 work (production
+        // Vsync / implicit-animation tick) will be added HERE immediately after
+        // this call, keeping the two frame paths converged.
+        {
+            let w = self.widgets.write();
+            w.service_child_requests(&self.shared_pipeline_owner);
+        }
+
         // Phase 4: Create Scene from LayerTree
         let size = constraints.constrain(Size::ZERO);
         let frame_number = self.frames_rendered.load(Ordering::Relaxed) + 1;
@@ -917,5 +931,148 @@ mod tests {
         // Shared process singleton — clean up this pointer's route + arena entry.
         app.gestures().pointer_router().remove_all_routes(pointer);
         app.gestures().sweep_arena(pointer);
+    }
+
+    // ========================================================================
+    // U4.4 — service_child_requests wiring tests
+    // ========================================================================
+
+    /// Wiring test: `AppBinding::draw_frame` must invoke
+    /// `WidgetsBinding::service_child_requests`, which drains the pipeline's
+    /// `pending_child_requests` buffer. We verify the drain happened by:
+    ///   1. Seeding one request via `push_pending_child_request_for_test`
+    ///      (`#[cfg(test)]` helper on `PipelineOwner`).
+    ///   2. Running one `draw_frame`.
+    ///   3. Asserting the buffer is now empty — `take_pending_child_requests`
+    ///      was called, proving the wiring is present.
+    ///
+    /// Without the `service_child_requests` call at ~line 460 of `draw_frame`,
+    /// `take_pending_child_requests` is never called and the buffer remains
+    /// non-empty after the frame. The test is RED without step-2 and GREEN with
+    /// it; no root attach is needed.
+    #[test]
+    fn draw_frame_invokes_service_child_requests() {
+        // A fresh binding so we avoid the singleton root-attach collision.
+        let binding = AppBinding::new();
+
+        // Insert a dummy render object to obtain a valid RenderId (the pending
+        // buffer stores `(RenderId, index)` pairs — any valid id works).
+        let sliver_id = binding.shared_pipeline_owner.write().insert(Box::new(
+            flui_objects::RenderColoredBox::red(10.0, 10.0),
+        )
+            as Box<
+                dyn flui_rendering::traits::RenderObject<flui_rendering::protocol::BoxProtocol>,
+            >);
+
+        // Seed one pending child-build request.  This is the `#[cfg(test)]`
+        // seeding helper — the test-only mirror of `SubtreeArena::request_child_build`.
+        binding
+            .shared_pipeline_owner
+            .write()
+            .push_pending_child_request_for_test(sliver_id, 0);
+
+        // Verify the seed is present (precondition).
+        {
+            let mut guard = binding.shared_pipeline_owner.write();
+            let drained = guard.take_pending_child_requests();
+            assert_eq!(drained.len(), 1, "seed must be present before draw_frame");
+            // Re-push so draw_frame sees it.
+            guard.push_pending_child_request_for_test(sliver_id, 0);
+        }
+
+        // Run one draw_frame.  No root render object is attached (fresh binding)
+        // so no scene is produced, but the service path must still be traversed.
+        let _ = binding.draw_frame(flui_rendering::constraints::BoxConstraints::tight(
+            flui_types::Size::new(
+                flui_types::geometry::px(800.0),
+                flui_types::geometry::px(600.0),
+            ),
+        ));
+
+        // After draw_frame the pending buffer must be empty — drained by
+        // `service_child_requests`.  Without the wiring the buffer is never
+        // drained and this take returns a non-empty vec.
+        let remaining = binding
+            .shared_pipeline_owner
+            .write()
+            .take_pending_child_requests();
+        assert!(
+            remaining.is_empty(),
+            "draw_frame must drain pending_child_requests via service_child_requests; \
+             {} request(s) remained undrained — wiring is absent",
+            remaining.len(),
+        );
+    }
+
+    /// Wake-gate contract: after a frame marks a render node dirty (simulating
+    /// what `service_child_requests` does to a sliver after building new
+    /// children), `has_pending_work()` must return `true` so the runner gate
+    /// (`runner.rs:225`: `needs_redraw() || has_pending_work()`) schedules the
+    /// settling frame.
+    ///
+    /// Also asserts the quiescence direction: once no nodes are dirty,
+    /// `has_pending_work()` is `false` and the app can go idle.
+    ///
+    /// # Wake-gate invariant
+    ///
+    /// The settling frame survives because `layout` marks the sliver dirty
+    /// (`has_dirty_nodes`), NOT because the pending-request buffer is non-empty
+    /// (`has_pending_work` does not consult `pending_child_requests` or
+    /// `pending_retain_bands`). A future change that emits a child request
+    /// WITHOUT calling `mark_needs_layout` would strand the settling frame —
+    /// this test documents and guards that invariant.
+    #[test]
+    fn wake_gate_schedules_settling_frame_after_dirty_mark() {
+        let binding = AppBinding::new();
+
+        // `mark_rendered` puts `needs_redraw` in a known state so the
+        // has_pending_work assertion is insulated from any prior redraw state
+        // set by other singleton tests sharing the same process.
+        binding.mark_rendered();
+        assert!(!binding.needs_redraw(), "precondition: needs_redraw clear");
+
+        // Insert a node and mark it dirty — this is what service_child_requests
+        // does to a sliver after building new children.
+        let node_id = binding.shared_pipeline_owner.write().insert(Box::new(
+            flui_objects::RenderColoredBox::red(10.0, 10.0),
+        )
+            as Box<
+                dyn flui_rendering::traits::RenderObject<flui_rendering::protocol::BoxProtocol>,
+            >);
+        binding
+            .shared_pipeline_owner
+            .write()
+            .clear_all_dirty_nodes();
+        // Confirm quiescence baseline: nothing dirty yet.
+        assert!(
+            !binding.has_pending_work(),
+            "baseline: no pending work after clearing dirty nodes",
+        );
+
+        // Mark the node dirty (as service_child_requests does after building children).
+        binding
+            .shared_pipeline_owner
+            .write()
+            .mark_needs_layout(node_id);
+
+        // The runner gate reads has_pending_work(); it must be true now.
+        assert!(
+            binding.has_pending_work(),
+            "a dirty layout node must make has_pending_work() true so the runner \
+             schedules the settling frame; this is the invariant that lazy-list \
+             settling depends on (NOT the pending_child_requests buffer)",
+        );
+
+        // Once all dirty nodes are cleared (settled frame ran layout), the app
+        // must go idle — no infinite redraw.
+        binding
+            .shared_pipeline_owner
+            .write()
+            .clear_all_dirty_nodes();
+        assert!(
+            !binding.has_pending_work(),
+            "after clearing dirty nodes has_pending_work() must be false so a \
+             settled lazy-list app does not loop forever",
+        );
     }
 }

--- a/crates/flui-app/src/app/binding.rs
+++ b/crates/flui-app/src/app/binding.rs
@@ -964,8 +964,9 @@ mod tests {
                 dyn flui_rendering::traits::RenderObject<flui_rendering::protocol::BoxProtocol>,
             >);
 
-        // Seed one pending child-build request.  This is the `#[cfg(test)]`
-        // seeding helper — the test-only mirror of `SubtreeArena::request_child_build`.
+        // Seed one pending child-build request. The seeding helper is gated
+        // behind flui-rendering's `testing` feature (enabled for this crate's
+        // dev builds) — the test-only mirror of `SubtreeArena::request_child_build`.
         binding
             .shared_pipeline_owner
             .write()

--- a/crates/flui-rendering/src/pipeline/owner/accessors.rs
+++ b/crates/flui-rendering/src/pipeline/owner/accessors.rs
@@ -1113,13 +1113,13 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
     /// Directly seed a pending child-build request for wiring tests.
     ///
     /// Mirrors the internal push that `SubtreeArena::request_child_build`
-    /// performs during layout. Exposed as `pub` (not `#[cfg(test)]`) so that
-    /// integration tests in other crates (e.g. `flui-app`) can verify
-    /// `service_child_requests` wiring without attaching a full lazy-sliver
-    /// tree — the same precedent as `clear_all_dirty_nodes`.
-    ///
-    /// The name makes the test-helper intent explicit; production code never
-    /// calls this (layout emits requests through `SubtreeArena` internally).
+    /// performs during layout, so a cross-crate test (e.g. `flui-app`) can
+    /// verify `service_child_requests` wiring without building a full
+    /// lazy-sliver tree. Gated behind the `testing` feature (plus this crate's
+    /// own `test` cfg) so it never lands in a normal/release build; downstream
+    /// crates opt in via `flui-rendering = { features = ["testing"] }` in their
+    /// dev-dependencies, exactly as the render-object `testing` harness does.
+    #[cfg(any(test, feature = "testing"))]
     pub fn push_pending_child_request_for_test(
         &mut self,
         sliver_id: flui_foundation::RenderId,

--- a/crates/flui-rendering/src/pipeline/owner/accessors.rs
+++ b/crates/flui-rendering/src/pipeline/owner/accessors.rs
@@ -1109,4 +1109,22 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
     pub fn has_mid_layout_marks(&self) -> bool {
         self.scheduler.has_mid_marks()
     }
+
+    /// Directly seed a pending child-build request for wiring tests.
+    ///
+    /// Mirrors the internal push that `SubtreeArena::request_child_build`
+    /// performs during layout. Exposed as `pub` (not `#[cfg(test)]`) so that
+    /// integration tests in other crates (e.g. `flui-app`) can verify
+    /// `service_child_requests` wiring without attaching a full lazy-sliver
+    /// tree — the same precedent as `clear_all_dirty_nodes`.
+    ///
+    /// The name makes the test-helper intent explicit; production code never
+    /// calls this (layout emits requests through `SubtreeArena` internally).
+    pub fn push_pending_child_request_for_test(
+        &mut self,
+        sliver_id: flui_foundation::RenderId,
+        index: usize,
+    ) {
+        self.pending_child_requests.push((sliver_id, index));
+    }
 }

--- a/crates/flui-view/src/binding.rs
+++ b/crates/flui-view/src/binding.rs
@@ -1034,8 +1034,8 @@ impl WidgetsBinding {
     /// Service pending lazy-sliver child-build requests accumulated during the
     /// most recent layout pass.
     ///
-    /// This is the **production entry point** for lazy [`SliverList`] /
-    /// [`ListView::builder`] child building. It mirrors step 6 of
+    /// This is the **production entry point** for lazy `SliverList` /
+    /// `ListView::builder` child building. It mirrors step 6 of
     /// `HeadlessBinding::pump_frame`, and must be called immediately after
     /// `PipelineOwner::run_frame` releases its write-lock so no `NodePtr`
     /// alias is live.

--- a/crates/flui-view/src/binding.rs
+++ b/crates/flui-view/src/binding.rs
@@ -1031,6 +1031,53 @@ impl WidgetsBinding {
         }
     }
 
+    /// Service pending lazy-sliver child-build requests accumulated during the
+    /// most recent layout pass.
+    ///
+    /// This is the **production entry point** for lazy [`SliverList`] /
+    /// [`ListView::builder`] child building. It mirrors step 6 of
+    /// `HeadlessBinding::pump_frame`, and must be called immediately after
+    /// `PipelineOwner::run_frame` releases its write-lock so no `NodePtr`
+    /// alias is live.
+    ///
+    /// `AppBinding::draw_frame` calls this method after the `run_frame`
+    /// write-guard drops (~line 459), passing the same `shared_pipeline_owner`
+    /// that `run_frame` used. The lock order is `widgets → pipeline`: the
+    /// `widgets` write-lock (`WidgetsBinding::inner`) is held here; the brief
+    /// `pipeline.write()` taken inside the delegate is a narrower, nested
+    /// acquisition. This matches the order established in Phase 1 (`build_scope`
+    /// → `pipeline`) and does not introduce a new ordering edge.
+    ///
+    /// # True cost on a no-lazy-list app
+    ///
+    /// This method is **not** a free no-op on applications without lazy lists.
+    /// It always takes a brief `pipeline.write()` to drain the two pending
+    /// `Vec`s (`pending_child_requests` and `pending_retain_bands`) before
+    /// the early-return triggered by their being empty. On a no-lazy-list app
+    /// that is two short lock acquisitions on empty vecs per frame (~microseconds
+    /// on an uncontested `parking_lot::RwLock`). Callers that need to avoid even
+    /// this overhead can gate on `pipeline.read().has_pending_child_requests()`
+    /// before calling, but the unconditional call is simpler and the cost is
+    /// negligible in practice.
+    ///
+    /// # Flutter parity — production↔headless convergence point
+    ///
+    /// This call site is the **production↔headless convergence point** for the
+    /// post-`run_frame` pipeline tail steps. `HeadlessBinding::pump_frame`
+    /// step 6 and `AppBinding::draw_frame` (via this method) now execute the
+    /// same code path. Future gap-#2 work (production Vsync / implicit-animation
+    /// tick) will land at the same `draw_frame` call site immediately after this
+    /// call, keeping both bindings in sync.
+    pub fn service_child_requests(&self, pipeline: &Arc<RwLock<PipelineOwner>>) {
+        let mut inner = self.inner.write();
+        let WidgetsBindingInner {
+            ref mut build_owner,
+            ref mut element_tree,
+            ..
+        } = *inner;
+        build_owner.service_child_requests(element_tree, pipeline);
+    }
+
     /// Check if we are currently building dirty elements.
     ///
     /// Reads the atomic flag directly — no lock acquired.

--- a/crates/flui-view/src/owner/build_owner.rs
+++ b/crates/flui-view/src/owner/build_owner.rs
@@ -700,11 +700,14 @@ impl BuildOwner {
     /// 7. `finalize_tree` cleans up any evicted children pushed to inactive by
     ///    `retain_band` or `on_unmount`.
     ///
-    /// # Headless-binding only
+    /// # Production and headless bindings
     ///
-    /// Production `flui-app` has no `BuildOwner` in scope during `run_frame`;
-    /// production wiring is deferred to when the platform binding has a
-    /// unified tree-holding pattern. Headless tests drive this path directly.
+    /// Called by both `HeadlessBinding::pump_frame` (step 6) and
+    /// `AppBinding::draw_frame` (after `run_frame` drops the pipeline write-lock)
+    /// — the two frame paths are now converged at this call site. Headless
+    /// tests drive it directly via `HeadlessBinding`; a real window drives it via
+    /// `WidgetsBinding::service_child_requests`, which `AppBinding` invokes after
+    /// each `run_frame`.
     pub fn service_child_requests(
         &mut self,
         tree: &mut ElementTree,

--- a/crates/flui-widgets/src/scroll/list_view.rs
+++ b/crates/flui-widgets/src/scroll/list_view.rs
@@ -21,9 +21,17 @@ use crate::scroll::{SliverChildBuilderDelegate, SliverFixedExtentList, SliverLis
 ///
 /// - **Lazy** ([`ListView::builder`]): children built on demand from a
 ///   closure, only for the viewport-visible + cache band. Backed by
-///   [`SliverList`] (variable-height, element-owned). Wired into
-///   `HeadlessBinding::pump_frame` in U4.3; production-window support is
-///   a deferred unit.
+///   [`SliverList`] (variable-height, element-owned). Wired into both
+///   `HeadlessBinding::pump_frame` and the production `AppBinding::draw_frame`
+///   (U4.3 + U4.4 convergence).
+///
+///   **First-frame settling (Flutter divergence):** lazy children are built
+///   *after* the frame's paint, so the first frame a viewport band appears it
+///   paints blank; content lands on the next frame (~16 ms @ 60 fps). The
+///   settling frame is automatically scheduled because layout marks the sliver
+///   dirty. This is a deliberate divergence from Flutter, which builds lazy
+///   children during the same-frame layout pass. See [`SliverChildBuilderDelegate`]
+///   for the full rationale.
 ///
 /// Both modes compose a [`Viewport`] over their respective sliver. `offset`
 /// is a programmatic scroll position in logical pixels.

--- a/crates/flui-widgets/src/scroll/sliver_list.rs
+++ b/crates/flui-widgets/src/scroll/sliver_list.rs
@@ -25,12 +25,19 @@ pub use flui_view::element::SliverList;
 /// lazily-virtualized list that only builds children visible in the viewport
 /// plus a configurable cache margin.
 ///
-/// # Headless-only (U4.3)
+/// # First-frame settling (Flutter divergence)
 ///
-/// Lazy lists are wired into `HeadlessBinding::pump_frame`;
-/// production-window support (a `widgets-binding` that owns a `BuildOwner`) is
-/// a deferred unit. The API is forward-compatible — no delegate-shape changes
-/// will be needed.
+/// Lazy children are built **after** the frame's paint completes, not during
+/// layout as Flutter does. This means the very first frame a viewport band
+/// becomes visible, the children paint blank; content lands on the *next*
+/// frame (~16 ms at 60 fps). The settling frame is automatically scheduled
+/// because layout marks the sliver dirty (`PipelineOwner::has_dirty_nodes`
+/// returns `true`), which keeps the runner's `has_pending_work()` gate open.
+///
+/// This is a deliberate, recorded divergence from Flutter — Flutter builds
+/// lazy children during the same-frame layout pass so no blank frame is
+/// visible. FLUI defers to the post-paint service step for architectural
+/// simplicity; prefetch-hidden items are not affected.
 #[derive(Clone)]
 pub struct SliverChildBuilderDelegate {
     pub(crate) item_count: usize,


### PR DESCRIPTION
## Summary

Wires lazy-sliver child building into the **production** frame path, so a `ListView::builder` / `SliverList` builds its on-demand children in a real window — not just in headless tests (the honest deferral from C1 / PR #320).

The gap: `HeadlessBinding::pump_frame` calls `BuildOwner::service_child_requests` (step 6) but `AppBinding::draw_frame` did not, even though it already runs build_scope + `run_frame` over a real widget tree. So a windowed lazy list emitted child-build requests nobody serviced → empty list forever.

The fix (panel-verified sound, ~10 LOC):
- New `WidgetsBinding::service_child_requests(&self, &Arc<RwLock<PipelineOwner>>)` — one `inner.write()` for the simultaneous `&mut build_owner` + `&mut element_tree` borrow, delegating to `BuildOwner::service_child_requests`.
- Called in `AppBinding::draw_frame` right after the `run_frame` write-guard drops (lock order `widgets → pipeline`, no re-entrancy). Marked as the **production↔headless convergence point** where headless `pump_frame`'s tail steps land.
- The existing `on_need_visual_update` → `wake_frame` → `request_redraw` schedules the next-frame settling; U4.3's quiescence gate keeps a settled list from relaying out forever.

## How it was built

`/dev-task` with a **3-agent plan panel** (chief-architect + systems-perf-lead ACCEPTABLE; harsh-critic DOESN'T-SURVIVE-AS-WRITTEN). All three agreed the wiring is sound; the critic caught that the obvious test (`attach ListView::builder` root, loop `draw_frame`) was **broken three ways** — won't compile (flui-app has no flui-widgets dep), can't re-attach the `OnceLock` singleton, and re-proves the headless path through a renamed entry point. The test strategy was fully replaced:

- **Wiring test** — seed a pending request on a fresh `AppBinding::new()`, run one `draw_frame`, assert the buffer drains (only `service_child_requests` drains it → genuine red→green, no singleton root-attach).
- **Wake-gate contract test** — after a dirty mark, `has_pending_work()` is true (the `runner.rs` gate schedules the settling frame); clean → false (a settled app idles). Documents the invariant that settling survives via layout-dirty, NOT the request buffer.
- Review (rust-reviewer) then gated the test-only `push_pending_child_request_for_test` seeding helper behind flui-rendering's `testing` feature (out of the production API).

## Honest scope (deferred, recorded)

- **Production implicit-animation `Vsync` ticking is NOT wired** — an `AnimatedContainer` in a window stays frozen until the next unit lands at the same `draw_frame` convergence point. (`Vsync` registry has zero flui-app wiring; production ticks plain `AnimationController`s via the `Scheduler`.)
- **First-frame settling** is documented as a deliberate Flutter divergence: lazy children build after paint, so the first frame a band appears is blank and content lands next frame (~16ms @ 60fps). Flutter builds during layout (same-frame).

## Verification

- `cargo test -p flui-view -p flui-app --test-threads=1` — green (2 new tests)
- `cargo clippy -p flui-rendering -p flui-view -p flui-app --all-targets -- -D warnings` clean · `cargo fmt --check` clean
- `cargo doc --workspace --no-deps --document-private-items` (RUSTDOCFLAGS=-D warnings) → 0 (fixed proactively)
- flui-rendering normal build excludes the test helper; flui-app test build sees it via the dev-only `testing` feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)