### PR TITLE
test(objects): assert RenderDecoratedBox paint order + coverage (3.44.0 contract)

### DIFF
--- a/crates/flui-objects/tests/render_object_harness.rs
+++ b/crates/flui-objects/tests/render_object_harness.rs
@@ -3068,6 +3068,90 @@ fn harness_decorated_box_layout_wraps_child_geometry() {
 }
 
 #[test]
+fn harness_decorated_box_paints_background_before_child() {
+    // Flutter parity: proxy_box.dart `RenderDecoratedBox.paint` (3.44.0) — with
+    // the default `DecorationPosition::Background`, the decoration's fill must
+    // land on the canvas BEFORE the child's. `harness_decorated_box_wraps_child`
+    // only asserts `run.painted()` (a layer tree exists somewhere), which would
+    // stay green even if the decoration painted the wrong color or after the
+    // child instead of before it. Assert the actual draw commands and their
+    // order, mirroring `harness_custom_paint_orders_background_child_foreground`.
+    let run = RenderTester::mount(
+        box_node(RenderDecoratedBox::new(BoxDecoration::with_color(
+            Color::RED,
+        )))
+        .child(box_node(RenderColoredBox::blue(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_frame();
+
+    // Layout stays a passthrough to the child even though paint now does
+    // real work: the decorated box must not claim any size of its own.
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(40.0), px(40.0)));
+
+    let painted = run
+        .display_commands()
+        .into_iter()
+        .map(|cmd| cmd.line)
+        .collect::<Vec<_>>();
+    let rects = painted
+        .iter()
+        .filter(|line| line.contains("DrawRect"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        rects.len(),
+        2,
+        "expected the decoration's background fill and the child's fill; commands:\n{}",
+        painted.join("\n"),
+    );
+    assert!(
+        rects[0].contains("#FF0000FF") && rects[1].contains("#0000FFFF"),
+        "paint order must be background red -> child blue; commands:\n{}",
+        painted.join("\n"),
+    );
+}
+
+#[test]
+fn harness_decorated_box_foreground_paints_after_child() {
+    // Flutter parity: proxy_box.dart `RenderDecoratedBox.paint` (3.44.0) — with
+    // `DecorationPosition::Foreground` the decoration paints AFTER
+    // `super.paint` (the child), e.g. a vignette or focus ring drawn over
+    // content. Same command-order assertion as the background case, reversed.
+    let run = RenderTester::mount(
+        box_node(
+            RenderDecoratedBox::new(BoxDecoration::with_color(Color::RED))
+                .with_position(DecorationPosition::Foreground),
+        )
+        .child(box_node(RenderColoredBox::blue(40.0, 40.0)).label("child")),
+    )
+    .with_constraints(loose(200.0))
+    .run_frame();
+
+    assert_eq!(run.box_geometry(run.root()), Size::new(px(40.0), px(40.0)));
+
+    let painted = run
+        .display_commands()
+        .into_iter()
+        .map(|cmd| cmd.line)
+        .collect::<Vec<_>>();
+    let rects = painted
+        .iter()
+        .filter(|line| line.contains("DrawRect"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        rects.len(),
+        2,
+        "expected the child's fill and the decoration's foreground fill; commands:\n{}",
+        painted.join("\n"),
+    );
+    assert!(
+        rects[0].contains("#0000FFFF") && rects[1].contains("#FF0000FF"),
+        "paint order must be child blue -> foreground red; commands:\n{}",
+        painted.join("\n"),
+    );
+}
+
+#[test]
 fn harness_clip_rect_self_describes() {
     let run = RenderTester::mount(
         box_node(RenderClipRect::new(Clip::HardEdge))


### PR DESCRIPTION
Extends RenderDecoratedBox harness coverage (Business.1 fidelity). DecoratedBox paints its `BoxDecoration` before the child (`DecorationPosition::Background`, default) or after (`Foreground`); layout is a passthrough to the child.

## Oracle source (honest fallback)
Flutter 3.44.0 has **no dedicated `decorated_box_test.dart`**. Real files touch DecoratedBox (`box_decoration_test.dart`, `proxy_box_test.dart` — where it's used only as a RepaintBoundary fixture), but **none asserts draw-command paint order** (Flutter verifies that via golden/pixel + `paints..` matchers, which have no headless equivalent here). So the paint-order behavior is cited to the render-object contract in `proxy_box.dart` `RenderDecoratedBox.paint` (by NAME + tag `3.44.0`, framed as contract-derived) — the honest source, no oracle test missed.

## Scope — 4 harness tests (`render_object_harness.rs`)
- `harness_decorated_box_paints_background_before_child` — via the real `display_commands()` LayerTree capture: exactly 2 `DrawRect`s, decoration red (`#FF0000FF`) BEFORE child blue (`#0000FFFF`); a mutant painting the decoration after the child flips the order and fails. Layout confirmed passthrough (box size == child size).
- `harness_decorated_box_layout_wraps_child_geometry` — passthrough sizing.
- `harness_decorated_box_wraps_child` — decoration property present.
- `harness_decorated_box_hit_tests_child_before_decoration_shape` — child in a rounded-corner cutout still hits (child tested before the decoration's own shape).

## Evidence
- rust-reviewer: SHIP, no blockers. Oracle-source ruled honest fallback (no paint-order oracle test exists); paint-order test genuine; facet coverage confirmed — color-fill/gradient/image/border/box_shadow all real in `flui-painting/decoration.rs::paint_box_decoration` (only inset shadows deferred, with an honest `tracing::warn!`); the 2 new tests exercise color-fill, others implemented-but-untested (future scope).
- Gates green (warm, scoped): nextest `-p flui-objects` (8 decorated_box tests pass), clippy `-D warnings` (CI shape), port-check (incl. catalog guard). No production code changed; no Cross.H; NAME+tag citations, no line numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)