### PR TITLE
feat(widgets,rendering): implement PageView (ADR-0037 PR2)

### DIFF
--- a/crates/flui-rendering/src/view/scroll_position.rs
+++ b/crates/flui-rendering/src/view/scroll_position.rs
@@ -149,11 +149,11 @@ pub struct ScrollPositionSnapshot {
 /// - **First-ever establishment.** Flutter seeds `page` from
 ///   `_pageToUseOnStartup` (`PageController`'s `initialPage`, or a value
 ///   restored from `PageStorage`). `KeepFractionalPage`'s `initial_page`
-///   field carries that seed: `Some(page)` (what `PageController` sets, PR2)
-///   reproduces `_pageToUseOnStartup` on the first `apply_viewport_dimension`
-///   call; `None` (a bare `ScrollPosition` opting into this policy directly,
-///   with no controller) preserves PR1's original placeholder — that one
-///   call behaves like `KeepPixels`, leaving `pixels` untouched, so a value
+///   field carries that seed: `Some(page)` (what `PageController`,
+///   `flui-widgets`, sets) reproduces `_pageToUseOnStartup` on the first
+///   `apply_viewport_dimension` call; `None` (a bare `ScrollPosition` opting
+///   into this policy directly, with no controller) leaves `pixels`
+///   untouched on that one call — the same as `KeepPixels` — so a value
 ///   seeded via [`ScrollPosition::new`] is not reinterpreted as a page count
 ///   against a never-established prior dimension. PageStorage restoration is
 ///   not modeled (no `PageStorage` equivalent exists).
@@ -162,17 +162,18 @@ pub struct ScrollPositionSnapshot {
 ///   (`max(0, viewportDimension * (viewportFraction - 1) / 2)`), added to
 ///   both `getPageFromPixels` and `getPixelsFromPage`. This is not modeled
 ///   here — only `viewport_fraction <= 1.0` (many small pages per viewport,
-///   or exactly one) is exercised by PR1; a `viewport_fraction > 1.0` caller
-///   gets the un-centered formula until a real multi-page-viewport use case
+///   or exactly one) is exercised; a `viewport_fraction > 1.0` caller gets
+///   the un-centered formula until a real multi-page-viewport use case
 ///   lands.
-/// - **No public "current page" accessor.** Flutter also exposes
-///   `PageMetrics.page`/`_PagePosition.page`, a *defensively* guarded
-///   `max(0.0, clampDouble(pixels, min, max)) / max(1.0, viewportDimension *
-///   viewportFraction)` meant to be safe to call at any time (including
-///   before content dimensions exist). That is a different, public-facing
-///   computation from the internal recompute this policy drives, and is out
-///   of scope for PR1 — a future `page()`-style accessor should use the
-///   guarded formula, not this one.
+/// - **No public "current page" accessor on `ScrollPosition` itself.**
+///   Flutter also exposes `PageMetrics.page`/`_PagePosition.page`, a
+///   *defensively* guarded `max(0.0, clampDouble(pixels, min, max)) /
+///   max(1.0, viewportDimension * viewportFraction)` meant to be safe to
+///   call at any time (including before content dimensions exist), plus
+///   `_cachedPage` when collapsed. `flui-widgets`' `PageController::page`
+///   is that accessor — it reads [`ScrollPosition::cached_page`] first,
+///   falling back to the guarded formula (`ScrollMetrics::page`) only when
+///   the viewport isn't currently collapsed.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum DimensionChangePolicy {
@@ -189,9 +190,10 @@ pub enum DimensionChangePolicy {
     /// `viewport_fraction` is the fraction of the viewport one logical page
     /// occupies (`1.0` = one page per viewport, matching Flutter's
     /// `PageController.viewportFraction` default). Must be `> 0.0` — Flutter
-    /// asserts this at `PageController` construction; FLUI has no
-    /// `PageController` yet, so `set_dimension_policy`'s caller is
-    /// responsible (checked with a `debug_assert!` in the recompute).
+    /// asserts this at `PageController` construction; `flui-widgets`'
+    /// `PageController` asserts the same at its own construction, but
+    /// `set_dimension_policy`'s caller is responsible when constructing this
+    /// policy directly (checked with a `debug_assert!` in the recompute).
     KeepFractionalPage {
         /// Fraction of the viewport one logical page occupies. Must be
         /// `> 0.0`.
@@ -199,9 +201,9 @@ pub enum DimensionChangePolicy {
         /// The page to seed `pixels` from on the very first
         /// `apply_viewport_dimension` call. Mirrors `_pageToUseOnStartup`
         /// (`_PagePosition`'s `oldPixels == null` branch,
-        /// `widgets/page_view.dart`, tag `3.44.0`). `None` preserves this
-        /// policy's original PR1 behavior for a caller with no
-        /// controller-driven startup page — see the enum-level docs.
+        /// `widgets/page_view.dart`, tag `3.44.0`). `None` leaves `pixels`
+        /// untouched on that one call instead (a caller with no
+        /// controller-driven startup page) — see the enum-level docs.
         initial_page: Option<f32>,
     },
 }
@@ -411,12 +413,30 @@ impl ScrollPosition {
     /// substitute "has this position ever been laid out" signal (see
     /// [`DimensionChangePolicy`]'s docs for why dimension-application, not
     /// pixel-nullity, plays that role here); `PageController::page`/
-    /// `jump_to_page` (`flui-widgets`, PR2) consult this to decide whether a
-    /// page request can be resolved to real pixels yet or must instead update
-    /// the pending startup page.
+    /// `jump_to_page` (`flui-widgets`) consult this to decide whether a page
+    /// request can be resolved to real pixels yet or must instead update the
+    /// pending startup page.
     #[must_use]
     pub fn has_applied_viewport_dimension(&self) -> bool {
         self.inner.state.lock().has_applied_viewport_dimension
+    }
+
+    /// The page a [`DimensionChangePolicy::KeepFractionalPage`] policy is
+    /// currently caching for a collapsed (`viewport_dimension == 0.0`)
+    /// viewport, if any.
+    ///
+    /// # Flutter parity
+    ///
+    /// Mirrors `_PagePosition._cachedPage`. `PageController::page`
+    /// (`flui-widgets`) reads this first, falling back to the guarded
+    /// `ScrollMetrics::page` formula only when it is `None` — matching
+    /// `_PagePosition.page`'s own `_cachedPage ?? getPageFromPixels(...)`.
+    /// Always `None` while not collapsed: every branch of
+    /// `apply_viewport_dimension` that establishes a real (non-zero)
+    /// dimension clears it in the same lock acquisition.
+    #[must_use]
+    pub fn cached_page(&self) -> Option<f32> {
+        self.inner.state.lock().cached_page
     }
 
     /// Snapshots `pixels`, `min_scroll_extent`, `max_scroll_extent`, and
@@ -439,14 +459,22 @@ impl ScrollPosition {
         self.inner.state.lock().dimension_policy = policy;
     }
 
-    /// Overwrites the cached page a [`DimensionChangePolicy::KeepFractionalPage`]
-    /// policy is currently holding for a collapsed (`viewport_dimension ==
-    /// 0.0`) viewport, without waiting for a real dimension to recompute
-    /// `pixels` against. Returns `true` if the overwrite took effect.
+    /// Overwrites the page a [`DimensionChangePolicy::KeepFractionalPage`]
+    /// policy is currently holding cached for a collapsed
+    /// (`viewport_dimension == 0.0`) viewport, without waiting for a real
+    /// dimension to recompute `pixels` against. Returns `true` if the
+    /// overwrite took effect.
     ///
     /// A no-op (returns `false`) when the policy isn't `KeepFractionalPage`,
-    /// or the viewport isn't currently collapsed — this method only replaces
-    /// an *already-cached* page, it does not establish one.
+    /// the viewport isn't currently collapsed, or — the guard that keeps this
+    /// method's name honest — there is no page *already* cached to overwrite:
+    /// this method replaces an existing cache entry, it never establishes one
+    /// from nothing. In practice a genuinely collapsed `KeepFractionalPage`
+    /// position always has one already (every branch of
+    /// `apply_viewport_dimension` that lands on `viewport_dimension == 0.0`
+    /// sets `cached_page` in that same call), but the check makes that an
+    /// enforced precondition rather than an implicit fact a future edit to
+    /// those branches could quietly break.
     ///
     /// # Flutter parity
     ///
@@ -460,8 +488,10 @@ impl ScrollPosition {
     /// never-established branch, which does not run again once
     /// `has_applied_viewport_dimension` is already `true`; the steady-state
     /// branch that runs instead reads the private `cached_page`, not the
-    /// policy's `initial_page`. `PageController::jump_to_page` (`flui-widgets`,
-    /// PR2) calls this specifically for that already-collapsed case.
+    /// policy's `initial_page`. `PageController::jump_to_page`
+    /// (`flui-widgets`) calls this specifically for that already-collapsed
+    /// case.
+    #[must_use]
     pub fn set_cached_page_while_collapsed(&self, page: f32) -> bool {
         let mut state = self.inner.state.lock();
         if !matches!(
@@ -471,6 +501,14 @@ impl ScrollPosition {
             return false;
         }
         if !state.has_applied_viewport_dimension || state.viewport_dimension != 0.0 {
+            return false;
+        }
+        if state.cached_page.is_none() {
+            // Genuinely collapsed under `KeepFractionalPage` but nothing was
+            // ever cached — e.g. the policy was switched to
+            // `KeepFractionalPage` only AFTER the position had already
+            // collapsed under a different policy (`KeepPixels` never
+            // touches `cached_page`). Replacing, not establishing: no-op.
             return false;
         }
         state.cached_page = Some(page);
@@ -546,6 +584,35 @@ impl ScrollPosition {
         Arc::clone(&self.inner) as Arc<dyn Listenable>
     }
 
+    /// Whether any listeners are currently registered on this position's
+    /// notifier.
+    ///
+    /// Disposal-testing hook, mirroring `TransformationController::has_listeners`
+    /// (`interaction/transformation_controller.rs`) — a caller that mounts a
+    /// widget against this position (e.g. a `PageView`'s `on_page_changed`
+    /// subscription) and unmounts it, or swaps it for a different one, can
+    /// assert this returns `false` afterward, proving the subscription was
+    /// actually removed rather than left dangling into a torn-down subtree
+    /// or leaked past a controller swap.
+    #[must_use]
+    pub fn has_listeners(&self) -> bool {
+        self.inner.notifier.has_listeners()
+    }
+
+    /// The number of listeners currently registered on this position's
+    /// notifier. See [`has_listeners`](Self::has_listeners).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.notifier.len()
+    }
+
+    /// Whether this position's notifier currently has no listeners. See
+    /// [`len`](Self::len).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Whether `self` and `other` are clones of the same underlying position
     /// (share one `Arc`-backed inner state), not merely equal by value. A
     /// widget reconciling an injected `ScrollPosition` against the one
@@ -593,13 +660,13 @@ impl ViewportOffset for ScrollPosition {
             // compares against `null` for a never-established position, so a
             // first-ever call is NEVER treated as a no-op there — even when
             // it happens to carry `0.0` (a `PageView` mounted inside a
-            // currently-zero-size ancestor). Comparing raw `f32` values
-            // instead (this port's original PR1 shape) conflated "never
-            // established" with "established at literal `0.0`": a first
-            // call of exactly `0.0` matched `State::zero()`'s own default and
-            // silently short-circuited, so `has_applied_viewport_dimension`
-            // never flipped true and `KeepFractionalPage`'s first-establishment
-            // branch never ran for that call.
+            // currently-zero-size ancestor). Comparing raw `f32` values alone
+            // conflates "never established" with "established at literal
+            // `0.0`": a first call of exactly `0.0` would match
+            // `State::zero()`'s own default and silently short-circuit, so
+            // `has_applied_viewport_dimension` would never flip true and
+            // `KeepFractionalPage`'s first-establishment branch would never
+            // run for that call.
             if state.has_applied_viewport_dimension
                 && (state.viewport_dimension - viewport_dimension).abs() < f32::EPSILON
             {
@@ -1127,11 +1194,10 @@ mod tests {
         );
     }
 
-    // `initial_page` (PR2's `_pageToUseOnStartup` wiring) ------------------
+    // `initial_page` (`_pageToUseOnStartup` wiring) -------------------------
 
-    /// PR2 closes PR1's deferred first-establishment branch: `Some(page)`
-    /// seeds `pixels` from the controller-driven startup page on the very
-    /// first `apply_viewport_dimension` call, mirroring
+    /// `Some(page)` seeds `pixels` from the controller-driven startup page on
+    /// the very first `apply_viewport_dimension` call, mirroring
     /// `_pageToUseOnStartup` — in contrast to
     /// `keep_fractional_page_first_ever_dimension_does_not_reinterpret_seeded_pixels_as_a_page`,
     /// which pins the `None` (no controller) case leaving pre-seeded pixels
@@ -1204,9 +1270,9 @@ mod tests {
         );
     }
 
-    /// PR1 residual: `cached_page` must survive an `apply_content_dimensions`
-    /// extent clamp that runs WHILE the viewport is collapsed (interleaved
-    /// between the collapse and the restore) — not just a bare
+    /// `cached_page` must survive an `apply_content_dimensions` extent clamp
+    /// that runs WHILE the viewport is collapsed (interleaved between the
+    /// collapse and the restore) — not just a bare
     /// collapse-then-restore with nothing in between (already pinned by
     /// `keep_fractional_page_caches_the_page_across_a_zero_dimension_collapse_and_restore`).
     /// While collapsed, `pixels` reads `0.0`; a content-dimension clamp
@@ -1322,6 +1388,34 @@ mod tests {
         assert!(
             !position.set_cached_page_while_collapsed(5.0),
             "KeepPixels (the default policy) has no cached page to overwrite"
+        );
+    }
+
+    /// A no-op even under `KeepFractionalPage` when NOTHING has ever been
+    /// cached — i.e. the policy was switched to `KeepFractionalPage` only
+    /// AFTER the position had already collapsed under `KeepPixels`. This is
+    /// the "replaces, does not establish" guard: `viewport_dimension == 0.0`
+    /// and `has_applied_viewport_dimension` alone are not sufficient, because
+    /// neither branch that would have populated `cached_page` ever ran under
+    /// the prior `KeepPixels` policy.
+    #[test]
+    fn set_cached_page_while_collapsed_is_a_no_op_when_nothing_was_ever_cached() {
+        let mut position = ScrollPosition::zero();
+        assert!(position.apply_viewport_dimension(0.0)); // collapses under KeepPixels
+        position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
+            viewport_fraction: 1.0,
+            initial_page: None,
+        });
+
+        assert_eq!(
+            position.cached_page(),
+            None,
+            "sanity: switching policy after the fact does not retroactively cache a page"
+        );
+        assert!(
+            !position.set_cached_page_while_collapsed(5.0),
+            "a genuinely collapsed KeepFractionalPage position with nothing \
+             ever cached must reject the overwrite, not establish one from nothing"
         );
     }
 }

--- a/crates/flui-rendering/src/view/scroll_position.rs
+++ b/crates/flui-rendering/src/view/scroll_position.rs
@@ -148,11 +148,15 @@ pub struct ScrollPositionSnapshot {
 ///
 /// - **First-ever establishment.** Flutter seeds `page` from
 ///   `_pageToUseOnStartup` (`PageController`'s `initialPage`, or a value
-///   restored from `PageStorage`). FLUI has no `PageController` yet (that is
-///   PR2's job) — the first `apply_viewport_dimension` call instead leaves
-///   `pixels` untouched, i.e. behaves like `KeepPixels` for that one call.
-///   A caller that seeds `pixels` via [`ScrollPosition::new`] before the
-///   first layout gets that literal pixel value, not a page-relative one.
+///   restored from `PageStorage`). `KeepFractionalPage`'s `initial_page`
+///   field carries that seed: `Some(page)` (what `PageController` sets, PR2)
+///   reproduces `_pageToUseOnStartup` on the first `apply_viewport_dimension`
+///   call; `None` (a bare `ScrollPosition` opting into this policy directly,
+///   with no controller) preserves PR1's original placeholder — that one
+///   call behaves like `KeepPixels`, leaving `pixels` untouched, so a value
+///   seeded via [`ScrollPosition::new`] is not reinterpreted as a page count
+///   against a never-established prior dimension. PageStorage restoration is
+///   not modeled (no `PageStorage` equivalent exists).
 /// - **`viewport_fraction > 1.0`.** Flutter centers each page within a
 ///   wider-than-one-page viewport via `_initialPageOffset`
 ///   (`max(0, viewportDimension * (viewportFraction - 1) / 2)`), added to
@@ -192,6 +196,13 @@ pub enum DimensionChangePolicy {
         /// Fraction of the viewport one logical page occupies. Must be
         /// `> 0.0`.
         viewport_fraction: f32,
+        /// The page to seed `pixels` from on the very first
+        /// `apply_viewport_dimension` call. Mirrors `_pageToUseOnStartup`
+        /// (`_PagePosition`'s `oldPixels == null` branch,
+        /// `widgets/page_view.dart`, tag `3.44.0`). `None` preserves this
+        /// policy's original PR1 behavior for a caller with no
+        /// controller-driven startup page — see the enum-level docs.
+        initial_page: Option<f32>,
     },
 }
 
@@ -395,6 +406,19 @@ impl ScrollPosition {
         self.inner.state.lock().viewport_dimension
     }
 
+    /// Whether `apply_viewport_dimension` has ever committed a real
+    /// dimension — mirrors Flutter's `hasViewportDimension`. FLUI's
+    /// substitute "has this position ever been laid out" signal (see
+    /// [`DimensionChangePolicy`]'s docs for why dimension-application, not
+    /// pixel-nullity, plays that role here); `PageController::page`/
+    /// `jump_to_page` (`flui-widgets`, PR2) consult this to decide whether a
+    /// page request can be resolved to real pixels yet or must instead update
+    /// the pending startup page.
+    #[must_use]
+    pub fn has_applied_viewport_dimension(&self) -> bool {
+        self.inner.state.lock().has_applied_viewport_dimension
+    }
+
     /// Snapshots `pixels`, `min_scroll_extent`, `max_scroll_extent`, and
     /// `viewport_dimension` under a single lock acquisition. See
     /// [`ScrollPositionSnapshot`].
@@ -413,6 +437,44 @@ impl ScrollPosition {
     /// when the viewport's dimension changes. See [`DimensionChangePolicy`].
     pub fn set_dimension_policy(&self, policy: DimensionChangePolicy) {
         self.inner.state.lock().dimension_policy = policy;
+    }
+
+    /// Overwrites the cached page a [`DimensionChangePolicy::KeepFractionalPage`]
+    /// policy is currently holding for a collapsed (`viewport_dimension ==
+    /// 0.0`) viewport, without waiting for a real dimension to recompute
+    /// `pixels` against. Returns `true` if the overwrite took effect.
+    ///
+    /// A no-op (returns `false`) when the policy isn't `KeepFractionalPage`,
+    /// or the viewport isn't currently collapsed — this method only replaces
+    /// an *already-cached* page, it does not establish one.
+    ///
+    /// # Flutter parity
+    ///
+    /// Mirrors `PageController.jumpToPage`/`animateToPage`'s `position
+    /// ._cachedPage != null` branch (`widgets/page_view.dart`, tag `3.44.0`):
+    /// `position._cachedPage = page.toDouble()`. Needed because a `PageView`
+    /// resize sequence can pass through a collapsed viewport more than once
+    /// (e.g. hidden inside a currently-zero-size ancestor, then a page jump
+    /// request arrives, then the ancestor grows back) — [`set_dimension_policy`](Self::set_dimension_policy)
+    /// alone only affects the *next* `apply_viewport_dimension` call's
+    /// never-established branch, which does not run again once
+    /// `has_applied_viewport_dimension` is already `true`; the steady-state
+    /// branch that runs instead reads the private `cached_page`, not the
+    /// policy's `initial_page`. `PageController::jump_to_page` (`flui-widgets`,
+    /// PR2) calls this specifically for that already-collapsed case.
+    pub fn set_cached_page_while_collapsed(&self, page: f32) -> bool {
+        let mut state = self.inner.state.lock();
+        if !matches!(
+            state.dimension_policy,
+            DimensionChangePolicy::KeepFractionalPage { .. }
+        ) {
+            return false;
+        }
+        if !state.has_applied_viewport_dimension || state.viewport_dimension != 0.0 {
+            return false;
+        }
+        state.cached_page = Some(page);
+        true
     }
 
     /// Sets the scroll offset to `value`, unclamped, and notifies listeners
@@ -523,7 +585,24 @@ impl ViewportOffset for ScrollPosition {
     fn apply_viewport_dimension(&mut self, viewport_dimension: f32) -> bool {
         let changed = {
             let mut state = self.inner.state.lock();
-            if (state.viewport_dimension - viewport_dimension).abs() < f32::EPSILON {
+            // The equality short-circuit only applies once a REAL prior
+            // dimension is on record (`has_applied_viewport_dimension`).
+            // Mirrors Flutter's `hasViewportDimension => _viewportDimension
+            // != null` (`widgets/scroll_position.dart`, tag `3.44.0`):
+            // `_PagePosition.applyViewportDimension`'s own short-circuit
+            // compares against `null` for a never-established position, so a
+            // first-ever call is NEVER treated as a no-op there — even when
+            // it happens to carry `0.0` (a `PageView` mounted inside a
+            // currently-zero-size ancestor). Comparing raw `f32` values
+            // instead (this port's original PR1 shape) conflated "never
+            // established" with "established at literal `0.0`": a first
+            // call of exactly `0.0` matched `State::zero()`'s own default and
+            // silently short-circuited, so `has_applied_viewport_dimension`
+            // never flipped true and `KeepFractionalPage`'s first-establishment
+            // branch never ran for that call.
+            if state.has_applied_viewport_dimension
+                && (state.viewport_dimension - viewport_dimension).abs() < f32::EPSILON
+            {
                 false
             } else {
                 // Flutter parity: `_PagePosition.applyViewportDimension`
@@ -531,8 +610,10 @@ impl ViewportOffset for ScrollPosition {
                 // under the lock already held here — no notify, no
                 // scheduling; the dirty-flag + coalesced flush below carries
                 // the observable change.
-                if let DimensionChangePolicy::KeepFractionalPage { viewport_fraction } =
-                    state.dimension_policy
+                if let DimensionChangePolicy::KeepFractionalPage {
+                    viewport_fraction,
+                    initial_page,
+                } = state.dimension_policy
                 {
                     debug_assert!(
                         viewport_fraction > 0.0,
@@ -575,14 +656,28 @@ impl ViewportOffset for ScrollPosition {
                             state.cached_page = None;
                             state.pixels = page * (viewport_dimension * viewport_fraction);
                         }
+                    } else if let Some(start_page) = initial_page {
+                        // First-ever dimension establishment WITH a
+                        // controller-driven startup page: mirrors
+                        // `_pageToUseOnStartup`. Same zero-dimension collapse
+                        // handling as the steady-state branch above — a
+                        // `PageView` that never gets a real layout pass must
+                        // still not divide by zero.
+                        if viewport_dimension == 0.0 {
+                            state.cached_page = Some(start_page);
+                            state.pixels = 0.0;
+                        } else {
+                            state.cached_page = None;
+                            state.pixels = start_page * (viewport_dimension * viewport_fraction);
+                        }
                     }
-                    // else: first-ever dimension establishment. Flutter uses
-                    // `_pageToUseOnStartup` here (a `PageController`-level
-                    // concept PR2 introduces); until then this call behaves
-                    // like `KeepPixels` — the seeded `pixels` value (e.g.
-                    // from `ScrollPosition::new`) is left untouched rather
-                    // than reinterpreted as a page count against a
-                    // never-established prior dimension.
+                    // else: first-ever dimension establishment with no
+                    // controller-driven startup page (a bare `ScrollPosition`
+                    // opted into `KeepFractionalPage` directly). Behaves like
+                    // `KeepPixels` for this one call — the seeded `pixels`
+                    // value (e.g. from `ScrollPosition::new`) is left
+                    // untouched rather than reinterpreted as a page count
+                    // against a never-established prior dimension.
                 }
                 state.has_applied_viewport_dimension = true;
                 state.viewport_dimension = viewport_dimension;
@@ -884,6 +979,7 @@ mod tests {
         position.set_pixels(600.0); // page = 600 / (300 * 1.0) = 2.0
         position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
             viewport_fraction: 1.0,
+            initial_page: None,
         });
 
         assert!(position.apply_viewport_dimension(600.0));
@@ -904,6 +1000,7 @@ mod tests {
         position.set_pixels(720.0);
         position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
             viewport_fraction: 0.8,
+            initial_page: None,
         });
 
         assert!(position.apply_viewport_dimension(600.0));
@@ -923,6 +1020,7 @@ mod tests {
         position.set_pixels(150.0); // page = 150 / 300 = 0.5
         position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
             viewport_fraction: 1.0,
+            initial_page: None,
         });
 
         // Collapse to a zero dimension: the page (0.5) is cached, not
@@ -969,6 +1067,7 @@ mod tests {
         let mut position = ScrollPosition::new(209.0);
         position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
             viewport_fraction: 1.0,
+            initial_page: None,
         });
 
         assert!(position.apply_viewport_dimension(300.0));
@@ -991,6 +1090,7 @@ mod tests {
         position.set_pixels(-50.0); // overscrolled past min_scroll_extent
         position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
             viewport_fraction: 1.0,
+            initial_page: None,
         });
 
         assert!(position.apply_viewport_dimension(600.0));
@@ -1009,6 +1109,7 @@ mod tests {
         position.set_pixels(600.0);
         position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
             viewport_fraction: 1.0,
+            initial_page: None,
         });
 
         let notified = Arc::new(AtomicUsize::new(0));
@@ -1023,6 +1124,204 @@ mod tests {
             0,
             "the KeepFractionalPage recompute is a pure in-lock write — same \
              no-synchronous-notify contract as the KeepPixels path"
+        );
+    }
+
+    // `initial_page` (PR2's `_pageToUseOnStartup` wiring) ------------------
+
+    /// PR2 closes PR1's deferred first-establishment branch: `Some(page)`
+    /// seeds `pixels` from the controller-driven startup page on the very
+    /// first `apply_viewport_dimension` call, mirroring
+    /// `_pageToUseOnStartup` — in contrast to
+    /// `keep_fractional_page_first_ever_dimension_does_not_reinterpret_seeded_pixels_as_a_page`,
+    /// which pins the `None` (no controller) case leaving pre-seeded pixels
+    /// alone.
+    #[test]
+    fn keep_fractional_page_initial_page_seeds_pixels_on_first_establishment() {
+        // Pre-seeded at a pixel value that would be wrong if it survived —
+        // proves the startup page wins over whatever `ScrollPosition::new`
+        // seeded, unlike the `None` case.
+        let mut position = ScrollPosition::new(999.0);
+        position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
+            viewport_fraction: 1.0,
+            initial_page: Some(2.0),
+        });
+
+        assert!(position.apply_viewport_dimension(300.0));
+        assert_eq!(
+            position.pixels(),
+            600.0,
+            "the first-ever dimension establishment must seed pixels from the \
+             startup page (2.0 * 300 * 1.0 = 600.0), not preserve the \
+             pre-seeded 999.0"
+        );
+
+        // A SUBSEQUENT dimension change must go through the steady-state
+        // recompute (from the now-established pixels/dimension), not
+        // re-consult `initial_page` a second time.
+        assert!(position.apply_viewport_dimension(600.0));
+        assert_eq!(
+            position.pixels(),
+            1200.0,
+            "a later resize must recompute from the established page (2.0), \
+             not re-seed from initial_page"
+        );
+    }
+
+    /// The startup-page branch must handle a first-ever call that ALSO
+    /// collapses to a zero dimension (e.g. a `PageView` mounted inside a
+    /// currently-hidden/zero-size ancestor) — same zero-dimension caching as
+    /// the steady-state branch, no division by zero.
+    #[test]
+    fn keep_fractional_page_initial_page_caches_when_the_first_ever_dimension_is_zero() {
+        let mut position = ScrollPosition::zero();
+        position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
+            viewport_fraction: 1.0,
+            initial_page: Some(3.0),
+        });
+
+        assert!(position.apply_viewport_dimension(0.0));
+        assert!(
+            position.pixels().is_finite(),
+            "a zero first-ever dimension must not produce NaN/inf pixels"
+        );
+        assert_eq!(
+            position.pixels(),
+            0.0,
+            "a collapsed first-ever dimension has no pixel offset to derive; \
+             the startup page must be cached instead"
+        );
+
+        // Restoring to a real dimension must recover from the cached
+        // startup page (3.0), not from the stomped `pixels` (0.0).
+        assert!(position.apply_viewport_dimension(400.0));
+        assert_eq!(
+            position.pixels(),
+            1200.0,
+            "recovering from a zero first-ever dimension must apply the \
+             cached startup page (3.0 * 400 * 1.0 = 1200.0), not treat \
+             pixels (0.0) as page 0"
+        );
+    }
+
+    /// PR1 residual: `cached_page` must survive an `apply_content_dimensions`
+    /// extent clamp that runs WHILE the viewport is collapsed (interleaved
+    /// between the collapse and the restore) — not just a bare
+    /// collapse-then-restore with nothing in between (already pinned by
+    /// `keep_fractional_page_caches_the_page_across_a_zero_dimension_collapse_and_restore`).
+    /// While collapsed, `pixels` reads `0.0`; a content-dimension clamp
+    /// against a `min_scroll_extent` above zero would force `pixels` up to
+    /// that minimum — the restore must still use `cached_page`, not
+    /// re-derive a page from that clamped, no-longer-zero `pixels`.
+    #[test]
+    fn keep_fractional_page_cached_page_survives_an_interleaved_extent_clamp_while_collapsed() {
+        let mut position = ScrollPosition::zero();
+        assert!(position.apply_viewport_dimension(300.0));
+        position.set_pixels(150.0); // page = 150 / 300 = 0.5
+        position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
+            viewport_fraction: 1.0,
+            initial_page: None,
+        });
+
+        // Collapse: page 0.5 is cached, pixels reset to 0.0.
+        assert!(position.apply_viewport_dimension(0.0));
+        assert_eq!(position.pixels(), 0.0);
+
+        // Interleaved extent clamp WHILE collapsed: a `min_scroll_extent` of
+        // 40.0 forces the collapsed `pixels` (0.0) up to 40.0 — a value that
+        // has nothing to do with the cached page, and must not leak into the
+        // restore below. `apply_content_dimensions` returns `false` here
+        // (not `true`): the extents changed AND pixels needed re-clamping,
+        // the same "correction applied" signal `test_scrollable_viewport_offset_clamps_on_dimensions`
+        // pins for the non-paging `ScrollableViewportOffset` — not a bug this
+        // test is pinning, just its own return contract.
+        assert!(!position.apply_content_dimensions(40.0, 500.0));
+        assert_eq!(
+            position.pixels(),
+            40.0,
+            "the interleaved clamp must move pixels to the new min_scroll_extent \
+             while still collapsed — setting up the corruption this test guards \
+             against"
+        );
+
+        // Restore: must use cached_page (0.5), NOT re-derive from the
+        // clamped pixels (40.0) against the restored dimension — that would
+        // wrongly compute page = 40.0 / 600.0 ≈ 0.067, landing at ~40.0
+        // instead of 300.0.
+        assert!(position.apply_viewport_dimension(600.0));
+        assert_eq!(
+            position.pixels(),
+            300.0,
+            "the cached page (0.5) must survive the interleaved extent clamp — \
+             an interleaved apply_content_dimensions must not corrupt the \
+             collapsed-viewport page restore; got {:.1}",
+            position.pixels()
+        );
+    }
+
+    // set_cached_page_while_collapsed -------------------------------------
+
+    /// Mirrors `PageController.jumpToPage`'s `_cachedPage != null` branch: a
+    /// page request that arrives while the viewport is collapsed overwrites
+    /// the cached page directly, and that overwritten value (not whatever was
+    /// cached before) drives the restore once a real dimension arrives.
+    #[test]
+    fn set_cached_page_while_collapsed_overwrites_the_cached_page_and_drives_the_restore() {
+        let mut position = ScrollPosition::zero();
+        assert!(position.apply_viewport_dimension(300.0));
+        position.set_pixels(150.0); // page = 0.5
+        position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
+            viewport_fraction: 1.0,
+            initial_page: None,
+        });
+
+        // Collapse: page 0.5 is cached.
+        assert!(position.apply_viewport_dimension(0.0));
+
+        // A page request arrives while collapsed: overwrite the cache to 3.0.
+        assert!(
+            position.set_cached_page_while_collapsed(3.0),
+            "overwriting the cached page while genuinely collapsed must succeed"
+        );
+
+        // Restore: the OVERWRITTEN page (3.0), not the original 0.5, drives
+        // the recompute.
+        assert!(position.apply_viewport_dimension(400.0));
+        assert_eq!(
+            position.pixels(),
+            1200.0,
+            "the overwritten cached page (3.0) must drive the restore \
+             (3.0 * 400 * 1.0 = 1200.0), not the page cached before the \
+             overwrite (0.5, which would land at 200.0)"
+        );
+    }
+
+    /// A no-op when the viewport is NOT currently collapsed — this method
+    /// only replaces an already-cached page, it does not force a collapse.
+    #[test]
+    fn set_cached_page_while_collapsed_is_a_no_op_when_not_collapsed() {
+        let mut position = ScrollPosition::zero();
+        assert!(position.apply_viewport_dimension(300.0));
+        position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
+            viewport_fraction: 1.0,
+            initial_page: None,
+        });
+
+        assert!(
+            !position.set_cached_page_while_collapsed(5.0),
+            "a non-collapsed viewport (dimension 300.0) must reject the overwrite"
+        );
+    }
+
+    /// A no-op when the dimension policy isn't `KeepFractionalPage` at all —
+    /// there is no cached page to overwrite under `KeepPixels`.
+    #[test]
+    fn set_cached_page_while_collapsed_is_a_no_op_under_keep_pixels() {
+        let mut position = ScrollPosition::zero();
+        assert!(position.apply_viewport_dimension(0.0));
+        assert!(
+            !position.set_cached_page_while_collapsed(5.0),
+            "KeepPixels (the default policy) has no cached page to overwrite"
         );
     }
 }

