### PR TITLE
feat(widgets): port AnimatedSwitcher and its parity corpus

### DIFF
--- a/crates/flui-widgets/src/animated/animated_switcher.rs
+++ b/crates/flui-widgets/src/animated/animated_switcher.rs
@@ -1,0 +1,617 @@
+//! [`AnimatedSwitcher`] — cross-fades (or custom-transitions) between a
+//! sequence of children keyed by [`View::can_update`].
+//!
+//! Flutter parity: `widgets/animated_switcher.dart` `AnimatedSwitcher`, tag
+//! `3.44.0`. Structurally this widget is the odd one out among its
+//! `animated/` siblings: `AnimatedContainer`/`AnimatedOpacity`/… hold ONE
+//! persistent [`AnimationController`] retargeted in place
+//! ([`crate::animated::implicitly_animated::ImplicitController`]).
+//! `AnimatedSwitcher` instead owns a **set of entries**, each with its own
+//! controller — a new child gets a fresh entry that animates in while the
+//! previous entry (now "outgoing") animates out, and outgoing entries are
+//! disposed once their reverse run dismisses. This mirrors the oracle's
+//! `_ChildEntry` / `_currentEntry` / `_outgoingEntries` bookkeeping.
+//!
+//! # Why `build` needs interior mutability
+//!
+//! `ViewState::build` takes `&self` (unlike `did_update_view`, which takes
+//! `&mut self`), but an outgoing entry's dismissal is discovered
+//! asynchronously — from an [`AnimationController`] status-listener callback
+//! that fires on a later frame, independent of any `did_update_view` call.
+//! The listener itself only flips a `Send + Sync`-safe [`AtomicBool`] and
+//! schedules a rebuild ([`RebuildHandle::schedule`]) — it never touches
+//! `BoxedView`/`AnimationController`, which are not required to be `Send`
+//! ([`View`] carries no such bound). The actual sweep (disposing the
+//! dismissed entry and dropping it from the list) happens inside `build`,
+//! reading that flag, through a `RefCell<Vec<ChildEntry>>` — the same
+//! shared-mutable-state-behind-`&self` idiom `Overlay`/`Navigator` already use
+//! (`parking_lot::Mutex` there; `RefCell` here since nothing here crosses a
+//! thread boundary). This is the same "pull, don't push" shape
+//! [`AnimatedSize`](crate::AnimatedSize)'s `completed_runs` counter uses for
+//! its `on_end` callback.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use flui_animation::curve::{ArcCurve, Curve};
+use flui_animation::{
+    Animation, AnimationController, AnimationStatus, CurvedAnimation, Curves, Scheduler, Vsync,
+    VsyncRegistration,
+};
+use flui_foundation::{ListenerId, ViewKey};
+use flui_types::Alignment;
+use flui_view::element::ElementKind;
+use flui_view::prelude::{BuildContext, StatefulView};
+use flui_view::{
+    BoxedView, BuildContextExt, IntoView, RebuildHandle, StatelessView, ValueKey, View, ViewExt,
+    ViewState,
+};
+
+use crate::animated::vsync_scope::VsyncScope;
+use crate::{FadeTransition, Stack};
+
+/// A custom transition for [`AnimatedSwitcher`]: wraps an incoming/outgoing
+/// `child` with a widget driven by `animation` (`0.0` = fully switched out,
+/// `1.0` = fully switched in).
+///
+/// Flutter parity: `AnimatedSwitcherTransitionBuilder`
+/// (`animated_switcher.dart`, tag `3.44.0`).
+pub type AnimatedSwitcherTransitionBuilder =
+    Rc<dyn Fn(BoxedView, Arc<dyn Animation<f32>>) -> BoxedView>;
+
+/// A custom layout for [`AnimatedSwitcher`]: arranges the incoming
+/// `current_child` (if any) alongside the still-animating-out
+/// `previous_children` (oldest first).
+///
+/// Flutter parity: `AnimatedSwitcherLayoutBuilder` (`animated_switcher.dart`,
+/// tag `3.44.0`).
+pub type AnimatedSwitcherLayoutBuilder = Rc<dyn Fn(Option<BoxedView>, Vec<BoxedView>) -> BoxedView>;
+
+/// Cross-fades between children, keyed by [`View::can_update`] (Flutter's
+/// `Widget.canUpdate`: same concrete type and same key).
+///
+/// Setting [`AnimatedSwitcher::child`] to a widget that is NOT
+/// `can_update`-compatible with the previous one starts a transition: the old
+/// child animates out along `switch_out_curve` while the new one animates in
+/// along `switch_in_curve`, both over `duration` (or `reverse_duration` for
+/// the outgoing run, if set). A `can_update`-compatible child instead updates
+/// the existing entry in place — no transition restarts. Setting the SAME
+/// key on a new child that is mid-transition-out (e.g. a value oscillating A
+/// → B → A faster than `duration`) does not collapse into the old outgoing
+/// entry; it starts its own fresh entry, exactly as `Widget.canUpdate` would
+/// never unify two different `_ChildEntry`s.
+///
+/// The default `transition_builder` cross-fades via [`FadeTransition`]; the
+/// default `layout_builder` overlaps every still-animating entry in a
+/// [`Stack`], centered, oldest-to-newest with the incoming child painted
+/// last (on top).
+#[derive(Clone, StatefulView)]
+pub struct AnimatedSwitcher {
+    child: Option<BoxedView>,
+    duration: Duration,
+    reverse_duration: Option<Duration>,
+    switch_in_curve: ArcCurve,
+    switch_out_curve: ArcCurve,
+    transition_builder: AnimatedSwitcherTransitionBuilder,
+    layout_builder: AnimatedSwitcherLayoutBuilder,
+}
+
+thread_local! {
+    // Canonical, thread-shared handles for the default builders — mirrors
+    // `crate::animated::implicitly_animated::default_curve`'s `ArcCurve`
+    // caching (same rationale, `thread_local!` here rather than a
+    // `static OnceLock` because `Rc<dyn Fn>` is neither `Send` nor `Sync`).
+    // Without this, every `AnimatedSwitcher::new()` would mint a FRESH `Rc`
+    // allocation wrapping the same default function, so
+    // `did_update_view`'s `Rc::ptr_eq` builder-changed check (which detects a
+    // genuine `transition_builder` override) would report "changed" on
+    // EVERY reconfigure even when the caller never touched it — needlessly
+    // rebuilding every entry's cached transition on every rebuild.
+    static DEFAULT_TRANSITION_BUILDER: AnimatedSwitcherTransitionBuilder =
+        Rc::new(AnimatedSwitcher::default_transition_builder);
+    static DEFAULT_LAYOUT_BUILDER: AnimatedSwitcherLayoutBuilder =
+        Rc::new(AnimatedSwitcher::default_layout_builder);
+}
+
+impl AnimatedSwitcher {
+    /// A switcher with no child yet, transitioning over `duration` with
+    /// `Curves::Linear` in both directions (oracle default — deliberately
+    /// NOT the `EaseInOut` default of the sibling implicit-animation
+    /// widgets), the default fade transition, and the default centered-stack
+    /// layout.
+    pub fn new(duration: Duration) -> Self {
+        Self {
+            child: None,
+            duration,
+            reverse_duration: None,
+            switch_in_curve: ArcCurve::new(Curves::Linear),
+            switch_out_curve: ArcCurve::new(Curves::Linear),
+            transition_builder: DEFAULT_TRANSITION_BUILDER.with(Clone::clone),
+            layout_builder: DEFAULT_LAYOUT_BUILDER.with(Clone::clone),
+        }
+    }
+
+    /// The child to display. Setting a `can_update`-incompatible child
+    /// (different concrete type or key) starts a transition.
+    #[must_use]
+    pub fn child(mut self, child: impl IntoView) -> Self {
+        self.child = Some(child.into_view().boxed());
+        self
+    }
+
+    /// Overrides the outgoing-run duration; defaults to `duration`.
+    #[must_use]
+    pub fn reverse_duration(mut self, reverse_duration: Duration) -> Self {
+        self.reverse_duration = Some(reverse_duration);
+        self
+    }
+
+    /// Overrides the curve applied while a child transitions in.
+    #[must_use]
+    pub fn switch_in_curve(mut self, curve: impl Curve + Send + Sync + 'static) -> Self {
+        self.switch_in_curve = ArcCurve::new(curve);
+        self
+    }
+
+    /// Overrides the curve applied while a child transitions out.
+    #[must_use]
+    pub fn switch_out_curve(mut self, curve: impl Curve + Send + Sync + 'static) -> Self {
+        self.switch_out_curve = ArcCurve::new(curve);
+        self
+    }
+
+    /// Overrides how each entry is wrapped for transition; defaults to
+    /// [`AnimatedSwitcher::default_transition_builder`].
+    #[must_use]
+    pub fn transition_builder(
+        mut self,
+        builder: impl Fn(BoxedView, Arc<dyn Animation<f32>>) -> BoxedView + 'static,
+    ) -> Self {
+        self.transition_builder = Rc::new(builder);
+        self
+    }
+
+    /// Overrides how the current and outgoing entries are laid out together;
+    /// defaults to [`AnimatedSwitcher::default_layout_builder`].
+    #[must_use]
+    pub fn layout_builder(
+        mut self,
+        builder: impl Fn(Option<BoxedView>, Vec<BoxedView>) -> BoxedView + 'static,
+    ) -> Self {
+        self.layout_builder = Rc::new(builder);
+        self
+    }
+
+    /// The default `transition_builder`: cross-fades `child` via
+    /// [`FadeTransition`].
+    ///
+    /// Flutter parity: `AnimatedSwitcher.defaultTransitionBuilder`
+    /// (`animated_switcher.dart`, tag `3.44.0`) wraps in a `FadeTransition`
+    /// additionally keyed by `child.key`. FLUI's `FadeTransition` has no
+    /// `.key(...)` setter (a keyed `impl View` cannot come from
+    /// `impl_animated_view!`'s generated block — see `flui-macros`'
+    /// "Keyed widgets" doc), so that inner re-key is not reproduced; the
+    /// entry's OWN stable identity (this builder's caller wraps the result
+    /// in a per-entry key, mirroring the oracle's `KeyedSubtree.wrap(...,
+    /// _childNumber)`) is what the corpus actually asserts on.
+    pub fn default_transition_builder(
+        child: BoxedView,
+        animation: Arc<dyn Animation<f32>>,
+    ) -> BoxedView {
+        FadeTransition::new(animation, child).boxed()
+    }
+
+    /// The default `layout_builder`: a [`Stack`] centering every
+    /// still-animating entry, oldest `previous_children` first, then
+    /// `current_child` last (so it paints on top).
+    ///
+    /// Flutter parity: `AnimatedSwitcher.defaultLayoutBuilder`
+    /// (`animated_switcher.dart`, tag `3.44.0`).
+    pub fn default_layout_builder(
+        current_child: Option<BoxedView>,
+        previous_children: Vec<BoxedView>,
+    ) -> BoxedView {
+        let mut children = previous_children;
+        children.extend(current_child);
+        Stack::new(children).alignment(Alignment::CENTER).boxed()
+    }
+}
+
+impl std::fmt::Debug for AnimatedSwitcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnimatedSwitcher")
+            .field("duration", &self.duration)
+            .field("has_child", &self.child.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Attaches a stable per-entry identity to an already-built transition widget
+/// so the layout builder's dynamic `Vec<BoxedView>` — reconciled by
+/// `flui-view`'s keyed-child machinery — recognizes the SAME entry across
+/// rebuilds even though [`AnimatedSwitcherState::build`] constructs a fresh
+/// `Vec` every time. Rust-native stand-in for Flutter's `KeyedSubtree`
+/// (`widgets/basic.dart`), which the oracle's `_newEntry` /
+/// `_updateTransitionForEntry` wrap every transition in for exactly this
+/// reason — the key is the entry's `child_number`, never rebuilt once
+/// assigned, so `_updateTransitionForEntry`-equivalent calls
+/// ([`ChildEntry::update_transition`]) can swap the wrapped content without
+/// losing the slot's element identity.
+#[derive(Clone)]
+struct KeyedEntry {
+    key: ValueKey<u64>,
+    child: BoxedView,
+}
+
+impl KeyedEntry {
+    fn new(child_number: u64, child: BoxedView) -> Self {
+        Self {
+            key: ValueKey::new(child_number),
+            child,
+        }
+    }
+}
+
+impl std::fmt::Debug for KeyedEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KeyedEntry")
+            .field("key", &self.key)
+            .finish_non_exhaustive()
+    }
+}
+
+impl View for KeyedEntry {
+    fn create_element(&self) -> ElementKind {
+        ElementKind::stateless(self)
+    }
+
+    fn key(&self) -> Option<&dyn ViewKey> {
+        Some(&self.key)
+    }
+}
+
+impl StatelessView for KeyedEntry {
+    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+        self.child.clone()
+    }
+}
+
+/// One child that is, now or in the past, the value [`AnimatedSwitcher`]'s
+/// `child` was set to but is still transitioning. Flutter parity:
+/// `_ChildEntry` (`animated_switcher.dart`, tag `3.44.0`).
+struct ChildEntry {
+    /// This entry's stable identity — assigned once at creation, carried
+    /// unchanged by its [`KeyedEntry`] wrapper for the entry's whole life.
+    child_number: u64,
+    /// The transition's driver. Runs forward while incoming, reverse once
+    /// demoted to outgoing.
+    controller: AnimationController,
+    /// `controller`, eased by `switch_in_curve` going forward and
+    /// `switch_out_curve` going backward — what `transition_builder`
+    /// actually animates against.
+    curved: CurvedAnimation<ArcCurve>,
+    /// The `Vsync` this entry registered with, kept alongside the
+    /// registration so [`ChildEntry::dispose`] can unregister (mirrors
+    /// `ImplicitController::dispose`).
+    vsync: Option<Vsync>,
+    vsync_registration: Option<VsyncRegistration>,
+    status_listener_id: Option<ListenerId>,
+    /// Flipped by the status-listener callback when `controller` reaches
+    /// [`AnimationStatus::Dismissed`] (a completed reverse run). Read — and
+    /// acted on — by [`AnimatedSwitcherState::build`]'s sweep; see the
+    /// module docs for why the listener cannot dispose the entry itself.
+    dismissed: Arc<AtomicBool>,
+    /// The child widget this entry was built from, used to detect a
+    /// same-entry rebuild (`View::can_update`) and to re-run
+    /// `transition_builder` on demand.
+    widget_child: BoxedView,
+    /// The cached, already-built (and stably keyed) transition widget.
+    transition: BoxedView,
+}
+
+impl ChildEntry {
+    /// A fresh entry wrapping `child`, at rest (`animate: false`, the very
+    /// first entry created from `create_state`) or animating in
+    /// (`animate: true`, every later swap). Builds the controller, curve,
+    /// and initial transition, but does NOT register with a `Vsync` or
+    /// attach the dismissal status-listener — [`ChildEntry::register`] does
+    /// that once a [`BuildContext`] is available (`create_state` has none;
+    /// see `AnimatedSwitcherState::init_state`).
+    #[allow(clippy::too_many_arguments)] // one argument per oracle constructor parameter
+    fn new(
+        child: BoxedView,
+        child_number: u64,
+        duration: Duration,
+        reverse_duration: Option<Duration>,
+        switch_in_curve: ArcCurve,
+        switch_out_curve: ArcCurve,
+        transition_builder: &AnimatedSwitcherTransitionBuilder,
+        animate: bool,
+    ) -> Self {
+        let controller = AnimationController::new(duration, Arc::new(Scheduler::new()));
+        if let Some(reverse_duration) = reverse_duration {
+            controller.set_reverse_duration(reverse_duration);
+        }
+        let parent: Arc<dyn Animation<f32>> = Arc::new(controller.clone());
+        let curved =
+            CurvedAnimation::new(parent, switch_in_curve).with_reverse_curve(switch_out_curve);
+
+        if animate {
+            // Oracle: `controller.forward();` (`_addEntryForNewChild`,
+            // `animated_switcher.dart`, tag `3.44.0`).
+            let _ = controller.forward();
+        } else {
+            // Oracle: `controller.value = 1.0;` for the very first entry — sits
+            // at rest, fully switched in, no motion.
+            controller.set_value(1.0);
+        }
+
+        let transition = Self::build_transition(child_number, &child, &curved, transition_builder);
+
+        Self {
+            child_number,
+            controller,
+            curved,
+            vsync: None,
+            vsync_registration: None,
+            status_listener_id: None,
+            dismissed: Arc::new(AtomicBool::new(false)),
+            widget_child: child,
+            transition,
+        }
+    }
+
+    /// Register with `vsync` (if any) and attach the dismissal
+    /// status-listener, which flips [`ChildEntry::dismissed`] and schedules
+    /// `rebuild` when `controller` reaches
+    /// [`AnimationStatus::Dismissed`] — the oracle's
+    /// `animation.addStatusListener` in `_newEntry`.
+    fn register(&mut self, vsync: Option<Vsync>, rebuild: RebuildHandle) {
+        if let Some(vsync) = &vsync {
+            self.vsync_registration = Some(vsync.register(self.controller.clone()));
+        }
+        self.vsync = vsync;
+
+        let dismissed = Arc::clone(&self.dismissed);
+        self.status_listener_id =
+            Some(self.controller.add_status_listener(Arc::new(move |status| {
+                if status == AnimationStatus::Dismissed {
+                    dismissed.store(true, Ordering::Release);
+                    rebuild.schedule();
+                }
+            })));
+    }
+
+    /// Re-run `transition_builder` over the current `widget_child`/`curved`,
+    /// preserving this entry's key. Oracle: `_updateTransitionForEntry`
+    /// (`animated_switcher.dart`, tag `3.44.0`) — called both when
+    /// `transition_builder` itself changes and when a `can_update`-compatible
+    /// child rebuilds the current entry in place.
+    fn update_transition(&mut self, transition_builder: &AnimatedSwitcherTransitionBuilder) {
+        self.transition = Self::build_transition(
+            self.child_number,
+            &self.widget_child,
+            &self.curved,
+            transition_builder,
+        );
+    }
+
+    fn build_transition(
+        child_number: u64,
+        widget_child: &BoxedView,
+        curved: &CurvedAnimation<ArcCurve>,
+        transition_builder: &AnimatedSwitcherTransitionBuilder,
+    ) -> BoxedView {
+        let animation: Arc<dyn Animation<f32>> = Arc::new(curved.clone());
+        let content = transition_builder(widget_child.clone(), animation);
+        KeyedEntry::new(child_number, content).boxed()
+    }
+
+    /// Detach the status listener, unregister from `vsync`, and dispose the
+    /// controller. Oracle: `dispose()` (`animated_switcher.dart`, tag
+    /// `3.44.0`) disposes every entry's controller and animation.
+    fn dispose(&mut self) {
+        if let Some(id) = self.status_listener_id.take() {
+            self.controller.remove_status_listener(id);
+        }
+        if let (Some(vsync), Some(registration)) =
+            (self.vsync.take(), self.vsync_registration.take())
+        {
+            vsync.unregister(registration);
+        }
+        self.controller.dispose();
+    }
+}
+
+impl std::fmt::Debug for ChildEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChildEntry")
+            .field("child_number", &self.child_number)
+            .field("status", &self.controller.status())
+            .field("dismissed", &self.dismissed.load(Ordering::Acquire))
+            .finish_non_exhaustive()
+    }
+}
+
+/// State for [`AnimatedSwitcher`]. See the module docs for why
+/// `outgoing_entries` needs interior mutability.
+pub struct AnimatedSwitcherState {
+    current_entry: Option<ChildEntry>,
+    outgoing_entries: RefCell<Vec<ChildEntry>>,
+    /// Monotonically increasing entry counter — the source of each
+    /// [`ChildEntry::child_number`]. Oracle: `_childNumber`
+    /// (`animated_switcher.dart`, tag `3.44.0`).
+    child_number: u64,
+    /// Captured in `init_state` (unavailable in `create_state`, which has no
+    /// `BuildContext`); reused for every later entry `did_update_view`
+    /// creates. `None` only in the pre-`init_state` window.
+    rebuild: Option<RebuildHandle>,
+    vsync: Option<Vsync>,
+}
+
+impl std::fmt::Debug for AnimatedSwitcherState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnimatedSwitcherState")
+            .field("has_current_entry", &self.current_entry.is_some())
+            .field("outgoing_count", &self.outgoing_entries.borrow().len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl StatefulView for AnimatedSwitcher {
+    type State = AnimatedSwitcherState;
+
+    fn create_state(&self) -> Self::State {
+        // Oracle: `initState` calls `_addEntryForNewChild(animate: false)`
+        // (`animated_switcher.dart`, tag `3.44.0`). FLUI splits controller
+        // construction (here, no `BuildContext` yet) from vsync/listener
+        // registration (`init_state`, below) — see `ChildEntry::new`'s doc.
+        let current_entry = self.child.clone().map(|child| {
+            ChildEntry::new(
+                child,
+                0,
+                self.duration,
+                self.reverse_duration,
+                self.switch_in_curve.clone(),
+                self.switch_out_curve.clone(),
+                &self.transition_builder,
+                false,
+            )
+        });
+        AnimatedSwitcherState {
+            current_entry,
+            outgoing_entries: RefCell::new(Vec::new()),
+            child_number: 0,
+            rebuild: None,
+            vsync: None,
+        }
+    }
+}
+
+impl AnimatedSwitcherState {
+    /// Demote the current entry to outgoing (reversing it) and install a
+    /// fresh incoming entry for `view.child`, or do nothing if `view` has no
+    /// child. Oracle: `_addEntryForNewChild` (`animated_switcher.dart`, tag
+    /// `3.44.0`).
+    fn add_entry_for_new_child(&mut self, view: &AnimatedSwitcher, animate: bool) {
+        debug_assert!(
+            animate || self.current_entry.is_none(),
+            "BUG: a non-animated entry replacement is only valid for the very first entry"
+        );
+        if let Some(old_entry) = self.current_entry.take() {
+            debug_assert!(animate, "BUG: demoting a current entry always animates");
+            let _ = old_entry.controller.reverse();
+            self.outgoing_entries.get_mut().push(old_entry);
+        }
+        let Some(child) = view.child.clone() else {
+            return;
+        };
+        let mut entry = ChildEntry::new(
+            child,
+            self.child_number,
+            view.duration,
+            view.reverse_duration,
+            view.switch_in_curve.clone(),
+            view.switch_out_curve.clone(),
+            &view.transition_builder,
+            animate,
+        );
+        if let Some(rebuild) = self.rebuild.clone() {
+            entry.register(self.vsync.clone(), rebuild);
+        }
+        self.current_entry = Some(entry);
+    }
+}
+
+impl ViewState<AnimatedSwitcher> for AnimatedSwitcherState {
+    fn init_state(&mut self, ctx: &dyn BuildContext) {
+        let rebuild = ctx.rebuild_handle();
+        let vsync = ctx.get::<VsyncScope, _>(|scope| scope.vsync().clone());
+        if let Some(entry) = self.current_entry.as_mut() {
+            entry.register(vsync.clone(), rebuild.clone());
+        }
+        self.rebuild = Some(rebuild);
+        self.vsync = vsync;
+    }
+
+    fn build(&self, view: &AnimatedSwitcher, _ctx: &dyn BuildContext) -> impl IntoView {
+        // Sweep entries whose reverse run dismissed since the last build — see
+        // the module docs for why this cannot happen inside the status
+        // listener itself. Oracle: the `setState` inside
+        // `animation.addStatusListener` in `_newEntry` removes the entry from
+        // `_outgoingEntries` and disposes it.
+        self.outgoing_entries.borrow_mut().retain_mut(|entry| {
+            if entry.dismissed.load(Ordering::Acquire) {
+                entry.dispose();
+                false
+            } else {
+                true
+            }
+        });
+
+        let current_child_number = self.current_entry.as_ref().map(|entry| entry.child_number);
+        let current_transition = self
+            .current_entry
+            .as_ref()
+            .map(|entry| entry.transition.clone());
+        // Oracle: `_outgoingWidgets!.where((w) => w.key != _currentEntry?.transition.key)`
+        // (`build`, `animated_switcher.dart`, tag `3.44.0`) — an outgoing entry
+        // sharing the current entry's key is suppressed from
+        // `previousChildren`; translated here as the same `child_number` never
+        // appearing in both lists at once.
+        let previous_transitions: Vec<BoxedView> = self
+            .outgoing_entries
+            .borrow()
+            .iter()
+            .filter(|entry| Some(entry.child_number) != current_child_number)
+            .map(|entry| entry.transition.clone())
+            .collect();
+
+        (view.layout_builder)(current_transition, previous_transitions)
+    }
+
+    fn did_update_view(&mut self, old_view: &AnimatedSwitcher, new_view: &AnimatedSwitcher) {
+        // Oracle: a `transitionBuilder` swap rebuilds every cached transition in
+        // place, preserving each entry's key (`didUpdateWidget`,
+        // `animated_switcher.dart`, tag `3.44.0`).
+        if !Rc::ptr_eq(&old_view.transition_builder, &new_view.transition_builder) {
+            for entry in self.outgoing_entries.get_mut() {
+                entry.update_transition(&new_view.transition_builder);
+            }
+            if let Some(entry) = self.current_entry.as_mut() {
+                entry.update_transition(&new_view.transition_builder);
+            }
+        }
+
+        // Oracle: `hasNewChild != hasOldChild || (hasNewChild &&
+        // !Widget.canUpdate(widget.child!, _currentEntry!.widgetChild))`.
+        let needs_new_entry = match (new_view.child.as_ref(), self.current_entry.as_ref()) {
+            (Some(new_child), Some(entry)) => !new_child.can_update(&entry.widget_child),
+            (Some(_), None) | (None, Some(_)) => true,
+            (None, None) => false,
+        };
+
+        if needs_new_entry {
+            self.child_number += 1;
+            self.add_entry_for_new_child(new_view, true);
+        } else if let (Some(new_child), Some(entry)) =
+            (new_view.child.clone(), self.current_entry.as_mut())
+        {
+            // Same entry, updated in place — no transition restart.
+            entry.widget_child = new_child;
+            entry.update_transition(&new_view.transition_builder);
+        }
+    }
+
+    fn dispose(&mut self) {
+        if let Some(entry) = self.current_entry.as_mut() {
+            entry.dispose();
+        }
+        for entry in self.outgoing_entries.get_mut() {
+            entry.dispose();
+        }
+    }
+}

--- a/crates/flui-widgets/src/animated/mod.rs
+++ b/crates/flui-widgets/src/animated/mod.rs
@@ -15,6 +15,7 @@ mod animated_container;
 mod animated_opacity;
 mod animated_padding;
 mod animated_size;
+mod animated_switcher;
 mod implicitly_animated;
 mod ticker_mode;
 mod vsync_scope;
@@ -24,5 +25,9 @@ pub use animated_container::{AnimatedContainer, AnimatedContainerState};
 pub use animated_opacity::{AnimatedOpacity, AnimatedOpacityState};
 pub use animated_padding::{AnimatedPadding, AnimatedPaddingState};
 pub use animated_size::{AnimatedSize, AnimatedSizeState};
+pub use animated_switcher::{
+    AnimatedSwitcher, AnimatedSwitcherLayoutBuilder, AnimatedSwitcherState,
+    AnimatedSwitcherTransitionBuilder,
+};
 pub use ticker_mode::{TickerMode, TickerModeState};
 pub use vsync_scope::VsyncScope;

--- a/crates/flui-widgets/src/lib.rs
+++ b/crates/flui-widgets/src/lib.rs
@@ -131,7 +131,8 @@ pub use localization::{
 pub use animated::{
     AnimatedAlign, AnimatedAlignState, AnimatedContainer, AnimatedContainerState, AnimatedOpacity,
     AnimatedOpacityState, AnimatedPadding, AnimatedPaddingState, AnimatedSize, AnimatedSizeState,
-    TickerMode, TickerModeState, VsyncScope,
+    AnimatedSwitcher, AnimatedSwitcherLayoutBuilder, AnimatedSwitcherState,
+    AnimatedSwitcherTransitionBuilder, TickerMode, TickerModeState, VsyncScope,
 };
 pub use clip::{ClipOval, ClipPath, ClipRRect, ClipRect};
 // `Image` widget over `RenderImage`; provider types live in the same module.

--- a/crates/flui-widgets/tests/parity/animated_switcher_test.rs
+++ b/crates/flui-widgets/tests/parity/animated_switcher_test.rs
@@ -1,0 +1,764 @@
+//! ## Test parity notes
+//!
+//! Flutter source: `packages/flutter/test/widgets/animated_switcher_test.dart`
+//! (tag `3.44.0`), oracle: `packages/flutter/lib/src/widgets/animated_switcher.dart`
+//! (tag `3.44.0`).
+//!
+//! Widget → render-object mapping:
+//! - `AnimatedSwitcher` → a `StatefulView` composing `layout_builder`'s output
+//!   (default: [`Stack`] → `RenderStack`) over each entry's
+//!   `transition_builder` output (default: [`FadeTransition`] →
+//!   [`Opacity`](crate) → `RenderOpacity`)
+//!   (`crates/flui-widgets/src/animated/animated_switcher.rs`).
+//!
+//! Key-based substitution: the oracle forces "not `Widget.canUpdate`-compatible"
+//! by giving several instances of the SAME concrete type (`Container`) distinct
+//! `Key`s. FLUI's `Keyed<V>` wrapper (`flui_foundation::Keyed`) carries no
+//! `impl View` (confirmed: no such impl exists anywhere in `flui-view` or
+//! `flui-widgets`; keying a widget from the outside requires hand-rolling
+//! `impl View { fn key() }`, same as `flui-widgets/src/overlay/mod.rs`'s
+//! `OverlayEntryView`) — not a gap `AnimatedSwitcher` itself needs to work
+//! around (its own `did_update_view` reuses `View::can_update` exactly as the
+//! oracle uses `Widget.canUpdate`, see the widget's module doc), just a
+//! missing convenience for a TEST to mint several keyed instances of one
+//! type. Cases that only need "force a fresh, non-`can_update`-compatible
+//! entry" (1, 2, 10) substitute distinct CONCRETE TYPES instead of distinct
+//! keys — an equally valid way to fail `can_update` (which is `view_type_id`
+//! equality AND key equality; different types already fail the first half).
+//! The one case that specifically exercises a KEY reappearing after its
+//! original entry has already gone through the pipeline (11) uses a small
+//! test-local `Keyed<W>` — the exact hand-rolled-`impl View` pattern
+//! `OverlayEntryView` already uses in production, not new framework surface.
+//!
+//! Ported: 10 of 12 oracle cases.
+//! - `'AnimatedSwitcher fades in a new child.'`
+//! - `'AnimatedSwitcher can handle back-to-back changes.'` (adapted: distinct
+//!   types substitute for distinct keys, see above — otherwise ported in
+//!   full, including the middle child's disappearance; see the harness note
+//!   below)
+//! - `'AnimatedSwitcher doesn't transition in a new child of the same type.'`
+//! - `'AnimatedSwitcher handles null children.'`
+//! - `'AnimatedSwitcher doesn't start any animations after dispose.'`
+//! - `'AnimatedSwitcher uses custom layout.'`
+//! - `'AnimatedSwitcher uses custom transitions.'`
+//! - `'AnimatedSwitcher doesn't reset state of the children in transitions.'`
+//!   (adapted: three distinct probe types substitute for one `StatefulTest`
+//!   type keyed three ways, per the key-substitution note above)
+//! - `'AnimatedSwitcher updates widgets without animating if they are
+//!   isomorphic.'`
+//! - `'AnimatedSwitcher does not crash at zero area'`
+//!
+//! Adapted-and-narrowed: 1 of 12.
+//! - `'AnimatedSwitcher updates previous child transitions if the
+//!   transitionBuilder changes.'` — ported the core assertion (every cached
+//!   transition, including outgoing ones, is rebuilt under the new
+//!   `transition_builder`); the oracle's OWN preceding sub-assertion (each
+//!   cached child is `isA<KeyedSubtree>()`) is FLUI's `KeyedEntry` wrapper,
+//!   which is a private (non-`pub`) implementation type with nothing for an
+//!   integration test outside the module to assert on — the render-type
+//!   evidence (transitions actually swap) is asserted instead.
+//!
+//! Out of scope: 1 of 12.
+//! - `'AnimatedSwitcher does not duplicate animations if the same child is
+//!   entered twice.'` — needs a KEYED widget re-entering after its ORIGINAL
+//!   entry already exists (possibly still outgoing); ported as
+//!   `reentering_a_still_dismissing_key_starts_a_fresh_entry_not_a_duplicate`
+//!   using the test-local `Keyed<W>` wrapper (see above), so functionally
+//!   this is covered — filed under "adapted", not dropped; see that test.
+//!
+//! No divergence: oracle case 2's `container2 findsNothing` after the third
+//! back-to-back swap (with no elapsed time between swaps) is not special-cased
+//! Flutter behavior — it falls straight out of `AnimationController::reverse()`
+//! firing `Dismissed` SYNCHRONOUSLY when called on a controller already
+//! sitting at `value == 0.0` (`container2`'s entry, demoted the instant its own
+//! forward run started, never having ticked away from 0). `back_to_back_swaps`
+//! ports this in full, and `demoting_an_entry_still_at_the_lower_bound_dismisses_it_immediately`
+//! pins the mechanism directly at the `AnimationController` level.
+//!
+//! Harness note (not a divergence): a `pump_widget`/`pump_for` call ticks
+//! registered controllers on the virtual clock BEFORE running that frame's
+//! build pass (`flui-binding`'s `pump_frame`: `vsync.tick_all` is step 3,
+//! `build_scope` is step 4-7) — so a `reverse()`/`forward()` call made
+//! DURING a build (as `did_update_view` does) is not observed by
+//! `vsync.tick_all` until the FOLLOWING tick, which then spends itself purely
+//! anchoring the fresh run's `t = 0` (elapsed `0` for that call) rather than
+//! advancing it. Any assertion that reads a just-started run's value after
+//! real elapsed time needs one extra `pump_for(Duration::ZERO)` "detection"
+//! tick first — the same idiom `animated_container_test.rs`'s
+//! `animated_container_retargets_one_property_while_sibling_holds_steady`
+//! already uses (`laid.pump_for(Duration::ZERO); // detection frame: anchors
+//! the fresh run`). Flutter's own `tester.pump(duration)` has no such
+//! artifact (its ticker observes the SAME frame's `forward()`/`reverse()`
+//! call), so this is purely how this headless harness sequences one
+//! `pump_frame` call, not a product-behavior difference.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use flui_animation::{Animation, AnimationController, Scheduler, Vsync};
+use flui_foundation::{ValueKey, ViewKey};
+use flui_types::Color;
+use flui_view::element::ElementKind;
+use flui_view::prelude::{BuildContext, StatefulView};
+use flui_view::{BoxedView, IntoView, StatelessView, View, ViewExt, ViewState};
+use flui_widgets::{
+    AnimatedSwitcher, ColoredBox, Column, FadeTransition, ScaleTransition, SizedBox, Text,
+    VsyncScope,
+};
+
+use crate::common::{self, lay_out, lay_out_animated, tight};
+use crate::harness::screen;
+
+const RUN: Duration = Duration::from_millis(100);
+
+/// The three colors the oracle's `containerOne`/`Two`/`Three` paint (values
+/// are cosmetic only — no test reads them back, only opacity/transition
+/// identity matters).
+fn child_a() -> BoxedView {
+    ColoredBox::new(Color::rgba(0, 0, 0, 0)).boxed()
+}
+fn child_b() -> BoxedView {
+    SizedBox::new(10.0, 10.0).boxed()
+}
+fn child_c() -> BoxedView {
+    Text::new("three").boxed()
+}
+
+/// `AnimatedSwitcher fades in a new child.`
+///
+/// Oracle: `animated_switcher_test.dart`, tag `3.44.0`. Three back-to-back,
+/// `can_update`-incompatible children (distinct concrete types substitute for
+/// the oracle's distinct `Key`s — see the module doc). Exact fade values at
+/// each step follow from `Curves::Linear` (the widget's default in both
+/// directions) driving `AnimationController::value` linearly over `RUN`.
+#[test]
+fn fades_in_a_new_child() {
+    let vsync = Vsync::new();
+    let root = VsyncScope::new(vsync.clone(), AnimatedSwitcher::new(RUN).child(child_a()));
+    let mut laid = lay_out_animated(root, screen(), vsync.clone());
+
+    let opacities = |laid: &common::LaidOut| -> Vec<f32> {
+        laid.find_all_by_render_type("RenderOpacity")
+            .iter()
+            .map(|&id| laid.opacity(id))
+            .collect()
+    };
+
+    assert_eq!(
+        opacities(&laid),
+        vec![1.0],
+        "the first child mounts fully opaque, no motion"
+    );
+
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(child_b()),
+    ));
+    laid.pump_for(Duration::ZERO); // detection tick (module doc's harness note): anchors the fresh reverse and forward runs
+    laid.pump_for(Duration::from_millis(50));
+    let mid = opacities(&laid);
+    assert_eq!(
+        mid.len(),
+        2,
+        "outgoing child_a and incoming child_b are both mounted mid-transition"
+    );
+    assert_eq!(
+        mid[0], 0.5,
+        "child_a (outgoing) is halfway through its 100ms reverse at 50ms"
+    );
+    assert_eq!(
+        mid[1], 0.5,
+        "child_b (incoming) is halfway through its 100ms forward at 50ms"
+    );
+
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(child_c()),
+    ));
+    laid.pump_for(Duration::ZERO); // detection tick for child_b's fresh reverse and child_c's fresh forward
+    laid.pump_for(Duration::from_millis(10));
+    let late = opacities(&laid);
+    assert_eq!(
+        late.len(),
+        3,
+        "all three entries are still mounted 10ms after the second swap"
+    );
+    assert!(
+        (late[0] - 0.4).abs() < 1e-4,
+        "child_a: reversing from 0.5, 10ms further along its own 100ms run -> 0.4, got {}",
+        late[0]
+    );
+    assert!(
+        (late[1] - 0.4).abs() < 1e-4,
+        "child_b: demoted at 0.5, reversing 10ms into a FRESH 100ms run -> 0.4, got {}",
+        late[1]
+    );
+    assert!(
+        (late[2] - 0.1).abs() < 1e-4,
+        "child_c: forward 10ms into its 100ms run -> 0.1, got {}",
+        late[2]
+    );
+
+    laid.pump_for(RUN);
+    assert_eq!(
+        opacities(&laid),
+        vec![1.0],
+        "settling the run dismisses every outgoing entry, leaving only child_c at full opacity"
+    );
+}
+
+/// `AnimatedSwitcher can handle back-to-back changes.` (adapted: distinct
+/// types substitute for distinct keys — see the module doc — otherwise
+/// ported in full)
+///
+/// Oracle: `animated_switcher_test.dart`, tag `3.44.0`. Three back-to-back
+/// swaps with NO elapsed time between them: `child_a` survives (present
+/// throughout, current then outgoing), `child_b` is demoted to outgoing the
+/// instant its own forward run started — before any real time gave it a
+/// value above `0.0` — so reversing it synchronously dismisses it (see the
+/// module doc's harness note); `child_c` is the new current entry.
+#[test]
+fn back_to_back_swaps() {
+    let vsync = Vsync::new();
+    let root = VsyncScope::new(vsync.clone(), AnimatedSwitcher::new(RUN).child(child_a()));
+    let mut laid = lay_out_animated(root, screen(), vsync.clone());
+    assert_eq!(
+        laid.find_all_by_render_type("RenderDecoratedBox").len(),
+        1,
+        "child_a present"
+    );
+    assert_eq!(
+        laid.find_all_by_render_type("RenderConstrainedBox").len(),
+        0,
+        "child_b absent"
+    );
+    assert!(laid.find_text("three").is_none(), "child_c absent");
+
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(child_b()),
+    ));
+    assert_eq!(
+        laid.find_all_by_render_type("RenderDecoratedBox").len(),
+        1,
+        "child_a still present (outgoing)"
+    );
+    assert_eq!(
+        laid.find_all_by_render_type("RenderConstrainedBox").len(),
+        1,
+        "child_b present (current)"
+    );
+    assert!(laid.find_text("three").is_none(), "child_c absent");
+
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(child_c()),
+    ));
+    assert_eq!(
+        laid.find_all_by_render_type("RenderDecoratedBox").len(),
+        1,
+        "child_a still present (outgoing)"
+    );
+    assert_eq!(
+        laid.find_all_by_render_type("RenderConstrainedBox").len(),
+        0,
+        "child_b dismissed synchronously: it never ticked away from value 0.0 before being reversed"
+    );
+    assert!(
+        laid.find_text("three").is_some(),
+        "child_c present (current)"
+    );
+}
+
+/// `AnimatedSwitcher doesn't transition in a new child of the same type.`
+///
+/// Oracle: `animated_switcher_test.dart`, tag `3.44.0`. Two keyless
+/// `ColoredBox` values (same concrete type, same `None` key) are
+/// `can_update`-compatible — the entry updates in place, no second
+/// `FadeTransition`/`RenderOpacity` mounts, and the existing one stays at its
+/// already-settled opacity.
+#[test]
+fn same_type_keyless_child_does_not_transition() {
+    let vsync = Vsync::new();
+    let root = VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(ColoredBox::new(Color::rgba(0, 0, 0, 0))),
+    );
+    let mut laid = lay_out_animated(root, screen(), vsync.clone());
+    assert_eq!(laid.find_all_by_render_type("RenderOpacity").len(), 1);
+    assert_eq!(laid.opacity(laid.find_by_render_type("RenderOpacity")), 1.0);
+
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(ColoredBox::new(Color::rgba(0, 0, 0, 255))),
+    ));
+    laid.pump_for(Duration::from_millis(50));
+
+    assert_eq!(
+        laid.find_all_by_render_type("RenderOpacity").len(),
+        1,
+        "a can_update-compatible child update must not start a second transition"
+    );
+    assert_eq!(
+        laid.opacity(laid.find_by_render_type("RenderOpacity")),
+        1.0,
+        "the untouched entry stays at its already-settled opacity"
+    );
+}
+
+/// `AnimatedSwitcher handles null children.`
+///
+/// Oracle: `animated_switcher_test.dart`, tag `3.44.0`. `None` <-> `Some`
+/// transitions animate exactly like any other `can_update`-incompatible swap.
+#[test]
+fn handles_no_child() {
+    let vsync = Vsync::new();
+    let root = VsyncScope::new(vsync.clone(), AnimatedSwitcher::new(RUN));
+    let mut laid = lay_out_animated(root, screen(), vsync.clone());
+    assert_eq!(laid.find_all_by_render_type("RenderOpacity").len(), 0);
+
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(ColoredBox::new(Color::rgba(0, 0, 0, 255))),
+    ));
+    laid.pump_for(Duration::ZERO); // detection tick: anchors the fresh forward run
+    laid.pump_for(Duration::from_millis(50));
+    assert_eq!(laid.opacity(laid.find_by_render_type("RenderOpacity")), 0.5);
+    laid.pump_for(RUN);
+
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(ColoredBox::new(Color::rgba(0, 0, 0, 0))),
+    ));
+    assert_eq!(
+        laid.find_all_by_render_type("RenderOpacity").len(),
+        1,
+        "same-type keyless swap updates in place, does not start a None-shaped transition"
+    );
+
+    laid.pump_widget(VsyncScope::new(vsync.clone(), AnimatedSwitcher::new(RUN)));
+    laid.pump_for(Duration::ZERO); // detection tick: anchors the fresh reverse run
+    laid.pump_for(Duration::from_millis(50));
+    assert_eq!(
+        laid.opacity(laid.find_by_render_type("RenderOpacity")),
+        0.5,
+        "child -> None transitions out exactly like child -> child"
+    );
+}
+
+/// `AnimatedSwitcher doesn't start any animations after dispose.`
+///
+/// Oracle: `animated_switcher_test.dart`, tag `3.44.0`. Replacing the whole
+/// root (unmounting `AnimatedSwitcher` mid-transition) must dispose every
+/// entry's controller — driving a further frame must not panic.
+#[test]
+fn no_animation_after_dispose() {
+    let vsync = Vsync::new();
+    let root = VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(ColoredBox::new(Color::rgba(0, 0, 0, 255))),
+    );
+    let mut laid = lay_out_animated(root, screen(), vsync.clone());
+    laid.pump_for(Duration::from_millis(50));
+
+    laid.pump_widget(ColoredBox::new(Color::rgba(255, 0, 0, 255)));
+    laid.pump_for(RUN); // must not panic: every entry's controller was disposed
+}
+
+/// `AnimatedSwitcher uses custom layout.`
+///
+/// Oracle: `animated_switcher_test.dart`, tag `3.44.0`.
+#[test]
+fn uses_custom_layout() {
+    let vsync = Vsync::new();
+    let root = VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN)
+            .layout_builder(|current, previous| {
+                let mut children = previous;
+                children.extend(current);
+                Column::new(children).boxed()
+            })
+            .child(ColoredBox::new(Color::rgba(0, 0, 0, 0))),
+    );
+    let laid = lay_out_animated(root, screen(), vsync);
+
+    assert_eq!(
+        laid.find_all_by_render_type("RenderFlex").len(),
+        1,
+        "the custom layout_builder's Column (-> RenderFlex) replaces the default Stack"
+    );
+}
+
+/// `AnimatedSwitcher uses custom transitions.`
+///
+/// Oracle: `animated_switcher_test.dart`, tag `3.44.0`. A custom
+/// `transition_builder` (here `ScaleTransition` -> `RenderTransform`) is used
+/// instead of the default fade, both for the initial child and for a
+/// transitioning-out one.
+#[test]
+fn uses_custom_transitions() {
+    let vsync = Vsync::new();
+    let scale_builder = |child: BoxedView, animation: Arc<dyn Animation<f32>>| -> BoxedView {
+        ScaleTransition::new(animation, child).boxed()
+    };
+    let root = VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN)
+            .transition_builder(scale_builder)
+            .child(ColoredBox::new(Color::rgba(0, 0, 0, 0))),
+    );
+    let mut laid = lay_out_animated(root, screen(), vsync.clone());
+    assert_eq!(laid.find_all_by_render_type("RenderTransform").len(), 1);
+    assert_eq!(
+        laid.find_all_by_render_type("RenderOpacity").len(),
+        0,
+        "no default fade is built"
+    );
+
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).transition_builder(scale_builder),
+    ));
+    laid.pump_for(Duration::from_millis(50));
+    assert_eq!(
+        laid.find_all_by_render_type("RenderTransform").len(),
+        1,
+        "the outgoing entry (child -> None) is scaled too, via the same custom builder"
+    );
+}
+
+/// Declares a `StatefulView` marker type (a distinct concrete type per
+/// invocation, so each is `can_update`-incompatible with the others) whose
+/// state bumps a shared generation counter exactly once, in `init_state`.
+/// Substitutes for the oracle's single `StatefulTest` type instantiated three
+/// times under three distinct `UniqueKey`s — see the module doc's key
+/// substitution note.
+macro_rules! generation_probe {
+    ($view:ident, $state:ident) => {
+        #[derive(Clone, StatefulView)]
+        struct $view(Arc<AtomicU32>);
+
+        struct $state(Arc<AtomicU32>);
+
+        impl StatefulView for $view {
+            type State = $state;
+            fn create_state(&self) -> Self::State {
+                $state(Arc::clone(&self.0))
+            }
+        }
+
+        impl ViewState<$view> for $state {
+            fn init_state(&mut self, _ctx: &dyn BuildContext) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+            fn build(&self, _view: &$view, _ctx: &dyn BuildContext) -> impl IntoView {
+                SizedBox::new(10.0, 10.0)
+            }
+        }
+    };
+}
+
+/// `AnimatedSwitcher doesn't reset state of the children in transitions.`
+/// (adapted: three distinct probe types substitute for one `StatefulTest`
+/// type keyed three ways — see the module doc.)
+///
+/// Oracle: `animated_switcher_test.dart`, tag `3.44.0`. Each of three
+/// back-to-back swaps mounts exactly ONE fresh `State` (`init_state` runs
+/// once per swap, not once per frame) — an entry animating out must stay
+/// MOUNTED, not be torn down and rebuilt.
+#[test]
+fn preserves_child_state_across_transitions() {
+    generation_probe!(ProbeA, ProbeAState);
+    generation_probe!(ProbeB, ProbeBState);
+    generation_probe!(ProbeC, ProbeCState);
+
+    let generation = Arc::new(AtomicU32::new(0));
+    let vsync = Vsync::new();
+    let root = VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(ProbeA(Arc::clone(&generation))),
+    );
+    let mut laid = lay_out_animated(root, screen(), vsync.clone());
+    assert_eq!(generation.load(Ordering::SeqCst), 1);
+
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(ProbeB(Arc::clone(&generation))),
+    ));
+    laid.pump_for(Duration::from_millis(50));
+    assert_eq!(
+        generation.load(Ordering::SeqCst),
+        2,
+        "exactly one more State mounted, not re-mounted per frame"
+    );
+
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(ProbeC(Arc::clone(&generation))),
+    ));
+    laid.pump_for(Duration::from_millis(10));
+    assert_eq!(generation.load(Ordering::SeqCst), 3);
+    laid.pump_for(RUN);
+    assert_eq!(
+        generation.load(Ordering::SeqCst),
+        3,
+        "settling the whole run must not remount anything further"
+    );
+}
+
+/// `AnimatedSwitcher updates widgets without animating if they are
+/// isomorphic.`
+///
+/// Oracle: `animated_switcher_test.dart`, tag `3.44.0`. `Text` values with no
+/// key are `can_update`-compatible regardless of their `data` — the entry
+/// updates in place at full opacity throughout.
+#[test]
+fn isomorphic_rebuild_does_not_animate() {
+    let vsync = Vsync::new();
+    let root = VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(Text::new("1")),
+    );
+    let mut laid = lay_out_animated(root, screen(), vsync.clone());
+    laid.pump_for(Duration::from_millis(10));
+    assert_eq!(laid.opacity(laid.find_by_render_type("RenderOpacity")), 1.0);
+    assert!(laid.find_text("1").is_some());
+    assert!(laid.find_text("2").is_none());
+
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(Text::new("2")),
+    ));
+    laid.pump_for(Duration::from_millis(20));
+
+    assert_eq!(
+        laid.find_all_by_render_type("RenderOpacity").len(),
+        1,
+        "same type, no key: updates the one existing entry, no second transition"
+    );
+    assert_eq!(laid.opacity(laid.find_by_render_type("RenderOpacity")), 1.0);
+    assert!(laid.find_text("1").is_none());
+    assert!(laid.find_text("2").is_some());
+}
+
+/// `AnimatedSwitcher updates previous child transitions if the
+/// transitionBuilder changes.` (narrowed — see the module doc for the
+/// dropped `isA<KeyedSubtree>()` sub-assertion.)
+///
+/// Oracle: `animated_switcher_test.dart`, tag `3.44.0`. Three back-to-back
+/// swaps leave three entries in flight (one current, two outgoing); swapping
+/// `transition_builder` alone (same child) must rebuild ALL THREE cached
+/// transitions under the new builder, not just future ones.
+#[test]
+fn transition_builder_change_updates_every_cached_entry() {
+    let vsync = Vsync::new();
+    let root = VsyncScope::new(vsync.clone(), AnimatedSwitcher::new(RUN).child(child_a()));
+    let mut laid = lay_out_animated(root, screen(), vsync.clone());
+    laid.pump_for(Duration::from_millis(10));
+
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(child_b()),
+    ));
+    // Detection tick (see the module doc's harness note): without it, child_a's
+    // just-reversed run would be un-anchored, and this call's real 10ms would
+    // be spent anchoring rather than advancing.
+    laid.pump_for(Duration::ZERO);
+    laid.pump_for(Duration::from_millis(10));
+
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(child_c()),
+    ));
+    // Detection tick: child_b was demoted at value 0.1 (not 0.0), so this run
+    // needs the same anchor-then-advance sequence to avoid synchronous dismiss.
+    // Only 5ms of real time here (not 10ms): child_b's reverse run would
+    // complete EXACTLY at 10ms (it was demoted at value 0.1 of a 100ms run),
+    // dismissing it before the assertion below can observe all three entries
+    // simultaneously.
+    laid.pump_for(Duration::ZERO);
+    laid.pump_for(Duration::from_millis(5));
+
+    assert_eq!(
+        laid.find_all_by_render_type("RenderOpacity").len(),
+        3,
+        "three entries (child_a, child_b outgoing; child_c current) are in flight"
+    );
+
+    let scale_builder = |child: BoxedView, animation: Arc<dyn Animation<f32>>| -> BoxedView {
+        ScaleTransition::new(animation, child).boxed()
+    };
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN)
+            .transition_builder(scale_builder)
+            .child(child_c()),
+    ));
+
+    assert_eq!(
+        laid.find_all_by_render_type("RenderOpacity").len(),
+        0,
+        "every cached transition (current AND both outgoing) was rebuilt under the new builder"
+    );
+    assert_eq!(
+        laid.find_all_by_render_type("RenderTransform").len(),
+        3,
+        "all three entries now render via ScaleTransition"
+    );
+}
+
+/// A test-local stand-in for Flutter's `KeyedSubtree` / FLUI's private
+/// `KeyedEntry` (`animated_switcher.rs`) — hand-rolled `impl View` carrying
+/// an explicit key, the same sanctioned pattern
+/// `flui-widgets/src/overlay/mod.rs`'s `OverlayEntryView` uses in production.
+/// Needed here (and only here) because `flui_foundation::Keyed<V>` has no
+/// `impl View` anywhere in the codebase — see the module doc.
+#[derive(Clone)]
+struct Keyed {
+    key: ValueKey<&'static str>,
+    child: BoxedView,
+}
+
+impl Keyed {
+    fn new(key: &'static str, child: impl IntoView) -> Self {
+        Self {
+            key: ValueKey::new(key),
+            child: child.into_view().boxed(),
+        }
+    }
+}
+
+impl View for Keyed {
+    fn create_element(&self) -> ElementKind {
+        ElementKind::stateless(self)
+    }
+    fn key(&self) -> Option<&dyn ViewKey> {
+        Some(&self.key)
+    }
+}
+
+impl StatelessView for Keyed {
+    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+        self.child.clone()
+    }
+}
+
+/// `AnimatedSwitcher does not duplicate animations if the same child is
+/// entered twice.` (adapted: uses the test-local `Keyed` wrapper — see the
+/// module doc.)
+///
+/// Oracle: `animated_switcher_test.dart`, tag `3.44.0`. `Text('1', key:
+/// '1')` -> `Text('2', key: '2')` -> `Text('1', key: '1')` (same key as the
+/// FIRST child, reappearing while that first entry may still be mid-reverse)
+/// must not collapse two live entries into one or crash; each swap starts a
+/// fresh, independent entry (`AnimatedSwitcher` does no key-based entry
+/// lookup — every `can_update`-incompatible swap mints a new `child_number`,
+/// exactly like the oracle's `_childNumber += 1`), and the run settles with
+/// exactly the reentered child visible.
+#[test]
+fn reentering_a_still_dismissing_key_starts_a_fresh_entry_not_a_duplicate() {
+    let vsync = Vsync::new();
+    let root = VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(Keyed::new("1", Text::new("1"))),
+    );
+    let mut laid = lay_out_animated(root, screen(), vsync.clone());
+
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(Keyed::new("2", Text::new("2"))),
+    ));
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        AnimatedSwitcher::new(RUN).child(Keyed::new("1", Text::new("1"))),
+    ));
+
+    laid.pump_for(RUN);
+    assert_eq!(
+        laid.find_all_by_render_type("RenderOpacity").len(),
+        1,
+        "the run settles to exactly one entry"
+    );
+    assert!(
+        laid.find_text("1").is_some(),
+        "the reentered key-\"1\" child is the one left standing"
+    );
+    assert!(laid.find_text("2").is_none());
+}
+
+/// Pins the mechanism the module doc's Divergence note names: reversing a
+/// controller that is ALREADY at its lower bound (value `0.0`) transitions it
+/// straight to `Dismissed` — synchronously, with no elapsed time. This is
+/// what makes the oracle's `container2` (demoted the instant its own forward
+/// run started, at value `0.0`) disappear immediately rather than animate out
+/// over the reverse duration.
+#[test]
+fn demoting_an_entry_still_at_the_lower_bound_dismisses_it_immediately() {
+    let controller = AnimationController::new(RUN, Arc::new(Scheduler::new()));
+    assert_eq!(controller.value(), 0.0);
+    let _ = controller.reverse();
+    assert_eq!(
+        controller.status(),
+        flui_animation::AnimationStatus::Dismissed,
+        "reverse() called while already at the lower bound must dismiss synchronously"
+    );
+}
+
+/// `AnimatedSwitcher does not crash at zero area`
+///
+/// Oracle: `animated_switcher_test.dart`, tag `3.44.0`.
+#[test]
+fn does_not_crash_at_zero_area() {
+    let short = Duration::from_micros(500);
+    let mut laid = lay_out(
+        SizedBox::shrink().child(AnimatedSwitcher::new(short)),
+        tight(0.0, 0.0),
+    );
+    assert_eq!(laid.size(laid.current_root()), common::size(0.0, 0.0));
+
+    laid.pump_widget(SizedBox::shrink().child(AnimatedSwitcher::new(short).child(Text::new("x"))));
+    assert_eq!(laid.size(laid.current_root()), common::size(0.0, 0.0));
+
+    laid.pump_widget(SizedBox::shrink().child(AnimatedSwitcher::new(short).child(Text::new("y"))));
+    assert_eq!(laid.size(laid.current_root()), common::size(0.0, 0.0));
+}
+
+/// Not an oracle case — pins the harness-tick-ordering mechanism the module
+/// doc's harness note describes and every `Duration::ZERO` detection tick in
+/// this file relies on: a controller's very first tick after a fresh
+/// `reverse()`/`forward()` call only anchors the run (elapsed `0`); a SECOND
+/// tick is required to observe real progress. Isolated to a bare
+/// `AnimationController` + `FadeTransition`, decoupled from
+/// `AnimatedSwitcher`, so a future change to `pump_frame`'s phase ordering
+/// fails this test directly instead of only failing as an unexplained
+/// timing flake in the oracle ports above.
+#[test]
+fn reverse_needs_a_detection_tick_before_progress_is_observable() {
+    let vsync = Vsync::new();
+    let controller = AnimationController::new(RUN, Arc::new(Scheduler::new()));
+    controller.set_value(1.0);
+    let root = VsyncScope::new(
+        vsync.clone(),
+        FadeTransition::new(Arc::new(controller.clone()), SizedBox::new(1.0, 1.0)),
+    );
+    let mut laid = lay_out_animated(root, screen(), vsync.clone());
+    laid.register_controller(controller.clone());
+    assert_eq!(laid.opacity(laid.find_by_render_type("RenderOpacity")), 1.0);
+
+    let _ = controller.reverse();
+    laid.pump_for(Duration::from_millis(50));
+    assert_eq!(
+        laid.opacity(laid.find_by_render_type("RenderOpacity")),
+        1.0,
+        "the FIRST tick after reverse() only anchors the run; it must not advance the value"
+    );
+
+    laid.pump_for(Duration::from_millis(50));
+    assert_eq!(
+        laid.opacity(laid.find_by_render_type("RenderOpacity")),
+        0.5,
+        "the SECOND tick observes real elapsed time against the anchor set by the first"
+    );
+}

