### PR TITLE
test: mount 103 integration tests that never ran, and guard the gap

### DIFF
--- a/crates/flui-binding/tests/main.rs
+++ b/crates/flui-binding/tests/main.rs
@@ -10,7 +10,17 @@
 //! flui-binding's integration tests do — both drive a per-test
 //! `HeadlessBinding` instance (no singletons, no env vars, no statics).
 
+#[path = "async_driver.rs"]
+mod async_driver;
 #[path = "controller_restart.rs"]
 mod controller_restart;
+#[path = "layout_builder_seam.rs"]
+mod layout_builder_seam;
 #[path = "long_press_via_pump_frame.rs"]
 mod long_press_via_pump_frame;
+#[path = "owner_scope.rs"]
+mod owner_scope;
+#[path = "post_frame_after_layout.rs"]
+mod post_frame_after_layout;
+#[path = "self_rescheduling_local_post_frame.rs"]
+mod self_rescheduling_local_post_frame;

--- a/crates/flui-platform/tests/main.rs
+++ b/crates/flui-platform/tests/main.rs
@@ -24,6 +24,8 @@ mod executor_tests;
 mod integration_template;
 #[path = "performance.rs"]
 mod performance;
+#[path = "window_callback_unwind.rs"]
+mod window_callback_unwind;
 #[path = "window_lifecycle.rs"]
 mod window_lifecycle;
 #[path = "window_modes.rs"]

--- a/crates/flui-rendering/tests/main.rs
+++ b/crates/flui-rendering/tests/main.rs
@@ -74,6 +74,8 @@ mod sliver_grid;
 mod sliver_hit_direction_matrix;
 #[path = "sliver_to_box_adapter.rs"]
 mod sliver_to_box_adapter;
+#[path = "transform_to.rs"]
+mod transform_to;
 #[path = "u21b_cyclic_intrinsic_query.rs"]
 mod u21b_cyclic_intrinsic_query;
 #[path = "u3c_lazy_sliver_contract.rs"]

--- a/crates/flui-widgets/tests/animated_builder_swap.rs
+++ b/crates/flui-widgets/tests/animated_builder_swap.rs
@@ -18,12 +18,10 @@
 //! `ChangeNotifier` swap is enough to drive the element-level bug without an
 //! `AnimationController`/`Vsync` in the loop.
 
-mod common;
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use common::{lay_out, tight};
+use crate::common::{lay_out, tight};
 use flui_foundation::{ChangeNotifier, Listenable, ListenerId};
 use flui_widgets::{AnimatedBuilder, SizedBox};
 

--- a/crates/flui-widgets/tests/exclude_focus.rs
+++ b/crates/flui-widgets/tests/exclude_focus.rs
@@ -1,12 +1,10 @@
 //! Public `ExcludeFocus` construction and focus-policy behavior.
 
-mod common;
-
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
 
-use common::{lay_out, loose};
+use crate::common::{lay_out, loose};
 use flui_interaction::FocusNode;
 use flui_widgets::prelude::*;
 

--- a/crates/flui-widgets/tests/future_builder.rs
+++ b/crates/flui-widgets/tests/future_builder.rs
@@ -16,13 +16,11 @@
 //! `'gracefully handles transition to other future'`,
 //! `'gracefully handles transition to null future'`).
 
-mod common;
-
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::task::{Context, Poll, Waker};
 use std::{rc::Rc, sync::Arc};
 
-use common::{lay_out, loose};
+use crate::common::{lay_out, loose};
 use flui_foundation::ConnectionState;
 use parking_lot::Mutex;
 

--- a/crates/flui-widgets/tests/hero_public.rs
+++ b/crates/flui-widgets/tests/hero_public.rs
@@ -18,13 +18,11 @@
 //! disappears mid-flight'` (`:1233`), `'Hero push transition interrupted by a pop'`
 //! (`:1063`), `'One route, two heroes, same tag, throws'` (`:1004` — FLUI logs).
 
-mod common;
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
-use common::{LaidOut, lay_out_animated, tight};
+use crate::common::{LaidOut, lay_out_animated, tight};
 use flui_animation::{Animatable, Vsync};
 use flui_geometry::Rect;
 use flui_rendering::pipeline::PipelineOwner;

--- a/crates/flui-widgets/tests/layout_builder.rs
+++ b/crates/flui-widgets/tests/layout_builder.rs
@@ -14,12 +14,10 @@
 //! `.flutter/packages/flutter/lib/src/widgets/layout_builder.dart`
 //! (`_RenderLayoutBuilder.performLayout`).
 
-mod common;
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use common::{lay_out, loose};
+use crate::common::{lay_out, loose};
 use flui_rendering::constraints::BoxConstraints;
 use flui_types::geometry::px;
 use flui_types::{Offset, Size};

--- a/crates/flui-widgets/tests/main.rs
+++ b/crates/flui-widgets/tests/main.rs
@@ -6,6 +6,8 @@ mod common;
 
 #[path = "absorb_pointer.rs"]
 mod absorb_pointer;
+#[path = "animated_builder_swap.rs"]
+mod animated_builder_swap;
 #[path = "animated_size.rs"]
 mod animated_size;
 #[path = "baseline.rs"]
@@ -30,6 +32,8 @@ mod custom_paint;
 mod custom_single_child_layout;
 #[path = "decorated_box.rs"]
 mod decorated_box;
+#[path = "exclude_focus.rs"]
+mod exclude_focus;
 #[path = "fade_transition.rs"]
 mod fade_transition;
 #[path = "fitted_box.rs"]
@@ -40,10 +44,14 @@ mod flex;
 mod flex_parent_data;
 #[path = "flow.rs"]
 mod flow;
+#[path = "future_builder.rs"]
+mod future_builder;
 #[path = "gesture_detector.rs"]
 mod gesture_detector;
 #[path = "gesture_detector_advanced.rs"]
 mod gesture_detector_advanced;
+#[path = "hero_public.rs"]
+mod hero_public;
 #[path = "image.rs"]
 mod image;
 #[path = "implicit_animations.rs"]
@@ -56,6 +64,8 @@ mod inherited_app;
 mod intrinsic_and_overflow;
 #[path = "layout.rs"]
 mod layout;
+#[path = "layout_builder.rs"]
+mod layout_builder;
 #[path = "lazy_grid.rs"]
 mod lazy_grid;
 #[path = "lazy_list.rs"]
@@ -68,12 +78,18 @@ mod listener;
 mod modifiers;
 #[path = "mouse_region.rs"]
 mod mouse_region;
+#[path = "navigator_public.rs"]
+mod navigator_public;
 #[path = "overflow_box.rs"]
 mod overflow_box;
+#[path = "post_frame_handle.rs"]
+mod post_frame_handle;
 #[path = "rich_text.rs"]
 mod rich_text;
 #[path = "rotation_transition.rs"]
 mod rotation_transition;
+#[path = "routes.rs"]
+mod routes;
 #[path = "scale_transition.rs"]
 mod scale_transition;
 #[path = "scroll.rs"]
@@ -82,6 +98,8 @@ mod scroll;
 mod semantics;
 #[path = "shrink_wrapping_viewport.rs"]
 mod shrink_wrapping_viewport;
+#[path = "slide_transition.rs"]
+mod slide_transition;
 #[path = "sliver_opacity.rs"]
 mod sliver_opacity;
 #[path = "spacer.rs"]
@@ -90,6 +108,8 @@ mod spacer;
 mod stack_positioned;
 #[path = "stateful.rs"]
 mod stateful;
+#[path = "stream_builder.rs"]
+mod stream_builder;
 #[path = "table.rs"]
 mod table;
 #[path = "text.rs"]

--- a/crates/flui-widgets/tests/navigator_public.rs
+++ b/crates/flui-widgets/tests/navigator_public.rs
@@ -18,13 +18,11 @@
 // tests are separate crates, so repeat it here.
 #![allow(clippy::arc_with_non_send_sync)]
 
-mod common;
-
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use common::{lay_out, loose};
+use crate::common::{lay_out, loose};
 use parking_lot::Mutex;
 
 // Exercise the public prelude import path.

--- a/crates/flui-widgets/tests/post_frame_handle.rs
+++ b/crates/flui-widgets/tests/post_frame_handle.rs
@@ -8,15 +8,13 @@
 //! The capability is acquired in `init_state` — a lifecycle hook, never `build`
 //! (port-check trigger #22) — and fired by the real `pump_frame` frame order.
 
-mod common;
-
 use std::cell::Cell;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
-use common::{lay_out, loose, tight};
+use crate::common::{lay_out, loose, tight};
 use flui_foundation::HasInstance;
 use flui_scheduler::Scheduler;
 use flui_view::prelude::*;
@@ -260,7 +258,7 @@ fn an_owner_local_post_frame_callback_observes_committed_geometry() {
     let observed = Arc::new(AtomicBool::new(false));
     let desired_width = Arc::new(AtomicUsize::new(32));
     let rebuild = Arc::new(Mutex::new(None));
-    let mut laid = common::lay_out_with_pipeline_owner(
+    let mut laid = crate::common::lay_out_with_pipeline_owner(
         LocalPostFrameProbe {
             pipeline: Arc::clone(&pipeline),
             observed_committed_geometry: Arc::clone(&observed),

--- a/crates/flui-widgets/tests/routes.rs
+++ b/crates/flui-widgets/tests/routes.rs
@@ -13,15 +13,13 @@
 //! `'Can push, pop, and replace in sequence'`. Expected values are read from
 //! `pages.dart` / `routes.dart`, not from running this code.
 
-mod common;
-
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use common::{lay_out_animated, tight};
+use crate::common::{lay_out_animated, tight};
 use flui_animation::Vsync;
 use flui_types::Color;
 use flui_widgets::prelude::*;

--- a/crates/flui-widgets/tests/slide_transition.rs
+++ b/crates/flui-widgets/tests/slide_transition.rs
@@ -3,13 +3,11 @@
 //! *current* animated offset and its `transform_hit_tests` flag, not a
 //! hardcoded snapshot or the render object's own default.
 
-mod common;
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use common::{lay_out, loose};
+use crate::common::{lay_out, loose};
 use flui_animation::ext::AnimatableExt;
 use flui_animation::{Animation, AnimationController, Tween};
 use flui_objects::TranslationFraction;

--- a/crates/flui-widgets/tests/stream_builder.rs
+++ b/crates/flui-widgets/tests/stream_builder.rs
@@ -12,8 +12,6 @@
 //! `'gracefully handles transition to other stream'`,
 //! `'gracefully handles transition to null stream'`).
 
-mod common;
-
 use std::collections::VecDeque;
 use std::pin::Pin;
 use std::rc::Rc;
@@ -21,7 +19,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::task::{Context, Poll, Waker};
 
-use common::{lay_out, loose};
+use crate::common::{lay_out, loose};
 use flui_foundation::ConnectionState;
 use flui_widgets::Stream;
 use parking_lot::Mutex;

--- a/scripts/check-workspace-inventory.sh
+++ b/scripts/check-workspace-inventory.sh
@@ -213,6 +213,79 @@ for package in workspace_packages:
     if raw_manifest.get("lints") != {"workspace": True}:
         errors.append(f"{rel} must set `[lints] workspace = true` (local or missing lint tables bypass workspace lints)")
 
+    # `autotests = false` disables Cargo's default `tests/*.rs` auto-discovery
+    # (commit 820a083c consolidated per-crate integration tests into one
+    # linked binary for build-time/disk reasons). The cost: a test file added
+    # to `tests/` afterward silently never runs unless something declares it
+    # — this bit the workspace for 11+ days across 5 crates before anyone
+    # noticed. Verify every top-level `tests/*.rs` file (excluding `main.rs`
+    # itself, and subdirectory module files like `tests/common/mod.rs` or
+    # `tests/parity/*`, which auto-discovery never touches either way) is
+    # reachable: either declared as its own `[[test]]` target, or `mod`/
+    # `#[path]`-mounted from a declared `[[test]]` target file. Usually that
+    # mounting file is `tests/main.rs`, but it does not have to be —
+    # `flui-objects` has no `tests/main.rs` and mounts a sibling file
+    # (`harness_snapshot.rs`) straight from its sole `[[test]]` target.
+    if raw_package.get("autotests") is False:
+        tests_dir = manifest.parent / "tests"
+        if tests_dir.is_dir():
+            test_targets = raw_manifest.get("test", [])
+            declared_test_paths = {
+                (manifest.parent / target["path"]).resolve()
+                for target in test_targets
+                if isinstance(target, dict) and target.get("path")
+            }
+
+            candidate_test_files = {
+                test_file.resolve()
+                for test_file in tests_dir.glob("*.rs")
+                if test_file.name != "main.rs"
+            }
+
+            mount_source_files = set(declared_test_paths)
+            main_rs = tests_dir / "main.rs"
+            if main_rs.exists():
+                mount_source_files.add(main_rs.resolve())
+
+            # `#[path = "foo.rs"]\nmod foo;` (the mount idiom every consolidated
+            # `tests/main.rs` in this workspace uses) — the explicit path is the
+            # ground truth for what file a `mod` statement resolves to.
+            path_mod_re = re.compile(
+                r'#\[path\s*=\s*"(?P<path>[^"]+)"\]\s*(?:pub\s+)?mod\s+(?P<name>\w+)\s*;'
+            )
+            # A bare `mod foo;` (no `#[path]`) resolves via Rust's default module
+            # resolution: relative to the *mounting file's own* directory. That
+            # default only lands back in `tests_dir` when the mounting file is
+            # `tests/main.rs` itself (a target file living in a subdirectory,
+            # like `flui-objects`' `render_object_harness.rs`, would resolve a
+            # bare `mod foo;` into a nonexistent subdirectory next to itself).
+            any_mod_re = re.compile(r"(?:^|\n)\s*(?:pub\s+)?mod\s+(?P<name>\w+)\s*;")
+
+            reachable_test_files: set[Path] = set()
+            for mount_source in mount_source_files:
+                if not mount_source.is_file():
+                    continue
+                mount_source_text = mount_source.read_text()
+                mount_source_dir = mount_source.parent
+                explicitly_pathed_names: set[str] = set()
+                for match in path_mod_re.finditer(mount_source_text):
+                    explicitly_pathed_names.add(match.group("name"))
+                    reachable_test_files.add((mount_source_dir / match.group("path")).resolve())
+                if mount_source_dir == tests_dir:
+                    for match in any_mod_re.finditer(mount_source_text):
+                        mod_name = match.group("name")
+                        if mod_name in explicitly_pathed_names:
+                            continue
+                        reachable_test_files.add((tests_dir / f"{mod_name}.rs").resolve())
+
+            orphaned_test_files = candidate_test_files - declared_test_paths - reachable_test_files
+            for orphan in sorted(orphaned_test_files):
+                errors.append(
+                    f"{orphan.relative_to(root)} is not reachable: `{name}` sets `autotests = false`, "
+                    "so this file needs its own `[[test]]` target in Cargo.toml, or a `mod`/`#[path]` "
+                    "mount in `tests/main.rs` (or whichever `[[test]]` target file mounts sibling test modules)"
+                )
+
 # Design-system decoupling contract (ADR-0028): core crates never depend on a
 # design system. `flui-material`/`flui-cupertino` depend downward on the
 # widgets substrate (see docs/FOUNDATIONS.md's layer DAG, L7 --> L6); the

--- a/scripts/check-workspace-inventory.sh
+++ b/scripts/check-workspace-inventory.sh
@@ -242,10 +242,20 @@ for package in workspace_packages:
                 if test_file.name != "main.rs"
             }
 
+            # Only DECLARED `[[test]]` targets may act as mount sources. An
+            # undeclared `tests/main.rs` is not compiled at all under
+            # `autotests = false`, so trusting its `mod` declarations would let
+            # this guard report every sibling as reachable while none of them
+            # run — the exact failure this check exists to catch, reproduced
+            # inside the check. Flag such a `main.rs` instead of reading it.
             mount_source_files = set(declared_test_paths)
             main_rs = tests_dir / "main.rs"
-            if main_rs.exists():
-                mount_source_files.add(main_rs.resolve())
+            if main_rs.exists() and main_rs.resolve() not in declared_test_paths:
+                errors.append(
+                    f"{main_rs.relative_to(root)} exists but is not a declared `[[test]]` target: "
+                    f"`{name}` sets `autotests = false`, so Cargo never compiles it and the "
+                    "modules it declares do not run. Declare it in Cargo.toml, or delete it"
+                )
 
             # `#[path = "foo.rs"]\nmod foo;` (the mount idiom every consolidated
             # `tests/main.rs` in this workspace uses) — the explicit path is the


### PR DESCRIPTION
## The defect

`autotests = false` — introduced when flui-widgets' 49 test binaries were collapsed into one `widgets_it` — means a file dropped into `tests/` **does not run** unless it is also mounted: as a `mod` in the crate's `tests/main.rs`, or as its own `[[test]]` target.

Nothing warns. The run stays green and the test count simply never rises. So every test file added after that consolidation was dead on arrival:

| crate | dead tests | files |
|---|---:|---|
| flui-widgets | 69 | `hero_public` 19, `navigator_public` 13, `routes` 8, `future_builder` 7, `stream_builder` 6, `layout_builder` 5, `animated_builder_swap` 4, `post_frame_handle` 4, `slide_transition` 2, `exclude_focus` 1 |
| flui-binding | 17 | `owner_scope` 6, `async_driver` 4, `post_frame_after_layout` 4, `layout_builder_seam` 2, `self_rescheduling_local_post_frame` 1 |
| flui-rendering | 11 | `transform_to` |
| flui-platform | 6 | `window_callback_unwind` |

**All 103 pass** once mounted — no rot, no hidden bugs. The cost was eleven days of coverage that guarded nothing.

Some of it was load-bearing *in argument*: `docs/ROADMAP.md` cites `hero_public.rs` / `navigator_public.rs` as existing Hero and Navigator coverage, and `tests/parity/heroes_test.rs` declines to port several Flutter cases on the grounds that those files already cover them.

## The fix

Mounting needed only the shape the consolidation established: drop each file's own `mod common;`, rewrite `common::` → `crate::common::`. **No test content changed.**

## The guard (the part that matters)

`scripts/check-workspace-inventory.sh` — already the drift guard, already in CI's `checks` job and `just inventory-check` — now fails if any `tests/*.rs` in an `autotests = false` crate is unreachable.

It follows `#[path]` mounts out of *whichever* file is the `[[test]]` target, not just `main.rs`. That matters: `flui-objects`' `harness_snapshot.rs` is mounted that way from `render_object_harness.rs` and must not be flagged — a first census of this bug did flag it, wrongly, which is why the guard is written to handle it.

**Proven to fail**, not just to pass: planting a dummy orphan under `crates/flui-rendering/tests/` makes `just inventory-check` exit 1 with

```
workspace-inventory: drift detected
  - crates/flui-rendering/tests/zz_orphan_probe.rs is not reachable: `flui-rendering` sets
    `autotests = false`, so this file needs its own `[[test]]` target in Cargo.toml, or a
    `mod`/`#[path]` mount in `tests/main.rs` (or whichever `[[test]]` target file mounts
    sibling test modules)
```

## Gates

Workspace **8028 → 8125** passed, 0 failed. clippy · fmt · inventory-check · port-check · doc-strict all clean.

`flui-platform` (excluded from CI's `test` job): 114 → 120 tests, 83 → 89 passed. Its **31 failures are unchanged and pre-existing** — verified by running the crate on a clean tree at `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117t1jX2FFcCzP3YBLoQB94