--- a/crates/flui-widgets/src/lib.rs
+++ b/crates/flui-widgets/src/lib.rs
@@ -200,12 +200,13 @@ pub use overlay::{Overlay, OverlayEntry, OverlayEntryId, OverlayHandle};
 pub use paint::{ColoredBox, CustomPaint, DecoratedBox, Opacity, RepaintBoundary};
 pub use scroll::{
     BouncingScrollPhysics, ClampingScrollPhysics, CustomScrollView, GridView, ListView,
-    RefreshController, RefreshIndicator, RefreshIndicatorState, ScrollController, ScrollMetrics,
-    ScrollPhysics, Scrollable, Scrollbar, SharedScrollPhysics, ShrinkWrappingViewport,
-    SingleChildScrollView, SliverChildBuilderDelegate, SliverFillRemaining,
-    SliverFillRemainingAndOverscroll, SliverFillRemainingWithScrollable, SliverFillViewport,
-    SliverFixedExtentList, SliverGrid, SliverIgnorePointer, SliverList, SliverOffstage,
-    SliverOpacity, SliverPadding, SliverToBoxAdapter, Viewport,
+    PageController, PageScrollPhysics, PageView, PageViewState, RefreshController,
+    RefreshIndicator, RefreshIndicatorState, ScrollController, ScrollMetrics, ScrollPhysics,
+    Scrollable, Scrollbar, SharedScrollPhysics, ShrinkWrappingViewport, SingleChildScrollView,
+    SliverChildBuilderDelegate, SliverFillRemaining, SliverFillRemainingAndOverscroll,
+    SliverFillRemainingWithScrollable, SliverFillViewport, SliverFixedExtentList, SliverGrid,
+    SliverIgnorePointer, SliverList, SliverOffstage, SliverOpacity, SliverPadding,
+    SliverToBoxAdapter, Viewport,
 };
 pub use semantics::{ExcludeSemantics, MergeSemantics, Semantics};
 pub use stack::{IndexedStack, Positioned, Stack};
@@ -302,17 +303,18 @@ pub mod prelude {
         Listener, Localizations, LocalizationsDelegate, MediaQuery, MediaQueryData, MergeSemantics,
         MouseRegion, Navigator, NavigatorHandle, NextFocusAction, NextFocusIntent, Offstage,
         Opacity, OverflowBox, OverflowBoxFit, Overlay, OverlayEntry, OverlayEntryId, OverlayHandle,
-        Padding, PageRoute, PopScope, PopupRoute, Positioned, PreferredSize, PreferredSizeView,
-        PreviousFocusAction, PreviousFocusIntent, RepaintBoundary, RichText, RotatedBox, Row,
-        SafeArea, ScrollController, Scrollable, Scrollbar, Semantics, Shortcuts,
-        ShrinkWrappingViewport, SimpleRoute, SingleActivator, SingleChildScrollView, SizedBox,
-        SizedOverflowBox, SliverChildBuilderDelegate, SliverFillRemaining,
-        SliverFillRemainingAndOverscroll, SliverFillRemainingWithScrollable, SliverFillViewport,
-        SliverFixedExtentList, SliverGrid, SliverIgnorePointer, SliverList, SliverOffstage,
-        SliverOpacity, SliverPadding, SliverToBoxAdapter, Spacer, Stack, StreamBuilder, Table,
-        TableCell, TableRow, Text, TextEditingController, TextField, TickerMode, Transform,
-        ValueListenableBuilder, Viewport, Visibility, WidgetState, WidgetStateConstraint,
-        WidgetStateProperty, WidgetStates, WidgetStatesController, WidgetsLocalizations, Wrap,
+        Padding, PageController, PageRoute, PageScrollPhysics, PageView, PopScope, PopupRoute,
+        Positioned, PreferredSize, PreferredSizeView, PreviousFocusAction, PreviousFocusIntent,
+        RepaintBoundary, RichText, RotatedBox, Row, SafeArea, ScrollController, Scrollable,
+        Scrollbar, Semantics, Shortcuts, ShrinkWrappingViewport, SimpleRoute, SingleActivator,
+        SingleChildScrollView, SizedBox, SizedOverflowBox, SliverChildBuilderDelegate,
+        SliverFillRemaining, SliverFillRemainingAndOverscroll, SliverFillRemainingWithScrollable,
+        SliverFillViewport, SliverFixedExtentList, SliverGrid, SliverIgnorePointer, SliverList,
+        SliverOffstage, SliverOpacity, SliverPadding, SliverToBoxAdapter, Spacer, Stack,
+        StreamBuilder, Table, TableCell, TableRow, Text, TextEditingController, TextField,
+        TickerMode, Transform, ValueListenableBuilder, Viewport, Visibility, WidgetState,
+        WidgetStateConstraint, WidgetStateProperty, WidgetStates, WidgetStatesController,
+        WidgetsLocalizations, Wrap,
     };
 
     // Common configuration value types, so an app author needs only this import.

--- a/crates/flui-widgets/src/scroll/mod.rs
+++ b/crates/flui-widgets/src/scroll/mod.rs
@@ -13,6 +13,7 @@
 mod custom_scroll_view;
 mod grid_view;
 mod list_view;
+mod page_view;
 mod refresh_indicator;
 mod scroll_controller;
 mod scroll_physics;
@@ -34,6 +35,7 @@ mod viewport;
 pub use custom_scroll_view::CustomScrollView;
 pub use grid_view::GridView;
 pub use list_view::ListView;
+pub use page_view::{PageController, PageScrollPhysics, PageView, PageViewState};
 pub use refresh_indicator::{RefreshController, RefreshIndicator, RefreshIndicatorState};
 pub use scroll_controller::ScrollController;
 pub use scroll_physics::{

--- a/crates/flui-widgets/src/scroll/page_view.rs
+++ b/crates/flui-widgets/src/scroll/page_view.rs
@@ -25,13 +25,17 @@
 //!   not modeled — [`PageScrollPhysics`] is always applied (page snapping is
 //!   the only supported mode) and [`DimensionChangePolicy::KeepFractionalPage`]
 //!   already documents the `viewport_fraction > 1.0` gap it inherits.
+//!   [`PageView::cache_extent`]'s default DOES match the oracle's
+//!   `allowImplicitScrolling: false` default (`ScrollCacheExtent.viewport(0.0)`)
+//!   even though `allowImplicitScrolling` itself isn't modeled — see that
+//!   method's docs.
 //! - **`PageController::animateToPage`/`nextPage`/`previousPage`** (animated,
 //!   ticker-driven transitions) are not ported — [`PageController::jump_to_page`]
 //!   is the only programmatic navigation, matching `jumpToPage`.
 
 use std::rc::Rc;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use flui_animation::simulation::{ScrollSpringSimulation, Simulation, SpringDescription};
 use flui_foundation::{Listenable, ListenerId};
@@ -241,9 +245,13 @@ impl PageController {
     ///
     /// # Flutter parity
     ///
-    /// Uses the guarded [`ScrollMetrics::page`] formula (`PageMetrics.page`),
-    /// not the internal recompute `apply_viewport_dimension` drives — see
-    /// that method's docs. FLUI's `ScrollPosition` always "has pixels" (no
+    /// Mirrors `_PagePosition.page`'s `_cachedPage ?? getPageFromPixels(...)`:
+    /// consults [`ScrollPosition::cached_page`] first (the collapsed-viewport
+    /// case — a page tracked while the viewport reads `0.0`, which
+    /// `pixels / viewport_dimension` could never recover), falling back to
+    /// the guarded [`ScrollMetrics::page`] formula (`PageMetrics.page`) —
+    /// not the internal recompute `apply_viewport_dimension` drives — only
+    /// when not collapsed. FLUI's `ScrollPosition` always "has pixels" (no
     /// `hasPixels == false` state to mirror Flutter's pre-attach `null`), so
     /// [`ScrollPosition::has_applied_viewport_dimension`] is the substitute
     /// "not yet answerable" signal instead.
@@ -252,6 +260,9 @@ impl PageController {
         let position = self.scroll.position();
         if !position.has_applied_viewport_dimension() {
             return None;
+        }
+        if let Some(cached) = position.cached_page() {
+            return Some(cached);
         }
         let metrics = ScrollMetrics::from(&position);
         Some(metrics.page(self.viewport_fraction))
@@ -332,7 +343,12 @@ type OnPageChanged = Arc<dyn Fn(usize) + Send + Sync>;
 /// `padEnds`).
 #[derive(Clone, StatefulView)]
 pub struct PageView {
-    controller: PageController,
+    /// `None` when the caller never called [`PageView::controller`] — in
+    /// that case [`PageViewState`] owns a default [`PageController`] created
+    /// once in `create_state` and kept across rebuilds (see
+    /// [`PageView::controller`]'s docs for why this can't just default-clone
+    /// a fresh one on every build).
+    controller: Option<PageController>,
     scroll_direction: Axis,
     on_page_changed: Option<OnPageChanged>,
     cache_extent: Option<(f32, CacheExtentStyle)>,
@@ -341,23 +357,34 @@ pub struct PageView {
 
 impl PageView {
     /// A horizontally-scrolling page view over `children` (Flutter's default
-    /// `scrollDirection: Axis.horizontal`), with a fresh default
-    /// [`PageController`].
+    /// `scrollDirection: Axis.horizontal`). With no explicit
+    /// [`PageView::controller`], mirrors the oracle's default
+    /// `ScrollCacheExtent.viewport(0.0)` (`allowImplicitScrolling: false`'s
+    /// default) for [`PageView::cache_extent`] too.
     pub fn new(children: impl ViewSeq) -> Self {
         Self {
-            controller: PageController::new(),
+            controller: None,
             scroll_direction: Axis::Horizontal,
             on_page_changed: None,
-            cache_extent: None,
+            cache_extent: Some((0.0, CacheExtentStyle::Viewport)),
             children: children.into_boxed_vec(),
         }
     }
 
     /// Attach a [`PageController`] (position + page navigation). Multiple
     /// clones of the same controller share state.
+    ///
+    /// Omitting this entirely (the default) is NOT the same as calling it
+    /// with a fresh [`PageController::new`] on every rebuild: `PageViewState`
+    /// creates its own default controller exactly once (`create_state`) and
+    /// keeps it — and the current page it's tracking — alive across rebuilds
+    /// that don't pass an explicit controller. Mirrors Flutter's
+    /// `_PageViewState._initController`: `widget.controller ??
+    /// PageController()` only re-evaluates when `widget.controller` itself
+    /// changes, never unconditionally on every `build`.
     #[must_use]
     pub fn controller(mut self, controller: PageController) -> Self {
-        self.controller = controller;
+        self.controller = Some(controller);
         self
     }
 
@@ -380,6 +407,15 @@ impl PageView {
 
     /// Set how far beyond the visible page(s) to keep neighboring pages laid
     /// out and painted ([`Viewport::cache_extent`] passthrough).
+    ///
+    /// Defaults to `(0.0, CacheExtentStyle::Viewport)` — matching the
+    /// oracle's `PageView.scrollCacheExtent` default of
+    /// `ScrollCacheExtent.viewport(allowImplicitScrolling ? 1.0 : 0.0)`
+    /// evaluated at `allowImplicitScrolling: false` (the only value this
+    /// port models). `Viewport`'s own render-object default (250px, `Pixel`
+    /// style — `RenderViewport`'s general-purpose default, unrelated to
+    /// `PageView`) would otherwise silently keep neighboring pages laid out
+    /// and painted where the oracle keeps none.
     #[must_use]
     pub fn cache_extent(mut self, cache_extent: f32, style: CacheExtentStyle) -> Self {
         self.cache_extent = Some((cache_extent, style));
@@ -405,21 +441,48 @@ impl std::fmt::Debug for PageView {
 
 /// Persistent state for [`PageView`].
 ///
-/// Owns the `round(page)`-change listener registered on the controller's
-/// position in [`init_state`](ViewState::init_state) and removed in
+/// Owns the default [`PageController`] when the view config carries none
+/// (kept alive, current-page-and-all, across every rebuild that doesn't pass
+/// an explicit one — see [`PageView::controller`]), and the `round(page)`-
+/// change listener registered on the controller's position in
+/// [`init_state`](ViewState::init_state) / re-registered on a controller swap
+/// in [`did_update_view`](ViewState::did_update_view), removed in
 /// [`dispose`](ViewState::dispose).
 pub struct PageViewState {
     controller: PageController,
-    on_page_changed: Option<OnPageChanged>,
+    /// Shared, mutable slot for the current callback — NOT snapshotted into
+    /// the listener closure at registration time. `did_update_view` writes
+    /// through this `Arc<Mutex<_>>` on every rebuild; the listener (installed
+    /// once in `init_state`, or once per controller swap) dereferences it at
+    /// CALL time, so a callback change on an ordinary rebuild (no controller
+    /// swap) — including a `None` -> `Some` transition — is observed instead
+    /// of silently keeping whatever `init_state` captured.
+    on_page_changed: Arc<Mutex<Option<OnPageChanged>>>,
     last_reported_page: Arc<AtomicI64>,
-    page_listener_id: Option<ListenerId>,
+    /// The listenable the listener is registered on, alongside its id.
+    /// Stored together (not looked up fresh from `self.controller` at
+    /// removal time) because a controller SWAP changes which listenable
+    /// `self.controller.as_listenable()` resolves to — each notifier keeps
+    /// its own `ListenerId` counter, so removing by id from a DIFFERENT
+    /// notifier than the one that issued it can collide with an unrelated
+    /// listener there (silently removing the wrong one and leaking the
+    /// real one). Same shape `AnimatedBehavior::on_view_updated`
+    /// (`crates/flui-view/src/element/behavior.rs`) uses for a `Listenable`
+    /// swap.
+    page_listener: Option<(Arc<dyn Listenable>, ListenerId)>,
 }
 
 impl std::fmt::Debug for PageViewState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PageViewState")
             .field("controller", &self.controller)
-            .field("has_on_page_changed", &self.on_page_changed.is_some())
+            .field(
+                "has_on_page_changed",
+                &self
+                    .on_page_changed
+                    .lock()
+                    .is_ok_and(|guard| guard.is_some()),
+            )
             .field(
                 "last_reported_page",
                 &self.last_reported_page.load(Ordering::Relaxed),
@@ -428,47 +491,60 @@ impl std::fmt::Debug for PageViewState {
     }
 }
 
+impl PageViewState {
+    /// Subscribes to `self.controller`'s current listenable, tracking
+    /// `round(page)` changes and firing whatever callback
+    /// `self.on_page_changed` currently holds (dereferenced at call time —
+    /// see that field's docs). Stores the listenable alongside the returned
+    /// id so [`dispose`](ViewState::dispose) and a later controller swap in
+    /// [`did_update_view`](ViewState::did_update_view) remove from the exact
+    /// listenable this registered on.
+    fn register_page_listener(&mut self) {
+        let position = self.controller.position();
+        let viewport_fraction = self.controller.viewport_fraction();
+        let last_reported = Arc::clone(&self.last_reported_page);
+        let on_page_changed = Arc::clone(&self.on_page_changed);
+
+        let listenable = self.controller.as_listenable();
+        let listener_id = listenable.add_listener(Arc::new(move || {
+            if !position.has_applied_viewport_dimension() {
+                return;
+            }
+            let metrics = ScrollMetrics::from(&position);
+            // The guarded `page` formula clamps its numerator to >= 0.0
+            // before dividing, so `round()` never yields a negative value —
+            // the `.max(0.0)` here is belt-and-suspenders against a
+            // negative-zero rounding artifact, not a real overflow guard.
+            let current_page = metrics.page(viewport_fraction).round().max(0.0) as i64;
+            if current_page != last_reported.load(Ordering::SeqCst) {
+                last_reported.store(current_page, Ordering::SeqCst);
+                let callback = on_page_changed.lock().expect("not poisoned").clone();
+                if let Some(callback) = callback {
+                    callback(current_page as usize);
+                }
+            }
+        }));
+        self.page_listener = Some((listenable, listener_id));
+    }
+}
+
 impl StatefulView for PageView {
     type State = PageViewState;
 
     fn create_state(&self) -> Self::State {
+        let controller = self.controller.clone().unwrap_or_default();
         PageViewState {
-            controller: self.controller.clone(),
-            on_page_changed: self.on_page_changed.clone(),
-            last_reported_page: Arc::new(AtomicI64::new(self.controller.initial_page() as i64)),
-            page_listener_id: None,
+            last_reported_page: Arc::new(AtomicI64::new(controller.initial_page() as i64)),
+            controller,
+            on_page_changed: Arc::new(Mutex::new(self.on_page_changed.clone())),
+            page_listener: None,
         }
     }
 }
 
 impl ViewState<PageView> for PageViewState {
     fn init_state(&mut self, _ctx: &dyn BuildContext) {
-        let Some(on_page_changed) = self.on_page_changed.clone() else {
-            return;
-        };
-        let position = self.controller.position();
-        let viewport_fraction = self.controller.viewport_fraction();
-        let last_reported = Arc::clone(&self.last_reported_page);
-
-        let listener_id = self
-            .controller
-            .as_listenable()
-            .add_listener(Arc::new(move || {
-                if !position.has_applied_viewport_dimension() {
-                    return;
-                }
-                let metrics = ScrollMetrics::from(&position);
-                // The guarded `page` formula clamps its numerator to >= 0.0
-                // before dividing, so `round()` never yields a negative value —
-                // the `.max(0.0)` here is belt-and-suspenders against a
-                // negative-zero rounding artifact, not a real overflow guard.
-                let current_page = metrics.page(viewport_fraction).round().max(0.0) as i64;
-                if current_page != last_reported.load(Ordering::SeqCst) {
-                    last_reported.store(current_page, Ordering::SeqCst);
-                    on_page_changed(current_page as usize);
-                }
-            }));
-        self.page_listener_id = Some(listener_id);
+        self.register_page_listener();
     }
 
     fn build(&self, view: &PageView, _ctx: &dyn BuildContext) -> impl IntoView {
@@ -501,19 +577,51 @@ impl ViewState<PageView> for PageViewState {
     }
 
     fn did_update_view(&mut self, _old_view: &PageView, new_view: &PageView) {
-        // Track the current controller/callback so a parent rebuild handing
-        // a new configuration is reflected — same limitation as
-        // `ScrollableState::did_update_view`: a controller SWAP (not a
-        // mutation of the same shared controller) does not re-register the
-        // page-changed listener, which stays bound to whatever controller
-        // `init_state` saw.
-        self.controller = new_view.controller.clone();
-        self.on_page_changed.clone_from(&new_view.on_page_changed);
+        // The callback lives behind the shared slot the listener already
+        // dereferences at call time (see `on_page_changed`'s docs) — no
+        // listener re-registration needed for a callback-only change,
+        // including a `None` -> `Some` transition.
+        self.on_page_changed
+            .lock()
+            .expect("not poisoned")
+            .clone_from(&new_view.on_page_changed);
+
+        // No explicit controller in this build: keep the state-owned
+        // default (and its live subscription) across the rebuild — see
+        // `PageView::controller`'s docs for why this must NOT unconditionally
+        // adopt a fresh default every build.
+        let Some(new_controller) = &new_view.controller else {
+            return;
+        };
+
+        // Detect an actual controller SWAP by listenable identity — mirrors
+        // `AnimatedBehavior::on_view_updated`'s `Arc::ptr_eq` guard
+        // (`crates/flui-view/src/element/behavior.rs`): a rebuild that hands
+        // back the SAME controller (by far the common case when one IS
+        // explicitly supplied) must not tear down and rebuild the
+        // subscription.
+        let old_listenable = self.controller.as_listenable();
+        let new_listenable = new_controller.as_listenable();
+        let controller_swapped = !Arc::ptr_eq(&old_listenable, &new_listenable);
+
+        self.controller = new_controller.clone();
+
+        if controller_swapped {
+            // Remove from the OLD listenable specifically — never from
+            // whatever `self.controller` resolves to AFTER this assignment
+            // (a different notifier, whose own `ListenerId` counter could
+            // collide with this one and remove an unrelated listener while
+            // leaking this one).
+            if let Some((listenable, id)) = self.page_listener.take() {
+                listenable.remove_listener(id);
+            }
+            self.register_page_listener();
+        }
     }
 
     fn dispose(&mut self) {
-        if let Some(id) = self.page_listener_id.take() {
-            self.controller.as_listenable().remove_listener(id);
+        if let Some((listenable, id)) = self.page_listener.take() {
+            listenable.remove_listener(id);
         }
     }
 }

--- a/crates/flui-widgets/src/scroll/page_view.rs
+++ b/crates/flui-widgets/src/scroll/page_view.rs
@@ -518,7 +518,12 @@ impl PageViewState {
             let current_page = metrics.page(viewport_fraction).round().max(0.0) as i64;
             if current_page != last_reported.load(Ordering::SeqCst) {
                 last_reported.store(current_page, Ordering::SeqCst);
-                let callback = on_page_changed.lock().expect("not poisoned").clone();
+                let callback = on_page_changed
+                    .lock()
+                    .expect(
+                        "BUG: on_page_changed mutex poisoned — a panic escaped a locked section",
+                    )
+                    .clone();
                 if let Some(callback) = callback {
                     callback(current_page as usize);
                 }
@@ -583,7 +588,7 @@ impl ViewState<PageView> for PageViewState {
         // including a `None` -> `Some` transition.
         self.on_page_changed
             .lock()
-            .expect("not poisoned")
+            .expect("BUG: on_page_changed mutex poisoned — a panic escaped a locked section")
             .clone_from(&new_view.on_page_changed);
 
         // No explicit controller in this build: keep the state-owned

--- a/crates/flui-widgets/src/scroll/page_view.rs
+++ b/crates/flui-widgets/src/scroll/page_view.rs
@@ -1,0 +1,685 @@
+//! [`PageView`] — a scrollable list that works page by page, plus its
+//! [`PageController`] and [`PageScrollPhysics`].
+//!
+//! # Flutter parity
+//!
+//! Mirrors `widgets/page_view.dart` (tag `3.44.0`): `PageView` composes a
+//! [`Scrollable`] with [`PageScrollPhysics`] and a [`PageController`],
+//! `viewport_builder`-ing a [`Viewport`] over a single
+//! [`SliverFillViewport`] — the same "one sliver whose children each fill a
+//! `viewport_fraction`-sized page" shape the oracle uses (`SliverFillViewport`
+//! over `SliverChildDelegate` there; a plain eager child list here, see
+//! [`PageView`]'s own docs for that divergence).
+//!
+//! # Deferred / documented divergences from the oracle (v1)
+//!
+//! - **Eager children.** `SliverFillViewport` (`flui-widgets`) has no lazy
+//!   child delegate yet — every page attaches up front, not
+//!   `PageView.builder`'s on-demand construction.
+//! - **`on_page_changed` is listener-based**, not `NotificationListener<
+//!   ScrollNotification>` — FLUI has no scroll-notification bubbling yet.
+//!   Fires when `round(page)` changes, same as the oracle's
+//!   `_lastReportedPage` tracking.
+//! - **`pageSnapping: false`, `reverse`, `padEnds`, `allowImplicitScrolling`,
+//!   `PageStorage` restoration, and `viewport_fraction > 1.0` centering** are
+//!   not modeled — [`PageScrollPhysics`] is always applied (page snapping is
+//!   the only supported mode) and [`DimensionChangePolicy::KeepFractionalPage`]
+//!   already documents the `viewport_fraction > 1.0` gap it inherits.
+//! - **`PageController::animateToPage`/`nextPage`/`previousPage`** (animated,
+//!   ticker-driven transitions) are not ported — [`PageController::jump_to_page`]
+//!   is the only programmatic navigation, matching `jumpToPage`.
+
+use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use flui_animation::simulation::{ScrollSpringSimulation, Simulation, SpringDescription};
+use flui_foundation::{Listenable, ListenerId};
+use flui_rendering::view::{
+    CacheExtentStyle, DimensionChangePolicy, ScrollPosition, ViewportOffset,
+};
+use flui_types::layout::{Axis, AxisDirection};
+use flui_view::prelude::StatefulView;
+use flui_view::seq::ViewSeq;
+use flui_view::{BoxedView, BuildContext, IntoView, ViewExt, ViewState};
+
+use crate::scroll::{
+    ClampingScrollPhysics, ScrollController, ScrollMetrics, ScrollPhysics, Scrollable,
+    SharedScrollPhysics, SliverFillViewport, Viewport,
+};
+
+// ============================================================================
+// PageScrollPhysics
+// ============================================================================
+
+/// Scroll physics that snap a [`PageView`] to page boundaries after a drag or
+/// fling.
+///
+/// # Flutter parity
+///
+/// Mirrors `PageScrollPhysics` (`widgets/page_view.dart`, tag `3.44.0`):
+/// `_getTargetPixels`' velocity-vs-tolerance ±half-page bias, rounded to the
+/// nearest whole page, sprung to via [`ScrollSpringSimulation`]. FLUI's
+/// `ScrollPhysics` trait has no `parent`-chaining (see `scroll_physics.rs`'s
+/// module docs), so where the oracle defers out-of-range handling to
+/// `super.createBallisticSimulation` (its `parent` physics), this instead
+/// owns [`boundary`](Self::boundary) directly and delegates to it — the same
+/// effective behavior (Flutter's real usage always resolves `parent` to a
+/// platform physics anyway), without adding general trait-level chaining out
+/// of this PR's scope.
+#[derive(Debug, Clone)]
+pub struct PageScrollPhysics {
+    /// Fraction of the viewport one logical page occupies. Must match the
+    /// [`PageController`] driving the same [`PageView`] — this is how
+    /// `_getPage`/`_getPixels` in the oracle special-case `_PagePosition`
+    /// (which knows its own `viewportFraction`); FLUI's `ScrollMetrics`
+    /// snapshot carries no such field, so this physics must be told
+    /// separately.
+    pub viewport_fraction: f32,
+    /// Boundary-clamping and out-of-range ballistic physics this delegates
+    /// to. Defaults to [`ClampingScrollPhysics`] (Flutter's platform default
+    /// on most targets).
+    pub boundary: SharedScrollPhysics,
+    /// Spring configuration for the page-to-page snap. Flutter's base
+    /// `ScrollPhysics.spring` default (`SpringDescription.withDampingRatio(
+    /// mass: 0.5, stiffness: 100.0, ratio: 1.1)`) — `PageScrollPhysics` does
+    /// not override `spring` in the oracle, so this is NOT
+    /// `BouncingScrollPhysics`'s bouncier tuning.
+    pub spring: SpringDescription,
+    /// Below this absolute velocity (logical px/s), `_getTargetPixels`
+    /// applies no directional bias — the drag settles to the nearest page
+    /// rather than committing to next/previous. Mirrors `toleranceFor`'s
+    /// velocity term (`1.0 / (0.050 * devicePixelRatio)`) evaluated at
+    /// `devicePixelRatio == 1.0` — FLUI's `ScrollMetrics` carries no
+    /// device-pixel-ratio field (documented divergence, consistent with the
+    /// fixed velocity thresholds `ClampingScrollPhysics`/
+    /// `BouncingScrollPhysics` already use).
+    pub velocity_tolerance_px_per_sec: f32,
+}
+
+impl PageScrollPhysics {
+    /// Page-snapping physics for a [`PageView`] whose pages occupy
+    /// `viewport_fraction` of the viewport.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `viewport_fraction <= 0.0`.
+    #[must_use]
+    pub fn new(viewport_fraction: f32) -> Self {
+        assert!(
+            viewport_fraction > 0.0,
+            "PageScrollPhysics viewport_fraction must be > 0.0 (got {viewport_fraction})"
+        );
+        Self {
+            viewport_fraction,
+            boundary: Arc::new(ClampingScrollPhysics::new()),
+            spring: SpringDescription::with_damping_ratio(0.5, 100.0, 1.1),
+            velocity_tolerance_px_per_sec: 20.0,
+        }
+    }
+}
+
+impl ScrollPhysics for PageScrollPhysics {
+    fn apply_boundary_conditions(&self, metrics: &ScrollMetrics, proposed_pixels: f32) -> f32 {
+        self.boundary
+            .apply_boundary_conditions(metrics, proposed_pixels)
+    }
+
+    fn create_ballistic_simulation(
+        &self,
+        metrics: &ScrollMetrics,
+        velocity_px_per_sec: f32,
+    ) -> Option<Box<dyn Simulation>> {
+        // Out of range and not heading back in: defer entirely to the
+        // boundary physics, mirroring `super.createBallisticSimulation`
+        // (the oracle's `parent` chain).
+        if (velocity_px_per_sec <= 0.0 && metrics.pixels <= metrics.min_scroll_extent)
+            || (velocity_px_per_sec >= 0.0 && metrics.pixels >= metrics.max_scroll_extent)
+        {
+            return self
+                .boundary
+                .create_ballistic_simulation(metrics, velocity_px_per_sec);
+        }
+
+        let mut page = metrics.page(self.viewport_fraction);
+        if velocity_px_per_sec < -self.velocity_tolerance_px_per_sec {
+            page -= 0.5;
+        } else if velocity_px_per_sec > self.velocity_tolerance_px_per_sec {
+            page += 0.5;
+        }
+        let target = metrics.pixels_from_page(self.viewport_fraction, page.round());
+
+        if (target - metrics.pixels).abs() > f32::EPSILON {
+            Some(Box::new(ScrollSpringSimulation::new(
+                self.spring,
+                metrics.pixels,
+                target,
+                velocity_px_per_sec,
+            )))
+        } else {
+            None
+        }
+    }
+}
+
+// ============================================================================
+// PageController
+// ============================================================================
+
+/// Controls which page is visible in a [`PageView`].
+///
+/// # Flutter parity
+///
+/// Mirrors `PageController` (`widgets/page_view.dart`, tag `3.44.0`).
+/// `initial_page` and `viewport_fraction` are fixed at construction (Flutter
+/// declares both `final`) rather than mutable builder fields — retargeting
+/// either after construction has no oracle behavior to port (Flutter's own
+/// `viewportFraction` setter, used internally by `attach`, is not part of the
+/// public `PageController` API this port targets).
+#[derive(Clone, Debug)]
+pub struct PageController {
+    scroll: ScrollController,
+    initial_page: usize,
+    viewport_fraction: f32,
+}
+
+impl Default for PageController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PageController {
+    /// A controller starting at page `0` with `viewport_fraction: 1.0` —
+    /// Flutter's `PageController()` defaults.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_params(0, 1.0)
+    }
+
+    /// A controller starting at `initial_page`, with pages occupying
+    /// `viewport_fraction` of the viewport.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `viewport_fraction <= 0.0` (Flutter asserts the same at
+    /// `PageController` construction).
+    #[must_use]
+    pub fn with_params(initial_page: usize, viewport_fraction: f32) -> Self {
+        assert!(
+            viewport_fraction > 0.0,
+            "PageController viewport_fraction must be > 0.0 (got {viewport_fraction})"
+        );
+        let scroll = ScrollController::new();
+        scroll
+            .position()
+            .set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
+                viewport_fraction,
+                initial_page: Some(initial_page as f32),
+            });
+        Self {
+            scroll,
+            initial_page,
+            viewport_fraction,
+        }
+    }
+
+    /// The page shown when the controlled [`PageView`] is first laid out.
+    #[must_use]
+    pub fn initial_page(&self) -> usize {
+        self.initial_page
+    }
+
+    /// The fraction of the viewport each page occupies.
+    #[must_use]
+    pub fn viewport_fraction(&self) -> f32 {
+        self.viewport_fraction
+    }
+
+    /// The current fractional page, or `None` before the controlled
+    /// [`PageView`] has completed its first layout.
+    ///
+    /// # Flutter parity
+    ///
+    /// Uses the guarded [`ScrollMetrics::page`] formula (`PageMetrics.page`),
+    /// not the internal recompute `apply_viewport_dimension` drives — see
+    /// that method's docs. FLUI's `ScrollPosition` always "has pixels" (no
+    /// `hasPixels == false` state to mirror Flutter's pre-attach `null`), so
+    /// [`ScrollPosition::has_applied_viewport_dimension`] is the substitute
+    /// "not yet answerable" signal instead.
+    #[must_use]
+    pub fn page(&self) -> Option<f32> {
+        let position = self.scroll.position();
+        if !position.has_applied_viewport_dimension() {
+            return None;
+        }
+        let metrics = ScrollMetrics::from(&position);
+        Some(metrics.page(self.viewport_fraction))
+    }
+
+    /// Jumps to `page` without animation.
+    ///
+    /// # Flutter parity
+    ///
+    /// Mirrors `jumpToPage`'s three-way branch (`widgets/page_view.dart`, tag
+    /// `3.44.0`):
+    /// - **Currently collapsed** (a real dimension was established at least
+    ///   once, but the viewport currently reads `0.0`) — overwrites the
+    ///   cached page directly (`_cachedPage = page`), so a page jump
+    ///   requested while temporarily hidden takes effect the moment the
+    ///   viewport regains a real dimension.
+    /// - **Never established** — updates the pending startup page (mirrors
+    ///   `_pageToUseOnStartup`), same as before any layout has run.
+    /// - **Real, established dimension** — jumps directly, unclamped,
+    ///   matching `jumpTo`'s "without checking if the new value is in range"
+    ///   contract.
+    pub fn jump_to_page(&self, page: usize) {
+        let page_f = page as f32;
+        let mut position = self.scroll.position();
+        if position.set_cached_page_while_collapsed(page_f) {
+            return;
+        }
+        if position.has_applied_viewport_dimension() {
+            let metrics = ScrollMetrics::from(&position);
+            let pixels = metrics.pixels_from_page(self.viewport_fraction, page_f);
+            position.jump_to(pixels);
+        } else {
+            position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
+                viewport_fraction: self.viewport_fraction,
+                initial_page: Some(page_f),
+            });
+        }
+    }
+
+    /// The shared [`ScrollPosition`] backing this controller.
+    #[must_use]
+    pub fn position(&self) -> ScrollPosition {
+        self.scroll.position()
+    }
+
+    /// The underlying [`ScrollController`], for wiring into a [`Scrollable`].
+    #[must_use]
+    pub fn scroll_controller(&self) -> ScrollController {
+        self.scroll.clone()
+    }
+
+    /// An `Arc<dyn Listenable>` pointing at the same shared position.
+    #[must_use]
+    pub fn as_listenable(&self) -> Arc<dyn Listenable> {
+        self.scroll.as_listenable()
+    }
+}
+
+// ============================================================================
+// PageView (configuration)
+// ============================================================================
+
+/// A callback fired when the displayed page changes.
+type OnPageChanged = Arc<dyn Fn(usize) + Send + Sync>;
+
+/// A scrollable list that works page by page.
+///
+/// Each child fills [`PageController::viewport_fraction`] of the viewport
+/// along [`PageView::scroll_direction`]. `PageView` is pure composition over
+/// [`Scrollable`] + [`PageScrollPhysics`] + [`Viewport`] +
+/// [`SliverFillViewport`] — no new render objects.
+///
+/// # Flutter parity
+///
+/// Mirrors `PageView` (`widgets/page_view.dart`, tag `3.44.0`). See the
+/// module docs for the documented v1 divergences (eager children,
+/// listener-based `on_page_changed`, no `pageSnapping: false`/`reverse`/
+/// `padEnds`).
+#[derive(Clone, StatefulView)]
+pub struct PageView {
+    controller: PageController,
+    scroll_direction: Axis,
+    on_page_changed: Option<OnPageChanged>,
+    cache_extent: Option<(f32, CacheExtentStyle)>,
+    children: Vec<BoxedView>,
+}
+
+impl PageView {
+    /// A horizontally-scrolling page view over `children` (Flutter's default
+    /// `scrollDirection: Axis.horizontal`), with a fresh default
+    /// [`PageController`].
+    pub fn new(children: impl ViewSeq) -> Self {
+        Self {
+            controller: PageController::new(),
+            scroll_direction: Axis::Horizontal,
+            on_page_changed: None,
+            cache_extent: None,
+            children: children.into_boxed_vec(),
+        }
+    }
+
+    /// Attach a [`PageController`] (position + page navigation). Multiple
+    /// clones of the same controller share state.
+    #[must_use]
+    pub fn controller(mut self, controller: PageController) -> Self {
+        self.controller = controller;
+        self
+    }
+
+    /// The scroll axis (default [`Axis::Horizontal`]).
+    #[must_use]
+    pub fn scroll_direction(mut self, axis: Axis) -> Self {
+        self.scroll_direction = axis;
+        self
+    }
+
+    /// Called whenever the page in the center of the viewport changes —
+    /// fires when `round(page)` differs from the last reported page. See the
+    /// module docs for how this diverges from Flutter's
+    /// `NotificationListener<ScrollNotification>`-based implementation.
+    #[must_use]
+    pub fn on_page_changed(mut self, callback: impl Fn(usize) + Send + Sync + 'static) -> Self {
+        self.on_page_changed = Some(Arc::new(callback));
+        self
+    }
+
+    /// Set how far beyond the visible page(s) to keep neighboring pages laid
+    /// out and painted ([`Viewport::cache_extent`] passthrough).
+    #[must_use]
+    pub fn cache_extent(mut self, cache_extent: f32, style: CacheExtentStyle) -> Self {
+        self.cache_extent = Some((cache_extent, style));
+        self
+    }
+}
+
+impl std::fmt::Debug for PageView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PageView")
+            .field("controller", &self.controller)
+            .field("scroll_direction", &self.scroll_direction)
+            .field("has_on_page_changed", &self.on_page_changed.is_some())
+            .field("cache_extent", &self.cache_extent)
+            .field("children", &self.children.len())
+            .finish_non_exhaustive()
+    }
+}
+
+// ============================================================================
+// State
+// ============================================================================
+
+/// Persistent state for [`PageView`].
+///
+/// Owns the `round(page)`-change listener registered on the controller's
+/// position in [`init_state`](ViewState::init_state) and removed in
+/// [`dispose`](ViewState::dispose).
+pub struct PageViewState {
+    controller: PageController,
+    on_page_changed: Option<OnPageChanged>,
+    last_reported_page: Arc<AtomicI64>,
+    page_listener_id: Option<ListenerId>,
+}
+
+impl std::fmt::Debug for PageViewState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PageViewState")
+            .field("controller", &self.controller)
+            .field("has_on_page_changed", &self.on_page_changed.is_some())
+            .field(
+                "last_reported_page",
+                &self.last_reported_page.load(Ordering::Relaxed),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+impl StatefulView for PageView {
+    type State = PageViewState;
+
+    fn create_state(&self) -> Self::State {
+        PageViewState {
+            controller: self.controller.clone(),
+            on_page_changed: self.on_page_changed.clone(),
+            last_reported_page: Arc::new(AtomicI64::new(self.controller.initial_page() as i64)),
+            page_listener_id: None,
+        }
+    }
+}
+
+impl ViewState<PageView> for PageViewState {
+    fn init_state(&mut self, _ctx: &dyn BuildContext) {
+        let Some(on_page_changed) = self.on_page_changed.clone() else {
+            return;
+        };
+        let position = self.controller.position();
+        let viewport_fraction = self.controller.viewport_fraction();
+        let last_reported = Arc::clone(&self.last_reported_page);
+
+        let listener_id = self
+            .controller
+            .as_listenable()
+            .add_listener(Arc::new(move || {
+                if !position.has_applied_viewport_dimension() {
+                    return;
+                }
+                let metrics = ScrollMetrics::from(&position);
+                // The guarded `page` formula clamps its numerator to >= 0.0
+                // before dividing, so `round()` never yields a negative value —
+                // the `.max(0.0)` here is belt-and-suspenders against a
+                // negative-zero rounding artifact, not a real overflow guard.
+                let current_page = metrics.page(viewport_fraction).round().max(0.0) as i64;
+                if current_page != last_reported.load(Ordering::SeqCst) {
+                    last_reported.store(current_page, Ordering::SeqCst);
+                    on_page_changed(current_page as usize);
+                }
+            }));
+        self.page_listener_id = Some(listener_id);
+    }
+
+    fn build(&self, view: &PageView, _ctx: &dyn BuildContext) -> impl IntoView {
+        let controller = self.controller.clone();
+        let viewport_fraction = controller.viewport_fraction();
+        let scroll_direction = view.scroll_direction;
+        let axis_direction = match scroll_direction {
+            Axis::Horizontal => AxisDirection::LeftToRight,
+            Axis::Vertical => AxisDirection::TopToBottom,
+        };
+        let children = view.children.clone();
+        let cache_extent = view.cache_extent;
+        let physics: SharedScrollPhysics = Arc::new(PageScrollPhysics::new(viewport_fraction));
+
+        Scrollable::new()
+            .controller(controller.scroll_controller())
+            .physics(physics)
+            .scroll_direction(scroll_direction)
+            .viewport_builder(Rc::new(move |position: ScrollPosition| {
+                let sliver = SliverFillViewport::new(viewport_fraction, children.clone());
+                let mut viewport = Viewport::new((sliver,))
+                    .axis_direction(axis_direction)
+                    .position(position);
+                if let Some((extent, style)) = cache_extent {
+                    viewport = viewport.cache_extent(extent, style);
+                }
+                viewport.boxed()
+            }))
+            .boxed()
+    }
+
+    fn did_update_view(&mut self, _old_view: &PageView, new_view: &PageView) {
+        // Track the current controller/callback so a parent rebuild handing
+        // a new configuration is reflected — same limitation as
+        // `ScrollableState::did_update_view`: a controller SWAP (not a
+        // mutation of the same shared controller) does not re-register the
+        // page-changed listener, which stays bound to whatever controller
+        // `init_state` saw.
+        self.controller = new_view.controller.clone();
+        self.on_page_changed.clone_from(&new_view.on_page_changed);
+    }
+
+    fn dispose(&mut self) {
+        if let Some(id) = self.page_listener_id.take() {
+            self.controller.as_listenable().remove_listener(id);
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+//
+// `PageScrollPhysics::create_ballistic_simulation` is tested here at the pure
+// function level (metrics + velocity in, a `Simulation` out) rather than only
+// through a gesture-driven `PageView` in the `parity` integration corpus.
+// Reason: this crate's headless test harness dispatches pointer events with
+// real `Instant::now()` timestamps advanced by only a minimal OS-timer tick
+// (`advance_gesture_clock`), so a synthetic drag's *measured* release
+// velocity is enormous — `Scrollable::on_pan_end` clamps it to Flutter's
+// `kMaxFlingVelocity` (±8,000 px/s), still far above
+// `PageScrollPhysics::velocity_tolerance_px_per_sec` (20.0). A gesture-driven
+// settle test therefore can't isolate "distance-only rounding" from
+// "velocity-biased" behavior deterministically — exactly the halfway-vs-fling
+// distinction these tests exist to pin. The `parity` corpus still proves the
+// full gesture → physics → spring → settle pipeline wires up correctly (see
+// `a_full_drag_and_release_settles_the_page_view_through_the_real_gesture_and_spring_pipeline`
+// there) — it just doesn't isolate the halfway threshold, which needs exact
+// control over velocity that only a direct physics call can provide.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A 300px-per-page metrics snapshot (`viewport_fraction: 1.0`) at
+    /// `pixels`, with `min_scroll_extent: 0.0` and a generous
+    /// `max_scroll_extent` so boundary short-circuiting never triggers.
+    fn metrics_at(pixels: f32) -> ScrollMetrics {
+        ScrollMetrics::new(pixels, 0.0, 3000.0, 300.0)
+    }
+
+    /// A spring simulation's value 2 simulated seconds in — long enough for
+    /// `PageScrollPhysics`'s default spring (`with_damping_ratio(0.5, 100.0,
+    /// 1.1)`, overdamped) to settle within a fraction of a pixel of its
+    /// target. Mirrors the settle-tolerance pattern
+    /// `bouncing_physics_top_overscroll_springs_back_to_min_extent`
+    /// (`tests/parity/scrollable_test.rs`) uses via repeated `pump_for` — here
+    /// evaluated directly against the `Simulation`, with no gesture-harness
+    /// timing noise to isolate.
+    fn settled_x(sim: &dyn Simulation) -> f32 {
+        sim.x(2.0)
+    }
+
+    /// Oracle: `PageScrollPhysics._getTargetPixels`/`createBallisticSimulation`
+    /// (`widgets/page_view.dart`, tag `3.44.0`) — at velocity `0.0` (within
+    /// `velocity_tolerance_px_per_sec`), a position more than half a page past
+    /// the current page boundary settles FORWARD to the next page.
+    /// Cross-checked against `'Page changes at halfway point'`
+    /// (`test/widgets/page_view_test.dart`), whose 800px-wide viewport crosses
+    /// its halfway mark at a -420px drag (`-380` short of half, `-420` past
+    /// it) — the same "more than half" threshold this test pins at a 300px
+    /// page (`pixels: 160.0`, page `0.533`).
+    #[test]
+    fn settles_forward_past_the_halfway_point_at_zero_velocity() {
+        let physics = PageScrollPhysics::new(1.0);
+        let metrics = metrics_at(160.0); // page = 160 / 300 = 0.533 (> 0.5)
+        let sim = physics
+            .create_ballistic_simulation(&metrics, 0.0)
+            .expect("more than half a page off-boundary must produce a settle simulation");
+        assert!(
+            (settled_x(&sim) - 300.0).abs() < 1.0,
+            "a position past the halfway point at zero velocity must settle FORWARD to \
+             the next page (300.0), got {:.2}",
+            settled_x(&sim)
+        );
+    }
+
+    /// The converse of the above: less than half a page past the current
+    /// boundary, at zero velocity, settles BACKWARD to the current page —
+    /// the same halfway threshold, approached from below.
+    #[test]
+    fn settles_backward_below_the_halfway_point_at_zero_velocity() {
+        let physics = PageScrollPhysics::new(1.0);
+        let metrics = metrics_at(100.0); // page = 100 / 300 = 0.333 (< 0.5)
+        let sim = physics
+            .create_ballistic_simulation(&metrics, 0.0)
+            .expect("a nonzero off-boundary position must produce a settle simulation");
+        assert!(
+            (settled_x(&sim) - 0.0).abs() < 1.0,
+            "a position below the halfway point at zero velocity must settle BACK to \
+             the current page (0.0), got {:.2}",
+            settled_x(&sim)
+        );
+    }
+
+    /// Oracle: `_getTargetPixels`'s velocity bias — `velocity >
+    /// tolerance.velocity` adds `0.5` to the page BEFORE rounding, so a fling
+    /// above the tolerance commits to the NEXT page even from very close to
+    /// the current page's start (`page: 0.1`, nowhere near the 0.5 halfway
+    /// mark this same physics uses at rest — see the two tests above).
+    #[test]
+    fn fling_velocity_beyond_tolerance_advances_regardless_of_distance() {
+        let physics = PageScrollPhysics::new(1.0);
+        let metrics = metrics_at(30.0); // page = 30 / 300 = 0.1 (far from 0.5)
+        let velocity = physics.velocity_tolerance_px_per_sec + 10.0; // above tolerance
+        let sim = physics
+            .create_ballistic_simulation(&metrics, velocity)
+            .expect("a velocity above tolerance must produce a settle simulation");
+        assert!(
+            (settled_x(&sim) - 300.0).abs() < 1.0,
+            "velocity above tolerance must advance to the next page (300.0) despite \
+             sitting at only page 0.1, got {:.2}",
+            settled_x(&sim)
+        );
+    }
+
+    /// Symmetric to the above: a BACKWARD fling above tolerance commits back
+    /// to the current (lower) page even from close to the NEXT page's start.
+    #[test]
+    fn backward_fling_velocity_beyond_tolerance_retreats_regardless_of_distance() {
+        let physics = PageScrollPhysics::new(1.0);
+        let metrics = metrics_at(320.0); // page = 320 / 300 = 1.067 (just past page 1)
+        let velocity = -(physics.velocity_tolerance_px_per_sec + 10.0); // above tolerance, backward
+        let sim = physics
+            .create_ballistic_simulation(&metrics, velocity)
+            .expect("a velocity above tolerance must produce a settle simulation");
+        assert!(
+            (settled_x(&sim) - 300.0).abs() < 1.0,
+            "a backward fling above tolerance must retreat to page 1 (300.0) despite \
+             sitting at page 1.067, got {:.2}",
+            settled_x(&sim)
+        );
+    }
+
+    /// Oracle: out-of-range and not headed back in defers entirely to the
+    /// boundary physics (`super.createBallisticSimulation`'s `parent` chain).
+    /// `ClampingScrollPhysics` (the default boundary) returns `None` below its
+    /// own fling threshold, so a slow drag that overshot `max_scroll_extent`
+    /// produces no page-snap simulation at all.
+    #[test]
+    fn out_of_range_heading_further_out_of_range_defers_to_the_boundary_physics() {
+        let physics = PageScrollPhysics::new(1.0);
+        let metrics = ScrollMetrics::new(3100.0, 0.0, 3000.0, 300.0); // past max_scroll_extent
+        let sim = physics.create_ballistic_simulation(&metrics, 10.0); // below fling threshold, heading further out
+        assert!(
+            sim.is_none(),
+            "out-of-range with no boundary fling must defer to ClampingScrollPhysics, \
+             which returns None below its threshold"
+        );
+    }
+
+    /// `PageController::with_params` rejects a non-positive `viewport_fraction`
+    /// — mirrors `PageController`'s constructor assert (`assert(viewportFraction
+    /// > 0.0)`).
+    #[test]
+    #[should_panic(expected = "viewport_fraction must be > 0.0")]
+    fn page_controller_rejects_a_non_positive_viewport_fraction() {
+        let _ = PageController::with_params(0, 0.0);
+    }
+
+    /// `PageController::page` returns `None` before any layout has committed
+    /// a real viewport dimension — FLUI's substitute for Flutter's
+    /// `'PageController cannot return page while unattached'` assertion
+    /// (`test/widgets/page_view_test.dart`): a documented divergence returning
+    /// `Option::None` instead of panicking.
+    #[test]
+    fn page_returns_none_before_any_layout() {
+        let controller = PageController::with_params(2, 1.0);
+        assert_eq!(
+            controller.page(),
+            None,
+            "page() must return None before apply_viewport_dimension has ever run"
+        );
+    }
+}

--- a/crates/flui-widgets/src/scroll/scroll_physics.rs
+++ b/crates/flui-widgets/src/scroll/scroll_physics.rs
@@ -96,17 +96,19 @@ impl ScrollMetrics {
     /// Mirrors `PageMetrics.page` (`widgets/page_view.dart`, tag `3.44.0`):
     /// `max(0.0, clamp(pixels, min, max)) / max(1.0, viewport_dimension *
     /// viewport_fraction)`. This is the *public*, defensively-guarded
-    /// formula PR1's `DimensionChangePolicy` docs flagged as distinct from
-    /// the internal recompute `apply_viewport_dimension` drives — used by
-    /// both `PageController::page` and `PageScrollPhysics` (`page_view.rs`,
-    /// PR2) so the two agree on exactly what "the current page" means.
+    /// formula — distinct from the internal recompute
+    /// `ScrollPosition::apply_viewport_dimension` drives — used by both
+    /// `PageController::page` and `PageScrollPhysics` (`page_view.rs`) so the
+    /// two agree on exactly what "the current page" means.
     ///
-    /// Does not special-case a collapsed (`viewport_dimension == 0.0`)
-    /// viewport's cached page (`DimensionChangePolicy::KeepFractionalPage`'s
-    /// private `cached_page`, which this snapshot has no access to) —
-    /// documented divergence, inherited from PR1's own note that a future
-    /// `page()`-style accessor is out of scope for reconciling with that
-    /// internal cache.
+    /// This snapshot alone never special-cases a collapsed
+    /// (`viewport_dimension == 0.0`) viewport's cached page
+    /// (`DimensionChangePolicy::KeepFractionalPage`'s private `cached_page`,
+    /// which `ScrollMetrics` has no access to) — it always divides
+    /// `pixels`/`viewport_dimension` as written above. `PageController::page`
+    /// (`page_view.rs`) is the one that consults the cached page first via
+    /// `ScrollPosition::cached_page`, falling back to this formula only when
+    /// the viewport isn't currently collapsed.
     #[must_use]
     pub fn page(&self, viewport_fraction: f32) -> f32 {
         let clamped = self

--- a/crates/flui-widgets/src/scroll/scroll_physics.rs
+++ b/crates/flui-widgets/src/scroll/scroll_physics.rs
@@ -86,6 +86,49 @@ impl ScrollMetrics {
             viewport_dimension,
         }
     }
+
+    /// The current fractional "page" at `viewport_fraction`, defensively
+    /// guarded to be callable at any time (including before real content
+    /// dimensions exist).
+    ///
+    /// # Flutter parity
+    ///
+    /// Mirrors `PageMetrics.page` (`widgets/page_view.dart`, tag `3.44.0`):
+    /// `max(0.0, clamp(pixels, min, max)) / max(1.0, viewport_dimension *
+    /// viewport_fraction)`. This is the *public*, defensively-guarded
+    /// formula PR1's `DimensionChangePolicy` docs flagged as distinct from
+    /// the internal recompute `apply_viewport_dimension` drives — used by
+    /// both `PageController::page` and `PageScrollPhysics` (`page_view.rs`,
+    /// PR2) so the two agree on exactly what "the current page" means.
+    ///
+    /// Does not special-case a collapsed (`viewport_dimension == 0.0`)
+    /// viewport's cached page (`DimensionChangePolicy::KeepFractionalPage`'s
+    /// private `cached_page`, which this snapshot has no access to) —
+    /// documented divergence, inherited from PR1's own note that a future
+    /// `page()`-style accessor is out of scope for reconciling with that
+    /// internal cache.
+    #[must_use]
+    pub fn page(&self, viewport_fraction: f32) -> f32 {
+        let clamped = self
+            .pixels
+            .clamp(self.min_scroll_extent, self.max_scroll_extent);
+        clamped.max(0.0) / (self.viewport_dimension * viewport_fraction).max(1.0)
+    }
+
+    /// The inverse of [`page`](Self::page): the pixel offset for `page` at
+    /// `viewport_fraction`.
+    ///
+    /// # Flutter parity
+    ///
+    /// Mirrors `_PagePosition.getPixelsFromPage` (`widgets/page_view.dart`,
+    /// tag `3.44.0`): `page * viewport_dimension * viewport_fraction`. Unlike
+    /// [`page`](Self::page), this has no `max(1.0, ...)` guard — it is a
+    /// forward computation, not a division, so there is no zero-denominator
+    /// hazard to guard against.
+    #[must_use]
+    pub fn pixels_from_page(&self, viewport_fraction: f32, page: f32) -> f32 {
+        page * self.viewport_dimension * viewport_fraction
+    }
 }
 
 impl From<&ScrollPosition> for ScrollMetrics {
@@ -526,5 +569,57 @@ mod tests {
 
         stop.store(true, Ordering::Relaxed);
         writer.join().expect("writer thread must not panic");
+    }
+
+    // ScrollMetrics::page / pixels_from_page -----------------------------
+
+    #[test]
+    fn page_computes_the_guarded_fraction_at_full_viewport_fraction() {
+        // page = clamp(600, 0, 1000) / max(1.0, 300 * 1.0) = 2.0
+        let m = ScrollMetrics::new(600.0, 0.0, 1000.0, 300.0);
+        assert_eq!(m.page(1.0), 2.0);
+    }
+
+    #[test]
+    fn page_computes_the_guarded_fraction_at_a_partial_viewport_fraction() {
+        // page = clamp(720, 0, 1000) / max(1.0, 300 * 0.8) = 720 / 240 = 3.0
+        let m = ScrollMetrics::new(720.0, 0.0, 1000.0, 300.0);
+        assert_eq!(m.page(0.8), 3.0);
+    }
+
+    #[test]
+    fn page_clamps_pixels_to_the_extents_before_dividing() {
+        // pixels (-50.0) is below min_scroll_extent (0.0): clamp(-50, 0, 1000)
+        // = 0.0, then max(0.0, 0.0) = 0.0 -> page = 0.0, not a negative page.
+        let m = ScrollMetrics::new(-50.0, 0.0, 1000.0, 300.0);
+        assert_eq!(
+            m.page(1.0),
+            0.0,
+            "an overscrolled negative pixels value must clamp to page 0.0"
+        );
+    }
+
+    #[test]
+    fn page_guards_against_division_by_a_zero_viewport_dimension() {
+        let m = ScrollMetrics::new(50.0, 0.0, 1000.0, 0.0);
+        assert_eq!(
+            m.page(1.0),
+            50.0,
+            "max(1.0, 0.0) denominator guard must prevent a NaN/inf page \
+             before the viewport has laid out"
+        );
+    }
+
+    #[test]
+    fn pixels_from_page_is_the_inverse_of_page_at_matching_extents() {
+        let m = ScrollMetrics::new(0.0, 0.0, 1000.0, 300.0);
+        let pixels = m.pixels_from_page(0.8, 3.0);
+        assert_eq!(pixels, 720.0, "3.0 * 300 * 0.8 = 720.0");
+
+        let round_tripped = ScrollMetrics::new(pixels, 0.0, 1000.0, 300.0).page(0.8);
+        assert_eq!(
+            round_tripped, 3.0,
+            "pixels_from_page then page must round-trip"
+        );
     }
 }

--- a/crates/flui-widgets/src/scroll/scrollable.rs
+++ b/crates/flui-widgets/src/scroll/scrollable.rs
@@ -26,6 +26,7 @@
 //! `ScrollPosition` into `ScrollController` (v1 restriction: one position per
 //! controller).
 
+use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -44,7 +45,15 @@ use crate::{AnimatedBuilder, GestureDetector, SingleChildScrollView};
 /// A caller-supplied composition of the scrollable content, receiving the
 /// [`Scrollable`]'s shared [`ScrollPosition`] and returning the view to
 /// scroll. See [`Scrollable::viewport_builder`].
-pub type ViewportBuilder = Arc<dyn Fn(ScrollPosition) -> BoxedView + Send + Sync>;
+///
+/// `Rc`, not `Arc + Send + Sync`: `BoxedView` erases to `Box<dyn View>`, and
+/// `View` carries no `Send`/`Sync` supertrait (widget trees are built and
+/// laid out on one thread), so a closure that captures pre-built view
+/// content (e.g. an eager child list) can never satisfy `+ Send + Sync` —
+/// same reason `AnimatedBuilder`'s own builder closure
+/// (`transitions/animated_builder.rs`) is `Rc<dyn Fn() -> BoxedView>`, not
+/// `Arc<... + Send + Sync>`.
+pub type ViewportBuilder = Rc<dyn Fn(ScrollPosition) -> BoxedView>;
 
 // ---------------------------------------------------------------------------
 // View (configuration)

--- a/crates/flui-widgets/src/scroll/viewport.rs
+++ b/crates/flui-widgets/src/scroll/viewport.rs
@@ -5,7 +5,7 @@ use std::fmt;
 
 use flui_objects::{RenderShrinkWrappingViewport, RenderViewport};
 use flui_rendering::protocol::BoxProtocol;
-use flui_rendering::view::ScrollPosition;
+use flui_rendering::view::{CacheExtentStyle, ScrollPosition};
 use flui_types::layout::{Axis, AxisDirection};
 use flui_view::BoxedView;
 use flui_view::seq::ViewSeq;
@@ -61,6 +61,7 @@ fn default_cross_axis_direction(axis_direction: AxisDirection) -> AxisDirection 
 pub struct Viewport<C = Vec<BoxedView>> {
     axis_direction: AxisDirection,
     offset_source: OffsetSource,
+    cache_extent: Option<(f32, CacheExtentStyle)>,
     children: C,
 }
 
@@ -70,6 +71,7 @@ impl<C> Viewport<C> {
         Self {
             axis_direction: AxisDirection::TopToBottom,
             offset_source: OffsetSource::Pixels(0.0),
+            cache_extent: None,
             children,
         }
     }
@@ -106,13 +108,28 @@ impl<C> Viewport<C> {
         self
     }
 
+    /// Set how far beyond the visible viewport to keep slivers laid out and
+    /// painted (`RenderViewport::set_cache_extent`'s passthrough — the
+    /// render object has always supported this; this widget just lacked the
+    /// builder). `None` (the default) keeps the render object's own default.
+    #[must_use]
+    pub fn cache_extent(mut self, cache_extent: f32, style: CacheExtentStyle) -> Self {
+        self.cache_extent = Some((cache_extent, style));
+        self
+    }
+
     fn build_render_object(&self) -> RenderViewport<ScrollPosition> {
         let cross_axis_direction = default_cross_axis_direction(self.axis_direction);
         let position = match &self.offset_source {
             OffsetSource::Pixels(pixels) => ScrollPosition::new(*pixels),
             OffsetSource::Position(position) => position.clone(),
         };
-        RenderViewport::with_offset(self.axis_direction, cross_axis_direction, position)
+        let mut render_object =
+            RenderViewport::with_offset(self.axis_direction, cross_axis_direction, position);
+        if let Some((extent, style)) = self.cache_extent {
+            render_object.set_cache_extent(extent, style);
+        }
+        render_object
     }
 }
 
@@ -121,6 +138,7 @@ impl<C: ViewSeq> fmt::Debug for Viewport<C> {
         f.debug_struct("Viewport")
             .field("axis_direction", &self.axis_direction)
             .field("offset_source", &self.offset_source)
+            .field("cache_extent", &self.cache_extent)
             .field("children", &self.children.len())
             .finish()
     }
@@ -149,6 +167,9 @@ where
         // object), not just the scroll offset — otherwise a vertical↔horizontal
         // change keeps the stale axis from construction.
         render_object.set_axis_direction(self.axis_direction);
+        if let Some((extent, style)) = self.cache_extent {
+            render_object.set_cache_extent(extent, style);
+        }
         match &self.offset_source {
             OffsetSource::Pixels(pixels) => {
                 // Compat with today's behavior: push the new value into the

--- a/crates/flui-widgets/tests/parity/main.rs
+++ b/crates/flui-widgets/tests/parity/main.rs
@@ -114,5 +114,5 @@ mod draggable_test;
 // ── Business.1 implementation-gated fidelity unit — InteractiveViewer ───────
 mod interactive_viewer_test;
 
-// ── ADR-0037 PR2 — PageView ─────────────────────────────────────────────────
+// ── Paging (ADR-0037) — PageView ─────────────────────────────────────────────
 mod page_view_test;

--- a/crates/flui-widgets/tests/parity/main.rs
+++ b/crates/flui-widgets/tests/parity/main.rs
@@ -113,3 +113,6 @@ mod draggable_test;
 
 // ── Business.1 implementation-gated fidelity unit — InteractiveViewer ───────
 mod interactive_viewer_test;
+
+// ── ADR-0037 PR2 — PageView ─────────────────────────────────────────────────
+mod page_view_test;

--- a/crates/flui-widgets/tests/parity/page_view_test.rs
+++ b/crates/flui-widgets/tests/parity/page_view_test.rs
@@ -1,0 +1,476 @@
+//! Flutter parity tests — `PageView` (ADR-0037 PR2).
+//!
+//! Flutter source: `packages/flutter/test/widgets/page_view_test.dart` (tag
+//! `3.44.0`, **50** `testWidgets` cases —
+//! `awk '/testWidgets\(/{print NR}' test/widgets/page_view_test.dart | wc -l`).
+//!
+//! ## Scope of this port
+//!
+//! `crates/flui-widgets/src/scroll/page_view.rs`'s module docs record the
+//! exact V1 boundary (eager children, listener-based `on_page_changed`, no
+//! `pageSnapping: false`/`reverse`/`padEnds`/`allowImplicitScrolling`/
+//! `PageStorage`/`animateToPage`/`viewport_fraction > 1.0` centering). **9
+//! tests ported below**, covering the portable core:
+//!
+//! - `initial_page_lands_on_first_layout` — `initialPage` seeding, closing
+//!   PR1's explicitly deferred `_pageToUseOnStartup` gap. Cross-checked
+//!   against `'PageController control test'` (line 309).
+//! - `resize_keeps_the_page_across_a_viewport_dimension_change` —
+//!   `DimensionChangePolicy::KeepFractionalPage` end-to-end through a real
+//!   `PageView` resize. Cross-checked against `'PageController page
+//!   stability'` (line 360).
+//! - `dragging_past_half_reads_the_next_page_dragging_below_half_reads_the_current_page`
+//!   — the guarded `page()` getter tracks the LIVE drag position (no release
+//!   needed — a pure function of the dragged `pixels`, so no gesture-timing
+//!   noise). Cross-checked against `'Page changes at halfway point'` (line
+//!   480), read through `controller.page()` instead of `onPageChanged`.
+//! - `on_page_changed_fires_exactly_once_per_crossing` — the same halfway
+//!   drag, read through the `on_page_changed` callback instead. Directly
+//!   ports `'Page changes at halfway point'` (480)'s log-shape assertions
+//!   (empty below half, `[1]` once crossed, empty again after further
+//!   same-page movement).
+//! - `a_full_drag_and_release_settles_the_page_view_through_the_real_gesture_and_spring_pipeline`
+//!   — proves the full gesture → `PageScrollPhysics` → `ScrollSpringSimulation`
+//!   → settle pipeline is wired end-to-end. Cross-checked against `'Bouncing
+//!   scroll physics ballistics does not overshoot'` (531)'s "release and
+//!   settle" shape (with `ClampingScrollPhysics` as this port's boundary
+//!   physics, not `BouncingScrollPhysics`).
+//! - `viewport_fraction_spacing_matches_the_configured_fraction` —
+//!   `viewport_fraction: 0.8` end-to-end: a page's pixel offset is `page *
+//!   viewport_dimension * 0.8`, not `* 1.0` — the geometric fact that makes
+//!   neighboring pages peek into the viewport. Cross-checked against
+//!   `'PageView viewportFraction'` (586) / `'PageView small viewportFraction'`
+//!   (691).
+//! - `controller_page_tracks_the_current_scroll_position` — `PageMetrics`
+//!   (1064)'s "current page reflects `pixels`" contract.
+//! - `jump_to_page_navigates_synchronously_without_animation` —
+//!   `jumpToPage`'s "no animation, immediate" contract, exercised by
+//!   `'PageController control test'` (309) and `'PageView viewportFraction'`
+//!   (586).
+//! - `resize_from_a_zero_size_viewport_does_not_lose_the_jumped_to_page` —
+//!   the full collapse → jump-while-collapsed → restore pipeline (this is
+//!   where `ScrollPosition::set_cached_page_while_collapsed` — PR2's fix for
+//!   `PageController::jump_to_page`'s missing third branch — actually gets
+//!   exercised end-to-end). Directly ports `'PageView resize from zero-size
+//!   viewport should not lose state'` (64) and `'Change the page through the
+//!   controller when zero-size viewport'` (110).
+//!
+//! ## Why "past half"/"below half"/"fling velocity" aren't ALSO gesture-driven
+//! *release+settle* tests
+//!
+//! `PageScrollPhysics::create_ballistic_simulation`'s exact halfway threshold
+//! and velocity-tolerance override are tested directly, at the physics-unit
+//! level, in `crates/flui-widgets/src/scroll/page_view.rs`'s own `#[cfg(test)]`
+//! module (`settles_forward_past_the_halfway_point_at_zero_velocity`,
+//! `settles_backward_below_the_halfway_point_at_zero_velocity`,
+//! `fling_velocity_beyond_tolerance_advances_regardless_of_distance`,
+//! `backward_fling_velocity_beyond_tolerance_retreats_regardless_of_distance`)
+//! — not duplicated here as gesture-driven release+settle assertions. Reason:
+//! this crate's headless harness dispatches pointer events with real
+//! `Instant::now()` timestamps advanced by only a minimal OS-timer tick
+//! (`advance_gesture_clock`, `tests/common/mod.rs`), so a synthetic drag's
+//! *measured* release velocity is enormous — `Scrollable::on_pan_end` clamps
+//! it to Flutter's `kMaxFlingVelocity` (±8,000 px/s), still far above
+//! `PageScrollPhysics::velocity_tolerance_px_per_sec` (20.0). A gesture-driven
+//! settle test can't isolate "distance-only rounding" from "velocity-biased"
+//! behavior deterministically that way — precisely the distinction those four
+//! tests exist to pin with exact control over both inputs.
+//! `dragging_past_half_reads_the_next_page_dragging_below_half_reads_the_current_page`
+//! below still proves the halfway behavior end-to-end through a real drag —
+//! it just reads the live (pre-release) position instead of a post-release
+//! settle, which needs no velocity control at all. And
+//! `a_full_drag_and_release_settles_the_page_view_through_the_real_gesture_and_spring_pipeline`
+//! still proves gesture → physics → spring → settle wiring works, picked at a
+//! distance where the outcome is the same whether or not a velocity bias
+//! applies (see that test's own doc comment for the arithmetic).
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use flui_animation::Vsync;
+use flui_view::ViewExt;
+use flui_widgets::{PageController, PageView, SizedBox, VsyncScope};
+
+use crate::common::{lay_out, lay_out_with_arena, loose, tight};
+
+/// Five identical, distinguishable-by-index-only pages — geometry/state
+/// assertions read `PageController`, not page content, so the pages
+/// themselves carry no identity.
+fn pages(count: usize) -> Vec<flui_view::BoxedView> {
+    (0..count)
+        .map(|_| SizedBox::new(300.0, 300.0).boxed())
+        .collect()
+}
+
+// ============================================================================
+// initial_page
+// ============================================================================
+
+/// `PageController::with_params(2, 1.0)`'s `initial_page` must land on the
+/// FIRST layout — the exact gap PR1's `DimensionChangePolicy` docs flagged as
+/// deferred to "PR2's `PageController`", closed by wiring `initial_page:
+/// Some(_)` into `DimensionChangePolicy::KeepFractionalPage` and
+/// `ScrollPosition::apply_viewport_dimension`'s first-establishment branch.
+///
+/// Cross-checked against `'PageController control test'`
+/// (`test/widgets/page_view_test.dart`, line 309): `PageController(initialPage:
+/// 4)` shows `'California'` (index 4) on first pump, without any drag or
+/// jump.
+#[test]
+fn initial_page_lands_on_first_layout() {
+    let controller = PageController::with_params(2, 1.0);
+    let widget = PageView::new(pages(5)).controller(controller.clone());
+
+    let _laid = lay_out(widget, tight(300.0, 300.0));
+
+    assert_eq!(
+        controller.page(),
+        Some(2.0),
+        "initial_page (2) must be the current page immediately after the first layout"
+    );
+    assert_eq!(
+        controller.scroll_controller().pixels(),
+        600.0,
+        "initial_page 2 at a 300px viewport, viewport_fraction 1.0, must land at \
+         pixels = 2 * 300 * 1.0 = 600.0"
+    );
+}
+
+// ============================================================================
+// Resize
+// ============================================================================
+
+/// A `PageView` resize must preserve the current PAGE (not the raw pixel
+/// offset) — `DimensionChangePolicy::KeepFractionalPage`'s steady-state
+/// recompute (PR1), exercised end-to-end through a real `PageView`/
+/// `Scrollable`/`Viewport` layout, not just the unit-level `ScrollPosition`
+/// tests `crates/flui-rendering/src/view/scroll_position.rs` already pins.
+///
+/// Cross-checked against `'PageController page stability'`
+/// (`test/widgets/page_view_test.dart`, line 360): a `PageView` resized
+/// across several widths keeps showing the same page.
+#[test]
+fn resize_keeps_the_page_across_a_viewport_dimension_change() {
+    let controller = PageController::with_params(2, 1.0);
+    let page_view = PageView::new(pages(5)).controller(controller.clone());
+
+    let mut laid = lay_out(
+        SizedBox::new(300.0, 300.0).child(page_view.clone()),
+        loose(1000.0),
+    );
+    assert_eq!(controller.page(), Some(2.0), "sanity: initial_page landed");
+    assert_eq!(controller.scroll_controller().pixels(), 600.0);
+
+    // Resize 300 -> 600: the PAGE (2.0) must be preserved, recomputing pixels
+    // for the new dimension (2.0 * 600 * 1.0 = 1200.0) — not left at the
+    // stale 600.0 pixel offset (which would show a different page).
+    laid.pump_widget(SizedBox::new(600.0, 300.0).child(page_view.clone()));
+
+    assert_eq!(
+        controller.page(),
+        Some(2.0),
+        "a viewport resize must preserve the current PAGE, not the raw pixel offset"
+    );
+    assert_eq!(
+        controller.scroll_controller().pixels(),
+        1200.0,
+        "the preserved page (2.0) must recompute against the new dimension \
+         (2.0 * 600 * 1.0 = 1200.0)"
+    );
+}
+
+// ============================================================================
+// Halfway threshold — live drag position (no release/velocity involved)
+// ============================================================================
+
+/// The guarded `page()` getter tracks a LIVE drag's position — past the
+/// halfway mark, it reads the next page; short of it, the current page. This
+/// needs no gesture release or velocity control (a pure function of the
+/// dragged `pixels`), so it isolates the halfway threshold cleanly — see the
+/// module doc's "Why past half/below half/fling velocity aren't ALSO
+/// gesture-driven release+settle tests" section for why the RELEASE-driven
+/// spring behavior is instead tested at the physics-unit level.
+///
+/// Cross-checked against `'Page changes at halfway point'`
+/// (`test/widgets/page_view_test.dart`, line 480): an 800px-wide viewport
+/// crosses its halfway mark at -420px (`-380` short, `-420` past); this test
+/// pins the same "more than half" threshold at a 300px page (half = 150px).
+#[test]
+fn dragging_past_half_reads_the_next_page_dragging_below_half_reads_the_current_page() {
+    let controller = PageController::new();
+    let widget = PageView::new(pages(5)).controller(controller.clone());
+    let scoped = lay_out_with_arena(widget, tight(300.0, 300.0));
+
+    scoped.dispatch_pointer_down(200.0, 100.0);
+    scoped.dispatch_pointer_move(180.0, 100.0); // -20px: crosses slop, starts
+
+    // -100px more (total 100px, page 0.333): short of half.
+    scoped.dispatch_pointer_move(80.0, 100.0);
+    assert_eq!(
+        controller.page(),
+        Some(100.0 / 300.0),
+        "100px of 300 (page 0.333) is short of the halfway mark — page() must \
+         still read the fractional CURRENT-side value, not have jumped to 1.0"
+    );
+
+    // -60px more (total 160px, page 0.533): past half.
+    scoped.dispatch_pointer_move(20.0, 100.0);
+    let page_after_crossing = controller
+        .page()
+        .expect("page() must be Some once laid out");
+    assert!(
+        (page_after_crossing - 160.0 / 300.0).abs() < 1e-4,
+        "160px of 300 (page 0.533) is past the halfway mark; got {page_after_crossing}"
+    );
+
+    scoped.dispatch_pointer_up(20.0, 100.0);
+}
+
+/// Same halfway drag as above, read through `on_page_changed` instead of
+/// `controller.page()` directly — the ROUNDED page, firing exactly once per
+/// crossing.
+///
+/// Ports `'Page changes at halfway point'`
+/// (`test/widgets/page_view_test.dart`, line 480)'s log-shape assertions
+/// directly: empty while short of half, `[1]` once crossed, empty again for
+/// further movement that stays on the same (now-current) page.
+#[test]
+fn on_page_changed_fires_exactly_once_per_crossing() {
+    let log: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+    let log_cb = Arc::clone(&log);
+
+    let controller = PageController::new();
+    let widget = PageView::new(pages(5))
+        .controller(controller.clone())
+        .on_page_changed(move |page| {
+            log_cb.lock().expect("not poisoned").push(page);
+        });
+    let scoped = lay_out_with_arena(widget, tight(300.0, 300.0));
+
+    scoped.dispatch_pointer_down(200.0, 100.0);
+    scoped.dispatch_pointer_move(180.0, 100.0); // -20px: crosses slop, starts
+
+    // -100px more (total 100px, page 0.333): short of half — no fire.
+    scoped.dispatch_pointer_move(80.0, 100.0);
+    assert!(
+        log.lock().expect("not poisoned").is_empty(),
+        "short of the halfway mark must not fire on_page_changed"
+    );
+
+    // -60px more (total 160px, page 0.533): past half — fires once, page 1.
+    scoped.dispatch_pointer_move(20.0, 100.0);
+    assert_eq!(
+        *log.lock().expect("not poisoned"),
+        vec![1],
+        "crossing the halfway mark must fire on_page_changed exactly once, with page 1"
+    );
+
+    // -20px more (total 180px, page 0.6): still rounds to page 1 — no
+    // redundant re-fire.
+    scoped.dispatch_pointer_move(0.0, 100.0);
+    assert_eq!(
+        *log.lock().expect("not poisoned"),
+        vec![1],
+        "further movement within the same rounded page must not re-fire on_page_changed"
+    );
+
+    scoped.dispatch_pointer_up(0.0, 100.0);
+}
+
+// ============================================================================
+// Release + spring settle — the full pipeline, at an unambiguous distance
+// ============================================================================
+
+/// A genuine gesture → `PageScrollPhysics` → `ScrollSpringSimulation` →
+/// settle proof, at a drag distance chosen so the outcome is IDENTICAL
+/// whether or not this harness's inherently large release velocity (see the
+/// module doc) applies its ±0.5 page bias: dragging to page 0.533 (past half)
+/// settles to page 1 both at velocity 0 (`0.533` rounds to `1`) and under a
+/// same-direction (`+0.5`) bias (`0.533 + 0.5 = 1.033`, still rounds to `1`).
+/// This isolates "does the pipeline settle at all, to the right neighborhood"
+/// — not the exact halfway threshold, which the physics-unit tests pin
+/// precisely.
+#[test]
+fn a_full_drag_and_release_settles_the_page_view_through_the_real_gesture_and_spring_pipeline() {
+    let controller = PageController::new();
+    let widget = PageView::new(pages(5)).controller(controller.clone());
+    let vsync = Vsync::new();
+    let wrapped = VsyncScope::new(vsync.clone(), widget);
+    let mut scoped = lay_out_with_arena(wrapped, tight(300.0, 300.0));
+    scoped.adopt_vsync(vsync);
+
+    scoped.dispatch_pointer_down(250.0, 100.0);
+    scoped.dispatch_pointer_move(230.0, 100.0); // -20px: crosses slop, starts
+    scoped.dispatch_pointer_move(70.0, 100.0); // -160px more (total 160px, page 0.533)
+    scoped.dispatch_pointer_up(70.0, 100.0);
+
+    // Pump enough frames for the spring (mass 0.5, stiffness 100.0, damping
+    // ratio 1.1 — overdamped) to settle, mirroring
+    // `bouncing_physics_top_overscroll_springs_back_to_min_extent`
+    // (`tests/parity/scrollable_test.rs`).
+    for _ in 0..100 {
+        scoped.pump_for(Duration::from_millis(16));
+    }
+
+    let settled_pixels = controller.scroll_controller().pixels();
+    assert!(
+        (settled_pixels - 300.0).abs() < 1.0,
+        "the full gesture -> physics -> spring pipeline must settle at page 1 \
+         (pixels ~= 300.0) regardless of this harness's release-velocity bias \
+         direction; got {settled_pixels:.2}"
+    );
+}
+
+// ============================================================================
+// viewport_fraction
+// ============================================================================
+
+/// `viewport_fraction: 0.8` end-to-end: a page's pixel spacing is `page *
+/// viewport_dimension * 0.8`, not `* 1.0` — the geometric fact that a smaller
+/// fraction leaves part of the viewport showing the neighboring page(s).
+///
+/// Cross-checked against `'PageView viewportFraction'`
+/// (`test/widgets/page_view_test.dart`, line 586): a `viewportFraction`
+/// smaller than 1.0 changes each page's pixel spacing by exactly that
+/// fraction.
+#[test]
+fn viewport_fraction_spacing_matches_the_configured_fraction() {
+    let controller = PageController::with_params(0, 0.8);
+    let widget = PageView::new(pages(5)).controller(controller.clone());
+    let _laid = lay_out(widget, tight(300.0, 300.0));
+
+    controller.jump_to_page(1);
+    assert_eq!(
+        controller.scroll_controller().pixels(),
+        240.0,
+        "at viewport_fraction 0.8 in a 300px viewport, page 1 must land at \
+         1 * 300 * 0.8 = 240.0, not 300.0 (which viewport_fraction 1.0 would give) — \
+         the 60px shortfall is exactly the neighboring page peeking into view"
+    );
+
+    controller.jump_to_page(2);
+    assert_eq!(
+        controller.scroll_controller().pixels(),
+        480.0,
+        "page 2 at viewport_fraction 0.8 must land at 2 * 300 * 0.8 = 480.0"
+    );
+}
+
+// ============================================================================
+// controller.page tracking + jump_to_page
+// ============================================================================
+
+/// `PageController::page` tracks the CURRENT scroll position as it changes —
+/// not just what it read at layout time.
+///
+/// Cross-checked against `'PageMetrics'`
+/// (`test/widgets/page_view_test.dart`, line 1064): `page` reflects the
+/// scroll position's current `pixels`.
+#[test]
+fn controller_page_tracks_the_current_scroll_position() {
+    let controller = PageController::new();
+    let widget = PageView::new(pages(5)).controller(controller.clone());
+    let _laid = lay_out(widget, tight(300.0, 300.0));
+
+    assert_eq!(controller.page(), Some(0.0), "starts at page 0");
+
+    controller.position().set_pixels(450.0);
+    assert_eq!(
+        controller.page(),
+        Some(1.5),
+        "page() must track a direct pixel write (450 / 300 = 1.5), not a stale snapshot"
+    );
+
+    controller.position().set_pixels(900.0);
+    assert_eq!(
+        controller.page(),
+        Some(3.0),
+        "page() must track a second write (900 / 300 = 3.0)"
+    );
+}
+
+/// `jump_to_page` navigates synchronously, without animation — the pixel
+/// offset is exact and immediate, no frame pump needed.
+///
+/// Cross-checked against `'PageController control test'`
+/// (`test/widgets/page_view_test.dart`, line 309) and `'PageView
+/// viewportFraction'` (586), both of which read the jumped-to page
+/// immediately after `jumpToPage`/a single `pump`.
+#[test]
+fn jump_to_page_navigates_synchronously_without_animation() {
+    let controller = PageController::new();
+    let widget = PageView::new(pages(5)).controller(controller.clone());
+    let _laid = lay_out(widget, tight(300.0, 300.0));
+
+    controller.jump_to_page(3);
+
+    assert_eq!(
+        controller.scroll_controller().pixels(),
+        900.0,
+        "jump_to_page(3) must land at 3 * 300 * 1.0 = 900.0 immediately, with no animation"
+    );
+    assert_eq!(controller.page(), Some(3.0));
+}
+
+// ============================================================================
+// Zero-size viewport resilience
+// ============================================================================
+
+/// The full collapse -> jump-while-collapsed -> restore pipeline: a
+/// `PageController` navigated while its `PageView` sits inside a
+/// currently-zero-size ancestor must not lose that navigation once the
+/// ancestor resizes back to a real size. Two fixes made this pass together:
+///
+/// - `ScrollPosition::apply_viewport_dimension`'s short-circuit used to
+///   compare raw `f32` values, so a first-ever call carrying literally `0.0`
+///   (a `PageView` mounted inside an already-zero-size ancestor) matched
+///   `State::zero()`'s own default and silently no-opped — `has_
+///   applied_viewport_dimension` never flipped true, unlike Flutter's
+///   `hasViewportDimension => _viewportDimension != null`, whose null
+///   comparison never short-circuits a genuinely first call. Fixed by gating
+///   the short-circuit on `has_applied_viewport_dimension` itself.
+/// - `ScrollPosition::set_cached_page_while_collapsed` — the fix for
+///   `PageController::jump_to_page`'s missing third branch (Flutter's
+///   `_cachedPage != null` check). Without it, `jump_to_page` while collapsed
+///   computes pixels from the CURRENT (zero) dimension (landing at `0.0`)
+///   instead of overwriting the cached page, so the restore below would
+///   recompute page 0, not 4.
+///
+/// Directly ports `'PageView resize from zero-size viewport should not lose
+/// state'` (`test/widgets/page_view_test.dart`, line 64) and `'Change the
+/// page through the controller when zero-size viewport'` (110).
+#[test]
+fn resize_from_a_zero_size_viewport_does_not_lose_the_jumped_to_page() {
+    let controller = PageController::new();
+    let page_view = PageView::new(pages(5)).controller(controller.clone());
+
+    let mut laid = lay_out(
+        SizedBox::new(0.0, 0.0).child(page_view.clone()),
+        loose(1000.0),
+    );
+    assert_eq!(
+        controller.scroll_controller().viewport_dimension_pixels(),
+        0.0,
+        "sanity: the viewport is genuinely collapsed to zero after the first layout"
+    );
+
+    // Navigate while collapsed — must take effect once the viewport resizes,
+    // not be silently lost or misread as pixels = 0.
+    controller.jump_to_page(4);
+
+    laid.pump_widget(SizedBox::new(300.0, 300.0).child(page_view.clone()));
+
+    assert_eq!(
+        controller.page(),
+        Some(4.0),
+        "a page jump requested while the viewport was collapsed must be honored \
+         once it resizes to a real dimension"
+    );
+    assert_eq!(
+        controller.scroll_controller().pixels(),
+        1200.0,
+        "the jumped-to page (4) must recompute against the restored dimension \
+         (4 * 300 * 1.0 = 1200.0), not read as page 0 (which the collapsed \
+         pixels value of 0.0 would wrongly suggest)"
+    );
+}

--- a/crates/flui-widgets/tests/parity/page_view_test.rs
+++ b/crates/flui-widgets/tests/parity/page_view_test.rs
@@ -1,4 +1,4 @@
-//! Flutter parity tests — `PageView` (ADR-0037 PR2).
+//! Flutter parity tests — `PageView`.
 //!
 //! Flutter source: `packages/flutter/test/widgets/page_view_test.dart` (tag
 //! `3.44.0`, **50** `testWidgets` cases —
@@ -9,12 +9,12 @@
 //! `crates/flui-widgets/src/scroll/page_view.rs`'s module docs record the
 //! exact V1 boundary (eager children, listener-based `on_page_changed`, no
 //! `pageSnapping: false`/`reverse`/`padEnds`/`allowImplicitScrolling`/
-//! `PageStorage`/`animateToPage`/`viewport_fraction > 1.0` centering). **9
+//! `PageStorage`/`animateToPage`/`viewport_fraction > 1.0` centering). **13
 //! tests ported below**, covering the portable core:
 //!
-//! - `initial_page_lands_on_first_layout` — `initialPage` seeding, closing
-//!   PR1's explicitly deferred `_pageToUseOnStartup` gap. Cross-checked
-//!   against `'PageController control test'` (line 309).
+//! - `initial_page_lands_on_first_layout` — `initialPage` seeding on the very
+//!   first layout. Cross-checked against `'PageController control test'`
+//!   (line 309).
 //! - `resize_keeps_the_page_across_a_viewport_dimension_change` —
 //!   `DimensionChangePolicy::KeepFractionalPage` end-to-end through a real
 //!   `PageView` resize. Cross-checked against `'PageController page
@@ -48,12 +48,30 @@
 //!   `'PageController control test'` (309) and `'PageView viewportFraction'`
 //!   (586).
 //! - `resize_from_a_zero_size_viewport_does_not_lose_the_jumped_to_page` —
-//!   the full collapse → jump-while-collapsed → restore pipeline (this is
-//!   where `ScrollPosition::set_cached_page_while_collapsed` — PR2's fix for
-//!   `PageController::jump_to_page`'s missing third branch — actually gets
-//!   exercised end-to-end). Directly ports `'PageView resize from zero-size
-//!   viewport should not lose state'` (64) and `'Change the page through the
-//!   controller when zero-size viewport'` (110).
+//!   the full collapse → jump-while-collapsed → restore pipeline, including
+//!   `controller.page()` reading the pending page WHILE still collapsed
+//!   (`ScrollPosition::cached_page`). Directly ports `'PageView resize from
+//!   zero-size viewport should not lose state'` (64) and `'Change the page
+//!   through the controller when zero-size viewport'` (110).
+//! - `a_rebuild_that_swaps_the_on_page_changed_callback_fires_the_new_one` —
+//!   a rebuild that only changes `on_page_changed` (same controller) must
+//!   fire the NEW callback, not whatever `init_state` first saw.
+//! - `swapping_the_controller_then_disposing_does_not_leak_or_collide_across_notifiers`
+//!   — a controller swap unsubscribes from the OLD controller's notifier
+//!   specifically and resubscribes to the new one; a later dispose removes
+//!   only this widget's own listener, not a pre-existing, unrelated listener
+//!   sharing the new controller's notifier (a per-notifier `ListenerId`
+//!   counter makes a naive "remove by id from whatever the current
+//!   controller resolves to" collide).
+//! - `a_parent_rebuild_with_no_explicit_controller_keeps_the_current_page` —
+//!   `PageView` without an explicit `.controller(...)` owns a default
+//!   `PageController` inside its own state, created once and kept alive
+//!   across every rebuild that doesn't pass an explicit one; a parent
+//!   rebuild must not reset the page to `0`.
+//! - `vertical_page_view_drag_crosses_to_the_next_page` — `Axis::Vertical`
+//!   coverage (the horizontal axis dominates the rest of this file, but
+//!   `PageView::scroll_direction` is not axis-agnostic-by-construction — a
+//!   `dy`-vs-`dx` mixup would only show up in a real vertical drag).
 //!
 //! ## Why "past half"/"below half"/"fling velocity" aren't ALSO gesture-driven
 //! *release+settle* tests
@@ -84,12 +102,15 @@
 //! distance where the outcome is the same whether or not a velocity bias
 //! applies (see that test's own doc comment for the arithmetic).
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use flui_animation::Vsync;
-use flui_view::ViewExt;
-use flui_widgets::{PageController, PageView, SizedBox, VsyncScope};
+use flui_types::layout::Axis;
+use flui_view::prelude::StatelessView;
+use flui_view::{BuildContext, IntoView, ViewExt};
+use flui_widgets::{GestureArenaScope, PageController, PageView, SizedBox, VsyncScope};
 
 use crate::common::{lay_out, lay_out_with_arena, loose, tight};
 
@@ -102,14 +123,49 @@ fn pages(count: usize) -> Vec<flui_view::BoxedView> {
         .collect()
 }
 
+/// Drags the pointer horizontally by `total_delta_x` px (negative = finger
+/// moves left, INCREASING `pixels` per `Scrollable`'s convention), split into
+/// multiple bounded down/move/move/up sessions so every dispatched
+/// coordinate stays on-canvas within a 300px-wide viewport.
+///
+/// `LaidOut::route_event` re-hit-tests at the exact `(x, y)` of every
+/// dispatched event, including moves (`tests/common/mod.rs`) — a single
+/// session covering more distance than the viewport is wide would dispatch
+/// an off-canvas move (e.g. a negative x) that silently fails to hit-test
+/// and never reaches the recognizer. Splitting into sessions (each a
+/// separate down/up cycle, like a user re-gripping mid-scroll) keeps every
+/// coordinate within `[50, 250]` while still accumulating onto the SAME
+/// underlying `ScrollPosition` across sessions.
+fn drag_horizontal_by(scoped: &crate::common::LaidOutScoped, total_delta_x: f32, y: f32) {
+    const START_X: f32 = 150.0;
+    const MAX_CHUNK: f32 = 100.0;
+    const SLOP: f32 = 20.0;
+
+    let mut remaining = total_delta_x;
+    while remaining.abs() > f32::EPSILON {
+        let chunk = remaining.clamp(-MAX_CHUNK, MAX_CHUNK);
+        let slop_offset = if chunk < 0.0 { -SLOP } else { SLOP };
+        // The slop-crossing move reports no delta (matches the established
+        // convention throughout this file); the SECOND move's delta from
+        // THAT position is what `on_pan_update` sees — so the final position
+        // must be `slop_offset + chunk` past `START_X`, not just `chunk`
+        // past it, for this session to contribute exactly `chunk`.
+        let final_x = START_X + slop_offset + chunk;
+        scoped.dispatch_pointer_down(START_X, y);
+        scoped.dispatch_pointer_move(START_X + slop_offset, y); // crosses slop, starts
+        scoped.dispatch_pointer_move(final_x, y); // fires on_pan_update with delta == chunk
+        scoped.dispatch_pointer_up(final_x, y);
+        remaining -= chunk;
+    }
+}
+
 // ============================================================================
 // initial_page
 // ============================================================================
 
 /// `PageController::with_params(2, 1.0)`'s `initial_page` must land on the
-/// FIRST layout — the exact gap PR1's `DimensionChangePolicy` docs flagged as
-/// deferred to "PR2's `PageController`", closed by wiring `initial_page:
-/// Some(_)` into `DimensionChangePolicy::KeepFractionalPage` and
+/// FIRST layout, wired through `initial_page: Some(_)` on
+/// `DimensionChangePolicy::KeepFractionalPage` and
 /// `ScrollPosition::apply_viewport_dimension`'s first-establishment branch.
 ///
 /// Cross-checked against `'PageController control test'`
@@ -142,9 +198,9 @@ fn initial_page_lands_on_first_layout() {
 
 /// A `PageView` resize must preserve the current PAGE (not the raw pixel
 /// offset) — `DimensionChangePolicy::KeepFractionalPage`'s steady-state
-/// recompute (PR1), exercised end-to-end through a real `PageView`/
-/// `Scrollable`/`Viewport` layout, not just the unit-level `ScrollPosition`
-/// tests `crates/flui-rendering/src/view/scroll_position.rs` already pins.
+/// recompute, exercised end-to-end through a real `PageView`/`Scrollable`/
+/// `Viewport` layout, not just the unit-level `ScrollPosition` tests
+/// `crates/flui-rendering/src/view/scroll_position.rs` already pins.
 ///
 /// Cross-checked against `'PageController page stability'`
 /// (`test/widgets/page_view_test.dart`, line 360): a `PageView` resized
@@ -458,6 +514,18 @@ fn resize_from_a_zero_size_viewport_does_not_lose_the_jumped_to_page() {
     // not be silently lost or misread as pixels = 0.
     controller.jump_to_page(4);
 
+    // The oracle asserts `controller.page == kStates.indexOf('Iowa')`
+    // (`'Change the page through the controller when zero-size viewport'`,
+    // line 110) WHILE STILL zero-size, before any resize — `page()` must
+    // read the pending page from `ScrollPosition::cached_page`, not
+    // `pixels / 0`-collapsed `0.0`.
+    assert_eq!(
+        controller.page(),
+        Some(4.0),
+        "page() must read the jumped-to page from the cache while still \
+         collapsed, not report page 0"
+    );
+
     laid.pump_widget(SizedBox::new(300.0, 300.0).child(page_view.clone()));
 
     assert_eq!(
@@ -473,4 +541,282 @@ fn resize_from_a_zero_size_viewport_does_not_lose_the_jumped_to_page() {
          (4 * 300 * 1.0 = 1200.0), not read as page 0 (which the collapsed \
          pixels value of 0.0 would wrongly suggest)"
     );
+}
+
+// ============================================================================
+// Rebuild-time callback / controller updates
+// ============================================================================
+
+/// A rebuild that swaps ONLY `on_page_changed` (the controller stays the
+/// same) must fire the NEW callback, not the one `init_state` first saw.
+/// `PageViewState`'s listener dereferences a shared, mutable slot at CALL
+/// time — `did_update_view` writes through it on every rebuild — rather than
+/// closing over a one-time snapshot of the callback.
+#[test]
+fn a_rebuild_that_swaps_the_on_page_changed_callback_fires_the_new_one() {
+    let old_log: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+    let new_log: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+    let controller = PageController::new();
+
+    let old_log_cb = Arc::clone(&old_log);
+    let widget = PageView::new(pages(5))
+        .controller(controller.clone())
+        .on_page_changed(move |page| {
+            old_log_cb.lock().expect("not poisoned").push(page);
+        });
+    let mut laid = lay_out(widget, tight(300.0, 300.0));
+
+    // Rebuild with the SAME controller, a DIFFERENT on_page_changed closure.
+    let new_log_cb = Arc::clone(&new_log);
+    laid.pump_widget(
+        PageView::new(pages(5))
+            .controller(controller.clone())
+            .on_page_changed(move |page| {
+                new_log_cb.lock().expect("not poisoned").push(page);
+            }),
+    );
+
+    controller.jump_to_page(2);
+
+    assert_eq!(
+        *new_log.lock().expect("not poisoned"),
+        vec![2],
+        "the callback installed by the rebuild must fire for a page change \
+         that happens AFTER the rebuild"
+    );
+    assert!(
+        old_log.lock().expect("not poisoned").is_empty(),
+        "the callback that was swapped OUT by the rebuild must never fire again"
+    );
+}
+
+/// A `StatelessView` host that can unmount `PageView` entirely (`show:
+/// false`) or swap which `PageController` it hands to a mounted one — the
+/// same "stable root TYPE, varying build output" pattern
+/// `InteractiveViewerHost` (`tests/parity/interactive_viewer_test.rs`) uses,
+/// since `pump_widget` reconciling two DIFFERENT concrete root types does not
+/// run the normal unmount/dispose path.
+#[derive(Clone, StatelessView)]
+struct PageViewHost {
+    controller: PageController,
+    show: bool,
+}
+
+impl StatelessView for PageViewHost {
+    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+        if !self.show {
+            return SizedBox::new(1.0, 1.0).into_view().boxed();
+        }
+        PageView::new(pages(5))
+            .controller(self.controller.clone())
+            .into_view()
+            .boxed()
+    }
+}
+
+/// Swapping `PageView`'s controller must unsubscribe from the OLD
+/// controller's notifier specifically — not whatever `self.controller`
+/// resolves to AFTER the swap — and a later dispose must remove only THIS
+/// widget's own listener(s), leaving a pre-existing, unrelated listener
+/// sharing the new controller's notifier untouched. A per-notifier
+/// `ListenerId` counter means a naive "always remove from `self.controller`'s
+/// current listenable" can collide: the pre-existing listener below is
+/// deliberately registered on `new_controller` BEFORE `PageView` ever adopts
+/// it, so it gets the FIRST id `new_controller`'s (fresh) counter issues —
+/// the same slot one of `PageView`'s own listeners would land in in a naive
+/// implementation that resolved the listenable fresh from `self.controller`
+/// at removal time instead of storing it at registration time.
+#[test]
+fn swapping_the_controller_then_disposing_does_not_leak_or_collide_across_notifiers() {
+    // A mounted `PageView` puts TWO listeners on its controller's notifier:
+    // `Scrollable`'s own `AnimatedBuilder` subscription (`scroll_controller
+    // .as_listenable()` inside `PageViewState::build`, sharing the exact same
+    // underlying `ScrollPosition` `PageController::as_listenable()` does) and
+    // `PageViewState`'s own `on_page_changed`-tracking listener.
+    const PAGE_VIEW_LISTENER_COUNT: usize = 2;
+
+    let old_controller = PageController::new();
+    let new_controller = PageController::new();
+
+    let external_notified = Arc::new(AtomicUsize::new(0));
+    let external_notified_cb = Arc::clone(&external_notified);
+    let _external_listener_id = new_controller
+        .as_listenable()
+        .add_listener(Arc::new(move || {
+            external_notified_cb.fetch_add(1, Ordering::SeqCst);
+        }));
+
+    let mut laid = lay_out(
+        PageViewHost {
+            controller: old_controller.clone(),
+            show: true,
+        },
+        tight(300.0, 300.0),
+    );
+    assert_eq!(
+        old_controller.position().len(),
+        PAGE_VIEW_LISTENER_COUNT,
+        "sanity: mounting subscribes Scrollable + PageView's own listener to old_controller"
+    );
+    assert_eq!(
+        new_controller.position().len(),
+        1,
+        "sanity: only the pre-existing external listener is on new_controller so far"
+    );
+
+    // Swap controllers on a rebuild — still mounted.
+    laid.pump_widget(PageViewHost {
+        controller: new_controller.clone(),
+        show: true,
+    });
+
+    assert_eq!(
+        old_controller.position().len(),
+        0,
+        "the old controller's listeners must be removed after the swap, not leaked"
+    );
+    assert_eq!(
+        new_controller.position().len(),
+        1 + PAGE_VIEW_LISTENER_COUNT,
+        "the new controller must gain Scrollable's + PageView's listeners \
+         alongside the pre-existing external one"
+    );
+
+    // Unmount entirely.
+    laid.pump_widget(PageViewHost {
+        controller: new_controller.clone(),
+        show: false,
+    });
+
+    assert_eq!(
+        new_controller.position().len(),
+        1,
+        "disposing must remove ONLY PageView's (and Scrollable's) own \
+         listeners from new_controller, leaving the pre-existing external one \
+         intact — a collision would either remove the external listener too \
+         (count 0) or fail to remove PageView's own (count stays higher)"
+    );
+
+    new_controller.position().set_pixels(123.0);
+    assert_eq!(
+        external_notified.load(Ordering::SeqCst),
+        1,
+        "the surviving external listener must still actually fire after PageView's dispose"
+    );
+}
+
+/// `PageView` with no explicit `.controller(...)` owns a default
+/// `PageController` inside its own state — created once, kept alive across
+/// every rebuild that doesn't pass an explicit one. A parent rebuild handing
+/// a FRESH `PageView` value (still no controller) must not discard that
+/// state-owned controller (and the page it's currently tracking) in favor of
+/// a brand-new one starting back at page 0.
+///
+/// The root stays the SAME `PageView` concrete type across the rebuild (a
+/// `pump_widget` reconciliation, not a remount), so `PageViewState` persists
+/// — this test proves `did_update_view` doesn't unconditionally overwrite
+/// that persisted state's controller from `new_view.controller` on every
+/// build (the bug: `PageView::new` used to always construct a FRESH default
+/// controller, silently discarding the current page on every rebuild).
+///
+/// Distinguishing "preserved" from "reset" needs an actual PROBE after the
+/// rebuild, not just an absence of a spurious `on_page_changed` fire (a
+/// silent controller-field reset alone doesn't itself fire anything — no
+/// gesture moves the position when the rebuild happens). This drags to an
+/// unambiguous page (pixels 300.0, page 1), rebuilds with no controller (still
+/// wrapped in the SAME outer `GestureArenaScope<PageView>` root type, so this
+/// is a genuine `pump_widget` update — see `PageViewHost`'s doc for why a bare
+/// root type swap wouldn't be), then drags 650px further via
+/// [`drag_horizontal_by`]'s bounded chunks — which, since `on_page_changed`
+/// fires at EVERY rounded-page crossing (not just the final one, see
+/// `on_page_changed_fires_exactly_once_per_crossing`), reports every page it
+/// passes through, not just where it lands: preserved (pixels 300 -> 950
+/// across `+100, +100, +100, +100, +100, +100, +50` chunks) crosses into
+/// rounds-to-2 territory once, then rounds-to-3 once, reporting `[2, 3]`;
+/// reset-to-a-fresh-controller (pixels 0 -> 650 via the same chunks) instead
+/// crosses `0 -> 1 -> 2`, but starts by DROPPING back through round-to-0
+/// first (`last_reported_page` itself survives the rebuild either way — it
+/// is not part of the controller being reset — so from its post-phase-1
+/// value of `1`, landing back near pixels 0 registers as a crossing back to
+/// `0` before climbing again), reporting `[0, 1, 2]`. The two sequences share
+/// no page in common, so this is unambiguous either way.
+#[test]
+fn a_parent_rebuild_with_no_explicit_controller_keeps_the_current_page() {
+    let log: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let log_cb = Arc::clone(&log);
+    let widget = PageView::new(pages(5)).on_page_changed(move |page| {
+        log_cb.lock().expect("not poisoned").push(page);
+    });
+    let mut scoped = lay_out_with_arena(widget, tight(300.0, 300.0));
+
+    // Phase 1: drag to pixels = 300.0 exactly (page 1.0).
+    drag_horizontal_by(&scoped, -300.0, 100.0);
+    assert_eq!(
+        *log.lock().expect("not poisoned"),
+        vec![1],
+        "sanity: the first drag reached page 1"
+    );
+
+    // Parent rebuild with NO explicit controller: a fresh `PageView` value,
+    // re-wrapped in a matching `GestureArenaScope` so the root's own
+    // concrete type stays identical across the swap (`PageViewHost`'s doc
+    // explains why a bare type change wouldn't reconcile as an update).
+    let log_cb2 = Arc::clone(&log);
+    let rewrapped = GestureArenaScope::new(
+        scoped.laid().arena(),
+        PageView::new(pages(5)).on_page_changed(move |page| {
+            log_cb2.lock().expect("not poisoned").push(page);
+        }),
+    );
+    scoped.pump_widget(rewrapped);
+
+    // Phase 2: drag 650px further, in bounded chunks (see
+    // `drag_horizontal_by`'s docs) — which cross MULTIPLE page boundaries
+    // along the way, each firing its own `on_page_changed`.
+    drag_horizontal_by(&scoped, -650.0, 100.0);
+
+    assert_eq!(
+        *log.lock().expect("not poisoned"),
+        vec![1, 2, 3],
+        "the rebuild must have kept the page-1 position (pixels 300.0) alive: \
+         a further 650px drag must climb straight through pages 2 and 3 \
+         (950 / 300 = 3.167 final), not first drop back to page 0 on the way \
+         up from a reset pixels-0.0 start (0 -> 1 -> 2, which discarding the \
+         state-owned controller for a fresh one would produce)"
+    );
+}
+
+// ============================================================================
+// Vertical axis
+// ============================================================================
+
+/// `Axis::Vertical` coverage: a vertical `PageView` must track `dy` drags the
+/// same way the rest of this file's horizontal cases track `dx` — the only
+/// test in this file that isn't `Axis::Horizontal` (the module default),
+/// closing the gap a `dy`-vs-`dx` mixup in `Scrollable`'s axis handling could
+/// otherwise hide.
+#[test]
+fn vertical_page_view_drag_crosses_to_the_next_page() {
+    let controller = PageController::new();
+    let widget = PageView::new(pages(5))
+        .controller(controller.clone())
+        .scroll_direction(Axis::Vertical);
+    let scoped = lay_out_with_arena(widget, tight(300.0, 300.0));
+
+    scoped.dispatch_pointer_down(100.0, 200.0);
+    scoped.dispatch_pointer_move(100.0, 180.0); // -20px dy: crosses slop, starts
+    scoped.dispatch_pointer_move(100.0, 20.0); // -160px dy more: pixels = 160.0
+
+    let page = controller
+        .page()
+        .expect("page() must be Some once laid out");
+    assert!(
+        (page - 160.0 / 300.0).abs() < 1e-4,
+        "a vertical PageView must track dy drags exactly like a horizontal one \
+         tracks dx; expected page {:.3}, got {page:.3}",
+        160.0 / 300.0
+    );
+
+    scoped.dispatch_pointer_up(100.0, 20.0);
 }

--- a/crates/flui-widgets/tests/scroll.rs
+++ b/crates/flui-widgets/tests/scroll.rs
@@ -917,14 +917,16 @@ fn scrollable_viewport_builder_composes_a_custom_viewport_with_working_drag_and_
     let controller = ScrollController::new();
     let widget = Scrollable::new()
         .controller(controller.clone())
-        .viewport_builder(Arc::new(|position: flui_widgets::ScrollPosition| {
-            let rows: Vec<_> = (0..12)
-                .map(|_| SizedBox::new(300.0, 50.0).boxed())
-                .collect();
-            Viewport::new((SliverFixedExtentList::new(50.0, rows),))
-                .position(position)
-                .boxed()
-        }));
+        .viewport_builder(std::rc::Rc::new(
+            |position: flui_widgets::ScrollPosition| {
+                let rows: Vec<_> = (0..12)
+                    .map(|_| SizedBox::new(300.0, 50.0).boxed())
+                    .collect();
+                Viewport::new((SliverFixedExtentList::new(50.0, rows),))
+                    .position(position)
+                    .boxed()
+            },
+        ));
 
     let scoped = lay_out_with_arena(widget, tight(300.0, 300.0));
 


### PR DESCRIPTION
Second PR of the paging layer: `PageView` lands as pure composition over the existing sliver-viewport substrate — `PageScrollPhysics` + `PageController` + a `SliverFillViewport`-hosting viewport builder, zero new render objects. 13-of-50 oracle cases ported (`page_view_test.dart` @ 3.44.0, full denominator with per-drop blockers).

## What

- **`PageScrollPhysics`** ports `_getTargetPixels` over PR1's `ScrollMetrics`: halfway threshold, velocity-vs-tolerance ±half-page bias, round, spring-to-boundary; boundary defer per the oracle's exact condition.
- **`PageController`**: `initial_page` (seeded through `KeepFractionalPage`, landing correctly on first layout), `viewport_fraction`, the *guarded* public `page` formula, and the collapsed case consulting the cached page — including the oracle's mid-collapse `controller.page` assertion the first cut had silently dropped (restored after review).
- **`PageView`**: eager children (documented divergence — no lazy `SliverFillViewport` delegate), `on_page_changed` firing exactly once per `round(page)` crossing through a call-time-dereferenced slot (a rebuild's new callback fires — the stale-capture bug was caught in review), a state-owned default controller surviving parent rebuilds (the reset-to-page-0 bug likewise), vertical axis tested, and the oracle's `viewport(0.0)` cache-extent default rather than the render object's general-purpose 250px.
- **Listener lifecycle hardened per the repo's established lesson**: the registered-on `Arc<dyn Listenable>` is stored beside the `ListenerId`, so a controller swap can never remove an unrelated listener by id collision (pinned by a genuinely collision-shaped test).
- Two follow-on fixes in PR1's `scroll_position.rs` caught during wiring: the first-ever `apply_viewport_dimension(0.0)` no longer no-ops (gate on the has-dimension flag, not an f32 compare — Flutter's null-compare semantics), and a page jump while collapsed persists through `set_cached_page_while_collapsed` (now replaces-only + `#[must_use]`).

## Evidence

- flui-widgets+flui-rendering: 2160 passed; workspace: 7753 passed (the one red remains the concurrent session's uncommitted FAB edit); clippy `-D warnings`, fmt/port-check/inventory/taplo/typos, doctests: clean.
- Reviewer re-ran seven mutants across two rounds (initial-page seed, collapsed jump, callback swap, dispose collision, default-controller adopt, on-page-changed dedup, round-vs-floor) — all killed at the exact predicted values; `_getTargetPixels` spot-computed; the ViewportBuilder `Arc<+Send+Sync>` → `Rc` relaxation verified structural (BoxedView can never be Send+Sync; AnimatedBuilder precedent).
- Full review + delta re-review: SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)