### PR TITLE
test(widgets): port Flutter's Shortcuts/Actions test corpus and fix a resolution bug

### DIFF
--- a/crates/flui-widgets/src/interaction/actions.rs
+++ b/crates/flui-widgets/src/interaction/actions.rs
@@ -13,12 +13,17 @@
 //! # The Rust shape (ADR-0023)
 //!
 //! Flutter keys its map by the intent's runtime `Type` and walks
-//! `_ActionsScope` ancestors at invoke time. FLUI keys by [`TypeId`] and
-//! **chains at provide time**: each `Actions` widget layers its own map over
-//! the enclosing chain, so one nearest-provider lookup sees, per intent type,
-//! the same ordered candidates Flutter's walk would visit — nearest first,
-//! first *enabled* one wins, a disabled nearer action falls through to an
-//! enabled outer one exactly as `maybeInvoke` continues its walk.
+//! `_ActionsScope` ancestors at invoke time, **stopping at the first scope
+//! whose own map declares the intent's type at all** — enabled or not
+//! (`_castAction`/`_visitActionsAncestors`, `:736-753`, `:920-931`).
+//! `maybeInvoke`'s own doc is explicit: "If a suitable Action is found but its
+//! `isEnabled` returns false, the search will stop" (`:993-995`) — a disabled
+//! mapping does **not** fall through to an enclosing scope's mapping for the
+//! same type. FLUI keys by [`TypeId`] and **chains at provide time**: each
+//! `Actions` widget layers its own map over the enclosing chain, so one
+//! nearest-provider lookup sees, per intent type, the single entry Flutter's
+//! walk would stop at — the nearest declaring scope's action, whether enabled
+//! or not.
 //!
 //! The erasure (`TypeId` key + `dyn Any` downcast inside the typed wrapper)
 //! is the same shape as the one sanctioned `Navigator` pop-result boundary
@@ -80,8 +85,11 @@ pub enum ActionOutcome {
 /// `Action<T>` (`actions.dart:135`).
 pub trait Action<T: Intent> {
     /// Whether this action can run for `intent` right now (`:267`). A
-    /// disabled action lets resolution fall through to an enclosing
-    /// [`Actions`] scope, as Flutter's walk does.
+    /// disabled action stops resolution **at this scope** — it does not fall
+    /// through to an enclosing [`Actions`] scope's mapping for the same
+    /// intent type, matching `maybeInvoke`'s documented contract that the
+    /// search stops the moment a scope declares the type, enabled or not
+    /// (`actions.dart:993-995`).
     fn is_enabled(&self, intent: &T) -> bool {
         let _ = intent;
         true
@@ -204,18 +212,24 @@ impl ErasedAction {
     }
 }
 
-/// Per intent type, the candidate actions in resolution order — nearest
-/// `Actions` scope first. What Flutter's ancestor walk visits, precomputed at
-/// provide time.
-pub(crate) type ActionChain = Rc<HashMap<TypeId, Vec<ErasedAction>>>;
+/// Per intent type, the action bound by the **nearest** `Actions` scope that
+/// declares it — the single entry Flutter's ancestor walk would stop at
+/// (`_castAction`/`_visitActionsAncestors`, `actions.dart:736-753`,
+/// `:920-931`), precomputed at provide time. A nearer scope's mapping
+/// entirely replaces an enclosing scope's mapping for the same type; there is
+/// no fallback list to search past it.
+pub(crate) type ActionChain = Rc<HashMap<TypeId, ErasedAction>>;
 
-/// The first **enabled** action for `intent` in `chain` — `Actions.maybeInvoke`'s
-/// walk-until-enabled (`actions.dart:1032-1044`).
+/// The action bound to `intent`'s type, if its nearest declaring scope's
+/// mapping is enabled — `Actions.maybeInvoke`'s walk, which **stops** the
+/// moment a scope declares the type, whether or not that mapping is enabled
+/// (`actions.dart:1032-1044`, doc at `:993-995`: "If a suitable Action is
+/// found but its `isEnabled` returns false, the search will stop"). A
+/// disabled nearest mapping therefore returns `None` here rather than
+/// falling through to an enclosing scope's mapping for the same type.
 pub(crate) fn resolve<'c>(chain: &'c ActionChain, intent: &dyn Any) -> Option<&'c ErasedAction> {
-    chain
-        .get(&intent.type_id())?
-        .iter()
-        .find(|action| action.is_enabled(intent))
+    let action = chain.get(&intent.type_id())?;
+    action.is_enabled(intent).then_some(action)
 }
 
 // ============================================================================
@@ -225,10 +239,13 @@ pub(crate) fn resolve<'c>(chain: &'c ActionChain, intent: &dyn Any) -> Option<&'
 /// Binds intent types to [`Action`]s for a subtree — Flutter's `Actions`
 /// (`actions.dart:729`).
 ///
-/// Resolution is nearest-scope-first with fall-through past disabled actions,
-/// as Flutter's ancestor walk resolves (`:1032-1044`). Invoke with
-/// [`Actions::maybe_invoke`] from build-time code, or let a
-/// [`Shortcuts`](crate::Shortcuts) dispatch into it from the keyboard.
+/// Resolution stops at the **nearest** scope that declares a mapping for the
+/// intent's type — enabled or not — exactly as Flutter's ancestor walk
+/// resolves and its own doc states (`:1032-1044`, `:993-995`): a disabled
+/// nearer mapping is not skipped in favor of an enclosing scope's mapping for
+/// the same type. Invoke with [`Actions::maybe_invoke`] from build-time code,
+/// or let a [`Shortcuts`](crate::Shortcuts) dispatch into it from the
+/// keyboard.
 #[derive(Clone)]
 pub struct Actions {
     own: Vec<(TypeId, ErasedAction)>,
@@ -244,8 +261,10 @@ impl Actions {
         }
     }
 
-    /// Bind intent type `T` to `action`. A binding nearer the invoker shadows
-    /// an enclosing one — unless disabled, which falls through.
+    /// Bind intent type `T` to `action`. A binding nearer the invoker
+    /// entirely shadows an enclosing one for the same type — even when
+    /// `action` turns out disabled, since Flutter's walk stops at the
+    /// nearest declaring scope regardless of its enabled state.
     #[must_use]
     pub fn action<T: Intent>(mut self, action: impl Action<T> + 'static) -> Self {
         self.own
@@ -253,10 +272,10 @@ impl Actions {
         self
     }
 
-    /// Find the first enabled action for `intent` — nearest scope first — and
-    /// invoke it. Returns whether one ran. Flutter's `Actions.maybeInvoke`
-    /// (`actions.dart:1032-1044`), minus the result value (dropped on the key
-    /// path anyway, `:348-349`).
+    /// Resolve `intent`'s type to its nearest declaring scope's action and, if
+    /// enabled, invoke it. Returns whether one ran. Flutter's
+    /// `Actions.maybeInvoke` (`actions.dart:1032-1044`), minus the result
+    /// value (dropped on the key path anyway, `:348-349`).
     pub fn maybe_invoke<T: Intent>(ctx: &dyn BuildContext, intent: &T) -> bool {
         let Some(chain) = ambient_action_chain(ctx) else {
             return false;
@@ -287,13 +306,19 @@ impl View for Actions {
 
 impl StatelessView for Actions {
     /// Layer this widget's bindings over the enclosing chain: own actions
-    /// **prepend** per type, so the nearest scope resolves first.
+    /// **replace** the enclosing entry per type, so the nearest scope's
+    /// mapping is the only one a lookup ever sees — matching Flutter's walk,
+    /// which stops at the nearest scope that declares the type at all
+    /// (`actions.dart:920-931`). A type this widget does not declare keeps
+    /// falling back to whatever the enclosing chain already had. If `own`
+    /// binds the same type twice, the later call wins, same as a duplicate
+    /// key in Flutter's `Map<Type, Action<Intent>>` literal.
     fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
-        let mut chain: HashMap<TypeId, Vec<ErasedAction>> = ambient_action_chain(ctx)
+        let mut chain: HashMap<TypeId, ErasedAction> = ambient_action_chain(ctx)
             .map(|enclosing| (*enclosing).clone())
             .unwrap_or_default();
-        for (type_id, action) in self.own.iter().rev() {
-            chain.entry(*type_id).or_default().insert(0, action.clone());
+        for (type_id, action) in &self.own {
+            chain.insert(*type_id, action.clone());
         }
         ActionChainProvider {
             chain: Rc::new(chain),
@@ -398,6 +423,13 @@ mod tests {
     ///
     /// Red-check: resolve from the raw own-map instead of the layered chain —
     /// the outer counter moves and the inner assertion flips.
+    ///
+    /// Flutter parity (`actions_test.dart`, tag `3.44.0`): covers
+    /// `'Actions widget can invoke actions with default dispatcher'` and
+    /// `'Actions widget can invoke actions with default dispatcher and
+    /// maybeInvoke'` — FLUI has one dispatch path (no replaceable
+    /// `ActionDispatcher`, ADR-0023 deferred), so both oracle cases collapse
+    /// onto this one.
     #[test]
     fn the_nearest_enabled_action_wins_and_receives_the_payload() {
         let ran = Arc::new(AtomicUsize::new(0));
@@ -434,6 +466,8 @@ mod tests {
         );
     }
 
+    /// Flutter parity (`actions_test.dart`, tag `3.44.0`): stands in for
+    /// `'CallbackAction passes correct intent when invoked.'`.
     #[test]
     fn callback_action_accepts_owner_local_rc_state() {
         let ran = Arc::new(AtomicUsize::new(0));
@@ -454,12 +488,22 @@ mod tests {
         assert_eq!(total.get(), 11, "owner-local callback captured Rc<Cell<_>>");
     }
 
-    /// A **disabled** nearer action falls through to an enabled outer one —
-    /// Flutter's walk continues past scopes whose action is disabled
-    /// (`actions.dart:1032-1044`). A plain nearest-map merge would shadow the
-    /// outer action and invoke nothing.
+    /// A **disabled** nearer action stops resolution at its own scope — it
+    /// does *not* fall through to an outer scope's mapping for the same
+    /// intent type. This is Flutter's actual contract, not the inverse:
+    /// `Actions.maybeInvoke`'s own doc states "If a suitable Action is found
+    /// but its `isEnabled` returns false, the search will stop"
+    /// (`actions.dart:993-995`) — the walk stops at the first scope that
+    /// *declares* the type at all, whether or not it is enabled, and never
+    /// reaches the outer action.
+    ///
+    /// Red-check: merge `own` into the enclosing chain as a fallback list
+    /// instead of an outright replace (i.e. keep the outer entry reachable
+    /// once the inner one is checked) — `outer_sum` becomes `7` and `ran`
+    /// becomes `1`, silently reintroducing the fall-through this test pins
+    /// against.
     #[test]
-    fn a_disabled_nearer_action_falls_through_to_the_outer_scope() {
+    fn a_disabled_nearer_action_stops_resolution_at_its_own_scope() {
         let ran = Arc::new(AtomicUsize::new(0));
         let outer_sum = Arc::new(AtomicUsize::new(0));
 
@@ -477,15 +521,24 @@ mod tests {
             })),
         );
 
-        assert_eq!(ran.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            ran.load(Ordering::SeqCst),
+            0,
+            "maybe_invoke reported false: the disabled nearer mapping stopped the search"
+        );
         assert_eq!(
             outer_sum.load(Ordering::SeqCst),
-            7,
-            "resolution fell through the disabled nearer action"
+            0,
+            "the outer action was never reached, let alone invoked"
         );
     }
 
     /// No binding anywhere: `maybe_invoke` reports `false` and nothing runs.
+    ///
+    /// Flutter parity (`actions_test.dart`, tag `3.44.0`): stands in for
+    /// `'maybeInvoke returns null when no action is found'` — FLUI's
+    /// `maybe_invoke` reports "did anything run" as a `bool` rather than
+    /// Dart's `Object?`, so "returns null" ports as "returns `false`".
     #[test]
     fn maybe_invoke_without_a_binding_reports_false() {
         let ran = Arc::new(AtomicUsize::new(0));

--- a/crates/flui-widgets/src/interaction/shortcuts.rs
+++ b/crates/flui-widgets/src/interaction/shortcuts.rs
@@ -336,6 +336,20 @@ mod tests {
     /// (`shortcuts.dart:560-565`): Ctrl+C matches Ctrl+C only — not bare C,
     /// not Ctrl+Shift+C — and never a key-up. Repeats match unless opted out
     /// (`:461`, `:576-581`).
+    ///
+    /// Flutter parity (`shortcuts_test.dart`, tag `3.44.0`, `SingleActivator`
+    /// group): this single assertion set covers what that oracle spreads
+    /// across five separate `testWidgets` cases exercising the same
+    /// per-event exact-modifier-match contract through a real
+    /// `HardwareKeyboard` pressed-key simulator instead of direct
+    /// `KeyEvent` construction — `'isActivatedBy works as expected'`,
+    /// `'handles Ctrl-C'`, `'handles repeated events'`, `'rejects repeated
+    /// events if requested'`, `'handles Shift-Ctrl-C'`. Not duplicated here:
+    /// FLUI's `SingleActivator::matches` reads modifiers straight off the
+    /// event it is given, so the oracle's own multi-key press/release
+    /// *sequencing* (physical Ctrl held across several key events) has no
+    /// separate code path to pin — each event's modifier snapshot is all
+    /// `matches` ever sees.
     #[test]
     fn single_activator_matches_exact_modifiers_only() {
         let ctrl_c = SingleActivator::character("c").control();
@@ -593,6 +607,14 @@ mod intent_tests {
     /// maps a `NotPerformed` outcome to `SkipRemainingHandlers`
     /// (`actions.dart:312-314`): the action runs, but the event reports
     /// unconsumed and stops bubbling.
+    ///
+    /// Flutter parity (`actions_test.dart`, tag `3.44.0`): stands in for
+    /// `'Base Action class default toKeyEventResult delegates to
+    /// consumesKey'`. **Adapted, documented divergence**: Flutter splits the
+    /// question across two independently overridable methods,
+    /// `consumesKey`/`toKeyEventResult`, which can disagree; FLUI collapsed
+    /// them into the one method this test exercises (ADR-0023/ADR-0026) —
+    /// there is no separate `consumes_key` to assert delegates to anything.
     #[test]
     fn a_non_consuming_action_runs_but_leaves_the_event_unconsumed() {
         // An action that runs but changes nothing declines the key, so the

--- a/crates/flui-widgets/tests/parity/main.rs
+++ b/crates/flui-widgets/tests/parity/main.rs
@@ -74,3 +74,6 @@ mod localizations_test;
 
 // ── Business.1 fidelity front — Focus/FocusScope parity (family 4) ──────────
 mod focus_test;
+
+// ── Business.1 fidelity front — Shortcuts/Actions parity (family 5) ─────────
+mod shortcuts_test;

--- a/crates/flui-widgets/tests/parity/shortcuts_test.rs
+++ b/crates/flui-widgets/tests/parity/shortcuts_test.rs
@@ -1,0 +1,624 @@
+//! ## Test parity notes
+//!
+//! Flutter source: `packages/flutter/test/widgets/shortcuts_test.dart` and
+//! `.../actions_test.dart` (tag `3.44.0`).
+//!
+//! FLUI's `Shortcuts`/`CallbackShortcuts`/`SingleActivator`
+//! (`crates/flui-widgets/src/interaction/shortcuts.rs`) and
+//! `Actions`/`Intent`/`Action`/`CallbackAction`
+//! (`crates/flui-widgets/src/interaction/actions.rs`) already carry a
+//! substantial self-authored unit-test suite pinning ADR-0023's bubbling
+//! key-dispatch design end to end. This file's job is different, matching
+//! this crate's `navigator_test.rs`/`focus_test.rs` precedent: every case
+//! below is anchored to a **named upstream Flutter test**. Where a case is
+//! already fully exercised by an existing self-authored test, the citation
+//! was added there instead of duplicating it here (see each function's doc
+//! comment in `interaction/shortcuts.rs`/`interaction/actions.rs`).
+//!
+//! `FocusManager::global()` is an owner-thread (thread-local) singleton;
+//! nextest's libtest runner reuses OS threads across many `#[test]`
+//! functions in this binary, so every key-dispatching case below takes
+//! [`SHORTCUTS_TEST_LOCK`] and explicitly `unfocus()`s whatever it attached
+//! — the same convention `focus_test.rs` documents and uses.
+//!
+//! ## Ported cases
+//! - `'trigger on key events'` (`CallbackShortcuts` group) — two independent
+//!   bindings on one `CallbackShortcuts`, each firing only for its own key —
+//!   [`callback_shortcuts_trigger_on_matching_key_events_only`].
+//! - `'nested CallbackShortcuts stop propagation'` — an inner
+//!   `CallbackShortcuts` binding the same key as an outer one consumes the
+//!   event first; the outer never sees it —
+//!   [`nested_callback_shortcuts_the_inner_consuming_binding_stops_the_outer`].
+//! - `'non-overlapping nested CallbackShortcuts fire appropriately'` — each
+//!   nested `CallbackShortcuts` reacts only to its own key, and a key the
+//!   inner ignores still bubbles to the outer —
+//!   [`non_overlapping_nested_callback_shortcuts_each_fire_for_their_own_key`].
+//!   **Adapted**: the oracle uses `CharacterActivator` (not ported, no
+//!   consumer yet — ADR-0023); `SingleActivator::character` serves the same
+//!   "bind by produced character" role for this case.
+//! - `'Works correctly with Shortcuts too'` (`CallbackShortcuts` group) — a
+//!   `CallbackShortcuts` nested with an `Intent`-mapped `Shortcuts`/`Actions`
+//!   pair: the innermost `CallbackShortcuts` consumes its key before
+//!   `Shortcuts` ever sees it, and `Shortcuts` resolving its intent consumes
+//!   the key before it can bubble to the outermost `CallbackShortcuts` —
+//!   [`callback_shortcuts_interoperate_with_a_nested_shortcuts_actions_pair`].
+//!   **Adapted**: `CharacterActivator` → `SingleActivator::character`, same
+//!   substitution as above.
+//! - `"Shortcuts passes to the next Shortcuts widget if it doesn't map the
+//!   key"` — an inner `Shortcuts` with no matching binding lets the key
+//!   bubble past it to an outer `Shortcuts` that does map it —
+//!   [`an_unmatched_key_bubbles_past_an_inner_shortcuts_to_an_outer_one`].
+//!   **Adapted**: the oracle roots the outer `Shortcuts` on a
+//!   `Shortcuts.manager` (a shared `ShortcutManager`, not ported — ADR-0023)
+//!   with `Actions` sitting *between* the two `Shortcuts` widgets. FLUI's
+//!   `Shortcuts` resolves its `Actions` chain from its own position, not the
+//!   focused leaf's (ADR-0023's documented resolve-at-own-position
+//!   divergence — see `tab_tests` in `interaction/shortcuts.rs`), so `Actions`
+//!   must wrap *both* `Shortcuts` widgets here instead of sitting between
+//!   them, or the outer `Shortcuts` would resolve against no chain at all.
+//!   The bubbling assertion this test exists to pin — an unmapped key
+//!   passing an inner `Shortcuts` to reach an outer one — is unaffected by
+//!   where `Actions` sits.
+//! - `'Disabled actions stop propagation to an ancestor'` — **the divergence
+//!   this port found**: a nearer `Actions` scope's mapping for an intent
+//!   type, if disabled, stops resolution outright rather than falling
+//!   through to an enclosing scope's mapping for the same type. FLUI's
+//!   `Actions::resolve` shipped with the opposite behavior (a Vec-of-
+//!   candidates walk that skipped disabled entries down to an enabled outer
+//!   one) — traced to a misreading of `_visitActionsAncestors`/`_castAction`
+//!   recorded in ADR-0023; `maybeInvoke`'s own doc is explicit that the
+//!   search stops the moment a scope declares the type, enabled or not
+//!   (`actions.dart:993-995`). Fixed alongside this port:
+//!   `ActionChain` is now one candidate per type (a nearer scope's mapping
+//!   *replaces* an enclosing one), not a fallback list — see the ADR-0023
+//!   correction note and `interaction/actions.rs`'s
+//!   `a_disabled_nearer_action_stops_resolution_at_its_own_scope` for the
+//!   internal-unit-test half of this fix. This file's version is an
+//!   independent, oracle-named regression pin against the same behavior —
+//!   [`a_disabled_action_stops_propagation_to_an_ancestor_scope`].
+//!   **Adapted**: no `ActionDispatcher`/`Actions.invoke` static API (ADR-0023
+//!   deferred); ported through `Actions::maybe_invoke` from a probe widget's
+//!   `build`, which is the same "does resolution stop here" question the
+//!   oracle's `Actions.invoke` asks.
+//! - `'Actions can invoke actions in ancestor dispatcher'` — the fix's other
+//!   branch: a nearer scope that declares **no** mapping for the intent type
+//!   at all still lets resolution continue to an enclosing scope's mapping
+//!   (only a *declared* mapping stops the walk) —
+//!   [`an_intent_undeclared_at_the_nearer_scope_resolves_from_the_ancestor`].
+//!   Paired with the disabled-action case above per this port's mutation
+//!   discipline: one pins each side of `resolve`'s "found but disabled" vs.
+//!   "not found here" branch. **Adapted**: same `ActionDispatcher` substitution
+//!   as above.
+//!
+//! ## Not ported
+//! - `LogicalKeySet` group (`test('LogicalKeySet passes parameters
+//!   correctly.')`, `'... works as a map key.'`, `'.hashCode is stable'`,
+//!   `'.hashCode is order-independent'`, `'.diagnostics work.'`, `'handles
+//!   two keys'`, the three `numLock works as expected...` cases) —
+//!   `LogicalKeySet`'s exact-pressed-set semantics need a
+//!   `HardwareKeyboard`-style pressed-key tracker FLUI does not have;
+//!   documented not-ported in `interaction/shortcuts.rs`'s module doc
+//!   (ADR-0023). `SingleActivator` covers the catalog's real uses.
+//! - `CharacterActivator` group (`'is triggered on events with correct
+//!   character'`, `'handles repeated events'`, `'rejects repeated events if
+//!   requested'`, `'handles Alt, Ctrl and Meta'`, `'isActivatedBy works as
+//!   expected'`, its diagnostics case) — `CharacterActivator` itself waits
+//!   for a consumer (ADR-0023); the two `CallbackShortcuts` ports above
+//!   substitute `SingleActivator::character` where the oracle's own case
+//!   only needs "bind by produced character", not `CharacterActivator`'s
+//!   shift-insensitivity.
+//! - `ShortcutManager`/`Shortcuts.manager` group (`'Default constructed
+//!   Shortcuts has empty shortcuts'`, `'Default constructed Shortcuts.manager
+//!   has empty shortcuts'`, `'Shortcuts.manager passes on shortcuts'`,
+//!   `'ShortcutManager handles shortcuts'`, `'Shortcuts.manager lets manager
+//!   handle shortcuts'`, `'ShortcutManager ignores key presses with no
+//!   primary focus'`, its object-creation leak-tracker case) — a shared,
+//!   externally-constructed `ShortcutManager` is not ported; FLUI's
+//!   `Shortcuts` is one manager per widget (ADR-0023, named not-ported).
+//! - `'Shortcuts can disable a shortcut with Intent.doNothing'` — depends on
+//!   `Shortcuts.manager` plus a `WidgetsApp` host; not ported (see above).
+//! - `"Shortcuts that aren't bound to an action don't absorb keys meant for
+//!   text fields"`, `'Shortcuts that are bound to an action do override text
+//!   fields'`, `'Shortcuts can override intents that apply to text fields'`
+//!   (plus its `DoNothingAndStopPropagationIntent` variant) — these pin
+//!   `WidgetsApp`'s default text-editing shortcut wiring and a
+//!   `TestTextField` fixture; FLUI has no default-text-shortcuts layer yet.
+//! - `'Shortcuts pass debug label to focus node.'` — FLUI's `Shortcuts`
+//!   hardcodes its own `debug_label("Shortcuts")` (see `shortcuts.rs`); there
+//!   is no per-instance override constructor parameter to port a distinct
+//!   assertion against, and no `Focus.of` ambient lookup (not ported) to
+//!   reach the node from a `BuildContext` the way the oracle does.
+//! - `'Shortcuts support multiple intents'` — exercises `PrioritizedIntents`,
+//!   `ScrollIntent`, a full `WidgetsApp`/`ListView`/`PrimaryScrollController`
+//!   stack; none of that machinery exists in FLUI yet.
+//! - `'Shortcuts support activators that returns null in triggers'` — a
+//!   custom `ShortcutActivator` implementation with nullable `triggers`;
+//!   FLUI's activator surface is the sealed `SingleActivator`, not a trait
+//!   third-party activators implement.
+//! - `'Shortcuts does not insert a semantics node when includeSemantics is
+//!   false'` — no semantics-layer integration for `Shortcuts` yet
+//!   (`includeSemantics`, ADR-0023 named not-ported).
+//! - `'Updating shortcuts triggers dependency rebuild'` — exercises
+//!   `ShortcutRegistrar`'s dependency-notification callback; not ported (see
+//!   `ShortcutRegistrar` group below).
+//! - `ShortcutRegistrar` group in full (`'trigger ShortcutRegistrar on key
+//!   events'`, `'WidgetsApp has a ShortcutRegistrar listening'`, `"doesn't
+//!   override text field shortcuts"`, `'nested ShortcutRegistrars stop
+//!   propagation'`, `'non-overlapping nested ShortcutRegistrars fire
+//!   appropriately'`, `'Works correctly with Shortcuts too'` (the
+//!   `ShortcutRegistrar` one), its object-creation case, `'using a disposed
+//!   token asserts'`, `'setting duplicate bindings asserts'`, `'sets debug
+//!   label on focus node'`) — `ShortcutRegistrar`/`ShortcutRegistryEntry` has
+//!   no FLUI equivalent (ADR-0023, named not-ported); no consumers yet.
+//! - `actions_test.dart`'s `ActionDispatcher`/`Actions.of`/`Actions.find`
+//!   group (`'ActionDispatcher invokes actions when asked.'`, the custom-
+//!   dispatcher cases, `'invoke throws when no action is found'`, `'Actions
+//!   widget can be found with of'`, `'Action can be found with find'`) — no
+//!   replaceable `ActionDispatcher` object, and no `Actions.of`/`Actions.find`
+//!   ambient lookups; FLUI's only entry points are `Actions::maybe_invoke`
+//!   and `Shortcuts`' own key dispatch (ADR-0023, named not-ported).
+//! - `FocusableActionDetector` group in full (both copies of `'keeps track of
+//!   focus and hover even when disabled.'`, `'changes mouse cursor when
+//!   hovered'`, `'can be used without callbacks'`, `'can prevent its
+//!   descendants from being focusable'`, `'... from being traversable'`,
+//!   `'can exclude Focus semantics'`) — `FocusableActionDetector` does not
+//!   exist in FLUI.
+//! - `'Actions.invoke returns the value of Action.invoke'`, `'ContextAction
+//!   can return null'` — FLUI's `Action::invoke` returns the fixed
+//!   [`ActionOutcome`] enum (ADR-0023/ADR-0026), not an arbitrary `Object?`;
+//!   there is no `ContextAction` variant.
+//! - `'can listen to enabled state of Actions'` — `Action.addActionListener`
+//!   is not ported (ADR-0023, named not-ported).
+//! - `'VoidCallbackAction'` — not implemented; the deferral note in
+//!   `interaction/actions.rs`'s module doc already names the workaround
+//!   (`CallbackAction::new(|_| ())`).
+//! - `'default Intent debugFillProperties'`, `'default Actions
+//!   debugFillProperties'`, `'Actions implements debugFillProperties'` — no
+//!   `Diagnosticable` tree-dump equivalent for `Intent`/`Actions`.
+//! - The overridable-action group in full (`'Basic usage'`, `'Does not break
+//!   after use'`, `'Does not override if not overridable'`, `'The final
+//!   override controls isEnabled'`, `'The override can choose to defer
+//!   isActionEnabled to the overridable'`, `'Throws on infinite recursions'`,
+//!   `'Throws on invoking invalid override'`, `'Make an overridable action
+//!   overridable'`, `'Overriding Actions can change the intent'`, `'Override
+//!   non-context overridable Actions with a ContextAction'`, `'Override a
+//!   ContextAction with a regular Action'`) — `Action.overridable`/
+//!   `OverridableAction`'s override-chain mechanism does not exist in FLUI;
+//!   adding it is a new public-API decision, out of this test-port's bounds.
+//!
+//! Widget mapping: `Shortcuts`/`CallbackShortcuts` → a
+//! `Focus(can_request_focus: false)` wrapper; `Actions` → an `InheritedView`
+//! scope layering an `ActionChain` (`interaction/actions.rs`).
+
+use std::cell::Cell;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use flui_interaction::events::{Key, KeyEvent, KeyState, Modifiers};
+use flui_interaction::routing::{FocusManager, FocusNode};
+use flui_view::element::ElementKind;
+use flui_widgets::prelude::*;
+use flui_widgets::{
+    Action, ActionOutcome, Actions, CallbackAction, CallbackShortcuts, Focus, Intent, Shortcuts,
+    SingleActivator, SizedBox,
+};
+use parking_lot::Mutex;
+
+use crate::common::{lay_out, loose};
+
+/// Conservatively serializes this file's key-dispatch fixtures on top of
+/// `FocusManager::global()`'s owner-thread singleton — see the module doc.
+static SHORTCUTS_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// A leaf big enough to mount without tripping a zero-size edge case, and
+/// otherwise inert — geometry is not what these tests assert about.
+fn leaf() -> SizedBox {
+    SizedBox::new(10.0, 10.0)
+}
+
+fn key_down(character: &str, modifiers: Modifiers) -> KeyEvent {
+    KeyEvent {
+        state: KeyState::Down,
+        key: Key::Character(character.into()),
+        modifiers,
+        ..KeyEvent::default()
+    }
+}
+
+fn key_up(character: &str, modifiers: Modifiers) -> KeyEvent {
+    KeyEvent {
+        state: KeyState::Up,
+        ..key_down(character, modifiers)
+    }
+}
+
+// ============================================================================
+// CallbackShortcuts
+// ============================================================================
+
+/// `'trigger on key events'` (`CallbackShortcuts` group, `shortcuts_test.dart`).
+#[test]
+fn callback_shortcuts_trigger_on_matching_key_events_only() {
+    let _guard = SHORTCUTS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let invoked_a = Rc::new(Cell::new(0));
+    let invoked_b = Rc::new(Cell::new(0));
+    let field = FocusNode::with_debug_label("two-binding-field");
+
+    let a_for_binding = Rc::clone(&invoked_a);
+    let b_for_binding = Rc::clone(&invoked_b);
+    let _laid = lay_out(
+        CallbackShortcuts::new(Focus::new(leaf()).focus_node(Arc::clone(&field)))
+            .binding(SingleActivator::character("a"), move || {
+                a_for_binding.set(a_for_binding.get() + 1);
+            })
+            .binding(SingleActivator::character("b"), move || {
+                b_for_binding.set(b_for_binding.get() + 1);
+            }),
+        loose(200.0),
+    );
+    field.request_focus();
+
+    assert!(manager.dispatch_key_event(&key_down("a", Modifiers::empty())));
+    assert_eq!(invoked_a.get(), 1);
+    assert_eq!(invoked_b.get(), 0);
+    assert!(!manager.dispatch_key_event(&key_up("a", Modifiers::empty())));
+    assert_eq!(invoked_a.get(), 1);
+    assert_eq!(invoked_b.get(), 0);
+
+    invoked_a.set(0);
+    invoked_b.set(0);
+    assert!(manager.dispatch_key_event(&key_down("b", Modifiers::empty())));
+    assert_eq!(invoked_a.get(), 0);
+    assert_eq!(invoked_b.get(), 1);
+    assert!(!manager.dispatch_key_event(&key_up("b", Modifiers::empty())));
+    assert_eq!(invoked_a.get(), 0);
+    assert_eq!(invoked_b.get(), 1);
+
+    manager.unfocus();
+}
+
+/// `'nested CallbackShortcuts stop propagation'` (`CallbackShortcuts` group,
+/// `shortcuts_test.dart`).
+#[test]
+fn nested_callback_shortcuts_the_inner_consuming_binding_stops_the_outer() {
+    let _guard = SHORTCUTS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let invoked_outer = Rc::new(Cell::new(0));
+    let invoked_inner = Rc::new(Cell::new(0));
+    let field = FocusNode::with_debug_label("nested-cs-stop-field");
+
+    let outer_for_binding = Rc::clone(&invoked_outer);
+    let inner_for_binding = Rc::clone(&invoked_inner);
+    let inner = CallbackShortcuts::new(Focus::new(leaf()).focus_node(Arc::clone(&field))).binding(
+        SingleActivator::character("a"),
+        move || {
+            inner_for_binding.set(inner_for_binding.get() + 1);
+        },
+    );
+    let _laid = lay_out(
+        CallbackShortcuts::new(inner).binding(SingleActivator::character("a"), move || {
+            outer_for_binding.set(outer_for_binding.get() + 1);
+        }),
+        loose(200.0),
+    );
+    field.request_focus();
+
+    assert!(manager.dispatch_key_event(&key_down("a", Modifiers::empty())));
+    assert_eq!(
+        invoked_outer.get(),
+        0,
+        "the inner binding consumed the key first"
+    );
+    assert_eq!(invoked_inner.get(), 1);
+
+    manager.unfocus();
+}
+
+/// `'non-overlapping nested CallbackShortcuts fire appropriately'`
+/// (`CallbackShortcuts` group, `shortcuts_test.dart`). **Adapted**:
+/// `CharacterActivator` → `SingleActivator::character` (see module doc).
+#[test]
+fn non_overlapping_nested_callback_shortcuts_each_fire_for_their_own_key() {
+    let _guard = SHORTCUTS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let invoked_outer = Rc::new(Cell::new(0));
+    let invoked_inner = Rc::new(Cell::new(0));
+    let field = FocusNode::with_debug_label("non-overlapping-cs-field");
+
+    let outer_for_binding = Rc::clone(&invoked_outer);
+    let inner_for_binding = Rc::clone(&invoked_inner);
+    let inner = CallbackShortcuts::new(Focus::new(leaf()).focus_node(Arc::clone(&field))).binding(
+        SingleActivator::character("a"),
+        move || {
+            inner_for_binding.set(inner_for_binding.get() + 1);
+        },
+    );
+    let _laid = lay_out(
+        CallbackShortcuts::new(inner).binding(SingleActivator::character("b"), move || {
+            outer_for_binding.set(outer_for_binding.get() + 1);
+        }),
+        loose(200.0),
+    );
+    field.request_focus();
+
+    assert!(manager.dispatch_key_event(&key_down("a", Modifiers::empty())));
+    assert_eq!(invoked_outer.get(), 0);
+    assert_eq!(invoked_inner.get(), 1);
+
+    assert!(manager.dispatch_key_event(&key_down("b", Modifiers::empty())));
+    assert_eq!(
+        invoked_outer.get(),
+        1,
+        "the inner CallbackShortcuts ignored 'b', so it bubbled to the outer"
+    );
+    assert_eq!(invoked_inner.get(), 1);
+
+    manager.unfocus();
+}
+
+/// `'Works correctly with Shortcuts too'` (`CallbackShortcuts` group,
+/// `shortcuts_test.dart`). **Adapted**: `CharacterActivator` →
+/// `SingleActivator::character` (see module doc).
+#[test]
+fn callback_shortcuts_interoperate_with_a_nested_shortcuts_actions_pair() {
+    struct TestIntentA;
+    impl Intent for TestIntentA {}
+    struct TestIntentB;
+    impl Intent for TestIntentB {}
+
+    let _guard = SHORTCUTS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let invoked_callback_a = Rc::new(Cell::new(0));
+    let invoked_callback_b = Rc::new(Cell::new(0));
+    let invoked_action_a = Arc::new(AtomicUsize::new(0));
+    let invoked_action_b = Arc::new(AtomicUsize::new(0));
+    let field = FocusNode::with_debug_label("cs-shortcuts-interop-field");
+
+    let cb_a = Rc::clone(&invoked_callback_a);
+    let cb_b = Rc::clone(&invoked_callback_b);
+    let act_a = Arc::clone(&invoked_action_a);
+    let act_b = Arc::clone(&invoked_action_b);
+
+    let innermost = CallbackShortcuts::new(Focus::new(leaf()).focus_node(Arc::clone(&field)))
+        .binding(SingleActivator::character("a"), move || {
+            cb_a.set(cb_a.get() + 1);
+        });
+    let shortcuts = Shortcuts::new(innermost)
+        .shortcut(SingleActivator::character("a"), TestIntentA)
+        .shortcut(SingleActivator::character("b"), TestIntentB);
+    let outer_callback =
+        CallbackShortcuts::new(shortcuts).binding(SingleActivator::character("b"), move || {
+            cb_b.set(cb_b.get() + 1);
+        });
+
+    let _laid = lay_out(
+        Actions::new(outer_callback)
+            .action(CallbackAction::new(move |_intent: &TestIntentA| {
+                act_a.fetch_add(1, Ordering::SeqCst);
+            }))
+            .action(CallbackAction::new(move |_intent: &TestIntentB| {
+                act_b.fetch_add(1, Ordering::SeqCst);
+            })),
+        loose(200.0),
+    );
+    field.request_focus();
+
+    assert!(manager.dispatch_key_event(&key_down("a", Modifiers::empty())));
+    assert_eq!(
+        invoked_callback_a.get(),
+        1,
+        "the innermost CallbackShortcuts consumed 'a' before Shortcuts ever saw it"
+    );
+    assert_eq!(invoked_callback_b.get(), 0);
+    assert_eq!(invoked_action_a.load(Ordering::SeqCst), 0);
+    assert_eq!(invoked_action_b.load(Ordering::SeqCst), 0);
+
+    invoked_callback_a.set(0);
+    invoked_callback_b.set(0);
+    invoked_action_a.store(0, Ordering::SeqCst);
+    invoked_action_b.store(0, Ordering::SeqCst);
+
+    assert!(manager.dispatch_key_event(&key_down("b", Modifiers::empty())));
+    assert_eq!(invoked_callback_a.get(), 0);
+    assert_eq!(
+        invoked_callback_b.get(),
+        0,
+        "Shortcuts consumed 'b' via TestIntentB before it could bubble to the outer CallbackShortcuts"
+    );
+    assert_eq!(invoked_action_a.load(Ordering::SeqCst), 0);
+    assert_eq!(invoked_action_b.load(Ordering::SeqCst), 1);
+
+    manager.unfocus();
+}
+
+// ============================================================================
+// Shortcuts
+// ============================================================================
+
+/// `"Shortcuts passes to the next Shortcuts widget if it doesn't map the
+/// key"` (`shortcuts_test.dart`). **Adapted**: see module doc — `Actions`
+/// wraps both `Shortcuts` widgets instead of sitting between them.
+#[test]
+fn an_unmatched_key_bubbles_past_an_inner_shortcuts_to_an_outer_one() {
+    struct OuterIntent;
+    impl Intent for OuterIntent {}
+    struct InnerIntent;
+    impl Intent for InnerIntent {}
+
+    let _guard = SHORTCUTS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let outer_invoked = Rc::new(Cell::new(0));
+    let inner_invoked = Rc::new(Cell::new(0));
+    let field = FocusNode::with_debug_label("nested-shortcuts-bubble-field");
+
+    let outer_for_action = Rc::clone(&outer_invoked);
+    let inner_for_action = Rc::clone(&inner_invoked);
+
+    let inner_shortcuts = Shortcuts::new(Focus::new(leaf()).focus_node(Arc::clone(&field)))
+        .shortcut(SingleActivator::character("z"), InnerIntent);
+    let outer_shortcuts = Shortcuts::new(inner_shortcuts)
+        .shortcut(SingleActivator::character("s").shift(), OuterIntent);
+
+    let _laid = lay_out(
+        Actions::new(outer_shortcuts)
+            .action(CallbackAction::new(move |_intent: &OuterIntent| {
+                outer_for_action.set(outer_for_action.get() + 1);
+            }))
+            .action(CallbackAction::new(move |_intent: &InnerIntent| {
+                inner_for_action.set(inner_for_action.get() + 1);
+            })),
+        loose(200.0),
+    );
+    field.request_focus();
+
+    assert!(
+        manager.dispatch_key_event(&key_down("s", Modifiers::SHIFT)),
+        "consumed by the outer Shortcuts"
+    );
+    assert_eq!(
+        outer_invoked.get(),
+        1,
+        "the key bubbled past the inner Shortcuts, which does not map it, to the outer one"
+    );
+    assert_eq!(
+        inner_invoked.get(),
+        0,
+        "the inner Shortcuts' own binding never matched"
+    );
+
+    manager.unfocus();
+}
+
+// ============================================================================
+// Actions — the resolution-stops-at-the-nearest-declaring-scope divergence
+// ============================================================================
+
+/// A leaf whose build invokes `TestIntent` through the ambient `Actions`
+/// chain — the only place a `BuildContext` exists to call
+/// [`Actions::maybe_invoke`]. Mirrors `interaction/actions.rs`'s own
+/// `InvokeProbe` test fixture, reimplemented here because that one is
+/// crate-private and this file is a separate, external test crate.
+#[derive(Clone)]
+struct InvokeProbe<T: Intent + Clone + 'static> {
+    intent: T,
+    ran: Rc<Cell<bool>>,
+}
+
+impl<T: Intent + Clone + 'static> View for InvokeProbe<T> {
+    fn create_element(&self) -> ElementKind {
+        ElementKind::stateless(self)
+    }
+}
+
+impl<T: Intent + Clone + 'static> StatelessView for InvokeProbe<T> {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        if Actions::maybe_invoke(ctx, &self.intent) {
+            self.ran.set(true);
+        }
+        SizedBox::new(1.0, 1.0)
+    }
+}
+
+/// `'Disabled actions stop propagation to an ancestor'` (`actions_test.dart`)
+/// — the divergence this port found and fixed; see the module doc's "Ported
+/// cases" entry and the ADR-0023 correction note.
+///
+/// Red-check: this exact assertion pair failed against the pre-fix
+/// `ActionChain` (a per-type `Vec<ErasedAction>` searched for the first
+/// *enabled* candidate across every declaring scope) — `ran` was `true` and
+/// `outer_ran` was `true`, because the disabled inner mapping was skipped in
+/// favor of the outer's enabled one. See `interaction/actions.rs`'s
+/// `a_disabled_nearer_action_stops_resolution_at_its_own_scope` for the
+/// mutation-verified internal half of this fix.
+#[test]
+fn a_disabled_action_stops_propagation_to_an_ancestor_scope() {
+    #[derive(Clone)]
+    struct TestIntent;
+    impl Intent for TestIntent {}
+
+    struct DisabledAction;
+    impl Action<TestIntent> for DisabledAction {
+        fn is_enabled(&self, _intent: &TestIntent) -> bool {
+            false
+        }
+        fn invoke(&self, _intent: &TestIntent) -> ActionOutcome {
+            unreachable!("BUG: a disabled action must never be invoked");
+        }
+    }
+
+    let ran = Rc::new(Cell::new(false));
+    let outer_ran = Rc::new(Cell::new(false));
+    let outer_for_action = Rc::clone(&outer_ran);
+
+    let _laid = lay_out(
+        Actions::new(
+            Actions::new(InvokeProbe {
+                intent: TestIntent,
+                ran: Rc::clone(&ran),
+            })
+            .action(DisabledAction),
+        )
+        .action(CallbackAction::new(move |_intent: &TestIntent| {
+            outer_for_action.set(true);
+        })),
+        loose(50.0),
+    );
+
+    assert!(
+        !ran.get(),
+        "maybe_invoke reported false: the disabled nearer mapping stopped the search"
+    );
+    assert!(
+        !outer_ran.get(),
+        "the outer action was never reached — maybeInvoke's own doc says the search \
+         stops once a scope declares the type, enabled or not (actions.dart:993-995)"
+    );
+}
+
+/// `'Actions can invoke actions in ancestor dispatcher'` (`actions_test.dart`)
+/// — the fix's other branch: a nearer scope declaring **no** mapping for the
+/// type (as opposed to a disabled one) still lets resolution reach the
+/// ancestor. Paired with
+/// [`a_disabled_action_stops_propagation_to_an_ancestor_scope`] per this
+/// port's mutation discipline — together they pin both branches of
+/// `resolve`'s "declared but disabled" vs. "not declared here" distinction.
+///
+/// Red-check: makes the merge in `Actions::build` skip inheriting the
+/// enclosing chain whenever `own` is non-empty (instead of only overwriting
+/// the types `own` actually declares) — `ran` flips to `false`, since the
+/// inner scope's now-empty-looking chain would shadow the outer's mapping
+/// for `TestIntent` even though `own` never declared it.
+#[test]
+fn an_intent_undeclared_at_the_nearer_scope_resolves_from_the_ancestor() {
+    #[derive(Clone)]
+    struct TestIntent;
+    impl Intent for TestIntent {}
+
+    let ran = Rc::new(Cell::new(false));
+
+    let _laid = lay_out(
+        Actions::new(Actions::new(InvokeProbe {
+            intent: TestIntent,
+            ran: Rc::clone(&ran),
+        }))
+        .action(CallbackAction::new(move |_intent: &TestIntent| {})),
+        loose(50.0),
+    );
+
+    assert!(
+        ran.get(),
+        "the nearer scope declared nothing for this type, so resolution continued to the ancestor"
+    );
+}

--- a/crates/flui-widgets/tests/parity/shortcuts_test.rs
+++ b/crates/flui-widgets/tests/parity/shortcuts_test.rs
@@ -80,32 +80,53 @@
 //!   deferred); ported through `Actions::maybe_invoke` from a probe widget's
 //!   `build`, which is the same "does resolution stop here" question the
 //!   oracle's `Actions.invoke` asks.
-//! - `'Actions can invoke actions in ancestor dispatcher'` — the fix's other
-//!   branch: a nearer scope that declares **no** mapping for the intent type
-//!   at all still lets resolution continue to an enclosing scope's mapping
-//!   (only a *declared* mapping stops the walk) —
+//! - `'Actions can invoke actions in ancestor dispatcher'` (plus its sibling
+//!   `"...if a lower one isn't specified"`, which differs only in whether
+//!   the nearer scope also omits a custom `ActionDispatcher` — a distinction
+//!   FLUI has no concept of, so both collapse onto this one port) — the
+//!   fix's other branch: a nearer scope that declares **no** mapping for the
+//!   intent type at all still lets resolution continue to an enclosing
+//!   scope's mapping (only a *declared* mapping stops the walk) —
 //!   [`an_intent_undeclared_at_the_nearer_scope_resolves_from_the_ancestor`].
 //!   Paired with the disabled-action case above per this port's mutation
 //!   discipline: one pins each side of `resolve`'s "found but disabled" vs.
 //!   "not found here" branch. **Adapted**: same `ActionDispatcher` substitution
 //!   as above.
+//! - A third mutation-paired case, not tied to its own oracle test:
+//!   [`a_scope_that_binds_one_intent_still_inherits_the_ancestor_for_another`]
+//!   — a scope's own mapping for one intent type must not shadow the
+//!   ambient chain's entries for *other* types. Needed because the other two
+//!   cases' inner scope always declares nothing of its own, so neither one
+//!   kills a "drop the ambient chain whenever this scope declares anything"
+//!   mutant; this fixture's inner scope declares a different type than the
+//!   one the probe needs, closing that gap.
 //!
 //! ## Not ported
 //! - `LogicalKeySet` group (`test('LogicalKeySet passes parameters
 //!   correctly.')`, `'... works as a map key.'`, `'.hashCode is stable'`,
 //!   `'.hashCode is order-independent'`, `'.diagnostics work.'`, `'handles
-//!   two keys'`, the three `numLock works as expected...` cases) —
-//!   `LogicalKeySet`'s exact-pressed-set semantics need a
-//!   `HardwareKeyboard`-style pressed-key tracker FLUI does not have;
+//!   two keys'`, `'isActivatedBy works as expected'` (the `LogicalKeySet`
+//!   one — a second, distinct case of this name lives in the
+//!   `SingleActivator` group, cited above), the three `numLock works as
+//!   expected...` cases) — `LogicalKeySet`'s exact-pressed-set semantics
+//!   need a `HardwareKeyboard`-style pressed-key tracker FLUI does not have;
 //!   documented not-ported in `interaction/shortcuts.rs`'s module doc
 //!   (ADR-0023). `SingleActivator` covers the catalog's real uses.
+//! - The `SingleActivator` group's `'diagnostics.'` subgroup (`'single
+//!   key'`, `'no repeats'`, `'combination'`) and the four `'Shortcuts
+//!   diagnostics work...'` cases (plain, `'...when debugLabel specified.'`,
+//!   `'...when manager not specified.'`, `'...when manager specified.'`) —
+//!   no `Diagnosticable`/`debugFillProperties` tree-dump equivalent exists
+//!   for `SingleActivator`/`Shortcuts` (same reason as the
+//!   `debugFillProperties` group under `actions_test.dart`, below).
 //! - `CharacterActivator` group (`'is triggered on events with correct
 //!   character'`, `'handles repeated events'`, `'rejects repeated events if
 //!   requested'`, `'handles Alt, Ctrl and Meta'`, `'isActivatedBy works as
-//!   expected'`, its diagnostics case) — `CharacterActivator` itself waits
-//!   for a consumer (ADR-0023); the two `CallbackShortcuts` ports above
-//!   substitute `SingleActivator::character` where the oracle's own case
-//!   only needs "bind by produced character", not `CharacterActivator`'s
+//!   expected'`, and its `'diagnostics.'` subgroup — `'single key'`, `'no
+//!   repeats'`, `'combination'`) — `CharacterActivator` itself waits for a
+//!   consumer (ADR-0023); the two `CallbackShortcuts` ports above substitute
+//!   `SingleActivator::character` where the oracle's own case only needs
+//!   "bind by produced character", not `CharacterActivator`'s
 //!   shift-insensitivity.
 //! - `ShortcutManager`/`Shortcuts.manager` group (`'Default constructed
 //!   Shortcuts has empty shortcuts'`, `'Default constructed Shortcuts.manager
@@ -316,6 +337,9 @@ fn nested_callback_shortcuts_the_inner_consuming_binding_stops_the_outer() {
         "the inner binding consumed the key first"
     );
     assert_eq!(invoked_inner.get(), 1);
+    assert!(!manager.dispatch_key_event(&key_up("a", Modifiers::empty())));
+    assert_eq!(invoked_outer.get(), 0);
+    assert_eq!(invoked_inner.get(), 1);
 
     manager.unfocus();
 }
@@ -359,6 +383,14 @@ fn non_overlapping_nested_callback_shortcuts_each_fire_for_their_own_key() {
         1,
         "the inner CallbackShortcuts ignored 'b', so it bubbled to the outer"
     );
+    assert_eq!(invoked_inner.get(), 1);
+
+    // Neither key-up matches any binding — `SingleActivator::matches` requires
+    // a down (or allowed-repeat) event — so both stay unconsumed and the
+    // counters hold.
+    assert!(!manager.dispatch_key_event(&key_up("a", Modifiers::empty())));
+    assert!(!manager.dispatch_key_event(&key_up("b", Modifiers::empty())));
+    assert_eq!(invoked_outer.get(), 1);
     assert_eq!(invoked_inner.get(), 1);
 
     manager.unfocus();
@@ -595,11 +627,16 @@ fn a_disabled_action_stops_propagation_to_an_ancestor_scope() {
 /// port's mutation discipline — together they pin both branches of
 /// `resolve`'s "declared but disabled" vs. "not declared here" distinction.
 ///
-/// Red-check: makes the merge in `Actions::build` skip inheriting the
-/// enclosing chain whenever `own` is non-empty (instead of only overwriting
-/// the types `own` actually declares) — `ran` flips to `false`, since the
-/// inner scope's now-empty-looking chain would shadow the outer's mapping
-/// for `TestIntent` even though `own` never declared it.
+/// Red-check (run against `Actions::build` with the ambient-inheritance seed
+/// dropped entirely — `let mut chain = HashMap::default();` instead of
+/// cloning `ambient_action_chain(ctx)` first): `ran` flips to `false`. The
+/// inner scope declares no mapping of its own, so with no ambient seed its
+/// chain is empty and `TestIntent` never resolves to the outer's mapping.
+/// (A "skip inheriting only when `own` is non-empty" mutant does *not* fail
+/// this test — this fixture's inner scope has an empty `own`, so that guard
+/// never triggers here; see
+/// [`a_scope_that_binds_one_intent_still_inherits_the_ancestor_for_another`]
+/// for the fixture that actually kills *that* mutant.)
 #[test]
 fn an_intent_undeclared_at_the_nearer_scope_resolves_from_the_ancestor() {
     #[derive(Clone)]
@@ -620,5 +657,53 @@ fn an_intent_undeclared_at_the_nearer_scope_resolves_from_the_ancestor() {
     assert!(
         ran.get(),
         "the nearer scope declared nothing for this type, so resolution continued to the ancestor"
+    );
+}
+
+/// A scope that binds one intent type still inherits the ambient chain's
+/// entries for **other** types — Flutter's `_visitActionsAncestors` walk
+/// continues past a scope whose map lacks the sought intent's type,
+/// regardless of what else that scope's map declares (`_castAction` looks up
+/// only the specific type sought — `actions.dart:920-931`).
+///
+/// Paired with [`a_disabled_action_stops_propagation_to_an_ancestor_scope`]
+/// and [`an_intent_undeclared_at_the_nearer_scope_resolves_from_the_ancestor`]
+/// per this port's mutation discipline: this is the fixture that actually
+/// kills a "skip inheriting the ambient chain whenever `own` is non-empty"
+/// mutant — the other two do not, because their inner scope's `own` is
+/// empty, so that mutant's guard never triggers for them.
+///
+/// Red-check (run against `Actions::build` with the ambient-inheritance seed
+/// guarded on `self.own.is_empty()` — inherit only when this scope declares
+/// nothing, otherwise start from an empty chain): `ran` flips to `false`.
+/// The inner scope's `own` binds `IntentA`, so the mutant drops the ambient
+/// chain entirely instead of merely overwriting `IntentA`'s entry, losing
+/// the outer's `IntentB` mapping the probe needs.
+#[test]
+fn a_scope_that_binds_one_intent_still_inherits_the_ancestor_for_another() {
+    #[derive(Clone)]
+    struct IntentA;
+    impl Intent for IntentA {}
+    #[derive(Clone)]
+    struct IntentB;
+    impl Intent for IntentB {}
+
+    let ran = Rc::new(Cell::new(false));
+
+    let _laid = lay_out(
+        Actions::new(
+            Actions::new(InvokeProbe {
+                intent: IntentB,
+                ran: Rc::clone(&ran),
+            })
+            .action(CallbackAction::new(|_intent: &IntentA| {})),
+        )
+        .action(CallbackAction::new(|_intent: &IntentB| {})),
+        loose(50.0),
+    );
+
+    assert!(
+        ran.get(),
+        "the inner scope's own mapping for IntentA must not shadow the outer's mapping for IntentB"
     );
 }

--- a/docs/adr/ADR-0023-actions-shortcuts-seam.md
+++ b/docs/adr/ADR-0023-actions-shortcuts-seam.md
@@ -156,6 +156,24 @@ typed wrapper behind the intent's `TypeId` and carries the FR-033/widgets
 marker. Rust 1.86 trait upcasting (`dyn Intent: Any`) removes any `as_any`
 ceremony. Original design follows.
 
+**Correction (2026-07-18, Shortcuts/Actions parity port).** The paragraph
+above misreads `_visitActionsAncestors`/`_castAction`
+(`actions.dart:736-753`, `:920-931`): Flutter's walk stops at the **first**
+`Actions` scope whose own map declares the intent's type *at all*, enabled or
+not — `maybeInvoke`'s own doc is explicit that a disabled match ends the
+search rather than falling through to an enclosing scope's mapping for the
+same type (`:993-995`). There is no fall-through past a disabled nearer
+action; the oracle test `'Disabled actions stop propagation to an ancestor'`
+(`actions_test.dart`) pins the opposite of what this ADR originally shipped.
+Fixed alongside the parity port: `ActionChain` is now
+`HashMap<TypeId, ErasedAction>` (one candidate per type, not a fallback
+list) — a nearer scope's own mapping for a type entirely *replaces* the
+enclosing chain's entry for that type, so a disabled nearer mapping is the
+last one `resolve` ever sees. Red-checked against the reverted
+Vec-of-candidates shape (see `interaction/actions.rs`'s
+`a_disabled_nearer_action_stops_resolution_at_its_own_scope`, formerly named
+for the fall-through this correction removes).
+
 
 The typed layer. Rust shape for Flutter's `Map<Type, Action<Intent>>`:
 


### PR DESCRIPTION
Business.1 fidelity unit: the Shortcuts/Actions family joins the parity corpus — 8 ported cases in `parity/shortcuts_test.rs` plus 10 oracle cases covered by named citations on existing unit tests (~18 upstream cases accounted), against `shortcuts_test.dart`/`actions_test.dart` @ 3.44.0. Every remaining oracle case is explicitly listed as not-ported with its reason (no `Diagnosticable` equivalent for the diagnostics subgroups, no `ActionDispatcher` concept, etc.).

## Real bug found and fixed

`Actions` resolution kept a fallback **chain** of handlers per intent type — a disabled action at the nearer scope silently fell through to an enclosing scope's handler. Flutter's `_visitActionsAncestors` stops at the first scope whose map declares the type, enabled or not (`'Disabled actions stop propagation to an ancestor'` expects no invocation). The fix stores one action per `TypeId` with replace-on-provide, reproducing the oracle contract on both `maybe_invoke` and the key-dispatch path; ADR-0023 amended with the corrected reading.

Both sides of the new behavior are mutation-pinned after the review rounds: dropping the ambient-inheritance seed fails the undeclared-at-nearer-scope test, and the skip-inherit-when-scope-declares-anything mutant — which previously survived the entire suite because no fixture instantiated a declaring-but-disjoint inner scope — is killed by a dedicated test (inner scope binds `IntentA`, probe invokes `IntentB` declared outer). One initially mis-transcribed red-check note was caught by the reviewer, rewritten against an actually-executed mutant, and independently reproduced.

## Evidence

- `cargo nextest run --workspace --exclude flui-platform`: 7501 passed; clippy `-D warnings`, fmt/port-check/inventory/taplo/typos, doctests: clean.
- Reviewer independently re-ran both mutants in an isolated worktree across two rounds; assertion lists diffed case-by-case against the oracle's expect lists (restored key-up/re-assert pairs where the port had trimmed them).
- Full review + delta re-review: SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)