### PR TITLE
feat(material): ListTile + Divider/VerticalDivider — data display family starter

### DIFF
--- a/crates/flui-material/src/divider.rs
+++ b/crates/flui-material/src/divider.rs
@@ -1,0 +1,421 @@
+//! [`Divider`]/[`VerticalDivider`] — a thin, inset rule painted with the M3
+//! `_DividerDefaultsM3` token defaults.
+//!
+//! # Flutter parity
+//!
+//! `material/divider.dart`'s `Divider`/`VerticalDivider`, composed with
+//! `_DividerDefaultsM3` (oracle tag `3.44.0`):
+//!
+//! | Token | Value | Oracle |
+//! |---|---|---|
+//! | `space` (height/width) | `16.0` | `_DividerDefaultsM3` constructor |
+//! | `thickness` | `1.0` | `_DividerDefaultsM3` constructor |
+//! | `indent` | `0.0` | `_DividerDefaultsM3` constructor |
+//! | `endIndent` | `0.0` | `_DividerDefaultsM3` constructor |
+//! | `color` | `ColorScheme.outlineVariant` | `_DividerDefaultsM3.color` |
+//!
+//! Note the M3 `thickness` default is `1.0`, not M2's `0.0` — a divider with
+//! no theme/widget override still paints a visible 1dp line.
+//!
+//! # Composition: a filled rectangle, not a bottom border
+//!
+//! The oracle paints the line as a `Container(height: thickness)` whose
+//! `BoxDecoration.border` is a single `bottom BorderSide` of width
+//! `thickness` — since the border's width equals the container's own height,
+//! that border covers the container's entire area, which is paint-equivalent
+//! to filling the container with `color` outright. This substrate does
+//! exactly that: [`Container::decoration`](flui_widgets::Container::decoration)
+//! with `BoxDecoration::with_color`, which also lets [`Divider::radius`]/
+//! [`DividerThemeData::radius`](crate::theme_data::DividerThemeData::radius)
+//! round the filled rect's corners directly, without inventing a
+//! border-inset reduction FLUI's `BoxDecoration` doesn't model (see
+//! [`crate::material::Material`]'s docs on the same class of
+//! simplification).
+//!
+//! # Deferred, and named
+//!
+//! - **`Divider::createBorderSide`** — a `BuildContext`-optional static
+//!   helper for composing a manual divider border; no caller needs it yet.
+//! - **`ListTile::divideTiles`** — the `Iterable<Widget>` inter-tile divider
+//!   helper; a natural, additive follow-up once a caller list-builds
+//!   `ListTile`s.
+//! - **`PopupMenuDivider`** — a distinct oracle type, out of this scope.
+
+use flui_types::EdgeInsets;
+use flui_types::geometry::px;
+use flui_types::styling::{BorderRadius, BoxDecoration, Color};
+use flui_view::prelude::*;
+use flui_widgets::{Center, Container, SizedBox};
+
+use crate::theme::Theme;
+use crate::theme_data::ThemeData;
+
+/// `_DividerDefaultsM3`'s height/width (`divider.dart`, oracle tag `3.44.0`).
+const DEFAULT_SPACE: f32 = 16.0;
+/// `_DividerDefaultsM3`'s thickness (`divider.dart`, oracle tag `3.44.0`).
+const DEFAULT_THICKNESS: f32 = 1.0;
+/// `_DividerDefaultsM3`'s indent (`divider.dart`, oracle tag `3.44.0`).
+const DEFAULT_INDENT: f32 = 0.0;
+/// `_DividerDefaultsM3`'s end indent (`divider.dart`, oracle tag `3.44.0`).
+const DEFAULT_END_INDENT: f32 = 0.0;
+
+/// A thin horizontal rule, with padding on either side.
+///
+/// See the module docs for the M3 default token table and how the line is
+/// painted.
+///
+/// ```rust
+/// use flui_material::Divider;
+///
+/// let _divider = Divider::new().indent(16.0);
+/// ```
+#[derive(Clone, Debug, Default, StatelessView)]
+pub struct Divider {
+    height: Option<f32>,
+    thickness: Option<f32>,
+    indent: Option<f32>,
+    end_indent: Option<f32>,
+    color: Option<Color>,
+    radius: Option<BorderRadius>,
+}
+
+impl Divider {
+    /// A `Divider` with every property falling through to
+    /// `_DividerDefaultsM3` (see the module docs' token table).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Overrides the divider's total height (the line is vertically centered
+    /// within it). Defaults to `16.0`.
+    #[must_use]
+    pub fn height(mut self, height: f32) -> Self {
+        self.height = Some(height);
+        self
+    }
+
+    /// Overrides the line's thickness. Defaults to `1.0`.
+    #[must_use]
+    pub fn thickness(mut self, thickness: f32) -> Self {
+        self.thickness = Some(thickness);
+        self
+    }
+
+    /// Overrides the empty space before the line's leading edge. Defaults to
+    /// `0.0`.
+    #[must_use]
+    pub fn indent(mut self, indent: f32) -> Self {
+        self.indent = Some(indent);
+        self
+    }
+
+    /// Overrides the empty space after the line's trailing edge. Defaults to
+    /// `0.0`.
+    #[must_use]
+    pub fn end_indent(mut self, end_indent: f32) -> Self {
+        self.end_indent = Some(end_indent);
+        self
+    }
+
+    /// Overrides the line's color. Defaults to `ColorScheme.outlineVariant`.
+    #[must_use]
+    pub fn color(mut self, color: Color) -> Self {
+        self.color = Some(color);
+        self
+    }
+
+    /// Overrides the line's corner radius. Unset paints square corners.
+    #[must_use]
+    pub fn radius(mut self, radius: BorderRadius) -> Self {
+        self.radius = Some(radius);
+        self
+    }
+}
+
+impl StatelessView for Divider {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        let theme = Theme::of(ctx);
+        let resolved = resolve_style(
+            &theme,
+            self.height,
+            self.thickness,
+            self.indent,
+            self.end_indent,
+            self.color,
+            self.radius,
+        );
+
+        SizedBox::height(resolved.space).child(
+            Center::new().child(
+                Container::new()
+                    .height(resolved.thickness)
+                    .margin(EdgeInsets::new(
+                        px(0.0),
+                        px(resolved.end_indent),
+                        px(0.0),
+                        px(resolved.indent),
+                    ))
+                    .decoration(decoration(resolved.color, resolved.radius)),
+            ),
+        )
+    }
+}
+
+/// A thin vertical rule, with padding on either side. The vertical analog of
+/// [`Divider`] — see the module docs for the shared M3 token table.
+///
+/// ```rust
+/// use flui_material::VerticalDivider;
+///
+/// let _divider = VerticalDivider::new().indent(8.0);
+/// ```
+#[derive(Clone, Debug, Default, StatelessView)]
+pub struct VerticalDivider {
+    width: Option<f32>,
+    thickness: Option<f32>,
+    indent: Option<f32>,
+    end_indent: Option<f32>,
+    color: Option<Color>,
+    radius: Option<BorderRadius>,
+}
+
+impl VerticalDivider {
+    /// A `VerticalDivider` with every property falling through to
+    /// `_DividerDefaultsM3` (see the module docs' token table).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Overrides the divider's total width (the line is horizontally
+    /// centered within it). Defaults to `16.0`.
+    #[must_use]
+    pub fn width(mut self, width: f32) -> Self {
+        self.width = Some(width);
+        self
+    }
+
+    /// Overrides the line's thickness. Defaults to `1.0`.
+    #[must_use]
+    pub fn thickness(mut self, thickness: f32) -> Self {
+        self.thickness = Some(thickness);
+        self
+    }
+
+    /// Overrides the empty space above the line's top edge. Defaults to
+    /// `0.0`.
+    #[must_use]
+    pub fn indent(mut self, indent: f32) -> Self {
+        self.indent = Some(indent);
+        self
+    }
+
+    /// Overrides the empty space below the line's bottom edge. Defaults to
+    /// `0.0`.
+    #[must_use]
+    pub fn end_indent(mut self, end_indent: f32) -> Self {
+        self.end_indent = Some(end_indent);
+        self
+    }
+
+    /// Overrides the line's color. Defaults to `ColorScheme.outlineVariant`.
+    #[must_use]
+    pub fn color(mut self, color: Color) -> Self {
+        self.color = Some(color);
+        self
+    }
+
+    /// Overrides the line's corner radius. Unset paints square corners.
+    #[must_use]
+    pub fn radius(mut self, radius: BorderRadius) -> Self {
+        self.radius = Some(radius);
+        self
+    }
+}
+
+impl StatelessView for VerticalDivider {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        let theme = Theme::of(ctx);
+        let resolved = resolve_style(
+            &theme,
+            self.width,
+            self.thickness,
+            self.indent,
+            self.end_indent,
+            self.color,
+            self.radius,
+        );
+
+        SizedBox::width(resolved.space).child(
+            Center::new().child(
+                Container::new()
+                    .width(resolved.thickness)
+                    .margin(EdgeInsets::new(
+                        px(resolved.indent),
+                        px(0.0),
+                        px(resolved.end_indent),
+                        px(0.0),
+                    ))
+                    .decoration(decoration(resolved.color, resolved.radius)),
+            ),
+        )
+    }
+}
+
+/// [`Divider`]/[`VerticalDivider`]'s theme-resolved geometry/color — see
+/// [`resolve_style`]'s doc comment for the widget → theme → default cascade.
+struct ResolvedDividerStyle {
+    space: f32,
+    thickness: f32,
+    indent: f32,
+    end_indent: f32,
+    color: Color,
+    /// Unlike every other field, `radius` has no concrete M3 default to fall
+    /// through to — square corners (`None`) are Flutter's own fallback too
+    /// (`BoxDecoration`'s default), not a value this module invents.
+    radius: Option<BorderRadius>,
+}
+
+/// Resolve the M3 divider defaults through the widget → theme → default
+/// cascade, per field. Flutter parity: `this.height ?? dividerTheme.space ??
+/// defaults.space!` (and the `thickness`/`indent`/`endIndent`/`color`
+/// equivalents), `divider.dart`, oracle tag `3.44.0`.
+#[allow(clippy::too_many_arguments)] // mirrors the oracle's own per-field cascade; a patch struct would only relocate this
+fn resolve_style(
+    theme: &ThemeData,
+    space: Option<f32>,
+    thickness: Option<f32>,
+    indent: Option<f32>,
+    end_indent: Option<f32>,
+    color: Option<Color>,
+    radius: Option<BorderRadius>,
+) -> ResolvedDividerStyle {
+    let divider_theme = theme.divider_theme.as_ref();
+
+    ResolvedDividerStyle {
+        space: space
+            .or_else(|| divider_theme.and_then(|t| t.space))
+            .unwrap_or(DEFAULT_SPACE),
+        thickness: thickness
+            .or_else(|| divider_theme.and_then(|t| t.thickness))
+            .unwrap_or(DEFAULT_THICKNESS),
+        indent: indent
+            .or_else(|| divider_theme.and_then(|t| t.indent))
+            .unwrap_or(DEFAULT_INDENT),
+        end_indent: end_indent
+            .or_else(|| divider_theme.and_then(|t| t.end_indent))
+            .unwrap_or(DEFAULT_END_INDENT),
+        color: color
+            .or_else(|| divider_theme.and_then(|t| t.color))
+            .unwrap_or(theme.color_scheme.outline_variant),
+        radius: radius.or_else(|| divider_theme.and_then(|t| t.radius)),
+    }
+}
+
+/// The line's fill: `color`, optionally rounded to `radius` — see the module
+/// docs' "Composition" section for why a filled rect stands in for the
+/// oracle's full-height bottom border.
+fn decoration(color: Color, radius: Option<BorderRadius>) -> BoxDecoration<flui_types::Pixels> {
+    BoxDecoration::with_color(color).set_border_radius(radius)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_leaves_every_override_unset() {
+        let divider = Divider::new();
+        assert!(divider.height.is_none());
+        assert!(divider.thickness.is_none());
+        assert!(divider.indent.is_none());
+        assert!(divider.end_indent.is_none());
+        assert!(divider.color.is_none());
+        assert!(divider.radius.is_none());
+    }
+
+    #[test]
+    fn overrides_are_stored_verbatim() {
+        let divider = Divider::new()
+            .height(24.0)
+            .thickness(2.0)
+            .indent(8.0)
+            .end_indent(12.0)
+            .color(Color::rgb(1, 2, 3));
+
+        assert_eq!(divider.height, Some(24.0));
+        assert_eq!(divider.thickness, Some(2.0));
+        assert_eq!(divider.indent, Some(8.0));
+        assert_eq!(divider.end_indent, Some(12.0));
+        assert_eq!(divider.color, Some(Color::rgb(1, 2, 3)));
+    }
+
+    /// `_DividerDefaultsM3`'s literal token table (`divider.dart`, oracle
+    /// tag `3.44.0`). Pins this module's own constants against the oracle's
+    /// literals — the M3 `thickness` default is `1.0`, not M2's `0.0`.
+    #[test]
+    fn default_constants_match_the_oracle() {
+        assert_eq!(DEFAULT_SPACE, 16.0);
+        assert_eq!(DEFAULT_THICKNESS, 1.0);
+        assert_eq!(DEFAULT_INDENT, 0.0);
+        assert_eq!(DEFAULT_END_INDENT, 0.0);
+    }
+
+    #[test]
+    fn resolve_style_defaults_to_the_m3_token_table() {
+        let theme = ThemeData::light();
+        let resolved = resolve_style(&theme, None, None, None, None, None, None);
+
+        assert_eq!(resolved.space, DEFAULT_SPACE);
+        assert_eq!(resolved.thickness, DEFAULT_THICKNESS);
+        assert_eq!(resolved.indent, DEFAULT_INDENT);
+        assert_eq!(resolved.end_indent, DEFAULT_END_INDENT);
+        assert_eq!(resolved.color, theme.color_scheme.outline_variant);
+        assert!(resolved.radius.is_none());
+    }
+
+    #[test]
+    fn resolve_style_falls_through_to_the_divider_theme_when_no_widget_override_is_set() {
+        let mut theme = ThemeData::light();
+        let themed_color = Color::rgb(4, 5, 6);
+        theme.divider_theme = Some(crate::theme_data::DividerThemeData {
+            color: Some(themed_color),
+            thickness: Some(3.0),
+            ..Default::default()
+        });
+
+        let resolved = resolve_style(&theme, None, None, None, None, None, None);
+
+        assert_eq!(resolved.color, themed_color);
+        assert_eq!(resolved.thickness, 3.0);
+        // `space`/`indent`/`end_indent` were left unset on the theme slot —
+        // each falls through to its own M3 default independently.
+        assert_eq!(resolved.space, DEFAULT_SPACE);
+        assert_eq!(resolved.indent, DEFAULT_INDENT);
+    }
+
+    #[test]
+    fn resolve_style_widget_override_wins_over_the_divider_theme() {
+        let mut theme = ThemeData::light();
+        theme.divider_theme = Some(crate::theme_data::DividerThemeData {
+            color: Some(Color::rgb(1, 1, 1)),
+            ..Default::default()
+        });
+        let widget_color = Color::rgb(9, 9, 9);
+
+        let resolved = resolve_style(&theme, None, None, None, None, Some(widget_color), None);
+
+        assert_eq!(resolved.color, widget_color);
+    }
+
+    #[test]
+    fn vertical_divider_new_leaves_every_override_unset() {
+        let divider = VerticalDivider::new();
+        assert!(divider.width.is_none());
+        assert!(divider.thickness.is_none());
+        assert!(divider.indent.is_none());
+        assert!(divider.end_indent.is_none());
+        assert!(divider.color.is_none());
+    }
+}

--- a/crates/flui-material/src/lib.rs
+++ b/crates/flui-material/src/lib.rs
@@ -7,8 +7,9 @@
 //! ([`ButtonStyle`], [`ElevatedButton`], [`FilledButton`], [`OutlinedButton`],
 //! [`TextButton`], [`IconButton`], [`FloatingActionButton`], [`BackButton`]),
 //! [`Scaffold`]/[`AppBar`], [`Card`], [`Dialog`]/[`AlertDialog`]/
-//! [`show_dialog`], and the input decoration substrate
-//! ([`InputDecoration`], [`InputDecorator`], [`TextField`]).
+//! [`show_dialog`], the input decoration substrate ([`InputDecoration`],
+//! [`InputDecorator`], [`TextField`]), and the data-display family
+//! ([`ListTile`], [`Divider`]/[`VerticalDivider`]).
 //!
 //! ## Flutter parity
 //!
@@ -69,12 +70,14 @@ mod button_style_button;
 pub mod card;
 pub mod color_scheme;
 pub mod dialog;
+pub mod divider;
 pub mod elevated_button;
 pub mod filled_button;
 pub mod floating_action_button;
 pub mod icon_button;
 pub mod ink_well;
 pub mod input_decorator;
+pub mod list_tile;
 pub mod material;
 pub mod outlined_button;
 pub mod scaffold;
@@ -92,12 +95,14 @@ pub use button_style::ButtonStyle;
 pub use card::Card;
 pub use color_scheme::{ColorScheme, ColorSchemeOverrides};
 pub use dialog::{AlertDialog, Dialog, show_dialog};
+pub use divider::{Divider, VerticalDivider};
 pub use elevated_button::ElevatedButton;
 pub use filled_button::FilledButton;
 pub use floating_action_button::FloatingActionButton;
 pub use icon_button::IconButton;
 pub use ink_well::{InkWell, InkWellState};
 pub use input_decorator::{InputDecoration, InputDecorator, InputDecoratorState};
+pub use list_tile::ListTile;
 pub use material::Material;
 pub use outlined_button::OutlinedButton;
 pub use scaffold::Scaffold;
@@ -107,8 +112,8 @@ pub use text_field::{TextField, TextFieldState};
 pub use text_theme::TextTheme;
 pub use theme::Theme;
 pub use theme_data::{
-    AppBarThemeData, CardThemeData, DialogThemeData, ElevatedButtonThemeData, FabThemeData,
-    FilledButtonThemeData, IconButtonThemeData, InputDecorationThemeData, OutlinedButtonThemeData,
-    TextButtonThemeData, ThemeData, ThemeDataOverrides,
+    AppBarThemeData, CardThemeData, DialogThemeData, DividerThemeData, ElevatedButtonThemeData,
+    FabThemeData, FilledButtonThemeData, IconButtonThemeData, InputDecorationThemeData,
+    ListTileThemeData, OutlinedButtonThemeData, TextButtonThemeData, ThemeData, ThemeDataOverrides,
 };
 pub use typography::english_like_2021;

--- a/crates/flui-material/src/list_tile.rs
+++ b/crates/flui-material/src/list_tile.rs
@@ -59,16 +59,29 @@
 //!   (`top`/`center`/`bottom`/`threeLine`/`titleHeight` each compute a
 //!   different y-offset — `list_tile.dart` `:130-165`). `ListTileTitleAlignment`
 //!   itself is not exposed; every tile lays out as the oracle's `threeLine`
-//!   variant (title above subtitle, both left-aligned).
+//!   variant's **`≤2`-line (centered) arm, always** — title above subtitle,
+//!   both left-aligned, `leading`/`trailing` vertically centered via
+//!   `Row`'s `CrossAxisAlignment::Center`. The oracle's `threeLine` variant
+//!   only centers `leading`/`trailing` when `isThreeLine` is `false`; when
+//!   `true`, it TOP-aligns them instead (`listTile.minVerticalPadding` from
+//!   the tile's top edge, `list_tile.dart` `:138-146`, `:161`) so a
+//!   three-line tile's icon sits flush with the title, not centered against
+//!   the full three-line block. This substrate always centers regardless of
+//!   `is_three_line` — a named divergence, not (as an earlier revision of
+//!   these docs claimed) a faithful port of the `threeLine` variant as a
+//!   whole.
 //! - **`trailing`**'s reserved-width floor (`max(trailingSize.width +
 //!   horizontalTitleGap, 32.0)`, `list_tile.dart` `:1611-1613`) is not
 //!   replicated — `Row`'s own intrinsic sizing handles it instead.
 //! - **`isThreeLine`** is ported as the SAME explicit `bool` flag the oracle
 //!   itself uses (`ListTile.isThreeLine`, never a subtitle-line-count
 //!   heuristic) — see [`ListTile::is_three_line`].
-//! - **`dense`** is ported as a plain `bool` switch between the two literal
-//!   height tables above; `VisualDensity`'s finer `baseSizeAdjustment`
-//!   nudge (`list_tile.dart` `:1548`) is a named deferral (no `VisualDensity`
+//! - **`dense`** switches between the two literal height tables above AND
+//!   clamps `title`'s resolved font size to `13.0`/subtitle's to `12.0`
+//!   (`titleStyle.copyWith(fontSize: _isDenseLayout ? 13.0 : null)` and the
+//!   subtitle equivalent, `list_tile.dart` `:923-926`/`:939-942`) — both
+//!   ported. `VisualDensity`'s finer `baseSizeAdjustment` nudge
+//!   (`list_tile.dart` `:1548`) is a named deferral (no `VisualDensity`
 //!   consumer wired to this substrate's `ListTile` yet).
 //! - **Baseline alignment** — every text run in this composition sits by
 //!   `Column`/`Row` box-model layout, not by shared text baseline. The
@@ -114,12 +127,17 @@
 //!   helper; a natural, additive follow-up once a caller list-builds
 //!   `ListTile`s (see [`crate::divider`]'s module docs).
 //! - **The oracle's `SafeArea`/`IconTheme.merge` wrapper layers ARE
-//!   ported** (`SafeArea::new().top(false).bottom(false).minimum(...)`,
-//!   `IconTheme::new(...)`) — only `IconButtonTheme` has no port: FLUI has no
-//!   `IconButtonTheme` ambient/`InheritedWidget` at all yet (`IconButton`
-//!   reads `ThemeData.icon_button_theme` directly — see `crate::icon_button`'s
-//!   module docs), so a nested `IconButton` in `leading`/`trailing` will not
-//!   automatically pick up this tile's resolved icon color the way the
+//!   ported**: `SafeArea::new().top(false).bottom(false).minimum(...)`, and
+//!   `IconTheme::new(IconThemeData { color: .., ..IconTheme::of(ctx) }, ..)`
+//!   — a genuine merge over the ambient `IconTheme::of(ctx)` snapshot (only
+//!   `color` is overridden; `size`/`opacity`/etc. pass through from whatever
+//!   `IconTheme` already wraps this tile), matching `IconTheme.merge`'s own
+//!   contract, not a blanket replacement. Only `IconButtonTheme` has no
+//!   port: FLUI has no `IconButtonTheme` ambient/`InheritedWidget` at all yet
+//!   (`IconButton` reads `ThemeData.icon_button_theme` directly — see
+//!   `crate::icon_button`'s module docs), so a nested `IconButton` in
+//!   `leading`/`trailing` will not automatically pick up this tile's
+//!   resolved icon color the way the
 //!   oracle's does.
 
 use std::rc::Rc;
