### PR TITLE
feat(material,widgets): input decoration substrate — InputDecorator (filled/underline), EditableText enabled+text_style

### DIFF
--- a/crates/flui-material/src/input_decorator.rs
+++ b/crates/flui-material/src/input_decorator.rs
@@ -499,6 +499,12 @@ impl ViewState<InputDecorator> for InputDecoratorState {
             )
             .unwrap_or_else(BorderSide::none);
 
+        // The 4dp top radius rounds the FILL only (`decoration_rrect` in
+        // `flui-painting`'s `paint_box_decoration`) — the non-uniform
+        // bottom-only border below paints a straight, unrounded line
+        // regardless of `border_radius` (`paint_border`'s non-uniform path
+        // ignores the rrect), exactly matching `UnderlineInputBorder`'s own
+        // rendering: a rounded fill, a straight underline stroke.
         let box_decoration = BoxDecoration::new()
             .set_color(Some(blended_fill))
             .set_border_radius(Some(BorderRadius::top(Radius::circular(px(4.0)))))

--- a/crates/flui-material/src/input_decorator.rs
+++ b/crates/flui-material/src/input_decorator.rs
@@ -1,0 +1,977 @@
+//! [`InputDecoration`] + [`InputDecorator`] — the M3 filled text field
+//! decoration substrate.
+//!
+//! **Scope**: M3 filled text field decoration — underline indicator, hint,
+//! floating label (snap), helper/error line, hover fill blend, and the M3
+//! state table — composed from existing widgets; NOT a `_RenderDecoration`
+//! port.
+//!
+//! Flutter parity: `material/input_decorator.dart` (oracle tag `3.44.0`),
+//! narrowed to the filled/underline variant.
+//!
+//! # Named divergences / deferrals
+//!
+//! - **Baseline slot layout** — the oracle's `_RenderDecoration` positions
+//!   the hint, label, and input text at a shared baseline, overlaid at the
+//!   same rect. This substrate composes plain [`flui_widgets::Column`] rows
+//!   instead: at most one of the label/hint rows renders per build (see
+//!   `should_show_hint`), and the input content is its own row below them
+//!   — not overlaid at the input's rect.
+//! - **Exact float metrics + the 167ms/0.75-scale label animation** — the
+//!   oracle animates the label's position/size over `_kTransitionDuration`
+//!   (167ms) between 1.0 and `_kFinalLabelScale` (0.75,
+//!   `input_decorator.dart:41`). V1 snaps: the floating label is scaled by
+//!   0.75 instantly, no interpolation, no exact pixel position.
+//! - **`isDense`** — no compact content-padding tier.
+//! - **`OutlineInputBorder` + label gap** — a real `input_border.dart` port
+//!   later; never faked here.
+//! - **`prefix`/`suffix`/counter** — no icon or character-count slots.
+//! - **Error shake** — the oracle's `_shakingLabelController`; not ported.
+//! - **`String`-only label/hint/helper/error slots** — the oracle's
+//!   `InputDecoration` additionally accepts a `Widget` for each
+//!   (`label`/`hint`/`helper`/`error`); V1 ships `String` only, additively
+//!   extensible (a `Widget` variant can be added to each field later without
+//!   breaking the `String` construction path).
+//!
+//! # State-table branch order
+//!
+//! Every M3 default table below follows the oracle's exact branch order:
+//! disabled → error (→ focused → hovered → plain) → focused → hovered →
+//! default. The oracle documents *why* focused precedes hovered for this
+//! widget specifically (`input_decorator.dart:5945-5953`, tag `3.44.0`):
+//! unlike most Material widgets, a focused **and** hovered field (common on
+//! desktop, where users often click into a field) must show the focused
+//! treatment, not the hovered one.
+
+use std::sync::Arc;
+
+use flui_foundation::ListenerId;
+use flui_foundation::notifier::Listenable;
+use flui_types::EdgeInsets;
+use flui_types::Pixels;
+use flui_types::geometry::{Radius, px};
+use flui_types::platform::Brightness;
+use flui_types::styling::{Border, BorderRadius, BorderSide, BorderStyle, BoxDecoration, Color};
+use flui_types::typography::TextStyle;
+use flui_view::prelude::*;
+use flui_widgets::{
+    Column, CrossAxisAlignment, DecoratedBox, MouseRegion, Padding, Text, WidgetState,
+    WidgetStateProperty, WidgetStates, WidgetStatesController,
+};
+
+use crate::color_scheme::ColorScheme;
+use crate::theme::Theme;
+use crate::theme_data::InputDecorationThemeData;
+
+// ============================================================================
+// InputDecoration
+// ============================================================================
+
+/// Data describing a text field's decoration — labels, fill, and enabled
+/// state. Carries no layout knobs: a future render-object decorator
+/// consumes this struct unchanged.
+///
+/// Flutter parity: `InputDecoration` (`material/input_decorator.dart`,
+/// oracle tag `3.44.0`), narrowed to the V1 field list — see the module
+/// docs for the full named-divergence list (no `Widget` slots, no
+/// `prefix`/`suffix`, no `isDense`, no `border` override).
+///
+/// Every field is a plain public field; build one with a struct literal and
+/// `..Default::default()`, the same convention as [`crate::ButtonStyle`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct InputDecoration {
+    /// The field's label — floats above the content when the field is
+    /// focused or non-empty, otherwise sits inline in place of the hint.
+    pub label_text: Option<String>,
+    /// Placeholder text shown when the field is empty and the label isn't
+    /// occupying the inline slot — see the crate's `should_show_hint` helper.
+    pub hint_text: Option<String>,
+    /// A helper line shown below the content, replaced by
+    /// [`error_text`](Self::error_text) when both are set.
+    pub helper_text: Option<String>,
+    /// An error line shown below the content, replacing
+    /// [`helper_text`](Self::helper_text) when both are set.
+    pub error_text: Option<String>,
+    /// Whether the container is filled (the M3 filled variant this
+    /// substrate implements). `false` renders a fully transparent
+    /// container with no hover blend — Flutter parity: `_getFillColor`
+    /// returns `Colors.transparent` when `filled != true`
+    /// (`input_decorator.dart:2131-2140`, tag `3.44.0`).
+    pub filled: bool,
+    /// Overrides the container's content padding. `None` falls through to
+    /// the ambient [`InputDecorationThemeData::content_padding`], then the
+    /// M3 default.
+    pub content_padding: Option<EdgeInsets>,
+    /// Whether the field accepts interaction. `true` by default. Disabled
+    /// selects the disabled M3 colors and suppresses the hover blend.
+    pub enabled: bool,
+}
+
+impl Default for InputDecoration {
+    fn default() -> Self {
+        Self {
+            label_text: None,
+            hint_text: None,
+            helper_text: None,
+            error_text: None,
+            filled: false,
+            content_padding: None,
+            enabled: true,
+        }
+    }
+}
+
+// ============================================================================
+// M3 defaults — `_InputDecoratorDefaultsM3` (input_decorator.dart, tag 3.44.0)
+// ============================================================================
+
+/// M3 default `fillColor` — `_InputDecoratorDefaultsM3.fillColor`
+/// (`input_decorator.dart:5964-5969`). No hovered branch: the container's
+/// hover treatment is a separate alpha blend over this color, not a fill
+/// state — see [`hover_blended_fill`] and the module doc on why this
+/// deliberately does not fold hover into the table.
+fn default_fill_color(colors: ColorScheme) -> WidgetStateProperty<Option<Color>> {
+    WidgetStateProperty::resolve_with(move |states| {
+        Some(if states.contains_state(WidgetState::Disabled) {
+            colors.on_surface.with_opacity(0.04)
+        } else {
+            colors.surface_container_highest
+        })
+    })
+}
+
+/// M3 default `activeIndicatorBorder` (the bottom underline) —
+/// `_InputDecoratorDefaultsM3.activeIndicatorBorder`
+/// (`input_decorator.dart:5972-5992`).
+fn default_active_indicator(
+    colors: ColorScheme,
+) -> WidgetStateProperty<Option<BorderSide<Pixels>>> {
+    WidgetStateProperty::resolve_with(move |states| {
+        Some(if states.contains_state(WidgetState::Disabled) {
+            BorderSide::new(
+                colors.on_surface.with_opacity(0.38),
+                px(1.0),
+                BorderStyle::Solid,
+            )
+        } else if states.contains_state(WidgetState::Error) {
+            if states.contains_state(WidgetState::Focused) {
+                BorderSide::new(colors.error, px(2.0), BorderStyle::Solid)
+            } else if states.contains_state(WidgetState::Hovered) {
+                BorderSide::new(colors.on_error_container, px(1.0), BorderStyle::Solid)
+            } else {
+                BorderSide::new(colors.error, px(1.0), BorderStyle::Solid)
+            }
+        } else if states.contains_state(WidgetState::Focused) {
+            BorderSide::new(colors.primary, px(2.0), BorderStyle::Solid)
+        } else if states.contains_state(WidgetState::Hovered) {
+            BorderSide::new(colors.on_surface, px(1.0), BorderStyle::Solid)
+        } else {
+            BorderSide::new(colors.on_surface_variant, px(1.0), BorderStyle::Solid)
+        })
+    })
+}
+
+/// M3 default `hintStyle` — `_InputDecoratorDefaultsM3.hintStyle`
+/// (`input_decorator.dart:5956-5961`). Only two branches (disabled/plain):
+/// the oracle's hint style carries no base font — a bare
+/// `TextStyle(color: ...)`, unlike [`default_label_style`]/
+/// [`default_helper_style`] which start from a `TextTheme` role.
+fn default_hint_style(colors: ColorScheme) -> WidgetStateProperty<Option<TextStyle>> {
+    WidgetStateProperty::resolve_with(move |states| {
+        Some(if states.contains_state(WidgetState::Disabled) {
+            TextStyle::default().with_color(colors.on_surface.with_opacity(0.38))
+        } else {
+            TextStyle::default().with_color(colors.on_surface_variant)
+        })
+    })
+}
+
+/// M3 default `labelStyle` — `_InputDecoratorDefaultsM3.labelStyle`
+/// (`input_decorator.dart:6043-6064`). `floatingLabelStyle`
+/// (`:6067-6088`) is byte-identical to this table in the oracle, so this
+/// one slot serves both the floating and inline positions — see the
+/// module doc's `String`-only-slots note and [`InputDecorationThemeData::label_style`].
+/// `base` is the ambient `TextTheme.bodyLarge` role.
+fn default_label_style(
+    colors: ColorScheme,
+    base: TextStyle,
+) -> WidgetStateProperty<Option<TextStyle>> {
+    WidgetStateProperty::resolve_with(move |states| {
+        let base = base.clone();
+        Some(if states.contains_state(WidgetState::Disabled) {
+            base.with_color(colors.on_surface.with_opacity(0.38))
+        } else if states.contains_state(WidgetState::Error) {
+            if states.contains_state(WidgetState::Focused) {
+                base.with_color(colors.error)
+            } else if states.contains_state(WidgetState::Hovered) {
+                base.with_color(colors.on_error_container)
+            } else {
+                base.with_color(colors.error)
+            }
+        } else if states.contains_state(WidgetState::Focused) {
+            base.with_color(colors.primary)
+        } else {
+            // Hovered and the oracle's unconditional fallback both resolve
+            // to `onSurfaceVariant` (`input_decorator.dart:6060-6063`).
+            base.with_color(colors.on_surface_variant)
+        })
+    })
+}
+
+/// M3 default `helperStyle` — `_InputDecoratorDefaultsM3.helperStyle`
+/// (`input_decorator.dart:6090-6097`). `base` is the ambient
+/// `TextTheme.bodySmall` role.
+fn default_helper_style(
+    colors: ColorScheme,
+    base: TextStyle,
+) -> WidgetStateProperty<Option<TextStyle>> {
+    WidgetStateProperty::resolve_with(move |states| {
+        Some(if states.contains_state(WidgetState::Disabled) {
+            base.clone()
+                .with_color(colors.on_surface.with_opacity(0.38))
+        } else {
+            base.clone().with_color(colors.on_surface_variant)
+        })
+    })
+}
+
+/// M3 default `errorStyle` — `_InputDecoratorDefaultsM3.errorStyle`
+/// (`input_decorator.dart:6099-6103`). Unconditionally `error`-colored — the
+/// oracle applies no other branch (not even `disabled`: an error line only
+/// ever appears on an enabled, invalid field). `base` is the ambient
+/// `TextTheme.bodySmall` role.
+fn default_error_style(
+    colors: ColorScheme,
+    base: TextStyle,
+) -> WidgetStateProperty<Option<TextStyle>> {
+    WidgetStateProperty::resolve_with(move |_states| Some(base.clone().with_color(colors.error)))
+}
+
+/// M3 default content padding for the filled, non-outline, non-dense case —
+/// `EdgeInsets.fromLTRB(12, 8, 12, 8)` (`InputDecoration.contentPadding`'s
+/// doc comment, `input_decorator.dart:3333-3334`, tag `3.44.0`).
+fn default_content_padding() -> EdgeInsets {
+    EdgeInsets::new(px(8.0), px(12.0), px(8.0), px(12.0))
+}
+
+/// `ThemeData.hoverColor`'s default (`theme_data.dart:468`, tag `3.44.0`):
+/// `isDark ? Colors.white.withOpacity(0.04) : Colors.black.withOpacity(0.04)`
+/// — a fixed brightness-keyed constant, **not** a `ColorScheme` role (the
+/// M3 button family's own hover overlay, `onSurface@8%`, is a different,
+/// unrelated constant — see `crate::elevated_button`'s
+/// `pressed_hovered_focused_overlay`). `_getHoverColor`
+/// (`input_decorator.dart:2142-2147`) falls back to this exact field when
+/// `InputDecoration.hoverColor` isn't set, which V1 has no override slot
+/// for yet.
+fn default_hover_color(brightness: Brightness) -> Color {
+    match brightness {
+        Brightness::Dark => Color::WHITE.with_opacity(0.04),
+        Brightness::Light => Color::BLACK.with_opacity(0.04),
+    }
+}
+
+/// The container fill after the hover blend — `_InputBorderPainter.blendedColor`
+/// (`input_decorator.dart:136`, tag `3.44.0`): `Color.alphaBlend(hoverColor,
+/// fillColor)` while hovering, `fillColor` unchanged otherwise (the oracle
+/// animates between `hoverColor.withAlpha(0)` and `hoverColor`; V1 snaps
+/// between the two ends, no interpolation). Guarded exactly like
+/// `_getHoverColor` (`input_decorator.dart:2142-2147`): only `filled &&
+/// enabled` fields blend at all.
+fn hover_blended_fill(
+    fill: Color,
+    brightness: Brightness,
+    filled: bool,
+    enabled: bool,
+    is_hovering: bool,
+) -> Color {
+    if filled && enabled && is_hovering {
+        default_hover_color(brightness).blend_over(fill)
+    } else {
+        fill
+    }
+}
+
+// ============================================================================
+// Floating label / hint visibility — pure, directly-tested formulas
+// ============================================================================
+
+/// Whether the label should float above the content row rather than sit
+/// inline in place of the hint.
+///
+/// Flutter parity: `_labelShouldWithdraw` (`input_decorator.dart:1969`, tag
+/// `3.44.0`): `!isEmpty || (isFocused && decoration.enabled)`. The `enabled`
+/// guard is load-bearing: a disabled, empty, "focused" field (focus a field
+/// then disable it) must NOT float — see the module's disabled-row test.
+#[must_use]
+fn label_should_float(is_empty: bool, focused: bool, enabled: bool) -> bool {
+    !is_empty || (focused && enabled)
+}
+
+/// Whether the hint text should be visible.
+///
+/// Flutter parity: `showHint` (`input_decorator.dart:2346`) =
+/// `isEmpty && !_hasInlineLabel`, where `_hasInlineLabel`
+/// (`:2176-2178`) is `!labelShouldWithdraw && hasLabel` — i.e. the label is
+/// "inline" (occupying the hint's slot) exactly when it is NOT floating and
+/// a label is set.
+#[must_use]
+fn should_show_hint(is_empty: bool, has_label: bool, float: bool) -> bool {
+    is_empty && (!has_label || float)
+}
+
+/// The helper-or-error line to render: error replaces helper when both are
+/// set (Flutter parity: `_HelperError` shows one or the other, never both —
+/// `input_decorator.dart`'s `_HelperErrorState`, tag `3.44.0`). Returns the
+/// text and whether it is the error line (vs. the helper line), so the
+/// caller can pick [`default_error_style`] vs [`default_helper_style`].
+#[must_use]
+fn helper_or_error_line(decoration: &InputDecoration) -> Option<(&str, bool)> {
+    if let Some(error) = decoration.error_text.as_deref() {
+        Some((error, true))
+    } else {
+        decoration
+            .helper_text
+            .as_deref()
+            .map(|helper| (helper, false))
+    }
+}
+
+// ============================================================================
+// InputDecorator
+// ============================================================================
+
+/// Composes [`InputDecoration`] data and a `child` (the field's content —
+/// e.g. an `EditableText`, in a future `TextField`) into the M3 filled/
+/// underline decoration: fill, underline, floating label, hint, and
+/// helper/error line.
+///
+/// # State inputs
+///
+/// [`focused`](Self::focused) and [`is_empty`](Self::is_empty) are explicit
+/// widget inputs — Flutter parity: `InputDecorator.isFocused`/`isEmpty`
+/// (`input_decorator.dart:1868-1958`, tag `3.44.0`). `enabled`/`error` come
+/// from [`InputDecoration`] itself. `hovered` is the one state this widget
+/// tracks internally, via its own [`MouseRegion`] (the seam is
+/// `flui_widgets::MouseRegion`, not `InkWell`'s press/ripple machinery) —
+/// a future `TextField` wires `focused`/`is_empty` from its own `FocusNode`/
+/// `TextEditingController`; a standalone consumer passes them explicitly.
+#[derive(Clone, Debug, StatefulView)]
+pub struct InputDecorator {
+    decoration: InputDecoration,
+    focused: bool,
+    is_empty: bool,
+    child: Child,
+}
+
+impl InputDecorator {
+    /// Create a decorator around `decoration`, initially unfocused and
+    /// non-empty (Flutter's own `isFocused`/`isEmpty` defaults — both
+    /// `false`, `input_decorator.dart:1877,1879`).
+    #[must_use]
+    pub fn new(decoration: InputDecoration) -> Self {
+        Self {
+            decoration,
+            focused: false,
+            is_empty: false,
+            child: Child::empty(),
+        }
+    }
+
+    /// Set whether the field currently holds keyboard focus.
+    #[must_use]
+    pub fn focused(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
+    }
+
+    /// Set whether the field's content is currently empty.
+    #[must_use]
+    pub fn is_empty(mut self, is_empty: bool) -> Self {
+        self.is_empty = is_empty;
+        self
+    }
+
+    /// Set the decorated content (the field's actual input surface).
+    #[must_use]
+    pub fn child(mut self, child: impl IntoView) -> Self {
+        self.child = Child::some(child.into_view());
+        self
+    }
+}
+
+/// Persistent state behind [`InputDecorator`] — owns the internal hover
+/// tracking (see the struct doc's "State inputs" section).
+pub struct InputDecoratorState {
+    hover: WidgetStatesController,
+    hover_listener: Option<ListenerId>,
+}
+
+impl std::fmt::Debug for InputDecoratorState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InputDecoratorState")
+            .field("hover", &self.hover.value())
+            .finish_non_exhaustive()
+    }
+}
+
+impl StatefulView for InputDecorator {
+    type State = InputDecoratorState;
+
+    fn create_state(&self) -> Self::State {
+        InputDecoratorState {
+            hover: WidgetStatesController::default(),
+            hover_listener: None,
+        }
+    }
+}
+
+impl ViewState<InputDecorator> for InputDecoratorState {
+    fn init_state(&mut self, ctx: &dyn BuildContext) {
+        // ADR-0018: `rebuild_handle()` is acquired here, fired later from the
+        // hover-controller listener below — never called from `build`.
+        let rebuild = ctx.rebuild_handle();
+        self.hover_listener = Some(self.hover.add_listener(Arc::new(move || {
+            rebuild.schedule();
+        })));
+    }
+
+    fn dispose(&mut self) {
+        if let Some(id) = self.hover_listener.take() {
+            self.hover.remove_listener(id);
+        }
+    }
+
+    fn build(&self, view: &InputDecorator, ctx: &dyn BuildContext) -> impl IntoView {
+        let theme = Theme::of(ctx);
+        let colors = theme.color_scheme;
+        let text_theme = theme.text_theme.clone();
+        let decoration_theme: InputDecorationThemeData =
+            theme.input_decoration_theme.clone().unwrap_or_default();
+        let decoration = &view.decoration;
+
+        // Flutter parity: `_InputDecoratorState.widgetState`
+        // (`input_decorator.dart:2250-2254`, tag `3.44.0`) — disabled,
+        // focused, hovering (already enabled-gated), error.
+        let is_hovering =
+            decoration.enabled && self.hover.value().contains_state(WidgetState::Hovered);
+        let mut states = WidgetStates::NONE;
+        if !decoration.enabled {
+            states = states.with_state(WidgetState::Disabled);
+        }
+        if view.focused {
+            states = states.with_state(WidgetState::Focused);
+        }
+        if is_hovering {
+            states = states.with_state(WidgetState::Hovered);
+        }
+        if decoration.error_text.is_some() {
+            states = states.with_state(WidgetState::Error);
+        }
+
+        // Fill + hover blend.
+        let fill_color = if decoration.filled {
+            decoration_theme
+                .fill_color
+                .as_ref()
+                .map_or_else(
+                    || default_fill_color(colors).resolve(&states),
+                    |p| p.resolve(&states),
+                )
+                .unwrap_or(Color::TRANSPARENT)
+        } else {
+            Color::TRANSPARENT
+        };
+        let blended_fill = hover_blended_fill(
+            fill_color,
+            colors.brightness,
+            decoration.filled,
+            decoration.enabled,
+            is_hovering,
+        );
+
+        // Bottom underline indicator.
+        let indicator = decoration_theme
+            .active_indicator
+            .as_ref()
+            .map_or_else(
+                || default_active_indicator(colors).resolve(&states),
+                |p| p.resolve(&states),
+            )
+            .unwrap_or_else(BorderSide::none);
+
+        let box_decoration = BoxDecoration::new()
+            .set_color(Some(blended_fill))
+            .set_border_radius(Some(BorderRadius::top(Radius::circular(px(4.0)))))
+            .set_border(Some(Border::new(None, None, Some(indicator), None)));
+
+        let content_padding = decoration
+            .content_padding
+            .or(decoration_theme.content_padding)
+            .unwrap_or_else(default_content_padding);
+
+        // Label / hint rows.
+        let has_label = decoration.label_text.is_some();
+        let float = label_should_float(view.is_empty, view.focused, decoration.enabled);
+        let show_hint = should_show_hint(view.is_empty, has_label, float);
+
+        let mut rows: Vec<BoxedView> = Vec::new();
+        if let Some(label_text) = decoration.label_text.clone() {
+            let base_label_style = decoration_theme.label_style.as_ref().map_or_else(
+                || {
+                    default_label_style(colors, text_theme.body_large.clone().unwrap_or_default())
+                        .resolve(&states)
+                },
+                |p| p.resolve(&states),
+            );
+            let mut label_style = base_label_style.unwrap_or_default();
+            if float {
+                // The oracle's `_kFinalLabelScale` (`input_decorator.dart:41`,
+                // tag `3.44.0`) — applied as a snap, not the oracle's
+                // 167ms-animated interpolation. See the module doc.
+                if let Some(font_size) = label_style.font_size {
+                    label_style = label_style.with_font_size(font_size * 0.75);
+                }
+            }
+            rows.push(Text::new(label_text).style(label_style).boxed());
+        }
+        if show_hint && let Some(hint_text) = decoration.hint_text.clone() {
+            let hint_style = decoration_theme
+                .hint_style
+                .as_ref()
+                .map_or_else(
+                    || default_hint_style(colors).resolve(&states),
+                    |p| p.resolve(&states),
+                )
+                .unwrap_or_default();
+            rows.push(Text::new(hint_text).style(hint_style).boxed());
+        }
+        if let Some(child) = view.child.clone().into_inner() {
+            rows.push(child);
+        }
+        if let Some((line_text, is_error)) = helper_or_error_line(decoration) {
+            let base = text_theme.body_small.clone().unwrap_or_default();
+            let style = if is_error {
+                decoration_theme.error_style.as_ref().map_or_else(
+                    || default_error_style(colors, base).resolve(&states),
+                    |p| p.resolve(&states),
+                )
+            } else {
+                decoration_theme.helper_style.as_ref().map_or_else(
+                    || default_helper_style(colors, base).resolve(&states),
+                    |p| p.resolve(&states),
+                )
+            }
+            .unwrap_or_default();
+            rows.push(Text::new(line_text.to_string()).style(style).boxed());
+        }
+
+        let content = Padding::new(content_padding)
+            .child(Column::new(rows).cross_axis_alignment(CrossAxisAlignment::Start));
+
+        let hover_on_enter = self.hover.clone();
+        let hover_on_exit = self.hover.clone();
+
+        MouseRegion::new()
+            .on_enter(move |_device, _offset| hover_on_enter.update(WidgetState::Hovered, true))
+            .on_exit(move |_device, _offset| hover_on_exit.update(WidgetState::Hovered, false))
+            .child(DecoratedBox::new(box_decoration).child(content))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use flui_widgets::WidgetState;
+
+    use super::*;
+
+    fn resolve<T: Clone + Default>(
+        property: &WidgetStateProperty<Option<T>>,
+        states: WidgetStates,
+    ) -> Option<T> {
+        property.resolve(&states)
+    }
+
+    // ========================================================================
+    // InputDecoration
+    // ========================================================================
+
+    #[test]
+    fn default_is_unfilled_enabled_with_every_text_slot_unset() {
+        let decoration = InputDecoration::default();
+        assert!(decoration.label_text.is_none());
+        assert!(decoration.hint_text.is_none());
+        assert!(decoration.helper_text.is_none());
+        assert!(decoration.error_text.is_none());
+        assert!(!decoration.filled);
+        assert!(decoration.content_padding.is_none());
+        assert!(decoration.enabled);
+    }
+
+    #[test]
+    fn default_content_padding_matches_m3_filled_non_dense_value() {
+        // `EdgeInsets.fromLTRB(12, 8, 12, 8)` (`input_decorator.dart:3333-3334`).
+        let padding = default_content_padding();
+        assert_eq!(padding.left, px(12.0));
+        assert_eq!(padding.top, px(8.0));
+        assert_eq!(padding.right, px(12.0));
+        assert_eq!(padding.bottom, px(8.0));
+    }
+
+    // ========================================================================
+    // State-table pins — `default_fill_color`
+    // ========================================================================
+
+    #[test]
+    fn fill_color_state_table_pins() {
+        let colors = ColorScheme::light();
+        let property = default_fill_color(colors);
+
+        assert_eq!(
+            resolve(&property, WidgetStates::NONE),
+            Some(colors.surface_container_highest)
+        );
+        assert_eq!(
+            resolve(&property, WidgetStates::from(WidgetState::Disabled)),
+            Some(colors.on_surface.with_opacity(0.04))
+        );
+        // No hovered branch: hovered-only resolves the same as the plain
+        // default — the hover blend is a separate compositing step, not a
+        // fill-color state (see `hover_blended_fill`).
+        assert_eq!(
+            resolve(&property, WidgetStates::from(WidgetState::Hovered)),
+            Some(colors.surface_container_highest)
+        );
+    }
+
+    // ========================================================================
+    // State-table pins — `default_active_indicator` (combined states pinned)
+    // ========================================================================
+
+    #[test]
+    fn active_indicator_state_table_pins_every_branch_including_combined_states() {
+        let colors = ColorScheme::light();
+        let property = default_active_indicator(colors);
+
+        let plain = resolve(&property, WidgetStates::NONE).expect("plain branch");
+        assert_eq!(plain.color, colors.on_surface_variant);
+        assert_eq!(plain.width, px(1.0));
+
+        let disabled =
+            resolve(&property, WidgetStates::from(WidgetState::Disabled)).expect("disabled branch");
+        assert_eq!(disabled.color, colors.on_surface.with_opacity(0.38));
+        assert_eq!(disabled.width, px(1.0));
+
+        let focused =
+            resolve(&property, WidgetStates::from(WidgetState::Focused)).expect("focused branch");
+        assert_eq!(focused.color, colors.primary);
+        assert_eq!(focused.width, px(2.0));
+
+        let hovered =
+            resolve(&property, WidgetStates::from(WidgetState::Hovered)).expect("hovered branch");
+        assert_eq!(hovered.color, colors.on_surface);
+        assert_eq!(hovered.width, px(1.0));
+
+        let error =
+            resolve(&property, WidgetStates::from(WidgetState::Error)).expect("error branch");
+        assert_eq!(error.color, colors.error);
+        assert_eq!(error.width, px(1.0));
+
+        // Combined-state pins: within `error`, `focused` beats `hovered`
+        // beats plain — and `error+focused` uses a 2.0 width (unlike the
+        // top-level `focused` branch's own 2.0, this confirms the nested
+        // branch, not a fallthrough to the outer one, produced it).
+        let error_focused = resolve(
+            &property,
+            WidgetStates::from(WidgetState::Error).with_state(WidgetState::Focused),
+        )
+        .expect("error+focused branch");
+        assert_eq!(error_focused.color, colors.error);
+        assert_eq!(error_focused.width, px(2.0));
+
+        let error_hovered = resolve(
+            &property,
+            WidgetStates::from(WidgetState::Error).with_state(WidgetState::Hovered),
+        )
+        .expect("error+hovered branch");
+        assert_eq!(error_hovered.color, colors.on_error_container);
+        assert_eq!(error_hovered.width, px(1.0));
+
+        // Top-level combined-state pin: focused+hovered resolves the
+        // focused (2.0, primary) branch, not hovered's — the oracle's own
+        // documented precedence for this widget (see the module docs).
+        let focused_hovered = resolve(
+            &property,
+            WidgetStates::from(WidgetState::Focused).with_state(WidgetState::Hovered),
+        )
+        .expect("focused+hovered branch");
+        assert_eq!(focused_hovered.color, colors.primary);
+        assert_eq!(focused_hovered.width, px(2.0));
+
+        // Disabled outranks every other state, including error.
+        let disabled_error = resolve(
+            &property,
+            WidgetStates::from(WidgetState::Disabled).with_state(WidgetState::Error),
+        )
+        .expect("disabled+error branch");
+        assert_eq!(disabled_error.color, colors.on_surface.with_opacity(0.38));
+        assert_eq!(disabled_error.width, px(1.0));
+    }
+
+    /// Mutation-style red-check: swapping the `error`/`focused` branch order
+    /// (checking `Focused` before `Error`) would make `error+focused`
+    /// resolve `colors.primary` (the top-level focused color) instead of
+    /// `colors.error` — this assertion fails under that mutant.
+    #[test]
+    fn active_indicator_error_branch_is_checked_before_focused_at_the_top_level() {
+        let colors = ColorScheme::light();
+        let property = default_active_indicator(colors);
+        let error_focused = resolve(
+            &property,
+            WidgetStates::from(WidgetState::Error).with_state(WidgetState::Focused),
+        )
+        .expect("error+focused branch");
+        assert_eq!(
+            error_focused.color, colors.error,
+            "error must be checked before focused"
+        );
+        assert_ne!(error_focused.color, colors.primary);
+    }
+
+    // ========================================================================
+    // State-table pins — `default_hint_style`
+    // ========================================================================
+
+    #[test]
+    fn hint_style_state_table_pins() {
+        let colors = ColorScheme::light();
+        let property = default_hint_style(colors);
+
+        assert_eq!(
+            resolve(&property, WidgetStates::NONE).and_then(|s| s.color),
+            Some(colors.on_surface_variant)
+        );
+        assert_eq!(
+            resolve(&property, WidgetStates::from(WidgetState::Disabled)).and_then(|s| s.color),
+            Some(colors.on_surface.with_opacity(0.38))
+        );
+    }
+
+    // ========================================================================
+    // State-table pins — `default_label_style` (combined states pinned)
+    // ========================================================================
+
+    #[test]
+    fn label_style_state_table_pins_every_branch_including_combined_states() {
+        let colors = ColorScheme::light();
+        let base = TextStyle::default().with_font_size(16.0);
+        let property = default_label_style(colors, base);
+
+        let color_of = |states: WidgetStates| resolve(&property, states).and_then(|s| s.color);
+
+        assert_eq!(
+            color_of(WidgetStates::NONE),
+            Some(colors.on_surface_variant)
+        );
+        assert_eq!(
+            color_of(WidgetStates::from(WidgetState::Disabled)),
+            Some(colors.on_surface.with_opacity(0.38))
+        );
+        assert_eq!(
+            color_of(WidgetStates::from(WidgetState::Focused)),
+            Some(colors.primary)
+        );
+        assert_eq!(
+            color_of(WidgetStates::from(WidgetState::Hovered)),
+            Some(colors.on_surface_variant)
+        );
+        assert_eq!(
+            color_of(WidgetStates::from(WidgetState::Error)),
+            Some(colors.error)
+        );
+        assert_eq!(
+            color_of(WidgetStates::from(WidgetState::Error).with_state(WidgetState::Focused)),
+            Some(colors.error)
+        );
+        assert_eq!(
+            color_of(WidgetStates::from(WidgetState::Error).with_state(WidgetState::Hovered)),
+            Some(colors.on_error_container)
+        );
+        assert_eq!(
+            color_of(WidgetStates::from(WidgetState::Focused).with_state(WidgetState::Hovered)),
+            Some(colors.primary),
+            "focused must win over hovered"
+        );
+        assert_eq!(
+            color_of(WidgetStates::from(WidgetState::Disabled).with_state(WidgetState::Error)),
+            Some(colors.on_surface.with_opacity(0.38)),
+            "disabled must win over error"
+        );
+    }
+
+    // ========================================================================
+    // State-table pins — `default_helper_style` / `default_error_style`
+    // ========================================================================
+
+    #[test]
+    fn helper_style_state_table_pins() {
+        let colors = ColorScheme::light();
+        let base = TextStyle::default().with_font_size(12.0);
+        let property = default_helper_style(colors, base);
+
+        assert_eq!(
+            resolve(&property, WidgetStates::NONE).and_then(|s| s.color),
+            Some(colors.on_surface_variant)
+        );
+        assert_eq!(
+            resolve(&property, WidgetStates::from(WidgetState::Disabled)).and_then(|s| s.color),
+            Some(colors.on_surface.with_opacity(0.38))
+        );
+    }
+
+    #[test]
+    fn error_style_is_unconditionally_error_colored() {
+        let colors = ColorScheme::light();
+        let base = TextStyle::default().with_font_size(12.0);
+        let property = default_error_style(colors, base);
+
+        // No other state changes the outcome — not even disabled, matching
+        // the oracle's unconditional `errorStyle` (`:6099-6103`).
+        for states in [
+            WidgetStates::NONE,
+            WidgetStates::from(WidgetState::Disabled),
+            WidgetStates::from(WidgetState::Focused),
+            WidgetStates::from(WidgetState::Hovered),
+        ] {
+            assert_eq!(
+                resolve(&property, states).and_then(|s| s.color),
+                Some(colors.error)
+            );
+        }
+    }
+
+    // ========================================================================
+    // Hover blend
+    // ========================================================================
+
+    #[test]
+    fn hover_blend_matches_blend_over_exactly_when_hovering() {
+        let fill = Color::rgb(200, 200, 200);
+        let brightness = Brightness::Light;
+        let blended = hover_blended_fill(fill, brightness, true, true, true);
+        let expected = default_hover_color(brightness).blend_over(fill);
+        assert_eq!(blended, expected);
+        assert_ne!(blended, fill, "a real blend must change the color");
+    }
+
+    #[test]
+    fn hover_blend_is_identity_when_not_hovering() {
+        let fill = Color::rgb(200, 200, 200);
+        assert_eq!(
+            hover_blended_fill(fill, Brightness::Light, true, true, false),
+            fill
+        );
+    }
+
+    #[test]
+    fn hover_blend_is_identity_when_not_filled() {
+        let fill = Color::TRANSPARENT;
+        assert_eq!(
+            hover_blended_fill(fill, Brightness::Light, false, true, true),
+            fill
+        );
+    }
+
+    #[test]
+    fn hover_blend_is_identity_when_disabled() {
+        let fill = Color::rgb(200, 200, 200);
+        assert_eq!(
+            hover_blended_fill(fill, Brightness::Light, true, false, true),
+            fill
+        );
+    }
+
+    #[test]
+    fn default_hover_color_is_keyed_on_brightness_not_a_color_scheme_role() {
+        assert_eq!(
+            default_hover_color(Brightness::Light),
+            Color::BLACK.with_opacity(0.04)
+        );
+        assert_eq!(
+            default_hover_color(Brightness::Dark),
+            Color::WHITE.with_opacity(0.04)
+        );
+    }
+
+    // ========================================================================
+    // Float truth table — all four (is_empty, focused) corners + disabled
+    // ========================================================================
+
+    #[test]
+    fn float_truth_table_all_four_corners_plus_disabled() {
+        // Corner 1: has text, unfocused, enabled -> floats (non-empty alone floats it).
+        assert!(label_should_float(false, false, true));
+        // Corner 2: has text, focused, enabled -> floats.
+        assert!(label_should_float(false, true, true));
+        // Corner 3: empty, unfocused, enabled -> does not float (inline).
+        assert!(!label_should_float(true, false, true));
+        // Corner 4: empty, focused, enabled -> floats (focus alone floats an
+        // empty field).
+        assert!(label_should_float(true, true, true));
+        // Disabled corner: empty, "focused", but disabled -> does not float.
+        // This is the load-bearing `enabled` guard the doc comment names —
+        // a field focused then disabled must not keep floating.
+        assert!(!label_should_float(true, true, false));
+    }
+
+    #[test]
+    fn should_show_hint_truth_table() {
+        // No label at all: hint tracks emptiness alone.
+        assert!(should_show_hint(true, false, false));
+        assert!(!should_show_hint(false, false, false));
+        // Label present, not floating (inline): hint is suppressed even
+        // though the field is empty — the label occupies the slot.
+        assert!(!should_show_hint(true, true, false));
+        // Label present AND floating: hint still shows when empty (both
+        // the floated label and the hint are visible at once).
+        assert!(should_show_hint(true, true, true));
+        // Non-empty: hint never shows regardless of label/float.
+        assert!(!should_show_hint(false, true, true));
+    }
+
+    // ========================================================================
+    // Helper/error line selection
+    // ========================================================================
+
+    #[test]
+    fn error_replaces_helper_when_both_are_set() {
+        let decoration = InputDecoration {
+            helper_text: Some("helper".to_string()),
+            error_text: Some("error".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(helper_or_error_line(&decoration), Some(("error", true)));
+    }
+
+    #[test]
+    fn helper_shows_alone_when_no_error() {
+        let decoration = InputDecoration {
+            helper_text: Some("helper".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(helper_or_error_line(&decoration), Some(("helper", false)));
+    }
+
+    #[test]
+    fn error_shows_alone_when_no_helper() {
+        let decoration = InputDecoration {
+            error_text: Some("error".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(helper_or_error_line(&decoration), Some(("error", true)));
+    }
+
+    #[test]
+    fn neither_helper_nor_error_line_when_both_unset() {
+        assert_eq!(helper_or_error_line(&InputDecoration::default()), None);
+    }
+}

--- a/crates/flui-material/src/lib.rs
+++ b/crates/flui-material/src/lib.rs
@@ -75,6 +75,7 @@ pub mod filled_button;
 pub mod floating_action_button;
 pub mod icon_button;
 pub mod ink_well;
+pub mod input_decorator;
 pub mod material;
 pub mod outlined_button;
 pub mod scaffold;
@@ -96,6 +97,7 @@ pub use filled_button::FilledButton;
 pub use floating_action_button::FloatingActionButton;
 pub use icon_button::IconButton;
 pub use ink_well::{InkWell, InkWellState};
+pub use input_decorator::{InputDecoration, InputDecorator, InputDecoratorState};
 pub use material::Material;
 pub use outlined_button::OutlinedButton;
 pub use scaffold::Scaffold;
@@ -105,7 +107,7 @@ pub use text_theme::TextTheme;
 pub use theme::Theme;
 pub use theme_data::{
     AppBarThemeData, CardThemeData, DialogThemeData, ElevatedButtonThemeData, FabThemeData,
-    FilledButtonThemeData, IconButtonThemeData, OutlinedButtonThemeData, TextButtonThemeData,
-    ThemeData, ThemeDataOverrides,
+    FilledButtonThemeData, IconButtonThemeData, InputDecorationThemeData, OutlinedButtonThemeData,
+    TextButtonThemeData, ThemeData, ThemeDataOverrides,
 };
 pub use typography::english_like_2021;

--- a/crates/flui-material/src/theme_data.rs
+++ b/crates/flui-material/src/theme_data.rs
@@ -693,4 +693,48 @@ mod tests {
         let patched = base.copy_with(ThemeDataOverrides::default());
         assert_eq!(patched.card_theme, Some(card_theme));
     }
+
+    /// `ThemeDataOverrides::input_decoration_theme` round-trips through
+    /// `copy_with` — the new slot's own dedicated proof, distinct from
+    /// `copy_with_sets_the_new_component_theme_slots`'s pre-existing
+    /// coverage of the other slots.
+    #[test]
+    fn copy_with_sets_input_decoration_theme_slot() {
+        use flui_types::geometry::px;
+
+        let base = ThemeData::light();
+        let input_decoration_theme = InputDecorationThemeData {
+            content_padding: Some(EdgeInsets::all(px(9.0))),
+            ..Default::default()
+        };
+
+        let patched = base.copy_with(ThemeDataOverrides {
+            input_decoration_theme: Some(input_decoration_theme.clone()),
+            ..Default::default()
+        });
+
+        assert_eq!(patched.input_decoration_theme, Some(input_decoration_theme));
+        // Untouched slots stay unset, mirroring the base theme.
+        assert!(patched.card_theme.is_none());
+    }
+
+    /// Same already-set-slot-survives-a-`None`-override proof as
+    /// `copy_with_none_preserves_an_already_set_component_theme_slot`, for
+    /// the new `input_decoration_theme` slot specifically.
+    #[test]
+    fn copy_with_none_preserves_an_already_set_input_decoration_theme_slot() {
+        use flui_types::geometry::px;
+
+        let input_decoration_theme = InputDecorationThemeData {
+            content_padding: Some(EdgeInsets::all(px(9.0))),
+            ..Default::default()
+        };
+        let base = ThemeData::light().copy_with(ThemeDataOverrides {
+            input_decoration_theme: Some(input_decoration_theme.clone()),
+            ..Default::default()
+        });
+
+        let patched = base.copy_with(ThemeDataOverrides::default());
+        assert_eq!(patched.input_decoration_theme, Some(input_decoration_theme));
+    }
 }

--- a/crates/flui-material/src/theme_data.rs
+++ b/crates/flui-material/src/theme_data.rs
@@ -4,9 +4,11 @@
 //! `3.44.0`).
 
 use flui_types::EdgeInsets;
+use flui_types::Pixels;
 use flui_types::platform::Brightness;
-use flui_types::styling::Color;
+use flui_types::styling::{BorderSide, Color};
 use flui_types::typography::TextStyle;
+use flui_widgets::WidgetStateProperty;
 
 use crate::button_style::ButtonStyle;
 use crate::color_scheme::ColorScheme;
@@ -239,6 +241,57 @@ pub struct FabThemeData {
     pub elevation: Option<f32>,
 }
 
+/// Overrides [`InputDecorator`](crate::input_decorator::InputDecorator)'s
+/// `_InputDecoratorDefaultsM3` token defaults, one field at a time — an unset
+/// field here still falls through to the M3 default table for that field
+/// (see `input_decorator.rs`'s `default_*` functions), it does not blank the
+/// whole slot.
+///
+/// Flutter parity: `InputDecorationThemeData` (`material/input_decorator.dart`,
+/// oracle tag `3.44.0`), narrowed to the fields FLUI's `InputDecorator`
+/// actually consumes: [`fill_color`](Self::fill_color),
+/// [`active_indicator`](Self::active_indicator), [`hint_style`](Self::hint_style),
+/// [`label_style`](Self::label_style), [`helper_style`](Self::helper_style),
+/// [`error_style`](Self::error_style), [`content_padding`](Self::content_padding).
+/// Named deferrals (no consumer in FLUI's `InputDecorator` yet — see that
+/// module's docs for the full named-divergence list): `outlineBorder` (no
+/// `OutlineInputBorder` variant in V1), `iconColor`/`prefixIconColor`/
+/// `suffixIconColor` (no icon slots), `floatingLabelStyle` (V1's snap float
+/// reuses [`label_style`](Self::label_style) for both positions — the oracle
+/// itself resolves both through an identical state table), `isDense`,
+/// `isCollapsed`, `border`, `focusColor`/`hoverColor` (the container's hover
+/// blend is a fixed `ThemeData.hoverColor`-shaped constant in V1, not yet a
+/// themeable slot), and every constraint/alignment/behavior field.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct InputDecorationThemeData {
+    /// Overrides the filled container's fill color, per state. `None` falls
+    /// through to the M3 default (disabled: `onSurface@4%`; otherwise
+    /// `surfaceContainerHighest`) — see `input_decorator.rs`'s
+    /// `default_fill_color`.
+    pub fill_color: Option<WidgetStateProperty<Option<Color>>>,
+    /// Overrides the bottom underline indicator's color/width, per state.
+    /// `None` falls through to the M3 default state table — see
+    /// `input_decorator.rs`'s `default_active_indicator`.
+    pub active_indicator: Option<WidgetStateProperty<Option<BorderSide<Pixels>>>>,
+    /// Overrides the hint text style, per state. `None` falls through to the
+    /// M3 default (disabled/enabled `onSurfaceVariant`).
+    pub hint_style: Option<WidgetStateProperty<Option<TextStyle>>>,
+    /// Overrides the label text style (both the floating and inline
+    /// positions — see the struct doc's `floatingLabelStyle` note), per
+    /// state. `None` falls through to the M3 default state table.
+    pub label_style: Option<WidgetStateProperty<Option<TextStyle>>>,
+    /// Overrides the helper line's text style, per state. `None` falls
+    /// through to the M3 default (disabled/enabled `onSurfaceVariant`).
+    pub helper_style: Option<WidgetStateProperty<Option<TextStyle>>>,
+    /// Overrides the error line's text style, per state. `None` falls
+    /// through to the M3 default (`error`, unconditionally).
+    pub error_style: Option<WidgetStateProperty<Option<TextStyle>>>,
+    /// Overrides the container's content padding. `None` falls through to
+    /// the M3 filled-non-outline default (`EdgeInsets.fromLTRB(12, 8, 12,
+    /// 8)`, `input_decorator.dart`'s `contentPadding` doc, tag `3.44.0`).
+    pub content_padding: Option<EdgeInsets>,
+}
+
 /// Visual-style configuration provided to descendants by a
 /// [`Theme`](crate::Theme) ancestor.
 ///
@@ -317,6 +370,11 @@ pub struct ThemeData {
     /// token defaults, per field. Flutter parity:
     /// `ThemeData.floatingActionButtonTheme`.
     pub floating_action_button_theme: Option<FabThemeData>,
+
+    /// Overrides [`InputDecorator`](crate::input_decorator::InputDecorator)'s
+    /// M3 token defaults, per field. Flutter parity:
+    /// `ThemeData.inputDecorationTheme`.
+    pub input_decoration_theme: Option<InputDecorationThemeData>,
 }
 
 impl ThemeData {
@@ -338,6 +396,7 @@ impl ThemeData {
             card_theme: None,
             dialog_theme: None,
             floating_action_button_theme: None,
+            input_decoration_theme: None,
         }
     }
 
@@ -359,6 +418,7 @@ impl ThemeData {
             card_theme: None,
             dialog_theme: None,
             floating_action_button_theme: None,
+            input_decoration_theme: None,
         }
     }
 
@@ -435,6 +495,9 @@ impl ThemeData {
             floating_action_button_theme: overrides
                 .floating_action_button_theme
                 .or_else(|| self.floating_action_button_theme.clone()),
+            input_decoration_theme: overrides
+                .input_decoration_theme
+                .or_else(|| self.input_decoration_theme.clone()),
         }
     }
 }
@@ -481,6 +544,8 @@ pub struct ThemeDataOverrides {
     /// Replaces [`ThemeData::floating_action_button_theme`] wholesale when
     /// `Some`.
     pub floating_action_button_theme: Option<FabThemeData>,
+    /// Replaces [`ThemeData::input_decoration_theme`] wholesale when `Some`.
+    pub input_decoration_theme: Option<InputDecorationThemeData>,
 }
 
 impl Default for ThemeData {
@@ -581,6 +646,7 @@ mod tests {
             assert!(theme.card_theme.is_none());
             assert!(theme.dialog_theme.is_none());
             assert!(theme.floating_action_button_theme.is_none());
+            assert!(theme.input_decoration_theme.is_none());
         }
     }
 

--- a/crates/flui-material/tests/input_decorator.rs
+++ b/crates/flui-material/tests/input_decorator.rs
@@ -23,9 +23,13 @@
 mod common;
 
 use common::{lay_out, tight};
-use flui_material::{InputDecoration, InputDecorator, Theme, ThemeData};
+use flui_material::{
+    InputDecoration, InputDecorationThemeData, InputDecorator, Theme, ThemeData, ThemeDataOverrides,
+};
 use flui_types::Color;
-use flui_widgets::SizedBox;
+use flui_types::geometry::px;
+use flui_types::styling::{BorderSide, BorderStyle};
+use flui_widgets::{SizedBox, WidgetStateProperty};
 
 /// A small render-object child standing in for a real field's content (e.g.
 /// a future `EditableText`) — `SizedBox` renders as `RenderConstrainedBox`,
@@ -154,11 +158,17 @@ fn disabled_row_reaches_the_mounted_decoration_with_disabled_m3_colors() {
     );
 }
 
-/// An enabled, unfilled field composes a fully transparent container — no
-/// fill and no underline color leak in from the M3 defaults.
+/// An enabled, unfilled field composes a TRANSPARENT fill — but the
+/// underline still paints: `filled` only gates `_getFillColor`
+/// (`input_decorator.dart:2131-2140`, tag `3.44.0`); `activeIndicatorBorder`
+/// is resolved unconditionally, filled or not. Pinning both halves matters —
+/// a prior version of this test asserted only the transparent fill and its
+/// doc comment claimed the underline was absent too, which is false and
+/// would not have caught a regression that dropped the underline entirely.
 #[test]
-fn unfilled_decoration_is_transparent() {
+fn unfilled_enabled_decoration_has_a_transparent_fill_but_still_paints_the_underline() {
     let theme = ThemeData::light();
+    let colors = theme.color_scheme;
     let decoration = InputDecoration::default();
     let laid = lay_out(
         Theme::new(
@@ -176,6 +186,73 @@ fn unfilled_decoration_is_transparent() {
         .expect("RenderDecoratedBox reports a \"decoration\" diagnostics property");
     assert!(
         decoration_debug.contains(&format!("{:?}", Color::TRANSPARENT)),
-        "an unfilled decoration must be transparent, got: {decoration_debug}"
+        "an unfilled decoration must have a transparent fill, got: {decoration_debug}"
+    );
+
+    let plain_indicator_color = colors.on_surface_variant;
+    assert!(
+        decoration_debug.contains(&format!("{plain_indicator_color:?}")),
+        "the underline must still paint its plain M3 color even when unfilled, got: \
+         {decoration_debug}"
+    );
+}
+
+/// `ThemeData.input_decoration_theme`'s `fill_color`/`active_indicator`
+/// override the M3 default at the mounted level — proving the theme-tier
+/// resolve arm in `InputDecoratorState::build` (`decoration_theme.fill_color
+/// .as_ref().map_or_else(...)`, and the identical shape for
+/// `active_indicator`) is actually reachable, not just correct in isolation
+/// (every other `decoration_theme.*` slot in that function follows the same
+/// `Option::as_ref().map_or_else(default, override)` shape, so this one
+/// mounted proof stands in for the pattern).
+#[test]
+fn themed_fill_color_and_active_indicator_beat_the_m3_default_at_the_mounted_level() {
+    let themed_fill = Color::rgb(11, 22, 33);
+    let themed_indicator = BorderSide::new(Color::rgb(44, 55, 66), px(3.0), BorderStyle::Solid);
+    let theme = ThemeData::light();
+    let colors = theme.color_scheme;
+    let theme = theme.copy_with(ThemeDataOverrides {
+        input_decoration_theme: Some(InputDecorationThemeData {
+            fill_color: Some(WidgetStateProperty::all(Some(themed_fill))),
+            active_indicator: Some(WidgetStateProperty::all(Some(themed_indicator))),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let decoration = InputDecoration {
+        filled: true,
+        ..Default::default()
+    };
+    let laid = lay_out(
+        Theme::new(theme, InputDecorator::new(decoration).child(child_stub())),
+        tight(300.0, 100.0),
+    );
+
+    let decorated_box = laid
+        .find_by_render_type("RenderDecoratedBox")
+        .expect("InputDecorator must compose a DecoratedBox");
+    let decoration_debug = laid
+        .render_property(decorated_box, "decoration")
+        .expect("RenderDecoratedBox reports a \"decoration\" diagnostics property");
+
+    assert!(
+        decoration_debug.contains(&format!("{themed_fill:?}")),
+        "a themed fill_color must beat the M3 default at the mounted level, got: \
+         {decoration_debug}"
+    );
+    assert!(
+        decoration_debug.contains(&format!("{:?}", themed_indicator.color)),
+        "a themed active_indicator must beat the M3 default at the mounted level, got: \
+         {decoration_debug}"
+    );
+
+    // The override must actually WIN, not merely coexist with the M3
+    // default — the plain-state M3 fill (`surfaceContainerHighest`) must
+    // not appear anywhere in the mounted decoration.
+    let m3_default_fill = colors.surface_container_highest;
+    assert!(
+        !decoration_debug.contains(&format!("{m3_default_fill:?}")),
+        "the M3 default fill must not leak through a configured theme override, got: \
+         {decoration_debug}"
     );
 }

--- a/crates/flui-material/tests/input_decorator.rs
+++ b/crates/flui-material/tests/input_decorator.rs
@@ -1,0 +1,181 @@
+//! `InputDecorator` widget-level integration coverage — mounts a real
+//! `InputDecorator` through the full render pipeline (`tests/common/mod.rs`,
+//! the same harness `tests/card.rs`/`tests/ink_well.rs` use) and probes the
+//! composed [`flui_widgets::DecoratedBox`] (`RenderDecoratedBox`),
+//! [`flui_widgets::MouseRegion`] (`RenderMouseRegion`), and
+//! [`flui_widgets::Text`] (`RenderParagraph`) render objects it produces.
+//!
+//! # Hover blend is not end-to-end drivable here
+//!
+//! `tests/ink_well.rs`'s own module doc already established this gap:
+//! `MouseRegion::on_enter`/`on_exit` require `MouseTracker::update_with_event`,
+//! which only a full `AppBinding` frame pump runs — the raw
+//! `HitTestResult::dispatch` this headless harness's `dispatch_pointer_move`
+//! calls never reaches it. `InputDecoratorState` uses `on_enter`/`on_exit`
+//! (the oracle's own `TextField._handleHover` wiring, `text_field.dart:1799`,
+//! tag `3.44.0`) for the same real-behavior reason `InkWell` does — the hover
+//! blend math itself is exhaustively pinned by `input_decorator.rs`'s own
+//! unit tests (`hover_blend_*`); this file only proves the `MouseRegion` is
+//! actually composed around the container, structurally.
+
+#![allow(clippy::unwrap_used)] // a panic IS the failure report in test code (docs/PANIC-POLICY.md)
+
+mod common;
+
+use common::{lay_out, tight};
+use flui_material::{InputDecoration, InputDecorator, Theme, ThemeData};
+use flui_types::Color;
+use flui_widgets::SizedBox;
+
+/// A small render-object child standing in for a real field's content (e.g.
+/// a future `EditableText`) — `SizedBox` renders as `RenderConstrainedBox`,
+/// distinct from the decorator's own `RenderDecoratedBox`/`RenderParagraph`
+/// nodes, so it can't be confused with them in a render-type count.
+fn child_stub() -> SizedBox {
+    SizedBox::new(20.0, 20.0)
+}
+
+#[test]
+fn mouse_region_wraps_the_composed_decoration() {
+    let theme = ThemeData::light();
+    let decoration = InputDecoration {
+        filled: true,
+        ..Default::default()
+    };
+    let laid = lay_out(
+        Theme::new(theme, InputDecorator::new(decoration).child(child_stub())),
+        tight(300.0, 100.0),
+    );
+
+    laid.find_by_render_type("RenderMouseRegion")
+        .expect("InputDecorator must wrap its content in a MouseRegion for hover tracking");
+    laid.find_by_render_type("RenderDecoratedBox")
+        .expect("InputDecorator must compose a DecoratedBox for the fill/underline");
+}
+
+/// All four text rows in one mount: the label floats (focused, empty) so
+/// both it AND the hint render, plus the child, plus the error line
+/// (replacing the unset-but-would-be helper). Proves slot presence — every
+/// documented row actually reaches the render tree.
+#[test]
+fn slot_presence_label_hint_child_and_error_all_render() {
+    let theme = ThemeData::light();
+    let decoration = InputDecoration {
+        label_text: Some("Email".to_string()),
+        hint_text: Some("you@example.com".to_string()),
+        error_text: Some("Required".to_string()),
+        filled: true,
+        ..Default::default()
+    };
+    let laid = lay_out(
+        Theme::new(
+            theme,
+            InputDecorator::new(decoration)
+                .focused(true)
+                .is_empty(true)
+                .child(child_stub()),
+        ),
+        tight(300.0, 200.0),
+    );
+
+    // Label (floating) + hint (empty && floating) + error line = 3 text rows.
+    let text_nodes = laid.find_all_by_render_type("RenderParagraph");
+    assert_eq!(
+        text_nodes.len(),
+        3,
+        "expected label + hint + error rows, found {text_nodes:?}"
+    );
+    laid.find_by_render_type("RenderConstrainedBox")
+        .expect("the child content must still be composed");
+}
+
+/// Error replaces helper: with both set, exactly one helper/error text row
+/// renders, not two.
+#[test]
+fn error_replaces_helper_at_the_mounted_level() {
+    let theme = ThemeData::light();
+    let decoration = InputDecoration {
+        helper_text: Some("Helper".to_string()),
+        error_text: Some("Error".to_string()),
+        filled: true,
+        ..Default::default()
+    };
+    // No label/hint set, so the only text row is the helper-or-error line.
+    let laid = lay_out(
+        Theme::new(theme, InputDecorator::new(decoration).child(child_stub())),
+        tight(300.0, 150.0),
+    );
+
+    let text_nodes = laid.find_all_by_render_type("RenderParagraph");
+    assert_eq!(
+        text_nodes.len(),
+        1,
+        "error must replace helper, not render alongside it"
+    );
+}
+
+/// A disabled, filled field renders the M3 disabled fill color, not the
+/// enabled default — proves the state table's `disabled` branch actually
+/// reaches painted configuration, not just `default_fill_color`'s own unit
+/// test in isolation.
+#[test]
+fn disabled_row_reaches_the_mounted_decoration_with_disabled_m3_colors() {
+    let theme = ThemeData::light();
+    let colors = theme.color_scheme;
+    let decoration = InputDecoration {
+        filled: true,
+        enabled: false,
+        ..Default::default()
+    };
+    let laid = lay_out(
+        Theme::new(theme, InputDecorator::new(decoration).child(child_stub())),
+        tight(300.0, 100.0),
+    );
+
+    let decorated_box = laid
+        .find_by_render_type("RenderDecoratedBox")
+        .expect("InputDecorator must compose a DecoratedBox");
+    let decoration_debug = laid
+        .render_property(decorated_box, "decoration")
+        .expect("RenderDecoratedBox reports a \"decoration\" diagnostics property");
+
+    let disabled_fill = colors.on_surface.with_opacity(0.04);
+    assert!(
+        decoration_debug.contains(&format!("{disabled_fill:?}")),
+        "disabled fill color {disabled_fill:?} must reach the mounted decoration, got: \
+         {decoration_debug}"
+    );
+
+    let disabled_indicator = colors.on_surface.with_opacity(0.38);
+    assert!(
+        decoration_debug.contains(&format!("{disabled_indicator:?}")),
+        "disabled indicator color {disabled_indicator:?} must reach the mounted decoration, got: \
+         {decoration_debug}"
+    );
+}
+
+/// An enabled, unfilled field composes a fully transparent container — no
+/// fill and no underline color leak in from the M3 defaults.
+#[test]
+fn unfilled_decoration_is_transparent() {
+    let theme = ThemeData::light();
+    let decoration = InputDecoration::default();
+    let laid = lay_out(
+        Theme::new(
+            theme,
+            InputDecorator::new(decoration).child(SizedBox::shrink()),
+        ),
+        tight(300.0, 100.0),
+    );
+
+    let decorated_box = laid
+        .find_by_render_type("RenderDecoratedBox")
+        .expect("InputDecorator must compose a DecoratedBox");
+    let decoration_debug = laid
+        .render_property(decorated_box, "decoration")
+        .expect("RenderDecoratedBox reports a \"decoration\" diagnostics property");
+    assert!(
+        decoration_debug.contains(&format!("{:?}", Color::TRANSPARENT)),
+        "an unfilled decoration must be transparent, got: {decoration_debug}"
+    );
+}

--- a/crates/flui-widgets/src/text/editable_text.rs
+++ b/crates/flui-widgets/src/text/editable_text.rs
@@ -63,9 +63,16 @@ pub struct EditableText {
     pub(super) caret_color: Color,
     /// Whether this field accepts focus and input. `true` by default.
     ///
-    /// Flutter parity: `EditableText.enabled` narrowed to the two behaviors
-    /// this substrate can actually withhold — see [`enabled`](Self::enabled)'s
-    /// doc comment.
+    /// **Named hoist, not a direct port**: the oracle has no
+    /// `EditableText.enabled` property at this tag — `enabled` lives on
+    /// `TextField` and flows down as `_isEnabled` into
+    /// `_effectiveFocusNode.canRequestFocus`
+    /// (`text_field.dart:1183,1282-1299`, tag `3.44.0`). FLUI's
+    /// [`TextField`](super::text_field::TextField) has no decoration/enabled
+    /// plumbing yet, so this substrate hoists the behavior onto
+    /// `EditableText` itself, one layer lower than the oracle — see
+    /// [`enabled`](Self::enabled)'s doc comment for exactly what it
+    /// withholds.
     pub(super) enabled: bool,
     /// Style applied to the field's [`TextSpan`], flowing through
     /// [`TextSpan::with_style`]. `None` renders with the span's own default.
@@ -100,7 +107,9 @@ impl EditableText {
     }
 
     /// Set whether the field accepts focus and keyboard input (default
-    /// `true`).
+    /// `true`) — see the [`enabled`](Self::enabled) field's doc comment for
+    /// why this is a named hoist of `TextField.enabled`, not a direct
+    /// `EditableText` parity port.
     ///
     /// A disabled field withholds focus acquisition — it stops publishing its
     /// [`FocusNode`] id on [`TextEditingController`], so an enclosing
@@ -109,8 +118,12 @@ impl EditableText {
     /// withdraw-on-unavailable mechanism `dispose` already uses for an
     /// unmounted field — and marks the node
     /// [`FocusNode::set_can_request_focus`]`(false)`, which keyboard-traversal
-    /// (`focus_next`/`focus_previous`) already honors. If the field is
-    /// focused when it becomes disabled, it is unfocused. Its key handler
+    /// (`focus_next`/`focus_previous`) already honors. **Unlike** Flutter's
+    /// `FocusNode.canRequestFocus` setter, FLUI's `set_can_request_focus` is a
+    /// bare atomic store with no side effects — so if the field is focused
+    /// when it becomes disabled, `did_update_view` explicitly calls
+    /// `FocusManager::unfocus` (a step the oracle's setter performs
+    /// implicitly as part of assigning `canRequestFocus`). Its key handler
     /// also stops mutating the controller while disabled, so even a stray
     /// dispatch reaching an already-focused-then-disabled node is a no-op.
     ///
@@ -166,8 +179,11 @@ pub struct EditableTextState {
     focus_listener_id: Option<ListenerId>,
     /// The view's `enabled` at construction time, cached because
     /// `init_state` has no `view` parameter — see [`EditableText::enabled`].
-    /// Every later change is read straight from the view in
-    /// `did_update_view`/`build`, not from this cache.
+    /// Read exactly once, by `init_state`'s initial-publish decision; there
+    /// is no reader afterward, so `did_update_view` deliberately does NOT
+    /// keep this field in sync post-mount (every later change is read
+    /// straight from the view in `did_update_view`/`build` instead, which is
+    /// the only place that still needs it).
     enabled: bool,
 }
 
@@ -251,7 +267,6 @@ impl ViewState<EditableText> for EditableTextState {
     }
 
     fn did_update_view(&mut self, _old_view: &EditableText, new_view: &EditableText) {
-        self.enabled = new_view.enabled;
         self.focus_node.set_can_request_focus(new_view.enabled);
         if new_view.enabled {
             self.controller
@@ -493,6 +508,100 @@ mod tests {
         assert!(
             controller.focus_node_id().is_some(),
             "an enabled field must publish a focus node"
+        );
+    }
+
+    /// Disabling a focused field unfocuses it and withdraws its published
+    /// node. Load-bearing: FLUI's `FocusNode::set_can_request_focus` is a
+    /// bare atomic store with no side effects — unlike Flutter's
+    /// `FocusNode.canRequestFocus` setter, which auto-unfocuses — so nothing
+    /// but `did_update_view`'s explicit `FocusManager::unfocus` call (see
+    /// [`EditableText::enabled`]'s doc comment) does this.
+    ///
+    /// Red-check: delete the `FocusManager::global().unfocus()` call in
+    /// `did_update_view`'s disabled branch — the node stays primary-focused
+    /// and the first assertion fails.
+    #[test]
+    fn disabling_a_focused_field_unfocuses_it_and_withdraws_the_node() {
+        let _guard = crate::test_harness::FOCUS_TEST_LOCK.lock();
+        FocusManager::global().unfocus();
+
+        let controller = TextEditingController::new();
+        let mut harness = crate::test_harness::mount(EditableText::new(controller.clone()));
+
+        let node_id = controller
+            .focus_node_id()
+            .expect("an enabled field publishes its node");
+        FocusManager::global().request_focus(node_id);
+        assert_eq!(FocusManager::global().primary_focus(), Some(node_id));
+
+        harness.swap_root(EditableText::new(controller.clone()).enabled(false));
+
+        assert_ne!(
+            FocusManager::global().primary_focus(),
+            Some(node_id),
+            "disabling a focused field must unfocus it"
+        );
+        assert_eq!(
+            controller.focus_node_id(),
+            None,
+            "disabling must withdraw the published focus node"
+        );
+    }
+
+    /// The contrast case: re-enabling a disabled field republishes its
+    /// node, so it becomes focusable again.
+    #[test]
+    fn re_enabling_a_disabled_field_republishes_its_focus_node() {
+        let _guard = crate::test_harness::FOCUS_TEST_LOCK.lock();
+        FocusManager::global().unfocus();
+
+        let controller = TextEditingController::new();
+        let mut harness =
+            crate::test_harness::mount(EditableText::new(controller.clone()).enabled(false));
+        assert_eq!(controller.focus_node_id(), None);
+
+        harness.swap_root(EditableText::new(controller.clone()));
+
+        assert!(
+            controller.focus_node_id().is_some(),
+            "re-enabling must republish the focus node"
+        );
+    }
+
+    /// The key handler's `can_request_focus` guard, in isolation: invoked
+    /// directly (bypassing `FocusManager::dispatch_key_event`'s own
+    /// primary-focus routing), a disabled node's handler must still refuse
+    /// to mutate the controller.
+    ///
+    /// Red-check: delete the `if !focus_node.can_request_focus() { return
+    /// false; }` guard at the top of `build_key_handler`'s closure — the
+    /// character is inserted and both assertions fail.
+    #[test]
+    fn disabled_key_handler_ignores_input_even_when_invoked_directly() {
+        use flui_interaction::events::Code;
+        use flui_interaction::testing::input::KeyEventBuilder;
+
+        let controller = TextEditingController::new();
+        let focus_node = FocusNode::with_debug_label("test");
+        focus_node.set_can_request_focus(false);
+        let handler = build_key_handler(controller.clone(), Arc::clone(&focus_node));
+
+        let event = KeyEventBuilder::new(Code::KeyA)
+            .with_key(Key::Character("a".to_string()))
+            .with_state(KeyState::Down)
+            .build();
+
+        let consumed = handler(&event);
+
+        assert!(
+            !consumed,
+            "a disabled node's key handler must not consume the event"
+        );
+        assert_eq!(
+            controller.text(),
+            "",
+            "a disabled node's key handler must not mutate the controller"
         );
     }
 

--- a/crates/flui-widgets/src/text/editable_text.rs
+++ b/crates/flui-widgets/src/text/editable_text.rs
@@ -11,7 +11,7 @@ use flui_objects::RenderEditable;
 use flui_rendering::protocol::BoxProtocol;
 use flui_types::{
     Color,
-    typography::{TextDirection, TextSpan},
+    typography::{TextDirection, TextSpan, TextStyle},
 };
 use flui_view::prelude::*;
 use flui_view::{BoxedView, RenderView, impl_render_view};
@@ -61,6 +61,15 @@ pub struct EditableText {
     pub(super) caret_height: f32,
     /// Color of the caret bar when the field is focused.
     pub(super) caret_color: Color,
+    /// Whether this field accepts focus and input. `true` by default.
+    ///
+    /// Flutter parity: `EditableText.enabled` narrowed to the two behaviors
+    /// this substrate can actually withhold — see [`enabled`](Self::enabled)'s
+    /// doc comment.
+    pub(super) enabled: bool,
+    /// Style applied to the field's [`TextSpan`], flowing through
+    /// [`TextSpan::with_style`]. `None` renders with the span's own default.
+    pub(super) text_style: Option<TextStyle>,
 }
 
 impl EditableText {
@@ -71,6 +80,8 @@ impl EditableText {
             controller,
             caret_height: 18.0,
             caret_color: Color::BLACK,
+            enabled: true,
+            text_style: None,
         }
     }
 
@@ -85,6 +96,38 @@ impl EditableText {
     #[must_use]
     pub fn caret_color(mut self, color: Color) -> Self {
         self.caret_color = color;
+        self
+    }
+
+    /// Set whether the field accepts focus and keyboard input (default
+    /// `true`).
+    ///
+    /// A disabled field withholds focus acquisition — it stops publishing its
+    /// [`FocusNode`] id on [`TextEditingController`], so an enclosing
+    /// `TextField`'s tap-to-focus (which reads
+    /// `controller.focus_node_id()`) finds nothing to focus, the same
+    /// withdraw-on-unavailable mechanism `dispose` already uses for an
+    /// unmounted field — and marks the node
+    /// [`FocusNode::set_can_request_focus`]`(false)`, which keyboard-traversal
+    /// (`focus_next`/`focus_previous`) already honors. If the field is
+    /// focused when it becomes disabled, it is unfocused. Its key handler
+    /// also stops mutating the controller while disabled, so even a stray
+    /// dispatch reaching an already-focused-then-disabled node is a no-op.
+    ///
+    /// Tap suppression is a decoration-level concern (an enclosing
+    /// `TextField`'s `GestureDetector`), not this primitive's — out of scope
+    /// here, see `TextField`'s own docs.
+    #[must_use]
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    /// Apply `style` to the field's rendered [`TextSpan`] via
+    /// [`TextSpan::with_style`].
+    #[must_use]
+    pub fn text_style(mut self, style: TextStyle) -> Self {
+        self.text_style = Some(style);
         self
     }
 }
@@ -121,6 +164,11 @@ pub struct EditableTextState {
     /// ID for the focus-change listener we added to the [`FocusManager`], so
     /// dispose removes exactly ours.
     focus_listener_id: Option<ListenerId>,
+    /// The view's `enabled` at construction time, cached because
+    /// `init_state` has no `view` parameter — see [`EditableText::enabled`].
+    /// Every later change is read straight from the view in
+    /// `did_update_view`/`build`, not from this cache.
+    enabled: bool,
 }
 
 impl std::fmt::Debug for EditableTextState {
@@ -135,14 +183,17 @@ impl StatefulView for EditableText {
     type State = EditableTextState;
 
     fn create_state(&self) -> EditableTextState {
+        let focus_node = FocusNode::with_debug_label("EditableText");
+        focus_node.set_can_request_focus(self.enabled);
         EditableTextState {
-            focus_node: FocusNode::with_debug_label("EditableText"),
+            focus_node,
             anchor: flui_objects::SubtreeAnchor::new(),
             parent: None,
             controller: self.controller.clone(),
             controller_listener_id: None,
             rebuild_notifier: flui_foundation::notifier::ChangeNotifier::new(),
             focus_listener_id: None,
+            enabled: self.enabled,
         }
     }
 }
@@ -156,14 +207,22 @@ impl ViewState<EditableText> for EditableTextState {
         //    focus *this* field.
         let parent = crate::interaction::enclosing_focus_parent(ctx);
         parent.attach_node(&self.focus_node);
-        self.controller
-            .set_focus_node_id(Some(self.focus_node.id()));
+        // Publish the node only while enabled — see `EditableText::enabled`'s
+        // doc comment on why withholding publication is the focus-acquisition
+        // gate (mirrors `dispose`'s withdraw-on-unmount below).
+        if self.enabled {
+            self.controller
+                .set_focus_node_id(Some(self.focus_node.id()));
+        }
         self.parent = Some(parent);
         crate::interaction::install_rect_provider(&self.focus_node, &self.anchor, ctx);
 
         // 2. Register a key handler with the FocusManager.  Only fires when
-        //    this node is the primary-focused node.
-        let key_handler = build_key_handler(self.controller.clone());
+        //    this node is the primary-focused node. Gated on
+        //    `can_request_focus` (kept in sync with `enabled` in
+        //    `did_update_view`) so a stray dispatch to an already-focused
+        //    field that has since been disabled is a no-op.
+        let key_handler = build_key_handler(self.controller.clone(), Arc::clone(&self.focus_node));
         FocusManager::global().register_key_handler(self.focus_node.id(), key_handler);
 
         // 3. Forward controller change events into the rebuild notifier so the
@@ -191,16 +250,42 @@ impl ViewState<EditableText> for EditableTextState {
         )));
     }
 
+    fn did_update_view(&mut self, _old_view: &EditableText, new_view: &EditableText) {
+        self.enabled = new_view.enabled;
+        self.focus_node.set_can_request_focus(new_view.enabled);
+        if new_view.enabled {
+            self.controller
+                .set_focus_node_id(Some(self.focus_node.id()));
+        } else {
+            self.controller.set_focus_node_id(None);
+            // A field disabled while focused must not keep the caret and
+            // keyboard input — mirrors Flutter's `TextField`/`EditableText`
+            // unfocusing when `enabled` flips false mid-focus.
+            if self.focus_node.has_primary_focus() {
+                FocusManager::global().unfocus();
+            }
+        }
+    }
+
     fn build(&self, view: &EditableText, _ctx: &dyn BuildContext) -> impl IntoView {
         let controller = self.controller.clone();
         let focus_node = Arc::clone(&self.focus_node);
         let caret_height = view.caret_height;
         let caret_color = view.caret_color;
+        let enabled = view.enabled;
+        let text_style = view.text_style.clone();
 
         crate::navigator::AnchoredBox::new(
             self.anchor.clone(),
             AnimatedBuilder::new(Arc::new(self.rebuild_notifier.clone()), move || {
-                build_field_view(&controller, &focus_node, caret_height, caret_color)
+                build_field_view(
+                    &controller,
+                    &focus_node,
+                    caret_height,
+                    caret_color,
+                    enabled,
+                    text_style.clone(),
+                )
             }),
         )
     }
@@ -244,10 +329,19 @@ impl ViewState<EditableText> for EditableTextState {
 
 /// Build the key-event handler closure for `controller`.
 ///
-/// Only `KeyState::Down` events (which cover key-repeat) are acted upon.
-/// Returns `true` when the event is consumed so propagation stops.
-fn build_key_handler(controller: TextEditingController) -> KeyEventCallback {
+/// Only `KeyState::Down` events (which cover key-repeat) are acted upon, and
+/// only while `focus_node` still allows focus — kept in sync with
+/// `EditableText::enabled` by `did_update_view` — so input is ignored on a
+/// field disabled after it was focused. Returns `true` when the event is
+/// consumed so propagation stops.
+fn build_key_handler(
+    controller: TextEditingController,
+    focus_node: Arc<FocusNode>,
+) -> KeyEventCallback {
     Rc::new(move |event| {
+        if !focus_node.can_request_focus() {
+            return false;
+        }
         if event.state != KeyState::Down {
             return false;
         }
@@ -292,11 +386,16 @@ struct EditableTextRenderView {
     show_caret: bool,
     caret_height: f32,
     caret_color: Color,
+    text_style: Option<TextStyle>,
 }
 
 impl EditableTextRenderView {
     fn build_render_object(&self) -> RenderEditable {
-        RenderEditable::new(TextSpan::new(self.text.clone()), TextDirection::Ltr)
+        let mut span = TextSpan::new(self.text.clone());
+        if let Some(style) = self.text_style.clone() {
+            span = span.with_style(style);
+        }
+        RenderEditable::new(span, TextDirection::Ltr)
             .with_caret_byte_offset(self.caret_byte_offset)
             .with_show_caret(self.show_caret)
             .with_caret_width(2.0)
@@ -333,13 +432,115 @@ fn build_field_view(
     focus_node: &Arc<FocusNode>,
     caret_height: f32,
     caret_color: Color,
+    enabled: bool,
+    text_style: Option<TextStyle>,
 ) -> BoxedView {
     EditableTextRenderView {
         text: controller.text(),
         caret_byte_offset: controller.caret_byte_offset(),
-        show_caret: focus_node.has_primary_focus(),
+        // `enabled` is defensive here: `did_update_view` already unfocuses a
+        // field that becomes disabled while focused, so `has_primary_focus`
+        // should already be `false` by the time this runs.
+        show_caret: enabled && focus_node.has_primary_focus(),
         caret_height,
         caret_color,
+        text_style,
     }
     .boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use flui_interaction::routing::FocusManager;
+
+    use super::*;
+    use crate::text::controller::TextEditingController;
+
+    /// A field constructed disabled never publishes its focus node, so an
+    /// enclosing `TextField`'s tap-to-focus (which reads
+    /// `controller.focus_node_id()`) finds nothing to focus — the
+    /// withhold-acquisition contract [`EditableText::enabled`] documents.
+    ///
+    /// Red-check: drop the `if self.enabled` guard around
+    /// `set_focus_node_id` in `init_state` — the node publishes
+    /// unconditionally and this assertion fails.
+    #[test]
+    fn disabled_field_does_not_publish_its_focus_node() {
+        let _guard = crate::test_harness::FOCUS_TEST_LOCK.lock();
+        FocusManager::global().unfocus();
+
+        let controller = TextEditingController::new();
+        let _harness =
+            crate::test_harness::mount(EditableText::new(controller.clone()).enabled(false));
+
+        assert_eq!(
+            controller.focus_node_id(),
+            None,
+            "a disabled field must not publish a focus node to focus"
+        );
+    }
+
+    /// An enabled field (the default) does publish, so the same field
+    /// re-enabled is focusable again — the contrast case for the test above.
+    #[test]
+    fn enabled_field_publishes_its_focus_node() {
+        let _guard = crate::test_harness::FOCUS_TEST_LOCK.lock();
+        FocusManager::global().unfocus();
+
+        let controller = TextEditingController::new();
+        let _harness = crate::test_harness::mount(EditableText::new(controller.clone()));
+
+        assert!(
+            controller.focus_node_id().is_some(),
+            "an enabled field must publish a focus node"
+        );
+    }
+
+    /// `EditableText::text_style` flows through to the rendered `TextSpan` —
+    /// the render-view assembly this builder feeds.
+    #[test]
+    fn text_style_reaches_the_rendered_span() {
+        let style = TextStyle::default().with_color(Color::rgb(10, 20, 30));
+        let render_view = EditableTextRenderView {
+            text: "hello".to_string(),
+            caret_byte_offset: 0,
+            show_caret: false,
+            caret_height: 18.0,
+            caret_color: Color::BLACK,
+            text_style: Some(style.clone()),
+        };
+
+        let render_object = render_view.build_render_object();
+        let rendered_style = render_object
+            .painter()
+            .text()
+            .expect("a span was set")
+            .style()
+            .expect("text_style was set");
+        assert_eq!(rendered_style.color, style.color);
+    }
+
+    /// Without `text_style`, the span carries no explicit style — no
+    /// override was silently invented.
+    #[test]
+    fn no_text_style_leaves_the_span_unstyled() {
+        let render_view = EditableTextRenderView {
+            text: "hello".to_string(),
+            caret_byte_offset: 0,
+            show_caret: false,
+            caret_height: 18.0,
+            caret_color: Color::BLACK,
+            text_style: None,
+        };
+
+        let render_object = render_view.build_render_object();
+        assert!(
+            render_object
+                .painter()
+                .text()
+                .expect("a span was set")
+                .style()
+                .is_none()
+        );
+    }
 }


### PR DESCRIPTION
## Summary

PR-1 of Material inputs (Catalog.1 "inputs" family), ported against Flutter 3.44.0 `material/{input_decorator,input_border,text_field}.dart`. An adversarial design review killed both extreme scopes (full ~1000-line `_RenderDecoration` port = premature subsystem; bare "EditableText + underline" = re-delivering the existing widgets TextField) — the settled shape is a **composed InputDecorator, filled/underline variant**, with the honest claim written into the module doc: composed from existing widgets, NOT a `_RenderDecoration` port.

### flui-widgets (own commit)
`EditableText::enabled(bool)` — a named **hoist** of `TextField.enabled → _effectiveFocusNode.canRequestFocus` (no such property exists on the oracle's EditableText — a false parity citation was review-corrected): disabled withholds focus publication, gates Tab-traversal, **force-unfocuses on live disable** (FLUI's `set_can_request_focus` is a bare atomic store that does NOT auto-unfocus, unlike Flutter's setter — the path is mutation-pinned via swap_root), and guards the key handler. Plus additive `text_style` flowing into the TextSpan.

### flui-material
- **`InputDecoration`** — data-only (label/hint/helper/error text, filled, content_padding, enabled); the future render-object decorator consumes it unchanged.
- **`InputDecorationThemeData`** — component-theme slot (ThemeDataOverrides convention, Option-inner `WidgetStateProperty` indicator per the ButtonStyle precedent), override-beats-default mutation-pinned at the mounted level.
- **`InputDecorator`** — top-4dp rounded fill + bottom-only underline (the non-uniform border path paints straight — exactly `UnderlineInputBorder`'s own rendering, caveat documented at the use site); floating label (`!empty || (focused && enabled)` — the oracle's exact condition, snap in V1); hint; helper-or-error line; **hover fill blend** (`ThemeData.hoverColor` = brightness-keyed 4% black/white — NOT the button family's 8% onSurface overlay — blended over the fill per `_InputBorderPainter.blendedColor`); M3 state tables from `_InputDecoratorDefaultsM3` with the oracle's exact branch order (disabled → error{focused→hovered→plain} → focused → hovered → default) and combined-state pins (error+focused=error@2.0, error+hovered=onErrorContainer@1.0).
- Named divergences/deferrals: baseline slot layout, float metrics + 167ms animation, isDense, OutlineInputBorder (a real input_border port later, never faked), prefix/suffix/counter, error shake, String-only slots.

PR-2 (next unit): material `TextField` wiring EditableText + InputDecorator + live focus/hover/error plumbing.

### Review trail
Architect (staged scope) → adversarial critique (disabled had no source — EditableText::enabled added; hover blend was missing; float condition lacked the enabled guard; Option-inner slot convention) → build → full review (oracle fidelity fully confirmed; 4 test gaps incl. the load-bearing force-unfocus path + 1 false citation) → fix pass with mutation evidence.

### Gates
Workspace nextest 6904 passed / 4 skipped · workspace clippy `-D warnings` clean · doc gates clean · port-check/inventory/fmt/taplo/typos · doctests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvkSGveJwxLVuygRAGVKuz