### PR TITLE
feat(widgets): implement InteractiveViewer with pan, wheel zoom, and boundary clamping

### DIFF
--- a/crates/flui-widgets/src/interaction/interactive_viewer.rs
+++ b/crates/flui-widgets/src/interaction/interactive_viewer.rs
@@ -930,7 +930,7 @@ mod tests {
     ///
     /// Scenario: child/viewport 200x200, `boundary_margin: 20` (boundary
     /// -20..220), scale = e, a hard-left drag attempting -1000 scene units.
-    /// Confirmed empirically (see the PR review fix-up) that this exact
+    /// Confirmed empirically that this exact
     /// input reproduces nonzero residue in `corrected_excess.dx` against
     /// the pre-fix exact-`f32`-equality code, which returns exactly `0.0`
     /// here; the epsilon-tolerant fix returns the correctly clamped

--- a/crates/flui-widgets/src/interaction/interactive_viewer.rs
+++ b/crates/flui-widgets/src/interaction/interactive_viewer.rs
@@ -1,0 +1,907 @@
+//! [`InteractiveViewer`] — pans and zooms its child through a transformation
+//! matrix.
+//!
+//! Flutter parity: `widgets/interactive_viewer.dart` (tag `3.44.0`). The
+//! contract this ports: a single [`TransformationController`]-held
+//! [`Matrix4`] maps the child's scene coordinates to viewport coordinates;
+//! gestures update that matrix; `min_scale`/`max_scale` clamp the zoom level;
+//! `boundary_margin` constrains how far the transformed viewport may drift
+//! from the child's own rect (an all-infinite margin removes the boundary
+//! entirely); `pan_enabled`/`scale_enabled` gate whether a gesture is allowed
+//! to *apply*, though `on_interaction_*` callbacks still fire regardless
+//! (matching Flutter's documented "will be called even if the interaction is
+//! disabled" contract).
+//!
+//! # Scope of this port (V1)
+//!
+//! - **Pan** is wired through [`GestureDetector::on_pan_start`]/`on_pan_update`/
+//!   `on_pan_end` — a genuine single-pointer drag, dispatched and slop-tested
+//!   through the real gesture arena in tests.
+//! - **Scale** is wired through [`Listener::on_pointer_signal`] — a real mouse
+//!   wheel / discrete-scroll event, matching Flutter's `_receivedPointerSignal`
+//!   mouse-wheel branch (`scaleChange = exp(-scrollDelta.dy / scaleFactor)`).
+//! - **Pinch-to-zoom and two-finger rotation are out of scope.** Flutter
+//!   recognizes them through `GestureDetector`'s combined scale gesture
+//!   (`onScaleStart`/`onScaleUpdate`/`onScaleEnd`, fed by two simultaneous
+//!   pointers); FLUI's `GestureDetector` has no such recognizer yet — this is
+//!   a framework-level gap, not merely a test-harness one. Rotation is in the
+//!   same position Flutter's own upstream is: `_rotateEnabled` is hardcoded
+//!   `false` in the oracle too (`interactive_viewer.dart` — rotation is
+//!   unimplemented pending flutter/flutter#57698), so dropping the
+//!   `Quad`/rotation-aware boundary math it would otherwise need is a
+//!   faithful simplification, not a cut corner: with rotation permanently
+//!   off, the general `Quad` axis-aligned-bounding-box algorithm and the
+//!   plain-`Rect` containment math below produce identical boundary
+//!   decisions.
+//! - **`constrained: false`** (an unconstrained child laid out via an
+//!   `OverflowBox`-equivalent, escaping the viewport) is **deferred**. V1
+//!   only supports `constrained: true` — the child is laid out under
+//!   whatever constraints this widget itself receives, exactly like
+//!   [`Transform`]. A consequence used throughout this file: because nothing
+//!   between the child and this widget's own box imposes a different size
+//!   (`Listener`/`GestureDetector`/`ClipRect`/`Transform` are all
+//!   layout-transparent, size-adopting proxies), **the viewport rect and the
+//!   child's own (unmargined) rect are numerically identical in V1** — see
+//!   [`InteractiveViewerState::geometry`]. Adding `constrained: false` later
+//!   means that identity stops holding and a second, viewport-only anchor
+//!   (mirroring Flutter's `_parentKey` vs. `_childKey` split) becomes load
+//!   bearing again.
+//! - **Inertia/fling after a pan release** (Flutter's `FrictionSimulation` in
+//!   `_onScaleEnd`) is deferred — `on_interaction_end` fires with the
+//!   release velocity, but no animation follows it. Needs an
+//!   `AnimationController`/`Vsync` wiring pass of its own.
+//!
+//! `on_interaction_start`/`on_interaction_update`/`on_interaction_end` carry
+//! FLUI's own detail types ([`InteractionStartDetails`] etc.), not a literal
+//! port of Flutter's `ScaleStartDetails`/`ScaleUpdateDetails`/`ScaleEndDetails`
+//! — those describe a combined pan+scale+rotate gesture this port does not
+//! recognize as one gesture. The shape here carries what pan and wheel-scale
+//! actually produce: a focal point, a scale multiplier (1.0 for a pure pan),
+//! a translation delta, and a release velocity.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use flui_geometry::{Matrix4, px};
+use flui_interaction::events::ScrollEventData;
+use flui_interaction::{DragEndDetails, DragStartDetails, DragUpdateDetails};
+use flui_objects::{RenderSubtreeAnchor, SubtreeAnchor};
+use flui_rendering::hit_testing::{HitTestBehavior, PointerEvent};
+use flui_rendering::pipeline::PipelineOwner;
+use flui_rendering::protocol::BoxProtocol;
+use flui_types::geometry::Pixels;
+use flui_types::gestures::Velocity;
+use flui_types::painting::Clip;
+use flui_types::{Alignment, Axis, EdgeInsets, Offset, Point, Rect};
+use flui_view::element::ElementKind;
+use flui_view::prelude::*;
+use flui_view::{
+    Child, IntoView, RenderObjectContext, RenderView, View, ViewState, impl_render_view,
+};
+use parking_lot::RwLock;
+
+use crate::{AnimatedBuilder, ClipRect, GestureDetector, Listener, Transform};
+
+use super::transformation_controller::TransformationController;
+
+// ============================================================================
+// PanAxis
+// ============================================================================
+
+/// Constrains which axis (or axes) [`InteractiveViewer`] pans along.
+///
+/// Flutter parity: `widgets/interactive_viewer.dart` `PanAxis`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PanAxis {
+    /// Panning is allowed only along the horizontal axis.
+    Horizontal,
+    /// Panning is allowed only along the vertical axis.
+    Vertical,
+    /// Panning is allowed along the horizontal and vertical axes, but never
+    /// diagonally — the drag's dominant axis (established on the first
+    /// non-zero movement of the gesture) locks for the rest of the gesture.
+    Aligned,
+    /// Panning is allowed freely in any direction.
+    #[default]
+    Free,
+}
+
+// ============================================================================
+// Interaction details
+// ============================================================================
+
+/// Details passed to `on_interaction_start`. See the module docs for why this
+/// is FLUI's own shape rather than a `ScaleStartDetails` port.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InteractionStartDetails {
+    /// The interaction's focal point, in the coordinates of the widget that
+    /// contains `InteractiveViewer`.
+    pub focal_point: Offset<Pixels>,
+    /// The interaction's focal point, in the coordinates of
+    /// `InteractiveViewer` itself (viewport-local).
+    pub local_focal_point: Offset<Pixels>,
+}
+
+/// Details passed to `on_interaction_update`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InteractionUpdateDetails {
+    /// The interaction's current focal point, in the coordinates of the
+    /// widget that contains `InteractiveViewer`.
+    pub focal_point: Offset<Pixels>,
+    /// The interaction's current focal point, in `InteractiveViewer`'s own
+    /// (viewport-local) coordinates.
+    pub local_focal_point: Offset<Pixels>,
+    /// The multiplicative scale change applied by this update. `1.0` for a
+    /// pure pan update (no scale change).
+    pub scale: f32,
+    /// The translation applied by this update, in viewport pixels. Zero for
+    /// a pure wheel-scale update.
+    pub focal_point_delta: Offset<Pixels>,
+}
+
+/// Details passed to `on_interaction_end`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InteractionEndDetails {
+    /// The gesture's release velocity. [`Velocity::ZERO`] for a discrete
+    /// wheel-scale interaction (there is no release to measure).
+    pub velocity: Velocity,
+}
+
+type StartCallback = Rc<dyn Fn(InteractionStartDetails)>;
+type UpdateCallback = Rc<dyn Fn(InteractionUpdateDetails)>;
+type EndCallback = Rc<dyn Fn(InteractionEndDetails)>;
+
+// ============================================================================
+// InteractiveViewer
+// ============================================================================
+
+/// Pans and zooms `child` through a [`TransformationController`]-held
+/// [`Matrix4`].
+///
+/// See the module docs for the exact scope this V1 port covers.
+#[derive(Clone)]
+pub struct InteractiveViewer {
+    controller: TransformationController,
+    boundary_margin: EdgeInsets,
+    min_scale: f32,
+    max_scale: f32,
+    pan_enabled: bool,
+    scale_enabled: bool,
+    pan_axis: PanAxis,
+    scale_factor: f32,
+    clip_behavior: Clip,
+    alignment: Option<Alignment>,
+    on_interaction_start: Option<StartCallback>,
+    on_interaction_update: Option<UpdateCallback>,
+    on_interaction_end: Option<EndCallback>,
+    child: Child,
+}
+
+impl std::fmt::Debug for InteractiveViewer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InteractiveViewer")
+            .field("controller", &self.controller)
+            .field("boundary_margin", &self.boundary_margin)
+            .field("min_scale", &self.min_scale)
+            .field("max_scale", &self.max_scale)
+            .field("pan_enabled", &self.pan_enabled)
+            .field("scale_enabled", &self.scale_enabled)
+            .field("pan_axis", &self.pan_axis)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for InteractiveViewer {
+    fn default() -> Self {
+        Self {
+            controller: TransformationController::new(),
+            boundary_margin: EdgeInsets::ZERO,
+            // Eyeballed defaults, matching Flutter's own (`minScale: 0.8`,
+            // `maxScale: 2.5`) — reasonable limits for common use cases.
+            min_scale: 0.8,
+            max_scale: 2.5,
+            pan_enabled: true,
+            scale_enabled: true,
+            pan_axis: PanAxis::Free,
+            // Flutter parity: `kDefaultMouseScrollToScaleFactor`.
+            scale_factor: 200.0,
+            clip_behavior: Clip::HardEdge,
+            alignment: None,
+            on_interaction_start: None,
+            on_interaction_update: None,
+            on_interaction_end: None,
+            child: Child::empty(),
+        }
+    }
+}
+
+impl InteractiveViewer {
+    /// A new `InteractiveViewer` with Flutter's default limits (`minScale:
+    /// 0.8`, `maxScale: 2.5`, zero boundary margin, pan and wheel-scale both
+    /// enabled).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Share this transform through an external [`TransformationController`]
+    /// instead of the one created internally. Multiple widgets can read (and
+    /// drive) the same controller.
+    #[must_use]
+    pub fn controller(mut self, controller: TransformationController) -> Self {
+        self.controller = controller;
+        self
+    }
+
+    /// A margin for the visible boundaries of the child.
+    ///
+    /// Any transformation that would move the viewport outside of the
+    /// boundary is clamped at the boundary. Pass `EdgeInsets::all(f32::
+    /// INFINITY)` for no boundary at all.
+    ///
+    /// # Precondition
+    ///
+    /// Every edge must be finite, or every edge must be infinite — not a mix
+    /// (checked with `debug_assert!`, matching Flutter's own `assert`, which
+    /// is likewise debug-only).
+    #[must_use]
+    pub fn boundary_margin(mut self, boundary_margin: EdgeInsets) -> Self {
+        debug_assert!(
+            (boundary_margin.left.is_infinite()
+                && boundary_margin.top.is_infinite()
+                && boundary_margin.right.is_infinite()
+                && boundary_margin.bottom.is_infinite())
+                || (boundary_margin.left.is_finite()
+                    && boundary_margin.top.is_finite()
+                    && boundary_margin.right.is_finite()
+                    && boundary_margin.bottom.is_finite()),
+            "InteractiveViewer::boundary_margin must be either fully finite or \
+             fully infinite on all four edges, not a mix"
+        );
+        self.boundary_margin = boundary_margin;
+        self
+    }
+
+    /// The minimum allowed scale. Must be finite and greater than zero, and
+    /// no greater than [`max_scale`](Self::max_scale).
+    #[must_use]
+    pub fn min_scale(mut self, min_scale: f32) -> Self {
+        debug_assert!(
+            min_scale > 0.0 && min_scale.is_finite(),
+            "InteractiveViewer::min_scale must be finite and greater than zero"
+        );
+        self.min_scale = min_scale;
+        self
+    }
+
+    /// The maximum allowed scale. Must be greater than zero, not NaN, and no
+    /// less than [`min_scale`](Self::min_scale).
+    #[must_use]
+    pub fn max_scale(mut self, max_scale: f32) -> Self {
+        debug_assert!(
+            max_scale > 0.0 && !max_scale.is_nan(),
+            "InteractiveViewer::max_scale must be greater than zero"
+        );
+        self.max_scale = max_scale;
+        self
+    }
+
+    /// If `false`, single-pointer drags do not pan the child.
+    /// `on_interaction_*` callbacks still fire (Flutter parity).
+    #[must_use]
+    pub fn pan_enabled(mut self, pan_enabled: bool) -> Self {
+        self.pan_enabled = pan_enabled;
+        self
+    }
+
+    /// If `false`, mouse-wheel scroll does not scale the child.
+    /// `on_interaction_*` callbacks still fire (Flutter parity).
+    #[must_use]
+    pub fn scale_enabled(mut self, scale_enabled: bool) -> Self {
+        self.scale_enabled = scale_enabled;
+        self
+    }
+
+    /// Restricts panning to one axis, or locks a free drag to whichever axis
+    /// dominates it. Defaults to [`PanAxis::Free`].
+    #[must_use]
+    pub fn pan_axis(mut self, pan_axis: PanAxis) -> Self {
+        self.pan_axis = pan_axis;
+        self
+    }
+
+    /// The divisor applied to a mouse-wheel scroll delta before it becomes an
+    /// exponential scale change (`scale_change = exp(-scroll_dy /
+    /// scale_factor)`). Larger values feel slower; smaller values feel
+    /// faster. Defaults to Flutter's `kDefaultMouseScrollToScaleFactor`
+    /// (`200.0`).
+    #[must_use]
+    pub fn scale_factor(mut self, scale_factor: f32) -> Self {
+        self.scale_factor = scale_factor;
+        self
+    }
+
+    /// How the child is clipped to this widget's bounds. Defaults to
+    /// [`Clip::HardEdge`] — pass [`Clip::None`] to let a zoomed-in child
+    /// paint outside its original area (it still won't receive gestures
+    /// there).
+    #[must_use]
+    pub fn clip_behavior(mut self, clip_behavior: Clip) -> Self {
+        self.clip_behavior = clip_behavior;
+        self
+    }
+
+    /// The alignment of the child's transform pivot. See
+    /// [`Transform::alignment`] for the exact contribution when combined
+    /// with an origin — `InteractiveViewer` never sets an origin, so this is
+    /// simply the pivot the transform matrix scales/rotates around.
+    #[must_use]
+    pub fn alignment(mut self, alignment: Alignment) -> Self {
+        self.alignment = Some(alignment);
+        self
+    }
+
+    /// Called when a pan or wheel-scale interaction begins.
+    #[must_use]
+    pub fn on_interaction_start(
+        mut self,
+        callback: impl Fn(InteractionStartDetails) + 'static,
+    ) -> Self {
+        self.on_interaction_start = Some(Rc::new(callback));
+        self
+    }
+
+    /// Called on every applied (or attempted, if disabled) pan/wheel-scale
+    /// update.
+    #[must_use]
+    pub fn on_interaction_update(
+        mut self,
+        callback: impl Fn(InteractionUpdateDetails) + 'static,
+    ) -> Self {
+        self.on_interaction_update = Some(Rc::new(callback));
+        self
+    }
+
+    /// Called when a pan or wheel-scale interaction ends.
+    #[must_use]
+    pub fn on_interaction_end(
+        mut self,
+        callback: impl Fn(InteractionEndDetails) + 'static,
+    ) -> Self {
+        self.on_interaction_end = Some(Rc::new(callback));
+        self
+    }
+
+    /// The child to pan and zoom.
+    #[must_use]
+    pub fn child(mut self, child: impl IntoView) -> Self {
+        self.child = Child::some(child.into_view());
+        self
+    }
+}
+
+impl View for InteractiveViewer {
+    fn create_element(&self) -> ElementKind {
+        ElementKind::stateful(self)
+    }
+}
+
+impl StatefulView for InteractiveViewer {
+    type State = InteractiveViewerState;
+
+    fn create_state(&self) -> Self::State {
+        InteractiveViewerState {
+            subtree_anchor: SubtreeAnchor::new(),
+            gesture: Rc::new(GestureTracking {
+                pan_start_local: Cell::new(None),
+                current_axis: Cell::new(None),
+            }),
+        }
+    }
+}
+
+// ============================================================================
+// State
+// ============================================================================
+
+/// Tracks the in-flight pan gesture's dominant-axis lock (for
+/// [`PanAxis::Aligned`]) across the several `on_pan_update` calls one drag
+/// produces. `Rc`-shared into the closures `build` hands to `GestureDetector`
+/// so it survives from `on_pan_start` through the matching `on_pan_end`, even
+/// across a rebuild that swaps in fresh closures mid-gesture.
+#[derive(Debug)]
+struct GestureTracking {
+    /// Viewport-local position at the most recent `on_pan_start`. `None`
+    /// between gestures.
+    pan_start_local: Cell<Option<Offset<Pixels>>>,
+    /// The axis a [`PanAxis::Aligned`] drag has locked to, established from
+    /// the first non-zero movement of the gesture. `None` before that, and
+    /// reset to `None` at the end of every gesture.
+    current_axis: Cell<Option<Axis>>,
+}
+
+/// Persistent state for [`InteractiveViewer`].
+#[derive(Debug)]
+pub struct InteractiveViewerState {
+    /// Publishes the child's `RenderId` while mounted — see
+    /// [`geometry`](Self::geometry) for why one anchor is enough in V1.
+    subtree_anchor: SubtreeAnchor,
+    gesture: Rc<GestureTracking>,
+}
+
+impl ViewState<InteractiveViewer> for InteractiveViewerState {
+    #[allow(clippy::too_many_lines)] // one gesture-wiring build(); splitting fragments the callback capture set
+    fn build(&self, view: &InteractiveViewer, ctx: &dyn BuildContext) -> impl IntoView {
+        let controller = view.controller.clone();
+        let anchor = self.subtree_anchor.clone();
+        let gesture = Rc::clone(&self.gesture);
+        let pipeline_owner = ctx.pipeline_owner();
+        let boundary_margin = view.boundary_margin;
+        let min_scale = view.min_scale;
+        let max_scale = view.max_scale;
+        let pan_enabled = view.pan_enabled;
+        let scale_enabled = view.scale_enabled;
+        let pan_axis = view.pan_axis;
+        let scale_factor = view.scale_factor;
+        let clip_behavior = view.clip_behavior;
+        let alignment = view.alignment;
+        let child = view.child.clone();
+        let on_start = view.on_interaction_start.clone();
+        let on_update = view.on_interaction_update.clone();
+        let on_end = view.on_interaction_end.clone();
+
+        let listenable = controller.as_listenable();
+
+        AnimatedBuilder::new(listenable, move || {
+            let matrix = controller.value();
+
+            // -- Pan (GestureDetector) -------------------------------------
+            let gesture_start = Rc::clone(&gesture);
+            let on_start_pan = on_start.clone();
+            let pan_start_details = move |details: DragStartDetails| {
+                gesture_start.current_axis.set(None);
+                gesture_start
+                    .pan_start_local
+                    .set(Some(details.local_position));
+                if let Some(callback) = &on_start_pan {
+                    callback(InteractionStartDetails {
+                        focal_point: details.global_position,
+                        local_focal_point: details.local_position,
+                    });
+                }
+            };
+
+            let gesture_update = Rc::clone(&gesture);
+            let controller_update = controller.clone();
+            let anchor_update = anchor.clone();
+            let pipeline_owner_update = pipeline_owner.clone();
+            let on_update_pan = on_update.clone();
+            let pan_update_details = move |details: DragUpdateDetails| {
+                if pan_enabled {
+                    if let Some(start_local) = gesture_update.pan_start_local.get()
+                        && gesture_update.current_axis.get().is_none()
+                        && pan_axis != PanAxis::Free
+                    {
+                        let total = details.local_position - start_local;
+                        if total != Offset::ZERO {
+                            gesture_update.current_axis.set(Some(dominant_axis(total)));
+                        }
+                    }
+                    if let Some((viewport, boundary)) = InteractiveViewerState::geometry(
+                        pipeline_owner_update.as_ref(),
+                        &anchor_update,
+                        boundary_margin,
+                    ) {
+                        let current_matrix = controller_update.value();
+                        let scale = uniform_scale(&current_matrix);
+                        let raw_delta = Offset::new(
+                            px(details.delta.dx.get() / scale),
+                            px(details.delta.dy.get() / scale),
+                        );
+                        let aligned = match pan_axis {
+                            PanAxis::Free => raw_delta,
+                            PanAxis::Horizontal => align_to_axis(raw_delta, Axis::Horizontal),
+                            PanAxis::Vertical => align_to_axis(raw_delta, Axis::Vertical),
+                            PanAxis::Aligned => match gesture_update.current_axis.get() {
+                                Some(axis) => align_to_axis(raw_delta, axis),
+                                None => raw_delta,
+                            },
+                        };
+                        let next = clamp_translation(current_matrix, aligned, viewport, boundary);
+                        controller_update.set_value(next);
+                    }
+                }
+                if let Some(callback) = &on_update_pan {
+                    callback(InteractionUpdateDetails {
+                        focal_point: details.global_position,
+                        local_focal_point: details.local_position,
+                        scale: 1.0,
+                        focal_point_delta: Offset::new(
+                            px(details.delta.dx.get()),
+                            px(details.delta.dy.get()),
+                        ),
+                    });
+                }
+            };
+
+            let gesture_end = Rc::clone(&gesture);
+            let on_end_pan = on_end.clone();
+            let pan_end_details = move |details: DragEndDetails| {
+                gesture_end.pan_start_local.set(None);
+                gesture_end.current_axis.set(None);
+                if let Some(callback) = &on_end_pan {
+                    callback(InteractionEndDetails {
+                        velocity: details.velocity,
+                    });
+                }
+            };
+
+            // -- Wheel scale (Listener::on_pointer_signal) -----------------
+            let controller_wheel = controller.clone();
+            let anchor_wheel = anchor.clone();
+            let pipeline_owner_wheel = pipeline_owner.clone();
+            let on_start_wheel = on_start.clone();
+            let on_update_wheel = on_update.clone();
+            let on_end_wheel = on_end.clone();
+            let pointer_signal = move |event: &PointerEvent| {
+                let PointerEvent::Scroll(scroll) = event else {
+                    return;
+                };
+                let data = ScrollEventData::from(scroll);
+                if data.delta.dy.get() == 0.0 {
+                    // Ignore horizontal-only wheel scroll, matching the
+                    // oracle (`_receivedPointerSignal` returns early on
+                    // `scrollDelta.dy == 0.0`).
+                    return;
+                }
+
+                if let Some(callback) = &on_start_wheel {
+                    callback(InteractionStartDetails {
+                        focal_point: data.position,
+                        local_focal_point: data.position,
+                    });
+                }
+
+                let scale_change = (-data.delta.dy.get() / scale_factor).exp();
+
+                if scale_enabled
+                    && let Some((viewport, boundary)) = InteractiveViewerState::geometry(
+                        pipeline_owner_wheel.as_ref(),
+                        &anchor_wheel,
+                        boundary_margin,
+                    )
+                {
+                    let scene_before = controller_wheel.to_scene(data.position);
+                    let scaled = clamp_scale(
+                        controller_wheel.value(),
+                        scale_change,
+                        min_scale,
+                        max_scale,
+                        viewport,
+                        boundary,
+                    );
+                    controller_wheel.set_value(scaled);
+
+                    // Keep the same scene point under the cursor before and
+                    // after the scale (Flutter parity).
+                    let scene_after = controller_wheel.to_scene(data.position);
+                    let correction = Offset::new(
+                        scene_after.dx - scene_before.dx,
+                        scene_after.dy - scene_before.dy,
+                    );
+                    let translated =
+                        clamp_translation(controller_wheel.value(), correction, viewport, boundary);
+                    controller_wheel.set_value(translated);
+                }
+
+                if let Some(callback) = &on_update_wheel {
+                    callback(InteractionUpdateDetails {
+                        focal_point: data.position,
+                        local_focal_point: data.position,
+                        scale: scale_change,
+                        focal_point_delta: Offset::ZERO,
+                    });
+                }
+                if let Some(callback) = &on_end_wheel {
+                    callback(InteractionEndDetails {
+                        velocity: Velocity::ZERO,
+                    });
+                }
+            };
+
+            let mut transform =
+                Transform::new(matrix).child(AnchoredChild::new(anchor.clone(), child.clone()));
+            if let Some(alignment) = alignment {
+                transform = transform.alignment(alignment);
+            }
+
+            let clipped = ClipRect::new()
+                .clip_behavior(clip_behavior)
+                .child(transform);
+
+            let recognized = GestureDetector::new()
+                // Flutter parity: `HitTestBehavior.opaque` — "necessary when
+                // panning off screen" (the child's own hit-test area can end
+                // up smaller than the viewport once transformed).
+                .behavior(HitTestBehavior::Opaque)
+                .on_pan_start(pan_start_details)
+                .on_pan_update(pan_update_details)
+                .on_pan_end(pan_end_details)
+                .child(clipped);
+
+            Listener::new()
+                .on_pointer_signal(pointer_signal)
+                .child(recognized)
+        })
+    }
+}
+
+impl InteractiveViewerState {
+    /// The viewport rect and the boundary rect, in scene coordinates, or
+    /// `None` before the child is mounted and laid out.
+    ///
+    /// Associated function rather than a `&self` method: the gesture
+    /// closures built in [`build`](ViewState::build) capture
+    /// `pipeline_owner`/`anchor`/`boundary_margin` by clone (they must be
+    /// `'static`, so they cannot borrow the `ViewState`), and call this with
+    /// those clones instead.
+    ///
+    /// V1 only supports `constrained: true`, under which
+    /// `Listener`/`GestureDetector`/`ClipRect`/`Transform` are all
+    /// layout-transparent proxies that adopt the child's own size — nothing
+    /// between this widget's box and the child imposes a different size. So
+    /// the **viewport** rect (Flutter's `_viewport`, `parentRenderBox.size`)
+    /// and the child's own unmargined rect (the base Flutter inflates by
+    /// `boundaryMargin` to get `_boundaryRect`) are the same rectangle. This
+    /// collapses Flutter's two keys (`_parentKey` on the outer `Listener`,
+    /// `_childKey` inside `Transform`) into the single `subtree_anchor` field.
+    fn geometry(
+        pipeline_owner: Option<&std::sync::Arc<RwLock<PipelineOwner>>>,
+        anchor: &SubtreeAnchor,
+        boundary_margin: EdgeInsets,
+    ) -> Option<(Rect<Pixels>, Rect<Pixels>)> {
+        let owner = pipeline_owner?;
+        let render_id = anchor.get()?;
+        let size = owner.read().box_size(render_id)?;
+        let rect = Rect::from_origin_size(Point::new(px(0.0), px(0.0)), size);
+        Some((rect, boundary_margin.inflate_rect(rect)))
+    }
+}
+
+// ============================================================================
+// AnchoredChild — publishes the child's RenderId for size queries
+// ============================================================================
+
+/// A transparent proxy that publishes its own `RenderId` into `anchor` while
+/// mounted, so gesture callbacks (which run outside `build`) can later query
+/// the child's committed size via `PipelineOwner::box_size`.
+///
+/// Same shape as the `AnchoredBox` helper in `navigator::subtree`/`hero`
+/// (each site keeps its own thin wrapper over the shared
+/// `flui_objects::RenderSubtreeAnchor` rather than exporting one — the
+/// wrapper itself is a few lines and `pub(crate)` visibility doesn't cross
+/// module boundaries here).
+#[derive(Debug, Clone)]
+struct AnchoredChild {
+    anchor: SubtreeAnchor,
+    child: Child,
+}
+
+impl AnchoredChild {
+    fn new(anchor: SubtreeAnchor, child: Child) -> Self {
+        Self { anchor, child }
+    }
+}
+
+impl RenderView for AnchoredChild {
+    type Protocol = BoxProtocol;
+    type RenderObject = RenderSubtreeAnchor;
+
+    fn create_render_object(&self, _ctx: &RenderObjectContext<'_>) -> Self::RenderObject {
+        RenderSubtreeAnchor::new(self.anchor.clone())
+    }
+
+    fn update_render_object(
+        &self,
+        _ctx: &RenderObjectContext<'_>,
+        _render_object: &mut Self::RenderObject,
+    ) {
+        // Nothing to update: a render object's anchor is its identity, fixed
+        // for the life of the node.
+    }
+
+    fn has_children(&self) -> bool {
+        self.child.is_some()
+    }
+
+    fn visit_child_views(&self, visitor: &mut dyn FnMut(&dyn View)) {
+        if let Some(child) = self.child.as_ref() {
+            visitor(child);
+        }
+    }
+}
+
+impl_render_view!(AnchoredChild);
+
+// ============================================================================
+// Matrix math — boundary-clamped translate/scale
+// ============================================================================
+
+/// The uniform scale factor of a matrix built solely from translation +
+/// uniform scale (no rotation — see the module docs on why rotation is out of
+/// scope): the length of the transformed x basis vector.
+fn uniform_scale(matrix: &Matrix4) -> f32 {
+    let m = matrix.to_col_major_array();
+    m[0].hypot(m[1])
+}
+
+/// Transforms `viewport`'s four corners by the inverse of `matrix` and
+/// returns their axis-aligned bounding box — the viewport's rect in scene
+/// coordinates after the child has been transformed by `matrix`. Falls back
+/// to `viewport` unchanged if `matrix` is singular (should not happen for a
+/// translation + uniform-scale matrix with a non-zero scale).
+fn transform_viewport(matrix: Matrix4, viewport: Rect<Pixels>) -> Rect<Pixels> {
+    match matrix.try_inverse() {
+        Some(inverse) => inverse.transform_rect(&viewport),
+        None => viewport,
+    }
+}
+
+/// How far `[view_min, view_max]` lies outside `[bound_min, bound_max]` along
+/// one axis, signed so that adding it to the viewport's position moves it
+/// back inside the boundary. Zero when already inside (inclusive).
+///
+/// Flutter parity: the axis-aligned specialization of
+/// `InteractiveViewer._exceedsBy`/`getNearestPointInside` — with rotation
+/// permanently disabled (see the module docs), the general `Quad`
+/// nearest-point algorithm and this plain interval comparison agree on every
+/// case, including a viewport wider than the boundary on this axis (checked
+/// against both edges; the edge quoting the larger-magnitude excess wins,
+/// exactly as the `Quad` algorithm's per-corner comparison would).
+fn axis_excess(view_min: f32, view_max: f32, bound_min: f32, bound_max: f32) -> f32 {
+    let excess_min = if view_min < bound_min {
+        bound_min - view_min
+    } else {
+        0.0
+    };
+    let excess_max = if view_max > bound_max {
+        bound_max - view_max
+    } else {
+        0.0
+    };
+    if excess_min.abs() >= excess_max.abs() {
+        excess_min
+    } else {
+        excess_max
+    }
+}
+
+fn rect_excess(boundary: Rect<Pixels>, viewport: Rect<Pixels>) -> Offset<Pixels> {
+    Offset::new(
+        px(axis_excess(
+            viewport.min.x.get(),
+            viewport.max.x.get(),
+            boundary.min.x.get(),
+            boundary.max.x.get(),
+        )),
+        px(axis_excess(
+            viewport.min.y.get(),
+            viewport.max.y.get(),
+            boundary.min.y.get(),
+            boundary.max.y.get(),
+        )),
+    )
+}
+
+/// Locks a `PanAxis::Aligned` drag to whichever axis dominates `delta`.
+/// `delta` must be non-zero (callers only invoke this on real movement).
+fn dominant_axis(delta: Offset<Pixels>) -> Axis {
+    if delta.dx.get().abs() > delta.dy.get().abs() {
+        Axis::Horizontal
+    } else {
+        Axis::Vertical
+    }
+}
+
+/// Zeroes out the off-axis component of `delta`.
+fn align_to_axis(delta: Offset<Pixels>, axis: Axis) -> Offset<Pixels> {
+    match axis {
+        Axis::Horizontal => Offset::new(delta.dx, px(0.0)),
+        Axis::Vertical => Offset::new(px(0.0), delta.dy),
+    }
+}
+
+/// Applies `translation` (in scene units) to `matrix`, clamped so the
+/// transformed viewport stays within `boundary` when `boundary` is finite.
+///
+/// Flutter parity: `_InteractiveViewerState._matrixTranslate`. Composed via
+/// `matrix * Matrix4::translation(..)` (post-multiply — the translation
+/// happens in the matrix's own local/scene space before the rest of the
+/// transform is applied), matching `vector_math`'s `translateByDouble`
+/// instance-method convention that the oracle relies on. `flui_geometry`'s
+/// own `Matrix4::translate` mutator has the *opposite* (pre-multiply,
+/// global-space) convention and must not be used here.
+fn clamp_translation(
+    matrix: Matrix4,
+    translation: Offset<Pixels>,
+    viewport: Rect<Pixels>,
+    boundary: Rect<Pixels>,
+) -> Matrix4 {
+    if translation == Offset::ZERO {
+        return matrix;
+    }
+    let next = matrix * Matrix4::translation(translation.dx.get(), translation.dy.get(), 0.0);
+
+    if !boundary.is_finite() {
+        return next;
+    }
+
+    let next_viewport = transform_viewport(next, viewport);
+    let excess = rect_excess(boundary, next_viewport);
+    if excess == Offset::ZERO {
+        return next;
+    }
+
+    let (next_tx, next_ty, next_tz) = next.translation_component();
+    let current_scale = uniform_scale(&matrix);
+    let corrected_tx = next_tx - excess.dx.get() * current_scale;
+    let corrected_ty = next_ty - excess.dy.get() * current_scale;
+    let mut corrected = matrix;
+    corrected.set_translation(corrected_tx, corrected_ty, next_tz);
+
+    let corrected_viewport = transform_viewport(corrected, viewport);
+    let corrected_excess = rect_excess(boundary, corrected_viewport);
+    if corrected_excess == Offset::ZERO {
+        return corrected;
+    }
+
+    if corrected_excess.dx.get() != 0.0 && corrected_excess.dy.get() != 0.0 {
+        // Neither axis fits at all (the viewport is larger than the
+        // boundary in both directions): no translation, matching the
+        // oracle.
+        return matrix;
+    }
+
+    let unidirectional_tx = if corrected_excess.dx.get() == 0.0 {
+        corrected_tx
+    } else {
+        0.0
+    };
+    let unidirectional_ty = if corrected_excess.dy.get() == 0.0 {
+        corrected_ty
+    } else {
+        0.0
+    };
+    let mut result = matrix;
+    result.set_translation(unidirectional_tx, unidirectional_ty, next_tz);
+    result
+}
+
+/// Applies `scale` (a multiplicative change) to `matrix`, clamped so the
+/// resulting overall scale stays within `[min_scale, max_scale]` and never
+/// shrinks the child so much it can't cover `boundary` from `viewport`.
+///
+/// Flutter parity: `_InteractiveViewerState._matrixScale`. Composed via
+/// `matrix * Matrix4::scaling(..)` — see [`clamp_translation`]'s doc for why
+/// the mutating `Matrix4::scale` method is the wrong tool here.
+fn clamp_scale(
+    matrix: Matrix4,
+    scale: f32,
+    min_scale: f32,
+    max_scale: f32,
+    viewport: Rect<Pixels>,
+    boundary: Rect<Pixels>,
+) -> Matrix4 {
+    if scale == 1.0 {
+        return matrix;
+    }
+    let current_scale = uniform_scale(&matrix);
+    // Finite / infinite (unbounded boundary) is naturally 0.0 here — no
+    // separate infinite-boundary branch needed.
+    let boundary_floor = (viewport.width().get() / boundary.width().get())
+        .max(viewport.height().get() / boundary.height().get());
+    let total_scale = (current_scale * scale).max(boundary_floor);
+    let clamped_total = total_scale.clamp(min_scale, max_scale);
+    let applied = clamped_total / current_scale;
+    matrix * Matrix4::scaling(applied, applied, applied)
+}

--- a/crates/flui-widgets/src/interaction/interactive_viewer.rs
+++ b/crates/flui-widgets/src/interaction/interactive_viewer.rs
@@ -65,21 +65,19 @@ use std::rc::Rc;
 use flui_geometry::{Matrix4, px};
 use flui_interaction::events::ScrollEventData;
 use flui_interaction::{DragEndDetails, DragStartDetails, DragUpdateDetails};
-use flui_objects::{RenderSubtreeAnchor, SubtreeAnchor};
+use flui_objects::SubtreeAnchor;
 use flui_rendering::hit_testing::{HitTestBehavior, PointerEvent};
 use flui_rendering::pipeline::PipelineOwner;
-use flui_rendering::protocol::BoxProtocol;
 use flui_types::geometry::Pixels;
 use flui_types::gestures::Velocity;
 use flui_types::painting::Clip;
 use flui_types::{Alignment, Axis, EdgeInsets, Offset, Point, Rect};
 use flui_view::element::ElementKind;
 use flui_view::prelude::*;
-use flui_view::{
-    Child, IntoView, RenderObjectContext, RenderView, View, ViewState, impl_render_view,
-};
+use flui_view::{Child, IntoView, View, ViewState};
 use parking_lot::RwLock;
 
+use crate::navigator::AnchoredBox;
 use crate::{AnimatedBuilder, ClipRect, GestureDetector, Listener, Transform};
 
 use super::transformation_controller::TransformationController;
@@ -609,8 +607,10 @@ impl ViewState<InteractiveViewer> for InteractiveViewerState {
                 }
             };
 
-            let mut transform =
-                Transform::new(matrix).child(AnchoredChild::new(anchor.clone(), child.clone()));
+            let mut transform = Transform::new(matrix);
+            if let Some(inner_child) = child.clone().into_inner() {
+                transform = transform.child(AnchoredBox::new(anchor.clone(), inner_child));
+            }
             if let Some(alignment) = alignment {
                 transform = transform.alignment(alignment);
             }
@@ -667,61 +667,6 @@ impl InteractiveViewerState {
         Some((rect, boundary_margin.inflate_rect(rect)))
     }
 }
-
-// ============================================================================
-// AnchoredChild — publishes the child's RenderId for size queries
-// ============================================================================
-
-/// A transparent proxy that publishes its own `RenderId` into `anchor` while
-/// mounted, so gesture callbacks (which run outside `build`) can later query
-/// the child's committed size via `PipelineOwner::box_size`.
-///
-/// Same shape as the `AnchoredBox` helper in `navigator::subtree`/`hero`
-/// (each site keeps its own thin wrapper over the shared
-/// `flui_objects::RenderSubtreeAnchor` rather than exporting one — the
-/// wrapper itself is a few lines and `pub(crate)` visibility doesn't cross
-/// module boundaries here).
-#[derive(Debug, Clone)]
-struct AnchoredChild {
-    anchor: SubtreeAnchor,
-    child: Child,
-}
-
-impl AnchoredChild {
-    fn new(anchor: SubtreeAnchor, child: Child) -> Self {
-        Self { anchor, child }
-    }
-}
-
-impl RenderView for AnchoredChild {
-    type Protocol = BoxProtocol;
-    type RenderObject = RenderSubtreeAnchor;
-
-    fn create_render_object(&self, _ctx: &RenderObjectContext<'_>) -> Self::RenderObject {
-        RenderSubtreeAnchor::new(self.anchor.clone())
-    }
-
-    fn update_render_object(
-        &self,
-        _ctx: &RenderObjectContext<'_>,
-        _render_object: &mut Self::RenderObject,
-    ) {
-        // Nothing to update: a render object's anchor is its identity, fixed
-        // for the life of the node.
-    }
-
-    fn has_children(&self) -> bool {
-        self.child.is_some()
-    }
-
-    fn visit_child_views(&self, visitor: &mut dyn FnMut(&dyn View)) {
-        if let Some(child) = self.child.as_ref() {
-            visitor(child);
-        }
-    }
-}
-
-impl_render_view!(AnchoredChild);
 
 // ============================================================================
 // Matrix math — boundary-clamped translate/scale
@@ -793,6 +738,37 @@ fn rect_excess(boundary: Rect<Pixels>, viewport: Rect<Pixels>) -> Offset<Pixels>
     )
 }
 
+/// Floating-point tolerance for the "did this transform round-trip produce
+/// zero excess" checks in [`clamp_translation`].
+///
+/// Flutter parity: `InteractiveViewer`'s own `_round` helper exists for
+/// exactly this reason — `_exceedsBy`'s result is rounded to 9 decimal
+/// places before the `== Offset.zero` check, because
+/// `_transformViewport`'s inverse-then-transform round trip leaves residue
+/// that *should* be exactly zero but isn't once the matrix carries a
+/// non-unit (and non-power-of-two) scale, per the oracle's own comment:
+/// "values that should have been zero were given as within 10^-10 of zero".
+/// `f32` carries far fewer significant digits than the `f64` the oracle
+/// rounds, so a fixed decimal count doesn't transfer numerically; this
+/// snaps anything within `EXCESS_EPSILON` of zero back to exactly zero
+/// instead. Chosen against the scale of one gesture's excess (tens to
+/// thousands of pixels) rather than absolute machine epsilon — comfortably
+/// larger than the ~1e-4 residue a `scale * (a - b)` round trip leaves at
+/// these magnitudes, comfortably smaller than any excess a real boundary
+/// hit produces.
+const EXCESS_EPSILON: f32 = 1e-3;
+
+/// Whether a single excess component is within [`EXCESS_EPSILON`] of zero.
+fn is_negligible(component: f32) -> bool {
+    component.abs() < EXCESS_EPSILON
+}
+
+/// Whether `excess` is within [`EXCESS_EPSILON`] of `Offset::ZERO` on both
+/// axes — the round-trip-tolerant replacement for `excess == Offset::ZERO`.
+fn excess_is_negligible(excess: Offset<Pixels>) -> bool {
+    is_negligible(excess.dx.get()) && is_negligible(excess.dy.get())
+}
+
 /// Locks a `PanAxis::Aligned` drag to whichever axis dominates `delta`.
 /// `delta` must be non-zero (callers only invoke this on real movement).
 fn dominant_axis(delta: Offset<Pixels>) -> Axis {
@@ -838,7 +814,7 @@ fn clamp_translation(
 
     let next_viewport = transform_viewport(next, viewport);
     let excess = rect_excess(boundary, next_viewport);
-    if excess == Offset::ZERO {
+    if excess_is_negligible(excess) {
         return next;
     }
 
@@ -851,23 +827,23 @@ fn clamp_translation(
 
     let corrected_viewport = transform_viewport(corrected, viewport);
     let corrected_excess = rect_excess(boundary, corrected_viewport);
-    if corrected_excess == Offset::ZERO {
+    if excess_is_negligible(corrected_excess) {
         return corrected;
     }
 
-    if corrected_excess.dx.get() != 0.0 && corrected_excess.dy.get() != 0.0 {
+    if !is_negligible(corrected_excess.dx.get()) && !is_negligible(corrected_excess.dy.get()) {
         // Neither axis fits at all (the viewport is larger than the
         // boundary in both directions): no translation, matching the
         // oracle.
         return matrix;
     }
 
-    let unidirectional_tx = if corrected_excess.dx.get() == 0.0 {
+    let unidirectional_tx = if is_negligible(corrected_excess.dx.get()) {
         corrected_tx
     } else {
         0.0
     };
-    let unidirectional_ty = if corrected_excess.dy.get() == 0.0 {
+    let unidirectional_ty = if is_negligible(corrected_excess.dy.get()) {
         corrected_ty
     } else {
         0.0
@@ -895,13 +871,107 @@ fn clamp_scale(
     if scale == 1.0 {
         return matrix;
     }
+    // Flutter parity: `assert(maxScale >= minScale)` on `InteractiveViewer`'s
+    // constructor — debug-only there too (Dart's `assert` is stripped in
+    // release), so this does not replace `clamp_double`'s non-panicking
+    // behavior below; it only surfaces the misconfiguration in debug builds.
+    debug_assert!(
+        max_scale >= min_scale,
+        "InteractiveViewer: max_scale ({max_scale}) must be >= min_scale ({min_scale})"
+    );
     let current_scale = uniform_scale(&matrix);
     // Finite / infinite (unbounded boundary) is naturally 0.0 here — no
     // separate infinite-boundary branch needed.
     let boundary_floor = (viewport.width().get() / boundary.width().get())
         .max(viewport.height().get() / boundary.height().get());
     let total_scale = (current_scale * scale).max(boundary_floor);
-    let clamped_total = total_scale.clamp(min_scale, max_scale);
+    let clamped_total = clamp_double(total_scale, min_scale, max_scale);
     let applied = clamped_total / current_scale;
     matrix * Matrix4::scaling(applied, applied, applied)
+}
+
+/// Flutter parity: `foundation.dart`'s `clampDouble`. Unlike `f32::clamp`
+/// (which panics — in every build profile, not just debug — whenever `min >
+/// max`), this never panics: a misconfigured `min_scale > max_scale` falls
+/// through to Dart's own release-mode behavior (the `assert` above is
+/// debug-only) instead of crashing a release build over a caller error that
+/// should have been caught in testing.
+fn clamp_double(x: f32, min: f32, max: f32) -> f32 {
+    if x < min {
+        min
+    } else if x > max {
+        max
+    } else {
+        x
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn child_rect() -> Rect<Pixels> {
+        Rect::from_min_max(
+            Point::new(px(0.0), px(0.0)),
+            Point::new(px(200.0), px(200.0)),
+        )
+    }
+
+    /// Regression: at a non-unit, non-power-of-two scale,
+    /// `transform_viewport`'s inverse-then-transform round trip can leave
+    /// floating-point residue in the corrected excess that is not exactly
+    /// zero even where the corrected transform mathematically fits the
+    /// boundary exactly. Comparing that residue to `0.0` exactly (the
+    /// pre-fix code) misread "should be zero, isn't quite" as "this axis
+    /// still doesn't fit", so the unidirectional branch discarded the
+    /// corrected translation on that axis entirely instead of keeping it —
+    /// observably, the transform snaps back to zero translation on a
+    /// boundary hit while zoomed, instead of clamping to the boundary edge.
+    ///
+    /// Scenario: child/viewport 200x200, `boundary_margin: 20` (boundary
+    /// -20..220), scale = e, a hard-left drag attempting -1000 scene units.
+    /// Confirmed empirically (see the PR review fix-up) that this exact
+    /// input reproduces nonzero residue in `corrected_excess.dx` against
+    /// the pre-fix exact-`f32`-equality code, which returns exactly `0.0`
+    /// here; the epsilon-tolerant fix returns the correctly clamped
+    /// `~= -398.022`. Reverting the `excess_is_negligible`/`is_negligible`
+    /// calls in `clamp_translation` back to `== Offset::ZERO` / `== 0.0` /
+    /// `!= 0.0` makes this test fail with `tx == 0.0`.
+    #[test]
+    fn clamp_translation_clamps_instead_of_snapping_to_zero_at_non_unit_scale() {
+        let rect = child_rect();
+        let boundary = EdgeInsets::all(px(20.0)).inflate_rect(rect);
+        let scale = std::f32::consts::E;
+        let matrix = Matrix4::scaling(scale, scale, scale);
+        let translation = Offset::new(px(-1000.0), px(0.0));
+
+        let result = clamp_translation(matrix, translation, rect, boundary);
+        let (tx, ty, _tz) = result.translation_component();
+
+        assert!(
+            (tx - (-398.022)).abs() < 0.01,
+            "expected the clamped translation to land near -398.022, got {tx} \
+             (exactly 0.0 here means the fix regressed back to the \
+             snap-to-zero bug)"
+        );
+        assert_eq!(ty, 0.0);
+    }
+
+    /// `f32::clamp` panics — in every build profile, not just debug builds —
+    /// whenever `min > max`. `clamp_double` must never panic on that input,
+    /// matching Dart's `clampDouble` (whose own `assert(min <= max)` is
+    /// debug-only, so release Flutter never crashes over this either).
+    #[test]
+    fn clamp_double_never_panics_when_min_exceeds_max() {
+        assert_eq!(
+            clamp_double(5.0, 10.0, 1.0),
+            10.0,
+            "x < min returns min first"
+        );
+        assert_eq!(
+            clamp_double(50.0, 10.0, 1.0),
+            1.0,
+            "x not < min falls through to the x > max check, which returns max"
+        );
+    }
 }

--- a/crates/flui-widgets/src/interaction/mod.rs
+++ b/crates/flui-widgets/src/interaction/mod.rs
@@ -11,10 +11,12 @@ mod focus;
 mod gesture_arena_scope;
 mod gesture_detector;
 mod ignore_pointer;
+mod interactive_viewer;
 mod listener;
 mod mouse_region;
 mod offstage;
 mod shortcuts;
+mod transformation_controller;
 mod visibility;
 
 pub use absorb_pointer::AbsorbPointer;
@@ -36,8 +38,13 @@ pub(crate) use focus::{enclosing_focus_parent, install_rect_provider};
 pub use gesture_arena_scope::GestureArenaScope;
 pub use gesture_detector::{GestureDetector, GestureDetectorState};
 pub use ignore_pointer::IgnorePointer;
+pub use interactive_viewer::{
+    InteractionEndDetails, InteractionStartDetails, InteractionUpdateDetails, InteractiveViewer,
+    InteractiveViewerState, PanAxis,
+};
 pub use listener::Listener;
 pub use mouse_region::MouseRegion;
 pub use offstage::Offstage;
 pub use shortcuts::{CallbackShortcuts, ShortcutCallback, Shortcuts, SingleActivator};
+pub use transformation_controller::TransformationController;
 pub use visibility::Visibility;

--- a/crates/flui-widgets/src/interaction/transformation_controller.rs
+++ b/crates/flui-widgets/src/interaction/transformation_controller.rs
@@ -1,0 +1,236 @@
+//! [`TransformationController`] — the external handle for
+//! [`InteractiveViewer`](super::InteractiveViewer)'s transform.
+
+use std::fmt;
+use std::sync::Arc;
+
+use flui_foundation::{ChangeNotifier, Listenable, ListenerCallback, ListenerId};
+use flui_geometry::Matrix4;
+use flui_types::{Offset, geometry::Pixels};
+use parking_lot::Mutex;
+
+/// The heap-allocated state shared by every clone of a
+/// [`TransformationController`].
+struct Inner {
+    value: Mutex<Matrix4>,
+    notifier: ChangeNotifier,
+}
+
+impl Listenable for Inner {
+    fn add_listener(&self, listener: ListenerCallback) -> ListenerId {
+        self.notifier.add_listener(listener)
+    }
+
+    fn remove_listener(&self, id: ListenerId) {
+        self.notifier.remove_listener(id);
+    }
+
+    fn remove_all_listeners(&self) {
+        self.notifier.remove_all_listeners();
+    }
+}
+
+/// A shared, cheaply-cloneable handle to an `InteractiveViewer`'s
+/// transformation matrix.
+///
+/// Flutter parity: `widgets/interactive_viewer.dart` `TransformationController`
+/// — "a thin wrapper on `ValueNotifier` whose value is a `Matrix4`". FLUI
+/// shapes it the way sibling controllers in this crate are shaped (see
+/// [`ScrollController`](crate::ScrollController) /
+/// `flui_rendering::view::ScrollPosition`): `Arc`-backed shared state plus a
+/// [`ChangeNotifier`], so every clone observes the same transform and the
+/// same notifications, and [`as_listenable`](Self::as_listenable) hands out
+/// a stable `Arc<dyn Listenable>` (`Arc::ptr_eq`-stable across calls) for
+/// `AnimatedBuilder`'s subscribe/swap machinery.
+///
+/// The value defaults to [`Matrix4::identity`] — no transformation.
+#[derive(Clone)]
+pub struct TransformationController {
+    inner: Arc<Inner>,
+}
+
+impl fmt::Debug for TransformationController {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TransformationController")
+            .field("value", &*self.inner.value.lock())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for TransformationController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TransformationController {
+    /// A controller starting at the identity matrix (no transformation).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_value(Matrix4::identity())
+    }
+
+    /// A controller starting at `value`.
+    #[must_use]
+    pub fn with_value(value: Matrix4) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                value: Mutex::new(value),
+                notifier: ChangeNotifier::new(),
+            }),
+        }
+    }
+
+    /// The current transform.
+    #[must_use]
+    pub fn value(&self) -> Matrix4 {
+        *self.inner.value.lock()
+    }
+
+    /// Replaces the transform and notifies listeners if it actually changed.
+    ///
+    /// Flutter parity: `ValueNotifier.value=` — no clamping is applied here.
+    /// `InteractiveViewer`'s own gesture handling is what runs a candidate
+    /// transform through `boundaryMargin`/`minScale`/`maxScale` before
+    /// writing it through this setter; a direct `set_value` call (from a
+    /// test, or an external animation) bypasses those clamps entirely,
+    /// exactly as it does in Flutter.
+    pub fn set_value(&self, value: Matrix4) {
+        let mut guard = self.inner.value.lock();
+        if guard.m == value.m {
+            return;
+        }
+        *guard = value;
+        drop(guard);
+        self.inner.notifier.notify_listeners();
+    }
+
+    /// Returns the scene point at the given viewport point.
+    ///
+    /// A viewport point is relative to the parent while a scene point is
+    /// relative to the child, regardless of transformation. The viewport
+    /// transforms as the inverse of the child (moving the child left is
+    /// equivalent to moving the viewport right).
+    ///
+    /// Flutter parity: `TransformationController.toScene`. Returns
+    /// `viewport_point` unchanged if the current value is singular (should
+    /// not happen for a matrix built solely from translation + uniform
+    /// scale, but a non-invertible matrix has no meaningful scene point).
+    #[must_use]
+    pub fn to_scene(&self, viewport_point: Offset<Pixels>) -> Offset<Pixels> {
+        let value = self.value();
+        let Some(inverse) = value.try_inverse() else {
+            return viewport_point;
+        };
+        let (x, y) = inverse.transform_point(viewport_point.dx, viewport_point.dy);
+        Offset::new(x, y)
+    }
+
+    /// An `Arc<dyn Listenable>` sharing this controller's notifier.
+    ///
+    /// The same `Arc<Inner>` is coerced on every call (not a fresh
+    /// allocation), so `Arc::ptr_eq` across two calls on the same controller
+    /// — or on two clones of it — is stable. This is what lets
+    /// `AnimatedBuilder`/`ValueListenableBuilder`-style subscribers detect
+    /// "same controller, just a different clone" instead of resubscribing on
+    /// every rebuild.
+    #[must_use]
+    pub fn as_listenable(&self) -> Arc<dyn Listenable> {
+        Arc::clone(&self.inner) as Arc<dyn Listenable>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[test]
+    fn new_starts_at_identity() {
+        let controller = TransformationController::new();
+        assert_eq!(controller.value().m, Matrix4::identity().m);
+    }
+
+    #[test]
+    fn set_value_notifies_on_real_change() {
+        let controller = TransformationController::new();
+        let notified = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&notified);
+        controller.as_listenable().add_listener(Arc::new(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        controller.set_value(Matrix4::translation(10.0, 0.0, 0.0));
+        assert_eq!(notified.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn set_value_same_matrix_does_not_renotify() {
+        let controller = TransformationController::new();
+        controller.set_value(Matrix4::translation(5.0, 5.0, 0.0));
+
+        let notified = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&notified);
+        controller.as_listenable().add_listener(Arc::new(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        controller.set_value(Matrix4::translation(5.0, 5.0, 0.0));
+        assert_eq!(
+            notified.load(Ordering::SeqCst),
+            0,
+            "writing the identical matrix must not notify"
+        );
+
+        controller.set_value(Matrix4::translation(6.0, 5.0, 0.0));
+        assert_eq!(notified.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn clones_share_state() {
+        let controller = TransformationController::new();
+        let clone = controller.clone();
+        controller.set_value(Matrix4::translation(1.0, 2.0, 0.0));
+        assert_eq!(clone.value().m, Matrix4::translation(1.0, 2.0, 0.0).m);
+    }
+
+    #[test]
+    fn as_listenable_is_ptr_stable_across_calls() {
+        // The same controller must hand out `Arc::ptr_eq`-equal listenables
+        // on repeated calls — this is what lets `AnimatedBuilder` detect
+        // "same controller" across rebuilds instead of resubscribing.
+        let controller = TransformationController::new();
+        let a = controller.as_listenable();
+        let b = controller.as_listenable();
+        assert!(Arc::ptr_eq(&a, &b));
+
+        let other = TransformationController::new();
+        let c = other.as_listenable();
+        assert!(!Arc::ptr_eq(&a, &c));
+    }
+
+    #[test]
+    fn to_scene_accounts_for_translation_and_scale() {
+        let controller = TransformationController::new();
+        // Scene content scaled 2x then shifted by (10, 20) in viewport space.
+        controller
+            .set_value(Matrix4::translation(10.0, 20.0, 0.0) * Matrix4::scaling(2.0, 2.0, 1.0));
+
+        let scene = controller.to_scene(Offset::new(
+            flui_geometry::px(10.0),
+            flui_geometry::px(20.0),
+        ));
+        // Viewport (10, 20) is exactly the translation, so it maps back to
+        // the scene origin.
+        assert!((scene.dx.get() - 0.0).abs() < 1e-5);
+        assert!((scene.dy.get() - 0.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn to_scene_identity_is_passthrough() {
+        let controller = TransformationController::new();
+        let point = Offset::new(flui_geometry::px(42.0), flui_geometry::px(7.0));
+        assert_eq!(controller.to_scene(point), point);
+    }
+}

--- a/crates/flui-widgets/src/interaction/transformation_controller.rs
+++ b/crates/flui-widgets/src/interaction/transformation_controller.rs
@@ -138,6 +138,29 @@ impl TransformationController {
     pub fn as_listenable(&self) -> Arc<dyn Listenable> {
         Arc::clone(&self.inner) as Arc<dyn Listenable>
     }
+
+    /// The number of listeners currently registered.
+    ///
+    /// Disposal-testing hook, mirroring `ChangeNotifier::len` — a caller
+    /// that mounts a widget against this controller and unmounts it can
+    /// assert this returns to `0`, proving the widget's subscription was
+    /// actually removed rather than left dangling into a torn-down subtree.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.notifier.len()
+    }
+
+    /// Whether any listeners are currently registered. See [`len`](Self::len).
+    #[must_use]
+    pub fn has_listeners(&self) -> bool {
+        self.inner.notifier.has_listeners()
+    }
+
+    /// Whether no listeners are currently registered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.notifier.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/crates/flui-widgets/src/lib.rs
+++ b/crates/flui-widgets/src/lib.rs
@@ -164,9 +164,11 @@ pub use interaction::{
     DragTargetDetails, DragTargetLeave, DragTargetMove, DragTargetState, DragTargetWillAccept,
     Draggable, DraggableDetails, DraggableState, ErasedDragData, ExcludeFocus, Focus,
     FocusChangeHandler, FocusScope, FocusScopeState, FocusState, GestureArenaScope,
-    GestureDetector, GestureDetectorState, IgnorePointer, Intent, Listener, MouseRegion,
-    NextFocusAction, NextFocusIntent, Offstage, PreviousFocusAction, PreviousFocusIntent,
-    ShortcutCallback, Shortcuts, SingleActivator, Visibility,
+    GestureDetector, GestureDetectorState, IgnorePointer, Intent, InteractionEndDetails,
+    InteractionStartDetails, InteractionUpdateDetails, InteractiveViewer, InteractiveViewerState,
+    Listener, MouseRegion, NextFocusAction, NextFocusIntent, Offstage, PanAxis,
+    PreviousFocusAction, PreviousFocusIntent, ShortcutCallback, Shortcuts, SingleActivator,
+    TransformationController, Visibility,
 };
 pub use layout::{
     Align, AspectRatio, Baseline, Center, ConstrainedBox, CustomMultiChildLayout,

--- a/crates/flui-widgets/tests/common/mod.rs
+++ b/crates/flui-widgets/tests/common/mod.rs
@@ -616,10 +616,20 @@ impl LaidOut {
         use flui_rendering::hit_testing::HitTestResult;
 
         let position = Offset::new(px(x), px(y));
-        let owner = self.pipeline_owner.read();
         let mut result = HitTestResult::new();
         self.binding.enter_owner_scope(|| {
-            owner.hit_test(position, &mut result);
+            // Scoped to the hit-test only: `dispatch` below can run
+            // gesture-callback code that itself acquires `pipeline_owner.read()`
+            // (e.g. a widget querying committed layout from inside its own
+            // pointer-signal/gesture handler). `parking_lot::RwLock` read locks
+            // are not safely reentrant on the same thread once a writer is
+            // queued — holding this guard across `dispatch` risks a
+            // same-thread self-deadlock that production avoids by dropping its
+            // own guard before dispatch.
+            {
+                let owner = self.pipeline_owner.read();
+                owner.hit_test(position, &mut result);
+            }
             result.dispatch(event);
         });
     }
@@ -635,14 +645,19 @@ impl LaidOut {
         use flui_rendering::hit_testing::HitTestResult;
 
         let position = Offset::new(px(x), px(y));
-        let owner = self.pipeline_owner.read();
         let mut result = HitTestResult::new();
         let event = flui_interaction::events::make_down_event(
             position,
             flui_interaction::events::PointerType::Mouse,
         );
         self.binding.enter_owner_scope(|| {
-            owner.hit_test(position, &mut result);
+            // See `route_event`'s comment: the read guard must not span
+            // `dispatch`, which can reenter `pipeline_owner.read()` from a
+            // gesture callback.
+            {
+                let owner = self.pipeline_owner.read();
+                owner.hit_test(position, &mut result);
+            }
             result.dispatch(&event);
         });
     }
@@ -653,14 +668,19 @@ impl LaidOut {
         use flui_rendering::hit_testing::HitTestResult;
 
         let position = Offset::new(px(x), px(y));
-        let owner = self.pipeline_owner.read();
         let mut result = HitTestResult::new();
         let event = flui_interaction::events::make_up_event(
             position,
             flui_interaction::events::PointerType::Mouse,
         );
         self.binding.enter_owner_scope(|| {
-            owner.hit_test(position, &mut result);
+            // See `route_event`'s comment: the read guard must not span
+            // `dispatch`, which can reenter `pipeline_owner.read()` from a
+            // gesture callback.
+            {
+                let owner = self.pipeline_owner.read();
+                owner.hit_test(position, &mut result);
+            }
             result.dispatch(&event);
         });
     }
@@ -670,14 +690,19 @@ impl LaidOut {
         use flui_rendering::hit_testing::HitTestResult;
 
         let position = Offset::new(px(x), px(y));
-        let owner = self.pipeline_owner.read();
         let mut result = HitTestResult::new();
         let event = flui_interaction::events::make_move_event(
             position,
             flui_interaction::events::PointerType::Mouse,
         );
         self.binding.enter_owner_scope(|| {
-            owner.hit_test(position, &mut result);
+            // See `route_event`'s comment: the read guard must not span
+            // `dispatch`, which can reenter `pipeline_owner.read()` from a
+            // gesture callback.
+            {
+                let owner = self.pipeline_owner.read();
+                owner.hit_test(position, &mut result);
+            }
             result.dispatch(&event);
         });
     }
@@ -688,13 +713,18 @@ impl LaidOut {
         use flui_rendering::hit_testing::HitTestResult;
 
         let position = Offset::new(px(x), px(y));
-        let owner = self.pipeline_owner.read();
         let mut result = HitTestResult::new();
         let event = flui_interaction::events::make_cancel_event(
             flui_interaction::events::PointerType::Mouse,
         );
         self.binding.enter_owner_scope(|| {
-            owner.hit_test(position, &mut result);
+            // See `route_event`'s comment: the read guard must not span
+            // `dispatch`, which can reenter `pipeline_owner.read()` from a
+            // gesture callback.
+            {
+                let owner = self.pipeline_owner.read();
+                owner.hit_test(position, &mut result);
+            }
             result.dispatch(&event);
         });
     }
@@ -708,7 +738,6 @@ impl LaidOut {
         use flui_rendering::hit_testing::HitTestResult;
 
         let position = Offset::new(px(x), px(y));
-        let owner = self.pipeline_owner.read();
         let mut result = HitTestResult::new();
         let event = flui_interaction::events::make_down_event_with_button(
             position,
@@ -716,7 +745,13 @@ impl LaidOut {
             PointerButton::Secondary,
         );
         self.binding.enter_owner_scope(|| {
-            owner.hit_test(position, &mut result);
+            // See `route_event`'s comment: the read guard must not span
+            // `dispatch`, which can reenter `pipeline_owner.read()` from a
+            // gesture callback.
+            {
+                let owner = self.pipeline_owner.read();
+                owner.hit_test(position, &mut result);
+            }
             result.dispatch(&event);
         });
     }
@@ -728,7 +763,6 @@ impl LaidOut {
         use flui_rendering::hit_testing::HitTestResult;
 
         let position = Offset::new(px(x), px(y));
-        let owner = self.pipeline_owner.read();
         let mut result = HitTestResult::new();
         let event = flui_interaction::events::make_up_event_with_button(
             position,
@@ -736,7 +770,13 @@ impl LaidOut {
             PointerButton::Secondary,
         );
         self.binding.enter_owner_scope(|| {
-            owner.hit_test(position, &mut result);
+            // See `route_event`'s comment: the read guard must not span
+            // `dispatch`, which can reenter `pipeline_owner.read()` from a
+            // gesture callback.
+            {
+                let owner = self.pipeline_owner.read();
+                owner.hit_test(position, &mut result);
+            }
             result.dispatch(&event);
         });
     }

--- a/crates/flui-widgets/tests/parity/interactive_viewer_test.rs
+++ b/crates/flui-widgets/tests/parity/interactive_viewer_test.rs
@@ -32,13 +32,14 @@
 //!   default, `trackpadScrollCausesScale`, and discrete
 //!   `PointerScaleEvent`/trackpad-gesture scaling are not ported.
 //!
-//! **13 tests ported below**, covering the portable core: pan translates the
+//! **16 tests ported below**, covering the portable core: pan translates the
 //! child (`pan_translates_child_by_the_drag_delta`), boundary clamp
 //! (`pan_clamps_at_the_boundary_edge`), an infinite margin removing the
 //! boundary (`infinite_boundary_margin_pans_without_clamping`), `pan_axis`
 //! locking (`pan_axis_horizontal_locks_out_vertical_movement`,
-//! `pan_axis_vertical_locks_out_horizontal_movement`), `pan_enabled: false`
-//! still firing callbacks without moving the transform
+//! `pan_axis_vertical_locks_out_horizontal_movement`,
+//! `pan_axis_aligned_locks_to_the_first_updates_dominant_axis_for_the_whole_gesture`),
+//! `pan_enabled: false` still firing callbacks without moving the transform
 //! (`pan_disabled_ignores_the_drag_but_still_fires_callbacks`), an external
 //! controller composing with a later gesture and notifying its own listener
 //! (`controller_driven_initial_value_composes_with_a_later_pan`), the wheel
@@ -47,14 +48,18 @@
 //! `scale_enabled: false` leaving the transform untouched while still firing
 //! callbacks (`wheel_scale_disabled_still_fires_callbacks_but_does_not_scale`),
 //! a scale-then-inverse-scale round trip returning to identity within
-//! floating-point tolerance (`wheel_scale_round_trips_back_to_identity`),
+//! floating-point tolerance (`wheel_scale_round_trips_back_to_identity`), the
+//! wheel path's off-center focal-point correction
+//! (`wheel_scale_keeps_the_scene_point_under_an_off_center_cursor_fixed`),
 //! `on_interaction_*` firing in start/update/end order for both the pan and
 //! wheel paths (`on_interaction_callbacks_fire_in_order_for_a_pan`,
-//! `on_interaction_callbacks_fire_in_order_for_a_wheel_scale`), and the
+//! `on_interaction_callbacks_fire_in_order_for_a_wheel_scale`), the
 //! `boundary_margin` mixed-finite/infinite precondition
-//! (`boundary_margin_mixing_finite_and_infinite_edges_is_rejected`).
+//! (`boundary_margin_mixing_finite_and_infinite_edges_is_rejected`), and
+//! unmounting unsubscribing from an external controller
+//! (`unmounting_the_widget_unsubscribes_from_an_external_controller`).
 //!
-//! None of the 13 corresponds 1:1 to a single named oracle `testWidgets` case
+//! None of the 16 corresponds 1:1 to a single named oracle `testWidgets` case
 //! (the oracle drives everything through `tester.pumpWidget` +
 //! `tester.startGesture`/`scrollAt`, which exercise pan and wheel together
 //! with the full `constrained: true` default this port also uses) — they are
@@ -74,6 +79,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use flui_geometry::Matrix4;
 use flui_interaction::events::make_scroll_event;
 use flui_types::{EdgeInsets, Offset, geometry::px};
+use flui_widgets::prelude::*;
 use flui_widgets::{
     InteractionEndDetails, InteractionStartDetails, InteractionUpdateDetails, InteractiveViewer,
     PanAxis, SizedBox, TransformationController,
@@ -494,4 +500,163 @@ fn boundary_margin_mixing_finite_and_infinite_edges_is_rejected() {
         left: px(10.0),
     };
     let _ = InteractiveViewer::new().boundary_margin(mixed);
+}
+
+// ============================================================================
+// Wheel focal-point correction (review finding 5a)
+// ============================================================================
+
+/// The wheel-scale path must keep the *same scene point* under the cursor
+/// before and after the zoom — Flutter parity: the `_receivedPointerSignal`
+/// mouse-wheel branch scales, then translates by exactly the shift the scale
+/// introduced at the focal point, cross-checked against the oracle's `'Can
+/// scale with mouse'` / `'onInteraction can be used to get scene point'`
+/// intent. A focal point at the widget's own center makes this correction a
+/// zero vector by symmetry, which is why an off-center focal point (`(50,
+/// 50)`, not the 200x200 widget's `(100, 100)` center) is required to
+/// exercise it at all: mutating the correction to `Offset::ZERO` passes
+/// every other test in this file but fails both assertions here.
+#[test]
+fn wheel_scale_keeps_the_scene_point_under_an_off_center_cursor_fixed() {
+    let controller = TransformationController::new();
+    let widget = InteractiveViewer::new()
+        .controller(controller.clone())
+        .boundary_margin(EdgeInsets::all(px(f32::INFINITY)))
+        .child(child());
+    let laid = lay_out(widget, loose(500.0));
+
+    let focal = Offset::new(px(50.0), px(50.0));
+    let scene_before = controller.to_scene(focal);
+
+    let event = make_scroll_event(focal, Offset::new(px(0.0), px(-20.0)));
+    laid.route_event(&event, 50.0, 50.0);
+
+    let (tx, ty, _) = controller.value().translation_component();
+    assert!(
+        tx != 0.0 || ty != 0.0,
+        "an off-center wheel-zoom must produce a compensating translation, not a pure \
+         scale-about-the-origin — a zeroed-out correction would leave the transform at \
+         (0.0, 0.0)"
+    );
+
+    let scene_after = controller.to_scene(focal);
+    assert!(
+        (scene_after.dx.get() - scene_before.dx.get()).abs() < 0.01,
+        "the scene point under the cursor must not drift on the x axis: before={scene_before:?} after={scene_after:?}"
+    );
+    assert!(
+        (scene_after.dy.get() - scene_before.dy.get()).abs() < 0.01,
+        "the scene point under the cursor must not drift on the y axis: before={scene_before:?} after={scene_after:?}"
+    );
+}
+
+// ============================================================================
+// PanAxis::Aligned (review finding 5b)
+// ============================================================================
+
+/// `PanAxis::Aligned` locks to whichever axis dominates the *first* update's
+/// cumulative movement from the drag's start position, and that lock holds
+/// for the rest of the gesture — even once a later update's own per-event
+/// delta leans the other way. Oracle group: `PanAxis.*`
+/// (`'PanAxis.aligned allows panning in one direction only...'`).
+#[test]
+fn pan_axis_aligned_locks_to_the_first_updates_dominant_axis_for_the_whole_gesture() {
+    let controller = TransformationController::new();
+    let widget = InteractiveViewer::new()
+        .controller(controller.clone())
+        .pan_axis(PanAxis::Aligned)
+        .boundary_margin(EdgeInsets::all(px(f32::INFINITY)))
+        .child(child());
+    let scoped = lay_out_with_arena(widget, loose(500.0));
+
+    scoped.dispatch_pointer_down(50.0, 50.0);
+    scoped.dispatch_pointer_move(110.0, 50.0); // +60,0: crosses slop, starts (start_local = (110, 50))
+    // Update 1: cumulative movement from start = (50, 10) -> x dominates -> locks Horizontal.
+    // This update's own per-event delta is (50, 10) -> aligned to (50, 0).
+    scoped.dispatch_pointer_move(160.0, 60.0);
+    // Update 2: per-event delta (-40, 80) is mostly VERTICAL, but the axis lock from
+    // update 1 must still force it to (-40, 0) — that's the behavior this test pins.
+    scoped.dispatch_pointer_move(120.0, 140.0);
+    scoped.dispatch_pointer_up(120.0, 140.0);
+
+    let (tx, ty, _) = controller.value().translation_component();
+    assert_eq!(
+        tx, 10.0,
+        "locked to horizontal: +50 (update 1) + -40 (update 2) = 10"
+    );
+    assert_eq!(
+        ty, 0.0,
+        "vertical must stay locked out for the whole gesture, even though update 2's own \
+         raw delta was mostly vertical"
+    );
+}
+
+// ============================================================================
+// Controller disposal (review finding 5c)
+// ============================================================================
+
+/// A stable root TYPE that toggles its shape internally — `pump_widget`
+/// dispatches by `TypeId`, so swapping between two *different* concrete root
+/// widget types is not the supported way to unmount a subtree (see
+/// `LaidOut::pump_widget`'s doc, and `focus_test.rs`'s
+/// `nodes_are_removed_when_all_focuses_are_removed` for the same pattern);
+/// `show` is.
+#[derive(Clone, StatelessView)]
+struct InteractiveViewerHost {
+    controller: TransformationController,
+    show: bool,
+}
+
+impl StatelessView for InteractiveViewerHost {
+    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+        if !self.show {
+            return SizedBox::new(1.0, 1.0).into_view().boxed();
+        }
+        InteractiveViewer::new()
+            .controller(self.controller.clone())
+            .child(child())
+            .into_view()
+            .boxed()
+    }
+}
+
+/// Unmounting `InteractiveViewer` must remove its `AnimatedBuilder`
+/// subscription from an externally supplied `TransformationController` — a
+/// dangling listener would keep firing into a torn-down subtree (and would
+/// keep the controller from ever reporting itself listener-free, which
+/// matters to a caller that wants to know it is safe to drop).
+///
+/// Uses plain `lay_out`/`LaidOut::pump_widget`, not
+/// `lay_out_with_arena`/`LaidOutScoped`: the latter mounts the root wrapped
+/// in a `GestureArenaScope`, so `LaidOutScoped::pump_widget(new_root)` would
+/// itself swap the *actual* mounted root from `GestureArenaScope<Host>` to a
+/// bare `Host` — the exact unsupported different-root-type swap
+/// `InteractiveViewerHost`'s own doc warns about, one level further out. This
+/// test dispatches no pointer events, so it does not need the arena.
+#[test]
+fn unmounting_the_widget_unsubscribes_from_an_external_controller() {
+    let controller = TransformationController::new();
+    let mut laid = lay_out(
+        InteractiveViewerHost {
+            controller: controller.clone(),
+            show: true,
+        },
+        loose(500.0),
+    );
+
+    assert!(
+        controller.has_listeners(),
+        "mounting must subscribe to the externally supplied controller"
+    );
+
+    laid.pump_widget(InteractiveViewerHost {
+        controller: controller.clone(),
+        show: false,
+    });
+
+    assert!(
+        !controller.has_listeners(),
+        "unmounting must remove the subscription — a leaked listener would keep this true \
+         forever, even though nothing is mounted against the controller anymore"
+    );
 }

--- a/crates/flui-widgets/tests/parity/interactive_viewer_test.rs
+++ b/crates/flui-widgets/tests/parity/interactive_viewer_test.rs
@@ -1,0 +1,497 @@
+//! Flutter parity tests — `InteractiveViewer`.
+//!
+//! Flutter source: `packages/flutter/test/widgets/interactive_viewer_test.dart`
+//! (tag `3.44.0`, **40** `testWidgets` cases —
+//! `grep -cE '^\s*testWidgets\(' interactive_viewer_test.dart`).
+//!
+//! ## Scope of this port
+//!
+//! `crates/flui-widgets/src/interaction/interactive_viewer.rs`'s module docs
+//! record the exact V1 boundary; the short version, so the denominator below
+//! is honest:
+//!
+//! - **Pan** is a genuine single-pointer drag, dispatched through the real
+//!   gesture arena (`LaidOutScoped::dispatch_pointer_*`), slop and all.
+//! - **Scale** is wired through mouse-wheel scroll only
+//!   (`Listener::on_pointer_signal`, dispatched with a real
+//!   `PointerEvent::Scroll` via `LaidOut::route_event`) — the wheel branch of
+//!   the oracle's `_receivedPointerSignal`.
+//! - **Pinch-to-zoom / two-finger rotation are out of scope**: FLUI's
+//!   `GestureDetector` has no combined scale/rotate recognizer yet (a
+//!   framework gap, not a harness one — see the widget module's docs). Every
+//!   oracle case built on `tester.createGesture()` × 2 (pinch, rotate,
+//!   two-finger "child bigger than viewport" checks) has no analogue here.
+//! - **`constrained: false`** is deferred (no `OverflowBox`-equivalent
+//!   wiring yet); every oracle case that depends on it (`'child bigger than
+//!   viewport'`, `'child has no dimensions'`, `'Scaling amount is equal
+//!   forth and back...'`'s literal `constrained: false`, `'builder can
+//!   change widgets that are off-screen'`, the `.builder` constructor
+//!   entirely) is out of scope. This port only exercises the `child:`
+//!   constructor.
+//! - Inertia/fling after a pan release, `alignment`, `scaleFactor` beyond the
+//!   default, `trackpadScrollCausesScale`, and discrete
+//!   `PointerScaleEvent`/trackpad-gesture scaling are not ported.
+//!
+//! **13 tests ported below**, covering the portable core: pan translates the
+//! child (`pan_translates_child_by_the_drag_delta`), boundary clamp
+//! (`pan_clamps_at_the_boundary_edge`), an infinite margin removing the
+//! boundary (`infinite_boundary_margin_pans_without_clamping`), `pan_axis`
+//! locking (`pan_axis_horizontal_locks_out_vertical_movement`,
+//! `pan_axis_vertical_locks_out_horizontal_movement`), `pan_enabled: false`
+//! still firing callbacks without moving the transform
+//! (`pan_disabled_ignores_the_drag_but_still_fires_callbacks`), an external
+//! controller composing with a later gesture and notifying its own listener
+//! (`controller_driven_initial_value_composes_with_a_later_pan`), the wheel
+//! path's `min_scale`/`max_scale` clamp
+//! (`wheel_scale_is_clamped_to_a_fixed_min_and_max_scale`),
+//! `scale_enabled: false` leaving the transform untouched while still firing
+//! callbacks (`wheel_scale_disabled_still_fires_callbacks_but_does_not_scale`),
+//! a scale-then-inverse-scale round trip returning to identity within
+//! floating-point tolerance (`wheel_scale_round_trips_back_to_identity`),
+//! `on_interaction_*` firing in start/update/end order for both the pan and
+//! wheel paths (`on_interaction_callbacks_fire_in_order_for_a_pan`,
+//! `on_interaction_callbacks_fire_in_order_for_a_wheel_scale`), and the
+//! `boundary_margin` mixed-finite/infinite precondition
+//! (`boundary_margin_mixing_finite_and_infinite_edges_is_rejected`).
+//!
+//! None of the 13 corresponds 1:1 to a single named oracle `testWidgets` case
+//! (the oracle drives everything through `tester.pumpWidget` +
+//! `tester.startGesture`/`scrollAt`, which exercise pan and wheel together
+//! with the full `constrained: true` default this port also uses) — they are
+//! written directly against this port's real gesture/wheel paths and the
+//! same boundary-clamp/scale-clamp contract the oracle's
+//! `_matrixTranslate`/`_matrixScale` encode, cross-checked against the
+//! oracle's `'boundary slightly bigger than child'` (clamp), `'no boundary'`
+//! (infinite margin), `'Can scale with mouse'` / `'Cannot scale with mouse
+//! when scale is disabled'` / `'Scale with mouse returns onInteraction
+//! properties'` / `'Scaling amount is equal forth and back with a mouse
+//! scroll'` (the four wheel-scale cases), and the `PanAxis.*` group.
+
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use flui_geometry::Matrix4;
+use flui_interaction::events::make_scroll_event;
+use flui_types::{EdgeInsets, Offset, geometry::px};
+use flui_widgets::{
+    InteractionEndDetails, InteractionStartDetails, InteractionUpdateDetails, InteractiveViewer,
+    PanAxis, SizedBox, TransformationController,
+};
+
+use crate::common::{lay_out, lay_out_with_arena, loose};
+
+/// A 200x200 child under loose (up-to-500px) constraints: the child settles
+/// at its own preferred 200x200 size, and — because `InteractiveViewer`'s
+/// proxy chain is layout-transparent under `constrained: true` (V1's only
+/// mode, see the widget's module docs) — that is also the viewport size.
+fn child() -> SizedBox {
+    SizedBox::new(200.0, 200.0)
+}
+
+/// The uniform scale factor of a matrix built solely from translation +
+/// scale (no rotation, matching every matrix `InteractiveViewer` produces):
+/// `m[0]` is exactly the x-scale.
+fn scale_of(matrix: Matrix4) -> f32 {
+    matrix.to_col_major_array()[0]
+}
+
+// ============================================================================
+// Pan
+// ============================================================================
+
+/// Down, a slop-crossing move (recognized as the drag start — no delta
+/// reported for it, matching `DragGestureRecognizer`'s `dragStartBehavior:
+/// Start` default, see `draggable_test.rs`'s
+/// `drag_update_reports_delta_after_start`), then a second move whose raw
+/// delta is what `on_pan_update` reports and what this widget applies.
+#[test]
+fn pan_translates_child_by_the_drag_delta() {
+    let controller = TransformationController::new();
+    let widget = InteractiveViewer::new()
+        .controller(controller.clone())
+        .boundary_margin(EdgeInsets::all(px(f32::INFINITY)))
+        .child(child());
+    let scoped = lay_out_with_arena(widget, loose(500.0));
+
+    scoped.dispatch_pointer_down(50.0, 50.0);
+    scoped.dispatch_pointer_move(100.0, 50.0); // +50px: crosses slop, starts
+    scoped.dispatch_pointer_move(140.0, 50.0); // +40px: the reported update
+    scoped.dispatch_pointer_up(140.0, 50.0);
+
+    let (tx, ty, _) = controller.value().translation_component();
+    assert_eq!(
+        tx, 40.0,
+        "the second move's raw +40px delta must apply exactly"
+    );
+    assert_eq!(ty, 0.0);
+}
+
+/// Child 200x200, `boundary_margin: 10` on every edge, so the boundary is
+/// 220x220 — 10px of slack past the (loose, so viewport == child) 200x200
+/// viewport on each side. A drag attempting -60px must clamp to exactly
+/// -10px, the same boundary-clamp arithmetic as the oracle's `'boundary
+/// slightly bigger than child'` (`translation.x == -boundaryMargin`).
+#[test]
+fn pan_clamps_at_the_boundary_edge() {
+    let controller = TransformationController::new();
+    let widget = InteractiveViewer::new()
+        .controller(controller.clone())
+        .boundary_margin(EdgeInsets::all(px(10.0)))
+        .child(child());
+    let scoped = lay_out_with_arena(widget, loose(500.0));
+
+    scoped.dispatch_pointer_down(150.0, 100.0);
+    scoped.dispatch_pointer_move(90.0, 100.0); // -60px: crosses slop, starts
+    scoped.dispatch_pointer_move(30.0, 100.0); // -60px: the reported update
+    scoped.dispatch_pointer_up(30.0, 100.0);
+
+    let (tx, ty, _) = controller.value().translation_component();
+    assert_eq!(tx, -10.0, "must clamp to exactly -boundary_margin (-10.0)");
+    assert_eq!(ty, 0.0);
+}
+
+/// `EdgeInsets::all(f32::INFINITY)` removes the boundary entirely. The exact
+/// same -60px drag [`pan_clamps_at_the_boundary_edge`] clamps to -10px with a
+/// 10px margin must apply in full here — a direct, same-magnitude contrast
+/// against that test. Oracle: `'no boundary'`.
+#[test]
+fn infinite_boundary_margin_pans_without_clamping() {
+    let controller = TransformationController::new();
+    let widget = InteractiveViewer::new()
+        .controller(controller.clone())
+        .boundary_margin(EdgeInsets::all(px(f32::INFINITY)))
+        .child(child());
+    let scoped = lay_out_with_arena(widget, loose(500.0));
+
+    scoped.dispatch_pointer_down(150.0, 100.0);
+    scoped.dispatch_pointer_move(90.0, 100.0); // -60px: crosses slop, starts
+    scoped.dispatch_pointer_move(30.0, 100.0); // -60px: the reported update
+    scoped.dispatch_pointer_up(30.0, 100.0);
+
+    let (tx, ty, _) = controller.value().translation_component();
+    assert_eq!(
+        tx, -60.0,
+        "an infinite margin must never clamp — contrast with pan_clamps_at_the_boundary_edge's -10.0"
+    );
+    assert_eq!(ty, 0.0);
+}
+
+/// `PanAxis::Horizontal` zeroes the vertical component of every update,
+/// regardless of the drag's own direction. Oracle group: `PanAxis.*`.
+#[test]
+fn pan_axis_horizontal_locks_out_vertical_movement() {
+    let controller = TransformationController::new();
+    let widget = InteractiveViewer::new()
+        .controller(controller.clone())
+        .pan_axis(PanAxis::Horizontal)
+        .boundary_margin(EdgeInsets::all(px(f32::INFINITY)))
+        .child(child());
+    let scoped = lay_out_with_arena(widget, loose(500.0));
+
+    scoped.dispatch_pointer_down(100.0, 100.0);
+    scoped.dispatch_pointer_move(150.0, 140.0); // +50,+40: crosses slop, starts
+    scoped.dispatch_pointer_move(190.0, 180.0); // +40,+40: the reported update
+    scoped.dispatch_pointer_up(190.0, 180.0);
+
+    let (tx, ty, _) = controller.value().translation_component();
+    assert_eq!(tx, 40.0, "horizontal component must still apply");
+    assert_eq!(ty, 0.0, "vertical component must be locked out entirely");
+}
+
+/// `PanAxis::Vertical` is `Horizontal`'s mirror image.
+#[test]
+fn pan_axis_vertical_locks_out_horizontal_movement() {
+    let controller = TransformationController::new();
+    let widget = InteractiveViewer::new()
+        .controller(controller.clone())
+        .pan_axis(PanAxis::Vertical)
+        .boundary_margin(EdgeInsets::all(px(f32::INFINITY)))
+        .child(child());
+    let scoped = lay_out_with_arena(widget, loose(500.0));
+
+    scoped.dispatch_pointer_down(100.0, 100.0);
+    scoped.dispatch_pointer_move(150.0, 140.0); // +50,+40: crosses slop, starts
+    scoped.dispatch_pointer_move(190.0, 180.0); // +40,+40: the reported update
+    scoped.dispatch_pointer_up(190.0, 180.0);
+
+    let (tx, ty, _) = controller.value().translation_component();
+    assert_eq!(tx, 0.0, "horizontal component must be locked out entirely");
+    assert_eq!(ty, 40.0, "vertical component must still apply");
+}
+
+/// `pan_enabled: false` must never move the transform, but
+/// `on_interaction_*` still fires — Flutter's documented "will be called
+/// even if the interaction is disabled" contract (`InteractiveViewer`'s
+/// `onInteractionEnd` doc, `{@template
+/// flutter.widgets.InteractiveViewer.onInteractionEnd}`).
+#[test]
+fn pan_disabled_ignores_the_drag_but_still_fires_callbacks() {
+    let controller = TransformationController::new();
+    let updates = Arc::new(AtomicUsize::new(0));
+    let updates_cb = Arc::clone(&updates);
+    let widget = InteractiveViewer::new()
+        .controller(controller.clone())
+        .pan_enabled(false)
+        .boundary_margin(EdgeInsets::all(px(f32::INFINITY)))
+        .on_interaction_update(move |_details| {
+            updates_cb.fetch_add(1, Ordering::SeqCst);
+        })
+        .child(child());
+    let scoped = lay_out_with_arena(widget, loose(500.0));
+
+    scoped.dispatch_pointer_down(150.0, 100.0);
+    scoped.dispatch_pointer_move(90.0, 100.0); // crosses slop, starts
+    scoped.dispatch_pointer_move(30.0, 100.0); // the reported update
+    scoped.dispatch_pointer_up(30.0, 100.0);
+
+    assert_eq!(
+        controller.value().m,
+        Matrix4::identity().m,
+        "pan_enabled: false must leave the transform untouched"
+    );
+    assert_eq!(
+        updates.load(Ordering::SeqCst),
+        1,
+        "on_interaction_update must still fire exactly once for the real update"
+    );
+}
+
+// ============================================================================
+// Controller
+// ============================================================================
+
+/// An externally supplied `TransformationController` seeded with a
+/// translation before mount composes with a *later* gesture-driven pan
+/// (proving the widget reads and writes through the caller's controller,
+/// not an internally created one — if it used its own, the gesture would
+/// start from identity and this would read `40.0`, not `60.0`), and the
+/// gesture's `set_value` call notifies the caller's own listener on that
+/// same controller.
+#[test]
+fn controller_driven_initial_value_composes_with_a_later_pan() {
+    let controller = TransformationController::new();
+    controller.set_value(Matrix4::translation(20.0, 0.0, 0.0));
+
+    let notified = Arc::new(AtomicUsize::new(0));
+    let notified_cb = Arc::clone(&notified);
+    controller.as_listenable().add_listener(Arc::new(move || {
+        notified_cb.fetch_add(1, Ordering::SeqCst);
+    }));
+
+    let widget = InteractiveViewer::new()
+        .controller(controller.clone())
+        .boundary_margin(EdgeInsets::all(px(f32::INFINITY)))
+        .child(child());
+    let scoped = lay_out_with_arena(widget, loose(500.0));
+
+    scoped.dispatch_pointer_down(50.0, 50.0);
+    scoped.dispatch_pointer_move(100.0, 50.0); // crosses slop, starts
+    scoped.dispatch_pointer_move(140.0, 50.0); // +40px update
+    scoped.dispatch_pointer_up(140.0, 50.0);
+
+    let (tx, _, _) = controller.value().translation_component();
+    assert_eq!(
+        tx, 60.0,
+        "the gesture's +40px must compose on top of the externally seeded +20px"
+    );
+    assert!(
+        notified.load(Ordering::SeqCst) >= 1,
+        "the gesture-driven set_value must notify the externally supplied controller's own listener"
+    );
+}
+
+// ============================================================================
+// Wheel scale
+// ============================================================================
+
+/// `min_scale == max_scale == 1.0` pins the scale exactly — a mouse-wheel
+/// scroll (which would otherwise scale up) must be clamped back to 1.0,
+/// leaving the transform at the identity. Oracle: the boundary-floor /
+/// min-max clamp `_matrixScale` applies, exercised through `'Can scale with
+/// mouse'`'s wheel path.
+#[test]
+fn wheel_scale_is_clamped_to_a_fixed_min_and_max_scale() {
+    let controller = TransformationController::new();
+    let widget = InteractiveViewer::new()
+        .controller(controller.clone())
+        .min_scale(1.0)
+        .max_scale(1.0)
+        .child(child());
+    let laid = lay_out(widget, loose(500.0));
+
+    let position = Offset::new(px(100.0), px(100.0));
+    let event = make_scroll_event(position, Offset::new(px(0.0), px(-20.0)));
+    laid.route_event(&event, 100.0, 100.0);
+
+    assert_eq!(
+        controller.value().m,
+        Matrix4::identity().m,
+        "min_scale == max_scale == 1.0 must clamp every wheel scroll back to identity"
+    );
+}
+
+/// `scale_enabled: false` must never change the transform, but
+/// `on_interaction_*` still fires (same Flutter contract as
+/// `pan_disabled_ignores_the_drag_but_still_fires_callbacks`). Oracle:
+/// `'Cannot scale with mouse when scale is disabled'`.
+#[test]
+fn wheel_scale_disabled_still_fires_callbacks_but_does_not_scale() {
+    let controller = TransformationController::new();
+    let starts = Arc::new(AtomicUsize::new(0));
+    let starts_cb = Arc::clone(&starts);
+    let widget = InteractiveViewer::new()
+        .controller(controller.clone())
+        .scale_enabled(false)
+        .on_interaction_start(move |_details| {
+            starts_cb.fetch_add(1, Ordering::SeqCst);
+        })
+        .child(child());
+    let laid = lay_out(widget, loose(500.0));
+
+    let position = Offset::new(px(100.0), px(100.0));
+    let event = make_scroll_event(position, Offset::new(px(0.0), px(-20.0)));
+    laid.route_event(&event, 100.0, 100.0);
+
+    assert_eq!(controller.value().m, Matrix4::identity().m);
+    assert_eq!(
+        starts.load(Ordering::SeqCst),
+        1,
+        "on_interaction_start must still fire once even though scale_enabled is false"
+    );
+}
+
+/// Scaling up then back down by the same wheel-scroll magnitude, with an
+/// infinite `boundary_margin` (removing the `min_scale`-below-1.0 floor a
+/// zero margin otherwise imposes — see the widget's `min_scale` doc), must
+/// return the scale to `1.0` within floating-point tolerance. Oracle:
+/// `'Scaling amount is equal forth and back with a mouse scroll'` — ported
+/// with an epsilon here (not exact) because `exp`/its floating-point inverse
+/// do not round-trip bit-for-bit, exactly as the oracle's own assertion
+/// needs `closeTo` for the same reason.
+#[test]
+fn wheel_scale_round_trips_back_to_identity() {
+    let controller = TransformationController::new();
+    let widget = InteractiveViewer::new()
+        .controller(controller.clone())
+        .boundary_margin(EdgeInsets::all(px(f32::INFINITY)))
+        .min_scale(0.01)
+        .max_scale(100_000.0)
+        .child(child());
+    let laid = lay_out(widget, loose(500.0));
+
+    let position = Offset::new(px(100.0), px(100.0));
+    let zoom_in = make_scroll_event(position, Offset::new(px(0.0), px(-200.0)));
+    let zoom_out = make_scroll_event(position, Offset::new(px(0.0), px(200.0)));
+
+    laid.route_event(&zoom_in, 100.0, 100.0);
+    let after_one_zoom_in = scale_of(controller.value());
+    assert!(
+        (after_one_zoom_in - std::f32::consts::E).abs() < 1e-3,
+        "expected scale ~= e^1, got {after_one_zoom_in}"
+    );
+
+    laid.route_event(&zoom_out, 100.0, 100.0);
+    let after_round_trip = scale_of(controller.value());
+    assert!(
+        (after_round_trip - 1.0).abs() < 1e-4,
+        "scale must round-trip back to ~1.0, got {after_round_trip}"
+    );
+}
+
+// ============================================================================
+// Callback ordering
+// ============================================================================
+
+/// `on_interaction_start`/`_update`/`_end` must fire in exactly that order
+/// for a pan gesture — one start (at slop-crossing), one update (the second
+/// move), one end (the release).
+#[test]
+fn on_interaction_callbacks_fire_in_order_for_a_pan() {
+    let order: Arc<StdMutex<Vec<&'static str>>> = Arc::new(StdMutex::new(Vec::new()));
+    let order_start = Arc::clone(&order);
+    let order_update = Arc::clone(&order);
+    let order_end = Arc::clone(&order);
+
+    let widget = InteractiveViewer::new()
+        .boundary_margin(EdgeInsets::all(px(f32::INFINITY)))
+        .on_interaction_start(move |_: InteractionStartDetails| {
+            order_start.lock().expect("not poisoned").push("start");
+        })
+        .on_interaction_update(move |_: InteractionUpdateDetails| {
+            order_update.lock().expect("not poisoned").push("update");
+        })
+        .on_interaction_end(move |_: InteractionEndDetails| {
+            order_end.lock().expect("not poisoned").push("end");
+        })
+        .child(child());
+    let scoped = lay_out_with_arena(widget, loose(500.0));
+
+    scoped.dispatch_pointer_down(50.0, 50.0);
+    scoped.dispatch_pointer_move(100.0, 50.0); // crosses slop: on_interaction_start
+    scoped.dispatch_pointer_move(140.0, 50.0); // the update: on_interaction_update
+    scoped.dispatch_pointer_up(140.0, 50.0); // on_interaction_end
+
+    assert_eq!(
+        *order.lock().expect("not poisoned"),
+        vec!["start", "update", "end"],
+        "callbacks must fire in exactly start, update, end order"
+    );
+}
+
+/// The same order contract for the discrete wheel path — a single scroll
+/// event fires start, then update, then end (Flutter parity:
+/// `_receivedPointerSignal`'s mouse-wheel branch treats one wheel tick as a
+/// complete, instantaneous interaction).
+#[test]
+fn on_interaction_callbacks_fire_in_order_for_a_wheel_scale() {
+    let order: Arc<StdMutex<Vec<&'static str>>> = Arc::new(StdMutex::new(Vec::new()));
+    let order_start = Arc::clone(&order);
+    let order_update = Arc::clone(&order);
+    let order_end = Arc::clone(&order);
+
+    let widget = InteractiveViewer::new()
+        .on_interaction_start(move |_: InteractionStartDetails| {
+            order_start.lock().expect("not poisoned").push("start");
+        })
+        .on_interaction_update(move |_: InteractionUpdateDetails| {
+            order_update.lock().expect("not poisoned").push("update");
+        })
+        .on_interaction_end(move |_: InteractionEndDetails| {
+            order_end.lock().expect("not poisoned").push("end");
+        })
+        .child(child());
+    let laid = lay_out(widget, loose(500.0));
+
+    let position = Offset::new(px(100.0), px(100.0));
+    let event = make_scroll_event(position, Offset::new(px(0.0), px(-20.0)));
+    laid.route_event(&event, 100.0, 100.0);
+
+    assert_eq!(
+        *order.lock().expect("not poisoned"),
+        vec!["start", "update", "end"],
+        "the wheel path must fire callbacks in exactly start, update, end order"
+    );
+}
+
+// ============================================================================
+// Precondition
+// ============================================================================
+
+/// `boundary_margin` must be either fully finite or fully infinite on all
+/// four edges — Flutter's own constructor `assert`, which (like all Dart
+/// `assert`s) is debug-only; this port's `debug_assert!` mirrors that
+/// exactly. Oracle: the constructor assert backing every finite-margin test
+/// (e.g. `'boundary slightly bigger than child'`) and every infinite-margin
+/// test (`'no boundary'`).
+#[test]
+#[should_panic(expected = "boundary_margin must be either fully finite or fully infinite")]
+fn boundary_margin_mixing_finite_and_infinite_edges_is_rejected() {
+    let mixed = EdgeInsets {
+        top: px(10.0),
+        right: px(f32::INFINITY),
+        bottom: px(10.0),
+        left: px(10.0),
+    };
+    let _ = InteractiveViewer::new().boundary_margin(mixed);
+}

--- a/crates/flui-widgets/tests/parity/interactive_viewer_test.rs
+++ b/crates/flui-widgets/tests/parity/interactive_viewer_test.rs
@@ -503,7 +503,7 @@ fn boundary_margin_mixing_finite_and_infinite_edges_is_rejected() {
 }
 
 // ============================================================================
-// Wheel focal-point correction (review finding 5a)
+// Wheel focal-point correction
 // ============================================================================
 
 /// The wheel-scale path must keep the *same scene point* under the cursor
@@ -551,7 +551,7 @@ fn wheel_scale_keeps_the_scene_point_under_an_off_center_cursor_fixed() {
 }
 
 // ============================================================================
-// PanAxis::Aligned (review finding 5b)
+// PanAxis::Aligned
 // ============================================================================
 
 /// `PanAxis::Aligned` locks to whichever axis dominates the *first* update's
@@ -592,7 +592,7 @@ fn pan_axis_aligned_locks_to_the_first_updates_dominant_axis_for_the_whole_gestu
 }
 
 // ============================================================================
-// Controller disposal (review finding 5c)
+// Controller disposal
 // ============================================================================
 
 /// A stable root TYPE that toggles its shape internally — `pump_widget`

--- a/crates/flui-widgets/tests/parity/main.rs
+++ b/crates/flui-widgets/tests/parity/main.rs
@@ -110,3 +110,6 @@ mod dismissible_test;
 
 // ── Business.1 implementation-gated fidelity unit — Draggable/DragTarget ────
 mod draggable_test;
+
+// ── Business.1 implementation-gated fidelity unit — InteractiveViewer ───────
+mod interactive_viewer_test;


### PR DESCRIPTION
Business.1 implementation-gated fidelity unit: `InteractiveViewer` + `TransformationController` land in `flui-widgets` with a 16-case parity corpus against `interactive_viewer.dart` / `interactive_viewer_test.dart` @ 3.44.0 (40-case denominator fully accounted).

## What

- **Pan/zoom through a transformation matrix**: single-pointer pan via the gesture arena; mouse-wheel zoom via pointer signals (`exp(-dy/scale_factor)`, the oracle's math) with the focal-point correction keeping the scene point under the cursor fixed (mutation-pinned); `min_scale`/`max_scale` clamps; `boundary_margin` containment with infinite-margin freedom; `PanAxis` locking incl. `Aligned`'s first-update dominant-axis lock; `pan_enabled`/`scale_enabled` (disabled still fires callbacks, per the oracle); `on_interaction_*` ordering.
- **Boundary math ported honestly**: the oracle's `Quad`/AABB machinery specializes to plain rect containment because upstream hardcodes `_rotateEnabled = false` (verified) — and the review caught that the port dropped the oracle's `_round` epsilon guard, so at non-unit scale every boundary hit snapped the translation to origin (f32 residuals failing an exact zero-compare). Fixed with an epsilon guard at all three comparison points, pinned by a non-unit-scale regression test (expected −398.02, the bug gave 0).
- **`TransformationController`**: the `ScrollController` shape; unclamped `set_value` (oracle parity — the widget clamps, not the controller); ptr-eq-stable listenable; unmount unsubscribes (registration-count-tested). `clamp` replaced with Dart's non-panicking min-priority `clampDouble` semantics (the std `f32::clamp` panics in release on a pathological min>max config).
- Harness hardening: the pointer-dispatch helpers no longer hold the pipeline-owner read guard across dispatch (same-thread recursive-read deadlock hazard; production scopes its guard first).

## Named deferrals

Pinch-to-zoom/rotation (`GestureDetector` has no scale recognizer — framework gap), `constrained: false`, inertia/fling after release.

## Evidence

- flui-widgets: 1346 passed; workspace: 7712 passed (the one red is a concurrent session's uncommitted FAB edit, outside this diff); clippy `-D warnings`, fmt/port-check/inventory/taplo/typos, doctests: clean.
- Reviewer ran 6 mutants across two rounds (translation clamp, scale clamp, axis lock, focal correction, epsilon revert) — all killed; the boundary clamp hand-computed; the `_rotateEnabled` specialization claim verified in the oracle.
- Full review + delta re-review: SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)