### PR TITLE
Drag-to-scroll for the demo list — Core.1 complete

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,7 +13,7 @@ This roadmap sits on top of [`FOUNDATIONS.md`](FOUNDATIONS.md) — the architect
 | Phase | Status |
 |---|---|
 | Core.0 — spine to spec | ✅ **Complete.** Pipeline phases wired and tested, keyed reconciliation production-wired, contracts locked, gate green. |
-| Core.1 — vertical slice | ◐ Slice widgets, contract validation, the combined demo app + shared-tree acceptance test, the four parity ports, and **frame-time evidence** (60 fps confirmed on a real window, 2026-07-14) are done; only drag-to-scroll remains. |
+| Core.1 — vertical slice | ✅ Slice widgets, contract validation, combined demo app + acceptance tests, parity ports, frame evidence, drag-to-scroll — all delivered. |
 | Core.2 — render-object catalog | ◐ **77 of ~80** objects built with harness tests in `crates/flui-objects`; `RenderAnimatedOpacity`/`RenderSliverAnimatedOpacity` and exit verification remain. |
 | Business.1 — widget catalog | ◐ Every named catalog widget implemented and integration-tested; **fidelity** (ported parity corpus) and named `Hero` gaps remain. |
 | Catalog.1 — Material ∥ Cupertino | ✗ Not started — `flui-material`, `flui-cupertino`, `flui-localizations` do not exist yet. |
@@ -44,7 +44,7 @@ The target is **full parity with released Flutter** — every framework package,
 
 The shape of the work: the machinery and framework catalog are largely landed; the remaining mass is **fidelity** (the ported Flutter test corpus) **and the design-system catalog.** `material` alone (210k LOC) is the terminal node and the single largest body of work in the entire port — roughly twice the rest of the catalog combined.
 
-**The critical path:** close Core.1/Business.1 fidelity residues → `flui-localizations` + theming → `flui-material`. Everything else is a parallel tributary or hangs off the end.
+**The critical path:** close Business.1 fidelity residues → `flui-localizations` + theming → `flui-material`. Everything else is a parallel tributary or hangs off the end.
 
 ---
 
@@ -158,7 +158,7 @@ Each phase states: **Goal**, **Status**, what was **Delivered** (for closed work
 
 ---
 
-## Core.1 — Vertical slice (Core × Business integration)  *(was Phase 1)* — ◐ MOSTLY COMPLETE
+## Core.1 — Vertical slice (Core × Business integration)  *(was Phase 1)* — ✅ COMPLETE
 
 **Goal.** Prove the locked contracts and the full pipeline on live widget code: ~8–12 widgets — one per render-object family — end-to-end, into a running demo app.
 
@@ -166,12 +166,10 @@ Each phase states: **Goal**, **Status**, what was **Delivered** (for closed work
 - **All slice widgets implemented and integration-tested** in `flui-widgets`: `Container`/`Padding`/`Center` (box layout), `Column`/`Row` (flex, generic over children with `Vec<BoxedView>` as the default type parameter — the mandatory dynamic path), `Text` (`RenderParagraph` over the cosmic-text stack), `GestureDetector` (input/hit-testing), `SingleChildScrollView` (viewport/offset), dynamic `ListView` (keyed reconciliation on reorder; `tests/lazy_list.rs`), `AnimatedContainer` + `AnimatedOpacity` (`flui-animation` + the `memoize`/`can_update` short-circuit), and a `StatefulView` counter (C1 `setState`).
 - **Contract-validation report** at [`research/2026-06-30-phase1-contract-validation.md`](research/2026-06-30-phase1-contract-validation.md), listing per contract the test that proved it. C8 (async edges) and C9 (type-erasure boundary) are framework invariants — validated by `port-check.sh` triggers, not per-widget tests.
 - **The parity oracle is live**: `crates/flui-widgets/tests/parity/` (25 files) covers Container, Center, Column/Row, Text, ListView, and the stateful counter.
-- **The combined demo app**, `examples/vertical_slice_demo/` — a stateful counter, a scrollable list, a gesture-responsive "+" button, and an `AnimatedContainer` box, all in one tree — with a shared-tree acceptance test at `tests/vertical_slice_demo.rs` (`#[path]`-includes the example's tree and mounts it headlessly, so the test exercises the exact tree the example runs). The list's scroll offset is driven programmatically in both the example and the test; drag-to-scroll needs `Scrollable` gesture wiring, still open (see Remains).
+- **The combined demo app**, `examples/vertical_slice_demo/` — a stateful counter, a scrollable list, a gesture-responsive "+" button, and an `AnimatedContainer` box, all in one tree — with a shared-tree acceptance test at `tests/vertical_slice_demo.rs` (`#[path]`-includes the example's tree and mounts it headlessly, so the test exercises the exact tree the example runs).
 - **Parity-test ports for the four remaining slice widgets** — `Padding`, `GestureDetector`, `SingleChildScrollView`, and the implicit-animation pair — ported into `tests/parity/` at Flutter tag `3.44.0`. Porting `SingleChildScrollView`'s cases exposed and fixed a missing `reverse` option.
 - **Frame-time evidence for the 60 fps assertion** — measured on a real winit-backed Wayland window (2026-07-14): the demo's implicit animation over a 25 s run shows inter-tick cadence median 16.72 ms / p90 16.78 ms / max 16.81 ms across three post-warmup 300-sample windows — a locked ~59.8 fps with zero dropped ticks. The original "≤ 16 ms median" phrasing conflated the per-frame budget with tick cadence: a steady 60 Hz cadence sits at ~16.7 ms by definition, so the honest criterion — the animation sustains 60 fps on the real frame loop — is met. The loop is wake-driven; true vsync pacing (`ControlFlow::Wait`) remains App.1's exit criterion.
-
-**Remains.**
-- **Drag-to-scroll wiring** for the demo list — `Scrollable` gesture integration; today the list's offset is only driven programmatically.
+- **Drag-to-scroll for the demo list** (2026-07-14): pointer drags over the `ListView` scroll it through `GestureDetector` pan → `ScrollController`, with clamped extents, proven by a red→green drag acceptance test against the shared demo tree. The demo feeds content extents manually — framework-level `Scrollable`↔viewport composition and `ViewportOffset`→`ScrollController` content-dimension feedback are Business.1 work (see below).
 
 **Parity delta.** `widgets` catalog seeded; `animation` exercised end-to-end; the pipeline is proven on live widget code.
 
@@ -206,6 +204,7 @@ Each phase states: **Goal**, **Status**, what was **Delivered** (for closed work
 **Remains.**
 - **Fidelity** — porting the Flutter `_test.dart` corpus for the catalog into `tests/parity/`. This is the bulk of what separates "built" from "at parity."
 - **Named `Hero` gaps** — user-gesture flights and cross-navigator flights, tracked in `ROADMAP-TRACKER.md` B1.4 / ADR-0021.
+- **Scrollable composition + content-dimension feedback** — `Scrollable` currently hardwires `SingleChildScrollView` with no offset feed-through to viewport widgets (`ListView`/`GridView`), and nothing feeds `ViewportOffset` content dimensions back to `ScrollController`, so every consumer must hand-wire extents. The scroll family needs the builder-style composition and the extent feedback loop before the catalog can claim scroll parity.
 - **`flui-assets` ↔ `Image` integration verification** — the crate is an active workspace member; confirm network + asset image and font loading through the `Image` widget end-to-end.
 - Exit criteria to demonstrate: a non-trivial sample app built entirely from `flui-widgets` (no raw render objects) with a scrolling list, gesture button, implicit animation, and navigated route; `flui-widgets` coverage ≥ 85% via `just coverage`.
 
@@ -278,7 +277,7 @@ Bundled into Core.0 because they were cheap-now / catalog-wide-later: the `flui-
 
 ### Cross.H — Foundation hardening
 
-**Goal.** The standing quality discipline — close the remaining systemic defects as the owning crates are next touched: the layer lifecycle protocol (gates App.1), parallel-type collapses, the `BuildContext` inherited-data hole (**gates Catalog.1** — `Theme` depends on it), the `TreeWrite::remove` cascade, Ticker lifecycle, and feature-gating of speculative scaffolding. Focus/tab navigation — originally on this list — has since landed in `flui-widgets` (`Focus`/`FocusScope`/`Actions`/`Shortcuts`, with tests). **Entry:** continuous from Core.0. **Exit:** the foundation is declared stable — all critical-tier defects closed, second-tier addressed opportunistically. This is the audit-and-repair methodology as permanent discipline, not a bounded effort.
+**Goal.** The standing quality discipline — close the remaining systemic defects as the owning crates are next touched: the layer lifecycle protocol (gates App.1), parallel-type collapses, the `BuildContext` inherited-data hole (**gates Catalog.1** — `Theme` depends on it), the `TreeWrite::remove` cascade, Ticker lifecycle, and feature-gating of speculative scaffolding. Focus/tab navigation — originally on this list — has since landed in `flui-widgets` (`Focus`/`FocusScope`/`Actions`/`Shortcuts`, with tests). **Known gap:** gesture settings do not adapt to pointer type — `DragGestureRecognizer` always uses touch slop (18px) even for mouse input, where Flutter differentiates precise-pointer slop (surfaced by Core.1's drag-to-scroll work, 2026-07-14). **Entry:** continuous from Core.0. **Exit:** the foundation is declared stable — all critical-tier defects closed, second-tier addressed opportunistically. This is the audit-and-repair methodology as permanent discipline, not a bounded effort.
 
 ---
 
@@ -286,11 +285,11 @@ Bundled into Core.0 because they were cheap-now / catalog-wide-later: the `flui-
 
 ```
 MAIN VERTICAL (sequential — Core → Business → Catalog → App):
-  Core.0 ✅ ── Core.1 ◐ ── Core.2 ◐ ── Business.1 ◐ ── Catalog.1 ✗ ── App.1 ◐
-              (slice:      (77/~80      (built;        (Material ∥     (partial:
-               demo app     objects;     fidelity +     Cupertino —     vsync, IME,
-               + parity     2 named      Hero gaps)     not started)    facade left)
-               ports left)  gaps)
+  Core.0 ✅ ── Core.1 ✅ ── Core.2 ◐ ── Business.1 ◐ ── Catalog.1 ✗ ── App.1 ◐
+                            (77/~80      (built;        (Material ∥     (partial:
+                             objects;     fidelity +     Cupertino —     vsync, IME,
+                             2 named      Hero gaps)     not started)    facade left)
+                             gaps)
 
 CROSS layer — continuous, with cross-track gates marked:
   Cross.P (platform)  ═════════════════════════════════════► joins App.1

--- a/examples/vertical_slice_demo/tree.rs
+++ b/examples/vertical_slice_demo/tree.rs
@@ -13,9 +13,32 @@
 //! builds a `Column` of:
 //! - a counter row: `Text` showing the count, plus a `GestureDetector` "+"
 //!   button that increments it;
-//! - a fixed-height `ListView` with enough rows to overflow its box;
+//! - a fixed-height, drag-to-scroll `ListView` with enough rows to overflow
+//!   its box;
 //! - a `GestureDetector`-wrapped `AnimatedContainer` that toggles its
 //!   width/height/color between a collapsed and an expanded target.
+//!
+//! # Drag-to-scroll wiring (demo-local, not `Scrollable`)
+//!
+//! The list is wrapped in a plain `GestureDetector` feeding a
+//! `ScrollController` directly, deliberately NOT the `Scrollable` widget:
+//! `Scrollable` hardwires a `SingleChildScrollView` as its layout/paint host
+//! with no offset feed-through to an arbitrary scrollable child
+//! (`scrollable.rs`), so nesting this `ListView` inside it would produce a
+//! degenerate viewport. Making `Scrollable` accept an arbitrary scrollable
+//! child is a framework-level fix, out of scope here (tracked as a Business.1
+//! item).
+//!
+//! Nothing in the framework yet propagates a `Viewport`'s committed
+//! content/viewport extents back to a `ScrollController`
+//! (`ViewportOffset` → `ScrollController` feedback is the same Business.1
+//! item), so [`DemoRootState::create_state`] feeds `update_dimensions` the
+//! same fixed constants the tree renders with, once, up front.
+//!
+//! Drag-only: there is no fling/ballistic simulation. The pan gesture's
+//! release velocity (`on_pan_end`) is intentionally left unwired — hand-
+//! rolling ballistics in the demo was ruled out, and a real fling belongs to
+//! the same Business.1 item.
 
 use std::cell::Cell;
 use std::rc::Rc;
@@ -54,19 +77,26 @@ const BACKGROUND_COLOR: Color = Color::rgb(18, 18, 24);
 /// The vertical-slice demo root.
 ///
 /// `count`/`expanded`/`scroll_offset` are `Rc<Cell<_>>` so a caller (the
-/// acceptance test) can keep a clone from before mounting: the counter and
-/// the animated box are driven the same way the running example drives them
-/// — by dispatching a pointer tap through the mounted `GestureDetector`s —
-/// but the list here has no drag-to-scroll gesture wired yet, so its offset
-/// is driven by mutating `scroll_offset` directly and forcing a rebuild
-/// (documented, honest fallback; see the acceptance test).
+/// acceptance test) can keep a clone from before mounting. All three are
+/// driven the same way the running example drives them — by dispatching
+/// synthetic pointer gestures through the mounted `GestureDetector`s: taps
+/// for the counter and the animated box, a drag for the list. `scroll_offset`
+/// is kept in sync with [`DemoRootState`]'s internal `ScrollController` by
+/// the drag's `on_pan_update` callback (see the module doc's drag-to-scroll
+/// wiring section above) — `ListView::offset` only accepts a plain `f32`, so
+/// the cell is still the value it reads each build.
 #[derive(Clone, StatefulView)]
 pub struct DemoRoot {
     /// Tap count, shown by the counter row and incremented by its "+" button.
     pub count: Rc<Cell<i32>>,
     /// Whether the animated box currently targets its expanded size/color.
     pub expanded: Rc<Cell<bool>>,
-    /// The list's programmatic scroll offset, in logical pixels.
+    /// The list's scroll offset, in logical pixels — driven by the drag
+    /// gesture wired in [`DemoRootState::build`], and read by `ListView`'s
+    /// `.offset(...)` each build. Also the seed value
+    /// [`DemoRootState::create_state`] jump-starts the internal
+    /// `ScrollController` from, so constructing a `DemoRoot` with a nonzero
+    /// offset does not snap back to zero on the first drag.
     pub scroll_offset: Rc<Cell<f32>>,
 }
 
@@ -97,6 +127,11 @@ pub struct DemoRootState {
     count: Rc<Cell<i32>>,
     expanded: Rc<Cell<bool>>,
     scroll_offset: Rc<Cell<f32>>,
+    /// The list's drag position, clamped to `[0, max_scroll_extent]` by
+    /// `jump_to`. Owned by the state (not `DemoRoot`) because it is pure
+    /// wiring, not app-visible data — `scroll_offset` above is what `build`
+    /// actually reads.
+    scroll_controller: ScrollController,
     /// `None` only before `init_state` has run; every `build` call happens
     /// after it (`ViewState` lifecycle order), so it is always `Some` there.
     rebuild: Option<RebuildHandle>,
@@ -106,10 +141,26 @@ impl StatefulView for DemoRoot {
     type State = DemoRootState;
 
     fn create_state(&self) -> Self::State {
+        let scroll_controller = ScrollController::new();
+        // Manual extent feed (see the module doc's Drag-to-scroll wiring
+        // section): these are the same fixed constants `build` renders the
+        // list with, so computing them once here — rather than from a real
+        // `Viewport` layout callback, which doesn't exist yet — is exact, not
+        // an approximation.
+        let max_scroll_extent =
+            (LIST_ITEM_EXTENT * LIST_ITEM_COUNT as f32 - LIST_BOX_HEIGHT).max(0.0);
+        scroll_controller.update_dimensions(LIST_BOX_HEIGHT, 0.0, max_scroll_extent);
+        // Seed from the pub cell (clamped through the extents just set) so a
+        // `DemoRoot` constructed with a nonzero `scroll_offset` doesn't snap
+        // back to 0 on the first drag — `jump_to` is the same clamp path the
+        // drag callback below uses.
+        scroll_controller.jump_to(self.scroll_offset.get());
+
         DemoRootState {
             count: Rc::clone(&self.count),
             expanded: Rc::clone(&self.expanded),
             scroll_offset: Rc::clone(&self.scroll_offset),
+            scroll_controller,
             rebuild: None,
         }
     }
@@ -153,21 +204,43 @@ impl ViewState<DemoRoot> for DemoRootState {
                 ),
         ]);
 
-        // -- fixed-height scrollable list --------------------------------------
-        let list_area = SizedBox::height(LIST_BOX_HEIGHT).child(
-            ListView::new(
-                LIST_ITEM_EXTENT,
-                (0..LIST_ITEM_COUNT)
-                    .map(|index| {
-                        Container::new()
-                            .padding(EdgeInsets::all(px(4.0)))
-                            .child(Text::new(format!("Item {index}")))
-                            .boxed()
-                    })
-                    .collect::<Vec<_>>(),
-            )
-            .offset(scroll_offset),
-        );
+        // -- fixed-height, drag-to-scroll list ---------------------------------
+        let scroll_offset_for_drag = Rc::clone(&self.scroll_offset);
+        let scroll_controller_for_drag = self.scroll_controller.clone();
+        let rebuild_for_drag = rebuild.clone();
+        let list_area = GestureDetector::new()
+            // Opaque: the drag must fire from anywhere in the list's box, not
+            // only where a hit-testable descendant (an item's `Text`/padding)
+            // happens to sit — same reasoning as the "+" button above.
+            .behavior(HitTestBehavior::Opaque)
+            .on_pan_update(move |details: DragUpdateDetails| {
+                // Flutter convention (matches `Scrollable`'s own pan-update
+                // wiring in `scrollable.rs`): a downward finger drag (positive
+                // delta on the scroll axis) moves the viewport toward the
+                // START of the content, so the offset DECREASES; dragging up
+                // increases it. `jump_to` clamps to the extents fed in
+                // `create_state` (see the module doc).
+                let proposed = scroll_controller_for_drag.pixels() - details.delta.dy.get();
+                scroll_controller_for_drag.jump_to(proposed);
+                scroll_offset_for_drag.set(scroll_controller_for_drag.pixels());
+                rebuild_for_drag.schedule();
+            })
+            .child(
+                SizedBox::height(LIST_BOX_HEIGHT).child(
+                    ListView::new(
+                        LIST_ITEM_EXTENT,
+                        (0..LIST_ITEM_COUNT)
+                            .map(|index| {
+                                Container::new()
+                                    .padding(EdgeInsets::all(px(4.0)))
+                                    .child(Text::new(format!("Item {index}")))
+                                    .boxed()
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                    .offset(scroll_offset),
+                ),
+            );
 
         // -- animated box: tap toggles expanded, AnimatedContainer eases to it -
         let expanded_for_tap = Rc::clone(&self.expanded);

--- a/tests/vertical_slice_demo.rs
+++ b/tests/vertical_slice_demo.rs
@@ -14,27 +14,30 @@
 //! `PipelineOwner` -> set root constraints -> run one frame -> `bind_tree`).
 //!
 //! Honesty notes (Definition of Done):
-//! - The counter and animated-box assertions are fully gesture-driven
-//!   (synthetic pointer taps through the mounted tree) — the same path a
-//!   real user would exercise.
-//! - `ListView` (the widget this demo composes) has no drag-to-scroll
-//!   gesture wired in `flui-widgets` yet — it is a `Viewport` over a sliver
-//!   with a purely programmatic `offset`. Dragging
-//!   through it fires no scroll. The scroll assertion therefore falls back
-//!   to the documented alternative: mutate `DemoRoot::scroll_offset`
-//!   directly and force a rebuild, then assert the resulting layout
-//!   (paint offset) actually moved — still a real behavioral assertion on
-//!   the render tree, not a tautology, just not drag-driven.
+//! - All three acceptance assertions (counter, drag-to-scroll, animated box)
+//!   are fully gesture-driven (synthetic pointer down/move/up through the
+//!   mounted tree) — the same path a real user's fingers would exercise.
+//! - The list's drag-to-scroll is demo-local wiring: a `GestureDetector`
+//!   feeding a `ScrollController` directly, NOT the `Scrollable` widget.
+//!   `Scrollable` hardwires a `SingleChildScrollView` with no offset
+//!   feed-through (`scrollable.rs`), and nesting `ListView` inside it would
+//!   produce a degenerate viewport — the framework-level fix (a `Scrollable`
+//!   that accepts an arbitrary scrollable child) is out of scope here; see
+//!   `tree.rs`'s module doc.
+//! - Drag-only: there is no fling/ballistic simulation. `on_pan_end`'s
+//!   release velocity is intentionally unused — hand-rolling ballistics in
+//!   the demo was ruled out; a real fling awaits the same framework-level
+//!   item.
 
 #[path = "../examples/vertical_slice_demo/tree.rs"]
 mod tree;
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use flui_binding::HeadlessBinding;
-use flui_foundation::{ElementId, RenderId};
-use flui_interaction::events::{PointerType, make_down_event, make_up_event};
+use flui_foundation::RenderId;
+use flui_interaction::events::{PointerType, make_down_event, make_move_event, make_up_event};
 use flui_rendering::constraints::BoxConstraints;
 use flui_rendering::hit_testing::HitTestResult;
 use flui_rendering::pipeline::PipelineOwner;
@@ -56,12 +59,6 @@ fn root_constraints() -> BoxConstraints {
 /// Everything the test needs to drive and inspect the mounted demo tree.
 struct MountedDemo {
     binding: HeadlessBinding,
-    /// The `Rc<Cell<_>>` handles from the exact `DemoRoot` that was mounted
-    /// (cloned before it was wrapped and moved into the tree), so the test
-    /// can read/mutate the same cells `DemoRootState::build` reads.
-    handles: tree::DemoRoot,
-    /// The tree's mounted root element (the outermost `VsyncScope`).
-    root_element: ElementId,
     pipeline_owner: Arc<RwLock<PipelineOwner>>,
 }
 
@@ -79,7 +76,6 @@ impl MountedDemo {
         let mut binding = HeadlessBinding::new();
 
         let root_view = tree::demo_root();
-        let handles = root_view.clone();
 
         let mut build_owner = BuildOwner::new();
         let mut tree = ElementTree::new();
@@ -93,7 +89,7 @@ impl MountedDemo {
 
         let scoped_root = VsyncScope::new(binding.vsync().clone(), root_view);
 
-        let root_element = binding.enter_owner_scope(|| {
+        binding.enter_owner_scope(|| {
             let root_element = tree.mount_root_with_pipeline_owner(
                 &scoped_root,
                 Some(Arc::clone(&pipeline_owner)),
@@ -101,7 +97,6 @@ impl MountedDemo {
             );
             build_owner.schedule_build_for(root_element, 0);
             build_owner.build_scope(&mut tree);
-            root_element
         });
 
         let root_render_id = {
@@ -137,8 +132,6 @@ impl MountedDemo {
 
         Self {
             binding,
-            handles,
-            root_element,
             pipeline_owner,
         }
     }
@@ -146,19 +139,6 @@ impl MountedDemo {
     /// Drive one deterministic frame.
     fn pump(&mut self, dt: Duration) {
         self.binding.pump_frame(dt);
-    }
-
-    /// Force the root element to rebuild on the next [`pump`](Self::pump) —
-    /// the headless equivalent of an external `setState`. Used only for the
-    /// list's scroll offset, which (unlike the counter/animated box) has no
-    /// gesture path scheduling its own rebuild.
-    fn mark_root_dirty(&mut self) {
-        if let Some(node) = self.binding.tree_mut().get_mut(self.root_element) {
-            node.element_mut().mark_needs_build();
-        }
-        self.binding
-            .build_owner_mut()
-            .schedule_build_for(self.root_element, 0);
     }
 
     /// Hit-test at root-local `(x, y)` and dispatch a synthetic pointer-down.
@@ -185,6 +165,31 @@ impl MountedDemo {
     fn tap(&self, x: f32, y: f32) {
         self.tap_down(x, y);
         self.tap_up(x, y);
+    }
+
+    /// Hit-test at root-local `(x, y)` and dispatch a synthetic pointer-down,
+    /// advancing the gesture clock first so the drag recognizer's first
+    /// velocity-tracker sample gets a fresh timestamp (see
+    /// [`advance_gesture_clock`]). Distinct from [`tap_down`](Self::tap_down):
+    /// only drag sequences need the clock advance, and `tap_down` is shared by
+    /// unrelated tests this change must not perturb.
+    fn drag_down(&self, x: f32, y: f32) {
+        advance_gesture_clock();
+        self.dispatch_at(make_down_event(offset(x, y), PointerType::Mouse), x, y);
+    }
+
+    /// Hit-test at root-local `(x, y)` and dispatch a synthetic pointer-move,
+    /// advancing the gesture clock first (see [`advance_gesture_clock`]).
+    fn drag_move(&self, x: f32, y: f32) {
+        advance_gesture_clock();
+        self.dispatch_at(make_move_event(offset(x, y), PointerType::Mouse), x, y);
+    }
+
+    /// Hit-test at root-local `(x, y)` and dispatch a synthetic pointer-up —
+    /// pairs with [`drag_down`](Self::drag_down)/[`drag_move`](Self::drag_move)
+    /// to complete a drag gesture.
+    fn drag_up(&self, x: f32, y: f32) {
+        self.dispatch_at(make_up_event(offset(x, y), PointerType::Mouse), x, y);
     }
 
     fn find_all_by_render_type(&self, render_type_name: &str) -> Vec<RenderId> {
@@ -261,6 +266,55 @@ impl MountedDemo {
         }
     }
 
+    /// The list's fixed-height `SizedBox` wrapper.
+    ///
+    /// Same disambiguation problem as [`animated_box_render_id`]'s doc
+    /// explains: several `RenderConstrainedBox` nodes exist in this tree.
+    /// This one is the unique node whose committed height equals
+    /// [`tree::LIST_BOX_HEIGHT`] (200px) — distinct by construction from the
+    /// counter spacer and the animated box's collapsed/expanded height range
+    /// (64/140px).
+    ///
+    /// # Panics
+    /// Panics when zero or more than one candidate matches.
+    fn list_box_render_id(&self) -> RenderId {
+        let owner = self.pipeline_owner.read();
+        let matches: Vec<RenderId> = self
+            .find_all_by_render_type("RenderConstrainedBox")
+            .into_iter()
+            .filter(|&id| {
+                inspect::box_geometry(&owner, id)
+                    .is_some_and(|size| (size.height.get() - tree::LIST_BOX_HEIGHT).abs() < 1.0)
+            })
+            .collect();
+        match matches.as_slice() {
+            [id] => *id,
+            [] => panic!(
+                "no RenderConstrainedBox matches the list box height ({})",
+                tree::LIST_BOX_HEIGHT
+            ),
+            _ => panic!(
+                "{} RenderConstrainedBox nodes match the list box height; expected exactly one",
+                matches.len()
+            ),
+        }
+    }
+
+    /// The list box's root-local center — a safe drag anchor: enough headroom
+    /// above and below to cross the slop and keep moving without the pointer
+    /// leaving the box (which would hit-test a different render path on the
+    /// next move).
+    fn list_box_center(&self) -> (f32, f32) {
+        let list_box = self.list_box_render_id();
+        let size = inspect::box_geometry(&self.pipeline_owner.read(), list_box)
+            .expect("the list box must have box geometry after the bootstrap frame");
+        let top_left = self.absolute_position(list_box);
+        (
+            top_left.dx.get() + size.width.get() / 2.0,
+            top_left.dy.get() + size.height.get() / 2.0,
+        )
+    }
+
     /// The screen-space (root-local) top-left of `id`, by summing paint
     /// offsets up the render-tree ancestry — every node between the root and
     /// `id` in this tree only translates (no scale/rotation), so a plain sum
@@ -287,6 +341,26 @@ impl MountedDemo {
 
 fn offset(x: f32, y: f32) -> Offset {
     Offset::new(px(x), px(y))
+}
+
+/// Spin until `Instant::now()` returns a value strictly greater than the one
+/// returned by the immediately preceding call.
+///
+/// Mirrors `flui-widgets/tests/common/mod.rs`'s
+/// `LaidOutScoped::advance_gesture_clock` (unreachable from this crate — that
+/// harness lives in a private integration-test module of a different crate,
+/// same reason `MountedDemo` re-bootstraps its own mount sequence instead of
+/// reusing it). `DragGestureRecognizer::handle_move` timestamps every
+/// velocity-tracker sample with `Instant::now()`; two dispatches landing in
+/// the same OS timer tick make the least-squares velocity fit singular
+/// (NaN). Calling this before each down/move dispatch that should count
+/// toward velocity guarantees consecutive samples get strictly increasing
+/// timestamps.
+fn advance_gesture_clock() {
+    let t0 = Instant::now();
+    while Instant::now() == t0 {
+        std::hint::spin_loop();
+    }
 }
 
 // ============================================================================
@@ -333,42 +407,102 @@ fn tapping_the_plus_button_updates_the_rendered_counter_text() {
 }
 
 // ============================================================================
-// (b) scrolling changes visible content — programmatic-offset fallback
+// (b) dragging inside the list box scrolls it — real gesture-driven, no
+//     programmatic fallback
 // ============================================================================
 
+/// Real per-move drag threshold for `GestureDetector`'s pan recognizer
+/// (`DragAxis::Free`).
+///
+/// `GestureDetector` constructs its `DragGestureRecognizer` once in
+/// `init_state` with `GestureSettings::default()`
+/// (`flui-interaction/src/recognizers/drag.rs`) and never adapts it to the
+/// dispatched pointer's device kind — so the operative slop is the *touch*
+/// default (`DEFAULT_PAN_SLOP` = 18px), not the mouse default, even though
+/// these events dispatch as `PointerType::Mouse`. This matches the identical
+/// "50 px > 18 px" comment on `flui-widgets/tests/scroll.rs`'s
+/// `scrollable_drag_up_increases_scroll_offset`, which exercises the same
+/// recognizer through `Scrollable`.
+const DRAG_SLOP: f32 = 18.0;
+
 #[test]
-fn changing_the_list_scroll_offset_moves_its_items() {
+fn dragging_inside_the_list_box_scrolls_its_items() {
     let mut demo = MountedDemo::mount();
 
     let item0 = demo
         .find_text("Item 0")
         .expect("the static list must render its first item");
     let offset_before = demo.absolute_position(item0);
+    let (anchor_x, anchor_y) = demo.list_box_center();
 
-    // `ListView` (this composition) has no drag-to-scroll gesture wired in
-    // flui-widgets yet — it is a `Viewport` over a sliver with a purely
-    // programmatic `offset`, no `Scrollable` ancestor. A pointer drag
-    // through the list area would therefore fire no scroll at all, so this
-    // asserts the documented fallback instead: mutate the shared offset cell
-    // directly and force a rebuild, then check the resulting layout moved.
-    let scroll_delta = 3.0 * tree::LIST_ITEM_EXTENT;
-    demo.handles.scroll_offset.set(scroll_delta);
-    demo.mark_root_dirty();
+    // The slop-crossing move (> DRAG_SLOP) fires on_pan_start; per
+    // `DragGestureRecognizer::handle_move`, that move's own delta is
+    // swallowed (used only to fix the drag's start position), so it must not
+    // count toward the expected scroll delta. Only the two subsequent moves,
+    // each already in the `Started` phase, fire on_pan_update.
+    const SLOP_CROSSING_DELTA: f32 = DRAG_SLOP + 7.0; // 25.0, safely > 18.0
+    const UPDATE_DELTA_1: f32 = 20.0;
+    const UPDATE_DELTA_2: f32 = 25.0;
+    let expected_scroll_delta = UPDATE_DELTA_1 + UPDATE_DELTA_2;
+
+    demo.drag_down(anchor_x, anchor_y);
+    demo.drag_move(anchor_x, anchor_y - SLOP_CROSSING_DELTA);
+    demo.drag_move(anchor_x, anchor_y - SLOP_CROSSING_DELTA - UPDATE_DELTA_1);
+    demo.drag_move(
+        anchor_x,
+        anchor_y - SLOP_CROSSING_DELTA - UPDATE_DELTA_1 - UPDATE_DELTA_2,
+    );
+    demo.drag_up(
+        anchor_x,
+        anchor_y - SLOP_CROSSING_DELTA - UPDATE_DELTA_1 - UPDATE_DELTA_2,
+    );
+    demo.pump(Duration::ZERO);
+
+    let offset_after = demo.absolute_position(item0);
+    // A `Viewport` translates its sliver content by `-offset` along the
+    // scroll axis, so an increasing offset must move content UP (a smaller
+    // `dy`) — the standard scroll convention, matching `Scrollable`'s own
+    // pan-update wiring in `scrollable.rs`.
+    let moved_up_by = offset_before.dy.get() - offset_after.dy.get();
+
+    assert!(
+        (moved_up_by - expected_scroll_delta).abs() < 1.0,
+        "dragging up {expected_scroll_delta}px worth of post-slop deltas must move item 0's \
+         paint position up by the same amount (the slop-crossing move's delta is swallowed): \
+         before={offset_before:?}, after={offset_after:?}, moved_up_by={moved_up_by}"
+    );
+}
+
+/// At the top of the list (offset 0, the fresh-mount default) a downward drag
+/// proposes a *negative* pixel value (`pixels() - delta.dy` with `delta.dy >
+/// 0`) — `ScrollController::jump_to`'s lower clamp must hold it at 0 through
+/// the real gesture path, not just in `scroll_controller.rs`'s unit tests.
+#[test]
+fn dragging_down_at_the_top_of_the_list_does_not_scroll_past_zero() {
+    let mut demo = MountedDemo::mount();
+
+    let item0 = demo
+        .find_text("Item 0")
+        .expect("the static list must render its first item");
+    let offset_before = demo.absolute_position(item0);
+    let (anchor_x, anchor_y) = demo.list_box_center();
+
+    // Post-slop deltas toward positive dy (finger moving down) — the mirror
+    // image of the upward drag above.
+    const SLOP_CROSSING_DELTA: f32 = DRAG_SLOP + 7.0; // 25.0, safely > 18.0
+    const UPDATE_DELTA: f32 = 20.0;
+
+    demo.drag_down(anchor_x, anchor_y);
+    demo.drag_move(anchor_x, anchor_y + SLOP_CROSSING_DELTA);
+    demo.drag_move(anchor_x, anchor_y + SLOP_CROSSING_DELTA + UPDATE_DELTA);
+    demo.drag_up(anchor_x, anchor_y + SLOP_CROSSING_DELTA + UPDATE_DELTA);
     demo.pump(Duration::ZERO);
 
     let offset_after = demo.absolute_position(item0);
     assert!(
-        (offset_after.dy.get() - offset_before.dy.get()).abs() > 1.0,
-        "changing the list's scroll offset must move its items' paint \
-         position: before={offset_before:?}, after={offset_after:?}"
-    );
-    // A `Viewport` translates its sliver content by `-offset` along the
-    // scroll axis: increasing the offset must move content UP (a smaller
-    // or more negative `dy`), matching the standard scroll convention.
-    assert!(
-        offset_after.dy.get() < offset_before.dy.get(),
-        "increasing the scroll offset must move item 0 upward: \
-         before={offset_before:?}, after={offset_after:?}"
+        (offset_after.dy.get() - offset_before.dy.get()).abs() < 1.0,
+        "dragging down at the top of the list (offset already 0) must not move item 0 at all — \
+         jump_to's lower clamp must hold: before={offset_before:?}, after={offset_after:?}"
     );
 }
 


### PR DESCRIPTION
## What this delivers

The last Core.1 residue: pointer drags over the vertical-slice demo's `ListView` now scroll it. **Core.1 flips to ✅ COMPLETE** in the roadmap.

**Wiring (demo-local, by adversarially-reviewed decision).** `GestureDetector` pan → `ScrollController` (`jump_to` clamps both ends; extents fed once from the list's own constants) → `ListView.offset` through the tree's rebuild path, mirroring the framework `Scrollable`'s pan-update convention with source citations at each mirrored line. `Scrollable` itself was deliberately **not** used: review proved it hardwires `SingleChildScrollView` with no offset feed-through to viewport widgets, and nothing in the framework feeds `ViewportOffset` content dimensions back to `ScrollController` — wrapping would have produced a degenerate viewport with drags clamped to zero. That framework work is now a **named Business.1 item** instead of an API grown ad-hoc under this change.

**Tests (genuine red→green).** The drag acceptance test drives a real gesture through the headless harness — down, slop-crossing move (whose delta the recognizer swallows, accounted for exactly), post-slop moves with strictly increasing timestamps, up — and asserts committed paint moved by the sum of post-crossing deltas within 1 px. Shown failing against the unwired tree (`moved_up_by=0`) before the wiring landed. A sibling test pins the lower clamp (drag down at offset 0 → no movement). The programmatic-offset fallback test and its honesty documentation are removed with the fallback.

## Evidence

- Acceptance: 5/5 (`flui::vertical_slice_demo`, incl. both drag tests) · `flui-widgets` full crate 890/890 · clippy `-D warnings`, fmt, port-check (22 triggers) green · example builds · live windowed smoke on Wayland (opens, renders, full 8 s, no panic).
- Review trail: scout's "Scrollable is production-ready, 10 lines" claim was adversarially refuted before code (no consumers exist; extents never fed); the maintainer review verified the delta/slop/clamp math against sources and returned COMPLETE (merge); its two demo-local polish findings (controller seeding from the initial-offset cell, lower-clamp test) are folded in.

## Also surfaced (recorded in the roadmap, not fixed here)

- `Scrollable` composition + content-dimension feedback — Business.1 scroll family.
- Gesture settings never adapt to pointer type (drag slop is always the 18 px touch value, even for mouse; Flutter differentiates precise-pointer slop) — known parity gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)