### PR TITLE
feat(widgets,rendering): scroll metrics snapshot + dimension-change policy (paging PR1)

### DIFF
--- a/crates/flui-rendering/src/view/mod.rs
+++ b/crates/flui-rendering/src/view/mod.rs
@@ -29,7 +29,7 @@ mod viewport_offset;
 
 pub use configuration::ViewConfiguration;
 pub use render_view::{CompositeResult, RenderView, RenderViewAdapter};
-pub use scroll_position::ScrollPosition;
+pub use scroll_position::{DimensionChangePolicy, ScrollPosition, ScrollPositionSnapshot};
 pub use viewport::{CacheExtentStyle, RenderAbstractViewport, RevealedOffset, SliverPaintOrder};
 pub use viewport_offset::{
     FixedViewportOffset, ScrollDirection, ScrollableViewportOffset, ViewportOffset,

--- a/crates/flui-rendering/src/view/scroll_position.rs
+++ b/crates/flui-rendering/src/view/scroll_position.rs
@@ -42,6 +42,24 @@ struct State {
     /// policy read and the recompute it drives happen under the one lock
     /// acquisition `apply_viewport_dimension` already takes.
     dimension_policy: DimensionChangePolicy,
+    /// Whether `apply_viewport_dimension` has ever committed a real
+    /// dimension. Distinguishes "never laid out" from "laid out at literal
+    /// `0.0`" — mirrors Flutter's `hasViewportDimension` (`this.viewportDimension`
+    /// vs. `null` in `_PagePosition.applyViewportDimension`). The very first
+    /// call must not run the `KeepFractionalPage` recompute: there is no
+    /// prior dimension to divide by, so treating `viewport_dimension: 0.0`'s
+    /// initial value as a real "old dimension" would reinterpret whatever
+    /// pixels were seeded before layout (e.g. `ScrollPosition::new`) as a
+    /// page count instead of a pixel offset.
+    has_applied_viewport_dimension: bool,
+    /// The fractional page cached by `KeepFractionalPage` whenever a resize
+    /// collapses the viewport to a `0.0` dimension. Mirrors
+    /// `_PagePosition._cachedPage`: while the dimension is `0.0`, `pixels`
+    /// itself is set to `0.0` (there is no viewport to derive a pixel offset
+    /// against), so the page must live in a separate field — one a
+    /// concurrent `apply_content_dimensions` clamp on `pixels` cannot
+    /// corrupt — until the viewport resizes back to a real dimension.
+    cached_page: Option<f32>,
 }
 
 impl State {
@@ -52,7 +70,38 @@ impl State {
             max_scroll_extent: 0.0,
             viewport_dimension: 0.0,
             dimension_policy: DimensionChangePolicy::KeepPixels,
+            has_applied_viewport_dimension: false,
+            cached_page: None,
         }
+    }
+}
+
+/// Floating-point tolerance for snapping a recomputed fractional page back to
+/// the nearest whole page when the value "should" have landed exactly on one.
+///
+/// # Flutter parity
+///
+/// Mirrors `_PagePosition.getPageFromPixels`'s round-snap against
+/// `precisionErrorTolerance` (`widgets/page_view.dart`, tag `3.44.0`): a
+/// `pixels / (dimension * fraction)` division should exactly reconstruct an
+/// integral page when the pixels were originally seeded from `page *
+/// dimension * fraction`, but float rounding leaves residue. Flutter's
+/// `precisionErrorTolerance` is `1e-10`, sized for `f64`; `f32` carries far
+/// fewer significant digits, so that fixed tolerance doesn't transfer
+/// numerically — same reasoning `EXCESS_EPSILON` documents in
+/// `interaction/interactive_viewer.rs`. Chosen against the scale of a page
+/// count (small integers, typically single digits to low hundreds) rather
+/// than absolute machine epsilon.
+const PAGE_ROUND_EPSILON: f32 = 1e-4;
+
+/// Snaps `page` to the nearest whole page when within [`PAGE_ROUND_EPSILON`]
+/// of one; otherwise returns it unchanged.
+fn round_snap_page(page: f32) -> f32 {
+    let rounded = page.round();
+    if (page - rounded).abs() < PAGE_ROUND_EPSILON {
+        rounded
+    } else {
+        page
     }
 }
 
@@ -87,7 +136,39 @@ pub struct ScrollPositionSnapshot {
 /// performs in `widgets/page_view.dart` (tag `3.44.0`) so the same logical
 /// page stays in view across a viewport resize. Ported here as a general
 /// policy on the plain `ScrollPosition` (rather than bolted onto a future
-/// `PageView`-only type) so any scrollable can opt in.
+/// `PageView`-only type) so any scrollable can opt in. The oracle branches
+/// three ways on the *old* dimension: never established (`null`) uses
+/// `_pageToUseOnStartup`; collapsed to `0.0` reads `_cachedPage`; anything
+/// else recomputes via `getPageFromPixels`/`getPixelsFromPage`. See
+/// [`ScrollPosition::apply_viewport_dimension`] for how each branch maps
+/// here, and the divergences (deferred pieces, not silently dropped
+/// behavior) called out below.
+///
+/// # Deferred / documented divergences from the oracle
+///
+/// - **First-ever establishment.** Flutter seeds `page` from
+///   `_pageToUseOnStartup` (`PageController`'s `initialPage`, or a value
+///   restored from `PageStorage`). FLUI has no `PageController` yet (that is
+///   PR2's job) — the first `apply_viewport_dimension` call instead leaves
+///   `pixels` untouched, i.e. behaves like `KeepPixels` for that one call.
+///   A caller that seeds `pixels` via [`ScrollPosition::new`] before the
+///   first layout gets that literal pixel value, not a page-relative one.
+/// - **`viewport_fraction > 1.0`.** Flutter centers each page within a
+///   wider-than-one-page viewport via `_initialPageOffset`
+///   (`max(0, viewportDimension * (viewportFraction - 1) / 2)`), added to
+///   both `getPageFromPixels` and `getPixelsFromPage`. This is not modeled
+///   here — only `viewport_fraction <= 1.0` (many small pages per viewport,
+///   or exactly one) is exercised by PR1; a `viewport_fraction > 1.0` caller
+///   gets the un-centered formula until a real multi-page-viewport use case
+///   lands.
+/// - **No public "current page" accessor.** Flutter also exposes
+///   `PageMetrics.page`/`_PagePosition.page`, a *defensively* guarded
+///   `max(0.0, clampDouble(pixels, min, max)) / max(1.0, viewportDimension *
+///   viewportFraction)` meant to be safe to call at any time (including
+///   before content dimensions exist). That is a different, public-facing
+///   computation from the internal recompute this policy drives, and is out
+///   of scope for PR1 — a future `page()`-style accessor should use the
+///   guarded formula, not this one.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum DimensionChangePolicy {
@@ -95,15 +176,21 @@ pub enum DimensionChangePolicy {
     /// only behavior, and the default.
     #[default]
     KeepPixels,
-    /// Keep the fractional "page" — `pixels / max(1.0, viewport_dimension *
+    /// Keep the fractional "page" — `pixels / (viewport_dimension *
     /// viewport_fraction)` — unchanged, recomputing `pixels` for the new
-    /// dimension.
+    /// dimension. See the enum-level docs for exactly how the old-dimension
+    /// null/zero/established three-way branch is handled, and the
+    /// documented divergences from the Flutter oracle.
     ///
     /// `viewport_fraction` is the fraction of the viewport one logical page
     /// occupies (`1.0` = one page per viewport, matching Flutter's
-    /// `PageController.viewportFraction` default).
+    /// `PageController.viewportFraction` default). Must be `> 0.0` — Flutter
+    /// asserts this at `PageController` construction; FLUI has no
+    /// `PageController` yet, so `set_dimension_policy`'s caller is
+    /// responsible (checked with a `debug_assert!` in the recompute).
     KeepFractionalPage {
-        /// Fraction of the viewport one logical page occupies.
+        /// Fraction of the viewport one logical page occupies. Must be
+        /// `> 0.0`.
         viewport_fraction: f32,
     },
 }
@@ -244,7 +331,12 @@ impl fmt::Debug for ScrollPosition {
                     .field("min_scroll_extent", &state.min_scroll_extent)
                     .field("max_scroll_extent", &state.max_scroll_extent)
                     .field("viewport_dimension", &state.viewport_dimension)
-                    .field("dimension_policy", &state.dimension_policy);
+                    .field("dimension_policy", &state.dimension_policy)
+                    .field(
+                        "has_applied_viewport_dimension",
+                        &state.has_applied_viewport_dimension,
+                    )
+                    .field("cached_page", &state.cached_page);
             }
             None => {
                 d.field("state", &"<locked>");
@@ -435,19 +527,64 @@ impl ViewportOffset for ScrollPosition {
                 false
             } else {
                 // Flutter parity: `_PagePosition.applyViewportDimension`
-                // (`widgets/page_view.dart`, tag `3.44.0`) recomputes the
-                // pixel offset from the page fraction *before* committing the
-                // new dimension, so the same logical page stays in view
-                // across a resize. Pure recompute under the lock already
-                // held here — no notify, no scheduling; the dirty-flag +
-                // coalesced flush below carries the observable change.
+                // (`widgets/page_view.dart`, tag `3.44.0`). Pure recompute
+                // under the lock already held here — no notify, no
+                // scheduling; the dirty-flag + coalesced flush below carries
+                // the observable change.
                 if let DimensionChangePolicy::KeepFractionalPage { viewport_fraction } =
                     state.dimension_policy
                 {
-                    let old_dimension = state.viewport_dimension;
-                    let old_page = state.pixels / (old_dimension * viewport_fraction).max(1.0);
-                    state.pixels = old_page * (viewport_dimension * viewport_fraction).max(1.0);
+                    debug_assert!(
+                        viewport_fraction > 0.0,
+                        "BUG: DimensionChangePolicy::KeepFractionalPage.viewport_fraction \
+                         must be > 0.0 (mirrors PageController's constructor assert in Flutter)"
+                    );
+                    // The oracle's three-way branch on the *old* dimension:
+                    // never established (null) is handled entirely by this
+                    // `if`'s absence below (see the comment after it); `0.0`
+                    // (a collapsed viewport) reads `cached_page` instead of
+                    // re-deriving it from `pixels`, which by then reads 0.0
+                    // and which a concurrent `apply_content_dimensions` clamp
+                    // could otherwise have stomped; anything else recomputes
+                    // via the pixels/dimension ratio.
+                    if state.has_applied_viewport_dimension {
+                        let old_dimension = state.viewport_dimension;
+                        let page = if old_dimension == 0.0 {
+                            state.cached_page.unwrap_or(0.0)
+                        } else {
+                            // Numerator clamp: an overscrolled `pixels` below
+                            // `min_scroll_extent` (allowed by
+                            // `BouncingScrollPhysics`) must not encode as a
+                            // negative page — Flutter's `getPageFromPixels`
+                            // clamps the same way (`math.max(0.0, ...)`).
+                            let raw_page =
+                                state.pixels.max(0.0) / (old_dimension * viewport_fraction);
+                            round_snap_page(raw_page)
+                        };
+
+                        if viewport_dimension == 0.0 {
+                            // Collapsing to zero: cache the page instead of
+                            // encoding it in `pixels` — `pixels` becomes
+                            // `0.0`, matching `getPixelsFromPage` evaluated at
+                            // a zero dimension, and the real state survives
+                            // in `cached_page` where a concurrent extent
+                            // clamp cannot reach it.
+                            state.cached_page = Some(page);
+                            state.pixels = 0.0;
+                        } else {
+                            state.cached_page = None;
+                            state.pixels = page * (viewport_dimension * viewport_fraction);
+                        }
+                    }
+                    // else: first-ever dimension establishment. Flutter uses
+                    // `_pageToUseOnStartup` here (a `PageController`-level
+                    // concept PR2 introduces); until then this call behaves
+                    // like `KeepPixels` — the seeded `pixels` value (e.g.
+                    // from `ScrollPosition::new`) is left untouched rather
+                    // than reinterpreted as a page count against a
+                    // never-established prior dimension.
                 }
+                state.has_applied_viewport_dimension = true;
                 state.viewport_dimension = viewport_dimension;
                 true
             }
@@ -780,7 +917,7 @@ mod tests {
     }
 
     #[test]
-    fn keep_fractional_page_guards_against_zero_dimension_without_nan_or_inf() {
+    fn keep_fractional_page_caches_the_page_across_a_zero_dimension_collapse_and_restore() {
         let mut position = ScrollPosition::zero();
         assert!(position.apply_viewport_dimension(300.0));
         position.set_pixels(150.0); // page = 150 / 300 = 0.5
@@ -788,8 +925,10 @@ mod tests {
             viewport_fraction: 1.0,
         });
 
-        // Collapse to a zero dimension: the `max(1.0, old_dim * fraction)`
-        // divisor guard must prevent a divide-by-zero, not produce NaN/inf.
+        // Collapse to a zero dimension: the page (0.5) is cached, not
+        // encoded in `pixels` — `pixels` becomes 0.0, matching
+        // `getPixelsFromPage` evaluated at a zero dimension. No NaN/inf
+        // either way.
         assert!(position.apply_viewport_dimension(0.0));
         assert!(
             position.pixels().is_finite(),
@@ -797,13 +936,13 @@ mod tests {
         );
         assert_eq!(
             position.pixels(),
-            0.5,
-            "page 0.5 recomputed against the guarded divisor (max(1.0, 0.0)) \
-             lands at pixels = 0.5 * 1.0"
+            0.0,
+            "a collapsed (0.0-dimension) viewport has no pixel offset to derive — \
+             the real page state lives in the cached page, not in `pixels`"
         );
 
-        // Recover from zero: the `max(1.0, new_dim * fraction)` multiplier
-        // guard must not produce NaN/inf either.
+        // Recover from zero: the cached page (0.5), not a formula re-derived
+        // from `pixels` (which reads 0.0 post-collapse), drives the restore.
         assert!(position.apply_viewport_dimension(600.0));
         assert!(
             position.pixels().is_finite(),
@@ -812,8 +951,54 @@ mod tests {
         assert_eq!(
             position.pixels(),
             300.0,
-            "page 0.5 recomputed against the guarded multiplier (max(1.0, 600.0)) \
-             lands at pixels = 0.5 * 600.0"
+            "the cached page (0.5) recomputed against the restored dimension \
+             (600 * 1.0) lands at pixels = 0.5 * 600.0, not 0.0 (which a \
+             pixels-derived formula would wrongly produce)"
+        );
+    }
+
+    /// Red-check for the reviewed 🔴 bug: the very first
+    /// `apply_viewport_dimension` call must not reinterpret pixels seeded
+    /// before any layout (e.g. via `ScrollPosition::new`) as a page count
+    /// against a never-established prior dimension. Before the
+    /// `has_applied_viewport_dimension` guard existed, this reproduced as
+    /// `209.0px` seeded, first layout at `300px`, exploding to `62,700px`
+    /// (`209 / max(1.0, 0.0) * 300`).
+    #[test]
+    fn keep_fractional_page_first_ever_dimension_does_not_reinterpret_seeded_pixels_as_a_page() {
+        let mut position = ScrollPosition::new(209.0);
+        position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
+            viewport_fraction: 1.0,
+        });
+
+        assert!(position.apply_viewport_dimension(300.0));
+        assert_eq!(
+            position.pixels(),
+            209.0,
+            "the first-ever dimension establishment must leave pre-seeded pixels \
+             untouched, not reinterpret them as a page count (209 / 0 * 300 \
+             would explode to 62,700px)"
+        );
+    }
+
+    /// Pins the numerator clamp: an overscrolled (negative) pixel value —
+    /// reachable under `BouncingScrollPhysics` — must not encode as a
+    /// negative page across a resize.
+    #[test]
+    fn keep_fractional_page_clamps_a_negative_overscrolled_page_to_zero() {
+        let mut position = ScrollPosition::zero();
+        assert!(position.apply_viewport_dimension(300.0));
+        position.set_pixels(-50.0); // overscrolled past min_scroll_extent
+        position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
+            viewport_fraction: 1.0,
+        });
+
+        assert!(position.apply_viewport_dimension(600.0));
+        assert_eq!(
+            position.pixels(),
+            0.0,
+            "an overscrolled negative pixel value must clamp to page 0.0, not \
+             encode a negative page (which would land pixels at -100.0)"
         );
     }
 

--- a/crates/flui-rendering/src/view/scroll_position.rs
+++ b/crates/flui-rendering/src/view/scroll_position.rs
@@ -37,6 +37,11 @@ struct State {
     min_scroll_extent: f32,
     max_scroll_extent: f32,
     viewport_dimension: f32,
+    /// How `apply_viewport_dimension` reconciles `pixels` across a dimension
+    /// change. Lives inside `State` (not a separate field/mutex) so the
+    /// policy read and the recompute it drives happen under the one lock
+    /// acquisition `apply_viewport_dimension` already takes.
+    dimension_policy: DimensionChangePolicy,
 }
 
 impl State {
@@ -46,8 +51,61 @@ impl State {
             min_scroll_extent: 0.0,
             max_scroll_extent: 0.0,
             viewport_dimension: 0.0,
+            dimension_policy: DimensionChangePolicy::KeepPixels,
         }
     }
+}
+
+/// A one-lock-acquisition snapshot of a [`ScrollPosition`]'s four extent
+/// fields (`pixels`, `min_scroll_extent`, `max_scroll_extent`,
+/// `viewport_dimension`).
+///
+/// Exists so a caller in a higher crate can build a physics-facing metrics
+/// value (e.g. `flui_widgets::scroll::ScrollMetrics`) without four separate
+/// mutex acquisitions — one per field — which could observe a torn read if
+/// another thread mutated the position between calls.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScrollPositionSnapshot {
+    /// Current scroll offset in logical pixels.
+    pub pixels: f32,
+    /// The smallest in-range value for `pixels`.
+    pub min_scroll_extent: f32,
+    /// The largest in-range value for `pixels`.
+    pub max_scroll_extent: f32,
+    /// The viewport's length along the scroll axis.
+    pub viewport_dimension: f32,
+}
+
+/// Controls how [`ScrollPosition::apply_viewport_dimension`] reconciles the
+/// current pixel offset when the viewport's length along the scroll axis
+/// changes.
+///
+/// # Flutter parity
+///
+/// Mirrors the page-preserving recompute `_PagePosition.applyViewportDimension`
+/// performs in `widgets/page_view.dart` (tag `3.44.0`) so the same logical
+/// page stays in view across a viewport resize. Ported here as a general
+/// policy on the plain `ScrollPosition` (rather than bolted onto a future
+/// `PageView`-only type) so any scrollable can opt in.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum DimensionChangePolicy {
+    /// Keep the pixel offset unchanged across a dimension change. Today's
+    /// only behavior, and the default.
+    #[default]
+    KeepPixels,
+    /// Keep the fractional "page" — `pixels / max(1.0, viewport_dimension *
+    /// viewport_fraction)` — unchanged, recomputing `pixels` for the new
+    /// dimension.
+    ///
+    /// `viewport_fraction` is the fraction of the viewport one logical page
+    /// occupies (`1.0` = one page per viewport, matching Flutter's
+    /// `PageController.viewportFraction` default).
+    KeepFractionalPage {
+        /// Fraction of the viewport one logical page occupies.
+        viewport_fraction: f32,
+    },
 }
 
 /// Coalescing bookkeeping for the post-frame extent flush.
@@ -185,7 +243,8 @@ impl fmt::Debug for ScrollPosition {
                 d.field("pixels", &state.pixels)
                     .field("min_scroll_extent", &state.min_scroll_extent)
                     .field("max_scroll_extent", &state.max_scroll_extent)
-                    .field("viewport_dimension", &state.viewport_dimension);
+                    .field("viewport_dimension", &state.viewport_dimension)
+                    .field("dimension_policy", &state.dimension_policy);
             }
             None => {
                 d.field("state", &"<locked>");
@@ -242,6 +301,26 @@ impl ScrollPosition {
     #[must_use]
     pub fn viewport_dimension(&self) -> f32 {
         self.inner.state.lock().viewport_dimension
+    }
+
+    /// Snapshots `pixels`, `min_scroll_extent`, `max_scroll_extent`, and
+    /// `viewport_dimension` under a single lock acquisition. See
+    /// [`ScrollPositionSnapshot`].
+    #[must_use]
+    pub fn extents_snapshot(&self) -> ScrollPositionSnapshot {
+        let state = self.inner.state.lock();
+        ScrollPositionSnapshot {
+            pixels: state.pixels,
+            min_scroll_extent: state.min_scroll_extent,
+            max_scroll_extent: state.max_scroll_extent,
+            viewport_dimension: state.viewport_dimension,
+        }
+    }
+
+    /// Sets how a future `apply_viewport_dimension` call reconciles `pixels`
+    /// when the viewport's dimension changes. See [`DimensionChangePolicy`].
+    pub fn set_dimension_policy(&self, policy: DimensionChangePolicy) {
+        self.inner.state.lock().dimension_policy = policy;
     }
 
     /// Sets the scroll offset to `value`, unclamped, and notifies listeners
@@ -355,6 +434,20 @@ impl ViewportOffset for ScrollPosition {
             if (state.viewport_dimension - viewport_dimension).abs() < f32::EPSILON {
                 false
             } else {
+                // Flutter parity: `_PagePosition.applyViewportDimension`
+                // (`widgets/page_view.dart`, tag `3.44.0`) recomputes the
+                // pixel offset from the page fraction *before* committing the
+                // new dimension, so the same logical page stays in view
+                // across a resize. Pure recompute under the lock already
+                // held here — no notify, no scheduling; the dirty-flag +
+                // coalesced flush below carries the observable change.
+                if let DimensionChangePolicy::KeepFractionalPage { viewport_fraction } =
+                    state.dimension_policy
+                {
+                    let old_dimension = state.viewport_dimension;
+                    let old_page = state.pixels / (old_dimension * viewport_fraction).max(1.0);
+                    state.pixels = old_page * (viewport_dimension * viewport_fraction).max(1.0);
+                }
                 state.viewport_dimension = viewport_dimension;
                 true
             }
@@ -627,6 +720,124 @@ mod tests {
         assert!(
             debug.contains("pixels: 5.0"),
             "Debug must report real field values once the lock is free, got: {debug}"
+        );
+    }
+
+    // DimensionChangePolicy -----------------------------------------------
+
+    #[test]
+    fn keep_pixels_default_policy_leaves_pixels_unchanged_across_a_dimension_change() {
+        let mut position = ScrollPosition::zero();
+        assert!(position.apply_viewport_dimension(300.0));
+        position.set_pixels(150.0);
+
+        assert!(position.apply_viewport_dimension(600.0));
+        assert_eq!(
+            position.pixels(),
+            150.0,
+            "KeepPixels (the default) must not move the pixel offset when the \
+             viewport dimension changes"
+        );
+    }
+
+    #[test]
+    fn keep_fractional_page_preserves_page_at_full_viewport_fraction() {
+        let mut position = ScrollPosition::zero();
+        assert!(position.apply_viewport_dimension(300.0));
+        position.set_pixels(600.0); // page = 600 / (300 * 1.0) = 2.0
+        position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
+            viewport_fraction: 1.0,
+        });
+
+        assert!(position.apply_viewport_dimension(600.0));
+        // page preserved at 2.0: new_pixels = 2.0 * (600 * 1.0) = 1200.0
+        assert_eq!(
+            position.pixels(),
+            1200.0,
+            "resizing 300 -> 600 at viewport_fraction 1.0 must preserve the \
+             fractional page (2.0), not the raw pixel offset"
+        );
+    }
+
+    #[test]
+    fn keep_fractional_page_preserves_page_at_partial_viewport_fraction() {
+        let mut position = ScrollPosition::zero();
+        assert!(position.apply_viewport_dimension(300.0));
+        // page = 720 / (300 * 0.8) = 720 / 240 = 3.0
+        position.set_pixels(720.0);
+        position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
+            viewport_fraction: 0.8,
+        });
+
+        assert!(position.apply_viewport_dimension(600.0));
+        // page preserved at 3.0: new_pixels = 3.0 * (600 * 0.8) = 1440.0
+        assert_eq!(
+            position.pixels(),
+            1440.0,
+            "resizing 300 -> 600 at viewport_fraction 0.8 must preserve the \
+             fractional page (3.0), not the raw pixel offset"
+        );
+    }
+
+    #[test]
+    fn keep_fractional_page_guards_against_zero_dimension_without_nan_or_inf() {
+        let mut position = ScrollPosition::zero();
+        assert!(position.apply_viewport_dimension(300.0));
+        position.set_pixels(150.0); // page = 150 / 300 = 0.5
+        position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
+            viewport_fraction: 1.0,
+        });
+
+        // Collapse to a zero dimension: the `max(1.0, old_dim * fraction)`
+        // divisor guard must prevent a divide-by-zero, not produce NaN/inf.
+        assert!(position.apply_viewport_dimension(0.0));
+        assert!(
+            position.pixels().is_finite(),
+            "collapsing to a zero viewport dimension must not produce NaN/inf pixels"
+        );
+        assert_eq!(
+            position.pixels(),
+            0.5,
+            "page 0.5 recomputed against the guarded divisor (max(1.0, 0.0)) \
+             lands at pixels = 0.5 * 1.0"
+        );
+
+        // Recover from zero: the `max(1.0, new_dim * fraction)` multiplier
+        // guard must not produce NaN/inf either.
+        assert!(position.apply_viewport_dimension(600.0));
+        assert!(
+            position.pixels().is_finite(),
+            "recovering from a zero viewport dimension must not produce NaN/inf pixels"
+        );
+        assert_eq!(
+            position.pixels(),
+            300.0,
+            "page 0.5 recomputed against the guarded multiplier (max(1.0, 600.0)) \
+             lands at pixels = 0.5 * 600.0"
+        );
+    }
+
+    #[test]
+    fn keep_fractional_page_recompute_does_not_notify_synchronously() {
+        let mut position = ScrollPosition::zero();
+        assert!(position.apply_viewport_dimension(300.0));
+        position.set_pixels(600.0);
+        position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
+            viewport_fraction: 1.0,
+        });
+
+        let notified = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&notified);
+        position.add_listener(Arc::new(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        assert!(position.apply_viewport_dimension(600.0));
+        assert_eq!(
+            notified.load(Ordering::SeqCst),
+            0,
+            "the KeepFractionalPage recompute is a pure in-lock write — same \
+             no-synchronous-notify contract as the KeepPixels path"
         );
     }
 }

--- a/crates/flui-widgets/src/lib.rs
+++ b/crates/flui-widgets/src/lib.rs
@@ -200,12 +200,12 @@ pub use overlay::{Overlay, OverlayEntry, OverlayEntryId, OverlayHandle};
 pub use paint::{ColoredBox, CustomPaint, DecoratedBox, Opacity, RepaintBoundary};
 pub use scroll::{
     BouncingScrollPhysics, ClampingScrollPhysics, CustomScrollView, GridView, ListView,
-    RefreshController, RefreshIndicator, RefreshIndicatorState, ScrollController, ScrollPhysics,
-    Scrollable, Scrollbar, SharedScrollPhysics, ShrinkWrappingViewport, SingleChildScrollView,
-    SliverChildBuilderDelegate, SliverFillRemaining, SliverFillRemainingAndOverscroll,
-    SliverFillRemainingWithScrollable, SliverFillViewport, SliverFixedExtentList, SliverGrid,
-    SliverIgnorePointer, SliverList, SliverOffstage, SliverOpacity, SliverPadding,
-    SliverToBoxAdapter, Viewport,
+    RefreshController, RefreshIndicator, RefreshIndicatorState, ScrollController, ScrollMetrics,
+    ScrollPhysics, Scrollable, Scrollbar, SharedScrollPhysics, ShrinkWrappingViewport,
+    SingleChildScrollView, SliverChildBuilderDelegate, SliverFillRemaining,
+    SliverFillRemainingAndOverscroll, SliverFillRemainingWithScrollable, SliverFillViewport,
+    SliverFixedExtentList, SliverGrid, SliverIgnorePointer, SliverList, SliverOffstage,
+    SliverOpacity, SliverPadding, SliverToBoxAdapter, Viewport,
 };
 pub use semantics::{ExcludeSemantics, MergeSemantics, Semantics};
 pub use stack::{IndexedStack, Positioned, Stack};

--- a/crates/flui-widgets/src/scroll/mod.rs
+++ b/crates/flui-widgets/src/scroll/mod.rs
@@ -37,7 +37,7 @@ pub use list_view::ListView;
 pub use refresh_indicator::{RefreshController, RefreshIndicator, RefreshIndicatorState};
 pub use scroll_controller::ScrollController;
 pub use scroll_physics::{
-    BouncingScrollPhysics, ClampingScrollPhysics, ScrollPhysics, SharedScrollPhysics,
+    BouncingScrollPhysics, ClampingScrollPhysics, ScrollMetrics, ScrollPhysics, SharedScrollPhysics,
 };
 pub use scrollable::Scrollable;
 pub use scrollbar::Scrollbar;

--- a/crates/flui-widgets/src/scroll/refresh_indicator.rs
+++ b/crates/flui-widgets/src/scroll/refresh_indicator.rs
@@ -49,7 +49,7 @@ use flui_view::{BuildContext, BuildContextExt, Child, IntoView, ViewExt, ViewSta
 
 use crate::animated::VsyncScope;
 use crate::scroll::single_child_scroll_view::SingleChildScrollView;
-use crate::scroll::{ClampingScrollPhysics, ScrollController, SharedScrollPhysics};
+use crate::scroll::{ClampingScrollPhysics, ScrollController, ScrollMetrics, SharedScrollPhysics};
 use crate::{AnimatedBuilder, ColoredBox, GestureDetector, Positioned, Stack};
 
 // ---------------------------------------------------------------------------
@@ -516,11 +516,8 @@ impl ViewState<RefreshIndicator> for RefreshIndicatorState {
                             sc_update.set_pixels(sc_update.min_scroll_extent());
                         } else {
                             rc_update.set_pull_distance_px(0.0);
-                            let clamped = ph_update.apply_boundary_conditions(
-                                proposed,
-                                sc_update.min_scroll_extent(),
-                                sc_update.max_scroll_extent(),
-                            );
+                            let metrics = ScrollMetrics::from(&sc_update.position());
+                            let clamped = ph_update.apply_boundary_conditions(&metrics, proposed);
                             sc_update.set_pixels(clamped);
                         }
                     })
@@ -544,12 +541,10 @@ impl ViewState<RefreshIndicator> for RefreshIndicatorState {
                                 // so spring-back still works without measurable velocity.
                                 if bounded.is_nan() { 0.0 } else { bounded }
                             };
-                            if let Some(sim) = ph_end.create_ballistic_simulation(
-                                fling_vel_px_per_sec,
-                                sc_end.pixels(),
-                                sc_end.min_scroll_extent(),
-                                sc_end.max_scroll_extent(),
-                            ) {
+                            let metrics = ScrollMetrics::from(&sc_end.position());
+                            if let Some(sim) =
+                                ph_end.create_ballistic_simulation(&metrics, fling_vel_px_per_sec)
+                            {
                                 let _ = fc_fling.animate_with(sim);
                             }
                         }

--- a/crates/flui-widgets/src/scroll/scroll_physics.rs
+++ b/crates/flui-widgets/src/scroll/scroll_physics.rs
@@ -7,7 +7,9 @@
 //! Mirrors `widgets/scroll_physics.dart` `ScrollPhysics`:
 //! - `apply_boundary_conditions` ↔ `applyBoundaryConditions` (returns the
 //!   _allowed_ position rather than the rejected overshoot, which is the
-//!   simpler contract for FLUI's purely-eager callbacks).
+//!   simpler contract for FLUI's purely-eager callbacks; both take a
+//!   `ScrollMetrics`, mirroring `widgets/scroll_metrics.dart`'s `ScrollMetrics`
+//!   mixin).
 //! - `create_ballistic_simulation` ↔ `createBallisticSimulation` (returns
 //!   `Option<Box<dyn Simulation>>` for the fling/spring-back animation).
 //!
@@ -23,6 +25,80 @@ use std::sync::Arc;
 use flui_animation::simulation::{
     BoundedFrictionSimulation, ScrollSpringSimulation, Simulation, SpringDescription,
 };
+use flui_rendering::view::ScrollPosition;
+
+// ---------------------------------------------------------------------------
+// ScrollMetrics
+// ---------------------------------------------------------------------------
+
+/// A point-in-time snapshot of a scroll position's extents — the value a
+/// [`ScrollPhysics`] method reads to decide a boundary/ballistic outcome.
+///
+/// This is a snapshot **value object**, not a live view: it is read once at
+/// the call site and passed by reference into the physics call, so the
+/// physics implementation always sees a self-consistent set of fields even
+/// if the underlying [`ScrollPosition`] is mutated concurrently afterward.
+///
+/// # Flutter parity
+///
+/// Mirrors the `ScrollMetrics` mixin (`widgets/scroll_metrics.dart`, tag
+/// `3.44.0`): FLUI exposes it as a plain `Copy` struct rather than a
+/// mixin/live interface, since `ScrollPhysics` never needs to observe further
+/// extent changes mid-call — the Dart docs for `applyBoundaryConditions`/
+/// `createBallisticSimulation` say as much ("the given `ScrollMetrics` are
+/// only valid during this method call").
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScrollMetrics {
+    /// Current scroll offset in logical pixels.
+    pub pixels: f32,
+    /// The smallest in-range value for `pixels`.
+    pub min_scroll_extent: f32,
+    /// The largest in-range value for `pixels`.
+    pub max_scroll_extent: f32,
+    /// The viewport's length along the scroll axis.
+    pub viewport_dimension: f32,
+}
+
+impl ScrollMetrics {
+    /// Builds a metrics snapshot directly from its four fields — for a test
+    /// fixture or a caller assembling metrics from values that don't come
+    /// from a live [`ScrollPosition`] (e.g. a hypothetical "what if" probe).
+    /// Prefer [`ScrollMetrics::from`] when a [`ScrollPosition`] is at hand.
+    #[must_use]
+    pub fn new(pixels: f32, min_scroll_extent: f32, max_scroll_extent: f32) -> Self {
+        Self {
+            pixels,
+            min_scroll_extent,
+            max_scroll_extent,
+            viewport_dimension: 0.0,
+        }
+    }
+
+    /// Same as [`ScrollMetrics::new`], additionally specifying
+    /// `viewport_dimension` (defaulted to `0.0` otherwise).
+    #[must_use]
+    pub fn with_viewport_dimension(mut self, viewport_dimension: f32) -> Self {
+        self.viewport_dimension = viewport_dimension;
+        self
+    }
+}
+
+impl From<&ScrollPosition> for ScrollMetrics {
+    /// Snapshots `position`'s four extent fields in a single lock
+    /// acquisition (via [`ScrollPosition::extents_snapshot`]) rather than
+    /// four separate reads that could observe a torn state if another
+    /// thread mutated the position in between.
+    fn from(position: &ScrollPosition) -> Self {
+        let snapshot = position.extents_snapshot();
+        Self {
+            pixels: snapshot.pixels,
+            min_scroll_extent: snapshot.min_scroll_extent,
+            max_scroll_extent: snapshot.max_scroll_extent,
+            viewport_dimension: snapshot.viewport_dimension,
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Trait
@@ -41,23 +117,20 @@ use flui_animation::simulation::{
 /// simpler for a callback-driven update model.
 pub trait ScrollPhysics: Send + Sync + std::fmt::Debug {
     /// Return the position the scroller should move to given a `proposed_pixels`
-    /// offset in the context of the current scroll extents.
+    /// offset in the context of `metrics`.
     ///
     /// For clamping physics this clips `proposed_pixels` to
-    /// `[min_scroll_extent, max_scroll_extent]`. For bouncing physics a
-    /// position past the edge is partially allowed with increasing resistance.
+    /// `[metrics.min_scroll_extent, metrics.max_scroll_extent]`. For bouncing
+    /// physics a position past the edge is partially allowed with increasing
+    /// resistance.
     ///
     /// # Flutter parity
     ///
-    /// Corresponds to `applyBoundaryConditions`: the sign difference is that
-    /// Flutter returns the _rejected_ overshoot; FLUI returns the _accepted_
-    /// position. The net visual result is identical.
-    fn apply_boundary_conditions(
-        &self,
-        proposed_pixels: f32,
-        min_scroll_extent: f32,
-        max_scroll_extent: f32,
-    ) -> f32;
+    /// Corresponds to `applyBoundaryConditions(ScrollMetrics position, double
+    /// value)`: the sign difference is that Flutter returns the _rejected_
+    /// overshoot; FLUI returns the _accepted_ position. The net visual result
+    /// is identical.
+    fn apply_boundary_conditions(&self, metrics: &ScrollMetrics, proposed_pixels: f32) -> f32;
 
     /// Create a `Simulation` that coasts the viewport to rest after the user
     /// lifts their finger.
@@ -73,13 +146,12 @@ pub trait ScrollPhysics: Send + Sync + std::fmt::Debug {
     ///
     /// # Flutter parity
     ///
-    /// Corresponds to `createBallisticSimulation`.
+    /// Corresponds to `createBallisticSimulation(ScrollMetrics position,
+    /// double velocity)`.
     fn create_ballistic_simulation(
         &self,
+        metrics: &ScrollMetrics,
         velocity_px_per_sec: f32,
-        current_pixels: f32,
-        min_scroll_extent: f32,
-        max_scroll_extent: f32,
     ) -> Option<Box<dyn Simulation>>;
 }
 
@@ -136,21 +208,14 @@ impl Default for ClampingScrollPhysics {
 }
 
 impl ScrollPhysics for ClampingScrollPhysics {
-    fn apply_boundary_conditions(
-        &self,
-        proposed_pixels: f32,
-        min_scroll_extent: f32,
-        max_scroll_extent: f32,
-    ) -> f32 {
-        proposed_pixels.clamp(min_scroll_extent, max_scroll_extent)
+    fn apply_boundary_conditions(&self, metrics: &ScrollMetrics, proposed_pixels: f32) -> f32 {
+        proposed_pixels.clamp(metrics.min_scroll_extent, metrics.max_scroll_extent)
     }
 
     fn create_ballistic_simulation(
         &self,
+        metrics: &ScrollMetrics,
         velocity_px_per_sec: f32,
-        current_pixels: f32,
-        min_scroll_extent: f32,
-        max_scroll_extent: f32,
     ) -> Option<Box<dyn Simulation>> {
         // Skip fling below the configured threshold.
         if velocity_px_per_sec.abs() < self.min_fling_velocity_px_per_sec {
@@ -159,15 +224,16 @@ impl ScrollPhysics for ClampingScrollPhysics {
         // If the position is already out of bounds (possible if the caller
         // skipped boundary conditions), do not attempt a physics fling — let
         // the caller snap it into range first.
-        if current_pixels < min_scroll_extent || current_pixels > max_scroll_extent {
+        if metrics.pixels < metrics.min_scroll_extent || metrics.pixels > metrics.max_scroll_extent
+        {
             return None;
         }
         Some(Box::new(BoundedFrictionSimulation::new(
             self.fling_drag_coefficient,
-            current_pixels,
+            metrics.pixels,
             velocity_px_per_sec,
-            min_scroll_extent,
-            max_scroll_extent,
+            metrics.min_scroll_extent,
+            metrics.max_scroll_extent,
         )))
     }
 }
@@ -224,20 +290,15 @@ impl Default for BouncingScrollPhysics {
 }
 
 impl ScrollPhysics for BouncingScrollPhysics {
-    fn apply_boundary_conditions(
-        &self,
-        proposed_pixels: f32,
-        min_scroll_extent: f32,
-        max_scroll_extent: f32,
-    ) -> f32 {
-        if proposed_pixels < min_scroll_extent {
+    fn apply_boundary_conditions(&self, metrics: &ScrollMetrics, proposed_pixels: f32) -> f32 {
+        if proposed_pixels < metrics.min_scroll_extent {
             // Allow overscroll past the top/left, but dampen it.
-            let overscroll = proposed_pixels - min_scroll_extent;
-            min_scroll_extent + overscroll * self.overscroll_spring_coefficient
-        } else if proposed_pixels > max_scroll_extent {
+            let overscroll = proposed_pixels - metrics.min_scroll_extent;
+            metrics.min_scroll_extent + overscroll * self.overscroll_spring_coefficient
+        } else if proposed_pixels > metrics.max_scroll_extent {
             // Allow overscroll past the bottom/right, but dampen it.
-            let overscroll = proposed_pixels - max_scroll_extent;
-            max_scroll_extent + overscroll * self.overscroll_spring_coefficient
+            let overscroll = proposed_pixels - metrics.max_scroll_extent;
+            metrics.max_scroll_extent + overscroll * self.overscroll_spring_coefficient
         } else {
             proposed_pixels
         }
@@ -245,25 +306,23 @@ impl ScrollPhysics for BouncingScrollPhysics {
 
     fn create_ballistic_simulation(
         &self,
+        metrics: &ScrollMetrics,
         velocity_px_per_sec: f32,
-        current_pixels: f32,
-        min_scroll_extent: f32,
-        max_scroll_extent: f32,
     ) -> Option<Box<dyn Simulation>> {
         // If the position is past an edge, spring back regardless of velocity.
-        if current_pixels < min_scroll_extent {
+        if metrics.pixels < metrics.min_scroll_extent {
             return Some(Box::new(ScrollSpringSimulation::new(
                 self.spring,
-                current_pixels,
-                min_scroll_extent,
+                metrics.pixels,
+                metrics.min_scroll_extent,
                 velocity_px_per_sec,
             )));
         }
-        if current_pixels > max_scroll_extent {
+        if metrics.pixels > metrics.max_scroll_extent {
             return Some(Box::new(ScrollSpringSimulation::new(
                 self.spring,
-                current_pixels,
-                max_scroll_extent,
+                metrics.pixels,
+                metrics.max_scroll_extent,
                 velocity_px_per_sec,
             )));
         }
@@ -273,10 +332,10 @@ impl ScrollPhysics for BouncingScrollPhysics {
         }
         Some(Box::new(BoundedFrictionSimulation::new(
             self.fling_drag_coefficient,
-            current_pixels,
+            metrics.pixels,
             velocity_px_per_sec,
-            min_scroll_extent,
-            max_scroll_extent,
+            metrics.min_scroll_extent,
+            metrics.max_scroll_extent,
         )))
     }
 }
@@ -288,28 +347,37 @@ impl ScrollPhysics for BouncingScrollPhysics {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::float_cmp)] // unit tests assert exact clamping/pass-through values, not computed floats
+    use flui_rendering::view::ViewportOffset;
+
     use super::*;
+
+    /// Builds a `ScrollMetrics` with the given `pixels`/`min`/`max`, leaving
+    /// `viewport_dimension` at 0.0 (unused by the boundary/ballistic math
+    /// under test here).
+    fn metrics(pixels: f32, min_scroll_extent: f32, max_scroll_extent: f32) -> ScrollMetrics {
+        ScrollMetrics::new(pixels, min_scroll_extent, max_scroll_extent)
+    }
 
     // ClampingScrollPhysics ---------------------------------------------------
 
     #[test]
     fn clamping_apply_boundary_clamps_to_min() {
         let physics = ClampingScrollPhysics::new();
-        let allowed = physics.apply_boundary_conditions(-50.0, 0.0, 400.0);
+        let allowed = physics.apply_boundary_conditions(&metrics(0.0, 0.0, 400.0), -50.0);
         assert_eq!(allowed, 0.0, "position below min is clamped to min");
     }
 
     #[test]
     fn clamping_apply_boundary_clamps_to_max() {
         let physics = ClampingScrollPhysics::new();
-        let allowed = physics.apply_boundary_conditions(500.0, 0.0, 400.0);
+        let allowed = physics.apply_boundary_conditions(&metrics(0.0, 0.0, 400.0), 500.0);
         assert_eq!(allowed, 400.0, "position above max is clamped to max");
     }
 
     #[test]
     fn clamping_apply_boundary_passes_through_in_bounds() {
         let physics = ClampingScrollPhysics::new();
-        let allowed = physics.apply_boundary_conditions(200.0, 0.0, 400.0);
+        let allowed = physics.apply_boundary_conditions(&metrics(0.0, 0.0, 400.0), 200.0);
         assert_eq!(
             allowed, 200.0,
             "in-bounds position passes through unchanged"
@@ -319,7 +387,7 @@ mod tests {
     #[test]
     fn clamping_ballistic_returns_none_below_fling_threshold() {
         let physics = ClampingScrollPhysics::new();
-        let sim = physics.create_ballistic_simulation(10.0, 100.0, 0.0, 400.0);
+        let sim = physics.create_ballistic_simulation(&metrics(100.0, 0.0, 400.0), 10.0);
         assert!(
             sim.is_none(),
             "velocity below min_fling_velocity should produce no simulation"
@@ -329,7 +397,7 @@ mod tests {
     #[test]
     fn clamping_ballistic_returns_simulation_above_fling_threshold() {
         let physics = ClampingScrollPhysics::new();
-        let sim = physics.create_ballistic_simulation(300.0, 100.0, 0.0, 400.0);
+        let sim = physics.create_ballistic_simulation(&metrics(100.0, 0.0, 400.0), 300.0);
         assert!(
             sim.is_some(),
             "velocity above min_fling_velocity should produce a bounded friction simulation"
@@ -342,7 +410,7 @@ mod tests {
     fn bouncing_apply_boundary_allows_overscroll_past_min_with_resistance() {
         let physics = BouncingScrollPhysics::new();
         // Propose a position 100 px past the top.
-        let allowed = physics.apply_boundary_conditions(-100.0, 0.0, 400.0);
+        let allowed = physics.apply_boundary_conditions(&metrics(0.0, 0.0, 400.0), -100.0);
         // Resistance: -100 * 0.52 = -52 → allowed = 0 + (-52) = -52.
         assert!(
             allowed > -100.0 && allowed < 0.0,
@@ -359,7 +427,7 @@ mod tests {
     fn bouncing_apply_boundary_allows_overscroll_past_max_with_resistance() {
         let physics = BouncingScrollPhysics::new();
         // Propose 80 px past the bottom (max = 400).
-        let allowed = physics.apply_boundary_conditions(480.0, 0.0, 400.0);
+        let allowed = physics.apply_boundary_conditions(&metrics(0.0, 0.0, 400.0), 480.0);
         // Resistance: 80 * 0.52 = 41.6 → allowed = 400 + 41.6 = 441.6.
         let expected = 400.0 + 80.0_f32 * 0.52;
         assert!(
@@ -372,7 +440,7 @@ mod tests {
     fn bouncing_ballistic_springs_back_when_overscrolled_past_min() {
         let physics = BouncingScrollPhysics::new();
         // Position is already below min; spring back regardless of velocity.
-        let sim = physics.create_ballistic_simulation(0.0, -50.0, 0.0, 400.0);
+        let sim = physics.create_ballistic_simulation(&metrics(-50.0, 0.0, 400.0), 0.0);
         assert!(
             sim.is_some(),
             "overscroll past min should produce a spring-back simulation even at zero velocity"
@@ -382,7 +450,7 @@ mod tests {
     #[test]
     fn bouncing_ballistic_springs_back_when_overscrolled_past_max() {
         let physics = BouncingScrollPhysics::new();
-        let sim = physics.create_ballistic_simulation(0.0, 450.0, 0.0, 400.0);
+        let sim = physics.create_ballistic_simulation(&metrics(450.0, 0.0, 400.0), 0.0);
         assert!(
             sim.is_some(),
             "overscroll past max should produce a spring-back simulation even at zero velocity"
@@ -392,10 +460,67 @@ mod tests {
     #[test]
     fn bouncing_ballistic_returns_none_below_fling_threshold_when_in_bounds() {
         let physics = BouncingScrollPhysics::new();
-        let sim = physics.create_ballistic_simulation(10.0, 200.0, 0.0, 400.0);
+        let sim = physics.create_ballistic_simulation(&metrics(200.0, 0.0, 400.0), 10.0);
         assert!(
             sim.is_none(),
             "in-bounds position with sub-threshold velocity should produce no simulation"
         );
+    }
+
+    // ScrollMetrics ------------------------------------------------------------
+
+    #[test]
+    fn scroll_metrics_from_scroll_position_snapshots_all_four_fields() {
+        let mut position = ScrollPosition::zero();
+        position.apply_viewport_dimension(300.0);
+        position.apply_content_dimensions(10.0, 500.0);
+        position.set_pixels(120.0);
+
+        let metrics = ScrollMetrics::from(&position);
+        assert_eq!(metrics.pixels, 120.0);
+        assert_eq!(metrics.min_scroll_extent, 10.0);
+        assert_eq!(metrics.max_scroll_extent, 500.0);
+        assert_eq!(metrics.viewport_dimension, 300.0);
+    }
+
+    /// Proves the snapshot is a genuinely atomic, single-lock read: a
+    /// background thread continuously mutates `min_scroll_extent`/
+    /// `max_scroll_extent` together so that `max - min == 100.0` always
+    /// holds, while the main thread races it with `ScrollMetrics::from`
+    /// snapshots. If `From<&ScrollPosition>` read the four fields through
+    /// four separate lock acquisitions instead of
+    /// `ScrollPosition::extents_snapshot`'s one, this test would
+    /// intermittently observe a torn state (a `min` written by one iteration
+    /// paired with the `max` from another) and fail.
+    #[test]
+    fn scroll_metrics_from_scroll_position_is_a_single_lock_atomic_snapshot() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let mut position = ScrollPosition::zero();
+        position.apply_content_dimensions(0.0, 100.0);
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let mut writer_position = position.clone();
+        let writer_stop = Arc::clone(&stop);
+        let writer = std::thread::spawn(move || {
+            let mut min = 0.0_f32;
+            while !writer_stop.load(Ordering::Relaxed) {
+                writer_position.apply_content_dimensions(min, min + 100.0);
+                min += 1.0;
+            }
+        });
+
+        for _ in 0..20_000 {
+            let metrics = ScrollMetrics::from(&position);
+            assert_eq!(
+                metrics.max_scroll_extent - metrics.min_scroll_extent,
+                100.0,
+                "a single-lock snapshot must never observe a torn min/max pair"
+            );
+        }
+
+        stop.store(true, Ordering::Relaxed);
+        writer.join().expect("writer thread must not panic");
     }
 }

--- a/crates/flui-widgets/src/scroll/scroll_physics.rs
+++ b/crates/flui-widgets/src/scroll/scroll_physics.rs
@@ -65,22 +65,26 @@ impl ScrollMetrics {
     /// fixture or a caller assembling metrics from values that don't come
     /// from a live [`ScrollPosition`] (e.g. a hypothetical "what if" probe).
     /// Prefer [`ScrollMetrics::from`] when a [`ScrollPosition`] is at hand.
+    ///
+    /// All four fields are required: a caller that only cares about
+    /// `pixels`/`min_scroll_extent`/`max_scroll_extent` still must pass an
+    /// explicit `viewport_dimension` (even if `0.0`) rather than have it
+    /// silently defaulted — a physics implementation that reads
+    /// `viewport_dimension` (e.g. a future page-snapping physics) must not
+    /// get `0.0` from every fixture that forgot to set it.
     #[must_use]
-    pub fn new(pixels: f32, min_scroll_extent: f32, max_scroll_extent: f32) -> Self {
+    pub fn new(
+        pixels: f32,
+        min_scroll_extent: f32,
+        max_scroll_extent: f32,
+        viewport_dimension: f32,
+    ) -> Self {
         Self {
             pixels,
             min_scroll_extent,
             max_scroll_extent,
-            viewport_dimension: 0.0,
+            viewport_dimension,
         }
-    }
-
-    /// Same as [`ScrollMetrics::new`], additionally specifying
-    /// `viewport_dimension` (defaulted to `0.0` otherwise).
-    #[must_use]
-    pub fn with_viewport_dimension(mut self, viewport_dimension: f32) -> Self {
-        self.viewport_dimension = viewport_dimension;
-        self
     }
 }
 
@@ -351,11 +355,11 @@ mod tests {
 
     use super::*;
 
-    /// Builds a `ScrollMetrics` with the given `pixels`/`min`/`max`, leaving
-    /// `viewport_dimension` at 0.0 (unused by the boundary/ballistic math
-    /// under test here).
+    /// Builds a `ScrollMetrics` with the given `pixels`/`min`/`max`, passing
+    /// `viewport_dimension: 0.0` explicitly — unused by the boundary/
+    /// ballistic math under test here.
     fn metrics(pixels: f32, min_scroll_extent: f32, max_scroll_extent: f32) -> ScrollMetrics {
-        ScrollMetrics::new(pixels, min_scroll_extent, max_scroll_extent)
+        ScrollMetrics::new(pixels, min_scroll_extent, max_scroll_extent, 0.0)
     }
 
     // ClampingScrollPhysics ---------------------------------------------------

--- a/crates/flui-widgets/src/scroll/scrollable.rs
+++ b/crates/flui-widgets/src/scroll/scrollable.rs
@@ -38,7 +38,7 @@ use flui_view::prelude::StatefulView;
 use flui_view::{BoxedView, BuildContext, BuildContextExt, Child, IntoView, ViewExt, ViewState};
 
 use crate::animated::VsyncScope;
-use crate::scroll::{ClampingScrollPhysics, ScrollController, SharedScrollPhysics};
+use crate::scroll::{ClampingScrollPhysics, ScrollController, ScrollMetrics, SharedScrollPhysics};
 use crate::{AnimatedBuilder, GestureDetector, SingleChildScrollView};
 
 /// A caller-supplied composition of the scrollable content, receiving the
@@ -365,11 +365,8 @@ impl ViewState<Scrollable> for ScrollableState {
                         Axis::Horizontal => details.delta.dx.get(),
                     };
                     let proposed = ctrl_update.pixels() - raw_delta;
-                    let clamped = phys_update.apply_boundary_conditions(
-                        proposed,
-                        ctrl_update.min_scroll_extent(),
-                        ctrl_update.max_scroll_extent(),
-                    );
+                    let metrics = ScrollMetrics::from(&ctrl_update.position());
+                    let clamped = phys_update.apply_boundary_conditions(&metrics, proposed);
                     ctrl_update.set_pixels(clamped);
                 })
                 .on_pan_end(move |details| {
@@ -399,12 +396,10 @@ impl ViewState<Scrollable> for ScrollableState {
                         fling_velocity_px_per_sec
                     };
 
-                    if let Some(sim) = phys_fling.create_ballistic_simulation(
-                        fling_velocity_px_per_sec,
-                        ctrl_fling.pixels(),
-                        ctrl_fling.min_scroll_extent(),
-                        ctrl_fling.max_scroll_extent(),
-                    ) {
+                    let metrics = ScrollMetrics::from(&ctrl_fling.position());
+                    if let Some(sim) =
+                        phys_fling.create_ballistic_simulation(&metrics, fling_velocity_px_per_sec)
+                    {
                         // `Box<dyn Simulation>` implements `Simulation` via the
                         // blanket impl in `flui-animation`, so it can be passed
                         // directly as `S: Simulation + 'static`.

--- a/crates/flui-widgets/tests/scroll.rs
+++ b/crates/flui-widgets/tests/scroll.rs
@@ -583,9 +583,10 @@ fn scroll_controller_thumb_offset_fraction_at_scroll_midpoint() {
 // ============================================================================
 
 /// Minimal metrics fixture for these boundary-clamp tests: only
-/// `min_scroll_extent`/`max_scroll_extent` matter to `ClampingScrollPhysics`.
+/// `min_scroll_extent`/`max_scroll_extent` matter to `ClampingScrollPhysics`;
+/// `pixels`/`viewport_dimension` are passed explicitly as `0.0` (unused here).
 fn metrics_with_extents(min_scroll_extent: f32, max_scroll_extent: f32) -> ScrollMetrics {
-    ScrollMetrics::new(0.0, min_scroll_extent, max_scroll_extent)
+    ScrollMetrics::new(0.0, min_scroll_extent, max_scroll_extent, 0.0)
 }
 
 #[test]

--- a/crates/flui-widgets/tests/scroll.rs
+++ b/crates/flui-widgets/tests/scroll.rs
@@ -19,8 +19,8 @@ use flui_types::geometry::px;
 use flui_view::ViewExt;
 use flui_widgets::{
     BouncingScrollPhysics, ClampingScrollPhysics, ColoredBox, CustomScrollView, GridView, ListView,
-    ScrollController, ScrollPhysics, Scrollable, SharedScrollPhysics, SingleChildScrollView,
-    SizedBox, SliverFixedExtentList, VsyncScope,
+    ScrollController, ScrollMetrics, ScrollPhysics, Scrollable, SharedScrollPhysics,
+    SingleChildScrollView, SizedBox, SliverFixedExtentList, VsyncScope,
 };
 
 /// Flutter parity (tag `3.44.0`):
@@ -582,11 +582,17 @@ fn scroll_controller_thumb_offset_fraction_at_scroll_midpoint() {
 // ScrollPhysics — clamping boundary enforcement
 // ============================================================================
 
+/// Minimal metrics fixture for these boundary-clamp tests: only
+/// `min_scroll_extent`/`max_scroll_extent` matter to `ClampingScrollPhysics`.
+fn metrics_with_extents(min_scroll_extent: f32, max_scroll_extent: f32) -> ScrollMetrics {
+    ScrollMetrics::new(0.0, min_scroll_extent, max_scroll_extent)
+}
+
 #[test]
 fn clamping_physics_clamps_proposed_offset_below_minimum() {
     let physics = ClampingScrollPhysics::default();
     // Proposing -50 (past the 0 minimum) must snap to 0.
-    let result = physics.apply_boundary_conditions(-50.0, 0.0, 500.0);
+    let result = physics.apply_boundary_conditions(&metrics_with_extents(0.0, 500.0), -50.0);
     assert_eq!(
         result, 0.0,
         "clamping physics must clamp below-min proposals to min_scroll_extent"
@@ -597,7 +603,7 @@ fn clamping_physics_clamps_proposed_offset_below_minimum() {
 fn clamping_physics_clamps_proposed_offset_above_maximum() {
     let physics = ClampingScrollPhysics::default();
     // Proposing 600 past the 500 maximum must snap to 500.
-    let result = physics.apply_boundary_conditions(600.0, 0.0, 500.0);
+    let result = physics.apply_boundary_conditions(&metrics_with_extents(0.0, 500.0), 600.0);
     assert_eq!(
         result, 500.0,
         "clamping physics must clamp above-max proposals to max_scroll_extent"
@@ -607,7 +613,7 @@ fn clamping_physics_clamps_proposed_offset_above_maximum() {
 #[test]
 fn clamping_physics_passes_through_in_range_offset() {
     let physics = ClampingScrollPhysics::default();
-    let result = physics.apply_boundary_conditions(250.0, 0.0, 500.0);
+    let result = physics.apply_boundary_conditions(&metrics_with_extents(0.0, 500.0), 250.0);
     assert_eq!(
         result, 250.0,
         "clamping physics must pass through in-range proposals unchanged"


### PR DESCRIPTION
First of three PRs for the paging layer over the (already-shipped) sliver-viewport substrate — ADR-0037. This PR widens the physics contract and gives `ScrollPosition` a page-preserving resize policy; PageView itself is PR2.

## What

- **`ScrollMetrics`** — a snapshot value object (`pixels`, min/max extents, `viewport_dimension`, `#[non_exhaustive]`) built from `ScrollPosition` in a single lock acquisition (torn-read mutation-pinned); `ScrollPhysics::apply_boundary_conditions`/`create_ballistic_simulation` re-signed to take it, matching the oracle's `ScrollMetrics`-first shape @ 3.44.0 — page snapping (PR2) needs the viewport dimension the old signatures couldn't carry. The constructor takes all four fields (the review killed a zero-filling three-arg shape before the surface ossified).
- **`DimensionChangePolicy`** on `ScrollPosition`: `KeepPixels` (default, behavior-neutral) / `KeepFractionalPage { viewport_fraction }` — applied inside `apply_viewport_dimension` under the existing mutex, pure recompute, no notify (the coalesced-flush discipline). The review caught the port conflating Flutter's null-vs-zero dimension branches: FLUI's state starts at `viewport_dimension: 0.0`, so the first layout reinterpreted pre-seeded pixels as a page count (`with_initial_scroll_offset(209)` → 62,700px). Now modeled per the oracle's triple branch: a has-had-dimension flag (first layout bypasses), a `cached_page` field surviving collapse (immune to interleaved extent clamps), the `max(0.0)` numerator clamp, and an f32-scaled round-snap — with the remaining deferrals (`_pageToUseOnStartup`, fraction>1 centering) documented, not silently dropped.

## Evidence

- flui-widgets+flui-rendering: 2128 passed; workspace: 7721 passed (the one red is the concurrent session's uncommitted FAB edit); clippy `-D warnings`, fmt/port-check/inventory/taplo/typos, doctests: clean; existing 3.44.0 scroll parity corpus unchanged and green.
- Reviewer re-ran four mutants across two rounds (torn-read, keep-page revert, first-call recompute, numerator clamp) — all killed at the exact predicted values; formula fidelity verified branch-by-branch against `_PagePosition.applyViewportDimension`.
- Full review (doubling as the D1 API gate) + delta re-review: SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)