### PR TITLE
fix(objects): correct RenderIntrinsicWidth/Height intrinsic queries + port intrinsic parity (3.44.0)

### DIFF
--- a/crates/flui-objects/src/layout/intrinsic_height.rs
+++ b/crates/flui-objects/src/layout/intrinsic_height.rs
@@ -149,10 +149,15 @@ impl RenderBox for RenderIntrinsicHeight {
         if ctx.child_count() == 0 {
             return 0.0;
         }
-        // When height is finite, the caller already knows the height extent;
-        // pass it through to the child.  When infinite, the child is
-        // unconstrained in height and should report its own unconstrained
-        // intrinsic width.
+        // Flutter (proxy_box.dart): an infinite height resolves to the
+        // child's own max intrinsic height at infinity before querying its
+        // min intrinsic width — "min width at infinite height" is not a
+        // meaningful query on its own.
+        let height = if height.is_finite() {
+            height
+        } else {
+            ctx.child_max_intrinsic_height(0, f32::INFINITY)
+        };
         ctx.child_min_intrinsic_width(0, height)
     }
 
@@ -160,6 +165,11 @@ impl RenderBox for RenderIntrinsicHeight {
         if ctx.child_count() == 0 {
             return 0.0;
         }
+        let height = if height.is_finite() {
+            height
+        } else {
+            ctx.child_max_intrinsic_height(0, f32::INFINITY)
+        };
         ctx.child_max_intrinsic_width(0, height)
     }
 

--- a/crates/flui-objects/src/layout/intrinsic_width.rs
+++ b/crates/flui-objects/src/layout/intrinsic_width.rs
@@ -257,24 +257,31 @@ impl RenderBox for RenderIntrinsicWidth {
     // ---- intrinsic dimensions -----------------------------------------------
     //
     // Flutter parity: proxy_box.dart RenderIntrinsicWidth.
-    // Width queries apply `apply_step` twice (height-extent snap + width snap);
-    // height queries just delegate to the child unchanged.
+    //
+    // * `computeMinIntrinsicWidth(height) => getMaxIntrinsicWidth(height)` —
+    //   the min-width query delegates to the max-width query verbatim instead
+    //   of asking the child for its own min. Forcing the child to a single
+    //   width (the max intrinsic) is the entire point of this render object,
+    //   so its own reported min and max width are always equal.
+    // * `computeMaxIntrinsicWidth(height)` queries the child's max intrinsic
+    //   width at the RAW `height` — no `step_height` snapping here; stepping
+    //   only tightens the layout height axis (`child_constraints`), not this
+    //   intrinsic query — then applies `step_width`.
+    // * `computeMinIntrinsicHeight`/`computeMaxIntrinsicHeight(width)` resolve
+    //   an infinite `width` to this object's own forced max intrinsic width
+    //   first (proxy_box.dart: `if (!width.isFinite) { width =
+    //   getMaxIntrinsicWidth(double.infinity); }`), then query the child's
+    //   min/max intrinsic height at that resolved width and apply `step_height`.
 
     fn compute_min_intrinsic_width(&self, height: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
-        if ctx.child_count() == 0 {
-            return 0.0;
-        }
-        let snapped_height = apply_step(height, self.step_height);
-        let child_min = ctx.child_min_intrinsic_width(0, snapped_height);
-        apply_step(child_min, self.step_width)
+        self.compute_max_intrinsic_width(height, ctx)
     }
 
     fn compute_max_intrinsic_width(&self, height: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
         if ctx.child_count() == 0 {
             return 0.0;
         }
-        let snapped_height = apply_step(height, self.step_height);
-        let child_max = ctx.child_max_intrinsic_width(0, snapped_height);
+        let child_max = ctx.child_max_intrinsic_width(0, height);
         apply_step(child_max, self.step_width)
     }
 
@@ -282,14 +289,26 @@ impl RenderBox for RenderIntrinsicWidth {
         if ctx.child_count() == 0 {
             return 0.0;
         }
-        ctx.child_min_intrinsic_height(0, width)
+        let width = if width.is_finite() {
+            width
+        } else {
+            self.compute_max_intrinsic_width(f32::INFINITY, ctx)
+        };
+        let child_min = ctx.child_min_intrinsic_height(0, width);
+        apply_step(child_min, self.step_height)
     }
 
     fn compute_max_intrinsic_height(&self, width: f32, ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
         if ctx.child_count() == 0 {
             return 0.0;
         }
-        ctx.child_max_intrinsic_height(0, width)
+        let width = if width.is_finite() {
+            width
+        } else {
+            self.compute_max_intrinsic_width(f32::INFINITY, ctx)
+        };
+        let child_max = ctx.child_max_intrinsic_height(0, width);
+        apply_step(child_max, self.step_height)
     }
 
     fn compute_dry_layout(

--- a/crates/flui-objects/tests/render_object_harness.rs
+++ b/crates/flui-objects/tests/render_object_harness.rs
@@ -74,8 +74,8 @@
 //! | `RenderViewport` | `harness_viewport_*` | yes | — | — | yes | — |
 //! | `RenderShrinkWrappingViewport` | `harness_shrink_wrapping_viewport_*` | yes | — | — | yes | — |
 //! | `RenderWrap` | `harness_render_wrap_*` | yes | yes | — | yes | — |
-//! | `RenderIntrinsicWidth` | `harness_intrinsic_width_*` | yes | — | — | yes | — |
-//! | `RenderIntrinsicHeight` | `harness_intrinsic_height_*` | yes | — | — | yes | — |
+//! | `RenderIntrinsicWidth` | `harness_intrinsic_width_*` | yes | — | — | yes | queries |
+//! | `RenderIntrinsicHeight` | `harness_intrinsic_height_*` | yes | — | — | yes | queries |
 //! | `RenderConstrainedOverflowBox` | `harness_constrained_overflow_box_*` | yes | — | — | yes | — |
 //! | `RenderSizedOverflowBox` | `harness_sized_overflow_box_*` | yes | — | — | yes | — |
 //! | `RenderRotatedBox` | `harness_rotated_box_*` | yes | yes | — | yes | paint transform |
@@ -97,6 +97,7 @@ use flui_objects::*;
 use flui_painting::{Canvas, Paint};
 use flui_rendering::{
     constraints::BoxConstraints,
+    context::BoxIntrinsicsCtx,
     delegates::{
         CustomPainter, FlowDelegate, FlowPaintingContext, MultiChildLayoutContext,
         MultiChildLayoutDelegate, SingleChildLayoutDelegate,
@@ -216,6 +217,182 @@ const RENDER_OBJECT_TYPES: &[&str] = &[
 
 fn loose(max: f32) -> BoxConstraints {
     BoxConstraints::new(px(0.0), px(max), px(0.0), px(max))
+}
+
+// ============================================================================
+// Intrinsics test doubles (RenderIntrinsicWidth / RenderIntrinsicHeight oracle port)
+// ============================================================================
+
+/// Leaf reporting independently configurable min/max intrinsic width and
+/// height, regardless of the queried extent — a Rust port of Flutter's own
+/// `RenderTestBox` fixture (`test/rendering/intrinsic_width_test.dart`,
+/// 3.44.0), which is itself test-only code, not a production Flutter class.
+///
+/// Lays itself out at the midpoint of its min/max on each axis, clamped to
+/// whatever constraints its parent hands it — mirroring the oracle's
+/// `performResize` (`sizedByParent = true`, `size = constraints.constrain(...)`).
+#[derive(Debug, Clone, Copy)]
+struct RenderTestBox {
+    min_width: f32,
+    max_width: f32,
+    min_height: f32,
+    max_height: f32,
+}
+
+impl RenderTestBox {
+    fn new(min_width: f32, max_width: f32, min_height: f32, max_height: f32) -> Self {
+        Self {
+            min_width,
+            max_width,
+            min_height,
+            max_height,
+        }
+    }
+}
+
+impl flui_foundation::Diagnosticable for RenderTestBox {}
+
+impl RenderBox for RenderTestBox {
+    type Arity = flui_tree::Leaf;
+    type ParentData = flui_rendering::parent_data::BoxParentData;
+
+    fn perform_layout(
+        &mut self,
+        ctx: &mut flui_rendering::context::BoxLayoutContext<'_, flui_tree::Leaf, Self::ParentData>,
+    ) -> Size {
+        let midpoint = Size::new(
+            px(self.min_width + (self.max_width - self.min_width) / 2.0),
+            px(self.min_height + (self.max_height - self.min_height) / 2.0),
+        );
+        ctx.constraints().constrain(midpoint)
+    }
+
+    fn hit_test(
+        &self,
+        _ctx: &mut flui_rendering::context::BoxHitTestContext<
+            '_,
+            flui_tree::Leaf,
+            Self::ParentData,
+        >,
+    ) -> bool {
+        false
+    }
+
+    fn compute_min_intrinsic_width(&self, _height: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        self.min_width
+    }
+
+    fn compute_max_intrinsic_width(&self, _height: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        self.max_width
+    }
+
+    fn compute_min_intrinsic_height(&self, _width: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        self.min_height
+    }
+
+    fn compute_max_intrinsic_height(&self, _width: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        self.max_height
+    }
+}
+
+/// Regression fixture (FLUI-added, not oracle-cited): pairs a constant width
+/// axis with a height axis that echoes its queried extent verbatim, so that
+/// `RenderIntrinsicWidth`'s height-axis intrinsics can be proven to resolve an
+/// infinite width extent to a concrete value (`proxy_box.dart`'s
+/// `if (!width.isFinite) { width = getMaxIntrinsicWidth(double.infinity); }`
+/// guard) before querying the child, instead of forwarding `f32::INFINITY`
+/// straight through.
+#[derive(Debug, Clone, Copy)]
+struct ExtentEchoProbe;
+
+impl flui_foundation::Diagnosticable for ExtentEchoProbe {}
+
+impl RenderBox for ExtentEchoProbe {
+    type Arity = flui_tree::Leaf;
+    type ParentData = flui_rendering::parent_data::BoxParentData;
+
+    fn perform_layout(
+        &mut self,
+        ctx: &mut flui_rendering::context::BoxLayoutContext<'_, flui_tree::Leaf, Self::ParentData>,
+    ) -> Size {
+        ctx.constraints().smallest()
+    }
+
+    fn hit_test(
+        &self,
+        _ctx: &mut flui_rendering::context::BoxHitTestContext<
+            '_,
+            flui_tree::Leaf,
+            Self::ParentData,
+        >,
+    ) -> bool {
+        false
+    }
+
+    fn compute_min_intrinsic_width(&self, _height: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        42.0
+    }
+
+    fn compute_max_intrinsic_width(&self, _height: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        42.0
+    }
+
+    fn compute_min_intrinsic_height(&self, width: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        width
+    }
+
+    fn compute_max_intrinsic_height(&self, width: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        width
+    }
+}
+
+/// Mirror image of [`ExtentEchoProbe`] for `RenderIntrinsicHeight`'s
+/// width-axis fix: a constant height axis paired with a width axis that
+/// echoes its queried extent verbatim, proving the
+/// `if (!height.isFinite) { height = child.getMaxIntrinsicHeight(double.infinity); }`
+/// substitution.
+#[derive(Debug, Clone, Copy)]
+struct ExtentEchoProbeSwapped;
+
+impl flui_foundation::Diagnosticable for ExtentEchoProbeSwapped {}
+
+impl RenderBox for ExtentEchoProbeSwapped {
+    type Arity = flui_tree::Leaf;
+    type ParentData = flui_rendering::parent_data::BoxParentData;
+
+    fn perform_layout(
+        &mut self,
+        ctx: &mut flui_rendering::context::BoxLayoutContext<'_, flui_tree::Leaf, Self::ParentData>,
+    ) -> Size {
+        ctx.constraints().smallest()
+    }
+
+    fn hit_test(
+        &self,
+        _ctx: &mut flui_rendering::context::BoxHitTestContext<
+            '_,
+            flui_tree::Leaf,
+            Self::ParentData,
+        >,
+    ) -> bool {
+        false
+    }
+
+    fn compute_min_intrinsic_width(&self, height: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        height
+    }
+
+    fn compute_max_intrinsic_width(&self, height: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        height
+    }
+
+    fn compute_min_intrinsic_height(&self, _width: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        42.0
+    }
+
+    fn compute_max_intrinsic_height(&self, _width: f32, _ctx: &mut BoxIntrinsicsCtx<'_>) -> f32 {
+        42.0
+    }
 }
 
 #[derive(Debug)]
@@ -6510,6 +6687,244 @@ fn harness_intrinsic_width_self_describes_step_knobs() {
     );
 }
 
+// ---- Oracle port: rendering/intrinsic_width_test.dart (3.44.0) ------------
+
+/// Oracle: `test('Shrink-wrapping width', ...)`.
+#[test]
+fn harness_intrinsic_width_shrink_wrapping_width_oracle() {
+    let mut run = RenderTester::mount(
+        box_node(RenderIntrinsicWidth::unconstrained())
+            .child(box_node(RenderTestBox::new(10.0, 100.0, 20.0, 200.0)).label("child")),
+    )
+    .with_constraints(BoxConstraints::new(px(5.0), px(500.0), px(8.0), px(800.0)))
+    .run_layout();
+
+    let root = run.root();
+    let child = run.id("child");
+    assert_eq!(run.box_geometry(root), Size::new(px(100.0), px(110.0)));
+    assert_eq!(run.box_geometry(child), Size::new(px(100.0), px(110.0)));
+
+    for h in [0.0, 10.0, 80.0, f32::INFINITY] {
+        assert_eq!(run.min_intrinsic_width(root, h), 100.0, "min width @ h={h}");
+        assert_eq!(run.max_intrinsic_width(root, h), 100.0, "max width @ h={h}");
+        assert_eq!(
+            run.min_intrinsic_height(root, h),
+            20.0,
+            "min height @ w={h}"
+        );
+        assert_eq!(
+            run.max_intrinsic_height(root, h),
+            200.0,
+            "max height @ w={h}"
+        );
+    }
+}
+
+/// Oracle: `test('IntrinsicWidth without a child', ...)`.
+#[test]
+fn harness_intrinsic_width_without_child_oracle() {
+    let mut run = RenderTester::mount(box_node(RenderIntrinsicWidth::unconstrained()))
+        .with_constraints(BoxConstraints::new(px(5.0), px(500.0), px(8.0), px(800.0)))
+        .run_layout();
+
+    let root = run.root();
+    assert_eq!(run.box_geometry(root), Size::new(px(5.0), px(8.0)));
+
+    for extent in [0.0, 10.0, 80.0, f32::INFINITY] {
+        assert_eq!(run.min_intrinsic_width(root, extent), 0.0);
+        assert_eq!(run.max_intrinsic_width(root, extent), 0.0);
+        assert_eq!(run.min_intrinsic_height(root, extent), 0.0);
+        assert_eq!(run.max_intrinsic_height(root, extent), 0.0);
+    }
+}
+
+/// Oracle: `test('Shrink-wrapping width (stepped width)', ...)`.
+#[test]
+fn harness_intrinsic_width_stepped_width_oracle() {
+    let mut run = RenderTester::mount(
+        box_node(RenderIntrinsicWidth::new(Some(47.0), None))
+            .child(box_node(RenderTestBox::new(10.0, 100.0, 20.0, 200.0)).label("child")),
+    )
+    .with_constraints(BoxConstraints::new(px(5.0), px(500.0), px(8.0), px(800.0)))
+    .run_layout();
+
+    let root = run.root();
+    let child = run.id("child");
+    assert_eq!(run.box_geometry(root), Size::new(px(3.0 * 47.0), px(110.0)));
+    assert_eq!(
+        run.box_geometry(child),
+        Size::new(px(3.0 * 47.0), px(110.0))
+    );
+
+    for h in [0.0, 10.0, 80.0, f32::INFINITY] {
+        assert_eq!(run.min_intrinsic_width(root, h), 3.0 * 47.0);
+        assert_eq!(run.max_intrinsic_width(root, h), 3.0 * 47.0);
+        assert_eq!(run.min_intrinsic_height(root, h), 20.0);
+        assert_eq!(run.max_intrinsic_height(root, h), 200.0);
+    }
+}
+
+/// Oracle: `test('Shrink-wrapping width (stepped height)', ...)`.
+#[test]
+fn harness_intrinsic_width_stepped_height_oracle() {
+    let mut run = RenderTester::mount(
+        box_node(RenderIntrinsicWidth::new(None, Some(47.0)))
+            .child(box_node(RenderTestBox::new(10.0, 100.0, 20.0, 200.0)).label("child")),
+    )
+    .with_constraints(BoxConstraints::new(px(5.0), px(500.0), px(8.0), px(800.0)))
+    .run_layout();
+
+    let root = run.root();
+    assert_eq!(run.box_geometry(root), Size::new(px(100.0), px(235.0)));
+
+    for h in [0.0, 10.0, 80.0, f32::INFINITY] {
+        assert_eq!(run.min_intrinsic_width(root, h), 100.0);
+        assert_eq!(run.max_intrinsic_width(root, h), 100.0);
+        assert_eq!(run.min_intrinsic_height(root, h), 1.0 * 47.0);
+        assert_eq!(run.max_intrinsic_height(root, h), 5.0 * 47.0);
+    }
+}
+
+/// Oracle: `test('Shrink-wrapping width (stepped everything)', ...)`.
+#[test]
+fn harness_intrinsic_width_stepped_everything_oracle() {
+    let mut run = RenderTester::mount(
+        box_node(RenderIntrinsicWidth::new(Some(37.0), Some(47.0)))
+            .child(box_node(RenderTestBox::new(10.0, 100.0, 20.0, 200.0)).label("child")),
+    )
+    .with_constraints(BoxConstraints::new(px(5.0), px(500.0), px(8.0), px(800.0)))
+    .run_layout();
+
+    let root = run.root();
+    assert_eq!(run.box_geometry(root), Size::new(px(3.0 * 37.0), px(235.0)));
+
+    for h in [0.0, 10.0, 80.0, f32::INFINITY] {
+        assert_eq!(run.min_intrinsic_width(root, h), 3.0 * 37.0);
+        assert_eq!(run.max_intrinsic_width(root, h), 3.0 * 37.0);
+        assert_eq!(run.min_intrinsic_height(root, h), 1.0 * 47.0);
+        assert_eq!(run.max_intrinsic_height(root, h), 5.0 * 47.0);
+    }
+}
+
+/// Oracle: `test('RenderIntrinsicWidth when parent is given loose constraints
+/// smaller than intrinsic width of child', ...)`.
+#[test]
+fn harness_intrinsic_width_loose_smaller_than_child_intrinsic_oracle() {
+    let run = RenderTester::mount(
+        box_node(RenderIntrinsicWidth::unconstrained())
+            .child(box_node(RenderTestBox::new(10.0, 100.0, 20.0, 200.0)).label("child")),
+    )
+    .with_constraints(BoxConstraints::new(px(50.0), px(70.0), px(8.0), px(800.0)))
+    .run_layout();
+
+    let root = run.root();
+    let child = run.id("child");
+    assert_eq!(run.box_geometry(root), Size::new(px(70.0), px(110.0)));
+    assert_eq!(run.box_geometry(child), Size::new(px(70.0), px(110.0)));
+}
+
+/// Oracle: `test('RenderIntrinsicWidth when parent is given tight constraints
+/// larger than intrinsic width of child', ...)`.
+#[test]
+fn harness_intrinsic_width_tight_larger_than_child_intrinsic_oracle() {
+    let run = RenderTester::mount(
+        box_node(RenderIntrinsicWidth::unconstrained())
+            .child(box_node(RenderTestBox::new(10.0, 100.0, 20.0, 200.0)).label("child")),
+    )
+    .with_constraints(BoxConstraints::new(
+        px(500.0),
+        px(500.0),
+        px(8.0),
+        px(800.0),
+    ))
+    .run_layout();
+
+    let root = run.root();
+    let child = run.id("child");
+    assert_eq!(run.box_geometry(root), Size::new(px(500.0), px(110.0)));
+    assert_eq!(run.box_geometry(child), Size::new(px(500.0), px(110.0)));
+}
+
+/// Oracle: `test('RenderIntrinsicWidth when parent is given tight constraints
+/// smaller than intrinsic width of child', ...)`.
+#[test]
+fn harness_intrinsic_width_tight_smaller_than_child_intrinsic_oracle() {
+    let run = RenderTester::mount(
+        box_node(RenderIntrinsicWidth::unconstrained())
+            .child(box_node(RenderTestBox::new(10.0, 100.0, 20.0, 200.0)).label("child")),
+    )
+    .with_constraints(BoxConstraints::new(px(50.0), px(50.0), px(8.0), px(800.0)))
+    .run_layout();
+
+    let root = run.root();
+    let child = run.id("child");
+    assert_eq!(run.box_geometry(root), Size::new(px(50.0), px(110.0)));
+    assert_eq!(run.box_geometry(child), Size::new(px(50.0), px(110.0)));
+}
+
+/// Oracle: `testWidgets('Intrinsic stepWidth, stepHeight', ...)`
+/// (widgets/intrinsic_width_test.dart, 3.44.0) — the `buildFrame(null, null)`
+/// and `buildFrame(0.0, 0.0)` cases, both of which expect the wrapped
+/// `SizedBox(100, 50)` to come through unchanged.
+///
+/// The oracle's `buildFrame(-1.0, 0.0)` / `buildFrame(0.0, -1.0)` cases assert
+/// a Dart `AssertionError` at widget-construction time. FLUI has no equivalent
+/// assertion: `apply_step` treats a non-positive or non-finite step as "no
+/// snapping" instead of panicking, because panicking on a layout path is
+/// disallowed by this repo's panic policy. That graceful-degradation behavior
+/// is already covered by the `apply_step_negative_step_treated_as_none` unit
+/// test in `crates/flui-objects/src/layout/intrinsic_width.rs` — a deliberate,
+/// documented Rust-native divergence, not a gap.
+#[test]
+fn harness_intrinsic_width_step_width_step_height_oracle() {
+    // buildFrame(null, null)
+    let run = RenderTester::mount(
+        box_node(RenderIntrinsicWidth::unconstrained())
+            .child(box_node(RenderSizedBox::fixed(px(100.0), px(50.0)))),
+    )
+    .with_constraints(loose(300.0))
+    .run_layout();
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(100.0), px(50.0)));
+
+    // buildFrame(0.0, 0.0) — apply_step treats a zero step as identity.
+    let run = RenderTester::mount(
+        box_node(RenderIntrinsicWidth::new(Some(0.0), Some(0.0)))
+            .child(box_node(RenderSizedBox::fixed(px(100.0), px(50.0)))),
+    )
+    .with_constraints(loose(300.0))
+    .run_layout();
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(100.0), px(50.0)));
+}
+
+/// FLUI-added regression (not oracle-cited): proves that
+/// `RenderIntrinsicWidth`'s height-axis intrinsics resolve an infinite width
+/// extent to a concrete value before querying the child (proxy_box.dart:
+/// `if (!width.isFinite) { width = getMaxIntrinsicWidth(double.infinity); }`)
+/// instead of forwarding `f32::INFINITY` straight through. `ExtentEchoProbe`
+/// echoes the width argument it receives back out as its intrinsic height, so
+/// an unresolved infinity would propagate all the way out as `f32::INFINITY`;
+/// a resolved call passes the finite `42.0` constant instead.
+#[test]
+fn harness_intrinsic_width_resolves_infinite_width_for_height_axis() {
+    let mut run = RenderTester::mount(
+        box_node(RenderIntrinsicWidth::unconstrained()).child(box_node(ExtentEchoProbe)),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    let root = run.root();
+    assert_eq!(
+        run.min_intrinsic_height(root, f32::INFINITY),
+        42.0,
+        "an unresolved infinity would echo back as f32::INFINITY"
+    );
+    assert_eq!(
+        run.max_intrinsic_height(root, f32::INFINITY),
+        42.0,
+        "an unresolved infinity would echo back as f32::INFINITY"
+    );
+}
+
 // ---- Slice-2 milestone: dry == committed for filling child ----------------
 
 /// `RenderIntrinsicWidth::unconstrained()` over a `RenderFlex` row (`MainAxisSize::Max`)
@@ -6758,6 +7173,143 @@ fn harness_intrinsic_height_with_child_passes_size_through() {
     .run_layout();
 
     assert_eq!(run.box_geometry(run.root()), Size::new(px(60.0), px(40.0)));
+}
+
+// ---- Oracle port: rendering/intrinsic_width_test.dart (3.44.0) ------------
+// (RenderIntrinsicHeight cases live in the same oracle file as
+// RenderIntrinsicWidth's.)
+
+/// Oracle: `test('Shrink-wrapping height', ...)`.
+#[test]
+fn harness_intrinsic_height_shrink_wrapping_height_oracle() {
+    let mut run = RenderTester::mount(
+        box_node(RenderIntrinsicHeight::new())
+            .child(box_node(RenderTestBox::new(10.0, 100.0, 20.0, 200.0)).label("child")),
+    )
+    .with_constraints(BoxConstraints::new(px(5.0), px(500.0), px(8.0), px(800.0)))
+    .run_layout();
+
+    let root = run.root();
+    assert_eq!(run.box_geometry(root), Size::new(px(55.0), px(200.0)));
+
+    for w in [0.0, 10.0, 80.0, f32::INFINITY] {
+        assert_eq!(run.min_intrinsic_width(root, w), 10.0, "min width @ h={w}");
+        assert_eq!(run.max_intrinsic_width(root, w), 100.0, "max width @ h={w}");
+        assert_eq!(
+            run.min_intrinsic_height(root, w),
+            200.0,
+            "min height @ w={w}"
+        );
+        assert_eq!(
+            run.max_intrinsic_height(root, w),
+            200.0,
+            "max height @ w={w}"
+        );
+    }
+}
+
+/// Oracle: `test('IntrinsicHeight without a child', ...)`.
+#[test]
+fn harness_intrinsic_height_without_child_oracle() {
+    let mut run = RenderTester::mount(box_node(RenderIntrinsicHeight::new()))
+        .with_constraints(BoxConstraints::new(px(5.0), px(500.0), px(8.0), px(800.0)))
+        .run_layout();
+
+    let root = run.root();
+    assert_eq!(run.box_geometry(root), Size::new(px(5.0), px(8.0)));
+
+    for extent in [0.0, 10.0, 80.0, f32::INFINITY] {
+        assert_eq!(run.min_intrinsic_width(root, extent), 0.0);
+        assert_eq!(run.max_intrinsic_width(root, extent), 0.0);
+        assert_eq!(run.min_intrinsic_height(root, extent), 0.0);
+        assert_eq!(run.max_intrinsic_height(root, extent), 0.0);
+    }
+}
+
+/// Oracle: `test('RenderIntrinsicHeight when parent is given loose
+/// constraints smaller than intrinsic height of child', ...)`.
+#[test]
+fn harness_intrinsic_height_loose_smaller_than_child_intrinsic_oracle() {
+    let run = RenderTester::mount(
+        box_node(RenderIntrinsicHeight::new())
+            .child(box_node(RenderTestBox::new(10.0, 100.0, 20.0, 200.0)).label("child")),
+    )
+    .with_constraints(BoxConstraints::new(px(5.0), px(500.0), px(8.0), px(80.0)))
+    .run_layout();
+
+    let root = run.root();
+    let child = run.id("child");
+    assert_eq!(run.box_geometry(root), Size::new(px(55.0), px(80.0)));
+    assert_eq!(run.box_geometry(child), Size::new(px(55.0), px(80.0)));
+}
+
+/// Oracle: `test('RenderIntrinsicHeight when parent is given tight
+/// constraints larger than intrinsic height of child', ...)`.
+#[test]
+fn harness_intrinsic_height_tight_larger_than_child_intrinsic_oracle() {
+    let run = RenderTester::mount(
+        box_node(RenderIntrinsicHeight::new())
+            .child(box_node(RenderTestBox::new(10.0, 100.0, 20.0, 200.0)).label("child")),
+    )
+    .with_constraints(BoxConstraints::new(
+        px(5.0),
+        px(500.0),
+        px(400.0),
+        px(400.0),
+    ))
+    .run_layout();
+
+    let root = run.root();
+    let child = run.id("child");
+    assert_eq!(run.box_geometry(root), Size::new(px(55.0), px(400.0)));
+    assert_eq!(run.box_geometry(child), Size::new(px(55.0), px(400.0)));
+}
+
+/// Oracle: `test('RenderIntrinsicHeight when parent is given tight
+/// constraints smaller than intrinsic height of child', ...)`.
+#[test]
+fn harness_intrinsic_height_tight_smaller_than_child_intrinsic_oracle() {
+    let run = RenderTester::mount(
+        box_node(RenderIntrinsicHeight::new())
+            .child(box_node(RenderTestBox::new(10.0, 100.0, 20.0, 200.0)).label("child")),
+    )
+    .with_constraints(BoxConstraints::new(px(5.0), px(500.0), px(80.0), px(80.0)))
+    .run_layout();
+
+    let root = run.root();
+    let child = run.id("child");
+    assert_eq!(run.box_geometry(root), Size::new(px(55.0), px(80.0)));
+    assert_eq!(run.box_geometry(child), Size::new(px(55.0), px(80.0)));
+}
+
+/// FLUI-added regression (not oracle-cited): proves that
+/// `RenderIntrinsicHeight`'s width-axis intrinsics resolve an infinite height
+/// extent to a concrete value before querying the child (proxy_box.dart:
+/// `if (!height.isFinite) { height = child.getMaxIntrinsicHeight(double.infinity); }`)
+/// instead of forwarding `f32::INFINITY` straight through.
+/// `ExtentEchoProbeSwapped` echoes the height argument it receives back out
+/// as its intrinsic width, so an unresolved infinity would propagate all the
+/// way out as `f32::INFINITY`; a resolved call passes the finite `42.0`
+/// constant instead.
+#[test]
+fn harness_intrinsic_height_resolves_infinite_height_for_width_axis() {
+    let mut run = RenderTester::mount(
+        box_node(RenderIntrinsicHeight::new()).child(box_node(ExtentEchoProbeSwapped)),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    let root = run.root();
+    assert_eq!(
+        run.min_intrinsic_width(root, f32::INFINITY),
+        42.0,
+        "an unresolved infinity would echo back as f32::INFINITY"
+    );
+    assert_eq!(
+        run.max_intrinsic_width(root, f32::INFINITY),
+        42.0,
+        "an unresolved infinity would echo back as f32::INFINITY"
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
Ports the IntrinsicWidth/Height parity corpus from Flutter `3.44.0` and — in the process — **fixes 3 real production bugs** in `flui-objects` intrinsic sizing, each cross-checked against `proxy_box.dart@3.44.0`.

## Production bug fixes (`intrinsic_width.rs`, `intrinsic_height.rs`)
1. `RenderIntrinsicWidth::compute_min_intrinsic_width` now delegates to `compute_max_intrinsic_width` — Flutter forces `computeMinIntrinsicWidth => getMaxIntrinsicWidth` (min≡max is the object's whole purpose). Also removed a bogus `step_height` snap from the max-width query.
2. `RenderIntrinsicWidth::compute_min/max_intrinsic_height` now resolve an infinite width via the object's own forced intrinsic width first, then apply `step_height` — matching Flutter's `if (!width.isFinite) { width = getMaxIntrinsicWidth(∞); } … _applyStep`.
3. `RenderIntrinsicHeight::compute_min/max_intrinsic_width` now resolve an infinite height to the child's max intrinsic height at infinity before forwarding, instead of passing ∞ through.

## Parity port (`render_object_harness.rs`) — 14/14 in-scope oracle cases
Oracle: `test/rendering/intrinsic_width_test.dart` (17 `test`, 4 out-of-scope = RenderPadding/RenderAspectRatio, different render object) + `test/widgets/intrinsic_width_test.dart` (1 `testWidgets`). Ported via `RenderTestBox`, a 1:1 port of Flutter's own inline test fixture (independent min/max per axis) — the same methodology the oracle uses. Stepped values (`3·37`, `5·47=235`, etc.) match Flutter exactly. Negative-`stepWidth`-throws is a documented PANIC-POLICY divergence covered by the existing `apply_step_negative_step_treated_as_none`.

## Evidence
- rust-reviewer: **SHIP** — all 3 fixes verified correct against Flutter line-by-line; red-checks genuine (reverting each hunk at source reproduces the exact pre-fix failures — "47 vs 141", "inf vs 42"); test doubles faithful (not rigged); **no downstream regression** (flui-objects 809/809, flui-widgets 1462/1462 — Table `IntrinsicColumnWidth`/Flex query children directly, untouched).
- Gates green: nextest `-p flui-objects` 809/809 + `-p flui-widgets` 1462/1462, clippy `-D warnings` (CI shape, full-workspace verified), port-check (incl. catalog guard), doc-tests.
- Known non-blocking test-gap: the max-width step-removal (`intrinsic_width.rs:284`) is Flutter-correct but lacks a dedicated regression test (the test doubles don't vary width-with-height); a follow-up could add a height-echoing-width probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)