### PR TITLE
fix(rendering): record the paint offset on the sliver hit-test walk

### DIFF
--- a/crates/flui-interaction/docs/HIT_TESTING.md
+++ b/crates/flui-interaction/docs/HIT_TESTING.md
@@ -86,6 +86,36 @@ the event is transformed into that entry's local coordinate space.
 Non-invertible transforms compose to a singular matrix and are skipped at
 delivery.
 
+### Sliver child transforms
+
+The sliver walk (`PipelineOwner::hit_test_subtree_impl`/
+`hit_test_sliver_subtree_impl`, `crates/flui-rendering/src/pipeline/owner/accessors.rs`)
+descends through both sliver→sliver and sliver→box edges. Each edge decides
+independently whether to push a child offset onto the `HitTestResult`
+transform stack, governed by one rule: **push iff the position handed to the
+child was moved into the child's own frame.**
+
+- Sliver→sliver, ordinary path: the position is converted from the parent's
+  main-axis coordinates into the child's via
+  `sliver_hit_position_minus_paint_offset`, so it pushes.
+- Sliver→sliver, override path: an override caller (the sole supplier today
+  is `RenderSliverOffstage::hit_test`, a transparent passthrough) already
+  hands back a sliver-local position and never repositions its child, so
+  nothing is pushed — asserted by a `debug_assert!` on the child's committed
+  offset being `Offset::ZERO`, so a future supplier with a nonzero offset
+  fails loudly instead of silently delivering a wrong position.
+- Sliver→box, both paths: `box_hit_offset_from_sliver_position` always
+  decomposes the main-axis position into box-local coordinates, override or
+  not, so both push.
+
+This matches Flutter, which has no override-position concept for slivers at
+all — every `hitTestChildren` override both repositions and pushes in the
+same call: `RenderSliverHelpers::hitTestBoxChild` and
+`RenderSliverPadding::hitTestChildren` (`rendering/sliver.dart`,
+`rendering/sliver_padding.dart`) always route through
+`SliverHitTestResult::addWithAxisOffset`, which unconditionally pushes
+`paintOffset` when it is non-null.
+
 ## HitTestBehavior
 
 `HitTestBehavior` controls whether a render object contributes itself to the hit
@@ -100,11 +130,11 @@ is leaf-first.
 
 ## Known gaps (not this document's transform-stack fix, tracked separately)
 
-Two call sites push nothing onto the `HitTestResult` transform stack that
-this document describes, so a `Listener` under them receives an
+One call site still pushes nothing onto the `HitTestResult` transform stack
+that this document describes, so a `Listener` under it receives an
 un-localized position — the same class of bug the `with_paint_offset`/
-`with_paint_transform` fix above addresses, just not reachable through
-those two paths yet:
+`with_paint_transform` fix above addresses, just not reachable through this
+path yet:
 
 - `crates/flui-rendering/src/context/hit_test.rs:189-225` — the ctx-level
   `push_offset`/`push_transform`/`with_transform` feed a per-node
@@ -114,10 +144,9 @@ those two paths yet:
   (`crates/flui-objects/src/layout/fractional_translation.rs:251`) and
   `RenderFlow` (`crates/flui-objects/src/layout/flow.rs:395`) deliver
   un-localized positions today.
-- `crates/flui-rendering/src/pipeline/owner/accessors.rs:820-901` — the
-  sliver walk pushes nothing; `box_hit_offset_from_sliver_position` crosses
-  sliver→box without a `with_paint_offset`, so a `Listener` inside a
-  scrolled sliver gets an un-localized position.
+
+The sliver walk's equivalent gap (`accessors.rs`, sliver→box edge skipping
+the transform-stack push) is fixed — see "Sliver child transforms" above.
 
 ## Tests
 

--- a/crates/flui-rendering/src/context/hit_test.rs
+++ b/crates/flui-rendering/src/context/hit_test.rs
@@ -164,25 +164,38 @@ where
     // CHILD TESTING
     // ════════════════════════════════════════════════════════════════════════
 
-    /// Tests a child at a caller-supplied position, bypassing the
-    /// transform-stack push.
+    /// Tests a child at a caller-supplied position.
     ///
-    /// This does NOT push anything onto the driver-level `HitTestResult`
-    /// transform stack — the caller is asserting that `position` is
-    /// already local to the child (no reframing happened), so there is
-    /// nothing to push. That is only sound when the child is committed at
-    /// `Offset::ZERO` (e.g. a transparent passthrough that never
-    /// repositions its child).
+    /// # Caller contract
     ///
-    /// If the caller DOES move `position` into the child's own frame, this
-    /// method alone leaves that offset un-recorded, and pushing it via
-    /// `push_offset`/`with_transform` on this ctx does not fix that either
-    /// today — see the ctx-level transform-stack gap tracked in
-    /// `crates/flui-interaction/docs/HIT_TESTING.md` ("Known gaps"). Prefer
+    /// `position` must ALREADY be local to the child: this method hands it
+    /// over verbatim, so any reframing the caller performed is invisible
+    /// here. Whether the driver records that reframing on the
+    /// `HitTestResult` transform stack is decided by the walk, not by this
+    /// method — and today the walk does not push for every parent/child
+    /// pairing:
+    ///
+    /// - box parent → any child, and sliver parent → sliver child: the
+    ///   driver pushes nothing on this path. Sound only when the child is
+    ///   committed at `Offset::ZERO` (a transparent passthrough that never
+    ///   repositions its child); a nonzero offset here silently yields an
+    ///   un-localized position, and the sliver walk carries a
+    ///   `debug_assert!` for exactly that.
+    /// - sliver parent → box child: the driver DOES push the child's paint
+    ///   offset, because crossing into a box frame always decomposes the
+    ///   position into box-local coordinates.
+    ///
+    /// Do not rely on that split. Prefer
     /// [`hit_test_child_at_layout_offset`](Self::hit_test_child_at_layout_offset)
-    /// whenever the child has a real laid-out offset — it resolves and
-    /// pushes that offset through the driver-level walk and cannot
-    /// silently deliver an un-localized position.
+    /// whenever the child has a real laid-out offset — it lets the driver
+    /// resolve and push the offset uniformly and cannot silently deliver an
+    /// un-localized position.
+    ///
+    /// Pushing the offset yourself via this context's `push_offset` /
+    /// `with_transform` does not help: the ctx-level transform stack is
+    /// discarded before it reaches `HitTestEntry.transform` — see the
+    /// "Known gaps" section of
+    /// `crates/flui-interaction/docs/HIT_TESTING.md`.
     pub fn hit_test_child(
         &mut self,
         index: usize,

--- a/crates/flui-rendering/src/context/hit_test.rs
+++ b/crates/flui-rendering/src/context/hit_test.rs
@@ -164,7 +164,25 @@ where
     // CHILD TESTING
     // ════════════════════════════════════════════════════════════════════════
 
-    /// Tests a child for hits with position transformation.
+    /// Tests a child at a caller-supplied position, bypassing the
+    /// transform-stack push.
+    ///
+    /// This does NOT push anything onto the driver-level `HitTestResult`
+    /// transform stack — the caller is asserting that `position` is
+    /// already local to the child (no reframing happened), so there is
+    /// nothing to push. That is only sound when the child is committed at
+    /// `Offset::ZERO` (e.g. a transparent passthrough that never
+    /// repositions its child).
+    ///
+    /// If the caller DOES move `position` into the child's own frame, this
+    /// method alone leaves that offset un-recorded, and pushing it via
+    /// `push_offset`/`with_transform` on this ctx does not fix that either
+    /// today — see the ctx-level transform-stack gap tracked in
+    /// `crates/flui-interaction/docs/HIT_TESTING.md` ("Known gaps"). Prefer
+    /// [`hit_test_child_at_layout_offset`](Self::hit_test_child_at_layout_offset)
+    /// whenever the child has a real laid-out offset — it resolves and
+    /// pushes that offset through the driver-level walk and cannot
+    /// silently deliver an un-localized position.
     pub fn hit_test_child(
         &mut self,
         index: usize,
@@ -174,9 +192,11 @@ where
     }
 
     /// Tests a child at its laid-out position (`RenderState.offset`)
-    /// — the parent supplies no offset, the driver resolves it. THE
-    /// way to hit-test children positioned during layout; parents no
-    /// longer mirror offsets in their own fields.
+    /// — the parent supplies no offset, the driver resolves it and pushes
+    /// it onto the transform stack. THE safe way to hit-test children
+    /// positioned during layout; parents no longer mirror offsets in their
+    /// own fields, and unlike [`hit_test_child`](Self::hit_test_child) this
+    /// cannot forget the push.
     pub fn hit_test_child_at_layout_offset(&mut self, index: usize) -> bool {
         self.inner.hit_test_child_at_layout_offset(index)
     }

--- a/crates/flui-rendering/src/pipeline/owner/accessors.rs
+++ b/crates/flui-rendering/src/pipeline/owner/accessors.rs
@@ -869,32 +869,65 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
             let Some(child_node) = self.render_tree.get(child_id) else {
                 return false;
             };
+            // Rule for whether this closure pushes the child's paint offset
+            // onto the `HitTestResult` transform stack: push iff the
+            // position handed to the child below was moved into the
+            // child's own frame. Flutter parity:
+            // `RenderSliverHelpers::hitTestBoxChild` (`rendering/sliver.dart`)
+            // and `RenderSliverPadding::hitTestChildren`
+            // (`rendering/sliver_padding.dart`) both always push
+            // `paintOffset` via `SliverHitTestResult::addWithAxisOffset`
+            // regardless of how the caller derived the position, because
+            // Flutter's sliver protocol has no override-position concept —
+            // every call site both repositions and pushes.
             if child_node.as_sliver().is_some() {
-                // Explicit positions are already in child sliver coordinates.
-                // The layout-offset fallback starts from physical paint data.
-                let child_position = match override_pos {
-                    Some(position) => position,
-                    None => Self::sliver_hit_position_minus_paint_offset(
+                if let Some(child_position) = override_pos {
+                    // NOT moved into a new frame: an override caller already
+                    // hands back sliver-local coordinates. Holds today only
+                    // because the sole workspace supplier
+                    // (`RenderSliverOffstage::hit_test`) is a transparent
+                    // passthrough that never repositions its child.
+                    debug_assert_eq!(
+                        child_node.offset(),
+                        Offset::ZERO,
+                        "sliver hit-test override skips the transform-stack push, which is \
+                         only sound while the child's committed paint offset is zero; a \
+                         supplier with a nonzero offset must route through the non-override \
+                         path so the offset gets pushed"
+                    );
+                    self.hit_test_sliver_subtree(child_id, child_position, result)
+                } else {
+                    let child_offset = child_node.offset();
+                    let child_position = Self::sliver_hit_position_minus_paint_offset(
                         constraints,
                         &geometry,
                         child_node,
                         position,
-                        child_node.offset(),
-                    ),
-                };
-                self.hit_test_sliver_subtree(child_id, child_position, result)
+                        child_offset,
+                    );
+                    result.with_paint_offset(child_offset, |result| {
+                        self.hit_test_sliver_subtree(child_id, child_position, result)
+                    })
+                }
             } else if let Some(child_entry) = child_node.as_box() {
                 let Some(child_size) = child_entry.state().geometry() else {
                     return false;
                 };
+                // Moved into the child's own box frame in both branches:
+                // `box_hit_offset_from_sliver_position` always decomposes
+                // into box-local coordinates, override or not. Both push.
+                let child_offset = child_node.offset();
+                let child_main_position = override_pos.unwrap_or(position);
                 let child_position = Self::box_hit_offset_from_sliver_position(
                     constraints,
                     &geometry,
                     child_size,
-                    override_pos.unwrap_or(position),
-                    child_node.offset(),
+                    child_main_position,
+                    child_offset,
                 );
-                self.hit_test_subtree(child_id, child_position, result)
+                result.with_paint_offset(child_offset, |result| {
+                    self.hit_test_subtree(child_id, child_position, result)
+                })
             } else {
                 false
             }

--- a/crates/flui-widgets/tests/scroll.rs
+++ b/crates/flui-widgets/tests/scroll.rs
@@ -8,11 +8,14 @@
 //! 5. `ScrollController::animate_to` (ADR-0037) — curve-driven animation,
 //!    grab-to-cancel, and jump_to-cancels-in-flight.
 
+use std::cell::Cell;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::common::{LaidOut, lay_out, size, tight};
+use crate::common::{LaidOut, lay_out, offset, size, tight};
 use flui_animation::{Curves, Vsync};
+use flui_interaction::events::{PointerEvent, PointerEventExt as _};
 use flui_rendering::constraints::BoxConstraints;
 use flui_types::Color;
 use flui_types::geometry::px;
@@ -20,7 +23,7 @@ use flui_view::prelude::StatelessView;
 use flui_view::{BuildContext, IntoView, ViewExt};
 use flui_widgets::{
     BouncingScrollPhysics, ClampingScrollPhysics, ColoredBox, CustomScrollView, GestureDetector,
-    GridView, ListView, ScrollController, ScrollMetrics, ScrollPhysics, Scrollable,
+    GridView, ListView, Listener, ScrollController, ScrollMetrics, ScrollPhysics, Scrollable,
     SharedScrollPhysics, SingleChildScrollView, SizedBox, SliverFixedExtentList, VsyncScope,
 };
 
@@ -1930,5 +1933,416 @@ fn refresh_indicator_finish_dismisses_spinner() {
     assert!(
         !refresh_ctrl.is_refreshing(),
         "spinner must be gone (is_refreshing=false) after finish() is called"
+    );
+}
+
+// ============================================================================
+// Hit-test transform-stack composition through the sliver hit-test walk
+// ============================================================================
+//
+// `PipelineOwner::hit_test_sliver_subtree` computes each child's position and
+// recurses into it, but (before the fix this section pins down) never pushed
+// the paint offset it consumed onto the `HitTestResult` transform stack --
+// unlike the box-side walk, which does for `RenderBox` ancestors
+// (`crates/flui-rendering/src/pipeline/owner/accessors.rs`). A `Listener`
+// living anywhere below a sliver therefore received the raw, un-localized
+// GLOBAL dispatch position instead of one local to its own box -- wrong for
+// any sliver whose child paints at a nonzero offset, the common case for a
+// scrolled list.
+//
+// Flutter's own regression test for the same class of bug --
+// `'SliverMainAxisGroup pointer event positions'`
+// (`packages/flutter/test/widgets/sliver_main_axis_group_test.dart`, tag
+// `3.44.0`, filed as flutter/flutter#173029) -- asserts
+// `TapDownDetails.localPosition` stays scroll-correct through nested slivers.
+// FLUI has no `SliverMainAxisGroup` yet, so these are non-parity regression
+// tests reproducing the same class of defect through the sliver widgets FLUI
+// does have: `ListView` (the sliver->box leg, under a real scroll offset,
+// vertical and horizontal), `SliverPadding` wrapping a `SliverToBoxAdapter`
+// (the sliver->sliver leg), and a reversed `AxisDirection` (the sliver->box
+// leg's sign, not just its axis).
+
+const ROW_COLOR: Color = Color::rgb(200, 30, 30);
+
+/// The `dx`/`dy` local position a `Listener`'s `on_pointer_down` callback
+/// records, readable back by the test.
+type RecordedPosition = Rc<Cell<Option<(f32, f32)>>>;
+
+/// A `Listener` that records the local position its `on_pointer_down`
+/// callback receives into a fresh, independently readable cell.
+fn recording_listener() -> (RecordedPosition, Listener) {
+    let recorded = Rc::new(Cell::new(None));
+    let probe = Rc::clone(&recorded);
+    let listener = Listener::new().on_pointer_down(move |event: &PointerEvent| {
+        let position = event.position();
+        probe.set(Some((position.dx.get(), position.dy.get())));
+    });
+    (recorded, listener)
+}
+
+/// A hit-testable leaf of the given size: `ColoredBox` wraps a childless
+/// `SizedBox` so it actually hit-tests true -- a bare `SizedBox` does not.
+/// See `crates/flui-widgets/tests/parity/pointer_local_position_test.rs::target`
+/// for the same convention.
+fn hit_testable_leaf(width: f32, height: f32) -> ColoredBox {
+    ColoredBox::new(ROW_COLOR).child(SizedBox::new(width, height))
+}
+
+/// Builds `count` rows, each a `Listener` wrapping a `width x height`
+/// hit-testable leaf, alongside a `RecordedPosition` per row (same index).
+fn recording_rows(
+    count: usize,
+    width: f32,
+    height: f32,
+) -> (Vec<RecordedPosition>, Vec<flui_view::BoxedView>) {
+    let mut recorders = Vec::with_capacity(count);
+    let rows = (0..count)
+        .map(|_| {
+            let (recorded, listener) = recording_listener();
+            recorders.push(recorded);
+            listener.child(hit_testable_leaf(width, height)).boxed()
+        })
+        .collect();
+    (recorders, rows)
+}
+
+/// Asserts `actual` is within floating-point tolerance of `expected`.
+fn assert_local_position(actual: (f32, f32), expected: (f32, f32), what: &str) {
+    const TOLERANCE: f32 = 1e-3;
+    assert!(
+        (actual.0 - expected.0).abs() < TOLERANCE && (actual.1 - expected.1).abs() < TOLERANCE,
+        "{what}: expected ({:.4}, {:.4}), got ({:.4}, {:.4})",
+        expected.0,
+        expected.1,
+        actual.0,
+        actual.1,
+    );
+}
+
+/// A `Listener` inside a scrolled `ListView` row must receive a position
+/// local to its OWN box, not the raw global dispatch position.
+///
+/// 10 rows at 50px in a 120px-tall viewport (380px of real scroll range).
+/// Row 3 spans layout y=150..200; after scrolling by 100px it paints at
+/// screen y=50..100, so a tap at screen (100, 60) lands 10px into row 3's
+/// own box.
+#[test]
+fn scrolled_list_view_row_listener_receives_a_locally_transformed_position() {
+    let (recorders, rows) = recording_rows(10, 200.0, 50.0);
+
+    let controller = ScrollController::new();
+    let mut laid = lay_out(
+        ListView::new(50.0, rows).position(controller.position()),
+        tight(200.0, 120.0),
+    );
+
+    laid.dispatch_pointer_down(100.0, 25.0);
+    laid.dispatch_pointer_up(100.0, 25.0);
+    assert_local_position(
+        recorders[0]
+            .get()
+            .expect("row 0's on_pointer_down must have fired for the unscrolled tap"),
+        (100.0, 25.0),
+        "unscrolled tap on row 0",
+    );
+    for (index, recorder) in recorders.iter().enumerate().skip(1) {
+        assert!(
+            recorder.get().is_none(),
+            "only row 0 should have received the unscrolled tap; row {index} also fired"
+        );
+    }
+
+    controller.set_pixels(100.0);
+    laid.pump();
+
+    laid.dispatch_pointer_down(100.0, 60.0);
+    laid.dispatch_pointer_up(100.0, 60.0);
+    assert_local_position(
+        recorders[3]
+            .get()
+            .expect("row 3's on_pointer_down must have fired after scrolling by 100px"),
+        (100.0, 10.0),
+        "scrolled tap on row 3 must localize to its own box, not the raw global dispatch position",
+    );
+}
+
+/// The horizontal-axis sibling of
+/// [`scrolled_list_view_row_listener_receives_a_locally_transformed_position`]
+/// -- proves the sliver->box leg's offset decomposition picks the correct
+/// axis (`LeftToRight`) rather than only ever having been exercised on the
+/// vertical default.
+#[test]
+fn scrolled_horizontal_list_view_column_listener_receives_a_locally_transformed_position() {
+    use flui_widgets::prelude::Axis;
+
+    let (recorders, columns) = recording_rows(10, 50.0, 200.0);
+
+    let controller = ScrollController::new();
+    let mut laid = lay_out(
+        ListView::new(50.0, columns)
+            .scroll_direction(Axis::Horizontal)
+            .position(controller.position()),
+        tight(120.0, 200.0),
+    );
+
+    laid.dispatch_pointer_down(25.0, 100.0);
+    laid.dispatch_pointer_up(25.0, 100.0);
+    assert_local_position(
+        recorders[0]
+            .get()
+            .expect("column 0's on_pointer_down must have fired for the unscrolled tap"),
+        (25.0, 100.0),
+        "unscrolled tap on column 0",
+    );
+    for (index, recorder) in recorders.iter().enumerate().skip(1) {
+        assert!(
+            recorder.get().is_none(),
+            "only column 0 should have received the unscrolled tap; column {index} also fired"
+        );
+    }
+
+    controller.set_pixels(100.0);
+    laid.pump();
+
+    laid.dispatch_pointer_down(60.0, 100.0);
+    laid.dispatch_pointer_up(60.0, 100.0);
+    assert_local_position(
+        recorders[3]
+            .get()
+            .expect("column 3's on_pointer_down must have fired after scrolling by 100px"),
+        (10.0, 100.0),
+        "scrolled tap on column 3 must localize to its own box",
+    );
+}
+
+/// The sliver->sliver leg (`SliverPadding` wrapping a `SliverToBoxAdapter`)
+/// must localize too. FLUI has no `SliverMainAxisGroup` (the sliver Flutter's
+/// own regression test cited above uses), so this reproduces the
+/// sliver->sliver class of the defect through the nested-sliver widgets FLUI
+/// does have.
+///
+/// The first tap is unscrolled: `SliverPadding`'s consumed offset is a fixed
+/// 20px padding constant, deterministic and independent of scroll --
+/// isolating the sliver->sliver leg cleanly. The second tap scrolls PAST the
+/// padding (30px > the 20px padding), so the padding's own consumed offset
+/// drops to 0 and the `SliverToBoxAdapter`->box (sliver->box) leg picks up a
+/// nonzero one instead -- the same nested tree exercises both not-yet-fixed
+/// legs.
+///
+/// Both taps target the same `local_point` inside the leaf's own box; the
+/// global dispatch coordinate is derived from [`LaidOut::absolute_offset`],
+/// which sums committed PAINT offsets set by `perform_layout`/
+/// `position_child` -- entirely independent of the HIT-TEST transform-stack
+/// walk this test exists to check, so recovering `local_point` back out is
+/// not a tautology against the code under test.
+#[test]
+fn scrolled_nested_sliver_listener_receives_a_locally_transformed_position() {
+    use flui_widgets::{SliverPadding, SliverToBoxAdapter, Viewport};
+
+    let (recorded, listener) = recording_listener();
+    let content = listener.child(hit_testable_leaf(160.0, 200.0));
+
+    let controller = ScrollController::new();
+    let widget =
+        Viewport::new((SliverPadding::all(20.0).child(SliverToBoxAdapter::new().child(content)),))
+            .position(controller.position());
+
+    let mut laid = lay_out(widget, tight(200.0, 150.0));
+
+    let padding = laid.only_child(laid.root());
+    let adapter = laid.only_child(padding);
+    let listener = laid.only_child(adapter);
+    let local_point = (10.0_f32, 10.0_f32);
+
+    // Anchors the geometry independently of `absolute_offset`: a 20px
+    // uniform `SliverPadding` places its sliver child at (20, 20)
+    // (cross-axis padding.left, main-axis padding.top) regardless of
+    // scroll, so this can't pass merely because two accumulations of
+    // the same (possibly wrong) `node.offset()` agree with each other.
+    assert_eq!(
+        laid.offset(adapter),
+        offset(20.0, 20.0),
+        "SliverPadding::all(20.0) must place its child 20px in on both axes"
+    );
+    let listener_offset = laid.absolute_offset(listener);
+    laid.dispatch_pointer_down(
+        listener_offset.dx.get() + local_point.0,
+        listener_offset.dy.get() + local_point.1,
+    );
+    laid.dispatch_pointer_up(
+        listener_offset.dx.get() + local_point.0,
+        listener_offset.dy.get() + local_point.1,
+    );
+    assert_local_position(
+        recorded
+            .get()
+            .expect("on_pointer_down must have fired through the padding"),
+        local_point,
+        "sliver->sliver: tap must localize past the SliverPadding offset",
+    );
+
+    recorded.set(None);
+    controller.set_pixels(30.0); // past the 20px padding, into the content
+    laid.pump();
+
+    let listener_offset = laid.absolute_offset(listener);
+    laid.dispatch_pointer_down(
+        listener_offset.dx.get() + local_point.0,
+        listener_offset.dy.get() + local_point.1,
+    );
+    laid.dispatch_pointer_up(
+        listener_offset.dx.get() + local_point.0,
+        listener_offset.dy.get() + local_point.1,
+    );
+    assert_local_position(
+        recorded
+            .get()
+            .expect("on_pointer_down must have fired after scrolling past the padding"),
+        local_point,
+        "sliver->box (within a nested-sliver chain): tap must localize past the \
+         scroll-shifted content offset",
+    );
+}
+
+/// A reversed [`AxisDirection`] (`BottomToTop`) must not flip the localized
+/// sign the wrong way -- `box_hit_offset_from_sliver_position`'s
+/// `right_way_up` branch treats a reversed direction specially, and the
+/// hit-test transform-stack fix must compose with it correctly rather than
+/// only ever having been exercised in the (default) `TopToBottom` direction
+/// the other tests in this section use.
+///
+/// As with the nested-sliver case, the expected local position is derived
+/// from [`LaidOut::absolute_offset`] (paint, not hit-test), so no
+/// hand-derived reversed-axis arithmetic is load-bearing here.
+#[test]
+fn scrolled_reversed_list_row_listener_receives_a_locally_transformed_position() {
+    use flui_types::layout::AxisDirection;
+    use flui_widgets::Viewport;
+
+    let (recorders, rows) = recording_rows(10, 200.0, 50.0);
+
+    let controller = ScrollController::new();
+    let widget = Viewport::new((SliverFixedExtentList::new(50.0, rows),))
+        .axis_direction(AxisDirection::BottomToTop)
+        .position(controller.position());
+    let mut laid = lay_out(widget, tight(200.0, 120.0));
+
+    let list = laid.only_child(laid.root());
+    let row0 = laid.child(list, 0);
+    let local_point = (20.0_f32, 15.0_f32);
+
+    // Anchors the geometry independently of `absolute_offset`: with a
+    // 120px viewport and 50px rows, `BottomToTop` places row 0's top-left
+    // at physical dy = 120 - 50 = 70 unscrolled -- computed from first
+    // principles, not from summing the same `node.offset()` values the
+    // fix under test pushes.
+    let row0_offset = laid.absolute_offset(row0);
+    assert_eq!(
+        row0_offset,
+        offset(0.0, 70.0),
+        "reversed-axis (BottomToTop) row 0 must sit at physical dy = 70 unscrolled"
+    );
+    laid.dispatch_pointer_down(
+        row0_offset.dx.get() + local_point.0,
+        row0_offset.dy.get() + local_point.1,
+    );
+    laid.dispatch_pointer_up(
+        row0_offset.dx.get() + local_point.0,
+        row0_offset.dy.get() + local_point.1,
+    );
+    assert_local_position(
+        recorders[0]
+            .get()
+            .expect("row 0's on_pointer_down must have fired for the reversed-axis unscrolled tap"),
+        local_point,
+        "reversed-axis (BottomToTop), unscrolled",
+    );
+    recorders[0].set(None);
+
+    controller.set_pixels(20.0);
+    laid.pump();
+
+    // Scrolling 20px moves the viewport's visible window, shifting row 0's
+    // physical dy to 120 - 50 - (0 - 20) = 90.
+    let row0_offset = laid.absolute_offset(row0);
+    assert_eq!(
+        row0_offset,
+        offset(0.0, 90.0),
+        "reversed-axis (BottomToTop) row 0 must sit at physical dy = 90 after scrolling by 20px"
+    );
+    laid.dispatch_pointer_down(
+        row0_offset.dx.get() + local_point.0,
+        row0_offset.dy.get() + local_point.1,
+    );
+    laid.dispatch_pointer_up(
+        row0_offset.dx.get() + local_point.0,
+        row0_offset.dy.get() + local_point.1,
+    );
+    assert_local_position(
+        recorders[0]
+            .get()
+            .expect("row 0's on_pointer_down must have fired for the reversed-axis scrolled tap"),
+        local_point,
+        "reversed-axis (BottomToTop), scrolled by 20px",
+    );
+}
+
+/// The sliver->sliver override arm in `accessors.rs`'s `hit_child` closure
+/// (the `Some(child_position)` branch, guarded by a `debug_assert!` that the
+/// child's committed offset is zero) has no driver-level coverage anywhere
+/// else in the workspace. The sole supplier is
+/// `RenderSliverOffstage::hit_test`
+/// (`crates/flui-objects/src/sliver/sliver_offstage.rs`), which forwards its
+/// own main-axis position unchanged to a sliver child; its existing harness
+/// coverage (`flui-objects/tests/render_object_harness.rs`) is
+/// layout/geometry only, never a driven hit test.
+///
+/// Drives a hit through a non-offstage (`visible`) `SliverOffstage` wrapping
+/// a `SliverToBoxAdapter` and confirms the delivered local position, so the
+/// override branch is exercised end to end rather than only by the
+/// `debug_assert!` it carries.
+#[test]
+fn hit_through_a_visible_sliver_offstage_reaches_its_child_at_the_correct_position() {
+    use flui_widgets::{SliverOffstage, SliverToBoxAdapter, Viewport};
+
+    let (recorded, listener) = recording_listener();
+    let content = listener.child(hit_testable_leaf(160.0, 200.0));
+
+    let controller = ScrollController::new();
+    let widget =
+        Viewport::new((SliverOffstage::visible().child(SliverToBoxAdapter::new().child(content)),))
+            .position(controller.position());
+
+    let laid = lay_out(widget, tight(200.0, 150.0));
+
+    let offstage = laid.only_child(laid.root());
+    let adapter = laid.only_child(offstage);
+    let target = laid.only_child(adapter);
+    let local_point = (10.0_f32, 10.0_f32);
+
+    // A visible `SliverOffstage` is a transparent passthrough -- it never
+    // calls `position_child`, so this is the ACTUAL invariant the
+    // `debug_assert!` on the override arm depends on, not merely assumed.
+    assert_eq!(
+        laid.offset(adapter),
+        offset(0.0, 0.0),
+        "a visible SliverOffstage must not reposition its sliver child"
+    );
+
+    let target_offset = laid.absolute_offset(target);
+    laid.dispatch_pointer_down(
+        target_offset.dx.get() + local_point.0,
+        target_offset.dy.get() + local_point.1,
+    );
+    laid.dispatch_pointer_up(
+        target_offset.dx.get() + local_point.0,
+        target_offset.dy.get() + local_point.1,
+    );
+    assert_local_position(
+        recorded
+            .get()
+            .expect("on_pointer_down must have fired through the visible SliverOffstage"),
+        local_point,
+        "sliver->sliver override arm (RenderSliverOffstage): tap must localize to the child's own box",
     );
 }


### PR DESCRIPTION
## The defect

`hit_test_sliver_subtree_impl` computed each child's descent position and recursed, but never pushed anything onto the `HitTestResult` transform stack. `HitTestEntry.transform` therefore omitted every offset consumed while descending through slivers, so a `Listener` inside a scrolled sliver received the raw **global** pointer position instead of one local to its own box.

Tappable list rows are the everyday case: any handler that needs "where in this row did the user tap" got a meaningless number.

This is the sliver-side counterpart of #460's box-side composition fix, which named this gap as out of scope.

## Measured before the fix

| case | got | want |
|---|---|---|
| vertical `ListView`, scrolled 100, tap (100,60) on row 3 | `(100, 60)` | `(100, 10)` |
| horizontal, scrolled, tap on column 3 | `(60, 100)` | `(10, 100)` |
| nested `SliverPadding` | `(30, 30)` | `(10, 10)` |
| reversed axis (`BottomToTop`), **unscrolled** | `(20, 85)` | `(20, 15)` |

The reversed-axis case failing *even unscrolled* shows this was not merely a missing scroll offset — the walk recorded no frame change at all.

## The fix

Both recursion arms push the offset they consume, via `with_paint_offset` (which negates internally, per #460's convention that every level pushes its own inverse).

The sliver→box arm is a single path again. An earlier shape skipped the push when the caller supplied an override position, on the theory that such a caller places the child itself — but that arm feeds `child_node.offset()` into `box_hit_offset_from_sliver_position`, i.e. it *does* move the position into the child's frame, so the push is unconditionally correct there. The rule, now stated once: **push the child offset iff the position handed to the child was moved into the child's frame.**

The sliver→sliver override arm genuinely does not consume the offset and still skips. The invariant that makes it sound — the child is committed at `Offset::ZERO` — is now a `debug_assert!` rather than a sentence, and `HitTestContext::hit_test_child` documents that it bypasses the transform stack and points at the safe sibling `hit_test_child_at_layout_offset`. Exactly one caller supplies an override today (`RenderSliverOffstage`), safe only because of that zero offset; nothing but prose stopped the next one from re-arming the bug.

## Tests

Four cases — vertical, horizontal, nested-sliver, reversed-axis — each shown failing before the fix, plus a driven hit through a visible `SliverOffstage` that **pins** the zero-offset precondition rather than assuming it.

Row geometry is anchored on hardcoded values (70/90 physical `dy`, `(20,20)` for `SliverPadding::all(20)`) so the expectations do not rest on the same `node.offset()` accumulation the fix pushes — otherwise the tests would have been a self-consistency check between two accumulations of one quantity.

## Still open, untouched

The ctx-level `BoxHitTestContext` transform stack is discarded by `hit_test_raw`, so `RenderFractionalTranslation` and `RenderFlow` continue to deliver un-localized positions. Documented in `HIT_TESTING.md` under "Known gaps"; separate work.

## Gates

workspace 8028 · parity 441 · `clippy --workspace --all-targets -D warnings` · `fmt --check` · `port-check` · `doc-strict` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117t1jX2FFcCzP3YBLoQB94
