### PR TITLE
fix(app): frame-loop and bootstrap correctness repairs

### DIFF
--- a/crates/flui-app/src/app/binding.rs
+++ b/crates/flui-app/src/app/binding.rs
@@ -354,31 +354,10 @@ impl AppBinding {
             .write()
             .set_on_need_visual_update(move || visual_wake.wake_frame());
 
-        // Animation-wake wiring: scheduling a frame callback (a ticker
-        // tick) fires this hook on the scheduler's false→true
-        // `frame_scheduled` transition (Flutter parity:
-        // `SchedulerBinding.scheduleFrame` → platform `scheduleFrame`).
-        // Without it an AnimationController only advances on frames some
-        // OTHER source produces — after the first idle frame the ticker
-        // starves and the animation freezes.
-        //
-        // Deliberately NOT `wake_handle.into_callback()`: `Scheduler::instance()`
-        // is itself a thread-local singleton, so this hook is a shared resource
-        // between every `AppBinding` constructed on this thread — including a
-        // throwaway `AppBinding::new()` a test builds alongside the real
-        // singleton. A hook closing over ONE construction's `wake_handle` would
-        // get silently overwritten by the next `new()` call, leaving whichever
-        // binding built the hook first (often the real singleton) with a dead
-        // ticker and no diagnostic. Resolving `AppBinding::instance()` fresh on
-        // every fire instead makes reinstallation idempotent — every `new()`
-        // call installs the same semantic hook — and always wakes the ONE
-        // binding `instance()` actually resolves to on this thread, regardless
-        // of how many throwaway bindings were constructed after it. Same
-        // lock-safety argument as the visual-update hook above: `wake_frame`
-        // touches only the `active_window` leaf Mutex, never re-entering here.
-        Scheduler::instance().set_on_frame_scheduled(Some(Arc::new(|| {
-            AppBinding::instance().wake_frame();
-        })));
+        // Animation-wake wiring (the scheduler's `on_frame_scheduled` hook) is
+        // installed in `instance()`'s one-time initializer, NOT here — see
+        // that method's doc for why a per-construction install is wrong both
+        // for steal-proofing and for cross-thread wake correctness.
 
         // Create RendererBinding sharing the SAME PipelineOwner
         let renderer =
@@ -410,7 +389,54 @@ impl AppBinding {
         thread_local! {
             static INSTANCE: &'static AppBinding = {
             tracing::info!("Initializing AppBinding");
-            Box::leak(Box::new(AppBinding::new()))
+            let binding: &'static AppBinding = Box::leak(Box::new(AppBinding::new()));
+
+            // Animation-wake wiring: scheduling a frame callback (a ticker
+            // tick) fires this hook on the scheduler's false→true
+            // `frame_scheduled` transition (Flutter parity:
+            // `SchedulerBinding.scheduleFrame` → platform `scheduleFrame`).
+            // Without it an AnimationController only advances on frames some
+            // OTHER source produces — after the first idle frame the ticker
+            // starves and the animation freezes.
+            //
+            // The SAME hook also fires from the async-driver's task waker
+            // (`AsyncDriver::set_request_frame`, wired in
+            // `Scheduler::with_frame_duration`) whenever a spawned future's
+            // `Waker::wake` runs — and that can happen on a thread that never
+            // called `AppBinding::instance()` at all (an executor thread
+            // completing an image-decode future, for instance). This is
+            // installed HERE — once, in this thread-local singleton's
+            // one-time initializer, capturing THIS canonical binding's
+            // `frame_wake_callback()` (an `Arc`-backed, `Send + Sync` handle)
+            // — rather than in `AppBinding::new()` resolving
+            // `AppBinding::instance()` fresh on every fire, for two reasons:
+            //
+            // 1. Cross-thread correctness (the reason resolving at fire time
+            //    is wrong): `AppBinding::instance()` is itself thread-local.
+            //    A hook that calls it AT FIRE TIME, fired from some OTHER
+            //    thread, would lazily construct a brand-new, windowless
+            //    `AppBinding` for THAT thread and wake it instead of the
+            //    owner — a lost wake / async-task starvation, exactly what
+            //    the visual-update hook above (same reasoning, same fix
+            //    shape) already avoids by capturing an `Arc`-based handle
+            //    instead of re-resolving the thread-local. Capturing
+            //    `frame_wake_callback()` up front sidesteps thread-local
+            //    resolution entirely: firing it only ever touches `Send +
+            //    Sync` `Arc` state, so it wakes the correct binding
+            //    regardless of which thread calls it.
+            // 2. Steal-proofing: `Scheduler::instance()` is itself a
+            //    thread-local singleton, so this hook is a shared resource
+            //    between every `AppBinding` constructed on this thread.
+            //    Installing it from `AppBinding::new()` meant a throwaway
+            //    `AppBinding::new()` a test builds alongside the real
+            //    singleton would silently steal the hook toward its own
+            //    (about-to-be-dropped) wake handle. Installing it only here
+            //    means a throwaway `new()` never touches the shared hook at
+            //    all — this initializer runs exactly once per thread, for
+            //    the canonical singleton only.
+            Scheduler::instance().set_on_frame_scheduled(Some(binding.frame_wake_callback()));
+
+            binding
             };
         }
 
@@ -2013,9 +2039,10 @@ mod tests {
     /// A second `AppBinding::new()` (a throwaway test binding, constructed
     /// alongside the real thread-local singleton) must not steal the
     /// process-global `Scheduler::instance()`'s animation wake hook away
-    /// from the singleton — it used to, because `AppBinding::new()` closed
-    /// the hook over that ONE construction's own `wake_handle`, and every
-    /// later construction on this thread overwrote it.
+    /// from the singleton. `new()` itself never touches the hook at all —
+    /// only `AppBinding::instance()`'s one-time initializer installs it — so
+    /// this also doubles as the "a throwaway `new()` alone does not install"
+    /// check: there is nothing for it to steal.
     ///
     /// Drives the real mechanism end to end: `Scheduler::instance().request_frame()`
     /// firing `on_frame_scheduled` (the same hook a running `AnimationController`
@@ -2023,9 +2050,10 @@ mod tests {
     /// still reaches `AppBinding::instance()` (the real singleton) rather
     /// than the throwaway.
     ///
-    /// Red-check: revert `AppBinding::new()`'s scheduler-hook line back to
-    /// `wake_handle.into_callback()` and this fails — the throwaway
-    /// binding's construction below steals the hook, so the real
+    /// Red-check: move the `set_on_frame_scheduled` install back into
+    /// `AppBinding::new()` using a per-construction `wake_handle.into_callback()`
+    /// (the original bug this test was written for) and this fails — the
+    /// throwaway binding's construction below steals the hook, so the real
     /// singleton's `needs_redraw` never flips.
     #[test]
     fn a_second_binding_does_not_steal_the_real_singletons_scheduler_wake_hook() {
@@ -2056,6 +2084,92 @@ mod tests {
              animation wake hook away from the real singleton — an animation \
              driven through Scheduler::instance() would otherwise freeze with \
              no diagnostic the first time a test built an extra binding",
+        );
+    }
+
+    /// The blocking cross-thread case: `on_frame_scheduled` also fires from
+    /// the async-driver's task waker (`AsyncDriver::set_request_frame`, wired
+    /// in `Scheduler::with_frame_duration`) whenever a spawned future's
+    /// `Waker` wakes — and that can happen on a thread that never called
+    /// `AppBinding::instance()` (an executor thread completing an
+    /// image-decode future, for instance), NOT only on the owner thread a
+    /// ticker would fire from.
+    ///
+    /// A hook that resolved `AppBinding::instance()` AT FIRE TIME would
+    /// construct a brand-new, windowless `AppBinding` on the waking thread
+    /// and wake THAT instead of the owner — a lost wake indistinguishable
+    /// from the ticker-starvation bug this whole hook exists to prevent.
+    /// Capturing `frame_wake_callback()` once, in `instance()`'s
+    /// initializer, avoids ever touching a thread-local at fire time, so the
+    /// real singleton wakes regardless of which thread fires the hook.
+    ///
+    /// Drives the real mechanism: spawn a future on the real singleton's
+    /// `Scheduler`, poll it once (registering a real `TaskWaker`-backed
+    /// `Waker` via `drive_async_tasks`), then wake that `Waker` from a
+    /// spawned OS thread — exactly how a completed async task's waker fires
+    /// in production.
+    ///
+    /// Red-check: change the hook installed in `instance()` back to
+    /// resolving `AppBinding::instance()` inside the closure (fire-time
+    /// resolution) and this fails — the spawned thread constructs its own
+    /// windowless binding and wakes it instead of `real`.
+    #[test]
+    fn scheduler_wake_hook_wakes_the_real_singleton_when_fired_from_another_thread() {
+        let _serialized = SINGLETON_FRAME_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let real = AppBinding::instance();
+        let scheduler = flui_scheduler::Scheduler::instance();
+        if scheduler.is_frame_scheduled() {
+            scheduler.drive_frame(flui_scheduler::Instant::now(), || {});
+        }
+        real.mark_rendered();
+
+        // Register a waker on first poll instead of completing, so it can be
+        // fired later, from another thread, exactly like a pending
+        // image-decode future's `Waker` firing once the decode completes on
+        // an executor thread.
+        let waker_slot: Arc<Mutex<Option<std::task::Waker>>> = Arc::new(Mutex::new(None));
+        let waker_slot_for_future = Arc::clone(&waker_slot);
+        let _token = scheduler.spawn_local(Box::pin(async move {
+            std::future::poll_fn(move |cx| {
+                *waker_slot_for_future.lock() = Some(cx.waker().clone());
+                std::task::Poll::<()>::Pending
+            })
+            .await;
+        }));
+
+        // A full `drive_frame` (not a bare `drive_async_tasks`) both polls the
+        // task above (registering its waker) AND resets `frame_scheduled`
+        // back to `false`: `spawn_local` itself already requested a frame (a
+        // freshly spawned task needs one to be polled in), and
+        // `request_frame_impl`'s coalescing would otherwise treat the
+        // cross-thread wake below as already-scheduled and silently skip
+        // calling the hook — a false pass unrelated to what this test
+        // exists to check.
+        scheduler.drive_frame(flui_scheduler::Instant::now(), || {});
+        real.mark_rendered();
+
+        let waker = waker_slot
+            .lock()
+            .take()
+            .expect("the first poll must have registered a waker");
+
+        // The waking thread never calls `AppBinding::instance()` — mirroring
+        // an executor thread that has no reason to ever touch this crate's
+        // singleton directly.
+        std::thread::spawn(move || {
+            waker.wake_by_ref();
+        })
+        .join()
+        .expect("waker thread must not panic");
+
+        assert!(
+            real.needs_redraw(),
+            "a task waker firing from a non-owner thread must wake the REAL singleton \
+             (via its captured, Send+Sync frame_wake_callback), not lazily construct a \
+             fresh thread-local AppBinding on the waking thread",
         );
     }
 
@@ -2673,8 +2787,7 @@ mod tests {
 
     /// `render_frame_entered`'s retry gate: a frame dropped mid-render (surface
     /// lost) must not be treated as settled. Drives `render_frame_entered`
-    /// directly against a scripted `RasterBackend` — no GPU device required —
-    /// covering the error arm the audit found had zero tests.
+    /// directly against a scripted `RasterBackend` — no GPU device required.
     mod frame_retry_semantics {
         use flui_types::geometry::{Pixels, Rect};
 

--- a/crates/flui-app/src/app/binding.rs
+++ b/crates/flui-app/src/app/binding.rs
@@ -247,9 +247,79 @@ impl TextInputPlatformBridge {
     }
 }
 
+/// A `'static`, `Arc`-cloneable handle onto exactly the state
+/// [`HotReloadBridge::apply`] needs — the shared pipeline owner and the
+/// `needs_redraw` flag — without borrowing `&AppBinding` itself.
+///
+/// [`UiRealm::bind_to_app`](super::ui_realm::UiRealm::bind_to_app) installs
+/// this (via [`AppBinding::hot_reload_bridge`]) so `UiRealm::drain_commands`'s
+/// `UiCommand::HotReload` arm applies against the app the realm was actually
+/// bound to. This is the same stale-binding class
+/// [`TextInputPlatformBridge`] exists to prevent for IME callbacks: hitting
+/// `AppBinding::instance()` directly from that arm would silently reassemble
+/// the process-wide singleton's tree instead of a standalone test instance's
+/// (`UiRealm::for_test`) — wrong under `for_test`, and a trap for a future
+/// multi-realm binding.
+#[derive(Clone)]
+pub(crate) struct HotReloadBridge {
+    pipeline: Arc<RwLock<flui_rendering::pipeline::PipelineOwner>>,
+    needs_redraw: Arc<AtomicBool>,
+}
+
+impl HotReloadBridge {
+    /// Reassembles the element and render trees and requests a redraw.
+    /// Mirrors [`AppBinding::perform_hot_reload_entered`] but through the
+    /// bound app's own handles rather than `&AppBinding`.
+    pub(crate) fn apply(
+        &self,
+        realm: &super::ui_realm::UiRealm,
+        tier: flui_hot_reload::HotReloadTier,
+    ) {
+        use flui_hot_reload::HotReloadTier;
+
+        match tier {
+            HotReloadTier::HotReload => {
+                realm.widgets().perform_reassemble();
+                self.pipeline.write().reassemble();
+                self.needs_redraw.store(true, Ordering::Relaxed);
+                tracing::info!("Hot reload applied — element and render trees reassembled");
+            }
+            HotReloadTier::HotRestart => {
+                tracing::warn!(
+                    "HotRestart requested — root remount not yet implemented; \
+                     falling back to reassemble (state may be stale)"
+                );
+                self.apply(realm, HotReloadTier::HotReload);
+            }
+            HotReloadTier::FullRestart => {
+                tracing::debug!("FullRestart is handled by the CLI process supervisor");
+            }
+        }
+    }
+}
+
+/// Outcome of one build+layout+paint pass, distinguishing "nothing was
+/// dirty" from "the pipeline failed" — both produce no layer tree, but only
+/// the latter must force a retry rather than being treated as a settled,
+/// up-to-date frame (see [`AppBinding::render_frame_entered`]'s retry gate).
+enum FramePaintOutcome {
+    /// A fresh layer tree was painted and turned into a `Scene`.
+    Painted(Arc<Scene>),
+    /// Nothing was dirty this frame; no new content to composite.
+    Idle,
+    /// The build/layout/paint transaction failed (e.g. a render object
+    /// panicked and was caught by `catch_unwind`); the frame was dropped and
+    /// must be retried.
+    Errored,
+}
+
 impl AppBinding {
-    /// Create a new AppBinding.
-    fn new() -> Self {
+    /// Create a new, standalone `AppBinding` — distinct from
+    /// [`AppBinding::instance()`]'s process-singleton. `pub(crate)` (not
+    /// private) specifically so `UiRealm`'s own tests (a sibling module) can
+    /// build one to bind a realm against, the same way this module's tests
+    /// do — see `UiRealm::for_test`.
+    pub(crate) fn new() -> Self {
         // Ensure the global Scheduler singleton is initialized
         let _ = Scheduler::instance();
 
@@ -290,10 +360,25 @@ impl AppBinding {
         // `SchedulerBinding.scheduleFrame` → platform `scheduleFrame`).
         // Without it an AnimationController only advances on frames some
         // OTHER source produces — after the first idle frame the ticker
-        // starves and the animation freezes. Same lock-safety argument as
-        // the visual-update hook above: `wake_frame` touches only the
-        // `active_window` leaf Mutex.
-        Scheduler::instance().set_on_frame_scheduled(Some(wake_handle.into_callback()));
+        // starves and the animation freezes.
+        //
+        // Deliberately NOT `wake_handle.into_callback()`: `Scheduler::instance()`
+        // is itself a thread-local singleton, so this hook is a shared resource
+        // between every `AppBinding` constructed on this thread — including a
+        // throwaway `AppBinding::new()` a test builds alongside the real
+        // singleton. A hook closing over ONE construction's `wake_handle` would
+        // get silently overwritten by the next `new()` call, leaving whichever
+        // binding built the hook first (often the real singleton) with a dead
+        // ticker and no diagnostic. Resolving `AppBinding::instance()` fresh on
+        // every fire instead makes reinstallation idempotent — every `new()`
+        // call installs the same semantic hook — and always wakes the ONE
+        // binding `instance()` actually resolves to on this thread, regardless
+        // of how many throwaway bindings were constructed after it. Same
+        // lock-safety argument as the visual-update hook above: `wake_frame`
+        // touches only the `active_window` leaf Mutex, never re-entering here.
+        Scheduler::instance().set_on_frame_scheduled(Some(Arc::new(|| {
+            AppBinding::instance().wake_frame();
+        })));
 
         // Create RendererBinding sharing the SAME PipelineOwner
         let renderer =
@@ -508,31 +593,16 @@ impl AppBinding {
     /// - [`flui_hot_reload::HotReloadTier::FullRestart`]: no-op here; use `flui run` process restart.
     ///
     /// Apply reload while the realm owner is at an Idle commit point.
+    ///
+    /// Delegates to [`HotReloadBridge::apply`] against THIS app's own
+    /// pipeline/redraw handles — the single implementation both this method
+    /// and `UiRealm::drain_commands`'s hot-reload arm share.
     pub(crate) fn perform_hot_reload_entered(
         &self,
         realm: &super::ui_realm::UiRealm,
         tier: flui_hot_reload::HotReloadTier,
     ) {
-        use flui_hot_reload::HotReloadTier;
-
-        match tier {
-            HotReloadTier::HotReload => {
-                realm.widgets().perform_reassemble();
-                self.render_pipeline_mut().reassemble();
-                self.request_redraw();
-                tracing::info!("Hot reload applied — element and render trees reassembled");
-            }
-            HotReloadTier::HotRestart => {
-                tracing::warn!(
-                    "HotRestart requested — root remount not yet implemented; \
-                     falling back to reassemble (state may be stale)"
-                );
-                self.perform_hot_reload_entered(realm, HotReloadTier::HotReload);
-            }
-            HotReloadTier::FullRestart => {
-                tracing::debug!("FullRestart is handled by the CLI process supervisor");
-            }
-        }
+        self.hot_reload_bridge().apply(realm, tier);
     }
 
     // ========================================================================
@@ -790,6 +860,18 @@ impl AppBinding {
         }
     }
 
+    /// A cloneable capability onto this app's pipeline + redraw flag, for
+    /// [`UiRealm::bind_to_app`](super::ui_realm::UiRealm::bind_to_app) to
+    /// install so hot-reload commands drained later apply against THIS app,
+    /// not whichever `AppBinding::instance()` resolves to at drain time. See
+    /// [`HotReloadBridge`]'s doc for why that distinction matters.
+    pub(crate) fn hot_reload_bridge(&self) -> HotReloadBridge {
+        HotReloadBridge {
+            pipeline: Arc::clone(&self.shared_pipeline_owner),
+            needs_redraw: Arc::clone(&self.needs_redraw),
+        }
+    }
+
     // ========================================================================
     // Haptics
     // ========================================================================
@@ -882,14 +964,17 @@ impl AppBinding {
         realm: &super::ui_realm::UiRealm,
         constraints: BoxConstraints,
     ) -> Option<Arc<Scene>> {
-        realm.enter(|realm| self.draw_frame_entered(realm, constraints))
+        match realm.enter(|realm| self.draw_frame_entered(realm, constraints)) {
+            FramePaintOutcome::Painted(scene) => Some(scene),
+            FramePaintOutcome::Idle | FramePaintOutcome::Errored => None,
+        }
     }
 
     fn draw_frame_entered(
         &self,
         realm: &super::ui_realm::UiRealm,
         constraints: BoxConstraints,
-    ) -> Option<Arc<Scene>> {
+    ) -> FramePaintOutcome {
         // Vsync tick — MUST precede the build phase (Phase 1).
         //
         // Implicit-animation controllers registered via a `VsyncScope` use a
@@ -962,6 +1047,7 @@ impl AppBinding {
         // the frame errored (e.g. a render object panicked and was
         // caught by `catch_unwind`), we log via tracing and drop the
         // frame -- the owner is still usable for the next call.
+        let mut pipeline_errored = false;
         let (layer_tree, link_registry) = {
             {
                 // The window's constraints ARE the root constraints — without
@@ -997,6 +1083,7 @@ impl AppBinding {
                 Ok(layer_tree) => (layer_tree, link_registry),
                 Err(e) => {
                     tracing::error!(error = ?e, "draw_frame: pipeline failed, dropping frame");
+                    pipeline_errored = true;
                     (None, link_registry)
                 }
             }
@@ -1051,10 +1138,15 @@ impl AppBinding {
                 reason = "Scene: Send but !Sync due to CompositionCallback (FnOnce + Send + 'static, no Sync). Sole reader is the binding thread; relaxing the callback bound is tracked under the engine composition redesign."
             )]
             let arc = Arc::new(scene);
-            Some(arc)
+            FramePaintOutcome::Painted(arc)
+        } else if pipeline_errored {
+            // No layer tree because `run_frame_with_layout_builders` errored
+            // above, not because nothing was dirty — the caller must retry
+            // rather than treat this as a settled, up-to-date frame.
+            FramePaintOutcome::Errored
         } else {
-            // No new layer tree
-            None
+            // No new layer tree, and no error: nothing was dirty this frame.
+            FramePaintOutcome::Idle
         }
     }
 
@@ -1093,11 +1185,19 @@ impl AppBinding {
         let dpr = self.shared_pipeline_owner.read().device_pixel_ratio();
         let constraints =
             BoxConstraints::tight(Size::new(px(width as f32 / dpr), px(height as f32 / dpr)));
-        let scene = self.draw_frame_entered(realm, constraints);
+        let outcome = self.draw_frame_entered(realm, constraints);
 
         // 3. Render scene to GPU
         let mut presented = false;
-        if let Some(ref scene) = scene
+        // Forces `wake_frame()` instead of `mark_rendered()` below for any
+        // frame that was dropped rather than settled — a pipeline error, or
+        // a recoverable GPU error below — so `needs_redraw` stays armed AND
+        // an actual wake is scheduled. Without this, a dropped frame on an
+        // otherwise-quiescent event loop (no animation, no further input)
+        // never gets retried: the loop falls back to `ControlFlow::Wait`
+        // and the UI stays stale until the next external event.
+        let mut retry_needed = matches!(outcome, FramePaintOutcome::Errored);
+        if let FramePaintOutcome::Painted(ref scene) = outcome
             && scene.has_content()
         {
             // The pipeline painted a FRESH scene this frame, so the
@@ -1130,7 +1230,8 @@ impl AppBinding {
                 }
                 Err(EngineError::SurfaceLost) => {
                     self.frames_dropped.fetch_add(1, Ordering::Relaxed);
-                    tracing::debug!("Surface lost, will retry next frame");
+                    retry_needed = true;
+                    tracing::debug!("Surface lost; frame dropped — retry armed via wake_frame()");
                 }
                 Err(EngineError::DeviceLost) => {
                     // GPU device lost (TDR / driver crash / GPU switch). Recovery
@@ -1163,8 +1264,14 @@ impl AppBinding {
             }
         }
 
-        // 4. Mark rendered
-        self.mark_rendered();
+        // 4. Mark rendered — unless this frame was dropped rather than
+        // settled, in which case `wake_frame()` re-arms `needs_redraw` AND
+        // schedules an actual platform wake (see `retry_needed` above).
+        if retry_needed {
+            self.wake_frame();
+        } else {
+            self.mark_rendered();
+        }
 
         presented
     }
@@ -1903,6 +2010,55 @@ mod tests {
         );
     }
 
+    /// A second `AppBinding::new()` (a throwaway test binding, constructed
+    /// alongside the real thread-local singleton) must not steal the
+    /// process-global `Scheduler::instance()`'s animation wake hook away
+    /// from the singleton — it used to, because `AppBinding::new()` closed
+    /// the hook over that ONE construction's own `wake_handle`, and every
+    /// later construction on this thread overwrote it.
+    ///
+    /// Drives the real mechanism end to end: `Scheduler::instance().request_frame()`
+    /// firing `on_frame_scheduled` (the same hook a running `AnimationController`
+    /// uses) after a throwaway binding was constructed, asserting the hook
+    /// still reaches `AppBinding::instance()` (the real singleton) rather
+    /// than the throwaway.
+    ///
+    /// Red-check: revert `AppBinding::new()`'s scheduler-hook line back to
+    /// `wake_handle.into_callback()` and this fails — the throwaway
+    /// binding's construction below steals the hook, so the real
+    /// singleton's `needs_redraw` never flips.
+    #[test]
+    fn a_second_binding_does_not_steal_the_real_singletons_scheduler_wake_hook() {
+        let _serialized = SINGLETON_FRAME_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // Ensure the real singleton exists on this thread (installs the hook,
+        // if some earlier test in this process has not already done so) and
+        // start from a known, settled state.
+        let real = AppBinding::instance();
+        let scheduler = flui_scheduler::Scheduler::instance();
+        if scheduler.is_frame_scheduled() {
+            scheduler.drive_frame(flui_scheduler::Instant::now(), || {});
+        }
+        real.mark_rendered();
+
+        // Construct a throwaway binding — pre-fix, this call would silently
+        // rebind the scheduler's wake hook to ITS OWN (windowless, about to
+        // be dropped) wake handle instead of the real singleton's.
+        let _throwaway = AppBinding::new();
+
+        scheduler.request_frame();
+
+        assert!(
+            real.needs_redraw(),
+            "constructing a second AppBinding must not steal the scheduler's \
+             animation wake hook away from the real singleton — an animation \
+             driven through Scheduler::instance() would otherwise freeze with \
+             no diagnostic the first time a test built an extra binding",
+        );
+    }
+
     // ========================================================================
     // layout-builder seam wiring test
     // ========================================================================
@@ -2513,6 +2669,115 @@ mod tests {
         // `needs_redraw` may be set by OTHER paths (the pipeline-owner dirty hook
         // fires when the new binding's PipelineOwner is touched).  We assert only
         // the Vsync-specific gate: has_vsync_running is false.
+    }
+
+    /// `render_frame_entered`'s retry gate: a frame dropped mid-render (surface
+    /// lost) must not be treated as settled. Drives `render_frame_entered`
+    /// directly against a scripted `RasterBackend` — no GPU device required —
+    /// covering the error arm the audit found had zero tests.
+    mod frame_retry_semantics {
+        use flui_types::geometry::{Pixels, Rect};
+
+        use super::*;
+
+        /// A `RasterBackend` whose `render_scene` outcome is fixed at
+        /// construction, so a test can force the exact arm
+        /// `render_frame_entered` must handle without a real GPU device.
+        struct ScriptedRasterBackend {
+            /// Consumed on the first `render_scene` call — a second call
+            /// within one of these single-frame tests would be a bug.
+            outcome: Option<Result<bool, EngineError>>,
+            render_scene_calls: u32,
+        }
+
+        impl ScriptedRasterBackend {
+            fn new(outcome: Result<bool, EngineError>) -> Self {
+                Self {
+                    outcome: Some(outcome),
+                    render_scene_calls: 0,
+                }
+            }
+        }
+
+        impl RasterBackend for ScriptedRasterBackend {
+            fn render_scene(&mut self, _scene: &Scene) -> Result<bool, EngineError> {
+                self.render_scene_calls += 1;
+                self.outcome
+                    .take()
+                    .expect("render_scene called more than once in a single-frame test")
+            }
+            fn resize(&mut self, _width: u32, _height: u32) {}
+            fn is_device_lost(&self) -> bool {
+                false
+            }
+            fn mark_dirty(&mut self, _rect: Rect<Pixels>) {}
+            fn mark_full_repaint(&mut self) {}
+            fn has_damage(&self) -> bool {
+                true
+            }
+            fn size(&self) -> (u32, u32) {
+                (800, 600)
+            }
+            fn reconfigure_surface(&mut self) -> Result<(), EngineError> {
+                Ok(())
+            }
+        }
+
+        /// Mounts a root so the pipeline actually paints a non-empty scene —
+        /// the SurfaceLost/success arms under test only run inside
+        /// `render_frame_entered`'s `scene.has_content()` gate.
+        fn mount_root(app: &AppBinding) -> super::super::super::ui_realm::UiRealm {
+            let realm = test_realm(app);
+            realm
+                .enter(|realm| app.attach_root_widget(realm, &LeafView))
+                .expect("attach succeeds");
+            realm
+        }
+
+        /// Red-check: replace the `retry_needed` branch with an unconditional
+        /// `self.mark_rendered()` (the pre-fix shape) and this fails —
+        /// `needs_redraw` comes back `false` after a dropped `SurfaceLost`
+        /// frame, so nothing would ever re-drive a static UI back to life.
+        #[test]
+        fn surface_lost_keeps_needs_redraw_armed_for_a_retry() {
+            let app = AppBinding::new();
+            let realm = mount_root(&app);
+            let mut backend = ScriptedRasterBackend::new(Err(EngineError::SurfaceLost));
+
+            app.mark_rendered(); // known state before the frame
+            let presented = app.render_frame_entered(&realm, &mut backend);
+
+            assert!(!presented, "a SurfaceLost frame never reaches present()");
+            assert_eq!(
+                backend.render_scene_calls, 1,
+                "precondition: the mounted scene actually reached render_scene"
+            );
+            assert!(
+                app.needs_redraw(),
+                "a dropped SurfaceLost frame must re-arm needs_redraw so the next wake \
+                 actually retries — 'will retry next frame' must be a mechanism, not \
+                 just a comment"
+            );
+        }
+
+        /// Control case: a successful, presented frame must still clear
+        /// `needs_redraw`, exactly as before this fix.
+        #[test]
+        fn a_successful_frame_still_clears_needs_redraw() {
+            let app = AppBinding::new();
+            let realm = mount_root(&app);
+            let mut backend = ScriptedRasterBackend::new(Ok(true));
+
+            app.request_redraw(); // simulate the wake that scheduled this frame
+            let presented = app.render_frame_entered(&realm, &mut backend);
+
+            assert!(presented, "Ok(true) means render_scene reached present()");
+            assert!(
+                !app.needs_redraw(),
+                "a successfully presented frame must clear needs_redraw, same as \
+                 before this fix"
+            );
+        }
     }
 
     /// `AppBinding::attach_text_input`/`detach_text_input` (the `ImeBackend`

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -210,8 +210,17 @@ fn dispatch_platform_realm(
         let mut state = slot.borrow_mut();
         if state.realm_id != Some(dispatcher.realm_id) {
             return Err(if state.realm_id.is_some() {
+                tracing::debug!(
+                    ?dispatcher,
+                    current_realm_id = ?state.realm_id,
+                    "dropping realm callback: a newer realm replaced the one it was dispatched for"
+                );
                 RealmDispatchError::StaleRealm
             } else {
+                tracing::debug!(
+                    ?dispatcher,
+                    "dropping realm callback: no realm installed (not yet ready, or already torn down)"
+                );
                 RealmDispatchError::RealmUnavailable
             });
         }
@@ -567,6 +576,30 @@ fn should_render_frame(dirty: bool, frame_scheduled: bool) -> bool {
     dirty || frame_scheduled
 }
 
+/// Whether another frame will be requested regardless of this one's
+/// outcome: `needs_redraw`, a scheduled ticker, or dirty
+/// pipeline/build work left over from the frame that just ran.
+///
+/// The pending-work leg matters for a frame that errored partway through
+/// (e.g. the pipeline transaction failed) and left dirty nodes behind but
+/// neither raised `needs_redraw` nor scheduled a ticker: without it, such a
+/// frame closes the gate, and — since it also never `present()`s — draws no
+/// `no_present_fallback_pace` throttle either. The loop then falls back to
+/// `ControlFlow::Wait` with real work still queued, sleeping through it
+/// until the next external input.
+#[cfg(all(
+    not(target_os = "android"),
+    not(target_os = "ios"),
+    not(target_arch = "wasm32")
+))]
+fn keeps_frame_gate_open(
+    needs_redraw: bool,
+    frame_scheduled: bool,
+    has_pending_work: bool,
+) -> bool {
+    needs_redraw || frame_scheduled || has_pending_work
+}
+
 /// Coarse fallback pace for a frame that ran the pipeline but never reached
 /// `present()`, applied only while a ticker keeps re-requesting a frame.
 ///
@@ -641,7 +674,10 @@ fn no_present_fallback_pace(presented: bool, keeps_gate_open: bool) -> Option<st
 mod desktop_pacing_tests {
     use std::time::{Duration, Instant};
 
-    use super::{NO_PRESENT_FALLBACK_PACE, no_present_fallback_pace, should_render_frame};
+    use super::{
+        NO_PRESENT_FALLBACK_PACE, keeps_frame_gate_open, no_present_fallback_pace,
+        should_render_frame,
+    };
 
     #[test]
     fn idle_wake_with_no_dirty_work_and_no_scheduled_frame_renders_nothing() {
@@ -659,6 +695,42 @@ mod desktop_pacing_tests {
             "a scheduled ticker alone renders (keeps animations alive with no other dirty state)"
         );
         assert!(should_render_frame(true, true));
+    }
+
+    #[test]
+    fn pending_work_alone_keeps_the_gate_open() {
+        assert!(
+            keeps_frame_gate_open(false, false, true),
+            "an errored frame that left dirty pipeline/build nodes behind must keep the \
+             loop awake even with no `needs_redraw` and no scheduled ticker"
+        );
+    }
+
+    #[test]
+    fn needs_redraw_or_scheduled_ticker_alone_keeps_the_gate_open() {
+        assert!(keeps_frame_gate_open(true, false, false));
+        assert!(keeps_frame_gate_open(false, true, false));
+    }
+
+    #[test]
+    fn no_signal_at_all_closes_the_gate() {
+        assert!(
+            !keeps_frame_gate_open(false, false, false),
+            "with no redraw request, no scheduled ticker, and no pending work, the gate \
+             must close so the loop can go idle"
+        );
+    }
+
+    #[test]
+    fn pending_work_drives_the_no_present_fallback_pace_like_any_other_open_gate() {
+        // A frame that never presents (surface lost / no damage) but left dirty
+        // pipeline work behind must still get the busy-spin-bounding fallback pace —
+        // exactly as if `needs_redraw` or a ticker had kept the gate open.
+        let keeps_gate_open = keeps_frame_gate_open(false, false, true);
+        assert_eq!(
+            no_present_fallback_pace(false, keeps_gate_open),
+            Some(NO_PRESENT_FALLBACK_PACE)
+        );
     }
 
     #[test]
@@ -761,7 +833,21 @@ where
     let has_worker_driver = worker_driver.is_some();
     let worker_driver = Arc::new(Mutex::new(worker_driver));
 
-    let platform = flui_platform::current_platform().expect("Failed to initialize platform");
+    // Platform init is an environment failure (missing display server, unsupported
+    // OS, driver problem), not a `BUG:` invariant — no `bootstrap_error_slot` exists
+    // yet to route this through (that cell, and the `platform` it needs for
+    // `quit()`, only exist once `on_ready` is running), so this is the one desktop
+    // failure this function still surfaces via `panic!` directly rather than the
+    // deferred-teardown path below. It still gets a full error log and the same
+    // "desktop bootstrap failed" wording as that deferred path, instead of a bare
+    // `.expect()`'s terse, context-free message.
+    let platform = match flui_platform::current_platform() {
+        Ok(platform) => platform,
+        Err(error) => {
+            tracing::error!(%error, "Failed to initialize platform");
+            panic!("desktop bootstrap failed: platform initialization error: {error:?}");
+        }
+    };
 
     // `rebuild_registration`'s `Drop` detaches the hot-reload hook and must
     // stay alive until the event loop exits — but it (like the window and
@@ -802,11 +888,23 @@ where
     {
         tracing::info!("Platform ready");
 
-        // 1. Open window now that the event loop is running.
+        // 1. Open window now that the event loop is running. Window creation is
+        // an environment failure (display server hiccup, resource exhaustion),
+        // not a `BUG:` invariant, and — unlike platform init above — this DOES
+        // run inside `on_ready` with a live `platform` and `bootstrap_error_slot`
+        // available, so it gets the same deferred-panic-after-teardown handling
+        // as the GPU/realm/attach failures below instead of an immediate bare
+        // `.expect()` panic mid-`on_ready`.
         let options: WindowOptions = (&config).into();
-        let window = platform
-            .open_window(options)
-            .expect("Failed to create window");
+        let window = match platform.open_window(options) {
+            Ok(window) => window,
+            Err(error) => {
+                tracing::error!(%error, "Window creation failed");
+                *bootstrap_error_slot.borrow_mut() = Some(error.context("Window creation failed"));
+                platform.quit();
+                return;
+            }
+        };
 
         // 2. Create GPU renderer directly (no DesktopEmbedder)
         let phys_size = window.physical_size();
@@ -1025,7 +1123,11 @@ where
         // happens when a ticker/animation keeps re-requesting a frame every
         // wake with nothing pacing it — `no_present_fallback_pace` fires
         // only in exactly that combination.
-            let keeps_gate_open = binding.needs_redraw() || scheduler.is_frame_scheduled();
+            let keeps_gate_open = keeps_frame_gate_open(
+                binding.needs_redraw(),
+                scheduler.is_frame_scheduled(),
+                binding.has_pending_work(realm),
+            );
             if let Some(pace) = no_present_fallback_pace(presented, keeps_gate_open) {
                 std::thread::sleep(pace);
             }
@@ -1079,17 +1181,29 @@ where
             let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::Active(active));
         }));
 
+        // 9. Store window in AppBinding for runtime access — BEFORE
+        // dispatching `Lifecycle::Started` or requesting the initial
+        // redraw. Both of those can synchronously run the first frame
+        // through `dispatch_platform_realm`; if `active_window` were still
+        // `None` at that point, anything resolving it during that frame
+        // (an autofocus `EditableText` attaching its IME client, for
+        // instance) would silently no-op instead of attaching.
+        AppBinding::instance().set_window(window);
+
         // Mark lifecycle as started
         let _ = dispatch_platform_realm(
             realm_dispatch,
             RealmEvent::Lifecycle(LifecycleEvent::Started),
         );
 
-        // 9. Request initial redraw
-        window.request_redraw();
-
-        // 10. Store window in AppBinding for runtime access
-        AppBinding::instance().set_window(window);
+        // 10. Request initial redraw, now that the window is stored.
+        // `wake_frame` (not `with_window(|w| w.request_redraw())`): it clones
+        // the window out from under `active_window`'s lock before calling
+        // through, so a backend whose `request_redraw` re-enters `AppBinding`
+        // synchronously (headless, in this crate's own tests) cannot
+        // deadlock on that same lock — the same clone-then-call discipline
+        // `TextInputPlatformBridge`/`perform_haptic_feedback` follow.
+        AppBinding::instance().wake_frame();
 
         tracing::info!("Desktop platform initialized with callbacks");
     }
@@ -1393,17 +1507,29 @@ where
         let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::Active(active));
     }));
 
+    // 9. Store window in AppBinding for runtime access — BEFORE
+    // dispatching `Lifecycle::Started` or requesting the initial redraw.
+    // Both of those can synchronously run the first frame through
+    // `dispatch_platform_realm`; if `active_window` were still `None` at
+    // that point, anything resolving it during that frame (an autofocus
+    // `EditableText` attaching its IME client, for instance) would
+    // silently no-op instead of attaching.
+    AppBinding::instance().set_window(window);
+
     // Mark lifecycle as started
     let _ = dispatch_platform_realm(
         realm_dispatch,
         RealmEvent::Lifecycle(LifecycleEvent::Started),
     );
 
-    // 9. Request initial redraw
-    window.request_redraw();
-
-    // 10. Store window in AppBinding for runtime access
-    AppBinding::instance().set_window(window);
+    // 10. Request initial redraw, now that the window is stored.
+    // `wake_frame` (not `with_window(|w| w.request_redraw())`): it clones
+    // the window out from under `active_window`'s lock before calling
+    // through, so a backend whose `request_redraw` re-enters `AppBinding`
+    // synchronously (headless, in this crate's own tests) cannot deadlock
+    // on that same lock — the same clone-then-call discipline
+    // `TextInputPlatformBridge`/`perform_haptic_feedback` follow.
+    AppBinding::instance().wake_frame();
 
     tracing::info!("Android platform initialized with callbacks (hot-reload enabled)");
 
@@ -1612,13 +1738,17 @@ where
         let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::Active(active));
     }));
 
+    // 7. Store window — BEFORE dispatching `Lifecycle::Started`, which can
+    // synchronously run the first frame through `dispatch_platform_realm`;
+    // anything resolving `active_window` during that frame (an autofocus
+    // `EditableText` attaching its IME client, for instance) must not see
+    // `None`.
+    AppBinding::instance().set_shared_window(window);
+
     let _ = dispatch_platform_realm(
         realm_dispatch,
         RealmEvent::Lifecycle(LifecycleEvent::Started),
     );
-
-    // 7. Store window
-    AppBinding::instance().set_shared_window(window);
 
     tracing::info!("Web platform initialized with callbacks");
 
@@ -1694,5 +1824,99 @@ mod tests {
 
         assert_eq!(config.title, "Test");
         assert_eq!(config.size.width, px(800.0));
+    }
+
+    /// Serializes tests that read/write `AppBinding::instance()`'s active
+    /// window (the repo rule for tests mutating shared binding state —
+    /// AGENTS.md "Testing quirks"). nextest gives each test its own process;
+    /// `cargo test` (also a stated gate for this crate) runs them on threads
+    /// in one process, where two tests each setting the singleton's window
+    /// could interleave.
+    static SINGLETON_WINDOW_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Bootstrap ordering invariant shared by `bootstrap_desktop`, `run_android`,
+    /// and `run_web`: the window must be stored in `AppBinding` before anything
+    /// that could synchronously observe `active_window` (the initial redraw
+    /// request, `Lifecycle::Started`) runs — otherwise the first such observer
+    /// (an autofocus `EditableText` attaching its IME client, for instance)
+    /// silently sees `None`.
+    ///
+    /// `bootstrap_desktop`/`run_android`/`run_web` themselves cannot run in a
+    /// unit test: each opens its window from inside a live platform event loop
+    /// (`ActiveEventLoop` is unreachable outside `Platform::run`) and creates a
+    /// real GPU `Renderer`, gated behind the separate `enable-wgpu-tests` CI job
+    /// (WARP), not this one. This instead drives the exact ordering invariant
+    /// headlessly: `HeadlessWindow::request_redraw` (flui-platform's headless
+    /// backend, used elsewhere in this crate's tests) dispatches its
+    /// `on_request_frame` callback SYNCHRONOUSLY — unlike a real winit window,
+    /// where a queued `RedrawRequested` would not fire until `on_ready` (and
+    /// this reordering) has already returned. That is exactly why the ordering
+    /// bug was invisible in a real window's actual first frame but is directly
+    /// observable here.
+    ///
+    /// Checks a unique window *size* rather than mere `is_some()`, so this
+    /// cannot pass merely because an earlier test left SOME window installed
+    /// on the singleton — only THIS test's window, with THIS test's
+    /// unmistakable marker size, proves `set_window` ran before the callback.
+    ///
+    /// Red-check: swap the order of the two `AppBinding::instance()` calls
+    /// below (request the redraw, then store the window — the pre-fix shape)
+    /// and this fails: `wake_frame` finds no active window yet, never calls
+    /// `request_redraw` on it, and the callback never fires at all.
+    #[test]
+    fn desktop_bootstrap_stores_the_window_before_the_first_synchronous_redraw_observes_it() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let _serialized = SINGLETON_WINDOW_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let marker_size = flui_types::Size::new(px(4001.0), px(4002.0));
+
+        let platform = flui_platform::headless_platform();
+        let window = platform
+            .open_window(flui_platform::traits::WindowOptions {
+                size: marker_size,
+                ..Default::default()
+            })
+            .expect("headless platform always opens a window");
+
+        // `on_request_frame` requires `Send` on the callback; `AppBinding` is
+        // not `Send` (owner-thread-affine gesture arena state — ADR-0027), so
+        // the closure below cannot capture a specific `&AppBinding`/`Arc`.
+        // Resolving `AppBinding::instance()` fresh inside the closure (zero
+        // captures for the binding itself) sidesteps that entirely — the same
+        // pattern the production scheduler wake hook (`AppBinding::new`) uses
+        // to avoid capturing one specific instance.
+        //
+        // Reads through `with_window`, NOT `wake_frame`/`request_redraw`: a
+        // headless window's `request_redraw` dispatches this very callback
+        // synchronously, so calling anything that re-locks `active_window`
+        // from in here (the two are on the same thread, same call stack)
+        // would deadlock on `AppBinding`'s own non-reentrant lock.
+        let saw_marker_window = Arc::new(AtomicBool::new(false));
+        let saw_marker_window_cb = Arc::clone(&saw_marker_window);
+        window.on_request_frame(Box::new(move || {
+            let matches_marker = AppBinding::instance()
+                .with_window(|w| w.bounds().size == marker_size)
+                .unwrap_or(false);
+            saw_marker_window_cb.store(matches_marker, Ordering::SeqCst);
+        }));
+
+        // Mirrors the FIXED order in `bootstrap_desktop`/`run_android`:
+        // store the window BEFORE requesting the initial redraw. `wake_frame`
+        // (not `with_window(|w| w.request_redraw())`) clones the window out
+        // from under the lock before calling through, so this call cannot
+        // deadlock against the callback's own `with_window` re-entry above —
+        // see `wake_frame`'s doc and `bootstrap_desktop`'s matching comment.
+        AppBinding::instance().set_window(window);
+        AppBinding::instance().wake_frame();
+
+        assert!(
+            saw_marker_window.load(Ordering::SeqCst),
+            "set_window must have taken effect before the initial redraw fires \
+             the frame callback that could read active_window",
+        );
     }
 }

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -580,13 +580,19 @@ fn should_render_frame(dirty: bool, frame_scheduled: bool) -> bool {
 /// outcome: `needs_redraw`, a scheduled ticker, or dirty
 /// pipeline/build work left over from the frame that just ran.
 ///
-/// The pending-work leg matters for a frame that errored partway through
-/// (e.g. the pipeline transaction failed) and left dirty nodes behind but
-/// neither raised `needs_redraw` nor scheduled a ticker: without it, such a
-/// frame closes the gate, and — since it also never `present()`s — draws no
-/// `no_present_fallback_pace` throttle either. The loop then falls back to
-/// `ControlFlow::Wait` with real work still queued, sleeping through it
-/// until the next external input.
+/// This only feeds [`no_present_fallback_pace`]'s THROTTLE decision below —
+/// it cannot itself wake anything. A `ControlFlow::Wait` loop only wakes on
+/// an actual `wake_frame()`/platform `request_redraw()` call or external
+/// input; a dropped/errored frame's retry wake comes from
+/// `render_frame_entered`'s `retry_needed` path, not from this function.
+///
+/// The pending-work leg matters when a frame that left dirty pipeline/build
+/// nodes behind is ALSO being re-invoked by some other wake source without
+/// ever reaching `present()`: without this leg, such a frame would read
+/// `keeps_gate_open == false`, skip the fallback sleep, and the loop could
+/// spin at full CPU speed re-processing the same leftover work on every
+/// rapid re-wake instead of being bounded like any other no-present,
+/// gate-open frame.
 #[cfg(all(
     not(target_os = "android"),
     not(target_os = "ios"),
@@ -701,8 +707,9 @@ mod desktop_pacing_tests {
     fn pending_work_alone_keeps_the_gate_open() {
         assert!(
             keeps_frame_gate_open(false, false, true),
-            "an errored frame that left dirty pipeline/build nodes behind must keep the \
-             loop awake even with no `needs_redraw` and no scheduled ticker"
+            "a frame that left dirty pipeline/build nodes behind must keep the fallback-pace \
+             gate open (so the busy-spin throttle still applies on a rapid re-wake) even with \
+             no `needs_redraw` and no scheduled ticker"
         );
     }
 

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -20,6 +20,7 @@
 //! generational [`RealmId`], so results stamped for a dead runtime are
 //! droppable by identity, not by convention.
 
+use std::cell::RefCell;
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
 use std::sync::Arc;
@@ -404,6 +405,15 @@ pub(crate) struct UiRealm {
     /// with the runtime and every outstanding sender turns `OwnerGone`.
     sender_prototype: UiCommandSender,
     redraw_pending: Arc<AtomicBool>,
+    /// The [`AppBinding`](super::binding::AppBinding) this realm is bound to,
+    /// installed by [`Self::bind_to_app`]. `drain_commands`'s
+    /// `UiCommand::HotReload` arm applies against THIS, never
+    /// `AppBinding::instance()` directly — the latter would silently
+    /// reassemble the wrong (process-singleton) tree for a realm bound to a
+    /// standalone test instance (`UiRealm::for_test`). `RefCell` because
+    /// `bind_to_app` takes `&self`; construction happens before binding, so
+    /// this starts `None`.
+    hot_reload_bridge: RefCell<Option<super::binding::HotReloadBridge>>,
     /// Whether this instance owns the transitional process-wide claim.
     claimed: bool,
     /// `*const ()` is `!Send + !Sync`; `PhantomData` of it makes the runtime
@@ -495,6 +505,7 @@ impl UiRealm {
                 wake,
             },
             redraw_pending,
+            hot_reload_bridge: RefCell::new(None),
             claimed,
             _owner_affine: PhantomData,
         })
@@ -541,6 +552,12 @@ impl UiRealm {
     /// Connect the realm-owned widget tree to the transitional app host's
     /// render pipeline and scheduler services.
     pub(crate) fn bind_to_app(&self, app: &super::binding::AppBinding) {
+        // Same reasoning as `text_input_platform_bridge` below: install the
+        // bridge tied to THIS `app`, so a later `drain_commands` hot-reload
+        // arm applies against it instead of resolving `AppBinding::instance()`
+        // fresh (and, for `UiRealm::for_test`, wrong).
+        *self.hot_reload_bridge.borrow_mut() = Some(app.hot_reload_bridge());
+
         self.widgets.set_pipeline_owner(app.render_pipeline_arc());
         self.widgets.with_build_owner_mut(|owner| {
             owner.set_async_driver(Scheduler::instance().async_driver().clone());
@@ -602,8 +619,16 @@ impl UiRealm {
             };
             match command {
                 UiCommand::HotReload(tier) => {
-                    super::binding::AppBinding::instance().perform_hot_reload_entered(self, tier);
-                    report.invoked += 1;
+                    if let Some(bridge) = self.hot_reload_bridge.borrow().as_ref() {
+                        bridge.apply(self, tier);
+                        report.invoked += 1;
+                    } else {
+                        tracing::error!(
+                            "hot-reload command dropped: realm was never bound to an \
+                             AppBinding (drain_commands ran before bind_to_app)"
+                        );
+                        report.dropped_stale += 1;
+                    }
                 }
                 UiCommand::Navigation(command) => match command.apply_on_owner() {
                     Ok(_) => {
@@ -974,5 +999,79 @@ mod tests {
 
     fn test_route(name: &'static str) -> SimpleRoute<i32> {
         SimpleRoute::new(move |_ctx| SizedBox::new(1.0, 1.0).into_view().boxed()).named(name)
+    }
+
+    /// Serializes tests that read/write `AppBinding::instance()` (the
+    /// process-singleton), per the repo rule for tests mutating shared
+    /// binding state (AGENTS.md "Testing quirks"). nextest gives each test
+    /// its own process; `cargo test` runs them on threads in one process,
+    /// where two tests each asserting on the singleton's `needs_redraw` flag
+    /// could interleave.
+    static SINGLETON_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// `drain_commands`'s `UiCommand::HotReload` arm must apply against the
+    /// app THIS realm was bound to via `bind_to_app`, never
+    /// `AppBinding::instance()` directly — the exact stale-binding class
+    /// `TextInputPlatformBridge` exists to prevent for IME callbacks. A
+    /// realm built with `UiRealm::for_test` (a standalone, non-singleton
+    /// `AppBinding`) is precisely the case where hard-coding the singleton
+    /// silently reassembles the WRONG (unrelated, windowless) app's tree.
+    ///
+    /// Red-check: revert `drain_commands`'s hot-reload arm to
+    /// `super::binding::AppBinding::instance().perform_hot_reload_entered(self, tier)`
+    /// and this fails — `bound_app.needs_redraw()` stays false while the
+    /// unrelated singleton's flips instead.
+    #[test]
+    fn hot_reload_command_applies_to_the_bound_app_not_the_instance_singleton() {
+        let _serialized = SINGLETON_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // Deliberately NOT `AppBinding::instance()`.
+        let bound_app = super::super::binding::AppBinding::new();
+        let realm = UiRealm::for_test(&bound_app);
+
+        let singleton = super::super::binding::AppBinding::instance();
+        bound_app.mark_rendered();
+        singleton.mark_rendered();
+
+        realm
+            .command_sender()
+            .request_hot_reload(flui_hot_reload::HotReloadTier::HotReload)
+            .expect("inbox has room");
+
+        let report = realm.drain_commands();
+
+        assert_eq!(
+            report.invoked, 1,
+            "the hot-reload command must be applied, not dropped as stale"
+        );
+        assert!(
+            bound_app.needs_redraw(),
+            "hot reload must apply against the app the realm was bound to via bind_to_app"
+        );
+        assert!(
+            !singleton.needs_redraw(),
+            "hot reload must NOT reach for AppBinding::instance() when the realm was \
+             bound to a different, standalone app"
+        );
+    }
+
+    /// A realm that never called `bind_to_app` (so `hot_reload_bridge` is
+    /// still `None`) must drop a hot-reload command rather than panic or
+    /// silently resolve some other binding.
+    #[test]
+    fn hot_reload_command_on_an_unbound_realm_is_dropped_not_panicked() {
+        let _claim = REALM_TEST_LOCK.lock();
+        let runtime = UiRealm::new(noop_wake()).expect("runtime");
+
+        runtime
+            .command_sender()
+            .request_hot_reload(flui_hot_reload::HotReloadTier::HotReload)
+            .expect("inbox has room");
+
+        let report = runtime.drain_commands();
+        assert_eq!(report.invoked, 0);
+        assert_eq!(report.dropped_stale, 1);
     }
 }

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -619,7 +619,15 @@ impl UiRealm {
             };
             match command {
                 UiCommand::HotReload(tier) => {
-                    if let Some(bridge) = self.hot_reload_bridge.borrow().as_ref() {
+                    // Cloned out of the `RefCell` (`HotReloadBridge` is cheap
+                    // `Arc`-clone `Clone`) BEFORE calling through — the same
+                    // take-out-of-the-slot discipline this method's own inbox
+                    // drain follows. `bridge.apply` runs arbitrary reassemble
+                    // code; holding the `Ref` guard across that call would
+                    // panic on any reentrant `bind_to_app` (the only
+                    // `borrow_mut` on this field) the reassemble triggers.
+                    let bridge = self.hot_reload_bridge.borrow().clone();
+                    if let Some(bridge) = bridge {
                         bridge.apply(self, tier);
                         report.invoked += 1;
                     } else {


### PR DESCRIPTION
Repair unit from the flui-app full-crate audit: seven correctness fixes in the frame loop and bootstrap paths, each with a red-checked regression test.

## What

- **Dropped-frame retry wake** — `draw_frame_entered` now distinguishes `Painted`/`Idle`/`Errored`; a dropped frame (`SurfaceLost`, pipeline error) re-arms `needs_redraw` AND requests a real platform wake via `wake_frame()` instead of unconditionally `mark_rendered()`-ing — previously "will retry next frame" was a comment, not a mechanism, and a static UI stayed stale until the next external input. `Idle` still marks rendered (no wake loop on a quiescent UI).
- **Cross-thread-safe scheduler wake hook** — the `on_frame_scheduled` install moved out of `AppBinding::new()` into `instance()`'s one-time initializer, capturing the canonical binding's `Send + Sync` wake callback at install time. Fixes two bugs in one shape: any second `new()` (test bindings) stole the hook toward a windowless binding, and a fire-time `instance()` resolve would construct a worker-local binding on cross-thread wakes (the async-driver `TaskWaker` fires from executor threads). Proven by a test firing a real task waker from a spawned OS thread.
- **`set_window` before the first redraw** on all three platforms — the first frame could run with an empty `active_window` (an autofocus `EditableText` attach in that frame silently got `None`). The initial redraw goes through `wake_frame()` (clone-then-call): requesting redraw inside `with_window` deadlocks reentrantly, caught live by the new headless test.
- **`keeps_frame_gate_open`** folds `has_pending_work` into the no-present fallback throttle gate (an errored frame leaving dirty nodes now throttles instead of spinning; the doc states the throttle-only mechanism honestly).
- **Bootstrap error routing** — `open_window` failure routes through the same `bootstrap_error` path as GPU/realm/attach failures instead of panicking inside `on_ready`; `current_platform()` failure logs before its (unavoidable, pre-event-loop) panic.
- **`HotReloadBridge`** — `drain_commands`' hot-reload arm applies against the binding the realm was bound to, not `AppBinding::instance()` (the stale-binding class the text-input bridge exists to prevent); single implementation shared with `perform_hot_reload_entered`; the bridge is cloned out of its `RefCell` before running reassemble code (reentrancy-safe).
- **Silent dispatch drops** — `StaleRealm`/`RealmUnavailable` now logged at debug.

## Evidence

- `cargo nextest run --workspace --exclude flui-platform`: 7445 passed; `flui-platform --lib`: 57 passed; clippy `-D warnings`, fmt/port-check/inventory/taplo/typos/doc gates: clean.
- 9 new tests; every load-bearing fix mutation-verified (retry branch, wrong-binding bridge, hook steal, hook cross-thread fire, window ordering) — reviewer independently re-ran four mutants across two rounds.
- Full review + delta re-review: SHIP.

## Out of scope (audit units still queued)

android/web command-inbox drain, semantics listener lock discipline, dead-surface sweep, Platform-handle storage / first-frame-deferral consolidation / lifecycle observers (design passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)