### PR TITLE
feat(material): M3 button family — ButtonStyle, ButtonStyleButton core, Elevated/Filled(+tonal)/Outlined/Text buttons

### DIFF
--- a/crates/flui-material/src/button_style.rs
+++ b/crates/flui-material/src/button_style.rs
@@ -1,0 +1,242 @@
+//! [`ButtonStyle`] — the property bag the M3 button family resolves against.
+//!
+//! # Flutter parity
+//!
+//! `material/button_style.dart`'s `ButtonStyle` (oracle tag `3.44.0`): a
+//! bag of nullable, per-state property slots. Every field is `null` by
+//! default; a button's visible style comes from resolving each slot through
+//! `crate::button_style_button`'s widget → theme → default cascade — see
+//! that module's docs for how the cascade consumes this shape.
+//!
+//! # Slot shape: `Option<WidgetStateProperty<Option<V>>>`
+//!
+//! The double `Option` encodes two independent "unset" signals the oracle
+//! collapses into one nullable field:
+//!
+//! - **Outer `Option`** — this property was never configured at all (the
+//!   whole slot falls through to the next tier: widget → theme → default).
+//! - **Inner `Option<V>` inside the [`WidgetStateProperty`]** — the property
+//!   IS configured, but has nothing to say for the *current* states (that one
+//!   resolution falls through, per [`WidgetStateProperty`]'s own
+//!   `Option`-fallthrough contract — see `flui_widgets::widget_state`'s
+//!   module docs, the substrate this button family was built against).
+//!
+//! Both signals fall through identically in
+//! `crate::button_style_button`'s resolver, matching the oracle's
+//! `getProperty(style)?.resolve(states) ?? …` chain (`button_style_button.dart`,
+//! tag `3.44.0`) where a null *property* and a property that *resolves* to
+//! null behave the same way.
+//!
+//! # Shape: an all-optional patch, not `#[non_exhaustive]`
+//!
+//! Every field here is already `Option`-wrapped — `ButtonStyle` plays the
+//! role [`crate::ThemeDataOverrides`] plays for [`crate::ThemeData`]: a patch
+//! callers build with a struct literal and `..Default::default()`
+//! (`ButtonStyle { background_color: Some(…), ..Default::default() }`), not
+//! a value with meaningful non-`None` defaults of its own. Per
+//! [`crate::ColorSchemeOverrides`]/[`crate::ThemeDataOverrides`]'s own
+//! precedent in this crate, a patch struct built exclusively through
+//! `..Default::default()` deliberately stays OFF `#[non_exhaustive]`:
+//! `#[non_exhaustive]` blocks external-crate struct-literal construction
+//! even with a functional update, which would break the only construction
+//! path this type has. Future V1+ slots are still additive for any caller
+//! already writing `..Default::default()`, without the `#[non_exhaustive]`
+//! ceremony — see those types' doc comments for the same reasoning spelled
+//! out in full.
+//!
+//! # V1 slots vs. the oracle's full field list
+//!
+//! Ported: `text_style`, `background_color`, `foreground_color`,
+//! `overlay_color`, `elevation`, `padding`, `minimum_size`, `fixed_size`,
+//! `maximum_size`, `side`, `shape` — the eleven slots every
+//! `_TokenDefaultsM3` table in `elevated_button.dart`/`filled_button.dart`/
+//! `outlined_button.dart`/`text_button.dart` (oracle tag `3.44.0`) populates.
+//!
+//! Named omissions, not silently dropped:
+//!
+//! - **`mouse_cursor`** — FLUI has no `MouseCursor` type yet.
+//! - **`icon_color` / `icon_size`** — arrive with a future `.icon()`
+//!   constructor on each button type; nothing consumes them yet.
+//! - **`animation_duration` / `enable_feedback` / `splash_factory`** — no
+//!   implicit shape/elevation animation (`material.rs`'s own named
+//!   deferral), no acoustic/haptic feedback substrate, and no ripple
+//!   substrate (`InkWell`'s own named deferral) to select a splash factory
+//!   for.
+//! - **`visual_density` / `tap_target_size`** — FLUI has no `VisualDensity`
+//!   type; every button below skips the `_InputPadding`/density-adjustment
+//!   step the oracle's `_ButtonStyleState.build` performs.
+//! - **`alignment`** — the oracle's `Align`-wrapped child slot; the V1
+//!   composition in `crate::button_style_button` omits the `Align` layer
+//!   entirely (see that module's docs).
+//! - **`shadow_color` / `surface_tint_color`** — `Material`'s own
+//!   `surfaceTintColor` is itself a named deferral (`material.rs`), and
+//!   `Material` has no `shadow_color` field yet for a resolved
+//!   `shadow_color` to feed.
+//! - **`icon_alignment` / `background_builder` / `foreground_builder`** —
+//!   all three presuppose the icon constructor and/or an extension point
+//!   (`crate::button_style_button`'s composition is currently fixed, not
+//!   builder-customizable).
+//! - **[`ButtonStyle::lerp`]** — arrives when a component first needs
+//!   `AnimatedTheme`; nothing here consumes an interpolated style yet.
+//!
+//! [`ButtonStyle::lerp`]: https://api.flutter.dev/flutter/material/ButtonStyle/lerp.html
+
+use flui_types::styling::BorderSide;
+use flui_types::typography::TextStyle;
+use flui_types::{Color, EdgeInsets, Pixels, Size};
+use flui_widgets::WidgetStateProperty;
+
+use crate::shape::MaterialShape;
+
+/// The visual properties most buttons have in common — Flutter's
+/// `ButtonStyle`.
+///
+/// Every field is `None` by default (Flutter parity: "All of the ButtonStyle
+/// properties are null by default", `button_style.dart` doc comment). Build
+/// one with a struct literal and `..Default::default()`:
+///
+/// ```rust
+/// use flui_material::ButtonStyle;
+/// use flui_widgets::WidgetStateProperty;
+/// use flui_types::Color;
+///
+/// let style = ButtonStyle {
+///     background_color: Some(WidgetStateProperty::all(Some(Color::rgb(0, 255, 0)))),
+///     ..Default::default()
+/// };
+/// assert!(style.foreground_color.is_none());
+/// ```
+///
+/// See the module docs for the double-`Option` slot shape, why this type is
+/// deliberately not `#[non_exhaustive]`, and the V1 slot list.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ButtonStyle {
+    /// The style for the button's text descendants. Flutter parity:
+    /// `ButtonStyle.textStyle`.
+    pub text_style: Option<WidgetStateProperty<Option<TextStyle>>>,
+
+    /// The button's background fill color. Flutter parity:
+    /// `ButtonStyle.backgroundColor`.
+    pub background_color: Option<WidgetStateProperty<Option<Color>>>,
+
+    /// The color for the button's text descendants — takes precedence over
+    /// [`text_style`](Self::text_style)'s own color (see the oracle's own
+    /// doc comment on `foregroundColor`). Flutter parity:
+    /// `ButtonStyle.foregroundColor`.
+    pub foreground_color: Option<WidgetStateProperty<Option<Color>>>,
+
+    /// The state-overlay highlight color, resolved and handed to the
+    /// button's `InkWell` as a live property (not a single baked value —
+    /// see `crate::button_style_button`'s docs). Flutter parity:
+    /// `ButtonStyle.overlayColor`.
+    pub overlay_color: Option<WidgetStateProperty<Option<Color>>>,
+
+    /// The elevation of the button's `Material`. Flutter parity:
+    /// `ButtonStyle.elevation`.
+    pub elevation: Option<WidgetStateProperty<Option<f32>>>,
+
+    /// The padding between the button's boundary and its child. Flutter
+    /// parity: `ButtonStyle.padding` (narrowed to `EdgeInsets`; the oracle's
+    /// `EdgeInsetsGeometry` directional variant has no FLUI consumer yet).
+    pub padding: Option<WidgetStateProperty<Option<EdgeInsets>>>,
+
+    /// The minimum size of the button itself. Flutter parity:
+    /// `ButtonStyle.minimumSize`.
+    pub minimum_size: Option<WidgetStateProperty<Option<Size>>>,
+
+    /// The button's fixed size, overriding [`minimum_size`](Self::minimum_size)/
+    /// [`maximum_size`](Self::maximum_size) on whichever axis is finite.
+    /// Flutter parity: `ButtonStyle.fixedSize`.
+    pub fixed_size: Option<WidgetStateProperty<Option<Size>>>,
+
+    /// The maximum size of the button itself. Flutter parity:
+    /// `ButtonStyle.maximumSize`.
+    pub maximum_size: Option<WidgetStateProperty<Option<Size>>>,
+
+    /// The color and weight of the button's outline. Flutter parity:
+    /// `ButtonStyle.side`.
+    ///
+    /// **Data-complete, not yet painted**: this slot resolves correctly
+    /// (exercised by [`OutlinedButton`](crate::OutlinedButton)'s
+    /// resolved-style tests), but [`MaterialShape`] is fill-and-clip-only —
+    /// `Material.shape`'s border painting is a pre-existing named deferral
+    /// (see `shape.rs`'s "Named deferral: `OutlinedBorder` sides"). An
+    /// `OutlinedButton` in V1 resolves an outline color/width but does not
+    /// yet draw a stroke.
+    pub side: Option<WidgetStateProperty<Option<BorderSide<Pixels>>>>,
+
+    /// The shape of the button's underlying `Material`. Flutter parity:
+    /// `ButtonStyle.shape` (narrowed to [`MaterialShape`]; the oracle's open
+    /// `OutlinedBorder` hierarchy is `Material`'s own named deferral).
+    pub shape: Option<WidgetStateProperty<Option<MaterialShape>>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use flui_widgets::{WidgetState, WidgetStates};
+
+    use super::*;
+
+    #[test]
+    fn default_is_every_slot_unset() {
+        let style = ButtonStyle::default();
+        assert!(style.text_style.is_none());
+        assert!(style.background_color.is_none());
+        assert!(style.foreground_color.is_none());
+        assert!(style.overlay_color.is_none());
+        assert!(style.elevation.is_none());
+        assert!(style.padding.is_none());
+        assert!(style.minimum_size.is_none());
+        assert!(style.fixed_size.is_none());
+        assert!(style.maximum_size.is_none());
+        assert!(style.side.is_none());
+        assert!(style.shape.is_none());
+    }
+
+    /// The struct-literal + `..Default::default()` construction path this
+    /// type is built around — see the module docs on why this shape (not
+    /// `#[non_exhaustive]`) was chosen.
+    #[test]
+    fn struct_literal_with_default_update_sets_only_the_given_fields() {
+        let style = ButtonStyle {
+            elevation: Some(WidgetStateProperty::all(Some(4.0))),
+            ..Default::default()
+        };
+        assert_eq!(
+            style.elevation.unwrap().resolve(&WidgetStates::NONE),
+            Some(4.0)
+        );
+        assert!(style.background_color.is_none());
+    }
+
+    #[test]
+    fn equality_is_structural_across_two_equivalently_built_styles() {
+        let a = ButtonStyle {
+            background_color: Some(WidgetStateProperty::all(Some(Color::rgb(1, 2, 3)))),
+            ..Default::default()
+        };
+        let b = ButtonStyle {
+            background_color: Some(WidgetStateProperty::all(Some(Color::rgb(1, 2, 3)))),
+            ..Default::default()
+        };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn a_configured_property_that_resolves_none_for_a_state_is_still_none() {
+        // The inner-Option fallthrough half of the double-Option contract
+        // (see the module docs): a `Map` with no matching entry resolves to
+        // `None`, distinct from the slot being unset outright.
+        let style = ButtonStyle {
+            overlay_color: Some(WidgetStateProperty::from_map([(
+                WidgetState::Pressed.into(),
+                Some(Color::rgb(0, 0, 0)),
+            )])),
+            ..Default::default()
+        };
+        assert_eq!(
+            style.overlay_color.unwrap().resolve(&WidgetStates::NONE),
+            None
+        );
+    }
+}

--- a/crates/flui-material/src/button_style_button.rs
+++ b/crates/flui-material/src/button_style_button.rs
@@ -1,0 +1,462 @@
+//! [`ButtonStyleButtonCore`] — the composition machinery shared by every M3
+//! button (`ElevatedButton`, `FilledButton`, `OutlinedButton`, `TextButton`).
+//!
+//! # Flutter parity
+//!
+//! `material/button_style_button.dart`'s `ButtonStyleButton`/`_ButtonStyleState`
+//! (oracle tag `3.44.0`). The oracle is an abstract `StatefulWidget` base
+//! class each concrete button subclasses, overriding `defaultStyleOf` /
+//! `themeStyleOf`. Rust has no implementation inheritance, so this crate
+//! inverts the relationship: each concrete button (`elevated_button.rs` etc.)
+//! is a thin [`StatelessView`] that reads
+//! the ambient [`Theme`](crate::Theme), computes its own `default_style`
+//! table, and hands both to this module's [`ButtonStyleButtonCore`] — the
+//! `StatefulView` that owns the interactive-state machinery and the actual
+//! composition. `theme_style_of` has no caller yet (component themes are a
+//! V1 deferral — see below), so it never reaches this type at all rather
+//! than being threaded through as a permanent `None`.
+//!
+//! # The resolve-then-coalesce cascade
+//!
+//! Oracle: `_ButtonStyleState.build`'s local `effectiveValue`/`resolve`
+//! helpers (`button_style_button.dart` `:315-327`) — for each property,
+//! `getProperty(widgetStyle)?.resolve(states) ?? getProperty(themeStyle)?.resolve(states)
+//! ?? getProperty(defaultStyle)?.resolve(states)`. [`resolve_property`] is
+//! the direct Rust translation: three tiers, each independently resolved
+//! against the *current* [`WidgetStates`] and coalesced with `Option::or_else`.
+//! This is exactly the shape `flui_widgets::widget_state`'s
+//! `option_property_coalesce_chain_mirrors_button_style_button` test
+//! demonstrates for a single tier — here extended to three.
+//!
+//! `theme_style` is always `None` in every call site below: component themes
+//! (`ElevatedButtonTheme` and friends) are a named V1 deferral, not yet
+//! implemented. The three-tier signature stays in [`resolve_property`] (not
+//! collapsed to two) so the seam is visible in the type, not just prose —
+//! wiring a real `theme_style_of` in later is a call-site change, not a
+//! rewrite of this function.
+//!
+//! # Composition
+//!
+//! Oracle: `_ButtonStyleState.build`'s widget tree (`button_style_button.dart`
+//! `:497-543`), trimmed to the properties [`crate::ButtonStyle`] actually
+//! carries (see that module's docs for the omitted slots this composition
+//! therefore also skips — `visual_density`/`tap_target_size` drop the
+//! `_InputPadding` wrapper, `alignment` drops the `Align` wrapper, and there
+//! is no `Semantics`/`Tooltip` layer). What ships, outermost to innermost:
+//!
+//! ```text
+//! ConstrainedBox(min/fixed/max size)
+//!   Material(color, elevation, shape)
+//!     InkWell(overlay_color, shared states controller, enabled = on_pressed.is_some())
+//!       Padding(padding)
+//!         DefaultTextStyle(text_style with foreground_color folded into its `color`)
+//!           child
+//! ```
+//!
+//! # Own `WidgetStatesController`, shared with the inner `InkWell`
+//!
+//! Every resolved property (background/foreground/elevation/…) depends on
+//! the *current* interactive state, which only changes through
+//! hover/press/focus events the inner `InkWell` observes. So this type owns
+//! its own [`WidgetStatesController`] — created once in `create_state`,
+//! `Disabled`-synced from `on_pressed.is_some()` before any listener is
+//! attached, and handed to the inner `InkWell` via
+//! [`InkWell::states_controller`] — mirroring
+//! `crate::ink_well::InkWellState`'s own `init_state`/`did_update_view`
+//! ordering precisely (see that module's docs for why the sync-before-listen
+//! order is load-bearing). Both this state and the inner `InkWell` state end
+//! up listening on the *same* controller and syncing the *same* `Disabled`
+//! bit from the *same* `enabled` predicate — redundant but harmless (each
+//! sync is idempotent), and it is not a divergence: the oracle's own
+//! `_ButtonStyleState` and `_InkResponseState` do the identical double-sync
+//! on the same shared `MaterialStatesController` (`ButtonStyleButton` passes
+//! `statesController: statesController` straight into its `InkWell`).
+//!
+//! [`overlay_color`](crate::ButtonStyle::overlay_color) is the one property
+//! NOT baked to a single value here: it is handed to `InkWell` as a live
+//! [`WidgetStateProperty`] (closing over the widget/default styles) so
+//! `InkWell`'s own internal rebuilds (e.g. its press-deactivation timer,
+//! which fires independently of this type's rebuild — see `ink_well.rs`)
+//! keep resolving it fresh, exactly matching the oracle's own
+//! `overlayColor: WidgetStateProperty.resolveWith(...)` wrapper.
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+use flui_foundation::{Listenable, ListenerId};
+use flui_rendering::constraints::BoxConstraints;
+use flui_types::Color;
+use flui_types::typography::TextStyle;
+use flui_view::RebuildHandle;
+use flui_view::prelude::*;
+use flui_widgets::{
+    ConstrainedBox, DefaultTextStyle, Padding, WidgetState, WidgetStateProperty, WidgetStates,
+    WidgetStatesController,
+};
+
+use crate::button_style::ButtonStyle;
+use crate::ink_well::InkWell;
+use crate::material::Material;
+
+/// A no-argument press handler — the button-family counterpart to
+/// `InkWell`'s own `Rc<dyn Fn()>` tap callback (owner-local, per ADR-0027).
+pub(crate) type PressCallback = Rc<dyn Fn()>;
+
+/// Resolves one [`ButtonStyle`] property through the widget → theme →
+/// default cascade — see the module docs.
+///
+/// `default` is `Option`, not a bare reference, because the oracle
+/// explicitly allows a concrete button's `defaultStyleOf` to leave some
+/// slots unset (`fixed_size` and `side`, in every V1 default table — see
+/// `button_style_button.dart`'s `defaultStyleOf` doc comment, "Properties
+/// that can be null").
+pub(crate) fn resolve_property<T: Clone + Default>(
+    states: &WidgetStates,
+    widget: Option<&WidgetStateProperty<Option<T>>>,
+    theme: Option<&WidgetStateProperty<Option<T>>>,
+    default: Option<&WidgetStateProperty<Option<T>>>,
+) -> Option<T> {
+    widget
+        .and_then(|property| property.resolve(states))
+        .or_else(|| theme.and_then(|property| property.resolve(states)))
+        .or_else(|| default.and_then(|property| property.resolve(states)))
+}
+
+/// Resolves every field of one [`ButtonStyle`] against `styles` for
+/// `states`, tier-by-tier — the per-property expansion of
+/// [`resolve_property`] used by both [`ButtonStyleButtonCoreState::build`]
+/// and [`overlay_color_property`].
+macro_rules! resolve_field {
+    ($states:expr, $widget:expr, $theme:expr, $default:expr, $field:ident) => {
+        resolve_property(
+            $states,
+            $widget.and_then(|s: &ButtonStyle| s.$field.as_ref()),
+            $theme.and_then(|s: &ButtonStyle| s.$field.as_ref()),
+            $default.and_then(|s: &ButtonStyle| s.$field.as_ref()),
+        )
+    };
+}
+
+/// The shared machinery every M3 button composes through: resolves its
+/// [`ButtonStyle`] (widget-level `style`, falling through to
+/// `default_style`) against the current interactive states, then wires
+/// [`Material`] + [`InkWell`] + padding + size constraints + the resolved
+/// text style around `child` — see the module docs.
+#[derive(Clone, StatefulView)]
+pub(crate) struct ButtonStyleButtonCore {
+    on_pressed: Option<PressCallback>,
+    style: Option<ButtonStyle>,
+    default_style: ButtonStyle,
+    child: BoxedView,
+}
+
+impl ButtonStyleButtonCore {
+    /// `child` wrapped with no press handler (disabled) and no style
+    /// override; `default_style` is the concrete button's own
+    /// `_TokenDefaultsM3` table, computed by the caller against the ambient
+    /// theme.
+    pub(crate) fn new(default_style: ButtonStyle, child: BoxedView) -> Self {
+        Self {
+            on_pressed: None,
+            style: None,
+            default_style,
+            child,
+        }
+    }
+
+    /// Sets the press handler. Its presence is what makes this button
+    /// [`enabled`](Self::is_interactive) — Flutter parity:
+    /// `ButtonStyleButton.enabled => onPressed != null || onLongPress != null`
+    /// (narrowed to `onPressed`; `onLongPress` is not part of this V1).
+    #[must_use]
+    pub(crate) fn on_pressed(mut self, callback: PressCallback) -> Self {
+        self.on_pressed = Some(callback);
+        self
+    }
+
+    /// Sets the widget-level style override — the highest-precedence tier
+    /// in the resolve cascade.
+    #[must_use]
+    pub(crate) fn style(mut self, style: ButtonStyle) -> Self {
+        self.style = Some(style);
+        self
+    }
+
+    fn is_interactive(&self) -> bool {
+        self.on_pressed.is_some()
+    }
+}
+
+impl std::fmt::Debug for ButtonStyleButtonCore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ButtonStyleButtonCore")
+            .field("enabled", &self.is_interactive())
+            .field("style", &self.style)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Persistent state behind [`ButtonStyleButtonCore`] — see
+/// `crate::ink_well::InkWellState`, whose `init_state`/`did_update_view`
+/// ordering this mirrors exactly (see the module docs).
+pub(crate) struct ButtonStyleButtonCoreState {
+    states: WidgetStatesController,
+    states_listener: Option<ListenerId>,
+    /// Seeded from the initial view in `create_state`; consumed once by
+    /// `init_state` (which has no `view` parameter — see `InkWellState`'s
+    /// identical `tap_slot` shape for why `create_state` is where a
+    /// `ViewState` impl captures anything it needs before its first
+    /// build).
+    initially_enabled: bool,
+    rebuild: Option<RebuildHandle>,
+}
+
+impl StatefulView for ButtonStyleButtonCore {
+    type State = ButtonStyleButtonCoreState;
+
+    fn create_state(&self) -> Self::State {
+        ButtonStyleButtonCoreState {
+            states: WidgetStatesController::default(),
+            states_listener: None,
+            initially_enabled: self.is_interactive(),
+            rebuild: None,
+        }
+    }
+}
+
+impl ViewState<ButtonStyleButtonCore> for ButtonStyleButtonCoreState {
+    fn init_state(&mut self, ctx: &dyn BuildContext) {
+        let rebuild = ctx.rebuild_handle();
+
+        // Sync BEFORE listening — see `InkWellState::init_state`'s module-doc
+        // rationale, which applies verbatim here.
+        self.states
+            .update(WidgetState::Disabled, !self.initially_enabled);
+
+        let rebuild_for_listener = rebuild.clone();
+        self.states_listener = Some(self.states.add_listener(Arc::new(move || {
+            rebuild_for_listener.schedule();
+        })));
+
+        self.rebuild = Some(rebuild);
+    }
+
+    fn did_update_view(
+        &mut self,
+        old_view: &ButtonStyleButtonCore,
+        new_view: &ButtonStyleButtonCore,
+    ) {
+        if new_view.is_interactive() != old_view.is_interactive() {
+            self.states
+                .update(WidgetState::Disabled, !new_view.is_interactive());
+        }
+    }
+
+    fn build(&self, view: &ButtonStyleButtonCore, _ctx: &dyn BuildContext) -> impl IntoView {
+        let states = self.states.value();
+        let widget_style = view.style.as_ref();
+        let default_style = Some(&view.default_style);
+        // Deferred: component themes (`ElevatedButtonTheme` and friends) —
+        // see the module docs. No call site threads a real value through
+        // yet.
+        let theme_style: Option<&ButtonStyle> = None;
+
+        let background_color = resolve_field!(
+            &states,
+            widget_style,
+            theme_style,
+            default_style,
+            background_color
+        )
+        .unwrap_or(Color::TRANSPARENT);
+        let foreground_color = resolve_field!(
+            &states,
+            widget_style,
+            theme_style,
+            default_style,
+            foreground_color
+        );
+        let elevation =
+            resolve_field!(&states, widget_style, theme_style, default_style, elevation)
+                .unwrap_or(0.0);
+        let padding = resolve_field!(&states, widget_style, theme_style, default_style, padding)
+            .unwrap_or_default();
+        let minimum_size = resolve_field!(
+            &states,
+            widget_style,
+            theme_style,
+            default_style,
+            minimum_size
+        )
+        .unwrap_or(flui_types::Size::ZERO);
+        let fixed_size = resolve_field!(
+            &states,
+            widget_style,
+            theme_style,
+            default_style,
+            fixed_size
+        );
+        let maximum_size = resolve_field!(
+            &states,
+            widget_style,
+            theme_style,
+            default_style,
+            maximum_size
+        )
+        .unwrap_or(flui_types::Size::INFINITY);
+        // Resolved for parity/completeness, but not yet painted — see
+        // `ButtonStyle::side`'s doc comment.
+        let _side = resolve_field!(&states, widget_style, theme_style, default_style, side);
+        let shape = resolve_field!(&states, widget_style, theme_style, default_style, shape)
+            .unwrap_or_default();
+        let text_style = resolve_field!(
+            &states,
+            widget_style,
+            theme_style,
+            default_style,
+            text_style
+        );
+
+        let text_style = fold_foreground_into_text_style(text_style, foreground_color);
+
+        let mut constraints = BoxConstraints::new(
+            minimum_size.width,
+            maximum_size.width,
+            minimum_size.height,
+            maximum_size.height,
+        );
+        if let Some(fixed) = fixed_size {
+            if fixed.width.is_finite() {
+                constraints.min_width = fixed.width;
+                constraints.max_width = fixed.width;
+            }
+            if fixed.height.is_finite() {
+                constraints.min_height = fixed.height;
+                constraints.max_height = fixed.height;
+            }
+        }
+
+        let overlay_color = overlay_color_property(view.style.clone(), view.default_style.clone());
+
+        let mut ink_well = InkWell::new(
+            Padding::new(padding).child(DefaultTextStyle::new(text_style, view.child.clone())),
+        )
+        .shape(shape)
+        .overlay_color(overlay_color)
+        .states_controller(self.states.clone());
+        if let Some(on_pressed) = view.on_pressed.clone() {
+            ink_well = ink_well.on_tap(move || on_pressed());
+        }
+
+        ConstrainedBox::new(constraints).child(
+            Material::new(background_color)
+                .elevation(elevation)
+                .shape(shape)
+                .child(ink_well),
+        )
+    }
+
+    fn dispose(&mut self) {
+        if let Some(id) = self.states_listener.take() {
+            self.states.remove_listener(id);
+        }
+    }
+}
+
+/// Folds `foreground_color` into `text_style`'s own `color` — Flutter
+/// parity: `resolvedTextStyle?.copyWith(color: resolvedForegroundColor)`
+/// (`button_style_button.dart` `:539`). `foreground_color` takes precedence
+/// over whatever color `text_style` already carries (see
+/// [`ButtonStyle::foreground_color`](crate::ButtonStyle::foreground_color)'s
+/// doc comment).
+fn fold_foreground_into_text_style(
+    text_style: Option<TextStyle>,
+    foreground_color: Option<Color>,
+) -> TextStyle {
+    let text_style = text_style.unwrap_or_default();
+    match foreground_color {
+        Some(color) => text_style.with_color(color),
+        None => text_style,
+    }
+}
+
+/// Builds the live [`WidgetStateProperty`] handed to the inner `InkWell` —
+/// see the module docs on why `overlay_color` is not baked to a single
+/// value like every other property.
+fn overlay_color_property(
+    widget_style: Option<ButtonStyle>,
+    default_style: ButtonStyle,
+) -> WidgetStateProperty<Option<Color>> {
+    WidgetStateProperty::resolve_with(move |states: &WidgetStates| {
+        resolve_field!(
+            states,
+            widget_style.as_ref(),
+            None::<&ButtonStyle>,
+            Some(&default_style),
+            overlay_color
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use flui_widgets::{WidgetStateConstraint, WidgetStates};
+
+    use super::*;
+
+    fn all_property<T: Clone>(value: T) -> WidgetStateProperty<Option<T>> {
+        WidgetStateProperty::all(Some(value))
+    }
+
+    #[test]
+    fn widget_tier_wins_when_all_three_are_set() {
+        let widget = all_property(1_u32);
+        let default = all_property(3_u32);
+        let resolved = resolve_property(&WidgetStates::NONE, Some(&widget), None, Some(&default));
+        assert_eq!(resolved, Some(1));
+    }
+
+    #[test]
+    fn default_tier_is_used_when_widget_and_theme_are_absent() {
+        let default = all_property(3_u32);
+        let resolved: Option<u32> =
+            resolve_property(&WidgetStates::NONE, None, None, Some(&default));
+        assert_eq!(resolved, Some(3));
+    }
+
+    /// Mutation-honest: if the coalesce stopped checking the widget
+    /// property's OWN resolution and instead treated "widget property is
+    /// present" as sufficient, this would return `Some(1)` from a widget
+    /// property that only covers `Pressed` while the button is unpressed —
+    /// it must fall through to `default` instead.
+    #[test]
+    fn a_widget_property_that_resolves_none_for_this_state_falls_through_to_default() {
+        let widget: WidgetStateProperty<Option<u32>> = WidgetStateProperty::from_map([(
+            WidgetStateConstraint::Is(flui_widgets::WidgetState::Pressed),
+            Some(1_u32),
+        )]);
+        let default = all_property(3_u32);
+        let resolved = resolve_property(&WidgetStates::NONE, Some(&widget), None, Some(&default));
+        assert_eq!(resolved, Some(3));
+    }
+
+    #[test]
+    fn nothing_set_anywhere_resolves_to_none() {
+        let resolved: Option<u32> = resolve_property(&WidgetStates::NONE, None, None, None);
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn fold_foreground_into_text_style_overrides_the_text_styles_own_color() {
+        let base = TextStyle::new().with_color(Color::rgb(1, 1, 1));
+        let folded = fold_foreground_into_text_style(Some(base), Some(Color::rgb(9, 9, 9)));
+        assert_eq!(folded.color, Some(Color::rgb(9, 9, 9)));
+    }
+
+    #[test]
+    fn fold_foreground_into_text_style_keeps_the_base_color_when_no_foreground_is_resolved() {
+        let base = TextStyle::new().with_color(Color::rgb(1, 1, 1));
+        let folded = fold_foreground_into_text_style(Some(base.clone()), None);
+        assert_eq!(folded.color, base.color);
+    }
+}

--- a/crates/flui-material/src/button_style_button.rs
+++ b/crates/flui-material/src/button_style_button.rs
@@ -304,9 +304,13 @@ impl ViewState<ButtonStyleButtonCore> for ButtonStyleButtonCoreState {
             maximum_size
         )
         .unwrap_or(flui_types::Size::INFINITY);
-        // Resolved for parity/completeness, but not yet painted — see
-        // `ButtonStyle::side`'s doc comment.
-        let _side = resolve_field!(&states, widget_style, theme_style, default_style, side);
+        // `side` is NOT resolved here: `Material`/`MaterialShape` has no
+        // border-side painting path yet (see `ButtonStyle::side`'s doc
+        // comment), so nothing in this composition would consume it. Each
+        // button's `default_style` (and any widget-level override) still
+        // carries the slot — `OutlinedButton`'s own tests exercise its
+        // resolution directly — this composition step just has nothing to
+        // do with the result yet.
         let shape = resolve_field!(&states, widget_style, theme_style, default_style, shape)
             .unwrap_or_default();
         let text_style = resolve_field!(
@@ -319,22 +323,7 @@ impl ViewState<ButtonStyleButtonCore> for ButtonStyleButtonCoreState {
 
         let text_style = fold_foreground_into_text_style(text_style, foreground_color);
 
-        let mut constraints = BoxConstraints::new(
-            minimum_size.width,
-            maximum_size.width,
-            minimum_size.height,
-            maximum_size.height,
-        );
-        if let Some(fixed) = fixed_size {
-            if fixed.width.is_finite() {
-                constraints.min_width = fixed.width;
-                constraints.max_width = fixed.width;
-            }
-            if fixed.height.is_finite() {
-                constraints.min_height = fixed.height;
-                constraints.max_height = fixed.height;
-            }
-        }
+        let constraints = effective_constraints(minimum_size, maximum_size, fixed_size);
 
         let overlay_color = overlay_color_property(view.style.clone(), view.default_style.clone());
 
@@ -378,6 +367,43 @@ fn fold_foreground_into_text_style(
         Some(color) => text_style.with_color(color),
         None => text_style,
     }
+}
+
+/// Builds the [`BoxConstraints`] the button's `ConstrainedBox` enforces from
+/// its three resolved size slots. Flutter parity:
+/// `_ButtonStyleState.build`'s `effectiveConstraints` construction
+/// (`button_style_button.dart` `:517-533`, oracle tag `3.44.0`), narrowed to
+/// the V1 slots (no `visualDensity` adjustment — see
+/// `crate::button_style`'s module docs).
+///
+/// `minimum`/`maximum` build the base envelope; `fixed`, if present, is
+/// clamped INTO that already-built envelope (`effectiveConstraints.constrain
+/// (resolvedFixedSize)`) before pinning `min == max` on each of its finite
+/// axes — clamping first, not pinning `fixed` directly, is load-bearing: a
+/// `fixed` smaller than `minimum` (or larger than `maximum`) would otherwise
+/// invert `min > max` into a malformed [`BoxConstraints`] instead of
+/// clamping to the envelope's edge, matching the oracle's own behavior.
+fn effective_constraints(
+    minimum: flui_types::Size,
+    maximum: flui_types::Size,
+    fixed: Option<flui_types::Size>,
+) -> BoxConstraints {
+    let mut constraints =
+        BoxConstraints::new(minimum.width, maximum.width, minimum.height, maximum.height);
+    let Some(fixed) = fixed else {
+        return constraints;
+    };
+
+    let clamped = constraints.constrain(fixed);
+    if fixed.width.is_finite() {
+        constraints.min_width = clamped.width;
+        constraints.max_width = clamped.width;
+    }
+    if fixed.height.is_finite() {
+        constraints.min_height = clamped.height;
+        constraints.max_height = clamped.height;
+    }
+    constraints
 }
 
 /// Builds the live [`WidgetStateProperty`] handed to the inner `InkWell` —
@@ -458,5 +484,88 @@ mod tests {
         let base = TextStyle::new().with_color(Color::rgb(1, 1, 1));
         let folded = fold_foreground_into_text_style(Some(base.clone()), None);
         assert_eq!(folded.color, base.color);
+    }
+
+    // ------------------------------------------------------------------
+    // effective_constraints — min/max envelope + fixed-size clamping
+    // ------------------------------------------------------------------
+
+    fn size(width: f32, height: f32) -> flui_types::Size {
+        flui_types::Size::new(
+            flui_types::geometry::px(width),
+            flui_types::geometry::px(height),
+        )
+    }
+
+    #[test]
+    fn no_fixed_size_passes_minimum_and_maximum_through_unpinned() {
+        let constraints = effective_constraints(size(64.0, 40.0), size(200.0, 100.0), None);
+        assert_eq!(constraints.min_width, flui_types::geometry::px(64.0));
+        assert_eq!(constraints.max_width, flui_types::geometry::px(200.0));
+        assert_eq!(constraints.min_height, flui_types::geometry::px(40.0));
+        assert_eq!(constraints.max_height, flui_types::geometry::px(100.0));
+    }
+
+    /// A `fixed_size` inside `[minimum, maximum]` pins `min == max` at
+    /// exactly that value on both axes.
+    #[test]
+    fn fixed_size_inside_the_envelope_pins_min_and_max_to_it() {
+        let constraints =
+            effective_constraints(size(64.0, 40.0), size(200.0, 100.0), Some(size(90.0, 60.0)));
+        assert_eq!(constraints.min_width, flui_types::geometry::px(90.0));
+        assert_eq!(constraints.max_width, flui_types::geometry::px(90.0));
+        assert_eq!(constraints.min_height, flui_types::geometry::px(60.0));
+        assert_eq!(constraints.max_height, flui_types::geometry::px(60.0));
+    }
+
+    /// Mutation-honest — the bug this test would have caught: a
+    /// `fixed_size` (10×10) SMALLER than `minimum` (64×40) must clamp UP to
+    /// the minimum before pinning, not pin directly to 10×10 (which would
+    /// invert `min > max` against a `maximum` of 200×100 anyway, but more
+    /// importantly silently produces a button smaller than its own declared
+    /// minimum — the oracle's `effectiveConstraints.constrain(resolvedFixedSize)`
+    /// step this function ports).
+    #[test]
+    fn fixed_size_smaller_than_minimum_is_clamped_up_to_the_minimum() {
+        let constraints =
+            effective_constraints(size(64.0, 40.0), size(200.0, 100.0), Some(size(10.0, 10.0)));
+        assert_eq!(constraints.min_width, flui_types::geometry::px(64.0));
+        assert_eq!(constraints.max_width, flui_types::geometry::px(64.0));
+        assert_eq!(constraints.min_height, flui_types::geometry::px(40.0));
+        assert_eq!(constraints.max_height, flui_types::geometry::px(40.0));
+    }
+
+    /// Symmetric case: a `fixed_size` LARGER than `maximum` clamps down.
+    #[test]
+    fn fixed_size_larger_than_maximum_is_clamped_down_to_the_maximum() {
+        let constraints = effective_constraints(
+            size(64.0, 40.0),
+            size(200.0, 100.0),
+            Some(size(500.0, 500.0)),
+        );
+        assert_eq!(constraints.min_width, flui_types::geometry::px(200.0));
+        assert_eq!(constraints.max_width, flui_types::geometry::px(200.0));
+        assert_eq!(constraints.min_height, flui_types::geometry::px(100.0));
+        assert_eq!(constraints.max_height, flui_types::geometry::px(100.0));
+    }
+
+    /// An infinite `fixed_size` axis is ignored on that axis (Flutter
+    /// parity: "Fixed size dimensions whose value is double.infinity are
+    /// ignored", `ButtonStyle.fixedSize`'s doc comment) — the other axis
+    /// still pins.
+    #[test]
+    fn an_infinite_fixed_axis_leaves_that_axis_at_the_envelope() {
+        let constraints = effective_constraints(
+            size(64.0, 40.0),
+            size(200.0, 100.0),
+            Some(flui_types::Size::new(
+                flui_types::Pixels::INFINITY,
+                flui_types::geometry::px(60.0),
+            )),
+        );
+        assert_eq!(constraints.min_width, flui_types::geometry::px(64.0));
+        assert_eq!(constraints.max_width, flui_types::geometry::px(200.0));
+        assert_eq!(constraints.min_height, flui_types::geometry::px(60.0));
+        assert_eq!(constraints.max_height, flui_types::geometry::px(60.0));
     }
 }

--- a/crates/flui-material/src/elevated_button.rs
+++ b/crates/flui-material/src/elevated_button.rs
@@ -1,0 +1,333 @@
+//! [`ElevatedButton`] — a filled M3 button whose `Material` elevates when
+//! pressed.
+//!
+//! # Flutter parity
+//!
+//! `material/elevated_button.dart`'s `ElevatedButton` (oracle tag `3.44.0`).
+//! `default_style` is a field-by-field port of `_ElevatedButtonDefaultsM3`
+//! (`elevated_button.dart` `:513-637`), narrowed to the V1 slots
+//! [`ButtonStyle`] carries — see that module's docs for the full omitted-slot
+//! list. Ported fields: `text_style`, `background_color`, `foreground_color`,
+//! `overlay_color`, `elevation`, `padding`, `minimum_size`, `maximum_size`,
+//! `shape`. Deferred alongside every other V1 button (not `_ElevatedButtonDefaultsM3`-
+//! specific): `icon_color`/`icon_size`, `mouse_cursor`,
+//! `visual_density`/`tap_target_size`, `animation_duration`/`enable_feedback`/
+//! `splash_factory`. `_ElevatedButtonDefaultsM3` sets no default `side` or
+//! `fixed_size` either (the oracle's own "No default fixedSize" / "No
+//! default side" comments), so neither field is populated here.
+
+use flui_types::Color;
+use flui_types::geometry::px;
+use flui_types::{EdgeInsets, Size};
+use flui_view::prelude::*;
+use flui_widgets::{WidgetState, WidgetStateProperty};
+
+use crate::ThemeData;
+use crate::button_style::ButtonStyle;
+use crate::button_style_button::{ButtonStyleButtonCore, PressCallback};
+use crate::shape::MaterialShape;
+use crate::theme::Theme;
+
+/// A filled Material 3 button whose `Material` elevates on press. Use for
+/// important actions in flat, low-emphasis layouts — see
+/// <https://m3.material.io/components/buttons/overview>.
+///
+/// ```rust
+/// use flui_material::ElevatedButton;
+/// use flui_widgets::Text;
+///
+/// let _button = ElevatedButton::new(Text::new("Save")).on_pressed(|| {});
+/// ```
+#[derive(Clone, StatelessView)]
+pub struct ElevatedButton {
+    on_pressed: Option<PressCallback>,
+    style: Option<ButtonStyle>,
+    child: BoxedView,
+}
+
+impl std::fmt::Debug for ElevatedButton {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ElevatedButton")
+            .field("enabled", &self.on_pressed.is_some())
+            .field("style", &self.style)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ElevatedButton {
+    /// An `ElevatedButton` around `child` with no press handler (disabled)
+    /// and no style override.
+    pub fn new(child: impl IntoView) -> Self {
+        Self {
+            on_pressed: None,
+            style: None,
+            child: BoxedView(Box::new(child.into_view())),
+        }
+    }
+
+    /// Sets the press handler. Presence of a handler is what makes this
+    /// button enabled.
+    #[must_use]
+    pub fn on_pressed(mut self, callback: impl Fn() + 'static) -> Self {
+        self.on_pressed = Some(std::rc::Rc::new(callback));
+        self
+    }
+
+    /// Overrides the default style, per property (unset properties keep
+    /// falling through to the default) — see
+    /// `crate::button_style_button`'s resolve-then-coalesce docs.
+    #[must_use]
+    pub fn style(mut self, style: ButtonStyle) -> Self {
+        self.style = Some(style);
+        self
+    }
+}
+
+impl StatelessView for ElevatedButton {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        let theme = Theme::of(ctx);
+        let mut core = ButtonStyleButtonCore::new(default_style(&theme), self.child.clone())
+            .style(self.style.clone().unwrap_or_default());
+        if let Some(on_pressed) = self.on_pressed.clone() {
+            core = core.on_pressed(on_pressed);
+        }
+        core
+    }
+}
+
+/// Verbatim, field-by-field port of `_ElevatedButtonDefaultsM3`
+/// (`elevated_button.dart`, oracle tag `3.44.0`), narrowed to the V1 slots —
+/// see the module docs.
+fn default_style(theme: &ThemeData) -> ButtonStyle {
+    let colors = theme.color_scheme;
+
+    ButtonStyle {
+        text_style: Some(WidgetStateProperty::all(
+            theme.text_theme.label_large.clone(),
+        )),
+        background_color: Some(WidgetStateProperty::resolve_with(move |states| {
+            Some(if states.contains_state(WidgetState::Disabled) {
+                colors.on_surface.with_opacity(0.12)
+            } else {
+                colors.surface_container_low
+            })
+        })),
+        foreground_color: Some(WidgetStateProperty::resolve_with(move |states| {
+            Some(if states.contains_state(WidgetState::Disabled) {
+                colors.on_surface.with_opacity(0.38)
+            } else {
+                colors.primary
+            })
+        })),
+        overlay_color: Some(WidgetStateProperty::resolve_with(move |states| {
+            pressed_hovered_focused_overlay(states, colors.primary)
+        })),
+        elevation: Some(WidgetStateProperty::resolve_with(move |states| {
+            Some(if states.contains_state(WidgetState::Disabled) {
+                0.0
+            } else if states.contains_state(WidgetState::Pressed) {
+                1.0
+            } else if states.contains_state(WidgetState::Hovered) {
+                3.0
+            } else {
+                // Focused, and the oracle's unconditional fallback, both
+                // resolve to 1.0.
+                1.0
+            })
+        })),
+        padding: Some(WidgetStateProperty::all(Some(scaled_padding_1x()))),
+        minimum_size: Some(WidgetStateProperty::all(Some(Size::new(
+            px(64.0),
+            px(40.0),
+        )))),
+        fixed_size: None,
+        maximum_size: Some(WidgetStateProperty::all(Some(Size::INFINITY))),
+        side: None,
+        shape: Some(WidgetStateProperty::all(Some(MaterialShape::Stadium))),
+    }
+}
+
+/// `24px` horizontal, `0px` vertical — the `effectiveTextScale <= 1` tier of
+/// `ButtonStyleButton.scaledPadding` (oracle: `elevated_button.dart`'s
+/// private `_scaledPadding`, tag `3.44.0`, `useMaterial3` branch). FLUI has
+/// no `MediaQuery` text-scaler consumer yet (named deferral, shared with
+/// every V1 button below), so only the 1x tier is ported; the 2x/3x lerp
+/// tiers arrive alongside that consumer.
+pub(crate) fn scaled_padding_1x() -> EdgeInsets {
+    EdgeInsets::symmetric(px(0.0), px(24.0))
+}
+
+/// The pressed(10%)/hovered(8%)/focused(10%) overlay ramp every V1 button's
+/// `_TokenDefaultsM3.overlayColor` shares, differing only in `base_color`.
+/// Oracle order matters: pressed is checked FIRST, so a state set containing
+/// both `Pressed` and `Hovered` resolves the pressed opacity, not hover's.
+/// `None` (no interactive state active) paints no overlay layer at all — see
+/// `crate::ink_well`'s module docs on why `None` is not a fallback color.
+pub(crate) fn pressed_hovered_focused_overlay(
+    states: &flui_widgets::WidgetStates,
+    base_color: Color,
+) -> Option<Color> {
+    if states.contains_state(WidgetState::Pressed) {
+        Some(base_color.with_opacity(0.1))
+    } else if states.contains_state(WidgetState::Hovered) {
+        Some(base_color.with_opacity(0.08))
+    } else if states.contains_state(WidgetState::Focused) {
+        Some(base_color.with_opacity(0.1))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use flui_widgets::{WidgetState, WidgetStates};
+
+    use super::*;
+
+    fn resolve<T: Clone + Default>(
+        property: Option<&WidgetStateProperty<Option<T>>>,
+        states: &WidgetStates,
+    ) -> Option<T> {
+        property.and_then(|p| p.resolve(states))
+    }
+
+    /// Oracle citation: `_ElevatedButtonDefaultsM3` (`elevated_button.dart`,
+    /// tag `3.44.0`). Default/hovered/pressed/disabled state matrix against
+    /// background/foreground/overlay/elevation — the parity core this test
+    /// file exists to prove. 9 of 11 `ButtonStyle` slots are exercised here
+    /// (`text_style` and `shape` are covered by their own dedicated tests
+    /// below); `fixed_size`/`side` are asserted absent, matching the
+    /// oracle's own "No default fixedSize"/"No default side" comments.
+    #[test]
+    fn default_style_matches_elevated_button_defaults_m3_state_matrix() {
+        let theme = ThemeData::light();
+        let colors = theme.color_scheme;
+        let style = default_style(&theme);
+
+        let none = WidgetStates::NONE;
+        let hovered = WidgetStates::from(WidgetState::Hovered);
+        let pressed = WidgetStates::from(WidgetState::Pressed);
+        let disabled = WidgetStates::from(WidgetState::Disabled);
+
+        assert_eq!(
+            resolve(style.background_color.as_ref(), &none),
+            Some(colors.surface_container_low)
+        );
+        assert_eq!(
+            resolve(style.background_color.as_ref(), &disabled),
+            Some(colors.on_surface.with_opacity(0.12))
+        );
+
+        assert_eq!(
+            resolve(style.foreground_color.as_ref(), &none),
+            Some(colors.primary)
+        );
+        assert_eq!(
+            resolve(style.foreground_color.as_ref(), &disabled),
+            Some(colors.on_surface.with_opacity(0.38))
+        );
+
+        assert_eq!(resolve(style.overlay_color.as_ref(), &none), None);
+        assert_eq!(
+            resolve(style.overlay_color.as_ref(), &pressed),
+            Some(colors.primary.with_opacity(0.1))
+        );
+        assert_eq!(
+            resolve(style.overlay_color.as_ref(), &hovered),
+            Some(colors.primary.with_opacity(0.08))
+        );
+
+        assert_eq!(resolve(style.elevation.as_ref(), &none), Some(1.0));
+        assert_eq!(resolve(style.elevation.as_ref(), &hovered), Some(3.0));
+        assert_eq!(resolve(style.elevation.as_ref(), &pressed), Some(1.0));
+        assert_eq!(resolve(style.elevation.as_ref(), &disabled), Some(0.0));
+    }
+
+    /// Pressed-first resolver order: a state set containing both `Pressed`
+    /// and `Hovered` resolves the pressed overlay opacity, not hover's.
+    #[test]
+    fn overlay_color_checks_pressed_before_hovered() {
+        let theme = ThemeData::light();
+        let colors = theme.color_scheme;
+        let style = default_style(&theme);
+
+        let pressed_and_hovered =
+            WidgetStates::from(WidgetState::Pressed).with_state(WidgetState::Hovered);
+        assert_eq!(
+            resolve(style.overlay_color.as_ref(), &pressed_and_hovered),
+            Some(colors.primary.with_opacity(0.1))
+        );
+    }
+
+    #[test]
+    fn default_style_leaves_fixed_size_and_side_unset() {
+        let style = default_style(&ThemeData::light());
+        assert!(style.fixed_size.is_none());
+        assert!(style.side.is_none());
+    }
+
+    #[test]
+    fn default_style_shape_is_stadium() {
+        let style = default_style(&ThemeData::light());
+        assert_eq!(
+            resolve(style.shape.as_ref(), &WidgetStates::NONE),
+            Some(MaterialShape::Stadium)
+        );
+    }
+
+    #[test]
+    fn default_style_text_style_is_the_themes_label_large() {
+        let theme = ThemeData::light();
+        let style = default_style(&theme);
+        assert_eq!(
+            resolve(style.text_style.as_ref(), &WidgetStates::NONE),
+            theme.text_theme.label_large
+        );
+    }
+
+    /// Style precedence: `widget.style` overrides the default per-property,
+    /// while every unset property keeps falling through. Mutation-honest:
+    /// breaking the coalesce in `resolve_property` fails this test.
+    #[test]
+    fn widget_style_overrides_the_default_elevation_only() {
+        let theme = ThemeData::light();
+        let default = default_style(&theme);
+
+        let widget_style = ButtonStyle {
+            elevation: Some(WidgetStateProperty::all(Some(42.0))),
+            ..Default::default()
+        };
+
+        // `resolve_property` (the actual production coalesce) rather than a
+        // hand-rolled `??`, so this test would fail if that helper regressed.
+        use crate::button_style_button::resolve_property;
+        let none = WidgetStates::NONE;
+        let resolved_elevation = resolve_property(
+            &none,
+            widget_style.elevation.as_ref(),
+            None,
+            default.elevation.as_ref(),
+        );
+        assert_eq!(resolved_elevation, Some(42.0));
+
+        let resolved_background = resolve_property(
+            &none,
+            widget_style.background_color.as_ref(),
+            None,
+            default.background_color.as_ref(),
+        );
+        assert_eq!(
+            resolved_background,
+            resolve(default.background_color.as_ref(), &none)
+        );
+    }
+
+    #[test]
+    fn is_disabled_when_no_press_handler_is_set() {
+        assert!(
+            ElevatedButton::new(flui_widgets::SizedBox::shrink())
+                .on_pressed
+                .is_none()
+        );
+    }
+}

--- a/crates/flui-material/src/elevated_button.rs
+++ b/crates/flui-material/src/elevated_button.rs
@@ -259,6 +259,24 @@ mod tests {
         );
     }
 
+    /// Same pressed-before-hovered order for `elevation`'s own chain
+    /// (`disabled` → `pressed` → `hovered` → `focused`/fallback,
+    /// `_ElevatedButtonDefaultsM3.elevation`, `elevated_button.dart`, tag
+    /// `3.44.0`): a state set containing both `Pressed` and `Hovered` must
+    /// resolve the pressed value (1.0), not hover's higher one (3.0).
+    #[test]
+    fn elevation_checks_pressed_before_hovered() {
+        let theme = ThemeData::light();
+        let style = default_style(&theme);
+
+        let pressed_and_hovered =
+            WidgetStates::from(WidgetState::Pressed).with_state(WidgetState::Hovered);
+        assert_eq!(
+            resolve(style.elevation.as_ref(), &pressed_and_hovered),
+            Some(1.0)
+        );
+    }
+
     #[test]
     fn default_style_leaves_fixed_size_and_side_unset() {
         let style = default_style(&ThemeData::light());

--- a/crates/flui-material/src/filled_button.rs
+++ b/crates/flui-material/src/filled_button.rs
@@ -149,16 +149,32 @@ fn default_style(theme: &ThemeData, variant: FilledButtonVariant) -> ButtonStyle
         overlay_color: Some(WidgetStateProperty::resolve_with(move |states| {
             pressed_hovered_focused_overlay(states, foreground)
         })),
+        // Oracle order matters: `disabled` and `pressed` are checked BEFORE
+        // `hovered`, so a state set containing both `Pressed` and `Hovered`
+        // (an ordinary mouse press on an already-hovered button) resolves
+        // the pressed value (0.0), never the hover value (1.0). Early
+        // returns (not an `if`/`else if` chain — clippy rightly flags
+        // adjacent identical `0.0` bodies there) still preserve the
+        // oracle's exact branch order: `disabled` → `pressed` → `hovered` →
+        // `focused` → the unconditional fallback (`_FilledButtonDefaultsM3
+        // .elevation`'s chain, `filled_button.dart`, tag `3.44.0`; same
+        // table shape as `_FilledTonalButtonDefaultsM3.elevation`). A
+        // collapsed `!disabled && hovered` condition already dropped this
+        // exact check once — see the mutation-honest
+        // `elevation_checks_pressed_before_hovered` test below.
         elevation: Some(WidgetStateProperty::resolve_with(move |states| {
-            Some(
-                if !states.contains_state(WidgetState::Disabled)
-                    && states.contains_state(WidgetState::Hovered)
-                {
-                    1.0
-                } else {
-                    0.0
-                },
-            )
+            if states.contains_state(WidgetState::Disabled) {
+                return Some(0.0);
+            }
+            if states.contains_state(WidgetState::Pressed) {
+                return Some(0.0);
+            }
+            if states.contains_state(WidgetState::Hovered) {
+                return Some(1.0);
+            }
+            // Focused, and the oracle's unconditional fallback, both
+            // resolve to 0.0.
+            Some(0.0)
         })),
         padding: Some(WidgetStateProperty::all(Some(scaled_padding_1x()))),
         minimum_size: Some(WidgetStateProperty::all(Some(Size::new(
@@ -243,6 +259,40 @@ mod tests {
             WidgetStates::from(WidgetState::Disabled).with_state(WidgetState::Hovered);
         assert_eq!(
             resolve(style.elevation.as_ref(), &disabled_and_hovered),
+            Some(0.0)
+        );
+    }
+
+    /// Pressed-first resolver order: a state set containing both `Pressed`
+    /// and `Hovered` (an ordinary mouse press on an already-hovered button)
+    /// resolves the pressed elevation (0.0), not hover's (1.0).
+    /// Mutation-honest: this is exactly the case a collapsed
+    /// `!disabled && hovered` condition gets wrong (it checked only
+    /// `hovered`, so `{Pressed, Hovered}` resolved 1.0 instead of 0.0) —
+    /// run that mutation against `default_style` below to see this test
+    /// fail.
+    #[test]
+    fn filled_elevation_checks_pressed_before_hovered() {
+        let theme = ThemeData::light();
+        let style = default_style(&theme, FilledButtonVariant::Filled);
+        let pressed_and_hovered =
+            WidgetStates::from(WidgetState::Pressed).with_state(WidgetState::Hovered);
+        assert_eq!(
+            resolve(style.elevation.as_ref(), &pressed_and_hovered),
+            Some(0.0)
+        );
+    }
+
+    /// Same pressed-before-hovered check for the tonal variant's identical
+    /// elevation table shape.
+    #[test]
+    fn tonal_elevation_checks_pressed_before_hovered() {
+        let theme = ThemeData::light();
+        let style = default_style(&theme, FilledButtonVariant::Tonal);
+        let pressed_and_hovered =
+            WidgetStates::from(WidgetState::Pressed).with_state(WidgetState::Hovered);
+        assert_eq!(
+            resolve(style.elevation.as_ref(), &pressed_and_hovered),
             Some(0.0)
         );
     }

--- a/crates/flui-material/src/filled_button.rs
+++ b/crates/flui-material/src/filled_button.rs
@@ -1,0 +1,301 @@
+//! [`FilledButton`] — a filled M3 button that does not elevate on press, plus
+//! its `tonal` variant.
+//!
+//! # Flutter parity
+//!
+//! `material/filled_button.dart`'s `FilledButton` (oracle tag `3.44.0`).
+//! `default_style` ports `_FilledButtonDefaultsM3`/`_FilledTonalButtonDefaultsM3`
+//! (`filled_button.dart` `:531-671` / `:672-810`) field-by-field, narrowed to
+//! the V1 slots [`ButtonStyle`] carries — see that module's docs. Ported:
+//! `text_style`, `background_color`, `foreground_color`, `overlay_color`,
+//! `elevation`, `padding`, `minimum_size`, `maximum_size`, `shape`. Neither
+//! table sets a default `side` or `fixed_size` (both oracle tables' own "No
+//! default fixedSize"/"No default side" comments), so neither field is
+//! populated here.
+
+use flui_types::geometry::px;
+use flui_types::{EdgeInsets, Size};
+use flui_view::prelude::*;
+use flui_widgets::{WidgetState, WidgetStateProperty};
+
+use crate::ThemeData;
+use crate::button_style::ButtonStyle;
+use crate::button_style_button::{ButtonStyleButtonCore, PressCallback};
+use crate::elevated_button::pressed_hovered_focused_overlay;
+use crate::shape::MaterialShape;
+use crate::theme::Theme;
+
+/// Which of the two `_TokenDefaultsM3` tables a [`FilledButton`] resolves
+/// against — see `default_style`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FilledButtonVariant {
+    /// `_FilledButtonDefaultsM3`: `primary`/`onPrimary` fill.
+    Filled,
+    /// `_FilledTonalButtonDefaultsM3`: `secondaryContainer`/
+    /// `onSecondaryContainer` fill. Flutter parity: `FilledButton.tonal`.
+    Tonal,
+}
+
+/// A filled Material 3 button that does not elevate on press. Use for
+/// important, final actions — see
+/// <https://m3.material.io/components/buttons/overview>. Construct the
+/// secondary "filled tonal" variant with [`FilledButton::tonal`].
+///
+/// ```rust
+/// use flui_material::FilledButton;
+/// use flui_widgets::Text;
+///
+/// let _filled = FilledButton::new(Text::new("Confirm")).on_pressed(|| {});
+/// let _tonal = FilledButton::tonal(Text::new("Confirm")).on_pressed(|| {});
+/// ```
+#[derive(Clone, StatelessView)]
+pub struct FilledButton {
+    on_pressed: Option<PressCallback>,
+    style: Option<ButtonStyle>,
+    variant: FilledButtonVariant,
+    child: BoxedView,
+}
+
+impl std::fmt::Debug for FilledButton {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FilledButton")
+            .field("enabled", &self.on_pressed.is_some())
+            .field("style", &self.style)
+            .field("variant", &self.variant)
+            .finish_non_exhaustive()
+    }
+}
+
+impl FilledButton {
+    /// A filled `FilledButton` around `child` with no press handler
+    /// (disabled) and no style override.
+    pub fn new(child: impl IntoView) -> Self {
+        Self {
+            on_pressed: None,
+            style: None,
+            variant: FilledButtonVariant::Filled,
+            child: BoxedView(Box::new(child.into_view())),
+        }
+    }
+
+    /// The "filled tonal" variant: `secondaryContainer`/`onSecondaryContainer`
+    /// in place of `primary`/`onPrimary`. Flutter parity: `FilledButton.tonal`.
+    pub fn tonal(child: impl IntoView) -> Self {
+        Self {
+            variant: FilledButtonVariant::Tonal,
+            ..Self::new(child)
+        }
+    }
+
+    /// Sets the press handler. Presence of a handler is what makes this
+    /// button enabled.
+    #[must_use]
+    pub fn on_pressed(mut self, callback: impl Fn() + 'static) -> Self {
+        self.on_pressed = Some(std::rc::Rc::new(callback));
+        self
+    }
+
+    /// Overrides the default style, per property (unset properties keep
+    /// falling through to the default).
+    #[must_use]
+    pub fn style(mut self, style: ButtonStyle) -> Self {
+        self.style = Some(style);
+        self
+    }
+}
+
+impl StatelessView for FilledButton {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        let theme = Theme::of(ctx);
+        let mut core =
+            ButtonStyleButtonCore::new(default_style(&theme, self.variant), self.child.clone())
+                .style(self.style.clone().unwrap_or_default());
+        if let Some(on_pressed) = self.on_pressed.clone() {
+            core = core.on_pressed(on_pressed);
+        }
+        core
+    }
+}
+
+/// Verbatim, field-by-field port of `_FilledButtonDefaultsM3`
+/// (`variant: Filled`) / `_FilledTonalButtonDefaultsM3` (`variant: Tonal`)
+/// (`filled_button.dart`, oracle tag `3.44.0`), narrowed to the V1 slots —
+/// see the module docs.
+fn default_style(theme: &ThemeData, variant: FilledButtonVariant) -> ButtonStyle {
+    let colors = theme.color_scheme;
+    let (background, foreground) = match variant {
+        FilledButtonVariant::Filled => (colors.primary, colors.on_primary),
+        FilledButtonVariant::Tonal => (colors.secondary_container, colors.on_secondary_container),
+    };
+
+    ButtonStyle {
+        text_style: Some(WidgetStateProperty::all(
+            theme.text_theme.label_large.clone(),
+        )),
+        background_color: Some(WidgetStateProperty::resolve_with(move |states| {
+            Some(if states.contains_state(WidgetState::Disabled) {
+                colors.on_surface.with_opacity(0.12)
+            } else {
+                background
+            })
+        })),
+        foreground_color: Some(WidgetStateProperty::resolve_with(move |states| {
+            Some(if states.contains_state(WidgetState::Disabled) {
+                colors.on_surface.with_opacity(0.38)
+            } else {
+                foreground
+            })
+        })),
+        overlay_color: Some(WidgetStateProperty::resolve_with(move |states| {
+            pressed_hovered_focused_overlay(states, foreground)
+        })),
+        elevation: Some(WidgetStateProperty::resolve_with(move |states| {
+            Some(
+                if !states.contains_state(WidgetState::Disabled)
+                    && states.contains_state(WidgetState::Hovered)
+                {
+                    1.0
+                } else {
+                    0.0
+                },
+            )
+        })),
+        padding: Some(WidgetStateProperty::all(Some(scaled_padding_1x()))),
+        minimum_size: Some(WidgetStateProperty::all(Some(Size::new(
+            px(64.0),
+            px(40.0),
+        )))),
+        fixed_size: None,
+        maximum_size: Some(WidgetStateProperty::all(Some(Size::INFINITY))),
+        side: None,
+        shape: Some(WidgetStateProperty::all(Some(MaterialShape::Stadium))),
+    }
+}
+
+/// `24px` horizontal, `0px` vertical — same 1x-tier padding as
+/// [`crate::elevated_button`] (both oracle tables call the identical
+/// `_scaledPadding` shape with `padding1x = 24.0`). See that module's docs
+/// for the `MediaQuery` text-scaler deferral this narrows to the 1x tier.
+fn scaled_padding_1x() -> EdgeInsets {
+    EdgeInsets::symmetric(px(0.0), px(24.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use flui_widgets::{WidgetState, WidgetStates};
+
+    use super::*;
+
+    fn resolve<T: Clone + Default>(
+        property: Option<&WidgetStateProperty<Option<T>>>,
+        states: &WidgetStates,
+    ) -> Option<T> {
+        property.and_then(|p| p.resolve(states))
+    }
+
+    /// Oracle citation: `_FilledButtonDefaultsM3` (`filled_button.dart`, tag
+    /// `3.44.0`). Default/hovered/pressed/disabled state matrix.
+    #[test]
+    fn filled_default_style_matches_filled_button_defaults_m3_state_matrix() {
+        let theme = ThemeData::light();
+        let colors = theme.color_scheme;
+        let style = default_style(&theme, FilledButtonVariant::Filled);
+
+        let none = WidgetStates::NONE;
+        let hovered = WidgetStates::from(WidgetState::Hovered);
+        let pressed = WidgetStates::from(WidgetState::Pressed);
+        let disabled = WidgetStates::from(WidgetState::Disabled);
+
+        assert_eq!(
+            resolve(style.background_color.as_ref(), &none),
+            Some(colors.primary)
+        );
+        assert_eq!(
+            resolve(style.background_color.as_ref(), &disabled),
+            Some(colors.on_surface.with_opacity(0.12))
+        );
+        assert_eq!(
+            resolve(style.foreground_color.as_ref(), &none),
+            Some(colors.on_primary)
+        );
+        assert_eq!(
+            resolve(style.foreground_color.as_ref(), &disabled),
+            Some(colors.on_surface.with_opacity(0.38))
+        );
+        assert_eq!(resolve(style.overlay_color.as_ref(), &none), None);
+        assert_eq!(
+            resolve(style.overlay_color.as_ref(), &pressed),
+            Some(colors.on_primary.with_opacity(0.1))
+        );
+        assert_eq!(resolve(style.elevation.as_ref(), &none), Some(0.0));
+        assert_eq!(resolve(style.elevation.as_ref(), &hovered), Some(1.0));
+        assert_eq!(resolve(style.elevation.as_ref(), &pressed), Some(0.0));
+        assert_eq!(resolve(style.elevation.as_ref(), &disabled), Some(0.0));
+    }
+
+    /// A disabled-but-hovered state must not resolve the hover elevation —
+    /// `disabled` is checked first in the oracle's own conditional chain.
+    #[test]
+    fn filled_elevation_disabled_wins_over_hovered() {
+        let theme = ThemeData::light();
+        let style = default_style(&theme, FilledButtonVariant::Filled);
+        let disabled_and_hovered =
+            WidgetStates::from(WidgetState::Disabled).with_state(WidgetState::Hovered);
+        assert_eq!(
+            resolve(style.elevation.as_ref(), &disabled_and_hovered),
+            Some(0.0)
+        );
+    }
+
+    /// Oracle citation: `_FilledTonalButtonDefaultsM3` (`filled_button.dart`,
+    /// tag `3.44.0`). Default/pressed/disabled state matrix.
+    #[test]
+    fn tonal_default_style_matches_filled_tonal_button_defaults_m3_state_matrix() {
+        let theme = ThemeData::light();
+        let colors = theme.color_scheme;
+        let style = default_style(&theme, FilledButtonVariant::Tonal);
+
+        let none = WidgetStates::NONE;
+        let pressed = WidgetStates::from(WidgetState::Pressed);
+        let disabled = WidgetStates::from(WidgetState::Disabled);
+
+        assert_eq!(
+            resolve(style.background_color.as_ref(), &none),
+            Some(colors.secondary_container)
+        );
+        assert_eq!(
+            resolve(style.foreground_color.as_ref(), &none),
+            Some(colors.on_secondary_container)
+        );
+        assert_eq!(
+            resolve(style.background_color.as_ref(), &disabled),
+            Some(colors.on_surface.with_opacity(0.12))
+        );
+        assert_eq!(
+            resolve(style.overlay_color.as_ref(), &pressed),
+            Some(colors.on_secondary_container.with_opacity(0.1))
+        );
+    }
+
+    #[test]
+    fn tonal_constructor_selects_the_tonal_variant() {
+        let button = FilledButton::tonal(flui_widgets::SizedBox::shrink());
+        assert_eq!(button.variant, FilledButtonVariant::Tonal);
+    }
+
+    #[test]
+    fn new_constructor_selects_the_filled_variant() {
+        let button = FilledButton::new(flui_widgets::SizedBox::shrink());
+        assert_eq!(button.variant, FilledButtonVariant::Filled);
+    }
+
+    #[test]
+    fn both_variants_leave_fixed_size_and_side_unset() {
+        let theme = ThemeData::light();
+        for variant in [FilledButtonVariant::Filled, FilledButtonVariant::Tonal] {
+            let style = default_style(&theme, variant);
+            assert!(style.fixed_size.is_none());
+            assert!(style.side.is_none());
+        }
+    }
+}

--- a/crates/flui-material/src/lib.rs
+++ b/crates/flui-material/src/lib.rs
@@ -1,19 +1,26 @@
 //! # `flui_material`
 //!
 //! Material Design theming foundation for FLUI: [`ColorScheme`], the M3 2021
-//! type scale ([`typography`]) and [`TextTheme`], [`ThemeData`], and the
-//! [`Theme`] inherited widget that publishes it to a subtree.
+//! type scale ([`typography`]) and [`TextTheme`], [`ThemeData`], the
+//! [`Theme`] inherited widget that publishes it to a subtree, the
+//! [`Material`]/[`InkWell`] surface primitives, and the M3 button family
+//! ([`ButtonStyle`], [`ElevatedButton`], [`FilledButton`], [`OutlinedButton`],
+//! [`TextButton`]).
 //!
 //! ## Flutter parity
 //!
 //! `package:flutter/material.dart`'s theming surface — primarily
 //! `material/color_scheme.dart`, `material/typography.dart`,
-//! `material/text_theme.dart`, `material/theme_data.dart`, and
-//! `material/theme.dart` (oracle tag `3.44.0`). Every constant table
-//! (`ColorScheme::light`/`dark`, [`typography::english_like_2021`],
-//! [`TextTheme::black_mountain_view`]/[`white_mountain_view`](TextTheme::white_mountain_view))
-//! is a verbatim, per-value-cited port — see each module's docs for the exact
-//! oracle source.
+//! `material/text_theme.dart`, `material/theme_data.dart`,
+//! `material/theme.dart`, `material/material.dart`, `material/ink_well.dart`,
+//! `material/button_style.dart`, `material/button_style_button.dart`, and the
+//! four concrete button files (`elevated_button.dart`, `filled_button.dart`,
+//! `outlined_button.dart`, `text_button.dart`) (oracle tag `3.44.0`). Every
+//! constant table (`ColorScheme::light`/`dark`,
+//! [`typography::english_like_2021`],
+//! [`TextTheme::black_mountain_view`]/[`white_mountain_view`](TextTheme::white_mountain_view),
+//! each button's `_TokenDefaultsM3`) is a verbatim, per-value-cited port —
+//! see each module's docs for the exact oracle source.
 //!
 //! ## Scope (V1 — constants-first)
 //!
@@ -48,19 +55,30 @@
 
 #![deny(missing_docs)]
 
+pub mod button_style;
+mod button_style_button;
 pub mod color_scheme;
+pub mod elevated_button;
+pub mod filled_button;
 pub mod ink_well;
 pub mod material;
+pub mod outlined_button;
 pub mod shape;
+pub mod text_button;
 pub mod text_theme;
 pub mod theme;
 pub mod theme_data;
 pub mod typography;
 
+pub use button_style::ButtonStyle;
 pub use color_scheme::{ColorScheme, ColorSchemeOverrides};
+pub use elevated_button::ElevatedButton;
+pub use filled_button::FilledButton;
 pub use ink_well::{InkWell, InkWellState};
 pub use material::Material;
+pub use outlined_button::OutlinedButton;
 pub use shape::MaterialShape;
+pub use text_button::TextButton;
 pub use text_theme::TextTheme;
 pub use theme::Theme;
 pub use theme_data::{ThemeData, ThemeDataOverrides};

--- a/crates/flui-material/src/outlined_button.rs
+++ b/crates/flui-material/src/outlined_button.rs
@@ -1,0 +1,231 @@
+//! [`OutlinedButton`] — an M3 button with an outlined border and no fill.
+//!
+//! # Flutter parity
+//!
+//! `material/outlined_button.dart`'s `OutlinedButton` (oracle tag `3.44.0`).
+//! `default_style` ports `_OutlinedButtonDefaultsM3` (`outlined_button.dart`
+//! `:460-575`) field-by-field, narrowed to the V1 slots [`ButtonStyle`]
+//! carries — see that module's docs. Ported: `text_style`, `background_color`
+//! (constant transparent), `foreground_color`, `overlay_color`, `elevation`
+//! (constant `0.0`), `padding`, `minimum_size`, `maximum_size`, `side`,
+//! `shape`. The oracle table sets no default `fixed_size` (its own "No
+//! default fixedSize" comment), so that field is left unset here.
+//!
+//! `side` is this button's whole reason to exist, and it resolves correctly
+//! (disabled `onSurface@12%`, focused `primary`, else `outline`, all at the
+//! oracle's default `1.0` stroke width) — but see
+//! [`ButtonStyle::side`](crate::ButtonStyle::side)'s doc comment: `Material`
+//! has no border-side painting path yet, so this V1 `OutlinedButton` does
+//! not yet draw a visible outline. A pre-existing deferral (`shape.rs`), not
+//! one introduced here.
+
+use flui_types::geometry::px;
+use flui_types::styling::{BorderSide, BorderStyle};
+use flui_types::{EdgeInsets, Size};
+use flui_view::prelude::*;
+use flui_widgets::{WidgetState, WidgetStateProperty};
+
+use crate::ThemeData;
+use crate::button_style::ButtonStyle;
+use crate::button_style_button::{ButtonStyleButtonCore, PressCallback};
+use crate::elevated_button::pressed_hovered_focused_overlay;
+use crate::shape::MaterialShape;
+use crate::theme::Theme;
+
+/// An outlined Material 3 button: no fill, a `primary`/`outline` stroke.
+/// Use for medium-emphasis actions — see
+/// <https://m3.material.io/components/buttons/overview>.
+///
+/// ```rust
+/// use flui_material::OutlinedButton;
+/// use flui_widgets::Text;
+///
+/// let _button = OutlinedButton::new(Text::new("Cancel")).on_pressed(|| {});
+/// ```
+#[derive(Clone, StatelessView)]
+pub struct OutlinedButton {
+    on_pressed: Option<PressCallback>,
+    style: Option<ButtonStyle>,
+    child: BoxedView,
+}
+
+impl std::fmt::Debug for OutlinedButton {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OutlinedButton")
+            .field("enabled", &self.on_pressed.is_some())
+            .field("style", &self.style)
+            .finish_non_exhaustive()
+    }
+}
+
+impl OutlinedButton {
+    /// An `OutlinedButton` around `child` with no press handler (disabled)
+    /// and no style override.
+    pub fn new(child: impl IntoView) -> Self {
+        Self {
+            on_pressed: None,
+            style: None,
+            child: BoxedView(Box::new(child.into_view())),
+        }
+    }
+
+    /// Sets the press handler. Presence of a handler is what makes this
+    /// button enabled.
+    #[must_use]
+    pub fn on_pressed(mut self, callback: impl Fn() + 'static) -> Self {
+        self.on_pressed = Some(std::rc::Rc::new(callback));
+        self
+    }
+
+    /// Overrides the default style, per property (unset properties keep
+    /// falling through to the default).
+    #[must_use]
+    pub fn style(mut self, style: ButtonStyle) -> Self {
+        self.style = Some(style);
+        self
+    }
+}
+
+impl StatelessView for OutlinedButton {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        let theme = Theme::of(ctx);
+        let mut core = ButtonStyleButtonCore::new(default_style(&theme), self.child.clone())
+            .style(self.style.clone().unwrap_or_default());
+        if let Some(on_pressed) = self.on_pressed.clone() {
+            core = core.on_pressed(on_pressed);
+        }
+        core
+    }
+}
+
+/// Verbatim, field-by-field port of `_OutlinedButtonDefaultsM3`
+/// (`outlined_button.dart`, oracle tag `3.44.0`), narrowed to the V1 slots —
+/// see the module docs.
+fn default_style(theme: &ThemeData) -> ButtonStyle {
+    let colors = theme.color_scheme;
+
+    ButtonStyle {
+        text_style: Some(WidgetStateProperty::all(
+            theme.text_theme.label_large.clone(),
+        )),
+        background_color: Some(WidgetStateProperty::all(Some(
+            flui_types::Color::TRANSPARENT,
+        ))),
+        foreground_color: Some(WidgetStateProperty::resolve_with(move |states| {
+            Some(if states.contains_state(WidgetState::Disabled) {
+                colors.on_surface.with_opacity(0.38)
+            } else {
+                colors.primary
+            })
+        })),
+        overlay_color: Some(WidgetStateProperty::resolve_with(move |states| {
+            pressed_hovered_focused_overlay(states, colors.primary)
+        })),
+        elevation: Some(WidgetStateProperty::all(Some(0.0))),
+        padding: Some(WidgetStateProperty::all(Some(scaled_padding_1x()))),
+        minimum_size: Some(WidgetStateProperty::all(Some(Size::new(
+            px(64.0),
+            px(40.0),
+        )))),
+        fixed_size: None,
+        maximum_size: Some(WidgetStateProperty::all(Some(Size::INFINITY))),
+        side: Some(WidgetStateProperty::resolve_with(move |states| {
+            let color = if states.contains_state(WidgetState::Disabled) {
+                colors.on_surface.with_opacity(0.12)
+            } else if states.contains_state(WidgetState::Focused) {
+                colors.primary
+            } else {
+                colors.outline
+            };
+            Some(BorderSide::new(color, px(1.0), BorderStyle::Solid))
+        })),
+        shape: Some(WidgetStateProperty::all(Some(MaterialShape::Stadium))),
+    }
+}
+
+/// `24px` horizontal, `0px` vertical — same 1x-tier padding as
+/// [`crate::elevated_button`]. See that module's docs for the `MediaQuery`
+/// text-scaler deferral this narrows to the 1x tier.
+fn scaled_padding_1x() -> EdgeInsets {
+    EdgeInsets::symmetric(px(0.0), px(24.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use flui_widgets::{WidgetState, WidgetStates};
+
+    use super::*;
+
+    fn resolve<T: Clone + Default>(
+        property: Option<&WidgetStateProperty<Option<T>>>,
+        states: &WidgetStates,
+    ) -> Option<T> {
+        property.and_then(|p| p.resolve(states))
+    }
+
+    /// Oracle citation: `_OutlinedButtonDefaultsM3` (`outlined_button.dart`,
+    /// tag `3.44.0`). Default/hovered/pressed/disabled state matrix.
+    #[test]
+    fn default_style_matches_outlined_button_defaults_m3_state_matrix() {
+        let theme = ThemeData::light();
+        let colors = theme.color_scheme;
+        let style = default_style(&theme);
+
+        let none = WidgetStates::NONE;
+        let hovered = WidgetStates::from(WidgetState::Hovered);
+        let pressed = WidgetStates::from(WidgetState::Pressed);
+        let disabled = WidgetStates::from(WidgetState::Disabled);
+
+        assert_eq!(
+            resolve(style.background_color.as_ref(), &none),
+            Some(flui_types::Color::TRANSPARENT)
+        );
+        assert_eq!(
+            resolve(style.foreground_color.as_ref(), &none),
+            Some(colors.primary)
+        );
+        assert_eq!(
+            resolve(style.foreground_color.as_ref(), &disabled),
+            Some(colors.on_surface.with_opacity(0.38))
+        );
+        assert_eq!(resolve(style.overlay_color.as_ref(), &none), None);
+        assert_eq!(
+            resolve(style.overlay_color.as_ref(), &pressed),
+            Some(colors.primary.with_opacity(0.1))
+        );
+        assert_eq!(
+            resolve(style.overlay_color.as_ref(), &hovered),
+            Some(colors.primary.with_opacity(0.08))
+        );
+        assert_eq!(resolve(style.elevation.as_ref(), &none), Some(0.0));
+        assert_eq!(resolve(style.elevation.as_ref(), &pressed), Some(0.0));
+    }
+
+    /// The whole point of this button: `side` resolves the disabled/focused/
+    /// default outline colors at the oracle's default `1.0` stroke width.
+    #[test]
+    fn default_style_side_resolves_disabled_focused_and_default_outline_colors() {
+        let theme = ThemeData::light();
+        let colors = theme.color_scheme;
+        let style = default_style(&theme);
+
+        let none = WidgetStates::NONE;
+        let focused = WidgetStates::from(WidgetState::Focused);
+        let disabled = WidgetStates::from(WidgetState::Disabled);
+
+        let default_side = resolve(style.side.as_ref(), &none).expect("default side is set");
+        assert_eq!(default_side.color, colors.outline);
+        assert_eq!(default_side.width, px(1.0));
+
+        let focused_side = resolve(style.side.as_ref(), &focused).expect("focused side is set");
+        assert_eq!(focused_side.color, colors.primary);
+
+        let disabled_side = resolve(style.side.as_ref(), &disabled).expect("disabled side is set");
+        assert_eq!(disabled_side.color, colors.on_surface.with_opacity(0.12));
+    }
+
+    #[test]
+    fn default_style_leaves_fixed_size_unset() {
+        assert!(default_style(&ThemeData::light()).fixed_size.is_none());
+    }
+}

--- a/crates/flui-material/src/text_button.rs
+++ b/crates/flui-material/src/text_button.rs
@@ -1,0 +1,211 @@
+//! [`TextButton`] — an M3 button with no outline or fill, the lowest-emphasis
+//! member of the button family.
+//!
+//! # Flutter parity
+//!
+//! `material/text_button.dart`'s `TextButton` (oracle tag `3.44.0`).
+//! `default_style` ports `_TextButtonDefaultsM3` (`text_button.dart`
+//! `:493-596`) field-by-field, narrowed to the V1 slots [`ButtonStyle`]
+//! carries — see that module's docs. Ported: `text_style`, `background_color`
+//! (constant transparent), `foreground_color`, `overlay_color`, `elevation`
+//! (constant `0.0`), `padding`, `minimum_size`, `maximum_size`, `shape`. The
+//! oracle table sets no default `side` or `fixed_size` (its own "No default
+//! fixedSize"/"No default side" comments), so neither field is populated
+//! here.
+//!
+//! `padding` is the one slot that differs in *shape*, not just color, from
+//! its siblings: `_scaledPadding` in `text_button.dart` uses `12px`
+//! horizontal / `8px` vertical at the M3 1x tier, versus `24px`/`0px` for
+//! `ElevatedButton`/`FilledButton`/`OutlinedButton` — text buttons ship
+//! tighter by design (no fill or outline to visually separate from
+//! surrounding content).
+
+use flui_types::geometry::px;
+use flui_types::{Color, EdgeInsets, Size};
+use flui_view::prelude::*;
+use flui_widgets::{WidgetState, WidgetStateProperty};
+
+use crate::ThemeData;
+use crate::button_style::ButtonStyle;
+use crate::button_style_button::{ButtonStyleButtonCore, PressCallback};
+use crate::elevated_button::pressed_hovered_focused_overlay;
+use crate::shape::MaterialShape;
+use crate::theme::Theme;
+
+/// A Material 3 button with no outline or fill. Use for the
+/// lowest-emphasis actions, e.g. a dialog's dismissive action — see
+/// <https://m3.material.io/components/buttons/overview>.
+///
+/// ```rust
+/// use flui_material::TextButton;
+/// use flui_widgets::Text;
+///
+/// let _button = TextButton::new(Text::new("Learn more")).on_pressed(|| {});
+/// ```
+#[derive(Clone, StatelessView)]
+pub struct TextButton {
+    on_pressed: Option<PressCallback>,
+    style: Option<ButtonStyle>,
+    child: BoxedView,
+}
+
+impl std::fmt::Debug for TextButton {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TextButton")
+            .field("enabled", &self.on_pressed.is_some())
+            .field("style", &self.style)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TextButton {
+    /// A `TextButton` around `child` with no press handler (disabled) and no
+    /// style override.
+    pub fn new(child: impl IntoView) -> Self {
+        Self {
+            on_pressed: None,
+            style: None,
+            child: BoxedView(Box::new(child.into_view())),
+        }
+    }
+
+    /// Sets the press handler. Presence of a handler is what makes this
+    /// button enabled.
+    #[must_use]
+    pub fn on_pressed(mut self, callback: impl Fn() + 'static) -> Self {
+        self.on_pressed = Some(std::rc::Rc::new(callback));
+        self
+    }
+
+    /// Overrides the default style, per property (unset properties keep
+    /// falling through to the default).
+    #[must_use]
+    pub fn style(mut self, style: ButtonStyle) -> Self {
+        self.style = Some(style);
+        self
+    }
+}
+
+impl StatelessView for TextButton {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        let theme = Theme::of(ctx);
+        let mut core = ButtonStyleButtonCore::new(default_style(&theme), self.child.clone())
+            .style(self.style.clone().unwrap_or_default());
+        if let Some(on_pressed) = self.on_pressed.clone() {
+            core = core.on_pressed(on_pressed);
+        }
+        core
+    }
+}
+
+/// Verbatim, field-by-field port of `_TextButtonDefaultsM3`
+/// (`text_button.dart`, oracle tag `3.44.0`), narrowed to the V1 slots — see
+/// the module docs.
+fn default_style(theme: &ThemeData) -> ButtonStyle {
+    let colors = theme.color_scheme;
+
+    ButtonStyle {
+        text_style: Some(WidgetStateProperty::all(
+            theme.text_theme.label_large.clone(),
+        )),
+        background_color: Some(WidgetStateProperty::all(Some(Color::TRANSPARENT))),
+        foreground_color: Some(WidgetStateProperty::resolve_with(move |states| {
+            Some(if states.contains_state(WidgetState::Disabled) {
+                colors.on_surface.with_opacity(0.38)
+            } else {
+                colors.primary
+            })
+        })),
+        overlay_color: Some(WidgetStateProperty::resolve_with(move |states| {
+            pressed_hovered_focused_overlay(states, colors.primary)
+        })),
+        elevation: Some(WidgetStateProperty::all(Some(0.0))),
+        padding: Some(WidgetStateProperty::all(Some(scaled_padding_1x()))),
+        minimum_size: Some(WidgetStateProperty::all(Some(Size::new(
+            px(64.0),
+            px(40.0),
+        )))),
+        fixed_size: None,
+        maximum_size: Some(WidgetStateProperty::all(Some(Size::INFINITY))),
+        side: None,
+        shape: Some(WidgetStateProperty::all(Some(MaterialShape::Stadium))),
+    }
+}
+
+/// `12px` horizontal, `8px` vertical — the M3 1x tier of `TextButton`'s own
+/// `_scaledPadding` (`text_button.dart`, oracle tag `3.44.0`), tighter than
+/// the `24px`/`0px` its filled/outlined siblings use. See
+/// `crate::elevated_button`'s docs for the shared `MediaQuery` text-scaler
+/// deferral this narrows to the 1x tier.
+fn scaled_padding_1x() -> EdgeInsets {
+    EdgeInsets::symmetric(px(8.0), px(12.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use flui_widgets::{WidgetState, WidgetStates};
+
+    use super::*;
+
+    fn resolve<T: Clone + Default>(
+        property: Option<&WidgetStateProperty<Option<T>>>,
+        states: &WidgetStates,
+    ) -> Option<T> {
+        property.and_then(|p| p.resolve(states))
+    }
+
+    /// Oracle citation: `_TextButtonDefaultsM3` (`text_button.dart`, tag
+    /// `3.44.0`). Default/hovered/pressed/disabled state matrix.
+    #[test]
+    fn default_style_matches_text_button_defaults_m3_state_matrix() {
+        let theme = ThemeData::light();
+        let colors = theme.color_scheme;
+        let style = default_style(&theme);
+
+        let none = WidgetStates::NONE;
+        let hovered = WidgetStates::from(WidgetState::Hovered);
+        let pressed = WidgetStates::from(WidgetState::Pressed);
+        let disabled = WidgetStates::from(WidgetState::Disabled);
+
+        assert_eq!(
+            resolve(style.background_color.as_ref(), &none),
+            Some(Color::TRANSPARENT)
+        );
+        assert_eq!(
+            resolve(style.foreground_color.as_ref(), &none),
+            Some(colors.primary)
+        );
+        assert_eq!(
+            resolve(style.foreground_color.as_ref(), &disabled),
+            Some(colors.on_surface.with_opacity(0.38))
+        );
+        assert_eq!(resolve(style.overlay_color.as_ref(), &none), None);
+        assert_eq!(
+            resolve(style.overlay_color.as_ref(), &pressed),
+            Some(colors.primary.with_opacity(0.1))
+        );
+        assert_eq!(
+            resolve(style.overlay_color.as_ref(), &hovered),
+            Some(colors.primary.with_opacity(0.08))
+        );
+        assert_eq!(resolve(style.elevation.as_ref(), &none), Some(0.0));
+        assert_eq!(resolve(style.elevation.as_ref(), &disabled), Some(0.0));
+    }
+
+    #[test]
+    fn default_style_padding_is_tighter_than_the_filled_siblings() {
+        let padding = resolve(
+            default_style(&ThemeData::light()).padding.as_ref(),
+            &WidgetStates::NONE,
+        )
+        .expect("padding is set");
+        assert_eq!(padding, EdgeInsets::symmetric(px(8.0), px(12.0)));
+    }
+
+    #[test]
+    fn default_style_leaves_fixed_size_and_side_unset() {
+        let style = default_style(&ThemeData::light());
+        assert!(style.fixed_size.is_none());
+        assert!(style.side.is_none());
+    }
+}

--- a/crates/flui-material/tests/common/mod.rs
+++ b/crates/flui-material/tests/common/mod.rs
@@ -244,6 +244,21 @@ impl LaidOut {
             ),
         }
     }
+
+    /// The string value of a mounted render node's named
+    /// [`Diagnosticable`](flui_foundation::Diagnosticable) property (e.g.
+    /// `"color"` on a `RenderPhysicalShape`) — lets a test assert on a
+    /// resolved value (a `WidgetStateProperty` resolution reaching all the
+    /// way to paint configuration) without downcasting to the concrete
+    /// render-object type, which this harness has no generic support for.
+    /// Returns `None` if `id` is not live or carries no such property.
+    pub fn render_property(&self, id: RenderId, property_name: &str) -> Option<String> {
+        let owner = self.pipeline_owner.read();
+        let diagnostics = owner.debug_node_diagnostics(id)?;
+        diagnostics
+            .find_property(property_name)
+            .map(|property| property.value().to_string())
+    }
 }
 
 /// Strips generic parameters (`Foo<Bar>` → `Foo`) so a diagnostics name

--- a/crates/flui-material/tests/elevated_button.rs
+++ b/crates/flui-material/tests/elevated_button.rs
@@ -23,6 +23,16 @@ use common::{lay_out, tight};
 use flui_material::{ElevatedButton, Theme, ThemeData};
 use flui_widgets::Text;
 
+/// `_ElevatedButtonDefaultsM3`'s formatted `Debug` string for a given
+/// resolved [`Color`](flui_types::Color) — what `RenderPhysicalShape`'s
+/// `Diagnosticable::debug_fill_properties` writes into its `"color"`
+/// property (`add_color("color", format!("{:?}", self.color))`,
+/// `crates/flui-objects/src/proxy/physical_model.rs`), so a test can compare
+/// against it without downcasting the render object.
+fn color_property(color: flui_types::Color) -> String {
+    format!("{color:?}")
+}
+
 #[test]
 fn tap_fires_on_pressed_and_the_button_mounts_a_material_surface() {
     let taps = Arc::new(AtomicUsize::new(0));
@@ -81,5 +91,95 @@ fn a_button_with_no_press_handler_is_disabled_and_a_tap_dispatch_is_a_no_op() {
         material_before, material_after,
         "the disabled button's render tree must not be torn down or rebuilt \
          under a tap dispatch it does not react to",
+    );
+}
+
+/// Mutation-honest coverage for `ButtonStyleButtonCoreState::init_state`'s
+/// `WidgetState::Disabled` sync (`crates/flui-material/src/button_style_button.rs`)
+/// — driven through the REAL `create_state`/`init_state` lifecycle of a
+/// mounted `ElevatedButton`, not a hand-constructed `WidgetStates` value.
+/// Deleting that sync line leaves every unit test in `elevated_button.rs`
+/// green (they all resolve against a states value they construct
+/// themselves), because `_ElevatedButtonDefaultsM3`'s `background_color`
+/// closure only produces a DIFFERENT color for `WidgetState::Disabled` —
+/// only an end-to-end mount, whose `states.value()` is fed by the real
+/// lifecycle hook, can tell whether that bit actually got set.
+#[test]
+fn a_handler_less_button_resolves_the_disabled_background_color_through_the_real_lifecycle() {
+    let theme = ThemeData::light();
+    let colors = theme.color_scheme;
+    let laid = lay_out(
+        Theme::new(theme, ElevatedButton::new(Text::new("Save"))),
+        tight(120.0, 48.0),
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("a disabled ElevatedButton must still mount its Material surface");
+    let resolved_color = laid
+        .render_property(material, "color")
+        .expect("RenderPhysicalShape reports a \"color\" diagnostics property");
+
+    assert_eq!(
+        resolved_color,
+        color_property(colors.on_surface.with_opacity(0.12)),
+        "a button with no on_pressed handler must resolve _ElevatedButtonDefaultsM3's disabled \
+         background color (onSurface@12%) — which only happens if init_state actually set \
+         WidgetState::Disabled before the first build; without that sync this resolves to the \
+         enabled default (surfaceContainerLow) instead",
+    );
+}
+
+/// Companion coverage for `did_update_view`'s re-sync branch: an ENABLED
+/// button (real `on_pressed`) resolves the enabled background first, then a
+/// root swap to a handler-less `ElevatedButton` (same element identity,
+/// `did_update_view` fires, not `init_state` again) must re-resolve the
+/// disabled background. Mutation-honest the same way as the test above:
+/// deleting `did_update_view`'s `WidgetState::Disabled` re-sync leaves the
+/// enabled color stuck after the swap.
+#[test]
+fn did_update_view_resyncs_disabled_when_the_press_handler_is_removed() {
+    let theme = ThemeData::light();
+    let colors = theme.color_scheme;
+    let mut laid = lay_out(
+        Theme::new(
+            theme.clone(),
+            ElevatedButton::new(Text::new("Save")).on_pressed(|| {}),
+        ),
+        tight(120.0, 48.0),
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("Material must mount");
+    let enabled_color = laid
+        .render_property(material, "color")
+        .expect("RenderPhysicalShape reports a \"color\" diagnostics property");
+    assert_eq!(
+        enabled_color,
+        color_property(colors.surface_container_low),
+        "an enabled button must resolve _ElevatedButtonDefaultsM3's enabled background color",
+    );
+
+    // Root swap to the SAME widget shape minus `.on_pressed(..)`:
+    // reconciliation keeps element/render identity, so this exercises
+    // `did_update_view`, not a fresh `init_state`.
+    laid.pump_widget(Theme::new(theme, ElevatedButton::new(Text::new("Save"))));
+
+    let material_after_swap = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("Material must still be mounted after the swap");
+    assert_eq!(
+        material, material_after_swap,
+        "the swap must reconcile onto the same render node (did_update_view), not remount",
+    );
+    let disabled_color = laid
+        .render_property(material_after_swap, "color")
+        .expect("RenderPhysicalShape reports a \"color\" diagnostics property");
+    assert_eq!(
+        disabled_color,
+        color_property(colors.on_surface.with_opacity(0.12)),
+        "removing the press handler must re-sync WidgetState::Disabled via did_update_view, \
+         re-resolving the disabled background color",
     );
 }

--- a/crates/flui-material/tests/elevated_button.rs
+++ b/crates/flui-material/tests/elevated_button.rs
@@ -1,0 +1,85 @@
+//! `ElevatedButton` widget-level integration coverage — mounts a real button
+//! through the full render pipeline (`tests/common/mod.rs`, matching
+//! `tests/ink_well.rs`/`tests/material.rs`'s established pattern) and drives
+//! real pointer dispatch. Hit-testing runs inside `enter_owner_scope` (see
+//! `common::LaidOut::route_event`'s doc comment) since `Material`'s clip
+//! resolves through the owner-lane path-clipper registry — mounting without
+//! it would silently degrade to the whole-box fallback clip instead of
+//! erroring, which is exactly the trap that module's doc comment warns
+//! about.
+//!
+//! `ElevatedButton` stands in for the whole `ButtonStyleButtonCore`
+//! composition here; `FilledButton`/`OutlinedButton`/`TextButton` share the
+//! identical composition path (only their `default_style` tables differ,
+//! covered by each file's own unit tests), so one button's worth of
+//! integration coverage is enough to prove the wiring, not four.
+
+mod common;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use common::{lay_out, tight};
+use flui_material::{ElevatedButton, Theme, ThemeData};
+use flui_widgets::Text;
+
+#[test]
+fn tap_fires_on_pressed_and_the_button_mounts_a_material_surface() {
+    let taps = Arc::new(AtomicUsize::new(0));
+    let counted = Arc::clone(&taps);
+    let laid = lay_out(
+        Theme::new(
+            ThemeData::light(),
+            ElevatedButton::new(Text::new("Save")).on_pressed(move || {
+                counted.fetch_add(1, Ordering::SeqCst);
+            }),
+        ),
+        tight(120.0, 48.0),
+    );
+
+    assert!(
+        laid.find_by_render_type("RenderPhysicalShape").is_some(),
+        "ElevatedButton must compose a Material (RenderPhysicalShape) surface",
+    );
+
+    laid.dispatch_pointer_down(60.0, 24.0);
+    laid.dispatch_pointer_up(60.0, 24.0);
+
+    assert_eq!(
+        taps.load(Ordering::SeqCst),
+        1,
+        "a down+up on an enabled ElevatedButton must fire on_pressed exactly once",
+    );
+}
+
+#[test]
+fn a_button_with_no_press_handler_is_disabled_and_a_tap_dispatch_is_a_no_op() {
+    // No `.on_pressed(..)`: `ButtonStyleButtonCore::is_interactive` is
+    // false, so the inner `InkWell` never gets an `on_tap` closure at all
+    // (unit-tested directly at the construction level by
+    // `elevated_button::tests::is_disabled_when_no_press_handler_is_set`).
+    // What only an end-to-end mount can prove: a real pointer down+up
+    // dispatched at a disabled button's composed
+    // ConstrainedBox/Material/InkWell/Padding stack does not panic and
+    // leaves the composition mounted — a regression guard against any of
+    // those four layers assuming an `on_tap` closure is always present.
+    let laid = lay_out(
+        Theme::new(ThemeData::light(), ElevatedButton::new(Text::new("Save"))),
+        tight(120.0, 48.0),
+    );
+    let material_before = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("a disabled ElevatedButton must still mount its Material surface");
+
+    laid.dispatch_pointer_down(60.0, 24.0);
+    laid.dispatch_pointer_up(60.0, 24.0);
+
+    let material_after = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("the Material surface must survive a tap dispatch");
+    assert_eq!(
+        material_before, material_after,
+        "the disabled button's render tree must not be torn down or rebuilt \
+         under a tap dispatch it does not react to",
+    );
+}


### PR DESCRIPTION
## Summary

Second half of the Material button family (Catalog.1), on top of the #371 substrate. Ported from Flutter 3.44.0 `material/{button_style,button_style_button,elevated_button,filled_button,outlined_button,text_button}.dart`.

- **`ButtonStyle`** — property bag with `Option<WidgetStateProperty<Option<V>>>` slots (background/foreground/overlay color, elevation, padding, min/fixed/max size, side, shape, text_style); FRU-constructed value struct (no `#[non_exhaustive]`, ThemeDataOverrides precedent documented). Named omissions: mouse_cursor/VisualDensity (no FLUI types yet), `.icon()` ctors, animation_duration/splash_factory (no ripple), `ButtonStyle::lerp` (AnimatedTheme unit).
- **`ButtonStyleButtonCore`** (private) — the per-property widget→theme→default resolve-then-coalesce cascade (theme tier is a live seam returning `None` until component themes land); owns a shared `WidgetStatesController` (sync-before-listen `init_state`/`did_update_view` parity); composes ConstrainedBox → Material → InkWell → Padding → DefaultTextStyle (whole padded area tappable — oracle nesting equivalence verified in review). `fixed_size` is constrained into the min/max envelope **before** pinning (oracle `effectiveConstraints.constrain` — min>max inversion impossible, infinite axes skip pinning).
- **Four buttons + `FilledButton::tonal`** — each `_TokenDefaultsM3` table ported field-by-field (colors incl. disabled onSurface 12%/38%, overlay 10/8/10 **pressed-first**, elevation state chains with **branch order preserved** — review caught filled/tonal collapsing the ordered chain so a pressed+hovered mouse click raised elevation instead of holding flat; all five tables now carry combined-state assertions). Only the 1× `_scaledPadding` tier ported (text-scaler deferral named). `OutlinedButton::side` resolves but isn't painted yet (Material has no border-side path — pre-existing named deferral).

### Tests
107 in-crate (35 new this PR): per-table resolved-style matrices against the oracle classes, style precedence (mutation-honest), pressed-first ordering, combined pressed+hovered pins on every ordered chain, fixed_size envelope (5 cases), through-the-lifecycle disabled resolution (kills the mutation that unit-level tests missed), controller re-sync on enabled↔disabled via same-element reconciliation, tap-fires-callback integration.

### Review trail
Settled design from #371's architect+critic → build → full review (2 parity bugs: elevation branch-order collapse, unclamped fixed_size; 1 mutation survivor) → fix pass → delta re-review: COMPLETE, 4/4 targeted mutations killed.

### Gates
Workspace nextest 6632 passed / 4 skipped · workspace clippy `-D warnings` clean · doc gate clean · port-check/inventory/fmt/taplo/typos clean · doctests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvkSGveJwxLVuygRAGVKuz