### PR TITLE
feat(material): component themes — ThemeData slots for buttons, AppBar, Card, Dialog, FAB

### DIFF
--- a/crates/flui-material/src/app_bar.rs
+++ b/crates/flui-material/src/app_bar.rs
@@ -264,7 +264,7 @@ impl std::fmt::Debug for AppBar {
     }
 }
 
-/// [`AppBar`]'s theme-resolved colors and title style — `_AppBarDefaultsM3`
+/// [`AppBar`]'s theme-resolved colors and text styles — `_AppBarDefaultsM3`
 /// (`app_bar.dart:2521-2570`, oracle tag `3.44.0`) applied to the caller's
 /// overrides, then coalesced. Factored out of [`AppBar::build`] so the
 /// resolution itself (a pure function of a [`ThemeData`] and the three
@@ -274,6 +274,27 @@ struct ResolvedAppBarStyle {
     background_color: Color,
     foreground_color: Color,
     elevation: f32,
+    /// The **toolbar-wide** ambient text style — Flutter parity:
+    /// `defaults.toolbarTextStyle?.copyWith(color: foregroundColor)`
+    /// (`app_bar.dart`, oracle tag `3.44.0`). Always the M3 default recolored
+    /// to `foreground_color`; FLUI has no `toolbarTextStyle` widget/theme
+    /// override slot yet (named deferral — nothing reads one). [`AppBar::build`]
+    /// wraps the WHOLE toolbar in this, so a bare `Text` in `leading`/`actions`
+    /// gets a sane ambient style — this must stay independent of
+    /// [`title_style`](Self::title_style) below, or a themed title style
+    /// leaks into every other toolbar child (the bug this split fixes).
+    toolbar_text_style: TextStyle,
+    /// The **title-only** text style — Flutter parity: `widget.titleTextStyle
+    /// ?? appBarTheme.titleTextStyle ?? defaults.titleTextStyle?.copyWith(
+    /// color: foregroundColor)` (`app_bar.dart`, oracle tag `3.44.0`).
+    /// [`AppBar::build`] wraps ONLY `self.title` in this, never the toolbar
+    /// at large — matching the oracle, where `titleTextStyle` styles the
+    /// title widget specifically, not `leading`/`actions`.
+    ///
+    /// A **verbatim** theme-tier value, not recolored, when
+    /// `app_bar_theme.title_text_style` is set: only the default tier gets
+    /// recolored to the resolved `foreground_color`, because a theme-supplied
+    /// style already carries its own intended color.
     title_style: TextStyle,
 }
 
@@ -286,13 +307,10 @@ struct ResolvedAppBarStyle {
 /// defaults.backgroundColor` (and the `foregroundColor`/`elevation`
 /// equivalents), `app_bar.dart`, oracle tag `3.44.0`.
 ///
-/// The title style is a **verbatim** theme-tier value, not recolored, when
-/// `app_bar_theme.title_text_style` is set — Flutter parity: `widget
-/// .titleTextStyle ?? appBarTheme.titleTextStyle ??
-/// defaults.titleTextStyle?.copyWith(color: foregroundColor)` (`app_bar.dart`,
-/// oracle tag `3.44.0`): only the default tier gets recolored to the
-/// resolved `foreground_color`, because a theme-supplied style already
-/// carries its own intended color.
+/// `title_style` and `toolbar_text_style` are deliberately DIFFERENT values
+/// once a theme configures `title_text_style` — see [`ResolvedAppBarStyle`]'s
+/// own doc comment on why collapsing them back into one shared value would
+/// leak the title's style onto every other toolbar child.
 fn resolve_style(
     theme: &ThemeData,
     background_color: Option<Color>,
@@ -310,21 +328,21 @@ fn resolve_style(
     let elevation = elevation
         .or_else(|| app_bar_theme.and_then(|t| t.elevation))
         .unwrap_or(0.0);
+    let toolbar_text_style = theme
+        .text_theme
+        .title_large
+        .clone()
+        .unwrap_or_default()
+        .with_color(foreground_color);
     let title_style = app_bar_theme
         .and_then(|t| t.title_text_style.clone())
-        .unwrap_or_else(|| {
-            theme
-                .text_theme
-                .title_large
-                .clone()
-                .unwrap_or_default()
-                .with_color(foreground_color)
-        });
+        .unwrap_or_else(|| toolbar_text_style.clone());
 
     ResolvedAppBarStyle {
         background_color,
         foreground_color,
         elevation,
+        toolbar_text_style,
         title_style,
     }
 }
@@ -388,6 +406,7 @@ impl StatelessView for AppBar {
             background_color,
             foreground_color,
             elevation,
+            toolbar_text_style,
             title_style,
         } = resolve_style(
             &theme,
@@ -422,8 +441,18 @@ impl StatelessView for AppBar {
         }
         if let Some(title) = &self.title {
             // Always start-aligned — see the module docs' `centerTitle` note.
+            // `title_style` is scoped to JUST this slot via its own
+            // `DefaultTextStyle` — it must NOT reach the toolbar-wide wrap
+            // below (which carries `toolbar_text_style` instead), or a
+            // themed `title_text_style` would restyle bare `Text` in
+            // `leading`/`actions` too. See `ResolvedAppBarStyle`'s doc
+            // comment.
             toolbar_children.push(
-                Expanded::new(Align::new(Alignment::CENTER_LEFT).child(title.clone())).boxed(),
+                Expanded::new(
+                    Align::new(Alignment::CENTER_LEFT)
+                        .child(DefaultTextStyle::new(title_style, title.clone())),
+                )
+                .boxed(),
             );
         }
         if !self.actions.is_empty() {
@@ -438,7 +467,7 @@ impl StatelessView for AppBar {
                 ..IconThemeData::default()
             },
             DefaultTextStyle::new(
-                title_style,
+                toolbar_text_style,
                 SizedBox::height(self.toolbar_height).child(toolbar),
             ),
         );

--- a/crates/flui-material/src/app_bar.rs
+++ b/crates/flui-material/src/app_bar.rs
@@ -277,25 +277,49 @@ struct ResolvedAppBarStyle {
     title_style: TextStyle,
 }
 
-/// Resolve `AppBar`'s M3 defaults: `background_color` falls back to
-/// `ColorScheme.surface`, `foreground_color` to `ColorScheme.on_surface`,
-/// `elevation` to `0.0`, and the title style to `TextTheme.title_large`
-/// recolored to the resolved foreground.
+/// Resolve `AppBar`'s M3 defaults through the widget → theme → default
+/// cascade: `background_color` falls back to `ThemeData.app_bar_theme`'s own
+/// `background_color`, then `ColorScheme.surface`; `foreground_color`
+/// likewise falls back through `app_bar_theme` to `ColorScheme.on_surface`;
+/// `elevation` through `app_bar_theme` to `0.0`. Flutter parity:
+/// `widget.backgroundColor ?? appBarTheme.backgroundColor ??
+/// defaults.backgroundColor` (and the `foregroundColor`/`elevation`
+/// equivalents), `app_bar.dart`, oracle tag `3.44.0`.
+///
+/// The title style is a **verbatim** theme-tier value, not recolored, when
+/// `app_bar_theme.title_text_style` is set — Flutter parity: `widget
+/// .titleTextStyle ?? appBarTheme.titleTextStyle ??
+/// defaults.titleTextStyle?.copyWith(color: foregroundColor)` (`app_bar.dart`,
+/// oracle tag `3.44.0`): only the default tier gets recolored to the
+/// resolved `foreground_color`, because a theme-supplied style already
+/// carries its own intended color.
 fn resolve_style(
     theme: &ThemeData,
     background_color: Option<Color>,
     foreground_color: Option<Color>,
     elevation: Option<f32>,
 ) -> ResolvedAppBarStyle {
-    let background_color = background_color.unwrap_or(theme.color_scheme.surface);
-    let foreground_color = foreground_color.unwrap_or(theme.color_scheme.on_surface);
-    let elevation = elevation.unwrap_or(0.0);
-    let title_style = theme
-        .text_theme
-        .title_large
-        .clone()
-        .unwrap_or_default()
-        .with_color(foreground_color);
+    let app_bar_theme = theme.app_bar_theme.as_ref();
+
+    let background_color = background_color
+        .or_else(|| app_bar_theme.and_then(|t| t.background_color))
+        .unwrap_or(theme.color_scheme.surface);
+    let foreground_color = foreground_color
+        .or_else(|| app_bar_theme.and_then(|t| t.foreground_color))
+        .unwrap_or(theme.color_scheme.on_surface);
+    let elevation = elevation
+        .or_else(|| app_bar_theme.and_then(|t| t.elevation))
+        .unwrap_or(0.0);
+    let title_style = app_bar_theme
+        .and_then(|t| t.title_text_style.clone())
+        .unwrap_or_else(|| {
+            theme
+                .text_theme
+                .title_large
+                .clone()
+                .unwrap_or_default()
+                .with_color(foreground_color)
+        });
 
     ResolvedAppBarStyle {
         background_color,
@@ -483,6 +507,69 @@ mod tests {
                 .with_color(theme.color_scheme.on_surface),
             "the title style must be TextTheme.title_large recolored to the resolved foreground"
         );
+    }
+
+    /// Middle-tier coverage: with no widget-level override, an
+    /// `app_bar_theme` slot's fields win over the M3 defaults, per field
+    /// (not as an all-or-nothing struct) — a themed `elevation` must not
+    /// force a themed `background_color`/`foreground_color` too.
+    #[test]
+    fn resolve_style_falls_through_to_the_app_bar_theme_when_no_widget_override_is_set() {
+        let mut theme = ThemeData::light();
+        let themed_background = Color::rgb(9, 8, 7);
+        theme.app_bar_theme = Some(crate::theme_data::AppBarThemeData {
+            background_color: Some(themed_background),
+            elevation: Some(5.0),
+            ..Default::default()
+        });
+
+        let resolved = resolve_style(&theme, None, None, None);
+
+        assert_eq!(resolved.background_color, themed_background);
+        assert_eq!(resolved.elevation, 5.0);
+        // `foreground_color` was left unset on the theme slot — falls all
+        // the way through to the M3 default, proving the per-field (not
+        // whole-struct) fallthrough.
+        assert_eq!(resolved.foreground_color, theme.color_scheme.on_surface);
+    }
+
+    /// Highest-tier coverage: an explicit widget-level override still wins
+    /// over a configured `app_bar_theme`, matching Flutter's
+    /// `widget.backgroundColor ?? appBarTheme.backgroundColor ?? …` order.
+    #[test]
+    fn resolve_style_widget_override_wins_over_the_app_bar_theme() {
+        let mut theme = ThemeData::light();
+        theme.app_bar_theme = Some(crate::theme_data::AppBarThemeData {
+            background_color: Some(Color::rgb(1, 1, 1)),
+            ..Default::default()
+        });
+        let widget_background = Color::rgb(2, 2, 2);
+
+        let resolved = resolve_style(&theme, Some(widget_background), None, None);
+
+        assert_eq!(resolved.background_color, widget_background);
+    }
+
+    /// The theme's `title_text_style` is used AS-IS, not recolored to the
+    /// resolved `foreground_color` — unlike the default tier (see the next
+    /// test) — matching the oracle's own
+    /// `titleTextStyle ?? appBarTheme.titleTextStyle ?? defaults….copyWith(…)`
+    /// order.
+    #[test]
+    fn resolve_style_theme_title_text_style_is_used_verbatim_not_recolored() {
+        let mut theme = ThemeData::light();
+        let themed_title_style =
+            flui_types::typography::TextStyle::new().with_color(Color::rgb(3, 3, 3));
+        theme.app_bar_theme = Some(crate::theme_data::AppBarThemeData {
+            title_text_style: Some(themed_title_style.clone()),
+            ..Default::default()
+        });
+        let widget_foreground = Color::rgb(4, 4, 4);
+
+        let resolved = resolve_style(&theme, None, Some(widget_foreground), None);
+
+        assert_eq!(resolved.title_style, themed_title_style);
+        assert_ne!(resolved.title_style.color, Some(widget_foreground));
     }
 
     #[test]

--- a/crates/flui-material/src/button_style_button.rs
+++ b/crates/flui-material/src/button_style_button.rs
@@ -10,11 +10,16 @@
 //! inverts the relationship: each concrete button (`elevated_button.rs` etc.)
 //! is a thin [`StatelessView`] that reads
 //! the ambient [`Theme`](crate::Theme), computes its own `default_style`
-//! table, and hands both to this module's [`ButtonStyleButtonCore`] — the
-//! `StatefulView` that owns the interactive-state machinery and the actual
-//! composition. `theme_style_of` has no caller yet (component themes are a
-//! V1 deferral — see below), so it never reaches this type at all rather
-//! than being threaded through as a permanent `None`.
+//! table, reads its own `ThemeData` component-theme slot (`elevated_button_theme`
+//! and friends), and hands all three to this module's [`ButtonStyleButtonCore`]
+//! — the `StatefulView` that owns the interactive-state machinery and the
+//! actual composition. **Named reduction**: the oracle also has a standalone
+//! `ElevatedButtonTheme` `InheritedTheme` widget per button (so a subtree can
+//! override just that button's style without touching the whole
+//! `ThemeData`); FLUI V1 has no per-widget `InheritedTheme` wrappers yet, so
+//! every concrete button reads only its `ThemeData` slot via `Theme::of` —
+//! see each concrete button's own module docs for the simplified
+//! `ElevatedButtonTheme.of(context)?.style` chain this collapses to.
 //!
 //! # The resolve-then-coalesce cascade
 //!
@@ -28,12 +33,12 @@
 //! `option_property_coalesce_chain_mirrors_button_style_button` test
 //! demonstrates for a single tier — here extended to three.
 //!
-//! `theme_style` is always `None` in every call site below: component themes
-//! (`ElevatedButtonTheme` and friends) are a named V1 deferral, not yet
-//! implemented. The three-tier signature stays in [`resolve_property`] (not
-//! collapsed to two) so the seam is visible in the type, not just prose —
-//! wiring a real `theme_style_of` in later is a call-site change, not a
-//! rewrite of this function.
+//! `theme_style` is threaded in via [`ButtonStyleButtonCore::theme_style`] —
+//! each concrete button passes its own `ThemeData` component-theme slot's
+//! `style` (when configured) at the same `Theme::of` read it already
+//! performs to compute `default_style`. A button whose slot is unset passes
+//! nothing, so `theme_style` stays `None` and the cascade falls straight
+//! through to `default_style` — unchanged from before this slot was wired.
 //!
 //! # Composition
 //!
@@ -146,6 +151,7 @@ macro_rules! resolve_field {
 pub(crate) struct ButtonStyleButtonCore {
     on_pressed: Option<PressCallback>,
     style: Option<ButtonStyle>,
+    theme_style: Option<ButtonStyle>,
     default_style: ButtonStyle,
     child: BoxedView,
 }
@@ -159,6 +165,7 @@ impl ButtonStyleButtonCore {
         Self {
             on_pressed: None,
             style: None,
+            theme_style: None,
             default_style,
             child,
         }
@@ -179,6 +186,19 @@ impl ButtonStyleButtonCore {
     #[must_use]
     pub(crate) fn style(mut self, style: ButtonStyle) -> Self {
         self.style = Some(style);
+        self
+    }
+
+    /// Sets the theme-level style — the middle tier in the resolve cascade,
+    /// between [`style`](Self::style) (widget-explicit, highest precedence)
+    /// and `default_style` (lowest). The caller passes its own `ThemeData`
+    /// component-theme slot's `style` here; leaving this unset (the default
+    /// from [`new`](Self::new)) means the cascade skips straight from
+    /// `style` to `default_style`, exactly as it did before this tier
+    /// existed.
+    #[must_use]
+    pub(crate) fn theme_style(mut self, style: ButtonStyle) -> Self {
+        self.theme_style = Some(style);
         self
     }
 
@@ -256,10 +276,9 @@ impl ViewState<ButtonStyleButtonCore> for ButtonStyleButtonCoreState {
         let states = self.states.value();
         let widget_style = view.style.as_ref();
         let default_style = Some(&view.default_style);
-        // Deferred: component themes (`ElevatedButtonTheme` and friends) —
-        // see the module docs. No call site threads a real value through
-        // yet.
-        let theme_style: Option<&ButtonStyle> = None;
+        // Set by the caller via `theme_style` when its `ThemeData`
+        // component-theme slot is configured — see the module docs.
+        let theme_style = view.theme_style.as_ref();
 
         let background_color = resolve_field!(
             &states,
@@ -325,7 +344,11 @@ impl ViewState<ButtonStyleButtonCore> for ButtonStyleButtonCoreState {
 
         let constraints = effective_constraints(minimum_size, maximum_size, fixed_size);
 
-        let overlay_color = overlay_color_property(view.style.clone(), view.default_style.clone());
+        let overlay_color = overlay_color_property(
+            view.style.clone(),
+            view.theme_style.clone(),
+            view.default_style.clone(),
+        );
 
         let mut ink_well = InkWell::new(
             Padding::new(padding).child(DefaultTextStyle::new(text_style, view.child.clone())),
@@ -408,16 +431,20 @@ fn effective_constraints(
 
 /// Builds the live [`WidgetStateProperty`] handed to the inner `InkWell` —
 /// see the module docs on why `overlay_color` is not baked to a single
-/// value like every other property.
+/// value like every other property. Closes over all three cascade tiers
+/// (widget/theme/default), same as [`ButtonStyleButtonCoreState::build`]'s
+/// own per-property resolution, so a theme-configured `overlay_color`
+/// reaches the live property too.
 fn overlay_color_property(
     widget_style: Option<ButtonStyle>,
+    theme_style: Option<ButtonStyle>,
     default_style: ButtonStyle,
 ) -> WidgetStateProperty<Option<Color>> {
     WidgetStateProperty::resolve_with(move |states: &WidgetStates| {
         resolve_field!(
             states,
             widget_style.as_ref(),
-            None::<&ButtonStyle>,
+            theme_style.as_ref(),
             Some(&default_style),
             overlay_color
         )

--- a/crates/flui-material/src/button_style_button.rs
+++ b/crates/flui-material/src/button_style_button.rs
@@ -461,6 +461,66 @@ mod tests {
         WidgetStateProperty::all(Some(value))
     }
 
+    /// `overlay_color_property`'s theme tier, resolved for a `Pressed` state
+    /// — the live `WidgetStateProperty` handed to `InkWell` (see the
+    /// function's own doc comment: it closes over all three cascade tiers,
+    /// same as `ButtonStyleButtonCoreState::build`'s per-property
+    /// resolution). Mutation-honest: with no widget-level `overlay_color`
+    /// set, the resolved value must be the THEME tier's color, not the
+    /// default tier's — reverting `theme_style.as_ref()` back to a
+    /// hardcoded `None` (its state before `theme_style` was wired) would
+    /// resolve `default_overlay` here instead of `themed_overlay`, failing
+    /// this assertion.
+    #[test]
+    fn overlay_color_property_resolves_the_theme_tier_for_a_pressed_state() {
+        let themed_overlay = Color::rgb(9, 9, 9);
+        let default_overlay = Color::rgb(1, 1, 1);
+        let theme_style = ButtonStyle {
+            overlay_color: Some(all_property(themed_overlay)),
+            ..Default::default()
+        };
+        let default_style = ButtonStyle {
+            overlay_color: Some(all_property(default_overlay)),
+            ..Default::default()
+        };
+
+        let property = overlay_color_property(None, Some(theme_style), default_style);
+        let resolved = property.resolve(&WidgetStates::from(WidgetState::Pressed));
+
+        assert_eq!(
+            resolved,
+            Some(themed_overlay),
+            "a theme-configured overlay_color, with no widget-level override, must reach the \
+             live WidgetStateProperty handed to InkWell — not fall through to the default tier",
+        );
+    }
+
+    /// Companion coverage: an explicit widget-level `overlay_color` still
+    /// wins over a configured theme tier, matching every other property's
+    /// widget > theme > default precedence.
+    #[test]
+    fn overlay_color_property_widget_tier_wins_over_the_theme_tier() {
+        let widget_overlay = Color::rgb(2, 2, 2);
+        let themed_overlay = Color::rgb(9, 9, 9);
+        let widget_style = ButtonStyle {
+            overlay_color: Some(all_property(widget_overlay)),
+            ..Default::default()
+        };
+        let theme_style = ButtonStyle {
+            overlay_color: Some(all_property(themed_overlay)),
+            ..Default::default()
+        };
+
+        let property = overlay_color_property(
+            Some(widget_style),
+            Some(theme_style),
+            ButtonStyle::default(),
+        );
+        let resolved = property.resolve(&WidgetStates::from(WidgetState::Pressed));
+
+        assert_eq!(resolved, Some(widget_overlay));
+    }
+
     #[test]
     fn widget_tier_wins_when_all_three_are_set() {
         let widget = all_property(1_u32);

--- a/crates/flui-material/src/card.rs
+++ b/crates/flui-material/src/card.rs
@@ -58,6 +58,7 @@ use flui_widgets::Padding;
 use crate::material::Material;
 use crate::shape::MaterialShape;
 use crate::theme::Theme;
+use crate::theme_data::ThemeData;
 
 /// `_CardDefaultsM3`'s corner radius (`card.dart`, oracle tag `3.44.0`).
 const DEFAULT_CORNER_RADIUS: f32 = 12.0;
@@ -153,21 +154,71 @@ impl Card {
     }
 }
 
-impl StatelessView for Card {
-    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
-        let colors = Theme::of(ctx).color_scheme;
-        let margin = self
-            .margin
-            .unwrap_or_else(|| EdgeInsets::all(px(DEFAULT_MARGIN)));
-        let shape = self.shape.unwrap_or_else(|| {
+/// [`Card`]'s theme-resolved color/elevation/shape/margin — see
+/// [`resolve_style`]'s doc comment for the widget → theme → default cascade.
+/// Factored out for the same reason [`crate::app_bar`]'s
+/// `ResolvedAppBarStyle` is: directly unit-testable without mounting a
+/// widget tree.
+struct ResolvedCardStyle {
+    color: Color,
+    elevation: f32,
+    shape: MaterialShape,
+    margin: EdgeInsets,
+}
+
+/// Resolve `Card`'s M3 defaults through the widget → theme → default
+/// cascade, per field: `color`/`elevation`/`shape`/`margin` each fall back
+/// through `ThemeData.card_theme`'s own field before the `_CardDefaultsM3`
+/// constant. Flutter parity: `color ?? cardTheme.color ?? defaults.color`
+/// (and the `elevation`/`shape`/`margin` equivalents), `card.dart`, oracle
+/// tag `3.44.0`.
+fn resolve_style(
+    theme: &ThemeData,
+    color: Option<Color>,
+    elevation: Option<f32>,
+    shape: Option<MaterialShape>,
+    margin: Option<EdgeInsets>,
+) -> ResolvedCardStyle {
+    let card_theme = theme.card_theme.as_ref();
+
+    let color = color
+        .or_else(|| card_theme.and_then(|t| t.color))
+        .unwrap_or(theme.color_scheme.surface_container_low);
+    let elevation = elevation
+        .or_else(|| card_theme.and_then(|t| t.elevation))
+        .unwrap_or(DEFAULT_ELEVATION);
+    let shape = shape
+        .or_else(|| card_theme.and_then(|t| t.shape))
+        .unwrap_or_else(|| {
             MaterialShape::RoundedRect(BorderRadius::all(Radius::circular(px(
                 DEFAULT_CORNER_RADIUS,
             ))))
         });
+    let margin = margin
+        .or_else(|| card_theme.and_then(|t| t.margin))
+        .unwrap_or_else(|| EdgeInsets::all(px(DEFAULT_MARGIN)));
+
+    ResolvedCardStyle {
+        color,
+        elevation,
+        shape,
+        margin,
+    }
+}
+
+impl StatelessView for Card {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        let theme = Theme::of(ctx);
+        let ResolvedCardStyle {
+            color,
+            elevation,
+            shape,
+            margin,
+        } = resolve_style(&theme, self.color, self.elevation, self.shape, self.margin);
 
         Padding::new(margin).child(
-            Material::new(self.color.unwrap_or(colors.surface_container_low))
-                .elevation(self.elevation.unwrap_or(DEFAULT_ELEVATION))
+            Material::new(color)
+                .elevation(elevation)
                 .shape(shape)
                 .clip_behavior(self.clip_behavior.unwrap_or(Clip::None))
                 .child(self.child.clone()),
@@ -215,5 +266,44 @@ mod tests {
     #[test]
     fn default_corner_radius_constant_matches_the_oracle() {
         assert_eq!(DEFAULT_CORNER_RADIUS, 12.0);
+    }
+
+    #[test]
+    fn resolve_style_falls_through_to_the_card_theme_when_no_widget_override_is_set() {
+        let mut theme = ThemeData::light();
+        let themed_color = Color::rgb(1, 2, 3);
+        theme.card_theme = Some(crate::theme_data::CardThemeData {
+            color: Some(themed_color),
+            elevation: Some(7.0),
+            ..Default::default()
+        });
+
+        let resolved = resolve_style(&theme, None, None, None, None);
+
+        assert_eq!(resolved.color, themed_color);
+        assert_eq!(resolved.elevation, 7.0);
+        // `shape`/`margin` were left unset on the theme slot — each falls
+        // through to its own M3 default independently.
+        assert_eq!(
+            resolved.shape,
+            MaterialShape::RoundedRect(BorderRadius::all(Radius::circular(px(
+                DEFAULT_CORNER_RADIUS
+            ))))
+        );
+        assert_eq!(resolved.margin, EdgeInsets::all(px(DEFAULT_MARGIN)));
+    }
+
+    #[test]
+    fn resolve_style_widget_override_wins_over_the_card_theme() {
+        let mut theme = ThemeData::light();
+        theme.card_theme = Some(crate::theme_data::CardThemeData {
+            color: Some(Color::rgb(1, 1, 1)),
+            ..Default::default()
+        });
+        let widget_color = Color::rgb(9, 9, 9);
+
+        let resolved = resolve_style(&theme, Some(widget_color), None, None, None);
+
+        assert_eq!(resolved.color, widget_color);
     }
 }

--- a/crates/flui-material/src/dialog.rs
+++ b/crates/flui-material/src/dialog.rs
@@ -150,6 +150,7 @@ use flui_rendering::constraints::BoxConstraints;
 use flui_types::geometry::{Radius, px};
 use flui_types::painting::Clip;
 use flui_types::styling::BorderRadius;
+use flui_types::typography::TextStyle;
 use flui_types::{Alignment, Color, EdgeInsets, Pixels};
 use flui_view::prelude::*;
 use flui_widgets::{
@@ -160,8 +161,8 @@ use flui_widgets::{
 
 use crate::material::Material;
 use crate::shape::MaterialShape;
-use crate::text_theme::TextTheme;
 use crate::theme::Theme;
+use crate::theme_data::ThemeData;
 
 /// `_DialogDefaultsM3`'s elevation (`dialog.dart`, oracle tag `3.44.0`).
 const DEFAULT_ELEVATION: f32 = 6.0;
@@ -282,9 +283,58 @@ impl Dialog {
     }
 }
 
+/// [`Dialog`]'s theme-resolved surface style — see [`resolve_style`]'s doc
+/// comment for the widget → theme → default cascade. Factored out for the
+/// same reason [`crate::app_bar`]'s `ResolvedAppBarStyle` is.
+struct ResolvedDialogStyle {
+    color: Color,
+    elevation: f32,
+    shape: MaterialShape,
+}
+
+/// Resolve `Dialog`'s M3 defaults through the widget → theme → default
+/// cascade, per field: `color`/`elevation`/`shape` each fall back through
+/// `ThemeData.dialog_theme`'s own field before the `_DialogDefaultsM3`
+/// constant. Flutter parity: `backgroundColor ?? dialogTheme.backgroundColor
+/// ?? defaults.backgroundColor` (and the `elevation`/`shape` equivalents),
+/// `dialog.dart`, oracle tag `3.44.0`.
+fn resolve_style(
+    theme: &ThemeData,
+    color: Option<Color>,
+    elevation: Option<f32>,
+    shape: Option<MaterialShape>,
+) -> ResolvedDialogStyle {
+    let dialog_theme = theme.dialog_theme.as_ref();
+
+    let color = color
+        .or_else(|| dialog_theme.and_then(|t| t.background_color))
+        .unwrap_or(theme.color_scheme.surface_container_high);
+    let elevation = elevation
+        .or_else(|| dialog_theme.and_then(|t| t.elevation))
+        .unwrap_or(DEFAULT_ELEVATION);
+    let shape = shape
+        .or_else(|| dialog_theme.and_then(|t| t.shape))
+        .unwrap_or_else(|| {
+            MaterialShape::RoundedRect(BorderRadius::all(Radius::circular(px(
+                DEFAULT_CORNER_RADIUS,
+            ))))
+        });
+
+    ResolvedDialogStyle {
+        color,
+        elevation,
+        shape,
+    }
+}
+
 impl StatelessView for Dialog {
     fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
-        let colors = Theme::of(ctx).color_scheme;
+        let theme = Theme::of(ctx);
+        let ResolvedDialogStyle {
+            color,
+            elevation,
+            shape,
+        } = resolve_style(&theme, self.color, self.elevation, self.shape);
         let inset_padding = self.inset_padding.unwrap_or_else(|| {
             EdgeInsets::symmetric(px(INSET_PADDING_VERTICAL), px(INSET_PADDING_HORIZONTAL))
         });
@@ -296,17 +346,12 @@ impl StatelessView for Dialog {
                 Pixels::INFINITY,
             )
         });
-        let shape = self.shape.unwrap_or_else(|| {
-            MaterialShape::RoundedRect(BorderRadius::all(Radius::circular(px(
-                DEFAULT_CORNER_RADIUS,
-            ))))
-        });
 
         Padding::new(inset_padding).child(
             Align::new(self.alignment.unwrap_or(Alignment::CENTER)).child(
                 ConstrainedBox::new(constraints).child(
-                    Material::new(self.color.unwrap_or(colors.surface_container_high))
-                        .elevation(self.elevation.unwrap_or(DEFAULT_ELEVATION))
+                    Material::new(color)
+                        .elevation(elevation)
                         .shape(shape)
                         .clip_behavior(self.clip_behavior.unwrap_or(Clip::None))
                         .child(self.child.clone()),
@@ -385,9 +430,36 @@ impl AlertDialog {
     }
 }
 
+/// `AlertDialog`'s title text style, through the theme → default cascade —
+/// no per-instance `AlertDialog::title_style` override exists yet (named V1
+/// deferral, see the module docs), so there is no widget tier here. Flutter
+/// parity: `titleTextStyle ?? dialogTheme.titleTextStyle ??
+/// defaults.titleTextStyle!` (`dialog.dart`, oracle tag `3.44.0`), narrowed
+/// to the theme/default tiers this crate exposes. Factored out as a pure
+/// function (like `Dialog`'s own `resolve_style`) so the cascade is
+/// unit-testable without mounting a widget tree.
+fn resolve_title_style(theme: &ThemeData) -> TextStyle {
+    theme
+        .dialog_theme
+        .as_ref()
+        .and_then(|t| t.title_text_style.clone())
+        .unwrap_or_else(|| theme.text_theme.headline_small.clone().unwrap_or_default())
+}
+
+/// `AlertDialog`'s content text style — same theme → default cascade as
+/// [`resolve_title_style`]. Flutter parity: `contentTextStyle ??
+/// dialogTheme.contentTextStyle ?? defaults.contentTextStyle!`.
+fn resolve_content_style(theme: &ThemeData) -> TextStyle {
+    theme
+        .dialog_theme
+        .as_ref()
+        .and_then(|t| t.content_text_style.clone())
+        .unwrap_or_else(|| theme.text_theme.body_medium.clone().unwrap_or_default())
+}
+
 impl StatelessView for AlertDialog {
     fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
-        let text_theme: TextTheme = Theme::of(ctx).text_theme;
+        let theme = Theme::of(ctx);
         let mut children: Vec<BoxedView> = Vec::new();
 
         if let Some(title) = &self.title {
@@ -400,7 +472,7 @@ impl StatelessView for AlertDialog {
                     px(24.0),
                 ))
                 .child(DefaultTextStyle::new(
-                    text_theme.headline_small.clone().unwrap_or_default(),
+                    resolve_title_style(&theme),
                     title.clone(),
                 ))
                 .boxed(),
@@ -415,10 +487,7 @@ impl StatelessView for AlertDialog {
             children.push(
                 Flexible::new(
                     Padding::new(EdgeInsets::new(px(16.0), px(24.0), px(24.0), px(24.0))).child(
-                        DefaultTextStyle::new(
-                            text_theme.body_medium.clone().unwrap_or_default(),
-                            content.clone(),
-                        ),
+                        DefaultTextStyle::new(resolve_content_style(&theme), content.clone()),
                     ),
                 )
                 .boxed(),
@@ -546,5 +615,83 @@ mod tests {
         assert_eq!(expected, Color::BLACK);
         assert_eq!(BARRIER_COLOR, Color::from_argb(0x8A00_0000));
         assert_eq!(BARRIER_COLOR.with_opacity(1.0), Color::BLACK);
+    }
+
+    #[test]
+    fn resolve_style_falls_through_to_the_dialog_theme_when_no_widget_override_is_set() {
+        let mut theme = ThemeData::light();
+        let themed_color = Color::rgb(5, 6, 7);
+        theme.dialog_theme = Some(crate::theme_data::DialogThemeData {
+            background_color: Some(themed_color),
+            elevation: Some(11.0),
+            ..Default::default()
+        });
+
+        let resolved = resolve_style(&theme, None, None, None);
+
+        assert_eq!(resolved.color, themed_color);
+        assert_eq!(resolved.elevation, 11.0);
+        assert_eq!(
+            resolved.shape,
+            MaterialShape::RoundedRect(BorderRadius::all(Radius::circular(px(
+                DEFAULT_CORNER_RADIUS
+            ))))
+        );
+    }
+
+    #[test]
+    fn resolve_style_widget_override_wins_over_the_dialog_theme() {
+        let mut theme = ThemeData::light();
+        theme.dialog_theme = Some(crate::theme_data::DialogThemeData {
+            background_color: Some(Color::rgb(1, 1, 1)),
+            ..Default::default()
+        });
+        let widget_color = Color::rgb(9, 9, 9);
+
+        let resolved = resolve_style(&theme, Some(widget_color), None, None);
+
+        assert_eq!(resolved.color, widget_color);
+    }
+
+    #[test]
+    fn resolve_title_style_falls_through_to_the_dialog_theme() {
+        let mut theme = ThemeData::light();
+        let themed_style = TextStyle::new().with_color(Color::rgb(1, 2, 3));
+        theme.dialog_theme = Some(crate::theme_data::DialogThemeData {
+            title_text_style: Some(themed_style.clone()),
+            ..Default::default()
+        });
+
+        assert_eq!(resolve_title_style(&theme), themed_style);
+    }
+
+    #[test]
+    fn resolve_title_style_defaults_to_headline_small_when_no_theme_is_set() {
+        let theme = ThemeData::light();
+        assert_eq!(
+            resolve_title_style(&theme),
+            theme.text_theme.headline_small.clone().unwrap_or_default()
+        );
+    }
+
+    #[test]
+    fn resolve_content_style_falls_through_to_the_dialog_theme() {
+        let mut theme = ThemeData::light();
+        let themed_style = TextStyle::new().with_color(Color::rgb(4, 5, 6));
+        theme.dialog_theme = Some(crate::theme_data::DialogThemeData {
+            content_text_style: Some(themed_style.clone()),
+            ..Default::default()
+        });
+
+        assert_eq!(resolve_content_style(&theme), themed_style);
+    }
+
+    #[test]
+    fn resolve_content_style_defaults_to_body_medium_when_no_theme_is_set() {
+        let theme = ThemeData::light();
+        assert_eq!(
+            resolve_content_style(&theme),
+            theme.text_theme.body_medium.clone().unwrap_or_default()
+        );
     }
 }

--- a/crates/flui-material/src/elevated_button.rs
+++ b/crates/flui-material/src/elevated_button.rs
@@ -88,6 +88,20 @@ impl StatelessView for ElevatedButton {
         let theme = Theme::of(ctx);
         let mut core = ButtonStyleButtonCore::new(default_style(&theme), self.child.clone())
             .style(self.style.clone().unwrap_or_default());
+        // Middle cascade tier — Flutter parity, simplified: the oracle reads
+        // `ElevatedButtonTheme.of(context)?.style`, a standalone
+        // `InheritedTheme`; FLUI V1 has no per-button `InheritedTheme`
+        // wrapper yet, so this reads the same style off the ambient
+        // `ThemeData`'s `elevated_button_theme` slot instead (see
+        // `crate::button_style_button`'s module docs for this reduction,
+        // shared by every button in this crate).
+        if let Some(theme_style) = theme
+            .elevated_button_theme
+            .as_ref()
+            .and_then(|t| t.style.clone())
+        {
+            core = core.theme_style(theme_style);
+        }
         if let Some(on_pressed) = self.on_pressed.clone() {
             core = core.on_pressed(on_pressed);
         }

--- a/crates/flui-material/src/filled_button.rs
+++ b/crates/flui-material/src/filled_button.rs
@@ -110,6 +110,18 @@ impl StatelessView for FilledButton {
         let mut core =
             ButtonStyleButtonCore::new(default_style(&theme, self.variant), self.child.clone())
                 .style(self.style.clone().unwrap_or_default());
+        // Middle cascade tier — see `crate::elevated_button`'s identical
+        // "simplified from `ElevatedButtonTheme.of`" note; the `tonal`
+        // variant shares the same `filled_button_theme` slot as the plain
+        // variant, matching the oracle (one `FilledButtonThemeData` for
+        // both `FilledButton` constructors).
+        if let Some(theme_style) = theme
+            .filled_button_theme
+            .as_ref()
+            .and_then(|t| t.style.clone())
+        {
+            core = core.theme_style(theme_style);
+        }
         if let Some(on_pressed) = self.on_pressed.clone() {
             core = core.on_pressed(on_pressed);
         }

--- a/crates/flui-material/src/floating_action_button.rs
+++ b/crates/flui-material/src/floating_action_button.rs
@@ -87,6 +87,7 @@ use std::sync::Arc;
 
 use flui_foundation::{Listenable, ListenerId};
 use flui_rendering::constraints::BoxConstraints;
+use flui_types::Color;
 use flui_types::Size;
 use flui_types::geometry::{Radius, px};
 use flui_types::styling::BorderRadius;
@@ -103,6 +104,7 @@ use crate::ink_well::InkWell;
 use crate::material::Material;
 use crate::shape::MaterialShape;
 use crate::theme::Theme;
+use crate::theme_data::ThemeData;
 
 /// The regular (non-mini) floating action button's side length. Flutter
 /// parity: `_FABDefaultsM3.sizeConstraints`, `BoxConstraints.tightFor(width:
@@ -114,21 +116,31 @@ pub const FAB_SIZE: f32 = 56.0;
 pub const FAB_ICON_SIZE: f32 = 24.0;
 
 /// The enabled default AND disabled elevation (they coincide — see the
-/// module docs). Flutter parity: `_FABDefaultsM3`'s `elevation: 6.0`.
+/// module docs). Flutter parity: `_FABDefaultsM3`'s `elevation: 6.0`. The
+/// `enabled` value this constant provides is itself theme-overridable (see
+/// [`crate::theme_data::FabThemeData::elevation`]) — [`resolve_elevation`]
+/// takes the (possibly overridden) effective value as a parameter rather
+/// than closing over this constant directly, so a theme override reaches
+/// both the `disabled` tier and the enabled-default fallback tier, matching
+/// `FloatingActionButton.build`'s own `disabledElevation ?? … ?? elevation`
+/// fallback chain (NOT `RawMaterialButton`'s constructor, whose own
+/// `disabledElevation` parameter flatly defaults to `0.0` — see the module
+/// docs' "The elevation chain" section) — `_FABDefaultsM3` never overrides
+/// `disabledElevation`, so it resolves to the same (possibly theme-resolved)
+/// enabled value.
 const ELEVATION_DEFAULT: f32 = 6.0;
-/// Flutter parity: `_FABDefaultsM3`'s `focusElevation: 6.0`.
+/// Flutter parity: `_FABDefaultsM3`'s `focusElevation: 6.0`. No
+/// `focus_elevation` theme slot exists (named deferral, see
+/// `crate::theme_data::FabThemeData`'s doc comment), so this constant is
+/// never theme-overridden.
 const ELEVATION_FOCUSED: f32 = 6.0;
-/// Flutter parity: `_FABDefaultsM3`'s `hoverElevation: 8.0`.
+/// Flutter parity: `_FABDefaultsM3`'s `hoverElevation: 8.0`. Same named
+/// deferral as [`ELEVATION_FOCUSED`] — no `hover_elevation` theme slot.
 const ELEVATION_HOVERED: f32 = 8.0;
 /// The pressed elevation — Flutter's `highlightElevation`. Flutter parity:
-/// `_FABDefaultsM3`'s `highlightElevation: 6.0`.
+/// `_FABDefaultsM3`'s `highlightElevation: 6.0`. Same named deferral as
+/// [`ELEVATION_FOCUSED`] — no `highlight_elevation` theme slot.
 const ELEVATION_PRESSED: f32 = 6.0;
-/// Flutter parity: `FloatingActionButton.build`'s own `disabledElevation ??
-/// … ?? elevation` fallback chain (NOT `RawMaterialButton`'s constructor,
-/// whose own `disabledElevation` parameter flatly defaults to `0.0` — see
-/// the module docs' "The elevation chain" section) — `_FABDefaultsM3` never
-/// overrides `disabledElevation`, so it resolves to the enabled default.
-const ELEVATION_DISABLED: f32 = ELEVATION_DEFAULT;
 
 /// The regular M3 FAB's shape: a rectangle with a 16dp corner radius —
 /// **not** a circle. See the module docs' "M3 shape" section.
@@ -188,11 +200,17 @@ impl std::fmt::Debug for FloatingActionButton {
 
 /// Resolves `_RawMaterialButtonState._effectiveElevation`'s exact
 /// disabled→pressed→hovered→focused→default if-chain — see the module docs.
-/// Kept as a free function (not inlined into `build`) so the chain order is
-/// independently unit-testable against hand-built [`WidgetStates`] values.
-fn resolve_elevation(states: &WidgetStates) -> f32 {
+/// `enabled_elevation` is the already-resolved widget/theme/default cascade
+/// for the enabled tier (see [`resolve_colors`]'s sibling resolution and
+/// [`FloatingActionButtonState::build`]'s call site); both the `disabled`
+/// branch and the unconditional fallback return it, matching the oracle's
+/// own `disabledElevation ?? … ?? elevation` chain (see [`ELEVATION_DEFAULT`]'s
+/// doc comment). Kept as a free function (not inlined into `build`) so the
+/// chain order is independently unit-testable against hand-built
+/// [`WidgetStates`] values.
+fn resolve_elevation(states: &WidgetStates, enabled_elevation: f32) -> f32 {
     if states.contains_state(WidgetState::Disabled) {
-        ELEVATION_DISABLED
+        enabled_elevation
     } else if states.contains_state(WidgetState::Pressed) {
         ELEVATION_PRESSED
     } else if states.contains_state(WidgetState::Hovered) {
@@ -200,7 +218,39 @@ fn resolve_elevation(states: &WidgetStates) -> f32 {
     } else if states.contains_state(WidgetState::Focused) {
         ELEVATION_FOCUSED
     } else {
-        ELEVATION_DEFAULT
+        enabled_elevation
+    }
+}
+
+/// [`FloatingActionButton`]'s theme-resolved background/foreground colors
+/// and enabled-tier elevation — see [`resolve_elevation`] for how the
+/// elevation value feeds the state chain. Flutter parity: `this
+/// .foregroundColor ?? floatingActionButtonTheme.foregroundColor ??
+/// defaults.foregroundColor!` (and the `backgroundColor`/`elevation`
+/// equivalents), `floating_action_button.dart`, oracle tag `3.44.0`,
+/// narrowed to FLUI's `FabThemeData` slots. No per-instance widget-level
+/// override exists yet for any of the three (a named V1 deferral — see the
+/// module docs), so this cascade is theme → default only.
+struct ResolvedFabStyle {
+    background_color: Color,
+    foreground_color: Color,
+    elevation: f32,
+}
+
+fn resolve_colors(theme: &ThemeData) -> ResolvedFabStyle {
+    let colors = theme.color_scheme;
+    let fab_theme = theme.floating_action_button_theme.as_ref();
+
+    ResolvedFabStyle {
+        background_color: fab_theme
+            .and_then(|t| t.background_color)
+            .unwrap_or(colors.primary_container),
+        foreground_color: fab_theme
+            .and_then(|t| t.foreground_color)
+            .unwrap_or(colors.on_primary_container),
+        elevation: fab_theme
+            .and_then(|t| t.elevation)
+            .unwrap_or(ELEVATION_DEFAULT),
     }
 }
 
@@ -279,20 +329,32 @@ impl ViewState<FloatingActionButton> for FloatingActionButtonState {
 
     fn build(&self, view: &FloatingActionButton, ctx: &dyn BuildContext) -> impl IntoView {
         let theme = Theme::of(ctx);
-        let colors = theme.color_scheme;
+        let ResolvedFabStyle {
+            background_color,
+            foreground_color,
+            elevation: enabled_elevation,
+        } = resolve_colors(&theme);
         let states = self.states.value();
 
-        let elevation = resolve_elevation(&states);
+        let elevation = resolve_elevation(&states, enabled_elevation);
         let shape = fab_shape();
 
-        let overlay_base = colors.on_primary_container;
+        // The overlay ramp's base color is `_FABDefaultsM3`'s own
+        // `splashColor`/`focusColor`/`hoverColor` — independent oracle
+        // fields (see `pressed_hovered_focused_overlay`'s call site here),
+        // NOT derived from the resolved `foreground_color` above. FLUI
+        // exposes no theme slot for them (named deferral, see
+        // `crate::theme_data::FabThemeData`'s doc comment), so this stays
+        // pinned to the M3 default regardless of a `foreground_color`
+        // theme/widget override.
+        let overlay_base = theme.color_scheme.on_primary_container;
         let overlay_color = WidgetStateProperty::resolve_with(move |states: &WidgetStates| {
             pressed_hovered_focused_overlay(states, overlay_base)
         });
 
         let icon = IconTheme::new(
             IconThemeData {
-                color: Some(colors.on_primary_container),
+                color: Some(foreground_color),
                 size: Some(FAB_ICON_SIZE),
                 ..IconThemeData::default()
             },
@@ -310,7 +372,7 @@ impl ViewState<FloatingActionButton> for FloatingActionButtonState {
         let constraints = BoxConstraints::tight(Size::new(px(FAB_SIZE), px(FAB_SIZE)));
 
         ConstrainedBox::new(constraints).child(
-            Material::new(colors.primary_container)
+            Material::new(background_color)
                 .elevation(elevation)
                 .shape(shape)
                 .child(ink_well),
@@ -380,21 +442,33 @@ mod tests {
         let hovered = WidgetStates::from(WidgetState::Hovered);
         let focused = WidgetStates::from(WidgetState::Focused);
 
-        assert_eq!(resolve_elevation(&none), 6.0, "enabled default is 6.0");
         assert_eq!(
-            resolve_elevation(&disabled),
+            resolve_elevation(&none, ELEVATION_DEFAULT),
+            6.0,
+            "enabled default is 6.0"
+        );
+        assert_eq!(
+            resolve_elevation(&disabled, ELEVATION_DEFAULT),
             6.0,
             "disabled elevation falls back to the enabled default (RawMaterialButton's \
              disabledElevation ?? elevation), NOT zero — matching the oracle's own warning that \
              a disabled FAB has no visual indication",
         );
         assert_eq!(
-            resolve_elevation(&pressed),
+            resolve_elevation(&pressed, ELEVATION_DEFAULT),
             6.0,
             "highlightElevation is 6.0"
         );
-        assert_eq!(resolve_elevation(&hovered), 8.0, "hoverElevation is 8.0");
-        assert_eq!(resolve_elevation(&focused), 6.0, "focusElevation is 6.0");
+        assert_eq!(
+            resolve_elevation(&hovered, ELEVATION_DEFAULT),
+            8.0,
+            "hoverElevation is 8.0"
+        );
+        assert_eq!(
+            resolve_elevation(&focused, ELEVATION_DEFAULT),
+            6.0,
+            "focusElevation is 6.0"
+        );
     }
 
     /// Mutation-honest ordered-chain coverage: `disabled` must be checked
@@ -405,7 +479,10 @@ mod tests {
     fn disabled_takes_precedence_over_a_combined_hovered_state() {
         let disabled_and_hovered =
             WidgetStates::from(WidgetState::Disabled).with_state(WidgetState::Hovered);
-        assert_eq!(resolve_elevation(&disabled_and_hovered), 6.0);
+        assert_eq!(
+            resolve_elevation(&disabled_and_hovered, ELEVATION_DEFAULT),
+            6.0
+        );
     }
 
     /// Mutation-honest ordered-chain coverage: `pressed` must be checked
@@ -420,7 +497,7 @@ mod tests {
         let pressed_and_hovered =
             WidgetStates::from(WidgetState::Pressed).with_state(WidgetState::Hovered);
         assert_eq!(
-            resolve_elevation(&pressed_and_hovered),
+            resolve_elevation(&pressed_and_hovered, ELEVATION_DEFAULT),
             ELEVATION_PRESSED,
             "pressed (highlightElevation, 6.0) must win over hovered (hoverElevation, 8.0) — \
              deleting the pressed branch, or reordering it after hovered, would resolve this to \
@@ -434,6 +511,75 @@ mod tests {
     fn hovered_takes_precedence_over_a_combined_focused_state() {
         let hovered_and_focused =
             WidgetStates::from(WidgetState::Hovered).with_state(WidgetState::Focused);
-        assert_eq!(resolve_elevation(&hovered_and_focused), ELEVATION_HOVERED);
+        assert_eq!(
+            resolve_elevation(&hovered_and_focused, ELEVATION_DEFAULT),
+            ELEVATION_HOVERED
+        );
+    }
+
+    /// Theme-tier coverage: a `FabThemeData::elevation` override reaches
+    /// both the enabled-default fallback tier AND the `disabled` tier (see
+    /// `resolve_elevation`'s doc comment on why `enabled_elevation` feeds
+    /// both), but leaves `pressed`/`hovered`/`focused` at their own fixed
+    /// constants — no theme slot exists for those.
+    #[test]
+    fn a_themed_elevation_reaches_the_enabled_and_disabled_tiers_but_not_the_others() {
+        let themed_elevation = 20.0;
+        let none = WidgetStates::NONE;
+        let disabled = WidgetStates::from(WidgetState::Disabled);
+        let pressed = WidgetStates::from(WidgetState::Pressed);
+        let hovered = WidgetStates::from(WidgetState::Hovered);
+
+        assert_eq!(resolve_elevation(&none, themed_elevation), themed_elevation);
+        assert_eq!(
+            resolve_elevation(&disabled, themed_elevation),
+            themed_elevation
+        );
+        assert_eq!(
+            resolve_elevation(&pressed, themed_elevation),
+            ELEVATION_PRESSED
+        );
+        assert_eq!(
+            resolve_elevation(&hovered, themed_elevation),
+            ELEVATION_HOVERED
+        );
+    }
+
+    #[test]
+    fn resolve_colors_falls_back_to_the_m3_defaults_when_no_theme_is_set() {
+        let theme = ThemeData::light();
+        let resolved = resolve_colors(&theme);
+
+        assert_eq!(
+            resolved.background_color,
+            theme.color_scheme.primary_container
+        );
+        assert_eq!(
+            resolved.foreground_color,
+            theme.color_scheme.on_primary_container
+        );
+        assert_eq!(resolved.elevation, ELEVATION_DEFAULT);
+    }
+
+    #[test]
+    fn resolve_colors_falls_through_to_the_fab_theme_per_field() {
+        let mut theme = ThemeData::light();
+        let themed_background = Color::rgb(1, 2, 3);
+        theme.floating_action_button_theme = Some(crate::theme_data::FabThemeData {
+            background_color: Some(themed_background),
+            elevation: Some(30.0),
+            ..Default::default()
+        });
+
+        let resolved = resolve_colors(&theme);
+
+        assert_eq!(resolved.background_color, themed_background);
+        assert_eq!(resolved.elevation, 30.0);
+        // `foreground_color` was left unset on the theme slot — falls
+        // through to its own M3 default independently.
+        assert_eq!(
+            resolved.foreground_color,
+            theme.color_scheme.on_primary_container
+        );
     }
 }

--- a/crates/flui-material/src/icon_button.rs
+++ b/crates/flui-material/src/icon_button.rs
@@ -87,6 +87,25 @@
 //! (`24.0`); no per-call override exists yet (`IconButton::icon_size` is a
 //! natural, additive V1+ follow-up).
 //!
+//! **This divergence extends verbatim to the theme tier
+//! (`icon_button_theme`).** `theme_style`'s `foreground_color` is folded
+//! into the SAME `resolve_property` call as `self.style`'s, against the
+//! SAME static `disabled`-only snapshot — so a
+//! `Theme.icon_button_theme.style.foreground_color` that varies by
+//! `Pressed`/`Hovered`/`Focused` behaves identically to a state-varying
+//! widget-level override: the live variation reaches
+//! `ButtonStyleButtonCore`'s own `DefaultTextStyle`/`InkWell` (which DO hold
+//! a live, hover/press/focus-tracking `WidgetStatesController` — see
+//! `crate::button_style_button`'s docs) but this icon's `IconTheme` only
+//! ever sees the `disabled`/enabled snapshot, never a live
+//! `Pressed`/`Hovered`/`Focused` re-resolution. Fixing this for real means
+//! sharing `ButtonStyleButtonCoreState`'s own `WidgetStatesController` with
+//! this icon color resolution — that controller is private to
+//! `button_style_button.rs` and created inside `ButtonStyleButtonCore`'s
+//! `create_state`, one layer below where `IconButton::build` runs, so there
+//! is no live states seam to read from at this call site today. A named
+//! divergence, not silently dropped, same as the widget-tier case above.
+//!
 //! # Deferred, and named
 //!
 //! - **`filled`/`filled_tonal`/`outlined` variants** — each is a distinct

--- a/crates/flui-material/src/icon_button.rs
+++ b/crates/flui-material/src/icon_button.rs
@@ -181,6 +181,12 @@ impl StatelessView for IconButton {
     fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
         let theme = Theme::of(ctx);
         let default = default_style(&theme);
+        // Middle cascade tier — see `crate::elevated_button`'s identical
+        // "simplified from `ElevatedButtonTheme.of`" note.
+        let theme_style = theme
+            .icon_button_theme
+            .as_ref()
+            .and_then(|t| t.style.clone());
 
         // A static enabled-or-disabled snapshot — see the module docs'
         // "Icon color and size" section for why that's sufficient for
@@ -191,19 +197,23 @@ impl StatelessView for IconButton {
             WidgetStates::from(WidgetState::Disabled)
         };
 
-        // The SAME widget-then-default coalesce `ButtonStyleButtonCore`
-        // performs internally (`resolve_property`) — computed here too so a
-        // caller's `.style(ButtonStyle { foreground_color: .. })` override
-        // reaches the icon's `IconTheme`, not just `DefaultTextStyle`. The
-        // `unwrap_or` fallback is unreachable in practice: `default_style`
-        // always sets `foreground_color`, so the coalesce always resolves
-        // `Some` — kept only because `resolve_property` returns `Option`.
+        // The SAME widget-then-theme-then-default coalesce
+        // `ButtonStyleButtonCore` performs internally (`resolve_property`)
+        // — computed here too so a caller's `.style(ButtonStyle {
+        // foreground_color: .. })` override, OR a theme-configured
+        // `icon_button_theme`, reaches the icon's `IconTheme`, not just
+        // `DefaultTextStyle`. The `unwrap_or` fallback is unreachable in
+        // practice: `default_style` always sets `foreground_color`, so the
+        // coalesce always resolves `Some` — kept only because
+        // `resolve_property` returns `Option`.
         let icon_color = resolve_property(
             &states,
             self.style
                 .as_ref()
                 .and_then(|style| style.foreground_color.as_ref()),
-            None,
+            theme_style
+                .as_ref()
+                .and_then(|style| style.foreground_color.as_ref()),
             default.foreground_color.as_ref(),
         )
         .unwrap_or(Color::TRANSPARENT);
@@ -219,6 +229,9 @@ impl StatelessView for IconButton {
 
         let mut core = ButtonStyleButtonCore::new(default, themed_icon.boxed())
             .style(self.style.clone().unwrap_or_default());
+        if let Some(theme_style) = theme_style {
+            core = core.theme_style(theme_style);
+        }
         if let Some(on_pressed) = self.on_pressed.clone() {
             core = core.on_pressed(on_pressed);
         }

--- a/crates/flui-material/src/lib.rs
+++ b/crates/flui-material/src/lib.rs
@@ -32,9 +32,15 @@
 //!
 //! - [`ColorScheme::fromSeed`](https://api.flutter.dev/flutter/material/ColorScheme/ColorScheme.fromSeed.html)
 //!   — dynamic-color generation from a seed. See [`color_scheme`] module docs.
-//! - Component themes (`ButtonThemeData`, `InputDecorationTheme`, …) — these
-//!   land with their owning components; [`ThemeData`] is `#[non_exhaustive]`
-//!   to receive them without a breaking change.
+//! - Component themes for widgets that don't exist yet (`InputDecorationTheme`
+//!   and friends) — the button family's, `AppBar`'s, `Card`'s, `Dialog`'s,
+//!   and `FloatingActionButton`'s own theme slots (`ElevatedButtonThemeData`
+//!   and friends, [`AppBarThemeData`], [`CardThemeData`], [`DialogThemeData`],
+//!   [`FabThemeData`]) have landed, each narrowed to the fields its owning
+//!   widget actually consumes — see `theme_data`'s module docs and each
+//!   type's own doc comment for the ported/deferred field split.
+//!   [`ThemeData`] stays `#[non_exhaustive]` to receive the rest without a
+//!   breaking change.
 //! - `AnimatedTheme` / `ColorScheme`/`TextTheme` lerp — no component consumes
 //!   an interpolated theme yet.
 //! - Dense/tall type-scale geometries (CJK / Farsi-Hindi-Thai) — only
@@ -97,5 +103,9 @@ pub use shape::MaterialShape;
 pub use text_button::TextButton;
 pub use text_theme::TextTheme;
 pub use theme::Theme;
-pub use theme_data::{ThemeData, ThemeDataOverrides};
+pub use theme_data::{
+    AppBarThemeData, CardThemeData, DialogThemeData, ElevatedButtonThemeData, FabThemeData,
+    FilledButtonThemeData, IconButtonThemeData, OutlinedButtonThemeData, TextButtonThemeData,
+    ThemeData, ThemeDataOverrides,
+};
 pub use typography::english_like_2021;

--- a/crates/flui-material/src/outlined_button.rs
+++ b/crates/flui-material/src/outlined_button.rs
@@ -91,6 +91,15 @@ impl StatelessView for OutlinedButton {
         let theme = Theme::of(ctx);
         let mut core = ButtonStyleButtonCore::new(default_style(&theme), self.child.clone())
             .style(self.style.clone().unwrap_or_default());
+        // Middle cascade tier — see `crate::elevated_button`'s identical
+        // "simplified from `ElevatedButtonTheme.of`" note.
+        if let Some(theme_style) = theme
+            .outlined_button_theme
+            .as_ref()
+            .and_then(|t| t.style.clone())
+        {
+            core = core.theme_style(theme_style);
+        }
         if let Some(on_pressed) = self.on_pressed.clone() {
             core = core.on_pressed(on_pressed);
         }

--- a/crates/flui-material/src/text_button.rs
+++ b/crates/flui-material/src/text_button.rs
@@ -91,6 +91,15 @@ impl StatelessView for TextButton {
         let theme = Theme::of(ctx);
         let mut core = ButtonStyleButtonCore::new(default_style(&theme), self.child.clone())
             .style(self.style.clone().unwrap_or_default());
+        // Middle cascade tier — see `crate::elevated_button`'s identical
+        // "simplified from `ElevatedButtonTheme.of`" note.
+        if let Some(theme_style) = theme
+            .text_button_theme
+            .as_ref()
+            .and_then(|t| t.style.clone())
+        {
+            core = core.theme_style(theme_style);
+        }
         if let Some(on_pressed) = self.on_pressed.clone() {
             core = core.on_pressed(on_pressed);
         }

--- a/crates/flui-material/src/theme_data.rs
+++ b/crates/flui-material/src/theme_data.rs
@@ -184,7 +184,11 @@ pub struct CardThemeData {
 /// title), [`content_text_style`](Self::content_text_style) (`AlertDialog`'s
 /// content). Named deferrals (no consumer yet): `shadow_color`,
 /// `surface_tint_color`, `alignment`, `icon_color`, `actions_padding`,
-/// `barrier_color`, `inset_padding`, `clip_behavior`.
+/// `barrier_color`, `inset_padding`, `clip_behavior`, `constraints` (the
+/// oracle's own `Dialog.build` reads `constraints ?? dialogTheme.constraints
+/// ?? const BoxConstraints(minWidth: 280.0)` — FLUI's `Dialog` has a widget
+/// tier for this via [`Dialog::constraints`](crate::Dialog::constraints) but
+/// no theme tier yet).
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct DialogThemeData {
     /// Overrides [`Dialog`](crate::Dialog)'s default background color

--- a/crates/flui-material/src/theme_data.rs
+++ b/crates/flui-material/src/theme_data.rs
@@ -3,10 +3,14 @@
 //! Flutter parity: `material/theme_data.dart` `ThemeData` (oracle tag
 //! `3.44.0`).
 
+use flui_types::EdgeInsets;
 use flui_types::platform::Brightness;
 use flui_types::styling::Color;
+use flui_types::typography::TextStyle;
 
+use crate::button_style::ButtonStyle;
 use crate::color_scheme::ColorScheme;
+use crate::shape::MaterialShape;
 use crate::text_theme::TextTheme;
 use crate::typography;
 
@@ -46,20 +50,209 @@ fn default_text_theme(brightness: Brightness, on_surface: Color) -> TextTheme {
     geometry.merge(&color_theme.apply_color(on_surface))
 }
 
+/// Overrides [`ElevatedButton`](crate::ElevatedButton)'s default
+/// [`ButtonStyle`], resolved between the widget's own `style` and
+/// `ElevatedButton::default_style` — see
+/// `crate::button_style_button`'s resolve-then-coalesce docs for how this
+/// slot's `style` participates in the three-tier cascade.
+///
+/// Flutter parity: `ElevatedButtonThemeData` (`material/elevated_button_theme.dart`,
+/// oracle tag `3.44.0`), which carries the identical single `style` field.
+/// **Named reduction**: the oracle also has a standalone `ElevatedButtonTheme`
+/// `InheritedTheme` widget (so a subtree can override the style without
+/// touching the whole [`ThemeData`]); FLUI V1 has no per-widget
+/// `InheritedTheme` wrappers yet, so `ElevatedButton` reads only this
+/// [`ThemeData`] slot via [`Theme::of`](crate::Theme::of).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ElevatedButtonThemeData {
+    /// Overrides for [`ElevatedButton`](crate::ElevatedButton)'s default
+    /// style. `None` means this theme doesn't override anything.
+    pub style: Option<ButtonStyle>,
+}
+
+/// Overrides [`FilledButton`](crate::FilledButton)'s default [`ButtonStyle`]
+/// (both the plain and `tonal` variants share this one slot, matching the
+/// oracle). Flutter parity: `FilledButtonThemeData`
+/// (`material/filled_button_theme.dart`, oracle tag `3.44.0`) — same named
+/// reduction as [`ElevatedButtonThemeData`] (no standalone `InheritedTheme`
+/// wrapper yet).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct FilledButtonThemeData {
+    /// Overrides for [`FilledButton`](crate::FilledButton)'s default style.
+    /// `None` means this theme doesn't override anything.
+    pub style: Option<ButtonStyle>,
+}
+
+/// Overrides [`OutlinedButton`](crate::OutlinedButton)'s default
+/// [`ButtonStyle`]. Flutter parity: `OutlinedButtonThemeData`
+/// (`material/outlined_button_theme.dart`, oracle tag `3.44.0`) — same named
+/// reduction as [`ElevatedButtonThemeData`].
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct OutlinedButtonThemeData {
+    /// Overrides for [`OutlinedButton`](crate::OutlinedButton)'s default
+    /// style. `None` means this theme doesn't override anything.
+    pub style: Option<ButtonStyle>,
+}
+
+/// Overrides [`TextButton`](crate::TextButton)'s default [`ButtonStyle`].
+/// Flutter parity: `TextButtonThemeData` (`material/text_button_theme.dart`,
+/// oracle tag `3.44.0`) — same named reduction as [`ElevatedButtonThemeData`].
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TextButtonThemeData {
+    /// Overrides for [`TextButton`](crate::TextButton)'s default style.
+    /// `None` means this theme doesn't override anything.
+    pub style: Option<ButtonStyle>,
+}
+
+/// Overrides [`IconButton`](crate::IconButton)'s default [`ButtonStyle`].
+/// Flutter parity: `IconButtonThemeData` (`material/icon_button_theme.dart`,
+/// oracle tag `3.44.0`) — same named reduction as [`ElevatedButtonThemeData`].
+/// Not to be confused with [`flui_widgets::IconThemeData`], which colors an
+/// `Icon` child, not an `IconButton`'s own resolved `ButtonStyle`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct IconButtonThemeData {
+    /// Overrides for [`IconButton`](crate::IconButton)'s default style.
+    /// `None` means this theme doesn't override anything.
+    pub style: Option<ButtonStyle>,
+}
+
+/// Overrides [`AppBar`](crate::AppBar)'s M3 token defaults, one field at a
+/// time — an unset field here still falls through to `AppBar`'s own default
+/// (see that type's `resolve_style`), it does not blank the whole slot.
+///
+/// Flutter parity: `AppBarThemeData` (`material/app_bar_theme.dart`, oracle
+/// tag `3.44.0`), narrowed to the fields FLUI's `AppBar` actually consumes:
+/// [`background_color`](Self::background_color),
+/// [`foreground_color`](Self::foreground_color),
+/// [`elevation`](Self::elevation), [`title_text_style`](Self::title_text_style).
+/// Named deferrals (no consumer in FLUI's `AppBar` yet, so a field here would
+/// have nothing to reach): `scrolled_under_elevation`, `shadow_color`,
+/// `surface_tint_color`, `shape`, `icon_theme`/`actions_icon_theme`,
+/// `center_title`, `title_spacing`, `leading_width`, `toolbar_height`,
+/// `toolbar_text_style`, `system_overlay_style`, `actions_padding`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct AppBarThemeData {
+    /// Overrides [`AppBar`](crate::AppBar)'s default background color
+    /// (`ColorScheme.surface`).
+    pub background_color: Option<Color>,
+    /// Overrides [`AppBar`](crate::AppBar)'s default icon/title color
+    /// (`ColorScheme.on_surface`).
+    pub foreground_color: Option<Color>,
+    /// Overrides [`AppBar`](crate::AppBar)'s default elevation (`0.0`).
+    pub elevation: Option<f32>,
+    /// Overrides the title's text style verbatim — Flutter parity:
+    /// `widget.titleTextStyle ?? appBarTheme.titleTextStyle ??
+    /// defaults.titleTextStyle?.copyWith(color: foregroundColor)`
+    /// (`app_bar.dart`, oracle tag `3.44.0`): unlike the default tier, a
+    /// theme-supplied style is used as-is, not recolored to the resolved
+    /// [`foreground_color`](Self::foreground_color).
+    pub title_text_style: Option<TextStyle>,
+}
+
+/// Overrides [`Card`](crate::Card)'s `_CardDefaultsM3` token defaults, one
+/// field at a time.
+///
+/// Flutter parity: `CardThemeData` (`material/card_theme.dart`, oracle tag
+/// `3.44.0`), narrowed to the fields FLUI's `Card` actually consumes:
+/// [`color`](Self::color), [`elevation`](Self::elevation),
+/// [`shape`](Self::shape), [`margin`](Self::margin). Named deferrals (no
+/// consumer in FLUI's `Card` yet): `shadow_color`, `surface_tint_color`,
+/// `clip_behavior`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct CardThemeData {
+    /// Overrides [`Card`](crate::Card)'s default fill color
+    /// (`ColorScheme.surfaceContainerLow`).
+    pub color: Option<Color>,
+    /// Overrides [`Card`](crate::Card)'s default elevation (`1.0`).
+    pub elevation: Option<f32>,
+    /// Overrides [`Card`](crate::Card)'s default shape (a 12dp rounded
+    /// rectangle).
+    pub shape: Option<MaterialShape>,
+    /// Overrides [`Card`](crate::Card)'s default outer margin
+    /// (`EdgeInsets.all(4.0)`).
+    pub margin: Option<EdgeInsets>,
+}
+
+/// Overrides [`Dialog`](crate::Dialog)/[`AlertDialog`](crate::AlertDialog)'s
+/// `_DialogDefaultsM3` token defaults, one field at a time.
+///
+/// Flutter parity: `DialogThemeData` (`material/dialog_theme.dart`, oracle
+/// tag `3.44.0`), narrowed to the fields FLUI's `Dialog`/`AlertDialog`
+/// actually consume: [`background_color`](Self::background_color) (`Dialog`),
+/// [`elevation`](Self::elevation) (`Dialog`), [`shape`](Self::shape)
+/// (`Dialog`), [`title_text_style`](Self::title_text_style) (`AlertDialog`'s
+/// title), [`content_text_style`](Self::content_text_style) (`AlertDialog`'s
+/// content). Named deferrals (no consumer yet): `shadow_color`,
+/// `surface_tint_color`, `alignment`, `icon_color`, `actions_padding`,
+/// `barrier_color`, `inset_padding`, `clip_behavior`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct DialogThemeData {
+    /// Overrides [`Dialog`](crate::Dialog)'s default background color
+    /// (`ColorScheme.surfaceContainerHigh`).
+    pub background_color: Option<Color>,
+    /// Overrides [`Dialog`](crate::Dialog)'s default elevation (`6.0`).
+    pub elevation: Option<f32>,
+    /// Overrides [`Dialog`](crate::Dialog)'s default shape (a 28dp rounded
+    /// rectangle).
+    pub shape: Option<MaterialShape>,
+    /// Overrides [`AlertDialog`](crate::AlertDialog)'s title text style
+    /// (default: `TextTheme.headlineSmall`).
+    pub title_text_style: Option<TextStyle>,
+    /// Overrides [`AlertDialog`](crate::AlertDialog)'s content text style
+    /// (default: `TextTheme.bodyMedium`).
+    pub content_text_style: Option<TextStyle>,
+}
+
+/// Overrides [`FloatingActionButton`](crate::FloatingActionButton)'s
+/// `_FABDefaultsM3` token defaults, one field at a time.
+///
+/// Flutter parity: `FloatingActionButtonThemeData`
+/// (`material/floating_action_button_theme.dart`, oracle tag `3.44.0`),
+/// narrowed to the fields FLUI's `FloatingActionButton` actually consumes:
+/// [`background_color`](Self::background_color),
+/// [`foreground_color`](Self::foreground_color),
+/// [`elevation`](Self::elevation) (the enabled/disabled tier — see
+/// `floating_action_button.rs`'s `resolve_elevation`). Named deferrals (no
+/// override surface in FLUI's `FloatingActionButton` yet, matching that
+/// module's own deferred list): `focus_color`/`hover_color`/`splash_color`,
+/// `focus_elevation`/`hover_elevation`/`disabled_elevation`/
+/// `highlight_elevation`, `shape`, `enable_feedback`, `icon_size`, every
+/// `*_size_constraints` field, the `extended*` fields, `mouse_cursor`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct FabThemeData {
+    /// Overrides [`FloatingActionButton`](crate::FloatingActionButton)'s
+    /// default background color (`ColorScheme.primaryContainer`).
+    pub background_color: Option<Color>,
+    /// Overrides [`FloatingActionButton`](crate::FloatingActionButton)'s
+    /// default foreground/icon color (`ColorScheme.onPrimaryContainer`).
+    pub foreground_color: Option<Color>,
+    /// Overrides [`FloatingActionButton`](crate::FloatingActionButton)'s
+    /// enabled-tier elevation (`6.0`) — the same value the `disabled` tier
+    /// falls back to (see `resolve_elevation`'s doc comment); the
+    /// `pressed`/`hovered`/`focused` tiers are unaffected, matching the
+    /// oracle's own independent `highlightElevation`/`hoverElevation`/
+    /// `focusElevation` fields (this crate exposes no override for those).
+    pub elevation: Option<f32>,
+}
+
 /// Visual-style configuration provided to descendants by a
 /// [`Theme`](crate::Theme) ancestor.
 ///
 /// Two ready-made M3 baselines are available: [`ThemeData::light`] and
-/// [`ThemeData::dark`]. `#[non_exhaustive]`: component themes (button, input
-/// decoration, …) land as additional fields alongside their owning widgets,
-/// not in this theming-foundation unit — see the crate root docs' scope
-/// section.
+/// [`ThemeData::dark`]. `#[non_exhaustive]`: further component themes (input
+/// decoration and any future widget's own slot) land as additional fields
+/// alongside their owning widgets, not in this theming-foundation unit — see
+/// the crate root docs' scope section.
 ///
 /// Flutter parity: `ThemeData` (`material/theme_data.dart`, oracle tag
-/// `3.44.0`) — implemented subset: [`color_scheme`](Self::color_scheme) and
-/// [`text_theme`](Self::text_theme). Deferred: component theme slots,
-/// `iconTheme`, `extensions`, `platform`, `useMaterial3` (this crate is
-/// M3-only — there is no M2 mode to switch away from).
+/// `3.44.0`) — implemented subset: [`color_scheme`](Self::color_scheme),
+/// [`text_theme`](Self::text_theme), and the button-family/`AppBar`/`Card`/
+/// `Dialog`/`FloatingActionButton` component-theme slots below (each
+/// narrowed to its owning widget's actually-consumed fields — see that
+/// slot's own doc comment). Deferred: `iconTheme`, `extensions`, `platform`,
+/// `useMaterial3` (this crate is M3-only — there is no M2 mode to switch
+/// away from), and every other widget's component theme (`inputDecorationTheme`
+/// and friends) until that widget lands.
 ///
 /// # Example
 ///
@@ -81,6 +274,45 @@ pub struct ThemeData {
     ///
     /// Flutter parity: `ThemeData.textTheme`.
     pub text_theme: TextTheme,
+
+    /// Overrides [`ElevatedButton`](crate::ElevatedButton)'s default style.
+    /// `None` (the default): no override, `ElevatedButton` uses its own
+    /// M3 token table verbatim. Flutter parity:
+    /// `ThemeData.elevatedButtonTheme`.
+    pub elevated_button_theme: Option<ElevatedButtonThemeData>,
+
+    /// Overrides [`FilledButton`](crate::FilledButton)'s default style.
+    /// Flutter parity: `ThemeData.filledButtonTheme`.
+    pub filled_button_theme: Option<FilledButtonThemeData>,
+
+    /// Overrides [`OutlinedButton`](crate::OutlinedButton)'s default style.
+    /// Flutter parity: `ThemeData.outlinedButtonTheme`.
+    pub outlined_button_theme: Option<OutlinedButtonThemeData>,
+
+    /// Overrides [`TextButton`](crate::TextButton)'s default style. Flutter
+    /// parity: `ThemeData.textButtonTheme`.
+    pub text_button_theme: Option<TextButtonThemeData>,
+
+    /// Overrides [`IconButton`](crate::IconButton)'s default style. Flutter
+    /// parity: `ThemeData.iconButtonTheme`.
+    pub icon_button_theme: Option<IconButtonThemeData>,
+
+    /// Overrides [`AppBar`](crate::AppBar)'s M3 token defaults, per field.
+    /// Flutter parity: `ThemeData.appBarTheme`.
+    pub app_bar_theme: Option<AppBarThemeData>,
+
+    /// Overrides [`Card`](crate::Card)'s M3 token defaults, per field.
+    /// Flutter parity: `ThemeData.cardTheme`.
+    pub card_theme: Option<CardThemeData>,
+
+    /// Overrides [`Dialog`](crate::Dialog)/[`AlertDialog`](crate::AlertDialog)'s
+    /// M3 token defaults, per field. Flutter parity: `ThemeData.dialogTheme`.
+    pub dialog_theme: Option<DialogThemeData>,
+
+    /// Overrides [`FloatingActionButton`](crate::FloatingActionButton)'s M3
+    /// token defaults, per field. Flutter parity:
+    /// `ThemeData.floatingActionButtonTheme`.
+    pub floating_action_button_theme: Option<FabThemeData>,
 }
 
 impl ThemeData {
@@ -93,6 +325,15 @@ impl ThemeData {
         Self {
             color_scheme,
             text_theme,
+            elevated_button_theme: None,
+            filled_button_theme: None,
+            outlined_button_theme: None,
+            text_button_theme: None,
+            icon_button_theme: None,
+            app_bar_theme: None,
+            card_theme: None,
+            dialog_theme: None,
+            floating_action_button_theme: None,
         }
     }
 
@@ -105,6 +346,15 @@ impl ThemeData {
         Self {
             color_scheme,
             text_theme,
+            elevated_button_theme: None,
+            filled_button_theme: None,
+            outlined_button_theme: None,
+            text_button_theme: None,
+            icon_button_theme: None,
+            app_bar_theme: None,
+            card_theme: None,
+            dialog_theme: None,
+            floating_action_button_theme: None,
         }
     }
 
@@ -152,6 +402,35 @@ impl ThemeData {
             text_theme: overrides
                 .text_theme
                 .unwrap_or_else(|| self.text_theme.clone()),
+            // Each component-theme slot is itself already `Option<_>` on
+            // `ThemeData`, so — unlike `color_scheme`/`text_theme` above —
+            // the override field mirrors that `Option<_>` shape directly
+            // rather than doubling it: `Some(_)` replaces the whole slot,
+            // `None` leaves whatever this theme already had (`Some` or
+            // `None`) unchanged. See `ThemeDataOverrides`'s doc comment.
+            elevated_button_theme: overrides
+                .elevated_button_theme
+                .or_else(|| self.elevated_button_theme.clone()),
+            filled_button_theme: overrides
+                .filled_button_theme
+                .or_else(|| self.filled_button_theme.clone()),
+            outlined_button_theme: overrides
+                .outlined_button_theme
+                .or_else(|| self.outlined_button_theme.clone()),
+            text_button_theme: overrides
+                .text_button_theme
+                .or_else(|| self.text_button_theme.clone()),
+            icon_button_theme: overrides
+                .icon_button_theme
+                .or_else(|| self.icon_button_theme.clone()),
+            app_bar_theme: overrides
+                .app_bar_theme
+                .or_else(|| self.app_bar_theme.clone()),
+            card_theme: overrides.card_theme.or_else(|| self.card_theme.clone()),
+            dialog_theme: overrides.dialog_theme.or_else(|| self.dialog_theme.clone()),
+            floating_action_button_theme: overrides
+                .floating_action_button_theme
+                .or_else(|| self.floating_action_button_theme.clone()),
         }
     }
 }
@@ -176,6 +455,28 @@ pub struct ThemeDataOverrides {
     pub color_scheme: Option<ColorScheme>,
     /// Overrides [`ThemeData::text_theme`].
     pub text_theme: Option<TextTheme>,
+    /// Replaces [`ThemeData::elevated_button_theme`] wholesale when `Some`;
+    /// `None` leaves it unchanged (see [`ThemeData::copy_with`]'s doc
+    /// comment on why this mirrors `Option<ElevatedButtonThemeData>`
+    /// directly rather than doubling the `Option`).
+    pub elevated_button_theme: Option<ElevatedButtonThemeData>,
+    /// Replaces [`ThemeData::filled_button_theme`] wholesale when `Some`.
+    pub filled_button_theme: Option<FilledButtonThemeData>,
+    /// Replaces [`ThemeData::outlined_button_theme`] wholesale when `Some`.
+    pub outlined_button_theme: Option<OutlinedButtonThemeData>,
+    /// Replaces [`ThemeData::text_button_theme`] wholesale when `Some`.
+    pub text_button_theme: Option<TextButtonThemeData>,
+    /// Replaces [`ThemeData::icon_button_theme`] wholesale when `Some`.
+    pub icon_button_theme: Option<IconButtonThemeData>,
+    /// Replaces [`ThemeData::app_bar_theme`] wholesale when `Some`.
+    pub app_bar_theme: Option<AppBarThemeData>,
+    /// Replaces [`ThemeData::card_theme`] wholesale when `Some`.
+    pub card_theme: Option<CardThemeData>,
+    /// Replaces [`ThemeData::dialog_theme`] wholesale when `Some`.
+    pub dialog_theme: Option<DialogThemeData>,
+    /// Replaces [`ThemeData::floating_action_button_theme`] wholesale when
+    /// `Some`.
+    pub floating_action_button_theme: Option<FabThemeData>,
 }
 
 impl Default for ThemeData {
@@ -262,5 +563,64 @@ mod tests {
     fn copy_with_no_overrides_is_identity() {
         let base = ThemeData::dark();
         assert_eq!(base.copy_with(ThemeDataOverrides::default()), base);
+    }
+
+    #[test]
+    fn light_and_dark_leave_every_component_theme_slot_unset() {
+        for theme in [ThemeData::light(), ThemeData::dark()] {
+            assert!(theme.elevated_button_theme.is_none());
+            assert!(theme.filled_button_theme.is_none());
+            assert!(theme.outlined_button_theme.is_none());
+            assert!(theme.text_button_theme.is_none());
+            assert!(theme.icon_button_theme.is_none());
+            assert!(theme.app_bar_theme.is_none());
+            assert!(theme.card_theme.is_none());
+            assert!(theme.dialog_theme.is_none());
+            assert!(theme.floating_action_button_theme.is_none());
+        }
+    }
+
+    #[test]
+    fn copy_with_sets_the_new_component_theme_slots() {
+        let base = ThemeData::light();
+        let elevated_button_theme = ElevatedButtonThemeData {
+            style: Some(ButtonStyle {
+                elevation: Some(flui_widgets::WidgetStateProperty::all(Some(42.0))),
+                ..Default::default()
+            }),
+        };
+        let app_bar_theme = AppBarThemeData {
+            elevation: Some(9.0),
+            ..Default::default()
+        };
+
+        let patched = base.copy_with(ThemeDataOverrides {
+            elevated_button_theme: Some(elevated_button_theme.clone()),
+            app_bar_theme: Some(app_bar_theme.clone()),
+            ..Default::default()
+        });
+
+        assert_eq!(patched.elevated_button_theme, Some(elevated_button_theme));
+        assert_eq!(patched.app_bar_theme, Some(app_bar_theme));
+        // Untouched slots stay unset, mirroring the base theme.
+        assert!(patched.card_theme.is_none());
+    }
+
+    /// `None` in the override leaves an ALREADY-SET slot alone — it must not
+    /// be read as "clear this slot back to `None`" (see `copy_with`'s doc
+    /// comment on why the override field mirrors `Option<T>` directly).
+    #[test]
+    fn copy_with_none_preserves_an_already_set_component_theme_slot() {
+        let card_theme = CardThemeData {
+            elevation: Some(3.0),
+            ..Default::default()
+        };
+        let base = ThemeData::light().copy_with(ThemeDataOverrides {
+            card_theme: Some(card_theme.clone()),
+            ..Default::default()
+        });
+
+        let patched = base.copy_with(ThemeDataOverrides::default());
+        assert_eq!(patched.card_theme, Some(card_theme));
     }
 }

--- a/crates/flui-material/tests/app_bar.rs
+++ b/crates/flui-material/tests/app_bar.rs
@@ -168,6 +168,97 @@ fn app_bar_theme_slot_reaches_the_mounted_materials_background_color() {
     );
 }
 
+/// Regression guard for a real bug: a theme-configured `title_text_style`
+/// must style ONLY `AppBar::title`, never leak onto other toolbar children
+/// (`leading`/`actions`) — Flutter parity: `titleTextStyle` styles the title
+/// widget specifically (`app_bar.dart`, oracle tag `3.44.0`), not the whole
+/// `NavigationToolbar`. Before the fix, `resolve_style`'s `title_style` fed
+/// the OUTER `DefaultTextStyle` wrapping the entire toolbar, so a bare
+/// `Text` action inherited the themed title style too.
+///
+/// Proven via measured height, not a `TextStyle` equality check — an
+/// ambient style change only visibly reaches a bare `Text` run through
+/// re-layout, so this is the mutation-honest way to prove the scoping
+/// (see `flui-widgets/tests/text.rs`'s identical
+/// `a_larger_font_size_measures_to_a_taller_box` technique).
+#[test]
+fn themed_title_text_style_does_not_leak_into_toolbar_actions() {
+    use flui_types::typography::TextStyle;
+    use flui_widgets::DefaultTextStyle;
+
+    let themed_font_size = 40.0;
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        app_bar_theme: Some(AppBarThemeData {
+            title_text_style: Some(TextStyle {
+                font_size: Some(themed_font_size),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    // Reference heights for the SAME text under each ambient style in
+    // isolation — what the action's Text SHOULD measure as (the unthemed
+    // toolbar ambient) vs. what it WOULD measure as if the bug were still
+    // present (the themed title style leaking in).
+    let default_ambient = theme.text_theme.title_large.clone().unwrap_or_default();
+    let default_reference = lay_out(
+        DefaultTextStyle::new(default_ambient, Text::new("Action")),
+        loose(1000.0),
+    );
+    let themed_reference = lay_out(
+        DefaultTextStyle::new(
+            TextStyle {
+                font_size: Some(themed_font_size),
+                ..Default::default()
+            },
+            Text::new("Action"),
+        ),
+        loose(1000.0),
+    );
+    let default_height = default_reference.size(default_reference.root()).height;
+    let themed_height = themed_reference.size(themed_reference.root()).height;
+    assert_ne!(
+        default_height, themed_height,
+        "the themed font_size must measure differently from the default — otherwise this test \
+         cannot distinguish a leak from no leak",
+    );
+
+    let laid = lay_out(
+        Theme::new(
+            theme,
+            MediaQuery::new(
+                MediaQueryData::default(),
+                AppBar::new()
+                    .title(Text::new("Title"))
+                    .actions(vec![Text::new("Action").boxed()]),
+            ),
+        ),
+        loose(400.0),
+    );
+
+    let paragraphs = laid.find_all_by_render_type("RenderParagraph");
+    assert_eq!(
+        paragraphs.len(),
+        2,
+        "expected exactly one title Text and one action Text"
+    );
+    let heights: Vec<_> = paragraphs.iter().map(|id| laid.size(*id).height).collect();
+
+    assert!(
+        heights.contains(&themed_height),
+        "the title's Text must measure at the THEMED font_size — the theme's \
+         title_text_style must reach the title slot",
+    );
+    assert!(
+        heights.contains(&default_height),
+        "the action's Text must measure at the DEFAULT (unthemed) toolbar ambient, NOT the \
+         theme's title_text_style — a themed title style must not leak into other toolbar \
+         children",
+    );
+}
+
 /// Flutter parity: `_AppBarState.build` wraps `leading` in
 /// `ConstrainedBox(BoxConstraints.tightFor(width: _kLeadingWidth))` — a
 /// fixed 56px-wide slot, independent of whatever the leading widget's own

--- a/crates/flui-material/tests/app_bar.rs
+++ b/crates/flui-material/tests/app_bar.rs
@@ -10,7 +10,7 @@
 mod common;
 
 use common::{lay_out, loose, tight};
-use flui_material::{AppBar, Theme, ThemeData};
+use flui_material::{AppBar, AppBarThemeData, Theme, ThemeData, ThemeDataOverrides};
 use flui_types::EdgeInsets;
 use flui_types::geometry::px;
 use flui_view::prelude::*;
@@ -130,6 +130,41 @@ fn background_color_override_replaces_the_theme_default() {
         laid.render_property(material, "color"),
         Some(color_property(overridden)),
         "an explicit background_color must win over the theme default",
+    );
+}
+
+/// The middle cascade tier, proven end to end: a `ThemeData.app_bar_theme`
+/// with a custom `background_color` reaches the mounted `Material`, with no
+/// widget-level `background_color` in the way.
+#[test]
+fn app_bar_theme_slot_reaches_the_mounted_materials_background_color() {
+    let themed_background = flui_types::Color::rgb(44, 55, 66);
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        app_bar_theme: Some(AppBarThemeData {
+            background_color: Some(themed_background),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    let laid = lay_out(
+        Theme::new(
+            theme,
+            MediaQuery::new(
+                MediaQueryData::default(),
+                AppBar::new().title(Text::new("Title")),
+            ),
+        ),
+        loose(400.0),
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("AppBar must compose a Material (RenderPhysicalShape) surface");
+    assert_eq!(
+        laid.render_property(material, "color"),
+        Some(color_property(themed_background)),
+        "a configured app_bar_theme.background_color must reach the mounted Material",
     );
 }
 

--- a/crates/flui-material/tests/card.rs
+++ b/crates/flui-material/tests/card.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use common::{lay_out, tight};
-use flui_material::{Card, MaterialShape, Theme, ThemeData};
+use flui_material::{Card, CardThemeData, MaterialShape, Theme, ThemeData, ThemeDataOverrides};
 use flui_types::Color;
 use flui_types::geometry::{Radius, px};
 use flui_types::styling::BorderRadius;
@@ -64,6 +64,42 @@ fn default_material_matches_card_defaults_m3() {
         clip_behavior, "None",
         "_CardDefaultsM3 constructs with clipBehavior: Clip.none"
     );
+}
+
+/// The middle cascade tier, proven end to end: a `ThemeData.card_theme` with
+/// custom `color`/`elevation` reaches the mounted `Material`, per field —
+/// an unset `shape` on the same theme slot must still fall through to the
+/// M3 default independently (proven via `card.rs`'s own unit tests; this
+/// mount only needs to prove the theme tier is reachable at all).
+#[test]
+fn card_theme_slot_reaches_the_mounted_materials_color_and_elevation() {
+    let themed_color = Color::rgb(77, 88, 99);
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        card_theme: Some(CardThemeData {
+            color: Some(themed_color),
+            elevation: Some(15.0),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    let laid = lay_out(
+        Theme::new(theme, Card::new(ColoredBox::new(Color::rgb(1, 2, 3)))),
+        tight(200.0, 200.0),
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("Card must compose a Material surface");
+    assert_eq!(
+        laid.render_property(material, "color"),
+        Some(color_property(themed_color)),
+        "a configured card_theme.color must reach the mounted Material",
+    );
+    let elevation = laid
+        .render_property(material, "elevation")
+        .expect("RenderPhysicalShape reports an \"elevation\" diagnostics property");
+    assert_eq!(elevation.parse::<f32>(), Ok(15.0));
 }
 
 /// `_CardDefaultsM3`'s 12dp corner radius (`card.dart`, oracle tag `3.44.0`),

--- a/crates/flui-material/tests/dialog.rs
+++ b/crates/flui-material/tests/dialog.rs
@@ -8,7 +8,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use common::{lay_out, tight};
-use flui_material::{AlertDialog, Dialog, MaterialShape, Theme, ThemeData};
+use flui_material::{
+    AlertDialog, Dialog, DialogThemeData, MaterialShape, Theme, ThemeData, ThemeDataOverrides,
+};
 use flui_types::Color;
 use flui_types::geometry::{Radius, px};
 use flui_types::styling::BorderRadius;
@@ -65,6 +67,40 @@ fn dialog_material_matches_dialog_defaults_m3() {
         clip_behavior, "None",
         "_DialogDefaultsM3 constructs with clipBehavior: Clip.none"
     );
+}
+
+/// The middle cascade tier, proven end to end: a `ThemeData.dialog_theme`
+/// with a custom `background_color`/`elevation` reaches the mounted
+/// `Material`.
+#[test]
+fn dialog_theme_slot_reaches_the_mounted_materials_color_and_elevation() {
+    let themed_color = Color::rgb(21, 32, 43);
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        dialog_theme: Some(DialogThemeData {
+            background_color: Some(themed_color),
+            elevation: Some(2.0),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    let laid = lay_out(
+        Theme::new(theme, Dialog::new(SizedBox::new(1.0, 1.0))),
+        tight(1000.0, 1000.0),
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("Dialog must compose a Material surface");
+    assert_eq!(
+        laid.render_property(material, "color"),
+        Some(color_property(themed_color)),
+        "a configured dialog_theme.background_color must reach the mounted Material",
+    );
+    let elevation = laid
+        .render_property(material, "elevation")
+        .expect("RenderPhysicalShape reports an \"elevation\" diagnostics property");
+    assert_eq!(elevation.parse::<f32>(), Ok(2.0));
 }
 
 /// `Dialog.build`'s fallback `constraints` (`BoxConstraints(minWidth:

--- a/crates/flui-material/tests/elevated_button.rs
+++ b/crates/flui-material/tests/elevated_button.rs
@@ -20,8 +20,10 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use common::{lay_out, tight};
-use flui_material::{ElevatedButton, Theme, ThemeData};
-use flui_widgets::Text;
+use flui_material::{
+    ButtonStyle, ElevatedButton, ElevatedButtonThemeData, Theme, ThemeData, ThemeDataOverrides,
+};
+use flui_widgets::{Text, WidgetStateProperty};
 
 /// `_ElevatedButtonDefaultsM3`'s formatted `Debug` string for a given
 /// resolved [`Color`](flui_types::Color) — what `RenderPhysicalShape`'s
@@ -181,5 +183,84 @@ fn did_update_view_resyncs_disabled_when_the_press_handler_is_removed() {
         color_property(colors.on_surface.with_opacity(0.12)),
         "removing the press handler must re-sync WidgetState::Disabled via did_update_view, \
          re-resolving the disabled background color",
+    );
+}
+
+/// The middle cascade tier, proven end to end: a `ThemeData.elevated_button_theme`
+/// with a custom `background_color` must reach the mounted `Material`'s
+/// resolved color — this is the wiring `button_style_button.rs`'s
+/// `theme_style` seam exists for; before it was wired, this exact scenario
+/// silently resolved the M3 default instead (`theme_style` was hardcoded
+/// `None` at every call site).
+#[test]
+fn elevated_button_theme_slot_reaches_the_mounted_materials_background_color() {
+    let themed_background = flui_types::Color::rgb(11, 22, 33);
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        elevated_button_theme: Some(ElevatedButtonThemeData {
+            style: Some(ButtonStyle {
+                background_color: Some(WidgetStateProperty::all(Some(themed_background))),
+                ..Default::default()
+            }),
+        }),
+        ..Default::default()
+    });
+
+    let laid = lay_out(
+        Theme::new(
+            theme,
+            ElevatedButton::new(Text::new("Save")).on_pressed(|| {}),
+        ),
+        tight(120.0, 48.0),
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("ElevatedButton must compose a Material surface");
+    assert_eq!(
+        laid.render_property(material, "color"),
+        Some(color_property(themed_background)),
+        "a configured elevated_button_theme.style.background_color must reach the mounted \
+         Material — the middle (theme) tier of the widget/theme/default cascade",
+    );
+}
+
+/// The highest tier still wins over a configured theme: an explicit
+/// `.style(..)` override on the widget itself must resolve over the theme's
+/// `elevated_button_theme`, matching Flutter's own `getProperty(widgetStyle)
+/// ?? getProperty(themeStyle) ?? …` precedence.
+#[test]
+fn widget_level_style_wins_over_the_elevated_button_theme() {
+    let themed_background = flui_types::Color::rgb(1, 1, 1);
+    let widget_background = flui_types::Color::rgb(9, 9, 9);
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        elevated_button_theme: Some(ElevatedButtonThemeData {
+            style: Some(ButtonStyle {
+                background_color: Some(WidgetStateProperty::all(Some(themed_background))),
+                ..Default::default()
+            }),
+        }),
+        ..Default::default()
+    });
+
+    let laid = lay_out(
+        Theme::new(
+            theme,
+            ElevatedButton::new(Text::new("Save"))
+                .on_pressed(|| {})
+                .style(ButtonStyle {
+                    background_color: Some(WidgetStateProperty::all(Some(widget_background))),
+                    ..Default::default()
+                }),
+        ),
+        tight(120.0, 48.0),
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("ElevatedButton must compose a Material surface");
+    assert_eq!(
+        laid.render_property(material, "color"),
+        Some(color_property(widget_background)),
+        "an explicit widget-level style must win over a configured elevated_button_theme",
     );
 }

--- a/crates/flui-material/tests/floating_action_button.rs
+++ b/crates/flui-material/tests/floating_action_button.rs
@@ -13,7 +13,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use common::{lay_out, tight};
-use flui_material::{FloatingActionButton, Scaffold, Theme, ThemeData};
+use flui_material::{
+    FabThemeData, FloatingActionButton, Scaffold, Theme, ThemeData, ThemeDataOverrides,
+};
 use flui_types::EdgeInsets;
 use flui_types::geometry::px;
 use flui_widgets::{MediaQuery, MediaQueryData, SizedBox};
@@ -145,6 +147,47 @@ fn enabled_fab_resolves_the_m3_default_background_and_elevation() {
     assert_eq!(
         laid.render_property(material, "elevation"),
         Some("6".to_string())
+    );
+}
+
+/// The middle cascade tier, proven end to end: a
+/// `ThemeData.floating_action_button_theme` with a custom
+/// `background_color`/`elevation` reaches the mounted `Material` — both the
+/// enabled-default and (per `resolve_elevation`'s doc comment) the disabled
+/// tier of the elevation state chain.
+#[test]
+fn fab_theme_slot_reaches_the_mounted_materials_color_and_elevation() {
+    let themed_background = flui_types::Color::rgb(70, 80, 90);
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        floating_action_button_theme: Some(FabThemeData {
+            background_color: Some(themed_background),
+            elevation: Some(12.0),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    let laid = lay_out(
+        Theme::new(
+            theme,
+            FloatingActionButton::new(Some(|| {}), SizedBox::square(24.0)),
+        ),
+        tight(56.0, 56.0),
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("Material must mount");
+    assert_eq!(
+        laid.render_property(material, "color"),
+        Some(color_property(themed_background)),
+        "a configured floating_action_button_theme.background_color must reach the mounted \
+         Material",
+    );
+    assert_eq!(
+        laid.render_property(material, "elevation"),
+        Some("12".to_string()),
+        "a configured floating_action_button_theme.elevation must reach the enabled tier",
     );
 }
 

--- a/crates/flui-material/tests/floating_action_button.rs
+++ b/crates/flui-material/tests/floating_action_button.rs
@@ -184,9 +184,12 @@ fn fab_theme_slot_reaches_the_mounted_materials_color_and_elevation() {
         "a configured floating_action_button_theme.background_color must reach the mounted \
          Material",
     );
+    let elevation = laid
+        .render_property(material, "elevation")
+        .expect("RenderPhysicalShape reports an \"elevation\" diagnostics property");
     assert_eq!(
-        laid.render_property(material, "elevation"),
-        Some("12".to_string()),
+        elevation.parse::<f32>(),
+        Ok(12.0),
         "a configured floating_action_button_theme.elevation must reach the enabled tier",
     );
 }

--- a/crates/flui-material/tests/icon_button.rs
+++ b/crates/flui-material/tests/icon_button.rs
@@ -21,7 +21,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use common::{lay_out, loose, tight};
-use flui_material::{ButtonStyle, IconButton, Theme, ThemeData};
+use flui_material::{
+    ButtonStyle, IconButton, IconButtonThemeData, Theme, ThemeData, ThemeDataOverrides,
+};
 use flui_types::Color;
 use flui_view::prelude::*;
 use flui_widgets::{IconTheme, IconThemeData, SizedBox, WidgetStateProperty};
@@ -182,6 +184,45 @@ fn enabled_icon_button_resolves_the_on_surface_variant_color_through_the_real_mo
 /// widget-then-default cascade `ButtonStyleButtonCore` performs internally)
 /// before feeding the icon's `IconTheme` — this test mounts exactly that
 /// override and asserts it actually reaches the icon.
+/// The middle cascade tier, proven end to end: a configured
+/// `icon_button_theme.style.foreground_color` must reach the icon's
+/// `IconTheme` — the same coalesce `resolve_property` performs for
+/// `IconButton::build`'s widget-level override (see
+/// `a_style_foreground_color_override_reaches_the_icons_icon_theme` below),
+/// now with a theme-tier value and no widget-level override in the way.
+#[test]
+fn icon_button_theme_slot_reaches_the_icons_icon_theme() {
+    let themed_color = Color::rgb(30, 40, 50);
+    let captured = Rc::new(RefCell::new(None));
+    let probe = IconThemeProbe {
+        captured: Rc::clone(&captured),
+    };
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        icon_button_theme: Some(IconButtonThemeData {
+            style: Some(ButtonStyle {
+                foreground_color: Some(WidgetStateProperty::all(Some(themed_color))),
+                ..Default::default()
+            }),
+        }),
+        ..Default::default()
+    });
+
+    let _laid = lay_out(
+        Theme::new(theme, IconButton::new(probe).on_pressed(|| {})),
+        tight(40.0, 40.0),
+    );
+
+    let resolved = captured
+        .borrow()
+        .clone()
+        .expect("IconThemeProbe must have built at least once");
+    assert_eq!(
+        resolved.color,
+        Some(themed_color),
+        "a configured icon_button_theme.style.foreground_color must reach the icon's IconTheme",
+    );
+}
+
 #[test]
 fn a_style_foreground_color_override_reaches_the_icons_icon_theme() {
     let overridden = Color::rgb(200, 10, 90);

--- a/crates/flui-material/tests/icon_button.rs
+++ b/crates/flui-material/tests/icon_button.rs
@@ -174,16 +174,6 @@ fn enabled_icon_button_resolves_the_on_surface_variant_color_through_the_real_mo
     );
 }
 
-/// The regression this test guards against: a naive port hardcodes
-/// `default_style`'s own foreground table straight into the icon's
-/// `IconTheme`, so a caller's `.style(ButtonStyle { foreground_color: .. })`
-/// override reaches `ButtonStyleButtonCore`'s `DefaultTextStyle` (for a
-/// `Text` child) but silently never reaches an `Icon` child at all — the
-/// override would visibly do nothing. `IconButton::build` instead coalesces
-/// `self.style`'s `foreground_color` with `default_style`'s own (the SAME
-/// widget-then-default cascade `ButtonStyleButtonCore` performs internally)
-/// before feeding the icon's `IconTheme` — this test mounts exactly that
-/// override and asserts it actually reaches the icon.
 /// The middle cascade tier, proven end to end: a configured
 /// `icon_button_theme.style.foreground_color` must reach the icon's
 /// `IconTheme` — the same coalesce `resolve_property` performs for
@@ -220,6 +210,62 @@ fn icon_button_theme_slot_reaches_the_icons_icon_theme() {
         resolved.color,
         Some(themed_color),
         "a configured icon_button_theme.style.foreground_color must reach the icon's IconTheme",
+    );
+}
+
+/// The regression this test guards against: a naive port hardcodes
+/// `default_style`'s own foreground table straight into the icon's
+/// `IconTheme`, so a caller's `.style(ButtonStyle { foreground_color: .. })`
+/// override reaches `ButtonStyleButtonCore`'s `DefaultTextStyle` (for a
+/// `Text` child) but silently never reaches an `Icon` child at all — the
+/// override would visibly do nothing. `IconButton::build` instead coalesces
+/// `self.style`'s `foreground_color` with `default_style`'s own (the SAME
+/// widget-then-default cascade `ButtonStyleButtonCore` performs internally)
+/// before feeding the icon's `IconTheme` — this test mounts exactly that
+/// override and asserts it actually reaches the icon.
+/// `core.theme_style(theme_style)` wiring, isolated from
+/// `IconButton::build`'s OWN separate `resolve_property` call (which only
+/// ever reads `foreground_color`, for the icon's `IconTheme` — see
+/// `icon_button_theme_slot_reaches_the_icons_icon_theme` above). A
+/// `background_color` set on `icon_button_theme` has no path to the mounted
+/// `Material` except through `ButtonStyleButtonCoreState::build`'s own
+/// three-tier resolve, which only sees it because `IconButton::build` wired
+/// `theme_style` onto the `ButtonStyleButtonCore` it constructs. Deleting
+/// that `core.theme_style(theme_style)` call leaves this property
+/// permanently `None` at the core's theme tier, so this assertion would
+/// fail (falling through to `_IconButtonDefaultsM3`'s transparent default)
+/// — the two `foreground_color` tests above would NOT catch that deletion,
+/// since they exercise a code path this test does not.
+#[test]
+fn icon_button_theme_slot_background_color_reaches_the_mounted_material() {
+    let themed_background = Color::rgb(60, 70, 80);
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        icon_button_theme: Some(IconButtonThemeData {
+            style: Some(ButtonStyle {
+                background_color: Some(WidgetStateProperty::all(Some(themed_background))),
+                ..Default::default()
+            }),
+        }),
+        ..Default::default()
+    });
+
+    let laid = lay_out(
+        Theme::new(
+            theme,
+            IconButton::new(SizedBox::square(24.0)).on_pressed(|| {}),
+        ),
+        tight(40.0, 40.0),
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("IconButton must compose a Material surface");
+    assert_eq!(
+        laid.render_property(material, "color"),
+        Some(format!("{themed_background:?}")),
+        "a configured icon_button_theme.style.background_color must reach the mounted \
+         Material — proving ButtonStyleButtonCore's own theme_style wiring, not just \
+         IconButton::build's separate foreground_color resolve",
     );
 }
 

--- a/crates/flui-material/tests/icon_button.rs
+++ b/crates/flui-material/tests/icon_button.rs
@@ -26,7 +26,7 @@ use flui_material::{
 };
 use flui_types::Color;
 use flui_view::prelude::*;
-use flui_widgets::{IconTheme, IconThemeData, SizedBox, WidgetStateProperty};
+use flui_widgets::{IconTheme, IconThemeData, SizedBox, WidgetState, WidgetStateProperty};
 
 /// Captures the ambient [`IconThemeData`] its parent publishes at build
 /// time — the same probe shape `tests/scaffold.rs`'s `MediaQueryProbe` uses
@@ -266,6 +266,70 @@ fn icon_button_theme_slot_background_color_reaches_the_mounted_material() {
         "a configured icon_button_theme.style.background_color must reach the mounted \
          Material — proving ButtonStyleButtonCore's own theme_style wiring, not just \
          IconButton::build's separate foreground_color resolve",
+    );
+}
+
+/// Regression lock for the named divergence `icon_button.rs`'s module docs
+/// extend to the theme tier: a state-varying
+/// `icon_button_theme.style.foreground_color` is resolved ONCE, against the
+/// static enabled/disabled snapshot `IconButton::build` builds itself, and
+/// frozen into the icon's `IconTheme` — a REAL hover afterward does not
+/// re-resolve it, even though `ButtonStyleButtonCore`'s own `InkWell` DOES
+/// track that live hover for its own background/overlay. If a future change
+/// starts sharing a live states controller for this icon color, this
+/// assertion's expected value would need to flip to `hovered_color` — that
+/// is the intended, honest failure mode of a regression-locking test for a
+/// named limitation, not a correctness bug this test exists to catch.
+#[test]
+fn a_hover_varying_icon_button_theme_foreground_color_stays_frozen_at_the_initial_snapshot() {
+    let enabled_color = Color::rgb(10, 20, 30);
+    let hovered_color = Color::rgb(200, 210, 220);
+    let captured = Rc::new(RefCell::new(None));
+    let probe = IconThemeProbe {
+        captured: Rc::clone(&captured),
+    };
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        icon_button_theme: Some(IconButtonThemeData {
+            style: Some(ButtonStyle {
+                foreground_color: Some(WidgetStateProperty::resolve_with(move |states| {
+                    Some(if states.contains_state(WidgetState::Hovered) {
+                        hovered_color
+                    } else {
+                        enabled_color
+                    })
+                })),
+                ..Default::default()
+            }),
+        }),
+        ..Default::default()
+    });
+
+    let laid = lay_out(
+        Theme::new(theme, IconButton::new(probe).on_pressed(|| {})),
+        tight(40.0, 40.0),
+    );
+
+    let before_hover = captured
+        .borrow()
+        .clone()
+        .expect("IconThemeProbe must have built at least once")
+        .color;
+    assert_eq!(
+        before_hover,
+        Some(enabled_color),
+        "the initial (non-hovered) snapshot must resolve the enabled branch",
+    );
+
+    laid.dispatch_pointer_move(20.0, 20.0);
+
+    let after_hover = captured.borrow().clone().unwrap().color;
+    assert_eq!(
+        after_hover,
+        Some(enabled_color),
+        "a real hover must NOT change the icon's IconTheme color — the theme-tier \
+         foreground_color was resolved once against the static enabled/disabled snapshot and \
+         stays frozen, the same named divergence the widget-level style override already \
+         carries (see icon_button.rs's module docs)",
     );
 }
 

--- a/crates/flui-material/tests/inherited_theme.rs
+++ b/crates/flui-material/tests/inherited_theme.rs
@@ -35,11 +35,16 @@ mod common;
 use std::sync::{Arc, Mutex};
 
 use common::{lay_out, loose};
-use flui_material::{ColorSchemeOverrides, Theme, ThemeData, ThemeDataOverrides};
+use flui_material::{
+    AppBar, AppBarThemeData, ButtonStyle, ColorSchemeOverrides, ElevatedButton,
+    ElevatedButtonThemeData, Theme, ThemeData, ThemeDataOverrides,
+};
 use flui_types::platform::Brightness;
 use flui_types::styling::Color;
 use flui_view::prelude::*;
-use flui_widgets::{InheritedTheme, SizedBox};
+use flui_widgets::{
+    InheritedTheme, MediaQuery, MediaQueryData, SizedBox, Text, WidgetStateProperty,
+};
 
 /// Captures whatever [`Theme::maybe_of`] returns during `build()`.
 ///
@@ -126,6 +131,72 @@ fn theme_maybe_of_returns_none_without_ancestor() {
         inner.is_none(),
         "Theme::maybe_of should return None when no Theme ancestor is present, \
          got: {inner:?}"
+    );
+}
+
+/// The task-level proof this crate's component-theme slots exist for: a
+/// SINGLE `Theme`, configured with BOTH a custom `elevated_button_theme`
+/// style AND a custom `app_bar_theme` background, must reach BOTH mounted
+/// widgets simultaneously — not just one slot in isolation (every other
+/// `*_theme_slot_reaches_the_mounted_*` test in this crate proves exactly
+/// one consumer at a time; this one proves the slots are independent,
+/// per-widget reads off the SAME `ThemeData`, not a global "last theme
+/// change wins" shared value).
+#[test]
+fn a_themed_subtree_carries_both_the_elevated_button_and_app_bar_theme_simultaneously() {
+    use flui_widgets::Column;
+
+    let themed_button_background = Color::from_argb(0xFF11_2233);
+    let themed_app_bar_background = Color::from_argb(0xFF44_5566);
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        elevated_button_theme: Some(ElevatedButtonThemeData {
+            style: Some(ButtonStyle {
+                background_color: Some(WidgetStateProperty::all(Some(themed_button_background))),
+                ..Default::default()
+            }),
+        }),
+        app_bar_theme: Some(AppBarThemeData {
+            background_color: Some(themed_app_bar_background),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    let laid = lay_out(
+        Theme::new(
+            theme,
+            MediaQuery::new(
+                MediaQueryData::default(),
+                Column::new(vec![
+                    AppBar::new().title(Text::new("Title")).boxed(),
+                    ElevatedButton::new(Text::new("Save"))
+                        .on_pressed(|| {})
+                        .boxed(),
+                ]),
+            ),
+        ),
+        loose(400.0),
+    );
+
+    let materials = laid.find_all_by_render_type("RenderPhysicalShape");
+    assert_eq!(
+        materials.len(),
+        2,
+        "both the AppBar and the ElevatedButton must compose their own Material surface"
+    );
+    let colors: std::collections::HashSet<String> = materials
+        .iter()
+        .filter_map(|id| laid.render_property(*id, "color"))
+        .collect();
+
+    assert!(
+        colors.contains(&format!("{themed_app_bar_background:?}")),
+        "the AppBar's Material must resolve the theme's app_bar_theme.background_color",
+    );
+    assert!(
+        colors.contains(&format!("{themed_button_background:?}")),
+        "the ElevatedButton's Material must resolve the theme's \
+         elevated_button_theme.style.background_color, from the SAME Theme ancestor",
     );
 }
 


### PR DESCRIPTION
## Summary

Fills the theme seam left across the Material catalog: `ThemeData` gains nine `Option<...Theme>` slots (five button themes wrapping `ButtonStyle`, plus `AppBarThemeData`/`CardThemeData`/`DialogThemeData`/`FabThemeData` as consumed-fields-only subsets), and every consumer's three-tier cascade (widget > theme > M3 default) now actually exercises the middle tier — previously `theme_style_of` permanently returned `None`. Ported against Flutter 3.44.0 `material/*_theme.dart`.

- **Per-field fallthrough, not whole-struct**: a theme setting only `background` never blanks other properties (oracle `effectiveValue` parity; mutation-killed per consumer with themed-field + untouched-default asserted simultaneously).
- **Named reduction**: FLUI V1 reads only the ThemeData slots — Flutter's standalone `ElevatedButtonTheme`-style inherited wrappers are a named deferral.
- **Field subsets honest**: each slot ports only what FLUI's widgets consume today, with the oracle's remaining fields named per file (AppBar 4/17, Card 4/7, Dialog 5/9 incl. the review-caught `constraints` omission, FAB 3+).
- Patch-struct convention maintained (`ThemeDataOverrides` named fields); existing default-value tests unweakened (M3 token tables still pin the same values as the fallback tier).

### Tests
230 in-crate (+31): cascade precedence per consumer (all three tiers, mutation-killed both directions), end-to-end themed subtree probes on mounted renders, overlay-color theme tier under pressed state, IconButton core wiring via a property only the core resolves (review-caught: the pre-existing icon-theme tests passed under the wiring deletion — the new test fails), copy_with with the new slots.

### Review trail
Builder → full review (cascade oracle-loyal; two surviving mutations on changed lines + one deferral omission) → fix pass with pasted mutation evidence including the confirming negatives.

### Gates
Workspace nextest 6860 passed / 4 skipped · workspace clippy `-D warnings` clean · doc gate clean · port-check/inventory/fmt/taplo/typos clean · doctests 605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvkSGveJwxLVuygRAGVKuz