### PR TITLE
feat(material): Tabs PR2 — TabBarView, AppBar.bottom, tabbed sample route

### DIFF
--- a/crates/flui-material/src/app_bar.rs
+++ b/crates/flui-material/src/app_bar.rs
@@ -4,8 +4,8 @@
 //! # Flutter parity
 //!
 //! `material/app_bar.dart`'s `AppBar` (oracle tag `3.44.0`). Implemented
-//! subset: `leading`, `title`, `actions`, `toolbar_height`, `background_color`,
-//! `foreground_color`, `elevation`, and the M3 token defaults
+//! subset: `leading`, `title`, `actions`, `toolbar_height`, `bottom`,
+//! `background_color`, `foreground_color`, `elevation`, and the M3 token defaults
 //! (`_AppBarDefaultsM3`, `app_bar.dart:2521-2570`): `background_color` falls
 //! back to `ColorScheme.surface`, `foreground_color` to `ColorScheme.on_surface`,
 //! `elevation` to `0.0`, and the title's text style to `TextTheme.title_large`
@@ -33,14 +33,61 @@
 //! for a platform-adaptive seam; today every platform gets the
 //! Android/Linux/Windows answer.
 //!
+//! ## `bottom`: a fixed-height slot below the toolbar
+//!
+//! [`AppBar::bottom`] accepts anything implementing [`PreferredSizeView`]
+//! (typically a [`crate::TabBar`]) and mounts it directly beneath the
+//! toolbar, inside the same [`SafeArea`]. Flutter parity: `_AppBarState.build`'s
+//! `if (widget.bottom != null)` branch (`app_bar.dart:1164-1183`, oracle tag
+//! `3.44.0`) — ported as the identical shape: a `Column` with
+//! `mainAxisAlignment: spaceBetween` whose first child is the toolbar wrapped
+//! in `Flexible(child: ConstrainedBox(maxHeight: toolbar_height))` and whose
+//! second is `bottom` itself, unwrapped. The whole `Column` is forced to
+//! `toolbar_height + bottom.preferred_size().height` via an outer
+//! [`SizedBox`] (this substrate's equivalent of the oracle's
+//! `_PreferredAppBarSize`-driven ambient sizing — see [`AppBar::preferred_size`]
+//! below), then handed to the same top-inset-consuming `SafeArea` the toolbar
+//! alone already used.
+//!
+//! **Why the toolbar flexes and `bottom` does not**: `Flexible` (not
+//! `Expanded`) with a *loose* fit means the toolbar happily shrinks below
+//! `toolbar_height` when the `Column`'s own available height falls short of
+//! `toolbar_height + bottom_height` (a caller-imposed cap tighter than this
+//! bar's own preferred size, or a `SafeArea` top inset large enough to eat
+//! into it) — `bottom` is the `Column`'s other, non-flexible child, so it
+//! always gets its own natural height first and the toolbar absorbs the
+//! shortfall. This is not a simplification: it's the exact oracle shape,
+//! ported so a `TabBar` mounted as `bottom` never gets silently clipped
+//! by a tight parent while the toolbar above it holds its full height.
+//!
+//! [`Scaffold::app_bar`](crate::Scaffold::app_bar)'s own cap math
+//! (`max_height = view.app_bar_preferred_height + media_query.padding.top`)
+//! is unaffected by `bottom`: `app_bar_preferred_height` already snapshots
+//! [`AppBar::preferred_size`]'s `toolbar_height + bottom_height` sum at
+//! `Scaffold::app_bar`-builder time (see that method's own doc comment for
+//! why the snapshot, not a live re-consult), so the cap this substrate hands
+//! back down already has exactly enough room for both slots plus the top
+//! inset — the `Flexible` shrink path above only fires when a caller
+//! deliberately imposes something tighter than that (or mounts `AppBar`
+//! standalone, with no `Scaffold` reserving room for it at all).
+//!
+//! **Deferred, and named** (this `bottom` slot specifically): `bottomOpacity`
+//! (the oracle's `Opacity`/`Interval`-curve fade as a `SliverAppBar` scrolls
+//! `bottom` toward its collapsed state — no `scrolledUnder`/sliver-collapse
+//! substrate here to drive it) and `PreferredSizeWidget`'s `Scaffold`-side
+//! bottom-height re-consult on data change (see [`PreferredSizeView`]'s own
+//! "Named divergence" doc — this whole substrate resolves it once, at
+//! `.bottom(...)`/`.app_bar(...)` builder time).
+//!
 //! ## Deferred, and named
 //!
 //! - `center_title` / a full `NavigationToolbar` port — the title area here
 //!   is a plain `Expanded` + `Align(center_left)`, not `NavigationToolbar`'s
 //!   overflow-aware middle-widget layout.
 //! - `scrolledUnder` — no `ScrollNotification` substrate to observe yet.
-//! - `flexibleSpace`, `bottom` (and therefore `PreferredSize`'s bottom-height
-//!   contribution — [`AppBar::preferred_size`] reports `toolbar_height` only).
+//! - `flexibleSpace` — stacked behind the toolbar+bottom in the oracle
+//!   (`app_bar.dart`'s trailing `Stack` when `widget.flexibleSpace != null`);
+//!   no consumer or substrate for it here yet.
 //! - **Named divergence: no shadow suppression at a nonzero elevation.**
 //!   `_AppBarDefaultsM3` sets `shadowColor: Colors.transparent` AND
 //!   `surfaceTintColor: Colors.transparent` (`app_bar.dart:2541-2545`) — the
@@ -113,8 +160,9 @@ use flui_types::typography::TextStyle;
 use flui_types::{Alignment, Pixels, Size};
 use flui_view::prelude::*;
 use flui_widgets::{
-    Align, Center, ConstrainedBox, CrossAxisAlignment, DefaultTextStyle, Expanded, IconTheme,
-    IconThemeData, NavigatorHandle, PreferredSizeView, Row, SafeArea, SizedBox,
+    Align, Center, Column, ConstrainedBox, CrossAxisAlignment, DefaultTextStyle, Expanded,
+    Flexible, IconTheme, IconThemeData, MainAxisAlignment, NavigatorHandle, PreferredSizeView, Row,
+    SafeArea, SizedBox,
 };
 
 use crate::back_button::BackButton;
@@ -160,6 +208,13 @@ pub struct AppBar {
     background_color: Option<Color>,
     foreground_color: Option<Color>,
     elevation: Option<f32>,
+    bottom: Option<BoxedView>,
+    /// `bottom`'s [`preferred_size`](PreferredSizeView::preferred_size)
+    /// height, snapshotted at [`Self::bottom`]-builder time — see that
+    /// method's doc comment and [`PreferredSizeView`]'s own "Named
+    /// divergence" note on why this substrate resolves it once rather than
+    /// re-consulting it later.
+    bottom_preferred_height: f32,
 }
 
 impl AppBar {
@@ -177,6 +232,8 @@ impl AppBar {
             background_color: None,
             foreground_color: None,
             elevation: None,
+            bottom: None,
+            bottom_preferred_height: 0.0,
         }
     }
 
@@ -241,6 +298,22 @@ impl AppBar {
         self.elevation = Some(elevation);
         self
     }
+
+    /// Sets a slot rendered directly below the toolbar (typically a
+    /// [`crate::TabBar`]) — see the module docs' `bottom` section for the
+    /// exact Flexible-toolbar/fixed-`bottom` layout this composes and why
+    /// the toolbar (not `bottom`) is what shrinks under a height shortfall.
+    ///
+    /// `bottom`'s [`preferred_size`](PreferredSizeView::preferred_size) is
+    /// resolved once, here, and its height captured — matching
+    /// [`crate::Scaffold::app_bar`]'s identical snapshot-at-builder-time
+    /// contract, for the same reason (see that method's doc comment).
+    #[must_use]
+    pub fn bottom(mut self, bottom: impl PreferredSizeView) -> Self {
+        self.bottom_preferred_height = bottom.preferred_size().height.get();
+        self.bottom = Some(bottom.boxed());
+        self
+    }
 }
 
 impl Default for AppBar {
@@ -260,6 +333,7 @@ impl std::fmt::Debug for AppBar {
             .field("has_title", &self.title.is_some())
             .field("action_count", &self.actions.len())
             .field("toolbar_height", &self.toolbar_height)
+            .field("has_bottom", &self.bottom.is_some())
             .finish_non_exhaustive()
     }
 }
@@ -472,9 +546,31 @@ impl StatelessView for AppBar {
             ),
         );
 
+        // With a `bottom` slot, the toolbar+bottom pair replaces the bare
+        // toolbar as the thing `SafeArea` pads — see the module docs' `bottom`
+        // section for exactly why the toolbar is `Flexible` (shrinks under a
+        // height shortfall) while `bottom` is not.
+        let toolbar_and_bottom: BoxedView = if let Some(bottom) = &self.bottom {
+            let flexible_toolbar = Flexible::new(
+                ConstrainedBox::new(BoxConstraints {
+                    max_height: px(self.toolbar_height),
+                    ..BoxConstraints::UNCONSTRAINED
+                })
+                .child(themed_toolbar),
+            );
+            SizedBox::height(self.toolbar_height + self.bottom_preferred_height)
+                .child(
+                    Column::new(vec![flexible_toolbar.boxed(), bottom.clone()])
+                        .main_axis_alignment(MainAxisAlignment::SpaceBetween),
+                )
+                .boxed()
+        } else {
+            themed_toolbar.boxed()
+        };
+
         // The app bar pads itself against the top safe-area inset — see the
         // module docs' "consumes the top inset itself" section.
-        let safe_toolbar = SafeArea::new().bottom(false).child(themed_toolbar);
+        let safe_toolbar = SafeArea::new().bottom(false).child(toolbar_and_bottom);
 
         Material::new(background_color)
             .elevation(elevation)
@@ -484,10 +580,13 @@ impl StatelessView for AppBar {
 
 impl PreferredSizeView for AppBar {
     fn preferred_size(&self) -> Size {
-        // Flutter oracle: `Size.fromHeight(toolbarHeight)` (`app_bar.dart`'s
-        // `_PreferredAppBarSize`, minus the `bottom` contribution — deferred,
-        // see the module docs).
-        Size::new(px(f32::INFINITY), px(self.toolbar_height))
+        // Flutter oracle: `_PreferredAppBarSize(toolbarHeight, bottom?.preferredSize.height)`
+        // (`app_bar.dart:76-81`, oracle tag `3.44.0`) — `toolbar_height` plus
+        // `bottom`'s own preferred height, `0.0` when there is no `bottom`.
+        Size::new(
+            px(f32::INFINITY),
+            px(self.toolbar_height + self.bottom_preferred_height),
+        )
     }
 }
 
@@ -510,6 +609,29 @@ mod tests {
     fn preferred_size_defaults_to_the_default_toolbar_height() {
         let bar = AppBar::new();
         assert_eq!(bar.preferred_size().height, px(DEFAULT_TOOLBAR_HEIGHT));
+    }
+
+    /// Flutter parity: `_PreferredAppBarSize(toolbarHeight, bottom?.preferredSize.height)`
+    /// — with a `bottom` slot set, `preferred_size` reports `toolbar_height
+    /// + bottom.preferred_size().height`, not `toolbar_height` alone.
+    ///
+    /// Red-check: revert `preferred_size` to `px(self.toolbar_height)` alone
+    /// — this assertion fails (`56.0` instead of `104.0`).
+    #[test]
+    fn preferred_size_adds_the_bottom_slots_height_when_set() {
+        use flui_widgets::layout::PreferredSize;
+
+        let bottom_height = 48.0;
+        let bar = AppBar::new().bottom(PreferredSize::new(
+            Size::new(px(f32::INFINITY), px(bottom_height)),
+            SizedBox::shrink(),
+        ));
+
+        assert_eq!(
+            bar.preferred_size().height,
+            px(DEFAULT_TOOLBAR_HEIGHT + bottom_height),
+            "preferred_size must be toolbar_height + the bottom slot's own preferred height"
+        );
     }
 
     #[test]
@@ -621,13 +743,19 @@ mod tests {
 
     #[test]
     fn builders_set_the_expected_fields() {
+        use flui_widgets::layout::PreferredSize;
+
         let bar = AppBar::new()
             .leading(flui_widgets::SizedBox::shrink())
             .title(flui_widgets::SizedBox::shrink())
             .actions(vec![flui_widgets::SizedBox::shrink().boxed()])
             .background_color(Color::rgb(10, 20, 30))
             .foreground_color(Color::rgb(40, 50, 60))
-            .elevation(4.0);
+            .elevation(4.0)
+            .bottom(PreferredSize::new(
+                Size::new(px(f32::INFINITY), px(48.0)),
+                SizedBox::shrink(),
+            ));
 
         assert!(bar.leading.is_some());
         assert!(bar.title.is_some());
@@ -635,6 +763,8 @@ mod tests {
         assert_eq!(bar.background_color, Some(Color::rgb(10, 20, 30)));
         assert_eq!(bar.foreground_color, Some(Color::rgb(40, 50, 60)));
         assert_eq!(bar.elevation, Some(4.0));
+        assert!(bar.bottom.is_some());
+        assert_eq!(bar.bottom_preferred_height, 48.0);
     }
 
     #[test]

--- a/crates/flui-material/src/lib.rs
+++ b/crates/flui-material/src/lib.rs
@@ -12,7 +12,7 @@
 //! ([`ListTile`], [`Divider`]/[`VerticalDivider`]), bottom navigation
 //! ([`NavigationBar`]/[`NavigationDestination`]), the chip family
 //! ([`Chip`], [`FilterChip`]), and secondary tabs ([`TabController`],
-//! [`DefaultTabController`], [`Tab`], [`TabBar`]).
+//! [`DefaultTabController`], [`Tab`], [`TabBar`], [`TabBarView`]).
 //!
 //! ## Flutter parity
 //!
@@ -94,6 +94,7 @@ pub mod shape;
 pub mod snack_bar;
 mod state_color;
 pub mod switch;
+pub mod tab_bar_view;
 pub mod tab_controller;
 pub mod tabs;
 pub mod text_button;
@@ -132,6 +133,7 @@ pub use scaffold_messenger::{
 pub use shape::MaterialShape;
 pub use snack_bar::{SnackBar, SnackBarAction, SnackBarActionState};
 pub use switch::{Switch, SwitchState};
+pub use tab_bar_view::{TabBarView, TabBarViewState};
 pub use tab_controller::{DefaultTabController, DefaultTabControllerState, TabController};
 pub use tabs::{Tab, TabBar, TabBarState};
 pub use text_button::TextButton;

--- a/crates/flui-material/src/tab_bar_view.rs
+++ b/crates/flui-material/src/tab_bar_view.rs
@@ -1,0 +1,299 @@
+//! [`TabBarView`] — a [`crate::TabController`]-synced page switcher, the
+//! usual body for a [`crate::TabBar`].
+//!
+//! # Flutter parity
+//!
+//! `material/tabs.dart`'s `TabBarView` (oracle tag `3.44.0`) — for the
+//! OBSERVABLE contract only: the active child tracks the controller's index,
+//! an already-visited child's state survives switching away and back, and a
+//! not-yet-visited child is never built. See "The switching mechanism: no
+//! `PageView`" below for what does *not* carry over.
+//!
+//! ## The switching mechanism: no `PageView`
+//!
+//! The oracle's `_TabBarViewState` drives a real `PageView` (`PageController`,
+//! `Scrollable`, `Viewport`): every child is a scrollable page, dragging
+//! between tabs is native, and `TabController.animateTo` warps the page
+//! controller to the target index over its animation duration. This
+//! substrate has no page-scroll substrate at all yet (no `Scrollable` that
+//! can host a viewport of arbitrary, individually-sized pages) — swiping is
+//! a **named deferral**, not a silent drop.
+//!
+//! Instead, this ports the OTHER lazy-keep-alive switcher this workspace
+//! already established: `flui_cupertino::CupertinoTabScaffold`'s private
+//! `_TabSwitchingView` mechanic (`cupertino/tab_scaffold.dart`, oracle tag
+//! `3.44.0`) — every child mounts a slot up front, but a child is only ever
+//! *built* the first time its index becomes active (tracked per index, never
+//! reset — "once visited, stays built"), and every non-active child is
+//! [`Offstage`]-hidden + [`TickerMode`]-disabled rather than unmounted, so an
+//! inactive child's own state (a counter, a scroll position, a nested
+//! animation) survives a switch away and back, and its animations genuinely
+//! stop advancing while hidden. This is the second occurrence of that exact
+//! composition in this workspace (`CupertinoTabScaffold` is the first); per
+//! this studio's rule of three, a second occurrence is composed again here,
+//! not extracted into a shared abstraction yet.
+//!
+//! `CupertinoTabScaffold` additionally wraps each slot in `HeroMode` (gating
+//! hero animations by tab) — that has no analog here: `TabBarView` has no
+//! bottom-tab-bar-driven navigation stack of its own, so there is nothing
+//! for `HeroMode` to gate.
+//!
+//! ## Controller resolution: explicit, else `DefaultTabController`
+//!
+//! Exactly [`crate::TabBar`]'s own contract: an explicit
+//! [`controller`](Self::controller) wins; otherwise the nearest
+//! [`crate::DefaultTabController`] ancestor's controller is used. Exactly one
+//! must be reachable, or `build` panics (Flutter parity: the oracle's
+//! `_updateTabController`'s `FlutterError`/`assert`). The listener
+//! subscription is registered the same way `TabBarState` registers its own
+//! (re-resolved every `build`, re-homed on controller-identity change) and
+//! removed in `dispose` — the PR1 lesson: a controller that outlives this
+//! view must not keep a dead `Rc` closure calling
+//! [`flui_view::RebuildHandle::schedule`] on an unmounted element.
+//!
+//! ## Length mismatch
+//!
+//! [`TabBarView::new`]'s `children` count is expected to equal the
+//! controller's [`length`](crate::TabController::length) — enforced with a
+//! `debug_assert!`, matching `CupertinoTabScaffold`'s own out-of-range-index
+//! precedent (`tab_scaffold.rs`'s `is_valid_tab_index` doc comment). In a
+//! release build (where `debug_assert!` compiles out), an out-of-range
+//! current index simply never matches any child's own index in `build`'s
+//! `0..children.len()` iteration — every child renders `Offstage`-hidden and
+//! none is marked active, with no panic and no `Vec` index out of bounds.
+//! This is a documented fall-through, not a silent one: do not "fix" it by
+//! clamping the index — the debug assertion exists so a real mismatch is
+//! caught long before any release build ships.
+
+use std::cell::RefCell;
+
+use flui_foundation::ListenerId;
+use flui_view::prelude::*;
+use flui_view::{BoxedView, RebuildHandle};
+use flui_widgets::{Offstage, SizedBox, Stack, StackFit, TickerMode};
+
+use crate::tab_controller::{DefaultTabController, TabController};
+
+/// A [`TabController`]-synced page switcher: one child per tab, the active
+/// one shown, every visited one kept alive `Offstage` (see the module docs
+/// for exactly what mechanism this uses and why).
+///
+/// A [`TabController`] is required either explicitly (via
+/// [`controller`](Self::controller)) or via a [`DefaultTabController`]
+/// ancestor — exactly one must be reachable, or `build` panics. See the
+/// module docs' "Controller resolution" section.
+///
+/// ```
+/// use flui_material::{DefaultTabController, TabBarView};
+/// use flui_widgets::{SizedBox, Text};
+/// use flui_view::ViewExt;
+///
+/// let children = vec![Text::new("One").boxed(), SizedBox::shrink().boxed()];
+/// let view = DefaultTabController::new(children.len(), TabBarView::new(children));
+/// ```
+#[derive(Clone, StatefulView)]
+pub struct TabBarView {
+    children: Vec<BoxedView>,
+    controller: Option<TabController>,
+}
+
+impl TabBarView {
+    /// A `TabBarView` over `children` — one child per tab, resolved against
+    /// an explicit or ambient [`TabController`] (see [`controller`](Self::controller)).
+    #[must_use]
+    pub fn new(children: Vec<BoxedView>) -> Self {
+        Self {
+            children,
+            controller: None,
+        }
+    }
+
+    /// Supplies an explicit [`TabController`] instead of relying on a
+    /// [`DefaultTabController`] ancestor.
+    #[must_use]
+    pub fn controller(mut self, controller: TabController) -> Self {
+        self.controller = Some(controller);
+        self
+    }
+}
+
+impl std::fmt::Debug for TabBarView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TabBarView")
+            .field("child_count", &self.children.len())
+            .field("has_explicit_controller", &self.controller.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Persistent state behind [`TabBarView`]: the currently-subscribed
+/// [`TabController`] and its listener registration (re-resolved every
+/// `build`, exactly [`crate::tabs::TabBarState`]'s own contract), plus which
+/// child indices have ever been built.
+pub struct TabBarViewState {
+    controller: RefCell<Option<TabController>>,
+    listener_id: RefCell<Option<ListenerId>>,
+    rebuild: Option<RebuildHandle>,
+    /// Flutter parity: `_TabSwitchingViewState.shouldBuildTab` — grown to
+    /// match `view.children.len()` on every build, never reset for an index
+    /// that already built once. See the module docs' "switching mechanism"
+    /// section.
+    should_build: RefCell<Vec<bool>>,
+}
+
+impl std::fmt::Debug for TabBarViewState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TabBarViewState")
+            .field("controller", &self.controller.borrow())
+            .finish_non_exhaustive()
+    }
+}
+
+impl StatefulView for TabBarView {
+    type State = TabBarViewState;
+
+    fn create_state(&self) -> Self::State {
+        TabBarViewState {
+            controller: RefCell::new(None),
+            listener_id: RefCell::new(None),
+            rebuild: None,
+            should_build: RefCell::new(Vec::new()),
+        }
+    }
+}
+
+impl TabBarViewState {
+    /// Resolves `view`'s effective controller (explicit, else
+    /// [`DefaultTabController::maybe_of`]) and, if it differs by identity
+    /// from the currently-subscribed one, swaps the listener registration
+    /// onto it. Identical contract to `crate::tabs::TabBarState::resolve_controller`
+    /// — see that method's doc comment for why this runs from `build` rather
+    /// than a lifecycle hook, and why re-resolving unconditionally on every
+    /// `build` is cheap and always correct.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `view` has no explicit controller and there is no
+    /// `DefaultTabController` ancestor. Flutter parity: `_updateTabController`'s
+    /// `FlutterError`.
+    fn resolve_controller(&self, view: &TabBarView, ctx: &dyn BuildContext) -> TabController {
+        let resolved = view
+            .controller
+            .clone()
+            .or_else(|| DefaultTabController::maybe_of(ctx))
+            .expect(
+                "TabBarView requires an explicit controller (TabBarView::controller) or a \
+                 DefaultTabController ancestor",
+            );
+
+        let changed = self
+            .controller
+            .borrow()
+            .as_ref()
+            .is_none_or(|current| *current != resolved);
+
+        if changed {
+            let previous_controller = self.controller.borrow_mut().take();
+            let previous_listener = self.listener_id.borrow_mut().take();
+            if let (Some(previous_controller), Some(id)) = (previous_controller, previous_listener)
+            {
+                previous_controller.remove_listener(id);
+            }
+
+            let rebuild = self
+                .rebuild
+                .clone()
+                .expect("init_state runs before the first build");
+            let id = resolved.add_listener(move || {
+                rebuild.schedule();
+            });
+            *self.listener_id.borrow_mut() = Some(id);
+            *self.controller.borrow_mut() = Some(resolved.clone());
+        }
+
+        resolved
+    }
+}
+
+impl ViewState<TabBarView> for TabBarViewState {
+    fn init_state(&mut self, ctx: &dyn BuildContext) {
+        self.rebuild = Some(ctx.rebuild_handle());
+    }
+
+    /// Unregisters this view's listener from whatever controller it's
+    /// currently subscribed to — see `crate::tabs::TabBarState::dispose`'s
+    /// doc comment for exactly what leaks without this (the PR1 lesson).
+    fn dispose(&mut self) {
+        let controller = self.controller.get_mut().take();
+        let listener_id = self.listener_id.get_mut().take();
+        if let (Some(controller), Some(id)) = (controller, listener_id) {
+            controller.remove_listener(id);
+        }
+    }
+
+    fn build(&self, view: &TabBarView, ctx: &dyn BuildContext) -> impl IntoView {
+        let controller = self.resolve_controller(view, ctx);
+        let child_count = view.children.len();
+
+        debug_assert!(
+            child_count == controller.length(),
+            "TabBarView: {child_count} children does not match the TabController's length of \
+             {} — the children list and the tab count must agree",
+            controller.length()
+        );
+
+        let current_index = controller.index();
+
+        let mut should_build = self.should_build.borrow_mut();
+        should_build.resize(child_count, false);
+        if let Some(flag) = should_build.get_mut(current_index) {
+            *flag = true;
+        }
+
+        let layers: Vec<BoxedView> = view
+            .children
+            .iter()
+            .enumerate()
+            .map(|(index, child)| {
+                let active = index == current_index;
+                let content = if should_build[index] {
+                    child.clone()
+                } else {
+                    SizedBox::shrink().boxed()
+                };
+                Offstage::new()
+                    .offstage(!active)
+                    .child(TickerMode::new(content).enabled(active))
+                    .boxed()
+            })
+            .collect();
+
+        Stack::new(layers).fit(StackFit::Expand)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_starts_with_no_explicit_controller() {
+        let view = TabBarView::new(vec![flui_widgets::SizedBox::shrink().boxed()]);
+        assert!(view.controller.is_none());
+    }
+
+    #[test]
+    fn controller_sets_the_explicit_controller() {
+        let controller = TabController::new(1, 0);
+        let view = TabBarView::new(vec![flui_widgets::SizedBox::shrink().boxed()])
+            .controller(controller.clone());
+        assert_eq!(view.controller, Some(controller));
+    }
+
+    #[test]
+    fn debug_format_does_not_panic() {
+        let view = TabBarView::new(vec![flui_widgets::SizedBox::shrink().boxed()]);
+        let rendered = format!("{view:?}");
+        assert!(rendered.contains("TabBarView"));
+    }
+}

--- a/crates/flui-material/src/tab_bar_view.rs
+++ b/crates/flui-material/src/tab_bar_view.rs
@@ -41,7 +41,7 @@
 //! ## Controller resolution: explicit, else `DefaultTabController`
 //!
 //! Exactly [`crate::TabBar`]'s own contract: an explicit
-//! [`controller`](Self::controller) wins; otherwise the nearest
+//! [`controller`](TabBarView::controller) wins; otherwise the nearest
 //! [`crate::DefaultTabController`] ancestor's controller is used. Exactly one
 //! must be reachable, or `build` panics (Flutter parity: the oracle's
 //! `_updateTabController`'s `FlutterError`/`assert`). The listener

--- a/crates/flui-material/src/tab_bar_view.rs
+++ b/crates/flui-material/src/tab_bar_view.rs
@@ -47,9 +47,9 @@
 //! `_updateTabController`'s `FlutterError`/`assert`). The listener
 //! subscription is registered the same way `TabBarState` registers its own
 //! (re-resolved every `build`, re-homed on controller-identity change) and
-//! removed in `dispose` — the PR1 lesson: a controller that outlives this
-//! view must not keep a dead `Rc` closure calling
-//! [`flui_view::RebuildHandle::schedule`] on an unmounted element.
+//! removed in `dispose`: a controller that outlives this view must not keep
+//! a dead `Rc` closure calling [`flui_view::RebuildHandle::schedule`] on an
+//! unmounted element.
 //!
 //! ## Length mismatch
 //!
@@ -221,8 +221,11 @@ impl ViewState<TabBarView> for TabBarViewState {
     }
 
     /// Unregisters this view's listener from whatever controller it's
-    /// currently subscribed to — see `crate::tabs::TabBarState::dispose`'s
-    /// doc comment for exactly what leaks without this (the PR1 lesson).
+    /// currently subscribed to — without this, a controller that outlives
+    /// this view keeps firing a dead `Rc` closure that calls
+    /// `rebuild.schedule()` on a `RebuildHandle` whose element no longer
+    /// exists (see `crate::tabs::TabBarState::dispose`'s doc comment for the
+    /// identical leak on `TabBar`'s side).
     fn dispose(&mut self) {
         let controller = self.controller.get_mut().take();
         let listener_id = self.listener_id.get_mut().take();

--- a/crates/flui-material/tests/app_bar.rs
+++ b/crates/flui-material/tests/app_bar.rs
@@ -11,11 +11,12 @@ mod common;
 
 use common::{lay_out, loose, tight};
 use flui_material::{AppBar, AppBarThemeData, Theme, ThemeData, ThemeDataOverrides};
-use flui_types::EdgeInsets;
 use flui_types::geometry::px;
+use flui_types::{EdgeInsets, Size};
 use flui_view::prelude::*;
 use flui_widgets::{
-    MediaQuery, MediaQueryData, Navigator, NavigatorHandle, SimpleRoute, SizedBox, Text,
+    MediaQuery, MediaQueryData, Navigator, NavigatorHandle, PreferredSize, SimpleRoute, SizedBox,
+    Text,
 };
 
 /// `_ElevatedButtonDefaultsM3`'s sibling formatting helper (see
@@ -432,5 +433,185 @@ fn tapping_the_implied_back_button_pops_the_route() {
         !handle.can_pop(),
         "tapping the implied back button must pop the pushed route via NavigatorHandle::maybe_pop, \
          leaving only the seeded initial route on the stack",
+    );
+}
+
+// ── `AppBar.bottom` — Flexible-toolbar/fixed-bottom Column layout ──
+//
+// `bottom.rs`'s own module docs and `app_bar.rs`'s `builders_set_the_expected_fields`/
+// `preferred_size_adds_the_bottom_slots_height_when_set` cover the pure
+// preferred-size math in isolation; these prove the mounted geometry end to
+// end: the toolbar and bottom slot actually stack at their expected sizes,
+// and a height shortfall shrinks the toolbar, never the bottom slot.
+
+/// A `bottom` slot whose `preferred_size` and actual mounted height always
+/// agree — matching how a real [`flui_material::TabBar`] behaves (its own
+/// `build` returns exactly the height it advertises via
+/// [`flui_widgets::PreferredSizeView::preferred_size`]).
+fn fixed_height_bottom(height: f32) -> PreferredSize {
+    PreferredSize::new(
+        Size::new(px(f32::INFINITY), px(height)),
+        SizedBox::height(height),
+    )
+}
+
+const BOTTOM_SLOT_HEIGHT: f32 = 48.0;
+
+/// The bottom slot's own mounted [`RenderConstrainedBox`](flui_objects::RenderConstrainedBox)
+/// — the only one in this tree sized to exactly [`BOTTOM_SLOT_HEIGHT`] (the
+/// toolbar's own `SizedBox` is 56px tall or, under a shortfall, shrunk below
+/// it; the outer `SizedBox` wrapping the whole `Column` sums to a different
+/// total again) — so filtering on that exact height disambiguates it without
+/// walking tree structure.
+fn find_bottom_slot_box(laid: &common::LaidOut) -> flui_foundation::RenderId {
+    let candidates: Vec<_> = laid
+        .find_all_by_render_type("RenderConstrainedBox")
+        .into_iter()
+        .filter(|&id| laid.size(id).height == px(BOTTOM_SLOT_HEIGHT))
+        .collect();
+    assert_eq!(
+        candidates.len(),
+        1,
+        "expected exactly one RenderConstrainedBox at the bottom slot's own {BOTTOM_SLOT_HEIGHT}px \
+         height"
+    );
+    candidates[0]
+}
+
+#[test]
+fn app_bar_with_a_bottom_slot_mounts_the_toolbar_then_the_bottom_at_their_full_heights() {
+    let laid = lay_out(
+        Theme::new(
+            ThemeData::light(),
+            MediaQuery::new(
+                MediaQueryData::default(),
+                AppBar::new()
+                    .title(Text::new("Title"))
+                    .bottom(fixed_height_bottom(BOTTOM_SLOT_HEIGHT)),
+            ),
+        ),
+        loose(400.0),
+    );
+
+    let root = laid.root();
+    assert_eq!(
+        laid.size(root).height,
+        px(56.0 + BOTTOM_SLOT_HEIGHT),
+        "with no height shortfall, the AppBar's total height must be toolbar_height + the \
+         bottom slot's own preferred height",
+    );
+
+    let bottom = find_bottom_slot_box(&laid);
+    assert_eq!(
+        laid.absolute_offset(bottom).dy,
+        px(56.0),
+        "the bottom slot must sit directly below the toolbar, at y == toolbar_height"
+    );
+}
+
+/// A caller-imposed height shortfall (here: an outer constraint that leaves
+/// no extra room for the `MediaQuery` top inset the `SafeArea` still
+/// consumes internally) must shrink the **toolbar**, not the bottom slot —
+/// see `app_bar.rs`'s module docs' `bottom` section on why `Flexible`
+/// (loose fit) wraps the toolbar specifically. `56 (toolbar) + 48 (bottom)
+/// == 104`, the exact outer constraint below; the 40px top inset eats into
+/// that 104 internally, leaving only `104 - 40 - 48 == 16px` for the toolbar.
+///
+/// Red-check: swap `Flexible`/`ConstrainedBox(max_height: toolbar_height)`
+/// for a plain (unwrapped) toolbar in `app_bar.rs`'s `build` — the Column
+/// would then try to give the toolbar its full, un-shrinkable natural size
+/// under `MainAxisSize::Max`, overflowing the available height instead of
+/// this test's exact 16px.
+#[test]
+fn a_height_shortfall_shrinks_the_toolbar_and_leaves_the_bottom_slot_at_its_full_height() {
+    let media = MediaQueryData {
+        padding: EdgeInsets::new(px(40.0), px(0.0), px(0.0), px(0.0)),
+        ..MediaQueryData::default()
+    };
+    let laid = lay_out(
+        Theme::new(
+            ThemeData::light(),
+            MediaQuery::new(
+                media,
+                AppBar::new()
+                    .title(Text::new("Title"))
+                    .bottom(fixed_height_bottom(BOTTOM_SLOT_HEIGHT)),
+            ),
+        ),
+        tight(400.0, 56.0 + BOTTOM_SLOT_HEIGHT),
+    );
+
+    let bottom = find_bottom_slot_box(&laid);
+    assert_eq!(
+        laid.size(bottom).height,
+        px(BOTTOM_SLOT_HEIGHT),
+        "the bottom slot must keep its full preferred height under a shortfall"
+    );
+
+    let toolbar_boxes: Vec<_> = laid
+        .find_all_by_render_type("RenderConstrainedBox")
+        .into_iter()
+        .filter(|&id| laid.size(id).height == px(56.0))
+        .collect();
+    assert!(
+        toolbar_boxes.is_empty(),
+        "the toolbar must have shrunk below its 56px preference under the shortfall"
+    );
+
+    // Both the toolbar's own `SizedBox` and the `ConstrainedBox(max_height:
+    // toolbar_height)` wrapping it end up reporting the SAME shrunk height
+    // (the inner one is fully absorbed by the outer's tighter constraint) —
+    // so this is `>= 1`, not `== 1`; the count is an implementation detail,
+    // the shrunk height itself is the behavior under test.
+    let shrunk_toolbar_boxes: Vec<_> = laid
+        .find_all_by_render_type("RenderConstrainedBox")
+        .into_iter()
+        .filter(|&id| laid.size(id).height == px(16.0))
+        .collect();
+    assert!(
+        !shrunk_toolbar_boxes.is_empty(),
+        "the toolbar must shrink to exactly the 16px left over (104 total - 40 top inset - \
+         48 bottom slot)"
+    );
+}
+
+/// A standalone `AppBar` (no `Scaffold`) with a `bottom` slot still consumes
+/// its own top safe-area inset unassisted — the same "consumes the top inset
+/// itself" contract `standalone_app_bar_consumes_the_top_padding_itself`
+/// proves for a bare toolbar, now with `bottom` in the mix and ample room
+/// (no shortfall), so the top inset adds cleanly on top of the full
+/// toolbar + bottom sum rather than eating into either.
+#[test]
+fn standalone_app_bar_with_a_bottom_slot_still_consumes_its_own_top_padding() {
+    let media = MediaQueryData {
+        padding: EdgeInsets::new(px(24.0), px(0.0), px(0.0), px(0.0)),
+        ..MediaQueryData::default()
+    };
+    let laid = lay_out(
+        Theme::new(
+            ThemeData::light(),
+            MediaQuery::new(
+                media,
+                AppBar::new()
+                    .title(Text::new("Title"))
+                    .bottom(fixed_height_bottom(BOTTOM_SLOT_HEIGHT)),
+            ),
+        ),
+        loose(400.0),
+    );
+
+    let root = laid.root();
+    assert_eq!(
+        laid.size(root).height,
+        px(56.0 + BOTTOM_SLOT_HEIGHT + 24.0),
+        "a primary AppBar with a bottom slot must add the ambient MediaQuery top padding to \
+         toolbar_height + the bottom slot's own preferred height, unassisted by any Scaffold",
+    );
+
+    let bottom = find_bottom_slot_box(&laid);
+    assert_eq!(
+        laid.size(bottom).height,
+        px(BOTTOM_SLOT_HEIGHT),
+        "with ample room (no shortfall), the bottom slot must mount at its full preferred height"
     );
 }

--- a/crates/flui-material/tests/tab_bar_view.rs
+++ b/crates/flui-material/tests/tab_bar_view.rs
@@ -18,10 +18,14 @@ use std::time::Duration;
 
 use common::{lay_out, lay_out_animated, tight};
 use flui_animation::{Animation, AnimationController, Vsync, VsyncRegistration};
-use flui_material::{DefaultTabController, TabBarView, TabController};
+use flui_material::{
+    DefaultTabController, Tab, TabBar, TabBarView, TabController, Theme, ThemeData,
+};
 use flui_scheduler::Scheduler;
 use flui_view::prelude::*;
-use flui_widgets::{MediaQuery, MediaQueryData, SizedBox, VsyncScope};
+use flui_widgets::{
+    Column, CrossAxisAlignment, Expanded, MediaQuery, MediaQueryData, SizedBox, VsyncScope,
+};
 
 /// Per-pump virtual-time step for the `TickerMode` animation test — half the
 /// probe `AnimationController`'s own 1s duration, matching
@@ -250,10 +254,12 @@ fn an_inactive_tabs_animation_is_muted_by_ticker_mode() {
 }
 
 /// Unmounting a `TabBarView` removes its listener from the (outliving)
-/// `TabController` it was subscribed to — same "count seam" pattern as
+/// `TabController` it was subscribed to — a controller that outlives the
+/// view must not keep firing a dead `Rc` closure against an unmounted
+/// element's `RebuildHandle`. Same "count seam" pattern as
 /// `crates/flui-material/tests/tabs.rs`'s
-/// `unmounting_a_tab_bar_removes_its_listener_from_the_controller` — the PR1
-/// lesson, now proven for `TabBarView`'s own `dispose`.
+/// `unmounting_a_tab_bar_removes_its_listener_from_the_controller`, now
+/// proven for `TabBarView`'s own `dispose`.
 #[test]
 fn unmounting_a_tab_bar_view_removes_its_listener_from_the_controller() {
     let controller = TabController::new(2, 0);
@@ -352,39 +358,76 @@ fn is_offstage(laid: &common::LaidOut, id: flui_foundation::RenderId) -> bool {
 }
 
 /// A `DefaultTabController` ancestor is reachable by (and sufficient for) a
-/// descendant `TabBarView` with no explicit controller — the fallback half
+/// descendant `TabBarView` with NO explicit controller — the fallback half
 /// of the "explicit, else `DefaultTabController`" contract
 /// `a_tab_bar_view_with_no_controller_and_no_default_tab_controller_ancestor_panics`
-/// proves the negative of. Also proves a controller-driven switch reaches
-/// the mounted tree (not just the controller's own state): the `Stack`'s
-/// per-tab `Offstage` layers (in `view.children` order) flip which one is
-/// offstage when the controller's index changes.
+/// proves the negative of.
+///
+/// Neither the co-mounted `TabBar` nor the `TabBarView` below is ever given
+/// an explicit `.controller(...)` — an earlier version of this test passed
+/// one to `TabBarView` directly, which (per `resolve_controller`'s "explicit
+/// wins" precedence) made the `DefaultTabController` ancestor inert and
+/// proved nothing about the fallback path. This version drives the switch
+/// the only way that actually exercises `DefaultTabController::maybe_of`:
+/// a real pointer tap on the co-mounted `TabBar`, mirroring
+/// `crates/flui-material/tests/tabs.rs`'s
+/// `default_tab_controller_is_reachable_by_a_descendant_tab_bar_and_drives_its_indicator`.
+/// Both widgets resolving to the SAME ancestor-owned `TabController` is
+/// exactly what makes the tap on one observable through the other's
+/// `Offstage` layers below.
 ///
 /// Sizes are NOT the probe here — `Stack::fit(StackFit::Expand)` (matching
 /// `CupertinoTabScaffold`'s own choice) forces every layer, on- or
 /// off-stage, to the `Stack`'s own tight size, so a size comparison cannot
 /// tell them apart; the `offstage` diagnostics flag can.
+///
+/// Mutation red-check (run and reverted, see the review evidence): remove
+/// the `.or_else(|| DefaultTabController::maybe_of(ctx))` arm from
+/// `tab_bar_view.rs`'s `resolve_controller` — `build` then panics on mount
+/// (no explicit controller, no fallback), and this test fails loudly
+/// instead of silently passing.
 #[test]
 fn default_tab_controller_ancestor_drives_the_active_child_through_offstage() {
-    let controller = TabController::new(2, 0);
+    let tabs = vec![Tab::new().text("One"), Tab::new().text("Two")];
     let mut laid = lay_out(
-        MediaQuery::new(
-            MediaQueryData::default(),
-            DefaultTabController::new(
-                2,
-                TabBarView::new(vec![
-                    SizedBox::new(30.0, 30.0).into_view().boxed(),
-                    SizedBox::new(40.0, 40.0).into_view().boxed(),
-                ])
-                .controller(controller.clone()),
+        Theme::new(
+            ThemeData::light(),
+            MediaQuery::new(
+                MediaQueryData::default(),
+                DefaultTabController::new(
+                    2,
+                    Column::new(vec![
+                        TabBar::secondary(tabs).boxed(),
+                        Expanded::new(TabBarView::new(vec![
+                            SizedBox::new(30.0, 30.0).into_view().boxed(),
+                            SizedBox::new(40.0, 40.0).into_view().boxed(),
+                        ]))
+                        .boxed(),
+                    ])
+                    .cross_axis_alignment(CrossAxisAlignment::Stretch),
+                ),
             ),
         ),
         tight(400.0, 400.0),
     );
     laid.tick();
 
+    // The co-mounted `TabBar` mounts its OWN `RenderStack` internally (the
+    // divider layer + tab row, see `tabs.rs`'s module docs) — disambiguate
+    // `TabBarView`'s own `Stack` structurally, as the one whose direct
+    // children are ALL `RenderOffstage` layers (the `TabBar`'s stack's
+    // children are not).
+    let offstage_ids: std::collections::HashSet<_> = laid
+        .find_all_by_render_type("RenderOffstage")
+        .into_iter()
+        .collect();
     let stack = laid
-        .find_by_render_type("RenderStack")
+        .find_all_by_render_type("RenderStack")
+        .into_iter()
+        .find(|&id| {
+            let kids = laid.children(id);
+            !kids.is_empty() && kids.iter().all(|kid| offstage_ids.contains(kid))
+        })
         .expect("TabBarView must mount a Stack of per-tab Offstage layers");
     let layers = laid.children(stack);
     assert_eq!(layers.len(), 2, "one Offstage layer per tab");
@@ -398,16 +441,21 @@ fn default_tab_controller_ancestor_drives_the_active_child_through_offstage() {
         "tab 1 is inactive on mount — its Offstage layer must be offstage"
     );
 
-    controller.set_index(1);
+    // Tap the second (of two, equal-width) tabs in the co-mounted TabBar —
+    // matching `tests/tabs.rs`'s `tap_sets_the_controller_index_through_real_pointer_dispatch`
+    // geometry, scaled to this test's 400px-wide bar (two 200px cells; the
+    // second spans x in [200, 400), 48px tall).
+    laid.dispatch_pointer_down(300.0, 24.0);
+    laid.dispatch_pointer_up(300.0, 24.0);
     laid.tick();
 
     let layers_after = laid.children(stack);
     assert!(
         is_offstage(&laid, layers_after[0]),
-        "after switching to tab 1, tab 0's Offstage layer must become offstage"
+        "after tapping the TabBar's second tab, TabBarView's tab 0 layer must become offstage"
     );
     assert!(
         !is_offstage(&laid, layers_after[1]),
-        "after switching to tab 1, its Offstage layer must become on-stage"
+        "after tapping the TabBar's second tab, TabBarView's tab 1 layer must become on-stage"
     );
 }

--- a/crates/flui-material/tests/tab_bar_view.rs
+++ b/crates/flui-material/tests/tab_bar_view.rs
@@ -1,0 +1,413 @@
+//! [`TabBarView`] widget-level mount/interaction coverage — complements
+//! `tab_bar_view.rs`'s own unit tests (the pure builder-field probes) with
+//! end-to-end mount proof of the lazy-keep-alive switcher contract this
+//! module docs cite `CupertinoTabScaffold`'s `_TabSwitchingView` mechanic
+//! for: a not-yet-visited child is never built, a visited-then-hidden
+//! child's own state survives (`Offstage`, not unmount), an inactive
+//! child's animation is muted (`TickerMode`), a controller swap/unmount
+//! removes the old listener, and an out-of-range controller index falls
+//! through without panicking in release (proven here via the `debug_assert!`
+//! itself, live in this crate's own debug test profile).
+
+mod common;
+
+use std::cell::Cell;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Duration;
+
+use common::{lay_out, lay_out_animated, tight};
+use flui_animation::{Animation, AnimationController, Vsync, VsyncRegistration};
+use flui_material::{DefaultTabController, TabBarView, TabController};
+use flui_scheduler::Scheduler;
+use flui_view::prelude::*;
+use flui_widgets::{MediaQuery, MediaQueryData, SizedBox, VsyncScope};
+
+/// Per-pump virtual-time step for the `TickerMode` animation test — half the
+/// probe `AnimationController`'s own 1s duration, matching
+/// `flui-cupertino/tests/tab_scaffold.rs`'s identical animation-probe
+/// pattern (`FRAME`).
+const FRAME: Duration = Duration::from_millis(300);
+
+/// A leaf whose `create_state` is counted — proves whether a tab's content
+/// element survived a visibility toggle (`Offstage`) versus being torn down
+/// and rebuilt from scratch. Same fixture shape as
+/// `flui-cupertino/tests/tab_scaffold.rs`'s own `Probe` (this crate cannot
+/// see that one — it's private to that test binary).
+#[derive(Clone)]
+struct Probe(Rc<Cell<u32>>);
+
+impl View for Probe {
+    fn create_element(&self) -> flui_view::element::ElementKind {
+        flui_view::element::ElementKind::stateful(self)
+    }
+}
+
+impl StatefulView for Probe {
+    type State = ProbeState;
+
+    fn create_state(&self) -> Self::State {
+        self.0.set(self.0.get() + 1);
+        ProbeState
+    }
+}
+
+struct ProbeState;
+
+impl ViewState<Probe> for ProbeState {
+    fn build(&self, _view: &Probe, _ctx: &dyn BuildContext) -> impl IntoView {
+        SizedBox::new(10.0, 10.0)
+    }
+}
+
+/// A tab's content is only ever built the first time it becomes active —
+/// Flutter parity (mechanism-adapted, see `tab_bar_view.rs`'s module docs):
+/// `_TabSwitchingViewState.shouldBuildTab`. Tab 1's `Probe` must never be
+/// constructed while tab 0 stays active.
+///
+/// Red-check: drop the `should_build[index]` gate in `tab_bar_view.rs`'s
+/// `build` (clone every child unconditionally instead of substituting
+/// `SizedBox::shrink()` for a not-yet-visited one) — tab 1's `Probe` would
+/// then mount (and its `create_state` fire) on the very first build, and
+/// this test's "must never be created while tab 0 is active" assertion
+/// fails.
+#[test]
+fn a_tab_is_not_built_until_it_becomes_active() {
+    let created = Rc::new(Cell::new(0_u32));
+    let created_for_tab_1 = Rc::clone(&created);
+
+    let controller = TabController::new(2, 0);
+    let view = TabBarView::new(vec![
+        SizedBox::new(10.0, 10.0).into_view().boxed(),
+        Probe(created_for_tab_1).into_view().boxed(),
+    ])
+    .controller(controller.clone());
+
+    let mut laid = lay_out(
+        MediaQuery::new(MediaQueryData::default(), view),
+        tight(400.0, 400.0),
+    );
+    laid.tick();
+
+    assert_eq!(
+        created.get(),
+        0,
+        "tab 1's Probe must never be created while tab 0 stays active"
+    );
+
+    controller.set_index(1);
+    laid.tick();
+
+    assert_eq!(
+        created.get(),
+        1,
+        "tab 1's Probe must be created once it becomes active"
+    );
+}
+
+/// An inactive tab's own element state survives a switch away and back —
+/// `Offstage`, not unmount. Same `_TabSwitchingViewState` contract as above,
+/// proven this time via a `create_state` COUNT staying at `1` across a
+/// round trip rather than merely becoming nonzero.
+///
+/// Red-check: key each tab's `Offstage` layer by `(index, current_index)`
+/// instead of `index` alone (forcing a fresh element identity on every
+/// switch) — `created.get()` would read `2` instead of `1` after the round
+/// trip below.
+#[test]
+fn an_inactive_tabs_state_survives_switching_away_and_back() {
+    let created = Rc::new(Cell::new(0_u32));
+    let created_for_tab_0 = Rc::clone(&created);
+
+    let controller = TabController::new(2, 0);
+    let view = TabBarView::new(vec![
+        Probe(created_for_tab_0).into_view().boxed(),
+        SizedBox::new(10.0, 10.0).into_view().boxed(),
+    ])
+    .controller(controller.clone());
+
+    let mut laid = lay_out(
+        MediaQuery::new(MediaQueryData::default(), view),
+        tight(400.0, 400.0),
+    );
+    laid.tick();
+    assert_eq!(
+        created.get(),
+        1,
+        "tab 0's Probe must have been created once"
+    );
+
+    controller.set_index(1);
+    laid.tick();
+    controller.set_index(0);
+    laid.tick();
+
+    assert_eq!(
+        created.get(),
+        1,
+        "switching away to tab 1 and back to tab 0 must not recreate tab 0's Probe state"
+    );
+}
+
+/// Registers `controller` against the ambient `VsyncScope` in `init_state`
+/// and unregisters it in `dispose` — the same `AnimationProbe` fixture
+/// `flui-cupertino/tests/tab_scaffold.rs` uses to prove its own
+/// `TickerMode` wiring.
+#[derive(Clone, StatefulView)]
+struct AnimationProbe {
+    controller: AnimationController,
+}
+
+struct AnimationProbeState {
+    controller: AnimationController,
+    registration: Option<(Vsync, VsyncRegistration)>,
+}
+
+impl StatefulView for AnimationProbe {
+    type State = AnimationProbeState;
+
+    fn create_state(&self) -> Self::State {
+        AnimationProbeState {
+            controller: self.controller.clone(),
+            registration: None,
+        }
+    }
+}
+
+impl ViewState<AnimationProbe> for AnimationProbeState {
+    fn init_state(&mut self, ctx: &dyn BuildContext) {
+        if let Some(vsync) = ctx.get::<VsyncScope, _>(|scope| scope.vsync().clone()) {
+            let registration = vsync.register(self.controller.clone());
+            self.registration = Some((vsync, registration));
+        }
+    }
+
+    fn dispose(&mut self) {
+        if let Some((vsync, registration)) = self.registration.take() {
+            vsync.unregister(registration);
+        }
+    }
+
+    fn build(&self, _view: &AnimationProbe, _ctx: &dyn BuildContext) -> impl IntoView {
+        SizedBox::new(10.0, 10.0)
+    }
+}
+
+/// An inactive tab's animation genuinely stops advancing — the same "Off
+/// stage tabs' animations are stopped" contract
+/// `flui-cupertino/tests/tab_scaffold.rs`'s
+/// `an_inactive_tabs_animation_is_muted_by_ticker_mode` proves for
+/// `CupertinoTabScaffold`. Proven by registering a real `AnimationController`
+/// against the ambient `VsyncScope` from inside tab 0's content, then
+/// switching to tab 1 and confirming the controller's value freezes.
+///
+/// Red-check: drop the `TickerMode::new(content).enabled(active)` wrap in
+/// `tab_bar_view.rs`'s `build` (go back to bare `Offstage`) — this test's
+/// final `assert_eq!` fails, since the controller keeps advancing while tab
+/// 0 is merely offstage, not ticker-muted.
+#[test]
+fn an_inactive_tabs_animation_is_muted_by_ticker_mode() {
+    let vsync = Vsync::new();
+    let animation = AnimationController::new(Duration::from_secs(1), Arc::new(Scheduler::new()));
+    let tab_controller = TabController::new(2, 0);
+
+    let probe_controller = animation.clone();
+    let view = TabBarView::new(vec![
+        AnimationProbe {
+            controller: probe_controller,
+        }
+        .into_view()
+        .boxed(),
+        SizedBox::new(10.0, 10.0).into_view().boxed(),
+    ])
+    .controller(tab_controller.clone());
+    let root = VsyncScope::new(
+        vsync.clone(),
+        MediaQuery::new(MediaQueryData::default(), view),
+    );
+    let mut laid = lay_out_animated(root, tight(400.0, 400.0), vsync);
+
+    animation.forward().expect("animation should start");
+    laid.pump_for(FRAME);
+    laid.pump_for(FRAME);
+    assert!(
+        animation.value() > 0.0,
+        "tab 0 is active on mount; its registered animation must advance"
+    );
+
+    tab_controller.set_index(1);
+    laid.tick();
+    let value_when_switched_away = animation.value();
+
+    laid.pump_for(FRAME);
+    laid.pump_for(FRAME);
+    assert_eq!(
+        animation.value(),
+        value_when_switched_away,
+        "an inactive tab's animation must not advance once TickerMode disables it"
+    );
+    animation.dispose();
+}
+
+/// Unmounting a `TabBarView` removes its listener from the (outliving)
+/// `TabController` it was subscribed to — same "count seam" pattern as
+/// `crates/flui-material/tests/tabs.rs`'s
+/// `unmounting_a_tab_bar_removes_its_listener_from_the_controller` — the PR1
+/// lesson, now proven for `TabBarView`'s own `dispose`.
+#[test]
+fn unmounting_a_tab_bar_view_removes_its_listener_from_the_controller() {
+    let controller = TabController::new(2, 0);
+
+    let before_mount = controller.listener_count();
+    let mut laid = lay_out(
+        MediaQuery::new(
+            MediaQueryData::default(),
+            TabBarView::new(vec![
+                SizedBox::new(10.0, 10.0).into_view().boxed(),
+                SizedBox::new(20.0, 20.0).into_view().boxed(),
+            ])
+            .controller(controller.clone()),
+        ),
+        tight(400.0, 400.0),
+    );
+    let while_mounted = controller.listener_count();
+    assert!(
+        while_mounted > before_mount,
+        "mounting a TabBarView must register its own listener on the controller"
+    );
+
+    // Root-swap to an unrelated tree — `TabBarViewState::dispose` must fire
+    // for the removed `TabBarView`.
+    laid.pump_widget(MediaQuery::new(
+        MediaQueryData::default(),
+        SizedBox::shrink(),
+    ));
+
+    let after_removal = controller.listener_count();
+    assert_eq!(
+        after_removal, before_mount,
+        "removing a TabBarView from the tree must remove its listener from the controller, \
+         not leak it"
+    );
+}
+
+/// A `TabBarView` with neither an explicit `controller` nor a
+/// `DefaultTabController` ancestor panics loudly (Flutter parity:
+/// `_updateTabController`'s `FlutterError`) instead of silently rendering
+/// with no active tab — same documented panic-boundary mechanism as
+/// `crates/flui-material/tests/tabs.rs`'s
+/// `a_tab_bar_with_no_controller_and_no_default_tab_controller_ancestor_panics`
+/// and `flui-cupertino/tests/tab_scaffold.rs`'s
+/// `out_of_range_controller_index_panics_instead_of_silently_hiding_every_tab`.
+#[test]
+#[should_panic(expected = "render root")]
+fn a_tab_bar_view_with_no_controller_and_no_default_tab_controller_ancestor_panics() {
+    let _ = lay_out(
+        MediaQuery::new(
+            MediaQueryData::default(),
+            TabBarView::new(vec![SizedBox::new(10.0, 10.0).into_view().boxed()]),
+        ),
+        tight(400.0, 400.0),
+    );
+}
+
+/// The `children.len() != controller.length()` mismatch `debug_assert!` is
+/// live in this crate's own (debug-profile) test build — a length mismatch
+/// panics inside `build`, caught by the framework's build-error boundary,
+/// which leaves nothing to render (same mechanism the previous test's doc
+/// comment cites).
+///
+/// Red-check: delete the `debug_assert!` in `tab_bar_view.rs`'s `build` —
+/// this test stops panicking; the view instead mounts with tab index 2
+/// (out of range for the 2-child `Vec`) simply never matching any child, so
+/// every child renders `Offstage`-hidden — the documented release
+/// fall-through this test's sibling assertion (module docs) describes,
+/// silently reached in a build where the assert should have fired instead.
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "render root")]
+fn a_children_count_mismatched_with_the_controllers_length_panics() {
+    let controller = TabController::new(3, 2);
+    let _ = lay_out(
+        MediaQuery::new(
+            MediaQueryData::default(),
+            TabBarView::new(vec![
+                SizedBox::new(10.0, 10.0).into_view().boxed(),
+                SizedBox::new(20.0, 20.0).into_view().boxed(),
+            ])
+            .controller(controller),
+        ),
+        tight(400.0, 400.0),
+    );
+}
+
+/// `RenderDiagnostics::add_flag` (`flui-foundation`'s `debug_fill_properties`
+/// helper) omits a flag property entirely when it's `false` — so
+/// `render_property(id, "offstage")` is `Some(_)` exactly when that
+/// `Offstage` layer IS offstage, `None` when it's on-stage. `TabBarView`
+/// mounts each tab's `Offstage` layer in `view.children` order (index 0
+/// first), so `laid.children(stack)[index]` is that tab's own layer.
+fn is_offstage(laid: &common::LaidOut, id: flui_foundation::RenderId) -> bool {
+    laid.render_property(id, "offstage").is_some()
+}
+
+/// A `DefaultTabController` ancestor is reachable by (and sufficient for) a
+/// descendant `TabBarView` with no explicit controller — the fallback half
+/// of the "explicit, else `DefaultTabController`" contract
+/// `a_tab_bar_view_with_no_controller_and_no_default_tab_controller_ancestor_panics`
+/// proves the negative of. Also proves a controller-driven switch reaches
+/// the mounted tree (not just the controller's own state): the `Stack`'s
+/// per-tab `Offstage` layers (in `view.children` order) flip which one is
+/// offstage when the controller's index changes.
+///
+/// Sizes are NOT the probe here — `Stack::fit(StackFit::Expand)` (matching
+/// `CupertinoTabScaffold`'s own choice) forces every layer, on- or
+/// off-stage, to the `Stack`'s own tight size, so a size comparison cannot
+/// tell them apart; the `offstage` diagnostics flag can.
+#[test]
+fn default_tab_controller_ancestor_drives_the_active_child_through_offstage() {
+    let controller = TabController::new(2, 0);
+    let mut laid = lay_out(
+        MediaQuery::new(
+            MediaQueryData::default(),
+            DefaultTabController::new(
+                2,
+                TabBarView::new(vec![
+                    SizedBox::new(30.0, 30.0).into_view().boxed(),
+                    SizedBox::new(40.0, 40.0).into_view().boxed(),
+                ])
+                .controller(controller.clone()),
+            ),
+        ),
+        tight(400.0, 400.0),
+    );
+    laid.tick();
+
+    let stack = laid
+        .find_by_render_type("RenderStack")
+        .expect("TabBarView must mount a Stack of per-tab Offstage layers");
+    let layers = laid.children(stack);
+    assert_eq!(layers.len(), 2, "one Offstage layer per tab");
+
+    assert!(
+        !is_offstage(&laid, layers[0]),
+        "tab 0 is the initial active index — its Offstage layer must be on-stage"
+    );
+    assert!(
+        is_offstage(&laid, layers[1]),
+        "tab 1 is inactive on mount — its Offstage layer must be offstage"
+    );
+
+    controller.set_index(1);
+    laid.tick();
+
+    let layers_after = laid.children(stack);
+    assert!(
+        is_offstage(&laid, layers_after[0]),
+        "after switching to tab 1, tab 0's Offstage layer must become offstage"
+    );
+    assert!(
+        !is_offstage(&laid, layers_after[1]),
+        "after switching to tab 1, its Offstage layer must become on-stage"
+    );
+}

--- a/examples/material_demo/tree.rs
+++ b/examples/material_demo/tree.rs
@@ -25,11 +25,12 @@
 //! the way a real `MaterialApp` mounts one at the root.
 //!
 //! [`MaterialDemoHome`] builds a `Scaffold`:
-//! - `app_bar`: an `AppBar` titled [`APP_TITLE`] with one action — an
-//!   `IconButton` (a settings glyph) that pushes [`settings_route`]. Its
-//!   `AppBar` has no explicit `leading`, so on the settings route (a second
-//!   stack entry, `can_pop() == true`) it synthesizes a `BackButton` — proven
-//!   by [`tests`](../../tests/material_demo.rs), not merely asserted.
+//! - `app_bar`: an `AppBar` titled [`APP_TITLE`] with two actions — a "tab"
+//!   glyph `IconButton` that pushes [`tabs_route`], and a settings glyph
+//!   `IconButton` that pushes [`settings_route`]. Its `AppBar` has no
+//!   explicit `leading`, so on either pushed route (a second stack entry,
+//!   `can_pop() == true`) it synthesizes a `BackButton` — proven by
+//!   [`tests`](../../tests/material_demo.rs), not merely asserted.
 //! - `body`: a selected-item `Text`, then a drag-to-scroll `ListView` of
 //!   `Card`s (each `Card(InkWell(Padding(Text)))`, the canonical Material
 //!   tap-target composition). Tapping a card sets the selected-item text.
@@ -46,6 +47,14 @@
 //!   `maintain_state: true`), so the home route stays mounted, laid out,
 //!   and painted beneath the dialog's barrier — only its hit-testing is
 //!   blocked (the full-screen barrier sits on top).
+//!
+//! [`tabs_route`] is a third route (Tabs PR2's own exit criterion): a
+//! `DefaultTabController`-scoped `Scaffold` whose `AppBar.bottom` carries a
+//! secondary `TabBar` and whose body is the matching `TabBarView`, over
+//! three tabs ([`OVERVIEW_TAB_LABEL`], [`COUNTER_TAB_LABEL`],
+//! [`ABOUT_TAB_LABEL`]) — see [`CounterTab`]'s own doc comment for the
+//! stateful-counter tab that demonstrates `TabBarView`'s keep-alive
+//! retention.
 //!
 //! # Honest caveats (Catalog.1 exit criterion, Material half)
 //!
@@ -71,8 +80,9 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use flui_material::{
-    AlertDialog, AppBar, Card, FilledButton, FloatingActionButton, IconButton, InkWell, Scaffold,
-    ScaffoldMessenger, ScaffoldMessengerHandle, ScaffoldMessengerScope, SnackBar, TextButton,
+    AlertDialog, AppBar, Card, DefaultTabController, ElevatedButton, FilledButton,
+    FloatingActionButton, IconButton, InkWell, Scaffold, ScaffoldMessenger,
+    ScaffoldMessengerHandle, ScaffoldMessengerScope, SnackBar, Tab, TabBar, TabBarView, TextButton,
     Theme, ThemeData, show_dialog,
 };
 use flui_view::RebuildHandle;
@@ -97,6 +107,26 @@ pub const APP_TITLE: &str = "Material Demo";
 pub const SETTINGS_ROUTE_TITLE: &str = "Settings";
 /// The settings route's body text.
 pub const SETTINGS_ROUTE_TEXT: &str = "Settings route";
+
+/// The tabbed route's app bar title.
+pub const TABS_ROUTE_TITLE: &str = "Tabs";
+/// The first tab's label — its content builds on mount (index `0` is the
+/// controller's initial index).
+pub const OVERVIEW_TAB_LABEL: &str = "Overview";
+/// The first tab's body text.
+pub const OVERVIEW_TAB_TEXT: &str = "Overview tab";
+/// The second (stateful-counter) tab's label.
+pub const COUNTER_TAB_LABEL: &str = "Counter";
+/// The counter tab's increment button label.
+pub const COUNTER_INCREMENT_LABEL: &str = "Increment";
+/// The prefix on the counter tab's live count display — the acceptance test
+/// reads `"{COUNTER_LABEL_PREFIX}{n}"` after each tap.
+pub const COUNTER_LABEL_PREFIX: &str = "Count: ";
+/// The third tab's label — never built until it's visited (the acceptance
+/// test's lazy-build proof).
+pub const ABOUT_TAB_LABEL: &str = "About";
+/// The third tab's body text.
+pub const ABOUT_TAB_TEXT: &str = "About tab";
 
 /// The FAB's child label.
 pub const FAB_LABEL: &str = "+";
@@ -124,6 +154,14 @@ pub const SNACK_BAR_ADDED_MESSAGE: &str = "Item added";
 #[must_use]
 pub fn settings_icon_data() -> IconData {
     IconData::new(0xE8B8).with_font_family("MaterialIcons")
+}
+
+/// `Icons.tab`'s codepoint (`icons.dart`'s `tab` constant) — the app bar
+/// action that pushes [`tabs_route`]. Same tofu-rendering gap as
+/// [`settings_icon_data`]; `pub` for the identical reason.
+#[must_use]
+pub fn tabs_icon_data() -> IconData {
+    IconData::new(0xE8D2).with_font_family("MaterialIcons")
 }
 
 /// The Material demo root: a `Navigator` shell over the home route.
@@ -323,7 +361,8 @@ impl ViewState<MaterialDemoHome> for MaterialDemoHomeState {
             })
             .child(ListView::new(ITEM_EXTENT, cards).position(self.scroll_controller.position()));
 
-        let navigator_for_action = self.navigator.clone();
+        let navigator_for_settings_action = self.navigator.clone();
+        let navigator_for_tabs_action = self.navigator.clone();
         let app_bar = AppBar::new()
             .title(Text::new(APP_TITLE))
             // The home route is the navigator's root — it never wants an
@@ -336,9 +375,14 @@ impl ViewState<MaterialDemoHome> for MaterialDemoHomeState {
             // synthesize a second, redundant `BackButton` here too.
             .automatically_imply_leading(false)
             .actions(vec![
+                IconButton::new(Icon::new(tabs_icon_data()))
+                    .on_pressed(move || {
+                        navigator_for_tabs_action.push(tabs_route());
+                    })
+                    .boxed(),
                 IconButton::new(Icon::new(settings_icon_data()))
                     .on_pressed(move || {
-                        navigator_for_action.push(settings_route());
+                        navigator_for_settings_action.push(settings_route());
                     })
                     .boxed(),
             ]);
@@ -431,6 +475,95 @@ fn settings_route() -> PageRoute<()> {
             .boxed()
     })
     .named("settings")
+}
+
+/// The `Counter` tab's content: a live count display plus an `Increment`
+/// button. `count` lives in an `Rc<Cell<i32>>` on [`CounterTabState`] (the
+/// same closure-captures-shared-state-then-`rebuild.schedule()` shape
+/// [`open_add_item_dialog`]'s `Add` action and the card-tap handler in
+/// [`MaterialDemoHomeState::build`] already use) — `TabBarView`'s
+/// keep-alive `Offstage` retention (not unmount) is what lets `count`
+/// survive switching to another tab and back, which is exactly the
+/// acceptance criterion this tab exists to demonstrate.
+#[derive(Clone, StatefulView)]
+struct CounterTab;
+
+/// Persistent state for [`CounterTab`].
+struct CounterTabState {
+    count: Rc<Cell<i32>>,
+    /// `None` only before `init_state` has run; every `build` call happens
+    /// after it.
+    rebuild: Option<RebuildHandle>,
+}
+
+impl StatefulView for CounterTab {
+    type State = CounterTabState;
+
+    fn create_state(&self) -> Self::State {
+        CounterTabState {
+            count: Rc::new(Cell::new(0)),
+            rebuild: None,
+        }
+    }
+}
+
+impl ViewState<CounterTab> for CounterTabState {
+    fn init_state(&mut self, ctx: &dyn BuildContext) {
+        self.rebuild = Some(ctx.rebuild_handle());
+    }
+
+    fn build(&self, _view: &CounterTab, _ctx: &dyn BuildContext) -> impl IntoView {
+        let rebuild = self
+            .rebuild
+            .clone()
+            .expect("BUG: init_state runs before build (ViewState lifecycle order)");
+        let displayed_count = self.count.get();
+        let count_for_tap = Rc::clone(&self.count);
+
+        Center::new().child(Column::new(column![
+            Text::new(format!("{COUNTER_LABEL_PREFIX}{displayed_count}")),
+            ElevatedButton::new(Text::new(COUNTER_INCREMENT_LABEL)).on_pressed(move || {
+                count_for_tap.set(count_for_tap.get() + 1);
+                rebuild.schedule();
+            }),
+        ]))
+    }
+}
+
+/// The tabbed route: a [`DefaultTabController`]-scoped `Scaffold` whose
+/// `AppBar.bottom` carries a secondary [`TabBar`] and whose body is the
+/// matching [`TabBarView`] — the Tabs PR2 sample-app exit criterion (see
+/// the module docs). Same "no explicit `leading`" implied-`BackButton`
+/// shape as [`settings_route`]. Tab 0 ([`OVERVIEW_TAB_LABEL`]) is the
+/// controller's initial index, so it alone is built on mount; tab 1
+/// ([`COUNTER_TAB_LABEL`]) carries [`CounterTab`]'s stateful counter; tab 2
+/// ([`ABOUT_TAB_LABEL`]) stays unbuilt until visited.
+fn tabs_route() -> PageRoute<()> {
+    PageRoute::new(|_ctx, _animation, _secondary| {
+        let tabs = vec![
+            Tab::new().text(OVERVIEW_TAB_LABEL),
+            Tab::new().text(COUNTER_TAB_LABEL),
+            Tab::new().text(ABOUT_TAB_LABEL),
+        ];
+        let pages: Vec<flui_view::BoxedView> = vec![
+            Center::new().child(Text::new(OVERVIEW_TAB_TEXT)).boxed(),
+            CounterTab.into_view().boxed(),
+            Center::new().child(Text::new(ABOUT_TAB_TEXT)).boxed(),
+        ];
+        DefaultTabController::new(
+            tabs.len(),
+            Scaffold::new()
+                .app_bar(
+                    AppBar::new()
+                        .title(Text::new(TABS_ROUTE_TITLE))
+                        .bottom(TabBar::secondary(tabs)),
+                )
+                .body(TabBarView::new(pages)),
+        )
+        .into_view()
+        .boxed()
+    })
+    .named("tabs")
 }
 
 /// Build a fresh demo tree, ready to mount.

--- a/examples/material_demo/tree.rs
+++ b/examples/material_demo/tree.rs
@@ -48,13 +48,13 @@
 //!   and painted beneath the dialog's barrier — only its hit-testing is
 //!   blocked (the full-screen barrier sits on top).
 //!
-//! [`tabs_route`] is a third route (Tabs PR2's own exit criterion): a
-//! `DefaultTabController`-scoped `Scaffold` whose `AppBar.bottom` carries a
-//! secondary `TabBar` and whose body is the matching `TabBarView`, over
-//! three tabs ([`OVERVIEW_TAB_LABEL`], [`COUNTER_TAB_LABEL`],
-//! [`ABOUT_TAB_LABEL`]) — see [`CounterTab`]'s own doc comment for the
-//! stateful-counter tab that demonstrates `TabBarView`'s keep-alive
-//! retention.
+//! [`tabs_route`] is a third route, demonstrating `TabBarView` and
+//! `AppBar.bottom`: a `DefaultTabController`-scoped `Scaffold` whose
+//! `AppBar.bottom` carries a secondary `TabBar` and whose body is the
+//! matching `TabBarView`, over three tabs ([`OVERVIEW_TAB_LABEL`],
+//! [`COUNTER_TAB_LABEL`], [`ABOUT_TAB_LABEL`]) — see [`CounterTab`]'s own
+//! doc comment for the stateful-counter tab that demonstrates
+//! `TabBarView`'s keep-alive retention.
 //!
 //! # Honest caveats (Catalog.1 exit criterion, Material half)
 //!
@@ -156,8 +156,12 @@ pub fn settings_icon_data() -> IconData {
     IconData::new(0xE8B8).with_font_family("MaterialIcons")
 }
 
-/// `Icons.tab`'s codepoint (`icons.dart`'s `tab` constant) — the app bar
-/// action that pushes [`tabs_route`]. Same tofu-rendering gap as
+/// The `tab` glyph's codepoint from the classic `MaterialIcons` font table —
+/// the same numbering convention [`settings_icon_data`]'s `0xE8B8` already
+/// uses, NOT `material/icons.dart`'s current table (oracle tag `3.44.0`
+/// numbers `Icons.tab` as `0xe638`; that codepoint would render the wrong
+/// glyph against the classic font this substrate actually bundles/targets).
+/// The app bar action that pushes [`tabs_route`]. Same tofu-rendering gap as
 /// [`settings_icon_data`]; `pub` for the identical reason.
 #[must_use]
 pub fn tabs_icon_data() -> IconData {
@@ -532,12 +536,13 @@ impl ViewState<CounterTab> for CounterTabState {
 
 /// The tabbed route: a [`DefaultTabController`]-scoped `Scaffold` whose
 /// `AppBar.bottom` carries a secondary [`TabBar`] and whose body is the
-/// matching [`TabBarView`] — the Tabs PR2 sample-app exit criterion (see
-/// the module docs). Same "no explicit `leading`" implied-`BackButton`
-/// shape as [`settings_route`]. Tab 0 ([`OVERVIEW_TAB_LABEL`]) is the
-/// controller's initial index, so it alone is built on mount; tab 1
-/// ([`COUNTER_TAB_LABEL`]) carries [`CounterTab`]'s stateful counter; tab 2
-/// ([`ABOUT_TAB_LABEL`]) stays unbuilt until visited.
+/// matching [`TabBarView`] — this sample app's `TabBarView`/`AppBar.bottom`
+/// demonstration (see the module docs). Same "no explicit `leading`"
+/// implied-`BackButton` shape as [`settings_route`]. Tab 0
+/// ([`OVERVIEW_TAB_LABEL`]) is the controller's initial index, so it alone
+/// is built on mount; tab 1 ([`COUNTER_TAB_LABEL`]) carries [`CounterTab`]'s
+/// stateful counter; tab 2 ([`ABOUT_TAB_LABEL`]) stays unbuilt until
+/// visited.
 fn tabs_route() -> PageRoute<()> {
     PageRoute::new(|_ctx, _animation, _secondary| {
         let tabs = vec![

--- a/tests/material_demo.rs
+++ b/tests/material_demo.rs
@@ -41,6 +41,7 @@ use flui_material::{Theme, ThemeData};
 use flui_rendering::constraints::BoxConstraints;
 use flui_rendering::hit_testing::HitTestResult;
 use flui_rendering::pipeline::PipelineOwner;
+use flui_rendering::testing::inspect;
 use flui_types::geometry::px;
 use flui_types::{Offset, Size};
 use flui_view::{BuildOwner, ElementTree};
@@ -243,6 +244,29 @@ impl MountedDemo {
         found
     }
 
+    /// Every render node whose short type name (generic parameters stripped)
+    /// equals `render_type_name` — duplicated from
+    /// `crates/flui-material/tests/common/mod.rs`'s `LaidOut::find_all_by_render_type`
+    /// for the same reason every other helper here is (see the module doc).
+    fn find_all_by_render_type(&self, render_type_name: &str) -> Vec<RenderId> {
+        let owner = self.pipeline_owner.read();
+        owner
+            .render_tree()
+            .iter()
+            .filter_map(|(id, _node)| {
+                let diagnostics = owner.debug_node_diagnostics(id)?;
+                let short_name = diagnostics.name()?.split('<').next().unwrap_or("");
+                (short_name == render_type_name).then_some(id)
+            })
+            .collect()
+    }
+
+    /// The laid-out size of a render node.
+    fn size(&self, id: RenderId) -> Size {
+        inspect::box_geometry(&self.pipeline_owner.read(), id)
+            .expect("render node should have box geometry after layout")
+    }
+
     /// The screen-space (root-local) top-left of `id`, by summing paint
     /// offsets up the render-tree ancestry — every node between the root and
     /// `id` in this tree only translates (no scale/rotation), so a plain sum
@@ -295,6 +319,14 @@ fn settings_glyph_text() -> String {
     tree::settings_icon_data()
         .code_point_string()
         .expect("the settings glyph's codepoint must be a valid Unicode scalar value")
+}
+
+/// The app bar action's glyph text for [`tree::tabs_icon_data`] — same
+/// reasoning as [`settings_glyph_text`].
+fn tabs_glyph_text() -> String {
+    tree::tabs_icon_data()
+        .code_point_string()
+        .expect("the tabs glyph's codepoint must be a valid Unicode scalar value")
 }
 
 /// The implied `BackButton`'s glyph text, computed from
@@ -726,6 +758,172 @@ fn dragging_inside_the_list_scrolls_its_items() {
         "dragging up {expected_scroll_delta}px worth of post-slop deltas must move item 0's \
          paint position up by the same amount (the slop-crossing move's delta is swallowed): \
          before={offset_before:?}, after={offset_after:?}, moved_up_by={moved_up_by}"
+    );
+}
+
+// ============================================================================
+// (8) Tabs route — TabBarView + AppBar.bottom (Tabs PR2's own exit criterion)
+// ============================================================================
+
+/// Pushes [`tree::tabs_route`] from the home route's app bar action and
+/// returns once the tabs route's title has rendered — the shared setup
+/// every test below starts from.
+fn push_tabs_route(demo: &mut MountedDemo) {
+    let tabs_glyph = tabs_glyph_text();
+    let tabs_button = demo
+        .find_text(&tabs_glyph)
+        .expect("the app bar's tabs action must render");
+    demo.tap_node(tabs_button);
+    demo.pump(Duration::ZERO);
+
+    assert!(
+        demo.find_text(tree::TABS_ROUTE_TITLE).is_some(),
+        "the tabs route's app bar title must render once pushed"
+    );
+}
+
+/// Taps a tab's own label text in the mounted `TabBar` — every test below
+/// needs this at least once, so it's factored out rather than copy-pasted
+/// three times.
+fn tap_tab(demo: &mut MountedDemo, tab_label: &str) {
+    let label = demo
+        .find_text(tab_label)
+        .unwrap_or_else(|| panic!("tab label {tab_label:?} must render in the mounted TabBar"));
+    demo.tap_node(label);
+    demo.pump(Duration::ZERO);
+}
+
+/// A tab tap switches the visible child: on mount, tab 0
+/// ([`tree::OVERVIEW_TAB_LABEL`])'s content is showing and neither other
+/// tab's is; tapping tab 1 ([`tree::COUNTER_TAB_LABEL`]) swaps which one is.
+#[test]
+fn tapping_a_tab_switches_the_visible_child() {
+    let mut demo = MountedDemo::mount();
+    push_tabs_route(&mut demo);
+
+    assert!(
+        demo.find_text(tree::OVERVIEW_TAB_TEXT).is_some(),
+        "tab 0 (Overview) is the controller's initial index — its content must be built and \
+         showing on mount"
+    );
+    assert!(
+        demo.find_text(&format!("{}0", tree::COUNTER_LABEL_PREFIX))
+            .is_none(),
+        "the Counter tab must not be showing before it's ever tapped"
+    );
+
+    tap_tab(&mut demo, tree::COUNTER_TAB_LABEL);
+
+    assert!(
+        demo.find_text(&format!("{}0", tree::COUNTER_LABEL_PREFIX))
+            .is_some(),
+        "tapping the Counter tab must switch the visible child to its content"
+    );
+}
+
+/// The Counter tab's count survives switching away to another tab and back —
+/// `TabBarView`'s `Offstage` keep-alive retention, not a rebuild that resets
+/// local state. Flutter parity target: `TabBarView`'s own "state survives a
+/// tab switch" contract (see `tab_bar_view.rs`'s module docs for the
+/// composed mechanism this substrate uses instead of a real `PageView`).
+#[test]
+fn the_counters_state_survives_switching_away_and_back() {
+    let mut demo = MountedDemo::mount();
+    push_tabs_route(&mut demo);
+
+    tap_tab(&mut demo, tree::COUNTER_TAB_LABEL);
+    let increment = demo
+        .find_text(tree::COUNTER_INCREMENT_LABEL)
+        .expect("the Counter tab's Increment button must render once visited");
+    // The tap position is captured ONCE, up front, and reused for every
+    // subsequent tap — re-resolving `absolute_position` off a `RenderId`
+    // AFTER a rebuild it triggered is unreliable (the node's parent chain
+    // can read back detached until the next full relayout), the same
+    // fixed-position-computed-once pattern
+    // `tests/vertical_slice_demo.rs`'s `tapping_the_plus_button_updates_the_rendered_counter_text`
+    // already established for its own repeatedly-tapped counter button.
+    let tap_at = demo.absolute_position(increment);
+    demo.tap(tap_at.dx.get() + 1.0, tap_at.dy.get() + 1.0);
+    demo.pump(Duration::ZERO);
+    demo.tap(tap_at.dx.get() + 1.0, tap_at.dy.get() + 1.0);
+    demo.pump(Duration::ZERO);
+    demo.tap(tap_at.dx.get() + 1.0, tap_at.dy.get() + 1.0);
+    demo.pump(Duration::ZERO);
+
+    assert!(
+        demo.find_text(&format!("{}3", tree::COUNTER_LABEL_PREFIX))
+            .is_some(),
+        "three taps on Increment must bring the count to 3"
+    );
+
+    // Switch away to Overview, then back to Counter. `TabBarView`'s
+    // `Offstage` keep-alive retention (see `tab_bar_view.rs`'s module docs)
+    // means the Counter tab's `RenderParagraph` stays in the tree the whole
+    // time — merely unpainted while inactive, not torn down — so a
+    // "must not be found while inactive" assertion here would test the
+    // wrong thing (`find_text` has no visibility/offstage awareness; that
+    // half of the contract is `crates/flui-material/tests/tab_bar_view.rs`'s
+    // `default_tab_controller_ancestor_drives_the_active_child_through_offstage`
+    // via the `RenderOffstage` diagnostics flag directly). The genuinely
+    // observable retention proof at this level is that the count reads 3
+    // again after the round trip, not 0 — a reset here is exactly what a
+    // regression to index-keyed (rebuild-from-scratch) tab elements would
+    // produce.
+    tap_tab(&mut demo, tree::OVERVIEW_TAB_LABEL);
+    tap_tab(&mut demo, tree::COUNTER_TAB_LABEL);
+
+    assert!(
+        demo.find_text(&format!("{}3", tree::COUNTER_LABEL_PREFIX))
+            .is_some(),
+        "the count must still read 3 after switching away and back — retention, not a reset"
+    );
+}
+
+/// The About tab (index 2) is never built until it's actually visited —
+/// `TabBarView`'s lazy-build contract, proven end to end through the real
+/// `TabBar`'s tap dispatch (not just `TabBarView` mounted directly, as
+/// `crates/flui-material/tests/tab_bar_view.rs`'s own
+/// `a_tab_is_not_built_until_it_becomes_active` already covers in
+/// isolation).
+#[test]
+fn the_about_tab_is_not_built_until_visited() {
+    let mut demo = MountedDemo::mount();
+    push_tabs_route(&mut demo);
+
+    assert!(
+        demo.find_text(tree::ABOUT_TAB_TEXT).is_none(),
+        "the About tab's content must not be built before it's ever visited"
+    );
+
+    tap_tab(&mut demo, tree::ABOUT_TAB_LABEL);
+
+    assert!(
+        demo.find_text(tree::ABOUT_TAB_TEXT).is_some(),
+        "the About tab's content must be built once it's visited"
+    );
+}
+
+/// With the `TabBar` mounted as `AppBar.bottom`, the app bar's total height
+/// is `toolbar_height (56) + the TabBar's own preferred height (48, three
+/// plain-text tabs: `TAB_HEIGHT` 46 + `indicator_weight` 2)` — the same
+/// `toolbar_height + bottom_height` math `crates/flui-material/tests/app_bar.rs`
+/// pins in isolation, now proven reachable through the full sample-app tree
+/// (real `Theme`/`MediaQuery` ancestors, a real `Navigator`-pushed route).
+#[test]
+fn the_app_bar_height_is_toolbar_plus_the_mounted_tab_bars_height() {
+    let mut demo = MountedDemo::mount();
+    push_tabs_route(&mut demo);
+
+    const EXPECTED_HEIGHT: f32 = 56.0 + 48.0;
+    let matches = demo
+        .find_all_by_render_type("RenderConstrainedBox")
+        .into_iter()
+        .filter(|&id| demo.size(id).height == px(EXPECTED_HEIGHT))
+        .count();
+    assert!(
+        matches > 0,
+        "expected at least one RenderConstrainedBox sized to toolbar_height + TabBar height \
+         ({EXPECTED_HEIGHT}px) once the tabs route is mounted"
     );
 }
 

--- a/tests/material_demo.rs
+++ b/tests/material_demo.rs
@@ -762,7 +762,7 @@ fn dragging_inside_the_list_scrolls_its_items() {
 }
 
 // ============================================================================
-// (8) Tabs route — TabBarView + AppBar.bottom (Tabs PR2's own exit criterion)
+// (8) Tabs route — TabBarView + AppBar.bottom
 // ============================================================================
 
 /// Pushes [`tree::tabs_route`] from the home route's app bar action and


### PR DESCRIPTION
## Summary

Completes Material Tabs, ported against Flutter 3.44.0 `material/{tabs,app_bar}.dart`.

- **`TabBarView`** — TabController-synced lazy keep-alive switcher: `Offstage` + `TickerMode` + `Stack(Expand)` composing the same `_TabSwitchingView` mechanic the cupertino tab scaffold established (occurrence #2 — rule-of-three, composed not extracted); lazy build-on-first-visit (mutation-pinned), retention across switches, TickerMode muting (mutation-pinned), controller resolution `explicit ?? DefaultTabController` (the fallback half driven through a real co-mounted TabBar tap — a review round caught the original test making the ancestor inert with an explicit controller), listener removed in dispose (count seam), length-mismatch `debug_assert` + documented no-panic release fall-through (all-offstage — verified against the oracle's assert-only error). Swiping/PageView deferred named (no page-scroll substrate).
- **`AppBar.bottom`** — the oracle's exact `Column(spaceBetween, [Flexible(ConstrainedBox(max: toolbar)), bottom])` inside the existing SafeArea: `preferred_size` = toolbar + bottom (`_PreferredAppBarSize`), **cap shortfall flexes the toolbar and keeps the bottom fixed** (mutation-pinned — a fixed-fixed Column would clip the TabBar exactly when top padding bites, the critique's PR-2 analysis); Scaffold's cap snapshot verified to need no change.
- **Sample app** — a tabbed route (DefaultTabController + AppBar.bottom(TabBar::secondary) + 3-tab TabBarView): tap-switches, counter retention, lazy About (all acceptance-pinned at the app level), AppBar height 56+48.

### Review trail
Settled PR2 plan → build (4 commits) → review (inert fallback test, false icon-codepoint citation — sample icons follow the classic MaterialIcons font table, not the regenerated icons.dart — and six reintroduced process-ordinal markers) → fix pass with the mandated mutation run.

### Gates
Workspace nextest 7297 passed · workspace clippy `-D warnings` clean · doc gate clean · port-check/inventory/fmt/taplo/typos · doctests · material_demo 13/13 · example builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvkSGveJwxLVuygRAGVKuz