### PR TITLE
feat(widgets): ScrollController::animate_to + PageController animation methods (ADR-0037)

### DIFF
--- a/crates/flui-widgets/src/scroll/page_view.rs
+++ b/crates/flui-widgets/src/scroll/page_view.rs
@@ -29,14 +29,19 @@
 //!   `allowImplicitScrolling: false` default (`ScrollCacheExtent.viewport(0.0)`)
 //!   even though `allowImplicitScrolling` itself isn't modeled — see that
 //!   method's docs.
-//! - **`PageController::animateToPage`/`nextPage`/`previousPage`** (animated,
-//!   ticker-driven transitions) are not ported — [`PageController::jump_to_page`]
-//!   is the only programmatic navigation, matching `jumpToPage`.
+//! - **`PageController::animate_to_page`/`next_page`/`previous_page`**
+//!   (ADR-0037 PR3) delegate to [`ScrollController::animate_to`] — see that
+//!   type's module docs for the "no `Future`" divergence this inherits, and
+//!   [`PageController::next_page`]/[`PageController::previous_page`]'s own
+//!   docs for how end-of-range behavior diverges from the oracle's
+//!   physics-clamped ticks.
 
 use std::rc::Rc;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
+use flui_animation::Curve;
 use flui_animation::simulation::{ScrollSpringSimulation, Simulation, SpringDescription};
 use flui_foundation::{Listenable, ListenerId};
 use flui_rendering::view::{
@@ -300,6 +305,95 @@ impl PageController {
                 initial_page: Some(page_f),
             });
         }
+    }
+
+    /// Animates to `page` over `duration`, easing through `curve` — page →
+    /// pixels via the guarded [`ScrollMetrics::pixels_from_page`] formula,
+    /// then delegates to [`ScrollController::animate_to`].
+    ///
+    /// # Flutter parity
+    ///
+    /// Mirrors `PageController.animateToPage`'s three-way branch
+    /// (`widgets/page_view.dart`, tag `3.44.0`) — the same shape
+    /// [`jump_to_page`](Self::jump_to_page) uses: a page requested while the
+    /// viewport is collapsed just overwrites the cached page (there is no
+    /// viewport for an animation to visibly run in), one requested before any
+    /// layout has committed a real dimension updates the pending startup
+    /// page, and only a real, established dimension actually starts a run.
+    ///
+    /// The target page is **not** bounds-checked against a page count —
+    /// `PageController` has no visibility into how many children the
+    /// `PageView` holds, matching the oracle: `getPixelsFromPage` never
+    /// clamps `page` either. [`ScrollController::animate_to`]'s own clamp to
+    /// `[min_scroll_extent, max_scroll_extent]` is what stops the run at the
+    /// last/first real page instead of overshooting past it — see
+    /// [`next_page`](Self::next_page)/[`previous_page`](Self::previous_page)'s
+    /// docs for the resulting end-of-range behavior.
+    pub fn animate_to_page(
+        &self,
+        page: usize,
+        duration: Duration,
+        curve: Arc<dyn Curve + Send + Sync>, // PORT-CHECK-OK-DYN: see PopPacing's doc (navigator/binding.rs) — same erased easing-curve boundary
+    ) {
+        let page_f = page as f32;
+        let position = self.scroll.position();
+        if position.set_cached_page_while_collapsed(page_f) {
+            return;
+        }
+        if position.has_applied_viewport_dimension() {
+            let metrics = ScrollMetrics::from(&position);
+            let pixels = metrics.pixels_from_page(self.viewport_fraction, page_f);
+            self.scroll.animate_to(pixels, duration, curve);
+        } else {
+            position.set_dimension_policy(DimensionChangePolicy::KeepFractionalPage {
+                viewport_fraction: self.viewport_fraction,
+                initial_page: Some(page_f),
+            });
+        }
+    }
+
+    /// Animates forward to the next whole page from the current fractional
+    /// page, rounded (`page().round() + 1`). A no-op before the first layout
+    /// — there is no current [`page`](Self::page) to round from yet.
+    ///
+    /// # Flutter parity
+    ///
+    /// Mirrors `PageController.nextPage` (`page!.round() + 1`,
+    /// `widgets/page_view.dart`, tag `3.44.0`) — including NOT clamping the
+    /// requested page to a known last page: `PageController` doesn't track a
+    /// page count, so neither does the oracle here. Past the last real page,
+    /// [`animate_to_page`](Self::animate_to_page)'s delegated
+    /// [`ScrollController::animate_to`] clamps the resulting pixel target to
+    /// `max_scroll_extent`, so the run visibly stops AT the last page instead
+    /// of scrolling past it — the oracle reaches the same visible stopping
+    /// point through its physics' boundary-clamped per-tick `setPixels`
+    /// (`ClampingScrollPhysics.applyBoundaryConditions`) instead, since
+    /// `ScrollPositionWithSingleContext.animateTo` itself does not pre-clamp
+    /// the target the way this port's `animate_to` does.
+    pub fn next_page(
+        &self,
+        duration: Duration,
+        curve: Arc<dyn Curve + Send + Sync>, // PORT-CHECK-OK-DYN: see PopPacing's doc (navigator/binding.rs) — same erased easing-curve boundary
+    ) {
+        let Some(page) = self.page() else { return };
+        self.animate_to_page((page.round() + 1.0).max(0.0) as usize, duration, curve);
+    }
+
+    /// Animates backward to the previous whole page (`page().round() - 1`),
+    /// saturating at page `0` rather than underflowing — FLUI's page index is
+    /// `usize`, unlike the oracle's signed `int` (which can pass a transient
+    /// negative page into `getPixelsFromPage`); the saturated pixel target is
+    /// the same either way, since a negative page produces a negative pixel
+    /// offset that [`animate_to_page`](Self::animate_to_page)'s delegated
+    /// `animate_to` clamps to `min_scroll_extent` regardless. A no-op before
+    /// the first layout.
+    pub fn previous_page(
+        &self,
+        duration: Duration,
+        curve: Arc<dyn Curve + Send + Sync>, // PORT-CHECK-OK-DYN: see PopPacing's doc (navigator/binding.rs) — same erased easing-curve boundary
+    ) {
+        let Some(page) = self.page() else { return };
+        self.animate_to_page((page.round() - 1.0).max(0.0) as usize, duration, curve);
     }
 
     /// The shared [`ScrollPosition`] backing this controller.

--- a/crates/flui-widgets/src/scroll/page_view.rs
+++ b/crates/flui-widgets/src/scroll/page_view.rs
@@ -30,7 +30,7 @@
 //!   even though `allowImplicitScrolling` itself isn't modeled — see that
 //!   method's docs.
 //! - **`PageController::animate_to_page`/`next_page`/`previous_page`**
-//!   (ADR-0037 PR3) delegate to [`ScrollController::animate_to`] — see that
+//!   (ADR-0037) delegate to [`ScrollController::animate_to`] — see that
 //!   type's module docs for the "no `Future`" divergence this inherits, and
 //!   [`PageController::next_page`]/[`PageController::previous_page`]'s own
 //!   docs for how end-of-range behavior diverges from the oracle's

--- a/crates/flui-widgets/src/scroll/scroll_controller.rs
+++ b/crates/flui-widgets/src/scroll/scroll_controller.rs
@@ -18,8 +18,36 @@
 //! # Deferred (v1)
 //!
 //! - Multiple attached positions (one controller → many scrollables).
-//! - `animateTo` (driven animation to a target offset) — `set_pixels` is the
-//!   only way to move the position in v1; animated-to requires ticking.
+//!
+//! # `animate_to` (ADR-0037 PR3)
+//!
+//! [`ScrollController::animate_to`] queues a `PendingScrollCommand` — a
+//! private, mutex-guarded cell — rather than driving a ticker itself: the
+//! controller has no `AnimationController` of its own to animate with.
+//! `Scrollable`'s `ScrollableState` (`scrollable.rs`) already owns one (the
+//! vsync-registered fling controller its module docs describe) and services
+//! the queued command from its `AnimatedBuilder` rebuild closure, which
+//! reruns on every notify this controller fires. A user grab (`on_pan_start`)
+//! cancels the run for free, since it `stop()`s that same controller;
+//! [`jump_to`](ScrollController::jump_to) cancels through a SECOND, synchronous path — a
+//! `stop_hook` installed the same way — because a merely queued cancellation
+//! would only take effect on the next rebuild, one frame after
+//! `flui-binding`'s `pump_frame` has already ticked the not-yet-cancelled
+//! controller (Flutter parity: `ScrollPosition.jumpTo` calls `goIdle()`
+//! unconditionally and synchronously, even when the value doesn't change).
+//!
+//! **Divergence: no `Future`.** The oracle's `ScrollController.animateTo`
+//! returns `Future<void>` so a caller can `await` completion
+//! (`scroll_controller.dart`, tag `3.44.0`). FLUI has no widget-level async
+//! gate to await from `build`/event-handler code, so `animate_to` returns
+//! nothing — a caller cannot observe when the run finishes short of polling
+//! [`ScrollController::pixels`] or watching [`ScrollController::as_listenable`].
+//! Named follow-up: `flui-material`'s `TabController`/`TabBarView`
+//! (`tab_controller.rs`'s "`animate_to` is a documented alias" section)
+//! documents `TabController::animate_to` as a plain `set_index` alias
+//! specifically because no real `AnimationController`/`Ticker` wiring existed
+//! anywhere in this crate yet — that rebase is this PR's closure signal, not
+//! something this change reaches into `flui-material` to do itself.
 //!
 //! # Content-dimension feedback
 //!
@@ -31,10 +59,44 @@
 //! directly — see that type's docs for the coalesced post-frame flush that
 //! replaces a synchronous notify from inside layout.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
+use flui_animation::{AnimationController, Curve};
 use flui_foundation::Listenable;
 use flui_rendering::view::{ScrollPosition, ViewportOffset};
+
+/// The synchronous `jump_to` cancellation hook — see [`ScrollController`]'s
+/// `stop_hook` field docs.
+type StopHook = Arc<dyn Fn() + Send + Sync>;
+
+// ---------------------------------------------------------------------------
+// Pending command — the animate_to/jump_to <-> ScrollableState handoff
+// ---------------------------------------------------------------------------
+
+/// A command queued by [`ScrollController::animate_to`]/[`jump_to`](ScrollController::jump_to)
+/// for [`ScrollController::service_pending_command`] to act on, called from
+/// `ScrollableState`'s notify-triggered `AnimatedBuilder` rebuild closure
+/// (`scrollable.rs`).
+///
+/// One slot, not a queue: a later command always supersedes an earlier,
+/// not-yet-serviced one — mirrors `ScrollPosition.jumpTo` cancelling whatever
+/// activity (ballistic or driven) is currently running, and a second
+/// `animateTo` replacing the first
+/// (`scroll_position_with_single_context.dart`, tag `3.44.0`).
+enum PendingScrollCommand {
+    /// Drive the fling controller through a curve/duration tween to
+    /// `target_pixels` (already clamped to `[min_scroll_extent,
+    /// max_scroll_extent]` by [`ScrollController::animate_to`]).
+    AnimateTo {
+        target_pixels: f32,
+        duration: Duration,
+        curve: Arc<dyn Curve + Send + Sync>, // PORT-CHECK-OK-DYN: see PopPacing's doc (navigator/binding.rs) — same erased easing-curve boundary
+    },
+    /// Stop whatever is currently driving the fling controller — `jump_to`
+    /// supersedes any pending or in-flight `animate_to`.
+    Cancel,
+}
 
 // ---------------------------------------------------------------------------
 // Public handle
@@ -65,12 +127,44 @@ use flui_rendering::view::{ScrollPosition, ViewportOffset};
 #[derive(Clone)]
 pub struct ScrollController {
     position: ScrollPosition,
+    /// See `PendingScrollCommand`'s docs. Behind a private lock — never
+    /// exposed through the public API — and shared across clones via the
+    /// same `Arc` every other piece of this controller's state rides on.
+    pending_command: Arc<Mutex<Option<PendingScrollCommand>>>,
+    /// A synchronous cancellation hook `ScrollableState::init_state` installs
+    /// (mirroring `ScrollPosition::set_flush_handle`'s install lifecycle),
+    /// closing over the fling `AnimationController` to call `stop()` on it
+    /// immediately.
+    ///
+    /// Needed alongside `PendingScrollCommand::Cancel`, not instead of it:
+    /// `flui-binding`'s `pump_frame` ticks vsync-registered controllers
+    /// *before* draining the rebuild queue that services a merely-queued
+    /// pending command (see its "Ordering" doc). Without this hook, `jump_to`
+    /// during an active `animate_to`/fling would queue a `Cancel` that only
+    /// takes effect on the NEXT frame's rebuild — one frame too late, since
+    /// that same frame's tick step would already have advanced (and
+    /// overwritten) the position via the not-yet-stopped controller's value
+    /// listener. Calling `stop()` here, synchronously, at `jump_to` call time
+    /// closes that gap — matching `ScrollPosition.jumpTo`'s `goIdle()`, which
+    /// the oracle also calls synchronously, before touching `pixels`.
+    stop_hook: Arc<Mutex<Option<StopHook>>>,
 }
 
 impl std::fmt::Debug for ScrollController {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ScrollController")
             .field("position", &self.position)
+            .field(
+                "has_pending_command",
+                &self
+                    .pending_command
+                    .lock()
+                    .is_ok_and(|guard| guard.is_some()),
+            )
+            .field(
+                "has_stop_hook",
+                &self.stop_hook.lock().is_ok_and(|guard| guard.is_some()),
+            )
             .finish()
     }
 }
@@ -92,6 +186,8 @@ impl ScrollController {
     pub fn new() -> Self {
         Self {
             position: ScrollPosition::zero(),
+            pending_command: Arc::new(Mutex::new(None)),
+            stop_hook: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -165,9 +261,74 @@ impl ScrollController {
     ///
     /// Notifies listeners on a real change; does not animate. Use this for
     /// programmatic jumps (e.g. `jump_to(0.0)` to scroll to the top).
+    ///
+    /// Flutter parity: `ScrollPosition.jumpTo` calls `goIdle()` — cancelling
+    /// whatever activity currently owns the position — unconditionally,
+    /// before comparing the value (`scroll_position_with_single_context.dart`,
+    /// tag `3.44.0`). This cancels the same way, synchronously, via the
+    /// installed `stop_hook` (see that field's doc on [`ScrollController`]):
+    /// a ballistic fling or an [`animate_to`](Self::animate_to) run currently
+    /// in flight on the driving `ScrollableState` is stopped THIS INSTANT
+    /// (not merely queued — see that field's doc for why a frame's delay is
+    /// observable), and any not-yet-serviced `animate_to` request is dropped
+    /// in favor of this jump.
     pub fn jump_to(&self, pixels: f32) {
         let clamped = pixels.clamp(self.min_scroll_extent(), self.max_scroll_extent());
+        if let Some(hook) = self
+            .stop_hook
+            .lock()
+            .expect("BUG: stop_hook mutex poisoned — a panic escaped a locked section")
+            .as_ref()
+        {
+            hook();
+        }
+        self.set_pending_command(PendingScrollCommand::Cancel);
         self.position.set_pixels(clamped);
+    }
+
+    /// Animate the scroll offset from its current value to `target_pixels`
+    /// over `duration`, easing through `curve` — clamped to
+    /// `[min_scroll_extent, max_scroll_extent]`, same as [`jump_to`](Self::jump_to).
+    ///
+    /// # Flutter parity
+    ///
+    /// Mirrors `ScrollController.animateTo` /
+    /// `ScrollPositionWithSingleContext.animateTo`
+    /// (`scroll_controller.dart`/`scroll_position_with_single_context.dart`,
+    /// tag `3.44.0`): any activity currently driving the position — a
+    /// ballistic fling, or an earlier `animate_to` — is interrupted, and the
+    /// new run starts from wherever the position currently sits. A user grab
+    /// (`Scrollable`'s `on_pan_start`) cancels the run for free, since it
+    /// stops the very `AnimationController` this drives — see this module's
+    /// docs and `scrollable.rs`.
+    ///
+    /// `duration == Duration::ZERO` jumps immediately via
+    /// [`jump_to`](Self::jump_to) instead of scheduling a zero-length
+    /// animation — the oracle instead asserts `duration > Duration.zero` at
+    /// the driving activity and requires callers to use `jumpTo` for that
+    /// case; panicking on a public entry point is not this crate's contract
+    /// (`docs/PANIC-POLICY.md`), so this documents the same "duration must be
+    /// positive to actually animate" rule as a graceful fallback instead.
+    ///
+    /// See this module's docs for why this returns nothing where the oracle
+    /// returns `Future<void>`.
+    pub fn animate_to(
+        &self,
+        target_pixels: f32,
+        duration: Duration,
+        curve: Arc<dyn Curve + Send + Sync>, // PORT-CHECK-OK-DYN: see PopPacing's doc (navigator/binding.rs) — same erased easing-curve boundary
+    ) {
+        if duration.is_zero() {
+            self.jump_to(target_pixels);
+            return;
+        }
+        let target = target_pixels.clamp(self.min_scroll_extent(), self.max_scroll_extent());
+        self.set_pending_command(PendingScrollCommand::AnimateTo {
+            target_pixels: target,
+            duration,
+            curve,
+        });
+        self.position.notify();
     }
 
     /// Update the scroll extents and viewport dimension, then unconditionally
@@ -218,6 +379,72 @@ impl ScrollController {
     #[must_use]
     pub fn position(&self) -> ScrollPosition {
         self.position.clone()
+    }
+
+    // -- animate_to servicing (ScrollableState only) --------------------------
+
+    /// Installs (or replaces) the synchronous cancellation hook `jump_to`
+    /// calls immediately — see the `stop_hook` field's doc for why this
+    /// exists alongside `PendingScrollCommand::Cancel` rather than instead of
+    /// it. Idempotent: safe to call from both `init_state` and
+    /// `did_change_dependencies`, mirroring `ScrollPosition::set_flush_handle`'s
+    /// own re-install tolerance.
+    pub(crate) fn set_stop_hook(&self, hook: StopHook) {
+        *self
+            .stop_hook
+            .lock()
+            .expect("BUG: stop_hook mutex poisoned — a panic escaped a locked section") =
+            Some(hook);
+    }
+
+    /// Overwrites the pending-command slot — a later command always
+    /// supersedes an earlier, not-yet-serviced one.
+    fn set_pending_command(&self, command: PendingScrollCommand) {
+        *self
+            .pending_command
+            .lock()
+            .expect("BUG: pending_command mutex poisoned — a panic escaped a locked section") =
+            Some(command);
+    }
+
+    /// Takes (and clears) the pending command, if any.
+    fn take_pending_command(&self) -> Option<PendingScrollCommand> {
+        self.pending_command
+            .lock()
+            .expect("BUG: pending_command mutex poisoned — a panic escaped a locked section")
+            .take()
+    }
+
+    /// Services one queued command (if any) against `fling` — the same
+    /// `AnimationController` `Scrollable`'s `on_pan_end` drives for ballistic
+    /// flings. Called from `ScrollableState`'s notify-triggered
+    /// `AnimatedBuilder` rebuild closure (`scrollable.rs`) on every rebuild,
+    /// so an `animate_to`/`jump_to` call made between rebuilds is picked up
+    /// on the very next one.
+    pub(crate) fn service_pending_command(&self, fling: &AnimationController) {
+        let Some(command) = self.take_pending_command() else {
+            return;
+        };
+        match command {
+            PendingScrollCommand::AnimateTo {
+                target_pixels,
+                duration,
+                curve,
+            } => {
+                // Sync `fling`'s own value to the true current pixel position
+                // first: its value listener only pushes FROM the controller
+                // INTO this position, so if pixels moved without ticking it (a
+                // `jump_to`, or this being the very first animation `fling`
+                // has ever driven), its value is stale and animating from it
+                // would visibly jump instead of starting from where the
+                // position actually sits.
+                fling.set_value(self.pixels());
+                let _ = fling.animate_to_curved(target_pixels, Some(duration), curve);
+            }
+            PendingScrollCommand::Cancel => {
+                let _ = fling.stop();
+            }
+        }
     }
 
     // -- Listenable bridge ---------------------------------------------------
@@ -512,6 +739,129 @@ mod tests {
             clone.pixels(),
             77.0,
             "a clone must observe mutations made through the original"
+        );
+    }
+
+    // -- animate_to / service_pending_command --------------------------------
+
+    /// Builds an unbounded fling-style `AnimationController` — the same
+    /// shape `ScrollableState::create_state` constructs (`scrollable.rs`):
+    /// wide-open bounds so a driven value is never clamped by the controller
+    /// itself, only by `animate_to`'s own pre-clamp of the target.
+    fn fling_stub() -> AnimationController {
+        AnimationController::with_bounds(
+            Duration::from_millis(1),
+            Arc::new(flui_scheduler::Scheduler::new()),
+            f32::NEG_INFINITY,
+            f32::INFINITY,
+        )
+        .expect("NEG_INFINITY < INFINITY satisfies the bounds invariant")
+    }
+
+    #[test]
+    fn animate_to_with_zero_duration_jumps_immediately() {
+        let controller = ScrollController::new();
+        controller.update_dimensions(300.0, 0.0, 500.0);
+
+        controller.animate_to(
+            200.0,
+            Duration::ZERO,
+            Arc::new(flui_animation::Curves::Linear),
+        );
+
+        assert_eq!(
+            controller.pixels(),
+            200.0,
+            "a zero-duration animate_to must jump immediately, like jump_to"
+        );
+    }
+
+    #[test]
+    fn animate_to_clamps_the_target_to_the_current_extents() {
+        use flui_animation::Animation;
+
+        let controller = ScrollController::new();
+        controller.update_dimensions(300.0, 0.0, 500.0);
+        let fling = fling_stub();
+
+        controller.animate_to(
+            999.0,
+            Duration::from_millis(50),
+            Arc::new(flui_animation::Curves::Linear),
+        );
+        controller.service_pending_command(&fling);
+
+        // Past the run's duration: `tick_time_based` snaps to `target_value`.
+        fling.tick_at(1.0);
+        assert_eq!(
+            fling.value(),
+            500.0,
+            "animate_to must clamp its target to max_scroll_extent (500.0) before \
+             driving the fling controller, not animate past it to the raw 999.0 request"
+        );
+    }
+
+    #[test]
+    fn a_second_animate_to_supersedes_the_first_before_either_is_serviced() {
+        use flui_animation::Animation;
+
+        let controller = ScrollController::new();
+        controller.update_dimensions(300.0, 0.0, 5000.0);
+        let fling = fling_stub();
+
+        controller.animate_to(
+            500.0,
+            Duration::from_millis(100),
+            Arc::new(flui_animation::Curves::Linear),
+        );
+        controller.animate_to(
+            900.0,
+            Duration::from_millis(100),
+            Arc::new(flui_animation::Curves::Linear),
+        );
+        // Only one command was ever queued: the second call overwrote the
+        // first before `service_pending_command` ever ran.
+        controller.service_pending_command(&fling);
+
+        fling.tick_at(1.0);
+        assert_eq!(
+            fling.value(),
+            900.0,
+            "a second animate_to, queued before the first was ever serviced, must \
+             replace it outright — the fling controller must drive toward the \
+             SECOND target (900.0), never the first (500.0)"
+        );
+    }
+
+    #[test]
+    fn jump_to_cancels_a_not_yet_serviced_animate_to() {
+        use flui_animation::Animation;
+
+        let controller = ScrollController::new();
+        controller.update_dimensions(300.0, 0.0, 500.0);
+        let fling = fling_stub();
+        fling
+            .forward()
+            .expect("fling_stub is not disposed, forward() must succeed");
+        assert!(
+            fling.status().is_running(),
+            "sanity: forward() leaves the fling controller running"
+        );
+
+        controller.animate_to(
+            400.0,
+            Duration::from_millis(100),
+            Arc::new(flui_animation::Curves::Linear),
+        );
+        // jump_to must overwrite the queued AnimateTo with Cancel — the next
+        // service call must stop the controller, not start the animation.
+        controller.jump_to(50.0);
+        controller.service_pending_command(&fling);
+
+        assert!(
+            !fling.status().is_running(),
+            "jump_to must cancel a not-yet-serviced animate_to instead of letting \
+             it start on the next service_pending_command call"
         );
     }
 }

--- a/crates/flui-widgets/src/scroll/scroll_controller.rs
+++ b/crates/flui-widgets/src/scroll/scroll_controller.rs
@@ -19,7 +19,7 @@
 //!
 //! - Multiple attached positions (one controller → many scrollables).
 //!
-//! # `animate_to` (ADR-0037 PR3)
+//! # `animate_to` (ADR-0037)
 //!
 //! [`ScrollController::animate_to`] queues a `PendingScrollCommand` — a
 //! private, mutex-guarded cell — rather than driving a ticker itself: the
@@ -274,12 +274,19 @@ impl ScrollController {
     /// in favor of this jump.
     pub fn jump_to(&self, pixels: f32) {
         let clamped = pixels.clamp(self.min_scroll_extent(), self.max_scroll_extent());
-        if let Some(hook) = self
+        // Clone the hook `Arc` out and drop the lock BEFORE calling it — do
+        // NOT invoke it while still holding the guard. `hook()` synchronously
+        // calls `fling.stop()`, which fires `fling`'s OWN status listeners
+        // synchronously (`AnimationController::stop`); a status listener that
+        // re-enters `jump_to` (directly, or via any other `stop_hook` caller)
+        // would try to re-lock this same, non-reentrant `std::sync::Mutex` on
+        // the same thread — a guaranteed deadlock, not just a slow path.
+        let hook = self
             .stop_hook
             .lock()
             .expect("BUG: stop_hook mutex poisoned — a panic escaped a locked section")
-            .as_ref()
-        {
+            .clone();
+        if let Some(hook) = hook {
             hook();
         }
         self.set_pending_command(PendingScrollCommand::Cancel);
@@ -310,6 +317,20 @@ impl ScrollController {
     /// (`docs/PANIC-POLICY.md`), so this documents the same "duration must be
     /// positive to actually animate" rule as a graceful fallback instead.
     ///
+    /// # Tolerance short-circuit divergence
+    ///
+    /// The oracle also skips the animation (jumping instead) when already
+    /// within `physics.toleranceFor(this).distance` of the target
+    /// (`scroll_position_with_single_context.dart:178-182`, tag `3.44.0`) —
+    /// a *physics-derived* tolerance. `ScrollController` is deliberately
+    /// physics-agnostic (see this module's docs), so threading a
+    /// `ScrollPhysics` dependency through just for this check isn't a fit
+    /// here; this instead short-circuits on EXACT equality only (below),
+    /// which still skips the queued-command round-trip's one-frame delay for
+    /// the common "already there" case, but — unlike the oracle — still
+    /// queues (and pays that one frame) for a target merely *close* to, but
+    /// not exactly at, the current position.
+    ///
     /// See this module's docs for why this returns nothing where the oracle
     /// returns `Future<void>`.
     pub fn animate_to(
@@ -323,6 +344,14 @@ impl ScrollController {
             return;
         }
         let target = target_pixels.clamp(self.min_scroll_extent(), self.max_scroll_extent());
+        if target == self.pixels() {
+            // Already there: jump (a no-op write, since the value doesn't
+            // change) rather than queuing a command whose own servicing
+            // would just reach `AnimationController::drive_to`'s identical
+            // "already at target" fast path one frame later.
+            self.jump_to(target);
+            return;
+        }
         self.set_pending_command(PendingScrollCommand::AnimateTo {
             target_pixels: target,
             duration,
@@ -386,15 +415,28 @@ impl ScrollController {
     /// Installs (or replaces) the synchronous cancellation hook `jump_to`
     /// calls immediately — see the `stop_hook` field's doc for why this
     /// exists alongside `PendingScrollCommand::Cancel` rather than instead of
-    /// it. Idempotent: safe to call from both `init_state` and
-    /// `did_change_dependencies`, mirroring `ScrollPosition::set_flush_handle`'s
-    /// own re-install tolerance.
+    /// it. Idempotent: safe to call from `init_state` AND `did_update_view`
+    /// (a controller swap must move the hook onto the NEW controller),
+    /// mirroring `ScrollPosition::set_flush_handle`'s own re-install
+    /// tolerance.
     pub(crate) fn set_stop_hook(&self, hook: StopHook) {
         *self
             .stop_hook
             .lock()
             .expect("BUG: stop_hook mutex poisoned — a panic escaped a locked section") =
             Some(hook);
+    }
+
+    /// Removes the stop hook, if any — called from `ScrollableState::dispose`
+    /// so a disposed `ScrollableState`'s fling controller isn't kept
+    /// reachable (and invoked, however harmlessly per `AnimationController::
+    /// stop`'s own `Disposed` guard) forever through an `Arc` the user-held
+    /// controller still holds after the widget that installed it is gone.
+    pub(crate) fn clear_stop_hook(&self) {
+        *self
+            .stop_hook
+            .lock()
+            .expect("BUG: stop_hook mutex poisoned — a panic escaped a locked section") = None;
     }
 
     /// Overwrites the pending-command slot — a later command always
@@ -413,6 +455,16 @@ impl ScrollController {
             .lock()
             .expect("BUG: pending_command mutex poisoned — a panic escaped a locked section")
             .take()
+    }
+
+    /// Drops any not-yet-serviced pending command — called from
+    /// `ScrollableState::dispose` so an `animate_to`/`jump_to` queued while
+    /// this controller was still attached to THIS `Scrollable` doesn't
+    /// resurface and get serviced against a DIFFERENT `ScrollableState`'s
+    /// fling controller if the same `ScrollController` is later re-attached
+    /// to a new `Scrollable`.
+    pub(crate) fn clear_pending_command(&self) {
+        let _ = self.take_pending_command();
     }
 
     /// Services one queued command (if any) against `fling` — the same
@@ -862,6 +914,147 @@ mod tests {
             !fling.status().is_running(),
             "jump_to must cancel a not-yet-serviced animate_to instead of letting \
              it start on the next service_pending_command call"
+        );
+    }
+
+    /// `animate_to`'s tolerance short-circuit (see that method's own doc):
+    /// a target exactly equal to the current position must jump immediately
+    /// rather than queue a command — proven here by NEVER installing a
+    /// `service_pending_command` call at all: if this queued anything, the
+    /// fling controller would simply never see it, so the only way `pixels`
+    /// could end up at `target` is the immediate `jump_to` path.
+    #[test]
+    fn animate_to_already_at_the_target_jumps_immediately_without_queuing() {
+        let controller = ScrollController::new();
+        controller.update_dimensions(300.0, 0.0, 500.0);
+        controller.set_pixels(200.0);
+
+        controller.animate_to(
+            200.0,
+            Duration::from_millis(100),
+            Arc::new(flui_animation::Curves::Linear),
+        );
+
+        assert_eq!(
+            controller.pixels(),
+            200.0,
+            "animate_to already at the target must leave pixels unchanged \
+             (via the immediate jump_to short-circuit), not merely queue a \
+             command that would settle there only once serviced"
+        );
+    }
+
+    /// Regression (latent deadlock): `jump_to` must clone the `stop_hook`
+    /// `Arc` out and drop the mutex guard BEFORE invoking it — not call it
+    /// while still holding the lock. `fling.stop()` (what the installed hook
+    /// calls) fires `fling`'s own status listeners SYNCHRONOUSLY on a real
+    /// status transition; a status listener that itself calls `jump_to`
+    /// again (directly, or through anything else that touches `stop_hook`)
+    /// would try to re-lock this same, non-reentrant `std::sync::Mutex` on
+    /// the SAME thread — an unconditional deadlock if the guard were still
+    /// held, since `std::sync::Mutex` never grants a second lock to the
+    /// thread already holding it.
+    ///
+    /// The risky call runs on a background thread with a bounded
+    /// `recv_timeout`: a real deadlock would hang forever, so this turns a
+    /// regression into a fast, clean test failure instead of hanging the
+    /// whole suite.
+    #[test]
+    fn jump_to_does_not_deadlock_when_its_stop_hook_reenters_jump_to() {
+        use flui_animation::Animation;
+
+        let controller = ScrollController::new();
+        controller.update_dimensions(300.0, 0.0, 500.0);
+        let fling = fling_stub();
+
+        // Establish a genuine RUNNING state FIRST, before any listener/hook
+        // is wired up — otherwise `forward()` itself would trigger the
+        // reentrant cascade below synchronously, on this (main) thread,
+        // before the sanity check even runs.
+        fling
+            .forward()
+            .expect("fling_stub is not disposed, forward() must succeed");
+        assert!(
+            fling.status().is_running(),
+            "sanity: forward() leaves the fling controller running, so the \
+             stop() fired from jump_to's hook below is a genuine status \
+             transition (not a no-op the listener would never see)"
+        );
+
+        // A status listener that re-enters `jump_to` on the SAME controller —
+        // fires synchronously from inside `fling.stop()` (called by the
+        // installed hook), on whichever thread calls it.
+        let reentrant_controller = controller.clone();
+        fling.add_status_listener(Arc::new(move |_status| {
+            reentrant_controller.jump_to(0.0);
+        }));
+
+        let hook_target = fling.clone();
+        controller.set_stop_hook(Arc::new(move || {
+            let _ = hook_target.stop();
+        }));
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            controller.jump_to(100.0);
+            let _ = tx.send(());
+        });
+
+        assert!(
+            rx.recv_timeout(Duration::from_secs(2)).is_ok(),
+            "jump_to must not deadlock when its stop_hook synchronously \
+             re-enters jump_to via a status listener — the stop_hook Arc must \
+             be cloned out of the mutex guard before the hook is invoked"
+        );
+    }
+
+    /// `ScrollableState::dispose` clears both the stop hook and any queued
+    /// pending command (`clear_stop_hook`/`clear_pending_command`) — proven
+    /// directly against the two pub(crate) entry points dispose calls,
+    /// rather than through a full widget mount/unmount (see
+    /// `disposing_a_scrollable_clears_the_controllers_pending_command_before_a_reattach`,
+    /// `tests/scroll.rs`, for the end-to-end version of the pending-command
+    /// half — `jump_to` after a REAL dispose is behaviorally identical
+    /// whether or not the hook was cleared, since `AnimationController::stop`
+    /// on an already-disposed controller harmlessly no-ops either way, so
+    /// only a direct check like this one can observe the hook itself being
+    /// gone).
+    #[test]
+    fn clear_stop_hook_and_clear_pending_command_remove_both() {
+        use flui_animation::Animation;
+
+        let controller = ScrollController::new();
+        controller.update_dimensions(300.0, 0.0, 500.0);
+
+        // A "poison" hook that panics if ever invoked — proves
+        // `clear_stop_hook` actually removes it, not merely that nothing
+        // happens to trigger it afterward.
+        controller.set_stop_hook(Arc::new(|| {
+            panic!("stop_hook must not fire after clear_stop_hook");
+        }));
+        controller.animate_to(
+            400.0,
+            Duration::from_millis(50),
+            Arc::new(flui_animation::Curves::Linear),
+        );
+
+        controller.clear_stop_hook();
+        controller.clear_pending_command();
+
+        // jump_to must not invoke the (cleared) poison hook.
+        controller.jump_to(10.0);
+        assert_eq!(controller.pixels(), 10.0);
+
+        // The queued animate_to must be gone too: servicing against a FRESH
+        // fling controller must be a complete no-op, not silently start the
+        // stale animation.
+        let fling = fling_stub();
+        controller.service_pending_command(&fling);
+        assert_eq!(
+            fling.status(),
+            flui_animation::AnimationStatus::Dismissed,
+            "clear_pending_command must drop the queued animate_to — \
+             servicing afterward must not start it"
         );
     }
 }

--- a/crates/flui-widgets/src/scroll/scrollable.rs
+++ b/crates/flui-widgets/src/scroll/scrollable.rs
@@ -20,6 +20,18 @@
 //! `on_pan_start` halts any in-flight fling via `stop()`, so grabbing a
 //! scrolling list feels physically correct.
 //!
+//! # `animate_to` servicing (ADR-0037 PR3)
+//!
+//! [`ScrollController::animate_to`]/[`jump_to`](ScrollController::jump_to)
+//! don't drive the fling controller directly — they queue a command (see
+//! `scroll_controller.rs`'s module docs) that this widget's `build` closure
+//! services on every rebuild the controller's notify triggers, via
+//! [`ScrollController::service_pending_command`]. Reusing the SAME
+//! `AnimationController` the ballistic fling above drives means `on_pan_start`
+//! cancels a running `animate_to` for free — it stops whichever of the two
+//! (fling or curve-driven tween) happens to be active — and `jump_to` queues
+//! an explicit cancel for the same reason.
+//!
 //! # Flutter parity
 //!
 //! Corresponds to `widgets/scrollable.dart` `Scrollable`. FLUI merges
@@ -280,11 +292,24 @@ impl ScrollableState {
             self.scroll_controller.position().set_flush_handle(handle);
         }
     }
+
+    /// Installs the synchronous `jump_to` cancellation hook (ADR-0037 PR3) on
+    /// [`ScrollController`], closing over this state's own fling controller —
+    /// see `ScrollController`'s `stop_hook` field docs for why `jump_to`
+    /// needs a hook called AT jump_to time rather than a merely-queued
+    /// command serviced on the next rebuild.
+    fn install_stop_hook(&self) {
+        let fling = self.fling_controller.clone();
+        self.scroll_controller.set_stop_hook(Arc::new(move || {
+            let _ = fling.stop();
+        }));
+    }
 }
 
 impl ViewState<Scrollable> for ScrollableState {
     fn init_state(&mut self, ctx: &dyn BuildContext) {
         self.install_flush_handle(ctx);
+        self.install_stop_hook();
 
         // Attach the value listener that pushes the fling simulation's current
         // pixel position into the scroll controller each tick. The listener
@@ -322,6 +347,14 @@ impl ViewState<Scrollable> for ScrollableState {
         let fling_controller = self.fling_controller.clone();
 
         AnimatedBuilder::new(scroll_controller.as_listenable(), move || {
+            // Service any `animate_to`/`jump_to`-queued command BEFORE
+            // building this rebuild's subtree — this closure reruns on every
+            // notify the controller fires (ADR-0037 PR3's "notify path"),
+            // exactly the trigger `ScrollController::animate_to`/`jump_to`
+            // fire after queuing a command. See `scroll_controller.rs`'s
+            // module docs and `ScrollController::service_pending_command`.
+            scroll_controller.service_pending_command(&fling_controller);
+
             // Clones for the gesture callbacks; each closure needs its own
             // `Arc`-counted handle (no refcount bump at call time).
             let fling_stop = fling_controller.clone();

--- a/crates/flui-widgets/src/scroll/scrollable.rs
+++ b/crates/flui-widgets/src/scroll/scrollable.rs
@@ -20,7 +20,7 @@
 //! `on_pan_start` halts any in-flight fling via `stop()`, so grabbing a
 //! scrolling list feels physically correct.
 //!
-//! # `animate_to` servicing (ADR-0037 PR3)
+//! # `animate_to` servicing (ADR-0037)
 //!
 //! [`ScrollController::animate_to`]/[`jump_to`](ScrollController::jump_to)
 //! don't drive the fling controller directly — they queue a command (see
@@ -220,10 +220,15 @@ pub struct ScrollableState {
     /// state so the fling listener (registered in `init_state`) can reach it
     /// without re-capturing on every `build`. Updated in `did_update_view`.
     ///
-    /// Note: if the caller replaces the controller with a different object
-    /// (rather than mutating the same `Arc`-backed handle), the listener will
-    /// continue driving the old one until the widget is disposed. Full
-    /// hot-swap is deferred — the common case is one stable controller.
+    /// Named follow-up (pre-existing, not fixed by ADR-0037): if the caller
+    /// replaces the controller with a different object (rather than mutating
+    /// the same `Arc`-backed handle), the fling VALUE LISTENER registered
+    /// once in `init_state` keeps pushing ticks into the OLD controller until
+    /// the widget is disposed — full hot-swap of that listener is deferred,
+    /// the common case is one stable controller. The `stop_hook`
+    /// `did_update_view` re-installs on every swap does NOT share this gap:
+    /// it is looked up fresh from `self.scroll_controller` (updated first),
+    /// not captured once in `init_state`.
     scroll_controller: ScrollController,
     /// The ballistic simulation driver. Bounds span `(NEG_INFINITY, INFINITY)`
     /// so pixel-space simulation positions are not clamped to `[0, 1]`.
@@ -293,11 +298,16 @@ impl ScrollableState {
         }
     }
 
-    /// Installs the synchronous `jump_to` cancellation hook (ADR-0037 PR3) on
+    /// Installs the synchronous `jump_to` cancellation hook (ADR-0037) on
     /// [`ScrollController`], closing over this state's own fling controller —
     /// see `ScrollController`'s `stop_hook` field docs for why `jump_to`
     /// needs a hook called AT jump_to time rather than a merely-queued
     /// command serviced on the next rebuild.
+    ///
+    /// Idempotent (mirrors `install_flush_handle`): called from `init_state`
+    /// AND `did_update_view` (a controller swap must move the hook onto the
+    /// NEW controller — see `scroll_controller`'s field doc), always against
+    /// whatever `self.scroll_controller` currently is.
     fn install_stop_hook(&self) {
         let fling = self.fling_controller.clone();
         self.scroll_controller.set_stop_hook(Arc::new(move || {
@@ -349,7 +359,7 @@ impl ViewState<Scrollable> for ScrollableState {
         AnimatedBuilder::new(scroll_controller.as_listenable(), move || {
             // Service any `animate_to`/`jump_to`-queued command BEFORE
             // building this rebuild's subtree — this closure reruns on every
-            // notify the controller fires (ADR-0037 PR3's "notify path"),
+            // notify the controller fires (ADR-0037's "notify path"),
             // exactly the trigger `ScrollController::animate_to`/`jump_to`
             // fire after queuing a command. See `scroll_controller.rs`'s
             // module docs and `ScrollController::service_pending_command`.
@@ -456,6 +466,18 @@ impl ViewState<Scrollable> for ScrollableState {
         // Track the current controller so the fling listener stays in sync if
         // a parent rebuild hands us a new configuration.
         self.scroll_controller = new_view.controller.clone();
+
+        // Re-install the stop hook on the (possibly new) controller —
+        // `install_stop_hook` is idempotent (see its doc), so this is cheap
+        // even when the controller didn't actually change. Without this, a
+        // controller SWAP would leave the hook on the OLD controller only:
+        // the new controller's `jump_to` would silently lose the
+        // synchronous cancel path (see `ScrollController`'s `stop_hook`
+        // field docs for the one-frame gap that reopens). The fling VALUE
+        // LISTENER is deliberately NOT re-subscribed here — see
+        // `scroll_controller`'s own field doc above for that pre-existing,
+        // out-of-scope gap.
+        self.install_stop_hook();
     }
 
     fn dispose(&mut self) {
@@ -471,6 +493,15 @@ impl ViewState<Scrollable> for ScrollableState {
         {
             vsync.unregister(registration);
         }
+        // Detach the ADR-0037 stop hook and drop any not-yet-serviced
+        // pending command — without this, the user-held `ScrollController`
+        // would keep an `Arc` closing over this about-to-be-disposed
+        // `fling_controller` alive (and reachable via `jump_to`) forever, and
+        // a command queued while still attached to THIS widget would
+        // otherwise resurface against a DIFFERENT `ScrollableState` if the
+        // same controller is later re-attached to a new `Scrollable`.
+        self.scroll_controller.clear_stop_hook();
+        self.scroll_controller.clear_pending_command();
         self.fling_controller.dispose();
     }
 }

--- a/crates/flui-widgets/tests/parity/page_view_test.rs
+++ b/crates/flui-widgets/tests/parity/page_view_test.rs
@@ -9,7 +9,7 @@
 //! `crates/flui-widgets/src/scroll/page_view.rs`'s module docs record the
 //! exact V1 boundary (eager children, listener-based `on_page_changed`, no
 //! `pageSnapping: false`/`reverse`/`padEnds`/`allowImplicitScrolling`/
-//! `PageStorage`/`animateToPage`/`viewport_fraction > 1.0` centering). **13
+//! `PageStorage`/`viewport_fraction > 1.0` centering). **15
 //! tests ported below**, covering the portable core:
 //!
 //! - `initial_page_lands_on_first_layout` — `initialPage` seeding on the very
@@ -72,6 +72,17 @@
 //!   coverage (the horizontal axis dominates the rest of this file, but
 //!   `PageView::scroll_direction` is not axis-agnostic-by-construction — a
 //!   `dy`-vs-`dx` mixup would only show up in a real vertical drag).
+//! - `animate_to_page_lands_on_the_page` (ADR-0037 PR3) — page → pixels
+//!   through the guarded formula, then a real curve/duration animation
+//!   pumped to completion. Cross-checked against `'PageController control
+//!   test'` (309), which exercises `animateToPage` the same way this port's
+//!   `PageController::animate_to_page` does.
+//! - `next_page_and_previous_page_navigate_and_clamp_at_the_ends`
+//!   (ADR-0037 PR3) — an ordinary one-page step, then `next_page` past the
+//!   last real page and `previous_page` below the first: both clamp at
+//!   `max_scroll_extent`/`0.0` via `ScrollController::animate_to`'s own
+//!   clamp, a documented divergence from the oracle's physics-clamped ticks
+//!   (see `PageController::next_page`'s doc).
 //!
 //! ## Why "past half"/"below half"/"fling velocity" aren't ALSO gesture-driven
 //! *release+settle* tests
@@ -106,7 +117,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use flui_animation::Vsync;
+use flui_animation::{Curves, Vsync};
 use flui_types::layout::Axis;
 use flui_view::prelude::StatelessView;
 use flui_view::{BuildContext, IntoView, ViewExt};
@@ -819,4 +830,102 @@ fn vertical_page_view_drag_crosses_to_the_next_page() {
     );
 
     scoped.dispatch_pointer_up(100.0, 20.0);
+}
+
+// ============================================================================
+// animate_to_page / next_page / previous_page (ADR-0037 PR3)
+// ============================================================================
+
+/// `animate_to_page` navigates via a real curve/duration animation — page →
+/// pixels through the guarded `ScrollMetrics::pixels_from_page` formula, then
+/// delegates to `ScrollController::animate_to`. Pumping past the duration
+/// must land EXACTLY on the target page's pixel offset.
+///
+/// Cross-checked against `'PageController control test'`
+/// (`test/widgets/page_view_test.dart`, line 309), which drives
+/// `animateToPage` the same way this port's `PageController::animate_to_page`
+/// does.
+#[test]
+fn animate_to_page_lands_on_the_page() {
+    let controller = PageController::new();
+    let widget = PageView::new(pages(5)).controller(controller.clone());
+    let vsync = Vsync::new();
+    let wrapped = VsyncScope::new(vsync.clone(), widget);
+    let mut scoped = lay_out_with_arena(wrapped, tight(300.0, 300.0));
+    scoped.adopt_vsync(vsync);
+
+    controller.animate_to_page(3, Duration::from_millis(100), Arc::new(Curves::Linear));
+
+    // Comfortably past the 100ms duration (see `scroll.rs`'s
+    // `scrollable_animate_to_reaches_the_target_through_the_curve` for why
+    // driving through the queued-command path needs a few warm-up pumps).
+    for _ in 0..20 {
+        scoped.pump_for(Duration::from_millis(16));
+    }
+
+    assert_eq!(
+        controller.scroll_controller().pixels(),
+        900.0,
+        "animate_to_page(3) must land at 3 * 300 * 1.0 = 900.0 once the \
+         animation has fully elapsed"
+    );
+    assert_eq!(controller.page(), Some(3.0));
+}
+
+/// `next_page`/`previous_page` step by one whole page from the current
+/// (rounded) page. Past the last real page or below the first, the run
+/// clamps at `max_scroll_extent`/`0.0` — via `ScrollController::animate_to`'s
+/// own clamp, not a page-count check `PageController` has no way to make
+/// (matching the oracle: `nextPage`/`previousPage` are plain
+/// `animateToPage(page!.round() +/- 1, ...)` calls with no bounds check of
+/// their own — see `PageController::next_page`'s doc for how FLUI reaches the
+/// same visible stopping point through a different mechanism than the
+/// oracle's boundary-clamped per-tick `setPixels`).
+#[test]
+fn next_page_and_previous_page_navigate_and_clamp_at_the_ends() {
+    let controller = PageController::new();
+    let widget = PageView::new(pages(5)).controller(controller.clone());
+    let vsync = Vsync::new();
+    let wrapped = VsyncScope::new(vsync.clone(), widget);
+    let mut scoped = lay_out_with_arena(wrapped, tight(300.0, 300.0));
+    scoped.adopt_vsync(vsync);
+
+    // Ordinary step: page 0 -> 1.
+    controller.next_page(Duration::from_millis(50), Arc::new(Curves::Linear));
+    for _ in 0..20 {
+        scoped.pump_for(Duration::from_millis(16));
+    }
+    assert_eq!(
+        controller.scroll_controller().pixels(),
+        300.0,
+        "next_page from page 0 must land on page 1 (300.0)"
+    );
+
+    // Jump to the last real page (4 of 5 — index 4), then next_page must
+    // clamp AT it, never overshooting to a nonexistent page 5.
+    controller.jump_to_page(4);
+    controller.next_page(Duration::from_millis(50), Arc::new(Curves::Linear));
+    for _ in 0..20 {
+        scoped.pump_for(Duration::from_millis(16));
+    }
+    let max_scroll_extent = controller.scroll_controller().max_scroll_extent();
+    assert_eq!(
+        controller.scroll_controller().pixels(),
+        max_scroll_extent,
+        "next_page past the last real page must clamp at max_scroll_extent \
+         ({max_scroll_extent}), not overshoot toward a page-5 pixel offset"
+    );
+
+    // Jump to the first page, then previous_page must clamp at 0, never
+    // going negative.
+    controller.jump_to_page(0);
+    controller.previous_page(Duration::from_millis(50), Arc::new(Curves::Linear));
+    for _ in 0..20 {
+        scoped.pump_for(Duration::from_millis(16));
+    }
+    assert_eq!(
+        controller.scroll_controller().pixels(),
+        0.0,
+        "previous_page below the first page must clamp at 0.0, not go negative"
+    );
 }

--- a/crates/flui-widgets/tests/parity/page_view_test.rs
+++ b/crates/flui-widgets/tests/parity/page_view_test.rs
@@ -72,13 +72,13 @@
 //!   coverage (the horizontal axis dominates the rest of this file, but
 //!   `PageView::scroll_direction` is not axis-agnostic-by-construction — a
 //!   `dy`-vs-`dx` mixup would only show up in a real vertical drag).
-//! - `animate_to_page_lands_on_the_page` (ADR-0037 PR3) — page → pixels
+//! - `animate_to_page_lands_on_the_page` (ADR-0037) — page → pixels
 //!   through the guarded formula, then a real curve/duration animation
 //!   pumped to completion. Cross-checked against `'PageController control
 //!   test'` (309), which exercises `animateToPage` the same way this port's
 //!   `PageController::animate_to_page` does.
 //! - `next_page_and_previous_page_navigate_and_clamp_at_the_ends`
-//!   (ADR-0037 PR3) — an ordinary one-page step, then `next_page` past the
+//!   (ADR-0037) — an ordinary one-page step, then `next_page` past the
 //!   last real page and `previous_page` below the first: both clamp at
 //!   `max_scroll_extent`/`0.0` via `ScrollController::animate_to`'s own
 //!   clamp, a documented divergence from the oracle's physics-clamped ticks
@@ -833,7 +833,7 @@ fn vertical_page_view_drag_crosses_to_the_next_page() {
 }
 
 // ============================================================================
-// animate_to_page / next_page / previous_page (ADR-0037 PR3)
+// animate_to_page / next_page / previous_page (ADR-0037)
 // ============================================================================
 
 /// `animate_to_page` navigates via a real curve/duration animation — page →

--- a/crates/flui-widgets/tests/scroll.rs
+++ b/crates/flui-widgets/tests/scroll.rs
@@ -5,6 +5,8 @@
 //! 2. `ScrollController` thumb geometry helpers.
 //! 3. `Scrollable` interactive drag integration (gesture → offset change).
 //! 4. `ClampingScrollPhysics` hard-boundary enforcement.
+//! 5. `ScrollController::animate_to` (ADR-0037 PR3) — curve-driven animation,
+//!    grab-to-cancel, and jump_to-cancels-in-flight.
 
 mod common;
 
@@ -12,7 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use common::{LaidOutScoped, lay_out, lay_out_with_arena, size, tight};
-use flui_animation::Vsync;
+use flui_animation::{Curves, Vsync};
 use flui_rendering::constraints::BoxConstraints;
 use flui_types::Color;
 use flui_types::geometry::px;
@@ -1161,6 +1163,249 @@ fn pan_start_during_fling_halts_momentum() {
         "halting the fling via on_pan_start must freeze the scroll offset; \
          offset drifted by {drift:.3} px after grab \
          (from {pixels_after_grab:.1} to {:.1})",
+        controller.pixels()
+    );
+}
+
+// ============================================================================
+// Scrollable — animate_to (ADR-0037 PR3)
+// ============================================================================
+
+/// `animate_to` drives the SAME fling `AnimationController` a ballistic fling
+/// uses, through a curve/duration tween: pumping frames must show the offset
+/// moving continuously between the start and target (not jumping straight to
+/// the end), landing EXACTLY on the target once the duration has elapsed.
+///
+/// Three pumps of warm-up before real advance begins, one more than
+/// `scrollable_fling_advances_offset_past_release`'s direct `animate_with`
+/// call needs: `animate_to` queues a command rather than driving the fling
+/// controller synchronously (see `scroll_controller.rs`'s module docs), so
+/// pump 1 is what services that queue (`flui-binding::pump_frame` ticks
+/// registered controllers BEFORE draining the rebuild that services it —
+/// `AnimationController::animate_to_curved` only runs during pump 1's
+/// rebuild step, too late for pump 1's OWN tick step to see it running).
+/// Pump 2 is then the vsync registry's own "detect the new run generation,
+/// anchor `t = 0`" pump (same as the direct-`animate_with` fling case);
+/// pump 3 is the first tick that actually advances the value.
+///
+/// Flutter parity: `ScrollController.animateTo`/`ScrollPositionWithSingleContext
+/// .animateTo` (`scroll_controller.dart`/`scroll_position_with_single_context.dart`,
+/// tag `3.44.0`) drive a `DrivenScrollActivity`'s curve/duration tween from
+/// the current position to the target.
+#[test]
+fn scrollable_animate_to_reaches_the_target_through_the_curve() {
+    let controller = ScrollController::new();
+    controller.update_dimensions(300.0, 0.0, 4700.0);
+
+    let vsync = Vsync::new();
+    let widget = Scrollable::new()
+        .controller(controller.clone())
+        .child(SizedBox::new(300.0, 5000.0));
+
+    let mut scoped = fling_scoped(widget, vsync, tight(300.0, 300.0));
+
+    controller.animate_to(1000.0, Duration::from_millis(100), Arc::new(Curves::Linear));
+
+    // Pump 1: services the queued command (starts the run). Pump 2: vsync
+    // anchors the new run generation at t=0. Pump 3: the first real tick,
+    // 16ms into a 100ms run (t = 0.16).
+    scoped.pump_for(Duration::from_millis(16));
+    scoped.pump_for(Duration::from_millis(16));
+    scoped.pump_for(Duration::from_millis(16));
+    let mid = controller.pixels();
+    assert!(
+        mid > 0.0 && mid < 1000.0,
+        "part-way through a 100ms animate_to, the offset must sit strictly \
+         between the start (0.0) and the target (1000.0); got {mid:.2}"
+    );
+
+    // Pump comfortably past the 100ms duration.
+    for _ in 0..10 {
+        scoped.pump_for(Duration::from_millis(16));
+    }
+    assert_eq!(
+        controller.pixels(),
+        1000.0,
+        "once the duration has fully elapsed, animate_to must land EXACTLY on \
+         the target; got {:.2}",
+        controller.pixels()
+    );
+}
+
+/// A pan gesture that crosses drag-slop DURING an in-flight `animate_to` must
+/// halt it at the finger's contact position — `on_pan_start` calls
+/// `fling_controller.stop()`, and `animate_to` drives that EXACT SAME
+/// controller (the whole reason `ScrollableState` reuses its fling
+/// controller instead of a separate one — see `scrollable.rs`'s module
+/// docs), so the cancellation falls out of the existing grab-to-stop
+/// discipline for free.
+#[test]
+fn scrollable_grab_during_animate_to_halts_it() {
+    let controller = ScrollController::new();
+    controller.update_dimensions(300.0, 0.0, 4700.0);
+
+    let vsync = Vsync::new();
+    let widget = Scrollable::new()
+        .controller(controller.clone())
+        .child(SizedBox::new(300.0, 5000.0));
+
+    let mut scoped = fling_scoped(widget, vsync, tight(300.0, 300.0));
+
+    controller.animate_to(1000.0, Duration::from_millis(300), Arc::new(Curves::Linear));
+    // Three pumps of warm-up — see `scrollable_animate_to_reaches_the_target_through_the_curve`'s
+    // doc for why this needs one more pump than a direct `animate_with` fling.
+    scoped.pump_for(Duration::from_millis(16));
+    scoped.pump_for(Duration::from_millis(16));
+    scoped.pump_for(Duration::from_millis(16));
+    let pixels_mid_animation = controller.pixels();
+    assert!(
+        pixels_mid_animation > 0.0 && pixels_mid_animation < 1000.0,
+        "sanity: the animation must be genuinely in flight before the grab; \
+         got {pixels_mid_animation:.2}"
+    );
+
+    // Grab: cross slop to fire on_pan_start -> fling_controller.stop(). A
+    // downward drag so it doesn't overlap numerically with the already-
+    // advanced scroll position, then cancel to avoid firing on_pan_end (and
+    // starting a new fling).
+    scoped.dispatch_pointer_down(150.0, 200.0);
+    scoped.dispatch_pointer_move(150.0, 250.0); // 50px downward: past the 18px slop
+    scoped.dispatch_pointer_cancel(150.0, 250.0);
+
+    let pixels_after_grab = controller.pixels();
+
+    for _ in 0..10 {
+        scoped.pump_for(Duration::from_millis(16));
+    }
+
+    let drift = (controller.pixels() - pixels_after_grab).abs();
+    assert!(
+        drift <= 1.0,
+        "grabbing mid-animate_to must halt the run; offset drifted by {drift:.3} px \
+         after the grab (from {pixels_after_grab:.1} to {:.1})",
+        controller.pixels()
+    );
+    assert!(
+        controller.pixels() < 1000.0,
+        "a halted animate_to must never reach its original target (1000.0); got {:.2}",
+        controller.pixels()
+    );
+}
+
+/// `jump_to` called while an `animate_to` is in flight must cancel it
+/// SYNCHRONOUSLY — a subsequent frame must not resume driving toward the
+/// original target, and must not even transiently show a stale fling-tick
+/// value before the cancellation "catches up" (see `ScrollController`'s
+/// `stop_hook` field docs for the one-frame race a merely QUEUED
+/// cancellation would otherwise leave open, since `flui-binding::pump_frame`
+/// ticks registered controllers before draining the rebuild queue that
+/// services a queued command).
+///
+/// Flutter parity: `ScrollPosition.jumpTo` calls `goIdle()` — cancelling
+/// whatever activity currently owns the position — before touching `pixels`
+/// (`scroll_position_with_single_context.dart`, tag `3.44.0`).
+#[test]
+fn scrollable_jump_to_during_animate_to_cancels_it_synchronously() {
+    let controller = ScrollController::new();
+    controller.update_dimensions(300.0, 0.0, 4700.0);
+
+    let vsync = Vsync::new();
+    let widget = Scrollable::new()
+        .controller(controller.clone())
+        .child(SizedBox::new(300.0, 5000.0));
+
+    let mut scoped = fling_scoped(widget, vsync, tight(300.0, 300.0));
+
+    controller.animate_to(1000.0, Duration::from_millis(300), Arc::new(Curves::Linear));
+    // Three pumps of warm-up — see `scrollable_animate_to_reaches_the_target_through_the_curve`'s
+    // doc for why this needs one more pump than a direct `animate_with` fling.
+    scoped.pump_for(Duration::from_millis(16));
+    scoped.pump_for(Duration::from_millis(16));
+    scoped.pump_for(Duration::from_millis(16));
+    assert!(
+        controller.pixels() > 0.0 && controller.pixels() < 1000.0,
+        "sanity: the animation must be in flight before jump_to"
+    );
+
+    controller.jump_to(42.0);
+    assert_eq!(
+        controller.pixels(),
+        42.0,
+        "jump_to must move to its own target immediately"
+    );
+
+    // The very next frame tick must NOT resume the old animation — if the
+    // cancellation were only queued (not synchronous), this frame's tick step
+    // (which runs BEFORE the rebuild that would service the queued Cancel)
+    // would advance the still-running fling controller once more, stomping
+    // the 42.0 this assertion checks.
+    scoped.pump_for(Duration::from_millis(16));
+    assert_eq!(
+        controller.pixels(),
+        42.0,
+        "the frame immediately after jump_to must not have resumed the \
+         canceled animate_to even transiently; got {:.2}",
+        controller.pixels()
+    );
+
+    for _ in 0..10 {
+        scoped.pump_for(Duration::from_millis(16));
+    }
+    assert_eq!(
+        controller.pixels(),
+        42.0,
+        "a jump_to mid-animate_to must cancel the run for good — later frames \
+         must not resume driving toward the original 1000.0 target; got {:.2}",
+        controller.pixels()
+    );
+}
+
+/// A second `animate_to`, issued before the first has finished, must replace
+/// it outright — the position must end up at the SECOND target, never
+/// pausing at or passing through the first.
+///
+/// Flutter parity: `ScrollPositionWithSingleContext.animateTo` calls
+/// `beginActivity`, which disposes whatever `DrivenScrollActivity` (or
+/// ballistic activity) was previously running before installing the new one
+/// (`scroll_position_with_single_context.dart`, tag `3.44.0`).
+#[test]
+fn scrollable_second_animate_to_supersedes_the_first() {
+    let controller = ScrollController::new();
+    controller.update_dimensions(300.0, 0.0, 4700.0);
+
+    let vsync = Vsync::new();
+    let widget = Scrollable::new()
+        .controller(controller.clone())
+        .child(SizedBox::new(300.0, 5000.0));
+
+    let mut scoped = fling_scoped(widget, vsync, tight(300.0, 300.0));
+
+    controller.animate_to(500.0, Duration::from_millis(100), Arc::new(Curves::Linear));
+    // Three pumps of warm-up — see `scrollable_animate_to_reaches_the_target_through_the_curve`'s
+    // doc for why the run only starts genuinely ticking on the third pump.
+    scoped.pump_for(Duration::from_millis(16));
+    scoped.pump_for(Duration::from_millis(16));
+    scoped.pump_for(Duration::from_millis(16));
+    let pixels_before_supersede = controller.pixels();
+    assert!(
+        pixels_before_supersede > 0.0 && pixels_before_supersede < 500.0,
+        "sanity: the first animate_to must be genuinely in flight before it is \
+         superseded; got {pixels_before_supersede:.2}"
+    );
+
+    // Replace it before it ever reaches 500.0.
+    controller.animate_to(2000.0, Duration::from_millis(100), Arc::new(Curves::Linear));
+
+    for _ in 0..20 {
+        scoped.pump_for(Duration::from_millis(16));
+    }
+
+    assert_eq!(
+        controller.pixels(),
+        2000.0,
+        "a second animate_to must supersede the first outright, landing on \
+         the SECOND target (2000.0), never settling at the first (500.0); \
+         got {:.2}",
         controller.pixels()
     );
 }

--- a/crates/flui-widgets/tests/scroll.rs
+++ b/crates/flui-widgets/tests/scroll.rs
@@ -5,7 +5,7 @@
 //! 2. `ScrollController` thumb geometry helpers.
 //! 3. `Scrollable` interactive drag integration (gesture → offset change).
 //! 4. `ClampingScrollPhysics` hard-boundary enforcement.
-//! 5. `ScrollController::animate_to` (ADR-0037 PR3) — curve-driven animation,
+//! 5. `ScrollController::animate_to` (ADR-0037) — curve-driven animation,
 //!    grab-to-cancel, and jump_to-cancels-in-flight.
 
 mod common;
@@ -18,11 +18,12 @@ use flui_animation::{Curves, Vsync};
 use flui_rendering::constraints::BoxConstraints;
 use flui_types::Color;
 use flui_types::geometry::px;
-use flui_view::ViewExt;
+use flui_view::prelude::StatelessView;
+use flui_view::{BuildContext, IntoView, ViewExt};
 use flui_widgets::{
-    BouncingScrollPhysics, ClampingScrollPhysics, ColoredBox, CustomScrollView, GridView, ListView,
-    ScrollController, ScrollMetrics, ScrollPhysics, Scrollable, SharedScrollPhysics,
-    SingleChildScrollView, SizedBox, SliverFixedExtentList, VsyncScope,
+    BouncingScrollPhysics, ClampingScrollPhysics, ColoredBox, CustomScrollView, GestureArenaScope,
+    GridView, ListView, ScrollController, ScrollMetrics, ScrollPhysics, Scrollable,
+    SharedScrollPhysics, SingleChildScrollView, SizedBox, SliverFixedExtentList, VsyncScope,
 };
 
 /// Flutter parity (tag `3.44.0`):
@@ -1168,7 +1169,7 @@ fn pan_start_during_fling_halts_momentum() {
 }
 
 // ============================================================================
-// Scrollable — animate_to (ADR-0037 PR3)
+// Scrollable — animate_to (ADR-0037)
 // ============================================================================
 
 /// `animate_to` drives the SAME fling `AnimationController` a ballistic fling
@@ -1406,6 +1407,205 @@ fn scrollable_second_animate_to_supersedes_the_first() {
         "a second animate_to must supersede the first outright, landing on \
          the SECOND target (2000.0), never settling at the first (500.0); \
          got {:.2}",
+        controller.pixels()
+    );
+}
+
+/// A controller SWAP (via `did_update_view` — same root `Scrollable` type
+/// before and after, so this reconciles as an update, not a remount) must
+/// move the synchronous `jump_to` cancellation hook onto the NEW controller.
+/// Without `ScrollableState::did_update_view` re-installing it there, the new
+/// controller's `jump_to` would find no hook installed at all (a fresh
+/// `ScrollController` starts with none) and fail to stop the SHARED fling
+/// controller synchronously.
+///
+/// This starts the fling via a REAL drag+release on the OLD controller
+/// BEFORE the swap (`Scrollable`'s `AnimatedBuilder`-rebuilt gesture
+/// callbacks are only known-good against the controller active at gesture
+/// time), then swaps, then exercises ONLY the stop hook — a plain field
+/// read-and-call at `jump_to` time, wired directly by `did_update_view`
+/// rather than by anything requiring a POST-swap `AnimatedBuilder` rebuild
+/// (a separate, pre-existing gap — see `scroll_controller`'s field doc in
+/// `scrollable.rs` — that a fresh `animate_to` call on the new controller
+/// would otherwise entangle this test with).
+#[test]
+fn scrollable_reinstalls_the_stop_hook_after_a_controller_swap() {
+    let old_controller = ScrollController::new();
+    let new_controller = ScrollController::new();
+    old_controller.update_dimensions(300.0, 0.0, 4700.0);
+
+    let vsync = Vsync::new();
+    let widget = Scrollable::new()
+        .controller(old_controller.clone())
+        .child(SizedBox::new(300.0, 5000.0));
+    let mut scoped = fling_scoped(widget, vsync.clone(), tight(300.0, 300.0));
+
+    // Start a REAL fling on the OLD controller — the shared fling
+    // `AnimationController` this drives is the SAME instance
+    // `ScrollableState` keeps across a controller swap (created once in
+    // `create_state`), so it stays running straight through the swap below.
+    scoped.dispatch_pointer_down(150.0, 250.0);
+    scoped.dispatch_pointer_move(150.0, 180.0); // slop-crossing: 70 px upward
+    scoped.dispatch_pointer_move(150.0, 150.0); // 30 px more: on_pan_update
+    scoped.dispatch_pointer_up(150.0, 150.0);
+    scoped.pump_for(Duration::from_millis(16));
+    scoped.pump_for(Duration::from_millis(16));
+    let old_pixels_mid_fling = old_controller.pixels();
+    assert!(
+        old_pixels_mid_fling > 0.0,
+        "sanity: the fling must be genuinely advancing the OLD controller \
+         before the swap; got {old_pixels_mid_fling:.2}"
+    );
+
+    // Swap to a DIFFERENT controller, re-wrapped in a matching
+    // `GestureArenaScope` (`fling_scoped`/`lay_out_with_arena` mounted the
+    // root as `GestureArenaScope<VsyncScope<Scrollable>>` — a root element
+    // TYPE change does not run the normal update/dispose path, so the
+    // replacement must keep that exact same outer shape for this to
+    // reconcile as an UPDATE through `did_update_view`, not a remount; same
+    // pattern `tests/parity/page_view_test.rs`'s
+    // `a_parent_rebuild_with_no_explicit_controller_keeps_the_current_page`
+    // uses).
+    let rewrapped = GestureArenaScope::new(
+        scoped.laid().arena(),
+        VsyncScope::new(
+            vsync,
+            Scrollable::new()
+                .controller(new_controller.clone())
+                .child(SizedBox::new(300.0, 5000.0)),
+        ),
+    );
+    scoped.pump_widget(rewrapped);
+
+    // The fling is STILL running on the shared controller post-swap (its
+    // value listener keeps pushing into the OLD controller — the named,
+    // pre-existing, out-of-scope swap gap `scrollable.rs` documents — so
+    // `old_controller` is what still observably advances).
+    scoped.pump_for(Duration::from_millis(16));
+    assert!(
+        old_controller.pixels() > old_pixels_mid_fling,
+        "sanity: the fling must still be advancing after the swap, before \
+         jump_to; old_controller: {:.2} -> {:.2}",
+        old_pixels_mid_fling,
+        old_controller.pixels()
+    );
+
+    // The SYNCHRONOUS cancellation path: `new_controller.jump_to` must find
+    // the stop hook `did_update_view` re-installed on it, and stop the
+    // SHARED fling controller THIS INSTANT.
+    new_controller.jump_to(0.0);
+    let old_pixels_after_jump = old_controller.pixels();
+
+    for _ in 0..5 {
+        scoped.pump_for(Duration::from_millis(16));
+    }
+
+    let drift = (old_controller.pixels() - old_pixels_after_jump).abs();
+    assert!(
+        drift <= 1.0,
+        "jump_to on the controller installed by a did_update_view SWAP must \
+         still stop the shared fling controller synchronously — the OLD \
+         controller's pixels (still fed by the fling's value listener) must \
+         stop drifting once jump_to is called on the NEW one; drifted \
+         {drift:.3} px after jump_to (from {old_pixels_after_jump:.1} to \
+         {:.1})",
+        old_controller.pixels()
+    );
+}
+
+/// A `StatelessView` host that can unmount `Scrollable` entirely (`show:
+/// false`) — the same "stable root TYPE, varying build output" pattern
+/// `PageViewHost` (`tests/parity/page_view_test.rs`) uses, since `pump_widget`
+/// reconciling two DIFFERENT concrete ROOT types does not run the normal
+/// unmount/dispose path; toggling the INNER build output under a stable
+/// outer type does.
+#[derive(Clone, StatelessView)]
+struct ScrollableHost {
+    controller: ScrollController,
+    show: bool,
+}
+
+impl StatelessView for ScrollableHost {
+    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+        if !self.show {
+            return SizedBox::new(1.0, 1.0).into_view().boxed();
+        }
+        Scrollable::new()
+            .controller(self.controller.clone())
+            .child(SizedBox::new(300.0, 5000.0))
+            .into_view()
+            .boxed()
+    }
+}
+
+/// Disposing a `Scrollable` must clear any not-yet-serviced pending command
+/// from its controller — otherwise an `animate_to` queued before dispose
+/// would replay against a DIFFERENT (freshly mounted) `ScrollableState`'s
+/// fling controller if the same `ScrollController` is later re-attached to a
+/// new `Scrollable`, instead of leaving the fresh, untouched state a caller
+/// re-attaching a controller would expect.
+#[test]
+fn disposing_a_scrollable_clears_the_controllers_pending_command_before_a_reattach() {
+    let controller = ScrollController::new();
+    controller.update_dimensions(300.0, 0.0, 4700.0);
+
+    let vsync = Vsync::new();
+    let mut scoped = lay_out_with_arena(
+        VsyncScope::new(
+            vsync.clone(),
+            ScrollableHost {
+                controller: controller.clone(),
+                show: true,
+            },
+        ),
+        tight(300.0, 300.0),
+    );
+    scoped.adopt_vsync(vsync.clone());
+
+    // Queue an animate_to but dispose before ANY pump services it.
+    controller.animate_to(1000.0, Duration::from_millis(100), Arc::new(Curves::Linear));
+
+    // Unmount: `show: false` toggles the INNER build output. Re-wrapped in a
+    // matching `GestureArenaScope` (`lay_out_with_arena` mounted the root as
+    // `GestureArenaScope<VsyncScope<ScrollableHost>>` — a root element TYPE
+    // change does not run the normal update/dispose path, so the
+    // replacement must keep that exact same outer shape for this to
+    // reconcile as a genuine update that runs `Scrollable`'s dispose, not a
+    // remount).
+    let unmounted = GestureArenaScope::new(
+        scoped.laid().arena(),
+        VsyncScope::new(
+            vsync.clone(),
+            ScrollableHost {
+                controller: controller.clone(),
+                show: false,
+            },
+        ),
+    );
+    scoped.pump_widget(unmounted);
+
+    // Re-attach the SAME controller to a brand-new mounted Scrollable.
+    let reattached = GestureArenaScope::new(
+        scoped.laid().arena(),
+        VsyncScope::new(
+            vsync,
+            ScrollableHost {
+                controller: controller.clone(),
+                show: true,
+            },
+        ),
+    );
+    scoped.pump_widget(reattached);
+
+    for _ in 0..10 {
+        scoped.pump_for(Duration::from_millis(16));
+    }
+
+    assert_eq!(
+        controller.pixels(),
+        0.0,
+        "an animate_to queued before dispose must NOT replay against a \
+         freshly re-attached Scrollable; got {:.2}",
         controller.pixels()
     );
 }


### PR DESCRIPTION
Third and final PR of the paging layer: animated scrolling for every scrollable, and the PageController page-animation methods.

## What

- **`ScrollController::animate_to(offset, duration, curve)`** — a private pending-command cell serviced by `ScrollableState`, which drives its existing vsync-registered `AnimationController` with a curve tween; an idle scrollable genuinely wakes (`position.notify()` is load-bearing and mutation-pinned). A user grab cancels; `jump_to` cancels **synchronously** through a stop hook (the queued path alone is one frame late — pinned); a second `animate_to` supersedes the first. Exact-equality targets short-circuit to `jump_to` (the oracle's `nearEqual → jumpTo` shape; the physics-derived-tolerance difference is a documented divergence, as is the no-`Future` return — FLUI has no widget-level async gate).
- **`PageController::{animate_to_page, next_page, previous_page}`** — page→pixels via the guarded formula, delegating to `animate_to`; `next/previous` are `page.round() ± 1` with clamping semantics verified verbatim against the oracle.
- **Controller-swap lifecycle hardened** (the review round's catch, the repo's recurring class): the stop hook re-installs in `did_update_view` and clears in `dispose` alongside the pending command — a swapped controller keeps synchronous cancel, a disposed scrollable leaves no dead hook, and a command queued while detached can't replay into the next attach (554px-drift and stale-replay mutants both killed). The `jump_to` hook invocation clones out and drops the guard first — the under-guard shape deadlocks a reentrant status listener, pinned by a bounded 2s background-thread red-check. The pre-existing fling-listener swap-blindness is a named follow-up, not silently inherited.

This completes ADR-0037: PR1 metrics+policy (#426), PR2 PageView (#427), PR3 animate_to — and closes flui-material's documented `animate_to`-as-jump-alias gap (the TabBarView rebase is the named follow-up, deferred while a concurrent session owns that crate).

## Evidence

- flui-widgets: 1388 passed; workspace: 7767 passed (the one red remains the concurrent session's uncommitted FAB edit); clippy `-D warnings`, fmt/port-check/inventory/taplo/typos, doc gates: clean.
- 7/7 mutants killed across two review rounds (grab-cancel, supersede, idle-wake, sync-cancel, swap re-install, dispose clear, hook-under-guard); oracle semantics cross-checked member-by-member.
- Full review + delta re-review: SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)