### PR TITLE
feat(widgets): Hero transitionOnUserGestures — user-gesture hero flights

### DIFF
--- a/crates/flui-widgets/src/navigator/hero.rs
+++ b/crates/flui-widgets/src/navigator/hero.rs
@@ -43,7 +43,7 @@
 //!   element walk. `HeroControllerScope::none` still blocks a nested navigator's own
 //!   *auto-default controller* (so it flies no heroes on its own pushes/pops), but it
 //!   does not gate this visibility hook — Flutter's predicate does not consult it
-//!   either. `transitionOnUserGestures` stays out of scope.
+//!   either.
 //!
 //! **A `GlobalKey`-reparented nested `Navigator`'s re-sync is verified in
 //! isolation, not end-to-end.** `NavigatorState::sync_nested_hero_registration`
@@ -450,6 +450,11 @@ struct HeroInner {
     /// Flutter never *visits* a disabled hero (`heroes.dart:335-337`); FLUI registers
     /// it and the measurement pass skips it instead.
     hero_mode_enabled: AtomicBool,
+    /// `Hero.transitionOnUserGestures` (`heroes.dart:264`). Defaults to
+    /// `false`; a pair flies during a gesture-driven transition only when
+    /// **both** ends opt in (`Hero._allHeroesFor`'s `inviteHero`,
+    /// `heroes.dart:308-314`).
+    transition_on_user_gestures: AtomicBool,
 }
 
 /// An owned, `'static` capability to drive one mounted [`Hero`].
@@ -479,6 +484,7 @@ impl HeroHandle {
                 curve: Mutex::new(view.curve.clone()),
                 reverse_curve: Mutex::new(view.reverse_curve.clone()),
                 hero_mode_enabled: AtomicBool::new(true),
+                transition_on_user_gestures: AtomicBool::new(view.transition_on_user_gestures),
             }),
         }
     }
