### PR TITLE
fix(cupertino): close three bot-review findings from #377/#379

### DIFF
--- a/crates/flui-cupertino/src/button.rs
+++ b/crates/flui-cupertino/src/button.rs
@@ -337,7 +337,39 @@ impl std::fmt::Debug for CupertinoButton {
 }
 
 /// Resolves the background fill, per `_CupertinoButtonState.build`'s
-/// `backgroundColor` computation (`button.dart`, oracle tag `3.44.0`).
+/// `backgroundColor` computation (`button.dart`, oracle tag `3.44.0`):
+///
+/// ```dart
+/// final Color? backgroundColor =
+///     (widget.color == null ? ... : CupertinoDynamicColor.maybeResolve(widget.color, context))
+///         ?.withOpacity(widget._style == tinted ? ... : widget.color?.opacity ?? 1.0);
+/// ```
+///
+/// ## Why the `Plain`/`Filled` alpha comes from `view.color`, not the resolved color
+///
+/// For `Tinted`, the multiplier is a fixed light/dark constant — no
+/// surprises. For `Plain`/`Filled`, the oracle multiplies by `widget.color?.opacity`,
+/// which reads the **original, never-resolved** `widget.color` — not the
+/// `CupertinoDynamicColor.maybeResolve` result assigned to `backgroundColor`
+/// two lines above. `CupertinoDynamicColor.opacity` forwards to its private
+/// `_effectiveColor`, which every public constructor seeds with `color` (the
+/// light/normal variant) and which is only ever replaced by calling
+/// `resolveFrom` — a call that returns a **new** instance, leaving the
+/// original `widget.color` untouched. So this multiplier is always the
+/// color's light-variant alpha, even when `backgroundColor` itself resolved
+/// to the dark variant.
+///
+/// This looks like a bug (a dark-mode background painted with the light
+/// alpha) but is the oracle's real, verified behavior: `CupertinoColors.separator`
+/// is alpha 73 light / 153 dark (`colors.dart`, oracle tag `3.44.0`), and a
+/// `.separator`-colored `Plain`/`Filled` button under a Dark theme really
+/// does render at alpha 73 in real Flutter — see
+/// `background_dynamic_color_keeps_the_light_variants_alpha_under_a_dark_theme`
+/// in `tests/button.rs`, which mounts a `.separator`-colored button under a
+/// Dark theme and pins this exact (surprising but oracle-faithful) value.
+/// Ported here as a direct alpha-channel copy (`Color::with_alpha`, `u8`)
+/// rather than the oracle's `opacity` (`f64`) round trip through
+/// `with_opacity` — same source byte, no float-precision risk.
 fn resolve_background_color(
     view: &CupertinoButton,
     ctx: &dyn BuildContext,
@@ -351,22 +383,23 @@ fn resolve_background_color(
         },
     };
 
-    base.map(|base_color| {
-        let opacity = match view.style {
-            ButtonFillStyle::Tinted => {
-                if CupertinoTheme::brightness_of(ctx) == Brightness::Light {
-                    K_TINTED_OPACITY_LIGHT
-                } else {
-                    K_TINTED_OPACITY_DARK
-                }
-            }
-            ButtonFillStyle::Plain | ButtonFillStyle::Filled => match view.color {
-                Some(CupertinoColor::Static(color)) => color.opacity(),
-                Some(CupertinoColor::Dynamic(dynamic)) => dynamic.color.opacity(),
-                None => 1.0,
-            },
-        };
-        base_color.with_opacity(opacity)
+    base.map(|base_color| match view.style {
+        ButtonFillStyle::Tinted => {
+            let opacity = if CupertinoTheme::brightness_of(ctx) == Brightness::Light {
+                K_TINTED_OPACITY_LIGHT
+            } else {
+                K_TINTED_OPACITY_DARK
+            };
+            base_color.with_opacity(opacity)
+        }
+        ButtonFillStyle::Plain | ButtonFillStyle::Filled => {
+            let alpha = match view.color {
+                Some(CupertinoColor::Static(color)) => color.a,
+                Some(CupertinoColor::Dynamic(dynamic)) => dynamic.color.a,
+                None => 255,
+            };
+            base_color.with_alpha(alpha)
+        }
     })
 }
 
@@ -387,6 +420,41 @@ fn resolve_foreground_color(
         (_, true) => primary_color,
         (_, false) => CupertinoColors::TERTIARY_LABEL.resolve_from(ctx),
     }
+}
+
+/// Starts the press-in fade on tap — `true` if it actually started a run.
+/// Extracted from the `on_tap` closure so "does a tap with `pressed_opacity:
+/// None` actually start the controller" is unit-testable without mounting a
+/// render tree (see the tests below).
+///
+/// `pressed_opacity: None` means [`CupertinoButton::pressed_opacity`]'s
+/// contract — "disables the fade animation entirely" — a stronger,
+/// FLUI-authored promise than the oracle's own doc ("opacity will not change
+/// on pressed"); the oracle's `_animate()` has no such guard and always
+/// drives the `AnimationController` on tap, even when `pressedOpacity` is
+/// `null` (the tween's begin/end both collapse to `1.0`, so the run ticks
+/// invisibly). Skipping the run here has no observable paint difference —
+/// `build`'s `opacity` `FloatTween` also collapses to `1.0..=1.0` in that
+/// case — it only removes wasted ticking, rebuild-scheduling, and
+/// status-listener work, so this does not diverge from the oracle's visible
+/// behavior, only from its incidental cost.
+fn start_press_fade(
+    controller: &AnimationController,
+    pressed_opacity: Option<f32>,
+    rebuild: Option<&RebuildHandle>,
+) -> bool {
+    if pressed_opacity.is_none() {
+        return false;
+    }
+    let curve: Arc<dyn flui_animation::Curve + Send + Sync> =
+        Arc::new(Curves::EaseInOutCubicEmphasized);
+    if let Err(error) = controller.animate_to_curved(1.0, Some(K_FADE_OUT_DURATION), curve) {
+        tracing::debug!(?error, "CupertinoButton press fade failed to start");
+    }
+    if let Some(rebuild) = rebuild {
+        rebuild.schedule();
+    }
+    true
 }
 
 /// Persistent state behind [`CupertinoButton`] — see [`StatefulView`]/
@@ -542,18 +610,10 @@ impl ViewState<CupertinoButton> for CupertinoButtonState {
             if let Some(on_pressed) = view.on_pressed.clone() {
                 let controller = self.controller.clone();
                 let rebuild = self.rebuild.clone();
+                let pressed_opacity = view.pressed_opacity;
                 gesture_detector = gesture_detector.on_tap(move || {
                     if let Some(controller) = &controller {
-                        let curve: Arc<dyn flui_animation::Curve + Send + Sync> =
-                            Arc::new(Curves::EaseInOutCubicEmphasized);
-                        if let Err(error) =
-                            controller.animate_to_curved(1.0, Some(K_FADE_OUT_DURATION), curve)
-                        {
-                            tracing::debug!(?error, "CupertinoButton press fade failed to start");
-                        }
-                        if let Some(rebuild) = &rebuild {
-                            rebuild.schedule();
-                        }
+                        start_press_fade(controller, pressed_opacity, rebuild.as_ref());
                     }
                     on_pressed();
                 });
@@ -691,5 +751,43 @@ mod tests {
         );
         assert!(debug.contains("Filled"));
         assert!(debug.contains("enabled: true"));
+    }
+
+    // ---- start_press_fade (pressed_opacity(None) truly starts no run) ----
+
+    fn fresh_controller() -> AnimationController {
+        AnimationController::new(Duration::from_millis(200), Arc::new(Scheduler::new()))
+    }
+
+    /// Red-check: delete the `pressed_opacity.is_none()` guard in
+    /// `start_press_fade` (call `animate_to_curved` unconditionally, as the
+    /// oracle's own `_animate()` does) — this assertion fails because the
+    /// controller starts animating.
+    #[test]
+    fn pressed_opacity_none_starts_no_controller_run() {
+        let controller = fresh_controller();
+        let started = start_press_fade(&controller, None, None);
+        assert!(
+            !started,
+            "pressed_opacity(None) must not start the press-fade run"
+        );
+        assert!(
+            !controller.is_animating(),
+            "the controller must never begin animating when pressed_opacity is None"
+        );
+    }
+
+    #[test]
+    fn pressed_opacity_some_starts_the_controller_run() {
+        let controller = fresh_controller();
+        let started = start_press_fade(&controller, Some(0.4), None);
+        assert!(
+            started,
+            "pressed_opacity(Some(_)) must start the press-fade run"
+        );
+        assert!(
+            controller.is_animating(),
+            "animate_to_curved should leave the controller animating immediately after starting"
+        );
     }
 }

--- a/crates/flui-cupertino/src/tab_scaffold.rs
+++ b/crates/flui-cupertino/src/tab_scaffold.rs
@@ -266,6 +266,43 @@ impl ViewState<CupertinoTabScaffold> for CupertinoTabScaffoldState {
         let current_index = view.controller.index();
         let tab_count = view.tab_bar.items().len();
 
+        // Flutter parity: the constructor's own `assert(controller == null ||
+        // controller.index < tabBar.items.length, ...)` plus
+        // `_onCurrentIndexChange`'s identical `assert` on every subsequent
+        // `controller.index` change (`tab_scaffold.dart`, oracle tag
+        // `3.44.0`) — both debug-only, like `debug_assert!`. Unlike a bare
+        // port of just those asserts, the oracle *also* crashes
+        // unconditionally in **release** builds: `_TabSwitchingViewState
+        // ._focusActiveTab` indexes `tabFocusNodes[widget.currentTabIndex]`,
+        // and Dart's `List` bounds-checks on every build profile, so an
+        // out-of-range index throws a `RangeError` there regardless of
+        // `assert` stripping. This port has no `tabFocusNodes` array (see the
+        // module doc's "Deferred, named" — no per-tab `FocusScope` wiring),
+        // so it has no equivalent unconditional check to inherit for free.
+        // Named divergence, not a silent one: release builds (where
+        // `debug_assert!` compiles out) fall through to every tab
+        // `Offstage`-hidden and `tab_builder` never invoked for
+        // `current_index` — the oracle instead crashes hard in every build
+        // mode. Do not "fix" this by silently clamping `current_index`; the
+        // oracle doesn't clamp either, it crashes.
+        //
+        // A panic here is caught by this crate's own build-error boundary
+        // (`build_or_recover`, `flui_view::element::behavior_commons`) and
+        // substitutes an `ErrorView` for this whole subtree rather than
+        // unwinding to the caller — mirroring Flutter's own
+        // `ComponentElement.performRebuild` try/catch → `ErrorWidget.builder`
+        // recovery for a `build()`-phase exception. So this crash is loud
+        // (a rendered error, or — when this scaffold is mounted as the sole
+        // render root, as in a headless test — a panic from having nothing
+        // left to render) rather than silent, but it is not a raw unwind out
+        // of `build`; see `tests/tab_scaffold.rs`'s
+        // `out_of_range_controller_index_panics_instead_of_silently_hiding_every_tab`.
+        debug_assert!(
+            is_valid_tab_index(current_index, tab_count),
+            "CupertinoTabScaffold's current index {current_index} is out of bounds for \
+             the tab bar with {tab_count} tabs"
+        );
+
         let tab_layers: Vec<BoxedView> = {
             let mut should_build = self.should_build_tab.borrow_mut();
             should_build.resize(tab_count, false);
@@ -364,5 +401,39 @@ impl ViewState<CupertinoTabScaffold> for CupertinoTabScaffoldState {
                 .bottom(0.0)
                 .boxed(),
         ]))
+    }
+}
+
+/// Whether `current_index` is a mountable tab index for `tab_count` tabs.
+/// Extracted from `build`'s `debug_assert!` so the exact guard condition is
+/// unit-testable without mounting a render tree — see `build`'s doc comment
+/// for the full oracle-mechanism citation.
+fn is_valid_tab_index(current_index: usize, tab_count: usize) -> bool {
+    current_index < tab_count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_valid_tab_index_accepts_every_in_range_index() {
+        assert!(is_valid_tab_index(0, 2));
+        assert!(is_valid_tab_index(1, 2));
+    }
+
+    /// Red-check: change `is_valid_tab_index` to `current_index <= tab_count`
+    /// (an off-by-one) — this assertion starts passing when it shouldn't.
+    #[test]
+    fn is_valid_tab_index_rejects_the_first_out_of_range_index() {
+        assert!(
+            !is_valid_tab_index(2, 2),
+            "index == tab_count is out of range"
+        );
+    }
+
+    #[test]
+    fn is_valid_tab_index_rejects_a_far_out_of_range_index() {
+        assert!(!is_valid_tab_index(5, 2));
     }
 }

--- a/crates/flui-cupertino/tests/button.rs
+++ b/crates/flui-cupertino/tests/button.rs
@@ -12,9 +12,11 @@ use std::time::Duration;
 
 use common::{lay_out, lay_out_animated, loose, tight};
 use flui_animation::Vsync;
-use flui_cupertino::{CupertinoButton, CupertinoButtonSize};
+use flui_cupertino::{CupertinoButton, CupertinoButtonSize, CupertinoColors};
+use flui_types::platform::Brightness;
 use flui_widgets::SizedBox;
 use flui_widgets::animated::VsyncScope;
+use flui_widgets::{MediaQuery, MediaQueryData};
 
 /// A tap on an enabled button reaches `on_pressed` — proving `GestureDetector`
 /// is actually wired, not merely constructed.
@@ -184,5 +186,49 @@ fn press_opacity_fades_out_then_back_in_over_the_oracle_durations() {
         (settled - 1.0).abs() < 1e-2,
         "once both fades complete (400ms total ticked, comfortably past 120ms + 180ms), \
          opacity ({settled}) should have returned to ~1.0"
+    );
+}
+
+/// `resolve_background_color`'s `Plain`/`Filled` alpha multiplier is the
+/// oracle's `widget.color?.opacity` (`button.dart`, oracle tag `3.44.0`) —
+/// read off the ORIGINAL, never-resolved `widget.color`, which for a
+/// `CupertinoDynamicColor` is always its light/normal variant (see
+/// `src/button.rs`'s `resolve_background_color` doc for the full mechanism
+/// citation). `CupertinoColors.separator` is alpha 73 light / 153 dark
+/// (`colors.dart`, oracle tag `3.44.0`): a `.separator`-colored `Plain`
+/// button under a Dark theme resolves its RGB to the dark variant
+/// (`84, 84, 88`) but keeps the LIGHT variant's alpha (`73`), matching real
+/// Flutter exactly.
+///
+/// Red-check: change `resolve_background_color`'s `Plain`/`Filled` branch to
+/// use the RESOLVED color's own alpha (`base_color.a`) instead of
+/// `view.color`'s — this assertion fails with `a: 153`, not `a: 73`.
+#[test]
+fn background_dynamic_color_keeps_the_light_variants_alpha_under_a_dark_theme() {
+    let dark = MediaQueryData {
+        platform_brightness: Brightness::Dark,
+        ..MediaQueryData::default()
+    };
+    let laid = lay_out(
+        MediaQuery::new(
+            dark,
+            CupertinoButton::new(SizedBox::shrink())
+                .color(CupertinoColors::SEPARATOR)
+                .on_pressed(|| {}),
+        ),
+        tight(100.0, 44.0),
+    );
+
+    let decorated = laid
+        .find_by_render_type("RenderDecoratedBox")
+        .expect("CupertinoButton always paints a DecoratedBox background");
+    let decoration = laid
+        .render_property(decorated, "decoration")
+        .expect("RenderDecoratedBox always reports its decoration");
+
+    assert!(
+        decoration.contains("r: 84, g: 84, b: 88, a: 73"),
+        "a Dynamic background under Dark theme must resolve the dark RGB but keep the \
+         light-variant alpha (oracle-faithful, not a bug): {decoration}"
     );
 }

--- a/crates/flui-cupertino/tests/tab_scaffold.rs
+++ b/crates/flui-cupertino/tests/tab_scaffold.rs
@@ -421,3 +421,42 @@ fn tapping_a_tab_item_switches_the_active_tab() {
         "tapping the second tab item must advance the controller to index 1"
     );
 }
+
+/// An out-of-range controller index must fail loudly, not silently render
+/// every tab `Offstage` with `tab_builder` never invoked. Flutter parity:
+/// `_onCurrentIndexChange`'s `assert(_controller.index >= 0 &&
+/// _controller.index < widget.tabBar.items.length, ...)` (`tab_scaffold.dart`,
+/// oracle tag `3.44.0`) — a debug-only `assert`, matched here by the
+/// `debug_assert!` in `tab_scaffold.rs`'s `build` (test binaries build in
+/// debug profile, so it is live).
+///
+/// This test asserts the panic message from `lay_out`'s own "the mounted
+/// subtree should have a render root" check, **not** the `debug_assert!`'s
+/// own message: this crate's build-error boundary
+/// (`flui_view::element::behavior_commons::build_or_recover`) catches a
+/// panicking `build()` and substitutes a render-less `ErrorView` for the
+/// whole subtree — the same recovery `flui-material/tests/theme.rs` and
+/// `flui-widgets/tests/visibility.rs` document for exactly this reason
+/// ("a panic inside build() is caught by the framework's build-error
+/// boundary... so #[should_panic] around the harness would not observe
+/// it"). With `CupertinoTabScaffold` mounted as the sole root here, that
+/// substitution leaves nothing at all to render, so `lay_out` itself panics
+/// — a loud, unmistakable mount failure, not the old silent
+/// every-tab-hidden mis-render.
+///
+/// Red-check: delete the `debug_assert!` in `CupertinoTabScaffoldState::build`
+/// — this test stops panicking entirely (the scaffold instead mounts
+/// successfully with every tab hidden and `tab_builder` uncalled for index 5).
+#[test]
+#[should_panic(expected = "render root")]
+fn out_of_range_controller_index_panics_instead_of_silently_hiding_every_tab() {
+    let controller = CupertinoTabController::new(5);
+    let scaffold = CupertinoTabScaffold::new(two_tab_bar(), controller, |_ctx, _index| {
+        SizedBox::new(10.0, 10.0).into_view().boxed()
+    });
+
+    let _ = lay_out(
+        MediaQuery::new(MediaQueryData::default(), scaffold),
+        tight(400.0, 800.0),
+    );
+}


### PR DESCRIPTION
## Summary

Resolves the bot review comments left on the merged cupertino PRs, each verified against the Flutter 3.44.0 oracle before acting:

1. **Dynamic-color alpha "clobber" (button.rs, Codex + Copilot on #377) — investigated, NOT a bug.** Flutter itself reads `opacity` off the unresolved light variant (`CupertinoDynamicColor._effectiveColor` is seeded by every public constructor and only changes via `resolveFrom`, which returns a new instance) — a `.separator`-colored button under a Dark theme genuinely renders at alpha 73 in real Flutter, and "fixing" it would have been a parity divergence. Kept the oracle mechanism; replaced the lossy `f32` opacity round-trip with a direct `u8` `with_alpha` copy (the float-precision half of the finding), documented the mechanism, and pinned the oracle-faithful value with a Dark-theme regression test.
2. **`pressed_opacity(None)` still ticking (Copilot on #377) — genuine bug, fixed.** The fade was invisible but the controller still ran and scheduled rebuilds; extracted `start_press_fade` with a `None` early-return, unit-tested via the real `AnimationController::is_animating()`.
3. **Out-of-range tab index silently hiding every tab (Codex on #379) — fixed.** `debug_assert!` via `is_valid_tab_index` (matching the oracle's own debug-mode assert); the oracle's unconditional release-mode crash rides a `tabFocusNodes` bounds-check FLUI doesn't carry — documented honestly instead of inventing a clamp.

`cargo mutants` over the two touched files: every mutant on the fixes' own changed lines caught (15 missed are all pre-existing out-of-scope code).

### Gates
Workspace nextest 6869 passed · flui-cupertino 87/87 · crate clippy `--all-features -D warnings` clean · fmt/port-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvkSGveJwxLVuygRAGVKuz