### PR TITLE
test(widgets): port Flutter's focus-family test corpus into the parity suite

### DIFF
--- a/crates/flui-interaction/src/routing/focus_scope.rs
+++ b/crates/flui-interaction/src/routing/focus_scope.rs
@@ -293,18 +293,30 @@ impl FocusNode {
 
     /// Sets whether this node can request focus.
     ///
-    /// On a `true` to `false` change, primary focus **held by this node
-    /// itself** is released (Flutter: `FocusNode.canRequestFocus` setter,
-    /// `focus_scope_test.dart`'s "Focus is lost when set to not focusable.",
-    /// tag 3.44.0). Unlike [`Self::set_descendants_are_focusable`], this does
-    /// not evict a focused *descendant* — `can_request_focus` gates only
-    /// whether this node itself may hold focus.
+    /// On a `true` to `false` change, focus this node is responsible for is
+    /// released — Flutter's `FocusNode.canRequestFocus` setter checks
+    /// `hasFocus` (this node **or any descendant**), then unfocuses with
+    /// `UnfocusDisposition.previouslyFocusedChild`
+    /// (`focus_manager.dart`'s `canRequestFocus` setter, tag `3.44.0`;
+    /// `focus_scope_test.dart`'s "Focus is lost when set to not focusable."
+    /// and "canRequestFocus causes descendants of scope to be skipped."'s
+    /// `pumpTest(allowScope2: false)` step, same tag).
+    ///
+    /// A **scope** additionally gates whether it allows descendant focus at
+    /// all (`allows_descendant_focus`), so disabling it evicts a focused
+    /// descendant too — checked via [`Self::has_focus`], mirroring the
+    /// oracle's `hasFocus` check. A plain node's own eligibility does not
+    /// carry that gate, so only [`Self::has_primary_focus`] (this node
+    /// itself) is checked — an intentional simplification of Flutter's
+    /// `previouslyFocusedChild` disposition, which walks up to the enclosing
+    /// scope and re-descends to restore whatever was focused before, rather
+    /// than leaving nothing focused the way this does.
     pub fn set_can_request_focus(&self, can: bool) {
         let previous = self.can_request_focus.swap(can, AtomicOrdering::AcqRel);
         if previous == can {
             return;
         }
-        if !can && self.has_primary_focus() {
+        if !can && (self.has_primary_focus() || (self.is_scope() && self.has_focus())) {
             crate::FocusManager::global().unfocus();
         }
     }

--- a/crates/flui-interaction/src/routing/focus_scope.rs
+++ b/crates/flui-interaction/src/routing/focus_scope.rs
@@ -198,6 +198,16 @@ pub struct FocusNode {
 
     /// Whether this node is attached to the focus tree.
     attached: AtomicBool,
+
+    /// A `request_focus()` call made while unattached, fulfilled the moment
+    /// [`Self::attach_child`] attaches this node — Flutter's requestFocus-
+    /// before-attach queuing (`FocusNode._requestFocus`/`_hasKeyboardToken`
+    /// resolve their pending grant on `FocusAttachment.reparent`).  Consumed
+    /// (cleared) on attach whether or not the retried request actually
+    /// succeeds, so a request dropped for another reason (e.g.
+    /// `can_request_focus` turned false in the meantime) does not linger and
+    /// fire on a later, unrelated attach.
+    pending_focus_request: AtomicBool,
 }
 
 impl FocusNode {
@@ -216,6 +226,7 @@ impl FocusNode {
             rect: RwLock::new(Rect::ZERO),
             rect_provider: RwLock::new(None),
             attached: AtomicBool::new(false),
+            pending_focus_request: AtomicBool::new(false),
         })
     }
 
@@ -234,6 +245,7 @@ impl FocusNode {
             rect: RwLock::new(Rect::ZERO),
             rect_provider: RwLock::new(None),
             attached: AtomicBool::new(false),
+            pending_focus_request: AtomicBool::new(false),
         })
     }
 
@@ -254,6 +266,7 @@ impl FocusNode {
             rect: RwLock::new(Rect::ZERO),
             rect_provider: RwLock::new(None),
             attached: AtomicBool::new(false),
+            pending_focus_request: AtomicBool::new(false),
         })
     }
 
@@ -279,8 +292,21 @@ impl FocusNode {
     }
 
     /// Sets whether this node can request focus.
+    ///
+    /// On a `true` to `false` change, primary focus **held by this node
+    /// itself** is released (Flutter: `FocusNode.canRequestFocus` setter,
+    /// `focus_scope_test.dart`'s "Focus is lost when set to not focusable.",
+    /// tag 3.44.0). Unlike [`Self::set_descendants_are_focusable`], this does
+    /// not evict a focused *descendant* — `can_request_focus` gates only
+    /// whether this node itself may hold focus.
     pub fn set_can_request_focus(&self, can: bool) {
-        self.can_request_focus.store(can, AtomicOrdering::Release);
+        let previous = self.can_request_focus.swap(can, AtomicOrdering::AcqRel);
+        if previous == can {
+            return;
+        }
+        if !can && self.has_primary_focus() {
+            crate::FocusManager::global().unfocus();
+        }
     }
 
     /// Returns whether to skip this node during traversal.
@@ -445,10 +471,19 @@ impl FocusNode {
 
     /// Requests primary focus for this node.
     ///
-    /// No-op when the node cannot request focus or is not attached to
-    /// the focus tree.
+    /// No-op when the node cannot request focus. A request made while the
+    /// node is not yet attached to the focus tree is deferred rather than
+    /// dropped: [`Self::attach_child`] retries it the moment this node joins
+    /// the tree — Flutter's requestFocus-before-attach queuing
+    /// (`FocusNode._requestFocus`/`_hasKeyboardToken`, fulfilled on
+    /// `FocusAttachment.reparent`).
     pub fn request_focus(self: &Arc<Self>) {
-        if !self.can_request_focus() || !self.is_attached() {
+        if !self.can_request_focus() {
+            return;
+        }
+        if !self.is_attached() {
+            self.pending_focus_request
+                .store(true, AtomicOrdering::Release);
             return;
         }
         crate::FocusManager::global().request_focus(self.id);
@@ -622,6 +657,17 @@ impl FocusNode {
 
         // Add to children
         self.children.write().push(child.clone());
+
+        // Fulfill a `request_focus()` call made before this node was
+        // attached. Consumed unconditionally: a request that no longer
+        // applies (`can_request_focus` turned false in the meantime) must not
+        // linger and fire on a later, unrelated attach.
+        if child
+            .pending_focus_request
+            .swap(false, AtomicOrdering::AcqRel)
+        {
+            child.request_focus();
+        }
     }
 
     fn detach_child(&self, child_id: FocusNodeId) {
@@ -688,6 +734,7 @@ impl Default for FocusNode {
             rect: RwLock::new(Rect::ZERO),
             rect_provider: RwLock::new(None),
             attached: AtomicBool::new(false),
+            pending_focus_request: AtomicBool::new(false),
         }
     }
 }
@@ -1373,6 +1420,80 @@ mod tests {
         assert!(node.parent().is_some());
         // After attach the child is marked attached.
         assert!(node.is_attached());
+    }
+
+    /// `request_focus()` called before a node is attached is deferred, not
+    /// dropped: `attach_child` retries it the moment the node joins the tree.
+    /// Flutter parity: `FocusManager.instance` queues a pre-attach
+    /// `requestFocus()` behind the node's `FocusAttachment` and grants it on
+    /// `reparent` (`focus_manager_test.dart`'s "Requesting focus before
+    /// adding to tree results in a request after adding", tag 3.44.0).
+    ///
+    /// Red-check (verified): reverting `request_focus`/`attach_child` to the
+    /// prior unconditional `!is_attached()` no-op leaves `child` never
+    /// focused — the final assertion fails.
+    #[test]
+    fn request_focus_before_attach_is_granted_on_attach() {
+        let _guard = GLOBAL_FOCUS_LOCK.lock();
+        let manager = crate::FocusManager::global();
+        manager.unfocus();
+
+        let scope = FocusScopeNode::with_debug_label("pending-request-scope");
+        manager.root_scope().attach_node(scope.as_focus_node());
+        let child = FocusNode::with_debug_label("pending-request-child");
+
+        // Requested while unattached: neither attached nor focused yet.
+        child.request_focus();
+        assert!(!child.is_attached());
+        assert!(!child.has_primary_focus());
+        assert_eq!(manager.primary_focus(), None);
+
+        scope.attach_node(&child);
+
+        assert!(
+            child.has_primary_focus(),
+            "the deferred request is granted the moment the node attaches"
+        );
+        assert_eq!(scope.focused_child(), Some(child.id()));
+
+        manager.unfocus();
+        manager.root_scope().detach_node(scope.as_focus_node().id());
+    }
+
+    /// A pending request is consumed on attach even when it can no longer
+    /// succeed: `can_request_focus(false)` set between the request and the
+    /// attach must not leave a stale grant that fires on some *later*,
+    /// unrelated attach.
+    #[test]
+    fn a_pending_request_dropped_by_can_request_focus_does_not_linger() {
+        let _guard = GLOBAL_FOCUS_LOCK.lock();
+        let manager = crate::FocusManager::global();
+        manager.unfocus();
+
+        let scope = FocusScopeNode::with_debug_label("stale-pending-scope");
+        manager.root_scope().attach_node(scope.as_focus_node());
+        let child = FocusNode::with_debug_label("stale-pending-child");
+        child.request_focus();
+        child.set_can_request_focus(false);
+
+        scope.attach_node(&child);
+        assert!(
+            !child.has_primary_focus(),
+            "can_request_focus(false) defeats the retried request"
+        );
+
+        // Detach, re-enable, and reattach: the earlier request must not have
+        // lingered to fire here.
+        scope.detach_node(child.id());
+        child.set_can_request_focus(true);
+        scope.attach_node(&child);
+        assert!(
+            !child.has_primary_focus(),
+            "a defeated pending request does not resurrect on a later attach"
+        );
+
+        manager.unfocus();
+        manager.root_scope().detach_node(scope.as_focus_node().id());
     }
 
     #[test]

--- a/crates/flui-widgets/src/interaction/focus.rs
+++ b/crates/flui-widgets/src/interaction/focus.rs
@@ -100,17 +100,6 @@ pub(crate) fn enclosing_focus_parent(ctx: &dyn BuildContext) -> Arc<FocusNode> {
         .unwrap_or_else(|| Arc::clone(FocusManager::global().root_scope().as_focus_node()))
 }
 
-/// The nearest enclosing **scope** — `FocusScope.of`'s fallback contract
-/// (`focus_scope.dart:843-850`): the nearest provider node when it is itself a
-/// scope, else that node's enclosing scope, else the root scope.
-pub(crate) fn enclosing_scope(ctx: &dyn BuildContext) -> Arc<FocusScopeNode> {
-    let parent = enclosing_focus_parent(ctx);
-    parent
-        .as_scope()
-        .or_else(|| parent.enclosing_scope())
-        .unwrap_or_else(|| Arc::clone(FocusManager::global().root_scope()))
-}
-
 // ============================================================================
 // Focus
 // ============================================================================
@@ -285,6 +274,7 @@ impl StatefulView for Focus {
             anchor: SubtreeAnchor::new(),
             focus_listener_id: None,
             autofocus: self.autofocus,
+            did_autofocus: false,
             on_focus_change: Rc::new(RefCell::new(self.on_focus_change.clone())),
             pending_focus_changes: Arc::new(Mutex::new(Vec::new())),
         }
@@ -306,6 +296,12 @@ pub struct FocusState {
     focus_listener_id: Option<ListenerId>,
     /// Captured at `create_state`: `init_state` has no view reference.
     autofocus: bool,
+    /// One-shot latch: whether this widget has already attempted its
+    /// autofocus request — Flutter's `_didAutofocus` (`focus_scope.dart`).
+    /// Set the moment the attempt is made, win or lose (an already-focused
+    /// sibling can still make the attempt lose), so a later rebuild that
+    /// merely re-asserts the same `autofocus` value does not re-request.
+    did_autofocus: bool,
     /// The current `on_focus_change` handler, behind a shared cell so the installed
     /// listener reads the *latest* one. `did_update_view` writes here rather than
     /// reinstalling the listener — a captured-by-value closure would keep firing the
@@ -342,6 +338,33 @@ impl FocusState {
             },
         )));
     }
+
+    /// `_handleAutofocus` (`:622-626`): a one-shot attempt, made the first
+    /// time `autofocus` is (or becomes) `true` and never repeated —
+    /// [`FocusState::did_autofocus`] latches regardless of whether the
+    /// attempt actually won the focus (an already-focused sibling can still
+    /// make it lose). Only when the enclosing scope has nothing focused yet
+    /// does the request land; either way the attempt is marked made.
+    /// Synchronous — FLUI has no end-of-frame focus batch (module docs).
+    ///
+    /// Derives the nearest scope from [`FocusState::parent`] (kept current by
+    /// `init_state`/`did_change_dependencies`) rather than an ambient
+    /// `BuildContext` lookup, so it can run from
+    /// [`ViewState::did_update_view`] too — that hook gets no `BuildContext`.
+    fn try_autofocus(&mut self) {
+        if self.did_autofocus || !self.autofocus {
+            return;
+        }
+        self.did_autofocus = true;
+        let scope = self
+            .parent
+            .as_ref()
+            .and_then(|parent| parent.as_scope().or_else(|| parent.enclosing_scope()))
+            .unwrap_or_else(|| Arc::clone(FocusManager::global().root_scope()));
+        if scope.focused_child().is_none() {
+            self.node.request_focus();
+        }
+    }
 }
 
 impl ViewState<Focus> for FocusState {
@@ -358,12 +381,7 @@ impl ViewState<Focus> for FocusState {
 
         self.install_focus_listener(ctx.rebuild_handle());
 
-        // `_handleAutofocus` (`:625-630`): only when the enclosing scope has
-        // nothing focused yet. Synchronous — FLUI has no end-of-frame focus
-        // batch (module docs).
-        if self.autofocus && enclosing_scope(ctx).focused_child().is_none() {
-            self.node.request_focus();
-        }
+        self.try_autofocus();
     }
 
     fn did_change_dependencies(&mut self, ctx: &dyn BuildContext) {
@@ -388,6 +406,12 @@ impl ViewState<Focus> for FocusState {
         // node is read once in `create_state`.
         new_view.configure(&self.node);
         self.autofocus = new_view.autofocus;
+        // `didUpdateWidget`'s `oldWidget.autofocus != widget.autofocus` guard
+        // (`:676-678`) is folded into `try_autofocus`'s own `did_autofocus`
+        // latch: a rebuild that flips `autofocus` from `false` to `true`
+        // makes the one still-unattempted autofocus request; one that merely
+        // repeats an already-`true` value is a no-op either way.
+        self.try_autofocus();
         // The listener installed at mount reads this cell, so a rebuild that
         // swaps the handler swaps what actually fires — capturing the handler
         // in the closure instead would pin the *first* one for the widget's
@@ -690,6 +714,12 @@ mod tests {
         }
     }
 
+    /// Flutter parity: `focus_scope_test.dart`'s `"Descendants of ExcludeFocus
+    /// aren't focusable."` (a request while excluding refuses) and
+    /// `"ExcludeFocus doesn't transfer focus to another descendant."` (turning
+    /// exclusion on evicts an already-focused descendant without picking a new
+    /// one), tag `3.44.0`. Also the idempotent-toggle and no-auto-refocus-on-
+    /// re-enable properties, which the oracle tests do not separately cover.
     #[test]
     fn exclude_focus_refuses_allows_evicts_idempotently_and_does_not_refocus() {
         let _guard = FOCUS_TEST_LOCK.lock();
@@ -736,6 +766,10 @@ mod tests {
     /// `focus_scope.dart:565-630`): the widget scope hangs under the root
     /// scope, the node hangs under the widget scope — **not** the root — and
     /// unmounting detaches both and releases the primary focus.
+    ///
+    /// Flutter parity: `focus_scope_test.dart`'s `'Removing a FocusScope
+    /// removes its node from the tree'` (the unmount-detaches-both half) and
+    /// `'Autofocus works'` (the autofocus-on-mount half), tag `3.44.0`.
     ///
     /// Red-check: make `enclosing_scope` always answer the root scope — the
     /// node parents to the root and the first assertion fails.
@@ -791,9 +825,72 @@ mod tests {
         );
     }
 
+    /// A rebuild that flips `autofocus` from `false` to `true` makes the
+    /// still-unattempted autofocus request — Flutter's `didUpdateWidget`
+    /// re-running `_handleAutofocus` on an `autofocus` change
+    /// (`focus_scope.dart`'s "Can autofocus a node.", tag 3.44.0), not just
+    /// `initState`/`didChangeDependencies`.
+    ///
+    /// Red-check (verified): drop the `try_autofocus()` call from
+    /// `did_update_view` — the node mounted with `autofocus: false` never
+    /// requests focus on the later rebuild, and the assertion fails.
+    #[test]
+    fn a_rebuild_that_turns_on_autofocus_requests_focus() {
+        let _guard = FOCUS_TEST_LOCK.lock();
+        let manager = FocusManager::global();
+        manager.unfocus();
+
+        let scope = FocusScopeNode::with_debug_label("rebuild-autofocus-scope");
+        let node = FocusNode::with_debug_label("rebuild-autofocus-node");
+        let mut harness = mount(Host {
+            show: true,
+            scope: Arc::clone(&scope),
+            node: Arc::clone(&node),
+            autofocus: false,
+            on_focus_change: None,
+        });
+        assert!(!node.has_primary_focus(), "sanity: not focused on mount");
+
+        harness.swap_root(Host {
+            show: true,
+            scope: Arc::clone(&scope),
+            node: Arc::clone(&node),
+            autofocus: true,
+            on_focus_change: None,
+        });
+
+        assert!(
+            node.has_primary_focus(),
+            "the rebuild's autofocus: true made its one-shot request"
+        );
+
+        // A second rebuild that merely repeats `autofocus: true` must not
+        // re-attempt: nothing else focused now, so an unfocus followed by a
+        // repeated-`true` rebuild staying unfocused proves the latch, not a
+        // silently-passing accident.
+        manager.unfocus();
+        harness.swap_root(Host {
+            show: true,
+            scope: Arc::clone(&scope),
+            node: Arc::clone(&node),
+            autofocus: true,
+            on_focus_change: None,
+        });
+        assert!(
+            !node.has_primary_focus(),
+            "the one-shot latch does not re-request on a value-repeating rebuild"
+        );
+
+        manager.unfocus();
+        manager.root_scope().detach_node(scope.as_focus_node().id());
+    }
+
     /// `autofocus` yields when the scope already focused something
     /// (`_handleAutofocus`, `focus_scope.dart:625-630`): with two autofocus
     /// siblings, the first to mount wins and the second is skipped.
+    ///
+    /// Flutter parity: `focus_scope_test.dart`'s `"Won't autofocus a node if
+    /// one is already focused."`, tag `3.44.0`.
     ///
     /// Red-check: drop the `focused_child().is_none()` gate in `init_state` —
     /// the second steals the focus and both assertions flip.

--- a/crates/flui-widgets/src/interaction/focus.rs
+++ b/crates/flui-widgets/src/interaction/focus.rs
@@ -339,8 +339,9 @@ impl FocusState {
         )));
     }
 
-    /// `_handleAutofocus` (`:622-626`): a one-shot attempt, made the first
-    /// time `autofocus` is (or becomes) `true` and never repeated —
+    /// `_handleAutofocus` (`focus_scope.dart`, tag `3.44.0`): a one-shot
+    /// attempt, made the first time `autofocus` is (or becomes) `true` and
+    /// never repeated —
     /// [`FocusState::did_autofocus`] latches regardless of whether the
     /// attempt actually won the focus (an already-focused sibling can still
     /// make it lose). Only when the enclosing scope has nothing focused yet
