### PR TITLE
feat(material): M3 Chip family — Chip + FilterChip

### DIFF
--- a/crates/flui-material/src/chip.rs
+++ b/crates/flui-material/src/chip.rs
@@ -121,10 +121,55 @@
 //! precedent this crate's `checkbox::CheckboxPainter`'s own module docs
 //! describe.
 //!
+//! # Disabled content: steady-state 38% opacity, no fade
+//!
+//! The oracle wraps a chip's avatar (`_paintAvatar`) and separately its
+//! label/delete icon (`_paintChild`) each in their own `pushOpacity` (or an
+//! equivalent `saveLayer`) at `_disabledColor.alpha`, gated on
+//! `!enableAnimation.isCompleted` (`chip.dart` `:2199-2231`/`:2236-2275`,
+//! oracle tag `3.44.0`) — and that gate is true not only *during* an
+//! enable/disable transition but for the entire steady-state lifetime of a
+//! chip that is (and stays) disabled, since `enableController` never runs
+//! `forward()` for it. `_disabledColor.alpha` itself resolves to
+//! `_kDisabledAlpha` (`0x61`, `chip.dart`) whenever `enableAnimation` is not
+//! completed, `0xff` (opaque) once it is. This V1 has no
+//! `enableController`/`AnimationController` to run at all (see the
+//! "Deferred" list below), but the *steady-state* alpha is still real,
+//! observable behavior a disabled chip must show — not merely a transition
+//! artifact safe to snap away. So [`Chip`]/[`FilterChip`] wrap their
+//! composed avatar/label/delete content (never the container fill or
+//! border, which the oracle's `Ink`/`ShapeDecoration` painting never wraps
+//! in this opacity layer either) in one [`flui_widgets::Opacity`] at the
+//! private `DISABLED_CONTENT_ALPHA` when disabled, `1.0` when enabled — a single
+//! group wrap rather than the oracle's three separate `pushOpacity` calls,
+//! which is equivalent here since every one of those three calls uses the
+//! identical alpha value (there is no per-slot variation to preserve by
+//! keeping them separate).
+//!
+//! # Nested tap targets: a local `GestureArenaScope`
+//!
+//! The delete icon's `InkWell` sits nested inside the chip body's own
+//! `InkWell` — two independent tappable regions on one hit-test path. A
+//! bare `GestureDetector` with no ambient `GestureArenaScope` above it
+//! builds its recognizers against a private arena it closes itself, which
+//! is exactly right when it's the only detector in play but means two such
+//! *standalone* detectors on the same path resolve completely
+//! independently: a tap on the delete icon would fire both `on_deleted` and
+//! the chip's own `on_pressed`/`on_selected`. Both [`Chip`] and
+//! [`FilterChip`] close this by wrapping their whole built subtree in a
+//! fresh, local `GestureArenaScope` (see this module's own
+//! `wrap_local_gesture_arena`) so the two `InkWell`s genuinely compete —
+//! confirmed by mounting a real tree and dispatching a real tap (see
+//! `tests/chip.rs`'s delete-vs-chip-tap coverage), not merely inferred from
+//! the tap-vs-long-press precedent `crates/flui-widgets/tests/gesture_detector_advanced.rs`
+//! establishes for a different pair of gesture types.
+//!
 //! # Deferred (named, not silently dropped)
 //!
-//! - **Avatar/delete/selection/enable animation** — every transition snaps;
-//!   see the sections above.
+//! - **Avatar/delete/selection/enable animation** — every transition snaps
+//!   directly to its settled end state (including the disabled-content
+//!   opacity — see the "Disabled content" section above: the *value* is
+//!   ported, the *fade into/out of* it is not); see the sections above.
 //! - **Elevated variants** (`FilterChip.elevated`, and any chip's non-zero
 //!   `elevation`/`pressElevation`) — V1 is flat-only, elevation fixed at
 //!   `0.0`.
@@ -163,7 +208,8 @@ use flui_view::prelude::*;
 use flui_widgets::icon::IconData;
 use flui_widgets::{
     ConstrainedBox, CrossAxisAlignment, CustomPaint, CustomPainter, DefaultTextStyle, Icon,
-    IconTheme, IconThemeData, MainAxisSize, Padding, Row, Semantics, WidgetState, WidgetStates,
+    IconTheme, IconThemeData, MainAxisSize, Opacity, Padding, Row, Semantics, WidgetState,
+    WidgetStates,
 };
 
 use crate::color_scheme::ColorScheme;
@@ -209,6 +255,20 @@ const DELETE_ICON_CANCEL_CODEPOINT: u32 = 0xE139;
 /// (`const Icon(Icons.clear, size: 18)`, `filter_chip.dart`, oracle tag
 /// `3.44.0`).
 const DELETE_ICON_CLEAR_CODEPOINT: u32 = 0xE168;
+
+/// The opacity a disabled chip's avatar/label/delete content settles at.
+/// Flutter parity: `_kDisabledAlpha` (`chip.dart`, `0x61`) — see the module
+/// docs' "Disabled content" section for why this is steady-state behavior,
+/// not merely a transition artifact this V1 is entitled to snap away.
+const DISABLED_CONTENT_ALPHA: f32 = 0x61 as f32 / 255.0;
+
+/// The content opacity for a chip in `enabled`'s state — `1.0` enabled,
+/// [`DISABLED_CONTENT_ALPHA`] disabled. Extracted as its own pure function
+/// (not left inline in `build`) so the two-value table is unit-testable
+/// without mounting a widget tree.
+fn disabled_content_opacity(enabled: bool) -> f32 {
+    if enabled { 1.0 } else { DISABLED_CONTENT_ALPHA }
+}
 
 // Compile-time geometry invariant (not a runtime test — every side is
 // `const`): the default padding must leave room for a positive content
@@ -272,11 +332,17 @@ fn resolve_pure_chip_default(
 }
 
 /// The label and delete-icon color default table. Flutter parity:
-/// `_ChipDefaultsM3.labelStyle`/`.deleteIconColor` and
-/// `_FilterChipDefaultsM3.labelStyle`/`.deleteIconColor` (`chip.dart`/
-/// `filter_chip.dart`, oracle tag `3.44.0`) — both fields resolve to the
-/// identical three colors in both files, so one function serves all four
-/// call sites.
+/// `_FilterChipDefaultsM3.labelStyle`/`.deleteIconColor` (`filter_chip.dart`,
+/// oracle tag `3.44.0`) — the real three-way (`disabled`/`selected`/`else`)
+/// table. `_ChipDefaultsM3.labelStyle`/`.deleteIconColor` (`chip.dart`) has
+/// **no** `isSelected` member at all — it is a plain two-way `isEnabled ?
+/// onSurfaceVariant : onSurface` ternary, since a bare `Chip` is never
+/// selected. That two-way table's `enabled` value is identical to this
+/// function's `unselected` branch, and [`Chip`]'s own [`chip_states`] call
+/// site never sets [`WidgetState::Selected`] (see [`chip_icon_color_default`]'s
+/// doc comment for the same note) — so reusing this one function for both
+/// [`Chip`] and [`FilterChip`] is safe, but is not itself evidence that
+/// `_ChipDefaultsM3` has a selected branch.
 fn chip_content_color_default(states: WidgetStates, colors: &ColorScheme) -> Color {
     resolve_pure_chip_default(
         states,
@@ -287,12 +353,15 @@ fn chip_content_color_default(states: WidgetStates, colors: &ColorScheme) -> Col
 }
 
 /// The avatar and checkmark icon color default table. Flutter parity:
-/// `_ChipDefaultsM3.iconTheme.color` and `_FilterChipDefaultsM3.iconTheme.color`/
-/// `.checkmarkColor` (`chip.dart`/`filter_chip.dart`, oracle tag `3.44.0`) —
-/// all three resolve to the identical three colors, so one function serves
-/// every call site. [`Chip`]'s own states never carry `Selected` (see
-/// [`chip_states`]'s call site in [`Chip`]'s build), so the `selected`
-/// branch is simply unreachable there rather than needing its own function.
+/// `_FilterChipDefaultsM3.iconTheme.color`/`.checkmarkColor`
+/// (`filter_chip.dart`, oracle tag `3.44.0`) — the real three-way
+/// (`disabled`/`selected`/`else`) table. `_ChipDefaultsM3.iconTheme.color`
+/// (`chip.dart`) has **no** `isSelected` member — it is a plain two-way
+/// `isEnabled ? primary : onSurface` ternary. That two-way table's `enabled`
+/// value is identical to this function's `unselected` branch, and
+/// [`Chip`]'s own states never carry `Selected` (see [`chip_states`]'s call
+/// site in [`Chip`]'s build), so the `selected` branch is simply
+/// unreachable there rather than evidence `_ChipDefaultsM3` itself has one.
 fn chip_icon_color_default(states: WidgetStates, colors: &ColorScheme) -> Color {
     resolve_pure_chip_default(
         states,
@@ -303,9 +372,14 @@ fn chip_icon_color_default(states: WidgetStates, colors: &ColorScheme) -> Color 
 }
 
 /// The container border default table. Flutter parity:
-/// `_ChipDefaultsM3.side`/`_FilterChipDefaultsM3.side` (flat variant only —
-/// see the module docs), `chip.dart`/`filter_chip.dart`, oracle tag
-/// `3.44.0`.
+/// `_FilterChipDefaultsM3.side` (flat variant only — see the module docs),
+/// `filter_chip.dart`, oracle tag `3.44.0` — the real `selected`-gated
+/// table. `_ChipDefaultsM3.side` (`chip.dart`) has **no** `isSelected`
+/// member — it is a plain two-way `isEnabled ? outlineVariant :
+/// onSurface@12%` ternary, since a bare `Chip` is never selected; that
+/// two-way table agrees with this function's `enabled`/`disabled`
+/// (unselected) branches, so [`Chip`] safely calls this same function with
+/// `selected` pinned to `false`.
 ///
 /// **Combined-state, not pure**: `selected` is checked FIRST and wins
 /// unconditionally (a selected chip's side is transparent whether or not it
@@ -554,6 +628,7 @@ impl StatelessView for Chip {
             label_padding,
             delete_view,
         );
+        let content = Opacity::new(disabled_content_opacity(self.enabled)).child(content);
 
         let padded_content = Padding::new(padding).child(
             ConstrainedBox::new(chip_content_constraints(padding, label_padding)).child(content),
@@ -575,10 +650,12 @@ impl StatelessView for Chip {
             )
             .child(Material::new(background_color).shape(shape).child(ink_well));
 
-        Semantics::new()
-            .button(self.on_pressed.is_some())
-            .enabled(self.enabled)
-            .child(container)
+        wrap_local_gesture_arena(
+            Semantics::new()
+                .button(self.on_pressed.is_some())
+                .enabled(self.enabled)
+                .child(container),
+        )
     }
 }
 
@@ -831,6 +908,7 @@ impl StatelessView for FilterChip {
             label_padding,
             delete_view,
         );
+        let content = Opacity::new(disabled_content_opacity(enabled)).child(content);
 
         let padded_content = Padding::new(padding).child(
             ConstrainedBox::new(chip_content_constraints(padding, label_padding)).child(content),
@@ -852,11 +930,13 @@ impl StatelessView for FilterChip {
             )
             .child(Material::new(background_color).shape(shape).child(ink_well));
 
-        Semantics::new()
-            .selected(selected)
-            .button(true)
-            .enabled(enabled)
-            .child(container)
+        wrap_local_gesture_arena(
+            Semantics::new()
+                .selected(selected)
+                .button(true)
+                .enabled(enabled)
+                .child(container),
+        )
     }
 }
 
@@ -898,6 +978,43 @@ fn chip_content_constraints(padding: EdgeInsets, label_padding: EdgeInsets) -> B
     )
 }
 
+/// Wraps a chip's whole built subtree in a fresh, local
+/// [`flui_widgets::GestureArenaScope`] so its two nested [`InkWell`]s (the
+/// delete button, inside the outer chip-body [`InkWell`]) genuinely compete
+/// for a tap instead of both firing.
+///
+/// [`flui_widgets::GestureDetector`]'s own module docs document the
+/// fallback this closes a real gap in: with **no** ambient
+/// `GestureArenaScope` above it, a `GestureDetector` builds its recognizers
+/// against a *private* arena it closes itself — correct in isolation, but
+/// when TWO such standalone detectors both sit on the same hit-test path
+/// (exactly what a delete icon nested inside a tappable chip produces), each
+/// resolves its own tap independently, so a tap on the delete icon fires
+/// BOTH `on_deleted` and the chip's own `on_pressed`/`on_selected`. Neither
+/// `flui-app`'s binding nor any ancestor this crate's components mount
+/// installs a `GestureArenaScope` anywhere today — confirmed by grepping the
+/// workspace for it outside `flui-widgets` itself — so a real app has this
+/// exact double-fire bug for any nested tap targets, not just this one.
+/// Fixing that project-wide is out of scope here; this closes it locally,
+/// the same way any composed widget with more than one nested tap target
+/// must.
+///
+/// Constructing a fresh [`flui_interaction::arena::GestureArena::new`] on
+/// every `build()` call is safe despite [`Chip`]/[`FilterChip`] being
+/// stateless (no persistent slot to cache it in): a descendant
+/// `GestureDetector` reads its ambient scope exactly once, in its own
+/// `init_state` (first mount) — see that type's own "Arena acquisition" doc
+/// section — never on a later rebuild. So only the arena captured at first
+/// mount is ever actually used; every subsequent rebuild's
+/// freshly-constructed (and immediately discarded)
+/// [`flui_interaction::arena::GestureArena`] is inert. This mirrors the
+/// same "cheap to reconstruct, only the first read matters" contract
+/// `GestureArenaScope::update_should_notify` documents (always `false`)
+/// already relies on.
+fn wrap_local_gesture_arena(child: impl IntoView) -> flui_widgets::GestureArenaScope {
+    flui_widgets::GestureArenaScope::new(flui_interaction::arena::GestureArena::new(), child)
+}
+
 /// Strokes a chip's resolved [`MaterialShape`] as an inset ring — the same
 /// `Canvas::draw_drrect`-between-two-insets approach the private
 /// `CheckboxPainter` (`checkbox.rs`) uses for its own stroked box, see the
@@ -933,14 +1050,22 @@ impl CustomPainter for ChipBorderPainter {
 
 /// Paints the settled (non-animated) checkmark [`FilterChip`] shows in its
 /// leading slot while selected — a direct port of the oracle's own
-/// relative-coordinate stroke path at its fully-settled shape. Flutter
-/// parity: `_RenderChip._paintCheck` (`chip.dart` `:2125-2172`, oracle tag
-/// `3.44.0`) evaluated at `t == 1.0` (the full `start -> mid -> end`
-/// polyline, no animated partial stroke) — the same "real stroked
-/// geometry, `t == 1.0`" precedent the private `CheckboxPainter`'s
-/// (`checkbox.rs`) own module docs describe, and in fact the identical relative
-/// coordinates (`0.15, 0.45` / `0.4, 0.7` / `0.85, 0.25`) that painter's
-/// own `draw_checkmark` uses.
+/// relative-coordinate stroke path at its fully-settled shape, scaled down
+/// and centered exactly as the oracle does. Flutter parity:
+/// `_RenderChip._paintSelectionOverlay`/`._paintCheck` (`chip.dart`
+/// `:2174-2195`/`:2125-2172`, oracle tag `3.44.0`) evaluated at `t == 1.0`
+/// (the full `start -> mid -> end` polyline, no animated partial stroke) —
+/// the same "real stroked geometry, `t == 1.0`" precedent the private
+/// `CheckboxPainter`'s (`checkbox.rs`) own module docs describe, using the
+/// identical relative coordinates (`0.15, 0.45` / `0.4, 0.7` / `0.85,
+/// 0.25`) that painter's own `draw_checkmark` uses — but, unlike that full-
+/// cell checkmark, scaled to `checkSize = avatar.size.height * 0.75` and
+/// offset by `avatar.size.height * 0.125` on both axes ("a little smaller
+/// than the avatar", `_paintSelectionOverlay`'s own comment, `:2188-2192`):
+/// this painter's `size` is the full leading-slot cell (avatar's own size),
+/// so the checkmark itself must be drawn at 75% of that cell, inset by
+/// 12.5% on each side — drawing at the full cell size would be ~33%
+/// oversized and pinned to the wrong corner.
 #[derive(Debug, Clone, Copy, PartialEq)]
 struct ChipCheckmarkPainter {
     color: Color,
@@ -948,17 +1073,23 @@ struct ChipCheckmarkPainter {
 
 impl CustomPainter for ChipCheckmarkPainter {
     fn paint(&self, canvas: &mut Canvas, size: Size) {
+        let cell = size.height.get();
         // Flutter parity: `_kCheckmarkStrokeWidth * avatar.size.height /
-        // 24.0` (`chip.dart`).
-        let stroke_width = 2.0 * size.height.get() / 24.0;
+        // 24.0` (`chip.dart`) — the FULL cell height, not `check_size`.
+        let stroke_width = 2.0 * cell / 24.0;
         let paint = Paint::stroke(self.color, stroke_width);
 
-        let point = |dx: f32, dy: f32| Point::new(px(dx), px(dy));
-        let edge = size.height.get();
+        // Flutter parity: `checkSize = avatar.size.height * 0.75` and the
+        // `avatar.size.height * 0.125` origin offset on both axes
+        // (`_paintSelectionOverlay`, `chip.dart` `:2188-2192`) — see this
+        // struct's own doc comment.
+        let check_size = cell * 0.75;
+        let origin_offset = cell * 0.125;
+        let point = |dx: f32, dy: f32| Point::new(px(origin_offset + dx), px(origin_offset + dy));
         let mut path = Path::new();
-        path.move_to(point(edge * 0.15, edge * 0.45));
-        path.line_to(point(edge * 0.4, edge * 0.7));
-        path.line_to(point(edge * 0.85, edge * 0.25));
+        path.move_to(point(check_size * 0.15, check_size * 0.45));
+        path.line_to(point(check_size * 0.4, check_size * 0.7));
+        path.line_to(point(check_size * 0.85, check_size * 0.25));
         canvas.draw_path(&path, &paint);
     }
 
@@ -977,7 +1108,6 @@ impl CustomPainter for ChipCheckmarkPainter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::theme_data::ChipThemeData;
 
     fn light() -> ColorScheme {
         ColorScheme::light()
@@ -1300,6 +1430,26 @@ mod tests {
         assert_eq!(height, px(0.0));
     }
 
+    // ------------------------------------------------------------------
+    // disabled_content_opacity — the steady-state 38% alpha, not a fade
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn disabled_content_opacity_enabled_is_fully_opaque() {
+        assert_eq!(disabled_content_opacity(true), 1.0);
+    }
+
+    /// Flutter parity: `_kDisabledAlpha` (`0x61`, `chip.dart`) as a `0.0..=1.0`
+    /// fraction. Mutation-run: hardcoding this to `1.0` (i.e. dropping the
+    /// disabled dimming entirely, the pre-fix shape) was confirmed to make
+    /// this test fail.
+    #[test]
+    fn disabled_content_opacity_disabled_is_the_m3_disabled_alpha() {
+        let opacity = disabled_content_opacity(false);
+        assert!((opacity - 0x61 as f32 / 255.0).abs() < f32::EPSILON);
+        assert_ne!(opacity, 1.0);
+    }
+
     #[test]
     fn default_shape_is_an_8dp_rounded_rectangle() {
         let size = Size::new(px(80.0), px(CHIP_HEIGHT));
@@ -1324,39 +1474,20 @@ mod tests {
         assert_eq!(padding.left, px(LABEL_PADDING_HORIZONTAL));
     }
 
-    // ------------------------------------------------------------------
-    // Theme tier beats default (plain-override cascade)
-    // ------------------------------------------------------------------
-
-    #[test]
-    fn theme_label_color_beats_the_default() {
-        let theme_color = Color::rgb(9, 9, 9);
-        let resolved = Some(theme_color)
-            .or_else(|| Some(chip_content_color_default(WidgetStates::NONE, &light())));
-        assert_eq!(resolved, Some(theme_color));
-    }
-
-    #[test]
-    fn theme_side_beats_the_default() {
-        let theme_side = BorderSide::new(Color::rgb(3, 3, 3), px(2.0), BorderStyle::Solid);
-        let chip_theme = ChipThemeData {
-            side: Some(theme_side),
-            ..Default::default()
-        };
-        let resolved = chip_theme
-            .side
-            .unwrap_or_else(|| chip_default_side(false, true, &light()));
-        assert_eq!(resolved, theme_side);
-    }
-
-    #[test]
-    fn no_theme_falls_through_to_the_default_side() {
-        let chip_theme = ChipThemeData::default();
-        let resolved = chip_theme
-            .side
-            .unwrap_or_else(|| chip_default_side(false, true, &light()));
-        assert_eq!(resolved, chip_default_side(false, true, &light()));
-    }
+    // Theme tier beats default (the widget/theme/default cascade for
+    // `label_color`/`side`) is proven through a REAL mount + `Chip::build`
+    // call in `tests/chip.rs` (`theme_label_color_reaches_the_mounted_paragraph_beating_the_default`/
+    // `theme_side_reaches_the_mounted_border_painter_beating_the_default`,
+    // plus their `no_theme_override_paints_the_m3_default_*` companions),
+    // not here: `ChipThemeData`'s fields are plain overrides (see the
+    // module docs), so a unit-level probe of the cascade can only
+    // re-implement `Option::or_else`/`unwrap_or_else` inline — exercising
+    // `std::option`, not `chip.rs`'s own `build()` wiring. A previous
+    // version of this test module carried exactly that vacuous shape; it
+    // was replaced, not merely supplemented, because it could not fail
+    // against a real wiring bug (confirmed: mutating `Chip::build` to drop
+    // the `chip_theme.label_color`/`.side` read entirely left the old
+    // in-module tests green).
 
     // ------------------------------------------------------------------
     // Painters
@@ -1422,6 +1553,82 @@ mod tests {
                 .iter()
                 .any(|command| matches!(command, DrawCommand::DrawPath { .. }))
         );
+    }
+
+    /// Pins the oracle's `checkSize = avatar.size.height * 0.75` scale-down
+    /// and `avatar.size.height * 0.125` origin offset
+    /// (`_paintSelectionOverlay`, `chip.dart` `:2188-2192`, oracle tag
+    /// `3.44.0`) — the mark must sit strictly inside a `0.125..0.875`
+    /// (75%-wide, centered) window of the full cell, not fill it edge to
+    /// edge. Mutation-run: reverting `ChipCheckmarkPainter::paint` to the
+    /// pre-fix version (`check_size`/`origin_offset` both dropped, the full
+    /// `cell` used directly, matching the original shipped bug) was
+    /// confirmed to make this test fail: `min x: got 2.7, expected 4.275`
+    /// (the mutant's un-scaled `0.15 * 18.0` vs. this test's scaled-and-
+    /// offset expectation) — the first of the four bound assertions below,
+    /// which stops the run before the other three (`max_x = 15.3` vs.
+    /// `13.725`, etc.) are reached, but the same un-scaled arithmetic
+    /// diverges from every one of them identically.
+    #[test]
+    fn checkmark_painter_scales_to_75_percent_and_centers_within_the_cell() {
+        use flui_painting::display_list::DrawCommand;
+
+        let cell = CHIP_ICON_SIZE;
+        let painter = ChipCheckmarkPainter {
+            color: Color::BLACK,
+        };
+        let mut canvas = Canvas::new();
+        painter.paint(&mut canvas, Size::new(px(cell), px(cell)));
+
+        let mut path = canvas
+            .display_list()
+            .iter()
+            .find_map(|command| match command {
+                DrawCommand::DrawPath { path, .. } => Some(path.clone()),
+                _ => None,
+            })
+            .expect("checkmark painter must emit a DrawPath command");
+        let bounds = path.bounds();
+
+        let check_size = cell * 0.75;
+        let origin_offset = cell * 0.125;
+        // The oracle's three stroke points: start (0.15, 0.45), mid (0.4,
+        // 0.7), end (0.85, 0.25) — the tight bounding box over all three is
+        // exactly [start.x, end.x] x [end.y, mid.y] (`0.15`/`0.85` bound x,
+        // `0.25`/`0.7` bound y).
+        let expected_min_x = origin_offset + check_size * 0.15;
+        let expected_max_x = origin_offset + check_size * 0.85;
+        let expected_min_y = origin_offset + check_size * 0.25;
+        let expected_max_y = origin_offset + check_size * 0.7;
+
+        let epsilon = 0.01;
+        assert!(
+            (bounds.min_x().get() - expected_min_x).abs() < epsilon,
+            "min x: got {}, expected {expected_min_x}",
+            bounds.min_x().get()
+        );
+        assert!(
+            (bounds.max_x().get() - expected_max_x).abs() < epsilon,
+            "max x: got {}, expected {expected_max_x}",
+            bounds.max_x().get()
+        );
+        assert!(
+            (bounds.min_y().get() - expected_min_y).abs() < epsilon,
+            "min y: got {}, expected {expected_min_y}",
+            bounds.min_y().get()
+        );
+        assert!(
+            (bounds.max_y().get() - expected_max_y).abs() < epsilon,
+            "max y: got {}, expected {expected_max_y}",
+            bounds.max_y().get()
+        );
+
+        // The whole mark must stay strictly inside the cell — never
+        // touching the full-cell edges the pre-fix version reached.
+        assert!(bounds.max_x().get() < cell);
+        assert!(bounds.max_y().get() < cell);
+        assert!(bounds.min_x().get() > 0.0);
+        assert!(bounds.min_y().get() > 0.0);
     }
 
     #[test]

--- a/crates/flui-material/src/chip.rs
+++ b/crates/flui-material/src/chip.rs
@@ -1,0 +1,1437 @@
+//! [`Chip`] and [`FilterChip`] — the M3 chip family V1: a compact,
+//! outlined/filled information element with an optional leading avatar and
+//! trailing delete affordance.
+//!
+//! # Flutter parity
+//!
+//! `material/chip.dart`'s `Chip`/`RawChip`/`_ChipDefaultsM3`,
+//! `material/chip_theme.dart`'s `ChipThemeData`, and
+//! `material/filter_chip.dart`'s `FilterChip`/`_FilterChipDefaultsM3` (oracle
+//! tag `3.44.0`).
+//!
+//! # V1 scope: `RawChip`, honestly reduced
+//!
+//! The oracle's chip family is one `RawChip` state machine that every
+//! concrete chip type (`Chip`, `InputChip`, `ChoiceChip`, `FilterChip`,
+//! `ActionChip`) configures differently. FLUI does not port `RawChip` itself
+//! — it ports the two shapes this V1 ships, [`Chip`] and [`FilterChip`],
+//! each composing the same reduced primitives ([`Material`], [`InkWell`],
+//! shared default-token functions in this module) directly. `InputChip`,
+//! `ChoiceChip`, and `ActionChip` are named deferrals: each is a thin
+//! `RawChip` reconfiguration the same shared functions already support, they
+//! just have no constructor yet.
+//!
+//! No `assist_chip.dart` file exists at this oracle tag — M3's "assist chip"
+//! shape is realized by `ActionChip`'s own `_ActionChipDefaultsM3`, a
+//! variant `_ChipDefaultsM3` this V1 does not port. [`Chip`] instead ports
+//! `_ChipDefaultsM3` directly (`RawChip`'s own generic fallback default
+//! table, the one `Chip.build` implicitly gets since it passes no
+//! `defaultProperties`) and widens it with an optional
+//! [`Chip::on_pressed`] — the oracle's bare `Chip` never exposes `onPressed`
+//! (`ActionChip` owns that), but `RawChip` itself already supports it, and a
+//! tappable "assist-shaped" chip is exactly what this task calls for. This
+//! is a deliberate, documented widening of `Chip`'s surface beyond the
+//! oracle's own `Chip`, not a divergence in `_ChipDefaultsM3`'s token
+//! values.
+//!
+//! Similarly, [`Chip::enabled`] surfaces `RawChip.isEnabled` directly (the
+//! oracle's `Chip.build` never varies it — it is always `true`) so the M3
+//! default table's disabled branch is reachable and testable on this V1
+//! type, matching the task's expected disabled-state coverage.
+//!
+//! # `ChipThemeData`: plain overrides, not `WidgetStateProperty`
+//!
+//! Unlike [`crate::CheckboxThemeData`]/[`crate::SwitchThemeData`]/
+//! [`crate::RadioThemeData`]/[`crate::NavigationBarThemeData`], whose color
+//! slots are all `Option<WidgetStateProperty<Option<Color>>>` — because
+//! their own oracle theme types (`checkbox_theme.dart` and siblings)
+//! genuinely type those fields as `WidgetStateProperty`, [`crate::ChipThemeData`]'s
+//! fields are **plain** (`Option<Color>`, `Option<BorderSide<Pixels>>`, …).
+//! This mirrors `chip_theme.dart` exactly: every `ChipThemeData` field
+//! except `color` (the container fill, not ported to the theme tier here —
+//! see below) is a plain, non-resolved value in the oracle too. Per-state
+//! variation for label/icon/delete-icon color is entirely a property of the
+//! `_ChipDefaultsM3`/`_FilterChipDefaultsM3` *default* tables (each
+//! reconstructed fresh per build with the current `isEnabled`/`isSelected`
+//! already closed over — so their getters return already-resolved plain
+//! values, not deferred per-state properties); the theme/widget tiers above
+//! that default only ever override with one fixed value, never a function
+//! of state.
+//!
+//! This has a structural benefit beyond fidelity: with no
+//! `WidgetStateProperty::Map` anywhere in [`crate::ChipThemeData`], the
+//! first-match-wins map-ordering hazard [`crate::NavigationBar`]'s own
+//! module docs warn about (a `Map` ordered `[Is(Selected), Is(Disabled),
+//! Any]`, queried with a combined `{Selected, Disabled}` set, resolving the
+//! wrong entry) cannot occur here at all — there is no map to order
+//! wrong. The only place this module builds a [`WidgetStates`] query set is
+//! `chip_states` (this module, private), which — like
+//! `navigation_bar::navigation_destination_states` (also private) — returns
+//! a **pure** single-state set (`{Disabled}` xor `{Selected}` xor `{}`,
+//! never both), used solely to walk the M3 default tables' own `disabled >
+//! selected > else` branch order for label/icon/delete-icon color. The
+//! container fill color and the border `side` both have a genuinely
+//! *combined*-state-dependent M3 default (see this module's own
+//! `filter_chip_default_background_color` and `chip_default_side`
+//! functions) that a pure query cannot express — both are implemented as
+//! plain `(bool, bool)`-parameterized functions instead, with no
+//! [`WidgetStates`]/`WidgetStateProperty` involved, sidestepping the hazard
+//! class entirely rather than papering over it.
+//!
+//! `color` (the container fill) is not exposed as a [`crate::ChipThemeData`]
+//! slot in V1: its M3 default has a real three-way branch (disabled-only,
+//! selected-only, and a *third*, distinct disabled-AND-selected value — see
+//! this module's own `filter_chip_default_background_color`) that only a
+//! genuinely combined-state query can reproduce, which is exactly the shape
+//! a caller-supplied `WidgetStateProperty` override could get wrong. Named
+//! deferral, not a silent gap.
+//!
+//! # Container: `CustomPaint` foreground border, `Material` fill
+//!
+//! [`Material`] fills, clips, and elevates but paints no border side (see
+//! that module's shape docs) — the same gap [`crate::OutlinedButton`] left
+//! unpainted. [`Chip`]'s outline is load-bearing (the base chip has no fill
+//! at all — `_ChipDefaultsM3.color` is `null`, i.e. transparent, so the
+//! stroke is the only visible container boundary), so this V1 draws it
+//! directly: a [`flui_widgets::CustomPaint`] wraps the [`Material`] subtree
+//! with a `foreground_painter` that strokes the resolved [`MaterialShape`]
+//! as an inset ring (`Canvas::draw_drrect` between the outer shape and an
+//! inward-inset copy) — the same real-geometry approach this crate's
+//! `checkbox::CheckboxPainter` (private) already established for a stroked
+//! rounded shape, extended from a fixed-size leaf painter to a
+//! child-sized container border. `CustomPaint` sizes to its child when one
+//! is present, so the border painter always strokes at the exact size the
+//! `Material`/`InkWell`/content subtree settles on.
+//!
+//! # Selection: checkmark replaces the avatar, snapped
+//!
+//! The oracle animates a selected [`FilterChip`]'s leading slot between the
+//! avatar and an overlaid checkmark (`AnimationController`-driven
+//! avatar-drawer width plus a `srcATop`-blended darkening scrim under the
+//! check, `chip.dart`'s `_paintSelectionOverlay`). This V1 **snaps**: no
+//! animation, and the checkmark *replaces* the avatar in the leading slot
+//! rather than painting an overlay on top of it (see this module's own
+//! `filter_chip_leading_content`) — a further reduction than the oracle's
+//! own overlay shape, chosen because painting a darkening scrim over an
+//! arbitrary caller-supplied avatar widget has no home in this substrate's
+//! paint primitives yet. The checkmark geometry itself (`ChipCheckmarkPainter`,
+//! this module, private) is a direct, honest port of the oracle's own
+//! relative-coordinate stroke path (`_paintCheck`, `chip.dart`) at its
+//! fully-settled shape — the same "real stroked geometry, `t == 1.0`"
+//! precedent this crate's `checkbox::CheckboxPainter`'s own module docs
+//! describe.
+//!
+//! # Deferred (named, not silently dropped)
+//!
+//! - **Avatar/delete/selection/enable animation** — every transition snaps;
+//!   see the sections above.
+//! - **Elevated variants** (`FilterChip.elevated`, and any chip's non-zero
+//!   `elevation`/`pressElevation`) — V1 is flat-only, elevation fixed at
+//!   `0.0`.
+//! - **`InputChip`, `ChoiceChip`, `ActionChip`** — see the "V1 scope"
+//!   section above.
+//! - **Custom `delete_icon` widget override** — the delete affordance
+//!   always renders the M3 default glyph (`Icons.cancel` for [`Chip`],
+//!   `Icons.clear` for [`FilterChip`] — see `_kDefaultDeleteIcon` and
+//!   `FilterChip.build`'s own `resolvedDeleteIcon`, both `chip.dart`/
+//!   `filter_chip.dart`).
+//! - **Delete-button tooltip** (`deleteButtonTooltipMessage`,
+//!   `MaterialLocalizations.deleteButtonTooltip`) — no localization
+//!   substrate consumes it yet.
+//! - **RTL** — the content `Row` always lays out left-to-right; no
+//!   `Directionality` ambient in this substrate yet (the same gap
+//!   [`flui_widgets::Icon`]'s own docs already name).
+//! - **`focus_node`/`autofocus`** — [`InkWell`] itself has no `autofocus`
+//!   hook yet, matching every other selection-control's own deferred list.
+//! - **`avatarBoxConstraints`/`deleteIconBoxConstraints`** — the avatar
+//!   sizes intrinsically (no forced square constraint); the delete icon is
+//!   fixed at [`CHIP_ICON_SIZE`].
+//! - **Material elevation interplay, press elevation** — elevation is fixed
+//!   at `0.0` for both types in V1 (matches "flat only").
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+use flui_rendering::constraints::BoxConstraints;
+use flui_rendering::pipeline::Canvas;
+use flui_types::geometry::px;
+use flui_types::painting::{Paint, Path};
+use flui_types::styling::{BorderSide, BorderStyle};
+use flui_types::typography::TextStyle;
+use flui_types::{Color, EdgeInsets, Pixels, Point, Size};
+use flui_view::prelude::*;
+use flui_widgets::icon::IconData;
+use flui_widgets::{
+    ConstrainedBox, CrossAxisAlignment, CustomPaint, CustomPainter, DefaultTextStyle, Icon,
+    IconTheme, IconThemeData, MainAxisSize, Padding, Row, Semantics, WidgetState, WidgetStates,
+};
+
+use crate::color_scheme::ColorScheme;
+use crate::ink_well::InkWell;
+use crate::material::Material;
+use crate::shape::MaterialShape;
+use crate::theme::Theme;
+
+/// The container's target height when its content fits within it. Flutter
+/// parity: `_kChipHeight` (`chip.dart`, oracle tag `3.44.0`).
+pub const CHIP_HEIGHT: f32 = 32.0;
+
+/// The container's corner radius. Flutter parity: `_ChipDefaultsM3.shape` /
+/// `_FilterChipDefaultsM3`'s constructor, both
+/// `RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8.0)))`.
+const CORNER_RADIUS: f32 = 8.0;
+
+/// The avatar/delete-icon/checkmark side length. Flutter parity:
+/// `_ChipDefaultsM3.iconTheme`/`_FilterChipDefaultsM3.iconTheme`'s
+/// `size: 18.0`.
+pub const CHIP_ICON_SIZE: f32 = 18.0;
+
+/// The default container padding. Flutter parity: `_ChipDefaultsM3.padding`/
+/// `_FilterChipDefaultsM3.padding`, `EdgeInsets.all(8.0)`.
+const PADDING: f32 = 8.0;
+
+/// The default label padding (horizontal only). Flutter parity: the
+/// text-scale-1x tier of `_ChipDefaultsM3.labelPadding`/
+/// `_FilterChipDefaultsM3.labelPadding`, `EdgeInsets.symmetric(horizontal:
+/// 8.0)` — the text-scaler-driven 8px-to-4px interpolation is a named V1
+/// simplification (no `MediaQuery` text-scaling substrate consumed here,
+/// the same gap [`crate::elevated_button`]'s own `scaled_padding_1x` docs
+/// already name for button padding).
+const LABEL_PADDING_HORIZONTAL: f32 = 8.0;
+
+/// `Icons.cancel`'s codepoint (`MaterialIcons`), [`Chip`]'s default delete
+/// glyph. Flutter parity: `_kDefaultDeleteIcon = Icon(Icons.cancel)`
+/// (`chip.dart`, oracle tag `3.44.0`).
+const DELETE_ICON_CANCEL_CODEPOINT: u32 = 0xE139;
+
+/// `Icons.clear`'s codepoint (`MaterialIcons`), [`FilterChip`]'s default
+/// delete glyph. Flutter parity: `FilterChip.build`'s `resolvedDeleteIcon`
+/// (`const Icon(Icons.clear, size: 18)`, `filter_chip.dart`, oracle tag
+/// `3.44.0`).
+const DELETE_ICON_CLEAR_CODEPOINT: u32 = 0xE168;
+
+// Compile-time geometry invariant (not a runtime test — every side is
+// `const`): the default padding must leave room for a positive content
+// height inside the target container height.
+const _: () = assert!(PADDING * 2.0 < CHIP_HEIGHT);
+
+fn cancel_icon_data() -> IconData {
+    IconData::new(DELETE_ICON_CANCEL_CODEPOINT).with_font_family("MaterialIcons")
+}
+
+fn clear_icon_data() -> IconData {
+    IconData::new(DELETE_ICON_CLEAR_CODEPOINT).with_font_family("MaterialIcons")
+}
+
+/// Builds the PURE (never-combined) [`WidgetStates`] query set the M3
+/// default tables' `disabled > selected > else` branch order resolves
+/// against.
+///
+/// Flutter parity: this is the same shape the private
+/// `navigation_destination_states` helper (`navigation_bar.rs`) establishes,
+/// applied here for the identical reason — `_ChipDefaultsM3`/
+/// `_FilterChipDefaultsM3`'s label/icon/delete-icon-color getters all read
+/// as a plain `isEnabled ? (isSelected ? A : B) : C` ternary (disabled
+/// always wins, selected only distinguishes within the enabled branch),
+/// never a state genuinely carrying both `Selected` and `Disabled` at once
+/// for those fields. A combined query would risk resolving the wrong branch
+/// through a `WidgetStateProperty::Map`-shaped consumer (see the module
+/// docs) even though [`crate::ChipThemeData`] itself has no such field
+/// today.
+///
+/// **Not** used for the container fill color or the border `side`, both of
+/// which have a genuinely combined-state-dependent M3 default that this
+/// pure set cannot express — see [`filter_chip_default_background_color`]
+/// and [`chip_default_side`].
+fn chip_states(selected: bool, enabled: bool) -> WidgetStates {
+    if !enabled {
+        WidgetStates::from(WidgetState::Disabled)
+    } else if selected {
+        WidgetStates::from(WidgetState::Selected)
+    } else {
+        WidgetStates::NONE
+    }
+}
+
+/// Resolves a pure `disabled > selected > else` M3 default against
+/// [`chip_states`]'s query set. Shared by every chip default-table function
+/// that has this exact branch shape (see [`chip_states`]'s doc comment).
+fn resolve_pure_chip_default(
+    states: WidgetStates,
+    disabled: Color,
+    selected: Color,
+    unselected: Color,
+) -> Color {
+    if states.contains_state(WidgetState::Disabled) {
+        disabled
+    } else if states.contains_state(WidgetState::Selected) {
+        selected
+    } else {
+        unselected
+    }
+}
+
+/// The label and delete-icon color default table. Flutter parity:
+/// `_ChipDefaultsM3.labelStyle`/`.deleteIconColor` and
+/// `_FilterChipDefaultsM3.labelStyle`/`.deleteIconColor` (`chip.dart`/
+/// `filter_chip.dart`, oracle tag `3.44.0`) — both fields resolve to the
+/// identical three colors in both files, so one function serves all four
+/// call sites.
+fn chip_content_color_default(states: WidgetStates, colors: &ColorScheme) -> Color {
+    resolve_pure_chip_default(
+        states,
+        colors.on_surface,
+        colors.on_secondary_container,
+        colors.on_surface_variant,
+    )
+}
+
+/// The avatar and checkmark icon color default table. Flutter parity:
+/// `_ChipDefaultsM3.iconTheme.color` and `_FilterChipDefaultsM3.iconTheme.color`/
+/// `.checkmarkColor` (`chip.dart`/`filter_chip.dart`, oracle tag `3.44.0`) —
+/// all three resolve to the identical three colors, so one function serves
+/// every call site. [`Chip`]'s own states never carry `Selected` (see
+/// [`chip_states`]'s call site in [`Chip`]'s build), so the `selected`
+/// branch is simply unreachable there rather than needing its own function.
+fn chip_icon_color_default(states: WidgetStates, colors: &ColorScheme) -> Color {
+    resolve_pure_chip_default(
+        states,
+        colors.on_surface,
+        colors.on_secondary_container,
+        colors.primary,
+    )
+}
+
+/// The container border default table. Flutter parity:
+/// `_ChipDefaultsM3.side`/`_FilterChipDefaultsM3.side` (flat variant only —
+/// see the module docs), `chip.dart`/`filter_chip.dart`, oracle tag
+/// `3.44.0`.
+///
+/// **Combined-state, not pure**: `selected` is checked FIRST and wins
+/// unconditionally (a selected chip's side is transparent whether or not it
+/// is also disabled) — unlike [`chip_content_color_default`]/
+/// [`chip_icon_color_default`], `disabled` does NOT take priority here. A
+/// disabled-and-selected chip's side is `transparent` (the selected
+/// branch), not the disabled-only `onSurface@12%` a pure `disabled`-first
+/// query would give — confirmed against a deliberately `disabled`-first
+/// branch order, which fails
+/// `default_side_selected_and_disabled_stays_transparent_not_the_disabled_color`.
+/// Because of this real branch-order difference, `side` is resolved from
+/// plain `(bool, bool)` parameters rather than a [`WidgetStates`] query —
+/// see the module docs' "`ChipThemeData`: plain overrides" section.
+fn chip_default_side(selected: bool, enabled: bool, colors: &ColorScheme) -> BorderSide<Pixels> {
+    if selected {
+        BorderSide::new(Color::TRANSPARENT, px(1.0), BorderStyle::Solid)
+    } else if enabled {
+        BorderSide::new(colors.outline_variant, px(1.0), BorderStyle::Solid)
+    } else {
+        BorderSide::new(
+            colors.on_surface.with_opacity(0.12),
+            px(1.0),
+            BorderStyle::Solid,
+        )
+    }
+}
+
+/// The default container shape: an 8dp rounded rectangle. Flutter parity:
+/// `_ChipDefaultsM3`/`_FilterChipDefaultsM3`'s constructor `shape:`.
+fn chip_default_shape() -> MaterialShape {
+    use flui_types::styling::BorderRadius;
+    MaterialShape::RoundedRect(BorderRadius::all(flui_types::geometry::Radius::circular(
+        px(CORNER_RADIUS),
+    )))
+}
+
+/// The default container padding: `EdgeInsets.all(8.0)`. Flutter parity:
+/// `_ChipDefaultsM3.padding`/`_FilterChipDefaultsM3.padding`.
+fn chip_default_padding() -> EdgeInsets {
+    EdgeInsets::all(px(PADDING))
+}
+
+/// The default label padding: `EdgeInsets.symmetric(horizontal: 8.0)` — the
+/// text-scale-1x tier (see the module doc on [`LABEL_PADDING_HORIZONTAL`]).
+fn chip_default_label_padding() -> EdgeInsets {
+    EdgeInsets::symmetric(px(0.0), px(LABEL_PADDING_HORIZONTAL))
+}
+
+/// The container's minimum content height (excludes `padding`, includes
+/// `label_padding`'s own vertical inset). Flutter parity: `_RenderChip
+/// ._computeSizes`'s `contentSize` floor, `math.max(_kChipHeight -
+/// theme.padding.vertical + theme.labelPadding.vertical, ...)` (`chip.dart`
+/// `:1953-1956`, oracle tag `3.44.0`) — narrowed to just the floor term
+/// (the `rawLabelSize.height + labelPadding.vertical` alternative is the
+/// label's own intrinsic height, which this substrate's plain
+/// `ConstrainedBox` + `Row` composition already accommodates by growing
+/// past the floor when the label needs more room, without needing to
+/// compute `rawLabelSize` up front).
+fn chip_content_min_height(padding: EdgeInsets, label_padding: EdgeInsets) -> Pixels {
+    let floor = CHIP_HEIGHT - padding.vertical_total().get() + label_padding.vertical_total().get();
+    px(floor.max(0.0))
+}
+
+/// A tap/press callback taking no arguments. `Rc`-based (owner-local, per
+/// ADR-0027) — matches [`InkWell::on_tap`]'s own callback shape.
+type ChipTapCallback = Rc<dyn Fn()>;
+
+/// A selection-change callback: the next selected value. `Rc`-based, same
+/// shape as [`ChipTapCallback`].
+type FilterChipSelectCallback = Rc<dyn Fn(bool)>;
+
+/// A Material Design chip: a compact label with an optional leading avatar
+/// and trailing delete affordance, outlined and unfilled by default.
+///
+/// See the module docs for the V1 scope (a reduced `RawChip`, an
+/// [`Chip::on_pressed`] widening beyond the oracle's own non-interactive
+/// `Chip`) and named deferrals.
+///
+/// ```rust
+/// use flui_material::Chip;
+/// use flui_widgets::Text;
+///
+/// let _info = Chip::new(Text::new("Tag"));
+/// let _pressable = Chip::new(Text::new("Tag")).on_pressed(|| {});
+/// let _deletable = Chip::new(Text::new("Tag")).on_deleted(|| {});
+/// ```
+#[derive(Clone, StatelessView)]
+pub struct Chip {
+    label: BoxedView,
+    avatar: Option<BoxedView>,
+    on_pressed: Option<ChipTapCallback>,
+    on_deleted: Option<ChipTapCallback>,
+    enabled: bool,
+}
+
+impl std::fmt::Debug for Chip {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Chip")
+            .field("has_avatar", &self.avatar.is_some())
+            .field("is_pressable", &self.is_pressable())
+            .field("has_delete_button", &self.has_delete_button())
+            .field("enabled", &self.enabled)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Chip {
+    /// A `Chip` showing `label`, enabled, with no avatar, press handler, or
+    /// delete handler.
+    pub fn new(label: impl IntoView) -> Self {
+        Self {
+            label: BoxedView(Box::new(label.into_view())),
+            avatar: None,
+            on_pressed: None,
+            on_deleted: None,
+            enabled: true,
+        }
+    }
+
+    /// Sets the leading avatar (typically a small icon or image).
+    #[must_use]
+    pub fn avatar(mut self, avatar: impl IntoView) -> Self {
+        self.avatar = Some(BoxedView(Box::new(avatar.into_view())));
+        self
+    }
+
+    /// Sets the press handler. Presence of a handler is what makes this
+    /// chip tappable — see the module docs' "V1 scope" section.
+    #[must_use]
+    pub fn on_pressed(mut self, callback: impl Fn() + 'static) -> Self {
+        self.on_pressed = Some(Rc::new(callback));
+        self
+    }
+
+    /// Sets the delete handler. Presence of a handler is what shows the
+    /// trailing delete icon. Flutter parity: `Chip.onDeleted`.
+    #[must_use]
+    pub fn on_deleted(mut self, callback: impl Fn() + 'static) -> Self {
+        self.on_deleted = Some(Rc::new(callback));
+        self
+    }
+
+    /// Sets whether this chip responds to interaction. Defaults to `true`.
+    /// Flutter parity: `RawChip.isEnabled` (the oracle's own `Chip` never
+    /// varies this — see the module docs).
+    #[must_use]
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    fn is_pressable(&self) -> bool {
+        self.enabled && self.on_pressed.is_some()
+    }
+
+    fn has_delete_button(&self) -> bool {
+        self.on_deleted.is_some()
+    }
+}
+
+impl StatelessView for Chip {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        let theme = Theme::of(ctx);
+        let colors = theme.color_scheme;
+        let chip_theme = theme.chip_theme.clone();
+
+        let states = chip_states(false, self.enabled);
+
+        let label_color = chip_theme
+            .as_ref()
+            .and_then(|t| t.label_color)
+            .unwrap_or_else(|| chip_content_color_default(states, &colors));
+        let label_style = theme
+            .text_theme
+            .label_large
+            .clone()
+            .unwrap_or_default()
+            .with_color(label_color);
+
+        let icon_color = chip_theme
+            .as_ref()
+            .and_then(|t| t.icon_color)
+            .unwrap_or_else(|| chip_icon_color_default(states, &colors));
+
+        let delete_icon_color = chip_theme
+            .as_ref()
+            .and_then(|t| t.delete_icon_color)
+            .unwrap_or_else(|| chip_content_color_default(states, &colors));
+
+        let side = chip_theme
+            .as_ref()
+            .and_then(|t| t.side)
+            .unwrap_or_else(|| chip_default_side(false, self.enabled, &colors));
+
+        let shape = chip_theme
+            .as_ref()
+            .and_then(|t| t.shape)
+            .unwrap_or_else(chip_default_shape);
+
+        let padding = chip_theme
+            .as_ref()
+            .and_then(|t| t.padding)
+            .unwrap_or_else(chip_default_padding);
+
+        let label_padding = chip_theme
+            .as_ref()
+            .and_then(|t| t.label_padding)
+            .unwrap_or_else(chip_default_label_padding);
+
+        // `_ChipDefaultsM3.color => null` — the base chip has no fill; see
+        // the module docs' "Container" section.
+        let background_color = Color::TRANSPARENT;
+
+        let avatar_view = self.avatar.clone().map(|avatar| {
+            IconTheme::new(
+                IconThemeData {
+                    size: Some(CHIP_ICON_SIZE),
+                    color: Some(icon_color),
+                    ..IconThemeData::default()
+                },
+                avatar,
+            )
+            .boxed()
+        });
+
+        let delete_view = self.on_deleted.clone().map(|on_deleted| {
+            let mut delete_button = InkWell::new(IconTheme::new(
+                IconThemeData {
+                    size: Some(CHIP_ICON_SIZE),
+                    color: Some(delete_icon_color),
+                    ..IconThemeData::default()
+                },
+                Icon::new(cancel_icon_data()),
+            ))
+            .shape(MaterialShape::Stadium);
+            if self.enabled {
+                delete_button = delete_button.on_tap(move || on_deleted());
+            }
+            delete_button.boxed()
+        });
+
+        let content = build_chip_row(
+            avatar_view,
+            self.label.clone(),
+            label_style,
+            label_padding,
+            delete_view,
+        );
+
+        let padded_content = Padding::new(padding).child(
+            ConstrainedBox::new(chip_content_constraints(padding, label_padding)).child(content),
+        );
+
+        let mut ink_well = InkWell::new(padded_content).shape(shape);
+        if self.is_pressable() {
+            let on_pressed = self.on_pressed.clone();
+            ink_well = ink_well.on_tap(move || {
+                if let Some(handler) = &on_pressed {
+                    handler();
+                }
+            });
+        }
+
+        let container = CustomPaint::new()
+            .foreground_painter(
+                Arc::new(ChipBorderPainter { side, shape }) as Arc<dyn CustomPainter>
+            )
+            .child(Material::new(background_color).shape(shape).child(ink_well));
+
+        Semantics::new()
+            .button(self.on_pressed.is_some())
+            .enabled(self.enabled)
+            .child(container)
+    }
+}
+
+/// The M3 filter chip: a toggleable chip showing a leading checkmark (in
+/// place of the avatar — see the module docs' "Selection" section) when
+/// [`FilterChip::selected`].
+///
+/// See the module docs for the V1 scope (flat variant only) and named
+/// deferrals.
+///
+/// ```rust
+/// use flui_material::FilterChip;
+/// use flui_widgets::Text;
+///
+/// let _chip = FilterChip::new(Text::new("Vegetarian"))
+///     .selected(true)
+///     .on_selected(|_next| { /* ... */ });
+/// let _disabled = FilterChip::new(Text::new("Vegetarian"));
+/// ```
+#[derive(Clone, StatelessView)]
+pub struct FilterChip {
+    label: BoxedView,
+    avatar: Option<BoxedView>,
+    selected: bool,
+    on_selected: Option<FilterChipSelectCallback>,
+    on_deleted: Option<ChipTapCallback>,
+}
+
+impl std::fmt::Debug for FilterChip {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FilterChip")
+            .field("selected", &self.selected)
+            .field("has_avatar", &self.avatar.is_some())
+            .field("is_interactive", &self.on_selected.is_some())
+            .field("has_delete_button", &self.on_deleted.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl FilterChip {
+    /// A `FilterChip` showing `label`, unselected, disabled (no
+    /// [`Self::on_selected`] set yet), with no avatar or delete handler.
+    pub fn new(label: impl IntoView) -> Self {
+        Self {
+            label: BoxedView(Box::new(label.into_view())),
+            avatar: None,
+            selected: false,
+            on_selected: None,
+            on_deleted: None,
+        }
+    }
+
+    /// Sets the leading avatar shown while unselected. Replaced by a
+    /// checkmark while selected — see the module docs' "Selection" section.
+    #[must_use]
+    pub fn avatar(mut self, avatar: impl IntoView) -> Self {
+        self.avatar = Some(BoxedView(Box::new(avatar.into_view())));
+        self
+    }
+
+    /// Sets whether this chip is currently selected.
+    #[must_use]
+    pub fn selected(mut self, selected: bool) -> Self {
+        self.selected = selected;
+        self
+    }
+
+    /// Sets the selection-change handler, fired with the next selected
+    /// value on tap. Presence of a handler is what makes this chip
+    /// interactive — Flutter parity: `FilterChip.isEnabled => onSelected !=
+    /// null`.
+    #[must_use]
+    pub fn on_selected(mut self, callback: impl Fn(bool) + 'static) -> Self {
+        self.on_selected = Some(Rc::new(callback));
+        self
+    }
+
+    /// Sets the delete handler. Presence of a handler is what shows the
+    /// trailing delete icon.
+    #[must_use]
+    pub fn on_deleted(mut self, callback: impl Fn() + 'static) -> Self {
+        self.on_deleted = Some(Rc::new(callback));
+        self
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.on_selected.is_some()
+    }
+}
+
+/// Which widget occupies a filter chip's leading slot. See
+/// [`filter_chip_leading_content`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FilterChipLeading {
+    /// Selected: a checkmark, regardless of whether an avatar is set — see
+    /// the module docs' "Selection" section.
+    Checkmark,
+    /// Unselected, with an avatar set.
+    Avatar,
+    /// Unselected, no avatar.
+    None,
+}
+
+/// Decides the leading slot's content — a pure decision function so the
+/// avatar/checkmark swap is unit-testable without mounting a widget tree.
+/// Flutter parity: `_layoutAvatar`'s `showCheckmark`/`showAvatar` branch
+/// (`chip.dart`, oracle tag `3.44.0`), reduced to "checkmark wins outright
+/// when selected" per the module docs' "Selection" section (the oracle
+/// itself keeps both children present and blends between them; V1 shows
+/// exactly one).
+fn filter_chip_leading_content(selected: bool, has_avatar: bool) -> FilterChipLeading {
+    if selected {
+        FilterChipLeading::Checkmark
+    } else if has_avatar {
+        FilterChipLeading::Avatar
+    } else {
+        FilterChipLeading::None
+    }
+}
+
+/// The container fill color default table (flat variant only — see the
+/// module docs). Flutter parity: `_FilterChipDefaultsM3.color`
+/// (`filter_chip.dart` `:341-361`, oracle tag `3.44.0`).
+///
+/// **Genuinely combined-state, not pure**: disabled-and-selected resolves
+/// to its own distinct value (`onSurface@12%`), different from BOTH plain
+/// `disabled` (`transparent` — no default color, the same "no fill" the
+/// base [`Chip`] has) and plain `selected` (`secondaryContainer`). A pure
+/// `disabled`-first-then-`selected` query cannot express this third
+/// outcome, which is why this function takes `(bool, bool)` directly
+/// rather than a [`WidgetStates`] set — see the module docs'
+/// `ChipThemeData` section.
+fn filter_chip_default_background_color(
+    selected: bool,
+    enabled: bool,
+    colors: &ColorScheme,
+) -> Color {
+    match (selected, enabled) {
+        (true, false) => colors.on_surface.with_opacity(0.12),
+        (true, true) => colors.secondary_container,
+        // Unselected resolves to no fill either way — enabled and disabled
+        // are genuinely the same value here (unlike the selected column
+        // above), matching `_FilterChipDefaultsM3.color`'s own `null`
+        // fall-through for both unselected branches.
+        (false, false | true) => Color::TRANSPARENT,
+    }
+}
+
+impl StatelessView for FilterChip {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        let theme = Theme::of(ctx);
+        let colors = theme.color_scheme;
+        let chip_theme = theme.chip_theme.clone();
+        let enabled = self.is_enabled();
+        let selected = self.selected;
+
+        let states = chip_states(selected, enabled);
+
+        let label_color = chip_theme
+            .as_ref()
+            .and_then(|t| t.label_color)
+            .unwrap_or_else(|| chip_content_color_default(states, &colors));
+        let label_style = theme
+            .text_theme
+            .label_large
+            .clone()
+            .unwrap_or_default()
+            .with_color(label_color);
+
+        let icon_color = chip_theme
+            .as_ref()
+            .and_then(|t| t.icon_color)
+            .unwrap_or_else(|| chip_icon_color_default(states, &colors));
+
+        let checkmark_color = chip_theme
+            .as_ref()
+            .and_then(|t| t.checkmark_color)
+            .unwrap_or_else(|| chip_icon_color_default(states, &colors));
+
+        let delete_icon_color = chip_theme
+            .as_ref()
+            .and_then(|t| t.delete_icon_color)
+            .unwrap_or_else(|| chip_content_color_default(states, &colors));
+
+        let side = chip_theme
+            .as_ref()
+            .and_then(|t| t.side)
+            .unwrap_or_else(|| chip_default_side(selected, enabled, &colors));
+
+        let shape = chip_theme
+            .as_ref()
+            .and_then(|t| t.shape)
+            .unwrap_or_else(chip_default_shape);
+
+        let padding = chip_theme
+            .as_ref()
+            .and_then(|t| t.padding)
+            .unwrap_or_else(chip_default_padding);
+
+        let label_padding = chip_theme
+            .as_ref()
+            .and_then(|t| t.label_padding)
+            .unwrap_or_else(chip_default_label_padding);
+
+        let background_color = filter_chip_default_background_color(selected, enabled, &colors);
+
+        let leading = match filter_chip_leading_content(selected, self.avatar.is_some()) {
+            FilterChipLeading::Checkmark => Some(
+                CustomPaint::new()
+                    .size(Size::new(px(CHIP_ICON_SIZE), px(CHIP_ICON_SIZE)))
+                    .painter(Arc::new(ChipCheckmarkPainter {
+                        color: checkmark_color,
+                    }) as Arc<dyn CustomPainter>)
+                    .boxed(),
+            ),
+            FilterChipLeading::Avatar => self.avatar.clone().map(|avatar| {
+                IconTheme::new(
+                    IconThemeData {
+                        size: Some(CHIP_ICON_SIZE),
+                        color: Some(icon_color),
+                        ..IconThemeData::default()
+                    },
+                    avatar,
+                )
+                .boxed()
+            }),
+            FilterChipLeading::None => None,
+        };
+
+        let delete_view = self.on_deleted.clone().map(|on_deleted| {
+            let mut delete_button = InkWell::new(IconTheme::new(
+                IconThemeData {
+                    size: Some(CHIP_ICON_SIZE),
+                    color: Some(delete_icon_color),
+                    ..IconThemeData::default()
+                },
+                Icon::new(clear_icon_data()),
+            ))
+            .shape(MaterialShape::Stadium);
+            if enabled {
+                delete_button = delete_button.on_tap(move || on_deleted());
+            }
+            delete_button.boxed()
+        });
+
+        let content = build_chip_row(
+            leading,
+            self.label.clone(),
+            label_style,
+            label_padding,
+            delete_view,
+        );
+
+        let padded_content = Padding::new(padding).child(
+            ConstrainedBox::new(chip_content_constraints(padding, label_padding)).child(content),
+        );
+
+        let mut ink_well = InkWell::new(padded_content).shape(shape);
+        if enabled {
+            let on_selected = self.on_selected.clone();
+            ink_well = ink_well.on_tap(move || {
+                if let Some(handler) = &on_selected {
+                    handler(!selected);
+                }
+            });
+        }
+
+        let container = CustomPaint::new()
+            .foreground_painter(
+                Arc::new(ChipBorderPainter { side, shape }) as Arc<dyn CustomPainter>
+            )
+            .child(Material::new(background_color).shape(shape).child(ink_well));
+
+        Semantics::new()
+            .selected(selected)
+            .button(true)
+            .enabled(enabled)
+            .child(container)
+    }
+}
+
+/// Assembles a chip's `leading? / label / delete?` content row. Shared by
+/// [`Chip`] and [`FilterChip`] — the only difference between the two is
+/// what `leading` resolves to.
+fn build_chip_row(
+    leading: Option<BoxedView>,
+    label: BoxedView,
+    label_style: TextStyle,
+    label_padding: EdgeInsets,
+    delete: Option<BoxedView>,
+) -> Row {
+    let mut children: Vec<BoxedView> = Vec::new();
+    if let Some(leading) = leading {
+        children.push(leading);
+    }
+    children.push(
+        Padding::new(label_padding)
+            .child(DefaultTextStyle::new(label_style, label))
+            .boxed(),
+    );
+    if let Some(delete) = delete {
+        children.push(delete);
+    }
+    Row::new(children)
+        .main_axis_size(MainAxisSize::Min)
+        .cross_axis_alignment(CrossAxisAlignment::Center)
+}
+
+/// The `ConstrainedBox` constraints imposing [`chip_content_min_height`]'s
+/// floor on the content row.
+fn chip_content_constraints(padding: EdgeInsets, label_padding: EdgeInsets) -> BoxConstraints {
+    BoxConstraints::new(
+        px(0.0),
+        Pixels::INFINITY,
+        chip_content_min_height(padding, label_padding),
+        Pixels::INFINITY,
+    )
+}
+
+/// Strokes a chip's resolved [`MaterialShape`] as an inset ring — the same
+/// `Canvas::draw_drrect`-between-two-insets approach the private
+/// `CheckboxPainter` (`checkbox.rs`) uses for its own stroked box, see the
+/// module docs' "Container" section for why this substitutes for
+/// [`Material`]'s own missing border-side paint path.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct ChipBorderPainter {
+    side: BorderSide<Pixels>,
+    shape: MaterialShape,
+}
+
+impl CustomPainter for ChipBorderPainter {
+    fn paint(&self, canvas: &mut Canvas, size: Size) {
+        if !self.side.style.is_solid() || self.side.width.get() <= 0.0 {
+            return;
+        }
+        let outer = self.shape.to_rrect(size);
+        let inner = outer.inflate(px(-self.side.width.get()));
+        canvas.draw_drrect(outer, inner, &Paint::fill(self.side.color));
+    }
+
+    fn should_repaint(&self, old_delegate: &dyn CustomPainter) -> bool {
+        old_delegate
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_none_or(|old| old != self)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Paints the settled (non-animated) checkmark [`FilterChip`] shows in its
+/// leading slot while selected — a direct port of the oracle's own
+/// relative-coordinate stroke path at its fully-settled shape. Flutter
+/// parity: `_RenderChip._paintCheck` (`chip.dart` `:2125-2172`, oracle tag
+/// `3.44.0`) evaluated at `t == 1.0` (the full `start -> mid -> end`
+/// polyline, no animated partial stroke) — the same "real stroked
+/// geometry, `t == 1.0`" precedent the private `CheckboxPainter`'s
+/// (`checkbox.rs`) own module docs describe, and in fact the identical relative
+/// coordinates (`0.15, 0.45` / `0.4, 0.7` / `0.85, 0.25`) that painter's
+/// own `draw_checkmark` uses.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct ChipCheckmarkPainter {
+    color: Color,
+}
+
+impl CustomPainter for ChipCheckmarkPainter {
+    fn paint(&self, canvas: &mut Canvas, size: Size) {
+        // Flutter parity: `_kCheckmarkStrokeWidth * avatar.size.height /
+        // 24.0` (`chip.dart`).
+        let stroke_width = 2.0 * size.height.get() / 24.0;
+        let paint = Paint::stroke(self.color, stroke_width);
+
+        let point = |dx: f32, dy: f32| Point::new(px(dx), px(dy));
+        let edge = size.height.get();
+        let mut path = Path::new();
+        path.move_to(point(edge * 0.15, edge * 0.45));
+        path.line_to(point(edge * 0.4, edge * 0.7));
+        path.line_to(point(edge * 0.85, edge * 0.25));
+        canvas.draw_path(&path, &paint);
+    }
+
+    fn should_repaint(&self, old_delegate: &dyn CustomPainter) -> bool {
+        old_delegate
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_none_or(|old| old != self)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::theme_data::ChipThemeData;
+
+    fn light() -> ColorScheme {
+        ColorScheme::light()
+    }
+
+    // ------------------------------------------------------------------
+    // Construction / builder surface
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn chip_new_leaves_every_override_unset_enabled_and_not_interactive() {
+        let chip = Chip::new(flui_widgets::Text::new("Tag"));
+        assert!(chip.avatar.is_none());
+        assert!(chip.on_pressed.is_none());
+        assert!(chip.on_deleted.is_none());
+        assert!(chip.enabled);
+        assert!(!chip.is_pressable());
+        assert!(!chip.has_delete_button());
+    }
+
+    #[test]
+    fn chip_on_pressed_makes_the_chip_pressable() {
+        let chip = Chip::new(flui_widgets::Text::new("Tag")).on_pressed(|| {});
+        assert!(chip.is_pressable());
+    }
+
+    #[test]
+    fn chip_disabled_is_never_pressable_even_with_a_handler() {
+        let chip = Chip::new(flui_widgets::Text::new("Tag"))
+            .on_pressed(|| {})
+            .enabled(false);
+        assert!(!chip.is_pressable());
+    }
+
+    #[test]
+    fn chip_on_deleted_shows_the_delete_button() {
+        let chip = Chip::new(flui_widgets::Text::new("Tag")).on_deleted(|| {});
+        assert!(chip.has_delete_button());
+    }
+
+    #[test]
+    fn filter_chip_new_is_unselected_and_disabled() {
+        let chip = FilterChip::new(flui_widgets::Text::new("Tag"));
+        assert!(!chip.selected);
+        assert!(!chip.is_enabled());
+        assert!(chip.avatar.is_none());
+        assert!(chip.on_deleted.is_none());
+    }
+
+    #[test]
+    fn filter_chip_on_selected_makes_it_enabled() {
+        let chip = FilterChip::new(flui_widgets::Text::new("Tag")).on_selected(|_| {});
+        assert!(chip.is_enabled());
+    }
+
+    // ------------------------------------------------------------------
+    // chip_states — pure query set (the NavigationBar-lesson regression)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn chip_states_selected_and_enabled_carries_only_selected() {
+        let states = chip_states(true, true);
+        assert!(states.contains_state(WidgetState::Selected));
+        assert!(!states.contains_state(WidgetState::Disabled));
+    }
+
+    #[test]
+    fn chip_states_unselected_and_disabled_carries_only_disabled() {
+        let states = chip_states(false, false);
+        assert!(states.contains_state(WidgetState::Disabled));
+        assert!(!states.contains_state(WidgetState::Selected));
+    }
+
+    /// Regression: a chip that is BOTH selected and disabled must query
+    /// with the PURE `{Disabled}` set, never a combined `{Selected,
+    /// Disabled}` one — mirrors
+    /// `navigation_bar::tests::states_selected_and_disabled_carries_only_disabled_not_both`.
+    #[test]
+    fn chip_states_selected_and_disabled_carries_only_disabled_not_both() {
+        let states = chip_states(true, false);
+        assert!(states.contains_state(WidgetState::Disabled));
+        assert!(
+            !states.contains_state(WidgetState::Selected),
+            "a disabled chip's query states must never also carry Selected, even when the chip \
+             is selected — combining them would let a theme Map resolve the wrong (selected) \
+             entry for a disabled chip",
+        );
+    }
+
+    /// Mutation-run: reverting `chip_states` to combine both flags whenever
+    /// both apply was confirmed to make this test fail — the combined set
+    /// satisfies `WidgetStateConstraint::Is(Selected)` (the first entry
+    /// below), so the broken version resolves `selected_style` for a
+    /// disabled+selected chip instead of `disabled_style`.
+    #[test]
+    fn theme_map_ordered_selected_before_disabled_still_resolves_disabled_for_a_disabled_selected_chip()
+     {
+        use flui_widgets::{WidgetStateConstraint, WidgetStateProperty};
+
+        let selected_style = Color::rgb(1, 1, 1);
+        let disabled_style = Color::rgb(2, 2, 2);
+        let theme: WidgetStateProperty<Option<Color>> = WidgetStateProperty::from_map([
+            (
+                WidgetStateConstraint::Is(WidgetState::Selected),
+                Some(selected_style),
+            ),
+            (
+                WidgetStateConstraint::Is(WidgetState::Disabled),
+                Some(disabled_style),
+            ),
+            (WidgetStateConstraint::Any, None),
+        ]);
+
+        let states = chip_states(true, false); // selected AND disabled
+        let resolved = theme.resolve(&states);
+
+        assert_eq!(
+            resolved,
+            Some(disabled_style),
+            "a disabled chip must resolve a theme Map's Disabled entry even when it is ALSO \
+             selected — chip_states never queries a combined {{selected, disabled}} set, so a \
+             Map ordered Selected-before-Disabled still gives the disabled result",
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // chip_content_color_default / chip_icon_color_default — branch order
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn content_color_default_unselected_enabled_is_on_surface_variant() {
+        assert_eq!(
+            chip_content_color_default(WidgetStates::NONE, &light()),
+            light().on_surface_variant
+        );
+    }
+
+    #[test]
+    fn content_color_default_selected_is_on_secondary_container() {
+        let states = WidgetStates::from(WidgetState::Selected);
+        assert_eq!(
+            chip_content_color_default(states, &light()),
+            light().on_secondary_container
+        );
+    }
+
+    #[test]
+    fn content_color_default_disabled_wins_over_selected() {
+        // Branch-order pin: `chip_states` never actually produces a
+        // combined set (see the regression tests above), but
+        // `resolve_pure_chip_default` itself must still check `disabled`
+        // before `selected` in case a future caller feeds it one directly.
+        let states = WidgetStates::from(WidgetState::Selected).with_state(WidgetState::Disabled);
+        assert_eq!(
+            chip_content_color_default(states, &light()),
+            light().on_surface
+        );
+    }
+
+    #[test]
+    fn icon_color_default_unselected_enabled_is_primary() {
+        assert_eq!(
+            chip_icon_color_default(WidgetStates::NONE, &light()),
+            light().primary
+        );
+    }
+
+    #[test]
+    fn icon_color_default_selected_is_on_secondary_container() {
+        let states = WidgetStates::from(WidgetState::Selected);
+        assert_eq!(
+            chip_icon_color_default(states, &light()),
+            light().on_secondary_container
+        );
+    }
+
+    #[test]
+    fn icon_color_default_disabled_is_on_surface() {
+        let states = WidgetStates::from(WidgetState::Disabled);
+        assert_eq!(
+            chip_icon_color_default(states, &light()),
+            light().on_surface
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // chip_default_side — Selected wins over Disabled (combined, not pure)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn default_side_unselected_enabled_is_outline_variant() {
+        let side = chip_default_side(false, true, &light());
+        assert_eq!(side.color, light().outline_variant);
+        assert_eq!(side.width, px(1.0));
+    }
+
+    #[test]
+    fn default_side_unselected_disabled_is_faded_on_surface() {
+        let side = chip_default_side(false, false, &light());
+        assert_eq!(side.color, light().on_surface.with_opacity(0.12));
+    }
+
+    #[test]
+    fn default_side_selected_enabled_is_transparent() {
+        let side = chip_default_side(true, true, &light());
+        assert_eq!(side.color, Color::TRANSPARENT);
+    }
+
+    /// The whole point of `chip_default_side` taking plain bools instead of
+    /// a `WidgetStates` set: `selected` wins over `disabled` outright, the
+    /// opposite priority from `chip_content_color_default`/
+    /// `chip_icon_color_default`. Mutation-run: swapping this function to
+    /// check `enabled` before `selected` (a `disabled`-first branch order)
+    /// was confirmed to make this test fail — it would resolve
+    /// `onSurface@12%` instead of `transparent`.
+    #[test]
+    fn default_side_selected_and_disabled_stays_transparent_not_the_disabled_color() {
+        let side = chip_default_side(true, false, &light());
+        assert_eq!(
+            side.color,
+            Color::TRANSPARENT,
+            "selected must win over disabled for `side` — the oracle's own `!isSelected` gate \
+             short-circuits before `isEnabled` is ever consulted",
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // filter_chip_default_background_color — the genuine 3-way branch
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn default_background_unselected_enabled_is_transparent() {
+        assert_eq!(
+            filter_chip_default_background_color(false, true, &light()),
+            Color::TRANSPARENT
+        );
+    }
+
+    #[test]
+    fn default_background_selected_enabled_is_secondary_container() {
+        assert_eq!(
+            filter_chip_default_background_color(true, true, &light()),
+            light().secondary_container
+        );
+    }
+
+    #[test]
+    fn default_background_unselected_disabled_is_transparent() {
+        assert_eq!(
+            filter_chip_default_background_color(false, false, &light()),
+            Color::TRANSPARENT
+        );
+    }
+
+    /// The genuine third branch: disabled-and-selected is NEITHER plain
+    /// `disabled` (`transparent`) NOR plain `selected`
+    /// (`secondaryContainer`) — a distinct color only a combined query can
+    /// produce. Mutation-run: collapsing this arm to fall through to either
+    /// neighbor was confirmed to make this test fail.
+    #[test]
+    fn default_background_selected_and_disabled_is_its_own_distinct_value() {
+        let combined = filter_chip_default_background_color(true, false, &light());
+        assert_eq!(combined, light().on_surface.with_opacity(0.12));
+        assert_ne!(
+            combined,
+            filter_chip_default_background_color(false, false, &light())
+        );
+        assert_ne!(
+            combined,
+            filter_chip_default_background_color(true, true, &light())
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // filter_chip_leading_content — the avatar/checkmark swap
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn leading_content_selected_is_always_checkmark() {
+        assert_eq!(
+            filter_chip_leading_content(true, true),
+            FilterChipLeading::Checkmark
+        );
+        assert_eq!(
+            filter_chip_leading_content(true, false),
+            FilterChipLeading::Checkmark
+        );
+    }
+
+    #[test]
+    fn leading_content_unselected_with_avatar_shows_the_avatar() {
+        assert_eq!(
+            filter_chip_leading_content(false, true),
+            FilterChipLeading::Avatar
+        );
+    }
+
+    #[test]
+    fn leading_content_unselected_without_avatar_shows_nothing() {
+        assert_eq!(
+            filter_chip_leading_content(false, false),
+            FilterChipLeading::None
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Geometry
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn content_min_height_with_default_padding_is_16() {
+        let height = chip_content_min_height(chip_default_padding(), chip_default_label_padding());
+        assert_eq!(height, px(CHIP_HEIGHT - 2.0 * PADDING));
+    }
+
+    #[test]
+    fn content_min_height_never_goes_negative_under_oversized_padding() {
+        let oversized = EdgeInsets::all(px(100.0));
+        let height = chip_content_min_height(oversized, chip_default_label_padding());
+        assert_eq!(height, px(0.0));
+    }
+
+    #[test]
+    fn default_shape_is_an_8dp_rounded_rectangle() {
+        let size = Size::new(px(80.0), px(CHIP_HEIGHT));
+        let rrect = chip_default_shape().to_rrect(size);
+        assert_eq!(
+            rrect.top_left,
+            flui_types::geometry::Radius::circular(px(CORNER_RADIUS))
+        );
+    }
+
+    #[test]
+    fn default_padding_is_8dp_all_sides() {
+        let padding = chip_default_padding();
+        assert_eq!(padding.top, px(PADDING));
+        assert_eq!(padding.left, px(PADDING));
+    }
+
+    #[test]
+    fn default_label_padding_is_horizontal_only() {
+        let padding = chip_default_label_padding();
+        assert_eq!(padding.top, px(0.0));
+        assert_eq!(padding.left, px(LABEL_PADDING_HORIZONTAL));
+    }
+
+    // ------------------------------------------------------------------
+    // Theme tier beats default (plain-override cascade)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn theme_label_color_beats_the_default() {
+        let theme_color = Color::rgb(9, 9, 9);
+        let resolved = Some(theme_color)
+            .or_else(|| Some(chip_content_color_default(WidgetStates::NONE, &light())));
+        assert_eq!(resolved, Some(theme_color));
+    }
+
+    #[test]
+    fn theme_side_beats_the_default() {
+        let theme_side = BorderSide::new(Color::rgb(3, 3, 3), px(2.0), BorderStyle::Solid);
+        let chip_theme = ChipThemeData {
+            side: Some(theme_side),
+            ..Default::default()
+        };
+        let resolved = chip_theme
+            .side
+            .unwrap_or_else(|| chip_default_side(false, true, &light()));
+        assert_eq!(resolved, theme_side);
+    }
+
+    #[test]
+    fn no_theme_falls_through_to_the_default_side() {
+        let chip_theme = ChipThemeData::default();
+        let resolved = chip_theme
+            .side
+            .unwrap_or_else(|| chip_default_side(false, true, &light()));
+        assert_eq!(resolved, chip_default_side(false, true, &light()));
+    }
+
+    // ------------------------------------------------------------------
+    // Painters
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn border_painter_draws_nothing_for_a_zero_width_side() {
+        use flui_painting::DisplayListCore;
+
+        let painter = ChipBorderPainter {
+            side: BorderSide::new(Color::BLACK, px(0.0), BorderStyle::Solid),
+            shape: chip_default_shape(),
+        };
+        let mut canvas = Canvas::new();
+        painter.paint(&mut canvas, Size::new(px(80.0), px(32.0)));
+        assert!(canvas.display_list().is_empty());
+    }
+
+    #[test]
+    fn border_painter_draws_a_ring_for_a_visible_side() {
+        use flui_painting::display_list::DrawCommand;
+
+        let painter = ChipBorderPainter {
+            side: BorderSide::new(Color::BLACK, px(1.0), BorderStyle::Solid),
+            shape: chip_default_shape(),
+        };
+        let mut canvas = Canvas::new();
+        painter.paint(&mut canvas, Size::new(px(80.0), px(32.0)));
+        assert!(
+            canvas
+                .display_list()
+                .iter()
+                .any(|command| matches!(command, DrawCommand::DrawDRRect { .. }))
+        );
+    }
+
+    #[test]
+    fn border_painter_should_repaint_is_true_when_the_side_changes() {
+        let old = ChipBorderPainter {
+            side: BorderSide::new(Color::BLACK, px(1.0), BorderStyle::Solid),
+            shape: chip_default_shape(),
+        };
+        let mut new = old;
+        new.side.color = Color::WHITE;
+        assert!(new.should_repaint(&old));
+    }
+
+    #[test]
+    fn checkmark_painter_draws_a_path() {
+        use flui_painting::display_list::DrawCommand;
+
+        let painter = ChipCheckmarkPainter {
+            color: Color::BLACK,
+        };
+        let mut canvas = Canvas::new();
+        painter.paint(
+            &mut canvas,
+            Size::new(px(CHIP_ICON_SIZE), px(CHIP_ICON_SIZE)),
+        );
+        assert!(
+            canvas
+                .display_list()
+                .iter()
+                .any(|command| matches!(command, DrawCommand::DrawPath { .. }))
+        );
+    }
+
+    #[test]
+    fn checkmark_painter_should_repaint_is_false_for_an_identical_delegate() {
+        let old = ChipCheckmarkPainter {
+            color: Color::BLACK,
+        };
+        let new = ChipCheckmarkPainter {
+            color: Color::BLACK,
+        };
+        assert!(!new.should_repaint(&old));
+    }
+}

--- a/crates/flui-material/src/lib.rs
+++ b/crates/flui-material/src/lib.rs
@@ -9,8 +9,9 @@
 //! [`Scaffold`]/[`AppBar`], [`Card`], [`Dialog`]/[`AlertDialog`]/
 //! [`show_dialog`], the input decoration substrate ([`InputDecoration`],
 //! [`InputDecorator`], [`TextField`]), the data-display family
-//! ([`ListTile`], [`Divider`]/[`VerticalDivider`]), and bottom navigation
-//! ([`NavigationBar`]/[`NavigationDestination`]).
+//! ([`ListTile`], [`Divider`]/[`VerticalDivider`]), bottom navigation
+//! ([`NavigationBar`]/[`NavigationDestination`]), and the chip family
+//! ([`Chip`], [`FilterChip`]).
 //!
 //! ## Flutter parity
 //!
@@ -70,6 +71,7 @@ pub mod button_style;
 mod button_style_button;
 pub mod card;
 pub mod checkbox;
+pub mod chip;
 pub mod color_scheme;
 pub mod dialog;
 pub mod divider;
@@ -103,6 +105,7 @@ pub use back_button::BackButton;
 pub use button_style::ButtonStyle;
 pub use card::Card;
 pub use checkbox::{Checkbox, CheckboxState};
+pub use chip::{Chip, FilterChip};
 pub use color_scheme::{ColorScheme, ColorSchemeOverrides};
 pub use dialog::{AlertDialog, Dialog, show_dialog};
 pub use divider::{Divider, VerticalDivider};
@@ -131,9 +134,10 @@ pub use text_field::{TextField, TextFieldState};
 pub use text_theme::TextTheme;
 pub use theme::Theme;
 pub use theme_data::{
-    AppBarThemeData, CardThemeData, CheckboxThemeData, DialogThemeData, DividerThemeData,
-    ElevatedButtonThemeData, FabThemeData, FilledButtonThemeData, IconButtonThemeData,
-    InputDecorationThemeData, ListTileThemeData, NavigationBarThemeData, OutlinedButtonThemeData,
-    RadioThemeData, SwitchThemeData, TextButtonThemeData, ThemeData, ThemeDataOverrides,
+    AppBarThemeData, CardThemeData, CheckboxThemeData, ChipThemeData, DialogThemeData,
+    DividerThemeData, ElevatedButtonThemeData, FabThemeData, FilledButtonThemeData,
+    IconButtonThemeData, InputDecorationThemeData, ListTileThemeData, NavigationBarThemeData,
+    OutlinedButtonThemeData, RadioThemeData, SwitchThemeData, TextButtonThemeData, ThemeData,
+    ThemeDataOverrides,
 };
 pub use typography::english_like_2021;

--- a/crates/flui-material/src/theme_data.rs
+++ b/crates/flui-material/src/theme_data.rs
@@ -477,7 +477,7 @@ pub struct CheckboxThemeData {
 /// [`icon_color`](Self::icon_color) alone — because [`Chip`](crate::Chip)/
 /// [`FilterChip`](crate::FilterChip)'s avatar/checkmark/delete-icon size is
 /// pinned at the M3 default (`CHIP_ICON_SIZE`, `18.0`, `chip.rs`) with no
-/// override surface yet, so the `size`/`fill`/`weight`/`grade`/`opical_size`
+/// override surface yet, so the `size`/`fill`/`weight`/`grade`/`optical_size`
 /// axes `IconThemeData` also carries have nothing to reach. The delete
 /// affordance's `_EnsureMinSemanticsSize`/`MaterialTapTargetSize`-driven
 /// minimum tap target (`chip.dart`'s `_buildDeleteIcon`, padding the visible

--- a/crates/flui-material/src/theme_data.rs
+++ b/crates/flui-material/src/theme_data.rs
@@ -430,6 +430,68 @@ pub struct CheckboxThemeData {
     pub side: Option<WidgetStateProperty<Option<BorderSide<Pixels>>>>,
 }
 
+/// Overrides [`Chip`](crate::Chip)/[`FilterChip`](crate::FilterChip)'s
+/// `_ChipDefaultsM3`/`_FilterChipDefaultsM3` token defaults, one field at a
+/// time — an unset field here still falls through to the owning widget's own
+/// M3 default table (see `chip.rs`'s `chip_default_*`/`chip_*_color_default`
+/// functions), it does not blank the whole slot.
+///
+/// Flutter parity: `ChipThemeData` (`material/chip_theme.dart`, oracle tag
+/// `3.44.0`), narrowed to the fields FLUI's [`Chip`](crate::Chip)/
+/// [`FilterChip`](crate::FilterChip) actually consume:
+/// [`label_color`](Self::label_color), [`icon_color`](Self::icon_color),
+/// [`delete_icon_color`](Self::delete_icon_color),
+/// [`checkmark_color`](Self::checkmark_color), [`side`](Self::side),
+/// [`shape`](Self::shape), [`padding`](Self::padding),
+/// [`label_padding`](Self::label_padding). Every field is a **plain**
+/// override rather than a `StateColor`/`WidgetStateProperty` — see
+/// `chip.rs`'s module docs ("`ChipThemeData`: plain overrides") for why this
+/// diverges from [`CheckboxThemeData`]/[`SwitchThemeData`]/
+/// [`RadioThemeData`]/[`NavigationBarThemeData`]'s per-state color slots:
+/// `chip_theme.dart` genuinely types these fields as plain values too (only
+/// `color`, the container fill, is a `WidgetStateProperty` in the oracle,
+/// and that field is a named V1 deferral here — see the same module docs).
+/// Named deferrals (no consumer in FLUI's `Chip`/`FilterChip` yet): `color`/
+/// `background_color`/`disabled_color`/`selected_color`/
+/// `secondary_selected_color` (the container fill — see `chip.rs`'s module
+/// docs), `shadow_color`/`surface_tint_color`/`selected_shadow_color`
+/// (`Material` has no such parameters yet, the same gap every other
+/// `Material`-backed M3 component in this crate already has),
+/// `show_checkmark` (V1 always shows one when selected), `brightness`,
+/// `elevation`/`press_elevation` (V1 is flat-only, elevation fixed `0.0`),
+/// `avatar_box_constraints`/`delete_icon_box_constraints`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ChipThemeData {
+    /// Overrides the label's resolved text color, per the widget's own
+    /// current state. `None` falls through to the M3 default table (see
+    /// `chip.rs`'s `chip_content_color_default`).
+    pub label_color: Option<Color>,
+    /// Overrides the leading avatar/checkmark icon's color. `None` falls
+    /// through to the M3 default table (see `chip.rs`'s
+    /// `chip_icon_color_default`).
+    pub icon_color: Option<Color>,
+    /// Overrides the trailing delete icon's color. `None` falls through to
+    /// the M3 default table (see `chip.rs`'s `chip_content_color_default`).
+    pub delete_icon_color: Option<Color>,
+    /// Overrides [`FilterChip`](crate::FilterChip)'s selected checkmark
+    /// color. `None` falls through to the M3 default table (see `chip.rs`'s
+    /// `chip_icon_color_default`). No effect on [`Chip`](crate::Chip),
+    /// which never shows a checkmark.
+    pub checkmark_color: Option<Color>,
+    /// Overrides the container's border side. `None` falls through to the
+    /// M3 default (see `chip.rs`'s `chip_default_side`).
+    pub side: Option<BorderSide<Pixels>>,
+    /// Overrides the container's shape. `None` falls through to the M3
+    /// default (an 8dp rounded rectangle).
+    pub shape: Option<MaterialShape>,
+    /// Overrides the container's outer padding. `None` falls through to the
+    /// M3 default (`EdgeInsets.all(8.0)`).
+    pub padding: Option<EdgeInsets>,
+    /// Overrides the label's inner padding. `None` falls through to the M3
+    /// default (`EdgeInsets.symmetric(horizontal: 8.0)`).
+    pub label_padding: Option<EdgeInsets>,
+}
+
 /// Overrides [`Switch`](crate::Switch)'s `_SwitchDefaultsM3` token defaults,
 /// one field at a time — an unset field here still falls through to
 /// `Switch`'s own M3 default table (see `switch.rs`'s `switch_default_*`
@@ -636,6 +698,10 @@ pub struct ThemeData {
     /// field. Flutter parity: `ThemeData.checkboxTheme`.
     pub checkbox_theme: Option<CheckboxThemeData>,
 
+    /// Overrides [`Chip`](crate::Chip)/[`FilterChip`](crate::FilterChip)'s
+    /// M3 token defaults, per field. Flutter parity: `ThemeData.chipTheme`.
+    pub chip_theme: Option<ChipThemeData>,
+
     /// Overrides [`Switch`](crate::Switch)'s M3 token defaults, per field.
     /// Flutter parity: `ThemeData.switchTheme`.
     pub switch_theme: Option<SwitchThemeData>,
@@ -672,6 +738,7 @@ impl ThemeData {
             list_tile_theme: None,
             divider_theme: None,
             checkbox_theme: None,
+            chip_theme: None,
             switch_theme: None,
             radio_theme: None,
             navigation_bar_theme: None,
@@ -700,6 +767,7 @@ impl ThemeData {
             list_tile_theme: None,
             divider_theme: None,
             checkbox_theme: None,
+            chip_theme: None,
             switch_theme: None,
             radio_theme: None,
             navigation_bar_theme: None,
@@ -791,6 +859,7 @@ impl ThemeData {
             checkbox_theme: overrides
                 .checkbox_theme
                 .or_else(|| self.checkbox_theme.clone()),
+            chip_theme: overrides.chip_theme.or_else(|| self.chip_theme.clone()),
             switch_theme: overrides.switch_theme.or_else(|| self.switch_theme.clone()),
             radio_theme: overrides.radio_theme.or_else(|| self.radio_theme.clone()),
             navigation_bar_theme: overrides
@@ -850,6 +919,8 @@ pub struct ThemeDataOverrides {
     pub divider_theme: Option<DividerThemeData>,
     /// Replaces [`ThemeData::checkbox_theme`] wholesale when `Some`.
     pub checkbox_theme: Option<CheckboxThemeData>,
+    /// Replaces [`ThemeData::chip_theme`] wholesale when `Some`.
+    pub chip_theme: Option<ChipThemeData>,
     /// Replaces [`ThemeData::switch_theme`] wholesale when `Some`.
     pub switch_theme: Option<SwitchThemeData>,
     /// Replaces [`ThemeData::radio_theme`] wholesale when `Some`.
@@ -966,6 +1037,7 @@ mod tests {
             assert!(theme.list_tile_theme.is_none());
             assert!(theme.divider_theme.is_none());
             assert!(theme.checkbox_theme.is_none());
+            assert!(theme.chip_theme.is_none());
             assert!(theme.switch_theme.is_none());
             assert!(theme.radio_theme.is_none());
             assert!(theme.navigation_bar_theme.is_none());
@@ -1179,6 +1251,44 @@ mod tests {
 
         let patched = base.copy_with(ThemeDataOverrides::default());
         assert_eq!(patched.checkbox_theme, Some(checkbox_theme));
+    }
+
+    /// Same shape as `copy_with_sets_input_decoration_theme_slot`, for the
+    /// `chip_theme` slot.
+    #[test]
+    fn copy_with_sets_chip_theme_slot() {
+        let base = ThemeData::light();
+        let chip_theme = ChipThemeData {
+            label_color: Some(Color::rgb(1, 2, 3)),
+            ..Default::default()
+        };
+
+        let patched = base.copy_with(ThemeDataOverrides {
+            chip_theme: Some(chip_theme.clone()),
+            ..Default::default()
+        });
+
+        assert_eq!(patched.chip_theme, Some(chip_theme));
+        // Untouched slots stay unset, mirroring the base theme.
+        assert!(patched.switch_theme.is_none());
+    }
+
+    /// Same already-set-slot-survives-a-`None`-override proof as
+    /// `copy_with_none_preserves_an_already_set_input_decoration_theme_slot`,
+    /// for the `chip_theme` slot.
+    #[test]
+    fn copy_with_none_preserves_an_already_set_chip_theme_slot() {
+        let chip_theme = ChipThemeData {
+            label_color: Some(Color::rgb(1, 2, 3)),
+            ..Default::default()
+        };
+        let base = ThemeData::light().copy_with(ThemeDataOverrides {
+            chip_theme: Some(chip_theme.clone()),
+            ..Default::default()
+        });
+
+        let patched = base.copy_with(ThemeDataOverrides::default());
+        assert_eq!(patched.chip_theme, Some(chip_theme));
     }
 
     /// Same shape as `copy_with_sets_input_decoration_theme_slot`, for the

--- a/crates/flui-material/src/theme_data.rs
+++ b/crates/flui-material/src/theme_data.rs
@@ -459,7 +459,33 @@ pub struct CheckboxThemeData {
 /// `Material`-backed M3 component in this crate already has),
 /// `show_checkmark` (V1 always shows one when selected), `brightness`,
 /// `elevation`/`press_elevation` (V1 is flat-only, elevation fixed `0.0`),
-/// `avatar_box_constraints`/`delete_icon_box_constraints`.
+/// `avatar_box_constraints`/`delete_icon_box_constraints`. `labelStyle`
+/// (`TextStyle?`) and `secondaryLabelStyle` (`FilterChip`'s selected-state
+/// label style in the oracle) are BOTH narrowed down to
+/// [`label_color`](Self::label_color) alone: every meaningful per-state
+/// difference in `_ChipDefaultsM3.labelStyle`/`_FilterChipDefaultsM3.labelStyle`
+/// is color-only (`_textTheme.labelLarge?.copyWith(color: ...)`, both files)
+/// — the font/size/weight geometry always comes from the ambient
+/// `TextTheme.labelLarge` and is not independently themeable here, and
+/// `secondaryLabelStyle` specifically (a full second `TextStyle` slot for
+/// the selected state) has no separate consumer since the private
+/// `chip_states`-driven color resolution (`chip.rs`) already covers
+/// `Selected` within the one
+/// [`label_color`](Self::label_color) field. `iconTheme`
+/// (`IconThemeData?`) is narrowed the same way [`NavigationBarThemeData::icon_color`]
+/// narrows its own `iconTheme` field — down to
+/// [`icon_color`](Self::icon_color) alone — because [`Chip`](crate::Chip)/
+/// [`FilterChip`](crate::FilterChip)'s avatar/checkmark/delete-icon size is
+/// pinned at the M3 default (`CHIP_ICON_SIZE`, `18.0`, `chip.rs`) with no
+/// override surface yet, so the `size`/`fill`/`weight`/`grade`/`opical_size`
+/// axes `IconThemeData` also carries have nothing to reach. The delete
+/// affordance's `_EnsureMinSemanticsSize`/`MaterialTapTargetSize`-driven
+/// minimum tap target (`chip.dart`'s `_buildDeleteIcon`, padding the visible
+/// 18dp glyph out to a `kMinInteractiveDimension`-or-`-8.0` accessible hit
+/// area) has no analogue here either — `chip.rs`'s delete `InkWell` hit-tests
+/// only its own visible icon bounds, a named accessibility-surface gap
+/// alongside the module docs' other deferred delete-affordance items
+/// (tooltip, custom icon override).
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ChipThemeData {
     /// Overrides the label's resolved text color, per the widget's own

--- a/crates/flui-material/tests/chip.rs
+++ b/crates/flui-material/tests/chip.rs
@@ -1,0 +1,458 @@
+//! `Chip`/`FilterChip` widget-level mount/interaction coverage.
+//!
+//! Complements `chip.rs`'s own unit tests (M3 default token-table probes,
+//! `chip_states`'s pure-query regression, painter geometry pins) with
+//! end-to-end mount/dispatch proof this crate's own conventions require for
+//! every interactive component (see `tests/checkbox.rs`/`tests/ink_well.rs`/
+//! `tests/elevated_button.rs`): a real down+up reaches
+//! [`Chip::on_pressed`]/[`FilterChip::on_selected`], a themed override
+//! actually reaches the mounted render tree (not just a cascade function
+//! evaluated in isolation), and — the one genuinely load-bearing claim
+//! `chip.rs`'s own module docs make without previously proving it — that
+//! the delete icon's small nested `InkWell` and the chip's own outer
+//! `InkWell` route a tap to exactly one of them, never both, depending on
+//! where the pointer lands. That claim rests on the same "most specific
+//! first" nested-detector resolution
+//! `crates/flui-widgets/tests/gesture_detector_advanced.rs`'s
+//! `overlapping_detectors_quick_tap_resolves_to_the_inner_tap` establishes
+//! for a tap-vs-long-press pair; this file is the first place it is proven
+//! for two plain, same-gesture-type taps at genuinely disjoint (not fully
+//! overlapping) sub-regions.
+//!
+//! **Not covered here** (see `chip.rs`'s own unit tests instead, since
+//! neither needs a render tree): the M3 default token-table branch
+//! order/combined-state pins, `chip_states`'s pure-query shape, and
+//! `ChipBorderPainter`/`ChipCheckmarkPainter`'s own paint-invocation/
+//! geometry proofs (real `Canvas`/`DisplayList` recordings).
+
+mod common;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use common::{lay_out, loose};
+use flui_material::chip::CHIP_ICON_SIZE;
+use flui_material::{Chip, ChipThemeData, FilterChip, Theme, ThemeData, ThemeDataOverrides};
+use flui_types::Color;
+use flui_widgets::Text;
+
+/// `_ChipDefaultsM3`/`_FilterChipDefaultsM3.padding` (`chip.dart`/
+/// `filter_chip.dart`, oracle tag `3.44.0`, `EdgeInsets.all(8.0)`) — a
+/// local re-citation of the oracle constant `chip.rs`'s own `PADDING` is
+/// (correctly) private, needed here only to locate the delete icon's
+/// rendered position from the outside.
+const CONTAINER_PADDING: f32 = 8.0;
+
+/// Every `Chip`/`FilterChip` needs a [`Theme`] ancestor (`Theme::of` panics
+/// without one) — mirrors `tests/checkbox.rs`'s own `themed` helper.
+fn themed(child: impl flui_view::IntoView) -> Theme {
+    Theme::new(ThemeData::light(), child)
+}
+
+/// `_ChipDefaultsM3`/`_FilterChipDefaultsM3`'s formatted `Debug` string for
+/// a given resolved [`Color`] — what `RenderPhysicalShape`'s
+/// `Diagnosticable::debug_fill_properties` writes into its `"color"`
+/// property, matching `tests/elevated_button.rs`'s own `color_property`
+/// helper.
+fn color_property(color: Color) -> String {
+    format!("{color:?}")
+}
+
+/// The mounted chip's overall container size — the outermost
+/// `RenderSemanticsAnnotations` node, which sizes to its `CustomPaint`/
+/// `Material`/content chain in full (mirrors `tests/checkbox.rs`'s own
+/// semantics-node-as-container-size assertion).
+fn container_size(laid: &common::LaidOut) -> flui_types::Size {
+    let semantics = laid
+        .find_by_render_type("RenderSemanticsAnnotations")
+        .expect("Chip/FilterChip must mount a Semantics wrapper");
+    laid.size(semantics)
+}
+
+/// The approximate on-screen center of the delete icon in a mounted chip
+/// with no avatar: the icon sits flush against the container's right edge,
+/// inset only by the container's own outer padding.
+fn delete_icon_center(laid: &common::LaidOut) -> (f32, f32) {
+    let size = container_size(laid);
+    (
+        size.width.get() - CONTAINER_PADDING - CHIP_ICON_SIZE / 2.0,
+        size.height.get() / 2.0,
+    )
+}
+
+/// A point safely inside the chip's own tap target but well clear of the
+/// delete icon's small box at the right edge — near the left edge, inside
+/// the outlined border.
+fn chip_only_point() -> (f32, f32) {
+    (CONTAINER_PADDING + 2.0, 16.0)
+}
+
+// ------------------------------------------------------------------
+// (a) Tap dispatch reaches the widget's own callback.
+// ------------------------------------------------------------------
+
+#[test]
+fn tap_fires_on_pressed_for_a_pressable_chip() {
+    let taps = Rc::new(RefCell::new(0_u32));
+    let counter = Rc::clone(&taps);
+    let laid = lay_out(
+        themed(Chip::new(Text::new("Tag")).on_pressed(move || {
+            *counter.borrow_mut() += 1;
+        })),
+        loose(300.0),
+    );
+
+    let (x, y) = chip_only_point();
+    laid.dispatch_pointer_down(x, y);
+    laid.dispatch_pointer_up(x, y);
+
+    assert_eq!(
+        *taps.borrow(),
+        1,
+        "a tap on a pressable chip must fire on_pressed"
+    );
+}
+
+#[test]
+fn tap_fires_on_selected_with_the_flipped_value_for_a_filter_chip() {
+    let observed = Rc::new(RefCell::new(None));
+    let recorder = Rc::clone(&observed);
+    let laid = lay_out(
+        themed(
+            FilterChip::new(Text::new("Vegetarian"))
+                .selected(false)
+                .on_selected(move |next| {
+                    *recorder.borrow_mut() = Some(next);
+                }),
+        ),
+        loose(300.0),
+    );
+
+    let (x, y) = chip_only_point();
+    laid.dispatch_pointer_down(x, y);
+    laid.dispatch_pointer_up(x, y);
+
+    assert_eq!(
+        *observed.borrow(),
+        Some(true),
+        "a tap on an unselected, enabled FilterChip must fire on_selected(true)",
+    );
+}
+
+// ------------------------------------------------------------------
+// (b) Delete-icon vs. chip-body tap separation — nested InkWells.
+// ------------------------------------------------------------------
+
+/// Mutation-run: dropping `chip.rs`'s `wrap_local_gesture_arena` call (so
+/// `Chip::build` returns its `Semantics` tree directly, with no local
+/// `GestureArenaScope`) was confirmed to make this test fail —
+/// `presses.borrow()` reads `1` instead of the expected `0`, meaning BOTH
+/// the delete button's `InkWell` and the chip body's own `InkWell` fired
+/// independently for the same contact. That is not a hypothetical: it is
+/// the exact `GestureDetector` "standalone" fallback (no ambient
+/// `GestureArenaScope` above it, so each detector closes its own private
+/// arena — see `GestureDetector`'s own module docs, "Arena acquisition")
+/// that this crate's plain `common::lay_out` harness exercises with no
+/// scope wrapper, and — confirmed by grepping the workspace — that no
+/// `flui-app`/binding-level ancestor installs anywhere either, so this was
+/// a real, previously unverified double-fire defect for any nested tap
+/// target, not a test-harness artifact.
+#[test]
+fn tapping_the_delete_icon_fires_on_deleted_only_not_the_chip_tap() {
+    let presses = Rc::new(RefCell::new(0_u32));
+    let deletions = Rc::new(RefCell::new(0_u32));
+    let press_counter = Rc::clone(&presses);
+    let delete_counter = Rc::clone(&deletions);
+
+    let laid = lay_out(
+        themed(
+            Chip::new(Text::new("Tag"))
+                .on_pressed(move || {
+                    *press_counter.borrow_mut() += 1;
+                })
+                .on_deleted(move || {
+                    *delete_counter.borrow_mut() += 1;
+                }),
+        ),
+        loose(300.0),
+    );
+
+    let (x, y) = delete_icon_center(&laid);
+    laid.dispatch_pointer_down(x, y);
+    laid.dispatch_pointer_up(x, y);
+
+    assert_eq!(
+        *deletions.borrow(),
+        1,
+        "a tap on the delete icon must fire on_deleted",
+    );
+    assert_eq!(
+        *presses.borrow(),
+        0,
+        "a tap on the delete icon must NOT also fire the chip's own on_pressed — the nested \
+         delete InkWell must win the shared arena, not let both recognizers fire",
+    );
+}
+
+#[test]
+fn tapping_elsewhere_on_the_chip_fires_the_chip_tap_only_not_on_deleted() {
+    let presses = Rc::new(RefCell::new(0_u32));
+    let deletions = Rc::new(RefCell::new(0_u32));
+    let press_counter = Rc::clone(&presses);
+    let delete_counter = Rc::clone(&deletions);
+
+    let laid = lay_out(
+        themed(
+            Chip::new(Text::new("Tag"))
+                .on_pressed(move || {
+                    *press_counter.borrow_mut() += 1;
+                })
+                .on_deleted(move || {
+                    *delete_counter.borrow_mut() += 1;
+                }),
+        ),
+        loose(300.0),
+    );
+
+    let (x, y) = chip_only_point();
+    laid.dispatch_pointer_down(x, y);
+    laid.dispatch_pointer_up(x, y);
+
+    assert_eq!(
+        *presses.borrow(),
+        1,
+        "a tap away from the delete icon must fire the chip's own on_pressed",
+    );
+    assert_eq!(
+        *deletions.borrow(),
+        0,
+        "a tap away from the delete icon must NOT fire on_deleted",
+    );
+}
+
+// ------------------------------------------------------------------
+// (c) Selected FilterChip fill reaches the mounted Material.
+// ------------------------------------------------------------------
+
+/// Mutation-run: hardcoding `FilterChip::build`'s `background_color` to
+/// `Color::TRANSPARENT` regardless of `filter_chip_default_background_color`'s
+/// result was confirmed to make this test fail (`got Color { r: 0, g: 0, b:
+/// 0, a: 0 }, expected Color { r: 232, g: 222, b: 248, a: 255 }`) — the
+/// exact "wiring mutation survives" gap the pre-fix test suite had, since
+/// only the pure default-table function itself was ever unit-tested, never
+/// its actual use inside `build()`.
+#[test]
+fn selected_filter_chip_fill_reaches_the_mounted_material() {
+    let laid = lay_out(
+        themed(
+            FilterChip::new(Text::new("Vegetarian"))
+                .selected(true)
+                .on_selected(|_| {}),
+        ),
+        loose(300.0),
+    );
+
+    let material = laid
+        .find_by_render_type("RenderPhysicalShape")
+        .expect("FilterChip must compose a Material container surface");
+
+    assert_eq!(
+        laid.render_property(material, "color"),
+        Some(color_property(
+            ThemeData::light().color_scheme.secondary_container
+        )),
+        "a selected, enabled FilterChip's container must fill with secondaryContainer through \
+         the real mount — not the transparent fill an unselected/base chip uses",
+    );
+}
+
+// ------------------------------------------------------------------
+// (d) Disabled chip + delete icon are inert through real dispatch.
+// ------------------------------------------------------------------
+
+#[test]
+fn disabled_chip_and_its_delete_icon_are_both_inert_through_dispatch() {
+    let presses = Rc::new(RefCell::new(0_u32));
+    let deletions = Rc::new(RefCell::new(0_u32));
+    let press_counter = Rc::clone(&presses);
+    let delete_counter = Rc::clone(&deletions);
+
+    let laid = lay_out(
+        themed(
+            Chip::new(Text::new("Tag"))
+                .enabled(false)
+                .on_pressed(move || {
+                    *press_counter.borrow_mut() += 1;
+                })
+                .on_deleted(move || {
+                    *delete_counter.borrow_mut() += 1;
+                }),
+        ),
+        loose(300.0),
+    );
+
+    let (delete_x, delete_y) = delete_icon_center(&laid);
+    laid.dispatch_pointer_down(delete_x, delete_y);
+    laid.dispatch_pointer_up(delete_x, delete_y);
+
+    let (chip_x, chip_y) = chip_only_point();
+    laid.dispatch_pointer_down(chip_x, chip_y);
+    laid.dispatch_pointer_up(chip_x, chip_y);
+
+    assert_eq!(
+        *presses.borrow(),
+        0,
+        "a disabled chip must swallow taps on its own body"
+    );
+    assert_eq!(
+        *deletions.borrow(),
+        0,
+        "a disabled chip must swallow taps on its delete icon too — Flutter parity: \
+         `onTap: widget.isEnabled ? widget.onDeleted : null`",
+    );
+}
+
+#[test]
+fn disabled_filter_chip_and_its_delete_icon_are_both_inert_through_dispatch() {
+    // `FilterChip` has no separate `enabled` builder — Flutter parity:
+    // `isEnabled => onSelected != null` (see `chip.rs`'s `FilterChip::is_enabled`).
+    let deletions = Rc::new(RefCell::new(0_u32));
+    let delete_counter = Rc::clone(&deletions);
+
+    let laid = lay_out(
+        themed(
+            FilterChip::new(Text::new("Vegetarian")).on_deleted(move || {
+                *delete_counter.borrow_mut() += 1;
+            }),
+        ),
+        loose(300.0),
+    );
+
+    let (delete_x, delete_y) = delete_icon_center(&laid);
+    laid.dispatch_pointer_down(delete_x, delete_y);
+    laid.dispatch_pointer_up(delete_x, delete_y);
+
+    assert_eq!(
+        *deletions.borrow(),
+        0,
+        "a FilterChip with no on_selected (disabled) must swallow taps on its delete icon too",
+    );
+}
+
+// ------------------------------------------------------------------
+// Theme tier beats default — proven through the real mount, not
+// `Option::or_else` re-implemented inline in the test (see chip.rs's
+// module doc: `ChipThemeData`'s fields are plain overrides, so this is the
+// one place their wiring into `build()` can be proven end to end).
+// ------------------------------------------------------------------
+
+/// Mutation-run: replacing `Chip::build`'s `label_color` binding with a bare
+/// `chip_content_color_default(states, &colors)` call (dropping the
+/// `chip_theme.label_color` read entirely) was confirmed to make this test
+/// fail — the resolved `style` carries the M3 default `onSurfaceVariant`
+/// (`Color { r: 73, g: 69, b: 79, a: 255 }`) instead of the configured
+/// override.
+#[test]
+fn theme_label_color_reaches_the_mounted_paragraph_beating_the_default() {
+    let themed_label_color = Color::rgb(11, 22, 33);
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        chip_theme: Some(ChipThemeData {
+            label_color: Some(themed_label_color),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    let laid = lay_out(Theme::new(theme, Chip::new(Text::new("Tag"))), loose(300.0));
+
+    let paragraph = laid
+        .find_by_render_type("RenderParagraph")
+        .expect("Chip must mount a RenderParagraph for its label");
+    let style = laid
+        .render_property(paragraph, "style")
+        .expect("RenderParagraph must expose its resolved style");
+
+    assert!(
+        style.contains(&color_property(themed_label_color)),
+        "a configured chip_theme.label_color must reach the mounted label's resolved text \
+         color — got style {style:?}",
+    );
+}
+
+#[test]
+fn no_theme_override_paints_the_m3_default_label_color() {
+    let laid = lay_out(themed(Chip::new(Text::new("Tag"))), loose(300.0));
+
+    let paragraph = laid
+        .find_by_render_type("RenderParagraph")
+        .expect("Chip must mount a RenderParagraph for its label");
+    let style = laid
+        .render_property(paragraph, "style")
+        .expect("RenderParagraph must expose its resolved style");
+
+    // `_ChipDefaultsM3.labelStyle`: `isEnabled ? onSurfaceVariant : onSurface`
+    // — an enabled, undecorated `Chip` resolves `onSurfaceVariant`.
+    let default_color = ThemeData::light().color_scheme.on_surface_variant;
+    assert!(
+        style.contains(&color_property(default_color)),
+        "with no chip_theme override, the label must paint the M3 default onSurfaceVariant — \
+         got style {style:?}",
+    );
+}
+
+/// Mutation-run: replacing `Chip::build`'s `side` binding with a bare
+/// `chip_default_side(false, self.enabled, &colors)` call (dropping the
+/// `chip_theme.side` read entirely) was confirmed to make this test fail —
+/// the mounted border painter carries the M3 default `outlineVariant`
+/// (`Color { r: 202, g: 196, b: 208, a: 255 }`) instead of the configured
+/// override.
+#[test]
+fn theme_side_reaches_the_mounted_border_painter_beating_the_default() {
+    let themed_side_color = Color::rgb(44, 55, 66);
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        chip_theme: Some(ChipThemeData {
+            side: Some(flui_types::styling::BorderSide::new(
+                themed_side_color,
+                flui_types::geometry::px(3.0),
+                flui_types::styling::BorderStyle::Solid,
+            )),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    let laid = lay_out(Theme::new(theme, Chip::new(Text::new("Tag"))), loose(300.0));
+
+    let custom_paint = laid
+        .find_by_render_type("RenderCustomPaint")
+        .expect("Chip must mount a RenderCustomPaint for its border");
+    let painter = laid
+        .render_property(custom_paint, "foreground_painter")
+        .expect("RenderCustomPaint must expose its foreground painter");
+
+    assert!(
+        painter.contains(&color_property(themed_side_color)),
+        "a configured chip_theme.side must reach the mounted border painter's resolved color — \
+         got painter {painter:?}",
+    );
+}
+
+#[test]
+fn no_theme_override_paints_the_m3_default_side_color() {
+    let laid = lay_out(themed(Chip::new(Text::new("Tag"))), loose(300.0));
+
+    let custom_paint = laid
+        .find_by_render_type("RenderCustomPaint")
+        .expect("Chip must mount a RenderCustomPaint for its border");
+    let painter = laid
+        .render_property(custom_paint, "foreground_painter")
+        .expect("RenderCustomPaint must expose its foreground painter");
+
+    // `_ChipDefaultsM3.side`: `isEnabled ? outlineVariant : onSurface@12%`.
+    let default_color = ThemeData::light().color_scheme.outline_variant;
+    assert!(
+        painter.contains(&color_property(default_color)),
+        "with no chip_theme override, the border must paint the M3 default outlineVariant — \
+         got painter {painter:?}",
+    );
+}

--- a/crates/flui-objects/src/proxy/custom_paint.rs
+++ b/crates/flui-objects/src/proxy/custom_paint.rs
@@ -275,6 +275,18 @@ impl flui_foundation::Diagnosticable for RenderCustomPaint {
         );
         properties.add_flag("is_complex", self.is_complex, "is complex");
         properties.add_flag("will_change", self.will_change, "will change");
+        // `CustomPainter: Debug` is already a supertrait bound (every
+        // implementer must derive/implement it), so this reuses an
+        // already-required impl rather than adding a new trait method —
+        // lets a mounted-widget test read a concrete painter's resolved
+        // field values back out (e.g. a themed color reaching the real
+        // painter instance a build produced) without this render object
+        // needing to know anything about what a painter actually paints.
+        properties.add("painter", format!("{:?}", self.painter));
+        properties.add(
+            "foreground_painter",
+            format!("{:?}", self.foreground_painter),
+        );
     }
 }
 

--- a/crates/flui-objects/src/text/paragraph.rs
+++ b/crates/flui-objects/src/text/paragraph.rs
@@ -151,6 +151,13 @@ impl Diagnosticable for RenderParagraph {
         // content without inspecting the full `InlineSpan` tree.
         if let Some(span) = self.painter.text() {
             properties.add("text", span.to_plain_text());
+            // Lets a mounted-widget test read a resolved text color back out
+            // (e.g. a themed/cascaded color reaching the real paragraph a
+            // build produced) without downcasting or inspecting paint
+            // output — `TextStyle: Debug` is already required for the type
+            // to be usable at all, so this is a pure diagnostics read, not
+            // a new capability.
+            properties.add("style", format!("{:?}", span.style()));
         }
     }
 }


### PR DESCRIPTION
## Summary

The M3 Chip family V1 (data-display), ported against Flutter 3.44.0 `material/{chip,chip_theme,filter_chip}.dart`.

- **`Chip`** — label + optional avatar + delete icon (`on_deleted` with its own gesture region — **the delete-vs-chip-tap separation surfaced a real framework interaction**: with no ambient arena, nested standalone GestureDetectors each close a private arena and BOTH taps fire; fixed via a component-local `GestureArenaScope`, mutation-proven both directions), 32dp `_kChipHeight`, 8dp shape, `_ChipDefaultsM3` tables (two-way `isEnabled` getters — the selected branches correctly attributed to the filter defaults only, a review citation fix).
- **`FilterChip`** — `selected`/`on_selected` toggle, secondaryContainer fill, leading checkmark painted at the oracle's exact frame (**0.75×cell with a 0.125×cell origin offset** — a review round caught a full-cell mark ~33% oversized behind a "direct port" claim), avatar-swap animation reduced to snap (named).
- **Disabled content renders at the oracle's steady 38% alpha** (`_kDisabledAlpha` — a review-caught silent gap; group Opacity over avatar/label/delete, container fill/border excluded per the oracle's unwrapped Ink).
- `ChipThemeData` slot with the full convention; theme cascades pinned by **mounted** override tests (a vacuous inline-Option unit was review-caught and replaced); pure-state-set resolution.
- Additive `debug_fill_properties` on `RenderCustomPaint`/`RenderParagraph` (flui-objects — observability only, no behavior change, needed by the mounted wiring pins).
- Deferred named: elevated variants, Input/Choice/Action ctors, animations, tooltip, RTL, labelStyle/iconTheme narrowings, `_EnsureMinSemanticsSize`.

### Review trail
Builder → full review (oversized checkmark, silent disabled-fade gap, zero mounted tests with the delete separation an unverified claim, one vacuous pin) → fix pass (the mounted separation test exposed and fixed the nested-arena double-fire) → delta re-review incl. the cross-crate scope-expansion audit: COMPLETE.

### Gates
Workspace nextest 7227 passed / 4 skipped · workspace clippy `-D warnings` clean · doc gates clean · port-check/inventory/fmt/taplo/typos · doctests 32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvkSGveJwxLVuygRAGVKuz