### PR TITLE
feat(material): M3 NavigationBar + NavigationDestination + Scaffold bottom-nav slot

### DIFF
--- a/crates/flui-material/src/lib.rs
+++ b/crates/flui-material/src/lib.rs
@@ -8,8 +8,9 @@
 //! [`TextButton`], [`IconButton`], [`FloatingActionButton`], [`BackButton`]),
 //! [`Scaffold`]/[`AppBar`], [`Card`], [`Dialog`]/[`AlertDialog`]/
 //! [`show_dialog`], the input decoration substrate ([`InputDecoration`],
-//! [`InputDecorator`], [`TextField`]), and the data-display family
-//! ([`ListTile`], [`Divider`]/[`VerticalDivider`]).
+//! [`InputDecorator`], [`TextField`]), the data-display family
+//! ([`ListTile`], [`Divider`]/[`VerticalDivider`]), and bottom navigation
+//! ([`NavigationBar`]/[`NavigationDestination`]).
 //!
 //! ## Flutter parity
 //!
@@ -81,6 +82,7 @@ pub mod ink_well;
 pub mod input_decorator;
 pub mod list_tile;
 pub mod material;
+pub mod navigation_bar;
 pub mod outlined_button;
 pub mod radio;
 pub mod scaffold;
@@ -113,6 +115,7 @@ pub use ink_well::{InkWell, InkWellState};
 pub use input_decorator::{InputDecoration, InputDecorator, InputDecoratorState};
 pub use list_tile::ListTile;
 pub use material::Material;
+pub use navigation_bar::{NavigationBar, NavigationDestination};
 pub use outlined_button::OutlinedButton;
 pub use radio::{Radio, RadioState};
 pub use scaffold::{Scaffold, ScaffoldScope, ScaffoldState};
@@ -130,7 +133,7 @@ pub use theme::Theme;
 pub use theme_data::{
     AppBarThemeData, CardThemeData, CheckboxThemeData, DialogThemeData, DividerThemeData,
     ElevatedButtonThemeData, FabThemeData, FilledButtonThemeData, IconButtonThemeData,
-    InputDecorationThemeData, ListTileThemeData, OutlinedButtonThemeData, RadioThemeData,
-    SwitchThemeData, TextButtonThemeData, ThemeData, ThemeDataOverrides,
+    InputDecorationThemeData, ListTileThemeData, NavigationBarThemeData, OutlinedButtonThemeData,
+    RadioThemeData, SwitchThemeData, TextButtonThemeData, ThemeData, ThemeDataOverrides,
 };
 pub use typography::english_like_2021;

--- a/crates/flui-material/src/navigation_bar.rs
+++ b/crates/flui-material/src/navigation_bar.rs
@@ -467,18 +467,30 @@ fn resolve_navigation_destination_label_style(
         .unwrap_or_else(|| navigation_destination_default_label_style(base, colors, states))
 }
 
-/// Builds the states set (`Selected`/`Disabled` only — see the module docs
-/// on why `Hovered`/`Focused`/`Pressed` never affect this component's own
-/// icon/label colors) for a destination at `selected`/`enabled`.
+/// Builds the PURE (never-combined) `WidgetStates` query set a destination's
+/// icon/label color resolves against.
+///
+/// Flutter parity: `NavigationDestination.build` resolves its icon/label
+/// themes with three INDEPENDENT constant sets — `selectedState =
+/// {selected}`, `unselectedState = {}`, `disabledState = {disabled}`
+/// (`navigation_bar.dart:427-429`) — never a set containing both `selected`
+/// AND `disabled` together, then picks ONE of the three resolved values via
+/// a plain `enabled ? (selected-branch) : disabledIconTheme` bool check
+/// (`:450-457`, `:498-502`). A combined `{selected, disabled}` query would
+/// let a theme [`WidgetStateProperty::Map`]
+/// ordered `[Is(Selected), Is(Disabled), Any]` resolve the SELECTED entry
+/// for a disabled destination (first-match-wins still matches `Is(Selected)`
+/// against the combined set), instead of the disabled entry the oracle's
+/// pure-set query guarantees — see
+/// `theme_disabled_and_selected_resolves_the_disabled_entry_not_the_selected_one`.
 fn navigation_destination_states(selected: bool, enabled: bool) -> WidgetStates {
-    let mut states = WidgetStates::NONE;
-    if selected {
-        states = states.with_state(WidgetState::Selected);
-    }
     if !enabled {
-        states = states.with_state(WidgetState::Disabled);
+        WidgetStates::from(WidgetState::Disabled)
+    } else if selected {
+        WidgetStates::from(WidgetState::Selected)
+    } else {
+        WidgetStates::NONE
     }
-    states
 }
 
 /// Builds one destination's `Expanded(MergeSemantics(Semantics(InkWell(...))))`
@@ -539,9 +551,25 @@ fn build_destination(
     let column = Column::new(vec![icon_stack.boxed(), label.boxed()])
         .main_axis_alignment(MainAxisAlignment::Center);
 
+    // Flutter parity: `NavigationBar._handleTap` always returns a real
+    // `VoidCallback` — the real callback when `onDestinationSelected` is
+    // set, a no-op closure `() {}` otherwise (`navigation_bar.dart:272-274`)
+    // — and `_IndicatorInkWell.onTap` is `enabled ? info.onTap : null`
+    // (`:606`), never gated on whether a callback was actually supplied. So
+    // `InkResponse.enabled` (`isWidgetEnabled`, any tap-family callback
+    // non-null) is `true` for an enabled destination even with no
+    // `on_destination_selected` at all — it still paints its hover/press
+    // overlay. Wiring `on_tap` only when a callback is present would leave
+    // a callback-less-but-enabled destination reading as disabled to
+    // `InkWell`, silently dropping its overlay.
     let mut ink_well = InkWell::new(column).overlay_color(overlay_color.clone());
-    if enabled && let Some(callback) = on_destination_selected.cloned() {
-        ink_well = ink_well.on_tap(move || callback(index));
+    if enabled {
+        let callback = on_destination_selected.cloned();
+        ink_well = ink_well.on_tap(move || {
+            if let Some(callback) = &callback {
+                callback(index);
+            }
+        });
     }
 
     let semantics = Semantics::new()
@@ -838,5 +866,61 @@ mod tests {
         let states = navigation_destination_states(false, false);
         assert!(!states.contains_state(WidgetState::Selected));
         assert!(states.contains_state(WidgetState::Disabled));
+    }
+
+    /// Regression: a destination that is BOTH selected and disabled (e.g.
+    /// the current tab of a now-locked section) must query with the PURE
+    /// `{disabled}` set, never a combined `{selected, disabled}` one — see
+    /// `navigation_destination_states`'s own doc comment for why the oracle
+    /// never queries a combined set, and
+    /// `theme_disabled_and_selected_resolves_the_disabled_entry_not_the_selected_one`
+    /// for the end-to-end proof this enables.
+    #[test]
+    fn states_selected_and_disabled_carries_only_disabled_not_both() {
+        let states = navigation_destination_states(true, false);
+        assert!(states.contains_state(WidgetState::Disabled));
+        assert!(
+            !states.contains_state(WidgetState::Selected),
+            "a disabled destination's query states must never also carry Selected, even when \
+             the destination is selected — combining them would let a theme Map resolve the \
+             wrong (selected) entry for a disabled destination",
+        );
+    }
+
+    /// Mutation-run: reverting `navigation_destination_states` to its
+    /// pre-fix shape (`Selected` and `Disabled` combined into one query set
+    /// whenever both apply) was confirmed to make this test fail — the
+    /// combined set satisfies `WidgetStateConstraint::Is(Selected)` (the
+    /// first entry in the map below), so the OLD code resolved
+    /// `selected_style` for a disabled+selected destination instead of
+    /// `disabled_style`.
+    #[test]
+    fn theme_disabled_and_selected_resolves_the_disabled_entry_not_the_selected_one() {
+        use flui_widgets::WidgetStateConstraint;
+
+        let selected_style = Color::rgb(1, 1, 1);
+        let disabled_style = Color::rgb(2, 2, 2);
+        let theme: WidgetStateProperty<Option<Color>> = WidgetStateProperty::from_map([
+            (
+                WidgetStateConstraint::Is(WidgetState::Selected),
+                Some(selected_style),
+            ),
+            (
+                WidgetStateConstraint::Is(WidgetState::Disabled),
+                Some(disabled_style),
+            ),
+            (WidgetStateConstraint::Any, None),
+        ]);
+
+        // Selected AND disabled.
+        let states = navigation_destination_states(true, false);
+        let resolved = resolve_navigation_destination_icon_color(Some(&theme), &light(), states);
+
+        assert_eq!(
+            resolved, disabled_style,
+            "a disabled destination must resolve the theme's Disabled entry even when it is \
+             ALSO selected — the oracle never queries a combined {{selected, disabled}} set, so \
+             a theme Map ordered Selected-before-Disabled must still give the disabled result",
+        );
     }
 }

--- a/crates/flui-material/src/navigation_bar.rs
+++ b/crates/flui-material/src/navigation_bar.rs
@@ -1,0 +1,842 @@
+//! [`NavigationBar`]/[`NavigationDestination`] — the M3 bottom navigation
+//! bar: a persistent row of equal-width destinations with a pill-shaped
+//! selection indicator.
+//!
+//! # Flutter parity
+//!
+//! `material/navigation_bar.dart`'s `NavigationBar`/`NavigationDestination`/
+//! `NavigationIndicator` and `material/navigation_bar_theme.dart`'s
+//! `NavigationBarThemeData` (oracle tag `3.44.0`).
+//!
+//! # V1 scope: a controlled, static-geometry component
+//!
+//! `NavigationBar` is a plain [`StatelessView`] here, exactly as in the
+//! oracle (`NavigationBar extends StatelessWidget`) — `selected_index` is a
+//! fully caller-controlled prop (Flutter parity: the widget itself holds no
+//! selection state, `onDestinationSelected` is expected to drive a rebuild
+//! with a new `selectedIndex`), so no `WidgetStatesController` needs to be
+//! threaded down to carry `Selected` the way [`crate::Switch`]/[`crate::Checkbox`]/
+//! [`crate::Radio`] share one with their own [`crate::InkWell`] — this
+//! component computes `selected`/`enabled` as plain booleans at build time
+//! and resolves every color/style from them directly. Each destination's own
+//! `Hovered`/`Focused`/`Pressed`/`Disabled` still lives inside its private
+//! `InkWell` element (unshared, persists across `NavigationBar` rebuilds the
+//! same way any other stateful child element does), but never needs to
+//! react outward: `_NavigationBarDefaultsM3`'s `iconTheme`/`labelTextStyle`
+//! only branch on `disabled`/`selected` — never `hovered`/`focused`/`pressed`
+//! — so icon/label color has nothing to recompute when those transient
+//! states change.
+//!
+//! # Label behavior: `alwaysShow` only, the enum itself deferred
+//!
+//! The oracle's `NavigationDestinationLabelBehavior` has three variants
+//! (`alwaysShow`/`alwaysHide`/`onlyShowSelected`); this V1 always behaves as
+//! `alwaysShow` and does not expose the enum at all (neither on the widget
+//! nor `NavigationBarThemeData`) — a half-wired enum that silently no-ops on
+//! two of its three variants is worse than not shipping the choice yet.
+//! `alwaysHide` needs no new geometry (an unconditionally-collapsed label
+//! column), but `onlyShowSelected` needs the padding-driven position/fade
+//! animation `_NavigationDestinationLayoutDelegate` drives from the
+//! selection animation (`:1096-1131`) — this V1 has no animation substrate
+//! for it (see the next section). Both are deferred together, named, rather
+//! than partially wired.
+//!
+//! # Layout: `Column(MainAxisAlignment::Center)` replaces the animated delegate
+//!
+//! The oracle positions each destination's icon/label pair with
+//! `_NavigationDestinationLayoutDelegate`, a `MultiChildLayoutDelegate` that
+//! interpolates the icon's vertical offset by the selection animation
+//! (`:1103-1109`). Because `alwaysShow` always evaluates that delegate at
+//! `kAlwaysCompleteAnimation` (animation == 1.0, `_DestinationLayoutAnimationBuilder`'s
+//! `alwaysShow` branch, `:967-968`) regardless of whether the destination is
+//! actually selected, the delegate's own math reduces to: center the
+//! icon+label block (no gap between them) within the full destination
+//! height. A plain `Column` with `MainAxisAlignment::Center` computes
+//! exactly that (no custom delegate needed) — verified against the oracle
+//! formula: `yPositionOffset = halfHeight(iconSize) + halfHeight(labelSize)`,
+//! i.e. the pair is centered as one block with zero inter-child gap, which
+//! is `Column`'s own `MainAxisAlignment::Center` behavior for a
+//! two-child, no-`Spacer` list.
+//!
+//! # Indicator: always laid out, snap-visible
+//!
+//! `NavigationIndicator`'s oracle scales in via a `Transform` (`:851-856`)
+//! driven by the selection animation — a `Transform` never changes layout
+//! size, so the 64×32 `Ink` box is *always* reserved in the `Stack` that
+//! backs every destination's icon, whether or not the destination is
+//! selected (this is what keeps a selected destination's icon vertically
+//! aligned with its unselected siblings). This V1 reserves the identical
+//! 64×32 `NAVIGATION_INDICATOR_WIDTH`×`NAVIGATION_INDICATOR_HEIGHT` box
+//! for every destination unconditionally, painting it filled
+//! ([`crate::material::Material`], `MaterialShape::Stadium`) only when
+//! selected and fully transparent otherwise — a snap substitute for the
+//! oracle's scale-in/fade animation (named deferral, not a layout
+//! divergence: the reserved space is identical either way).
+//!
+//! # Overlay: one shared `overlay_color`, no default table
+//!
+//! The oracle sets no default `overlayColor` in `_NavigationBarDefaultsM3` —
+//! `_IndicatorInkWell`'s `overlayColor: info.overlayColor ?? navigationBarTheme.overlayColor`
+//! falls through to `InkResponse`'s own `Theme.of(context).hoverColor`-family
+//! defaults when both are `null`, which [`crate::InkWell`] has no equivalent
+//! fallback for yet (see that module's own "no hardcoded opacities" /
+//! "`None` resolution = no overlay layer" policy). So absent a widget- or
+//! theme-level [`NavigationBar::overlay_color`]/[`crate::NavigationBarThemeData::overlay_color`]
+//! override, a destination's `InkWell` paints no overlay at all — matching
+//! the oracle's own effective default, not merely this substrate's usual
+//! gap.
+//!
+//! **Named simplification, not a shape divergence**: the oracle clips the
+//! overlay to the *icon's* rect specifically (`_IndicatorInkWell.getRectCallback`,
+//! `:637-644`, a `GlobalKey`-located `RenderBox` lookup) rather than the
+//! whole destination cell. [`crate::InkWell`] has no per-position rect
+//! callback (it always shape-clips its own bounds) — this V1 wraps the
+//! *entire* destination's icon+label column in one `InkWell` instead,
+//! painting over the full cell rather than a rect confined to the icon. This
+//! is the same "whole tap target, not a sub-region" approximation
+//! [`crate::Switch`]'s own module docs already establish for its thumb-splash
+//! substitution.
+//!
+//! # Semantics: a direct `SemanticsRole` port
+//!
+//! `Semantics(role: SemanticsRole.tabBar, ...)`/`Semantics(role: SemanticsRole.tab,
+//! selected: ...)` (`:293-296`, `:304-306`) port directly: FLUI's
+//! `flui_semantics::SemanticsRole` already carries `Tab`/`TabBar` variants —
+//! no substitution needed. This V1 flattens the oracle's two-widget-deep
+//! per-destination wrapper (an outer `Semantics(role: tab, selected: ...)`
+//! from `NavigationBar.build`, an inner `Semantics(enabled: ..., button:
+//! true)` from `_NavigationBarDestinationSemantics`) into one
+//! [`flui_widgets::Semantics`] node carrying every flag at once — the two
+//! nodes only exist in the oracle because two different widgets each own
+//! one; [`flui_widgets::Semantics`] can carry `role`/`selected`/`enabled`/
+//! `button` on a single builder, so nothing is lost by not re-nesting.
+//! [`flui_widgets::MergeSemantics`] still wraps it (Flutter parity:
+//! `MergeSemantics`, `:303`), which is load-bearing if a destination's own
+//! icon/label subtree ever contributes its own semantics nodes (Flutter
+//! parity: folding the label `Text`'s node into the tab node rather than
+//! leaving it a sibling).
+//!
+//! **Named deferral**: the oracle's extra "Tab N of M" accessibility label
+//! (`_NavigationBarDestinationSemantics`'s non-web `Stack` branch, `:1013-1026`)
+//! needs a `MaterialLocalizations.tabLabel`-equivalent localized string
+//! table this crate does not have yet — not wired.
+//!
+//! # Deferred (named, not silently dropped)
+//!
+//! - **Selection/indicator/label animation** (`animationDuration`,
+//!   `_SelectableAnimatedBuilder`, `NavigationIndicator`'s scale-in) — every
+//!   transition snaps; see the sections above.
+//! - **`NavigationDestinationLabelBehavior`** (`alwaysHide`/`onlyShowSelected`)
+//!   — see the "Label behavior" section above.
+//! - **`shadow_color`/`surface_tint_color`** (widget, theme, and default
+//!   tiers) — [`crate::material::Material`] has no such parameters yet, the
+//!   same gap every other `Material`-backed M3 component in this crate
+//!   already has.
+//! - **`indicator_shape`/`label_padding` overrides** — fixed at the M3
+//!   defaults (`StadiumBorder`, `EdgeInsets.only(top: 4)`).
+//! - **Destination `tooltip`** (long-press `Tooltip`) — no long-press
+//!   gesture wired here.
+//! - **`maintainBottomViewPadding`** — [`flui_widgets::SafeArea`] is used
+//!   with its own defaults; this substrate exposes no override for it yet.
+
+use std::rc::Rc;
+
+use flui_types::Alignment;
+use flui_types::styling::Color;
+use flui_types::typography::TextStyle;
+use flui_view::prelude::*;
+use flui_widgets::{
+    Column, Expanded, IconTheme, IconThemeData, MainAxisAlignment, MergeSemantics, Padding, Row,
+    SafeArea, Semantics, SemanticsRole, SizedBox, Stack, Text, WidgetState, WidgetStateProperty,
+    WidgetStates,
+};
+
+use crate::color_scheme::ColorScheme;
+use crate::ink_well::InkWell;
+use crate::material::Material;
+use crate::shape::MaterialShape;
+use crate::state_color::resolve_state_color;
+use crate::theme::Theme;
+use crate::theme_data::NavigationBarThemeData;
+
+/// The bar's default height. Flutter parity: `_NavigationBarDefaultsM3`'s
+/// `super(height: 80.0, ...)` (`navigation_bar.dart`, oracle tag `3.44.0`).
+pub const NAVIGATION_BAR_HEIGHT: f32 = 80.0;
+
+/// The bar's default elevation. Flutter parity:
+/// `_NavigationBarDefaultsM3`'s `super(elevation: 3.0, ...)`.
+pub const NAVIGATION_BAR_ELEVATION: f32 = 3.0;
+
+/// The selection indicator's width. Flutter parity: `_kIndicatorWidth`
+/// (`navigation_bar.dart`, `64.0`).
+const NAVIGATION_INDICATOR_WIDTH: f32 = 64.0;
+
+/// The selection indicator's height. Flutter parity: `_kIndicatorHeight`
+/// (`32.0`).
+const NAVIGATION_INDICATOR_HEIGHT: f32 = 32.0;
+
+/// Each destination's icon side length. Flutter parity:
+/// `_NavigationBarDefaultsM3.iconTheme`'s `size: 24.0`.
+const NAVIGATION_DESTINATION_ICON_SIZE: f32 = 24.0;
+
+/// The label's top padding. Flutter parity:
+/// `_NavigationBarDefaultsM3.labelPadding`, `EdgeInsets.only(top: 4)`.
+const NAVIGATION_LABEL_PADDING_TOP: f32 = 4.0;
+
+// Compile-time geometry invariant (not a runtime test — every side is
+// `const`): the indicator must fit within the destination's icon area
+// alongside the 24dp icon it backs.
+const _: () = assert!(NAVIGATION_DESTINATION_ICON_SIZE <= NAVIGATION_INDICATOR_HEIGHT);
+
+/// A destination-selected callback: the tapped destination's index.
+/// `Rc`-based (owner-local, per ADR-0027) — matches [`InkWell::on_tap`]'s own
+/// callback shape.
+type DestinationSelectedCallback = Rc<dyn Fn(usize)>;
+
+/// One destination (icon + label) in a [`NavigationBar`].
+///
+/// Flutter parity: `NavigationDestination` (`navigation_bar.dart`, oracle tag
+/// `3.44.0`).
+///
+/// # Examples
+///
+/// ```rust
+/// use flui_material::NavigationDestination;
+/// use flui_widgets::Icon;
+/// use flui_widgets::icon::IconData;
+///
+/// let _home = NavigationDestination::new(Icon::new(IconData::new(0xE88A)), "Home");
+/// ```
+#[derive(Clone)]
+pub struct NavigationDestination {
+    icon: BoxedView,
+    selected_icon: Option<BoxedView>,
+    label: String,
+    enabled: bool,
+}
+
+impl NavigationDestination {
+    /// A destination showing `icon` (used both selected and unselected) and
+    /// `label` below it.
+    pub fn new(icon: impl IntoView, label: impl Into<String>) -> Self {
+        Self {
+            icon: icon.into_view().boxed(),
+            selected_icon: None,
+            label: label.into(),
+            enabled: true,
+        }
+    }
+
+    /// Sets a distinct icon shown while this destination is selected.
+    /// Defaults to the same icon used unselected.
+    #[must_use]
+    pub fn selected_icon(mut self, selected_icon: impl IntoView) -> Self {
+        self.selected_icon = Some(selected_icon.into_view().boxed());
+        self
+    }
+
+    /// Sets whether this destination responds to taps. Defaults to `true`.
+    #[must_use]
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+}
+
+impl std::fmt::Debug for NavigationDestination {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NavigationDestination")
+            .field("label", &self.label)
+            .field("has_selected_icon", &self.selected_icon.is_some())
+            .field("enabled", &self.enabled)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A Material 3 bottom navigation bar: a row of equal-width
+/// [`NavigationDestination`]s with a pill-shaped selection indicator.
+///
+/// See the module docs for the full V1 scope and named deferrals.
+///
+/// # Examples
+///
+/// ```rust
+/// use flui_material::{NavigationBar, NavigationDestination};
+/// use flui_widgets::Icon;
+/// use flui_widgets::icon::IconData;
+///
+/// let _bar = NavigationBar::new(vec![
+///     NavigationDestination::new(Icon::new(IconData::new(0xE88A)), "Home"),
+///     NavigationDestination::new(Icon::new(IconData::new(0xE7FD)), "Profile"),
+/// ])
+/// .selected_index(0)
+/// .on_destination_selected(|index| {
+///     let _ = index;
+/// });
+/// ```
+#[derive(Clone, StatelessView)]
+pub struct NavigationBar {
+    destinations: Vec<NavigationDestination>,
+    selected_index: usize,
+    on_destination_selected: Option<DestinationSelectedCallback>,
+    height: Option<f32>,
+    background_color: Option<Color>,
+    elevation: Option<f32>,
+    indicator_color: Option<Color>,
+    overlay_color: Option<WidgetStateProperty<Option<Color>>>,
+}
+
+impl NavigationBar {
+    /// A bar over `destinations`, `selected_index: 0`, no overrides.
+    ///
+    /// Flutter parity: `NavigationBar`'s constructor asserts `destinations.length
+    /// >= 2` and `0 <= selectedIndex < destinations.length` (`navigation_bar.dart`
+    /// `:122-123`) — Dart `assert`s are stripped in release builds, so this
+    /// is a debug-only contract check there, not a production-enforced
+    /// invariant; `debug_assert!` mirrors that exactly.
+    #[must_use]
+    pub fn new(destinations: Vec<NavigationDestination>) -> Self {
+        debug_assert!(
+            destinations.len() >= 2,
+            "NavigationBar requires at least two destinations"
+        );
+        Self {
+            destinations,
+            selected_index: 0,
+            on_destination_selected: None,
+            height: None,
+            background_color: None,
+            elevation: None,
+            indicator_color: None,
+            overlay_color: None,
+        }
+    }
+
+    /// Sets which destination is currently selected.
+    #[must_use]
+    pub fn selected_index(mut self, selected_index: usize) -> Self {
+        debug_assert!(
+            selected_index < self.destinations.len(),
+            "selected_index must be < destinations.len()"
+        );
+        self.selected_index = selected_index;
+        self
+    }
+
+    /// Sets the callback fired with a destination's index when it is tapped
+    /// (and [`NavigationDestination::enabled`]).
+    #[must_use]
+    pub fn on_destination_selected(mut self, callback: impl Fn(usize) + 'static) -> Self {
+        self.on_destination_selected = Some(Rc::new(callback));
+        self
+    }
+
+    /// Overrides the bar's height. Defaults to [`NAVIGATION_BAR_HEIGHT`].
+    #[must_use]
+    pub fn height(mut self, height: f32) -> Self {
+        self.height = Some(height);
+        self
+    }
+
+    /// Overrides the bar's background color. Defaults to
+    /// `ColorScheme.surfaceContainer`.
+    #[must_use]
+    pub fn background_color(mut self, color: Color) -> Self {
+        self.background_color = Some(color);
+        self
+    }
+
+    /// Overrides the bar's elevation. Defaults to [`NAVIGATION_BAR_ELEVATION`].
+    #[must_use]
+    pub fn elevation(mut self, elevation: f32) -> Self {
+        self.elevation = Some(elevation);
+        self
+    }
+
+    /// Overrides the selection indicator's fill color. Defaults to
+    /// `ColorScheme.secondaryContainer`.
+    #[must_use]
+    pub fn indicator_color(mut self, color: Color) -> Self {
+        self.indicator_color = Some(color);
+        self
+    }
+
+    /// Overrides every destination's shared state-overlay color. `None` (the
+    /// default, at every tier) means no overlay layer — see the module
+    /// docs' "Overlay" section.
+    #[must_use]
+    pub fn overlay_color(mut self, overlay_color: WidgetStateProperty<Option<Color>>) -> Self {
+        self.overlay_color = Some(overlay_color);
+        self
+    }
+}
+
+impl std::fmt::Debug for NavigationBar {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NavigationBar")
+            .field("destinations", &self.destinations.len())
+            .field("selected_index", &self.selected_index)
+            .field("is_interactive", &self.on_destination_selected.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Resolves `height`/`elevation`/`background_color`/`indicator_color`
+/// through the widget → theme → default cascade — Flutter parity:
+/// `NavigationBar.build`'s `height ?? navigationBarTheme.height ?? defaults.height!`
+/// family (`navigation_bar.dart` `:281-287`), extracted as its own pure
+/// function per field so the tier precedence is unit-testable without
+/// mounting a widget tree.
+fn resolve_bar_geometry(
+    view: &NavigationBar,
+    theme: Option<&NavigationBarThemeData>,
+    colors: &ColorScheme,
+) -> (f32, f32, Color, Color) {
+    let height = view
+        .height
+        .or(theme.and_then(|t| t.height))
+        .unwrap_or(NAVIGATION_BAR_HEIGHT);
+    let elevation = view
+        .elevation
+        .or(theme.and_then(|t| t.elevation))
+        .unwrap_or(NAVIGATION_BAR_ELEVATION);
+    let background_color = view
+        .background_color
+        .or(theme.and_then(|t| t.background_color))
+        .unwrap_or(colors.surface_container);
+    let indicator_color = view
+        .indicator_color
+        .or(theme.and_then(|t| t.indicator_color))
+        .unwrap_or(colors.secondary_container);
+    (height, elevation, background_color, indicator_color)
+}
+
+/// `_NavigationBarDefaultsM3.iconTheme` (`navigation_bar.dart`, oracle tag
+/// `3.44.0`) — branches on `disabled`/`selected` only, never
+/// `hovered`/`focused`/`pressed` (see the module docs).
+fn navigation_destination_default_icon_color(colors: &ColorScheme, states: WidgetStates) -> Color {
+    if states.contains_state(WidgetState::Disabled) {
+        colors.on_surface_variant.with_opacity(0.38)
+    } else if states.contains_state(WidgetState::Selected) {
+        colors.on_secondary_container
+    } else {
+        colors.on_surface_variant
+    }
+}
+
+/// Resolves a destination's icon color through the theme → default cascade
+/// (there is no widget-level icon-color override — Flutter parity: neither
+/// `NavigationBar` nor `NavigationDestination` exposes one either).
+fn resolve_navigation_destination_icon_color(
+    theme_icon_color: Option<&WidgetStateProperty<Option<Color>>>,
+    colors: &ColorScheme,
+    states: WidgetStates,
+) -> Color {
+    resolve_state_color(theme_icon_color, &states)
+        .unwrap_or_else(|| navigation_destination_default_icon_color(colors, states))
+}
+
+/// `_NavigationBarDefaultsM3.labelTextStyle` (`navigation_bar.dart`, oracle
+/// tag `3.44.0`): `TextTheme.labelMedium` recolored per state — same
+/// `disabled`/`selected`-only branch as the icon color.
+fn navigation_destination_default_label_style(
+    base: &TextStyle,
+    colors: &ColorScheme,
+    states: WidgetStates,
+) -> TextStyle {
+    let color = if states.contains_state(WidgetState::Disabled) {
+        colors.on_surface_variant.with_opacity(0.38)
+    } else if states.contains_state(WidgetState::Selected) {
+        colors.on_surface
+    } else {
+        colors.on_surface_variant
+    };
+    base.clone().with_color(color)
+}
+
+/// Resolves a destination's label text style through the theme → default
+/// cascade (no widget-level override, matching [`resolve_navigation_destination_icon_color`]).
+fn resolve_navigation_destination_label_style(
+    theme_label_style: Option<&WidgetStateProperty<Option<TextStyle>>>,
+    base: &TextStyle,
+    colors: &ColorScheme,
+    states: WidgetStates,
+) -> TextStyle {
+    theme_label_style
+        .and_then(|property| property.resolve(&states))
+        .unwrap_or_else(|| navigation_destination_default_label_style(base, colors, states))
+}
+
+/// Builds the states set (`Selected`/`Disabled` only — see the module docs
+/// on why `Hovered`/`Focused`/`Pressed` never affect this component's own
+/// icon/label colors) for a destination at `selected`/`enabled`.
+fn navigation_destination_states(selected: bool, enabled: bool) -> WidgetStates {
+    let mut states = WidgetStates::NONE;
+    if selected {
+        states = states.with_state(WidgetState::Selected);
+    }
+    if !enabled {
+        states = states.with_state(WidgetState::Disabled);
+    }
+    states
+}
+
+/// Builds one destination's `Expanded(MergeSemantics(Semantics(InkWell(...))))`
+/// subtree — see the module docs for the layout/overlay/semantics shape.
+#[allow(clippy::too_many_arguments, reason = "internal helper, not public API")]
+fn build_destination(
+    colors: &ColorScheme,
+    indicator_color: Color,
+    icon_color_theme: Option<&WidgetStateProperty<Option<Color>>>,
+    label_style_theme: Option<&WidgetStateProperty<Option<TextStyle>>>,
+    label_base: &TextStyle,
+    overlay_color: &WidgetStateProperty<Option<Color>>,
+    index: usize,
+    selected: bool,
+    destination: &NavigationDestination,
+    on_destination_selected: Option<&DestinationSelectedCallback>,
+) -> Expanded {
+    let enabled = destination.enabled;
+    let states = navigation_destination_states(selected, enabled);
+
+    let icon_color = resolve_navigation_destination_icon_color(icon_color_theme, colors, states);
+    let label_style =
+        resolve_navigation_destination_label_style(label_style_theme, label_base, colors, states);
+
+    let icon_child = if selected {
+        destination
+            .selected_icon
+            .clone()
+            .unwrap_or_else(|| destination.icon.clone())
+    } else {
+        destination.icon.clone()
+    };
+    let icon_themed = IconTheme::new(
+        IconThemeData {
+            size: Some(NAVIGATION_DESTINATION_ICON_SIZE),
+            color: Some(icon_color),
+            ..IconThemeData::default()
+        },
+        icon_child,
+    );
+
+    // Always reserved at full size, painted transparent when unselected —
+    // see the module docs' "Indicator" section.
+    let indicator_fill = if selected {
+        indicator_color
+    } else {
+        Color::TRANSPARENT
+    };
+    let indicator = SizedBox::new(NAVIGATION_INDICATOR_WIDTH, NAVIGATION_INDICATOR_HEIGHT)
+        .child(Material::new(indicator_fill).shape(MaterialShape::Stadium));
+
+    let icon_stack =
+        Stack::new(vec![indicator.boxed(), icon_themed.boxed()]).alignment(Alignment::CENTER);
+
+    let label = Padding::only(0.0, NAVIGATION_LABEL_PADDING_TOP, 0.0, 0.0)
+        .child(Text::new(destination.label.clone()).style(label_style));
+
+    let column = Column::new(vec![icon_stack.boxed(), label.boxed()])
+        .main_axis_alignment(MainAxisAlignment::Center);
+
+    let mut ink_well = InkWell::new(column).overlay_color(overlay_color.clone());
+    if enabled && let Some(callback) = on_destination_selected.cloned() {
+        ink_well = ink_well.on_tap(move || callback(index));
+    }
+
+    let semantics = Semantics::new()
+        .role(SemanticsRole::Tab)
+        .selected(selected)
+        .enabled(enabled)
+        .button(true)
+        .child(ink_well);
+
+    Expanded::new(MergeSemantics::new().child(semantics))
+}
+
+impl StatelessView for NavigationBar {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        let theme = Theme::of(ctx);
+        let colors = theme.color_scheme;
+        let nav_theme = theme.navigation_bar_theme.as_ref();
+
+        let (height, elevation, background_color, indicator_color) =
+            resolve_bar_geometry(self, nav_theme, &colors);
+
+        let overlay_color = self
+            .overlay_color
+            .clone()
+            .or_else(|| nav_theme.and_then(|t| t.overlay_color.clone()))
+            .unwrap_or_else(|| WidgetStateProperty::all(None));
+        let icon_color_theme = nav_theme.and_then(|t| t.icon_color.as_ref());
+        let label_style_theme = nav_theme.and_then(|t| t.label_text_style.as_ref());
+        let label_base = theme.text_theme.label_medium.clone().unwrap_or_default();
+
+        let children: Vec<BoxedView> = self
+            .destinations
+            .iter()
+            .enumerate()
+            .map(|(index, destination)| {
+                build_destination(
+                    &colors,
+                    indicator_color,
+                    icon_color_theme,
+                    label_style_theme,
+                    &label_base,
+                    &overlay_color,
+                    index,
+                    index == self.selected_index,
+                    destination,
+                    self.on_destination_selected.as_ref(),
+                )
+                .boxed()
+            })
+            .collect();
+
+        let content = Semantics::new()
+            .role(SemanticsRole::TabBar)
+            .container(true)
+            .explicit_child_nodes(true)
+            .child(SizedBox::height(height).child(Row::new(children)));
+
+        Material::new(background_color)
+            .elevation(elevation)
+            .child(SafeArea::new().child(content))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn light() -> ColorScheme {
+        ColorScheme::light()
+    }
+
+    fn icon() -> flui_widgets::Icon {
+        flui_widgets::Icon::new(flui_widgets::icon::IconData::new(0xE88A))
+    }
+
+    // ------------------------------------------------------------------
+    // Construction / builder surface
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn new_leaves_every_override_unset_and_selects_the_first_destination() {
+        let bar = NavigationBar::new(vec![
+            NavigationDestination::new(icon(), "Home"),
+            NavigationDestination::new(icon(), "Profile"),
+        ]);
+        assert_eq!(bar.selected_index, 0);
+        assert!(bar.height.is_none());
+        assert!(bar.background_color.is_none());
+        assert!(bar.elevation.is_none());
+        assert!(bar.indicator_color.is_none());
+        assert!(bar.overlay_color.is_none());
+        assert!(bar.on_destination_selected.is_none());
+    }
+
+    #[test]
+    fn selected_index_builder_overrides_the_default() {
+        let bar = NavigationBar::new(vec![
+            NavigationDestination::new(icon(), "Home"),
+            NavigationDestination::new(icon(), "Profile"),
+        ])
+        .selected_index(1);
+        assert_eq!(bar.selected_index, 1);
+    }
+
+    #[test]
+    fn on_destination_selected_makes_the_bar_interactive() {
+        let bar = NavigationBar::new(vec![
+            NavigationDestination::new(icon(), "Home"),
+            NavigationDestination::new(icon(), "Profile"),
+        ])
+        .on_destination_selected(|_| {});
+        assert!(bar.on_destination_selected.is_some());
+    }
+
+    #[test]
+    fn new_destination_defaults_to_enabled_with_no_selected_icon() {
+        let destination = NavigationDestination::new(icon(), "Home");
+        assert!(destination.enabled);
+        assert!(destination.selected_icon.is_none());
+        assert_eq!(destination.label, "Home");
+    }
+
+    #[test]
+    fn destination_enabled_builder_overrides_the_default() {
+        let destination = NavigationDestination::new(icon(), "Home").enabled(false);
+        assert!(!destination.enabled);
+    }
+
+    // ------------------------------------------------------------------
+    // resolve_bar_geometry — widget > theme > default cascade, mutation-run:
+    // each probe below was verified to fail against a deliberately broken
+    // cascade (a tier short-circuited, or the wrong `ColorScheme` field
+    // read) before being confirmed against the real implementation.
+    // ------------------------------------------------------------------
+
+    fn bar() -> NavigationBar {
+        NavigationBar::new(vec![
+            NavigationDestination::new(icon(), "Home"),
+            NavigationDestination::new(icon(), "Profile"),
+        ])
+    }
+
+    #[test]
+    fn geometry_defaults_match_the_m3_token_table() {
+        let (height, elevation, background_color, indicator_color) =
+            resolve_bar_geometry(&bar(), None, &light());
+        assert_eq!(height, NAVIGATION_BAR_HEIGHT);
+        assert_eq!(elevation, NAVIGATION_BAR_ELEVATION);
+        assert_eq!(background_color, light().surface_container);
+        assert_eq!(indicator_color, light().secondary_container);
+    }
+
+    #[test]
+    fn theme_tier_beats_the_default_when_no_widget_override_is_set() {
+        let theme = NavigationBarThemeData {
+            height: Some(96.0),
+            elevation: Some(1.0),
+            background_color: Some(Color::rgb(9, 9, 9)),
+            indicator_color: Some(Color::rgb(8, 8, 8)),
+            ..Default::default()
+        };
+        let (height, elevation, background_color, indicator_color) =
+            resolve_bar_geometry(&bar(), Some(&theme), &light());
+        assert_eq!(height, 96.0);
+        assert_eq!(elevation, 1.0);
+        assert_eq!(background_color, Color::rgb(9, 9, 9));
+        assert_eq!(indicator_color, Color::rgb(8, 8, 8));
+    }
+
+    #[test]
+    fn widget_tier_wins_over_theme_and_default() {
+        let theme = NavigationBarThemeData {
+            height: Some(96.0),
+            ..Default::default()
+        };
+        let widget = bar().height(120.0).indicator_color(Color::rgb(1, 2, 3));
+        let (height, _, _, indicator_color) = resolve_bar_geometry(&widget, Some(&theme), &light());
+        assert_eq!(height, 120.0);
+        assert_eq!(indicator_color, Color::rgb(1, 2, 3));
+    }
+
+    // ------------------------------------------------------------------
+    // Icon/label color state table — per-state probes, oracle branch order
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn default_icon_color_unselected_enabled_is_on_surface_variant() {
+        assert_eq!(
+            navigation_destination_default_icon_color(&light(), WidgetStates::NONE),
+            light().on_surface_variant
+        );
+    }
+
+    #[test]
+    fn default_icon_color_selected_is_on_secondary_container() {
+        let states = WidgetStates::from(WidgetState::Selected);
+        assert_eq!(
+            navigation_destination_default_icon_color(&light(), states),
+            light().on_secondary_container
+        );
+    }
+
+    #[test]
+    fn default_icon_color_disabled_wins_over_selected() {
+        // Branch-order pin: `disabled` is checked BEFORE `selected` in the
+        // oracle (`_NavigationBarDefaultsM3.iconTheme`).
+        let states = WidgetStates::from(WidgetState::Selected).with_state(WidgetState::Disabled);
+        assert_eq!(
+            navigation_destination_default_icon_color(&light(), states),
+            light().on_surface_variant.with_opacity(0.38)
+        );
+    }
+
+    #[test]
+    fn default_icon_color_ignores_hover_focus_pressed() {
+        // Named-parity pin: the M3 default table has no branch for these —
+        // confirmed by asserting the plain-unselected default is unchanged
+        // under each.
+        let base = light().on_surface_variant;
+        for extra in [
+            WidgetState::Hovered,
+            WidgetState::Focused,
+            WidgetState::Pressed,
+        ] {
+            let states = WidgetStates::from(extra);
+            assert_eq!(
+                navigation_destination_default_icon_color(&light(), states),
+                base
+            );
+        }
+    }
+
+    #[test]
+    fn icon_color_theme_tier_beats_the_default() {
+        let theme = WidgetStateProperty::all(Some(Color::rgb(7, 7, 7)));
+        let resolved =
+            resolve_navigation_destination_icon_color(Some(&theme), &light(), WidgetStates::NONE);
+        assert_eq!(resolved, Color::rgb(7, 7, 7));
+    }
+
+    #[test]
+    fn default_label_style_selected_is_on_surface() {
+        let base = TextStyle::default();
+        let states = WidgetStates::from(WidgetState::Selected);
+        let style = navigation_destination_default_label_style(&base, &light(), states);
+        assert_eq!(style.color, Some(light().on_surface));
+    }
+
+    #[test]
+    fn default_label_style_unselected_enabled_is_on_surface_variant() {
+        let base = TextStyle::default();
+        let style = navigation_destination_default_label_style(&base, &light(), WidgetStates::NONE);
+        assert_eq!(style.color, Some(light().on_surface_variant));
+    }
+
+    #[test]
+    fn default_label_style_disabled_wins_over_selected() {
+        let base = TextStyle::default();
+        let states = WidgetStates::from(WidgetState::Selected).with_state(WidgetState::Disabled);
+        let style = navigation_destination_default_label_style(&base, &light(), states);
+        assert_eq!(
+            style.color,
+            Some(light().on_surface_variant.with_opacity(0.38))
+        );
+    }
+
+    #[test]
+    fn label_style_theme_tier_beats_the_default() {
+        let theme_style = TextStyle::default().with_color(Color::rgb(3, 3, 3));
+        let theme: WidgetStateProperty<Option<TextStyle>> =
+            WidgetStateProperty::all(Some(theme_style.clone()));
+        let resolved = resolve_navigation_destination_label_style(
+            Some(&theme),
+            &TextStyle::default(),
+            &light(),
+            WidgetStates::NONE,
+        );
+        assert_eq!(resolved.color, theme_style.color);
+    }
+
+    // ------------------------------------------------------------------
+    // navigation_destination_states
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn states_selected_and_enabled_carries_only_selected() {
+        let states = navigation_destination_states(true, true);
+        assert!(states.contains_state(WidgetState::Selected));
+        assert!(!states.contains_state(WidgetState::Disabled));
+    }
+
+    #[test]
+    fn states_unselected_and_disabled_carries_only_disabled() {
+        let states = navigation_destination_states(false, false);
+        assert!(!states.contains_state(WidgetState::Selected));
+        assert!(states.contains_state(WidgetState::Disabled));
+    }
+}

--- a/crates/flui-material/src/scaffold.rs
+++ b/crates/flui-material/src/scaffold.rs
@@ -6,9 +6,9 @@
 //!
 //! `material/scaffold.dart`'s `Scaffold` (oracle tag `3.44.0`). Implemented
 //! subset: the `app_bar`, `body`, `floating_action_button`, `snack_bar`,
-//! `drawer`, and `end_drawer` slots of `_ScaffoldLayout.performLayout`
-//! (`scaffold.dart:1027-1296`) — the remaining five slots
-//! (`bottomNavigationBar`, `persistentFooter`, `materialBanner`, `bodyScrim`,
+//! `bottom_navigation_bar`, `drawer`, and `end_drawer` slots of
+//! `_ScaffoldLayout.performLayout` (`scaffold.dart:1027-1296`) — the
+//! remaining four slots (`persistentFooter`, `materialBanner`, `bodyScrim`,
 //! `bottomSheet`, `statusBar`) are not ported; a future slot extends
 //! `ScaffoldLayoutDelegate`, it does not restructure it. The `snack_bar` slot
 //! only ever carries `SnackBarBehavior.fixed` content — see
@@ -18,6 +18,26 @@
 //! `themeData.scaffoldBackgroundColor`, which this substrate has not ported
 //! onto [`crate::ThemeData`] yet — `ColorScheme.surface` is the closer M3
 //! analogue in the meantime).
+//!
+//! ## `bottom_navigation_bar` slot: pads itself, like the app bar
+//!
+//! Mirrors the app bar's own contract (see "The inset contract" below): a
+//! [`crate::NavigationBar`] wraps its content in a `SafeArea` and consumes
+//! `MediaQuery.padding.bottom` internally (its own doc: "If this is used in
+//! `Scaffold.bottomNavigationBar` ... the safe area padding is also added to
+//! the height automatically"). So the body's own `MediaQuery.padding.bottom`
+//! is zeroed whenever a `bottom_navigation_bar` is set (oracle:
+//! `removeBottomPadding: widget.bottomNavigationBar != null ...`,
+//! `scaffold.dart:3032-3033`) — otherwise a `SafeArea` nested in the body
+//! would double-pad the same bottom inset the nav bar already consumed.
+//! `ScaffoldLayoutDelegate` measures the bar first (full width, loose
+//! height, Flutter parity: `_ScaffoldLayout.performLayout`'s
+//! `bottomNavigationBarHeight`/`bottomWidgetsHeight`, `scaffold.dart:1048-1055`)
+//! and folds its measured height into `content_bottom` (`max(minInsets.bottom,
+//! bottomWidgetsHeight)` — the greater of the keyboard inset or the bar's
+//! height wins), so the body shrinks above it and the floating action
+//! button's `content_bottom`-relative position (see below) lifts above it
+//! for free, with no separate FAB-specific term.
 //!
 //! ## Drawer wiring
 //!
@@ -74,8 +94,8 @@
 //!
 //! ## Deferred, and named
 //!
-//! `bottomNavigationBar`, `persistentFooterButtons`, `MaterialBanner`,
-//! `bottomSheet`, `extendBody`/`extendBodyBehindAppBar`, non-`endFloat`
+//! `persistentFooterButtons`, `MaterialBanner`, `bottomSheet`,
+//! `extendBody`/`extendBodyBehindAppBar`, non-`endFloat`
 //! `FloatingActionButtonLocation`s. Also deferred, specific to the drawer
 //! slots this update adds: the `AppBar` auto-hamburger (no `AppBar` ↔
 //! `Scaffold` coupling exists yet), per-side `enable_open_drag_gesture`
@@ -84,10 +104,11 @@
 //! both sides), and `drawerDragStartBehavior`/`drawerBarrierDismissible`
 //! overrides at the `Scaffold` level (fixed at
 //! `DrawerController`'s own defaults — see `crate::drawer`). None of these
-//! slots exist in `ScaffoldLayoutDelegate` yet — the six that do
-//! (`app_bar`/`body`/`floating_action_button`/`snack_bar`/`drawer`/`end_drawer`)
-//! are copied verbatim from `_ScaffoldLayout`'s branches for those same
-//! slots, so adding a slot later is additive, not a rewrite.
+//! slots exist in `ScaffoldLayoutDelegate` yet — the seven that do
+//! (`app_bar`/`body`/`floating_action_button`/`snack_bar`/`bottom_navigation_bar`/
+//! `drawer`/`end_drawer`) are copied verbatim from `_ScaffoldLayout`'s
+//! branches for those same slots, so adding a slot later is additive, not a
+//! rewrite.
 //!
 //! ## `ScaffoldMessenger` wiring
 //!
@@ -157,6 +178,8 @@ const SLOT_BODY: &str = "body";
 const SLOT_FLOATING_ACTION_BUTTON: &str = "floating_action_button";
 /// The `snack_bar` slot id — see [`ScaffoldLayoutDelegate`].
 const SLOT_SNACK_BAR: &str = "snack_bar";
+/// The `bottom_navigation_bar` slot id — see [`ScaffoldLayoutDelegate`].
+const SLOT_BOTTOM_NAV: &str = "bottom_navigation_bar";
 /// The `drawer` slot id — see [`ScaffoldLayoutDelegate`].
 const SLOT_DRAWER: &str = "drawer";
 /// The `end_drawer` slot id — see [`ScaffoldLayoutDelegate`].
@@ -191,6 +214,7 @@ pub struct Scaffold {
     app_bar: Option<BoxedView>,
     app_bar_preferred_height: f32,
     floating_action_button: Option<BoxedView>,
+    bottom_navigation_bar: Option<BoxedView>,
     resize_to_avoid_bottom_inset: bool,
     background_color: Option<Color>,
     drawer: Option<Drawer>,
@@ -214,6 +238,7 @@ impl Scaffold {
             app_bar: None,
             app_bar_preferred_height: 0.0,
             floating_action_button: None,
+            bottom_navigation_bar: None,
             resize_to_avoid_bottom_inset: true,
             background_color: None,
             drawer: None,
@@ -253,6 +278,16 @@ impl Scaffold {
     #[must_use]
     pub fn floating_action_button(mut self, floating_action_button: impl IntoView) -> Self {
         self.floating_action_button = Some(floating_action_button.into_view().boxed());
+        self
+    }
+
+    /// Sets the bottom navigation bar (typically a [`crate::NavigationBar`]),
+    /// pinned to the bottom of the scaffold. The body shrinks to make room
+    /// above it, and the floating action button lifts above it — see the
+    /// module docs' "`bottom_navigation_bar` slot" section.
+    #[must_use]
+    pub fn bottom_navigation_bar(mut self, bottom_navigation_bar: impl IntoView) -> Self {
+        self.bottom_navigation_bar = Some(bottom_navigation_bar.into_view().boxed());
         self
     }
 
@@ -341,6 +376,10 @@ impl std::fmt::Debug for Scaffold {
             .field(
                 "has_floating_action_button",
                 &self.floating_action_button.is_some(),
+            )
+            .field(
+                "has_bottom_navigation_bar",
+                &self.bottom_navigation_bar.is_some(),
             )
             .field("has_drawer", &self.drawer.is_some())
             .field("has_end_drawer", &self.end_drawer.is_some())
@@ -501,6 +540,14 @@ impl ViewState<Scaffold> for ScaffoldState {
             if view.app_bar.is_some() {
                 reduced_media_query.padding.top = px(0.0);
             }
+            if view.bottom_navigation_bar.is_some() {
+                // Oracle: `removeBottomPadding: widget.bottomNavigationBar !=
+                // null ...` (`scaffold.dart:3032-3033`) — the nav bar already
+                // consumes `padding.bottom` internally (see the module docs'
+                // "`bottom_navigation_bar` slot" section), so the body must
+                // not also see it.
+                reduced_media_query.padding.bottom = px(0.0);
+            }
             if view.resize_to_avoid_bottom_inset {
                 reduced_media_query.view_insets.bottom = px(0.0);
             }
@@ -526,6 +573,13 @@ impl ViewState<Scaffold> for ScaffoldState {
             children.push(LayoutId::new(
                 SLOT_FLOATING_ACTION_BUTTON,
                 floating_action_button.clone(),
+            ));
+        }
+
+        if let Some(bottom_navigation_bar) = &view.bottom_navigation_bar {
+            children.push(LayoutId::new(
+                SLOT_BOTTOM_NAV,
+                bottom_navigation_bar.clone(),
             ));
         }
 
@@ -706,10 +760,11 @@ impl ScaffoldState {
 }
 
 /// The layout algorithm for [`Scaffold`]'s `app_bar` / `body` /
-/// `floating_action_button` / `snack_bar` / `drawer` / `end_drawer` slots.
+/// `floating_action_button` / `snack_bar` / `bottom_navigation_bar` /
+/// `drawer` / `end_drawer` slots.
 ///
 /// Flutter parity: `_ScaffoldLayout` (`scaffold.dart:991-1308`), narrowed to
-/// the six slots this substrate ports — see the module docs for the full
+/// the seven slots this substrate ports — see the module docs for the full
 /// deferred-slot list and the inset contract this delegate enforces.
 #[derive(Debug, Clone, PartialEq)]
 struct ScaffoldLayoutDelegate {
@@ -744,11 +799,27 @@ impl MultiChildLayoutDelegate for ScaffoldLayoutDelegate {
             ctx.position_child(SLOT_APP_BAR, Offset::ZERO);
         }
 
+        // Oracle: `bottomNavigationBarHeight = layoutChild(bottomNavigationBar,
+        // fullWidthConstraints).height; bottomWidgetsHeight +=
+        // bottomNavigationBarHeight; bottomNavigationBarTop = max(0.0, bottom
+        // - bottomWidgetsHeight)` (`scaffold.dart:1048-1055`) — measured and
+        // bottom-pinned before `content_bottom` is computed, since
+        // `content_bottom` itself depends on this height (below).
+        let mut bottom_widgets_height = px(0.0);
+        if ctx.has_child(SLOT_BOTTOM_NAV) {
+            let bottom_nav_size = ctx.layout_child(SLOT_BOTTOM_NAV, full_width_loose_height);
+            bottom_widgets_height += bottom_nav_size.height;
+            let bottom_nav_top = (size.height - bottom_widgets_height).max(px(0.0));
+            ctx.position_child(SLOT_BOTTOM_NAV, Offset::new(px(0.0), bottom_nav_top));
+        }
+
         // Oracle: `contentBottom = max(0, bottom - max(minInsets.bottom,
-        // bottomWidgetsHeight))` (`:1088-1091`) — `bottomWidgetsHeight` is
-        // always `0.0` here (no `bottomNavigationBar`/persistent-footer
-        // slot in this substrate), so it reduces to `bottom - min_insets.bottom`.
-        let content_bottom = (size.height - self.min_insets.bottom).max(px(0.0));
+        // bottomWidgetsHeight))` (`:1088-1091`) — the greater of the keyboard
+        // inset or the bottom-anchored widgets' height (here, just the
+        // bottom navigation bar — no persistent-footer slot in this
+        // substrate) wins.
+        let content_bottom =
+            (size.height - self.min_insets.bottom.max(bottom_widgets_height)).max(px(0.0));
 
         if ctx.has_child(SLOT_BODY) {
             // Loose constraints, not tight-width — see the module docs.

--- a/crates/flui-material/src/scaffold.rs
+++ b/crates/flui-material/src/scaffold.rs
@@ -23,13 +23,23 @@
 //!
 //! Mirrors the app bar's own contract (see "The inset contract" below): a
 //! [`crate::NavigationBar`] wraps its content in a `SafeArea` and consumes
-//! `MediaQuery.padding.bottom` internally (its own doc: "If this is used in
+//! `MediaQuery.padding` internally (its own doc: "If this is used in
 //! `Scaffold.bottomNavigationBar` ... the safe area padding is also added to
-//! the height automatically"). So the body's own `MediaQuery.padding.bottom`
-//! is zeroed whenever a `bottom_navigation_bar` is set (oracle:
-//! `removeBottomPadding: widget.bottomNavigationBar != null ...`,
-//! `scaffold.dart:3032-3033`) — otherwise a `SafeArea` nested in the body
-//! would double-pad the same bottom inset the nav bar already consumed.
+//! the height automatically"). Two separate insets are involved, and the
+//! oracle zeroes them at two different slots:
+//!
+//! - **The slot's OWN `padding.top` is zeroed** (oracle: `_addIfNonNull(...,
+//!   removeTopPadding: true, ...)` for `_ScaffoldSlot.bottomNavigationBar`,
+//!   `scaffold.dart:3155-3169`) — the bar's internal `SafeArea` honors all
+//!   four sides by default, so a nonzero ambient `padding.top` (e.g. a
+//!   status-bar inset that has nothing to do with a BOTTOM bar) would
+//!   otherwise inflate it to `height + padding.top + padding.bottom` instead
+//!   of the oracle's `height + padding.bottom`.
+//! - **The body's `padding.bottom` is zeroed** (oracle: `removeBottomPadding:
+//!   widget.bottomNavigationBar != null ...`, `scaffold.dart:3032-3033`) —
+//!   the bar already consumes that inset itself; a `SafeArea` nested in the
+//!   body reading the un-reduced value would double-pad.
+//!
 //! `ScaffoldLayoutDelegate` measures the bar first (full width, loose
 //! height, Flutter parity: `_ScaffoldLayout.performLayout`'s
 //! `bottomNavigationBarHeight`/`bottomWidgetsHeight`, `scaffold.dart:1048-1055`)
@@ -577,9 +587,17 @@ impl ViewState<Scaffold> for ScaffoldState {
         }
 
         if let Some(bottom_navigation_bar) = &view.bottom_navigation_bar {
+            // Oracle: `removeTopPadding: true` for `_ScaffoldSlot.bottomNavigationBar`
+            // (`scaffold.dart:3155-3169`) — see the module docs' "pads itself"
+            // section. Only `padding.top` is reduced here; `padding.bottom`
+            // passes through unreduced so the bar's own `SafeArea` can
+            // consume it (that's the whole point of this slot padding
+            // itself).
+            let mut reduced_media_query = media_query.clone();
+            reduced_media_query.padding.top = px(0.0);
             children.push(LayoutId::new(
                 SLOT_BOTTOM_NAV,
-                bottom_navigation_bar.clone(),
+                MediaQuery::new(reduced_media_query, bottom_navigation_bar.clone()),
             ));
         }
 

--- a/crates/flui-material/src/theme_data.rs
+++ b/crates/flui-material/src/theme_data.rs
@@ -459,6 +459,57 @@ pub struct SwitchThemeData {
     pub overlay_color: Option<StateColor>,
 }
 
+/// Overrides [`NavigationBar`](crate::NavigationBar)'s `_NavigationBarDefaultsM3`
+/// token defaults, one field at a time — an unset field here still falls
+/// through to `NavigationBar`'s own M3 default table (see `navigation_bar.rs`'s
+/// `navigation_bar_default_*`/`navigation_destination_default_*` functions),
+/// it does not blank the whole slot.
+///
+/// Flutter parity: `NavigationBarThemeData` (`material/navigation_bar_theme.dart`,
+/// oracle tag `3.44.0`), narrowed to the fields FLUI's `NavigationBar` actually
+/// consumes: [`height`](Self::height), [`background_color`](Self::background_color),
+/// [`elevation`](Self::elevation), [`indicator_color`](Self::indicator_color),
+/// [`icon_color`](Self::icon_color), [`label_text_style`](Self::label_text_style),
+/// [`overlay_color`](Self::overlay_color). Named deferrals (no consumer in
+/// FLUI's `NavigationBar` yet — see that module's docs for the full
+/// named-divergence list): `shadow_color`/`surface_tint_color` (`Material` has
+/// no such parameters yet — the same gap every other `Material`-backed M3
+/// component in this crate already has), `indicator_shape` (fixed at the M3
+/// `StadiumBorder` default), `label_padding` (fixed at the M3 `EdgeInsets.only(top:
+/// 4)` default), `label_behavior` (V1 always behaves as `alwaysShow` — see the
+/// module docs' "Label behavior" section for why the other two variants are
+/// deferred wholesale rather than as a half-wired enum).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct NavigationBarThemeData {
+    /// Overrides [`NavigationBar`](crate::NavigationBar)'s default height
+    /// (`80.0`).
+    pub height: Option<f32>,
+    /// Overrides [`NavigationBar`](crate::NavigationBar)'s default background
+    /// color (`ColorScheme.surfaceContainer`).
+    pub background_color: Option<Color>,
+    /// Overrides [`NavigationBar`](crate::NavigationBar)'s default elevation
+    /// (`3.0`).
+    pub elevation: Option<f32>,
+    /// Overrides [`NavigationBar`](crate::NavigationBar)'s default selection
+    /// indicator color (`ColorScheme.secondaryContainer`).
+    pub indicator_color: Option<Color>,
+    /// Overrides each [`NavigationDestination`](crate::NavigationDestination)'s
+    /// default icon color, per state (`Selected`/`Disabled` only — the M3
+    /// default table does not vary by `Hovered`/`Focused`/`Pressed`).
+    pub icon_color: Option<StateColor>,
+    /// Overrides each [`NavigationDestination`](crate::NavigationDestination)'s
+    /// default label text style, per state. `None` for a given state falls
+    /// through to `TextTheme.labelMedium` recolored by the M3 default table.
+    pub label_text_style: Option<WidgetStateProperty<Option<TextStyle>>>,
+    /// Overrides each destination's state-overlay color (the `InkWell`-shaped
+    /// hover/focus/press ramp). `None` (the default, at every tier) means no
+    /// overlay layer at all — see [`crate::ink_well`]'s own "no hardcoded
+    /// opacities" policy, which this component inherits verbatim (the oracle
+    /// itself sets no default `overlayColor` in `_NavigationBarDefaultsM3`
+    /// either).
+    pub overlay_color: Option<StateColor>,
+}
+
 /// Overrides [`Radio`](crate::Radio)'s `_RadioDefaultsM3` token defaults,
 /// one field at a time — an unset field here still falls through to
 /// `Radio`'s own M3 default table (see `radio.rs`'s `radio_default_*`
@@ -586,6 +637,10 @@ pub struct ThemeData {
     /// Overrides [`Radio`](crate::Radio)'s M3 token defaults, per field.
     /// Flutter parity: `ThemeData.radioTheme`.
     pub radio_theme: Option<RadioThemeData>,
+
+    /// Overrides [`NavigationBar`](crate::NavigationBar)'s M3 token defaults,
+    /// per field. Flutter parity: `ThemeData.navigationBarTheme`.
+    pub navigation_bar_theme: Option<NavigationBarThemeData>,
 }
 
 impl ThemeData {
@@ -613,6 +668,7 @@ impl ThemeData {
             checkbox_theme: None,
             switch_theme: None,
             radio_theme: None,
+            navigation_bar_theme: None,
         }
     }
 
@@ -640,6 +696,7 @@ impl ThemeData {
             checkbox_theme: None,
             switch_theme: None,
             radio_theme: None,
+            navigation_bar_theme: None,
         }
     }
 
@@ -730,6 +787,9 @@ impl ThemeData {
                 .or_else(|| self.checkbox_theme.clone()),
             switch_theme: overrides.switch_theme.or_else(|| self.switch_theme.clone()),
             radio_theme: overrides.radio_theme.or_else(|| self.radio_theme.clone()),
+            navigation_bar_theme: overrides
+                .navigation_bar_theme
+                .or_else(|| self.navigation_bar_theme.clone()),
         }
     }
 }
@@ -788,6 +848,8 @@ pub struct ThemeDataOverrides {
     pub switch_theme: Option<SwitchThemeData>,
     /// Replaces [`ThemeData::radio_theme`] wholesale when `Some`.
     pub radio_theme: Option<RadioThemeData>,
+    /// Replaces [`ThemeData::navigation_bar_theme`] wholesale when `Some`.
+    pub navigation_bar_theme: Option<NavigationBarThemeData>,
 }
 
 impl Default for ThemeData {
@@ -900,6 +962,7 @@ mod tests {
             assert!(theme.checkbox_theme.is_none());
             assert!(theme.switch_theme.is_none());
             assert!(theme.radio_theme.is_none());
+            assert!(theme.navigation_bar_theme.is_none());
         }
 
         assert_every_slot_unset(&ThemeData::light());
@@ -1194,5 +1257,43 @@ mod tests {
 
         let patched = base.copy_with(ThemeDataOverrides::default());
         assert_eq!(patched.radio_theme, Some(radio_theme));
+    }
+
+    /// Same shape as `copy_with_sets_input_decoration_theme_slot`, for the
+    /// `navigation_bar_theme` slot.
+    #[test]
+    fn copy_with_sets_navigation_bar_theme_slot() {
+        let base = ThemeData::light();
+        let navigation_bar_theme = NavigationBarThemeData {
+            height: Some(96.0),
+            ..Default::default()
+        };
+
+        let patched = base.copy_with(ThemeDataOverrides {
+            navigation_bar_theme: Some(navigation_bar_theme.clone()),
+            ..Default::default()
+        });
+
+        assert_eq!(patched.navigation_bar_theme, Some(navigation_bar_theme));
+        // Untouched slots stay unset, mirroring the base theme.
+        assert!(patched.radio_theme.is_none());
+    }
+
+    /// Same already-set-slot-survives-a-`None`-override proof as
+    /// `copy_with_none_preserves_an_already_set_input_decoration_theme_slot`,
+    /// for the `navigation_bar_theme` slot.
+    #[test]
+    fn copy_with_none_preserves_an_already_set_navigation_bar_theme_slot() {
+        let navigation_bar_theme = NavigationBarThemeData {
+            height: Some(96.0),
+            ..Default::default()
+        };
+        let base = ThemeData::light().copy_with(ThemeDataOverrides {
+            navigation_bar_theme: Some(navigation_bar_theme.clone()),
+            ..Default::default()
+        });
+
+        let patched = base.copy_with(ThemeDataOverrides::default());
+        assert_eq!(patched.navigation_bar_theme, Some(navigation_bar_theme));
     }
 }

--- a/crates/flui-material/src/theme_data.rs
+++ b/crates/flui-material/src/theme_data.rs
@@ -478,7 +478,13 @@ pub struct SwitchThemeData {
 /// `StadiumBorder` default), `label_padding` (fixed at the M3 `EdgeInsets.only(top:
 /// 4)` default), `label_behavior` (V1 always behaves as `alwaysShow` — see the
 /// module docs' "Label behavior" section for why the other two variants are
-/// deferred wholesale rather than as a half-wired enum).
+/// deferred wholesale rather than as a half-wired enum). [`icon_color`](Self::icon_color)
+/// is itself a further narrowing: the oracle's `iconTheme` is a full
+/// `WidgetStateProperty<IconThemeData?>` (size, color, opacity, the `fill`/
+/// `weight`/`grade`/`optical_size` font-variation axes, shadows); this slot
+/// carries only the color, since `NavigationDestination`'s icon size is
+/// pinned at the M3 default (`NAVIGATION_DESTINATION_ICON_SIZE`, `24.0`) with
+/// no override surface yet.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct NavigationBarThemeData {
     /// Overrides [`NavigationBar`](crate::NavigationBar)'s default height

--- a/crates/flui-material/tests/navigation_bar.rs
+++ b/crates/flui-material/tests/navigation_bar.rs
@@ -1,0 +1,359 @@
+//! `NavigationBar` widget-level mount/interaction coverage.
+//!
+//! Complements `navigation_bar.rs`'s own unit tests (M3 default token-table
+//! probes for icon/label color, the widget → theme → default geometry
+//! cascade) with end-to-end mount proof: the destinations lay out at equal
+//! width, a real down+up reaches [`flui_material::NavigationBar::on_destination_selected`]
+//! with the tapped index, and a `selected_index` rebuild moves which
+//! destination's indicator paints filled.
+//!
+//! **Not covered here** (see `navigation_bar.rs`'s own unit tests instead,
+//! since neither needs a render tree): the M3 default icon/label color
+//! branch order and combined-state pins, and the widget → theme → default
+//! geometry cascade (`resolve_bar_geometry`).
+//!
+//! **Semantics**: `RenderSemanticsAnnotations`'s own `Diagnosticable` surface
+//! (`crates/flui-objects/src/proxy/semantics.rs`) exposes only
+//! `container`/`explicit_child_nodes`/`exclude_semantics`/
+//! `block_user_actions`/`has_semantics` — not the finer-grained
+//! `role`/`selected`/`enabled`/`button` flags a `Semantics` builder sets, so
+//! this file proves structural presence (one annotated node per destination
+//! plus the outer tab-bar container, each carrying real semantics content),
+//! not the individual flag values.
+//!
+//! **Constraint shape matters here**: every test mounts under a *tight
+//! width, loose height* root (see [`bar_constraints`]), matching what
+//! [`crate::common`]'s harness gives any real consumer (e.g. `Scaffold`'s
+//! `bottom_navigation_bar` slot measures with `full_width_loose_height` —
+//! see `scaffold.rs`). A fully tight root defeats `NavigationBar`'s own
+//! `SizedBox::height(80)` clamp (a tight incoming height constraint wins
+//! over the local override), which would silently make every geometry
+//! assertion below test the wrong height band.
+
+mod common;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use common::{lay_out, size};
+use flui_material::{NavigationBar, NavigationDestination, Theme, ThemeData};
+use flui_rendering::constraints::BoxConstraints;
+use flui_types::geometry::px;
+use flui_widgets::icon::IconData;
+use flui_widgets::{Icon, MediaQuery, MediaQueryData};
+
+/// Tight width, loose (`0..height`) height — see the module docs' note on
+/// why a fully-tight root is the wrong shape to mount a `NavigationBar`
+/// under.
+fn bar_constraints(width: f32, height: f32) -> BoxConstraints {
+    BoxConstraints::new(px(width), px(width), px(0.0), px(height))
+}
+
+/// Every `NavigationBar` needs a [`Theme`] ancestor (`Theme::of` panics
+/// without one) and a [`MediaQuery`] ancestor (its internal `SafeArea`
+/// panics without one, same as `tests/scaffold.rs`'s app-bar coverage) —
+/// mirrors `tests/switch.rs`'s own `themed` helper, extended with the
+/// `MediaQuery` wrap this component additionally needs.
+fn themed(bar: NavigationBar) -> Theme {
+    Theme::new(
+        ThemeData::light(),
+        MediaQuery::new(MediaQueryData::default(), bar),
+    )
+}
+
+fn icon() -> Icon {
+    Icon::new(IconData::new(0xE88A))
+}
+
+fn three_destinations() -> Vec<NavigationDestination> {
+    vec![
+        NavigationDestination::new(icon(), "Home"),
+        NavigationDestination::new(icon(), "Profile"),
+        NavigationDestination::new(icon(), "Settings"),
+    ]
+}
+
+/// The `Row`'s render id — disambiguated from the 3 per-destination
+/// `Column`s (both compile to `RenderFlex`) by child count: only the Row
+/// has exactly one child per destination.
+fn row_id(laid: &common::LaidOut, destination_count: usize) -> flui_foundation::RenderId {
+    laid.find_all_by_render_type("RenderFlex")
+        .into_iter()
+        .find(|&id| laid.children(id).len() == destination_count)
+        .expect("a RenderFlex with one child per destination (the Row) must be mounted")
+}
+
+/// The Row's children, left to right — true destination order, independent
+/// of the render arena's own id-allocation order (which need not match
+/// left-to-right tree order; see the module docs).
+fn destination_cells(
+    laid: &common::LaidOut,
+    destination_count: usize,
+) -> Vec<flui_foundation::RenderId> {
+    laid.children(row_id(laid, destination_count))
+}
+
+/// The single indicator `Material` (`RenderPhysicalShape`, the only render
+/// object under a destination cell reporting a `"color"` diagnostics
+/// property) nested under `cell`.
+///
+/// # Panics
+///
+/// Panics if `cell` contains zero or more than one such node — a
+/// destination is expected to mount exactly one indicator fill.
+fn indicator_in_cell(
+    laid: &common::LaidOut,
+    cell: flui_foundation::RenderId,
+) -> flui_foundation::RenderId {
+    fn collect(
+        laid: &common::LaidOut,
+        id: flui_foundation::RenderId,
+        out: &mut Vec<flui_foundation::RenderId>,
+    ) {
+        if laid.render_property(id, "color").is_some() {
+            out.push(id);
+        }
+        for child in laid.children(id) {
+            collect(laid, child, out);
+        }
+    }
+    let mut found = Vec::new();
+    collect(laid, cell, &mut found);
+    match found.as_slice() {
+        [id] => *id,
+        other => panic!(
+            "expected exactly one color-bearing render node (the indicator) under this \
+             destination cell, found {}",
+            other.len()
+        ),
+    }
+}
+
+#[test]
+fn destinations_lay_out_at_equal_width() {
+    let laid = lay_out(
+        themed(NavigationBar::new(three_destinations())),
+        bar_constraints(300.0, 800.0),
+    );
+
+    let cells = destination_cells(&laid, 3);
+    assert_eq!(cells.len(), 3, "one Row child per destination");
+    for cell in cells {
+        assert_eq!(
+            laid.size(cell).width,
+            px(100.0),
+            "each destination must take an equal 1/3 share of the bar's width",
+        );
+        assert_eq!(
+            laid.size(cell).height,
+            px(80.0),
+            "each destination cell must span the bar's full 80dp height",
+        );
+    }
+}
+
+#[test]
+fn tap_fires_on_destination_selected_with_the_tapped_index() {
+    let observed = Rc::new(RefCell::new(None));
+    let recorder = Rc::clone(&observed);
+    let laid = lay_out(
+        themed(
+            NavigationBar::new(three_destinations()).on_destination_selected(move |index| {
+                *recorder.borrow_mut() = Some(index);
+            }),
+        ),
+        bar_constraints(300.0, 800.0),
+    );
+
+    // Each destination cell spans 100px, 80dp tall; the second
+    // destination's midpoint is (150, 40).
+    laid.dispatch_pointer_down(150.0, 40.0);
+    laid.dispatch_pointer_up(150.0, 40.0);
+
+    assert_eq!(
+        *observed.borrow(),
+        Some(1),
+        "a tap in the second destination's cell must fire on_destination_selected(1)",
+    );
+}
+
+#[test]
+fn tapping_a_disabled_destination_does_not_fire_the_callback() {
+    let observed = Rc::new(RefCell::new(None));
+    let recorder = Rc::clone(&observed);
+    let mut destinations = three_destinations();
+    destinations[1] = NavigationDestination::new(icon(), "Profile").enabled(false);
+
+    let laid = lay_out(
+        themed(
+            NavigationBar::new(destinations).on_destination_selected(move |index| {
+                *recorder.borrow_mut() = Some(index);
+            }),
+        ),
+        bar_constraints(300.0, 800.0),
+    );
+
+    laid.dispatch_pointer_down(150.0, 40.0);
+    laid.dispatch_pointer_up(150.0, 40.0);
+
+    assert_eq!(
+        *observed.borrow(),
+        None,
+        "a disabled destination must swallow the tap and never fire the callback",
+    );
+}
+
+#[test]
+fn selected_index_change_moves_the_indicator_fill() {
+    let colors = ThemeData::light().color_scheme;
+    let color_at = |laid: &common::LaidOut, id: flui_foundation::RenderId| {
+        laid.render_property(id, "color")
+            .expect("RenderPhysicalShape reports a \"color\" diagnostics property")
+    };
+    let transparent = format!("{:?}", flui_types::styling::Color::TRANSPARENT);
+    let filled = format!("{:?}", colors.secondary_container);
+
+    let mut laid = lay_out(
+        themed(NavigationBar::new(three_destinations()).selected_index(0)),
+        bar_constraints(300.0, 800.0),
+    );
+    let cells = destination_cells(&laid, 3);
+    let indicators: Vec<_> = cells
+        .iter()
+        .map(|&cell| indicator_in_cell(&laid, cell))
+        .collect();
+
+    assert_eq!(
+        color_at(&laid, indicators[0]),
+        filled,
+        "the selected (index 0) destination's indicator must be filled",
+    );
+    assert_eq!(
+        color_at(&laid, indicators[1]),
+        transparent,
+        "an unselected destination's indicator must be fully transparent",
+    );
+    assert_eq!(
+        color_at(&laid, indicators[2]),
+        transparent,
+        "an unselected destination's indicator must be fully transparent",
+    );
+
+    laid.pump_widget(themed(
+        NavigationBar::new(three_destinations()).selected_index(1),
+    ));
+    let cells_after = destination_cells(&laid, 3);
+    let indicators_after: Vec<_> = cells_after
+        .iter()
+        .map(|&cell| indicator_in_cell(&laid, cell))
+        .collect();
+
+    assert_eq!(
+        color_at(&laid, indicators_after[0]),
+        transparent,
+        "after selecting index 1, the now-unselected index 0 indicator must go transparent",
+    );
+    assert_eq!(
+        color_at(&laid, indicators_after[1]),
+        filled,
+        "after selecting index 1, its indicator must become filled",
+    );
+    assert_eq!(
+        color_at(&laid, indicators_after[2]),
+        transparent,
+        "index 2 stays unselected and its indicator must remain transparent",
+    );
+}
+
+#[test]
+fn theme_indicator_color_beats_the_m3_default() {
+    let overridden = flui_types::styling::Color::rgb(9, 9, 9);
+    let laid = lay_out(
+        themed(
+            NavigationBar::new(three_destinations())
+                .selected_index(0)
+                .indicator_color(overridden),
+        ),
+        bar_constraints(300.0, 800.0),
+    );
+
+    let cells = destination_cells(&laid, 3);
+    let indicator = indicator_in_cell(&laid, cells[0]);
+    assert_eq!(
+        laid.render_property(indicator, "color"),
+        Some(format!("{overridden:?}")),
+        "a widget-level indicator_color override must reach the selected destination's \
+         rendered fill",
+    );
+}
+
+#[test]
+fn mounting_creates_a_tab_bar_container_and_one_annotated_node_per_destination() {
+    let laid = lay_out(
+        themed(NavigationBar::new(three_destinations())),
+        bar_constraints(300.0, 800.0),
+    );
+
+    let semantics_nodes = laid.find_all_by_render_type("RenderSemanticsAnnotations");
+    // One container node for the bar itself (`SemanticsRole::TabBar`) plus
+    // one per destination (`SemanticsRole::Tab`).
+    assert_eq!(
+        semantics_nodes.len(),
+        1 + three_destinations().len(),
+        "expected one tab-bar container node plus one tab node per destination",
+    );
+
+    // `RenderSemanticsAnnotations::debug_fill_properties` only *emits* a
+    // flag property when it's true (`DiagnosticsBuilder::add_flag` omits a
+    // false flag rather than writing `"false"`) — so `container`/
+    // `has_semantics` being present at all (`Some`, any string) IS the
+    // true-flag proof; a `None` means that particular flag is unset on that
+    // node, not "not yet populated".
+    let bar_container = semantics_nodes
+        .iter()
+        .find(|&&id| laid.size(id) == size(300.0, 80.0))
+        .copied()
+        .expect("the outer tab-bar Semantics node must span the bar's full 300×80 size");
+    assert!(
+        laid.render_property(bar_container, "container").is_some(),
+        "the outer tab-bar Semantics node must set container: true",
+    );
+
+    let destination_nodes: Vec<_> = semantics_nodes
+        .into_iter()
+        .filter(|&id| id != bar_container)
+        .collect();
+    assert_eq!(destination_nodes.len(), 3, "one tab node per destination");
+    for id in destination_nodes {
+        assert!(
+            laid.render_property(id, "has_semantics").is_some(),
+            "each destination's Semantics node (role: tab, selected, enabled, button) must \
+             carry real content, not an empty passthrough",
+        );
+    }
+}
+
+#[test]
+fn bar_height_and_elevation_match_the_m3_defaults() {
+    let laid = lay_out(
+        themed(NavigationBar::new(three_destinations())),
+        bar_constraints(300.0, 800.0),
+    );
+
+    // Every destination also mounts its own (always-reserved, see
+    // `navigation_bar.rs`'s module docs) indicator `RenderPhysicalShape` at
+    // a fixed 64×32 — the bar's own background surface is the only one
+    // sized to the full bar, so size disambiguates it from the three
+    // indicators.
+    let material = laid
+        .find_all_by_render_type("RenderPhysicalShape")
+        .into_iter()
+        .find(|&id| laid.size(id) == size(300.0, 80.0))
+        .expect("NavigationBar must compose a full-size top-level Material surface");
+    assert_eq!(
+        laid.render_property(material, "elevation")
+            .and_then(|value| value.parse::<f32>().ok()),
+        Some(3.0),
+        "_NavigationBarDefaultsM3.elevation is 3.0",
+    );
+}

--- a/crates/flui-material/tests/navigation_bar.rs
+++ b/crates/flui-material/tests/navigation_bar.rs
@@ -40,7 +40,9 @@ use flui_material::{NavigationBar, NavigationDestination, Theme, ThemeData};
 use flui_rendering::constraints::BoxConstraints;
 use flui_types::geometry::px;
 use flui_widgets::icon::IconData;
-use flui_widgets::{Icon, MediaQuery, MediaQueryData};
+use flui_widgets::{
+    Icon, MediaQuery, MediaQueryData, WidgetState, WidgetStateProperty, WidgetStates,
+};
 
 /// Tight width, loose (`0..height`) height — see the module docs' note on
 /// why a fully-tight root is the wrong shape to mount a `NavigationBar`
@@ -355,5 +357,49 @@ fn bar_height_and_elevation_match_the_m3_defaults() {
             .and_then(|value| value.parse::<f32>().ok()),
         Some(3.0),
         "_NavigationBarDefaultsM3.elevation is 3.0",
+    );
+}
+
+#[test]
+fn a_callback_less_but_enabled_destination_still_paints_the_hover_overlay() {
+    // Flutter parity: `NavigationBar._handleTap` always returns a real
+    // `VoidCallback` (the real callback or a no-op), so `_IndicatorInkWell.onTap`
+    // is non-null whenever the destination is enabled — regardless of
+    // whether `onDestinationSelected` was ever set (`navigation_bar.dart:272-274`,
+    // `:606`). A destination-level `InkWell` that only wires `on_tap` when a
+    // callback is present would read as non-interactive here and never
+    // paint its overlay, even with `overlay_color` configured.
+    let hover_color = flui_types::styling::Color::rgb(9, 9, 9);
+    let mut laid = lay_out(
+        themed(NavigationBar::new(three_destinations()).overlay_color(
+            WidgetStateProperty::resolve_with(move |states: &WidgetStates| {
+                states
+                    .contains_state(WidgetState::Hovered)
+                    .then_some(hover_color)
+            }),
+        )),
+        bar_constraints(300.0, 800.0),
+    );
+
+    // Hover over the first destination's cell (x in [0, 100), y in [0, 80)).
+    // A pump is needed after the dispatch: the states-controller listener
+    // only SCHEDULES a rebuild (see `crate::ink_well`'s own
+    // `overlay_color_resolution_reflects_the_hovered_state` test, same
+    // shape), it doesn't run one synchronously.
+    laid.dispatch_pointer_move(50.0, 40.0);
+    laid.pump();
+
+    let overlays: Vec<_> = laid
+        .find_all_by_render_type("RenderPhysicalShape")
+        .into_iter()
+        .filter(|&id| laid.render_property(id, "color") == Some(format!("{hover_color:?}")))
+        .collect();
+
+    assert_eq!(
+        overlays.len(),
+        1,
+        "a destination with NO on_destination_selected callback must still be interactive \
+         (on_tap wired to a no-op, matching the oracle's _handleTap fallback) — otherwise it \
+         never registers as enabled to InkWell and the hover overlay never paints",
     );
 }

--- a/crates/flui-material/tests/scaffold.rs
+++ b/crates/flui-material/tests/scaffold.rs
@@ -16,11 +16,12 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use common::{lay_out, offset, size, tight};
-use flui_material::{AppBar, Scaffold, Theme, ThemeData};
+use flui_material::{AppBar, NavigationBar, NavigationDestination, Scaffold, Theme, ThemeData};
 use flui_types::EdgeInsets;
 use flui_types::geometry::px;
 use flui_view::prelude::*;
-use flui_widgets::{MediaQuery, MediaQueryData, SizedBox, Text};
+use flui_widgets::icon::IconData;
+use flui_widgets::{Icon, MediaQuery, MediaQueryData, SizedBox, Text};
 
 /// The render-tree node for `CustomMultiChildLayout` (the scaffold's own
 /// `Material` surface is the mounted root; this is that root's only child).
@@ -626,5 +627,55 @@ fn body_media_query_has_zero_bottom_padding_under_a_bottom_navigation_bar() {
         "the body's ambient MediaQuery.padding.bottom must be zeroed when a bottom navigation \
          bar is present — the bar already consumes that inset internally (see its own SafeArea \
          wrapping); a SafeArea nested in the body reading the un-reduced 34px would double-pad",
+    );
+}
+
+/// Real (non-stand-in) destinations for a mounted `NavigationBar` — needed
+/// specifically to prove the top-padding leak (finding below): a bare
+/// `SizedBox` stand-in can't exercise `NavigationBar`'s own internal
+/// `SafeArea`, which is exactly the mechanism under test.
+fn two_destinations() -> Vec<NavigationDestination> {
+    vec![
+        NavigationDestination::new(Icon::new(IconData::new(0xE88A)), "Home"),
+        NavigationDestination::new(Icon::new(IconData::new(0xE7FD)), "Profile"),
+    ]
+}
+
+#[test]
+fn bottom_navigation_bar_does_not_leak_the_ambient_top_padding_into_its_own_safe_area() {
+    // A nonzero `padding.top` (e.g. a status-bar inset) that has nothing to
+    // do with a BOTTOM bar. Oracle: `_ScaffoldSlot.bottomNavigationBar` is
+    // added with `removeTopPadding: true` (`scaffold.dart:3155-3169`) — the
+    // bar's own `SafeArea` must never see this inset, or it inflates the
+    // bar past its fixed 80dp height.
+    let media_query = MediaQueryData {
+        padding: EdgeInsets::new(px(24.0), px(0.0), px(0.0), px(0.0)),
+        ..MediaQueryData::default()
+    };
+    let laid = lay_out(
+        Theme::new(
+            ThemeData::light(),
+            MediaQuery::new(
+                media_query,
+                Scaffold::new()
+                    .body(SizedBox::expand())
+                    .bottom_navigation_bar(NavigationBar::new(two_destinations())),
+            ),
+        ),
+        tight(400.0, 800.0),
+    );
+
+    let layout = layout_root(&laid);
+    // No app_bar, no floating_action_button: body is child 0, the bottom
+    // navigation bar is child 1.
+    let bottom_nav = laid.child(layout, 1);
+
+    assert_eq!(
+        laid.size(bottom_nav).height,
+        px(80.0),
+        "the bottom navigation bar's own SafeArea must not ALSO consume the ambient 24px \
+         padding.top on top of its fixed 80dp height — a leaked top inset would inflate the \
+         bar to 104 instead of the oracle's height + padding.bottom (80 here, since \
+         padding.bottom is 0)",
     );
 }

--- a/crates/flui-material/tests/scaffold.rs
+++ b/crates/flui-material/tests/scaffold.rs
@@ -539,3 +539,92 @@ fn body_media_query_keeps_bottom_view_inset_when_not_resizing() {
          itself if it cares to",
     );
 }
+
+#[test]
+fn bottom_navigation_bar_shrinks_the_body_and_lifts_the_floating_action_button() {
+    let laid = lay_out(
+        Theme::new(
+            ThemeData::light(),
+            MediaQuery::new(
+                MediaQueryData::default(),
+                Scaffold::new()
+                    .body(SizedBox::expand())
+                    .floating_action_button(SizedBox::new(56.0, 56.0))
+                    .bottom_navigation_bar(SizedBox::new(400.0, 80.0)),
+            ),
+        ),
+        tight(400.0, 800.0),
+    );
+
+    let layout = layout_root(&laid);
+    let body = laid.child(layout, 0);
+    let fab = laid.child(layout, 1);
+    let bottom_nav = laid.child(layout, 2);
+
+    // content_bottom = scaffold_height(800) - max(min_insets.bottom(0),
+    // bottom_widgets_height(80)) = 720.
+    assert_eq!(
+        laid.size(body),
+        size(400.0, 720.0),
+        "the body must shrink to make room above the bottom navigation bar's measured height, \
+         not fill the full scaffold height",
+    );
+    assert_eq!(
+        laid.offset(bottom_nav),
+        offset(0.0, 720.0),
+        "the bottom navigation bar must be pinned to the bottom of the scaffold, full width",
+    );
+    assert_eq!(
+        laid.size(bottom_nav),
+        size(400.0, 80.0),
+        "the bottom navigation bar is measured at full width, loose height",
+    );
+    // bottom_content_height = scaffold_height(800) - content_bottom(720) = 80.
+    // safe_margin = max(16, 0 - 80 + 16) = 16.
+    // fab_y = content_bottom(720) - fab_height(56) - safe_margin(16) = 648.
+    assert_eq!(
+        laid.offset(fab).dy,
+        px(648.0),
+        "the floating action button must lift above the bottom navigation bar — it is \
+         positioned from content_bottom, which already folds in the bar's measured height; \
+         with no bottom-nav-aware content_bottom the FAB would sit at 800 - 56 - 16 = 728, \
+         underneath the bar",
+    );
+}
+
+#[test]
+fn body_media_query_has_zero_bottom_padding_under_a_bottom_navigation_bar() {
+    let captured = Rc::new(RefCell::new(None));
+    let probe = MediaQueryProbe {
+        captured: Rc::clone(&captured),
+    };
+    let media_query = MediaQueryData {
+        padding: EdgeInsets::new(px(0.0), px(0.0), px(34.0), px(0.0)),
+        ..MediaQueryData::default()
+    };
+
+    let _laid = lay_out(
+        Theme::new(
+            ThemeData::light(),
+            MediaQuery::new(
+                media_query,
+                Scaffold::new()
+                    .body(probe)
+                    .bottom_navigation_bar(SizedBox::new(400.0, 80.0)),
+            ),
+        ),
+        tight(400.0, 800.0),
+    );
+
+    let observed = captured
+        .borrow()
+        .clone()
+        .expect("the body must have built at least once and read an ambient MediaQuery");
+    assert_eq!(
+        observed.padding.bottom,
+        px(0.0),
+        "the body's ambient MediaQuery.padding.bottom must be zeroed when a bottom navigation \
+         bar is present — the bar already consumes that inset internally (see its own SafeArea \
+         wrapping); a SafeArea nested in the body reading the un-reduced 34px would double-pad",
+    );
+}


### PR DESCRIPTION
## Summary

M3 bottom navigation (a roadmap-named component), ported against Flutter 3.44.0 `material/{navigation_bar,navigation_bar_theme,scaffold}.dart`.

- **`NavigationBar`** — destinations/selected_index/on_destination_selected, 80dp `_NavigationBarDefaultsM3` surface (surfaceContainer, elevation 3), equal-width Row, alwaysShow labels (the labelBehavior enum fully deferred — nothing half-wired).
- **`NavigationDestination`** — 64×32 secondaryContainer Stadium indicator (snap show/hide), icon colors disabled→selected(onSecondaryContainer)→onSurfaceVariant, labels labelMedium with **selected→onSurface** (the builder corrected the brief's wrong assumption against the oracle), `SemanticsRole::Tab`/`TabBar` direct port, whole-cell InkWell with **unconditionally-wired tap** (review-caught: a callback-less bar must still paint press overlays, `_handleTap` parity).
- **Theme-tier resolution with PURE state sets** (review-caught contract violation: the oracle queries exactly `{disabled}` for a disabled destination — a combined `{Selected|Disabled}` set let a Selected Map entry shadow the Disabled one).
- **Scaffold `bottom_navigation_bar` slot** — `bottomWidgetsHeight` folded into `contentBottom` per the oracle's exact max() chain (FAB influence flows entirely through contentBottom — verified `FabFloatOffsetY` has no separate term), body `padding.bottom` zeroed, and the slot child gets the oracle's **removeTopPadding** MediaQuery reduction (review-caught: NavigationBar's internal SafeArea otherwise ate the ambient top inset, inflating the bar to 80+top+bottom on notched devices — pinned under a nonzero top inset).
- `NavigationBarThemeData` with the full slot convention; icon-size narrowing named. Test methodology note: destination order is walked from the Row's children (the render arena's flat enumeration is not left-to-right — discovered and corrected in-session).

### Review trail
Builder (self-corrected the label token against the oracle) → full review (2 parity bugs: top-inset inflation, combined-state theme resolution; + tap wiring and a doc narrowing) → fix pass with per-finding mutation evidence.

### Gates
Workspace nextest 7174 passed / 4 skipped · workspace clippy `-D warnings` clean · doc gate clean · port-check/inventory/fmt/taplo/typos · doctests 617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvkSGveJwxLVuygRAGVKuz