### PR TITLE
fix(engine): clamp scissor rects to the attachment and keep rrect arcs in one contour

### DIFF
--- a/crates/flui-engine/src/wgpu/replay/flush.rs
+++ b/crates/flui-engine/src/wgpu/replay/flush.rs
@@ -589,7 +589,19 @@ impl GpuReplay {
             }
 
             if let Some((x, y, w, h)) = batch.scissor {
-                render_pass.set_scissor_rect(x, y, w, h);
+                // Clamp to the attachment. The SSAA tile remap rewrites a
+                // fully-clipped batch's scissor to an off-target sentinel, and a
+                // clip whose edge rounds one pixel past the attachment would fail
+                // wgpu's scissor containment validation. A zero-area result means
+                // the batch is fully clipped — skip its draw.
+                let clamped_x = x.min(full_w);
+                let clamped_y = y.min(full_h);
+                let clamped_w = w.min(full_w - clamped_x);
+                let clamped_h = h.min(full_h - clamped_y);
+                if clamped_w == 0 || clamped_h == 0 {
+                    continue;
+                }
+                render_pass.set_scissor_rect(clamped_x, clamped_y, clamped_w, clamped_h);
             } else {
                 render_pass.set_scissor_rect(0, 0, full_w, full_h);
             }

--- a/crates/flui-engine/src/wgpu/replay/flush.rs
+++ b/crates/flui-engine/src/wgpu/replay/flush.rs
@@ -19,6 +19,82 @@ use super::super::{
 };
 use super::GpuReplay;
 
+// =============================================================================
+// Scissor clamping
+// =============================================================================
+//
+// Every recorded scissor is captured against the frame's full viewport, but a
+// flush can target a smaller offscreen attachment (a grown-bounds opacity
+// layer, an SSAA supersample tile). `opacity_layer.rs::render_segment_to_grown_offscreen`
+// and `ssaa.rs`'s tile remap intersect each recorded scissor with the
+// attachment's local bounds and, on an empty intersection, emit a deliberate
+// off-target sentinel — `(full_w, full_h, 1, 1)` — to mean "fully clipped,
+// draw nothing". That sentinel's origin sits exactly on the attachment's far
+// edge, so `x + w` / `y + h` overshoot the attachment by one pixel: passed
+// straight to `set_scissor_rect` it fails wgpu's scissor-containment
+// validation. `TexturePool::acquire` sizes the offscreen target to the exact
+// requested bounds, so no margin absorbs the overshoot by accident — every
+// consumer of a recorded scissor must clamp it before calling
+// `set_scissor_rect`, not just the tessellated-geometry path.
+
+/// Clamp a `(x, y, w, h)` scissor rect (physical pixels) to fit inside a
+/// `(full_w, full_h)` render attachment.
+///
+/// Returns `None` when the clamped rect has zero area — the region has no
+/// visible intersection with the attachment and the caller must skip its
+/// draw call. Returns `Some` with the rect clamped to
+/// `[0, full_w) × [0, full_h)` otherwise (a no-op for an already in-bounds
+/// rect).
+fn clamp_scissor_to_attachment(
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+    full_w: u32,
+    full_h: u32,
+) -> Option<(u32, u32, u32, u32)> {
+    let clamped_x = x.min(full_w);
+    let clamped_y = y.min(full_h);
+    let clamped_w = w.min(full_w - clamped_x);
+    let clamped_h = h.min(full_h - clamped_y);
+    if clamped_w == 0 || clamped_h == 0 {
+        None
+    } else {
+        Some((clamped_x, clamped_y, clamped_w, clamped_h))
+    }
+}
+
+/// Set `render_pass`'s scissor rect for one draw region, clamped to the
+/// attachment, and report whether the caller should issue its draw call.
+///
+/// `scissor` is `None` for "no active clip" (the full attachment) or
+/// `Some((x, y, w, h))` for a recorded per-region clip in full-viewport
+/// device-pixel space. Returns `false` when the clamped region has no
+/// visible area, in which case the caller must skip its `draw_indexed` call
+/// rather than pass a possibly out-of-bounds rect to wgpu.
+///
+/// This is the only place in this module that calls
+/// `RenderPass::set_scissor_rect` — every batch and texture flush path below
+/// routes through it, so a new direct call can't silently reintroduce an
+/// unclamped scissor. `set_clamped_scissor_is_the_only_scissor_rect_call_site`
+/// in the `tests` module pins that invariant with a source scan.
+fn set_clamped_scissor(
+    render_pass: &mut wgpu::RenderPass<'_>,
+    scissor: ScissorRect,
+    full_w: u32,
+    full_h: u32,
+) -> bool {
+    let clamped = match scissor {
+        Some((x, y, w, h)) => clamp_scissor_to_attachment(x, y, w, h, full_w, full_h),
+        None => Some((0, 0, full_w, full_h)),
+    };
+    let Some((x, y, w, h)) = clamped else {
+        return false;
+    };
+    render_pass.set_scissor_rect(x, y, w, h);
+    true
+}
+
 // GPU rendering routinely converts between numeric types for pixel coordinates,
 // color channels, buffer indices, and instance counts; flush methods also carry
 // many GPU-handle parameters.
@@ -254,8 +330,9 @@ impl GpuReplay {
             let buf_start = shadow_offset;
             let buf_end = buf_start + shadow_size as u64;
             render_pass.set_vertex_buffer(1, instance_buffer.slice(buf_start..buf_end));
-            render_pass.set_scissor_rect(0, 0, full_w, full_h);
-            render_pass.draw_indexed(0..6, 0, 0..segment.shadow_batch.len() as u32);
+            if set_clamped_scissor(&mut render_pass, None, full_w, full_h) {
+                render_pass.draw_indexed(0..6, 0, 0..segment.shadow_batch.len() as u32);
+            }
         }
 
         // --- Rectangles (per-scissor-region) ---
@@ -266,12 +343,9 @@ impl GpuReplay {
             render_pass.set_vertex_buffer(1, instance_buffer.slice(buf_start..buf_end));
 
             for region in &segment.rect_scissors {
-                if let Some((x, y, w, h)) = region.scissor {
-                    render_pass.set_scissor_rect(x, y, w, h);
-                } else {
-                    render_pass.set_scissor_rect(0, 0, full_w, full_h);
+                if set_clamped_scissor(&mut render_pass, region.scissor, full_w, full_h) {
+                    render_pass.draw_indexed(0..6, 0, region.start..region.start + region.count);
                 }
-                render_pass.draw_indexed(0..6, 0, region.start..region.start + region.count);
             }
         }
 
@@ -283,12 +357,9 @@ impl GpuReplay {
             render_pass.set_vertex_buffer(1, instance_buffer.slice(buf_start..buf_end));
 
             for region in &segment.circle_scissors {
-                if let Some((x, y, w, h)) = region.scissor {
-                    render_pass.set_scissor_rect(x, y, w, h);
-                } else {
-                    render_pass.set_scissor_rect(0, 0, full_w, full_h);
+                if set_clamped_scissor(&mut render_pass, region.scissor, full_w, full_h) {
+                    render_pass.draw_indexed(0..6, 0, region.start..region.start + region.count);
                 }
-                render_pass.draw_indexed(0..6, 0, region.start..region.start + region.count);
             }
         }
 
@@ -300,12 +371,9 @@ impl GpuReplay {
             render_pass.set_vertex_buffer(1, instance_buffer.slice(buf_start..buf_end));
 
             for region in &segment.arc_scissors {
-                if let Some((x, y, w, h)) = region.scissor {
-                    render_pass.set_scissor_rect(x, y, w, h);
-                } else {
-                    render_pass.set_scissor_rect(0, 0, full_w, full_h);
+                if set_clamped_scissor(&mut render_pass, region.scissor, full_w, full_h) {
+                    render_pass.draw_indexed(0..6, 0, region.start..region.start + region.count);
                 }
-                render_pass.draw_indexed(0..6, 0, region.start..region.start + region.count);
             }
         }
 
@@ -442,12 +510,9 @@ impl GpuReplay {
             render_pass.set_vertex_buffer(1, instance_buffer.slice(linear_start..linear_end));
 
             for region in &segment.linear_grad_scissors {
-                if let Some((x, y, w, h)) = region.scissor {
-                    render_pass.set_scissor_rect(x, y, w, h);
-                } else {
-                    render_pass.set_scissor_rect(0, 0, full_w, full_h);
+                if set_clamped_scissor(&mut render_pass, region.scissor, full_w, full_h) {
+                    render_pass.draw_indexed(0..6, 0, region.start..region.start + region.count);
                 }
-                render_pass.draw_indexed(0..6, 0, region.start..region.start + region.count);
             }
         }
 
@@ -464,12 +529,9 @@ impl GpuReplay {
             render_pass.set_vertex_buffer(1, instance_buffer.slice(radial_start..radial_end));
 
             for region in &segment.radial_grad_scissors {
-                if let Some((x, y, w, h)) = region.scissor {
-                    render_pass.set_scissor_rect(x, y, w, h);
-                } else {
-                    render_pass.set_scissor_rect(0, 0, full_w, full_h);
+                if set_clamped_scissor(&mut render_pass, region.scissor, full_w, full_h) {
+                    render_pass.draw_indexed(0..6, 0, region.start..region.start + region.count);
                 }
-                render_pass.draw_indexed(0..6, 0, region.start..region.start + region.count);
             }
         }
 
@@ -486,12 +548,9 @@ impl GpuReplay {
             render_pass.set_vertex_buffer(1, instance_buffer.slice(sweep_start..sweep_end));
 
             for region in &segment.sweep_grad_scissors {
-                if let Some((x, y, w, h)) = region.scissor {
-                    render_pass.set_scissor_rect(x, y, w, h);
-                } else {
-                    render_pass.set_scissor_rect(0, 0, full_w, full_h);
+                if set_clamped_scissor(&mut render_pass, region.scissor, full_w, full_h) {
+                    render_pass.draw_indexed(0..6, 0, region.start..region.start + region.count);
                 }
-                render_pass.draw_indexed(0..6, 0, region.start..region.start + region.count);
             }
         }
 
@@ -588,22 +647,10 @@ impl GpuReplay {
                 active_key = Some(batch.pipeline_key);
             }
 
-            if let Some((x, y, w, h)) = batch.scissor {
-                // Clamp to the attachment. The SSAA tile remap rewrites a
-                // fully-clipped batch's scissor to an off-target sentinel, and a
-                // clip whose edge rounds one pixel past the attachment would fail
-                // wgpu's scissor containment validation. A zero-area result means
-                // the batch is fully clipped — skip its draw.
-                let clamped_x = x.min(full_w);
-                let clamped_y = y.min(full_h);
-                let clamped_w = w.min(full_w - clamped_x);
-                let clamped_h = h.min(full_h - clamped_y);
-                if clamped_w == 0 || clamped_h == 0 {
-                    continue;
-                }
-                render_pass.set_scissor_rect(clamped_x, clamped_y, clamped_w, clamped_h);
-            } else {
-                render_pass.set_scissor_rect(0, 0, full_w, full_h);
+            if !set_clamped_scissor(&mut render_pass, batch.scissor, full_w, full_h) {
+                // Fully clipped (a zero-area clamp, or the SSAA/opacity-layer
+                // remap's off-target sentinel) — nothing to draw for this batch.
+                continue;
             }
 
             let start = batch.index_start;
@@ -942,13 +989,9 @@ impl GpuReplay {
         );
 
         let (full_w, full_h) = viewport_size;
-        if let Some((x, y, w, h)) = scissor {
-            render_pass.set_scissor_rect(x, y, w, h);
-        } else {
-            render_pass.set_scissor_rect(0, 0, full_w, full_h);
+        if set_clamped_scissor(&mut render_pass, scissor, full_w, full_h) {
+            render_pass.draw_indexed(0..6, 0, 0..self.texture_batch.len() as u32);
         }
-
-        render_pass.draw_indexed(0..6, 0, 0..self.texture_batch.len() as u32);
         drop(render_pass);
         self.texture_batch.clear();
     }
@@ -1048,14 +1091,95 @@ impl GpuReplay {
         );
 
         let (full_w, full_h) = viewport_size;
-        if let Some((x, y, w, h)) = scissor {
-            render_pass.set_scissor_rect(x, y, w, h);
-        } else {
-            render_pass.set_scissor_rect(0, 0, full_w, full_h);
+        if set_clamped_scissor(&mut render_pass, scissor, full_w, full_h) {
+            render_pass.draw_indexed(0..6, 0, 0..self.texture_batch.len() as u32);
         }
-
-        render_pass.draw_indexed(0..6, 0, 0..self.texture_batch.len() as u32);
         drop(render_pass);
         self.texture_batch.clear();
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::clamp_scissor_to_attachment;
+
+    /// The off-target sentinel `(full_w, full_h, 1, 1)` that
+    /// `opacity_layer.rs`'s `render_segment_to_grown_offscreen` and
+    /// `ssaa.rs`'s tile remap emit for a fully-clipped region must clamp to
+    /// `None` — its origin already sits on the attachment's far edge, so any
+    /// non-zero extent overshoots.
+    #[test]
+    fn sentinel_rect_at_the_far_edge_clamps_to_none() {
+        let full_w = 800;
+        let full_h = 600;
+        let clamped = clamp_scissor_to_attachment(full_w, full_h, 1, 1, full_w, full_h);
+        assert_eq!(
+            clamped, None,
+            "the off-target sentinel (full_w, full_h, 1, 1) must clamp to None (fully clipped), \
+             not an out-of-bounds Some(...) that wgpu's scissor validation would reject"
+        );
+    }
+
+    /// A rect whose right/bottom edge overshoots the attachment by one pixel
+    /// clamps down to the visible remainder rather than being rejected or
+    /// passed through unclamped.
+    #[test]
+    fn rect_one_pixel_past_the_edge_clamps_to_the_visible_remainder() {
+        let full_w = 800;
+        let full_h = 600;
+        // Right edge at x=795+10=805, one past full_w=800 (and analogously
+        // for the bottom edge at y=595+10=605, one past full_h=600).
+        let clamped = clamp_scissor_to_attachment(795, 595, 10, 10, full_w, full_h);
+        assert_eq!(
+            clamped,
+            Some((795, 595, 5, 5)),
+            "a rect overshooting the attachment must clamp its extent down to the visible \
+             remainder, keeping the same origin"
+        );
+    }
+
+    /// An already in-bounds rect passes through unchanged (the common case —
+    /// clamping must be a no-op when nothing needs clamping).
+    #[test]
+    fn in_bounds_rect_passes_through_unchanged() {
+        let full_w = 800;
+        let full_h = 600;
+        let clamped = clamp_scissor_to_attachment(10, 10, 100, 100, full_w, full_h);
+        assert_eq!(clamped, Some((10, 10, 100, 100)));
+    }
+
+    /// Every scissor-consuming flush site must route through
+    /// `set_clamped_scissor` rather than calling `RenderPass::set_scissor_rect`
+    /// directly — a direct call bypasses the attachment clamp entirely and
+    /// the unit tests above, which only exercise the pure clamp function,
+    /// cannot catch that kind of bypass.
+    ///
+    /// Red-check: reverting any one flush site (e.g. the rect-scissor loop in
+    /// `flush_all_instanced_batches`) back to a bare
+    /// `render_pass.set_scissor_rect(x, y, w, h)` / `else` pair raises the
+    /// count below to 2 and fails this assertion, while every other test in
+    /// the suite (including the three above) still passes.
+    #[test]
+    fn set_clamped_scissor_is_the_only_scissor_rect_call_site() {
+        const SOURCE: &str = include_str!("flush.rs");
+        // Exclude this `tests` module itself: its own doc comments and this
+        // assertion's message reference `set_scissor_rect` in prose, and this
+        // test's `SOURCE` scan would otherwise count its own search needle.
+        let (production_source, _) = SOURCE
+            .split_once("mod tests {")
+            .expect("this module scans its own enclosing file");
+
+        let call_sites = production_source.matches("render_pass.set_scissor_rect(").count();
+        assert_eq!(
+            call_sites, 1,
+            "expected exactly one call to `render_pass.set_scissor_rect` in flush.rs — inside \
+             `set_clamped_scissor`. Every batch/texture flush path must route through that \
+             helper so the attachment clamp can't be bypassed by a new direct call; found \
+             {call_sites}"
+        );
     }
 }

--- a/crates/flui-engine/src/wgpu/replay/flush.rs
+++ b/crates/flui-engine/src/wgpu/replay/flush.rs
@@ -1173,7 +1173,9 @@ mod tests {
             .split_once("mod tests {")
             .expect("this module scans its own enclosing file");
 
-        let call_sites = production_source.matches("render_pass.set_scissor_rect(").count();
+        let call_sites = production_source
+            .matches("render_pass.set_scissor_rect(")
+            .count();
         assert_eq!(
             call_sites, 1,
             "expected exactly one call to `render_pass.set_scissor_rect` in flush.rs — inside \

--- a/crates/flui-engine/src/wgpu/state_stack.rs
+++ b/crates/flui-engine/src/wgpu/state_stack.rs
@@ -834,4 +834,47 @@ mod tests {
             "outer scissor restored"
         );
     }
+
+    /// A clip rect lying entirely past the surface's right edge must clamp
+    /// its origin to the surface bound, not emit an out-of-bounds `x`.
+    ///
+    /// This is the exact crash case the origin clamp in `clip_rect` fixes:
+    /// before the AABB math clamps the right edge, `right.saturating_sub(x)`
+    /// already yields `width == 0` (900 vs 800 no wgpu problem by itself),
+    /// but `x == 900` is still past the 800-wide surface — passed straight to
+    /// `set_scissor_rect` that `x` alone fails wgpu's scissor-containment
+    /// validation regardless of `width` being zero.
+    ///
+    /// Red-check: remove the `raw_x.min(surface_size.0)` / `raw_y.min(...)`
+    /// origin clamp (restoring `clamped_x = raw_x`, `clamped_y = raw_y`) and
+    /// this test fails — the stored scissor's `x` becomes 900, past the
+    /// surface's 800px width.
+    #[test]
+    fn clip_rect_entirely_past_right_edge_clamps_origin_into_bounds() {
+        let mut stack = identity_stack();
+        let surface = (800, 600);
+        let far_right_rect = Rect::from_ltrb(
+            flui_types::geometry::px(900.0),
+            flui_types::geometry::px(0.0),
+            flui_types::geometry::px(950.0),
+            flui_types::geometry::px(50.0),
+        );
+
+        stack.clip_rect(far_right_rect, surface);
+
+        let (x, _y, w, _h) = stack
+            .current_scissor()
+            .expect("clip_rect always sets a scissor, even a zero-width one");
+        assert!(
+            x <= surface.0,
+            "scissor origin x={x} must not exceed the surface width {}; an out-of-bounds x \
+             fails wgpu's scissor-rect containment validation even when w == 0",
+            surface.0
+        );
+        assert_eq!(
+            w, 0,
+            "a clip rect entirely past the right edge must clamp to zero width, not leave a \
+             residual extent past the surface bound"
+        );
+    }
 }

--- a/crates/flui-engine/src/wgpu/state_stack.rs
+++ b/crates/flui-engine/src/wgpu/state_stack.rs
@@ -412,16 +412,32 @@ impl GpuStateStack {
             (x, y, width, height)
         };
 
-        self.current_scissor = Some(new_scissor);
+        // Clamp the scissor to the render target. wgpu rejects a scissor whose
+        // origin or right/bottom edge lies outside the attachment; the AABB math
+        // above clamps the right/bottom edges but leaves the origin unclamped, so
+        // a clip lying entirely past the right/bottom edge (left >= surface width)
+        // would emit an out-of-bounds `x`/`y`. Clamping the origin first keeps the
+        // `surface - origin` extent subtraction from underflowing.
+        let (raw_x, raw_y, raw_w, raw_h) = new_scissor;
+        let clamped_x = raw_x.min(surface_size.0);
+        let clamped_y = raw_y.min(surface_size.1);
+        let clamped_scissor = (
+            clamped_x,
+            clamped_y,
+            raw_w.min(surface_size.0 - clamped_x),
+            raw_h.min(surface_size.1 - clamped_y),
+        );
+
+        self.current_scissor = Some(clamped_scissor);
 
         #[cfg(debug_assertions)]
         tracing::trace!(
             "GpuStateStack::clip_rect: rect={:?} → scissor=({}, {}, {}, {})",
             rect,
-            new_scissor.0,
-            new_scissor.1,
-            new_scissor.2,
-            new_scissor.3,
+            clamped_scissor.0,
+            clamped_scissor.1,
+            clamped_scissor.2,
+            clamped_scissor.3,
         );
     }
 

--- a/crates/flui-engine/src/wgpu/tessellator.rs
+++ b/crates/flui-engine/src/wgpu/tessellator.rs
@@ -1080,10 +1080,6 @@ impl IntoLyonPath for flui_types::painting::path::Path {
                 }
 
                 PathCommand::AddArc(rect, start_angle, sweep_angle) => {
-                    // Start new subpath for arc using lyon Arc primitive
-                    if has_begun {
-                        builder.end(false);
-                    }
                     let center = rect.center();
                     let rx = (rect.width() / 2.0).0;
                     let ry = (rect.height() / 2.0).0;
@@ -1096,9 +1092,21 @@ impl IntoLyonPath for flui_types::painting::path::Path {
                         x_rotation: lyon::geom::Angle::radians(0.0),
                     };
 
+                    // An arc appended to an open contour *continues* it: move
+                    // along the contour to the arc's start, then trace the arc.
+                    // `Path::from_rrect` builds a rounded rectangle as one
+                    // contour (edge, corner arc, edge, corner arc, …); starting
+                    // a fresh subpath per arc instead fragments it, and each open
+                    // fragment's implicit fill-closure chord renders as a
+                    // diagonal slash across the corner. Only open a new subpath
+                    // when nothing is in progress (a standalone arc).
                     let arc_start = arc.from();
-                    builder.begin(arc_start);
-                    has_begun = true;
+                    if has_begun {
+                        builder.line_to(arc_start);
+                    } else {
+                        builder.begin(arc_start);
+                        has_begun = true;
+                    }
 
                     arc.for_each_cubic_bezier(&mut |cubic| {
                         builder.cubic_bezier_to(cubic.ctrl1, cubic.ctrl2, cubic.to);
@@ -1284,6 +1292,33 @@ mod cpu_tests {
         assert!((tess.fill_tolerance() - DEVICE_FILL_TOLERANCE).abs() < 1e-6);
         tess.set_max_scale(-4.0);
         assert!((tess.fill_tolerance() - DEVICE_FILL_TOLERANCE).abs() < 1e-6);
+    }
+
+    /// A rounded rectangle must convert to ONE continuous lyon contour, not a
+    /// separate subpath per corner. `Path::from_rrect` traces edge → corner arc
+    /// → edge → corner arc as a single outline; when `AddArc` opened a fresh
+    /// subpath, that outline fragmented into the top edge plus four detached
+    /// arcs, and each open fragment's implicit fill-closure chord painted a
+    /// diagonal slash across the corner (seen on every Material `Card`). Guard
+    /// the single-contour invariant at the lyon-conversion boundary.
+    #[test]
+    fn rounded_rect_converts_to_one_contour_not_per_corner_subpaths() {
+        use flui_types::geometry::rrect::RRect;
+        use flui_types::painting::path::Path as FluiPath;
+
+        let rrect = RRect::from_xywh_circular(px(0.0), px(0.0), px(120.0), px(80.0), px(12.0));
+        let lyon_path = FluiPath::from_rrect(rrect).to_lyon_path();
+
+        let contour_starts = lyon_path
+            .iter()
+            .filter(|event| matches!(event, lyon::path::PathEvent::Begin { .. }))
+            .count();
+
+        assert_eq!(
+            contour_starts, 1,
+            "a rounded rectangle must be one contour; {contour_starts} subpaths \
+             means the corner arcs fragmented the outline into diagonal-slashed pieces",
+        );
     }
 }
 

--- a/crates/flui-types/src/painting/path.rs
+++ b/crates/flui-types/src/painting/path.rs
@@ -325,6 +325,27 @@ impl Path {
 
     /// Adds an arc on the oval inscribed in `rect`, starting at `start_angle`
     /// and sweeping by `sweep_angle` (both in radians).
+    ///
+    /// # Divergence from Flutter's `Path.addArc`
+    ///
+    /// Flutter's `Path.addArc` always starts a **new** sub-path — it behaves
+    /// like `arcTo(rect, startAngle, sweepAngle, forceMoveTo: true)`,
+    /// regardless of what the path was doing before the call.
+    ///
+    /// FLUI's `add_arc` does not: when called while a sub-path is already
+    /// open (a preceding `move_to`/`line_to`/`add_arc` with no `close`), the
+    /// tessellator (`flui-engine`'s `wgpu::tessellator`) draws a line from
+    /// the current position to the arc's start and *continues* that
+    /// contour — chord-connected, not a new sub-path. This is deliberate:
+    /// [`Self::from_rrect`] builds a fully-rounded rectangle as one
+    /// continuous contour (edge, corner arc, edge, corner arc, …); starting
+    /// a fresh sub-path per corner arc would fragment the contour into four
+    /// open pieces, each rendering an unwanted diagonal fill-closure chord
+    /// across its corner.
+    ///
+    /// A caller that wants Flutter's "always a new sub-path" semantics must
+    /// call [`Self::move_to`] (to the arc's start point) immediately before
+    /// `add_arc`, or call `add_arc` as the first command on a fresh `Path`.
     #[inline]
     pub fn add_arc(&mut self, rect: Rect<Pixels>, start_angle: f32, sweep_angle: f32) {
         self.commands


### PR DESCRIPTION
Three rendering-correctness fixes, adopted from uncommitted work found in the session tree (recovered from dropped stashes after an external reset; origin: an untracked debugging pass) and completed through review.

## What

- **Rounded rectangles no longer paint diagonal corner slashes.** `to_lyon_path`'s `AddArc` opened a fresh subpath per arc, so `Path::from_rrect`'s single outline fragmented into per-corner pieces whose implicit fill-closure chords cut across every corner (visible on every Material `Card`). An arc appended to an open contour now continues it; guarded by a single-contour unit test (mutation-killed). The continues-open-contour semantic — a divergence from Flutter's `Path.addArc` new-subpath contract — is documented on `Path::add_arc` in the owning crate with the `move_to`-first escape hatch.
- **wgpu scissor-validation crashes closed at every consumer.** The first cut clamped one site; review found the fully-clipped-batch sentinel `(w, h, 1, 1)` is produced by both `ssaa.rs` and `opacity_layer.rs` and consumed by nine `set_scissor_rect` sites. All nine now route through one pure `clamp_scissor_to_attachment` helper (zero-area → skip the draw), enforced by a source-scan test pinning the single-call-site invariant, plus boundary pins (sentinel → skip; one-pixel-past-edge → clamp; in-bounds → passthrough). `GpuStateStack::clip_rect` clamps the scissor origin before the extent subtraction — the entirely-past-the-edge clip previously underflowed (crash-case pinned; the revert red-check panics with subtract-with-overflow).

## Evidence

- `cargo nextest run --workspace --exclude flui-platform`: 7686 passed (engine 236/236, +6 new); clippy `-D warnings`, port-check/inventory/fmt/taplo/typos, doc gates: clean.
- Reviewer independently re-ran the contour mutant, the scan-test bypass mutant, and the origin-clamp revert in an isolated worktree — all killed. Actual wgpu validation acceptance is CI's WARP readback job (not locally verifiable).
- Full review + delta re-review: SHIP.

Note: the working tree carries a separate in-flight change (`rrect_hint` analytic-shadow work in `batches/paths.rs`) from a concurrent session — deliberately excluded from these commits and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)