### PR TITLE
feat(material): TextField — EditableText + InputDecorator with live focus/hover/error plumbing

### DIFF
--- a/crates/flui-interaction/src/routing/focus.rs
+++ b/crates/flui-interaction/src/routing/focus.rs
@@ -359,6 +359,19 @@ impl FocusManager {
         self.listeners.write().clear();
     }
 
+    /// The number of focus-change listeners currently registered.
+    ///
+    /// Test-only introspection: proves a `dispose`/teardown path actually
+    /// called [`Self::remove_listener`] rather than leaking a registration on
+    /// this process-wide singleton (a real recurring failure mode across
+    /// this workspace's tests, which all share one `FocusManager` per
+    /// thread).
+    #[cfg(any(test, feature = "testing"))]
+    #[must_use]
+    pub fn listener_count(&self) -> usize {
+        self.listeners.read().len()
+    }
+
     /// Notify all listeners of a focus change.
     fn notify_listeners(&self, previous: Option<FocusNodeId>, new: Option<FocusNodeId>) {
         // Clone the listener Vec so listener invocations can call

--- a/crates/flui-material/src/lib.rs
+++ b/crates/flui-material/src/lib.rs
@@ -6,8 +6,9 @@
 //! [`Material`]/[`InkWell`] surface primitives, the M3 button family
 //! ([`ButtonStyle`], [`ElevatedButton`], [`FilledButton`], [`OutlinedButton`],
 //! [`TextButton`], [`IconButton`], [`FloatingActionButton`], [`BackButton`]),
-//! [`Scaffold`]/[`AppBar`], [`Card`], and [`Dialog`]/[`AlertDialog`]/
-//! [`show_dialog`].
+//! [`Scaffold`]/[`AppBar`], [`Card`], [`Dialog`]/[`AlertDialog`]/
+//! [`show_dialog`], and the input decoration substrate
+//! ([`InputDecoration`], [`InputDecorator`], [`TextField`]).
 //!
 //! ## Flutter parity
 //!
@@ -32,15 +33,13 @@
 //!
 //! - [`ColorScheme::fromSeed`](https://api.flutter.dev/flutter/material/ColorScheme/ColorScheme.fromSeed.html)
 //!   — dynamic-color generation from a seed. See [`color_scheme`] module docs.
-//! - Component themes for widgets that don't exist yet (`InputDecorationTheme`
-//!   and friends) — the button family's, `AppBar`'s, `Card`'s, `Dialog`'s,
-//!   and `FloatingActionButton`'s own theme slots (`ElevatedButtonThemeData`
+//! - Every shipped widget's own component theme slot (`ElevatedButtonThemeData`
 //!   and friends, [`AppBarThemeData`], [`CardThemeData`], [`DialogThemeData`],
-//!   [`FabThemeData`]) have landed, each narrowed to the fields its owning
-//!   widget actually consumes — see `theme_data`'s module docs and each
-//!   type's own doc comment for the ported/deferred field split.
-//!   [`ThemeData`] stays `#[non_exhaustive]` to receive the rest without a
-//!   breaking change.
+//!   [`FabThemeData`], [`InputDecorationThemeData`]) is narrowed to the
+//!   fields its owning widget actually consumes — see `theme_data`'s module
+//!   docs and each type's own doc comment for the ported/deferred field
+//!   split. [`ThemeData`] stays `#[non_exhaustive]` to receive the rest
+//!   without a breaking change.
 //! - `AnimatedTheme` / `ColorScheme`/`TextTheme` lerp — no component consumes
 //!   an interpolated theme yet.
 //! - Dense/tall type-scale geometries (CJK / Farsi-Hindi-Thai) — only
@@ -81,6 +80,7 @@ pub mod outlined_button;
 pub mod scaffold;
 pub mod shape;
 pub mod text_button;
+pub mod text_field;
 pub mod text_theme;
 pub mod theme;
 pub mod theme_data;
@@ -103,6 +103,7 @@ pub use outlined_button::OutlinedButton;
 pub use scaffold::Scaffold;
 pub use shape::MaterialShape;
 pub use text_button::TextButton;
+pub use text_field::{TextField, TextFieldState};
 pub use text_theme::TextTheme;
 pub use theme::Theme;
 pub use theme_data::{

--- a/crates/flui-material/src/text_field.rs
+++ b/crates/flui-material/src/text_field.rs
@@ -1,0 +1,337 @@
+//! [`TextField`] — the Material single-line text field: an
+//! [`EditableText`] wrapped directly in an [`InputDecorator`], with live
+//! focus/enabled/error plumbing and a tap target spanning the whole
+//! decorated area.
+//!
+//! Flutter parity: `material/text_field.dart` `TextField` (oracle tag
+//! `3.44.0`). The oracle has no widgets-layer `TextField` to extend —
+//! `_TextFieldState.build` composes a raw `widgets.EditableText` and
+//! `InputDecorator` inline (`text_field.dart:1684-1782`), which is exactly
+//! this substrate's own shape: no
+//! [`flui_widgets::TextField`](flui_widgets::text::text_field::TextField) in
+//! the middle.
+//!
+//! # Live plumbing — what's wired and how
+//!
+//! - **Focus**: the oracle rebuilds on `_effectiveFocusNode`'s own
+//!   `addListener(_handleFocusChanged)` (`text_field.dart:1273`). This
+//!   substrate has no ambient `FocusNode` field to listen on directly —
+//!   instead it registers with the process-wide
+//!   [`FocusManager::add_listener`](flui_interaction::routing::FocusManager::add_listener)
+//!   in `init_state` and compares against
+//!   [`TextEditingController::focus_node_id`](flui_widgets::TextEditingController::focus_node_id)
+//!   — the node [`EditableText`] itself
+//!   published on mount — exactly the seam
+//!   `EditableTextState`'s own internal focus listener uses to drive its
+//!   caret visibility. A match/mismatch schedules a rebuild via
+//!   [`BuildContext::rebuild_handle`], never from inside `build`
+//!   (ADR-0018).
+//! - **Hover**: the oracle owns `_isHovering` at the `TextField` level via
+//!   its own outer `MouseRegion` and threads it into
+//!   `InputDecorator.isHovering` (`text_field.dart:1463-1470,1773,1797-1800`).
+//!   This substrate does **not** duplicate that — `InputDecorator` already
+//!   self-tracks hover through its own internal `MouseRegion` wrapping the
+//!   entire decorated area (see `input_decorator.rs`'s module docs), and
+//!   that `MouseRegion` sits *inside* the tree this `TextField` composes.
+//!   Adding a second, outer `MouseRegion` here would double-track the same
+//!   pointer with two independent state machines for no behavioral gain —
+//!   named divergence: `TextField` delegates hover entirely to the
+//!   decorator it wraps.
+//! - **Error**: [`InputDecoration::error_text`] presence — already the
+//!   decorator's own state input — drives both the error row/underline (in
+//!   `InputDecorator`) and this widget's caret color (see below). There is
+//!   no separate "has error" flag on `TextField` itself, matching the
+//!   oracle's `_hasError` being derived from the decoration, not a widget
+//!   field of its own (`text_field.dart:1196-1201`, narrowed here: the
+//!   oracle's `maxLength`-driven intrinsic error has no FLUI counterpart —
+//!   `maxLength` is not ported).
+//! - **Enabled**: [`TextField::enabled`] is the *single* source of truth,
+//!   written into the effective [`InputDecoration::enabled`] before it
+//!   reaches [`InputDecorator`] (mirroring `_getEffectiveDecoration()`'s
+//!   `.copyWith(enabled: _isEnabled)`, `text_field.dart:1206-1213`) and
+//!   passed straight to [`EditableText::enabled`] — both sinks always agree
+//!   because both read the same field. Named divergence: the oracle
+//!   resolves `_isEnabled` from a three-way null-coalescing chain
+//!   (`widget.enabled ?? widget.decoration?.enabled ?? true`,
+//!   `text_field.dart:1183`) since `TextField.enabled` is optional there;
+//!   this substrate has no optional-override slot for a bare `bool` field,
+//!   so `TextField::enabled` always wins outright rather than falling back
+//!   to whatever `enabled` the caller set directly on the
+//!   [`InputDecoration`] passed to [`TextField::decoration`].
+//!
+//! # Caret color and text style
+//!
+//! Caret color: `colors.error` when [`InputDecoration::error_text`] is set,
+//! `colors.primary` otherwise — Flutter parity: the oracle's
+//! `cursorColor = _hasError ? _errorColor : (widget.cursorColor ??
+//! selectionStyle.cursorColor ?? theme.colorScheme.primary)`
+//! (`text_field.dart:1637-1641`, the desktop/Android branch; every platform
+//! branch shares the same `_hasError ? _errorColor : ...` shape). No
+//! `cursorColor`/`cursorErrorColor` override slot yet — named deferral.
+//!
+//! Text style: `theme.text_theme.body_large`, unconditionally — Flutter
+//! parity: `_m3InputStyle` (`text_field.dart:1893`) is `Theme.of(context)
+//! .textTheme.bodyLarge!`, the M3 branch of `_getInputStyleForState`'s base
+//! style (`text_field.dart:1547-1549`). The oracle's per-state resolution
+//! table (`_m3StateInputStyle`) and the `TextField.style` override are both
+//! named deferrals — this substrate always renders `bodyLarge` verbatim.
+//!
+//! # Tap-to-focus over the whole decorated area
+//!
+//! A [`GestureDetector`] wraps the composed [`InputDecorator`] (not just the
+//! inner [`EditableText`]) — Flutter parity: the oracle's outer
+//! `MouseRegion` → `TextFieldTapRegion` → `Semantics(onTap: ...
+//! _requestKeyboard())` composition (`text_field.dart:1797,1811-1820`) makes
+//! the *entire* decorated box (fill, underline, label/hint rows) a valid tap
+//! target, not just the text-content rect. `GestureDetector`'s default
+//! [`flui_widgets::HitTestBehavior::DeferToChild`] is sufficient here
+//! because `InputDecorator`'s own inner `MouseRegion` defaults to
+//! [`flui_widgets::HitTestBehavior::Opaque`] and spans the full decorated
+//! rect, so every point within it already resolves a hit for the outer
+//! detector to defer to.
+//!
+//! # DEFERRED (v1)
+//!
+//! Everything [`EditableText`] itself defers applies here too (IME, drag
+//! selection, clipboard, multi-line, `obscureText`, input formatters,
+//! overflow scrolling) — see its own module docs. Additionally, narrowed at
+//! this layer:
+//! - **`on_changed`** — [`EditableText`] has no change callback yet (only a
+//!   [`Listenable`] seam); a caller observes edits via the
+//!   [`TextEditingController`] itself.
+//! - **`obscure_text`** — [`EditableText`] has no password-masking mode to
+//!   forward.
+//! - **Selection colors** — no collapsed-caret-only substrate has a
+//!   selection to color yet (see `TextEditingController`'s own deferral
+//!   list).
+//! - **`cursorColor`/style overrides** — see the caret-color/text-style
+//!   sections above.
+//! - **Label/hint/helper/error as `Widget`** — `InputDecoration` is
+//!   `String`-only V1 (see `input_decorator.rs`'s module docs).
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+use flui_foundation::ListenerId;
+use flui_foundation::notifier::Listenable;
+use flui_interaction::routing::FocusManager;
+use flui_view::prelude::*;
+use flui_widgets::{EditableText, GestureDetector, TextEditingController};
+
+use crate::input_decorator::{InputDecoration, InputDecorator};
+use crate::theme::Theme;
+
+// ============================================================================
+// TextField
+// ============================================================================
+
+/// The Material single-line text field — [`EditableText`] decorated by
+/// [`InputDecorator`], with live focus/enabled/error plumbing. See the
+/// module docs for exactly what's wired and what's deferred.
+#[derive(Clone, Debug, StatefulView)]
+pub struct TextField {
+    controller: TextEditingController,
+    decoration: InputDecoration,
+    enabled: bool,
+}
+
+impl TextField {
+    /// Create a `TextField` driven by `controller`, with no decoration
+    /// (label/hint/helper/error all unset — see [`InputDecoration::default`])
+    /// and enabled.
+    #[must_use]
+    pub fn new(controller: TextEditingController) -> Self {
+        Self {
+            controller,
+            decoration: InputDecoration::default(),
+            enabled: true,
+        }
+    }
+
+    /// Set the field's decoration — label, hint, helper/error text, and
+    /// fill. `decoration.enabled` is overridden by [`Self::enabled`] before
+    /// it reaches [`InputDecorator`] — see the module docs' "Enabled"
+    /// section for why a directly-set `decoration.enabled` never diverges
+    /// from `enabled` here.
+    #[must_use]
+    pub fn decoration(mut self, decoration: InputDecoration) -> Self {
+        self.decoration = decoration;
+        self
+    }
+
+    /// Set whether the field accepts focus and input (default `true`) —
+    /// flows into both [`InputDecoration::enabled`] and
+    /// [`EditableText::enabled`], see the module docs' "Enabled" section.
+    #[must_use]
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+}
+
+// ============================================================================
+// TextFieldState
+// ============================================================================
+
+/// Persistent state behind [`TextField`] — owns the live controller/focus
+/// listeners described in the module docs.
+pub struct TextFieldState {
+    controller: TextEditingController,
+    controller_listener_id: Option<ListenerId>,
+    focus_listener_id: Option<ListenerId>,
+}
+
+impl std::fmt::Debug for TextFieldState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TextFieldState")
+            .field("controller", &self.controller)
+            .finish_non_exhaustive()
+    }
+}
+
+impl StatefulView for TextField {
+    type State = TextFieldState;
+
+    fn create_state(&self) -> Self::State {
+        TextFieldState {
+            controller: self.controller.clone(),
+            controller_listener_id: None,
+            focus_listener_id: None,
+        }
+    }
+}
+
+impl ViewState<TextField> for TextFieldState {
+    fn init_state(&mut self, ctx: &dyn BuildContext) {
+        // ADR-0018: `rebuild_handle()` is acquired here, fired later from
+        // the listeners below — never called from `build`.
+        let rebuild = ctx.rebuild_handle();
+
+        // Rebuild on every edit — `is_empty` (fed to `InputDecorator`) is
+        // recomputed fresh in `build`, so a text change must trigger one.
+        let rebuild_on_edit = rebuild.clone();
+        self.controller_listener_id = Some(self.controller.add_listener(Arc::new(move || {
+            rebuild_on_edit.schedule();
+        })));
+
+        // Rebuild exactly when *this field's own* published node transitions
+        // into or out of primary focus — mirrors `EditableTextState`'s own
+        // `FocusManager` listener (step 4 of its `init_state`).
+        let controller_for_focus = self.controller.clone();
+        self.focus_listener_id = Some(FocusManager::global().add_listener(Rc::new(
+            move |previous, current| {
+                let Some(node_id) = controller_for_focus.focus_node_id() else {
+                    return;
+                };
+                let was_focused = previous == Some(node_id);
+                let now_focused = current == Some(node_id);
+                if was_focused != now_focused {
+                    rebuild.schedule();
+                }
+            },
+        )));
+    }
+
+    fn dispose(&mut self) {
+        if let Some(id) = self.controller_listener_id.take() {
+            self.controller.remove_listener(id);
+        }
+        if let Some(id) = self.focus_listener_id.take() {
+            FocusManager::global().remove_listener(id);
+        }
+    }
+
+    fn build(&self, view: &TextField, ctx: &dyn BuildContext) -> impl IntoView {
+        let theme = Theme::of(ctx);
+        let colors = theme.color_scheme;
+
+        let has_error = view.decoration.error_text.is_some();
+        let caret_color = if has_error {
+            colors.error
+        } else {
+            colors.primary
+        };
+
+        let is_empty = view.controller.text().is_empty();
+        let focused = view
+            .controller
+            .focus_node_id()
+            .is_some_and(|node_id| FocusManager::global().has_focus(node_id));
+
+        // The single `enabled` source of truth — see the module docs'
+        // "Enabled" section for why this overrides a directly-set
+        // `decoration.enabled` rather than falling back to it.
+        let mut decoration = view.decoration.clone();
+        decoration.enabled = view.enabled;
+
+        let mut editable = EditableText::new(view.controller.clone())
+            .enabled(view.enabled)
+            .caret_color(caret_color);
+        if let Some(text_style) = theme.text_theme.body_large.clone() {
+            editable = editable.text_style(text_style);
+        }
+
+        let controller_for_tap = view.controller.clone();
+
+        GestureDetector::new()
+            .on_tap(move || focus_field(&controller_for_tap))
+            .child(
+                InputDecorator::new(decoration)
+                    .focused(focused)
+                    .is_empty(is_empty)
+                    .child(editable),
+            )
+    }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Focus the field driven by `controller` — the node its `EditableTextState`
+/// published on mount (see
+/// [`TextEditingController::focus_node_id`](flui_widgets::TextEditingController::focus_node_id)).
+/// A no-op while the field is unmounted or disabled (a disabled field
+/// withholds its published node — see `EditableText::enabled`'s doc
+/// comment).
+fn focus_field(controller: &TextEditingController) {
+    if let Some(node_id) = controller.focus_node_id() {
+        FocusManager::global().request_focus(node_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_decorates_with_default_decoration_and_is_enabled() {
+        let field = TextField::new(TextEditingController::new());
+        assert_eq!(field.decoration, InputDecoration::default());
+        assert!(field.enabled);
+    }
+
+    #[test]
+    fn builder_methods_override_decoration_and_enabled() {
+        let decoration = InputDecoration {
+            label_text: Some("Email".to_string()),
+            ..Default::default()
+        };
+        let field = TextField::new(TextEditingController::new())
+            .decoration(decoration.clone())
+            .enabled(false);
+
+        assert_eq!(field.decoration, decoration);
+        assert!(!field.enabled);
+    }
+
+    #[test]
+    fn focus_field_is_a_no_op_when_the_controller_has_no_published_node() {
+        // No `EditableText` has mounted for this controller, so it has
+        // never published a focus node — `focus_field` must not panic or
+        // touch `FocusManager` in a way that would focus something.
+        let controller = TextEditingController::new();
+        assert_eq!(controller.focus_node_id(), None);
+        focus_field(&controller); // Must not panic.
+    }
+}

--- a/crates/flui-material/src/text_field.rs
+++ b/crates/flui-material/src/text_field.rs
@@ -45,19 +45,34 @@
 //!   field of its own (`text_field.dart:1196-1201`, narrowed here: the
 //!   oracle's `maxLength`-driven intrinsic error has no FLUI counterpart —
 //!   `maxLength` is not ported).
-//! - **Enabled**: [`TextField::enabled`] is the *single* source of truth,
-//!   written into the effective [`InputDecoration::enabled`] before it
+//! - **Enabled**: resolved exactly like the oracle's `_isEnabled`
+//!   (`widget.enabled ?? widget.decoration?.enabled ?? true`,
+//!   `text_field.dart:1183`), narrowed to two links —
+//!   [`TextField::enabled`] is `Option<bool>`; `Some` wins outright,
+//!   `None` falls through to [`InputDecoration::enabled`] (which already
+//!   defaults `true`, covering the oracle's trailing `?? true`). The
+//!   resolved value is written into the effective decoration before it
 //!   reaches [`InputDecorator`] (mirroring `_getEffectiveDecoration()`'s
 //!   `.copyWith(enabled: _isEnabled)`, `text_field.dart:1206-1213`) and
 //!   passed straight to [`EditableText::enabled`] — both sinks always agree
-//!   because both read the same field. Named divergence: the oracle
-//!   resolves `_isEnabled` from a three-way null-coalescing chain
-//!   (`widget.enabled ?? widget.decoration?.enabled ?? true`,
-//!   `text_field.dart:1183`) since `TextField.enabled` is optional there;
-//!   this substrate has no optional-override slot for a bare `bool` field,
-//!   so `TextField::enabled` always wins outright rather than falling back
-//!   to whatever `enabled` the caller set directly on the
-//!   [`InputDecoration`] passed to [`TextField::decoration`].
+//!   because both are computed from the one resolved value, never read
+//!   from two different fields independently.
+//!
+//! # Controller identity — swapping the controller on a live field is unsupported
+//!
+//! `TextFieldState` (this widget) and `EditableTextState` (the interior)
+//! each pin their *own* clone of the controller at `create_state` time and
+//! read `self.controller` in `build`, never `view.controller`. A parent that
+//! swaps in a different [`TextEditingController`] on an already-mounted
+//! `TextField` (passing a new one through [`TextField::new`] on rebuild)
+//! does **not** retarget either half — both keep driving the ORIGINAL
+//! controller. Reading `view.controller` in just one of the two halves
+//! would be worse: it would silently split-brain the composite (this
+//! widget's own `is_empty`/`focused` tracking the new controller while
+//! `EditableText` keeps typing into the old one) instead of consistently
+//! ignoring the swap. Full re-registration on controller swap (the oracle's
+//! `didUpdateWidget`, `text_field.dart:1303-1311`) is a named deferral at
+//! both layers — see [`EditableText`]'s own module docs.
 //!
 //! # Caret color and text style
 //!
@@ -132,39 +147,41 @@ use crate::theme::Theme;
 pub struct TextField {
     controller: TextEditingController,
     decoration: InputDecoration,
-    enabled: bool,
+    enabled: Option<bool>,
 }
 
 impl TextField {
     /// Create a `TextField` driven by `controller`, with no decoration
     /// (label/hint/helper/error all unset — see [`InputDecoration::default`])
-    /// and enabled.
+    /// and no `enabled` override (falls through to
+    /// [`InputDecoration::enabled`]'s own `true` default — see
+    /// [`Self::enabled`]).
     #[must_use]
     pub fn new(controller: TextEditingController) -> Self {
         Self {
             controller,
             decoration: InputDecoration::default(),
-            enabled: true,
+            enabled: None,
         }
     }
 
     /// Set the field's decoration — label, hint, helper/error text, and
-    /// fill. `decoration.enabled` is overridden by [`Self::enabled`] before
-    /// it reaches [`InputDecorator`] — see the module docs' "Enabled"
-    /// section for why a directly-set `decoration.enabled` never diverges
-    /// from `enabled` here.
+    /// fill. `decoration.enabled` is respected as-is unless [`Self::enabled`]
+    /// is *also* called — see the module docs' "Enabled" section for the
+    /// resolution order.
     #[must_use]
     pub fn decoration(mut self, decoration: InputDecoration) -> Self {
         self.decoration = decoration;
         self
     }
 
-    /// Set whether the field accepts focus and input (default `true`) —
-    /// flows into both [`InputDecoration::enabled`] and
-    /// [`EditableText::enabled`], see the module docs' "Enabled" section.
+    /// Override whether the field accepts focus and input, beating whatever
+    /// [`InputDecoration::enabled`] the decoration carries — see the module
+    /// docs' "Enabled" section for the full resolution chain. Absent this
+    /// call, [`InputDecoration::enabled`] decides.
     #[must_use]
     pub fn enabled(mut self, enabled: bool) -> Self {
-        self.enabled = enabled;
+        self.enabled = Some(enabled);
         self
     }
 }
@@ -252,26 +269,37 @@ impl ViewState<TextField> for TextFieldState {
             colors.primary
         };
 
-        let is_empty = view.controller.text().is_empty();
-        let focused = view
+        // `self.controller`, not `view.controller`: `EditableTextState`
+        // pins its own clone at `create_state` and never re-reads `view` for
+        // it (see the module docs' "Controller identity" section) — reading
+        // `view.controller` here instead would let a parent-driven swap
+        // split-brain the two halves of this composite (this field's own
+        // `is_empty`/`focused` tracking the NEW controller while the actual
+        // `EditableText` interior keeps typing into the OLD one).
+        let is_empty = self.controller.text().is_empty();
+        let focused = self
             .controller
             .focus_node_id()
             .is_some_and(|node_id| FocusManager::global().has_focus(node_id));
 
-        // The single `enabled` source of truth — see the module docs'
-        // "Enabled" section for why this overrides a directly-set
-        // `decoration.enabled` rather than falling back to it.
+        // The oracle's null-coalescing chain (`widget.enabled ??
+        // decoration?.enabled ?? true`, `text_field.dart:1183`), narrowed to
+        // two links since `InputDecoration::enabled` already defaults
+        // `true`: an explicit `TextField::enabled` call wins outright;
+        // absent that, the decoration's own `enabled` (set directly by the
+        // caller, or its `true` default) is respected as-is.
+        let effective_enabled = view.enabled.unwrap_or(view.decoration.enabled);
         let mut decoration = view.decoration.clone();
-        decoration.enabled = view.enabled;
+        decoration.enabled = effective_enabled;
 
-        let mut editable = EditableText::new(view.controller.clone())
-            .enabled(view.enabled)
+        let mut editable = EditableText::new(self.controller.clone())
+            .enabled(effective_enabled)
             .caret_color(caret_color);
         if let Some(text_style) = theme.text_theme.body_large.clone() {
             editable = editable.text_style(text_style);
         }
 
-        let controller_for_tap = view.controller.clone();
+        let controller_for_tap = self.controller.clone();
 
         GestureDetector::new()
             .on_tap(move || focus_field(&controller_for_tap))
@@ -305,10 +333,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn new_decorates_with_default_decoration_and_is_enabled() {
+    fn new_decorates_with_default_decoration_and_no_enabled_override() {
         let field = TextField::new(TextEditingController::new());
         assert_eq!(field.decoration, InputDecoration::default());
-        assert!(field.enabled);
+        assert_eq!(
+            field.enabled, None,
+            "no override set: enabled resolution must fall through to decoration.enabled"
+        );
     }
 
     #[test]
@@ -322,7 +353,7 @@ mod tests {
             .enabled(false);
 
         assert_eq!(field.decoration, decoration);
-        assert!(!field.enabled);
+        assert_eq!(field.enabled, Some(false));
     }
 
     #[test]

--- a/crates/flui-material/tests/text_field.rs
+++ b/crates/flui-material/tests/text_field.rs
@@ -13,18 +13,18 @@
 //! so tests in this file cannot interleave with each other's focus state
 //! even under a parallel test runner.
 //!
-//! # What's proven here that wasn't proven anywhere else
+//! # What's proven here
 //!
-//! `flui-widgets/tests/text_field.rs` already proved that a live
-//! `FocusManager` focus change reaches a mounted `RenderEditable` (its own
-//! `show_caret` flag) through a headless `tick()` — the finding that
-//! de-risked this file's approach; see that test's doc comment. This file
-//! proves the *next* layer: that `TextField`'s own `FocusManager` listener
-//! (registered against the field's own published node, not
-//! `EditableTextState`'s internal one) reaches its composed
-//! `InputDecorator`, and that its controller listener reaches the
-//! decorator's `is_empty`-driven hint visibility — neither of which
-//! `EditableTextState`'s own plumbing would produce on its own, since
+//! A live `FocusManager` focus change reaches a mounted render tree through
+//! a headless `tick()` — `flui-widgets/tests/text_field.rs`'s
+//! `requesting_focus_via_the_controllers_published_node_reveals_the_caret_after_a_tick`
+//! proves this for `EditableTextState`'s own internal listener driving
+//! `RenderEditable`'s `show_caret`. This file proves the *next* layer:
+//! that `TextField`'s own `FocusManager` listener (registered against the
+//! field's own published node, not `EditableTextState`'s internal one)
+//! reaches its composed `InputDecorator`, and that its controller listener
+//! reaches the decorator's `is_empty`-driven hint visibility — neither of
+//! which `EditableTextState`'s own plumbing would produce on its own, since
 //! `InputDecorator`'s `focused`/`is_empty` are `TextField`-level build
 //! inputs, not something `EditableText` itself exposes upward.
 
@@ -179,6 +179,333 @@ fn disabling_the_text_field_disables_both_editable_text_and_the_decorator() {
         FocusManager::global().primary_focus(),
         None,
         "tapping a disabled TextField must not focus anything"
+    );
+}
+
+// ============================================================================
+// enabled resolution chain — decoration-only value respected, override wins
+// ============================================================================
+
+/// `InputDecoration::enabled = false` alone (no `TextField::enabled` call at
+/// all — `None`) disables the field, proving the resolution chain's second
+/// link (`enabled.unwrap_or(decoration.enabled)`) is actually reachable, not
+/// just the `Some` branch the sibling test above exercises.
+#[test]
+fn decoration_only_enabled_false_is_respected_without_a_text_field_level_override() {
+    let _focus_serial = focus_test_guard();
+    let theme = ThemeData::light();
+    let colors = theme.color_scheme;
+    let controller = TextEditingController::new();
+    let decoration = InputDecoration {
+        enabled: false,
+        ..Default::default()
+    };
+
+    let laid = lay_out(
+        Theme::new(
+            theme,
+            TextField::new(controller.clone()).decoration(decoration),
+        ),
+        tight(300.0, 100.0),
+    );
+
+    assert_eq!(
+        controller.focus_node_id(),
+        None,
+        "decoration.enabled=false must disable EditableText with no TextField::enabled override"
+    );
+    let decorated_box = laid
+        .find_by_render_type("RenderDecoratedBox")
+        .expect("TextField must compose an InputDecorator's DecoratedBox");
+    let decoration_debug = laid.render_property(decorated_box, "decoration").unwrap();
+    let disabled_indicator = colors.on_surface.with_opacity(0.38);
+    assert!(
+        decoration_debug.contains(&format!("{disabled_indicator:?}")),
+        "decoration-only enabled=false must reach the decorator's disabled indicator, got: \
+         {decoration_debug}"
+    );
+}
+
+/// `TextField::enabled(true)` overrides a conflicting
+/// `InputDecoration::enabled = false` — the resolution chain's first link
+/// (`Some` wins outright) beats the second, matching the oracle's
+/// `widget.enabled ?? decoration?.enabled ?? true` precedence
+/// (`text_field.dart:1183`, tag `3.44.0`).
+///
+/// Mutation red-check: swap the `unwrap_or` argument order (i.e. resolve
+/// `decoration.enabled` before `view.enabled`) — this field would render
+/// disabled despite the explicit `enabled(true)` override, and the first
+/// assertion below fails.
+#[test]
+fn text_field_enabled_override_wins_over_a_conflicting_decoration_enabled() {
+    let _focus_serial = focus_test_guard();
+    let theme = ThemeData::light();
+    let colors = theme.color_scheme;
+    let controller = TextEditingController::new();
+    let decoration = InputDecoration {
+        enabled: false,
+        ..Default::default()
+    };
+
+    let laid = lay_out(
+        Theme::new(
+            theme,
+            TextField::new(controller.clone())
+                .decoration(decoration)
+                .enabled(true),
+        ),
+        tight(300.0, 100.0),
+    );
+
+    assert!(
+        controller.focus_node_id().is_some(),
+        "TextField::enabled(true) must override a conflicting decoration.enabled=false"
+    );
+    let decorated_box = laid
+        .find_by_render_type("RenderDecoratedBox")
+        .expect("TextField must compose an InputDecorator's DecoratedBox");
+    let decoration_debug = laid.render_property(decorated_box, "decoration").unwrap();
+    let disabled_indicator = colors.on_surface.with_opacity(0.38);
+    assert!(
+        !decoration_debug.contains(&format!("{disabled_indicator:?}")),
+        "the override must actually win, not merely coexist with the disabled default, got: \
+         {decoration_debug}"
+    );
+}
+
+// ============================================================================
+// Unmount — the FocusManager listener must not leak on the singleton
+// ============================================================================
+
+/// Unmounting a `TextField` removes its `FocusManager` listener —
+/// `FocusManager::global()` is a process-wide (per-thread) singleton every
+/// test in this binary shares, so a listener `dispose` fails to remove stays
+/// registered forever and fires on every future focus change for the rest of
+/// the process, including in unrelated later tests. Compares the listener
+/// count as a delta around mount/unmount rather than an absolute value,
+/// since other tests may have left the singleton at a nonzero baseline.
+///
+/// The `TextField` is a `Column` child here, not the mounted root — removing
+/// it from the children list goes through ordinary list reconciliation
+/// (proven elsewhere, e.g. `flui-widgets/src/text/text_field.rs`'s own
+/// `a_tap_focuses_the_fields_own_node_not_the_first_registered`, to
+/// correctly dispose a removed child), unlike swapping the ROOT widget's
+/// type outright via `pump_widget`/`swap_root_view`, which this harness
+/// documents as a same-type configuration replacement, not a full
+/// deactivate-and-remount.
+///
+/// Mutation red-check: delete `TextFieldState::dispose`'s
+/// `FocusManager::global().remove_listener(id)` call — the count after
+/// removal no longer matches the pre-mount baseline and the final assertion
+/// fails.
+#[test]
+fn unmounting_removes_the_focus_listener_from_the_process_wide_manager() {
+    use flui_view::{IntoView, ViewExt};
+    use flui_widgets::Column;
+
+    let _focus_serial = focus_test_guard();
+    let controller = TextEditingController::new();
+
+    let before_mount = FocusManager::global().listener_count();
+    let mut laid = lay_out(
+        Theme::new(
+            ThemeData::light(),
+            Column::new(vec![TextField::new(controller).into_view().boxed()]),
+        ),
+        tight(300.0, 100.0),
+    );
+    let while_mounted = FocusManager::global().listener_count();
+    assert!(
+        while_mounted > before_mount,
+        "mounting a TextField must register its own FocusManager listener"
+    );
+
+    // Remove the TextField from the Column's children — an ordinary child
+    // removal, not a root-type swap.
+    laid.pump_widget(Theme::new(
+        ThemeData::light(),
+        Column::new(Vec::<flui_view::BoxedView>::new()),
+    ));
+
+    let after_removal = FocusManager::global().listener_count();
+    assert_eq!(
+        after_removal, before_mount,
+        "removing a TextField from the tree must remove its FocusManager listener, not leak it"
+    );
+}
+
+// ============================================================================
+// Disable-while-focused: focus is lost, and re-enabling does not restore it
+// ============================================================================
+
+/// Disabling a focused field unfocuses it (`EditableTextState::did_update_view`)
+/// — and re-enabling afterward renders the UNFOCUSED indicator, not a stale
+/// focused one, matching Flutter: a field that loses focus while disabled
+/// does not regain it merely by becoming enabled again.
+///
+/// Behavioral pin only — NOT a discriminator for the listener-ordering fix
+/// below. Every `enabled` flip is itself a `TextField` rebuild that
+/// recomputes `focused` fresh from whatever `controller.focus_node_id()`
+/// resolves to AT THAT MOMENT; by the time this test inspects the render
+/// tree, a fresh build has always already happened, so the end state here
+/// is identical whether or not `TextFieldState`'s own focus listener fired
+/// for the intermediate transition (verified directly: this assertion still
+/// passes even with `did_update_view`'s unfocus/withdraw order reverted).
+/// The next test asserts the ordering itself, which no render-tree
+/// end-state check can distinguish.
+#[test]
+fn disabling_a_focused_field_then_re_enabling_renders_the_unfocused_indicator() {
+    let _focus_serial = focus_test_guard();
+    let theme = ThemeData::light();
+    let colors = theme.color_scheme;
+    let controller = TextEditingController::new();
+
+    let mut laid = lay_out(
+        Theme::new(theme.clone(), TextField::new(controller.clone())),
+        tight(300.0, 100.0),
+    );
+
+    // Focus it via a real tap.
+    laid.dispatch_pointer_down(150.0, 50.0);
+    laid.dispatch_pointer_up(150.0, 50.0);
+    laid.tick();
+    let decorated_box = laid
+        .find_by_render_type("RenderDecoratedBox")
+        .expect("TextField must compose an InputDecorator's DecoratedBox");
+    let focused_decoration = laid.render_property(decorated_box, "decoration").unwrap();
+    assert!(
+        focused_decoration.contains(&format!("{:?}", colors.primary)),
+        "sanity: the field must actually be focused before disabling it, got: {focused_decoration}"
+    );
+
+    // Disable while focused.
+    laid.pump_widget(Theme::new(
+        theme.clone(),
+        TextField::new(controller.clone()).enabled(false),
+    ));
+    assert_eq!(
+        FocusManager::global().primary_focus(),
+        None,
+        "disabling a focused field must unfocus it"
+    );
+
+    // Re-enable: focus must NOT be restored automatically.
+    laid.pump_widget(Theme::new(theme, TextField::new(controller)));
+    let decorated_box = laid
+        .find_by_render_type("RenderDecoratedBox")
+        .expect("TextField must compose an InputDecorator's DecoratedBox");
+    let reenabled_decoration = laid.render_property(decorated_box, "decoration").unwrap();
+    assert!(
+        reenabled_decoration.contains(&format!("{:?}", colors.on_surface_variant)),
+        "re-enabling a field that lost focus while disabled must render the UNFOCUSED \
+         indicator, got: {reenabled_decoration}"
+    );
+    assert!(
+        !reenabled_decoration.contains(&format!("{:?}", colors.primary)),
+        "the re-enabled field must not still show the focused indicator, got: \
+         {reenabled_decoration}"
+    );
+}
+
+/// Disabling a focused field notifies `FocusManager` listeners of the
+/// unfocus WHILE the field's node id is still published on the controller —
+/// proving `EditableTextState::did_update_view` calls `FocusManager::unfocus`
+/// *before* clearing `controller.focus_node_id()`, not after.
+///
+/// This is the ordering `TextFieldState`'s own focus listener depends on: it
+/// compares the unfocus notification's (previous, current) pair against
+/// `controller.focus_node_id()` to detect ITS OWN focus-loss transition
+/// (`text_field.rs`, `init_state`). Were the id cleared first, that
+/// comparison would already read `None` by the time the notification fires,
+/// silently no-op-ing the listener for this exact transition — masked, not
+/// caught, by the sibling test above (see its doc comment).
+///
+/// A spy listener stands in for `TextFieldState`'s own — checking `self`'s
+/// actual listener from outside isn't possible (its id is private), but
+/// both listeners observe the exact same notification and the exact same
+/// controller state at that instant, so the spy's observation is exactly
+/// what `TextFieldState`'s listener would see.
+///
+/// Mutation red-check: revert `did_update_view`'s disabled branch to clear
+/// the id before calling `unfocus` — the spy observes `None` instead of
+/// `Some(node_id)` and the assertion below fails (verified directly).
+#[test]
+fn disabling_a_focused_field_notifies_before_withdrawing_its_published_node() {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    let _focus_serial = focus_test_guard();
+    let controller = TextEditingController::new();
+
+    let mut laid = lay_out(
+        Theme::new(ThemeData::light(), TextField::new(controller.clone())),
+        tight(300.0, 100.0),
+    );
+    let node_id = controller
+        .focus_node_id()
+        .expect("EditableText publishes its focus node on mount");
+    FocusManager::global().request_focus(node_id);
+    laid.tick();
+    assert_eq!(FocusManager::global().primary_focus(), Some(node_id));
+
+    let observed_at_notify = Rc::new(RefCell::new(None));
+    let observed_for_spy = Rc::clone(&observed_at_notify);
+    let controller_for_spy = controller.clone();
+    let spy_id = FocusManager::global().add_listener(Rc::new(move |previous, _current| {
+        if previous == Some(node_id) {
+            *observed_for_spy.borrow_mut() = controller_for_spy.focus_node_id();
+        }
+    }));
+
+    laid.pump_widget(Theme::new(
+        ThemeData::light(),
+        TextField::new(controller).enabled(false),
+    ));
+
+    FocusManager::global().remove_listener(spy_id);
+
+    assert_eq!(
+        *observed_at_notify.borrow(),
+        Some(node_id),
+        "the unfocus notification for a disable-while-focused transition must fire while the \
+         node id is STILL published, so a listener comparing against it can detect the transition"
+    );
+}
+
+// ============================================================================
+// Whole-area tap — a point clearly outside EditableText's own rect
+// ============================================================================
+
+/// A tap inside the decorator's default content padding — outside
+/// `EditableText`'s own padded content rect entirely — still focuses the
+/// field, proving the tap target really is the whole decorated box, not
+/// just wherever the inner text happens to sit (a center-tap, as the other
+/// focus tests use, would likely land inside `EditableText`'s own rect and
+/// couldn't tell the two apart).
+#[test]
+fn tapping_the_padding_margin_outside_the_text_rect_also_focuses_the_field() {
+    let _focus_serial = focus_test_guard();
+    let controller = TextEditingController::new();
+
+    let laid = lay_out(
+        Theme::new(ThemeData::light(), TextField::new(controller.clone())),
+        tight(300.0, 100.0),
+    );
+
+    // (3, 3) sits inside the decorator's default content padding (8px top /
+    // 12px left, `default_content_padding`) — well outside EditableText's
+    // own padded content rect, but still within the decorator's own
+    // fill/border/`MouseRegion`, which spans the FULL box.
+    laid.dispatch_pointer_down(3.0, 3.0);
+    laid.dispatch_pointer_up(3.0, 3.0);
+
+    let node_id = controller
+        .focus_node_id()
+        .expect("EditableText publishes its focus node on mount");
+    assert_eq!(
+        FocusManager::global().primary_focus(),
+        Some(node_id),
+        "a tap inside the padding margin, outside the inner text rect, must still focus the field"
     );
 }
 

--- a/crates/flui-material/tests/text_field.rs
+++ b/crates/flui-material/tests/text_field.rs
@@ -1,0 +1,404 @@
+//! `flui_material::TextField` widget-level integration coverage — mounts a
+//! real `TextField` through the full render pipeline (`tests/common/mod.rs`,
+//! the same harness `tests/ink_well.rs`/`tests/input_decorator.rs` use) and
+//! drives it through real tap dispatch, real `FocusManager` key routing, and
+//! real controller mutation, asserting on the composed `InputDecorator`'s
+//! and `RenderEditable`'s mounted, resolved state.
+//!
+//! # `FocusManager` is a process-wide singleton
+//!
+//! Every test that touches focus takes [`focus_test_guard`], which serializes
+//! on a private [`Mutex`] and clears `FocusManager::global()`'s primary
+//! focus first — the same pattern `flui-widgets/tests/text_field.rs` uses,
+//! so tests in this file cannot interleave with each other's focus state
+//! even under a parallel test runner.
+//!
+//! # What's proven here that wasn't proven anywhere else
+//!
+//! `flui-widgets/tests/text_field.rs` already proved that a live
+//! `FocusManager` focus change reaches a mounted `RenderEditable` (its own
+//! `show_caret` flag) through a headless `tick()` — the finding that
+//! de-risked this file's approach; see that test's doc comment. This file
+//! proves the *next* layer: that `TextField`'s own `FocusManager` listener
+//! (registered against the field's own published node, not
+//! `EditableTextState`'s internal one) reaches its composed
+//! `InputDecorator`, and that its controller listener reaches the
+//! decorator's `is_empty`-driven hint visibility — neither of which
+//! `EditableTextState`'s own plumbing would produce on its own, since
+//! `InputDecorator`'s `focused`/`is_empty` are `TextField`-level build
+//! inputs, not something `EditableText` itself exposes upward.
+
+#![allow(clippy::unwrap_used)] // a panic IS the failure report in test code (docs/PANIC-POLICY.md)
+
+mod common;
+
+use std::sync::{Mutex, MutexGuard};
+
+use common::{lay_out, tight};
+use flui_interaction::events::{Code, Key, KeyState};
+use flui_interaction::routing::FocusManager;
+use flui_interaction::testing::input::KeyEventBuilder;
+use flui_material::{InputDecoration, TextField, Theme, ThemeData};
+use flui_widgets::TextEditingController;
+
+// ============================================================================
+// Focus-test serialization
+// ============================================================================
+
+static FOCUS_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Serialize on the process-wide `FocusManager` singleton and start every
+/// test from a clean, unfocused state — mirrors
+/// `flui-widgets/tests/text_field.rs`'s own `focus_test_guard`.
+fn focus_test_guard() -> MutexGuard<'static, ()> {
+    let guard = FOCUS_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    FocusManager::global().unfocus();
+    guard
+}
+
+/// Dispatch a single printable-character `KeyDown` event through
+/// `FocusManager::global()` — routes to whichever node currently holds
+/// primary focus, the same path a real keyboard event takes.
+fn type_char(ch: char) {
+    let event = KeyEventBuilder::new(Code::KeyA)
+        .with_key(Key::Character(ch.to_string()))
+        .with_state(KeyState::Down)
+        .build();
+    FocusManager::global().dispatch_key_event(&event);
+}
+
+// ============================================================================
+// Focus round-trip — a REAL tap, not a direct `request_focus` call
+// ============================================================================
+
+/// Tapping anywhere in the decorated area focuses the field, which reaches
+/// the composed `InputDecorator` (the active-indicator color/width flips to
+/// the focused branch) — and unfocusing reverts it. Exercises the full
+/// production path: `GestureDetector::on_tap` → `focus_field` →
+/// `FocusManager::request_focus` → `TextFieldState`'s own focus listener →
+/// `rebuild_handle().schedule()` → a headless `tick()`.
+///
+/// Mutation red-check: delete `TextFieldState::init_state`'s focus-listener
+/// registration (or its `rebuild.schedule()` call) — `tick()` then drains
+/// nothing, the decorator keeps rendering its first build's `focused: false`
+/// resolution, and the "after tap" assertion below fails.
+#[test]
+fn tapping_the_decorated_area_focuses_the_field_and_reaches_the_decorator() {
+    let _focus_serial = focus_test_guard();
+    let theme = ThemeData::light();
+    let colors = theme.color_scheme;
+    let controller = TextEditingController::new();
+
+    let mut laid = lay_out(
+        Theme::new(theme, TextField::new(controller.clone())),
+        tight(300.0, 100.0),
+    );
+    let decorated_box = laid
+        .find_by_render_type("RenderDecoratedBox")
+        .expect("TextField must compose an InputDecorator's DecoratedBox");
+
+    let unfocused = laid.render_property(decorated_box, "decoration").unwrap();
+    assert!(
+        unfocused.contains(&format!("{:?}", colors.on_surface_variant)),
+        "an unfocused, untapped field must render the plain M3 indicator color, got: {unfocused}"
+    );
+
+    // A real down+up inside the decorated area — not a direct
+    // `FocusManager::request_focus` call.
+    laid.dispatch_pointer_down(150.0, 50.0);
+    laid.dispatch_pointer_up(150.0, 50.0);
+    laid.tick();
+
+    let focused = laid.render_property(decorated_box, "decoration").unwrap();
+    assert!(
+        focused.contains(&format!("{:?}", colors.primary)),
+        "tapping the decorated area must focus the field and reach the decorator's focused \
+         indicator color, got: {focused}"
+    );
+
+    // Round trip: unfocusing must revert it.
+    FocusManager::global().unfocus();
+    laid.tick();
+
+    let reverted = laid.render_property(decorated_box, "decoration").unwrap();
+    assert!(
+        reverted.contains(&format!("{:?}", colors.on_surface_variant)),
+        "unfocusing must revert the decorator to the plain indicator color, got: {reverted}"
+    );
+}
+
+// ============================================================================
+// enabled: both sinks agree
+// ============================================================================
+
+/// `TextField::enabled(false)` disables both sinks from a single field —
+/// `EditableText` withholds its focus node (a tap cannot focus it) AND the
+/// decorator renders the M3 disabled indicator color — even though the
+/// `InputDecoration` passed in never set `enabled` itself, proving
+/// `TextField::enabled` is the one source of truth (see the module docs on
+/// `flui_material::text_field`'s "Enabled" section), not a value that must
+/// be set twice to agree.
+#[test]
+fn disabling_the_text_field_disables_both_editable_text_and_the_decorator() {
+    let _focus_serial = focus_test_guard();
+    let theme = ThemeData::light();
+    let colors = theme.color_scheme;
+    let controller = TextEditingController::new();
+
+    let laid = lay_out(
+        Theme::new(theme, TextField::new(controller.clone()).enabled(false)),
+        tight(300.0, 100.0),
+    );
+
+    // Sink 1: EditableText withholds its focus node.
+    assert_eq!(
+        controller.focus_node_id(),
+        None,
+        "a disabled TextField's EditableText must not publish a focus node"
+    );
+
+    // Sink 2: the decorator renders the disabled M3 indicator color.
+    let decorated_box = laid
+        .find_by_render_type("RenderDecoratedBox")
+        .expect("TextField must compose an InputDecorator's DecoratedBox");
+    let decoration_debug = laid.render_property(decorated_box, "decoration").unwrap();
+    let disabled_indicator = colors.on_surface.with_opacity(0.38);
+    assert!(
+        decoration_debug.contains(&format!("{disabled_indicator:?}")),
+        "a disabled TextField's decorator must render the M3 disabled indicator color, got: \
+         {decoration_debug}"
+    );
+
+    // A tap cannot focus a disabled field — `focus_field` reads
+    // `controller.focus_node_id()`, which is `None`.
+    laid.dispatch_pointer_down(150.0, 50.0);
+    laid.dispatch_pointer_up(150.0, 50.0);
+    assert_eq!(
+        FocusManager::global().primary_focus(),
+        None,
+        "tapping a disabled TextField must not focus anything"
+    );
+}
+
+// ============================================================================
+// Live plumbing — typing reaches the decorator's hint visibility
+// ============================================================================
+
+/// Typing a character while focused clears the hint row — proving
+/// `TextFieldState`'s own controller listener (not
+/// `EditableTextState`'s independent one, which only drives the rendered
+/// text/caret) reaches the decorator's `is_empty` build input.
+///
+/// The focus transition itself is resolved (via its own `tick()`) *before*
+/// typing, specifically so the typing `tick()` has no other pending rebuild
+/// to ride on — isolating the controller listener as the only thing that
+/// could still be dirtying `TextField`'s element at that point. Skipping
+/// this and ticking once after both focusing and typing would let a focus-
+/// triggered rebuild read the by-then-already-mutated text and pass for the
+/// wrong reason, even with the controller listener deleted.
+///
+/// Mutation red-check: delete `TextFieldState::init_state`'s controller
+/// listener registration — the decorator's `is_empty` stays pinned at its
+/// last-rebuilt value (`true`), the hint row never disappears, and the
+/// final paragraph-count assertion below fails (verified directly: the
+/// assertion trips with the registration removed and passes with it
+/// restored).
+#[test]
+fn typing_while_focused_clears_the_hint_row_in_the_decorator() {
+    let _focus_serial = focus_test_guard();
+    let theme = ThemeData::light();
+    let controller = TextEditingController::new();
+    let decoration = InputDecoration {
+        hint_text: Some("you@example.com".to_string()),
+        ..Default::default()
+    };
+
+    let mut laid = lay_out(
+        Theme::new(
+            theme,
+            TextField::new(controller.clone()).decoration(decoration),
+        ),
+        tight(300.0, 100.0),
+    );
+
+    // Empty field, no label: the hint renders as its own paragraph, plus the
+    // `EditableText` interior's own (empty) paragraph slot.
+    let hint_visible = laid.find_all_by_render_type("RenderParagraph").len();
+    assert_eq!(hint_visible, 1, "an empty field with a hint must render it");
+
+    // Resolve the focus transition (and whatever it dirties) on its own
+    // tick, before any typing happens.
+    let node_id = controller
+        .focus_node_id()
+        .expect("EditableText publishes its focus node on mount");
+    FocusManager::global().request_focus(node_id);
+    laid.tick();
+    assert_eq!(
+        laid.find_all_by_render_type("RenderParagraph").len(),
+        1,
+        "focusing an empty field must not, by itself, hide the hint"
+    );
+
+    // Now type, on a fresh tick with no other pending rebuild to ride on.
+    type_char('h');
+    laid.tick();
+
+    assert_eq!(
+        controller.text(),
+        "h",
+        "the keystroke must reach the controller"
+    );
+    let hint_after_typing = laid.find_all_by_render_type("RenderParagraph").len();
+    assert_eq!(
+        hint_after_typing, 0,
+        "typing must clear is_empty and hide the hint row in the mounted decorator"
+    );
+}
+
+// ============================================================================
+// Caret color — error vs. primary
+// ============================================================================
+
+/// Flutter parity: the oracle's `cursorColor = _hasError ? _errorColor :
+/// ... theme.colorScheme.primary` (`text_field.dart:1637-1641`, tag
+/// `3.44.0`). `InputDecoration::error_text` presence is the only input —
+/// no focus, no typing required.
+#[test]
+fn caret_color_is_error_colored_with_error_text_and_primary_otherwise() {
+    let theme = ThemeData::light();
+    let colors = theme.color_scheme;
+
+    let with_error = lay_out(
+        Theme::new(
+            theme,
+            TextField::new(TextEditingController::new()).decoration(InputDecoration {
+                error_text: Some("Required".to_string()),
+                ..Default::default()
+            }),
+        ),
+        tight(300.0, 100.0),
+    );
+    let editable = with_error.find_by_render_type("RenderEditable").unwrap();
+    let error_caret = with_error.render_property(editable, "caret_color").unwrap();
+    assert!(
+        error_caret.contains(&format!("{:?}", colors.error)),
+        "an errored field's caret must be error-colored, got: {error_caret}"
+    );
+
+    let theme = ThemeData::light();
+    let without_error = lay_out(
+        Theme::new(theme, TextField::new(TextEditingController::new())),
+        tight(300.0, 100.0),
+    );
+    let editable = without_error.find_by_render_type("RenderEditable").unwrap();
+    let plain_caret = without_error
+        .render_property(editable, "caret_color")
+        .unwrap();
+    assert!(
+        plain_caret.contains(&format!("{:?}", colors.primary)),
+        "a field with no error must have a primary-colored caret, got: {plain_caret}"
+    );
+}
+
+// ============================================================================
+// Hover — delegated entirely to the decorator, not double-tracked
+// ============================================================================
+
+/// `TextField` composes exactly ONE `MouseRegion` — the `InputDecorator`'s
+/// own self-tracked hover — proving `TextField` did not add a second, outer
+/// `MouseRegion` of its own (see `text_field.rs`'s module docs, "Hover").
+#[test]
+fn text_field_does_not_double_track_hover_with_its_own_mouse_region() {
+    let laid = lay_out(
+        Theme::new(
+            ThemeData::light(),
+            TextField::new(TextEditingController::new()),
+        ),
+        tight(300.0, 100.0),
+    );
+
+    let mouse_regions = laid.find_all_by_render_type("RenderMouseRegion");
+    assert_eq!(
+        mouse_regions.len(),
+        1,
+        "TextField must delegate hover entirely to InputDecorator's own MouseRegion, not add a \
+         second one, found {mouse_regions:?}"
+    );
+}
+
+// ============================================================================
+// Decoration passthrough
+// ============================================================================
+
+/// Label, hint, and helper all reach the mounted tree through `TextField`'s
+/// `decoration` builder — passthrough proof, not a re-test of the
+/// decorator's own row-selection logic (already pinned in
+/// `tests/input_decorator.rs`).
+#[test]
+fn label_hint_and_helper_flow_through_the_decoration_builder() {
+    let decoration = InputDecoration {
+        label_text: Some("Email".to_string()),
+        // No hint: with a label present and the field non-empty, the hint
+        // would be suppressed anyway (`should_show_hint`) — omitted here so
+        // this test counts only rows this decoration actually contributes.
+        helper_text: Some("We'll never share it".to_string()),
+        ..Default::default()
+    };
+    let controller = TextEditingController::with_text("a@b.com");
+
+    let laid = lay_out(
+        Theme::new(
+            ThemeData::light(),
+            TextField::new(controller).decoration(decoration),
+        ),
+        tight(300.0, 150.0),
+    );
+
+    // Label (floats: non-empty) + helper = 2 text rows, alongside the
+    // EditableText interior (its own RenderEditable, not a RenderParagraph).
+    let text_rows = laid.find_all_by_render_type("RenderParagraph");
+    assert_eq!(
+        text_rows.len(),
+        2,
+        "expected label + helper rows, found {text_rows:?}"
+    );
+    laid.find_by_render_type("RenderEditable")
+        .expect("the EditableText interior must still be composed");
+}
+
+// ============================================================================
+// Parity anchor — "TextField errorText trumps helperText" (text_field_test.dart, tag 3.44.0)
+// ============================================================================
+
+/// Named after the oracle's own `text_field_test.dart` test
+/// (`'TextField errorText trumps helperText'`, tag `3.44.0`) — asserted
+/// through `TextField`, not directly on `InputDecorator` (already covered
+/// there by `error_replaces_helper_at_the_mounted_level`).
+#[test]
+fn text_field_error_text_trumps_helper_text() {
+    let decoration = InputDecoration {
+        helper_text: Some("Helper".to_string()),
+        error_text: Some("Error".to_string()),
+        ..Default::default()
+    };
+
+    let laid = lay_out(
+        Theme::new(
+            ThemeData::light(),
+            TextField::new(TextEditingController::new()).decoration(decoration),
+        ),
+        tight(300.0, 150.0),
+    );
+
+    // No label/hint set (empty controller, no hint_text — see
+    // `should_show_hint`, false without `hint_text`), so the only text row
+    // possible is the helper-or-error line.
+    let text_rows = laid.find_all_by_render_type("RenderParagraph");
+    assert_eq!(
+        text_rows.len(),
+        1,
+        "error must replace helper, not render alongside it, found {text_rows:?}"
+    );
+}

--- a/crates/flui-widgets/src/text/controller.rs
+++ b/crates/flui-widgets/src/text/controller.rs
@@ -287,7 +287,19 @@ impl TextEditingController {
     /// The focus node of the `EditableText` this controller currently drives,
     /// or `None` between mounts. Published by `EditableTextState::init_state`
     /// and cleared by its `dispose`.
-    pub(crate) fn focus_node_id(&self) -> Option<flui_interaction::FocusNodeId> {
+    ///
+    /// `pub`, not `pub(crate)`: this is the seam an enclosing decorated field
+    /// built in another crate (e.g. `flui_material::TextField`) uses to
+    /// resolve *its own* node — for both tap-to-focus
+    /// ([`FocusManager::request_focus`](flui_interaction::routing::FocusManager::request_focus))
+    /// and live focus observation
+    /// ([`FocusManager::has_focus`](flui_interaction::routing::FocusManager::has_focus)
+    /// compared against this id from a
+    /// [`FocusManager::add_listener`](flui_interaction::routing::FocusManager::add_listener)
+    /// callback) — the same pattern
+    /// [`EditableTextState`](super::editable_text::EditableTextState) itself
+    /// uses internally to drive its caret's visibility.
+    pub fn focus_node_id(&self) -> Option<flui_interaction::FocusNodeId> {
         self.inner
             .lock()
             .unwrap_or_else(PoisonError::into_inner)

--- a/crates/flui-widgets/src/text/editable_text.rs
+++ b/crates/flui-widgets/src/text/editable_text.rs
@@ -53,6 +53,18 @@ use crate::text::controller::TextEditingController;
 /// - **`obscureText`** — password masking is not implemented.
 /// - **Input formatters** — no validation or transformation pipeline.
 /// - **Scroll when text overflows** — the rendered text clips without scrolling.
+/// - **Swapping the controller on a live field** — `EditableTextState` pins
+///   its own clone of `EditableText::controller` at `create_state` and reads
+///   `self.controller` in `build`/`init_state`, never `view.controller`
+///   again after mount. A parent rebuilding this widget with a *different*
+///   `TextEditingController` value does not retarget the mounted field's
+///   focus-node registration or key handler — both keep driving the
+///   ORIGINAL controller. Full re-registration on controller swap (the
+///   oracle's `didUpdateWidget`, `text_field.dart:1303-1311`, tag `3.44.0`)
+///   is a named deferral; an enclosing decorated field
+///   (`flui_material::TextField`) pins its own clone the same way for the
+///   same reason — see that type's module docs' "Controller identity"
+///   section.
 #[derive(Clone, Debug, StatefulView)]
 pub struct EditableText {
     /// Controller that owns the text buffer and caret.
@@ -272,13 +284,23 @@ impl ViewState<EditableText> for EditableTextState {
             self.controller
                 .set_focus_node_id(Some(self.focus_node.id()));
         } else {
-            self.controller.set_focus_node_id(None);
             // A field disabled while focused must not keep the caret and
             // keyboard input — mirrors Flutter's `TextField`/`EditableText`
             // unfocusing when `enabled` flips false mid-focus.
+            //
+            // Unfocus BEFORE withdrawing the published node id — load-
+            // bearing order, not incidental. `FocusManager::unfocus` notifies
+            // every registered listener with the (previous, current) pair;
+            // an enclosing decorated field (`flui_material::TextField`)
+            // compares that pair against `controller.focus_node_id()` to
+            // detect ITS OWN focus-loss transition. Clearing the id first
+            // would make that comparison vacuous by the time the
+            // notification fires (the id is already gone), silently masking
+            // the transition from any such listener.
             if self.focus_node.has_primary_focus() {
                 FocusManager::global().unfocus();
             }
+            self.controller.set_focus_node_id(None);
         }
     }
 

--- a/crates/flui-widgets/src/text/text_field.rs
+++ b/crates/flui-widgets/src/text/text_field.rs
@@ -1,5 +1,16 @@
-//! [`TextField`] — an [`EditableText`] with border decoration and
-//! tap-to-focus behavior.
+//! [`TextField`] — an [`EditableText`] with a plain border decoration and
+//! tap-to-focus behavior, for callers with no `Theme` ancestor.
+//!
+//! **Not a Flutter-parity port.** Flutter has no widgets-layer text field —
+//! `material/text_field.dart`'s `TextField` is the *only* oracle, and its
+//! parity claim belongs to
+//! [`flui_material::TextField`](https://docs.rs/flui-material) (M3
+//! decoration via `InputDecorator`, live focus/enabled/error plumbing, theme
+//! colors). This type is this crate's own plain stand-in: a fixed 1px
+//! gray-border box with no theming, no label/hint/helper/error slots, and no
+//! state-table colors — for a widgets-only tree with no `Theme` above it to
+//! decorate from. Prefer `flui_material::TextField` whenever a `Theme` is
+//! available.
 
 use flui_geometry::{EdgeInsets, px};
 use flui_types::styling::{Border, BorderSide, BorderStyle, BoxDecoration};
@@ -16,11 +27,11 @@ use crate::text::editable_text::EditableText;
 // TextField
 // ============================================================================
 
-/// A decorated, tap-to-focus single-line text input field.
-///
-/// Flutter parity: `material/text_field.dart` `TextField` — wraps
-/// [`EditableText`] with a [`DecoratedBox`] border and a [`GestureDetector`]
-/// that requests focus on tap.
+/// A plain decorated, tap-to-focus single-line text input field — wraps
+/// [`EditableText`] with a fixed [`DecoratedBox`] border and a
+/// [`GestureDetector`] that requests focus on tap. See the module docs: this
+/// is a theme-free stand-in, not the Material `TextField` — prefer
+/// `flui_material::TextField` whenever a `Theme` ancestor is available.
 ///
 /// # DEFERRED (v1)
 ///
@@ -36,6 +47,7 @@ use crate::text::editable_text::EditableText;
 /// - Focus decoration changes (highlighted border on focus)
 #[derive(Clone, Debug, StatelessView)]
 pub struct TextField {
+    // PORT-CHECK-OK-SP3: deliberate theme-free stand-in for a widgets-only tree; the M3 field is flui_material::TextField — see this module's docs
     /// Controller that owns the text buffer and caret position.
     controller: TextEditingController,
     /// Height of the caret bar, forwarded to [`EditableText`].

--- a/crates/flui-widgets/tests/text_field.rs
+++ b/crates/flui-widgets/tests/text_field.rs
@@ -471,8 +471,8 @@ fn editable_text_mounts_single_render_editable() {
 /// 4) actually reaches the mounted render tree: requesting focus on the
 /// node the field published via [`TextEditingController::focus_node_id`]
 /// schedules a rebuild that flips `RenderEditable`'s `show_caret` — the
-/// same live-focus-observation seam `flui_material::TextField` (PR-2) reuses
-/// to keep its `InputDecorator` in sync with real focus transitions.
+/// same live-focus-observation seam `flui_material::TextField` reuses to
+/// keep its `InputDecorator` in sync with real focus transitions.
 ///
 /// Previously unproven: every other focus test above asserts on
 /// `FocusManager`/`TextEditingController` state directly, never on whether a

--- a/crates/flui-widgets/tests/text_field.rs
+++ b/crates/flui-widgets/tests/text_field.rs
@@ -467,6 +467,53 @@ fn editable_text_mounts_single_render_editable() {
     );
 }
 
+/// Proves `EditableTextState`'s `FocusManager` listener (`init_state`, step
+/// 4) actually reaches the mounted render tree: requesting focus on the
+/// node the field published via [`TextEditingController::focus_node_id`]
+/// schedules a rebuild that flips `RenderEditable`'s `show_caret` — the
+/// same live-focus-observation seam `flui_material::TextField` (PR-2) reuses
+/// to keep its `InputDecorator` in sync with real focus transitions.
+///
+/// Previously unproven: every other focus test above asserts on
+/// `FocusManager`/`TextEditingController` state directly, never on whether a
+/// live focus change reaches *rendered output* through a headless
+/// `tick()` — this closes that gap.
+#[test]
+fn requesting_focus_via_the_controllers_published_node_reveals_the_caret_after_a_tick() {
+    let _focus_serial = focus_test_guard();
+    let controller = TextEditingController::with_text("hi");
+
+    let mut laid = common::lay_out(
+        EditableText::new(controller.clone()),
+        common::tight(120.0, 40.0),
+    );
+    let editable = laid.find_by_render_type("RenderEditable");
+    let show_caret_flag = |laid: &common::LaidOut| -> Option<String> {
+        laid.pipeline_owner()
+            .read()
+            .debug_node_diagnostics(editable)
+            .and_then(|diagnostics| diagnostics.get_property("show_caret").map(str::to_string))
+    };
+
+    assert_eq!(
+        show_caret_flag(&laid),
+        None,
+        "an unfocused field must not show the caret"
+    );
+
+    let node_id = controller
+        .focus_node_id()
+        .expect("EditableText publishes its focus node on mount");
+    FocusManager::global().request_focus(node_id);
+    laid.tick();
+
+    assert_eq!(
+        show_caret_flag(&laid),
+        Some("show caret".to_string()),
+        "requesting focus via the controller's published node must reveal the caret after a tick"
+    );
+}
+
 // ============================================================================
 // TextField — composition (mounts the full GestureDetector/DecoratedBox/
 // Padding/EditableText tree `TextField` builds, never previously exercised:


### PR DESCRIPTION
## Summary

PR-2 of Material inputs: the material `TextField`, wrapping `EditableText` directly (Flutter has no widgets-layer TextField) inside the #382 `InputDecorator`, ported against 3.44.0 `material/text_field.dart`.

- **Live plumbing**: focus observed via a FocusManager listener (registered `init_state`, removed by id in `dispose` — cleanup mutation-pinned via a new `testing`-gated `FocusManager::listener_count()` seam; a review-required leak test survived a real harness discovery: `swap_root` is a same-type configuration replacement, so the unmount path is exercised through list reconciliation instead); hover stays single-owner in the decorator (divergence from the oracle's TextField-owned `_isHovering` documented); error state derives from `error_text` presence; caret color `error → colors.error` else `colors.primary` (oracle chain, mutation-pinned); text style bodyLarge.
- **`enabled` is the oracle chain**: `Option<bool>` resolved as `enabled.unwrap_or(decoration.enabled)` (`widget.enabled ?? decoration?.enabled ?? true`) — a review-caught silent clobber of the caller's decoration field, now both directions tested. Disable-while-focused notifies **before** withdrawing the published node (widgets-layer reorder, spy-listener discriminates the ordering directly).
- **Controller-swap split-brain fixed the honest way**: `build` reads the create_state-pinned clone everywhere, matching `EditableText`'s own pinning; controller swap is a named unsupported deferral at both layers (the oracle's `didUpdateWidget` re-registration is the follow-up).
- Whole decorated area is the tap target (pinned at a padding-margin point outside the text rect). Widgets `TextField` doc reworded — the material parity claim has one owner now.
- Deferred named: on_changed/obscure_text (EditableText lacks them), selection colors (no selection rendering), cursor-color override, controller swap.

### Review trail
Settled architect plan → build → full review (controller split-brain, enabled clobber, reintroduced process markers, 3 test gaps) → fix pass with mutation evidence per finding.

### Gates
Workspace nextest 6921 passed / 4 skipped · clippy `-D warnings` (incl. --all-features on the three touched crates) clean · doc gates clean · port-check/inventory/fmt/taplo/typos · doctests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvkSGveJwxLVuygRAGVKuz