### PR TITLE
fix(app): consolidate first-frame deferral into one production-reachable gate

### DIFF
--- a/crates/flui-app/src/app/binding.rs
+++ b/crates/flui-app/src/app/binding.rs
@@ -1349,11 +1349,19 @@ impl AppBinding {
         // other, drifting counters that neither implemented this gate nor
         // were reachable from here were deleted in the same change.
         let send_to_engine = self.send_frames_to_engine();
-        if send_to_engine {
+        let errored = matches!(outcome, FramePaintOutcome::Errored);
+        if send_to_engine && !errored {
             // Mirrors the oracle's `_firstFrameSent = true`: latched once
-            // the gate is found open, independent of whether this
-            // particular frame painted anything (an `Idle` frame still
-            // means "no deferral is blocking presentation").
+            // the gate is found open AND the frame actually completed —
+            // independent of whether it painted anything (an `Idle` frame
+            // still means "no deferral is blocking presentation"), but
+            // NEVER on a phase that raised. The oracle's `_firstFrameSent`
+            // is likewise only set after `compositeFrame()` runs, which a
+            // thrown exception earlier in `drawFrame` would prevent.
+            // Latching on `Errored` would let a pipeline crash on the very
+            // first frame permanently defeat any LATER
+            // `defer_first_frame`/`allow_first_frame` pair, since
+            // `send_frames_to_engine` short-circuits true once sent.
             self.renderer.read().mark_first_frame_sent();
         }
 
@@ -1372,9 +1380,11 @@ impl AppBinding {
         // below falls through to `mark_rendered()` and the withheld scene
         // is simply dropped without a present — no retry spam. Presenting
         // it once the deferral lifts is `allow_first_frame`'s job (it
-        // schedules a warm-up frame via the `Scheduler`, which the runner's
-        // wake gate already observes), not a concern of this retry flag.
-        let mut retry_needed = matches!(outcome, FramePaintOutcome::Errored);
+        // re-marks the root dirty through a captured, cross-thread-safe
+        // `RepaintHandle` so the warm-up frame has content to paint, and
+        // the same mark fires the visual-update notifier the runner's wake
+        // gate already observes), not a concern of this retry flag.
+        let mut retry_needed = errored;
         if send_to_engine
             && let FramePaintOutcome::Painted(ref scene) = outcome
             && scene.has_content()
@@ -3111,19 +3121,51 @@ mod tests {
             realm
         }
 
-        /// `draw_frame_entered`'s pipeline pass consumes the current dirty
-        /// work whether or not the produced frame is later presented — a
-        /// deferred frame in these tests still ran build/layout/paint and
-        /// cleared the pipeline's dirty flags. Re-mark the root dirty so the
-        /// next `render_frame_entered` call has fresh content, mirroring
-        /// `RenderingFlutterBinding`'s own
-        /// `draw_frame_returns_layer_tree_and_defers_when_gated` test.
-        fn mark_root_dirty(app: &AppBinding) {
-            let root_id = app
-                .render_pipeline()
-                .root_id()
-                .expect("mount_root attached a root");
-            app.render_pipeline_mut().mark_needs_layout(root_id);
+        /// Root `RenderBox` whose layout panics — the exact catch_unwind
+        /// path any third-party panic in production widget code
+        /// (`panic!`/`unwrap()`/an assertion inside `RenderBox::
+        /// perform_layout`) reaches. Mirrors `flui-rendering`'s own
+        /// `PanickingLayoutBox` pipeline-level fixture, but lives here
+        /// (rather than being imported) since it exercises the trait
+        /// surface public to downstream crates, not `flui-rendering`
+        /// internals. `perform_layout` is `RenderBox`'s only method
+        /// without a default body; every other method (paint, hit-test,
+        /// intrinsics, ...) falls back to a harmless no-op default.
+        #[derive(Debug)]
+        struct PanicOnLayoutBox;
+
+        impl flui_foundation::Diagnosticable for PanicOnLayoutBox {}
+
+        impl flui_rendering::traits::RenderBox for PanicOnLayoutBox {
+            type Arity = flui_rendering::prelude::Leaf;
+            type ParentData = flui_rendering::prelude::BoxParentData;
+
+            fn perform_layout(
+                &mut self,
+                _ctx: &mut flui_rendering::context::BoxLayoutContext<
+                    '_,
+                    Self::Arity,
+                    Self::ParentData,
+                >,
+            ) -> Size {
+                panic!("PanicOnLayoutBox::perform_layout -- intentional test panic");
+            }
+        }
+
+        /// Mounts `PanicOnLayoutBox` directly as the pipeline root,
+        /// bypassing `attach_root_widget`/`View` entirely — same pattern
+        /// `dirty_mark_fires_wake_via_notifier` (above) uses to touch the
+        /// pipeline without the widget layer.
+        fn mount_panicking_root(app: &AppBinding) -> super::super::super::ui_realm::UiRealm {
+            let realm = test_realm(app);
+            let mut owner = app.shared_pipeline_owner.write();
+            let root_id = owner.insert(Box::new(PanicOnLayoutBox)
+                as Box<
+                    dyn flui_rendering::traits::RenderObject<flui_rendering::protocol::BoxProtocol>,
+                >);
+            owner.set_root_id(Some(root_id));
+            drop(owner);
+            realm
         }
 
         /// Red-check: remove the `send_to_engine` consult in
@@ -3156,8 +3198,17 @@ mod tests {
             );
         }
 
+        /// Red-check: comment out `allow_first_frame`'s `RepaintHandle`
+        /// re-mark (the wake+redirty block) and this fails — `presented`
+        /// comes back `false` because the woken frame finds a clean
+        /// pipeline (the deferred pass already consumed the dirty work)
+        /// and produces `FramePaintOutcome::Idle`. NO manual re-dirty
+        /// happens in this test: that is the whole point — a caller of
+        /// the public `defer_first_frame`/`allow_first_frame` API has no
+        /// pipeline handle to reach for, so the fix must live inside
+        /// `allow_first_frame` itself.
         #[test]
-        fn allow_first_frame_lets_the_next_dirty_frame_present() {
+        fn allow_first_frame_alone_presents_the_previously_withheld_content() {
             let app = AppBinding::new();
             let realm = mount_root(&app);
             let mut backend = CountingRasterBackend::new();
@@ -3171,13 +3222,13 @@ mod tests {
             assert_eq!(backend.render_scene_calls, 0);
 
             app.allow_first_frame();
-            mark_root_dirty(&app);
 
             let presented = app.render_frame_entered(&realm, &mut backend);
 
             assert!(
                 presented,
-                "once allowed, a dirty frame must reach present()"
+                "allow_first_frame alone (no external re-dirty) must make the \
+                 withheld content reach present() on the next pumped frame"
             );
             assert_eq!(backend.render_scene_calls, 1);
             assert_eq!(app.frames_rendered(), 1);
@@ -3201,7 +3252,6 @@ mod tests {
             assert_eq!(backend.render_scene_calls, 0);
 
             app.allow_first_frame(); // count = 1 -- still deferred
-            mark_root_dirty(&app);
             assert!(
                 !app.render_frame_entered(&realm, &mut backend),
                 "one matching allow of two nested defers must not yet open the gate"
@@ -3209,7 +3259,6 @@ mod tests {
             assert_eq!(backend.render_scene_calls, 0);
 
             app.allow_first_frame(); // count = 0 -- gate opens
-            mark_root_dirty(&app);
             assert!(
                 app.render_frame_entered(&realm, &mut backend),
                 "the last matching allow must open the gate"
@@ -3225,6 +3274,71 @@ mod tests {
         fn allow_first_frame_without_matching_defer_panics() {
             let app = AppBinding::new();
             app.allow_first_frame();
+        }
+
+        /// Oracle: `_firstFrameSent` latches only after a successful
+        /// `compositeFrame()` — never on a phase that raised. Latching on
+        /// `Errored` would let a pipeline crash on the very first frame
+        /// permanently defeat any LATER `defer_first_frame`/
+        /// `allow_first_frame` pair, since `send_frames_to_engine`
+        /// short-circuits `true` once sent.
+        ///
+        /// Red-check: drop the `!errored` guard around `mark_first_frame_sent`
+        /// in `render_frame_entered` and this fails — the errored frame
+        /// latches, and the later `defer_first_frame` cannot close the gate.
+        #[test]
+        fn errored_first_frame_does_not_latch_first_frame_sent() {
+            let app = AppBinding::new();
+            let realm = mount_panicking_root(&app);
+            let mut backend = CountingRasterBackend::new();
+
+            // Silence the default panic hook for the duration of the
+            // intentional panic -- same discipline as flui-rendering's own
+            // catch_unwind tests (`PipelineOwner::test_run_frame_catches_paint_panic`).
+            let prev_hook = std::panic::take_hook();
+            std::panic::set_hook(Box::new(|_| {}));
+            let presented = app.render_frame_entered(&realm, &mut backend);
+            std::panic::set_hook(prev_hook);
+
+            assert!(!presented, "an errored frame must never present");
+            assert_eq!(backend.render_scene_calls, 0);
+
+            // Precondition: the gate was open (no deferral was ever
+            // registered) before the errored frame ran.
+            assert!(app.send_frames_to_engine());
+
+            app.defer_first_frame();
+            assert!(
+                !app.send_frames_to_engine(),
+                "an errored first frame must not latch first_frame_sent -- a \
+                 later defer_first_frame must still be able to close the gate"
+            );
+        }
+
+        /// Oracle: `sendFramesToEngine => _firstFrameSent || \
+        /// _firstFrameDeferredCount == 0` — once the first frame has been
+        /// sent, a LATER `defer_first_frame` has no effect on the gate
+        /// (matching `defer_first_frame`'s own doc: "Calling this has no
+        /// effect after the first frame has been sent").
+        #[test]
+        fn first_frame_sent_latch_short_circuits_later_defers() {
+            let app = AppBinding::new();
+            let realm = mount_root(&app);
+            let mut backend = CountingRasterBackend::new();
+
+            let presented = app.render_frame_entered(&realm, &mut backend);
+            assert!(
+                presented,
+                "precondition: the first frame presents with no active deferral"
+            );
+            assert!(app.send_frames_to_engine());
+
+            app.defer_first_frame();
+            assert!(
+                app.send_frames_to_engine(),
+                "a defer registered AFTER the first frame was sent must not \
+                 re-close the gate"
+            );
         }
     }
 

--- a/crates/flui-app/src/app/binding.rs
+++ b/crates/flui-app/src/app/binding.rs
@@ -41,6 +41,7 @@ use flui_interaction::{
 };
 use flui_layer::Scene;
 use flui_platform::traits::{Clipboard, PlatformInput, PlatformWindow};
+use flui_rendering::binding::RendererBinding;
 use flui_rendering::constraints::BoxConstraints;
 use flui_scheduler::Scheduler;
 use flui_types::{
@@ -60,7 +61,7 @@ use crate::{
 ///
 /// AppBinding coordinates the specialized process services that remain during
 /// the ADR-0027 migration:
-/// - [`RendererBinding`](crate::bindings::RendererBinding) - Manages render tree and pipeline
+/// - [`RendererBinding`] - Manages render tree and pipeline
 /// - [`GestureBinding`] - Manages hit testing, pointer coalescing, and gestures
 /// - [`Scheduler`] - Manages frame scheduling
 ///
@@ -1050,6 +1051,52 @@ impl AppBinding {
         self.frames_dropped.load(Ordering::Relaxed)
     }
 
+    // ========================================================================
+    // First Frame Deferral
+    //
+    // Forwards to `RenderingFlutterBinding`'s counter (`self.renderer`,
+    // `crates/flui-app/src/bindings/renderer_binding.rs`) — the single
+    // canonical implementation (oracle tag `3.44.0`; see that module's doc
+    // for the full Flutter `RendererBinding.deferFirstFrame`/
+    // `allowFirstFrame`/`sendFramesToEngine` citation and the two drifting
+    // copies that were deleted alongside this consolidation). `self.renderer`
+    // is a plain field unique to this `AppBinding` — not the
+    // `RenderingFlutterBinding::instance()` process singleton — so these
+    // three methods need no cross-test lock discipline of their own; each
+    // `AppBinding` has its own independent counter.
+    //
+    // `Self::render_frame_entered` below is the ONLY production frame path
+    // that consults `send_frames_to_engine`; that is the fix this
+    // consolidation exists to make (previously the production path
+    // consulted none of the three counters that used to exist).
+    // ========================================================================
+
+    /// Defer sending the first frame to the engine until a matching
+    /// [`allow_first_frame`](Self::allow_first_frame).
+    ///
+    /// See [`RenderingFlutterBinding::defer_first_frame`] for the full
+    /// semantics (nested defer/allow, no-op after the first frame is sent).
+    pub fn defer_first_frame(&self) {
+        self.renderer.read().defer_first_frame();
+    }
+
+    /// Release one deferral registered by
+    /// [`defer_first_frame`](Self::defer_first_frame).
+    ///
+    /// # Panics
+    ///
+    /// Panics if called without a matching prior `defer_first_frame` —
+    /// see [`RenderingFlutterBinding::allow_first_frame`].
+    pub fn allow_first_frame(&self) {
+        self.renderer.read().allow_first_frame();
+    }
+
+    /// Whether the next produced frame may reach the engine (be presented),
+    /// or is still withheld by an open deferral.
+    pub fn send_frames_to_engine(&self) -> bool {
+        self.renderer.read().send_frames_to_engine()
+    }
+
     /// Draw a frame and return Scene for GPU rendering.
     ///
     /// This executes the complete rendering pipeline:
@@ -1291,7 +1338,25 @@ impl AppBinding {
             BoxConstraints::tight(Size::new(px(width as f32 / dpr), px(height as f32 / dpr)));
         let outcome = self.draw_frame_entered(realm, constraints);
 
-        // 3. Render scene to GPU
+        // 3. Render scene to GPU — gated by the first-frame deferral
+        // counter (oracle `RendererBinding.drawFrame`, tag `3.44.0`; full
+        // citation in `crates/flui-app/src/bindings/renderer_binding.rs`
+        // above `defer_first_frame`). Build/layout/paint above (step 2)
+        // ran unconditionally — Flutter pumps frames during deferral too,
+        // paying warm-up costs early — only the composite-to-engine step
+        // here is withheld while the first frame is deferred. This is the
+        // ONLY place the production frame path consults the counter; two
+        // other, drifting counters that neither implemented this gate nor
+        // were reachable from here were deleted in the same change.
+        let send_to_engine = self.send_frames_to_engine();
+        if send_to_engine {
+            // Mirrors the oracle's `_firstFrameSent = true`: latched once
+            // the gate is found open, independent of whether this
+            // particular frame painted anything (an `Idle` frame still
+            // means "no deferral is blocking presentation").
+            self.renderer.read().mark_first_frame_sent();
+        }
+
         let mut presented = false;
         // Forces `wake_frame()` instead of `mark_rendered()` below for any
         // frame that was dropped rather than settled — a pipeline error, or
@@ -1300,8 +1365,18 @@ impl AppBinding {
         // otherwise-quiescent event loop (no animation, no further input)
         // never gets retried: the loop falls back to `ControlFlow::Wait`
         // and the UI stays stale until the next external event.
+        //
+        // A DEFERRED frame is deliberately excluded from this retry path:
+        // deferred is not errored. The pipeline settled normally (it ran
+        // to completion; only presentation was withheld), so the frame
+        // below falls through to `mark_rendered()` and the withheld scene
+        // is simply dropped without a present — no retry spam. Presenting
+        // it once the deferral lifts is `allow_first_frame`'s job (it
+        // schedules a warm-up frame via the `Scheduler`, which the runner's
+        // wake gate already observes), not a concern of this retry flag.
         let mut retry_needed = matches!(outcome, FramePaintOutcome::Errored);
-        if let FramePaintOutcome::Painted(ref scene) = outcome
+        if send_to_engine
+            && let FramePaintOutcome::Painted(ref scene) = outcome
             && scene.has_content()
         {
             // The pipeline painted a FRESH scene this frame, so the
@@ -1414,7 +1489,6 @@ impl AppBinding {
                         // `flui_interaction::routing::HitTestResult`, so the
                         // same instance crosses both layers without conversion
                         // (no per-hit bridge that could silently drop targets).
-                        use flui_rendering::binding::RendererBinding;
                         let renderer = self.renderer.read();
                         let mut result = flui_interaction::routing::HitTestResult::new();
                         let offset = flui_types::Offset::new(position.dx, position.dy);
@@ -2968,6 +3042,189 @@ mod tests {
                 "a successfully presented frame must clear needs_redraw, same as \
                  before this fix"
             );
+        }
+    }
+
+    /// `AppBinding::defer_first_frame`/`allow_first_frame`/
+    /// `send_frames_to_engine` — the ONE deferral gate the production frame
+    /// path (`render_frame_entered`) actually consults (oracle
+    /// `RendererBinding`, tag `3.44.0`; full citation in
+    /// `crates/flui-app/src/bindings/renderer_binding.rs` above
+    /// `defer_first_frame`). Before this consolidation, `render_frame_entered`
+    /// consulted none of the three counters that used to exist — deferring
+    /// the first frame did nothing observable from here. Drives
+    /// `render_frame_entered` directly against a counting `RasterBackend`,
+    /// mirroring `frame_retry_semantics` above.
+    mod first_frame_deferral {
+        use flui_types::geometry::{Pixels, Rect};
+
+        use super::*;
+
+        /// A `RasterBackend` that always presents successfully and counts
+        /// how many times `render_scene` was actually called. Unlike
+        /// `frame_retry_semantics::ScriptedRasterBackend` (a single scripted
+        /// outcome consumed once), this backend is driven across several
+        /// `render_frame_entered` calls in one test — what matters here is
+        /// whether the gate lets the call through AT ALL, not any particular
+        /// GPU outcome.
+        struct CountingRasterBackend {
+            render_scene_calls: u32,
+        }
+
+        impl CountingRasterBackend {
+            fn new() -> Self {
+                Self {
+                    render_scene_calls: 0,
+                }
+            }
+        }
+
+        impl RasterBackend for CountingRasterBackend {
+            fn render_scene(&mut self, _scene: &Scene) -> Result<bool, EngineError> {
+                self.render_scene_calls += 1;
+                Ok(true)
+            }
+            fn resize(&mut self, _width: u32, _height: u32) {}
+            fn is_device_lost(&self) -> bool {
+                false
+            }
+            fn mark_dirty(&mut self, _rect: Rect<Pixels>) {}
+            fn mark_full_repaint(&mut self) {}
+            fn has_damage(&self) -> bool {
+                true
+            }
+            fn size(&self) -> (u32, u32) {
+                (800, 600)
+            }
+            fn reconfigure_surface(&mut self) -> Result<(), EngineError> {
+                Ok(())
+            }
+        }
+
+        /// Mounts a root so the pipeline actually paints a non-empty scene —
+        /// same shape as `frame_retry_semantics::mount_root`.
+        fn mount_root(app: &AppBinding) -> super::super::super::ui_realm::UiRealm {
+            let realm = test_realm(app);
+            realm
+                .enter(|realm| app.attach_root_widget(realm, &LeafView))
+                .expect("attach succeeds");
+            realm
+        }
+
+        /// `draw_frame_entered`'s pipeline pass consumes the current dirty
+        /// work whether or not the produced frame is later presented — a
+        /// deferred frame in these tests still ran build/layout/paint and
+        /// cleared the pipeline's dirty flags. Re-mark the root dirty so the
+        /// next `render_frame_entered` call has fresh content, mirroring
+        /// `RenderingFlutterBinding`'s own
+        /// `draw_frame_returns_layer_tree_and_defers_when_gated` test.
+        fn mark_root_dirty(app: &AppBinding) {
+            let root_id = app
+                .render_pipeline()
+                .root_id()
+                .expect("mount_root attached a root");
+            app.render_pipeline_mut().mark_needs_layout(root_id);
+        }
+
+        /// Red-check: remove the `send_to_engine` consult in
+        /// `render_frame_entered` (fall through to the unconditional present
+        /// branch as before this fix) and this fails — `render_scene` gets
+        /// called despite the deferral.
+        #[test]
+        fn deferred_first_frame_runs_the_pipeline_but_withholds_the_scene() {
+            let app = AppBinding::new();
+            let realm = mount_root(&app);
+            let mut backend = CountingRasterBackend::new();
+
+            app.defer_first_frame();
+            app.mark_rendered(); // known baseline before the frame
+
+            let presented = app.render_frame_entered(&realm, &mut backend);
+
+            assert!(!presented, "a deferred first frame must never present");
+            assert_eq!(
+                backend.render_scene_calls, 0,
+                "the scene must never reach render_scene while deferred — build/ \
+                 layout/paint above still ran (Flutter pumps frames during \
+                 deferral too), only the composite-to-engine step is gated"
+            );
+            assert_eq!(app.frames_rendered(), 0);
+            assert!(
+                !app.needs_redraw(),
+                "deferred is not errored: the frame settled normally (mark_rendered), \
+                 so it must not spam a retry wake the way a dropped/errored frame does"
+            );
+        }
+
+        #[test]
+        fn allow_first_frame_lets_the_next_dirty_frame_present() {
+            let app = AppBinding::new();
+            let realm = mount_root(&app);
+            let mut backend = CountingRasterBackend::new();
+
+            app.defer_first_frame();
+            let withheld = app.render_frame_entered(&realm, &mut backend);
+            assert!(
+                !withheld,
+                "precondition: the first frame is withheld while deferred"
+            );
+            assert_eq!(backend.render_scene_calls, 0);
+
+            app.allow_first_frame();
+            mark_root_dirty(&app);
+
+            let presented = app.render_frame_entered(&realm, &mut backend);
+
+            assert!(
+                presented,
+                "once allowed, a dirty frame must reach present()"
+            );
+            assert_eq!(backend.render_scene_calls, 1);
+            assert_eq!(app.frames_rendered(), 1);
+        }
+
+        /// Red-check: replace `first_frame_deferred_count.fetch_sub`'s
+        /// underflow-checked decrement with an unconditional "count == 0
+        /// means open" read that ignores nesting depth, and this fails —
+        /// the frame after the FIRST `allow_first_frame()` would present
+        /// even though a second `defer_first_frame()` is still outstanding.
+        #[test]
+        fn nested_defer_allow_only_presents_after_the_last_allow() {
+            let app = AppBinding::new();
+            let realm = mount_root(&app);
+            let mut backend = CountingRasterBackend::new();
+
+            app.defer_first_frame();
+            app.defer_first_frame(); // deferred count = 2
+
+            assert!(!app.render_frame_entered(&realm, &mut backend));
+            assert_eq!(backend.render_scene_calls, 0);
+
+            app.allow_first_frame(); // count = 1 -- still deferred
+            mark_root_dirty(&app);
+            assert!(
+                !app.render_frame_entered(&realm, &mut backend),
+                "one matching allow of two nested defers must not yet open the gate"
+            );
+            assert_eq!(backend.render_scene_calls, 0);
+
+            app.allow_first_frame(); // count = 0 -- gate opens
+            mark_root_dirty(&app);
+            assert!(
+                app.render_frame_entered(&realm, &mut backend),
+                "the last matching allow must open the gate"
+            );
+            assert_eq!(backend.render_scene_calls, 1);
+        }
+
+        /// Caller-contract violation: an `allow_first_frame` with no
+        /// matching prior `defer_first_frame` mirrors the oracle's
+        /// `assert(_firstFrameDeferredCount > 0)`.
+        #[test]
+        #[should_panic(expected = "allow_first_frame called without matching defer_first_frame")]
+        fn allow_first_frame_without_matching_defer_panics() {
+            let app = AppBinding::new();
+            app.allow_first_frame();
         }
     }
 

--- a/crates/flui-app/src/bindings/renderer_binding.rs
+++ b/crates/flui-app/src/bindings/renderer_binding.rs
@@ -186,6 +186,65 @@ impl RenderingFlutterBinding {
 
     // ========================================================================
     // First Frame Deferral
+    //
+    // This is the ONE canonical implementation of the first-frame deferral
+    // gate. It used to be duplicated: `WidgetsBinding` (flui-view) carried
+    // its own independent counter that neither matched this one's semantics
+    // (no `first_frame_sent` latch, no panic on an unmatched `allow`) nor
+    // was reachable from the production frame path; `RendererBinding`
+    // (flui-rendering) declared a default `send_frames_to_engine() -> true`
+    // plus a default `draw_frame()` gate that no real embedder overrode.
+    // Both were deleted — see AGENTS.md's port-methodology note against
+    // reintroducing a second copy of this state. Every consumer (the
+    // `RendererBinding` trait impl below and `AppBinding::defer_first_frame`
+    // / `allow_first_frame` / `send_frames_to_engine` in
+    // `crates/flui-app/src/app/binding.rs`, which the production
+    // `render_frame_entered` path actually calls) forwards to this struct.
+    //
+    // # Flutter Equivalence (oracle tag `3.44.0`)
+    //
+    // `packages/flutter/lib/src/rendering/binding.dart`,
+    // `RendererBinding`:
+    // ```dart
+    // int _firstFrameDeferredCount = 0;
+    // bool _firstFrameSent = false;
+    // bool get sendFramesToEngine =>
+    //     _firstFrameSent || _firstFrameDeferredCount == 0;
+    // void deferFirstFrame() {
+    //   assert(_firstFrameDeferredCount >= 0);
+    //   _firstFrameDeferredCount += 1;
+    // }
+    // void allowFirstFrame() {
+    //   assert(_firstFrameDeferredCount > 0);
+    //   _firstFrameDeferredCount -= 1;
+    //   if (!_firstFrameSent) {
+    //     scheduleWarmUpFrame();
+    //   }
+    // }
+    // ```
+    // and `drawFrame`'s gate:
+    // ```dart
+    // rootPipelineOwner.flushLayout();
+    // rootPipelineOwner.flushCompositingBits();
+    // rootPipelineOwner.flushPaint();
+    // if (sendFramesToEngine) {
+    //   for (final RenderView renderView in renderViews) {
+    //     renderView.compositeFrame();
+    //   }
+    //   rootPipelineOwner.flushSemantics();
+    //   _firstFrameSent = true;
+    // }
+    // ```
+    // Layout/compositing-bits/paint always run; only the composite-to-engine
+    // step (and Flutter's semantics flush alongside it) is gated. FLUI's
+    // production mirror of this split lives in `AppBinding::
+    // render_frame_entered` (`crates/flui-app/src/app/binding.rs`): the
+    // build/layout/paint pipeline always runs in `draw_frame_entered`, and
+    // only the GPU `render_scene` (present) call is gated on
+    // `send_frames_to_engine`. FLUI's `run_frame` does not yet gate its own
+    // semantics phase behind this flag the way the oracle's `flushSemantics`
+    // does — a documented, narrower scope than the oracle's for this unit,
+    // not a silent gap.
     // ========================================================================
 
     /// Tell the framework to not send the first frames to the engine until
@@ -216,7 +275,8 @@ impl RenderingFlutterBinding {
     ///
     /// Panics if called without a matching prior
     /// [`defer_first_frame`](Self::defer_first_frame) call (i.e. the deferred
-    /// count is already zero).
+    /// count is already zero) — a caller-contract violation, mirroring the
+    /// oracle's `assert(_firstFrameDeferredCount > 0)`.
     pub fn allow_first_frame(&self) {
         let prev = self
             .first_frame_deferred_count
@@ -241,6 +301,65 @@ impl RenderingFlutterBinding {
     /// frames have been sent to the engine yet.
     pub fn reset_first_frame_sent(&self) {
         self.first_frame_sent.store(false, Ordering::Relaxed);
+    }
+
+    /// Latch that the first frame has been sent to the engine.
+    ///
+    /// Mirrors the oracle's `_firstFrameSent = true`, set unconditionally
+    /// once `send_frames_to_engine()` is found `true` during a frame —
+    /// regardless of whether that particular frame painted anything.
+    /// Idempotent: once latched, [`Self::send_frames_to_engine`] stays
+    /// `true` forever (barring [`Self::reset_first_frame_sent`], a test-only
+    /// escape hatch), so calling this again is a harmless no-op.
+    pub fn mark_first_frame_sent(&self) {
+        self.first_frame_sent.store(true, Ordering::Relaxed);
+    }
+
+    /// Pump the rendering pipeline once and return the produced layer tree,
+    /// gated by the first-frame deferral counter.
+    ///
+    /// Consumes the root [`PipelineOwner`] out of its lock, drives it
+    /// through [`PipelineOwner::run_frame`] (layout, compositing bits,
+    /// paint, semantics), and restores it — the owner is always left
+    /// usable for the next frame, error or not. The layer tree this
+    /// produces is withheld (`None`) while [`Self::send_frames_to_engine`]
+    /// is `false`; the pipeline work itself (the warm-up cost) still runs
+    /// either way, matching the oracle's `drawFrame` split (see the module
+    /// note above `defer_first_frame`).
+    ///
+    /// This is a convenience for using `RenderingFlutterBinding` directly,
+    /// without `WidgetsBinding` (see the module doc). `AppBinding`'s
+    /// production frame path (`render_frame_entered`) does **not** call
+    /// this method — it drives the shared pipeline through
+    /// `WidgetsBinding::run_frame_with_layout_builders` instead (the
+    /// build-during-layout fixpoint this method does not need to settle)
+    /// and consults [`Self::send_frames_to_engine`] /
+    /// [`Self::mark_first_frame_sent`] directly at its own presentation
+    /// step.
+    pub fn draw_frame(&self) -> Option<flui_layer::LayerTree> {
+        let root_owner = self.root_pipeline_owner();
+        let layer_tree = {
+            let mut guard = root_owner.write();
+            let owner = std::mem::take(&mut *guard);
+            let (owner, result) = owner.run_frame();
+            *guard = owner;
+            match result {
+                Ok(layer_tree) => layer_tree,
+                Err(e) => {
+                    tracing::error!(error = ?e, "draw_frame: pipeline failed, dropping frame");
+                    None
+                }
+            }
+        };
+
+        if self.send_frames_to_engine() {
+            self.mark_first_frame_sent();
+            layer_tree
+        } else {
+            // Deferred-first-frame: pipeline work ran (warm-up), the
+            // output is withheld until the deferral count drains.
+            None
+        }
     }
 
     // ========================================================================
@@ -438,39 +557,6 @@ impl RendererBinding for RenderingFlutterBinding {
         } else {
             // Default configuration for testing
             ViewConfiguration::default()
-        }
-    }
-
-    fn draw_frame(&self) -> Option<flui_layer::LayerTree> {
-        // Single authoritative frame path: run_frame produces the
-        // layer tree; the caller (platform binding / embedder) wraps
-        // it in a Scene and submits it to the renderer. The previous
-        // shape dropped the tree here while a divergent
-        // `composite_frame()` loop computed per-view metadata that
-        // never reached a compositor — both dead ends are gone.
-        let root_owner = self.root_pipeline_owner();
-        let layer_tree = {
-            let mut guard = root_owner.write();
-            let owner = std::mem::take(&mut *guard);
-            let (owner, result) = owner.run_frame();
-            *guard = owner;
-            match result {
-                Ok(layer_tree) => layer_tree,
-                Err(e) => {
-                    tracing::error!(error = ?e, "draw_frame: pipeline failed, dropping frame");
-                    None
-                }
-            }
-        };
-
-        if self.send_frames_to_engine() {
-            // First non-deferred frame marks the gate open.
-            self.first_frame_sent.store(true, Ordering::Relaxed);
-            layer_tree
-        } else {
-            // Deferred-first-frame: pipeline work ran (warm-up), the
-            // output is withheld until the deferral count drains.
-            None
         }
     }
 

--- a/crates/flui-app/src/bindings/renderer_binding.rs
+++ b/crates/flui-app/src/bindings/renderer_binding.rs
@@ -286,11 +286,53 @@ impl RenderingFlutterBinding {
             "allow_first_frame called without matching defer_first_frame"
         );
 
-        // Schedule a warm up frame even if count is not zero yet
+        // Schedule a warm-up frame even if the count is not down to zero
+        // yet: removing one deferral may uncover a NEW one further down the
+        // widget tree (a subtree that only registers its own
+        // `defer_first_frame` once an outer one clears), so every
+        // `allow_first_frame` call gets a pass, not just the last.
         if !self.first_frame_sent.load(Ordering::Relaxed) {
-            Scheduler::instance().schedule_frame(Box::new(|_timing| {
-                // Warm-up frame callback
-            }));
+            // The withheld frame(s) already ran build/layout/paint while
+            // deferred (the pipeline work happens unconditionally — see the
+            // module note above `defer_first_frame`); their dirty flags are
+            // already clear by the time the deferral lifts. The oracle's
+            // `compositeFrame()` re-submits the RETAINED layer tree
+            // regardless of dirty state, so its `scheduleWarmUpFrame` always
+            // has something to present. FLUI has no such retained-scene
+            // re-present (a frame with nothing dirty produces
+            // `FramePaintOutcome::Idle`, not a repeat of the last `Scene`)
+            // — without re-marking the root dirty here, the warm-up frame
+            // would find nothing to do and the withheld content would sit
+            // blank until some UNRELATED input dirtied the tree.
+            //
+            // Routed through `PipelineOwner::repaint_handle` /
+            // `RepaintHandle::mark_needs_layout`, NOT `Scheduler::instance()`:
+            // the async-init caller this method exists for (a splash screen
+            // awaiting a network fetch, resolving on an executor thread) may
+            // not be the UI thread, and `Scheduler::instance()` is a
+            // thread-local — resolving it at fire time from a non-UI thread
+            // would schedule on THAT thread's fresh, undriven `Scheduler`
+            // and silently lose the wake (the exact fire-time-resolution
+            // hazard `AppBinding::new`'s wake-wiring comment warns against).
+            // `RepaintHandle` is `Send + Sync`, captured over a bounded
+            // channel at `PipelineOwner` construction time, and its
+            // `mark_needs_layout` fires the SAME visual-update notifier a
+            // local dirty mark does — safe and non-blocking from any
+            // thread.
+            let root_owner = self.root_pipeline_owner().read();
+            if let Some(root_id) = root_owner.root_id()
+                && let Some(handle) = root_owner.repaint_handle(root_id)
+            {
+                drop(root_owner);
+                if let Err(e) = handle.mark_needs_layout() {
+                    tracing::warn!(
+                        error = ?e,
+                        "allow_first_frame: failed to re-mark the root dirty for \
+                         the warm-up frame; the withheld content may not \
+                         present until something else dirties the tree",
+                    );
+                }
+            }
         }
     }
 

--- a/crates/flui-rendering/src/binding/mod.rs
+++ b/crates/flui-rendering/src/binding/mod.rs
@@ -481,8 +481,8 @@ mod tests {
 
     /// Minimal `RendererBinding` implementer exercising the trait's default
     /// methods (`add_render_view_with_config`, `create_view_configuration_for`,
-    /// `draw_frame`, `handle_metrics_changed`) and the free `debug_dump_*`
-    /// functions, none of which had any test coverage.
+    /// `handle_metrics_changed`) and the free `debug_dump_*` functions, plus
+    /// its own wiring of the required `send_frames_to_engine` method.
     struct TestBinding {
         owner: RwLock<PipelineOwner>,
         views: RwLock<HashMap<u64, Arc<RwLock<RenderView>>>>,
@@ -551,6 +551,26 @@ mod tests {
         fn send_frames_to_engine(&self) -> bool {
             self.send_frames.load(Ordering::SeqCst)
         }
+    }
+
+    /// `send_frames_to_engine` is a **required** trait method (no default)
+    /// precisely so each implementer wires its own deferral state instead of
+    /// inheriting a `true`-returning stub. This asserts `TestBinding`'s
+    /// minimal wiring actually reflects `send_frames`, not a trait-level
+    /// default silently masking an unwired knob.
+    #[test]
+    fn send_frames_to_engine_reflects_the_implementers_own_state() {
+        let binding = TestBinding::new();
+        assert!(
+            binding.send_frames_to_engine(),
+            "TestBinding::new defaults send_frames to true"
+        );
+
+        binding.send_frames.store(false, Ordering::SeqCst);
+        assert!(!binding.send_frames_to_engine());
+
+        binding.send_frames.store(true, Ordering::SeqCst);
+        assert!(binding.send_frames_to_engine());
     }
 
     #[test]

--- a/crates/flui-rendering/src/binding/mod.rs
+++ b/crates/flui-rendering/src/binding/mod.rs
@@ -26,7 +26,6 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 
 use flui_interaction::MouseTracker;
-use flui_layer::LayerTree;
 
 use crate::{
     hit_testing::HitTestResult,
@@ -59,7 +58,8 @@ use crate::{
 /// - Managing the root [`PipelineOwner`] tree
 /// - Managing [`RenderView`]s (add/remove)
 /// - Creating [`ViewConfiguration`]s for views
-/// - Coordinating frame production via [`draw_frame`](Self::draw_frame)
+/// - Declaring the first-frame deferral gate via
+///   [`send_frames_to_engine`](Self::send_frames_to_engine)
 /// - Managing [`MouseTracker`] for hover events
 /// - Responding to visual-update requests from pipeline owners
 /// - Tracking semantics-enabled state and its listeners
@@ -82,7 +82,12 @@ use crate::{
 /// onto their phase-typed impls on 2026-05-20. The
 /// orchestrator is [`PipelineOwner::<Idle>::run_frame`], which
 /// composes the four phase transitions and returns the owner back at
-/// `Idle` plus the produced layer tree.
+/// `Idle` plus the produced layer tree. Pumping that orchestrator and
+/// gating step 6 on [`send_frames_to_engine`](Self::send_frames_to_engine)
+/// is the implementer's job, not a trait default — see that method's
+/// doc for why. The production incarnation is
+/// `AppBinding::render_frame_entered` (`flui-app`), which consults
+/// `RenderingFlutterBinding::send_frames_to_engine` before presenting.
 pub trait RendererBinding {
     // ========================================================================
     // Pipeline / Manifold (formerly PipelineManifold)
@@ -254,53 +259,24 @@ pub trait RendererBinding {
     ///
     /// If false, the framework does all frame work but doesn't render.
     /// Used for deferring the first frame until ready.
-    fn send_frames_to_engine(&self) -> bool {
-        true
-    }
-
-    /// Pump the rendering pipeline to generate a frame, returning the
-    /// produced layer tree.
     ///
-    /// The single authoritative frame path: consume the owner out of
-    /// the `RwLock`, drive it through `run_frame` (all four phase
-    /// transitions; semantics included), put it back, and hand the
-    /// produced `LayerTree` to the caller. The caller — a platform
-    /// binding or embedder — wraps the tree in a `Scene` and submits
-    /// it to the renderer (`AppBinding::render_frame` is the
-    /// production incarnation: `draw_frame → Scene::new →
-    /// Renderer::render_scene`).
+    /// # Flutter Equivalence
     ///
-    /// Returns `None` when the frame is deferred
-    /// ([`Self::send_frames_to_engine`] is `false` — Flutter's
-    /// deferred-first-frame mechanism; pipeline work still runs so
-    /// warm-up costs are paid early), when the pipeline produced no
-    /// tree (no root), or when a phase errored (logged, frame
-    /// dropped, owner restored for the next frame).
-    fn draw_frame(&self) -> Option<LayerTree> {
-        let root_owner = self.root_pipeline_owner();
-
-        // Consume the owner through the typestate transitions.
-        let layer_tree = {
-            let mut guard = root_owner.write();
-            let owner = std::mem::take(&mut *guard);
-            let (owner, result) = owner.run_frame();
-            *guard = owner;
-            match result {
-                Ok(layer_tree) => layer_tree,
-                Err(e) => {
-                    tracing::error!(error = ?e, "draw_frame: pipeline failed, dropping frame");
-                    None
-                }
-            }
-        };
-
-        if self.send_frames_to_engine() {
-            layer_tree
-        } else {
-            // Deferred: the work ran (warm-up), the output is withheld.
-            None
-        }
-    }
+    /// Corresponds to `RendererBinding.sendFramesToEngine` (oracle tag
+    /// `3.44.0`, `packages/flutter/lib/src/rendering/binding.dart`):
+    /// `_firstFrameSent || _firstFrameDeferredCount == 0`.
+    ///
+    /// This is a **required** method (no default) deliberately: the
+    /// deferral counter behind it is per-binding state (a nested
+    /// defer/allow counter plus a latching "first frame already sent"
+    /// flag), and a `true`-returning default previously let an
+    /// implementer silently skip wiring the counter at all — the exact
+    /// drift this trait method's history was flagged for. The one
+    /// production implementation lives on `RenderingFlutterBinding`
+    /// (`flui-app`'s `crates/flui-app/src/bindings/renderer_binding.rs`);
+    /// implement this by delegating to that same counter rather than
+    /// growing a second one.
+    fn send_frames_to_engine(&self) -> bool;
 
     // ========================================================================
     // Metrics Handling
@@ -634,22 +610,6 @@ mod tests {
 
         binding.handle_metrics_changed();
         assert_eq!(binding.visual_update_calls.load(Ordering::SeqCst), 1);
-    }
-
-    #[test]
-    fn draw_frame_withholds_output_when_deferred_but_still_runs_pipeline_work() {
-        let binding = TestBinding::new();
-        binding.send_frames.store(false, Ordering::SeqCst);
-
-        // No root attached, so there is nothing to layout/paint regardless;
-        // the point of this test is that a deferred frame reports `None`.
-        assert!(binding.draw_frame().is_none());
-    }
-
-    #[test]
-    fn draw_frame_returns_none_when_pipeline_has_no_root() {
-        let binding = TestBinding::new();
-        assert!(binding.draw_frame().is_none());
     }
 
     #[test]

--- a/crates/flui-view/src/binding.rs
+++ b/crates/flui-view/src/binding.rs
@@ -54,7 +54,7 @@ use std::{
     pin::Pin,
     sync::{
         Arc,
-        atomic::{AtomicBool, AtomicU32, Ordering},
+        atomic::{AtomicBool, Ordering},
     },
 };
 
@@ -424,13 +424,6 @@ pub struct WidgetsBinding {
     /// Whether the first frame has been rasterized.
     first_frame_rasterized: AtomicBool,
 
-    /// Count of deferred first frame requests.
-    /// When > 0, the first frame is deferred (e.g., for splash screens).
-    first_frame_deferred_count: AtomicU32,
-
-    /// Whether the first frame has been sent to the engine.
-    first_frame_sent: AtomicBool,
-
     /// Whether binding is ready to produce frames.
     ready_to_produce_frames: AtomicBool,
 
@@ -540,8 +533,6 @@ impl WidgetsBinding {
             global_key_registry,
             on_need_frame: RwLock::new(None),
             first_frame_rasterized: AtomicBool::new(false),
-            first_frame_deferred_count: AtomicU32::new(0),
-            first_frame_sent: AtomicBool::new(false),
             ready_to_produce_frames: AtomicBool::new(false),
             #[cfg(debug_assertions)]
             debug_building_dirty_elements: AtomicBool::new(false),
@@ -1275,48 +1266,18 @@ impl WidgetsBinding {
         tracing::debug!("First frame rasterized");
     }
 
-    /// Whether the first frame has been sent to the engine.
-    ///
-    /// This is set after `draw_frame` completes for the first time.
-    pub fn debug_did_send_first_frame_event(&self) -> bool {
-        self.first_frame_sent.load(Ordering::Acquire)
-    }
-
-    /// Defer the first frame.
-    ///
-    /// Used for splash screens that need to delay showing content.
-    /// Call `allow_first_frame` to release.
-    ///
-    /// # Flutter Equivalent
-    ///
-    /// Corresponds to `RendererBinding.deferFirstFrame()`.
-    pub fn defer_first_frame(&self) {
-        self.first_frame_deferred_count
-            .fetch_add(1, Ordering::AcqRel);
-        tracing::debug!("First frame deferred");
-    }
-
-    /// Allow the first frame after a previous `defer_first_frame`.
-    ///
-    /// # Flutter Equivalent
-    ///
-    /// Corresponds to `RendererBinding.allowFirstFrame()`.
-    pub fn allow_first_frame(&self) {
-        let prev = self
-            .first_frame_deferred_count
-            .fetch_sub(1, Ordering::AcqRel);
-        if prev == 1 {
-            // No more deferrals, we can send frames now
-            tracing::debug!("First frame allowed - ready to produce frames");
-        }
-    }
-
-    /// Whether frames should be sent to the engine.
-    ///
-    /// Returns false if the first frame is deferred.
-    pub fn send_frames_to_engine(&self) -> bool {
-        self.first_frame_deferred_count.load(Ordering::Acquire) == 0
-    }
+    // Note: the first-frame *deferral counter* (`defer_first_frame` /
+    // `allow_first_frame` / `send_frames_to_engine`) used to be duplicated
+    // here as its own independent `AtomicU32` + `AtomicBool` pair. Flutter
+    // has exactly one such counter, on `RendererBinding` (`WidgetsBinding`
+    // is a mixin on top of it and shares the same state); a second,
+    // unrelated counter on this binding could drift from the real one and
+    // never actually gated anything reachable from the production frame
+    // path. It has been removed — the single canonical counter lives on
+    // `RenderingFlutterBinding` (`crates/flui-app/src/bindings/
+    // renderer_binding.rs`), forwarded through `AppBinding::defer_first_frame`
+    // / `allow_first_frame` / `send_frames_to_engine`, and consulted by
+    // `AppBinding::render_frame_entered`.
 
     /// Whether the binding is ready to produce frames.
     pub fn is_ready_to_produce_frames(&self) -> bool {


### PR DESCRIPTION
Design-pass repair from the flui-app audit: three drifting first-frame-deferral implementations, none consulted by the production frame path — the public `defer_first_frame`/`allow_first_frame` API did nothing.

## What

- **One canonical counter** on `RenderingFlutterBinding` (reachable from `AppBinding.renderer` with zero new crate edges), oracle-faithful (`RendererBinding` @ 3.44.0): `sendFramesToEngine = first_frame_sent || count == 0`, nested defer/allow, unmatched allow panics, once-sent latch short-circuits later defers. The flui-view counter is deleted (zero callers); flui-rendering's dead default `draw_frame` is deleted and `send_frames_to_engine()` is now a required trait method so no implementer can silently default to "always send".
- **The production gate**: `render_frame_entered` runs build/layout/paint unconditionally while deferred (Flutter's exact split — only `compositeFrame` is gated upstream) and withholds just the GPU present. Deferred ≠ errored: a deferred frame settles normally and never triggers the dropped-frame retry-wake.
- **The withheld frame actually appears when the gate opens** — caught in review, empirically: FLUI has no retained-scene re-present (an Idle frame produces no layer tree), so a wake alone after `allow_first_frame` left the splash-screen use case (defer → async init → allow) blank until unrelated input. `allow_first_frame` now re-dirties the root through a `Send + Sync` `RepaintHandle` captured from the binding's own pipeline owner — which also eliminates the second review finding, a fire-time `Scheduler::instance()` resolve that silently lost the wake when `allow` was called from a worker thread (the documented async-init case).
- **Errored first frame does not latch `first_frame_sent`** (oracle latches only after a successful composite) — proven by a fixture that panics in layout through the real `catch_unwind` path.

## Evidence

- `cargo nextest run --workspace --exclude flui-platform`: 7454 passed; clippy `-D warnings`, wasm32 check, port-check/inventory, doc gates: clean.
- 8 new tests incl. allow-alone-presents (no manual re-dirty), nested defer/allow present-once, latch short-circuit, errored-no-latch; all load-bearing behaviors mutation-verified — reviewer independently re-ran the gate-consult, counter-nesting, re-dirty, and errored-latch mutants across two rounds.
- Full review + delta re-review: SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)