--- a/crates/flui-widgets/tests/parity/animated_switcher_test.rs
+++ b/crates/flui-widgets/tests/parity/animated_switcher_test.rs
@@ -58,13 +58,15 @@
 //!   integration test outside the module to assert on — the render-type
 //!   evidence (transitions actually swap) is asserted instead.
 //!
-//! Out of scope: 1 of 12.
+//! Adapted: 1 of 12.
 //! - `'AnimatedSwitcher does not duplicate animations if the same child is
 //!   entered twice.'` — needs a KEYED widget re-entering after its ORIGINAL
 //!   entry already exists (possibly still outgoing); ported as
 //!   `reentering_a_still_dismissing_key_starts_a_fresh_entry_not_a_duplicate`
-//!   using the test-local `Keyed<W>` wrapper (see above), so functionally
-//!   this is covered — filed under "adapted", not dropped; see that test.
+//!   using the test-local `Keyed<W>` wrapper (see above) — functionally
+//!   covered, not dropped; see that test.
+//!
+//! Arithmetic: 10 ported + 1 adapted-and-narrowed + 1 adapted = 12.
 //!
 //! No divergence: oracle case 2's `container2 findsNothing` after the third
 //! back-to-back swap (with no elapsed time between swaps) is not special-cased
@@ -206,6 +208,11 @@ fn fades_in_a_new_child() {
         vec![1.0],
         "settling the run dismisses every outgoing entry, leaving only child_c at full opacity"
     );
+    assert_eq!(
+        vsync.len(),
+        1,
+        "settling must unregister every dismissed entry's controller, leaving only child_c's"
+    );
 }
 
 /// `AnimatedSwitcher can handle back-to-back changes.` (adapted: distinct
@@ -311,6 +318,10 @@ fn same_type_keyless_child_does_not_transition() {
 ///
 /// Oracle: `animated_switcher_test.dart`, tag `3.44.0`. `None` <-> `Some`
 /// transitions animate exactly like any other `can_update`-incompatible swap.
+/// Ported in full, including the oracle's tail: a SECOND `pumpWidget` of the
+/// SAME child-less switcher while the previous child is still reversing out
+/// is a genuine no-op reconfigure (`has_new_child == has_old_child == false`)
+/// that must not restart or otherwise disturb the in-flight entry.
 #[test]
 fn handles_no_child() {
     let vsync = Vsync::new();
@@ -336,6 +347,11 @@ fn handles_no_child() {
         1,
         "same-type keyless swap updates in place, does not start a None-shaped transition"
     );
+    assert_eq!(
+        laid.opacity(laid.find_by_render_type("RenderOpacity")),
+        1.0,
+        "an in-place update does not restart the transition; opacity stays at its settled value"
+    );
 
     laid.pump_widget(VsyncScope::new(vsync.clone(), AnimatedSwitcher::new(RUN)));
     laid.pump_for(Duration::ZERO); // detection tick: anchors the fresh reverse run
@@ -345,13 +361,51 @@ fn handles_no_child() {
         0.5,
         "child -> None transitions out exactly like child -> child"
     );
+
+    // Oracle tail: a SECOND pumpWidget of the same child-less switcher, mid
+    // reverse — a genuine no-op reconfigure. `did_update_view` matches
+    // `(None, None)` and takes neither branch, so the in-flight outgoing
+    // entry must continue completely undisturbed by this reconfigure.
+    laid.pump_widget(VsyncScope::new(vsync.clone(), AnimatedSwitcher::new(RUN)));
+    // 49ms, not the oracle's 50ms (which would land exactly on the 100ms
+    // reverse duration's completion): this harness ticks vsync BEFORE
+    // running that frame's build pass (see the module doc's harness note),
+    // so a controller dismissing exactly during a `pump_for` call is swept
+    // and removed from the tree within that SAME call — there is no
+    // observable "still mounted at exactly 0.0" frame the way Flutter's
+    // tick-then-rebuild-next-frame ordering provides. 49ms instead proves
+    // the same contract just as strongly: if the no-op reconfigure had
+    // wrongly restarted the reverse run, this tick would show ~0.5
+    // (a fresh run's detection tick) instead of continuing down to ~0.01.
+    laid.pump_for(Duration::from_millis(49));
+    let opacity = laid.opacity(laid.find_by_render_type("RenderOpacity"));
+    assert!(
+        (opacity - 0.01).abs() < 1e-3,
+        "the no-op reconfigure must not restart the reverse run: total elapsed \
+         (50ms + 49ms of the 100ms reverse) should show near-zero opacity, got \
+         {opacity} — 0.5 would mean the no-op reconfigure wrongly restarted the run"
+    );
 }
 
 /// `AnimatedSwitcher doesn't start any animations after dispose.`
 ///
-/// Oracle: `animated_switcher_test.dart`, tag `3.44.0`. Replacing the whole
-/// root (unmounting `AnimatedSwitcher` mid-transition) must dispose every
-/// entry's controller — driving a further frame must not panic.
+/// Oracle: `animated_switcher_test.dart`, tag `3.44.0` — asserts
+/// `tester.pumpAndSettle() == 1` (exactly one frame was needed to settle after
+/// the swap, i.e. nothing kept requesting more). FLUI's harness has no
+/// pump-count-until-settled equivalent, so this asserts the mechanism that
+/// guarantee rests on directly: unmounting `AnimatedSwitcher` mid-transition
+/// must dispose every entry's controller AND unregister it from `vsync` —
+/// `vsync.len() == 0` afterward is the evidence that nothing is left for a
+/// frame driver to keep ticking, and a further frame must not panic.
+///
+/// The unmount is a CHILD swap under a stable `VsyncScope` root (not a root
+/// swap): `ElementTree::update` on the ROOT position does not itself run
+/// `finalize_tree` before this harness's very next `vsync.len()` read is
+/// possible to express within one test body (a generic, pre-existing
+/// framework/harness property, confirmed independent of `AnimatedSwitcher` by
+/// reproducing it with a root-swapped `AnimatedContainer`) — swapping the
+/// CHILD under an unchanged root reconciles and finalizes normally within one
+/// `pump_widget` call, which is what actually exercises `AnimatedSwitcherState::dispose`.
 #[test]
 fn no_animation_after_dispose() {
     let vsync = Vsync::new();
@@ -360,10 +414,23 @@ fn no_animation_after_dispose() {
         AnimatedSwitcher::new(RUN).child(ColoredBox::new(Color::rgba(0, 0, 0, 255))),
     );
     let mut laid = lay_out_animated(root, screen(), vsync.clone());
+    assert_eq!(
+        vsync.len(),
+        1,
+        "the single mounted entry registers its controller"
+    );
     laid.pump_for(Duration::from_millis(50));
 
-    laid.pump_widget(ColoredBox::new(Color::rgba(255, 0, 0, 255)));
-    laid.pump_for(RUN); // must not panic: every entry's controller was disposed
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        ColoredBox::new(Color::rgba(255, 0, 0, 255)),
+    ));
+    assert_eq!(
+        vsync.len(),
+        0,
+        "unmounting AnimatedSwitcher mid-transition must dispose and unregister every entry"
+    );
+    laid.pump_for(RUN); // must not panic: nothing left registered to tick
 }
 
 /// `AnimatedSwitcher uses custom layout.`
@@ -468,6 +535,18 @@ macro_rules! generation_probe {
 /// back-to-back swaps mounts exactly ONE fresh `State` (`init_state` runs
 /// once per swap, not once per frame) — an entry animating out must stay
 /// MOUNTED, not be torn down and rebuilt.
+///
+/// Dropped co-assertions (this port keeps ONLY the generation counter, which
+/// is this test's own distinguishing point — the others duplicate coverage
+/// this file already carries elsewhere on the same shape of children):
+/// - The `FadeTransition` COUNT at each step (1, then 2, then 3 — via
+///   `find.byType(FadeTransition)` / `.at(0/1/2)`) — the same count
+///   trajectory `fades_in_a_new_child` already asserts.
+/// - The exact opacity VALUES at each step (`1.0`, then `0.5`, then
+///   `0.4`/`0.4`/`0.1`) — the identical trajectory (same durations, same
+///   `Curves::Linear`, same three-entries-in-flight shape)
+///   `fades_in_a_new_child` already asserts in full, just against
+///   `ColoredBox`/`SizedBox`/`Text` instead of `StatefulTest`.
 #[test]
 fn preserves_child_state_across_transitions() {
     generation_probe!(ProbeA, ProbeAState);

--- a/crates/flui-widgets/tests/parity/main.rs
+++ b/crates/flui-widgets/tests/parity/main.rs
@@ -88,6 +88,7 @@ mod animated_align_test;
 mod animated_container_test;
 mod animated_padding_test;
 mod animated_size_test;
+mod animated_switcher_test;
 
 // ── Business.1 fidelity front — Clip family parity (family 8) ───────────────
 mod clip_test;


### PR DESCRIPTION
Business.1 implementation-gated fidelity unit: `AnimatedSwitcher` lands in `flui-widgets` with its parity corpus — 14 tests covering the full 12-case oracle denominator (`10 ported + 1 adapted + 1 = 12`) against `animated_switcher.dart` / `animated_switcher_test.dart` @ 3.44.0.

## The widget

Per-entry explicit controllers: an incoming child fades in while every outgoing entry animates out simultaneously; switching is keyed by the reconciler's real `View::can_update` predicate (type-id + key — not an invented comparison); a same-key rebuild updates in place without re-animating; a mid-flight re-switch mints a fresh entry (the oracle's `_childNumber` semantics); `duration`/`reverse_duration`/`switch_in_curve`/`switch_out_curve` are captured per entry at creation so changing them never affects transitions in progress; `transition_builder` (default fade) and `layout_builder` (default stack, newest-on-top-center) follow the oracle's builder contract. Every per-entry controller is disposed on entry removal and on widget dispose.

## Discipline notes

- The dispose/leak contract is pinned the only way that actually works: Flutter's `pumpAndSettle() == 1` translates to `Vsync::len()` registration-count asserts — the review proved a "must not panic" pump lets BOTH disposal mutants survive (leaked registered controllers tick without panicking); both mutants now die against the count asserts and were independently re-run by the reviewer.
- `handles_no_child` carries the oracle's full tail including the unchanged-rebuild-mid-out-transition segment, with the one timing adaptation (49 ms vs an unobservable exactly-0.0 frame) justified at the assertion site by the harness's tick-before-build ordering.

## Evidence

- `cargo nextest run --workspace --exclude flui-platform`: 7607+ passed; clippy `-D warnings`, fmt/port-check/inventory/taplo/typos, doctests: clean.
- Reviewer verified the implementation contract line-by-line against the oracle, ran four mutants across two rounds (compatible-child re-animate, demote-reversal, both disposal paths) — all killed.
- Full review + delta re-review: SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)