### PR TITLE
Ship-quality Wave 2: core-services cohort — zero crate-level lint debt

### DIFF
--- a/crates/flui-engine/src/lib.rs
+++ b/crates/flui-engine/src/lib.rs
@@ -64,6 +64,9 @@
 //! - `wgpu` (default) - wgpu GPU backend
 //! - Future: `skia`, `vello`, `software`
 
+// Ship bar (wave 2): every public item is documented; keep it that way.
+#![deny(missing_docs)]
+
 // Compile-time guard: the `fragile-send-sync-non-atomic-wasm` wgpu feature
 // marks !Send types as Send+Sync, which is only sound when the wasm target has
 // no threads (no atomics target feature). Enabling atomics with this feature

--- a/crates/flui-interaction/src/arena/mod.rs
+++ b/crates/flui-interaction/src/arena/mod.rs
@@ -1302,7 +1302,7 @@ impl std::fmt::Debug for GestureArena {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GestureArena")
             .field("active_arenas", &self.entries.len())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -1397,7 +1397,7 @@ mod tests {
                 assert!(rejected, "reentrant member should have been rejected");
                 assert!(accepted, "winner should have been accepted");
             }
-            Err(_) => panic!("arena deadlocked on reentrant reject_gesture"),
+            Err(err) => panic!("arena deadlocked on reentrant reject_gesture: {err}"),
         }
     }
 

--- a/crates/flui-interaction/src/arena/signal_resolver.rs
+++ b/crates/flui-interaction/src/arena/signal_resolver.rs
@@ -108,6 +108,15 @@ struct ResolverInner {
     handlers: HashMap<PointerId, Vec<SignalHandler>>,
 }
 
+// Manual impl: the registered handlers hold `dyn Fn` callbacks, which have no
+// useful `Debug` representation.
+impl std::fmt::Debug for PointerSignalResolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PointerSignalResolver")
+            .finish_non_exhaustive()
+    }
+}
+
 impl PointerSignalResolver {
     /// Creates a new signal resolver
     pub fn new() -> Self {

--- a/crates/flui-interaction/src/binding.rs
+++ b/crates/flui-interaction/src/binding.rs
@@ -346,7 +346,7 @@ impl GestureBinding {
     {
         match event {
             PointerEvent::Down(e) => {
-                let pointer_id = self.extract_pointer_id(event);
+                let pointer_id = Self::extract_pointer_id(event);
 
                 // Bound per-pointer state growth (memory-DoS guard). A re-down of
                 // an already-tracked pointer replaces rather than grows, so it is
@@ -398,7 +398,7 @@ impl GestureBinding {
             }
 
             PointerEvent::Move(_) => {
-                let pointer_id = self.extract_pointer_id(event);
+                let pointer_id = Self::extract_pointer_id(event);
 
                 // Coalesce move events - store only the latest, process on flush
                 self.pending_moves.insert(pointer_id, event.clone());
@@ -413,7 +413,7 @@ impl GestureBinding {
             }
 
             PointerEvent::Up(_) | PointerEvent::Cancel(_) => {
-                let pointer_id = self.extract_pointer_id(event);
+                let pointer_id = Self::extract_pointer_id(event);
 
                 // Use cached hit test result
                 if let Some((_, result)) = self.hit_tests.remove(&pointer_id) {
@@ -432,14 +432,14 @@ impl GestureBinding {
             PointerEvent::Enter(_) | PointerEvent::Leave(_) => {
                 // Enter/Leave don't participate in gesture recognition
                 // but we still dispatch them
-                let pointer_id = self.extract_pointer_id(event);
+                let pointer_id = Self::extract_pointer_id(event);
                 if let Some(result) = self.hit_tests.get(&pointer_id) {
                     self.dispatch_event(event, &result);
                 }
             }
 
             PointerEvent::Scroll(e) => {
-                let pointer_id = self.extract_pointer_id(event);
+                let pointer_id = Self::extract_pointer_id(event);
 
                 // Scroll events might not have a cached hit test
                 // Use the position to do a hit test if needed
@@ -455,7 +455,7 @@ impl GestureBinding {
 
             PointerEvent::Gesture(_) => {
                 // Gesture events are high-level and handled separately
-                let pointer_id = self.extract_pointer_id(event);
+                let pointer_id = Self::extract_pointer_id(event);
                 if let Some(result) = self.hit_tests.get(&pointer_id) {
                     self.dispatch_event(event, &result);
                 }
@@ -468,7 +468,7 @@ impl GestureBinding {
     /// Use this when you already have a hit test result or want to
     /// manually control hit testing.
     pub fn handle_pointer_event_with_result(&self, event: &PointerEvent, result: &HitTestResult) {
-        let pointer_id = self.extract_pointer_id(event);
+        let pointer_id = Self::extract_pointer_id(event);
 
         match event {
             PointerEvent::Down(_) => {
@@ -749,7 +749,7 @@ impl GestureBinding {
 
     /// Extract pointer ID from event.
     #[inline]
-    fn extract_pointer_id(&self, event: &PointerEvent) -> PointerId {
+    fn extract_pointer_id(event: &PointerEvent) -> PointerId {
         crate::events::extract_pointer_id(event)
     }
 
@@ -773,7 +773,7 @@ impl std::fmt::Debug for GestureBinding {
             .field("active_pointers", &self.hit_tests.len())
             .field("pending_moves", &self.pending_moves.len())
             .field("arena_count", &self.arena.len())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-interaction/src/events.rs
+++ b/crates/flui-interaction/src/events.rs
@@ -225,7 +225,7 @@ impl PointerEventData {
 
     /// Create from a ui-events PointerEvent
     pub fn from_pointer_event(event: &PointerEvent) -> Option<Self> {
-        let info = get_pointer_info(event)?;
+        let info = get_pointer_info(event);
         let state = get_pointer_state(event);
 
         let (position, time_stamp, buttons) = if let Some(s) = state {
@@ -331,8 +331,9 @@ impl InputEvent {
     /// a hash of the persistent device ID if available.
     pub fn device_id(&self) -> Option<DeviceId> {
         match self {
-            InputEvent::DeviceAdded { device_id, .. } => Some(*device_id),
-            InputEvent::DeviceRemoved { device_id } => Some(*device_id),
+            InputEvent::DeviceAdded { device_id, .. } | InputEvent::DeviceRemoved { device_id } => {
+                Some(*device_id)
+            }
             InputEvent::Pointer(event) => {
                 // Extract pointer_id from the event into the legacy
                 // `DeviceId = i32` surface. Primary pointer ⇒ 0;
@@ -349,7 +350,7 @@ impl InputEvent {
                 // directly. Callers needing physical-device stability
                 // should consume `PointerInfo::persistent_device_id`
                 // upstream rather than via this legacy DeviceId mapping.
-                let info = get_pointer_info(event)?;
+                let info = get_pointer_info(event);
                 let id = info.pointer_id?;
                 if id.is_primary_pointer() {
                     Some(0)
@@ -413,17 +414,16 @@ impl From<KeyboardEvent> for InputEvent {
 // ============================================================================
 
 /// Extracts PointerInfo from a PointerEvent.
+///
+/// Infallible: every `PointerEvent` variant carries a `PointerInfo`.
 #[inline]
-fn get_pointer_info(event: &PointerEvent) -> Option<&PointerInfo> {
+fn get_pointer_info(event: &PointerEvent) -> &PointerInfo {
     match event {
-        PointerEvent::Down(e) => Some(&e.pointer),
-        PointerEvent::Up(e) => Some(&e.pointer),
-        PointerEvent::Move(e) => Some(&e.pointer),
-        PointerEvent::Cancel(info) | PointerEvent::Enter(info) | PointerEvent::Leave(info) => {
-            Some(info)
-        }
-        PointerEvent::Scroll(e) => Some(&e.pointer),
-        PointerEvent::Gesture(e) => Some(&e.pointer),
+        PointerEvent::Down(e) | PointerEvent::Up(e) => &e.pointer,
+        PointerEvent::Move(e) => &e.pointer,
+        PointerEvent::Cancel(info) | PointerEvent::Enter(info) | PointerEvent::Leave(info) => info,
+        PointerEvent::Scroll(e) => &e.pointer,
+        PointerEvent::Gesture(e) => &e.pointer,
     }
 }
 
@@ -431,8 +431,7 @@ fn get_pointer_info(event: &PointerEvent) -> Option<&PointerInfo> {
 #[inline]
 fn get_pointer_state(event: &PointerEvent) -> Option<&PointerState> {
     match event {
-        PointerEvent::Down(e) => Some(&e.state),
-        PointerEvent::Up(e) => Some(&e.state),
+        PointerEvent::Down(e) | PointerEvent::Up(e) => Some(&e.state),
         PointerEvent::Move(e) => Some(&e.current),
         PointerEvent::Scroll(e) => Some(&e.state),
         PointerEvent::Gesture(e) => Some(&e.state),
@@ -466,7 +465,7 @@ impl PointerEventExt for PointerEvent {
 
     #[inline]
     fn pointer_type(&self) -> Option<PointerType> {
-        get_pointer_info(self).map(|info| info.pointer_type)
+        Some(get_pointer_info(self).pointer_type)
     }
 }
 
@@ -885,8 +884,7 @@ pub fn make_scroll_event(position: Offset<Pixels>, delta: Offset<Pixels>) -> Poi
 #[must_use]
 pub fn extract_pointer_id(event: &PointerEvent) -> crate::ids::PointerId {
     let info = match event {
-        PointerEvent::Down(e) => &e.pointer,
-        PointerEvent::Up(e) => &e.pointer,
+        PointerEvent::Down(e) | PointerEvent::Up(e) => &e.pointer,
         PointerEvent::Move(e) => &e.pointer,
         PointerEvent::Cancel(info) | PointerEvent::Enter(info) | PointerEvent::Leave(info) => info,
         PointerEvent::Scroll(e) => &e.pointer,

--- a/crates/flui-interaction/src/lib.rs
+++ b/crates/flui-interaction/src/lib.rs
@@ -130,19 +130,8 @@
 //! - ✅ Clear separation of concerns (SOLID principles)
 //! - ✅ Smaller compile times and dependencies
 
-// Lint levels come from `[workspace.lints]`. Tracked ship-quality debt:
-#![allow(missing_docs)] // TODO(ship-wave-2): public-item doc backlog (~33 items), then delete
-#![allow(missing_debug_implementations)] // TODO(ship-wave-2): add Debug impls (7 types), then delete
-#![allow(
-    clippy::comparison_chain,
-    clippy::many_single_char_names,
-    clippy::match_same_arms,
-    clippy::match_wild_err_arm,
-    clippy::missing_fields_in_debug,
-    clippy::struct_field_names,
-    clippy::unnecessary_wraps,
-    clippy::unused_self
-)] // TODO(ship-wave-2): burn down per-lint, then delete
+// Ship bar (wave 2): every public item is documented; keep it that way.
+#![deny(missing_docs)]
 
 // ============================================================================
 // Core infrastructure modules

--- a/crates/flui-interaction/src/processing/lsq_solver.rs
+++ b/crates/flui-interaction/src/processing/lsq_solver.rs
@@ -138,6 +138,8 @@ impl PolynomialFit {
 /// fit the x and y pointer coordinates together via [`solve_two`], which shares
 /// the QR factorization.
 #[cfg(test)]
+// Math-style names (x, y, w, q, r, m, n) mirror Flutter's lsq_solver.dart.
+#[allow(clippy::many_single_char_names)]
 pub(crate) fn solve_one(x: &[f64], y: &[f64], w: &[f64], degree: usize) -> Option<PolynomialFit> {
     debug_assert_eq!(x.len(), y.len(), "x and y must have the same length");
     debug_assert_eq!(x.len(), w.len(), "x and w must have the same length");
@@ -156,6 +158,9 @@ pub(crate) fn solve_one(x: &[f64], y: &[f64], w: &[f64], degree: usize) -> Optio
 /// side, so it can be reused across multiple `y`-vectors — see [`solve_two`].
 /// Complexity: O(n²·m), and with n ≤ `MAX_DEGREE`+1 and m ≤ `MAX_SAMPLES` that is
 /// a small bounded constant.
+// Math-style names (x, w, q, r, a, m, n, h, i, j) mirror Flutter's
+// lsq_solver.dart QR/Gram-Schmidt algorithm; renaming would hurt parity review.
+#[allow(clippy::many_single_char_names)]
 fn factorize(
     x: &[f64],
     w: &[f64],
@@ -230,6 +235,9 @@ fn factorize(
 /// factorization from [`factorize`]. Back-substitutes `R B = Qᵀ W Y` and
 /// computes the R² confidence. `x`/`w` must be the slices that produced the
 /// factorization. Complexity: O(n·m).
+// Math-style names (x, y, w, q, r, m, n, h, i, j) mirror Flutter's
+// lsq_solver.dart back-substitution; renaming would hurt parity review.
+#[allow(clippy::many_single_char_names)]
 fn solve_rhs(
     x: &[f64],
     y: &[f64],
@@ -297,6 +305,8 @@ fn solve_rhs(
 /// dominant O(n²·m) cost — is computed once and reused for both, halving the
 /// factorization work versus two independent `solve_one` calls. (`solve_one`
 /// is `#[cfg(test)]`, so it is not an intra-doc link here.)
+// Math-style names (x, w, q, r, m, n) mirror Flutter's lsq_solver.dart.
+#[allow(clippy::many_single_char_names)]
 pub(crate) fn solve_two(
     x: &[f64],
     w: &[f64],
@@ -320,6 +330,8 @@ mod tests {
     use super::*;
 
     /// Helper: build (t, v) samples for a perfect line v = a + b·t.
+    // Math-style names (a, b, x, y, w) match the line equation in the doc.
+    #[allow(clippy::many_single_char_names)]
     fn linear_samples(a: f64, b: f64, count: usize, dt: f64) -> (Vec<f64>, Vec<f64>, Vec<f64>) {
         let x: Vec<f64> = (0..count).map(|i| -((count - 1 - i) as f64) * dt).collect();
         let y: Vec<f64> = x.iter().map(|&t| a + b * t).collect();

--- a/crates/flui-interaction/src/processing/resampler.rs
+++ b/crates/flui-interaction/src/processing/resampler.rs
@@ -95,11 +95,12 @@ struct BufferedEvent {
 /// # Thread Safety
 ///
 /// This type is thread-safe using `Arc<Mutex<_>>` internally.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct PointerEventResampler {
     inner: Arc<Mutex<ResamplerInner>>,
 }
 
+#[derive(Debug)]
 struct ResamplerInner {
     /// Pointer ID this resampler tracks
     pointer_id: PointerId,

--- a/crates/flui-interaction/src/recognizers/double_tap.rs
+++ b/crates/flui-interaction/src/recognizers/double_tap.rs
@@ -427,8 +427,7 @@ impl DoubleTapGestureRecognizer {
     fn extract_event_data(event: &PointerEvent) -> (Offset<Pixels>, PointerType) {
         let position = event.position();
         let pointer_type = match event {
-            PointerEvent::Down(e) => e.pointer.pointer_type,
-            PointerEvent::Up(e) => e.pointer.pointer_type,
+            PointerEvent::Down(e) | PointerEvent::Up(e) => e.pointer.pointer_type,
             PointerEvent::Move(e) => e.pointer.pointer_type,
             PointerEvent::Cancel(info) | PointerEvent::Enter(info) | PointerEvent::Leave(info) => {
                 info.pointer_type
@@ -586,7 +585,7 @@ impl std::fmt::Debug for DoubleTapGestureRecognizer {
             .field("state", &self.state)
             .field("gesture_state", &self.gesture_state.lock())
             .field("settings", &self.settings.lock())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-interaction/src/recognizers/drag.rs
+++ b/crates/flui-interaction/src/recognizers/drag.rs
@@ -107,11 +107,15 @@ pub struct DragEndDetails {
 // Re-export Velocity from the velocity module
 pub use crate::processing::Velocity;
 
-/// Callback types for drag events
+/// Callback fired when a pointer contacts the screen and might begin a drag.
 pub type DragDownCallback = Arc<dyn Fn(DragDownDetails) + Send + Sync>;
+/// Callback fired when the drag is recognized (slop crossed and arena won).
 pub type DragStartCallback = Arc<dyn Fn(DragStartDetails) + Send + Sync>;
+/// Callback fired for each pointer move while the drag is in progress.
 pub type DragUpdateCallback = Arc<dyn Fn(DragUpdateDetails) + Send + Sync>;
+/// Callback fired when the pointer lifts and the drag completes.
 pub type DragEndCallback = Arc<dyn Fn(DragEndDetails) + Send + Sync>;
+/// Callback fired when the gesture is cancelled (e.g. the arena rejects it).
 pub type DragCancelCallback = Arc<dyn Fn() + Send + Sync>;
 
 /// Recognizes drag gestures
@@ -175,6 +179,8 @@ impl std::fmt::Debug for DragGestureRecognizer {
     }
 }
 
+// Field names keep Flutter's `onDragStart`-style callback names (parity).
+#[allow(clippy::struct_field_names)]
 #[derive(Default)]
 struct DragCallbacks {
     on_down: Option<DragDownCallback>,
@@ -532,8 +538,7 @@ impl DragGestureRecognizer {
     fn extract_event_data(event: &PointerEvent) -> (Offset<Pixels>, PointerType) {
         let position = event.position();
         let pointer_type = match event {
-            PointerEvent::Down(e) => e.pointer.pointer_type,
-            PointerEvent::Up(e) => e.pointer.pointer_type,
+            PointerEvent::Down(e) | PointerEvent::Up(e) => e.pointer.pointer_type,
             PointerEvent::Move(e) => e.pointer.pointer_type,
             PointerEvent::Cancel(info) | PointerEvent::Enter(info) | PointerEvent::Leave(info) => {
                 info.pointer_type

--- a/crates/flui-interaction/src/recognizers/force_press.rs
+++ b/crates/flui-interaction/src/recognizers/force_press.rs
@@ -91,6 +91,8 @@ pub struct ForcePressGestureRecognizer {
     peak_pressure: f32,
 }
 
+// Field names keep Flutter's `onForcePressStart`-style callback names (parity).
+#[allow(clippy::struct_field_names)]
 #[derive(Default)]
 struct ForcePressCallbacks {
     on_start: Option<ForcePressStartCallback>,
@@ -254,7 +256,7 @@ impl ForcePressGestureRecognizer {
     }
 
     /// Create force press details from current state
-    fn create_details(&self, state: &ForcePressState) -> ForcePressDetails {
+    fn create_details(state: &ForcePressState) -> ForcePressDetails {
         ForcePressDetails::new(
             state.current_position,
             state.current_position, // local_position (updated during hit testing)
@@ -286,7 +288,7 @@ impl ForcePressGestureRecognizer {
         // Check if already past start threshold
         if state.current_pressure >= self.start_pressure {
             state.phase = ForcePressPhase::Started;
-            let details = self.create_details(&state);
+            let details = Self::create_details(&state);
             drop(state);
 
             // Call on_start callback
@@ -310,7 +312,7 @@ impl ForcePressGestureRecognizer {
                 if state.phase == ForcePressPhase::Started || state.phase == ForcePressPhase::Peaked
                 {
                     state.phase = ForcePressPhase::Ended;
-                    let details = self.create_details(&state);
+                    let details = Self::create_details(&state);
                     drop(state);
 
                     if let Some(callback) = self.callbacks.lock().on_end.clone() {
@@ -330,7 +332,7 @@ impl ForcePressGestureRecognizer {
             ForcePressPhase::Possible if state.current_pressure >= self.start_pressure => {
                 // Pressure crossed the start threshold — fire on_start.
                 state.phase = ForcePressPhase::Started;
-                let details = self.create_details(&state);
+                let details = Self::create_details(&state);
                 drop(state);
 
                 if let Some(callback) = self.callbacks.lock().on_start.clone() {
@@ -338,7 +340,7 @@ impl ForcePressGestureRecognizer {
                 }
             }
             ForcePressPhase::Started => {
-                let details = self.create_details(&state);
+                let details = Self::create_details(&state);
 
                 // Check for peak
                 if !state.peak_triggered && state.current_pressure >= self.peak_pressure {
@@ -366,7 +368,7 @@ impl ForcePressGestureRecognizer {
                 }
             }
             ForcePressPhase::Peaked => {
-                let details = self.create_details(&state);
+                let details = Self::create_details(&state);
                 drop(state);
 
                 // Call update callback
@@ -393,7 +395,7 @@ impl ForcePressGestureRecognizer {
 
         if state.phase == ForcePressPhase::Started || state.phase == ForcePressPhase::Peaked {
             state.phase = ForcePressPhase::Ended;
-            let details = self.create_details(&state);
+            let details = Self::create_details(&state);
             drop(state);
 
             if let Some(callback) = self.callbacks.lock().on_end.clone() {
@@ -411,7 +413,7 @@ impl ForcePressGestureRecognizer {
     fn handle_end(&self) {
         let mut state = self.gesture_state.lock();
         state.phase = ForcePressPhase::Ended;
-        let details = self.create_details(&state);
+        let details = Self::create_details(&state);
         drop(state);
 
         if let Some(callback) = self.callbacks.lock().on_end.clone() {
@@ -427,7 +429,7 @@ impl ForcePressGestureRecognizer {
 
         if state.phase == ForcePressPhase::Started || state.phase == ForcePressPhase::Peaked {
             state.phase = ForcePressPhase::Ended;
-            let details = self.create_details(&state);
+            let details = Self::create_details(&state);
             drop(state);
 
             if let Some(callback) = self.callbacks.lock().on_end.clone() {
@@ -560,7 +562,7 @@ impl GestureArenaMember for ForcePressGestureRecognizer {
         let mut state = self.gesture_state.lock();
         if state.phase == ForcePressPhase::Started || state.phase == ForcePressPhase::Peaked {
             state.phase = ForcePressPhase::Ended;
-            let details = self.create_details(&state);
+            let details = Self::create_details(&state);
             drop(state);
 
             if let Some(callback) = self.callbacks.lock().on_end.clone() {
@@ -580,7 +582,7 @@ impl std::fmt::Debug for ForcePressGestureRecognizer {
             .field("settings", &self.settings.lock())
             .field("start_pressure", &self.start_pressure)
             .field("peak_pressure", &self.peak_pressure)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-interaction/src/recognizers/long_press.rs
+++ b/crates/flui-interaction/src/recognizers/long_press.rs
@@ -113,6 +113,8 @@ pub struct LongPressGestureRecognizer {
     settings: Arc<Mutex<GestureSettings>>,
 }
 
+// Field names keep Flutter's `onLongPressStart`-style callback names (parity).
+#[allow(clippy::struct_field_names)]
 #[derive(Default)]
 struct LongPressCallbacks {
     on_long_press_down: Option<LongPressDownCallback>,
@@ -638,7 +640,7 @@ impl std::fmt::Debug for LongPressGestureRecognizer {
             .field("state", &self.state)
             .field("gesture_state", &self.gesture_state.lock())
             .field("settings", &self.settings.lock())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-interaction/src/recognizers/multi_tap.rs
+++ b/crates/flui-interaction/src/recognizers/multi_tap.rs
@@ -250,15 +250,18 @@ impl MultiTapGestureRecognizer {
 
                 state.device_kind = Some(kind);
 
-                if state.pointers.len() < self.required_pointer_count {
-                    state.phase = MultiTapPhase::Collecting;
-                } else if state.pointers.len() == self.required_pointer_count {
-                    // Got all required pointers!
-                    state.phase = MultiTapPhase::WaitingForUp;
-                } else {
-                    // Too many pointers - cancel (don't set phase here, let handle_cancel do it)
-                    drop(state);
-                    self.handle_cancel();
+                match state.pointers.len().cmp(&self.required_pointer_count) {
+                    std::cmp::Ordering::Less => state.phase = MultiTapPhase::Collecting,
+                    std::cmp::Ordering::Equal => {
+                        // Got all required pointers!
+                        state.phase = MultiTapPhase::WaitingForUp;
+                    }
+                    std::cmp::Ordering::Greater => {
+                        // Too many pointers - cancel (don't set phase here, let
+                        // handle_cancel do it)
+                        drop(state);
+                        self.handle_cancel();
+                    }
                 }
             }
             MultiTapPhase::WaitingForUp => {
@@ -314,7 +317,7 @@ impl MultiTapGestureRecognizer {
                     .map(|info| info.initial_position)
                     .collect();
 
-                let center = self.calculate_center(&positions);
+                let center = Self::calculate_center(&positions);
                 let count = positions.len();
 
                 drop(state);
@@ -355,7 +358,7 @@ impl MultiTapGestureRecognizer {
             let center = if positions.is_empty() {
                 Offset::new(Pixels::ZERO, Pixels::ZERO)
             } else {
-                self.calculate_center(&positions)
+                Self::calculate_center(&positions)
             };
 
             let count = positions.len();
@@ -381,7 +384,7 @@ impl MultiTapGestureRecognizer {
     }
 
     /// Calculate center point of all positions
-    fn calculate_center(&self, positions: &[Offset<Pixels>]) -> Offset<Pixels> {
+    fn calculate_center(positions: &[Offset<Pixels>]) -> Offset<Pixels> {
         if positions.is_empty() {
             return Offset::new(Pixels::ZERO, Pixels::ZERO);
         }
@@ -492,7 +495,7 @@ impl std::fmt::Debug for MultiTapGestureRecognizer {
             .field("required_pointer_count", &self.required_pointer_count)
             .field("gesture_state", &self.gesture_state.lock())
             .field("settings", &self.settings.lock())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-interaction/src/recognizers/scale.rs
+++ b/crates/flui-interaction/src/recognizers/scale.rs
@@ -127,6 +127,8 @@ impl std::fmt::Debug for ScaleGestureRecognizer {
     }
 }
 
+// Field names keep Flutter's `onScaleStart`-style callback names (parity).
+#[allow(clippy::struct_field_names)]
 #[derive(Default)]
 struct ScaleCallbacks {
     on_start: Option<ScaleStartCallback>,
@@ -247,21 +249,21 @@ impl ScaleGestureRecognizer {
             state.phase = ScalePhase::Possible;
 
             // Calculate initial spans and rotation
-            let spans = self.calculate_spans(&state.pointers);
+            let spans = Self::calculate_spans(&state.pointers);
             state.initial_span = Some(spans.0);
             state.initial_horizontal_span = Some(spans.1);
             state.initial_vertical_span = Some(spans.2);
-            state.initial_rotation = Some(self.calculate_rotation(&state.pointers));
+            state.initial_rotation = Some(Self::calculate_rotation(&state.pointers));
             state.previous_span = Some(spans.0);
             state.current_rotation = 0.0;
         } else if state.pointers.len() > 2 {
             // Additional pointers - recalculate initial span if not started
             if state.phase == ScalePhase::Possible {
-                let spans = self.calculate_spans(&state.pointers);
+                let spans = Self::calculate_spans(&state.pointers);
                 state.initial_span = Some(spans.0);
                 state.initial_horizontal_span = Some(spans.1);
                 state.initial_vertical_span = Some(spans.2);
-                state.initial_rotation = Some(self.calculate_rotation(&state.pointers));
+                state.initial_rotation = Some(Self::calculate_rotation(&state.pointers));
                 state.previous_span = Some(spans.0);
                 state.current_rotation = 0.0;
             }
@@ -281,7 +283,7 @@ impl ScaleGestureRecognizer {
             return; // Need at least 2 pointers
         }
 
-        let spans = self.calculate_spans(&state.pointers);
+        let spans = Self::calculate_spans(&state.pointers);
         let current_span = spans.0;
         let current_h_span = spans.1;
         let current_v_span = spans.2;
@@ -300,7 +302,7 @@ impl ScaleGestureRecognizer {
                         state.phase = ScalePhase::Started;
                         state.previous_span = Some(current_span);
 
-                        let focal_point = self.calculate_focal_point(&state.pointers);
+                        let focal_point = Self::calculate_focal_point(&state.pointers);
                         drop(state); // Release lock before callback
 
                         // Call on_start callback
@@ -333,7 +335,7 @@ impl ScaleGestureRecognizer {
                     let v_scale = current_v_span / initial_v_span;
 
                     // Calculate rotation delta from initial angle
-                    let current_rotation_raw = self.calculate_rotation(&state.pointers);
+                    let current_rotation_raw = Self::calculate_rotation(&state.pointers);
                     let rotation = current_rotation_raw - initial_rotation;
 
                     // Track scale velocity: use scale as a position-like value
@@ -347,7 +349,7 @@ impl ScaleGestureRecognizer {
                     state.previous_span = Some(current_span);
                     state.current_rotation = rotation;
 
-                    let focal_point = self.calculate_focal_point(&state.pointers);
+                    let focal_point = Self::calculate_focal_point(&state.pointers);
                     let pointer_count = state.pointers.len();
                     drop(state); // Release lock before callback
 
@@ -383,7 +385,7 @@ impl ScaleGestureRecognizer {
                 let focal_point = if state.pointers.is_empty() {
                     Offset::ZERO
                 } else {
-                    self.calculate_focal_point(&state.pointers)
+                    Self::calculate_focal_point(&state.pointers)
                 };
 
                 let scale = if let (Some(initial_span), Some(prev_span)) =
@@ -443,11 +445,11 @@ impl ScaleGestureRecognizer {
             }
         } else if state.pointers.len() >= 2 && state.phase == ScalePhase::Possible {
             // Still have 2+ pointers, recalculate initial span
-            let spans = self.calculate_spans(&state.pointers);
+            let spans = Self::calculate_spans(&state.pointers);
             state.initial_span = Some(spans.0);
             state.initial_horizontal_span = Some(spans.1);
             state.initial_vertical_span = Some(spans.2);
-            state.initial_rotation = Some(self.calculate_rotation(&state.pointers));
+            state.initial_rotation = Some(Self::calculate_rotation(&state.pointers));
             state.previous_span = Some(spans.0);
         }
     }
@@ -480,7 +482,7 @@ impl ScaleGestureRecognizer {
 
     /// Calculate span (distance) between pointers
     /// Returns (total_span, horizontal_span, vertical_span)
-    fn calculate_spans(&self, pointers: &HashMap<PointerId, Offset<Pixels>>) -> (f32, f32, f32) {
+    fn calculate_spans(pointers: &HashMap<PointerId, Offset<Pixels>>) -> (f32, f32, f32) {
         if pointers.len() < 2 {
             return (0.0, 0.0, 0.0);
         }
@@ -515,10 +517,7 @@ impl ScaleGestureRecognizer {
     }
 
     /// Calculate focal point (center of all pointers)
-    fn calculate_focal_point(
-        &self,
-        pointers: &HashMap<PointerId, Offset<Pixels>>,
-    ) -> Offset<Pixels> {
+    fn calculate_focal_point(pointers: &HashMap<PointerId, Offset<Pixels>>) -> Offset<Pixels> {
         if pointers.is_empty() {
             return Offset::ZERO;
         }
@@ -540,7 +539,7 @@ impl ScaleGestureRecognizer {
     /// For 2 pointers, returns the angle of the line between them.
     /// For more pointers, returns the average angle from the focal point to
     /// each pointer.
-    fn calculate_rotation(&self, pointers: &HashMap<PointerId, Offset<Pixels>>) -> f32 {
+    fn calculate_rotation(pointers: &HashMap<PointerId, Offset<Pixels>>) -> f32 {
         if pointers.len() < 2 {
             return 0.0;
         }
@@ -553,7 +552,7 @@ impl ScaleGestureRecognizer {
             delta.dy.atan2(delta.dx)
         } else {
             // For more pointers, calculate average angle from focal point
-            let focal = self.calculate_focal_point(pointers);
+            let focal = Self::calculate_focal_point(pointers);
             let mut total_angle = 0.0;
             let mut count = 0;
 
@@ -760,9 +759,6 @@ mod tests {
 
     #[test]
     fn test_focal_point_calculation() {
-        let arena = GestureArena::new();
-        let recognizer = ScaleGestureRecognizer::new(arena);
-
         let mut pointers = HashMap::new();
         pointers.insert(
             PointerId::new(2).expect("nonzero pointer id"),
@@ -773,7 +769,7 @@ mod tests {
             Offset::new(Pixels(100.0), Pixels(100.0)),
         );
 
-        let focal_point = recognizer.calculate_focal_point(&pointers);
+        let focal_point = ScaleGestureRecognizer::calculate_focal_point(&pointers);
 
         // Center should be at (50, 50)
         assert!((focal_point.dx - Pixels(50.0)).abs() < Pixels(0.01));
@@ -782,9 +778,6 @@ mod tests {
 
     #[test]
     fn test_span_calculation() {
-        let arena = GestureArena::new();
-        let recognizer = ScaleGestureRecognizer::new(arena);
-
         let mut pointers = HashMap::new();
         pointers.insert(
             PointerId::new(2).expect("nonzero pointer id"),
@@ -795,7 +788,7 @@ mod tests {
             Offset::new(Pixels(100.0), Pixels(0.0)),
         );
 
-        let (span, h_span, v_span) = recognizer.calculate_spans(&pointers);
+        let (span, h_span, v_span) = ScaleGestureRecognizer::calculate_spans(&pointers);
 
         // Distance should be 100
         assert!((span - 100.0).abs() < 0.01);
@@ -827,7 +820,7 @@ mod tests {
         recognizer.handle_pointer_move(pointer2, Offset::new(Pixels(200.0), Pixels(0.0)));
 
         let state = recognizer.gesture_state.lock();
-        let current_span = recognizer.calculate_spans(&state.pointers).0;
+        let current_span = ScaleGestureRecognizer::calculate_spans(&state.pointers).0;
         assert!((current_span - 200.0).abs() < 0.01);
 
         // Calculate scale manually

--- a/crates/flui-interaction/src/recognizers/tap.rs
+++ b/crates/flui-interaction/src/recognizers/tap.rs
@@ -167,6 +167,8 @@ impl std::fmt::Debug for TapGestureRecognizer {
     }
 }
 
+// Field names keep Flutter's `onTapDown`-style callback names (parity).
+#[allow(clippy::struct_field_names)]
 #[derive(Default)]
 struct TapCallbacks {
     on_tap_down: Option<TapCallback>,

--- a/crates/flui-interaction/src/recognizers/tap_and_drag.rs
+++ b/crates/flui-interaction/src/recognizers/tap_and_drag.rs
@@ -121,11 +121,18 @@ pub struct TapDragEndDetails {
 // Callbacks
 // ============================================================================
 
+/// Callback fired when the primary pointer contacts the screen.
 pub type TapDragDownCallback = Arc<dyn Fn(TapDragDownDetails) + Send + Sync>;
+/// Callback fired when the pointer lifts before crossing drag slop (a tap).
 pub type TapDragUpCallback = Arc<dyn Fn(TapDragUpDetails) + Send + Sync>;
+/// Callback fired when the pointer crosses drag slop and the drag begins.
 pub type TapDragStartCallback = Arc<dyn Fn(TapDragStartDetails) + Send + Sync>;
+/// Callback fired for each pointer move while the drag is in progress.
 pub type TapDragUpdateCallback = Arc<dyn Fn(TapDragUpdateDetails) + Send + Sync>;
+/// Callback fired when the pointer lifts and the drag completes.
 pub type TapDragEndCallback = Arc<dyn Fn(TapDragEndDetails) + Send + Sync>;
+/// Callback fired when the sequence is cancelled (arena loss or pointer
+/// cancel) — neither the tap nor the drag outcome will fire.
 pub type TapDragCancelCallback = Arc<dyn Fn() + Send + Sync>;
 
 // ============================================================================
@@ -147,6 +154,9 @@ enum Phase {
     Finished,
 }
 
+// Field names keep Flutter's `onTapDown`/`onDragStart`-style callback names
+// (parity with `BaseTapAndDragGestureRecognizer`).
+#[allow(clippy::struct_field_names)]
 #[derive(Default)]
 struct TapDragCallbacks {
     on_tap_down: Option<TapDragDownCallback>,
@@ -263,6 +273,8 @@ impl TapAndDragGestureRecognizer {
     // Builder-style callback setters
     // ========================================================================
 
+    /// Register the tap-down callback (fires on pointer contact, once the
+    /// arena has accepted this recogniser).
     pub fn with_on_tap_down(
         self: Arc<Self>,
         cb: impl Fn(TapDragDownDetails) + Send + Sync + 'static,
@@ -271,6 +283,8 @@ impl TapAndDragGestureRecognizer {
         self
     }
 
+    /// Register the tap-up callback (fires when the pointer lifts before
+    /// crossing drag slop, resolving the sequence as a tap).
     pub fn with_on_tap_up(
         self: Arc<Self>,
         cb: impl Fn(TapDragUpDetails) + Send + Sync + 'static,
@@ -279,6 +293,8 @@ impl TapAndDragGestureRecognizer {
         self
     }
 
+    /// Register the drag-start callback (fires when the pointer crosses drag
+    /// slop, voiding the tap outcome).
     pub fn with_on_drag_start(
         self: Arc<Self>,
         cb: impl Fn(TapDragStartDetails) + Send + Sync + 'static,
@@ -287,6 +303,8 @@ impl TapAndDragGestureRecognizer {
         self
     }
 
+    /// Register the drag-update callback (fires for each pointer move while
+    /// the drag is in progress).
     pub fn with_on_drag_update(
         self: Arc<Self>,
         cb: impl Fn(TapDragUpdateDetails) + Send + Sync + 'static,
@@ -295,6 +313,8 @@ impl TapAndDragGestureRecognizer {
         self
     }
 
+    /// Register the drag-end callback (fires when the pointer lifts after a
+    /// drag, with end-of-drag velocity).
     pub fn with_on_drag_end(
         self: Arc<Self>,
         cb: impl Fn(TapDragEndDetails) + Send + Sync + 'static,
@@ -303,6 +323,8 @@ impl TapAndDragGestureRecognizer {
         self
     }
 
+    /// Register the cancel callback (fires when the sequence is cancelled by
+    /// an arena loss or a pointer-cancel event).
     pub fn with_on_cancel(self: Arc<Self>, cb: impl Fn() + Send + Sync + 'static) -> Arc<Self> {
         self.callbacks.lock().on_cancel = Some(Arc::new(cb));
         self

--- a/crates/flui-interaction/src/routing/event_router.rs
+++ b/crates/flui-interaction/src/routing/event_router.rs
@@ -38,6 +38,7 @@ use crate::{
 /// // Route keyboard event (goes to focused element)
 /// router.route_event(&mut root_layer, &Event::Key(key_event));
 /// ```
+#[derive(Debug)]
 pub struct EventRouter {
     /// Pointer state tracking (for drag gestures)
     pointer_state: Arc<RwLock<HashMap<PointerId, PointerStateTracking>>>,
@@ -76,10 +77,10 @@ impl EventRouter {
                 self.route_pointer_event(root, pointer_event);
             }
             Event::Keyboard(key_event) | Event::Key(key_event) => {
-                self.route_key_event(root, key_event);
+                Self::route_key_event(root, key_event);
             }
             Event::Scroll(scroll_event_data) => {
-                self.route_scroll_event(root, scroll_event_data);
+                Self::route_scroll_event(root, scroll_event_data);
             }
         }
     }
@@ -178,7 +179,7 @@ impl EventRouter {
     /// 2. Focused node's handler
     ///
     /// Returns `true` if the event was handled.
-    fn route_key_event(&mut self, _root: &mut dyn HitTestable, event: &KeyEvent) -> bool {
+    fn route_key_event(_root: &mut dyn HitTestable, event: &KeyEvent) -> bool {
         let handled = FocusManager::global().dispatch_key_event(event);
 
         if !handled {
@@ -198,7 +199,7 @@ impl EventRouter {
     /// until a handler returns `EventPropagation::Stop`.
     ///
     /// Returns `true` if the event was handled.
-    fn route_scroll_event(&mut self, root: &mut dyn HitTestable, event: &ScrollEventData) -> bool {
+    fn route_scroll_event(root: &mut dyn HitTestable, event: &ScrollEventData) -> bool {
         let position = event.position;
 
         // Hit test to find scrollable targets

--- a/crates/flui-interaction/src/routing/focus.rs
+++ b/crates/flui-interaction/src/routing/focus.rs
@@ -157,7 +157,7 @@ impl std::fmt::Debug for FocusManager {
             .field("primary_focus", &*self.primary_focus.read())
             .field("root_scope_id", &self.root_scope.id())
             .field("listener_count", &self.listeners.read().len())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-interaction/src/routing/focus_scope.rs
+++ b/crates/flui-interaction/src/routing/focus_scope.rs
@@ -547,7 +547,7 @@ impl std::fmt::Debug for FocusNode {
             .field("skip_traversal", &self.skip_traversal())
             .field("attached", &self.is_attached())
             .field("children_count", &self.children.read().len())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -798,7 +798,7 @@ impl std::fmt::Debug for FocusScopeNode {
             .field("autofocus", &self.autofocus())
             .field("traps_focus", &self.traps_focus())
             .field("focused_child", &self.focused_child())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -833,14 +833,14 @@ pub struct ReadingOrderPolicy;
 
 impl FocusTraversalPolicy for ReadingOrderPolicy {
     fn find_next(&self, current: FocusNodeId, nodes: &[Arc<FocusNode>]) -> Option<FocusNodeId> {
-        let sorted = self.sorted_indices(nodes);
+        let sorted = Self::sorted_indices(nodes);
         let current_idx = sorted.iter().position(|&i| nodes[i].id() == current)?;
         let next_idx = (current_idx + 1) % sorted.len();
         Some(nodes[sorted[next_idx]].id())
     }
 
     fn find_previous(&self, current: FocusNodeId, nodes: &[Arc<FocusNode>]) -> Option<FocusNodeId> {
-        let sorted = self.sorted_indices(nodes);
+        let sorted = Self::sorted_indices(nodes);
         let current_idx = sorted.iter().position(|&i| nodes[i].id() == current)?;
         let prev_idx = if current_idx == 0 {
             sorted.len() - 1
@@ -851,12 +851,12 @@ impl FocusTraversalPolicy for ReadingOrderPolicy {
     }
 
     fn find_first(&self, nodes: &[Arc<FocusNode>]) -> Option<FocusNodeId> {
-        let sorted = self.sorted_indices(nodes);
+        let sorted = Self::sorted_indices(nodes);
         sorted.first().map(|&i| nodes[i].id())
     }
 
     fn find_last(&self, nodes: &[Arc<FocusNode>]) -> Option<FocusNodeId> {
-        let sorted = self.sorted_indices(nodes);
+        let sorted = Self::sorted_indices(nodes);
         sorted.last().map(|&i| nodes[i].id())
     }
 }
@@ -865,7 +865,7 @@ impl ReadingOrderPolicy {
     /// Returns indices into `nodes` sorted by reading order (top-to-bottom,
     /// left-to-right). Avoids cloning `Arc<FocusNode>` — only sorts
     /// lightweight indices.
-    fn sorted_indices(&self, nodes: &[Arc<FocusNode>]) -> Vec<usize> {
+    fn sorted_indices(nodes: &[Arc<FocusNode>]) -> Vec<usize> {
         let mut indices: Vec<usize> = (0..nodes.len()).collect();
         indices.sort_by(|&a, &b| {
             let rect_a = nodes[a].rect();

--- a/crates/flui-interaction/src/routing/hit_test.rs
+++ b/crates/flui-interaction/src/routing/hit_test.rs
@@ -34,17 +34,21 @@ use crate::{
 /// Event propagation control.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum EventPropagation {
+    /// Keep dispatching the event to the remaining entries on the route.
     #[default]
     Continue,
+    /// Stop dispatching; entries deeper on the route do not see the event.
     Stop,
 }
 
 impl EventPropagation {
+    /// Returns `true` if dispatch should continue to the next entry.
     #[inline]
     pub const fn should_continue(self) -> bool {
         matches!(self, Self::Continue)
     }
 
+    /// Returns `true` if dispatch should stop at this entry.
     #[inline]
     pub const fn should_stop(self) -> bool {
         matches!(self, Self::Stop)
@@ -68,18 +72,27 @@ pub type ScrollEventHandler = Arc<dyn Fn(&ScrollEventData) -> EventPropagation +
 /// Hit test behavior (Flutter's HitTestBehavior).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum HitTestBehavior {
+    /// Receive events only if a child is hit (Flutter's `deferToChild`).
     #[default]
     DeferToChild,
+    /// Hit within bounds even with no child hit, and block targets visually
+    /// behind from receiving the event (Flutter's `opaque`).
     Opaque,
+    /// Hit within bounds while still letting targets visually behind receive
+    /// the event too (Flutter's `translucent`).
     Translucent,
 }
 
 impl HitTestBehavior {
+    /// Returns `true` if the element adds itself to the hit-test result even
+    /// when no child was hit (`Opaque` and `Translucent`).
     #[inline]
     pub const fn registers_self(self) -> bool {
         matches!(self, Self::Opaque | Self::Translucent)
     }
 
+    /// Returns `true` if a hit on this element prevents targets visually
+    /// behind it from being hit (`Opaque` only).
     #[inline]
     pub const fn blocks_below(self) -> bool {
         matches!(self, Self::Opaque)
@@ -123,8 +136,9 @@ impl std::fmt::Debug for HitTestEntry {
             .field("has_transform", &self.transform.is_some())
             .field("has_handler", &self.handler.is_some())
             .field("cursor", &self.cursor)
+            .field("has_scroll_handler", &self.scroll_handler.is_some())
             .field("has_mouse_annotation", &self.mouse_annotation.is_some())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -478,6 +492,7 @@ impl HitTestResult {
 ///
 /// Automatically pops transform when dropped.
 #[must_use = "TransformGuard must be held to maintain the transform"]
+#[derive(Debug)]
 pub struct TransformGuard<'a> {
     result: &'a mut HitTestResult,
 }

--- a/crates/flui-interaction/src/routing/mouse_tracker.rs
+++ b/crates/flui-interaction/src/routing/mouse_tracker.rs
@@ -85,6 +85,19 @@ pub struct MouseTrackerAnnotation {
     pub on_hover: Option<MouseHoverCallback>,
 }
 
+// Manual impl: the callback fields are `dyn Fn` and have no useful `Debug`
+// representation; report their presence instead.
+impl std::fmt::Debug for MouseTrackerAnnotation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MouseTrackerAnnotation")
+            .field("region_id", &self.region_id)
+            .field("has_on_enter", &self.on_enter.is_some())
+            .field("has_on_exit", &self.on_exit.is_some())
+            .field("has_on_hover", &self.on_hover.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
 impl MouseTrackerAnnotation {
     /// Creates a new annotation for a region
     pub fn new(region_id: RegionId) -> Self {
@@ -142,6 +155,14 @@ struct DeviceState {
 #[derive(Clone)]
 pub struct MouseTracker {
     inner: Arc<Mutex<MouseTrackerInner>>,
+}
+
+// Manual impl: the tracker state holds annotation/cursor callbacks (`dyn Fn`)
+// behind a mutex, so there is no useful derived representation.
+impl std::fmt::Debug for MouseTracker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MouseTracker").finish_non_exhaustive()
+    }
 }
 
 /// Callback for cursor changes.

--- a/crates/flui-interaction/src/sealed.rs
+++ b/crates/flui-interaction/src/sealed.rs
@@ -163,6 +163,8 @@ pub trait CustomHitTestable: Send + Sync {
 ///
 /// **Do not implement directly.** Instead, implement [`CustomHitTestable`].
 pub mod hit_testable {
+    /// Marker supertrait sealing `HitTestable`; implemented automatically for
+    /// every [`CustomHitTestable`](super::CustomHitTestable) via blanket impl.
     pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
     // Blanket impl: any CustomHitTestable automatically gets Sealed
@@ -178,6 +180,9 @@ pub mod hit_testable {
 /// **Do not implement directly.** Instead, implement
 /// [`CustomGestureRecognizer`].
 pub mod gesture_recognizer {
+    /// Marker supertrait sealing `GestureRecognizer`; implemented for the
+    /// built-in recognisers and automatically for every
+    /// [`CustomGestureRecognizer`](super::CustomGestureRecognizer).
     pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
     // Blanket impl: any CustomGestureRecognizer automatically gets Sealed
@@ -203,6 +208,9 @@ pub mod gesture_recognizer {
 /// **Do not implement directly.** Instead, implement
 /// [`CustomGestureRecognizer`].
 pub mod arena_member {
+    /// Marker supertrait sealing `GestureArenaMember`; implemented for the
+    /// built-in recognisers and automatically for every
+    /// [`CustomGestureRecognizer`](super::CustomGestureRecognizer).
     pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
     // Blanket impl: any CustomGestureRecognizer automatically gets Sealed
@@ -225,5 +233,6 @@ pub mod arena_member {
 ///
 /// This restricts which types can receive keyboard focus.
 pub mod focus_node {
+    /// Marker supertrait restricting which types can receive keyboard focus.
     pub trait Sealed {} // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 }

--- a/crates/flui-interaction/src/settings.rs
+++ b/crates/flui-interaction/src/settings.rs
@@ -332,10 +332,10 @@ impl GestureSettings {
     /// ```
     pub fn for_device(device_kind: PointerType) -> Self {
         match device_kind {
-            PointerType::Touch => Self::touch_defaults(),
             PointerType::Mouse => Self::mouse_defaults(),
             PointerType::Pen => Self::pen_defaults(),
-            _ => Self::touch_defaults(), // Default to touch for unknown
+            // Touch, and any unknown device type, use touch defaults.
+            _ => Self::touch_defaults(),
         }
     }
 

--- a/crates/flui-interaction/src/testing/recording.rs
+++ b/crates/flui-interaction/src/testing/recording.rs
@@ -456,6 +456,7 @@ impl Iterator for GesturePlayer {
 // ============================================================================
 
 /// Utility for building common gesture patterns
+#[derive(Debug)]
 pub struct GestureBuilder;
 
 impl GestureBuilder {

--- a/crates/flui-interaction/src/timer.rs
+++ b/crates/flui-interaction/src/timer.rs
@@ -186,7 +186,7 @@ impl std::fmt::Debug for TimerEntry {
             .field("id", &self.id)
             .field("deadline", &self.deadline)
             .field("cancelled", &self.is_cancelled())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-layer/src/lib.rs
+++ b/crates/flui-layer/src/lib.rs
@@ -77,9 +77,8 @@
 //! 4. **Thread-safe**: All types are `Send + Sync`
 
 // Lint levels come from `[workspace.lints]` (Cargo.toml `[lints] workspace = true`).
-// The two remaining opt-outs are tracked ship-quality debt, not configuration:
-#![allow(dead_code, unused_variables)] // TODO(ship-wave-2): wire or delete each dead item (tracker M3 audit)
-#![allow(missing_docs)] // TODO(ship-wave-2): public-item doc backlog — burn down, then delete this line
+// Ship bar (wave 2): every public item is documented; keep it that way.
+#![deny(missing_docs)]
 
 // ============================================================================
 // MODULES

--- a/crates/flui-layer/src/tree/layer_tree.rs
+++ b/crates/flui-layer/src/tree/layer_tree.rs
@@ -550,7 +550,7 @@ impl LayerTree {
     /// O(subtree size) in time and memory. Layer cloning is cheap for
     /// most variants (f32 fields, Matrix4, Arc-backed data).
     pub fn clone_subtree(&self, root_id: LayerId) -> Option<Self> {
-        let root_node = self.get(root_id)?;
+        self.get(root_id)?; // existence check; the clone walk re-resolves ids
         let mut new_tree = Self::new();
         let new_root = self.clone_subtree_into(&mut new_tree, root_id)?;
         new_tree.set_root(Some(new_root));

--- a/crates/flui-painting/src/lib.rs
+++ b/crates/flui-painting/src/lib.rs
@@ -139,6 +139,8 @@
 //! - [`display_list`] - DisplayList and DrawCommand types
 //! - [`error`] - Error types
 
+// Ship bar (wave 2): every public item is documented; keep it that way.
+#![deny(missing_docs)]
 // ===== Quality Control: Compiler & Clippy Lints =====
 //
 // Note: Most lints are inherited from [workspace.lints] in root Cargo.toml.

--- a/crates/flui-scheduler/src/config.rs
+++ b/crates/flui-scheduler/src/config.rs
@@ -178,6 +178,16 @@ pub struct PerformanceModeRequestHandle {
     cleanup: Option<Box<dyn FnOnce() + Send>>,
 }
 
+impl std::fmt::Debug for PerformanceModeRequestHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `cleanup` is an opaque `dyn FnOnce`; report only whether the
+        // handle has already been disposed.
+        f.debug_struct("PerformanceModeRequestHandle")
+            .field("disposed", &self.cleanup.is_none())
+            .finish_non_exhaustive()
+    }
+}
+
 impl PerformanceModeRequestHandle {
     /// Create a new handle with a cleanup callback.
     pub(crate) fn new(cleanup: impl FnOnce() + Send + 'static) -> Self {

--- a/crates/flui-scheduler/src/frame.rs
+++ b/crates/flui-scheduler/src/frame.rs
@@ -352,6 +352,12 @@ impl AppLifecycleState {
     /// Check if the state transition is valid
     ///
     /// Most transitions are valid, but some are logically unusual.
+    #[allow(
+        clippy::match_same_arms,
+        reason = "deliberate transition table: each state pair is listed explicitly \
+                  (Flutter AppLifecycleState parity) so a future tightening edits one \
+                  arm instead of reconstructing the table"
+    )]
     pub const fn can_transition_to(self, next: Self) -> bool {
         match (self, next) {
             // Same state is always valid (no-op)

--- a/crates/flui-scheduler/src/id.rs
+++ b/crates/flui-scheduler/src/id.rs
@@ -75,6 +75,16 @@ pub struct IdGenerator<M: Marker> {
     _marker: PhantomData<M>,
 }
 
+// Manual impl instead of `#[derive(Debug)]` so no `M: Debug` bound is
+// required — marker types are never instantiated.
+impl<M: Marker> std::fmt::Debug for IdGenerator<M> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IdGenerator")
+            .field("counter", &self.counter)
+            .finish()
+    }
+}
+
 impl<M: Marker> IdGenerator<M> {
     /// Create a new ID generator starting from 1.
     pub const fn new() -> Self {

--- a/crates/flui-scheduler/src/lib.rs
+++ b/crates/flui-scheduler/src/lib.rs
@@ -127,14 +127,6 @@
 // `[workspace.lints]` supplies the baseline; this crate already holds the
 // stricter missing-docs bar.
 #![deny(missing_docs)]
-// Tracked ship-quality debt:
-#![allow(missing_debug_implementations)] // TODO(ship-wave-2): add Debug impls (6 types), then delete
-#![allow(clippy::unwrap_used)] // TODO(ship-wave-2): convert to Result / `expect("BUG: …")` per docs/PANIC-POLICY.md
-#![allow(
-    clippy::match_same_arms,
-    clippy::missing_fields_in_debug,
-    clippy::needless_continue
-)] // TODO(ship-wave-2): burn down per-lint, then delete
 
 // Core modules
 pub mod budget;

--- a/crates/flui-scheduler/src/scheduler.rs
+++ b/crates/flui-scheduler/src/scheduler.rs
@@ -145,6 +145,16 @@ pub struct FrameCompletionFuture {
     state: Arc<Mutex<FrameCompletionState>>,
 }
 
+impl std::fmt::Debug for FrameCompletionFuture {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `try_lock` so Debug never blocks (or deadlocks) on the shared state.
+        let completed = self.state.try_lock().map(|s| s.completed.is_some());
+        f.debug_struct("FrameCompletionFuture")
+            .field("completed", &completed)
+            .finish_non_exhaustive()
+    }
+}
+
 impl Future for FrameCompletionFuture {
     type Output = FrameTiming;
 
@@ -420,6 +430,22 @@ pub struct Scheduler {
     binding: Arc<BindingState>,
     /// Task queue (priority-based, already Arc-wrapped internally)
     task_queue: TaskQueue,
+}
+
+impl std::fmt::Debug for Scheduler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Report lock-free state only (atomics + TaskQueue's atomic len);
+        // the callback/binding state is opaque `dyn Fn` storage.
+        f.debug_struct("Scheduler")
+            .field("phase", &self.phase())
+            .field("frame_count", &self.frame_count())
+            .field(
+                "frame_scheduled",
+                &self.frame.frame_scheduled.load(Ordering::Acquire),
+            )
+            .field("task_queue", &self.task_queue)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Scheduler {

--- a/crates/flui-scheduler/src/task.rs
+++ b/crates/flui-scheduler/src/task.rs
@@ -263,6 +263,15 @@ pub struct TaskQueue {
     len: Arc<AtomicUsize>,
 }
 
+impl std::fmt::Debug for TaskQueue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The heap holds opaque task closures; report the lock-free length.
+        f.debug_struct("TaskQueue")
+            .field("len", &self.len())
+            .finish_non_exhaustive()
+    }
+}
+
 impl TaskQueue {
     /// Create a new task queue
     pub fn new() -> Self {
@@ -342,7 +351,10 @@ impl TaskQueue {
             let mut batch = Vec::with_capacity(queue.len());
             while let Some(pt) = queue.peek() {
                 if pt.0.priority >= min_priority {
-                    batch.push(queue.pop().unwrap().0);
+                    let task = queue
+                        .pop()
+                        .expect("BUG: peek returned Some under the same lock, so pop must succeed");
+                    batch.push(task.0);
                 } else {
                     break;
                 }
@@ -371,7 +383,10 @@ impl TaskQueue {
             let mut batch = Vec::with_capacity(queue.len());
             while let Some(pt) = queue.peek() {
                 if pt.0.priority == priority {
-                    batch.push(queue.pop().unwrap().0);
+                    let task = queue
+                        .pop()
+                        .expect("BUG: peek returned Some under the same lock, so pop must succeed");
+                    batch.push(task.0);
                 } else {
                     break;
                 }

--- a/crates/flui-scheduler/src/ticker.rs
+++ b/crates/flui-scheduler/src/ticker.rs
@@ -517,7 +517,11 @@ impl Ticker {
                     .checked_sub(std::time::Duration::from_secs_f64(
                         inner.muted_elapsed.value(),
                     ))
-                    .unwrap();
+                    .expect(
+                        "BUG: muted_elapsed was measured as (mute instant - start_time), so \
+                         subtracting it from a later `now` cannot precede the ticker's start \
+                         instant, which is a valid Instant",
+                    );
                 inner.start_time = Some(adjusted_start);
                 inner.state = TickerState::Active;
             }
@@ -777,7 +781,7 @@ impl std::fmt::Debug for Ticker {
             .field("id", &self.id)
             .field("state", &self.state())
             .field("elapsed", &self.elapsed())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -802,6 +806,7 @@ impl std::fmt::Debug for Ticker {
 /// group.unmute_all();
 /// group.stop_all();
 /// ```
+#[derive(Debug)]
 pub struct TickerGroup {
     tickers: Vec<Ticker>,
 }
@@ -1191,8 +1196,10 @@ impl Future for TickerFuture {
                     if let Some(ref mut listener) = self.listener {
                         match Pin::new(listener).poll(cx) {
                             Poll::Ready(()) => {
+                                // Event fired: clear the listener and fall
+                                // through to re-check state on the next
+                                // loop iteration.
                                 self.listener = None;
-                                continue; // Re-check state
                             }
                             Poll::Pending => return Poll::Pending,
                         }
@@ -1244,9 +1251,10 @@ impl Future for TickerFutureOrCancel {
                         let pinned = Pin::new(listener);
                         match pinned.poll(cx) {
                             Poll::Ready(()) => {
-                                // Event fired, clear listener and re-check state
+                                // Event fired: clear the listener and fall
+                                // through to re-check state on the next
+                                // loop iteration.
                                 self.listener = None;
-                                continue;
                             }
                             Poll::Pending => return Poll::Pending,
                         }

--- a/crates/flui-scheduler/src/vsync.rs
+++ b/crates/flui-scheduler/src/vsync.rs
@@ -288,7 +288,10 @@ impl VsyncScheduler {
                     let interval = self.frame_interval_duration();
 
                     if elapsed < interval {
-                        let wait_time = interval.checked_sub(elapsed).unwrap();
+                        let wait_time = interval.checked_sub(elapsed).expect(
+                            "BUG: `elapsed < interval` was checked on the previous line, \
+                             so the subtraction cannot underflow",
+                        );
                         std::thread::sleep(wait_time);
                         Instant::now()
                     } else {
@@ -403,7 +406,7 @@ impl std::fmt::Debug for VsyncScheduler {
             .field("mode", &inner.mode)
             .field("active", &inner.active)
             .field("stats", &inner.stats)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-semantics/Cargo.toml
+++ b/crates/flui-semantics/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
+readme = "README.md"
 description = "Semantics tree for FLUI accessibility - part of 5-tree architecture"
 keywords = ["ui", "accessibility", "semantics", "a11y", "screen-reader"]
 categories = ["gui", "accessibility"]

--- a/crates/flui-semantics/README.md
+++ b/crates/flui-semantics/README.md
@@ -1,0 +1,48 @@
+# flui-semantics
+
+**The accessibility tree — the fifth tree in FLUI's five-tree architecture**
+(View → Element → Render → Layer → **Semantics**).
+
+`flui-semantics` carries the information assistive technologies need — screen
+readers (VoiceOver, TalkBack, NVDA, JAWS), switch control, voice control,
+braille displays — mirroring Flutter's semantics protocol:
+
+| FLUI | Flutter |
+|------|---------|
+| `SemanticsNode` | `SemanticsNode` |
+| `SemanticsConfiguration` | `SemanticsConfiguration` |
+| `SemanticsOwner` | `SemanticsOwner` |
+| `SemanticsAction` / `SemanticsEvent` | `SemanticsAction` / semantics events |
+
+Part of the [FLUI](https://github.com/vanyastaff/flui) workspace — pre-release,
+consumed by path (not published to crates.io).
+
+## How it fits the pipeline
+
+```text
+RenderObject (flui-rendering)
+    │  assembleSemanticsNode() during the paint phase
+    ▼
+SemanticsNode (this crate)  —  SemanticsTree (slab storage, 1-based SemanticsId)
+    │  flush() batches dirty nodes into a SemanticsTreeUpdate
+    ▼
+Platform accessibility API (via flui-platform backends)
+```
+
+- `SemanticsTree` implements the generic `flui-tree` traits (`TreeRead`,
+  `TreeNav`, `TreeWrite`), so tree walks share the workspace's cycle-guarded
+  iterators.
+- `add_child` enforces cycle rejection at the public API; the `Ancestors`
+  iterator adds defence-in-depth bounding against corrupted parent pointers.
+- Labels/hints use `SmolStr` (O(1) clone), children/actions use `SmallVec`,
+  lookups use `FxHashMap`.
+
+## Documentation
+
+Every public item is documented (`#![deny(missing_docs)]`); build locally with
+`cargo doc -p flui-semantics --open`. Architecture context lives in
+[`docs/FOUNDATIONS.md`](../../docs/FOUNDATIONS.md).
+
+## License
+
+MIT OR Apache-2.0, per the workspace license.

--- a/crates/flui-semantics/src/lib.rs
+++ b/crates/flui-semantics/src/lib.rs
@@ -52,9 +52,8 @@
 //! - `SemanticsAction` ≈ Flutter's `SemanticsAction`
 
 // Lint levels come from `[workspace.lints]` (Cargo.toml `[lints] workspace = true`).
-// The two remaining opt-outs are tracked ship-quality debt, not configuration:
-#![allow(dead_code, unused_variables)] // TODO(ship-wave-2): wire or delete each dead item (tracker M3 audit)
-#![allow(missing_docs)] // TODO(ship-wave-2): public-item doc backlog — burn down, then delete this line
+// Ship bar (wave 2): every public item is documented; keep it that way.
+#![deny(missing_docs)]
 
 // ============================================================================
 // MODULES

--- a/crates/flui-semantics/src/tree.rs
+++ b/crates/flui-semantics/src/tree.rs
@@ -286,32 +286,6 @@ impl SemanticsTree {
         }
     }
 
-    /// Returns `true` if `candidate_ancestor` is an ancestor of `descendant`.
-    ///
-    /// Walk is bounded by the tree's slab size so a malformed parent
-    /// pointer cycle (which `add_child` no longer permits to be created)
-    /// can not hang the check.
-    fn is_ancestor_of(&self, candidate_ancestor: SemanticsId, descendant: SemanticsId) -> bool {
-        let mut current = Some(descendant);
-        let mut steps = 0;
-        let max_steps = self.nodes.len() + 1;
-        while let Some(id) = current {
-            if id == candidate_ancestor {
-                return true;
-            }
-            steps += 1;
-            if steps > max_steps {
-                tracing::warn!(
-                    "SemanticsTree::is_ancestor_of: walk exceeded slab \
-                     size — malformed parent pointers?"
-                );
-                return false;
-            }
-            current = self.get(id).and_then(SemanticsNode::parent);
-        }
-        false
-    }
-
     /// Removes a child from a parent SemanticsNode.
     pub fn remove_child(&mut self, parent_id: SemanticsId, child_id: SemanticsId) {
         // Update parent's children
@@ -392,14 +366,6 @@ impl SemanticsTree {
         self.nodes
             .iter_mut()
             .map(|(index, node)| (SemanticsId::new(index + 1), node))
-    }
-
-    // ========== Internal Access for Iterators ==========
-
-    /// Returns a reference to the internal slab (for iterator implementations).
-    #[inline]
-    pub(crate) fn slab(&self) -> &Slab<SemanticsNode> {
-        &self.nodes
     }
 }
 
@@ -680,7 +646,7 @@ mod tests {
         let mut tree = SemanticsTree::new();
 
         let id1 = tree.insert(SemanticsNode::new()); // dirty by default
-        let id2 = tree.insert(SemanticsNode::new());
+        let _id2 = tree.insert(SemanticsNode::new());
 
         // All nodes start dirty
         assert!(tree.has_dirty_nodes());


### PR DESCRIPTION
## Summary

Wave 2 of the ship-quality program: the core-services cohort (flui-painting, flui-scheduler, flui-layer, flui-semantics, flui-interaction, flui-engine) sheds every crate-level lint opt-out. All six crates now hold `#[deny(missing_docs)]`, and every surviving allow in the cohort is item-targeted with a written reason.

- **flui-layer / flui-semantics** — the audit's feared `dead_code` backlog resolved by per-item judgment, not blanket treatment: `SemanticsTree::is_ancestor_of` was a *superseded duplicate* (its cycle-bounded walk had been lifted into flui-tree's shared `Ancestors` iterator, and method resolution already routed `add_child` through the equally-guarded `TreeNav` default) — deleted; `slab()` predated the generic-iterator refactor with no consumer — deleted; one unused existence-check binding fixed. The blanket `allow(dead_code, unused_variables, missing_docs)` headers came off entirely — the docs beneath were already complete. flui-semantics gains its missing README.
- **flui-scheduler** — 6 Debug impls (manual where deriving would leak an `M: Debug` bound onto marker types or require locking in `fmt`), 4 unwrap sites dispositioned per `docs/PANIC-POLICY.md` (all genuine invariants; each `expect("BUG: …")` argues the actual invariant), `match_same_arms`/`missing_fields_in_debug`/`needless_continue` fixed at source — one justified targeted allow on the Flutter-parity lifecycle transition table.
- **flui-interaction** — 29 public items documented, 7 Debug impls, and the 8-lint allow block burned down: 30 findings fixed at source (incl. 9 `unused_self` private-method conversions and a single-file `unnecessary_wraps` signature fix, rg-verified in-crate), 11 targeted allows with reasons where Flutter-parity naming genuinely wins (`lsq_solver` QR math mirroring `lsq_solver.dart`, `on_*` callback field names).
- **flui-painting / flui-engine** — already doc-complete; graduated to `deny(missing_docs)` (verified zero items via `--force-warn` sweep).

## Verification

- [x] Full local gate suite green on 1.96.0: fmt-check, taplo, typos, inventory-check, port-check, workspace clippy `-D warnings`, full test suite (lib + integration, `--test-threads=1`), doc-tests, rustdoc `-D warnings`
- [x] Flutter reference checked — behavior preserved throughout; the one resolution-relevant change (deleting the shadowed `is_ancestor_of`) keeps the same guarded semantics via the `TreeNav` default + T-12-bounded `Ancestors` iterator; scheduler/interaction refactors are behavior-identical (399 + 356 tests unchanged-green)
- [x] New or changed behavior has tests — no behavior changes; `deny(missing_docs)` + clean clippy are the regression gates
- [x] Public API changes are documented — one private-scope signature change only (`get_pointer_info`, file-private, all callers in-file); no public surface changes

## Architecture

- [x] Layering unchanged
- [x] No new banned patterns — port-check green
- [x] No new dependencies

## Notes

- Policy applied per review guidance: dead code was classified item-by-item (superseded / forward-built / misplaced) rather than blanket-deleted or blanket-kept. Both deletions here were *superseded duplicates* whose guarantee had moved to the right place (flui-tree's shared iterator); nothing forward-built was removed.
- Remaining program state: Wave 3 (flui-rendering, flui-objects, flui-view, flui-widgets, flui-binding, flui-animation) carries the largest tracked-allow lists (`TODO(ship-wave-3)`); Wave 4 holds the structural items (flui-app singleton, flui-platform CI blackout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sjdi8ANg4pYBKDsyZJn9Mt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sjdi8ANg4pYBKDsyZJn9Mt)_