### PR TITLE
fix(app): drain android/web owner inboxes and fix semantics-listener deadlock

### DIFF
--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -259,6 +259,27 @@ fn dispatch_platform_realm(
     Ok(())
 }
 
+/// Drains the per-frame owner-inbox commands and reports whether the drain
+/// itself asked for a redraw.
+///
+/// Every platform's frame callback must call this exactly once per wake, at
+/// the Idle frame boundary — before the dirty gate, and before any
+/// early-return fast path a platform's frame callback takes (e.g. Android's
+/// hot-reload plugin scene) — never inside the frame transaction below.
+/// Running it unconditionally on every wake is what keeps
+/// `UiCommandSender`'s bounded inbox draining: a wake that skips the drain
+/// lets the inbox fill until it hard-errors, and a coalesced redraw request
+/// that nothing consumes never wakes the loop again (`take_redraw_request`
+/// only flips back to `false` once observed here).
+#[cfg(not(target_os = "ios"))]
+fn drain_owner_inbox(realm: &super::ui_realm::UiRealm) -> bool {
+    let report = realm.drain_commands();
+    if report != super::ui_realm::DrainReport::default() {
+        tracing::trace!(?report, "owner inbox drained");
+    }
+    realm.take_redraw_request()
+}
+
 #[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
 fn teardown_platform_realm() {
     let (realm, queued) = PLATFORM_REALM_HOST.with(|slot| {
@@ -1059,13 +1080,7 @@ where
         // borrow: a command that re-enters this frame callback through a
         // nested platform pump then finds an empty slot and skips the
         // drain, instead of panicking the borrow.
-            let inbox_redraw = {
-                let report = realm.drain_commands();
-                if report != super::ui_realm::DrainReport::default() {
-                    tracing::trace!(?report, "owner inbox drained");
-                }
-                realm.take_redraw_request()
-            };
+            let inbox_redraw = drain_owner_inbox(realm);
 
             let dirty =
                 inbox_redraw || binding.needs_redraw() || binding.has_pending_work(realm);
@@ -1421,6 +1436,15 @@ where
         let _ = dispatch_platform_realm(
             realm_dispatch,
             RealmEvent::Frame(Box::new(move |realm| {
+                // Owner-inbox drain: commands and worker results commit HERE,
+                // at the frame boundary while the scheduler phase is Idle —
+                // never inside the frame transaction below. Runs before
+                // everything else in this callback, including the hot-reload
+                // plugin scene fast path below, so a command-driven redraw
+                // request is observed by the very frame its wake produced
+                // regardless of which rendering path this frame takes.
+                let inbox_redraw = drain_owner_inbox(realm);
+
                 let mut r = renderer_frame.lock();
                 let (w, h) = r.size();
                 let mut hr = hot_reload_frame.lock();
@@ -1442,7 +1466,8 @@ where
 
                 let binding = AppBinding::instance();
                 let has_pending = binding.has_pending_work(realm);
-                if !binding.needs_redraw()
+                if !inbox_redraw
+                    && !binding.needs_redraw()
                     && !has_pending
                     && !Scheduler::instance().is_frame_scheduled()
                 {
@@ -1661,9 +1686,17 @@ where
         let _ = dispatch_platform_realm(
             realm_dispatch,
             RealmEvent::Frame(Box::new(move |realm| {
+                // Owner-inbox drain: commands and worker results commit HERE,
+                // at the frame boundary while the scheduler phase is Idle —
+                // never inside the frame transaction below. Runs before the
+                // dirty gate so a command-driven redraw request is observed
+                // by the very frame its wake produced.
+                let inbox_redraw = drain_owner_inbox(realm);
+
                 let binding = AppBinding::instance();
                 let has_pending = binding.has_pending_work(realm);
-                if !binding.needs_redraw()
+                if !inbox_redraw
+                    && !binding.needs_redraw()
                     && !has_pending
                     && !Scheduler::instance().is_frame_scheduled()
                 {

--- a/crates/flui-app/src/bindings/renderer_binding.rs
+++ b/crates/flui-app/src/bindings/renderer_binding.rs
@@ -238,9 +238,15 @@ impl RenderingFlutterBinding {
     pub fn set_semantics_enabled(&self, enabled: bool) {
         let was_enabled = self.semantics_enabled.swap(enabled, Ordering::Relaxed);
         if was_enabled != enabled {
-            // Notify listeners
-            let listeners = self.semantics_listeners.read();
-            for listener in listeners.iter() {
+            // Snapshot the listeners into an owned `Vec` and drop the read
+            // guard before invoking any of them — a listener that calls
+            // `add_semantics_enabled_listener`/`remove_semantics_enabled_listener`
+            // from inside its own callback would otherwise try to acquire the
+            // write lock while this thread still held the read guard and
+            // deadlock (same read-then-write reentrancy `PaintingBinding`'s
+            // `notify_listeners` guards against).
+            let listeners = self.semantics_listeners.read().clone();
+            for listener in &listeners {
                 listener(enabled);
             }
 
@@ -483,12 +489,16 @@ impl RendererBinding for RenderingFlutterBinding {
 mod tests {
     use super::*;
 
-    /// `RenderingFlutterBinding::instance()` is a process-wide singleton, so the
-    /// tests that toggle its `semantics_enabled` flag share one `AtomicBool`.
-    /// They serialize through this lock (held for each test's duration) so they
-    /// cannot interleave their writes and observe each other's state — the
-    /// listener test in particular asserts exact callback counts that a
-    /// concurrent toggle would corrupt.
+    /// `RenderingFlutterBinding::instance()` is a process-wide singleton, so any
+    /// test that mutates its shared state — the `semantics_enabled` flag, the
+    /// first-frame deferral counter, or (through `allow_first_frame`) the
+    /// global `Scheduler::instance()` — shares that state with every other
+    /// test in this module under `cargo test`'s one-process, multi-threaded
+    /// run (nextest's per-test process makes this belt and braces there, per
+    /// AGENTS.md "Testing quirks"). They serialize through this lock (held for
+    /// each test's duration) so they cannot interleave their writes and
+    /// observe each other's state — the listener tests in particular assert
+    /// exact callback counts that a concurrent toggle would corrupt.
     static SEMANTICS_TEST_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
 
     #[test]
@@ -526,6 +536,7 @@ mod tests {
 
     #[test]
     fn test_send_frames_to_engine() {
+        let _guard = SEMANTICS_TEST_LOCK.lock();
         let binding = RenderingFlutterBinding::instance();
         binding.reset_first_frame_sent();
 
@@ -695,5 +706,89 @@ mod tests {
 
         // Leave the shared singleton disabled for the next test.
         binding.set_semantics_enabled(false);
+    }
+
+    /// A listener that registers another listener from inside its own
+    /// callback must not deadlock `set_semantics_enabled`.
+    ///
+    /// The notification loop used to run listener callbacks while still
+    /// holding `semantics_listeners.read()`; a callback that then called
+    /// `add_semantics_enabled_listener` (which takes the write lock) would
+    /// block forever on `parking_lot`'s non-reentrant read-then-write on the
+    /// same thread. The fix snapshots the listeners into an owned `Vec` and
+    /// drops the read guard before invoking any of them.
+    ///
+    /// The whole scenario (attach, both toggles, detach) runs on one
+    /// dedicated background thread rather than the test thread, for two
+    /// reasons: `RenderingFlutterBinding::instance()` is owner-thread-local
+    /// (ADR-0027) — a fresh OS thread's first `instance()` call leaks its own
+    /// binding, so splitting the steps across threads would silently operate
+    /// on two unrelated bindings — and the deadlock under test is itself a
+    /// same-thread read-then-write lock reacquisition, which only reproduces
+    /// when every step runs on that one thread. The test thread only bounds
+    /// how long it waits for that thread's result over a channel: a bare
+    /// `.join()` would hang forever (and, under `cargo test`'s shared-process
+    /// threads, wedge the rest of the suite) if the deadlock regressed;
+    /// `recv_timeout` turns that hang into an explicit `expect` panic
+    /// instead.
+    #[test]
+    fn semantics_listener_that_registers_another_listener_does_not_deadlock() {
+        use std::sync::{atomic::AtomicUsize, mpsc};
+        use std::time::Duration;
+
+        let _guard = SEMANTICS_TEST_LOCK.lock();
+
+        let (result_tx, result_rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let binding = RenderingFlutterBinding::instance();
+            binding.set_semantics_enabled(false);
+
+            let late_calls = Arc::new(AtomicUsize::new(0));
+            let late_calls_for_listener = Arc::clone(&late_calls);
+            let late_listener: Arc<dyn Fn(bool) + Send + Sync> = Arc::new(move |_enabled| {
+                late_calls_for_listener.fetch_add(1, Ordering::Relaxed);
+            });
+
+            // Callbacks must be `Send + Sync` (the listener trait bound), but
+            // `RenderingFlutterBinding` itself is not — it owns a `Rc`-based
+            // `MouseTracker` — so the reentrant call goes back through the
+            // `'static` singleton accessor rather than capturing `binding`.
+            let late_listener_for_reentrant = late_listener.clone();
+            let reentrant_listener: Arc<dyn Fn(bool) + Send + Sync> = Arc::new(move |_enabled| {
+                RenderingFlutterBinding::instance()
+                    .add_semantics_enabled_listener(late_listener_for_reentrant.clone());
+            });
+            binding.add_semantics_enabled_listener(reentrant_listener.clone());
+
+            // First toggle: `reentrant_listener` fires and registers
+            // `late_listener`, but must not itself run in this same pass.
+            binding.set_semantics_enabled(true);
+            let after_first = late_calls.load(Ordering::Relaxed);
+
+            // Second toggle: now observes `late_listener`, registered above.
+            binding.set_semantics_enabled(false);
+            let after_second = late_calls.load(Ordering::Relaxed);
+
+            binding.remove_semantics_enabled_listener(&late_listener);
+            binding.remove_semantics_enabled_listener(&reentrant_listener);
+
+            let _ = result_tx.send((after_first, after_second));
+        });
+
+        let (after_first, after_second) = result_rx.recv_timeout(Duration::from_secs(5)).expect(
+            "set_semantics_enabled deadlocked: a listener that registers another \
+             listener from inside its own callback must not block on the \
+             notification loop's own read guard",
+        );
+
+        assert_eq!(
+            after_first, 0,
+            "a listener registered mid-notification must not run in the same \
+             pass that registered it",
+        );
+        assert_eq!(
+            after_second, 1,
+            "a later toggle must observe the listener registered mid-notification",
+        );
     }
 }


### PR DESCRIPTION
Two mechanical repairs from the flui-app audit.

## Command-inbox drain on android/web

The android and web frame callbacks never called `drain_commands()`/`take_redraw_request()` — on those targets `UiCommandSender` navigation/hot-reload/invoke commands were never delivered (the inbox fills to 256 then hard-errors), and `request_redraw` woke exactly once ever, since the pending flag never reset. The drain block is now a single shared helper (`drain_owner_inbox`) called from all three platform frame callbacks — desktop's behavior is unchanged (the helper is its former inline block verbatim), and any future frame-boundary step lands in one place instead of drifting per-platform. The android drain sits before the hot-reload plugin fast path so plugin-owned frames can't recreate the inbox-fill bug.

Evidence: wasm32 check green; android compile-check blocked on missing NDK (structural identity with the wasm-verified block is the stated evidence — no claims beyond that).

## Semantics-listener deadlock

`set_semantics_enabled` notified listeners and called the platform while holding the `semantics_listeners` read guard — a listener registering another listener from inside its callback deadlocked (parking_lot same-thread read→write). Now the listener list is cloned out and the guard dropped before any callback or platform call. Regression test is bounded (5s timeout panic, no suite wedge), takes `SEMANTICS_TEST_LOCK`, and pins snapshot semantics (a mid-notification registrant fires on the next toggle, not the current pass). `test_send_frames_to_engine` now also takes the lock it was missing.

## Evidence

- `cargo nextest run --workspace --exclude flui-platform`: 7446 passed, 4 skipped; clippy `-D warnings`, port-check, doc gates: clean.
- Deadlock mutant executed by builder and independently re-run by the reviewer (bounded 5s red). Review: SHIP, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)