@@ -546,6 +552,15 @@ impl HeroHandle {
     /// Whether the ambient [`HeroMode`] allows this hero to fly.
     pub(crate) fn hero_mode_enabled(&self) -> bool {
         self.inner.hero_mode_enabled.load(Ordering::Relaxed)
+    }
+
+    /// `Hero.transitionOnUserGestures` (`heroes.dart:264`): whether this hero
+    /// opts into a gesture-driven (e.g. edge swipe-back) flight. `false` by
+    /// default, matching Flutter.
+    pub(crate) fn transition_on_user_gestures(&self) -> bool {
+        self.inner
+            .transition_on_user_gestures
+            .load(Ordering::Relaxed)
     }
 
     /// Whether an in-flight hero keeps its child offstage inside the placeholder.
@@ -649,8 +664,8 @@ impl fmt::Debug for HeroHandle {
 /// grounded with [`HeroMode`]. Cross-navigator flights work — a hero inside a nested
 /// `Navigator`'s current `PageRoute` matches an outer route's hero of the same tag,
 /// per `Hero._allHeroesFor`'s nested-navigator branch (`heroes.dart:317-333`).
-/// `transitionOnUserGestures` (gesture-driven flights) remains deferred, blocked on
-/// FLUI having no back-swipe.
+/// [`transition_on_user_gestures`](Self::transition_on_user_gestures) opts a hero
+/// into a gesture-driven (edge swipe-back) flight; `false` by default, as Flutter's is.
 #[derive(Clone)]
 pub struct Hero {
     tag: HeroTag,
@@ -660,6 +675,7 @@ pub struct Hero {
     placeholder: Option<PlaceholderBuilder>,
     curve: ArcCurve,
     reverse_curve: Option<ArcCurve>,
+    transition_on_user_gestures: bool,
 }
 
 impl Hero {
@@ -676,6 +692,7 @@ impl Hero {
             placeholder: None,
             curve: ArcCurve::new(Curves::FastOutSlowIn),
             reverse_curve: None,
+            transition_on_user_gestures: false,
         }
     }
 
@@ -694,6 +711,20 @@ impl Hero {
     #[must_use]
     pub fn reverse_curve(mut self, curve: impl Curve + Send + Sync + 'static) -> Self {
         self.reverse_curve = Some(ArcCurve::new(curve));
+        self
+    }
+
+    /// Whether this hero participates in a **gesture-driven** transition
+    /// (e.g. an edge swipe-back), as opposed to only a programmatic push/pop.
+    /// Flutter's `Hero.transitionOnUserGestures` (`heroes.dart:251-264`).
+    ///
+    /// A pair flies during a gesture-driven transition only when **both**
+    /// ends opt in; a hero left out this way is explicitly un-hidden if a
+    /// prior flight had frozen it (`Hero._allHeroesFor`'s `inviteHero` else
+    /// branch, `heroes.dart:311-314`). Defaults to `false`.
+    #[must_use]
+    pub fn transition_on_user_gestures(mut self, enabled: bool) -> Self {
+        self.transition_on_user_gestures = enabled;
         self
     }
 
@@ -827,6 +858,10 @@ impl ViewState<Hero> for HeroState {
             .reverse_curve
             .lock()
             .clone_from(&new_view.reverse_curve);
+        self.handle
+            .inner
+            .transition_on_user_gestures
+            .store(new_view.transition_on_user_gestures, Ordering::Relaxed);
     }
 
     /// Everything a hero needs from outside itself is acquired **here**, in the one

--- a/crates/flui-widgets/src/navigator/hero_controller.rs
+++ b/crates/flui-widgets/src/navigator/hero_controller.rs
@@ -66,8 +66,7 @@
 //! FLUI's state-preserving `Hero::placeholder` (in place of Flutter's lossy
 //! `placeholderBuilder`), and `Hero::curve` / `Hero::reverse_curve` with Flutter's
 //! `Curves.fastOutSlowIn` default (`heroes.dart:181`). `FlightDirection` is public
-//! for the shuttle builder, and `HeroMode` grounds a subtree. Still absent:
-//! `transitionOnUserGestures`.
+//! for the shuttle builder, and `HeroMode` grounds a subtree.
 //!
 //! The private surface stays private: `HeroTag`, `HeroRegistry`, `HeroScope`,
 //! `HeroHandle`, `HeroFlightManifest`, and the flight machinery are `pub(crate)`, and
@@ -81,19 +80,18 @@
 //! its *own* controller (so it drives no flights of its own), but does not gate
 //! this matching — Flutter's predicate does not consult it either.
 //!
-//! **Gesture suppression substrate landed, per-hero opt-in still pending.**
-//! [`NavigatorHandle::user_gesture_in_progress`] mirrors Flutter's
-//! `NavigatorState.userGestureInProgress`, and [`did_change_top`](HeroController::did_change_top)
-//! consults it exactly where Flutter's `HeroController.didChangeTop` does
-//! (`heroes.dart:861`): a route change committed by a finger-driven pop starts no
-//! flight. What is still absent is the *other* half — `didStartUserGesture` calling
-//! `_maybeStartHeroTransition(isUserGestureTransition: true)` for immediate visual
-//! feedback the instant a drag begins (`heroes.dart:871-880`), the `hasValidSize`
-//! fast path that lets that flight measure without waiting a frame
-//! (`:952-960`), and `Hero.transitionOnUserGestures` itself — with no per-hero
-//! opt-in field, every FLUI hero behaves as `transitionOnUserGestures = false`,
-//! so a gesture-driven transition suppresses every hero's flight, never just the
-//! non-opted-in ones (`heroes.dart:281-311`'s `_allHeroesFor` filter).
+//! **User-gesture hero flights are live**, closing the last Flutter parity gap:
+//! [`did_start_user_gesture`](HeroController::did_start_user_gesture) launches a
+//! flight the instant a drag begins (`heroes.dart:871-880`), with a synchronous
+//! measurement fast path when the destination already has a valid laid-out size
+//! (`_maybeStartHeroTransition`'s `hasValidSize` branch, `:948-959`);
+//! [`did_stop_user_gesture`](HeroController::did_stop_user_gesture) manually
+//! dismisses a flight whose drag never moved (`:882-907`); and
+//! [`Hero::transition_on_user_gestures`](super::hero::Hero::transition_on_user_gestures)
+//! gates per-hero participation (`heroes.dart:281-311`'s `_allHeroesFor` filter) —
+//! a pair flies during a gesture only when both ends opt in. The terminal-status
+//! deferral this all rests on lives in `hero_flight.rs`
+//! (`_HeroFlight._handleAnimationUpdate`, `:622-650`).
 //!
 //! [`ModalHandle::set_offstage`]: super::modal_route::ModalHandle::set_offstage
 //! [`PostFrameHandle`]: flui_scheduler::PostFrameHandle
@@ -107,6 +105,7 @@
 // seam from being deleted and re-derived later, out of step with the design.
 #![allow(dead_code)]
 
+use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -138,11 +137,24 @@ pub enum FlightDirection {
 
 impl FlightDirection {
     /// `switch ((isUserGestureTransition, oldRouteAnimation.status,
-    /// newRouteAnimation.status))` (`heroes.dart:924-932`), minus the gesture arm.
+    /// newRouteAnimation.status))` (`heroes.dart:924-932`).
+    ///
+    /// A user-gesture transition is unconditionally a pop — Flutter's
+    /// `case (true, _, _): flightType = HeroFlightDirection.pop` fires before
+    /// either route's own status is even consulted, since the gesture (an edge
+    /// swipe-back) is definitionally a pop-in-progress regardless of what the
+    /// drag has done to the routes' animation values so far.
     ///
     /// `None` means "neither route is transitioning" — Flutter's `default: flightType
     /// = null`, which does **not** abort: the measurement still runs (`:934-976`).
-    fn classify(from_status: AnimationStatus, to_status: AnimationStatus) -> Option<Self> {
+    fn classify(
+        is_user_gesture_transition: bool,
+        from_status: AnimationStatus,
+        to_status: AnimationStatus,
+    ) -> Option<Self> {
+        if is_user_gesture_transition {
+            return Some(Self::Pop);
+        }
         match (from_status, to_status) {
             (AnimationStatus::Reverse, _) => Some(Self::Pop),
             (_, AnimationStatus::Forward) => Some(Self::Push),
@@ -211,6 +223,9 @@ pub(crate) struct HeroFlightManifest {
     pub(crate) from_rect: Rect,
     /// `toHero`'s bounding box in `toRoute`'s coordinate space (`:520`).
     pub(crate) to_rect: Rect,
+    /// `manifest.isUserGestureTransition` (`heroes.dart:453`): started by
+    /// `didStartUserGesture`, not a programmatic push/pop.
+    pub(crate) is_user_gesture_transition: bool,
 }
 
 /// Watches a navigator, measures where hero flights land, and launches private flights.
@@ -302,15 +317,20 @@ impl HeroController {
         &self.flights
     }
 
-    /// Flutter's `_maybeStartHeroTransition` (`heroes.dart:892-976`), reduced to the
-    /// eligibility test and the offstage-then-schedule move.
+    /// Flutter's `_maybeStartHeroTransition` (`heroes.dart:892-976`): the
+    /// eligibility test, then either the gesture-pop sync fast path or the
+    /// offstage-then-schedule move.
     ///
-    /// Runs **inside an observer callback**, so it does exactly two kinds of work:
-    /// registry lookups behind their own mutexes, and scheduling. No element-tree
-    /// read, no render-tree read, no `history` mutation. (Those would be legal since
-    /// notification is delivered outside the history lock — but they would be
-    /// wrong: nothing has laid out yet.)
-    fn maybe_start(&self, from: Option<RouteId>, to: Option<RouteId>) {
+    /// Runs **inside an observer callback** (`did_change_top` or
+    /// `did_start_user_gesture`), so it does exactly three kinds of work:
+    /// registry lookups behind their own mutexes, a same-frame geometry read
+    /// (the sync fast path only, never `history` mutation), and scheduling.
+    fn maybe_start(
+        &self,
+        from: Option<RouteId>,
+        to: Option<RouteId>,
+        is_user_gesture_transition: bool,
+    ) {
         let Some(navigator) = self.navigator() else {
             return; // Detached. Flutter: `if (navigator == null) return;` (`:970`).
         };
@@ -336,7 +356,11 @@ impl HeroController {
 
         let from_animation = source.primary_animation();
         let to_animation = destination.primary_animation();
-        let direction = FlightDirection::classify(from_animation.status(), to_animation.status());
+        let direction = FlightDirection::classify(
+            is_user_gesture_transition,
+            from_animation.status(),
+            to_animation.status(),
+        );
 
         // `:934-946` — a flight that has already arrived is not a flight. Note the
         // `null` arm falls through: no direction still measures.
@@ -346,8 +370,40 @@ impl HeroController {
             _ => {}
         }
 
-        // `WidgetsBinding.instance.addPostFrameCallback(…)` (`:968`). Acquired from a
-        // handle the navigator captured in `init_state`, never from a frame phase.
+        // `:948-959` — the gesture-pop sync fast path: the destination route
+        // maintains state and is already laid out (its subtree render box has a
+        // valid, finite size), so there is nothing to wait a frame for. No
+        // offstage flip, no post-frame schedule — measure and launch right now,
+        // synchronously, inside this observer callback.
+        if is_user_gesture_transition
+            && direction == Some(FlightDirection::Pop)
+            && destination.maintain_state()
+            && navigator
+                .route_subtree(to)
+                .zip(navigator.render_tree())
+                .and_then(|(subtree, owner)| owner.read().box_size(subtree.render_id))
+                .is_some_and(Size::is_finite)
+        {
+            let pass = MeasurementPass {
+                navigator: &navigator,
+                source: &source,
+                destination: &destination,
+                from,
+                to,
+                direction,
+                is_user_gesture_transition,
+                flights: &self.flights,
+                default_rect_factory: &self.default_rect_factory,
+            };
+            let started = pass.start_transition();
+            self.manifests.lock().extend(started);
+            return;
+        }
+
+        // Otherwise, delay measuring until the end of the next frame
+        // (`:960-973`): `WidgetsBinding.instance.addPostFrameCallback(…)`
+        // (`:968`). Acquired from a handle the navigator captured in
+        // `init_state`, never from a frame phase.
         //
         // **Before the offstage flip, not after.** Flutter's `addPostFrameCallback`
         // cannot fail, so its setter runs first (`:967-968`); FLUI's capability is an
@@ -373,6 +429,7 @@ impl HeroController {
                 from,
                 to,
                 direction,
+                is_user_gesture_transition,
                 flights: &flights,
                 default_rect_factory: &default_rect_factory,
             };
@@ -413,6 +470,11 @@ struct MeasurementPass<'a> {
     from: RouteId,
     to: RouteId,
     direction: Option<FlightDirection>,
+    /// Whether this transition was started by `didStartUserGesture` rather
+    /// than a programmatic push/pop — threaded into every
+    /// [`HeroFlightManifest`] and used to filter heroes that did not opt in
+    /// (`Hero._allHeroesFor`'s `inviteHero`, `heroes.dart:308-314`).
+    is_user_gesture_transition: bool,
     flights: &'a Arc<FlightManager>,
     /// The controller-level `create_rect_tween` fallback (`heroes.dart:847`), used for a
     /// hero that set none of its own.
@@ -431,13 +493,9 @@ impl MeasurementPass<'_> {
             return;
         }
 
-        // Read before restoring: this is the value the frame under measurement
-        // actually laid out with.
+        // Read before `start_transition` restores offstage: this is the value the
+        // frame under measurement actually laid out with.
         let to_animation_while_offstage = self.destination.primary_animation().value();
-
-        // `to.offstage = false;` (`:987`). Geometry stays committed until the next
-        // layout, so measuring after this is safe — and it is what Flutter does.
-        self.destination.set_offstage(false);
 
         let to_subtree = self.navigator.route_subtree(self.to);
         let owner = self.navigator.render_tree();
@@ -464,6 +522,22 @@ impl MeasurementPass<'_> {
             to_animation_while_offstage,
         });
 
+        let started = self.start_transition();
+        manifests.lock().extend(started);
+    }
+
+    /// `_startHeroTransition`'s manifest-collection-and-launch core
+    /// (`heroes.dart:979-1060`, from `to.offstage = false` onward) — shared by
+    /// [`run`](Self::run) (the offstage-then-post-frame path) and
+    /// `HeroController::maybe_start`'s gesture-pop sync fast path, which calls
+    /// this directly with no offstage flip: the destination route is already
+    /// laid out, so there is nothing to restore.
+    fn start_transition(&self) -> Vec<HeroFlightManifest> {
+        // `to.offstage = false;` (`:987`) — a no-op when the sync fast path
+        // never flipped it. Geometry stays committed until the next layout, so
+        // measuring after this is safe either way.
+        self.destination.set_offstage(false);
+
         // Retired flights are dropped here, outside every animation listener — see
         // `FlightManager`'s type docs for why that matters.
         self.flights.drain_retired();
@@ -478,9 +552,7 @@ impl MeasurementPass<'_> {
         for (manifest, from_hero, to_hero) in &started {
             self.launch(manifest, from_hero, to_hero);
         }
-        manifests
-            .lock()
-            .extend(started.into_iter().map(|(manifest, ..)| manifest));
+        started.into_iter().map(|(manifest, ..)| manifest).collect()
     }
 
     /// `_HeroFlight(_handleFlightEnded)..start(manifest)` (`heroes.dart:1054`).
@@ -545,8 +617,40 @@ impl MeasurementPass<'_> {
                 animation,
                 rect_factory,
                 shuttle_builder,
+                is_user_gesture_transition: self.is_user_gesture_transition,
+                gesture_signal: self.navigator.user_gesture_signal(),
             },
         );
+    }
+
+    /// `Hero._allHeroesFor`'s `inviteHero`/else-branch (`heroes.dart:308-314`):
+    /// during a gesture-driven transition, a hero that did not opt into
+    /// [`transition_on_user_gestures`](super::hero::Hero::transition_on_user_gestures)
+    /// is excluded from the match — but not silently. It is told to drop any
+    /// placeholder a *prior* flight left it in, so a gesture transition
+    /// interleaved with a programmatic one never leaves a non-opted-in hero
+    /// hidden. A no-op for a programmatic transition
+    /// (`is_user_gesture_transition == false`), where every hero participates
+    /// unconditionally, exactly as `!isUserGestureTransition` short-circuits
+    /// the oracle's own check.
+    fn filter_for_gesture(
+        &self,
+        heroes: HashMap<HeroTag, HeroHandle>,
+    ) -> HashMap<HeroTag, HeroHandle> {
+        if !self.is_user_gesture_transition {
+            return heroes;
+        }
+        heroes
+            .into_iter()
+            .filter_map(|(tag, hero)| {
+                if hero.transition_on_user_gestures() {
+                    Some((tag, hero))
+                } else {
+                    hero.end_flight(false);
+                    None
+                }
+            })
+            .collect()
     }
 
     /// `_startHeroTransition`'s matching loop (`heroes.dart:1014-1060`), reduced to
@@ -567,8 +671,8 @@ impl MeasurementPass<'_> {
             return Vec::new();
         };
 
-        let from_heroes = self.source.all_heroes();
-        let to_heroes = self.destination.all_heroes();
+        let from_heroes = self.filter_for_gesture(self.source.all_heroes());
+        let to_heroes = self.filter_for_gesture(self.destination.all_heroes());
 
         let mut manifests = Vec::new();
         for (tag, from_hero) in &from_heroes {
@@ -607,6 +711,7 @@ impl MeasurementPass<'_> {
                     to_route: self.to,
                     from_rect,
                     to_rect,
+                    is_user_gesture_transition: self.is_user_gesture_transition,
                 },
                 from_hero.clone(),
                 to_hero.clone(),
@@ -672,20 +777,51 @@ impl NavigatorObserver for HeroController {
         // pops the route), but a user gesture stays "in progress" until the
         // settling controller reports its final status (see `back_gesture.rs`), so
         // this still observes `user_gesture_in_progress() == true` at that instant
-        // and suppresses the flight — matching Flutter's default
-        // `Hero.transitionOnUserGestures = false` with no per-hero opt-in wired yet
-        // (`heroes.dart:281-311`'s `_allHeroesFor` filter, not yet threaded through
-        // this controller's measurement pass). Flutter's *other* gesture-driven
-        // path — `didStartUserGesture` calling `_maybeStartHeroTransition` with
-        // `isUserGestureTransition: true` for immediate visual feedback the instant
-        // a drag begins — is out of scope here: it only ever produces a flight for
-        // an opted-in hero, which does not exist in FLUI yet.
+        // and suppresses the flight — this is not a substitute for
+        // `did_start_user_gesture` below (which already ran its own flight, if any,
+        // the instant the drag began); it is Flutter's own belt-and-braces guard
+        // against a *second*, redundant flight from the programmatic-looking route
+        // change the gesture's commit produces.
         if self
             .navigator()
             .is_some_and(|navigator| navigator.user_gesture_in_progress())
         {
             return;
         }
-        self.maybe_start(previous_top, Some(top));
+        self.maybe_start(previous_top, Some(top), false);
+    }
+
+    /// `HeroController.didStartUserGesture` (`heroes.dart:871-879`): the
+    /// instant a gesture (e.g. an edge swipe-back) begins, run the same
+    /// eligibility-and-launch path `did_change_top` would, but pre-emptively
+    /// and always classified as a pop (`FlightDirection::classify`'s
+    /// `is_user_gesture_transition` arm) — this is what gives the very first
+    /// drag frame a flight already in progress instead of waiting for a route
+    /// change to commit.
+    ///
+    /// Note the argument order: `fromRoute: route, toRoute: previousRoute`
+    /// (`:874-878`) — the route being dragged away from is `from`, the one it
+    /// would reveal is `to`, exactly `maybe_start`'s own `(from, to)` shape.
+    fn did_start_user_gesture(&self, route: RouteId, previous: Option<RouteId>) {
+        self.maybe_start(Some(route), previous, true);
+    }
+
+    /// `HeroController.didStopUserGesture` (`heroes.dart:881-907`).
+    ///
+    /// Early-returns while the navigator still reports a gesture in progress
+    /// — nested/overlapping gestures on the same navigator collapse to one
+    /// stop, matching [`NavigatorHandle::did_stop_user_gesture`]'s own
+    /// 1→0-only observer notification. Once genuinely stopped, sweeps every
+    /// still-airborne, gesture-driven pop flight whose proxy never left
+    /// `Dismissed` — the drag never moved, so no status transition ever fired
+    /// to end it on its own — and manually dismisses each one.
+    fn did_stop_user_gesture(&self) {
+        let Some(navigator) = self.navigator() else {
+            return;
+        };
+        if navigator.user_gesture_in_progress() {
+            return;
+        }
+        self.flights.finish_stalled_gesture_pops();
     }
 }

--- a/crates/flui-widgets/src/navigator/hero_flight.rs
+++ b/crates/flui-widgets/src/navigator/hero_flight.rs
@@ -39,9 +39,11 @@
 //!   `placeholder` hook instead. The animation handed to this flight is already the
 //!   manifest's `CurvedAnimation` (`:472-491`), built by the controller's `launch` —
 //!   `Curves::FastOutSlowIn` by default, as Flutter's is (`:181`).
-//! * **No `userGestureInProgress`.** `_handleAnimationUpdate`'s delay (`:620-648`)
-//!   exists only for the iOS back-swipe. FLUI has none, so the status update is never
-//!   deferred.
+//! * **`userGestureInProgress` deferral is implemented.** `_handleAnimationUpdate`
+//!   (`:622-650`) parks a terminal status update while the navigator's user gesture
+//!   is in progress and replays it once the gesture ends, so dragging a pop back to
+//!   zero mid-gesture does not tear the flight down with the finger still down. See
+//!   `FlightInner::wake`'s doc for the Send+Sync boundary this crosses.
 //! * **No `navigatorSize`.** Flutter converts the rect to a `RelativeRect` against it
 //!   (`:591-592`) because its `Positioned` takes edge insets; FLUI's takes
 //!   `left`/`top`/`width`/`height` directly, so the size is not needed.
@@ -55,7 +57,7 @@ use flui_animation::{
     Animatable, Animation, AnimationStatus, Curve, Interval, ProxyAnimation, RectTween,
     ReverseAnimation, Tween, animate,
 };
-use flui_foundation::{Listenable, ListenerId, RenderId};
+use flui_foundation::{ChangeNotifier, Listenable, ListenerId, RenderId};
 use flui_geometry::Rect;
 use flui_scheduler::PostFrameHandle;
 use flui_view::prelude::*;
@@ -64,6 +66,7 @@ use parking_lot::Mutex;
 
 use super::hero::{HeroHandle, HeroTag, RectTweenFactory, ShuttleBuilder};
 use super::hero_controller::{FlightDirection, HeroFlightManifest};
+use super::navigator::UserGestureSignal;
 use crate::overlay::{InsertPosition, OverlayEntry, OverlayHandle};
 use crate::{IgnorePointer, Opacity, Positioned, Stack, StackFit};
 
@@ -78,6 +81,12 @@ struct FlightState {
     to_hero: HeroHandle,
     /// The destination route's coordinate root, for the per-tick re-measure.
     to_route_subtree: RenderId,
+    /// `manifest.isUserGestureTransition` (`heroes.dart:453`, `:915`): set by
+    /// [`FlightManager::start`] and rewritten by [`HeroFlight::divert`]
+    /// (`manifest = newManifest`, `:815`). Read by
+    /// `HeroController::did_stop_user_gesture`'s manual-dismiss sweep
+    /// (`didStopUserGesture`, `:882-907`).
+    is_user_gesture_transition: bool,
 }
 
 /// Everything one in-flight hero shares between its overlay entry, its animation
@@ -113,12 +122,42 @@ struct FlightInner {
 
     entry: Mutex<Option<OverlayEntry>>,
     subscriptions: Mutex<Option<ListenerId>>,
+    /// A Send+Sync-safe read of this flight's navigator's user-gesture state
+    /// (`_HeroFlight._handleAnimationUpdate`, `heroes.dart:622-650`). Fixed
+    /// for the flight's whole life — every divert stays within the same
+    /// controller, hence the same navigator.
+    gesture_signal: UserGestureSignal,
+    /// What [`Shuttle`] actually subscribes to (`AnimatedView::listenable`),
+    /// in place of [`proxy`](Self::proxy) directly: a relay that forwards
+    /// both `proxy`'s own ticks *and* [`gesture_signal`](Self::gesture_signal)'s
+    /// notifier — the same "merge multiple `Listenable`s into one"
+    /// `ChangeNotifier` idiom `ModalInner::relay` uses. `proxy` alone cannot
+    /// tell the shuttle to rebuild when a gesture ends (nothing about the
+    /// animation itself changed then); this is what gives a status parked
+    /// mid-gesture a rebuild to drain, the moment the gesture ends.
+    wake: Arc<ChangeNotifier>,
+    /// The forwarding subscription feeding [`wake`](Self::wake) from
+    /// [`proxy`](Self::proxy)'s own value changes.
+    proxy_wake_subscription: Mutex<Option<ListenerId>>,
+    /// The forwarding subscription feeding [`wake`](Self::wake) from
+    /// [`gesture_signal`](Self::gesture_signal)'s notifier — the same
+    /// listener that replays a terminal status parked mid-gesture. Registered
+    /// once at [`FlightManager::start`] and removed in [`HeroFlight::finish`]
+    /// — never re-registered, unlike Flutter's reactive
+    /// `_scheduledPerformAnimationUpdate` add/remove dance, because one
+    /// listener for the flight's whole life costs nothing and needs no extra
+    /// "already scheduled" bookkeeping.
+    gesture_wake_subscription: Mutex<Option<ListenerId>>,
     /// Terminal status reported by the data-plane animation listener.
     ///
     /// `0` means "none", `1` means dismissed, and `2` means completed. The
     /// listener that writes this field must stay `Send + Sync`, so it cannot
     /// capture [`FlightInner`] or [`FlightManager`]. The owner-local shuttle
-    /// drains the flag from `build`.
+    /// drains the flag from `build`. Written only while no user gesture is in
+    /// progress on this flight's navigator — a terminal status arriving mid-
+    /// gesture is parked instead (see
+    /// [`gesture_wake_subscription`](Self::gesture_wake_subscription)),
+    /// exactly as `_handleAnimationUpdate` defers `_performAnimationUpdate`.
     settled_status: Arc<AtomicU8>,
     /// The in-flight widget (`:553` / `:571-579`), inflated once at start and rebuilt on
     /// a divert. Either the resolved `flight_shuttle_builder`'s output or, when none is
@@ -281,6 +320,18 @@ impl HeroFlight {
         self.inner.state.lock().direction
     }
 
+    /// Whether this is a gesture-driven pop whose proxy never left
+    /// `Dismissed` — Flutter's `isInvalidFlight` predicate inside
+    /// `HeroController.didStopUserGesture` (`heroes.dart:892-896`): the drag
+    /// never moved, so no status transition ever fired to report it, and
+    /// nothing else will end this flight on its own.
+    fn is_stalled_gesture_pop(&self) -> bool {
+        let state = self.inner.state.lock();
+        state.is_user_gesture_transition
+            && state.direction == FlightDirection::Pop
+            && self.inner.proxy.is_dismissed()
+    }
+
     /// `_HeroFlight._performAnimationUpdate` (`heroes.dart:600-618`), minus the
     /// `onFlightEnded` callback — the manager does that half.
     ///
@@ -293,6 +344,12 @@ impl HeroFlight {
 
         if let Some(status_id) = self.inner.subscriptions.lock().take() {
             self.inner.proxy.remove_status_listener(status_id);
+        }
+        if let Some(id) = self.inner.proxy_wake_subscription.lock().take() {
+            self.inner.proxy.remove_listener(id);
+        }
+        if let Some(id) = self.inner.gesture_wake_subscription.lock().take() {
+            self.inner.gesture_signal.notifier().remove_listener(id);
         }
 
         if let Some(entry) = self.inner.entry.lock().take()
@@ -332,6 +389,11 @@ impl HeroFlight {
             animation: new_anim,
             rect_factory: new_rect_factory,
             shuttle_builder: new_shuttle_builder,
+            is_user_gesture_transition: new_is_user_gesture_transition,
+            // Fixed for the flight's whole life (see `FlightInner::gesture_signal`'s
+            // doc) — every divert stays within the same controller/navigator, so
+            // there is nothing to repoint here.
+            gesture_signal: _,
         } = plan;
 
         let (old_dir, old_from, old_to) = {
@@ -469,6 +531,7 @@ impl HeroFlight {
             state.from_hero = new_from;
             state.to_hero = new_to;
             state.to_route_subtree = new_subtree;
+            state.is_user_gesture_transition = new_is_user_gesture_transition;
         }
 
         // `manifest = newManifest` is the last line of `divert`; the proxy repoint is
@@ -505,6 +568,14 @@ pub(crate) struct FlightPlan {
     /// The resolved `flight_shuttle_builder` (`heroes.dart:1040`): the destination
     /// hero's, else the source hero's, else `None` (default shuttle).
     pub(crate) shuttle_builder: Option<ShuttleBuilder>,
+    /// `manifest.isUserGestureTransition` (`heroes.dart:453`): whether this
+    /// transition was started by `didStartUserGesture` rather than a
+    /// programmatic push/pop.
+    pub(crate) is_user_gesture_transition: bool,
+    /// A Send+Sync-safe read of the navigator's user-gesture state, for the
+    /// terminal-status deferral (`_handleAnimationUpdate`,
+    /// `heroes.dart:622-650`).
+    pub(crate) gesture_signal: UserGestureSignal,
 }
 
 /// `HeroController._flights` (`heroes.dart:850`) plus the deferred-drop discipline
@@ -648,6 +719,8 @@ impl FlightManager {
             animation,
             rect_factory,
             shuttle_builder,
+            is_user_gesture_transition,
+            gesture_signal,
         } = plan;
 
         // The shuttle builder gets `manifest.animation` — the curved route animation, not
@@ -668,6 +741,7 @@ impl FlightManager {
                 from_hero: from_hero.clone(),
                 to_hero: to_hero.clone(),
                 to_route_subtree,
+                is_user_gesture_transition,
             }),
             proxy: Arc::new(ProxyAnimation::new(parent)),
             rect: Mutex::new(RectTween {
@@ -681,6 +755,10 @@ impl FlightManager {
             ended: AtomicBool::new(false),
             entry: Mutex::new(None),
             subscriptions: Mutex::new(None),
+            gesture_signal: gesture_signal.clone(),
+            wake: Arc::new(ChangeNotifier::new()),
+            proxy_wake_subscription: Mutex::new(None),
+            gesture_wake_subscription: Mutex::new(None),
             settled_status: Arc::new(AtomicU8::new(0)),
             shuttle: Mutex::new(None),
             shuttle_builder: Mutex::new(shuttle_builder),
@@ -722,15 +800,33 @@ impl FlightManager {
         // `_proxyAnimation.addListener(onTick)` (`:735`) is served by the shuttle's
         // `AnimatedView` rebuild: every value tick marks the owner-local subtree
         // dirty, and `ShuttleState::build` runs `on_tick` before reading the rect.
-        //
+        // The shuttle listens to `wake`, not `proxy` directly — forward every proxy
+        // tick into it so that stays true.
+        let proxy_to_wake = Arc::clone(&inner.wake);
+        let proxy_wake_id = inner
+            .proxy
+            .add_listener(Arc::new(move || proxy_to_wake.notify_listeners()));
+        *inner.proxy_wake_subscription.lock() = Some(proxy_wake_id);
+
         // The status listener installed in the constructor (`:547`) must remain a
         // data-plane callback. It records only a tiny terminal-status flag; the
         // owner-local shuttle drains the flag and calls back into the manager.
+        //
+        // `_handleAnimationUpdate` (`heroes.dart:622-650`): while a user gesture is
+        // in progress on this flight's navigator, a terminal status is *not*
+        // recorded here — the gesture-notifier listener registered below (armed
+        // once, for the flight's whole life) picks it up when the gesture ends,
+        // reading the proxy's status fresh at that time rather than trusting
+        // whatever it was at the moment it was skipped.
         let settled_status = Arc::clone(&inner.settled_status);
+        let listener_gesture_signal = gesture_signal.clone();
         let status_id = inner.proxy.add_status_listener(Arc::new(move |status| {
             // `if (!status.isAnimating)` (`heroes.dart:601`) — `AnimationStatus` here
             // carries no `is_animating`, and forward/reverse is exactly the complement
             // of dismissed/completed.
+            if listener_gesture_signal.in_progress() {
+                return;
+            }
             match status {
                 AnimationStatus::Dismissed => settled_status.store(1, Ordering::Release),
                 AnimationStatus::Completed => settled_status.store(2, Ordering::Release),
@@ -738,6 +834,33 @@ impl FlightManager {
             }
         }));
         *inner.subscriptions.lock() = Some(status_id);
+
+        // The deferred-replay half of `_handleAnimationUpdate` (`:639-649`): fires
+        // on every 0→1/1→0 transition of the navigator's gesture state, for the
+        // flight's whole life. Must stay `Send + Sync` exactly like the status
+        // listener above — it can only touch the same data-plane primitives
+        // (`proxy`, `settled_status`, `wake`, all `Send + Sync`), never
+        // `Arc<FlightInner>`/`Arc<FlightManager>` as a whole (both hold owner-local,
+        // `Rc`-based view state). Writing `settled_status` alone would not be seen:
+        // nothing about `proxy` itself changed on a gesture-end, so the owner-local
+        // shuttle needs telling to rebuild and drain it — hence also waking.
+        let settled_status = Arc::clone(&inner.settled_status);
+        let proxy_for_replay = Arc::clone(&inner.proxy);
+        let gesture_to_wake = Arc::clone(&inner.wake);
+        let replay_gesture_signal = gesture_signal.clone();
+        let gesture_wake_id = gesture_signal.notifier().add_listener(Arc::new(move || {
+            if !replay_gesture_signal.in_progress() {
+                // `_performAnimationUpdate(_proxyAnimation.status)` (`:644`): read
+                // fresh, not whatever status was skipped when it was parked.
+                match proxy_for_replay.status() {
+                    AnimationStatus::Dismissed => settled_status.store(1, Ordering::Release),
+                    AnimationStatus::Completed => settled_status.store(2, Ordering::Release),
+                    _ => {} // Still animating; nothing to replay.
+                }
+            }
+            gesture_to_wake.notify_listeners();
+        }));
+        *inner.gesture_wake_subscription.lock() = Some(gesture_wake_id);
 
         self.flights.lock().insert(manifest.tag.clone(), flight);
     }
@@ -753,6 +876,29 @@ impl FlightManager {
             // the end of this frame.
             self.retired.lock().push(removed);
             self.schedule_drain();
+        }
+    }
+
+    /// `HeroController.didStopUserGesture`'s manual sweep (`heroes.dart:882-907`):
+    /// every still-airborne, gesture-driven pop flight whose proxy never left
+    /// `Dismissed` (the drag never moved) is fed a synthetic `Dismissed` update
+    /// through the same [`finish`](Self::finish) path a real terminal status
+    /// would use.
+    ///
+    /// Called directly from `HeroController::did_stop_user_gesture` — owner-local,
+    /// never from inside an animation listener — so calling `finish` here (which
+    /// may drop the flight) is unconditionally safe, unlike the data-plane status
+    /// listeners in [`start`](Self::start).
+    pub(crate) fn finish_stalled_gesture_pops(self: &Arc<Self>) {
+        let stalled: Vec<HeroFlight> = self
+            .flights
+            .lock()
+            .values()
+            .filter(|flight| flight.is_stalled_gesture_pop())
+            .cloned()
+            .collect();
+        for flight in stalled {
+            self.finish(&flight, AnimationStatus::Dismissed);
         }
     }
 }
@@ -787,8 +933,12 @@ impl std::fmt::Debug for Shuttle {
 impl_animated_view!(Shuttle);
 
 impl AnimatedView for Shuttle {
+    /// `self.flight.wake`, not `proxy` directly: the relay that also
+    /// forwards the navigator's gesture-notifier, so a flight parked
+    /// mid-gesture (`FlightInner::gesture_wake_subscription`) gets a rebuild
+    /// the moment the gesture ends, to drain the status that was replayed.
     fn listenable(&self) -> Arc<dyn Listenable> {
-        Arc::clone(&self.flight.proxy) as Arc<dyn Listenable>
+        Arc::clone(&self.flight.wake) as Arc<dyn Listenable>
     }
 }
 

--- a/crates/flui-widgets/src/navigator/hero_flight.rs
+++ b/crates/flui-widgets/src/navigator/hero_flight.rs
@@ -142,11 +142,22 @@ struct FlightInner {
     /// The forwarding subscription feeding [`wake`](Self::wake) from
     /// [`gesture_signal`](Self::gesture_signal)'s notifier — the same
     /// listener that replays a terminal status parked mid-gesture. Registered
-    /// once at [`FlightManager::start`] and removed in [`HeroFlight::finish`]
-    /// — never re-registered, unlike Flutter's reactive
+    /// once at [`FlightManager::start`] and removed in [`HeroFlight::finish`],
+    /// or — if this flight is ever dropped without going through `finish` —
+    /// in `FlightInner`'s own `Drop` impl below. Never re-registered, unlike
+    /// Flutter's reactive
     /// `_scheduledPerformAnimationUpdate` add/remove dance, because one
     /// listener for the flight's whole life costs nothing and needs no extra
     /// "already scheduled" bookkeeping.
+    ///
+    /// **Why this one specifically needs the `Drop` backstop and the others
+    /// on this struct do not:** it is registered on
+    /// [`gesture_signal`](Self::gesture_signal)'s notifier, which is owned by
+    /// the *navigator*, not by this flight — so it outlives any one flight by
+    /// construction. Every other subscription here targets `self.proxy`
+    /// (owned by this same struct), which simply drops the registry along
+    /// with itself; only a registration on someone else's longer-lived
+    /// notifier can leak a closure this way.
     gesture_wake_subscription: Mutex<Option<ListenerId>>,
     /// Terminal status reported by the data-plane animation listener.
     ///
@@ -243,6 +254,36 @@ impl FlightInner {
             1 => Some(AnimationStatus::Dismissed),
             2 => Some(AnimationStatus::Completed),
             _ => None,
+        }
+    }
+}
+
+impl Drop for FlightInner {
+    /// A flight normally tears down through [`HeroFlight::finish`], which
+    /// removes every subscription this struct opened. But nothing guarantees
+    /// `finish` ever runs before the last `Arc<FlightInner>` drops — a
+    /// `FlightManager` torn down with a flight still airborne, or every
+    /// `HeroController`/observer holding one detached mid-flight, both drop
+    /// this struct directly. Without this, [`gesture_wake_subscription`]'s
+    /// closure (and everything it captured — a clone of this very `Arc`'s
+    /// dependencies) would stay registered in the *navigator's* longer-lived
+    /// notifier forever: a leak, not merely a stale listener, because nothing
+    /// else will ever remove it.
+    ///
+    /// Idempotent with `finish`, in either order: each subscription is an
+    /// `Option` a prior teardown already took, so a second attempt here (or
+    /// there) finds `None` and does nothing.
+    ///
+    /// [`gesture_wake_subscription`]: FlightInner::gesture_wake_subscription
+    fn drop(&mut self) {
+        if let Some(status_id) = self.subscriptions.lock().take() {
+            self.proxy.remove_status_listener(status_id);
+        }
+        if let Some(id) = self.proxy_wake_subscription.lock().take() {
+            self.proxy.remove_listener(id);
+        }
+        if let Some(id) = self.gesture_wake_subscription.lock().take() {
+            self.gesture_signal.notifier().remove_listener(id);
         }
     }
 }

--- a/crates/flui-widgets/src/navigator/hero_gesture_tests.rs
+++ b/crates/flui-widgets/src/navigator/hero_gesture_tests.rs
@@ -262,12 +262,21 @@ fn a_non_opted_heroes_placeholder_is_cleared_when_a_gesture_transition_starts() 
 /// — dragging back to zero mid-gesture must not tear the flight down with the
 /// finger still down, and dragging forward again must keep tracking it.
 ///
+/// **The tick between each drag and its assertion is load-bearing, not
+/// incidental.** A terminal status only ever tears the flight down once the
+/// shuttle's own `build` drains `settled_status` (`FlightInner`'s data-plane
+/// listener never calls `finish` itself); nothing about `drag_update` runs a
+/// build synchronously. Asserting right after `drag_update`, with no tick,
+/// would pass whether or not the deferral guard exists — there would be
+/// nothing yet to drain either way, guard or no guard.
+///
 /// Red-check: delete the `gesture_signal.in_progress()` guard from the status
-/// listener in `FlightManager::start` — the flight tears down (`get` returns
-/// `None`) the instant the drag reaches zero.
+/// listener in `FlightManager::start` — after the tick following the full
+/// swipe to zero, `flights().get(&tag)` returns `None`.
 #[test]
 fn a_full_swipe_to_zero_mid_gesture_does_not_tear_down_the_flight() {
-    let (navigator, _harness, controller, _to, from, from_controller) = gesture_fixture(true, true);
+    let (navigator, mut harness, controller, _to, from, from_controller) =
+        gesture_fixture(true, true);
 
     let gesture = BackGestureController::new(navigator, from, from_controller.clone());
     assert!(
@@ -280,6 +289,9 @@ fn a_full_swipe_to_zero_mid_gesture_does_not_tear_down_the_flight() {
     gesture.drag_update(1.0);
     assert_eq!(from_controller.value(), 0.0);
     assert_eq!(from_controller.status(), AnimationStatus::Dismissed);
+    // Give the shuttle the build that would drain a terminal status and call
+    // `finish` if the deferral guard were missing.
+    harness.tick();
     assert!(
         controller.flights().get(&hero_tag()).is_some(),
         "the flight must not tear down while the user gesture is still in progress"
@@ -288,6 +300,7 @@ fn a_full_swipe_to_zero_mid_gesture_does_not_tear_down_the_flight() {
     // Drag forward again: still airborne, still tracked.
     gesture.drag_update(-0.6);
     assert!(from_controller.value() > 0.0);
+    harness.tick();
     assert!(
         controller.flights().get(&hero_tag()).is_some(),
         "still airborne after dragging forward again"
@@ -299,14 +312,32 @@ fn a_full_swipe_to_zero_mid_gesture_does_not_tear_down_the_flight() {
 // ============================================================================
 
 /// A cancelled gesture (release with no fling, past the halfway point) stays
-/// on the `from` page, and the hero's child state must survive the whole
-/// round trip — not a vacuous pin: a real `StatefulView` `create_state`
-/// counter proves no reparenting happened.
+/// on the `from` page — and the *page's* state must survive the whole round
+/// trip, not just its stack position: a real `StatefulView` `create_state`
+/// counter, on a plain sibling of the hero (not the hero's own child), proves
+/// the page was never torn down and rebuilt from scratch while the flight was
+/// airborne and then aborted.
 ///
-/// Red-check: reparent the hero's child on `HeroHandle::start_flight`/
-/// `end_flight` instead of freezing it offstage — `creations` reads `2`.
+/// A sibling, deliberately, not the hero's own child: the hero *itself* is
+/// this flight's `from_hero`, always classified `Pop`
+/// (`FlightDirection::classify`), which Flutter starts with
+/// `shouldIncludeChildInPlaceholder: false` (`heroes.dart:721-724`, ported by
+/// `HeroFlight::start`'s `direction == Push` check) — so the hero's own child
+/// is legitimately *not* preserved in place while airborne (same as
+/// Flutter's own pop-source hero); pinning that non-preservation is not this
+/// test's concern. What must hold regardless is that the surrounding page —
+/// the route we stayed on — keeps everything else alive.
+///
+/// **The tick between the cancel and the assertion is load-bearing.** A
+/// route rebuild is not synchronous with `drag_end`; checking `creations`
+/// with no tick in between would pass even if the page were torn down and
+/// rebuilt, because the rebuild that would prove it never runs.
+///
+/// Red-check: have `ModalScope` unconditionally discard and rebuild its page
+/// subtree on every primary-animation notify instead of diffing it — after
+/// the tick, `creations` reads more than `1`.
 #[test]
-fn cancel_release_preserves_the_from_pages_hero_state() {
+fn cancel_release_preserves_the_from_pages_sibling_state() {
     #[derive(Clone)]
     struct Counter(Arc<AtomicUsize>);
     impl View for Counter {
@@ -324,7 +355,7 @@ fn cancel_release_preserves_the_from_pages_hero_state() {
     struct CounterState;
     impl ViewState<Counter> for CounterState {
         fn build(&self, _v: &Counter, _c: &dyn BuildContext) -> impl IntoView {
-            SizedBox::new(30.0, 18.0)
+            SizedBox::new(1.0, 1.0)
         }
     }
 
@@ -344,16 +375,15 @@ fn cancel_release_preserves_the_from_pages_hero_state() {
 
     let creations_for_page = Arc::clone(&creations);
     let from_route = PageRoute::<i32>::new(move |_ctx, _p, _s| {
-        Center::new()
-            .child(
-                Hero::new(
-                    ValueKey::new("shared"),
-                    Counter(Arc::clone(&creations_for_page)),
-                )
-                .transition_on_user_gestures(true),
-            )
-            .into_view()
-            .boxed()
+        crate::Stack::new(vec![
+            Hero::new(ValueKey::new("shared"), SizedBox::new(30.0, 18.0))
+                .transition_on_user_gestures(true)
+                .into_view()
+                .boxed(),
+            Counter(Arc::clone(&creations_for_page)).into_view().boxed(),
+        ])
+        .into_view()
+        .boxed()
     })
     .transition_duration(TRANSITION);
     let transition = from_route.transition_handle();
@@ -372,6 +402,8 @@ fn cancel_release_preserves_the_from_pages_hero_state() {
     let gesture = BackGestureController::new(navigator.clone(), from, from_controller.clone());
     gesture.drag_update(0.3); // Partway: value 0.7, past the halfway "stay" threshold.
     let _still_settling = gesture.drag_end(0.0); // No fling: value > 0.5 => cancel.
+    // Let the cancel's return-to-normal shape actually build.
+    harness.tick();
 
     assert_eq!(
         navigator.current(),
@@ -381,7 +413,7 @@ fn cancel_release_preserves_the_from_pages_hero_state() {
     assert_eq!(
         creations.load(Ordering::SeqCst),
         1,
-        "the hero's child state survived the cancelled gesture — no rebuild"
+        "the page's sibling state survived the cancelled gesture — no rebuild"
     );
 }
 
@@ -390,19 +422,58 @@ fn cancel_release_preserves_the_from_pages_hero_state() {
 // ============================================================================
 
 /// A completed gesture (release with no fling, past the halfway point toward
-/// zero) pops through to the destination route.
+/// zero) pops through to the destination route — synchronously, since the
+/// stack mutation itself does not wait for the release animation. Once the
+/// release's own 350ms pacing run actually settles (driven here by
+/// `AnimationController::tick_at`, matching `back_gesture.rs`'s own
+/// `full_settle_after_release_reports_did_stop_and_clears_the_counter`) and
+/// the navigator reports the gesture stopped, the parked terminal status
+/// replays and the flight lands: `finish`'s `Completed` arm keeps the
+/// (now-gone) from-hero's placeholder rather than clearing it
+/// (`from_hero.end_flight(status.is_completed())`, `heroes.dart:614`).
 #[test]
-fn complete_release_pops_to_the_destination_route() {
-    let (navigator, _harness, _controller, to, from, from_controller) = gesture_fixture(true, true);
+fn complete_release_pops_to_the_destination_route_and_the_flight_lands() {
+    let (navigator, mut harness, controller, to, from, from_controller) =
+        gesture_fixture(true, true);
+
+    let from_modal = navigator
+        .route_modal(from)
+        .expect("a PageRoute publishes a ModalHandle");
+    let from_hero = from_modal
+        .all_heroes()
+        .get(&hero_tag())
+        .cloned()
+        .expect("the from-hero registered with its route");
 
     let gesture = BackGestureController::new(navigator.clone(), from, from_controller.clone());
     gesture.drag_update(0.7); // value 0.3: drag_end's pop branch.
-    let _still_settling = gesture.drag_end(0.0);
+    let still_settling = gesture.drag_end(0.0);
 
     assert_eq!(
         navigator.current(),
         Some(to),
         "a completed gesture pops through to the destination route"
+    );
+
+    // Drive the release's own pacing run (350ms) to completion, then report
+    // the gesture stopped — mirrors `BackGestureDetectorState::poll_settle`
+    // once `!controller.is_animating()`.
+    from_controller.tick_at(0.35);
+    if still_settling {
+        navigator.did_stop_user_gesture();
+    }
+    // The parked terminal status was just replayed (written + the shuttle
+    // woken); this tick is what actually drains it and calls `finish`.
+    harness.tick();
+
+    assert!(
+        controller.flights().get(&hero_tag()).is_none(),
+        "the flight lands once the release genuinely settles"
+    );
+    assert!(
+        from_hero.placeholder_size().is_some(),
+        "a Completed pop keeps the from-hero's placeholder (heroes.dart:614) — \
+         its route is gone, so its child must not reappear"
     );
 }
 

--- a/crates/flui-widgets/src/navigator/hero_gesture_tests.rs
+++ b/crates/flui-widgets/src/navigator/hero_gesture_tests.rs
@@ -1,0 +1,488 @@
+//! User-gesture hero flights — `Hero.transitionOnUserGestures`.
+//!
+//! Every test here drives a real [`BackGestureController`] against a real
+//! [`HeroController`], exactly as an edge swipe-back would, and observes the
+//! private flight/hero seams directly — the crate-internal counterpart to
+//! `tests/hero_public.rs`'s render-tree observation, needed here because
+//! [`BackGestureController`] itself is `pub(crate)`.
+//!
+//! # Oracle
+//!
+//! `.flutter/packages/flutter/lib/src/widgets/heroes.dart` (3.44.0):
+//! `HeroController.didStartUserGesture` / `didStopUserGesture` (`:871-907`),
+//! `_maybeStartHeroTransition`'s `hasValidSize` fast path (`:948-959`),
+//! `Hero._allHeroesFor`'s `inviteHero` (`:308-314`), and
+//! `_HeroFlight._handleAnimationUpdate` (`:622-650`).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use flui_animation::{Animation, AnimationController, AnimationStatus};
+use flui_foundation::ValueKey;
+use flui_view::ViewExt;
+use flui_view::prelude::*;
+
+use super::back_gesture::BackGestureController;
+use super::hero::{Hero, HeroTag};
+use super::hero_controller::HeroController;
+use super::navigator::{Navigator, NavigatorHandle};
+use super::observer::NavigatorObserver;
+use super::overlay_route::SimpleRoute;
+use super::page_route::PageRoute;
+use super::route::RouteId;
+use crate::test_harness::{Harness, mount};
+use crate::{Center, SizedBox};
+
+const TRANSITION: Duration = Duration::from_millis(300);
+
+fn hero_tag() -> HeroTag {
+    HeroTag::new(ValueKey::new("shared"))
+}
+
+/// A `PageRoute` whose page centres one `Hero` tagged `"shared"`, sized
+/// `width`x`height` so two pages never accidentally share a bounding rect.
+fn hero_page(opt_in: bool, width: f32, height: f32) -> PageRoute<i32> {
+    PageRoute::<i32>::new(move |_ctx, _p, _s| {
+        Center::new()
+            .child(
+                Hero::new(ValueKey::new("shared"), SizedBox::new(width, height))
+                    .transition_on_user_gestures(opt_in),
+            )
+            .into_view()
+            .boxed()
+    })
+    .transition_duration(TRANSITION)
+}
+
+fn install(navigator: &NavigatorHandle) -> Arc<HeroController> {
+    let controller = HeroController::new();
+    navigator.add_observer(Arc::clone(&controller) as Arc<dyn NavigatorObserver>);
+    controller
+}
+
+#[derive(Clone)]
+struct Root {
+    navigator: NavigatorHandle,
+}
+
+impl View for Root {
+    fn create_element(&self) -> flui_view::element::ElementKind {
+        flui_view::element::ElementKind::stateless(self)
+    }
+}
+
+impl StatelessView for Root {
+    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+        Navigator::new(self.navigator.clone())
+    }
+}
+
+fn mount_navigator(navigator: &NavigatorHandle) -> Harness {
+    mount(Root {
+        navigator: navigator.clone(),
+    })
+}
+
+/// A mounted navigator with a base (non-hero) route, a hero page the gesture
+/// will reveal (`to`), and a second hero page pushed on top of it (`from`) —
+/// the one a [`BackGestureController`] drags. Both hero pages share the tag
+/// `"shared"` but differ in size, so a flight's `begin`/`end` rects are never
+/// accidentally equal.
+///
+/// The `from` route's own transition controller is left at `set_value(1.0)`
+/// — "fully on top, not yet popped" — the resting state a real edge-swipe
+/// starts from; a [`BackGestureController`] then drags it down from there.
+fn gesture_fixture_with(
+    to_opt_in: bool,
+    from_opt_in: bool,
+    to_maintain_state: bool,
+) -> (
+    NavigatorHandle,
+    Harness,
+    Arc<HeroController>,
+    RouteId,
+    RouteId,
+    AnimationController,
+) {
+    let navigator = NavigatorHandle::new();
+    navigator.seed_initial(SimpleRoute::<i32>::new(|_ctx| {
+        SizedBox::new(1.0, 1.0).into_view().boxed()
+    }));
+    // No controller yet: both hero pages share the tag `"shared"`, and an
+    // attached `HeroController` would otherwise fly a real *programmatic*
+    // flight between them right here (`did_change_top` does not consult
+    // `transition_on_user_gestures` at all) — contaminating every assertion
+    // below with an unrelated, already-airborne flight.
+    let mut harness = mount_navigator(&navigator);
+
+    let to_route = hero_page(to_opt_in, 40.0, 24.0).maintain_state(to_maintain_state);
+    let _to_push = harness.enter_owner_scope(|| navigator.push(to_route));
+    harness.tick();
+    let to = navigator
+        .current()
+        .expect("the destination route is pushed");
+
+    let from_route = hero_page(from_opt_in, 30.0, 18.0);
+    let transition = from_route.transition_handle();
+    let _from_push = harness.enter_owner_scope(|| navigator.push(from_route));
+    harness.tick();
+    let from = navigator.current().expect("the dragged route is pushed");
+
+    // Attach the controller only now — after both hero pages already sit on
+    // the stack — so the gesture is the first `did_change_top`-adjacent
+    // event it ever reacts to.
+    let controller = install(&navigator);
+
+    let from_controller = transition
+        .controller()
+        .expect("install() created the transition controller");
+    from_controller.set_value(1.0);
+
+    (navigator, harness, controller, to, from, from_controller)
+}
+
+fn gesture_fixture(
+    to_opt_in: bool,
+    from_opt_in: bool,
+) -> (
+    NavigatorHandle,
+    Harness,
+    Arc<HeroController>,
+    RouteId,
+    RouteId,
+    AnimationController,
+) {
+    gesture_fixture_with(to_opt_in, from_opt_in, true)
+}
+
+// ============================================================================
+// 1. Both ends opted in: synchronous start, shuttle tracks the drag
+// ============================================================================
+
+/// `_maybeStartHeroTransition`'s `hasValidSize` fast path (`heroes.dart:948-959`):
+/// with the destination already laid out and `maintainState`, the flight starts
+/// synchronously inside `did_start_user_gesture` — no frame needed — and the
+/// shuttle's rect tracks the drag from that first instant.
+///
+/// Red-check: delete the sync fast-path branch from `HeroController::maybe_start`
+/// — `controller.flights().get(&tag)` is `None` immediately after
+/// `BackGestureController::new`, only appearing after a `harness.tick()`.
+#[test]
+fn gesture_pop_with_both_ends_opted_in_starts_synchronously_and_tracks_the_drag() {
+    let (navigator, _harness, controller, _to, from, from_controller) = gesture_fixture(true, true);
+
+    let gesture = BackGestureController::new(navigator, from, from_controller.clone());
+
+    let flight = controller
+        .flights()
+        .get(&hero_tag())
+        .expect("both ends opted in: the flight started synchronously, no frame needed");
+
+    let begin = flight.begin_rect();
+    let end = flight.target_rect();
+    assert_ne!(
+        begin, end,
+        "the two hero pages differ in size, so begin and end must differ"
+    );
+
+    let before = flight.shuttle_rect();
+    gesture.drag_update(0.5);
+    let after = flight.shuttle_rect();
+    assert_ne!(before, after, "the shuttle rect tracks the drag fraction");
+}
+
+// ============================================================================
+// 2. One-end-only opt-in: no flight
+// ============================================================================
+
+/// `Hero._allHeroesFor`'s `inviteHero` (`heroes.dart:308-314`): a pair flies
+/// during a gesture transition only when **both** ends opt in.
+///
+/// Red-check: drop the `hero_mode_enabled`-style filter — `filter_for_gesture`
+/// — from `MeasurementPass::collect_manifests` and this starts a flight anyway.
+#[test]
+fn one_end_only_opting_in_starts_no_flight() {
+    let (navigator, _harness, controller, _to, from, from_controller) =
+        gesture_fixture(true, false);
+
+    let _gesture = BackGestureController::new(navigator, from, from_controller);
+
+    assert!(
+        controller.flights().get(&hero_tag()).is_none(),
+        "the from-hero did not opt in, so no pair flies"
+    );
+}
+
+// ============================================================================
+// 3. Non-opted hero un-hidden (the endFlight else-branch)
+// ============================================================================
+
+/// The oracle's else-branch calls `endFlight` on a non-participating hero to
+/// un-hide it if a prior flight left it hidden (`heroes.dart:311-314`).
+///
+/// Red-check: change `HeroController::filter_for_gesture` to plain
+/// `.retain(...)` (drop the `hero.end_flight(false)` call in the rejected arm)
+/// — the simulated prior flight's placeholder never clears.
+#[test]
+fn a_non_opted_heroes_placeholder_is_cleared_when_a_gesture_transition_starts() {
+    let (navigator, _harness, _controller, _to, from, from_controller) =
+        gesture_fixture(true, false);
+
+    let from_modal = navigator
+        .route_modal(from)
+        .expect("a PageRoute publishes a ModalHandle");
+    let hero = from_modal
+        .all_heroes()
+        .get(&hero_tag())
+        .cloned()
+        .expect("the hero registered with its route");
+    // Simulate a prior (programmatic) flight that left this hero hidden.
+    hero.start_flight(false);
+    assert!(
+        hero.placeholder_size().is_some(),
+        "hidden by the simulated prior flight"
+    );
+
+    let _gesture = BackGestureController::new(navigator, from, from_controller);
+
+    assert!(
+        hero.placeholder_size().is_none(),
+        "a gesture transition's per-hero filter un-hides a non-opted-in hero \
+         instead of silently skipping it"
+    );
+}
+
+// ============================================================================
+// 4. Mid-drag return to zero: deferral, not teardown
+// ============================================================================
+
+/// `_HeroFlight._handleAnimationUpdate` (`heroes.dart:622-650`): a terminal
+/// status update while the user gesture is in progress is parked, not applied
+/// — dragging back to zero mid-gesture must not tear the flight down with the
+/// finger still down, and dragging forward again must keep tracking it.
+///
+/// Red-check: delete the `gesture_signal.in_progress()` guard from the status
+/// listener in `FlightManager::start` — the flight tears down (`get` returns
+/// `None`) the instant the drag reaches zero.
+#[test]
+fn a_full_swipe_to_zero_mid_gesture_does_not_tear_down_the_flight() {
+    let (navigator, _harness, controller, _to, from, from_controller) = gesture_fixture(true, true);
+
+    let gesture = BackGestureController::new(navigator, from, from_controller.clone());
+    assert!(
+        controller.flights().get(&hero_tag()).is_some(),
+        "flight started synchronously"
+    );
+
+    // Drag all the way: the from-route's controller hits exactly 0 — Dismissed
+    // — while the finger is still down.
+    gesture.drag_update(1.0);
+    assert_eq!(from_controller.value(), 0.0);
+    assert_eq!(from_controller.status(), AnimationStatus::Dismissed);
+    assert!(
+        controller.flights().get(&hero_tag()).is_some(),
+        "the flight must not tear down while the user gesture is still in progress"
+    );
+
+    // Drag forward again: still airborne, still tracked.
+    gesture.drag_update(-0.6);
+    assert!(from_controller.value() > 0.0);
+    assert!(
+        controller.flights().get(&hero_tag()).is_some(),
+        "still airborne after dragging forward again"
+    );
+}
+
+// ============================================================================
+// 5. Cancel-release: flight returns, page state preserved
+// ============================================================================
+
+/// A cancelled gesture (release with no fling, past the halfway point) stays
+/// on the `from` page, and the hero's child state must survive the whole
+/// round trip — not a vacuous pin: a real `StatefulView` `create_state`
+/// counter proves no reparenting happened.
+///
+/// Red-check: reparent the hero's child on `HeroHandle::start_flight`/
+/// `end_flight` instead of freezing it offstage — `creations` reads `2`.
+#[test]
+fn cancel_release_preserves_the_from_pages_hero_state() {
+    #[derive(Clone)]
+    struct Counter(Arc<AtomicUsize>);
+    impl View for Counter {
+        fn create_element(&self) -> flui_view::element::ElementKind {
+            flui_view::element::ElementKind::stateful(self)
+        }
+    }
+    impl StatefulView for Counter {
+        type State = CounterState;
+        fn create_state(&self) -> Self::State {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            CounterState
+        }
+    }
+    struct CounterState;
+    impl ViewState<Counter> for CounterState {
+        fn build(&self, _v: &Counter, _c: &dyn BuildContext) -> impl IntoView {
+            SizedBox::new(30.0, 18.0)
+        }
+    }
+
+    let creations = Arc::new(AtomicUsize::new(0));
+    let navigator = NavigatorHandle::new();
+    navigator.seed_initial(SimpleRoute::<i32>::new(|_ctx| {
+        SizedBox::new(1.0, 1.0).into_view().boxed()
+    }));
+    // No controller yet — see `gesture_fixture_with`'s doc for why: both hero
+    // pages below share the tag `"shared"`, and an attached controller would
+    // fly a real programmatic flight between them right here.
+    let mut harness = mount_navigator(&navigator);
+
+    let to_route = hero_page(true, 40.0, 24.0);
+    let _to_push = harness.enter_owner_scope(|| navigator.push(to_route));
+    harness.tick();
+
+    let creations_for_page = Arc::clone(&creations);
+    let from_route = PageRoute::<i32>::new(move |_ctx, _p, _s| {
+        Center::new()
+            .child(
+                Hero::new(
+                    ValueKey::new("shared"),
+                    Counter(Arc::clone(&creations_for_page)),
+                )
+                .transition_on_user_gestures(true),
+            )
+            .into_view()
+            .boxed()
+    })
+    .transition_duration(TRANSITION);
+    let transition = from_route.transition_handle();
+    let _from_push = harness.enter_owner_scope(|| navigator.push(from_route));
+    harness.tick();
+    let from = navigator.current().expect("the from route is pushed");
+    assert_eq!(creations.load(Ordering::SeqCst), 1, "built once");
+
+    install(&navigator);
+
+    let from_controller = transition
+        .controller()
+        .expect("install() created the transition controller");
+    from_controller.set_value(1.0);
+
+    let gesture = BackGestureController::new(navigator.clone(), from, from_controller.clone());
+    gesture.drag_update(0.3); // Partway: value 0.7, past the halfway "stay" threshold.
+    let _still_settling = gesture.drag_end(0.0); // No fling: value > 0.5 => cancel.
+
+    assert_eq!(
+        navigator.current(),
+        Some(from),
+        "a cancelled gesture stays on the from page"
+    );
+    assert_eq!(
+        creations.load(Ordering::SeqCst),
+        1,
+        "the hero's child state survived the cancelled gesture — no rebuild"
+    );
+}
+
+// ============================================================================
+// 6. Complete-release: flight lands at the to-hero
+// ============================================================================
+
+/// A completed gesture (release with no fling, past the halfway point toward
+/// zero) pops through to the destination route.
+#[test]
+fn complete_release_pops_to_the_destination_route() {
+    let (navigator, _harness, _controller, to, from, from_controller) = gesture_fixture(true, true);
+
+    let gesture = BackGestureController::new(navigator.clone(), from, from_controller.clone());
+    gesture.drag_update(0.7); // value 0.3: drag_end's pop branch.
+    let _still_settling = gesture.drag_end(0.0);
+
+    assert_eq!(
+        navigator.current(),
+        Some(to),
+        "a completed gesture pops through to the destination route"
+    );
+}
+
+// ============================================================================
+// 7. Invalid destination size: falls back to the deferred path, no panic
+// ============================================================================
+
+/// `_maybeStartHeroTransition`'s `hasValidSize` fast path requires
+/// `toRoute.maintainState` (`heroes.dart:957`); without it, the transition
+/// falls back to the ordinary offstage-then-post-frame path — same code path
+/// a programmatic push/pop over the same destination would take — with no
+/// panic anywhere.
+///
+/// A `maintainState == false` destination that is still covered when the
+/// gesture starts has no mounted subtree to flip onstage in the first
+/// place (`ModalRoute`'s own doc: "a covered modal with `maintain_state ==
+/// false` is unmounted"), so there is nothing to measure — the deferred path
+/// correctly measures nothing, exactly as it would for a programmatic
+/// transition onto the same unmeasurable destination
+/// (`a_measurement_whose_navigator_vanished_before_the_frame_records_nothing`'s
+/// sibling case). The behavior under test is "falls back, does not crash
+/// trying" — not "recovers a flight from an inherently unmeasurable route".
+///
+/// Red-check: drop the `destination.maintain_state()` conjunct from the sync
+/// fast-path condition in `HeroController::maybe_start` — the flight starts
+/// synchronously and the first assertion (`flights().get(...).is_none()`
+/// before any tick) fails.
+#[test]
+fn a_to_route_that_does_not_maintain_state_falls_back_to_the_deferred_path_without_panicking() {
+    let (navigator, mut harness, controller, _to, from, from_controller) =
+        gesture_fixture_with(true, true, false);
+
+    let _gesture = BackGestureController::new(navigator, from, from_controller);
+    assert!(
+        controller.flights().get(&hero_tag()).is_none(),
+        "no maintainState on the destination: the sync fast path must not fire"
+    );
+
+    // The deferred (offstage-then-post-frame) path runs next — no panic, and
+    // correctly nothing to fly, since the destination's subtree was never
+    // mounted to begin with.
+    harness.tick();
+    assert!(
+        controller.flights().get(&hero_tag()).is_none(),
+        "still nothing to fly — the point is that reaching here never panicked"
+    );
+}
+
+// ============================================================================
+// 8. Drag-never-moved release: did_stop dismisses the parked flight
+// ============================================================================
+
+/// `HeroController.didStopUserGesture`'s manual sweep (`heroes.dart:882-907`):
+/// a gesture-driven pop flight whose proxy never left `Dismissed` (the drag
+/// never moved) has no status transition to end it on its own — it must be
+/// dismissed manually once the gesture genuinely stops.
+///
+/// Red-check: delete `HeroController::did_stop_user_gesture`'s
+/// `finish_stalled_gesture_pops` call — the flight leaks forever, and
+/// `flights().get(...)` still returns `Some` after this test's final step.
+#[test]
+fn a_never_moved_drag_is_dismissed_once_the_gesture_genuinely_stops() {
+    let (navigator, _harness, controller, _to, from, from_controller) = gesture_fixture(true, true);
+
+    let gesture = BackGestureController::new(navigator.clone(), from, from_controller.clone());
+    assert!(
+        controller.flights().get(&hero_tag()).is_some(),
+        "flight started"
+    );
+
+    // Release without ever moving: `drag_end` at value 1.0, no fling — "stay".
+    let still_settling = gesture.drag_end(0.0);
+    if still_settling {
+        // Mirrors what `BackGestureDetectorState::poll_settle` eventually
+        // reports once the release run settles.
+        navigator.did_stop_user_gesture();
+    }
+
+    assert!(
+        controller.flights().get(&hero_tag()).is_none(),
+        "did_stop_user_gesture must manually dismiss a flight whose drag never moved"
+    );
+}

--- a/crates/flui-widgets/src/navigator/mod.rs
+++ b/crates/flui-widgets/src/navigator/mod.rs
@@ -29,9 +29,10 @@
 //!
 //! The public baseline now includes `Navigator`, `PageRoute` / `PopupRoute`,
 //! `Hero` / `HeroController` / `HeroControllerScope` / `HeroMode`, the Hero
-//! customization hooks, and cross-navigator hero flights. Still deferred: Navigator
-//! 2.0, restoration, named-route generation, `PopScope`, `LocalHistoryRoute`,
-//! per-route focus scope, and gesture-driven (`transitionOnUserGestures`) flights.
+//! customization hooks, cross-navigator hero flights, and gesture-driven
+//! (`transitionOnUserGestures`) flights. Still deferred: Navigator 2.0,
+//! restoration, named-route generation, `PopScope`, `LocalHistoryRoute`, and
+//! per-route focus scope.
 
 mod back_gesture;
 mod binding;
@@ -79,6 +80,8 @@ mod export_guard;
 mod hero_controller_tests;
 #[cfg(test)]
 mod hero_flight_tests;
+#[cfg(test)]
+mod hero_gesture_tests;
 #[cfg(test)]
 mod hero_seam_tests;
 #[cfg(test)]

--- a/crates/flui-widgets/src/navigator/modal_route.rs
+++ b/crates/flui-widgets/src/navigator/modal_route.rs
@@ -765,6 +765,15 @@ impl ModalHandle {
         self.inner.heroes.all_heroes()
     }
 
+    /// `route.maintainState` (`heroes.dart:957`): whether this route keeps
+    /// its subtree built while covered. Read by
+    /// `HeroController::maybe_start`'s gesture-pop sync fast path — a
+    /// destination that does not maintain state may not be laid out yet, so
+    /// only a `true` here can skip the offstage measurement dance.
+    pub(crate) fn maintain_state(&self) -> bool {
+        self.inner.maintain_state.load(Ordering::Relaxed)
+    }
+
     /// There is no `maintainState` setter in Flutter — it is an abstract getter a
     /// subclass overrides, and `changedInternalState` republishes it. This is the
     /// same thing with a cell behind it, which is what lets a test observe the

--- a/crates/flui-widgets/src/navigator/navigator.rs
+++ b/crates/flui-widgets/src/navigator/navigator.rs
@@ -409,11 +409,16 @@ impl NavigatorShared {
         }
         // Same ordering as `did_start_user_gesture`: the notifier fires
         // before the observer loop (`navigator.dart:5806`, `:5848-5855`),
-        // with no navigator lock held. A `HeroFlight` parked on this
-        // notifier replays its terminal status here, *before*
-        // `HeroController::did_stop_user_gesture` below sweeps whatever
-        // flights are still airborne — so a flight this notify just finished
-        // is already gone from that sweep, not double-handled.
+        // with no navigator lock held. A `HeroFlight` parked on this notifier
+        // fires here, *before* `HeroController::did_stop_user_gesture` below
+        // sweeps whatever flights are still airborne — but that reply only
+        // writes the flight's terminal-status flag and wakes its shuttle
+        // (`FlightInner::wake`); the actual `HeroFlight::finish` call still
+        // waits for that shuttle's next `build`. So the same flight can still
+        // be a live candidate for the sweep below, and may have `finish`
+        // called on it twice in one turn — safe only because
+        // `HeroFlight::finish` is idempotent (guarded by its own `ended`
+        // flag), not because the two paths are mutually exclusive.
         self.user_gesture_in_progress_notifier.notify_listeners();
         for observer in self.observers() {
             observer.did_stop_user_gesture();

--- a/crates/flui-widgets/src/navigator/navigator.rs
+++ b/crates/flui-widgets/src/navigator/navigator.rs
@@ -48,6 +48,7 @@ use std::thread::{self, ThreadId};
 use std::time::Duration;
 
 use flui_animation::Curve;
+use flui_foundation::ChangeNotifier;
 use flui_view::BuildContextExt;
 use flui_view::element::ElementKind;
 use flui_view::prelude::*;
@@ -170,7 +171,28 @@ struct NavigatorShared {
     /// `NavigatorState._userGesturesInProgress` (`navigator.dart:5803`) — only
     /// the 0→1 and 1→0 transitions notify observers, so nested gestures on
     /// the same navigator collapse to one notification pair.
-    user_gestures_in_progress: AtomicU32,
+    ///
+    /// `Arc`-wrapped so [`UserGestureSignal`] can share this exact counter
+    /// with a Send+Sync context (a hero flight's data-plane animation
+    /// listener) without holding the owner-affine [`NavigatorHandle`] itself.
+    user_gestures_in_progress: Arc<AtomicU32>,
+
+    /// Flutter's `userGestureInProgressNotifier` (`ValueNotifier<bool>`,
+    /// `navigator.dart:5819`): fires exactly on the 0→1 and 1→0 transitions
+    /// of [`user_gestures_in_progress`](Self::user_gestures_in_progress) —
+    /// the same edges that notify [`NavigatorObserver::did_start_user_gesture`]
+    /// / [`did_stop_user_gesture`](NavigatorObserver::did_stop_user_gesture).
+    ///
+    /// A pure notification relay rather than a `ValueNotifier<bool>` clone:
+    /// this codebase's `ValueNotifier::clone` shares only the listener
+    /// registry, not the value (each clone owns an independent `value`
+    /// field), which would desync the instant it was cloned into a flight —
+    /// the same [`ChangeNotifier`] idiom `ModalInner::relay` and
+    /// `TransitionRouteInner::status_wake` already use to bridge a Send+Sync
+    /// animation callback back to owner-local code. `HeroFlight` subscribes
+    /// once, for its whole life, to replay a terminal status update parked
+    /// mid-gesture (`_handleAnimationUpdate`, `heroes.dart:622-650`).
+    user_gesture_in_progress_notifier: ChangeNotifier,
 }
 
 impl NavigatorShared {
@@ -350,6 +372,11 @@ impl NavigatorShared {
         if count_before != 0 {
             return;
         }
+        // Flutter's `ValueNotifier` setter fires before the observer loop
+        // (`navigator.dart:5806`, then `:5826-5841`) — no navigator lock is
+        // held at this call, so a listener that reads back through a
+        // `NavigatorHandle` cannot deadlock on it.
+        self.user_gesture_in_progress_notifier.notify_listeners();
         let Some((route, previous)) = self.history.lock().top_and_previous_for_gesture() else {
             return;
         };
@@ -380,6 +407,14 @@ impl NavigatorShared {
         if count_before != 1 {
             return;
         }
+        // Same ordering as `did_start_user_gesture`: the notifier fires
+        // before the observer loop (`navigator.dart:5806`, `:5848-5855`),
+        // with no navigator lock held. A `HeroFlight` parked on this
+        // notifier replays its terminal status here, *before*
+        // `HeroController::did_stop_user_gesture` below sweeps whatever
+        // flights are still airborne — so a flight this notify just finished
+        // is already gone from that sweep, not double-handled.
+        self.user_gesture_in_progress_notifier.notify_listeners();
         for observer in self.observers() {
             observer.did_stop_user_gesture();
         }
@@ -548,6 +583,37 @@ fn resolve_command_target(
     })
 }
 
+/// A Send+Sync-safe view onto a navigator's user-gesture state: the live
+/// in-progress count and its change notifier, bundled.
+///
+/// What a data-plane animation status listener needs to defer a terminal
+/// status update until a gesture ends (`_HeroFlight._handleAnimationUpdate`,
+/// `heroes.dart:622-650`) without capturing the owner-affine
+/// [`NavigatorHandle`] itself — `ProxyAnimation::add_status_listener` requires
+/// `Send + Sync`, which `NavigatorHandle` deliberately is not (see its own
+/// doc). Cloning this is cheap: both fields are `Arc`-backed.
+#[derive(Clone)]
+pub(crate) struct UserGestureSignal {
+    in_progress: Arc<AtomicU32>,
+    notifier: ChangeNotifier,
+}
+
+impl UserGestureSignal {
+    /// Whether a user gesture is in progress right now — Flutter's
+    /// `NavigatorState.userGestureInProgress` (`navigator.dart:5816`), read
+    /// from a Send+Sync context.
+    pub(crate) fn in_progress(&self) -> bool {
+        self.in_progress.load(Ordering::Acquire) > 0
+    }
+
+    /// Fires on the 0→1 and 1→0 transitions of
+    /// [`in_progress`](Self::in_progress). Register a listener once; it is
+    /// cheap to keep for a flight's whole life.
+    pub(crate) fn notifier(&self) -> &ChangeNotifier {
+        &self.notifier
+    }
+}
+
 /// An owned, `'static` capability to drive a [`Navigator`].
 ///
 /// This is what `Navigator::of` returns — never `&mut NavigatorState`, which no
@@ -585,7 +651,8 @@ impl NavigatorHandle {
             auto_hero_observer: Mutex::new(None),
             observers_attached: AtomicBool::new(false),
             nested_hero_registration: Mutex::new(None),
-            user_gestures_in_progress: AtomicU32::new(0),
+            user_gestures_in_progress: Arc::new(AtomicU32::new(0)),
+            user_gesture_in_progress_notifier: ChangeNotifier::new(),
         });
         let command_target = register_command_target(&shared);
         Self {
@@ -674,6 +741,29 @@ impl NavigatorHandle {
     #[must_use]
     pub fn user_gesture_in_progress(&self) -> bool {
         self.shared.user_gesture_in_progress()
+    }
+
+    /// Flutter's `userGestureInProgressNotifier` (`ValueNotifier<bool>`,
+    /// `navigator.dart:5819`): fires on the 0→1 and 1→0 transitions of
+    /// [`user_gesture_in_progress`](Self::user_gesture_in_progress), with no
+    /// navigator lock held. Test-facing: production code reaches the same
+    /// notifier only through [`user_gesture_signal`](Self::user_gesture_signal)'s
+    /// Send+Sync-safe bundle.
+    #[cfg(test)]
+    pub(crate) fn user_gesture_in_progress_notifier(&self) -> ChangeNotifier {
+        self.shared.user_gesture_in_progress_notifier.clone()
+    }
+
+    /// A Send+Sync-safe snapshot of this navigator's user-gesture state — the
+    /// live count and its notifier, bundled — for a data-plane animation
+    /// listener that cannot hold this owner-affine handle. `HeroFlight` uses
+    /// it to defer a terminal status update mid-gesture
+    /// (`_handleAnimationUpdate`, `heroes.dart:622-650`).
+    pub(crate) fn user_gesture_signal(&self) -> UserGestureSignal {
+        UserGestureSignal {
+            in_progress: Arc::clone(&self.shared.user_gestures_in_progress),
+            notifier: self.shared.user_gesture_in_progress_notifier.clone(),
+        }
     }
 
     /// Whether both handles name the same navigator — an `Arc` identity check, for the

--- a/crates/flui-widgets/src/navigator/navigator_tests.rs
+++ b/crates/flui-widgets/src/navigator/navigator_tests.rs
@@ -1890,4 +1890,50 @@ mod user_gesture {
         assert_eq!(observer.calls_seen.load(Ordering::SeqCst), 1);
         handle.did_stop_user_gesture();
     }
+
+    /// `userGestureInProgressNotifier` (`navigator.dart:5819`) fires exactly on
+    /// the 0→1 and 1→0 transitions — the same edges that notify
+    /// `NavigatorObserver::did_start_user_gesture`/`did_stop_user_gesture` — and
+    /// never on a nested/overlapping start or stop in between.
+    ///
+    /// **No lock held over the callback is structural here, not merely
+    /// tested**: `ChangeNotifier::add_listener` requires `Send + Sync`
+    /// (`ProxyAnimation::add_status_listener`'s own bound, which a hero
+    /// flight's terminal-status listener relies on), and `NavigatorHandle` is
+    /// deliberately `!Send + !Sync` — so a listener on this notifier cannot
+    /// even *name* the owner-affine handle to read back through it, let alone
+    /// deadlock on a lock it holds. The equivalent reentrancy guarantee for
+    /// `NavigatorObserver` callbacks (which *do* hold a handle) is pinned by
+    /// `an_observer_may_call_back_into_the_navigator_from_did_start_user_gesture`
+    /// above.
+    ///
+    /// Red-check: notify unconditionally on every `did_start_user_gesture`/
+    /// `did_stop_user_gesture` call instead of gating on the 0→1/1→0 count —
+    /// `fires` reads `3` after three nested starts, not `1`.
+    #[test]
+    fn user_gesture_in_progress_notifier_fires_only_on_the_0_1_and_1_0_edges() {
+        use flui_foundation::Listenable;
+
+        let built = Built::default();
+        let handle = NavigatorHandle::new();
+        handle.seed_initial(page(&built, "/"));
+
+        let fires = Arc::new(AtomicUsize::new(0));
+        let fires_for_listener = Arc::clone(&fires);
+        let notifier = handle.user_gesture_in_progress_notifier();
+        notifier.add_listener(Arc::new(move || {
+            fires_for_listener.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        handle.did_start_user_gesture(); // 0 -> 1: fires.
+        handle.did_start_user_gesture(); // 1 -> 2: nested, no fire.
+        handle.did_start_user_gesture(); // 2 -> 3: nested, no fire.
+        assert_eq!(fires.load(Ordering::SeqCst), 1);
+
+        handle.did_stop_user_gesture(); // 3 -> 2: no fire.
+        handle.did_stop_user_gesture(); // 2 -> 1: no fire.
+        assert_eq!(fires.load(Ordering::SeqCst), 1);
+        handle.did_stop_user_gesture(); // 1 -> 0: fires.
+        assert_eq!(fires.load(Ordering::SeqCst), 2);
+    }
 }


### PR DESCRIPTION
## Summary

Closes the last Hero parity gap (B1.4): hero flights now participate in gesture-driven route transitions (swipe-back), riding the substrate merged in #364. Ported from Flutter 3.44.0 `heroes.dart`.

- **Navigator user-gesture notifier** — `ChangeNotifier` firing on 0→1/1→0 edges of the gesture counter (Flutter's `userGestureInProgressNotifier`), notify with no lock held; `UserGestureSignal` Send+Sync bundle for data-plane animation listeners.
- **Flight terminal-status deferral** (`_handleAnimationUpdate` parity) — while a gesture is in progress, completed/dismissed status updates park and replay at gesture end, so dragging back to zero never tears the flight down under the finger. Subscriptions removed in `finish` **and** a `Drop` backstop (idempotent).
- **`Hero::transition_on_user_gestures(bool)`** opt-in, default `false` (Flutter parity). During a gesture transition both ends must opt in; non-participating heroes left hidden by a prior flight are un-hidden (the `endFlight` branch — silent skip would leave them invisible).
- **Controller wiring** — gesture flights enter via `did_start_user_gesture` → sync fast path (pop-typed + `maintain_state` + destination already laid out → flight starts synchronously, no offstage flip) with post-frame fallback; the existing `didChangeTop` suppression stays (it is Flutter's own guard against double-flights on swipe snap). `did_stop_user_gesture` handles nested gestures and sweeps drag-never-moved flights.

### Tests
9 new tests (8 gesture-flow + notifier edge-count), each mutation-verified to fail without its fix — including the deferral test (guard deleted → fails), the landing test (replay neutered → fails), sync fast path (deleted → 4 fail). Review round fixed a vacuous-pin: flight-persistence assertions need a tick between the animation event and the assert (teardown drains through the shuttle rebuild).

### Gates
`cargo nextest run --workspace --exclude flui-platform` 6455 passed / 4 skipped · workspace clippy `-D warnings` clean · doc gate clean · port-check clean · fmt/taplo/typos/inventory clean. Adversarial plan review pre-code (3 fatal plan misreads corrected against the oracle) + full review + delta re-review: COMPLETE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvkSGveJwxLVuygRAGVKuz