### PR TITLE
feat(widgets): gesture-driven route transitions (swipe-back) substrate

### DIFF
--- a/crates/flui-animation/src/controller.rs
+++ b/crates/flui-animation/src/controller.rs
@@ -1,6 +1,7 @@
 //! `AnimationController` - The primary animation driver.
 
 use crate::animation::{Animation, AnimationDirection, StatusCallback};
+use crate::curve::Curve;
 use crate::error::AnimationError;
 use crate::simulation::{Simulation, SpringDescription, SpringSimulation, SpringType, Tolerance};
 use crate::status::AnimationStatus;
@@ -187,6 +188,22 @@ struct AnimationControllerInner {
 
     /// Active physics simulation (if using fling/animate_with).
     simulation: Option<Box<dyn Simulation>>,
+
+    /// Per-run easing curve for a time-based `animate_to_curved`/
+    /// `animate_back_curved` run (`None` = linear). Cleared by
+    /// [`clear_run_modes`](AnimationControllerInner::clear_run_modes) so a
+    /// later plain `forward`/`reverse`/`animate_to` run does not inherit a
+    /// stale curve. Flutter parity: `AnimationController._animateToInternal`
+    /// threads `curve` straight into `_InterpolationSimulation`.
+    run_curve: Option<Arc<dyn Curve + Send + Sync>>,
+
+    /// Status most recently delivered to status listeners. The emission seam
+    /// ([`take_status_change`](AnimationControllerInner::take_status_change))
+    /// compares against this before firing, so a call that leaves `status`
+    /// unchanged (e.g. `set_value` re-asserting the same directional status
+    /// every frame of a gesture drag) does not re-notify. Flutter parity:
+    /// `AnimationController._lastReportedStatus` / `_checkStatusChanged`.
+    last_reported_status: AnimationStatus,
 }
 
 impl AnimationController {
@@ -276,6 +293,8 @@ impl AnimationController {
             repeat_count: None,
             repeat_done: 0,
             simulation: None,
+            run_curve: None,
+            last_reported_status: AnimationStatus::Dismissed,
         };
 
         Ok(Self {
@@ -422,10 +441,7 @@ impl AnimationController {
         let mut inner = self.inner.lock();
         Self::check_disposed(&inner)?;
 
-        inner.clear_run_modes();
-        if let Some(ticker) = &mut inner.ticker {
-            ticker.stop();
-        }
+        inner.stop_running();
 
         let status = inner.settled_status_directed();
         inner.status = status;
@@ -452,10 +468,12 @@ impl AnimationController {
             ticker.stop();
         }
 
-        let callbacks = Self::snapshot_status_listeners(&inner);
+        let callbacks = inner.take_status_change();
         drop(inner);
         self.notifier.notify_listeners();
-        Self::fire_status(&callbacks, AnimationStatus::Dismissed);
+        if let Some(callbacks) = callbacks {
+            Self::fire_status(&callbacks, AnimationStatus::Dismissed);
+        }
         Ok(())
     }
 
@@ -480,7 +498,7 @@ impl AnimationController {
         target: f32,
         duration: Option<Duration>,
     ) -> Result<(), AnimationError> {
-        self.drive_to(target, duration, false)
+        self.drive_to(target, duration, false, None)
     }
 
     /// Animate back to a specific value, defaulting to the reverse duration.
@@ -497,12 +515,46 @@ impl AnimationController {
         target: f32,
         duration: Option<Duration>,
     ) -> Result<(), AnimationError> {
-        self.drive_to(target, duration, true)
+        self.drive_to(target, duration, true, None)
     }
 
-    /// Shared driver for [`animate_to`](Self::animate_to)/[`animate_back`](Self::animate_back):
-    /// linearly interpolate from the current value to `target`, picking
-    /// direction from their order. `prefer_reverse_duration` makes the
+    /// Like [`animate_to`](Self::animate_to), but eases the run through
+    /// `curve` instead of running linearly. Flutter parity:
+    /// `AnimationController.animateTo(target, duration: ..., curve: ...)`,
+    /// which threads `curve` into `_InterpolationSimulation`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnimationError::Disposed`] if the controller has been disposed.
+    pub fn animate_to_curved(
+        &self,
+        target: f32,
+        duration: Option<Duration>,
+        curve: Arc<dyn Curve + Send + Sync>,
+    ) -> Result<(), AnimationError> {
+        self.drive_to(target, duration, false, Some(curve))
+    }
+
+    /// Like [`animate_back`](Self::animate_back), but eases the run through
+    /// `curve` instead of running linearly. Flutter parity:
+    /// `AnimationController.animateBack(target, duration: ..., curve: ...)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnimationError::Disposed`] if the controller has been disposed.
+    pub fn animate_back_curved(
+        &self,
+        target: f32,
+        duration: Option<Duration>,
+        curve: Arc<dyn Curve + Send + Sync>,
+    ) -> Result<(), AnimationError> {
+        self.drive_to(target, duration, true, Some(curve))
+    }
+
+    /// Shared driver for [`animate_to`](Self::animate_to)/[`animate_back`](Self::animate_back)
+    /// and their `_curved` variants: interpolate from the current value to
+    /// `target`, picking direction from their order and easing through
+    /// `curve` (`None` = linear). `prefer_reverse_duration` makes the
     /// `None`-duration default the reverse duration regardless of the run's
     /// direction (the `animate_back` contract).
     fn drive_to(
@@ -510,12 +562,14 @@ impl AnimationController {
         target: f32,
         duration: Option<Duration>,
         prefer_reverse_duration: bool,
+        curve: Option<Arc<dyn Curve + Send + Sync>>,
     ) -> Result<(), AnimationError> {
         let mut inner = self.inner.lock();
         Self::check_disposed(&inner)?;
 
         let target = target.clamp(inner.lower_bound, inner.upper_bound);
         inner.clear_run_modes();
+        inner.run_curve = curve;
         inner.start_value = inner.value;
         inner.target_value = target;
         inner.direction = if target >= inner.value {
@@ -567,10 +621,12 @@ impl AnimationController {
         }
         let status = inner.settled_status_directed();
         inner.status = status;
-        let callbacks = Self::snapshot_status_listeners(&inner);
+        let callbacks = inner.take_status_change();
         drop(inner);
         self.notifier.notify_listeners();
-        Self::fire_status(&callbacks, status);
+        if let Some(callbacks) = callbacks {
+            Self::fire_status(&callbacks, status);
+        }
     }
 
     /// Repeat the animation, bouncing if `reverse` is true. Repeats forever.
@@ -874,10 +930,12 @@ impl AnimationController {
             }
             let status = inner.settled_status_directed();
             inner.status = status;
-            let callbacks = Self::snapshot_status_listeners(&inner);
+            let callbacks = inner.take_status_change();
             drop(inner);
             self.notifier.notify_listeners();
-            Self::fire_status(&callbacks, status);
+            if let Some(callbacks) = callbacks {
+                Self::fire_status(&callbacks, status);
+            }
         } else {
             drop(inner);
             self.notifier.notify_listeners();
@@ -898,7 +956,17 @@ impl AnimationController {
             narrow_f32((cycle / duration.as_secs_f64()).clamp(0.0, 1.0))
         };
         let range = inner.target_value - inner.start_value;
-        inner.value = inner.start_value + range * t;
+        // Flutter parity: `_InterpolationSimulation.x` special-cases the
+        // endpoints to the exact begin/end value and only runs the curve
+        // through the interior, so a curve that overshoots slightly at its
+        // bounds (e.g. an elastic curve) never reports outside [start, target].
+        let eased_t = match (&inner.run_curve, t) {
+            (_, 0.0) => 0.0,
+            (_, t) if t >= 1.0 => 1.0,
+            (Some(curve), t) => curve.transform(t),
+            (None, t) => t,
+        };
+        inner.value = inner.start_value + range * eased_t;
 
         if t < 1.0 {
             drop(inner);
@@ -963,10 +1031,12 @@ impl AnimationController {
                 inner.is_repeating = false;
                 let status = inner.settled_status_directed();
                 inner.status = status;
-                let callbacks = Self::snapshot_status_listeners(&inner);
+                let callbacks = inner.take_status_change();
                 drop(inner);
                 self.notifier.notify_listeners();
-                Self::fire_status(&callbacks, status);
+                if let Some(callbacks) = callbacks {
+                    Self::fire_status(&callbacks, status);
+                }
                 return;
             }
 
@@ -977,14 +1047,18 @@ impl AnimationController {
             // `begin_next_repeat_cycle` is an idempotent reset in restart mode
             // and a pure direction flip in bounce mode, so only the parity of the
             // retired-cycle count matters — collapse N cycles to at most one
-            // transition rather than looping.
-            let status_changed = if inner.repeat_reverse {
-                cycles % 2 == 1 && inner.begin_next_repeat_cycle()
+            // transition rather than looping. In bounce mode an even retired
+            // count cancels out (net no flip), so the cycle-begin step is
+            // skipped entirely rather than calling it twice.
+            if inner.repeat_reverse {
+                if cycles % 2 == 1 {
+                    inner.begin_next_repeat_cycle();
+                }
             } else {
-                inner.begin_next_repeat_cycle()
-            };
+                inner.begin_next_repeat_cycle();
+            }
             let status = inner.status;
-            let callbacks = status_changed.then(|| Self::snapshot_status_listeners(&inner));
+            let callbacks = inner.take_status_change();
             drop(inner);
             self.notifier.notify_listeners();
             if let Some(callbacks) = callbacks {
@@ -999,19 +1073,28 @@ impl AnimationController {
         }
         let status = inner.settled_status_keep_direction();
         inner.status = status;
-        let callbacks = Self::snapshot_status_listeners(&inner);
+        let callbacks = inner.take_status_change();
         drop(inner);
         self.notifier.notify_listeners();
-        Self::fire_status(&callbacks, status);
+        if let Some(callbacks) = callbacks {
+            Self::fire_status(&callbacks, status);
+        }
     }
 
     /// Set the value directly without animating; recomputes status and notifies.
+    ///
+    /// Stops any active run first (Flutter parity: `AnimationController`'s
+    /// `value=` setter calls `stop()` before `_internalSetValue`) — otherwise
+    /// a live ticker keeps re-registering itself with the scheduler and the
+    /// next frame recomputes the value from the stale run's `start_value`/
+    /// `target_value`, silently overwriting what was just set.
     ///
     /// A `NaN` input is canonicalized to the lower bound: Rust's `clamp`
     /// propagates `NaN`, which would otherwise poison every downstream
     /// curve/tween evaluation for the rest of the controller's life.
     pub fn set_value(&self, value: f32) {
         let mut inner = self.inner.lock();
+        inner.stop_running();
         let value = if value.is_nan() {
             tracing::warn!(
                 "set_value(NaN) canonicalized to lower bound; drive the controller with finite values"
@@ -1023,10 +1106,12 @@ impl AnimationController {
         inner.value = value.clamp(inner.lower_bound, inner.upper_bound);
         let status = inner.settled_status_keep_direction();
         inner.status = status;
-        let callbacks = Self::snapshot_status_listeners(&inner);
+        let callbacks = inner.take_status_change();
         drop(inner);
         self.notifier.notify_listeners();
-        Self::fire_status(&callbacks, status);
+        if let Some(callbacks) = callbacks {
+            Self::fire_status(&callbacks, status);
+        }
     }
 
     /// **CRITICAL:** Dispose when done to prevent leaks.
@@ -1088,17 +1173,6 @@ impl AnimationController {
         }
     }
 
-    /// Snapshot status callbacks so they can be fired after the lock is dropped.
-    fn snapshot_status_listeners(
-        inner: &AnimationControllerInner,
-    ) -> SmallVec<[StatusCallback; 4]> {
-        inner
-            .status_listeners
-            .iter()
-            .map(|(_, cb)| Arc::clone(cb))
-            .collect()
-    }
-
     /// Fire status callbacks. MUST be called with no controller lock held.
     fn fire_status(callbacks: &[StatusCallback], status: AnimationStatus) {
         for cb in callbacks {
@@ -1110,22 +1184,55 @@ impl AnimationController {
     ///
     /// Used by the run-start methods, which change status but not value.
     fn emit_status_after_unlock(
-        inner: parking_lot::MutexGuard<'_, AnimationControllerInner>,
+        mut inner: parking_lot::MutexGuard<'_, AnimationControllerInner>,
         status: AnimationStatus,
     ) {
-        let callbacks = Self::snapshot_status_listeners(&inner);
+        let callbacks = inner.take_status_change();
         drop(inner);
-        Self::fire_status(&callbacks, status);
+        if let Some(callbacks) = callbacks {
+            Self::fire_status(&callbacks, status);
+        }
     }
 }
 
 impl AnimationControllerInner {
-    /// Clear repeat/simulation/per-run-duration modes (used when a new explicit
-    /// run begins).
+    /// Clear repeat/simulation/per-run-duration/curve modes (used when a new
+    /// explicit run begins).
     fn clear_run_modes(&mut self) {
         self.is_repeating = false;
         self.run_duration = None;
         self.simulation = None;
+        self.run_curve = None;
+    }
+
+    /// Halt any active run at the current value: stop the ticker and clear
+    /// simulation/repeat/curve state, without touching `status` or emitting
+    /// any notification. Flutter parity: the raw `AnimationController.stop()`
+    /// that the `value=` setter calls before `_internalSetValue` — it only
+    /// clears `_simulation`/`_lastElapsedDuration` and stops the ticker, it
+    /// does not recompute status (the caller does that separately).
+    fn stop_running(&mut self) {
+        self.clear_run_modes();
+        if let Some(ticker) = &mut self.ticker {
+            ticker.stop();
+        }
+    }
+
+    /// Snapshot the callbacks to fire **iff** `self.status` differs from the
+    /// last-reported status, updating the marker so a later same-status
+    /// emission is suppressed. Every status-emission site in this file
+    /// funnels through this seam — Flutter parity: `_checkStatusChanged`.
+    fn take_status_change(&mut self) -> Option<SmallVec<[StatusCallback; 4]>> {
+        if self.status == self.last_reported_status {
+            return None;
+        }
+        self.last_reported_status = self.status;
+        Some(
+            self.status_listeners
+                .iter()
+                .map(|(_, cb)| Arc::clone(cb))
+                .collect(),
+        )
     }
 
     /// Effective duration for the current run: per-run override, else repeat
@@ -1218,9 +1325,10 @@ impl AnimationControllerInner {
         }
     }
 
-    /// Set up the next repeat cycle; returns whether the status changed (only
-    /// the bounce path flips Forward<->Reverse).
-    fn begin_next_repeat_cycle(&mut self) -> bool {
+    /// Set up the next repeat cycle: flips direction in bounce mode, restarts
+    /// at `repeat_min` otherwise. Status change detection is the caller's
+    /// job, via [`take_status_change`](Self::take_status_change).
+    fn begin_next_repeat_cycle(&mut self) {
         if self.repeat_reverse {
             let was_forward = self.direction == AnimationDirection::Forward;
             self.direction = if was_forward {
@@ -1236,14 +1344,12 @@ impl AnimationControllerInner {
                 self.start_value = self.repeat_min;
                 self.target_value = self.repeat_max;
             }
-            true
         } else {
             self.direction = AnimationDirection::Forward;
             self.status = AnimationStatus::Forward;
             self.value = self.repeat_min;
             self.start_value = self.repeat_min;
             self.target_value = self.repeat_max;
-            false
         }
     }
 }
@@ -1778,5 +1884,176 @@ mod tests {
         let value = c.value();
         c.dispose();
         assert!((value - 0.5).abs() < 1e-3, "value={value}");
+    }
+
+    // ---- set_value parity: stops an active run, change-detects status ----
+
+    #[test]
+    fn set_value_stops_the_ticker_so_a_later_frame_does_not_clobber_it() {
+        // Flutter parity: `AnimationController`'s `value=` setter calls
+        // `stop()` before `_internalSetValue`. Drive a REAL frame through the
+        // scheduler (not a direct `tick_at` call) so this exercises the same
+        // path production code does: an auto-scheduling ticker re-registers
+        // itself with the scheduler every frame while active, and only
+        // `ticker.stop()` deregisters it.
+        let _serial = serial();
+        let scheduler = Arc::new(Scheduler::new());
+        let c = AnimationController::new(Duration::from_millis(100), scheduler.clone());
+
+        c.forward().unwrap();
+        scheduler.execute_frame();
+        assert!(
+            c.value() > 0.0,
+            "sanity: the ticker actually drove a frame, got value={}",
+            c.value()
+        );
+
+        c.set_value(0.5);
+        assert!(
+            !c.is_animating(),
+            "set_value must stop the ticker like Flutter's value= setter"
+        );
+
+        // The "next vsync": if the ticker were still registered, this frame
+        // would recompute the value from the stale run and clobber 0.5.
+        scheduler.execute_frame();
+        assert_eq!(
+            c.value(),
+            0.5,
+            "a frame after set_value must not overwrite the value that was just set"
+        );
+        c.dispose();
+    }
+
+    #[test]
+    fn set_value_reports_completed_status_at_upper_bound() {
+        let _serial = serial();
+        let c = controller(100);
+        c.forward().unwrap();
+        c.set_value(1.0);
+        assert_eq!(c.value(), 1.0);
+        assert_eq!(c.status(), AnimationStatus::Completed);
+        assert!(!c.is_animating(), "set_value stops the run before settling");
+        c.dispose();
+    }
+
+    #[test]
+    fn status_listener_is_not_refired_for_an_unchanged_status() {
+        // Flutter parity: `AnimationController._checkStatusChanged` only
+        // notifies status listeners when `status` actually differs from
+        // `_lastReportedStatus`. Without this, a 120Hz gesture-driven
+        // `set_value` loop (or an interior set_value immediately followed by
+        // `forward()` in the same direction) would re-fire `Forward` every
+        // frame and a one-shot status listener would misfire repeatedly.
+        let _serial = serial();
+        let c = controller(100);
+        let fire_count = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&fire_count);
+        c.add_status_listener(Arc::new(move |_status| {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        // set_value(0.5) is the FIRST transition (Dismissed -> Forward): fires once.
+        c.set_value(0.5);
+        assert_eq!(fire_count.load(Ordering::SeqCst), 1);
+
+        // forward() keeps the same Forward status (direction was already
+        // Forward, value already interior) — must NOT re-fire.
+        c.forward().unwrap();
+        assert_eq!(
+            fire_count.load(Ordering::SeqCst),
+            1,
+            "forward() after an already-Forward set_value must not re-fire the same status"
+        );
+
+        // A second set_value that keeps the status Forward must also not re-fire.
+        c.set_value(0.6);
+        assert_eq!(
+            fire_count.load(Ordering::SeqCst),
+            1,
+            "a same-status set_value must not re-fire (mirrors a 120Hz gesture drag)"
+        );
+
+        // A genuine status change (interior -> Completed) DOES fire.
+        c.set_value(1.0);
+        assert_eq!(fire_count.load(Ordering::SeqCst), 2);
+        c.dispose();
+    }
+
+    // ---- animate_to_curved / animate_back_curved thread a curve through the run ----
+
+    #[test]
+    fn animate_to_curved_eases_through_the_given_curve() {
+        use crate::curve::Curves;
+        let _serial = serial();
+        let c = controller(100);
+        c.animate_to_curved(
+            1.0,
+            Some(Duration::from_millis(100)),
+            Arc::new(Curves::EaseInQuint),
+        )
+        .unwrap();
+        c.tick_at(0.05); // t=0.5 raw
+        let expected = Curves::EaseInQuint.transform(0.5);
+        assert!(
+            (c.value() - expected).abs() < 1e-3,
+            "expected the curve applied at t=0.5: got {}, want {expected}",
+            c.value()
+        );
+        c.tick_at(0.10);
+        assert_eq!(
+            c.value(),
+            1.0,
+            "the curve must land exactly on the target at t=1.0"
+        );
+        assert_eq!(c.status(), AnimationStatus::Completed);
+        c.dispose();
+    }
+
+    #[test]
+    fn plain_animate_to_after_a_curved_run_is_linear_again() {
+        // The per-run curve must not leak into a later plain (linear) run.
+        use crate::curve::Curves;
+        let _serial = serial();
+        let c = controller(100);
+        c.animate_to_curved(
+            1.0,
+            Some(Duration::from_millis(100)),
+            Arc::new(Curves::EaseInQuint),
+        )
+        .unwrap();
+        c.tick_at(0.10);
+        c.reset().unwrap();
+
+        c.animate_to(1.0, Some(Duration::from_millis(100))).unwrap();
+        c.tick_at(0.05);
+        assert!(
+            (c.value() - 0.5).abs() < 1e-3,
+            "a plain animate_to after a curved run must be linear again: got {}",
+            c.value()
+        );
+        c.dispose();
+    }
+
+    #[test]
+    fn animate_back_curved_eases_toward_the_lower_bound() {
+        use crate::curve::Curves;
+        let _serial = serial();
+        let c = controller(100);
+        c.set_value(1.0);
+        c.animate_back_curved(
+            0.0,
+            Some(Duration::from_millis(100)),
+            Arc::new(Curves::EaseInQuint),
+        )
+        .unwrap();
+        c.tick_at(0.05);
+        let expected = 1.0 - Curves::EaseInQuint.transform(0.5);
+        assert!(
+            (c.value() - expected).abs() < 1e-3,
+            "got {}, want {expected}",
+            c.value()
+        );
+        c.dispose();
     }
 }

--- a/crates/flui-animation/src/curved.rs
+++ b/crates/flui-animation/src/curved.rs
@@ -65,25 +65,23 @@ impl<C: Curve + Clone + Send + Sync> CurvedAnimation<C> {
 
         let curve_direction = Arc::new(Mutex::new(None));
         let weak_direction = Arc::downgrade(&curve_direction);
-        let weak_parent = Arc::downgrade(&parent);
         let status_id = parent.add_status_listener(Arc::new(move |status| {
             if let Some(direction) = weak_direction.upgrade() {
                 let mut direction = direction.lock();
                 match status {
-                    // At rest the lock is released; the next run re-captures.
+                    // At rest the lock is released; the next transition re-captures.
                     AnimationStatus::Dismissed | AnimationStatus::Completed => *direction = None,
-                    // First running transition wins; mid-run flips keep it.
+                    // First transition into a running status wins; a same-run
+                    // direction flip (or a directional report from `set_value`
+                    // that isn't a fresh run) keeps the entry curve, matching
+                    // Flutter `CurvedAnimation._updateCurveDirection`: it reads
+                    // only the reported `AnimationStatus`, with no separate
+                    // "is a ticker literally running" check — the controller's
+                    // own change-detected status emission (`_checkStatusChanged`)
+                    // is what makes `get_or_insert` fire exactly once per real
+                    // transition.
                     AnimationStatus::Forward | AnimationStatus::Reverse => {
-                        // Only capture from a LIVE run: a stopped controller's
-                        // set_value at an interior value also reports a
-                        // directional status (Flutter `_internalSetValue`),
-                        // and caching that would pin the wrong curve for the
-                        // next real run (e.g. position at 0.5, then
-                        // reverse()).
-                        let running = weak_parent.upgrade().is_some_and(|p| p.is_animating());
-                        if running {
-                            direction.get_or_insert(status);
-                        }
+                        direction.get_or_insert(status);
                     }
                 }
             }
@@ -309,11 +307,14 @@ mod tests {
     }
 
     #[test]
-    fn interior_set_value_does_not_pin_curve_direction() {
-        // A stopped controller positioned mid-range reports a directional
-        // status (Flutter `_internalSetValue`); that must NOT be captured as
-        // the run direction, or a subsequent reverse() would run on the
-        // forward curve.
+    fn interior_set_value_pins_curve_direction_like_a_live_run() {
+        // Flutter `CurvedAnimation._updateCurveDirection` (3.44.0) reads only
+        // the reported `AnimationStatus` — it has no separate check for
+        // whether a ticker is literally running. So the FIRST transition
+        // into a directional status, even one reported by the `value=`
+        // setter's own `_internalSetValue`, pins the entry direction; a
+        // same-run flip (here, `reverse()` with no intervening Dismissed/
+        // Completed) keeps that pinned curve to avoid a visual discontinuity.
         let scheduler = Arc::new(Scheduler::new());
         let controller = Arc::new(AnimationController::new(
             Duration::from_millis(100),
@@ -325,15 +326,47 @@ mod tests {
         )
         .with_reverse_curve(Curves::EaseInQuint);
 
-        // Position while stopped: fires a Forward status with no live run.
+        // Dismissed -> Forward: the FIRST directional transition, pinning
+        // the forward curve.
         controller.set_value(0.5);
-        // Now genuinely start in reverse: the reverse curve must apply.
+        // reverse() flips the running direction but not the pinned curve.
         let _ = controller.reverse();
+        let value = curved.value();
+        let expected = 0.5; // forward curve is the identity cubic
+        assert!(
+            (value - expected).abs() < 1e-3,
+            "reverse() right after the first set_value keeps the forward \
+             curve pinned from that first transition ({value} vs {expected})"
+        );
+
+        controller.dispose();
+    }
+
+    #[test]
+    fn settling_to_rest_releases_the_curve_direction_pin() {
+        // Flutter `_updateCurveDirection` resets `_curveDirection` to null on
+        // Dismissed/Completed, so a run that genuinely starts fresh after
+        // settling picks its own curve rather than inheriting a stale pin.
+        let scheduler = Arc::new(Scheduler::new());
+        let controller = Arc::new(AnimationController::new(
+            Duration::from_millis(100),
+            scheduler,
+        ));
+        let curved = CurvedAnimation::new(
+            controller.clone() as Arc<dyn Animation<f32>>,
+            Cubic::new(0.0, 0.0, 1.0, 1.0), // y(x) = x
+        )
+        .with_reverse_curve(Curves::EaseInQuint);
+
+        controller.set_value(0.5); // pins forward
+        controller.set_value(1.0); // Completed -> pin released
+        let _ = controller.reverse(); // fresh entry, genuinely Reverse
+        controller.set_value(0.5);
         let value = curved.value();
         let expected = Curves::EaseInQuint.transform(0.5);
         assert!(
             (value - expected).abs() < 1e-3,
-            "a run entered in Reverse after an interior set_value must use \
+            "a run entered in Reverse after settling to Completed must use \
              the reverse curve ({value} vs {expected})"
         );
 

--- a/crates/flui-animation/src/curved.rs
+++ b/crates/flui-animation/src/curved.rs
@@ -8,6 +8,25 @@ use parking_lot::Mutex;
 use std::fmt;
 use std::sync::Arc;
 
+/// Flutter's `CurvedAnimation._updateCurveDirection` (`animations.dart`,
+/// 3.44.0): `_curveDirection = status.isAnimating ? _curveDirection ??
+/// status : null`. Reads only the reported `AnimationStatus` — no separate
+/// "is a ticker literally running" check. Shared by the constructor's seed
+/// call and the status-listener callback so both apply the identical rule.
+fn update_curve_direction(direction: &Mutex<Option<AnimationStatus>>, status: AnimationStatus) {
+    let mut direction = direction.lock();
+    match status {
+        // At rest the lock is released; the next transition re-captures.
+        AnimationStatus::Dismissed | AnimationStatus::Completed => *direction = None,
+        // First transition into a running status wins; a same-run direction
+        // flip (or a directional report from `set_value` that isn't a fresh
+        // run) keeps the entry curve.
+        AnimationStatus::Forward | AnimationStatus::Reverse => {
+            direction.get_or_insert(status);
+        }
+    }
+}
+
 /// An animation that applies a curve to another animation.
 ///
 /// Takes an `Animation<f32>` (typically an `AnimationController`) and applies
@@ -64,26 +83,22 @@ impl<C: Curve + Clone + Send + Sync> CurvedAnimation<C> {
         let parent_sub = link_parent(&parent, &notifier);
 
         let curve_direction = Arc::new(Mutex::new(None));
+        // Flutter's `CurvedAnimation` constructor (`animations.dart`, 3.44.0):
+        // `_updateCurveDirection(parent.status); parent.addStatusListener(...)`
+        // — the seed runs BEFORE the listener is registered. A
+        // `CurvedAnimation` built while the parent is already mid-run (e.g.
+        // constructed against a controller some other code already called
+        // `forward()` on) captures the run's entering direction immediately;
+        // without this seed, `curve_direction` stays `None` until the
+        // listener observes its first transition — and if that first
+        // transition is a mid-run *flip* (`reverse()` right after
+        // construction), the flip itself would be wrongly recorded as the
+        // entering direction instead of preserved as a flip.
+        update_curve_direction(&curve_direction, parent.status());
         let weak_direction = Arc::downgrade(&curve_direction);
         let status_id = parent.add_status_listener(Arc::new(move |status| {
             if let Some(direction) = weak_direction.upgrade() {
-                let mut direction = direction.lock();
-                match status {
-                    // At rest the lock is released; the next transition re-captures.
-                    AnimationStatus::Dismissed | AnimationStatus::Completed => *direction = None,
-                    // First transition into a running status wins; a same-run
-                    // direction flip (or a directional report from `set_value`
-                    // that isn't a fresh run) keeps the entry curve, matching
-                    // Flutter `CurvedAnimation._updateCurveDirection`: it reads
-                    // only the reported `AnimationStatus`, with no separate
-                    // "is a ticker literally running" check — the controller's
-                    // own change-detected status emission (`_checkStatusChanged`)
-                    // is what makes `get_or_insert` fire exactly once per real
-                    // transition.
-                    AnimationStatus::Forward | AnimationStatus::Reverse => {
-                        direction.get_or_insert(status);
-                    }
-                }
+                update_curve_direction(&direction, status);
             }
         }));
         let status_parent = Arc::clone(&parent);
@@ -368,6 +383,43 @@ mod tests {
             (value - expected).abs() < 1e-3,
             "a run entered in Reverse after settling to Completed must use \
              the reverse curve ({value} vs {expected})"
+        );
+
+        controller.dispose();
+    }
+
+    #[test]
+    fn constructor_seeds_curve_direction_from_the_parents_current_status() {
+        // Flutter's `CurvedAnimation` constructor (`animations.dart`, 3.44.0):
+        // `_updateCurveDirection(parent.status); parent.addStatusListener(...)`
+        // — the seed runs BEFORE the listener is registered, so a
+        // `CurvedAnimation` built while the parent is ALREADY mid-run captures
+        // the run's entering direction immediately.
+        let scheduler = Arc::new(Scheduler::new());
+        let controller = Arc::new(AnimationController::new(
+            Duration::from_millis(100),
+            scheduler,
+        ));
+        controller.set_value(0.5);
+        let _ = controller.forward(); // already Forward before CurvedAnimation exists
+
+        let curved = CurvedAnimation::new(
+            controller.clone() as Arc<dyn Animation<f32>>,
+            Cubic::new(0.0, 0.0, 1.0, 1.0), // y(x) = x
+        )
+        .with_reverse_curve(Curves::EaseInQuint);
+
+        // The FIRST transition the listener ever observes is this flip to
+        // Reverse. Without the constructor seed, curve_direction would still
+        // be `None` at this point and would wrongly lock onto Reverse here
+        // instead of preserving the already-Forward entering direction.
+        let _ = controller.reverse();
+        let value = curved.value();
+        let expected = 0.5; // forward curve is the identity cubic — must stay pinned
+        assert!(
+            (value - expected).abs() < 1e-3,
+            "the seeded Forward direction must survive the first observed \
+             flip ({value} vs {expected})"
         );
 
         controller.dispose();

--- a/crates/flui-widgets/src/navigator/back_gesture.rs
+++ b/crates/flui-widgets/src/navigator/back_gesture.rs
@@ -192,11 +192,6 @@ struct BackGestureRuntime {
     /// reading `widget.enabledCallback()` fresh each time.
     enabled: Rc<dyn Fn() -> bool>,
     direction: TextDirection,
-    /// The width a drag fraction is normalized against — Flutter's
-    /// `context.size!.width`. Refreshed every `build` from the incoming
-    /// `BoxConstraints` (`LayoutBuilder`), since FLUI has no
-    /// "my own rendered size" query off `BuildContext`.
-    width: Cell<f32>,
     /// The in-flight gesture, if a drag has started. `None` both before the
     /// first pointer down and after `drag_end`/`drag_cancel`/`dispose` have
     /// consumed it — the multi-touch guard (`Some` blocks a second pointer
@@ -301,15 +296,34 @@ impl BackGestureRuntime {
     /// bookkeeping expects a gesture-stop from), and only if the navigator is
     /// still mounted.
     ///
-    /// A gesture that already reached `drag_end`/`drag_cancel` before this
-    /// runs is not in `self.gesture` anymore (mutually exclusive with
-    /// `finish_drag`'s `take`), so this can never double-report a stop that
-    /// `drag_end`'s own path (immediate or `poll_settle`) already reported.
+    /// Two, not one, cases owe a deferred report here — both leave the
+    /// navigator's gesture count still incremented:
+    ///
+    /// 1. A live drag (finger still down, `self.gesture` is `Some`) that
+    ///    never reached `drag_end`/`drag_cancel` at all.
+    /// 2. A *released* drag whose settle animation is still running
+    ///    (`drag_end` returned `true`, `self.gesture` is already `None` —
+    ///    `finish_drag` always takes it — but `awaiting_settle` is `true`):
+    ///    the route was swept away (e.g. by `push_and_remove_until`) or lost
+    ///    the race between the pop's own settle and this detector's final
+    ///    rebuild before `poll_settle` ever got to observe
+    ///    `!controller.is_animating()`. Checking only `self.gesture` misses
+    ///    this case entirely and leaks the count forever — caught by
+    ///    `dispose_while_awaiting_settle_after_release_returns_the_counter_to_zero`.
+    ///
+    /// Either owes the same deferred `did_stop_user_gesture` Flutter's
+    /// `_CupertinoBackGestureDetectorState.dispose` posts unconditionally
+    /// whenever `_backGestureController != null` — its `null` check happens
+    /// to conflate both cases because `_backGestureController` is not
+    /// separately tracked from "is a release animation still owed a stop"
+    /// there; this port keeps them as two flags (`gesture`/`awaiting_settle`)
+    /// so `poll_settle`'s cheap common case doesn't need a live controller.
     fn dispose_safety_net(&self) {
-        let Some(_gesture) = self.gesture.borrow_mut().take() else {
+        let had_live_gesture = self.gesture.borrow_mut().take().is_some();
+        let was_awaiting_settle = self.awaiting_settle.replace(false);
+        if !had_live_gesture && !was_awaiting_settle {
             return;
-        };
-        self.awaiting_settle.set(false);
+        }
         let navigator = self.navigator.clone();
         match navigator.post_frame_handle() {
             Some(post_frame) => {
@@ -333,10 +347,25 @@ impl BackGestureRuntime {
         }
     }
 
-    /// `self.width`, floored so a zero/negative/unmeasured width never
-    /// divides a finite delta into infinity or NaN.
+    /// The route's own laid-out width — Flutter's `context.size!.width`,
+    /// read straight off `context` in `_handleDragUpdate`/`_handleDragEnd`.
+    /// FLUI has no "my own rendered size" query off `BuildContext`, so this
+    /// reads the page's committed geometry the same way
+    /// `hero_controller.rs`'s `MeasurementPass::run` does: through the
+    /// route's registered subtree and the navigator's render tree, live on
+    /// every call — never cached, so it cannot go stale mid-gesture (e.g.
+    /// across an orientation change). Floored to 1.0 so a genuinely
+    /// unmeasured width (before the very first layout — a state a drag
+    /// cannot start from, since hit-testing itself requires laid-out
+    /// geometry) never divides a delta into infinity or NaN.
     fn normalized_width(&self) -> f32 {
-        self.width.get().max(1.0)
+        let width = self
+            .navigator
+            .route_subtree(self.route)
+            .zip(self.navigator.render_tree())
+            .and_then(|(subtree, owner)| owner.read().box_size(subtree.render_id))
+            .map_or(BACK_GESTURE_WIDTH, |size| size.width.0);
+        width.max(1.0)
     }
 }
 
@@ -409,7 +438,6 @@ impl StatefulView for BackGestureDetector {
                 enabled: Rc::clone(&self.enabled),
                 // No ambient `Directionality` — see the module docs.
                 direction: TextDirection::Ltr,
-                width: Cell::new(BACK_GESTURE_WIDTH.max(1.0)),
                 gesture: RefCell::new(None),
                 awaiting_settle: Cell::new(false),
             }),
@@ -738,7 +766,6 @@ mod tests {
             controller: c,
             enabled: Rc::new(|| true),
             direction: TextDirection::Ltr,
-            width: Cell::new(BACK_GESTURE_WIDTH),
             gesture: RefCell::new(None),
             awaiting_settle: Cell::new(false),
         };
@@ -776,6 +803,137 @@ mod tests {
         );
     }
 
+    /// A one-shot observer that counts `did_stop_user_gesture` calls.
+    #[derive(Default)]
+    struct GestureStopObserver {
+        stops: AtomicUsize,
+    }
+    impl super::super::NavigatorObserver for GestureStopObserver {
+        fn did_stop_user_gesture(&self) {
+            self.stops.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    // ---- full settle after release: did_stop fires, counter clears ----
+
+    /// A released drag settled by genuinely ticking the run out (not
+    /// `set_value`) must report `did_stop_user_gesture` to observers exactly
+    /// once and leave `user_gesture_in_progress()` false — Flutter's
+    /// trailing `AnimationStatusListener` in `dragEnd` firing on the run's
+    /// real terminal status.
+    ///
+    /// Red-check: drop `poll_settle`'s call entirely — `awaiting_settle`
+    /// stays `true` forever and this test hangs on the final assertion
+    /// (never becomes `false`).
+    #[test]
+    fn full_settle_after_release_reports_did_stop_and_clears_the_counter() {
+        let (navigator, _harness, top, c) = mounted_with_transition_route();
+        let observer = Arc::new(GestureStopObserver::default());
+        navigator.add_observer(Arc::clone(&observer) as Arc<dyn super::super::NavigatorObserver>);
+
+        c.set_value(0.49); // <= 0.5, no fling: dragEnd's pop branch
+        let runtime = BackGestureRuntime {
+            navigator: navigator.clone(),
+            route: top,
+            controller: c.clone(),
+            enabled: Rc::new(|| true),
+            direction: TextDirection::Ltr,
+            gesture: RefCell::new(Some(BackGestureController::new(
+                navigator.clone(),
+                top,
+                c.clone(),
+            ))),
+            awaiting_settle: Cell::new(false),
+        };
+
+        runtime.finish_drag(0.0);
+        assert!(
+            runtime.awaiting_settle.get(),
+            "the 350ms reverse run is still going"
+        );
+        assert!(navigator.user_gesture_in_progress());
+
+        // Genuinely tick the run out (not `set_value`) — mid-flight polls
+        // must not report early.
+        c.tick_at(0.10);
+        runtime.poll_settle();
+        assert!(
+            navigator.user_gesture_in_progress(),
+            "must not report stopped before the run actually settles"
+        );
+        assert_eq!(observer.stops.load(Ordering::SeqCst), 0);
+
+        c.tick_at(0.35); // >= the 350ms pacing -> settles to Dismissed
+        assert_eq!(c.status(), flui_animation::AnimationStatus::Dismissed);
+        runtime.poll_settle();
+
+        assert!(
+            !navigator.user_gesture_in_progress(),
+            "the counter must clear once the run genuinely settles"
+        );
+        assert_eq!(
+            observer.stops.load(Ordering::SeqCst),
+            1,
+            "did_stop_user_gesture must fire exactly once"
+        );
+    }
+
+    // ---- dispose while awaiting settle (post-release, pre-poll): counter clears ----
+
+    /// Blocker: `dispose_safety_net` must own the deferred report for a
+    /// gesture that already *released* (so `self.gesture` is `None` —
+    /// `finish_drag` always takes it) but whose settle animation is still
+    /// running when the detector unmounts — e.g. the route was swept away by
+    /// a `push_and_remove_until` mid-settle, or lost the race between the
+    /// pop's own settle and this detector's final rebuild. Checking only
+    /// `self.gesture` (as if a live drag were the only case that owes a
+    /// report) leaks the counter forever.
+    ///
+    /// Red-check: guard `dispose_safety_net` on `self.gesture` alone (drop
+    /// the `awaiting_settle` check) — this test's final assertion fails,
+    /// `user_gesture_in_progress()` stays `true` forever.
+    #[test]
+    fn dispose_while_awaiting_settle_after_release_returns_the_counter_to_zero() {
+        let (navigator, mut harness, top, c) = mounted_with_transition_route();
+        c.set_value(0.49);
+        let runtime = BackGestureRuntime {
+            navigator: navigator.clone(),
+            route: top,
+            controller: c.clone(),
+            enabled: Rc::new(|| true),
+            direction: TextDirection::Ltr,
+            gesture: RefCell::new(Some(BackGestureController::new(
+                navigator.clone(),
+                top,
+                c.clone(),
+            ))),
+            awaiting_settle: Cell::new(false),
+        };
+
+        runtime.finish_drag(0.0);
+        assert!(
+            runtime.gesture.borrow().is_none(),
+            "finish_drag always takes it"
+        );
+        assert!(
+            runtime.awaiting_settle.get(),
+            "the release animation is still running"
+        );
+        assert!(navigator.user_gesture_in_progress());
+
+        // The detector unmounts before the settle run's next poll — no
+        // `poll_settle` call ever ran.
+        assert!(navigator.is_mounted());
+        harness.enter_owner_scope(|| runtime.dispose_safety_net());
+        harness.tick();
+
+        assert!(
+            !navigator.user_gesture_in_progress(),
+            "dispose must clear the counter for a release still awaiting \
+             settle, not only for a still-dragging gesture"
+        );
+    }
+
     // ---- second pointer mid-drag ignored ----
 
     #[test]
@@ -793,7 +951,6 @@ mod tests {
                 true
             }),
             direction: TextDirection::Ltr,
-            width: Cell::new(BACK_GESTURE_WIDTH),
             gesture: RefCell::new(None),
             awaiting_settle: Cell::new(false),
         };
@@ -845,7 +1002,6 @@ mod tests {
             controller: c,
             enabled: Rc::new(move || allow_for_closure.get()),
             direction: TextDirection::Ltr,
-            width: Cell::new(BACK_GESTURE_WIDTH),
             gesture: RefCell::new(None),
             awaiting_settle: Cell::new(false),
         };

--- a/crates/flui-widgets/src/navigator/back_gesture.rs
+++ b/crates/flui-widgets/src/navigator/back_gesture.rs
@@ -1,0 +1,883 @@
+//! [`BackGestureController`] and the edge-anchored swipe-back detector —
+//! the iOS-style drag-to-pop substrate. `pub(crate)` only.
+//!
+//! # Oracle
+//!
+//! `.flutter/packages/flutter/lib/src/cupertino/route.dart` (3.44.0):
+//! `_CupertinoBackGestureController`, `_CupertinoBackGestureDetector`,
+//! `_CupertinoBackGestureDetectorState`. Cited by method name, not by line —
+//! this file ports the *3.44.0* flat pacing (a fixed 350ms /
+//! `Curves.fastEaseInToSlowEaseOut` "stay" animation), not the pre-3.4x
+//! velocity-scaled lerp shape.
+//!
+//! # Deferred by design
+//!
+//! No public detector API (this whole module is `pub(crate)`), no Cupertino
+//! edge-shadow/visuals, no per-hero `Hero.transitionOnUserGestures` opt-in
+//! (see `hero_controller.rs`'s doc block — every hero currently behaves as
+//! `transitionOnUserGestures = false`), and no `fullscreenDialog` (FLUI has
+//! no such route flag yet; opting a route into `back_gesture` is this port's
+//! substitute gate, not a `!fullscreenDialog` check).
+//!
+//! # No ambient `Directionality`
+//!
+//! FLUI has no `Directionality` inherited widget yet (see `icon.rs`'s and
+//! `single_child_scroll_view.rs`'s own notes on the same gap). Every other
+//! FLUI widget that would read it defaults to left-to-right; this module does
+//! the same, but keeps the sign-normalizing conversion
+//! ([`convert_to_logical`]) as a single, independently testable function
+//! rather than inlining an LTR assumption at each call site — the day
+//! `Directionality::of` exists, only the call site needs to change.
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Duration;
+
+use flui_animation::{Animation, AnimationController, Curve, Curves};
+use flui_foundation::Listenable;
+use flui_interaction::arena::{GestureArena, SweepModel};
+use flui_interaction::recognizers::drag_variants::horizontal_drag;
+use flui_interaction::{
+    DragEndDetails, DragGestureRecognizer, DragStartDetails, DragUpdateDetails, GestureRecognizer,
+    PointerEvent, PointerEventExt,
+};
+use flui_rendering::hit_testing::HitTestBehavior;
+use flui_types::typography::TextDirection;
+use flui_view::prelude::*;
+use flui_view::{AnimatedView, impl_animated_view};
+
+use super::navigator::NavigatorHandle;
+use super::route::RouteId;
+use crate::{GestureArenaScope, Listener, Positioned, SizedBox, Stack, StackFit};
+
+/// Flutter's `_kBackGestureWidth` (`cupertino/route.dart`, 3.44.0): the
+/// width of the edge-anchored hit region that can start a drag.
+pub(crate) const BACK_GESTURE_WIDTH: f32 = 20.0;
+
+/// Flutter's `_kMinFlingVelocity`: screen-widths per second.
+const MIN_FLING_VELOCITY: f32 = 1.0;
+
+/// Flutter's `_kDroppedSwipePageAnimationDuration`.
+const DROPPED_SWIPE_DURATION: Duration = Duration::from_millis(350);
+
+/// Flutter's `_CupertinoBackGestureDetectorState._convertToLogical`:
+/// normalizes a horizontal delta/velocity fraction into pop-direction
+/// coordinates (positive = toward revealing the previous route), in exactly
+/// one place — see the module docs on the missing ambient `Directionality`.
+pub(crate) fn convert_to_logical(value: f32, direction: TextDirection) -> f32 {
+    match direction {
+        TextDirection::Rtl => -value,
+        TextDirection::Ltr => value,
+    }
+}
+
+/// A controller for an iOS-style back gesture — Flutter's
+/// `_CupertinoBackGestureController`.
+///
+/// Works entirely in logical fractions of the controller's own `0.0..1.0`
+/// range (`0.0` = new page dismissed, `1.0` = new page fully on top), exactly
+/// as the oracle documents itself.
+pub(crate) struct BackGestureController {
+    navigator: NavigatorHandle,
+    route: RouteId,
+    controller: AnimationController,
+}
+
+impl BackGestureController {
+    /// Flutter's ctor body: `navigator.didStartUserGesture()` fires
+    /// immediately, before the first `drag_update`.
+    pub(crate) fn new(
+        navigator: NavigatorHandle,
+        route: RouteId,
+        controller: AnimationController,
+    ) -> Self {
+        navigator.did_start_user_gesture();
+        Self {
+            navigator,
+            route,
+            controller,
+        }
+    }
+
+    /// `dragUpdate(delta)`: `controller.value -= delta`.
+    ///
+    /// `AnimationController::set_value` now stops any active run first (step
+    /// 0's Flutter-parity fix) — exactly Flutter's `value -=` setter
+    /// semantics, so no separate `stop()` call is needed here.
+    pub(crate) fn drag_update(&self, delta: f32) {
+        self.controller.set_value(self.controller.value() - delta);
+    }
+
+    /// `dragEnd(velocity)`.
+    ///
+    /// Returns `true` if the release animation is still running and the
+    /// caller must keep watching for it to settle (see
+    /// `BackGestureDetectorState`'s per-rebuild poll) — `false` if it settled
+    /// inline, in which case the gesture is already fully closed out
+    /// (`did_stop_user_gesture` already called).
+    pub(crate) fn drag_end(&self, velocity: f32) -> bool {
+        let curve: Arc<dyn Curve + Send + Sync> = Arc::new(Curves::FastEaseInToSlowEaseOut); // PORT-CHECK-OK-DYN: see `PopPacing`'s doc (binding.rs) — same erased easing-curve boundary
+        let is_current = self.navigator.current() == Some(self.route);
+        let animate_forward = if !is_current {
+            // https://github.com/flutter/flutter/issues/141268 — a route
+            // already navigated away from (but perhaps still in the stack)
+            // animates by whether it is still active, never by velocity or
+            // drag position.
+            self.navigator.route_is_active(self.route)
+        } else if velocity.abs() >= MIN_FLING_VELOCITY {
+            velocity <= 0.0
+        } else {
+            self.controller.value() > 0.5
+        };
+
+        if animate_forward {
+            let _ = self.controller.animate_to_curved(
+                1.0,
+                Some(DROPPED_SWIPE_DURATION),
+                Arc::clone(&curve),
+            );
+        } else {
+            if is_current {
+                // Reuse the navigator's pop, paced to match this gesture. The
+                // pacing rides the pop command itself (`pop_paced`), reaching
+                // `TransitionRoute::did_pop`'s `animate_back_curved` call
+                // atomically — the controller's very first reverse run after
+                // this drag uses the gesture's pacing, never a transient
+                // default one (see `navigator.rs`'s `pop_paced` doc for why
+                // this is not Flutter's own two-step
+                // `navigator.pop(); controller.animateBack(...)`).
+                let _ = self.navigator.pop_paced(
+                    self.route,
+                    DROPPED_SWIPE_DURATION,
+                    Arc::clone(&curve),
+                );
+            }
+            // Flutter's fallback: "The popping may have finished inline if
+            // already at the target destination" — covers both that case
+            // (nothing left to override) and `!is_current` (no pop happened
+            // above at all, but this route's own controller may still need
+            // to settle toward 0).
+            if self.controller.is_animating() {
+                let _ =
+                    self.controller
+                        .animate_back_curved(0.0, Some(DROPPED_SWIPE_DURATION), curve);
+            }
+        }
+
+        if self.controller.is_animating() {
+            true
+        } else {
+            self.navigator.did_stop_user_gesture();
+            false
+        }
+    }
+}
+
+/// Shared, owner-thread state a [`BackGestureDetector`] drives from its
+/// recognizer callbacks and polls from `build`.
+///
+/// A plain struct behind `Rc`, not `Arc`: every field here is owner-affine
+/// (`NavigatorHandle` itself is `!Send + !Sync`), and every callback that
+/// touches it runs on the owner thread — a drag recognizer's callbacks are
+/// `Fn(..) + 'static`, not `Send + Sync` (unlike an `AnimationController`
+/// status listener, which is why the settle wait below is a poll, not a
+/// second status listener; see `poll_settle`'s doc).
+struct BackGestureRuntime {
+    navigator: NavigatorHandle,
+    route: RouteId,
+    controller: AnimationController,
+    /// Re-evaluated on **every** pointer-down, never baked at build time —
+    /// Flutter's `_CupertinoBackGestureDetectorState._handlePointerDown`
+    /// reading `widget.enabledCallback()` fresh each time.
+    enabled: Rc<dyn Fn() -> bool>,
+    direction: TextDirection,
+    /// The width a drag fraction is normalized against — Flutter's
+    /// `context.size!.width`. Refreshed every `build` from the incoming
+    /// `BoxConstraints` (`LayoutBuilder`), since FLUI has no
+    /// "my own rendered size" query off `BuildContext`.
+    width: Cell<f32>,
+    /// The in-flight gesture, if a drag has started. `None` both before the
+    /// first pointer down and after `drag_end`/`drag_cancel`/`dispose` have
+    /// consumed it — the multi-touch guard (`Some` blocks a second pointer
+    /// from starting a second gesture) and the "nothing to watch" case share
+    /// this one slot.
+    gesture: RefCell<Option<BackGestureController>>,
+    /// Set when `drag_end`/`drag_cancel` left the release animation running;
+    /// cleared by `poll_settle` once it reports `did_stop_user_gesture`.
+    awaiting_settle: Cell<bool>,
+}
+
+impl BackGestureRuntime {
+    fn on_pointer_down(
+        &self,
+        recognizer: &Arc<DragGestureRecognizer>,
+        arena: &GestureArena,
+        self_close: bool,
+        event: &PointerEvent,
+    ) {
+        if !(self.enabled)() {
+            return;
+        }
+        // Multi-touch: while a drag is active, a second pointer-down in the
+        // edge region must not start a second gesture — Flutter's
+        // `assert(_backGestureController == null)` in `_handleDragStart`,
+        // enforced here as a hard guard rather than a debug-only assertion.
+        if self.gesture.borrow().is_some() {
+            return;
+        }
+        let pointer = event.pointer_id();
+        recognizer.add_pointer(pointer, event.position());
+        if self_close {
+            arena.close(pointer);
+        }
+    }
+
+    fn on_drag_start(&self, _details: DragStartDetails) {
+        if self.gesture.borrow().is_some() {
+            return;
+        }
+        let gesture =
+            BackGestureController::new(self.navigator.clone(), self.route, self.controller.clone());
+        *self.gesture.borrow_mut() = Some(gesture);
+    }
+
+    fn on_drag_update(&self, details: DragUpdateDetails) {
+        let delta = convert_to_logical(
+            details.primary_delta / self.normalized_width(),
+            self.direction,
+        );
+        if let Some(gesture) = self.gesture.borrow().as_ref() {
+            gesture.drag_update(delta);
+        }
+    }
+
+    fn on_drag_end(&self, details: DragEndDetails) {
+        let velocity = convert_to_logical(
+            details.primary_velocity / self.normalized_width(),
+            self.direction,
+        );
+        self.finish_drag(velocity);
+    }
+
+    fn on_drag_cancel(&self) {
+        // "This can be called even if start is not called" — Flutter's
+        // `_handleDragCancel`. `finish_drag` is a no-op if no gesture is
+        // in flight.
+        self.finish_drag(0.0);
+    }
+
+    fn finish_drag(&self, velocity: f32) {
+        let Some(gesture) = self.gesture.borrow_mut().take() else {
+            return;
+        };
+        if gesture.drag_end(velocity) {
+            self.awaiting_settle.set(true);
+        }
+    }
+
+    /// Flutter's trailing status listener in `dragEnd`: "Keep the
+    /// userGestureInProgress in true state so we don't change the curve of
+    /// the page transition mid-flight." Expressed as a poll, called from
+    /// `BackGestureDetectorState::build` on every rebuild — which happens on
+    /// every tick of the release animation, because that `ViewState` is an
+    /// `AnimatedView` subscribed to this same controller. A genuine second
+    /// status listener would need to be `Send + Sync`
+    /// (`AnimationController::add_status_listener`'s bound) and could
+    /// therefore never touch this owner-affine `NavigatorHandle` directly.
+    fn poll_settle(&self) {
+        if self.awaiting_settle.get() && !self.controller.is_animating() {
+            self.awaiting_settle.set(false);
+            self.navigator.did_stop_user_gesture();
+        }
+    }
+
+    /// A dispose-time safety net for a gesture whose finger is still down
+    /// when the detector unmounts (e.g. the route was swept away by a
+    /// `push_and_remove_until` mid-drag) — Flutter's
+    /// `_CupertinoBackGestureDetectorState.dispose`: post a deferred
+    /// `didStopUserGesture` rather than calling it synchronously from
+    /// `dispose` (an unmount is not a frame phase the navigator's own
+    /// bookkeeping expects a gesture-stop from), and only if the navigator is
+    /// still mounted.
+    ///
+    /// A gesture that already reached `drag_end`/`drag_cancel` before this
+    /// runs is not in `self.gesture` anymore (mutually exclusive with
+    /// `finish_drag`'s `take`), so this can never double-report a stop that
+    /// `drag_end`'s own path (immediate or `poll_settle`) already reported.
+    fn dispose_safety_net(&self) {
+        let Some(_gesture) = self.gesture.borrow_mut().take() else {
+            return;
+        };
+        self.awaiting_settle.set(false);
+        let navigator = self.navigator.clone();
+        match navigator.post_frame_handle() {
+            Some(post_frame) => {
+                let deferred = navigator.clone();
+                let schedule_result = post_frame.schedule_local(move |_timing| {
+                    if deferred.is_mounted() {
+                        deferred.did_stop_user_gesture();
+                    }
+                });
+                if schedule_result.is_err() && navigator.is_mounted() {
+                    // No owner-local post-frame lane available — report now
+                    // rather than leak the gesture count forever.
+                    navigator.did_stop_user_gesture();
+                }
+            }
+            None => {
+                if navigator.is_mounted() {
+                    navigator.did_stop_user_gesture();
+                }
+            }
+        }
+    }
+
+    /// `self.width`, floored so a zero/negative/unmeasured width never
+    /// divides a finite delta into infinity or NaN.
+    fn normalized_width(&self) -> f32 {
+        self.width.get().max(1.0)
+    }
+}
+
+/// An edge-anchored, arena-fed detector that turns a horizontal drag inside
+/// [`BACK_GESTURE_WIDTH`] of the leading edge into a
+/// [`BackGestureController`]-driven pop. Flutter's
+/// `_CupertinoBackGestureDetector`. `pub(crate)`: no public detector API is
+/// exposed yet.
+#[derive(Clone)]
+pub(crate) struct BackGestureDetector {
+    navigator: NavigatorHandle,
+    route: RouteId,
+    controller: AnimationController,
+    enabled: Rc<dyn Fn() -> bool>,
+    child: Child,
+}
+
+impl BackGestureDetector {
+    /// Wrap `child` with the edge-swipe-back detector for `route`, driving
+    /// `controller` (the route's own primary `AnimationController`).
+    /// `enabled` is re-evaluated on every pointer-down — pass
+    /// `NavigatorHandle::pop_gesture_enabled` bound to `route`, not a
+    /// snapshot taken at build time.
+    pub(crate) fn new(
+        navigator: NavigatorHandle,
+        route: RouteId,
+        controller: AnimationController,
+        enabled: Rc<dyn Fn() -> bool>,
+        child: impl IntoView,
+    ) -> Self {
+        Self {
+            navigator,
+            route,
+            controller,
+            enabled,
+            child: Child::some(child.into_view()),
+        }
+    }
+}
+
+impl std::fmt::Debug for BackGestureDetector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BackGestureDetector")
+            .field("route", &self.route)
+            .finish_non_exhaustive()
+    }
+}
+
+impl_animated_view!(BackGestureDetector);
+
+impl AnimatedView for BackGestureDetector {
+    /// Subscribing to the route's own primary controller is what makes
+    /// `poll_settle` fire promptly: every tick of a gesture-driven release
+    /// animation renotifies this same controller, which reschedules this
+    /// `ViewState`'s `build`.
+    fn listenable(&self) -> Arc<dyn Listenable> {
+        Arc::new(self.controller.clone()) as Arc<dyn Listenable>
+    }
+}
+
+impl StatefulView for BackGestureDetector {
+    type State = BackGestureDetectorState;
+
+    fn create_state(&self) -> Self::State {
+        BackGestureDetectorState {
+            runtime: Rc::new(BackGestureRuntime {
+                navigator: self.navigator.clone(),
+                route: self.route,
+                controller: self.controller.clone(),
+                enabled: Rc::clone(&self.enabled),
+                // No ambient `Directionality` — see the module docs.
+                direction: TextDirection::Ltr,
+                width: Cell::new(BACK_GESTURE_WIDTH.max(1.0)),
+                gesture: RefCell::new(None),
+                awaiting_settle: Cell::new(false),
+            }),
+            recognizer: RefCell::new(None),
+        }
+    }
+}
+
+pub(crate) struct BackGestureDetectorState {
+    runtime: Rc<BackGestureRuntime>,
+    /// Built lazily in the first `build` (not `init_state`): reading the
+    /// ambient `GestureArenaScope` only needs a one-time, non-dependency
+    /// lookup, and `build` is where every other FLUI gesture widget already
+    /// does it (`GestureDetectorState`), so this stays consistent with that
+    /// established pattern rather than inventing a second convention.
+    recognizer: RefCell<Option<Recognizer>>,
+}
+
+struct Recognizer {
+    arena: GestureArena,
+    self_close: bool,
+    drag: Arc<DragGestureRecognizer>,
+}
+
+impl std::fmt::Debug for BackGestureDetectorState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BackGestureDetectorState")
+            .finish_non_exhaustive()
+    }
+}
+
+impl ViewState<BackGestureDetector> for BackGestureDetectorState {
+    fn build(&self, view: &BackGestureDetector, ctx: &dyn BuildContext) -> impl IntoView {
+        self.runtime.poll_settle();
+
+        if self.recognizer.borrow().is_none() {
+            *self.recognizer.borrow_mut() = Some(self.build_recognizer(ctx));
+        }
+        let recognizer = self.recognizer.borrow();
+        let recognizer = recognizer
+            .as_ref()
+            .expect("built immediately above if absent");
+
+        let down_runtime = Rc::clone(&self.runtime);
+        let down_drag = Arc::clone(&recognizer.drag);
+        let down_arena = recognizer.arena.clone();
+        let down_self_close = recognizer.self_close;
+        let move_drag = Arc::clone(&recognizer.drag);
+        let up_drag = Arc::clone(&recognizer.drag);
+        let cancel_drag = Arc::clone(&recognizer.drag);
+
+        let listener = Listener::new()
+            .behavior(HitTestBehavior::Translucent)
+            .on_pointer_down(move |event| {
+                down_runtime.on_pointer_down(&down_drag, &down_arena, down_self_close, event);
+            })
+            .on_pointer_move(move |event| move_drag.handle_event(event))
+            .on_pointer_up(move |event| up_drag.handle_event(event))
+            .on_pointer_cancel(move |event| cancel_drag.handle_event(event));
+
+        let child = view
+            .child
+            .clone()
+            .into_inner()
+            .unwrap_or_else(|| SizedBox::shrink().boxed());
+
+        Stack::new(vec![
+            child,
+            Positioned::new(listener)
+                .left(0.0)
+                .top(0.0)
+                .bottom(0.0)
+                .width(BACK_GESTURE_WIDTH)
+                .boxed(),
+        ])
+        .fit(StackFit::Passthrough)
+    }
+
+    fn dispose(&mut self) {
+        self.runtime.dispose_safety_net();
+        if let Some(recognizer) = self.recognizer.get_mut() {
+            recognizer.drag.dispose();
+        }
+    }
+}
+
+impl BackGestureDetectorState {
+    fn build_recognizer(&self, ctx: &dyn BuildContext) -> Recognizer {
+        // `get`, not `depend_on`: the arena handle never changes, matching
+        // `GestureDetectorState`'s own non-dependency lookup.
+        let arena = ctx
+            .get::<GestureArenaScope, _>(|scope| scope.arena().clone())
+            .unwrap_or_else(GestureArena::new);
+        let self_close = arena.sweep_model() == SweepModel::SelfDriven;
+
+        let start_runtime = Rc::clone(&self.runtime);
+        let update_runtime = Rc::clone(&self.runtime);
+        let end_runtime = Rc::clone(&self.runtime);
+        let cancel_runtime = Rc::clone(&self.runtime);
+        let drag = horizontal_drag(arena.clone())
+            .with_on_start(move |details| start_runtime.on_drag_start(details))
+            .with_on_update(move |details| update_runtime.on_drag_update(details))
+            .with_on_end(move |details| end_runtime.on_drag_end(details))
+            .with_on_cancel(move || cancel_runtime.on_drag_cancel());
+
+        Recognizer {
+            arena,
+            self_close,
+            drag,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use flui_scheduler::Scheduler;
+
+    use super::*;
+    use crate::navigator::overlay_route::SimpleRoute;
+
+    fn navigator_with_two_routes() -> (NavigatorHandle, RouteId, RouteId) {
+        let navigator = NavigatorHandle::new();
+        navigator.seed_initial(SimpleRoute::<i32>::new(|_ctx| {
+            SizedBox::new(1.0, 1.0).into_view().boxed()
+        }));
+        let root = navigator.route_ids()[0];
+        navigator.push(SimpleRoute::<i32>::new(|_ctx| {
+            SizedBox::new(1.0, 1.0).into_view().boxed()
+        }));
+        let top = *navigator.route_ids().last().expect("pushed");
+        (navigator, root, top)
+    }
+
+    fn controller(ms: u64) -> AnimationController {
+        let scheduler = Arc::new(Scheduler::new());
+        AnimationController::new(Duration::from_millis(ms), scheduler)
+    }
+
+    /// A mounted navigator with a pushed [`PageRoute`], and that route's own
+    /// [`AnimationController`] — the same one `pop_paced` reaches through
+    /// `did_pop`. Needed by any test that drives `drag_end`'s pop branch:
+    /// `BackGestureController` must be constructed with the route's *real*
+    /// controller, or the pacing it applies through `pop_paced` lands on a
+    /// route with no relationship to the controller the test observes.
+    fn mounted_with_transition_route() -> (
+        NavigatorHandle,
+        crate::test_harness::Harness,
+        RouteId,
+        AnimationController,
+    ) {
+        use super::super::page_route::PageRoute;
+        use crate::test_harness::mount;
+
+        let navigator = NavigatorHandle::new();
+        navigator.seed_initial(SimpleRoute::<i32>::new(|_ctx| {
+            SizedBox::new(1.0, 1.0).into_view().boxed()
+        }));
+        let mut harness = mount(crate::navigator::Navigator::new(navigator.clone()));
+
+        let route = PageRoute::<i32>::new(|_ctx, _primary, _secondary| {
+            SizedBox::new(1.0, 1.0).into_view().boxed()
+        })
+        .transition_duration(Duration::from_millis(300));
+        let transition = route.transition_handle();
+        let _pushed = harness.enter_owner_scope(|| navigator.push(route));
+        harness.tick();
+
+        let top = *navigator.route_ids().last().expect("pushed");
+        let controller = transition
+            .controller()
+            .expect("install() created the controller");
+        (navigator, harness, top, controller)
+    }
+
+    #[test]
+    fn convert_to_logical_flips_sign_only_for_rtl() {
+        assert_eq!(convert_to_logical(0.3, TextDirection::Ltr), 0.3);
+        assert_eq!(convert_to_logical(0.3, TextDirection::Rtl), -0.3);
+        assert_eq!(convert_to_logical(-0.5, TextDirection::Rtl), 0.5);
+    }
+
+    // ---- ctor: reports gesture start immediately ----
+
+    #[test]
+    fn ctor_reports_user_gesture_start_immediately() {
+        let (navigator, _root, top) = navigator_with_two_routes();
+        let c = controller(300);
+        assert!(!navigator.user_gesture_in_progress());
+        let gesture = BackGestureController::new(navigator.clone(), top, c);
+        assert!(navigator.user_gesture_in_progress());
+        drop(gesture);
+    }
+
+    // ---- drag_update tracks controller.value exactly ----
+
+    #[test]
+    fn drag_update_tracks_controller_value_exactly() {
+        let (navigator, _root, top) = navigator_with_two_routes();
+        let c = controller(300);
+        c.set_value(1.0);
+        let gesture = BackGestureController::new(navigator, top, c.clone());
+
+        gesture.drag_update(0.3);
+        assert!((c.value() - 0.7).abs() < 1e-6, "value={}", c.value());
+        gesture.drag_update(-0.1);
+        assert!((c.value() - 0.8).abs() < 1e-6, "value={}", c.value());
+        gesture.drag_update(0.9);
+        assert!(
+            (c.value() - 0.0).abs() < 1e-6,
+            "clamped to the lower bound: value={}",
+            c.value()
+        );
+    }
+
+    // ---- release matrix: v = -2.0 / +2.0 / 0 at value 0.49 / 0.51 ----
+
+    #[test]
+    fn release_matrix_fling_and_slow_release() {
+        // Fast negative velocity (screen-widths/s): stay (route animates
+        // forward to 1.0 = new page fully covers again) regardless of value.
+        {
+            let (navigator, _harness, top, c) = mounted_with_transition_route();
+            c.set_value(0.51);
+            let gesture = BackGestureController::new(navigator, top, c.clone());
+            let still_settling = gesture.drag_end(-2.0);
+            assert!(still_settling, "an animated release keeps the run going");
+            assert_eq!(c.status(), flui_animation::AnimationStatus::Forward);
+        }
+        // Fast positive velocity: pop (route animates back to 0.0).
+        {
+            let (navigator, _harness, top, c) = mounted_with_transition_route();
+            c.set_value(0.49);
+            let gesture = BackGestureController::new(navigator, top, c.clone());
+            let still_settling = gesture.drag_end(2.0);
+            assert!(still_settling);
+            assert_eq!(c.status(), flui_animation::AnimationStatus::Reverse);
+        }
+        // No meaningful velocity, value > 0.5: stay.
+        {
+            let (navigator, _harness, top, c) = mounted_with_transition_route();
+            c.set_value(0.51);
+            let gesture = BackGestureController::new(navigator, top, c.clone());
+            let still_settling = gesture.drag_end(0.0);
+            assert!(still_settling);
+            assert_eq!(c.status(), flui_animation::AnimationStatus::Forward);
+        }
+        // No meaningful velocity, value <= 0.5: pop.
+        {
+            let (navigator, _harness, top, c) = mounted_with_transition_route();
+            c.set_value(0.49);
+            let gesture = BackGestureController::new(navigator, top, c.clone());
+            let still_settling = gesture.drag_end(0.0);
+            assert!(still_settling);
+            assert_eq!(c.status(), flui_animation::AnimationStatus::Reverse);
+        }
+    }
+
+    // ---- mid-drag programmatic pop: the pop itself must not be clobbered ----
+
+    /// Flutter's `dragUpdate` has no `is_active`/`is_current` guard at all —
+    /// `controller.value -= delta` runs unconditionally, so a drag_update
+    /// after a programmatic pop still moves the value (this is *not* a
+    /// no-op, and asserting otherwise would pin a divergence). What must
+    /// hold is the other direction: the programmatic pop that landed
+    /// mid-drag stays popped — a later drag_update must not resurrect the
+    /// route or panic reaching into it.
+    #[test]
+    fn mid_drag_programmatic_pop_is_not_undone_by_a_later_drag_update() {
+        let (navigator, mut harness, top, c) = mounted_with_transition_route();
+        c.set_value(1.0);
+        let gesture = BackGestureController::new(navigator.clone(), top, c.clone());
+        gesture.drag_update(0.3); // value 0.7, mid-drag
+
+        // A programmatic pop lands while the finger is still down. The route
+        // stays in `route_ids()` until its (non-zero-duration) exit
+        // transition finishes — `finished_when_popped` — so "the pop took
+        // effect" is checked through `current()`, not stack membership.
+        assert!(harness.enter_owner_scope(|| navigator.pop()));
+        harness.tick();
+        assert_ne!(
+            navigator.current(),
+            Some(top),
+            "the mid-drag pop must actually move `current` off this route"
+        );
+
+        // A further drag_update on the now-stale gesture must not panic or
+        // resurrect the popped route.
+        gesture.drag_update(0.05);
+        assert_ne!(
+            navigator.current(),
+            Some(top),
+            "a stale drag_update after the pop must not undo it"
+        );
+    }
+
+    // ---- full swipe to 0.0, then drag back: no Dismissed-finalize thrash ----
+
+    #[test]
+    fn full_swipe_to_zero_then_drag_back_does_not_thrash() {
+        let (navigator, _root, top) = navigator_with_two_routes();
+        let c = controller(300);
+        c.set_value(1.0);
+        let gesture = BackGestureController::new(navigator, top, c.clone());
+
+        gesture.drag_update(1.0); // value -> 0.0, fully swiped
+        assert_eq!(c.value(), 0.0);
+        assert_eq!(c.status(), flui_animation::AnimationStatus::Dismissed);
+
+        // Dragging back must not panic, and must move the value back up —
+        // set_value's status is recomputed, not stuck at a stale Dismissed.
+        gesture.drag_update(-0.4);
+        assert!((c.value() - 0.4).abs() < 1e-6, "value={}", c.value());
+        assert_ne!(c.status(), flui_animation::AnimationStatus::Dismissed);
+    }
+
+    // ---- dispose-mid-settle: counter returns to 0 ----
+
+    #[test]
+    fn dispose_mid_gesture_returns_the_counter_to_zero() {
+        let (navigator, mut harness, top, c) = mounted_with_transition_route();
+        let runtime = BackGestureRuntime {
+            navigator: navigator.clone(),
+            route: top,
+            controller: c,
+            enabled: Rc::new(|| true),
+            direction: TextDirection::Ltr,
+            width: Cell::new(BACK_GESTURE_WIDTH),
+            gesture: RefCell::new(None),
+            awaiting_settle: Cell::new(false),
+        };
+        runtime.on_drag_start(DragStartDetails {
+            global_position: flui_types::geometry::Offset::ZERO,
+            local_position: flui_types::geometry::Offset::ZERO,
+            kind: flui_interaction::events::PointerType::Touch,
+            timestamp: std::time::Instant::now(),
+        });
+        assert!(navigator.user_gesture_in_progress());
+
+        // The detector unmounts mid-drag (finger still down) — no drag_end
+        // ever ran. The navigator IS mounted here (unlike an inert
+        // `NavigatorHandle::new()` fixture), so Flutter's own `if (mounted)`
+        // gate in `dispose` is actually exercised, not vacuously satisfied.
+        // `dispose` runs from within the element tree's own owner scope in
+        // production, exactly like `push`/`pop` do — reproduced here so the
+        // local post-frame lane is actually active and the report is
+        // genuinely deferred, not caught by the synchronous fallback.
+        assert!(navigator.is_mounted());
+        harness.enter_owner_scope(|| runtime.dispose_safety_net());
+
+        // `mount()` installs a real owner-local post-frame lane, so the
+        // report is deferred (Flutter's own `addPostFrameCallback`, not a
+        // synchronous call from `dispose`) — a frame tick is what delivers it.
+        assert!(
+            navigator.user_gesture_in_progress(),
+            "the report is deferred to the next frame, not synchronous"
+        );
+        harness.tick();
+        assert!(
+            !navigator.user_gesture_in_progress(),
+            "dispose must return the counter to 0 by the next frame, even \
+             with no drag_end"
+        );
+    }
+
+    // ---- second pointer mid-drag ignored ----
+
+    #[test]
+    fn a_second_pointer_down_mid_drag_is_ignored() {
+        let (navigator, _root, top) = navigator_with_two_routes();
+        let c = controller(300);
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_for_enabled = Arc::clone(&attempts);
+        let runtime = BackGestureRuntime {
+            navigator,
+            route: top,
+            controller: c,
+            enabled: Rc::new(move || {
+                attempts_for_enabled.fetch_add(1, Ordering::SeqCst);
+                true
+            }),
+            direction: TextDirection::Ltr,
+            width: Cell::new(BACK_GESTURE_WIDTH),
+            gesture: RefCell::new(None),
+            awaiting_settle: Cell::new(false),
+        };
+
+        // First pointer starts a gesture — simulate what `on_pointer_down`
+        // would hand off by driving `on_drag_start` directly (the recognizer
+        // plumbing itself is exercised only through a mounted harness).
+        runtime.on_drag_start(DragStartDetails {
+            global_position: flui_types::geometry::Offset::ZERO,
+            local_position: flui_types::geometry::Offset::ZERO,
+            kind: flui_interaction::events::PointerType::Touch,
+            timestamp: std::time::Instant::now(),
+        });
+        assert!(runtime.gesture.borrow().is_some());
+
+        // A second pointer's down still evaluates the predicate (it is
+        // per-pointer-down, not skipped), but the multi-touch guard refuses
+        // to hand it to the recognizer or replace the in-flight gesture.
+        let arena = GestureArena::new();
+        let drag = horizontal_drag(arena.clone());
+        let event = flui_interaction::events::make_down_event_for_id(
+            flui_interaction::PointerId::new(2).expect("nonzero id"),
+            flui_types::geometry::Offset::ZERO,
+            flui_interaction::events::PointerType::Touch,
+        );
+        runtime.on_pointer_down(&drag, &arena, false, &event);
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "the predicate still runs per pointer-down"
+        );
+        assert!(
+            runtime.gesture.borrow().is_some(),
+            "the original gesture must not be replaced by the second pointer"
+        );
+    }
+
+    // ---- predicate per pointer-down: a route becoming ineligible is honored ----
+
+    #[test]
+    fn the_enabled_predicate_is_evaluated_fresh_per_pointer_down() {
+        let (navigator, _root, top) = navigator_with_two_routes();
+        let c = controller(300);
+        let allow = Rc::new(Cell::new(true));
+        let allow_for_closure = Rc::clone(&allow);
+        let runtime = BackGestureRuntime {
+            navigator,
+            route: top,
+            controller: c,
+            enabled: Rc::new(move || allow_for_closure.get()),
+            direction: TextDirection::Ltr,
+            width: Cell::new(BACK_GESTURE_WIDTH),
+            gesture: RefCell::new(None),
+            awaiting_settle: Cell::new(false),
+        };
+
+        let arena = GestureArena::new();
+        let drag = horizontal_drag(arena.clone());
+        let down_1 = flui_interaction::events::make_down_event_for_id(
+            flui_interaction::PointerId::new(1).expect("nonzero id"),
+            flui_types::geometry::Offset::ZERO,
+            flui_interaction::events::PointerType::Touch,
+        );
+        runtime.on_pointer_down(&drag, &arena, false, &down_1);
+        assert!(
+            runtime.gesture.borrow().is_none(),
+            "on_pointer_down alone does not start a gesture (that's on_drag_start); \
+             this only proves the predicate did not block add_pointer"
+        );
+
+        // The route becomes ineligible between builds — no rebuild needed,
+        // since the predicate closure reads live state.
+        allow.set(false);
+        let down_2 = flui_interaction::events::make_down_event_for_id(
+            flui_interaction::PointerId::new(2).expect("nonzero id"),
+            flui_types::geometry::Offset::ZERO,
+            flui_interaction::events::PointerType::Touch,
+        );
+        // A disabled predicate must refuse before ever touching the
+        // recognizer — verified indirectly: no panic, no state change, and
+        // (per `a_second_pointer_down_mid_drag_is_ignored` above) an enabled
+        // predicate DOES reach `add_pointer`. The direct assertion is that
+        // `enabled` itself, not a cached bool, gates this call.
+        runtime.on_pointer_down(&drag, &arena, false, &down_2);
+        assert!(!(runtime.enabled)());
+    }
+}

--- a/crates/flui-widgets/src/navigator/back_gesture.rs
+++ b/crates/flui-widgets/src/navigator/back_gesture.rs
@@ -880,7 +880,7 @@ mod tests {
 
     // ---- dispose while awaiting settle (post-release, pre-poll): counter clears ----
 
-    /// Blocker: `dispose_safety_net` must own the deferred report for a
+    /// `dispose_safety_net` must own the deferred report for a
     /// gesture that already *released* (so `self.gesture` is `None` —
     /// `finish_drag` always takes it) but whose settle animation is still
     /// running when the detector unmounts — e.g. the route was swept away by

--- a/crates/flui-widgets/src/navigator/binding.rs
+++ b/crates/flui-widgets/src/navigator/binding.rs
@@ -67,8 +67,9 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::Duration;
 
-use flui_animation::{Animation, Vsync};
+use flui_animation::{Animation, Curve, Vsync};
 use parking_lot::Mutex;
 
 use super::modal_route::ModalHandle;
@@ -218,15 +219,46 @@ pub(crate) type RouteSubtrees = Arc<Mutex<HashMap<RouteId, RouteSubtreeCell>>>;
 /// `ModalRoute` publishes its handle here at `install()`.
 pub(crate) type RouteModals = Arc<Mutex<HashMap<RouteId, ModalHandle>>>;
 
+/// How a route's exit transition should run, overriding its own default
+/// reverse pacing for exactly one pop.
+///
+/// Flutter's `_CupertinoBackGestureController.dragEnd` (`cupertino/route.dart`,
+/// 3.44.0) calls `_controller.animateBack(...)` with a duration/curve it
+/// computed from the drag (the fling velocity, or the flat 350ms/
+/// `Curves.fastEaseInToSlowEaseOut` "stay" pacing) — never the route's plain
+/// `reverse()`. FLUI has no `Route` object a gesture controller can reach to
+/// override, so the navigator publishes the override here, keyed by the one
+/// route it applies to, and [`RouteBinding::take_pop_pacing`] consumes it
+/// exactly once, from that route's own `did_pop`.
+/// A gesture-supplied easing curve is a value-only, `Send + Sync` transform
+/// (no tree/element access) carried from `back_gesture.rs`'s controller
+/// through the pop command to `AnimationController::animate_back_curved` —
+/// the same erased-`Animatable`-transform shape ADR-0021 §7n already
+/// sanctions for `Hero::create_rect_tween`.
+#[derive(Clone)]
+pub(crate) struct PopPacing {
+    pub(crate) duration: Duration,
+    pub(crate) curve: Arc<dyn Curve + Send + Sync>, // PORT-CHECK-OK-DYN: see the struct doc — erased easing-curve transform, ADR-0021 §7n shape
+}
+
+/// `RouteId -> PopPacing`, a one-shot override the navigator sets immediately
+/// before popping a specific route and every path removes on the way out —
+/// consumed by a successful pop, and swept by the setter itself if the pop
+/// never reaches that route's `did_pop` (a veto, or the route was no longer
+/// current). Never a field on the route: a stored field would go stale on a
+/// veto or apply to the wrong pop if a *different* route reached `did_pop`
+/// first (see `navigator.rs`'s `pop_paced`).
+pub(crate) type PopPacingRegistry = Arc<Mutex<HashMap<RouteId, PopPacing>>>;
+
 /// The queue a [`RouteBinding`] writes to and a `RouteHistory` drains.
 ///
 /// Its own mutex, deliberately: it must be lockable while the history's mutex is
 /// held by an in-progress flush.
 pub(crate) type RouteCommandQueue = Arc<Mutex<VecDeque<RouteCommand>>>;
 
-/// The four `RouteId`-keyed maps a navigator owns and every binding shares.
+/// The `RouteId`-keyed maps a navigator owns and every binding shares.
 ///
-/// A bundle rather than four parameters: they are created together in
+/// A bundle rather than five parameters: they are created together in
 /// `NavigatorHandle::new`, cloned together into every binding, and each is a
 /// `RouteId -> _` map Flutter reads straight off the `Route` object.
 #[derive(Clone)]
@@ -240,6 +272,8 @@ pub(crate) struct RouteRegistries {
     pub(crate) subtrees: RouteSubtrees,
     /// `RouteId -> ModalHandle`.
     pub(crate) modals: RouteModals,
+    /// `RouteId -> PopPacing`, a one-shot override for the next `did_pop`.
+    pub(crate) pop_pacing: PopPacingRegistry,
 }
 
 /// An owned, `'static` capability, pre-bound to one [`RouteId`].
@@ -363,9 +397,17 @@ impl RouteBinding {
         self.registries.modals.lock().remove(&self.route);
     }
 
-    /// The route this binding drives. Test-facing: production code never needs it,
-    /// because every capability is already pre-bound to this id.
-    #[cfg(test)]
+    /// Consume this route's one-shot [`PopPacing`] override, if the navigator
+    /// set one immediately before this pop — see `navigator.rs`'s `pop_paced`.
+    /// `None` means "pop normally": the route's own default reverse pacing.
+    pub(crate) fn take_pop_pacing(&self) -> Option<PopPacing> {
+        self.registries.pop_pacing.lock().remove(&self.route)
+    }
+
+    /// The route this binding drives. Every other capability on this type is
+    /// already pre-bound to this id; a back-gesture detector needs the id
+    /// itself, to bind a drag to the specific route it started on
+    /// (`navigator.rs`'s `pop_paced`, `back_gesture.rs`).
     pub(crate) fn route_id(&self) -> RouteId {
         self.route
     }

--- a/crates/flui-widgets/src/navigator/hero_controller.rs
+++ b/crates/flui-widgets/src/navigator/hero_controller.rs
@@ -81,11 +81,19 @@
 //! its *own* controller (so it drives no flights of its own), but does not gate
 //! this matching — Flutter's predicate does not consult it either.
 //!
-//! No `userGestureInProgress` either: FLUI has no back-swipe, so
-//! `isUserGestureTransition` is always `false`. That collapses `didStartUserGesture`
-//! / `didStopUserGesture` (`heroes.dart:871-889`) and the `hasValidSize` fast path
-//! (`:952-960`) — which only ever runs for a gesture-driven pop — out of this port.
-//! Both are recorded as absent, not as done.
+//! **Gesture suppression substrate landed, per-hero opt-in still pending.**
+//! [`NavigatorHandle::user_gesture_in_progress`] mirrors Flutter's
+//! `NavigatorState.userGestureInProgress`, and [`did_change_top`](HeroController::did_change_top)
+//! consults it exactly where Flutter's `HeroController.didChangeTop` does
+//! (`heroes.dart:861`): a route change committed by a finger-driven pop starts no
+//! flight. What is still absent is the *other* half — `didStartUserGesture` calling
+//! `_maybeStartHeroTransition(isUserGestureTransition: true)` for immediate visual
+//! feedback the instant a drag begins (`heroes.dart:871-880`), the `hasValidSize`
+//! fast path that lets that flight measure without waiting a frame
+//! (`:952-960`), and `Hero.transitionOnUserGestures` itself — with no per-hero
+//! opt-in field, every FLUI hero behaves as `transitionOnUserGestures = false`,
+//! so a gesture-driven transition suppresses every hero's flight, never just the
+//! non-opted-in ones (`heroes.dart:281-311`'s `_allHeroesFor` filter).
 //!
 //! [`ModalHandle::set_offstage`]: super::modal_route::ModalHandle::set_offstage
 //! [`PostFrameHandle`]: flui_scheduler::PostFrameHandle
@@ -657,6 +665,27 @@ impl NavigatorObserver for HeroController {
         // `top` transiently not-current by the time this fires. The flight path is
         // guarded downstream anyway (`route_peer`/`route_modal` return `None` for a
         // superseded route), so a stale top simply measures nothing.
+        //
+        // `didChangeTop`'s own guard (`heroes.dart:861`): "Don't trigger another
+        // flight when a pop is committed as a user gesture back swipe is snapped."
+        // A finger-driven pop still fires `did_change_top` (the swipe's own commit
+        // pops the route), but a user gesture stays "in progress" until the
+        // settling controller reports its final status (see `back_gesture.rs`), so
+        // this still observes `user_gesture_in_progress() == true` at that instant
+        // and suppresses the flight — matching Flutter's default
+        // `Hero.transitionOnUserGestures = false` with no per-hero opt-in wired yet
+        // (`heroes.dart:281-311`'s `_allHeroesFor` filter, not yet threaded through
+        // this controller's measurement pass). Flutter's *other* gesture-driven
+        // path — `didStartUserGesture` calling `_maybeStartHeroTransition` with
+        // `isUserGestureTransition: true` for immediate visual feedback the instant
+        // a drag begins — is out of scope here: it only ever produces a flight for
+        // an opted-in hero, which does not exist in FLUI yet.
+        if self
+            .navigator()
+            .is_some_and(|navigator| navigator.user_gesture_in_progress())
+        {
+            return;
+        }
         self.maybe_start(previous_top, Some(top));
     }
 }

--- a/crates/flui-widgets/src/navigator/hero_controller_tests.rs
+++ b/crates/flui-widgets/src/navigator/hero_controller_tests.rs
@@ -646,6 +646,67 @@ fn controller_collects_matching_tags_and_records_one_manifest() {
     assert!(manifest.to_rect.min.x.0 > 0.0 && manifest.to_rect.min.y.0 > 0.0);
 }
 
+/// `HeroController.didChangeTop`'s own guard (`heroes.dart:861`): "Don't
+/// trigger another flight when a pop is committed as a user gesture back
+/// swipe is snapped." A pop that lands while `user_gesture_in_progress()` is
+/// still true starts no flight, even with a matching hero tag on both
+/// routes; the identical pop with no gesture in progress does.
+///
+/// Red-check: drop the `user_gesture_in_progress()` guard from
+/// `HeroController::did_change_top` — the gesture-pop assertion (zero
+/// manifests) fails.
+#[test]
+fn a_gesture_driven_pop_starts_no_flight_but_a_programmatic_pop_does() {
+    let navigator = seeded_navigator();
+    let controller = install(&navigator);
+    let mut harness = mount_navigator(&navigator);
+
+    let _first =
+        harness.enter_owner_scope(|| navigator.push(hero_page_route("shared", 30.0, 20.0)));
+    harness.tick();
+    let _second =
+        harness.enter_owner_scope(|| navigator.push(hero_page_route("shared", 60.0, 45.0)));
+    harness.tick();
+
+    // `manifests()` is cumulative over the controller's life, and the setup
+    // push above already flew once (both routes share the tag) — a baseline,
+    // not zero.
+    let manifests_before_gesture_pop = controller.manifests().len();
+    assert_eq!(manifests_before_gesture_pop, 1, "the setup push flew once");
+    let scheduled_before_gesture_pop = controller.scheduled_count();
+
+    // A finger-driven pop: the gesture is still "in progress" (it settles
+    // asynchronously, see `back_gesture.rs`) at the instant the pop commits and
+    // fires `did_change_top`.
+    navigator.did_start_user_gesture();
+    assert!(harness.enter_owner_scope(|| navigator.pop()));
+    harness.tick();
+    navigator.did_stop_user_gesture();
+
+    assert_eq!(
+        controller.manifests().len(),
+        manifests_before_gesture_pop,
+        "no flight starts while a user gesture is in progress"
+    );
+    assert_eq!(
+        controller.scheduled_count(),
+        scheduled_before_gesture_pop,
+        "no measurement is even scheduled while a user gesture is in progress"
+    );
+
+    // The same push/pop shape, but programmatic: now it flies.
+    let _third =
+        harness.enter_owner_scope(|| navigator.push(hero_page_route("shared", 60.0, 45.0)));
+    harness.tick();
+    assert!(harness.enter_owner_scope(|| navigator.pop()));
+    harness.tick();
+
+    assert!(
+        controller.manifests().len() > manifests_before_gesture_pop,
+        "a programmatic pop with no gesture in progress still starts a flight"
+    );
+}
+
 /// `final toHero = toHeroes[tag]; if (toHero == null) …` (`heroes.dart:1044-1046`) — a
 /// tag on only one route is not a flight.
 ///

--- a/crates/flui-widgets/src/navigator/history.rs
+++ b/crates/flui-widgets/src/navigator/history.rs
@@ -571,12 +571,67 @@ impl RouteHistory {
             .map(RouteEntry::state)
     }
 
+    /// Whether `id` names a route that is both in this stack and present —
+    /// Flutter's `Route.isActive` (`navigator.dart:584-643`: `navigator!
+    /// .contains(this) && entry.isPresent`, collapsed into one lookup since a
+    /// route not in this navigator's stack cannot be found at all).
+    pub(crate) fn is_present(&self, id: RouteId) -> bool {
+        self.entries
+            .iter()
+            .any(|entry| entry.id() == id && entry.state.is_present())
+    }
+
+    /// `id`'s own `Route::will_handle_pop_internally` — e.g. a non-empty
+    /// `LocalHistoryRoute` claims the pop. `None` if `id` names no entry
+    /// (already disposed and dropped, or never existed).
+    pub(crate) fn will_handle_pop_internally(&self, id: RouteId) -> Option<bool> {
+        self.entries
+            .iter()
+            .find(|entry| entry.id() == id)
+            .map(|entry| entry.route.will_handle_pop_internally())
+    }
+
+    /// The bottom-most **present** route — Flutter's `Route.isFirst`
+    /// (`navigator.dart:601-611`): `_firstRouteEntryWhereOrNull(isPresentPredicate)`.
+    /// Read by `NavigatorHandle::pop_gesture_enabled`'s `isFirst` check.
+    pub(crate) fn first_present(&self) -> Option<RouteId> {
+        self.entries
+            .iter()
+            .find(|entry| entry.state.is_present())
+            .map(RouteEntry::id)
+    }
+
     /// The topmost present route. Flutter's `_lastRouteEntryWhereOrNull(isPresent)`.
     pub(crate) fn current(&self) -> Option<RouteId> {
         self.entries
             .iter()
             .rfind(|entry| entry.state.is_present())
             .map(RouteEntry::id)
+    }
+
+    /// The route a user gesture (e.g. an edge swipe-back) is manipulating,
+    /// and the route beneath it a completed pop would reveal — Flutter's
+    /// inline resolution inside `NavigatorState.didStartUserGesture`
+    /// (`navigator.dart:5826-5841`): scans with `willBePresentPredicate`
+    /// (a route mid-push counts, unlike `current`'s `isPresent`), and leaves
+    /// `previous` `None` when the top route handles its own pop (a
+    /// `LocalHistoryRoute` swallows it internally, so there is nothing
+    /// "beneath" from the gesture's point of view).
+    pub(crate) fn top_and_previous_for_gesture(&self) -> Option<(RouteId, Option<RouteId>)> {
+        let route_index = self
+            .entries
+            .iter()
+            .rposition(|entry| entry.state.will_be_present())?;
+        let top_entry = &self.entries[route_index];
+        let top = top_entry.id();
+        let previous = if top_entry.route.will_handle_pop_internally() || route_index == 0 {
+            None
+        } else {
+            // Safety of the cast: `route_index > 0` here, and `entries.len()`
+            // is bounded well under `isize::MAX` for any real route stack.
+            self.route_before((route_index - 1) as isize, RouteLifecycle::will_be_present)
+        };
+        Some((top, previous))
     }
 
     // ── Public mutations (each ends in a flush, as in Flutter) ───────────────

--- a/crates/flui-widgets/src/navigator/history.rs
+++ b/crates/flui-widgets/src/navigator/history.rs
@@ -591,6 +591,24 @@ impl RouteHistory {
             .map(|entry| entry.route.will_handle_pop_internally())
     }
 
+    /// `id`'s own `Route::vetoes_pop` — a registered `PopScope` with
+    /// `can_pop = false` on **this** route specifically. `None` if `id`
+    /// names no entry.
+    ///
+    /// This is *not* `pop_disposition_of_top`: Flutter's
+    /// `ModalRoute.popDisposition` (`routes.dart`) walks `this` route's own
+    /// `_popEntries`, then falls back to `Route.popDisposition`'s `isFirst ?
+    /// bubble : pop` (`navigator.dart`) — which never itself yields
+    /// `doNotPop`. So `popDisposition == RoutePopDisposition.doNotPop` in
+    /// `popGestureEnabled` collapses to exactly this route's own veto check,
+    /// for *this* route, not necessarily the top of the stack.
+    pub(crate) fn vetoes_pop(&self, id: RouteId) -> Option<bool> {
+        self.entries
+            .iter()
+            .find(|entry| entry.id() == id)
+            .map(|entry| entry.route.vetoes_pop())
+    }
+
     /// The bottom-most **present** route — Flutter's `Route.isFirst`
     /// (`navigator.dart:601-611`): `_firstRouteEntryWhereOrNull(isPresentPredicate)`.
     /// Read by `NavigatorHandle::pop_gesture_enabled`'s `isFirst` check.

--- a/crates/flui-widgets/src/navigator/mod.rs
+++ b/crates/flui-widgets/src/navigator/mod.rs
@@ -33,6 +33,7 @@
 //! 2.0, restoration, named-route generation, `PopScope`, `LocalHistoryRoute`,
 //! per-route focus scope, and gesture-driven (`transitionOnUserGestures`) flights.
 
+mod back_gesture;
 mod binding;
 mod hero;
 mod hero_controller;

--- a/crates/flui-widgets/src/navigator/modal_route.rs
+++ b/crates/flui-widgets/src/navigator/modal_route.rs
@@ -82,6 +82,7 @@ use flui_view::prelude::*;
 use flui_view::{AnimatedView, BoxedView, ViewExt, impl_animated_view};
 use parking_lot::Mutex;
 
+use super::back_gesture::BackGestureDetector;
 use super::binding::{RouteBindingSlot, TransitionGroup};
 use super::hero::{HeroHandle, HeroRegistry, HeroScope, HeroTag};
 use super::local_history::{LocalHistoryHandle, LocalHistoryRegistry, LocalHistoryScope};
@@ -120,6 +121,14 @@ struct ModalInner {
     /// with the content builder from the moment the route is constructed, so a
     /// `.barrier_dismissible(true)` builder cannot reach it through `&mut`.
     barrier_dismissible: AtomicBool,
+    /// Whether this route opts into the edge-swipe-back gesture substrate
+    /// (`back_gesture.rs`). Default `false` — see `PageRoute::back_gesture`'s
+    /// doc for why. Set only before the route is pushed, exactly like
+    /// `maintain_state`/`barrier_dismissible`: toggling it mid-life is not a
+    /// supported path, so the detector wrapper's presence in the built tree
+    /// never flips (`ModalScopeState::build` reads it once per build, but the
+    /// value itself never changes after construction).
+    back_gesture_enabled: AtomicBool,
     /// `barrierColor` (`:1774`). `None` means an invisible barrier that still
     /// absorbs pointers — Flutter's `ModalBarrier` with no colour.
     barrier_color: Mutex<Option<Color>>,
@@ -258,6 +267,7 @@ impl ModalInner {
                 heroes: self.heroes.clone(),
                 pop_entries: self.pop_entries.clone(),
                 local_history: self.local_history_handle(),
+                back_gesture_enabled: self.back_gesture_enabled.load(Ordering::Relaxed),
             }
             .boxed(),
             // Unreachable in a pushed route: `install()` seeds the `OnceLock`
@@ -410,6 +420,10 @@ struct ModalScope {
     /// The route's local-history handle, provided to the page as an ambient
     /// (ADR-0025).
     local_history: LocalHistoryHandle,
+    /// Whether this route opted into `back_gesture.rs`'s edge-swipe-back
+    /// detector — a per-route, construction-time flag (`ModalRoute::back_gesture`),
+    /// never toggled mid-life.
+    back_gesture_enabled: bool,
 }
 
 impl_animated_view!(ModalScope);
@@ -460,6 +474,36 @@ impl ViewState<ModalScope> for ModalScopeState {
             ),
         )
         .boxed();
+        // The wrapper's presence never depends on anything read here besides
+        // `back_gesture_enabled` itself (a construction-time flag) — the page
+        // subtree's identity does not flip across builds. `maybe_of`/`binding`/
+        // `controller` are all `Some` for any route that reached this `build`
+        // through the normal push → install → mount path; the `None` arm only
+        // guards the same "unreachable in a pushed route" bootstrapping window
+        // `build_scope`'s own `None` arm documents.
+        let anchored = if view.back_gesture_enabled {
+            match (
+                NavigatorHandle::maybe_of(ctx),
+                view.transition.binding(),
+                view.transition.controller(),
+            ) {
+                (Some(navigator), Some(binding), Some(controller)) => {
+                    let route = binding.route_id();
+                    let enabled_navigator = navigator.clone();
+                    BackGestureDetector::new(
+                        navigator,
+                        route,
+                        controller,
+                        Rc::new(move || enabled_navigator.pop_gesture_enabled(route)),
+                        anchored,
+                    )
+                    .boxed()
+                }
+                _ => anchored,
+            }
+        } else {
+            anchored
+        };
         (view.transitions)(ctx, &primary, &secondary, anchored)
     }
 }
@@ -484,6 +528,7 @@ impl<T: Send + Clone + 'static> ModalRoute<T> {
             offstage: AtomicBool::new(false),
             maintain_state: AtomicBool::new(true),
             barrier_dismissible: AtomicBool::new(false),
+            back_gesture_enabled: AtomicBool::new(false),
             barrier_color: Mutex::new(None),
             page,
             transitions: Mutex::new(default_transitions_builder()),
@@ -578,6 +623,15 @@ impl<T: Send + Clone + 'static> ModalRoute<T> {
         self.inner
             .barrier_dismissible
             .store(dismissible, Ordering::Relaxed);
+        self
+    }
+
+    /// Opt into the edge-swipe-back gesture substrate (`back_gesture.rs`).
+    /// See `PageRoute::back_gesture`'s doc for the full contract.
+    pub(crate) fn back_gesture(self, enabled: bool) -> Self {
+        self.inner
+            .back_gesture_enabled
+            .store(enabled, Ordering::Relaxed);
         self
     }
 

--- a/crates/flui-widgets/src/navigator/navigator.rs
+++ b/crates/flui-widgets/src/navigator/navigator.rs
@@ -42,16 +42,20 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::num::NonZeroU64;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 use std::thread::{self, ThreadId};
+use std::time::Duration;
 
+use flui_animation::Curve;
 use flui_view::BuildContextExt;
 use flui_view::element::ElementKind;
 use flui_view::prelude::*;
 use parking_lot::Mutex;
 
-use super::binding::{RouteBinding, RouteRegistries, RouteVsync, TransitionGroup, TransitionPeer};
+use super::binding::{
+    PopPacing, RouteBinding, RouteRegistries, RouteVsync, TransitionGroup, TransitionPeer,
+};
 use super::hero::{HeroRegistry, HeroScope, NestedHeroSource};
 use super::hero_controller::HeroController;
 use super::hero_controller_scope::HeroControllerScope;
@@ -160,6 +164,13 @@ struct NavigatorShared {
     /// to. Cleared in `dispose`, together with the registry it was registered
     /// on, so a disposed navigator's heroes are never visited again.
     nested_hero_registration: Mutex<Option<(HeroRegistry, NestedHeroSource)>>,
+
+    /// How many overlapping user gestures (e.g. edge swipe-backs) are
+    /// currently manipulating this navigator. Flutter's
+    /// `NavigatorState._userGesturesInProgress` (`navigator.dart:5803`) — only
+    /// the 0→1 and 1→0 transitions notify observers, so nested gestures on
+    /// the same navigator collapse to one notification pair.
+    user_gestures_in_progress: AtomicU32,
 }
 
 impl NavigatorShared {
@@ -323,6 +334,53 @@ impl NavigatorShared {
         for observer in self.observers() {
             observer.did_detach();
         }
+    }
+
+    /// Flutter's `NavigatorState.didStartUserGesture` (`navigator.dart:5826-5841`).
+    ///
+    /// Only the 0→1 transition resolves the current route and notifies
+    /// observers — a nested/overlapping gesture on the same navigator just
+    /// bumps the count. The history lock is **released before** observers run:
+    /// `did_start_user_gesture` hands out a `NavigatorHandle`, and an observer
+    /// reading the stack back through it would deadlock on the same thread.
+    fn did_start_user_gesture(&self) {
+        let count_before = self
+            .user_gestures_in_progress
+            .fetch_add(1, Ordering::AcqRel);
+        if count_before != 0 {
+            return;
+        }
+        let Some((route, previous)) = self.history.lock().top_and_previous_for_gesture() else {
+            return;
+        };
+        for observer in self.observers() {
+            observer.did_start_user_gesture(route, previous);
+        }
+    }
+
+    /// Flutter's `NavigatorState.didStopUserGesture` (`navigator.dart:5847-5855`).
+    /// Only the 1→0 transition notifies observers.
+    fn did_stop_user_gesture(&self) {
+        let count_before = self
+            .user_gestures_in_progress
+            .fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(
+            count_before > 0,
+            "BUG: did_stop_user_gesture called without a matching did_start_user_gesture"
+        );
+        if count_before != 1 {
+            return;
+        }
+        for observer in self.observers() {
+            observer.did_stop_user_gesture();
+        }
+    }
+
+    /// Whether at least one user gesture is currently in progress on this
+    /// navigator. Flutter's `NavigatorState.userGestureInProgress`
+    /// (`navigator.dart:5816`).
+    fn user_gesture_in_progress(&self) -> bool {
+        self.user_gestures_in_progress.load(Ordering::Acquire) > 0
     }
 
     /// Run `mutate` against the stack, then apply whatever it flushed.
@@ -510,6 +568,7 @@ impl NavigatorHandle {
                 entries: Arc::new(Mutex::new(HashMap::new())),
                 subtrees: Arc::new(Mutex::new(HashMap::new())),
                 modals: Arc::new(Mutex::new(HashMap::new())),
+                pop_pacing: Arc::new(Mutex::new(HashMap::new())),
             },
             post_frame: Mutex::new(None),
             render_tree: Mutex::new(None),
@@ -517,6 +576,7 @@ impl NavigatorHandle {
             auto_hero_observer: Mutex::new(None),
             observers_attached: AtomicBool::new(false),
             nested_hero_registration: Mutex::new(None),
+            user_gestures_in_progress: AtomicU32::new(0),
         });
         let command_target = register_command_target(&shared);
         Self {
@@ -571,6 +631,40 @@ impl NavigatorHandle {
     #[must_use]
     pub fn is_mounted(&self) -> bool {
         self.shared.overlay.is_mounted()
+    }
+
+    /// Report that a user gesture (e.g. an edge swipe-back) started
+    /// manipulating this navigator. Flutter's
+    /// `NavigatorState.didStartUserGesture` (`navigator.dart:5826-5841`).
+    ///
+    /// Pair with a matching [`did_stop_user_gesture`](Self::did_stop_user_gesture)
+    /// once the gesture settles. Calls nest: only the first call (0→1) resolves
+    /// the current route and notifies [`NavigatorObserver::did_start_user_gesture`];
+    /// an overlapping second call just bumps the count.
+    pub fn did_start_user_gesture(&self) {
+        self.shared.did_start_user_gesture();
+    }
+
+    /// Report that the gesture reported by a matching
+    /// [`did_start_user_gesture`](Self::did_start_user_gesture) has finished.
+    /// Flutter's `NavigatorState.didStopUserGesture` (`navigator.dart:5847-5855`).
+    ///
+    /// # Panics (debug only)
+    ///
+    /// Debug-asserts it is never called more often than
+    /// [`did_start_user_gesture`](Self::did_start_user_gesture) — an unmatched
+    /// call is a caller bug (mirrors Flutter's `assert(_userGesturesInProgress
+    /// > 0)`).
+    pub fn did_stop_user_gesture(&self) {
+        self.shared.did_stop_user_gesture();
+    }
+
+    /// Whether at least one user gesture is currently in progress on this
+    /// navigator. Flutter's `NavigatorState.userGestureInProgress`
+    /// (`navigator.dart:5816`).
+    #[must_use]
+    pub fn user_gesture_in_progress(&self) -> bool {
+        self.shared.user_gesture_in_progress()
     }
 
     /// Whether both handles name the same navigator — an `Arc` identity check, for the
@@ -785,6 +879,42 @@ impl NavigatorHandle {
         self.pop_erased(Some(Box::new(result)))
     }
 
+    /// Pop `route`, but drive its exit transition with `duration`/`curve`
+    /// instead of its own default reverse pacing — for a gesture-driven pop
+    /// whose pacing comes from the drag itself (fling velocity, or the flat
+    /// "stay" pacing), not the route's static configuration. Flutter's
+    /// `_CupertinoBackGestureController.dragEnd` calling
+    /// `route.navigator!.pop()` while overriding `_controller.animateBack`'s
+    /// duration/curve (`cupertino/route.dart`, 3.44.0).
+    ///
+    /// Returns `false` and pops nothing if `route` is no longer the current
+    /// top route — Flutter's `!route.isCurrent` branch: a route swept away by
+    /// something else between the gesture's last frame and this call must not
+    /// have a stale drag finish it. Only a [`TransitionRoute`](super::transition_route::TransitionRoute)
+    /// (directly, or via `ModalRoute`/`PageRoute`) consumes the pacing; a plain
+    /// route's `did_pop` never asks for it.
+    pub(crate) fn pop_paced(
+        &self,
+        route: RouteId,
+        duration: Duration,
+        curve: Arc<dyn Curve + Send + Sync>, // PORT-CHECK-OK-DYN: see `PopPacing`'s marker (binding.rs) — same erased-easing-curve boundary
+    ) -> bool {
+        if self.current() != Some(route) {
+            return false;
+        }
+        self.shared
+            .registries
+            .pop_pacing
+            .lock()
+            .insert(route, PopPacing { duration, curve });
+        let popped = self.pop_erased(None);
+        // `did_pop` consumes this on a successful pop; a refused pop (or one
+        // that somehow never reached `route`) must not leave a stale override
+        // for a later, unrelated pop of the same route.
+        self.shared.registries.pop_pacing.lock().remove(&route);
+        popped
+    }
+
     /// Remove `id` without popping it — Flutter's `Navigator.removeRoute`
     /// (`:5733-5751`).
     ///
@@ -898,6 +1028,15 @@ impl NavigatorHandle {
     #[must_use]
     pub fn route_ids(&self) -> Vec<RouteId> {
         self.shared.history.lock().ids()
+    }
+
+    /// Whether `route` is present in this navigator's stack — Flutter's
+    /// `Route.isActive`. Used by a gesture's `!isCurrent` fallback
+    /// (`back_gesture.rs`): a route that has been swept off the stack
+    /// entirely (not just covered) animates forward rather than trying to
+    /// pop again.
+    pub(crate) fn route_is_active(&self, route: RouteId) -> bool {
+        self.shared.history.lock().is_present(route)
     }
 
     /// The lifecycle state of `id`'s entry. Test-facing.
@@ -1051,6 +1190,38 @@ impl NavigatorHandle {
     /// `None` for a route that is not a `ModalRoute`, or one already disposed.
     pub(crate) fn route_modal(&self, id: RouteId) -> Option<ModalHandle> {
         self.shared.registries.modals.lock().get(&id).cloned()
+    }
+
+    /// Whether `route` may start an edge-swipe-back gesture right now.
+    /// Flutter's `PageRoute.popGestureEnabled` (`pages.dart:63-66`) composed
+    /// with `super.popGestureEnabled` = `ModalRoute.popGestureEnabled`
+    /// (`routes.dart:1908-1930`): not the first (present) route, does not
+    /// handle its own pop, the pop disposition allows it (no `PopScope` veto,
+    /// no `WillPopScope` — FLUI has none, so that half is vacuously clear),
+    /// and the primary animation has finished (`animation!.isCompleted`).
+    /// `fullscreenDialog` is not ported (see `PageRoute::back_gesture`'s
+    /// doc), so that half of `PageRoute`'s own override is skipped.
+    ///
+    /// **FLUI addition, not in the oracle text:** also `false` while a user
+    /// gesture is already in progress on this navigator — the per-pointer-down
+    /// predicate must not admit a second, overlapping gesture start.
+    pub(crate) fn pop_gesture_enabled(&self, route: RouteId) -> bool {
+        if self.user_gesture_in_progress() {
+            return false;
+        }
+        let (is_first, will_handle_pop_internally, veto) = {
+            let history = self.shared.history.lock();
+            (
+                history.first_present() == Some(route),
+                history.will_handle_pop_internally(route),
+                history.pop_disposition_of_top() == Some(RoutePopDisposition::DoNotPop),
+            )
+        };
+        if is_first || will_handle_pop_internally != Some(false) || veto {
+            return false;
+        }
+        self.route_modal(route)
+            .is_some_and(|modal| modal.primary_animation().status().is_completed())
     }
 
     /// The binding's post-frame capability — `WidgetsBinding.instance

--- a/crates/flui-widgets/src/navigator/navigator.rs
+++ b/crates/flui-widgets/src/navigator/navigator.rs
@@ -361,9 +361,18 @@ impl NavigatorShared {
     /// Flutter's `NavigatorState.didStopUserGesture` (`navigator.dart:5847-5855`).
     /// Only the 1→0 transition notifies observers.
     fn did_stop_user_gesture(&self) {
+        // Saturating, not `fetch_sub`: `fetch_sub` on an unmatched call at 0
+        // wraps to `u32::MAX` in release (the debug_assert below is compiled
+        // out there), which would make every later `user_gesture_in_progress()`
+        // read `true` forever. `fetch_update` with `saturating_sub` makes an
+        // unmatched call a true no-op in release, exactly as the debug-only
+        // assert already documents it should be.
         let count_before = self
             .user_gestures_in_progress
-            .fetch_sub(1, Ordering::AcqRel);
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+                Some(count.saturating_sub(1))
+            })
+            .expect("BUG: the update closure always returns Some, fetch_update cannot fail");
         debug_assert!(
             count_before > 0,
             "BUG: did_stop_user_gesture called without a matching did_start_user_gesture"
@@ -1209,15 +1218,19 @@ impl NavigatorHandle {
         if self.user_gesture_in_progress() {
             return false;
         }
-        let (is_first, will_handle_pop_internally, veto) = {
+        // `popDisposition == RoutePopDisposition.doNotPop` in the oracle
+        // reads *this* route's own `popDisposition` (`ModalRoute
+        // .popDisposition`, `routes.dart`), not the top of the stack —
+        // `RouteHistory::vetoes_pop` is that per-route check. See its doc.
+        let (is_first, will_handle_pop_internally, vetoes_pop) = {
             let history = self.shared.history.lock();
             (
                 history.first_present() == Some(route),
                 history.will_handle_pop_internally(route),
-                history.pop_disposition_of_top() == Some(RoutePopDisposition::DoNotPop),
+                history.vetoes_pop(route),
             )
         };
-        if is_first || will_handle_pop_internally != Some(false) || veto {
+        if is_first || will_handle_pop_internally != Some(false) || vetoes_pop != Some(false) {
             return false;
         }
         self.route_modal(route)

--- a/crates/flui-widgets/src/navigator/navigator_tests.rs
+++ b/crates/flui-widgets/src/navigator/navigator_tests.rs
@@ -1300,7 +1300,7 @@ mod local_history {
 
     /// A modal page whose content captures the route's [`LocalHistoryHandle`]
     /// on mount.
-    fn page_with_handle(
+    pub(super) fn page_with_handle(
         sink: &Arc<Mutex<Option<LocalHistoryHandle>>>,
         duration: Duration,
     ) -> PageRoute<i32> {
@@ -1722,4 +1722,172 @@ fn a_focus_listener_may_call_back_into_the_navigator_during_a_transition() {
     );
 
     manager.unfocus();
+}
+
+// ============================================================================
+// User gestures (navigator.dart:5803-5860)
+// ============================================================================
+
+mod user_gesture {
+    use super::*;
+    use crate::navigator::observer::NavigatorObserver;
+    use crate::navigator::route::RouteId;
+
+    /// Records every `did_start_user_gesture`/`did_stop_user_gesture` call, in order.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum Note {
+        Start(RouteId, Option<RouteId>),
+        Stop,
+    }
+
+    #[derive(Default)]
+    struct Spy {
+        notes: Mutex<Vec<Note>>,
+    }
+
+    impl Spy {
+        fn notes(&self) -> Vec<Note> {
+            self.notes.lock().clone()
+        }
+    }
+
+    impl NavigatorObserver for Spy {
+        fn did_start_user_gesture(&self, route: RouteId, previous: Option<RouteId>) {
+            self.notes.lock().push(Note::Start(route, previous));
+        }
+        fn did_stop_user_gesture(&self) {
+            self.notes.lock().push(Note::Stop);
+        }
+    }
+
+    /// Flutter's `didStartUserGesture` resolves `route`/`previousRoute` from the
+    /// live history, so a two-route stack reports the top and the route beneath.
+    ///
+    /// Red-check: don't release the history lock before firing observers — a
+    /// `did_start_user_gesture` observer that reads `handle.route_ids()` back
+    /// deadlocks instead of failing this assertion.
+    #[test]
+    fn did_start_user_gesture_reports_the_current_and_previous_route() {
+        let built = Built::default();
+        let handle = NavigatorHandle::new();
+        handle.seed_initial(page(&built, "/"));
+        let root = handle.route_ids()[0];
+        let spy = Arc::new(Spy::default());
+        handle.add_observer(Arc::clone(&spy) as Arc<dyn NavigatorObserver>);
+
+        let _pushed = handle.push(page(&built, "/next"));
+        let top_id = *handle.route_ids().last().expect("pushed route present");
+
+        assert!(!handle.user_gesture_in_progress());
+        handle.did_start_user_gesture();
+        assert!(handle.user_gesture_in_progress());
+        assert_eq!(spy.notes(), vec![Note::Start(top_id, Some(root))]);
+
+        handle.did_stop_user_gesture();
+        assert!(!handle.user_gesture_in_progress());
+        assert_eq!(
+            spy.notes(),
+            vec![Note::Start(top_id, Some(root)), Note::Stop]
+        );
+    }
+
+    /// The first (bottom) route has nothing beneath it — Flutter's `routeIndex
+    /// > 0` guard in `didStartUserGesture`.
+    #[test]
+    fn did_start_user_gesture_on_the_first_route_reports_no_previous() {
+        let built = Built::default();
+        let handle = NavigatorHandle::new();
+        handle.seed_initial(page(&built, "/"));
+        let root = handle.route_ids()[0];
+        let spy = Arc::new(Spy::default());
+        handle.add_observer(Arc::clone(&spy) as Arc<dyn NavigatorObserver>);
+
+        handle.did_start_user_gesture();
+        assert_eq!(spy.notes(), vec![Note::Start(root, None)]);
+        handle.did_stop_user_gesture();
+    }
+
+    /// Nested/overlapping gestures on the same navigator collapse to one
+    /// notification pair — only the 0→1 and 1→0 transitions fire.
+    #[test]
+    fn nested_user_gestures_notify_observers_exactly_once() {
+        let built = Built::default();
+        let handle = NavigatorHandle::new();
+        handle.seed_initial(page(&built, "/"));
+        let spy = Arc::new(Spy::default());
+        handle.add_observer(Arc::clone(&spy) as Arc<dyn NavigatorObserver>);
+
+        handle.did_start_user_gesture();
+        handle.did_start_user_gesture();
+        assert_eq!(spy.notes().len(), 1, "second start must not re-notify");
+        assert!(handle.user_gesture_in_progress());
+
+        handle.did_stop_user_gesture();
+        assert_eq!(spy.notes().len(), 1, "still one gesture outstanding");
+        assert!(handle.user_gesture_in_progress());
+
+        handle.did_stop_user_gesture();
+        assert_eq!(spy.notes().len(), 2, "the last stop notifies");
+        assert!(!handle.user_gesture_in_progress());
+    }
+
+    /// A route with a `LocalHistoryEntry` handles its own pop, so Flutter's
+    /// `!route.willHandlePopInternally` guard reports no previous route even
+    /// with a route beneath it.
+    #[test]
+    fn did_start_user_gesture_reports_no_previous_when_the_top_handles_its_own_pop() {
+        use std::time::Duration;
+
+        use crate::navigator::local_history::{LocalHistoryEntry, LocalHistoryHandle};
+
+        let built = Built::default();
+        let (handle, mut harness) = navigator_with(&built);
+        let sink: Arc<Mutex<Option<LocalHistoryHandle>>> = Arc::new(Mutex::new(None));
+        let _pushed = handle.push(super::local_history::page_with_handle(
+            &sink,
+            Duration::ZERO,
+        ));
+        harness.tick();
+        let local = sink.lock().clone().expect("the page captured its handle");
+        let _entry = local.add(LocalHistoryEntry::new());
+
+        let top_id = *handle.route_ids().last().expect("pushed route present");
+        let spy = Arc::new(Spy::default());
+        handle.add_observer(Arc::clone(&spy) as Arc<dyn NavigatorObserver>);
+
+        handle.did_start_user_gesture();
+        assert_eq!(spy.notes(), vec![Note::Start(top_id, None)]);
+        handle.did_stop_user_gesture();
+    }
+
+    /// A `NavigatorObserver::did_start_user_gesture` callback that calls back
+    /// into the navigator (e.g. `can_pop`) must not deadlock — the history
+    /// lock is released before observers run (the same lock-hazard class the
+    /// `PopScope` fan-out and the focus-listener path were fixed for).
+    #[test]
+    fn an_observer_may_call_back_into_the_navigator_from_did_start_user_gesture() {
+        struct ReentrantObserver {
+            handle: NavigatorHandle,
+            calls_seen: AtomicUsize,
+        }
+        impl NavigatorObserver for ReentrantObserver {
+            fn did_start_user_gesture(&self, _route: RouteId, _previous: Option<RouteId>) {
+                let _ = self.handle.can_pop();
+                self.calls_seen.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let built = Built::default();
+        let handle = NavigatorHandle::new();
+        handle.seed_initial(page(&built, "/"));
+        let observer = Arc::new(ReentrantObserver {
+            handle: handle.clone(),
+            calls_seen: AtomicUsize::new(0),
+        });
+        handle.add_observer(Arc::clone(&observer) as Arc<dyn NavigatorObserver>);
+
+        handle.did_start_user_gesture();
+        assert_eq!(observer.calls_seen.load(Ordering::SeqCst), 1);
+        handle.did_stop_user_gesture();
+    }
 }

--- a/crates/flui-widgets/src/navigator/observer.rs
+++ b/crates/flui-widgets/src/navigator/observer.rs
@@ -126,6 +126,20 @@ pub trait NavigatorObserver {
     fn did_replace(&self, new_route: Option<RouteId>, old_route: Option<RouteId>) {}
     /// The topmost present route changed.
     fn did_change_top(&self, top: RouteId, previous_top: Option<RouteId>) {}
+
+    /// A user gesture (e.g. an edge swipe-back) started manipulating `route`.
+    /// Flutter's `NavigatorObserver.didStartUserGesture` (`navigator.dart:811`).
+    ///
+    /// Fires once per navigator when the in-progress gesture count goes from
+    /// zero to one — [`NavigatorHandle::did_start_user_gesture`] paired with
+    /// [`NavigatorHandle::did_stop_user_gesture`] tracks that count, not this
+    /// callback directly, so a nested/overlapping gesture on the same
+    /// navigator does not re-fire.
+    fn did_start_user_gesture(&self, route: RouteId, previous: Option<RouteId>) {}
+    /// The user gesture reported by the most recent
+    /// [`did_start_user_gesture`](Self::did_start_user_gesture) finished.
+    /// Flutter's `NavigatorObserver.didStopUserGesture` (`navigator.dart:816`).
+    fn did_stop_user_gesture(&self) {}
 }
 
 /// One queued notification. Flutter's `_NavigatorObservation` hierarchy

--- a/crates/flui-widgets/src/navigator/page_route.rs
+++ b/crates/flui-widgets/src/navigator/page_route.rs
@@ -282,6 +282,29 @@ impl<T: Send + Clone + 'static> PageRoute<T> {
         self.modal = self.modal.with_current_result(result);
         self
     }
+
+    /// Opt into an iOS-style edge-swipe-back gesture. Default `false`.
+    ///
+    /// Flutter's `CupertinoPageRoute`/`CupertinoRouteTransitionMixin` wire this
+    /// on automatically under the Cupertino theme; FLUI has no platform-theme
+    /// selection yet, so it is an explicit opt-in per route instead. Ports
+    /// `PageRoute.popGestureEnabled` ∘ `ModalRoute.popGestureEnabled`
+    /// (`pages.dart:63-66`, `routes.dart:1908-1930`, 3.44.0) minus the
+    /// `!fullscreenDialog` half — FLUI has no `fullscreenDialog` flag, so
+    /// this opt-in itself is the substitute gate.
+    ///
+    /// **Not a mid-life toggle.** Set it once, before pushing the route:
+    /// `ModalScopeState::build` reads the flag on every build to decide
+    /// whether to wrap the page in the detector, and flipping it after the
+    /// route is live would change the page subtree's identity out from under
+    /// any `StatefulView` inside it, discarding its state (a cancelled
+    /// mid-gesture drag must not do this — see
+    /// `back_gesture_enabled_preserves_page_state_across_a_cancelled_gesture`).
+    #[must_use]
+    pub fn back_gesture(mut self, enabled: bool) -> Self {
+        self.modal = self.modal.back_gesture(enabled);
+        self
+    }
 }
 
 impl<T: Send + Clone + 'static> PageRoute<T> {

--- a/crates/flui-widgets/src/navigator/page_route_tests.rs
+++ b/crates/flui-widgets/src/navigator/page_route_tests.rs
@@ -526,3 +526,85 @@ fn page_and_transitions_builders_receive_both_animations_and_rebuild_on_tick() {
         "the page builder sees the current animation value, got {samples:?}"
     );
 }
+
+// ============================================================================
+// back_gesture — the swipe-back detector substrate (back_gesture.rs)
+// ============================================================================
+
+/// `PageRoute::back_gesture(true)` wraps the page in the edge-swipe-back
+/// detector (`ModalScopeState::build`, `back_gesture.rs`'s `Stack` +
+/// `Positioned` + `Listener` + arena-fed recognizer). Mounting, laying out
+/// and painting it end to end must not panic, and once the entrance settles
+/// the route reports itself gesture-eligible.
+#[test]
+fn back_gesture_enabled_route_mounts_and_becomes_pop_gesture_eligible() {
+    let (navigator, mut harness, _bottom) = navigator_with_seed();
+
+    let route = PageRoute::<i32>::new(leaf).back_gesture(true);
+    let transition = route.transition_handle();
+    let _pushed = harness.enter_owner_scope(|| navigator.push(route));
+    complete_entrance(&transition, &mut harness);
+
+    let top = *navigator.route_ids().last().expect("pushed");
+    assert!(
+        navigator.pop_gesture_enabled(top),
+        "a settled, non-first, unvetoed route with back_gesture(true) is eligible"
+    );
+}
+
+/// The detector wrapper's presence must not flip the page subtree's
+/// identity: a `StatefulView` inside the page keeps its state (here, its
+/// `create_state` call count stays at 1) across the rebuilds a released-but-
+/// cancelled gesture ("stay": the finger let go before crossing halfway, so
+/// the route animates back to fully on top rather than popping) drives.
+///
+/// Red-check: wrap the page in a *freshly constructed* detector view each
+/// build instead of the same stable shape — `Probe::create_state` would then
+/// fire more than once as the element tree treats the page as a new subtree.
+#[test]
+fn back_gesture_enabled_preserves_page_state_across_a_cancelled_gesture() {
+    let created = Arc::new(AtomicUsize::new(0));
+    let probe = Probe(Arc::clone(&created));
+
+    let (navigator, mut harness, _bottom) = navigator_with_seed();
+    let route = PageRoute::<i32>::new(move |_ctx, _animation, _secondary| {
+        probe.clone().into_view().boxed()
+    })
+    .back_gesture(true);
+    let transition = route.transition_handle();
+    let _pushed = harness.enter_owner_scope(|| navigator.push(route));
+    complete_entrance(&transition, &mut harness);
+    assert_eq!(
+        created.load(Ordering::Relaxed),
+        1,
+        "one initial create_state"
+    );
+
+    let top = *navigator.route_ids().last().expect("pushed");
+    let controller = transition.controller().expect("installed");
+
+    // Simulate a released-but-cancelled drag: partway back, then released
+    // with no fling and value > 0.5, so the oracle's `dragEnd` "stay" branch
+    // animates forward to 1.0 rather than popping.
+    let gesture =
+        super::back_gesture::BackGestureController::new(navigator.clone(), top, controller.clone());
+    gesture.drag_update(0.2); // value -> 0.8
+    let still_settling = gesture.drag_end(0.0);
+    assert!(still_settling, "the stay animation keeps running");
+    assert_eq!(controller.status(), AnimationStatus::Forward);
+
+    // Drive the stay animation to completion across several ticks — each one
+    // rebuilds `ModalScope`, and therefore the detector-wrapped page.
+    for _ in 0..4 {
+        harness.tick();
+    }
+    controller.set_value(1.0);
+    harness.tick();
+
+    assert_eq!(
+        created.load(Ordering::Relaxed),
+        1,
+        "the page's StatefulView must not be recreated across the cancelled \
+         gesture's rebuilds"
+    );
+}

--- a/crates/flui-widgets/src/navigator/page_route_tests.rs
+++ b/crates/flui-widgets/src/navigator/page_route_tests.rs
@@ -16,7 +16,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use flui_animation::{Animation, AnimationStatus};
+use flui_rendering::hit_testing::HitTestResult;
 use flui_types::Color;
+use flui_types::geometry::{Offset, px};
 use flui_view::prelude::*;
 use flui_view::{BoxedView, BuildContext};
 
@@ -552,6 +554,115 @@ fn back_gesture_enabled_route_mounts_and_becomes_pop_gesture_eligible() {
     );
 }
 
+/// Dispatches a synthetic pointer event at `(x, y)` through the harness's
+/// **real** hit-testing pipeline (`PipelineOwner::hit_test` +
+/// `HitTestResult::dispatch`) — the same path `Listener::on_pointer_*`
+/// callbacks fire from in production, so this actually exercises
+/// `back_gesture.rs`'s `Listener` → `DragGestureRecognizer` →
+/// `BackGestureRuntime` wiring, not a bypass of it.
+///
+/// This harness's dispatch re-hit-tests at each call's position (no
+/// pointer-id capture, unlike the real `EventRouter`), so every position in
+/// one gesture must land on the *same* hit-testable target throughout —
+/// see the caller for why that keeps every position inside the 20px-wide
+/// edge strip.
+fn dispatch_pointer_event(
+    harness: &Harness,
+    x: f32,
+    y: f32,
+    make_event: fn(
+        Offset<flui_types::Pixels>,
+        flui_interaction::events::PointerType,
+    ) -> flui_interaction::PointerEvent,
+) {
+    let position = Offset::new(px(x), px(y));
+    let owner = harness.pipeline_owner();
+    let mut result = HitTestResult::new();
+    owner.read().hit_test(position, &mut result);
+    let event = make_event(position, flui_interaction::events::PointerType::Mouse);
+    harness.enter_owner_scope(|| result.dispatch(&event));
+}
+
+/// A real, hit-tested horizontal drag through the mounted tree must move the
+/// controller's value by `delta / route_width` — the harness's fixed 800px
+/// screen (`test_harness.rs`), which the route's page fills
+/// (`Stack(fit: expand)`) — never by `delta / BACK_GESTURE_WIDTH` (20px).
+/// This is exactly the path that would have caught
+/// `BackGestureRuntime::normalized_width` never reading the route's real
+/// laid-out size and silently normalizing against the 20px hit strip
+/// instead.
+///
+/// Every dispatched position stays inside the 20px-wide, full-height edge
+/// strip on purpose: `dispatch_pointer_event` re-hit-tests at each call (no
+/// pointer-id capture), so a position outside the strip's own bounds would
+/// simply stop reaching the detector's `Listener` — the same constraint
+/// `gesture_detector_recognizes_a_pan_and_suppresses_the_tap`
+/// (`tests/gesture_detector.rs`) documents for that harness. The
+/// recognizer's own delta reporting (`DragGestureRecognizer::handle_move`)
+/// is a clean *incremental* delta since the last update once the run has
+/// started, not "total move minus slop" — so a sub-pixel post-slop move is
+/// still a clean, exact signal, not a fragile one.
+///
+/// Red-check: put back `width: Cell::new(BACK_GESTURE_WIDTH)` with no
+/// refresh — the observed value drop becomes ~40x larger (0.4/20 instead of
+/// 0.4/800) and the `< 0.01` assertion fails.
+#[test]
+fn back_gesture_edge_drag_normalizes_against_the_routes_real_width_not_the_hit_strip() {
+    let (navigator, mut harness, _bottom) = navigator_with_seed();
+
+    let route = PageRoute::<i32>::new(leaf).back_gesture(true);
+    let transition = route.transition_handle();
+    let _pushed = harness.enter_owner_scope(|| navigator.push(route));
+    complete_entrance(&transition, &mut harness);
+    let controller = transition.controller().expect("installed");
+    assert_eq!(controller.value(), 1.0);
+
+    // Down at x=1 (inside [0, 20)); the first move crosses the recognizer's
+    // 18px horizontal slop (`DEFAULT_PAN_SLOP_HORIZONTAL`) and fires
+    // `on_start` with no reported delta (`DragStartBehavior::Start`); the
+    // second, 0.4px further, fires `on_update` with a clean incremental
+    // `primary_delta` of 0.4px — both moves stay inside the 20px strip.
+    dispatch_pointer_event(
+        &harness,
+        1.0,
+        300.0,
+        flui_interaction::events::make_down_event,
+    );
+    dispatch_pointer_event(
+        &harness,
+        19.5,
+        300.0,
+        flui_interaction::events::make_move_event,
+    );
+    dispatch_pointer_event(
+        &harness,
+        19.9,
+        300.0,
+        flui_interaction::events::make_move_event,
+    );
+
+    let dropped = 1.0 - controller.value();
+    assert!(
+        dropped > 0.0,
+        "the drag must have moved the controller at all through real hit-testing \
+         — got value={}",
+        controller.value()
+    );
+    assert!(
+        dropped < 0.01,
+        "0.4px over an 800px-wide route should barely move the value \
+         (expected ~0.0005); got a drop of {dropped}, consistent with \
+         normalizing against the 20px hit strip instead (0.4/20 = 0.02)"
+    );
+
+    dispatch_pointer_event(
+        &harness,
+        19.9,
+        300.0,
+        flui_interaction::events::make_up_event,
+    );
+}
+
 /// The detector wrapper's presence must not flip the page subtree's
 /// identity: a `StatefulView` inside the page keeps its state (here, its
 /// `create_state` call count stays at 1) across the rebuilds a released-but-
@@ -593,14 +704,26 @@ fn back_gesture_enabled_preserves_page_state_across_a_cancelled_gesture() {
     assert!(still_settling, "the stay animation keeps running");
     assert_eq!(controller.status(), AnimationStatus::Forward);
 
-    // Drive the stay animation to completion across several ticks — each one
-    // rebuilds `ModalScope`, and therefore the detector-wrapped page.
-    for _ in 0..4 {
-        harness.tick();
-    }
-    controller.set_value(1.0);
+    // Genuinely tick the 350ms stay run out through the controller's own
+    // tick mechanism — not a `set_value(1.0)` shortcut, which would settle
+    // it inline without ever exercising the mid-run rebuilds this test
+    // exists to check. Safe to drive directly: this route's controller was
+    // built with its own standalone `Scheduler` (no ambient `VsyncScope` in
+    // this fixture), so `harness.tick()` — which drives the *harness's*
+    // separate binding/scheduler — never independently re-ticks it; nothing
+    // races the explicit `tick_at` calls below.
+    controller.tick_at(0.10); // mid-flight
+    harness.tick(); // rebuilds ModalScope, and therefore the detector-wrapped page
+    controller.tick_at(0.25); // still mid-flight
+    harness.tick();
+    controller.tick_at(0.35); // >= the 350ms stay duration -> settles to Completed
     harness.tick();
 
+    assert_eq!(
+        controller.status(),
+        AnimationStatus::Completed,
+        "the stay run must have genuinely settled, not been forced"
+    );
     assert_eq!(
         created.load(Ordering::Relaxed),
         1,

--- a/crates/flui-widgets/src/navigator/tests.rs
+++ b/crates/flui-widgets/src/navigator/tests.rs
@@ -1247,6 +1247,7 @@ fn binding_for(history: &RouteHistory, id: RouteId) -> RouteBinding {
             entries: Arc::new(Mutex::new(std::collections::HashMap::new())),
             subtrees: Arc::new(Mutex::new(std::collections::HashMap::new())),
             modals: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            pop_pacing: Arc::new(Mutex::new(std::collections::HashMap::new())),
         },
     )
 }
@@ -1267,6 +1268,7 @@ fn route_binding_wake_accepts_owner_local_rc_state() {
             entries: Arc::new(Mutex::new(std::collections::HashMap::new())),
             subtrees: Arc::new(Mutex::new(std::collections::HashMap::new())),
             modals: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            pop_pacing: Arc::new(Mutex::new(std::collections::HashMap::new())),
         },
     );
 

--- a/crates/flui-widgets/src/navigator/transition_route.rs
+++ b/crates/flui-widgets/src/navigator/transition_route.rs
@@ -677,10 +677,29 @@ impl<T: Send + Clone + 'static> Route for TransitionRoute<T> {
     /// `didPop(result)` (`routes.dart:376-391`): drive the controller in reverse
     /// and consent. The route's `RouteResult` completes **now**, via
     /// `RouteRecord::did_pop`; only its disposal waits for `dismissed`.
+    ///
+    /// A gesture-driven pop rides its own pacing in here: `pop_paced` (see
+    /// `navigator.rs`) publishes a one-shot [`PopPacing`](super::binding::PopPacing)
+    /// for exactly this route immediately before triggering the pop, and this
+    /// is where it is consumed — Flutter's
+    /// `_CupertinoBackGestureController.dragEnd` calling `_controller.animateBack`
+    /// with its own duration/curve instead of the route's plain `reverse()`
+    /// (`cupertino/route.dart`, 3.44.0). No pacing published (the ordinary,
+    /// programmatic pop) falls back to the plain reverse.
     fn did_pop(&mut self) -> bool {
         self.inner.popped.store(true, Ordering::Release);
+        let pacing = self
+            .inner
+            .binding
+            .get()
+            .and_then(|binding| binding.take_pop_pacing());
         if let Some(controller) = self.inner.controller.lock().as_ref() {
-            let _ = controller.reverse();
+            let _ = match pacing {
+                Some(pacing) => {
+                    controller.animate_back_curved(0.0, Some(pacing.duration), pacing.curve)
+                }
+                None => controller.reverse(),
+            };
         }
         true
     }

--- a/crates/flui-widgets/src/navigator/transition_route_tests.rs
+++ b/crates/flui-widgets/src/navigator/transition_route_tests.rs
@@ -16,7 +16,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use flui_animation::{Animation, AnimationStatus, Vsync};
+use flui_animation::{Animation, AnimationStatus, Curve, Curves, Vsync};
 use flui_view::prelude::*;
 use parking_lot::Mutex;
 
@@ -591,7 +591,14 @@ fn a_stale_train_does_not_clobber_a_newer_parent() {
     harness.tick();
     let middle_controller = middle_animation.controller().expect("installed");
     middle_controller.set_value(0.2);
-    assert!(middle_controller.is_animating());
+    // `update_secondary_animation`'s "is this train moving" check reads
+    // `status()` (Forward|Reverse), not `is_animating()` — see the divergence
+    // note at `transition_route.rs`'s `update_secondary_animation`
+    // (`routes.dart:438-439`). `is_animating()` is ticker-based
+    // (`AnimationController::is_animating` doc), and `set_value` now stops
+    // the ticker like Flutter's `value=` setter, so it is no longer a stand-in
+    // for "moving" here.
+    assert!(middle_controller.status().is_running());
 
     // `top` is settled, so `can_remove_or_add` is true and removals actually
     // dispose. Without this, nothing below is ever disposed.
@@ -742,4 +749,132 @@ fn status_listener_does_not_hold_a_lock_across_the_binding_call() {
     harness.tick();
     assert_eq!(navigator_handle.route_ids().len(), 1);
     let _ = Arc::new(Mutex::new(()));
+}
+
+// ============================================================================
+// `pop_paced` — gesture pacing rides the pop command, no stored field
+// ============================================================================
+
+/// `pop_paced` reaches `TransitionRoute::did_pop`, which eases through the
+/// given curve/duration instead of the route's own plain `reverse()` —
+/// Flutter's `_CupertinoBackGestureController.dragEnd` calling
+/// `_controller.animateBack(target, duration: ..., curve: ...)`
+/// (`cupertino/route.dart`, 3.44.0).
+///
+/// Red-check: drop the `take_pop_pacing()` branch from `TransitionRoute::did_pop`
+/// — the eased-value assertion fails (a plain `reverse()` lands at 0.75, not
+/// `EaseInQuint`'s ~0.945 at t=0.5 reversed).
+#[test]
+fn pop_paced_drives_the_controller_with_the_given_duration_and_curve() {
+    let (navigator_handle, mut harness) = navigator();
+    let (route, animation) = transition("only");
+    navigator_handle.push(route);
+    complete(&animation);
+    harness.tick();
+
+    let route_id = navigator_handle
+        .route_ids()
+        .last()
+        .copied()
+        .expect("pushed");
+    let controller = animation.controller().expect("installed");
+
+    let curve: Arc<dyn Curve + Send + Sync> = Arc::new(Curves::EaseInQuint); // PORT-CHECK-OK-DYN: see `PopPacing`'s doc (binding.rs) — same erased easing-curve boundary
+    assert!(navigator_handle.pop_paced(route_id, Duration::from_millis(100), curve));
+    assert_eq!(controller.status(), AnimationStatus::Reverse);
+
+    controller.tick_at(0.05); // 50ms of the 100ms paced duration
+    let expected = 1.0 - Curves::EaseInQuint.transform(0.5);
+    assert!(
+        (controller.value() - expected).abs() < 1e-3,
+        "got {}, want {expected} (eased through the given curve over the given \
+         duration, not the route's own linear reverse)",
+        controller.value()
+    );
+}
+
+/// Flutter's `!route.isCurrent` branch in `dragEnd`: a route swept away by
+/// something else between the gesture's last frame and the drag's completion
+/// must not have a stale drag finish it.
+///
+/// Red-check: drop the `self.current() != Some(route)` guard from `pop_paced`
+/// — it pops "top" instead of refusing, and this test's `!popped` assertion
+/// fails.
+#[test]
+fn pop_paced_no_ops_when_the_route_is_no_longer_current() {
+    let (navigator_handle, mut harness) = navigator();
+    let (bottom, bottom_animation) = transition("bottom");
+    navigator_handle.push(bottom);
+    complete(&bottom_animation);
+    harness.tick();
+    let bottom_id = navigator_handle
+        .route_ids()
+        .last()
+        .copied()
+        .expect("pushed");
+
+    let (top, top_animation) = transition("top");
+    navigator_handle.push(top);
+    complete(&top_animation);
+    harness.tick();
+
+    let curve: Arc<dyn Curve + Send + Sync> = Arc::new(Curves::EaseInQuint); // PORT-CHECK-OK-DYN: see `PopPacing`'s doc (binding.rs) — same erased easing-curve boundary
+    let popped = navigator_handle.pop_paced(bottom_id, Duration::from_millis(100), curve);
+    assert!(
+        !popped,
+        "bottom is covered by top — the gesture's pop must no-op"
+    );
+
+    let bottom_controller = bottom_animation.controller().expect("installed");
+    assert_eq!(
+        bottom_controller.status(),
+        AnimationStatus::Completed,
+        "bottom's controller must be untouched by the refused pop"
+    );
+    assert!(!bottom_controller.is_animating());
+}
+
+/// A `pop_paced` call that no-ops (the target route was not current) must not
+/// leave its pacing override behind for a *later, unrelated* pop to pick up —
+/// the whole reason `PopPacing` lives in a one-shot registry entry rather
+/// than a field on the route: no route to go stale on.
+///
+/// Red-check: remove the cleanup `self.shared.registries.pop_pacing.lock().remove(&route)`
+/// from `NavigatorHandle::pop_paced` — the plain `pop()` below picks up
+/// `bottom`'s leftover 999ms eased pacing instead of `top`'s own linear one.
+#[test]
+fn a_refused_pop_paced_does_not_leak_pacing_into_a_later_unrelated_pop() {
+    let (navigator_handle, mut harness) = navigator();
+    let (bottom, bottom_animation) = transition("bottom");
+    navigator_handle.push(bottom);
+    complete(&bottom_animation);
+    harness.tick();
+    let bottom_id = navigator_handle
+        .route_ids()
+        .last()
+        .copied()
+        .expect("pushed");
+
+    let (top, top_animation) = transition("top");
+    navigator_handle.push(top);
+    complete(&top_animation);
+    harness.tick();
+
+    let curve: Arc<dyn Curve + Send + Sync> = Arc::new(Curves::EaseInQuint); // PORT-CHECK-OK-DYN: see `PopPacing`'s doc (binding.rs) — same erased easing-curve boundary
+    assert!(!navigator_handle.pop_paced(bottom_id, Duration::from_millis(999), curve));
+
+    // A plain pop of the real current route ("top") must use ITS OWN linear
+    // 300ms pacing, not bottom's stale override.
+    assert!(navigator_handle.pop());
+    harness.tick();
+
+    let top_controller = top_animation.controller().expect("installed");
+    assert_eq!(top_controller.status(), AnimationStatus::Reverse);
+    top_controller.tick_at(0.15); // 150ms of the route's own 300ms duration
+    assert!(
+        (top_controller.value() - 0.5).abs() < 1e-3,
+        "a plain pop must use the route's own linear pacing, not a leftover \
+         pop_paced override meant for a different route: got {}",
+        top_controller.value()
+    );
 }


### PR DESCRIPTION
## Summary

Delivers the swipe-back substrate (ADR-0020 §7e front) — the blocker for the last Hero parity gap (user-gesture flights). Ports Flutter 3.44.0's `_CupertinoBackGestureDetector`/`_CupertinoBackGestureController` shape into `flui-widgets`, with the Cupertino-styled visuals and per-hero `transitionOnUserGestures` opt-in deferred to follow-up units.

### flui-animation contract fixes (prerequisite)
- `AnimationController::set_value` now matches Flutter's `value=` setter: stops any active run first, and status emission is change-detected (`_checkStatusChanged` parity — previously listeners re-fired on every call). Both RED-first.
- `CurvedAnimation` seeds its direction capture from the parent's status at construction (`_updateCurveDirection` parity).
- Additive `animate_to_curved` / `animate_back_curved`.

### Navigator substrate
- `NavigatorHandle::{did_start_user_gesture, did_stop_user_gesture, user_gesture_in_progress}` + `NavigatorObserver` hooks (saturating counter; observer notify with no lock held).
- `pop_paced`: pacing travels with the pop command through a `RouteId`-keyed one-shot registry — no route-side mutable override state, so a vetoed/no-op pop can't leak pacing onto a later pop.
- `pop_gesture_enabled` ports `PageRoute.popGestureEnabled` (per-route `popDisposition`; one documented non-oracle addition: refuses while a gesture is already in progress).
- `PageRoute::back_gesture(bool)` opt-in (default off — no platform theme yet, documented divergence).

### back_gesture.rs (new, pub(crate))
- `BackGestureController`: full `dragEnd` matrix (fling ≥ 1.0 screen-widths/s, `value > 0.5` threshold, 350 ms flat `FastEaseInToSlowEaseOut` pacing, `!isCurrent → is_active` fallback per flutter#141268). Drag deltas normalize against the route's live laid-out width.
- Edge detector: 20 px strip inside the transition, arena-fed `horizontal_drag` (nested scrollables compete normally), per-pointer-down enablement predicate, RTL sign normalization, multi-touch guard, and a dispose safety net covering **both** owed-stop states (live gesture and awaiting-settle) so a route swept mid-settle can't leak the navigator-wide gesture counter.
- Hero flights are suppressed during gesture-driven pops (Flutter's `transitionOnUserGestures=false` default).

### Tests
~40 new tests, including a mounted pointer-event-driven end-to-end swipe through real hit-testing, full-settle-via-ticking with observer assertions, swept-mid-settle counter recovery, the release matrix, RTL, and per-pointer-down predicate re-evaluation. Adversarial design review pre-code (2 fatal findings fixed in design) + full review with 2 blockers fixed and re-verified.

### Gates
`cargo nextest run --workspace --exclude flui-platform` 6446 passed / 4 skipped · workspace clippy `-D warnings` clean · doc gate clean · port-check (22 triggers) clean · fmt/taplo/typos/inventory clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvkSGveJwxLVuygRAGVKuz