### PR TITLE
fix(widgets): fresh FeedbackSignal per drag entry, fling-listener swap rewire, Focus::of/FocusScope::of

### DIFF
--- a/crates/flui-widgets/src/interaction/draggable.rs
+++ b/crates/flui-widgets/src/interaction/draggable.rs
@@ -354,26 +354,30 @@ pub struct DraggableState<T: Clone + Send + Sync + 'static> {
     /// (`build`'s removal is deferred to the next rebuild, which a rapid
     /// restart — end, then a new drag starts before that rebuild drains —
     /// can easily race ahead of; evicting unconditionally here, not only
-    /// when the slot looks "stale," is what closes that race). One further
-    /// named case this does **not** fix: if the session that currently owns
-    /// the slot ends while some other, still-active session continues (and
-    /// no new session ever starts to evict it), this slot stays `Some` —
-    /// nothing clears it on that one session's end alone — so the layer is
+    /// when the slot looks "stale," is what closes that race).
+    ///
+    /// One named case this does **not** fix: if the session that currently
+    /// owns the slot ends while some other, still-active session continues
+    /// (and no new session ever starts to evict it), this slot stays `Some`
+    /// — nothing clears it on that one session's end alone — so the layer is
     /// left mounted but frozen (no session left is writing to its
     /// `FeedbackSignal`) until `build` next observes zero active sessions
-    /// and tears it down. A third named case, introduced by the eviction:
-    /// when a later session evicts a STILL-LIVE earlier one, both sessions
-    /// keep `Some` of the one shared [`FeedbackSignal`], so both write
-    /// offsets and the single mounted layer jitters between the two drags'
-    /// displacements until either ends (a fresh signal per inserted entry
-    /// would detach the stale writer — a follow-up shape). All three are
-    /// honest scope cuts of the same root cause: no harness capability here
-    /// can even drive two truly concurrent contacts to observe any of them
-    /// directly (see this file's own module docs on that limitation).
+    /// and tears it down. An honest scope cut of the same root cause as
+    /// eviction itself: no harness capability here can even drive two truly
+    /// concurrent contacts to observe it directly (see this file's own
+    /// module docs on that limitation).
+    ///
+    /// A second case this doc used to name is now fixed: eviction of a
+    /// STILL-LIVE earlier session used to leave both sessions holding `Some`
+    /// of the one shared [`FeedbackSignal`] carried on `DraggableState`, so
+    /// both wrote offsets and the single mounted layer jittered between the
+    /// two drags' displacements until either ended. `on_start` now mints a
+    /// **fresh** [`FeedbackSignal::new`] for every inserted entry instead of
+    /// reusing one shared field — the evicted session's `DragSession` keeps
+    /// writing to *its own*, now-detached signal, which nothing reads (inert,
+    /// the same shape as [`FeedbackSignal::reposition`]'s existing
+    /// before-mount/after-unmount no-op).
     feedback_entry: Rc<RefCell<Option<OverlayEntry>>>,
-    /// The `Send + Sync` handle shared with whichever `DragSession` currently
-    /// owns `feedback_entry`, if any.
-    feedback_signal: FeedbackSignal,
     /// `feedback`/`feedback_offset`, refreshed each `build` — read by
     /// `on_start` at drag-start time. Owner-local (`Rc<RefCell<_>>`): see
     /// [`FeedbackConfig`]'s docs on why it cannot live in [`DragConfig`].
@@ -732,7 +736,6 @@ impl<T: Clone + Send + Sync + 'static> StatefulView for Draggable<T> {
             config: Arc::new(Mutex::new(DragConfig::from_view(self))),
             overlay: Arc::new(Mutex::new(None)),
             feedback_entry: Rc::new(RefCell::new(None)),
-            feedback_signal: FeedbackSignal::new(),
             feedback_config: Rc::new(RefCell::new(FeedbackConfig::from_view(self))),
             recognizer: None,
             _data: std::marker::PhantomData,
@@ -760,7 +763,6 @@ impl<T: Clone + Send + Sync + 'static> ViewState<Draggable<T>> for DraggableStat
         let config = Arc::clone(&self.config);
         let overlay = Arc::clone(&self.overlay);
         let feedback_entry_slot = Rc::clone(&self.feedback_entry);
-        let feedback_signal = self.feedback_signal.clone();
         let feedback_config = Rc::clone(&self.feedback_config);
         let on_start: MultiDragStartCallback = Rc::new(move |_pointer, _position| {
             {
@@ -802,11 +804,17 @@ impl<T: Clone + Send + Sync + 'static> ViewState<Draggable<T>> for DraggableStat
 
             let feedback = match (overlay_handle, feedback_builder) {
                 (Some(handle), Some(builder)) => {
-                    feedback_signal.set_offset(Offset::ZERO);
-                    let entry = feedback_entry(builder, feedback_offset, feedback_signal.clone());
+                    // A FRESH signal per inserted entry, not one shared
+                    // across sessions on `DraggableState` — see
+                    // `feedback_entry`'s docs: reusing one shared instance is
+                    // exactly what let a still-live evicted session keep
+                    // writing into the surviving layer. `FeedbackSignal::new`
+                    // already starts at `Offset::ZERO`.
+                    let signal = FeedbackSignal::new();
+                    let entry = feedback_entry(builder, feedback_offset, signal.clone());
                     handle.insert(&entry, &InsertPosition::Top);
                     *feedback_entry_slot.borrow_mut() = Some(entry);
-                    Some(feedback_signal.clone())
+                    Some(signal)
                 }
                 _ => None,
             };
@@ -915,5 +923,178 @@ impl<T: Clone + Send + Sync + 'static> ViewState<Draggable<T>> for DraggableStat
         if let Some(entry) = stale {
             entry.remove();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use flui_interaction::PointerId;
+    use flui_interaction::events::PointerType;
+
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // Fresh-`FeedbackSignal`-per-entry — the fix for the documented third
+    // scope-cut `feedback_entry`'s docs used to name: a later session
+    // evicting a STILL-LIVE earlier one used to leave both sessions writing
+    // to the one shared `FeedbackSignal`, jittering the mounted layer.
+    //
+    // No `LaidOutScoped` capability can drive two truly concurrent pointer
+    // contacts (`tests/parity/draggable_test.rs`'s own module doc; each
+    // `dispatch_pointer_down` reassigns the harness's single "current
+    // contact"), so an end-to-end integration test cannot construct the
+    // "still-live earlier session" this fixes. This constructs the two
+    // `DragSession`s directly instead — exactly the shape two overlapping
+    // `on_start` calls now produce (see `init_state`'s `on_start` closure:
+    // each inserts its own entry via a freshly-minted `FeedbackSignal::new()`,
+    // never `self.feedback_signal.clone()` — that shared field no longer
+    // exists).
+    // ------------------------------------------------------------------
+
+    /// A trivial `StatefulView` whose only job is to capture the
+    /// `RebuildHandle` `init_state` acquires. `RebuildHandle` has no public
+    /// standalone constructor (only a real mount ever mints one), so this
+    /// mounts the smallest possible real element tree to get one. Mirrors
+    /// `dismissible.rs`'s own `RebuildHandleCapture` fixture.
+    #[derive(Clone, StatefulView)]
+    struct RebuildHandleCapture {
+        captured: Rc<RefCell<Option<RebuildHandle>>>,
+    }
+
+    struct RebuildHandleCaptureState {
+        captured: Rc<RefCell<Option<RebuildHandle>>>,
+    }
+
+    impl StatefulView for RebuildHandleCapture {
+        type State = RebuildHandleCaptureState;
+
+        fn create_state(&self) -> Self::State {
+            RebuildHandleCaptureState {
+                captured: Rc::clone(&self.captured),
+            }
+        }
+    }
+
+    impl ViewState<RebuildHandleCapture> for RebuildHandleCaptureState {
+        fn init_state(&mut self, ctx: &dyn BuildContext) {
+            *self.captured.borrow_mut() = Some(ctx.rebuild_handle());
+        }
+
+        fn build(&self, _view: &RebuildHandleCapture, _ctx: &dyn BuildContext) -> impl IntoView {
+            crate::SizedBox::shrink()
+        }
+    }
+
+    fn mount_and_capture_rebuild_handle() -> RebuildHandle {
+        use flui_view::{BuildOwner, ElementTree};
+
+        let captured = Rc::new(RefCell::new(None));
+        let view = RebuildHandleCapture {
+            captured: Rc::clone(&captured),
+        };
+        let mut owner = BuildOwner::new();
+        let mut tree = ElementTree::new();
+        let root = tree.mount_root(&view, &mut owner.element_owner_mut());
+        owner.schedule_build_for(root, 0);
+        owner.build_scope(&mut tree);
+
+        captured
+            .borrow()
+            .clone()
+            .expect("init_state must have captured a handle")
+    }
+
+    fn empty_config() -> Arc<Mutex<DragConfig>> {
+        Arc::new(Mutex::new(DragConfig {
+            axis: None,
+            max_simultaneous_drags: None,
+            on_drag_started: None,
+            on_drag_update: None,
+            on_draggable_canceled: None,
+            on_drag_end: None,
+        }))
+    }
+
+    fn update_details(dx: f32, dy: f32) -> MultiDragUpdateDetails {
+        MultiDragUpdateDetails {
+            pointer_id: PointerId::new(1).expect("contact ids start at 1"),
+            global_position: Offset::new(Pixels(dx), Pixels(dy)),
+            local_position: Offset::new(Pixels(dx), Pixels(dy)),
+            delta: Offset::new(PixelDelta(dx), PixelDelta(dy)),
+            kind: PointerType::Mouse,
+            timestamp: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn on_start_mints_a_fresh_feedback_signal_every_time_not_a_shared_one() {
+        // `feedback_entry`'s docs: this is exactly what `on_start` mints per
+        // inserted entry now — two independent instances, not two handles to
+        // the same one.
+        let signal_1 = FeedbackSignal::new();
+        let signal_2 = FeedbackSignal::new();
+
+        assert!(
+            !Arc::ptr_eq(&signal_1.offset, &signal_2.offset),
+            "each call must produce a distinct FeedbackSignal instance"
+        );
+    }
+
+    /// Pins the actual fix: an evicted-but-still-live session's writes land
+    /// on its own detached signal, not on the surviving session's.
+    ///
+    /// Red-check: give `session_1` and `session_2` the SAME `FeedbackSignal`
+    /// (the pre-fix shape `on_start` used to have via the shared
+    /// `feedback_signal` field) — the final assertion then fails, because
+    /// `session_1`'s write clobbers what `signal_2` reads.
+    #[test]
+    fn evicted_sessions_write_only_reaches_its_own_detached_signal() {
+        let rebuild = mount_and_capture_rebuild_handle();
+
+        // Session 1 "wins" the feedback slot first...
+        let signal_1 = FeedbackSignal::new();
+        let session_1 = DragSession {
+            active_count: Arc::new(AtomicUsize::new(1)),
+            rebuild: rebuild.clone(),
+            config: empty_config(),
+            offset: Mutex::new(Offset::ZERO),
+            feedback: Some(signal_1.clone()),
+        };
+
+        // ...then a second session starts and evicts it — minting its OWN
+        // signal per the fix, not `signal_1.clone()`.
+        let signal_2 = FeedbackSignal::new();
+        let session_2 = DragSession {
+            active_count: Arc::new(AtomicUsize::new(1)),
+            rebuild,
+            config: empty_config(),
+            offset: Mutex::new(Offset::ZERO),
+            feedback: Some(signal_2.clone()),
+        };
+
+        // Session 1 is stale/evicted but still live (its own pointer hasn't
+        // lifted yet) — its `update()` calls keep landing somewhere.
+        session_1.update(update_details(10.0, 0.0));
+        // Session 2 is the surviving session whose signal the mounted layer
+        // actually reads.
+        session_2.update(update_details(0.0, 25.0));
+
+        assert_eq!(
+            signal_2.offset(),
+            Offset::new(Pixels(0.0), Pixels(25.0)),
+            "the surviving signal must reflect only the surviving session's own moves"
+        );
+        assert_eq!(
+            signal_1.offset(),
+            Offset::new(Pixels(10.0), Pixels(0.0)),
+            "the evicted session's own signal still tracks its own displacement locally"
+        );
+        assert_ne!(
+            signal_1.offset(),
+            signal_2.offset(),
+            "the evicted session's writes must never bleed into the surviving signal"
+        );
     }
 }

--- a/crates/flui-widgets/src/interaction/draggable.rs
+++ b/crates/flui-widgets/src/interaction/draggable.rs
@@ -480,6 +480,13 @@ impl FeedbackSignal {
         }
     }
 
+    /// Whether two handles name the same signal. Identity, not structural
+    /// equality — mirrors [`OverlayHandle::is_same`]/[`OverlayEntry::is_same`].
+    #[cfg(test)]
+    fn is_same(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.offset, &other.offset)
+    }
+
     fn offset(&self) -> Offset<Pixels> {
         *self.offset.lock()
     }
@@ -561,6 +568,54 @@ impl ViewState<FeedbackAnchor> for FeedbackAnchorState {
                 .boxed(),
         ])
         .fit(StackFit::Expand)
+    }
+}
+
+/// Evicts whatever `feedback_entry_slot` currently holds and, if both an
+/// ancestor overlay and a feedback builder are configured, mints a FRESH
+/// [`FeedbackSignal`] for a newly-inserted entry — returning it so the caller
+/// can attach it to the new [`DragSession`]. Returns `None` (having still
+/// evicted any stale entry) when there is nowhere or nothing to show.
+///
+/// This is the exact code `on_start` calls at drag-start time — split out of
+/// its closure body so the fresh-signal-per-entry fix is directly
+/// unit-testable. `on_start` itself returns an opaque
+/// `Option<Box<dyn MultiDragHandle>>` with no accessor back to the
+/// `FeedbackSignal` a `DragSession` captured, so a test invoking `on_start`
+/// twice cannot observe signal identity through its return value alone;
+/// calling this function directly (twice, with the same `feedback_entry_slot`
+/// and a bare, never-mounted `OverlayHandle` — see its own doc on why that
+/// needs no element tree at all) is the real pin for the mint-fresh-signal
+/// fix `feedback_entry`'s docs describe, not a parallel reimplementation of
+/// it.
+///
+/// Every lock/borrow taken here is cloned out and dropped before the
+/// framework calls (`stale.remove()`, `handle.insert()`) that follow — never
+/// held across them.
+fn evict_and_mount_feedback(
+    feedback_entry_slot: &Rc<RefCell<Option<OverlayEntry>>>,
+    overlay_handle: Option<OverlayHandle>,
+    feedback_builder: Option<Rc<dyn Fn() -> BoxedView>>,
+    feedback_offset: Offset<Pixels>,
+) -> Option<FeedbackSignal> {
+    let stale = feedback_entry_slot.borrow_mut().take();
+    if let Some(stale) = stale {
+        stale.remove();
+    }
+    match (overlay_handle, feedback_builder) {
+        (Some(handle), Some(builder)) => {
+            // A FRESH signal per inserted entry, not one shared across
+            // sessions on `DraggableState` — see `feedback_entry`'s docs:
+            // reusing one shared instance is exactly what let a still-live
+            // evicted session keep writing into the surviving layer.
+            // `FeedbackSignal::new` already starts at `Offset::ZERO`.
+            let signal = FeedbackSignal::new();
+            let entry = feedback_entry(builder, feedback_offset, signal.clone());
+            handle.insert(&entry, &InsertPosition::Top);
+            *feedback_entry_slot.borrow_mut() = Some(entry);
+            Some(signal)
+        }
+        _ => None,
     }
 }
 
@@ -788,36 +843,17 @@ impl<T: Clone + Send + Sync + 'static> ViewState<Draggable<T>> for DraggableStat
             // including a stale one an earlier session's own end/cancel
             // never got to remove yet (`build`'s teardown is deferred to the
             // next rebuild, which may not have drained before this call).
-            //
-            // Every lock/borrow below is cloned out and dropped before the
-            // framework calls (`stale.remove()`, `handle.insert()`) that
-            // follow — never held across them.
-            let stale = feedback_entry_slot.borrow_mut().take();
-            if let Some(stale) = stale {
-                stale.remove();
-            }
             let overlay_handle = overlay.lock().clone();
             let (feedback_builder, feedback_offset) = {
                 let cfg = feedback_config.borrow();
                 (cfg.feedback.clone(), cfg.feedback_offset)
             };
-
-            let feedback = match (overlay_handle, feedback_builder) {
-                (Some(handle), Some(builder)) => {
-                    // A FRESH signal per inserted entry, not one shared
-                    // across sessions on `DraggableState` — see
-                    // `feedback_entry`'s docs: reusing one shared instance is
-                    // exactly what let a still-live evicted session keep
-                    // writing into the surviving layer. `FeedbackSignal::new`
-                    // already starts at `Offset::ZERO`.
-                    let signal = FeedbackSignal::new();
-                    let entry = feedback_entry(builder, feedback_offset, signal.clone());
-                    handle.insert(&entry, &InsertPosition::Top);
-                    *feedback_entry_slot.borrow_mut() = Some(entry);
-                    Some(signal)
-                }
-                _ => None,
-            };
+            let feedback = evict_and_mount_feedback(
+                &feedback_entry_slot,
+                overlay_handle,
+                feedback_builder,
+                feedback_offset,
+            );
 
             Some(Box::new(DragSession {
                 active_count: Arc::clone(&active_count),
@@ -941,16 +977,25 @@ mod tests {
     // evicting a STILL-LIVE earlier one used to leave both sessions writing
     // to the one shared `FeedbackSignal`, jittering the mounted layer.
     //
-    // No `LaidOutScoped` capability can drive two truly concurrent pointer
-    // contacts (`tests/parity/draggable_test.rs`'s own module doc; each
-    // `dispatch_pointer_down` reassigns the harness's single "current
-    // contact"), so an end-to-end integration test cannot construct the
-    // "still-live earlier session" this fixes. This constructs the two
-    // `DragSession`s directly instead — exactly the shape two overlapping
-    // `on_start` calls now produce (see `init_state`'s `on_start` closure:
-    // each inserts its own entry via a freshly-minted `FeedbackSignal::new()`,
-    // never `self.feedback_signal.clone()` — that shared field no longer
-    // exists).
+    // `evict_and_mount_feedback_mints_a_fresh_signal_every_call_not_a_shared_one`
+    // below is the real pin: it calls `evict_and_mount_feedback` — the exact
+    // code `on_start` calls at drag-start time — directly, twice, and checks
+    // the two returned `FeedbackSignal`s are distinct instances. This is only
+    // possible because that mounting logic was split out of `on_start`'s
+    // closure body into a standalone function: `on_start` itself returns an
+    // opaque `Option<Box<dyn MultiDragHandle>>` with no accessor back to the
+    // `FeedbackSignal` a `DragSession` captured, so invoking `on_start` twice
+    // cannot observe signal identity through its return value alone, and no
+    // `LaidOutScoped` capability can drive two truly concurrent pointer
+    // contacts through it end-to-end either (`tests/parity/draggable_test.rs`'s
+    // own module doc; each `dispatch_pointer_down` reassigns the harness's
+    // single "current contact").
+    //
+    // `evicted_sessions_write_only_reaches_its_own_detached_signal` further
+    // down is a DIFFERENT, narrower characterization: not of the minting
+    // fix itself, but of `DragSession::update`'s pre-existing "write only to
+    // whichever `FeedbackSignal` I was constructed with" semantics — a real
+    // property, just not the one that was broken.
     // ------------------------------------------------------------------
 
     /// A trivial `StatefulView` whose only job is to capture the
@@ -1028,29 +1073,83 @@ mod tests {
         }
     }
 
+    /// Pins the real fix (see the module-doc comment above this block):
+    /// `evict_and_mount_feedback` — the exact function `on_start` calls at
+    /// drag-start time — must mint a FRESH `FeedbackSignal` on every call,
+    /// never hand back (a clone of) a signal an earlier call already
+    /// returned.
+    ///
+    /// `OverlayHandle::new()` is never mounted anywhere in this test — its
+    /// own doc says mutating an unmounted handle is legal (the first real
+    /// build reads whatever the list holds; `schedule_rebuild` on a `None`
+    /// hook is a no-op) — so this needs no element tree, `BuildContext`, or
+    /// harness at all to exercise the actual production code path.
+    ///
+    /// Red-check: reintroduce a shared signal inside `evict_and_mount_feedback`
+    /// (e.g. read it from a `thread_local`/captured cell instead of calling
+    /// `FeedbackSignal::new()`) — the identity assertion below fails. See this
+    /// function's own doc comment for the exact red-check run against this fix.
     #[test]
-    fn on_start_mints_a_fresh_feedback_signal_every_time_not_a_shared_one() {
-        // `feedback_entry`'s docs: this is exactly what `on_start` mints per
-        // inserted entry now — two independent instances, not two handles to
-        // the same one.
-        let signal_1 = FeedbackSignal::new();
-        let signal_2 = FeedbackSignal::new();
+    fn evict_and_mount_feedback_mints_a_fresh_signal_every_call_not_a_shared_one() {
+        let slot: Rc<RefCell<Option<OverlayEntry>>> = Rc::new(RefCell::new(None));
+        let overlay_handle = OverlayHandle::new();
+        let builder: Rc<dyn Fn() -> BoxedView> =
+            Rc::new(|| crate::SizedBox::new(1.0, 1.0).into_view().boxed());
+
+        let signal_1 = evict_and_mount_feedback(
+            &slot,
+            Some(overlay_handle.clone()),
+            Some(Rc::clone(&builder)),
+            Offset::ZERO,
+        )
+        .expect("an overlay handle and a builder are both configured — must mint a signal");
+
+        // A second call — exactly what a second overlapping `on_start` call
+        // does while the first session is still live (nothing here has
+        // ended the first session; this call alone evicts its entry).
+        let signal_2 = evict_and_mount_feedback(
+            &slot,
+            Some(overlay_handle.clone()),
+            Some(Rc::clone(&builder)),
+            Offset::ZERO,
+        )
+        .expect("an overlay handle and a builder are both configured — must mint a signal");
 
         assert!(
-            !Arc::ptr_eq(&signal_1.offset, &signal_2.offset),
-            "each call must produce a distinct FeedbackSignal instance"
+            !signal_1.is_same(&signal_2),
+            "each call must mint its own FeedbackSignal — a still-live \
+             evicted session must not keep writing into the surviving one"
         );
     }
 
-    /// Pins the actual fix: an evicted-but-still-live session's writes land
-    /// on its own detached signal, not on the surviving session's.
-    ///
-    /// Red-check: give `session_1` and `session_2` the SAME `FeedbackSignal`
-    /// (the pre-fix shape `on_start` used to have via the shared
-    /// `feedback_signal` field) — the final assertion then fails, because
-    /// `session_1`'s write clobbers what `signal_2` reads.
+    /// `evict_and_mount_feedback` returns `None` — minting nothing — when
+    /// there is nowhere to show feedback (no overlay) or nothing configured
+    /// to show (no builder), the same as before this port's feedback wiring
+    /// landed at all.
     #[test]
-    fn evicted_sessions_write_only_reaches_its_own_detached_signal() {
+    fn evict_and_mount_feedback_mints_nothing_without_both_an_overlay_and_a_builder() {
+        let slot: Rc<RefCell<Option<OverlayEntry>>> = Rc::new(RefCell::new(None));
+        let builder: Rc<dyn Fn() -> BoxedView> =
+            Rc::new(|| crate::SizedBox::new(1.0, 1.0).into_view().boxed());
+
+        assert!(
+            evict_and_mount_feedback(&slot, None, Some(builder), Offset::ZERO).is_none(),
+            "no overlay ancestor: nowhere to paint feedback"
+        );
+        assert!(
+            evict_and_mount_feedback(&slot, Some(OverlayHandle::new()), None, Offset::ZERO)
+                .is_none(),
+            "no feedback builder configured: nothing to paint"
+        );
+    }
+
+    /// A narrower, separate characterization from the two tests above: not
+    /// of the minting fix itself, but of `DragSession::update`'s pre-existing
+    /// "write only to whichever `FeedbackSignal` I was constructed with"
+    /// semantics — two sessions built with two independent signals never
+    /// cross-write, regardless of how those signals were minted.
+    #[test]
+    fn drag_session_update_writes_only_to_its_own_constructed_signal() {
         let rebuild = mount_and_capture_rebuild_handle();
 
         // Session 1 "wins" the feedback slot first...

--- a/crates/flui-widgets/src/interaction/focus.rs
+++ b/crates/flui-widgets/src/interaction/focus.rs
@@ -27,9 +27,12 @@
 //!   `applyFocusChangesIfNeeded` at end of frame; FLUI's `FocusManager` is
 //!   synchronous throughout, so `autofocus` runs inline from `init_state`.
 //! * Not ported: `onKey` (legacy), `includeSemantics` (needs the semantics
-//!   layer), `parentNode`, `descendantsAreTraversable` (no node-layer flag),
-//!   and `Focus.of`/`maybeOf` (descendants read the provider directly; a
-//!   public lookup waits for `Actions`/`Shortcuts`).
+//!   layer), `parentNode`, `descendantsAreTraversable` (no node-layer flag).
+//!   `Focus.of`/`maybeOf`/`FocusScope.of` ARE ported (ADR-0036's
+//!   `OverlayScope` precedent, applied here — see [`Focus::of`]) — only their
+//!   `scopeOk: true` variant of `Focus.of`/`maybeOf` is not: nothing in this
+//!   crate needs a Focus-flavored lookup that also accepts a scope node,
+//!   since [`FocusScope::of`] already covers "give me the nearest scope".
 
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
@@ -98,6 +101,44 @@ impl_inherited_view!(FocusParentProvider);
 pub(crate) fn enclosing_focus_parent(ctx: &dyn BuildContext) -> Arc<FocusNode> {
     ctx.get::<FocusParentProvider, _>(|provider| Arc::clone(&provider.parent))
         .unwrap_or_else(|| Arc::clone(FocusManager::global().root_scope().as_focus_node()))
+}
+
+/// Raw lookup behind [`Focus::of`]/[`Focus::maybe_of`]/[`FocusScope::of`]:
+/// the nearest enclosing [`FocusParentProvider`]'s node, registering a
+/// dependency, with **no** scope-node filtering. Flutter's own
+/// `Focus.maybeOf(context, scopeOk: true)` (`focus_scope.dart:452`, tag
+/// `3.44.0`) — the call [`FocusScope::of`] makes internally; [`Focus::maybe_of`]
+/// layers the `scopeOk: false` filter back on top.
+///
+/// # Depend, not get
+///
+/// Unlike `Overlay::maybe_of` (`overlay/mod.rs`), routing through
+/// [`BuildContextExt::depend_on`] here is not a FLUI-native divergence from
+/// the oracle — it is the loyal port. Flutter's `Focus.maybeOf` calls
+/// `context.dependOnInheritedWidgetOfExactType` under its **default**
+/// `createDependency: true` (not an override, the way `Overlay.maybeOf`
+/// explicitly passes `createDependency: false`), so registering a dependency
+/// is what the oracle itself does by default.
+///
+/// This resolves the SAME [`FocusParentProvider`] marker `Focus`/`FocusScope`'s
+/// own `build` already mounts around their child for
+/// [`enclosing_focus_parent`]'s mount-time attach/reparent lookups —
+/// Flutter's `_FocusInheritedScope`. No second, redundant marker is mounted
+/// just for this public entry point.
+///
+/// One named divergence, inherited from [`FocusParentProvider`] as it already
+/// existed (not introduced here): Flutter's `_FocusInheritedScope` extends
+/// `InheritedNotifier<FocusNode>`, so a dependent also rebuilds whenever the
+/// resolved `FocusNode` itself fires `notifyListeners` — e.g. a plain gain/
+/// loss of focus, not just a reparent. `FocusParentProvider::update_should_notify`
+/// only compares node IDENTITY (`Arc::ptr_eq`), so a descendant reading
+/// `Focus::of`/`maybe_of`/`FocusScope::of` does NOT automatically rebuild on
+/// a focus-state change alone — only on the enclosing node changing outright.
+/// Changing that notify contract is a separate, wider-reaching decision
+/// (it would also affect `enclosing_focus_parent`'s own callers) and is not
+/// attempted here.
+fn nearest_focus_node(ctx: &dyn BuildContext) -> Option<Arc<FocusNode>> {
+    ctx.depend_on::<FocusParentProvider, _>(|provider| Arc::clone(&provider.parent))
 }
 
 // ============================================================================
@@ -211,6 +252,43 @@ impl Focus {
     pub fn debug_label(mut self, label: &'static str) -> Self {
         self.debug_label = Some(label);
         self
+    }
+
+    /// Returns the [`FocusNode`] of the [`Focus`] that most tightly encloses
+    /// `ctx` — Flutter's `Focus.of` (`focus_scope.dart:398`, tag `3.44.0`),
+    /// `scopeOk: false` only (see the module divergence notes for the
+    /// unported `scopeOk: true` variant; [`FocusScope::of`] covers that case).
+    ///
+    /// # Panics
+    ///
+    /// Panics with a message naming the missing ancestor if no enclosing
+    /// [`Focus`] provides one (Flutter's own assert-time `FlutterError`,
+    /// `focus_scope.dart:398-424`). Use [`maybe_of`](Self::maybe_of) for a
+    /// non-panicking lookup.
+    #[must_use]
+    pub fn of(ctx: &dyn BuildContext) -> Arc<FocusNode> {
+        Self::maybe_of(ctx).expect(
+            "Focus::of() was called with a context that does not contain a Focus widget. \
+             No Focus widget ancestor could be found starting from the context passed to \
+             Focus::of() — wrap the subtree in a Focus, or use Focus::maybe_of with a \
+             caller-chosen fallback.",
+        )
+    }
+
+    /// Returns the [`FocusNode`] of the [`Focus`] that most tightly encloses
+    /// `ctx`, registering a dependency — Flutter's `Focus.maybeOf`
+    /// (`focus_scope.dart:452`, tag `3.44.0`) with its default
+    /// `createDependency: true` (see [`nearest_focus_node`]'s doc for why
+    /// that default, not `Overlay::maybe_of`'s override, is what this
+    /// mirrors).
+    ///
+    /// `None` if the nearest enclosing node is a [`FocusScope`]'s own scope
+    /// node rather than a plain [`Focus`] (`scopeOk: false` — a scope only
+    /// satisfies [`FocusScope::of`], not this), or if there is no enclosing
+    /// [`Focus`]/[`FocusScope`] at all.
+    #[must_use]
+    pub fn maybe_of(ctx: &dyn BuildContext) -> Option<Arc<FocusNode>> {
+        nearest_focus_node(ctx).filter(|node| !node.is_scope())
     }
 
     /// The node this widget will drive: the external one, or a fresh one.
@@ -523,6 +601,27 @@ impl FocusScope {
             child: BoxedView(Box::new(child.into_view())),
             external_scope: Some(scope),
         }
+    }
+
+    /// Returns the [`FocusScopeNode`] of the nearest enclosing [`Focus`] or
+    /// [`FocusScope`], walked up to its scope — Flutter's `FocusScope.of`
+    /// (`focus_scope.dart:834`, tag `3.44.0`): `Focus.maybeOf(context,
+    /// scopeOk: true)` (unfiltered — [`nearest_focus_node`] directly, not
+    /// [`Focus::maybe_of`]'s scope-filtering wrapper), then `.nearestScope`
+    /// (itself if it already is a scope, else the nearest scope ancestor —
+    /// [`FocusNode::as_scope`]/[`FocusNode::enclosing_scope`], the exact pair
+    /// [`FocusState::try_autofocus`] already uses to find "the enclosing
+    /// scope" for autofocus purposes).
+    ///
+    /// Falls back to the process-global root scope
+    /// ([`FocusManager::global`]'s [`root_scope`](FocusManager::root_scope))
+    /// when there is no enclosing [`Focus`]/[`FocusScope`] at all — Flutter
+    /// never returns null here, unlike [`Focus::maybe_of`].
+    #[must_use]
+    pub fn of(ctx: &dyn BuildContext) -> Arc<FocusScopeNode> {
+        nearest_focus_node(ctx)
+            .and_then(|node| node.as_scope().or_else(|| node.enclosing_scope()))
+            .unwrap_or_else(|| Arc::clone(FocusManager::global().root_scope()))
     }
 }
 
@@ -1123,6 +1222,334 @@ mod tests {
         );
 
         manager.root_scope().detach_node(scope.as_focus_node().id());
+    }
+
+    // ------------------------------------------------------------------
+    // Focus::of / Focus::maybe_of / FocusScope::of
+    // ------------------------------------------------------------------
+
+    /// Which tree shape a [`FocusOfProbe`] is mounted under — one reusable
+    /// host below instead of a bespoke type per shape.
+    #[derive(Clone, Copy)]
+    enum FocusOfShape {
+        /// No Focus/FocusScope ancestor at all.
+        Bare,
+        /// A single plain `Focus` directly wrapping the probe.
+        OneFocus,
+        /// Two nested plain `Focus` widgets — the probe sits under the INNER
+        /// one, so a correct lookup must not stop at the outer one.
+        NestedFocus,
+        /// A bare `FocusScope` directly wrapping the probe (no plain `Focus`
+        /// in between) — the scope-vs-node distinction.
+        BareScope,
+        /// `FocusScope`, then a plain `Focus`, then the probe —
+        /// `FocusScope::of` must walk past the plain `Focus` to the scope.
+        ScopeThenFocus,
+    }
+
+    /// A leaf that records what [`Focus::maybe_of`] and [`FocusScope::of`]
+    /// resolve to from its own build context.
+    #[derive(Clone, StatelessView)]
+    struct FocusOfProbe {
+        found_node: Rc<RefCell<Option<Arc<FocusNode>>>>,
+        found_scope: Rc<RefCell<Option<Arc<FocusScopeNode>>>>,
+    }
+
+    impl StatelessView for FocusOfProbe {
+        fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+            *self.found_node.borrow_mut() = Focus::maybe_of(ctx);
+            *self.found_scope.borrow_mut() = Some(FocusScope::of(ctx));
+            SizedBox::new(1.0, 1.0)
+        }
+    }
+
+    /// Composes a [`FocusOfProbe`] under `shape`, or drops the whole subtree
+    /// when `show` is `false` — the same toggle-to-unmount idiom `Host`/
+    /// `ExcludeHost` above use, so a test can `swap_root` back to a bare leaf
+    /// at the end and let real `dispose()` detach every node this mounted.
+    #[derive(Clone, StatelessView)]
+    struct FocusOfHost {
+        shape: FocusOfShape,
+        show: bool,
+        outer_node: Arc<FocusNode>,
+        inner_node: Arc<FocusNode>,
+        scope: Arc<FocusScopeNode>,
+        found_node: Rc<RefCell<Option<Arc<FocusNode>>>>,
+        found_scope: Rc<RefCell<Option<Arc<FocusScopeNode>>>>,
+    }
+
+    impl StatelessView for FocusOfHost {
+        fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
+            if !self.show {
+                return SizedBox::new(1.0, 1.0).into_view().boxed();
+            }
+            let probe = FocusOfProbe {
+                found_node: Rc::clone(&self.found_node),
+                found_scope: Rc::clone(&self.found_scope),
+            };
+            match self.shape {
+                FocusOfShape::Bare => probe.into_view().boxed(),
+                FocusOfShape::OneFocus => Focus::new(probe)
+                    .focus_node(Arc::clone(&self.outer_node))
+                    .into_view()
+                    .boxed(),
+                FocusOfShape::NestedFocus => {
+                    Focus::new(Focus::new(probe).focus_node(Arc::clone(&self.inner_node)))
+                        .focus_node(Arc::clone(&self.outer_node))
+                        .into_view()
+                        .boxed()
+                }
+                FocusOfShape::BareScope => {
+                    FocusScope::with_external_node(Arc::clone(&self.scope), probe)
+                        .into_view()
+                        .boxed()
+                }
+                FocusOfShape::ScopeThenFocus => FocusScope::with_external_node(
+                    Arc::clone(&self.scope),
+                    Focus::new(probe).focus_node(Arc::clone(&self.outer_node)),
+                )
+                .into_view()
+                .boxed(),
+            }
+        }
+    }
+
+    /// Builds a fresh [`FocusOfHost`] with brand-new nodes/scope and empty
+    /// result cells for `shape`.
+    fn focus_of_host(shape: FocusOfShape) -> FocusOfHost {
+        FocusOfHost {
+            shape,
+            show: true,
+            outer_node: FocusNode::with_debug_label("focus-of-outer"),
+            inner_node: FocusNode::with_debug_label("focus-of-inner"),
+            scope: FocusScopeNode::with_debug_label("focus-of-scope"),
+            found_node: Rc::new(RefCell::new(None)),
+            found_scope: Rc::new(RefCell::new(None)),
+        }
+    }
+
+    /// Without any enclosing `Focus`/`FocusScope`, `Focus::maybe_of` is
+    /// `None` and `FocusScope::of` falls back to the root scope.
+    #[test]
+    fn focus_maybe_of_is_none_and_focus_scope_of_falls_back_to_root_without_an_ancestor() {
+        let _guard = FOCUS_TEST_LOCK.lock();
+        let manager = FocusManager::global();
+        manager.unfocus();
+
+        let host = focus_of_host(FocusOfShape::Bare);
+        let mut harness = mount(host.clone());
+
+        assert!(
+            host.found_node.borrow().is_none(),
+            "Focus::maybe_of must return None with no Focus/FocusScope ancestor"
+        );
+        let resolved_scope = host
+            .found_scope
+            .borrow()
+            .clone()
+            .expect("the probe's build must have run");
+        assert!(
+            Arc::ptr_eq(&resolved_scope, manager.root_scope()),
+            "FocusScope::of must fall back to the root scope with no ancestor"
+        );
+
+        harness.swap_root(FocusOfHost {
+            show: false,
+            ..host
+        });
+    }
+
+    /// A descendant's `Focus::maybe_of` resolves the one enclosing `Focus`'s
+    /// own node.
+    #[test]
+    fn focus_maybe_of_returns_the_nearest_enclosing_focus_node() {
+        let _guard = FOCUS_TEST_LOCK.lock();
+        let manager = FocusManager::global();
+        manager.unfocus();
+
+        let host = focus_of_host(FocusOfShape::OneFocus);
+        let mut harness = mount(host.clone());
+
+        let resolved = host
+            .found_node
+            .borrow()
+            .clone()
+            .expect("Focus::maybe_of must find the enclosing Focus's node");
+        assert!(
+            Arc::ptr_eq(&resolved, &host.outer_node),
+            "Focus::maybe_of must resolve THIS Focus's own node"
+        );
+
+        harness.swap_root(FocusOfHost {
+            show: false,
+            ..host
+        });
+    }
+
+    /// Oracle: `'Focus.of stops at the nearest Focus widget.'`
+    /// (`focus_scope_test.dart`, tag `3.44.0`) — nesting two plain `Focus`
+    /// widgets, a descendant's lookup must resolve the INNER one, never
+    /// reaching past it to the outer one.
+    #[test]
+    fn focus_maybe_of_nearest_wins_over_an_outer_focus() {
+        let _guard = FOCUS_TEST_LOCK.lock();
+        let manager = FocusManager::global();
+        manager.unfocus();
+
+        let host = focus_of_host(FocusOfShape::NestedFocus);
+        let mut harness = mount(host.clone());
+
+        let resolved = host
+            .found_node
+            .borrow()
+            .clone()
+            .expect("Focus::maybe_of must find the nearest enclosing Focus's node");
+        assert!(
+            Arc::ptr_eq(&resolved, &host.inner_node),
+            "the NEAREST Focus must win"
+        );
+        assert!(
+            !Arc::ptr_eq(&resolved, &host.outer_node),
+            "must not resolve the outer Focus instead of the inner one"
+        );
+
+        harness.swap_root(FocusOfHost {
+            show: false,
+            ..host
+        });
+    }
+
+    /// Oracle: `'Focus.of stops at the nearest Focus widget.'`
+    /// (`focus_scope_test.dart`, tag `3.44.0`) — the `Focus.maybeOf(element2),
+    /// isNull` assertion: a bare enclosing `FocusScope` (no plain `Focus` in
+    /// between) does not satisfy `Focus::maybe_of` (`scopeOk: false`), even
+    /// though `FocusScope::of` still resolves the scope itself.
+    #[test]
+    fn focus_maybe_of_returns_none_for_a_bare_enclosing_scope() {
+        let _guard = FOCUS_TEST_LOCK.lock();
+        let manager = FocusManager::global();
+        manager.unfocus();
+
+        let host = focus_of_host(FocusOfShape::BareScope);
+        let mut harness = mount(host.clone());
+
+        assert!(
+            host.found_node.borrow().is_none(),
+            "a bare enclosing FocusScope must not satisfy Focus::maybe_of — \
+             only a plain Focus counts"
+        );
+        let resolved_scope = host
+            .found_scope
+            .borrow()
+            .clone()
+            .expect("the probe's build must have run");
+        assert!(
+            Arc::ptr_eq(&resolved_scope, &host.scope),
+            "FocusScope::of must still resolve the enclosing scope itself"
+        );
+
+        harness.swap_root(FocusOfHost {
+            show: false,
+            ..host
+        });
+    }
+
+    /// `FocusScope::of` walks past an intervening plain `Focus` to the
+    /// nearest enclosing SCOPE — Flutter's `.nearestScope` — rather than
+    /// stopping at (or being refused by) the plain `Focus` the way
+    /// `Focus::maybe_of` would be.
+    #[test]
+    fn focus_scope_of_walks_up_past_a_plain_focus_to_the_nearest_scope() {
+        let _guard = FOCUS_TEST_LOCK.lock();
+        let manager = FocusManager::global();
+        manager.unfocus();
+
+        let host = focus_of_host(FocusOfShape::ScopeThenFocus);
+        let mut harness = mount(host.clone());
+
+        let resolved_node =
+            host.found_node.borrow().clone().expect(
+                "Focus::maybe_of must find the plain Focus between the scope and the probe",
+            );
+        assert!(Arc::ptr_eq(&resolved_node, &host.outer_node));
+        let resolved_scope = host
+            .found_scope
+            .borrow()
+            .clone()
+            .expect("the probe's build must have run");
+        assert!(
+            Arc::ptr_eq(&resolved_scope, &host.scope),
+            "FocusScope::of must walk past the plain Focus to the enclosing scope"
+        );
+
+        harness.swap_root(FocusOfHost {
+            show: false,
+            ..host
+        });
+    }
+
+    /// A stateless leaf that runs an arbitrary `on_build` closure once —
+    /// mirrors `overlay/tests.rs`'s own `Peek`, kept file-local since only
+    /// this one test needs a caller-supplied closure (the others above reuse
+    /// `FocusOfHost`/`FocusOfProbe`).
+    #[derive(Clone)]
+    struct Peek<F: Fn(&dyn BuildContext) + Clone + 'static>(F);
+
+    impl<F: Fn(&dyn BuildContext) + Clone + 'static> View for Peek<F> {
+        fn create_element(&self) -> ElementKind {
+            ElementKind::stateless(self)
+        }
+    }
+
+    impl<F: Fn(&dyn BuildContext) + Clone + 'static> StatelessView for Peek<F> {
+        fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+            (self.0)(ctx);
+            SizedBox::new(1.0, 1.0)
+        }
+    }
+
+    /// `Focus::of` panics with a message naming the failing call and hinting
+    /// at the non-panicking fallback — Flutter's own assert-time
+    /// `FlutterError` (`focus_scope.dart:398-424`), matching the
+    /// `Overlay::of` precedent (`overlay/tests.rs`).
+    ///
+    /// The panic is caught with `catch_unwind` **inside** the probe's own
+    /// build, rather than expecting it to unwind through `mount`: the
+    /// framework's own `build_or_recover` catches a `build()` panic to keep
+    /// one bad widget from taking down the whole test process.
+    #[test]
+    fn focus_of_panics_with_a_helpful_message_without_a_focus_ancestor() {
+        let _guard = FOCUS_TEST_LOCK.lock();
+        FocusManager::global().unfocus();
+
+        let message: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let message_for_probe = Arc::clone(&message);
+        let probe = Peek(move |ctx: &dyn BuildContext| {
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| Focus::of(ctx)));
+            if let Err(payload) = outcome {
+                let text = payload
+                    .downcast_ref::<&str>() // PORT-CHECK-OK-DOWNCAST: test-only extraction of a caught panic's message, not V-type smuggling
+                    .map(|s| (*s).to_string())
+                    .or_else(|| payload.downcast_ref::<String>().cloned()) // PORT-CHECK-OK-DOWNCAST: same panic-message extraction, the `String`-payload case
+                    .unwrap_or_default();
+                *message_for_probe.lock() = Some(text);
+            }
+        });
+
+        let _harness = mount(probe);
+
+        let text = message
+            .lock()
+            .clone()
+            .expect("Focus::of must panic without a Focus ancestor");
+        assert!(
+            text.contains("Focus::of") && text.contains("Focus widget"),
+            "panic message must name the failing call, got: {text:?}"
+        );
+        assert!(
+            text.contains("Focus::maybe_of"),
+            "panic message must hint at the non-panicking fallback, got: {text:?}"
+        );
     }
 }
 

--- a/crates/flui-widgets/src/scroll/scrollable.rs
+++ b/crates/flui-widgets/src/scroll/scrollable.rs
@@ -217,18 +217,13 @@ impl Scrollable {
 /// position into the [`ScrollController`] each tick.
 pub struct ScrollableState {
     /// The scroll controller from the current view configuration. Kept in
-    /// state so the fling listener (registered in `init_state`) can reach it
-    /// without re-capturing on every `build`. Updated in `did_update_view`.
-    ///
-    /// Named follow-up (pre-existing, not fixed by ADR-0037): if the caller
-    /// replaces the controller with a different object (rather than mutating
-    /// the same `Arc`-backed handle), the fling VALUE LISTENER registered
-    /// once in `init_state` keeps pushing ticks into the OLD controller until
-    /// the widget is disposed — full hot-swap of that listener is deferred,
-    /// the common case is one stable controller. The `stop_hook`
-    /// `did_update_view` re-installs on every swap does NOT share this gap:
-    /// it is looked up fresh from `self.scroll_controller` (updated first),
-    /// not captured once in `init_state`.
+    /// state so the fling listener (installed by
+    /// [`install_fling_listener`](ScrollableState::install_fling_listener))
+    /// can reach it without re-capturing on every `build`. Updated in
+    /// `did_update_view` BEFORE both `install_fling_listener` and
+    /// `install_stop_hook` re-run — each always reads whatever this field
+    /// currently holds, so a controller SWAP moves both onto the new
+    /// controller in the same call.
     scroll_controller: ScrollController,
     /// The ballistic simulation driver. Bounds span `(NEG_INFINITY, INFINITY)`
     /// so pixel-space simulation positions are not clamped to `[0, 1]`.
@@ -237,7 +232,10 @@ pub struct ScrollableState {
     /// `VsyncScope` in `init_state`; disposed in `dispose`.
     fling_controller: AnimationController,
     /// Value-listener ID on `fling_controller` that pushes pixels into
-    /// `scroll_controller` each tick. Registered in `init_state`, removed in
+    /// `scroll_controller` each tick. Installed by
+    /// [`install_fling_listener`](ScrollableState::install_fling_listener)
+    /// (called from `init_state`, and re-run on every `did_update_view` so a
+    /// controller swap moves it onto the new controller), removed in
     /// `dispose`.
     fling_listener_id: Option<ListenerId>,
     /// Vsync handle kept for `unregister` in `dispose`.
@@ -314,22 +312,37 @@ impl ScrollableState {
             let _ = fling.stop();
         }));
     }
