### PR TITLE
fix(foundation): allow ChangeNotifier::remove_listener after dispose (Flutter parity)

### DIFF
--- a/crates/flui-foundation/src/listener_registry.rs
+++ b/crates/flui-foundation/src/listener_registry.rs
@@ -81,12 +81,15 @@ trait RemoveFrom: Send + Sync {
 
 impl<S: Send + Sync + 'static> RemoveFrom for RegistryInner<S> {
     fn remove(&self, channel: Channel, id: ListenerId) {
-        // After `dispose()` both channels have already cleared their listeners
-        // and a further `remove` would debug-panic (use-after-dispose). A live
+        // After `dispose()` both channels have already cleared their listeners.
+        // The Value channel (`ChangeNotifier::remove_listener`) tolerates
+        // post-dispose removal per Flutter parity, so its guard below is merely
+        // redundant; the Status channel (`Notifier::remove`) still debug-panics
+        // on use-after-dispose, so ITS guard is load-bearing. A live
         // `ListenerSubscription` dropped after the registry is disposed must stay
         // safe — otherwise disposing while a subscription is alive aborts on its
-        // drop — so skip the now-redundant channel removal once disposed, while
-        // still decrementing the shared count to keep the 1 → 0 edge exact.
+        // drop — so skip the channel removal once disposed, while still
+        // decrementing the shared count to keep the 1 → 0 edge exact.
         match channel {
             Channel::Value => {
                 if !self.value.is_disposed() {

--- a/crates/flui-foundation/src/notifier.rs
+++ b/crates/flui-foundation/src/notifier.rs
@@ -406,8 +406,8 @@ impl Listenable for ChangeNotifier {
     fn remove_listener(&self, id: ListenerId) {
         // Deliberately NO disposed check here — Flutter parity.
         // `ChangeNotifier.removeListener` in `change_notifier.dart` carries no
-        // `debugAssertNotDisposed`, unlike `addListener`/`dispose` (and the
-        // implicit assert `notifyListeners` inherits): its doc comment states
+        // `debugAssertNotDisposed`, unlike `addListener`/`dispose`/
+        // `notifyListeners` (each carries an explicit assert): its doc comment states
         // "This method returns immediately if [dispose] has been called," and
         // the rationale is explicit — "it is common that the owner of this
         // instance would be disposed a frame earlier than the listeners.

--- a/crates/flui-foundation/src/notifier.rs
+++ b/crates/flui-foundation/src/notifier.rs
@@ -91,6 +91,10 @@ pub trait Listenable: Send + Sync {
     fn add_listener(&self, listener: ListenerCallback) -> ListenerId;
 
     /// Remove a previously registered listener.
+    ///
+    /// A no-op if `id` is not registered — including after the listenable
+    /// has been disposed (Flutter parity: `ChangeNotifier.removeListener`
+    /// tolerates a disposed receiver so teardown code can always detach).
     fn remove_listener(&self, id: ListenerId);
 
     /// Remove all listeners.
@@ -135,12 +139,17 @@ pub trait ValueListenable<T>: Listenable {
 ///
 /// # Disposal
 ///
-/// After [`dispose`] has been called, the notifier is no longer usable:
-/// [`add_listener`], [`notify_listeners`], and [`remove_listener`] panic in
-/// debug builds via `debug_assert!` and degrade to a `tracing::warn!` + no-op
-/// in release builds. Mirrors Flutter's `ChangeNotifier.dispose` and
-/// `_debugAssertNotDisposed` semantics
+/// After [`dispose`] has been called, [`add_listener`] and
+/// [`notify_listeners`] panic in debug builds via `debug_assert!` and
+/// degrade to a `tracing::warn!` + no-op in release builds. Mirrors
+/// Flutter's `ChangeNotifier.dispose` and `_debugAssertNotDisposed` semantics
 /// (`flutter/lib/src/foundation/change_notifier.dart:181`, :376).
+///
+/// [`remove_listener`] is the deliberate exception: it carries no disposed
+/// check in either build profile, matching `ChangeNotifier.removeListener`
+/// upstream, which has no `debugAssertNotDisposed` so that teardown code can
+/// detach from an already-disposed listenable. It is always a silent no-op
+/// once disposed (the listener map is already empty).
 ///
 /// `is_disposed` is shared across clones via `Arc<AtomicBool>` so that a
 /// listener-callback holding its own clone sees disposal performed elsewhere.
@@ -199,9 +208,11 @@ impl ChangeNotifier {
     /// Discards listeners and marks this notifier as disposed.
     ///
     /// After this is called, the notifier is not in a usable state:
-    /// subsequent calls to [`add_listener`], [`notify_listeners`], or
-    /// [`remove_listener`] panic in debug builds via `debug_assert!` and
-    /// degrade to a `tracing::warn!` + no-op in release builds.
+    /// subsequent calls to [`add_listener`] or [`notify_listeners`] panic in
+    /// debug builds via `debug_assert!` and degrade to a `tracing::warn!` +
+    /// no-op in release builds. [`remove_listener`] is the deliberate
+    /// exception — it stays a silent no-op after dispose (Flutter parity;
+    /// see [`Listenable::remove_listener`]'s impl on this type).
     ///
     /// Mirrors Flutter's `ChangeNotifier.dispose` at
     /// `flutter/lib/src/foundation/change_notifier.dart:376`. Disposal does
@@ -393,9 +404,17 @@ impl Listenable for ChangeNotifier {
     }
 
     fn remove_listener(&self, id: ListenerId) {
-        if self.check_disposed() {
-            return;
-        }
+        // Deliberately NO disposed check here — Flutter parity.
+        // `ChangeNotifier.removeListener` in `change_notifier.dart` carries no
+        // `debugAssertNotDisposed`, unlike `addListener`/`dispose` (and the
+        // implicit assert `notifyListeners` inherits): its doc comment states
+        // "This method returns immediately if [dispose] has been called," and
+        // the rationale is explicit — "it is common that the owner of this
+        // instance would be disposed a frame earlier than the listeners.
+        // Allowing calls to this method after it is disposed makes it easier
+        // for listeners to properly clean up." `dispose()` already cleared
+        // `self.listeners`, so the lookup below is naturally a no-op; the id
+        // simply isn't found.
         self.listeners.lock().remove(&id);
     }
 
@@ -1011,14 +1030,18 @@ mod tests {
         notifier.notify_listeners();
     }
 
-    #[cfg(debug_assertions)]
     #[test]
-    #[should_panic(expected = "ChangeNotifier used after dispose")]
-    fn dispose_then_remove_listener_debug_asserts() {
+    fn dispose_then_remove_listener_is_a_silent_no_op() {
+        // Flutter parity: `ChangeNotifier.removeListener` carries no
+        // `debugAssertNotDisposed`, unlike `addListener`/`notifyListeners`/
+        // `dispose` — its doc comment explains that teardown code must be
+        // able to detach from an already-disposed listenable. Must not
+        // panic in debug OR release; behavior is identical in both.
         let notifier = ChangeNotifier::new();
         let id = notifier.add_listener(Arc::new(|| {}));
         notifier.dispose();
-        notifier.remove_listener(id);
+        notifier.remove_listener(id); // must not panic
+        notifier.remove_listener(ListenerId::new(9999)); // unknown id: also fine
     }
 
     #[test]

--- a/crates/flui-foundation/src/notifier_generic.rs
+++ b/crates/flui-foundation/src/notifier_generic.rs
@@ -108,6 +108,13 @@ impl<Arg> Notifier<Arg> {
     }
 
     /// Remove a previously registered listener. No-op if absent.
+    ///
+    /// Unlike `ChangeNotifier::remove_listener` (which tolerates post-dispose
+    /// removal for Flutter parity), this generic notifier keeps its disposed
+    /// gate: it has no Flutter reference contract, and `ListenerRegistry`'s
+    /// Status-channel guard depends on the current shape. Re-seat on the
+    /// parity semantics deliberately if the planned `ChangeNotifier` →
+    /// `Notifier<()>` consolidation lands.
     pub fn remove(&self, id: ListenerId) {
         if self.check_disposed() {
             return;

--- a/crates/flui-view/src/element/behavior.rs
+++ b/crates/flui-view/src/element/behavior.rs
@@ -1220,13 +1220,12 @@ where
         let new_listenable = core.view().listenable();
 
         if !Arc::ptr_eq(&old_listenable, &new_listenable) {
-            // Safe to unsubscribe unconditionally: none of `AnimatedView`'s
-            // current listenable sources (`AnimationController`, wrapped in
-            // `flui-animation`) dispose their backing `ChangeNotifier` from
-            // `AnimationController::dispose` — only the controller's own
-            // "disposed" flag flips, so `remove_listener` on an
-            // instance-swapped-away-from old listenable never hits
-            // `ChangeNotifier`'s used-after-dispose debug assert here.
+            // Safe to unsubscribe unconditionally, even if the old
+            // listenable's backing `ChangeNotifier` were already disposed:
+            // `Listenable::remove_listener` is a silent no-op on a disposed
+            // notifier (Flutter parity — `ChangeNotifier.removeListener`
+            // carries no `debugAssertNotDisposed`, precisely so teardown
+            // code can detach from an already-disposed listenable).
             if let Some(listener_id) = self.listener_id.take() {
                 old_listenable.remove_listener(listener_id);
             }

--- a/crates/flui-widgets/src/text/editable_text.rs
+++ b/crates/flui-widgets/src/text/editable_text.rs
@@ -556,20 +556,23 @@ impl ViewState<EditableText> for EditableTextState {
             self.controller.remove_listener(id);
         }
 
-        // Deliberately NOT disposed: `self.rebuild_notifier` is also held by
-        // the `AnimatedBuilder` this state's own `build()` output wraps
-        // around (`Arc::new(self.rebuild_notifier.clone())`), and that
+        // Deliberately NOT disposed here: `self.rebuild_notifier` is also
+        // held by the `AnimatedBuilder` this state's own `build()` output
+        // wraps around (`Arc::new(self.rebuild_notifier.clone())`), and that
         // child element's own `on_unmount` calls `remove_listener` on its
         // clone as part of the SAME unmount sweep. `ViewState::dispose`
-        // (this method) runs before that child unmounts, so calling
-        // `dispose()` here first would mark the shared notifier disposed
-        // out from under a still-live subscriber, and
-        // `ChangeNotifier::remove_listener` panics in debug builds against
-        // exactly that "used after dispose" case — turning ordinary
-        // unmount-while-focused teardown into a panic. Letting the
-        // notifier's `Arc` refcount reach zero naturally (Rust's normal
-        // drop, once every clone — this state's and the child element's —
-        // is gone) is sufficient; nothing reads its disposed-flag.
+        // (this method) runs before that child unmounts.
+        //
+        // `ChangeNotifier::remove_listener` is a safe no-op after dispose
+        // (Flutter parity — see `Listenable::remove_listener`'s doc), so
+        // calling `dispose()` here first would no longer panic against the
+        // child's later `remove_listener` call. It is still left undone: an
+        // explicit `dispose()` would mark the shared notifier disposed while
+        // the child's subscription is still live, which is unnecessary
+        // churn for no behavioral gain here — letting the notifier's `Arc`
+        // refcount reach zero naturally (once every clone — this state's
+        // and the child element's — is gone) is sufficient, since nothing
+        // reads its disposed-flag on this path.
     }
 }
 

--- a/crates/flui-widgets/tests/animated_builder_swap.rs
+++ b/crates/flui-widgets/tests/animated_builder_swap.rs
@@ -188,3 +188,42 @@ fn animated_builder_same_instance_rebuild_does_not_resubscribe() {
         "no unsubscribe/resubscribe cycle ran on a same-instance rebuild"
     );
 }
+
+/// A widget swap must tolerate the OLD listenable already having been
+/// disposed by its owner before the swap runs — e.g. the user disposes
+/// notifier A themselves ahead of pumping the new-listenable frame.
+///
+/// `on_view_updated` calls `old_listenable.remove_listener(...)` to detach
+/// from the pre-swap instance; if A is already disposed by then, that call
+/// must be a silent no-op (Flutter parity — `ChangeNotifier.removeListener`
+/// carries no `debugAssertNotDisposed`), not a panic. The swap must still
+/// complete and subscribe to the new listenable.
+#[test]
+fn animated_builder_swap_tolerates_a_disposed_old_listenable() {
+    let notifier_a = Arc::new(ChangeNotifier::new());
+    let notifier_b = Arc::new(ChangeNotifier::new());
+
+    let listenable_a: Arc<dyn Listenable> = notifier_a.clone();
+    let mut laid = lay_out(
+        AnimatedBuilder::new(listenable_a, || SizedBox::new(10.0, 10.0)),
+        tight(10.0, 10.0),
+    );
+
+    assert!(notifier_a.has_listeners(), "mount subscribes to A");
+
+    // The owner disposes A before the swap runs.
+    notifier_a.dispose();
+
+    let listenable_b: Arc<dyn Listenable> = notifier_b.clone();
+    // Must not panic: `on_view_updated`'s `remove_listener` against the
+    // now-disposed A is a no-op, and the swap proceeds to subscribe to B.
+    laid.pump_widget(AnimatedBuilder::new(listenable_b, || {
+        SizedBox::new(10.0, 10.0)
+    }));
+
+    assert!(
+        notifier_b.has_listeners(),
+        "the swap must still subscribe to the new listenable even though \
+         detaching from the disposed old one was a no-op"
+    );
+}


### PR DESCRIPTION
Foundation parity fix surfaced by the AnimatedBehavior swap-leak review: `ChangeNotifier::remove_listener` debug-panicked after `dispose`, but Flutter's `removeListener` deliberately carries NO disposed assert (`change_notifier.dart` @ 3.44.0: "This method returns immediately if [dispose] has been called" — owners commonly dispose a frame earlier than their listeners detach).

## What

- `remove_listener` after dispose is now a silent no-op (the listener map is already cleared), in both debug and release. `add_listener`/`notify_listeners`/`dispose` keep their asserts exactly as Flutter does (each carries an explicit `debugAssertNotDisposed`); their pinning tests are untouched.
- The reviewer-named exposure is closed and tested: an `AnimatedBuilder` listenable swap now tolerates the old listenable being disposed before the swap pumps.
- Stale comments that cited the old panic as a design constraint corrected (`AnimatedBehavior`'s swap-safety note, `EditableText`'s dispose note, `ListenerRegistry`'s channel guards — the Status-channel guard remains load-bearing).
- **Recorded asymmetry**: `Notifier<Arg>::remove` (the generic notifier, no Flutter reference contract) deliberately keeps its disposed gate, documented at the site; FLUI's idempotent `dispose` (vs Flutter's double-dispose assert) remains a pre-existing documented divergence.

## Evidence

- Red-check executed and reviewer-reproduced: restoring the gate fails both new tests with the exact old panic.
- `cargo nextest run --workspace --exclude flui-platform`: 7617 passed; clippy `-D warnings`, port-check, fmt/taplo/typos, doctests: clean.
- Lean review: SHIP after the record-level notes landed (final commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)