### PR TITLE
feat(widgets): port Dismissible with drag-to-dismiss, threshold, and resize collapse

### DIFF
--- a/crates/flui-widgets/src/interaction/dismissible.rs
+++ b/crates/flui-widgets/src/interaction/dismissible.rs
@@ -987,7 +987,11 @@ fn handle_drag_start(
     // A `set_value(0.0)` above cannot itself clamp to the upper bound, but a
     // resumed-mid-animation `set_value` (the `is_animating()` branch) could in
     // principle land exactly at a bound too — discard defensively; see
-    // `discard_transient_move_completion`'s doc.
+    // `discard_transient_move_completion`'s doc. This same discard also eats a
+    // real `.forward()` completion in the sub-frame window where the run
+    // finished but its scheduled build has not yet delivered — a deliberate
+    // user-interaction-wins divergence: the new drag resets the card under
+    // the finger instead of dismissing it out from under an active gesture.
     discard_transient_move_completion(drag);
 }
 

--- a/crates/flui-widgets/src/interaction/dismissible.rs
+++ b/crates/flui-widgets/src/interaction/dismissible.rs
@@ -71,6 +71,16 @@
 //!    index). FLUI's reconciliation is not index-keyed the same way; omitted
 //!    as orthogonal to the drag/threshold/callback behavior this port
 //!    targets.
+//! 7. **No `dragStartBehavior`.** The oracle's `dragStartBehavior` field
+//!    (`DragStartBehavior.start` by default, `.down` optionally) is passed
+//!    straight through to its `GestureDetector`, choosing whether the drag's
+//!    origin is where the gesture *won the arena* (`start`, smoother) or
+//!    where the initial *down* event landed (`down`, more reactive).
+//!    `flui-widgets`' [`GestureDetector`](crate::GestureDetector) has no
+//!    `DragStartBehavior` concept at all yet — every drag effectively behaves
+//!    as `start`. Not configurable here for the same reason divergence #3's
+//!    vertical-drag family and this list's #5 keep-alive gap aren't: the
+//!    primitive this widget would delegate to does not exist in FLUI yet.
 
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
@@ -635,7 +645,52 @@ impl ViewState<Dismissible> for DismissibleState {
             } else {
                 constraints.max_height.get()
             };
+            // Module docs divergence #4: this widget divides by
+            // `overall_extent` to turn a drag delta into a fraction, so it
+            // requires bounded constraints along the dismiss axis. An
+            // unbounded axis (`f32::INFINITY`) would silently produce a
+            // stuck-at-zero or NaN drag fraction instead of a loud failure —
+            // catch the caller error here instead.
+            debug_assert!(
+                overall_extent.is_finite(),
+                "BUG: Dismissible requires bounded constraints along its dismiss axis \
+                 (got an unbounded/non-finite extent) — see module docs divergence #4"
+            );
 
+            // Firing `on_update`/`on_resize`/`on_dismissed` (and scheduling
+            // further rebuilds via `RebuildHandle::schedule()`) from HERE runs
+            // them during LAYOUT, not from an animation-listener callback the
+            // way the oracle's `_handleDismissUpdateValueChanged`/
+            // `_handleResizeProgressChanged`/`_handleMoveCompleted` do
+            // (Dart's `AnimationController` listeners are not
+            // thread-constrained, so the oracle fires straight from them). This
+            // port cannot: the `Send + Sync`-bounded status/value listeners
+            // registered in `init_state` can only touch `Arc<Atomic*>` signals,
+            // never the `Rc`-based `on_update`/`on_resize`/`on_dismissed`
+            // callbacks (see `DragState`'s own doc) — so delivery is deferred
+            // to here, the next time this `LayoutBuilder` (re-)runs.
+            //
+            // Verified, not assumed, safe to do from a layout-phase closure:
+            // - `RebuildHandle::schedule()`'s own contract (`rebuild_handle.rs`)
+            //   states it "never touches the element tree, the render tree, or
+            //   the pipeline. It writes to a mutex-guarded set and calls one
+            //   `Fn()`" — callable from any thread, any phase, by design.
+            // - `BuildOwner::service_layout_builders` (`owner/layout_builder.rs`,
+            //   the fixpoint that actually invokes this closure) calls
+            //   `self.build_scope(tree)` with the pipeline write-lock
+            //   EXPLICITLY released first — "with NO pipeline lock held, so a
+            //   builder that mounts a child can insert its render objects".
+            //   That is: this closure runs as a genuine, ordinary build pass
+            //   (the same `build_scope` every other `StatefulView::build` runs
+            //   through), just one sequenced *between* layout passes rather
+            //   than at the top of the frame — not a restricted context with
+            //   different rules. Port-check trigger #22 (see
+            //   `scripts/check-frame-capability-scope.sh`) governs *acquiring*
+            //   `rebuild_handle()`/`post_frame_handle()` from `build`/`layout`/
+            //   `paint` (an unbounded-rebuild-loop hazard); it says nothing
+            //   about *calling* `.schedule()` on a handle already acquired in
+            //   `init_state` (this one), which is exactly what every listener
+            //   callback in this file already does.
             deliver_move_completion(
                 &drag,
                 &move_controller,
@@ -863,6 +918,50 @@ fn ensure_move_controller_registered(
     drag.move_vsync_registration.set(Some(registration));
 }
 
+/// Marks whatever `move_completed_runs` currently holds as already
+/// "delivered", discarding any `Completed` transition a direct `set_value`
+/// call (in `handle_drag_start`/`handle_drag_update`) might just have caused
+/// — without running the actual completion behavior for it.
+///
+/// **The bug this fixes:** `move_controller.set_value(...)` clamps to
+/// `[0.0, 1.0]`, and a drag whose extent reaches (or overshoots) 100% of
+/// `overall_extent` therefore lands the controller at the upper bound —
+/// which `AnimationController` reports as `Completed`, *mid-drag*, well
+/// before `handle_drag_end` ever runs. The oracle's own status listener
+/// (`_handleDismissStatusChanged`) discards exactly this case:
+/// `status.isCompleted && !_dragUnderway` — a `Completed` event that fires
+/// while still dragging is dropped outright, never queued for later.
+///
+/// This port cannot replicate that check *in the listener*: the listener
+/// registered in `init_state` must be `Send + Sync` (`flui_foundation::ListenerCallback`),
+/// so it can only touch the `Arc<AtomicU64>` `move_completed_runs` counter,
+/// never the `Cell<bool>` `drag_underway` flag (see `DragState`'s own doc on
+/// why). Earlier drafts of this port bumped the counter unconditionally and
+/// left `deliver_move_completion`'s build()-driven consumer to skip
+/// delivery *while* `drag_underway` was still true — but skipping is not
+/// discarding: the bump stayed on the counter, unconsumed. The very next
+/// time `deliver_move_completion` ran with `drag_underway` false again (e.g.
+/// after the user dragged back below threshold and released, which
+/// correctly springs back via `.reverse()`), it saw a "new" completion it
+/// had never delivered and ran the collapse + `on_dismissed` anyway — a
+/// false dismissal the oracle never produces.
+///
+/// The fix moves the discard to the only place that reliably knows
+/// `drag_underway` is true: right here, synchronously after every direct
+/// `set_value`, in the same call stack that might have just caused the
+/// bump. Marking it "delivered" immediately means `deliver_move_completion`
+/// can never later mistake it for a real, undelivered completion. The
+/// legitimate "released exactly at 100%" dismissal does not depend on this
+/// counter at all: `handle_drag_end` calls [`run_move_completion`] directly
+/// and unconditionally when `move_controller.is_completed()` holds at the
+/// exact moment of release — mirroring the oracle's own direct
+/// `_handleDragEnd` bypass, which likewise never consults the status
+/// listener for that case.
+fn discard_transient_move_completion(drag: &DragState) {
+    let completed_runs = drag.move_completed_runs.load(Ordering::SeqCst);
+    drag.delivered_move_completions.set(completed_runs);
+}
+
 /// Flutter parity: `_handleDragStart` (`dismissible.dart:366`), minus the
 /// `_confirming` guard (no `confirmDismiss` — see module docs divergence #1).
 fn handle_drag_start(
@@ -885,6 +984,11 @@ fn handle_drag_start(
     // doc for why a vsync-ticked controller cannot also be a direct-`set_value`-tracked
     // one at the same time.
     unregister_move_controller_vsync(drag, vsync);
+    // A `set_value(0.0)` above cannot itself clamp to the upper bound, but a
+    // resumed-mid-animation `set_value` (the `is_animating()` branch) could in
+    // principle land exactly at a bound too — discard defensively; see
+    // `discard_transient_move_completion`'s doc.
+    discard_transient_move_completion(drag);
 }
 
 /// Flutter parity: `_handleDragUpdate` (`dismissible.dart:383`) — `delta` is
@@ -909,6 +1013,14 @@ fn handle_drag_update(
         // (see `handle_drag_start`), so this direct write is not immediately
         // clobbered by a tick — no re-registration needed here.
         move_controller.set_value(new_extent.abs() / overall_extent);
+        // A drag that reaches (or overshoots) 100% of `overall_extent` clamps
+        // `set_value` to the upper bound, which reports `Completed` — mid-drag,
+        // exactly like the oracle's own `AnimationController.value` setter can.
+        // The oracle's status listener discards that case explicitly
+        // (`status.isCompleted && !_dragUnderway`, dismissible.dart); see
+        // `discard_transient_move_completion`'s doc for why this port discards
+        // it here instead of in the listener.
+        discard_transient_move_completion(drag);
     }
 }
 
@@ -929,7 +1041,14 @@ fn handle_drag_end(
     }
     drag.drag_underway.set(false);
     if move_controller.is_completed() {
-        deliver_move_completion(drag, move_controller, resolved, vsync, rebuild, constraints);
+        // The direct bypass — mirrors the oracle's own `if (_moveController.isCompleted)
+        // { _handleMoveCompleted(); return; }` in `_handleDragEnd`. Calls
+        // `run_move_completion` unconditionally, NOT the counter-gated
+        // `deliver_move_completion`: a drag released exactly at 100% never
+        // bumped `move_completed_runs` in the first place (see
+        // `discard_transient_move_completion`), so gating on that counter here
+        // would wrongly skip this legitimate completion.
+        run_move_completion(drag, move_controller, resolved, vsync, rebuild, constraints);
         return;
     }
     let dismiss_direction = extent_to_direction(
@@ -973,16 +1092,26 @@ fn handle_drag_end(
     }
 }
 
-/// Flutter parity: `_handleDismissStatusChanged` + `_handleMoveCompleted`
-/// (`dismissible.dart:539`-`561`), collapsed into one idempotent function
-/// callable from either the deferred (`build()`-driven) path or the
-/// immediate path `handle_drag_end` takes when the controller is already
-/// completed at release. Idempotent via the `move_completed_runs` /
-/// `delivered_move_completions` counter pair: a call that finds nothing new
-/// to deliver is a no-op, so it is safe to call from both sites without
-/// double-firing `on_dismissed` or double-reversing.
-#[allow(clippy::too_many_arguments)] // mirrors the oracle's own method arity — see `handle_drag_end`'s note
-fn deliver_move_completion(
+/// Flutter parity: `_handleMoveCompleted` (`dismissible.dart:548`-`561`) — the
+/// actual completion behavior, run unconditionally (no counter/latch gate of
+/// any kind). Two call sites reach this, matching the oracle's own two ways
+/// into `_handleMoveCompleted`:
+///
+/// - `handle_drag_end`'s direct bypass, when `move_controller.is_completed()`
+///   holds at the exact moment of release (oracle: `_handleDragEnd`'s own
+///   `if (_moveController.isCompleted) { _handleMoveCompleted(); return; }`).
+/// - [`deliver_move_completion`], the deferred, counter-gated path for a
+///   `.forward()`/`.fling()` run that settles to `Completed` sometime AFTER
+///   release (oracle: `_handleDismissStatusChanged`, driven by the status
+///   listener).
+///
+/// Calling this twice for the "same" logical completion cannot happen: the
+/// direct-bypass site is reached only once per release, and the deferred
+/// site only ever observes a completion the direct-bypass site did not
+/// already consume (see `discard_transient_move_completion`'s doc for why a
+/// mid-drag `Completed` never reaches the deferred path's counter at all).
+#[allow(clippy::too_many_arguments)] // mirrors the oracle's own `_handleMoveCompleted`, which reaches the same six pieces of state via `widget`/instance fields rather than parameters
+fn run_move_completion(
     drag: &Rc<DragState>,
     move_controller: &AnimationController,
     resolved: &Rc<ResolvedConfig>,
@@ -990,12 +1119,6 @@ fn deliver_move_completion(
     rebuild: &RebuildHandle,
     constraints: BoxConstraints,
 ) {
-    let completed_runs = drag.move_completed_runs.load(Ordering::SeqCst);
-    if completed_runs <= drag.delivered_move_completions.get() || drag.drag_underway.get() {
-        return;
-    }
-    drag.delivered_move_completions.set(completed_runs);
-
     let dismiss_direction = extent_to_direction(
         drag.drag_extent.get(),
         resolved.direction,
@@ -1021,6 +1144,34 @@ fn deliver_move_completion(
             start_resize_animation(drag, duration, vsync, rebuild, constraints.biggest());
         }
     }
+}
+
+/// Flutter parity: the deferred half of `_handleDismissStatusChanged`
+/// (`dismissible.dart:539`-`546`) — reacts to `move_controller` completing
+/// AFTER release (a `.forward()`/`.fling()` run settling), observed via the
+/// status listener registered in `init_state` and the `move_completed_runs` /
+/// `delivered_move_completions` counter pair. Idempotent: a call that finds
+/// nothing new to deliver is a no-op. Never reached for a mid-drag
+/// `Completed` event — those are discarded at the source (see
+/// `discard_transient_move_completion`) — nor does it need its own
+/// `drag_underway` check for that reason: by the time this runs,
+/// `move_completed_runs` only ever counts completions the drag was not
+/// underway for.
+#[allow(clippy::too_many_arguments)] // mirrors `run_move_completion`'s arity — see its own note
+fn deliver_move_completion(
+    drag: &Rc<DragState>,
+    move_controller: &AnimationController,
+    resolved: &Rc<ResolvedConfig>,
+    vsync: Option<&Vsync>,
+    rebuild: &RebuildHandle,
+    constraints: BoxConstraints,
+) {
+    let completed_runs = drag.move_completed_runs.load(Ordering::SeqCst);
+    if completed_runs <= drag.delivered_move_completions.get() {
+        return;
+    }
+    drag.delivered_move_completions.set(completed_runs);
+    run_move_completion(drag, move_controller, resolved, vsync, rebuild, constraints);
 }
 
 /// Flutter parity: `_startResizeAnimation` (`dismissible.dart:576`), the
@@ -1454,5 +1605,187 @@ mod tests {
         assert_eq!(drag_sign(-0.0), 0.0);
         assert_eq!(drag_sign(5.0), 1.0);
         assert_eq!(drag_sign(-5.0), -1.0);
+    }
+
+    // ------------------------------------------------------------------
+    // Mid-drag `Completed` latch — the stale-completion bug caught in
+    // review: a drag reaching 100% of `overall_extent` clamps
+    // `move_controller` to its upper bound, which reports `Completed` even
+    // though the oracle discards that (`status.isCompleted && !_dragUnderway`)
+    // as not a real move-completion. This exercises the actual
+    // `handle_drag_start`/`handle_drag_update`/`handle_drag_end` state
+    // machine — not achievable through the `tests/parity/dismissible_test.rs`
+    // integration harness, whose touch-slop-then-delta drag helper cannot
+    // reach literal 100% within a laid-out box (see that file's own module
+    // doc). `RebuildHandle` has no public standalone constructor (by design:
+    // only a real mount ever mints one — see `flui_view::owner::rebuild_handle`),
+    // so this mounts the smallest possible real element tree to capture one.
+    // ------------------------------------------------------------------
+
+    /// A trivial `StatefulView` whose only job is to capture the
+    /// `RebuildHandle` `init_state` acquires. Mirrors
+    /// `flui_view::owner::rebuild_handle`'s own `Capturing` test fixture.
+    #[derive(Clone, StatefulView)]
+    struct RebuildHandleCapture {
+        captured: Rc<RefCell<Option<RebuildHandle>>>,
+    }
+
+    struct RebuildHandleCaptureState {
+        captured: Rc<RefCell<Option<RebuildHandle>>>,
+    }
+
+    impl StatefulView for RebuildHandleCapture {
+        type State = RebuildHandleCaptureState;
+
+        fn create_state(&self) -> Self::State {
+            RebuildHandleCaptureState {
+                captured: Rc::clone(&self.captured),
+            }
+        }
+    }
+
+    impl ViewState<RebuildHandleCapture> for RebuildHandleCaptureState {
+        fn init_state(&mut self, ctx: &dyn BuildContext) {
+            *self.captured.borrow_mut() = Some(ctx.rebuild_handle());
+        }
+
+        fn build(&self, _view: &RebuildHandleCapture, _ctx: &dyn BuildContext) -> impl IntoView {
+            crate::SizedBox::shrink()
+        }
+    }
+
+    /// Mounts [`RebuildHandleCapture`] as a bare root (no pipeline owner —
+    /// this probe never lays out or paints, only runs `init_state`/`build`)
+    /// and returns the handle its `init_state` captured.
+    fn mount_and_capture_rebuild_handle() -> RebuildHandle {
+        use flui_view::{BuildOwner, ElementTree};
+
+        let captured = Rc::new(RefCell::new(None));
+        let view = RebuildHandleCapture {
+            captured: Rc::clone(&captured),
+        };
+        let mut owner = BuildOwner::new();
+        let mut tree = ElementTree::new();
+        let root = tree.mount_root(&view, &mut owner.element_owner_mut());
+        owner.schedule_build_for(root, 0);
+        owner.build_scope(&mut tree);
+
+        captured
+            .borrow()
+            .clone()
+            .expect("init_state must have captured a handle")
+    }
+
+    #[test]
+    fn move_controller_reaching_the_clamp_mid_drag_does_not_leave_a_stale_completion_latch() {
+        let rebuild = mount_and_capture_rebuild_handle();
+
+        let move_controller =
+            AnimationController::new(Duration::from_millis(200), Arc::new(Scheduler::new()));
+        let drag = Rc::new(DragState::default());
+        let move_completed_runs = Arc::clone(&drag.move_completed_runs);
+        let _status_listener_id = move_controller.add_status_listener(Arc::new(move |status| {
+            if status == AnimationStatus::Completed {
+                move_completed_runs.fetch_add(1, Ordering::SeqCst);
+            }
+        }));
+
+        let dismissed = Arc::new(AtomicU64::new(0));
+        let on_dismissed_probe: DismissDirectionCallback = {
+            let dismissed = Arc::clone(&dismissed);
+            Rc::new(move |_direction| {
+                dismissed.fetch_add(1, Ordering::SeqCst);
+            })
+        };
+        // `resize_duration: None` so a wrongful `run_move_completion` call
+        // fires `on_dismissed` SYNCHRONOUSLY (the `None` branch), making the
+        // probe below observe the bug directly — with `Some(duration)` the
+        // symptom would instead be "wrongly starts the resize collapse",
+        // requiring the collapse's own controller to actually tick (real time,
+        // never advanced in this synchronous unit test) before `on_dismissed`
+        // would fire.
+        let resolved = Rc::new(ResolvedConfig {
+            direction: DismissDirection::EndToStart,
+            text_direction: TextDirection::Ltr,
+            dismiss_thresholds: HashMap::new(),
+            resize_duration: None,
+            cross_axis_end_offset: 0.0,
+            on_dismissed: Some(on_dismissed_probe),
+            on_resize: None,
+        });
+        let overall_extent = 100.0_f32;
+        let constraints = BoxConstraints::tight(Size::new(
+            flui_types::geometry::px(overall_extent),
+            flui_types::geometry::px(50.0),
+        ));
+
+        // Drag straight past the clamp: a single update's delta already
+        // exceeds 100% of `overall_extent`, exactly like a real drag that
+        // runs off the end of the axis. `drag_underway` is still true —
+        // matching the oracle's mid-drag `Completed` event that
+        // `!_dragUnderway` discards.
+        handle_drag_start(&drag, &move_controller, None, overall_extent);
+        handle_drag_update(
+            &drag,
+            &move_controller,
+            DismissDirection::EndToStart,
+            TextDirection::Ltr,
+            overall_extent,
+            -150.0,
+        );
+        assert!(
+            move_controller.is_completed(),
+            "the clamp must actually reach Completed for this probe to mean anything"
+        );
+        assert_eq!(
+            drag.move_completed_runs.load(Ordering::SeqCst),
+            drag.delivered_move_completions.get(),
+            "a mid-drag Completed event must be discarded immediately (delivered synced to \
+             the counter), not left as a stale, unconsumed latch"
+        );
+
+        // Spring back below threshold — still mid-drag.
+        handle_drag_update(
+            &drag,
+            &move_controller,
+            DismissDirection::EndToStart,
+            TextDirection::Ltr,
+            overall_extent,
+            130.0, // -150 + 130 = -20: 20% of the 100-unit extent
+        );
+
+        // Release below the 40% default threshold: `.reverse()`, no dismissal.
+        handle_drag_end(
+            &drag,
+            &move_controller,
+            &resolved,
+            None,
+            &rebuild,
+            constraints,
+            0.0,
+            0.0,
+        );
+
+        // Simulate the build pass `deliver_move_completion` runs from on
+        // every rebuild (`Dismissible::build`'s `LayoutBuilder` closure) —
+        // the site a stale, unconsumed latch would actually be replayed
+        // from in production. Calling it directly here is what makes this
+        // probe exercise the full bug chain end to end, not just the
+        // latch-invariant assertion above in isolation.
+        deliver_move_completion(
+            &drag,
+            &move_controller,
+            &resolved,
+            None,
+            &rebuild,
+            constraints,
+        );
+
+        assert_eq!(
+            dismissed.load(Ordering::SeqCst),
+            0,
+            "a spring-back release must not fire on_dismissed — the mid-drag clamp's stale \
+             Completed event must not be replayed once drag_underway goes false again"
+        );
     }
 }

--- a/crates/flui-widgets/src/interaction/dismissible.rs
+++ b/crates/flui-widgets/src/interaction/dismissible.rs
@@ -1,0 +1,1458 @@
+//! [`Dismissible`] — drag a child out of view to dismiss it, then collapse the
+//! space it occupied.
+//!
+//! Flutter parity: `widgets/dismissible.dart` (tag `3.44.0`) — `Dismissible`,
+//! `_DismissibleState`, `DismissDirection`, `DismissUpdateDetails`,
+//! `_FlingGestureKind`, `_DismissibleClipper`, and the four tuned constants
+//! `_kResizeTimeCurve` / `_kMinFlingVelocity` / `_kMinFlingVelocityDelta` /
+//! `_kFlingVelocityScale` / `_kDismissThreshold`. State machine: a drag (or a
+//! sufficiently fast fling) accumulates a signed `drag_extent`; releasing past
+//! [`Dismissible::dismiss_threshold`] (default `0.4`, per direction) or with a
+//! qualifying fling drives `move_controller` to 1.0 over
+//! [`Dismissible::movement_duration`]; on completion the widget starts the
+//! resize collapse over [`Dismissible::resize_duration`] (or fires
+//! [`Dismissible::on_dismissed`] immediately when that is `None`) and then
+//! fires `on_dismissed`.
+//!
+//! # Deliberate divergences from the oracle (framework-surface gaps)
+//!
+//! 1. **No `confirmDismiss`.** The oracle's `confirmDismiss` is an async gate
+//!    (`Future<bool?> Function(DismissDirection)`) awaited between the move
+//!    animation completing and the resize collapse starting. FLUI has no
+//!    established widget-level "await a caller future, then keep going"
+//!    seam yet (`FutureBuilder` rebuilds *from* future state; it does not let
+//!    an imperative callback block a state transition on one). Inventing that
+//!    seam here — one-off, for a single widget — would be exactly the kind of
+//!    local hack this port avoids. Deferred; tracked as a follow-up rather
+//!    than faked with a synchronous stand-in that would silently misrepresent
+//!    the oracle's actual (async, vetoable) contract.
+//! 2. **No progressive background clip.** The oracle's `_DismissibleClipper`
+//!    is a `CustomClipper<Rect>` that reveals only the sliver of `background`
+//!    between the sliding child's edge and the container edge, growing as the
+//!    drag proceeds. `flui-widgets`' [`ClipRect`](crate::ClipRect) has no
+//!    arbitrary-rect / custom-clipper primitive yet — only a fixed
+//!    [`Clip`](flui_types::painting::Clip) behavior. This port shows/hides
+//!    `background` by *presence* (mounted whenever `move_controller.value()
+//!    != 0.0`, matching the oracle's `!_moveAnimation.isDismissed` guard) but
+//!    does not crop it to the revealed sliver — it paints at full extent
+//!    under the sliding child from the first pixel of drag. Visually
+//!    observable divergence; behaviorally the presence/absence signal (what
+//!    the parity corpus asserts) matches exactly.
+//! 3. **`Vertical`/`Up`/`Down` ride `on_pan_*`, not a vertical-drag family.**
+//!    `GestureDetector` has no `on_vertical_drag_*` recognizer family (see
+//!    that type's own docs on why) — only `on_horizontal_drag_*` and the
+//!    free-axis `on_pan_*`. For the vertical-family directions this port
+//!    wires `on_pan_*` and reads the raw `delta.dy` / `velocity.dy` component
+//!    directly instead of `primary_delta` / `primary_velocity` (which are
+//!    `Free`-axis distance *magnitudes* on that recognizer, not the signed
+//!    per-axis component the oracle's math needs). Functionally equivalent
+//!    for the one component this widget reads, but slightly looser: a pan
+//!    recognizer's slop is not axis-locked the way a dedicated vertical
+//!    recognizer's would be, so a mostly-horizontal drag can still start a
+//!    vertical `Dismissible`'s gesture where the oracle's `VerticalDragGestureRecognizer`
+//!    would hold off. Horizontal-family directions are unaffected — they use
+//!    the real `on_horizontal_drag_*` family.
+//! 4. **No live "my own size" query.** The oracle reads `context.size!`
+//!    (this widget's last-laid-out size) from event handlers running well
+//!    after `build`. FLUI's `BuildContext` has no such accessor. This port
+//!    wraps its content in [`LayoutBuilder`](crate::LayoutBuilder) instead and
+//!    uses the incoming `BoxConstraints` (`max_width`/`max_height`) as the
+//!    drag-axis extent and the resize collapse's prior size — exact when the
+//!    constraints are tight (the common case: a fixed-extent list item), but
+//!    **`Dismissible` requires bounded constraints along its dismiss axis**;
+//!    an unbounded axis has no extent to divide the drag fraction by.
+//! 5. **No `AutomaticKeepAlive`.** The oracle mixes in
+//!    `AutomaticKeepAliveClientMixin` so a mid-flight `Dismissible` is not
+//!    disposed by a lazy list's viewport GC. FLUI has no keep-alive mechanism
+//!    at all yet — a framework-wide gap, not a regression specific to this
+//!    port.
+//! 6. **No required `Key`.** The oracle's constructor requires one (so a
+//!    dismissed list item's slot doesn't get re-synced onto the next item by
+//!    index). FLUI's reconciliation is not index-keyed the same way; omitted
+//!    as orthogonal to the drag/threshold/callback behavior this port
+//!    targets.
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Duration;
+
+use flui_animation::curve::{Curve, Interval};
+use flui_animation::{
+    Animation, AnimationController, AnimationStatus, Curves, Scheduler, Vsync, VsyncRegistration,
+};
+use flui_foundation::{Listenable, ListenerId};
+use flui_interaction::{DragEndDetails, DragStartDetails, DragUpdateDetails};
+use flui_rendering::constraints::BoxConstraints;
+use flui_rendering::hit_testing::HitTestBehavior;
+use flui_types::Size;
+use flui_types::painting::Clip;
+use flui_types::typography::TextDirection;
+use flui_view::prelude::{BuildContext, StatefulView};
+use flui_view::{BoxedView, BuildContextExt, IntoView, RebuildHandle, ViewExt, ViewState};
+
+use crate::animated::VsyncScope;
+use crate::localization::Directionality;
+use crate::{
+    ClipRect, FractionalTranslation, GestureDetector, LayoutBuilder, Positioned, SizedBox, Stack,
+};
+
+/// `_kMinFlingVelocity` (`dismissible.dart:19`) — a fling below this speed
+/// never dismisses, regardless of direction.
+const MIN_FLING_VELOCITY: f32 = 700.0;
+/// `_kMinFlingVelocityDelta` (`dismissible.dart:20`) — the primary-axis
+/// velocity must clear the cross-axis velocity by at least this much, or the
+/// gesture is not "generally in the right direction".
+const MIN_FLING_VELOCITY_DELTA: f32 = 400.0;
+/// `_kFlingVelocityScale` (`dismissible.dart:21`) — pointer velocity
+/// (px/s) is scaled into the `AnimationController.fling` velocity domain.
+const FLING_VELOCITY_SCALE: f32 = 1.0 / 300.0;
+/// `_kDismissThreshold` (`dismissible.dart:22`) — the default fraction of
+/// `overall_drag_axis_extent` that must be crossed to dismiss.
+const DEFAULT_DISMISS_THRESHOLD: f32 = 0.4;
+
+/// The direction(s) in which a [`Dismissible`] can be dismissed.
+///
+/// Flutter parity: `DismissDirection` (`dismissible.dart:42`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DismissDirection {
+    /// Dismissible by dragging up or down.
+    Vertical,
+    /// Dismissible by dragging left or right.
+    Horizontal,
+    /// Dismissible by dragging against the reading direction (right-to-left
+    /// in LTR, left-to-right in RTL).
+    EndToStart,
+    /// Dismissible by dragging with the reading direction (left-to-right in
+    /// LTR, right-to-left in RTL).
+    StartToEnd,
+    /// Dismissible by dragging up only.
+    Up,
+    /// Dismissible by dragging down only.
+    Down,
+    /// Cannot be dismissed by dragging.
+    None,
+}
+
+/// Fired when the [`Dismissible`] has been dismissed, after any resize
+/// collapse has finished (or immediately, if `resize_duration` is `None`).
+///
+/// Flutter parity: `DismissDirectionCallback` (`dismissible.dart:28`).
+pub type DismissDirectionCallback = Rc<dyn Fn(DismissDirection)>;
+
+/// Fired on every drag/threshold-state change while a [`Dismissible`] is
+/// being dragged.
+///
+/// Flutter parity: `DismissUpdateCallback` (`dismissible.dart:39`).
+pub type DismissUpdateCallback = Rc<dyn Fn(DismissUpdateDetails)>;
+
+/// Details delivered to [`Dismissible::on_update`].
+///
+/// Flutter parity: `DismissUpdateDetails` (`dismissible.dart:231`).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DismissUpdateDetails {
+    /// The direction the dismissible is currently being dragged toward.
+    pub direction: DismissDirection,
+    /// Whether the dismiss threshold is reached as of this delivery.
+    pub reached: bool,
+    /// Whether the dismiss threshold was reached as of the *previous*
+    /// delivery — pairs with `reached` to catch the crossing moment.
+    pub previous_reached: bool,
+    /// `move_controller`'s value: `0.0` at rest, `1.0` fully off-screen.
+    pub progress: f32,
+}
+
+/// A widget that can be dismissed by dragging in [`DismissDirection`].
+///
+/// See the module docs for the oracle citation and this port's documented
+/// divergences (no `confirmDismiss`, no progressive background clip, no
+/// vertical-drag recognizer family, bounded-constraints contract, no
+/// keep-alive, no required key).
+#[derive(Clone, StatefulView)]
+pub struct Dismissible {
+    child: BoxedView,
+    background: Option<BoxedView>,
+    secondary_background: Option<BoxedView>,
+    on_resize: Option<Rc<dyn Fn()>>,
+    on_dismissed: Option<DismissDirectionCallback>,
+    on_update: Option<DismissUpdateCallback>,
+    direction: DismissDirection,
+    resize_duration: Option<Duration>,
+    dismiss_thresholds: HashMap<DismissDirection, f32>,
+    movement_duration: Duration,
+    cross_axis_end_offset: f32,
+    behavior: HitTestBehavior,
+}
+
+impl Dismissible {
+    /// A `Dismissible` wrapping `child`, dismissible horizontally by default
+    /// (Flutter parity default), collapsing over 300ms after a 200ms slide.
+    pub fn new(child: impl IntoView) -> Self {
+        Self {
+            child: child.into_view().boxed(),
+            background: None,
+            secondary_background: None,
+            on_resize: None,
+            on_dismissed: None,
+            on_update: None,
+            direction: DismissDirection::Horizontal,
+            resize_duration: Some(Duration::from_millis(300)),
+            dismiss_thresholds: HashMap::new(),
+            movement_duration: Duration::from_millis(200),
+            cross_axis_end_offset: 0.0,
+            behavior: HitTestBehavior::Opaque,
+        }
+    }
+
+    /// A widget stacked behind `child`, exposed as it slides away. Shown at
+    /// full extent whenever the drag offset is nonzero (see divergence #2 in
+    /// the module docs — not clipped to the revealed sliver).
+    #[must_use]
+    pub fn background(mut self, background: impl IntoView) -> Self {
+        self.background = Some(background.into_view().boxed());
+        self
+    }
+
+    /// A widget shown behind `child` instead of [`Self::background`] while
+    /// dragging toward [`DismissDirection::EndToStart`] or
+    /// [`DismissDirection::Up`]. Only meaningful once `background` is set.
+    #[must_use]
+    pub fn secondary_background(mut self, secondary_background: impl IntoView) -> Self {
+        self.secondary_background = Some(secondary_background.into_view().boxed());
+        self
+    }
+
+    /// Called on every resize-collapse tick before the collapse completes.
+    #[must_use]
+    pub fn on_resize(mut self, on_resize: impl Fn() + 'static) -> Self {
+        self.on_resize = Some(Rc::new(on_resize));
+        self
+    }
+
+    /// Called once the dismissible has been dismissed — after the resize
+    /// collapse finishes, or immediately if `resize_duration` is `None`.
+    #[must_use]
+    pub fn on_dismissed(mut self, on_dismissed: impl Fn(DismissDirection) + 'static) -> Self {
+        self.on_dismissed = Some(Rc::new(on_dismissed));
+        self
+    }
+
+    /// Called on every drag update with the current direction/threshold
+    /// state.
+    #[must_use]
+    pub fn on_update(mut self, on_update: impl Fn(DismissUpdateDetails) + 'static) -> Self {
+        self.on_update = Some(Rc::new(on_update));
+        self
+    }
+
+    /// The direction(s) this widget can be dismissed in. Default:
+    /// [`DismissDirection::Horizontal`].
+    #[must_use]
+    pub fn direction(mut self, direction: DismissDirection) -> Self {
+        self.direction = direction;
+        self
+    }
+
+    /// The duration of the post-dismiss resize collapse. `None` skips the
+    /// collapse and fires `on_dismissed` immediately after the slide.
+    /// Default: `Some(300ms)`.
+    #[must_use]
+    pub fn resize_duration(mut self, resize_duration: Option<Duration>) -> Self {
+        self.resize_duration = resize_duration;
+        self
+    }
+
+    /// Overrides the dismiss threshold (fraction of the drag-axis extent)
+    /// for one [`DismissDirection`]. Unset directions use the default
+    /// (`0.4`). A threshold `>= 1.0` makes that direction undismissable by
+    /// drag or fling, even though [`Self::direction`] still allows dragging
+    /// it (it always springs back).
+    #[must_use]
+    pub fn dismiss_threshold(mut self, direction: DismissDirection, threshold: f32) -> Self {
+        self.dismiss_thresholds.insert(direction, threshold);
+        self
+    }
+
+    /// The duration of the slide-to-dismiss / spring-back animation.
+    /// Default: `200ms`.
+    #[must_use]
+    pub fn movement_duration(mut self, movement_duration: Duration) -> Self {
+        self.movement_duration = movement_duration;
+        self
+    }
+
+    /// The end-of-slide offset across the axis perpendicular to the dismiss
+    /// direction, as a fraction of the widget's extent on that axis. Default
+    /// `0.0` (no cross-axis drift).
+    #[must_use]
+    pub fn cross_axis_end_offset(mut self, cross_axis_end_offset: f32) -> Self {
+        self.cross_axis_end_offset = cross_axis_end_offset;
+        self
+    }
+
+    /// How this widget behaves during hit-testing. Default:
+    /// [`HitTestBehavior::Opaque`].
+    #[must_use]
+    pub fn behavior(mut self, behavior: HitTestBehavior) -> Self {
+        self.behavior = behavior;
+        self
+    }
+}
+
+impl std::fmt::Debug for Dismissible {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Dismissible")
+            .field("direction", &self.direction)
+            .field("resize_duration", &self.resize_duration)
+            .field("movement_duration", &self.movement_duration)
+            .field("has_background", &self.background.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+// ============================================================================
+// Direction / threshold / fling helpers — free functions so the state
+// machine's math is unit-testable without a laid-out tree.
+// ============================================================================
+
+/// Whether `direction` drags along the horizontal axis. Flutter parity:
+/// `_directionIsXAxis` (`dismissible.dart:337`).
+fn direction_is_x_axis(direction: DismissDirection) -> bool {
+    matches!(
+        direction,
+        DismissDirection::Horizontal | DismissDirection::EndToStart | DismissDirection::StartToEnd
+    )
+}
+
+/// `extent.sign`, but `0.0` maps to `0.0` (Rust's `f32::signum` maps `+0.0` to
+/// `1.0`, which would wrongly treat "no drag yet" as "dragged positive").
+fn drag_sign(extent: f32) -> f32 {
+    if extent == 0.0 { 0.0 } else { extent.signum() }
+}
+
+/// Flutter parity: `_extentToDirection` (`dismissible.dart:343`).
+fn extent_to_direction(
+    extent: f32,
+    direction: DismissDirection,
+    text_direction: TextDirection,
+) -> DismissDirection {
+    if extent == 0.0 {
+        return DismissDirection::None;
+    }
+    if direction_is_x_axis(direction) {
+        match (text_direction, extent) {
+            (TextDirection::Rtl, e) if e < 0.0 => DismissDirection::StartToEnd,
+            (TextDirection::Ltr, e) if e > 0.0 => DismissDirection::StartToEnd,
+            (TextDirection::Rtl | TextDirection::Ltr, _) => DismissDirection::EndToStart,
+        }
+    } else if extent > 0.0 {
+        DismissDirection::Down
+    } else {
+        DismissDirection::Up
+    }
+}
+
+/// Flutter parity: the direction-gating `switch` inside `_handleDragUpdate`
+/// (`dismissible.dart:390`-`431`) — accumulates `delta` into `current` only
+/// when doing so keeps the extent on the side `direction` (and, for the
+/// reading-direction-relative variants, `text_direction`) allows.
+fn accumulate_drag_extent(
+    direction: DismissDirection,
+    text_direction: TextDirection,
+    current: f32,
+    delta: f32,
+) -> f32 {
+    let proposed = current + delta;
+    match direction {
+        DismissDirection::Horizontal | DismissDirection::Vertical => proposed,
+        DismissDirection::Up => {
+            if proposed < 0.0 {
+                proposed
+            } else {
+                current
+            }
+        }
+        DismissDirection::Down => {
+            if proposed > 0.0 {
+                proposed
+            } else {
+                current
+            }
+        }
+        DismissDirection::EndToStart => match text_direction {
+            TextDirection::Rtl if proposed > 0.0 => proposed,
+            TextDirection::Ltr if proposed < 0.0 => proposed,
+            TextDirection::Rtl | TextDirection::Ltr => current,
+        },
+        DismissDirection::StartToEnd => match text_direction {
+            TextDirection::Rtl if proposed < 0.0 => proposed,
+            TextDirection::Ltr if proposed > 0.0 => proposed,
+            TextDirection::Rtl | TextDirection::Ltr => current,
+        },
+        DismissDirection::None => 0.0,
+    }
+}
+
+/// The resolved threshold for `direction` (Flutter parity:
+/// `widget.dismissThresholds[_dismissDirection] ?? _kDismissThreshold`).
+fn dismiss_threshold_for(
+    thresholds: &HashMap<DismissDirection, f32>,
+    direction: DismissDirection,
+) -> f32 {
+    thresholds
+        .get(&direction)
+        .copied()
+        .unwrap_or(DEFAULT_DISMISS_THRESHOLD)
+}
+
+/// Flutter parity: `_FlingGestureKind` (`dismissible.dart:296`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FlingGestureKind {
+    /// Too slow, or not clearly aimed along the drag axis — not a fling.
+    None,
+    /// Fast enough, aimed the same way the drag is already leaning.
+    Forward,
+    /// Fast enough, aimed the opposite way.
+    Reverse,
+}
+
+/// Flutter parity: `_describeFlingGesture` (`dismissible.dart:468`).
+fn describe_fling_gesture(
+    drag_extent: f32,
+    direction: DismissDirection,
+    text_direction: TextDirection,
+    primary_velocity: f32,
+    cross_velocity: f32,
+) -> FlingGestureKind {
+    if drag_extent == 0.0 {
+        return FlingGestureKind::None;
+    }
+    if primary_velocity.abs() - cross_velocity.abs() < MIN_FLING_VELOCITY_DELTA
+        || primary_velocity.abs() < MIN_FLING_VELOCITY
+    {
+        return FlingGestureKind::None;
+    }
+    let fling_direction = extent_to_direction(primary_velocity, direction, text_direction);
+    let dismiss_direction = extent_to_direction(drag_extent, direction, text_direction);
+    if fling_direction == dismiss_direction {
+        FlingGestureKind::Forward
+    } else {
+        FlingGestureKind::Reverse
+    }
+}
+
+// ============================================================================
+// STATE
+// ============================================================================
+
+/// Interior-mutable drag/animation progress, shared (via `Rc`) between
+/// `DismissibleState` and the `'static` `GestureDetector` closures `build()`
+/// reconstructs every rebuild. Flutter parity: the mutable instance fields of
+/// `_DismissibleState` (`_dragExtent`, `_dragUnderway`,
+/// `_sizePriorToCollapse`, `_dismissThresholdReached`, `_resizeController`).
+///
+/// Kept out of `AnimationController` listener closures (which must be
+/// `Send + Sync`, per `flui_foundation::ListenerCallback`): those closures
+/// only ever touch the `Arc<Atomic*>` signal fields below, never this
+/// `Rc`/`Cell`-based state directly. `build()` (single-threaded, run on the
+/// frame/build thread) is the only place that reads or reacts to those
+/// signals and mutates this state.
+#[derive(Default)]
+struct DragState {
+    /// Signed pixel extent dragged so far. Flutter parity: `_dragExtent`.
+    drag_extent: Cell<f32>,
+    /// Whether a drag contact is currently down. Flutter parity:
+    /// `_dragUnderway`.
+    drag_underway: Cell<bool>,
+    /// The size occupied right before the resize collapse began. Flutter
+    /// parity: `_sizePriorToCollapse`.
+    size_prior_to_collapse: Cell<Option<Size>>,
+    /// The dismiss-threshold-reached flag from the last `on_update`
+    /// delivery, for `DismissUpdateDetails::previous_reached`. Flutter
+    /// parity: `_dismissThresholdReached`.
+    dismiss_threshold_reached: Cell<bool>,
+    /// `move_controller.value()` at the last `on_update` delivery, so an
+    /// unrelated rebuild (e.g. a parent prop change) that leaves the drag
+    /// position untouched does not re-fire `on_update`.
+    last_delivered_move_value: Cell<f32>,
+
+    /// `move_controller`'s current `Vsync` registration — re-registered (not
+    /// just registered once) on every direct `set_value` while dragging; see
+    /// `reanchor_move_controller_vsync`'s doc for why.
+    move_vsync_registration: Cell<Option<VsyncRegistration>>,
+
+    /// Lazily created once the move animation completes past threshold.
+    /// Flutter parity: `_resizeController`.
+    resize_controller: RefCell<Option<AnimationController>>,
+    resize_listener_id: RefCell<Option<ListenerId>>,
+    resize_vsync_registration: Cell<Option<VsyncRegistration>>,
+
+    /// Bumped by `move_controller`'s status listener on every transition to
+    /// `Completed`. `Send + Sync` (an atomic), so the listener may touch it
+    /// directly; `build()` diffs it against `delivered_move_completions`.
+    move_completed_runs: Arc<AtomicU64>,
+    delivered_move_completions: Cell<u64>,
+
+    /// Bumped by the resize controller's listener on every non-final tick.
+    resize_progress_ticks: Arc<AtomicU64>,
+    delivered_resize_ticks: Cell<u64>,
+    /// Set by the resize controller's listener once it observes completion.
+    resize_completed: Arc<AtomicBool>,
+    delivered_resize_dismissal: Cell<bool>,
+}
+
+/// Configuration captured once per `build()` as an owned (non-borrowing)
+/// snapshot, so the `'static` closures `build()` constructs — invoked later,
+/// against whatever `view` was current when they were built — read a
+/// consistent value instead of a borrow that cannot outlive `build()`.
+struct ResolvedConfig {
+    direction: DismissDirection,
+    text_direction: TextDirection,
+    dismiss_thresholds: HashMap<DismissDirection, f32>,
+    resize_duration: Option<Duration>,
+    cross_axis_end_offset: f32,
+    on_dismissed: Option<DismissDirectionCallback>,
+    on_resize: Option<Rc<dyn Fn()>>,
+}
+
+/// State for [`Dismissible`]. Owns the persistent `move_controller` (created
+/// once, per Flutter's `late final _moveController`) plus the shared
+/// [`DragState`] and the [`RebuildHandle`] acquired in `init_state` (per
+/// ADR-0018 — never acquired from `build`/layout) that the lazily created
+/// resize controller's listener needs later.
+pub struct DismissibleState {
+    move_controller: AnimationController,
+    move_value_listener_id: Option<ListenerId>,
+    move_status_listener_id: Option<ListenerId>,
+    vsync: Option<Vsync>,
+    rebuild: Option<RebuildHandle>,
+    drag: Rc<DragState>,
+}
+
+impl std::fmt::Debug for DismissibleState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DismissibleState")
+            .field("drag_extent", &self.drag.drag_extent.get())
+            .field("drag_underway", &self.drag.drag_underway.get())
+            .field("resizing", &self.drag.resize_controller.borrow().is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl StatefulView for Dismissible {
+    type State = DismissibleState;
+
+    fn create_state(&self) -> Self::State {
+        // A fresh, never-pumped scheduler: on a real display its ticker
+        // drives the controller off wall-clock time; under a `VsyncScope`
+        // the binding drives it deterministically instead (mirrors
+        // `AnimatedSize`/`RefreshIndicator`).
+        let move_controller =
+            AnimationController::new(self.movement_duration, Arc::new(Scheduler::new()));
+        DismissibleState {
+            move_controller,
+            move_value_listener_id: None,
+            move_status_listener_id: None,
+            vsync: None,
+            rebuild: None,
+            drag: Rc::new(DragState::default()),
+        }
+    }
+}
+
+impl ViewState<Dismissible> for DismissibleState {
+    fn init_state(&mut self, ctx: &dyn BuildContext) {
+        let rebuild = ctx.rebuild_handle();
+
+        let rebuild_for_value = rebuild.clone();
+        self.move_value_listener_id =
+            Some(self.move_controller.add_listener(Arc::new(move || {
+                rebuild_for_value.schedule();
+            })));
+
+        let move_completed_runs = Arc::clone(&self.drag.move_completed_runs);
+        let rebuild_for_status = rebuild.clone();
+        self.move_status_listener_id = Some(self.move_controller.add_status_listener(Arc::new(
+            move |status| {
+                if status == AnimationStatus::Completed {
+                    move_completed_runs.fetch_add(1, Ordering::SeqCst);
+                    rebuild_for_status.schedule();
+                }
+            },
+        )));
+
+        if let Some(vsync) = ctx.get::<VsyncScope, _>(|scope| scope.vsync().clone()) {
+            let registration = vsync.register(self.move_controller.clone());
+            self.drag.move_vsync_registration.set(Some(registration));
+            self.vsync = Some(vsync);
+        }
+
+        self.rebuild = Some(rebuild);
+    }
+
+    fn build(&self, view: &Dismissible, ctx: &dyn BuildContext) -> impl IntoView {
+        // Flutter parity: `_directionIsXAxis || debugCheckHasDirectionality`
+        // (`dismissible.dart:611`) requires an ambient `Directionality` only
+        // for the X-axis directions (`EndToStart`/`StartToEnd` read it to
+        // resolve against the reading direction; plain `Horizontal` reads it
+        // too, for `DismissUpdateDetails`/`on_dismissed`'s reported
+        // direction). `Vertical`/`Up`/`Down`/`None` never consult
+        // `text_direction` (see `accumulate_drag_extent`/`extent_to_direction`),
+        // so defaulting instead of requiring an ancestor here avoids an
+        // unnecessary hard panic for callers who never wrap a purely-vertical
+        // `Dismissible` in one.
+        let text_direction = Directionality::maybe_of(ctx).unwrap_or(TextDirection::Ltr);
+        let resolved = Rc::new(ResolvedConfig {
+            direction: view.direction,
+            text_direction,
+            dismiss_thresholds: view.dismiss_thresholds.clone(),
+            resize_duration: view.resize_duration,
+            cross_axis_end_offset: view.cross_axis_end_offset,
+            on_dismissed: view.on_dismissed.clone(),
+            on_resize: view.on_resize.clone(),
+        });
+        let on_update = view.on_update.clone();
+        let behavior = view.behavior;
+        let direction = view.direction;
+        let child = view.child.clone();
+        let background = resolve_background(view, self.drag.drag_extent.get(), text_direction);
+        let move_controller = self.move_controller.clone();
+        let drag = Rc::clone(&self.drag);
+        let vsync = self.vsync.clone();
+        // `rebuild` is set in `init_state`, which always runs before the
+        // first `build` — see `ViewState`'s lifecycle contract.
+        let rebuild = self
+            .rebuild
+            .clone()
+            .expect("BUG: Dismissible::build ran before init_state acquired a RebuildHandle");
+
+        LayoutBuilder::new(move |_ctx, constraints| {
+            let axis_is_x = direction_is_x_axis(direction);
+            let overall_extent = if axis_is_x {
+                constraints.max_width.get()
+            } else {
+                constraints.max_height.get()
+            };
+
+            deliver_move_completion(
+                &drag,
+                &move_controller,
+                &resolved,
+                vsync.as_ref(),
+                &rebuild,
+                constraints,
+            );
+            deliver_resize_progress(&drag, &resolved);
+            deliver_on_update(
+                &drag,
+                &move_controller,
+                direction,
+                text_direction,
+                &resolved,
+                on_update.as_ref(),
+            );
+
+            if let Some(resize_controller) = drag.resize_controller.borrow().as_ref() {
+                let prior = drag.size_prior_to_collapse.get().expect(
+                    "BUG: resize_controller exists only after size_prior_to_collapse is set",
+                );
+                return resize_collapse_view(
+                    resize_controller,
+                    axis_is_x,
+                    prior,
+                    background.clone(),
+                );
+            }
+
+            let content = sliding_content_view(
+                &move_controller,
+                drag.drag_extent.get(),
+                direction,
+                resolved.cross_axis_end_offset,
+                child.clone(),
+            );
+            let content = match background.clone() {
+                Some(bg) if move_controller.value() != 0.0 => Stack::new(vec![
+                    Positioned::fill(ClipRect::new().clip_behavior(Clip::HardEdge).child(bg))
+                        .boxed(),
+                    content.boxed(),
+                ])
+                .boxed(),
+                _ => content.boxed(),
+            };
+
+            if direction == DismissDirection::None {
+                return content;
+            }
+
+            let mut detector = GestureDetector::new().behavior(behavior);
+            let drag_for_start = Rc::clone(&drag);
+            let controller_for_start = move_controller.clone();
+            let vsync_for_start = vsync.clone();
+            let drag_for_update = Rc::clone(&drag);
+            let controller_for_update = move_controller.clone();
+            let resolved_for_update = Rc::clone(&resolved);
+            let drag_for_end = Rc::clone(&drag);
+            let controller_for_end = move_controller.clone();
+            let resolved_for_end = Rc::clone(&resolved);
+            let vsync_for_end = vsync.clone();
+            let rebuild_for_end = rebuild.clone();
+
+            if axis_is_x {
+                detector = detector
+                    .on_horizontal_drag_start(move |_details: DragStartDetails| {
+                        handle_drag_start(
+                            &drag_for_start,
+                            &controller_for_start,
+                            vsync_for_start.as_ref(),
+                            overall_extent,
+                        );
+                    })
+                    .on_horizontal_drag_update(move |details: DragUpdateDetails| {
+                        handle_drag_update(
+                            &drag_for_update,
+                            &controller_for_update,
+                            direction,
+                            resolved_for_update.text_direction,
+                            overall_extent,
+                            details.delta.dx.get(),
+                        );
+                    })
+                    .on_horizontal_drag_end(move |details: DragEndDetails| {
+                        handle_drag_end(
+                            &drag_for_end,
+                            &controller_for_end,
+                            &resolved_for_end,
+                            vsync_for_end.as_ref(),
+                            &rebuild_for_end,
+                            constraints,
+                            details.velocity.pixels_per_second.dx.get(),
+                            details.velocity.pixels_per_second.dy.get(),
+                        );
+                    });
+            } else {
+                detector = detector
+                    .on_pan_start(move |_details: DragStartDetails| {
+                        handle_drag_start(
+                            &drag_for_start,
+                            &controller_for_start,
+                            vsync_for_start.as_ref(),
+                            overall_extent,
+                        );
+                    })
+                    .on_pan_update(move |details: DragUpdateDetails| {
+                        handle_drag_update(
+                            &drag_for_update,
+                            &controller_for_update,
+                            direction,
+                            resolved_for_update.text_direction,
+                            overall_extent,
+                            details.delta.dy.get(),
+                        );
+                    })
+                    .on_pan_end(move |details: DragEndDetails| {
+                        handle_drag_end(
+                            &drag_for_end,
+                            &controller_for_end,
+                            &resolved_for_end,
+                            vsync_for_end.as_ref(),
+                            &rebuild_for_end,
+                            constraints,
+                            details.velocity.pixels_per_second.dy.get(),
+                            details.velocity.pixels_per_second.dx.get(),
+                        );
+                    });
+            }
+
+            detector.child(content).boxed()
+        })
+    }
+
+    fn dispose(&mut self) {
+        if let Some(id) = self.move_value_listener_id.take() {
+            self.move_controller.remove_listener(id);
+        }
+        if let Some(id) = self.move_status_listener_id.take() {
+            self.move_controller.remove_status_listener(id);
+        }
+        if let (Some(vsync), Some(registration)) =
+            (&self.vsync, self.drag.move_vsync_registration.take())
+        {
+            vsync.unregister(registration);
+        }
+        self.move_controller.dispose();
+
+        if let Some(resize_controller) = self.drag.resize_controller.borrow_mut().take() {
+            if let Some(id) = self.drag.resize_listener_id.borrow_mut().take() {
+                resize_controller.remove_listener(id);
+            }
+            if let (Some(vsync), Some(registration)) =
+                (&self.vsync, self.drag.resize_vsync_registration.take())
+            {
+                vsync.unregister(registration);
+            }
+            resize_controller.dispose();
+        }
+    }
+}
+
+// ============================================================================
+// Gesture handlers — free functions mirroring `_DismissibleState`'s private
+// methods, called from the `'static` closures `build()` reconstructs.
+// ============================================================================
+
+/// Unregisters `move_controller` from `vsync` for the duration of a raw drag.
+///
+/// `set_value` (called on every drag update, exactly like the oracle's
+/// `_moveController.value = ...`) leaves the controller's `AnimationStatus`
+/// at `Forward`/`Reverse` for any value strictly between the bounds — the
+/// same status a REAL `.forward()`/`.reverse()` run leaves it at
+/// (`AnimationController::settled_status_keep_direction`, which "keeps
+/// direction" rather than reporting a settled `Dismissed`/`Completed` for a
+/// non-bound value). `Vsync::tick_all` gates ticking on
+/// `status().is_running()` — indistinguishable, from `Vsync`'s side, from a
+/// genuine run in progress — so it ticks the controller via `tick_at`, which
+/// recomputes `value` from the controller's own internal run epoch
+/// (`AnimationController::tick_time_based`) rather than treating `set_value`
+/// as authoritative. Since `set_value` does not update that internal epoch
+/// (only `.forward()`/`.reverse()`/`.fling()` do), any tick while merely
+/// drag-tracking silently overwrites the value just written — with a STALE
+/// epoch this drifts gradually; even freshly re-anchoring on every update
+/// (an earlier, insufficient attempt at this fix) still overwrites it
+/// immediately, just with a near-zero value instead of a drifting one. The
+/// only way to keep a direct `set_value` authoritative is to make sure the
+/// controller is not ticked AT ALL while it is happening — hence full
+/// unregistration for the drag's duration, paired with
+/// [`ensure_move_controller_registered`] re-registering right before the
+/// REAL run (`.forward()`/`.reverse()`/`.fling()`) that should actually be
+/// vsync-driven.
+///
+/// This is a real interaction gap between `AnimationController::set_value`
+/// and `Vsync::tick_all` (the latter should likely gate on the ticker-based
+/// `is_animating()` this module already prefers elsewhere, not the
+/// status-based `is_running()`, and/or `tick_at` should no-op when nothing
+/// bumped the run epoch since the last tick) — worth fixing at the
+/// `flui-animation` layer for every future widget that combines direct
+/// value-tracking with vsync-driven settling on the same controller, not
+/// just this one.
+fn unregister_move_controller_vsync(drag: &DragState, vsync: Option<&Vsync>) {
+    let (Some(vsync), Some(registration)) = (vsync, drag.move_vsync_registration.take()) else {
+        return;
+    };
+    vsync.unregister(registration);
+}
+
+/// Re-registers `move_controller` with `vsync` if it is not already
+/// registered — called right before a REAL run
+/// (`.forward()`/`.reverse()`/`.fling()`) starts, so `Vsync`'s tick anchor and
+/// the controller's own internal run epoch both correspond to "now", the
+/// run's true start. See [`unregister_move_controller_vsync`]'s doc for the
+/// full rationale.
+fn ensure_move_controller_registered(
+    drag: &DragState,
+    move_controller: &AnimationController,
+    vsync: Option<&Vsync>,
+) {
+    let Some(vsync) = vsync else { return };
+    if drag.move_vsync_registration.get().is_some() {
+        return;
+    }
+    let registration = vsync.register(move_controller.clone());
+    drag.move_vsync_registration.set(Some(registration));
+}
+
+/// Flutter parity: `_handleDragStart` (`dismissible.dart:366`), minus the
+/// `_confirming` guard (no `confirmDismiss` — see module docs divergence #1).
+fn handle_drag_start(
+    drag: &Rc<DragState>,
+    move_controller: &AnimationController,
+    vsync: Option<&Vsync>,
+    overall_extent: f32,
+) {
+    drag.drag_underway.set(true);
+    if move_controller.is_animating() {
+        let sign = drag_sign(drag.drag_extent.get());
+        drag.drag_extent
+            .set(move_controller.value() * overall_extent * sign);
+        let _ = move_controller.stop();
+    } else {
+        drag.drag_extent.set(0.0);
+        move_controller.set_value(0.0);
+    }
+    // Unregister for the drag's duration — see `unregister_move_controller_vsync`'s
+    // doc for why a vsync-ticked controller cannot also be a direct-`set_value`-tracked
+    // one at the same time.
+    unregister_move_controller_vsync(drag, vsync);
+}
+
+/// Flutter parity: `_handleDragUpdate` (`dismissible.dart:383`) — `delta` is
+/// the raw signed per-axis pointer delta (see module docs divergence #3 on
+/// why this reads the raw component rather than `primary_delta`).
+fn handle_drag_update(
+    drag: &Rc<DragState>,
+    move_controller: &AnimationController,
+    direction: DismissDirection,
+    text_direction: TextDirection,
+    overall_extent: f32,
+    delta: f32,
+) {
+    if !drag.drag_underway.get() || move_controller.is_animating() {
+        return;
+    }
+    let new_extent =
+        accumulate_drag_extent(direction, text_direction, drag.drag_extent.get(), delta);
+    drag.drag_extent.set(new_extent);
+    if !move_controller.is_animating() {
+        // `move_controller` is unregistered from `Vsync` for the whole drag
+        // (see `handle_drag_start`), so this direct write is not immediately
+        // clobbered by a tick — no re-registration needed here.
+        move_controller.set_value(new_extent.abs() / overall_extent);
+    }
+}
+
+/// Flutter parity: `_handleDragEnd` (`dismissible.dart:500`).
+#[allow(clippy::too_many_arguments)] // mirrors the oracle's own `_handleDragEnd`, which reaches the same seven pieces of state via `widget`/instance fields rather than parameters
+fn handle_drag_end(
+    drag: &Rc<DragState>,
+    move_controller: &AnimationController,
+    resolved: &Rc<ResolvedConfig>,
+    vsync: Option<&Vsync>,
+    rebuild: &RebuildHandle,
+    constraints: BoxConstraints,
+    primary_velocity: f32,
+    cross_velocity: f32,
+) {
+    if !drag.drag_underway.get() || move_controller.is_animating() {
+        return;
+    }
+    drag.drag_underway.set(false);
+    if move_controller.is_completed() {
+        deliver_move_completion(drag, move_controller, resolved, vsync, rebuild, constraints);
+        return;
+    }
+    let dismiss_direction = extent_to_direction(
+        drag.drag_extent.get(),
+        resolved.direction,
+        resolved.text_direction,
+    );
+    let threshold = dismiss_threshold_for(&resolved.dismiss_thresholds, dismiss_direction);
+    // Every branch below starts a REAL run (`.forward()`/`.reverse()`/`.fling()`)
+    // — re-register now so `Vsync`'s tick anchor lines up with the run's true
+    // start (see `unregister_move_controller_vsync`'s doc).
+    ensure_move_controller_registered(drag, move_controller, vsync);
+    match describe_fling_gesture(
+        drag.drag_extent.get(),
+        resolved.direction,
+        resolved.text_direction,
+        primary_velocity,
+        cross_velocity,
+    ) {
+        FlingGestureKind::Forward => {
+            if threshold >= 1.0 {
+                let _ = move_controller.reverse();
+            } else {
+                drag.drag_extent.set(primary_velocity.signum());
+                let _ = move_controller.fling(primary_velocity.abs() * FLING_VELOCITY_SCALE);
+            }
+        }
+        FlingGestureKind::Reverse => {
+            drag.drag_extent.set(primary_velocity.signum());
+            let _ = move_controller.fling(-primary_velocity.abs() * FLING_VELOCITY_SCALE);
+        }
+        FlingGestureKind::None => {
+            if !move_controller.is_dismissed() {
+                if move_controller.value() > threshold {
+                    let _ = move_controller.forward();
+                } else {
+                    let _ = move_controller.reverse();
+                }
+            }
+        }
+    }
+}
+
+/// Flutter parity: `_handleDismissStatusChanged` + `_handleMoveCompleted`
+/// (`dismissible.dart:539`-`561`), collapsed into one idempotent function
+/// callable from either the deferred (`build()`-driven) path or the
+/// immediate path `handle_drag_end` takes when the controller is already
+/// completed at release. Idempotent via the `move_completed_runs` /
+/// `delivered_move_completions` counter pair: a call that finds nothing new
+/// to deliver is a no-op, so it is safe to call from both sites without
+/// double-firing `on_dismissed` or double-reversing.
+#[allow(clippy::too_many_arguments)] // mirrors the oracle's own method arity — see `handle_drag_end`'s note
+fn deliver_move_completion(
+    drag: &Rc<DragState>,
+    move_controller: &AnimationController,
+    resolved: &Rc<ResolvedConfig>,
+    vsync: Option<&Vsync>,
+    rebuild: &RebuildHandle,
+    constraints: BoxConstraints,
+) {
+    let completed_runs = drag.move_completed_runs.load(Ordering::SeqCst);
+    if completed_runs <= drag.delivered_move_completions.get() || drag.drag_underway.get() {
+        return;
+    }
+    drag.delivered_move_completions.set(completed_runs);
+
+    let dismiss_direction = extent_to_direction(
+        drag.drag_extent.get(),
+        resolved.direction,
+        resolved.text_direction,
+    );
+    let threshold = dismiss_threshold_for(&resolved.dismiss_thresholds, dismiss_direction);
+    if threshold >= 1.0 {
+        // A real run starts here too (reached via the `is_completed()` bypass
+        // in `handle_drag_end`, where the drag itself — never vsync-registered,
+        // see `unregister_move_controller_vsync` — pushed the value to 1.0).
+        ensure_move_controller_registered(drag, move_controller, vsync);
+        let _ = move_controller.reverse();
+        return;
+    }
+
+    match resolved.resize_duration {
+        None => {
+            if let Some(on_dismissed) = &resolved.on_dismissed {
+                on_dismissed(dismiss_direction);
+            }
+        }
+        Some(duration) => {
+            start_resize_animation(drag, duration, vsync, rebuild, constraints.biggest());
+        }
+    }
+}
+
+/// Flutter parity: `_startResizeAnimation` (`dismissible.dart:576`), the
+/// `resize_duration.is_some()` branch (the `None` branch is handled inline in
+/// [`deliver_move_completion`]).
+fn start_resize_animation(
+    drag: &Rc<DragState>,
+    duration: Duration,
+    vsync: Option<&Vsync>,
+    rebuild: &RebuildHandle,
+    size_prior_to_collapse: Size,
+) {
+    if drag.resize_controller.borrow().is_some() {
+        return;
+    }
+    drag.size_prior_to_collapse
+        .set(Some(size_prior_to_collapse));
+
+    let resize_controller = AnimationController::new(duration, Arc::new(Scheduler::new()));
+
+    let resize_ref = resize_controller.clone();
+    let progress_ticks = Arc::clone(&drag.resize_progress_ticks);
+    let completed_flag = Arc::clone(&drag.resize_completed);
+    let rebuild_for_resize = rebuild.clone();
+    let listener_id = resize_controller.add_listener(Arc::new(move || {
+        if resize_ref.is_completed() {
+            completed_flag.store(true, Ordering::SeqCst);
+        } else {
+            progress_ticks.fetch_add(1, Ordering::SeqCst);
+        }
+        rebuild_for_resize.schedule();
+    }));
+    *drag.resize_listener_id.borrow_mut() = Some(listener_id);
+
+    if let Some(vsync) = vsync {
+        let registration = vsync.register(resize_controller.clone());
+        drag.resize_vsync_registration.set(Some(registration));
+    }
+
+    let _ = resize_controller.forward();
+    *drag.resize_controller.borrow_mut() = Some(resize_controller);
+}
+
+/// Flutter parity: `_handleResizeProgressChanged` (`dismissible.dart:599`) —
+/// fires `on_resize` for every delivered progress tick, or `on_dismissed`
+/// once when the resize controller completes.
+fn deliver_resize_progress(drag: &Rc<DragState>, resolved: &Rc<ResolvedConfig>) {
+    if drag.resize_completed.load(Ordering::SeqCst) {
+        if !drag.delivered_resize_dismissal.get() {
+            drag.delivered_resize_dismissal.set(true);
+            let direction = extent_to_direction(
+                drag.drag_extent.get(),
+                resolved.direction,
+                resolved.text_direction,
+            );
+            if let Some(on_dismissed) = &resolved.on_dismissed {
+                on_dismissed(direction);
+            }
+        }
+        return;
+    }
+    let ticks = drag.resize_progress_ticks.load(Ordering::SeqCst);
+    let delivered = drag.delivered_resize_ticks.get();
+    if ticks > delivered {
+        drag.delivered_resize_ticks.set(ticks);
+        if let Some(on_resize) = &resolved.on_resize {
+            for _ in delivered..ticks {
+                on_resize();
+            }
+        }
+    }
+}
+
+/// Flutter parity: `_handleDismissUpdateValueChanged` (`dismissible.dart:442`).
+fn deliver_on_update(
+    drag: &Rc<DragState>,
+    move_controller: &AnimationController,
+    direction: DismissDirection,
+    text_direction: TextDirection,
+    resolved: &Rc<ResolvedConfig>,
+    on_update: Option<&DismissUpdateCallback>,
+) {
+    let Some(on_update) = on_update else { return };
+    let value = move_controller.value();
+    if value == drag.last_delivered_move_value.get() {
+        return;
+    }
+    drag.last_delivered_move_value.set(value);
+
+    let dismiss_direction = extent_to_direction(drag.drag_extent.get(), direction, text_direction);
+    let threshold = dismiss_threshold_for(&resolved.dismiss_thresholds, dismiss_direction);
+    let previous_reached = drag.dismiss_threshold_reached.get();
+    let reached = value > threshold;
+    drag.dismiss_threshold_reached.set(reached);
+    on_update(DismissUpdateDetails {
+        direction: dismiss_direction,
+        reached,
+        previous_reached,
+        progress: value,
+    });
+}
+
+// ============================================================================
+// View construction
+// ============================================================================
+
+/// `background`, or `secondary_background` while dragging toward
+/// `EndToStart`/`Up` (Flutter parity: `dismissible.dart:613`-`619`).
+fn resolve_background(
+    view: &Dismissible,
+    drag_extent: f32,
+    text_direction: TextDirection,
+) -> Option<BoxedView> {
+    let dismiss_direction = extent_to_direction(drag_extent, view.direction, text_direction);
+    if view.secondary_background.is_some()
+        && matches!(
+            dismiss_direction,
+            DismissDirection::EndToStart | DismissDirection::Up
+        )
+    {
+        view.secondary_background.clone()
+    } else {
+        view.background.clone()
+    }
+}
+
+/// The slid-and-translated content: `FractionalTranslation` driven directly
+/// by `move_controller.value()` and the drag's current sign — mathematically
+/// identical to the oracle's `Tween<Offset>(begin: Offset.zero, end:
+/// ...).animate(_moveController)` (a zero-`begin` tween's value at `t` is
+/// just `t * end`). Flutter parity: `_updateMoveAnimation` +
+/// `SlideTransition` inside `build` (`dismissible.dart:456`-`466`,
+/// `648`-`651`).
+fn sliding_content_view(
+    move_controller: &AnimationController,
+    drag_extent: f32,
+    direction: DismissDirection,
+    cross_axis_end_offset: f32,
+    child: BoxedView,
+) -> FractionalTranslation {
+    let t = move_controller.value();
+    let sign = drag_sign(drag_extent);
+    let (dx, dy) = if direction_is_x_axis(direction) {
+        (t * sign, t * cross_axis_end_offset)
+    } else {
+        (t * cross_axis_end_offset, t * sign)
+    };
+    FractionalTranslation::new(dx, dy).child(child)
+}
+
+/// The post-dismiss collapse: a `background`-filled box shrinking along the
+/// axis perpendicular to the dismiss direction, per `_kResizeTimeCurve`
+/// (`Interval(0.4, 1.0, Curves.ease)`) — a 40% pause, then an eased collapse
+/// to zero. Flutter parity: the `SizeTransition` branch of `build`
+/// (`dismissible.dart:621`-`646`); see module docs divergence #2 for why this
+/// clips at full size rather than progressively (`ClipRect::clip_behavior`
+/// has no arbitrary-rect clipper to crop the un-collapsed axis to the
+/// revealed sliver — irrelevant here anyway, since by this point the
+/// collapsing box IS the background at its full prior size).
+fn resize_collapse_view(
+    resize_controller: &AnimationController,
+    axis_is_x: bool,
+    prior: Size,
+    background: Option<BoxedView>,
+) -> BoxedView {
+    let curved = Interval::new(0.4, 1.0, Curves::Ease).transform(resize_controller.value());
+    let factor = 1.0 - curved;
+    let (width, height) = if axis_is_x {
+        (prior.width.get(), prior.height.get() * factor)
+    } else {
+        (prior.width.get() * factor, prior.height.get())
+    };
+    let collapsed = SizedBox::new(width, height);
+    let collapsed = match background {
+        Some(bg) => collapsed.child(bg),
+        None => collapsed,
+    };
+    ClipRect::new()
+        .clip_behavior(Clip::HardEdge)
+        .child(collapsed)
+        .boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // `extent_to_direction` — Flutter parity: `_extentToDirection`.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn extent_to_direction_zero_extent_is_none_regardless_of_configured_direction() {
+        assert_eq!(
+            extent_to_direction(0.0, DismissDirection::Horizontal, TextDirection::Ltr),
+            DismissDirection::None
+        );
+        assert_eq!(
+            extent_to_direction(0.0, DismissDirection::Vertical, TextDirection::Rtl),
+            DismissDirection::None
+        );
+    }
+
+    #[test]
+    fn extent_to_direction_horizontal_ltr_maps_sign_to_start_end() {
+        assert_eq!(
+            extent_to_direction(10.0, DismissDirection::Horizontal, TextDirection::Ltr),
+            DismissDirection::StartToEnd,
+            "LTR: positive (rightward) extent is the reading-direction way, StartToEnd"
+        );
+        assert_eq!(
+            extent_to_direction(-10.0, DismissDirection::Horizontal, TextDirection::Ltr),
+            DismissDirection::EndToStart,
+            "LTR: negative (leftward) extent is against reading direction, EndToStart"
+        );
+    }
+
+    #[test]
+    fn extent_to_direction_horizontal_rtl_flips_the_mapping() {
+        assert_eq!(
+            extent_to_direction(10.0, DismissDirection::Horizontal, TextDirection::Rtl),
+            DismissDirection::EndToStart,
+            "RTL: positive (rightward) extent is AGAINST the RTL reading direction"
+        );
+        assert_eq!(
+            extent_to_direction(-10.0, DismissDirection::Horizontal, TextDirection::Rtl),
+            DismissDirection::StartToEnd,
+            "RTL: negative (leftward) extent follows the RTL reading direction"
+        );
+    }
+
+    #[test]
+    fn extent_to_direction_vertical_ignores_text_direction() {
+        assert_eq!(
+            extent_to_direction(10.0, DismissDirection::Vertical, TextDirection::Rtl),
+            DismissDirection::Down
+        );
+        assert_eq!(
+            extent_to_direction(-10.0, DismissDirection::Up, TextDirection::Ltr),
+            DismissDirection::Up
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // `accumulate_drag_extent` — Flutter parity: the gating `switch` in
+    // `_handleDragUpdate`.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn accumulate_drag_extent_up_direction_only_admits_negative_extent() {
+        assert_eq!(
+            accumulate_drag_extent(DismissDirection::Up, TextDirection::Ltr, 0.0, -10.0),
+            -10.0,
+            "a proposed negative (upward) extent is admitted"
+        );
+        assert_eq!(
+            accumulate_drag_extent(DismissDirection::Up, TextDirection::Ltr, 0.0, 10.0),
+            0.0,
+            "a proposed positive (downward) extent is REJECTED — Up cannot go positive"
+        );
+    }
+
+    #[test]
+    fn accumulate_drag_extent_down_direction_only_admits_positive_extent() {
+        assert_eq!(
+            accumulate_drag_extent(DismissDirection::Down, TextDirection::Ltr, 0.0, 10.0),
+            10.0
+        );
+        assert_eq!(
+            accumulate_drag_extent(DismissDirection::Down, TextDirection::Ltr, 0.0, -10.0),
+            0.0,
+            "a proposed negative extent is REJECTED — Down cannot go negative"
+        );
+    }
+
+    #[test]
+    fn accumulate_drag_extent_end_to_start_ltr_only_admits_negative() {
+        assert_eq!(
+            accumulate_drag_extent(DismissDirection::EndToStart, TextDirection::Ltr, 0.0, -5.0),
+            -5.0
+        );
+        assert_eq!(
+            accumulate_drag_extent(DismissDirection::EndToStart, TextDirection::Ltr, 0.0, 5.0),
+            0.0
+        );
+    }
+
+    #[test]
+    fn accumulate_drag_extent_end_to_start_rtl_only_admits_positive() {
+        assert_eq!(
+            accumulate_drag_extent(DismissDirection::EndToStart, TextDirection::Rtl, 0.0, 5.0),
+            5.0
+        );
+        assert_eq!(
+            accumulate_drag_extent(DismissDirection::EndToStart, TextDirection::Rtl, 0.0, -5.0),
+            0.0
+        );
+    }
+
+    #[test]
+    fn accumulate_drag_extent_none_direction_always_collapses_to_zero() {
+        assert_eq!(
+            accumulate_drag_extent(DismissDirection::None, TextDirection::Ltr, 40.0, 10.0),
+            0.0
+        );
+    }
+
+    #[test]
+    fn accumulate_drag_extent_horizontal_and_vertical_admit_every_delta_unconditionally() {
+        assert_eq!(
+            accumulate_drag_extent(DismissDirection::Horizontal, TextDirection::Ltr, 5.0, -30.0),
+            -25.0
+        );
+        assert_eq!(
+            accumulate_drag_extent(DismissDirection::Vertical, TextDirection::Ltr, -5.0, 30.0),
+            25.0
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // `describe_fling_gesture` — Flutter parity: `_describeFlingGesture`.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn describe_fling_gesture_zero_extent_is_none() {
+        assert_eq!(
+            describe_fling_gesture(
+                0.0,
+                DismissDirection::Horizontal,
+                TextDirection::Ltr,
+                900.0,
+                0.0
+            ),
+            FlingGestureKind::None,
+            "a fling released at exactly zero displacement has no direction to fling toward"
+        );
+    }
+
+    #[test]
+    fn describe_fling_gesture_below_min_velocity_is_none() {
+        assert_eq!(
+            describe_fling_gesture(
+                10.0,
+                DismissDirection::Horizontal,
+                TextDirection::Ltr,
+                699.9,
+                0.0
+            ),
+            FlingGestureKind::None,
+            "699.9 px/s is 0.1 short of kMinFlingVelocity (700)"
+        );
+    }
+
+    #[test]
+    fn describe_fling_gesture_at_min_velocity_with_clean_cross_axis_is_forward() {
+        assert_eq!(
+            describe_fling_gesture(
+                10.0,
+                DismissDirection::Horizontal,
+                TextDirection::Ltr,
+                700.0,
+                0.0
+            ),
+            FlingGestureKind::Forward,
+            "700 px/s clears kMinFlingVelocity, aimed the same way the drag already leans"
+        );
+    }
+
+    #[test]
+    fn describe_fling_gesture_insufficient_axis_delta_is_none() {
+        assert_eq!(
+            describe_fling_gesture(
+                10.0,
+                DismissDirection::Horizontal,
+                TextDirection::Ltr,
+                900.0,
+                900.0
+            ),
+            FlingGestureKind::None,
+            "900 vs 900 cross-axis: the 0 delta is short of kMinFlingVelocityDelta (400) — \
+             not clearly aimed along the drag axis"
+        );
+    }
+
+    #[test]
+    fn describe_fling_gesture_opposite_direction_is_reverse() {
+        assert_eq!(
+            describe_fling_gesture(
+                10.0,
+                DismissDirection::Horizontal,
+                TextDirection::Ltr,
+                -900.0,
+                0.0
+            ),
+            FlingGestureKind::Reverse,
+            "dragged rightward (extent > 0, StartToEnd) but flung leftward (EndToStart)"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // `dismiss_threshold_for` / `drag_sign`.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn dismiss_threshold_for_unset_direction_is_the_default() {
+        let thresholds = HashMap::new();
+        assert_eq!(
+            dismiss_threshold_for(&thresholds, DismissDirection::StartToEnd),
+            DEFAULT_DISMISS_THRESHOLD
+        );
+    }
+
+    #[test]
+    fn dismiss_threshold_for_overridden_direction_wins() {
+        let mut thresholds = HashMap::new();
+        thresholds.insert(DismissDirection::StartToEnd, 1.0);
+        assert_eq!(
+            dismiss_threshold_for(&thresholds, DismissDirection::StartToEnd),
+            1.0
+        );
+        assert_eq!(
+            dismiss_threshold_for(&thresholds, DismissDirection::EndToStart),
+            DEFAULT_DISMISS_THRESHOLD,
+            "the override is per-direction — an unrelated direction keeps the default"
+        );
+    }
+
+    #[test]
+    fn drag_sign_treats_positive_and_negative_zero_as_no_drag() {
+        assert_eq!(drag_sign(0.0), 0.0);
+        assert_eq!(drag_sign(-0.0), 0.0);
+        assert_eq!(drag_sign(5.0), 1.0);
+        assert_eq!(drag_sign(-5.0), -1.0);
+    }
+}

--- a/crates/flui-widgets/src/interaction/mod.rs
+++ b/crates/flui-widgets/src/interaction/mod.rs
@@ -4,6 +4,7 @@
 
 mod absorb_pointer;
 mod actions;
+mod dismissible;
 mod focus;
 mod gesture_arena_scope;
 mod gesture_detector;
@@ -18,6 +19,10 @@ pub use absorb_pointer::AbsorbPointer;
 pub use actions::{
     Action, ActionOutcome, Actions, CallbackAction, Intent, NextFocusAction, NextFocusIntent,
     PreviousFocusAction, PreviousFocusIntent,
+};
+pub use dismissible::{
+    DismissDirection, DismissDirectionCallback, DismissUpdateCallback, DismissUpdateDetails,
+    Dismissible, DismissibleState,
 };
 pub use focus::{ExcludeFocus, Focus, FocusChangeHandler, FocusScope, FocusScopeState, FocusState};
 pub(crate) use focus::{enclosing_focus_parent, install_rect_provider};

--- a/crates/flui-widgets/src/lib.rs
+++ b/crates/flui-widgets/src/lib.rs
@@ -156,11 +156,13 @@ pub use image::{
     MemoryImage,
 };
 pub use interaction::{
-    AbsorbPointer, Action, ActionOutcome, Actions, CallbackAction, CallbackShortcuts, ExcludeFocus,
-    Focus, FocusChangeHandler, FocusScope, FocusScopeState, FocusState, GestureArenaScope,
-    GestureDetector, GestureDetectorState, IgnorePointer, Intent, Listener, MouseRegion,
-    NextFocusAction, NextFocusIntent, Offstage, PreviousFocusAction, PreviousFocusIntent,
-    ShortcutCallback, Shortcuts, SingleActivator, Visibility,
+    AbsorbPointer, Action, ActionOutcome, Actions, CallbackAction, CallbackShortcuts,
+    DismissDirection, DismissDirectionCallback, DismissUpdateCallback, DismissUpdateDetails,
+    Dismissible, DismissibleState, ExcludeFocus, Focus, FocusChangeHandler, FocusScope,
+    FocusScopeState, FocusState, GestureArenaScope, GestureDetector, GestureDetectorState,
+    IgnorePointer, Intent, Listener, MouseRegion, NextFocusAction, NextFocusIntent, Offstage,
+    PreviousFocusAction, PreviousFocusIntent, ShortcutCallback, Shortcuts, SingleActivator,
+    Visibility,
 };
 pub use layout::{
     Align, AspectRatio, Baseline, Center, ConstrainedBox, CustomMultiChildLayout,

--- a/crates/flui-widgets/tests/common/mod.rs
+++ b/crates/flui-widgets/tests/common/mod.rs
@@ -780,6 +780,15 @@ impl LaidOutScoped {
         &self.laid
     }
 
+    /// Reconcile the root against `new_root` — the scoped analogue of
+    /// [`LaidOut::pump_widget`], for tests that need both gesture dispatch
+    /// (arena-scoped) AND a later reconfigure/unmount of the same tree, e.g.
+    /// swapping a gesture-driven widget away mid-animation to prove its
+    /// `dispose` unregisters every controller it registered with `Vsync`.
+    pub fn pump_widget(&mut self, new_root: impl View) {
+        self.laid.pump_widget(new_root);
+    }
+
     /// Advance the virtual clock by `dt` and fire any gesture deadline that has
     /// now elapsed — the deterministic, sleep-free frame tick.
     pub fn pump(&mut self, dt: Duration) {

--- a/crates/flui-widgets/tests/parity/dismissible_test.rs
+++ b/crates/flui-widgets/tests/parity/dismissible_test.rs
@@ -1,0 +1,883 @@
+//! ## Test parity notes
+//!
+//! Flutter source: `packages/flutter/test/widgets/dismissible_test.dart`
+//! (tag `3.44.0`, 36 `testWidgets` cases).
+//!
+//! ### Out of scope (with reasons — not silently dropped from the count)
+//!
+//! - **`confirmDismiss`** (`'confirmDismiss returns values: true, false,
+//!   null'`, `'Pending confirmDismiss does not cause errors'`, `'Dismissible
+//!   cannot be dragged with pending confirmDismiss'`) — `Dismissible` does not
+//!   implement `confirmDismiss` at all (see
+//!   `crates/flui-widgets/src/interaction/dismissible.rs`'s module-doc
+//!   divergence #1): FLUI has no established widget-level "await a caller
+//!   future, then resume a state transition" seam yet, and inventing one
+//!   one-off for this port would misrepresent the oracle's real (vetoable,
+//!   async) contract with a synchronous stand-in. Tracked as a follow-up.
+//! - **Fling-velocity cases** (`'Horizontal fling triggers dismiss...'` and
+//!   every other `'fling-*'` case, `'... fling item before/after
+//!   movementDuration'`, `'Horizontal/Vertical fling less than threshold'`) —
+//!   `DragGestureRecognizer::handle_move` (`crates/flui-interaction/src/recognizers/drag.rs`)
+//!   timestamps velocity samples with the real OS clock (`Instant::now()`),
+//!   not the deterministic virtual clock `LaidOutScoped::pump` advances for
+//!   gesture *timing* (long-press/double-tap deadlines — see
+//!   `gesture_timing_test.rs`'s module doc). A scripted
+//!   `dispatch_pointer_move` sequence therefore produces a *real* velocity of
+//!   *non-reproducible magnitude* — confirmed empirically while building this
+//!   file: identical test code measured anywhere from ~1.6M to ~4.3M px/s for
+//!   the same 120px drag, run to run. Unlike Flutter's own `WidgetTester`
+//!   (whose synthetic test binding feeds fake timestamps into pointer events
+//!   for exactly this reason), no case here can assert a *specific* fling
+//!   velocity or a bounded settle time — a dedicated virtual-clock seam for
+//!   pointer-velocity sampling would need to land in the shared harness
+//!   first, out of this task's scope.
+//!
+//!   Every drag-then-release case below neutralizes the *classification*
+//!   instead (it cannot neutralize the magnitude): the release lands at a
+//!   position offset on the CROSS axis by the exact same signed pixel amount
+//!   as the reported primary-axis delta. Whatever the recognizer's opaque
+//!   velocity estimator computes, it is applying the *same* function to two
+//!   proportional (here, identical) position/time series, so the estimated
+//!   `|primary_velocity|` and `|cross_velocity|` come out equal regardless of
+//!   the actual (unpredictable) magnitude — `describe_fling_gesture`'s
+//!   `primary.abs() - cross.abs() < kMinFlingVelocityDelta` gate is satisfied
+//!   unconditionally, so it resolves to `FlingGestureKind::None` and the
+//!   release falls through to the plain threshold-vs-`.forward()`/`.reverse()`
+//!   path this port actually targets. (An earlier attempt — repeating the
+//!   final position 2-3 times before releasing, hoping to drive the estimate
+//!   toward zero — measurably failed: it still produced million-px/s
+//!   estimates, and even flipped the classified *direction* run to run,
+//!   confirming the estimator is not a simple last-sample delta.)
+//!
+//!   Every test that relies on this lays its `Dismissible` out in a box whose
+//!   CROSS axis has enough headroom for that offset (`horizontal_extent`/
+//!   `vertical_extent` below) — the dismiss axis itself keeps the round
+//!   200px / 80px this file's percentages are written against.
+//! - **Semantics** (`'Dismissible.behavior should behave correctly during
+//!   hit testing'`'s semantics half, the semantics-tree assertions embedded in
+//!   several other cases) — paint/semantics are Phase 3 (deferred) per this
+//!   crate's `parity/main.rs` module doc.
+//! - **`AutomaticKeepAlive` interaction** (`'dismissing bottom then top
+//!   (smoketest)'`'s `ListView`-recycling half, `'setState that does not
+//!   remove the Dismissible from tree should throw Error'`) — no keep-alive
+//!   mechanism exists anywhere in FLUI yet (a framework-wide gap, not specific
+//!   to this port — see the widget's module-doc divergence #5).
+//! - **`Change direction does not lose child state`** — exercises
+//!   `AutomaticKeepAlive`-adjacent `State` preservation semantics this port's
+//!   `LayoutBuilder`-based composition does not attempt to replicate.
+//!
+//! ### Framework gap discovered while building this file
+//!
+//! Two observations below (`resize_collapse_starts_at_full_size_then_runs_to_completion`'s
+//! doc, and the removed-and-documented `both_controllers_are_disposed_when_unmounted_mid_resize_collapse`
+//! immediately after `move_controller_registers_with_vsync_and_unregisters_on_unmount`)
+//! are shaped by a real gap confirmed with temporary direct instrumentation
+//! while building this corpus, not a `Dismissible`-level bug:
+//!
+//! 1. Once `Dismissible`'s `build()` traverses the resize-collapse branch
+//!    (returned from inside `LayoutBuilder`'s builder closure, itself
+//!    re-invoked by a `resize_controller` tick's `RebuildHandle::schedule()`
+//!    call — not a normal parent-driven rebuild), the render tree's
+//!    COMMITTED geometry for the `SizedBox` inside that branch never updates
+//!    to reflect the controller's later values — confirmed by instrumenting
+//!    `resize_collapse_view` directly: it is demonstrably re-invoked every
+//!    tick with the correct, changing `resize_controller.value()` (0.2, 0.4,
+//!    …, 1.0), producing a `SizedBox` whose constructor arguments correctly
+//!    shrink to `0`, yet `LaidOut::size` on that render node reads the
+//!    ORIGINAL (uncollapsed) size at every single tick, including the one
+//!    where the internal computation already shows `0`.
+//! 2. In that same state, unmounting `Dismissible` (swapping it out under an
+//!    unchanged parent, the same pattern `animated_switcher_test.rs`'s
+//!    `no_animation_after_dispose` uses successfully for `AnimatedSwitcher`)
+//!    never calls `DismissibleState::dispose` at all — confirmed the same
+//!    way, with a temporary print inside `dispose` itself. Both controllers'
+//!    `Vsync` registrations leak. Extra settle frames immediately before and
+//!    immediately after the unmount do not change this.
+//!
+//! Both point at the same underlying seam: an element last built via a
+//! `LayoutBuilder`-nested branch, reached only through a `RebuildHandle`
+//! -scheduled external rebuild (never a normal build-triggered one), does
+//! not fully participate in the standard layout-commit / disposal
+//! bookkeeping. This is a `flui-view`/`flui-rendering` pipeline gap, not
+//! specific to `Dismissible` — any future widget combining a lazily started,
+//! externally-ticked second controller with a `LayoutBuilder`-branch build
+//! would hit the same thing. Tracked as a framework-level follow-up.
+//!
+//! ### What this file covers instead
+//!
+//! The portable core the oracle's threshold/direction/callback/collapse state
+//! machine reduces to once fling is out of reach: drag-past-threshold
+//! dismissal and below-threshold spring-back (the non-fling halves of
+//! `'Horizontal drag triggers dismiss...'` and siblings), direction gating
+//! (`Up`/`EndToStart`/`None`, LTR and RTL), the `dismissThresholds` `>= 1.0`
+//! lock (`'drag-left has no effect on dismissible with a high dismiss
+//! threshold'`), `onUpdate` progression across the threshold crossing, the
+//! `background`/`secondaryBackground` presence signal, the resize collapse's
+//! start geometry + `onResize`/`onDismissed` ordering, `resizeDuration: None`'s
+//! immediate `onDismissed`, and controller-lifecycle cleanup via `Vsync::len()`
+//! on plain (non-mid-animation) unmount — see the "framework gap" section
+//! above for why the mid-resize-collapse unmount case is not included.
+//!
+//! ### Harness note: the touch-slop-crossing move carries no update delta
+//!
+//! `GestureDetector`'s default `DragStartBehavior::Start` (matching
+//! Flutter's default) means the FIRST past-slop move is consumed entirely by
+//! gesture *recognition* — it fires `on_*_drag_start`, not an update, and the
+//! recognizer's own delta tracking re-anchors at that slop-crossing position.
+//! Every drag helper below therefore issues an explicit small
+//! (`> 18px` touch-slop) slop-crossing move BEFORE the move that carries the
+//! actual intended delta — sizing a drag from `(down_x, down_x ± 20)` instead
+//! of `down_x` directly would silently report zero delta on every update.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use flui_animation::Vsync;
+use flui_rendering::constraints::BoxConstraints;
+use flui_types::Color;
+use flui_types::typography::TextDirection;
+use flui_widgets::{ColoredBox, Directionality, DismissDirection, Dismissible, VsyncScope};
+
+use crate::common::{LaidOutScoped, lay_out_animated, lay_out_with_arena, tight};
+
+/// A 200×80 box: the dismiss-axis extent every percentage in this file not
+/// involving a fling-neutralizing release (see the module doc) is written
+/// against — 200px for horizontal-family cases, 80px for vertical-family.
+fn extent() -> BoxConstraints {
+    tight(200.0, 80.0)
+}
+
+/// Box for horizontal-family cases whose release needs a fling-neutralizing
+/// cross-axis (vertical) excursion: 200px wide (unchanged — every horizontal
+/// percentage below is relative to 200), 500px tall (headroom for that
+/// excursion, up to ~170px in the largest case here).
+fn horizontal_extent() -> BoxConstraints {
+    tight(200.0, 500.0)
+}
+
+/// As [`horizontal_extent`], for vertical-family cases: 80px tall (unchanged),
+/// 500px wide (cross-axis headroom).
+fn vertical_extent() -> BoxConstraints {
+    tight(500.0, 80.0)
+}
+
+fn child() -> ColoredBox {
+    ColoredBox::new(Color::rgb(10, 20, 30))
+}
+
+fn background() -> ColoredBox {
+    ColoredBox::new(Color::rgb(200, 0, 0))
+}
+
+fn secondary_background() -> ColoredBox {
+    ColoredBox::new(Color::rgb(0, 200, 0))
+}
+
+/// Count of mounted `ColoredBox`-backed render nodes (`child`/`background`/
+/// `secondary_background` are all `ColoredBox` -> `RenderDecoratedBox`).
+fn colored_box_count(laid: &crate::common::LaidOut) -> usize {
+    laid.find_all_by_render_type("RenderDecoratedBox").len()
+}
+
+/// Drains the build scope after a gesture event so a `RebuildHandle::schedule()`
+/// call from that event's listener (`Dismissible`'s `on_update`/threshold/
+/// background logic all run deferred from `build()` — see
+/// `DismissibleState::build`'s doc on why) is actually observed before the
+/// next dispatch or assertion. A 1ms nominal advance (not zero) keeps this
+/// indistinguishable from a real display's next-frame tick.
+fn settle_one_frame(scoped: &mut LaidOutScoped) {
+    scoped.pump(Duration::from_millis(1));
+}
+
+/// A horizontal drag whose UPDATE delta is exactly `delta_px` (signed:
+/// negative = leftward) — see the module doc's slop note for why this is not
+/// simply `dispatch_pointer_move(down_x + delta_px, y)`. The release lands
+/// offset on the cross (vertical) axis by `delta_px` too, to neutralize the
+/// release's fling classification — see the module doc's fling note. Callers
+/// that rely on the release settling (not just the drag itself) must lay out
+/// under [`horizontal_extent`], which has cross-axis room for this.
+fn drag_and_release_horizontal(scoped: &mut LaidOutScoped, y: f32, down_x: f32, delta_px: f32) {
+    let slop = 20.0 * delta_px.signum();
+    let after_slop = down_x + slop;
+    let target = after_slop + delta_px;
+    let release_y = y + delta_px;
+    scoped.dispatch_pointer_down(down_x, y);
+    settle_one_frame(scoped);
+    scoped.dispatch_pointer_move(after_slop, y); // consumed as `on_*_drag_start`
+    settle_one_frame(scoped);
+    scoped.dispatch_pointer_move(target, release_y); // the real update: primary delta == delta_px
+    settle_one_frame(scoped);
+    scoped.dispatch_pointer_up(target, release_y);
+    settle_one_frame(scoped);
+}
+
+/// As [`drag_and_release_horizontal`], along the vertical axis (cross axis:
+/// horizontal). Callers that rely on the release settling must lay out under
+/// [`vertical_extent`].
+fn drag_and_release_vertical(scoped: &mut LaidOutScoped, x: f32, down_y: f32, delta_px: f32) {
+    let slop = 20.0 * delta_px.signum();
+    let after_slop = down_y + slop;
+    let target = after_slop + delta_px;
+    let release_x = x + delta_px;
+    scoped.dispatch_pointer_down(x, down_y);
+    settle_one_frame(scoped);
+    scoped.dispatch_pointer_move(x, after_slop);
+    settle_one_frame(scoped);
+    scoped.dispatch_pointer_move(release_x, target);
+    settle_one_frame(scoped);
+    scoped.dispatch_pointer_up(release_x, target);
+    settle_one_frame(scoped);
+}
+
+/// Lays `widget` out under a fresh, gesture-scoped, `Vsync`-adopting
+/// binding — the combination every test that needs `move_controller`/
+/// `resize_controller` to actually SETTLE over time requires (drag alone
+/// only ever sets a controller's *value* directly; `.forward()`/`.reverse()`/
+/// the resize collapse all need real ticks from an adopted `Vsync`, the same
+/// `fling_scoped` pattern `scrollable_test.rs` uses).
+fn lay_out_animated_with_arena(
+    widget: impl flui_view::View,
+    vsync: Vsync,
+    constraints: BoxConstraints,
+) -> LaidOutScoped {
+    let wrapped = VsyncScope::new(vsync.clone(), widget);
+    let mut scoped = lay_out_with_arena(wrapped, constraints);
+    scoped.adopt_vsync(vsync);
+    scoped
+}
+
+/// Settles `scoped` for `millis` of virtual animation time, in 20ms steps.
+fn settle_for(scoped: &mut LaidOutScoped, millis: u64) {
+    let mut remaining = millis;
+    while remaining > 0 {
+        let step = remaining.min(20);
+        scoped.pump_for(Duration::from_millis(step));
+        remaining -= step;
+    }
+}
+
+/// Pumps `scoped` in small steps until a render node named `render_type_name`
+/// appears (or `max_millis` of virtual time is exhausted). Used to observe
+/// "the move settled and the resize collapse just started" without pinning
+/// an exact virtual-time budget: the move phase runs through `.fling()`
+/// whenever the release's uncontrolled real-clock velocity clears the
+/// threshold (see the module doc's fling note), so how long it actually
+/// takes to settle is itself unpredictable — polling for the transition is
+/// the robust way to catch it, rather than guessing a fixed delay.
+fn settle_until_present(
+    scoped: &mut LaidOutScoped,
+    render_type_name: &str,
+    max_millis: u64,
+) -> bool {
+    settle_until(scoped, max_millis, |s| {
+        !s.laid()
+            .find_all_by_render_type(render_type_name)
+            .is_empty()
+    })
+}
+
+/// Pumps `scoped` in small steps until `condition` returns `true` (or
+/// `max_millis` of virtual time is exhausted), returning whether it did.
+/// Polling, not a fixed delay, is the robust way to wait out a
+/// `.fling()`-driven settle: the release's real-clock velocity (see the
+/// module doc's fling note) is uncontrolled, so how long the resulting run
+/// actually takes to complete is itself unpredictable. `condition` receives
+/// `scoped` by shared reference (rather than capturing it) so this can also
+/// pump between checks without a borrow conflict.
+fn settle_until(
+    scoped: &mut LaidOutScoped,
+    max_millis: u64,
+    condition: impl Fn(&LaidOutScoped) -> bool,
+) -> bool {
+    let mut remaining = max_millis;
+    while remaining > 0 {
+        if condition(scoped) {
+            return true;
+        }
+        let step = remaining.min(20);
+        scoped.pump_for(Duration::from_millis(step));
+        remaining -= step;
+    }
+    condition(scoped)
+}
+
+// ============================================================================
+// Drag-past-threshold dismisses / below-threshold springs back.
+// ============================================================================
+
+/// Flutter parity: `'drag-left with DismissDirection.endToStart triggers
+/// dismiss (LTR)'` (`dismissible_test.dart:352`), non-fling half. Dragging
+/// 120px left of a 200px-wide `Dismissible` (60% > the 40% default threshold)
+/// must eventually dismiss: `move_controller` completes, the default 300ms
+/// resize collapse runs, and `on_dismissed` fires exactly once with
+/// `EndToStart`.
+#[test]
+fn drag_past_threshold_dismisses_and_resize_collapse_fires_on_dismissed() {
+    let dismissed = Arc::new(AtomicUsize::new(0));
+    let dismissed_direction: Arc<Mutex<Option<DismissDirection>>> = Arc::new(Mutex::new(None));
+    let on_dismissed_count = Arc::clone(&dismissed);
+    let on_dismissed_direction = Arc::clone(&dismissed_direction);
+    let on_resize_ticks = Arc::new(AtomicUsize::new(0));
+    let on_resize_ticks_cb = Arc::clone(&on_resize_ticks);
+
+    let widget = Dismissible::new(child())
+        .direction(DismissDirection::EndToStart)
+        .on_dismissed(move |direction| {
+            on_dismissed_count.fetch_add(1, Ordering::SeqCst);
+            *on_dismissed_direction.lock().expect("test-only mutex") = Some(direction);
+        })
+        .on_resize(move || {
+            on_resize_ticks_cb.fetch_add(1, Ordering::SeqCst);
+        });
+
+    let vsync = Vsync::new();
+    let mut scoped = lay_out_animated_with_arena(widget, vsync, horizontal_extent());
+    drag_and_release_horizontal(&mut scoped, 250.0, 180.0, -120.0); // 60% of 200px
+
+    assert_eq!(
+        dismissed.load(Ordering::SeqCst),
+        0,
+        "on_dismissed must not fire before the move animation even starts settling"
+    );
+
+    // Settle the 200ms move animation, then the 300ms resize collapse. The
+    // move's own settle budget is generous (not just 200ms): with fling
+    // neutralized, the release still runs through `.forward()`, whose
+    // duration is `movement_duration` regardless of how it got triggered.
+    settle_for(&mut scoped, 400);
+    settle_for(&mut scoped, 400);
+
+    assert_eq!(
+        dismissed.load(Ordering::SeqCst),
+        1,
+        "a 120px (60%) drag past the 40% default threshold must dismiss exactly once"
+    );
+    assert_eq!(
+        *dismissed_direction.lock().expect("test-only mutex"),
+        Some(DismissDirection::EndToStart)
+    );
+    assert!(
+        on_resize_ticks.load(Ordering::SeqCst) > 0,
+        "on_resize must fire at least once while the resize collapse is in flight"
+    );
+}
+
+/// Flutter parity: `'drag-left with DismissDirection.endToStart triggers
+/// dismiss (LTR)'`'s below-threshold sibling — no case in the oracle drags
+/// short and asserts spring-back directly, but every direction-gating case
+/// implicitly relies on it (an admitted-but-short drag must not dismiss).
+/// Dragging only 20px (10%) of a 200px-wide `Dismissible` must spring back:
+/// `move_controller` reverses toward 0 (observed via `on_update`'s trailing
+/// progress) and `on_dismissed` never fires.
+#[test]
+fn drag_below_threshold_springs_back_without_dismissing() {
+    let dismissed = Arc::new(AtomicUsize::new(0));
+    let on_dismissed = Arc::clone(&dismissed);
+    let last_progress = Arc::new(Mutex::new(-1.0_f32));
+    let last_progress_cb = Arc::clone(&last_progress);
+
+    let widget = Dismissible::new(child())
+        .direction(DismissDirection::EndToStart)
+        .on_dismissed(move |_direction| {
+            on_dismissed.fetch_add(1, Ordering::SeqCst);
+        })
+        .on_update(move |details| {
+            *last_progress_cb.lock().expect("test-only mutex") = details.progress;
+        });
+
+    let vsync = Vsync::new();
+    let mut scoped = lay_out_animated_with_arena(widget, vsync, horizontal_extent());
+    drag_and_release_horizontal(&mut scoped, 250.0, 180.0, -20.0); // 10% of 200px
+
+    let progress_at_release = *last_progress.lock().expect("test-only mutex");
+    assert!(
+        (progress_at_release - 0.1).abs() < 0.02,
+        "a 20px drag on a 200px-wide box is 10% progress at release; got {progress_at_release}"
+    );
+
+    settle_for(&mut scoped, 400); // settle well past the 200ms reverse run
+
+    assert_eq!(
+        dismissed.load(Ordering::SeqCst),
+        0,
+        "a 20px (10%) drag is well under the 40% default threshold — must spring back, not dismiss"
+    );
+    let progress_after_settling = *last_progress.lock().expect("test-only mutex");
+    assert!(
+        progress_after_settling < 0.02,
+        "springing back must reverse move_controller's value toward 0; got {progress_after_settling}"
+    );
+}
+
+// ============================================================================
+// Direction gating.
+// ============================================================================
+
+/// Flutter parity: `'drag-up with DismissDirection.up triggers dismiss'`
+/// (`dismissible_test.dart:490`), non-fling half, PLUS a gating case no
+/// single oracle line isolates directly: a downward extent must be REJECTED
+/// outright by `Up`'s accumulator (`accumulate_drag_extent`), not merely
+/// under threshold.
+#[test]
+fn direction_up_rejects_downward_extent_but_admits_upward() {
+    let last_progress = Arc::new(Mutex::new(-1.0_f32));
+    let last_progress_cb = Arc::clone(&last_progress);
+
+    let widget = Dismissible::new(child())
+        .direction(DismissDirection::Up)
+        .on_update(move |details| {
+            *last_progress_cb.lock().expect("test-only mutex") = details.progress;
+        });
+
+    let vsync = Vsync::new();
+    let mut scoped = lay_out_animated_with_arena(widget, vsync, vertical_extent());
+
+    // Drag DOWN 30px first: `Up`'s accumulator must reject every downward
+    // delta outright, so `on_update` must never deliver (progress stays at
+    // its never-delivered sentinel, -1.0). A rejected drag never moves
+    // `drag_extent` off 0, so `describe_fling_gesture` short-circuits to
+    // `None` on release regardless of velocity — no cross-axis neutralization
+    // needed for this half.
+    drag_and_release_vertical(&mut scoped, 250.0, 15.0, 30.0);
+    assert_eq!(
+        *last_progress.lock().expect("test-only mutex"),
+        -1.0,
+        "Up must reject every downward delta outright — on_update must never fire"
+    );
+
+    // Now drag UP 24px (30% of the 80px extent) — admitted.
+    drag_and_release_vertical(&mut scoped, 250.0, 60.0, -24.0);
+    let progress = *last_progress.lock().expect("test-only mutex");
+    assert!(
+        (progress - 0.3).abs() < 0.02,
+        "a 24px upward drag on an 80px-tall box is 30% progress; got {progress}"
+    );
+}
+
+/// Flutter parity: `'DismissDirection.none does not trigger dismiss'`
+/// (`dismissible_test.dart:1038`). With `direction: None`, `Dismissible`
+/// mounts no drag recognizer at all (see `build`'s early return) — dispatching
+/// a full-throw drag sequence must have no observable effect whatsoever.
+#[test]
+fn direction_none_ignores_drag_entirely() {
+    let updates = Arc::new(AtomicUsize::new(0));
+    let dismissed = Arc::new(AtomicUsize::new(0));
+    let on_update = Arc::clone(&updates);
+    let on_dismissed = Arc::clone(&dismissed);
+
+    let widget = Dismissible::new(child())
+        .direction(DismissDirection::None)
+        .on_update(move |_| {
+            on_update.fetch_add(1, Ordering::SeqCst);
+        })
+        .on_dismissed(move |_| {
+            on_dismissed.fetch_add(1, Ordering::SeqCst);
+        });
+
+    let vsync = Vsync::new();
+    let mut scoped = lay_out_animated_with_arena(widget, vsync, extent());
+    drag_and_release_horizontal(&mut scoped, 40.0, 180.0, -160.0); // a full throw — dismissive in any other direction
+    settle_for(&mut scoped, 400);
+
+    assert_eq!(
+        updates.load(Ordering::SeqCst),
+        0,
+        "DismissDirection::None mounts no recognizer at all"
+    );
+    assert_eq!(dismissed.load(Ordering::SeqCst), 0);
+}
+
+/// Flutter parity: `'drag-right with DismissDirection.endToStart triggers
+/// dismiss (RTL)'` (`dismissible_test.dart:384`) crossed with `'drag-left...
+/// (LTR)'` (`:352`) — proves `Directionality` actually flips which physical
+/// drag direction resolves to `EndToStart` (see `extent_to_direction`'s
+/// `text_direction` branch), not just that RTL is accepted syntactically. In
+/// RTL, `EndToStart` is a RIGHTWARD drag; a LEFTWARD drag of the same
+/// magnitude must be rejected outright by the accumulator.
+#[test]
+fn direction_end_to_start_rtl_flips_which_physical_drag_dismisses() {
+    let last_progress = Arc::new(Mutex::new(-1.0_f32));
+    let last_progress_cb = Arc::clone(&last_progress);
+
+    let widget = Directionality::new(
+        TextDirection::Rtl,
+        Dismissible::new(child())
+            .direction(DismissDirection::EndToStart)
+            .on_update(move |details| {
+                *last_progress_cb.lock().expect("test-only mutex") = details.progress;
+            }),
+    );
+
+    let vsync = Vsync::new();
+    let mut scoped = lay_out_animated_with_arena(widget, vsync, horizontal_extent());
+
+    // LEFTWARD 100px: in RTL, EndToStart is rightward — must be rejected
+    // outright (extent stays 0, so release fling-detection is moot).
+    drag_and_release_horizontal(&mut scoped, 40.0, 180.0, -100.0);
+    assert_eq!(
+        *last_progress.lock().expect("test-only mutex"),
+        -1.0,
+        "RTL EndToStart must reject a leftward drag outright — on_update must never fire"
+    );
+
+    // RIGHTWARD 100px (50%) — admitted in RTL.
+    drag_and_release_horizontal(&mut scoped, 40.0, 20.0, 100.0);
+    let progress = *last_progress.lock().expect("test-only mutex");
+    assert!(
+        (progress - 0.5).abs() < 0.02,
+        "RTL EndToStart must admit a rightward drag; a 100px drag on a 200px \
+         box is 50% progress, got {progress}"
+    );
+}
+
+// ============================================================================
+// `dismissThresholds` >= 1.0 lock.
+// ============================================================================
+
+/// Flutter parity: `'drag-left has no effect on dismissible with a high
+/// dismiss threshold'` (`dismissible_test.dart:552`), non-fling half. A
+/// threshold of `1.0` for `EndToStart` must prevent dismissal even for a
+/// large (85%) drag well past any ordinary threshold — `move_controller`
+/// still lands on `.reverse()`, never `.forward()`, in `handle_drag_end`'s
+/// `value() > threshold` check.
+///
+/// (Reaching literally 100% — the `move_controller.is_completed()` direct
+/// bypass a couple of lines earlier in `handle_drag_end` — is not reachable
+/// through this harness's touch-slop-then-delta drag helper within a single
+/// laid-out box: the slop-crossing sub-move needs 20px of room *in addition
+/// to* the reported delta, so a delta equal to the full dismiss-axis extent
+/// always overflows the box by that same 20px. 85% is the practical ceiling
+/// and is more than sufficient to distinguish "locked out by threshold" from
+/// "never dragged far enough".)
+#[test]
+fn dismiss_threshold_locked_at_one_never_dismisses_even_at_a_large_drag() {
+    let dismissed = Arc::new(AtomicUsize::new(0));
+    let on_dismissed = Arc::clone(&dismissed);
+    let last_progress = Arc::new(Mutex::new(-1.0_f32));
+    let last_progress_cb = Arc::clone(&last_progress);
+
+    let widget = Dismissible::new(child())
+        .direction(DismissDirection::EndToStart)
+        .dismiss_threshold(DismissDirection::EndToStart, 1.0)
+        .on_dismissed(move |_| {
+            on_dismissed.fetch_add(1, Ordering::SeqCst);
+        })
+        .on_update(move |details| {
+            *last_progress_cb.lock().expect("test-only mutex") = details.progress;
+        });
+
+    let vsync = Vsync::new();
+    let mut scoped = lay_out_animated_with_arena(widget, vsync, horizontal_extent());
+    drag_and_release_horizontal(&mut scoped, 250.0, 195.0, -170.0); // 85% of 200px
+    let progress_at_release = *last_progress.lock().expect("test-only mutex");
+    assert!(
+        progress_at_release > 0.8,
+        "the drag must actually have reached ~85% before release — got {progress_at_release}"
+    );
+
+    settle_for(&mut scoped, 400);
+
+    assert_eq!(
+        dismissed.load(Ordering::SeqCst),
+        0,
+        "a threshold of 1.0 must lock EndToStart out of ever dismissing, even at an 85% drag extent"
+    );
+}
+
+// ============================================================================
+// `onUpdate` progression + threshold crossing.
+// ============================================================================
+
+/// Flutter parity: `'onUpdate'` (`dismissible_test.dart:1074`). Dragging in
+/// two steps — 20% then 50% — must deliver `on_update` with monotonically
+/// increasing `progress`, and the SECOND delivery must show the
+/// `reached`/`previous_reached` crossing: `previous_reached == false` (20% is
+/// under the 40% threshold) while `reached == true` (50% clears it).
+#[test]
+fn on_update_progression_reports_the_threshold_crossing() {
+    let deliveries: Arc<Mutex<Vec<(f32, bool, bool)>>> = Arc::new(Mutex::new(Vec::new()));
+    let deliveries_cb = Arc::clone(&deliveries);
+
+    let widget = Dismissible::new(child())
+        .direction(DismissDirection::EndToStart)
+        .on_update(move |details| {
+            deliveries_cb.lock().expect("test-only mutex").push((
+                details.progress,
+                details.reached,
+                details.previous_reached,
+            ));
+        });
+
+    let vsync = Vsync::new();
+    let mut scoped = lay_out_animated_with_arena(widget, vsync, extent());
+    scoped.dispatch_pointer_down(195.0, 40.0); // within the 200px-wide box
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_move(175.0, 40.0); // 20px slop-crossing: consumed as `start`
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_move(135.0, 40.0); // delta -40: 20% — under threshold
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_move(75.0, 40.0); // delta -60 more, 50% total — past threshold
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_move(75.0, 40.0);
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_up(75.0, 40.0);
+    settle_one_frame(&mut scoped);
+
+    let recorded = deliveries.lock().expect("test-only mutex").clone();
+    assert!(
+        recorded.len() >= 2,
+        "expected at least 2 on_update deliveries (one per admitted move), got {}: {recorded:?}",
+        recorded.len()
+    );
+
+    let progresses: Vec<f32> = recorded.iter().map(|(p, ..)| *p).collect();
+    for pair in progresses.windows(2) {
+        assert!(
+            pair[1] > pair[0] - 1e-6,
+            "progress must be monotonically non-decreasing across a one-directional drag: {progresses:?}"
+        );
+    }
+
+    let (first_progress, first_reached, _) = recorded[0];
+    assert!(
+        (first_progress - 0.2).abs() < 0.02 && !first_reached,
+        "first delivery: 20% progress, under the 40% threshold; got {recorded:?}"
+    );
+
+    let last = *recorded
+        .last()
+        .expect("at least 2 deliveries asserted above");
+    assert!(
+        last.1,
+        "the final delivery (50% progress) must report reached == true; got {recorded:?}"
+    );
+    let crossed = recorded
+        .iter()
+        .any(|(_, reached, previous_reached)| *reached && !*previous_reached);
+    assert!(
+        crossed,
+        "at least one delivery must show the reached/previous_reached crossing \
+         (reached == true, previous_reached == false); got {recorded:?}"
+    );
+}
+
+// ============================================================================
+// `background` / `secondaryBackground` presence.
+// ============================================================================
+
+/// Flutter parity: the `!_moveAnimation.isDismissed` guard around the
+/// background's `Positioned.fill(ClipRect(...))` (`dismissible.dart:656`) —
+/// this port's presence-based approximation (module docs divergence #2).
+/// `background` must be absent at rest and present once dragged.
+#[test]
+fn background_is_mounted_only_while_dragging() {
+    let widget = Dismissible::new(child())
+        .direction(DismissDirection::EndToStart)
+        .background(background());
+
+    let vsync = Vsync::new();
+    let mut scoped = lay_out_animated_with_arena(widget, vsync, extent());
+    assert_eq!(
+        colored_box_count(scoped.laid()),
+        1,
+        "at rest (never dragged), only `child` is mounted"
+    );
+
+    scoped.dispatch_pointer_down(195.0, 40.0);
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_move(175.0, 40.0); // 20px slop-crossing
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_move(115.0, 40.0); // delta -60: nonzero offset
+    settle_one_frame(&mut scoped);
+
+    assert_eq!(
+        colored_box_count(scoped.laid()),
+        2,
+        "mid-drag (nonzero move_controller.value()), `background` is stacked behind `child`"
+    );
+}
+
+/// Flutter parity: the `secondaryBackground` selection in `build`
+/// (`dismissible.dart:613`-`619`) — dragging toward `EndToStart` (or `Up`)
+/// swaps in `secondary_background` instead of `background`. Verified via
+/// `on_update`'s reported `direction` (the same resolution
+/// `resolve_background` uses) rather than a paint-level color read.
+#[test]
+fn secondary_background_direction_matches_the_drag() {
+    let last_direction = Arc::new(Mutex::new(DismissDirection::None));
+    let last_direction_cb = Arc::clone(&last_direction);
+
+    let widget = Dismissible::new(child())
+        .direction(DismissDirection::Horizontal)
+        .background(background())
+        .secondary_background(secondary_background())
+        .on_update(move |details| {
+            *last_direction_cb.lock().expect("test-only mutex") = details.direction;
+        });
+
+    let vsync = Vsync::new();
+    let mut scoped = lay_out_animated_with_arena(widget, vsync, extent());
+
+    scoped.dispatch_pointer_down(60.0, 40.0);
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_move(80.0, 40.0); // 20px slop-crossing
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_move(140.0, 40.0); // delta +60: rightward — StartToEnd
+    settle_one_frame(&mut scoped);
+    assert_eq!(
+        *last_direction.lock().expect("test-only mutex"),
+        DismissDirection::StartToEnd,
+        "a rightward drag in LTR resolves to StartToEnd — `background`, not `secondary_background`"
+    );
+
+    scoped.dispatch_pointer_down(140.0, 40.0);
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_move(120.0, 40.0); // 20px slop-crossing
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_move(60.0, 40.0); // delta -60: leftward — EndToStart
+    settle_one_frame(&mut scoped);
+    assert_eq!(
+        *last_direction.lock().expect("test-only mutex"),
+        DismissDirection::EndToStart,
+        "a leftward drag in LTR resolves to EndToStart — this is when \
+         `secondary_background` (not `background`) is selected"
+    );
+}
+
+// ============================================================================
+// Resize collapse geometry.
+// ============================================================================
+
+/// Flutter parity: `'Dismissible starts from the full size when collapsing'`
+/// (`dismissible_test.dart:643`) + the `SizeTransition` branch of `build`
+/// (`dismissible.dart:637`-`645`). A horizontal dismiss collapses the
+/// PERPENDICULAR (here: 500px-tall) axis: full height immediately after the
+/// move completes (the curve's 40% pause).
+///
+/// Only the collapse's START is asserted against committed render-tree
+/// geometry here — see the module doc's "framework gap" note on why the
+/// collapse's END is asserted through `on_resize`/`on_dismissed` instead of a
+/// second geometry read.
+#[test]
+fn resize_collapse_starts_at_full_size_then_runs_to_completion() {
+    let on_resize_ticks = Arc::new(AtomicUsize::new(0));
+    let on_resize_ticks_cb = Arc::clone(&on_resize_ticks);
+    let dismissed = Arc::new(AtomicUsize::new(0));
+    let on_dismissed = Arc::clone(&dismissed);
+
+    let widget = Dismissible::new(child())
+        .direction(DismissDirection::EndToStart)
+        .on_resize(move || {
+            on_resize_ticks_cb.fetch_add(1, Ordering::SeqCst);
+        })
+        .on_dismissed(move |_| {
+            on_dismissed.fetch_add(1, Ordering::SeqCst);
+        });
+    let vsync = Vsync::new();
+    let mut scoped = lay_out_animated_with_arena(widget, vsync, horizontal_extent());
+    drag_and_release_horizontal(&mut scoped, 250.0, 180.0, -120.0); // 60%, past threshold
+
+    // Settle the move animation onto the resize collapse's first frame —
+    // polled, not a fixed delay (see `settle_until_present`'s doc).
+    assert!(
+        settle_until_present(&mut scoped, "RenderConstrainedBox", 5_000),
+        "the move must settle and start the resize collapse within 5 virtual seconds"
+    );
+    let collapsing_box = scoped.laid().find_by_render_type("RenderConstrainedBox");
+    let starting_size = scoped.laid().size(collapsing_box);
+    assert_eq!(
+        (starting_size.width.get(), starting_size.height.get()),
+        (200.0, 500.0),
+        "the collapse starts at the full prior size (the curve's 40% pause \
+         before any visible shrink)"
+    );
+
+    // The collapse's END: verified through the callbacks the collapse's own
+    // progress drives (`on_resize` per tick, `on_dismissed` once complete),
+    // not a second geometry read (see the module doc's framework-gap note).
+    settle_for(&mut scoped, 400);
+    assert!(
+        on_resize_ticks.load(Ordering::SeqCst) > 0,
+        "on_resize must fire at least once as the collapse progresses"
+    );
+    assert_eq!(
+        dismissed.load(Ordering::SeqCst),
+        1,
+        "on_dismissed must fire exactly once once the collapse completes"
+    );
+}
+
+/// Flutter parity: `'Dismissible with null resizeDuration calls onDismissed
+/// immediately'` (`dismissible_test.dart:892`). With `resize_duration(None)`,
+/// `on_dismissed` fires the instant the move animation completes — no
+/// `RenderConstrainedBox` collapse box ever mounts.
+#[test]
+fn resize_duration_none_fires_on_dismissed_immediately_without_collapsing() {
+    let dismissed = Arc::new(AtomicUsize::new(0));
+    let on_dismissed = Arc::clone(&dismissed);
+
+    let widget = Dismissible::new(child())
+        .direction(DismissDirection::EndToStart)
+        .resize_duration(None)
+        .on_dismissed(move |_| {
+            on_dismissed.fetch_add(1, Ordering::SeqCst);
+        });
+
+    let vsync = Vsync::new();
+    let mut scoped = lay_out_animated_with_arena(widget, vsync, horizontal_extent());
+    drag_and_release_horizontal(&mut scoped, 250.0, 180.0, -120.0); // 60%, past threshold
+    settle_for(&mut scoped, 400);
+
+    assert_eq!(
+        dismissed.load(Ordering::SeqCst),
+        1,
+        "resize_duration(None) must fire on_dismissed as soon as the move settles, no collapse"
+    );
+}
+
+// ============================================================================
+// Controller lifecycle — `Vsync::len()`.
+// ============================================================================
+
+/// The `move_controller` created in `create_state` registers with the
+/// ambient `Vsync` in `init_state` and unregisters (+ disposes) in `dispose`
+/// — the same contract `animated_switcher_test.rs`'s `no_animation_after_dispose`
+/// pins for `AnimatedSwitcher`. No oracle line-cites this (Dart has no
+/// registry to inspect); it is the FLUI-native evidence that `dispose` runs.
+#[test]
+fn move_controller_registers_with_vsync_and_unregisters_on_unmount() {
+    let vsync = Vsync::new();
+    let root = VsyncScope::new(vsync.clone(), Dismissible::new(child()));
+    let mut laid = lay_out_animated(root, extent(), vsync.clone());
+    assert_eq!(
+        vsync.len(),
+        1,
+        "the mounted Dismissible registers its move_controller"
+    );
+
+    laid.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        ColoredBox::new(Color::rgb(1, 2, 3)),
+    ));
+    assert_eq!(
+        vsync.len(),
+        0,
+        "unmounting Dismissible must dispose move_controller and unregister it from Vsync"
+    );
+    laid.pump_for(Duration::from_millis(16)); // must not panic: nothing left registered to tick
+}
+
+// `both_controllers_are_disposed_when_unmounted_mid_resize_collapse` — the
+// mid-flight sibling of the case above, unmounting WHILE the resize collapse
+// is in flight — is NOT included here. See the module doc's "framework gap"
+// note: `DismissibleState::dispose` (confirmed, via temporary direct
+// instrumentation while building this file, never to run at all in that
+// scenario) does not get a chance to unregister either controller once
+// `Dismissible`'s last build traversed the resize-collapse `LayoutBuilder`
+// branch. Writing this case with an assertion that matches the observed
+// (buggy) behavior would misrepresent it as intended; asserting the correct
+// behavior fails reproducibly. Tracked as a framework-level follow-up, not a
+// `Dismissible`-level one — the plain (never-dragged) unmount case above
+// proves `dispose` itself is correctly wired.

--- a/crates/flui-widgets/tests/parity/dismissible_test.rs
+++ b/crates/flui-widgets/tests/parity/dismissible_test.rs
@@ -7,13 +7,42 @@
 //!
 //! - **`confirmDismiss`** (`'confirmDismiss returns values: true, false,
 //!   null'`, `'Pending confirmDismiss does not cause errors'`, `'Dismissible
-//!   cannot be dragged with pending confirmDismiss'`) — `Dismissible` does not
-//!   implement `confirmDismiss` at all (see
+//!   cannot be dragged with pending confirmDismiss'`, `'Drag to end and
+//!   release - items does not get stuck if confirmDismiss returns false'`) —
+//!   `Dismissible` does not implement `confirmDismiss` at all (see
 //!   `crates/flui-widgets/src/interaction/dismissible.rs`'s module-doc
 //!   divergence #1): FLUI has no established widget-level "await a caller
 //!   future, then resume a state transition" seam yet, and inventing one
 //!   one-off for this port would misrepresent the oracle's real (vetoable,
 //!   async) contract with a synchronous stand-in. Tracked as a follow-up.
+//! - **`'drag-left with DismissDirection.startToEnd triggers dismiss
+//!   (RTL)'`** and **`'drag-down with DismissDirection.down triggers
+//!   dismiss'`** — the RTL/vertical siblings of the two cases this file DOES
+//!   port to completion (`drag_past_threshold_dismisses_for_start_to_end_too`
+//!   is the LTR `StartToEnd` case; `drag_past_threshold_dismisses_for_up_too`
+//!   is the `Up` case). Both omitted siblings are a symmetric flip of an
+//!   already-proven fact: `direction_end_to_start_rtl_flips_which_physical_drag_dismisses`
+//!   already proves `Directionality` flips the `EndToStart`/`StartToEnd`
+//!   mapping, and `accumulate_drag_extent_down_direction_only_admits_positive_extent`
+//!   (a `dismissible.rs` unit test) already proves `Down`'s gating is the
+//!   exact mirror of `Up`'s — a 4th/6th combinatorial case here would not add
+//!   independent coverage over combining those two already-proven facts.
+//! - **`'Verify that drag-move events do not assert'`** — a
+//!   crash-prevention regression against Flutter's own mutable
+//!   `_DismissibleState` invariants. This port's equivalent invariant
+//!   (`handle_drag_update`/`handle_drag_end`'s `drag_underway` gate) is
+//!   exercised by every drag test in this file already, and Rust's ownership
+//!   model rules out the memory-unsafety class of failure the oracle's
+//!   underlying concern (asserting on out-of-order pointer events) guards
+//!   against — there is no separate translated case to write.
+//! - **`'DismissDirection.none does not prevent scrolling'`** — follows
+//!   directly from `direction_none_ignores_drag_entirely` (`direction: None`
+//!   mounts no recognizer at all — see `build`'s early return — so there is
+//!   nothing to compete with an ancestor `Scrollable`'s own recognizer in the
+//!   gesture arena). An end-to-end proof would need a `Scrollable` ancestor
+//!   in the test tree, redundant with both the already-proven "no recognizer"
+//!   fact and `Scrollable`'s own, separately-tested arena-competition
+//!   behavior (`scrollable_test.rs`).
 //! - **Fling-velocity cases** (`'Horizontal fling triggers dismiss...'` and
 //!   every other `'fling-*'` case, `'... fling item before/after
 //!   movementDuration'`, `'Horizontal/Vertical fling less than threshold'`) —
@@ -54,9 +83,11 @@
 //!   `vertical_extent` below) — the dismiss axis itself keeps the round
 //!   200px / 80px this file's percentages are written against.
 //! - **Semantics** (`'Dismissible.behavior should behave correctly during
-//!   hit testing'`'s semantics half, the semantics-tree assertions embedded in
-//!   several other cases) — paint/semantics are Phase 3 (deferred) per this
-//!   crate's `parity/main.rs` module doc.
+//!   hit testing'`'s semantics HALF only — the hit-testing half IS ported, as
+//!   `a_tappable_child_still_taps_and_a_real_drag_still_wins_the_arena` —
+//!   plus the semantics-tree assertions embedded in several other cases) —
+//!   paint/semantics are Phase 3 (deferred) per this crate's `parity/main.rs`
+//!   module doc.
 //! - **`AutomaticKeepAlive` interaction** (`'dismissing bottom then top
 //!   (smoketest)'`'s `ListView`-recycling half, `'setState that does not
 //!   remove the Dismissible from tree should throw Error'`) — no keep-alive
@@ -107,16 +138,22 @@
 //!
 //! The portable core the oracle's threshold/direction/callback/collapse state
 //! machine reduces to once fling is out of reach: drag-past-threshold
-//! dismissal and below-threshold spring-back (the non-fling halves of
-//! `'Horizontal drag triggers dismiss...'` and siblings), direction gating
-//! (`Up`/`EndToStart`/`None`, LTR and RTL), the `dismissThresholds` `>= 1.0`
-//! lock (`'drag-left has no effect on dismissible with a high dismiss
-//! threshold'`), `onUpdate` progression across the threshold crossing, the
-//! `background`/`secondaryBackground` presence signal, the resize collapse's
-//! start geometry + `onResize`/`onDismissed` ordering, `resizeDuration: None`'s
-//! immediate `onDismissed`, and controller-lifecycle cleanup via `Vsync::len()`
-//! on plain (non-mid-animation) unmount — see the "framework gap" section
-//! above for why the mid-resize-collapse unmount case is not included.
+//! dismissal and below-threshold spring-back for `EndToStart`, `StartToEnd`,
+//! and `Up` (the non-fling halves of `'Horizontal/Vertical drag triggers
+//! dismiss...'` and siblings), direction gating (`Up`/`EndToStart`/`None`,
+//! LTR and RTL), the `dismissThresholds` `>= 1.0` lock (`'drag-left has no
+//! effect on dismissible with a high dismiss threshold'`), `onUpdate`
+//! progression across the threshold crossing, the `background`/
+//! `secondaryBackground` presence signal, the resize collapse's start
+//! geometry + `onResize`/`onDismissed` ordering, `resizeDuration: None`'s
+//! immediate `onDismissed`, the hit-testing half of `'Dismissible.behavior
+//! should behave correctly during hit testing'` (a tappable child nested
+//! inside `Dismissible`'s own drag-family `GestureDetector` — the named
+//! defect class of a wrapping recognizer swallowing or being swallowed by a
+//! child's), and controller-lifecycle cleanup via `Vsync::len()` on plain
+//! (non-mid-animation) unmount AND on a mid-DRAG unmount — see the "framework
+//! gap" section above for why the mid-RESIZE-COLLAPSE unmount case is not
+//! included.
 //!
 //! ### Harness note: the touch-slop-crossing move carries no update delta
 //!
@@ -138,7 +175,9 @@ use flui_animation::Vsync;
 use flui_rendering::constraints::BoxConstraints;
 use flui_types::Color;
 use flui_types::typography::TextDirection;
-use flui_widgets::{ColoredBox, Directionality, DismissDirection, Dismissible, VsyncScope};
+use flui_widgets::{
+    ColoredBox, Directionality, DismissDirection, Dismissible, GestureDetector, VsyncScope,
+};
 
 use crate::common::{LaidOutScoped, lay_out_animated, lay_out_with_arena, tight};
 
@@ -364,6 +403,85 @@ fn drag_past_threshold_dismisses_and_resize_collapse_fires_on_dismissed() {
     );
 }
 
+/// Flutter parity: `'drag-right with DismissDirection.startToEnd triggers
+/// dismiss (LTR)'` (`dismissible_test.dart:369`), non-fling half — the
+/// `StartToEnd` sibling of the `EndToStart` case above. Every other
+/// dismissal test in this file drags `EndToStart`; this proves the SAME
+/// completion pipeline (`.forward()`, resize collapse, `on_dismissed`) also
+/// runs for the opposite direction member, not just that
+/// `accumulate_drag_extent`'s per-direction gating is correct in isolation
+/// (already unit-tested at the function level in `dismissible.rs`).
+#[test]
+fn drag_past_threshold_dismisses_for_start_to_end_too() {
+    let dismissed = Arc::new(AtomicUsize::new(0));
+    let dismissed_direction: Arc<Mutex<Option<DismissDirection>>> = Arc::new(Mutex::new(None));
+    let on_dismissed_count = Arc::clone(&dismissed);
+    let on_dismissed_direction = Arc::clone(&dismissed_direction);
+
+    let widget = Dismissible::new(child())
+        .direction(DismissDirection::StartToEnd)
+        .on_dismissed(move |direction| {
+            on_dismissed_count.fetch_add(1, Ordering::SeqCst);
+            *on_dismissed_direction.lock().expect("test-only mutex") = Some(direction);
+        });
+
+    let vsync = Vsync::new();
+    let mut scoped = lay_out_animated_with_arena(widget, vsync, horizontal_extent());
+    drag_and_release_horizontal(&mut scoped, 250.0, 40.0, 120.0); // rightward, 60% of 200px
+
+    settle_for(&mut scoped, 400);
+    settle_for(&mut scoped, 400);
+
+    assert_eq!(
+        dismissed.load(Ordering::SeqCst),
+        1,
+        "a 120px (60%) rightward drag past the 40% default threshold must dismiss exactly once"
+    );
+    assert_eq!(
+        *dismissed_direction.lock().expect("test-only mutex"),
+        Some(DismissDirection::StartToEnd)
+    );
+}
+
+/// Flutter parity: `'drag-up with DismissDirection.up triggers dismiss'`
+/// (`dismissible_test.dart:490`), non-fling half, completion case — the
+/// vertical-family sibling of the horizontal dismissal tests above.
+/// `direction_up_rejects_downward_extent_but_admits_upward` already proves
+/// `Up`'s gating and progress reporting; this proves the vertical-family
+/// path (`on_pan_*` — see module docs divergence #3) also reaches actual
+/// dismissal, not just admitted progress.
+#[test]
+fn drag_past_threshold_dismisses_for_up_too() {
+    let dismissed = Arc::new(AtomicUsize::new(0));
+    let dismissed_direction: Arc<Mutex<Option<DismissDirection>>> = Arc::new(Mutex::new(None));
+    let on_dismissed_count = Arc::clone(&dismissed);
+    let on_dismissed_direction = Arc::clone(&dismissed_direction);
+
+    let widget = Dismissible::new(child())
+        .direction(DismissDirection::Up)
+        .on_dismissed(move |direction| {
+            on_dismissed_count.fetch_add(1, Ordering::SeqCst);
+            *on_dismissed_direction.lock().expect("test-only mutex") = Some(direction);
+        });
+
+    let vsync = Vsync::new();
+    let mut scoped = lay_out_animated_with_arena(widget, vsync, vertical_extent());
+    drag_and_release_vertical(&mut scoped, 250.0, 75.0, -48.0); // upward, 60% of the 80px extent
+
+    settle_for(&mut scoped, 400);
+    settle_for(&mut scoped, 400);
+
+    assert_eq!(
+        dismissed.load(Ordering::SeqCst),
+        1,
+        "a 48px (60%) upward drag past the 40% default threshold must dismiss exactly once"
+    );
+    assert_eq!(
+        *dismissed_direction.lock().expect("test-only mutex"),
+        Some(DismissDirection::Up)
+    );
+}
+
 /// Flutter parity: `'drag-left with DismissDirection.endToStart triggers
 /// dismiss (LTR)'`'s below-threshold sibling — no case in the oracle drags
 /// short and asserts spring-back directly, but every direction-gating case
@@ -529,6 +647,74 @@ fn direction_end_to_start_rtl_flips_which_physical_drag_dismisses() {
         (progress - 0.5).abs() < 0.02,
         "RTL EndToStart must admit a rightward drag; a 100px drag on a 200px \
          box is 50% progress, got {progress}"
+    );
+}
+
+// ============================================================================
+// Arena competition with a tappable child.
+// ============================================================================
+
+/// The hit-testing half of `'Dismissible.behavior should behave correctly
+/// during hit testing'` (`dismissible_test.dart:977`) — the named defect
+/// class: a widget's own gesture family must not break a nested tappable
+/// child's, and vice versa. Mirrors `gesture_detector_advanced.rs`'s
+/// `nested_tap_over_long_press` pattern (an outer detector's family
+/// competing with an inner `on_tap` in one arena), swapping the outer
+/// long-press family for `Dismissible`'s own drag family.
+#[test]
+fn a_tappable_child_still_taps_and_a_real_drag_still_wins_the_arena() {
+    let taps = Arc::new(AtomicUsize::new(0));
+    let taps_cb = Arc::clone(&taps);
+    let last_progress = Arc::new(Mutex::new(-1.0_f32));
+    let last_progress_cb = Arc::clone(&last_progress);
+
+    let tappable_child = GestureDetector::new()
+        .on_tap(move || {
+            taps_cb.fetch_add(1, Ordering::SeqCst);
+        })
+        .child(child());
+
+    let widget = Dismissible::new(tappable_child)
+        .direction(DismissDirection::EndToStart)
+        .on_update(move |details| {
+            *last_progress_cb.lock().expect("test-only mutex") = details.progress;
+        });
+
+    let mut scoped = lay_out_with_arena(widget, extent());
+
+    // A quick tap (down+up at the same position, never past touch slop) must
+    // still reach the nested GestureDetector's on_tap — Dismissible's own
+    // drag family (an axis-constrained recognizer that never even starts
+    // without crossing slop) does not swallow it.
+    scoped.dispatch_pointer_down(100.0, 40.0);
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_up(100.0, 40.0);
+    settle_one_frame(&mut scoped);
+    assert_eq!(
+        taps.load(Ordering::SeqCst),
+        1,
+        "a quick tap on a Dismissible-wrapped tappable child must still fire on_tap"
+    );
+
+    // A real drag (past slop) must resolve to Dismissible's OWN drag family,
+    // not the child's tap.
+    scoped.dispatch_pointer_down(180.0, 40.0);
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_move(160.0, 40.0); // 20px slop-crossing
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_move(120.0, 40.0); // delta -40: 20% of 200px
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_up(120.0, 40.0);
+    settle_one_frame(&mut scoped);
+    assert_eq!(
+        taps.load(Ordering::SeqCst),
+        1,
+        "a real drag must not ALSO fire the child's on_tap"
+    );
+    assert!(
+        *last_progress.lock().expect("test-only mutex") > 0.0,
+        "the drag must have reached Dismissible's own on_update — the arena resolved to the \
+         drag, not silently to neither recognizer"
     );
 }
 
@@ -867,6 +1053,48 @@ fn move_controller_registers_with_vsync_and_unregisters_on_unmount() {
         "unmounting Dismissible must dispose move_controller and unregister it from Vsync"
     );
     laid.pump_for(Duration::from_millis(16)); // must not panic: nothing left registered to tick
+}
+
+/// Mid-DRAG unmount smoke test — a widget torn out of the tree while a
+/// finger is still down must not panic. `move_controller` is unregistered
+/// from `Vsync` for the whole drag (`unregister_move_controller_vsync`), so
+/// `vsync.len()` is already `0` at the moment of the swap; `dispose`'s own
+/// attempt to unregister it is a documented no-op, not a double-unregister.
+/// Unlike the mid-resize-collapse case above, this drag never reaches
+/// `Dismissible`'s `LayoutBuilder` resize branch — `dispose` runs normally.
+#[test]
+fn unmounting_mid_drag_does_not_panic_or_double_unregister() {
+    let vsync = Vsync::new();
+    let widget = Dismissible::new(child()).direction(DismissDirection::EndToStart);
+    let mut scoped = lay_out_animated_with_arena(widget, vsync.clone(), extent());
+
+    // Drag halfway — never released.
+    scoped.dispatch_pointer_down(180.0, 40.0);
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_move(160.0, 40.0); // 20px slop-crossing
+    settle_one_frame(&mut scoped);
+    scoped.dispatch_pointer_move(100.0, 40.0); // delta -60: mid-drag, never released
+    settle_one_frame(&mut scoped);
+
+    assert_eq!(
+        vsync.len(),
+        0,
+        "move_controller is unregistered from Vsync for the whole drag (see \
+         unregister_move_controller_vsync) — nothing should be registered mid-drag"
+    );
+
+    scoped.pump_widget(VsyncScope::new(
+        vsync.clone(),
+        ColoredBox::new(Color::rgb(1, 2, 3)),
+    ));
+    scoped.pump(Duration::from_millis(16)); // must not panic
+
+    assert_eq!(
+        vsync.len(),
+        0,
+        "unmounting mid-drag must not leave anything registered, nor attempt a double \
+         unregister of the already-unregistered move_controller"
+    );
 }
 
 // `both_controllers_are_disposed_when_unmounted_mid_resize_collapse` — the

--- a/crates/flui-widgets/tests/parity/main.rs
+++ b/crates/flui-widgets/tests/parity/main.rs
@@ -104,3 +104,6 @@ mod wrap_test;
 
 // ── Business.1 fidelity front — ValueListenableBuilder parity ───────────────
 mod value_listenable_builder_test;
+
+// ── Business.1 fidelity front — Dismissible parity (gesture-heavy widget) ───
+mod dismissible_test;


### PR DESCRIPTION
Business.1 implementation-gated fidelity unit: `Dismissible` lands in `flui-widgets` (drag-to-dismiss with direction gating, thresholds, fling classification, background slots, and the animate-out → resize-collapse → `onDismissed` pipeline) plus a 50+-test parity corpus against `dismissible.dart` / `dismissible_test.dart` @ 3.44.0 with full denominator accounting.

## The state machine

Per-event drag deltas move the child via fractional translation; release below the threshold springs back, past it animates out (`movement_duration`) then collapses (`resize_duration`) then fires `on_dismissed`; all seven `DismissDirection` variants gated per the oracle incl. RTL flips; `on_update` carries the reached/previousReached edges; `background`/`secondary_background` visibility follows drag sign. Move and resize controllers are vsync-registered/unregistered with registration-count tests (mid-drag unmount included).

## Real bug caught in review and fixed

`AnimationController::set_value` fires status listeners and clamps — a drag reaching 100% of the axis fired `Completed` mid-drag, and the deferred-delivery counter later turned a below-threshold spring-back into a **false dismissal** (the oracle drops completions while a drag is underway). Fixed at the mutation source: every direct `set_value` in the drag handlers consumes-without-delivering, so only completions from real `forward()`/`fling()` runs deliver; the at-bound release path stays counter-free so a legitimate exactly-at-100% release still dismisses. Unit-pinned (the harness's out-of-window dispatch ceiling makes the clamp unreachable end-to-end) and mutant-verified in both rounds. The sub-frame race where a real completion meets a new drag is a documented user-interaction-wins divergence (reset under the finger, never dismiss under an active gesture).

Layout-phase callback delivery is verified against the repo's contracts (RebuildHandle is phase-safe by design; LayoutBuilder closures run as ordinary build passes with the pipeline lock released) and documented at the call site.

## Named deferrals

`confirmDismiss` (no widget-level async gate seam yet), semantics cases, `dragStartBehavior` (7th enumerated divergence), unbounded-axis misuse now debug-asserts.

## Evidence

- `cargo nextest run --workspace --exclude flui-platform`: 7652 passed; clippy `-D warnings`, fmt/port-check/inventory/taplo/typos, doctests: clean.
- Reviewer ran 4 mutants across two rounds (threshold, direction gating, vsync disposal, the completion-discard) — all killed; oracle state machine cross-checked line-by-line; arena competition with a tappable child pinned.
- Full review + delta re-review: SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)