### PR TITLE
Ship-quality Phase 0: full CI gate coverage, workspace lint enforcement, facade + repo polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,5 +407,8 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
 
+      # `+nightly` is required: the committed rust-toolchain.toml pin (1.96.0)
+      # overrides the job's installed default toolchain, and the pinned stable
+      # has no miri component (first run failed exactly there).
       - name: cargo miri test (subtree_arena)
-        run: cargo miri test -p flui-rendering --lib pipeline::owner::subtree_arena
+        run: cargo +nightly miri test -p flui-rendering --lib pipeline::owner::subtree_arena

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     continue-on-error: true
+    env:
+      # Override the workflow-level `-D warnings`: nightly deprecates APIs
+      # ahead of stable (e.g. `Atomic::fetch_update` -> `try_update`, which
+      # does not exist on the 1.96 MSRV yet), and those deprecation warnings
+      # would fail this job spuriously. Lint enforcement is the stable jobs'
+      # business; this job exists solely to catch undefined behavior.
+      RUSTFLAGS: ""
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,15 +178,18 @@ jobs:
         if: runner.os == 'Linux'
         run: df -h /
 
+      # Runs BOTH unit (--lib) and integration (tests/) targets — the
+      # integration dirs carry the Core.0/Core.2 exit-gate suites
+      # (flui-rendering 37 files, flui-widgets 51, flui-view 26) and were
+      # previously never executed in CI (the invocation was `--lib` only).
       # `--test-threads=1` guards the documented pre-existing flui-app
       # singleton-state flake (CLAUDE.md). flui-platform tests are excluded
       # until the spawned STATUS_HEAP_CORRUPTION investigation lands a fix.
-      - name: cargo nextest run (--lib, --test-threads 1)
+      - name: cargo nextest run (lib + integration, --test-threads 1)
         run: >
           cargo nextest run
           --workspace
           --exclude flui-platform
-          --lib
           --no-fail-fast
           --test-threads 1
 
@@ -209,12 +212,12 @@ jobs:
   # passed), and the run is fast (nextest ~16 s; the ~8 min is the wgpu-stack
   # build). So this now runs the FULL `enable-wgpu-tests` suite (~440 tests).
   #
-  # Still `continue-on-error` (ADVISORY) for now: this first full-suite run
-  # measures real wall-time + surfaces any WARP-slow/flaky test before the gate
-  # becomes merge-blocking. Once the full suite shows ~3 consecutive green runs
-  # within budget, drop `continue-on-error` and add `gpu-test` to required
-  # checks. Verified only by THIS workflow's run — the dev machine is hardware
-  # DX12, so the WARP software path cannot be exercised locally.
+  # MERGE-BLOCKING as of 2026-07: the full suite showed 3 consecutive green
+  # runs on main (CI #583/#586/#595 — job wall-time 5m/7m/15m, nextest step
+  # 4m/5m/13m) against the 60-minute budget, satisfying the promotion
+  # criterion recorded here during the pilot. Verified only by THIS
+  # workflow's run — the dev machine is hardware DX12, so the WARP software
+  # path cannot be exercised locally.
   # ─────────────────────────────────────────────────────────────────────────
   gpu-test:
     name: gpu-test (wgpu readback, WARP)
@@ -225,10 +228,6 @@ jobs:
     # full run measures the real figure; tighten or shard (nextest partition)
     # afterward if needed.
     timeout-minutes: 60
-    # Advisory until the full suite is proven green + in-budget across a few
-    # runs: a flaky/slow required GPU gate is worse than none. Drop this line to
-    # make it merge-blocking.
-    continue-on-error: true
     env:
       CARGO_PROFILE_TEST_DEBUG: line-tables-only
       # Surface the wgpu adapter selection in the log so the run confirms WARP
