### PR TITLE
Core.2 complete: animated-opacity pair, scrolling lazy-sliver proof, coverage verified

### DIFF
--- a/crates/flui-objects/src/lib.rs
+++ b/crates/flui-objects/src/lib.rs
@@ -58,11 +58,11 @@ pub use layout::{
 
 // --- flat re-exports (proxy) ---
 pub use proxy::{
-    ClipGeometry, DecorationPosition, Oval, RenderBackdropFilter, RenderClip, RenderClipOval,
-    RenderClipPath, RenderClipRRect, RenderClipRect, RenderColoredBox, RenderCustomPaint,
-    RenderDecoratedBox, RenderFollowerLayer, RenderLeaderLayer, RenderOpacity, RenderPhysicalModel,
-    RenderPhysicalShape, RenderRepaintBoundary, RenderSemanticsAnnotations, RenderShaderMask,
-    RenderSubtreeAnchor, SubtreeAnchor,
+    ClipGeometry, DecorationPosition, Oval, RenderAnimatedOpacity, RenderBackdropFilter,
+    RenderClip, RenderClipOval, RenderClipPath, RenderClipRRect, RenderClipRect, RenderColoredBox,
+    RenderCustomPaint, RenderDecoratedBox, RenderFollowerLayer, RenderLeaderLayer, RenderOpacity,
+    RenderPhysicalModel, RenderPhysicalShape, RenderRepaintBoundary, RenderSemanticsAnnotations,
+    RenderShaderMask, RenderSubtreeAnchor, SubtreeAnchor,
 };
 pub use proxy::{RenderExcludeSemantics, RenderMergeSemantics};
 
@@ -81,7 +81,7 @@ pub use image::{ImageAlignment, ImageFit, RenderImage};
 // --- flat re-exports (sliver) ---
 pub use sliver::{
     FloatingHeaderSnapConfiguration, OverScrollHeaderStretchConfiguration,
-    RenderShrinkWrappingViewport, RenderSliverFillRemaining,
+    RenderShrinkWrappingViewport, RenderSliverAnimatedOpacity, RenderSliverFillRemaining,
     RenderSliverFillRemainingAndOverscroll, RenderSliverFillRemainingWithScrollable,
     RenderSliverFillViewport, RenderSliverFixedExtentList, RenderSliverFloatingPersistentHeader,
     RenderSliverFloatingPinnedPersistentHeader, RenderSliverGrid, RenderSliverGridLazy,

--- a/crates/flui-objects/src/proxy/animated_opacity.rs
+++ b/crates/flui-objects/src/proxy/animated_opacity.rs
@@ -169,7 +169,7 @@ impl RenderAnimatedOpacity {
     /// The cache commits (`alpha.store`) only after every mark this
     /// recompute owes has been sent successfully — never before. `handle`'s
     /// send can fail under backpressure or once the pipeline owner is gone
-    /// ([`SendError`]); committing first would make that failure invisible,
+    /// (`SendError`); committing first would make that failure invisible,
     /// since the next tick would then compare its new value against an
     /// already-updated cache and see no change, permanently losing the mark
     /// for whatever the animation settles on. Leaving the cache at

--- a/crates/flui-objects/src/proxy/animated_opacity.rs
+++ b/crates/flui-objects/src/proxy/animated_opacity.rs
@@ -1,0 +1,549 @@
+//! `RenderAnimatedOpacity` — applies a continuously-animated transparency to
+//! a single child, driven by an injected [`AnimationController`].
+//!
+//! # Flutter equivalence
+//!
+//! Behavior-faithful port of Flutter's `RenderAnimatedOpacityMixin` +
+//! `RenderAnimatedOpacity` (`packages/flutter/lib/src/rendering/proxy_box.dart`,
+//! tag `3.44.0`). The oracle's mixin caches an `_alpha`, recomputes it on
+//! every `opacity` animation tick via a listener registered in `attach`
+//! (and once more, unconditionally, right after registering — "in case it
+//! changed while we weren't listening"), and on each recompute: marks
+//! needs-paint whenever the alpha value changed, and additionally marks
+//! needs-compositing-bits whenever the recompute crosses the
+//! `_alpha > 0` repaint-boundary threshold (`isRepaintBoundary` flips).
+//!
+//! # Documented divergence — no composited-layer update
+//!
+//! Flutter's mixin is a `isRepaintBoundary` node: on a tick it calls
+//! `updateCompositedLayer`, which mutates the *retained* `OpacityLayer`'s
+//! alpha in place, so a tick never repaints the child subtree — only the
+//! compositor re-blends the cached layer. FLUI has no composited-layer-update
+//! machinery (no `updateCompositedLayer`/`markNeedsCompositedLayerUpdate`
+//! equivalent anywhere in `flui-rendering`/`flui-objects`), so this port
+//! instead marks the node dirty for a real repaint whenever the effective
+//! alpha changes, exactly like `layout::animated_size` documents its own
+//! divergence at `layout/animated_size.rs:452-457`. The
+//! retained-layer alpha update is Flutter's efficiency path, not yet built
+//! here; a tick costs a full repaint of the subtree instead of a blend-only
+//! update.
+//!
+//! # Zero-consumer honesty
+//!
+//! The `AnimatedOpacity` widget (`flui-widgets/src/animated/animated_opacity.rs`)
+//! still drives its `Opacity` child through an `AnimatedBuilder` rebuild loop,
+//! not through this render object. Wiring the widget to a persistent
+//! render-view wrapper around `RenderAnimatedOpacity` — the pattern
+//! `AnimatedSizeRenderView` establishes at
+//! `flui-widgets/src/animated/animated_size.rs:239-272` — is a deliberately
+//! deferred follow-up, not part of this unit.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use flui_tree::Single;
+use flui_types::{Offset, Size};
+
+use flui_animation::curve::ArcCurve;
+use flui_animation::{Animation, AnimationController, CurvedAnimation};
+use flui_foundation::{Listenable, ListenerId};
+
+use flui_rendering::{
+    context::{BoxHitTestContext, BoxLayoutContext},
+    parent_data::BoxParentData,
+    pipeline::RepaintHandle,
+    traits::RenderBox,
+};
+
+/// A render object that applies a continuously-animated transparency to its
+/// child.
+///
+/// Unlike [`RenderOpacity`](crate::RenderOpacity), the alpha is not set
+/// directly — it tracks an injected [`AnimationController`] (optionally
+/// eased through a [`Curve`](flui_animation::curve::Curve)) and updates
+/// itself on every animation tick via a listener registered in
+/// [`attach`](RenderBox::attach). See the module docs for the exact
+/// dirty-marking rule ported from Flutter's `RenderAnimatedOpacityMixin`.
+///
+/// # Performance
+///
+/// See the module docs' *documented divergence* section: every alpha change
+/// costs a full repaint of the subtree (FLUI has no retained-layer
+/// alpha-blend update yet), not just a compositor re-blend.
+pub struct RenderAnimatedOpacity {
+    /// The controller driving [`animation`](Self::animation). Kept alive
+    /// (and listened to in `attach`) as the sole source of opacity change —
+    /// constructor-injected only, matching
+    /// [`RenderAnimatedSize`](crate::RenderAnimatedSize)'s shape;
+    /// there is no setter to swap it post-construction, so Flutter's
+    /// `didUpdateAnimation` equivalent (`set opacity` on a live mixin) is
+    /// unreachable here by construction.
+    controller: AnimationController,
+    /// The eased view of `controller`'s value in `[0.0, 1.0]`.
+    animation: CurvedAnimation<ArcCurve>,
+    /// Alpha cache (`0..=255`), shared with the tick listener closure via
+    /// `Arc` so both the listener (running off the owning thread, per
+    /// [`RepaintHandle`]'s cross-thread contract) and `paint_alpha`/
+    /// `skip_paint` (called with `&self` from the pipeline's paint walk)
+    /// observe the same up-to-date value. `AtomicU8` over `Mutex<u8>`: a
+    /// single-byte cache with no compound invariant needs no lock.
+    /// `Ordering::Relaxed` suffices because the dirty-channel send in
+    /// [`recompute_alpha`](Self::recompute_alpha) — not the atomic op — is
+    /// the synchronization edge: `alpha` is only stored *after* the mark
+    /// send succeeds, so the paint walk that observes the mark is
+    /// guaranteed to run after the store that produced it, via the
+    /// channel's own happens-before, independent of atomic memory order.
+    alpha: Arc<AtomicU8>,
+    /// Whether child semantics are included regardless of alpha (Flutter
+    /// parity: `alwaysIncludeSemantics`). Stored for diagnostics/API parity;
+    /// this port does not yet gate `visitChildrenForSemantics` on it (no
+    /// semantics-tree visitor override exists on this proxy today).
+    always_include_semantics: bool,
+    /// Tick-listener subscription on `controller`, torn down in `detach`.
+    listener_id: Option<ListenerId>,
+}
+
+impl RenderAnimatedOpacity {
+    /// Creates a render object driven by an **already-built** `controller`
+    /// (this object never constructs a controller and never sees a
+    /// `Vsync`/`Scheduler` — the owning view builds and registers the
+    /// controller and passes it in here, matching
+    /// [`RenderAnimatedSize::new`](crate::RenderAnimatedSize::new)).
+    #[must_use]
+    pub fn new(
+        controller: AnimationController,
+        curve: ArcCurve,
+        always_include_semantics: bool,
+    ) -> Self {
+        let parent: Arc<dyn Animation<f32>> = Arc::new(controller.clone());
+        let animation = CurvedAnimation::new(parent, curve);
+        let alpha = Arc::new(AtomicU8::new(Self::opacity_to_alpha(animation.value())));
+        Self {
+            controller,
+            animation,
+            alpha,
+            always_include_semantics,
+            listener_id: None,
+        }
+    }
+
+    /// Returns the current cached alpha (`0..=255`), refreshed by the last
+    /// tick that changed it (and once at construction / attach time).
+    #[inline]
+    #[must_use]
+    pub fn alpha(&self) -> u8 {
+        self.alpha.load(Ordering::Relaxed)
+    }
+
+    /// Whether child semantics are included regardless of alpha.
+    #[inline]
+    #[must_use]
+    pub fn always_include_semantics(&self) -> bool {
+        self.always_include_semantics
+    }
+
+    /// Converts opacity (`0.0..=1.0`) to alpha (`0..=255`).
+    #[inline]
+    fn opacity_to_alpha(opacity: f32) -> u8 {
+        (opacity.clamp(0.0, 1.0) * 255.0).round() as u8
+    }
+
+    /// Whether `alpha` sits in the "layered" range `(0, 255)` — the exact
+    /// threshold `paint_alpha`/`skip_paint` use to decide whether an
+    /// `OpacityLayer` is needed. Crossing this threshold is what Flutter's
+    /// mixin calls a `isRepaintBoundary` flip (`_alpha! > 0`); FLUI's own
+    /// `RenderOpacity` uses the same `alpha != 255` narrowing for its
+    /// no-layer fast path at full/zero opacity (see `proxy/opacity.rs`).
+    #[inline]
+    fn is_layered(alpha: u8) -> bool {
+        alpha > 0 && alpha < 255
+    }
+
+    /// Recomputes `alpha` from `animation`'s current value and marks the
+    /// node dirty through `handle` per the module docs' ported rule:
+    /// needs-paint whenever alpha changed, plus needs-compositing-bits
+    /// whenever the recompute crosses the [`is_layered`](Self::is_layered)
+    /// threshold. Returns `true` iff alpha changed AND every required mark
+    /// was sent successfully.
+    ///
+    /// The cache commits (`alpha.store`) only after every mark this
+    /// recompute owes has been sent successfully — never before. `handle`'s
+    /// send can fail under backpressure or once the pipeline owner is gone
+    /// ([`SendError`]); committing first would make that failure invisible,
+    /// since the next tick would then compare its new value against an
+    /// already-updated cache and see no change, permanently losing the mark
+    /// for whatever the animation settles on. Leaving the cache at
+    /// `old_alpha` on failure means the next tick re-derives the same delta
+    /// (or a larger one) against the true old value and retries the send.
+    ///
+    /// Free function (not `&self`) so both [`attach`](RenderBox::attach)
+    /// (called with the live `self.animation`/`self.alpha`) and the tick
+    /// listener closure (called with cloned copies, since the closure must
+    /// be `'static` and cannot borrow `self`) share one implementation.
+    fn recompute_alpha(
+        animation: &CurvedAnimation<ArcCurve>,
+        alpha: &AtomicU8,
+        handle: &RepaintHandle,
+    ) -> bool {
+        let new_alpha = Self::opacity_to_alpha(animation.value());
+        let old_alpha = alpha.load(Ordering::Relaxed);
+        if old_alpha == new_alpha {
+            return false;
+        }
+
+        if Self::is_layered(old_alpha) != Self::is_layered(new_alpha)
+            && let Err(error) = handle.mark_needs_compositing_bits_update()
+        {
+            tracing::warn!(
+                %error,
+                old_alpha,
+                new_alpha,
+                "RenderAnimatedOpacity: compositing-bits mark send failed; \
+                 alpha cache left at the old value so the next tick retries"
+            );
+            return false;
+        }
+
+        if let Err(error) = handle.mark_needs_paint() {
+            tracing::warn!(
+                %error,
+                old_alpha,
+                new_alpha,
+                "RenderAnimatedOpacity: paint mark send failed; alpha cache \
+                 left at the old value so the next tick retries"
+            );
+            return false;
+        }
+
+        alpha.store(new_alpha, Ordering::Relaxed);
+        true
+    }
+}
+
+impl std::fmt::Debug for RenderAnimatedOpacity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RenderAnimatedOpacity")
+            .field("alpha", &self.alpha())
+            .field("always_include_semantics", &self.always_include_semantics)
+            .finish_non_exhaustive()
+    }
+}
+
+impl flui_foundation::Diagnosticable for RenderAnimatedOpacity {
+    fn debug_fill_properties(&self, properties: &mut flui_foundation::DiagnosticsBuilder) {
+        properties.add_default_double("opacity", f32::from(self.alpha()) / 255.0, 1.0, None);
+        properties.add_flag(
+            "always_include_semantics",
+            self.always_include_semantics,
+            "always include semantics",
+        );
+    }
+}
+
+impl RenderBox for RenderAnimatedOpacity {
+    type Arity = Single;
+    type ParentData = BoxParentData;
+
+    fn perform_layout(&mut self, ctx: &mut BoxLayoutContext<'_, Single, BoxParentData>) -> Size {
+        let constraints = *ctx.constraints();
+        if ctx.child_count() > 0 {
+            ctx.layout_child(0, constraints)
+        } else {
+            constraints.smallest()
+        }
+    }
+
+    flui_rendering::forward_single_child_box_queries!();
+
+    fn hit_test(&self, ctx: &mut BoxHitTestContext<'_, Single, BoxParentData>) -> bool {
+        // Flutter parity: an animated-opacity node does not override
+        // `hitTestChildren` — it hit-tests regardless of alpha, same as
+        // `RenderOpacity` (see `proxy/opacity.rs`).
+        if !ctx.is_within_own_size() {
+            return false;
+        }
+        ctx.hit_test_child_at_offset(0, Offset::ZERO)
+    }
+
+    // The whole point of this object: the pipeline reads paint_alpha through
+    // `&dyn RenderObject<BoxProtocol>`; the blanket impl forwards here.
+    fn paint_alpha(&self) -> Option<u8> {
+        let alpha = self.alpha();
+        // None when fully opaque (255) or fully transparent (0): neither
+        // requires an OpacityLayer. Flutter: alpha=0 -> layer=null.
+        if alpha == 255 || alpha == 0 {
+            None
+        } else {
+            Some(alpha)
+        }
+    }
+
+    fn skip_paint(&self) -> bool {
+        // Flutter RenderAnimatedOpacityMixin.paint: `if (_alpha == 0) return;`
+        self.alpha() == 0
+    }
+
+    // Compositing-layer requirement: the pipeline's compositing-bits walk
+    // (`PipelineOwner::update_subtree_compositing_bits`) reads
+    // `always_needs_compositing` through `dyn RenderObject<BoxProtocol>`,
+    // exactly as it does for slivers (see
+    // `RenderSliverAnimatedOpacity::always_needs_compositing`'s comment for
+    // the walk's mechanics). Without this override, `recompute_alpha`'s
+    // `mark_needs_compositing_bits_update()` calls would be inert: the
+    // dirty bit fires a re-walk, but the walk would still read the
+    // `RenderBox` trait's default `false` (`render_box.rs`'s
+    // `always_needs_compositing` default) and never allocate the layer.
+    //
+    // Flutter parity: `RenderAnimatedOpacityMixin.isRepaintBoundary`
+    // (`proxy_box.dart:985`) = `child != null && _currentlyIsRepaintBoundary`
+    // where `_currentlyIsRepaintBoundary = _alpha! > 0` — Flutter's own
+    // threshold is plain `alpha > 0` (fully opaque still counts as
+    // needing its own layer). This port instead uses
+    // [`is_layered`](Self::is_layered) (`0 < alpha < 255`), the SAME
+    // predicate `paint_alpha`/`skip_paint` above already use, and the one
+    // `RenderOpacity`/`RenderSliverOpacity` establish for this crate: at
+    // `alpha == 255` no layer is ever allocated (`paint_alpha` returns
+    // `None`), so requiring compositing there would be pure overhead with
+    // no visual effect — consistency with the sibling opacity pair's
+    // predicate wins over a literal transcription of Flutter's threshold.
+    //
+    // `RenderOpacity` (the non-animated box sibling) has no analogous
+    // override at all — a separate, pre-existing gap in this crate that
+    // predates this change and stays out of scope here.
+    fn always_needs_compositing(&self) -> bool {
+        Self::is_layered(self.alpha())
+    }
+
+    fn attach(&mut self, handle: RepaintHandle) {
+        let animation = self.animation.clone();
+        let alpha = self.alpha.clone();
+        let mark_handle = handle.clone();
+        self.listener_id = Some(self.controller.add_listener(Arc::new(move || {
+            Self::recompute_alpha(&animation, &alpha, &mark_handle);
+        })));
+
+        // Oracle (`proxy_box.dart` attach): `opacity.addListener(_updateOpacity);
+        // _updateOpacity();` — refresh once more in case the animation's value
+        // changed while this node wasn't listening (e.g. a detach/reattach).
+        Self::recompute_alpha(&self.animation, &self.alpha, &handle);
+    }
+
+    fn detach(&mut self) {
+        if let Some(id) = self.listener_id.take() {
+            self.controller.remove_listener(id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flui_animation::{Curves, Scheduler};
+    use flui_rendering::pipeline::PipelineOwner;
+    use flui_rendering::protocol::BoxProtocol;
+    use std::time::Duration;
+
+    fn controller(ms: u64) -> AnimationController {
+        AnimationController::new(Duration::from_millis(ms), Arc::new(Scheduler::new()))
+    }
+
+    fn render_at(opacity: f32) -> RenderAnimatedOpacity {
+        let c = controller(100);
+        c.set_value(opacity);
+        RenderAnimatedOpacity::new(c, ArcCurve::new(Curves::Linear), false)
+    }
+
+    fn curved_at(opacity: f32) -> CurvedAnimation<ArcCurve> {
+        let c = controller(100);
+        c.set_value(opacity);
+        let parent: Arc<dyn Animation<f32>> = Arc::new(c);
+        CurvedAnimation::new(parent, ArcCurve::new(Curves::Linear))
+    }
+
+    /// Mints a real [`RepaintHandle`] by inserting a throwaway anchor node —
+    /// `RepaintHandle::new` is `pub(super)` to `flui_rendering::pipeline`, so
+    /// a real one can only come from a live `PipelineOwner` (matches
+    /// `RenderAnimatedSize`'s own tests, which go through `PipelineOwner::insert`
+    /// rather than constructing a handle by hand).
+    fn anchor_handle() -> (PipelineOwner, RepaintHandle) {
+        let mut owner = PipelineOwner::new();
+        let anchor = owner
+            .insert(Box::new(render_at(1.0))
+                as Box<dyn flui_rendering::traits::RenderObject<BoxProtocol>>);
+        let handle = owner
+            .repaint_handle(anchor)
+            .expect("just-inserted id must be live");
+        (owner, handle)
+    }
+
+    #[test]
+    fn new_caches_alpha_from_initial_animation_value() {
+        let ro = render_at(0.5);
+        assert_eq!(ro.alpha(), 128);
+    }
+
+    #[test]
+    fn paint_alpha_returns_none_when_opaque_or_transparent() {
+        assert_eq!(render_at(1.0).paint_alpha(), None);
+        assert_eq!(render_at(0.0).paint_alpha(), None);
+    }
+
+    #[test]
+    fn paint_alpha_returns_some_for_partial() {
+        assert_eq!(render_at(0.5).paint_alpha(), Some(128));
+    }
+
+    #[test]
+    fn skip_paint_true_only_when_fully_transparent() {
+        assert!(render_at(0.0).skip_paint());
+        assert!(!render_at(1.0).skip_paint());
+        assert!(!render_at(0.5).skip_paint());
+    }
+
+    #[test]
+    fn is_layered_is_false_exactly_at_0_and_255() {
+        assert!(!RenderAnimatedOpacity::is_layered(0));
+        assert!(!RenderAnimatedOpacity::is_layered(255));
+        assert!(RenderAnimatedOpacity::is_layered(1));
+        assert!(RenderAnimatedOpacity::is_layered(254));
+    }
+
+    // `recompute_alpha` is the function attach's listener closure delegates
+    // to. These three tests pin its dirty-marking decision table directly —
+    // no-op on an unchanged value, paint-only on a same-bucket change,
+    // paint+compositing-bits on a boundary-crossing change — independent of
+    // the pipeline wiring (the harness file proves the wiring separately).
+    #[test]
+    fn recompute_alpha_reports_no_change_when_value_is_unchanged() {
+        let (mut owner, handle) = anchor_handle();
+        let cache = AtomicU8::new(128);
+
+        // `insert()` already marks a fresh node needing paint (every new node
+        // needs its first paint) — baseline before asserting `recompute_alpha`
+        // adds nothing further.
+        owner.drain_pending_dirty();
+        let paint_dirty_before = owner.nodes_needing_paint().len();
+
+        let changed = RenderAnimatedOpacity::recompute_alpha(&curved_at(0.5), &cache, &handle);
+
+        assert!(
+            !changed,
+            "recomputing the same alpha (128, from opacity 0.5) must report no change"
+        );
+        owner.drain_pending_dirty();
+        assert_eq!(
+            owner.nodes_needing_paint().len(),
+            paint_dirty_before,
+            "an unchanged alpha must not add a new paint-dirty entry"
+        );
+    }
+
+    // Proves the commit-ordering fix: when the mark send fails, the cache
+    // must NOT advance, so a later successful tick still sees the true
+    // delta and retries the mark instead of silently losing it. Dropping
+    // `owner` closes the dirty-request channel's receiver, so any further
+    // send on `handle` returns `SendError::OwnerGone` — a real, cheaply
+    // reproducible failure path (not a channel-full simulation, but exactly
+    // the same code path: `RepaintHandle::mark_needs_paint`/
+    // `mark_needs_compositing_bits_update` returning `Err`).
+    #[test]
+    fn recompute_alpha_does_not_advance_the_cache_when_the_mark_send_fails() {
+        let (owner, handle) = anchor_handle();
+        drop(owner);
+
+        // 0.0 -> 0.5 crosses the layered boundary, so the compositing-bits
+        // send is attempted first; it fails immediately (owner gone) and
+        // the function must return before ever touching the cache or
+        // attempting the paint-mark send.
+        let cache = AtomicU8::new(0);
+        let changed = RenderAnimatedOpacity::recompute_alpha(&curved_at(0.5), &cache, &handle);
+
+        assert!(
+            !changed,
+            "a failed mark send must report no committed change"
+        );
+        assert_eq!(
+            cache.load(Ordering::Relaxed),
+            0,
+            "the cache must stay at the old value when the send fails, so \
+             the next tick re-derives the same delta against the true old \
+             value and retries the mark instead of losing it"
+        );
+    }
+
+    #[test]
+    fn recompute_alpha_marks_paint_only_within_the_same_layered_bucket() {
+        let (mut owner, handle) = anchor_handle();
+        let anchor = handle.id();
+        let cache = AtomicU8::new(RenderAnimatedOpacity::opacity_to_alpha(0.4));
+
+        // 0.4 -> 0.6: both land in the open (0, 255) layered range, so no
+        // repaint-boundary threshold is crossed.
+        let changed = RenderAnimatedOpacity::recompute_alpha(&curved_at(0.6), &cache, &handle);
+        assert!(changed);
+
+        owner.drain_pending_dirty();
+        assert!(
+            owner
+                .nodes_needing_paint()
+                .iter()
+                .any(|dirty| dirty.id == anchor),
+            "a same-bucket alpha change must still mark paint dirty"
+        );
+        assert!(
+            owner
+                .nodes_needing_compositing_bits_update()
+                .iter()
+                .all(|dirty| dirty.id != anchor),
+            "a same-bucket alpha change must NOT mark compositing bits dirty"
+        );
+    }
+
+    #[test]
+    fn recompute_alpha_marks_compositing_bits_when_crossing_the_layered_boundary() {
+        let (mut owner, handle) = anchor_handle();
+        let anchor = handle.id();
+        let cache = AtomicU8::new(0); // starts fully transparent — not layered
+
+        // 0 -> 0.5 (alpha 128): crosses into the layered range.
+        let changed = RenderAnimatedOpacity::recompute_alpha(&curved_at(0.5), &cache, &handle);
+        assert!(changed);
+
+        owner.drain_pending_dirty();
+        assert!(
+            owner
+                .nodes_needing_paint()
+                .iter()
+                .any(|dirty| dirty.id == anchor),
+            "a boundary-crossing alpha change must mark paint dirty"
+        );
+        assert!(
+            owner
+                .nodes_needing_compositing_bits_update()
+                .iter()
+                .any(|dirty| dirty.id == anchor),
+            "crossing the layered/unlayered threshold must mark compositing bits dirty"
+        );
+    }
+
+    // attach must register a listener and detach must clear it — a
+    // white-box assertion on the private `listener_id` field is the most
+    // direct proof available (a real `PipelineOwner::remove_render_object`
+    // detach cannot isolate "listener removed" from "id went stale", since
+    // both share the same observable no-op — see that method's own doc).
+    #[test]
+    fn attach_registers_listener_and_detach_clears_it() {
+        let (_owner, handle) = anchor_handle();
+        let mut ro = render_at(0.5);
+        assert!(ro.listener_id.is_none(), "no listener before attach");
+
+        RenderBox::attach(&mut ro, handle);
+        assert!(ro.listener_id.is_some(), "attach must register a listener");
+
+        RenderBox::detach(&mut ro);
+        assert!(
+            ro.listener_id.is_none(),
+            "detach must clear the listener id"
+        );
+    }
+}

--- a/crates/flui-objects/src/proxy/mod.rs
+++ b/crates/flui-objects/src/proxy/mod.rs
@@ -1,3 +1,4 @@
+mod animated_opacity;
 mod backdrop_filter;
 mod clip;
 mod colored_box;
@@ -12,6 +13,7 @@ mod semantics;
 mod shader_mask;
 mod subtree_anchor;
 
+pub use animated_opacity::*;
 pub use backdrop_filter::*;
 pub use clip::*;
 pub use colored_box::*;

--- a/crates/flui-objects/src/sliver/mod.rs
+++ b/crates/flui-objects/src/sliver/mod.rs
@@ -1,3 +1,4 @@
+mod sliver_animated_opacity;
 mod sliver_fill_remaining;
 mod sliver_fill_viewport;
 mod sliver_fixed_extent_list;
@@ -14,6 +15,7 @@ mod sliver_to_box_adapter;
 mod viewport;
 mod virtualized_band;
 
+pub use sliver_animated_opacity::*;
 pub use sliver_fill_remaining::*;
 pub use sliver_fill_viewport::*;
 pub use sliver_fixed_extent_list::*;

--- a/crates/flui-objects/src/sliver/sliver_animated_opacity.rs
+++ b/crates/flui-objects/src/sliver/sliver_animated_opacity.rs
@@ -1,0 +1,425 @@
+//! `RenderSliverAnimatedOpacity` — applies a continuously-animated
+//! transparency to a single sliver child, driven by an injected
+//! [`AnimationController`].
+//!
+//! # Flutter equivalence
+//!
+//! Behavior-faithful port of Flutter's `RenderAnimatedOpacityMixin` +
+//! `RenderSliverAnimatedOpacity` (`packages/flutter/lib/src/rendering/proxy_sliver.dart`,
+//! tag `3.44.0`). `RenderSliverAnimatedOpacity` is a bare
+//! `RenderProxySliver with RenderAnimatedOpacityMixin<RenderSliver>` — it
+//! mixes in the SAME alpha-caching/dirty-marking rule the box variant uses.
+//! See [`RenderAnimatedOpacity`](crate::RenderAnimatedOpacity)'s module docs
+//! for the full ported-mechanism writeup (alpha caching, the
+//! paint/compositing-bits marking rule, the documented
+//! no-composited-layer-update divergence, and the `is_layered` predicate
+//! both variants use for `always_needs_compositing`) — this module only
+//! restates the sliver-specific contract surface (`RenderSliverOpacity`'s
+//! layout/hit-test passthrough) that the mixin's host class supplies.
+//!
+//! # Zero-consumer honesty
+//!
+//! No widget in `flui-widgets` constructs this render object yet; wiring a
+//! sliver-flavored `AnimatedOpacity` to it is a deferred follow-up, same as
+//! the box variant.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use flui_tree::Single;
+
+use flui_animation::curve::ArcCurve;
+use flui_animation::{Animation, AnimationController, CurvedAnimation};
+use flui_foundation::{Listenable, ListenerId};
+
+use flui_rendering::{
+    constraints::SliverGeometry,
+    context::{SliverHitTestContext, SliverLayoutContext},
+    parent_data::SliverPhysicalParentData,
+    pipeline::RepaintHandle,
+    traits::RenderSliver,
+};
+
+/// A sliver render object that applies a continuously-animated transparency
+/// to its single sliver child.
+///
+/// Mirrors [`RenderAnimatedOpacity`](crate::RenderAnimatedOpacity) over
+/// [`RenderSliverOpacity`](crate::RenderSliverOpacity)'s contract instead of
+/// `RenderOpacity`'s. See the module docs.
+pub struct RenderSliverAnimatedOpacity {
+    /// The controller driving [`animation`](Self::animation).
+    /// Constructor-injected only — see
+    /// [`RenderAnimatedOpacity`](crate::RenderAnimatedOpacity)'s field
+    /// doc for why no post-construction swap setter exists.
+    controller: AnimationController,
+    /// The eased view of `controller`'s value in `[0.0, 1.0]`.
+    animation: CurvedAnimation<ArcCurve>,
+    /// Alpha cache (`0..=255`), shared with the tick listener closure.
+    /// See [`RenderAnimatedOpacity`](crate::RenderAnimatedOpacity)'s
+    /// field doc for why this is an `AtomicU8`, not a `Cell`/`Mutex`, and
+    /// why `Ordering::Relaxed` suffices (the dirty-channel send in
+    /// [`recompute_alpha`](Self::recompute_alpha), not the atomic op, is
+    /// the synchronization edge).
+    alpha: Arc<AtomicU8>,
+    /// Whether child semantics are included regardless of alpha.
+    always_include_semantics: bool,
+    /// Tick-listener subscription on `controller`, torn down in `detach`.
+    listener_id: Option<ListenerId>,
+}
+
+impl RenderSliverAnimatedOpacity {
+    /// Creates a render object driven by an **already-built** `controller`
+    /// (never constructs one itself — see
+    /// [`RenderAnimatedOpacity::new`](crate::RenderAnimatedOpacity::new)).
+    #[must_use]
+    pub fn new(
+        controller: AnimationController,
+        curve: ArcCurve,
+        always_include_semantics: bool,
+    ) -> Self {
+        let parent: Arc<dyn Animation<f32>> = Arc::new(controller.clone());
+        let animation = CurvedAnimation::new(parent, curve);
+        let alpha = Arc::new(AtomicU8::new(Self::opacity_to_alpha(animation.value())));
+        Self {
+            controller,
+            animation,
+            alpha,
+            always_include_semantics,
+            listener_id: None,
+        }
+    }
+
+    /// Returns the current cached alpha (`0..=255`).
+    #[inline]
+    #[must_use]
+    pub fn alpha(&self) -> u8 {
+        self.alpha.load(Ordering::Relaxed)
+    }
+
+    /// Whether child semantics are included regardless of alpha.
+    #[inline]
+    #[must_use]
+    pub fn always_include_semantics(&self) -> bool {
+        self.always_include_semantics
+    }
+
+    /// Converts opacity (`0.0..=1.0`) to alpha (`0..=255`).
+    #[inline]
+    fn opacity_to_alpha(opacity: f32) -> u8 {
+        (opacity.clamp(0.0, 1.0) * 255.0).round() as u8
+    }
+
+    /// Whether `alpha` sits in the "layered" range `(0, 255)`. See
+    /// [`RenderAnimatedOpacity`](crate::RenderAnimatedOpacity)'s
+    /// `is_layered` doc for the rationale — identical rule here.
+    #[inline]
+    fn is_layered(alpha: u8) -> bool {
+        alpha > 0 && alpha < 255
+    }
+
+    /// Recomputes `alpha` and marks the node dirty through `handle`. See
+    /// [`RenderAnimatedOpacity`](crate::RenderAnimatedOpacity)'s
+    /// `recompute_alpha` for the full rule this mirrors, including why the
+    /// cache commit is ordered strictly after every required mark send
+    /// succeeds. Returns `true` iff alpha changed AND every required mark
+    /// was sent successfully.
+    fn recompute_alpha(
+        animation: &CurvedAnimation<ArcCurve>,
+        alpha: &AtomicU8,
+        handle: &RepaintHandle,
+    ) -> bool {
+        let new_alpha = Self::opacity_to_alpha(animation.value());
+        let old_alpha = alpha.load(Ordering::Relaxed);
+        if old_alpha == new_alpha {
+            return false;
+        }
+
+        if Self::is_layered(old_alpha) != Self::is_layered(new_alpha)
+            && let Err(error) = handle.mark_needs_compositing_bits_update()
+        {
+            tracing::warn!(
+                %error,
+                old_alpha,
+                new_alpha,
+                "RenderSliverAnimatedOpacity: compositing-bits mark send \
+                 failed; alpha cache left at the old value so the next tick \
+                 retries"
+            );
+            return false;
+        }
+
+        if let Err(error) = handle.mark_needs_paint() {
+            tracing::warn!(
+                %error,
+                old_alpha,
+                new_alpha,
+                "RenderSliverAnimatedOpacity: paint mark send failed; alpha \
+                 cache left at the old value so the next tick retries"
+            );
+            return false;
+        }
+
+        alpha.store(new_alpha, Ordering::Relaxed);
+        true
+    }
+}
+
+impl std::fmt::Debug for RenderSliverAnimatedOpacity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RenderSliverAnimatedOpacity")
+            .field("alpha", &self.alpha())
+            .field("always_include_semantics", &self.always_include_semantics)
+            .finish_non_exhaustive()
+    }
+}
+
+impl flui_foundation::Diagnosticable for RenderSliverAnimatedOpacity {
+    fn debug_fill_properties(&self, builder: &mut flui_foundation::DiagnosticsBuilder) {
+        builder.add_default_double("opacity", f32::from(self.alpha()) / 255.0, 1.0, None);
+        builder.add_flag(
+            "always_include_semantics",
+            self.always_include_semantics,
+            "always include semantics",
+        );
+    }
+}
+
+impl RenderSliver for RenderSliverAnimatedOpacity {
+    type Arity = Single;
+    type ParentData = SliverPhysicalParentData;
+
+    fn perform_layout(
+        &mut self,
+        ctx: &mut SliverLayoutContext<'_, Single, SliverPhysicalParentData>,
+    ) -> SliverGeometry {
+        let constraints = *ctx.constraints();
+        if ctx.child_count() > 0 {
+            // Transparent passthrough — opacity does not affect layout.
+            ctx.layout_child(0, constraints)
+        } else {
+            SliverGeometry::ZERO
+        }
+    }
+
+    fn hit_test(
+        &self,
+        ctx: &mut SliverHitTestContext<'_, Single, SliverPhysicalParentData>,
+    ) -> bool {
+        // Flutter parity: same as `RenderSliverOpacity` — hit-tests
+        // regardless of alpha.
+        ctx.hit_test_child_at_layout_offset(0)
+    }
+
+    // Mirrors `RenderSliverOpacity::always_needs_compositing`: the sliver
+    // compositing-bits walk reads this through
+    // `dyn RenderObject<SliverProtocol>` (see `sliver/sliver_opacity.rs`'s
+    // comment on that override for the walk's mechanics). The box variant,
+    // `RenderAnimatedOpacity`, carries the analogous override for the same
+    // reason — see its own comment for the predicate this port uses
+    // (`is_layered`, `0 < alpha < 255`) and why, versus Flutter's raw
+    // `alpha > 0`.
+    fn always_needs_compositing(&self) -> bool {
+        Self::is_layered(self.alpha())
+    }
+
+    fn paint_alpha(&self) -> Option<u8> {
+        let alpha = self.alpha();
+        if alpha == 255 || alpha == 0 {
+            None
+        } else {
+            Some(alpha)
+        }
+    }
+
+    fn skip_paint(&self) -> bool {
+        self.alpha() == 0
+    }
+
+    fn attach(&mut self, handle: RepaintHandle) {
+        let animation = self.animation.clone();
+        let alpha = self.alpha.clone();
+        let mark_handle = handle.clone();
+        self.listener_id = Some(self.controller.add_listener(Arc::new(move || {
+            Self::recompute_alpha(&animation, &alpha, &mark_handle);
+        })));
+        Self::recompute_alpha(&self.animation, &self.alpha, &handle);
+    }
+
+    fn detach(&mut self) {
+        if let Some(id) = self.listener_id.take() {
+            self.controller.remove_listener(id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flui_animation::{Curves, Scheduler};
+    use flui_rendering::pipeline::PipelineOwner;
+    use flui_rendering::protocol::SliverProtocol;
+    use std::time::Duration;
+
+    fn controller(ms: u64) -> AnimationController {
+        AnimationController::new(Duration::from_millis(ms), Arc::new(Scheduler::new()))
+    }
+
+    fn render_at(opacity: f32) -> RenderSliverAnimatedOpacity {
+        let c = controller(100);
+        c.set_value(opacity);
+        RenderSliverAnimatedOpacity::new(c, ArcCurve::new(Curves::Linear), false)
+    }
+
+    fn curved_at(opacity: f32) -> CurvedAnimation<ArcCurve> {
+        let c = controller(100);
+        c.set_value(opacity);
+        let parent: Arc<dyn Animation<f32>> = Arc::new(c);
+        CurvedAnimation::new(parent, ArcCurve::new(Curves::Linear))
+    }
+
+    fn anchor_handle() -> (PipelineOwner, RepaintHandle) {
+        let mut owner = PipelineOwner::new();
+        let anchor = owner.insert(Box::new(render_at(1.0))
+            as Box<dyn flui_rendering::traits::RenderObject<SliverProtocol>>);
+        let handle = owner
+            .repaint_handle(anchor)
+            .expect("just-inserted id must be live");
+        (owner, handle)
+    }
+
+    #[test]
+    fn new_caches_alpha_from_initial_animation_value() {
+        assert_eq!(render_at(0.5).alpha(), 128);
+    }
+
+    #[test]
+    fn paint_alpha_returns_none_when_opaque_or_transparent() {
+        assert_eq!(render_at(1.0).paint_alpha(), None);
+        assert_eq!(render_at(0.0).paint_alpha(), None);
+    }
+
+    #[test]
+    fn paint_alpha_returns_some_for_partial() {
+        assert_eq!(render_at(0.5).paint_alpha(), Some(128));
+    }
+
+    #[test]
+    fn skip_paint_true_only_when_fully_transparent() {
+        assert!(render_at(0.0).skip_paint());
+        assert!(!render_at(1.0).skip_paint());
+    }
+
+    #[test]
+    fn always_needs_compositing_tracks_the_layered_range() {
+        assert!(!render_at(0.0).always_needs_compositing());
+        assert!(!render_at(1.0).always_needs_compositing());
+        assert!(render_at(0.5).always_needs_compositing());
+    }
+
+    #[test]
+    fn recompute_alpha_reports_no_change_when_value_is_unchanged() {
+        let (mut owner, handle) = anchor_handle();
+        let cache = AtomicU8::new(128);
+
+        // `insert()` already marks a fresh node needing paint — baseline
+        // before asserting `recompute_alpha` adds nothing further.
+        owner.drain_pending_dirty();
+        let paint_dirty_before = owner.nodes_needing_paint().len();
+
+        let changed =
+            RenderSliverAnimatedOpacity::recompute_alpha(&curved_at(0.5), &cache, &handle);
+
+        assert!(!changed);
+        owner.drain_pending_dirty();
+        assert_eq!(
+            owner.nodes_needing_paint().len(),
+            paint_dirty_before,
+            "an unchanged alpha must not add a new paint-dirty entry"
+        );
+    }
+
+    // Mirrors the box variant's failed-send test: dropping `owner` closes
+    // the dirty-request channel's receiver, so `handle`'s send returns
+    // `SendError::OwnerGone` — a real, cheaply reproducible failure of the
+    // exact code path `recompute_alpha` calls. The cache must stay at the
+    // old value so a later successful tick still re-derives the delta and
+    // retries the mark instead of losing it.
+    #[test]
+    fn recompute_alpha_does_not_advance_the_cache_when_the_mark_send_fails() {
+        let (owner, handle) = anchor_handle();
+        drop(owner);
+
+        let cache = AtomicU8::new(0);
+        let changed =
+            RenderSliverAnimatedOpacity::recompute_alpha(&curved_at(0.5), &cache, &handle);
+
+        assert!(
+            !changed,
+            "a failed mark send must report no committed change"
+        );
+        assert_eq!(
+            cache.load(Ordering::Relaxed),
+            0,
+            "the cache must stay at the old value when the send fails"
+        );
+    }
+
+    #[test]
+    fn recompute_alpha_marks_compositing_bits_when_crossing_the_layered_boundary() {
+        let (mut owner, handle) = anchor_handle();
+        let anchor = handle.id();
+        let cache = AtomicU8::new(0);
+
+        let changed =
+            RenderSliverAnimatedOpacity::recompute_alpha(&curved_at(0.5), &cache, &handle);
+        assert!(changed);
+
+        owner.drain_pending_dirty();
+        assert!(
+            owner
+                .nodes_needing_paint()
+                .iter()
+                .any(|dirty| dirty.id == anchor)
+        );
+        assert!(
+            owner
+                .nodes_needing_compositing_bits_update()
+                .iter()
+                .any(|dirty| dirty.id == anchor),
+            "crossing the layered/unlayered threshold must mark compositing bits dirty"
+        );
+    }
+
+    #[test]
+    fn recompute_alpha_marks_paint_only_within_the_same_layered_bucket() {
+        let (mut owner, handle) = anchor_handle();
+        let anchor = handle.id();
+        let cache = AtomicU8::new(RenderSliverAnimatedOpacity::opacity_to_alpha(0.4));
+
+        let changed =
+            RenderSliverAnimatedOpacity::recompute_alpha(&curved_at(0.6), &cache, &handle);
+        assert!(changed);
+
+        owner.drain_pending_dirty();
+        assert!(
+            owner
+                .nodes_needing_compositing_bits_update()
+                .iter()
+                .all(|dirty| dirty.id != anchor),
+            "a same-bucket alpha change must NOT mark compositing bits dirty"
+        );
+    }
+
+    #[test]
+    fn attach_registers_listener_and_detach_clears_it() {
+        let (_owner, handle) = anchor_handle();
+        let mut ro = render_at(0.5);
+        assert!(ro.listener_id.is_none());
+
+        RenderSliver::attach(&mut ro, handle);
+        assert!(ro.listener_id.is_some());
+
+        RenderSliver::detach(&mut ro);
+        assert!(ro.listener_id.is_none());
+    }
+}

--- a/crates/flui-objects/tests/harness_snapshot.rs
+++ b/crates/flui-objects/tests/harness_snapshot.rs
@@ -383,3 +383,160 @@ fn snapshot_lazy_sliver_visible_band() {
 
     insta::assert_snapshot!("lazy_sliver_visible_band", snap);
 }
+
+// ---------------------------------------------------------------------------
+// 5. RenderSliverListLazy — scrolling a 1 000-item list keeps the
+//    materialized band bounded and correctly windowed at each stop
+// ---------------------------------------------------------------------------
+
+/// Scrolls a `RenderSliverListLazy` of 1 000 items from the top, to a mid
+/// offset (~item 500), to a deep offset (the tail), and at each stop asserts
+/// the materialized (attached) child band is both bounded (laziness: distant
+/// items are never built) and correctly windowed (the band tracks the scroll
+/// position, not a stale one).
+///
+/// Companion to [`snapshot_lazy_sliver_visible_band`], which only proves
+/// laziness at a fixed offset=0; this proves it holds across a scroll.
+#[test]
+#[allow(clippy::type_complexity)] // matches snapshot_lazy_sliver_visible_band's own item source type
+fn scrolling_lazy_sliver_keeps_materialized_band_bounded_and_windowed() {
+    use std::sync::Arc;
+
+    use flui_objects::{RenderColoredBox as SnapColoredBox, RenderSliverListLazy, RenderViewport};
+    use flui_rendering::{
+        parent_data::SliverMultiBoxAdaptorParentData,
+        protocol::{BoxProtocol, RenderObject},
+        testing::{Probe, sliver_node},
+        view::ScrollableViewportOffset,
+    };
+    use flui_types::{Size, geometry::px, layout::AxisDirection};
+
+    let n_items = 1_000usize;
+    let item_height = 50.0_f32;
+    let viewport_height = 200.0_f32;
+    // Same generous bound as `snapshot_lazy_sliver_visible_band`: total
+    // *attached* children (not just painted ones) must never approach N.
+    let band_limit = ((viewport_height + 500.0) / item_height).ceil() as usize * 3 + 5;
+    let settle_frames = ((viewport_height + 500.0) / item_height).ceil() as usize + 10;
+    let max_scroll = n_items as f32 * item_height - viewport_height;
+    let mid_scroll = 500.0 * item_height;
+
+    let source: Arc<dyn Fn(usize) -> Option<Box<dyn RenderObject<BoxProtocol>>> + Send + Sync> =
+        Arc::new(move |_idx| {
+            Some(Box::new(SnapColoredBox::red(300.0, item_height))
+                as Box<dyn RenderObject<BoxProtocol>>)
+        });
+    let lazy = RenderSliverListLazy::new(n_items, item_height, Arc::clone(&source));
+
+    let mut run = RenderTester::mount(
+        box_node(RenderViewport::new(AxisDirection::TopToBottom)).child(sliver_node(lazy)),
+    )
+    .with_size(Size::new(px(300.0), px(viewport_height)))
+    .run_layout();
+
+    let vp_id = run.root();
+    let sliver_id = *run
+        .pipeline()
+        .render_tree()
+        .children(vp_id)
+        .first()
+        .expect("viewport must have the lazy sliver as its one child");
+
+    // Reads the currently-attached children's stamped logical indices —
+    // "materialized" here means "has a live render object under the sliver",
+    // not "was painted" (a stricter, layout-level laziness check than the
+    // paint-snapshot test above).
+    let materialized_indices = |run: &flui_rendering::testing::LayoutRun| -> Vec<usize> {
+        let tree = run.pipeline().render_tree();
+        tree.children(sliver_id)
+            .iter()
+            .filter_map(|&child_id| tree.get(child_id))
+            .filter_map(|node| {
+                node.parent_data()?
+                    .downcast_ref::<SliverMultiBoxAdaptorParentData>()
+            })
+            .map(|pd| pd.index)
+            .collect()
+    };
+
+    let settle = |run: &mut flui_rendering::testing::LayoutRun| {
+        for _ in 0..settle_frames {
+            run.relayout();
+        }
+    };
+
+    let scroll_to = |run: &mut flui_rendering::testing::LayoutRun, pixels: f32| {
+        run.update::<RenderViewport<ScrollableViewportOffset>>(vp_id, |vp| {
+            vp.offset_mut().set_pixels(pixels);
+        });
+    };
+
+    // ---- Stop 1: offset 0 — the band sits at the head ---------------------
+    settle(&mut run);
+    let head = materialized_indices(&run);
+    assert!(
+        !head.is_empty(),
+        "head stop: at least one child must be materialized"
+    );
+    assert!(
+        head.len() <= band_limit,
+        "head stop: {} materialized children exceeds band_limit {band_limit} \
+         (laziness violated): {head:?}",
+        head.len(),
+    );
+    assert!(
+        head.iter().all(|&idx| idx < 100),
+        "head stop: a far-tail item was materialized at scroll_offset=0 \
+         (laziness violated): {head:?}",
+    );
+    assert!(
+        !head.contains(&999),
+        "head stop: the very last item must not be materialized while scrolled to the top",
+    );
+
+    // ---- Stop 2: mid offset (~item 500) ------------------------------------
+    scroll_to(&mut run, mid_scroll);
+    settle(&mut run);
+    let mid = materialized_indices(&run);
+    assert!(
+        !mid.is_empty(),
+        "mid stop: at least one child must be materialized"
+    );
+    assert!(
+        mid.len() <= band_limit,
+        "mid stop: {} materialized children exceeds band_limit {band_limit}: {mid:?}",
+        mid.len(),
+    );
+    assert!(
+        mid.iter().all(|&idx| (440..=560).contains(&idx)),
+        "mid stop: materialized band did not track scroll_offset={mid_scroll} \
+         (expected indices near item 500): {mid:?}",
+    );
+    assert!(
+        !mid.contains(&0) && !mid.contains(&999),
+        "mid stop: head/tail items must not still be materialized after scrolling away: {mid:?}",
+    );
+
+    // ---- Stop 3: deep offset (the tail) ------------------------------------
+    scroll_to(&mut run, max_scroll);
+    settle(&mut run);
+    let tail = materialized_indices(&run);
+    assert!(
+        !tail.is_empty(),
+        "tail stop: at least one child must be materialized"
+    );
+    assert!(
+        tail.len() <= band_limit,
+        "tail stop: {} materialized children exceeds band_limit {band_limit}: {tail:?}",
+        tail.len(),
+    );
+    assert!(
+        tail.iter().all(|&idx| idx >= 900),
+        "tail stop: materialized band did not reach the list's tail \
+         at scroll_offset={max_scroll}: {tail:?}",
+    );
+    assert!(
+        !tail.contains(&0) && !tail.contains(&500),
+        "tail stop: head/mid items must not still be materialized at the tail: {tail:?}",
+    );
+}

--- a/crates/flui-objects/tests/render_object_harness.rs
+++ b/crates/flui-objects/tests/render_object_harness.rs
@@ -23,6 +23,7 @@
 //! | `RenderLimitedBox` | `harness_limited_box_*` | yes | — | — | yes | — |
 //! | `RenderOffstage` | `harness_offstage_*` | yes | yes | — | yes | — |
 //! | `RenderOpacity` | `harness_opacity_*` | yes | — | yes | yes | queries |
+//! | `RenderAnimatedOpacity` | `harness_animated_opacity_*` | yes | yes | yes | yes | tick dirty-marking |
 //! | `RenderTransform` | `harness_transform_*` | yes | — | yes | yes | paint transform |
 //! | `RenderFittedBox` | `harness_fitted_box_*` | yes | — | — | yes | paint transform |
 //! | `RenderFractionallySizedBox` | `harness_fractionally_sized_box_*` | yes | — | — | yes | — |
@@ -69,6 +70,7 @@
 //! | `RenderSliverListLazy` | `harness_sliver_list_lazy_*` | yes | — | — | yes | — |
 //! | `RenderSliverOffstage` | `harness_sliver_offstage_*` | yes | — | — | yes | — |
 //! | `RenderSliverOpacity` | `harness_sliver_opacity_*` | yes | — | yes | yes | compositing |
+//! | `RenderSliverAnimatedOpacity` | `harness_sliver_animated_opacity_*` | yes | yes | yes | yes | tick dirty-marking |
 //! | `RenderViewport` | `harness_viewport_*` | yes | — | — | yes | — |
 //! | `RenderShrinkWrappingViewport` | `harness_shrink_wrapping_viewport_*` | yes | — | — | yes | — |
 //! | `RenderWrap` | `harness_render_wrap_*` | yes | yes | — | yes | — |
@@ -119,7 +121,8 @@ use flui_types::{
     Alignment, EdgeInsets, Matrix4, Offset, Point, Rect, Size,
     geometry::px,
     layout::{
-        AxisDirection, BoxFit, BoxShape, StackFit, TableCellVerticalAlignment, TableColumnWidth,
+        Axis, AxisDirection, BoxFit, BoxShape, StackFit, TableCellVerticalAlignment,
+        TableColumnWidth,
     },
     painting::{BlendMode, Clip, ImageFilter, Path, Shader},
     styling::{
@@ -148,6 +151,7 @@ const RENDER_OBJECT_TYPES: &[&str] = &[
     "RenderLimitedBox",
     "RenderOffstage",
     "RenderOpacity",
+    "RenderAnimatedOpacity",
     "RenderTransform",
     "RenderFittedBox",
     "RenderFractionallySizedBox",
@@ -194,6 +198,7 @@ const RENDER_OBJECT_TYPES: &[&str] = &[
     "RenderSliverListLazy",
     "RenderSliverOffstage",
     "RenderSliverOpacity",
+    "RenderSliverAnimatedOpacity",
     "RenderViewport",
     "RenderShrinkWrappingViewport",
     "RenderWrap",
@@ -1792,6 +1797,124 @@ fn harness_opacity_paints_with_alpha_layer() {
 
     assert!(run.painted());
     assert!(run.structure().contains(&"Opacity"));
+}
+
+// ── RenderAnimatedOpacity ────────────────────────────────────────────────
+
+fn ticking_controller(ms: u64, value: f32) -> AnimationController {
+    let controller =
+        AnimationController::new(Duration::from_millis(ms), Arc::new(Scheduler::new()));
+    controller.set_value(value);
+    controller
+}
+
+#[test]
+fn harness_animated_opacity_layout_passthrough_matches_child_size() {
+    let controller = ticking_controller(100, 0.5);
+    let run = RenderTester::mount(
+        box_node(RenderAnimatedOpacity::new(
+            controller,
+            ArcCurve::new(Curves::Linear),
+            false,
+        ))
+        .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert_eq!(
+        run.box_geometry(run.root()),
+        Size::new(px(40.0), px(40.0)),
+        "opacity does not affect layout — a pure passthrough of the child's size"
+    );
+}
+
+#[test]
+fn harness_animated_opacity_paint_alpha_tracks_controller_value_at_0_partial_255() {
+    for (value, expect_layer) in [(0.0, false), (0.5, true), (1.0, false)] {
+        let controller = ticking_controller(100, value);
+        let run = RenderTester::mount(
+            box_node(RenderAnimatedOpacity::new(
+                controller,
+                ArcCurve::new(Curves::Linear),
+                false,
+            ))
+            .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+        )
+        .with_constraints(loose(200.0))
+        .run_frame();
+
+        assert_eq!(
+            run.structure().contains(&"Opacity"),
+            expect_layer,
+            "opacity={value} must {}emit an OpacityLayer (Flutter: alpha 0/255 -> \
+             layer=null): {:?}",
+            if expect_layer { "" } else { "NOT " },
+            run.structure(),
+        );
+    }
+}
+
+// This test fails if the attach-registered controller listener never fires:
+// a settled frame followed by an external controller tick would leave the
+// pipeline idle (`report.painted == false`) unless `attach`
+// (proxy/animated_opacity.rs) wires the listener to `mark_needs_paint` and
+// the tick actually reaches the owner's paint-dirty set through `RepaintHandle`.
+#[test]
+fn harness_animated_opacity_tick_marks_needs_paint() {
+    let controller = ticking_controller(100, 0.0);
+    let mut run = RenderTester::mount(
+        box_node(RenderAnimatedOpacity::new(
+            controller.clone(),
+            ArcCurve::new(Curves::Linear),
+            false,
+        ))
+        .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_frame();
+    assert!(
+        run.is_clean(),
+        "a settled first frame must leave nothing pending"
+    );
+
+    controller.set_value(0.5);
+    let report = run.pump();
+
+    assert!(
+        report.painted,
+        "a controller tick that changes the effective alpha must reach the \
+         pipeline through the attach()-registered listener and trigger a \
+         repaint: {report}"
+    );
+}
+
+#[test]
+fn harness_animated_opacity_boundary_crossing_tick_marks_compositing_bits() {
+    let controller = ticking_controller(100, 0.0); // alpha=0, not layered
+    let mut run = RenderTester::mount(
+        box_node(RenderAnimatedOpacity::new(
+            controller.clone(),
+            ArcCurve::new(Curves::Linear),
+            false,
+        ))
+        .child(box_node(RenderColoredBox::red(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_frame();
+    let id = run.root();
+
+    controller.set_value(0.5); // crosses into the layered (0, 255) range
+    run.owner_mut().drain_pending_dirty();
+
+    assert!(
+        run.owner()
+            .nodes_needing_compositing_bits_update()
+            .iter()
+            .any(|dirty| dirty.id == id),
+        "crossing the layered/unlayered alpha threshold must mark compositing \
+         bits dirty (RepaintHandle::mark_needs_compositing_bits_update)"
+    );
 }
 
 #[test]
@@ -3544,6 +3667,54 @@ fn harness_wrap_max_intrinsic_width_omits_spacing() {
     assert_eq!(run.max_intrinsic_width(run.root(), 100.0), 120.0);
 }
 
+/// `compute_min_intrinsic_width` for a horizontal wrap is the WORST case —
+/// every child forced onto its own row — so it is the MAX of child min
+/// widths, never their sum. Distinguishes it from `compute_max_intrinsic_width`
+/// (the sum, best-case, all-on-one-row formula tested above); swapping the
+/// two formulas would still compile and is exactly the kind of regression
+/// this pins.
+#[test]
+fn harness_wrap_min_intrinsic_width_is_the_max_child_width_not_the_sum() {
+    let mut run = RenderTester::mount(
+        box_node(RenderWrap::new())
+            .child(box_node(RenderColoredBox::red(30.0, 20.0)).label("a"))
+            .child(box_node(RenderColoredBox::green(50.0, 20.0)).label("b")),
+    )
+    .with_size(Size::new(px(200.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(
+        run.min_intrinsic_width(run.root(), 100.0),
+        50.0,
+        "min intrinsic width must be the max child width (50), not the sum (80)",
+    );
+}
+
+/// `compute_max_intrinsic_height` for a VERTICAL wrap is the best case —
+/// all children in one column — so it sums child max heights with NO
+/// `run_spacing` term, mirroring the horizontal max-width path
+/// (`harness_wrap_max_intrinsic_width_omits_spacing`) on the other axis.
+#[test]
+fn harness_wrap_max_intrinsic_height_vertical_omits_run_spacing() {
+    let mut run = RenderTester::mount(
+        box_node(
+            RenderWrap::new()
+                .with_direction(Axis::Vertical)
+                .with_run_spacing(10.0),
+        )
+        .child(box_node(RenderColoredBox::red(20.0, 20.0)).label("a"))
+        .child(box_node(RenderColoredBox::green(20.0, 30.0)).label("b")),
+    )
+    .with_size(Size::new(px(100.0), px(200.0)))
+    .run_layout();
+
+    assert_eq!(
+        run.max_intrinsic_height(run.root(), 100.0),
+        50.0,
+        "vertical max intrinsic height sums child heights (20+30=50) with no run_spacing term",
+    );
+}
+
 #[test]
 fn harness_stack_hit_tests_top_child_first() {
     let run = RenderTester::mount(
@@ -3815,6 +3986,70 @@ fn harness_list_body_dry_layout_and_baseline_follow_oracle_order() {
     assert!(
         (dry - 15.0).abs() < 0.01,
         "vertical down dry baseline must skip the first non-baseline child and add its height; got {dry}",
+    );
+}
+
+/// Oracle quirk (`list_body.dart:288-333`): `computeMinIntrinsicWidth` AND
+/// `computeMinIntrinsicHeight` key off the SAME `mainAxis` switch with the
+/// SAME sum/max mapping (`Axis.horizontal => sum, Axis.vertical => max`) —
+/// height's formula does not independently reason about "is height the main
+/// or the cross axis"; it mirrors width's axis-keyed switch verbatim. For a
+/// default (vertical, `TopToBottom`) list body this means BOTH width and
+/// height intrinsics take the max-across-children branch, not just width.
+/// Confirmed against the oracle before writing this pair — the naive
+/// "sum along main axis, max across cross axis" mental model this test's
+/// name might suggest is WRONG for `RenderListBody`; `horizontal_intrinsic`
+/// and `vertical_intrinsic` are (correctly) byte-identical in this crate.
+#[test]
+fn harness_list_body_min_intrinsic_width_takes_the_max_across_children() {
+    let mut run = RenderTester::mount(
+        box_node(RenderListBody::new())
+            .child(box_node(RenderSizedBox::fixed(px(20.0), px(10.0))))
+            .child(box_node(RenderSizedBox::fixed(px(30.0), px(15.0)))),
+    )
+    .with_constraints(BoxConstraints::new(
+        px(0.0),
+        px(100.0),
+        px(0.0),
+        px(f32::INFINITY),
+    ))
+    .run_layout();
+
+    assert_eq!(
+        run.min_intrinsic_width(run.root(), 100.0),
+        30.0,
+        "cross-axis (width) intrinsic must be the max child width (30), not the sum (50)",
+    );
+}
+
+/// The height-side mirror of the test above, pinning the SAME oracle quirk
+/// (`list_body.dart:312-321`) from the other dimension: at a default
+/// (vertical) main axis, `computeMaxIntrinsicHeight` ALSO takes the
+/// `_getIntrinsicCrossAxis` (max) branch, not `_getIntrinsicMainAxis` (sum)
+/// — despite height being the main-stacking axis here. Without this test,
+/// a "fix" that made `vertical_intrinsic` swap its match arms to the
+/// intuitive-but-wrong sum-on-main-axis mapping would look like a bugfix
+/// and silently diverge from Flutter.
+#[test]
+fn harness_list_body_max_intrinsic_height_at_vertical_main_axis_takes_the_max_not_sum() {
+    let mut run = RenderTester::mount(
+        box_node(RenderListBody::new())
+            .child(box_node(RenderSizedBox::fixed(px(20.0), px(10.0))))
+            .child(box_node(RenderSizedBox::fixed(px(30.0), px(15.0)))),
+    )
+    .with_constraints(BoxConstraints::new(
+        px(0.0),
+        px(100.0),
+        px(0.0),
+        px(f32::INFINITY),
+    ))
+    .run_layout();
+
+    assert_eq!(
+        run.max_intrinsic_height(run.root(), 100.0),
+        15.0,
+        "oracle quirk: height intrinsic at a vertical main axis is the max \
+         child height (15), NOT the sum (25) — see list_body.dart:312-321",
     );
 }
 
@@ -4832,6 +5067,101 @@ fn harness_sliver_opacity_always_needs_compositing_reaches_pipeline() {
          always_needs_compositing=true through RenderNode (the pipeline \
          compositing-bits walk path); blanket impl must forward via UFCS \
          (Flutter parity: alwaysNeedsCompositing = child != null && alpha > 0)"
+    );
+}
+
+// ── RenderSliverAnimatedOpacity ──────────────────────────────────────────
+
+fn animated_opacity_sliver_spec(controller: AnimationController) -> TreeNode {
+    sliver_node(RenderSliverAnimatedOpacity::new(
+        controller,
+        ArcCurve::new(Curves::Linear),
+        false,
+    ))
+    .label("opacity")
+    .child(
+        sliver_node(RenderSliverFixedExtentList::new(30.0))
+            .child(box_node(RenderColoredBox::red(300.0, 1000.0))),
+    )
+}
+
+#[test]
+fn harness_sliver_animated_opacity_passes_geometry() {
+    let run = RenderTester::mount(viewport(animated_opacity_sliver_spec(ticking_controller(
+        100, 0.5,
+    ))))
+    .with_size(Size::new(px(300.0), px(100.0)))
+    .run_layout();
+
+    assert_eq!(
+        run.sliver_geometry(run.id("opacity")).scroll_extent,
+        30.0,
+        "opacity does not affect layout — a pure passthrough of the child's geometry"
+    );
+}
+
+#[test]
+fn harness_sliver_animated_opacity_paint_alpha_tracks_controller_value_at_0_partial_255() {
+    for (value, expect_layer) in [(0.0, false), (0.5, true), (1.0, false)] {
+        let run = RenderTester::mount(viewport(animated_opacity_sliver_spec(ticking_controller(
+            100, value,
+        ))))
+        .with_size(Size::new(px(300.0), px(100.0)))
+        .run_frame();
+
+        assert_eq!(
+            run.structure().contains(&"Opacity"),
+            expect_layer,
+            "opacity={value} must {}emit an OpacityLayer: {:?}",
+            if expect_layer { "" } else { "NOT " },
+            run.structure(),
+        );
+    }
+}
+
+// Sliver mirror of `harness_animated_opacity_tick_marks_needs_paint` above:
+// this test fails the same way if the sliver's attach-registered listener
+// never fires.
+#[test]
+fn harness_sliver_animated_opacity_tick_marks_needs_paint() {
+    let controller = ticking_controller(100, 0.0);
+    let mut run = RenderTester::mount(viewport(animated_opacity_sliver_spec(controller.clone())))
+        .with_size(Size::new(px(300.0), px(100.0)))
+        .run_frame();
+    assert!(
+        run.is_clean(),
+        "a settled first frame must leave nothing pending"
+    );
+
+    controller.set_value(0.5);
+    let report = run.pump();
+
+    assert!(
+        report.painted,
+        "a controller tick that changes the effective alpha must reach the \
+         pipeline through the attach()-registered listener and trigger a \
+         repaint: {report}"
+    );
+}
+
+#[test]
+fn harness_sliver_animated_opacity_boundary_crossing_tick_marks_compositing_bits() {
+    let controller = ticking_controller(100, 0.0); // alpha=0, not layered
+    let mut run = RenderTester::mount(viewport(animated_opacity_sliver_spec(controller.clone())))
+        .with_size(Size::new(px(300.0), px(100.0)))
+        .run_frame();
+    let id = run.id("opacity");
+
+    controller.set_value(0.5); // crosses into the layered (0, 255) range
+    run.owner_mut().drain_pending_dirty();
+
+    assert!(
+        run.owner()
+            .nodes_needing_compositing_bits_update()
+            .iter()
+            .any(|dirty| dirty.id == id),
+        "crossing the layered/unlayered alpha threshold must mark compositing \
+         bits dirty (RepaintHandle::mark_needs_compositing_bits_update)"
     );
 }
 
@@ -6661,6 +6991,41 @@ fn harness_table_dry_baseline_matches_the_committed_first_row_baseline() {
         Some(30.0),
         "table dry baseline must equal the committed first-row baseline \
          (max of the row's cell baselines 30 and 10)",
+    );
+}
+
+/// Pins the oracle's own documented quirk (`table.dart:1023-1026`,
+/// restated at `RenderTable::compute_max_intrinsic_height`'s call site):
+/// `computeMaxIntrinsicHeight` returns `computeMinIntrinsicHeight` VERBATIM
+/// — not a typo. `compute_min_intrinsic_height` itself is genuinely
+/// non-trivial (resolve column widths at the query width, take each row's
+/// tallest cell, sum the rows) and had zero coverage anywhere in this crate.
+///
+/// 2 columns x 2 rows, row 0 cell heights (10, 15) -> row max 15; row 1 cell
+/// heights (25, 5) -> row max 25; summed = 40.
+#[test]
+fn harness_table_min_and_max_intrinsic_height_both_equal_the_row_summed_value() {
+    let mut run = RenderTester::mount(
+        box_node(RenderTable::new(2))
+            .child(box_node(RenderColoredBox::red(20.0, 10.0)))
+            .child(box_node(RenderColoredBox::green(30.0, 15.0)))
+            .child(box_node(RenderColoredBox::blue(20.0, 25.0)))
+            .child(box_node(RenderColoredBox::red(30.0, 5.0))),
+    )
+    .with_size(Size::new(px(100.0), px(100.0)))
+    .run_layout();
+
+    let min_h = run.min_intrinsic_height(run.root(), 100.0);
+    let max_h = run.max_intrinsic_height(run.root(), 100.0);
+
+    assert_eq!(
+        min_h, 40.0,
+        "row 0 max-height 15 + row 1 max-height 25 = 40 (per-row max, summed)",
+    );
+    assert_eq!(
+        max_h, min_h,
+        "table.dart quirk: computeMaxIntrinsicHeight returns \
+         computeMinIntrinsicHeight verbatim, not an independent formula",
     );
 }
 

--- a/crates/flui-rendering/src/pipeline/handle.rs
+++ b/crates/flui-rendering/src/pipeline/handle.rs
@@ -263,6 +263,25 @@ impl RepaintHandle {
         self.handle
             .request_mark_dirty(self.id, self.depth, DirtyKind::Layout)
     }
+
+    /// Requests a compositing-bits update of the bound node on the next
+    /// frame and wakes the platform. Callable from any thread.
+    ///
+    /// This is the verb an object whose compositing requirement depends on
+    /// out-of-band state (e.g. an animated alpha crossing the
+    /// layered/unlayered threshold) calls when that threshold crosses, so
+    /// the owner's compositing-bits walk revisits this node on the next
+    /// frame.
+    ///
+    /// # Errors
+    ///
+    /// [`SendError::ChannelFull`] under backpressure (back off and
+    /// retry), [`SendError::OwnerGone`] once the pipeline owner is
+    /// dropped.
+    pub fn mark_needs_compositing_bits_update(&self) -> Result<(), SendError> {
+        self.handle
+            .request_mark_dirty(self.id, self.depth, DirtyKind::Compositing)
+    }
 }
 
 #[cfg(test)]
@@ -303,6 +322,21 @@ mod tests {
         assert_eq!(req.id, id(7));
         assert_eq!(req.depth, 3);
         assert_eq!(req.kind, DirtyKind::Layout);
+    }
+
+    #[test]
+    fn repaint_handle_mark_needs_compositing_bits_update_round_trips_as_compositing_kind() {
+        let (pipeline_handle, rx) = pair(4);
+        let repaint_handle = RepaintHandle::new(pipeline_handle, id(9), 5);
+
+        repaint_handle
+            .mark_needs_compositing_bits_update()
+            .expect("first send must succeed");
+
+        let req = rx.try_recv().expect("receiver should observe the request");
+        assert_eq!(req.id, id(9));
+        assert_eq!(req.depth, 5);
+        assert_eq!(req.kind, DirtyKind::Compositing);
     }
 
     #[test]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ This roadmap sits on top of [`FOUNDATIONS.md`](FOUNDATIONS.md) — the architect
 |---|---|
 | Core.0 — spine to spec | ✅ **Complete.** Pipeline phases wired and tested, keyed reconciliation production-wired, contracts locked, gate green. |
 | Core.1 — vertical slice | ✅ Slice widgets, contract validation, combined demo app + acceptance tests, parity ports, frame evidence, drag-to-scroll — all delivered. |
-| Core.2 — render-object catalog | ◐ **77 of ~80** objects built with harness tests in `crates/flui-objects`; `RenderAnimatedOpacity`/`RenderSliverAnimatedOpacity` and exit verification remain. |
+| Core.2 — render-object catalog | ✅ **79 of ~80** objects built with harness tests in `crates/flui-objects`, incl. `RenderAnimatedOpacity`/`RenderSliverAnimatedOpacity`; exit verification (scrolling test, intrinsics audit, coverage ≥80%) met. |
 | Business.1 — widget catalog | ◐ Every named catalog widget implemented and integration-tested; **fidelity** (ported parity corpus) and named `Hero` gaps remain. |
 | Catalog.1 — Material ∥ Cupertino | ✗ Not started — `flui-material`, `flui-cupertino`, `flui-localizations` do not exist yet. |
 | App.1 — application integration | ◐ `run_app`, both bindings, and a wake-driven frame loop exist; true vsync pacing, IME, and the facade crate remain. |
@@ -36,7 +36,7 @@ The target is **full parity with released Flutter** — every framework package,
 | `semantics` | 7.9k | ~70% | Cross.H |
 | `animation` | 5.3k | ~85% | Core.1 (active workspace member) |
 | `painting` | 24.9k | ~60% | Core.0 → Core.2 |
-| `rendering` | 52.1k | machine ~90%; catalog **77/~80 harness-tested** (`crates/flui-objects`) | Core.2 (near-complete) |
+| `rendering` | 52.1k | machine ~90%; catalog **79/~80 harness-tested** (`crates/flui-objects`) | Core.2 ✅ |
 | `widgets` | 157.4k | spine ~85%; catalog built (est. ~70% coverage), **fidelity partial** | Business.1 (fidelity) |
 | `services` | 30.2k | ~40% | App.1 + Cross.P (dissolved into `flui-platform`) |
 | `material` | 210.8k | ~1% | Catalog.1 |
@@ -175,23 +175,29 @@ Each phase states: **Goal**, **Status**, what was **Delivered** (for closed work
 
 ---
 
-## Core.2 — Render-object catalog  *(was Phase 2)* — ◐ NEAR-COMPLETE
+## Core.2 — Render-object catalog  *(was Phase 2)* — ✅ COMPLETE
 
 **Goal.** Build the ~80-object render catalog. Every widget is a thin configuration object over a render object — this was the hidden bottleneck under the widget catalog, and it has been substantially cleared.
 
 **Where it lives.** The catalog is the dedicated **`crates/flui-objects`** crate (extracted out of `flui-rendering` — the machine and the catalog are now separate crates). `flui-rendering` keeps only machine types (`RenderTree`, `RenderState`, `RenderView`, `RenderTester`, …).
 
-**Delivered.** **77 exported render-object types** (72 concrete structs plus type aliases such as the `RenderClipRect`/`RRect`/`Oval`/`Path` family over a generic clip base), enumerated in the `RENDER_OBJECT_TYPES` harness catalog (`crates/flui-objects/tests/render_object_harness.rs`) whose CI guard asserts the list matches the crate's `pub use` exports, with per-type `harness_*` tests. Every family the phase named is implemented:
+**Delivered.** **79 exported render-object types** (74 concrete structs plus type aliases such as the `RenderClipRect`/`RRect`/`Oval`/`Path` family over a generic clip base), enumerated in the `RENDER_OBJECT_TYPES` harness catalog (`crates/flui-objects/tests/render_object_harness.rs`) whose CI guard asserts the list matches the crate's `pub use` exports, with per-type `harness_*` tests. Every family the phase named is implemented:
 - **Box layout** — `RenderStack`/`RenderIndexedStack`, `RenderConstrainedBox`/`RenderLimitedBox`, `RenderAspectRatio`, `RenderBaseline`, `RenderWrap`, `RenderFlow`, `RenderTable`, `RenderFractionallySizedBox`. (Flutter's `Positioned` is a `ParentDataWidget` over `RenderStack`, not a render object — nothing is missing there.)
-- **Paint effects** — the clip family, `RenderDecoratedBox`, `RenderOpacity` (+ `RenderSliverOpacity`), the `RenderTransform` family (+ `RenderFractionalTranslation`, `RenderRotatedBox`), `RenderCustomPaint`, `RenderRepaintBoundary`, `RenderPhysicalModel`/`Shape`.
-- **Slivers** — `RenderViewport` + `RenderShrinkWrappingViewport`, `RenderSliverList`/`Grid` (each with lazy variants), `Padding`/`FillViewport`/`ToBoxAdapter`, `RenderSliverFixedExtentList`, three `FillRemaining` variants, four persistent-header variants, `Offstage`/`Opacity`/`IgnorePointer`.
+- **Paint effects** — the clip family, `RenderDecoratedBox`, `RenderOpacity` (+ `RenderSliverOpacity`), `RenderAnimatedOpacity` (+ `RenderSliverAnimatedOpacity`), the `RenderTransform` family (+ `RenderFractionalTranslation`, `RenderRotatedBox`), `RenderCustomPaint`, `RenderRepaintBoundary`, `RenderPhysicalModel`/`Shape`.
+- **Slivers** — `RenderViewport` + `RenderShrinkWrappingViewport`, `RenderSliverList`/`Grid` (each with lazy variants), `Padding`/`FillViewport`/`ToBoxAdapter`, `RenderSliverFixedExtentList`, three `FillRemaining` variants, four persistent-header variants, `Offstage`/`Opacity`/`AnimatedOpacity`/`IgnorePointer`.
 - **Input / leaf** — `RenderParagraph` + `RenderEditable`, `RenderImage`, `RenderMouseRegion`, `RenderListBody`, and Flutter's `RenderPointerListener` ported as **`RenderListener`**.
+- **`RenderAnimatedOpacity`/`RenderSliverAnimatedOpacity`** (the last named gap) ported the mixin's alpha-caching/dirty-marking contract with one **documented divergence**: Flutter's mixin is a retained-layer node — a tick calls `updateCompositedLayer` to blend the existing `OpacityLayer` in place, so it never repaints the child subtree, only re-composites. FLUI has no composited-layer-update machinery (`updateCompositedLayer`/`markNeedsCompositedLayerUpdate` do not exist anywhere in `flui-rendering`/`flui-objects`), so a tick here marks a full repaint whenever the effective alpha changes, plus a compositing-bits mark when it crosses the layered/unlayered boundary. This is a real, currently-open pipeline gap, not a hidden shortcut — tracked as a named Cross.H item below, not swept back into Core.2.
 
-**Remains.**
-- `RenderAnimatedOpacity` and `RenderSliverAnimatedOpacity` (the only named gaps found by audit).
-- Exit verification: a sliver integration test scrolling a 1,000-item list with correct lazy layout; intrinsic-size tests where applicable across the catalog; `flui-objects`/`flui-rendering` coverage ≥ 80% via `just coverage`.
+**Exit verification (all met).**
+- **Scrolling.** `scrolling_lazy_sliver_keeps_materialized_band_bounded_and_windowed` (`crates/flui-objects/tests/harness_snapshot.rs`) scrolls a 1 000-item `RenderSliverListLazy` from the head to a mid offset (~item 500) to the tail, asserting at each stop that the materialized child band is both bounded (laziness — distant items are never attached) and correctly windowed (the band tracks the scroll position). Companion to the existing offset-0-only `snapshot_lazy_sliver_visible_band`.
+- **Intrinsics audit.** Catalog families with non-trivial intrinsic-size logic: `flex` (harness-covered), `table` (column-width unit tests covered width; **added** a min/max-intrinsic-height test that also pins the oracle's own documented quirk — `computeMaxIntrinsicHeight` returns `computeMinIntrinsicHeight` verbatim), `wrap` (harness covered max-width only; **added** min-width and vertical-axis max-height tests), `aspect_ratio` (already covered by in-file unit tests), `list_body` (had zero intrinsic coverage; **added** width and height tests — the height test also pins a second oracle quirk: `computeMaxIntrinsicHeight`/`computeMinIntrinsicWidth` share the identical axis-keyed sum/max switch, so height does not independently reason about "am I the main or cross axis"), `paragraph` (already covered by in-file unit tests). 5 tests added (audit cap), 0 skipped as low-value.
+- **Coverage** (`cargo llvm-cov --summary-only -p flui-objects -p flui-rendering`, 2026-07-14): `flui-objects` **81.41%** line coverage, `flui-rendering` **83.27%** line coverage — both ≥ the 80% Core threshold.
 
-**Parity delta.** `rendering` catalog → ~95% coverage (mechanical count 77/~80); `painting` advanced correspondingly.
+**Deliberately deferred (named, not silently dropped):**
+- **Composited-layer pipeline gap** (no `updateCompositedLayer`/retained-layer alpha-blend-without-repaint path) — tracked under Cross.H below; it is a `flui-rendering` machine capability, not specific to the opacity pair, and would benefit any future retained-layer effect.
+- **`AnimatedOpacity` widget rewiring** — the `flui-widgets` `AnimatedOpacity` widget still drives its child through an `AnimatedBuilder` rebuild loop, not through `RenderAnimatedOpacity`; tracked under Business.1 below (the render-view-wrapper pattern `AnimatedSizeRenderView` already establishes is the intended shape).
+
+**Parity delta.** `rendering` catalog → ~95% coverage (mechanical count 79/~80); `painting` advanced correspondingly.
 
 ---
 
@@ -206,6 +212,7 @@ Each phase states: **Goal**, **Status**, what was **Delivered** (for closed work
 - **Named `Hero` gaps** — user-gesture flights and cross-navigator flights, tracked in `ROADMAP-TRACKER.md` B1.4 / ADR-0021.
 - **Scrollable composition + content-dimension feedback** — `Scrollable` currently hardwires `SingleChildScrollView` with no offset feed-through to viewport widgets (`ListView`/`GridView`), and nothing feeds `ViewportOffset` content dimensions back to `ScrollController`, so every consumer must hand-wire extents. The scroll family needs the builder-style composition and the extent feedback loop before the catalog can claim scroll parity.
 - **`flui-assets` ↔ `Image` integration verification** — the crate is an active workspace member; confirm network + asset image and font loading through the `Image` widget end-to-end.
+- **`AnimatedOpacity` render-object rewiring** — the widget still drives its `Opacity` child through an `AnimatedBuilder` rebuild loop rather than the persistent `RenderAnimatedOpacity` Core.2 delivered; adopt the `AnimatedSizeRenderView` render-view-wrapper pattern (`crates/flui-widgets/src/animated/animated_size.rs:239-272`) to wire it through directly.
 - Exit criteria to demonstrate: a non-trivial sample app built entirely from `flui-widgets` (no raw render objects) with a scrolling list, gesture button, implicit animation, and navigated route; `flui-widgets` coverage ≥ 85% via `just coverage`.
 
 **Parity delta.** `widgets` catalog coverage largely in place; parity completes when the ported corpus passes.
@@ -277,7 +284,7 @@ Bundled into Core.0 because they were cheap-now / catalog-wide-later: the `flui-
 
 ### Cross.H — Foundation hardening
 
-**Goal.** The standing quality discipline — close the remaining systemic defects as the owning crates are next touched: the layer lifecycle protocol (gates App.1), parallel-type collapses, the `BuildContext` inherited-data hole (**gates Catalog.1** — `Theme` depends on it), the `TreeWrite::remove` cascade, Ticker lifecycle, and feature-gating of speculative scaffolding. Focus/tab navigation — originally on this list — has since landed in `flui-widgets` (`Focus`/`FocusScope`/`Actions`/`Shortcuts`, with tests). **Known gap:** gesture settings do not adapt to pointer type — `DragGestureRecognizer` always uses touch slop (18px) even for mouse input, where Flutter differentiates precise-pointer slop (surfaced by Core.1's drag-to-scroll work, 2026-07-14). **Entry:** continuous from Core.0. **Exit:** the foundation is declared stable — all critical-tier defects closed, second-tier addressed opportunistically. This is the audit-and-repair methodology as permanent discipline, not a bounded effort.
+**Goal.** The standing quality discipline — close the remaining systemic defects as the owning crates are next touched: the layer lifecycle protocol (gates App.1), parallel-type collapses, the `BuildContext` inherited-data hole (**gates Catalog.1** — `Theme` depends on it), the `TreeWrite::remove` cascade, Ticker lifecycle, and feature-gating of speculative scaffolding. Focus/tab navigation — originally on this list — has since landed in `flui-widgets` (`Focus`/`FocusScope`/`Actions`/`Shortcuts`, with tests). **Known gap:** gesture settings do not adapt to pointer type — `DragGestureRecognizer` always uses touch slop (18px) even for mouse input, where Flutter differentiates precise-pointer slop (surfaced by Core.1's drag-to-scroll work, 2026-07-14). **Known gap:** no composited-layer-update pipeline path — Flutter's `RenderObject.updateCompositedLayer`/`markNeedsCompositedLayerUpdate` let a retained layer (e.g. `OpacityLayer`) re-blend in place on a tick without repainting its subtree; FLUI has no equivalent anywhere in `flui-rendering`/`flui-objects`, so every such tick (currently `RenderAnimatedOpacity`/`RenderSliverAnimatedOpacity`, Core.2, 2026-07-14) pays a full repaint instead of a compositor-only blend — a documented, currently-accepted performance divergence, not a correctness one. **Entry:** continuous from Core.0. **Exit:** the foundation is declared stable — all critical-tier defects closed, second-tier addressed opportunistically. This is the audit-and-repair methodology as permanent discipline, not a bounded effort.
 
 ---
 
@@ -285,11 +292,10 @@ Bundled into Core.0 because they were cheap-now / catalog-wide-later: the `flui-
 
 ```
 MAIN VERTICAL (sequential — Core → Business → Catalog → App):
-  Core.0 ✅ ── Core.1 ✅ ── Core.2 ◐ ── Business.1 ◐ ── Catalog.1 ✗ ── App.1 ◐
-                            (77/~80      (built;        (Material ∥     (partial:
+  Core.0 ✅ ── Core.1 ✅ ── Core.2 ✅ ── Business.1 ◐ ── Catalog.1 ✗ ── App.1 ◐
+                            (79/~80      (built;        (Material ∥     (partial:
                              objects;     fidelity +     Cupertino —     vsync, IME,
-                             2 named      Hero gaps)     not started)    facade left)
-                             gaps)
+                             exit met)    Hero gaps)     not started)    facade left)
 
 CROSS layer — continuous, with cross-track gates marked:
   Cross.P (platform)  ═════════════════════════════════════► joins App.1
@@ -315,7 +321,7 @@ Within phases: Core.2's render-object families parallelize (box / sliver / paint
 | # | Risk | Mitigation |
 |---|---|---|
 | R1 | Widget catalog built on a spine not yet at target spec — defects compound across ~80 widgets, silently | **Realized as designed:** Core.0 was a hard gate with objective exit tests and is met; Core.1's vertical slice re-proved the spine under live load before breadth |
-| R2 | Render-object catalog under-scoped — Business.1 stalls mid-widget on a missing render object | The widget → render-object checklist ([`research/widget-renderobject-map.md`](research/widget-renderobject-map.md)) was built before the catalog; 77/~80 objects now exist with harness tests |
+| R2 | Render-object catalog under-scoped — Business.1 stalls mid-widget on a missing render object | The widget → render-object checklist ([`research/widget-renderobject-map.md`](research/widget-renderobject-map.md)) was built before the catalog; Core.2 is complete — 79/~80 objects exist with harness tests |
 | R3 | A contract flaw discovered inside `flui-material` (210k LOC) = catastrophic rework | Core.1's slice exercised every contract on live code; Catalog.1 starts only after the contract-validation report ([`research/2026-06-30-phase1-contract-validation.md`](research/2026-06-30-phase1-contract-validation.md)) is clean and Core.1's residues close |
 | R4 | `flui-material` is one monolithic terminal phase | Phased internally by component family (theming → buttons → inputs → navigation → data); ships in increments; runs ∥ `flui-cupertino` |
 | R5 | `Scene`/`DrawCommand` contract drift breaks the parallel engine track | The contract is frozen with a documented change protocol (`docs/designs/2026-06-30-scene-drawcommand-contract.md`); any later change is a coordinated cross-track change |


### PR DESCRIPTION
## What this delivers

The third roadmap unit in the loop (after #344, #345): **Core.2 — render-object catalog — flips to ✅ COMPLETE.**

**The pair.** `RenderAnimatedOpacity` + `RenderSliverAnimatedOpacity` — the catalog's last two named gaps — as single-child proxies over the existing opacity contract, with an injected `AnimationController` whose tick recomputes alpha and marks paint + compositing bits on layered-boundary crossings. Oracle fetched at Flutter tag 3.44.0 (`RenderAnimatedOpacityMixin`): Flutter 3.x updates a retained composited layer without repainting the subtree — FLUI has no composited-layer path, so this ports the paint-marking semantics as a **documented divergence**, named in module docs and tracked in the roadmap (Cross.H), not papered over. `RepaintHandle` gains the missing `mark_needs_compositing_bits_update()` verb (the dirty kind existed and drained; no public verb reached it).

**Review-hardened.** The maintainer review caught a real correctness bug before merge: the tick committed the alpha cache before sending dirty marks and swallowed send errors — a full/closed channel would strand a settled animation's final frame forever. Fixed by send-first/store-on-success ordering, pinned by a regression test that exercises a real closed-channel failure (shown red under the old ordering: cache wrongly advanced to 128). Also fixed: the box variant's compositing-bits mark was inert (`always_needs_compositing` now overridden off the same `0 < alpha < 255` predicate the opacity siblings establish, with the predicate choice vs Flutter's `alpha > 0` documented).

**Exit criteria, verified not asserted.** The 1,000-item lazy-sliver test now genuinely **scrolls** (head/mid/tail offsets, visible-band membership + non-materialization asserted at each stop — the prior snapshot never left offset 0). Intrinsics audit added table/wrap/list_body tests; the list_body expectations pin Flutter's own axis-switch quirk (first draft "fixed" the intuitive formula, the fetched oracle proved Flutter does the same switch — the test now guards against that future "obvious fix"). Coverage: **81.41%** (flui-objects) / **83.27%** (flui-rendering) against the ≥80% bar.

## Evidence

- flui-objects 772/772 · flui-rendering 758/758 (+2 regression tests) · workspace 6316/6316 · doctests green
- fmt, clippy `-D warnings` (both crates + workspace), port-check (22 triggers), `RUSTDOCFLAGS="-D warnings" cargo doc` on both crates
- Review trail: adversarial plan review (RESHAPE — caught the composited-layer mechanism mismatch and the missing pipeline verb before code) → build with genuine red evidence → maintainer review NEEDS WORK (the stale-frame bug + 3 more) → fixes → re-review **COMPLETE (merge)**, gates re-verified by the reviewer independently

## Follow-ups (filed in the roadmap)

- Composited-layer update path (tick-without-repaint) — Cross.H
- `AnimatedOpacity` widget adoption of the new render object (currently zero-consumer catalog entry; widget still uses `AnimatedBuilder` rebuilds) — Business.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)