### PR TITLE
Ship-quality Wave 1: foundation cohort docs complete, deny(missing_docs) locked

### DIFF
--- a/crates/flui-foundation/src/lib.rs
+++ b/crates/flui-foundation/src/lib.rs
@@ -135,8 +135,9 @@
 //! - Change notifiers use efficient listener storage
 //! - Atomic flags provide lock-free state management
 
+// Ship bar (wave 1): every public item is documented; keep it that way.
+#![deny(missing_docs)]
 #![warn(
-    missing_docs,
     missing_debug_implementations,
     rust_2018_idioms,
     unreachable_pub,

--- a/crates/flui-geometry/Cargo.toml
+++ b/crates/flui-geometry/Cargo.toml
@@ -7,13 +7,12 @@ authors.workspace = true
 license.workspace = true
 description = "Type-safe 2D geometry primitives for FLUI (split from flui-types in D-block PR-C-2)"
 repository.workspace = true
+readme = "README.md"
 keywords = ["geometry", "graphics", "ui", "flui", "math"]
 categories = ["graphics", "mathematics"]
 
-# Geometry-specific lint relaxations — mirrors crates/flui-types/Cargo.toml
-# pre-split. Math/geometry crates legitimately have many single-char names,
-# tolerated truncation casts, similar names (x/y/z), float comparisons (with
-# epsilon checks done at higher levels), and wildcard imports in preludes.
+# Crate-specific lint relaxations live in src/lib.rs next to the code they
+# cover; the manifest inherits [workspace.lints] unmodified.
 [lints]
 workspace = true
 