@@ -322,3 +321,91 @@ jobs:
 
       - name: cargo doc --no-deps
         run: cargo doc --workspace --no-deps --document-private-items
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # doc-test — run every rustdoc example as a test. nextest does NOT execute
+  # doctests (cargo-nextest#16), so the `test` job above never covers them;
+  # without this job the 700+ doc code fences in the workspace are unverified
+  # prose. Same exclusion as `test`: flui-platform (STATUS_HEAP_CORRUPTION).
+  # ─────────────────────────────────────────────────────────────────────────
+  doc-test:
+    name: doc-test
+    needs: checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      - name: cargo test --doc
+        run: cargo test --workspace --exclude flui-platform --doc
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # msrv — verify the declared MSRV actually compiles the workspace. Every
+  # other job installs `dtolnay/rust-toolchain@stable`, which OVERRIDES the
+  # committed rust-toolchain.toml pin — so before this job, the 1.96 floor in
+  # `[workspace.package].rust-version` was never exercised in CI. `check`
+  # (not `test`): MSRV promises "compiles on 1.96", behavior is the stable
+  # jobs' concern. Bump procedure lives in rust-toolchain.toml's header.
+  # ─────────────────────────────────────────────────────────────────────────
+  msrv:
+    name: msrv (1.96)
+    needs: checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust 1.96 (declared MSRV)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.96"
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      - name: cargo check --workspace (MSRV)
+        run: cargo check --workspace --all-targets
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # miri — undefined-behavior check for the workspace's densest unsafe hot
+  # spot: flui-rendering's subtree arena (raw-pointer arena with ~49 unsafe
+  # sites). flui-rendering has no wgpu dependency, so miri can execute it;
+  # the test filter keeps runtime sane (workspace-wide miri is not realistic
+  # on this stack). ADVISORY (continue-on-error) until a few runs establish
+  # it is stable and in-budget — then drop the line, same playbook as
+  # gpu-test.
+  # ─────────────────────────────────────────────────────────────────────────
+  miri:
+    name: miri (flui-rendering subtree_arena)
+    needs: checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust nightly + miri
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      - name: cargo miri test (subtree_arena)
+        run: cargo miri test -p flui-rendering --lib pipeline::owner::subtree_arena

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ FLUI is a Flutter-inspired declarative UI framework for Rust with a three-tree a
 - **Graphics:** `wgpu` 29.x, `lyon`, `glyphon`, `cosmic-text`, `glam`
 - **Platform:** native Win32, AppKit, headless backends + `winit` 0.30 fallback
 - **Diagnostics:** `tracing` only — **no `println!`, `eprintln!`, or `dbg!` in shipped code** (CI enforces this in foundation/tree/macros crates via port-check trigger #15)
-- **Errors:** `thiserror` (libraries), `anyhow` (applications)
+- **Errors:** `thiserror` (libraries), `anyhow` (applications); panics only per [`docs/PANIC-POLICY.md`](docs/PANIC-POLICY.md) — `expect("BUG: <invariant>")` for internal invariants, never bare `unwrap()` on production paths (`clippy::unwrap_used` gates this)
 - **Async runtime:** `tokio` 1.43 LTS
 
 ## Key Entry Points
@@ -108,8 +108,10 @@ This project uses **`justfile`** for build automation. Install [`just`](https://
 | `just clippy` | Lint gate: `cargo clippy --workspace --all-targets -- -D warnings` |
 | `just fmt` | Format with rustfmt |
 | `just fmt-check` | Format check (CI gate) |
-| `just inventory-check` | Docs / justfile crate inventory drift guard |
-| `just ci` | Full local CI: `fmt-check` → `inventory-check` → `port-check` → `clippy` → `test` |
+| `just inventory-check` | Docs / justfile crate inventory drift guard (incl. `[lints] workspace = true` on every crate) |
+| `just ci` | Full local CI: `fmt-check` → `inventory-check` → `port-check` → `clippy` → `test` → `test-doc` |
+| `just test-doc` | Run rustdoc examples as tests (nextest never executes doctests) |
+| `just miri` | Miri over the `flui-rendering` subtree arena (unsafe hot spot; needs nightly + miri) |
 | `just example-hello` | Platform smoke test |
 | `just port-check` | Port-methodology refusal triggers |
 | `just port-check-verbose` | Per-trigger pass/fail + marker totals |
@@ -174,6 +176,7 @@ When changing render-tree, sliver, layout, paint, hit-test, semantics, schedulin
 | **Architecture** | `docs/architecture.md` | Three-tree pipeline overview |
 | **Crates map** | `docs/crates.md` | Per-layer crate inventory |
 | **Testing** | `docs/testing.md` | Build/test/coverage commands |
+| **Panic policy** | `docs/PANIC-POLICY.md` | When `expect("BUG: …")` is allowed vs. `Result`; `clippy::unwrap_used` gate |
 | **Render harness** | `crates/flui-rendering/docs/TESTING.md` | RenderTester API, catalog rules |
 | **Crate ARCHITECTURE.md** | `crates/flui-{foundation,rendering,engine,layer,painting}/ARCHITECTURE.md` | Per-crate deep architecture |
 
@@ -194,13 +197,17 @@ When changing render-tree, sliver, layout, paint, hit-test, semantics, schedulin
 
 ## CI Pipeline
 
-CI runs on PR + push to main. Jobs (in dependency order):
+CI runs on PR + push to main. Jobs (all gated on `checks`):
 
-1. **checks** — `cargo fmt --check`, `taplo fmt --check`, `typos`, `scripts/check-workspace-inventory.sh`, `port-check.sh`
-2. **clippy** — `cargo clippy --workspace --all-targets -- -D warnings` (needs: checks)
-3. **test** — `cargo nextest run --workspace --exclude flui-platform --lib --test-threads 1` (needs: checks, Linux only)
-4. **bench-compile** — `cargo bench -p flui-rendering --no-run` (needs: checks)
-5. **doc** — `cargo doc --workspace --no-deps --document-private-items` with `RUSTDOCFLAGS="-D warnings"` (needs: checks)
+1. **checks** — `cargo fmt --check`, `taplo fmt --check`, `typos`, `scripts/check-workspace-inventory.sh` (incl. the `[lints] workspace = true` drift guard), `port-check.sh`
+2. **clippy** — `cargo clippy --workspace --all-targets -- -D warnings`
+3. **test** — `cargo nextest run --workspace --exclude flui-platform --test-threads 1` (lib **and** integration targets; Linux only)
+4. **gpu-test** — full `enable-wgpu-tests` readback suite on WARP (windows-latest; merge-blocking)
+5. **doc-test** — `cargo test --workspace --exclude flui-platform --doc` (nextest never runs doctests)
+6. **msrv** — `cargo check --workspace --all-targets` on Rust 1.96 (the declared MSRV; other jobs run latest stable)
+7. **miri** — `cargo miri test -p flui-rendering` scoped to `pipeline::owner::subtree_arena` (advisory while stabilizing)
+8. **bench-compile** — `cargo bench -p flui-rendering --no-run`
+9. **doc** — `cargo doc --workspace --no-deps --document-private-items` with `RUSTDOCFLAGS="-D warnings"`
 
 ## Important Config
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to the FLUI workspace are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+FLUI is pre-release and not published to crates.io; entries are grouped under
+`[Unreleased]` until a first tagged release cuts them over. Workspace version:
+`0.2.0` (all crates share `[workspace.package].version`). Fine-grained phase
+history lives in [`docs/ROADMAP-TRACKER.md`](docs/ROADMAP-TRACKER.md); this
+file records the repo-consumer-visible summary.
+
+## [Unreleased]
+
+### Added
+
+- **CI gates**: integration tests now run in CI (previously `--lib` only —
+  the Core.0/Core.2 exit-gate suites in `crates/*/tests/` were never
+  executed); new `doc-test` job runs every rustdoc example; new `msrv` job
+  verifies the declared 1.96 floor; new advisory `miri` job checks the
+  `flui-rendering` subtree arena (the workspace's densest `unsafe` hot spot);
+  the `gpu-test` WARP readback suite is promoted from advisory to
+  merge-blocking after 3 consecutive green full-suite runs.
+- **Panic policy** ([`docs/PANIC-POLICY.md`](docs/PANIC-POLICY.md)):
+  `Result` for caller-triggerable failures, `expect("BUG: <invariant>")` for
+  internal invariants, enforced by `clippy::unwrap_used` at workspace level
+  (tracked crate-level opt-outs burned down per quality wave).
+- This changelog.
+
+### Changed
+
+- **Lint normalization**: every workspace crate now inherits
+  `[workspace.lints]` via `[lints] workspace = true` (12 crates previously
+  bypassed workspace lints entirely; 3 carried stale local copies), enforced
+  by a new drift guard in `scripts/check-workspace-inventory.sh`.
+- `flui-assets` restored to `[workspace] members` — it is built and tested by
+  CI again.
+
+### Pre-changelog milestones
+
+Recorded retroactively from `docs/ROADMAP-TRACKER.md`; evidence links live
+there.
+
+- **2026-07-01 — Core.2 exit**: full render-object catalog (37 concrete
+  RenderBox/RenderSliver objects extracted to `flui-objects`), 250/250
+  per-object harness tests, catalog CI guard.
+- **2026-06-30 — Core.0 exit / Core.1 substantially delivered**: view/element
+  core contracts locked (`specs/004-view-element-core`, keyed reconciliation,
+  `IntoView` authoring surface, element storage); `flui-widgets` slice with 14
+  widget families; `flui-animation` re-enabled; production vsync + lazy
+  slivers end-to-end; C1.11 contract-validation report (4,847 tests passing).
+  Core.1 formal exit still awaits a windowed run (C1.10/C1.12 — see the OPEN
+  ITEM in the tracker).
+- **2026-06 — GPU engine hardening**: WGSL readback/oracle suite (~440 tests)
+  runs on CI via WARP; image-filter pipeline (blur/ColorFilter) sized to
+  content bounds; deterministic-replay IR purity witness.
+- **Business.1 (in flight)**: Flutter widget-catalog port continues
+  (`RichText`/`Icon` landed); tracked in `docs/ROADMAP.md`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,6 +1436,7 @@ dependencies = [
  "flui-app",
  "flui-engine",
  "flui-foundation",
+ "flui-geometry",
  "flui-hot-reload",
  "flui-layer",
  "flui-objects",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ members = [
     "crates/flui-binding",   # Headless deterministic frame driver (pump_frame) (ACTIVE — Phase 1)
 
     # === Phase 4: Application Layer ===
-    "crates/flui-app", # Application framework (ACTIVE - Migration)
+    "crates/flui-app",    # Application framework (ACTIVE - Migration)
+    "crates/flui-assets", # Asset loading/caching (ACTIVE — wired into Image per Cross.A)
 
     # === Examples (platform-specific) ===
     # NOTE: Android examples are excluded from workspace.members because they
@@ -64,9 +65,8 @@ members = [
     # "crates/flui-reactivity",
 ]
 
-# Default members exclude platform-specific examples/tools and flui-assets'
-# heavier optional integration path. `cargo build --workspace` still builds every
-# workspace member listed above.
+# Default members exclude platform-specific examples/tools. `cargo build
+# --workspace` still builds every workspace member listed above.
 default-members = [
     "crates/flui-geometry",
     "crates/flui-types",
@@ -87,6 +87,7 @@ default-members = [
     "crates/flui-widgets",
     "crates/flui-binding",
     "crates/flui-app",
+    "crates/flui-assets",
     "crates/flui-animation",
     "crates/flui-devtools",
     "crates/flui-build",
@@ -231,6 +232,13 @@ rust_2018_idioms = "warn"
 # Lint groups need lower priority to allow individual lint overrides
 all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
+# Panic policy (docs/PANIC-POLICY.md): production paths return Result or
+# assert invariants via `expect("BUG: ...")`; bare unwrap() is banned. Test
+# code is exempt via clippy.toml (allow-unwrap-in-tests). Crates predating
+# the policy carry a tracked `#![allow(clippy::unwrap_used)]` burned down in
+# ship-quality waves. `expect_used` stays off — expect() with the BUG:
+# message convention IS the sanctioned invariant idiom.
+unwrap_used = "warn"
 # Allow reasonable exceptions
 cast_precision_loss = "allow"
 module_name_repetitions = "allow"
@@ -240,6 +248,29 @@ missing_panics_doc = "allow"
 must_use_candidate = "allow"
 return_self_not_must_use = "allow"
 doc_markdown = "allow"
+# Graphics/layout idiom, workspace-wide: pixel math converts between float
+# and integer spaces constantly (px ↔ DevicePixels ↔ buffer indices), and
+# layout values are exact-by-construction so strict float comparison in
+# code and tests is deliberate (Flutter's own layout tests compare doubles
+# exactly). Same rationale as `cast_precision_loss` above.
+cast_possible_truncation = "allow"
+cast_sign_loss = "allow"
+cast_lossless = "allow"
+cast_possible_wrap = "allow"
+float_cmp = "allow"
+# Pedantic style relaxations that fight this codebase's idiom: math-adjacent
+# names (`x0`/`x1`, `min_w`/`max_w`) and helper items declared next to the
+# test statements that use them.
+similar_names = "allow"
+items_after_statements = "allow"
+# Declarative-UI API idiom: widget builders and `run_app` consume their
+# configuration by value (the View IS the argument — 100+ sites in
+# flui-widgets alone); small Copy geometry types are passed by ref for API
+# symmetry with their non-Copy siblings; UI config structs (WindowOptions,
+# gesture settings) are naturally bool-heavy.
+needless_pass_by_value = "allow"
+trivially_copy_pass_by_ref = "allow"
+struct_excessive_bools = "allow"
 
 [package]
 name = "flui"
@@ -254,12 +285,23 @@ readme = "README.md"
 keywords = ["gui", "ui", "wgpu", "flutter", "reactive"]
 categories = ["gui", "rendering::engine"]
 
+[lints]
+workspace = true
+
+# The facade surface (src/lib.rs): the layers an application author consumes.
+# Lower layers (rendering/painting/engine/platform) stay dev-deps — examples
+# reach them directly, app authors go through the widget layer.
 [dependencies]
+flui-types = { path = "crates/flui-types", version = "0.2.0" }
+flui-geometry = { path = "crates/flui-geometry", version = "0.2.0" }
+flui-foundation = { path = "crates/flui-foundation", version = "0.2.0" }
+flui-view = { path = "crates/flui-view", version = "0.2.0" }
+flui-widgets = { path = "crates/flui-widgets", version = "0.2.0" }
+flui-animation = { path = "crates/flui-animation", version = "0.2.0" }
+flui-app = { path = "crates/flui-app", version = "0.2.0" }
 
 [dev-dependencies]
 # === Foundation Layer ===
-flui-types = { path = "crates/flui-types", version = "0.2.0" }
-flui-foundation = { path = "crates/flui-foundation", version = "0.2.0" } # HasInstance/Listenable in animated_box_app
 # flui-tree = { path = "crates/flui-tree" }
 
 # === Core Layer ===
@@ -269,18 +311,8 @@ flui-painting = { path = "crates/flui-painting", version = "0.2.0" }
 flui-rendering = { path = "crates/flui-rendering", version = "0.2.0" }
 flui-objects = { path = "crates/flui-objects", version = "0.2.0" }
 
-# === View Layer ===
-flui-view = { path = "crates/flui-view", version = "0.2.0" }
-
-# === Widget Catalog (widgets_gallery example) ===
-flui-widgets = { path = "crates/flui-widgets", version = "0.2.0" }
-
 # === Reactive Layer (animated_box_app example) ===
 flui-scheduler = { path = "crates/flui-scheduler", version = "0.2.0" }
-flui-animation = { path = "crates/flui-animation", version = "0.2.0" }
-
-# === Application Layer ===
-flui-app = { path = "crates/flui-app", version = "0.2.0" }
 
 # === Platform Layer (for examples) ===
 flui-platform = { path = "crates/flui-platform", version = "0.2.0" }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # FLUI
 
+[![CI](https://github.com/vanyastaff/flui/actions/workflows/ci.yml/badge.svg)](https://github.com/vanyastaff/flui/actions/workflows/ci.yml)
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](README.md#license)
+[![MSRV: 1.96](https://img.shields.io/badge/MSRV-1.96-orange.svg)](README.md#minimum-supported-rust-version)
+
 > A modular, Flutter-inspired declarative UI framework for Rust with GPU-accelerated rendering.
 
 FLUI brings the proven three-tree architecture (View → Element → Render) to Rust, adapted to native ownership, type-safe arity, and a strict layered crate DAG. The Core.1 vertical slice is complete: the widget catalog (`flui-widgets`) is live, the full build → layout → paint → composite pipeline is exercised end-to-end, and the gesture/animation integration ships.
+
+**Project stage: pre-release — build from source.** FLUI is not published to crates.io; the workspace builds and runs from a clone (instructions below), and APIs may still change between commits. See [`CHANGELOG.md`](CHANGELOG.md) for notable changes and [`docs/ROADMAP.md`](docs/ROADMAP.md) for what lands next.
 
 ## Status
 
@@ -16,13 +22,13 @@ See [`docs/crates.md`](docs/crates.md) for the full layered map and per-crate st
 
 ## Quick Start
 
-Prerequisites: Rust 1.96 (edition 2024). The repository is a Cargo workspace, not yet published to crates.io. A `rust-toolchain.toml` is committed, so `rustup` will install and select the correct toolchain automatically.
+Prerequisites: Rust 1.96 (edition 2024). The repository is a Cargo workspace consumed by path — clone and build. A `rust-toolchain.toml` is committed, so `rustup` will install and select the correct toolchain automatically.
 
 ```bash
 git clone https://github.com/vanyastaff/flui
 cd flui
 cargo build --workspace
-cargo run --example hello_world
+cargo run --example widgets_gallery
 ```
 
 A [`justfile`](justfile) is provided for common tasks — install [`just`](https://just.systems) and run `just` for the recipe list (`just check`, `just test`, `just clippy`, `just ci`, ...). Raw `cargo` commands always work too.
@@ -40,37 +46,62 @@ For a step-by-step setup including platform notes (Windows / macOS / Android NDK
 
 ## Hello World
 
+An app is a `View` that builds other views — the widget layer drives the whole
+pipeline (element tree → render objects → layout → paint → `wgpu`):
+
 ```rust
-//! examples/hello_world.rs (excerpt)
-use flui_platform::{WindowOptions, current_platform};
-use flui_types::geometry::{Size, px};
+//! examples/widgets_gallery.rs (excerpt)
+use flui_app::run_app;
+use flui_widgets::prelude::*;
+use flui_widgets::{column, row};
+
+/// A circular colour avatar: a coloured box clipped to an inscribed oval.
+fn avatar(color: Color) -> ClipOval {
+    ClipOval::new().child(ColoredBox::new(color).child(SizedBox::square(64.0)))
+}
+
+#[derive(Clone, StatelessView)]
+struct Gallery;
+
+impl StatelessView for Gallery {
+    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+        Container::new()
+            .color(Color::rgb(18, 18, 24))
+            .padding(EdgeInsets::all(px(24.0)))
+            .child(Column::new(column![
+                Text::new("FLUI widget gallery"),
+                SizedBox::height(16.0),
+                Row::new(row![
+                    avatar(Color::rgb(229, 57, 53)),
+                    SizedBox::width(12.0),
+                    avatar(Color::rgb(30, 136, 229)),
+                ]),
+                Container::new()
+                    .color(Color::rgb(38, 38, 48))
+                    .padding(EdgeInsets::all(px(16.0)))
+                    .child(Center::new().child(Text::new("centered in a card"))),
+            ]))
+    }
+}
 
 fn main() {
-    tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).init();
-
-    let platform = current_platform().expect("failed to initialize platform");
-    tracing::info!("Platform: {:?}", platform.name());
-
-    let window = platform
-        .open_window(WindowOptions {
-            title: "Hello FLUI!".to_string(),
-            size: Size::new(px(800.0), px(600.0)),
-            resizable: true,
-            visible: true,
-            decorated: true,
-            min_size: None,
-            max_size: None,
-        })
-        .expect("failed to create window");
-
-    platform.run(Box::new(move || {
-        tracing::info!("ready");
-        let _window = window; // keep window alive in event loop
-    }));
+    run_app(Gallery);
 }
 ```
 
-Run with `cargo run --example hello_world`. More examples live under `examples/` and per-target crates (`examples/desktop_scene/`, `examples/web_demo/`, `examples/painting_demo/`).
+Run with `cargo run --example widgets_gallery`. For the platform layer without
+widgets (raw window + event loop), see `examples/hello_world.rs`; more examples
+live under `examples/` and per-target crates (`examples/desktop_scene/`,
+`examples/web_demo/`, `examples/painting_demo/`).
+
+## Minimum Supported Rust Version
+
+The MSRV is **Rust 1.96**, declared as `rust-version` in the workspace
+manifest, pinned by `rust-toolchain.toml`, and verified by a dedicated CI job.
+Policy: pre-release, the MSRV may be bumped in any commit when a dependency or
+language feature warrants it; every bump updates the manifest, the toolchain
+pin, this section, and CI together (the procedure lives in
+`rust-toolchain.toml`'s header).
 
 ## Documentation
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,7 @@
+# Workspace clippy configuration.
+#
+# Panic policy support (docs/PANIC-POLICY.md): a panic in test code IS the
+# failure report, so `#[test]` fns and `#[cfg(test)]` modules are exempt from
+# the `unwrap_used` gate that guards production paths.
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/crates/flui-animation/benches/animation_bench.rs
+++ b/crates/flui-animation/benches/animation_bench.rs
@@ -5,6 +5,10 @@
 //! `cargo bench -p flui-animation`; the numbers in `docs/PERFORMANCE.md` should
 //! be sourced from here, not estimated.
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::unwrap_used)]
 // Benchmark harness functions are internal measurement scaffolding, not a
 // public API surface, so they are exempt from the crate's missing-docs lint.
 #![allow(missing_docs)]

--- a/crates/flui-animation/src/lib.rs
+++ b/crates/flui-animation/src/lib.rs
@@ -84,10 +84,8 @@
 //! [`Arc`]: std::sync::Arc
 
 #![warn(missing_docs)]
-#![warn(clippy::all)]
-// Curve endpoints (`t == 0.0` / `t == 1.0`) and tween math use exact float
-// equality against known sentinel values; tolerance comparison would be wrong here.
-#![allow(clippy::float_cmp)]
+// Tracked ship-quality debt:
+#![allow(clippy::unwrap_used)] // TODO(ship-wave-3): convert to Result / `expect("BUG: …")` per docs/PANIC-POLICY.md
 
 // Core animation modules
 pub mod animation;

--- a/crates/flui-app/Cargo.toml
+++ b/crates/flui-app/Cargo.toml
@@ -74,3 +74,6 @@ flui-interaction = { path = "../flui-interaction", version = "0.2.0", features =
 # seed pending child-build requests via `push_pending_child_request_for_test`.
 # Same dev-only feature-unification pattern; helper stays out of release builds.
 flui-rendering = { path = "../flui-rendering", version = "0.2.0", features = ["testing"] }
+
+[lints]
+workspace = true

--- a/crates/flui-app/src/app/direct.rs
+++ b/crates/flui-app/src/app/direct.rs
@@ -88,7 +88,7 @@ pub fn run_direct(
     let options: WindowOptions = (&config).into();
     let window = platform
         .open_window(options)
-        .map_err(|e| anyhow::anyhow!("Failed to create window: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to create window: {e}"))?;
 
     // 2. Create GPU renderer
     let phys_size = window.physical_size();
@@ -100,7 +100,7 @@ pub fn run_direct(
         Ok(r) => r,
         Err(e) => {
             tracing::error!("GPU init failed: {:?}", e);
-            return Err(anyhow::anyhow!("GPU initialization failed: {}", e));
+            return Err(anyhow::anyhow!("GPU initialization failed: {e}"));
         }
     };
     renderer.resize(phys_size.width.0 as u32, phys_size.height.0 as u32);

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -257,7 +257,7 @@ where
         if !dirty && let Some(started) = last_frame_started {
             let elapsed = started.elapsed();
             if elapsed < frame_budget {
-                std::thread::sleep(frame_budget - elapsed);
+                std::thread::sleep(frame_budget.checked_sub(elapsed).unwrap());
             }
         }
 

--- a/crates/flui-app/src/lib.rs
+++ b/crates/flui-app/src/lib.rs
@@ -32,7 +32,10 @@
 //! ```
 
 #![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
+// Tracked ship-quality debt:
+#![allow(clippy::unwrap_used)] // TODO(ship-wave-4): convert to Result / `expect("BUG: …")` per docs/PANIC-POLICY.md
+#![allow(clippy::missing_fields_in_debug)] // TODO(ship-wave-4): `finish_non_exhaustive()` or full fields
+#![allow(clippy::unreadable_literal)] // TODO(ship-wave-4): add digit separators
 
 // Modules
 pub mod app;

--- a/crates/flui-app/src/overlay/manager.rs
+++ b/crates/flui-app/src/overlay/manager.rs
@@ -90,8 +90,7 @@ impl OverlayManager {
         self.order.iter().rev().copied().find(|id| {
             self.entries
                 .get(id)
-                .map(|e| e.is_modal() && e.is_visible())
-                .unwrap_or(false)
+                .is_some_and(|e| e.is_modal() && e.is_visible())
         })
     }
 
@@ -108,8 +107,7 @@ impl OverlayManager {
         self.order.iter().copied().filter(|id| {
             self.entries
                 .get(id)
-                .map(|e| e.is_visible())
-                .unwrap_or(false)
+                .is_some_and(super::entry::OverlayEntry::is_visible)
         })
     }
 
@@ -154,8 +152,7 @@ impl OverlayManager {
         let pos = self.order.partition_point(|&oid| {
             self.entries
                 .get(&oid)
-                .map(|e| e.priority() <= priority)
-                .unwrap_or(false)
+                .is_some_and(|e| e.priority() <= priority)
         });
         self.order.insert(pos, id);
     }

--- a/crates/flui-assets/Cargo.toml
+++ b/crates/flui-assets/Cargo.toml
@@ -20,10 +20,10 @@ flui-types = { path = "../flui-types", version = "0.2.0" }
 tokio = { workspace = true, features = ["fs", "io-util"] }
 
 # High-performance cache
-moka = { version = "0.12", features = ["future"] }
+moka = { workspace = true }
 
 # String interning for efficient asset keys
-lasso = { version = "0.7", features = ["multi-threaded"] }
+lasso = { workspace = true }
 
 # Sync primitives
 parking_lot = { workspace = true }
@@ -71,3 +71,6 @@ network = ["dep:reqwest"]
 
 # Enable all stable features (recommended for applications)
 full = ["images", "network"]
+
+[lints]
+workspace = true

--- a/crates/flui-assets/src/assets/font.rs
+++ b/crates/flui-assets/src/assets/font.rs
@@ -84,7 +84,7 @@ impl Asset for FontAsset {
                 .await
                 .map_err(|e| AssetError::LoadFailed {
                     path: self.path.clone(),
-                    reason: format!("Failed to read file: {}", e),
+                    reason: format!("Failed to read file: {e}"),
                 })?
         };
 
@@ -121,10 +121,10 @@ impl Asset for FontAsset {
         let format = Path::new(&self.path)
             .extension()
             .and_then(|ext| ext.to_str())
-            .map(|ext| ext.to_uppercase());
+            .map(str::to_uppercase);
 
         Some(AssetMetadata {
-            size_bytes: self.bytes.as_ref().map(|b| b.len()),
+            size_bytes: self.bytes.as_ref().map(std::vec::Vec::len),
             format,
             ..Default::default()
         })

--- a/crates/flui-assets/src/assets/image.rs
+++ b/crates/flui-assets/src/assets/image.rs
@@ -86,7 +86,7 @@ impl Asset for ImageAsset {
                 .await
                 .map_err(|e| AssetError::LoadFailed {
                     path: self.path.clone(),
-                    reason: format!("Failed to read file: {}", e),
+                    reason: format!("Failed to read file: {e}"),
                 })?
         };
 
@@ -120,10 +120,10 @@ impl Asset for ImageAsset {
         let format = Path::new(&self.path)
             .extension()
             .and_then(|ext| ext.to_str())
-            .map(|ext| ext.to_uppercase());
+            .map(str::to_uppercase);
 
         Some(AssetMetadata {
-            size_bytes: self.bytes.as_ref().map(|b| b.len()),
+            size_bytes: self.bytes.as_ref().map(std::vec::Vec::len),
             format,
             ..Default::default()
         })

--- a/crates/flui-assets/src/cache/mod.rs
+++ b/crates/flui-assets/src/cache/mod.rs
@@ -73,7 +73,7 @@ impl<T: Asset> AssetCache<T> {
         // Assume average asset is ~10KB
         let estimated_items = (capacity_bytes / 10_240).max(100);
 
-        Self::with_config(estimated_items, Duration::from_secs(300))
+        Self::with_config(estimated_items, Duration::from_mins(5))
     }
 
     /// Creates a cache with custom configuration.
@@ -86,7 +86,7 @@ impl<T: Asset> AssetCache<T> {
         let cache = MokaCache::builder()
             .max_capacity(max_capacity as u64)
             .time_to_live(time_to_live)
-            .time_to_idle(Duration::from_secs(60))
+            .time_to_idle(Duration::from_mins(1))
             .build();
 
         Self {
@@ -245,7 +245,7 @@ impl<T: Asset> AssetCache<T> {
 /// Sealed trait module to prevent external implementations.
 #[doc(hidden)]
 pub mod sealed {
-    use super::*;
+    use super::{Asset, AssetCache};
 
     /// Sealed trait to prevent external implementations of AssetCacheCore.
     pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
@@ -572,7 +572,7 @@ mod tests {
         let cache = AssetCache::<TestAsset>::new(1024 * 1024);
 
         for i in 0..10 {
-            let key = AssetKey::new(&format!("test{}", i));
+            let key = AssetKey::new(&format!("test{i}"));
             cache.insert(key, TestData { value: i }).await;
         }
 
@@ -632,7 +632,7 @@ mod tests {
     #[test]
     fn test_cache_debug() {
         let cache = AssetCache::<TestAsset>::new(1024 * 1024);
-        let debug_str = format!("{:?}", cache);
+        let debug_str = format!("{cache:?}");
         assert!(debug_str.contains("AssetCache"));
         assert!(debug_str.contains("entry_count"));
     }

--- a/crates/flui-assets/src/core/metadata.rs
+++ b/crates/flui-assets/src/core/metadata.rs
@@ -134,8 +134,8 @@ mod tests {
 
     #[test]
     fn test_audio_metadata() {
-        let meta = AssetMetadata::audio(Duration::from_secs(180), 44100, 2, "audio/mp3");
-        assert_eq!(meta.duration, Some(Duration::from_secs(180)));
+        let meta = AssetMetadata::audio(Duration::from_mins(3), 44100, 2, "audio/mp3");
+        assert_eq!(meta.duration, Some(Duration::from_mins(3)));
         assert_eq!(meta.sample_rate, Some(44100));
         assert_eq!(meta.channels, Some(2));
         assert_eq!(meta.format, Some("audio/mp3".to_string()));
@@ -143,9 +143,9 @@ mod tests {
 
     #[test]
     fn test_video_metadata() {
-        let meta = AssetMetadata::video(1920, 1080, Duration::from_secs(120), 30.0, "video/mp4");
+        let meta = AssetMetadata::video(1920, 1080, Duration::from_mins(2), 30.0, "video/mp4");
         assert_eq!(meta.dimensions, Some((1920, 1080)));
-        assert_eq!(meta.duration, Some(Duration::from_secs(120)));
+        assert_eq!(meta.duration, Some(Duration::from_mins(2)));
         assert_eq!(meta.frame_rate, Some(30.0));
         assert_eq!(meta.format, Some("video/mp4".to_string()));
     }

--- a/crates/flui-assets/src/lib.rs
+++ b/crates/flui-assets/src/lib.rs
@@ -165,7 +165,9 @@
 //! for detailed compliance report.
 
 #![warn(missing_docs)]
-#![warn(clippy::all)]
+// Tracked ship-quality debt:
+#![allow(clippy::missing_fields_in_debug)] // TODO(ship-wave-4): `finish_non_exhaustive()` or full fields
+#![allow(clippy::unused_async)] // TODO(ship-wave-4): drop `async` from fns with no await or document why
 
 // Core traits and interfaces
 pub mod core;

--- a/crates/flui-assets/src/loaders/file.rs
+++ b/crates/flui-assets/src/loaders/file.rs
@@ -93,7 +93,7 @@ where
             format: path
                 .extension()
                 .and_then(|ext| ext.to_str())
-                .map(|ext| ext.to_uppercase()),
+                .map(str::to_uppercase),
             ..Default::default()
         }))
     }
@@ -166,7 +166,7 @@ impl BytesFileLoader {
             format: full_path
                 .extension()
                 .and_then(|ext| ext.to_str())
-                .map(|ext| ext.to_uppercase()),
+                .map(str::to_uppercase),
             ..Default::default()
         })
     }

--- a/crates/flui-assets/src/loaders/memory.rs
+++ b/crates/flui-assets/src/loaders/memory.rs
@@ -135,7 +135,7 @@ where
             .get(key)
             .map(|arc| (**arc).clone())
             .ok_or_else(|| AssetError::NotFound {
-                path: format!("memory://{}", key),
+                path: format!("memory://{key}"),
             })
     }
 

--- a/crates/flui-assets/src/registry/mod.rs
+++ b/crates/flui-assets/src/registry/mod.rs
@@ -61,8 +61,7 @@ impl AssetRegistry {
     /// let image = registry.load(ImageAsset::file("logo.png")).await?;
     /// ```
     pub fn global() -> &'static Self {
-        use once_cell::sync::Lazy;
-        static REGISTRY: Lazy<AssetRegistry> = Lazy::new(|| {
+        static REGISTRY: std::sync::LazyLock<AssetRegistry> = std::sync::LazyLock::new(|| {
             AssetRegistryBuilder::new()
                 .with_capacity(100 * 1024 * 1024) // 100 MB default
                 .build()
@@ -315,6 +314,7 @@ pub struct HasCapacity(pub(crate) usize);
 ///     .with_default_capacity() // 100 MB
 ///     .build();
 /// ```
+#[derive(Debug)]
 pub struct AssetRegistryBuilder<C = NoCapacity> {
     capacity: C,
 }
@@ -490,7 +490,7 @@ mod tests {
         // Load multiple fonts
         for i in 0..3 {
             let ttf_bytes = vec![0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-            let font = FontAsset::from_bytes(format!("test{}.ttf", i), ttf_bytes);
+            let font = FontAsset::from_bytes(format!("test{i}.ttf"), ttf_bytes);
             let _handle = registry.load(font).await.unwrap();
         }
 
@@ -601,7 +601,7 @@ mod tests {
     #[test]
     fn test_registry_debug() {
         let registry = AssetRegistry::default();
-        let debug_str = format!("{:?}", registry);
+        let debug_str = format!("{registry:?}");
         assert!(debug_str.contains("AssetRegistry"));
         assert!(debug_str.contains("cache_count"));
         assert!(debug_str.contains("default_capacity"));
@@ -612,8 +612,8 @@ mod tests {
         let no_cap = NoCapacity;
         let has_cap = HasCapacity(100);
 
-        let debug1 = format!("{:?}", no_cap);
-        let debug2 = format!("{:?}", has_cap);
+        let debug1 = format!("{no_cap:?}");
+        let debug2 = format!("{has_cap:?}");
 
         assert!(debug1.contains("NoCapacity"));
         assert!(debug2.contains("HasCapacity"));

--- a/crates/flui-assets/src/types/handle.rs
+++ b/crates/flui-assets/src/types/handle.rs
@@ -276,7 +276,7 @@ where
 /// used directly. It's hidden from documentation.
 #[doc(hidden)]
 pub mod sealed {
-    use super::*;
+    use super::AssetHandle;
 
     /// Sealed trait to prevent external implementations of AssetHandleCore.
     ///
@@ -576,7 +576,7 @@ mod tests {
         let data = TestData { value: 42 };
         let handle = AssetHandle::new(Arc::new(data), AssetKey::new("test"));
 
-        let debug_str = format!("{:?}", handle);
+        let debug_str = format!("{handle:?}");
         assert!(debug_str.contains("AssetHandle"));
         // AssetKey debug format includes the string
         assert!(debug_str.contains("key"));

--- a/crates/flui-assets/src/types/key.rs
+++ b/crates/flui-assets/src/types/key.rs
@@ -1,7 +1,6 @@
 //! Interned asset keys for efficient hashing and comparison.
 
 use lasso::{Rodeo, Spur};
-use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -10,7 +9,8 @@ use std::hash::{Hash, Hasher};
 ///
 /// This uses `lasso` for efficient string interning. Strings are stored once
 /// and referenced by a 32-bit integer (`Spur`), making keys only 4 bytes.
-static INTERNER: Lazy<RwLock<Rodeo>> = Lazy::new(|| RwLock::new(Rodeo::new()));
+static INTERNER: std::sync::LazyLock<RwLock<Rodeo>> =
+    std::sync::LazyLock::new(|| RwLock::new(Rodeo::new()));
 
 /// An interned asset key.
 ///
@@ -175,7 +175,7 @@ mod tests {
     #[test]
     fn test_key_display() {
         let key = AssetKey::new("image.png");
-        assert_eq!(format!("{}", key), "image.png");
+        assert_eq!(format!("{key}"), "image.png");
     }
 
     #[test]
@@ -197,7 +197,7 @@ mod tests {
     fn test_multiple_keys_interned() {
         // Test that many different strings can be interned
         let keys: Vec<_> = (0..1000)
-            .map(|i| AssetKey::new(&format!("asset_{}.png", i)))
+            .map(|i| AssetKey::new(&format!("asset_{i}.png")))
             .collect();
 
         // Each should be unique

--- a/crates/flui-build/src/lib.rs
+++ b/crates/flui-build/src/lib.rs
@@ -45,6 +45,9 @@
 //! }
 //! ```
 
+// Tracked ship-quality debt:
+#![allow(clippy::unwrap_used)] // TODO(ship-wave-4): convert to Result / `expect("BUG: …")` per docs/PANIC-POLICY.md
+
 /// Android platform build support
 pub mod android;
 /// Type-state builder for `BuilderContext`

--- a/crates/flui-devtools/Cargo.toml
+++ b/crates/flui-devtools/Cargo.toml
@@ -75,3 +75,6 @@ required-features = ["profiling"]
 # [[bench]]
 # name = "profiler_bench"
 # harness = false
+
+[lints]
+workspace = true

--- a/crates/flui-geometry/Cargo.toml
+++ b/crates/flui-geometry/Cargo.toml
@@ -14,38 +14,8 @@ categories = ["graphics", "mathematics"]
 # pre-split. Math/geometry crates legitimately have many single-char names,
 # tolerated truncation casts, similar names (x/y/z), float comparisons (with
 # epsilon checks done at higher levels), and wildcard imports in preludes.
-[lints.rust]
-unsafe_code = "warn"
-rust_2018_idioms = "warn"
-
-[lints.clippy]
-# Inherit workspace-like base
-all = { level = "warn", priority = -1 }
-pedantic = { level = "warn", priority = -1 }
-# Workspace-level allows
-cast_precision_loss = "allow"
-module_name_repetitions = "allow"
-too_many_lines = "allow"
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-must_use_candidate = "allow"
-# Math/geometry crate specifics
-many_single_char_names = "allow"
-cast_possible_truncation = "allow"
-cast_sign_loss = "allow"
-cast_lossless = "allow"
-similar_names = "allow"
-# Doc lints — will address incrementally
-doc_markdown = "allow"
-# Geometry code often passes small Copy types by ref for API consistency
-needless_pass_by_value = "allow"
-trivially_copy_pass_by_ref = "allow"
-# Builder-pattern methods returning Self are pervasive
-return_self_not_must_use = "allow"
-# Float comparisons are intentional in geometry/physics (tolerance-checked elsewhere)
-float_cmp = "allow"
-# Wildcard imports used in preludes
-wildcard_imports = "allow"
+[lints]
+workspace = true
 
 [dependencies]
 # Error handling

--- a/crates/flui-geometry/src/lib.rs
+++ b/crates/flui-geometry/src/lib.rs
@@ -107,6 +107,16 @@
 //! - [`transform`] - 2D transformations
 //! - [`bezier`] - Bézier curve types
 
+// Math-crate idiom: these pedantic lints fight geometry/physics code (single-
+// letter coordinate names, Copy types passed by ref for API symmetry, prelude
+// glob re-exports). Permanent, not debt — the manifest inherits
+// `[workspace.lints]`; crate-specific relaxations live here where they are
+// visible next to the code they cover. (The float-comparison / numeric-cast
+// family is allowed workspace-wide — see `[workspace.lints.clippy]`.)
+#![allow(clippy::many_single_char_names, clippy::wildcard_imports)]
+// Tracked ship-quality debt (unlike the permanent idiom block above):
+#![allow(missing_docs)] // TODO(ship-wave-1): public-item doc backlog (~77 items), then delete
+
 // =============================================================================
 // MODULES
 // =============================================================================

--- a/crates/flui-geometry/src/relative_rect.rs
+++ b/crates/flui-geometry/src/relative_rect.rs
@@ -8,6 +8,7 @@ use std::ops::{Add, Mul, Neg, Sub};
 use super::traits::{NumericUnit, Unit};
 use crate::{Offset, Size};
 
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RelativeRect<T: Unit> {
     /// Offset from the left edge of the parent.

--- a/crates/flui-geometry/src/rotation.rs
+++ b/crates/flui-geometry/src/rotation.rs
@@ -1,4 +1,4 @@
-#[derive(Default)]
+#[derive(Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum QuarterTurns {
     #[default]

--- a/crates/flui-interaction/Cargo.toml
+++ b/crates/flui-interaction/Cargo.toml
@@ -81,3 +81,6 @@ testing = []
 
 # Serialization support (if needed in the future)
 serde = ["flui-types/serde"]
+
+[lints]
+workspace = true

--- a/crates/flui-interaction/benches/gesture_arena_bench.rs
+++ b/crates/flui-interaction/benches/gesture_arena_bench.rs
@@ -21,6 +21,10 @@
 //!
 //! Run with `cargo bench -p flui-interaction --bench gesture_arena_bench`.
 
+// Bench harness, not public API; `criterion_group!` generates the
+// undocumentable entry fn.
+#![allow(missing_docs)]
+
 use std::hint::black_box;
 use std::sync::Arc;
 

--- a/crates/flui-interaction/benches/pointer_resampler_bench.rs
+++ b/crates/flui-interaction/benches/pointer_resampler_bench.rs
@@ -24,6 +24,10 @@
 //!
 //! Run with `cargo bench -p flui-interaction --bench pointer_resampler_bench`.
 
+// Bench harness, not public API; `criterion_group!` generates the
+// undocumentable entry fn.
+#![allow(missing_docs)]
+
 use std::hint::black_box;
 use std::time::{Duration, Instant};
 
@@ -98,7 +102,7 @@ fn bench_sample_flush(c: &mut Criterion) {
     }
     // Push 100 ns past MIN_SAMPLE_INTERVAL so the per-sample
     // throttling gate does not early-return.
-    let now = Instant::now() + Duration::from_micros(2000);
+    let now = Instant::now() + Duration::from_millis(2);
     let next = now + Duration::from_millis(16);
     c.bench_function(
         "PointerEventResampler::sample (drain 60-event queue)",

--- a/crates/flui-interaction/benches/tap_detector_bench.rs
+++ b/crates/flui-interaction/benches/tap_detector_bench.rs
@@ -21,6 +21,10 @@
 //!
 //! Run with `cargo bench -p flui-interaction --bench tap_detector_bench`.
 
+// Bench harness, not public API; `criterion_group!` generates the
+// undocumentable entry fn.
+#![allow(missing_docs)]
+
 use std::hint::black_box;
 use std::sync::Arc;
 

--- a/crates/flui-interaction/benches/velocity_tracker_bench.rs
+++ b/crates/flui-interaction/benches/velocity_tracker_bench.rs
@@ -17,6 +17,10 @@
 //!
 //! Run with `cargo bench -p flui-interaction --bench velocity_tracker_bench`.
 
+// Bench harness, not public API; `criterion_group!` generates the
+// undocumentable entry fn.
+#![allow(missing_docs)]
+
 use std::hint::black_box;
 use std::time::{Duration, Instant};
 

--- a/crates/flui-interaction/src/arena/mod.rs
+++ b/crates/flui-interaction/src/arena/mod.rs
@@ -1134,8 +1134,7 @@ impl GestureArena {
     pub fn winner_count(&self, pointer: PointerId) -> usize {
         self.entries
             .get(&pointer)
-            .map(|entry_ref| entry_ref.lock().winners.len())
-            .unwrap_or(0)
+            .map_or(0, |entry_ref| entry_ref.lock().winners.len())
     }
 
     /// Check if an arena is resolved.
@@ -1177,8 +1176,7 @@ impl GestureArena {
     pub fn member_count(&self, pointer: PointerId) -> usize {
         self.entries
             .get(&pointer)
-            .map(|entry_ref| entry_ref.lock().members.len())
-            .unwrap_or(0)
+            .map_or(0, |entry_ref| entry_ref.lock().members.len())
     }
 
     // ========================================================================
@@ -1807,7 +1805,7 @@ mod tests {
         arena.add(pointer, member.clone());
 
         // With a very long timeout, should not force resolve
-        let resolved = arena.force_resolve_if_timed_out(pointer, Duration::from_secs(3600));
+        let resolved = arena.force_resolve_if_timed_out(pointer, Duration::from_hours(1));
 
         assert!(!resolved);
         assert!(!arena.is_resolved(pointer));
@@ -2108,7 +2106,7 @@ mod tests {
         let member = Arc::new(MockMember::new());
 
         let entry = arena.add(pointer, member);
-        let debug = format!("{:?}", entry);
+        let debug = format!("{entry:?}");
 
         assert!(debug.contains("GestureArenaEntry"));
         assert!(debug.contains("pointer"));

--- a/crates/flui-interaction/src/arena/signal_resolver.rs
+++ b/crates/flui-interaction/src/arena/signal_resolver.rs
@@ -237,8 +237,7 @@ impl PointerSignalResolver {
             .lock()
             .handlers
             .get(&pointer_id)
-            .map(|h| h.len())
-            .unwrap_or(0)
+            .map_or(0, std::vec::Vec::len)
     }
 }
 

--- a/crates/flui-interaction/src/arena/team.rs
+++ b/crates/flui-interaction/src/arena/team.rs
@@ -693,7 +693,7 @@ mod tests {
     #[test]
     fn test_team_debug_impl() {
         let team = GestureArenaTeam::new();
-        let debug = format!("{:?}", team);
+        let debug = format!("{team:?}");
 
         assert!(debug.contains("GestureArenaTeam"));
         assert!(debug.contains("active_combiners"));
@@ -708,7 +708,7 @@ mod tests {
         let member = MockMember::new(1);
 
         let entry = team.add(pointer, member, &arena);
-        let debug = format!("{:?}", entry);
+        let debug = format!("{entry:?}");
 
         assert!(debug.contains("TeamEntry"));
     }

--- a/crates/flui-interaction/src/binding.rs
+++ b/crates/flui-interaction/src/binding.rs
@@ -569,7 +569,7 @@ impl GestureBinding {
             // and would otherwise grow unbounded to `MAX_BUFFERED_EVENTS` and
             // emit drop warnings every frame, since this path never drains
             // them via `sample()`.
-            for resampler in self.resamplers.iter() {
+            for resampler in &self.resamplers {
                 resampler.clear();
             }
         }
@@ -1069,8 +1069,7 @@ mod tests {
         let tracked = binding
             .resamplers
             .get(&PointerId::PRIMARY)
-            .map(|r| r.is_tracked())
-            .unwrap_or(false);
+            .is_some_and(|r| r.is_tracked());
         assert!(tracked, "resampler must be tracked after the Down");
     }
 

--- a/crates/flui-interaction/src/events.rs
+++ b/crates/flui-interaction/src/events.rs
@@ -258,7 +258,7 @@ impl PointerEventData {
             device_kind: info.pointer_type,
             device,
             buttons,
-            pressure: state.map(|s| s.pressure).unwrap_or(0.0),
+            pressure: state.map_or(0.0, |s| s.pressure),
             time_stamp,
         })
     }

--- a/crates/flui-interaction/src/ids.rs
+++ b/crates/flui-interaction/src/ids.rs
@@ -269,8 +269,8 @@ mod tests {
     fn test_focus_node_id() {
         let id = FocusNodeId::new(123);
         assert_eq!(id.get(), 123);
-        assert_eq!(format!("{:?}", id), "FocusNodeId(123)");
-        assert_eq!(format!("{}", id), "focus:123");
+        assert_eq!(format!("{id:?}"), "FocusNodeId(123)");
+        assert_eq!(format!("{id}"), "focus:123");
     }
 
     #[test]
@@ -305,7 +305,7 @@ mod tests {
     fn test_handler_id() {
         let id = HandlerId::new(999);
         assert_eq!(id.get(), 999);
-        assert_eq!(format!("{:?}", id), "HandlerId(999)");
+        assert_eq!(format!("{id:?}"), "HandlerId(999)");
     }
 
     #[test]

--- a/crates/flui-interaction/src/lib.rs
+++ b/crates/flui-interaction/src/lib.rs
@@ -130,6 +130,20 @@
 //! - ✅ Clear separation of concerns (SOLID principles)
 //! - ✅ Smaller compile times and dependencies
 
+// Lint levels come from `[workspace.lints]`. Tracked ship-quality debt:
+#![allow(missing_docs)] // TODO(ship-wave-2): public-item doc backlog (~33 items), then delete
+#![allow(missing_debug_implementations)] // TODO(ship-wave-2): add Debug impls (7 types), then delete
+#![allow(
+    clippy::comparison_chain,
+    clippy::many_single_char_names,
+    clippy::match_same_arms,
+    clippy::match_wild_err_arm,
+    clippy::missing_fields_in_debug,
+    clippy::struct_field_names,
+    clippy::unnecessary_wraps,
+    clippy::unused_self
+)] // TODO(ship-wave-2): burn down per-lint, then delete
+
 // ============================================================================
 // Core infrastructure modules
 // ============================================================================

--- a/crates/flui-interaction/src/pan_zoom.rs
+++ b/crates/flui-interaction/src/pan_zoom.rs
@@ -350,10 +350,10 @@ mod tests {
             PointerPanZoomEvent::Update {
                 scale, rotation, ..
             } => {
-                assert!((scale - 1.2).abs() < 1e-6, "scale={}", scale);
+                assert!((scale - 1.2).abs() < 1e-6, "scale={scale}");
                 assert_eq!(rotation, 0.0);
             }
-            _ => panic!("expected Update, got {:?}", ev),
+            _ => panic!("expected Update, got {ev:?}"),
         }
     }
 
@@ -364,7 +364,7 @@ mod tests {
         let ev = convert_gesture(&gesture);
         match ev {
             PointerPanZoomEvent::Update { scale, .. } => {
-                assert!((scale - 0.9).abs() < 1e-6, "scale={}", scale);
+                assert!((scale - 0.9).abs() < 1e-6, "scale={scale}");
             }
             _ => panic!("expected Update"),
         }

--- a/crates/flui-interaction/src/processing/raw_input.rs
+++ b/crates/flui-interaction/src/processing/raw_input.rs
@@ -411,8 +411,7 @@ impl RawInputHandler {
                     let mut tracking = self.tracking.lock();
                     tracking
                         .remove(&pointer)
-                        .map(|s| s.last_position)
-                        .unwrap_or(Offset::ZERO)
+                        .map_or(Offset::ZERO, |s| s.last_position)
                 };
 
                 Some(RawPointerEvent::Cancel {

--- a/crates/flui-interaction/src/processing/resampler.rs
+++ b/crates/flui-interaction/src/processing/resampler.rs
@@ -72,7 +72,7 @@ pub const DEFAULT_RESAMPLE_LOOKBACK: Duration = Duration::from_millis(38);
 const MAX_BUFFERED_EVENTS: usize = 100;
 
 /// Minimum time between samples to prevent excessive resampling
-const MIN_SAMPLE_INTERVAL: Duration = Duration::from_micros(1000); // 1ms
+const MIN_SAMPLE_INTERVAL: Duration = Duration::from_millis(1); // 1ms
 
 /// Callback for handling resampled events
 #[allow(dead_code)] // Future public API

--- a/crates/flui-interaction/src/processing/sampling_clock.rs
+++ b/crates/flui-interaction/src/processing/sampling_clock.rs
@@ -217,19 +217,17 @@ mod tests {
         let (now1, next1) = clock.tick().expect("Fixed tick is Some");
         let (now2, next2) = clock.tick().expect("Fixed tick is Some");
         // Wall clock is monotonic: now2 >= now1.
-        assert!(now2 >= now1, "now1={:?} now2={:?}", now1, now2);
+        assert!(now2 >= now1, "now1={now1:?} now2={now2:?}");
         // next = now + period exactly (within 1µs of measurement).
         let stride1 = next1.duration_since(now1);
         let stride2 = next2.duration_since(now2);
         assert!(
             (stride1.as_micros() as i128 - 8_000).abs() <= 1_000,
-            "stride1={:?}",
-            stride1
+            "stride1={stride1:?}"
         );
         assert!(
             (stride2.as_micros() as i128 - 8_000).abs() <= 1_000,
-            "stride2={:?}",
-            stride2
+            "stride2={stride2:?}"
         );
     }
 

--- a/crates/flui-interaction/src/recognizers/multi_tap.rs
+++ b/crates/flui-interaction/src/recognizers/multi_tap.rs
@@ -156,8 +156,7 @@ impl MultiTapGestureRecognizer {
     pub fn new(arena: crate::arena::GestureArena, required_pointer_count: usize) -> Arc<Self> {
         assert!(
             required_pointer_count >= 2,
-            "MultiTapGestureRecognizer requires at least 2 pointers, got {}",
-            required_pointer_count
+            "MultiTapGestureRecognizer requires at least 2 pointers, got {required_pointer_count}"
         );
         Arc::new(Self {
             state: RecognizerBase::new(arena),
@@ -177,8 +176,7 @@ impl MultiTapGestureRecognizer {
     ) -> Arc<Self> {
         assert!(
             required_pointer_count >= 2,
-            "MultiTapGestureRecognizer requires at least 2 pointers, got {}",
-            required_pointer_count
+            "MultiTapGestureRecognizer requires at least 2 pointers, got {required_pointer_count}"
         );
         Arc::new(Self {
             state: RecognizerBase::new(arena),
@@ -354,10 +352,10 @@ impl MultiTapGestureRecognizer {
                 .map(|info| info.initial_position)
                 .collect();
 
-            let center = if !positions.is_empty() {
-                self.calculate_center(&positions)
-            } else {
+            let center = if positions.is_empty() {
                 Offset::new(Pixels::ZERO, Pixels::ZERO)
+            } else {
+                self.calculate_center(&positions)
             };
 
             let count = positions.len();

--- a/crates/flui-interaction/src/recognizers/multidrag.rs
+++ b/crates/flui-interaction/src/recognizers/multidrag.rs
@@ -827,8 +827,7 @@ mod tests {
         let recorded = recorded.expect("first update fired");
         assert!(
             recorded.dx.0.abs() > 18.0,
-            "expected first update to carry ≥slop delta, got {:?}",
-            recorded
+            "expected first update to carry ≥slop delta, got {recorded:?}"
         );
     }
 

--- a/crates/flui-interaction/src/recognizers/scale.rs
+++ b/crates/flui-interaction/src/recognizers/scale.rs
@@ -380,10 +380,10 @@ impl ScaleGestureRecognizer {
             // Not enough pointers anymore
             if state.phase == ScalePhase::Started {
                 // End the gesture
-                let focal_point = if !state.pointers.is_empty() {
-                    self.calculate_focal_point(&state.pointers)
-                } else {
+                let focal_point = if state.pointers.is_empty() {
                     Offset::ZERO
+                } else {
+                    self.calculate_focal_point(&state.pointers)
                 };
 
                 let scale = if let (Some(initial_span), Some(prev_span)) =
@@ -834,8 +834,7 @@ mod tests {
         let scale = current_span / state.initial_span.unwrap();
         assert!(
             (scale - 2.0).abs() < 0.01,
-            "Scale was {}, expected 2.0",
-            scale
+            "Scale was {scale}, expected 2.0"
         );
     }
 }

--- a/crates/flui-interaction/src/routing/event_router.rs
+++ b/crates/flui-interaction/src/routing/event_router.rs
@@ -122,8 +122,7 @@ impl EventRouter {
                     .pointer_state
                     .read()
                     .get(&pointer_id)
-                    .map(|s| s.is_down)
-                    .unwrap_or(false);
+                    .is_some_and(|s| s.is_down);
 
                 if is_dragging {
                     // Send to original down target (drag continuity)

--- a/crates/flui-interaction/src/routing/focus.rs
+++ b/crates/flui-interaction/src/routing/focus.rs
@@ -266,8 +266,8 @@ impl FocusManager {
         };
 
         tracing::trace!(
-            previous = ?previous.map(|id| id.get()),
-            new = ?node_id.map(|id| id.get()),
+            previous = ?previous.map(super::super::ids::FocusNodeId::get),
+            new = ?node_id.map(super::super::ids::FocusNodeId::get),
             "Focus changed"
         );
 

--- a/crates/flui-interaction/src/routing/focus_scope.rs
+++ b/crates/flui-interaction/src/routing/focus_scope.rs
@@ -283,7 +283,10 @@ impl FocusNode {
 
     /// Returns the parent node.
     pub fn parent(&self) -> Option<Arc<FocusNode>> {
-        self.parent.read().as_ref().and_then(|w| w.upgrade())
+        self.parent
+            .read()
+            .as_ref()
+            .and_then(std::sync::Weak::upgrade)
     }
 
     /// Returns the children.

--- a/crates/flui-interaction/src/routing/mouse_tracker.rs
+++ b/crates/flui-interaction/src/routing/mouse_tracker.rs
@@ -159,8 +159,8 @@ struct MouseTrackerInner {
 }
 
 // Global singleton
-static GLOBAL_TRACKER: once_cell::sync::Lazy<MouseTracker> =
-    once_cell::sync::Lazy::new(MouseTracker::new);
+static GLOBAL_TRACKER: std::sync::LazyLock<MouseTracker> =
+    std::sync::LazyLock::new(MouseTracker::new);
 
 impl MouseTracker {
     /// Creates a new mouse tracker.
@@ -561,8 +561,7 @@ impl MouseTracker {
             .lock()
             .devices
             .get(&device_id)
-            .map(|state| state.current_cursor)
-            .unwrap_or(CursorIcon::Default)
+            .map_or(CursorIcon::Default, |state| state.current_cursor)
     }
 
     /// Sets the callback for cursor changes.

--- a/crates/flui-interaction/src/routing/pointer_router.rs
+++ b/crates/flui-interaction/src/routing/pointer_router.rs
@@ -269,8 +269,7 @@ impl PointerRouter {
         self.routes
             .read()
             .get(&pointer)
-            .map(|h| h.len())
-            .unwrap_or(0)
+            .map_or(0, std::vec::Vec::len)
     }
 
     /// Get the total number of pointers with registered handlers.

--- a/crates/flui-interaction/src/testing/recording.rs
+++ b/crates/flui-interaction/src/testing/recording.rs
@@ -249,12 +249,11 @@ impl GestureRecorder {
     /// Get the current time offset from start
     fn time_offset(&mut self) -> Duration {
         let now = Instant::now();
-        match self.start_time {
-            Some(start) => now.duration_since(start),
-            None => {
-                self.start_time = Some(now);
-                Duration::ZERO
-            }
+        if let Some(start) = self.start_time {
+            now.duration_since(start)
+        } else {
+            self.start_time = Some(now);
+            Duration::ZERO
         }
     }
 
@@ -406,7 +405,7 @@ impl GesturePlayer {
 
     /// Get the next PointerEvent and advance
     pub fn next_pointer_event(&mut self) -> Option<PointerEvent> {
-        self.next_event().map(|e| e.to_pointer_event())
+        self.next_event().map(RecordedEvent::to_pointer_event)
     }
 
     /// Check if there are more events
@@ -439,7 +438,7 @@ impl GesturePlayer {
         self.recording
             .events
             .iter()
-            .map(|e| e.to_pointer_event())
+            .map(RecordedEvent::to_pointer_event)
             .collect()
     }
 }

--- a/crates/flui-interaction/src/timer.rs
+++ b/crates/flui-interaction/src/timer.rs
@@ -391,7 +391,7 @@ impl GestureTimerService {
                 .min(Duration::from_millis(100));
 
             tokio::select! {
-                _ = tokio::time::sleep(wait_duration) => {}
+                () = tokio::time::sleep(wait_duration) => {}
                 _ = &mut shutdown => {
                     tracing::trace!("Timer service shutting down");
                     break;
@@ -421,8 +421,8 @@ impl std::fmt::Debug for GestureTimerService {
 // ============================================================================
 
 /// Global timer service instance.
-static GLOBAL_TIMER_SERVICE: once_cell::sync::Lazy<GestureTimerService> =
-    once_cell::sync::Lazy::new(GestureTimerService::new);
+static GLOBAL_TIMER_SERVICE: std::sync::LazyLock<GestureTimerService> =
+    std::sync::LazyLock::new(GestureTimerService::new);
 
 /// Get the global timer service.
 ///
@@ -505,7 +505,7 @@ mod tests {
         let fired_clone = fired.clone();
 
         // Schedule a timer far in the future
-        service.schedule(Duration::from_secs(3600), move || {
+        service.schedule(Duration::from_hours(1), move || {
             fired_clone.store(true, Ordering::SeqCst);
         });
 
@@ -592,7 +592,7 @@ mod tests {
         let service = GestureTimerService::new();
         let timer = service.schedule(Duration::from_millis(100), || {});
 
-        let debug = format!("{:?}", timer);
+        let debug = format!("{timer:?}");
         assert!(debug.contains("GestureTimer"));
         assert!(debug.contains("cancelled"));
     }

--- a/crates/flui-interaction/src/traits.rs
+++ b/crates/flui-interaction/src/traits.rs
@@ -210,7 +210,7 @@ pub trait Disposable {
 
 impl<T: HitTestTarget + ?Sized> HitTestTarget for Box<T> {
     fn handle_event(&self, event: &PointerEvent, entry: &HitTestEntry) {
-        (**self).handle_event(event, entry)
+        (**self).handle_event(event, entry);
     }
 }
 

--- a/crates/flui-layer/Cargo.toml
+++ b/crates/flui-layer/Cargo.toml
@@ -45,3 +45,6 @@ thiserror = { workspace = true }
 # Self dev-dependency that turns the off-by-default `testing` feature on for
 # this crate's own integration tests, so `tests/*.rs` can reach the harness.
 flui-layer = { path = ".", version = "0.2.0", features = ["testing"] }
+
+[lints]
+workspace = true

--- a/crates/flui-layer/src/compositor/builder.rs
+++ b/crates/flui-layer/src/compositor/builder.rs
@@ -57,6 +57,7 @@ use crate::{
 /// let root = builder.build();
 /// assert!(root.is_some());
 /// ```
+#[derive(Debug)]
 pub struct SceneBuilder<'a> {
     /// Reference to the layer tree being built
     tree: &'a mut LayerTree,

--- a/crates/flui-layer/src/lib.rs
+++ b/crates/flui-layer/src/lib.rs
@@ -76,18 +76,10 @@
 //! 3. **Separation of concerns**: Layer types here, rendering in `flui_engine`
 //! 4. **Thread-safe**: All types are `Send + Sync`
 
-#![warn(rust_2018_idioms, clippy::all, clippy::pedantic)]
-#![allow(
-    dead_code,
-    unused_variables,
-    missing_docs,
-    clippy::module_name_repetitions,
-    clippy::must_use_candidate,
-    clippy::return_self_not_must_use,
-    clippy::doc_markdown,
-    clippy::missing_errors_doc,
-    clippy::missing_panics_doc
-)]
+// Lint levels come from `[workspace.lints]` (Cargo.toml `[lints] workspace = true`).
+// The two remaining opt-outs are tracked ship-quality debt, not configuration:
+#![allow(dead_code, unused_variables)] // TODO(ship-wave-2): wire or delete each dead item (tracker M3 audit)
+#![allow(missing_docs)] // TODO(ship-wave-2): public-item doc backlog — burn down, then delete this line
 
 // ============================================================================
 // MODULES

--- a/crates/flui-layer/src/testing/spec.rs
+++ b/crates/flui-layer/src/testing/spec.rs
@@ -15,6 +15,7 @@ use crate::{Layer, LayerTree};
 /// Build one with [`layer`], nest children with [`child`](LayerSpec::child) /
 /// [`children`](LayerSpec::children), and tag it with
 /// [`label`](LayerSpec::label) for lookup after mounting.
+#[derive(Debug)]
 pub struct LayerSpec {
     layer: Layer,
     label: Option<&'static str>,

--- a/crates/flui-layer/src/testing/tester.rs
+++ b/crates/flui-layer/src/testing/tester.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 
 /// A mounted layer tree plus its label registry, ready to inspect.
+#[derive(Debug)]
 pub struct LayerTester {
     tree: LayerTree,
     root: LayerId,

--- a/crates/flui-layer/src/tree/layer_tree.rs
+++ b/crates/flui-layer/src/tree/layer_tree.rs
@@ -975,6 +975,11 @@ impl Default for LayerTree {
 
 #[cfg(test)]
 mod lifecycle_tests {
+    // `drop_marks_node_disposed` observes the AtomicBool disposed flag through
+    // a raw pointer after `drop_in_place` — deliberate, SAFETY-commented, and
+    // confined to this test module.
+    #![allow(unsafe_code)]
+
     use crate::layer::{CanvasLayer, Layer};
 
     use super::LayerNode;

--- a/crates/flui-layer/tests/damage_tracking.rs
+++ b/crates/flui-layer/tests/damage_tracking.rs
@@ -1,3 +1,5 @@
+//! Damage-tracker integration tests: dirty-region accumulation and reset.
+
 use flui_layer::damage::DamageTracker;
 use flui_types::geometry::{Rect, px};
 

--- a/crates/flui-objects/Cargo.toml
+++ b/crates/flui-objects/Cargo.toml
@@ -32,3 +32,6 @@ flui-types = { path = "../flui-types", version = "0.2.0" }
 insta = { workspace = true }
 flui-scheduler = { path = "../flui-scheduler", version = "0.2.0" }
 flui-interaction = { path = "../flui-interaction", version = "0.2.0", features = ["testing"] }
+
+[lints]
+workspace = true

--- a/crates/flui-objects/src/lib.rs
+++ b/crates/flui-objects/src/lib.rs
@@ -27,9 +27,23 @@
 //! [`RenderSliver`]: flui_rendering::traits::RenderSliver
 
 #![warn(missing_docs)]
-#![warn(clippy::all)]
+// Crate-specific relaxations (same rationale as flui-rendering):
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
+// Tracked ship-quality debt:
+#![allow(
+    clippy::enum_glob_use,
+    clippy::if_not_else,
+    clippy::manual_midpoint,
+    clippy::map_unwrap_or,
+    clippy::match_same_arms,
+    clippy::missing_fields_in_debug,
+    clippy::redundant_closure_for_method_calls,
+    clippy::semicolon_if_nothing_returned,
+    clippy::single_match_else,
+    clippy::uninlined_format_args,
+    clippy::unused_self
+)] // TODO(ship-wave-3): burn down per-lint, then delete
 
 mod image;
 mod interaction;

--- a/crates/flui-objects/src/sliver/sliver_persistent_header.rs
+++ b/crates/flui-objects/src/sliver/sliver_persistent_header.rs
@@ -723,6 +723,7 @@ pub trait FloatingHeaderMode: sealed::Sealed + Send + Sync + 'static {
 /// A read-only view of the fields of [`PersistentHeaderCore`] the sealed
 /// [`FloatingHeaderMode`] formulas need, without giving them access to
 /// `layout_child`/setters (which stay `perform_layout`'s job).
+#[derive(Debug)]
 pub struct PersistentHeaderCoreView<'a> {
     core: &'a PersistentHeaderCore,
 }

--- a/crates/flui-objects/tests/render_object_harness.rs
+++ b/crates/flui-objects/tests/render_object_harness.rs
@@ -1187,8 +1187,10 @@ fn harness_padding_hit_localizes_to_padding_inset() {
     let child_transform = hit_entries
         .iter()
         .find(|(id, _)| *id == child_id)
-        .map(|(_, t)| *t)
-        .unwrap_or_else(|| panic!("child must be hit at ({HIT_X}, {HIT_Y})"));
+        .map_or_else(
+            || panic!("child must be hit at ({HIT_X}, {HIT_Y})"),
+            |(_, t)| *t,
+        );
 
     let recorded_transform = child_transform.expect(
         "child HitTestEntry must carry a recorded transform from hit_test_child_at_layout_offset",
@@ -5010,8 +5012,10 @@ fn harness_align_hit_localizes_to_child_offset() {
     let child_transform = hit_entries
         .iter()
         .find(|(id, _)| *id == child_id)
-        .map(|(_, t)| *t)
-        .unwrap_or_else(|| panic!("child must be in the hit path at ({HIT_X}, {HIT_Y})"));
+        .map_or_else(
+            || panic!("child must be in the hit path at ({HIT_X}, {HIT_Y})"),
+            |(_, t)| *t,
+        );
 
     let recorded_transform = child_transform.unwrap_or_else(|| {
         panic!(

--- a/crates/flui-platform/Cargo.toml
+++ b/crates/flui-platform/Cargo.toml
@@ -133,10 +133,11 @@ web = []
 wayland = []
 x11 = []
 
-[lints.rust]
-# objc 0.2 macros expand `cfg(feature = "cargo-clippy")` probes (macOS backend);
-# declare the value so `unexpected_cfgs` stays quiet under the clippy driver.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }
+# The `unexpected_cfgs` check-cfg declaration for objc 0.2's
+# `cfg(feature = "cargo-clippy")` probes lives in build.rs — Cargo forbids
+# mixing local lint keys with `workspace = true`.
+[lints]
+workspace = true
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/crates/flui-platform/build.rs
+++ b/crates/flui-platform/build.rs
@@ -1,0 +1,12 @@
+//! Build script for `flui-platform`.
+//!
+//! Declares the `cargo-clippy` feature value for the `unexpected_cfgs` lint:
+//! objc 0.2 macros (macOS backend) expand `cfg(feature = "cargo-clippy")`
+//! probes, which rustc would otherwise flag. This used to live as a local
+//! `[lints.rust]` table in Cargo.toml, but Cargo forbids mixing local lint
+//! keys with `[lints] workspace = true`, so the declaration moved here when
+//! the crate switched to workspace lints.
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(feature, values(\"cargo-clippy\"))");
+}

--- a/crates/flui-platform/examples/displays.rs
+++ b/crates/flui-platform/examples/displays.rs
@@ -186,8 +186,8 @@ fn main() -> anyhow::Result<()> {
 
         // Check for scale factor differences
         let scales: Vec<_> = displays.iter().map(|d| d.scale_factor()).collect();
-        let min_scale = scales.iter().cloned().fold(f64::INFINITY, f64::min);
-        let max_scale = scales.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        let min_scale = scales.iter().copied().fold(f64::INFINITY, f64::min);
+        let max_scale = scales.iter().copied().fold(f64::NEG_INFINITY, f64::max);
 
         if (max_scale - min_scale).abs() > 0.1 {
             tracing::warn!(

--- a/crates/flui-platform/examples/event_handling.rs
+++ b/crates/flui-platform/examples/event_handling.rs
@@ -159,7 +159,7 @@ fn main() -> anyhow::Result<()> {
 
     // For this demo, we'll just keep the window open
     // In a real app, platform.run() would handle the event loop
-    std::thread::sleep(std::time::Duration::from_secs(60));
+    std::thread::sleep(std::time::Duration::from_mins(1));
 
     tracing::info!("\n👋 Demo complete!");
     Ok(())

--- a/crates/flui-platform/examples/executor.rs
+++ b/crates/flui-platform/examples/executor.rs
@@ -4,6 +4,11 @@
 //! execution. Shows how to run CPU-intensive work on background threads and
 //! update UI safely on the foreground thread.
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::unwrap_used)]
+
 use std::{
     sync::{
         Arc,
@@ -63,9 +68,9 @@ fn example_background_cpu_work() {
             );
 
             // Simulate CPU-intensive work
-            let result = (0..10_000_000).fold(0u64, |acc, x| acc.wrapping_add(x));
+            let result = (0..10_000_000).fold(0u64, u64::wrapping_add);
 
-            println!("Background work complete: result = {}", result);
+            println!("Background work complete: result = {result}");
             completed_clone.store(1, Ordering::SeqCst);
         })
         .detach();
@@ -104,7 +109,7 @@ fn example_background_with_ui_update() {
             PlatformExecutor::spawn(
                 &foreground_clone,
                 Box::new(move || {
-                    println!("Foreground: Updating UI with loaded data: {}", data);
+                    println!("Foreground: Updating UI with loaded data: {data}");
                     ui_state_bg.store(data, Ordering::SeqCst);
                 }),
             );
@@ -132,9 +137,9 @@ fn example_parallel_background_tasks() {
         let count_clone = Arc::clone(&completed_count);
         executor
             .spawn(async move {
-                println!("Task {} started", i);
+                println!("Task {i} started");
                 tokio::time::sleep(Duration::from_millis(100)).await;
-                println!("Task {} completed", i);
+                println!("Task {i} completed");
                 count_clone.fetch_add(1, Ordering::SeqCst);
             })
             .detach();
@@ -146,10 +151,7 @@ fn example_parallel_background_tasks() {
     }
 
     let elapsed = start.elapsed();
-    println!(
-        "All 4 tasks completed in {:?} (parallel execution)",
-        elapsed
-    );
+    println!("All 4 tasks completed in {elapsed:?} (parallel execution)");
     println!(
         "Sequential would take ~400ms, parallel took ~{}ms",
         elapsed.as_millis()
@@ -208,7 +210,7 @@ fn example_async_await_integration() {
 
             // Simulate async I/O
             let result = async_compute().await;
-            println!("Async task: computed result = {}", result);
+            println!("Async task: computed result = {result}");
 
             completed_clone.store(1, Ordering::SeqCst);
         })

--- a/crates/flui-platform/src/lib.rs
+++ b/crates/flui-platform/src/lib.rs
@@ -148,6 +148,15 @@
 //! }
 //! ```
 
+// Platform FFI is the sanctioned `unsafe` boundary of the workspace (Win32 /
+// AppKit / headless backends); every block carries a `// SAFETY:` comment.
+// Permanent, unlike the tracked debt below.
+#![allow(unsafe_code)]
+// Lint levels come from `[workspace.lints]`. Tracked ship-quality debt:
+#![allow(missing_docs)] // TODO(ship-wave-4): public-item doc backlog (~18 items), then delete
+#![allow(missing_debug_implementations)] // TODO(ship-wave-4): add Debug impls (5 types), then delete
+#![allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)] // TODO(ship-wave-4): burn down, then delete
+
 pub mod config;
 pub mod cursor;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/flui-platform/src/platforms/linux/mod.rs
+++ b/crates/flui-platform/src/platforms/linux/mod.rs
@@ -79,7 +79,10 @@ use std::sync::Arc;
 use anyhow::Result;
 pub use window_ext::*;
 
-use crate::traits::*;
+use crate::traits::{
+    Clipboard, Platform, PlatformCapabilities, PlatformDisplay, PlatformExecutor, PlatformWindow,
+    WindowEvent, WindowId, WindowOptions,
+};
 
 /// Linux platform implementation (stub)
 ///

--- a/crates/flui-platform/src/window.rs
+++ b/crates/flui-platform/src/window.rs
@@ -549,10 +549,10 @@ pub enum WindowError {
 impl std::fmt::Display for WindowError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            WindowError::CreationFailed(msg) => write!(f, "Window creation failed: {}", msg),
-            WindowError::NotFound(id) => write!(f, "Window not found: {:?}", id),
-            WindowError::InvalidState(msg) => write!(f, "Invalid window state: {}", msg),
-            WindowError::PlatformError(msg) => write!(f, "Platform error: {}", msg),
+            WindowError::CreationFailed(msg) => write!(f, "Window creation failed: {msg}"),
+            WindowError::NotFound(id) => write!(f, "Window not found: {id:?}"),
+            WindowError::InvalidState(msg) => write!(f, "Invalid window state: {msg}"),
+            WindowError::PlatformError(msg) => write!(f, "Platform error: {msg}"),
         }
     }
 }

--- a/crates/flui-platform/tests/contract.rs
+++ b/crates/flui-platform/tests/contract.rs
@@ -173,7 +173,7 @@ fn contract_clipboard_empty() {
     let clipboard = platform.clipboard();
 
     // WHEN: We clear the clipboard
-    clipboard.write_text("".to_string());
+    clipboard.write_text(String::new());
 
     // THEN: has_text should reflect the state correctly
     // Note: Empty string behavior may vary - some platforms treat "" as no text
@@ -480,8 +480,7 @@ fn test_display_enumeration_contract() {
         // Contract: Scale factor must be positive and reasonable
         assert!(
             scale > 0.0 && scale <= 4.0,
-            "Display scale factor should be 0.0-4.0, got {}",
-            scale
+            "Display scale factor should be 0.0-4.0, got {scale}"
         );
 
         // Contract: Display bounds must be valid

--- a/crates/flui-platform/tests/display_enumeration.rs
+++ b/crates/flui-platform/tests/display_enumeration.rs
@@ -3,6 +3,11 @@
 //! Comprehensive tests for display/monitor enumeration with DPI-aware bounds,
 //! refresh rates, and multi-monitor support.
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::ignore_without_reason)]
+
 use std::collections::HashSet;
 
 use flui_platform::current_platform;
@@ -72,14 +77,12 @@ fn test_displays_enumeration() {
 
         assert!(
             scale > 0.0 && scale <= 4.0,
-            "Scale factor should be reasonable (0.0-4.0), got {}",
-            scale
+            "Scale factor should be reasonable (0.0-4.0), got {scale}"
         );
 
         assert!(
             refresh > 0.0 && refresh <= 500.0,
-            "Refresh rate should be reasonable (0-500Hz), got {}",
-            refresh
+            "Refresh rate should be reasonable (0-500Hz), got {refresh}"
         );
     }
 
@@ -88,8 +91,7 @@ fn test_displays_enumeration() {
     if !displays.is_empty() {
         assert_eq!(
             primary_count, 1,
-            "Exactly one display should be marked as primary, found {}",
-            primary_count
+            "Exactly one display should be marked as primary, found {primary_count}"
         );
     }
 
@@ -165,7 +167,7 @@ fn test_high_dpi_scale_factor() {
     let mut found_hidpi = false;
     let mut found_standard = false;
 
-    for display in displays.iter() {
+    for display in &displays {
         let scale = display.scale_factor();
         let bounds = display.bounds();
         let name = display.name();
@@ -217,8 +219,7 @@ fn test_high_dpi_scale_factor() {
         // All scale factors should be positive and reasonable
         assert!(
             scale > 0.0 && scale <= 4.0,
-            "Scale factor should be 0.0-4.0, got {}",
-            scale
+            "Scale factor should be 0.0-4.0, got {scale}"
         );
     }
 
@@ -244,7 +245,7 @@ fn test_usable_bounds_exclude_system_ui() {
         return;
     }
 
-    for display in displays.iter() {
+    for display in &displays {
         let full_bounds = display.bounds();
         let usable_bounds = display.usable_bounds();
         let name = display.name();
@@ -590,8 +591,7 @@ fn test_display_enumeration_performance() {
     // Most systems should be much faster (<1ms)
     assert!(
         avg_ms < 10.0,
-        "Display enumeration should take <10ms, got {:.3}ms",
-        avg_ms
+        "Display enumeration should take <10ms, got {avg_ms:.3}ms"
     );
 
     if avg_ms < 1.0 {

--- a/crates/flui-platform/tests/event_contracts.rs
+++ b/crates/flui-platform/tests/event_contracts.rs
@@ -5,6 +5,11 @@
 //! - T062: Event handler demo example (created separately)
 //! - T063: Event dispatch latency benchmarking (<5ms target)
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::no_effect_underscore_binding)]
+
 use std::time::Instant;
 
 use flui_platform::{WindowOptions, current_platform};
@@ -85,13 +90,11 @@ fn test_platform_event_contract() {
 
     assert!(
         width_diff < 2.0,
-        "Coordinate conversion mismatch: width diff = {}",
-        width_diff
+        "Coordinate conversion mismatch: width diff = {width_diff}"
     );
     assert!(
         height_diff < 2.0,
-        "Coordinate conversion mismatch: height diff = {}",
-        height_diff
+        "Coordinate conversion mismatch: height diff = {height_diff}"
     );
 
     tracing::info!("✓ Contract 2: Coordinate system consistency verified");
@@ -188,7 +191,7 @@ fn test_cross_platform_event_consistency() {
 
     // Create identical window options for all platforms
     let options = WindowOptions {
-        title: format!("Event Consistency Test - {}", platform_name),
+        title: format!("Event Consistency Test - {platform_name}"),
         size: Size::new(px(640.0), px(480.0)),
         resizable: true,
         visible: false,
@@ -242,15 +245,11 @@ fn test_cross_platform_event_consistency() {
 
     assert!(
         width_error < 2.0,
-        "{}: Width conversion error too large: {}",
-        platform_name,
-        width_error
+        "{platform_name}: Width conversion error too large: {width_error}"
     );
     assert!(
         height_error < 2.0,
-        "{}: Height conversion error too large: {}",
-        platform_name,
-        height_error
+        "{platform_name}: Height conversion error too large: {height_error}"
     );
 
     tracing::info!("✓ {} platform behaves consistently", platform_name);
@@ -342,7 +341,7 @@ fn test_event_handling_performance_baseline() {
     let start = Instant::now();
     for i in 0..window_count {
         let options = WindowOptions {
-            title: format!("Perf Test Window {}", i),
+            title: format!("Perf Test Window {i}"),
             size: Size::new(px(400.0), px(300.0)),
             resizable: false,
             visible: false,

--- a/crates/flui-platform/tests/event_handling.rs
+++ b/crates/flui-platform/tests/event_handling.rs
@@ -6,6 +6,11 @@
 //! - Window events (T048)
 //! - Multi-touch events (T050)
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::no_effect_underscore_binding)]
+
 use std::sync::{Arc, Mutex};
 
 use flui_platform::{Platform, WindowOptions, current_platform};
@@ -198,13 +203,11 @@ fn test_window_resize_event() {
     let height_diff = (logical_height - 480.0).abs();
     assert!(
         width_diff < 5.0,
-        "Width mismatch: expected ~640, got {}",
-        logical_width
+        "Width mismatch: expected ~640, got {logical_width}"
     );
     assert!(
         height_diff < 5.0,
-        "Height mismatch: expected ~480, got {}",
-        logical_height
+        "Height mismatch: expected ~480, got {logical_height}"
     );
 
     // Contract: Platform fires WindowEvent::Resized on size change

--- a/crates/flui-platform/tests/executor_tests.rs
+++ b/crates/flui-platform/tests/executor_tests.rs
@@ -390,8 +390,7 @@ fn test_executor_spawn_overhead_benchmark() {
 
         assert!(
             avg_micros < 100.0,
-            "Background spawn overhead ({:.2}us) exceeds 100us target",
-            avg_micros
+            "Background spawn overhead ({avg_micros:.2}us) exceeds 100us target"
         );
     }
 
@@ -415,8 +414,7 @@ fn test_executor_spawn_overhead_benchmark() {
 
         assert!(
             avg_micros < 100.0,
-            "Foreground spawn overhead ({:.2}us) exceeds 100us target",
-            avg_micros
+            "Foreground spawn overhead ({avg_micros:.2}us) exceeds 100us target"
         );
     }
 

--- a/crates/flui-platform/tests/headless.rs
+++ b/crates/flui-platform/tests/headless.rs
@@ -2,6 +2,10 @@
 //!
 //! Tests for headless platform used in CI/testing environments.
 
+// `std::env::set_var`/`remove_var` are `unsafe` in edition 2024; tests run
+// serially (`--test-threads 1`), which is the safety condition.
+#![allow(unsafe_code)]
+
 use flui_platform::{WindowOptions, current_platform, headless_platform};
 use flui_types::geometry::{Size, px};
 

--- a/crates/flui-platform/tests/integration_template.rs
+++ b/crates/flui-platform/tests/integration_template.rs
@@ -38,6 +38,11 @@
 //! }
 //! ```
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::ignore_without_reason)]
+
 use flui_platform::{WindowOptions, current_platform};
 use flui_types::geometry::{Size, px};
 
@@ -112,7 +117,7 @@ fn test_window_handle_compatibility() {
             );
         }
         Err(e) => {
-            panic!("Failed to create window: {}", e);
+            panic!("Failed to create window: {e}");
         }
     }
 }

--- a/crates/flui-platform/tests/performance.rs
+++ b/crates/flui-platform/tests/performance.rs
@@ -2,6 +2,11 @@
 //!
 //! Tests to ensure test suite execution meets performance targets.
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::ignore_without_reason)]
+
 use std::{process::Command, time::Instant};
 
 #[test]

--- a/crates/flui-platform/tests/window_modes.rs
+++ b/crates/flui-platform/tests/window_modes.rs
@@ -174,16 +174,14 @@ fn test_dpi_scaling_change() {
             // Verify scale factor is positive
             assert!(
                 initial_scale > 0.0,
-                "Scale factor should be positive, got {}",
-                initial_scale
+                "Scale factor should be positive, got {initial_scale}"
             );
 
             // Typical scale factors: 1.0 (96 DPI), 1.25 (120 DPI), 1.5 (144 DPI), 2.0 (192
             // DPI)
             assert!(
                 (1.0..=3.0).contains(&initial_scale),
-                "Scale factor should be reasonable (1.0-3.0), got {}",
-                initial_scale
+                "Scale factor should be reasonable (1.0-3.0), got {initial_scale}"
             );
 
             // TODO: Once event system is implemented (Phase 5), test:

--- a/crates/flui-reactivity/README.md
+++ b/crates/flui-reactivity/README.md
@@ -1,5 +1,13 @@
 # flui-reactivity
 
+> **Status: excluded from the workspace, standalone by design.** This crate is
+> not in `[workspace] members` and is not built by CI: FLUI's locked contract
+> C1 (`docs/FOUNDATIONS.md`) keeps signals out of the view layer, so the crate
+> has zero workspace consumers, and its manifest inherits `any_spawner` from
+> `workspace.dependencies`, which the root does not declare. It re-enters the
+> workspace only if/when signals are integrated into the view layer (see the
+> note in the root `Cargo.toml` members list).
+
 Production-ready reactive state management system for Rust, inspired by React Hooks and Solid.js. Provides signals, computed values, effects, and a comprehensive hook system with full thread-safety.
 
 ## Features

--- a/crates/flui-rendering/Cargo.toml
+++ b/crates/flui-rendering/Cargo.toml
@@ -122,3 +122,6 @@ testing = ["flui-layer/testing"]
 # `RenderCustomMultiChildLayoutBox`) landed; the remaining gated module is
 # `custom_clipper.rs`. Opt in via `--features experimental-delegates`.
 experimental-delegates = []
+
+[lints]
+workspace = true

--- a/crates/flui-rendering/benches/intrinsic_parent_data.rs
+++ b/crates/flui-rendering/benches/intrinsic_parent_data.rs
@@ -38,6 +38,10 @@
 //! env -u CARGO_TARGET_DIR cargo bench -p flui-rendering --bench intrinsic_parent_data
 //! ```
 
+// Bench harness, not public API; `criterion_group!` generates the
+// undocumentable entry fn.
+#![allow(missing_docs)]
+
 mod helpers;
 
 use std::hint::black_box;

--- a/crates/flui-rendering/benches/layout.rs
+++ b/crates/flui-rendering/benches/layout.rs
@@ -7,6 +7,10 @@
 //! Run with:
 //!   cargo bench -p flui-rendering --bench layout
 
+// Bench harness, not public API; `criterion_group!` generates the
+// undocumentable entry fn.
+#![allow(missing_docs)]
+
 mod helpers;
 
 use std::hint::black_box;

--- a/crates/flui-rendering/benches/paint.rs
+++ b/crates/flui-rendering/benches/paint.rs
@@ -7,6 +7,10 @@
 //! Run with:
 //!   cargo bench -p flui-rendering --bench paint
 
+// Bench harness, not public API; `criterion_group!` generates the
+// undocumentable entry fn.
+#![allow(missing_docs)]
+
 mod helpers;
 
 use std::hint::black_box;

--- a/crates/flui-rendering/benches/virtualizer.rs
+++ b/crates/flui-rendering/benches/virtualizer.rs
@@ -37,6 +37,10 @@
 //! Run with:
 //!   cargo bench -p flui-rendering --bench virtualizer
 
+// Bench harness, not public API; `criterion_group!` generates the
+// undocumentable entry fn.
+#![allow(missing_docs)]
+
 use std::hint::black_box;
 use std::sync::Arc;
 

--- a/crates/flui-rendering/src/binding/mod.rs
+++ b/crates/flui-rendering/src/binding/mod.rs
@@ -407,7 +407,7 @@ pub fn debug_dump_render_tree<B: RendererBinding + ?Sized>(binding: &B) -> Strin
         .filter_map(|id| {
             binding.render_view(id).map(|view| {
                 let view_guard = view.read();
-                format!("=== RenderView {} ===\n{:?}", id, view_guard)
+                format!("=== RenderView {id} ===\n{view_guard:?}")
             })
         })
         .collect::<Vec<_>>()
@@ -426,9 +426,9 @@ pub fn debug_dump_layer_tree<B: RendererBinding + ?Sized>(binding: &B) -> String
             binding.render_view(id).map(|view| {
                 let view_guard = view.read();
                 if let Some(layer) = view_guard.layer() {
-                    format!("=== LayerTree {} ===\n{:?}", id, layer)
+                    format!("=== LayerTree {id} ===\n{layer:?}")
                 } else {
-                    format!("=== LayerTree {} ===\nLayer tree unavailable", id)
+                    format!("=== LayerTree {id} ===\nLayer tree unavailable")
                 }
             })
         })
@@ -463,10 +463,8 @@ pub fn debug_dump_semantics_tree<B: RendererBinding + ?Sized>(
             // 1. View to expose its PipelineOwner
             // 2. RendererBinding to route each view id to that PipelineOwner
             // 3. SemanticsTree to implement Debug or custom formatting
-            let mut message = format!(
-                "=== SemanticsTree {} ===\nSemantics dump not available via binding.",
-                id
-            );
+            let mut message =
+                format!("=== SemanticsTree {id} ===\nSemantics dump not available via binding.");
             if !printed_explanation {
                 printed_explanation = true;
                 message.push('\n');

--- a/crates/flui-rendering/src/constraints/box_constraints.rs
+++ b/crates/flui-rendering/src/constraints/box_constraints.rs
@@ -497,18 +497,14 @@ impl BoxConstraints {
     #[must_use]
     pub fn tighten(&self, width: Option<Pixels>, height: Option<Pixels>) -> Self {
         Self {
-            min_width: width
-                .map(|w| w.clamp(self.min_width, self.max_width))
-                .unwrap_or(self.min_width),
-            max_width: width
-                .map(|w| w.clamp(self.min_width, self.max_width))
-                .unwrap_or(self.max_width),
-            min_height: height
-                .map(|h| h.clamp(self.min_height, self.max_height))
-                .unwrap_or(self.min_height),
-            max_height: height
-                .map(|h| h.clamp(self.min_height, self.max_height))
-                .unwrap_or(self.max_height),
+            min_width: width.map_or(self.min_width, |w| w.clamp(self.min_width, self.max_width)),
+            max_width: width.map_or(self.max_width, |w| w.clamp(self.min_width, self.max_width)),
+            min_height: height.map_or(self.min_height, |h| {
+                h.clamp(self.min_height, self.max_height)
+            }),
+            max_height: height.map_or(self.max_height, |h| {
+                h.clamp(self.min_height, self.max_height)
+            }),
         }
     }
 
@@ -742,21 +738,21 @@ impl BoxConstraints {
     #[inline]
     #[must_use]
     pub fn round(&self) -> Self {
-        self.map(|v| v.round())
+        self.map(flui_types::Pixels::round)
     }
 
     /// Floors all constraint values.
     #[inline]
     #[must_use]
     pub fn floor(&self) -> Self {
-        self.map(|v| v.floor())
+        self.map(flui_types::Pixels::floor)
     }
 
     /// Ceils all constraint values.
     #[inline]
     #[must_use]
     pub fn ceil(&self) -> Self {
-        self.map(|v| v.ceil())
+        self.map(flui_types::Pixels::ceil)
     }
 }
 
@@ -777,10 +773,10 @@ fn round_pixels_to_hundredths(value: Pixels) -> Pixels {
 /// Checks if a Pixels value is already normalized.
 #[inline]
 fn is_pixels_normalized(value: Pixels) -> bool {
-    if !value.is_finite() {
-        true
-    } else {
+    if value.is_finite() {
         value == round_pixels_to_hundredths(value)
+    } else {
+        true
     }
 }
 
@@ -835,7 +831,7 @@ impl fmt::Debug for BoxConstraints {
 
 impl fmt::Display for BoxConstraints {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/flui-rendering/src/constraints/mod.rs
+++ b/crates/flui-rendering/src/constraints/mod.rs
@@ -120,8 +120,7 @@ pub trait Constraints: Clone + PartialEq + fmt::Debug + Send + Sync + 'static {
     fn debug_assert_is_valid(&self, is_applied_constraint: bool) -> bool {
         debug_assert!(
             self.is_normalized(),
-            "Constraints must be normalized: {:?}",
-            self
+            "Constraints must be normalized: {self:?}"
         );
 
         if is_applied_constraint {

--- a/crates/flui-rendering/src/constraints/sliver_constraints.rs
+++ b/crates/flui-rendering/src/constraints/sliver_constraints.rs
@@ -339,10 +339,10 @@ fn round_to_hundredths_runtime(value: f32) -> f32 {
 /// Checks if value is already normalized to hundredths precision.
 #[inline]
 fn is_normalized(value: f32) -> bool {
-    if !value.is_finite() {
-        true // Infinity/NaN are "normalized"
-    } else {
+    if value.is_finite() {
         value == round_to_hundredths_runtime(value)
+    } else {
+        true // Infinity/NaN are "normalized"
     }
 }
 
@@ -376,8 +376,7 @@ impl Constraints for SliverConstraints {
     fn debug_assert_is_valid(&self, is_applied_constraint: bool) -> bool {
         debug_assert!(
             self.is_normalized(),
-            "SliverConstraints must be normalized: {:?}",
-            self
+            "SliverConstraints must be normalized: {self:?}"
         );
 
         if is_applied_constraint {
@@ -423,7 +422,7 @@ impl fmt::Debug for SliverConstraints {
 
 impl fmt::Display for SliverConstraints {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/flui-rendering/src/constraints/sliver_geometry.rs
+++ b/crates/flui-rendering/src/constraints/sliver_geometry.rs
@@ -452,7 +452,7 @@ impl fmt::Debug for SliverGeometry {
 
 impl fmt::Display for SliverGeometry {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/flui-rendering/src/context/intrinsics.rs
+++ b/crates/flui-rendering/src/context/intrinsics.rs
@@ -426,7 +426,11 @@ impl<'a> BoxDryLayoutCtx<'a> {
 /// these when the `testing` feature is enabled.
 #[cfg(any(test, feature = "testing"))]
 pub mod test_support {
-    use super::*;
+    use super::{
+        BoxDryBaselineCtx, BoxDryLayoutCtx, BoxIntrinsicsCtx, DryBaselineChildRequest,
+        DryBaselineChildResponse, DryLayoutChildRequest, DryLayoutChildResponse,
+        IntrinsicDimension,
+    };
 
     /// A leaf context for unit-testing `compute_*` implementations of
     /// childless objects: any child query is a contract violation and

--- a/crates/flui-rendering/src/context/layout.rs
+++ b/crates/flui-rendering/src/context/layout.rs
@@ -513,7 +513,7 @@ where
         crate::protocol::sliver_protocol::SliverLayoutCtxErased::dispose_box_child(
             &mut self.inner,
             id,
-        )
+        );
     }
 
     /// Returns the [`RenderId`](flui_foundation::RenderId) of the Box child at
@@ -563,7 +563,7 @@ where
             &mut self.inner,
             first,
             last,
-        )
+        );
     }
 }
 

--- a/crates/flui-rendering/src/lib.rs
+++ b/crates/flui-rendering/src/lib.rs
@@ -45,12 +45,29 @@
 //! }
 //! ```
 
-#![warn(missing_docs)]
-#![warn(clippy::all)]
+// Lint levels come from `[workspace.lints]` (Cargo.toml `[lints] workspace = true`).
+// Crate-specific relaxations:
 // Rendering crate uses complex generic types for type-safe protocols
 #![allow(clippy::type_complexity)]
 // Some render objects have many configuration parameters
 #![allow(clippy::too_many_arguments)]
+// Tracked ship-quality debt:
+#![allow(missing_debug_implementations)] // TODO(ship-wave-3): add Debug impls (15 types), then delete
+#![allow(
+    clippy::default_trait_access,
+    clippy::format_push_string,
+    clippy::manual_let_else,
+    clippy::many_single_char_names,
+    clippy::map_unwrap_or,
+    clippy::match_same_arms,
+    clippy::match_wildcard_for_single_variants,
+    clippy::missing_fields_in_debug,
+    clippy::should_panic_without_expect,
+    clippy::struct_field_names,
+    clippy::unreadable_literal,
+    clippy::unused_self,
+    clippy::used_underscore_binding
+)] // TODO(ship-wave-3): burn down per-lint, then delete
 
 pub mod binding;
 pub mod constraints;

--- a/crates/flui-rendering/src/parent_data/table_text.rs
+++ b/crates/flui-rendering/src/parent_data/table_text.rs
@@ -207,7 +207,7 @@ impl TextParentData {
     /// Get span length if present.
     #[inline]
     pub fn span_length(&self) -> Option<usize> {
-        self.span.as_ref().map(|s| s.len())
+        self.span.as_ref().map(TextRange::len)
     }
 }
 

--- a/crates/flui-rendering/src/pipeline/owner/accessors.rs
+++ b/crates/flui-rendering/src/pipeline/owner/accessors.rs
@@ -427,35 +427,31 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
             if child_node.as_sliver().is_some() {
                 // Explicit positions are already child-local; the layout-offset
                 // fallback starts from the child's physical paint offset.
-                return match override_pos {
-                    Some(position) => {
-                        let child_position =
-                            Self::sliver_hit_position_from_offset(child_node, position);
-                        self.hit_test_sliver_subtree(child_id, child_position, result)
+                return if let Some(position) = override_pos {
+                    let child_position =
+                        Self::sliver_hit_position_from_offset(child_node, position);
+                    self.hit_test_sliver_subtree(child_id, child_position, result)
+                } else {
+                    if !Self::sliver_child_is_visible(child_node) {
+                        return false;
                     }
-                    None => {
-                        if !Self::sliver_child_is_visible(child_node) {
-                            return false;
-                        }
-                        let child_offset = child_node.offset();
-                        result.with_paint_offset(child_offset, |result| {
-                            let child_position = Self::sliver_hit_position_from_paint_offset(
-                                child_node,
-                                position - child_offset,
-                            );
-                            self.hit_test_sliver_subtree(child_id, child_position, result)
-                        })
-                    }
-                };
-            }
-            match override_pos {
-                Some(child_position) => self.hit_test_subtree(child_id, child_position, result),
-                None => {
                     let child_offset = child_node.offset();
                     result.with_paint_offset(child_offset, |result| {
-                        self.hit_test_subtree(child_id, position - child_offset, result)
+                        let child_position = Self::sliver_hit_position_from_paint_offset(
+                            child_node,
+                            position - child_offset,
+                        );
+                        self.hit_test_sliver_subtree(child_id, child_position, result)
                     })
-                }
+                };
+            }
+            if let Some(child_position) = override_pos {
+                self.hit_test_subtree(child_id, child_position, result)
+            } else {
+                let child_offset = child_node.offset();
+                result.with_paint_offset(child_offset, |result| {
+                    self.hit_test_subtree(child_id, position - child_offset, result)
+                })
             }
         };
 

--- a/crates/flui-rendering/src/pipeline/owner/query.rs
+++ b/crates/flui-rendering/src/pipeline/owner/query.rs
@@ -167,8 +167,8 @@ pub(super) struct QuerySlot<'a> {
 ///
 /// The slice is built from owned `Box<dyn ParentData>` values so it can
 /// coexist with the `&mut slots` that the recursion closure needs.
-fn build_child_parent_data<'slot>(
-    slots: &rustc_hash::FxHashMap<RenderId, QuerySlot<'slot>>,
+fn build_child_parent_data(
+    slots: &rustc_hash::FxHashMap<RenderId, QuerySlot<'_>>,
     children: &[RenderId],
     #[cfg(any(test, feature = "testing"))] seeds: &FxHashMap<RenderId, ParentDataSeed>,
     #[cfg(not(any(test, feature = "testing")))] _seeds: &(),

--- a/crates/flui-rendering/src/pipeline/owner/subtree_arena.rs
+++ b/crates/flui-rendering/src/pipeline/owner/subtree_arena.rs
@@ -34,6 +34,12 @@
 //! attached to each `unsafe` block document the invariant that makes the
 //! operation sound; they are the primary artefact for the audit.
 
+// The sanctioned `unsafe` island for the layout walk (see module docs above).
+// The opt-out is scoped to this file; every block carries a `// SAFETY:`
+// comment, and the invariants are machine-checked by the miri CI job /
+// `just miri`, which runs exactly this module's tests.
+#![allow(unsafe_code)]
+
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -217,7 +223,13 @@ impl<'tree> SubtreeArena<'tree> {
         let mut by_id = HashMap::with_capacity(ids.len());
         for (&id, r) in ids.iter().zip(refs) {
             // `AtomicBool::new(false)` — not in-flight at construction.
-            by_id.insert(id, (NodePtr(r as *mut RenderNode), AtomicBool::new(false)));
+            by_id.insert(
+                id,
+                (
+                    NodePtr(std::ptr::from_mut::<RenderNode>(r)),
+                    AtomicBool::new(false),
+                ),
+            );
         }
         #[cfg(any(test, feature = "testing"))]
         let parent_data_seeds = ids
@@ -253,19 +265,19 @@ impl<'tree> SubtreeArena<'tree> {
     #[inline]
     fn check_thread(&self) {
         let current = std::thread::current().id();
-        if current != self.owner_thread {
-            panic!(
-                "SubtreeArena accessed from non-owner thread: \
-                 owner = {:?}, current = {:?}. The U20 layout walk \
-                 requires the layout_child callback to fire on the \
-                 same thread as PipelineOwner::layout_dirty_root \
-                 (the pipeline phase holds &mut self synchronously). \
-                 User RenderBox::perform_layout body must not spawn \
-                 ctx.layout_child(...) calls to other threads — the \
-                 underlying RenderTree slab is not Sync.",
-                self.owner_thread, current,
-            );
-        }
+        assert!(
+            current == self.owner_thread,
+            "SubtreeArena accessed from non-owner thread: \
+             owner = {:?}, current = {:?}. The U20 layout walk \
+             requires the layout_child callback to fire on the \
+             same thread as PipelineOwner::layout_dirty_root \
+             (the pipeline phase holds &mut self synchronously). \
+             User RenderBox::perform_layout body must not spawn \
+             ctx.layout_child(...) calls to other threads — the \
+             underlying RenderTree slab is not Sync.",
+            self.owner_thread,
+            current,
+        );
     }
 
     /// Returns the [`NodePtr`] for `id` if present, panicking
@@ -507,7 +519,7 @@ impl<'arena, 'tree> LayoutCycleGuard<'arena, 'tree> {
     }
 }
 
-impl<'arena, 'tree> Drop for LayoutCycleGuard<'arena, 'tree> {
+impl Drop for LayoutCycleGuard<'_, '_> {
     fn drop(&mut self) {
         // Unconditional clear — runs on every exit path including unwind.
         // The in-flight flag stays consistent for the next frame.
@@ -651,8 +663,8 @@ unsafe fn build_intrinsic_child_parent_data(
 ///    `LayoutCycleGuard` (returns
 ///    [`crate::error::RenderError::LayoutCycle`] on re-entry into
 ///    a slot already in flight up the stack).
-unsafe fn layout_subtree_borrowed<'tree>(
-    arena: &SubtreeArena<'tree>,
+unsafe fn layout_subtree_borrowed(
+    arena: &SubtreeArena<'_>,
     id: RenderId,
     constraints: BoxConstraints,
 ) -> crate::error::RenderResult<flui_types::Size> {
@@ -671,8 +683,8 @@ unsafe fn layout_subtree_borrowed<'tree>(
 /// # Safety
 ///
 /// Same contract as [`layout_subtree_borrowed`].
-unsafe fn layout_subtree_borrowed_impl<'tree>(
-    arena: &SubtreeArena<'tree>,
+unsafe fn layout_subtree_borrowed_impl(
+    arena: &SubtreeArena<'_>,
     id: RenderId,
     constraints: BoxConstraints,
 ) -> crate::error::RenderResult<flui_types::Size> {
@@ -718,14 +730,14 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
         let needs_layout_flag = entry.needs_layout();
         // Snapshot the cached geometry for the short-circuit check below;
         // no allocation — `Size` is `Copy`.
-        let cached_geometry: Option<flui_types::Size> = if !needs_layout_flag {
+        let cached_geometry: Option<flui_types::Size> = if needs_layout_flag {
+            None
+        } else {
             entry
                 .state()
                 .has_constraints(&constraints)
                 .then(|| entry.state().geometry())
                 .flatten()
-        } else {
-            None
         };
         let is_leaf = child_ids.is_empty();
         (
@@ -1053,14 +1065,14 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
         // Only clear NEEDS_LAYOUT if the recursive callback observed no
         // descendant failure.  Preserves retry-next-frame semantics.
         let had_descendant_error = descendant_error_flag.load(std::sync::atomic::Ordering::Relaxed);
-        if !had_descendant_error {
-            entry.clear_needs_layout();
-        } else {
+        if had_descendant_error {
             tracing::debug!(
                 parent = ?id,
                 "layout_dirty_root: a descendant errored during this walk; \
                  keeping parent NEEDS_LAYOUT set for next-frame retry"
             );
+        } else {
+            entry.clear_needs_layout();
         }
 
         // `entry`, `node_ref`, and all callbacks drop here.
@@ -1129,8 +1141,8 @@ unsafe fn layout_subtree_borrowed_impl<'tree>(
 /// layout.  It shares the layout walk's [`SubtreeArena`] pool instead of
 /// re-entering `PipelineOwner`, preserving the same disjoint-slot discipline
 /// as `layout_subtree_borrowed`.
-unsafe fn box_intrinsic_query_borrowed<'tree>(
-    arena: &SubtreeArena<'tree>,
+unsafe fn box_intrinsic_query_borrowed(
+    arena: &SubtreeArena<'_>,
     id: RenderId,
     dimension: crate::storage::IntrinsicDimension,
     extent: f32,
@@ -1149,8 +1161,8 @@ unsafe fn box_intrinsic_query_borrowed<'tree>(
 /// Same contract as [`layout_subtree_borrowed`]: `arena` must outlive this
 /// call and recursive child callbacks, and re-entry into an in-flight node is
 /// rejected by [`LayoutCycleGuard`] before any second mutable reborrow occurs.
-unsafe fn box_intrinsic_query_borrowed_impl<'tree>(
-    arena: &SubtreeArena<'tree>,
+unsafe fn box_intrinsic_query_borrowed_impl(
+    arena: &SubtreeArena<'_>,
     id: RenderId,
     dimension: crate::storage::IntrinsicDimension,
     extent: f32,
@@ -1284,8 +1296,8 @@ unsafe fn box_intrinsic_query_borrowed_impl<'tree>(
 ///    exist.  The `LayoutCycleGuard` enforces this by returning
 ///    [`crate::error::RenderError::LayoutCycle`] on re-entry into a slot
 ///    already in flight, preventing the otherwise-UB second Unique tag.
-unsafe fn layout_sliver_subtree_borrowed<'tree>(
-    arena: &SubtreeArena<'tree>,
+unsafe fn layout_sliver_subtree_borrowed(
+    arena: &SubtreeArena<'_>,
     id: flui_foundation::RenderId,
     constraints: SliverConstraints,
 ) -> crate::error::RenderResult<SliverGeometry> {
@@ -1304,8 +1316,8 @@ unsafe fn layout_sliver_subtree_borrowed<'tree>(
 /// # Safety
 ///
 /// Same contract as [`layout_sliver_subtree_borrowed`].
-unsafe fn layout_sliver_subtree_borrowed_impl<'tree>(
-    arena: &SubtreeArena<'tree>,
+unsafe fn layout_sliver_subtree_borrowed_impl(
+    arena: &SubtreeArena<'_>,
     id: flui_foundation::RenderId,
     constraints: SliverConstraints,
 ) -> crate::error::RenderResult<SliverGeometry> {
@@ -1565,14 +1577,14 @@ unsafe fn layout_sliver_subtree_borrowed_impl<'tree>(
             has_parent,
         );
 
-        if !descendant_error_flag.load(std::sync::atomic::Ordering::Relaxed) {
-            entry.clear_needs_layout();
-        } else {
+        if descendant_error_flag.load(std::sync::atomic::Ordering::Relaxed) {
             tracing::debug!(
                 parent = ?id,
                 "layout_dirty_root: a sliver descendant errored during this walk; \
                  keeping parent NEEDS_LAYOUT set for next-frame retry"
             );
+        } else {
+            entry.clear_needs_layout();
         }
 
         // `entry`, `node_ref`, and all callbacks drop here.

--- a/crates/flui-rendering/src/protocol/box_protocol.rs
+++ b/crates/flui-rendering/src/protocol/box_protocol.rs
@@ -558,7 +558,7 @@ impl<'ctx, A: Arity, P: ParentData + Default> LayoutContextApi<'ctx, BoxLayout, 
     fn child_count(&self) -> usize {
         match &self.storage {
             BoxLayoutCtxStorage::Direct { children, .. } => {
-                children.as_ref().map(|c| c.len()).unwrap_or(0)
+                children.as_ref().map_or(0, |c| c.len())
             }
             BoxLayoutCtxStorage::Proxy { erased, .. } => erased.child_count(),
         }
@@ -931,7 +931,7 @@ impl<A: Arity, P: ParentData + Default> BoxLayoutCtxErased for BoxLayoutCtx<'_, 
 
     #[inline]
     fn position_child(&mut self, index: usize, offset: Offset) {
-        <Self as LayoutContextApi<'_, BoxLayout, A, P>>::position_child(self, index, offset)
+        <Self as LayoutContextApi<'_, BoxLayout, A, P>>::position_child(self, index, offset);
     }
 
     #[inline]
@@ -1185,8 +1185,7 @@ impl BoxLayoutCtxErased for ErasedBoxLayoutCtx<'_> {
     fn sliver_child_needs_layout(&self, index: usize) -> bool {
         self.children
             .get(index)
-            .map(|slot| slot.needs_layout)
-            .unwrap_or(true)
+            .is_none_or(|slot| slot.needs_layout)
     }
 
     fn position_child(&mut self, index: usize, offset: Offset) {

--- a/crates/flui-rendering/src/protocol/sliver_protocol.rs
+++ b/crates/flui-rendering/src/protocol/sliver_protocol.rs
@@ -536,7 +536,7 @@ impl<'ctx, A: Arity, P: ParentData + Default> LayoutContextApi<'ctx, SliverLayou
     fn child_count(&self) -> usize {
         match &self.storage {
             SliverLayoutCtxStorage::Direct { children, .. } => {
-                children.as_ref().map(|c| c.len()).unwrap_or(0)
+                children.as_ref().map_or(0, |c| c.len())
             }
             SliverLayoutCtxStorage::Proxy { erased, .. } => erased.child_count(),
         }
@@ -846,7 +846,7 @@ impl<A: Arity, P: ParentData + Default> SliverLayoutCtxErased for SliverLayoutCt
 
     #[inline]
     fn position_child(&mut self, index: usize, offset: Offset) {
-        <Self as LayoutContextApi<'_, SliverLayout, A, P>>::position_child(self, index, offset)
+        <Self as LayoutContextApi<'_, SliverLayout, A, P>>::position_child(self, index, offset);
     }
 
     #[inline]

--- a/crates/flui-rendering/src/storage/flags.rs
+++ b/crates/flui-rendering/src/storage/flags.rs
@@ -1089,7 +1089,7 @@ mod tests {
     #[test]
     fn test_display() {
         let flags = RenderFlags::NEEDS_LAYOUT | RenderFlags::NEEDS_PAINT;
-        let display = format!("{}", flags);
+        let display = format!("{flags}");
         assert!(display.contains("NEEDS_LAYOUT"));
         assert!(display.contains("NEEDS_PAINT"));
     }

--- a/crates/flui-rendering/src/storage/node.rs
+++ b/crates/flui-rendering/src/storage/node.rs
@@ -697,11 +697,11 @@ impl RenderNode {
         match self {
             Self::Box(entry) => {
                 let size = entry.state().geometry().unwrap_or(flui_types::Size::ZERO);
-                entry.render_object().paint_raw(recorder, child_count, size)
+                entry.render_object().paint_raw(recorder, child_count, size);
             }
             Self::Sliver(entry) => {
                 let size = entry.state().absolute_paint_size();
-                entry.render_object().paint_raw(recorder, child_count, size)
+                entry.render_object().paint_raw(recorder, child_count, size);
             }
         }
     }

--- a/crates/flui-rendering/src/storage/state/constraints.rs
+++ b/crates/flui-rendering/src/storage/state/constraints.rs
@@ -72,9 +72,6 @@ impl<P: Protocol> RenderState<P> {
     where
         ProtocolConstraints<P>: PartialEq,
     {
-        self.constraints
-            .as_ref()
-            .map(|c| c == constraints)
-            .unwrap_or(false)
+        self.constraints.as_ref().is_some_and(|c| c == constraints)
     }
 }

--- a/crates/flui-rendering/src/storage/state/geometry.rs
+++ b/crates/flui-rendering/src/storage/state/geometry.rs
@@ -18,7 +18,7 @@
 //! state borrow.
 
 use super::RenderState;
-use crate::constraints::{Constraints, SliverGeometry};
+use crate::constraints::SliverGeometry;
 use crate::protocol::{BoxProtocol, Protocol, ProtocolGeometry, SliverProtocol};
 
 // ============================================================================
@@ -182,7 +182,9 @@ impl RenderState<BoxProtocol> {
         // is_boundary = !parent_uses_size || sized_by_parent || constraints.is_tight()
         // || !has_parent
 
-        let constraints_are_tight = self.constraints().map(|c| c.is_tight()).unwrap_or(false);
+        let constraints_are_tight = self
+            .constraints()
+            .is_some_and(crate::constraints::Constraints::is_tight);
 
         let is_boundary = !parent_uses_size  // Parent doesn't use size
             || sized_by_parent                // Size determined by constraints
@@ -235,7 +237,7 @@ impl RenderState<BoxProtocol> {
     /// ```
     #[inline]
     pub fn has_size(&self, size: flui_types::Size) -> bool {
-        self.geometry().map(|s| s == size).unwrap_or(false)
+        self.geometry().is_some_and(|s| s == size)
     }
 }
 
@@ -253,7 +255,7 @@ impl RenderState<SliverProtocol> {
     /// ```
     #[inline]
     pub fn scroll_extent(&self) -> f32 {
-        self.geometry().map(|g| g.scroll_extent).unwrap_or(0.0)
+        self.geometry().map_or(0.0, |g| g.scroll_extent)
     }
 
     /// Returns paint extent, or 0.0 if geometry is not set.
@@ -268,19 +270,19 @@ impl RenderState<SliverProtocol> {
     /// ```
     #[inline]
     pub fn paint_extent(&self) -> f32 {
-        self.geometry().map(|g| g.paint_extent).unwrap_or(0.0)
+        self.geometry().map_or(0.0, |g| g.paint_extent)
     }
 
     /// Returns layout extent, or 0.0 if geometry is not set.
     #[inline]
     pub fn layout_extent(&self) -> f32 {
-        self.geometry().map(|g| g.layout_extent).unwrap_or(0.0)
+        self.geometry().map_or(0.0, |g| g.layout_extent)
     }
 
     /// Returns max paint extent, or 0.0 if geometry is not set.
     #[inline]
     pub fn max_paint_extent(&self) -> f32 {
-        self.geometry().map(|g| g.max_paint_extent).unwrap_or(0.0)
+        self.geometry().map_or(0.0, |g| g.max_paint_extent)
     }
 
     /// Sets sliver geometry (convenience wrapper for `set_geometry()`).

--- a/crates/flui-rendering/src/storage/tree.rs
+++ b/crates/flui-rendering/src/storage/tree.rs
@@ -504,7 +504,7 @@ impl RenderTree {
         }
 
         // Get parent and remove from parent's children
-        if let Some(parent_id) = self.get(id).and_then(|n| n.parent())
+        if let Some(parent_id) = self.get(id).and_then(super::node::RenderNode::parent)
             && let Some(parent) = self.get_mut(parent_id)
         {
             parent.remove_child(id);
@@ -575,13 +575,15 @@ impl RenderTree {
     /// Returns the children IDs of a node.
     #[inline]
     pub fn children(&self, id: RenderId) -> &[RenderId] {
-        self.get(id).map(|n| n.children()).unwrap_or(&[])
+        self.get(id)
+            .map(super::node::RenderNode::children)
+            .unwrap_or(&[])
     }
 
     /// Returns the depth of a node in the tree.
     #[inline]
     pub fn depth(&self, id: RenderId) -> Option<u16> {
-        self.get(id).map(|n| n.depth())
+        self.get(id).map(super::node::RenderNode::depth)
     }
 
     /// Collects `root_id` plus every transitive descendant in
@@ -945,7 +947,7 @@ impl TreeWrite<RenderId> for RenderTree {
         }
 
         // Get parent and remove from parent's children
-        if let Some(parent_id) = self.get(id).and_then(|n| n.parent())
+        if let Some(parent_id) = self.get(id).and_then(super::node::RenderNode::parent)
             && let Some(parent) = RenderTree::get_mut(self, parent_id)
         {
             parent.remove_child(id);
@@ -1004,14 +1006,12 @@ impl TreeNav<RenderId> for RenderTree {
 
     #[inline]
     fn child_count(&self, id: RenderId) -> usize {
-        self.get(id).map(|node| node.children().len()).unwrap_or(0)
+        self.get(id).map_or(0, |node| node.children().len())
     }
 
     #[inline]
     fn has_children(&self, id: RenderId) -> bool {
-        self.get(id)
-            .map(|node| !node.children().is_empty())
-            .unwrap_or(false)
+        self.get(id).is_some_and(|node| !node.children().is_empty())
     }
 }
 
@@ -1121,7 +1121,10 @@ mod tests {
         assert!(pair.is_some(), "two existing distinct ids must yield Some");
         let (na, nb) = pair.unwrap();
         // The two refs must point to different RenderNodes -- compare addresses.
-        assert!(!std::ptr::eq(na as *const _, nb as *const _));
+        assert!(!std::ptr::eq(
+            std::ptr::from_ref(na),
+            std::ptr::from_ref(nb)
+        ));
     }
 
     #[test]
@@ -1218,7 +1221,10 @@ mod tests {
 
         // Verify disjointness — all 4 references point to distinct
         // RenderNodes (compare addresses through *const _).
-        let addrs: Vec<*const RenderNode> = refs.iter().map(|r| *r as *const RenderNode).collect();
+        let addrs: Vec<*const RenderNode> = refs
+            .iter()
+            .map(|r| std::ptr::from_ref::<RenderNode>(*r))
+            .collect();
         for (i, &a_addr) in addrs.iter().enumerate() {
             for &b_addr in &addrs[i + 1..] {
                 assert!(

--- a/crates/flui-rendering/src/testing/assertions.rs
+++ b/crates/flui-rendering/src/testing/assertions.rs
@@ -8,7 +8,11 @@ use flui_foundation::DiagnosticsNode;
 /// Asserts that `node` exposes every property name in `required`.
 #[track_caller]
 pub fn assert_properties(node: &DiagnosticsNode, required: &[&str]) {
-    let names: Vec<&str> = node.properties().iter().map(|p| p.name()).collect();
+    let names: Vec<&str> = node
+        .properties()
+        .iter()
+        .map(flui_foundation::DiagnosticsProperty::name)
+        .collect();
     for &req in required {
         assert!(
             names.contains(&req),

--- a/crates/flui-rendering/src/testing/snapshot.rs
+++ b/crates/flui-rendering/src/testing/snapshot.rs
@@ -655,7 +655,7 @@ pub fn summarize_command(cmd: &DrawCommand) -> DrawCommandSummary {
 /// `BackdropFilter` commands so that masked content appears in the snapshot.
 fn write_display_list(out: &mut String, dl: &DisplayList, depth: usize) {
     let indent = "  ".repeat(depth);
-    for cmd in dl.iter() {
+    for cmd in dl {
         // Recurse into effect-command children before printing the line so that
         // the child content appears nested under the effect header.
         match cmd {
@@ -688,7 +688,7 @@ fn write_display_list(out: &mut String, dl: &DisplayList, depth: usize) {
 /// Collect all `DrawCommandSummary` values from a `DisplayList`, recursing
 /// into `ShaderMask` and `BackdropFilter` child lists.
 fn collect_from_display_list(dl: &DisplayList, out: &mut Vec<DrawCommandSummary>) {
-    for cmd in dl.iter() {
+    for cmd in dl {
         match cmd {
             DrawCommand::ShaderMask { child, .. } => {
                 out.push(summarize_command(cmd));
@@ -978,12 +978,11 @@ pub fn commands_of(tree: Option<&LayerTree>) -> Vec<DrawCommandSummary> {
 /// Unlike Flutter's `paints..something()` matcher this assertion is **strict**:
 /// if `pred` never matches it is always a test failure, never a silent pass.
 pub fn assert_any(tree: Option<&LayerTree>, pred: impl Fn(&DrawCommandSummary) -> bool) {
-    if !commands_of(tree).iter().any(pred) {
-        panic!(
-            "no painted command matched the predicate:\n{}",
-            snapshot_tree(tree),
-        );
-    }
+    assert!(
+        commands_of(tree).iter().any(pred),
+        "no painted command matched the predicate:\n{}",
+        snapshot_tree(tree),
+    );
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/crates/flui-rendering/src/testing/tree.rs
+++ b/crates/flui-rendering/src/testing/tree.rs
@@ -187,9 +187,10 @@ impl RenderLabelRegistry {
     /// Records a label -> id mapping, panicking on a duplicate label (a
     /// duplicate is a test-authoring bug, not a runtime condition).
     fn record(&mut self, label: &'static str, id: RenderId) {
-        if self.by_label.insert(label, id).is_some() {
-            panic!("duplicate node label in test tree: {label:?}");
-        }
+        assert!(
+            self.by_label.insert(label, id).is_none(),
+            "duplicate node label in test tree: {label:?}"
+        );
     }
 
     /// Returns the id for `label`, if one was registered.

--- a/crates/flui-rendering/src/traits/render_box.rs
+++ b/crates/flui-rendering/src/traits/render_box.rs
@@ -731,7 +731,7 @@ where
         &self,
         config: &mut crate::semantics::SemanticsConfiguration,
     ) {
-        <T as RenderBox>::describe_semantics_configuration(self, config)
+        <T as RenderBox>::describe_semantics_configuration(self, config);
     }
 
     fn excludes_semantics_subtree(&self) -> bool {
@@ -739,15 +739,15 @@ where
     }
 
     fn reassemble(&mut self) {
-        <T as RenderBox>::reassemble(self)
+        <T as RenderBox>::reassemble(self);
     }
 
     fn attach(&mut self, handle: crate::pipeline::RepaintHandle) {
-        <T as RenderBox>::attach(self, handle)
+        <T as RenderBox>::attach(self, handle);
     }
 
     fn detach(&mut self) {
-        <T as RenderBox>::detach(self)
+        <T as RenderBox>::detach(self);
     }
 
     fn debug_name(&self) -> &'static str {

--- a/crates/flui-rendering/src/traits/render_sliver.rs
+++ b/crates/flui-rendering/src/traits/render_sliver.rs
@@ -608,7 +608,7 @@ where
         &self,
         config: &mut crate::semantics::SemanticsConfiguration,
     ) {
-        <T as RenderSliver>::describe_semantics_configuration(self, config)
+        <T as RenderSliver>::describe_semantics_configuration(self, config);
     }
 
     fn excludes_semantics_subtree(&self) -> bool {
@@ -616,15 +616,15 @@ where
     }
 
     fn reassemble(&mut self) {
-        <T as RenderSliver>::reassemble(self)
+        <T as RenderSliver>::reassemble(self);
     }
 
     fn attach(&mut self, handle: crate::pipeline::RepaintHandle) {
-        <T as RenderSliver>::attach(self, handle)
+        <T as RenderSliver>::attach(self, handle);
     }
 
     fn detach(&mut self) {
-        <T as RenderSliver>::detach(self)
+        <T as RenderSliver>::detach(self);
     }
 
     // Compositing / layer-boundary forwards — mirror the RenderBox blanket

--- a/crates/flui-rendering/tests/cross_protocol_layout.rs
+++ b/crates/flui-rendering/tests/cross_protocol_layout.rs
@@ -16,6 +16,11 @@
 //!   * `crates/flui-rendering/src/pipeline/owner.rs` `layout_sliver_subtree_borrowed`
 //!   * `crates/flui-rendering/src/protocol/box_protocol.rs` `BoxLayoutCtxErased::layout_sliver_child`
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::unwrap_used)]
+
 use std::sync::{Arc, Mutex};
 
 use flui_foundation::Diagnosticable;

--- a/crates/flui-rendering/tests/flex_layout_fixes.rs
+++ b/crates/flui-rendering/tests/flex_layout_fixes.rs
@@ -17,6 +17,11 @@
 //! 5. non-stretch children receive a LOOSE cross even when the
 //!    incoming cross is tight.
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::unwrap_used)]
+
 use std::sync::{Arc, Mutex};
 
 use flui_foundation::RenderId;

--- a/crates/flui-rendering/tests/render_viewport.rs
+++ b/crates/flui-rendering/tests/render_viewport.rs
@@ -367,10 +367,7 @@ impl RenderSliver for CorrectingSliver {
         &mut self,
         _ctx: &mut SliverLayoutContext<'_, Leaf, Self::ParentData>,
     ) -> SliverGeometry {
-        if !self.corrected {
-            self.corrected = true;
-            SliverGeometry::scroll_offset_correction(self.correction)
-        } else {
+        if self.corrected {
             SliverGeometry {
                 scroll_extent: 80.0,
                 paint_extent: 80.0,
@@ -381,6 +378,9 @@ impl RenderSliver for CorrectingSliver {
                 visible: true,
                 ..SliverGeometry::ZERO
             }
+        } else {
+            self.corrected = true;
+            SliverGeometry::scroll_offset_correction(self.correction)
         }
     }
 
@@ -564,7 +564,7 @@ fn viewport_lays_out_forward_slivers_and_applies_content_dimensions() {
     let laid_out_size = owner
         .render_tree()
         .get(root_id)
-        .and_then(|node| node.geometry_box())
+        .and_then(flui_rendering::storage::RenderNode::geometry_box)
         .expect("root viewport has committed box geometry");
     let viewport = owner
         .render_tree()

--- a/crates/flui-rendering/tests/root_resize_repaint.rs
+++ b/crates/flui-rendering/tests/root_resize_repaint.rs
@@ -53,7 +53,7 @@ fn run_frame_sizes(
     let root_geometry = owner
         .render_tree()
         .get(root_id)
-        .and_then(|n| n.geometry_box())
+        .and_then(flui_rendering::storage::RenderNode::geometry_box)
         .expect("root geometry computed");
 
     (root_geometry, painted, owner.into_idle())

--- a/crates/flui-rendering/tests/sliver_fill_remaining.rs
+++ b/crates/flui-rendering/tests/sliver_fill_remaining.rs
@@ -1,3 +1,5 @@
+//! Harness tests for the `RenderSliverFillRemaining` family.
+
 use flui_objects::{
     RenderSliverFillRemaining, RenderSliverFillRemainingAndOverscroll,
     RenderSliverFillRemainingWithScrollable,

--- a/crates/flui-rendering/tests/sliver_geometry_validation.rs
+++ b/crates/flui-rendering/tests/sliver_geometry_validation.rs
@@ -1,5 +1,10 @@
 //! Runtime validation for `SliverGeometry` layout results.
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::unwrap_used)]
+
 use std::sync::{Arc, Mutex};
 
 use flui_foundation::Diagnosticable;

--- a/crates/flui-rendering/tests/u19_bridge.rs
+++ b/crates/flui-rendering/tests/u19_bridge.rs
@@ -157,8 +157,7 @@ fn u19_single_bridge_pads_child_and_returns_total_size() {
     assert!(
         (child_offset.dx.get() - 10.0).abs() < f32::EPSILON
             && (child_offset.dy.get() - 10.0).abs() < f32::EPSILON,
-        "child offset {:?} should equal (10, 10)",
-        child_offset
+        "child offset {child_offset:?} should equal (10, 10)"
     );
 }
 
@@ -244,8 +243,7 @@ fn u19_variable_bridge_walks_child_slice_with_typed_parent_data() {
         size,
         Size::new(px(300.0), px(100.0)),
         "Variable bridge with flex 1:2 over 300px main axis must produce \
-         exact (300, 100) — actual {:?}",
-        size,
+         exact (300, 100) — actual {size:?}",
     );
 
     // Each child's constraints prove the typed parent-data round-tripped

--- a/crates/flui-rendering/tests/u20_layout_dirty_root.rs
+++ b/crates/flui-rendering/tests/u20_layout_dirty_root.rs
@@ -162,11 +162,11 @@ fn u20_three_level_padding_center_colored_box_grandchild_propagation() {
     let padding_geom = pipeline
         .render_tree()
         .get(padding_id)
-        .and_then(|n| n.geometry_box());
+        .and_then(flui_rendering::storage::RenderNode::geometry_box);
     let center_geom = pipeline
         .render_tree()
         .get(center_id)
-        .and_then(|n| n.geometry_box());
+        .and_then(flui_rendering::storage::RenderNode::geometry_box);
 
     assert_eq!(padding_geom, Some(Size::new(px(400.0), px(300.0))));
     assert_eq!(
@@ -258,7 +258,7 @@ fn u20_leaf_path_delegates_to_layout_leaf_only() {
     let geom = pipeline
         .render_tree()
         .get(leaf_id)
-        .and_then(|n| n.geometry_box());
+        .and_then(flui_rendering::storage::RenderNode::geometry_box);
     assert_eq!(geom, Some(Size::new(px(120.0), px(50.0))));
 }
 

--- a/crates/flui-rendering/tests/u23_run_layout_wiring.rs
+++ b/crates/flui-rendering/tests/u23_run_layout_wiring.rs
@@ -107,7 +107,7 @@ fn u23_run_layout_uses_cached_constraints_on_frame_two() {
     let frame_1_size = owner
         .render_tree()
         .get(padding_id)
-        .and_then(|n| n.geometry_box());
+        .and_then(flui_rendering::storage::RenderNode::geometry_box);
     assert_eq!(frame_1_size, Some(Size::new(px(64.0), px(34.0))));
 
     // Clear root_constraints to prove frame 2 doesn't depend on it.
@@ -124,7 +124,7 @@ fn u23_run_layout_uses_cached_constraints_on_frame_two() {
     let frame_2_size = owner
         .render_tree()
         .get(padding_id)
-        .and_then(|n| n.geometry_box());
+        .and_then(flui_rendering::storage::RenderNode::geometry_box);
     assert_eq!(
         frame_2_size, frame_1_size,
         "frame 2 must produce the same geometry as frame 1 — \
@@ -161,7 +161,7 @@ fn u23_run_layout_skips_dirty_entry_with_no_constraints() {
         owner
             .render_tree()
             .get(padding_id)
-            .and_then(|n| n.geometry_box())
+            .and_then(flui_rendering::storage::RenderNode::geometry_box)
             .is_none(),
         "skipped entry must NOT have geometry computed",
     );
@@ -272,7 +272,7 @@ fn u23_run_layout_skips_already_cleaned_dirty_entries() {
     let padding_geom = owner
         .render_tree()
         .get(padding_id)
-        .and_then(|n| n.geometry_box());
+        .and_then(flui_rendering::storage::RenderNode::geometry_box);
     assert_eq!(padding_geom, Some(Size::new(px(50.0), px(50.0))));
     // No way to count perform_layout invocations from integration test,
     // but the skip path is exercised (covered by lib-scoped test if

--- a/crates/flui-rendering/tests/u34_compositing_bits_walk.rs
+++ b/crates/flui-rendering/tests/u34_compositing_bits_walk.rs
@@ -156,16 +156,14 @@ fn u34_run_compositing_short_circuits_when_flag_cleared_after_enqueue() {
     let needs_compositing_before = owner
         .render_tree()
         .get(padding_id)
-        .map(|n| n.needs_compositing())
-        .unwrap_or(false);
+        .is_some_and(flui_rendering::storage::RenderNode::needs_compositing);
 
     owner.run_compositing().expect("run_compositing succeeds");
 
     let needs_compositing_after = owner
         .render_tree()
         .get(padding_id)
-        .map(|n| n.needs_compositing())
-        .unwrap_or(false);
+        .is_some_and(flui_rendering::storage::RenderNode::needs_compositing);
 
     // Walk short-circuits → NEEDS_COMPOSITING unchanged.
     assert_eq!(

--- a/crates/flui-rendering/tests/u3c_lazy_sliver_contract.rs
+++ b/crates/flui-rendering/tests/u3c_lazy_sliver_contract.rs
@@ -249,8 +249,7 @@ fn step3_logical_index_stamped_on_deferred_insert() {
     assert_eq!(
         unique_count,
         indices.len(),
-        "duplicate logical indices: {:?}",
-        indices,
+        "duplicate logical indices: {indices:?}",
     );
 }
 
@@ -385,8 +384,7 @@ fn u3c_9a_convergence_logical_indices_reconcile() {
     assert_eq!(
         unique_count,
         indices.len(),
-        "duplicate logical indices detected: {:?} — two children claim the same item",
-        indices,
+        "duplicate logical indices detected: {indices:?} — two children claim the same item",
     );
 
     // The lowest visible logical index must be ≥ cache_first.  With
@@ -395,7 +393,7 @@ fn u3c_9a_convergence_logical_indices_reconcile() {
     // scroll_offset = 500 px (cache reaches back 50 px before the viewport).
     // Asserting ≥ 9 (= cache_first) is the correct invariant; ≥ 10 (= visible
     // first) would be too tight and would spuriously fail on valid pre-fetch.
-    let min_idx = pairs.first().map(|(idx, _)| *idx).unwrap_or(0);
+    let min_idx = pairs.first().map_or(0, |(idx, _)| *idx);
     assert!(
         min_idx >= 9,
         "scroll_offset={scroll_offset}: visible band must start at item ≥ 9 \
@@ -405,8 +403,8 @@ fn u3c_9a_convergence_logical_indices_reconcile() {
     eprintln!(
         "9a convergence ok: {} children, logical indices {}..{}",
         pairs.len(),
-        pairs.first().map(|(i, _)| *i).unwrap_or(0),
-        pairs.last().map(|(i, _)| *i).unwrap_or(0),
+        pairs.first().map_or(0, |(i, _)| *i),
+        pairs.last().map_or(0, |(i, _)| *i),
     );
 }
 
@@ -605,7 +603,7 @@ fn u3c_9c_full_range_scroll_reaches_tail_with_bounded_children() {
         // scroll position actually visited.
         if step == scroll_steps - 1 {
             let pairs = collect_child_indices(&owner, sliver_id);
-            last_min_idx = pairs.first().map(|(idx, _)| *idx).unwrap_or(0);
+            last_min_idx = pairs.first().map_or(0, |(idx, _)| *idx);
         }
     }
 

--- a/crates/flui-scheduler/Cargo.toml
+++ b/crates/flui-scheduler/Cargo.toml
@@ -45,3 +45,6 @@ path = "src/lib.rs"
 [features]
 default = []
 serde = ["dep:serde"]
+
+[lints]
+workspace = true

--- a/crates/flui-scheduler/examples/animation_ticker.rs
+++ b/crates/flui-scheduler/examples/animation_ticker.rs
@@ -48,7 +48,7 @@ fn demo_manual_ticker() {
     let fc = Arc::clone(&frame_count);
     ticker.start(move |elapsed| {
         fc.fetch_add(1, Ordering::SeqCst);
-        println!("  Tick! Elapsed: {:.3}s", elapsed);
+        println!("  Tick! Elapsed: {elapsed:.3}s");
     });
 
     println!("Ticker state: {:?}", ticker.state());

--- a/crates/flui-scheduler/examples/basic_scheduler.rs
+++ b/crates/flui-scheduler/examples/basic_scheduler.rs
@@ -30,7 +30,7 @@ fn main() {
     let tc = Arc::clone(&transient_count);
     scheduler.schedule_frame_callback(Box::new(move |timestamp| {
         tc.fetch_add(1, Ordering::SeqCst);
-        println!("  Transient callback fired! Timestamp: {:?}", timestamp);
+        println!("  Transient callback fired! Timestamp: {timestamp:?}");
     }));
 
     // 2. Add a persistent callback (runs every frame)
@@ -54,7 +54,7 @@ fn main() {
     println!("Executing 3 frames...\n");
 
     for i in 1..=3 {
-        println!("--- Frame {} ---", i);
+        println!("--- Frame {i} ---");
         println!("  Phase before: {:?}", scheduler.scheduler_phase());
 
         scheduler.execute_frame();

--- a/crates/flui-scheduler/src/budget.rs
+++ b/crates/flui-scheduler/src/budget.rs
@@ -240,9 +240,9 @@ impl FrameBudget {
 
     /// Get elapsed time since frame start
     pub fn elapsed(&self) -> Milliseconds {
-        self.frame_start
-            .map(|start| Milliseconds::new(start.elapsed().as_secs_f64() * 1000.0))
-            .unwrap_or(Milliseconds::ZERO)
+        self.frame_start.map_or(Milliseconds::ZERO, |start| {
+            Milliseconds::new(start.elapsed().as_secs_f64() * 1000.0)
+        })
     }
 
     /// Get elapsed time since frame start (raw f64 for backwards compat)

--- a/crates/flui-scheduler/src/frame.rs
+++ b/crates/flui-scheduler/src/frame.rs
@@ -118,12 +118,13 @@ impl SchedulerPhase {
         matches!(
             (self, next),
             (Self::Idle, Self::TransientCallbacks)
-                | (Self::TransientCallbacks, Self::MidFrameMicrotasks)
+                | (
+                    Self::TransientCallbacks,
+                    Self::MidFrameMicrotasks | Self::PersistentCallbacks
+                )
                 | (Self::MidFrameMicrotasks, Self::PersistentCallbacks)
                 | (Self::PersistentCallbacks, Self::PostFrameCallbacks)
                 | (Self::PostFrameCallbacks, Self::Idle)
-                // Allow skipping MidFrameMicrotasks if no microtasks pending
-                | (Self::TransientCallbacks, Self::PersistentCallbacks)
         )
     }
 

--- a/crates/flui-scheduler/src/id.rs
+++ b/crates/flui-scheduler/src/id.rs
@@ -155,7 +155,7 @@ mod tests {
     #[test]
     fn test_id_display() {
         let frame_id = FrameId::zip(42);
-        let display = format!("{}", frame_id);
+        let display = format!("{frame_id}");
         assert!(display.contains("Frame"));
         assert!(display.contains("42"));
     }

--- a/crates/flui-scheduler/src/lib.rs
+++ b/crates/flui-scheduler/src/lib.rs
@@ -124,8 +124,17 @@
 //!
 //! [`web_time`]: https://docs.rs/web-time
 
+// `[workspace.lints]` supplies the baseline; this crate already holds the
+// stricter missing-docs bar.
 #![deny(missing_docs)]
-#![warn(clippy::all)]
+// Tracked ship-quality debt:
+#![allow(missing_debug_implementations)] // TODO(ship-wave-2): add Debug impls (6 types), then delete
+#![allow(clippy::unwrap_used)] // TODO(ship-wave-2): convert to Result / `expect("BUG: …")` per docs/PANIC-POLICY.md
+#![allow(
+    clippy::match_same_arms,
+    clippy::missing_fields_in_debug,
+    clippy::needless_continue
+)] // TODO(ship-wave-2): burn down per-lint, then delete
 
 // Core modules
 pub mod budget;

--- a/crates/flui-scheduler/src/scheduler.rs
+++ b/crates/flui-scheduler/src/scheduler.rs
@@ -500,9 +500,7 @@ impl Scheduler {
                 .unwrap_or(SchedulerPhase::Idle);
         debug_assert!(
             current.can_transition_to(new_phase),
-            "Invalid phase transition: {:?} -> {:?}",
-            current,
-            new_phase
+            "Invalid phase transition: {current:?} -> {new_phase:?}"
         );
         self.frame
             .scheduler_phase
@@ -947,7 +945,7 @@ impl Scheduler {
             .current_frame
             .lock()
             .as_ref()
-            .is_some_and(|t| t.is_over_budget())
+            .is_some_and(super::frame::FrameTiming::is_over_budget)
     }
 
     /// Check if deadline is near (>80% budget used)
@@ -956,7 +954,7 @@ impl Scheduler {
             .current_frame
             .lock()
             .as_ref()
-            .is_some_and(|t| t.is_deadline_near())
+            .is_some_and(super::frame::FrameTiming::is_deadline_near)
     }
 
     /// Get remaining budget as type-safe Milliseconds
@@ -965,7 +963,7 @@ impl Scheduler {
             .current_frame
             .lock()
             .as_ref()
-            .map_or(Milliseconds::ZERO, |t| t.remaining())
+            .map_or(Milliseconds::ZERO, super::frame::FrameTiming::remaining)
     }
 
     /// Get remaining budget in milliseconds (raw f64)

--- a/crates/flui-scheduler/src/ticker.rs
+++ b/crates/flui-scheduler/src/ticker.rs
@@ -513,8 +513,11 @@ impl Ticker {
             let mut inner = self.inner.lock();
             if inner.state == TickerState::Muted {
                 let now = Instant::now();
-                let adjusted_start =
-                    now - std::time::Duration::from_secs_f64(inner.muted_elapsed.value());
+                let adjusted_start = now
+                    .checked_sub(std::time::Duration::from_secs_f64(
+                        inner.muted_elapsed.value(),
+                    ))
+                    .unwrap();
                 inner.start_time = Some(adjusted_start);
                 inner.state = TickerState::Active;
             }
@@ -599,8 +602,7 @@ impl Ticker {
             TickerState::Muted => inner.muted_elapsed,
             TickerState::Active => inner
                 .start_time
-                .map(|s| Seconds::new(s.elapsed().as_secs_f64()))
-                .unwrap_or(Seconds::ZERO),
+                .map_or(Seconds::ZERO, |s| Seconds::new(s.elapsed().as_secs_f64())),
         }
     }
 
@@ -1209,7 +1211,7 @@ impl std::fmt::Debug for TickerFuture {
             TickerFutureState::Complete => "complete",
             TickerFutureState::Canceled => "canceled",
         };
-        write!(f, "TickerFuture({})", state_str)
+        write!(f, "TickerFuture({state_str})")
     }
 }
 

--- a/crates/flui-scheduler/src/vsync.rs
+++ b/crates/flui-scheduler/src/vsync.rs
@@ -288,7 +288,7 @@ impl VsyncScheduler {
                     let interval = self.frame_interval_duration();
 
                     if elapsed < interval {
-                        let wait_time = interval - elapsed;
+                        let wait_time = interval.checked_sub(elapsed).unwrap();
                         std::thread::sleep(wait_time);
                         Instant::now()
                     } else {

--- a/crates/flui-scheduler/tests/integration_tests.rs
+++ b/crates/flui-scheduler/tests/integration_tests.rs
@@ -3,6 +3,15 @@
 //! These tests verify the complete scheduler system works correctly
 //! across multiple components working together.
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::default_trait_access)]
+// A no-op `RawWaker` vtable is built manually to poll futures without a
+// runtime; `Waker::from_raw` is the one `unsafe` entry point, SAFETY-bound by
+// the vtable's no-op contract.
+#![allow(unsafe_code)]
+
 use std::{
     sync::{
         Arc,
@@ -1055,7 +1064,7 @@ fn test_frame_phase_all_variants() {
 
     for phase in phases {
         // Test display
-        let _ = format!("{}", phase);
+        let _ = format!("{phase}");
 
         // Test next
         let _ = phase.next();
@@ -1073,7 +1082,7 @@ fn test_scheduler_phase_all_variants() {
 
     for phase in phases {
         // Test display
-        let _ = format!("{}", phase);
+        let _ = format!("{phase}");
 
         // Test is_in_frame
         let _ = phase.is_in_frame();
@@ -1096,7 +1105,7 @@ fn test_app_lifecycle_state_all_variants() {
 
     for state in states {
         // Test display
-        let _ = format!("{}", state);
+        let _ = format!("{state}");
 
         // Test is_visible
         let _ = state.is_visible();
@@ -1293,7 +1302,7 @@ fn test_vsync_scheduler_default() {
 #[test]
 fn test_vsync_scheduler_debug() {
     let vsync = VsyncScheduler::try_new(60).expect("refresh > 0");
-    let debug_str = format!("{:?}", vsync);
+    let debug_str = format!("{vsync:?}");
     assert!(debug_str.contains("VsyncScheduler"));
     assert!(debug_str.contains("refresh_rate"));
 }
@@ -1348,7 +1357,7 @@ fn test_foundation_id_display() {
     use flui_scheduler::id::FrameId;
 
     let id = FrameId::zip(42);
-    let display = format!("{}", id);
+    let display = format!("{id}");
 
     assert!(display.contains("Frame"));
     assert!(display.contains("42"));
@@ -1359,7 +1368,7 @@ fn test_foundation_id_debug() {
     use flui_scheduler::id::FrameId;
 
     let id = FrameId::zip(42);
-    let debug = format!("{:?}", id);
+    let debug = format!("{id:?}");
 
     assert!(debug.contains("Frame"));
     assert!(debug.contains("42"));
@@ -1631,7 +1640,7 @@ fn test_microseconds_from_u64() {
 fn test_microseconds_from_duration() {
     use flui_scheduler::duration::Microseconds;
 
-    let std_dur = Duration::from_micros(1000);
+    let std_dur = Duration::from_millis(1);
     let us: Microseconds = std_dur.into();
 
     assert_eq!(us.value(), 1000);
@@ -1695,7 +1704,7 @@ fn test_frame_duration_default() {
 #[test]
 fn test_frame_duration_display() {
     let fd = FrameDuration::try_from_fps(60).expect("fps > 0");
-    let display = format!("{}", fd);
+    let display = format!("{fd}");
 
     assert!(display.contains("ms"));
     assert!(display.contains("FPS"));
@@ -1737,7 +1746,7 @@ fn test_percentage_display() {
     use flui_scheduler::duration::Percentage;
 
     let p = Percentage::new(75.5);
-    let display = format!("{}", p);
+    let display = format!("{p}");
 
     assert_eq!(display, "75.5%");
 }
@@ -1853,7 +1862,7 @@ fn test_ticker_independent_instances() {
 #[test]
 fn test_ticker_debug() {
     let ticker = Ticker::new();
-    let debug = format!("{:?}", ticker);
+    let debug = format!("{ticker:?}");
 
     assert!(debug.contains("Ticker"));
     assert!(debug.contains("id"));
@@ -1964,7 +1973,7 @@ fn test_auto_scheduling_ticker_debug() {
     let scheduler = Arc::new(Scheduler::new());
     let ticker = Ticker::new_with_scheduler(scheduler);
 
-    let debug = format!("{:?}", ticker);
+    let debug = format!("{ticker:?}");
     assert!(debug.contains("Ticker"));
 }
 
@@ -1976,7 +1985,7 @@ fn test_ticker_future_or_cancel() {
     let cancel_future = future.or_cancel();
 
     // Just verify it compiles and creates
-    let _ = format!("{:?}", cancel_future);
+    let _ = format!("{cancel_future:?}");
 }
 
 #[test]
@@ -1992,7 +2001,7 @@ fn test_ticker_future_clone() {
 #[test]
 fn test_ticker_future_debug() {
     let future = TickerFuture::new();
-    let debug = format!("{:?}", future);
+    let debug = format!("{future:?}");
     assert!(debug.contains("TickerFuture"));
 }
 
@@ -2001,7 +2010,7 @@ fn test_ticker_or_cancel_debug() {
     let future = TickerFuture::new();
     let cancel_future = future.or_cancel();
 
-    let debug = format!("{:?}", cancel_future);
+    let debug = format!("{cancel_future:?}");
     assert!(debug.contains("TickerFutureOrCancel"));
 }
 
@@ -2100,7 +2109,7 @@ fn test_task_debug() {
     use flui_scheduler::task::Task;
 
     let task = Task::new(Priority::Idle, || {});
-    let debug = format!("{:?}", task);
+    let debug = format!("{task:?}");
 
     assert!(debug.contains("Task"));
     assert!(debug.contains("priority"));
@@ -2596,7 +2605,7 @@ fn test_performance_mode_all_variants() {
     ];
 
     for mode in modes {
-        let _ = format!("{:?}", mode);
+        let _ = format!("{mode:?}");
     }
 
     // Default
@@ -2743,7 +2752,7 @@ fn test_ticker_new_gets_unique_id() {
 #[test]
 fn test_ticker_debug_contains_fields() {
     let ticker = Ticker::new();
-    let debug_str = format!("{:?}", ticker);
+    let debug_str = format!("{ticker:?}");
     assert!(debug_str.contains("Ticker"));
     assert!(debug_str.contains("id"));
     assert!(debug_str.contains("state"));
@@ -2854,13 +2863,13 @@ fn test_ticker_future_default_pending() {
 #[test]
 fn test_ticker_future_debug_active_state() {
     let pending = TickerFuture::new();
-    assert!(format!("{:?}", pending).contains("active"));
+    assert!(format!("{pending:?}").contains("active"));
 }
 
 #[test]
 fn test_ticker_future_debug_complete_state() {
     let complete = TickerFuture::complete();
-    assert!(format!("{:?}", complete).contains("complete"));
+    assert!(format!("{complete:?}").contains("complete"));
 }
 
 #[test]
@@ -2983,7 +2992,7 @@ fn test_ticker_canceled_display_msg() {
 #[test]
 fn test_ticker_canceled_debug_output() {
     let error = TickerCanceled;
-    assert_eq!(format!("{:?}", error), "TickerCanceled");
+    assert_eq!(format!("{error:?}"), "TickerCanceled");
 }
 
 #[test]

--- a/crates/flui-semantics/Cargo.toml
+++ b/crates/flui-semantics/Cargo.toml
@@ -46,3 +46,6 @@ smallvec = "1.15"
 rustc-hash = "2.1"
 
 [dev-dependencies]
+
+[lints]
+workspace = true

--- a/crates/flui-semantics/src/binding.rs
+++ b/crates/flui-semantics/src/binding.rs
@@ -425,6 +425,7 @@ impl SemanticsActionEvent {
 /// // Make an assertive announcement
 /// SemanticsService::announce_with_assertiveness("Error occurred", Assertiveness::Assertive);
 /// ```
+#[derive(Debug)]
 pub struct SemanticsService;
 
 impl SemanticsService {

--- a/crates/flui-semantics/src/lib.rs
+++ b/crates/flui-semantics/src/lib.rs
@@ -51,18 +51,10 @@
 //! - `SemanticsOwner` ≈ Flutter's `SemanticsOwner`
 //! - `SemanticsAction` ≈ Flutter's `SemanticsAction`
 
-#![warn(rust_2018_idioms, clippy::all, clippy::pedantic)]
-#![allow(
-    dead_code,
-    unused_variables,
-    missing_docs,
-    clippy::module_name_repetitions,
-    clippy::must_use_candidate,
-    clippy::return_self_not_must_use,
-    clippy::doc_markdown,
-    clippy::missing_errors_doc,
-    clippy::missing_panics_doc
-)]
+// Lint levels come from `[workspace.lints]` (Cargo.toml `[lints] workspace = true`).
+// The two remaining opt-outs are tracked ship-quality debt, not configuration:
+#![allow(dead_code, unused_variables)] // TODO(ship-wave-2): wire or delete each dead item (tracker M3 audit)
+#![allow(missing_docs)] // TODO(ship-wave-2): public-item doc backlog — burn down, then delete this line
 
 // ============================================================================
 // MODULES

--- a/crates/flui-types/Cargo.toml
+++ b/crates/flui-types/Cargo.toml
@@ -77,41 +77,8 @@ harness = false
 name = "conversions_bench"
 harness = false
 
-[lints.rust]
-unsafe_code = "warn"
-rust_2018_idioms = "warn"
+[lints]
+workspace = true
 
-[lints.clippy]
-# Inherit workspace-like base
-all = { level = "warn", priority = -1 }
-pedantic = { level = "warn", priority = -1 }
-# Workspace-level allows
-cast_precision_loss = "allow"
-module_name_repetitions = "allow"
-too_many_lines = "allow"
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-must_use_candidate = "allow"
-# Math/geometry crate specifics
-many_single_char_names = "allow"
-cast_possible_truncation = "allow"
-cast_sign_loss = "allow"
-cast_lossless = "allow"
-similar_names = "allow"
-# Doc lints — will address incrementally
-doc_markdown = "allow"
-# Geometry code often passes small Copy types by ref for API consistency
-needless_pass_by_value = "allow"
-trivially_copy_pass_by_ref = "allow"
-# Builder-pattern methods returning Self are pervasive
-return_self_not_must_use = "allow"
-# Float comparisons are intentional in geometry/physics (tolerance-checked elsewhere)
-float_cmp = "allow"
-# Wildcard imports used in preludes
-wildcard_imports = "allow"
-
-# cargo-shear: suppress false positives for trybuild compile-fail test inputs.
-# These files are driven by `unit_mixing_compile_fail.rs` via trybuild and are
-# not directly `mod`-ed, so shear cannot see the reference.
 [package.metadata.cargo-shear]
 ignored-paths = ["tests/compile_fail/*.rs"]

--- a/crates/flui-types/benches/color_bench.rs
+++ b/crates/flui-types/benches/color_bench.rs
@@ -4,6 +4,10 @@
 //! - Color::lerp (mix): <20ns
 //! - Color::blend_over: <20ns
 
+// Bench harness, not public API; `criterion_group!` generates the
+// undocumentable entry fn.
+#![allow(missing_docs)]
+
 use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/crates/flui-types/benches/conversions_bench.rs
+++ b/crates/flui-types/benches/conversions_bench.rs
@@ -1,3 +1,6 @@
+// Bench harness, not public API; `criterion_group!` generates the
+// undocumentable entry fn.
+#![allow(missing_docs)]
 #![allow(deprecated)]
 // N-geom U5: target intentionally exercises the deprecated raw-scalar device conversions (to_device_pixels(f32)/from_device_pixels).
 //! Unit conversion benchmarks

--- a/crates/flui-types/benches/geometry_bench.rs
+++ b/crates/flui-types/benches/geometry_bench.rs
@@ -5,6 +5,10 @@
 //! - Rect::intersect: <20ns
 //! - Rect::union: <20ns
 
+// Bench harness, not public API; `criterion_group!` generates the
+// undocumentable entry fn.
+#![allow(missing_docs)]
+
 use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/crates/flui-types/examples/color_blending.rs
+++ b/crates/flui-types/examples/color_blending.rs
@@ -7,6 +7,11 @@
 //! - HSL operations (lighten, darken)
 //! - Practical UI scenarios
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::unwrap_used)]
+
 use flui_types::styling::Color;
 
 fn main() {

--- a/crates/flui-types/examples/types_basic_usage.rs
+++ b/crates/flui-types/examples/types_basic_usage.rs
@@ -1,3 +1,7 @@
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::unwrap_used)]
 #![allow(deprecated)]
 // N-geom U5: target intentionally exercises the deprecated raw-scalar device conversions (to_device_pixels(f32)/from_device_pixels).
 //! Basic usage example for flui_types

--- a/crates/flui-types/src/lib.rs
+++ b/crates/flui-types/src/lib.rs
@@ -83,7 +83,13 @@
 //! etc.) have been moved to `flui_rendering::constraints` as they are part of
 //! the rendering protocol rather than basic types.
 
-#![allow(missing_docs)] // TODO: Add comprehensive docs (486 items remaining - ongoing improvement)
+#![allow(missing_docs)] // TODO(ship-wave-1): 486-item doc backlog — burn down per module, then delete this line
+#![allow(missing_debug_implementations)]
+// TODO(ship-wave-1): add Debug impls (28 types), then delete
+// Math-crate idiom shared with flui-geometry (see its lib.rs): permanent
+// crate-specific relaxations of workspace pedantic lints for math-heavy code.
+// (The float-comparison / numeric-cast family is allowed workspace-wide.)
+#![allow(clippy::many_single_char_names, clippy::wildcard_imports)]
 // Geometry primitives split out into flui-geometry crate in D-block PR-C-2 (U6+U7).
 // Re-exported here under the original `geometry` namespace so existing consumers
 // of `flui_types::geometry::*` continue to compile unchanged during the transition.

--- a/crates/flui-types/tests/typed_geometry_integration.rs
+++ b/crates/flui-types/tests/typed_geometry_integration.rs
@@ -1,3 +1,7 @@
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::many_single_char_names)]
 #![allow(deprecated)]
 // N-geom U5: target intentionally exercises the deprecated raw-scalar device conversions (to_device_pixels(f32)/from_device_pixels).
 //! Integration tests for typed geometry system

--- a/crates/flui-view/Cargo.toml
+++ b/crates/flui-view/Cargo.toml
@@ -91,3 +91,6 @@ harness = false
 [[bench]]
 name = "sc012_global_key_reparent"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/flui-view/benches/s1_key_storage.rs
+++ b/crates/flui-view/benches/s1_key_storage.rs
@@ -36,6 +36,10 @@
 //! - [`docs/plans/2026-05-22-005-feat-view-element-core-contracts-plan.md`] U2
 //! - [`specs/004-view-element-core/spec.md`] Deferred S1, FR-022
 
+// Bench harness, not public API; `criterion_group!` generates the
+// undocumentable entry fn.
+#![allow(missing_docs)]
+
 #[path = "shared/mock_node.rs"]
 mod mock_node;
 

--- a/crates/flui-view/benches/s2_static_path.rs
+++ b/crates/flui-view/benches/s2_static_path.rs
@@ -52,6 +52,10 @@
 //! - [`docs/plans/2026-05-22-005-feat-view-element-core-contracts-plan.md`] U3
 //! - [`specs/004-view-element-core/spec.md`] Deferred S2, FR-016
 
+// Bench harness, not public API; `criterion_group!` generates the
+// undocumentable entry fn.
+#![allow(missing_docs)]
+
 #[path = "shared/mock_tuple.rs"]
 mod mock_tuple;
 

--- a/crates/flui-view/benches/sc012_global_key_reparent.rs
+++ b/crates/flui-view/benches/sc012_global_key_reparent.rs
@@ -12,6 +12,10 @@
 //! `ReconcileEvent::Reparent` emission) so the latency signal is
 //! representative.
 
+// Bench harness, not public API; `criterion_group!` generates the
+// undocumentable entry fn.
+#![allow(missing_docs)]
+
 use std::sync::Arc;
 
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};

--- a/crates/flui-view/benches/shared/mock_node.rs
+++ b/crates/flui-view/benches/shared/mock_node.rs
@@ -45,6 +45,11 @@
 //!
 //! See [`MemoryAccounting`] for the public surface.
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::struct_field_names)]
+
 use std::collections::HashMap;
 use std::num::NonZeroU64;
 

--- a/crates/flui-view/tests/ancestor_finders.rs
+++ b/crates/flui-view/tests/ancestor_finders.rs
@@ -199,7 +199,7 @@ fn find_ancestor_view_returns_nearest_match() {
 
     let ctx = ElementBuildContext::for_element(child_id, tree.clone(), owner.clone()).unwrap();
 
-    let value = ctx.find_ancestor::<LabeledView, u32>(|v| v.value());
+    let value = ctx.find_ancestor::<LabeledView, u32>(LabeledView::value);
     assert_eq!(
         value,
         Some(42),
@@ -234,7 +234,7 @@ fn find_ancestor_view_picks_nearest_when_multiple_match() {
 
     let ctx = ElementBuildContext::for_element(child_id, tree.clone(), owner.clone()).unwrap();
 
-    let value = ctx.find_ancestor::<LabeledView, u32>(|v| v.value());
+    let value = ctx.find_ancestor::<LabeledView, u32>(LabeledView::value);
     assert_eq!(
         value,
         Some(2),
@@ -260,7 +260,7 @@ fn find_ancestor_view_returns_none_when_no_match() {
 
     let ctx = ElementBuildContext::for_element(child_id, tree, owner).unwrap();
 
-    let value = ctx.find_ancestor::<LabeledView, u32>(|v| v.value());
+    let value = ctx.find_ancestor::<LabeledView, u32>(LabeledView::value);
     assert_eq!(value, None, "no LabeledView ancestor -> None");
 }
 
@@ -279,7 +279,7 @@ fn find_ancestor_view_excludes_self() {
 
     let ctx = ElementBuildContext::for_element(labeled_id, tree, owner).unwrap();
 
-    let value = ctx.find_ancestor::<LabeledView, u32>(|v| v.value());
+    let value = ctx.find_ancestor::<LabeledView, u32>(LabeledView::value);
     assert_eq!(
         value, None,
         "self is excluded from strict-ancestor walk per Flutter parity"
@@ -317,7 +317,7 @@ fn find_ancestor_state_returns_nearest_match() {
 
     let ctx = ElementBuildContext::for_element(child_id, tree.clone(), owner.clone()).unwrap();
 
-    let count = ctx.find_state::<CounterState, i32>(|s| s.snapshot());
+    let count = ctx.find_state::<CounterState, i32>(CounterState::snapshot);
     assert_eq!(
         count,
         Some(10),
@@ -354,7 +354,7 @@ fn find_ancestor_state_picks_nearest_when_multiple_match() {
 
     let ctx = ElementBuildContext::for_element(child_id, tree, owner).unwrap();
 
-    let count = ctx.find_state::<CounterState, i32>(|s| s.snapshot());
+    let count = ctx.find_state::<CounterState, i32>(CounterState::snapshot);
     assert_eq!(
         count,
         Some(2),
@@ -380,7 +380,7 @@ fn find_ancestor_state_returns_none_when_no_match() {
 
     let ctx = ElementBuildContext::for_element(child_id, tree, owner).unwrap();
 
-    let count = ctx.find_state::<CounterState, i32>(|s| s.snapshot());
+    let count = ctx.find_state::<CounterState, i32>(CounterState::snapshot);
     assert_eq!(count, None, "no CounterState ancestor -> None");
 }
 
@@ -449,7 +449,7 @@ fn find_root_ancestor_state_returns_root_most_match() {
 
     let ctx = ElementBuildContext::for_element(child_id, tree, owner).unwrap();
 
-    let count = ctx.find_root_state::<CounterState, i32>(|s| s.snapshot());
+    let count = ctx.find_root_state::<CounterState, i32>(CounterState::snapshot);
     assert_eq!(
         count,
         Some(100),
@@ -485,7 +485,7 @@ fn find_root_ancestor_state_single_match_works() {
 
     let ctx = ElementBuildContext::for_element(child_id, tree, owner).unwrap();
 
-    let count = ctx.find_root_state::<CounterState, i32>(|s| s.snapshot());
+    let count = ctx.find_root_state::<CounterState, i32>(CounterState::snapshot);
     assert_eq!(
         count,
         Some(7),
@@ -511,7 +511,7 @@ fn find_root_ancestor_state_returns_none_when_no_match() {
 
     let ctx = ElementBuildContext::for_element(child_id, tree, owner).unwrap();
 
-    let count = ctx.find_root_state::<CounterState, i32>(|s| s.snapshot());
+    let count = ctx.find_root_state::<CounterState, i32>(CounterState::snapshot);
     assert_eq!(count, None, "no Counter ancestor -> None");
 }
 
@@ -552,7 +552,7 @@ fn find_root_ancestor_state_with_non_matching_intermediate() {
 
     let ctx = ElementBuildContext::for_element(child_id, tree, owner).unwrap();
 
-    let count = ctx.find_root_state::<CounterState, i32>(|s| s.snapshot());
+    let count = ctx.find_root_state::<CounterState, i32>(CounterState::snapshot);
     assert_eq!(
         count,
         Some(1),

--- a/crates/flui-view/tests/build_context_tests.rs
+++ b/crates/flui-view/tests/build_context_tests.rs
@@ -646,7 +646,7 @@ fn test_depend_on_returns_none_when_no_inherited_ancestor() {
 
     let ctx = ElementBuildContext::for_element(root_id, tree, owner).unwrap();
 
-    let result: Option<String> = ctx.depend_on::<String, String>(|s| s.clone());
+    let result: Option<String> = ctx.depend_on::<String, String>(std::clone::Clone::clone);
     assert!(result.is_none());
 }
 
@@ -686,7 +686,7 @@ fn test_context_debug() {
 
     let ctx = ElementBuildContext::for_element(root_id, tree, owner).unwrap();
 
-    let debug_str = format!("{:?}", ctx);
+    let debug_str = format!("{ctx:?}");
     assert!(debug_str.contains("ElementBuildContext"));
     assert!(debug_str.contains("element_id"));
     assert!(debug_str.contains("depth"));
@@ -696,7 +696,7 @@ fn test_context_debug() {
 #[test]
 fn test_builder_debug() {
     let builder = ElementBuildContextBuilder::new();
-    let debug_str = format!("{:?}", builder);
+    let debug_str = format!("{builder:?}");
     assert!(debug_str.contains("ElementBuildContextBuilder"));
 }
 
@@ -721,7 +721,7 @@ fn test_deep_tree_ancestor_traversal() {
 
     for i in 1..10 {
         let view = SimpleView {
-            name: format!("node_{}", i),
+            name: format!("node_{i}"),
         };
         let child_id =
             tree.write()

--- a/crates/flui-view/tests/build_owner_tests.rs
+++ b/crates/flui-view/tests/build_owner_tests.rs
@@ -310,7 +310,7 @@ fn test_build_owner_debug() {
     owner.schedule_build_for(ElementId::new(1), 0);
     owner.register_global_key(123, ElementId::new(2));
 
-    let debug_str = format!("{:?}", owner);
+    let debug_str = format!("{owner:?}");
 
     assert!(debug_str.contains("BuildOwner"));
     assert!(debug_str.contains("dirty_count"));
@@ -415,5 +415,5 @@ fn test_reassemble_marks_all_live_elements_dirty() {
 fn test_build_owner_memory_size() {
     let size = std::mem::size_of::<BuildOwner>();
     // Should be reasonably sized (BinaryHeap + HashSet + HashMap + debug flags)
-    assert!(size < 512, "BuildOwner is too large: {} bytes", size);
+    assert!(size < 512, "BuildOwner is too large: {size} bytes");
 }

--- a/crates/flui-view/tests/derive_smoke.rs
+++ b/crates/flui-view/tests/derive_smoke.rs
@@ -16,6 +16,11 @@
 //! - the typed `View::create_element` returns a valid `ElementBase`
 //!   for both stateless and stateful authoring shapes
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::no_effect_underscore_binding, clippy::used_underscore_items)]
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use flui_view::context::BuildContext;

--- a/crates/flui-view/tests/dispatch_shim.rs
+++ b/crates/flui-view/tests/dispatch_shim.rs
@@ -74,7 +74,7 @@ fn identity_shim_succeeds_on_type_match() {
     let node = tree.get(id).expect("node alive after update");
     let stored_hash = node
         .key()
-        .map(|k| k.key_hash())
+        .map(flui_foundation::ViewKey::key_hash)
         .expect("key survives update");
     let probe = ValueKey::<u32>::new(42_u32);
     assert_eq!(

--- a/crates/flui-view/tests/element_tree_tests.rs
+++ b/crates/flui-view/tests/element_tree_tests.rs
@@ -481,7 +481,7 @@ fn test_tree_memory_layout() {
     // ElementTree should be reasonably sized
     let size = std::mem::size_of::<ElementTree>();
     // Slab + Option<ElementId>
-    assert!(size < 128, "ElementTree is too large: {} bytes", size);
+    assert!(size < 128, "ElementTree is too large: {size} bytes");
 }
 
 #[test]
@@ -523,7 +523,7 @@ fn test_tree_debug() {
 
     tree.mount_root(&view, &mut owner.element_owner_mut());
 
-    let debug_str = format!("{:?}", tree);
+    let debug_str = format!("{tree:?}");
     assert!(debug_str.contains("ElementTree"));
     assert!(debug_str.contains("len"));
 }
@@ -537,7 +537,7 @@ fn test_element_node_debug() {
     let id = tree.mount_root(&view, &mut owner.element_owner_mut());
     let node = tree.get(id).unwrap();
 
-    let debug_str = format!("{:?}", node);
+    let debug_str = format!("{node:?}");
     assert!(debug_str.contains("ElementNode"));
     assert!(debug_str.contains("depth"));
 }

--- a/crates/flui-view/tests/error_view_recovery.rs
+++ b/crates/flui-view/tests/error_view_recovery.rs
@@ -17,6 +17,11 @@
 //! caught — that stderr noise is expected; the test process must NOT
 //! abort and the assertions below must hold.
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::unwrap_used)]
+
 use std::{
     any::TypeId,
     sync::{

--- a/crates/flui-view/tests/global_key.rs
+++ b/crates/flui-view/tests/global_key.rs
@@ -172,7 +172,7 @@ fn global_key_current_state_after_mount() {
         "current_element should map back to the mounted element id"
     );
 
-    let snapshot = key.with_current_state::<i32>(|state| state.count());
+    let snapshot = key.with_current_state::<i32>(KeyedCounterState::count);
     assert_eq!(
         snapshot,
         Some(7),
@@ -247,8 +247,8 @@ fn global_key_state_migrates_to_new_parent_slot() {
     );
 
     // State is still reachable and the sentinel survived the migration.
-    let count = key.with_current_state::<i32>(|s| s.count());
-    let sentinel = key.with_current_state::<u64>(|s| s.sentinel());
+    let count = key.with_current_state::<i32>(KeyedCounterState::count);
+    let sentinel = key.with_current_state::<u64>(KeyedCounterState::sentinel);
     assert_eq!(
         count,
         Some(11),
@@ -303,7 +303,7 @@ fn global_key_returns_none_after_full_unmount() {
         "after finalize_tree drains inactive, registry should be empty"
     );
     assert_eq!(
-        key.with_current_state::<i32>(|s| s.count()),
+        key.with_current_state::<i32>(KeyedCounterState::count),
         None,
         "current_state returns None once the element is finalized"
     );
@@ -453,7 +453,7 @@ fn global_key_state_preserved_across_100_reparents() {
         );
 
         assert_eq!(
-            key.with_current_state::<u64>(|s| s.sentinel()),
+            key.with_current_state::<u64>(KeyedCounterState::sentinel),
             Some(sentinel_value),
             "cycle {cycle}: sentinel must survive every reparent",
         );

--- a/crates/flui-view/tests/inherited_dependency.rs
+++ b/crates/flui-view/tests/inherited_dependency.rs
@@ -23,6 +23,11 @@
 //! non-recording read), and `framework.dart:6414`
 //! (`InheritedElement.notifyClients`).
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::unreadable_literal, clippy::unwrap_used)]
+
 use std::sync::Arc;
 
 use flui_objects::RenderSizedBox;
@@ -632,8 +637,7 @@ mod did_change_dependencies_on_inherited_update {
         let events = probe.lock().unwrap().clone();
         assert!(
             events.iter().any(|e| e == "dcd:1"),
-            "ViewState::did_change_dependencies must fire exactly once. recorded: {:?}",
-            events
+            "ViewState::did_change_dependencies must fire exactly once. recorded: {events:?}"
         );
         // Exactly once: the typed hook must not have fired a second
         // time. `ProbeDependentState.dcd_calls` increments on every
@@ -641,8 +645,7 @@ mod did_change_dependencies_on_inherited_update {
         // probe vec.
         assert!(
             !events.iter().any(|e| e == "dcd:2"),
-            "ViewState::did_change_dependencies fired more than once. recorded: {:?}",
-            events
+            "ViewState::did_change_dependencies fired more than once. recorded: {events:?}"
         );
         let dcd_idx = events
             .iter()
@@ -654,8 +657,7 @@ mod did_change_dependencies_on_inherited_update {
             .expect("build present (perform_build must run after notify_dependency_change)");
         assert!(
             dcd_idx < build_idx,
-            "did_change_dependencies must fire BEFORE build. recorded: {:?}",
-            events
+            "did_change_dependencies must fire BEFORE build. recorded: {events:?}"
         );
         // Sequencing contract: the recorded order is exactly
         // [dcd:1, build] — `dcd` immediately precedes `build` with no
@@ -793,8 +795,7 @@ mod did_change_dependencies_on_inherited_update {
         let events = probe.lock().unwrap().clone();
         assert!(
             events.iter().all(|e| e != "dcd:1"),
-            "did_change_dependencies must NOT fire when update_should_notify=false. recorded: {:?}",
-            events
+            "did_change_dependencies must NOT fire when update_should_notify=false. recorded: {events:?}"
         );
     }
 

--- a/crates/flui-view/tests/sc009_boxed_view_conditional.rs
+++ b/crates/flui-view/tests/sc009_boxed_view_conditional.rs
@@ -32,6 +32,11 @@
 //!    which fails E0308. We test the canonical "every arm
 //!    `.boxed()`" shape only.
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::used_underscore_items)]
+
 use flui_view::context::BuildContext;
 use flui_view::prelude::*;
 

--- a/crates/flui-view/tests/stateless_stateful_tests.rs
+++ b/crates/flui-view/tests/stateless_stateful_tests.rs
@@ -3,6 +3,11 @@
 //!
 //! Tests view creation, element management, state handling, and update cycles.
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::struct_field_names, clippy::unwrap_used)]
+
 use std::{
     any::TypeId,
     sync::{
@@ -473,7 +478,7 @@ fn test_stateless_element_is_small() {
     // StatelessElement should be reasonably sized
     let size = std::mem::size_of::<StatelessElement<SimpleStatelessView>>();
     // Should be less than 256 bytes (view + lifecycle + depth + child + dirty)
-    assert!(size < 256, "StatelessElement is too large: {} bytes", size);
+    assert!(size < 256, "StatelessElement is too large: {size} bytes");
 }
 
 #[test]
@@ -481,7 +486,7 @@ fn test_stateful_element_is_reasonably_sized() {
     // StatefulElement includes state, so it can be larger
     let size = std::mem::size_of::<StatefulElement<CounterView>>();
     // Should be less than 512 bytes
-    assert!(size < 512, "StatefulElement is too large: {} bytes", size);
+    assert!(size < 512, "StatefulElement is too large: {size} bytes");
 }
 
 // ============================================================================
@@ -511,7 +516,7 @@ fn test_stateless_element_debug() {
     };
     let element = StatelessElement::new(&view, StatelessBehavior);
 
-    let debug_str = format!("{:?}", element);
+    let debug_str = format!("{element:?}");
     assert!(debug_str.contains("StatelessElement"));
     assert!(debug_str.contains("lifecycle"));
 }
@@ -521,7 +526,7 @@ fn test_stateful_element_debug() {
     let view = CounterView { initial_count: 42 };
     let element = StatefulElement::new(&view, StatefulBehavior::new(&view));
 
-    let debug_str = format!("{:?}", element);
+    let debug_str = format!("{element:?}");
     assert!(debug_str.contains("StatefulElement"));
     assert!(debug_str.contains("lifecycle"));
 }

--- a/crates/flui-view/tests/view_reconcile_match.rs
+++ b/crates/flui-view/tests/view_reconcile_match.rs
@@ -152,8 +152,8 @@ fn covers_fr028_type_mismatch() {
 fn covers_fr028_mixed_keyed_unkeyed() {
     let keyed = Alpha::with_key(ValueKey::new(7_u32));
     let keyless = Alpha::keyless();
-    assert!(!keyed.can_update(&keyless), "keyed must NOT update keyless",);
-    assert!(!keyless.can_update(&keyed), "keyless must NOT update keyed",);
+    assert!(!keyed.can_update(&keyless), "keyed must NOT update keyless");
+    assert!(!keyless.can_update(&keyed), "keyless must NOT update keyed");
 }
 
 // ============================================================================

--- a/crates/flui-widgets/Cargo.toml
+++ b/crates/flui-widgets/Cargo.toml
@@ -78,3 +78,6 @@ images = ["dep:image"]
 # not advertise a constructor that always resolves to `AsyncNotWired`.
 network-images = []
 serde = ["flui-types/serde"]
+
+[lints]
+workspace = true

--- a/crates/flui-widgets/tests/inherited_app.rs
+++ b/crates/flui-widgets/tests/inherited_app.rs
@@ -21,6 +21,11 @@
 //! "No ancestor" tests first assert `is_some()` on the outer option so they
 //! fail loudly if the framework skips `build()` entirely.
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::option_option, clippy::unwrap_used)]
+
 mod common;
 
 use std::sync::{Arc, Mutex};

--- a/crates/flui-widgets/tests/text_field.rs
+++ b/crates/flui-widgets/tests/text_field.rs
@@ -41,7 +41,7 @@ static FOCUS_TEST_LOCK: Mutex<()> = Mutex::new(());
 fn focus_test_guard() -> MutexGuard<'static, ()> {
     let guard = FOCUS_TEST_LOCK
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     FocusManager::global().unfocus();
     guard
 }

--- a/crates/flui-widgets/tests/theme.rs
+++ b/crates/flui-widgets/tests/theme.rs
@@ -12,6 +12,11 @@
 //! node) rather than unwinding out to the test, so `#[should_panic]` around
 //! the harness would not observe it.
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::unwrap_used)]
+
 mod common;
 
 use std::sync::{Arc, Mutex};

--- a/docs/PANIC-POLICY.md
+++ b/docs/PANIC-POLICY.md
@@ -1,0 +1,74 @@
+# Panic Policy
+
+> When FLUI code is allowed to panic, what a panic message must say, and how
+> the `clippy::unwrap_used` gate enforces the boundary. Applies to every crate
+> in the workspace. Companion to the error-handling split in `AGENTS.md`
+> (`thiserror` in libraries, `anyhow` in applications).
+
+## The rule
+
+A panic is a **bug report**, never a control-flow mechanism.
+
+| Situation | Required handling |
+|---|---|
+| Caller-triggerable failure (bad input, missing file, lock contention, platform error) | Return `Result` with a `thiserror` error type. Never panic. |
+| Internal invariant that the module itself maintains (slab index handed out by this arena, ID minted by this tree, state machine transition guarded upstream) | `expect("BUG: <invariant that was violated>")` |
+| Test code, benches, examples | `unwrap()`/`expect()` freely — a panic *is* the failure report there. |
+| Compile-time-checkable invariant | Prefer the type system (`NonZeroUsize` IDs, Arity system) over any runtime check. This is the house style — see the ID offset pattern in `AGENTS.md`. |
+
+### The `BUG:` message convention
+
+Every production-path `expect()` documents the invariant it asserts, prefixed
+with `BUG:` so a user hitting it knows immediately the fault is FLUI's, not
+theirs, and grep can find every invariant assertion in the workspace:
+
+```rust
+// YES — states the invariant, identifies the owner of the bug
+let node = self.nodes
+    .get(index)
+    .expect("BUG: RenderId minted by this tree must resolve in its slab");
+
+// NO — restates the operation, blames nobody
+let node = self.nodes.get(index).expect("failed to get node");
+
+// NO — caller-triggerable, must be a Result
+let file = std::fs::read(path).expect("BUG: asset must exist");
+```
+
+`unwrap()` carries no message and is therefore **never** acceptable on a
+production path — if the invariant is real, name it with `expect("BUG: …")`;
+if you cannot name it, it is not an invariant and the path needs a `Result`.
+
+Panics inside `unsafe` contexts deserve extra scrutiny: an `expect()` whose
+failure would leave a raw-pointer structure half-updated must either be
+hoisted above the unsafe region or the SAFETY comment must cover the
+unwind path.
+
+## Enforcement
+
+`[workspace.lints.clippy]` sets `unwrap_used = "warn"`, and the clippy CI job
+runs with `-D warnings`, so an unannotated production `unwrap()` fails CI.
+The root `clippy.toml` sets `allow-unwrap-in-tests = true` and
+`allow-expect-in-tests = true`, so `#[test]` functions and `#[cfg(test)]`
+modules are exempt automatically.
+
+**Transitional state (ship-quality waves).** Crates that predate this policy
+carry a tracked crate-level opt-out:
+
+```rust
+#![allow(clippy::unwrap_used)] // TODO(ship-wave-N): burn down per docs/PANIC-POLICY.md
+```
+
+Each quality wave removes the allow for its cohort by converting every
+`unwrap()` to either a `Result` path or a `BUG:`-message `expect()`. New
+crates must not add the opt-out; new code in existing crates should conform
+even while the crate-level allow is still present.
+
+`expect()` is deliberately **not** linted (`expect_used` stays off): with the
+`BUG:` convention it is the sanctioned invariant idiom, and the review bar is
+the message, not the call. Audit them with:
+
+```bash
+rg '\.expect\("(?!BUG: )' crates/*/src --pcre2   # expects missing the convention
+rg '\.unwrap\(\)' crates/*/src                   # should be test-only or allow-tracked
+```

--- a/docs/ROADMAP-TRACKER.md
+++ b/docs/ROADMAP-TRACKER.md
@@ -175,6 +175,16 @@ These are written into ROADMAP.md and are non-negotiable — violating them crea
 | C1.12 | Frame-time histogram ≤ 16ms median over 5-second animation run | 🛇 needs display | proves real `Ticker`; needs a windowed animation run |
 | C1.13 | Ported Flutter test scaffolding at `crates/flui-widgets/tests/parity/` | ✅ first slice (2026-06-30) | Scaffolding + 18 oracle-cited parity tests land (commit 0f0e14b2; plan `docs/research/2026-06-30-c1-13-parity-scaffolding-plan.md`). WidgetTester-shim (screen/find_by_render_type/find_text/pump_widget) over the existing HeadlessBinding+LaidOut harness. Gate = scaffolding exists + first slice passes ✓. Broader corpus + paint/semantics/key finders = Phase 3, grow incrementally. |
 
+> **OPEN ITEM — Core.1 formal exit (C1.10 + C1.12).** Core.1 has never been
+> formally closed: the two `🛇 needs display` rows above require a windowed
+> desktop session (demo app assembled from slice widgets with a real frame
+> loop, plus a 5-second animation run with a ≤ 16 ms median frame-time
+> histogram). Every agent checkout so far has been headless, so the rows have
+> sat implicit. **Owner action:** on a machine with a display, run the demo
+> app and the histogram capture, then promote C1.10/C1.12 with the run
+> evidence. Until then, downstream phase entries that cite "Core.1 exit"
+> stand on C1.11/C1.13 evidence only.
+
 ---
 
 ## Core.2 — Render-object catalog  *(entry: Core.1 exit + N12)*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,7 +21,7 @@ The target is **full parity with released Flutter** — every framework package,
 | `scheduler` | 2.2k | ~95% | Core.0 |
 | `gestures` | 14.3k | ~95% | Cross.H |
 | `semantics` | 7.9k | ~70% | Cross.H |
-| `animation` | 5.3k | ~85% (disabled) | Core.1 (re-enable) |
+| `animation` | 5.3k | ~85% | Core.1 ✓ (re-enabled; active workspace member) |
 | `painting` | 24.9k | ~60% | Core.0 → Core.2 |
 | `rendering` | 52.1k | machine ~90%, catalog ~12% | Core.0 (machine) + Core.2 (catalog) |
 | `widgets` | 157.4k | spine ~85%, catalog ~2% | Core.0 (spine) + Core.1 / Business.1 (catalog) |

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -65,7 +65,7 @@ These crates compose the rendering substrate without knowing about each other.
 | `flui-objects` | ✅ ACTIVE | Concrete `RenderBox` / `RenderSliver` catalog that `flui-widgets` wraps |
 | `flui-widgets` | ✅ ACTIVE | User-facing Flutter-style widget catalog (configuration objects over `flui-objects`) |
 | `flui-binding` | ✅ ACTIVE | Deterministic non-singleton headless frame driver: `HeadlessBinding::pump_frame(dt)` advances a virtual `ManualClock` and polls clock-bound gesture-arena deadlines — sleep-free time-based gesture tests (long-press, double-tap). Animation-controller ticks (Phase 3) and tree-rebuild integration (Phase 1b) are deferred. |
-| `flui-assets` | ✅ ACTIVE (not in `default-members`) | Asset loading, caching, image decoding |
+| `flui-assets` | ✅ ACTIVE | Asset loading, caching, image decoding |
 | `flui-build` | ✅ ACTIVE | Async cross-platform build pipeline (`PlatformBuilder` typestate) |
 
 ## Layer 7 — Hot-Reload

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -240,8 +240,15 @@ typos
 bash scripts/check-workspace-inventory.sh
 bash scripts/port-check.sh -v
 cargo clippy --workspace --all-targets -- -D warnings
-cargo nextest run --workspace --exclude flui-platform --lib --no-fail-fast --test-threads 1
+cargo nextest run --workspace --exclude flui-platform --no-fail-fast --test-threads 1
+cargo test --workspace --exclude flui-platform --doc
+cargo check --workspace --all-targets           # repeated on Rust 1.96 (MSRV job)
+cargo miri test -p flui-rendering --lib pipeline::owner::subtree_arena  # advisory
 ```
+
+The `gpu-test` job additionally runs the full `enable-wgpu-tests` readback
+suite on a windows-latest runner (WARP software rasterizer) and is
+merge-blocking.
 
 A change cannot be merged if any of these fail. If you encounter a flaky test, file a fix issue rather than retrying CI.
 

--- a/examples/color_filter_demo.rs
+++ b/examples/color_filter_demo.rs
@@ -19,6 +19,11 @@
 //!
 //! Run with: cargo run --example color_filter_demo
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::unwrap_used)]
+
 use std::sync::{Arc, Mutex};
 
 use flui_engine::wgpu::Renderer;

--- a/examples/filter_demo.rs
+++ b/examples/filter_demo.rs
@@ -11,6 +11,11 @@
 //!
 //! Run with: cargo run --example filter_demo
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::unwrap_used)]
+
 use std::sync::{Arc, Mutex};
 
 use flui_engine::wgpu::Renderer;

--- a/examples/image_demo.rs
+++ b/examples/image_demo.rs
@@ -67,10 +67,10 @@ impl View for App {
 }
 
 fn load_image() -> anyhow::Result<SharedImage> {
-    let input = std::env::args()
-        .nth(1)
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| std::env::temp_dir().join("flui_test_cat.jpg"));
+    let input = std::env::args().nth(1).map_or_else(
+        || std::env::temp_dir().join("flui_test_cat.jpg"),
+        std::path::PathBuf::from,
+    );
     println!("Loading image: {}", input.display());
 
     let decoded = image::open(&input)?.to_rgba8();

--- a/examples/scene_render.rs
+++ b/examples/scene_render.rs
@@ -29,6 +29,11 @@
 //!
 //! Run with: cargo run --example scene_render
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::unwrap_used)]
+
 use std::sync::{Arc, Mutex};
 
 use flui_engine::wgpu::Renderer;

--- a/examples/wgpu_window.rs
+++ b/examples/wgpu_window.rs
@@ -6,6 +6,11 @@
 //!
 //! Run with: cargo run --example wgpu_window
 
+// Target-level lint relaxations — crate-level allows don't reach this
+// target. `unwrap` in test/example code: a panic IS the failure report
+// (docs/PANIC-POLICY.md); style items here are ship-wave debt.
+#![allow(clippy::unwrap_used)]
+
 use std::sync::{Arc, Mutex};
 
 use flui_platform::{WindowOptions, current_platform, traits::PlatformWindow};

--- a/justfile
+++ b/justfile
@@ -108,6 +108,16 @@ test-release:
     cargo test --workspace --release
 
 [group("test")]
+[doc("Run rustdoc examples as tests (CI gate; nextest does not execute doctests)")]
+test-doc:
+    cargo test --workspace --exclude flui-platform --doc
+
+[group("test")]
+[doc("Run miri on the flui-rendering subtree arena (the unsafe hot spot; requires nightly + miri component)")]
+miri:
+    cargo +nightly miri test -p flui-rendering --lib pipeline::owner::subtree_arena
+
+[group("test")]
 [doc("Generate an HTML coverage report (requires cargo-llvm-cov)")]
 coverage:
     cargo llvm-cov --workspace --html
@@ -295,8 +305,8 @@ watch-test crate="":
 # =============================================================================
 
 [group("ci")]
-[doc("Run local CI gates (fmt-check + inventory + port-check + clippy + test)")]
-ci: fmt-check inventory-check port-check clippy test
+[doc("Run local CI gates (fmt-check + inventory + port-check + clippy + test + doctests)")]
+ci: fmt-check inventory-check port-check clippy test test-doc
 
 # =============================================================================
 # Maintenance

--- a/scripts/check-workspace-inventory.sh
+++ b/scripts/check-workspace-inventory.sh
@@ -200,10 +200,18 @@ for package in workspace_packages:
     if not package.get("description"):
         errors.append(f"{rel} is missing package description")
 
-    raw_package = tomllib.loads(manifest.read_text())["package"]
+    raw_manifest = tomllib.loads(manifest.read_text())
+    raw_package = raw_manifest["package"]
     for key in ("version", "edition", "rust-version", "license", "authors", "repository"):
         if raw_package.get(key) != {"workspace": True}:
             errors.append(f"{rel} must inherit `{key}.workspace = true`")
+
+    # Workspace lints must apply to every active crate. A missing `[lints]`
+    # table silently opts the crate out of `[workspace.lints]`; a local table
+    # shadows it with a stale copy (and Cargo forbids mixing `workspace = true`
+    # with local keys, so equality is the only valid shape).
+    if raw_manifest.get("lints") != {"workspace": True}:
+        errors.append(f"{rel} must set `[lints] workspace = true` (local or missing lint tables bypass workspace lints)")
 
 if errors:
     print("workspace-inventory: drift detected", file=sys.stderr)

--- a/specs/004-view-element-core/spec.md
+++ b/specs/004-view-element-core/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `004-view-element-core` *(historical name — originally scoped as C4+C6; expanded per the 2026-05-22 doc-review finding that the four contracts cannot be locked independently)*
 **Created**: 2026-05-22
 **Last revised**: 2026-05-22 (round 5 — post-ideation doc-review verification; clusters C1-C5 + singletons applied; S6 mechanism redesigned)
-**Status**: Draft (round-5 — post-doc-review verification)
+**Status**: Closed (2026-06-30 — all four phases delivered with executable evidence; see `docs/ROADMAP-TRACKER.md` N5: Phase 0 S1/S2 spikes, Phase 1 storage/key round-trip tests, Phase 2 production keyed reconciliation + GlobalKey reparent tests, Phase 3 `IntoView`/derive/macro/port-check authoring surface)
 **Input**: Lock the FLUI Core Contracts — heterogeneous children (C2), widget-authoring API (C3), and the View / Element / Reconciliation core (C4 + C6) from `docs/FOUNDATIONS.md` Part III. Co-designed as one atomic merge unit because the four contracts share files and propagate constraints across each other (the `ViewSeq` shape forces the reconciler signature; `impl IntoView` ergonomics force the authoring surface; the element-storage shape couples to the heterogeneous-children boundary).
 
 ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,66 @@
+//! FLUI — a Flutter-inspired declarative UI framework for Rust with a
+//! `wgpu`-backed GPU rendering engine.
+//!
+//! This crate is the **facade** over the FLUI workspace: it re-exports the
+//! layered crates an application author needs, so a downstream consumer can
+//! depend on `flui` alone (by path — FLUI is pre-release and not on
+//! crates.io) instead of naming each layer.
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use flui::prelude::*;
+//!
+//! #[derive(Clone, StatelessView)]
+//! struct Hello;
+//!
+//! impl StatelessView for Hello {
+//!     fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+//!         Container::new()
+//!             .color(Color::rgb(18, 18, 24))
+//!             .child(Center::new().child(Text::new("Hello, FLUI!")))
+//!     }
+//! }
+//!
+//! fn main() {
+//!     flui::run_app(Hello);
+//! }
+//! ```
+//!
+//! # Layers
+//!
+//! Each re-exported module is one workspace crate; the layering (no upward
+//! edges) is documented in `docs/FOUNDATIONS.md`:
+//!
+//! | Module | Crate | Layer |
+//! |---|---|---|
+//! | [`types`] | `flui-types` | foundation types + unit system |
+//! | [`geometry`] | `flui-geometry` | geometry primitives |
+//! | [`foundation`] | `flui-foundation` | keys, listenables, diagnostics |
+//! | [`view`] | `flui-view` | View/Element tree |
+//! | [`widgets`] | `flui-widgets` | user-facing widget catalog |
+//! | [`animation`] | `flui-animation` | curves, tweens, tickers |
+//! | [`app`] | `flui-app` | `run_app` + bindings |
+//!
+//! Lower layers (rendering, painting, engine, platform) are deliberately not
+//! re-exported: their surfaces are consumed *through* the widget layer and
+//! remain path-dependencies for the rare integrator who needs them directly.
+
+pub use flui_animation as animation;
+pub use flui_app as app;
+pub use flui_foundation as foundation;
+pub use flui_geometry as geometry;
+pub use flui_types as types;
+pub use flui_view as view;
+pub use flui_widgets as widgets;
+
+/// The application entry point — builds the tree, opens a window, and drives
+/// the frame loop. Re-exported from [`app`] (`flui-app`).
+pub use flui_app::run_app;
+
+/// Everything an application author needs in scope to write widget code:
+/// the widget catalog prelude plus [`run_app`].
+pub mod prelude {
+    pub use flui_app::run_app;
+    pub use flui_widgets::prelude::*;
+}


### PR DESCRIPTION
## Summary

Phase 0 of the open-source ship-quality program (tokio bar): make every existing quality gate actually enforce, and close the repo-metadata gaps a first-time contributor hits. Three commits:

1. **CI gates** — the `test` job drops `--lib` (the integration dirs, including the Core.0/Core.2 exit-gate suites, were never executed in CI); new `doc-test` job (nextest never runs doctests — 700+ fences were unverified); new `msrv` job (every job installed `@stable`, so the declared 1.96 floor was never exercised); new advisory `miri` job scoped to the `subtree_arena` unsafe island; `gpu-test` promoted to merge-blocking per its own recorded criterion (3 consecutive green full-suite runs on main: #583/#586/#595, 5–15 min against the 60-min budget). *Note: `gpu-test` should also be added to required checks in branch-protection settings — that's a repo setting, not workflow YAML.*
2. **Lint enforcement** — 12 crates had no `[lints]` table (workspace lints silently didn't apply); 3 had stale local copies. All 24 crates now inherit `[lints] workspace = true`, guarded against regression by a new check in `scripts/check-workspace-inventory.sh` (negative-tested). Panic policy (`docs/PANIC-POLICY.md`) lands with `clippy::unwrap_used = warn` + test exemption via `clippy.toml`; pre-existing debt carries tracked `TODO(ship-wave-N)` allows with item counts, burned down in the per-crate quality waves. ~1,300 mechanical pedantic fixes applied via `clippy --fix`; 8 missing `Debug` impls derived outright.
3. **Facade + polish** — the root `flui` package gains a real library surface (`flui::prelude`, `flui::run_app`, layer re-exports; its `[dependencies]` was empty); `flui-assets` rejoins workspace members (CI never built it); README gets badges/MSRV policy/status block and a widget-level Hello World; CHANGELOG seeded; doc drift fixed (spec 004 status, ROADMAP scoreboard, Core.1 open item made explicit).

## Verification

- [x] `just ci` — fmt-check, inventory-check (incl. new lints guard), port-check, workspace clippy `-D warnings`, full test suite (lib + integration, `--test-threads=1`), doc-tests: all green locally on 1.96.0
- [x] Flutter reference checked — not applicable (no render/layout/paint/lifecycle behavior changes; lint fixes are mechanical)
- [x] New or changed behavior has tests that would fail without this change — the drift guard was negative-tested (removing one `[lints]` table fails `check-workspace-inventory.sh`); the CI gates themselves are the enforcement
- [x] Public API changes are documented — the new `flui` facade lib carries full rustdoc incl. a compiled doc-example; `rustdoc -D warnings` green

## Architecture

- [x] Layering still follows `docs/FOUNDATIONS.md` — facade re-exports only the app-author layers; lower layers deliberately not re-exported (documented in `src/lib.rs`)
- [x] No new banned patterns from `docs/PORT.md` — `port-check.sh` green
- [x] New dependencies are declared through workspace dependencies — no new external deps; `flui-assets`' moka/lasso pins moved to `workspace = true`

## Notes

- **Intentional lint decisions**: the float-comparison/numeric-cast pedantic family plus `needless_pass_by_value`/`trivially_copy_pass_by_ref`/`struct_excessive_bools` are now workspace-level allows with rationale comments (graphics/layout idiom; widget builders consume configs by value — 100+ sites in flui-widgets alone). `expect_used` deliberately stays off: `expect("BUG: …")` is the sanctioned invariant idiom per the panic policy.
- **Deferred (tracked)**: per-crate `TODO(ship-wave-N)` allows enumerate the remaining doc/Debug/pedantic/unwrap debt with counts; waves 1–4 burn them down cohort by cohort. The miri job starts advisory — drop its `continue-on-error` after a few green runs, same playbook as gpu-test.
- Core.1's formal exit (C1.10/C1.12 windowed run) is now an explicit OPEN ITEM in `docs/ROADMAP-TRACKER.md` — it needs a machine with a display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sjdi8ANg4pYBKDsyZJn9Mt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sjdi8ANg4pYBKDsyZJn9Mt)_