### PR TITLE
feat(material): SnackBar + ScaffoldMessenger — queue, timers, FAB lift, action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,6 +1746,7 @@ dependencies = [
  "flui-interaction",
  "flui-objects",
  "flui-rendering",
+ "flui-scheduler",
  "flui-types",
  "flui-view",
  "flui-widgets",

--- a/crates/flui-material/Cargo.toml
+++ b/crates/flui-material/Cargo.toml
@@ -35,6 +35,9 @@ flui-foundation = { path = "../flui-foundation", version = "0.2.0" }
 flui-animation = { path = "../flui-animation", version = "0.2.0" }
 # `FocusNode` — `InkWell::focus_node`'s external-node pass-through.
 flui-interaction = { path = "../flui-interaction", version = "0.2.0" }
+# `PostFrameHandle` — `ScaffoldMessenger` defers a tick-driven `SnackBar`
+# `on_closed` callback out of the build phase through it (trigger #22).
+flui-scheduler = { path = "../flui-scheduler", version = "0.2.0" }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/flui-material/src/lib.rs
+++ b/crates/flui-material/src/lib.rs
@@ -82,7 +82,9 @@ pub mod list_tile;
 pub mod material;
 pub mod outlined_button;
 pub mod scaffold;
+pub mod scaffold_messenger;
 pub mod shape;
+pub mod snack_bar;
 pub mod text_button;
 pub mod text_field;
 pub mod text_theme;
@@ -108,7 +110,12 @@ pub use list_tile::ListTile;
 pub use material::Material;
 pub use outlined_button::OutlinedButton;
 pub use scaffold::{Scaffold, ScaffoldScope, ScaffoldState};
+pub use scaffold_messenger::{
+    ScaffoldMessenger, ScaffoldMessengerHandle, ScaffoldMessengerScope, ScaffoldMessengerState,
+    SnackBarClosedReason, SnackBarController,
+};
 pub use shape::MaterialShape;
+pub use snack_bar::{SnackBar, SnackBarAction, SnackBarActionState};
 pub use text_button::TextButton;
 pub use text_field::{TextField, TextFieldState};
 pub use text_theme::TextTheme;

--- a/crates/flui-material/src/scaffold.rs
+++ b/crates/flui-material/src/scaffold.rs
@@ -5,12 +5,14 @@
 //! # Flutter parity
 //!
 //! `material/scaffold.dart`'s `Scaffold` (oracle tag `3.44.0`). Implemented
-//! subset: the `app_bar`, `body`, `floating_action_button`, `drawer`, and
-//! `end_drawer` slots of `_ScaffoldLayout.performLayout`
-//! (`scaffold.dart:1027-1296`) — the remaining six slots
+//! subset: the `app_bar`, `body`, `floating_action_button`, `snack_bar`,
+//! `drawer`, and `end_drawer` slots of `_ScaffoldLayout.performLayout`
+//! (`scaffold.dart:1027-1296`) — the remaining five slots
 //! (`bottomNavigationBar`, `persistentFooter`, `materialBanner`, `bodyScrim`,
-//! `snackBar`, `bottomSheet`, `statusBar`) are not ported; a future slot
-//! extends `ScaffoldLayoutDelegate`, it does not restructure it.
+//! `bottomSheet`, `statusBar`) are not ported; a future slot extends
+//! `ScaffoldLayoutDelegate`, it does not restructure it. The `snack_bar` slot
+//! only ever carries `SnackBarBehavior.fixed` content — see
+//! `crate::snack_bar`'s module docs for the V1 scope that narrowing implies.
 //! `resize_to_avoid_bottom_inset` defaults to `true`, same as the oracle.
 //! `background_color` falls back to `ColorScheme.surface` (the oracle's
 //! `themeData.scaffoldBackgroundColor`, which this substrate has not ported
@@ -73,8 +75,7 @@
 //! ## Deferred, and named
 //!
 //! `bottomNavigationBar`, `persistentFooterButtons`, `MaterialBanner`,
-//! `SnackBar` (via `ScaffoldMessenger`), `bottomSheet`,
-//! `extendBody`/`extendBodyBehindAppBar`, non-`endFloat`
+//! `bottomSheet`, `extendBody`/`extendBodyBehindAppBar`, non-`endFloat`
 //! `FloatingActionButtonLocation`s. Also deferred, specific to the drawer
 //! slots this update adds: the `AppBar` auto-hamburger (no `AppBar` ↔
 //! `Scaffold` coupling exists yet), per-side `enable_open_drag_gesture`
@@ -83,10 +84,34 @@
 //! both sides), and `drawerDragStartBehavior`/`drawerBarrierDismissible`
 //! overrides at the `Scaffold` level (fixed at
 //! `DrawerController`'s own defaults — see `crate::drawer`). None of these
-//! slots exist in `ScaffoldLayoutDelegate` yet — the five that do
-//! (`app_bar`/`body`/`floating_action_button`/`drawer`/`end_drawer`) are
-//! copied verbatim from `_ScaffoldLayout`'s branches for those same slots,
-//! so adding a slot later is additive, not a rewrite.
+//! slots exist in `ScaffoldLayoutDelegate` yet — the six that do
+//! (`app_bar`/`body`/`floating_action_button`/`snack_bar`/`drawer`/`end_drawer`)
+//! are copied verbatim from `_ScaffoldLayout`'s branches for those same
+//! slots, so adding a slot later is additive, not a rewrite.
+//!
+//! ## `ScaffoldMessenger` wiring
+//!
+//! `ScaffoldState` registers with the nearest ancestor
+//! [`crate::ScaffoldMessengerScope`] (if any) — not `build` (ADR-0018/trigger
+//! #22, same reasoning the drawer wiring section above gives). **Not**
+//! `did_change_dependencies` alone, either: `ScaffoldMessengerScope::maybe_of`
+//! is a no-dependency ambient lookup (`ctx.get`, matching `ScaffoldScope`'s
+//! own `DrawerHandle` lookup — see that type's doc), and this substrate's
+//! `did_change_dependencies` only fires when a TRACKED (`ctx.depend_on`)
+//! inherited ancestor's `update_should_notify` returns `true` since the last
+//! build — never merely "this element was just mounted under some ancestor".
+//! So the actual, guaranteed registration point is `ViewState::init_state`
+//! (the same proven pattern `DrawerControllerState::init_state` already uses
+//! for its own `VsyncScope` lookup); `did_change_dependencies` re-runs the
+//! identical `ScaffoldState::sync_messenger_registration` helper as a
+//! best-effort re-home for the rare case it DOES fire, but nothing depends
+//! on it firing. Registration is keyed by this scaffold's own `ElementId` and
+//! idempotent; a messenger-identity change (`ScaffoldMessengerHandle::ptr_eq`)
+//! unregisters from the old messenger before registering with the new one,
+//! and `dispose` unregisters unconditionally. `build` reads
+//! `crate::ScaffoldMessengerHandle::current_entry` (private) fresh every call and, if
+//! `Some`, mounts a `SnackBarPresenter` at `SLOT_SNACK_BAR` — see
+//! `crate::snack_bar`'s module docs for what that presenter renders.
 //!
 //! **Named divergence: no `TextDirection` / RTL.** The oracle's
 //! `_ScaffoldLayout` carries a `textDirection` field, both to mirror
@@ -104,6 +129,7 @@ use std::any::Any;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use flui_foundation::ElementId;
 use flui_rendering::constraints::BoxConstraints;
 use flui_types::geometry::px;
 use flui_types::styling::Color;
@@ -119,6 +145,8 @@ use crate::drawer::{
     Drawer, DrawerAlignment, DrawerController, DrawerControllerState, DrawerHandle,
 };
 use crate::material::Material;
+use crate::scaffold_messenger::{ScaffoldMessengerHandle, ScaffoldMessengerScope};
+use crate::snack_bar::SnackBarPresenter;
 use crate::theme::Theme;
 
 /// The `app_bar` slot id — see [`ScaffoldLayoutDelegate`].
@@ -127,6 +155,8 @@ const SLOT_APP_BAR: &str = "app_bar";
 const SLOT_BODY: &str = "body";
 /// The `floating_action_button` slot id — see [`ScaffoldLayoutDelegate`].
 const SLOT_FLOATING_ACTION_BUTTON: &str = "floating_action_button";
+/// The `snack_bar` slot id — see [`ScaffoldLayoutDelegate`].
+const SLOT_SNACK_BAR: &str = "snack_bar";
 /// The `drawer` slot id — see [`ScaffoldLayoutDelegate`].
 const SLOT_DRAWER: &str = "drawer";
 /// The `end_drawer` slot id — see [`ScaffoldLayoutDelegate`].
@@ -382,7 +412,7 @@ impl InheritedView for ScaffoldScope {
 impl_inherited_view!(ScaffoldScope);
 
 /// Persistent state behind [`Scaffold`] — see the module docs' "Drawer
-/// wiring" section.
+/// wiring" and "`ScaffoldMessenger` wiring" sections.
 pub struct ScaffoldState {
     handle: DrawerHandle,
     /// Acquired in [`init_state`](ViewState::init_state), per ADR-0018 —
@@ -395,6 +425,13 @@ pub struct ScaffoldState {
     /// first `init_state` — never observed by `build`, which always runs
     /// after `init_state`.
     rebuild: Option<RebuildHandle>,
+    /// This scaffold's own `ElementId`, captured in `init_state` (ctx is not
+    /// available in `dispose`) so `dispose` can unregister from
+    /// [`Self::messenger`] without a context.
+    element_id: Option<ElementId>,
+    /// The currently-registered [`ScaffoldMessengerHandle`] (if any) — see
+    /// the module docs' "`ScaffoldMessenger` wiring" section.
+    messenger: Option<ScaffoldMessengerHandle>,
 }
 
 impl std::fmt::Debug for ScaffoldState {
@@ -402,6 +439,7 @@ impl std::fmt::Debug for ScaffoldState {
         f.debug_struct("ScaffoldState")
             .field("drawer_open", &self.handle.is_drawer_open())
             .field("end_drawer_open", &self.handle.is_end_drawer_open())
+            .field("has_messenger", &self.messenger.is_some())
             .finish_non_exhaustive()
     }
 }
@@ -413,6 +451,8 @@ impl StatefulView for Scaffold {
         ScaffoldState {
             handle: DrawerHandle::new(),
             rebuild: None,
+            element_id: None,
+            messenger: None,
         }
     }
 }
@@ -420,6 +460,30 @@ impl StatefulView for Scaffold {
 impl ViewState<Scaffold> for ScaffoldState {
     fn init_state(&mut self, ctx: &dyn BuildContext) {
         self.rebuild = Some(ctx.rebuild_handle());
+        self.element_id = Some(ctx.element_id());
+        // The primary, guaranteed-to-run registration point — see this
+        // method's own doc comment on `Self::sync_messenger_registration`
+        // for why `did_change_dependencies` alone is not enough here.
+        self.sync_messenger_registration(ctx);
+    }
+
+    fn did_change_dependencies(&mut self, ctx: &dyn BuildContext) {
+        // Best-effort re-home: `ScaffoldMessengerScope::maybe_of` is a
+        // no-dependency ambient lookup (`ctx.get`, not `ctx.depend_on`),
+        // per its own doc — so this hook only fires here if some OTHER
+        // depended-upon inherited ancestor notifies in the same rebuild,
+        // not on a `ScaffoldMessenger` swap by itself. `init_state` above
+        // is what actually guarantees the initial registration; this call
+        // is a defensive no-op the rest of the time (see
+        // `Self::sync_messenger_registration`'s own identity-comparison
+        // short-circuit).
+        self.sync_messenger_registration(ctx);
+    }
+
+    fn dispose(&mut self) {
+        if let (Some(messenger), Some(element_id)) = (self.messenger.take(), self.element_id) {
+            messenger.unregister_scaffold(element_id);
+        }
     }
 
     fn build(&self, view: &Scaffold, ctx: &dyn BuildContext) -> impl IntoView {
@@ -462,6 +526,17 @@ impl ViewState<Scaffold> for ScaffoldState {
             children.push(LayoutId::new(
                 SLOT_FLOATING_ACTION_BUTTON,
                 floating_action_button.clone(),
+            ));
+        }
+
+        if let Some((snack_bar, animation)) = self
+            .messenger
+            .as_ref()
+            .and_then(ScaffoldMessengerHandle::current_entry)
+        {
+            children.push(LayoutId::new(
+                SLOT_SNACK_BAR,
+                SnackBarPresenter::new(snack_bar, animation),
             ));
         }
 
@@ -595,13 +670,46 @@ impl ScaffoldState {
         }
         controller
     }
+
+    /// Compares the nearest ancestor [`ScaffoldMessengerScope`]'s handle
+    /// (if any) against [`Self::messenger`] by [`ScaffoldMessengerHandle::ptr_eq`]
+    /// identity and, if it changed, unregisters from the old messenger and
+    /// registers with the new one. A no-op when the identity is unchanged
+    /// (including the common "both `None`" and "same handle, called again"
+    /// cases) — see [`ViewState::init_state`]/[`ViewState::did_change_dependencies`]'s
+    /// own doc comments for why this runs from both hooks.
+    fn sync_messenger_registration(&mut self, ctx: &dyn BuildContext) {
+        let new_messenger = ScaffoldMessengerScope::maybe_of(ctx);
+        let identity_changed = match (&self.messenger, &new_messenger) {
+            (Some(old), Some(new)) => !old.ptr_eq(new),
+            (None, None) => false,
+            _ => true,
+        };
+        if !identity_changed {
+            return;
+        }
+        let element_id = self
+            .element_id
+            .expect("BUG: init_state always runs before this method (both its own call site and \
+                     did_change_dependencies, which the ViewState lifecycle guarantees runs after it)");
+        if let Some(old) = &self.messenger {
+            old.unregister_scaffold(element_id);
+        }
+        if let Some(new) = &new_messenger {
+            let rebuild = self.rebuild.clone().expect(
+                "BUG: init_state always runs before this method — see the identical note above",
+            );
+            new.register_scaffold(element_id, rebuild);
+        }
+        self.messenger = new_messenger;
+    }
 }
 
 /// The layout algorithm for [`Scaffold`]'s `app_bar` / `body` /
-/// `floating_action_button` / `drawer` / `end_drawer` slots.
+/// `floating_action_button` / `snack_bar` / `drawer` / `end_drawer` slots.
 ///
 /// Flutter parity: `_ScaffoldLayout` (`scaffold.dart:991-1308`), narrowed to
-/// the five slots this substrate ports — see the module docs for the full
+/// the six slots this substrate ports — see the module docs for the full
 /// deferred-slot list and the inset contract this delegate enforces.
 #[derive(Debug, Clone, PartialEq)]
 struct ScaffoldLayoutDelegate {
@@ -651,6 +759,24 @@ impl MultiChildLayoutDelegate for ScaffoldLayoutDelegate {
             ctx.position_child(SLOT_BODY, Offset::new(px(0.0), content_top));
         }
 
+        // Oracle: "Set the size of the SnackBar early if the behavior is
+        // fixed so the FAB can be positioned correctly" (`:1140-1144`) — this
+        // substrate only ever mounts `SnackBarBehavior.fixed` content (see
+        // `crate::snack_bar`'s module docs), so the snack bar is always
+        // measured and positioned here, before the FAB. Full-width, loose
+        // height — its rendered height varies frame-to-frame while its
+        // entrance/exit animation runs (the animating child dirties this
+        // render object's own layout, which bubbles up to this delegate
+        // exactly like any other child-size change).
+        let mut snack_bar_size = Size::ZERO;
+        if ctx.has_child(SLOT_SNACK_BAR) {
+            snack_bar_size = ctx.layout_child(SLOT_SNACK_BAR, full_width_loose_height);
+            ctx.position_child(
+                SLOT_SNACK_BAR,
+                Offset::new(px(0.0), content_bottom - snack_bar_size.height),
+            );
+        }
+
         if ctx.has_child(SLOT_FLOATING_ACTION_BUTTON) {
             // Loose on both axes — the button reports its own intrinsic
             // size, never forced from `size` (oracle: `layoutChild(...,
@@ -681,7 +807,22 @@ impl MultiChildLayoutDelegate for ScaffoldLayoutDelegate {
             let safe_margin = (self.min_view_padding_bottom - bottom_content_height
                 + px(FLOATING_ACTION_BUTTON_MARGIN))
             .max(px(FLOATING_ACTION_BUTTON_MARGIN));
-            let fab_y = content_bottom - fab_size.height - safe_margin;
+            let mut fab_y = content_bottom - fab_size.height - safe_margin;
+
+            // `FabFloatOffsetY`'s snack-bar branch (`:571-576`): a visible
+            // snack bar (any nonzero measured height, including a
+            // mid-animation, partially-grown one — see the `snack_bar_size`
+            // comment above) pulls the FAB up to sit `kFloatingActionButtonMargin`
+            // above it, whenever that's tighter than the plain safe-margin
+            // position.
+            if snack_bar_size.height > px(0.0) {
+                fab_y = fab_y.min(
+                    content_bottom
+                        - snack_bar_size.height
+                        - fab_size.height
+                        - px(FLOATING_ACTION_BUTTON_MARGIN),
+                );
+            }
             ctx.position_child(SLOT_FLOATING_ACTION_BUTTON, Offset::new(fab_x, fab_y));
         }
 

--- a/crates/flui-material/src/scaffold_messenger.rs
+++ b/crates/flui-material/src/scaffold_messenger.rs
@@ -32,11 +32,18 @@
 //!
 //! ## The drain state machine
 //!
-//! `DrainState` makes the oracle's implicit `_snackBarController` status
-//! machine explicit: `Idle` (nothing showing) → `Entering` (250ms forward) →
-//! `Displayed` (entrance complete, display timer running) → `Exiting` (250ms
-//! reverse) → back to `Idle`, which immediately re-enters if the queue is
-//! still non-empty (`MessengerCore::pop_and_advance`).
+//! There is no separate `enum` tracking Idle/Entering/Displayed/Exiting: the
+//! entrance controller's own [`AnimationStatus`] already carries every bit of
+//! that state (`Dismissed` = idle, `Forward` = entering, `Completed` =
+//! displayed, `Reverse` = exiting) with the queue as the one piece it does
+//! not — an earlier version of this module shadowed that status in a
+//! `DrainState` cell, which nothing ever read except its own tests, exactly
+//! the "two sources of truth, one inert" shape this module now avoids.
+//! `MessengerCore::handle_entry_status` translates a *change* in that status
+//! into the one queue-affecting consequence it has (`Dismissed` → pop and
+//! advance to the next entry; `Completed` → start the display timer) — `pop
+//! and advance` on `Dismissed`, then immediately re-entering if the queue is
+//! still non-empty, IS the state machine.
 //!
 //! ## Why status edges are polled, not pushed, from the controller
 //!
@@ -93,6 +100,42 @@
 //! `MessengerCore::advancing` guards `pop_and_advance` itself against
 //! double-entry from that same re-entrant path.
 //!
+//! ## Deferring `on_closed` out of the build phase
+//!
+//! `MessengerCore::reconcile` runs from two kinds of call site with
+//! different obligations, captured in `ReconcileOrigin`:
+//!
+//! - **`ReconcileOrigin::Direct`** — synchronously, at the end of every
+//!   public [`ScaffoldMessengerHandle`] method (`show_snack_bar`/
+//!   `hide_current_snack_bar`/`remove_current_snack_bar`/`clear_snack_bars`),
+//!   which only ever run from event-handler call stacks. `on_closed` fires
+//!   immediately here — Flutter parity: `removeCurrentSnackBar` completes its
+//!   completer synchronously, in the same call.
+//! - **`ReconcileOrigin::Build`** — from [`ScaffoldMessengerState::build`],
+//!   reached when the Send-safe controller listeners scheduled a rebuild for
+//!   a PURELY tick-driven status settle (no explicit API call in between —
+//!   e.g. the entrance animation finishing, or the display timer expiring
+//!   and starting the exit reverse, which later settles on its own). Firing
+//!   arbitrary caller-supplied `on_closed` code inline, mid-`build`, is the
+//!   same hazard trigger #22 names for `rebuild_handle`/`post_frame_handle`
+//!   themselves: an `on_closed` that calls `show_snack_bar` would mutate the
+//!   queue and schedule further rebuilds *after* this build's siblings have
+//!   already built against the pre-mutation tree, silently.
+//!   `MessengerCore::pop_and_advance` instead defers the fire through the
+//!   [`flui_scheduler::PostFrameHandle`] acquired in
+//!   [`ScaffoldMessengerState::init_state`] (ADR-0021) — the callback runs
+//!   after this frame's build/layout/paint have committed, its own reentrant
+//!   `show_snack_bar`/etc. call landing squarely in a safe, ordinary
+//!   event-handler-shaped window. If no `PostFrameHandle` is available (the
+//!   messenger was never `attach`ed — a bare unit test constructing
+//!   [`ScaffoldMessengerHandle`] directly), the fire falls back to
+//!   synchronous, the same as `Direct`, rather than silently dropping the
+//!   callback.
+//!
+//! State BOOKKEEPING (which entry is at the front, the recorded reason,
+//! whether the display timer is running) is safe to mutate from `build` —
+//! only the arbitrary-code DISPATCH of `on_closed` needs to leave it.
+//!
 //! ## Multi-scaffold fan-out
 //!
 //! `show_snack_bar` shows the current entry on every registered
@@ -120,11 +163,30 @@
 //!
 //! ## Completion slot
 //!
-//! Each queued entry's [`SnackBarClosedReason`] is recorded exactly once
-//! (`QueuedEntry::set_reason_once`) at hide/remove/action time — a slot the
-//! drain pop reads but never invents or overwrites (falling back to
-//! [`SnackBarClosedReason::Remove`] only in the unreachable-in-practice case
-//! of a pop with no reason ever recorded).
+//! Each queued entry carries a `reason` cell the eventual pop reads (falling
+//! back to [`SnackBarClosedReason::Remove`] only in the unreachable-in-
+//! practice case of a pop with no reason ever recorded). It is set two
+//! different ways, matching an asymmetry in the oracle itself:
+//!
+//! - `QueuedEntry::set_reason_once` (hide, timeout) — **provisional**: only
+//!   applies if nothing has been recorded yet. Flutter parity:
+//!   `hideCurrentSnackBar`'s completion is itself deferred to
+//!   `_snackBarController!.reverse().then(...)` — it does not complete
+//!   anything until the reverse actually settles, so whatever reason is
+//!   recorded here is only a promise about what a LATER completion will
+//!   carry, not a completion itself.
+//! - `QueuedEntry::set_reason` (remove) — **unconditional overwrite**.
+//!   Flutter parity: `removeCurrentSnackBar` completes the still-pending
+//!   completer with ITS OWN reason immediately, `if (!completer.isCompleted)`
+//!   — a race it always wins against a hide/timeout that recorded a reason
+//!   but has not yet actually completed (settled to `Dismissed`). So a
+//!   `remove_current_snack_bar()` call arriving mid-reverse (after an
+//!   earlier `hide_current_snack_bar()`) must report `Remove`, not the
+//!   hide's own `Hide` — see `hide_then_remove_mid_reverse_reports_remove`.
+//!
+//! Both a provisional (hide/timeout) and a completed (remove/action) call
+//! only ever *record* a reason on the entry — see the previous section for
+//! when that recording turns into an actual `on_closed` fire.
 //!
 //! ## V1 scope
 //!
@@ -147,6 +209,7 @@ use flui_animation::{
     Animation, AnimationController, AnimationStatus, Scheduler, Vsync, VsyncRegistration,
 };
 use flui_foundation::ElementId;
+use flui_scheduler::PostFrameHandle;
 use flui_view::prelude::*;
 use flui_view::{RebuildHandle, impl_inherited_view};
 use flui_widgets::animated::VsyncScope;
@@ -226,11 +289,20 @@ struct QueuedEntry {
 
 impl QueuedEntry {
     /// Records `reason` only if nothing has been recorded yet — the
-    /// once-only guard the module docs describe.
+    /// provisional guard [`hide_current`](MessengerCore::hide_current)/timeout
+    /// use. See the module docs' "Completion slot" section.
     fn set_reason_once(&self, reason: SnackBarClosedReason) {
         if self.reason.get().is_none() {
             self.reason.set(Some(reason));
         }
+    }
+
+    /// Unconditionally overwrites the recorded reason —
+    /// [`remove_current`](MessengerCore::remove_current)'s own use, which
+    /// always wins over a not-yet-completed provisional reason. See the
+    /// module docs' "Completion slot" section.
+    fn set_reason(&self, reason: SnackBarClosedReason) {
+        self.reason.set(Some(reason));
     }
 
     /// Fires `on_closed` with the recorded reason (falling back to
@@ -251,18 +323,16 @@ impl QueuedEntry {
     }
 }
 
-/// The explicit drain state — see the module docs' "The drain state
-/// machine" section.
+/// Where a [`MessengerCore::reconcile`] call originated — see the module
+/// docs' "Deferring `on_closed` out of the build phase" section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DrainState {
-    /// Nothing showing, queue empty (or about to be re-entered).
-    Idle,
-    /// The shared controller is running forward.
-    Entering,
-    /// The shared controller is at `1.0`; the display timer is running.
-    Displayed,
-    /// The shared controller is running in reverse.
-    Exiting,
+enum ReconcileOrigin {
+    /// A public [`ScaffoldMessengerHandle`] method, called synchronously
+    /// from an event-handler call stack — `on_closed` fires immediately.
+    Direct,
+    /// [`ScaffoldMessengerState::build`], reached from a purely tick-driven
+    /// status settle — `on_closed` is deferred past this frame.
+    Build,
 }
 
 /// The messenger's interior-mutable state, `Rc`-shared between
@@ -281,8 +351,12 @@ struct MessengerCore {
     /// reaches [`Self::reconcile`] via [`ScaffoldMessengerState::build`].
     /// `None` until [`ScaffoldMessengerHandle::attach`] runs.
     rebuild: RefCell<Option<RebuildHandle>>,
+    /// Acquired in [`ScaffoldMessengerHandle::attach`] (`init_state`, per
+    /// ADR-0021/trigger #22). `None` until then, or if no binding installed
+    /// one — see the module docs' "Deferring `on_closed` out of the build
+    /// phase" section for the synchronous fallback that implies.
+    post_frame: RefCell<Option<PostFrameHandle>>,
     queue: RefCell<VecDeque<Rc<QueuedEntry>>>,
-    state: Cell<DrainState>,
     last_entry_status: Cell<AnimationStatus>,
     last_duration_status: Cell<AnimationStatus>,
     /// Reentrancy guard for [`Self::pop_and_advance`] — see the module docs'
@@ -302,14 +376,14 @@ impl MessengerCore {
     /// translates every change into a state transition/pop, looping until a
     /// full pass detects no further change. See the module docs' "Why
     /// status edges are polled, not pushed, from the controller" section.
-    fn reconcile(&self) {
+    fn reconcile(&self, origin: ReconcileOrigin) {
         loop {
             let mut changed = false;
 
             let entry_status = self.entry_controller.status();
             if entry_status != self.last_entry_status.get() {
                 self.last_entry_status.set(entry_status);
-                self.handle_entry_status(entry_status);
+                self.handle_entry_status(entry_status, origin);
                 changed = true;
             }
 
@@ -338,25 +412,24 @@ impl MessengerCore {
 
     /// Translates one entrance-controller status into a state
     /// transition/pop.
-    fn handle_entry_status(&self, status: AnimationStatus) {
+    fn handle_entry_status(&self, status: AnimationStatus, origin: ReconcileOrigin) {
         match status {
-            AnimationStatus::Dismissed => self.pop_and_advance(),
-            AnimationStatus::Completed => {
-                self.state.set(DrainState::Displayed);
-                self.start_display_timer();
-            }
-            AnimationStatus::Forward => self.state.set(DrainState::Entering),
-            AnimationStatus::Reverse => self.state.set(DrainState::Exiting),
+            AnimationStatus::Dismissed => self.pop_and_advance(origin),
+            AnimationStatus::Completed => self.start_display_timer(),
+            // Forward/Reverse carry no further consequence here — the
+            // controller's own `status()` already IS the observable state
+            // (see the module docs' "The drain state machine" section).
             // `AnimationStatus` is `#[non_exhaustive]`; every variant it has
             // today is handled above.
             _ => {}
         }
     }
 
-    /// Pops the just-exited front entry (if any), fires its `on_closed`,
-    /// then begins the next entry's entrance if the queue is still
-    /// non-empty. The single place that ever pops the queue.
-    fn pop_and_advance(&self) {
+    /// Pops the just-exited front entry (if any), fires (or, for
+    /// [`ReconcileOrigin::Build`], defers) its `on_closed`, then begins the
+    /// next entry's entrance if the queue is still non-empty. The single
+    /// place that ever pops the queue.
+    fn pop_and_advance(&self, origin: ReconcileOrigin) {
         if self.advancing.get() {
             // A re-entrant call from inside the `on_closed` callback this
             // very function is about to invoke below — the outer call owns
@@ -368,18 +441,45 @@ impl MessengerCore {
         self.cancel_display_timer();
         let popped = self.queue.borrow_mut().pop_front();
         if let Some(entry) = popped {
-            entry.complete();
+            self.complete_entry(entry, origin);
         }
 
-        self.state.set(DrainState::Idle);
         let has_next = !self.queue.borrow().is_empty();
         if has_next {
-            self.state.set(DrainState::Entering);
             let _ = self.entry_controller.forward();
         }
 
         self.advancing.set(false);
         self.schedule_rebuild_on_scaffolds();
+    }
+
+    /// Fires `entry`'s `on_closed` per `origin` — immediately for
+    /// [`ReconcileOrigin::Direct`], or deferred through [`Self::post_frame`]
+    /// for [`ReconcileOrigin::Build`] (falling back to immediate if no
+    /// [`PostFrameHandle`] is available). See the module docs' "Deferring
+    /// `on_closed` out of the build phase" section.
+    fn complete_entry(&self, entry: Rc<QueuedEntry>, origin: ReconcileOrigin) {
+        if origin == ReconcileOrigin::Direct {
+            entry.complete();
+            return;
+        }
+        let Some(post_frame) = self.post_frame.borrow().clone() else {
+            entry.complete();
+            return;
+        };
+        // `schedule_local` DROPS the callback without running it on error
+        // (per its own doc) — keep a fallback handle so a scheduling failure
+        // still completes the entry instead of silently losing the call.
+        let entry_for_fallback = Rc::clone(&entry);
+        let scheduled = post_frame.schedule_local(move |_timing| entry.complete());
+        if let Err(error) = scheduled {
+            tracing::warn!(
+                %error,
+                "SnackBar on_closed post-frame scheduling failed; firing immediately instead \
+                 of silently dropping it"
+            );
+            entry_for_fallback.complete();
+        }
     }
 
     fn start_display_timer(&self) {
@@ -438,15 +538,21 @@ impl MessengerCore {
 
     /// Flutter parity: `removeCurrentSnackBar` (`:424-436`) — no
     /// `isDismissed` early return in the oracle, which is exactly why this
-    /// needs the direct-pop fallback the module docs describe.
+    /// needs the direct-pop fallback the module docs describe. Overwrites
+    /// the reason unconditionally, not once-only — see the module docs'
+    /// "Completion slot" section for why `remove` always wins over a
+    /// not-yet-completed `hide`/timeout. Only ever reached from
+    /// [`ScaffoldMessengerHandle::remove_current_snack_bar`], an
+    /// event-handler call stack, so the direct-pop fallback fires
+    /// synchronously ([`ReconcileOrigin::Direct`]).
     fn remove_current(&self, reason: SnackBarClosedReason) {
         let Some(front) = self.queue.borrow().front().cloned() else {
             return;
         };
-        front.set_reason_once(reason);
+        front.set_reason(reason);
         self.cancel_display_timer();
         if self.entry_controller.status() == AnimationStatus::Dismissed {
-            self.pop_and_advance();
+            self.pop_and_advance(ReconcileOrigin::Direct);
         } else {
             self.entry_controller.set_value(0.0);
         }
@@ -509,8 +615,8 @@ impl ScaffoldMessengerHandle {
             entry_vsync_registration: RefCell::new(None),
             duration_vsync_registration: RefCell::new(None),
             rebuild: RefCell::new(None),
+            post_frame: RefCell::new(None),
             queue: RefCell::new(VecDeque::new()),
-            state: Cell::new(DrainState::Idle),
             last_entry_status: Cell::new(AnimationStatus::Dismissed),
             last_duration_status: Cell::new(AnimationStatus::Dismissed),
             advancing: Cell::new(false),
@@ -519,9 +625,12 @@ impl ScaffoldMessengerHandle {
         Self { shared }
     }
 
-    /// Wires the ambient `Vsync` and installs the entrance controller's
-    /// Send-safe "reschedule [`ScaffoldMessenger`]'s rebuild" listener — see
-    /// [`Self::new`]'s doc for why this is deferred out of construction.
+    /// Wires the ambient `Vsync`, installs the entrance controller's
+    /// Send-safe "reschedule [`ScaffoldMessenger`]'s rebuild" listener, and
+    /// acquires the binding's post-frame capability (ADR-0021) — see
+    /// [`Self::new`]'s doc for why this is deferred out of construction, and
+    /// the module docs' "Deferring `on_closed` out of the build phase"
+    /// section for what the post-frame handle is for.
     pub(crate) fn attach(&self, ctx: &dyn BuildContext) {
         let rebuild = ctx.rebuild_handle();
         let rebuild_for_listener = rebuild.clone();
@@ -531,6 +640,7 @@ impl ScaffoldMessengerHandle {
                 rebuild_for_listener.schedule();
             }));
         *self.shared.rebuild.borrow_mut() = Some(rebuild);
+        *self.shared.post_frame.borrow_mut() = ctx.post_frame_handle();
 
         let vsync = ctx.get::<VsyncScope, _>(|scope| scope.vsync().clone());
         if let Some(vsync) = &vsync {
@@ -551,11 +661,13 @@ impl ScaffoldMessengerHandle {
         self.shared.entry_controller.dispose();
     }
 
-    /// Re-runs the state-machine reconciliation — called from
-    /// [`ScaffoldMessengerState::build`] whenever the Send-safe listeners
-    /// scheduled a rebuild.
-    pub(crate) fn reconcile(&self) {
-        self.shared.reconcile();
+    /// Re-runs the state-machine reconciliation for a purely tick-driven
+    /// settle — called from [`ScaffoldMessengerState::build`] whenever the
+    /// Send-safe listeners scheduled a rebuild. Any `on_closed` this
+    /// reaches is deferred, never fired inline mid-`build` — see the module
+    /// docs' "Deferring `on_closed` out of the build phase" section.
+    pub(crate) fn reconcile_after_tick_driven_settle(&self) {
+        self.shared.reconcile(ReconcileOrigin::Build);
     }
 
     /// Registers a [`crate::Scaffold`] so it receives `schedule_rebuild`
@@ -635,11 +747,10 @@ impl ScaffoldMessengerHandle {
             queue.len() == 1
         };
         if should_enter {
-            self.shared.state.set(DrainState::Entering);
             let _ = self.shared.entry_controller.forward();
             self.shared.schedule_rebuild_on_scaffolds();
         }
-        self.shared.reconcile();
+        self.shared.reconcile(ReconcileOrigin::Direct);
 
         SnackBarController { on_closed }
     }
@@ -649,7 +760,7 @@ impl ScaffoldMessengerHandle {
     /// currently showing.
     pub fn hide_current_snack_bar(&self) {
         self.shared.hide_current(SnackBarClosedReason::Hide);
-        self.shared.reconcile();
+        self.shared.reconcile(ReconcileOrigin::Direct);
     }
 
     /// Reason-carrying counterpart of [`Self::hide_current_snack_bar`], for
@@ -657,7 +768,7 @@ impl ScaffoldMessengerHandle {
     /// [`crate::snack_bar::SnackBarAction`]'s single-fire press).
     pub(crate) fn hide_current_snack_bar_because(&self, reason: SnackBarClosedReason) {
         self.shared.hide_current(reason);
-        self.shared.reconcile();
+        self.shared.reconcile(ReconcileOrigin::Direct);
     }
 
     /// Removes the current snack bar (if any) immediately, with no exit
@@ -665,7 +776,7 @@ impl ScaffoldMessengerHandle {
     /// are queued, the next begins its entrance immediately.
     pub fn remove_current_snack_bar(&self) {
         self.shared.remove_current(SnackBarClosedReason::Remove);
-        self.shared.reconcile();
+        self.shared.reconcile(ReconcileOrigin::Direct);
     }
 
     /// Drops every queued (not-yet-shown) snack bar silently (their
@@ -673,7 +784,7 @@ impl ScaffoldMessengerHandle {
     /// exit animation. See the module docs' "`clearSnackBars`" section.
     pub fn clear_snack_bars(&self) {
         self.shared.clear();
-        self.shared.reconcile();
+        self.shared.reconcile(ReconcileOrigin::Direct);
     }
 }
 
@@ -807,9 +918,10 @@ impl ViewState<ScaffoldMessenger> for ScaffoldMessengerState {
 
     fn build(&self, view: &ScaffoldMessenger, _ctx: &dyn BuildContext) -> impl IntoView {
         // Absorbs any tick-driven status settle the Send-safe listeners
-        // scheduled this rebuild for — see the module docs' "Why status
-        // edges are polled, not pushed, from the controller" section.
-        self.handle.reconcile();
+        // scheduled this rebuild for — see the module docs' "Deferring
+        // `on_closed` out of the build phase" section for why any
+        // `on_closed` this reaches is deferred, not fired inline here.
+        self.handle.reconcile_after_tick_driven_settle();
         ScaffoldMessengerScope {
             handle: self.handle.clone(),
             child: view.child.clone(),
@@ -838,7 +950,6 @@ mod tests {
     fn show_snack_bar_on_an_empty_queue_starts_entering() {
         let handle = ScaffoldMessengerHandle::new();
         handle.show_snack_bar(snack_bar("a"));
-        assert_eq!(handle.shared.state.get(), DrainState::Entering);
         assert_eq!(
             handle.shared.entry_controller.status(),
             AnimationStatus::Forward
@@ -875,8 +986,11 @@ mod tests {
             AnimationStatus::Forward
         );
         handle.shared.entry_controller.set_value(1.0); // settle "a"'s entrance -> Completed
-        handle.shared.reconcile();
-        assert_eq!(handle.shared.state.get(), DrainState::Displayed);
+        handle.shared.reconcile(ReconcileOrigin::Direct);
+        assert_eq!(
+            handle.shared.entry_controller.status(),
+            AnimationStatus::Completed
+        );
 
         handle.remove_current_snack_bar(); // "a" removed abruptly -> "b" starts entering
         assert_eq!(
@@ -908,7 +1022,7 @@ mod tests {
         let handle = ScaffoldMessengerHandle::new();
         handle.show_snack_bar(snack_bar("a"));
         handle.shared.entry_controller.set_value(1.0);
-        handle.shared.reconcile();
+        handle.shared.reconcile(ReconcileOrigin::Direct);
 
         handle.hide_current_snack_bar();
 
@@ -916,7 +1030,6 @@ mod tests {
             handle.shared.entry_controller.status(),
             AnimationStatus::Reverse
         );
-        assert_eq!(handle.shared.state.get(), DrainState::Exiting);
         // Still queued — the entry pops only once the reverse animation
         // actually settles at Dismissed.
         assert_eq!(handle.shared.queue.borrow().len(), 1);
@@ -929,6 +1042,54 @@ mod tests {
         assert_eq!(
             handle.shared.entry_controller.status(),
             AnimationStatus::Dismissed
+        );
+    }
+
+    /// `remove_current_snack_bar` called mid-reverse, after an earlier
+    /// `hide_current_snack_bar`, must report `Remove` — not the hide's own
+    /// `Hide`, which never actually completed (the reverse hadn't settled
+    /// yet). Flutter parity: `removeCurrentSnackBar` completes the
+    /// still-pending completer with its own reason immediately,
+    /// `if (!completer.isCompleted)`, always winning that race — see the
+    /// module docs' "Completion slot" section.
+    ///
+    /// Red-check: change `remove_current`'s `front.set_reason(reason)` back
+    /// to `front.set_reason_once(reason)` — this test fails: the final
+    /// reason reads `Hide` (the once-only guard preserves hide's earlier,
+    /// still-provisional record instead of letting remove overwrite it).
+    #[test]
+    fn hide_then_remove_mid_reverse_reports_remove() {
+        let handle = ScaffoldMessengerHandle::new();
+        let reason = Rc::new(RefCell::new(None));
+        let reason_for_cb = Rc::clone(&reason);
+        handle
+            .show_snack_bar(snack_bar("a"))
+            .on_closed(move |r| *reason_for_cb.borrow_mut() = Some(r));
+
+        handle.shared.entry_controller.set_value(1.0); // fully shown
+        handle.shared.reconcile(ReconcileOrigin::Direct);
+
+        handle.hide_current_snack_bar(); // provisionally records Hide, starts reversing
+        assert_eq!(
+            handle.shared.entry_controller.status(),
+            AnimationStatus::Reverse,
+            "hide must not have completed yet — still mid-reverse"
+        );
+        assert!(
+            reason.borrow().is_none(),
+            "hide's own reason must not have fired yet"
+        );
+
+        handle.remove_current_snack_bar(); // mid-reverse: must win the race and fire NOW
+
+        assert_eq!(
+            *reason.borrow(),
+            Some(SnackBarClosedReason::Remove),
+            "remove must overwrite hide's not-yet-completed provisional reason"
+        );
+        assert!(
+            handle.shared.queue.borrow().is_empty(),
+            "the queue must have drained, not merely recorded a reason"
         );
     }
 
@@ -977,6 +1138,15 @@ mod tests {
     /// re-entrancy, the state the module docs describe) and confirm the
     /// queue still drains rather than sitting forever with a
     /// recorded-but-unfired reason.
+    ///
+    /// Red-check: remove the `status() == Dismissed` branch from
+    /// `MessengerCore::remove_current` (always call `set_value(0.0)`) — this
+    /// test fails: `set_value` on an already-`Dismissed` controller is a
+    /// genuine no-op (value and status both already at rest), so no edge
+    /// fires and the queue never drains — confirmed by actually running
+    /// this mutation, not merely asserted (see
+    /// `remove_current_reentrantly_from_on_closed_still_drains_the_queue`'s
+    /// own doc for why THAT test does not also catch it).
     #[test]
     fn remove_current_direct_pops_when_the_controller_is_already_dismissed() {
         let handle = ScaffoldMessengerHandle::new();
@@ -1006,20 +1176,28 @@ mod tests {
     /// `forward()` call for the next entry) — exactly the scenario the
     /// module docs' "Queue-wedge invariant" section describes.
     ///
-    /// Red-check A: remove the `status() == Dismissed` branch from
-    /// `MessengerCore::remove_current` (always call `set_value(0.0)`) — this
-    /// test fails: the reentrant call's `set_value(0.0)` is a genuine no-op
-    /// (status unchanged, so no edge fires and nothing advances past
-    /// `Dismissed`) — the assertion on `entry_controller.status()` below
-    /// reads `Dismissed` instead of `Forward`.
+    /// This test does NOT, by itself, catch removing `remove_current`'s
+    /// `status() == Dismissed` fallback branch (confirmed by actually
+    /// running that mutation): with the fallback gone, the reentrant call's
+    /// unconditional `set_value(0.0)` on "b" is a genuine no-op (value and
+    /// status already at rest) — the SAME observable no-op the fallback
+    /// branch's own `pop_and_advance` call would also produce here, since
+    /// `advancing` guards it right back out. Either version leaves the
+    /// reentrant call inert and the OUTER `pop_and_advance` (already
+    /// in-flight) to `forward()` to "b" on its own — so this test cannot
+    /// distinguish the two.
+    /// `remove_current_direct_pops_when_the_controller_is_already_dismissed`
+    /// is the one that actually exercises the fallback branch (a COLD call
+    /// against an already-`Dismissed` controller, no `advancing` reentrancy
+    /// involved) — see that test's own red-check.
     ///
-    /// Red-check B: remove `MessengerCore::advancing`'s guard in
-    /// `pop_and_advance` — this test fails differently: the reentrant call's
-    /// direct-pop path now ALSO pops "b" (queue empties before the OUTER
+    /// Red-check: remove `MessengerCore::advancing`'s guard in
+    /// `pop_and_advance` — this test fails: the reentrant call's direct-pop
+    /// path now ALSO pops "b" (queue empties before the OUTER
     /// `pop_and_advance` resumes), so the outer call's own `has_next` check
     /// finds nothing to `forward()` — "b" is silently dropped without ever
-    /// entering, and `entry_controller.status()` again reads `Dismissed`
-    /// instead of `Forward`.
+    /// entering, and `entry_controller.status()` reads `Dismissed` instead
+    /// of `Forward`.
     #[test]
     fn remove_current_reentrantly_from_on_closed_still_drains_the_queue() {
         let handle = ScaffoldMessengerHandle::new();
@@ -1042,7 +1220,7 @@ mod tests {
             .on_closed(move |reason| order_b.borrow_mut().push(("b", reason)));
 
         handle.shared.entry_controller.set_value(1.0); // settle "a"'s entrance
-        handle.shared.reconcile();
+        handle.shared.reconcile(ReconcileOrigin::Direct);
 
         handle.remove_current_snack_bar(); // triggers the reentrant chain above
 
@@ -1068,7 +1246,7 @@ mod tests {
         // entered — the once-only guard means its eventual close still
         // reports Remove, not whatever later closes it.
         handle.shared.entry_controller.set_value(1.0);
-        handle.shared.reconcile();
+        handle.shared.reconcile(ReconcileOrigin::Direct);
         handle.remove_current_snack_bar();
         assert_eq!(
             order.borrow().as_slice(),
@@ -1095,7 +1273,7 @@ mod tests {
             .on_closed(move |_| *queued_closed_for_cb.borrow_mut() = true);
 
         handle.shared.entry_controller.set_value(1.0); // "current" fully shown
-        handle.shared.reconcile();
+        handle.shared.reconcile(ReconcileOrigin::Direct);
 
         handle.clear_snack_bars();
 
@@ -1118,7 +1296,7 @@ mod tests {
         );
 
         handle.shared.entry_controller.set_value(0.0); // settle the reverse
-        handle.shared.reconcile();
+        handle.shared.reconcile(ReconcileOrigin::Direct);
         assert_eq!(*current_closed.borrow(), Some(SnackBarClosedReason::Hide));
     }
 
@@ -1150,8 +1328,11 @@ mod tests {
             .on_closed(move |r| *reason_for_cb.borrow_mut() = Some(r));
 
         handle.shared.entry_controller.set_value(1.0); // fully shown, display timer starts
-        handle.shared.reconcile();
-        assert_eq!(handle.shared.state.get(), DrainState::Displayed);
+        handle.shared.reconcile(ReconcileOrigin::Direct);
+        assert!(
+            handle.shared.duration_controller.borrow().is_some(),
+            "the display timer must have started once the entrance settled at Completed"
+        );
 
         // The display timer expires first: reconcile observes its Completed
         // edge, records Timeout, and starts the exit reverse.
@@ -1162,7 +1343,7 @@ mod tests {
             .as_ref()
             .expect("Displayed state must have started the display timer")
             .set_value(1.0);
-        handle.shared.reconcile();
+        handle.shared.reconcile(ReconcileOrigin::Direct);
         assert_eq!(
             handle.shared.entry_controller.status(),
             AnimationStatus::Reverse
@@ -1173,7 +1354,7 @@ mod tests {
         handle.hide_current_snack_bar();
 
         handle.shared.entry_controller.set_value(0.0); // settle the reverse
-        handle.shared.reconcile();
+        handle.shared.reconcile(ReconcileOrigin::Direct);
 
         assert_eq!(*reason.borrow(), Some(SnackBarClosedReason::Timeout));
     }

--- a/crates/flui-material/src/scaffold_messenger.rs
+++ b/crates/flui-material/src/scaffold_messenger.rs
@@ -1,0 +1,1180 @@
+//! [`ScaffoldMessenger`] — manages [`crate::SnackBar`] queuing/display for
+//! every registered [`crate::Scaffold`] descendant, plus [`SnackBarController`]
+//! (returned by [`ScaffoldMessengerHandle::show_snack_bar`]) and
+//! [`SnackBarClosedReason`].
+//!
+//! # Flutter parity
+//!
+//! `material/scaffold.dart`'s `ScaffoldMessenger`/`ScaffoldMessengerState`
+//! (oracle tag `3.44.0`), narrowed to the snack-bar half of that type (no
+//! `MaterialBanner` queue — a separate, undated feature). Every citation
+//! below is `scaffold.dart` unless noted.
+//!
+//! ## Named divergence: `AnimationController`-as-timer
+//!
+//! The oracle drives the per-snackbar display duration with a real
+//! `dart:async` `Timer` (`_snackBarTimer`, `:619`). FLUI has no
+//! frame-independent virtual-clock timer primitive yet (`flui-scheduler`
+//! only drives the frame loop) — see `docs/ROADMAP.md`. This substrate
+//! substitutes a second, per-snackbar [`AnimationController`] whose
+//! `duration` is the snackbar's own configured display duration
+//! ([`crate::SnackBar::duration`]): it is `forward()`-ed when the entrance
+//! animation completes, and its own `Completed` status stands in for the
+//! oracle's `Timer` callback. **Honest cost**: unlike a real timer, this
+//! keeps the frame loop scheduled for the full display duration (a `Vsync`
+//! registration ticks every frame, not just once at expiry) — accepted
+//! because it makes the duration trivially controllable under a virtual
+//! clock in tests, the same reason `crate::drawer`'s settle animation
+//! already rides this mechanism. An event-driven timer is a named follow-up
+//! once `flui-scheduler` grows one. The timer restarts fresh for each
+//! snackbar and is cancelled on hide/remove/clear
+//! (`MessengerCore::cancel_display_timer`).
+//!
+//! ## The drain state machine
+//!
+//! `DrainState` makes the oracle's implicit `_snackBarController` status
+//! machine explicit: `Idle` (nothing showing) → `Entering` (250ms forward) →
+//! `Displayed` (entrance complete, display timer running) → `Exiting` (250ms
+//! reverse) → back to `Idle`, which immediately re-enters if the queue is
+//! still non-empty (`MessengerCore::pop_and_advance`).
+//!
+//! ## Why status edges are polled, not pushed, from the controller
+//!
+//! `AnimationController::add_status_listener` requires its callback to be
+//! `Send + Sync` (`StatusCallback = Arc<dyn Fn(AnimationStatus) + Send +
+//! Sync>`) because the controller itself is a general-purpose, thread-safe
+//! primitive. `MessengerCore` is deliberately **not** `Send`/`Sync` — it is
+//! `Rc`-based, owner-affine, the same reasoning
+//! `crate::drawer::DrawerHandle`'s module doc gives (and its queue's
+//! `on_closed` slots are plain `Box<dyn FnOnce(..)>`, not `+ Send`, matching
+//! every other UI callback in this crate). So the controllers' own listeners
+//! (installed in `ScaffoldMessengerHandle::attach`/
+//! `MessengerCore::start_display_timer`) do the ONE thing a `Send + Sync`
+//! closure can safely do without capturing `Rc` state: reschedule
+//! [`ScaffoldMessenger`]'s own rebuild via a plain `RebuildHandle` (itself
+//! `Send + Sync`).
+//!
+//! The actual state-machine translation — "did a controller's status change
+//! since we last looked, and if so what does that mean for the queue" —
+//! lives in `MessengerCore::reconcile`, called from two places: **directly,
+//! synchronously**, at the end of every queue-mutating method
+//! (`show_snack_bar`/`hide_current`/`remove_current`/`clear`) so an explicit
+//! call observes its own effect immediately (no frame boundary needed — the
+//! "remove twice rapidly" test below asserts on this), and from
+//! [`ScaffoldMessengerState::build`] (scheduled by the Send-safe listeners)
+//! for the natural case where a controller settles purely from ticking, with
+//! no explicit API call in between. `reconcile` loops until a full pass
+//! detects no further change, so it correctly drains a multi-step cascade
+//! (e.g. `Dismissed` → pop → `forward()` → `Forward`) within one call.
+//! `reconcile` never holds the `queue` `RefCell` borrowed across a call back
+//! into the controller or into caller-supplied code
+//! (`SnackBarController::on_closed`) — this crate has shipped five separate
+//! `RefCell`/lock-held-over-closure incidents, and `forward()`/`reverse()`/
+//! `set_value()` change status *synchronously*, so an `on_closed` callback
+//! that itself calls back into `show_snack_bar`/`remove_current_snack_bar`
+//! reaches this same machine again, from the same call stack.
+//!
+//! **Queue-wedge invariant**: *the queue is non-empty ⇒ the entrance
+//! controller is not `Dismissed`, except transiently inside
+//! `MessengerCore::pop_and_advance` itself.* Maintaining this is what lets
+//! `MessengerCore::hide_current` simply early-return when the controller is
+//! already `Dismissed` (oracle parity — nothing to hide). But
+//! `MessengerCore::remove_current`/`MessengerCore::clear` have no such
+//! early return in the oracle (`removeCurrentSnackBar` only checks
+//! `_snackBars.isEmpty`) — calling `set_value(0.0)` on an ALREADY-`Dismissed`
+//! controller is a **no-op status change**: `set_value` only fires a status
+//! *transition* on an actual change, so an edge-only drain would silently
+//! wedge the queue forever the moment `remove`/`clear` is called while the
+//! controller is already settled at `Dismissed` (reachable via the exact
+//! re-entrancy this module warns about: an `on_closed` callback that itself
+//! calls `remove_current_snack_bar`). Both methods therefore check
+//! `status() == Dismissed` themselves and, when true, directly call
+//! `pop_and_advance` instead of routing through `set_value`.
+//! `MessengerCore::advancing` guards `pop_and_advance` itself against
+//! double-entry from that same re-entrant path.
+//!
+//! ## Multi-scaffold fan-out
+//!
+//! `show_snack_bar` shows the current entry on every registered
+//! [`crate::Scaffold`] simultaneously (oracle: `_updateScaffolds` iterates
+//! `_scaffolds`, `:231-238`) — [`crate::Scaffold`] itself reads
+//! `ScaffoldMessengerHandle::current_entry` (private) in its own `build`. **Named
+//! divergence**: the oracle additionally narrows this to the *root* scaffold
+//! of a nested set (`_isRoot`, `:242-245`, comparing
+//! `findAncestorStateOfType<ScaffoldState>`); this substrate has no
+//! ancestor-state lookup by concrete `ViewState` type, so nested-`Scaffold`
+//! double-show is not filtered — every registered scaffold shows the current
+//! snack bar, nested or not. Tracked, not silently dropped.
+//!
+//! ## `clearSnackBars`
+//!
+//! Drops every queued (not-yet-shown) entry's `on_closed` **silently** — no
+//! callback fires, matching the oracle dropping their `Completer`s
+//! unfulfilled (`:463-472`; a never-completed `Future` observably never
+//! resolves, the same as a callback that never runs). The current entry is
+//! then hidden via `MessengerCore::hide_current` with
+//! [`SnackBarClosedReason::Hide`] — `clearSnackBars` delegates to
+//! `hideCurrentSnackBar()`, whose reason parameter defaults to
+//! `SnackBarClosedReason.hide` (`:441`), *not* `.remove` as its name might
+//! suggest.
+//!
+//! ## Completion slot
+//!
+//! Each queued entry's [`SnackBarClosedReason`] is recorded exactly once
+//! (`QueuedEntry::set_reason_once`) at hide/remove/action time — a slot the
+//! drain pop reads but never invents or overwrites (falling back to
+//! [`SnackBarClosedReason::Remove`] only in the unreachable-in-practice case
+//! of a pop with no reason ever recorded).
+//!
+//! ## V1 scope
+//!
+//! Reachable in V1: [`SnackBarClosedReason::Timeout`],
+//! [`SnackBarClosedReason::Hide`], [`SnackBarClosedReason::Remove`],
+//! [`SnackBarClosedReason::Action`]. [`SnackBarClosedReason::Dismiss`] and
+//! [`SnackBarClosedReason::Swipe`] exist for oracle parity (a future
+//! close-icon / swipe-to-dismiss feature reaches them) but nothing in this
+//! crate produces them yet. `SnackBar.persist`/`ModalRoute`-pausing
+//! (`:614-616`) are deferred, named — the display timer always runs,
+//! regardless of whether the snack bar carries an action.
+
+use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, VecDeque};
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Duration;
+
+use flui_animation::{
+    Animation, AnimationController, AnimationStatus, Scheduler, Vsync, VsyncRegistration,
+};
+use flui_foundation::ElementId;
+use flui_view::prelude::*;
+use flui_view::{RebuildHandle, impl_inherited_view};
+use flui_widgets::animated::VsyncScope;
+
+use crate::snack_bar::SnackBar;
+
+/// The shared entrance/exit controller's duration — Flutter's
+/// `_snackBarTransitionDuration` (`snack_bar.dart`).
+const ENTRY_TRANSITION_DURATION: Duration = Duration::from_millis(250);
+
+/// Specifies how a [`SnackBar`] was closed.
+///
+/// Flutter parity: `SnackBarClosedReason` (`snack_bar.dart`). See the module
+/// docs' "V1 scope" section for which variants are reachable today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SnackBarClosedReason {
+    /// Closed after the user pressed the [`crate::snack_bar::SnackBarAction`].
+    Action,
+    /// Closed through an accessibility dismiss action. Unreachable in V1.
+    Dismiss,
+    /// Closed by a user swipe. Unreachable in V1 (no swipe-to-dismiss yet).
+    Swipe,
+    /// Closed by [`ScaffoldMessengerHandle::hide_current_snack_bar`] — also
+    /// what [`ScaffoldMessengerHandle::clear_snack_bars`] hides the
+    /// surviving current entry with.
+    Hide,
+    /// Closed by [`ScaffoldMessengerHandle::remove_current_snack_bar`] —
+    /// abrupt, no exit animation.
+    Remove,
+    /// Closed because its display-duration timer expired.
+    Timeout,
+}
+
+/// The shared, once-only completion-callback slot [`SnackBarController`] and
+/// [`QueuedEntry`] both hold a clone of — set by
+/// [`SnackBarController::on_closed`], taken (and invoked) exactly once by
+/// [`QueuedEntry::complete`].
+type ClosedCallbackSlot = Rc<RefCell<Option<Box<dyn FnOnce(SnackBarClosedReason)>>>>;
+
+/// Handle returned by [`ScaffoldMessengerHandle::show_snack_bar`] — lets the
+/// caller register a one-shot callback for when this particular entry
+/// closes.
+///
+/// Flutter parity: `ScaffoldFeatureController<SnackBar,
+/// SnackBarClosedReason>` narrowed to the one capability V1 exposes: the
+/// oracle's `Completer<SnackBarClosedReason>`/`Future` pair becomes a
+/// synchronous one-shot callback slot (this substrate has no async
+/// `Future`-in-the-view-tree plumbing to hang a `Future` on).
+#[derive(Clone)]
+pub struct SnackBarController {
+    on_closed: ClosedCallbackSlot,
+}
+
+impl SnackBarController {
+    /// Registers `callback`, run exactly once when this entry closes
+    /// (whatever the reason) — never for a queued entry silently dropped by
+    /// [`ScaffoldMessengerHandle::clear_snack_bars`] (see that method's
+    /// doc). A later call replaces an earlier, unfired callback.
+    pub fn on_closed(&self, callback: impl FnOnce(SnackBarClosedReason) + 'static) {
+        *self.on_closed.borrow_mut() = Some(Box::new(callback));
+    }
+}
+
+impl std::fmt::Debug for SnackBarController {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SnackBarController").finish_non_exhaustive()
+    }
+}
+
+/// One queued (or currently showing) snack bar plus its once-only completion
+/// slot. See the module docs' "Completion slot" section.
+struct QueuedEntry {
+    snack_bar: SnackBar,
+    reason: Cell<Option<SnackBarClosedReason>>,
+    on_closed: ClosedCallbackSlot,
+}
+
+impl QueuedEntry {
+    /// Records `reason` only if nothing has been recorded yet — the
+    /// once-only guard the module docs describe.
+    fn set_reason_once(&self, reason: SnackBarClosedReason) {
+        if self.reason.get().is_none() {
+            self.reason.set(Some(reason));
+        }
+    }
+
+    /// Fires `on_closed` with the recorded reason (falling back to
+    /// [`SnackBarClosedReason::Remove`] — see the module docs' "Completion
+    /// slot" section for why this fallback is not expected to be reachable).
+    fn complete(&self) {
+        let reason = self.reason.get().unwrap_or(SnackBarClosedReason::Remove);
+        if let Some(callback) = self.on_closed.borrow_mut().take() {
+            callback(reason);
+        }
+    }
+
+    /// Drops `on_closed` WITHOUT invoking it — `clear_snack_bars`' silent
+    /// drop of a still-queued entry (oracle parity: an abandoned
+    /// `Completer`).
+    fn complete_silently(&self) {
+        self.on_closed.borrow_mut().take();
+    }
+}
+
+/// The explicit drain state — see the module docs' "The drain state
+/// machine" section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DrainState {
+    /// Nothing showing, queue empty (or about to be re-entered).
+    Idle,
+    /// The shared controller is running forward.
+    Entering,
+    /// The shared controller is at `1.0`; the display timer is running.
+    Displayed,
+    /// The shared controller is running in reverse.
+    Exiting,
+}
+
+/// The messenger's interior-mutable state, `Rc`-shared between
+/// [`ScaffoldMessengerHandle`] clones. See the module docs' "Why status
+/// edges are polled, not pushed, from the controller" section for why this
+/// type never appears inside an `AnimationController`'s own listener list.
+struct MessengerCore {
+    entry_controller: AnimationController,
+    duration_controller: RefCell<Option<AnimationController>>,
+    vsync: RefCell<Option<Vsync>>,
+    entry_vsync_registration: RefCell<Option<VsyncRegistration>>,
+    duration_vsync_registration: RefCell<Option<VsyncRegistration>>,
+    /// [`ScaffoldMessenger`]'s own rebuild handle — cloned into both
+    /// controllers' Send-safe "reschedule" listeners, so a purely
+    /// tick-driven status settle (no explicit API call in between) still
+    /// reaches [`Self::reconcile`] via [`ScaffoldMessengerState::build`].
+    /// `None` until [`ScaffoldMessengerHandle::attach`] runs.
+    rebuild: RefCell<Option<RebuildHandle>>,
+    queue: RefCell<VecDeque<Rc<QueuedEntry>>>,
+    state: Cell<DrainState>,
+    last_entry_status: Cell<AnimationStatus>,
+    last_duration_status: Cell<AnimationStatus>,
+    /// Reentrancy guard for [`Self::pop_and_advance`] — see the module docs'
+    /// "The drain state machine" section.
+    advancing: Cell<bool>,
+    scaffolds: RefCell<HashMap<ElementId, RebuildHandle>>,
+}
+
+impl MessengerCore {
+    fn schedule_rebuild_on_scaffolds(&self) {
+        for rebuild in self.scaffolds.borrow().values() {
+            rebuild.schedule();
+        }
+    }
+
+    /// Polls both controllers against the last-observed status and
+    /// translates every change into a state transition/pop, looping until a
+    /// full pass detects no further change. See the module docs' "Why
+    /// status edges are polled, not pushed, from the controller" section.
+    fn reconcile(&self) {
+        loop {
+            let mut changed = false;
+
+            let entry_status = self.entry_controller.status();
+            if entry_status != self.last_entry_status.get() {
+                self.last_entry_status.set(entry_status);
+                self.handle_entry_status(entry_status);
+                changed = true;
+            }
+
+            let duration_status = self
+                .duration_controller
+                .borrow()
+                .as_ref()
+                .map(Animation::status);
+            match duration_status {
+                Some(status) if status != self.last_duration_status.get() => {
+                    self.last_duration_status.set(status);
+                    if status == AnimationStatus::Completed {
+                        self.hide_current(SnackBarClosedReason::Timeout);
+                    }
+                    changed = true;
+                }
+                None => self.last_duration_status.set(AnimationStatus::Dismissed),
+                Some(_) => {}
+            }
+
+            if !changed {
+                break;
+            }
+        }
+    }
+
+    /// Translates one entrance-controller status into a state
+    /// transition/pop.
+    fn handle_entry_status(&self, status: AnimationStatus) {
+        match status {
+            AnimationStatus::Dismissed => self.pop_and_advance(),
+            AnimationStatus::Completed => {
+                self.state.set(DrainState::Displayed);
+                self.start_display_timer();
+            }
+            AnimationStatus::Forward => self.state.set(DrainState::Entering),
+            AnimationStatus::Reverse => self.state.set(DrainState::Exiting),
+            // `AnimationStatus` is `#[non_exhaustive]`; every variant it has
+            // today is handled above.
+            _ => {}
+        }
+    }
+
+    /// Pops the just-exited front entry (if any), fires its `on_closed`,
+    /// then begins the next entry's entrance if the queue is still
+    /// non-empty. The single place that ever pops the queue.
+    fn pop_and_advance(&self) {
+        if self.advancing.get() {
+            // A re-entrant call from inside the `on_closed` callback this
+            // very function is about to invoke below — the outer call owns
+            // finishing the advance; see the module docs.
+            return;
+        }
+        self.advancing.set(true);
+
+        self.cancel_display_timer();
+        let popped = self.queue.borrow_mut().pop_front();
+        if let Some(entry) = popped {
+            entry.complete();
+        }
+
+        self.state.set(DrainState::Idle);
+        let has_next = !self.queue.borrow().is_empty();
+        if has_next {
+            self.state.set(DrainState::Entering);
+            let _ = self.entry_controller.forward();
+        }
+
+        self.advancing.set(false);
+        self.schedule_rebuild_on_scaffolds();
+    }
+
+    fn start_display_timer(&self) {
+        let Some(front) = self.queue.borrow().front().cloned() else {
+            return;
+        };
+        let controller = AnimationController::new(
+            front.snack_bar.configured_duration(),
+            Arc::new(Scheduler::new()),
+        );
+        if let Some(vsync) = self.vsync.borrow().as_ref() {
+            let registration = vsync.register(controller.clone());
+            *self.duration_vsync_registration.borrow_mut() = Some(registration);
+        }
+        if let Some(rebuild) = self.rebuild.borrow().clone() {
+            controller.add_status_listener(Arc::new(move |_status| {
+                rebuild.schedule();
+            }));
+        }
+        self.last_duration_status.set(AnimationStatus::Dismissed);
+        let _ = controller.forward();
+        *self.duration_controller.borrow_mut() = Some(controller);
+    }
+
+    fn cancel_display_timer(&self) {
+        if let Some(registration) = self.duration_vsync_registration.borrow_mut().take()
+            && let Some(vsync) = self.vsync.borrow().as_ref()
+        {
+            vsync.unregister(registration);
+        }
+        if let Some(controller) = self.duration_controller.borrow_mut().take() {
+            controller.dispose();
+        }
+        self.last_duration_status.set(AnimationStatus::Dismissed);
+    }
+
+    /// Flutter parity: `hideCurrentSnackBar` (`:441-459`), minus the
+    /// `accessibleNavigation` immediate-complete branch (not ported — no
+    /// `MediaQuery.accessibleNavigation` consumer exists yet in this
+    /// substrate; always takes the animated-reverse path).
+    fn hide_current(&self, reason: SnackBarClosedReason) {
+        if self.entry_controller.status() == AnimationStatus::Dismissed {
+            // Oracle: `if (_snackBars.isEmpty || controller.isDismissed)
+            // return;` — nothing showing to hide, including the empty-queue
+            // case (an empty queue always leaves the controller Dismissed
+            // under this module's invariant).
+            return;
+        }
+        let Some(front) = self.queue.borrow().front().cloned() else {
+            return;
+        };
+        front.set_reason_once(reason);
+        self.cancel_display_timer();
+        let _ = self.entry_controller.reverse();
+    }
+
+    /// Flutter parity: `removeCurrentSnackBar` (`:424-436`) — no
+    /// `isDismissed` early return in the oracle, which is exactly why this
+    /// needs the direct-pop fallback the module docs describe.
+    fn remove_current(&self, reason: SnackBarClosedReason) {
+        let Some(front) = self.queue.borrow().front().cloned() else {
+            return;
+        };
+        front.set_reason_once(reason);
+        self.cancel_display_timer();
+        if self.entry_controller.status() == AnimationStatus::Dismissed {
+            self.pop_and_advance();
+        } else {
+            self.entry_controller.set_value(0.0);
+        }
+    }
+
+    /// Flutter parity: `clearSnackBars` (`:463-472`) — see the module docs'
+    /// "`clearSnackBars`" section for the exact reason `hide_current` closes
+    /// the surviving current entry with.
+    fn clear(&self) {
+        if self.queue.borrow().is_empty()
+            || self.entry_controller.status() == AnimationStatus::Dismissed
+        {
+            return;
+        }
+        let dropped: Vec<Rc<QueuedEntry>> = {
+            let mut queue = self.queue.borrow_mut();
+            let current = queue
+                .pop_front()
+                .expect("BUG: emptiness checked immediately above");
+            let dropped = queue.drain(..).collect();
+            queue.push_back(current);
+            dropped
+        };
+        for entry in dropped {
+            entry.complete_silently();
+        }
+        self.hide_current(SnackBarClosedReason::Hide);
+    }
+}
+
+/// An owned, `Rc`-based (owner-affine, **not** `Send`/`Sync` — same reasoning
+/// [`crate::drawer::DrawerHandle`]'s module doc gives) capability to show,
+/// hide, remove, or clear [`SnackBar`]s across every registered
+/// [`crate::Scaffold`]. Published via [`ScaffoldMessengerScope`]
+/// (`ScaffoldMessengerScope::of`/`maybe_of`).
+#[derive(Clone)]
+pub struct ScaffoldMessengerHandle {
+    shared: Rc<MessengerCore>,
+}
+
+impl std::fmt::Debug for ScaffoldMessengerHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScaffoldMessengerHandle")
+            .finish_non_exhaustive()
+    }
+}
+
+impl ScaffoldMessengerHandle {
+    /// A handle with an empty queue and no `Vsync`/rebuild wiring yet —
+    /// [`Self::attach`] (`ViewState::init_state`, per ADR-0018 — a
+    /// frame-phase-only capability may not be acquired from `build`) does
+    /// that.
+    fn new() -> Self {
+        let entry_controller =
+            AnimationController::new(ENTRY_TRANSITION_DURATION, Arc::new(Scheduler::new()));
+        let shared = Rc::new(MessengerCore {
+            entry_controller,
+            duration_controller: RefCell::new(None),
+            vsync: RefCell::new(None),
+            entry_vsync_registration: RefCell::new(None),
+            duration_vsync_registration: RefCell::new(None),
+            rebuild: RefCell::new(None),
+            queue: RefCell::new(VecDeque::new()),
+            state: Cell::new(DrainState::Idle),
+            last_entry_status: Cell::new(AnimationStatus::Dismissed),
+            last_duration_status: Cell::new(AnimationStatus::Dismissed),
+            advancing: Cell::new(false),
+            scaffolds: RefCell::new(HashMap::new()),
+        });
+        Self { shared }
+    }
+
+    /// Wires the ambient `Vsync` and installs the entrance controller's
+    /// Send-safe "reschedule [`ScaffoldMessenger`]'s rebuild" listener — see
+    /// [`Self::new`]'s doc for why this is deferred out of construction.
+    pub(crate) fn attach(&self, ctx: &dyn BuildContext) {
+        let rebuild = ctx.rebuild_handle();
+        let rebuild_for_listener = rebuild.clone();
+        self.shared
+            .entry_controller
+            .add_status_listener(Arc::new(move |_status| {
+                rebuild_for_listener.schedule();
+            }));
+        *self.shared.rebuild.borrow_mut() = Some(rebuild);
+
+        let vsync = ctx.get::<VsyncScope, _>(|scope| scope.vsync().clone());
+        if let Some(vsync) = &vsync {
+            let registration = vsync.register(self.shared.entry_controller.clone());
+            *self.shared.entry_vsync_registration.borrow_mut() = Some(registration);
+        }
+        *self.shared.vsync.borrow_mut() = vsync;
+    }
+
+    /// Unregisters from `Vsync` and disposes both controllers.
+    pub(crate) fn detach(&self) {
+        self.shared.cancel_display_timer();
+        if let Some(registration) = self.shared.entry_vsync_registration.borrow_mut().take()
+            && let Some(vsync) = self.shared.vsync.borrow_mut().take()
+        {
+            vsync.unregister(registration);
+        }
+        self.shared.entry_controller.dispose();
+    }
+
+    /// Re-runs the state-machine reconciliation — called from
+    /// [`ScaffoldMessengerState::build`] whenever the Send-safe listeners
+    /// scheduled a rebuild.
+    pub(crate) fn reconcile(&self) {
+        self.shared.reconcile();
+    }
+
+    /// Registers a [`crate::Scaffold`] so it receives `schedule_rebuild`
+    /// calls whenever the current entry's identity changes. Idempotent —
+    /// keyed by [`ElementId`], a later call with the same id simply replaces
+    /// the stored [`RebuildHandle`]. If a snack bar is already
+    /// showing/queued, schedules an immediate rebuild so the newly
+    /// registered scaffold picks it up (Flutter parity: `_register`,
+    /// `:211-223`).
+    pub(crate) fn register_scaffold(&self, element_id: ElementId, rebuild: RebuildHandle) {
+        if !self.shared.queue.borrow().is_empty() {
+            rebuild.schedule();
+        }
+        self.shared
+            .scaffolds
+            .borrow_mut()
+            .insert(element_id, rebuild);
+    }
+
+    /// Unregisters a [`crate::Scaffold`] — called from its `dispose`.
+    pub(crate) fn unregister_scaffold(&self, element_id: ElementId) {
+        self.shared.scaffolds.borrow_mut().remove(&element_id);
+    }
+
+    /// The number of currently-registered [`crate::Scaffold`]s — mainly a
+    /// test seam proving `Self::unregister_scaffold` actually ran (an
+    /// unmounted element's stale `RebuildHandle` would silently no-op
+    /// forever either way, per that type's own doc, so a mere
+    /// absence-of-panic assertion cannot distinguish "unregistered" from
+    /// "leaked").
+    #[must_use]
+    pub fn registered_scaffold_count(&self) -> usize {
+        self.shared.scaffolds.borrow().len()
+    }
+
+    /// Whether `self` and `other` name the same underlying messenger — the
+    /// `Rc::ptr_eq` identity check [`crate::Scaffold`]'s
+    /// `did_change_dependencies` uses to decide whether to re-home its
+    /// registration.
+    #[must_use]
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.shared, &other.shared)
+    }
+
+    /// The entry every registered [`crate::Scaffold`] should currently
+    /// display, if any: the config plus a clone of the shared entrance/exit
+    /// controller driving its height animation.
+    #[must_use]
+    pub(crate) fn current_entry(&self) -> Option<(SnackBar, AnimationController)> {
+        self.shared.queue.borrow().front().map(|entry| {
+            (
+                entry.snack_bar.clone(),
+                self.shared.entry_controller.clone(),
+            )
+        })
+    }
+
+    /// Shows `snack_bar` across every registered [`crate::Scaffold`]. If one
+    /// is already showing, `snack_bar` queues behind it (FIFO) and is shown
+    /// once every earlier entry has closed.
+    ///
+    /// Flutter parity: `showSnackBar` (`:314-384`), narrowed to the one
+    /// snack bar per call this substrate exposes (no `snackBarAnimationStyle`
+    /// override — the transition duration is fixed at
+    /// `ENTRY_TRANSITION_DURATION`).
+    pub fn show_snack_bar(&self, snack_bar: SnackBar) -> SnackBarController {
+        let on_closed = Rc::new(RefCell::new(None));
+        let entry = Rc::new(QueuedEntry {
+            snack_bar,
+            reason: Cell::new(None),
+            on_closed: Rc::clone(&on_closed),
+        });
+
+        let should_enter = {
+            let mut queue = self.shared.queue.borrow_mut();
+            queue.push_back(entry);
+            queue.len() == 1
+        };
+        if should_enter {
+            self.shared.state.set(DrainState::Entering);
+            let _ = self.shared.entry_controller.forward();
+            self.shared.schedule_rebuild_on_scaffolds();
+        }
+        self.shared.reconcile();
+
+        SnackBarController { on_closed }
+    }
+
+    /// Removes the current snack bar (if any) by running its normal exit
+    /// animation, with [`SnackBarClosedReason::Hide`]. A no-op if nothing is
+    /// currently showing.
+    pub fn hide_current_snack_bar(&self) {
+        self.shared.hide_current(SnackBarClosedReason::Hide);
+        self.shared.reconcile();
+    }
+
+    /// Reason-carrying counterpart of [`Self::hide_current_snack_bar`], for
+    /// callers inside this crate that close with a specific reason (e.g.
+    /// [`crate::snack_bar::SnackBarAction`]'s single-fire press).
+    pub(crate) fn hide_current_snack_bar_because(&self, reason: SnackBarClosedReason) {
+        self.shared.hide_current(reason);
+        self.shared.reconcile();
+    }
+
+    /// Removes the current snack bar (if any) immediately, with no exit
+    /// animation, with [`SnackBarClosedReason::Remove`]. If any snack bars
+    /// are queued, the next begins its entrance immediately.
+    pub fn remove_current_snack_bar(&self) {
+        self.shared.remove_current(SnackBarClosedReason::Remove);
+        self.shared.reconcile();
+    }
+
+    /// Drops every queued (not-yet-shown) snack bar silently (their
+    /// `on_closed` never fires) and hides the current one with its normal
+    /// exit animation. See the module docs' "`clearSnackBars`" section.
+    pub fn clear_snack_bars(&self) {
+        self.shared.clear();
+        self.shared.reconcile();
+    }
+}
+
+/// Publishes a [`ScaffoldMessengerHandle`] to its subtree.
+///
+/// Flutter parity: `_ScaffoldMessengerScope` (`scaffold.dart`).
+#[derive(Clone)]
+pub struct ScaffoldMessengerScope {
+    handle: ScaffoldMessengerHandle,
+    child: BoxedView,
+}
+
+impl std::fmt::Debug for ScaffoldMessengerScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScaffoldMessengerScope")
+            .finish_non_exhaustive()
+    }
+}
+
+impl ScaffoldMessengerScope {
+    /// The nearest ancestor [`ScaffoldMessenger`]'s handle.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there is no [`ScaffoldMessenger`] ancestor. Use
+    /// [`maybe_of`](Self::maybe_of) for a non-panicking variant.
+    #[must_use]
+    pub fn of(ctx: &dyn BuildContext) -> ScaffoldMessengerHandle {
+        Self::maybe_of(ctx).expect(
+            "ScaffoldMessengerScope::of called with no ScaffoldMessenger ancestor in the tree — \
+             wrap the subtree in a ScaffoldMessenger, or use ScaffoldMessengerScope::maybe_of \
+             with a caller-chosen fallback",
+        )
+    }
+
+    /// Looks up the nearest ancestor [`ScaffoldMessenger`]'s handle, or
+    /// `None` if there is none.
+    ///
+    /// No dependency is registered — same reasoning `crate::ScaffoldScope::maybe_of`'s
+    /// doc gives for `DrawerHandle`: the handle is a stable capability
+    /// object, not a value whose identity changing should trigger a rebuild.
+    #[must_use]
+    pub fn maybe_of(ctx: &dyn BuildContext) -> Option<ScaffoldMessengerHandle> {
+        ctx.get::<Self, _>(|scope| scope.handle.clone())
+    }
+}
+
+impl InheritedView for ScaffoldMessengerScope {
+    type Data = ScaffoldMessengerHandle;
+
+    fn data(&self) -> &Self::Data {
+        &self.handle
+    }
+
+    fn child(&self) -> &dyn View {
+        &self.child
+    }
+
+    fn update_should_notify(&self, _old: &Self) -> bool {
+        // The handle is the same stable object across every rebuild — see
+        // `Self::maybe_of`'s doc.
+        false
+    }
+}
+
+impl_inherited_view!(ScaffoldMessengerScope);
+
+/// Manages [`SnackBar`] queuing/display for every registered
+/// [`crate::Scaffold`] descendant. Mount once, above every [`crate::Scaffold`]
+/// that should share a queue.
+///
+/// Flutter parity: `ScaffoldMessenger` (`scaffold.dart`, oracle tag `3.44.0`).
+///
+/// # Examples
+///
+/// ```rust
+/// use flui_material::{Scaffold, ScaffoldMessenger};
+/// use flui_widgets::Text;
+///
+/// let _app = ScaffoldMessenger::new(Scaffold::new().body(Text::new("Hello")));
+/// ```
+#[derive(Clone, StatefulView)]
+pub struct ScaffoldMessenger {
+    child: BoxedView,
+}
+
+impl ScaffoldMessenger {
+    /// Wraps `child`, publishing a fresh [`ScaffoldMessengerHandle`] to its
+    /// subtree.
+    #[must_use]
+    pub fn new(child: impl IntoView) -> Self {
+        Self {
+            child: child.into_view().boxed(),
+        }
+    }
+}
+
+impl std::fmt::Debug for ScaffoldMessenger {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScaffoldMessenger").finish_non_exhaustive()
+    }
+}
+
+/// Persistent state behind [`ScaffoldMessenger`] — owns the
+/// [`ScaffoldMessengerHandle`] for the widget's whole life.
+pub struct ScaffoldMessengerState {
+    handle: ScaffoldMessengerHandle,
+}
+
+impl std::fmt::Debug for ScaffoldMessengerState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScaffoldMessengerState")
+            .finish_non_exhaustive()
+    }
+}
+
+impl StatefulView for ScaffoldMessenger {
+    type State = ScaffoldMessengerState;
+
+    fn create_state(&self) -> Self::State {
+        ScaffoldMessengerState {
+            handle: ScaffoldMessengerHandle::new(),
+        }
+    }
+}
+
+impl ViewState<ScaffoldMessenger> for ScaffoldMessengerState {
+    fn init_state(&mut self, ctx: &dyn BuildContext) {
+        self.handle.attach(ctx);
+    }
+
+    fn build(&self, view: &ScaffoldMessenger, _ctx: &dyn BuildContext) -> impl IntoView {
+        // Absorbs any tick-driven status settle the Send-safe listeners
+        // scheduled this rebuild for — see the module docs' "Why status
+        // edges are polled, not pushed, from the controller" section.
+        self.handle.reconcile();
+        ScaffoldMessengerScope {
+            handle: self.handle.clone(),
+            child: view.child.clone(),
+        }
+    }
+
+    fn dispose(&mut self) {
+        self.handle.detach();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use flui_widgets::Text;
+
+    use super::*;
+
+    fn snack_bar(label: &str) -> SnackBar {
+        SnackBar::new(Text::new(label.to_string()))
+    }
+
+    #[test]
+    fn show_snack_bar_on_an_empty_queue_starts_entering() {
+        let handle = ScaffoldMessengerHandle::new();
+        handle.show_snack_bar(snack_bar("a"));
+        assert_eq!(handle.shared.state.get(), DrainState::Entering);
+        assert_eq!(
+            handle.shared.entry_controller.status(),
+            AnimationStatus::Forward
+        );
+    }
+
+    #[test]
+    fn show_snack_bar_while_draining_queues_without_touching_the_controller() {
+        let handle = ScaffoldMessengerHandle::new();
+        handle.show_snack_bar(snack_bar("a"));
+        let value_before = handle.shared.entry_controller.value();
+        handle.show_snack_bar(snack_bar("b"));
+        assert_eq!(handle.shared.queue.borrow().len(), 2);
+        assert_eq!(handle.shared.entry_controller.value(), value_before);
+    }
+
+    #[test]
+    fn fifo_drain_shows_each_entry_once_in_order() {
+        let handle = ScaffoldMessengerHandle::new();
+        let order = Rc::new(RefCell::new(Vec::new()));
+
+        let order_a = Rc::clone(&order);
+        handle
+            .show_snack_bar(snack_bar("a"))
+            .on_closed(move |reason| order_a.borrow_mut().push(("a", reason)));
+        let order_b = Rc::clone(&order);
+        handle
+            .show_snack_bar(snack_bar("b"))
+            .on_closed(move |reason| order_b.borrow_mut().push(("b", reason)));
+
+        // "a" entering.
+        assert_eq!(
+            handle.shared.entry_controller.status(),
+            AnimationStatus::Forward
+        );
+        handle.shared.entry_controller.set_value(1.0); // settle "a"'s entrance -> Completed
+        handle.shared.reconcile();
+        assert_eq!(handle.shared.state.get(), DrainState::Displayed);
+
+        handle.remove_current_snack_bar(); // "a" removed abruptly -> "b" starts entering
+        assert_eq!(
+            order.borrow().as_slice(),
+            &[("a", SnackBarClosedReason::Remove)]
+        );
+        assert_eq!(
+            handle.shared.entry_controller.status(),
+            AnimationStatus::Forward
+        );
+
+        handle.remove_current_snack_bar(); // "b" removed abruptly -> queue empty
+        assert_eq!(
+            order.borrow().as_slice(),
+            &[
+                ("a", SnackBarClosedReason::Remove),
+                ("b", SnackBarClosedReason::Remove)
+            ]
+        );
+        assert_eq!(
+            handle.shared.entry_controller.status(),
+            AnimationStatus::Dismissed
+        );
+        assert!(handle.shared.queue.borrow().is_empty());
+    }
+
+    #[test]
+    fn hide_current_snack_bar_reverses_instead_of_jumping() {
+        let handle = ScaffoldMessengerHandle::new();
+        handle.show_snack_bar(snack_bar("a"));
+        handle.shared.entry_controller.set_value(1.0);
+        handle.shared.reconcile();
+
+        handle.hide_current_snack_bar();
+
+        assert_eq!(
+            handle.shared.entry_controller.status(),
+            AnimationStatus::Reverse
+        );
+        assert_eq!(handle.shared.state.get(), DrainState::Exiting);
+        // Still queued — the entry pops only once the reverse animation
+        // actually settles at Dismissed.
+        assert_eq!(handle.shared.queue.borrow().len(), 1);
+    }
+
+    #[test]
+    fn hide_current_snack_bar_on_an_empty_queue_is_a_no_op() {
+        let handle = ScaffoldMessengerHandle::new();
+        handle.hide_current_snack_bar(); // must not panic
+        assert_eq!(
+            handle.shared.entry_controller.status(),
+            AnimationStatus::Dismissed
+        );
+    }
+
+    /// Remove the current entry, then remove again immediately (before any
+    /// tick) — the second call's target must observably differ from the
+    /// first, and neither entry may go unclosed. This does NOT by itself
+    /// exercise `MessengerCore::remove_current`'s already-`Dismissed`
+    /// fallback branch (each `remove_current_snack_bar` call's own trailing
+    /// `reconcile()` already fully drains and re-advances the controller
+    /// before the next call begins, so it never observes an already-settled
+    /// controller here) — see
+    /// `remove_current_reentrantly_from_on_closed_still_drains_the_queue`
+    /// for a test that reaches that branch through genuine re-entrancy, and
+    /// `remove_current_direct_pops_when_the_controller_is_already_dismissed`
+    /// for the direct (non-reentrant) red-check on that branch.
+    #[test]
+    fn remove_twice_rapidly_drains_both_entries() {
+        let handle = ScaffoldMessengerHandle::new();
+        let closed = Rc::new(RefCell::new(0));
+
+        let closed_a = Rc::clone(&closed);
+        handle
+            .show_snack_bar(snack_bar("a"))
+            .on_closed(move |_| *closed_a.borrow_mut() += 1);
+        let closed_b = Rc::clone(&closed);
+        handle
+            .show_snack_bar(snack_bar("b"))
+            .on_closed(move |_| *closed_b.borrow_mut() += 1);
+
+        handle.remove_current_snack_bar();
+        handle.remove_current_snack_bar();
+
+        assert_eq!(*closed.borrow(), 2, "both queued entries must have closed");
+        assert!(
+            handle.shared.queue.borrow().is_empty(),
+            "the queue must not wedge"
+        );
+        assert_eq!(
+            handle.shared.entry_controller.status(),
+            AnimationStatus::Dismissed
+        );
+    }
+
+    /// The wedge pin, direct: call `remove_current` while the controller is
+    /// ALREADY `Dismissed` with a non-empty queue (reproducing, without real
+    /// re-entrancy, the state the module docs describe) and confirm the
+    /// queue still drains rather than sitting forever with a
+    /// recorded-but-unfired reason.
+    #[test]
+    fn remove_current_direct_pops_when_the_controller_is_already_dismissed() {
+        let handle = ScaffoldMessengerHandle::new();
+        handle
+            .shared
+            .queue
+            .borrow_mut()
+            .push_back(Rc::new(QueuedEntry {
+                snack_bar: snack_bar("a"),
+                reason: Cell::new(None),
+                on_closed: Rc::new(RefCell::new(None)),
+            }));
+        assert_eq!(
+            handle.shared.entry_controller.status(),
+            AnimationStatus::Dismissed
+        );
+
+        handle.remove_current_snack_bar();
+
+        assert!(handle.shared.queue.borrow().is_empty());
+    }
+
+    /// The queue-wedge pin, via genuine re-entrancy: an `on_closed` callback
+    /// that itself calls `remove_current_snack_bar` reaches
+    /// `MessengerCore::remove_current` while `entry_controller` is ALREADY
+    /// `Dismissed` (the outer `pop_and_advance` hasn't yet reached its own
+    /// `forward()` call for the next entry) — exactly the scenario the
+    /// module docs' "Queue-wedge invariant" section describes.
+    ///
+    /// Red-check A: remove the `status() == Dismissed` branch from
+    /// `MessengerCore::remove_current` (always call `set_value(0.0)`) — this
+    /// test fails: the reentrant call's `set_value(0.0)` is a genuine no-op
+    /// (status unchanged, so no edge fires and nothing advances past
+    /// `Dismissed`) — the assertion on `entry_controller.status()` below
+    /// reads `Dismissed` instead of `Forward`.
+    ///
+    /// Red-check B: remove `MessengerCore::advancing`'s guard in
+    /// `pop_and_advance` — this test fails differently: the reentrant call's
+    /// direct-pop path now ALSO pops "b" (queue empties before the OUTER
+    /// `pop_and_advance` resumes), so the outer call's own `has_next` check
+    /// finds nothing to `forward()` — "b" is silently dropped without ever
+    /// entering, and `entry_controller.status()` again reads `Dismissed`
+    /// instead of `Forward`.
+    #[test]
+    fn remove_current_reentrantly_from_on_closed_still_drains_the_queue() {
+        let handle = ScaffoldMessengerHandle::new();
+        let order = Rc::new(RefCell::new(Vec::new()));
+
+        let order_a = Rc::clone(&order);
+        let handle_for_reentrant_call = handle.clone();
+        handle
+            .show_snack_bar(snack_bar("a"))
+            .on_closed(move |reason| {
+                order_a.borrow_mut().push(("a", reason));
+                // Reentrant: fires while `entry_controller` is still
+                // `Dismissed` from THIS SAME `set_value` call, before the
+                // outer `pop_and_advance` has forwarded to "b".
+                handle_for_reentrant_call.remove_current_snack_bar();
+            });
+        let order_b = Rc::clone(&order);
+        handle
+            .show_snack_bar(snack_bar("b"))
+            .on_closed(move |reason| order_b.borrow_mut().push(("b", reason)));
+
+        handle.shared.entry_controller.set_value(1.0); // settle "a"'s entrance
+        handle.shared.reconcile();
+
+        handle.remove_current_snack_bar(); // triggers the reentrant chain above
+
+        assert_eq!(
+            order.borrow().as_slice(),
+            &[("a", SnackBarClosedReason::Remove)],
+            "\"a\" must close exactly once; \"b\" must NOT have closed yet — it was re-tagged \
+             Remove while still queued, not popped"
+        );
+        assert_eq!(
+            handle.shared.queue.borrow().len(),
+            1,
+            "\"b\" must still be queued, not dropped"
+        );
+        assert_eq!(
+            handle.shared.entry_controller.status(),
+            AnimationStatus::Forward,
+            "\"b\" must have started entering — the outer pop_and_advance's forward() call must \
+             not be skipped because of the reentrant call"
+        );
+
+        // "b" was pre-tagged Remove by the reentrant call before it ever
+        // entered — the once-only guard means its eventual close still
+        // reports Remove, not whatever later closes it.
+        handle.shared.entry_controller.set_value(1.0);
+        handle.shared.reconcile();
+        handle.remove_current_snack_bar();
+        assert_eq!(
+            order.borrow().as_slice(),
+            &[
+                ("a", SnackBarClosedReason::Remove),
+                ("b", SnackBarClosedReason::Remove)
+            ]
+        );
+    }
+
+    #[test]
+    fn clear_snack_bars_drops_queued_entries_silently_and_hides_the_current_one() {
+        let handle = ScaffoldMessengerHandle::new();
+        let current_closed = Rc::new(RefCell::new(None));
+        let queued_closed = Rc::new(RefCell::new(false));
+
+        let current_closed_for_cb = Rc::clone(&current_closed);
+        handle
+            .show_snack_bar(snack_bar("current"))
+            .on_closed(move |reason| *current_closed_for_cb.borrow_mut() = Some(reason));
+        let queued_closed_for_cb = Rc::clone(&queued_closed);
+        handle
+            .show_snack_bar(snack_bar("queued"))
+            .on_closed(move |_| *queued_closed_for_cb.borrow_mut() = true);
+
+        handle.shared.entry_controller.set_value(1.0); // "current" fully shown
+        handle.shared.reconcile();
+
+        handle.clear_snack_bars();
+
+        assert_eq!(
+            handle.shared.queue.borrow().len(),
+            1,
+            "only the current entry survives"
+        );
+        assert_eq!(
+            handle.shared.entry_controller.status(),
+            AnimationStatus::Reverse
+        );
+        assert!(
+            !*queued_closed.borrow(),
+            "a queued (never-shown) entry's on_closed must not fire"
+        );
+        assert!(
+            current_closed.borrow().is_none(),
+            "current entry closes when the reverse settles, not immediately"
+        );
+
+        handle.shared.entry_controller.set_value(0.0); // settle the reverse
+        handle.shared.reconcile();
+        assert_eq!(*current_closed.borrow(), Some(SnackBarClosedReason::Hide));
+    }
+
+    #[test]
+    fn clear_snack_bars_on_an_empty_queue_is_a_no_op() {
+        let handle = ScaffoldMessengerHandle::new();
+        handle.clear_snack_bars();
+        assert_eq!(
+            handle.shared.entry_controller.status(),
+            AnimationStatus::Dismissed
+        );
+    }
+
+    /// Racing timeout + hide: the display timer's `Completed` edge fires
+    /// first (recording `Timeout` and starting the exit reverse); a later
+    /// `hide_current_snack_bar()` call before that reverse settles must NOT
+    /// overwrite the already-recorded reason.
+    ///
+    /// Red-check: drop the once-only guard from `QueuedEntry::set_reason_once`
+    /// (always overwrite) — this test fails: the final reason reads `Hide`,
+    /// not `Timeout`.
+    #[test]
+    fn reason_is_recorded_once_under_racing_timeout_and_hide() {
+        let handle = ScaffoldMessengerHandle::new();
+        let reason = Rc::new(RefCell::new(None));
+        let reason_for_cb = Rc::clone(&reason);
+        handle
+            .show_snack_bar(snack_bar("a"))
+            .on_closed(move |r| *reason_for_cb.borrow_mut() = Some(r));
+
+        handle.shared.entry_controller.set_value(1.0); // fully shown, display timer starts
+        handle.shared.reconcile();
+        assert_eq!(handle.shared.state.get(), DrainState::Displayed);
+
+        // The display timer expires first: reconcile observes its Completed
+        // edge, records Timeout, and starts the exit reverse.
+        handle
+            .shared
+            .duration_controller
+            .borrow()
+            .as_ref()
+            .expect("Displayed state must have started the display timer")
+            .set_value(1.0);
+        handle.shared.reconcile();
+        assert_eq!(
+            handle.shared.entry_controller.status(),
+            AnimationStatus::Reverse
+        );
+
+        // A racing hide call before the reverse settles must not steal the
+        // already-recorded reason.
+        handle.hide_current_snack_bar();
+
+        handle.shared.entry_controller.set_value(0.0); // settle the reverse
+        handle.shared.reconcile();
+
+        assert_eq!(*reason.borrow(), Some(SnackBarClosedReason::Timeout));
+    }
+}

--- a/crates/flui-material/src/snack_bar.rs
+++ b/crates/flui-material/src/snack_bar.rs
@@ -1,0 +1,401 @@
+//! [`SnackBar`] — a lightweight message with an optional action, shown via
+//! [`crate::ScaffoldMessengerHandle::show_snack_bar`] — and
+//! [`SnackBarAction`], its single-fire action button.
+//!
+//! # Flutter parity
+//!
+//! `material/snack_bar.dart`'s `SnackBar`/`SnackBarAction`/`_SnackBarState`
+//! (oracle tag `3.44.0`), narrowed to `SnackBarBehavior.fixed` — see the
+//! module docs' "V1 scope" section. M3 token values are `_SnackbarDefaultsM3`
+//! (`snack_bar.dart:941-999`), cited per value below.
+//!
+//! ## Entrance animation
+//!
+//! Fixed behavior always takes the oracle's LAST transition branch
+//! (`_SnackBarState.build`, `:850-875`): `accessibleNavigation` is not ported
+//! (no `MediaQuery.accessibleNavigation` consumer exists yet), and
+//! `isFloatingSnackBar` is always `false` (fixed-only), so the
+//! `ValueListenableBuilder`-over-`_heightAnimation` branch is the only one
+//! this substrate ever takes — an `Align(alignment: topStart, heightFactor:
+//! value)` grown by [`Curves::FastOutSlowIn`] (`_snackBarHeightCurve`,
+//! `:30`), applied symmetrically on entrance and exit (the oracle sets no
+//! `reverseCurve` on `_heightAnimation`, `:576`). Wrapped in
+//! [`AnimatedBuilder`] rather than a `ValueListenableBuilder`+`CurvedAnimation`
+//! pair — this substrate applies the curve inline in the builder closure,
+//! which is equivalent and needs no extra `CurvedAnimation` object.
+//! **`FadeTransition` is never used**: the oracle's inner `Material`-wrapping
+//! fade (`_fadeOutAnimation`) is skipped whenever `accessibleNavigation ||
+//! useMaterial3` (`:809`) — this substrate is M3-only, so that condition is
+//! always true.
+//!
+//! ## V1 scope
+//!
+//! `SnackBarBehavior` is **not exposed** — fixed only, wrapped in
+//! `SafeArea(top: false)` unconditionally (oracle: `:790-792`), no
+//! `width`/`margin`/floating positioning, no action-overflow-to-a-second-row
+//! layout (`actionOverflowThreshold`, `:735-740` — the action always shares
+//! the content's row; a very long label may visually crowd the content,
+//! which the oracle avoids by wrapping — a named, cosmetic-only
+//! simplification). No close icon (`showCloseIcon` — pulls in
+//! `SnackBarClosedReason::Dismiss`, which this substrate has no other
+//! producer for yet either). No `Hero`/`Dismissible`/swipe-to-dismiss — see
+//! `crate::scaffold_messenger`'s module doc for the reachable
+//! [`crate::SnackBarClosedReason`] set. `SnackBarThemeData` — no such
+//! component-theme extension slot exists in [`crate::ThemeData`] yet (same
+//! deferral shape as `crate::drawer`'s `DrawerTheme` note); every value below
+//! is the hand-coded M3 default with no theme/instance override lens beyond
+//! [`SnackBar::background_color`]/[`SnackBar::elevation`].
+
+use std::cell::Cell;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Duration;
+
+use flui_animation::{Animation, AnimationController, Curve, Curves};
+use flui_foundation::Listenable;
+use flui_types::geometry::px;
+use flui_types::painting::Clip;
+use flui_types::{Alignment, Color, EdgeInsets};
+use flui_view::RebuildHandle;
+use flui_view::prelude::*;
+use flui_widgets::{
+    Align, AnimatedBuilder, DefaultTextStyle, Expanded, Padding, Row, SafeArea, WidgetStateProperty,
+};
+
+use crate::button_style::ButtonStyle;
+use crate::material::Material;
+use crate::scaffold_messenger::{ScaffoldMessengerScope, SnackBarClosedReason};
+use crate::text_button::TextButton;
+use crate::theme::Theme;
+use crate::theme_data::ThemeData;
+
+/// `_snackBarDisplayDuration` (`snack_bar.dart:29`) — the default
+/// [`SnackBar::duration`].
+const DEFAULT_DISPLAY_DURATION: Duration = Duration::from_secs(4);
+/// `_singleLineVerticalPadding` (`snack_bar.dart:27`).
+const SINGLE_LINE_VERTICAL_PADDING: f32 = 14.0;
+/// `_SnackbarDefaultsM3.elevation` (`snack_bar.dart:980`).
+const DEFAULT_ELEVATION: f32 = 6.0;
+/// Fixed behavior's content horizontal padding — `isFloatingSnackBar ? 16.0 :
+/// 24.0` (`snack_bar.dart:687`), always the `false` branch here.
+const HORIZONTAL_PADDING: f32 = 24.0;
+
+/// A lightweight message with an optional action, briefly shown near the
+/// bottom of the screen via
+/// [`crate::ScaffoldMessengerHandle::show_snack_bar`].
+///
+/// Flutter parity: `SnackBar` (`snack_bar.dart`, oracle tag `3.44.0`). See
+/// the module docs for the fixed-only V1 scope.
+///
+/// # Examples
+///
+/// ```rust
+/// use flui_material::SnackBar;
+/// use flui_widgets::Text;
+///
+/// let _snack_bar = SnackBar::new(Text::new("Saved")).duration(std::time::Duration::from_secs(2));
+/// ```
+#[derive(Clone)]
+pub struct SnackBar {
+    content: BoxedView,
+    action: Option<SnackBarAction>,
+    duration: Duration,
+    background_color: Option<Color>,
+    elevation: Option<f32>,
+}
+
+impl SnackBar {
+    /// A snack bar showing `content`, `DEFAULT_DISPLAY_DURATION` (4000ms),
+    /// no action, M3 default colors/elevation.
+    #[must_use]
+    pub fn new(content: impl IntoView) -> Self {
+        Self {
+            content: content.into_view().boxed(),
+            action: None,
+            duration: DEFAULT_DISPLAY_DURATION,
+            background_color: None,
+            elevation: None,
+        }
+    }
+
+    /// Sets the action button, shown at the row's end.
+    #[must_use]
+    pub fn action(mut self, action: SnackBarAction) -> Self {
+        self.action = Some(action);
+        self
+    }
+
+    /// Overrides how long the snack bar stays visible before auto-dismissing.
+    /// Defaults to `DEFAULT_DISPLAY_DURATION` (4000ms) — Flutter's
+    /// `snackBar.duration`.
+    #[must_use]
+    pub fn duration(mut self, duration: Duration) -> Self {
+        self.duration = duration;
+        self
+    }
+
+    /// Overrides the background color. Defaults to
+    /// `ColorScheme.inverseSurface`.
+    #[must_use]
+    pub fn background_color(mut self, color: Color) -> Self {
+        self.background_color = Some(color);
+        self
+    }
+
+    /// Overrides the elevation (must be non-negative). Defaults to
+    /// `DEFAULT_ELEVATION` (6.0).
+    #[must_use]
+    pub fn elevation(mut self, elevation: f32) -> Self {
+        debug_assert!(elevation >= 0.0, "SnackBar elevation must be non-negative");
+        self.elevation = Some(elevation);
+        self
+    }
+
+    /// The configured display duration — what
+    /// `crate::scaffold_messenger::MessengerCore::start_display_timer` drives
+    /// the per-snackbar timer controller with.
+    #[must_use]
+    pub(crate) fn configured_duration(&self) -> Duration {
+        self.duration
+    }
+}
+
+impl std::fmt::Debug for SnackBar {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SnackBar")
+            .field("has_action", &self.action.is_some())
+            .field("duration", &self.duration)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A button for a [`SnackBar`], known as an "action". Single-fire: a second
+/// press after the first is ignored, and the button visually disables
+/// (`disabledTextColor`) once pressed.
+///
+/// Flutter parity: `SnackBarAction`/`_SnackBarActionState` (`snack_bar.dart`,
+/// oracle tag `3.44.0`).
+///
+/// # Examples
+///
+/// ```rust
+/// use flui_material::SnackBarAction;
+///
+/// let _action = SnackBarAction::new("UNDO", || {});
+/// ```
+#[derive(Clone, StatefulView)]
+pub struct SnackBarAction {
+    label: String,
+    on_pressed: std::rc::Rc<dyn Fn()>,
+}
+
+impl SnackBarAction {
+    /// An action labeled `label`, calling `on_pressed` at most once when
+    /// pressed.
+    #[must_use]
+    pub fn new(label: impl Into<String>, on_pressed: impl Fn() + 'static) -> Self {
+        Self {
+            label: label.into(),
+            on_pressed: std::rc::Rc::new(on_pressed),
+        }
+    }
+}
+
+impl std::fmt::Debug for SnackBarAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SnackBarAction")
+            .field("label", &self.label)
+            .finish_non_exhaustive()
+    }
+}
+
+/// State for [`SnackBarAction`] — the `_haveTriggeredAction` single-fire
+/// latch. `triggered` is `Rc<Cell<bool>>`, not a plain `bool`: the press
+/// closure is `'static` (outlives the `&self` borrow `build` takes) and must
+/// flip the latch itself, matching the oracle's `setState(() {
+/// _haveTriggeredAction = true; })` inside `_handlePressed`.
+#[derive(Debug, Default)]
+pub struct SnackBarActionState {
+    triggered: Rc<Cell<bool>>,
+    /// Acquired in [`init_state`](ViewState::init_state), per ADR-0018
+    /// (trigger #22: a frame-phase-only capability may not be acquired from
+    /// `build`, even to hand straight to a press closure) — `None` only in
+    /// the window between `create_state` and the first `init_state`, never
+    /// observed by `build`.
+    rebuild: Option<RebuildHandle>,
+}
+
+impl StatefulView for SnackBarAction {
+    type State = SnackBarActionState;
+
+    fn create_state(&self) -> Self::State {
+        SnackBarActionState::default()
+    }
+}
+
+impl ViewState<SnackBarAction> for SnackBarActionState {
+    fn init_state(&mut self, ctx: &dyn BuildContext) {
+        self.rebuild = Some(ctx.rebuild_handle());
+    }
+
+    fn build(&self, view: &SnackBarAction, ctx: &dyn BuildContext) -> impl IntoView {
+        let theme = Theme::of(ctx);
+        let colors = theme.color_scheme;
+        // `_SnackbarDefaultsM3.actionTextColor`/`.disabledActionTextColor`
+        // (`snack_bar.dart:952-970`) both resolve to `inversePrimary` — the
+        // disabled state is distinguished visually by the button becoming
+        // unpressable, not by a different disabled color, matching the
+        // oracle's own (slightly surprising, but verbatim) token table.
+        let foreground_color = WidgetStateProperty::all(Some(colors.inverse_primary));
+        let style = ButtonStyle {
+            foreground_color: Some(foreground_color),
+            ..ButtonStyle::default()
+        };
+
+        let mut button = TextButton::new(flui_widgets::Text::new(view.label.clone())).style(style);
+        if !self.triggered.get() {
+            let messenger = ScaffoldMessengerScope::maybe_of(ctx);
+            let on_pressed = view.on_pressed.clone();
+            let triggered = Rc::clone(&self.triggered);
+            let rebuild = self
+                .rebuild
+                .clone()
+                .expect("BUG: init_state runs before the first build");
+            button = button.on_pressed(move || {
+                triggered.set(true);
+                on_pressed();
+                if let Some(messenger) = &messenger {
+                    messenger.hide_current_snack_bar_because(SnackBarClosedReason::Action);
+                }
+                rebuild.schedule();
+            });
+        }
+        button
+    }
+}
+
+/// Builds the static (non-animated) visual content of a [`SnackBar`]:
+/// `Material(color, elevation) > SafeArea(top: false) > Padding > Row[content,
+/// action?]`. Flutter parity: `_SnackBarState.build`'s content assembly
+/// (`snack_bar.dart:622-826`), narrowed to the fixed-behavior branches (see
+/// the module docs).
+fn build_content(snack_bar: &SnackBar, theme: &ThemeData) -> BoxedView {
+    let colors = theme.color_scheme;
+    let background_color = snack_bar.background_color.unwrap_or(colors.inverse_surface);
+    let elevation = snack_bar.elevation.unwrap_or(DEFAULT_ELEVATION);
+    let content_text_style = theme
+        .text_theme
+        .body_medium
+        .clone()
+        .unwrap_or_default()
+        .with_color(colors.on_inverse_surface);
+
+    let has_action = snack_bar.action.is_some();
+    let content_padding = EdgeInsets::new(
+        px(0.0),
+        if has_action {
+            px(0.0)
+        } else {
+            px(HORIZONTAL_PADDING)
+        },
+        px(0.0),
+        px(HORIZONTAL_PADDING),
+    );
+
+    let mut row_children: Vec<BoxedView> = vec![
+        Expanded::new(
+            Padding::new(EdgeInsets::symmetric(
+                px(SINGLE_LINE_VERTICAL_PADDING),
+                px(0.0),
+            ))
+            .child(DefaultTextStyle::new(
+                content_text_style,
+                snack_bar.content.clone(),
+            )),
+        )
+        .boxed(),
+    ];
+    if let Some(action) = &snack_bar.action {
+        row_children.push(
+            Padding::new(EdgeInsets::symmetric(px(0.0), px(HORIZONTAL_PADDING / 2.0)))
+                .child(action.clone())
+                .boxed(),
+        );
+    }
+
+    let padded = Padding::new(content_padding).child(Row::new(row_children));
+    let safe_area = SafeArea::new().top(false).child(padded);
+
+    Material::new(background_color)
+        .elevation(elevation)
+        .clip_behavior(Clip::HardEdge)
+        .child(safe_area)
+        .boxed()
+}
+
+/// The [`SnackBar`] presenter mounted at `crate::scaffold::SLOT_SNACK_BAR` —
+/// wraps [`build_content`] in the [`Curves::FastOutSlowIn`] `heightFactor`
+/// entrance/exit animation, re-rendering on every `animation` tick via
+/// [`AnimatedBuilder`]. See the module docs' "Entrance animation" section.
+#[derive(Clone, StatelessView)]
+pub(crate) struct SnackBarPresenter {
+    snack_bar: SnackBar,
+    animation: AnimationController,
+}
+
+impl SnackBarPresenter {
+    pub(crate) fn new(snack_bar: SnackBar, animation: AnimationController) -> Self {
+        Self {
+            snack_bar,
+            animation,
+        }
+    }
+}
+
+impl std::fmt::Debug for SnackBarPresenter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SnackBarPresenter").finish_non_exhaustive()
+    }
+}
+
+impl StatelessView for SnackBarPresenter {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        let theme = Theme::of(ctx);
+        let content = build_content(&self.snack_bar, &theme);
+        let animation = self.animation.clone();
+        let listenable = Arc::new(self.animation.clone()) as Arc<dyn Listenable>;
+
+        AnimatedBuilder::new(listenable, move || {
+            let height_factor = Curves::FastOutSlowIn.transform(animation.value().clamp(0.0, 1.0));
+            Align::new(Alignment::TOP_LEFT)
+                .height_factor(height_factor)
+                .child(content.clone())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_snack_bar_defaults_to_the_display_duration_and_no_action() {
+        let snack_bar = SnackBar::new(flui_widgets::Text::new("hi"));
+        assert_eq!(snack_bar.configured_duration(), DEFAULT_DISPLAY_DURATION);
+        assert!(snack_bar.action.is_none());
+    }
+
+    #[test]
+    fn duration_builder_overrides_the_default() {
+        let snack_bar =
+            SnackBar::new(flui_widgets::Text::new("hi")).duration(Duration::from_secs(2));
+        assert_eq!(snack_bar.configured_duration(), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn action_builder_attaches_the_action() {
+        let snack_bar =
+            SnackBar::new(flui_widgets::Text::new("hi")).action(SnackBarAction::new("UNDO", || {}));
+        assert!(snack_bar.action.is_some());
+    }
+}

--- a/crates/flui-material/src/snack_bar.rs
+++ b/crates/flui-material/src/snack_bar.rs
@@ -59,7 +59,8 @@ use flui_types::{Alignment, Color, EdgeInsets};
 use flui_view::RebuildHandle;
 use flui_view::prelude::*;
 use flui_widgets::{
-    Align, AnimatedBuilder, DefaultTextStyle, Expanded, Padding, Row, SafeArea, WidgetStateProperty,
+    Align, AnimatedBuilder, ClipRect, DefaultTextStyle, Expanded, Padding, Row, SafeArea,
+    WidgetStateProperty,
 };
 
 use crate::button_style::ButtonStyle;
@@ -365,12 +366,26 @@ impl StatelessView for SnackBarPresenter {
         let animation = self.animation.clone();
         let listenable = Arc::new(self.animation.clone()) as Arc<dyn Listenable>;
 
-        AnimatedBuilder::new(listenable, move || {
+        // Flutter parity: `_SnackBarState.build`'s outermost wrap is
+        // `ClipRect(clipBehavior: widget.clipBehavior, child: snackBarTransition)`
+        // (`snack_bar.dart:877-881`), around the exact `Align(heightFactor:)`
+        // transition this builds. `Align`/`RenderPositionedBox` lays its
+        // child out LOOSE at that child's full natural height regardless of
+        // `heightFactor` — only `Align`'s own REPORTED size shrinks — and
+        // paints the child unclipped at that full size in `Align`'s local
+        // coordinate space. Mid-entrance (a partially-grown `heightFactor`),
+        // that full-height paint bleeds past `Align`'s own (still-shrunk)
+        // box into whatever paints below it (an adjacent scaffold's own
+        // snack bar, in the multi-scaffold case) unless something clips to
+        // `Align`'s reported box. `ClipRect`'s own layout is a pass-through
+        // (it reports exactly its child's size), so wrapping it here clips
+        // paint to the CURRENT animated height every tick, not a stale one.
+        ClipRect::new().child(AnimatedBuilder::new(listenable, move || {
             let height_factor = Curves::FastOutSlowIn.transform(animation.value().clamp(0.0, 1.0));
             Align::new(Alignment::TOP_LEFT)
                 .height_factor(height_factor)
                 .child(content.clone())
-        })
+        }))
     }
 }
 

--- a/crates/flui-material/tests/snack_bar.rs
+++ b/crates/flui-material/tests/snack_bar.rs
@@ -128,6 +128,29 @@ fn scaffold_roots(laid: &common::LaidOut) -> Vec<RenderId> {
     laid.find_all_by_render_type("RenderCustomMultiChildLayoutBox")
 }
 
+/// The `RenderParagraph` node whose rendered text exactly matches `text` —
+/// mirrors `tests/material_demo.rs`'s own `find_text` helper (that file
+/// cannot share this one; see this crate's `tests/common/mod.rs` module
+/// doc on why the harness itself is duplicated, not shared, per test binary).
+fn find_text(laid: &common::LaidOut, text: &str) -> Option<RenderId> {
+    laid.find_all_by_render_type("RenderParagraph")
+        .into_iter()
+        .find(|&id| laid.render_property(id, "text").as_deref() == Some(text))
+}
+
+/// The snack bar's own `Material` (`RenderPhysicalShape` at elevation
+/// `6.0`) — see [`snack_bar_material_count`]'s doc for why elevation is the
+/// distinguishing property.
+fn find_snack_bar_material(laid: &common::LaidOut) -> Option<RenderId> {
+    laid.find_all_by_render_type("RenderPhysicalShape")
+        .into_iter()
+        .find(|&id| {
+            laid.render_property(id, "elevation")
+                .and_then(|value| value.parse::<f32>().ok())
+                == Some(6.0)
+        })
+}
+
 /// The number of mounted `Material` surfaces (`RenderPhysicalShape`) with
 /// elevation `6.0` — `crate::snack_bar`'s `DEFAULT_ELEVATION`, distinctive
 /// among this tree's other surfaces (`Scaffold`'s own root `Material`
@@ -279,15 +302,8 @@ fn action_press_closes_the_snack_bar_and_is_single_fire() {
     // `snack_bar_material_count` uses, so this test does not depend on
     // internal render-node identification beyond that one distinctive
     // property.
-    let snack_bar_material = laid
-        .find_all_by_render_type("RenderPhysicalShape")
-        .into_iter()
-        .find(|&id| {
-            laid.render_property(id, "elevation")
-                .and_then(|value| value.parse::<f32>().ok())
-                == Some(6.0)
-        })
-        .expect("the snack bar's Material must be mounted");
+    let snack_bar_material =
+        find_snack_bar_material(&laid).expect("the snack bar's Material must be mounted");
     let bar_offset = laid.absolute_offset(snack_bar_material);
     let bar_size = laid.size(snack_bar_material);
     let tap_x = bar_offset.dx.get() + bar_size.width.get() * 0.92;
@@ -565,5 +581,187 @@ fn a_scaffold_mounted_fresh_under_a_new_messenger_registers_with_that_one_not_a_
         second_handle.registered_scaffold_count(),
         1,
         "the freshly-mounted Scaffold must register with its OWN nearest messenger"
+    );
+}
+
+// ============================================================================
+// 9. A Scaffold that mounts while a snack bar is already showing renders it
+//    immediately.
+//
+// `register_scaffold`'s "queue non-empty -> schedule an immediate rebuild"
+// branch (Flutter parity: `_register`, `scaffold.dart:211-223`) is what this
+// test SETS OUT to isolate, but a mutation run against it (dropping the
+// branch entirely) still leaves this test green: a freshly-mounted
+// `Scaffold`'s `init_state` (which registers) always runs immediately
+// before that SAME element's own first `build()`, in the same synchronous
+// mount pass — so the first `build()` already reads `current_entry()`
+// fresh regardless of whether `register_scaffold` additionally scheduled a
+// rebuild. The branch is therefore genuinely unobservable via a fresh-mount
+// scenario in this substrate (confirmed by actually running that exact
+// mutation, not merely asserted). It is kept anyway: it mirrors the
+// oracle's own defensive `_register` (which similarly calls
+// `scaffold._updateSnackBar()` unconditionally, not gated on "is this the
+// very first build"), and would matter the moment `ScaffoldState`'s
+// re-home path (`did_change_dependencies`) becomes reachable without an
+// immediately-following rebuild of the same element. This test still earns
+// its place as a genuine behavior guarantee — "mount while showing renders
+// it" — even though it does not, by itself, prove WHICH code path delivers
+// that guarantee.
+// ============================================================================
+
+#[test]
+fn mounting_a_scaffold_while_a_snack_bar_is_already_showing_renders_it_immediately() {
+    let vsync = Vsync::new();
+    let handle_slot: Rc<RefCell<Option<ScaffoldMessengerHandle>>> = Rc::new(RefCell::new(None));
+    let tree = themed_animated(
+        &vsync,
+        ScaffoldMessenger::new(flui_widgets::Column::new(vec![
+            ViewExt::boxed(HandleProbe {
+                slot: Rc::clone(&handle_slot),
+            }),
+            ViewExt::boxed(flui_widgets::Expanded::new(
+                Scaffold::new().body(body_marker()),
+            )),
+        ])),
+    );
+    let mut laid = lay_out_animated(tree, tight(400.0, 1600.0), vsync.clone());
+    let handle = handle_slot
+        .borrow()
+        .clone()
+        .expect("handle must be published");
+
+    handle.show_snack_bar(SnackBar::new(Text::new("already showing")));
+    pump_ms(&mut laid, ENTRY.as_millis() as u64);
+    assert_eq!(
+        snack_bar_material_count(&laid),
+        1,
+        "showing on the first Scaffold"
+    );
+
+    // Mount a SECOND Scaffold under the SAME messenger while the snack bar
+    // is already showing.
+    let replacement = themed_animated(
+        &vsync,
+        ScaffoldMessenger::new(flui_widgets::Column::new(vec![
+            ViewExt::boxed(HandleProbe {
+                slot: Rc::clone(&handle_slot),
+            }),
+            ViewExt::boxed(flui_widgets::Expanded::new(
+                Scaffold::new().body(body_marker()),
+            )),
+            ViewExt::boxed(flui_widgets::Expanded::new(
+                Scaffold::new().body(body_marker()),
+            )),
+        ])),
+    );
+    laid.pump_widget(replacement);
+
+    assert_eq!(
+        scaffold_roots(&laid).len(),
+        2,
+        "both Scaffolds must be mounted"
+    );
+    assert_eq!(
+        snack_bar_material_count(&laid),
+        2,
+        "the newly-mounted Scaffold must render the ALREADY-showing snack bar immediately, \
+         not wait for the next unrelated rebuild"
+    );
+}
+
+// ============================================================================
+// 10. Paint-bounds pin: the entrance/exit transition is clipped to its
+//     CURRENT (animated) height, not painted at the content's full natural
+//     height past that box — the exact overflow-into-a-stacked-sibling bug
+//     an omitted `ClipRect` produces.
+// ============================================================================
+
+#[test]
+fn snack_bar_clips_to_its_animated_height_mid_entrance() {
+    let vsync = Vsync::new();
+    let (mut laid, handle) =
+        mount_with_scaffolds(&vsync, vec![Scaffold::new().body(body_marker())]);
+
+    handle.show_snack_bar(SnackBar::new(Text::new("clip me")));
+    pump_ms(&mut laid, 60); // mid-entrance: a partial, still-growing height
+
+    let clip_rect = laid.find_by_render_type("RenderClipRect").expect(
+        "the entrance/exit transition must be wrapped in a ClipRect (snack_bar.dart's own \
+             outermost wrap) — without it, Align's full-height, unclipped child paint bleeds \
+             past the partially-grown box into whatever sits below (an adjacent Scaffold's own \
+             content, in the multi-scaffold layout)",
+    );
+    let material =
+        find_snack_bar_material(&laid).expect("the snack bar's Material must be mounted");
+
+    let clip_height = laid.size(clip_rect).height.get();
+    let content_height = laid.size(material).height.get();
+    assert!(
+        clip_height < content_height - 1.0,
+        "mid-entrance, the ClipRect's own (animated, shrunk) reported box must be measurably \
+         SMALLER than the content's full natural height — content_height={content_height}, \
+         clip_height={clip_height} — otherwise there is no actual overflow for the clip to \
+         contain, and dropping the ClipRect wrap would go unnoticed by this test"
+    );
+}
+
+// ============================================================================
+// 11. A tick-driven close's `on_closed` is deferred out of the build phase:
+//     a reentrant `show_snack_bar` from it must not corrupt the frame, and
+//     must not take effect until a LATER frame.
+// ============================================================================
+
+#[test]
+fn tick_driven_close_defers_a_reentrant_show_snack_bar_out_of_the_build_phase() {
+    let vsync = Vsync::new();
+    let (mut laid, handle) =
+        mount_with_scaffolds(&vsync, vec![Scaffold::new().body(body_marker())]);
+
+    let handle_for_on_closed = handle.clone();
+    handle
+        .show_snack_bar(SnackBar::new(Text::new("a")).duration(Duration::from_millis(60)))
+        .on_closed(move |_reason| {
+            // Reentrant, reached from a PURELY tick-driven close (no
+            // explicit hide/remove call below) — must land in a safe,
+            // post-build window, not corrupt the frame that just built.
+            handle_for_on_closed.show_snack_bar(SnackBar::new(Text::new("b")));
+        });
+
+    pump_ms(&mut laid, ENTRY.as_millis() as u64); // "a" fully shown
+    assert!(find_text(&laid, "a").is_some(), "\"a\" must be shown");
+
+    // Single-frame-stepped through "a"'s natural timeout + exit reverse, so
+    // the exact frame it disappears on can be pinned down.
+    let settle_budget =
+        (60 / FRAME.as_millis() as u64) + (ENTRY.as_millis() as u64 / FRAME.as_millis() as u64) + 4;
+    let mut settled_on_frame = None;
+    for frame_index in 0..settle_budget {
+        laid.pump_for(FRAME);
+        if find_text(&laid, "a").is_none() {
+            settled_on_frame = Some(frame_index);
+            break;
+        }
+    }
+    assert!(
+        settled_on_frame.is_some(),
+        "\"a\" must have closed on its own from purely ticking (timeout + exit reverse), \
+         within the pumped budget"
+    );
+
+    // THE SAME frame "a" disappeared on: the reentrant `show_snack_bar("b")`
+    // must NOT have taken effect yet — it was deferred past this frame.
+    assert!(
+        find_text(&laid, "b").is_none(),
+        "a reentrant show_snack_bar from a build-phase-deferred on_closed must not be visible \
+         in the SAME frame its closing on_closed fired — it must wait for the post-frame \
+         callback to run"
+    );
+
+    // One more frame runs the deferred post-frame callback, which shows
+    // "b" — then it enters over the usual 250ms.
+    pump_ms(&mut laid, ENTRY.as_millis() as u64);
+    assert!(
+        find_text(&laid, "b").is_some(),
+        "the reentrant show_snack_bar from a's deferred on_closed must eventually take effect"
     );
 }

--- a/crates/flui-material/tests/snack_bar.rs
+++ b/crates/flui-material/tests/snack_bar.rs
@@ -1,0 +1,569 @@
+//! `SnackBar`/`ScaffoldMessenger`/`Scaffold` snack-bar-slot end-to-end
+//! coverage — a real [`Vsync`] clock drives both the 250ms entrance/exit
+//! controller and each snack bar's own display-duration timer, matching
+//! `tests/drawer.rs`'s established harness pattern (see that file's module
+//! doc for the `themed`/`themed_animated` `VsyncScope` distinction, which
+//! this file mirrors).
+//!
+//! Pure queue/state-machine mechanics (FIFO drain, the wedge pin, reason
+//! once-only, `clearSnackBars` semantics) are covered synchronously at the
+//! `MessengerCore` unit level in
+//! `crates/flui-material/src/scaffold_messenger.rs`'s own test module — this
+//! file additionally covers what only a real mounted tree proves: the
+//! `Scaffold` slot mounting/unmounting on a real clock, the FAB-lift layout
+//! interaction, real pointer dispatch through `SnackBarAction`, and
+//! multi-scaffold fan-out.
+
+mod common;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use common::{lay_out_animated, tight};
+use flui_animation::Vsync;
+use flui_foundation::RenderId;
+use flui_material::FloatingActionButton;
+use flui_material::{
+    Scaffold, ScaffoldMessenger, ScaffoldMessengerHandle, ScaffoldMessengerScope, SnackBar,
+    SnackBarAction, Theme, ThemeData,
+};
+use flui_types::Color;
+use flui_view::prelude::*;
+use flui_widgets::{ColoredBox, MediaQuery, MediaQueryData, SizedBox, Text, VsyncScope};
+
+/// Wraps `child` in the `Theme`/`MediaQuery` ancestors `Scaffold`/`Material`
+/// require, plus a `VsyncScope` over `vsync` — required for
+/// `ScaffoldMessengerHandle::attach`'s `ctx.get::<VsyncScope, _>` lookup to
+/// register the entrance/exit controller against the SAME clock
+/// [`lay_out_animated`] adopts onto the binding. Without this, `pump_for`
+/// advances virtual time but ticks nothing (matching `tests/drawer.rs`'s
+/// identical `themed_animated` requirement).
+fn themed_animated(vsync: &Vsync, child: impl IntoView) -> impl View {
+    MediaQuery::new(
+        MediaQueryData::default(),
+        Theme::new(ThemeData::light(), VsyncScope::new(vsync.clone(), child)),
+    )
+}
+
+/// The shared entrance/exit transition's duration —
+/// `ENTRY_TRANSITION_DURATION` in `scaffold_messenger.rs`.
+const ENTRY: Duration = Duration::from_millis(250);
+/// The per-pump virtual-time step.
+const FRAME: Duration = Duration::from_millis(16);
+
+/// Pumps enough `FRAME`-sized steps to carry `millis` of virtual time past
+/// its end, with headroom for one extra frame (matching
+/// `tests/drawer.rs`'s `PUMPS`/`FLING_SETTLE_PUMPS` `+ 2` margin).
+fn pump_ms(laid: &mut common::LaidOut, millis: u64) {
+    let pumps = (millis / FRAME.as_millis() as u64) as usize + 2;
+    for _ in 0..pumps {
+        laid.pump_for(FRAME);
+    }
+}
+
+/// A tappable, visibly-sized marker body — `Scaffold`'s body slot is loosely
+/// constrained (see `scaffold.rs`'s module docs), so a bare `ColoredBox`
+/// alone would collapse to zero size.
+fn body_marker() -> impl IntoView {
+    SizedBox::new(400.0, 500.0).child(ColoredBox::new(Color::rgb(10, 20, 30)))
+}
+
+/// Captures the ambient [`ScaffoldMessengerHandle`] into `slot` on every
+/// build — the harness's way of reaching `ScaffoldMessengerScope::of` from
+/// outside the tree, matching `tests/drawer.rs`'s `HandleProbe` pattern.
+#[derive(Clone, StatelessView)]
+struct HandleProbe {
+    slot: Rc<RefCell<Option<ScaffoldMessengerHandle>>>,
+}
+
+impl StatelessView for HandleProbe {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        *self.slot.borrow_mut() = ScaffoldMessengerScope::maybe_of(ctx);
+        SizedBox::shrink()
+    }
+}
+
+/// Mounts `ScaffoldMessenger` over one or more `Scaffold`s (each given an
+/// equal `Expanded` share of the root's height, behind a `HandleProbe`
+/// sibling so the test can drive the shared handle), and returns the
+/// laid-out tree plus the captured handle. Each `Scaffold::get_size`
+/// requires BOUNDED constraints from its parent (see `scaffold.rs`'s own
+/// debug assertion) — `Expanded` is what gives every one of several stacked
+/// scaffolds a finite share, rather than each claiming the Column's full
+/// loose height.
+fn mount_with_scaffolds(
+    vsync: &Vsync,
+    scaffolds: Vec<Scaffold>,
+) -> (common::LaidOut, ScaffoldMessengerHandle) {
+    let handle_slot: Rc<RefCell<Option<ScaffoldMessengerHandle>>> = Rc::new(RefCell::new(None));
+    let mut children: Vec<flui_view::BoxedView> = vec![
+        HandleProbe {
+            slot: Rc::clone(&handle_slot),
+        }
+        .boxed(),
+    ];
+    children.extend(
+        scaffolds
+            .into_iter()
+            .map(|scaffold| flui_widgets::Expanded::new(scaffold).boxed()),
+    );
+    let tree = themed_animated(
+        vsync,
+        ScaffoldMessenger::new(flui_widgets::Column::new(children)),
+    );
+    let laid = lay_out_animated(tree, tight(400.0, 1600.0), vsync.clone());
+    let handle = handle_slot
+        .borrow()
+        .clone()
+        .expect("ScaffoldMessengerHandle must be published by ScaffoldMessenger");
+    (laid, handle)
+}
+
+/// Every `Scaffold`'s own `CustomMultiChildLayout` render root, in mount
+/// order.
+fn scaffold_roots(laid: &common::LaidOut) -> Vec<RenderId> {
+    laid.find_all_by_render_type("RenderCustomMultiChildLayoutBox")
+}
+
+/// The number of mounted `Material` surfaces (`RenderPhysicalShape`) with
+/// elevation `6.0` — `crate::snack_bar`'s `DEFAULT_ELEVATION`, distinctive
+/// among this tree's other surfaces (`Scaffold`'s own root `Material`
+/// defaults to elevation `0.0`, and every button's `Material` does too), so
+/// counting them is a reliable "is a snack bar currently mounted, and how
+/// many" signal without downcasting to `SnackBarPresenter`.
+fn snack_bar_material_count(laid: &common::LaidOut) -> usize {
+    laid.find_all_by_render_type("RenderPhysicalShape")
+        .into_iter()
+        .filter(|&id| {
+            laid.render_property(id, "elevation")
+                .and_then(|value| value.parse::<f32>().ok())
+                == Some(6.0)
+        })
+        .count()
+}
+
+// ============================================================================
+// 1. FIFO drain: the first entry fully exits before the second enters, and
+//    both eventually close (abrupt remove, then a natural timeout).
+// ============================================================================
+
+#[test]
+fn fifo_drain_shows_the_current_entry_then_the_next_after_it_closes() {
+    let vsync = Vsync::new();
+    let (mut laid, handle) =
+        mount_with_scaffolds(&vsync, vec![Scaffold::new().body(body_marker())]);
+
+    assert_eq!(snack_bar_material_count(&laid), 0, "nothing shown yet");
+
+    handle.show_snack_bar(SnackBar::new(Text::new("first")).duration(Duration::from_millis(60)));
+    pump_ms(&mut laid, ENTRY.as_millis() as u64);
+    assert_eq!(
+        snack_bar_material_count(&laid),
+        1,
+        "\"first\" must be mounted after entering"
+    );
+
+    handle.show_snack_bar(SnackBar::new(Text::new("second")).duration(Duration::from_millis(60)));
+    handle.remove_current_snack_bar(); // abrupt: "first" gone, "second" begins entering immediately
+    pump_ms(&mut laid, ENTRY.as_millis() as u64);
+    assert_eq!(
+        snack_bar_material_count(&laid),
+        1,
+        "exactly one entry (\"second\") must be mounted — never zero (a gap) or two (both at once)"
+    );
+
+    // "second" naturally times out and exits.
+    pump_ms(&mut laid, 60);
+    pump_ms(&mut laid, ENTRY.as_millis() as u64);
+    assert_eq!(
+        snack_bar_material_count(&laid),
+        0,
+        "both entries must have fully drained"
+    );
+}
+
+// ============================================================================
+// 2. Timeout at exactly the per-snackbar duration (custom duration honored).
+// ============================================================================
+
+#[test]
+fn a_custom_duration_snack_bar_auto_dismisses_after_that_duration_not_the_default() {
+    let vsync = Vsync::new();
+    let (mut laid, handle) =
+        mount_with_scaffolds(&vsync, vec![Scaffold::new().body(body_marker())]);
+
+    handle.show_snack_bar(SnackBar::new(Text::new("brief")).duration(Duration::from_millis(120)));
+    pump_ms(&mut laid, ENTRY.as_millis() as u64);
+    assert_eq!(
+        snack_bar_material_count(&laid),
+        1,
+        "must be shown right after entering"
+    );
+
+    // Comfortably before 120ms of display time has elapsed: still shown.
+    pump_ms(&mut laid, 40);
+    assert_eq!(
+        snack_bar_material_count(&laid),
+        1,
+        "must still be shown well before its configured 120ms duration elapses"
+    );
+
+    // Past 120ms of display time plus the 250ms exit reverse: gone.
+    pump_ms(&mut laid, 120);
+    pump_ms(&mut laid, ENTRY.as_millis() as u64);
+    assert_eq!(
+        snack_bar_material_count(&laid),
+        0,
+        "must have auto-dismissed once its own configured duration elapsed"
+    );
+}
+
+// ============================================================================
+// 3. Early hide cancels the display timer (no dangling early auto-dismiss).
+// ============================================================================
+
+#[test]
+fn hiding_before_the_duration_elapses_cancels_the_display_timer() {
+    let vsync = Vsync::new();
+    let (mut laid, handle) =
+        mount_with_scaffolds(&vsync, vec![Scaffold::new().body(body_marker())]);
+
+    handle
+        .show_snack_bar(SnackBar::new(Text::new("hidden early")).duration(Duration::from_secs(10)));
+    pump_ms(&mut laid, ENTRY.as_millis() as u64);
+    assert_eq!(snack_bar_material_count(&laid), 1);
+
+    handle.hide_current_snack_bar();
+    pump_ms(&mut laid, ENTRY.as_millis() as u64);
+    assert_eq!(
+        snack_bar_material_count(&laid),
+        0,
+        "an explicit hide must close the snack bar well before its 10s duration would have"
+    );
+
+    // If the cancelled timer were still ticking toward its original 10s
+    // duration, its later firing would call `hide_current` on an EMPTY
+    // queue — a no-op per `MessengerCore::hide_current`'s own guard — so the
+    // only way this stays reliably closed (not, say, re-opened by a stray
+    // side effect) is confirming it's still gone well past that point too.
+    pump_ms(&mut laid, 500);
+    assert_eq!(snack_bar_material_count(&laid), 0);
+}
+
+// ============================================================================
+// 4. Action press closes with Action reason and disables after one press.
+// ============================================================================
+
+#[test]
+fn action_press_closes_the_snack_bar_and_is_single_fire() {
+    let vsync = Vsync::new();
+    let action_presses = Arc::new(AtomicUsize::new(0));
+    let action_presses_for_cb = Arc::clone(&action_presses);
+
+    let (mut laid, handle) =
+        mount_with_scaffolds(&vsync, vec![Scaffold::new().body(body_marker())]);
+
+    handle.show_snack_bar(
+        SnackBar::new(Text::new("Saved")).action(SnackBarAction::new("UNDO", move || {
+            action_presses_for_cb.fetch_add(1, Ordering::SeqCst);
+        })),
+    );
+    pump_ms(&mut laid, ENTRY.as_millis() as u64);
+    assert_eq!(snack_bar_material_count(&laid), 1);
+
+    // The action sits at the row's end, vertically centered in the snack
+    // bar's own bounding box — found via the same elevation-based filter
+    // `snack_bar_material_count` uses, so this test does not depend on
+    // internal render-node identification beyond that one distinctive
+    // property.
+    let snack_bar_material = laid
+        .find_all_by_render_type("RenderPhysicalShape")
+        .into_iter()
+        .find(|&id| {
+            laid.render_property(id, "elevation")
+                .and_then(|value| value.parse::<f32>().ok())
+                == Some(6.0)
+        })
+        .expect("the snack bar's Material must be mounted");
+    let bar_offset = laid.absolute_offset(snack_bar_material);
+    let bar_size = laid.size(snack_bar_material);
+    let tap_x = bar_offset.dx.get() + bar_size.width.get() * 0.92;
+    let tap_y = bar_offset.dy.get() + bar_size.height.get() * 0.5;
+
+    laid.dispatch_pointer_down(tap_x, tap_y);
+    laid.dispatch_pointer_up(tap_x, tap_y);
+    assert_eq!(
+        action_presses.load(Ordering::SeqCst),
+        1,
+        "the action must fire on press"
+    );
+
+    pump_ms(&mut laid, ENTRY.as_millis() as u64);
+    assert_eq!(
+        snack_bar_material_count(&laid),
+        0,
+        "pressing the action must close the snack bar (SnackBarClosedReason::Action)"
+    );
+
+    // A second dispatch at the same coordinates hits whatever is now
+    // mounted there (the body, since the snack bar closed) — confirms the
+    // action truly stopped being interactable, not merely that its
+    // callback happens not to have re-fired for an unrelated reason.
+    laid.dispatch_pointer_down(tap_x, tap_y);
+    laid.dispatch_pointer_up(tap_x, tap_y);
+    assert_eq!(
+        action_presses.load(Ordering::SeqCst),
+        1,
+        "a press after the action closed the snack bar must not re-fire it"
+    );
+}
+
+// ============================================================================
+// 5. Multi-scaffold fan-out: the same messenger shows the current entry on
+//    every registered scaffold simultaneously.
+// ============================================================================
+
+#[test]
+fn messenger_over_two_scaffolds_shows_the_current_entry_on_both() {
+    let vsync = Vsync::new();
+    let (mut laid, handle) = mount_with_scaffolds(
+        &vsync,
+        vec![
+            Scaffold::new().body(body_marker()),
+            Scaffold::new().body(body_marker()),
+        ],
+    );
+
+    let roots = scaffold_roots(&laid);
+    assert_eq!(roots.len(), 2, "both Scaffolds must be mounted");
+    for &root in &roots {
+        assert_eq!(
+            laid.children(root).len(),
+            1,
+            "body only, before any snack bar shows"
+        );
+    }
+
+    handle.show_snack_bar(SnackBar::new(Text::new("both")));
+    pump_ms(&mut laid, ENTRY.as_millis() as u64);
+
+    for &root in &scaffold_roots(&laid) {
+        assert_eq!(
+            laid.children(root).len(),
+            2,
+            "every registered Scaffold's CustomMultiChildLayout must mount a snack-bar slot child"
+        );
+    }
+    assert_eq!(
+        snack_bar_material_count(&laid),
+        2,
+        "one snack bar Material per registered Scaffold, not one shared across both"
+    );
+}
+
+// ============================================================================
+// 6. FAB lift: above the snack bar, both mid-animation and at rest.
+// ============================================================================
+
+#[test]
+fn floating_action_button_lifts_above_the_snack_bar_mid_animation_and_at_rest() {
+    let vsync = Vsync::new();
+    let (mut laid, handle) = mount_with_scaffolds(
+        &vsync,
+        vec![
+            Scaffold::new()
+                .body(body_marker())
+                .floating_action_button(FloatingActionButton::new(Some(|| {}), Text::new("+"))),
+        ],
+    );
+
+    let scaffold_root = scaffold_roots(&laid)[0];
+    let fab_id = |laid: &common::LaidOut| -> RenderId {
+        laid.children(scaffold_root)
+            .into_iter()
+            .find(|&id| {
+                let size = laid.size(id);
+                size.width.get() < 100.0 && size.height.get() < 100.0
+            })
+            .expect("the FAB must be mounted")
+    };
+
+    let fab_y_at_rest_before = laid.offset(fab_id(&laid)).dy.get();
+
+    handle.show_snack_bar(SnackBar::new(Text::new("lift me")));
+
+    // Mid-animation: partway through the 250ms entrance, the snack bar has
+    // SOME height (not zero, not yet its final height) — the FAB must
+    // already be lifted, strictly between its resting position and where it
+    // ends up once the snack bar is fully grown.
+    pump_ms(&mut laid, 60);
+    let fab_y_mid_entrance = laid.offset(fab_id(&laid)).dy.get();
+    assert!(
+        fab_y_mid_entrance < fab_y_at_rest_before,
+        "the FAB must already be lifted mid-entrance: before={fab_y_at_rest_before}, mid={fab_y_mid_entrance}"
+    );
+
+    pump_ms(&mut laid, ENTRY.as_millis() as u64);
+    let fab_y_fully_shown = laid.offset(fab_id(&laid)).dy.get();
+    assert!(
+        fab_y_fully_shown < fab_y_mid_entrance,
+        "the FAB must keep rising as the snack bar keeps growing: mid={fab_y_mid_entrance}, \
+         fully_shown={fab_y_fully_shown}"
+    );
+
+    handle.remove_current_snack_bar();
+    pump_ms(&mut laid, ENTRY.as_millis() as u64);
+    let fab_y_at_rest_after = laid.offset(fab_id(&laid)).dy.get();
+    assert!(
+        (fab_y_at_rest_after - fab_y_at_rest_before).abs() < 1.0,
+        "the FAB must return to its original resting position once the snack bar is gone: \
+         before={fab_y_at_rest_before}, after={fab_y_at_rest_after}"
+    );
+}
+
+// ============================================================================
+// 7. Unregister on dispose: an unmounted Scaffold must not linger in the
+//    messenger's registered set.
+// ============================================================================
+
+#[test]
+fn unmounting_a_scaffold_unregisters_it_from_the_messenger() {
+    let vsync = Vsync::new();
+    let handle_slot: Rc<RefCell<Option<ScaffoldMessengerHandle>>> = Rc::new(RefCell::new(None));
+    let tree = themed_animated(
+        &vsync,
+        ScaffoldMessenger::new(flui_widgets::Column::new(vec![
+            ViewExt::boxed(HandleProbe {
+                slot: Rc::clone(&handle_slot),
+            }),
+            ViewExt::boxed(flui_widgets::Expanded::new(
+                Scaffold::new().body(body_marker()),
+            )),
+        ])),
+    );
+    let mut laid = lay_out_animated(tree, tight(400.0, 800.0), vsync.clone());
+    let handle = handle_slot
+        .borrow()
+        .clone()
+        .expect("handle must be published");
+    assert_eq!(
+        handle.registered_scaffold_count(),
+        1,
+        "the mounted Scaffold must have registered"
+    );
+
+    // Swap the root to the SAME ScaffoldMessenger subtree, minus the
+    // Scaffold — `ScaffoldMessenger`'s own element persists (same handle),
+    // but the Scaffold underneath it is torn down.
+    let replacement = themed_animated(
+        &vsync,
+        ScaffoldMessenger::new(flui_widgets::Column::new(vec![ViewExt::boxed(
+            HandleProbe {
+                slot: Rc::clone(&handle_slot),
+            },
+        )])),
+    );
+    laid.pump_widget(replacement);
+
+    assert_eq!(
+        handle.registered_scaffold_count(),
+        0,
+        "the unmounted Scaffold's dispose must have unregistered it"
+    );
+}
+
+// ============================================================================
+// 8. Scope re-home: a FRESH Scaffold element that mounts under a messenger
+//    registers with that messenger, never a stale one from elsewhere in the
+//    tree — the practical shape "re-homing" actually takes in this
+//    substrate.
+//
+// A literal "the SAME Scaffold element persists in place while its ANCESTOR
+// messenger identity changes" scenario is not exercised here: FLUI (like
+// Flutter) reconciles `ScaffoldMessenger::new(...)` at the same type+position
+// in the tree as an UPDATE to the existing element, not a fresh mount — so
+// two structurally-identical `ScaffoldMessenger::new(...)` calls in
+// sequence are the SAME element/handle, not "old" vs "new" (confirmed
+// empirically: `pump_widget` with a second, differently-parameterized
+// `ScaffoldMessenger::new(...)` at the same tree shape yields
+// `first_handle.ptr_eq(&second_handle) == true`). Reaching a genuinely
+// different ancestor identity without remounting the Scaffold would need
+// `GlobalKey`-based reparenting across two structurally distinct branches,
+// which `ScaffoldMessengerScope::maybe_of`'s no-dependency ambient lookup
+// (see `scaffold.rs`'s own module docs' "`ScaffoldMessenger` wiring"
+// section) cannot pick up anyway, since `did_change_dependencies` never
+// fires for it — a documented, honest limitation, not silently papered
+// over.
+// ============================================================================
+
+#[test]
+fn a_scaffold_mounted_fresh_under_a_new_messenger_registers_with_that_one_not_a_stale_one() {
+    let vsync = Vsync::new();
+    let first_handle_slot: Rc<RefCell<Option<ScaffoldMessengerHandle>>> =
+        Rc::new(RefCell::new(None));
+    let tree = themed_animated(
+        &vsync,
+        ScaffoldMessenger::new(flui_widgets::Column::new(vec![ViewExt::boxed(
+            HandleProbe {
+                slot: Rc::clone(&first_handle_slot),
+            },
+        )])),
+    );
+    let mut laid = lay_out_animated(tree, tight(400.0, 800.0), vsync.clone());
+    let first_handle = first_handle_slot
+        .borrow()
+        .clone()
+        .expect("handle must be published");
+    assert_eq!(
+        first_handle.registered_scaffold_count(),
+        0,
+        "no Scaffold mounted under it yet"
+    );
+
+    // A structurally distinct second `ScaffoldMessenger` (nested one level
+    // deeper, so reconciliation treats it as a genuinely different element,
+    // not an update of the first) with a freshly-mounted `Scaffold`.
+    let second_handle_slot: Rc<RefCell<Option<ScaffoldMessengerHandle>>> =
+        Rc::new(RefCell::new(None));
+    let replacement = themed_animated(
+        &vsync,
+        ScaffoldMessenger::new(flui_widgets::Column::new(vec![
+            ViewExt::boxed(HandleProbe {
+                slot: Rc::clone(&first_handle_slot),
+            }),
+            ViewExt::boxed(flui_widgets::Expanded::new(ScaffoldMessenger::new(
+                flui_widgets::Column::new(vec![
+                    ViewExt::boxed(HandleProbe {
+                        slot: Rc::clone(&second_handle_slot),
+                    }),
+                    ViewExt::boxed(flui_widgets::Expanded::new(
+                        Scaffold::new().body(body_marker()),
+                    )),
+                ]),
+            ))),
+        ])),
+    );
+    laid.pump_widget(replacement);
+    let second_handle = second_handle_slot
+        .borrow()
+        .clone()
+        .expect("nested handle must be published");
+
+    assert!(
+        !first_handle.ptr_eq(&second_handle),
+        "the outer and the freshly-mounted nested ScaffoldMessenger must be distinct instances"
+    );
+    assert_eq!(
+        first_handle.registered_scaffold_count(),
+        0,
+        "the outer messenger must never see a Scaffold that mounted under the nested one"
+    );
+    assert_eq!(
+        second_handle.registered_scaffold_count(),
+        1,
+        "the freshly-mounted Scaffold must register with its OWN nearest messenger"
+    );
+}

--- a/examples/material_demo/tree.rs
+++ b/examples/material_demo/tree.rs
@@ -19,6 +19,11 @@
 //! a home route whose content is [`MaterialDemoHome`] — wrapped once, at the
 //! very root, in `Theme(ThemeData::light())` ([`MaterialDemoApp`]).
 //!
+//! [`MaterialDemoRootState`] wraps its `Navigator` in a [`ScaffoldMessenger`]
+//! (the scope-mount pattern — see that type's own module docs) so every
+//! route's `Scaffold` shares one snack-bar queue for the whole app's life,
+//! the way a real `MaterialApp` mounts one at the root.
+//!
 //! [`MaterialDemoHome`] builds a `Scaffold`:
 //! - `app_bar`: an `AppBar` titled [`APP_TITLE`] with one action — an
 //!   `IconButton` (a settings glyph) that pushes [`settings_route`]. Its
@@ -35,14 +40,16 @@
 //! - `floating_action_button`: a `FloatingActionButton` labeled "+" that
 //!   calls [`show_dialog`] with an `AlertDialog` ("Add item"): `Cancel`
 //!   (`TextButton`) pops with no change, `Add` (`FilledButton`) appends a
-//!   fresh item and pops. `show_dialog` pushes a `PopupRoute`
-//!   (`opaque: false`, `maintain_state: true`), so the home route stays
-//!   mounted, laid out, and painted beneath the dialog's barrier — only its
-//!   hit-testing is blocked (the full-screen barrier sits on top).
+//!   fresh item, pops, and shows [`SNACK_BAR_ADDED_MESSAGE`] via the
+//!   ambient `ScaffoldMessenger` — auto-dismissing after its own default
+//!   4s duration. `show_dialog` pushes a `PopupRoute` (`opaque: false`,
+//!   `maintain_state: true`), so the home route stays mounted, laid out,
+//!   and painted beneath the dialog's barrier — only its hit-testing is
+//!   blocked (the full-screen barrier sits on top).
 //!
 //! # Honest caveats (Catalog.1 exit criterion, Material half)
 //!
-//! This app proves the five named components mount, lay out, and respond to
+//! This app proves the six named components mount, lay out, and respond to
 //! real gesture dispatch. It does **not** exercise:
 //! - **Ink ripple/splash visuals** — `InkWell` here paints only the static
 //!   resolved overlay fill (see `flui_material::ink_well`'s module docs); no
@@ -50,9 +57,12 @@
 //! - **Component themes** (`AppBarTheme`, `CardTheme`, …) — every widget
 //!   resolves the fixed M3 baseline token tables; `ThemeData` carries no
 //!   component-theme overrides yet.
-//! - **`SnackBar`/`Drawer`** — neither has a `Scaffold` slot in this
-//!   substrate (see `flui_material::scaffold`'s module docs' deferred-slot
-//!   list).
+//! - **`Drawer`** — no `Scaffold::drawer` is configured in this demo tree
+//!   (`crates/flui-material/tests/drawer.rs` covers that widget directly).
+//! - **`SnackBar` action/multi-scaffold fan-out** — the "Item added"
+//!   snack bar carries no action button, and this demo has only one
+//!   `Scaffold` registered with its `ScaffoldMessenger` (both covered
+//!   directly by `crates/flui-material/tests/snack_bar.rs`).
 //!
 //! The Cupertino half of the Catalog.1 exit criterion is untouched by this
 //! app.
@@ -62,7 +72,8 @@ use std::rc::Rc;
 
 use flui_material::{
     AlertDialog, AppBar, Card, FilledButton, FloatingActionButton, IconButton, InkWell, Scaffold,
-    TextButton, Theme, ThemeData, show_dialog,
+    ScaffoldMessenger, ScaffoldMessengerHandle, ScaffoldMessengerScope, SnackBar, TextButton,
+    Theme, ThemeData, show_dialog,
 };
 use flui_view::RebuildHandle;
 use flui_widgets::column;
@@ -97,6 +108,9 @@ pub const ADD_DIALOG_CONTENT: &str = "A new item will be appended to the list.";
 pub const CANCEL_LABEL: &str = "Cancel";
 /// The dialog's confirming action label.
 pub const ADD_LABEL: &str = "Add";
+
+/// The [`SnackBar`] message shown once "Add" appends an item.
+pub const SNACK_BAR_ADDED_MESSAGE: &str = "Item added";
 
 /// `Icons.settings`'s codepoint (`icons.dart`'s `settings` constant) — the
 /// app bar action's glyph. Renders as tofu (no bundled icon font; see
@@ -193,7 +207,10 @@ impl StatefulView for MaterialDemoRoot {
 
 impl ViewState<MaterialDemoRoot> for MaterialDemoRootState {
     fn build(&self, _view: &MaterialDemoRoot, _ctx: &dyn BuildContext) -> impl IntoView {
-        Navigator::new(self.navigator.clone())
+        // The scope-mount pattern: one `ScaffoldMessenger` above the whole
+        // `Navigator`, so every route's `Scaffold` shares one snack-bar
+        // queue for the app's life — see the module docs.
+        ScaffoldMessenger::new(Navigator::new(self.navigator.clone()))
     }
 }
 
@@ -261,7 +278,11 @@ impl ViewState<MaterialDemoHome> for MaterialDemoHomeState {
         }
     }
 
-    fn build(&self, _view: &MaterialDemoHome, _ctx: &dyn BuildContext) -> impl IntoView {
+    fn build(&self, _view: &MaterialDemoHome, ctx: &dyn BuildContext) -> impl IntoView {
+        // A plain ambient lookup (`ctx.get`, no dependency registered) —
+        // unlike `rebuild_handle`/`post_frame_handle`, safe to call from
+        // `build` itself; see `ScaffoldMessengerScope::maybe_of`'s own doc.
+        let messenger = ScaffoldMessengerScope::of(ctx);
         let rebuild = self
             .rebuild
             .clone()
@@ -325,12 +346,14 @@ impl ViewState<MaterialDemoHome> for MaterialDemoHomeState {
         let navigator_for_fab = self.navigator.clone();
         let items_for_fab = Rc::clone(&self.items);
         let rebuild_for_fab = rebuild;
+        let messenger_for_fab = messenger;
         let fab = FloatingActionButton::new(
             Some(move || {
                 open_add_item_dialog(
                     &navigator_for_fab,
                     Rc::clone(&items_for_fab),
                     rebuild_for_fab.clone(),
+                    messenger_for_fab.clone(),
                 );
             }),
             Text::new(FAB_LABEL),
@@ -347,7 +370,10 @@ impl ViewState<MaterialDemoHome> for MaterialDemoHomeState {
 }
 
 /// Opens the "Add item" dialog: `Cancel` pops with no change, `Add` appends
-/// a fresh item to `items`, schedules the home route's rebuild, and pops.
+/// a fresh item to `items`, schedules the home route's rebuild, pops, and
+/// shows [`SNACK_BAR_ADDED_MESSAGE`] via `messenger` — the scope-mount
+/// pattern's payoff: one call against the ambient handle, no `Scaffold`
+/// plumbing at this call site.
 ///
 /// `show_dialog` pushes a `PopupRoute` (`opaque: false`) — the home route
 /// stays mounted underneath, so `rebuild`'s `RebuildHandle` (captured from
@@ -357,6 +383,7 @@ fn open_add_item_dialog(
     navigator: &NavigatorHandle,
     items: Rc<RefCell<Vec<String>>>,
     rebuild: RebuildHandle,
+    messenger: ScaffoldMessengerHandle,
 ) {
     let navigator_for_builder = navigator.clone();
     show_dialog::<(), _, _>(navigator, move |_ctx| {
@@ -364,6 +391,7 @@ fn open_add_item_dialog(
         let navigator_for_add = navigator_for_builder.clone();
         let items_for_add = Rc::clone(&items);
         let rebuild_for_add = rebuild.clone();
+        let messenger_for_add = messenger.clone();
 
         AlertDialog::new()
             .title(Text::new(ADD_DIALOG_TITLE))
@@ -382,6 +410,8 @@ fn open_add_item_dialog(
                             .push(format!("{ITEM_LABEL_PREFIX}{next_index}"));
                         navigator_for_add.pop();
                         rebuild_for_add.schedule();
+                        messenger_for_add
+                            .show_snack_bar(SnackBar::new(Text::new(SNACK_BAR_ADDED_MESSAGE)));
                     })
                     .boxed(),
             ])

--- a/tests/material_demo.rs
+++ b/tests/material_demo.rs
@@ -463,6 +463,77 @@ fn dialog_add_appends_an_item_and_preserves_home_state() {
 }
 
 // ============================================================================
+// (3b) Add shows a snack bar via the scope-mounted ScaffoldMessenger, which
+//      auto-dismisses after its own display duration
+// ============================================================================
+
+#[test]
+fn adding_an_item_shows_a_snack_bar_that_auto_dismisses() {
+    let mut demo = MountedDemo::mount();
+
+    let fab = demo
+        .find_text(tree::FAB_LABEL)
+        .expect("the FAB must render");
+    demo.tap_node(fab);
+    demo.pump(Duration::ZERO);
+    assert!(
+        demo.find_text(tree::ADD_DIALOG_TITLE).is_some(),
+        "the FAB must still open the Add-item dialog with the ScaffoldMessenger mounted above it"
+    );
+
+    let add_button = demo
+        .find_text(tree::ADD_LABEL)
+        .expect("the dialog's Add action must render");
+    demo.tap_node(add_button);
+    demo.pump(Duration::ZERO);
+
+    assert!(
+        demo.find_text(tree::ADD_DIALOG_TITLE).is_none(),
+        "the dialog must still close on Add"
+    );
+
+    // Pumped in small (one simulated frame each) steps rather than a few
+    // large jumps: the entrance -> display-timer -> exit sequence spawns a
+    // fresh controller mid-sequence (`ScaffoldMessengerHandle`'s display
+    // timer starts only once the entrance controller's own `Completed`
+    // status is observed), so a single huge `pump` would not give that
+    // freshly-registered controller its fair share of the elapsed time —
+    // matching `crates/flui-material/tests/snack_bar.rs`'s own
+    // frame-stepped `pump_ms` helper.
+    let frame = Duration::from_millis(16);
+    let pump_ms = |demo: &mut MountedDemo, millis: u64| {
+        let frames = (millis / frame.as_millis() as u64) + 2;
+        for _ in 0..frames {
+            demo.pump(frame);
+        }
+    };
+
+    // Carry the 250ms entrance past its end. (The snack bar's content
+    // mounts immediately, at `heightFactor: 0` — `find_text` sees it
+    // regardless of animated height, so the meaningful assertion is that
+    // it survives well past the entrance, not that it's absent before it.)
+    pump_ms(&mut demo, 250);
+    assert!(
+        demo.find_text(tree::SNACK_BAR_ADDED_MESSAGE).is_some(),
+        "the snack bar must be shown once its entrance animation completes"
+    );
+
+    // Comfortably before its 4s default display duration elapses: still shown.
+    pump_ms(&mut demo, 2000);
+    assert!(
+        demo.find_text(tree::SNACK_BAR_ADDED_MESSAGE).is_some(),
+        "the snack bar must still be visible well before its display duration elapses"
+    );
+
+    // Past the 4s display duration plus the 250ms exit reverse: gone.
+    pump_ms(&mut demo, 2500);
+    assert!(
+        demo.find_text(tree::SNACK_BAR_ADDED_MESSAGE).is_none(),
+        "the snack bar must have auto-dismissed once its display duration elapsed"
+    );
+}
+
+// ============================================================================
 // (4) Dialog "Cancel" dismisses without appending
 // ============================================================================
 


### PR DESCRIPTION
## Summary

SnackBar + ScaffoldMessenger V1 (the last big Scaffold-slot deferral), ported against Flutter 3.44.0 `material/{snack_bar,scaffold,snack_bar_theme}.dart` through an adversarial design pass that caught two fatal plan errors before code (the entrance recipe cited the floating-M3 branch — fixed behavior is `fastOutSlowIn` heightFactor with **no fade**; and the queue-wedge invariant was unstated).

- **`ScaffoldMessenger`/`ScaffoldMessengerScope`** — user-mounted above Scaffolds (Theme pattern; a future MaterialApp absorbs the mount): FIFO queue over one shared 250ms entrance controller, drain driven by an idempotent `reconcile()` (the status-listener shape was Send-incompatible with the Rc queue — a documented deviation) with **user `on_closed` callbacks post-frame-deferred when reached from the build phase** (ADR-0021 — Flutter never completes completers during build; review-caught), direct-pop on remove-while-Dismissed (the wedge pin: change-detected emission fires no edge), reasons per the oracle (hide→remove reports **Remove** — removeCurrentSnackBar overwrites a provisional reason immediately, review-caught divergence), clear drops queued completers silently, per-snackbar `duration` honored, registration in `init_state` (FLUI's `did_change_dependencies` fires only for tracked dependencies — verified semantics), multi-scaffold fan-out (nested `_isRoot` filtering deferred named).
- **`SnackBar` + `SnackBarAction`** — `_SnackbarDefaultsM3` (inverseSurface, elevation 6, bodyMedium/onInverseSurface, inversePrimary action + disabled), fixed-behavior entrance **wrapped in the oracle's ClipRect** (review-caught: RenderAlign lays the child loose and paints overflow unclipped — mid-animation the bar painted over stacked siblings; paint-bounds pin added), single-fire action with the disabled color.
- **Scaffold** — `SLOT_SNACK_BAR` + the real `FabFloatOffsetY` snackbar term: the FAB tracks the **animated** height (mid-animation triple-sample test, mutation-killed).
- Timer = AnimationController-as-timer with an honest cost note (keeps frames scheduled during display; event-driven Timer is a named follow-up — chosen for virtual-clock testability).
- Deferred named: floating behavior, close icon (Dismiss), swipe-dismiss, persist/route-pausing, action overflow row, SnackBarTheme slot, nested-scaffold filtering.

### Review trail
Architect → critique (2 fatals + drain restructure + timer honesty + multi-scaffold/clear corrections) → build (2 documented deviations, both verified true by review) → full review (3 blockers: missing ClipRect, build-phase callbacks, reason divergence; + a false red-check attribution and a write-only state field) → fix pass with per-finding mutation evidence.

### Gates
Workspace nextest 7033 passed / 4 skipped · workspace clippy `-D warnings` clean · doc gate clean · port-check/inventory/fmt/taplo/typos · doctests · material_demo 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvkSGveJwxLVuygRAGVKuz