### PR TITLE
fix(rendering): deliver the ctx-level hit-test transform to the driver

### DIFF
--- a/crates/flui-interaction/docs/HIT_TESTING.md
+++ b/crates/flui-interaction/docs/HIT_TESTING.md
@@ -128,25 +128,54 @@ path and whether it blocks targets visually behind it:
 Typical render-object hit testing still checks children before self so the path
 is leaf-first.
 
-## Known gaps (not this document's transform-stack fix, tracked separately)
+## Ctx-level transform pushes (box protocol)
 
-One call site still pushes nothing onto the `HitTestResult` transform stack
-that this document describes, so a `Listener` under it receives an
-un-localized position — the same class of bug the `with_paint_offset`/
-`with_paint_transform` fix above addresses, just not reachable through this
-path yet:
+`BoxHitTestContext`'s `push_offset`/`push_transform`/`with_transform`/
+`with_offset` (`crates/flui-rendering/src/context/hit_test.rs`) let a render
+object record a FORWARD (paint-direction) transform before recursing into a
+child via `hit_test_child`/`hit_test_child_at_layout_offset`. That push used
+to feed a per-node `BoxHitTestCtx` stack that `hit_test_raw`
+(`crates/flui-rendering/src/traits/render_box.rs`) discarded when the
+context went out of scope, so `RenderFractionalTranslation`
+(`crates/flui-objects/src/layout/fractional_translation.rs`) and
+`RenderFlow` (`crates/flui-objects/src/layout/flow.rs`) delivered
+un-localized positions.
 
-- `crates/flui-rendering/src/context/hit_test.rs:189-225` — the ctx-level
-  `push_offset`/`push_transform`/`with_transform` feed a per-node
-  `BoxHitTestCtx` stack that `hit_test_raw`
-  (`crates/flui-rendering/src/traits/render_box.rs:630-639`) discards, so
-  `RenderFractionalTranslation`
-  (`crates/flui-objects/src/layout/fractional_translation.rs:251`) and
-  `RenderFlow` (`crates/flui-objects/src/layout/flow.rs:395`) deliver
-  un-localized positions today.
+The ctx now hands its accumulated forward transform to the driver's
+`HitTestChildCallback` on every `hit_test_child`/`hit_test_child_at_layout_offset`
+call (`crates/flui-rendering/src/protocol/box_protocol.rs`,
+`BoxHitTestCtx::local_transform_for_driver`); the driver pushes its inverse
+onto the SAME `HitTestResult` this document describes, scoped to that one
+recursive call, via `with_paint_transform` — the identical mechanism the
+walk already uses for `hit_test_transform` and resolved follower offsets
+(`crates/flui-rendering/src/pipeline/owner/accessors.rs`). The sliver
+protocol's ctx-level stack stays a permanent no-op (main-axis position
+covers its needs); its own transform-stack gap (sliver→box edges skipping
+the push) was fixed separately — see "Sliver child transforms" above.
 
-The sliver walk's equivalent gap (`accessors.rs`, sliver→box edge skipping
-the transform-stack push) is fixed — see "Sliver child transforms" above.
+Two more gaps in the same family, found by auditing every caller of every
+`hit_test_child*` variant once the mechanism above started actually
+reaching the driver:
+
+- `HitTestContext::hit_test_child_at_offset` (the box-specific convenience
+  wrapper that subtracts a caller-supplied offset before delegating to
+  `hit_test_child`) computed the child-local position but never pushed the
+  offset it consumed — a bug in the wrapper itself, distinct from the
+  `BoxHitTestCtx`-discarded-on-scope-exit bug fixed above. Its only
+  nonzero-offset caller, `RenderFractionallySizedBox::hit_test`
+  (`crates/flui-objects/src/layout/fractionally_sized_box.rs`), delivered
+  un-localized positions to a fractionally-sized, off-center-aligned child.
+  Fixed by pushing the consumed offset unconditionally (mirroring
+  `hit_test_child_at_layout_offset`): the method always moves the position
+  into the child's frame, so per the rule above it must always push.
+- `RenderFittedBox::hit_test` (`crates/flui-objects/src/layout/fitted_box.rs`)
+  computed a child position through the inverse of its own scale/align
+  matrix and called the raw `hit_test_child` directly, recording nothing —
+  it has no `hit_test_transform` override (the driver-level mechanism
+  `RenderTransform`/`RenderRotatedBox` use) and never pushed a ctx-level
+  transform either (the mechanism `RenderFlow` uses). Fixed by wrapping the
+  child call in `ctx.with_transform`, the same pattern `RenderFlow` already
+  used.
 
 ## Tests
 

--- a/crates/flui-objects/src/layout/fitted_box.rs
+++ b/crates/flui-objects/src/layout/fitted_box.rs
@@ -449,14 +449,22 @@ impl RenderBox for RenderFittedBox {
         // both directions), so scaled children receive the correct
         // local point. (The pre-fix shape shifted by align_offset only
         // — any non-unit scale sent the child a wrong local point.)
-        let Some(inverse) = self.effective_transform().try_inverse() else {
+        let transform = self.effective_transform();
+        let Some(inverse) = transform.try_inverse() else {
             // Degenerate scale (zero area) — nothing is visually
             // hittable under a non-invertible transform.
             return false;
         };
         let pos = ctx.offset();
         let (tx, ty) = inverse.transform_point(pos.dx, pos.dy);
-        ctx.hit_test_child(0, Offset::new(tx, ty))
+        // Push the FORWARD (paint-direction) transform onto the ctx-level
+        // stack so the driver folds its inverse into `HitTestEntry.transform`
+        // — this render object has no `hit_test_transform` override (unlike
+        // `RenderTransform`/`RenderRotatedBox`, which record via that
+        // driver-level hook instead), so without this push the descent above
+        // would still land on the right child pixel while the delivered
+        // event position stayed un-localized.
+        ctx.with_transform(transform, |ctx| ctx.hit_test_child(0, Offset::new(tx, ty)))
     }
 
     // The `paint_transform` override is the whole point of RenderFittedBox:

--- a/crates/flui-objects/src/layout/shifted_box.rs
+++ b/crates/flui-objects/src/layout/shifted_box.rs
@@ -196,10 +196,15 @@ impl AligningShiftedBox {
     /// from `RenderState` (committed by [`align_child`]) AND records the paint
     /// offset into the `HitTestResult` so `HitTestResult::dispatch` can localize
     /// pointer/scroll events to the child's coordinate space. This is the
-    /// canonical path (`hit_test_child_at_offset` only transforms the recursive
-    /// descent and would leave handlers on an aligned child receiving parent
-    /// coordinates — Flutter `RenderShiftedBox.hitTestChildren` records the
-    /// offset via `addWithPaintOffset`).
+    /// canonical path — it reads the single `RenderState`-owned offset
+    /// directly rather than a value this object must keep mirrored in its own
+    /// field. (`hit_test_child_at_offset` also records the offset it consumes
+    /// now, but takes it as a caller-supplied parameter that can drift from
+    /// what `RenderState` actually committed; prefer
+    /// `hit_test_child_at_layout_offset` whenever the child's real laid-out
+    /// offset is what you mean to test against — Flutter
+    /// `RenderShiftedBox.hitTestChildren` records the offset via
+    /// `addWithPaintOffset`.)
     ///
     /// [`hit_test_child_at_layout_offset`]: BoxHitTestContext::hit_test_child_at_layout_offset
     /// [`align_child`]: AligningShiftedBox::align_child

--- a/crates/flui-objects/tests/harness_snapshot.rs
+++ b/crates/flui-objects/tests/harness_snapshot.rs
@@ -139,7 +139,13 @@ impl RenderObject<BoxProtocol> for PanicPaintBox {
         _child_count: usize,
         _size: flui_types::Size,
         _hit_child: &mut (
-                 dyn FnMut(usize, Option<ProtocolPosition<BoxProtocol>>) -> bool + Send + Sync
+                 dyn FnMut(
+            usize,
+            Option<ProtocolPosition<BoxProtocol>>,
+            Option<flui_types::Matrix4>,
+        ) -> bool
+                     + Send
+                     + Sync
              ),
     ) -> flui_rendering::traits::HitTestOutcome {
         flui_rendering::traits::HitTestOutcome::miss()

--- a/crates/flui-rendering/src/context/hit_test.rs
+++ b/crates/flui-rendering/src/context/hit_test.rs
@@ -169,33 +169,46 @@ where
     /// # Caller contract
     ///
     /// `position` must ALREADY be local to the child: this method hands it
-    /// over verbatim, so any reframing the caller performed is invisible
-    /// here. Whether the driver records that reframing on the
-    /// `HitTestResult` transform stack is decided by the walk, not by this
-    /// method — and today the walk does not push for every parent/child
-    /// pairing:
+    /// over verbatim, so any reframing the caller performed to compute it
+    /// is invisible here — it does not, by itself, tell the driver to
+    /// record anything on the `HitTestResult` transform stack. Whether the
+    /// walk pushes something for THIS call depends on whether a transform
+    /// was pushed on this context before calling (see below) and, absent
+    /// that, on the parent/child pairing:
     ///
-    /// - box parent → any child, and sliver parent → sliver child: the
-    ///   driver pushes nothing on this path. Sound only when the child is
-    ///   committed at `Offset::ZERO` (a transparent passthrough that never
-    ///   repositions its child); a nonzero offset here silently yields an
-    ///   un-localized position, and the sliver walk carries a
-    ///   `debug_assert!` for exactly that.
+    /// - box parent → any child, and sliver parent → sliver child: with no
+    ///   ctx-level push in effect, the driver pushes nothing on this path.
+    ///   Sound only when the child is committed at `Offset::ZERO` (a
+    ///   transparent passthrough that never repositions its child); a
+    ///   nonzero offset here silently yields an un-localized position, and
+    ///   the sliver walk carries a `debug_assert!` for exactly that.
     /// - sliver parent → box child: the driver DOES push the child's paint
     ///   offset, because crossing into a box frame always decomposes the
     ///   position into box-local coordinates.
     ///
-    /// Do not rely on that split. Prefer
+    /// Prefer
     /// [`hit_test_child_at_layout_offset`](Self::hit_test_child_at_layout_offset)
     /// whenever the child has a real laid-out offset — it lets the driver
     /// resolve and push the offset uniformly and cannot silently deliver an
-    /// un-localized position.
+    /// un-localized position. Reach for `push_offset`/`push_transform`/
+    /// `with_transform`/`with_offset` (below) plus this method only when the
+    /// child's effective position was computed some OTHER way — e.g. a
+    /// paint-time-only offset that never lands in `RenderState.offset`
+    /// (`RenderFractionalTranslation`), an inverted delegate-supplied matrix
+    /// (`RenderFlow`), or an inverted scale/alignment matrix
+    /// (`RenderFittedBox`).
     ///
-    /// Pushing the offset yourself via this context's `push_offset` /
-    /// `with_transform` does not help: the ctx-level transform stack is
-    /// discarded before it reaches `HitTestEntry.transform` — see the
-    /// "Known gaps" section of
-    /// `crates/flui-interaction/docs/HIT_TESTING.md`.
+    /// # Ctx-level pushes ARE forwarded to the driver
+    ///
+    /// A transform pushed on this context (`push_offset`, `push_transform`,
+    /// or the `with_offset`/`with_transform` scope helpers) before calling
+    /// this method is folded into the shared `HitTestResult` for the
+    /// duration of the recursive call: the driver pushes its INVERSE
+    /// (mirroring `hit_test_transform`'s own forward-then-invert handling),
+    /// so `HitTestEntry.transform` composes correctly. Only the box
+    /// protocol does this — `BoxHitTestContext`'s ctx-level stack reaches
+    /// the driver; the sliver protocol's ctx-level stack stays a no-op
+    /// (main-axis position covers its needs).
     pub fn hit_test_child(
         &mut self,
         index: usize,
@@ -217,24 +230,45 @@ where
     // ════════════════════════════════════════════════════════════════════════
     // TRANSFORM MANAGEMENT
     // ════════════════════════════════════════════════════════════════════════
+    //
+    // Unlike the driver-level `HitTestResult::push_transform`/`push_offset`
+    // (RAW primitives — the caller supplies the ALREADY-INVERTED,
+    // global-to-local value; see `crates/flui-interaction/docs/HIT_TESTING.md`),
+    // these ctx-level methods take the FORWARD, paint-direction transform —
+    // the same value a render object already computes to know where its
+    // child sits (`RenderFractionalTranslation`'s pixel offset,
+    // `RenderFlow`'s per-child delegate matrix). The bridge from this
+    // context to the driver — `hit_test_child`/`hit_test_child_at_layout_offset`
+    // above — inverts it for you when composing the real
+    // `HitTestEntry.transform`, mirroring `HitTestResult::with_paint_transform`.
+    // A push here only takes effect for hit-test calls made on THIS context
+    // before the matching pop; it does not retroactively affect entries
+    // already added.
 
-    /// Adds a transform to the hit test path.
+    /// Pushes a FORWARD (paint-direction) transform, applied to the next
+    /// `hit_test_child`/`hit_test_child_at_layout_offset` call on this
+    /// context (see the section doc above). Must be paired with
+    /// [`pop_transform`](Self::pop_transform) — prefer
+    /// [`with_transform`](Self::with_transform), which pairs them for you.
     pub fn push_transform(&mut self, transform: Matrix4) {
         self.inner.push_transform(transform);
     }
 
-    /// Removes the most recent transform.
+    /// Removes the most recently pushed transform or offset.
     pub fn pop_transform(&mut self) {
         self.inner.pop_transform();
     }
 
-    /// Adds an offset transform.
+    /// Pushes a FORWARD (paint-direction) offset — see
+    /// [`push_transform`](Self::push_transform)'s doc; a pure translation
+    /// convenience over the same mechanism.
     pub fn push_offset(&mut self, offset: Offset) {
         self.inner.push_offset(offset);
     }
 
-    /// Executes a closure with a pushed transform, automatically popping
-    /// afterward.
+    /// Runs `f` with `transform` pushed (see
+    /// [`push_transform`](Self::push_transform)) and pops it before
+    /// returning.
     pub fn with_transform<F, R>(&mut self, transform: Matrix4, f: F) -> R
     where
         F: FnOnce(&mut Self) -> R,
@@ -245,8 +279,8 @@ where
         result
     }
 
-    /// Executes a closure with a pushed offset, automatically popping
-    /// afterward.
+    /// Runs `f` with `offset` pushed (see
+    /// [`push_offset`](Self::push_offset)) and pops it before returning.
     pub fn with_offset<F, R>(&mut self, offset: Offset, f: F) -> R
     where
         F: FnOnce(&mut Self) -> R,
@@ -345,10 +379,27 @@ where
 
     /// Tests a child at the given offset.
     ///
-    /// Automatically transforms position by subtracting the offset.
+    /// Automatically transforms position by subtracting the offset — and,
+    /// mirroring what [`hit_test_child_at_layout_offset`](Self::hit_test_child_at_layout_offset)
+    /// does for a `RenderState`-owned offset, records that same offset on
+    /// the ctx-level transform stack
+    /// (see the "Ctx-level pushes ARE forwarded to the driver" section on
+    /// [`hit_test_child`](Self::hit_test_child)) so it reaches
+    /// `HitTestEntry.transform`. The push happens unconditionally — this
+    /// method always moves `position` into the child's frame (even when
+    /// `offset` is `Offset::ZERO`, a no-op translation), so per the rule
+    /// this API follows throughout (push the child offset iff the position
+    /// handed to the child was moved into the child's frame), it must
+    /// always push. A previous version of this method moved the position
+    /// but never pushed, which silently dropped it from the recorded
+    /// `HitTestEntry.transform` — see
+    /// `crates/flui-interaction/docs/HIT_TESTING.md`.
     pub fn hit_test_child_at_offset(&mut self, index: usize, offset: Offset) -> bool {
         let local_position = self.position_minus(offset);
-        self.inner.hit_test_child(index, local_position)
+        self.push_offset(offset);
+        let hit = self.inner.hit_test_child(index, local_position);
+        self.pop_transform();
+        hit
     }
 }
 

--- a/crates/flui-rendering/src/context/hit_test.rs
+++ b/crates/flui-rendering/src/context/hit_test.rs
@@ -396,6 +396,17 @@ where
     /// `crates/flui-interaction/docs/HIT_TESTING.md`.
     pub fn hit_test_child_at_offset(&mut self, index: usize, offset: Offset) -> bool {
         let local_position = self.position_minus(offset);
+        // A zero offset is no frame change, so there is nothing to record —
+        // and skipping it keeps the stack EMPTY, which is what lets
+        // `local_transform_for_driver` return `None` and the driver avoid a
+        // `with_paint_transform(IDENTITY)` (a determinant plus a full 4x4
+        // inverse) per level. Most callers pass `Offset::ZERO`: the proxy
+        // render objects (opacity, repaint boundary, listener, mouse region,
+        // absorb/ignore pointer, ...) sit on the pointer hot path and stack
+        // several deep in an ordinary tree.
+        if offset == Offset::ZERO {
+            return self.inner.hit_test_child(index, local_position);
+        }
         self.push_offset(offset);
         let hit = self.inner.hit_test_child(index, local_position);
         self.pop_transform();

--- a/crates/flui-rendering/src/pipeline/owner/accessors.rs
+++ b/crates/flui-rendering/src/pipeline/owner/accessors.rs
@@ -593,41 +593,62 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
             None => position,
         };
 
-        let mut hit_child = |index: usize, override_pos: Option<Offset>| -> bool {
+        let mut hit_child = |index: usize,
+                             override_pos: Option<Offset>,
+                             local_transform: Option<Matrix4>|
+         -> bool {
             let Some(&child_id) = children.get(index) else {
                 return false;
             };
             let Some(child_node) = self.render_tree.get(child_id) else {
                 return false;
             };
-            if child_node.as_sliver().is_some() {
-                // Explicit positions are already child-local; the layout-offset
-                // fallback starts from the child's physical paint offset.
-                return if let Some(position) = override_pos {
-                    let child_position =
-                        Self::sliver_hit_position_from_offset(child_node, position);
-                    self.hit_test_sliver_subtree(child_id, child_position, result)
+            // `local_transform` is the object's own FORWARD (paint-direction)
+            // transform, accumulated by its ctx-level `push_transform`/
+            // `push_offset` calls (`BoxHitTestCtx::composed_transform`).
+            // `with_paint_transform` pushes its INVERSE onto the shared
+            // `HitTestResult`, matching every other forward-transform push
+            // in this walk (`hit_test_transform` above, the follower offset,
+            // Flutter's own `addWithPaintTransform`). Scoped to exactly this
+            // one child recursion — the ctx that accumulated it already
+            // scoped the push/pop to the same call.
+            let dispatch_child = |result: &mut crate::hit_testing::HitTestResult| -> bool {
+                if child_node.as_sliver().is_some() {
+                    // Explicit positions are already child-local; the layout-offset
+                    // fallback starts from the child's physical paint offset.
+                    return if let Some(position) = override_pos {
+                        let child_position =
+                            Self::sliver_hit_position_from_offset(child_node, position);
+                        self.hit_test_sliver_subtree(child_id, child_position, result)
+                    } else {
+                        if !Self::sliver_child_is_visible(child_node) {
+                            return false;
+                        }
+                        let child_offset = child_node.offset();
+                        result.with_paint_offset(child_offset, |result| {
+                            let child_position = Self::sliver_hit_position_from_paint_offset(
+                                child_node,
+                                position - child_offset,
+                            );
+                            self.hit_test_sliver_subtree(child_id, child_position, result)
+                        })
+                    };
+                }
+                if let Some(child_position) = override_pos {
+                    self.hit_test_subtree(child_id, child_position, result)
                 } else {
-                    if !Self::sliver_child_is_visible(child_node) {
-                        return false;
-                    }
                     let child_offset = child_node.offset();
                     result.with_paint_offset(child_offset, |result| {
-                        let child_position = Self::sliver_hit_position_from_paint_offset(
-                            child_node,
-                            position - child_offset,
-                        );
-                        self.hit_test_sliver_subtree(child_id, child_position, result)
+                        self.hit_test_subtree(child_id, position - child_offset, result)
                     })
-                };
-            }
-            if let Some(child_position) = override_pos {
-                self.hit_test_subtree(child_id, child_position, result)
-            } else {
-                let child_offset = child_node.offset();
-                result.with_paint_offset(child_offset, |result| {
-                    self.hit_test_subtree(child_id, position - child_offset, result)
-                })
+                }
+            };
+
+            match local_transform {
+                Some(local_transform) => {
+                    result.with_paint_transform(local_transform, dispatch_child)
+                }
+                None => dispatch_child(result),
             }
         };
 
@@ -862,7 +883,15 @@ impl<Phase: PipelinePhase> PipelineOwner<Phase> {
         // driver-owned (checked above), so the sliver context ignores it.
         let own_size = entry.state().absolute_paint_size();
 
-        let mut hit_child = |index: usize, override_pos: Option<MainAxisPosition>| -> bool {
+        let mut hit_child = |index: usize,
+                             override_pos: Option<MainAxisPosition>,
+                             // The sliver protocol's ctx-level transform stack is a
+                             // permanent no-op (`SliverHitTestCtx::push_transform`) —
+                             // this is threaded only for signature uniformity with
+                             // the shared `RenderObject::hit_test_raw` trait method
+                             // and is always `None`.
+                             _local_transform: Option<Matrix4>|
+         -> bool {
             let Some(&child_id) = children.get(index) else {
                 return false;
             };

--- a/crates/flui-rendering/src/pipeline/owner/mod.rs
+++ b/crates/flui-rendering/src/pipeline/owner/mod.rs
@@ -969,6 +969,7 @@ mod tests {
                      dyn FnMut(
                 usize,
                 Option<crate::protocol::ProtocolPosition<crate::protocol::BoxProtocol>>,
+                Option<flui_types::Matrix4>,
             ) -> bool
                          + Send
                          + Sync
@@ -1030,6 +1031,7 @@ mod tests {
                      dyn FnMut(
                 usize,
                 Option<crate::protocol::ProtocolPosition<crate::protocol::BoxProtocol>>,
+                Option<flui_types::Matrix4>,
             ) -> bool
                          + Send
                          + Sync
@@ -1346,6 +1348,7 @@ mod tests {
                      dyn FnMut(
                 usize,
                 Option<crate::protocol::ProtocolPosition<crate::protocol::BoxProtocol>>,
+                Option<flui_types::Matrix4>,
             ) -> bool
                          + Send
                          + Sync

--- a/crates/flui-rendering/src/pipeline/scheduler.rs
+++ b/crates/flui-rendering/src/pipeline/scheduler.rs
@@ -772,6 +772,7 @@ mod tests {
                      dyn FnMut(
                 usize,
                 Option<crate::protocol::ProtocolPosition<crate::protocol::BoxProtocol>>,
+                Option<flui_types::Matrix4>,
             ) -> bool
                          + Send
                          + Sync

--- a/crates/flui-rendering/src/protocol/box_protocol.rs
+++ b/crates/flui-rendering/src/protocol/box_protocol.rs
@@ -1349,7 +1349,33 @@ impl BoxHitTestEntry {
     }
 }
 
-/// Box hit test context implementation.
+/// Driver-supplied child recursion for the box hit-test walk.
+///
+/// `(index, position_override, local_transform)`:
+/// - `position_override`: `Some(p)` tests the child at the exact position
+///   `p` (the parent already transformed it — clip / transform objects);
+///   `None` tests at the child's laid-out position (the driver subtracts
+///   the child's `RenderState.offset`).
+/// - `local_transform`: the FORWARD (paint-direction) transform
+///   [`BoxHitTestCtx`]'s own ctx-level stack accumulated before this call
+///   (`None` when nothing was pushed). The driver pushes its inverse onto
+///   the shared `HitTestResult` for the duration of the recursive call —
+///   see [`BoxHitTestCtx::hit_test_child`] — so a render object that calls
+///   `ctx.push_offset`/`ctx.push_transform`/`ctx.with_transform` before
+///   testing a child gets that push folded into `HitTestEntry.transform`
+///   instead of silently discarded.
+///
+/// Returns whether the child subtree was hit.
+// `Send + Sync` mechanically required by `HitTestContextApi`'s bounds
+// (inherited like `LayoutChildCallback`'s bound); the walk itself
+// is control-plane single-threaded.
+pub type HitTestChildCallback<'a> =
+    &'a mut (dyn FnMut(usize, Option<Offset>, Option<Matrix4>) -> bool + Send + Sync);
+
+/// Box-protocol hit-test context: local-space position, the entry
+/// path under construction, the live child recursion supplied by the
+/// pipeline driver, and the transform stack (with a cached composition,
+/// see [`BoxHitTestCtx::current_transform`]).
 ///
 /// # Transform accumulation
 ///
@@ -1366,23 +1392,20 @@ impl BoxHitTestEntry {
 /// (one full re-fold over the now-shorter stack). Per-call cost
 /// drops from O(stack_depth) to O(1) for queries, and pops stay
 /// O(stack_depth) but amortize across the matched push.
-/// Driver-supplied child recursion for the box hit-test walk.
 ///
-/// `(index, position_override)`: `Some(p)` tests the child at the
-/// exact position `p` (the parent already transformed it — clip /
-/// transform objects); `None` tests at the child's laid-out position
-/// (the driver subtracts the child's `RenderState.offset`). Returns
-/// whether the child subtree was hit.
-// `Send + Sync` mechanically required by `HitTestContextApi`'s bounds
-// (inherited like `LayoutChildCallback`'s bound); the walk itself
-// is control-plane single-threaded.
-pub type HitTestChildCallback<'a> =
-    &'a mut (dyn FnMut(usize, Option<Offset>) -> bool + Send + Sync);
-
-/// Box-protocol hit-test context: local-space position, the entry
-/// path under construction, the live child recursion supplied by the
-/// pipeline driver, and the transform stack (with a cached composition,
-/// see [`BoxHitTestCtx::current_transform`]).
+/// # Reaching the driver
+///
+/// `composed_transform` used to be purely local bookkeeping: nothing ever
+/// read it except [`BoxHitTestCtx::add_self`], which is itself dead in
+/// production (render objects use [`HitTestContext::register_self_hit_entry`]
+/// instead — see that method's doc). [`hit_test_child`](Self::hit_test_child)
+/// and [`hit_test_child_at_layout_offset`](Self::hit_test_child_at_layout_offset)
+/// now hand `composed_transform` to the driver's [`HitTestChildCallback`]
+/// on every call, so a push made via `push_transform`/`push_offset` (or
+/// the `with_transform`/`with_offset` scope helpers) actually reaches
+/// `HitTestEntry.transform`.
+///
+/// [`HitTestContext::register_self_hit_entry`]: crate::context::HitTestContext::register_self_hit_entry
 pub struct BoxHitTestCtx<'ctx, A: Arity, P: ParentData> {
     position: Offset,
     result: BoxHitTestResult,
@@ -1457,6 +1480,22 @@ impl<'ctx, A: Arity, P: ParentData> BoxHitTestCtx<'ctx, A, P> {
             .fold(Matrix4::IDENTITY, |acc, t| acc * *t);
     }
 
+    /// The FORWARD transform to hand the driver for the next child call,
+    /// or `None` when nothing is pushed — an empty stack must stay `None`
+    /// rather than `Some(IDENTITY)` so the driver's hot path (the
+    /// overwhelming majority of render objects, which never touch
+    /// `push_transform`/`push_offset`) skips the `with_paint_transform`
+    /// scope entirely instead of pushing a no-op identity onto the shared
+    /// `HitTestResult` stack on every single child recursion.
+    #[inline]
+    fn local_transform_for_driver(&self) -> Option<Matrix4> {
+        if self.transform_stack.is_empty() {
+            None
+        } else {
+            Some(self.composed_transform)
+        }
+    }
+
     /// Adds self as a hit target with the given render ID.
     pub fn add_self(&mut self, target_id: RenderId) {
         let transform = self.current_transform();
@@ -1489,15 +1528,17 @@ impl<'ctx, A: Arity, P: ParentData> HitTestContextApi<'ctx, BoxHitTest, A, P>
     }
 
     fn hit_test_child(&mut self, index: usize, position: Offset) -> bool {
+        let local_transform = self.local_transform_for_driver();
         match self.child_callback.as_mut() {
-            Some(callback) => callback(index, Some(position)),
+            Some(callback) => callback(index, Some(position), local_transform),
             None => false,
         }
     }
 
     fn hit_test_child_at_layout_offset(&mut self, index: usize) -> bool {
+        let local_transform = self.local_transform_for_driver();
         match self.child_callback.as_mut() {
-            Some(callback) => callback(index, None),
+            Some(callback) => callback(index, None, local_transform),
             None => false,
         }
     }

--- a/crates/flui-rendering/src/protocol/sliver_protocol.rs
+++ b/crates/flui-rendering/src/protocol/sliver_protocol.rs
@@ -1310,8 +1310,16 @@ impl SliverHitTestEntry {
 }
 
 /// Driver-supplied child recursion for the sliver hit-test walk.
+///
+/// The third parameter mirrors the box protocol's
+/// [`box_protocol::HitTestChildCallback`](crate::protocol::box_protocol::HitTestChildCallback)
+/// for signature uniformity with the shared `RenderObject::hit_test_raw`
+/// trait method, but `SliverHitTestCtx`'s own transform stack is a no-op
+/// (see its `push_transform`/`pop_transform` impl below — main-axis
+/// position covers the sliver protocol's needs), so this is always
+/// `None` in practice.
 pub type SliverHitTestChildCallback<'a> =
-    &'a mut (dyn FnMut(usize, Option<MainAxisPosition>) -> bool + Send + Sync);
+    &'a mut (dyn FnMut(usize, Option<MainAxisPosition>, Option<Matrix4>) -> bool + Send + Sync);
 
 /// Sliver hit test context implementation.
 pub struct SliverHitTestCtx<'ctx, A: Arity, P: ParentData> {
@@ -1393,14 +1401,14 @@ impl<'ctx, A: Arity, P: ParentData> HitTestContextApi<'ctx, SliverHitTest, A, P>
 
     fn hit_test_child(&mut self, index: usize, position: MainAxisPosition) -> bool {
         match self.child_callback.as_mut() {
-            Some(callback) => callback(index, Some(position)),
+            Some(callback) => callback(index, Some(position), None),
             None => false,
         }
     }
 
     fn hit_test_child_at_layout_offset(&mut self, index: usize) -> bool {
         match self.child_callback.as_mut() {
-            Some(callback) => callback(index, None),
+            Some(callback) => callback(index, None, None),
             None => false,
         }
     }

--- a/crates/flui-rendering/src/traits/render_box.rs
+++ b/crates/flui-rendering/src/traits/render_box.rs
@@ -553,11 +553,12 @@ pub use flui_types::layout::TextBaseline;
 /// which demonstrably returned `Size::ZERO` for fresh boxes. The real
 /// bridge is now live.
 ///
-/// `hit_test_raw` is still a placeholder — hit testing flows through
-/// `RenderBox::hit_test()` with `BoxHitTestContext` and is wired
-/// separately by the hit-test pipeline. `paint_raw` is the live paint
-/// bridge: it wraps the pipeline's `FragmentRecorder` in the typed
-/// `PaintCx<T::Arity>` and calls `RenderBox::paint`.
+/// `hit_test_raw` is a live bridge too: it wraps the driver's child
+/// recursion in a typed `BoxHitTestContext` and calls `RenderBox::hit_test`
+/// — see its own doc for the ctx-level transform-stack handoff to the
+/// driver. `paint_raw` is the live paint bridge: it wraps the pipeline's
+/// `FragmentRecorder` in the typed `PaintCx<T::Arity>` and calls
+/// `RenderBox::paint`.
 ///
 /// Note: This requires T to also implement Diagnosticable since `RenderObject<P>`
 /// requires it.
@@ -615,7 +616,11 @@ where
         _child_count: usize,
         size: flui_types::Size,
         hit_child: &mut (
-                 dyn FnMut(usize, Option<crate::protocol::ProtocolPosition<BoxProtocol>>) -> bool
+                 dyn FnMut(
+            usize,
+            Option<crate::protocol::ProtocolPosition<BoxProtocol>>,
+            Option<flui_types::Matrix4>,
+        ) -> bool
                      + Send
                      + Sync
              ),
@@ -627,6 +632,17 @@ where
         // `size` is the node's committed `RenderState` geometry, threaded
         // by the driver so the default bounds gate reads
         // `ctx.is_within_own_size()` (2B field dedup).
+        //
+        // `hit_child`'s third parameter is the ctx-level transform stack's
+        // accumulated forward transform at call time (`BoxHitTestCtx::
+        // local_transform_for_driver`) — `ctx.push_offset`/`push_transform`/
+        // `with_transform` push onto that stack, and the driver folds it
+        // into `HitTestEntry.transform` for exactly the scoped recursive
+        // call (see `RenderObject::hit_test_raw`'s doc and
+        // `crate::context::HitTestContext`'s "Ctx-level pushes ARE
+        // forwarded to the driver" doc). `BoxHitTestCtx` itself never talks
+        // to the driver directly; it only accumulates the stack and hands
+        // the top-of-scope composition to `hit_child` on every call.
         let inner = crate::protocol::BoxHitTestCtx::<T::Arity, T::ParentData>::with_child_callback(
             position, hit_child,
         );

--- a/crates/flui-rendering/src/traits/render_object.rs
+++ b/crates/flui-rendering/src/traits/render_object.rs
@@ -262,6 +262,17 @@ pub trait RenderObject<P: Protocol>: Diagnosticable + DowncastSync + Send + Sync
     /// driver). Returns whether the position hits this node or any
     /// child. Hit entries are recorded by the driver, leaf-first.
     ///
+    /// The third argument is the FORWARD (paint-direction) transform the
+    /// object's own ctx-level transform stack accumulated before this
+    /// child call (`None` when nothing was pushed) — the driver pushes
+    /// its inverse onto the shared `HitTestResult` for the duration of
+    /// the recursive call, exactly like [`hit_test_transform`]'s own
+    /// forward-then-invert handling, so `HitTestEntry.transform` composes
+    /// correctly. Only the box protocol's ctx (`BoxHitTestCtx`) ever
+    /// produces `Some` here today; the sliver protocol keeps a no-op
+    /// transform stack (main-axis position covers its needs) and always
+    /// passes `None`.
+    ///
     /// **Users don't implement this directly.** Protocol traits provide
     /// blanket implementations that create typed contexts and call the
     /// protocol-level `hit_test` (e.g. `RenderBox::hit_test`).
@@ -272,12 +283,18 @@ pub trait RenderObject<P: Protocol>: Diagnosticable + DowncastSync + Send + Sync
     /// bounds gate (`ctx.is_within_own_size()`); the sliver protocol
     /// ignores it (the driver owns the geometry/cross-axis gate). Render
     /// objects no longer cache their own size (2B field dedup).
+    ///
+    /// [`hit_test_transform`]: Self::hit_test_transform
     fn hit_test_raw(
         &self,
         position: ProtocolPosition<P>,
         child_count: usize,
         size: flui_types::Size,
-        hit_child: &mut (dyn FnMut(usize, Option<ProtocolPosition<P>>) -> bool + Send + Sync),
+        hit_child: &mut (
+                 dyn FnMut(usize, Option<ProtocolPosition<P>>, Option<flui_types::Matrix4>) -> bool
+                     + Send
+                     + Sync
+             ),
     ) -> HitTestOutcome;
 
     // ========================================================================
@@ -764,7 +781,15 @@ mod tests {
             _position: flui_types::Offset,
             _child_count: usize,
             _size: Size,
-            _hit_child: &mut (dyn FnMut(usize, Option<flui_types::Offset>) -> bool + Send + Sync),
+            _hit_child: &mut (
+                     dyn FnMut(
+                usize,
+                Option<flui_types::Offset>,
+                Option<flui_types::Matrix4>,
+            ) -> bool
+                         + Send
+                         + Sync
+                 ),
         ) -> HitTestOutcome {
             HitTestOutcome::miss()
         }

--- a/crates/flui-rendering/src/traits/render_sliver.rs
+++ b/crates/flui-rendering/src/traits/render_sliver.rs
@@ -561,7 +561,11 @@ where
         _child_count: usize,
         size: flui_types::Size,
         hit_child: &mut (
-                 dyn FnMut(usize, Option<crate::protocol::ProtocolPosition<SliverProtocol>>) -> bool
+                 dyn FnMut(
+            usize,
+            Option<crate::protocol::ProtocolPosition<SliverProtocol>>,
+            Option<flui_types::Matrix4>,
+        ) -> bool
                      + Send
                      + Sync
              ),

--- a/crates/flui-rendering/src/view/render_view.rs
+++ b/crates/flui-rendering/src/view/render_view.rs
@@ -522,6 +522,7 @@ impl crate::protocol::RenderObject<crate::protocol::BoxProtocol> for RenderViewA
                  dyn FnMut(
             usize,
             Option<crate::protocol::ProtocolPosition<crate::protocol::BoxProtocol>>,
+            Option<flui_types::Matrix4>,
         ) -> bool
                      + Send
                      + Sync
@@ -532,7 +533,7 @@ impl crate::protocol::RenderObject<crate::protocol::BoxProtocol> for RenderViewA
         // empty window region reports a miss instead of a phantom
         // root target.
         for index in (0..child_count).rev() {
-            if hit_child(index, None) {
+            if hit_child(index, None, None) {
                 return crate::traits::HitTestOutcome::from_hit(true);
             }
         }

--- a/crates/flui-rendering/tests/layout_poison.rs
+++ b/crates/flui-rendering/tests/layout_poison.rs
@@ -31,7 +31,7 @@ use flui_rendering::{
     traits::{HitTestOutcome, RenderBox, RenderObject, RenderSliver},
 };
 use flui_tree::{Leaf, Single};
-use flui_types::{Size, geometry::px};
+use flui_types::{Matrix4, Size, geometry::px};
 
 // ============================================================================
 // FlakyLeaf — a leaf render object that fails layout on demand
@@ -94,6 +94,7 @@ impl RenderObject<BoxProtocol> for FlakyLeaf {
                  dyn FnMut(
             usize,
             Option<flui_rendering::protocol::ProtocolPosition<BoxProtocol>>,
+            Option<Matrix4>,
         ) -> bool
                      + Send
                      + Sync
@@ -479,6 +480,7 @@ impl RenderObject<BoxProtocol> for CountingIntrinsicBox {
                  dyn FnMut(
             usize,
             Option<flui_rendering::protocol::ProtocolPosition<BoxProtocol>>,
+            Option<Matrix4>,
         ) -> bool
                      + Send
                      + Sync
@@ -781,6 +783,7 @@ impl RenderObject<BoxProtocol> for UnboundedHatingLeaf {
                  dyn FnMut(
             usize,
             Option<flui_rendering::protocol::ProtocolPosition<BoxProtocol>>,
+            Option<Matrix4>,
         ) -> bool
                      + Send
                      + Sync
@@ -835,6 +838,7 @@ impl RenderObject<BoxProtocol> for WidthSwitchParent {
                  dyn FnMut(
             usize,
             Option<flui_rendering::protocol::ProtocolPosition<BoxProtocol>>,
+            Option<Matrix4>,
         ) -> bool
                      + Send
                      + Sync

--- a/crates/flui-widgets/tests/parity/flow_test.rs
+++ b/crates/flui-widgets/tests/parity/flow_test.rs
@@ -61,8 +61,11 @@
 //!    `FlowDelegate`/`RenderFlow` behavioral contract this slice scopes to,
 //!    so its absence is noted here rather than filed to Cross.H.
 
+use std::cell::Cell;
+use std::rc::Rc;
 use std::sync::Arc;
 
+use flui_interaction::events::PointerEventExt as _;
 use flui_rendering::constraints::BoxConstraints;
 use flui_types::{Color, Matrix4, Size};
 use flui_widgets::row;
@@ -186,6 +189,100 @@ fn flow_hit_test_inverts_each_child_real_transform_after_offset_changes() {
         "with start_offset=50.0, (20,90) now falls outside child 1's real \
          bounds and inside child 0's — matching the oracle's log == [0] \
          after startOffset.value = 50.0",
+    );
+}
+
+/// Positions its single child via a fixed forward (paint-direction)
+/// translation matrix — a minimal `FlowDelegate` for isolating the
+/// hit-test transform-stack composition, as opposed to `StackedFlowDelegate`
+/// above (which exists to test paint-order hit resolution across
+/// overlapping children).
+#[derive(Debug)]
+struct TranslateFlowDelegate {
+    dx: f32,
+    dy: f32,
+}
+
+impl FlowDelegate for TranslateFlowDelegate {
+    fn get_size(&self, constraints: BoxConstraints) -> Size {
+        constraints.biggest()
+    }
+
+    fn get_constraints_for_child(
+        &self,
+        _index: usize,
+        constraints: BoxConstraints,
+    ) -> BoxConstraints {
+        constraints.loosen()
+    }
+
+    fn paint_children(&self, context: &mut FlowPaintingContext<'_, '_>) {
+        for i in 0..context.child_count() {
+            context.paint_child(i, Matrix4::translation(self.dx, self.dy, 0.0));
+        }
+    }
+
+    fn should_relayout(&self, _old_delegate: &dyn FlowDelegate) -> bool {
+        false
+    }
+
+    fn should_repaint(&self, _old_delegate: &dyn FlowDelegate) -> bool {
+        false
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// `RenderFlow::hit_test` pushes each child's FORWARD paint transform onto
+/// the ctx-level `BoxHitTestContext` stack (`ctx.with_transform(transform,
+/// ...)`, `crates/flui-objects/src/layout/flow.rs:395-397`) before
+/// delegating to the transformed child. That ctx-level stack lived in a
+/// private `BoxHitTestCtx` that `RenderBox::hit_test_raw`
+/// (`crates/flui-rendering/src/traits/render_box.rs`) discarded when it
+/// went out of scope, so `HitTestEntry.transform` never recorded the
+/// transform even though `hit_test` itself inverted it to decide which
+/// child pixel was hit.
+///
+/// Flutter parity: `RenderFlow.hitTestChildren` (`rendering/flow.dart:428-453`)
+/// calls `result.addWithPaintTransform(transform: transform, position:
+/// position, hitTest: ...)` with the child's `FlowParentData._transform` —
+/// the SAME `BoxHitTestResult` the whole walk shares records it, there is
+/// no separate context to lose it in.
+///
+/// RED before the fix: a tap on the child's transformed location delivered
+/// the raw global position instead of the position local to the child's
+/// own box.
+#[test]
+fn flow_child_transform_localises_the_delivered_pointer_position() {
+    let recorded: Rc<Cell<Option<(f32, f32)>>> = Rc::new(Cell::new(None));
+    let probe = Rc::clone(&recorded);
+
+    let laid = harness::pump_widget(
+        Flow::new(
+            Arc::new(TranslateFlowDelegate { dx: 20.0, dy: 30.0 }),
+            row![
+                Listener::new()
+                    .on_pointer_down(move |event: &flui_widgets::prelude::PointerEvent| {
+                        probe.set(Some((event.position().dx.get(), event.position().dy.get())));
+                    })
+                    .child(SizedBox::new(100.0, 100.0).child(ColoredBox::new(Color::BLUE)))
+            ],
+        ),
+        harness::screen(),
+    );
+
+    // The child is painted at (20, 30); tap a point inside its transformed
+    // 100x100 box.
+    laid.dispatch_pointer_down(40.0, 45.0);
+
+    let local = recorded.get().expect("on_pointer_down must have fired");
+    let expected = (20.0_f32, 15.0_f32);
+    assert!(
+        (local.0 - expected.0).abs() < 1e-3 && (local.1 - expected.1).abs() < 1e-3,
+        "expected the tap to localise to {expected:?} (global (40, 45) minus the child's \
+         (20, 30) paint translation), got {local:?}",
     );
 }
 

--- a/crates/flui-widgets/tests/parity/pointer_local_position_test.rs
+++ b/crates/flui-widgets/tests/parity/pointer_local_position_test.rs
@@ -11,6 +11,34 @@
 //! - `'rotated for touch/signal'` —
 //!   [`a_rotated_ancestor_localises_the_delivered_position`].
 //!
+//! Also (not a `listener_test.dart` port; a second, independent defect this
+//! file's fix also closes): [`fractional_translation_true_localises_to_the_shifted_child`]
+//! and [`fractional_translation_false_localises_to_the_unshifted_child`] pin
+//! down `RenderFractionalTranslation`'s ctx-level hit-test transform push,
+//! which used to be discarded before reaching `HitTestEntry.transform` —
+//! see `crates/flui-interaction/docs/HIT_TESTING.md`'s former "Known gaps"
+//! section.
+//!
+//! A third, independent defect (also not a `listener_test.dart` port):
+//! [`fractionally_sized_box_localises_the_delivered_position_to_the_aligned_child`]
+//! pins down `HitTestContext::hit_test_child_at_offset`
+//! (`crates/flui-rendering/src/context/hit_test.rs`) itself — every caller of
+//! that method (`RenderFractionallySizedBox::hit_test` among them) moves the
+//! position into the child's frame but, before the fix, never recorded that
+//! move on the ctx-level transform stack, so descent hit-tested correctly
+//! while the delivered position stayed un-localized.
+//!
+//! A fourth, independent defect surfaced by auditing every caller of the raw
+//! `ctx.hit_test_child` for the same "moves the position but never records
+//! it" shape: [`fitted_box_localises_the_delivered_position_through_the_scale`]
+//! pins down `RenderFittedBox::hit_test`
+//! (`crates/flui-objects/src/layout/fitted_box.rs`), which computed a child
+//! position through the inverse of its own scale/align matrix but never
+//! pushed that matrix anywhere — neither the driver-level `hit_test_transform`
+//! hook (`RenderTransform`/`RenderRotatedBox`'s mechanism) nor the ctx-level
+//! `push_transform`/`with_transform` stack (`Flow`'s mechanism, and now this
+//! one's).
+//!
 //! Not ported:
 //! - `'scaled for touch/signal'` — `Align(topLeft)` contributes a zero offset
 //!   (`TOP_LEFT`'s alignment factor is `(0, 0)` regardless of the size
@@ -68,6 +96,7 @@ use flui_interaction::events::PointerEventExt as _;
 use flui_types::Color;
 use flui_widgets::prelude::*;
 
+use crate::common::{loose, tight};
 use crate::harness;
 
 const TOLERANCE: f32 = 1e-3;
@@ -242,5 +271,194 @@ fn a_rotated_ancestor_localises_the_delivered_position() {
         local,
         local_down,
         "a rotated+offset ancestor must localise back to Flutter's own quoted local position",
+    );
+}
+
+/// `RenderFractionalTranslation::hit_test` (`transform_hit_tests(true)`,
+/// the default) pushes the pixel offset it computed onto the ctx-level
+/// `BoxHitTestContext` transform stack (`ctx.push_offset(offset)`,
+/// `crates/flui-objects/src/layout/fractional_translation.rs:251`) before
+/// delegating to the shifted child. That ctx-level stack lived in a private
+/// `BoxHitTestCtx` that `RenderBox::hit_test_raw`
+/// (`crates/flui-rendering/src/traits/render_box.rs`) discarded when it
+/// went out of scope, so `HitTestEntry.transform` never recorded the
+/// offset even though `hit_test` itself moved `position` by that same
+/// offset to decide which child pixel was hit.
+///
+/// Flutter parity: `RenderFractionalTranslation.hitTestChildren`
+/// (`rendering/proxy_box.dart:3121-3132`) calls
+/// `result.addWithPaintOffset(offset: Offset(translation.dx * size.width,
+/// translation.dy * size.height), position: position, hitTest: ...)` —
+/// the SAME `BoxHitTestResult` the whole walk shares records the offset,
+/// there is no separate context to lose it in.
+///
+/// RED before the fix: a tap on the visually-shifted child delivered the
+/// raw global position instead of the position local to the child's own
+/// box.
+#[test]
+fn fractional_translation_true_localises_to_the_shifted_child() {
+    let (recorded, listener) = recording_listener();
+
+    // 100x100 target, translated by half its own size on both axes ->
+    // painted (and, with `transform_hit_tests(true)`, hit-tested) at
+    // global (50, 50)..(150, 150).
+    let laid = harness::pump_widget(
+        FractionalTranslation::new(0.5, 0.5).child(listener.child(target())),
+        loose(200.0),
+    );
+
+    // Dead center of the shifted child's occupied region.
+    laid.dispatch_pointer_down(100.0, 100.0);
+
+    let local = recorded.get().expect("on_pointer_down must have fired");
+    assert_close(
+        local,
+        (50.0, 50.0),
+        "a tap on the shifted child must localise to the child's own 100x100 box",
+    );
+    assert_ne!(
+        local,
+        (100.0, 100.0),
+        "the recorded position must be LOCAL to the child, not the raw dispatch position"
+    );
+}
+
+/// `transform_hit_tests(false)` is the control: `RenderFractionalTranslation`
+/// takes `ctx.hit_test_child_at_layout_offset(0)`
+/// (`crates/flui-objects/src/layout/fractional_translation.rs:259`), which
+/// the pipeline driver already resolves and pushes correctly — this path
+/// never touched the discarded ctx-level stack, so it must deliver the
+/// correct position both before and after the fix.
+///
+/// Flutter parity: same `hitTestChildren`, `transformHitTests == false`
+/// branch — `addWithPaintOffset(offset: null, ...)` performs no
+/// transform at all, matching a layout-offset-only child test.
+#[test]
+fn fractional_translation_false_localises_to_the_unshifted_child() {
+    let (recorded, listener) = recording_listener();
+
+    let laid = harness::pump_widget(
+        FractionalTranslation::new(0.5, 0.5)
+            .transform_hit_tests(false)
+            .child(listener.child(target())),
+        loose(200.0),
+    );
+
+    // Within the child's ORIGINAL (unshifted) 100x100 bounds.
+    laid.dispatch_pointer_down(30.0, 40.0);
+
+    let local = recorded.get().expect("on_pointer_down must have fired");
+    assert_close(
+        local,
+        (30.0, 40.0),
+        "transform_hit_tests(false) must localise against the child's original, unshifted \
+         layout position",
+    );
+}
+
+/// `RenderFractionallySizedBox::hit_test`
+/// (`crates/flui-objects/src/layout/fractionally_sized_box.rs:319-328`) takes
+/// `ctx.hit_test_child_at_offset(0, self.child_offset)` — the same
+/// alignment-resolved offset `perform_layout` handed to `ctx.position_child`.
+/// `hit_test_child_at_offset` (`crates/flui-rendering/src/context/hit_test.rs`)
+/// subtracts that offset to compute the child-local position it hands to the
+/// child's own `hit_test`, so hit/miss descent was always correct — but,
+/// before the fix, never recorded the offset on the ctx-level transform
+/// stack the way `hit_test_child_at_layout_offset` (and, since the sibling
+/// fix in this same change, the ctx-level `push_offset`/`push_transform`
+/// stack in general) does, so the RECORDED `HitTestEntry.transform` stayed
+/// identity: delivery localized against the raw global dispatch point
+/// instead of the child's own box.
+///
+/// Non-parity regression test — this is a FLUI-internal transform-stack
+/// bookkeeping bug in a single ctx method, not Flutter behavior being ported.
+///
+/// A tight 200×200 `FractionallySizedBox(width_factor: 0.5, height_factor:
+/// 0.5, alignment: CENTER)` constrains its 400×400 child down to a tight
+/// 100×100 (`factor × incoming max` on each axis — see `child_constraints`)
+/// and centers it inside its own 200×200 box, so `child_offset = (50, 50)`.
+/// A tap at the global point `(60, 60)` lands `(10, 10)` inside the child's
+/// own 100×100 box.
+///
+/// RED before the fix: the delivered local position was `(60, 60)` — the
+/// raw global dispatch point, un-localized.
+#[test]
+fn fractionally_sized_box_localises_the_delivered_position_to_the_aligned_child() {
+    let (recorded, listener) = recording_listener();
+
+    let laid =
+        harness::pump_widget(
+            FractionallySizedBox::new()
+                .width_factor(0.5)
+                .height_factor(0.5)
+                .alignment(Alignment::CENTER)
+                .child(listener.child(
+                    ColoredBox::new(Color::rgb(255, 0, 0)).child(SizedBox::new(400.0, 400.0)),
+                )),
+            tight(200.0, 200.0),
+        );
+
+    laid.dispatch_pointer_down(60.0, 60.0);
+
+    let local = recorded.get().expect("on_pointer_down must have fired");
+    assert_close(
+        local,
+        (10.0, 10.0),
+        "a tap on the centered, factor-shrunk child must localise to the child's own 100x100 box",
+    );
+    assert_ne!(
+        local,
+        (60.0, 60.0),
+        "the recorded position must be LOCAL to the child, not the raw dispatch position"
+    );
+}
+
+/// `RenderFittedBox::hit_test` (`crates/flui-objects/src/layout/fitted_box.rs`)
+/// computes the child-local position by inverting `effective_transform()` —
+/// the same scale/align matrix `paint_transform` hands the pipeline — but,
+/// before the fix, called the raw `ctx.hit_test_child` directly with that
+/// computed position, recording nothing: neither a driver-level
+/// `hit_test_transform` override (the mechanism `RenderTransform` and
+/// `RenderRotatedBox` use) nor a ctx-level `push_transform`/`with_transform`
+/// scope (the mechanism `RenderFlow` uses for its own per-child delegate
+/// matrix). Hit/miss descent was still correct — the computed local position
+/// IS where the child sits — but the RECORDED `HitTestEntry.transform` stayed
+/// identity, so delivery localized against the raw global dispatch point.
+///
+/// Non-parity regression test — a FLUI-internal transform-stack bookkeeping
+/// bug, not Flutter behavior being ported.
+///
+/// `FittedBox::fit(BoxFit::Fill)` under tight 100×100 constraints stretches
+/// its unconstrained-intrinsic 50×50 child to exactly fill the box on both
+/// axes (`Fill` never crops or letterboxes): `scale_x = scale_y = 2.0`,
+/// `align_offset = source_offset = Offset::ZERO`, so `effective_transform()`
+/// is a pure `scale(2, 2)`. A tap at the global point `(30, 40)` lands at the
+/// child-local point `(15, 20)` (divide by the scale).
+///
+/// RED before the fix: the delivered local position was `(30, 40)` — the raw
+/// global dispatch point, un-localized.
+#[test]
+fn fitted_box_localises_the_delivered_position_through_the_scale() {
+    let (recorded, listener) = recording_listener();
+
+    let laid = harness::pump_widget(
+        FittedBox::new().fit(BoxFit::Fill).child(
+            listener.child(ColoredBox::new(Color::rgb(255, 0, 0)).child(SizedBox::new(50.0, 50.0))),
+        ),
+        tight(100.0, 100.0),
+    );
+
+    laid.dispatch_pointer_down(30.0, 40.0);
+
+    let local = recorded.get().expect("on_pointer_down must have fired");
+    assert_close(
+        local,
+        (15.0, 20.0),
+        "a tap through a 2x FittedBox scale must localise to the child's own unscaled box",
+    );
+    assert_ne!(
+        local,
+        (30.0, 40.0),
+        "the recorded position must be LOCAL to the child, not the raw dispatch position"
     );
 }

--- a/crates/flui-widgets/tests/slide_transition.rs
+++ b/crates/flui-widgets/tests/slide_transition.rs
@@ -181,11 +181,18 @@ fn build_delivers_the_animation_localized_position_to_the_child_mid_animation() 
     laid.dispatch_pointer_down(75.0, 60.0);
 
     let local = recorded.get().expect("on_pointer_down must have fired");
-    assert_eq!(
-        local,
-        (25.0, 60.0),
+    // The shift is produced by tween/curve math, so compare within a
+    // tolerance rather than exactly — the same 1e-3 the other delivered-
+    // position tests use. The defect this pins was a 50px miss; any epsilon
+    // far below that still fails on it.
+    const TOLERANCE: f32 = 1e-3;
+    assert!(
+        (local.0 - 25.0).abs() < TOLERANCE && (local.1 - 60.0).abs() < TOLERANCE,
         "the delivered position must be local to the child (global (75, 60) minus the \
-         mid-animation 50px shift on x), not the raw global dispatch position",
+         mid-animation 50px shift on x), not the raw global dispatch position; \
+         got ({:.4}, {:.4})",
+        local.0,
+        local.1,
     );
 
     controller.dispose();

--- a/crates/flui-widgets/tests/slide_transition.rs
+++ b/crates/flui-widgets/tests/slide_transition.rs
@@ -3,6 +3,8 @@
 //! *current* animated offset and its `transform_hit_tests` flag, not a
 //! hardcoded snapshot or the render object's own default.
 
+use std::cell::Cell;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -10,10 +12,11 @@ use std::time::Duration;
 use crate::common::{lay_out, loose};
 use flui_animation::ext::AnimatableExt;
 use flui_animation::{Animation, AnimationController, Tween};
+use flui_interaction::events::PointerEventExt as _;
 use flui_objects::TranslationFraction;
 use flui_scheduler::Scheduler;
 use flui_types::Color;
-use flui_widgets::{ColoredBox, GestureDetector, SizedBox, SlideTransition};
+use flui_widgets::{ColoredBox, GestureDetector, Listener, SizedBox, SlideTransition};
 
 fn position_animation(
     begin: TranslationFraction,
@@ -128,6 +131,61 @@ fn build_wires_transform_hit_tests_false_into_fractional_translation() {
         taps.load(Ordering::SeqCst),
         1,
         "transform_hit_tests(false) leaves hit-testing at the child's original layout position",
+    );
+
+    controller.dispose();
+}
+
+/// A realistic composite: `SlideTransition` mid-animation (not fully at
+/// either endpoint) must deliver a LOCALIZED position to its child, not
+/// just register a hit. `SlideTransition::build` constructs a
+/// `FractionalTranslation` (`crates/flui-widgets/src/transitions/slide_transition.rs`)
+/// whose `hit_test` pushed its computed offset onto a ctx-level transform
+/// stack that the pipeline used to discard before it reached
+/// `HitTestEntry.transform` — the tap-count assertions above already prove
+/// the shifted region is *reachable*, but a stub that always recorded
+/// `Matrix4::IDENTITY` would also pass those; only asserting the exact
+/// delivered position proves the recorded transform is the real one.
+///
+/// Reachability: this is the exact shape `Dismissible` (swipe-to-dismiss)
+/// and page-transition slides put in front of interactive children —
+/// gesture-heavy widgets that need their child's real local position, not
+/// just a hit/miss bit.
+#[test]
+fn build_delivers_the_animation_localized_position_to_the_child_mid_animation() {
+    let recorded: Rc<Cell<Option<(f32, f32)>>> = Rc::new(Cell::new(None));
+    let probe = Rc::clone(&recorded);
+
+    let (controller, position) = position_animation(
+        TranslationFraction::ZERO,
+        TranslationFraction::new(1.0, 0.0),
+    );
+    // Mid-animation, not at either endpoint: dx = 0.5.
+    controller.set_value(0.5);
+
+    let laid = lay_out(
+        SlideTransition::new(
+            position,
+            Listener::new()
+                .on_pointer_down(move |event| {
+                    let local = event.position();
+                    probe.set(Some((local.dx.get(), local.dy.get())));
+                })
+                .child(SizedBox::new(100.0, 100.0).child(ColoredBox::new(Color::rgb(10, 20, 30)))),
+        ),
+        loose(200.0),
+    );
+
+    // dx=0.5 over a 100-wide child paints (and, by default, hit-tests) it
+    // shifted right by 50px. Tap a point inside the shifted box.
+    laid.dispatch_pointer_down(75.0, 60.0);
+
+    let local = recorded.get().expect("on_pointer_down must have fired");
+    assert_eq!(
+        local,
+        (25.0, 60.0),
+        "the delivered position must be local to the child (global (75, 60) minus the \
+         mid-animation 50px shift on x), not the raw global dispatch position",
     );
 
     controller.dispose();


### PR DESCRIPTION
## The defect

`RenderBox::hit_test_raw` built a `BoxHitTestCtx` locally and returned only `self_hit_entry_registered` / `blocks_below`. Anything a render object pushed onto the **ctx-level** transform stack — `push_offset`, `push_transform`, `with_transform` — was dropped when that ctx went out of scope.

The object consumed the offset while computing the child's position, but nothing recorded the frame change. The delivered pointer position was un-localized by exactly that amount. **The ctx API compiled and lied.**

This is the third and last member of the same family, after the box-side composition order (#460) and the sliver walk's missing push (#462).

## Measured before the fix

| case | got | want |
|---|---|---|
| `FractionalTranslation(0.5)` over a 100×100 leaf | `(100, 100)` | `(50, 50)` |
| `Flow` with a child transform | `(40, 45)` | `(20, 15)` |
| `SlideTransition` mid-animation | `(75, 60)` | `(25, 60)` |
| `FractionallySizedBox` centred at 0.5 | `(60, 60)` | `(10, 10)` |

The control — `FractionalTranslation` with `transform_hit_tests(false)`, which takes the safe `hit_test_child_at_layout_offset` path — was correct before *and* after, isolating the defect to the discarded stack rather than to the widget.

Reachability is not theoretical: `FractionalTranslation` backs `SlideTransition` (page transitions) and `Dismissible` (swipe-to-dismiss rows). Both are gesture-heavy and both handed their child a wrong local position mid-transition.

## The fix

`hit_test_raw`'s child callback now carries the forward (paint-direction) transform the ctx accumulated, and the walk wraps the child's dispatch in `with_paint_transform`, which inverts and pushes it onto the shared `HitTestResult` — the same mechanism already used for `hit_test_transform` and resolved follower offsets. `None` when the stack is empty, so the common path pays nothing.

Neither `fractional_translation.rs` nor `flow.rs` changed: both already pushed the right value, only the plumbing was missing.

`hit_test_child_at_offset` moved the position into the child's frame without pushing anything, so it stayed broken *after* the plumbing landed — `FractionallySizedBox` still delivered a position off by its alignment offset. It now pushes what it consumes, per the rule the sliver fix settled on: **push the child offset iff the position handed to the child was moved into the child's frame.**

## Caller census — every `hit_test_child*` path classified

| path | status |
|---|---|
| `hit_test_child_at_layout_offset` (~20 sites) | safe — the driver resolves and pushes |
| `hit_test_child_at_offset(_, ZERO)` (~10 sites) | nothing to push |
| `hit_test_child_at_offset(_, child_offset)` — `FractionallySizedBox` | **was broken, fixed here** |
| `with_transform` + `hit_test_child` — `Flow`, `FittedBox` | fixed by the plumbing |
| `push_offset` + `hit_test_child` — `FractionalTranslation` | fixed by the plumbing |
| `hit_test_child(0, position)` — `SliverOffstage` | zero child offset, already `debug_assert`ed |

`FittedBox` was found by that sweep — it was not named in advance by the task. The sliver protocol's ctx-level stack stays an intentional no-op and now says so; its main-axis position already covers its needs.

## Gates

workspace **8131** passed (8125 on main) · parity **446** · doctests 630 · clippy · fmt · inventory-check · port-check · doc-strict — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117t1jX2FFcCzP3YBLoQB94