@@ -407,10 +408,11 @@ impl ViewState<Focus> for FocusState {
         new_view.configure(&self.node);
         self.autofocus = new_view.autofocus;
         // `didUpdateWidget`'s `oldWidget.autofocus != widget.autofocus` guard
-        // (`:676-678`) is folded into `try_autofocus`'s own `did_autofocus`
-        // latch: a rebuild that flips `autofocus` from `false` to `true`
-        // makes the one still-unattempted autofocus request; one that merely
-        // repeats an already-`true` value is a no-op either way.
+        // (`focus_scope.dart`, tag `3.44.0`) is folded into `try_autofocus`'s
+        // own `did_autofocus` latch: a rebuild that flips `autofocus` from
+        // `false` to `true` makes the one still-unattempted autofocus
+        // request; one that merely repeats an already-`true` value is a
+        // no-op either way.
         self.try_autofocus();
         // The listener installed at mount reads this cell, so a rebuild that
         // swaps the handler swaps what actually fires — capturing the handler
@@ -828,8 +830,8 @@ mod tests {
     /// A rebuild that flips `autofocus` from `false` to `true` makes the
     /// still-unattempted autofocus request — Flutter's `didUpdateWidget`
     /// re-running `_handleAutofocus` on an `autofocus` change
-    /// (`focus_scope.dart`'s "Can autofocus a node.", tag 3.44.0), not just
-    /// `initState`/`didChangeDependencies`.
+    /// (`focus_scope_test.dart`'s "Can autofocus a node.", tag 3.44.0), not
+    /// just `initState`/`didChangeDependencies`.
     ///
     /// Red-check (verified): drop the `try_autofocus()` call from
     /// `did_update_view` — the node mounted with `autofocus: false` never

--- a/crates/flui-widgets/src/text/editable_text.rs
+++ b/crates/flui-widgets/src/text/editable_text.rs
@@ -174,14 +174,12 @@ impl EditableText {
     /// withdraw-on-unavailable mechanism `dispose` already uses for an
     /// unmounted field — and marks the node
     /// [`FocusNode::set_can_request_focus`]`(false)`, which keyboard-traversal
-    /// (`focus_next`/`focus_previous`) already honors. **Unlike** Flutter's
-    /// `FocusNode.canRequestFocus` setter, FLUI's `set_can_request_focus` is a
-    /// bare atomic store with no side effects — so if the field is focused
-    /// when it becomes disabled, `did_update_view` explicitly calls
-    /// `FocusManager::unfocus` (a step the oracle's setter performs
-    /// implicitly as part of assigning `canRequestFocus`). Its key handler
-    /// also stops mutating the controller while disabled, so even a stray
-    /// dispatch reaching an already-focused-then-disabled node is a no-op.
+    /// (`focus_next`/`focus_previous`) already honors and which — matching
+    /// Flutter's `FocusNode.canRequestFocus` setter — releases primary focus
+    /// itself if the field is focused when it becomes disabled; no separate
+    /// `did_update_view` unfocus step is needed. Its key handler also stops
+    /// mutating the controller while disabled, so even a stray dispatch
+    /// reaching an already-focused-then-disabled node is a no-op.
     ///
     /// Tap suppression is a decoration-level concern (an enclosing
     /// `TextField`'s `GestureDetector`), not this primitive's — out of scope
@@ -455,27 +453,26 @@ impl ViewState<EditableText> for EditableTextState {
     }
 
     fn did_update_view(&mut self, _old_view: &EditableText, new_view: &EditableText) {
+        // A field disabled while focused must not keep the caret and keyboard
+        // input — mirrors Flutter's `TextField`/`EditableText` unfocusing when
+        // `enabled` flips false mid-focus. `FocusNode::set_can_request_focus`
+        // itself releases primary focus on a true-to-false change (Flutter's
+        // `FocusNode.canRequestFocus` setter semantics), so this call alone
+        // covers the unfocus — no separate `has_primary_focus` check needed.
+        //
+        // Load-bearing order: this runs BEFORE `set_focus_node_id(None)`
+        // below. `FocusManager::unfocus` notifies every registered listener
+        // with the (previous, current) pair; an enclosing decorated field
+        // (`flui_material::TextField`) compares that pair against
+        // `controller.focus_node_id()` to detect ITS OWN focus-loss
+        // transition. Clearing the id first would make that comparison
+        // vacuous by the time the notification fires (the id is already
+        // gone), silently masking the transition from any such listener.
         self.focus_node.set_can_request_focus(new_view.enabled);
         if new_view.enabled {
             self.controller
                 .set_focus_node_id(Some(self.focus_node.id()));
         } else {
-            // A field disabled while focused must not keep the caret and
-            // keyboard input — mirrors Flutter's `TextField`/`EditableText`
-            // unfocusing when `enabled` flips false mid-focus.
-            //
-            // Unfocus BEFORE withdrawing the published node id — load-
-            // bearing order, not incidental. `FocusManager::unfocus` notifies
-            // every registered listener with the (previous, current) pair;
-            // an enclosing decorated field (`flui_material::TextField`)
-            // compares that pair against `controller.focus_node_id()` to
-            // detect ITS OWN focus-loss transition. Clearing the id first
-            // would make that comparison vacuous by the time the
-            // notification fires (the id is already gone), silently masking
-            // the transition from any such listener.
-            if self.focus_node.has_primary_focus() {
-                FocusManager::global().unfocus();
-            }
             self.controller.set_focus_node_id(None);
         }
     }
@@ -946,15 +943,13 @@ mod tests {
     }
 
     /// Disabling a focused field unfocuses it and withdraws its published
-    /// node. Load-bearing: FLUI's `FocusNode::set_can_request_focus` is a
-    /// bare atomic store with no side effects — unlike Flutter's
-    /// `FocusNode.canRequestFocus` setter, which auto-unfocuses — so nothing
-    /// but `did_update_view`'s explicit `FocusManager::unfocus` call (see
-    /// [`EditableText::enabled`]'s doc comment) does this.
+    /// node — `did_update_view`'s `set_can_request_focus(false)` call (see
+    /// [`EditableText::enabled`]'s doc comment) releases primary focus itself,
+    /// matching Flutter's `FocusNode.canRequestFocus` setter.
     ///
-    /// Red-check: delete the `FocusManager::global().unfocus()` call in
-    /// `did_update_view`'s disabled branch — the node stays primary-focused
-    /// and the first assertion fails.
+    /// Red-check: pass `true` instead of `new_view.enabled` to
+    /// `set_can_request_focus` in `did_update_view` — the node stays
+    /// primary-focused and the first assertion fails.
     #[test]
     fn disabling_a_focused_field_unfocuses_it_and_withdraws_the_node() {
         let _guard = crate::test_harness::FOCUS_TEST_LOCK.lock();

--- a/crates/flui-widgets/tests/parity/focus_test.rs
+++ b/crates/flui-widgets/tests/parity/focus_test.rs
@@ -457,7 +457,11 @@ fn focus_changes_notify_listeners_on_each_synchronous_request() {
 ///
 /// Adapted: node-level, trimmed to one `Focus` level (the oracle nests a
 /// second, `focus2`, under `focus1`; one level already shows the contrast).
-/// A plain `FocusNode`'s own `canRequestFocus: false` gates only itself.
+/// A plain `FocusNode`'s own `canRequestFocus: false` gates only itself —
+/// in both directions the oracle checks: a descendant's *already-held*
+/// focus survives the ancestor being disabled (the oracle's
+/// `pumpTest(allowFocus1: false)` step while `focus2` held focus —
+/// `hasFocus, isTrue`), and a fresh descendant request still succeeds.
 #[test]
 fn can_request_focus_on_a_plain_focus_does_not_restrict_its_descendants() {
     let _guard = FOCUS_TEST_LOCK.lock();
@@ -471,9 +475,19 @@ fn can_request_focus_on_a_plain_focus_does_not_restrict_its_descendants() {
     let focus2 = FocusNode::with_debug_label("focus2");
     focus1.attach_node(&focus2);
 
-    focus1.set_can_request_focus(false);
     focus2.request_focus();
+    assert!(focus2.has_primary_focus());
 
+    focus1.set_can_request_focus(false);
+    assert!(
+        focus2.has_focus(),
+        "disabling a plain (non-scope) ancestor must NOT evict a descendant's \
+         already-held focus — only a scope's canRequestFocus(false) reaches \
+         its descendants"
+    );
+
+    manager.unfocus();
+    focus2.request_focus();
     assert!(
         focus2.has_primary_focus(),
         "an ancestor Focus's canRequestFocus(false) does not restrict a descendant"

--- a/crates/flui-widgets/tests/parity/focus_test.rs
+++ b/crates/flui-widgets/tests/parity/focus_test.rs
@@ -1,0 +1,1076 @@
+//! ## Test parity notes
+//!
+//! Flutter source: `packages/flutter/test/widgets/focus_manager_test.dart` and
+//! `.../focus_scope_test.dart` (tag `3.44.0`). `focus_traversal_test.dart` was
+//! read too — see *Not ported* for why almost none of it lands here.
+//!
+//! FLUI's `Focus`/`FocusScope`/`ExcludeFocus` widgets
+//! (`crates/flui-widgets/src/interaction/focus.rs`) already carry a
+//! substantial self-authored unit-test suite (mount/unmount lifecycle,
+//! autofocus, `on_focus_change`, rebuild-config-reset, Tab traversal), and
+//! `flui-interaction`'s `FocusManager`/`FocusNode`/`FocusScopeNode` carry an
+//! even larger one (traversal edge behavior, key-event bubbling, reparenting).
+//! This file's job is different, matching this crate's `navigator_test.rs`
+//! precedent: every case below is anchored to a **named upstream Flutter
+//! test** and asserts the sequence or contrast Flutter itself asserts. Where
+//! a case is already fully exercised by an existing self-authored test, the
+//! citation was added there instead of duplicating it here (see each
+//! function's doc comment in `interaction/focus.rs`).
+//!
+//! Two styles of case appear, matching each oracle test's own style:
+//! - **Widget-mounted** — a `Focus`/`FocusScope`/`ExcludeFocus` tree is built
+//!   through this crate's headless [`crate::common::lay_out`] harness, for
+//!   cases whose Flutter oracle is itself about widget mount/rebuild/unmount
+//!   behavior (the `ViewState` glue, not just the node API).
+//! - **Node-level** — `FocusNode`/`FocusScopeNode`/`FocusManager` are
+//!   exercised directly, for cases whose Flutter oracle asserts a node-API
+//!   contract and only uses a widget to obtain a `BuildContext`/node
+//!   reference (FLUI has no `Focus.of`/`FocusScope.of` ambient lookup — see
+//!   *Not ported* — so the direct node reference stands in for it).
+//!
+//! `FocusManager::global()` is an owner-thread (thread-local) singleton
+//! (`crates/flui-interaction/src/routing/focus.rs`); nextest's libtest runner
+//! reuses OS threads across many `#[test]` functions in this binary, so every
+//! case below takes [`FOCUS_TEST_LOCK`] and explicitly `unfocus()`s /
+//! detaches whatever it attached, mirroring `flui-interaction`'s own
+//! `GLOBAL_FOCUS_LOCK` convention (`routing/focus_scope.rs`) and
+//! `flui-widgets`' crate-private `FOCUS_TEST_LOCK`
+//! (`src/test_harness.rs`, unreachable from this external integration-test
+//! crate).
+//!
+//! ## Ported cases
+//! - `'Can add children to scope and focus'` (focus_manager_test.dart) —
+//!   `hasFocus` (any descendant focused) vs `hasPrimaryFocus` (this node
+//!   specifically) contrast on a parent/child/child chain, node-level —
+//!   [`can_add_children_to_scope_and_focus_contrasts_has_focus_and_has_primary_focus`].
+//! - `'Can focus'` (focus_scope_test.dart) — `request_focus` on a mounted
+//!   `Focus`'s node yields `has_focus` —
+//!   [`can_focus_via_request_focus`].
+//! - `'Can unfocus'` (focus_scope_test.dart) — focusing sibling B unfocuses A
+//!   (focus gain/loss ordering) — [`can_unfocus_by_focusing_a_sibling`].
+//! - `'Can have multiple focused children and they update accordingly'`
+//!   (focus_scope_test.dart) — autofocus plus toggling focus back and forth
+//!   between two siblings —
+//!   [`multiple_focused_children_update_accordingly_as_focus_moves_between_siblings`].
+//! - `'Removing focused widget moves focus to next widget'`
+//!   (focus_scope_test.dart) — despite the name, the assertion is that focus
+//!   is **not** auto-transferred to the survivor; a dispose-while-focused
+//!   lifecycle case —
+//!   [`removing_the_focused_widget_does_not_transfer_focus_to_the_survivor`].
+//! - `"Removing focused widget doesn't move focus to next widget within
+//!   FocusScope"` (focus_scope_test.dart) — the scoped variant —
+//!   [`removing_the_focused_widget_within_a_scope_does_not_transfer_focus`].
+//! - `'Adding a new FocusScope attaches the child to its parent.'`
+//!   (focus_scope_test.dart) — FocusScope node capture: a child scope added
+//!   on a later rebuild attaches under the parent scope's node —
+//!   [`adding_a_new_focus_scope_attaches_its_node_under_the_parent_scope`].
+//! - `'Can focus root node.'` (focus_scope_test.dart) — the root scope itself
+//!   can hold primary focus. **Adapted**: node-level — the oracle mounts a
+//!   widget only to reach `FocusScope.of`, which FLUI does not have —
+//!   [`can_focus_the_root_scope_directly`].
+//! - `'Focus is ignored when set to not focusable.'` (focus_scope_test.dart)
+//!   — `canRequestFocus: false` refuses a `request_focus` call and
+//!   `on_focus_change` never fires — [`focus_is_ignored_when_not_focusable`].
+//! - `'Focus is lost when set to not focusable.'` (focus_scope_test.dart) —
+//!   flipping `canRequestFocus` to `false` on a rebuild releases focus the
+//!   node currently holds — exercises the `FocusNode::set_can_request_focus`
+//!   fix landed alongside this port (see below) —
+//!   [`focus_is_lost_when_set_to_not_focusable_mid_focus`].
+//! - `'Child of unfocusable Focus can get focus.'` (focus_scope_test.dart) —
+//!   `canRequestFocus: false` gates only the node it is set on, not its
+//!   descendants — [`child_of_an_unfocusable_focus_can_still_get_focus`].
+//! - `'descendantsAreFocusable works as expected.'` (focus_scope_test.dart) —
+//!   the inverse gate: `descendantsAreFocusable: false` blocks every
+//!   descendant while leaving the node's own eligibility alone —
+//!   [`descendants_are_focusable_gates_descendants_not_the_node_itself`].
+//! - `'canRequestFocus causes descendants of scope to be skipped.'`
+//!   (focus_scope_test.dart) — **Adapted and split in two**: node-level
+//!   against `FocusNode`/`FocusScopeNode` directly (the oracle's widget tree
+//!   only supplies node references via `GlobalKey`), and trimmed to one
+//!   scope level (the oracle's outer `scope1` layer asserts the identical
+//!   scope-level contract `scope2` already covers). A plain `Focus`'s own
+//!   `canRequestFocus: false` does **not** restrict its descendants —
+//!   [`can_request_focus_on_a_plain_focus_does_not_restrict_its_descendants`]
+//!   — but a **scope**'s does, because a scope additionally gates whether it
+//!   allows descendant focus at all —
+//!   [`can_request_focus_on_a_scope_restricts_its_descendants`].
+//! - `'Nodes are removed when all Focuses are removed.'`
+//!   (focus_scope_test.dart) — focus node lifecycle: unmounting detaches the
+//!   node and releases the focus it held. **Adapted**: the oracle's
+//!   `rootScope.descendants, hasLength(2)` counts Flutter's baseline
+//!   traversal-group nodes, which FLUI has no equivalent of; ported as
+//!   "detached and unfocused" instead of an exact count —
+//!   [`nodes_are_removed_when_all_focuses_are_removed`].
+//! - `'FocusManager notifies listeners when a widget loses focus because it
+//!   was removed.'` (focus_manager_test.dart) — removing the focused
+//!   widget's node notifies exactly once, and the survivor does not inherit
+//!   focus —
+//!   [`removing_a_focused_node_notifies_listeners_exactly_once_without_transferring_focus`].
+//! - `'Focus changes notify listeners.'` (focus_manager_test.dart) —
+//!   **Adapted**: the oracle's `child1→child2→child1` burst collapses to one
+//!   notification because Flutter batches focus changes to end-of-frame;
+//!   FLUI's `FocusManager` notifies synchronously per call (module doc,
+//!   ADR-0022) — ported as two synchronous notifications instead of one
+//!   batched one, with the divergence stated inline —
+//!   [`focus_changes_notify_listeners_on_each_synchronous_request`].
+//!
+//! ## Not ported
+//! - `Focus.of`/`Focus.maybeOf`/`FocusScope.of` (ambient lookup) and every
+//!   case whose only role for them is obtaining a node reference — already
+//!   documented not-ported in `interaction/focus.rs`'s module doc; a direct
+//!   node/scope reference stands in wherever the case is otherwise portable
+//!   (see *Adapted* notes above).
+//! - `'Setting first focus requests focus for the scope properly.'`,
+//!   `'Can move focus in and out of FocusScope'`, `'Moving widget from one
+//!   scope to another retains focus'`, `'Moving FocusScopeNodes retains
+//!   focus'`, and the `isFirstFocus`/pinned-`GlobalKey` cases — Flutter's
+//!   `FocusScopeNode.setFirstFocus`/`isFirstFocus` designate which child a
+//!   parent scope restores focus to; FLUI's `FocusScopeNode::set_first_focus`
+//!   instead focuses the first *traversable* descendant directly and has no
+//!   restore-priority concept. The underlying "reparenting preserves primary
+//!   focus" invariant these lean on is already covered node-level by
+//!   `flui-interaction`'s `adopt_preserves_primary_focus_across_a_reparent`.
+//! - `'Autofocus works with global key reparenting'`, `"Doesn't lose focused
+//!   child when reparenting if the nearestScope doesn't change."` — FLUI's
+//!   reparent path is `did_change_dependencies`-driven (ADR-0022), not
+//!   `GlobalKey` cross-parent teleport; same underlying invariant as above.
+//! - `'node detached before autofocus is applied'`, `'works when the
+//!   previous focused node is detached'` — edge cases in Flutter's two-phase
+//!   `FocusAttachment.attach`/`.reparent()` lifecycle, which FLUI's
+//!   single-phase `attach_node` does not reproduce.
+//! - `'Setting canRequestFocus on focus node causes update.'` — a rebuild
+//!   bookkeeping check with no distinct FLUI behavior beyond what
+//!   `a_rebuild_resets_dropped_focus_config` (`interaction/focus.rs`) already
+//!   exercises.
+//! - `'skipTraversal works as expected.'`, `'descendantsAreTraversable works
+//!   as expected.'` — `skipTraversal` is already covered
+//!   (`a_rebuild_resets_dropped_focus_config`,
+//!   `a_skip_traversal_cursor_still_steps_to_the_node_after_it` in
+//!   `flui-interaction`); `descendantsAreTraversable` has no FLUI node-layer
+//!   flag (documented not-ported in `interaction/focus.rs`).
+//! - `'Focus updates the onKey handler...'` (legacy `onKey`) — legacy
+//!   `onKey` is not ported. The modern `onKeyEvent` half is covered by
+//!   `a_rebuild_resets_dropped_focus_config`.
+//! - `'Focus passes changes in attribute values to its focus node'` —
+//!   covered by `a_rebuild_resets_dropped_focus_config`.
+//! - `'Focus widgets set Semantics information about focus'`, `"Focus
+//!   doesn't introduce a Semantics node when includeSemantics is false"`,
+//!   `"ExcludeFocus doesn't introduce a Semantics node"`, `'Focus widget
+//!   gains input focus when it gains accessibility focus'` — no semantics-
+//!   layer integration for `Focus` yet (`includeSemantics` documented
+//!   not-ported).
+//! - `'Initial highlight mode guesses correctly.'` and the other
+//!   `FocusHighlightMode` cases — `FocusHighlightMode` (mouse/keyboard/touch
+//!   interaction-mode heuristic) is not implemented in FLUI.
+//! - `'Scopes can be focused without sending focus to descendants.'` — no
+//!   FLUI scenario distinct from `can_focus_the_root_scope_directly`, which
+//!   already proves a scope alone can hold primary focus with no descendant
+//!   involved.
+//! - `hasAGoodToStringDeep`/`toStringDeep`/`debugDescribeFocusTree`/
+//!   `debugFillProperties`/`debugFocusChanges` cases — no `Diagnosticable`
+//!   tree-dump equivalent for the focus tree.
+//! - `'Ancestors get notified exactly as often as needed if focused child
+//!   changes focus.'` — the dedup-on-edges contract this pins is already
+//!   covered widget-level by `on_focus_change_reports_gain_and_loss`
+//!   (`interaction/focus.rs`).
+//! - `'Unfocus with disposition previouslyFocusedChild works properly'`,
+//!   `'...disposition scope...'`, `'Unfocus works properly when some nodes
+//!   are unfocusable'` — `UnfocusDisposition` has no FLUI equivalent;
+//!   `FocusManager::unfocus`/`FocusNode::unfocus` always clear to `None`.
+//!   Adding a disposition parameter is a new public-API decision, out of
+//!   this test-port's bounds.
+//! - `'Removing a FocusScope removes its node from the tree'` — already
+//!   fully exercised widget-level by
+//!   `a_focus_widget_attaches_under_the_nearest_scope_and_unmount_releases`
+//!   (`interaction/focus.rs`), which the citation was added to instead.
+//! - `'Autofocus works'` (focus_scope_test.dart) and `'Can autofocus a
+//!   node.'` — the mount-time half is already covered by
+//!   `a_focus_widget_attaches_under_the_nearest_scope_and_unmount_releases`;
+//!   the rebuild-time half (`autofocus` flipping `false` → `true` on an
+//!   already-mounted node) exposed a real gap, fixed alongside this port and
+//!   pinned by the new `a_rebuild_that_turns_on_autofocus_requests_focus`
+//!   unit test (both in `interaction/focus.rs`).
+//! - `"Won't autofocus a node if one is already focused."` — already
+//!   exercised by `autofocus_yields_to_an_already_focused_scope`
+//!   (`interaction/focus.rs`), which the citation was added to instead.
+//! - `"Descendants of ExcludeFocus aren't focusable."`, `"ExcludeFocus
+//!   doesn't transfer focus to another descendant."` — already exercised by
+//!   `exclude_focus_refuses_allows_evicts_idempotently_and_does_not_refocus`
+//!   (`interaction/focus.rs`), which the citations were added to instead.
+//! - `'Requesting focus before adding to tree results in a request after
+//!   adding'` (focus_manager_test.dart) — a real gap (`FocusNode::request_focus`
+//!   was an unconditional no-op while unattached), fixed alongside this port
+//!   in `flui-interaction` and pinned by
+//!   `request_focus_before_attach_is_granted_on_attach` +
+//!   `a_pending_request_dropped_by_can_request_focus_does_not_linger`
+//!   (`crates/flui-interaction/src/routing/focus_scope.rs`).
+//! - `focus_traversal_test.dart` as a whole — its `FocusTraversalGroup` /
+//!   per-subtree traversal-**policy**-selection widget does not exist in
+//!   FLUI (traversal itself — `FocusManager::focus_next`/`focus_previous`
+//!   against `ReadingOrderPolicy` — is implemented and extensively covered
+//!   node-level in `flui-interaction` and widget-level by
+//!   `tab_traversal_follows_geometry_not_attach_order`,
+//!   `interaction/focus.rs`).
+//! - `'FocusScope does not crash at zero area'`, `'Focus does not crash at
+//!   zero area'` — a physical-size-zero layout/paint edge case orthogonal to
+//!   focus semantics, not meaningfully portable without a platform-size
+//!   harness.
+//! - `"FocusScope doesn't update the focusNode attributes when the widget
+//!   updates if withExternalFocusNode is used"` — exercises legacy `onKey`
+//!   (not ported) and `descendantsAreTraversable` (no FLUI flag); the
+//!   `onKeyEvent`/`descendantsAreFocusable` half is covered by
+//!   `a_rebuild_resets_dropped_focus_config`.
+//! - `'Focus.of stops at the nearest Focus widget.'`, `'Can traverse Focus
+//!   children.'` — `Focus.of` is not ported; the traversal-ordering half of
+//!   the latter is covered by `tab_traversal_follows_geometry_not_attach_order`.
+//! - `'Can set focus.'` — redundant with `'Can focus'` (ported) plus
+//!   `on_focus_change` coverage already in `interaction/focus.rs`.
+//!
+//! Widget → node mapping: `Focus` → `FocusNode`, `FocusScope` →
+//! `FocusScopeNode`, both via `flui-interaction`'s `routing` module.
+
+use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use flui_interaction::{FocusManager, FocusNode, FocusScopeNode};
+use flui_widgets::prelude::*;
+use flui_widgets::{Column, Focus, FocusScope, SizedBox};
+use parking_lot::Mutex;
+
+use crate::common::{lay_out, loose};
+
+/// Conservatively serializes this file's focus fixtures on top of
+/// `FocusManager::global()`'s owner-thread singleton — see the module doc.
+static FOCUS_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// A leaf big enough to mount without tripping any zero-size edge case, and
+/// otherwise inert — geometry is not what these tests assert about.
+fn leaf() -> SizedBox {
+    SizedBox::new(10.0, 10.0)
+}
+
+// ============================================================================
+// Reusable fixtures
+// ============================================================================
+
+/// Zero, one, or two `Focus` widgets (each driving its own external node) in
+/// a `Column`, with no explicit `FocusScope` wrapper — matching the bare
+/// `Column(children: [TestFocus, TestFocus])` shape most `focus_scope_test
+/// .dart`/`focus_manager_test.dart` cases mount. Falls back to
+/// `FocusManager::global().root_scope()` (`Focus`'s own documented fallback).
+///
+/// Both `Column` slots are always present — a hidden slot renders an inert
+/// placeholder rather than being omitted from the list. `Column`'s
+/// reconciliation is positional: omitting a slot would shift the survivor
+/// into the removed slot's *position*, reusing that position's existing
+/// `Focus` element (and its `FocusState`, which keeps its original node —
+/// external nodes are read once, see `Focus::focus_node`'s doc) instead of
+/// actually unmounting the node this fixture means to remove.
+#[derive(Clone, StatelessView)]
+struct TwoFocusHost {
+    a: Arc<FocusNode>,
+    b: Arc<FocusNode>,
+    show_a: bool,
+    show_b: bool,
+    a_autofocus: bool,
+    b_autofocus: bool,
+}
+
+impl StatelessView for TwoFocusHost {
+    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+        let slot_a: BoxedView = if self.show_a {
+            Focus::new(leaf())
+                .focus_node(Arc::clone(&self.a))
+                .autofocus(self.a_autofocus)
+                .into_view()
+                .boxed()
+        } else {
+            leaf().into_view().boxed()
+        };
+        let slot_b: BoxedView = if self.show_b {
+            Focus::new(leaf())
+                .focus_node(Arc::clone(&self.b))
+                .autofocus(self.b_autofocus)
+                .into_view()
+                .boxed()
+        } else {
+            leaf().into_view().boxed()
+        };
+        Column::new(vec![slot_a, slot_b])
+    }
+}
+
+/// A parent `FocusScope` whose child scope is present only when
+/// `show_child` is set — `'Adding a new FocusScope attaches the child to its
+/// parent.'`'s shape.
+#[derive(Clone, StatelessView)]
+struct NestedScopeHost {
+    parent: Arc<FocusScopeNode>,
+    child: Arc<FocusScopeNode>,
+    show_child: bool,
+}
+
+impl StatelessView for NestedScopeHost {
+    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+        let inner: BoxedView = if self.show_child {
+            FocusScope::with_external_node(Arc::clone(&self.child), leaf())
+                .into_view()
+                .boxed()
+        } else {
+            leaf().into_view().boxed()
+        };
+        FocusScope::with_external_node(Arc::clone(&self.parent), inner)
+    }
+}
+
+// ============================================================================
+// Node-level cases (focus_manager_test.dart style)
+// ============================================================================
+
+/// Oracle: `'Can add children to scope and focus'` (focus_manager_test.dart).
+///
+/// `hasFocus` (this node or any descendant) vs `hasPrimaryFocus` (this node
+/// specifically) on a `scope > parent > {child1, child2}` chain, switching
+/// which child holds focus.
+#[test]
+fn can_add_children_to_scope_and_focus_contrasts_has_focus_and_has_primary_focus() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let scope = FocusScopeNode::with_debug_label("add-children-scope");
+    manager.root_scope().attach_node(scope.as_focus_node());
+    let parent = FocusNode::with_debug_label("parent");
+    scope.attach_node(&parent);
+    let child1 = FocusNode::with_debug_label("child1");
+    parent.attach_node(&child1);
+    let child2 = FocusNode::with_debug_label("child2");
+    parent.attach_node(&child2);
+
+    child1.request_focus();
+    assert_eq!(scope.focused_child(), Some(child1.id()));
+    assert!(
+        parent.has_focus(),
+        "an ancestor of the focused node reports hasFocus"
+    );
+    assert!(
+        !parent.has_primary_focus(),
+        "but not hasPrimaryFocus — it isn't the focused node itself"
+    );
+    assert!(child1.has_focus());
+    assert!(child1.has_primary_focus());
+    assert!(!child2.has_focus());
+    assert!(!child2.has_primary_focus());
+
+    child2.request_focus();
+    assert_eq!(scope.focused_child(), Some(child2.id()));
+    assert!(parent.has_focus());
+    assert!(!parent.has_primary_focus());
+    assert!(!child1.has_focus());
+    assert!(!child1.has_primary_focus());
+    assert!(child2.has_focus());
+    assert!(child2.has_primary_focus());
+
+    manager.unfocus();
+    manager.root_scope().detach_node(scope.as_focus_node().id());
+}
+
+/// Oracle: `'Can focus root node.'` (focus_scope_test.dart).
+///
+/// Adapted: node-level — the oracle mounts a `Focus` widget only to reach
+/// `FocusScope.of(element)`; FLUI has no ambient lookup (module doc), so the
+/// root scope's own backing node is exercised directly.
+#[test]
+fn can_focus_the_root_scope_directly() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let root = manager.root_scope().as_focus_node();
+    root.request_focus();
+
+    assert!(root.has_primary_focus(), "the root scope itself can focus");
+
+    manager.unfocus();
+}
+
+/// Oracle: `'Focus changes notify listeners.'` (focus_manager_test.dart).
+///
+/// Adapted: the oracle's `child1.requestFocus(); child2.requestFocus();
+/// child1.requestFocus();` burst collapses to one `notifyCount` because
+/// Flutter batches focus changes to end-of-frame (`applyFocusChangesIfNeeded`).
+/// FLUI's `FocusManager` notifies synchronously per call (module doc,
+/// ADR-0022) — ported as two synchronous notifications for the two real
+/// changes, not Flutter's one batched notification.
+#[test]
+fn focus_changes_notify_listeners_on_each_synchronous_request() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let scope = FocusScopeNode::with_debug_label("notify-scope");
+    manager.root_scope().attach_node(scope.as_focus_node());
+    let child1 = FocusNode::with_debug_label("child1");
+    scope.attach_node(&child1);
+    let child2 = FocusNode::with_debug_label("child2");
+    scope.attach_node(&child2);
+
+    let notify_count = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&notify_count);
+    let listener_id = manager.add_listener(Rc::new(move |_previous, _new| {
+        counter.fetch_add(1, Ordering::SeqCst);
+    }));
+
+    child1.request_focus();
+    assert_eq!(notify_count.load(Ordering::SeqCst), 1);
+
+    notify_count.store(0, Ordering::SeqCst);
+    child2.request_focus();
+    child1.request_focus();
+    assert_eq!(
+        notify_count.load(Ordering::SeqCst),
+        2,
+        "two real focus changes, notified synchronously per change — not \
+         batched into Flutter's single end-of-frame notification"
+    );
+
+    notify_count.store(0, Ordering::SeqCst);
+    child1.unfocus();
+    assert_eq!(notify_count.load(Ordering::SeqCst), 1);
+
+    manager.remove_listener(listener_id);
+    manager.unfocus();
+    manager.root_scope().detach_node(scope.as_focus_node().id());
+}
+
+/// Oracle: `'canRequestFocus causes descendants of scope to be skipped.'`
+/// (focus_scope_test.dart), the plain-`Focus` half.
+///
+/// Adapted: node-level, trimmed to one `Focus` level (the oracle nests a
+/// second, `focus2`, under `focus1`; one level already shows the contrast).
+/// A plain `FocusNode`'s own `canRequestFocus: false` gates only itself.
+#[test]
+fn can_request_focus_on_a_plain_focus_does_not_restrict_its_descendants() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let scope = FocusScopeNode::with_debug_label("plain-gate-scope");
+    manager.root_scope().attach_node(scope.as_focus_node());
+    let focus1 = FocusNode::with_debug_label("focus1");
+    scope.attach_node(&focus1);
+    let focus2 = FocusNode::with_debug_label("focus2");
+    focus1.attach_node(&focus2);
+
+    focus1.set_can_request_focus(false);
+    focus2.request_focus();
+
+    assert!(
+        focus2.has_primary_focus(),
+        "an ancestor Focus's canRequestFocus(false) does not restrict a descendant"
+    );
+
+    manager.unfocus();
+    manager.root_scope().detach_node(scope.as_focus_node().id());
+}
+
+/// Oracle: `'canRequestFocus causes descendants of scope to be skipped.'`
+/// (focus_scope_test.dart), the scope half — see the module doc's *Adapted*
+/// note for what was trimmed.
+///
+/// A **scope**'s own `canRequestFocus: false` gates every descendant, not
+/// just itself — the contrast with the plain-`Focus` case above.
+#[test]
+fn can_request_focus_on_a_scope_restricts_its_descendants() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let scope = FocusScopeNode::with_debug_label("scope-gate-scope");
+    manager.root_scope().attach_node(scope.as_focus_node());
+    let focus1 = FocusNode::with_debug_label("focus1");
+    scope.attach_node(&focus1);
+    let focus2 = FocusNode::with_debug_label("focus2");
+    focus1.attach_node(&focus2);
+
+    scope.as_focus_node().set_can_request_focus(false);
+    focus2.request_focus();
+
+    assert!(
+        !focus2.has_primary_focus(),
+        "the scope's own canRequestFocus(false) blocks every descendant"
+    );
+    assert_eq!(manager.primary_focus(), None);
+
+    scope.as_focus_node().set_can_request_focus(true);
+    focus2.request_focus();
+
+    assert!(
+        focus2.has_primary_focus(),
+        "re-enabling the scope restores descendant focus"
+    );
+
+    manager.unfocus();
+    manager.root_scope().detach_node(scope.as_focus_node().id());
+}
+
+// ============================================================================
+// Widget-mounted cases (focus_scope_test.dart / focus_manager_test.dart style)
+// ============================================================================
+
+/// Oracle: `'Can focus'` (focus_scope_test.dart).
+#[test]
+fn can_focus_via_request_focus() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let a = FocusNode::with_debug_label("a");
+    let b = FocusNode::with_debug_label("b");
+    let _laid = lay_out(
+        TwoFocusHost {
+            a: Arc::clone(&a),
+            b: Arc::clone(&b),
+            show_a: true,
+            show_b: false,
+            a_autofocus: false,
+            b_autofocus: false,
+        },
+        loose(200.0),
+    );
+
+    assert!(!a.has_focus(), "not focused before the request");
+    a.request_focus();
+
+    assert!(a.has_focus());
+
+    manager.unfocus();
+    manager.root_scope().detach_node(a.id());
+}
+
+/// Oracle: `'Can unfocus'` (focus_scope_test.dart) — focus gain/loss
+/// ordering: focusing sibling B unfocuses sibling A.
+#[test]
+fn can_unfocus_by_focusing_a_sibling() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let a = FocusNode::with_debug_label("a");
+    let b = FocusNode::with_debug_label("b");
+    let _laid = lay_out(
+        TwoFocusHost {
+            a: Arc::clone(&a),
+            b: Arc::clone(&b),
+            show_a: true,
+            show_b: true,
+            a_autofocus: false,
+            b_autofocus: false,
+        },
+        loose(200.0),
+    );
+
+    a.request_focus();
+    assert!(a.has_focus());
+    assert!(!b.has_focus());
+
+    b.request_focus();
+    assert!(!a.has_focus(), "focusing b unfocuses a");
+    assert!(b.has_focus());
+
+    manager.unfocus();
+    manager.root_scope().detach_node(a.id());
+    manager.root_scope().detach_node(b.id());
+}
+
+/// Oracle: `'Can have multiple focused children and they update accordingly'`
+/// (focus_scope_test.dart) — autofocus on mount, then focus toggles back and
+/// forth between the two siblings.
+#[test]
+fn multiple_focused_children_update_accordingly_as_focus_moves_between_siblings() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let a = FocusNode::with_debug_label("a");
+    let b = FocusNode::with_debug_label("b");
+    let _laid = lay_out(
+        TwoFocusHost {
+            a: Arc::clone(&a),
+            b: Arc::clone(&b),
+            show_a: true,
+            show_b: true,
+            a_autofocus: true,
+            b_autofocus: false,
+        },
+        loose(200.0),
+    );
+
+    assert!(a.has_focus(), "autofocus landed on mount");
+    assert!(!b.has_focus());
+
+    b.request_focus();
+    assert!(!a.has_focus());
+    assert!(b.has_focus());
+
+    a.request_focus();
+    assert!(a.has_focus());
+    assert!(!b.has_focus());
+
+    manager.unfocus();
+    manager.root_scope().detach_node(a.id());
+    manager.root_scope().detach_node(b.id());
+}
+
+/// Oracle: `'Removing focused widget moves focus to next widget'`
+/// (focus_scope_test.dart). Despite the name, the assertion is that the
+/// survivor does **not** inherit focus — a dispose-while-focused lifecycle
+/// case.
+#[test]
+fn removing_the_focused_widget_does_not_transfer_focus_to_the_survivor() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let a = FocusNode::with_debug_label("a");
+    let b = FocusNode::with_debug_label("b");
+    let mut laid = lay_out(
+        TwoFocusHost {
+            a: Arc::clone(&a),
+            b: Arc::clone(&b),
+            show_a: true,
+            show_b: true,
+            a_autofocus: false,
+            b_autofocus: false,
+        },
+        loose(200.0),
+    );
+
+    a.request_focus();
+    assert!(a.has_focus());
+    assert!(!b.has_focus());
+
+    laid.pump_widget(TwoFocusHost {
+        a: Arc::clone(&a),
+        b: Arc::clone(&b),
+        show_a: false,
+        show_b: true,
+        a_autofocus: false,
+        b_autofocus: false,
+    });
+
+    assert!(!a.is_attached(), "a's widget was removed");
+    assert!(
+        !b.has_focus(),
+        "b does not inherit the focus a's removal released"
+    );
+
+    manager.unfocus();
+    manager.root_scope().detach_node(b.id());
+}
+
+/// Oracle: `"Removing focused widget doesn't move focus to next widget
+/// within FocusScope"` (focus_scope_test.dart) — the explicit-`FocusScope`
+/// variant of the case above.
+#[test]
+fn removing_the_focused_widget_within_a_scope_does_not_transfer_focus() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let scope = FocusScopeNode::with_debug_label("removal-scope");
+    let a = FocusNode::with_debug_label("a");
+    let b = FocusNode::with_debug_label("b");
+
+    // Both `Column` slots stay present (see `TwoFocusHost`'s doc for why an
+    // omitted slot would let the survivor reuse the removed slot's element).
+    #[derive(Clone, StatelessView)]
+    struct ScopedTwoFocusHost {
+        scope: Arc<FocusScopeNode>,
+        a: Arc<FocusNode>,
+        b: Arc<FocusNode>,
+        show_a: bool,
+    }
+    impl StatelessView for ScopedTwoFocusHost {
+        fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+            let slot_a: BoxedView = if self.show_a {
+                Focus::new(leaf())
+                    .focus_node(Arc::clone(&self.a))
+                    .into_view()
+                    .boxed()
+            } else {
+                leaf().into_view().boxed()
+            };
+            let slot_b: BoxedView = Focus::new(leaf())
+                .focus_node(Arc::clone(&self.b))
+                .into_view()
+                .boxed();
+            FocusScope::with_external_node(
+                Arc::clone(&self.scope),
+                Column::new(vec![slot_a, slot_b]),
+            )
+        }
+    }
+
+    let mut laid = lay_out(
+        ScopedTwoFocusHost {
+            scope: Arc::clone(&scope),
+            a: Arc::clone(&a),
+            b: Arc::clone(&b),
+            show_a: true,
+        },
+        loose(200.0),
+    );
+
+    a.request_focus();
+    manager.set_active_scope(Some(Arc::clone(&scope)));
+    assert!(a.has_focus());
+
+    laid.pump_widget(ScopedTwoFocusHost {
+        scope: Arc::clone(&scope),
+        a: Arc::clone(&a),
+        b: Arc::clone(&b),
+        show_a: false,
+    });
+
+    assert!(!a.is_attached());
+    assert!(
+        !b.has_focus(),
+        "b does not inherit the focus a's removal released, even inside the scope"
+    );
+
+    manager.unfocus();
+    manager.set_active_scope(None);
+    manager.root_scope().detach_node(scope.as_focus_node().id());
+}
+
+/// Oracle: `'Adding a new FocusScope attaches the child to its parent.'`
+/// (focus_scope_test.dart) — FocusScope node capture: a child scope added on
+/// a later rebuild attaches under the parent scope's node.
+#[test]
+fn adding_a_new_focus_scope_attaches_its_node_under_the_parent_scope() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let parent_scope = FocusScopeNode::with_debug_label("parent-scope");
+    let child_scope = FocusScopeNode::with_debug_label("child-scope");
+    let mut laid = lay_out(
+        NestedScopeHost {
+            parent: Arc::clone(&parent_scope),
+            child: Arc::clone(&child_scope),
+            show_child: false,
+        },
+        loose(200.0),
+    );
+
+    assert!(
+        !child_scope.as_focus_node().is_attached(),
+        "the child scope is not yet in the tree"
+    );
+
+    laid.pump_widget(NestedScopeHost {
+        parent: Arc::clone(&parent_scope),
+        child: Arc::clone(&child_scope),
+        show_child: true,
+    });
+
+    assert_eq!(
+        child_scope.as_focus_node().parent().map(|node| node.id()),
+        Some(parent_scope.as_focus_node().id()),
+        "the child scope now hangs under the parent scope's node"
+    );
+
+    manager.unfocus();
+    manager
+        .root_scope()
+        .detach_node(parent_scope.as_focus_node().id());
+}
+
+/// Oracle: `'Focus is ignored when set to not focusable.'`
+/// (focus_scope_test.dart).
+#[test]
+fn focus_is_ignored_when_not_focusable() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let node = FocusNode::with_debug_label("unfocusable");
+    let got_focus = Arc::new(Mutex::new(Vec::<bool>::new()));
+    let recorded = Arc::clone(&got_focus);
+    let root = Focus::new(leaf())
+        .focus_node(Arc::clone(&node))
+        .can_request_focus(false)
+        .on_focus_change(move |focused| recorded.lock().push(focused));
+    let _laid = lay_out(root, loose(200.0));
+
+    node.request_focus();
+
+    assert!(got_focus.lock().is_empty(), "on_focus_change never fires");
+    assert!(!node.has_focus());
+
+    manager.unfocus();
+    manager.root_scope().detach_node(node.id());
+}
+
+/// Oracle: `'Focus is lost when set to not focusable.'`
+/// (focus_scope_test.dart) — exercises the `FocusNode::set_can_request_focus`
+/// fix landed alongside this port (see this crate's module doc): flipping
+/// `canRequestFocus` to `false` on a rebuild now releases focus the node
+/// currently holds, matching Flutter's setter semantics.
+#[test]
+fn focus_is_lost_when_set_to_not_focusable_mid_focus() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    #[derive(Clone, StatelessView)]
+    struct Host {
+        node: Arc<FocusNode>,
+        can_request_focus: bool,
+        on_focus_change: Rc<dyn Fn(bool)>,
+    }
+    impl StatelessView for Host {
+        fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+            let handler = Rc::clone(&self.on_focus_change);
+            Focus::new(leaf())
+                .focus_node(Arc::clone(&self.node))
+                .autofocus(true)
+                .can_request_focus(self.can_request_focus)
+                .on_focus_change(move |focused| handler(focused))
+        }
+    }
+
+    let node = FocusNode::with_debug_label("was-focusable");
+    let got_focus = Arc::new(Mutex::new(Vec::<bool>::new()));
+    let recorded = Arc::clone(&got_focus);
+    let mut laid = lay_out(
+        Host {
+            node: Arc::clone(&node),
+            can_request_focus: true,
+            on_focus_change: Rc::new(move |focused| recorded.lock().push(focused)),
+        },
+        loose(200.0),
+    );
+
+    assert!(node.has_focus(), "autofocus landed on mount");
+    assert_eq!(got_focus.lock().as_slice(), [true]);
+    got_focus.lock().clear();
+
+    laid.pump_widget(Host {
+        node: Arc::clone(&node),
+        can_request_focus: false,
+        on_focus_change: Rc::new(move |_focused| {}),
+    });
+
+    assert!(
+        !node.has_focus(),
+        "flipping canRequestFocus false released the focus this node held"
+    );
+
+    manager.unfocus();
+    manager.root_scope().detach_node(node.id());
+}
+
+/// Oracle: `'Child of unfocusable Focus can get focus.'`
+/// (focus_scope_test.dart) — `canRequestFocus: false` gates only the node it
+/// is set on, not its descendants.
+#[test]
+fn child_of_an_unfocusable_focus_can_still_get_focus() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let outer = FocusNode::with_debug_label("outer-unfocusable");
+    let inner = FocusNode::with_debug_label("inner");
+    let root = Focus::new(Focus::new(leaf()).focus_node(Arc::clone(&inner)))
+        .focus_node(Arc::clone(&outer))
+        .can_request_focus(false);
+    let _laid = lay_out(root, loose(200.0));
+
+    outer.request_focus();
+    assert!(!outer.has_focus(), "the unfocusable outer refuses");
+
+    inner.request_focus();
+    assert!(
+        inner.has_focus(),
+        "its child is not gated by the parent's canRequestFocus"
+    );
+    assert!(
+        outer.has_focus(),
+        "the outer now reports hasFocus transitively, through the focused child"
+    );
+
+    manager.unfocus();
+    manager.root_scope().detach_node(outer.id());
+}
+
+/// Oracle: `'descendantsAreFocusable works as expected.'`
+/// (focus_scope_test.dart) — the inverse gate from the case above:
+/// `descendantsAreFocusable: false` blocks every descendant while leaving
+/// the node's own eligibility alone.
+#[test]
+fn descendants_are_focusable_gates_descendants_not_the_node_itself() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let outer = FocusNode::with_debug_label("blocks-descendants");
+    let inner = FocusNode::with_debug_label("blocked-descendant");
+    let root = Focus::new(Focus::new(leaf()).focus_node(Arc::clone(&inner)))
+        .focus_node(Arc::clone(&outer))
+        .descendants_are_focusable(false);
+    let _laid = lay_out(root, loose(200.0));
+
+    inner.request_focus();
+    assert!(
+        !inner.has_focus(),
+        "descendantsAreFocusable(false) blocks the descendant's request"
+    );
+
+    outer.request_focus();
+    assert!(
+        outer.has_focus(),
+        "the node's own eligibility is untouched by its descendants-are-focusable flag"
+    );
+
+    manager.unfocus();
+    manager.root_scope().detach_node(outer.id());
+}
+
+/// Oracle: `'Nodes are removed when all Focuses are removed.'`
+/// (focus_scope_test.dart) — focus node lifecycle: unmounting detaches the
+/// node and releases the focus it held.
+///
+/// Adapted: the oracle's `rootScope.descendants, hasLength(2)` counts
+/// Flutter's baseline traversal-group/view-scope nodes, which FLUI's
+/// simpler, single-phase attach model has no equivalent of; ported as
+/// "detached and unfocused" rather than an exact descendant count.
+#[test]
+fn nodes_are_removed_when_all_focuses_are_removed() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    // A stable root TYPE that toggles its shape internally — `pump_widget`
+    // dispatches by `TypeId`, so swapping between two *different* concrete
+    // root widget types is not the supported way to unmount a subtree (see
+    // `LaidOut::pump_widget`'s doc); `show` is.
+    #[derive(Clone, StatelessView)]
+    struct SoloFocusHost {
+        scope: Arc<FocusScopeNode>,
+        node: Arc<FocusNode>,
+        on_focus_change: Rc<dyn Fn(bool)>,
+        show: bool,
+    }
+    impl StatelessView for SoloFocusHost {
+        fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+            if !self.show {
+                return leaf().into_view().boxed();
+            }
+            let handler = Rc::clone(&self.on_focus_change);
+            FocusScope::with_external_node(
+                Arc::clone(&self.scope),
+                Focus::new(leaf())
+                    .focus_node(Arc::clone(&self.node))
+                    .on_focus_change(move |focused| handler(focused)),
+            )
+            .into_view()
+            .boxed()
+        }
+    }
+
+    let node = FocusNode::with_debug_label("solo");
+    let scope = FocusScopeNode::with_debug_label("solo-scope");
+    let got_focus = Arc::new(Mutex::new(Vec::<bool>::new()));
+    let recorded = Arc::clone(&got_focus);
+    let mut laid = lay_out(
+        SoloFocusHost {
+            scope: Arc::clone(&scope),
+            node: Arc::clone(&node),
+            on_focus_change: Rc::new(move |focused| recorded.lock().push(focused)),
+            show: true,
+        },
+        loose(200.0),
+    );
+
+    node.request_focus();
+    laid.tick();
+    assert!(node.has_focus());
+    assert_eq!(got_focus.lock().as_slice(), [true]);
+
+    laid.pump_widget(SoloFocusHost {
+        scope: Arc::clone(&scope),
+        node: Arc::clone(&node),
+        on_focus_change: Rc::new(|_focused| {}),
+        show: false,
+    });
+
+    assert!(!node.is_attached(), "unmounting detached the node");
+    assert_eq!(
+        manager.primary_focus(),
+        None,
+        "a disposed focused widget releases the primary focus"
+    );
+
+    manager.unfocus();
+}
+
+/// Oracle: `'FocusManager notifies listeners when a widget loses focus
+/// because it was removed.'` (focus_manager_test.dart) — removing the
+/// focused widget's node notifies exactly once, and the survivor does not
+/// inherit focus.
+#[test]
+fn removing_a_focused_node_notifies_listeners_exactly_once_without_transferring_focus() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let a = FocusNode::with_debug_label("a");
+    let b = FocusNode::with_debug_label("b");
+    let mut laid = lay_out(
+        TwoFocusHost {
+            a: Arc::clone(&a),
+            b: Arc::clone(&b),
+            show_a: true,
+            show_b: true,
+            a_autofocus: false,
+            b_autofocus: false,
+        },
+        loose(200.0),
+    );
+
+    a.request_focus();
+    assert!(a.has_focus());
+
+    let notify_count = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&notify_count);
+    let listener_id = manager.add_listener(Rc::new(move |_previous, _new| {
+        counter.fetch_add(1, Ordering::SeqCst);
+    }));
+
+    laid.pump_widget(TwoFocusHost {
+        a: Arc::clone(&a),
+        b: Arc::clone(&b),
+        show_a: false,
+        show_b: true,
+        a_autofocus: false,
+        b_autofocus: false,
+    });
+
+    assert_eq!(
+        notify_count.load(Ordering::SeqCst),
+        1,
+        "removing the focused node's widget notifies exactly once"
+    );
+    assert!(!a.has_focus());
+    assert!(
+        !b.has_focus(),
+        "the survivor does not inherit the released focus"
+    );
+
+    manager.remove_listener(listener_id);
+    manager.unfocus();
+    manager.root_scope().detach_node(b.id());
+}

--- a/crates/flui-widgets/tests/parity/focus_test.rs
+++ b/crates/flui-widgets/tests/parity/focus_test.rs
@@ -88,11 +88,19 @@
 //!   against `FocusNode`/`FocusScopeNode` directly (the oracle's widget tree
 //!   only supplies node references via `GlobalKey`), and trimmed to one
 //!   scope level (the oracle's outer `scope1` layer asserts the identical
-//!   scope-level contract `scope2` already covers). A plain `Focus`'s own
-//!   `canRequestFocus: false` does **not** restrict its descendants —
+//!   scope-level contract `scope2` already covers) at the oracle's own
+//!   `focus1`-holds-`focus2` depth. Dropped from the oracle: the redundant
+//!   outer `scope1` sub-case; the `unfocus()`-then-refocus round-trip inside
+//!   the plain-Focus-ancestor sub-case; and re-mounting a whole widget tree
+//!   per state (each kept assertion runs directly against the current node
+//!   state instead). Kept: a plain `Focus`'s own `canRequestFocus: false`
+//!   does **not** restrict its descendants —
 //!   [`can_request_focus_on_a_plain_focus_does_not_restrict_its_descendants`]
-//!   — but a **scope**'s does, because a scope additionally gates whether it
-//!   allows descendant focus at all —
+//!   — but a **scope**'s does, in both directions the oracle checks:
+//!   disabling it before a descendant requests refuses the request, and
+//!   disabling it *while* a descendant already holds focus evicts that
+//!   focus (the oracle's `pumpTest(allowScope2: false)` step, checked while
+//!   `focus2` held focus) — and re-enabling restores descendant focus —
 //!   [`can_request_focus_on_a_scope_restricts_its_descendants`].
 //! - `'Nodes are removed when all Focuses are removed.'`
 //!   (focus_scope_test.dart) — focus node lifecycle: unmounting detaches the
@@ -477,10 +485,20 @@ fn can_request_focus_on_a_plain_focus_does_not_restrict_its_descendants() {
 
 /// Oracle: `'canRequestFocus causes descendants of scope to be skipped.'`
 /// (focus_scope_test.dart), the scope half — see the module doc's *Adapted*
-/// note for what was trimmed.
+/// note for what was trimmed and kept.
 ///
 /// A **scope**'s own `canRequestFocus: false` gates every descendant, not
-/// just itself — the contrast with the plain-`Focus` case above.
+/// just itself — the contrast with the plain-`Focus` case above — in both
+/// directions the oracle checks: refusing a fresh request while disabled,
+/// AND evicting a descendant's *already-held* focus the moment the scope is
+/// disabled (the oracle's `pumpTest(allowScope2: false)` step, checked while
+/// `focus2` held focus — `FocusNode.canRequestFocus`'s setter,
+/// `focus_manager.dart`, checks `hasFocus`, not `hasPrimaryFocus`, so a
+/// scope's own eviction reaches a focused descendant, not just itself).
+///
+/// Red-check (verified): before `FocusNode::set_can_request_focus` also
+/// checked `is_scope() && has_focus()`, the mid-focus disable left `focus2`
+/// focused and the eviction assertion failed.
 #[test]
 fn can_request_focus_on_a_scope_restricts_its_descendants() {
     let _guard = FOCUS_TEST_LOCK.lock();
@@ -494,9 +512,24 @@ fn can_request_focus_on_a_scope_restricts_its_descendants() {
     let focus2 = FocusNode::with_debug_label("focus2");
     focus1.attach_node(&focus2);
 
-    scope.as_focus_node().set_can_request_focus(false);
+    // `focus2` already holds focus when the scope is disabled — the
+    // mid-focus eviction case.
     focus2.request_focus();
+    assert!(
+        focus2.has_primary_focus(),
+        "sanity: focus2 is focused first"
+    );
 
+    scope.as_focus_node().set_can_request_focus(false);
+
+    assert!(
+        !focus2.has_focus(),
+        "disabling the scope evicts the descendant's already-held focus"
+    );
+    assert_eq!(manager.primary_focus(), None);
+
+    // While still disabled, a fresh request is refused too.
+    focus2.request_focus();
     assert!(
         !focus2.has_primary_focus(),
         "the scope's own canRequestFocus(false) blocks every descendant"
@@ -858,15 +891,21 @@ fn focus_is_lost_when_set_to_not_focusable_mid_focus() {
     assert_eq!(got_focus.lock().as_slice(), [true]);
     got_focus.lock().clear();
 
+    let recorded = Arc::clone(&got_focus);
     laid.pump_widget(Host {
         node: Arc::clone(&node),
         can_request_focus: false,
-        on_focus_change: Rc::new(move |_focused| {}),
+        on_focus_change: Rc::new(move |focused| recorded.lock().push(focused)),
     });
 
     assert!(
         !node.has_focus(),
         "flipping canRequestFocus false released the focus this node held"
+    );
+    assert_eq!(
+        got_focus.lock().as_slice(),
+        [false],
+        "on_focus_change reports the loss, matching the oracle's `expect(gotFocus, false)`"
     );
 
     manager.unfocus();

--- a/crates/flui-widgets/tests/parity/main.rs
+++ b/crates/flui-widgets/tests/parity/main.rs
@@ -71,3 +71,6 @@ mod heroes_test;
 
 // ── Catalog.1 — theming + localizations substrate ────────────────────────────
 mod localizations_test;
+
+// ── Business.1 fidelity front — Focus/FocusScope parity (family 4) ──────────
+mod focus_test;


### PR DESCRIPTION
Business.1 fidelity unit: the focus family joins the parity corpus — 17 ported cases in `parity/focus_test.rs` plus 5 upstream cases satisfied by adding citations to existing overlapping unit tests (~23 upstream cases addressed), against `focus_manager_test.dart`/`focus_scope_test.dart` @ 3.44.0. Every case cited by upstream test name + tag; every out-of-scope case listed with its reason (no ambient `Focus.of`, no `setFirstFocus` restore-priority, no `UnfocusDisposition`, traversal-group widget absent, etc.).

## Three real divergences found and fixed (RED→GREEN each)

1. **`FocusNode::request_focus()` was a no-op while unattached** — now defers and is granted on attach, matching `_doRequestFocus`'s defer-when-unparented + flag consumption on reparent; the pending flag lives on the node, so a node dropped before attach drops the request with it (no leak, no dead-node fire — pinned).
2. **`set_can_request_focus(false)` didn't release held focus** — now unfocuses per the oracle's `canRequestFocus` setter. The review caught the subtle half: Flutter checks `hasFocus`, so a **scope** disabled mid-focus evicts its focused *descendant*, while a plain node keeps the primary-focus-only approximation (Flutter's disposition net-restores the descendant — documented). Both directions mutation-pinned: dropping the eviction fails the scope test; dropping the `is_scope` gate fails the plain-node test. `EditableText`'s compensating manual-unfocus workaround became redundant and was removed (its pinning test unchanged).
3. **Autofocus only fired from `init_state`** — a rebuild flipping `autofocus` false→true now makes the one-shot request (Flutter's `didUpdateWidget` guard shape).

## Evidence

- `cargo nextest run --workspace --exclude flui-platform`: 7493+ passed; clippy `-D warnings`, fmt/port-check/inventory/taplo/typos, doctests: clean.
- Reviewer independently re-ran three fix-revert mutants plus the inverse plain-node mutant across two rounds; oracle assertions diffed case-by-case against the upstream `expect()` lists (one trimmed assertion was caught masking the scope divergence and restored).
- Full review + delta re-review: SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)