### PR TITLE
fix(interaction,rendering): compose hit-test transforms in Flutter's order

### DIFF
--- a/crates/flui-geometry/src/matrix4.rs
+++ b/crates/flui-geometry/src/matrix4.rs
@@ -544,22 +544,51 @@ impl Matrix4 {
         &mut self.m[col * 4 + row]
     }
 
+    /// Returns whether this matrix has an inverse.
+    ///
+    /// This is exactly the predicate [`try_inverse`](Self::try_inverse) gates
+    /// success on -- `determinant().abs() >= f32::EPSILON` -- computed
+    /// without building the full inverse. `try_inverse` is defined in terms
+    /// of this method, so the cheap probe and the real inversion can never
+    /// disagree about a borderline (near-singular) matrix.
+    ///
+    /// Prefer this over `try_inverse().is_some()` when the inverse itself is
+    /// discarded: callers on a hot path (e.g. once per hit-test entry per
+    /// pointer event) that only need a well-formedness check should not pay
+    /// for `glam::Mat4::inverse()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use flui_geometry::Matrix4;
+    ///
+    /// assert!(Matrix4::identity().is_invertible());
+    /// assert!(Matrix4::translation(3.0, -1.0, 0.0).is_invertible());
+    ///
+    /// // Zero-scale on one axis collapses the matrix to singular.
+    /// assert!(!Matrix4::scaling(0.0, 1.0, 1.0).is_invertible());
+    /// ```
+    #[must_use]
+    pub fn is_invertible(&self) -> bool {
+        // `glam::Mat4::inverse` returns a matrix of NaNs/inf for a
+        // non-invertible matrix rather than signalling, so this (and
+        // `try_inverse`, below) gate on the determinant explicitly.
+        self.to_glam().determinant().abs() >= f32::EPSILON
+    }
+
     /// Attempts to invert this matrix.
     ///
-    /// Returns `None` if the matrix is singular (determinant is zero).
+    /// Returns `None` if the matrix is singular (see
+    /// [`is_invertible`](Self::is_invertible) for the exact threshold).
     /// Uses Gauss-Jordan elimination for general 4x4 matrices.
     ///
     /// For simple transformations (translation, rotation, uniform scaling),
     /// consider using specialized inverse methods if available.
     pub fn try_inverse(&self) -> Option<Self> {
-        // Guard singularity explicitly: `glam::Mat4::inverse` returns a matrix
-        // of NaNs/inf for a non-invertible matrix rather than signalling, so we
-        // gate on the determinant to preserve the `Option` contract.
-        let g = self.to_glam();
-        if g.determinant().abs() < f32::EPSILON {
-            None
+        if self.is_invertible() {
+            Some(Self::from_glam(self.to_glam().inverse()))
         } else {
-            Some(Self::from_glam(g.inverse()))
+            None
         }
     }
 
@@ -799,5 +828,31 @@ mod glam_backend_tests {
         let singular = Matrix4::scaling(0.0, 1.0, 1.0);
         assert!(singular.try_inverse().is_none());
         assert!(Matrix4::identity().try_inverse().is_some());
+    }
+
+    #[test]
+    fn is_invertible_agrees_with_try_inverse() {
+        let invertible = Matrix4::rotation_z(0.7) * Matrix4::translation(10.0, -3.0, 0.0);
+        assert!(invertible.is_invertible());
+        assert!(invertible.try_inverse().is_some());
+
+        let singular = Matrix4::scaling(0.0, 1.0, 1.0);
+        assert!(!singular.is_invertible());
+        assert!(singular.try_inverse().is_none());
+    }
+
+    #[test]
+    fn is_invertible_matches_try_inverse_at_the_epsilon_boundary() {
+        // A scale just above f32::EPSILON must read as invertible; a scale
+        // just below it must read as singular -- `is_invertible` and
+        // `try_inverse` must never disagree, even this close to the
+        // threshold they share.
+        let just_above = Matrix4::scaling(f32::EPSILON * 2.0, 1.0, 1.0);
+        assert!(just_above.is_invertible());
+        assert!(just_above.try_inverse().is_some());
+
+        let just_below = Matrix4::scaling(f32::EPSILON * 0.5, 1.0, 1.0);
+        assert!(!just_below.is_invertible());
+        assert!(just_below.try_inverse().is_none());
     }
 }

--- a/crates/flui-interaction/README.md
+++ b/crates/flui-interaction/README.md
@@ -34,14 +34,19 @@ impl HitTestable for MyWidget {
         if !self.bounds.contains(position) {
             return false;
         }
-        
-        // Push transform for children
-        result.push_offset(self.offset);
-        for child in &self.children {
-            child.hit_test(position, result);
-        }
-        result.pop_transform();
-        
+
+        // `with_paint_offset` takes the forward (paint-direction) offset and
+        // pushes its inverse internally, popping automatically when the
+        // closure returns -- the stack accumulates a GLOBAL-TO-LOCAL
+        // mapping as the walk descends, so callers must never push the
+        // forward offset directly (that's what the raw `push_offset`/
+        // `pop_transform` pair does, and it does NOT invert for you).
+        result.with_paint_offset(self.offset, |result| {
+            for child in &self.children {
+                child.hit_test(position, result);
+            }
+        });
+
         // Add self
         result.add(HitTestEntry::new(self.id, position, self.bounds));
         true

--- a/crates/flui-interaction/docs/HIT_TESTING.md
+++ b/crates/flui-interaction/docs/HIT_TESTING.md
@@ -49,7 +49,10 @@ signal. Do not use `EventPropagation` for ordinary pointer delivery.
 
 ## Transform support
 
-`HitTestResult` maintains a transform stack:
+`HitTestResult` maintains a transform stack. It accumulates the
+GLOBAL-TO-LOCAL mapping as the walk descends, so each level must push the
+INVERSE of its own forward (paint-direction) offset/matrix — prefer the
+scope helpers, which invert and pop for you:
 
 ```rust
 use flui_interaction::prelude::*;
@@ -57,19 +60,31 @@ use flui_types::geometry::{Matrix4, Offset};
 
 let mut result = HitTestResult::new();
 
-result.push_offset(Offset::new(10.0.into(), 20.0.into()));
-child.hit_test(position, &mut result);
-result.pop_transform();
+// `with_paint_offset` takes the forward paint offset and pushes its
+// inverse (negated) internally.
+result.with_paint_offset(Offset::new(10.0.into(), 20.0.into()), |result| {
+    child.hit_test(position, result);
+});
 
+// `with_paint_transform` takes the forward paint matrix and pushes its
+// inverse internally (falling back to the singular forward matrix if the
+// transform is not invertible — see its doc).
 let rotation = Matrix4::rotation_z(std::f32::consts::PI / 4.0);
-result.push_transform(rotation);
-child.hit_test(position, &mut result);
-result.pop_transform();
+result.with_paint_transform(rotation, |result| {
+    child.hit_test(position, result);
+});
 ```
 
-Each entry captures the current transform. During dispatch the event is
-transformed into that entry's local coordinate space. Non-invertible transforms
-skip that entry.
+`push_offset`/`push_transform` are the raw primitives underneath — they push
+exactly what they are given, no inversion, and the caller is responsible for
+negating/inverting before calling them. Reach for them directly only when the
+scope-helper's closure shape does not fit; `with_paint_offset`/
+`with_paint_transform` are correct by construction and should be preferred.
+
+Each entry captures the current (already-inverted) transform. During dispatch
+the event is transformed into that entry's local coordinate space.
+Non-invertible transforms compose to a singular matrix and are skipped at
+delivery.
 
 ## HitTestBehavior
 
@@ -82,6 +97,27 @@ path and whether it blocks targets visually behind it:
 
 Typical render-object hit testing still checks children before self so the path
 is leaf-first.
+
+## Known gaps (not this document's transform-stack fix, tracked separately)
+
+Two call sites push nothing onto the `HitTestResult` transform stack that
+this document describes, so a `Listener` under them receives an
+un-localized position — the same class of bug the `with_paint_offset`/
+`with_paint_transform` fix above addresses, just not reachable through
+those two paths yet:
+
+- `crates/flui-rendering/src/context/hit_test.rs:189-225` — the ctx-level
+  `push_offset`/`push_transform`/`with_transform` feed a per-node
+  `BoxHitTestCtx` stack that `hit_test_raw`
+  (`crates/flui-rendering/src/traits/render_box.rs:630-639`) discards, so
+  `RenderFractionalTranslation`
+  (`crates/flui-objects/src/layout/fractional_translation.rs:251`) and
+  `RenderFlow` (`crates/flui-objects/src/layout/flow.rs:395`) deliver
+  un-localized positions today.
+- `crates/flui-rendering/src/pipeline/owner/accessors.rs:820-901` — the
+  sliver walk pushes nothing; `box_hit_offset_from_sliver_position` crosses
+  sliver→box without a `with_paint_offset`, so a `Listener` inside a
+  scrolled sliver gets an un-localized position.
 
 ## Tests
 

--- a/crates/flui-interaction/src/routing/hit_test.rs
+++ b/crates/flui-interaction/src/routing/hit_test.rs
@@ -119,7 +119,7 @@ pub struct HitTestEntry {
     /// VERBATIM -- they do not invert. It is the higher-level scope helpers
     /// [`HitTestResult::with_paint_offset`] and
     /// [`HitTestResult::with_paint_transform`] that push each level's OWN
-    /// INVERSE, so [`HitTestResult::last_transform`] folds those inverses
+    /// INVERSE, so `HitTestResult::last_transform` folds those inverses
     /// left-multiplied in descent order and the result already maps global
     /// to local -- no further inversion is needed at delivery. Flutter
     /// parity: `pushTransform(Matrix4.tryInvert(...))` (`rendering/box.dart`,

--- a/crates/flui-interaction/src/routing/hit_test.rs
+++ b/crates/flui-interaction/src/routing/hit_test.rs
@@ -110,7 +110,22 @@ pub struct HitTestEntry {
     /// Element/render ID.
     pub target: RenderId,
 
-    /// Transform from global to local coordinates.
+    /// The composed global-to-local transform for this entry's coordinate
+    /// space.
+    ///
+    /// Assembled by [`HitTestResult`] as the walk descends. The raw
+    /// primitives [`HitTestResult::push_offset`] and
+    /// [`HitTestResult::push_transform`] push whatever they are given
+    /// VERBATIM -- they do not invert. It is the higher-level scope helpers
+    /// [`HitTestResult::with_paint_offset`] and
+    /// [`HitTestResult::with_paint_transform`] that push each level's OWN
+    /// INVERSE, so [`HitTestResult::last_transform`] folds those inverses
+    /// left-multiplied in descent order and the result already maps global
+    /// to local -- no further inversion is needed at delivery. Flutter
+    /// parity: `pushTransform(Matrix4.tryInvert(...))` (`rendering/box.dart`,
+    /// `addWithPaintTransform`/`addWithPaintOffset`), folded by
+    /// `HitTestResult._globalizeTransforms` (`gestures/hit_test.dart`).
+    ///
     /// Set automatically when added to HitTestResult.
     pub transform: Option<Matrix4>,
 
@@ -298,16 +313,40 @@ impl HitTestResult {
         self.path.push(entry);
     }
 
-    /// Pushes a transform matrix onto the stack.
+    /// Pushes a transform matrix onto the stack, VERBATIM -- no inversion.
+    ///
+    /// This is the raw primitive: it pushes exactly the matrix it is given.
+    /// [`HitTestEntry::transform`] is documented (and Flutter's own
+    /// `pushTransform`/`_globalizeTransforms` contract requires) that the
+    /// stack accumulates the GLOBAL-TO-LOCAL mapping as the walk descends,
+    /// so the CALLER is responsible for passing this method the inverse of
+    /// whatever forward (paint-direction) transform the level represents.
+    /// Prefer [`HitTestResult::with_paint_transform`], which computes and
+    /// pushes that inverse for you and pops it automatically. Pushing the
+    /// forward matrix here by mistake is exactly the composition-order bug
+    /// `with_paint_offset`/`with_paint_transform` exist to prevent -- see
+    /// their docs.
     ///
     /// Flutter equivalent: `@protected void pushTransform(Matrix4 transform)`
+    /// (callers invert before calling, e.g. `addWithPaintTransform` in
+    /// `rendering/box.dart`).
     pub fn push_transform(&mut self, transform: Matrix4) {
         self.local_transforms.push(TransformPart::Matrix(transform));
     }
 
-    /// Pushes an offset translation onto the stack.
+    /// Pushes an offset translation onto the stack, VERBATIM -- no negation.
+    ///
+    /// This is the raw primitive: `push_offset(o)` pushes `translate(+o)`
+    /// exactly as given. Same caller-must-invert contract as
+    /// [`HitTestResult::push_transform`] -- for a pure translation the
+    /// inverse of "translate by `offset`" is "translate by `-offset`", so a
+    /// caller composing a global-to-local stack must pass `-offset`, not
+    /// `offset`. Prefer [`HitTestResult::with_paint_offset`], which negates
+    /// and pops for you.
     ///
     /// Flutter equivalent: `@protected void pushOffset(Offset offset)`
+    /// (callers negate before calling, e.g. `addWithPaintOffset` in
+    /// `rendering/box.dart:839` calls `pushOffset(-offset)`).
     pub fn push_offset(&mut self, offset: Offset<Pixels>) {
         self.local_transforms.push(TransformPart::Offset(offset));
     }
@@ -331,6 +370,20 @@ impl HitTestResult {
     /// `rendering/box.dart`: the Flutter code uses a try/finally
     /// pair around the pushOffset/popTransform sequence; Rust
     /// expresses the same scope via a closure.
+    ///
+    /// # Why the offset is negated
+    ///
+    /// `box.dart:839` calls `pushOffset(-offset)`, not `pushOffset(offset)`:
+    /// the transform stack accumulates the GLOBAL-TO-LOCAL mapping as the
+    /// walk descends, so each level must push its own inverse. For a pure
+    /// translation the inverse of "translate by `offset`" is "translate by
+    /// `-offset`". Pushing the forward (un-negated) offset here recorded a
+    /// composed transform that was `inv(B)·inv(A)`'s mirror-image
+    /// `inv(A)·inv(B)` for any chain mixing offsets with a non-commuting
+    /// matrix transform (e.g. a scaled `Transform` ancestor) -- correct only
+    /// when every part in the chain is a pure translation, where the two
+    /// compositions coincide. See `crates/flui-widgets/tests/parity/
+    /// pointer_local_position_test.rs` for the regression this fixes.
     ///
     /// # Why a closure and not a guard
     ///
@@ -359,25 +412,63 @@ impl HitTestResult {
     where
         F: FnOnce(&mut Self) -> R,
     {
-        self.push_offset(offset);
+        self.push_offset(-offset);
         let result = f(self);
         self.pop_transform();
         result
     }
 
-    /// Runs `f` with `transform` pushed onto the transform stack and
-    /// pops the transform before returning.
+    /// Runs `f` with the INVERSE of `transform` pushed onto the transform
+    /// stack and pops it before returning.
     ///
     /// See [`with_paint_offset`](Self::with_paint_offset) for the
     /// Flutter-parity rationale and the closure-vs-guard discussion
-    /// (closure-vs-guard rationale); this is the matrix-typed sibling
-    /// for callers that need a full 4x4 transform rather than a
-    /// paint-offset.
+    /// (closure-vs-guard rationale); this is the matrix-typed sibling for
+    /// callers that need a full 4x4 transform rather than a paint-offset --
+    /// same caller-supplies-the-forward-matrix, callee-inverts-it contract.
+    /// Flutter parity: `BoxHitTestResult.addWithPaintTransform`
+    /// (`rendering/box.dart:799-812`), which inverts via `Matrix4.tryInvert`
+    /// at line 805 before delegating at line 811 to `addWithRawTransform`.
+    ///
+    /// # Known divergences from Flutter
+    ///
+    /// 1. **Non-invertible transforms.** Flutter's `addWithPaintTransform`
+    ///    returns `false` outright when the transform cannot be inverted
+    ///    (the subtree is not visible/hittable). This method instead falls
+    ///    back to pushing the still-singular forward matrix, the same
+    ///    convention `PipelineOwner::hit_test_subtree` already uses for
+    ///    `RenderBox::hit_test_transform`
+    ///    (`crates/flui-rendering/src/pipeline/owner/accessors.rs`:
+    ///    `t.try_inverse().unwrap_or(t)`): when the determinant is exactly
+    ///    zero, the composed chain stays singular, so delivery still
+    ///    detects and skips it (`LocalEventTransform::capture`) without
+    ///    this method needing to thread a `bool` result back through every
+    ///    caller. The skip is only threshold-relative, not guaranteed, for
+    ///    a merely near-singular transform (`0 < |det| < f32::EPSILON`,
+    ///    which `Matrix4::is_invertible` also rejects): determinants
+    ///    compose multiplicatively, so a large-determinant ancestor
+    ///    elsewhere in the chain can lift the product back above
+    ///    `f32::EPSILON`. In that case delivery sees an invertible
+    ///    composite and delivers the entry with a garbage local position --
+    ///    a wider divergence from Flutter's hard refusal than the
+    ///    still-singular fallback above covers by itself.
+    /// 2. **No perspective removal.** `box.dart:805` inverts
+    ///    `PointerEvent.removePerspectiveTransform(transform)`, not
+    ///    `transform` itself -- Flutter strips the perspective row/column
+    ///    before inverting so a perspective-projected transform still
+    ///    inverts to a usable affine map. This method calls
+    ///    `transform.try_inverse()` directly, with no perspective removal.
+    ///    Low reachability today: nothing in the widget layer constructs a
+    ///    perspective (non-affine) transform, so every `transform` reaching
+    ///    this method in practice is already affine. Perspective removal is
+    ///    intentionally not implemented here (out of scope); a
+    ///    perspective-producing widget added later would make this
+    ///    divergence live and worth revisiting.
     pub fn with_paint_transform<F, R>(&mut self, transform: Matrix4, f: F) -> R
     where
         F: FnOnce(&mut Self) -> R,
     {
-        self.push_transform(transform);
+        self.push_transform(transform.try_inverse().unwrap_or(transform));
         let result = f(self);
         self.pop_transform();
         result
@@ -509,8 +600,16 @@ impl HitTestResult {
         for entry in &self.path {
             if let Some(target) = entry.scroll_target {
                 let local_event = if let Some(ref transform) = entry.transform {
-                    if let Some(inverse) = transform.try_inverse() {
-                        transform_scroll_event(event, &inverse)
+                    // `transform` is already global-to-local (see
+                    // `HitTestEntry::transform`'s doc) -- apply it directly.
+                    // `is_invertible` is a well-formedness probe -- it skips
+                    // computing (and discarding) the inverse itself: a
+                    // degenerate ancestor transform makes the composed
+                    // `transform` itself singular, and such an entry must
+                    // still skip delivery rather than report a bogus point
+                    // (unchanged pre-existing behavior).
+                    if transform.is_invertible() {
+                        transform_scroll_event(event, transform)
                     } else {
                         continue;
                     }
@@ -690,11 +789,30 @@ mod tests {
     fn test_hit_test_result_transform_stack() {
         let mut result = HitTestResult::new();
 
+        // `push_offset` is the raw primitive -- it pushes exactly what it is
+        // given, no negation (see its doc). The composed entry transform
+        // must therefore be the FORWARD translation(10, 20), not just
+        // "present": asserting only `.is_some()` (as this test used to)
+        // would pass even if the composition folded the wrong matrix in --
+        // the exact vacuous shape that let the `with_paint_offset`/
+        // `with_paint_transform` direction bug ship undetected.
         result.push_offset(Offset::new(Pixels(10.0), Pixels(20.0)));
         result.add(HitTestEntry::new(RenderId::new(1)));
 
-        // Entry should have captured the transform
-        assert!(result.path()[0].transform.is_some());
+        let transform = result.path()[0]
+            .transform
+            .expect("add() must record a transform");
+        assert_eq!(
+            transform.translation_component(),
+            (10.0, 20.0, 0.0),
+            "push_offset(10, 20) must compose to the forward translation, unnegated"
+        );
+        let (local_x, local_y) = transform.transform_point(Pixels(0.0), Pixels(0.0));
+        assert_eq!(
+            (local_x.0, local_y.0),
+            (10.0, 20.0),
+            "the composed matrix must actually map the origin to (10, 20)"
+        );
 
         result.pop_transform();
     }
@@ -799,9 +917,13 @@ mod tests {
             let mut result = HitTestResult::new();
             // The entry sits in a subtree translated by (10, 20): the handler
             // must observe the event mapped into its local space.
-            result.push_offset(Offset::new(Pixels(10.0), Pixels(20.0)));
-            result.add(HitTestEntry::new(RenderId::new(1)).pointer_target(target));
-            result.pop_transform();
+            // `with_paint_offset` is the production path (the paint-offset
+            // child descent in `PipelineOwner::hit_test_subtree`) -- it
+            // pushes the offset's inverse internally, so the entry's
+            // recorded transform is already global-to-local.
+            result.with_paint_offset(Offset::new(Pixels(10.0), Pixels(20.0)), |result| {
+                result.add(HitTestEntry::new(RenderId::new(1)).pointer_target(target));
+            });
 
             let event = crate::events::make_down_event(
                 Offset::new(Pixels(50.0), Pixels(50.0)),
@@ -810,6 +932,47 @@ mod tests {
             result.dispatch(&event);
         });
         assert_eq!(observed.get(), Offset::new(Pixels(40.0), Pixels(30.0)));
+    }
+
+    #[test]
+    fn dispatch_applies_the_entry_local_transform_via_paint_transform() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        use crate::events::PointerEventExt as _;
+        use crate::routing::InteractionLane;
+
+        let lane = InteractionLane::try_new().expect("lane");
+        let handle = lane.dispatch_handle();
+        let observed = Rc::new(Cell::new(Offset::new(Pixels(0.0), Pixels(0.0))));
+        lane.enter(|| {
+            let position_probe = Rc::clone(&observed);
+            let target = handle
+                .register_pointer(move |event| position_probe.set(event.position()))
+                .expect("register");
+            let mut result = HitTestResult::new();
+            // The entry sits in a subtree scaled 2x from its parent --
+            // matrix-typed sibling of `dispatch_applies_the_entry_local_transform`.
+            // `with_paint_transform` takes the FORWARD (paint-direction)
+            // matrix and must invert it internally before pushing, exactly
+            // like `with_paint_offset` does for a pure translation; without
+            // that inversion the handler would observe the position
+            // multiplied by the scale instead of divided by it. This method
+            // has no production caller yet, so this is the only regression
+            // coverage for the fix.
+            let mut forward = Matrix4::identity();
+            forward.scale(2.0, 2.0, 1.0);
+            result.with_paint_transform(forward, |result| {
+                result.add(HitTestEntry::new(RenderId::new(1)).pointer_target(target));
+            });
+
+            let event = crate::events::make_down_event(
+                Offset::new(Pixels(50.0), Pixels(50.0)),
+                PointerType::Mouse,
+            );
+            result.dispatch(&event);
+        });
+        assert_eq!(observed.get(), Offset::new(Pixels(25.0), Pixels(25.0)));
     }
 
     #[test]
@@ -911,9 +1074,12 @@ mod tests {
                 })
                 .expect("register");
             let mut result = HitTestResult::new();
-            result.push_offset(Offset::new(Pixels(10.0), Pixels(20.0)));
-            result.add(HitTestEntry::new(RenderId::new(1)).scroll_target(target));
-            result.pop_transform();
+            // See `dispatch_applies_the_entry_local_transform`: exercise the
+            // production `with_paint_offset` path, not the raw push/pop pair,
+            // so this proves the fixed (inverse-pushing) contract.
+            result.with_paint_offset(Offset::new(Pixels(10.0), Pixels(20.0)), |result| {
+                result.add(HitTestEntry::new(RenderId::new(1)).scroll_target(target));
+            });
 
             let event = make_scroll_event(
                 Offset::new(Pixels(50.0), Pixels(50.0)),

--- a/crates/flui-interaction/src/routing/interaction_lane.rs
+++ b/crates/flui-interaction/src/routing/interaction_lane.rs
@@ -401,8 +401,8 @@ impl ShaderMaskCell {
 enum LocalEventTransform {
     /// The entry captured no transform; it receives the global event.
     Global,
-    /// Global-to-local inverse computed once at resolution time.
-    Inverse(Matrix4),
+    /// The already-composed global-to-local transform, applied directly.
+    Local(Matrix4),
     /// The captured transform is singular; the entry is skipped, matching the
     /// pre-route dispatch behavior for non-invertible transforms.
     NonInvertible,
@@ -412,9 +412,22 @@ impl LocalEventTransform {
     fn capture(transform: Option<Matrix4>) -> Self {
         match transform {
             None => Self::Global,
-            Some(transform) => transform
-                .try_inverse()
-                .map_or(Self::NonInvertible, Self::Inverse),
+            // `HitTestResult` composes `transform` by left-multiplying each
+            // ancestor level's own inverse as the walk descends (see
+            // `HitTestEntry::transform`'s doc), so it already maps global to
+            // local -- no further inversion here. `is_invertible` is only a
+            // well-formedness probe (cheaper than computing and discarding
+            // the inverse): a degenerate ancestor transform (e.g. a
+            // zero-scale `Transform`) propagates as a singular composed
+            // `transform`, and such an entry must still skip delivery rather
+            // than report a bogus point (unchanged pre-existing behavior).
+            Some(transform) => {
+                if transform.is_invertible() {
+                    Self::Local(transform)
+                } else {
+                    Self::NonInvertible
+                }
+            }
         }
     }
 }
@@ -441,9 +454,7 @@ impl ResolvedHitRoute {
         for entry in &self.entries {
             let local_event = match &entry.local_transform {
                 LocalEventTransform::Global => None,
-                LocalEventTransform::Inverse(inverse) => {
-                    Some(transform_pointer_event(event, inverse))
-                }
+                LocalEventTransform::Local(local) => Some(transform_pointer_event(event, local)),
                 LocalEventTransform::NonInvertible => continue,
             };
             let handler = entry.handler_cell.snapshot();

--- a/crates/flui-objects/src/layout/transform.rs
+++ b/crates/flui-objects/src/layout/transform.rs
@@ -230,8 +230,9 @@ impl RenderBox for RenderTransform {
         // position; the inverse was used only for a bounds gate, so any
         // scaled/rotated child hit-tested at the wrong local point.)
 
-        // The pipeline pushes the forward transform onto HitTestResult
-        // via hit_test_transform() before calling hit_test_raw, so
+        // The pipeline pushes the INVERSE of hit_test_transform() onto
+        // HitTestResult before calling hit_test_raw (HitTestResult composes
+        // the global-to-local mapping from each level's own inverse), so
         // child entries capture the correct accumulated transform.
         // No push/pop needed here.
         ctx.hit_test_child(0, Offset::new(tx, ty))

--- a/crates/flui-rendering/src/pipeline/owner/accessors.rs
+++ b/crates/flui-rendering/src/pipeline/owner/accessors.rs
@@ -542,21 +542,45 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
         // stack BEFORE recursing, so child entries captured during
         // hit_test_raw see the correct accumulated transform. The
         // transform stays on the stack until after the parent entry
-        // is added (Flutter parity: pushTransform in hitTest). The hook
-        // gets `own_size` from RenderState for alignment-relative origins.
+        // is added (Flutter parity: `addWithPaintTransform`
+        // (`rendering/box.dart:799-812`) inverts the incoming transform at
+        // line 805 and delegates at line 811 to `addWithRawTransform`,
+        // which pushes the (already-inverted) transform at line 876). The
+        // hook gets `own_size` from RenderState for alignment-relative
+        // origins.
+        //
+        // Pushed as the INVERSE of `hit_test_transform`: `HitTestResult`
+        // composes the global-to-local mapping by left-multiplying each
+        // level's own inverse in descent order (see `HitTestEntry::transform`),
+        // so a caller pushing the forward (paint-direction) matrix here
+        // recorded the wrong composition for any chain mixing this transform
+        // with an outer offset -- correct only when the whole chain
+        // commutes (pure translations). A non-invertible `hit_test_transform`
+        // (e.g. a zero-scale `Transform`) falls back to pushing the
+        // still-singular forward matrix: when the determinant is exactly
+        // zero, the composed chain stays singular, so delivery still
+        // detects and skips it (`LocalEventTransform::capture`). For a
+        // merely near-singular transform (`0 < |det| < f32::EPSILON`, which
+        // `Matrix4::is_invertible` also rejects) the skip is only
+        // threshold-relative, not guaranteed: determinants compose
+        // multiplicatively, so a large-determinant ancestor can lift the
+        // product back above `f32::EPSILON`, and delivery then hands the
+        // entry a garbage local position instead of skipping it -- out of
+        // scope to change that skip behavior here.
         let hit_transform = render_object.hit_test_transform(own_size);
         let has_transform = hit_transform.is_some();
         if let Some(t) = hit_transform {
-            result.push_transform(t);
+            result.push_transform(t.try_inverse().unwrap_or(t));
         }
         // A resolved follower offset rides the SAME transform-stack
         // lifecycle as `hit_test_transform` (ADR-0015) — the same
         // translation the paint/GPU path applies via
         // `backend.push_offset(resolved)` (renderer.rs:1586), lifted to a
         // `Matrix4` (exact and lossless — the composer only ever
-        // shifts coordinate space via translation).
+        // shifts coordinate space via translation). Pushed as the inverse
+        // translation for the same reason as `hit_test_transform` above.
         if let Some(r) = follower_offset {
-            result.push_transform(Matrix4::translation(r.dx.get(), r.dy.get(), 0.0));
+            result.push_transform(Matrix4::translation(-r.dx.get(), -r.dy.get(), 0.0));
         }
 
         // Shift the position handed into this node's own subtree by the

--- a/crates/flui-rendering/src/testing/inspect.rs
+++ b/crates/flui-rendering/src/testing/inspect.rs
@@ -72,12 +72,13 @@ pub fn hit_path<P: PipelinePhase + Sync>(
 /// Hit-tests at root-local `(x, y)` (logical pixels) and returns the
 /// leaf-first path of `(RenderId, recorded_transform)` pairs.
 ///
-/// The recorded `Option<Matrix4>` is the globalized global-to-local transform
-/// that `HitTestResult` captures for each entry when
-/// [`hit_test_child_at_layout_offset`] is used.  A `None` transform means
-/// the entry was added without pushing an offset onto the result's transform
-/// stack — i.e. the child was hit-tested via the old `hit_test_child_at_offset`
-/// path that records no transform.
+/// The recorded value is the globalized global-to-local transform that
+/// `HitTestResult::add` unconditionally attaches to every entry
+/// (`crates/flui-interaction/src/routing/hit_test.rs`'s `add`, which sets
+/// `entry.transform = Some(self.last_transform())` regardless of whether any
+/// offset/transform was ever pushed — an empty stack still folds to
+/// `Matrix4::identity()`). The `Option` wrapper exists for the field's
+/// general shape, not because `None` is reachable through this path.
 ///
 /// Pair with [`localize_hit_point`] to assert that the recorded transform
 /// correctly maps a global hit point to the child's local coordinate space.
@@ -101,7 +102,22 @@ pub fn hit_path_with_transforms<P: PipelinePhase + Sync>(
 /// a global hit point, returning the equivalent point in the entry's local
 /// coordinate space.
 ///
-/// Returns `None` when the matrix is singular (non-invertible).
+/// `transform` already maps global to local -- `HitTestResult` composes it by
+/// left-multiplying each ancestor level's own inverse as the walk descends
+/// (see `HitTestEntry::transform`'s doc), so this applies it directly with no
+/// further inversion.
+///
+/// Returns `None` when `transform` is singular (non-invertible). This is
+/// guaranteed whenever a degenerate ancestor transform (e.g. a zero-scale
+/// `Transform`) contributed an exactly-zero determinant somewhere in the
+/// composed chain. For a merely near-singular ancestor (`0 < |det| <
+/// f32::EPSILON`, which `Matrix4::is_invertible` also rejects) the composed
+/// `transform` is not guaranteed to stay singular -- determinants compose
+/// multiplicatively, so a large-determinant ancestor elsewhere in the chain
+/// can lift the product back above `f32::EPSILON`. In that case this
+/// function returns `Some` with a meaningless local point instead of
+/// `None`, so a `Some` result is not proof the whole chain was
+/// well-conditioned.
 ///
 /// # Usage
 ///
@@ -114,10 +130,11 @@ pub fn hit_path_with_transforms<P: PipelinePhase + Sync>(
 /// assert_eq!(local, Offset::new(px(20.0), px(20.0)));
 /// ```
 pub fn localize_hit_point(transform: Matrix4, global_x: f32, global_y: f32) -> Option<Offset> {
-    transform.try_inverse().map(|inverse| {
-        let (local_x, local_y) = inverse.transform_point(Pixels(global_x), Pixels(global_y));
-        Offset::new(local_x, local_y)
-    })
+    if !transform.is_invertible() {
+        return None;
+    }
+    let (local_x, local_y) = transform.transform_point(Pixels(global_x), Pixels(global_y));
+    Some(Offset::new(local_x, local_y))
 }
 
 // ============================================================================

--- a/crates/flui-rendering/tests/hit_test_pipeline.rs
+++ b/crates/flui-rendering/tests/hit_test_pipeline.rs
@@ -222,13 +222,18 @@ fn hit_entry_records_child_paint_offset_transform() {
         "laid-out child offset must contribute a non-identity transform",
     );
 
-    let inverse = transform
-        .try_inverse()
-        .expect("paint-offset transform must be invertible");
-    let (local_x, local_y) = inverse.transform_point(px(20.0), px(20.0));
+    // `transform` is already global-to-local (each level pushes its own
+    // inverse as the walk descends; see `HitTestEntry::transform`'s doc) --
+    // apply it directly. The invertibility check stays as a well-formedness
+    // assertion for this translation-only case.
+    assert!(
+        transform.try_inverse().is_some(),
+        "paint-offset transform must be invertible"
+    );
+    let (local_x, local_y) = transform.transform_point(px(20.0), px(20.0));
     assert!(
         (local_x.get() - 15.0).abs() < 0.01 && (local_y.get() - 15.0).abs() < 0.01,
-        "inverse transform must map global (20,20) to child-local (15,15) through 5px padding",
+        "recorded transform must map global (20,20) to child-local (15,15) through 5px padding",
     );
 }
 

--- a/crates/flui-widgets/tests/parity/main.rs
+++ b/crates/flui-widgets/tests/parity/main.rs
@@ -148,3 +148,7 @@ mod offstage_test;
 
 // ── Business.1 fidelity — RotatedBox parity ─────────────────────────────────
 mod rotated_box_test;
+
+// ── Business.1 fidelity — pointer hit-test parity ──
+mod pointer_hit_test_test;
+mod pointer_local_position_test;

--- a/crates/flui-widgets/tests/parity/pointer_hit_test_test.rs
+++ b/crates/flui-widgets/tests/parity/pointer_hit_test_test.rs
@@ -1,0 +1,686 @@
+//! ## Test parity notes
+//!
+//! Flutter source: `packages/flutter/test/widgets/absorb_pointer_test.dart`,
+//! `packages/flutter/test/widgets/listener_test.dart`,
+//! `packages/flutter/lib/src/widgets/basic.dart`,
+//! `packages/flutter/lib/src/rendering/proxy_box.dart`, and
+//! `packages/flutter/lib/src/gestures/binding.dart` (tag `3.44.0`).
+//!
+//! Ported cases:
+//! - `'AbsorbPointers do not block siblings'` (`absorb_pointer_test.dart`) —
+//!   [`absorb_pointer_does_not_block_a_column_sibling`].
+//! - `RenderAbsorbPointer.hitTest` (`proxy_box.dart`: `absorbing ?
+//!   size.contains(position) : super.hitTest(...)`) and the `AbsorbPointer`/
+//!   `IgnorePointer` doc contracts (`basic.dart`) —
+//!   [`absorbing_blocks_a_stack_sibling_below`],
+//!   [`absorbing_still_delivers_to_a_listener_above_it`],
+//!   [`ignoring_hides_the_subtree_and_itself_from_hit_testing`],
+//!   [`ignoring_lets_a_stack_sibling_below_receive_the_pointer`],
+//!   [`toggling_ignoring_on_a_mounted_tree_takes_effect_without_a_remount`].
+//! - `'Events bubble up the tree'` (`listener_test.dart`) —
+//!   [`pointer_events_bubble_from_the_innermost_listener_outward`].
+//! - `HitTestBehavior.translucent`'s "receive without blocking" contract
+//!   (`gestures/hit_test.dart` doc, exercised end-to-end through the widget →
+//!   render-object wiring) —
+//!   [`translucent_listener_receives_without_blocking_a_sibling_below`].
+//! - `GestureBinding._handlePointerEventImmediately`'s down-cached-route reuse
+//!   (`gestures/binding.dart:418-428`: `PointerMoveEvent`/`PointerUpEvent`
+//!   look up `_hitTests[event.pointer]` — the path recorded at `PointerDown`
+//!   — rather than hit-testing again) —
+//!   [`pressed_move_and_up_outside_the_bounds_reach_the_down_route`],
+//!   [`pointer_cancel_is_delivered_on_the_route_captured_at_down`],
+//!   [`a_rebuilt_listener_callback_receives_the_up_on_the_cached_down_route`],
+//!   [`an_unmounted_listener_still_receives_the_up_on_its_active_route`].
+//! - A pointer outside every hit-testable bound reaches nothing — the
+//!   baseline every case above assumes —
+//!   [`a_pointer_outside_every_bound_hits_nothing`].
+//!
+//! Not ported:
+//! - `absorb_pointer_test.dart`'s `group('AbsorbPointer semantics', ...)` (3
+//!   cases: `'does not change semantics when not absorbing'`, `'drops
+//!   semantics when its ignoreSemantics is true'`, and `'ignores user
+//!   interactions'`) — FLUI's semantics tree is Phase 3 per
+//!   `crates/flui-widgets/tests/parity/main.rs`'s own phase banner; nothing
+//!   to assert against yet. `absorb_pointer_test.dart` has 4 `testWidgets`
+//!   total at tag `3.44.0` (verified via `git show 3.44.0:.../absorb_pointer_test.dart`);
+//!   this file ports 1 of them (`'AbsorbPointers do not block siblings'`,
+//!   above) — 1/4.
+//! - `listener_test.dart`'s two `"RenderPointerListener's debugFillProperties
+//!   when default/full"` cases — diagnostics-string formatting, not hit-test
+//!   behavior; out of scope for a hit-test parity file.
+//! - `'Detects hover events from touch devices'` (`listener_test.dart:45`) —
+//!   duplicates `crates/flui-widgets/tests/listener.rs:130`
+//!   (`listener_routes_buttonless_move_to_hover_callback`) except for the
+//!   pointer device kind (mouse there, a touch-originated hover here); FLUI's
+//!   hit-test and hover-delivery path does not branch on device kind, so the
+//!   existing mouse-driven case already covers the contract this one would
+//!   re-assert. `listener_test.dart` has 8 `testWidgets` total at tag
+//!   `3.44.0` (verified via `git show 3.44.0:.../listener_test.dart`):
+//!   `'Events bubble up the tree'` (ported above), this hover case, the two
+//!   `debugFillProperties` cases just above, and the four-case
+//!   `'transformed events'` group ported/not-ported in
+//!   `pointer_local_position_test.rs` (3 ported, 1 not) — 4/8 ported across
+//!   both files, the other 4 explicitly accounted for above and in that
+//!   file's own module doc.
+//! - `MouseRegion` (Flutter has no single oracle file for it analogous to
+//!   `listener_test.dart`; the closest equivalent, `mouse_region_test.dart`,
+//!   has 44 cases spanning hover-enter/exit device tracking) needs a
+//!   `LaidOut::add_mouse_device` helper that does not exist in this harness —
+//!   out of scope for this pass.
+//!
+//! Divergence: FLUI's childless `GestureDetector` defaults to
+//! [`HitTestBehavior::DeferToChild`] where Flutter's childless
+//! `GestureDetector` defaults to `translucent`
+//! (`crates/flui-widgets/src/interaction/gesture_detector.rs:142` vs
+//! `widgets/gesture_detector.dart:1571-1573` at tag `3.44.0`) — already
+//! documented in `crates/flui-widgets/tests/parity/gesture_detector_test.rs`'s
+//! own module doc, restated here because it's WHY case 1 below probes with a
+//! bare [`Listener`] rather than a `GestureDetector` the way Flutter's
+//! `'AbsorbPointers do not block siblings'` literally does: a childless
+//! `GestureDetector` in FLUI would register `DeferToChild` and never fire,
+//! which is not what the upstream test is checking.
+//!
+//! This file is additive to hit-test coverage that already exists:
+//! `crates/flui-widgets/tests/listener.rs` (7 tests: `HitTestBehavior`
+//! contract, down/up/hover/move/signal/pan-zoom routing) covers a SINGLE
+//! `Listener` in isolation; `crates/flui-widgets/tests/absorb_pointer.rs` (4
+//! tests) and `crates/flui-widgets/tests/modifiers.rs:40`
+//! (`ignore_pointer_is_a_layout_passthrough`) cover `AbsorbPointer`/
+//! `IgnorePointer` as isolated layout pass-throughs and a single
+//! absorb-then-`GestureDetector` block; `crates/flui-widgets/tests/mouse_region.rs`
+//! (3 tests) covers `MouseRegion` in isolation;
+//! `crates/flui-objects/tests/render_object_harness.rs:943` (translucent
+//! Listener + Stack sibling), `:1021`/`:1042` (`MouseRegion` sibling/tracker
+//! entries), `:5342` (`RenderAbsorbPointer` blocks a child), and `:5361`
+//! (`RenderIgnorePointer` lets a sibling through) exercise the render objects
+//! directly, below the widget layer; `crates/flui-widgets/tests/parity/gesture_detector_test.rs`
+//! covers `HitTestBehavior` on a childless `GestureDetector` stacked over a
+//! `Listener`. None of the above cover: siblings across a `Column`/`Expanded`
+//! split (case 1), nested absorb/ignore wrapping (cases 3-4), a live
+//! `ignoring` toggle on an already-mounted tree (case 6), event bubbling
+//! through three nested `Listener`s (case 7), or the down-cached-route reuse
+//! for move/up/cancel/rebuild/unmount (cases 9-12) — every case in this file
+//! targets one of those gaps.
+//!
+//! Widget → render-object mapping:
+//! - `Listener` → `RenderListener`
+//!   (`crates/flui-objects/src/interaction/listener.rs`)
+//! - `AbsorbPointer` → `RenderAbsorbPointer`, `IgnorePointer` →
+//!   `RenderIgnorePointer` (`crates/flui-objects/src/interaction/`)
+//! - `Stack` → `RenderStack` (top-most child tested first, stops at the
+//!   first hit that reports `blocks_below`)
+//! - `Column`/`Expanded` → `RenderFlex` (`Expanded` forces tight cross-axis
+//!   AND main-axis-share constraints on its child, per `FlexFit::Tight`)
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use flui_view::ViewExt;
+use flui_widgets::prelude::*;
+
+use crate::harness;
+
+/// A hit-testable 100×100 leaf — `ColoredBox` wraps a childless `SizedBox` so
+/// the box actually hit-tests true (a bare `SizedBox` with no child does
+/// not; see `crates/flui-objects/src/layout/constrained_box.rs:130-139`).
+/// `ColoredBox` maps to `RenderDecoratedBox` — the same render object
+/// Flutter's `DecoratedBox(decoration: BoxDecoration())` produces, which is
+/// why case 7 below reuses it in place of Flutter's literal `DecoratedBox`.
+fn target() -> ColoredBox {
+    ColoredBox::new(Color::rgb(10, 20, 30)).child(SizedBox::new(100.0, 100.0))
+}
+
+fn counter() -> (Rc<Cell<usize>>, impl Fn(&PointerEvent) + Clone) {
+    let count = Rc::new(Cell::new(0));
+    let probe = Rc::clone(&count);
+    (count, move |_event: &PointerEvent| {
+        probe.set(probe.get() + 1);
+    })
+}
+
+/// `AbsorbPointer` (bare, no child) sitting in the LOWER half of a
+/// `Column` must not block a `Listener` in the UPPER half.
+///
+/// Flutter parity: `'AbsorbPointers do not block siblings'`
+/// (`absorb_pointer_test.dart`) — `Column(Expanded(GestureDetector),
+/// Expanded(AbsorbPointer()))`, taps the `GestureDetector` and expects it to
+/// still fire. Ported with a bare `Listener` in place of `GestureDetector`
+/// (see the module doc's Divergence note) and split into two dispatches (one
+/// per half) so the RED check is explicit on both sides: a wiring bug that
+/// made `AbsorbPointer` absorb its OWN half's Listener too, or one that let
+/// it swallow the WHOLE column, would each fail a different assertion here.
+///
+/// `Expanded`'s `FlexFit::Tight` gives the bare, childless `AbsorbPointer` a
+/// concrete non-zero size (Flutter's literal shape) — under a merely loose
+/// constraint a childless `AbsorbPointer` would size to zero and this test
+/// would vacuously pass regardless of the fix.
+#[test]
+fn absorb_pointer_does_not_block_a_column_sibling() {
+    let (hits, on_down) = counter();
+
+    let laid = harness::pump_widget(
+        Column::new(vec![
+            Expanded::new(Listener::new().on_pointer_down(on_down).child(target())).boxed(),
+            Expanded::new(AbsorbPointer::new()).boxed(),
+        ]),
+        harness::screen_of(100.0, 200.0),
+    );
+
+    // Upper half (y in [0, 100)): the Listener's own half.
+    laid.dispatch_pointer_down(50.0, 50.0);
+    laid.dispatch_pointer_up(50.0, 50.0);
+    assert_eq!(
+        hits.get(),
+        1,
+        "the Listener must still fire from within its own half"
+    );
+
+    // Lower half (y in [100, 200)): the bare AbsorbPointer's half — must not
+    // reach back up to the Listener above it.
+    laid.dispatch_pointer_down(50.0, 150.0);
+    laid.dispatch_pointer_up(50.0, 150.0);
+    assert_eq!(
+        hits.get(),
+        1,
+        "AbsorbPointer's own half must not fire the sibling Listener stacked above it"
+    );
+}
+
+/// `AbsorbPointer` (`absorbing = true`, the default) stacked ON TOP of a
+/// `Listener` must block that sibling from ever receiving the pointer.
+///
+/// Flutter parity: `RenderAbsorbPointer.hitTest` (`proxy_box.dart`):
+/// `absorbing ? size.contains(position) : super.hitTest(...)` — when
+/// absorbing, a hit within bounds is unconditional and never descends, so a
+/// `Stack` sibling visually behind it (tested next, since `Stack` tests
+/// top-most first and stops at the first hit) never gets tested at all. Also
+/// pins `basic.dart`'s `AbsorbPointer` doc contract ("this render object
+/// absorbs pointers ... regardless of ... layout/painting").
+#[test]
+fn absorbing_blocks_a_stack_sibling_below() {
+    let (below_hits, on_down) = counter();
+
+    let laid = harness::pump_widget(
+        Stack::new((
+            Listener::new().on_pointer_down(on_down).child(target()),
+            AbsorbPointer::new(),
+        ))
+        .fit(StackFit::Expand),
+        harness::screen_of(100.0, 100.0),
+    );
+
+    laid.dispatch_pointer_down(50.0, 50.0);
+
+    assert_eq!(
+        below_hits.get(),
+        0,
+        "an absorbing AbsorbPointer stacked above must block the Listener below it"
+    );
+}
+
+/// Absorbing still lets a `Listener` ABOVE the `AbsorbPointer` (an
+/// ancestor, not a `Stack` sibling) receive the pointer — only the
+/// `AbsorbPointer`'s own subtree is swallowed.
+///
+/// Flutter parity: same `RenderAbsorbPointer.hitTest` contract as case 2,
+/// exercised on the opposite side of the absorbing node: `Listener(outer) >
+/// AbsorbPointer > Listener(inner)`. `AbsorbPointer` self-registers (its
+/// `hitTest` returns `true` within bounds), which is exactly what the outer
+/// `Listener`'s `DeferToChild` behavior is watching for — "a descendant was
+/// hit" — so the outer still fires even though the inner never gets
+/// hit-tested at all.
+#[test]
+fn absorbing_still_delivers_to_a_listener_above_it() {
+    let (outer_hits, on_outer) = counter();
+    let (inner_hits, on_inner) = counter();
+
+    let laid = harness::pump_widget(
+        Listener::new().on_pointer_down(on_outer).child(
+            AbsorbPointer::new().child(Listener::new().on_pointer_down(on_inner).child(target())),
+        ),
+        harness::screen_of(100.0, 100.0),
+    );
+
+    laid.dispatch_pointer_down(50.0, 50.0);
+
+    assert_eq!(outer_hits.get(), 1, "the outer Listener must still fire");
+    assert_eq!(
+        inner_hits.get(),
+        0,
+        "the inner Listener must never be hit-tested — AbsorbPointer swallows its own subtree"
+    );
+}
+
+/// `IgnorePointer` (`ignoring = true`, the default) hides BOTH itself and
+/// its whole subtree from hit-testing — unlike `AbsorbPointer`, it never
+/// self-registers. Flipping `ignoring` to `false` restores normal
+/// (transparent pass-through) hit-testing for the whole chain.
+///
+/// Flutter parity: `RenderIgnorePointer.hitTest` (`proxy_box.dart`): `return
+/// !ignoring && super.hitTest(...)` — when ignoring, the method returns
+/// `false` unconditionally, before even checking its own bounds, so nothing
+/// under it (and it itself) ever contributes a hit entry. Also pins
+/// `basic.dart`'s `IgnorePointer` doc contract.
+#[test]
+fn ignoring_hides_the_subtree_and_itself_from_hit_testing() {
+    let (outer_hits, on_outer) = counter();
+    let (inner_hits, on_inner) = counter();
+
+    let hidden = harness::pump_widget(
+        Listener::new().on_pointer_down(on_outer.clone()).child(
+            IgnorePointer::new().child(
+                Listener::new()
+                    .on_pointer_down(on_inner.clone())
+                    .child(target()),
+            ),
+        ),
+        harness::screen_of(100.0, 100.0),
+    );
+    hidden.dispatch_pointer_down(50.0, 50.0);
+    assert_eq!(
+        outer_hits.get(),
+        0,
+        "ignoring must hide the subtree from the outer Listener's DeferToChild check too"
+    );
+    assert_eq!(
+        inner_hits.get(),
+        0,
+        "the inner Listener must never be hit-tested"
+    );
+
+    let (outer_hits, on_outer) = counter();
+    let (inner_hits, on_inner) = counter();
+    let visible = harness::pump_widget(
+        Listener::new().on_pointer_down(on_outer).child(
+            IgnorePointer::new()
+                .ignoring(false)
+                .child(Listener::new().on_pointer_down(on_inner).child(target())),
+        ),
+        harness::screen_of(100.0, 100.0),
+    );
+    visible.dispatch_pointer_down(50.0, 50.0);
+    assert_eq!(
+        outer_hits.get(),
+        1,
+        "ignoring(false) restores the outer Listener"
+    );
+    assert_eq!(
+        inner_hits.get(),
+        1,
+        "ignoring(false) restores the inner Listener too"
+    );
+}
+
+/// `IgnorePointer` above a `Stack` sibling lets that sibling receive the
+/// pointer while ignoring, and blocks it once `ignoring` is turned off (its
+/// own hittable child then wins the `Stack`'s top-most-first search).
+///
+/// Flutter parity: same `RenderIgnorePointer.hitTest` contract as case 4,
+/// read from the `Stack`-sibling angle this time — `!ignoring &&
+/// super.hitTest(...)`: while ignoring, the short-circuit means the sibling
+/// below is never blocked; once not ignoring, `super.hitTest` (a normal
+/// hittable child) returns `true` and — same `Stack` top-most-first-and-stop
+/// rule as case 2 — the sibling below never gets tested.
+#[test]
+fn ignoring_lets_a_stack_sibling_below_receive_the_pointer() {
+    let (below_hits, on_down) = counter();
+    let ignoring = harness::pump_widget(
+        Stack::new((
+            Listener::new().on_pointer_down(on_down).child(target()),
+            IgnorePointer::new().child(target()),
+        ))
+        .fit(StackFit::Expand),
+        harness::screen_of(100.0, 100.0),
+    );
+    ignoring.dispatch_pointer_down(50.0, 50.0);
+    assert_eq!(
+        below_hits.get(),
+        1,
+        "ignoring must let the sibling below receive the pointer"
+    );
+
+    let (below_hits, on_down) = counter();
+    let not_ignoring = harness::pump_widget(
+        Stack::new((
+            Listener::new().on_pointer_down(on_down).child(target()),
+            IgnorePointer::new().ignoring(false).child(target()),
+        ))
+        .fit(StackFit::Expand),
+        harness::screen_of(100.0, 100.0),
+    );
+    not_ignoring.dispatch_pointer_down(50.0, 50.0);
+    assert_eq!(
+        below_hits.get(),
+        0,
+        "not ignoring: IgnorePointer's own hittable child wins the Stack's top-most search first"
+    );
+}
+
+/// Flipping `ignoring` on an ALREADY-MOUNTED tree (`pump_widget`, the
+/// harness's view-diffing update path — not a fresh [`harness::pump_widget`]
+/// call) takes effect immediately, with no special-case "remount" needed.
+///
+/// A `RenderId` is a 1-based slab index; a free-then-reinsert during
+/// reconciliation can return the SAME id for an unrelated node, so `RenderId`
+/// equality across two pumps is not evidence of "the same node kept its
+/// identity" (see this file's harness-facts). What actually makes this a
+/// remount test (and not a vacuous one) is `LaidOut::pump_widget` itself
+/// (`crates/flui-widgets/tests/common/mod.rs:662-667`): it is
+/// `swap_root_view` + `pump_frame`, with no second
+/// [`harness::pump_widget`] (fresh-mount) call anywhere in this test — the
+/// tree is updated IN PLACE. The `on_down` handler installed on the second
+/// `pump_widget` call (line below) shares the SAME underlying
+/// `Rc<Cell<usize>>` as the handler installed at mount time --
+/// [`counter`]'s closure is `Clone`, and every clone closes over that one
+/// `Rc`, so the hit count is genuinely cumulative across both states (which
+/// is exactly why `hits.get() == 1` after the toggle reads as a delta, not
+/// a fresh count). It is the single continuously-live [`LaidOut`] and its
+/// in-place update path that prove no remount happened, not the counter
+/// identity.
+#[test]
+fn toggling_ignoring_on_a_mounted_tree_takes_effect_without_a_remount() {
+    let (hits, on_down) = counter();
+
+    let mut laid = harness::pump_widget(
+        IgnorePointer::new().child(
+            Listener::new()
+                .on_pointer_down(on_down.clone())
+                .child(target()),
+        ),
+        harness::screen_of(80.0, 80.0),
+    );
+
+    laid.dispatch_pointer_down(40.0, 40.0);
+    laid.dispatch_pointer_up(40.0, 40.0);
+    assert_eq!(
+        hits.get(),
+        0,
+        "ignoring(true) (the default) must still block at mount time"
+    );
+
+    laid.pump_widget(
+        IgnorePointer::new()
+            .ignoring(false)
+            .child(Listener::new().on_pointer_down(on_down).child(target())),
+    );
+
+    laid.dispatch_pointer_down(40.0, 40.0);
+    assert_eq!(
+        hits.get(),
+        1,
+        "flipping ignoring to false via pump_widget must take effect on the live tree"
+    );
+}
+
+/// A pointer landing on a target reaches every ancestor `Listener`,
+/// innermost first.
+///
+/// Flutter parity: `'Events bubble up the tree'` (`listener_test.dart`):
+/// `Listener(top) > Listener(middle) > DecoratedBox > Listener(bottom) >
+/// Text('X')`, `tester.tap(find.text('X'))`, expects `log == ['bottom',
+/// 'middle', 'top']`. The hit point is derived from the mounted `Text`
+/// node's own geometry (`find_text` + `absolute_offset` + `size / 2`), never
+/// hardcoded, so a layout change to any ancestor cannot silently make this
+/// pass by accident.
+#[test]
+fn pointer_events_bubble_from_the_innermost_listener_outward() {
+    let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+    let (top_log, middle_log, bottom_log) = (Rc::clone(&log), Rc::clone(&log), Rc::clone(&log));
+
+    let laid = harness::pump_widget(
+        Listener::new()
+            .on_pointer_down(move |_| top_log.borrow_mut().push("top"))
+            .child(
+                Listener::new()
+                    .on_pointer_down(move |_| middle_log.borrow_mut().push("middle"))
+                    .child(
+                        ColoredBox::new(Color::rgb(0, 0, 0)).child(
+                            Listener::new()
+                                .on_pointer_down(move |_| bottom_log.borrow_mut().push("bottom"))
+                                .child(Text::new("X")),
+                        ),
+                    ),
+            ),
+        harness::screen_of(300.0, 300.0),
+    );
+
+    let text_id = laid.find_text("X").expect("Text(\"X\") must be mounted");
+    let text_position = laid.absolute_offset(text_id);
+    let text_size = laid.size(text_id);
+    laid.dispatch_pointer_down(
+        text_position.dx.get() + text_size.width.get() / 2.0,
+        text_position.dy.get() + text_size.height.get() / 2.0,
+    );
+
+    assert_eq!(&*log.borrow(), &["bottom", "middle", "top"]);
+}
+
+/// A translucent `Listener` receives the pointer AND does not block a
+/// `Stack` sibling visually behind it — the one `HitTestBehavior` variant
+/// designed to do both at once.
+///
+/// Flutter parity: `HitTestBehavior.translucent`'s doc contract
+/// (`gestures/hit_test.dart`), the same shape
+/// `crates/flui-objects/tests/render_object_harness.rs:943`
+/// (`harness_listener_translucent_adds_entry_without_blocking_lower_sibling`)
+/// proves at the render-object level — this is that same scenario reached
+/// through the widget → render-object wiring. The translucent `Listener` is
+/// deliberately CHILDLESS: `RenderListener::hit_test`'s `Translucent` arm
+/// only self-registers via `register_self_hit_entry` (without blocking)
+/// when its OWN child was NOT hit (`!hit_target`); with a hit child, a
+/// translucent `Listener` returns `true` from `hit_test` exactly like
+/// `DeferToChild`/`Opaque` do, which DOES block the sibling below through
+/// the generic child-hit-stops-the-Stack-search convention (see case 2) —
+/// there is nothing translucent-specific about that path.
+#[test]
+fn translucent_listener_receives_without_blocking_a_sibling_below() {
+    let (top_hits, on_top) = counter();
+    let (below_hits, on_below) = counter();
+
+    let laid = harness::pump_widget(
+        Stack::new((
+            Listener::new().on_pointer_down(on_below).child(target()),
+            Listener::new()
+                .behavior(HitTestBehavior::Translucent)
+                .on_pointer_down(on_top),
+        ))
+        .fit(StackFit::Expand),
+        harness::screen_of(100.0, 100.0),
+    );
+
+    laid.dispatch_pointer_down(50.0, 50.0);
+
+    assert_eq!(
+        top_hits.get(),
+        1,
+        "the translucent Listener must still fire"
+    );
+    assert_eq!(
+        below_hits.get(),
+        1,
+        "a translucent Listener must not block the sibling behind it"
+    );
+}
+
+/// A pressed move and the matching up, dispatched OUTSIDE the target's
+/// bounds, still reach the route captured at `down` — they do not
+/// re-hit-test at their current (miss) position. A hover AFTER the contact
+/// ends performs a genuinely fresh hit-test and hits nothing out there.
+///
+/// Flutter parity: `GestureBinding._handlePointerEventImmediately`
+/// (`gestures/binding.dart:418-428`): `PointerMoveEvent`/`PointerUpEvent`
+/// read `_hitTests[event.pointer]` — the `HitTestResult` recorded at
+/// `PointerDownEvent` — rather than hit-testing again; a `PointerHoverEvent`
+/// with no down in flight always hit-tests fresh (`event.down` is false, so
+/// none of the down/up/move branches apply — it falls through to a bare
+/// `dispatchEvent` with no cached result).
+#[test]
+fn pressed_move_and_up_outside_the_bounds_reach_the_down_route() {
+    let (downs, on_down) = counter();
+    let (moves, on_move) = counter();
+    let (ups, on_up) = counter();
+    let (hovers, on_hover) = counter();
+
+    let laid = harness::pump_widget(
+        Listener::new()
+            .on_pointer_down(on_down)
+            .on_pointer_move(on_move)
+            .on_pointer_up(on_up)
+            .on_pointer_hover(on_hover)
+            .child(target()),
+        harness::screen_of(100.0, 100.0),
+    );
+
+    laid.dispatch_pointer_down(50.0, 50.0);
+    assert_eq!(downs.get(), 1);
+
+    laid.dispatch_pointer_move(400.0, 400.0);
+    assert_eq!(
+        moves.get(),
+        1,
+        "a pressed move must reach the down-cached route even far outside the bounds"
+    );
+
+    laid.dispatch_pointer_up(400.0, 400.0);
+    assert_eq!(
+        ups.get(),
+        1,
+        "up must reach the down-cached route the same way move did"
+    );
+
+    // The contact is over now; a hover performs a fresh hit-test and (400,
+    // 400) is genuinely outside the 100x100 target.
+    laid.dispatch_pointer_hover(400.0, 400.0);
+    assert_eq!(
+        hovers.get(),
+        0,
+        "hover has no cached route to fall back on and must hit-test fresh"
+    );
+}
+
+/// A cancelled contact delivers `on_pointer_cancel` on the route
+/// captured at `down`, and must NOT also deliver `on_pointer_up`.
+///
+/// `on_pointer_cancel` has zero coverage anywhere else in the existing
+/// `flui-widgets` test suite before this case. Flutter parity: the same
+/// down-cached-route contract as case 9, for `PointerCancelEvent`
+/// (`gestures/binding.dart:418-428`, the `PointerCancelEvent` branch of the
+/// same `if`).
+#[test]
+fn pointer_cancel_is_delivered_on_the_route_captured_at_down() {
+    let (cancels, on_cancel) = counter();
+    let (ups, on_up) = counter();
+
+    let laid = harness::pump_widget(
+        Listener::new()
+            .on_pointer_cancel(on_cancel)
+            .on_pointer_up(on_up)
+            .child(target()),
+        harness::screen_of(80.0, 80.0),
+    );
+
+    laid.dispatch_pointer_down(40.0, 40.0);
+    laid.dispatch_pointer_cancel();
+
+    assert_eq!(
+        cancels.get(),
+        1,
+        "on_pointer_cancel must fire on the down-cached route"
+    );
+    assert_eq!(
+        ups.get(),
+        0,
+        "a cancelled contact must not also deliver on_pointer_up"
+    );
+}
+
+/// Rebuilding a `Listener` with a NEW callback (a `setState`-style
+/// `pump_widget`, not a fresh mount) between `down` and `up` routes the `up`
+/// to the NEW callback, never the old one.
+///
+/// Flutter parity: same down-cached-route contract as cases 9-10, combined
+/// with `Listener::update_render_object`'s documented behavior
+/// (`crates/flui-widgets/src/interaction/listener.rs`): "Rebuild replaces
+/// the handler INSIDE the existing cell, so an active cached route observes
+/// the new configuration."
+#[test]
+fn a_rebuilt_listener_callback_receives_the_up_on_the_cached_down_route() {
+    let (old_ups, on_old_up) = counter();
+    let (new_ups, on_new_up) = counter();
+
+    let mut laid = harness::pump_widget(
+        Listener::new().on_pointer_up(on_old_up).child(target()),
+        harness::screen_of(80.0, 80.0),
+    );
+
+    laid.dispatch_pointer_down(40.0, 40.0);
+
+    laid.pump_widget(Listener::new().on_pointer_up(on_new_up).child(target()));
+
+    laid.dispatch_pointer_up(40.0, 40.0);
+
+    assert_eq!(
+        old_ups.get(),
+        0,
+        "the OLD callback must not fire after the rebuild replaced it"
+    );
+    assert_eq!(
+        new_ups.get(),
+        1,
+        "up must reach the NEW callback on the still-cached down route"
+    );
+}
+
+/// Unmounting a `Listener` entirely (a `pump_widget` root-swap to a tree
+/// that no longer contains it) between `down` and `up` still delivers the
+/// `up` to that Listener's callback — the active route's handler cell
+/// outlives the render object's own mount lifetime.
+///
+/// Pins the prose contract at
+/// `crates/flui-widgets/src/interaction/listener.rs:265-266`
+/// (`did_unmount_render_object`): "Unmount removes the target from NEW route
+/// resolution; an active cached route keeps its strong handler cell through
+/// Up/Cancel."
+#[test]
+fn an_unmounted_listener_still_receives_the_up_on_its_active_route() {
+    let (ups, on_up) = counter();
+
+    let mut laid = harness::pump_widget(
+        Listener::new().on_pointer_up(on_up).child(target()),
+        harness::screen_of(80.0, 80.0),
+    );
+
+    laid.dispatch_pointer_down(40.0, 40.0);
+
+    // Swap to a tree with no Listener anywhere -- the mounted one is gone.
+    laid.pump_widget(target());
+
+    laid.dispatch_pointer_up(40.0, 40.0);
+
+    assert_eq!(
+        ups.get(),
+        1,
+        "an unmounted Listener's active cached route must still deliver its up"
+    );
+}
+
+/// A pointer outside every hit-testable bound in the tree hits nothing —
+/// the baseline every other case in this file assumes when it dispatches
+/// inside a target's bounds and expects exactly one delivery.
+#[test]
+fn a_pointer_outside_every_bound_hits_nothing() {
+    let (hits, on_down) = counter();
+
+    let laid = harness::pump_widget(
+        Listener::new().on_pointer_down(on_down).child(target()),
+        harness::screen_of(50.0, 50.0),
+    );
+
+    laid.dispatch_pointer_down(500.0, 500.0);
+
+    assert_eq!(
+        hits.get(),
+        0,
+        "a pointer entirely outside the tree's bounds must hit nothing"
+    );
+}

--- a/crates/flui-widgets/tests/parity/pointer_local_position_test.rs
+++ b/crates/flui-widgets/tests/parity/pointer_local_position_test.rs
@@ -1,0 +1,246 @@
+//! ## Test parity notes
+//!
+//! Flutter source: `packages/flutter/test/widgets/listener_test.dart` (tag
+//! `3.44.0`), group `'transformed events'`.
+//!
+//! Ported cases:
+//! - `'simple offset for touch/signal'` —
+//!   [`a_delivered_event_carries_the_receivers_local_position`].
+//! - `'scaled and offset for touch/signal'` —
+//!   [`a_scaled_and_offset_ancestor_localises_the_delivered_position`].
+//! - `'rotated for touch/signal'` —
+//!   [`a_rotated_ancestor_localises_the_delivered_position`].
+//!
+//! Not ported:
+//! - `'scaled for touch/signal'` — `Align(topLeft)` contributes a zero offset
+//!   (`TOP_LEFT`'s alignment factor is `(0, 0)` regardless of the size
+//!   difference), so only ONE non-identity transform (the scale) ever lands
+//!   on the hit-test transform stack. A single-level chain cannot expose a
+//!   composition-*order* bug — ordering only matters once two or more
+//!   non-commuting parts are folded together — so this case adds no coverage
+//!   beyond `'simple offset for touch/signal'` once the offset+scale case
+//!   (below) is ported.
+//! - The `.position`/`.delta`/`.localPosition`/`.localDelta`/`.transform`
+//!   assertions on the `move`/`up` events and the trailing `scrollAt` leg of
+//!   each upstream case: FLUI's `transform_pointer_event` only overwrites
+//!   `position` in place and leaves `delta`/`coalesced`/`predicted`
+//!   untransformed (`crates/flui-interaction/src/routing/hit_test.rs:608-676`),
+//!   and there is no `.transform` field on FLUI's `PointerEvent` at all — a
+//!   separate, undocumented gap, out of scope for this file. Each case below
+//!   asserts only the `down` event's localized `position`, the minimum
+//!   surface that proves (or disproves) the transform-stack composition this
+//!   file exists to pin down.
+//!
+//! Widget → render-object mapping:
+//! - `Listener` → `RenderListener`
+//!   (`crates/flui-objects/src/interaction/listener.rs`)
+//! - `Center` → `RenderCenter`, `Transform` → `RenderTransform`
+//!
+//! Divergence: FLUI's `Transform::alignment` defaults to `Alignment::CENTER`
+//! where Flutter's bare `Transform(transform:, origin:)` constructor
+//! contributes no pivot at all when both `alignment` and `origin` are left
+//! unset (documented at `crates/flui-widgets/src/layout/transform.rs:14-24`).
+//! Every case below that uses `Transform` sets `.alignment(Alignment::TOP_LEFT)`
+//! explicitly — `TOP_LEFT`'s `alongSize` contributes `(0, 0)`, matching
+//! Flutter's null-origin default exactly — so the pivot lands at the box's
+//! own local origin, as upstream.
+//!
+//! # Why this file exists
+//!
+//! `crates/flui-widgets/tests/parity/transform_test.rs` covers hit/miss
+//! (whether a `Transform`-nested target is hit at all) extensively but never
+//! asserts the *position* a `Listener` callback receives once it fires — a
+//! render/layout defect in the hit-test transform-stack composition (see
+//! `crates/flui-interaction/src/routing/hit_test.rs`'s `HitTestResult`
+//! transform stack, fixed alongside this file) left the RECORDED position
+//! wrong for any ancestor chain that mixes a paint offset with a
+//! non-commuting matrix transform (scale, rotation), while leaving hit/miss
+//! itself unaffected (descent computes its own coordinates independently of
+//! the recorded bookkeeping transform). The first case here is
+//! translation-only and already passed before that fix — kept as the control
+//! case proving the defect needs a non-commuting ancestor to surface, not as
+//! a regression risk in isolation.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use flui_interaction::events::PointerEventExt as _;
+use flui_types::Color;
+use flui_widgets::prelude::*;
+
+use crate::harness;
+
+const TOLERANCE: f32 = 1e-3;
+
+fn assert_close(actual: (f32, f32), expected: (f32, f32), what: &str) {
+    assert!(
+        (actual.0 - expected.0).abs() < TOLERANCE && (actual.1 - expected.1).abs() < TOLERANCE,
+        "{what}: expected ({:.4}, {:.4}), got ({:.4}, {:.4})",
+        expected.0,
+        expected.1,
+        actual.0,
+        actual.1,
+    );
+}
+
+/// A hit-testable 100×100 leaf — `ColoredBox` wraps a childless `SizedBox` so
+/// the box actually hit-tests true (a bare `SizedBox` with no child does not;
+/// see `crates/flui-objects/src/layout/constrained_box.rs:130-139`).
+fn target() -> ColoredBox {
+    ColoredBox::new(Color::rgb(255, 0, 0)).child(SizedBox::new(100.0, 100.0))
+}
+
+/// The `dx`/`dy` of a locally-transformed position, recorded by a callback
+/// and readable back by the test.
+type RecordedPosition = Rc<Cell<Option<(f32, f32)>>>;
+
+/// A `Listener` recording the `dx`/`dy` of the position its `on_pointer_down`
+/// receives, plus a handle to read it back.
+fn recording_listener() -> (RecordedPosition, Listener) {
+    let recorded = Rc::new(Cell::new(None));
+    let probe = Rc::clone(&recorded);
+    let listener = Listener::new().on_pointer_down(move |event: &PointerEvent| {
+        let position = event.position();
+        probe.set(Some((position.dx.get(), position.dy.get())));
+    });
+    (recorded, listener)
+}
+
+/// A delivered pointer-down event carries the position local to the
+/// `Listener` that receives it, not the raw global dispatch position —
+/// translation-only ancestry.
+///
+/// Flutter parity: `'simple offset for touch/signal'`. `Center` places the
+/// 100×100 target at `((800-100)/2, (600-100)/2) = (350, 250)` on the
+/// `harness::screen()` 800×600 surface; its center is global `(400, 300)`.
+/// The `Listener`'s own local center is `(50, 50)`.
+///
+/// This case is translation-only (`with_paint_offset` is the only transform
+/// pushed): the composition-order defect this file targets needs a second,
+/// non-commuting part on the stack to surface (see the module doc), so this
+/// passes both before and after the fix. It stays as the control case: if
+/// THIS one goes red, the regression is somewhere else entirely.
+#[test]
+fn a_delivered_event_carries_the_receivers_local_position() {
+    let (recorded, listener) = recording_listener();
+
+    let laid = harness::pump_widget(
+        Center::new().child(listener.child(target())),
+        harness::screen(),
+    );
+
+    laid.dispatch_pointer_down(400.0, 300.0);
+
+    let local = recorded.get().expect("on_pointer_down must have fired");
+    assert_close(local, (50.0, 50.0), "translation-only local position");
+    assert_ne!(
+        local,
+        (400.0, 300.0),
+        "the recorded position must be LOCAL to the Listener, not the raw dispatch position"
+    );
+}
+
+/// A scaled AND offset ancestor chain must still localise the delivered
+/// position to the `Listener`'s own box.
+///
+/// Flutter parity: `'scaled and offset for touch/signal'`
+/// (`listener_test.dart`). `Center(Transform(scale(2))(Listener(Container(100×100))))`:
+/// `Transform`'s own laid-out size equals its child's untransformed size
+/// (100×100 — the transform affects paint/hit-test, not layout), so `Center`
+/// places it at `(350, 250)`, same as case 1 — the fixed point the scale
+/// pivots around (`Alignment::TOP_LEFT`'s `alongSize` is `(0, 0)`, matching
+/// Flutter's null-origin default). The painted container's own local center
+/// `(50, 50)` therefore lands at the global point
+/// `(350, 250) + 2 * (50, 50) = (450, 350)`.
+///
+/// RED before the fix: the pre-fix `HitTestResult` transform stack composes
+/// this two-level (offset, scale) chain in the wrong order — left-multiplying
+/// FORWARD parts and inverting once yields `inv(scale)·inv(offset)` where the
+/// correct global→local mapping needs `inv(offset)·inv(scale)`. The two
+/// coincide only when every part commutes (pure translations, case 1); they
+/// do not here, so the recorded local position is wrong.
+#[test]
+fn a_scaled_and_offset_ancestor_localises_the_delivered_position() {
+    let (recorded, listener) = recording_listener();
+
+    let laid = harness::pump_widget(
+        Center::new().child(
+            Transform::scale(2.0, 2.0)
+                .alignment(Alignment::TOP_LEFT)
+                .child(listener.child(target())),
+        ),
+        harness::screen(),
+    );
+
+    laid.dispatch_pointer_down(450.0, 350.0);
+
+    let local = recorded.get().expect("on_pointer_down must have fired");
+    assert_close(
+        local,
+        (50.0, 50.0),
+        "a scaled+offset ancestor must still localise to the Listener's own 100x100 box",
+    );
+}
+
+/// A rotated AND offset ancestor chain must still localise the delivered
+/// position to the `Listener`'s own box.
+///
+/// Flutter parity: `'rotated for touch/signal'` (`listener_test.dart`).
+/// Upstream dispatches at `downPosition = center + (10, 5)` and states
+/// directly that `down.localPosition == Offset(50, 50) + Offset(5, -10) ==
+/// (55, 40)` — Flutter's own quoted answer, not re-derived here. Rather than
+/// hand-compute the rotated GLOBAL dispatch point (risking an independent
+/// sign/handedness error unrelated to the bug under test), this forward-maps
+/// that quoted local answer through the exact matrix the pipeline pushes
+/// (`RenderTransform::hit_test_transform`, proven identical to
+/// `paint_transform` by its own `paint_and_hit_test_share_one_transform` unit
+/// test) to get the global dispatch point, then asserts the round trip
+/// recovers Flutter's local answer.
+///
+/// RED before the fix: same composition-order defect as the scaled case —
+/// rotation does not commute with the outer `Center` offset either.
+///
+/// # What this does NOT prove
+///
+/// Because `global_down` is derived by forward-mapping Flutter's own quoted
+/// local answer through this same rotation matrix, the round trip is
+/// tautological for ANY invertible rotation `R`: forward-map by `R`, then
+/// localise by `R`'s inverse, always recovers the starting point, regardless
+/// of whether `R`'s sign/handedness actually matches Flutter's rotation
+/// convention. This case genuinely detects composition-ORDER bugs (offset
+/// and rotation folded in the wrong sequence) — it went red before the fix
+/// for exactly that reason — but it cannot by itself catch a wrong rotation
+/// sign or handedness relative to Flutter, because the dispatch point it
+/// tests against was computed from FLUI's own matrix, not from an
+/// independently-derived global point the way upstream's hardcoded
+/// `downPosition = center + (10, 5)` is.
+#[test]
+fn a_rotated_ancestor_localises_the_delivered_position() {
+    let (recorded, listener) = recording_listener();
+
+    let laid = harness::pump_widget(
+        Center::new().child(
+            Transform::new(Matrix4::rotation_z(std::f32::consts::FRAC_PI_2))
+                .alignment(Alignment::TOP_LEFT)
+                .child(listener.child(target())),
+        ),
+        harness::screen(),
+    );
+
+    // Same pivot as case 2: Transform's untransformed 100x100 box is centered
+    // by `Center` on the 800x600 screen at (350, 250).
+    let pivot = (350.0_f32, 250.0_f32);
+    let local_down = (55.0_f32, 40.0_f32); // Flutter's own quoted local answer.
+    let forward = Matrix4::rotation_z(std::f32::consts::FRAC_PI_2);
+    let (dx, dy) = forward.transform_point(px(local_down.0), px(local_down.1));
+    let global_down = (pivot.0 + dx.get(), pivot.1 + dy.get());
+
+    laid.dispatch_pointer_down(global_down.0, global_down.1);
+
+    let local = recorded.get().expect("on_pointer_down must have fired");
+    assert_close(
+        local,
+        local_down,
+        "a rotated+offset ancestor must localise back to Flutter's own quoted local position",
+    );
+}


### PR DESCRIPTION
## The defect

Flutter pushes **inverse** matrices onto the hit-test transform stack — `box.dart:805` inverts via `Matrix4.tryInvert` before pushing, `:839` pushes `-offset` — and folds them by left-multiplication, so the composed result is already global→local.

FLUI pushed **forward** matrices and inverted the product once at delivery. That yields `inv(A)·inv(B)` where global→local needs `inv(B)·inv(A)` — equal only when the parts commute, i.e. translation-only paths.

Hit/miss was unaffected: the descent computes child positions independently. Only the recorded `HitTestEntry.transform` was wrong, so a `Listener` under a scaled or rotated ancestor received a meaningless local position.

**Why it survived:** both existing localization tests are translation-only, and translations commute. Flutter's own `'scaled for touch/signal'` uses `Align(topLeft)`, where the zero offset makes the composition order unobservable — porting it 1:1 would have *certified* the bug.

## Red → green

Reproduced by stashing only the production files and keeping the new tests:

| case | before | after |
|---|---|---|
| `a_delivered_event_carries_the_receivers_local_position` (translation-only control) | pass | pass |
| `a_scaled_and_offset_ancestor_localises_the_delivered_position` | **fail** — expected `(50,50)`, got `(-125,-75)` | pass |
| `a_rotated_ancestor_localises_the_delivered_position` | **fail** — expected `(55,40)`, got `(-45,-560)` | pass |

`(-125,-75)` matches a hand calculation made during planning, before any code was written.

## The fix

Push what Flutter pushes. `with_paint_offset` negates internally; `hit_test_subtree` pushes the inverted `hit_test_transform`; the delivery-time inversion is dropped. `dispatch_scroll` carried the same double inversion and is fixed with it.

`with_paint_transform` now mirrors `addWithPaintTransform` and inverts internally too. The raw `push_offset`/`push_transform` primitives keep verbatim semantics and now document the caller-must-invert contract that was missing — that gap is how the bug entered.

Adds `Matrix4::is_invertible` and expresses `try_inverse` in terms of it, so the three sites that only probed invertibility no longer compute and discard a full 4×4 inverse per hit-test entry per pointer event — and probe and inversion cannot disagree on a borderline matrix.

## Parity corpus

Ports Flutter's pointer hit-test corpus for `Listener` / `AbsorbPointer` / `IgnorePointer` — none had a parity file before, and `IgnorePointer` had no widget-level hit-test coverage anywhere. 13 routing/blocking cases plus 3 delivered-local-position cases.

Every case cites tag `3.44.0`. Not-ported cases are named with reasons: `absorb_pointer_test.dart` **1/4** (3 semantics cases are Phase 3), `listener_test.dart` **4/8** (hover-from-touch duplicates an existing test bar the device kind; two `debugFillProperties` are diagnostics; `'scaled for touch/signal'` has a zero offset and so cannot observe composition order).

## Known gaps — documented, not fixed

- The ctx-level `BoxHitTestContext` stack is discarded by `hit_test_raw`, so `RenderFractionalTranslation` and `RenderFlow` still deliver un-localized positions.
- The sliver walk pushes no transform — a `Listener` inside a scrolled sliver is un-localized.
- A near-singular (not exactly zero determinant) transform is not guaranteed to be skipped: determinants compose multiplicatively, so a large-determinant ancestor can lift the product back above `f32::EPSILON`.
- FLUI omits Flutter's `removePerspectiveTransform` before inverting (no widget constructs a perspective transform today).
- Flutter refuses the hit outright on a non-invertible transform; FLUI keeps the entry and skips delivery.

## Gates

parity 441 · workspace 8023 (`--exclude flui-platform`) · doc-tests 170 · `clippy --workspace --all-targets -D warnings` · `fmt --check` · `port-check` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117t1jX2FFcCzP3YBLoQB94
