### PR TITLE
test(parity): port CustomPaint/RenderCustomPaint parity from custom_paint_test.dart (3.44.0)

### DIFF
--- a/crates/flui-objects/tests/render_object_harness.rs
+++ b/crates/flui-objects/tests/render_object_harness.rs
@@ -8,7 +8,7 @@
 //! |------|-----------------|--------|----------|-------|-------------|---------|
 //! | `RenderSizedBox` | `harness_sized_box_*` | yes | — | — | yes | queries |
 //! | `RenderColoredBox` | `harness_colored_box_*` | yes | yes | yes | yes | — |
-//! | `RenderCustomPaint` | `harness_custom_paint_*` | yes | yes | yes | yes | order |
+//! | `RenderCustomPaint` | `harness_custom_paint_*` | yes | yes | yes | yes | order, paint size, poison |
 //! | `RenderImage` | `harness_image_*` | yes | — | yes | yes | — |
 //! | `RenderParagraph` | `harness_paragraph_*` | yes | — | yes | yes | — |
 //! | `RenderEditable` | `harness_editable_*` | yes | yes | yes | yes | — |
@@ -681,11 +681,21 @@ fn harness_custom_paint_childless_uses_preferred_size_and_paints() {
 
     assert_eq!(run.box_geometry(run.root()), Size::new(px(30.0), px(20.0)));
     assert!(run.hit_first(10.0, 10.0).is_some());
+    // Flutter parity: `paint(canvas, size)` must receive the node's OWN
+    // committed size (custom_paint.dart `_paintWithPainter`) — a color-only
+    // check would pass even if the wrong `size` reached the painter, so this
+    // asserts the full draw-rect extent (30x20) matches `box_geometry` above.
     assert!(
         run.display_commands()
             .iter()
-            .any(|cmd| cmd.line.contains("#FF0000FF")),
-        "background painter must emit a red draw command",
+            .any(|cmd| cmd.line == "DrawRect rect=(0.00,0.00 30.00x20.00) fill #FF0000FF"),
+        "background painter must be invoked with size == committed layout size \
+         (30x20), not some other extent; commands:\n{}",
+        run.display_commands()
+            .iter()
+            .map(|cmd| cmd.line.clone())
+            .collect::<Vec<_>>()
+            .join("\n"),
     );
     assert_descendant_properties(
         &run.diagnostics(),
@@ -729,6 +739,19 @@ fn harness_custom_paint_orders_background_child_foreground() {
         "paint order must be background red -> child green -> foreground blue; commands:\n{}",
         painted.join("\n"),
     );
+    // CustomPaint sizes to its child (20x10 `RenderColoredBox`), so both
+    // painters must be invoked with THAT size, not the Size::ZERO preferred
+    // size given at construction (Flutter parity: background/foreground
+    // painters share the node's one committed `size`, custom_paint.dart
+    // `paint()`).
+    assert!(
+        rects
+            .iter()
+            .all(|line| line.contains("(0.00,0.00 20.00x10.00)")),
+        "background, child, and foreground must all paint at the node's \
+         committed 20x10 size; commands:\n{}",
+        painted.join("\n"),
+    );
 }
 
 #[test]
@@ -742,6 +765,101 @@ fn harness_custom_paint_foreground_hit_test_wins() {
     .run_frame();
 
     assert_eq!(run.hit_first(10.0, 10.0), Some(run.root()));
+}
+
+/// A present-but-zero-size child must still drive layout through the
+/// has-child branch, producing `Size::ZERO` because the CHILD does, not
+/// because `RenderCustomPaint` special-cases a small/zero `preferred_size`.
+/// The large, distinctive `preferred_size` (999x999) makes the two branches
+/// unmistakable: any regression that let a zero-size child fall through to
+/// the childless branch (or vice versa) would report 999x999, not 0x0.
+///
+/// Flutter parity: `custom_paint_test.dart` "CustomPaint sizing" (oracle
+/// L163-164) — `CustomPaint(child: const SizedBox.shrink())` measures to
+/// `Size.zero`, distinct from the childless-default-Size.zero case (oracle
+/// L127-128) which this file's `custom_paint_childless_uses_preferred_size`
+/// widget test and this suite's `dry_layout_childless_*` unit tests already
+/// cover via the `preferred_size` mechanism.
+#[test]
+fn harness_custom_paint_with_zero_size_child_sizes_to_zero_not_preferred_size() {
+    let run = RenderTester::mount(
+        box_node(RenderCustomPaint::new(
+            None,
+            None,
+            Size::new(px(999.0), px(999.0)),
+        ))
+        .child(box_node(RenderSizedBox::shrink())),
+    )
+    .with_constraints(loose(200.0))
+    .run_layout();
+
+    assert_eq!(
+        run.box_geometry(run.root()),
+        Size::ZERO,
+        "a zero-size child must size CustomPaint to zero, not to preferred_size",
+    );
+}
+
+/// A painter that calls `canvas.save()` without a matching `restore()` before
+/// `paint()` returns must poison the paint phase rather than silently
+/// corrupting the canvas save/restore stack.
+///
+/// Divergence from the oracle (documented, not silently dropped): Flutter's
+/// `custom_paint_test.dart` "Throws FlutterError on custom painter incorrect
+/// restore/save calls" asserts the exact multi-line `FlutterError` diagnostic
+/// text produced by a *catchable* Dart exception. FLUI's parity check is the
+/// `debug_assert_eq!` in `paint_with_painter`
+/// (`crates/flui-objects/src/proxy/custom_paint.rs`), which raises a Rust
+/// panic; the pipeline's `catch_unwind` wrapper
+/// (`crates/flui-rendering/src/pipeline/owner/paint.rs`) converts ANY paint
+/// panic into `RenderError::Poisoned { render_object, phase }` and discards
+/// the panic payload — so the specific "must pair every canvas.save()..."
+/// message the oracle asserts on has no observable equivalent here. What IS
+/// verified, faithfully: the imbalance is detected and the paint phase is
+/// rejected rather than producing a broken display.
+#[test]
+fn harness_custom_paint_unbalanced_save_poisons_the_paint_phase() {
+    #[derive(Debug)]
+    struct UnbalancedSavePainter;
+
+    impl CustomPainter for UnbalancedSavePainter {
+        fn paint(&self, canvas: &mut Canvas, _size: Size) {
+            canvas.save();
+            // Deliberately no matching `restore()`.
+        }
+
+        fn should_repaint(&self, _old_delegate: &dyn CustomPainter) -> bool {
+            true
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    let result = RenderTester::mount(box_node(RenderCustomPaint::new(
+        Some(Arc::new(UnbalancedSavePainter)),
+        None,
+        Size::new(px(10.0), px(10.0)),
+    )))
+    .with_constraints(loose(200.0))
+    .try_run_frame();
+
+    match result {
+        Err(flui_rendering::RenderError::Poisoned {
+            render_object,
+            phase,
+        }) => {
+            assert!(
+                render_object.contains("RenderCustomPaint"),
+                "render_object name must identify the offending node; got {render_object}",
+            );
+            assert_eq!(phase, "paint", "phase tag must identify the paint phase");
+        }
+        other => {
+            panic!("expected RenderError::Poisoned from the unbalanced save(), got {other:?}")
+        }
+    }
 }
 
 #[test]

--- a/crates/flui-objects/tests/render_object_harness.rs
+++ b/crates/flui-objects/tests/render_object_harness.rs
@@ -774,12 +774,12 @@ fn harness_custom_paint_foreground_hit_test_wins() {
 /// unmistakable: any regression that let a zero-size child fall through to
 /// the childless branch (or vice versa) would report 999x999, not 0x0.
 ///
-/// Flutter parity: `custom_paint_test.dart` "CustomPaint sizing" (oracle
-/// L163-164) — `CustomPaint(child: const SizedBox.shrink())` measures to
-/// `Size.zero`, distinct from the childless-default-Size.zero case (oracle
-/// L127-128) which this file's `custom_paint_childless_uses_preferred_size`
-/// widget test and this suite's `dry_layout_childless_*` unit tests already
-/// cover via the `preferred_size` mechanism.
+/// Flutter parity: `custom_paint_test.dart` "CustomPaint sizing" (3.44.0) —
+/// `CustomPaint(child: const SizedBox.shrink())` measures to `Size.zero`,
+/// distinct from the childless-default-Size.zero case (same oracle test)
+/// which this file's `custom_paint_childless_uses_preferred_size` widget
+/// test and this suite's `dry_layout_childless_*` unit tests already cover
+/// via the `preferred_size` mechanism.
 #[test]
 fn harness_custom_paint_with_zero_size_child_sizes_to_zero_not_preferred_size() {
     let run = RenderTester::mount(

--- a/crates/flui-widgets/tests/custom_paint.rs
+++ b/crates/flui-widgets/tests/custom_paint.rs
@@ -10,9 +10,8 @@ use flui_widgets::{CustomPaint, SizedBox};
 /// value, but this proves it through an actual layout pass rather than just
 /// reading the constructed field back.
 ///
-/// Flutter parity: `custom_paint_test.dart` "CustomPaint sizing" (oracle
-/// L127-128) — `Center(child: CustomPaint(key: target))` measures to
-/// `Size.zero`.
+/// Flutter parity: `custom_paint_test.dart` "CustomPaint sizing" (3.44.0) —
+/// `Center(child: CustomPaint(key: target))` measures to `Size.zero`.
 #[test]
 fn custom_paint_childless_default_size_is_zero() {
     let laid = lay_out(CustomPaint::new(), loose(200.0));

--- a/crates/flui-widgets/tests/custom_paint.rs
+++ b/crates/flui-widgets/tests/custom_paint.rs
@@ -5,6 +5,20 @@ mod common;
 use common::{lay_out, loose, size};
 use flui_widgets::{CustomPaint, SizedBox};
 
+/// The true default (`CustomPaint::new()`, no `.size()` call and no child)
+/// lays out to `Size::ZERO` — `Size`'s `Default` and `ZERO` are the same
+/// value, but this proves it through an actual layout pass rather than just
+/// reading the constructed field back.
+///
+/// Flutter parity: `custom_paint_test.dart` "CustomPaint sizing" (oracle
+/// L127-128) — `Center(child: CustomPaint(key: target))` measures to
+/// `Size.zero`.
+#[test]
+fn custom_paint_childless_default_size_is_zero() {
+    let laid = lay_out(CustomPaint::new(), loose(200.0));
+    assert_eq!(laid.size(laid.root()), size(0.0, 0.0));
+}
+
 #[test]
 fn custom_paint_childless_uses_preferred_size() {
     let laid = lay_out(CustomPaint::new().size(size(30.0, 20.0)), loose(200.0));


### PR DESCRIPTION
Ports the CustomPaint/RenderCustomPaint parity cases from Flutter `3.44.0` (Business.1 fidelity). Painter invocation, size, and background→child→foreground ordering are genuinely observed via the real paint phase (captured `LayerTree` draw commands), not faked.

## Scope
- **Render-harness tests** (`render_object_harness.rs`): background painter invoked with size == committed layout size; background→child→foreground paint ordering (verified via captured colored-rect commands from the real `owner.run_frame()` `LayerTree`); zero-size-child sizes to zero (not the `size` param); an unbalanced `canvas.save` poisons the paint phase (`RenderError::Poisoned{phase:"paint"}` — legitimate observable proxy for Flutter's FlutterError, whose message granularity has no headless equivalent).
- **Widget-level sizing tests** (`custom_paint.rs`): childless default → zero; childless → `size` param; with-child → child size.

## Oracle reconciliation (both files)
- `custom_painter_test.dart` (14 cases): all `CustomPainterSemantics`/`semanticsBuilder` — a documented DEFERRED feature (`custom_paint.rs:17`); entire file legitimately out of scope.
- `custom_paint_test.dart` (7 cases): paint-order, save/restore imbalance, the 6 sizing sub-assertions, and intrinsics-preferred/not-infinite — all covered (new + existing citations).

## Evidence
- rust-reviewer: SHIP. Paint-capture confirmed genuine — `display_commands()` walks the real `LayerTree` from `owner.run_frame()`; a painter that never ran emits no `DrawRect`, and a wrong paint order (foreground before child) would collect red→blue→green and fail. Full oracle reconciled across both files; no gamed green, no vacuous assertions. One low citation-style nit (line-number suffixes) fixed in the follow-up commit — oracle now cited by NAME + tag only.
- Gates green (warm, scoped): nextest `-p flui-objects -p flui-widgets` (26 custom_paint tests pass), clippy `-D warnings` (CI shape), port-check (incl. catalog guard). No production code changed; no Cross.H needed (impl real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)