-}
 
-impl ViewState<Scrollable> for ScrollableState {
-    fn init_state(&mut self, ctx: &dyn BuildContext) {
-        self.install_flush_handle(ctx);
-        self.install_stop_hook();
-
-        // Attach the value listener that pushes the fling simulation's current
-        // pixel position into the scroll controller each tick. The listener
-        // holds `Arc`-backed clones, so it survives across widget rebuilds.
+    /// Installs (or re-installs) the fling value listener that pushes the
+    /// ballistic simulation's current pixel position into
+    /// `self.scroll_controller` each tick.
+    ///
+    /// Idempotent, mirroring `install_stop_hook`: called from `init_state`
+    /// AND `did_update_view`, always against whatever `self.scroll_controller`
+    /// currently is. Removes any previously-installed listener first — this
+    /// is what closes the swap-blindness bug: without it, a controller SWAP
+    /// left the listener captured in `init_state` pushing ticks into the OLD
+    /// controller forever, so an `animate_to`/fling on the NEW controller
+    /// drove `fling_controller`'s value but the new controller's own
+    /// `pixels()` never moved.
+    fn install_fling_listener(&mut self) {
+        if let Some(id) = self.fling_listener_id.take() {
+            self.fling_controller.remove_listener(id);
+        }
         let fling_ref = self.fling_controller.clone();
         let scroll_ref = self.scroll_controller.clone();
         let listener_id = self.fling_controller.add_listener(Arc::new(move || {
             scroll_ref.set_pixels(fling_ref.value());
         }));
         self.fling_listener_id = Some(listener_id);
+    }
+}
+
+impl ViewState<Scrollable> for ScrollableState {
+    fn init_state(&mut self, ctx: &dyn BuildContext) {
+        self.install_flush_handle(ctx);
+        self.install_stop_hook();
+        self.install_fling_listener();
 
         // Register with the ambient VsyncScope so the binding ticks the fling
         // controller on each virtual frame — the same pattern used by
@@ -463,9 +476,22 @@ impl ViewState<Scrollable> for ScrollableState {
     }
 
     fn did_update_view(&mut self, _old_view: &Scrollable, new_view: &Scrollable) {
-        // Track the current controller so the fling listener stays in sync if
-        // a parent rebuild hands us a new configuration.
+        // Track the current controller so the fling listener and stop hook
+        // stay in sync if a parent rebuild hands us a new configuration —
+        // both re-installs below always read `self.scroll_controller` as
+        // just updated here.
         self.scroll_controller = new_view.controller.clone();
+
+        // Re-install the fling value listener on the (possibly new)
+        // controller. `install_fling_listener` is idempotent (removes any
+        // previous listener first), so this is cheap even when the
+        // controller didn't actually change. Without this, a controller
+        // SWAP would leave the listener pushing ticks into the OLD
+        // controller forever: an `animate_to`/fling driven on the NEW
+        // controller would move `fling_controller`'s value, but nothing
+        // would ever copy it into the new controller's own `ScrollPosition`
+        // — its pixels would never move.
+        self.install_fling_listener();
 
         // Re-install the stop hook on the (possibly new) controller —
         // `install_stop_hook` is idempotent (see its doc), so this is cheap
@@ -473,10 +499,7 @@ impl ViewState<Scrollable> for ScrollableState {
         // controller SWAP would leave the hook on the OLD controller only:
         // the new controller's `jump_to` would silently lose the
         // synchronous cancel path (see `ScrollController`'s `stop_hook`
-        // field docs for the one-frame gap that reopens). The fling VALUE
-        // LISTENER is deliberately NOT re-subscribed here — see
-        // `scroll_controller`'s own field doc above for that pre-existing,
-        // out-of-scope gap.
+        // field docs for the one-frame gap that reopens).
         self.install_stop_hook();
     }
 

--- a/crates/flui-widgets/tests/parity/focus_test.rs
+++ b/crates/flui-widgets/tests/parity/focus_test.rs
@@ -25,8 +25,13 @@
 //! - **Node-level** — `FocusNode`/`FocusScopeNode`/`FocusManager` are
 //!   exercised directly, for cases whose Flutter oracle asserts a node-API
 //!   contract and only uses a widget to obtain a `BuildContext`/node
-//!   reference (FLUI has no `Focus.of`/`FocusScope.of` ambient lookup — see
-//!   *Not ported* — so the direct node reference stands in for it).
+//!   reference. `Focus::of`/`Focus::maybe_of`/`FocusScope::of` are now ported
+//!   (`interaction/focus.rs`, ADR-0036's `OverlayScope` precedent applied to
+//!   the pre-existing `FocusParentProvider` marker) — most node-level cases
+//!   below still use a direct node reference anyway, unchanged, since porting
+//!   the lookup itself doesn't retroactively make the REST of a case's own
+//!   node-API assertions any more portable; see *Ported cases* below for the
+//!   one case this newly unlocked.
 //!
 //! `FocusManager::global()` is an owner-thread (thread-local) singleton
 //! (`crates/flui-interaction/src/routing/focus.rs`); nextest's libtest runner
@@ -66,7 +71,11 @@
 //!   [`adding_a_new_focus_scope_attaches_its_node_under_the_parent_scope`].
 //! - `'Can focus root node.'` (focus_scope_test.dart) — the root scope itself
 //!   can hold primary focus. **Adapted**: node-level — the oracle mounts a
-//!   widget only to reach `FocusScope.of`, which FLUI does not have —
+//!   widget only to reach `FocusScope.of`; `FocusScope::of` is ported now
+//!   (see *Ported cases* below), but this specific case's own assertion is
+//!   about the ROOT scope's own `hasPrimaryFocus`, not about the lookup
+//!   itself, so it stays node-level rather than being re-plumbed through a
+//!   probe widget for no behavioral gain —
 //!   [`can_focus_the_root_scope_directly`].
 //! - `'Focus is ignored when set to not focusable.'` (focus_scope_test.dart)
 //!   — `canRequestFocus: false` refuses a `request_focus` call and
@@ -121,13 +130,29 @@
 //!   ADR-0022) — ported as two synchronous notifications instead of one
 //!   batched one, with the divergence stated inline —
 //!   [`focus_changes_notify_listeners_on_each_synchronous_request`].
+//! - `'Focus.of stops at the nearest Focus widget.'` (focus_scope_test.dart)
+//!   — now portable: `Focus::of`/`Focus::maybe_of`/`FocusScope::of` are
+//!   ported (`interaction/focus.rs`, ADR-0036's `OverlayScope` precedent).
+//!   **Adapted**: the oracle's own assertion walks Flutter's internal
+//!   node-parent depth from a descendant up to the root
+//!   (`Focus.of(element4).parent!.parent!.parent!.parent == root`) — a depth
+//!   this port has no reason to reproduce exactly (its own attach shape may
+//!   need a different number of hops; see `enclosing_focus_parent`'s doc).
+//!   Ported instead is the oracle's actual point, by identity rather than
+//!   hop-counting: `Focus::maybe_of` from a context between a `FocusScope`
+//!   and its first plain `Focus` descendant is `None` (the bare scope alone
+//!   does not satisfy it — `scopeOk: false`), and from a context past that
+//!   plain `Focus` it resolves EXACTLY that `Focus`'s own node, not the
+//!   enclosing `FocusScope`'s —
+//!   [`focus_of_stops_at_the_nearest_focus_widget_not_the_enclosing_scope`].
 //!
 //! ## Not ported
-//! - `Focus.of`/`Focus.maybeOf`/`FocusScope.of` (ambient lookup) and every
-//!   case whose only role for them is obtaining a node reference — already
-//!   documented not-ported in `interaction/focus.rs`'s module doc; a direct
-//!   node/scope reference stands in wherever the case is otherwise portable
-//!   (see *Adapted* notes above).
+//! - `Focus.maybeOf`/`FocusScope.of`'s `scopeOk: true` variant, and every
+//!   case whose only role for them is obtaining a node reference where a
+//!   direct node/scope reference already stands in (see *Adapted* notes
+//!   above) — the base `Focus::of`/`maybe_of`/`FocusScope::of` lookups
+//!   themselves are ported now (see *Ported cases* above and
+//!   `interaction/focus.rs`'s module doc).
 //! - `'Setting first focus requests focus for the scope properly.'`,
 //!   `'Can move focus in and out of FocusScope'`, `'Moving widget from one
 //!   scope to another retains focus'`, `'Moving FocusScopeNodes retains
@@ -228,15 +253,20 @@
 //!   (not ported) and `descendantsAreTraversable` (no FLUI flag); the
 //!   `onKeyEvent`/`descendantsAreFocusable` half is covered by
 //!   `a_rebuild_resets_dropped_focus_config`.
-//! - `'Focus.of stops at the nearest Focus widget.'`, `'Can traverse Focus
-//!   children.'` — `Focus.of` is not ported; the traversal-ordering half of
-//!   the latter is covered by `tab_traversal_follows_geometry_not_attach_order`.
+//! - `'Can traverse Focus children.'` — `Focus.of` (its only use here is
+//!   obtaining a starting node for `FocusNode.descendants`) is ported now,
+//!   but the `descendants` traversal-order walk this case actually asserts
+//!   is not: FLUI's `FocusNode` has no `descendants` iterator, and the
+//!   traversal-ordering contract it would prove is already covered by
+//!   `tab_traversal_follows_geometry_not_attach_order`. (`'Focus.of stops at
+//!   the nearest Focus widget.'` is ported now — see *Ported cases* above.)
 //! - `'Can set focus.'` — redundant with `'Can focus'` (ported) plus
 //!   `on_focus_change` coverage already in `interaction/focus.rs`.
 //!
 //! Widget → node mapping: `Focus` → `FocusNode`, `FocusScope` →
 //! `FocusScopeNode`, both via `flui-interaction`'s `routing` module.
 
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -789,6 +819,81 @@ fn removing_the_focused_widget_within_a_scope_does_not_transfer_focus() {
 
     manager.unfocus();
     manager.set_active_scope(None);
+    manager.root_scope().detach_node(scope.as_focus_node().id());
+}
+
+/// A leaf that records what `Focus::maybe_of` resolves to from its own
+/// build context — the widget-mounted counterpart of this file's node-level
+/// probes, now that `interaction/focus.rs` ports the lookup.
+///
+/// `Rc<RefCell<_>>`, not `Arc<Mutex<_>>`: `FocusNode` is owner-thread-only
+/// (`!Send + !Sync`, per ADR-0027), same reason `Mutex<Option<Arc<FocusNode>>>`
+/// itself would not be `Send`/`Sync` either.
+#[derive(Clone, StatelessView)]
+struct FocusOfProbe {
+    found: Rc<RefCell<Option<Arc<FocusNode>>>>,
+}
+
+impl StatelessView for FocusOfProbe {
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        *self.found.borrow_mut() = Focus::maybe_of(ctx);
+        leaf()
+    }
+}
+
+/// Oracle: `'Focus.of stops at the nearest Focus widget.'`
+/// (`focus_scope_test.dart`, tag `3.44.0`). See this file's module doc for
+/// what is adapted (identity checks against known nodes, not a hop-counted
+/// walk up Flutter's own internal node-parent chain).
+#[test]
+fn focus_of_stops_at_the_nearest_focus_widget_not_the_enclosing_scope() {
+    let _guard = FOCUS_TEST_LOCK.lock();
+    let manager = FocusManager::global();
+    manager.unfocus();
+
+    let scope = FocusScopeNode::with_debug_label("focus-of-scope");
+    let plain = FocusNode::with_debug_label("focus-of-plain");
+    // Seeded `Some` so a probe that silently never ran would not be mistaken
+    // for a correct `None`.
+    let found_at_scope: Rc<RefCell<Option<Arc<FocusNode>>>> =
+        Rc::new(RefCell::new(Some(FocusNode::with_debug_label("seed"))));
+    let found_past_focus: Rc<RefCell<Option<Arc<FocusNode>>>> = Rc::new(RefCell::new(None));
+
+    let tree = FocusScope::with_external_node(
+        Arc::clone(&scope),
+        Column::new(vec![
+            FocusOfProbe {
+                found: Rc::clone(&found_at_scope),
+            }
+            .into_view()
+            .boxed(),
+            Focus::new(FocusOfProbe {
+                found: Rc::clone(&found_past_focus),
+            })
+            .focus_node(Arc::clone(&plain))
+            .into_view()
+            .boxed(),
+        ]),
+    );
+    let _laid = lay_out(tree, loose(200.0));
+
+    assert!(
+        found_at_scope.borrow().is_none(),
+        "Focus::maybe_of from a context whose nearest ancestor provider is \
+         the FocusScope's own node (not a plain Focus) must be None — the \
+         oracle's `Focus.maybeOf(element2), isNull`"
+    );
+    let resolved = found_past_focus
+        .borrow()
+        .clone()
+        .expect("the second probe's build must have run");
+    assert!(
+        Arc::ptr_eq(&resolved, &plain),
+        "Focus::maybe_of past the plain Focus must resolve THAT Focus's own \
+         node, not the enclosing FocusScope's — the oracle's `Focus.of(element4)`"
+    );
+
+    manager.unfocus();
     manager.root_scope().detach_node(scope.as_focus_node().id());
 }
 

--- a/crates/flui-widgets/tests/scroll.rs
+++ b/crates/flui-widgets/tests/scroll.rs
@@ -1422,12 +1422,17 @@ fn scrollable_second_animate_to_supersedes_the_first() {
 /// This starts the fling via a REAL drag+release on the OLD controller
 /// BEFORE the swap (`Scrollable`'s `AnimatedBuilder`-rebuilt gesture
 /// callbacks are only known-good against the controller active at gesture
-/// time), then swaps, then exercises ONLY the stop hook — a plain field
-/// read-and-call at `jump_to` time, wired directly by `did_update_view`
-/// rather than by anything requiring a POST-swap `AnimatedBuilder` rebuild
-/// (a separate, pre-existing gap — see `scroll_controller`'s field doc in
-/// `scrollable.rs` — that a fresh `animate_to` call on the new controller
-/// would otherwise entangle this test with).
+/// time), then swaps, then exercises the stop hook.
+///
+/// The fling VALUE LISTENER is ALSO re-wired onto the new controller by the
+/// same swap (`ScrollableState::install_fling_listener`, called from
+/// `did_update_view` right alongside the stop-hook re-install — the fix for
+/// the swap-blindness gap `scrollable.rs`'s `scroll_controller` field doc
+/// used to name). That's why the OLD controller's own pixels stop moving
+/// right after the swap below, and the NEW controller's pixels are what the
+/// still-in-flight fling — and later the stop hook — are observed against.
+/// See `scrollable_reinstalls_the_fling_listener_after_a_controller_swap`
+/// for a test isolating just that half via a post-swap `animate_to`.
 #[test]
 fn scrollable_reinstalls_the_stop_hook_after_a_controller_swap() {
     let old_controller = ScrollController::new();
@@ -1477,39 +1482,125 @@ fn scrollable_reinstalls_the_stop_hook_after_a_controller_swap() {
     );
     scoped.pump_widget(rewrapped);
 
-    // The fling is STILL running on the shared controller post-swap (its
-    // value listener keeps pushing into the OLD controller — the named,
-    // pre-existing, out-of-scope swap gap `scrollable.rs` documents — so
-    // `old_controller` is what still observably advances).
+    // The fling is STILL running on the shared `fling_controller` post-swap,
+    // but its value listener now writes into the NEW controller — the OLD
+    // one is frozen at whatever it reached right before the swap.
     scoped.pump_for(Duration::from_millis(16));
-    assert!(
-        old_controller.pixels() > old_pixels_mid_fling,
-        "sanity: the fling must still be advancing after the swap, before \
-         jump_to; old_controller: {:.2} -> {:.2}",
+    assert_eq!(
+        old_controller.pixels(),
         old_pixels_mid_fling,
-        old_controller.pixels()
+        "the OLD controller must stop moving once the fling listener has \
+         been re-wired onto the new controller by the swap"
+    );
+    let new_pixels_mid_fling = new_controller.pixels();
+    assert!(
+        new_pixels_mid_fling > 0.0,
+        "sanity: the still-in-flight fling must now be advancing the NEW \
+         controller after the swap; got {new_pixels_mid_fling:.2}"
     );
 
     // The SYNCHRONOUS cancellation path: `new_controller.jump_to` must find
     // the stop hook `did_update_view` re-installed on it, and stop the
     // SHARED fling controller THIS INSTANT.
     new_controller.jump_to(0.0);
-    let old_pixels_after_jump = old_controller.pixels();
+    let new_pixels_after_jump = new_controller.pixels();
 
     for _ in 0..5 {
         scoped.pump_for(Duration::from_millis(16));
     }
 
-    let drift = (old_controller.pixels() - old_pixels_after_jump).abs();
+    let drift = (new_controller.pixels() - new_pixels_after_jump).abs();
     assert!(
         drift <= 1.0,
         "jump_to on the controller installed by a did_update_view SWAP must \
-         still stop the shared fling controller synchronously — the OLD \
-         controller's pixels (still fed by the fling's value listener) must \
-         stop drifting once jump_to is called on the NEW one; drifted \
-         {drift:.3} px after jump_to (from {old_pixels_after_jump:.1} to \
-         {:.1})",
-        old_controller.pixels()
+         still stop the shared fling controller synchronously — the NEW \
+         controller's pixels (now fed by the fling's value listener) must \
+         stop drifting once jump_to is called on it; drifted {drift:.3} px \
+         after jump_to (from {new_pixels_after_jump:.1} to {:.1})",
+        new_controller.pixels()
+    );
+}
+
+/// Isolates the fling-listener half of the swap fix: a post-swap
+/// `animate_to` on the NEW controller must move the NEW controller's own
+/// `pixels()`.
+///
+/// Before the fix, `ScrollableState::init_state` captured the scroll
+/// controller once into the fling value listener's closure and never
+/// re-captured it; `did_update_view` only ever re-installed the `stop_hook`.
+/// A controller swap therefore left the listener writing into the OLD
+/// controller forever — `animate_to`/a fling driven on the NEW controller
+/// still moved the shared `fling_controller`'s own value (queued and
+/// serviced correctly, see `scroll_controller.rs`'s ADR-0037 docs), but
+/// nothing ever copied that value into the NEW controller's `ScrollPosition`,
+/// so its `pixels()` never moved at all.
+///
+/// Red-check: comment out `did_update_view`'s `self.install_fling_listener()`
+/// call — this test's first assertion fails (`new_controller.pixels()` stays
+/// at its pre-`animate_to` value).
+#[test]
+fn scrollable_reinstalls_the_fling_listener_after_a_controller_swap() {
+    let old_controller = ScrollController::new();
+    let new_controller = ScrollController::new();
+    old_controller.update_dimensions(300.0, 0.0, 4700.0);
+
+    let vsync = Vsync::new();
+    let widget = Scrollable::new()
+        .controller(old_controller.clone())
+        .child(SizedBox::new(300.0, 5000.0));
+    let mut scoped = fling_scoped(widget, vsync.clone(), tight(300.0, 300.0));
+
+    // Swap to a DIFFERENT controller — same shape as
+    // `scrollable_reinstalls_the_stop_hook_after_a_controller_swap` above,
+    // but with NO pre-swap gesture: the very first fling this test ever
+    // drives is via `animate_to` on the NEW controller, after the swap.
+    let rewrapped = GestureArenaScope::new(
+        scoped.laid().arena(),
+        VsyncScope::new(
+            vsync,
+            Scrollable::new()
+                .controller(new_controller.clone())
+                .child(SizedBox::new(300.0, 5000.0)),
+        ),
+    );
+    scoped.pump_widget(rewrapped);
+
+    let new_pixels_before = new_controller.pixels();
+
+    // Drives the SAME shared `fling_controller` `ScrollableState` has kept
+    // since `create_state` (queued and serviced regardless of this bug) —
+    // it's the value listener's re-wiring that this test actually pins.
+    new_controller.animate_to(500.0, Duration::from_millis(100), Arc::new(Curves::Linear));
+
+    // Same 3-pump warm-up as `scrollable_animate_to_reaches_the_target_through_the_curve`.
+    scoped.pump_for(Duration::from_millis(16));
+    scoped.pump_for(Duration::from_millis(16));
+    scoped.pump_for(Duration::from_millis(16));
+
+    assert!(
+        new_controller.pixels() > new_pixels_before,
+        "a post-swap animate_to must move the NEW controller's own position \
+         — did_update_view must re-wire the fling value listener onto it, \
+         not leave it writing into the old controller forever; got \
+         {new_pixels_before:.2} -> {:.2}",
+        new_controller.pixels()
+    );
+    assert_eq!(
+        old_controller.pixels(),
+        0.0,
+        "the OLD controller must receive no ticks at all once the listener \
+         has been re-wired onto the new one by the swap"
+    );
+
+    for _ in 0..10 {
+        scoped.pump_for(Duration::from_millis(16));
+    }
+    assert_eq!(
+        new_controller.pixels(),
+        500.0,
+        "once the duration has fully elapsed, the post-swap animate_to must \
+         land EXACTLY on the target on the NEW controller; got {:.2}",
+        new_controller.pixels()
     );
 }
 


### PR DESCRIPTION
Three small follow-ups bundled from the Draggable, animate_to, and Overlay units.

## What

- **Fresh `FeedbackSignal` per drag entry** (Draggable): a later session evicting a still-live earlier one previously left both sharing the one `DraggableState` signal — both wrote offsets and the single layer jittered. The mounting logic is extracted into `evict_and_mount_feedback` (the exact function `on_start` calls at drag-start) which now mints a fresh signal per inserted entry, so a stale session writes to its own detached signal. Pinned by a test that drives `evict_and_mount_feedback` directly (a source mutant reintroducing the shared signal fails it — the first test cut characterized only `DragSession::update` and let the source revert survive; caught in review and corrected). The three-case scope-cut doc shrinks to the one remaining case.
- **Fling-listener swap re-wire** (Scrollable): the fling value listener's captured ref pushed pixels into the OLD controller after a `did_update_view` controller swap (`animate_to` on a swapped controller drove the fling but never moved the new position). `install_fling_listener` is now idempotent and re-installed in `did_update_view` (cleared symmetrically in `dispose`); the swap tests are strengthened (OLD frozen, NEW lands exactly) rather than accommodating the old bug.
- **`Focus::of` / `Focus::maybe_of` / `FocusScope::of`** (the next consumer of the inherited-lookup seam): reuses the existing `FocusParentProvider` marker (the oracle's `_FocusInheritedScope`); `depend_on` is loyal here — `Focus.maybeOf`'s `createDependency: true` default (the exact opposite of `Overlay.maybeOf`, verified @ 3.44.0). Scope-vs-node filter matches the oracle (`Focus::of` skips bare scopes; `FocusScope::of` walks up to the nearest scope with root fallback). Previously-skipped `Focus.of` parity case now ported (hop-count walk adapted to identity checks, disclosed).

## Evidence

- flui-widgets: 1399 passed; workspace: 7778 passed (the one red remains the concurrent session's uncommitted FAB edit); clippy `-D warnings`, fmt/port-check/inventory/taplo/typos, doctests: clean.
- Every fix mutation-pinned incl. the corrected source-level FeedbackSignal mutant; reviewer verified fixes #2/#3 clean and re-ran mutants across two rounds; the parity adaptation cross-checked against the oracle.
- Full review + resumed delta re-review: SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)