--- a/crates/flui-geometry/README.md
+++ b/crates/flui-geometry/README.md
@@ -1,0 +1,65 @@
+# flui-geometry
+
+**Type-safe 2D geometry primitives for the FLUI framework.**
+
+`flui-geometry` is FLUI's foundation geometry crate: points, sizes, rectangles,
+transforms, and curves, all parameterized by a compile-time **unit system** so
+that logical pixels, physical device pixels, and font-relative units cannot be
+mixed by accident.
+
+Part of the [FLUI](https://github.com/vanyastaff/flui) workspace — pre-release,
+consumed by path (not published to crates.io).
+
+## Core types
+
+| Type | Description |
+|------|-------------|
+| `Point<T>` | Absolute position in 2D space |
+| `Vec2<T>` | Direction + magnitude (displacement) |
+| `Size<T>` | Width/height dimensions |
+| `Offset<T>` | UI displacement (Flutter-compatible) |
+| `Rect` / `RRect` / `RSuperellipse` | Axis-aligned, rounded, and superellipse rectangles |
+| `Circle` / `Line` / `Bezier` | Curve and shape primitives |
+| `Matrix4` / `Transform2D` | 4×4 and 2D affine transforms (glam-backed) |
+| `RelativeRect` / `QuarterTurns` | Parent-relative positioning and 90° rotation steps |
+
+## Unit system
+
+| Unit | Meaning |
+|------|---------|
+| `Pixels` | Logical pixels — UI layout and design coordinates |
+| `DevicePixels` | Physical pixels (integer) — framebuffer addressing |
+| `Rems` | Root-em, font-relative sizing |
+
+Conversions between unit spaces are explicit (`ScaleFactor`), and `From<f32>`
+escape hatches are deliberately absent — the unit barrier is enforced by the
+workspace's port-check CI gate.
+
+```rust
+use flui_geometry::{Point, Size, Rect, px};
+
+let origin = Point::new(px(10.0), px(20.0));
+let size = Size::new(px(100.0), px(50.0));
+let rect = Rect::from_origin_size(origin, size);
+assert_eq!(rect.center().x, px(60.0));
+```
+
+## Design notes
+
+- **Flutter parity, Rust shape.** The observable behavior (edge cases,
+  ordering, coordinate conventions) follows Flutter's `dart:ui` geometry;
+  the structure is Rust-native (`Copy` value types, `glam` SIMD backing for
+  `Matrix4`, `bytemuck` Pod derives for zero-copy GPU upload).
+- **No heap allocations** in the core types; everything is stack-`Copy`.
+- **Interop:** optional `mint` (math ecosystem), `kurbo` (Bézier bridge for
+  the painting layer), and `serde` support behind feature flags.
+
+## Documentation
+
+Every public item is documented (`#![deny(missing_docs)]`); build locally with
+`cargo doc -p flui-geometry --open`. Architecture context lives in the
+workspace's [`docs/FOUNDATIONS.md`](../../docs/FOUNDATIONS.md).
+
+## License
+
+MIT OR Apache-2.0, per the workspace license.

--- a/crates/flui-geometry/src/lib.rs
+++ b/crates/flui-geometry/src/lib.rs
@@ -114,8 +114,8 @@
 // visible next to the code they cover. (The float-comparison / numeric-cast
 // family is allowed workspace-wide — see `[workspace.lints.clippy]`.)
 #![allow(clippy::many_single_char_names, clippy::wildcard_imports)]
-// Tracked ship-quality debt (unlike the permanent idiom block above):
-#![allow(missing_docs)] // TODO(ship-wave-1): public-item doc backlog (~77 items), then delete
+// Ship bar (wave 1): every public item is documented; keep it that way.
+#![deny(missing_docs)]
 
 // =============================================================================
 // MODULES

--- a/crates/flui-geometry/src/matrix4.rs
+++ b/crates/flui-geometry/src/matrix4.rs
@@ -339,6 +339,8 @@ impl Matrix4 {
         Self::skew_2d(skew_x, skew_y)
     }
 
+    /// Returns whether this is an identity matrix, using a default epsilon of
+    /// `1e-5`.
     #[inline]
     pub fn is_identity(&self) -> bool {
         self.is_identity_with_epsilon(1e-5)
@@ -354,6 +356,8 @@ impl Matrix4 {
         true
     }
 
+    /// Returns whether this matrix represents only a translation, using
+    /// `f32::EPSILON` as the comparison tolerance.
     #[inline]
     pub fn is_translation_only(&self) -> bool {
         self.is_translation_only_with_epsilon(f32::EPSILON)

--- a/crates/flui-geometry/src/offset.rs
+++ b/crates/flui-geometry/src/offset.rs
@@ -445,18 +445,24 @@ impl Offset<Pixels> {
         }
     }
 
+    /// Compute the dot product of this offset and another.
     #[inline]
     #[must_use]
     pub const fn dot(self, other: Offset<Pixels>) -> Pixels {
         Pixels(self.dx.0 * other.dx.0 + self.dy.0 * other.dy.0)
     }
 
+    /// Compute the 2D cross product (determinant) of this offset and another.
+    ///
+    /// Positive when `other` is counter-clockwise from `self`, negative when
+    /// clockwise, and zero when the offsets are parallel.
     #[inline]
     #[must_use]
     pub const fn cross(self, other: Offset<Pixels>) -> Pixels {
         Pixels(self.dx.0 * other.dy.0 - self.dy.0 * other.dx.0)
     }
 
+    /// Rotate this offset around the origin by `angle` radians.
     #[inline]
     #[must_use]
     pub fn rotate(self, angle: f32) -> Offset<Pixels> {
@@ -464,36 +470,45 @@ impl Offset<Pixels> {
         Offset::new(self.dx * cos - self.dy * sin, self.dx * sin + self.dy * cos)
     }
 
+    /// Rotate this offset around the origin by a typed [`Radians`](crate::Radians) angle.
     #[inline]
     #[must_use]
     pub fn rotate_radians(self, angle: crate::Radians) -> Offset<Pixels> {
         self.rotate(angle.0)
     }
 
+    /// Round each component to the nearest whole pixel.
     #[inline]
     #[must_use]
     pub fn round(self) -> Offset<Pixels> {
         Offset::new(self.dx.round(), self.dy.round())
     }
 
+    /// Round each component down to the nearest whole pixel.
     #[inline]
     #[must_use]
     pub fn floor(self) -> Offset<Pixels> {
         Offset::new(self.dx.floor(), self.dy.floor())
     }
 
+    /// Round each component up to the nearest whole pixel.
     #[inline]
     #[must_use]
     pub fn ceil(self) -> Offset<Pixels> {
         Offset::new(self.dx.ceil(), self.dy.ceil())
     }
 
+    /// Clamp each component to the range defined by `min` and `max`.
+    ///
+    /// Components are clamped independently; `min` and `max` are not treated
+    /// as a magnitude bound (see [`clamp_magnitude`](Self::clamp_magnitude)).
     #[inline]
     #[must_use]
     pub fn clamp(self, min: Offset<Pixels>, max: Offset<Pixels>) -> Offset<Pixels> {
         Offset::new(self.dx.clamp(min.dx, max.dx), self.dy.clamp(min.dy, max.dy))
     }
 
+    /// Take the absolute value of each component.
     #[inline]
     #[must_use]
     pub const fn abs(self) -> Offset<Pixels> {
@@ -605,6 +620,10 @@ impl Offset<Pixels> {
         det.atan2(dot).abs()
     }
 
+    /// Calculate the angle between this offset and another as typed [`Radians`](crate::Radians).
+    ///
+    /// Same as [`angle_to`](Self::angle_to), returning the absolute angle
+    /// difference in range [0, π] as a typed unit.
     #[inline]
     #[must_use]
     pub fn angle_to_radians(self, other: impl Into<Offset<Pixels>>) -> crate::Radians {

--- a/crates/flui-geometry/src/relative_rect.rs
+++ b/crates/flui-geometry/src/relative_rect.rs
@@ -8,6 +8,11 @@ use std::ops::{Add, Mul, Neg, Sub};
 use super::traits::{NumericUnit, Unit};
 use crate::{Offset, Size};
 
+/// A rectangle expressed as distances from the edges of a parent rectangle.
+///
+/// Unlike a plain rect, each field is an inset from the corresponding parent
+/// edge, so the described rectangle depends on the parent's size. Equivalent
+/// to Flutter's `RelativeRect`, used by `Positioned` and `RelativeRectTween`.
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RelativeRect<T: Unit> {
@@ -27,6 +32,8 @@ pub struct RelativeRect<T: Unit> {
 // ============================================================================
 
 impl<T: Unit> RelativeRect<T> {
+    /// Creates a relative rect from offsets to the left, top, right, and
+    /// bottom parent edges.
     #[inline]
     #[must_use]
     pub const fn from_ltrb(left: T, top: T, right: T, bottom: T) -> Self {
@@ -47,6 +54,8 @@ impl<T: NumericUnit> RelativeRect<T>
 where
     T: Add<Output = T> + Sub<Output = T> + Mul<f32, Output = T>,
 {
+    /// Creates a relative rect for a child at `offset` with the given `size`
+    /// inside a parent of size `parent`.
     #[inline]
     #[must_use]
     pub fn from_size(offset: Offset<T>, size: Size<T>, parent: Size<T>) -> Self {
@@ -58,6 +67,8 @@ where
         }
     }
 
+    /// Creates a relative rect from a left/top position and a width/height
+    /// inside a parent of size `parent`.
     #[inline]
     #[must_use]
     pub fn from_left_top_width_height(
@@ -75,6 +86,8 @@ where
         }
     }
 
+    /// Returns the size of the described rectangle within a parent of size
+    /// `parent`.
     #[inline]
     #[must_use]
     pub fn to_size(&self, parent: Size<T>) -> Size<T> {
@@ -84,6 +97,8 @@ where
         )
     }
 
+    /// Returns a new relative rect translated by the given offset, keeping
+    /// the same size.
     #[inline]
     #[must_use]
     pub fn shift(&self, offset: Offset<T>) -> Self {
@@ -95,6 +110,8 @@ where
         }
     }
 
+    /// Returns a new relative rect grown by `delta` on each side (each edge
+    /// inset is reduced by `delta`).
     #[inline]
     #[must_use]
     pub fn inflate(&self, delta: T) -> Self {
@@ -106,6 +123,7 @@ where
         }
     }
 
+    /// Returns a new relative rect shrunk by `delta` on each side.
     #[inline]
     #[must_use]
     pub fn deflate(&self, delta: T) -> Self

--- a/crates/flui-geometry/src/rotation.rs
+++ b/crates/flui-geometry/src/rotation.rs
@@ -1,6 +1,11 @@
+/// A rotation expressed as a whole number of 90° clockwise turns.
+///
+/// Only the four axis-aligned orientations are representable, which makes
+/// rotations exact (no floating-point drift) and cheap to compose.
 #[derive(Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum QuarterTurns {
+    /// No rotation.
     #[default]
     Zero = 0,
     /// 90° clockwise
@@ -12,6 +17,10 @@ pub enum QuarterTurns {
 }
 
 impl QuarterTurns {
+    /// Creates a rotation from an integer number of quarter turns.
+    ///
+    /// The value is normalized modulo 4, so negative and out-of-range
+    /// counts wrap (e.g. `-1` becomes [`QuarterTurns::Three`]).
     #[must_use]
     pub fn from_int(turns: i32) -> Self {
         match turns.rem_euclid(4) {
@@ -23,26 +32,31 @@ impl QuarterTurns {
         }
     }
 
+    /// Returns the number of quarter turns as an integer in `0..=3`.
     #[must_use]
     pub const fn as_int(self) -> i32 {
         self as i32
     }
 
+    /// Returns `true` if this rotation swaps width and height (90° or 270°).
     #[must_use]
     pub const fn swaps_dimensions(self) -> bool {
         matches!(self, QuarterTurns::One | QuarterTurns::Three)
     }
 
+    /// Returns the rotation angle in degrees (0.0, 90.0, 180.0, or 270.0).
     #[must_use]
     pub const fn degrees(self) -> f32 {
         (self as i32 * 90) as f32
     }
 
+    /// Returns the rotation angle in radians as a raw `f32`.
     #[must_use]
     pub fn radians(self) -> f32 {
         self.degrees().to_radians()
     }
 
+    /// Returns the rotation angle as a typed [`Radians`](crate::Radians) value.
     #[must_use]
     pub fn to_radians(self) -> crate::Radians {
         crate::radians(self.radians())

--- a/crates/flui-geometry/src/rsuperellipse.rs
+++ b/crates/flui-geometry/src/rsuperellipse.rs
@@ -13,6 +13,11 @@
 
 use super::{Pixels, Radius, Rect, px};
 
+/// A rounded superellipse (squircle) with independent corner radii.
+///
+/// Like a rounded rectangle, but corners blend smoothly into the edges,
+/// matching iOS/SwiftUI's `.continuous` corner style. Corresponds to
+/// Flutter's `RSuperellipse`.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -43,6 +48,8 @@ impl RSuperellipse {
     // Constructors
     // ========================================================================
 
+    /// Creates a rounded superellipse from edge coordinates with the same
+    /// radius for all corners.
     #[inline]
     #[must_use]
     pub fn from_ltrb_r(
@@ -61,6 +68,8 @@ impl RSuperellipse {
         }
     }
 
+    /// Creates a rounded superellipse from edge coordinates with separate
+    /// x and y radii for all corners.
     #[inline]
     #[must_use]
     pub fn from_ltrb_xy(
@@ -75,6 +84,8 @@ impl RSuperellipse {
         Self::from_ltrb_r(left, top, right, bottom, radius)
     }
 
+    /// Creates a rounded superellipse from edge coordinates with independent
+    /// corner radii.
     #[allow(clippy::too_many_arguments)]
     #[inline]
     pub fn from_ltrb_and_corners(
@@ -96,6 +107,8 @@ impl RSuperellipse {
         }
     }
 
+    /// Creates a rounded superellipse from a rectangle with the same radius
+    /// for all corners.
     #[inline]
     #[must_use]
     pub fn from_rect_and_radius(rect: Rect<Pixels>, radius: Radius<Pixels>) -> Self {
@@ -108,6 +121,8 @@ impl RSuperellipse {
         }
     }
 
+    /// Creates a rounded superellipse from a rectangle with independent
+    /// corner radii.
     #[inline]
     #[must_use]
     pub fn from_rect_and_corners(
@@ -126,6 +141,8 @@ impl RSuperellipse {
         }
     }
 
+    /// Creates a rounded superellipse from a rectangle with a circular radius
+    /// for all corners.
     #[inline]
     #[must_use]
     pub fn from_rect_circular(rect: Rect<Pixels>, radius: Pixels) -> Self {
@@ -136,72 +153,84 @@ impl RSuperellipse {
     // Properties
     // ========================================================================
 
+    /// Returns the bounding rectangle.
     #[inline]
     #[must_use]
     pub fn outer_rect(&self) -> Rect<Pixels> {
         self.rect
     }
 
+    /// Returns the left edge x-coordinate.
     #[inline]
     #[must_use]
     pub fn left(&self) -> Pixels {
         self.rect.left()
     }
 
+    /// Returns the top edge y-coordinate.
     #[inline]
     #[must_use]
     pub fn top(&self) -> Pixels {
         self.rect.top()
     }
 
+    /// Returns the right edge x-coordinate.
     #[inline]
     #[must_use]
     pub fn right(&self) -> Pixels {
         self.rect.right()
     }
 
+    /// Returns the bottom edge y-coordinate.
     #[inline]
     #[must_use]
     pub fn bottom(&self) -> Pixels {
         self.rect.bottom()
     }
 
+    /// Returns the width of the bounding rectangle.
     #[inline]
     #[must_use]
     pub fn width(&self) -> Pixels {
         self.rect.width()
     }
 
+    /// Returns the height of the bounding rectangle.
     #[inline]
     #[must_use]
     pub fn height(&self) -> Pixels {
         self.rect.height()
     }
 
+    /// Returns the top-left corner radius.
     #[inline]
     #[must_use]
     pub fn tl_radius(&self) -> Radius<Pixels> {
         self.tl_radius
     }
 
+    /// Returns the top-right corner radius.
     #[inline]
     #[must_use]
     pub fn tr_radius(&self) -> Radius<Pixels> {
         self.tr_radius
     }
 
+    /// Returns the bottom-right corner radius.
     #[inline]
     #[must_use]
     pub fn br_radius(&self) -> Radius<Pixels> {
         self.br_radius
     }
 
+    /// Returns the bottom-left corner radius.
     #[inline]
     #[must_use]
     pub fn bl_radius(&self) -> Radius<Pixels> {
         self.bl_radius
     }
 
+    /// Checks if all four corner radii are equal.
     #[inline]
     #[must_use]
     pub fn has_uniform_corners(&self) -> bool {
@@ -210,6 +239,7 @@ impl RSuperellipse {
             && self.br_radius == self.bl_radius
     }
 
+    /// Checks if every corner radius is circular (x equals y).
     #[inline]
     #[must_use]
     pub fn has_circular_corners(&self) -> bool {
@@ -219,6 +249,7 @@ impl RSuperellipse {
             && self.bl_radius.is_circular()
     }
 
+    /// Checks if all corner radii are zero (a plain rectangle).
     #[inline]
     #[must_use]
     pub fn is_rect(&self) -> bool {
@@ -228,6 +259,7 @@ impl RSuperellipse {
             && self.bl_radius.is_zero()
     }
 
+    /// Checks if the bounding rectangle is empty.
     #[inline]
     #[must_use]
     pub fn is_empty(&self) -> bool {
@@ -238,6 +270,11 @@ impl RSuperellipse {
     // Safe inner rectangles
     // ========================================================================
 
+    /// Returns the largest axis-aligned rectangle guaranteed to lie inside
+    /// the shape.
+    ///
+    /// Each side is inset by the maximum corner radius component along that
+    /// side, so the result avoids all four corner regions.
     #[inline]
     #[must_use]
     pub fn safe_inner_rect(&self) -> Rect<Pixels> {
@@ -255,6 +292,10 @@ impl RSuperellipse {
         )
     }
 
+    /// Returns the widest inner rectangle spanning the full width.
+    ///
+    /// Only the top and bottom edges are inset (by the maximum vertical
+    /// corner radii); the left and right edges match the bounding rectangle.
     #[inline]
     #[must_use]
     pub fn wide_middle_rect(&self) -> Rect<Pixels> {
@@ -269,6 +310,10 @@ impl RSuperellipse {
         )
     }
 
+    /// Returns the tallest inner rectangle spanning the full height.
+    ///
+    /// Only the left and right edges are inset (by the maximum horizontal
+    /// corner radii); the top and bottom edges match the bounding rectangle.
     #[inline]
     #[must_use]
     pub fn tall_middle_rect(&self) -> Rect<Pixels> {
@@ -287,6 +332,8 @@ impl RSuperellipse {
     // Transformations
     // ========================================================================
 
+    /// Returns a copy inflated by `delta` on all sides, with corner radii
+    /// grown by the same amount.
     #[inline]
     #[must_use]
     pub fn inflate(&self, delta: Pixels) -> Self {
@@ -299,12 +346,18 @@ impl RSuperellipse {
         }
     }
 
+    /// Returns a copy deflated by `delta` on all sides, with corner radii
+    /// shrunk by the same amount.
     #[inline]
     #[must_use]
     pub fn deflate(&self, delta: Pixels) -> Self {
         self.inflate(-delta)
     }
 
+    /// Returns a copy with the bounding rectangle and all corner radii scaled
+    /// by `factor`.
+    ///
+    /// Edge coordinates are scaled about the origin, not the shape's center.
     #[inline]
     #[must_use]
     pub fn scale(&self, factor: f32) -> Self {
@@ -346,6 +399,10 @@ impl RSuperellipse {
     // Interpolation
     // ========================================================================
 
+    /// Linearly interpolates between two rounded superellipses.
+    ///
+    /// The bounding rectangle and each corner radius are interpolated
+    /// component-wise.
     #[inline]
     #[must_use]
     pub fn lerp(a: Self, b: Self, t: f32) -> Self {

--- a/crates/flui-geometry/src/text_path.rs
+++ b/crates/flui-geometry/src/text_path.rs
@@ -43,6 +43,7 @@ use crate::{
     traits::{FloatUnit, NumericUnit, Unit},
 };
 
+/// Position and rotation for a single character placed along a path.
 #[derive(Debug, Clone, Copy)]
 pub struct CharTransform<T: Unit> {
     /// Position of the character (center point or baseline)
@@ -51,6 +52,12 @@ pub struct CharTransform<T: Unit> {
     pub rotation: f64,
 }
 
+/// Calculate the position and rotation of a character along a circular arc.
+///
+/// The character at `char_index` (of `total_chars`) is placed on a circle of
+/// `radius` centered at the origin, sweeping `arc_length` radians from
+/// `start_angle`. The rotation is the arc angle plus 90° so glyphs face
+/// outward along the tangent.
 #[inline]
 pub fn arc_position(
     char_index: usize,
@@ -71,11 +78,20 @@ pub fn arc_position(
     }
 }
 
+/// Calculate the sinusoidal vertical offset for a character in a wave effect.
+///
+/// Returns `sin(char_index * frequency) * amplitude`.
 #[inline]
 pub fn wave_offset(char_index: usize, frequency: f64, amplitude: f64) -> f64 {
     (char_index as f64 * frequency).sin() * amplitude
 }
 
+/// Calculate the position and rotation of a character along an Archimedean spiral.
+///
+/// The spiral starts at `start_radius` and grows by `radius_per_revolution`
+/// for each of the `revolutions` turns; characters are spread evenly along it.
+/// The rotation is the spiral angle plus 90° so glyphs face outward along the
+/// tangent.
 #[inline]
 pub fn spiral_position(
     char_index: usize,
@@ -97,16 +113,29 @@ pub fn spiral_position(
     }
 }
 
+/// Calculate the sinusoidal rotation for a character in a wave effect, in radians.
+///
+/// Returns `sin(char_index * frequency) * max_angle`, oscillating between
+/// `-max_angle` and `max_angle`.
 #[inline]
 pub fn wave_rotation(char_index: usize, frequency: f64, max_angle: f64) -> f64 {
     (char_index as f64 * frequency).sin() * max_angle
 }
 
+/// Linearly interpolate a scale factor between `top_scale` and `bottom_scale`.
+///
+/// `normalized_y` is clamped to `[0.0, 1.0]`, where 0.0 yields `top_scale`
+/// and 1.0 yields `bottom_scale`. Useful for perspective-style text effects.
 #[inline]
 pub fn vertical_scale(normalized_y: f64, top_scale: f64, bottom_scale: f64) -> f64 {
     top_scale + (bottom_scale - top_scale) * normalized_y.clamp(0.0, 1.0)
 }
 
+/// Calculate the position of a character in a fixed-size grid layout.
+///
+/// Characters fill rows left-to-right, wrapping every `chars_per_row`
+/// characters (treated as at least 1); each cell is `char_width` by
+/// `char_height`.
 #[inline]
 pub fn grid_position<T>(
     char_index: usize,
@@ -126,6 +155,10 @@ where
     )
 }
 
+/// Evaluate a quadratic Bezier curve at parameter `t`.
+///
+/// `t` is clamped to `[0.0, 1.0]`; `p0` and `p2` are the endpoints and `p1`
+/// is the control point.
 #[inline]
 pub fn bezier_point<T>(t: f64, p0: Point<T>, p1: Point<T>, p2: Point<T>) -> Point<T>
 where
@@ -145,6 +178,11 @@ where
     Point::new(T::from_f32(x), T::from_f32(y))
 }
 
+/// Calculate the tangent angle of a quadratic Bezier curve at parameter `t`, in radians.
+///
+/// `t` is clamped to `[0.0, 1.0]`. The angle is derived from the curve's
+/// derivative via `atan2`, suitable for rotating characters to follow the
+/// curve.
 #[inline]
 pub fn bezier_tangent_rotation<T>(t: f64, p0: Point<T>, p1: Point<T>, p2: Point<T>) -> f64
 where
@@ -168,6 +206,11 @@ where
     dy.atan2(dx)
 }
 
+/// Calculate a character transform from a user-supplied parametric path function.
+///
+/// `path_fn` receives the normalized position `t` in `[0.0, 1.0)` for
+/// `char_index` of `total_chars` and returns `(x, y, rotation)`, where the
+/// coordinates are in pixels and the rotation is in radians.
 #[inline]
 pub fn parametric_position<F>(
     char_index: usize,

--- a/crates/flui-geometry/src/traits.rs
+++ b/crates/flui-geometry/src/traits.rs
@@ -203,6 +203,7 @@ pub trait Along {
 /// assert_eq!(width.half(), px(50.0));
 /// ```
 pub trait Half {
+    /// Returns half of this value.
     #[must_use]
     fn half(self) -> Self;
 }
@@ -262,6 +263,7 @@ impl Half for DevicePixels {
 /// assert_eq!(width.double(), px(100.0));
 /// ```
 pub trait Double {
+    /// Returns double of this value.
     #[must_use]
     fn double(self) -> Self;
 }

--- a/crates/flui-geometry/src/transform2d.rs
+++ b/crates/flui-geometry/src/transform2d.rs
@@ -69,11 +69,17 @@ pub struct Transform2D<T: Unit> {
     // 2x3 affine matrix stored as f32
     // [ m11  m12  m31 ]
     // [ m21  m22  m32 ]
+    /// X-axis scale factor (`sx`).
     pub m11: f32,
+    /// Y-axis shear factor (`shy`).
     pub m12: f32,
+    /// X-axis shear factor (`shx`).
     pub m21: f32,
+    /// Y-axis scale factor (`sy`).
     pub m22: f32,
+    /// X translation offset (`tx`).
     pub m31: f32,
+    /// Y translation offset (`ty`).
     pub m32: f32,
     _phantom: PhantomData<T>,
 }

--- a/crates/flui-geometry/src/units.rs
+++ b/crates/flui-geometry/src/units.rs
@@ -1270,6 +1270,10 @@ impl<'a> Sum<&'a DevicePixels> for DevicePixels {
 // String parsing (FromStr)
 // ============================================================================
 
+/// Error returned when a length string fails to parse.
+///
+/// Produced by the [`FromStr`](std::str::FromStr) implementations on unit
+/// types such as [`Pixels`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParseLengthError {
     /// The input string that failed to parse.

--- a/crates/flui-geometry/src/vector.rs
+++ b/crates/flui-geometry/src/vector.rs
@@ -335,6 +335,8 @@ where
         }
     }
 
+    /// Returns a normalized (unit length) vector, or `Vec2::ZERO` if the
+    /// length is near zero.
     #[inline]
     #[must_use]
     pub fn normalize(self) -> Vec2<Pixels> {

--- a/crates/flui-macros/src/lib.rs
+++ b/crates/flui-macros/src/lib.rs
@@ -35,7 +35,9 @@
 //! Authors who pull the derive via the prelude automatically satisfy
 //! this requirement.
 
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+// Ship bar (wave 1): every public item is documented; keep it that way.
+#![deny(missing_docs)]
+#![warn(missing_debug_implementations, rust_2018_idioms)]
 
 mod derive_animatable;
 mod derive_diagnosticable;

--- a/crates/flui-tree/src/lib.rs
+++ b/crates/flui-tree/src/lib.rs
@@ -27,6 +27,8 @@
 
 #![warn(rust_2018_idioms, clippy::all, clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
+// Ship bar (wave 1): every public item is documented; keep it that way.
+#![deny(missing_docs)]
 
 // ============================================================================
 // MODULES

--- a/crates/flui-types/src/gestures/details.rs
+++ b/crates/flui-types/src/gestures/details.rs
@@ -17,6 +17,8 @@ use crate::geometry::{Offset, Pixels};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Details for a tap-down event: the pointer has contacted the screen and
+/// might begin a tap.
 pub struct TapDownDetails {
     /// The global position where the tap occurred
     pub global_position: Offset<Pixels>,
@@ -49,6 +51,8 @@ impl TapDownDetails {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Details for a tap-up event: the pointer that triggered a tap has
+/// stopped contacting the screen.
 pub struct TapUpDetails {
     /// The global position where the tap ended
     pub global_position: Offset<Pixels>,
@@ -85,6 +89,8 @@ impl TapUpDetails {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Details for a drag-start event: the pointer has begun to move and a
+/// drag gesture has been recognized.
 pub struct DragStartDetails {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The time when the drag started
@@ -126,6 +132,8 @@ impl DragStartDetails {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Details for a drag-down event: the pointer has contacted the screen
+/// and might begin a drag.
 pub struct DragDownDetails {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The global position where the pointer contacted
@@ -148,6 +156,8 @@ impl DragDownDetails {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Details for a drag-update event: a dragging pointer has moved, carrying
+/// the movement delta since the previous update.
 pub struct DragUpdateDetails {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The time when the update occurred
@@ -197,6 +207,8 @@ impl DragUpdateDetails {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Details for a drag-end event: the pointer has been released, carrying
+/// the velocity at which it was moving for fling handling.
 pub struct DragEndDetails {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The velocity of the pointer when the drag ended
@@ -230,6 +242,8 @@ impl DragEndDetails {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Details for a scale-start event: the pointers in contact have
+/// established a focal point and a scale gesture has begun.
 pub struct ScaleStartDetails {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The focal point of the pointers in contact with the screen
@@ -252,6 +266,8 @@ impl ScaleStartDetails {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Details for a scale-update event: the pointers have moved, carrying
+/// the new focal point, scale factors, and rotation.
 pub struct ScaleUpdateDetails {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The focal point of the pointers in contact with the screen
@@ -316,6 +332,8 @@ impl ScaleUpdateDetails {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Details for a scale-end event: the pointers are no longer in contact
+/// with the screen and the scale gesture has ended.
 pub struct ScaleEndDetails {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The velocity of the gesture
@@ -342,6 +360,8 @@ impl ScaleEndDetails {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Details for a long-press-down event: the pointer has contacted the
+/// screen and might begin a long press.
 pub struct LongPressDownDetails {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The global position where the pointer contacted
@@ -375,6 +395,8 @@ impl LongPressDownDetails {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Details for a long-press-start event: the pointer has remained in
+/// contact long enough for a long press to be recognized.
 pub struct LongPressStartDetails {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
     /// The global position where the long press started
@@ -397,6 +419,8 @@ impl LongPressStartDetails {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Details for a long-press-move-update event: the pointer has moved
+/// while the long press is held, carrying offsets from the press origin.
 pub struct LongPressMoveUpdateDetails {
     /// The global position of the pointer
     pub global_position: Offset<Pixels>,
@@ -431,6 +455,8 @@ impl LongPressMoveUpdateDetails {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Details for a long-press-end event: the pointer that held the long
+/// press has stopped contacting the screen.
 pub struct LongPressEndDetails {
     /// The global position where the long press ended
     pub global_position: Offset<Pixels>,
@@ -464,6 +490,8 @@ impl LongPressEndDetails {
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Details for a force-press event: the pointer's pressure on a
+/// pressure-sensitive screen, along with its position.
 pub struct ForcePressDetails {
     /// The global position of the pointer
     pub global_position: Offset<Pixels>,

--- a/crates/flui-types/src/layout/alignment.rs
+++ b/crates/flui-types/src/layout/alignment.rs
@@ -7,6 +7,9 @@ use std::ops::{Add, Neg};
 
 use crate::geometry::{Offset, Pixels, Rect, Size};
 
+/// How much space a flex container should occupy in its main axis.
+///
+/// Mirrors Flutter's `MainAxisSize`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MainAxisSize {
@@ -16,6 +19,9 @@ pub enum MainAxisSize {
     /// children.
     Min,
 
+    /// Maximize the amount of space along the main axis (the default).
+    ///
+    /// The widget expands to fill the incoming main-axis constraint.
     #[default]
     Max,
 }
@@ -34,10 +40,18 @@ impl MainAxisSize {
     }
 }
 
+/// How children should be placed along the main axis of a flex layout
+/// (the horizontal axis for `Row`, the vertical axis for `Column`).
+///
+/// Mirrors Flutter's `MainAxisAlignment`.
 #[derive(Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MainAxisAlignment {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
+    /// Place children at the start of the main axis (the default).
+    ///
+    /// For Row: left side (in LTR)
+    /// For Column: top side
     #[default]
     Start,
 
@@ -138,10 +152,18 @@ impl MainAxisAlignment {
     }
 }
 
+/// How children should be placed along the cross axis of a flex layout
+/// (the vertical axis for `Row`, the horizontal axis for `Column`).
+///
+/// Mirrors Flutter's `CrossAxisAlignment`.
 #[derive(Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CrossAxisAlignment {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
+    /// Place children at the start of the cross axis (the default).
+    ///
+    /// For Row: top side
+    /// For Column: left side (in LTR)
     #[default]
     Start,
 
@@ -188,6 +210,13 @@ impl CrossAxisAlignment {
     }
 }
 
+/// A point within a rectangle, in normalized coordinates.
+///
+/// Mirrors Flutter's `Alignment`: both axes run from -1.0 to 1.0,
+/// where (-1, -1) is the top-left corner, (0, 0) the center, and
+/// (1, 1) the bottom-right corner. Values outside that range place
+/// the point outside the rectangle. For text-direction-aware
+/// alignment, use `AlignmentDirectional`.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Alignment {
@@ -356,6 +385,12 @@ impl Neg for Alignment {
     }
 }
 
+/// An `Alignment` whose horizontal component depends on text direction.
+///
+/// Mirrors Flutter's `AlignmentDirectional`: `start` is the reading
+/// edge (left in LTR, right in RTL) and must be resolved with
+/// [`resolve`](Self::resolve) before use; the vertical axis matches
+/// `Alignment`.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AlignmentDirectional {
@@ -450,6 +485,10 @@ impl Neg for AlignmentDirectional {
     }
 }
 
+/// Either an absolute or a text-direction-relative alignment.
+///
+/// Mirrors Flutter's `AlignmentGeometry` base class as a Rust enum;
+/// call [`resolve`](Self::resolve) to obtain an absolute `Alignment`.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AlignmentGeometry {

--- a/crates/flui-types/src/layout/alignment.rs
+++ b/crates/flui-types/src/layout/alignment.rs
@@ -44,7 +44,7 @@ impl MainAxisSize {
 /// (the horizontal axis for `Row`, the vertical axis for `Column`).
 ///
 /// Mirrors Flutter's `MainAxisAlignment`.
-#[derive(Default)]
+#[derive(Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MainAxisAlignment {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
@@ -156,7 +156,7 @@ impl MainAxisAlignment {
 /// (the vertical axis for `Row`, the horizontal axis for `Column`).
 ///
 /// Mirrors Flutter's `CrossAxisAlignment`.
-#[derive(Default)]
+#[derive(Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CrossAxisAlignment {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked

--- a/crates/flui-types/src/layout/baseline.rs
+++ b/crates/flui-types/src/layout/baseline.rs
@@ -1,5 +1,10 @@
 //! Baseline types for text alignment
 
+/// A horizontal line used for aligning text, equivalent to Flutter's
+/// `TextBaseline`.
+///
+/// Baseline-aligned layout (e.g. `CrossAxisAlignment::Baseline`) lines up
+/// children along the selected baseline kind rather than their box edges.
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TextBaseline {

--- a/crates/flui-types/src/layout/flex.rs
+++ b/crates/flui-types/src/layout/flex.rs
@@ -1,9 +1,16 @@
 //! Flex layout types
 
+/// How a flexible child is inscribed into the space allocated by a
+/// flex layout.
+///
+/// Mirrors Flutter's `FlexFit`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FlexFit {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
+    /// Child is forced to fill the available space (the default).
+    ///
+    /// This is the behavior for `Expanded` widgets.
     #[default]
     Tight,
 
@@ -16,18 +23,21 @@ pub enum FlexFit {
 }
 
 impl FlexFit {
+    /// Returns `true` if this is `FlexFit::Tight`.
     #[must_use]
     #[inline]
     pub const fn is_tight(&self) -> bool {
         matches!(self, FlexFit::Tight)
     }
 
+    /// Returns `true` if this is `FlexFit::Loose`.
     #[must_use]
     #[inline]
     pub const fn is_loose(&self) -> bool {
         matches!(self, FlexFit::Loose)
     }
 
+    /// Returns the opposite fit (`Tight` ↔ `Loose`).
     #[must_use]
     #[inline]
     pub const fn flip(&self) -> Self {

--- a/crates/flui-types/src/layout/fractional_offset.rs
+++ b/crates/flui-types/src/layout/fractional_offset.rs
@@ -4,6 +4,11 @@
 //! -1.0 to 1.0 coordinates, `FractionalOffset` uses 0.0 to 1.0 where
 //! (0.0, 0.0) is the top-left corner.
 
+/// An offset expressed as a fraction of a container's size.
+///
+/// Mirrors Flutter's `FractionalOffset`. Unlike `Alignment`, which is
+/// centered at (0, 0), coordinates run from 0.0 to 1.0 with (0, 0) at
+/// the top-left corner and (1, 1) at the bottom-right corner.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FractionalOffset {
     /// The distance fraction in the horizontal direction.
@@ -45,12 +50,16 @@ impl FractionalOffset {
     /// The bottom-right corner (1.0, 1.0).
     pub const BOTTOM_RIGHT: Self = Self { dx: 1.0, dy: 1.0 };
 
+    /// Creates a fractional offset with the given horizontal and
+    /// vertical fractions.
     #[must_use]
     #[inline]
     pub const fn new(dx: f32, dy: f32) -> Self {
         Self { dx, dy }
     }
 
+    /// Converts an `Alignment` (-1.0..=1.0 coordinates) into the
+    /// equivalent fractional offset (0.0..=1.0 coordinates).
     #[must_use]
     #[inline]
     #[allow(clippy::manual_midpoint)]
@@ -61,12 +70,20 @@ impl FractionalOffset {
         }
     }
 
+    /// Converts this fractional offset into the equivalent `Alignment`
+    /// (-1.0..=1.0 coordinates); the inverse of
+    /// [`from_alignment`](Self::from_alignment).
     #[must_use]
     #[inline]
     pub fn to_alignment(&self) -> crate::layout::Alignment {
         crate::layout::Alignment::new(self.dx * 2.0 - 1.0, self.dy * 2.0 - 1.0)
     }
 
+    /// Linearly interpolates between two fractional offsets.
+    ///
+    /// `t == 0.0` returns `a`; `t == 1.0` returns `b`. Values of `t`
+    /// outside `[0, 1]` extrapolate — they are **not** clamped,
+    /// matching `Alignment::lerp`.
     #[must_use]
     #[inline]
     pub fn lerp(a: Self, b: Self, t: f32) -> Self {
@@ -76,12 +93,16 @@ impl FractionalOffset {
         }
     }
 
+    /// Returns `true` if both `dx` and `dy` are finite
+    /// (neither infinite nor NaN).
     #[must_use]
     #[inline]
     pub fn is_finite(&self) -> bool {
         self.dx.is_finite() && self.dy.is_finite()
     }
 
+    /// Returns the offset with both components negated
+    /// (the `-` operator delegates to this).
     #[must_use]
     #[inline]
     pub fn negate(&self) -> Self {

--- a/crates/flui-types/src/layout/fractional_offset.rs
+++ b/crates/flui-types/src/layout/fractional_offset.rs
@@ -9,6 +9,7 @@
 /// Mirrors Flutter's `FractionalOffset`. Unlike `Alignment`, which is
 /// centered at (0, 0), coordinates run from 0.0 to 1.0 with (0, 0) at
 /// the top-left corner and (1, 1) at the bottom-right corner.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FractionalOffset {
     /// The distance fraction in the horizontal direction.

--- a/crates/flui-types/src/layout/stack.rs
+++ b/crates/flui-types/src/layout/stack.rs
@@ -1,8 +1,16 @@
 //! Stack layout types
 
+/// How a `Stack` sizes its non-positioned children.
+///
+/// Mirrors Flutter's `StackFit`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum StackFit {
+    /// The constraints passed to the stack from its parent are loosened
+    /// (the default).
+    ///
+    /// Non-positioned children may be any size up to the stack's
+    /// incoming maximum constraints.
     #[default]
     Loose,
 

--- a/crates/flui-types/src/layout/table.rs
+++ b/crates/flui-types/src/layout/table.rs
@@ -34,7 +34,11 @@ pub enum TableColumnWidth {
     ///
     /// Flutter parity: `IntrinsicColumnWidth({double? flex})`
     /// (`rendering/table.dart:94`).
-    Intrinsic { flex: Option<f32> },
+    Intrinsic {
+        /// Optional flex factor for distributing leftover space;
+        /// `None` means the column never takes extra space.
+        flex: Option<f32>,
+    },
 
     /// Fraction of available width (0.0-1.0).
     ///

--- a/crates/flui-types/src/layout/viewport.rs
+++ b/crates/flui-types/src/layout/viewport.rs
@@ -2,10 +2,16 @@
 //!
 //! Types for configuring viewport caching behavior.
 
+/// How a viewport's cache extent value should be interpreted.
+///
+/// Mirrors Flutter's `CacheExtentStyle`. The cache extent is the area
+/// beyond the visible bounds where children are still laid out (and
+/// pre-rendered) so scrolling reveals them without jank.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CacheExtentStyle {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
+    /// Cache extent is an absolute value in logical pixels (the default).
     #[default]
     Pixel,
 

--- a/crates/flui-types/src/layout/wrap.rs
+++ b/crates/flui-types/src/layout/wrap.rs
@@ -1,8 +1,14 @@
 //! Wrap layout types
 
+/// How children within a run should be placed in the main axis of a
+/// `Wrap` layout.
+///
+/// Mirrors Flutter's `WrapAlignment`. Applies to each run (line)
+/// independently.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum WrapAlignment {
+    /// Place children at the start of each run (the default).
     #[default]
     Start,
 
@@ -27,6 +33,8 @@ pub enum WrapAlignment {
 }
 
 impl WrapAlignment {
+    /// Returns `true` for the space-distributing variants
+    /// (`SpaceBetween`, `SpaceAround`, `SpaceEvenly`).
     #[must_use]
     #[inline]
     pub const fn uses_spacing(&self) -> bool {
@@ -36,12 +44,15 @@ impl WrapAlignment {
         )
     }
 
+    /// Returns `true` if children are packed against a run edge
+    /// (`Start` or `End`).
     #[must_use]
     #[inline]
     pub const fn is_edge_aligned(&self) -> bool {
         matches!(self, WrapAlignment::Start | WrapAlignment::End)
     }
 
+    /// Returns `true` if this is `Center`.
     #[must_use]
     #[inline]
     pub const fn is_centered(&self) -> bool {
@@ -49,9 +60,14 @@ impl WrapAlignment {
     }
 }
 
+/// How children within a run should be aligned relative to each other
+/// in the cross axis of a `Wrap` layout.
+///
+/// Mirrors Flutter's `WrapCrossAlignment`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum WrapCrossAlignment {
+    /// Place runs at the start of the cross axis (the default).
     #[default]
     Start,
 
@@ -63,12 +79,15 @@ pub enum WrapCrossAlignment {
 }
 
 impl WrapCrossAlignment {
+    /// Returns `true` if runs are packed against a cross-axis edge
+    /// (`Start` or `End`).
     #[must_use]
     #[inline]
     pub const fn is_edge_aligned(&self) -> bool {
         matches!(self, WrapCrossAlignment::Start | WrapCrossAlignment::End)
     }
 
+    /// Returns `true` if this is `Center`.
     #[must_use]
     #[inline]
     pub const fn is_centered(&self) -> bool {

--- a/crates/flui-types/src/lib.rs
+++ b/crates/flui-types/src/lib.rs
@@ -85,8 +85,6 @@
 
 // Ship bar (wave 1): every public item is documented; keep it that way.
 #![deny(missing_docs)]
-#![allow(missing_debug_implementations)]
-// TODO(ship-wave-1): add Debug impls (28 types), then delete
 // Math-crate idiom shared with flui-geometry (see its lib.rs): permanent
 // crate-specific relaxations of workspace pedantic lints for math-heavy code.
 // (The float-comparison / numeric-cast family is allowed workspace-wide.)

--- a/crates/flui-types/src/lib.rs
+++ b/crates/flui-types/src/lib.rs
@@ -83,7 +83,8 @@
 //! etc.) have been moved to `flui_rendering::constraints` as they are part of
 //! the rendering protocol rather than basic types.
 
-#![allow(missing_docs)] // TODO(ship-wave-1): 486-item doc backlog — burn down per module, then delete this line
+// Ship bar (wave 1): every public item is documented; keep it that way.
+#![deny(missing_docs)]
 #![allow(missing_debug_implementations)]
 // TODO(ship-wave-1): add Debug impls (28 types), then delete
 // Math-crate idiom shared with flui-geometry (see its lib.rs): permanent

--- a/crates/flui-types/src/painting/blend_mode.rs
+++ b/crates/flui-types/src/painting/blend_mode.rs
@@ -1,5 +1,11 @@
 //! Blend modes for compositing colors.
 
+/// Algorithms for blending a source (the pixels being drawn) with a
+/// destination (the pixels already on the canvas).
+///
+/// The first fourteen variants are Porter-Duff compositing operators; the
+/// rest are "advanced" (separable and non-separable) blend modes matching
+/// CSS/Skia semantics. Mirrors Flutter's `BlendMode`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BlendMode {
@@ -18,6 +24,10 @@ pub enum BlendMode {
     /// This corresponds to the "dst" Porter-Duff operator.
     Dst,
 
+    /// Composite the source over the destination.
+    ///
+    /// This is the default blend mode for ordinary painting and corresponds
+    /// to the "src-over" Porter-Duff operator.
     #[default]
     SrcOver,
 
@@ -153,6 +163,8 @@ pub enum BlendMode {
 }
 
 impl BlendMode {
+    /// Returns `true` if this is one of the fourteen Porter-Duff compositing
+    /// operators (`Clear` through `Modulate`).
     #[must_use]
     #[inline]
     pub const fn is_porter_duff(&self) -> bool {
@@ -175,18 +187,26 @@ impl BlendMode {
         )
     }
 
+    /// Returns `true` if the result depends on the destination pixels.
+    ///
+    /// Only `Clear` and `Src` ignore the destination entirely; every other
+    /// mode must read the existing pixels to compute its output.
     #[must_use]
     #[inline]
     pub const fn requires_destination(&self) -> bool {
         !matches!(self, BlendMode::Clear | BlendMode::Src)
     }
 
+    /// Returns `true` for the advanced (non-Porter-Duff) blend modes, i.e.
+    /// `Screen` and beyond.
     #[must_use]
     #[inline]
     pub const fn is_advanced(&self) -> bool {
         !self.is_porter_duff()
     }
 
+    /// Returns `true` for modes that can only lighten colors
+    /// (`Screen`, `Lighten`, `ColorDodge`, `Plus`).
     #[must_use]
     #[inline]
     pub const fn can_lighten(&self) -> bool {
@@ -196,6 +216,8 @@ impl BlendMode {
         )
     }
 
+    /// Returns `true` for modes that can only darken colors
+    /// (`Darken`, `ColorBurn`, `Multiply`, `Modulate`).
     #[must_use]
     #[inline]
     pub const fn can_darken(&self) -> bool {
@@ -205,6 +227,8 @@ impl BlendMode {
         )
     }
 
+    /// Returns `true` if this mode is purely compositional (alpha-driven)
+    /// rather than a color blend; currently an alias for `is_porter_duff`.
     #[must_use]
     #[inline]
     pub const fn is_compositional(&self) -> bool {

--- a/crates/flui-types/src/painting/canvas.rs
+++ b/crates/flui-types/src/painting/canvas.rs
@@ -81,7 +81,7 @@ pub enum FilterQuality {
 }
 
 /// Whether to paint a shape's interior, or its outline.
-#[derive(Default)]
+#[derive(Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PaintingStyle {
     /// Fill the interior of the shape with the paint's color.
@@ -93,6 +93,7 @@ pub enum PaintingStyle {
 }
 
 /// Boolean operations for combining two paths.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PathOperation {
     /// Subtract the second path from the first path.
@@ -170,7 +171,7 @@ pub enum StrokeJoin {
 }
 
 /// How a list of vertices is interpreted when drawing a triangle mesh.
-#[derive(Default)]
+#[derive(Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum VertexMode {
     /// Draw each sequence of three vertices as a separate triangle.

--- a/crates/flui-types/src/painting/canvas.rs
+++ b/crates/flui-types/src/painting/canvas.rs
@@ -1,8 +1,12 @@
 //! Canvas painting primitives.
 
+/// How a shader (gradient or image) samples beyond its defined bounds.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TileMode {
+    /// Edge colors are extended (clamped) beyond the bounds.
+    ///
+    /// Samples outside the gradient or image use the nearest edge color.
     #[default]
     Clamp,
 
@@ -23,9 +27,13 @@ pub enum TileMode {
     Decal,
 }
 
+/// Styles for blur effects in a mask filter.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BlurStyle {
+    /// Blur inside and outside the shape.
+    ///
+    /// This is the typical Gaussian blur applied across the shape's edge.
     #[default]
     Normal,
 
@@ -46,6 +54,7 @@ pub enum BlurStyle {
     Inner,
 }
 
+/// Quality levels for sampling images and scaled textures.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FilterQuality {
@@ -54,6 +63,9 @@ pub enum FilterQuality {
     /// Fastest, but lowest quality. Good for pixel art.
     None,
 
+    /// Bilinear interpolation.
+    ///
+    /// A reasonable quality/performance trade-off; the default.
     #[default]
     Low,
 
@@ -68,9 +80,11 @@ pub enum FilterQuality {
     High,
 }
 
+/// Whether to paint a shape's interior, or its outline.
 #[derive(Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PaintingStyle {
+    /// Fill the interior of the shape with the paint's color.
     #[default]
     Fill,
 
@@ -78,6 +92,7 @@ pub enum PaintingStyle {
     Stroke,
 }
 
+/// Boolean operations for combining two paths.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PathOperation {
     /// Subtract the second path from the first path.
@@ -107,9 +122,14 @@ pub enum PathOperation {
     ReverseDifference,
 }
 
+/// Fill rules that determine which regions of a path are inside it.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PathFillType {
+    /// The non-zero winding rule.
+    ///
+    /// A point is inside the path if the signed sum of edge crossings
+    /// (winding number) is non-zero.
     #[default]
     NonZero,
 
@@ -119,9 +139,11 @@ pub enum PathFillType {
     EvenOdd,
 }
 
+/// Styles for the endings of unclosed stroked contours.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum StrokeCap {
+    /// Begin and end contours with a flat edge and no extension.
     #[default]
     Butt,
 
@@ -132,9 +154,11 @@ pub enum StrokeCap {
     Square,
 }
 
+/// Styles for the joints between stroked line segments.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum StrokeJoin {
+    /// Join line segments with a sharp corner, extended to the miter limit.
     #[default]
     Miter,
 
@@ -145,9 +169,13 @@ pub enum StrokeJoin {
     Bevel,
 }
 
+/// How a list of vertices is interpreted when drawing a triangle mesh.
 #[derive(Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum VertexMode {
+    /// Draw each sequence of three vertices as a separate triangle.
+    ///
+    /// Vertices 0, 1, 2 form a triangle, then 3, 4, 5, etc.
     #[default]
     Triangles,
 
@@ -162,23 +190,29 @@ pub enum VertexMode {
     TriangleFan,
 }
 
+/// An opaque identifier for a texture registered with the rendering engine.
+///
+/// The raw value `0` is reserved as the null identifier (see `is_null`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextureId(u64);
 
 impl TextureId {
+    /// Creates a texture identifier wrapping the given raw id.
     #[must_use]
     #[inline]
     pub const fn new(id: u64) -> Self {
         Self(id)
     }
 
+    /// Returns the raw `u64` value of this identifier.
     #[must_use]
     #[inline]
     pub const fn get(self) -> u64 {
         self.0
     }
 
+    /// Returns `true` if this is the null identifier (raw value `0`).
     #[must_use]
     #[inline]
     pub const fn is_null(self) -> bool {
@@ -200,9 +234,11 @@ impl From<TextureId> for u64 {
     }
 }
 
+/// How a list of points is interpreted when drawn to a canvas.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PointMode {
+    /// Draw each point as a separate dot.
     #[default]
     Points,
 
@@ -220,24 +256,29 @@ pub enum PointMode {
 }
 
 impl PointMode {
+    /// Returns `true` if this is `PointMode::Points`.
     #[must_use]
     #[inline]
     pub const fn is_points(&self) -> bool {
         matches!(self, PointMode::Points)
     }
 
+    /// Returns `true` if this is `PointMode::Lines`.
     #[must_use]
     #[inline]
     pub const fn is_lines(&self) -> bool {
         matches!(self, PointMode::Lines)
     }
 
+    /// Returns `true` if this is `PointMode::Polygon`.
     #[must_use]
     #[inline]
     pub const fn is_polygon(&self) -> bool {
         matches!(self, PointMode::Polygon)
     }
 
+    /// Returns the minimum number of points needed to draw anything in this
+    /// mode (1 for points, 2 for lines, 3 for a polygon).
     #[must_use]
     #[inline]
     pub const fn min_points(&self) -> usize {

--- a/crates/flui-types/src/painting/clipping.rs
+++ b/crates/flui-types/src/painting/clipping.rs
@@ -2,9 +2,12 @@
 
 use crate::geometry::{Offset, Pixels, Rect, Size, px};
 
+/// How a new clip region combines with the current clip.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ClipOp {
+    /// The new region is intersected with the current clip.
+    /// Only pixels inside both regions remain visible.
     #[default]
     Intersect,
     /// The new region is subtracted from the current clip.
@@ -12,6 +15,9 @@ pub enum ClipOp {
     Difference,
 }
 
+/// The quality (and cost) with which content is clipped.
+///
+/// Ordered from cheapest to most expensive; mirrors Flutter's `Clip` enum.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Clip {
@@ -21,6 +27,10 @@ pub enum Clip {
     /// will not exceed the bounds of the box, use this.
     None,
 
+    /// Clip, but do not apply anti-aliasing.
+    ///
+    /// Faster than `AntiAlias`, but jagged on non-axis-aligned edges. This is
+    /// the default and is appropriate for rectangular clips.
     #[default]
     HardEdge,
 
@@ -39,24 +49,29 @@ pub enum Clip {
 }
 
 impl Clip {
+    /// Returns `true` if this mode applies anti-aliasing to clip edges.
     #[must_use]
     #[inline]
     pub const fn is_anti_aliased(&self) -> bool {
         matches!(self, Clip::AntiAlias | Clip::AntiAliasWithSaveLayer)
     }
 
+    /// Returns `true` if this mode saves a layer in addition to clipping.
     #[must_use]
     #[inline]
     pub const fn saves_layer(&self) -> bool {
         matches!(self, Clip::AntiAliasWithSaveLayer)
     }
 
+    /// Returns `true` if this mode performs any clipping at all.
     #[must_use]
     #[inline]
     pub const fn clips(&self) -> bool {
         !matches!(self, Clip::None)
     }
 
+    /// Returns `true` for the cheap modes (`None` and `HardEdge`) that need
+    /// neither anti-aliasing nor a saved layer.
     #[must_use]
     #[inline]
     pub const fn is_efficient(&self) -> bool {
@@ -64,12 +79,14 @@ impl Clip {
     }
 }
 
+/// Widget-level clipping behavior, convertible to a low-level [`Clip`] mode.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ClipBehavior {
     /// No clipping.
     None,
 
+    /// Clip without anti-aliasing; the default.
     #[default]
     HardEdge,
 
@@ -86,6 +103,7 @@ pub enum ClipBehavior {
 }
 
 impl ClipBehavior {
+    /// Converts this behavior to the equivalent low-level [`Clip`] mode.
     #[must_use]
     #[inline]
     pub const fn to_clip(self) -> Clip {
@@ -97,12 +115,14 @@ impl ClipBehavior {
         }
     }
 
+    /// Returns `true` if this behavior performs any clipping at all.
     #[must_use]
     #[inline]
     pub const fn clips(self) -> bool {
         !matches!(self, ClipBehavior::None)
     }
 
+    /// Returns `true` if this behavior applies anti-aliasing to clip edges.
     #[must_use]
     #[inline]
     pub const fn is_anti_aliased(self) -> bool {
@@ -141,6 +161,10 @@ pub trait NotchedShape: std::fmt::Debug {
     ) -> Vec<Offset<Pixels>>;
 }
 
+/// A rectangle with a semi-circular notch cut out of its top edge.
+///
+/// Similar to Flutter's `CircularNotchedRectangle`; used by a bottom app bar
+/// to make room for a circular floating action button.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CircularNotchedRectangle {
@@ -149,12 +173,15 @@ pub struct CircularNotchedRectangle {
 }
 
 impl CircularNotchedRectangle {
+    /// Creates a circular notched rectangle with the default margin (4.0).
     #[must_use]
     #[inline]
     pub const fn new() -> Self {
         Self { margin: 4.0 }
     }
 
+    /// Creates a circular notched rectangle with the given margin around the
+    /// guest.
     #[must_use]
     #[inline]
     pub const fn with_margin(margin: f32) -> Self {
@@ -228,6 +255,8 @@ impl NotchedShape for CircularNotchedRectangle {
     }
 }
 
+/// A [`NotchedShape`] wrapper that scales the guest rectangle around its
+/// center before delegating to the inner shape.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AutomaticNotchedShape<T: NotchedShape> {
@@ -239,12 +268,15 @@ pub struct AutomaticNotchedShape<T: NotchedShape> {
 }
 
 impl<T: NotchedShape> AutomaticNotchedShape<T> {
+    /// Wraps `inner` without scaling the guest (scale factor 1.0).
     #[must_use]
     #[inline]
     pub const fn new(inner: T) -> Self {
         Self { inner, scale: 1.0 }
     }
 
+    /// Wraps `inner`, scaling the guest rectangle by `scale` around its
+    /// center before computing the notch.
     #[must_use]
     #[inline]
     pub const fn with_scale(inner: T, scale: f32) -> Self {

--- a/crates/flui-types/src/painting/paint.rs
+++ b/crates/flui-types/src/painting/paint.rs
@@ -372,6 +372,7 @@ impl PaintStyle {
 }
 
 /// Builder for constructing `Paint` instances.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PaintBuilder {
     paint: Paint,

--- a/crates/flui-types/src/painting/path.rs
+++ b/crates/flui-types/src/painting/path.rs
@@ -10,6 +10,7 @@ use crate::{
     painting::PathFillType,
 };
 
+/// A single drawing command within a [`Path`].
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PathCommand {
@@ -52,6 +53,11 @@ pub enum PathCommand {
     AddArc(Rect<Pixels>, f32, f32),
 }
 
+/// A sequence of drawing commands describing a vector shape.
+///
+/// A path is an ordered list of [`PathCommand`]s (lines, Bézier curves, and
+/// whole shapes) plus a [`PathFillType`] that determines which regions count
+/// as inside when filling or hit-testing.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Path {
@@ -67,6 +73,7 @@ pub struct Path {
 }
 
 impl Path {
+    /// Creates an empty path with the default fill type (non-zero).
     #[must_use]
     #[inline]
     pub fn new() -> Self {
@@ -77,6 +84,7 @@ impl Path {
         }
     }
 
+    /// Creates an empty path with the given fill type.
     #[must_use]
     #[inline]
     pub fn with_fill_type(fill_type: PathFillType) -> Self {
@@ -87,6 +95,7 @@ impl Path {
         }
     }
 
+    /// Creates a path consisting of a single rectangle.
     #[must_use]
     #[inline]
     pub fn rectangle(rect: Rect<Pixels>) -> Self {
@@ -95,6 +104,7 @@ impl Path {
         path
     }
 
+    /// Creates a path consisting of a single oval inscribed in `rect`.
     #[must_use]
     #[inline]
     pub fn oval(rect: Rect<Pixels>) -> Self {
@@ -141,6 +151,10 @@ impl Path {
         path
     }
 
+    /// Creates a path consisting of a single arc.
+    ///
+    /// The arc lies on the oval inscribed in `rect`, starting at
+    /// `start_angle` and sweeping by `sweep_angle` (both in radians).
     #[must_use]
     #[inline]
     pub fn arc(rect: Rect<Pixels>, start_angle: f32, sweep_angle: f32) -> Self {
@@ -149,6 +163,10 @@ impl Path {
         path
     }
 
+    /// Creates a path outlining a rounded rectangle.
+    ///
+    /// Corners are approximated with quarter-circle arcs; a rounded rectangle
+    /// with no rounding degenerates to a plain rectangle.
     #[must_use]
     #[inline]
     pub fn from_rrect(rrect: crate::geometry::RRect) -> Self {
@@ -240,11 +258,13 @@ impl Path {
         path
     }
 
+    /// Sets the fill type used for filling and containment tests.
     #[inline]
     pub fn set_fill_type(&mut self, fill_type: PathFillType) {
         self.fill_type = fill_type;
     }
 
+    /// Returns the path's current fill type.
     #[must_use]
     #[inline]
     pub const fn fill_type(&self) -> PathFillType {
@@ -269,35 +289,42 @@ impl Path {
         }
     }
 
+    /// Starts a new subpath at `point` without drawing.
     #[inline]
     pub fn move_to(&mut self, point: Point<Pixels>) {
         self.commands.push(PathCommand::MoveTo(point));
         self.bounds = None;
     }
 
+    /// Adds a straight line from the current position to `point`.
     #[inline]
     pub fn line_to(&mut self, point: Point<Pixels>) {
         self.commands.push(PathCommand::LineTo(point));
         self.bounds = None;
     }
 
+    /// Closes the current subpath with a line back to its starting point.
     #[inline]
     pub fn close(&mut self) {
         self.commands.push(PathCommand::Close);
     }
 
+    /// Adds a rectangle as a separate subpath.
     #[inline]
     pub fn add_rect(&mut self, rect: Rect<Pixels>) {
         self.commands.push(PathCommand::AddRect(rect));
         self.bounds = None;
     }
 
+    /// Adds an oval inscribed in `rect` as a separate subpath.
     #[inline]
     pub fn add_oval(&mut self, rect: Rect<Pixels>) {
         self.commands.push(PathCommand::AddOval(rect));
         self.bounds = None;
     }
 
+    /// Adds an arc on the oval inscribed in `rect`, starting at `start_angle`
+    /// and sweeping by `sweep_angle` (both in radians).
     #[inline]
     pub fn add_arc(&mut self, rect: Rect<Pixels>, start_angle: f32, sweep_angle: f32) {
         self.commands
@@ -305,30 +332,41 @@ impl Path {
         self.bounds = None;
     }
 
+    /// Returns the path's commands in insertion order.
     #[must_use]
     #[inline]
     pub fn commands(&self) -> &[PathCommand] {
         &self.commands
     }
 
+    /// Returns `true` if the path contains no commands.
     #[must_use]
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.commands.is_empty()
     }
 
+    /// Removes all commands, leaving the path empty.
+    ///
+    /// The fill type is preserved; the cached bounds are invalidated.
     #[inline]
     pub fn reset(&mut self) {
         self.commands.clear();
         self.bounds = None;
     }
 
+    /// Returns the cached bounding box, if one has been computed via
+    /// `bounds` and not invalidated by a later mutation.
     #[must_use]
     #[inline]
     pub fn cached_bounds(&self) -> Option<Rect<Pixels>> {
         self.bounds
     }
 
+    /// Computes the bounding box of the path without caching the result.
+    ///
+    /// Uses the cached value when available. Curve bounds are conservative
+    /// (control points are included). Returns `Rect::ZERO` for an empty path.
     #[must_use]
     #[inline]
     pub fn compute_bounds(&self) -> Rect<Pixels> {
@@ -395,6 +433,11 @@ impl Path {
         }
     }
 
+    /// Returns the bounding box of the path, computing and caching it if
+    /// necessary.
+    ///
+    /// Same semantics as `compute_bounds`, but stores the result so later
+    /// calls are free until the path is mutated.
     #[must_use]
     #[inline]
     pub fn bounds(&mut self) -> Rect<Pixels> {
@@ -407,6 +450,7 @@ impl Path {
         bounds
     }
 
+    /// Returns a copy of this path with every command translated by `offset`.
     #[must_use]
     #[inline]
     pub fn translate(&self, offset: Offset<Pixels>) -> Self {

--- a/crates/flui-types/src/physics/friction.rs
+++ b/crates/flui-types/src/physics/friction.rs
@@ -12,6 +12,7 @@ use super::{Simulation, Tolerance};
 /// coefficient). The simulation is done once the speed drops below the
 /// velocity tolerance; position converges to `final_position` but never
 /// reverses direction.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FrictionSimulation {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
@@ -202,6 +203,7 @@ impl Simulation for FrictionSimulation {
 /// `0.0` once the boundary is reached. See
 /// `BoundedFrictionSimulation::new` for the documented divergences from
 /// Flutter's two-bound `BoundedFrictionSimulation`.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BoundedFrictionSimulation {
     // PORT-CHECK-OK-SP3: parallel to flui-animation::simulation::BoundedFrictionSimulation; the two physics layers use distinct Simulation traits (position/velocity here vs x/dx + Send+Sync there). Consolidation tracked.

--- a/crates/flui-types/src/physics/friction.rs
+++ b/crates/flui-types/src/physics/friction.rs
@@ -4,6 +4,14 @@
 
 use super::{Simulation, Tolerance};
 
+/// A friction (exponential deceleration) simulation: velocity decays as
+/// `v(t) = v₀·e^(−k·t)` toward a finite stopping position.
+///
+/// Positions are in logical pixels, time in seconds, `k` is the decay rate
+/// (see `FrictionSimulation::new` for how this differs from Flutter's drag
+/// coefficient). The simulation is done once the speed drops below the
+/// velocity tolerance; position converges to `final_position` but never
+/// reverses direction.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FrictionSimulation {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
@@ -56,6 +64,10 @@ impl FrictionSimulation {
         }
     }
 
+    /// Returns the simulation with its tolerance replaced (builder style).
+    ///
+    /// The velocity tolerance controls when `is_done` reports the motion as
+    /// stopped.
     #[must_use]
     #[inline]
     pub fn with_tolerance(mut self, tolerance: Tolerance) -> Self {
@@ -63,30 +75,38 @@ impl FrictionSimulation {
         self
     }
 
+    /// Returns the exponential decay rate `k` (per second); higher values
+    /// mean stronger friction.
     #[must_use]
     #[inline]
     pub fn decay_rate(&self) -> f32 {
         self.decay_rate
     }
 
+    /// Returns the position at `t = 0`, in logical pixels.
     #[must_use]
     #[inline]
     pub fn start_position(&self) -> f32 {
         self.position_at_zero
     }
 
+    /// Returns the velocity at `t = 0`, in logical pixels per second.
     #[must_use]
     #[inline]
     pub fn initial_velocity(&self) -> f32 {
         self.velocity_at_zero
     }
 
+    /// Returns the position the simulation converges to as `t → ∞`:
+    /// `x₀ + v₀/k`, in logical pixels.
     #[must_use]
     #[inline]
     pub fn final_position(&self) -> f32 {
         self.position_at_zero + self.velocity_at_zero / self.decay_rate
     }
 
+    /// Returns whether the simulation is well-formed: a positive finite decay
+    /// rate, finite position and velocity, and a valid tolerance.
     #[must_use]
     #[inline]
     pub fn is_valid(&self) -> bool {
@@ -97,6 +117,13 @@ impl FrictionSimulation {
             && self.tolerance.is_valid()
     }
 
+    /// Returns the time, in seconds, at which the velocity decays to
+    /// `target_velocity`.
+    ///
+    /// Returns `Some(f32::INFINITY)` for a target of exactly `0.0` (the decay
+    /// only reaches zero asymptotically), and `None` when the target is
+    /// unreachable: its magnitude exceeds the initial speed, or its sign
+    /// differs from the initial velocity's.
     #[must_use]
     #[inline]
     pub fn time_to_velocity(&self, target_velocity: f32) -> Option<f32> {
@@ -118,6 +145,11 @@ impl FrictionSimulation {
         Some(-ratio.ln() / self.decay_rate)
     }
 
+    /// Returns the signed distance travelled, in logical pixels, until the
+    /// velocity decays to `target_velocity`.
+    ///
+    /// When the target velocity is unreachable, returns the total remaining
+    /// travel (`final_position` minus the start position) instead.
     #[must_use]
     #[inline]
     pub fn distance_to_velocity(&self, target_velocity: f32) -> f32 {
@@ -128,6 +160,10 @@ impl FrictionSimulation {
         }
     }
 
+    /// Returns the acceleration `−k·v(t)` at `time` seconds, in logical
+    /// pixels per second squared.
+    ///
+    /// Its sign always opposes the current velocity (friction decelerates).
     #[must_use]
     #[inline]
     pub fn deceleration(&self, time: f32) -> f32 {
@@ -158,6 +194,14 @@ impl Simulation for FrictionSimulation {
     }
 }
 
+/// A friction simulation whose position stops at a single directional
+/// boundary.
+///
+/// The travel direction is inferred from the sign of the initial velocity;
+/// position is clamped at `boundary` in that direction and velocity reports
+/// `0.0` once the boundary is reached. See
+/// `BoundedFrictionSimulation::new` for the documented divergences from
+/// Flutter's two-bound `BoundedFrictionSimulation`.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BoundedFrictionSimulation {
     // PORT-CHECK-OK-SP3: parallel to flui-animation::simulation::BoundedFrictionSimulation; the two physics layers use distinct Simulation traits (position/velocity here vs x/dx + Send+Sync there). Consolidation tracked.
@@ -206,6 +250,8 @@ impl BoundedFrictionSimulation {
         }
     }
 
+    /// Returns the simulation with the underlying friction simulation's
+    /// tolerance replaced (builder style).
     #[must_use]
     #[inline]
     pub fn with_tolerance(mut self, tolerance: Tolerance) -> Self {
@@ -213,18 +259,22 @@ impl BoundedFrictionSimulation {
         self
     }
 
+    /// Returns the boundary position, in logical pixels.
     #[must_use]
     #[inline]
     pub fn boundary(&self) -> f32 {
         self.boundary
     }
 
+    /// Returns a reference to the underlying unbounded friction simulation.
     #[must_use]
     #[inline]
     pub fn inner(&self) -> &FrictionSimulation {
         &self.friction
     }
 
+    /// Returns whether the unbounded simulation's final position reaches or
+    /// passes the boundary in the direction of travel.
     #[must_use]
     #[inline]
     pub fn will_hit_boundary(&self) -> bool {
@@ -236,6 +286,10 @@ impl BoundedFrictionSimulation {
         }
     }
 
+    /// Returns whether the unbounded position at `time` has reached or passed
+    /// the boundary in the direction of travel.
+    ///
+    /// When this is `true`, `velocity` reports `0.0`.
     #[must_use]
     #[inline]
     pub fn is_at_boundary(&self, time: f32) -> bool {
@@ -247,6 +301,8 @@ impl BoundedFrictionSimulation {
         }
     }
 
+    /// Returns whether the simulation is well-formed: a valid underlying
+    /// friction simulation and a finite boundary.
     #[must_use]
     #[inline]
     pub fn is_valid(&self) -> bool {

--- a/crates/flui-types/src/physics/gravity.rs
+++ b/crates/flui-types/src/physics/gravity.rs
@@ -4,6 +4,14 @@
 
 use super::{Simulation, Tolerance};
 
+/// A constant-acceleration simulation: `x(t) = x₀ + v₀·t + ½·a·t²`.
+///
+/// Positions are in logical pixels, time in seconds, acceleration in logical
+/// pixels per second squared. The simulation is done once the position
+/// reaches or passes the signed target `end` (within the distance tolerance)
+/// in the direction implied by the sign of `acceleration`, or of `velocity`
+/// when acceleration is zero — see `GravitySimulation::new` for how this
+/// diverges from Flutter's magnitude-threshold `endDistance`.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GravitySimulation {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
@@ -61,6 +69,9 @@ impl GravitySimulation {
         }
     }
 
+    /// Returns the simulation with its tolerance replaced (builder style).
+    ///
+    /// The distance tolerance widens the end-position check used by `is_done`.
     #[must_use]
     #[inline]
     pub fn with_tolerance(mut self, tolerance: Tolerance) -> Self {
@@ -68,30 +79,38 @@ impl GravitySimulation {
         self
     }
 
+    /// Returns the constant acceleration, in logical pixels per second
+    /// squared.
     #[must_use]
     #[inline]
     pub fn acceleration(&self) -> f32 {
         self.acceleration
     }
 
+    /// Returns the starting position, in logical pixels.
     #[must_use]
     #[inline]
     pub fn start(&self) -> f32 {
         self.start
     }
 
+    /// Returns the signed target position at which the simulation finishes,
+    /// in logical pixels.
     #[must_use]
     #[inline]
     pub fn end(&self) -> f32 {
         self.end
     }
 
+    /// Returns the initial velocity, in logical pixels per second.
     #[must_use]
     #[inline]
     pub fn initial_velocity(&self) -> f32 {
         self.initial_velocity
     }
 
+    /// Returns whether the simulation is well-formed: finite acceleration,
+    /// start, end, and velocity, and a valid tolerance.
     #[must_use]
     #[inline]
     pub fn is_valid(&self) -> bool {
@@ -102,6 +121,13 @@ impl GravitySimulation {
             && self.tolerance.is_valid()
     }
 
+    /// Returns the earliest non-negative time, in seconds, at which the
+    /// position exactly equals `end`, or `None` if the trajectory never
+    /// reaches it (e.g. gravity pulls away from the target, or the particle
+    /// is not moving).
+    ///
+    /// Solved from the quadratic `½·a·t² + v₀·t − (end − start) = 0`; with
+    /// negligible acceleration the linear case `t = (end − start)/v₀` is used.
     #[must_use]
     #[inline]
     pub fn time_at_end(&self) -> Option<f32> {

--- a/crates/flui-types/src/physics/gravity.rs
+++ b/crates/flui-types/src/physics/gravity.rs
@@ -12,6 +12,7 @@ use super::{Simulation, Tolerance};
 /// in the direction implied by the sign of `acceleration`, or of `velocity`
 /// when acceleration is zero — see `GravitySimulation::new` for how this
 /// diverges from Flutter's magnitude-threshold `endDistance`.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GravitySimulation {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked

--- a/crates/flui-types/src/physics/mod.rs
+++ b/crates/flui-types/src/physics/mod.rs
@@ -42,21 +42,37 @@ pub use tolerance::Tolerance;
 /// ```
 pub trait Simulation {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
+    /// Returns the position at `time` seconds, in logical pixels.
     #[must_use]
     fn position(&self, time: f32) -> f32;
 
+    /// Returns the velocity at `time` seconds, in logical pixels per second.
     #[must_use]
     fn velocity(&self, time: f32) -> f32;
 
+    /// Returns whether the simulation has settled at `time` seconds.
+    ///
+    /// Once this returns `true` the caller may stop sampling; what "settled"
+    /// means (position and/or velocity within [`Tolerance`]) is defined by
+    /// each implementation.
     #[must_use]
     fn is_done(&self, time: f32) -> bool;
 
+    /// Returns the tolerance used to decide when this simulation is done.
+    ///
+    /// Defaults to `Tolerance::default()`.
     #[must_use]
     fn tolerance(&self) -> Tolerance {
         Tolerance::default()
     }
 }
 
+/// A simulation that clamps another simulation's position to `[min, max]`.
+///
+/// Position is clamped on every sample; velocity reports `0.0` whenever the
+/// underlying (unclamped) position is at or beyond a boundary, so callers see
+/// the object as pinned rather than still moving. `is_done` and `tolerance`
+/// delegate to the inner simulation unchanged.
 #[derive(Debug, Clone)]
 pub struct ClampedSimulation<S: Simulation> {
     // PORT-CHECK-OK-SP3: parallel to flui-animation::simulation::ClampedSimulation; the two physics layers use distinct Simulation traits (position/velocity here vs x/dx + Send+Sync there). Consolidation tracked.
@@ -71,6 +87,8 @@ pub struct ClampedSimulation<S: Simulation> {
 }
 
 impl<S: Simulation> ClampedSimulation<S> {
+    /// Creates a clamped simulation wrapping `simulation`, limiting its
+    /// position to `[min, max]`.
     #[must_use]
     pub fn new(simulation: S, min: f32, max: f32) -> Self {
         Self {
@@ -80,26 +98,34 @@ impl<S: Simulation> ClampedSimulation<S> {
         }
     }
 
+    /// Returns the minimum allowed position, in logical pixels.
     #[must_use]
     pub fn min(&self) -> f32 {
         self.min
     }
 
+    /// Returns the maximum allowed position, in logical pixels.
     #[must_use]
     pub fn max(&self) -> f32 {
         self.max
     }
 
+    /// Returns a reference to the wrapped simulation.
     #[must_use]
     pub fn inner(&self) -> &S {
         &self.simulation
     }
 
+    /// Consumes the wrapper and returns the wrapped simulation.
     #[must_use]
     pub fn into_inner(self) -> S {
         self.simulation
     }
 
+    /// Returns whether the unclamped position at `time` is at or beyond
+    /// either boundary.
+    ///
+    /// When this is `true`, `velocity` reports `0.0`.
     #[must_use]
     pub fn is_at_boundary(&self, time: f32) -> bool {
         let unclamped_pos = self.simulation.position(time);

--- a/crates/flui-types/src/physics/spring.rs
+++ b/crates/flui-types/src/physics/spring.rs
@@ -10,6 +10,7 @@ use super::{Simulation, Tolerance};
 /// Classified from the discriminant `c² − 4mk` (see
 /// `SpringDescription::spring_type`): ζ < 1 is underdamped, ζ = 1 is
 /// critically damped, ζ > 1 is overdamped. Mirrors Flutter's `SpringType`.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SpringType {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
@@ -30,6 +31,7 @@ pub enum SpringType {
 /// Describes the spring itself, independent of any particular motion; pair
 /// it with a start/end position and initial velocity via `SpringSimulation`.
 /// Mirrors Flutter's `SpringDescription`.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SpringDescription {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
@@ -216,6 +218,7 @@ impl SpringDescription {
 /// Positions are in logical pixels, time in seconds. The simulation is done
 /// once both the distance to `end` and the velocity are within tolerance.
 /// Mirrors Flutter's `SpringSimulation`.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SpringSimulation {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked

--- a/crates/flui-types/src/physics/spring.rs
+++ b/crates/flui-types/src/physics/spring.rs
@@ -5,6 +5,11 @@
 
 use super::{Simulation, Tolerance};
 
+/// The damping regime of a spring, determined by its damping ratio ζ.
+///
+/// Classified from the discriminant `c² − 4mk` (see
+/// `SpringDescription::spring_type`): ζ < 1 is underdamped, ζ = 1 is
+/// critically damped, ζ > 1 is overdamped. Mirrors Flutter's `SpringType`.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SpringType {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
@@ -19,6 +24,12 @@ pub enum SpringType {
     Overdamped,
 }
 
+/// The physical parameters of a damped harmonic spring: mass, stiffness,
+/// and damping coefficient.
+///
+/// Describes the spring itself, independent of any particular motion; pair
+/// it with a start/end position and initial velocity via `SpringSimulation`.
+/// Mirrors Flutter's `SpringDescription`.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SpringDescription {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
@@ -33,6 +44,11 @@ pub struct SpringDescription {
 }
 
 impl SpringDescription {
+    /// Creates a spring description from raw mass, stiffness, and damping
+    /// coefficient.
+    ///
+    /// Values are not validated here; use `is_valid` to check that mass and
+    /// stiffness are positive, damping is non-negative, and all are finite.
     #[must_use]
     #[inline]
     pub const fn new(mass: f32, stiffness: f32, damping: f32) -> Self {
@@ -43,6 +59,10 @@ impl SpringDescription {
         }
     }
 
+    /// Creates a critically damped spring (ζ = 1) from mass and stiffness.
+    ///
+    /// The damping coefficient is computed as `2√(mk)`, so the spring returns
+    /// to rest as fast as possible without oscillating.
     #[must_use]
     #[inline]
     pub fn with_critical_damping(mass: f32, stiffness: f32) -> Self {
@@ -54,6 +74,10 @@ impl SpringDescription {
         }
     }
 
+    /// Preset for a bouncy, underdamped spring (ζ ≈ 0.4) that visibly
+    /// overshoots and oscillates before settling.
+    ///
+    /// Parameters: mass 1, stiffness 300, damping 10.
     #[must_use]
     #[inline]
     pub fn bouncy() -> Self {
@@ -61,12 +85,18 @@ impl SpringDescription {
         Self::new(1.0, 300.0, 10.0)
     }
 
+    /// Preset for a stiff, critically damped spring (mass 1, stiffness 500)
+    /// that snaps to its target quickly without overshooting.
     #[must_use]
     #[inline]
     pub fn stiff() -> Self {
         Self::with_critical_damping(1.0, 500.0)
     }
 
+    /// Preset for a soft, overdamped spring (ζ ≈ 1.5) that eases to its
+    /// target slowly without oscillating.
+    ///
+    /// Parameters: mass 1, stiffness 100, damping 30.
     #[must_use]
     #[inline]
     pub fn soft() -> Self {
@@ -110,6 +140,10 @@ impl SpringDescription {
         }
     }
 
+    /// Returns the damping ratio `ζ = c / (2√(mk))`.
+    ///
+    /// ζ < 1 is underdamped, ζ = 1 critically damped, ζ > 1 overdamped
+    /// (though `spring_type` classifies via the discriminant, not this value).
     #[must_use]
     #[inline]
     pub fn damping_ratio(&self) -> f32 {
@@ -117,12 +151,20 @@ impl SpringDescription {
         self.damping / critical_damping
     }
 
+    /// Returns the undamped natural angular frequency `ω₀ = √(k/m)`, in
+    /// radians per second.
     #[must_use]
     #[inline]
     pub fn natural_frequency(&self) -> f32 {
         (self.stiffness / self.mass).sqrt()
     }
 
+    /// Returns the damped angular frequency `ω_d = ω₀·√(1 − ζ²)`, in radians
+    /// per second.
+    ///
+    /// This is the frequency at which an underdamped spring actually
+    /// oscillates. For critically damped or overdamped springs (ζ ≥ 1) the
+    /// radicand is clamped to zero, so this returns `0.0`.
     #[must_use]
     #[inline]
     pub fn damped_frequency(&self) -> f32 {
@@ -131,6 +173,8 @@ impl SpringDescription {
         w0 * (1.0 - zeta * zeta).max(0.0).sqrt()
     }
 
+    /// Returns the oscillation period `2π/ω_d` in seconds, or `None` when the
+    /// spring does not oscillate (damped frequency is zero, i.e. ζ ≥ 1).
     #[must_use]
     #[inline]
     pub fn period(&self) -> Option<f32> {
@@ -142,6 +186,8 @@ impl SpringDescription {
         }
     }
 
+    /// Returns whether the parameters describe a physically meaningful spring:
+    /// positive finite mass and stiffness, non-negative finite damping.
     #[must_use]
     #[inline]
     pub fn is_valid(&self) -> bool {
@@ -153,6 +199,8 @@ impl SpringDescription {
             && self.damping.is_finite()
     }
 
+    /// Returns the critical damping coefficient `2√(mk)` for this mass and
+    /// stiffness — the damping at which ζ = 1.
     #[must_use]
     #[inline]
     pub fn critical_damping(&self) -> f32 {
@@ -160,6 +208,14 @@ impl SpringDescription {
     }
 }
 
+/// A spring simulation: motion of a particle attached to a damped harmonic
+/// spring toward an equilibrium position.
+///
+/// The closed-form solution is selected per sample from the spring's damping
+/// regime (underdamped, critically damped, or overdamped — see `SpringType`).
+/// Positions are in logical pixels, time in seconds. The simulation is done
+/// once both the distance to `end` and the velocity are within tolerance.
+/// Mirrors Flutter's `SpringSimulation`.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SpringSimulation {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
@@ -180,6 +236,9 @@ pub struct SpringSimulation {
 }
 
 impl SpringSimulation {
+    /// Creates a spring simulation from `start` toward the equilibrium
+    /// position `end`, beginning with the given `velocity` (logical pixels
+    /// per second), using the default tolerance.
     #[must_use]
     #[inline]
     pub fn new(spring: SpringDescription, start: f32, end: f32, velocity: f32) -> Self {
@@ -192,6 +251,9 @@ impl SpringSimulation {
         }
     }
 
+    /// Returns the simulation with its tolerance replaced (builder style).
+    ///
+    /// The tolerance controls when `is_done` reports the spring as settled.
     #[must_use]
     #[inline]
     pub fn with_tolerance(mut self, tolerance: Tolerance) -> Self {
@@ -199,30 +261,36 @@ impl SpringSimulation {
         self
     }
 
+    /// Returns the spring description driving this simulation.
     #[must_use]
     #[inline]
     pub fn spring(&self) -> &SpringDescription {
         &self.spring
     }
 
+    /// Returns the starting position, in logical pixels.
     #[must_use]
     #[inline]
     pub fn start(&self) -> f32 {
         self.start
     }
 
+    /// Returns the equilibrium (target) position, in logical pixels.
     #[must_use]
     #[inline]
     pub fn end(&self) -> f32 {
         self.end
     }
 
+    /// Returns the initial velocity, in logical pixels per second.
     #[must_use]
     #[inline]
     pub fn initial_velocity(&self) -> f32 {
         self.initial_velocity
     }
 
+    /// Returns whether the simulation is well-formed: a valid spring, finite
+    /// start/end/velocity, and a valid tolerance.
     #[must_use]
     #[inline]
     pub fn is_valid(&self) -> bool {

--- a/crates/flui-types/src/physics/tolerance.rs
+++ b/crates/flui-types/src/physics/tolerance.rs
@@ -3,6 +3,13 @@
 //! This module provides types for defining tolerances used to determine
 //! when a simulation has reached a stable state.
 
+/// Structure that specifies maximum allowable magnitudes for distances,
+/// durations, and velocity differences to be considered equal.
+///
+/// Simulations use these thresholds to decide when they are done: a value
+/// whose magnitude is strictly below the corresponding epsilon is treated as
+/// zero. Distances are in logical pixels, velocities in logical pixels per
+/// second, times in seconds. Mirrors Flutter's `Tolerance`.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Tolerance {
@@ -54,6 +61,8 @@ impl Tolerance {
         time: 0.01,
     };
 
+    /// Creates a tolerance from explicit distance (logical pixels), velocity
+    /// (logical pixels per second), and time (seconds) epsilons.
     #[must_use]
     #[inline]
     pub const fn new(distance: f32, velocity: f32, time: f32) -> Self {
@@ -64,36 +73,48 @@ impl Tolerance {
         }
     }
 
+    /// Returns whether all three epsilons are finite (not NaN or infinite).
     #[must_use]
     #[inline]
     pub fn is_finite(&self) -> bool {
         self.distance.is_finite() && self.velocity.is_finite() && self.time.is_finite()
     }
 
+    /// Returns whether all three epsilons are finite and non-negative.
     #[must_use]
     #[inline]
     pub fn is_valid(&self) -> bool {
         self.is_finite() && self.distance >= 0.0 && self.velocity >= 0.0 && self.time >= 0.0
     }
 
+    /// Returns whether `distance` is negligible: its magnitude is strictly
+    /// below the distance epsilon.
     #[must_use]
     #[inline]
     pub fn is_distance_within(&self, distance: f32) -> bool {
         distance.abs() < self.distance
     }
 
+    /// Returns whether `velocity` is negligible: its magnitude is strictly
+    /// below the velocity epsilon.
     #[must_use]
     #[inline]
     pub fn is_velocity_within(&self, velocity: f32) -> bool {
         velocity.abs() < self.velocity
     }
 
+    /// Returns whether `time` is negligible: its magnitude is strictly below
+    /// the time epsilon.
     #[must_use]
     #[inline]
     pub fn is_time_within(&self, time: f32) -> bool {
         time.abs() < self.time
     }
 
+    /// Returns a copy with all three epsilons multiplied by `factor`.
+    ///
+    /// Use a factor greater than `1.0` to relax the tolerance, or less than
+    /// `1.0` to tighten it.
     #[must_use]
     #[inline]
     pub fn scale(self, factor: f32) -> Self {
@@ -104,6 +125,8 @@ impl Tolerance {
         }
     }
 
+    /// Creates a tolerance from distance and velocity epsilons, using the
+    /// default time epsilon (`0.001` seconds).
     #[must_use]
     #[inline]
     pub const fn from_distance_velocity(distance: f32, velocity: f32) -> Self {

--- a/crates/flui-types/src/platform/brightness.rs
+++ b/crates/flui-types/src/platform/brightness.rs
@@ -17,18 +17,21 @@ pub enum Brightness {
 }
 
 impl Brightness {
+    /// Returns `true` if this is `Brightness::Light`.
     #[must_use]
     #[inline]
     pub const fn is_light(&self) -> bool {
         matches!(self, Self::Light)
     }
 
+    /// Returns `true` if this is `Brightness::Dark`.
     #[must_use]
     #[inline]
     pub const fn is_dark(&self) -> bool {
         matches!(self, Self::Dark)
     }
 
+    /// Returns the opposite brightness (`Light` ↔ `Dark`).
     #[must_use]
     #[inline]
     pub const fn invert(&self) -> Self {
@@ -38,6 +41,8 @@ impl Brightness {
         }
     }
 
+    /// Returns the default background color for this brightness:
+    /// white for `Light`, near-black for `Dark`.
     #[must_use]
     #[inline]
     pub const fn background_color(&self) -> Color {
@@ -47,6 +52,8 @@ impl Brightness {
         }
     }
 
+    /// Returns the default foreground (text) color for this brightness:
+    /// black for `Light`, white for `Dark`.
     #[must_use]
     #[inline]
     pub const fn foreground_color(&self) -> Color {
@@ -56,6 +63,8 @@ impl Brightness {
         }
     }
 
+    /// Returns the default surface color (cards, sheets) for this
+    /// brightness: white for `Light`, dark gray for `Dark`.
     #[must_use]
     #[inline]
     pub const fn surface_color(&self) -> Color {
@@ -65,6 +74,10 @@ impl Brightness {
         }
     }
 
+    /// Returns the default shadow opacity for this brightness.
+    ///
+    /// Dark themes use a stronger shadow (0.4 vs 0.2) so elevation
+    /// stays legible against dark surfaces.
     #[must_use]
     #[inline]
     pub const fn shadow_opacity(&self) -> f32 {
@@ -74,6 +87,9 @@ impl Brightness {
         }
     }
 
+    /// Parses a brightness from `"light"` or `"dark"`, case-insensitively.
+    ///
+    /// Returns `None` for unrecognized input.
     #[must_use]
     #[inline]
     pub fn parse(s: &str) -> Option<Self> {
@@ -84,6 +100,8 @@ impl Brightness {
         }
     }
 
+    /// Returns the canonical lowercase name (`"light"` or `"dark"`),
+    /// the inverse of [`parse`](Self::parse).
     #[must_use]
     #[inline]
     pub const fn as_str(&self) -> &'static str {

--- a/crates/flui-types/src/platform/locale.rs
+++ b/crates/flui-types/src/platform/locale.rs
@@ -2,6 +2,11 @@
 
 use std::fmt;
 
+/// An identifier for a user's language and regional preferences.
+///
+/// Mirrors Flutter's `Locale`: a language code plus optional country
+/// and script subtags (e.g. `en_US`, `zh_Hans_CN`), used for
+/// localization and text-direction resolution.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Locale {
     /// The language code (e.g., "en", "es", "fr")
@@ -60,24 +65,31 @@ impl Locale {
         }
     }
 
+    /// Returns the language code (e.g. `"en"`).
     #[must_use]
     #[inline]
     pub fn language(&self) -> &str {
         &self.language
     }
 
+    /// Returns the country/region code, if any (e.g. `"US"`).
     #[must_use]
     #[inline]
     pub fn country(&self) -> Option<&str> {
         self.country.as_deref()
     }
 
+    /// Returns the script code, if any (e.g. `"Hans"`).
     #[must_use]
     #[inline]
     pub fn script(&self) -> Option<&str> {
         self.script.as_deref()
     }
 
+    /// Formats this locale as an underscore-separated language tag
+    /// (e.g. `"en_US"`, or just `"en"` when there is no country).
+    ///
+    /// Note: the script code is not included in the output.
     #[must_use]
     #[inline]
     pub fn to_language_tag(&self) -> String {
@@ -88,12 +100,20 @@ impl Locale {
         }
     }
 
+    /// Returns `true` if this locale's text direction is left-to-right.
+    ///
+    /// The complement of [`is_rtl`](Self::is_rtl).
     #[must_use]
     #[inline]
     pub fn is_ltr(&self) -> bool {
         !self.is_rtl()
     }
 
+    /// Returns `true` if this locale's text direction is right-to-left.
+    ///
+    /// Determined by the language code against a fixed set of RTL
+    /// languages (Arabic, Hebrew, Persian, Urdu, Yiddish); the script
+    /// code is not consulted.
     #[must_use]
     #[inline]
     pub fn is_rtl(&self) -> bool {
@@ -103,6 +123,11 @@ impl Locale {
         )
     }
 
+    /// Parses a locale from a language tag with `-` or `_` separators.
+    ///
+    /// Accepts `"en"`, `"en_US"`/`"en-US"`, `"zh_Hans"` (a 4-character
+    /// second subtag is treated as a script), and `"zh_Hans_CN"`.
+    /// Returns `None` for empty input or more than three subtags.
     #[must_use]
     #[inline]
     pub fn from_language_tag(tag: &str) -> Option<Self> {

--- a/crates/flui-types/src/platform/locale.rs
+++ b/crates/flui-types/src/platform/locale.rs
@@ -7,6 +7,7 @@ use std::fmt;
 /// Mirrors Flutter's `Locale`: a language code plus optional country
 /// and script subtags (e.g. `en_US`, `zh_Hans_CN`), used for
 /// localization and text-direction resolution.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Locale {
     /// The language code (e.g., "en", "es", "fr")

--- a/crates/flui-types/src/platform/orientation.rs
+++ b/crates/flui-types/src/platform/orientation.rs
@@ -1,8 +1,14 @@
 //! Device orientation types
 
+/// The physical orientation of the device screen.
+///
+/// Mirrors Flutter's `DeviceOrientation` enum. The four variants describe
+/// where the top of the device is pointing relative to its natural
+/// portrait position.
 #[derive(Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeviceOrientation {
+    /// Portrait orientation with the top of the device up (the default).
     #[default]
     PortraitUp,
 
@@ -17,18 +23,26 @@ pub enum DeviceOrientation {
 }
 
 impl DeviceOrientation {
+    /// Returns `true` if this is a portrait orientation
+    /// (`PortraitUp` or `PortraitDown`).
     #[must_use]
     #[inline]
     pub const fn is_portrait(&self) -> bool {
         matches!(self, Self::PortraitUp | Self::PortraitDown)
     }
 
+    /// Returns `true` if this is a landscape orientation
+    /// (`LandscapeLeft` or `LandscapeRight`).
     #[must_use]
     #[inline]
     pub const fn is_landscape(&self) -> bool {
         matches!(self, Self::LandscapeLeft | Self::LandscapeRight)
     }
 
+    /// Returns the rotation angle in degrees relative to `PortraitUp`.
+    ///
+    /// `PortraitUp` is 0°, `LandscapeLeft` 90°, `PortraitDown` 180°,
+    /// and `LandscapeRight` 270°.
     #[must_use]
     #[inline]
     pub const fn rotation_degrees(&self) -> f32 {
@@ -40,12 +54,18 @@ impl DeviceOrientation {
         }
     }
 
+    /// Returns the rotation angle in radians relative to `PortraitUp`.
+    ///
+    /// Same as [`rotation_degrees`](Self::rotation_degrees) converted
+    /// to radians.
     #[must_use]
     #[inline]
     pub fn rotation_radians(&self) -> f32 {
         self.rotation_degrees().to_radians()
     }
 
+    /// Returns the orientation reached by rotating the device 90°
+    /// clockwise from this one.
     #[must_use]
     #[inline]
     pub const fn rotate_clockwise(&self) -> Self {
@@ -57,6 +77,8 @@ impl DeviceOrientation {
         }
     }
 
+    /// Returns the orientation reached by rotating the device 90°
+    /// counter-clockwise from this one.
     #[must_use]
     #[inline]
     pub const fn rotate_counter_clockwise(&self) -> Self {
@@ -68,6 +90,8 @@ impl DeviceOrientation {
         }
     }
 
+    /// Returns the orientation rotated 180° from this one
+    /// (e.g. `PortraitUp` ↔ `PortraitDown`).
     #[must_use]
     #[inline]
     pub const fn opposite(&self) -> Self {
@@ -79,12 +103,17 @@ impl DeviceOrientation {
         }
     }
 
+    /// Returns `true` if the device is upside down (`PortraitDown`).
     #[must_use]
     #[inline]
     pub const fn is_upside_down(&self) -> bool {
         matches!(self, Self::PortraitDown)
     }
 
+    /// Parses an orientation from its string name, case-insensitively.
+    ///
+    /// Accepts snake_case (`"portrait_up"`) and concatenated
+    /// (`"portraitup"`) forms; returns `None` for unrecognized input.
     #[must_use]
     #[inline]
     pub fn parse(s: &str) -> Option<Self> {
@@ -97,6 +126,8 @@ impl DeviceOrientation {
         }
     }
 
+    /// Returns the canonical snake_case name of this orientation
+    /// (e.g. `"portrait_up"`), the inverse of [`parse`](Self::parse).
     #[must_use]
     #[inline]
     pub const fn as_str(&self) -> &'static str {

--- a/crates/flui-types/src/platform/orientation.rs
+++ b/crates/flui-types/src/platform/orientation.rs
@@ -5,7 +5,7 @@
 /// Mirrors Flutter's `DeviceOrientation` enum. The four variants describe
 /// where the top of the device is pointing relative to its natural
 /// portrait position.
-#[derive(Default)]
+#[derive(Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeviceOrientation {
     /// Portrait orientation with the top of the device up (the default).

--- a/crates/flui-types/src/styling/border.rs
+++ b/crates/flui-types/src/styling/border.rs
@@ -12,6 +12,7 @@ use crate::{
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BorderStyle {
+    /// Draw the border as a solid line.
     #[default]
     Solid,
 

--- a/crates/flui-types/src/styling/color.rs
+++ b/crates/flui-types/src/styling/color.rs
@@ -3,6 +3,11 @@
 //! This module provides a comprehensive Color type with conversions between
 //! different color spaces (RGB, HSL, HSV), similar to Flutter's Color system.
 
+/// An RGBA color with four 8-bit channels and straight (unmultiplied) alpha.
+///
+/// Channels are in sRGB gamma space, matching Flutter's `Color`. For the
+/// packed premultiplied-alpha representation used by the renderer, see
+/// `Color32`.
 // `Color` is a plain RGBA quadruple of independent `u8` channels — every bit
 // pattern is a valid `Color`. The derived `Deserialize` therefore cannot
 // produce an instance that violates any invariant the `unsafe` SIMD helpers
@@ -146,6 +151,7 @@ impl Color {
 
     // ===== Component accessors =====
 
+    /// Returns the alpha channel as an opacity value in `0.0..=1.0`.
     #[inline]
     #[must_use]
     pub const fn opacity(&self) -> f32 {
@@ -366,12 +372,19 @@ impl Color {
         }
     }
 
+    /// Converts to a 32-bit ARGB value in `0xAARRGGBB` format.
+    ///
+    /// Inverse of [`Color::from_argb`].
     #[inline]
     #[must_use]
     pub const fn to_argb(&self) -> u32 {
         ((self.a as u32) << 24) | ((self.r as u32) << 16) | ((self.g as u32) << 8) | (self.b as u32)
     }
 
+    /// Formats as an uppercase hex string: `#RRGGBB` when fully opaque,
+    /// `#AARRGGBB` otherwise.
+    ///
+    /// Both forms round-trip through [`Color::from_hex`].
     #[must_use]
     #[inline]
     pub fn to_hex(&self) -> String {
@@ -398,6 +411,8 @@ impl Color {
         }
     }
 
+    /// Returns the RGBA channels as an `(r, g, b, a)` tuple of `f32` values
+    /// in `0.0..=1.0`.
     #[inline]
     #[must_use]
     pub const fn to_rgba_f32(&self) -> (f32, f32, f32, f32) {
@@ -409,6 +424,8 @@ impl Color {
         )
     }
 
+    /// Returns the RGBA channels as an `[r, g, b, a]` array of `f32` values
+    /// in `0.0..=1.0`.
     #[inline]
     #[must_use]
     pub const fn to_rgba_f32_array(&self) -> [f32; 4] {
@@ -420,6 +437,10 @@ impl Color {
         ]
     }
 
+    /// Creates a color from an `[r, g, b, a]` array of `f32` values in
+    /// `0.0..=1.0`.
+    ///
+    /// Values are clamped to `0.0..=1.0` before conversion.
     #[inline]
     #[must_use]
     pub fn from_rgba_f32_array(rgba: [f32; 4]) -> Self {
@@ -431,6 +452,10 @@ impl Color {
         )
     }
 
+    /// Returns the RGBA channels as an `[r, g, b, a]` array of `f32` values
+    /// in `0.0..=1.0`.
+    ///
+    /// Equivalent to [`Color::to_rgba_f32_array`].
     #[inline]
     #[must_use]
     pub fn to_f32_array(&self) -> [f32; 4] {
@@ -442,24 +467,28 @@ impl Color {
         ]
     }
 
+    /// Returns the red channel as an `f32` in `0.0..=1.0`.
     #[inline]
     #[must_use]
     pub const fn red_f32(&self) -> f32 {
         self.r as f32 / 255.0
     }
 
+    /// Returns the green channel as an `f32` in `0.0..=1.0`.
     #[inline]
     #[must_use]
     pub const fn green_f32(&self) -> f32 {
         self.g as f32 / 255.0
     }
 
+    /// Returns the blue channel as an `f32` in `0.0..=1.0`.
     #[inline]
     #[must_use]
     pub const fn blue_f32(&self) -> f32 {
         self.b as f32 / 255.0
     }
 
+    /// Returns the alpha channel as an `f32` in `0.0..=1.0`.
     #[inline]
     #[must_use]
     pub const fn alpha_f32(&self) -> f32 {
@@ -468,6 +497,12 @@ impl Color {
 
     // ===== Helper methods for rendering =====
 
+    /// Alpha-blends this color over `background` (Porter-Duff "source over",
+    /// straight alpha, gamma space).
+    ///
+    /// Fully opaque returns `self` and fully transparent returns
+    /// `background`; other alphas take a SIMD path when the `simd` feature
+    /// and target support are available.
     #[must_use]
     #[inline]
     pub fn blend_over(&self, background: Color) -> Color {
@@ -652,6 +687,7 @@ impl Color {
         }
     }
 
+    /// Multiplies each channel (including alpha) componentwise with `other`.
     #[inline]
     #[must_use]
     pub const fn multiply(&self, other: Color) -> Color {
@@ -663,6 +699,11 @@ impl Color {
         )
     }
 
+    /// Darkens the color by scaling the RGB channels by `factor` (clamped to
+    /// `0.0..=1.0`).
+    ///
+    /// `0.0` yields black; `1.0` leaves the color unchanged. Alpha is
+    /// preserved.
     #[inline]
     #[must_use]
     pub fn darken(&self, factor: f32) -> Color {
@@ -675,6 +716,11 @@ impl Color {
         )
     }
 
+    /// Lightens the color by moving the RGB channels toward white by
+    /// `factor` (clamped to `0.0..=1.0`).
+    ///
+    /// `0.0` leaves the color unchanged; `1.0` yields white. Alpha is
+    /// preserved.
     #[inline]
     #[must_use]
     pub fn lighten(&self, factor: f32) -> Color {
@@ -687,24 +733,30 @@ impl Color {
         )
     }
 
+    /// Returns the perceived brightness in `0.0..=1.0`, using Rec. 709 luma
+    /// coefficients on the gamma-encoded channels.
     #[inline]
     #[must_use]
     pub const fn luminance(&self) -> f32 {
         (0.2126 * self.r as f32 + 0.7152 * self.g as f32 + 0.0722 * self.b as f32) / 255.0
     }
 
+    /// Returns `true` if the luminance is below 0.5.
     #[inline]
     #[must_use]
     pub const fn is_dark(&self) -> bool {
         self.luminance() < 0.5
     }
 
+    /// Returns `true` if the luminance is 0.5 or above.
     #[inline]
     #[must_use]
     pub const fn is_light(&self) -> bool {
         self.luminance() >= 0.5
     }
 
+    /// Returns a legible text color for use over this background: white for
+    /// dark colors, black for light ones.
     #[inline]
     #[must_use]
     pub const fn contrasting_text_color(&self) -> Color {
@@ -798,6 +850,12 @@ impl Color {
         Color::from_oklab(mixed, alpha)
     }
 
+    /// Samples a multi-stop color ramp at position `t` (clamped to
+    /// `0.0..=1.0`), like evaluating a gradient.
+    ///
+    /// `stops` are `(color, position)` pairs sorted by ascending position.
+    /// Returns `Color::TRANSPARENT` for an empty slice, and the nearest
+    /// endpoint color when `t` falls outside the stop range.
     #[must_use]
     #[inline]
     pub fn lerp_multi_stop(stops: &[(Color, f32)], t: f32) -> Color {
@@ -1259,6 +1317,8 @@ impl crate::geometry::ApproxEq for Color {
 
 // ===== Error types =====
 
+/// Error returned by [`Color::from_hex`] when parsing a hex color string
+/// fails.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParseColorError {
     /// Invalid hex string format

--- a/crates/flui-types/src/styling/color32.rs
+++ b/crates/flui-types/src/styling/color32.rs
@@ -27,6 +27,12 @@
 
 use super::Color;
 
+/// A packed 32-bit sRGB color with premultiplied alpha.
+///
+/// Stored as `[r, g, b, a]` bytes where the RGB channels are already
+/// multiplied by alpha. Alpha of 0 with non-zero RGB encodes an additive
+/// color. See the module docs for the premultiplication and gamma-space
+/// trade-offs; use [`Color`] for straight-alpha colors.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Color32([u8; 4]);
@@ -58,21 +64,29 @@ impl std::ops::IndexMut<usize> for Color32 {
 impl Color32 {
     // ===== Constructors =====
 
+    /// Creates a fully opaque color from RGB values.
     #[inline]
     pub const fn from_rgb(r: u8, g: u8, b: u8) -> Self {
         Self([r, g, b, 255])
     }
 
+    /// Creates an additive color (alpha = 0) from RGB values.
+    ///
+    /// When blended, an additive color adds to the background instead of
+    /// covering it.
     #[inline]
     pub const fn from_rgb_additive(r: u8, g: u8, b: u8) -> Self {
         Self([r, g, b, 0])
     }
 
+    /// Creates a color from RGBA values that are already premultiplied.
     #[inline]
     pub const fn from_rgba_premultiplied(r: u8, g: u8, b: u8, a: u8) -> Self {
         Self([r, g, b, a])
     }
 
+    /// Creates a color from straight (unmultiplied) RGBA values,
+    /// premultiplying the RGB channels by alpha.
     #[inline]
     pub fn from_rgba_unmultiplied(r: u8, g: u8, b: u8, a: u8) -> Self {
         match a {
@@ -90,22 +104,29 @@ impl Color32 {
         }
     }
 
+    /// Creates an opaque gray with all RGB channels set to `l`.
     #[inline]
     pub const fn from_gray(l: u8) -> Self {
         Self([l, l, l, 255])
     }
 
+    /// Creates black with the given alpha (premultiplied black keeps RGB at
+    /// zero).
     #[inline]
     pub const fn from_black_alpha(a: u8) -> Self {
         Self([0, 0, 0, a])
     }
 
+    /// Creates white with the given alpha (premultiplied, so all four
+    /// channels equal `a`).
     #[inline]
     pub fn from_white_alpha(a: u8) -> Self {
         // Premultiply: white * alpha = (a, a, a, a)
         Self([a, a, a, a])
     }
 
+    /// Creates an additive gray (alpha = 0) that brightens the background by
+    /// `l`.
     #[inline]
     pub const fn from_additive_luminance(l: u8) -> Self {
         Self([l, l, l, 0])
@@ -113,21 +134,25 @@ impl Color32 {
 
     // ===== Component accessors =====
 
+    /// Returns the red channel (premultiplied by alpha).
     #[inline]
     pub const fn r(&self) -> u8 {
         self.0[0]
     }
 
+    /// Returns the green channel (premultiplied by alpha).
     #[inline]
     pub const fn g(&self) -> u8 {
         self.0[1]
     }
 
+    /// Returns the blue channel (premultiplied by alpha).
     #[inline]
     pub const fn b(&self) -> u8 {
         self.0[2]
     }
 
+    /// Returns the alpha channel.
     #[inline]
     pub const fn a(&self) -> u8 {
         self.0[3]
@@ -135,16 +160,21 @@ impl Color32 {
 
     // ===== Checks =====
 
+    /// Returns `true` if the alpha channel is 255 (fully opaque).
     #[inline]
     pub const fn is_opaque(&self) -> bool {
         self.a() == 255
     }
 
+    /// Returns `true` if the alpha channel is 0 (fully transparent or
+    /// additive).
     #[inline]
     pub const fn is_transparent(&self) -> bool {
         self.a() == 0
     }
 
+    /// Returns `true` if this is an additive color: alpha is 0 but at least
+    /// one RGB channel is non-zero.
     #[inline]
     pub fn is_additive(&self) -> bool {
         self.a() == 0 && (self.r() != 0 || self.g() != 0 || self.b() != 0)
@@ -152,16 +182,22 @@ impl Color32 {
 
     // ===== Conversions =====
 
+    /// Returns the premultiplied RGBA components as a `[r, g, b, a]` array.
     #[inline]
     pub const fn to_array(&self) -> [u8; 4] {
         [self.r(), self.g(), self.b(), self.a()]
     }
 
+    /// Returns the premultiplied RGBA components as a `(r, g, b, a)` tuple.
     #[inline]
     pub const fn to_tuple(&self) -> (u8, u8, u8, u8) {
         (self.r(), self.g(), self.b(), self.a())
     }
 
+    /// Converts to straight (unmultiplied) RGBA by dividing the RGB channels
+    /// by alpha.
+    ///
+    /// Lossy for partially transparent colors due to `u8` rounding.
     #[inline]
     pub fn to_rgba_unmultiplied(&self) -> [u8; 4] {
         let [r, g, b, a] = self.to_array();
@@ -179,6 +215,8 @@ impl Color32 {
         }
     }
 
+    /// Returns the premultiplied RGBA components as `f32` values in
+    /// `0.0..=1.0`.
     #[inline]
     pub fn to_rgba_f32(&self) -> [f32; 4] {
         [
@@ -191,12 +229,16 @@ impl Color32 {
 
     // ===== Modifiers =====
 
+    /// Returns this color with alpha forced to 255, keeping the RGB channels
+    /// unchanged.
     #[inline]
     pub const fn to_opaque(self) -> Self {
         let [r, g, b, _] = self.to_array();
         Self([r, g, b, 255])
     }
 
+    /// Returns this color with alpha forced to 0, turning it into an additive
+    /// color.
     #[inline]
     pub const fn to_additive(self) -> Self {
         let [r, g, b, _] = self.to_array();
@@ -205,6 +247,10 @@ impl Color32 {
 
     // ===== Operations =====
 
+    /// Multiplies all four channels by `factor` in gamma space, with
+    /// rounding.
+    ///
+    /// Debug-asserts that `factor` is finite and non-negative.
     #[inline]
     pub fn gamma_multiply(self, factor: f32) -> Self {
         debug_assert!(
@@ -220,6 +266,8 @@ impl Color32 {
         ])
     }
 
+    /// Multiplies all four channels by `factor / 255` in gamma space, using
+    /// integer arithmetic with rounding.
     #[inline]
     pub fn gamma_multiply_u8(self, factor: u8) -> Self {
         let Self([r, g, b, a]) = self;
@@ -278,16 +326,20 @@ impl Color32 {
         background.gamma_multiply_u8(255 - self.a()) + self
     }
 
+    /// Returns the perceived brightness in `0.0..=1.0`, using Rec. 601 luma
+    /// coefficients on the gamma-encoded channels.
     #[inline]
     pub fn intensity(&self) -> f32 {
         (self.r() as f32 * 0.299 + self.g() as f32 * 0.587 + self.b() as f32 * 0.114) / 255.0
     }
 
+    /// Returns `true` if the perceived brightness is below 0.5.
     #[inline]
     pub fn is_dark(&self) -> bool {
         self.intensity() < 0.5
     }
 
+    /// Returns `true` if the perceived brightness is 0.5 or above.
     #[inline]
     pub fn is_light(&self) -> bool {
         self.intensity() >= 0.5

--- a/crates/flui-types/src/styling/decoration.rs
+++ b/crates/flui-types/src/styling/decoration.rs
@@ -16,6 +16,7 @@ use crate::{
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DecorationImage {
+    /// The image to paint.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub image: Image,
 
@@ -38,6 +39,8 @@ pub struct DecorationImage {
 }
 
 impl DecorationImage {
+    /// Creates a decoration image with default settings: no fit, centered,
+    /// not repeated, fully opaque, and no color filter.
     #[must_use]
     #[inline]
     pub fn new(image: Image) -> Self {
@@ -51,6 +54,7 @@ impl DecorationImage {
         }
     }
 
+    /// Sets how to inscribe the image into the space allocated during layout.
     #[must_use]
     #[inline]
     pub fn with_fit(mut self, fit: BoxFit) -> Self {
@@ -58,6 +62,7 @@ impl DecorationImage {
         self
     }
 
+    /// Sets how to align the image within its bounds.
     #[must_use]
     #[inline]
     pub const fn with_alignment(mut self, alignment: Alignment) -> Self {
@@ -65,6 +70,7 @@ impl DecorationImage {
         self
     }
 
+    /// Sets how to repeat the image.
     #[must_use]
     #[inline]
     pub const fn with_repeat(mut self, repeat: ImageRepeat) -> Self {
@@ -72,6 +78,8 @@ impl DecorationImage {
         self
     }
 
+    /// Sets the opacity to apply to the image (0.0 = fully transparent,
+    /// 1.0 = fully opaque).
     #[must_use]
     #[inline]
     pub const fn with_opacity(mut self, opacity: f32) -> Self {
@@ -79,6 +87,7 @@ impl DecorationImage {
         self
     }
 
+    /// Sets a color filter to apply to the image before painting it.
     #[must_use]
     #[inline]
     pub const fn with_color_filter(mut self, color_filter: ColorFilter) -> Self {

--- a/crates/flui-types/src/styling/gradient.rs
+++ b/crates/flui-types/src/styling/gradient.rs
@@ -4,6 +4,7 @@
 pub use crate::painting::TileMode;
 use crate::{layout::Alignment, styling::Color};
 
+/// A description of a color gradient, similar to Flutter's `Gradient`.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Gradient {
@@ -60,6 +61,8 @@ impl Gradient {
     }
 }
 
+/// A gradient that transitions colors along a line between two alignment
+/// points, similar to Flutter's `LinearGradient`.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LinearGradient {
@@ -218,6 +221,8 @@ impl LinearGradient {
     }
 }
 
+/// A gradient that radiates outward from a center point, similar to
+/// Flutter's `RadialGradient`.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RadialGradient {
@@ -251,6 +256,7 @@ pub struct RadialGradient {
 }
 
 impl RadialGradient {
+    /// Creates a radial gradient.
     #[allow(clippy::too_many_arguments)]
     #[inline]
     pub fn new(
@@ -362,6 +368,8 @@ impl RadialGradient {
     }
 }
 
+/// A gradient that sweeps through an arc of angles around a center point,
+/// similar to Flutter's `SweepGradient`.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SweepGradient {
@@ -467,6 +475,8 @@ pub trait GradientTransform: std::fmt::Debug {
     fn transform(&self) -> [[f32; 3]; 3];
 }
 
+/// A gradient transform that rotates the gradient by a fixed angle, similar
+/// to Flutter's `GradientRotation`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GradientRotation {

--- a/crates/flui-types/src/styling/hsl_hsv.rs
+++ b/crates/flui-types/src/styling/hsl_hsv.rs
@@ -5,6 +5,7 @@
 
 use super::color::Color;
 
+/// A color in the HSL (hue, saturation, lightness) color space.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HSLColor {
     /// Hue in degrees (0.0-360.0).
@@ -125,6 +126,7 @@ impl From<HSLColor> for Color {
     }
 }
 
+/// A color in the HSV (hue, saturation, value) color space.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HSVColor {
     /// Hue in degrees (0.0-360.0).

--- a/crates/flui-types/src/styling/hsl_hsv.rs
+++ b/crates/flui-types/src/styling/hsl_hsv.rs
@@ -6,6 +6,7 @@
 use super::color::Color;
 
 /// A color in the HSL (hue, saturation, lightness) color space.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HSLColor {
     /// Hue in degrees (0.0-360.0).
@@ -127,6 +128,7 @@ impl From<HSLColor> for Color {
 }
 
 /// A color in the HSV (hue, saturation, value) color space.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HSVColor {
     /// Hue in degrees (0.0-360.0).

--- a/crates/flui-types/src/styling/material_colors.rs
+++ b/crates/flui-types/src/styling/material_colors.rs
@@ -18,6 +18,7 @@ use super::color::Color;
 /// let primary = MaterialColors::BLUE_500;
 /// let accent = MaterialColors::PINK_A200;
 /// ```
+#[derive(Debug)]
 pub struct MaterialColors;
 
 impl MaterialColors {

--- a/crates/flui-types/src/styling/physical_model.rs
+++ b/crates/flui-types/src/styling/physical_model.rs
@@ -52,6 +52,7 @@ pub enum MaterialType {
 /// Custom elevations can be used by specifying f32 values directly.
 ///
 /// Reference: Material Design 3 elevation scale
+#[derive(Debug)]
 pub struct Elevation;
 
 impl Elevation {

--- a/crates/flui-types/src/typography/text_alignment.rs
+++ b/crates/flui-types/src/typography/text_alignment.rs
@@ -2,7 +2,9 @@
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// How text is aligned horizontally within its container.
 pub enum TextAlign {
+    /// Align text to the left edge.
     #[default]
     Left,
     /// Align text to the right edge.
@@ -18,6 +20,9 @@ pub enum TextAlign {
 }
 
 impl TextAlign {
+    /// Resolves `Start`/`End` to `Left`/`Right` for the given text direction.
+    ///
+    /// Direction-independent variants are returned unchanged.
     #[must_use]
     #[inline]
     pub const fn resolve(&self, direction: TextDirection) -> Self {
@@ -34,12 +39,17 @@ impl TextAlign {
         }
     }
 
+    /// Returns `true` if this alignment depends on the text direction (`Start` or `End`).
     #[must_use]
     #[inline]
     pub const fn is_direction_dependent(&self) -> bool {
         matches!(self, Self::Start | Self::End)
     }
 
+    /// Returns the horizontal alignment factor: 0.0 (left), 0.5 (center), or 1.0 (right).
+    ///
+    /// `Start` maps to 0.0 and `End` to 1.0 without direction resolution;
+    /// call `resolve` first for RTL-aware alignment.
     #[must_use]
     #[inline]
     pub const fn horizontal_factor(&self) -> f32 {
@@ -53,9 +63,11 @@ impl TextAlign {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// How text is aligned vertically within its container.
 pub enum TextAlignVertical {
     /// Align text to the top.
     Top,
+    /// Center text vertically.
     #[default]
     Center,
     /// Align text to the bottom.
@@ -63,6 +75,7 @@ pub enum TextAlignVertical {
 }
 
 impl TextAlignVertical {
+    /// Returns the vertical alignment factor: 0.0 (top), 0.5 (center), or 1.0 (bottom).
     #[must_use]
     #[inline]
     pub const fn vertical_factor(&self) -> f32 {
@@ -79,8 +92,10 @@ pub use crate::layout::TextBaseline;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// The directionality in which text flows.
 pub enum TextDirection {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
+    /// Left-to-right text direction.
     #[default]
     Ltr,
     /// Right-to-left text direction.
@@ -88,18 +103,21 @@ pub enum TextDirection {
 }
 
 impl TextDirection {
+    /// Returns `true` if the direction is left-to-right.
     #[must_use]
     #[inline]
     pub const fn is_ltr(&self) -> bool {
         matches!(self, Self::Ltr)
     }
 
+    /// Returns `true` if the direction is right-to-left.
     #[must_use]
     #[inline]
     pub const fn is_rtl(&self) -> bool {
         matches!(self, Self::Rtl)
     }
 
+    /// Returns the opposite direction (`Ltr` <-> `Rtl`).
     #[must_use]
     #[inline]
     pub const fn opposite(&self) -> Self {
@@ -112,7 +130,10 @@ impl TextDirection {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Which side of a text position the cursor associates with when the
+/// position is ambiguous (e.g. at a line break or bidi boundary).
 pub enum TextAffinity {
+    /// Cursor has affinity for the upstream (previous) character.
     #[default]
     Upstream,
     /// Cursor has affinity for the downstream (next) character.

--- a/crates/flui-types/src/typography/text_decoration.rs
+++ b/crates/flui-types/src/typography/text_decoration.rs
@@ -2,6 +2,11 @@
 
 use crate::Color;
 
+/// A linear decoration to draw near the text (underline, overline, line-through).
+///
+/// Decorations are stored as a bitfield, so multiple decorations can be
+/// combined via [`TextDecoration::combine`] (mirroring Flutter's
+/// `TextDecoration.combine`).
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextDecoration {
     /// Bitfield of decoration flags.
@@ -18,12 +23,14 @@ impl TextDecoration {
     /// Line-through decoration.
     pub const LINE_THROUGH: Self = Self { flags: 1 << 2 };
 
+    /// Creates a decoration from a raw bitfield of decoration flags.
     #[must_use]
     #[inline]
     pub const fn new(flags: u8) -> Self {
         Self { flags }
     }
 
+    /// Combines multiple decorations into one by OR-ing their flags.
     #[must_use]
     #[inline]
     pub const fn combine(decorations: &[Self]) -> Self {
@@ -36,24 +43,28 @@ impl TextDecoration {
         Self { flags }
     }
 
+    /// Returns `true` if the underline decoration is set.
     #[must_use]
     #[inline]
     pub const fn has_underline(&self) -> bool {
         self.flags & Self::UNDERLINE.flags != 0
     }
 
+    /// Returns `true` if the overline decoration is set.
     #[must_use]
     #[inline]
     pub const fn has_overline(&self) -> bool {
         self.flags & Self::OVERLINE.flags != 0
     }
 
+    /// Returns `true` if the line-through decoration is set.
     #[must_use]
     #[inline]
     pub const fn has_line_through(&self) -> bool {
         self.flags & Self::LINE_THROUGH.flags != 0
     }
 
+    /// Returns `true` if no decoration is set.
     #[must_use]
     #[inline]
     pub const fn is_none(&self) -> bool {
@@ -70,7 +81,9 @@ impl Default for TextDecoration {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// The style in which a text decoration line is drawn.
 pub enum TextDecorationStyle {
+    /// A single solid line.
     #[default]
     Solid,
     /// Double line.
@@ -85,7 +98,9 @@ pub enum TextDecorationStyle {
 
 #[derive(Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// How visual text overflow is handled.
 pub enum TextOverflow {
+    /// Clip the overflowing text at its container boundary.
     #[default]
     Clip,
     /// Fade the overflowing text to transparent.
@@ -98,7 +113,9 @@ pub enum TextOverflow {
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// How the width of a text paragraph is measured.
 pub enum TextWidthBasis {
+    /// Width fills the parent's width constraint (multiline text takes the full width).
     #[default]
     Parent,
     /// Width is based on the longest line.
@@ -107,6 +124,8 @@ pub enum TextWidthBasis {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// How the `height` line-height multiplier applies to the ascent of the
+/// first line and the descent of the last line of a paragraph.
 pub struct TextHeightBehavior {
     /// Whether to apply height to the first line ascent.
     pub apply_height_to_first_ascent: bool,
@@ -155,13 +174,18 @@ impl TextHeightBehavior {
 
 #[derive(Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// How the extra vertical space added by the `height` multiplier is
+/// distributed above and below the text.
 pub enum TextLeadingDistribution {
+    /// Distribute leading according to the font's ascent/descent ratio.
     #[default]
     Proportional,
     /// Leading is distributed evenly.
     Even,
 }
 
+/// Full decoration description: which lines to draw plus their style,
+/// color, and thickness.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextDecorationConfig {
     /// The decoration type.
@@ -187,6 +211,7 @@ impl Default for TextDecorationConfig {
 }
 
 impl TextDecorationConfig {
+    /// Creates a config for the given decoration with default style, color, and thickness.
     #[must_use]
     #[inline]
     pub fn new(decoration: TextDecoration) -> Self {
@@ -196,6 +221,7 @@ impl TextDecorationConfig {
         }
     }
 
+    /// Sets the decoration style.
     #[must_use]
     #[inline]
     pub fn with_style(mut self, style: TextDecorationStyle) -> Self {
@@ -203,6 +229,7 @@ impl TextDecorationConfig {
         self
     }
 
+    /// Sets the decoration color.
     #[must_use]
     #[inline]
     pub fn with_color(mut self, color: Color) -> Self {
@@ -210,6 +237,7 @@ impl TextDecorationConfig {
         self
     }
 
+    /// Sets the decoration thickness.
     #[must_use]
     #[inline]
     pub fn with_thickness(mut self, thickness: f64) -> Self {

--- a/crates/flui-types/src/typography/text_decoration.rs
+++ b/crates/flui-types/src/typography/text_decoration.rs
@@ -7,6 +7,7 @@ use crate::Color;
 /// Decorations are stored as a bitfield, so multiple decorations can be
 /// combined via [`TextDecoration::combine`] (mirroring Flutter's
 /// `TextDecoration.combine`).
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextDecoration {
     /// Bitfield of decoration flags.
@@ -96,7 +97,7 @@ pub enum TextDecorationStyle {
     Wavy,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// How visual text overflow is handled.
 pub enum TextOverflow {
@@ -172,7 +173,7 @@ impl TextHeightBehavior {
     };
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// How the extra vertical space added by the `height` multiplier is
 /// distributed above and below the text.
@@ -186,6 +187,7 @@ pub enum TextLeadingDistribution {
 
 /// Full decoration description: which lines to draw plus their style,
 /// color, and thickness.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextDecorationConfig {
     /// The decoration type.

--- a/crates/flui-types/src/typography/text_metrics.rs
+++ b/crates/flui-types/src/typography/text_metrics.rs
@@ -65,6 +65,7 @@ impl Default for TextPosition {
 ///
 /// Represents a contiguous span of text characters. Start is inclusive, end is
 /// exclusive.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextRange {
     // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
@@ -190,6 +191,7 @@ impl Default for TextRange {
 /// Represents a text selection with separate tracking of where it started
 /// (base) and where it currently ends (extent). This allows for directional
 /// selections.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextSelection {
     /// Base position (where selection started).
@@ -324,6 +326,7 @@ impl Default for TextSelection {
 ///
 /// Represents the rectangular bounds of text with directional information
 /// for handling bidirectional text layout.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextBox {
     /// Bounding rectangle.
@@ -395,6 +398,7 @@ impl TextBox {
 ///
 /// Contains rendering information for a single glyph including its ID,
 /// Unicode code point, bounding box, and advance width.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GlyphInfo {
     /// Glyph ID in the font.
@@ -467,6 +471,7 @@ impl GlyphInfo {
 ///
 /// Contains comprehensive layout information for a text line including
 /// dimensions, baseline, and text range information.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LineMetrics {
     /// Whether this line ends with a hard break.

--- a/crates/flui-types/src/typography/text_scaler.rs
+++ b/crates/flui-types/src/typography/text_scaler.rs
@@ -77,12 +77,21 @@ impl Clone for Box<dyn TextScaler> {
     }
 }
 
+/// A [`TextScaler`] that multiplies every font size by a constant factor.
+///
+/// This is the default scaling model, equivalent to Flutter's
+/// `TextScaler.linear`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LinearTextScaler {
     factor: f64,
 }
 
 impl LinearTextScaler {
+    /// Creates a linear scaler with the given scale factor.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `factor` is negative or NaN.
     #[must_use]
     #[inline]
     pub fn new(factor: f64) -> Self {
@@ -93,12 +102,14 @@ impl LinearTextScaler {
         Self { factor }
     }
 
+    /// Creates the identity scaler (factor 1.0, no scaling).
     #[must_use]
     #[inline]
     pub const fn identity() -> Self {
         Self { factor: 1.0 }
     }
 
+    /// Returns the scale factor.
     #[must_use]
     #[inline]
     pub const fn factor(&self) -> f64 {
@@ -130,6 +141,10 @@ impl TextScaler for LinearTextScaler {
     }
 }
 
+/// A [`TextScaler`] that never scales: every font size is returned unchanged.
+///
+/// Use this to opt out of system text scaling, equivalent to Flutter's
+/// `TextScaler.noScaling`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct NoScaling;
 
@@ -150,6 +165,11 @@ impl TextScaler for NoScaling {
     }
 }
 
+/// A [`TextScaler`] that applies different factors to small and large text.
+///
+/// Font sizes below `threshold` are multiplied by `small_factor`; sizes at
+/// or above it by `large_factor`. This supports non-linear accessibility
+/// scaling where already-large text is scaled less aggressively.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ClampedTextScaler {
     /// Scale factor for small text.
@@ -161,6 +181,12 @@ pub struct ClampedTextScaler {
 }
 
 impl ClampedTextScaler {
+    /// Creates a clamped scaler with the given small/large factors and size threshold.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either factor is negative or NaN, or if `threshold` is
+    /// not strictly positive.
     #[must_use]
     #[inline]
     pub fn new(small_factor: f64, large_factor: f64, threshold: f64) -> Self {
@@ -183,18 +209,21 @@ impl ClampedTextScaler {
         }
     }
 
+    /// Returns the scale factor applied to sizes below the threshold.
     #[must_use]
     #[inline]
     pub const fn small_factor(&self) -> f64 {
         self.small_factor
     }
 
+    /// Returns the scale factor applied to sizes at or above the threshold.
     #[must_use]
     #[inline]
     pub const fn large_factor(&self) -> f64 {
         self.large_factor
     }
 
+    /// Returns the font size threshold that separates small from large text.
     #[must_use]
     #[inline]
     pub const fn threshold(&self) -> f64 {

--- a/crates/flui-types/src/typography/text_style.rs
+++ b/crates/flui-types/src/typography/text_style.rs
@@ -4,6 +4,7 @@ use crate::Color;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// The thickness of glyphs used to draw text, on the standard 100–900 scale.
 pub enum FontWeight {
     /// Thin (100)
     W100,
@@ -32,6 +33,7 @@ impl FontWeight {
     /// Bold font weight (700).
     pub const BOLD: Self = Self::W700;
 
+    /// Returns the numeric weight value (100 for `W100` through 900 for `W900`).
     #[must_use]
     #[inline]
     pub const fn value(&self) -> u16 {
@@ -48,12 +50,17 @@ impl FontWeight {
         }
     }
 
+    /// Returns `true` if this weight renders as bold (600 or heavier).
     #[must_use]
     #[inline]
     pub const fn is_bold(&self) -> bool {
         self.value() >= 600
     }
 
+    /// Converts a CSS numeric weight to the nearest `FontWeight` variant.
+    ///
+    /// Values are bucketed to the closest hundred; out-of-range values
+    /// clamp to `W100` or `W900`.
     #[must_use]
     #[inline]
     pub const fn from_css(value: i32) -> Self {
@@ -80,7 +87,9 @@ impl Default for FontWeight {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Whether glyphs are drawn upright or slanted.
 pub enum FontStyle {
+    /// Upright (non-italic) font style.
     #[default]
     Normal,
     /// Italic font style.
@@ -89,6 +98,8 @@ pub enum FontStyle {
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// An OpenType feature setting (e.g. `"smcp"` for small caps) applied
+/// during text shaping.
 pub struct FontFeature {
     /// OpenType feature tag (4 characters).
     pub feature: String,
@@ -121,6 +132,8 @@ impl FontFeature {
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// A variable-font axis setting (e.g. `"wght"` for weight) applied
+/// during text shaping.
 pub struct FontVariation {
     /// Variation axis tag (4 characters).
     pub axis: String,
@@ -139,6 +152,9 @@ impl FontVariation {
     }
 }
 
+/// Defines a strut: a minimum line-height scaffold that vertical text
+/// metrics are laid out against, independent of the actual glyphs
+/// (mirrors Flutter's `StrutStyle`).
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct StrutStyle {
     /// Font family name.
@@ -196,6 +212,12 @@ impl StrutStyle {
 }
 
 #[derive(Default, Clone, Debug, PartialEq)]
+/// Visual and layout styling to apply to a span of text (mirrors
+/// Flutter's `TextStyle`).
+///
+/// All fields are optional; unset fields inherit from an enclosing style
+/// via `merge`. Use `layout_affecting_eq` to compare only the fields that
+/// influence glyph shaping and layout.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextStyle {
     /// Text color.
@@ -382,6 +404,7 @@ impl TextStyle {
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// A single shadow cast by text.
 pub struct TextShadow {
     /// Shadow color.
     pub color: Color,


### PR DESCRIPTION
## Summary

Wave 1 of the ship-quality program: the foundation cohort (flui-geometry, flui-types, flui-foundation, flui-tree, flui-macros) reaches the Definition of Ship for docs and Debug hygiene, with the bar locked by `#[deny(missing_docs)]` in all five crates.

- **flui-geometry** (calibration crate): all 77 undocumented public items documented (rsuperellipse, text_path, offset, rotation, relative_rect, transform2d, traits, matrix4, vector, units); crate README added; `readme` manifest field set; tracked allow replaced with `deny(missing_docs)`.
- **flui-types**: the long-standing doc backlog (tracked as "486 items remaining" since the `#[allow(missing_docs)]` era; 344 live items) is cleared across styling (66), painting (77), typography+gestures (71), physics (66), layout+platform (64+1) — Flutter-parity notes where behavior is non-obvious (premultiplied vs straight alpha, damping regimes, TextDecoration bitfields, winding rules). All 28 `missing_debug_implementations` fixed with derives; the crate now carries **zero tracked lint debt**.
- **flui-foundation / flui-tree / flui-macros**: already doc-complete; graduated from warn to `deny(missing_docs)` so the bar cannot silently regress.

Doc comments and Debug derives only — no behavior, signature, or visibility changes anywhere in the diff.

## Verification

- [x] `just ci` equivalent, all green locally on 1.96.0: fmt-check, taplo, typos, inventory-check (incl. lints guard), port-check, workspace clippy `-D warnings`, full test suite (lib + integration, `--test-threads=1`), doc-tests, rustdoc `-D warnings`
- [x] Flutter reference checked — docs describe the code's actual behavior (agents read implementations, not the reference); no behavior changes
- [x] New or changed behavior has tests — N/A (docs + derives only); `deny(missing_docs)` is itself the regression gate
- [x] Public API changes are documented — that is the entire diff; flui-types 118 doctests + 735 tests pass, flui-geometry 5 doctests pass

## Architecture

- [x] Layering unchanged — no dependency or code-structure edits
- [x] No new banned patterns — port-check green
- [x] No new dependencies

## Notes

- The stale "486 items remaining" figure in the old allow-comment was measured at 344 live items at burn-down time; both are now zero.
- Wave 1 hardening (unwrap/expect) needed no work: with `clippy::unwrap_used` active and clippy clean, the cohort has no production-path unwraps and no crate-level opt-outs.
- Next per the program: Wave 2 (flui-painting, flui-scheduler, flui-layer, flui-semantics, flui-interaction, flui-engine), whose tracked `TODO(ship-wave-2)` allows enumerate the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sjdi8ANg4pYBKDsyZJn9Mt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sjdi8ANg4pYBKDsyZJn9Mt)_