### PR TITLE
chore(justfile): wire the rustdoc gate into `just ci`

### DIFF
--- a/justfile
+++ b/justfile
@@ -234,7 +234,7 @@ doc-open:
 [group("quality")]
 [doc("Build rustdoc with -D warnings (CI gate)")]
 doc-strict:
-    RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+    RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked --document-private-items
 
 [group("quality")]
 [doc("Check docs/justfile crate inventories against Cargo metadata")]
@@ -388,8 +388,8 @@ watch-test crate="":
 #   just deny             (advisories / bans / licenses / sources)
 #   just miri             (nightly UB check, narrow scope — see its comment)
 [group("ci")]
-[doc("Run local CI gates (fmt-check + inventory + port-check + clippy + test + doctests)")]
-ci: fmt-check inventory-check port-check clippy test-ci test-doc
+[doc("Run local CI gates (fmt-check + inventory + port-check + clippy + test + doctests + rustdoc)")]
+ci: fmt-check inventory-check port-check clippy test-ci test-doc doc-strict
 
 # =============================================================================
 # Maintenance


### PR DESCRIPTION
CI's `doc` job is merge-blocking, but `just ci` never ran it — so a local "full gate" run could be green while the PR failed.

That is not hypothetical: it happened on #460. A public doc comment linked a private item (`HitTestEntry::transform` → `HitTestResult::last_transform`), every local gate passed, and CI caught it.

The `doc-strict` recipe already existed and, verified by re-introducing the bad link, **already catches that error** — it simply was not in `ci`'s dependency list. This adds it, and aligns its flags with the workflow (`--locked --document-private-items`) so the local gate runs the same command CI does instead of an approximation.

Before:
```
ci: fmt-check inventory-check port-check clippy test-ci test-doc
doc-strict:
    RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
```
After:
```
ci: fmt-check inventory-check port-check clippy test-ci test-doc doc-strict
doc-strict:
    RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked --document-private-items
```

`just doc-strict` exits 0 on current `main`, so this does not turn the local gate red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117t1jX2FFcCzP3YBLoQB94