@@ -198,7 +216,7 @@ pub struct ListTile {
     title: Option<BoxedView>,
     subtitle: Option<BoxedView>,
     trailing: Option<BoxedView>,
-    is_three_line: bool,
+    is_three_line: Option<bool>,
     dense: Option<bool>,
     shape: Option<MaterialShape>,
     selected_color: Option<Color>,
@@ -226,7 +244,7 @@ impl Default for ListTile {
             title: None,
             subtitle: None,
             trailing: None,
-            is_three_line: false,
+            is_three_line: None,
             dense: None,
             shape: None,
             selected_color: None,
@@ -303,9 +321,15 @@ impl ListTile {
     /// Marks this tile as displaying three lines of text. Flutter parity: an
     /// explicit flag, never a subtitle-line-count heuristic — see the module
     /// docs. Only meaningful with [`ListTile::subtitle`] set.
+    ///
+    /// Stored as `Option<bool>` internally (this setter still takes a plain
+    /// `bool`) so an explicit `false` here can still be overridden by a
+    /// theme-level `Some(true)` — mirroring [`ListTile::dense`]'s identical
+    /// widget → theme → default cascade rather than special-casing this one
+    /// field to always win.
     #[must_use]
     pub fn is_three_line(mut self, is_three_line: bool) -> Self {
-        self.is_three_line = is_three_line;
+        self.is_three_line = Some(is_three_line);
         self
     }
 
@@ -556,6 +580,16 @@ fn resolve_style(theme: &ThemeData, view: &ListTile) -> ResolvedListTileStyle {
         Some(color) => title_style.with_color(color),
         None => title_style,
     };
+    // Flutter parity: `titleStyle.copyWith(fontSize: _isDenseLayout ? 13.0 :
+    // null)` (`list_tile.dart` `:923-926`, oracle tag `3.44.0`) — Dart's
+    // `copyWith(fontSize: null)` means "leave the current value alone", not
+    // "clear it", so the non-dense branch intentionally does nothing here
+    // rather than resetting `font_size` to `None`.
+    let title_style = if is_dense {
+        title_style.with_font_size(13.0)
+    } else {
+        title_style
+    };
 
     let subtitle_style = view
         .subtitle_text_style
@@ -572,6 +606,15 @@ fn resolve_style(theme: &ThemeData, view: &ListTile) -> ResolvedListTileStyle {
     let subtitle_style = match text_color {
         Some(color) => subtitle_style.with_color(color),
         None => subtitle_style,
+    };
+    // Flutter parity: `subtitleStyle.copyWith(fontSize: _isDenseLayout ?
+    // 12.0 : null)` (`list_tile.dart` `:939-942`, oracle tag `3.44.0`) — see
+    // `title_style`'s identical clamp above for the `copyWith(fontSize:
+    // null)` = "leave alone" semantics.
+    let subtitle_style = if is_dense {
+        subtitle_style.with_font_size(12.0)
+    } else {
+        subtitle_style
     };
 
     let leading_and_trailing_style = view
@@ -639,16 +682,16 @@ fn resolve_style(theme: &ThemeData, view: &ListTile) -> ResolvedListTileStyle {
         .or_else(|| tile_theme.and_then(|t| t.min_leading_width))
         .unwrap_or(MIN_LEADING_WIDTH);
 
-    // `view.is_three_line` is a plain `bool` (not `Option<bool>` like the
-    // oracle's own `ListTile.isThreeLine`), so unlike the oracle's `??`
-    // cascade, an explicit widget-level `false` cannot override a
-    // theme-level `true` — a named V1 simplification. `debug_assert!` in
-    // `build` already enforces the oracle's `isThreeLine != true ||
-    // subtitle != null` contract against the raw widget flag, matching the
-    // oracle's own assert scope (the constructor parameter, not this
-    // theme-resolved value).
-    let is_three_line =
-        view.is_three_line || tile_theme.and_then(|t| t.is_three_line).unwrap_or(false);
+    // Flutter parity: `isThreeLine ?? tileTheme.isThreeLine ?? false`
+    // (`list_tile.dart` `:1019-1023`, oracle tag `3.44.0`) — the same
+    // widget → theme → default cascade `dense` uses just above, now that
+    // `ListTile::is_three_line` is `Option<bool>` too: an explicit
+    // widget-level `false` short-circuits the cascade and wins over a
+    // theme-level `true`, exactly like the oracle's `??` chain.
+    let is_three_line = view
+        .is_three_line
+        .or_else(|| tile_theme.and_then(|t| t.is_three_line))
+        .unwrap_or(false);
     let tile_height = view
         .min_tile_height
         .or_else(|| tile_theme.and_then(|t| t.min_tile_height))
@@ -734,7 +777,7 @@ fn build_content_row(view: &ListTile, resolved: &ResolvedListTileStyle) -> Row<V
 impl StatelessView for ListTile {
     fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
         debug_assert!(
-            !self.is_three_line || self.subtitle.is_some(),
+            self.is_three_line != Some(true) || self.subtitle.is_some(),
             "ListTile::is_three_line(true) requires ListTile::subtitle to be set — \
              Flutter parity: `assert(isThreeLine != true || subtitle != null)` \
              (list_tile.dart, oracle tag 3.44.0)"
@@ -743,6 +786,15 @@ impl StatelessView for ListTile {
         let theme = Theme::of(ctx);
         let resolved = resolve_style(&theme, self);
 
+        // Flutter parity: `IconTheme.merge(data: iconThemeData, child: ...)`
+        // (`list_tile.dart` `:1008-1009`) — a MERGE over the ambient theme,
+        // not a replacement: only `color` is overridden, every other field
+        // (`size`, `opacity`, …) passes the enclosing `IconTheme::of`
+        // through unchanged. `IconThemeData { color: ..,
+        // ..IconThemeData::default() }` would instead blank every other
+        // field back to `None`, discarding an ambient `size` override an
+        // app-level `IconTheme` set above this tile.
+        let ambient_icon_theme = IconTheme::of(ctx);
         let content = SafeArea::new()
             .top(false)
             .bottom(false)
@@ -750,7 +802,7 @@ impl StatelessView for ListTile {
             .child(IconTheme::new(
                 IconThemeData {
                     color: Some(resolved.icon_color),
-                    ..IconThemeData::default()
+                    ..ambient_icon_theme
                 },
                 build_content_row(self, &resolved),
             ));
@@ -797,7 +849,7 @@ mod tests {
         assert!(tile.title.is_none());
         assert!(tile.subtitle.is_none());
         assert!(tile.trailing.is_none());
-        assert!(!tile.is_three_line);
+        assert!(tile.is_three_line.is_none());
         assert!(tile.dense.is_none());
         assert!(tile.enabled);
         assert!(!tile.selected);
@@ -889,6 +941,50 @@ mod tests {
         assert_eq!(resolved.tile_height, 88.0);
     }
 
+    /// A theme-level `is_three_line: Some(true)` reaches the resolved tile
+    /// height when the widget itself leaves `is_three_line` unset — Flutter
+    /// parity: `isThreeLine ?? tileTheme.isThreeLine ?? false`
+    /// (`list_tile.dart` `:1019-1023`, oracle tag `3.44.0`). This is the
+    /// cascade tier that a plain `bool` field (rather than `Option<bool>`)
+    /// could never reach at all.
+    #[test]
+    fn resolve_style_theme_level_is_three_line_reaches_the_tile_height_when_widget_leaves_it_unset()
+    {
+        let mut theme = ThemeData::light();
+        theme.list_tile_theme = Some(ListTileThemeData {
+            is_three_line: Some(true),
+            ..Default::default()
+        });
+        let tile = ListTile::new().subtitle(flui_widgets::SizedBox::shrink());
+
+        let resolved = resolve_style(&theme, &tile);
+        assert_eq!(resolved.tile_height, 88.0);
+    }
+
+    /// Mutation-honest combined-tier pin: an explicit widget-level
+    /// `is_three_line(false)` must WIN over a theme-level `Some(true)` —
+    /// the exact case a plain `bool` widget field couldn't represent (no way
+    /// to distinguish "unset" from "explicitly false"), and the reason this
+    /// field is `Option<bool>` like `dense`, not `bool`.
+    #[test]
+    fn resolve_style_widget_level_is_three_line_false_overrides_a_theme_level_true() {
+        let mut theme = ThemeData::light();
+        theme.list_tile_theme = Some(ListTileThemeData {
+            is_three_line: Some(true),
+            ..Default::default()
+        });
+        let tile = ListTile::new()
+            .subtitle(flui_widgets::SizedBox::shrink())
+            .is_three_line(false);
+
+        let resolved = resolve_style(&theme, &tile);
+        assert_eq!(
+            resolved.tile_height, 72.0,
+            "an explicit widget-level is_three_line(false) must override the theme's \
+             is_three_line: Some(true), matching the oracle's `??` short-circuit"
+        );
+    }
+
     #[test]
     fn resolve_style_dense_two_line_tile_uses_the_dense_height() {
         let theme = ThemeData::light();
@@ -897,6 +993,36 @@ mod tests {
             .dense(true);
         let resolved = resolve_style(&theme, &tile);
         assert_eq!(resolved.tile_height, 64.0);
+    }
+
+    /// `dense` clamps title to `13.0` and subtitle to `12.0` — Flutter
+    /// parity: `titleStyle.copyWith(fontSize: _isDenseLayout ? 13.0 : null)`
+    /// and the subtitle equivalent (`list_tile.dart` `:923-926`/`:939-942`,
+    /// oracle tag `3.44.0`). Mutation-honest: `13.0`/`12.0` are distinct
+    /// literals, so a resolver that swapped them or clamped only one slot
+    /// would fail this.
+    #[test]
+    fn resolve_style_dense_clamps_title_and_subtitle_font_size() {
+        let theme = ThemeData::light();
+        let tile = ListTile::new()
+            .subtitle(flui_widgets::SizedBox::shrink())
+            .dense(true);
+        let resolved = resolve_style(&theme, &tile);
+        assert_eq!(resolved.title_style.font_size, Some(13.0));
+        assert_eq!(resolved.subtitle_style.font_size, Some(12.0));
+    }
+
+    /// Non-dense leaves each style's own baked-in M3 type-scale size alone
+    /// (`bodyLarge`: `16.0`, `bodyMedium`: `14.0`) — Dart's
+    /// `copyWith(fontSize: null)` means "unchanged", not "clear to null", so
+    /// the non-dense branch must NOT reset `font_size` to `None`.
+    #[test]
+    fn resolve_style_non_dense_leaves_the_type_scale_font_size_untouched() {
+        let theme = ThemeData::light();
+        let tile = ListTile::new().subtitle(flui_widgets::SizedBox::shrink());
+        let resolved = resolve_style(&theme, &tile);
+        assert_eq!(resolved.title_style.font_size, Some(16.0));
+        assert_eq!(resolved.subtitle_style.font_size, Some(14.0));
     }
 
     /// Selected recolors both icon and title text to `ColorScheme.primary` —

--- a/crates/flui-material/src/list_tile.rs
+++ b/crates/flui-material/src/list_tile.rs
@@ -1,0 +1,982 @@
+//! [`ListTile`] — a single fixed-height row of leading/title/subtitle/
+//! trailing content, the data-display building block for lists, drawers, and
+//! menus.
+//!
+//! # Flutter parity
+//!
+//! `material/list_tile.dart`'s `ListTile`, composed with `_LisTileDefaultsM3`
+//! (oracle tag `3.44.0`, M3-only — this crate has no M2 mode):
+//!
+//! | Token | Value | Oracle |
+//! |---|---|---|
+//! | `contentPadding` | `EdgeInsetsDirectional.only(start: 16.0, end: 24.0)` | `_LisTileDefaultsM3` constructor |
+//! | `minLeadingWidth` | `24.0` | `_LisTileDefaultsM3` constructor |
+//! | `minVerticalPadding` | `8.0` | `_LisTileDefaultsM3` constructor |
+//! | `shape` | `RoundedRectangleBorder()` (square corners) | `_LisTileDefaultsM3` constructor |
+//! | `tileColor` | `Colors.transparent` | `_LisTileDefaultsM3.tileColor` |
+//! | `titleTextStyle` | `TextTheme.bodyLarge` colored `onSurface` | `_LisTileDefaultsM3.titleTextStyle` |
+//! | `subtitleTextStyle` | `TextTheme.bodyMedium` colored `onSurfaceVariant` | `_LisTileDefaultsM3.subtitleTextStyle` |
+//! | `leadingAndTrailingTextStyle` | `TextTheme.labelSmall` colored `onSurfaceVariant` | `_LisTileDefaultsM3.leadingAndTrailingTextStyle` |
+//! | `selectedColor` | `ColorScheme.primary` | `_LisTileDefaultsM3.selectedColor` |
+//! | `iconColor` | `ColorScheme.onSurfaceVariant` | `_LisTileDefaultsM3.iconColor` |
+//!
+//! `minLeadingWidth` is `24.0`, not `40.0` — that's `_LisTileDefaultsM2`'s
+//! value; the M3 table halves it.
+//!
+//! The one/two/three-line minimum tile heights (`_RenderListTile._defaultTileHeight`,
+//! `list_tile.dart`, tag `3.44.0`) are a **flat literal table**, not part of
+//! `_LisTileDefaultsM3`: `56.0`/`72.0`/`88.0` (one/two/three lines), reduced
+//! to `48.0`/`64.0`/`76.0` when [`ListTile::dense`] is set. Note the
+//! three-line dense height is `76.0`, not `88.0 - 12.0`— it's its own table
+//! entry, not derived arithmetically.
+//!
+//! `horizontalTitleGap` defaults to `16.0` — also a bare `list_tile.dart`
+//! literal (`ListTile.build`'s `horizontalTitleGap ?? tileTheme.horizontalTitleGap
+//! ?? 16`), not a `_LisTileDefaultsM3` field.
+//!
+//! # Scope: M3 composition, not a `_RenderListTile` port
+//!
+//! The oracle lays out leading/title/subtitle/trailing with a custom
+//! baseline-aware `_RenderListTile` (`SlottedMultiChildRenderObjectWidget`),
+//! computing exact baseline offsets per `ListTileTitleAlignment` variant and
+//! a `titleStart`/`adjustedTrailingWidth` intrinsic-width negotiation. This
+//! substrate composes the SAME visible shape from `Row`/`Column`/`Padding`/
+//! `ConstrainedBox`/`Expanded` instead — the honest claim is **M3 list-tile
+//! composition (colors, typography, min-heights, tap), not a
+//! `_RenderListTile` port**. Concretely:
+//!
+//! - **`leading`** is wrapped in `ConstrainedBox(min_width:
+//!   min_leading_width)` — Flutter parity for `titleStart = max(minLeadingWidth,
+//!   leadingSize.width) + horizontalTitleGap` (`list_tile.dart` `:1607-1609`):
+//!   the leading slot never shrinks below `min_leading_width`, but (unlike the
+//!   oracle) this substrate does not separately track and error on a leading
+//!   widget that consumes the entire tile width.
+//! - **`title`/`subtitle`** sit in an `Expanded(Column(...))`, wrapped in a
+//!   single `Padding(vertical: min_vertical_padding)` around the whole
+//!   two-line block — Flutter parity for "the minimum padding on the top and
+//!   bottom of the title and subtitle widgets" ([`ListTile::min_vertical_padding`]'s
+//!   doc), but NOT the oracle's per-`ListTileTitleAlignment` baseline math
+//!   (`top`/`center`/`bottom`/`threeLine`/`titleHeight` each compute a
+//!   different y-offset — `list_tile.dart` `:130-165`). `ListTileTitleAlignment`
+//!   itself is not exposed; every tile lays out as the oracle's `threeLine`
+//!   variant (title above subtitle, both left-aligned).
+//! - **`trailing`**'s reserved-width floor (`max(trailingSize.width +
+//!   horizontalTitleGap, 32.0)`, `list_tile.dart` `:1611-1613`) is not
+//!   replicated — `Row`'s own intrinsic sizing handles it instead.
+//! - **`isThreeLine`** is ported as the SAME explicit `bool` flag the oracle
+//!   itself uses (`ListTile.isThreeLine`, never a subtitle-line-count
+//!   heuristic) — see [`ListTile::is_three_line`].
+//! - **`dense`** is ported as a plain `bool` switch between the two literal
+//!   height tables above; `VisualDensity`'s finer `baseSizeAdjustment`
+//!   nudge (`list_tile.dart` `:1548`) is a named deferral (no `VisualDensity`
+//!   consumer wired to this substrate's `ListTile` yet).
+//! - **Baseline alignment** — every text run in this composition sits by
+//!   `Column`/`Row` box-model layout, not by shared text baseline. The
+//!   oracle's `_ListTile.performLayout` positions `title`/`subtitle` by
+//!   their own top-of-box offsets too (not a true cross-widget baseline
+//!   grid), so this is a smaller divergence than it may sound — but it is
+//!   still not a byte-for-byte port and is named here for the record.
+//!
+//! # State-color cascade: a flat resolve, not `WidgetStateColor`
+//!
+//! The oracle resolves `iconColor`/`textColor` through
+//! `_IndividualOverrides`, a `WidgetStateProperty<Color?>` with a
+//! `disabled > selected > enabled` precedence (`list_tile.dart`
+//! `_IndividualOverrides.resolve`, `:1217-1229`) and a `WidgetStateColor`
+//! escape hatch this crate's plain `Color` fields have no counterpart for
+//! (matching every other widget in this crate — see `crate::icon_button`'s
+//! module docs). `resolve_content_color` carries the exact same
+//! precedence, collapsed to a direct `if`/`else if`/`else` since there is no
+//! live [`flui_widgets::WidgetStatesController`] backing a stateless
+//! `ListTile` the way [`crate::ink_well::InkWell`] backs an interactive
+//! surface — `selected`/`enabled` are plain `bool` widget properties, so a
+//! static resolve at `build` time is exact, not an approximation.
+//!
+//! `theme.disabled_color` (Flutter's `ThemeData.disabledColor`) has no
+//! `ThemeData` field in this crate yet — the disabled branch instead uses
+//! `on_surface@38%`, the same M3 "disabled content" convention
+//! `crate::icon_button`'s own `default_style` already applies for the
+//! identical reason (see that module's `default_style`).
+//!
+//! # Deferred, and named
+//!
+//! - **`onLongPress`**, **`onFocusChange`**, **`mouseCursor`**,
+//!   **`focusColor`/`hoverColor`/`splashColor`**, **`focusNode`/`autofocus`**,
+//!   **`enableFeedback`**, **`statesController`** — no override surface yet,
+//!   matching every other V1 interactive widget in this crate.
+//! - **`style`** (`ListTileStyle.list`/`drawer`, an M2-only fork) —
+//!   irrelevant to this M3-only crate.
+//! - **`visualDensity`**, **`titleAlignment`** — see the "Scope" section.
+//! - **`internalAddSemanticForOnTap`** — always behaves as the oracle's own
+//!   eventual-default (`true`): the emitted `Semantics.button` flag is just
+//!   `on_tap.is_some()`.
+//! - **`ListTile.divideTiles`** — the `Iterable<Widget>` inter-tile divider
+//!   helper; a natural, additive follow-up once a caller list-builds
+//!   `ListTile`s (see [`crate::divider`]'s module docs).
+//! - **The oracle's `SafeArea`/`IconTheme.merge` wrapper layers ARE
+//!   ported** (`SafeArea::new().top(false).bottom(false).minimum(...)`,
+//!   `IconTheme::new(...)`) — only `IconButtonTheme` has no port: FLUI has no
+//!   `IconButtonTheme` ambient/`InheritedWidget` at all yet (`IconButton`
+//!   reads `ThemeData.icon_button_theme` directly — see `crate::icon_button`'s
+//!   module docs), so a nested `IconButton` in `leading`/`trailing` will not
+//!   automatically pick up this tile's resolved icon color the way the
+//!   oracle's does.
+
+use std::rc::Rc;
+
+use flui_rendering::constraints::BoxConstraints;
+use flui_types::geometry::px;
+use flui_types::styling::Color;
+use flui_types::typography::TextStyle;
+use flui_types::{EdgeInsets, Pixels};
+use flui_view::prelude::*;
+use flui_widgets::{
+    Column, ConstrainedBox, CrossAxisAlignment, DefaultTextStyle, Expanded, IconTheme,
+    IconThemeData, MainAxisSize, Padding, Row, SafeArea, Semantics, SizedBox,
+};
+
+use crate::ink_well::InkWell;
+use crate::material::Material;
+use crate::shape::MaterialShape;
+use crate::theme::Theme;
+use crate::theme_data::ThemeData;
+
+/// `_LisTileDefaultsM3`'s content padding start inset (`list_tile.dart`,
+/// oracle tag `3.44.0`).
+const CONTENT_PADDING_START: f32 = 16.0;
+/// `_LisTileDefaultsM3`'s content padding end inset (`list_tile.dart`,
+/// oracle tag `3.44.0`).
+const CONTENT_PADDING_END: f32 = 24.0;
+/// `_LisTileDefaultsM3`'s minimum leading width (`list_tile.dart`, oracle tag
+/// `3.44.0`) — `24.0`, not M2's `40.0`.
+const MIN_LEADING_WIDTH: f32 = 24.0;
+/// `_LisTileDefaultsM3`'s minimum vertical padding (`list_tile.dart`, oracle
+/// tag `3.44.0`).
+const MIN_VERTICAL_PADDING: f32 = 8.0;
+/// `ListTile.build`'s bare horizontal-title-gap literal (`list_tile.dart`
+/// `:1029`, oracle tag `3.44.0`) — not part of `_LisTileDefaultsM3`.
+const HORIZONTAL_TITLE_GAP: f32 = 16.0;
+
+/// The M3 "disabled content" opacity this substrate uses in place of
+/// `ThemeData.disabledColor` (no such field exists yet) — see the module
+/// docs' "State-color cascade" section.
+const DISABLED_CONTENT_OPACITY: f32 = 0.38;
+
+/// `_RenderListTile._defaultTileHeight`'s one/two/three-line ×
+/// dense/not-dense table (`list_tile.dart` `:1503-1510`, oracle tag
+/// `3.44.0`) — a flat literal table, NOT `_LisTileDefaultsM3` and NOT
+/// arithmetically derived from the non-dense values.
+fn default_tile_height(is_three_line: bool, has_subtitle: bool, is_dense: bool) -> f32 {
+    match (is_three_line, has_subtitle, is_dense) {
+        (true, _, true) => 76.0,
+        (true, _, false) => 88.0,
+        (false, true, true) => 64.0,
+        (false, true, false) => 72.0,
+        (false, false, true) => 48.0,
+        (false, false, false) => 56.0,
+    }
+}
+
+/// A single-row Material Design list entry: leading/title/subtitle/trailing
+/// slots, an optional whole-tile tap target, and `enabled`/`selected` states.
+/// See the module docs for the M3 default token table and this substrate's
+/// composition-vs-`_RenderListTile` scope.
+///
+/// ```rust
+/// use flui_material::ListTile;
+/// use flui_widgets::{Icon, IconData, Text};
+///
+/// let _tile = ListTile::new()
+///     .leading(Icon::new(IconData::new(0xE87D)))
+///     .title(Text::new("Inbox"))
+///     .subtitle(Text::new("12 unread messages"))
+///     .on_tap(|| {});
+/// ```
+#[derive(Clone, StatelessView)]
+pub struct ListTile {
+    leading: Option<BoxedView>,
+    title: Option<BoxedView>,
+    subtitle: Option<BoxedView>,
+    trailing: Option<BoxedView>,
+    is_three_line: bool,
+    dense: Option<bool>,
+    shape: Option<MaterialShape>,
+    selected_color: Option<Color>,
+    icon_color: Option<Color>,
+    text_color: Option<Color>,
+    title_text_style: Option<TextStyle>,
+    subtitle_text_style: Option<TextStyle>,
+    leading_and_trailing_text_style: Option<TextStyle>,
+    content_padding: Option<EdgeInsets>,
+    enabled: bool,
+    on_tap: Option<Rc<dyn Fn()>>,
+    selected: bool,
+    tile_color: Option<Color>,
+    selected_tile_color: Option<Color>,
+    horizontal_title_gap: Option<f32>,
+    min_vertical_padding: Option<f32>,
+    min_leading_width: Option<f32>,
+    min_tile_height: Option<f32>,
+}
+
+impl Default for ListTile {
+    fn default() -> Self {
+        Self {
+            leading: None,
+            title: None,
+            subtitle: None,
+            trailing: None,
+            is_three_line: false,
+            dense: None,
+            shape: None,
+            selected_color: None,
+            icon_color: None,
+            text_color: None,
+            title_text_style: None,
+            subtitle_text_style: None,
+            leading_and_trailing_text_style: None,
+            content_padding: None,
+            enabled: true,
+            on_tap: None,
+            selected: false,
+            tile_color: None,
+            selected_tile_color: None,
+            horizontal_title_gap: None,
+            min_vertical_padding: None,
+            min_leading_width: None,
+            min_tile_height: None,
+        }
+    }
+}
+
+impl std::fmt::Debug for ListTile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ListTile")
+            .field("has_leading", &self.leading.is_some())
+            .field("has_title", &self.title.is_some())
+            .field("has_subtitle", &self.subtitle.is_some())
+            .field("has_trailing", &self.trailing.is_some())
+            .field("is_three_line", &self.is_three_line)
+            .field("enabled", &self.enabled)
+            .field("selected", &self.selected)
+            .field("interactive", &self.on_tap.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ListTile {
+    /// An empty `ListTile` — `enabled: true`, every other property falling
+    /// through to its M3 default or theme override.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the leading slot (typically an icon or avatar).
+    #[must_use]
+    pub fn leading(mut self, leading: impl IntoView) -> Self {
+        self.leading = Some(BoxedView(Box::new(leading.into_view())));
+        self
+    }
+
+    /// Sets the title slot (typically `Text`).
+    #[must_use]
+    pub fn title(mut self, title: impl IntoView) -> Self {
+        self.title = Some(BoxedView(Box::new(title.into_view())));
+        self
+    }
+
+    /// Sets the subtitle slot (typically `Text`).
+    #[must_use]
+    pub fn subtitle(mut self, subtitle: impl IntoView) -> Self {
+        self.subtitle = Some(BoxedView(Box::new(subtitle.into_view())));
+        self
+    }
+
+    /// Sets the trailing slot (typically an icon or metadata).
+    #[must_use]
+    pub fn trailing(mut self, trailing: impl IntoView) -> Self {
+        self.trailing = Some(BoxedView(Box::new(trailing.into_view())));
+        self
+    }
+
+    /// Marks this tile as displaying three lines of text. Flutter parity: an
+    /// explicit flag, never a subtitle-line-count heuristic — see the module
+    /// docs. Only meaningful with [`ListTile::subtitle`] set.
+    #[must_use]
+    pub fn is_three_line(mut self, is_three_line: bool) -> Self {
+        self.is_three_line = is_three_line;
+        self
+    }
+
+    /// Switches between the dense and non-dense tile-height tables — see
+    /// `default_tile_height`.
+    #[must_use]
+    pub fn dense(mut self, dense: bool) -> Self {
+        self.dense = Some(dense);
+        self
+    }
+
+    /// Overrides the tile's shape (its `InkWell` clip and background fill).
+    #[must_use]
+    pub fn shape(mut self, shape: MaterialShape) -> Self {
+        self.shape = Some(shape);
+        self
+    }
+
+    /// Overrides the icon/text color used when [`ListTile::selected`] is
+    /// `true`. Defaults to `ColorScheme.primary`.
+    #[must_use]
+    pub fn selected_color(mut self, color: Color) -> Self {
+        self.selected_color = Some(color);
+        self
+    }
+
+    /// Overrides the default `leading`/`trailing` icon color. Defaults to
+    /// `ColorScheme.onSurfaceVariant`.
+    #[must_use]
+    pub fn icon_color(mut self, color: Color) -> Self {
+        self.icon_color = Some(color);
+        self
+    }
+
+    /// Overrides the default `title`/`subtitle`/`leading`/`trailing` text
+    /// color. `None` (the default) leaves each slot's own baked-in default
+    /// color untouched.
+    #[must_use]
+    pub fn text_color(mut self, color: Color) -> Self {
+        self.text_color = Some(color);
+        self
+    }
+
+    /// Overrides the title's text style verbatim.
+    #[must_use]
+    pub fn title_text_style(mut self, style: TextStyle) -> Self {
+        self.title_text_style = Some(style);
+        self
+    }
+
+    /// Overrides the subtitle's text style verbatim.
+    #[must_use]
+    pub fn subtitle_text_style(mut self, style: TextStyle) -> Self {
+        self.subtitle_text_style = Some(style);
+        self
+    }
+
+    /// Overrides the leading/trailing slots' text style verbatim.
+    #[must_use]
+    pub fn leading_and_trailing_text_style(mut self, style: TextStyle) -> Self {
+        self.leading_and_trailing_text_style = Some(style);
+        self
+    }
+
+    /// Overrides the tile's internal content padding. Defaults to
+    /// `left: 16.0, right: 24.0`.
+    #[must_use]
+    pub fn content_padding(mut self, padding: EdgeInsets) -> Self {
+        self.content_padding = Some(padding);
+        self
+    }
+
+    /// Whether this tile responds to interaction. When `false`, `on_tap` is
+    /// inoperative and every color resolves through the disabled branch.
+    /// Defaults to `true`.
+    #[must_use]
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    /// Sets the whole-tile tap handler, wired through an [`InkWell`].
+    /// Inoperative while [`ListTile::enabled`] is `false`.
+    #[must_use]
+    pub fn on_tap(mut self, callback: impl Fn() + 'static) -> Self {
+        self.on_tap = Some(Rc::new(callback));
+        self
+    }
+
+    /// Marks this tile as selected — recolors icons/text to
+    /// [`ListTile::selected_color`]. Defaults to `false`.
+    #[must_use]
+    pub fn selected(mut self, selected: bool) -> Self {
+        self.selected = selected;
+        self
+    }
+
+    /// Overrides the background color used when [`ListTile::selected`] is
+    /// `false`. Defaults to `Colors.transparent`.
+    #[must_use]
+    pub fn tile_color(mut self, color: Color) -> Self {
+        self.tile_color = Some(color);
+        self
+    }
+
+    /// Overrides the background color used when [`ListTile::selected`] is
+    /// `true`. Defaults to `Colors.transparent`.
+    #[must_use]
+    pub fn selected_tile_color(mut self, color: Color) -> Self {
+        self.selected_tile_color = Some(color);
+        self
+    }
+
+    /// Overrides the gap between the leading/trailing slots and the title
+    /// column. Defaults to `16.0`.
+    #[must_use]
+    pub fn horizontal_title_gap(mut self, gap: f32) -> Self {
+        self.horizontal_title_gap = Some(gap);
+        self
+    }
+
+    /// Overrides the minimum padding above/below the title/subtitle column.
+    /// Defaults to `8.0`.
+    #[must_use]
+    pub fn min_vertical_padding(mut self, padding: f32) -> Self {
+        self.min_vertical_padding = Some(padding);
+        self
+    }
+
+    /// Overrides the minimum width reserved for [`ListTile::leading`].
+    /// Defaults to `24.0`.
+    #[must_use]
+    pub fn min_leading_width(mut self, width: f32) -> Self {
+        self.min_leading_width = Some(width);
+        self
+    }
+
+    /// Overrides the tile's minimum height. `None` (the default) falls
+    /// through to the one/two/three-line table — see `default_tile_height`.
+    #[must_use]
+    pub fn min_tile_height(mut self, height: f32) -> Self {
+        self.min_tile_height = Some(height);
+        self
+    }
+
+    /// Whether this tile responds to a whole-tile tap — Flutter parity:
+    /// `enabled ? onTap : null` being non-null.
+    fn is_interactive(&self) -> bool {
+        self.enabled && self.on_tap.is_some()
+    }
+}
+
+/// [`ListTile`]'s theme-resolved geometry/color/style — see [`resolve_style`]'s
+/// doc comment for the widget → theme → default cascade.
+struct ResolvedListTileStyle {
+    tile_color: Color,
+    icon_color: Color,
+    shape: MaterialShape,
+    title_style: TextStyle,
+    subtitle_style: TextStyle,
+    leading_and_trailing_style: TextStyle,
+    content_padding: EdgeInsets,
+    horizontal_title_gap: f32,
+    min_vertical_padding: f32,
+    min_leading_width: f32,
+    tile_height: f32,
+}
+
+/// Resolves the `disabled > selected > enabled` color precedence Flutter's
+/// `_IndividualOverrides.resolve` applies (`list_tile.dart` `:1217-1229`,
+/// oracle tag `3.44.0`) — see the module docs' "State-color cascade" section
+/// for why this is a direct `if`/`else if`/`else`, not a
+/// `WidgetStateProperty`.
+fn resolve_content_color(
+    enabled: bool,
+    selected: bool,
+    selected_color: Option<Color>,
+    enabled_color: Option<Color>,
+    disabled_fallback: Color,
+) -> Option<Color> {
+    if !enabled {
+        Some(disabled_fallback)
+    } else if selected {
+        selected_color
+    } else {
+        enabled_color
+    }
+}
+
+/// Resolve `ListTile`'s M3 defaults through the widget → theme → default
+/// cascade — see the module docs' token table and "State-color cascade"
+/// section. Flutter parity: `ListTile.build`, `list_tile.dart`, oracle tag
+/// `3.44.0`.
+fn resolve_style(theme: &ThemeData, view: &ListTile) -> ResolvedListTileStyle {
+    let tile_theme = theme.list_tile_theme.as_ref();
+    let colors = theme.color_scheme;
+    let disabled_content = colors.on_surface.with_opacity(DISABLED_CONTENT_OPACITY);
+
+    let is_dense = view
+        .dense
+        .or_else(|| tile_theme.and_then(|t| t.dense))
+        .unwrap_or(false);
+
+    // The selected-color cascade is shared by icon and text resolution —
+    // Flutter parity: both `resolveColor` calls in `ListTile.build` pass the
+    // SAME `selectedColor` chain (`list_tile.dart` `:855-861`, `:878-884`).
+    let selected_color = view
+        .selected_color
+        .or_else(|| tile_theme.and_then(|t| t.selected_color))
+        .unwrap_or(colors.primary);
+
+    let icon_color = resolve_content_color(
+        view.enabled,
+        view.selected,
+        Some(selected_color),
+        view.icon_color
+            .or_else(|| tile_theme.and_then(|t| t.icon_color)),
+        disabled_content,
+    )
+    .unwrap_or(colors.on_surface_variant);
+
+    // Unlike `icon_color`, the enabled/not-selected branch stays `None` when
+    // no override is set: each text style below already carries its own
+    // baked-in M3 color (`onSurface`/`onSurfaceVariant`), and `None` means
+    // "don't touch it" — see the module docs.
+    let text_color = resolve_content_color(
+        view.enabled,
+        view.selected,
+        Some(selected_color),
+        view.text_color
+            .or_else(|| tile_theme.and_then(|t| t.text_color)),
+        disabled_content,
+    );
+
+    let title_style = view
+        .title_text_style
+        .clone()
+        .or_else(|| tile_theme.and_then(|t| t.title_text_style.clone()))
+        .unwrap_or_else(|| {
+            theme
+                .text_theme
+                .body_large
+                .clone()
+                .unwrap_or_default()
+                .with_color(colors.on_surface)
+        });
+    let title_style = match text_color {
+        Some(color) => title_style.with_color(color),
+        None => title_style,
+    };
+
+    let subtitle_style = view
+        .subtitle_text_style
+        .clone()
+        .or_else(|| tile_theme.and_then(|t| t.subtitle_text_style.clone()))
+        .unwrap_or_else(|| {
+            theme
+                .text_theme
+                .body_medium
+                .clone()
+                .unwrap_or_default()
+                .with_color(colors.on_surface_variant)
+        });
+    let subtitle_style = match text_color {
+        Some(color) => subtitle_style.with_color(color),
+        None => subtitle_style,
+    };
+
+    let leading_and_trailing_style = view
+        .leading_and_trailing_text_style
+        .clone()
+        .or_else(|| tile_theme.and_then(|t| t.leading_and_trailing_text_style.clone()))
+        .unwrap_or_else(|| {
+            theme
+                .text_theme
+                .label_small
+                .clone()
+                .unwrap_or_default()
+                .with_color(colors.on_surface_variant)
+        });
+    let leading_and_trailing_style = match text_color {
+        Some(color) => leading_and_trailing_style.with_color(color),
+        None => leading_and_trailing_style,
+    };
+
+    // Flutter parity: `backgroundColor`/`selectedBackgroundColor` both fall
+    // through to the SAME `defaults.tileColor` (`Colors.transparent`,
+    // `list_tile.dart` `:823-830`) — there is no separate "default selected
+    // tile color" constant.
+    let background_color = view
+        .tile_color
+        .or_else(|| tile_theme.and_then(|t| t.tile_color))
+        .unwrap_or(Color::TRANSPARENT);
+    let selected_background_color = view
+        .selected_tile_color
+        .or_else(|| tile_theme.and_then(|t| t.selected_tile_color))
+        .unwrap_or(Color::TRANSPARENT);
+    let tile_color = if view.selected {
+        selected_background_color
+    } else {
+        background_color
+    };
+
+    let shape = view
+        .shape
+        .or_else(|| tile_theme.and_then(|t| t.shape))
+        .unwrap_or_default();
+
+    let content_padding = view
+        .content_padding
+        .or_else(|| tile_theme.and_then(|t| t.content_padding))
+        .unwrap_or_else(|| {
+            EdgeInsets::new(
+                px(0.0),
+                px(CONTENT_PADDING_END),
+                px(0.0),
+                px(CONTENT_PADDING_START),
+            )
+        });
+
+    let horizontal_title_gap = view
+        .horizontal_title_gap
+        .or_else(|| tile_theme.and_then(|t| t.horizontal_title_gap))
+        .unwrap_or(HORIZONTAL_TITLE_GAP);
+    let min_vertical_padding = view
+        .min_vertical_padding
+        .or_else(|| tile_theme.and_then(|t| t.min_vertical_padding))
+        .unwrap_or(MIN_VERTICAL_PADDING);
+    let min_leading_width = view
+        .min_leading_width
+        .or_else(|| tile_theme.and_then(|t| t.min_leading_width))
+        .unwrap_or(MIN_LEADING_WIDTH);
+
+    // `view.is_three_line` is a plain `bool` (not `Option<bool>` like the
+    // oracle's own `ListTile.isThreeLine`), so unlike the oracle's `??`
+    // cascade, an explicit widget-level `false` cannot override a
+    // theme-level `true` — a named V1 simplification. `debug_assert!` in
+    // `build` already enforces the oracle's `isThreeLine != true ||
+    // subtitle != null` contract against the raw widget flag, matching the
+    // oracle's own assert scope (the constructor parameter, not this
+    // theme-resolved value).
+    let is_three_line =
+        view.is_three_line || tile_theme.and_then(|t| t.is_three_line).unwrap_or(false);
+    let tile_height = view
+        .min_tile_height
+        .or_else(|| tile_theme.and_then(|t| t.min_tile_height))
+        .unwrap_or_else(|| default_tile_height(is_three_line, view.subtitle.is_some(), is_dense));
+
+    ResolvedListTileStyle {
+        tile_color,
+        icon_color,
+        shape,
+        title_style,
+        subtitle_style,
+        leading_and_trailing_style,
+        content_padding,
+        horizontal_title_gap,
+        min_vertical_padding,
+        min_leading_width,
+        tile_height,
+    }
+}
+
+/// Composes the `leading`/title-column/`trailing` row — see the module docs'
+/// "Scope" section for how this stands in for `_RenderListTile`.
+fn build_content_row(view: &ListTile, resolved: &ResolvedListTileStyle) -> Row<Vec<BoxedView>> {
+    let mut children: Vec<BoxedView> = Vec::new();
+
+    if let Some(leading) = &view.leading {
+        let leading_constraints = BoxConstraints::new(
+            px(resolved.min_leading_width),
+            Pixels::INFINITY,
+            px(0.0),
+            Pixels::INFINITY,
+        );
+        children.push(
+            ConstrainedBox::new(leading_constraints)
+                .child(DefaultTextStyle::new(
+                    resolved.leading_and_trailing_style.clone(),
+                    leading.clone(),
+                ))
+                .boxed(),
+        );
+        children.push(SizedBox::width(resolved.horizontal_title_gap).boxed());
+    }
+
+    let title_view: BoxedView = view
+        .title
+        .clone()
+        .unwrap_or_else(|| flui_widgets::SizedBox::shrink().boxed());
+    let mut column_children: Vec<BoxedView> =
+        vec![DefaultTextStyle::new(resolved.title_style.clone(), title_view).boxed()];
+    if let Some(subtitle) = &view.subtitle {
+        column_children
+            .push(DefaultTextStyle::new(resolved.subtitle_style.clone(), subtitle.clone()).boxed());
+    }
+    children.push(
+        Expanded::new(
+            Padding::new(EdgeInsets::symmetric(
+                px(resolved.min_vertical_padding),
+                px(0.0),
+            ))
+            .child(
+                Column::new(column_children)
+                    .cross_axis_alignment(CrossAxisAlignment::Start)
+                    .main_axis_size(MainAxisSize::Min),
+            ),
+        )
+        .boxed(),
+    );
+
+    if let Some(trailing) = &view.trailing {
+        children.push(SizedBox::width(resolved.horizontal_title_gap).boxed());
+        children.push(
+            DefaultTextStyle::new(
+                resolved.leading_and_trailing_style.clone(),
+                trailing.clone(),
+            )
+            .boxed(),
+        );
+    }
+
+    Row::new(children).cross_axis_alignment(CrossAxisAlignment::Center)
+}
+
+impl StatelessView for ListTile {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        debug_assert!(
+            !self.is_three_line || self.subtitle.is_some(),
+            "ListTile::is_three_line(true) requires ListTile::subtitle to be set — \
+             Flutter parity: `assert(isThreeLine != true || subtitle != null)` \
+             (list_tile.dart, oracle tag 3.44.0)"
+        );
+
+        let theme = Theme::of(ctx);
+        let resolved = resolve_style(&theme, self);
+
+        let content = SafeArea::new()
+            .top(false)
+            .bottom(false)
+            .minimum(resolved.content_padding)
+            .child(IconTheme::new(
+                IconThemeData {
+                    color: Some(resolved.icon_color),
+                    ..IconThemeData::default()
+                },
+                build_content_row(self, &resolved),
+            ));
+
+        let semantics = Semantics::new()
+            .button(self.on_tap.is_some())
+            .selected(self.selected)
+            .enabled(self.enabled)
+            .child(content);
+
+        let mut ink_well = InkWell::new(semantics).shape(resolved.shape);
+        if self.is_interactive() {
+            let on_tap = self
+                .on_tap
+                .clone()
+                .expect("BUG: is_interactive() checked on_tap.is_some()");
+            ink_well = ink_well.on_tap(move || on_tap());
+        }
+
+        let tile_constraints = BoxConstraints::new(
+            Pixels::ZERO,
+            Pixels::INFINITY,
+            px(resolved.tile_height),
+            Pixels::INFINITY,
+        );
+
+        ConstrainedBox::new(tile_constraints).child(
+            Material::new(resolved.tile_color)
+                .shape(resolved.shape)
+                .child(ink_well),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::theme_data::ListTileThemeData;
+
+    #[test]
+    fn new_leaves_every_override_unset_and_defaults_enabled() {
+        let tile = ListTile::new();
+        assert!(tile.leading.is_none());
+        assert!(tile.title.is_none());
+        assert!(tile.subtitle.is_none());
+        assert!(tile.trailing.is_none());
+        assert!(!tile.is_three_line);
+        assert!(tile.dense.is_none());
+        assert!(tile.enabled);
+        assert!(!tile.selected);
+        assert!(tile.on_tap.is_none());
+    }
+
+    #[test]
+    fn is_interactive_requires_both_enabled_and_on_tap() {
+        assert!(!ListTile::new().is_interactive());
+        assert!(
+            !ListTile::new()
+                .enabled(false)
+                .on_tap(|| {})
+                .is_interactive()
+        );
+        assert!(ListTile::new().on_tap(|| {}).is_interactive());
+    }
+
+    /// `_RenderListTile._defaultTileHeight`'s literal table (`list_tile.dart`
+    /// `:1503-1510`, oracle tag `3.44.0`) — the mutation-honest pin for every
+    /// branch, including the non-arithmetic three-line-dense value (`76.0`,
+    /// not `88.0 - 12.0`).
+    #[test]
+    fn default_tile_height_matches_the_oracle_table() {
+        assert_eq!(default_tile_height(false, false, false), 56.0);
+        assert_eq!(default_tile_height(false, false, true), 48.0);
+        assert_eq!(default_tile_height(false, true, false), 72.0);
+        assert_eq!(default_tile_height(false, true, true), 64.0);
+        assert_eq!(default_tile_height(true, true, false), 88.0);
+        assert_eq!(default_tile_height(true, true, true), 76.0);
+    }
+
+    /// `_LisTileDefaultsM3`'s literal token table (`list_tile.dart`, oracle
+    /// tag `3.44.0`). `min_leading_width` is `24.0`, not M2's `40.0`.
+    #[test]
+    fn default_constants_match_the_oracle() {
+        assert_eq!(CONTENT_PADDING_START, 16.0);
+        assert_eq!(CONTENT_PADDING_END, 24.0);
+        assert_eq!(MIN_LEADING_WIDTH, 24.0);
+        assert_eq!(MIN_VERTICAL_PADDING, 8.0);
+        assert_eq!(HORIZONTAL_TITLE_GAP, 16.0);
+    }
+
+    #[test]
+    fn resolve_style_defaults_to_the_m3_token_table() {
+        let theme = ThemeData::light();
+        let colors = theme.color_scheme;
+        let tile = ListTile::new();
+        let resolved = resolve_style(&theme, &tile);
+
+        assert_eq!(resolved.tile_color, Color::TRANSPARENT);
+        assert_eq!(resolved.icon_color, colors.on_surface_variant);
+        assert_eq!(resolved.shape, MaterialShape::default());
+        assert_eq!(resolved.title_style.color, Some(colors.on_surface));
+        assert_eq!(
+            resolved.subtitle_style.color,
+            Some(colors.on_surface_variant)
+        );
+        assert_eq!(
+            resolved.content_padding,
+            EdgeInsets::new(
+                px(0.0),
+                px(CONTENT_PADDING_END),
+                px(0.0),
+                px(CONTENT_PADDING_START)
+            )
+        );
+        assert_eq!(resolved.horizontal_title_gap, HORIZONTAL_TITLE_GAP);
+        assert_eq!(resolved.min_vertical_padding, MIN_VERTICAL_PADDING);
+        assert_eq!(resolved.min_leading_width, MIN_LEADING_WIDTH);
+        assert_eq!(resolved.tile_height, 56.0);
+    }
+
+    #[test]
+    fn resolve_style_two_line_tile_uses_the_two_line_height() {
+        let theme = ThemeData::light();
+        let tile = ListTile::new().subtitle(flui_widgets::SizedBox::shrink());
+        let resolved = resolve_style(&theme, &tile);
+        assert_eq!(resolved.tile_height, 72.0);
+    }
+
+    #[test]
+    fn resolve_style_three_line_tile_uses_the_three_line_height() {
+        let theme = ThemeData::light();
+        let tile = ListTile::new()
+            .subtitle(flui_widgets::SizedBox::shrink())
+            .is_three_line(true);
+        let resolved = resolve_style(&theme, &tile);
+        assert_eq!(resolved.tile_height, 88.0);
+    }
+
+    #[test]
+    fn resolve_style_dense_two_line_tile_uses_the_dense_height() {
+        let theme = ThemeData::light();
+        let tile = ListTile::new()
+            .subtitle(flui_widgets::SizedBox::shrink())
+            .dense(true);
+        let resolved = resolve_style(&theme, &tile);
+        assert_eq!(resolved.tile_height, 64.0);
+    }
+
+    /// Selected recolors both icon and title text to `ColorScheme.primary` —
+    /// `_LisTileDefaultsM3.selectedColor` (`list_tile.dart`, oracle tag
+    /// `3.44.0`).
+    #[test]
+    fn resolve_style_selected_uses_the_primary_color() {
+        let theme = ThemeData::light();
+        let colors = theme.color_scheme;
+        let tile = ListTile::new().selected(true);
+        let resolved = resolve_style(&theme, &tile);
+
+        assert_eq!(resolved.icon_color, colors.primary);
+        assert_eq!(resolved.title_style.color, Some(colors.primary));
+    }
+
+    /// Mutation-honest combined-state pin: `disabled` must win over
+    /// `selected` — Flutter parity: `_IndividualOverrides.resolve` checks
+    /// `WidgetState.disabled` BEFORE `WidgetState.selected` (`list_tile.dart`
+    /// `:1222-1227`, oracle tag `3.44.0`). A resolver that checked `selected`
+    /// first would report `primary`, not the disabled color, here.
+    #[test]
+    fn resolve_style_disabled_wins_over_selected() {
+        let theme = ThemeData::light();
+        let colors = theme.color_scheme;
+        let tile = ListTile::new().selected(true).enabled(false);
+        let resolved = resolve_style(&theme, &tile);
+
+        let expected = colors.on_surface.with_opacity(DISABLED_CONTENT_OPACITY);
+        assert_eq!(resolved.icon_color, expected);
+        assert_eq!(resolved.title_style.color, Some(expected));
+    }
+
+    #[test]
+    fn resolve_style_falls_through_to_the_list_tile_theme_when_no_widget_override_is_set() {
+        let mut theme = ThemeData::light();
+        let themed_icon_color = Color::rgb(1, 2, 3);
+        theme.list_tile_theme = Some(ListTileThemeData {
+            icon_color: Some(themed_icon_color),
+            min_leading_width: Some(30.0),
+            ..Default::default()
+        });
+
+        let resolved = resolve_style(&theme, &ListTile::new());
+
+        assert_eq!(resolved.icon_color, themed_icon_color);
+        assert_eq!(resolved.min_leading_width, 30.0);
+        // `horizontal_title_gap` was left unset on the theme slot — it falls
+        // through to its own default independently.
+        assert_eq!(resolved.horizontal_title_gap, HORIZONTAL_TITLE_GAP);
+    }
+
+    #[test]
+    fn resolve_style_widget_override_wins_over_the_list_tile_theme() {
+        let mut theme = ThemeData::light();
+        theme.list_tile_theme = Some(ListTileThemeData {
+            icon_color: Some(Color::rgb(1, 1, 1)),
+            ..Default::default()
+        });
+        let widget_color = Color::rgb(9, 9, 9);
+
+        let tile = ListTile::new().icon_color(widget_color);
+        let resolved = resolve_style(&theme, &tile);
+
+        assert_eq!(resolved.icon_color, widget_color);
+    }
+
+    #[test]
+    fn resolve_style_enabled_unselected_text_color_stays_unset_by_default() {
+        // Unlike `icon_color`, an enabled/unselected tile with no override
+        // leaves `text_color` at `None` — the title/subtitle styles keep
+        // their own baked-in M3 color instead of being forced to a shared
+        // constant. See the module docs' "State-color cascade" section.
+        let theme = ThemeData::light();
+        let colors = theme.color_scheme;
+        let resolved = resolve_style(&theme, &ListTile::new());
+        assert_eq!(resolved.title_style.color, Some(colors.on_surface));
+        assert_eq!(
+            resolved.subtitle_style.color,
+            Some(colors.on_surface_variant)
+        );
+    }
+}

--- a/crates/flui-material/src/theme_data.rs
+++ b/crates/flui-material/src/theme_data.rs
@@ -6,7 +6,7 @@
 use flui_types::EdgeInsets;
 use flui_types::Pixels;
 use flui_types::platform::Brightness;
-use flui_types::styling::{BorderSide, Color};
+use flui_types::styling::{BorderRadius, BorderSide, Color};
 use flui_types::typography::TextStyle;
 use flui_widgets::WidgetStateProperty;
 
@@ -292,6 +292,110 @@ pub struct InputDecorationThemeData {
     pub content_padding: Option<EdgeInsets>,
 }
 
+/// Overrides [`ListTile`](crate::ListTile)'s `_LisTileDefaultsM3` token
+/// defaults, one field at a time — an unset field here still falls through to
+/// `ListTile`'s own default (see `list_tile.rs`'s `resolve_*` functions), it
+/// does not blank the whole slot.
+///
+/// Flutter parity: `ListTileThemeData` (`material/list_tile_theme.dart`,
+/// oracle tag `3.44.0`), narrowed to the fields FLUI's `ListTile` actually
+/// consumes — every field below except [`is_three_line`](Self::is_three_line).
+/// FLUI collapses the oracle's two theme tiers (the ambient `ListTileTheme`
+/// inherited widget and this [`ThemeData`] slot) into this one slot, the same
+/// "named reduction" every other component-theme type in this crate already
+/// makes (see [`CardThemeData`]'s doc comment) — `list_tile.dart`'s own
+/// `ListTile.build` reads both (`tileTheme.iconColor ??
+/// theme.listTileTheme.iconColor`), so this slot stands in for both reads.
+/// Named deferrals (no consumer in FLUI's `ListTile` yet):
+/// `style` (`ListTileStyle` is an M2-only fork this M3-only crate has no use
+/// for), `enable_feedback`, `mouse_cursor`, `visual_density`,
+/// `title_alignment` (baseline-precise top/center/bottom placement — this
+/// substrate's `ListTile` is a `Row`/`Column` composition, not a baseline-aware
+/// `_RenderListTile` port, see that module's docs), `control_affinity` (no
+/// checkbox/switch/radio list-tile variants yet).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ListTileThemeData {
+    /// Overrides [`ListTile`](crate::ListTile)'s dense-layout flag.
+    pub dense: Option<bool>,
+    /// Overrides [`ListTile`](crate::ListTile)'s default shape (a plain
+    /// rectangle).
+    pub shape: Option<MaterialShape>,
+    /// Overrides the color used for icons/text when the tile is selected
+    /// (`ColorScheme.primary`).
+    pub selected_color: Option<Color>,
+    /// Overrides the default `leading`/`trailing` icon color
+    /// (`ColorScheme.onSurfaceVariant`).
+    pub icon_color: Option<Color>,
+    /// Overrides the default `title`/`subtitle`/`leading`/`trailing` text
+    /// color. `None` (the default) leaves each slot's own baked-in default
+    /// color untouched — see `list_tile.rs`'s `resolve_content_color`.
+    pub text_color: Option<Color>,
+    /// Overrides [`ListTile::title`](crate::ListTile::title)'s text style
+    /// (`TextTheme.bodyLarge` colored `onSurface`).
+    pub title_text_style: Option<TextStyle>,
+    /// Overrides [`ListTile::subtitle`](crate::ListTile::subtitle)'s text
+    /// style (`TextTheme.bodyMedium` colored `onSurfaceVariant`).
+    pub subtitle_text_style: Option<TextStyle>,
+    /// Overrides [`ListTile::leading`](crate::ListTile::leading)/
+    /// [`trailing`](crate::ListTile::trailing)'s text style
+    /// (`TextTheme.labelSmall` colored `onSurfaceVariant`).
+    pub leading_and_trailing_text_style: Option<TextStyle>,
+    /// Overrides the tile's internal content padding
+    /// (`EdgeInsetsDirectional.only(start: 16.0, end: 24.0)`).
+    pub content_padding: Option<EdgeInsets>,
+    /// Overrides the tile's background color when
+    /// [`ListTile::selected`](crate::ListTile::selected) is `false`
+    /// (`Colors.transparent`).
+    pub tile_color: Option<Color>,
+    /// Overrides the tile's background color when
+    /// [`ListTile::selected`](crate::ListTile::selected) is `true`
+    /// (`Colors.transparent`).
+    pub selected_tile_color: Option<Color>,
+    /// Overrides the gap between the leading/trailing slots and the title
+    /// column (`16.0` — a bare `list_tile.dart` literal, not part of
+    /// `_LisTileDefaultsM3`).
+    pub horizontal_title_gap: Option<f32>,
+    /// Overrides the minimum padding above/below the title/subtitle column
+    /// (`8.0`).
+    pub min_vertical_padding: Option<f32>,
+    /// Overrides the minimum width reserved for
+    /// [`ListTile::leading`](crate::ListTile::leading) (`24.0`).
+    pub min_leading_width: Option<f32>,
+    /// Overrides the tile's minimum height. `None` (the default) falls
+    /// through to the one/two/three-line table — see `list_tile.rs`'s
+    /// `default_tile_height`.
+    pub min_tile_height: Option<f32>,
+    /// Overrides [`ListTile::is_three_line`](crate::ListTile::is_three_line)
+    /// when the widget itself leaves it unset.
+    pub is_three_line: Option<bool>,
+}
+
+/// Overrides [`Divider`](crate::Divider)/[`VerticalDivider`](crate::VerticalDivider)'s
+/// `_DividerDefaultsM3` token defaults, one field at a time.
+///
+/// Flutter parity: `DividerThemeData` (`material/divider_theme.dart`, oracle
+/// tag `3.44.0`) — every oracle field has a consumer here, so nothing is
+/// narrowed. FLUI collapses the oracle's `DividerTheme` inherited widget into
+/// this one [`ThemeData`] slot, the same named reduction
+/// [`ListTileThemeData`] makes.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct DividerThemeData {
+    /// Overrides the line color (`ColorScheme.outlineVariant`).
+    pub color: Option<Color>,
+    /// Overrides [`Divider`](crate::Divider)'s height /
+    /// [`VerticalDivider`](crate::VerticalDivider)'s width (`16.0`).
+    pub space: Option<f32>,
+    /// Overrides the line's thickness (`1.0`).
+    pub thickness: Option<f32>,
+    /// Overrides the leading-edge indent (`0.0`).
+    pub indent: Option<f32>,
+    /// Overrides the trailing-edge indent (`0.0`).
+    pub end_indent: Option<f32>,
+    /// Overrides the line's corner radius. `None` (the default) paints a
+    /// square-cornered line.
+    pub radius: Option<BorderRadius>,
+}
+
 /// Visual-style configuration provided to descendants by a
 /// [`Theme`](crate::Theme) ancestor.
 ///
@@ -375,6 +479,15 @@ pub struct ThemeData {
     /// M3 token defaults, per field. Flutter parity:
     /// `ThemeData.inputDecorationTheme`.
     pub input_decoration_theme: Option<InputDecorationThemeData>,
+
+    /// Overrides [`ListTile`](crate::ListTile)'s M3 token defaults, per
+    /// field. Flutter parity: `ThemeData.listTileTheme`.
+    pub list_tile_theme: Option<ListTileThemeData>,
+
+    /// Overrides [`Divider`](crate::Divider)/
+    /// [`VerticalDivider`](crate::VerticalDivider)'s M3 token defaults, per
+    /// field. Flutter parity: `ThemeData.dividerTheme`.
+    pub divider_theme: Option<DividerThemeData>,
 }
 
 impl ThemeData {
@@ -397,6 +510,8 @@ impl ThemeData {
             dialog_theme: None,
             floating_action_button_theme: None,
             input_decoration_theme: None,
+            list_tile_theme: None,
+            divider_theme: None,
         }
     }
 
@@ -419,6 +534,8 @@ impl ThemeData {
             dialog_theme: None,
             floating_action_button_theme: None,
             input_decoration_theme: None,
+            list_tile_theme: None,
+            divider_theme: None,
         }
     }
 
@@ -498,6 +615,12 @@ impl ThemeData {
             input_decoration_theme: overrides
                 .input_decoration_theme
                 .or_else(|| self.input_decoration_theme.clone()),
+            list_tile_theme: overrides
+                .list_tile_theme
+                .or_else(|| self.list_tile_theme.clone()),
+            divider_theme: overrides
+                .divider_theme
+                .or_else(|| self.divider_theme.clone()),
         }
     }
 }
@@ -546,6 +669,10 @@ pub struct ThemeDataOverrides {
     pub floating_action_button_theme: Option<FabThemeData>,
     /// Replaces [`ThemeData::input_decoration_theme`] wholesale when `Some`.
     pub input_decoration_theme: Option<InputDecorationThemeData>,
+    /// Replaces [`ThemeData::list_tile_theme`] wholesale when `Some`.
+    pub list_tile_theme: Option<ListTileThemeData>,
+    /// Replaces [`ThemeData::divider_theme`] wholesale when `Some`.
+    pub divider_theme: Option<DividerThemeData>,
 }
 
 impl Default for ThemeData {
@@ -636,7 +763,13 @@ mod tests {
 
     #[test]
     fn light_and_dark_leave_every_component_theme_slot_unset() {
-        for theme in [ThemeData::light(), ThemeData::dark()] {
+        // A helper `fn`, not a `[ThemeData; 2]`/`vec![...]` loop: `ThemeData`
+        // now carries enough `Option<ComponentThemeData>` slots that a
+        // stack-allocated 2-element array trips clippy's
+        // `large_stack_arrays` lint, and a `Vec` of the same trips
+        // `useless_vec` right back (the loop consumes it immediately, so
+        // clippy sees no reason for the heap allocation).
+        fn assert_every_slot_unset(theme: &ThemeData) {
             assert!(theme.elevated_button_theme.is_none());
             assert!(theme.filled_button_theme.is_none());
             assert!(theme.outlined_button_theme.is_none());
@@ -647,7 +780,12 @@ mod tests {
             assert!(theme.dialog_theme.is_none());
             assert!(theme.floating_action_button_theme.is_none());
             assert!(theme.input_decoration_theme.is_none());
+            assert!(theme.list_tile_theme.is_none());
+            assert!(theme.divider_theme.is_none());
         }
+
+        assert_every_slot_unset(&ThemeData::light());
+        assert_every_slot_unset(&ThemeData::dark());
     }
 
     #[test]

--- a/crates/flui-material/src/theme_data.rs
+++ b/crates/flui-material/src/theme_data.rs
@@ -299,8 +299,7 @@ pub struct InputDecorationThemeData {
 ///
 /// Flutter parity: `ListTileThemeData` (`material/list_tile_theme.dart`,
 /// oracle tag `3.44.0`), narrowed to the fields FLUI's `ListTile` actually
-/// consumes — every field below except [`is_three_line`](Self::is_three_line).
-/// FLUI collapses the oracle's two theme tiers (the ambient `ListTileTheme`
+/// consumes. FLUI collapses the oracle's two theme tiers (the ambient `ListTileTheme`
 /// inherited widget and this [`ThemeData`] slot) into this one slot, the same
 /// "named reduction" every other component-theme type in this crate already
 /// makes (see [`CardThemeData`]'s doc comment) — `list_tile.dart`'s own
@@ -874,5 +873,81 @@ mod tests {
 
         let patched = base.copy_with(ThemeDataOverrides::default());
         assert_eq!(patched.input_decoration_theme, Some(input_decoration_theme));
+    }
+
+    /// Same shape as `copy_with_sets_input_decoration_theme_slot`, for the
+    /// `list_tile_theme` slot.
+    #[test]
+    fn copy_with_sets_list_tile_theme_slot() {
+        let base = ThemeData::light();
+        let list_tile_theme = ListTileThemeData {
+            min_leading_width: Some(30.0),
+            ..Default::default()
+        };
+
+        let patched = base.copy_with(ThemeDataOverrides {
+            list_tile_theme: Some(list_tile_theme.clone()),
+            ..Default::default()
+        });
+
+        assert_eq!(patched.list_tile_theme, Some(list_tile_theme));
+        // Untouched slots stay unset, mirroring the base theme.
+        assert!(patched.divider_theme.is_none());
+    }
+
+    /// Same already-set-slot-survives-a-`None`-override proof as
+    /// `copy_with_none_preserves_an_already_set_input_decoration_theme_slot`,
+    /// for the `list_tile_theme` slot.
+    #[test]
+    fn copy_with_none_preserves_an_already_set_list_tile_theme_slot() {
+        let list_tile_theme = ListTileThemeData {
+            min_leading_width: Some(30.0),
+            ..Default::default()
+        };
+        let base = ThemeData::light().copy_with(ThemeDataOverrides {
+            list_tile_theme: Some(list_tile_theme.clone()),
+            ..Default::default()
+        });
+
+        let patched = base.copy_with(ThemeDataOverrides::default());
+        assert_eq!(patched.list_tile_theme, Some(list_tile_theme));
+    }
+
+    /// Same shape as `copy_with_sets_input_decoration_theme_slot`, for the
+    /// `divider_theme` slot.
+    #[test]
+    fn copy_with_sets_divider_theme_slot() {
+        let base = ThemeData::light();
+        let divider_theme = DividerThemeData {
+            thickness: Some(3.0),
+            ..Default::default()
+        };
+
+        let patched = base.copy_with(ThemeDataOverrides {
+            divider_theme: Some(divider_theme.clone()),
+            ..Default::default()
+        });
+
+        assert_eq!(patched.divider_theme, Some(divider_theme));
+        // Untouched slots stay unset, mirroring the base theme.
+        assert!(patched.list_tile_theme.is_none());
+    }
+
+    /// Same already-set-slot-survives-a-`None`-override proof as
+    /// `copy_with_none_preserves_an_already_set_input_decoration_theme_slot`,
+    /// for the `divider_theme` slot.
+    #[test]
+    fn copy_with_none_preserves_an_already_set_divider_theme_slot() {
+        let divider_theme = DividerThemeData {
+            thickness: Some(3.0),
+            ..Default::default()
+        };
+        let base = ThemeData::light().copy_with(ThemeDataOverrides {
+            divider_theme: Some(divider_theme.clone()),
+            ..Default::default()
+        });
+
+        let patched = base.copy_with(ThemeDataOverrides::default());
+        assert_eq!(patched.divider_theme, Some(divider_theme));
     }
 }

--- a/crates/flui-material/tests/divider.rs
+++ b/crates/flui-material/tests/divider.rs
@@ -1,0 +1,104 @@
+//! `Divider`/`VerticalDivider` widget-level integration coverage — mounts a
+//! real `Divider` through the full render pipeline (`tests/common/mod.rs`,
+//! the same harness `tests/card.rs` uses) and proves the M3 geometry
+//! (height/thickness/indents) and the theme cascade actually reach a mounted
+//! tree, not just `resolve_style` computed in isolation.
+
+mod common;
+
+use common::{lay_out, loose};
+use flui_material::{Divider, DividerThemeData, Theme, ThemeData, ThemeDataOverrides};
+use flui_types::Color;
+
+/// `_DividerDefaultsM3`'s full geometry table reaches the mounted tree: the
+/// filled line is `1.0` thick and inset by `indent`/`end_indent` on the
+/// left/right, under a loose (not tight) root so the divider's own
+/// intrinsic `16.0` height request isn't overridden by a forced parent size.
+#[test]
+fn default_geometry_matches_the_m3_token_table() {
+    let laid = lay_out(
+        Theme::new(
+            ThemeData::light(),
+            Divider::new().indent(8.0).end_indent(12.0),
+        ),
+        loose(400.0),
+    );
+
+    let decorated = laid
+        .find_by_render_type("RenderDecoratedBox")
+        .expect("Divider must compose a decorated (filled) line");
+    assert_eq!(
+        laid.size(decorated).height.get(),
+        1.0,
+        "_DividerDefaultsM3.thickness (1.0) must set the filled line's height"
+    );
+
+    let width = laid.size(decorated).width.get();
+    assert_eq!(
+        width,
+        400.0 - 8.0 - 12.0,
+        "indent (8.0) and end_indent (12.0) must both reduce the line's width from the \
+         400px root"
+    );
+}
+
+/// The theme tier's `color` reaches the mounted line's decoration — proving
+/// `ThemeData.divider_theme` is actually consulted, not just computed in
+/// `resolve_style` isolation.
+#[test]
+fn themed_color_beats_the_m3_default() {
+    let themed_color = Color::rgb(44, 55, 66);
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        divider_theme: Some(DividerThemeData {
+            color: Some(themed_color),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    let laid = lay_out(Theme::new(theme, Divider::new()), loose(400.0));
+
+    let decorated = laid
+        .find_by_render_type("RenderDecoratedBox")
+        .expect("Divider must compose a decorated (filled) line");
+    let decoration = laid
+        .render_property(decorated, "decoration")
+        .expect("RenderDecoratedBox reports a \"decoration\" diagnostics property");
+
+    assert!(
+        decoration.contains(&format!("{themed_color:?}")),
+        "a configured divider_theme.color must reach the mounted line — got {decoration:?}"
+    );
+}
+
+/// A widget-level `.color(...)` override wins over a configured
+/// `divider_theme.color` — the standard widget → theme → default cascade.
+#[test]
+fn widget_color_override_wins_over_the_divider_theme() {
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        divider_theme: Some(DividerThemeData {
+            color: Some(Color::rgb(1, 1, 1)),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let widget_color = Color::rgb(9, 9, 9);
+
+    let laid = lay_out(
+        Theme::new(theme, Divider::new().color(widget_color)),
+        loose(400.0),
+    );
+
+    let decorated = laid
+        .find_by_render_type("RenderDecoratedBox")
+        .expect("Divider must compose a decorated (filled) line");
+    let decoration = laid
+        .render_property(decorated, "decoration")
+        .expect("RenderDecoratedBox reports a \"decoration\" diagnostics property");
+
+    assert!(
+        decoration.contains(&format!("{widget_color:?}")),
+        "an explicit Divider::color override must win over divider_theme.color — got \
+         {decoration:?}"
+    );
+}

--- a/crates/flui-material/tests/divider.rs
+++ b/crates/flui-material/tests/divider.rs
@@ -7,7 +7,9 @@
 mod common;
 
 use common::{lay_out, loose};
-use flui_material::{Divider, DividerThemeData, Theme, ThemeData, ThemeDataOverrides};
+use flui_material::{
+    Divider, DividerThemeData, Theme, ThemeData, ThemeDataOverrides, VerticalDivider,
+};
 use flui_types::Color;
 
 /// `_DividerDefaultsM3`'s full geometry table reaches the mounted tree: the
@@ -39,6 +41,44 @@ fn default_geometry_matches_the_m3_token_table() {
         400.0 - 8.0 - 12.0,
         "indent (8.0) and end_indent (12.0) must both reduce the line's width from the \
          400px root"
+    );
+}
+
+/// `VerticalDivider`'s geometry mirrors `Divider`'s on the TRANSPOSED axis:
+/// thickness sets the line's WIDTH (not height), and `indent`/`end_indent`
+/// reduce the line's HEIGHT (not width) — Flutter parity: `Divider`'s
+/// `height`/margin-`top`/margin-`bottom` axis vs. `VerticalDivider`'s
+/// `width`/margin-`left`/margin-`right` axis (`divider.dart`, oracle tag
+/// `3.44.0`). A width/height mapping that was accidentally left transposed
+/// (or copy-pasted from `Divider` unchanged) fails this test: swap
+/// `laid.size(decorated).width`/`.height` below and both assertions flip
+/// from matching to mismatching the M3 token values.
+#[test]
+fn vertical_divider_default_geometry_matches_the_m3_token_table_on_the_transposed_axis() {
+    let laid = lay_out(
+        Theme::new(
+            ThemeData::light(),
+            VerticalDivider::new().indent(8.0).end_indent(12.0),
+        ),
+        loose(400.0),
+    );
+
+    let decorated = laid
+        .find_by_render_type("RenderDecoratedBox")
+        .expect("VerticalDivider must compose a decorated (filled) line");
+    assert_eq!(
+        laid.size(decorated).width.get(),
+        1.0,
+        "_DividerDefaultsM3.thickness (1.0) must set the filled line's WIDTH for \
+         VerticalDivider"
+    );
+
+    let height = laid.size(decorated).height.get();
+    assert_eq!(
+        height,
+        400.0 - 8.0 - 12.0,
+        "indent (8.0) and end_indent (12.0) must both reduce the line's HEIGHT (not width) \
+         from the 400px root"
     );
 }
 

--- a/crates/flui-material/tests/list_tile.rs
+++ b/crates/flui-material/tests/list_tile.rs
@@ -13,7 +13,7 @@ use common::{lay_out, loose, tight};
 use flui_material::{ListTile, ListTileThemeData, Theme, ThemeData, ThemeDataOverrides};
 use flui_types::Color;
 use flui_view::IntoView;
-use flui_widgets::{MediaQuery, MediaQueryData, Text};
+use flui_widgets::{Icon, IconData, IconTheme, IconThemeData, MediaQuery, MediaQueryData, Text};
 
 /// `ListTile::build` reads `SafeArea`, which panics without an ambient
 /// `MediaQuery` (`tests/app_bar.rs`'s own tests wrap the same way) — every
@@ -156,6 +156,50 @@ fn every_slot_present_mounts_a_two_line_tile() {
         text_runs.len(),
         4,
         "all four slots (leading, title, subtitle, trailing) must mount their own text run"
+    );
+}
+
+/// `ListTile` MERGES its resolved icon color into the ambient `IconTheme`
+/// rather than replacing it — an app-level `IconTheme(size: ..)` above the
+/// tile must still reach a bare `Icon` in `leading`, matching Flutter's
+/// `IconTheme.merge` (`list_tile.dart` `:1008-1009`, oracle tag `3.44.0`).
+/// Probed by comparing the mounted glyph's `RenderParagraph` height across
+/// two distinct ambient sizes (far from `IconThemeData::fallback`'s
+/// `24.0`): if `ListTile` replaced the ambient theme instead of merging
+/// into it, both mounts would collapse to the SAME `24.0` fallback and this
+/// height comparison would fail to distinguish them.
+#[test]
+fn ambient_icon_theme_size_reaches_a_bare_leading_icon_through_the_tile() {
+    fn mounted_glyph_height(ambient_size: f32) -> f32 {
+        let laid = lay_out(
+            themed(
+                ThemeData::light(),
+                IconTheme::new(
+                    IconThemeData {
+                        size: Some(ambient_size),
+                        ..IconThemeData::default()
+                    },
+                    ListTile::new().leading(Icon::new(IconData::new(0xE87D))),
+                ),
+            ),
+            loose(400.0),
+        );
+
+        let glyph = laid
+            .find_by_render_type("RenderParagraph")
+            .expect("the leading Icon must mount its glyph as a RenderParagraph");
+        laid.size(glyph).height.get()
+    }
+
+    let small = mounted_glyph_height(10.0);
+    let large = mounted_glyph_height(80.0);
+
+    assert!(
+        large > small,
+        "a larger ambient IconTheme size (80.0) must mount a taller glyph box than a smaller \
+         one (10.0) — got small={small}, large={large}. Equal heights mean the ambient size \
+         never reached the icon (ListTile replaced the ambient IconTheme instead of merging \
+         into it)."
     );
 }
 

--- a/crates/flui-material/tests/list_tile.rs
+++ b/crates/flui-material/tests/list_tile.rs
@@ -1,0 +1,193 @@
+//! `ListTile` widget-level integration coverage — mounts a real `ListTile`
+//! through the full render pipeline (`tests/common/mod.rs`, the same harness
+//! `tests/card.rs`/`tests/ink_well.rs` use) and proves the whole-tile tap
+//! target, the `enabled`/theme cascades, and slot presence/absence actually
+//! reach a mounted tree, not just `resolve_style` computed in isolation.
+
+mod common;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use common::{lay_out, loose, tight};
+use flui_material::{ListTile, ListTileThemeData, Theme, ThemeData, ThemeDataOverrides};
+use flui_types::Color;
+use flui_view::IntoView;
+use flui_widgets::{MediaQuery, MediaQueryData, Text};
+
+/// `ListTile::build` reads `SafeArea`, which panics without an ambient
+/// `MediaQuery` (`tests/app_bar.rs`'s own tests wrap the same way) — every
+/// test mounts under this default `MediaQueryData` (no system insets) so the
+/// `Theme`/`ListTile` under test is the only thing varying per case.
+fn themed(theme: ThemeData, child: impl IntoView) -> MediaQuery {
+    MediaQuery::new(MediaQueryData::default(), Theme::new(theme, child))
+}
+
+/// A tap anywhere on the tile — including inside the content padding gutter,
+/// well away from `title`'s own text glyphs — fires `on_tap`: the whole tile
+/// is the tap target, not just the title. Flutter parity: `ListTile.build`
+/// wraps its ENTIRE content (padding included) in a single `InkWell`
+/// (`list_tile.dart`, oracle tag `3.44.0`), mirroring `tests/card.rs`'s
+/// `default_corner_radius_reaches_the_mounted_material` pattern of probing
+/// the mounted surface rather than the title's own bounds.
+#[test]
+fn whole_tile_tap_fires_from_a_point_inside_the_content_padding() {
+    let taps = Arc::new(AtomicUsize::new(0));
+    let counted = Arc::clone(&taps);
+    let laid = lay_out(
+        themed(
+            ThemeData::light(),
+            ListTile::new().title(Text::new("Inbox")).on_tap(move || {
+                counted.fetch_add(1, Ordering::SeqCst);
+            }),
+        ),
+        tight(400.0, 56.0),
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("ListTile must compose a Material surface");
+    let origin = laid.absolute_offset(material);
+
+    // `_LisTileDefaultsM3.contentPadding` starts at `left: 16.0` — a point
+    // 2px from the tile's left edge sits inside that padding gutter, well
+    // before any title glyph begins.
+    laid.dispatch_pointer_down(origin.dx.get() + 2.0, origin.dy.get() + 2.0);
+    laid.dispatch_pointer_up(origin.dx.get() + 2.0, origin.dy.get() + 2.0);
+
+    assert_eq!(
+        taps.load(Ordering::SeqCst),
+        1,
+        "a tap inside the content padding (not on the title's own glyphs) must still fire \
+         on_tap — the whole mounted tile, not just the title, is the tap target"
+    );
+}
+
+/// `enabled(false)` swallows a tap entirely: the same point that fires
+/// `on_tap` on an enabled tile produces zero calls once disabled — Flutter
+/// parity: `InkWell(onTap: enabled ? onTap : null)` (`list_tile.dart`, oracle
+/// tag `3.44.0`).
+#[test]
+fn disabled_tile_swallows_a_tap() {
+    let taps = Arc::new(AtomicUsize::new(0));
+    let counted = Arc::clone(&taps);
+    let laid = lay_out(
+        themed(
+            ThemeData::light(),
+            ListTile::new()
+                .title(Text::new("Inbox"))
+                .enabled(false)
+                .on_tap(move || {
+                    counted.fetch_add(1, Ordering::SeqCst);
+                }),
+        ),
+        tight(400.0, 56.0),
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("ListTile must compose a Material surface");
+    let origin = laid.absolute_offset(material);
+
+    laid.dispatch_pointer_down(origin.dx.get() + 20.0, origin.dy.get() + 20.0);
+    laid.dispatch_pointer_up(origin.dx.get() + 20.0, origin.dy.get() + 20.0);
+
+    assert_eq!(
+        taps.load(Ordering::SeqCst),
+        0,
+        "enabled(false) must swallow the tap — on_tap must not fire"
+    );
+}
+
+/// A `ListTile` with only a title (no leading/subtitle/trailing) still
+/// mounts a single-line tile at the default one-line height (`56.0`) —
+/// proving the composition tolerates every slot being absent, not just
+/// every slot being present.
+#[test]
+fn title_only_tile_mounts_at_the_one_line_height() {
+    // Loose (not tight) constraints: a tight incoming height would force
+    // the tile to exactly that height regardless of its own min-height
+    // request, masking the very default this test exists to pin.
+    let laid = lay_out(
+        themed(ThemeData::light(), ListTile::new().title(Text::new("Solo"))),
+        loose(400.0),
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("ListTile must compose a Material surface");
+
+    assert_eq!(
+        laid.size(material).height.get(),
+        56.0,
+        "a title-only tile (no subtitle) must mount at the one-line M3 default height"
+    );
+}
+
+/// A `ListTile` with leading, title, subtitle, and trailing all present
+/// mounts without dropping any slot — each slot's content reaches the tree.
+#[test]
+fn every_slot_present_mounts_a_two_line_tile() {
+    let laid = lay_out(
+        themed(
+            ThemeData::light(),
+            ListTile::new()
+                .leading(Text::new("L"))
+                .title(Text::new("Title"))
+                .subtitle(Text::new("Subtitle"))
+                .trailing(Text::new("T")),
+        ),
+        loose(400.0),
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("ListTile must compose a Material surface");
+
+    assert_eq!(
+        laid.size(material).height.get(),
+        72.0,
+        "leading+title+subtitle+trailing (two lines, not three) must mount at the two-line \
+         M3 default height"
+    );
+
+    let text_runs = laid.find_all_by_render_type("RenderParagraph");
+    assert_eq!(
+        text_runs.len(),
+        4,
+        "all four slots (leading, title, subtitle, trailing) must mount their own text run"
+    );
+}
+
+/// The theme tier's `tile_color` reaches the mounted `Material` fill —
+/// proving `ThemeData.list_tile_theme` is actually consulted, not just
+/// computed in `resolve_style` isolation.
+#[test]
+fn list_tile_theme_slot_reaches_the_mounted_materials_color() {
+    let themed_color = Color::rgb(11, 22, 33);
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        list_tile_theme: Some(ListTileThemeData {
+            tile_color: Some(themed_color),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    let laid = lay_out(
+        themed(theme, ListTile::new().title(Text::new("Themed"))),
+        tight(400.0, 56.0),
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("ListTile must compose a Material surface");
+    let color = laid
+        .render_property(material, "color")
+        .expect("RenderPhysicalShape reports a \"color\" diagnostics property");
+
+    assert_eq!(
+        color,
+        format!("{themed_color:?}"),
+        "a configured list_tile_theme.tile_color must reach the mounted Material"
+    );
+}

--- a/crates/flui-material/tests/parity/theme_data_test.rs
+++ b/crates/flui-material/tests/parity/theme_data_test.rs
@@ -63,7 +63,11 @@ fn copy_with_no_args_is_identity() {
 /// comment in `src/theme_data.rs` for the derivation.
 #[test]
 fn default_text_theme_role_colors_equal_on_surface() {
-    for theme in [ThemeData::light(), ThemeData::dark()] {
+    // A helper `fn`, not a `[ThemeData; 2]`/`vec![...]` loop — see
+    // `src/theme_data.rs`'s identical fix: a stack array of two
+    // `ThemeData`s trips clippy's `large_stack_arrays` lint, and a `Vec`
+    // consumed immediately by the loop trips `useless_vec` right back.
+    fn assert_role_colors_equal_on_surface(theme: &ThemeData) {
         for role in theme.text_theme.roles() {
             let style = role.expect("every englishLike2021 role is populated");
             assert_eq!(
@@ -74,6 +78,9 @@ fn default_text_theme_role_colors_equal_on_surface() {
             );
         }
     }
+
+    assert_role_colors_equal_on_surface(&ThemeData::light());
+    assert_role_colors_equal_on_surface(&ThemeData::dark());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The data-display family starter for Catalog.1, ported against Flutter 3.44.0 `material/{list_tile,divider,list_tile_theme,divider_theme}.dart`.

- **`ListTile`** — leading/title/subtitle/trailing composition over InkWell (whole-tile tappable, pinned at a padding-gutter point): `_LisTileDefaultsM3` values (the oracle's actual class name, typo included), the 56/72/88 + dense 48/64/76 height table (min-height semantics via ConstrainedBox), `_IndividualOverrides` disabled > selected > enabled precedence with combined pins, `isThreeLine` as the oracle's explicit flag riding the full `?? tileTheme ?? false` cascade (review-reshaped from bare bool — an explicit widget `false` must override a theme `true`), **dense also clamps title/subtitle fonts to 13/12** (review-caught: dense is more than the height table), IconTheme layered as a true **merge** preserving ambient size/opacity (review-caught replace-vs-merge), the oracle's wrapper stack (InkWell > Semantics(button/selected/enabled) > fill > SafeArea > IconTheme) in order. Named divergences: three-line top-alignment (FLUI always centers — the ≤2-line arm), VisualDensity, baseline details.
- **`Divider` + `VerticalDivider`** — height (layout) vs thickness (painted line) correctly separated, indents, M3 outlineVariant/1.0 defaults; the vertical variant behaviorally pinned on the transposed axis (a swapped-axis mutation fails it).
- **`ListTileThemeData`/`DividerThemeData`** slots (ThemeDataOverrides convention, copy_with round-trip + None-preserves pins per the file's own pattern).

### Review trail
Builder → full review (dense font clamp missing, IconTheme replace-vs-merge with a false merge claim, is_three_line cascade break on a new public surface, doc overclaim, 2 test gaps) → fix pass with per-finding mutation evidence.

### Gates
Workspace nextest 6959 passed / 4 skipped · workspace clippy `-D warnings` clean · doc gate clean · port-check/inventory/fmt/taplo/typos · doctests 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvkSGveJwxLVuygRAGVKuz