### PR TITLE
feat(material): Tabs PR1 — TabController, DefaultTabController, Tab, TabBar (secondary contract)

### DIFF
--- a/crates/flui-material/src/lib.rs
+++ b/crates/flui-material/src/lib.rs
@@ -10,8 +10,9 @@
 //! [`show_dialog`], the input decoration substrate ([`InputDecoration`],
 //! [`InputDecorator`], [`TextField`]), the data-display family
 //! ([`ListTile`], [`Divider`]/[`VerticalDivider`]), bottom navigation
-//! ([`NavigationBar`]/[`NavigationDestination`]), and the chip family
-//! ([`Chip`], [`FilterChip`]).
+//! ([`NavigationBar`]/[`NavigationDestination`]), the chip family
+//! ([`Chip`], [`FilterChip`]), and secondary tabs ([`TabController`],
+//! [`DefaultTabController`], [`Tab`], [`TabBar`]).
 //!
 //! ## Flutter parity
 //!
@@ -93,6 +94,8 @@ pub mod shape;
 pub mod snack_bar;
 mod state_color;
 pub mod switch;
+pub mod tab_controller;
+pub mod tabs;
 pub mod text_button;
 pub mod text_field;
 pub mod text_theme;
@@ -129,6 +132,8 @@ pub use scaffold_messenger::{
 pub use shape::MaterialShape;
 pub use snack_bar::{SnackBar, SnackBarAction, SnackBarActionState};
 pub use switch::{Switch, SwitchState};
+pub use tab_controller::{DefaultTabController, DefaultTabControllerState, TabController};
+pub use tabs::{Tab, TabBar, TabBarState};
 pub use text_button::TextButton;
 pub use text_field::{TextField, TextFieldState};
 pub use text_theme::TextTheme;
@@ -137,7 +142,7 @@ pub use theme_data::{
     AppBarThemeData, CardThemeData, CheckboxThemeData, ChipThemeData, DialogThemeData,
     DividerThemeData, ElevatedButtonThemeData, FabThemeData, FilledButtonThemeData,
     IconButtonThemeData, InputDecorationThemeData, ListTileThemeData, NavigationBarThemeData,
-    OutlinedButtonThemeData, RadioThemeData, SwitchThemeData, TextButtonThemeData, ThemeData,
-    ThemeDataOverrides,
+    OutlinedButtonThemeData, RadioThemeData, SwitchThemeData, TabBarThemeData, TextButtonThemeData,
+    ThemeData, ThemeDataOverrides,
 };
 pub use typography::english_like_2021;

--- a/crates/flui-material/src/tab_controller.rs
+++ b/crates/flui-material/src/tab_controller.rs
@@ -1,0 +1,720 @@
+//! [`TabController`] — shared selection state for [`crate::TabBar`], plus
+//! [`DefaultTabController`], the inherited-widget shortcut that owns one for
+//! a subtree.
+//!
+//! # Flutter parity
+//!
+//! `material/tab_controller.dart`'s `TabController`/`DefaultTabController`
+//! (oracle tag `3.44.0`).
+//!
+//! # `TabController`: one non-`Send` cell, not an `Arc<AtomicUsize>` pair
+//!
+//! The oracle's `TabController` is a `ChangeNotifier` (Dart has no
+//! `Send`/`Sync` distinction) holding two plain `int` fields, `_index` and
+//! `_previousIndex`, mutated together by `_changeIndex` and then notified
+//! once. A naive Rust port — following
+//! [`crate::CupertinoTabController`](../flui_cupertino/struct.CupertinoTabController.html)'s
+//! `Arc<AtomicUsize>` precedent, but for a *pair* of counters — would let a
+//! listener observe a **torn** snapshot: `index` swapped to the new value on
+//! one atomic while `previous_index` still reads the old-old value on the
+//! other, if anything ever raced the two swaps. It would also advertise
+//! `Send + Sync` on a type this crate's own state model never shares across
+//! threads — every `TabController` is created, read, and mutated from the UI
+//! realm only (`DefaultTabController`'s state, or a caller's own
+//! single-realm code) — so `Send + Sync` would be a claim with no real
+//! backing, "false Send advertising" that invites a caller to hand a
+//! `TabController` across a thread boundary where nothing here actually
+//! makes that safe.
+//!
+//! Instead, `(index, previous_index)` lives in **one** `Cell<(usize,
+//! usize)>` behind an `Rc` — Copy, so `Cell::set` replaces the whole pair in
+//! one non-interruptible store; there is no window where a reader can
+//! observe one field updated and not the other, because on a single
+//! (`!Send`) realm nothing else can run between the `set` and the `notify`.
+//! `Rc<Cell<_>>` is `!Send`/`!Sync`, so `TabController` itself does not (and
+//! cannot) implement [`Listenable`](flui_foundation::Listenable) — that
+//! trait requires `Send + Sync` — which is exactly the point: the compiler
+//! now enforces single-realm use instead of a doc comment promising it.
+//!
+//! The listener registry follows the same logic: [`TabController::add_listener`]
+//! takes a plain `Rc<dyn Fn()>` (this crate's usual owner-local callback
+//! shape — see [`crate::ink_well::InkWell::on_tap`]), not
+//! `flui_foundation::ListenerCallback` (`Arc<dyn Fn() + Send + Sync>`). A
+//! `Send + Sync`-bound callback could never legally capture this
+//! `TabController` (or its `Rc<Cell<_>>` state) to begin with, so reusing
+//! `flui_foundation::ChangeNotifier` here would make the *listener*
+//! unable to read back the very state it was notified about.
+//! [`TabBar`](crate::TabBar) subscribes with a plain closure that schedules
+//! a rebuild via [`flui_view::RebuildHandle`] (itself `Send + Sync`, but
+//! that is incidental — nothing about the registry requires it).
+//!
+//! # `animate_to` is a documented alias, not an animation
+//!
+//! The oracle's `animateTo`/`_changeIndex` additionally: (a) fires **two**
+//! `notifyListeners()` calls when a `duration` is given — once immediately
+//! (so [`indexIsChanging`](https://api.flutter.dev/flutter/material/TabController/indexIsChanging.html)
+//! flips true) and once when the drive animation completes; (b) exposes
+//! `indexIsChanging`, read by `TabBarView`'s warp-to-adjacent-page
+//! optimization to distinguish a programmatic tab change from a drag; (c)
+//! animates `animation.value` from the old index to the new one over
+//! `duration`/`curve`. None of that is ported here: this V1 has no
+//! `AnimationController`/`Ticker` wiring on `TabController` at all — see
+//! [`crate::tabs`] module docs for why `TabBarView` itself is out of scope
+//! for this unit. [`TabController::animate_to`] is therefore a plain alias
+//! for [`TabController::set_index`]: one synchronous index change, one
+//! synchronous notify, no interpolation. `indexIsChanging` and the
+//! start/completion double-notify are named deferrals, not silently dropped
+//! — they return when a caller (`TabBarView`, or a real
+//! `AnimationController`-driven indicator sweep) needs them.
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use flui_foundation::ListenerId;
+use flui_view::prelude::*;
+use flui_view::{BoxedView, InheritedView, impl_inherited_view};
+
+/// `(index, previous_index)`, mutated and read as one unit — see the module
+/// docs' "one non-`Send` cell" section for why this is a single `Cell` of a
+/// packed pair rather than two independent counters.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct IndexPair {
+    index: usize,
+    previous_index: usize,
+}
+
+/// A [`TabController`] change listener — `Rc`-based, matching this crate's
+/// other owner-local callback types (e.g. [`crate::ink_well::InkWell`]'s
+/// `on_tap`), NOT `flui_foundation::ListenerCallback`
+/// (`Arc<dyn Fn() + Send + Sync>`). This is deliberate, not an oversight: a
+/// `Send + Sync` callback could never legally capture a `TabController` (or
+/// anything reachable from its `Rc<Cell<_>>` state) in the first place, so a
+/// `TabController`-flavored listener registry needs its own `!Send`
+/// callback type rather than reusing `flui_foundation::ChangeNotifier`'s.
+type TabChangeListener = Rc<dyn Fn()>;
+
+/// [`TabController`]'s own listener registry — a private, `!Send`
+/// counterpart to `flui_foundation::ChangeNotifier` (see
+/// [`TabChangeListener`]'s doc comment for why that type doesn't fit here).
+/// `Rc`-shared so every [`TabController`] clone registers into and notifies
+/// from the same underlying list.
+#[derive(Clone)]
+struct TabListenerRegistry {
+    listeners: Rc<RefCell<Vec<(ListenerId, TabChangeListener)>>>,
+    /// The next id to hand out. `ListenerId` is 1-based (see this
+    /// workspace's ID offset pattern — public ids are `NonZeroUsize`), so
+    /// this starts at `1`, not `0`.
+    next_id: Rc<Cell<usize>>,
+}
+
+impl Default for TabListenerRegistry {
+    fn default() -> Self {
+        Self {
+            listeners: Rc::new(RefCell::new(Vec::new())),
+            next_id: Rc::new(Cell::new(1)),
+        }
+    }
+}
+
+impl TabListenerRegistry {
+    fn add_listener(&self, listener: TabChangeListener) -> ListenerId {
+        let id = ListenerId::new(self.next_id.get());
+        self.next_id.set(self.next_id.get() + 1);
+        self.listeners.borrow_mut().push((id, listener));
+        id
+    }
+
+    fn remove_listener(&self, id: ListenerId) {
+        self.listeners
+            .borrow_mut()
+            .retain(|(entry, _)| *entry != id);
+    }
+
+    /// Fires every registered listener. Snapshots the list first (cloning
+    /// the `Rc<dyn Fn()>` handles, not the `Vec`'s backing allocation) so a
+    /// listener that adds/removes a listener mid-notify does not conflict
+    /// with the in-progress borrow — same reentrancy shape as
+    /// `flui_foundation::ChangeNotifier::notify_listeners`.
+    fn notify(&self) {
+        let snapshot: Vec<TabChangeListener> = self
+            .listeners
+            .borrow()
+            .iter()
+            .map(|(_, listener)| Rc::clone(listener))
+            .collect();
+        for listener in snapshot {
+            listener();
+        }
+    }
+}
+
+/// Coordinates tab selection for [`TabBar`](crate::TabBar) (and, in a later
+/// unit, `TabBarView`). Flutter parity: `TabController`
+/// (`tab_controller.dart`, oracle tag `3.44.0`) — see the module docs for
+/// what this V1 does and does not carry over.
+///
+/// `Clone` is cheap and shares identity: every clone observes and mutates
+/// the *same* underlying state, the same shape as
+/// [`crate::navigation_bar`]'s and `flui_cupertino::CupertinoTabController`'s
+/// shared-handle controllers (that crate is not a dependency of this one, so
+/// this is a plain-text cross-reference, not a doc link).
+///
+/// ```
+/// use flui_material::TabController;
+///
+/// let controller = TabController::new(3, 0);
+/// assert_eq!(controller.index(), 0);
+/// controller.set_index(2);
+/// assert_eq!(controller.index(), 2);
+/// assert_eq!(controller.previous_index(), 0);
+/// ```
+pub struct TabController {
+    state: Rc<Cell<IndexPair>>,
+    length: usize,
+    listeners: TabListenerRegistry,
+}
+
+impl TabController {
+    /// A controller over `length` tabs, starting at `initial_index`.
+    ///
+    /// Flutter parity: `TabController`'s constructor asserts (`length >= 0`
+    /// is implied by `usize`; `initialIndex` valid for `length`) — ported as
+    /// a `debug_assert!`, matching this crate's other oracle-assert ports
+    /// (e.g. `flui_cupertino::CupertinoTabScaffold`'s index-bounds check).
+    #[must_use]
+    pub fn new(length: usize, initial_index: usize) -> Self {
+        debug_assert!(
+            (length == 0 && initial_index == 0) || initial_index < length,
+            "TabController: initial_index {initial_index} is out of range for length {length}"
+        );
+        Self::with_previous(length, initial_index, initial_index)
+    }
+
+    /// A controller starting at `index` with a distinct `previous_index` —
+    /// the shape [`DefaultTabController`]'s length-change re-creation needs
+    /// (Flutter parity: `TabController._copyWithAndDispose`'s
+    /// `index`/`previousIndex` pair, see that type's docs).
+    fn with_previous(length: usize, index: usize, previous_index: usize) -> Self {
+        Self {
+            state: Rc::new(Cell::new(IndexPair {
+                index,
+                previous_index,
+            })),
+            length,
+            listeners: TabListenerRegistry::default(),
+        }
+    }
+
+    /// The index of the currently selected tab.
+    #[must_use]
+    pub fn index(&self) -> usize {
+        self.state.get().index
+    }
+
+    /// The index of the previously selected tab. Initially equal to
+    /// [`index`](Self::index).
+    #[must_use]
+    pub fn previous_index(&self) -> usize {
+        self.state.get().previous_index
+    }
+
+    /// The total number of tabs this controller was created for. Immutable
+    /// for the lifetime of one `TabController` instance — a change in tab
+    /// count is a *new* controller identity, not a mutation (see
+    /// [`DefaultTabController`]'s docs).
+    #[must_use]
+    pub fn length(&self) -> usize {
+        self.length
+    }
+
+    /// Selects `index`, updating [`previous_index`](Self::previous_index)
+    /// and notifying listeners — unless this is a no-op.
+    ///
+    /// Flutter parity: `TabController._changeIndex`'s core (the
+    /// non-animating branch; see the module docs for what is deferred).
+    /// **No-op, no notify** when `index == self.index()` OR
+    /// `self.length() < 2` — both conditions the oracle checks before
+    /// touching any state (`if (value == _index || length < 2) return;`).
+    /// The pair update itself is a single [`Cell::set`] of the whole
+    /// `(index, previous_index)` tuple, so a listener invoked by the
+    /// `notify_listeners()` that follows always observes a consistent pair
+    /// — never `index` updated with a stale `previous_index` or vice versa.
+    pub fn set_index(&self, index: usize) {
+        let current = self.state.get();
+        if index == current.index || self.length < 2 {
+            return;
+        }
+        self.state.set(IndexPair {
+            index,
+            previous_index: current.index,
+        });
+        self.listeners.notify();
+    }
+
+    /// An alias for [`set_index`](Self::set_index) — see the module docs'
+    /// "`animate_to` is a documented alias" section for exactly what the
+    /// oracle's `animateTo` does that this does not (yet) do.
+    pub fn animate_to(&self, index: usize) {
+        self.set_index(index);
+    }
+
+    /// Registers a listener, called whenever [`set_index`](Self::set_index)
+    /// actually changes the selection. `listener` is `Rc`-based internally
+    /// (see the module docs' "listener registry follows the same logic"
+    /// section) — it may freely capture this same `TabController` (or any
+    /// other owner-local, `!Send` state) to read the just-updated `(index,
+    /// previous_index)` pair.
+    pub fn add_listener(&self, listener: impl Fn() + 'static) -> ListenerId {
+        self.listeners.add_listener(Rc::new(listener))
+    }
+
+    /// Unregisters a previously-registered listener.
+    pub fn remove_listener(&self, id: ListenerId) {
+        self.listeners.remove_listener(id);
+    }
+}
+
+impl Clone for TabController {
+    fn clone(&self) -> Self {
+        Self {
+            state: Rc::clone(&self.state),
+            length: self.length,
+            listeners: self.listeners.clone(),
+        }
+    }
+}
+
+/// Identity equality — two clones of the same controller are equal; two
+/// independently-constructed controllers are not, even with identical
+/// `(index, previous_index, length)`. Flutter parity: the oracle's
+/// `TabController` has no `==` override, so Dart's default reference
+/// equality applies to `_TabControllerScope.updateShouldNotify`'s `controller
+/// != old.controller` check — this is that same reference-identity
+/// comparison, ported as `Rc::ptr_eq` over the shared cell.
+impl PartialEq for TabController {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.state, &other.state)
+    }
+}
+
+impl Eq for TabController {}
+
+impl std::fmt::Debug for TabController {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let pair = self.state.get();
+        f.debug_struct("TabController")
+            .field("index", &pair.index)
+            .field("previous_index", &pair.previous_index)
+            .field("length", &self.length)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The inherited node [`DefaultTabController`] publishes its
+/// [`TabController`] through. Flutter parity: `_TabControllerScope` — a
+/// private `InheritedWidget`, ported as a private `InheritedView` for the
+/// same reason: nothing outside this module should construct one directly,
+/// only read it via [`DefaultTabController::of`]/[`maybe_of`](DefaultTabController::maybe_of).
+#[derive(Clone)]
+struct TabControllerScope {
+    controller: TabController,
+    child: BoxedView,
+}
+
+impl InheritedView for TabControllerScope {
+    type Data = TabController;
+
+    fn data(&self) -> &Self::Data {
+        &self.controller
+    }
+
+    fn child(&self) -> &dyn View {
+        &self.child
+    }
+
+    fn update_should_notify(&self, old: &Self) -> bool {
+        // Flutter parity: `_TabControllerScope.updateShouldNotify` also
+        // compares `enabled` (a `TickerMode.of(context)` snapshot) — no
+        // consumer here depends on ticker-mode-gated notification yet (this
+        // controller has no ticker to gate), so only the controller-identity
+        // half of that comparison is ported; see `DefaultTabController`'s
+        // docs.
+        self.controller != old.controller
+    }
+}
+
+impl_inherited_view!(TabControllerScope);
+
+/// Shares one [`TabController`] with a `TabBar`/`TabBarView` pair that don't
+/// have a convenient stateful ancestor to own it directly.
+///
+/// Flutter parity: `DefaultTabController` (`tab_controller.dart`, oracle tag
+/// `3.44.0`).
+///
+/// # Length-change re-creation
+///
+/// Rebuilding with a different `length` does not mutate the existing
+/// controller's `length` field in place (`TabController::length` is
+/// immutable per instance — see that type's docs). Instead, exactly like the
+/// oracle's `_copyWithAndDispose`, this creates a **new** `TabController`
+/// identity:
+///
+/// - If the old `index` is still in range for the new `length`, it carries
+///   over unchanged, and `previous_index` carries over unchanged too.
+/// - If the old `index` is now out of range (the tab list shrank past it),
+///   the new controller clamps to `length - 1` and records the *old* index
+///   as its `previous_index` — Flutter parity: `newIndex = max(0,
+///   widget.length - 1); previousIndex = _controller.index;`
+///   (`_DefaultTabControllerState.didUpdateWidget`).
+///
+/// Because [`TabController`]'s equality is identity-based (see its `PartialEq`
+/// doc), this re-creation is itself what makes the private
+/// `_TabControllerScope::update_should_notify` equivalent fire: dependents (a
+/// `TabBar` re-reading [`DefaultTabController::maybe_of`] every `build`) see
+/// a *different* controller and re-resolve their listener subscription onto
+/// it — see `crate::tabs::TabBarState`'s `resolve_controller` for the
+/// consumer side of that contract.
+///
+/// ```
+/// use flui_material::DefaultTabController;
+/// use flui_widgets::SizedBox;
+///
+/// let _root = DefaultTabController::new(3, SizedBox::shrink());
+/// ```
+#[derive(Clone, StatefulView)]
+pub struct DefaultTabController {
+    length: usize,
+    initial_index: usize,
+    child: BoxedView,
+}
+
+impl DefaultTabController {
+    /// A `DefaultTabController` over `length` tabs (starting at index `0`)
+    /// wrapping `child`.
+    #[must_use]
+    pub fn new(length: usize, child: impl IntoView) -> Self {
+        Self {
+            length,
+            initial_index: 0,
+            child: child.into_view().boxed(),
+        }
+    }
+
+    /// Overrides the initially-selected tab. Defaults to `0`.
+    #[must_use]
+    pub fn initial_index(mut self, initial_index: usize) -> Self {
+        self.initial_index = initial_index;
+        self
+    }
+
+    /// The closest ancestor [`DefaultTabController`]'s [`TabController`],
+    /// registering a dependency so this element rebuilds when the
+    /// controller identity changes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there is no `DefaultTabController` ancestor. Flutter
+    /// parity: `DefaultTabController.of`, which throws a `FlutterError` in
+    /// release mode (an `assert` in debug) under the identical condition.
+    #[must_use]
+    pub fn of(ctx: &dyn BuildContext) -> TabController {
+        Self::maybe_of(ctx).expect(
+            "DefaultTabController::of called with a context that has no DefaultTabController \
+             ancestor — wrap the subtree in a DefaultTabController, or pass an explicit \
+             TabController instead",
+        )
+    }
+
+    /// Like [`of`](Self::of), but returns `None` instead of panicking when
+    /// there is no ancestor. Flutter parity: `DefaultTabController.maybeOf`.
+    #[must_use]
+    pub fn maybe_of(ctx: &dyn BuildContext) -> Option<TabController> {
+        ctx.depend_on::<TabControllerScope, _>(|scope| scope.controller.clone())
+    }
+}
+
+impl std::fmt::Debug for DefaultTabController {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DefaultTabController")
+            .field("length", &self.length)
+            .field("initial_index", &self.initial_index)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Persistent state behind [`DefaultTabController`]: the [`TabController`]
+/// it owns, re-created (not mutated) on a `length` change — see
+/// [`DefaultTabController`]'s docs.
+pub struct DefaultTabControllerState {
+    controller: TabController,
+}
+
+impl std::fmt::Debug for DefaultTabControllerState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DefaultTabControllerState")
+            .field("controller", &self.controller)
+            .finish()
+    }
+}
+
+impl StatefulView for DefaultTabController {
+    type State = DefaultTabControllerState;
+
+    fn create_state(&self) -> Self::State {
+        DefaultTabControllerState {
+            controller: TabController::new(self.length, self.initial_index),
+        }
+    }
+}
+
+impl ViewState<DefaultTabController> for DefaultTabControllerState {
+    fn did_update_view(
+        &mut self,
+        old_view: &DefaultTabController,
+        new_view: &DefaultTabController,
+    ) {
+        if new_view.length == old_view.length {
+            return;
+        }
+        self.controller = recreate_for_length_change(&self.controller, new_view.length);
+    }
+
+    fn build(&self, view: &DefaultTabController, _ctx: &dyn BuildContext) -> impl IntoView {
+        TabControllerScope {
+            controller: self.controller.clone(),
+            child: view.child.clone(),
+        }
+    }
+}
+
+/// The re-creation rule for a `length` change — extracted from
+/// [`DefaultTabControllerState::did_update_view`] so it is unit-testable in
+/// isolation. Flutter parity:
+/// `_DefaultTabControllerState.didUpdateWidget`'s `newIndex`/`previousIndex`
+/// computation (`tab_controller.dart`, oracle tag `3.44.0`); see
+/// [`DefaultTabController`]'s docs for the full contract.
+fn recreate_for_length_change(old: &TabController, new_length: usize) -> TabController {
+    let old_index = old.index();
+    if old_index >= new_length {
+        let clamped = new_length.saturating_sub(1);
+        TabController::with_previous(new_length, clamped, old_index)
+    } else {
+        TabController::with_previous(new_length, old_index, old.previous_index())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A listener that counts its own invocations. `Rc<Cell<usize>>`, not
+    /// `Arc<AtomicUsize>` — [`TabController::add_listener`] takes a plain
+    /// `!Send` closure (see the module docs), so nothing here needs to be
+    /// thread-safe.
+    fn counting_listener() -> (impl Fn() + 'static, Rc<Cell<usize>>) {
+        let count = Rc::new(Cell::new(0usize));
+        let count_for_listener = Rc::clone(&count);
+        let listener = move || {
+            count_for_listener.set(count_for_listener.get() + 1);
+        };
+        (listener, count)
+    }
+
+    #[test]
+    fn new_starts_with_index_equal_to_previous_index() {
+        let controller = TabController::new(3, 1);
+        assert_eq!(controller.index(), 1);
+        assert_eq!(controller.previous_index(), 1);
+        assert_eq!(controller.length(), 3);
+    }
+
+    #[test]
+    fn set_index_updates_index_and_previous_index() {
+        let controller = TabController::new(3, 0);
+        controller.set_index(2);
+        assert_eq!(controller.index(), 2);
+        assert_eq!(controller.previous_index(), 0);
+    }
+
+    #[test]
+    fn set_index_notifies_listeners_on_a_real_change() {
+        let controller = TabController::new(3, 0);
+        let (listener, count) = counting_listener();
+        let _id = controller.add_listener(listener);
+
+        controller.set_index(1);
+
+        assert_eq!(count.get(), 1);
+    }
+
+    /// Red-check: if `set_index` stopped checking `index == current.index`
+    /// and always wrote + notified, this would observe a spurious notify.
+    #[test]
+    fn set_index_is_a_no_op_when_the_index_does_not_change() {
+        let controller = TabController::new(3, 1);
+        let (listener, count) = counting_listener();
+        let _id = controller.add_listener(listener);
+
+        controller.set_index(1);
+
+        assert_eq!(count.get(), 0);
+        assert_eq!(
+            controller.previous_index(),
+            1,
+            "previous_index must not move on a no-op"
+        );
+    }
+
+    /// Red-check: if `set_index` dropped the `length < 2` guard, a
+    /// single-tab controller would incorrectly accept `set_index(0)` as a
+    /// "change" the first time and notify.
+    #[test]
+    fn set_index_is_a_no_op_when_length_is_below_two() {
+        let controller = TabController::new(1, 0);
+        let (listener, count) = counting_listener();
+        let _id = controller.add_listener(listener);
+
+        controller.set_index(0);
+
+        assert_eq!(count.get(), 0);
+    }
+
+    #[test]
+    fn set_index_on_a_zero_length_controller_is_a_no_op() {
+        let controller = TabController::new(0, 0);
+        let (listener, count) = counting_listener();
+        let _id = controller.add_listener(listener);
+
+        controller.set_index(0);
+
+        assert_eq!(count.get(), 0);
+        assert_eq!(controller.index(), 0);
+    }
+
+    #[test]
+    fn a_listener_reading_both_fields_mid_notify_sees_a_consistent_pair() {
+        // The pair is a single Cell::set before notify_listeners fires, so a
+        // listener invoked BY that notify must see index/previous_index
+        // already updated together, never a torn half-update.
+        let controller = TabController::new(3, 0);
+        let observed = Rc::new(Cell::new(None::<(usize, usize)>));
+        let observed_for_listener = Rc::clone(&observed);
+        let controller_for_listener = controller.clone();
+        let _id = controller.add_listener(move || {
+            observed_for_listener.set(Some((
+                controller_for_listener.index(),
+                controller_for_listener.previous_index(),
+            )));
+        });
+
+        controller.set_index(2);
+
+        assert_eq!(observed.get(), Some((2, 0)));
+    }
+
+    #[test]
+    fn animate_to_is_an_alias_for_set_index() {
+        let controller = TabController::new(3, 0);
+        controller.animate_to(2);
+        assert_eq!(controller.index(), 2);
+        assert_eq!(controller.previous_index(), 0);
+    }
+
+    #[test]
+    fn remove_listener_stops_future_notifications() {
+        let controller = TabController::new(3, 0);
+        let (listener, count) = counting_listener();
+        let id = controller.add_listener(listener);
+        controller.remove_listener(id);
+
+        controller.set_index(1);
+
+        assert_eq!(count.get(), 0);
+    }
+
+    #[test]
+    fn clones_share_identity() {
+        let a = TabController::new(3, 0);
+        let b = a.clone();
+        assert_eq!(a, b);
+
+        b.set_index(2);
+        assert_eq!(
+            a.index(),
+            2,
+            "a clone must observe the other clone's mutation"
+        );
+    }
+
+    #[test]
+    fn independently_constructed_controllers_are_not_equal() {
+        let a = TabController::new(3, 0);
+        let b = TabController::new(3, 0);
+        assert_ne!(a, b, "identical (index, length) does not imply identity");
+    }
+
+    #[test]
+    fn recreate_for_length_change_carries_a_still_valid_index_over_unchanged() {
+        let old = TabController::new(5, 2);
+        old.set_index(3);
+
+        let recreated = recreate_for_length_change(&old, 4);
+
+        assert_eq!(recreated.length(), 4);
+        assert_eq!(recreated.index(), 3, "3 is still < 4, so it carries over");
+        assert_eq!(recreated.previous_index(), old.previous_index());
+        assert_ne!(recreated, old, "recreation must produce a new identity");
+    }
+
+    /// Red-check: if the clamp used `new_length` instead of `new_length -
+    /// 1`, this would accept an out-of-range index equal to the new length.
+    #[test]
+    fn recreate_for_length_change_clamps_an_out_of_range_index_to_the_last_tab() {
+        let old = TabController::new(5, 4);
+
+        let recreated = recreate_for_length_change(&old, 2);
+
+        assert_eq!(recreated.length(), 2);
+        assert_eq!(recreated.index(), 1, "clamped to length - 1");
+        assert_eq!(
+            recreated.previous_index(),
+            4,
+            "the old out-of-range index becomes previous_index"
+        );
+    }
+
+    #[test]
+    fn recreate_for_length_change_to_zero_clamps_to_zero() {
+        let old = TabController::new(3, 2);
+
+        let recreated = recreate_for_length_change(&old, 0);
+
+        assert_eq!(recreated.length(), 0);
+        assert_eq!(recreated.index(), 0);
+        assert_eq!(recreated.previous_index(), 2);
+    }
+
+    #[test]
+    fn default_tab_controller_new_leaves_initial_index_at_zero() {
+        let root = DefaultTabController::new(3, flui_widgets::SizedBox::shrink());
+        assert_eq!(root.length, 3);
+        assert_eq!(root.initial_index, 0);
+    }
+
+    #[test]
+    fn default_tab_controller_initial_index_overrides_the_start() {
+        let root = DefaultTabController::new(3, flui_widgets::SizedBox::shrink()).initial_index(2);
+        assert_eq!(root.initial_index, 2);
+    }
+
+    #[test]
+    fn debug_format_does_not_panic() {
+        let controller = TabController::new(3, 1);
+        let rendered = format!("{controller:?}");
+        assert!(rendered.contains("TabController"));
+
+        let root = DefaultTabController::new(3, flui_widgets::SizedBox::shrink());
+        let rendered = format!("{root:?}");
+        assert!(rendered.contains("DefaultTabController"));
+    }
+}

--- a/crates/flui-material/src/tab_controller.rs
+++ b/crates/flui-material/src/tab_controller.rs
@@ -130,6 +130,10 @@ impl TabListenerRegistry {
             .retain(|(entry, _)| *entry != id);
     }
 
+    fn len(&self) -> usize {
+        self.listeners.borrow().len()
+    }
+
     /// Fires every registered listener. Snapshots the list first (cloning
     /// the `Rc<dyn Fn()>` handles, not the `Vec`'s backing allocation) so a
     /// listener that adds/removes a listener mid-notify does not conflict
@@ -239,7 +243,19 @@ impl TabController {
     /// `(index, previous_index)` tuple, so a listener invoked by the
     /// `notify_listeners()` that follows always observes a consistent pair
     /// — never `index` updated with a stale `previous_index` or vice versa.
+    ///
+    /// Flutter parity: `_changeIndex`'s own bounds assert (`assert(value >=
+    /// 0 && (value < length || length == 0))`) is ported as a
+    /// `debug_assert!` here too, matching [`new`](Self::new)'s — `index`
+    /// must be in range for [`length`](Self::length) (or `length` must be
+    /// `0`, in which case only `index == 0` ever reaches this far since the
+    /// `length < 2` no-op guard below returns first).
     pub fn set_index(&self, index: usize) {
+        debug_assert!(
+            index < self.length || self.length == 0,
+            "TabController::set_index: index {index} is out of range for length {}",
+            self.length
+        );
         let current = self.state.get();
         if index == current.index || self.length < 2 {
             return;
@@ -271,6 +287,15 @@ impl TabController {
     /// Unregisters a previously-registered listener.
     pub fn remove_listener(&self, id: ListenerId) {
         self.listeners.remove_listener(id);
+    }
+
+    /// The number of currently-registered listeners. Mainly a test seam —
+    /// mirrors `flui_foundation::ChangeNotifier::len`'s own reason for
+    /// existing: proving a consumer's `dispose()` actually unregisters
+    /// (rather than leaking) is otherwise unobservable from outside.
+    #[must_use]
+    pub fn listener_count(&self) -> usize {
+        self.listeners.len()
     }
 }
 
@@ -589,6 +614,18 @@ mod tests {
 
         assert_eq!(count.get(), 0);
         assert_eq!(controller.index(), 0);
+    }
+
+    /// Flutter parity: `_changeIndex`'s own bounds assert. Red-check: delete
+    /// the `debug_assert!` in `set_index` — this test stops panicking and
+    /// `set_index(7)` on a length-3 controller instead silently stores 7 and
+    /// notifies.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "index 7 is out of range for length 3")]
+    fn set_index_out_of_range_debug_asserts() {
+        let controller = TabController::new(3, 0);
+        controller.set_index(7);
     }
 
     #[test]

--- a/crates/flui-material/src/tabs.rs
+++ b/crates/flui-material/src/tabs.rs
@@ -1,0 +1,941 @@
+//! [`Tab`] and [`TabBar`] — the secondary M3 tab bar. See the module docs
+//! below for exactly which oracle contract this V1 ships.
+//!
+//! # Flutter parity
+//!
+//! `material/tabs.dart` (oracle tag `3.44.0`).
+//!
+//! # `TabBar` ships the SECONDARY contract only
+//!
+//! The oracle's `TabBar` has two constructors sharing one `_TabBarState`:
+//! the default (primary — a 3dp, `TabBarIndicatorSize.label`-by-default
+//! indicator meant for an `AppBar.bottom`) and `TabBar.secondary` (a 2dp,
+//! `TabBarIndicatorSize.tab` indicator meant to separate content within a
+//! page body, `_TabsSecondaryDefaultsM3`). This crate ships **only** the
+//! secondary style, as [`TabBar::secondary`] — there is no plain
+//! `TabBar::new` that could read as "the primary bar, just less finished".
+//! Shipping a primary bar honestly needs `TabBarIndicatorSize::Label`, which
+//! needs the *width of each tab's own label content* after layout
+//! (`_IndicatorPainter.indicatorRect`'s `tabKeys[tabIndex].currentContext!.size!.width`
+//! — a `GlobalKey`-mediated post-layout measurement this crate has no
+//! established pattern for yet). Rather than ship a primary bar that
+//! silently degrades to `TabBarIndicatorSize::Tab` sizing, primary is
+//! deferred wholesale until that measurement exists.
+//!
+//! # Fixed equal-share layout only (no `isScrollable`)
+//!
+//! The oracle's non-scrollable path already gives every tab an equal share
+//! via `Expanded` (`_TabBarState.build`'s `effectiveTabAlignment ==
+//! TabAlignment.fill` branch) — that is the only layout this crate ports.
+//! `isScrollable`, `TabAlignment::{Start, StartOffset, Center}`, and
+//! `scrollController` are named deferrals: the scrollable path additionally
+//! needs `_saveTabOffsets`'s post-layout tab-offset bookkeeping and a
+//! horizontal `SingleChildScrollView`, neither of which any test in this
+//! unit's acceptance list exercises.
+//!
+//! # Indicator: per-cell reserved band, not a `CustomPainter`
+//!
+//! The oracle's `_IndicatorPainter` computes one animated `Rect` per frame
+//! from `Animation<double>` + `TabController.index`/`previousIndex` and
+//! paints it (plus the divider) directly on a `Canvas`. This crate has no
+//! `AnimationController` wired to [`crate::TabController`] (see that type's
+//! module docs), so there is no per-frame interpolated value to paint in the
+//! first place — every index change is instantaneous. Given that, painting
+//! the 2dp indicator as a literal `Canvas` rect is unnecessary machinery:
+//! each tab cell reserves a fixed-height band at its own bottom edge
+//! (`indicator_weight` tall) and fills it with the resolved indicator color
+//! when selected, [`Color::TRANSPARENT`] otherwise — the same "always
+//! reserved, painted transparent when unselected" shape
+//! [`crate::NavigationBar`]'s destination indicator already uses. Because
+//! every tab cell is an equal `Expanded` share of the bar's width (see
+//! above), this composition renders **exactly** the rect the oracle's
+//! `_IndicatorPainter.indicatorRect` computes for `TabBarIndicatorSize::Tab`
+//! with `indicatorPadding: EdgeInsets.zero` — independently pinned by this
+//! module's test-only `indicator_rect` re-derivation of that geometry (see
+//! `tests`), not a function the paint path itself calls.
+//!
+//! The divider (`showDivider: true` for a non-scrollable M3 bar) is a
+//! `Positioned` full-width strip at the bar's bottom edge, stacked *behind*
+//! the tab row — so an unselected tab's transparent band still lets the
+//! divider line show through beneath it, and a selected tab's opaque
+//! indicator band paints over it, matching the oracle's paint order
+//! (divider drawn first, indicator second, in the same `Canvas` pass).
+//!
+//! # Named deferrals (not silently dropped)
+//!
+//! - **Indicator animation** (linear sweep / elastic stretch between tabs,
+//!   `_applyLinearEffect`/`_applyElasticEffect`) — needs the
+//!   `AnimationController` `TabController` doesn't have yet.
+//! - **`TabBarIndicatorSize::Label`**, custom `indicator: Decoration`,
+//!   `indicatorPadding`, rounded-corner indicators — primary-bar-only or
+//!   `Label`-sizing-only oracle features; see the "SECONDARY contract"
+//!   section above.
+//! - **`WidgetStateColor` for `labelColor`** — the oracle lets `labelColor`
+//!   itself be state-varying, ignoring `unselectedLabelColor` when it is.
+//!   This crate resolves `labelColor`/`unselectedLabelColor` as two plain
+//!   colors (exactly the M3 default table's own shape:
+//!   `_TabsSecondaryDefaultsM3.labelColor`/`unselectedLabelColor` are both
+//!   plain `Color`s, not `WidgetStateColor`s).
+//!   `overlayColor` — the hover/press/focus ramp — IS state-resolved (a
+//!   genuine `WidgetStateProperty`), since the M3 default table needs it.
+//! - **Icon recoloring** — the oracle wraps tab content in
+//!   `IconTheme.merge` so a bare `Icon` child inherits the resolved
+//!   label/icon color. This crate wraps only in
+//!   [`flui_widgets::DefaultTextStyle`] (text recoloring); a caller-supplied
+//!   icon keeps whatever color it was given. No test in this unit's
+//!   acceptance list exercises icon color.
+//! - **`labelPadding`/`TabBarThemeData` overrides for it** — fixed at
+//!   [`kTabLabelPadding`](Self) (`16.0` horizontal), no widget or theme
+//!   override surface yet.
+//! - **`onHover`/`onFocusChange`/`mouseCursor`/`splashFactory`/
+//!   `splashBorderRadius`/`dragStartBehavior`/`physics`/`textScaler`** — no
+//!   consumer yet; `InkWell`'s own defaults apply.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use flui_foundation::ListenerId;
+use flui_types::styling::Color;
+use flui_types::typography::TextStyle;
+use flui_types::{EdgeInsets, Size, geometry::px};
+use flui_view::prelude::*;
+use flui_view::{BoxedView, RebuildHandle};
+use flui_widgets::{
+    Center, Column, Container, CrossAxisAlignment, DefaultTextStyle, Expanded, Padding, Positioned,
+    PreferredSizeView, Row, SizedBox, Stack, Text, WidgetState, WidgetStateConstraint,
+    WidgetStateProperty,
+};
+
+use crate::ink_well::InkWell;
+use crate::tab_controller::{DefaultTabController, TabController};
+use crate::theme::Theme;
+use crate::theme_data::ThemeData;
+
+/// A `Tab` with no icon's height. Flutter parity: `_kTabHeight`
+/// (`tabs.dart`, oracle tag `3.44.0`).
+pub const TAB_HEIGHT: f32 = 46.0;
+
+/// A `Tab` with both an icon and text/child's height. Flutter parity:
+/// `_kTextAndIconTabHeight`.
+pub const TEXT_AND_ICON_TAB_HEIGHT: f32 = 72.0;
+
+/// The horizontal padding every tab label gets, both sides. Flutter parity:
+/// `kTabLabelPadding` (`constants.dart`, `EdgeInsets.symmetric(horizontal:
+/// 16.0)`) — see the module docs for why this crate has no override surface
+/// for it yet.
+pub const TAB_LABEL_HORIZONTAL_PADDING: f32 = 16.0;
+
+/// One [`TabBar`] tab's label content: some combination of `text`/`child`
+/// and `icon`. Flutter parity: `Tab` (`tabs.dart`, oracle tag `3.44.0`).
+///
+/// ```
+/// use flui_material::Tab;
+///
+/// let _text_tab = Tab::new().text("Home");
+/// let _custom_height_tab = Tab::new().text("Settings").height(56.0);
+/// ```
+#[derive(Clone, Debug, Default, StatelessView)]
+pub struct Tab {
+    text: Option<String>,
+    child: Option<BoxedView>,
+    icon: Option<BoxedView>,
+    height: Option<f32>,
+}
+
+impl Tab {
+    /// An empty tab — set `text`, `child`, and/or `icon` before using it (at
+    /// least one is required; a tab with none debug-asserts in `build`).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the tab's text label. Mutually exclusive with
+    /// [`child`](Self::child) — the last one set wins (mirrors the oracle's
+    /// constructor-time assert as a "last write wins" builder instead, since
+    /// a builder has no single constructor call to assert against).
+    #[must_use]
+    pub fn text(mut self, text: impl Into<String>) -> Self {
+        self.text = Some(text.into());
+        self.child = None;
+        self
+    }
+
+    /// Sets an arbitrary label widget in place of [`text`](Self::text).
+    #[must_use]
+    pub fn child(mut self, child: impl IntoView) -> Self {
+        self.child = Some(child.into_view().boxed());
+        self.text = None;
+        self
+    }
+
+    /// Adds an icon above the text/child label (or, alone, makes this an
+    /// icon-only tab).
+    #[must_use]
+    pub fn icon(mut self, icon: impl IntoView) -> Self {
+        self.icon = Some(icon.into_view().boxed());
+        self
+    }
+
+    /// Overrides the computed height (`46.0`, or `72.0` when both an icon
+    /// and text/child are present). Flutter parity: `Tab.height`.
+    #[must_use]
+    pub fn height(mut self, height: f32) -> Self {
+        self.height = Some(height);
+        self
+    }
+
+    fn has_icon(&self) -> bool {
+        self.icon.is_some()
+    }
+
+    fn has_text_or_child(&self) -> bool {
+        self.text.is_some() || self.child.is_some()
+    }
+}
+
+/// This tab's content height: `height` override first, else `72.0` when
+/// both an icon and text/child are present, else `46.0`. Flutter parity:
+/// `Tab.preferredSize`/`Tab.build`'s `calculatedHeight` (`tabs.dart`, oracle
+/// tag `3.44.0`) — the two oracle computations agree, so one function here
+/// serves both [`Tab::preferred_size`] and [`TabBar`]'s own height math.
+fn tab_content_height(tab: &Tab) -> f32 {
+    if let Some(height) = tab.height {
+        return height;
+    }
+    if tab.has_icon() && tab.has_text_or_child() {
+        TEXT_AND_ICON_TAB_HEIGHT
+    } else {
+        TAB_HEIGHT
+    }
+}
+
+/// `_TabsPrimaryDefaultsM3.iconMargin` (`Tab.iconMargin`'s M3 default,
+/// `EdgeInsets.only(bottom: 2.0)`, per `Tab.iconMargin`'s own doc comment)
+/// — no per-tab override surface yet.
+fn icon_margin() -> Padding {
+    Padding::only(0.0, 0.0, 0.0, 2.0)
+}
+
+impl StatelessView for Tab {
+    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+        debug_assert!(
+            self.has_text_or_child() || self.has_icon(),
+            "Tab requires at least one of text, child, or icon"
+        );
+
+        let label: BoxedView = if !self.has_icon() {
+            label_content(self)
+        } else if !self.has_text_or_child() {
+            self.icon
+                .clone()
+                .expect("has_icon() checked above guarantees this")
+        } else {
+            Column::new(vec![
+                icon_margin()
+                    .child(
+                        self.icon
+                            .clone()
+                            .expect("has_icon() checked above guarantees this"),
+                    )
+                    .boxed(),
+                label_content(self).boxed(),
+            ])
+            .boxed()
+        };
+
+        SizedBox::height(tab_content_height(self)).child(Center::new().child(label))
+    }
+}
+
+/// The text/child label alone (no icon) — `child` if set, else a plain
+/// `Text(text)`. Only called where `has_text_or_child()` is already known
+/// true.
+fn label_content(tab: &Tab) -> BoxedView {
+    if let Some(child) = &tab.child {
+        child.clone()
+    } else {
+        Text::new(
+            tab.text
+                .clone()
+                .expect("caller guarantees text or child is set"),
+        )
+        .boxed()
+    }
+}
+
+impl PreferredSizeView for Tab {
+    fn preferred_size(&self) -> Size {
+        Size::new(px(0.0), px(tab_content_height(self)))
+    }
+}
+
+/// The M3 secondary tab bar — see the module docs for exactly what this
+/// ships (secondary only, fixed equal-share layout, no indicator
+/// animation).
+///
+/// Flutter parity: `TabBar.secondary` (`tabs.dart`, oracle tag `3.44.0`).
+///
+/// A [`TabController`] is required either explicitly (via
+/// [`controller`](Self::controller)) or via a
+/// [`DefaultTabController`] ancestor — exactly
+/// one must be reachable, or `build` panics (Flutter parity: the oracle's
+/// `_updateTabController` `FlutterError`/`assert`).
+///
+/// ```
+/// use flui_material::{DefaultTabController, Tab, TabBar};
+///
+/// let tabs = vec![Tab::new().text("One"), Tab::new().text("Two")];
+/// let bar = DefaultTabController::new(tabs.len(), TabBar::secondary(tabs));
+/// ```
+#[derive(Clone, StatefulView)]
+pub struct TabBar {
+    tabs: Vec<Tab>,
+    controller: Option<TabController>,
+    indicator_weight: f32,
+    on_tap: Option<Rc<dyn Fn(usize)>>,
+}
+
+impl TabBar {
+    /// The M3 secondary tab bar over `tabs`. See the module/type docs for
+    /// why this is the only constructor this crate ships.
+    #[must_use]
+    pub fn secondary(tabs: Vec<Tab>) -> Self {
+        Self {
+            tabs,
+            controller: None,
+            indicator_weight: 2.0,
+            on_tap: None,
+        }
+    }
+
+    /// Supplies an explicit [`TabController`] instead of relying on a
+    /// [`DefaultTabController`] ancestor.
+    #[must_use]
+    pub fn controller(mut self, controller: TabController) -> Self {
+        self.controller = Some(controller);
+        self
+    }
+
+    /// A callback fired with the tapped tab's index, in addition to (not
+    /// instead of) the default `controller.animate_to(index)` dispatch.
+    /// Flutter parity: `TabBar.onTap`.
+    #[must_use]
+    pub fn on_tap(mut self, callback: impl Fn(usize) + 'static) -> Self {
+        self.on_tap = Some(Rc::new(callback));
+        self
+    }
+}
+
+impl std::fmt::Debug for TabBar {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TabBar")
+            .field("tab_count", &self.tabs.len())
+            .field("has_explicit_controller", &self.controller.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PreferredSizeView for TabBar {
+    fn preferred_size(&self) -> Size {
+        Size::new(
+            px(f32::INFINITY),
+            px(bar_height(&self.tabs, self.indicator_weight)),
+        )
+    }
+}
+
+/// The bar's total height: the tallest tab's content height (`46.0` if
+/// `tabs` is empty — Flutter parity: `TabBar.preferredSize`'s `maxHeight`
+/// seed) plus `indicator_weight`. Also, unmodified, the oracle's zero-tab
+/// special case (`_kTabHeight + indicatorWeight`, `_TabBarState.build`'s
+/// early return) — no separate branch is needed here because folding over
+/// an empty `tabs` slice already returns the `TAB_HEIGHT` seed.
+fn bar_height(tabs: &[Tab], indicator_weight: f32) -> f32 {
+    let max_content_height = tabs
+        .iter()
+        .map(tab_content_height)
+        .fold(TAB_HEIGHT, f32::max);
+    max_content_height + indicator_weight
+}
+
+/// Whether any tab in `tabs` has both an icon and text/child (i.e. its
+/// content height is `TEXT_AND_ICON_TAB_HEIGHT`). Flutter parity:
+/// `TabBar.tabHasTextAndIcon`.
+fn tab_has_text_and_icon(tabs: &[Tab]) -> bool {
+    tabs.iter()
+        .any(|tab| tab_content_height(tab) == TEXT_AND_ICON_TAB_HEIGHT)
+}
+
+/// [`TabBar`]'s theme-resolved colors/styles — see [`resolve_style`]'s doc
+/// comment for the widget → theme → default cascade (this V1 has no
+/// per-widget override for these, only theme → default; see the module
+/// docs).
+struct ResolvedTabBarStyle {
+    indicator_color: Color,
+    label_color: Color,
+    unselected_label_color: Color,
+    label_style: TextStyle,
+    unselected_label_style: TextStyle,
+    divider_color: Color,
+    divider_height: f32,
+    overlay_color: WidgetStateProperty<Option<Color>>,
+}
+
+/// Resolves the M3 secondary defaults (`_TabsSecondaryDefaultsM3`,
+/// `tabs.dart`, oracle tag `3.44.0`) through the theme → default cascade:
+/// `TabBarThemeData` field if set, else the literal M3 secondary default.
+///
+/// | Field | M3 secondary default | Oracle |
+/// |---|---|---|
+/// | `indicator_color` | `ColorScheme.primary` | `_TabsSecondaryDefaultsM3.indicatorColor` |
+/// | `label_color` | `ColorScheme.onSurface` | `_TabsSecondaryDefaultsM3.labelColor` |
+/// | `unselected_label_color` | `ColorScheme.onSurfaceVariant` | `_TabsSecondaryDefaultsM3.unselectedLabelColor` |
+/// | `label_style` / `unselected_label_style` | `TextTheme.titleSmall` | `_TabsSecondaryDefaultsM3.labelStyle`/`unselectedLabelStyle` |
+/// | `divider_color` | `ColorScheme.outlineVariant` | `_TabsSecondaryDefaultsM3.dividerColor` |
+/// | `divider_height` | `1.0` | `_TabsSecondaryDefaultsM3.dividerHeight` |
+/// | `overlay_color` | pressed→`onSurface@0.1`, hovered→`onSurface@0.08`, focused→`onSurface@0.1`, else none | `_TabsSecondaryDefaultsM3.overlayColor` |
+fn resolve_style(theme: &ThemeData) -> ResolvedTabBarStyle {
+    let tab_bar_theme = theme.tab_bar_theme.as_ref();
+    let colors = &theme.color_scheme;
+    let title_small = theme.text_theme.title_small.clone().unwrap_or_default();
+
+    ResolvedTabBarStyle {
+        indicator_color: tab_bar_theme
+            .and_then(|t| t.indicator_color)
+            .unwrap_or(colors.primary),
+        label_color: tab_bar_theme
+            .and_then(|t| t.label_color)
+            .unwrap_or(colors.on_surface),
+        unselected_label_color: tab_bar_theme
+            .and_then(|t| t.unselected_label_color)
+            .unwrap_or(colors.on_surface_variant),
+        label_style: tab_bar_theme
+            .and_then(|t| t.label_style.clone())
+            .unwrap_or_else(|| title_small.clone()),
+        unselected_label_style: tab_bar_theme
+            .and_then(|t| t.unselected_label_style.clone())
+            .unwrap_or(title_small),
+        divider_color: tab_bar_theme
+            .and_then(|t| t.divider_color)
+            .unwrap_or(colors.outline_variant),
+        divider_height: tab_bar_theme.and_then(|t| t.divider_height).unwrap_or(1.0),
+        overlay_color: tab_bar_theme
+            .and_then(|t| t.overlay_color.clone())
+            .unwrap_or_else(|| default_overlay_color(colors.on_surface)),
+    }
+}
+
+/// `_TabsSecondaryDefaultsM3.overlayColor`'s resolver — pressed/hovered/
+/// focused ramp over `on_surface`, identical whether or not the tab is
+/// selected (the oracle's own `selected`-branch and non-`selected`-branch
+/// happen to produce the same three values — see `tabs.dart`'s
+/// `_TabsSecondaryDefaultsM3.overlayColor` getter, oracle tag `3.44.0`).
+fn default_overlay_color(on_surface: Color) -> WidgetStateProperty<Option<Color>> {
+    WidgetStateProperty::from_map([
+        (
+            WidgetStateConstraint::Is(WidgetState::Pressed),
+            Some(on_surface.with_opacity(0.1)),
+        ),
+        (
+            WidgetStateConstraint::Is(WidgetState::Hovered),
+            Some(on_surface.with_opacity(0.08)),
+        ),
+        (
+            WidgetStateConstraint::Is(WidgetState::Focused),
+            Some(on_surface.with_opacity(0.1)),
+        ),
+    ])
+}
+
+/// This tab's label padding: [`TAB_LABEL_HORIZONTAL_PADDING`] both sides,
+/// plus `±13.0` vertical when `tab`'s own content height is `TAB_HEIGHT`
+/// (`46.0`) but the bar as a whole has a text-and-icon tab (`72.0`) — the
+/// mechanism that centers a plain tab's content inside a taller mixed bar.
+/// Flutter parity: `_TabBarState.build`'s `verticalAdjustment` (`(
+/// _kTextAndIconTabHeight - _kTabHeight) / 2.0`, i.e. `13.0`), added to
+/// `kTabLabelPadding` when `tab.preferredSize.height == _kTabHeight &&
+/// widget.tabHasTextAndIcon` (`tabs.dart`, oracle tag `3.44.0`) — ported
+/// honestly as padding, not as a `Center`-widget trick, because that is
+/// exactly the mechanism the oracle itself uses.
+fn label_padding(tab: &Tab, bar_has_mixed_tabs: bool) -> EdgeInsets {
+    let vertical = if bar_has_mixed_tabs && tab_content_height(tab) == TAB_HEIGHT {
+        (TEXT_AND_ICON_TAB_HEIGHT - TAB_HEIGHT) / 2.0
+    } else {
+        0.0
+    };
+    EdgeInsets::symmetric(px(vertical), px(TAB_LABEL_HORIZONTAL_PADDING))
+}
+
+/// Persistent state behind [`TabBar`]: the currently-subscribed
+/// [`TabController`] and its listener registration, re-resolved every
+/// `build` — see `resolve_controller`'s doc comment (private, `impl
+/// TabBarState`) for exactly when the subscription is re-homed.
+pub struct TabBarState {
+    controller: RefCell<Option<TabController>>,
+    listener_id: RefCell<Option<ListenerId>>,
+    rebuild: Option<RebuildHandle>,
+}
+
+impl std::fmt::Debug for TabBarState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TabBarState")
+            .field("controller", &self.controller.borrow())
+            .finish_non_exhaustive()
+    }
+}
+
+impl StatefulView for TabBar {
+    type State = TabBarState;
+
+    fn create_state(&self) -> Self::State {
+        TabBarState {
+            controller: RefCell::new(None),
+            listener_id: RefCell::new(None),
+            rebuild: None,
+        }
+    }
+}
+
+impl TabBarState {
+    /// Resolves `view`'s effective controller (explicit, else
+    /// [`DefaultTabController::maybe_of`]) and, if it differs by identity
+    /// from the currently-subscribed one, swaps the listener registration
+    /// onto it. Called from `build` (see that trait's doc on why `&self`
+    /// mutation goes through `RefCell` here, matching
+    /// [`crate::InkWellState`]'s own pattern) — `ViewState::did_change_dependencies`
+    /// has no `view` parameter, so it cannot see `view.controller` to decide
+    /// the fallback, and re-resolving unconditionally on every `build` is
+    /// cheap (one identity comparison) and always correct regardless of
+    /// which lifecycle hook triggered the rebuild.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `view` has no explicit controller and there is no
+    /// `DefaultTabController` ancestor. Flutter parity: `_updateTabController`'s
+    /// `FlutterError`.
+    fn resolve_controller(&self, view: &TabBar, ctx: &dyn BuildContext) -> TabController {
+        let resolved = view
+            .controller
+            .clone()
+            .or_else(|| DefaultTabController::maybe_of(ctx))
+            .expect(
+                "TabBar requires an explicit controller (TabBar::controller) or a \
+             DefaultTabController ancestor",
+            );
+
+        let changed = self
+            .controller
+            .borrow()
+            .as_ref()
+            .is_none_or(|current| *current != resolved);
+
+        if changed {
+            let previous_controller = self.controller.borrow_mut().take();
+            let previous_listener = self.listener_id.borrow_mut().take();
+            if let (Some(previous_controller), Some(id)) = (previous_controller, previous_listener)
+            {
+                previous_controller.remove_listener(id);
+            }
+
+            let rebuild = self
+                .rebuild
+                .clone()
+                .expect("init_state runs before the first build");
+            let id = resolved.add_listener(move || {
+                rebuild.schedule();
+            });
+            *self.listener_id.borrow_mut() = Some(id);
+            *self.controller.borrow_mut() = Some(resolved.clone());
+        }
+
+        resolved
+    }
+}
+
+impl ViewState<TabBar> for TabBarState {
+    fn init_state(&mut self, ctx: &dyn BuildContext) {
+        self.rebuild = Some(ctx.rebuild_handle());
+    }
+
+    fn build(&self, view: &TabBar, ctx: &dyn BuildContext) -> impl IntoView {
+        let controller = self.resolve_controller(view, ctx);
+        let theme = Theme::of(ctx);
+        let resolved = resolve_style(&theme);
+        let height = bar_height(&view.tabs, view.indicator_weight);
+
+        if view.tabs.is_empty() {
+            // Flutter parity: `_TabBarState.build`'s zero-tabs early return
+            // (`LimitedBox(maxWidth: 0.0, child: SizedBox(width:
+            // double.infinity, height: _kTabHeight + indicatorWeight))`).
+            // The `LimitedBox(maxWidth: 0.0)` half only matters when the
+            // incoming width constraint is unbounded — a plain
+            // width-unconstrained `SizedBox::height` behaves identically in
+            // every bounded parent this bar is normally mounted under; named
+            // simplification for that one unbounded-width edge case.
+            //
+            // A controller is still resolved above even for zero tabs —
+            // matching the oracle exactly: `_updateTabController`'s
+            // controller resolution runs in `didChangeDependencies`,
+            // unconditionally, before `build` ever checks
+            // `_controller!.length == 0`. A zero-tab `TabBar` with no
+            // controller and no `DefaultTabController` ancestor still
+            // panics, same as a non-empty one.
+            return SizedBox::height(height).boxed();
+        }
+
+        let mixed = tab_has_text_and_icon(&view.tabs);
+        let current_index = controller.index();
+
+        let cells: Vec<BoxedView> = view
+            .tabs
+            .iter()
+            .enumerate()
+            .map(|(index, tab)| {
+                build_tab_cell(
+                    index,
+                    tab,
+                    index == current_index,
+                    mixed,
+                    &resolved,
+                    view.indicator_weight,
+                    &controller,
+                    view.on_tap.as_ref(),
+                )
+            })
+            .collect();
+
+        let row = Row::new(cells).cross_axis_alignment(CrossAxisAlignment::Stretch);
+
+        let content: BoxedView =
+            if resolved.divider_height > 0.0 && resolved.divider_color != Color::TRANSPARENT {
+                let divider = Positioned::new(
+                    Container::new()
+                        .color(resolved.divider_color)
+                        .height(resolved.divider_height),
+                )
+                .left(0.0)
+                .right(0.0)
+                .bottom(0.0);
+                Stack::new(vec![divider.boxed(), row.boxed()]).boxed()
+            } else {
+                row.boxed()
+            };
+
+        SizedBox::height(height).child(content).boxed()
+    }
+}
+
+/// Builds one tab's `Expanded` cell: label content (recolored/padded per
+/// selection), the reserved indicator band, wrapped in an [`InkWell`] that
+/// dispatches taps to `controller`/`on_tap`. Flutter parity: the relevant
+/// slice of `_TabBarState.build` (label wrapping, `_TabStyle`, `InkWell`,
+/// `Expanded`) — see the module docs for what is and is not ported.
+#[allow(clippy::too_many_arguments, reason = "internal helper, not public API")]
+fn build_tab_cell(
+    index: usize,
+    tab: &Tab,
+    selected: bool,
+    bar_has_mixed_tabs: bool,
+    resolved: &ResolvedTabBarStyle,
+    indicator_weight: f32,
+    controller: &TabController,
+    on_tap: Option<&Rc<dyn Fn(usize)>>,
+) -> BoxedView {
+    let (label_color, label_style) = if selected {
+        (resolved.label_color, resolved.label_style.clone())
+    } else {
+        (
+            resolved.unselected_label_color,
+            resolved.unselected_label_style.clone(),
+        )
+    };
+
+    let padded = Padding::new(label_padding(tab, bar_has_mixed_tabs))
+        .child(Center::new().child(tab.clone()));
+    let styled = DefaultTextStyle::new(label_style.with_color(label_color), padded);
+
+    let band_color = if selected {
+        resolved.indicator_color
+    } else {
+        Color::TRANSPARENT
+    };
+    let band = Container::new().height(indicator_weight).color(band_color);
+
+    let cell = Column::new(vec![Expanded::new(styled).boxed(), band.boxed()])
+        .cross_axis_alignment(CrossAxisAlignment::Stretch);
+
+    let tap_controller = controller.clone();
+    let tap_callback = on_tap.cloned();
+    let ink_well = InkWell::new(cell)
+        .overlay_color(resolved.overlay_color.clone())
+        .on_tap(move || {
+            tap_controller.animate_to(index);
+            if let Some(callback) = &tap_callback {
+                callback(index);
+            }
+        });
+
+    Expanded::new(ink_well).boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use flui_types::Rect;
+
+    use super::*;
+    use crate::theme_data::TabBarThemeData;
+
+    /// The 2dp indicator's rect for `index` in a `tab_count`-tab bar —
+    /// re-derives the geometry `build_tab_cell`'s per-cell band composition
+    /// implicitly renders (see the module docs' "Indicator: per-cell
+    /// reserved band" section), so that geometry is pinned by a test
+    /// independent of the widget tree. Flutter parity:
+    /// `_IndicatorPainter.indicatorRect` specialized to
+    /// `TabBarIndicatorSize::Tab` with `indicatorPadding: EdgeInsets.zero`
+    /// (this crate's only supported combination) and this crate's fixed
+    /// equal-share tab widths.
+    fn indicator_rect(
+        bar_width: f32,
+        bar_height: f32,
+        tab_count: usize,
+        indicator_weight: f32,
+        index: usize,
+    ) -> Rect {
+        assert!(tab_count > 0, "indicator_rect requires at least one tab");
+        assert!(index < tab_count, "index out of range for tab_count");
+        let tab_width = bar_width / tab_count as f32;
+        Rect::from_ltwh(
+            px(tab_width * index as f32),
+            px(bar_height - indicator_weight),
+            px(tab_width),
+            px(indicator_weight),
+        )
+    }
+
+    #[test]
+    fn tab_content_height_defaults_to_tab_height_with_no_icon() {
+        let tab = Tab::new().text("Home");
+        assert_eq!(tab_content_height(&tab), TAB_HEIGHT);
+    }
+
+    #[test]
+    fn tab_content_height_is_text_and_icon_height_with_both() {
+        let tab = Tab::new()
+            .text("Home")
+            .icon(flui_widgets::SizedBox::shrink());
+        assert_eq!(tab_content_height(&tab), TEXT_AND_ICON_TAB_HEIGHT);
+    }
+
+    #[test]
+    fn tab_content_height_is_tab_height_for_icon_only() {
+        let tab = Tab::new().icon(flui_widgets::SizedBox::shrink());
+        assert_eq!(tab_content_height(&tab), TAB_HEIGHT);
+    }
+
+    #[test]
+    fn tab_content_height_override_wins_over_computed_height() {
+        let tab = Tab::new()
+            .text("Home")
+            .icon(flui_widgets::SizedBox::shrink())
+            .height(20.0);
+        assert_eq!(tab_content_height(&tab), 20.0);
+    }
+
+    #[test]
+    fn tab_preferred_size_matches_content_height() {
+        let tab = Tab::new().text("Home");
+        assert_eq!(tab.preferred_size().height, px(TAB_HEIGHT));
+    }
+
+    #[test]
+    fn bar_height_is_48_for_the_default_tab_height() {
+        let tabs = vec![Tab::new().text("A"), Tab::new().text("B")];
+        assert_eq!(bar_height(&tabs, 2.0), 48.0);
+    }
+
+    /// Red-check: mutating the `fold` seed from `TAB_HEIGHT` to `0.0` would
+    /// still pass every non-empty case (a real tab is always >= 46) but
+    /// break the empty-bar case below.
+    #[test]
+    fn bar_height_for_zero_tabs_is_48() {
+        assert_eq!(bar_height(&[], 2.0), TAB_HEIGHT + 2.0);
+    }
+
+    #[test]
+    fn bar_height_is_74_when_a_tab_has_text_and_icon() {
+        let tabs = vec![
+            Tab::new().text("A"),
+            Tab::new().text("B").icon(flui_widgets::SizedBox::shrink()),
+        ];
+        assert_eq!(bar_height(&tabs, 2.0), TEXT_AND_ICON_TAB_HEIGHT + 2.0);
+    }
+
+    #[test]
+    fn tab_bar_preferred_size_matches_bar_height() {
+        let tabs = vec![Tab::new().text("A"), Tab::new().text("B")];
+        let bar = TabBar::secondary(tabs);
+        assert_eq!(bar.preferred_size().height, px(48.0));
+    }
+
+    #[test]
+    fn tab_bar_preferred_size_for_zero_tabs_is_48() {
+        let bar = TabBar::secondary(vec![]);
+        assert_eq!(bar.preferred_size().height, px(48.0));
+    }
+
+    #[test]
+    fn tab_has_text_and_icon_is_false_with_no_mixed_tabs() {
+        let tabs = vec![Tab::new().text("A"), Tab::new().text("B")];
+        assert!(!tab_has_text_and_icon(&tabs));
+    }
+
+    #[test]
+    fn tab_has_text_and_icon_is_true_with_one_mixed_tab() {
+        let tabs = vec![
+            Tab::new().text("A"),
+            Tab::new().text("B").icon(flui_widgets::SizedBox::shrink()),
+        ];
+        assert!(tab_has_text_and_icon(&tabs));
+    }
+
+    #[test]
+    fn label_padding_has_no_vertical_adjustment_in_a_uniform_bar() {
+        let tab = Tab::new().text("A");
+        let padding = label_padding(&tab, false);
+        assert_eq!(padding, EdgeInsets::symmetric(px(0.0), px(16.0)));
+    }
+
+    #[test]
+    fn label_padding_adds_13dp_vertical_for_a_plain_tab_in_a_mixed_bar() {
+        let tab = Tab::new().text("A");
+        let padding = label_padding(&tab, true);
+        assert_eq!(padding, EdgeInsets::symmetric(px(13.0), px(16.0)));
+    }
+
+    /// Red-check: if the mixed-bar check ignored `Tab::height` overrides and
+    /// compared only computed height, a height-overridden tab that happens
+    /// to equal `TAB_HEIGHT` numerically would still get the adjustment even
+    /// when it's a deliberate override rather than the plain 46px default —
+    /// this asserts the *override* path is not skipped for that comparison.
+    #[test]
+    fn label_padding_uses_the_overridden_height_not_only_the_computed_one() {
+        let overridden = Tab::new().text("A").height(TEXT_AND_ICON_TAB_HEIGHT);
+        assert_eq!(
+            label_padding(&overridden, true),
+            EdgeInsets::symmetric(px(0.0), px(16.0))
+        );
+    }
+
+    #[test]
+    fn indicator_rect_spans_the_first_of_two_equal_tabs() {
+        let rect = indicator_rect(200.0, 48.0, 2, 2.0, 0);
+        assert_eq!(rect, Rect::from_ltwh(px(0.0), px(46.0), px(100.0), px(2.0)));
+    }
+
+    #[test]
+    fn indicator_rect_spans_the_second_of_two_equal_tabs() {
+        let rect = indicator_rect(200.0, 48.0, 2, 2.0, 1);
+        assert_eq!(
+            rect,
+            Rect::from_ltwh(px(100.0), px(46.0), px(100.0), px(2.0))
+        );
+    }
+
+    /// Red-check: if `indicator_rect` divided by `index` instead of
+    /// `tab_count`, three equal tabs would not tile the bar width evenly.
+    #[test]
+    fn indicator_rect_tiles_three_equal_tabs_across_the_full_width() {
+        let first = indicator_rect(300.0, 48.0, 3, 2.0, 0);
+        let second = indicator_rect(300.0, 48.0, 3, 2.0, 1);
+        let third = indicator_rect(300.0, 48.0, 3, 2.0, 2);
+        assert_eq!(first.width(), px(100.0));
+        assert_eq!(second.width(), px(100.0));
+        assert_eq!(third.width(), px(100.0));
+        assert_eq!(first.left(), px(0.0));
+        assert_eq!(second.left(), px(100.0));
+        assert_eq!(third.left(), px(200.0));
+    }
+
+    #[test]
+    fn resolve_style_defaults_to_the_m3_secondary_token_table() {
+        let theme = ThemeData::light();
+        let resolved = resolve_style(&theme);
+
+        assert_eq!(resolved.indicator_color, theme.color_scheme.primary);
+        assert_eq!(resolved.label_color, theme.color_scheme.on_surface);
+        assert_eq!(
+            resolved.unselected_label_color,
+            theme.color_scheme.on_surface_variant
+        );
+        assert_eq!(resolved.divider_color, theme.color_scheme.outline_variant);
+        assert_eq!(resolved.divider_height, 1.0);
+        assert_eq!(
+            resolved.label_style,
+            theme.text_theme.title_small.clone().unwrap_or_default()
+        );
+        assert_eq!(resolved.label_style, resolved.unselected_label_style);
+    }
+
+    #[test]
+    fn resolve_style_overlay_color_matches_the_secondary_defaults_table() {
+        let theme = ThemeData::light();
+        let resolved = resolve_style(&theme);
+        let on_surface = theme.color_scheme.on_surface;
+
+        let pressed = resolved
+            .overlay_color
+            .resolve(&flui_widgets::WidgetStates::from(WidgetState::Pressed));
+        let hovered = resolved
+            .overlay_color
+            .resolve(&flui_widgets::WidgetStates::from(WidgetState::Hovered));
+        let focused = resolved
+            .overlay_color
+            .resolve(&flui_widgets::WidgetStates::from(WidgetState::Focused));
+        let none = resolved
+            .overlay_color
+            .resolve(&flui_widgets::WidgetStates::NONE);
+
+        assert_eq!(pressed, Some(on_surface.with_opacity(0.1)));
+        assert_eq!(hovered, Some(on_surface.with_opacity(0.08)));
+        assert_eq!(focused, Some(on_surface.with_opacity(0.1)));
+        assert_eq!(none, None);
+    }
+
+    #[test]
+    fn resolve_style_theme_override_beats_the_default() {
+        let mut theme = ThemeData::light();
+        let themed_indicator = Color::rgb(9, 9, 9);
+        theme.tab_bar_theme = Some(TabBarThemeData {
+            indicator_color: Some(themed_indicator),
+            ..Default::default()
+        });
+
+        let resolved = resolve_style(&theme);
+
+        assert_eq!(resolved.indicator_color, themed_indicator);
+        // Fields left unset on the theme slot still fall through to their
+        // own M3 default independently.
+        assert_eq!(resolved.label_color, theme.color_scheme.on_surface);
+    }
+
+    #[test]
+    fn tab_bar_secondary_starts_with_no_explicit_controller() {
+        let bar = TabBar::secondary(vec![Tab::new().text("A")]);
+        assert!(bar.controller.is_none());
+    }
+
+    #[test]
+    fn tab_bar_controller_sets_the_explicit_controller() {
+        let controller = TabController::new(1, 0);
+        let bar = TabBar::secondary(vec![Tab::new().text("A")]).controller(controller.clone());
+        assert_eq!(bar.controller, Some(controller));
+    }
+
+    #[test]
+    fn debug_format_does_not_panic() {
+        let bar = TabBar::secondary(vec![Tab::new().text("A")]);
+        let rendered = format!("{bar:?}");
+        assert!(rendered.contains("TabBar"));
+    }
+}

--- a/crates/flui-material/src/tabs.rs
+++ b/crates/flui-material/src/tabs.rs
@@ -50,16 +50,26 @@
 //! every tab cell is an equal `Expanded` share of the bar's width (see
 //! above), this composition renders **exactly** the rect the oracle's
 //! `_IndicatorPainter.indicatorRect` computes for `TabBarIndicatorSize::Tab`
-//! with `indicatorPadding: EdgeInsets.zero` — independently pinned by this
-//! module's test-only `indicator_rect` re-derivation of that geometry (see
-//! `tests`), not a function the paint path itself calls.
+//! with `indicatorPadding: EdgeInsets.zero`: the *horizontal* bounds are
+//! pinned in isolation by this module's test-only `indicator_rect`
+//! re-derivation (see `tests`, not a function the paint path itself calls),
+//! and the *vertical* position (the band sits at the bar's bottom edge, not
+//! its top) is pinned end to end, against the real mounted render tree, by
+//! `crates/flui-material/tests/tabs.rs`'s
+//! `indicator_band_sits_at_the_bar_bottom_beneath_the_divider_and_paints_over_it`
+//! — the horizontal-only unit test cannot see a regression that reverses
+//! the `Column`'s child order, so the vertical claim needs its own,
+//! independent, mounted proof.
 //!
 //! The divider (`showDivider: true` for a non-scrollable M3 bar) is a
 //! `Positioned` full-width strip at the bar's bottom edge, stacked *behind*
 //! the tab row — so an unselected tab's transparent band still lets the
 //! divider line show through beneath it, and a selected tab's opaque
 //! indicator band paints over it, matching the oracle's paint order
-//! (divider drawn first, indicator second, in the same `Canvas` pass).
+//! (divider drawn first, indicator second, in the same `Canvas` pass). The
+//! same mounted test above proves this stacking order structurally (the
+//! `Stack`'s divider layer is its first, earlier-painted child; the tab row
+//! is its second, later-painted — hence on top — child).
 //!
 //! # Named deferrals (not silently dropped)
 //!
@@ -90,6 +100,27 @@
 //! - **`onHover`/`onFocusChange`/`mouseCursor`/`splashFactory`/
 //!   `splashBorderRadius`/`dragStartBehavior`/`physics`/`textScaler`** — no
 //!   consumer yet; `InkWell`'s own defaults apply.
+//! - **Per-tab `Semantics`** — the oracle wraps each tab in
+//!   `Semantics(role: SemanticsRole.tab, child: Stack([content,
+//!   Semantics(selected: ..., label: "Tab N of M")]))` plus a
+//!   `SemanticsRole.tabBar` container on the bar itself
+//!   (`_TabBarState.build`, `tabs.dart`, oracle tag `3.44.0`). This crate
+//!   mounts no semantics annotation at all for `TabBar` — no "Tab 2 of 3"
+//!   label, no `selected` flag, no `tab`/`tabBar` role — so an assistive
+//!   technology gets no structured information about a mounted `TabBar`
+//!   today. Named, not silently dropped: a real gap, not a stylistic
+//!   simplification.
+//! - **`enableFeedback`** — the oracle's `InkWell.enableFeedback` (haptic/
+//!   acoustic click feedback on tap, defaulting to `true`) has no analog
+//!   here; [`crate::InkWell`] itself has no `enableFeedback` parameter yet
+//!   (see that module's own docs), so `TabBar` has nothing to plumb it to.
+//! - **`automaticIndicatorColorAdjustment`** — the oracle snaps
+//!   `indicatorColor` to white when it would otherwise match the ambient
+//!   `Material`'s own fill color (avoiding an invisible indicator). This
+//!   crate's indicator band is a plain `Container` fill with no ambient-color
+//!   lookup at all — an indicator configured (via `TabBarThemeData` or a
+//!   theme with an unusual `ColorScheme.primary`) to match the bar's actual
+//!   background paints invisibly, with no automatic correction.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -556,6 +587,32 @@ impl TabBarState {
 impl ViewState<TabBar> for TabBarState {
     fn init_state(&mut self, ctx: &dyn BuildContext) {
         self.rebuild = Some(ctx.rebuild_handle());
+    }
+
+    /// Unregisters this bar's listener from whatever controller it's
+    /// currently subscribed to — Flutter parity: `_TabBarState.dispose`'s
+    /// `_controller!.animation!.removeListener(...)`/
+    /// `_controller!.removeListener(_handleTabControllerTick)`. Without
+    /// this, a controller that outlives the bar (an explicit
+    /// `TabBar::controller` shared with a sibling, or any
+    /// `DefaultTabController` ancestor that itself outlives one particular
+    /// `TabBar` child) keeps firing an `Rc` closure that calls
+    /// `rebuild.schedule()` on a `RebuildHandle` whose element no longer
+    /// exists — a leaked listener per unmount, same class of bug
+    /// `TextFieldState::dispose` guards against for `FocusManager`
+    /// (`crates/flui-material/tests/text_field.rs`'s
+    /// `unmounting_removes_the_focus_listener_from_the_process_wide_manager`).
+    ///
+    /// `&mut self` here (unlike `resolve_controller`, called from `build`'s
+    /// `&self`) means the `RefCell`s can be read via `get_mut` — a plain
+    /// field access with no runtime borrow check — rather than
+    /// `borrow_mut`.
+    fn dispose(&mut self) {
+        let controller = self.controller.get_mut().take();
+        let listener_id = self.listener_id.get_mut().take();
+        if let (Some(controller), Some(id)) = (controller, listener_id) {
+            controller.remove_listener(id);
+        }
     }
 
     fn build(&self, view: &TabBar, ctx: &dyn BuildContext) -> impl IntoView {

--- a/crates/flui-material/src/theme_data.rs
+++ b/crates/flui-material/src/theme_data.rs
@@ -604,6 +604,53 @@ pub struct NavigationBarThemeData {
     pub overlay_color: Option<StateColor>,
 }
 
+/// Overrides [`TabBar`](crate::TabBar)'s `_TabsSecondaryDefaultsM3` token
+/// defaults, one field at a time — an unset field still falls through to
+/// `TabBar`'s own M3 secondary default table (see `tabs.rs`'s
+/// `resolve_style`), it does not blank the whole slot.
+///
+/// Flutter parity: `TabBarThemeData` (`material/tab_bar_theme.dart`, oracle
+/// tag `3.44.0`), narrowed to the fields FLUI's `TabBar` actually consumes:
+/// [`indicator_color`](Self::indicator_color), [`label_color`](Self::label_color),
+/// [`unselected_label_color`](Self::unselected_label_color),
+/// [`label_style`](Self::label_style),
+/// [`unselected_label_style`](Self::unselected_label_style),
+/// [`divider_color`](Self::divider_color), [`divider_height`](Self::divider_height),
+/// [`overlay_color`](Self::overlay_color). Named deferrals (no consumer in
+/// FLUI's `TabBar` yet — see that module's docs for the full
+/// named-divergence list): `indicator` (custom `Decoration`), `indicator_size`
+/// (fixed at `TabBarIndicatorSize::Tab`, the only size the secondary-only V1
+/// supports), `label_padding` (fixed at `kTabLabelPadding`), `splash_factory`,
+/// `mouse_cursor`, `tab_alignment` (fixed at the fill/equal-share layout),
+/// `text_scaler`, `indicator_animation` (no `AnimationController` on
+/// `TabController` yet), `splash_border_radius`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TabBarThemeData {
+    /// Overrides [`TabBar`](crate::TabBar)'s default selected-tab indicator
+    /// color (`ColorScheme.primary`).
+    pub indicator_color: Option<Color>,
+    /// Overrides [`TabBar`](crate::TabBar)'s default selected-label color
+    /// (`ColorScheme.onSurface`).
+    pub label_color: Option<Color>,
+    /// Overrides [`TabBar`](crate::TabBar)'s default unselected-label color
+    /// (`ColorScheme.onSurfaceVariant`).
+    pub unselected_label_color: Option<Color>,
+    /// Overrides [`TabBar`](crate::TabBar)'s default selected-label text
+    /// style (`TextTheme.titleSmall`).
+    pub label_style: Option<TextStyle>,
+    /// Overrides [`TabBar`](crate::TabBar)'s default unselected-label text
+    /// style (`TextTheme.titleSmall`).
+    pub unselected_label_style: Option<TextStyle>,
+    /// Overrides [`TabBar`](crate::TabBar)'s default divider color
+    /// (`ColorScheme.outlineVariant`).
+    pub divider_color: Option<Color>,
+    /// Overrides [`TabBar`](crate::TabBar)'s default divider height (`1.0`).
+    pub divider_height: Option<f32>,
+    /// Overrides each tab's default hover/focus/press overlay color, per
+    /// state.
+    pub overlay_color: Option<StateColor>,
+}
+
 /// Overrides [`Radio`](crate::Radio)'s `_RadioDefaultsM3` token defaults,
 /// one field at a time — an unset field here still falls through to
 /// `Radio`'s own M3 default table (see `radio.rs`'s `radio_default_*`
@@ -739,6 +786,10 @@ pub struct ThemeData {
     /// Overrides [`NavigationBar`](crate::NavigationBar)'s M3 token defaults,
     /// per field. Flutter parity: `ThemeData.navigationBarTheme`.
     pub navigation_bar_theme: Option<NavigationBarThemeData>,
+
+    /// Overrides [`TabBar`](crate::TabBar)'s M3 secondary token defaults,
+    /// per field. Flutter parity: `ThemeData.tabBarTheme`.
+    pub tab_bar_theme: Option<TabBarThemeData>,
 }
 
 impl ThemeData {
@@ -768,6 +819,7 @@ impl ThemeData {
             switch_theme: None,
             radio_theme: None,
             navigation_bar_theme: None,
+            tab_bar_theme: None,
         }
     }
 
@@ -797,6 +849,7 @@ impl ThemeData {
             switch_theme: None,
             radio_theme: None,
             navigation_bar_theme: None,
+            tab_bar_theme: None,
         }
     }
 
@@ -891,6 +944,9 @@ impl ThemeData {
             navigation_bar_theme: overrides
                 .navigation_bar_theme
                 .or_else(|| self.navigation_bar_theme.clone()),
+            tab_bar_theme: overrides
+                .tab_bar_theme
+                .or_else(|| self.tab_bar_theme.clone()),
         }
     }
 }
@@ -953,6 +1009,8 @@ pub struct ThemeDataOverrides {
     pub radio_theme: Option<RadioThemeData>,
     /// Replaces [`ThemeData::navigation_bar_theme`] wholesale when `Some`.
     pub navigation_bar_theme: Option<NavigationBarThemeData>,
+    /// Replaces [`ThemeData::tab_bar_theme`] wholesale when `Some`.
+    pub tab_bar_theme: Option<TabBarThemeData>,
 }
 
 impl Default for ThemeData {

--- a/crates/flui-material/tests/tabs.rs
+++ b/crates/flui-material/tests/tabs.rs
@@ -1,0 +1,337 @@
+//! `Tab`/`TabBar`/`DefaultTabController` widget-level mount/interaction
+//! coverage — complements `tabs.rs`'s/`tab_controller.rs`'s own unit tests
+//! (M3 secondary default token-table probes, the pure `TabController`
+//! state-machine, `bar_height`/`label_padding`/`indicator_rect` geometry)
+//! with end-to-end mount proof: a real pointer down+up reaches
+//! [`TabController::set_index`] through [`InkWell`]'s dispatch, the divider
+//! and its theme override actually reach the mounted render tree (not just
+//! `resolve_style` computed in isolation), a zero-tab bar mounts the
+//! documented 48px empty box, and a `DefaultTabController` ancestor is
+//! actually reachable by (and required by) a descendant `TabBar`.
+
+mod common;
+
+use common::{lay_out, tight};
+use flui_material::{
+    DefaultTabController, Tab, TabBar, TabBarThemeData, TabController, Theme, ThemeData,
+    ThemeDataOverrides,
+};
+use flui_rendering::constraints::BoxConstraints;
+use flui_types::Color;
+use flui_types::geometry::px;
+
+fn two_tabs() -> Vec<Tab> {
+    vec![Tab::new().text("One"), Tab::new().text("Two")]
+}
+
+/// Tight width, loose (`0..height`) height — a `TabBar`'s own requested
+/// height must win over a merely-permissive parent, the same reasoning
+/// `tests/navigation_bar.rs`'s `bar_constraints` and `tests/divider.rs`'s
+/// module doc give for why a fully-tight root would test the wrong height.
+fn bar_constraints(width: f32, max_height: f32) -> BoxConstraints {
+    BoxConstraints::new(px(width), px(width), px(0.0), px(max_height))
+}
+
+fn themed(theme: ThemeData, child: impl flui_view::prelude::IntoView) -> Theme {
+    Theme::new(theme, child)
+}
+
+/// A real pointer down+up over the second (of two, equal-width) tabs reaches
+/// [`TabController::set_index`] through [`flui_material::InkWell`]'s
+/// dispatch — not just a directly-called closure, as the unit tests in
+/// `tabs.rs` exercise.
+#[test]
+fn tap_sets_the_controller_index_through_real_pointer_dispatch() {
+    let controller = TabController::new(2, 0);
+    let laid = lay_out(
+        themed(
+            ThemeData::light(),
+            TabBar::secondary(two_tabs()).controller(controller.clone()),
+        ),
+        tight(200.0, 48.0),
+    );
+
+    // Two equal-width tabs over a 200px bar: the second tab spans x in
+    // [100, 200), 48px tall — (150, 24) is its midpoint.
+    laid.dispatch_pointer_down(150.0, 24.0);
+    laid.dispatch_pointer_up(150.0, 24.0);
+
+    assert_eq!(
+        controller.index(),
+        1,
+        "a tap in the second tab's cell must reach controller.set_index(1)"
+    );
+}
+
+/// A tap on the already-selected tab is the no-op [`TabController`] itself
+/// already guarantees (`index == self.index()`) — this proves that no-op
+/// reaches all the way through real dispatch too, not just direct
+/// `set_index` calls.
+#[test]
+fn tapping_the_already_selected_tab_leaves_the_index_unchanged() {
+    let controller = TabController::new(2, 0);
+    let laid = lay_out(
+        themed(
+            ThemeData::light(),
+            TabBar::secondary(two_tabs()).controller(controller.clone()),
+        ),
+        tight(200.0, 48.0),
+    );
+
+    laid.dispatch_pointer_down(50.0, 24.0);
+    laid.dispatch_pointer_up(50.0, 24.0);
+
+    assert_eq!(controller.index(), 0);
+}
+
+/// The M3 secondary bar's divider (1dp, `outlineVariant`) reaches the
+/// mounted tree as a full-bar-width [`flui_widgets::DecoratedBox`]-backed
+/// fill, and a `TabBarThemeData.divider_color` override actually changes
+/// what's painted — not just what `resolve_style` computes in isolation
+/// (see `tabs.rs`'s own `resolve_style_theme_override_beats_the_default`
+/// for that unit-level half of this contract).
+#[test]
+fn divider_theme_override_reaches_the_mounted_tree() {
+    let themed_divider = Color::rgb(10, 20, 30);
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        tab_bar_theme: Some(TabBarThemeData {
+            divider_color: Some(themed_divider),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    let laid = lay_out(
+        themed(
+            theme,
+            TabBar::secondary(two_tabs()).controller(TabController::new(2, 0)),
+        ),
+        tight(200.0, 48.0),
+    );
+
+    // Every per-tab indicator band is ALSO a `RenderDecoratedBox` (a
+    // `Container::color(...)`, same as the divider) — 100px wide, 2dp
+    // tall. The divider is the one spanning the FULL bar width at 1dp
+    // tall, which disambiguates it without walking exact tree structure.
+    let divider = laid
+        .find_all_by_render_type("RenderDecoratedBox")
+        .into_iter()
+        .find(|&id| {
+            let size = laid.size(id);
+            size.height.get() == 1.0 && size.width.get() == 200.0
+        })
+        .expect("a full-width 1dp divider must be mounted");
+
+    let decoration = laid
+        .render_property(divider, "decoration")
+        .expect("RenderDecoratedBox reports a \"decoration\" diagnostics property");
+
+    assert!(
+        decoration.contains(&format!("{themed_divider:?}")),
+        "a configured tab_bar_theme.divider_color must reach the mounted divider — got \
+         {decoration:?}"
+    );
+}
+
+/// The selected tab's indicator band (2dp, `indicator_color`) is the OTHER
+/// `RenderDecoratedBox` shape — 100px wide (one of two equal tabs), 2dp
+/// tall — and a `TabBarThemeData.indicator_color` override reaches it too.
+#[test]
+fn indicator_theme_override_reaches_the_mounted_selected_tab_band() {
+    let themed_indicator = Color::rgb(200, 30, 40);
+    let theme = ThemeData::light().copy_with(ThemeDataOverrides {
+        tab_bar_theme: Some(TabBarThemeData {
+            indicator_color: Some(themed_indicator),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    let laid = lay_out(
+        themed(
+            theme,
+            TabBar::secondary(two_tabs()).controller(TabController::new(2, 0)),
+        ),
+        tight(200.0, 48.0),
+    );
+
+    // Both tabs' indicator bands are 100px wide, 2dp tall — the size alone
+    // doesn't distinguish selected (opaque) from unselected (transparent);
+    // search for the one whose decoration actually carries the themed
+    // color instead of guessing which match is "first".
+    let indicator_bands: Vec<_> = laid
+        .find_all_by_render_type("RenderDecoratedBox")
+        .into_iter()
+        .filter(|&id| {
+            let size = laid.size(id);
+            size.height.get() == 2.0 && size.width.get() == 100.0
+        })
+        .collect();
+    assert_eq!(
+        indicator_bands.len(),
+        2,
+        "both tabs' indicator bands (one per tab) must be mounted"
+    );
+
+    let has_themed_band = indicator_bands.iter().any(|&id| {
+        laid.render_property(id, "decoration")
+            .is_some_and(|decoration| decoration.contains(&format!("{themed_indicator:?}")))
+    });
+
+    assert!(
+        has_themed_band,
+        "a configured tab_bar_theme.indicator_color must reach the selected tab's band"
+    );
+}
+
+/// A zero-tab `TabBar` mounts the documented `48px` empty box (`TAB_HEIGHT +
+/// indicator_weight`), not a collapsed/zero-height `Row` — Flutter parity:
+/// `_TabBarState.build`'s zero-tabs early return. A (length-0) controller is
+/// still required, matching the oracle: controller resolution happens
+/// unconditionally, before `build` ever checks the tab count (see
+/// `TabBar::build`'s doc comment on its zero-tabs branch).
+#[test]
+fn zero_tab_bar_mounts_a_48px_box() {
+    let laid = lay_out(
+        themed(
+            ThemeData::light(),
+            TabBar::secondary(vec![]).controller(TabController::new(0, 0)),
+        ),
+        bar_constraints(300.0, 100.0),
+    );
+
+    let root_size = laid.size(laid.root());
+    assert_eq!(
+        root_size.height.get(),
+        48.0,
+        "a zero-tab TabBar must report the TAB_HEIGHT + indicator_weight (48px) box"
+    );
+}
+
+/// A `TabBar` with neither an explicit `controller` nor a
+/// [`DefaultTabController`] ancestor panics loudly (Flutter parity:
+/// `_updateTabController`'s `FlutterError`) instead of silently rendering
+/// with no selection.
+///
+/// The panic itself happens inside `build()`, which this crate's build-error
+/// boundary (`flui_view::element::behavior_commons::build_or_recover`)
+/// catches and substitutes a render-less `ErrorView` for — so `#[should_panic]`
+/// around the mount call would not observe THAT panic message directly. With
+/// `TabBar` mounted as the sole root here, the substitution leaves nothing
+/// to render, so `lay_out` itself panics next ("render root") — the same
+/// documented mechanism `flui-cupertino/tests/tab_scaffold.rs`'s
+/// `out_of_range_controller_index_panics_instead_of_silently_hiding_every_tab`
+/// exercises for an identical reason.
+#[test]
+#[should_panic(expected = "render root")]
+fn a_tab_bar_with_no_controller_and_no_default_tab_controller_ancestor_panics() {
+    let _ = lay_out(
+        themed(ThemeData::light(), TabBar::secondary(two_tabs())),
+        tight(200.0, 48.0),
+    );
+}
+
+/// A [`DefaultTabController`] ancestor is genuinely reachable by a
+/// descendant `TabBar` with no explicit `controller` — mounting does not
+/// panic (which it would, per the test above, with no controller reachable
+/// at all), and a real pointer dispatch through it still reaches the
+/// ancestor-owned [`TabController`]: tapping the second tab colors ITS
+/// indicator band with the resolved indicator color and leaves the first
+/// tab's band transparent.
+#[test]
+fn default_tab_controller_is_reachable_by_a_descendant_tab_bar_and_drives_its_indicator() {
+    let mut laid = lay_out(
+        themed(
+            ThemeData::light(),
+            DefaultTabController::new(2, TabBar::secondary(two_tabs())),
+        ),
+        tight(200.0, 48.0),
+    );
+
+    laid.dispatch_pointer_down(150.0, 24.0);
+    laid.dispatch_pointer_up(150.0, 24.0);
+    laid.pump();
+
+    let indicator_color = ThemeData::light().color_scheme.primary;
+    let bands = laid.find_all_by_render_type("RenderDecoratedBox");
+    let opaque_bands: Vec<_> = bands
+        .into_iter()
+        .filter(|&id| laid.size(id).height.get() == 2.0 && laid.size(id).width.get() == 100.0)
+        .filter(|&id| {
+            laid.render_property(id, "decoration")
+                .is_some_and(|decoration| decoration.contains(&format!("{indicator_color:?}")))
+        })
+        .collect();
+
+    assert_eq!(
+        opaque_bands.len(),
+        1,
+        "exactly one tab's indicator band must be opaque (the selected one) after the tap"
+    );
+    let selected_x = laid.absolute_offset(opaque_bands[0]).dx.get();
+    assert_eq!(
+        selected_x, 100.0,
+        "the SECOND tab's band (starting at x=100) must be the opaque one after tapping it"
+    );
+}
+
+/// A `DefaultTabController` whose `length` shrinks while its last tab is
+/// selected re-creates the controller with a clamped index (Flutter parity:
+/// `_DefaultTabControllerState.didUpdateWidget`; see `tab_controller.rs`'s
+/// own `recreate_for_length_change_clamps_an_out_of_range_index_to_the_last_tab`
+/// for the pure-function proof) — end to end, through a real root swap:
+/// mounting does not panic, and a subsequent tap still dispatches correctly
+/// through the re-created controller.
+#[test]
+fn default_tab_controller_survives_a_length_shrink_past_the_selected_index() {
+    let three_tabs = vec![
+        Tab::new().text("One"),
+        Tab::new().text("Two"),
+        Tab::new().text("Three"),
+    ];
+    let mut laid = lay_out(
+        themed(
+            ThemeData::light(),
+            DefaultTabController::new(3, TabBar::secondary(three_tabs)),
+        ),
+        bar_constraints(300.0, 48.0),
+    );
+
+    // Select the last tab (index 2, x in [200, 300)) before the shrink.
+    laid.dispatch_pointer_down(250.0, 24.0);
+    laid.dispatch_pointer_up(250.0, 24.0);
+    laid.pump();
+
+    // Shrink from 3 tabs to 2 — the old index (2) is now out of range and
+    // must clamp to 1, not panic or leave the bar unselectable.
+    laid.pump_widget(themed(
+        ThemeData::light(),
+        DefaultTabController::new(2, TabBar::secondary(two_tabs())),
+    ));
+
+    // A tap on the (new) second tab must still dispatch through the
+    // re-created controller and repaint a single opaque indicator band —
+    // proof the swap left a live, correctly-wired TabController behind.
+    // With 2 (not 3) tabs over the same 300px width, each tab is now
+    // 150px wide — the second tab's midpoint is (225, 24), not (150, 24).
+    laid.dispatch_pointer_down(225.0, 24.0);
+    laid.dispatch_pointer_up(225.0, 24.0);
+    laid.pump();
+
+    let indicator_color = ThemeData::light().color_scheme.primary;
+    let opaque_bands: Vec<_> = laid
+        .find_all_by_render_type("RenderDecoratedBox")
+        .into_iter()
+        .filter(|&id| laid.size(id).height.get() == 2.0 && laid.size(id).width.get() == 150.0)
+        .filter(|&id| {
+            laid.render_property(id, "decoration")
+                .is_some_and(|decoration| decoration.contains(&format!("{indicator_color:?}")))
+        })
+        .collect();
+
+    assert_eq!(
+        opaque_bands.len(),
+        1,
+        "exactly one indicator band must be opaque after the post-shrink tap"
+    );
+}

--- a/crates/flui-material/tests/tabs.rs
+++ b/crates/flui-material/tests/tabs.rs
@@ -36,6 +36,68 @@ fn themed(theme: ThemeData, child: impl flui_view::prelude::IntoView) -> Theme {
     Theme::new(theme, child)
 }
 
+/// Unmounting a `TabBar` removes its listener from the (outliving)
+/// `TabController` it was subscribed to — without `TabBarState::dispose`,
+/// every unmount leaks an `Rc` closure that calls `rebuild.schedule()` on a
+/// `RebuildHandle` whose element no longer exists, and repeated mount/unmount
+/// cycles against a long-lived controller (an explicit `TabBar::controller`
+/// shared with a sibling, or a `DefaultTabController` that outlives one
+/// particular child) accumulate dead listeners forever.
+///
+/// Same "count seam" pattern as
+/// `crates/flui-material/tests/text_field.rs`'s
+/// `unmounting_removes_the_focus_listener_from_the_process_wide_manager`:
+/// the `TabBar` is a `Column` CHILD here, not the mounted root, so removing
+/// it from the children list goes through ordinary list reconciliation
+/// (ending in `dispose`) rather than a same-type root-config swap
+/// (`pump_widget`/`swap_root_view` on the ROOT documents itself as NOT a
+/// full deactivate-and-remount in that same test's module doc).
+///
+/// Mutation red-check (run and reverted, see the review evidence): deleting
+/// `TabBarState::dispose`'s body makes `after_removal` stay at `while_mounted`
+/// (`1`) instead of returning to `before_mount` (`0`) — confirmed by running
+/// this test against that mutation before restoring the real `dispose`.
+#[test]
+fn unmounting_a_tab_bar_removes_its_listener_from_the_controller() {
+    use flui_view::{IntoView, ViewExt};
+    use flui_widgets::Column;
+
+    let controller = TabController::new(2, 0);
+
+    let before_mount = controller.listener_count();
+    let mut laid = lay_out(
+        themed(
+            ThemeData::light(),
+            Column::new(vec![
+                TabBar::secondary(two_tabs())
+                    .controller(controller.clone())
+                    .into_view()
+                    .boxed(),
+            ]),
+        ),
+        tight(200.0, 48.0),
+    );
+    let while_mounted = controller.listener_count();
+    assert!(
+        while_mounted > before_mount,
+        "mounting a TabBar must register its own listener on the controller"
+    );
+
+    // Remove the TabBar from the Column's children — an ordinary child
+    // removal, not a root-type swap.
+    laid.pump_widget(themed(
+        ThemeData::light(),
+        Column::new(Vec::<flui_view::BoxedView>::new()),
+    ));
+
+    let after_removal = controller.listener_count();
+    assert_eq!(
+        after_removal, before_mount,
+        "removing a TabBar from the tree must remove its listener from the controller, not \
+         leak it"
+    );
+}
+
 /// A real pointer down+up over the second (of two, equal-width) tabs reaches
 /// [`TabController::set_index`] through [`flui_material::InkWell`]'s
 /// dispatch — not just a directly-called closure, as the unit tests in
@@ -184,6 +246,112 @@ fn indicator_theme_override_reaches_the_mounted_selected_tab_band() {
     );
 }
 
+/// The indicator band sits at the BOTTOM of its 48px-tall cell (`dy ==
+/// 46.0` — the 46px content area's bottom edge, spanning the reserved 2dp
+/// gutter to the bar's own bottom edge), the divider sits at the very
+/// bottom of the whole bar (`dy == 47.0` — its own 1dp occupies the last
+/// pixel of that gutter), and the tab row (carrying the indicator bands) is
+/// the STACK's later child, so it paints over the divider wherever a
+/// band is opaque — Flutter parity: `_IndicatorPainter.paint`'s draw order
+/// (divider's `canvas.drawLine` first, then `_painter!.paint` for the
+/// indicator, `tabs.dart` oracle tag `3.44.0`) and `_TabBarState.build`'s
+/// `TabBarIndicatorSize::Tab` geometry (the indicator rect's height spans
+/// the full bar height, i.e. its top is `bar_height - indicator_weight`).
+///
+/// Neither `resolve_style_defaults_to_the_m3_secondary_token_table` (a pure
+/// unit test) nor `divider_theme_override_reaches_the_mounted_tree`/
+/// `indicator_theme_override_reaches_the_mounted_selected_tab_band` (mounted,
+/// but width/height-only) constrain the VERTICAL position of either shape —
+/// a `build_tab_cell` regression that puts the band at the top of the cell
+/// (`Column::new(vec![band.boxed(), Expanded::new(styled).boxed()])`,
+/// reversed from the correct order) still passes every one of them. This
+/// test is the one that catches it.
+///
+/// Mutation red-check (run and reverted, see the review evidence): swapping
+/// `build_tab_cell`'s `Column` children to `[band, Expanded::new(styled)]`
+/// (band first/top instead of last/bottom) makes the `band_top` assertion
+/// below fail (`0.0` instead of `46.0`) — confirmed by running this test
+/// against that mutation before restoring the correct order.
+#[test]
+fn indicator_band_sits_at_the_bar_bottom_beneath_the_divider_and_paints_over_it() {
+    let laid = lay_out(
+        themed(
+            ThemeData::light(),
+            TabBar::secondary(two_tabs()).controller(TabController::new(2, 0)),
+        ),
+        tight(200.0, 48.0),
+    );
+
+    let divider = laid
+        .find_all_by_render_type("RenderDecoratedBox")
+        .into_iter()
+        .find(|&id| {
+            let size = laid.size(id);
+            size.height.get() == 1.0 && size.width.get() == 200.0
+        })
+        .expect("a full-width 1dp divider must be mounted");
+    let band = laid
+        .find_all_by_render_type("RenderDecoratedBox")
+        .into_iter()
+        .find(|&id| {
+            let size = laid.size(id);
+            size.height.get() == 2.0 && size.width.get() == 100.0
+        })
+        .expect("a per-tab 2dp indicator band must be mounted");
+
+    let divider_top = laid.absolute_offset(divider).dy.get();
+    let band_top = laid.absolute_offset(band).dy.get();
+    assert_eq!(
+        band_top, 46.0,
+        "the indicator band must sit at the BOTTOM of the 48px bar (46px content + 2dp band), \
+         not the top"
+    );
+    assert_eq!(
+        divider_top, 47.0,
+        "the 1dp divider must sit at the very bottom of the 48px bar"
+    );
+
+    // Structural "paints over" proof: the harness documents render-tree
+    // child order as paint AND hit-test order, with a LATER child painting
+    // on top (`tests/common/mod.rs`'s `LaidOut::children` doc comment). The
+    // tab row (which carries the indicator bands) must be the STACK's
+    // second (later) child, with the divider strip first — so wherever a
+    // band is opaque, it paints over the divider beneath it.
+    let stack = laid
+        .find_by_render_type("RenderStack")
+        .expect("the divider and tab row must be layered in a Stack");
+    let stack_children = laid.children(stack);
+    assert_eq!(
+        stack_children.len(),
+        2,
+        "the Stack must have exactly two layers: the divider strip and the tab row"
+    );
+    assert!(
+        subtree_contains(&laid, stack_children[0], divider),
+        "the Stack's FIRST (earlier-painted) child must be the divider layer"
+    );
+    assert!(
+        subtree_contains(&laid, stack_children[1], band),
+        "the Stack's SECOND (later-painted, on top) child must be the tab row carrying the \
+         indicator bands"
+    );
+}
+
+/// Whether `id` is `root` itself or appears anywhere in `root`'s render
+/// subtree — a small DFS helper for structural paint-order assertions.
+fn subtree_contains(
+    laid: &common::LaidOut,
+    root: flui_foundation::RenderId,
+    id: flui_foundation::RenderId,
+) -> bool {
+    if root == id {
+        return true;
+    }
+    laid.children(root)
+        .into_iter()
+        .any(|child| subtree_contains(laid, child, id))
+}
+
 /// A zero-tab `TabBar` mounts the documented `48px` empty box (`TAB_HEIGHT +
 /// indicator_weight`), not a collapsed/zero-height `Row` — Flutter parity:
 /// `_TabBarState.build`'s zero-tabs early return. A (length-0) controller is
@@ -309,6 +477,30 @@ fn default_tab_controller_survives_a_length_shrink_past_the_selected_index() {
         DefaultTabController::new(2, TabBar::secondary(two_tabs())),
     ));
 
+    // The clamp itself — index 1, not the tap about to happen — must
+    // already be reflected BEFORE any post-shrink tap. Asserting this only
+    // after tapping the very index the clamp should have produced would
+    // mask a broken clamp (e.g. one that leaves the old, now out-of-range
+    // index 2 in place): the subsequent tap on index 1 would still light up
+    // exactly one band regardless of whether the clamp ran at all, since a
+    // tap always selects whatever it lands on.
+    let indicator_color = ThemeData::light().color_scheme.primary;
+    let clamped_band_x = laid
+        .find_all_by_render_type("RenderDecoratedBox")
+        .into_iter()
+        .filter(|&id| laid.size(id).height.get() == 2.0 && laid.size(id).width.get() == 150.0)
+        .find(|&id| {
+            laid.render_property(id, "decoration")
+                .is_some_and(|decoration| decoration.contains(&format!("{indicator_color:?}")))
+        })
+        .map(|id| laid.absolute_offset(id).dx.get());
+    assert_eq!(
+        clamped_band_x,
+        Some(150.0),
+        "the re-created controller must already select index 1 (x=150) right after the shrink, \
+         before any post-shrink tap"
+    );
+
     // A tap on the (new) second tab must still dispatch through the
     // re-created controller and repaint a single opaque indicator band —
     // proof the swap left a live, correctly-wired TabController behind.
@@ -318,7 +510,6 @@ fn default_tab_controller_survives_a_length_shrink_past_the_selected_index() {
     laid.dispatch_pointer_up(225.0, 24.0);
     laid.pump();
 
-    let indicator_color = ThemeData::light().color_scheme.primary;
     let opaque_bands: Vec<_> = laid
         .find_all_by_render_type("RenderDecoratedBox")
         .into_iter()


### PR DESCRIPTION
## Summary

Material Tabs PR1, ported against Flutter 3.44.0 `material/{tabs,tab_controller}.dart` through an adversarial design pass that killed an indicator chimera before code: the planned "full-tab-width 3dp rounded primary" matches **no cell** of the oracle's style matrix (primary=label/3dp/rounded, secondary=tab/2dp/square) — so V1 ships **the secondary contract exactly**, with the primary/label-size style deferred behind the child-size-feedback gap rather than shipping a divergent hybrid.

- **`TabController`** — one non-Send `Rc<Cell<IndexPair>>` (packed index+previous, single set, ONE notify — the critic killed a torn `Arc<AtomicUsize>` pair), the oracle's exact `_changeIndex` semantics (no-op + no notify on same index and `length < 2`, both mutation-pinned; bounds `debug_assert!` — a review catch), `animate_to` as a documented alias (double-notify + `indexIsChanging` named deferrals), listener registry with a count seam.
- **`DefaultTabController`** — InheritedView; **length change recreates the controller identity with the index clamped** (`_copyWithAndDispose` shape), pre-tap clamp assertion (a review round caught the tap masking a broken clamp).
- **`TabBar::secondary`** — `_TabsSecondaryDefaultsM3` verbatim (onSurface/onSurfaceVariant labels, primary 2dp square tab-width indicator, outlineVariant 1dp divider, .1/.08/.1 overlays), reserved-band composition with the **vertical geometry mounted-pinned** (band top 46.0/divider 47.0/paint order — a review round proved the prior "geometry pin" survived a band-at-top mutation), 46/72 heights + `Tab::height` + the ±13dp mixed-bar centering + the zero-length 48px box incl. the controller-resolves quirk. `TabBarState::dispose` unregisters the controller listener (review-caught leak; unmount test via the count seam).
- `TabBarThemeData` slot (full convention, pure-set resolution, mounted overrides).
- PR2 (next): TabBarView (Offstage lazy retention) + AppBar.bottom wiring (toolbar-Flexible under the cap per the critic's shortfall analysis).

### Review trail
Architect → critique (indicator chimera, torn atomics, undefined length semantics, AppBar-cap shortfall) → build → review (listener leak, missing bounds assert, vacuous vertical pin, clamp-masking test) → fix pass with per-finding mutation evidence.

### Gates
Workspace nextest 7279 passed / 4 skipped · workspace clippy `-D warnings` clean · doc gate clean · port-check/inventory/fmt/taplo/typos · doctests 623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvkSGveJwxLVuygRAGVKuz