### PR TITLE
Ship-quality Wave 3: framework cohort — rendering/objects burn-downs, six crates at deny(missing_docs)

### DIFF
--- a/crates/flui-animation/src/lib.rs
+++ b/crates/flui-animation/src/lib.rs
@@ -83,9 +83,8 @@
 //! [`Listenable`]: flui_foundation::Listenable
 //! [`Arc`]: std::sync::Arc
 
-#![warn(missing_docs)]
-// Tracked ship-quality debt:
-#![allow(clippy::unwrap_used)] // TODO(ship-wave-3): convert to Result / `expect("BUG: …")` per docs/PANIC-POLICY.md
+// Ship bar (wave 3): every public item is documented; keep it that way.
+#![deny(missing_docs)]
 
 // Core animation modules
 pub mod animation;

--- a/crates/flui-animation/src/tween_types.rs
+++ b/crates/flui-animation/src/tween_types.rs
@@ -432,8 +432,14 @@ impl<T, A: Animatable<T>> Animatable<T> for TweenSequence<T, A> {
             accumulated_weight += item.weight;
         }
 
-        // Should never reach here, but return last item's end value just in case
-        self.items.last().unwrap().tween.transform(1.0)
+        // Unreachable: `new()` (the only constructor) asserts `items` is
+        // non-empty, and the loop's `i == len - 1` arm returns on the final
+        // iteration. Kept as a typed fallthrough for the compiler.
+        self.items
+            .last()
+            .expect("BUG: TweenSequence items are non-empty (asserted in new), so the loop above returns on its final iteration")
+            .tween
+            .transform(1.0)
     }
 }
 

--- a/crates/flui-binding/Cargo.toml
+++ b/crates/flui-binding/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
+readme = "README.md"
 description = "Deterministic headless frame driver (pump_frame) over the gesture arena + virtual clock for FLUI"
 keywords = ["ui", "gesture", "headless", "testing"]
 categories = ["gui"]

--- a/crates/flui-binding/README.md
+++ b/crates/flui-binding/README.md
@@ -1,0 +1,35 @@
+# flui-binding
+
+**Deterministic headless frame driver for FLUI tests.**
+
+`flui-binding` provides `HeadlessBinding::pump_frame(dt)`: a non-singleton,
+sleep-free way to advance a FLUI application by exact time steps. A virtual
+`ManualClock` drives the gesture arena's clock-bound deadlines (long-press,
+double-tap windows) and the frame pipeline, so time-based behavior is tested
+deterministically — no real timers, no flaky sleeps.
+
+Part of the [FLUI](https://github.com/vanyastaff/flui) workspace — pre-release,
+consumed by path (not published to crates.io). It sits above `flui-widgets`
+and below `flui-app` in the layer DAG: production apps use `flui-app`'s real
+event loop; tests use this crate's pumped one.
+
+```rust,ignore
+let mut binding = HeadlessBinding::new(root_view);
+binding.pump_frame(Duration::from_millis(300)); // advance exactly 300ms
+assert!(long_press_fired.load(Ordering::SeqCst));
+```
+
+## Scope
+
+Implemented: virtual-clock frame pumping and gesture-arena deadline polling.
+Deferred (tracked in `docs/ROADMAP.md`): animation-controller ticks (Phase 3)
+and tree-rebuild integration (Phase 1b).
+
+## Documentation
+
+Every public item is documented (`#![deny(missing_docs)]`); build locally with
+`cargo doc -p flui-binding --open`.
+
+## License
+
+MIT OR Apache-2.0, per the workspace license.

--- a/crates/flui-binding/src/lib.rs
+++ b/crates/flui-binding/src/lib.rs
@@ -82,6 +82,9 @@
 //! assert!(fired.load(Ordering::SeqCst));
 //! ```
 
+// Ship bar (wave 3): every public item is documented; keep it that way.
+#![deny(missing_docs)]
+
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/flui-objects/Cargo.toml
+++ b/crates/flui-objects/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 license.workspace = true
 description = "Concrete RenderBox/RenderSliver catalog for Flui (the object catalog atop flui-rendering's engine)"
 repository.workspace = true
+readme = "README.md"
 
 [dependencies]
 flui-rendering = { path = "../flui-rendering", version = "0.2.0" }

--- a/crates/flui-objects/README.md
+++ b/crates/flui-objects/README.md
@@ -1,0 +1,42 @@
+# flui-objects
+
+**The concrete `RenderBox` / `RenderSliver` catalog for FLUI** — 74
+ready-to-use render objects in six domain families, sitting directly above the
+`flui-rendering` engine crate.
+
+Part of the [FLUI](https://github.com/vanyastaff/flui) workspace — pre-release,
+consumed by path (not published to crates.io).
+
+## Families
+
+| Family | Contents |
+|--------|----------|
+| `layout` | sizing, alignment, flex, stack, transform, fitted-box, intrinsics, overflow, rotation, table |
+| `proxy` | paint-effect proxies: opacity, clips, decoration, color, repaint boundary, leader/follower, shader mask |
+| `interaction` | hit-test/visibility proxies: absorb/ignore pointer, offstage, mouse region, metadata |
+| `text` | `RenderEditable`, `RenderParagraph` |
+| `image` | `RenderImage` |
+| `sliver` | the `RenderSliver*` family + `RenderViewport` |
+
+All types re-export flat from the crate root: `flui_objects::RenderPadding`.
+
+## Guarantees
+
+- **Flutter parity by contract.** Each object ports the observable behavior
+  (layout math, edge cases, hit-test order) of its Flutter counterpart;
+  divergences are documented at the item.
+- **Harness-tested.** Every exported object appears in the render-object
+  test catalog (`RENDER_OBJECT_TYPES`) with `harness_*` tests exercising the
+  real pipeline — the catalog completeness is CI-enforced.
+- **Authoring-surface proof.** 74 objects compiling from outside
+  `flui-rendering` prove the engine's custom-object authoring API is complete.
+
+## Documentation
+
+Every public item is documented (`#![deny(missing_docs)]`); build locally with
+`cargo doc -p flui-objects --open`. The harness API is documented in
+[`flui-rendering/docs/TESTING.md`](../flui-rendering/docs/TESTING.md).
+
+## License
+
+MIT OR Apache-2.0, per the workspace license.

--- a/crates/flui-objects/src/image/render_image.rs
+++ b/crates/flui-objects/src/image/render_image.rs
@@ -321,14 +321,12 @@ impl Diagnosticable for RenderImage {
         properties.add(
             "width",
             self.width
-                .map(|w| format!("{w:?}"))
-                .unwrap_or_else(|| "unset".to_string()),
+                .map_or_else(|| "unset".to_string(), |w| format!("{w:?}")),
         );
         properties.add(
             "height",
             self.height
-                .map(|h| format!("{h:?}"))
-                .unwrap_or_else(|| "unset".to_string()),
+                .map_or_else(|| "unset".to_string(), |h| format!("{h:?}")),
         );
         properties.add_default_double("scale", self.scale, 1.0, None);
         properties.add_enum("fit", self.fit);

--- a/crates/flui-objects/src/interaction/listener.rs
+++ b/crates/flui-objects/src/interaction/listener.rs
@@ -133,9 +133,8 @@ impl RenderBox for RenderListener {
         let child_hit = self.has_child && ctx.hit_test_child_at_offset(0, Offset::ZERO);
 
         let hit_target = match self.behavior {
-            HitTestBehavior::DeferToChild => child_hit,
             HitTestBehavior::Opaque => true,
-            HitTestBehavior::Translucent => child_hit,
+            HitTestBehavior::DeferToChild | HitTestBehavior::Translucent => child_hit,
         };
 
         if !hit_target && self.behavior == HitTestBehavior::Translucent {

--- a/crates/flui-objects/src/interaction/mouse_region.rs
+++ b/crates/flui-objects/src/interaction/mouse_region.rs
@@ -210,9 +210,8 @@ impl RenderBox for RenderMouseRegion {
 
         let child_hit = self.has_child && ctx.hit_test_child_at_offset(0, Offset::ZERO);
         let hit_target = match self.behavior {
-            HitTestBehavior::DeferToChild => child_hit,
             HitTestBehavior::Opaque => true,
-            HitTestBehavior::Translucent => child_hit,
+            HitTestBehavior::DeferToChild | HitTestBehavior::Translucent => child_hit,
         };
 
         if hit_target || self.behavior == HitTestBehavior::Translucent {

--- a/crates/flui-objects/src/layout/animated_size.rs
+++ b/crates/flui-objects/src/layout/animated_size.rs
@@ -237,11 +237,7 @@ impl RenderAnimatedSize {
     /// value". Getting this branch wrong (reusing `current_size` here) is
     /// the headline risk this module's docs call out.
     fn layout_changed(&mut self, child_size: Size) {
-        if self.size_tween.end != child_size {
-            self.size_tween = SizeTween::new(child_size, child_size);
-            self.restart_animation();
-            self.state = AnimatedSizeState::Unstable;
-        } else {
+        if self.size_tween.end == child_size {
             // The child's size repeated -> stabilized. The genuine
             // interpolation span from `layout_stable` is left untouched and
             // keeps running to completion; just resume it if it stopped.
@@ -249,6 +245,10 @@ impl RenderAnimatedSize {
             if !self.controller.is_animating() {
                 let _ = self.controller.forward();
             }
+        } else {
+            self.size_tween = SizeTween::new(child_size, child_size);
+            self.restart_animation();
+            self.state = AnimatedSizeState::Unstable;
         }
     }
 
@@ -258,12 +258,12 @@ impl RenderAnimatedSize {
     /// already `begin == end == this size` from the last unstable
     /// iteration, so there is no visual glitch).
     fn layout_unstable(&mut self, child_size: Size) {
-        if self.size_tween.end != child_size {
-            self.size_tween = SizeTween::new(child_size, child_size);
-            self.restart_animation();
-        } else {
+        if self.size_tween.end == child_size {
             let _ = self.controller.stop();
             self.state = AnimatedSizeState::Stable;
+        } else {
+            self.size_tween = SizeTween::new(child_size, child_size);
+            self.restart_animation();
         }
     }
 
@@ -291,10 +291,10 @@ impl RenderAnimatedSize {
                 }
             }
             AnimatedSizeState::Changed | AnimatedSizeState::Unstable => {
-                if self.size_tween.end != child_size {
-                    constraints.constrain(child_size)
-                } else {
+                if self.size_tween.end == child_size {
                     constraints.constrain(self.size_tween.transform(self.animation.value()))
+                } else {
+                    constraints.constrain(child_size)
                 }
             }
         }
@@ -430,6 +430,10 @@ impl RenderBox for RenderAnimatedSize {
         Some(child_baseline + offset.dy.get())
     }
 
+    // Closure is load-bearing: `PaintCx::paint_child` is ambiguous as a method path
+    // (Single's zero-arg overload vs the indexed variant on other arities), so the
+    // closure cannot be replaced by a method reference.
+    #[allow(clippy::redundant_closure_for_method_calls)]
     fn paint(&self, ctx: &mut PaintCx<'_, Single>) {
         if self.has_visual_overflow && self.clip_behavior != Clip::None {
             let bounds = Rect::from_origin_size(Point::ZERO, ctx.size());

--- a/crates/flui-objects/src/layout/constrained_box.rs
+++ b/crates/flui-objects/src/layout/constrained_box.rs
@@ -163,10 +163,10 @@ impl RenderBox for RenderConstrainedBox {
             width.is_finite(),
             "child min intrinsic width must be finite"
         );
-        if !ac.has_infinite_width() {
-            ac.constrain_width(flui_types::geometry::px(width)).get()
-        } else {
+        if ac.has_infinite_width() {
             width
+        } else {
+            ac.constrain_width(flui_types::geometry::px(width)).get()
         }
     }
 
@@ -188,10 +188,10 @@ impl RenderBox for RenderConstrainedBox {
             width.is_finite(),
             "child max intrinsic width must be finite"
         );
-        if !ac.has_infinite_width() {
-            ac.constrain_width(flui_types::geometry::px(width)).get()
-        } else {
+        if ac.has_infinite_width() {
             width
+        } else {
+            ac.constrain_width(flui_types::geometry::px(width)).get()
         }
     }
 
@@ -213,10 +213,10 @@ impl RenderBox for RenderConstrainedBox {
             height.is_finite(),
             "child min intrinsic height must be finite"
         );
-        if !ac.has_infinite_height() {
-            ac.constrain_height(flui_types::geometry::px(height)).get()
-        } else {
+        if ac.has_infinite_height() {
             height
+        } else {
+            ac.constrain_height(flui_types::geometry::px(height)).get()
         }
     }
 
@@ -238,10 +238,10 @@ impl RenderBox for RenderConstrainedBox {
             height.is_finite(),
             "child max intrinsic height must be finite"
         );
-        if !ac.has_infinite_height() {
-            ac.constrain_height(flui_types::geometry::px(height)).get()
-        } else {
+        if ac.has_infinite_height() {
             height
+        } else {
+            ac.constrain_height(flui_types::geometry::px(height)).get()
         }
     }
 

--- a/crates/flui-objects/src/layout/custom_single_child_layout.rs
+++ b/crates/flui-objects/src/layout/custom_single_child_layout.rs
@@ -72,11 +72,7 @@ impl RenderCustomSingleChildLayoutBox {
         self.delegate.get_constraints_for_child(constraints)
     }
 
-    fn child_size_for_position(
-        &self,
-        child_constraints: BoxConstraints,
-        actual_child_size: Size,
-    ) -> Size {
+    fn child_size_for_position(child_constraints: BoxConstraints, actual_child_size: Size) -> Size {
         if child_constraints.is_tight() {
             child_constraints.smallest()
         } else {
@@ -144,7 +140,7 @@ impl RenderBox for RenderCustomSingleChildLayoutBox {
         self.has_child = true;
         let child_constraints = self.child_constraints(constraints);
         let child_size = ctx.layout_child(0, child_constraints);
-        let child_size_for_position = self.child_size_for_position(child_constraints, child_size);
+        let child_size_for_position = Self::child_size_for_position(child_constraints, child_size);
         self.child_offset = self
             .delegate
             .get_position_for_child(size, child_size_for_position);

--- a/crates/flui-objects/src/layout/flex.rs
+++ b/crates/flui-objects/src/layout/flex.rs
@@ -283,7 +283,6 @@ impl RenderFlex {
 
     /// Folds child intrinsics along the cross axis (max of child cross sizes).
     fn intrinsic_cross(
-        &self,
         ctx: &mut BoxIntrinsicsCtx<'_>,
         main_extent: f32,
         mut child_cross: impl FnMut(&mut BoxIntrinsicsCtx<'_>, usize, f32) -> f32,
@@ -565,15 +564,14 @@ impl RenderFlex {
             let child_size = slot.unwrap_or(Size::ZERO);
 
             let cross_offset = match self.cross_axis_alignment {
-                CrossAxisAlignment::Start => Pixels::ZERO,
+                CrossAxisAlignment::Start | CrossAxisAlignment::Stretch => Pixels::ZERO,
                 CrossAxisAlignment::End => cross_extent - self.cross_size(child_size),
                 CrossAxisAlignment::Center => (cross_extent - self.cross_size(child_size)) / 2.0,
-                CrossAxisAlignment::Stretch => Pixels::ZERO,
                 CrossAxisAlignment::Baseline => {
                     max_alignment_baseline.map_or(Pixels::ZERO, |max_dist| {
-                        alignment_baselines[i]
-                            .map(|child_dist| Pixels::new(max_dist - child_dist))
-                            .unwrap_or(Pixels::ZERO)
+                        alignment_baselines[i].map_or(Pixels::ZERO, |child_dist| {
+                            Pixels::new(max_dist - child_dist)
+                        })
                     })
                 }
             };
@@ -625,8 +623,7 @@ impl RenderBox for RenderFlex {
         for i in 0..child_count {
             let (flex, fit) = ctx
                 .child_parent_data(i)
-                .map(|pd| (pd.flex, pd.fit))
-                .unwrap_or((None, FlexFit::Loose));
+                .map_or((None, FlexFit::Loose), |pd| (pd.flex, pd.fit));
             flex_factors.push(flex);
             flex_fits.push(fit);
         }
@@ -719,8 +716,7 @@ impl RenderBox for RenderFlex {
         for i in 0..child_count {
             let (flex, fit) = ctx
                 .child_parent_data_as::<FlexParentData>(i)
-                .map(|pd| (pd.flex, pd.fit))
-                .unwrap_or((None, FlexFit::Loose));
+                .map_or((None, FlexFit::Loose), |pd| (pd.flex, pd.fit));
             flex_factors.push(flex);
             flex_fits.push(fit);
         }
@@ -769,8 +765,7 @@ impl RenderBox for RenderFlex {
         for i in 0..child_count {
             let (flex, fit) = ctx
                 .child_parent_data_as::<FlexParentData>(i)
-                .map(|pd| (pd.flex, pd.fit))
-                .unwrap_or((None, FlexFit::Loose));
+                .map_or((None, FlexFit::Loose), |pd| (pd.flex, pd.fit));
             flex_factors.push(flex);
             flex_fits.push(fit);
         }
@@ -828,6 +823,10 @@ impl RenderBox for RenderFlex {
         reported
     }
 
+    // Closure is load-bearing: a `BoxIntrinsicsCtx::child_*` method path is rejected
+    // ("implementation of `FnMut` is not general enough" -- the fn item's ctx lifetime
+    // is not higher-ranked), so the closure cannot be replaced by a method reference.
+    #[allow(clippy::redundant_closure_for_method_calls)]
     fn compute_min_intrinsic_width(&self, height: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
         match self.direction {
             FlexDirection::Horizontal => {
@@ -836,11 +835,15 @@ impl RenderBox for RenderFlex {
                 })
             }
             FlexDirection::Vertical => {
-                self.intrinsic_cross(ctx, height, |ctx, i, e| ctx.child_min_intrinsic_width(i, e))
+                Self::intrinsic_cross(ctx, height, |ctx, i, e| ctx.child_min_intrinsic_width(i, e))
             }
         }
     }
 
+    // Closure is load-bearing: a `BoxIntrinsicsCtx::child_*` method path is rejected
+    // ("implementation of `FnMut` is not general enough" -- the fn item's ctx lifetime
+    // is not higher-ranked), so the closure cannot be replaced by a method reference.
+    #[allow(clippy::redundant_closure_for_method_calls)]
     fn compute_max_intrinsic_width(&self, height: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
         match self.direction {
             FlexDirection::Horizontal => {
@@ -849,29 +852,37 @@ impl RenderBox for RenderFlex {
                 })
             }
             FlexDirection::Vertical => {
-                self.intrinsic_cross(ctx, height, |ctx, i, e| ctx.child_max_intrinsic_width(i, e))
+                Self::intrinsic_cross(ctx, height, |ctx, i, e| ctx.child_max_intrinsic_width(i, e))
             }
         }
     }
 
+    // Closure is load-bearing: a `BoxIntrinsicsCtx::child_*` method path is rejected
+    // ("implementation of `FnMut` is not general enough" -- the fn item's ctx lifetime
+    // is not higher-ranked), so the closure cannot be replaced by a method reference.
+    #[allow(clippy::redundant_closure_for_method_calls)]
     fn compute_min_intrinsic_height(&self, width: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
         match self.direction {
             FlexDirection::Vertical => self.fold_main_axis_intrinsics(ctx, width, |ctx, i, e| {
                 ctx.child_min_intrinsic_height(i, e)
             }),
             FlexDirection::Horizontal => {
-                self.intrinsic_cross(ctx, width, |ctx, i, e| ctx.child_min_intrinsic_height(i, e))
+                Self::intrinsic_cross(ctx, width, |ctx, i, e| ctx.child_min_intrinsic_height(i, e))
             }
         }
     }
 
+    // Closure is load-bearing: a `BoxIntrinsicsCtx::child_*` method path is rejected
+    // ("implementation of `FnMut` is not general enough" -- the fn item's ctx lifetime
+    // is not higher-ranked), so the closure cannot be replaced by a method reference.
+    #[allow(clippy::redundant_closure_for_method_calls)]
     fn compute_max_intrinsic_height(&self, width: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
         match self.direction {
             FlexDirection::Vertical => self.fold_main_axis_intrinsics(ctx, width, |ctx, i, e| {
                 ctx.child_max_intrinsic_height(i, e)
             }),
             FlexDirection::Horizontal => {
-                self.intrinsic_cross(ctx, width, |ctx, i, e| ctx.child_max_intrinsic_height(i, e))
+                Self::intrinsic_cross(ctx, width, |ctx, i, e| ctx.child_max_intrinsic_height(i, e))
             }
         }
     }

--- a/crates/flui-objects/src/layout/flow.rs
+++ b/crates/flui-objects/src/layout/flow.rs
@@ -314,10 +314,10 @@ impl RenderBox for RenderFlow {
         // Clip-gating on `!= Clip::None` mirrors `RenderStack`'s FLUI idiom
         // (fewer emitted layers when clipping is off) rather than the
         // oracle's unconditional `pushClipRect` call — same visible result.
-        if self.clip_behavior != Clip::None {
-            ctx.with_clip_rect(bounds, self.clip_behavior, body);
-        } else {
+        if self.clip_behavior == Clip::None {
             body(ctx);
+        } else {
+            ctx.with_clip_rect(bounds, self.clip_behavior, body);
         }
     }
 

--- a/crates/flui-objects/src/layout/fractionally_sized_box.rs
+++ b/crates/flui-objects/src/layout/fractionally_sized_box.rs
@@ -212,12 +212,12 @@ impl RenderFractionallySizedBox {
     /// Width factor as a bare multiplier, `1.0` when unset (Flutter's
     /// `_widthFactor ?? 1.0` in the intrinsic formulas).
     fn width_factor_or_one(&self) -> f32 {
-        self.width_factor.map_or(1.0, |f| f.value())
+        self.width_factor.map_or(1.0, FractionFactor::value)
     }
 
     /// Height factor as a bare multiplier, `1.0` when unset.
     fn height_factor_or_one(&self) -> f32 {
-        self.height_factor.map_or(1.0, |f| f.value())
+        self.height_factor.map_or(1.0, FractionFactor::value)
     }
 
     fn child_constraints(&self, incoming: BoxConstraints) -> BoxConstraints {
@@ -275,14 +275,12 @@ impl flui_foundation::Diagnosticable for RenderFractionallySizedBox {
         builder.add(
             "width_factor",
             self.width_factor
-                .map(|f| format!("{}", f.value()))
-                .unwrap_or_else(|| "unset".to_string()),
+                .map_or_else(|| "unset".to_string(), |f| format!("{}", f.value())),
         );
         builder.add(
             "height_factor",
             self.height_factor
-                .map(|f| format!("{}", f.value()))
-                .unwrap_or_else(|| "unset".to_string()),
+                .map_or_else(|| "unset".to_string(), |f| format!("{}", f.value())),
         );
         builder.add(
             "alignment",

--- a/crates/flui-objects/src/layout/intrinsic_height.rs
+++ b/crates/flui-objects/src/layout/intrinsic_height.rs
@@ -73,7 +73,6 @@ impl RenderIntrinsicHeight {
     /// method.  Callers pass `|dim, extent| ctx.child_intrinsic(0, dim, extent)`
     /// for all three compute passes; only the ctx type differs.
     fn child_constraints(
-        &self,
         constraints: BoxConstraints,
         mut intrinsic: impl FnMut(IntrinsicDimension, f32) -> f32,
     ) -> BoxConstraints {
@@ -121,7 +120,7 @@ impl RenderBox for RenderIntrinsicHeight {
 
         // `child_constraints` queries the child's max intrinsic height through
         // the live `box_intrinsic_query_borrowed` callback, same as before.
-        let child_constraints = self.child_constraints(constraints, |dim, extent| {
+        let child_constraints = Self::child_constraints(constraints, |dim, extent| {
             ctx.child_intrinsic(0, dim, extent)
         });
         let child_size = ctx.layout_child(0, child_constraints);
@@ -192,7 +191,7 @@ impl RenderBox for RenderIntrinsicHeight {
         // the real intrinsic sub-query through DryLayoutChildRequest::Intrinsic
         // (ADR-0011 Slice 1), routed by the driver to the memoized intrinsic_query.
         // The old `child_dry_layout`-based approximation is removed — dry ≡ committed.
-        let child_constraints = self.child_constraints(constraints, |dim, extent| {
+        let child_constraints = Self::child_constraints(constraints, |dim, extent| {
             ctx.child_intrinsic(0, dim, extent)
         });
         let child_size = ctx.child_dry_layout(0, child_constraints);
@@ -210,7 +209,7 @@ impl RenderBox for RenderIntrinsicHeight {
         }
         // Same child_constraints helper; the intrinsic closure routes through
         // BoxDryBaselineCtx's intrinsic channel.
-        let child_constraints = self.child_constraints(constraints, |dim, extent| {
+        let child_constraints = Self::child_constraints(constraints, |dim, extent| {
             ctx.child_intrinsic(0, dim, extent)
         });
         ctx.child_dry_baseline(0, child_constraints, baseline)
@@ -232,10 +231,9 @@ mod tests {
 
     #[test]
     fn child_constraints_tight_height_not_queried() {
-        let node = RenderIntrinsicHeight::new();
         // When incoming height is tight, the closure must NOT be called.
         let constraints = BoxConstraints::tight(Size::new(px(100.0), px(50.0)));
-        let child_c = node.child_constraints(constraints, |_, _| {
+        let child_c = RenderIntrinsicHeight::child_constraints(constraints, |_, _| {
             panic!("intrinsic queried on tight height")
         });
         assert!(child_c.has_tight_height());
@@ -244,20 +242,18 @@ mod tests {
 
     #[test]
     fn child_constraints_intrinsic_height_clamped() {
-        let node = RenderIntrinsicHeight::new();
         // Incoming height range [20, 80]; child says max intrinsic = 150 → clamp to 80.
         let constraints = bc(0.0, 200.0, 20.0, 80.0);
-        let child_c = node.child_constraints(constraints, |_, _| 150.0);
+        let child_c = RenderIntrinsicHeight::child_constraints(constraints, |_, _| 150.0);
         assert!(child_c.has_tight_height());
         assert_eq!(child_c.min_height, px(80.0));
     }
 
     #[test]
     fn child_constraints_intrinsic_height_within_range() {
-        let node = RenderIntrinsicHeight::new();
         // Child says 60, range [20, 80] → stays at 60.
         let constraints = bc(0.0, 200.0, 20.0, 80.0);
-        let child_c = node.child_constraints(constraints, |_, _| 60.0);
+        let child_c = RenderIntrinsicHeight::child_constraints(constraints, |_, _| 60.0);
         assert!(child_c.has_tight_height());
         assert_eq!(child_c.min_height, px(60.0));
     }
@@ -265,10 +261,9 @@ mod tests {
     #[test]
     fn child_constraints_height_raw_arg_is_max_width() {
         // The height query arg must be constraints.max_width (raw).
-        let node = RenderIntrinsicHeight::new();
         let constraints = bc(0.0, 120.0, 0.0, 200.0);
         let mut saw_extent = f32::NAN;
-        node.child_constraints(constraints, |dim, extent| {
+        RenderIntrinsicHeight::child_constraints(constraints, |dim, extent| {
             assert_eq!(dim, IntrinsicDimension::MaxHeight);
             saw_extent = extent;
             40.0

--- a/crates/flui-objects/src/layout/limited_box.rs
+++ b/crates/flui-objects/src/layout/limited_box.rs
@@ -160,14 +160,12 @@ impl flui_foundation::Diagnosticable for RenderLimitedBox {
         builder.add(
             "max_width",
             self.max_width
-                .map(|v| format!("{}", v.get()))
-                .unwrap_or_else(|| "unset".to_string()),
+                .map_or_else(|| "unset".to_string(), |v| format!("{}", v.get())),
         );
         builder.add(
             "max_height",
             self.max_height
-                .map(|v| format!("{}", v.get()))
-                .unwrap_or_else(|| "unset".to_string()),
+                .map_or_else(|| "unset".to_string(), |v| format!("{}", v.get())),
         );
     }
 }

--- a/crates/flui-objects/src/layout/sized_box.rs
+++ b/crates/flui-objects/src/layout/sized_box.rs
@@ -89,14 +89,12 @@ impl RenderSizedBox {
     }
 
     fn resolved_size(&self, constraints: &BoxConstraints) -> Size {
-        let width = self
-            .width
-            .map(|w| w.clamp(constraints.min_width, constraints.max_width))
-            .unwrap_or(constraints.max_width);
-        let height = self
-            .height
-            .map(|h| h.clamp(constraints.min_height, constraints.max_height))
-            .unwrap_or(constraints.max_height);
+        let width = self.width.map_or(constraints.max_width, |w| {
+            w.clamp(constraints.min_width, constraints.max_width)
+        });
+        let height = self.height.map_or(constraints.max_height, |h| {
+            h.clamp(constraints.min_height, constraints.max_height)
+        });
         Size::new(width, height)
     }
 }
@@ -115,15 +113,13 @@ impl RenderBox for RenderSizedBox {
         let constraints = ctx.constraints();
 
         // Use fixed dimension or constrain to max
-        let width = self
-            .width
-            .map(|w| w.clamp(constraints.min_width, constraints.max_width))
-            .unwrap_or(constraints.max_width);
+        let width = self.width.map_or(constraints.max_width, |w| {
+            w.clamp(constraints.min_width, constraints.max_width)
+        });
 
-        let height = self
-            .height
-            .map(|h| h.clamp(constraints.min_height, constraints.max_height))
-            .unwrap_or(constraints.max_height);
+        let height = self.height.map_or(constraints.max_height, |h| {
+            h.clamp(constraints.min_height, constraints.max_height)
+        });
 
         Size::new(width, height)
     }
@@ -133,7 +129,7 @@ impl RenderBox for RenderSizedBox {
         _height: f32,
         _ctx: &mut flui_rendering::context::BoxIntrinsicsCtx<'_>,
     ) -> f32 {
-        self.width.map(|w| w.get()).unwrap_or(0.0)
+        self.width.map_or(0.0, Pixels::get)
     }
 
     fn compute_max_intrinsic_width(
@@ -141,7 +137,7 @@ impl RenderBox for RenderSizedBox {
         _height: f32,
         _ctx: &mut flui_rendering::context::BoxIntrinsicsCtx<'_>,
     ) -> f32 {
-        self.width.map(|w| w.get()).unwrap_or(0.0)
+        self.width.map_or(0.0, Pixels::get)
     }
 
     fn compute_min_intrinsic_height(
@@ -149,7 +145,7 @@ impl RenderBox for RenderSizedBox {
         _width: f32,
         _ctx: &mut flui_rendering::context::BoxIntrinsicsCtx<'_>,
     ) -> f32 {
-        self.height.map(|h| h.get()).unwrap_or(0.0)
+        self.height.map_or(0.0, Pixels::get)
     }
 
     fn compute_max_intrinsic_height(
@@ -157,7 +153,7 @@ impl RenderBox for RenderSizedBox {
         _width: f32,
         _ctx: &mut flui_rendering::context::BoxIntrinsicsCtx<'_>,
     ) -> f32 {
-        self.height.map(|h| h.get()).unwrap_or(0.0)
+        self.height.map_or(0.0, Pixels::get)
     }
 
     fn compute_dry_layout(

--- a/crates/flui-objects/src/layout/transform.rs
+++ b/crates/flui-objects/src/layout/transform.rs
@@ -143,8 +143,8 @@ impl RenderTransform {
     /// `origin` is optional. The prior code returned `origin` alone whenever it
     /// was set, silently dropping the alignment contribution.
     fn compute_origin(&self, size: Size) -> Offset {
-        let align_x = size.width * ((self.alignment.x + 1.0) / 2.0);
-        let align_y = size.height * ((self.alignment.y + 1.0) / 2.0);
+        let align_x = size.width * f32::midpoint(self.alignment.x, 1.0);
+        let align_y = size.height * f32::midpoint(self.alignment.y, 1.0);
         let origin = self.origin.unwrap_or(Offset::ZERO);
         Offset::new(align_x + origin.dx, align_y + origin.dy)
     }

--- a/crates/flui-objects/src/layout/wrap.rs
+++ b/crates/flui-objects/src/layout/wrap.rs
@@ -375,7 +375,7 @@ impl RenderWrap {
         let max_run_main: f32 = runs
             .iter()
             .map(|r| r.main_axis_extent)
-            .fold(0.0_f32, |a, b| a.max(b));
+            .fold(0.0_f32, f32::max);
 
         let container = self.constrain_size(&constraints, max_run_main, total_cross);
 

--- a/crates/flui-objects/src/lib.rs
+++ b/crates/flui-objects/src/lib.rs
@@ -26,24 +26,11 @@
 //! [`RenderBox`]: flui_rendering::traits::RenderBox
 //! [`RenderSliver`]: flui_rendering::traits::RenderSliver
 
-#![warn(missing_docs)]
+// Ship bar (wave 3): every public item is documented; keep it that way.
+#![deny(missing_docs)]
 // Crate-specific relaxations (same rationale as flui-rendering):
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
-// Tracked ship-quality debt:
-#![allow(
-    clippy::enum_glob_use,
-    clippy::if_not_else,
-    clippy::manual_midpoint,
-    clippy::map_unwrap_or,
-    clippy::match_same_arms,
-    clippy::missing_fields_in_debug,
-    clippy::redundant_closure_for_method_calls,
-    clippy::semicolon_if_nothing_returned,
-    clippy::single_match_else,
-    clippy::uninlined_format_args,
-    clippy::unused_self
-)] // TODO(ship-wave-3): burn down per-lint, then delete
 
 mod image;
 mod interaction;

--- a/crates/flui-objects/src/proxy/backdrop_filter.rs
+++ b/crates/flui-objects/src/proxy/backdrop_filter.rs
@@ -207,7 +207,7 @@ impl RenderBox for RenderBackdropFilter {
         // every other `with_*` scope method) and the composer shifts it
         // to global space — no manual bounds arithmetic needed here.
         ctx.with_backdrop_filter(self.filter.clone(), self.blend_mode, |ctx| {
-            ctx.paint_child()
+            ctx.paint_child();
         });
     }
 

--- a/crates/flui-objects/src/proxy/clip.rs
+++ b/crates/flui-objects/src/proxy/clip.rs
@@ -518,6 +518,10 @@ impl<S: ClipGeometry> RenderBox for RenderClip<S> {
 
     flui_rendering::forward_single_child_box_queries!();
 
+    // Closure is load-bearing: `PaintCx::paint_child` is ambiguous as a method path
+    // (Single's zero-arg overload vs the indexed variant on other arities), so the
+    // closure cannot be replaced by a method reference.
+    #[allow(clippy::redundant_closure_for_method_calls)]
     fn paint(&self, ctx: &mut flui_rendering::context::PaintCx<'_, Single>) {
         // The clip is a LAYER scope so it covers the child subtree —
         // canvas clips are run-local in the fragment paint model and

--- a/crates/flui-objects/src/proxy/decorated_box.rs
+++ b/crates/flui-objects/src/proxy/decorated_box.rs
@@ -79,7 +79,7 @@ impl RenderDecoratedBox {
         self.position = position;
     }
 
-    fn paint_rect(&self, size: Size) -> Rect {
+    fn paint_rect(size: Size) -> Rect {
         Rect::from_origin_size(Point::ZERO, size)
     }
 }
@@ -111,7 +111,7 @@ impl RenderBox for RenderDecoratedBox {
     flui_rendering::forward_single_child_box_queries!();
 
     fn paint(&self, ctx: &mut PaintCx<'_, Single>) {
-        let rect = self.paint_rect(ctx.size());
+        let rect = Self::paint_rect(ctx.size());
         if self.position == DecorationPosition::Background {
             paint_box_decoration(ctx.canvas(), rect, &self.decoration);
         }
@@ -139,7 +139,7 @@ impl RenderBox for RenderDecoratedBox {
         // hitTestSelf: the decorated area is hit-opaque within the decoration
         // shape (a Container with a color absorbs taps), excluding cut corners.
         box_decoration_hit_test(
-            self.paint_rect(ctx.own_size()),
+            Self::paint_rect(ctx.own_size()),
             &self.decoration,
             *ctx.position(),
         )

--- a/crates/flui-objects/src/proxy/follower.rs
+++ b/crates/flui-objects/src/proxy/follower.rs
@@ -272,7 +272,7 @@ impl RenderBox for RenderFollowerLayer {
             self.show_when_unlinked,
             self.leader_anchor,
             self.follower_anchor,
-            |ctx| ctx.paint_children_in_order(),
+            PaintCx::paint_children_in_order,
         );
     }
 

--- a/crates/flui-objects/src/proxy/leader.rs
+++ b/crates/flui-objects/src/proxy/leader.rs
@@ -130,7 +130,7 @@ impl RenderBox for RenderLeaderLayer {
         // child presence; `super.paint` (paints nothing when childless)
         // runs inside the scope either way.
         let size = ctx.size();
-        ctx.with_leader(self.link, size, |ctx| ctx.paint_children_in_order());
+        ctx.with_leader(self.link, size, PaintCx::paint_children_in_order);
     }
 
     fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Single, BoxParentData>) -> bool {

--- a/crates/flui-objects/src/proxy/physical_model.rs
+++ b/crates/flui-objects/src/proxy/physical_model.rs
@@ -303,15 +303,14 @@ impl PhysicalClipSource for PathClip {
     const DIAGNOSTIC_NAME: &'static str = "RenderPhysicalShape";
 
     fn compute_clip(&self, size: Size) -> Path {
-        match &self.clipper {
-            Some(clipper) => clipper(size),
+        if let Some(clipper) = &self.clipper {
+            clipper(size)
+        } else {
             // Oracle `:2296`'s `_defaultClip` fallback — only reachable
             // once a clipper is cleared via `set_clipper(None)`.
-            None => {
-                let mut path = Path::new();
-                path.add_rect(Rect::from_origin_size(Point::ZERO, size));
-                path
-            }
+            let mut path = Path::new();
+            path.add_rect(Rect::from_origin_size(Point::ZERO, size));
+            path
         }
     }
 

--- a/crates/flui-objects/src/proxy/semantics.rs
+++ b/crates/flui-objects/src/proxy/semantics.rs
@@ -345,7 +345,7 @@ impl RenderBox for RenderExcludeSemantics {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use flui_rendering::semantics::SemanticsFlag;
+    use flui_rendering::semantics::{AttributedString, SemanticsFlag};
 
     #[test]
     fn annotations_describe_semantics_configuration() {
@@ -366,7 +366,7 @@ mod tests {
         assert!(config.is_semantics_boundary());
         assert!(config.explicit_children_are_traversal_groups());
         assert!(config.blocks_user_actions());
-        assert_eq!(config.label().map(|label| label.as_str()), Some("Submit"));
+        assert_eq!(config.label().map(AttributedString::as_str), Some("Submit"));
         assert!(config.is_button());
         assert_eq!(config.is_enabled(), Some(true));
         assert_eq!(config.is_toggled(), Some(false));
@@ -417,11 +417,11 @@ mod tests {
         assert!(config.names_route());
         assert!(config.is_in_mutually_exclusive_group());
         assert_eq!(
-            config.increased_value().map(|value| value.as_str()),
+            config.increased_value().map(AttributedString::as_str),
             Some("More"),
         );
         assert_eq!(
-            config.decreased_value().map(|value| value.as_str()),
+            config.decreased_value().map(AttributedString::as_str),
             Some("Less"),
         );
     }

--- a/crates/flui-objects/src/proxy/shader_mask.rs
+++ b/crates/flui-objects/src/proxy/shader_mask.rs
@@ -154,10 +154,11 @@ impl Clone for RenderShaderMask {
 
 impl fmt::Debug for RenderShaderMask {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // `shader_callback` is an opaque closure with no useful `Debug` form.
         f.debug_struct("RenderShaderMask")
             .field("blend_mode", &self.blend_mode)
             .field("has_child", &self.has_child)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -197,6 +198,10 @@ impl RenderBox for RenderShaderMask {
         self.has_child
     }
 
+    // Closure is load-bearing: `PaintCx::paint_child` is ambiguous as a method path
+    // (Single's zero-arg overload vs the indexed variant on other arities), so the
+    // closure cannot be replaced by a method reference.
+    #[allow(clippy::redundant_closure_for_method_calls)]
     fn paint(&self, ctx: &mut PaintCx<'_, Single>) {
         // Oracle `:1191-1193` — no child means nothing at all is drawn
         // (not even an empty mask layer).

--- a/crates/flui-objects/src/sliver/sliver_fill_remaining.rs
+++ b/crates/flui-objects/src/sliver/sliver_fill_remaining.rs
@@ -9,7 +9,11 @@
 
 use flui_foundation::Diagnosticable;
 use flui_tree::Single;
-use flui_types::{Offset, geometry::px, layout::AxisDirection::*};
+use flui_types::{
+    Offset,
+    geometry::px,
+    layout::AxisDirection::{BottomToTop, LeftToRight, RightToLeft, TopToBottom},
+};
 
 use flui_rendering::{
     constraints::{SliverConstraints, SliverGeometry},

--- a/crates/flui-objects/src/sliver/sliver_list.rs
+++ b/crates/flui-objects/src/sliver/sliver_list.rs
@@ -116,8 +116,7 @@ impl RenderSliverList {
     pub fn new(item_count: usize, default_extent_estimate: f32) -> Self {
         assert!(
             default_extent_estimate.is_finite() && default_extent_estimate > 0.0,
-            "default_extent_estimate must be finite and positive, got {}",
-            default_extent_estimate,
+            "default_extent_estimate must be finite and positive, got {default_extent_estimate}",
         );
         Self {
             item_count,

--- a/crates/flui-objects/src/sliver/sliver_to_box_adapter.rs
+++ b/crates/flui-objects/src/sliver/sliver_to_box_adapter.rs
@@ -6,7 +6,10 @@
 
 use flui_foundation::Diagnosticable;
 use flui_tree::Single;
-use flui_types::{geometry::px, layout::AxisDirection::*};
+use flui_types::{
+    geometry::px,
+    layout::AxisDirection::{BottomToTop, LeftToRight, RightToLeft, TopToBottom},
+};
 
 use flui_rendering::{
     constraints::{SliverConstraints, SliverGeometry, child_paint_offset},

--- a/crates/flui-objects/src/sliver/viewport.rs
+++ b/crates/flui-objects/src/sliver/viewport.rs
@@ -10,7 +10,10 @@ use flui_tree::Variable;
 use flui_types::{
     Offset, Pixels, Point, Rect, Size,
     geometry::px,
-    layout::{Axis, AxisDirection, AxisDirection::*},
+    layout::{
+        Axis, AxisDirection,
+        AxisDirection::{BottomToTop, LeftToRight, RightToLeft, TopToBottom},
+    },
     painting::Clip,
 };
 

--- a/crates/flui-objects/src/sliver/virtualized_band.rs
+++ b/crates/flui-objects/src/sliver/virtualized_band.rs
@@ -307,6 +307,11 @@ where
         } else {
             // Absent: strategy owns the complete decision.
             let result = on_absent(logical_i, dense_count, box_constraints, ctx);
+            // match_same_arms: the `Scheduled | Ready(_)` no-op arm is kept separate
+            // from the `#[non_exhaustive]` forward-compat wildcard on purpose — the
+            // arm exists to document the per-variant semantics, and merging it into
+            // `_` would silently absorb future `ChildLayout` variants.
+            #[allow(clippy::match_same_arms)]
             match result {
                 ChildLayout::Scheduled | ChildLayout::Ready(_) => {
                     // Scheduled = parked for next frame (v1 next-frame backend).
@@ -352,8 +357,7 @@ where
             if !in_band {
                 let keep_alive = ctx
                     .child_parent_data(slot)
-                    .map(|pd| pd.keep_alive.keep_alive)
-                    .unwrap_or(false);
+                    .is_some_and(|pd| pd.keep_alive.keep_alive);
                 if keep_alive {
                     continue;
                 }

--- a/crates/flui-objects/src/text/editable.rs
+++ b/crates/flui-objects/src/text/editable.rs
@@ -236,8 +236,7 @@ impl Diagnosticable for RenderEditable {
             "text_direction",
             self.painter
                 .text_direction()
-                .map(|d| format!("{d:?}"))
-                .unwrap_or_else(|| "unset".to_string()),
+                .map_or_else(|| "unset".to_string(), |d| format!("{d:?}")),
         );
         properties.add("caret_byte_offset", self.caret_byte_offset);
         properties.add_flag("show_caret", self.show_caret, "show caret");

--- a/crates/flui-objects/src/text/paragraph.rs
+++ b/crates/flui-objects/src/text/paragraph.rs
@@ -132,23 +132,20 @@ impl Diagnosticable for RenderParagraph {
             "text_direction",
             self.painter
                 .text_direction()
-                .map(|d| format!("{d:?}"))
-                .unwrap_or_else(|| "unset".to_string()),
+                .map_or_else(|| "unset".to_string(), |d| format!("{d:?}")),
         );
         properties.add_flag("soft_wrap", self.soft_wrap, "soft wrap");
         properties.add(
             "max_lines",
             self.painter
                 .max_lines()
-                .map(|n| n.to_string())
-                .unwrap_or_else(|| "unlimited".to_string()),
+                .map_or_else(|| "unlimited".to_string(), |n| n.to_string()),
         );
         properties.add(
             "ellipsis",
             self.painter
                 .ellipsis()
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| "none".to_string()),
+                .map_or_else(|| "none".to_string(), ToString::to_string),
         );
         // Emit the plain text so diagnostics dumps and test finders can match on
         // content without inspecting the full `InlineSpan` tree.

--- a/crates/flui-rendering/Cargo.toml
+++ b/crates/flui-rendering/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 license.workspace = true
 description = "Rendering layer for Flui framework"
 repository.workspace = true
+readme = "README.md"
 # Benches are declared explicitly below; disable auto-discovery so the shared
 # `benches/helpers.rs` module is not itself compiled as a standalone bench target.
 autobenches = false

--- a/crates/flui-rendering/README.md
+++ b/crates/flui-rendering/README.md
@@ -1,0 +1,48 @@
+# flui-rendering
+
+**The render-tree engine of FLUI** — the third tree in the five-tree
+architecture (View → Element → **Render** → Layer → Semantics) and the densest
+crate in the workspace: traits, layout/paint/hit-test protocols, the pipeline
+owner, and the render-object test harness.
+
+Part of the [FLUI](https://github.com/vanyastaff/flui) workspace — pre-release,
+consumed by path (not published to crates.io). Concrete render objects live in
+[`flui-objects`](../flui-objects); this crate owns the machinery they plug
+into.
+
+## What lives here
+
+- **Traits & protocols** — `RenderObject`, `RenderBox` (2D cartesian),
+  `RenderSliver` (scrollable), with the type-safe `Protocol` abstraction and
+  Arity-parameterized children (`Leaf`/`Single`/`Optional`/`Variable` —
+  child-count mismatches are compile errors).
+- **Pipeline** — `PipelineOwner` drives dirty-tracked layout → paint →
+  composite through the Flutter contract (sync, on-demand phases). The
+  re-entrant layout walk's `unsafe` is confined to one SAFETY-audited arena
+  module (`pipeline/owner/subtree_arena.rs`), machine-checked by a miri CI
+  job.
+- **Storage** — slab-backed `RenderTree` with 1-based `NonZeroUsize`
+  `RenderId`s (the workspace-wide ID offset pattern).
+- **Virtualization** — protocol-agnostic windowing math backing the lazy
+  sliver family.
+- **Testing harness** (`testing` feature) — `RenderTester`/`Probe` build real
+  `PipelineOwner` trees through the production pipeline; every concrete
+  render object in `flui-objects` is catalog-tested against it. See
+  [`docs/TESTING.md`](docs/TESTING.md).
+
+## Flutter parity
+
+Layout, paint, hit-test, and dirty-propagation behavior is ported 1:1 from
+Flutter's `rendering/` library (behavior, not structure). Changes here must be
+cross-checked against the reference; the harness suite and `docs/PORT.md`'s
+refusal triggers are the enforcement.
+
+## Documentation
+
+Every public item is documented (`#![deny(missing_docs)]`); build locally with
+`cargo doc -p flui-rendering --open`. Deep architecture:
+[`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+## License
+
+MIT OR Apache-2.0, per the workspace license.

--- a/crates/flui-rendering/src/constraints/sliver_constraints.rs
+++ b/crates/flui-rendering/src/constraints/sliver_constraints.rs
@@ -416,7 +416,7 @@ impl fmt::Debug for SliverConstraints {
             .field("scroll_offset", &self.scroll_offset)
             .field("remaining_paint", &self.remaining_paint_extent)
             .field("cross_extent", &self.cross_axis_extent)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-rendering/src/constraints/sliver_geometry.rs
+++ b/crates/flui-rendering/src/constraints/sliver_geometry.rs
@@ -446,7 +446,8 @@ impl fmt::Debug for SliverGeometry {
             debug.field("scroll_correction", &correction);
         }
 
-        debug.finish()
+        // Fields at their default/derived values are elided above.
+        debug.finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-rendering/src/context/hit_test.rs
+++ b/crates/flui-rendering/src/context/hit_test.rs
@@ -73,6 +73,17 @@ pub struct HitTestContext<'ctx, P: Protocol, A: Arity, PD: ParentData> {
     self_hit_entry_registered: bool,
 }
 
+impl<P: Protocol, A: Arity, PD: ParentData> std::fmt::Debug for HitTestContext<'_, P, A, PD> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `inner` is a capability-GAT context (may hold live driver callbacks);
+        // report only the driver-resolved scalars.
+        f.debug_struct("HitTestContext")
+            .field("own_size", &self.own_size)
+            .field("self_hit_entry_registered", &self.self_hit_entry_registered)
+            .finish_non_exhaustive()
+    }
+}
+
 impl<'ctx, P: Protocol, A: Arity, PD: ParentData> HitTestContext<'ctx, P, A, PD>
 where
     <P::HitTest as HitTestCapability>::Context<'ctx, A, PD>:

--- a/crates/flui-rendering/src/context/intrinsics.rs
+++ b/crates/flui-rendering/src/context/intrinsics.rs
@@ -101,6 +101,15 @@ pub struct BoxDryBaselineCtx<'a> {
             ),
 }
 
+impl std::fmt::Debug for BoxDryBaselineCtx<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `query` is a live driver callback into the slot map; show counters only.
+        f.debug_struct("BoxDryBaselineCtx")
+            .field("child_count", &self.child_count)
+            .finish_non_exhaustive()
+    }
+}
+
 impl<'a> BoxDryBaselineCtx<'a> {
     /// Wraps the driver's child dry-baseline callback.
     pub(crate) fn new(
@@ -224,6 +233,15 @@ pub struct BoxIntrinsicsCtx<'a> {
     query: &'a mut (dyn FnMut(usize, IntrinsicDimension, f32) -> f32 + Send + Sync),
 }
 
+impl std::fmt::Debug for BoxIntrinsicsCtx<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `query` is a live driver callback into the slot map; show counters only.
+        f.debug_struct("BoxIntrinsicsCtx")
+            .field("child_count", &self.child_count)
+            .finish_non_exhaustive()
+    }
+}
+
 impl<'a> BoxIntrinsicsCtx<'a> {
     /// Wraps the driver's child-query callback.
     pub(crate) fn new(
@@ -331,6 +349,15 @@ pub struct BoxDryLayoutCtx<'a> {
     child_parent_data: &'a [Option<&'a dyn ParentData>],
     query:
         &'a mut (dyn FnMut(usize, DryLayoutChildRequest) -> DryLayoutChildResponse + Send + Sync),
+}
+
+impl std::fmt::Debug for BoxDryLayoutCtx<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `query` is a live driver callback into the slot map; show counters only.
+        f.debug_struct("BoxDryLayoutCtx")
+            .field("child_count", &self.child_count)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'a> BoxDryLayoutCtx<'a> {

--- a/crates/flui-rendering/src/context/layout.rs
+++ b/crates/flui-rendering/src/context/layout.rs
@@ -56,6 +56,15 @@ pub struct LayoutContext<'ctx, P: Protocol, A: Arity, PD: ParentData + Default> 
     inner: <P::Layout as LayoutCapability>::Context<'ctx, A, PD>,
 }
 
+impl<P: Protocol, A: Arity, PD: ParentData + Default> std::fmt::Debug
+    for LayoutContext<'_, P, A, PD>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `inner` is a capability-GAT context (may hold live driver callbacks).
+        f.debug_struct("LayoutContext").finish_non_exhaustive()
+    }
+}
+
 impl<'ctx, P: Protocol, A: Arity, PD: ParentData + Default> LayoutContext<'ctx, P, A, PD>
 where
     <P::Layout as LayoutCapability>::Context<'ctx, A, PD>: LayoutContextApi<'ctx, P::Layout, A, PD>,

--- a/crates/flui-rendering/src/context/paint_cx.rs
+++ b/crates/flui-rendering/src/context/paint_cx.rs
@@ -368,6 +368,16 @@ pub struct PaintCx<'a, A: Arity> {
     _arity: PhantomData<fn() -> A>,
 }
 
+impl<A: Arity> std::fmt::Debug for PaintCx<'_, A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `rec` is the live recording canvas; report the node-scoped scalars.
+        f.debug_struct("PaintCx")
+            .field("child_count", &self.child_count)
+            .field("size", &self.size)
+            .finish_non_exhaustive()
+    }
+}
+
 impl<'a, A: Arity> PaintCx<'a, A> {
     /// Creates a typed context over a recorder.
     ///

--- a/crates/flui-rendering/src/delegates/custom_painter.rs
+++ b/crates/flui-rendering/src/delegates/custom_painter.rs
@@ -210,9 +210,9 @@ mod tests {
 
     #[test]
     fn test_should_repaint_same_type() {
-        let painter1 = TestPainter { color: 0xFF0000 };
-        let painter2 = TestPainter { color: 0xFF0000 };
-        let painter3 = TestPainter { color: 0x00FF00 };
+        let painter1 = TestPainter { color: 0x00FF_0000 };
+        let painter2 = TestPainter { color: 0x00FF_0000 };
+        let painter3 = TestPainter { color: 0x0000_FF00 };
 
         assert!(!painter1.should_repaint(&painter2));
         assert!(painter1.should_repaint(&painter3));
@@ -220,13 +220,13 @@ mod tests {
 
     #[test]
     fn test_default_hit_test() {
-        let painter = TestPainter { color: 0xFF0000 };
+        let painter = TestPainter { color: 0x00FF_0000 };
         assert_eq!(painter.hit_test(Offset::ZERO), None);
     }
 
     #[test]
     fn test_default_semantics() {
-        let painter = TestPainter { color: 0xFF0000 };
+        let painter = TestPainter { color: 0x00FF_0000 };
         assert!(painter.semantics_builder().is_none());
     }
 }

--- a/crates/flui-rendering/src/delegates/flow_delegate.rs
+++ b/crates/flui-rendering/src/delegates/flow_delegate.rs
@@ -185,6 +185,20 @@ pub struct FlowPaintingContext<'ctx, 'cx> {
     painted: &'ctx mut Vec<bool>,
 }
 
+impl std::fmt::Debug for FlowPaintingContext<'_, '_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `live` holds a &mut PaintCx (the live recording canvas); report
+        // the replayable recording state instead.
+        f.debug_struct("FlowPaintingContext")
+            .field("size", &self.size)
+            .field("child_sizes", &self.child_sizes)
+            .field("live", &self.live.is_some())
+            .field("paint_order", &self.paint_order)
+            .field("painted", &self.painted)
+            .finish_non_exhaustive()
+    }
+}
+
 impl<'ctx, 'cx> FlowPaintingContext<'ctx, 'cx> {
     /// Builds a paint-mode context that forwards each [`Self::paint_child`]
     /// call to the live `ctx` via [`PaintCx::with_transform`].

--- a/crates/flui-rendering/src/lib.rs
+++ b/crates/flui-rendering/src/lib.rs
@@ -51,23 +51,8 @@
 #![allow(clippy::type_complexity)]
 // Some render objects have many configuration parameters
 #![allow(clippy::too_many_arguments)]
-// Tracked ship-quality debt:
-#![allow(missing_debug_implementations)] // TODO(ship-wave-3): add Debug impls (15 types), then delete
-#![allow(
-    clippy::default_trait_access,
-    clippy::format_push_string,
-    clippy::manual_let_else,
-    clippy::many_single_char_names,
-    clippy::map_unwrap_or,
-    clippy::match_same_arms,
-    clippy::match_wildcard_for_single_variants,
-    clippy::missing_fields_in_debug,
-    clippy::should_panic_without_expect,
-    clippy::struct_field_names,
-    clippy::unreadable_literal,
-    clippy::unused_self,
-    clippy::used_underscore_binding
-)] // TODO(ship-wave-3): burn down per-lint, then delete
+// Ship bar (wave 3): every public item is documented; keep it that way.
+#![deny(missing_docs)]
 
 pub mod binding;
 pub mod constraints;

--- a/crates/flui-rendering/src/pipeline/notifier.rs
+++ b/crates/flui-rendering/src/pipeline/notifier.rs
@@ -31,25 +31,22 @@ type Callback = Box<dyn Fn() + Send + Sync>;
 /// pipeline-owner trait bound.
 #[derive(Default)]
 pub struct VisualUpdateNotifier {
-    on_need_visual_update: Option<Callback>,
-    on_semantics_owner_created: Option<Callback>,
-    on_semantics_owner_disposed: Option<Callback>,
+    need_visual_update: Option<Callback>,
+    semantics_owner_created: Option<Callback>,
+    semantics_owner_disposed: Option<Callback>,
 }
 
 impl std::fmt::Debug for VisualUpdateNotifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("VisualUpdateNotifier")
+            .field("need_visual_update", &self.need_visual_update.is_some())
             .field(
-                "on_need_visual_update",
-                &self.on_need_visual_update.is_some(),
+                "semantics_owner_created",
+                &self.semantics_owner_created.is_some(),
             )
             .field(
-                "on_semantics_owner_created",
-                &self.on_semantics_owner_created.is_some(),
-            )
-            .field(
-                "on_semantics_owner_disposed",
-                &self.on_semantics_owner_disposed.is_some(),
+                "semantics_owner_disposed",
+                &self.semantics_owner_disposed.is_some(),
             )
             .finish()
     }
@@ -69,13 +66,13 @@ impl VisualUpdateNotifier {
     where
         F: Fn() + Send + Sync + 'static,
     {
-        self.on_need_visual_update = Some(Box::new(callback));
+        self.need_visual_update = Some(Box::new(callback));
     }
 
     /// Fires the visual-update callback if one is set; otherwise no-op.
     #[inline]
     pub fn fire_need_visual_update(&self) {
-        if let Some(callback) = &self.on_need_visual_update {
+        if let Some(callback) = &self.need_visual_update {
             callback();
         }
     }
@@ -87,13 +84,13 @@ impl VisualUpdateNotifier {
     where
         F: Fn() + Send + Sync + 'static,
     {
-        self.on_semantics_owner_created = Some(Box::new(callback));
+        self.semantics_owner_created = Some(Box::new(callback));
     }
 
     /// Fires the semantics-owner-created callback if one is set.
     #[inline]
     pub fn fire_semantics_owner_created(&self) {
-        if let Some(callback) = &self.on_semantics_owner_created {
+        if let Some(callback) = &self.semantics_owner_created {
             callback();
         }
     }
@@ -105,13 +102,13 @@ impl VisualUpdateNotifier {
     where
         F: Fn() + Send + Sync + 'static,
     {
-        self.on_semantics_owner_disposed = Some(Box::new(callback));
+        self.semantics_owner_disposed = Some(Box::new(callback));
     }
 
     /// Fires the semantics-owner-disposed callback if one is set.
     #[inline]
     pub fn fire_semantics_owner_disposed(&self) {
-        if let Some(callback) = &self.on_semantics_owner_disposed {
+        if let Some(callback) = &self.semantics_owner_disposed {
             callback();
         }
     }

--- a/crates/flui-rendering/src/pipeline/owner/mod.rs
+++ b/crates/flui-rendering/src/pipeline/owner/mod.rs
@@ -269,7 +269,7 @@ impl<Phase: PipelinePhase> std::fmt::Debug for PipelineOwner<Phase> {
                 &self.last_hidden_follower_ids.len(),
             )
             .field("has_semantics_owner", &self.semantics_owner.is_some())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-rendering/src/pipeline/owner/subtree_arena.rs
+++ b/crates/flui-rendering/src/pipeline/owner/subtree_arena.rs
@@ -698,9 +698,8 @@ unsafe fn layout_subtree_borrowed_impl(
     let _cycle_guard = LayoutCycleGuard::enter(arena, id)?;
 
     // Resolve id → NodePtr.  Cross-thread access panics inside `get`.
-    let NodePtr(node_ptr) = match arena.get(id) {
-        Some(np) => np,
-        None => return Err(crate::error::RenderError::NodeNotFound(id)),
+    let Some(NodePtr(node_ptr)) = arena.get(id) else {
+        return Err(crate::error::RenderError::NodeNotFound(id));
     };
 
     // -----------------------------------------------------------------------
@@ -1169,9 +1168,8 @@ unsafe fn box_intrinsic_query_borrowed_impl(
 ) -> crate::error::RenderResult<f32> {
     let _cycle_guard = LayoutCycleGuard::enter(arena, id)?;
 
-    let NodePtr(node_ptr) = match arena.get(id) {
-        Some(np) => np,
-        None => return Err(crate::error::RenderError::NodeNotFound(id)),
+    let Some(NodePtr(node_ptr)) = arena.get(id) else {
+        return Err(crate::error::RenderError::NodeNotFound(id));
     };
 
     // SAFETY: this is the only live reborrow of `id` in this intrinsic
@@ -1329,9 +1327,8 @@ unsafe fn layout_sliver_subtree_borrowed_impl(
     let _cycle_guard = LayoutCycleGuard::enter(arena, id)?;
 
     // Resolve id → NodePtr.  Cross-thread access panics inside `get`.
-    let NodePtr(node_ptr) = match arena.get(id) {
-        Some(np) => np,
-        None => return Err(crate::error::RenderError::NodeNotFound(id)),
+    let Some(NodePtr(node_ptr)) = arena.get(id) else {
+        return Err(crate::error::RenderError::NodeNotFound(id));
     };
 
     // -----------------------------------------------------------------------

--- a/crates/flui-rendering/src/protocol/box_protocol.rs
+++ b/crates/flui-rendering/src/protocol/box_protocol.rs
@@ -215,6 +215,10 @@ pub struct BoxLayout;
 /// Uses integer representation of floats (bits) for reliable hashing.
 /// This handles -0.0/+0.0 and provides exact equality.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+// The `_bits` postfix is load-bearing: each field is the `f32::to_bits` image
+// of the same-named `BoxConstraints` field, and dropping it would suggest the
+// fields hold pixel values.
+#[allow(clippy::struct_field_names)]
 pub struct BoxConstraintsCacheKey {
     min_width_bits: u32,
     max_width_bits: u32,
@@ -376,6 +380,21 @@ type ProxyChildSizeCache = Vec<Option<Size>>;
 pub struct BoxLayoutCtx<'ctx, A: Arity, P: ParentData + Default> {
     storage: BoxLayoutCtxStorage<'ctx, P>,
     _phantom: std::marker::PhantomData<A>,
+}
+
+impl<A: Arity, P: ParentData + Default> std::fmt::Debug for BoxLayoutCtx<'_, A, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Storage holds live driver callbacks / an erased pipeline context;
+        // report the storage mode and the (Copy) constraints only.
+        let (mode, constraints) = match &self.storage {
+            BoxLayoutCtxStorage::Direct { constraints, .. } => ("Direct", constraints),
+            BoxLayoutCtxStorage::Proxy { constraints, .. } => ("Proxy", constraints),
+        };
+        f.debug_struct("BoxLayoutCtx")
+            .field("storage", &mode)
+            .field("constraints", constraints)
+            .finish_non_exhaustive()
+    }
 }
 
 /// Internal storage variants. See [`BoxLayoutCtx`] doc.
@@ -1092,6 +1111,18 @@ pub struct ErasedBoxLayoutCtx<'ctx> {
     intrinsics_child_callback: Option<BoxChildIntrinsicCallback<'ctx>>,
 }
 
+impl std::fmt::Debug for ErasedBoxLayoutCtx<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The layout / baseline / intrinsic callbacks are live driver
+        // closures over the slot map; report constraints and child state.
+        f.debug_struct("ErasedBoxLayoutCtx")
+            .field("constraints", &self.constraints)
+            .field("children", &self.children)
+            .field("child_ids", &self.child_ids)
+            .finish_non_exhaustive()
+    }
+}
+
 impl<'ctx> ErasedBoxLayoutCtx<'ctx> {
     /// Creates the walk-side context over pre-built child slots.
     ///
@@ -1363,6 +1394,19 @@ pub struct BoxHitTestCtx<'ctx, A: Arity, P: ParentData> {
     /// `pop_transform` (full re-fold over the truncated stack).
     composed_transform: Matrix4,
     _phantom: std::marker::PhantomData<(&'ctx (), A, P)>,
+}
+
+impl<A: Arity, P: ParentData> std::fmt::Debug for BoxHitTestCtx<'_, A, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `child_callback` is the driver's live hit-test recursion; report
+        // the position, accumulated result, and transform state.
+        f.debug_struct("BoxHitTestCtx")
+            .field("position", &self.position)
+            .field("result", &self.result)
+            .field("transform_stack", &self.transform_stack)
+            .field("composed_transform", &self.composed_transform)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'ctx, A: Arity, P: ParentData> BoxHitTestCtx<'ctx, A, P> {

--- a/crates/flui-rendering/src/protocol/sliver_protocol.rs
+++ b/crates/flui-rendering/src/protocol/sliver_protocol.rs
@@ -306,6 +306,21 @@ pub struct SliverLayoutCtx<'ctx, A: Arity, P: ParentData + Default> {
     _phantom: std::marker::PhantomData<(A, P)>,
 }
 
+impl<A: Arity, P: ParentData + Default> std::fmt::Debug for SliverLayoutCtx<'_, A, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Storage holds live driver callbacks / an erased pipeline context;
+        // report the storage mode and the (Copy) constraints only.
+        let (mode, constraints) = match &self.storage {
+            SliverLayoutCtxStorage::Direct { constraints, .. } => ("Direct", constraints),
+            SliverLayoutCtxStorage::Proxy { constraints, .. } => ("Proxy", constraints),
+        };
+        f.debug_struct("SliverLayoutCtx")
+            .field("storage", &mode)
+            .field("constraints", constraints)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Internal storage variants for [`SliverLayoutCtx`].
 enum SliverLayoutCtxStorage<'ctx, P: ParentData + Default> {
     /// Production / pipeline path: owns constraints, geometry slot, and
@@ -992,6 +1007,19 @@ pub struct ErasedSliverLayoutCtx<'ctx> {
     pending_retain_bands: &'ctx parking_lot::Mutex<Vec<(RenderId, usize, usize)>>,
 }
 
+impl std::fmt::Debug for ErasedSliverLayoutCtx<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Callbacks are live driver closures and the pending_* sinks are
+        // shared mutexes (never locked in fmt); report ids + child state.
+        f.debug_struct("ErasedSliverLayoutCtx")
+            .field("constraints", &self.constraints)
+            .field("children", &self.children)
+            .field("child_ids", &self.child_ids)
+            .field("node_id", &self.node_id)
+            .finish_non_exhaustive()
+    }
+}
+
 impl<'ctx> ErasedSliverLayoutCtx<'ctx> {
     /// Creates the walk-side context over pre-built child slots. `node_id` is the
     /// sliver being laid out, `pending_builds` is the walk-owned sink for
@@ -1283,6 +1311,16 @@ pub struct SliverHitTestCtx<'ctx, A: Arity, P: ParentData> {
     result: SliverHitTestResult,
     child_callback: Option<SliverHitTestChildCallback<'ctx>>,
     _phantom: std::marker::PhantomData<(&'ctx (), A, P)>,
+}
+
+impl<A: Arity, P: ParentData> std::fmt::Debug for SliverHitTestCtx<'_, A, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `child_callback` is the driver's live hit-test recursion.
+        f.debug_struct("SliverHitTestCtx")
+            .field("position", &self.position)
+            .field("result", &self.result)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'ctx, A: Arity, P: ParentData> SliverHitTestCtx<'ctx, A, P> {

--- a/crates/flui-rendering/src/storage/node.rs
+++ b/crates/flui-rendering/src/storage/node.rs
@@ -161,7 +161,7 @@ impl RenderNode {
     pub fn as_box(&self) -> Option<&RenderEntry<BoxProtocol>> {
         match self {
             Self::Box(entry) => Some(entry),
-            _ => None,
+            Self::Sliver(_) => None,
         }
     }
 
@@ -170,7 +170,7 @@ impl RenderNode {
     pub fn as_box_mut(&mut self) -> Option<&mut RenderEntry<BoxProtocol>> {
         match self {
             Self::Box(entry) => Some(entry),
-            _ => None,
+            Self::Sliver(_) => None,
         }
     }
 
@@ -195,7 +195,7 @@ impl RenderNode {
     pub fn as_sliver(&self) -> Option<&RenderEntry<SliverProtocol>> {
         match self {
             Self::Sliver(entry) => Some(entry),
-            _ => None,
+            Self::Box(_) => None,
         }
     }
 
@@ -205,7 +205,7 @@ impl RenderNode {
     pub fn as_sliver_mut(&mut self) -> Option<&mut RenderEntry<SliverProtocol>> {
         match self {
             Self::Sliver(entry) => Some(entry),
-            _ => None,
+            Self::Box(_) => None,
         }
     }
 }

--- a/crates/flui-rendering/src/storage/tree.rs
+++ b/crates/flui-rendering/src/storage/tree.rs
@@ -575,9 +575,7 @@ impl RenderTree {
     /// Returns the children IDs of a node.
     #[inline]
     pub fn children(&self, id: RenderId) -> &[RenderId] {
-        self.get(id)
-            .map(super::node::RenderNode::children)
-            .unwrap_or(&[])
+        self.get(id).map_or(&[], super::node::RenderNode::children)
     }
 
     /// Returns the depth of a node in the tree.

--- a/crates/flui-rendering/src/testing/harness.rs
+++ b/crates/flui-rendering/src/testing/harness.rs
@@ -96,6 +96,16 @@ pub struct RenderTester {
     semantics_enabled: bool,
 }
 
+impl std::fmt::Debug for RenderTester {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RenderTester")
+            .field("spec", &self.spec)
+            .field("constraints", &self.constraints)
+            .field("semantics_enabled", &self.semantics_enabled)
+            .finish()
+    }
+}
+
 impl RenderTester {
     /// Configures a test from a [`TreeNode`] spec (the root must be a Box
     /// node — see [`crate::testing::tree::mount`]).

--- a/crates/flui-rendering/src/testing/snapshot.rs
+++ b/crates/flui-rendering/src/testing/snapshot.rs
@@ -11,6 +11,8 @@
 //! Task 4 will expose `serialize_layer_tree` on `FrameRun::snapshot()`.
 //! Keep this file focused: summary helpers + the tree walk.
 
+use std::fmt::Write as _;
+
 use flui_foundation::{LayerId, RenderId};
 use flui_layer::LayerTree;
 use flui_painting::PaintStyle;
@@ -659,14 +661,8 @@ fn write_display_list(out: &mut String, dl: &DisplayList, depth: usize) {
         // Recurse into effect-command children before printing the line so that
         // the child content appears nested under the effect header.
         match cmd {
-            DrawCommand::ShaderMask { child, .. } => {
-                let summary = summarize_command(cmd);
-                out.push_str(&indent);
-                out.push_str(&summary.line);
-                out.push('\n');
-                write_display_list(out, child, depth + 1);
-            }
-            DrawCommand::BackdropFilter {
+            DrawCommand::ShaderMask { child, .. }
+            | DrawCommand::BackdropFilter {
                 child: Some(child), ..
             } => {
                 let summary = summarize_command(cmd);
@@ -690,11 +686,8 @@ fn write_display_list(out: &mut String, dl: &DisplayList, depth: usize) {
 fn collect_from_display_list(dl: &DisplayList, out: &mut Vec<DrawCommandSummary>) {
     for cmd in dl {
         match cmd {
-            DrawCommand::ShaderMask { child, .. } => {
-                out.push(summarize_command(cmd));
-                collect_from_display_list(child, out);
-            }
-            DrawCommand::BackdropFilter {
+            DrawCommand::ShaderMask { child, .. }
+            | DrawCommand::BackdropFilter {
                 child: Some(child), ..
             } => {
                 out.push(summarize_command(cmd));
@@ -730,13 +723,14 @@ fn write_layer(out: &mut String, tree: &LayerTree, id: LayerId, depth: usize) {
         Layer::Picture(p) => {
             let b = p.bounds();
             out.push_str(&indent);
-            out.push_str(&format!(
-                "Picture bounds=({},{} {}x{})\n",
+            let _ = writeln!(
+                out,
+                "Picture bounds=({},{} {}x{})",
                 f(b.left().get()),
                 f(b.top().get()),
                 f(b.width().get()),
                 f(b.height().get()),
-            ));
+            );
             // Emit commands one level deeper.
             write_display_list(out, p.picture(), depth + 1);
         }
@@ -755,25 +749,27 @@ fn write_layer(out: &mut String, tree: &LayerTree, id: LayerId, depth: usize) {
         Layer::ClipRect(c) => {
             let r = c.clip_rect();
             out.push_str(&indent);
-            out.push_str(&format!(
-                "ClipRect rect=({},{} {}x{}) clip={}\n",
+            let _ = writeln!(
+                out,
+                "ClipRect rect=({},{} {}x{}) clip={}",
                 f(r.left().get()),
                 f(r.top().get()),
                 f(r.width().get()),
                 f(r.height().get()),
                 fmt_clip(c.clip_behavior()),
-            ));
+            );
         }
         Layer::ClipRRect(c) => {
             // Serialize the full rounded rect (outer bounds + corner radii) so a
             // regression that drops or changes the radii diffs the snapshot
             // instead of passing under an identical outer-rect line.
             out.push_str(&indent);
-            out.push_str(&format!(
-                "ClipRRect rrect={} clip={}\n",
+            let _ = writeln!(
+                out,
+                "ClipRRect rrect={} clip={}",
                 fmt_rrect(c.clip_rrect()),
                 fmt_clip(c.clip_behavior()),
-            ));
+            );
         }
         Layer::ClipPath(c) => {
             // Mirror the command-path summary: clipping geometry shape (bounds +
@@ -781,28 +777,30 @@ fn write_layer(out: &mut String, tree: &LayerTree, id: LayerId, depth: usize) {
             // "ClipPath" marker that hides every shape/quality change.
             let path = c.clip_path();
             out.push_str(&indent);
-            out.push_str(&format!(
-                "ClipPath bounds={} pts={} clip={}\n",
+            let _ = writeln!(
+                out,
+                "ClipPath bounds={} pts={} clip={}",
                 fmt_rect(path.compute_bounds()),
                 path.commands().len(),
                 fmt_clip(c.clip_behavior()),
-            ));
+            );
         }
         Layer::ClipSuperellipse(c) => {
             let r = c.clip_superellipse().outer_rect();
             out.push_str(&indent);
-            out.push_str(&format!(
-                "ClipSuperellipse rect=({},{} {}x{}) clip={}\n",
+            let _ = writeln!(
+                out,
+                "ClipSuperellipse rect=({},{} {}x{}) clip={}",
                 f(r.left().get()),
                 f(r.top().get()),
                 f(r.width().get()),
                 f(r.height().get()),
                 fmt_clip(c.clip_behavior()),
-            ));
+            );
         }
         Layer::Offset(o) => {
             out.push_str(&indent);
-            out.push_str(&format!("Offset dx={} dy={}\n", f(o.dx()), f(o.dy())));
+            let _ = writeln!(out, "Offset dx={} dy={}", f(o.dx()), f(o.dy()));
         }
         Layer::Transform(_) => {
             // Known blind spot: `TransformLayer` exposes no public matrix getter
@@ -815,7 +813,7 @@ fn write_layer(out: &mut String, tree: &LayerTree, id: LayerId, depth: usize) {
         }
         Layer::Opacity(o) => {
             out.push_str(&indent);
-            out.push_str(&format!("Opacity alpha={}\n", f(o.alpha())));
+            let _ = writeln!(out, "Opacity alpha={}", f(o.alpha()));
         }
         Layer::ColorFilter(_) => {
             out.push_str(&indent);
@@ -828,24 +826,26 @@ fn write_layer(out: &mut String, tree: &LayerTree, id: LayerId, depth: usize) {
         Layer::ShaderMask(s) => {
             let r = s.bounds();
             out.push_str(&indent);
-            out.push_str(&format!(
-                "ShaderMask bounds=({},{} {}x{})\n",
+            let _ = writeln!(
+                out,
+                "ShaderMask bounds=({},{} {}x{})",
                 f(r.left().get()),
                 f(r.top().get()),
                 f(r.width().get()),
                 f(r.height().get()),
-            ));
+            );
         }
         Layer::BackdropFilter(b) => {
             let r = b.bounds();
             out.push_str(&indent);
-            out.push_str(&format!(
-                "BackdropFilter bounds=({},{} {}x{})\n",
+            let _ = writeln!(
+                out,
+                "BackdropFilter bounds=({},{} {}x{})",
                 f(r.left().get()),
                 f(r.top().get()),
                 f(r.width().get()),
                 f(r.height().get()),
-            ));
+            );
         }
         Layer::Leader(_) => {
             out.push_str(&indent);

--- a/crates/flui-rendering/src/testing/tree.rs
+++ b/crates/flui-rendering/src/testing/tree.rs
@@ -57,6 +57,22 @@ pub struct TreeNode {
     children: Vec<TreeNode>,
 }
 
+impl std::fmt::Debug for TreeNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `payload` boxes a type-erased render object with no Debug bound;
+        // report the protocol tag plus the spec metadata.
+        let protocol = match self.payload {
+            NodePayload::Box(_) => "Box",
+            NodePayload::Sliver(_) => "Sliver",
+        };
+        f.debug_struct("TreeNode")
+            .field("protocol", &protocol)
+            .field("label", &self.label)
+            .field("children", &self.children)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Creates a Box-protocol node from any concrete `RenderBox`-derived render
 /// object.
 pub fn box_node<R>(render_object: R) -> TreeNode

--- a/crates/flui-rendering/src/view/render_view.rs
+++ b/crates/flui-rendering/src/view/render_view.rs
@@ -85,7 +85,7 @@ impl Debug for RenderView {
             .field("configuration", &self.configuration)
             .field("size", &self.size)
             .field("has_layer", &self.layer.is_some())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -280,15 +280,16 @@ impl RenderView {
             "set a configuration before calling prepare_initial_frame"
         );
 
-        self.schedule_initial_layout_internal();
+        Self::schedule_initial_layout_internal();
         self.schedule_initial_paint_internal();
     }
 
-    fn schedule_initial_layout_internal(&mut self) {
+    fn schedule_initial_layout_internal() {
         // Cycle 4 R-14: the previous `self.needs_layout = true` write
         // had zero readers. RenderState<P>::flags::NEEDS_LAYOUT is
         // the load-bearing equivalent; the full plumbing lands when
-        // RenderView grows its own RenderState (or attaches to one).
+        // RenderView grows its own RenderState (or attaches to one) —
+        // at which point this becomes a `&mut self` method again.
     }
 
     fn schedule_initial_paint_internal(&mut self) {
@@ -303,7 +304,7 @@ impl RenderView {
         if self.root_transform.is_some() {
             return;
         }
-        self.schedule_initial_layout_internal();
+        Self::schedule_initial_layout_internal();
         self.schedule_initial_paint_internal();
     }
 
@@ -502,12 +503,13 @@ impl crate::protocol::RenderObject<crate::protocol::BoxProtocol> for RenderViewA
         &self,
         recorder: &mut crate::context::FragmentRecorder,
         child_count: usize,
-        _size: flui_types::Size,
+        size: flui_types::Size,
     ) {
         // Root pass-through: the view draws nothing itself and splices
-        // every child subtree in order — its own `_size` is unused.
+        // every child subtree in order — `size` is only forwarded to
+        // the child-painting context.
         let mut cx =
-            crate::context::PaintCx::<flui_tree::Variable>::new(recorder, child_count, _size);
+            crate::context::PaintCx::<flui_tree::Variable>::new(recorder, child_count, size);
         cx.paint_children();
     }
 
@@ -855,7 +857,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "self.root_transform.is_some()")]
     fn composite_frame_panics_before_initial_frame_is_prepared() {
         let config = ViewConfiguration::from_size(Size::new(px(800.0), px(600.0)), 2.0);
         let view = RenderView::with_configuration(config);

--- a/crates/flui-rendering/src/view/viewport.rs
+++ b/crates/flui-rendering/src/view/viewport.rs
@@ -150,13 +150,13 @@ mod tests {
 
     #[test]
     fn test_cache_extent_style_default() {
-        let style: CacheExtentStyle = Default::default();
+        let style = CacheExtentStyle::default();
         assert_eq!(style, CacheExtentStyle::Pixel);
     }
 
     #[test]
     fn test_sliver_paint_order_default() {
-        let order: SliverPaintOrder = Default::default();
+        let order = SliverPaintOrder::default();
         assert_eq!(order, SliverPaintOrder::FirstIsTop);
     }
 

--- a/crates/flui-rendering/src/view/viewport_offset.rs
+++ b/crates/flui-rendering/src/view/viewport_offset.rs
@@ -274,7 +274,7 @@ impl Debug for ScrollableViewportOffset {
             .field("user_scroll_direction", &self.user_scroll_direction)
             .field("allow_implicit_scrolling", &self.allow_implicit_scrolling)
             .field("listeners_count", &self.listeners.read().len())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-rendering/src/virtualization/tests.rs
+++ b/crates/flui-rendering/src/virtualization/tests.rs
@@ -59,7 +59,9 @@ fn estimated_to_exact_transition() {
     assert_eq!(v.estimated_count(), 1);
     match v.total_extent() {
         Extent::Estimated(t) => assert!(approx(t, 12.0 + 8.0 + 10.0)),
-        other => panic!("expected Estimated while a prefix is unmeasured, got {other:?}"),
+        other @ Extent::Exact(_) => {
+            panic!("expected Estimated while a prefix is unmeasured, got {other:?}")
+        }
     }
 
     // Measure the last — now Exact.
@@ -865,20 +867,20 @@ mod tree_edits {
     /// someone reintroduced incremental-delta summary maintenance.
     #[test]
     fn drift_long_edit_session() {
-        let n = 4000usize;
-        let mut t = ExtentTree::from_fn(n, |_| measured(0.1));
-        let mut o = Vecf(vec![0.1; n]);
-        let mut x = 0u64;
+        let len = 4000usize;
+        let mut tree = ExtentTree::from_fn(len, |_| measured(0.1));
+        let mut oracle = Vecf(vec![0.1; len]);
+        let mut state = 0u64;
         for _ in 0..200_000usize {
-            x = x
-                .wrapping_mul(6364136223846793005)
-                .wrapping_add(1442695040888963407);
-            let i = (x >> 33) as usize % t.len();
-            let e = ((x & 0xffff) as f32) / 6553.6;
-            t.set(i, measured(e));
-            o.set(i, e);
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            let idx = (state >> 33) as usize % tree.len();
+            let extent = ((state & 0xffff) as f32) / 6553.6;
+            tree.set(idx, measured(extent));
+            oracle.set(idx, extent);
         }
-        let drift = (t.total_extent() - o.total()).abs();
+        let drift = (tree.total_extent() - oracle.total()).abs();
         assert!(drift < 5.0, "drift {drift} too large — incremental delta?");
     }
 

--- a/crates/flui-view/src/binding.rs
+++ b/crates/flui-view/src/binding.rs
@@ -1455,7 +1455,7 @@ impl std::fmt::Debug for WidgetsBinding {
             .field("dirty_count", &inner.build_owner.dirty_count())
             .field("element_count", &inner.element_tree.len())
             .field("observer_count", &inner.observers.len())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-view/src/element/generic.rs
+++ b/crates/flui-view/src/element/generic.rs
@@ -567,7 +567,7 @@ where
             .field("dirty", &self.dirty.load(Ordering::Relaxed))
             .field("has_pipeline_owner", &self.pipeline_owner.is_some())
             .field("parent_render_id", &self.parent_render_id)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-view/src/lib.rs
+++ b/crates/flui-view/src/lib.rs
@@ -63,23 +63,12 @@
 //! }
 //! ```
 
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    clippy::all,
-    clippy::pedantic
-)]
-#![allow(
-    clippy::module_name_repetitions,
-    clippy::must_use_candidate,
-    clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
-    clippy::doc_markdown,
-    clippy::module_inception,
-    clippy::missing_fields_in_debug,
-    clippy::bool_to_int_with_if
-)]
+// Lint levels come from `[workspace.lints]`. Ship bar (wave 3): every public
+// item is documented; keep it that way.
+#![deny(missing_docs)]
+// `element/element.rs`, `view/view.rs`: a one-type family module named after
+// its type is the catalog's house style (matches flui-widgets/flui-objects).
+#![allow(clippy::module_inception)]
 
 // ============================================================================
 // Modules

--- a/crates/flui-view/src/owner/build_owner.rs
+++ b/crates/flui-view/src/owner/build_owner.rs
@@ -1022,7 +1022,7 @@ impl std::fmt::Debug for BuildOwner {
         f.debug_struct("BuildOwner")
             .field("dirty_count", &self.dirty_elements.len())
             .field("global_keys", &self.global_keys.len())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-view/src/tree/element_tree.rs
+++ b/crates/flui-view/src/tree/element_tree.rs
@@ -181,7 +181,7 @@ impl ElementNode {
     /// after `ElementNode::new` so the field is populated before
     /// the element is returned.
     pub fn new(kind: ElementKind, parent: Option<ElementId>, slot: usize) -> Self {
-        let depth = if parent.is_some() { 1 } else { 0 }; // Will be updated by tree
+        let depth = usize::from(parent.is_some()); // Will be updated by tree
         Self {
             kind: Some(kind),
             parent,
@@ -332,7 +332,7 @@ impl std::fmt::Debug for ElementNode {
                 "lifecycle",
                 &self.kind.as_ref().map(|k| k.element().lifecycle()),
             )
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -1561,7 +1561,7 @@ impl std::fmt::Debug for ElementTree {
         f.debug_struct("ElementTree")
             .field("len", &self.nodes.len())
             .field("root", &self.root)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/flui-widgets/src/lib.rs
+++ b/crates/flui-widgets/src/lib.rs
@@ -51,23 +51,12 @@
 //! [`StatelessView`]: flui_view::prelude::StatelessView
 //! [`ParentDataView`]: flui_view::prelude::ParentDataView
 
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    clippy::all,
-    clippy::pedantic
-)]
-#![allow(
-    clippy::module_name_repetitions,
-    clippy::must_use_candidate,
-    clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
-    clippy::doc_markdown,
-    // `flex/flex.rs`, `text/text.rs`: a one-type family module named after its
-    // type is the catalog's house style (matches `flui-view`/`flui-objects`).
-    clippy::module_inception
-)]
+// Lint levels come from `[workspace.lints]`. Ship bar (wave 3): every public
+// item is documented; keep it that way.
+#![deny(missing_docs)]
+// `flex/flex.rs`, `text/text.rs`: a one-type family module named after its
+// type is the catalog's house style (matches `flui-view`/`flui-objects`).
+#![allow(clippy::module_inception)]
 
 // ============================================================================
 // Modules


### PR DESCRIPTION
## Summary

Wave 3 of the ship-quality program: the framework cohort (flui-rendering, flui-objects, flui-view, flui-widgets, flui-binding, flui-animation) sheds its tracked lint debt. All six crates now hold `#[deny(missing_docs)]`; every surviving allow is item-targeted with an argued reason.

- **flui-rendering** (the parity-critical engine crate): both tracked opt-outs removed. All 15 missing Debug impls are necessarily manual — every flagged type holds dyn driver callbacks, capability-GAT contexts, or type-erased boxes. Of 41 clippy findings, 40 fixed at source (mechanical only — layout/paint/hit-test logic untouched); 1 targeted allow (`BoxConstraintsCacheKey`'s load-bearing `_bits` postfix, `f32::to_bits` images). 524 lib tests + all integration suites incl. the harness catalog green; port-check clean.
- **flui-objects** (the render-object catalog): the 11-lint block cleared — 60 of 68 findings fixed at source (23 `map_unwrap_or`, 13 closure→method-ref, branch swaps, `f32::midpoint` where semantics are provably identical). The 8 surviving allows carry concrete proofs: 7 closures clippy's own suggestion cannot replace (higher-ranked `FnMut` inference failures — demonstrated by `clippy --fix` erroring and rolling back — and `PaintCx::paint_child` E0034 overload ambiguity), plus one match arm kept separate from a `#[non_exhaustive]` forward-compat wildcard. 439 lib + 251 harness-catalog + 12 snapshot tests green.
- **flui-view**: last two crate-level allows burned down (5 manual Debug impls → `finish_non_exhaustive()`, one `usize::from`); redundant local warn lists dropped in favor of workspace lints.
- **flui-animation**: `unwrap_used` opt-out removed — exactly one production site existed, now `expect("BUG: …")` with the invariant argued from `TweenSequence::new`'s non-empty assert.
- **flui-widgets / flui-binding**: already clean; graduated to `deny(missing_docs)`.
- **READMEs** added for flui-rendering, flui-objects, flui-binding (+ manifest `readme` fields).

## Verification

- [x] Full local gate suite green on 1.96.0: fmt-check, taplo, typos, inventory-check, port-check, workspace clippy `-D warnings`, full test suite (lib + integration, `--test-threads=1`), doc-tests, rustdoc `-D warnings`
- [x] Flutter reference checked — no render/layout/paint/hit-test behavior changes; all transforms mechanical, with the harness catalog (251 per-object tests) as the referee
- [x] New or changed behavior has tests — no behavior changes; `deny(missing_docs)` + clean clippy are the regression gates
- [x] Public API changes are documented — no public surface changes

## Architecture

- [x] Layering unchanged
- [x] No new banned patterns — port-check green
- [x] No new dependencies

## Notes

- The subtree_arena unsafe island and the permanent `type_complexity`/`too_many_arguments` relaxations are intentionally untouched (documented as permanent, not debt).
- Program state after this merge: waves 1–3 complete — 17 of 24 crates at `deny(missing_docs)` with zero crate-level lint debt. Wave 4 remains: app/platform/DX cohort, including the two structural items (flui-app singleton state forcing `--test-threads 1`, flui-platform CI blackout + STATUS_HEAP_CORRUPTION investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sjdi8ANg4pYBKDsyZJn9Mt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sjdi8ANg4pYBKDsyZJn9Mt)_