### PR TITLE
test(widgets): port the MouseRegion parity corpus

### DIFF
--- a/crates/flui-widgets/tests/common/mod.rs
+++ b/crates/flui-widgets/tests/common/mod.rs
@@ -844,9 +844,15 @@ impl LaidOut {
 
     /// A mouse hover move to `(x, y)` with no active contact.
     pub fn dispatch_pointer_hover(&self, x: f32, y: f32) {
+        self.dispatch_pointer_hover_with_kind(x, y, PointerType::Mouse);
+    }
+
+    /// As [`dispatch_pointer_hover`](Self::dispatch_pointer_hover), but for a
+    /// caller-chosen device kind (e.g. `PointerType::Pen` for stylus tests) —
+    /// the same construction, parameterised instead of hardcoded to `Mouse`.
+    pub fn dispatch_pointer_hover_with_kind(&self, x: f32, y: f32, kind: PointerType) {
         Self::advance_gesture_clock();
-        let mut event =
-            make_move_event_for_id(PointerId::PRIMARY, offset(x, y), PointerType::Mouse);
+        let mut event = make_move_event_for_id(PointerId::PRIMARY, offset(x, y), kind);
         let PointerEvent::Move(update) = &mut event else {
             unreachable!("the test move constructor must produce PointerEvent::Move");
         };

--- a/crates/flui-widgets/tests/parity/main.rs
+++ b/crates/flui-widgets/tests/parity/main.rs
@@ -152,3 +152,6 @@ mod rotated_box_test;
 // ── Business.1 fidelity — pointer hit-test parity ──
 mod pointer_hit_test_test;
 mod pointer_local_position_test;
+
+// ── Business.1 fidelity — MouseRegion parity ────────────────────────────────
+mod mouse_region_test;

--- a/crates/flui-widgets/tests/parity/mouse_region_test.rs
+++ b/crates/flui-widgets/tests/parity/mouse_region_test.rs
@@ -1,0 +1,945 @@
+//! ## Test parity notes
+//!
+//! Flutter source: `packages/flutter/test/widgets/mouse_region_test.dart`
+//! (tag `3.44.0`, 43 `testWidgets` cases — verified via `git show
+//! 3.44.0:packages/flutter/test/widgets/mouse_region_test.dart`). This is
+//! `MouseRegion`'s own oracle file — the last input-family widget without a
+//! parity file (`Listener`/`AbsorbPointer`/`IgnorePointer` landed in
+//! `pointer_hit_test_test.rs`; that file's own module doc left `MouseRegion`
+//! explicitly out of scope pending a device-tracking harness capability that
+//! this file re-checks rather than assumes).
+//!
+//! ### Harness capabilities checked before writing this file
+//!
+//! - **No device connect/disconnect primitive.** `PointerEvent` has exactly
+//!   four kinds — `Down`/`Move`/`Up`/`Cancel`
+//!   (`crates/flui-interaction/src/events.rs:913-922`); there is no
+//!   `Added`/`Removed` kind analogous to Flutter's `PointerAddedEvent`/
+//!   `PointerRemovedEvent`, and `MouseTracker::add_device`/`remove_device`
+//!   (`crates/flui-interaction/src/routing/mouse_tracker.rs:180-205`) are
+//!   never called from the pointer-dispatch pipeline
+//!   (`crates/flui-interaction/src/binding.rs`) — only from
+//!   `#[cfg(test)]` unit tests inside `mouse_tracker.rs` itself. A "mouse
+//!   connects/disconnects" event cannot be synthesized through
+//!   [`LaidOut`](crate::common::LaidOut)'s public dispatch surface.
+//! - **No stationary-device postframe recheck reachable from the widget-test
+//!   harness.** `MouseTracker::update_all_devices` — the mechanism that
+//!   re-hit-tests every tracked device after a frame that changed the tree
+//!   shape, with no new pointer motion (Flutter's implicit
+//!   `MouseTracker.schedulePostFrameCheck`) — is called exactly once in the
+//!   whole workspace: `crates/flui-app/src/app/binding.rs:1257`, inside
+//!   `Presentation::render_frame_entered`. `flui-binding`'s
+//!   `HeadlessBinding::pump_frame` (what `LaidOut::pump_widget`/`pump` drive)
+//!   never calls it. A production FLUI app running through `flui-app`'s real
+//!   frame loop reproduces Flutter's "widget moves under a stationary
+//!   pointer ⇒ automatic enter/exit" contract correctly — the mechanism
+//!   exists and is wired at that layer — but this widget-level harness
+//!   cannot observe or prove it.
+//! - **`dispatch_pointer_hover` hardcodes `PointerType::Mouse`.** There is no
+//!   `LaidOut` method for a non-mouse hover device. This file adds a local
+//!   `dispatch_pen_hover` helper (same construction as
+//!   `LaidOut::dispatch_pointer_hover`, `PointerType::Pen` instead) to reach
+//!   the one case that needs it — see [`stylus_hover_delivers_enter_hover_exit_like_a_mouse`].
+//! - **No paint-count, compositing-layer, cursor, or `hasScheduledFrame`
+//!   introspection.** Same category of gap `transform_test.rs` and
+//!   `clip_test.rs` already document for `TransformLayer`/`paints()`
+//!   assertions — `LaidOut` exposes geometry and dispatch, not a paint
+//!   recorder, a compositing-layer tree, `MouseTracker::device_cursor`
+//!   (exists but not surfaced — the `binding` field is private), or a
+//!   scheduled-frame flag.
+//!
+//! ### A genuine FLUI/Flutter divergence found while classifying, not fixed
+//! here — reported per this file's honesty bar, not silently ported around:
+//! Flutter's `RenderMouseRegion.handleEvent` (`rendering/proxy_box.dart`
+//! 3.44.0, lines 3344-3349) fires `onHover` for **any** `PointerHoverEvent`
+//! reaching it as an ordinary `HitTestTarget`, regardless of device kind —
+//! independent of `MouseTracker`, which separately gates enter/exit to
+//! `mouse`/`stylus` only (`rendering/mouse_tracker.dart:302`). FLUI's
+//! `RenderMouseRegion` (`crates/flui-objects/src/interaction/mouse_region.rs`)
+//! has no such generic hit-test-event handler at all — it contributes only a
+//! [`MouseTrackerAnnotation`], so `on_hover` fires **exclusively** through
+//! `MouseTracker::update_with_motion`, which is gated to `Mouse | Pen`
+//! (`mouse_tracker.rs:220-222`) — the same gate Flutter uses for enter/exit,
+//! but Flutter does not apply it to hover. A touch-kind hover therefore
+//! delivers `on_hover` in Flutter and delivers nothing at all in FLUI. See
+//! [`'detects hover from touch devices'`](#not-ported) below.
+//!
+//! ### Ported (15 of 43)
+//! - `'hitTestBehavior test - HitTestBehavior.deferToChild/opaque'` —
+//!   [`hit_test_behavior_defer_to_child_then_opaque_toggles_enter`].
+//! - `'hitTestBehavior test - HitTestBehavior.deferToChild and non-opaque'` —
+//!   [`hit_test_behavior_defer_to_child_non_opaque_does_not_block_the_region_below`].
+//! - `'hitTestBehavior test - HitTestBehavior.translucent'` —
+//!   [`hit_test_behavior_translucent_does_not_block_the_region_below`].
+//! - `'onEnter and onExit can be triggered with mouse buttons pressed'`
+//!   (adapted: FLUI's `on_enter`/`on_hover`/`on_exit` deliver a single
+//!   `Offset` — see the render-object's `MouseRegionCallback` type alias,
+//!   `crates/flui-objects/src/interaction/mouse_region.rs:22` — which is the
+//!   raw event position (`DeviceWork::invoke`,
+//!   `mouse_tracker.rs:543-609`, calls every callback with the same
+//!   `self.position`), never a region-local position; the upstream
+//!   `enter!.localPosition`/`exit!.localPosition` assertions have nothing to
+//!   port against, so only `.position` is checked) —
+//!   [`enter_and_exit_fire_while_a_mouse_button_is_held`].
+//! - `'detects pointer enter'` — [`detects_pointer_enter`].
+//! - `'detects pointer exiting'` — [`detects_pointer_exiting`].
+//! - `"doesn't trigger pointer exit when widget disappears"` —
+//!   [`removing_a_hovered_region_does_not_synthesize_an_exit`].
+//! - `'Hover works with nested listeners'` —
+//!   [`hover_works_with_nested_regions`].
+//! - `'Hover transfers between two listeners'` —
+//!   [`hover_transfers_between_two_regions`].
+//! - `'MouseRegion uses updated callbacks'` —
+//!   [`mouse_region_uses_updated_callbacks`].
+//! - `'works with transform'` (the geometry legs only — the `delta` field
+//!   assertion has no FLUI equivalent for the same single-`Offset`-callback
+//!   reason as the mouse-buttons-pressed case above; substituted with an
+//!   equally strong direct check that the delivered `Offset` matches the
+//!   dispatched global position) —
+//!   [`hit_test_transitions_correctly_through_a_2x_transform_scale`]. This is
+//!   the highest-value port in this file: it proves the delivered hit-test
+//!   position under a `Transform::scale` is now correct end-to-end through
+//!   `MouseRegion`, the exact class of bug three hit-test-transform-
+//!   composition fixes just landed for (`b1bb4905`, and the PRs
+//!   `pointer_hit_test_test.rs`/`pointer_local_position_test.rs` cite).
+//! - `"Callbacks aren't called during build"` (adapted: Flutter's oracle
+//!   drives the rebuild through an internal `setState` inside the
+//!   `HoverClient`/`HoverFeedback` `StatefulWidget`s that own the callbacks;
+//!   wiring a FLUI `StatefulView`'s rebuild handle into a callback registered
+//!   from `build()` is real but disproportionate plumbing for this single
+//!   case, so this port drives the exact same rebuild — a `pump_widget`
+//!   root-swap with no new pointer dispatch between it and the prior
+//!   dispatch — from the test body directly. The invariant under test
+//!   (rebuilding an already-hovered/already-exited region must not refire
+//!   `on_enter`/`on_exit`) is identical either way) —
+//!   [`rebuilding_an_active_region_does_not_refire_enter_or_exit`].
+//! - `'opaque should default to true'` (`group('MouseRegion respects
+//!   opacity:', ...)`) —
+//!   [`opaque_defaults_to_true_and_blocks_the_region_below`].
+//! - `'an empty opaque MouseRegion is effective'` —
+//!   [`a_childless_opaque_mouse_region_still_blocks_everything_beneath_it`].
+//! - `'stylus input works'` (via the local `dispatch_pen_hover` helper —
+//!   see the harness-capabilities note above) —
+//!   [`stylus_hover_delivers_enter_hover_exit_like_a_mouse`].
+//!
+//! ### Not ported (28 of 43) {#not-ported}
+//! Grouped by shared reason so the arithmetic stays checkable (15 + 28 = 43)
+//! without repeating each explanation 43 times:
+//!
+//! **No device connect/disconnect primitive** (3): `'triggers pointer enter
+//! when a mouse is connected'`, `'triggers pointer exit when a mouse is
+//! disconnected'`, `'Exit event when unplugging mouse should have a
+//! position'`.
+//!
+//! **No stationary-device postframe recheck reachable from this harness**
+//! (5): `'triggers pointer enter when widget appears'`, `'triggers pointer
+//! enter when widget moves in'`, `'triggers pointer exit when widget moves
+//! out'` (its initial "enter" leg is also an implicit-connect, the first
+//! reason above), `'A MouseRegion mounted under the pointer should take
+//! effect in the next postframe'`, `'A MouseRegion moved into the mouse
+//! should take effect in the next postframe'`.
+//!
+//! **`hasScheduledFrame` has no harness equivalent** (2, one overlapping the
+//! postframe-recheck group above): `'A MouseRegion unmounted under the
+//! pointer should not trigger state change'`, `'No new frames are scheduled
+//! when mouse moves without triggering callbacks'`.
+//!
+//! **Touch-kind hover is a genuine FLUI/Flutter divergence, not just a
+//! harness gap** (1) — see the section above: `'detects hover from touch
+//! devices'`.
+//!
+//! **No cursor introspection surfaced by `LaidOut`** (1) —
+//! `MouseTracker::device_cursor` exists (`mouse_tracker.rs:450`) but nothing
+//! exposes it through the widget-test harness (`LaidOut`'s `binding` field is
+//! private); a legitimate small harness extension, out of scope for a
+//! test-porting pass: `'applies mouse cursor'`.
+//!
+//! **No compositing-layer/`needsCompositing`/layer-count introspection** (2)
+//! — the same gap `transform_test.rs`'s own module doc documents for
+//! `TransformLayer` assertions: `'needsCompositing set when parent class
+//! needsCompositing is set'`, `'needsCompositing is always false'`.
+//!
+//! **No paint-count introspection** (6) — `LaidOut` has no `CustomPaint`
+//! call-count recorder: `'MouseRegion paints child once and only once when
+//! MouseRegion is inactive'`, `'... when MouseRegion is active'`, `"Changing
+//! MouseRegion's callbacks is effective and doesn't repaint"`, `'Changing
+//! MouseRegion.opaque is effective and repaints'`, `'Changing
+//! MouseRegion.cursor is effective and repaints'` (also needs cursor
+//! introspection, above), `'Changing whether MouseRegion.cursor is null is
+//! effective and repaints'` (same, also needs cursor introspection).
+//!
+//! **Diagnostics-string formatting, not hit-test behavior** (2) — same
+//! out-of-scope call `pointer_hit_test_test.rs`'s module doc already makes
+//! for `Listener`'s `debugFillProperties` cases: `"RenderMouseRegion's
+//! debugFillProperties when default"`, `"RenderMouseRegion's
+//! debugFillProperties when full"`.
+//!
+//! **`StatefulView`-rebuild-handle-in-callback plumbing, deferred** (2) —
+//! same real-but-disproportionate cost as the one case adapted around above
+//! ([`rebuilding_an_active_region_does_not_refire_enter_or_exit`]), but these
+//! two don't clear the "worth the substitution" bar the way that one does:
+//! `'MouseRegion activate/deactivate don't duplicate annotations'` (also
+//! needs `GlobalKey`-based deactivate/reactivate), `'detects pointer enter
+//! with closure arguments'` (tests no `MouseRegion` contract beyond
+//! [`detects_pointer_enter`]/[`detects_pointer_exiting`]/
+//! [`removing_a_hovered_region_does_not_synthesize_an_exit`] once the
+//! `StatefulWidget` indirection is stripped away).
+//!
+//! **`GlobalKey` reparent does not preserve render-object identity in
+//! FLUI** (1) — `'Does not trigger side effects during a reparent'` depends
+//! on the *same* `RenderMouseRegion`/mouse-tracker annotation surviving a
+//! structural move so no cursor-platform-channel call re-fires.
+//! `animated_size_test.rs`'s own module doc already documents this
+//! architectural divergence for `AnimatedSize`: "FLUI's remove+insert
+//! reparent model cannot preserve a Rust render object's identity across
+//! that boundary." A reparented `MouseRegion` mints a fresh
+//! `RenderMouseRegion`, tearing down the old mouse-tracker annotation and
+//! registering a new one within the same `pump_widget` call, with no pointer
+//! event dispatched in between — porting this case would only re-prove "no
+//! dispatch ⇒ no spurious event," which
+//! [`removing_a_hovered_region_does_not_synthesize_an_exit`] already covers;
+//! it would not prove what the Flutter test's name claims.
+//!
+//! **Disproportionate regression-scenario setup, not a `MouseRegion`
+//! capability gap** (1) — `'Handle mouse events should ignore the detached
+//! MouseTrackerAnnotation'` exercises a `Draggable`-drag-causes-mid-gesture-
+//! detachment regression; `Draggable`'s own parity lives in
+//! `draggable_test.rs`, and this specific detached-annotation scenario is
+//! large new setup for a case outside this file's `MouseRegion`-behavior
+//! scope.
+//!
+//! **Deliberate scope cut, not a capability gap** (2) — `group('MouseRegion
+//! respects opacity:', ...)`'s other two cases, `'a transparent one should
+//! allow MouseRegions behind it to receive pointers'` and `'an opaque one
+//! should prevent MouseRegions behind it receiving pointers'`, replay the
+//! same three-way-stack + opaque/non-opaque hit-test contract the three
+//! `hitTestBehavior` cases and
+//! [`opaque_defaults_to_true_and_blocks_the_region_below`] already establish,
+//! across six sequential move legs of cumulative order-sensitive log
+//! assertions instead of two. Valuable as an exhaustive transition matrix;
+//! disproportionate additional scope for this pass.
+//!
+//! Count check, one primary reason per case, no case counted twice: 3
+//! (connect/disconnect) + 5 (postframe recheck) + 2 (`hasScheduledFrame`) + 1
+//! (touch hover) + 1 (cursor introspection) + 2 (compositing) + 6
+//! (paint-count) + 2 (`debugFillProperties`) + 2 (`StatefulView` plumbing) +
+//! 1 (`GlobalKey` reparent) + 1 (`Draggable` regression) + 2 (opacity
+//! transition matrix) = 28 not ported. 15 ported + 28 not ported = 43.
+//!
+//! Widget → render-object mapping:
+//! - `MouseRegion` → `RenderMouseRegion`
+//!   (`crates/flui-objects/src/interaction/mouse_region.rs`)
+//! - Enter/hover/exit delivery → `MouseTracker`
+//!   (`crates/flui-interaction/src/routing/mouse_tracker.rs`)
+//!
+//! This file is additive to `crates/flui-widgets/tests/mouse_region.rs` (3
+//! non-parity tests: childless fill/sizes-to-child geometry, a single
+//! `on_hover` smoke test) and `crates/flui-objects/tests/render_object_harness.rs`
+//! (`:1021`/`:1042`, `RenderMouseRegion` sibling/tracker entries at the
+//! render-object level).
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use flui_interaction::PointerId;
+use flui_interaction::events::{PointerButtons, PointerType, make_move_event_for_id};
+use flui_types::{Alignment, Offset};
+use flui_view::ViewExt;
+use flui_widgets::prelude::*;
+
+use crate::common::LaidOut;
+use crate::harness;
+
+/// Dispatches a stylus/pen-kind hover move — the same construction
+/// [`LaidOut::dispatch_pointer_hover`] uses internally, but with
+/// `PointerType::Pen` in place of the hardcoded `PointerType::Mouse`. There is
+/// no harness method for a non-mouse hover device (see the module doc); this
+/// is test-local rather than a `common/mod.rs` addition because
+/// [`stylus_hover_delivers_enter_hover_exit_like_a_mouse`] is the only case
+/// that needs it.
+fn dispatch_pen_hover(laid: &LaidOut, x: f32, y: f32) {
+    let mut event = make_move_event_for_id(PointerId::PRIMARY, offset(x, y), PointerType::Pen);
+    let flui_interaction::events::PointerEvent::Move(update) = &mut event else {
+        unreachable!("make_move_event_for_id must produce PointerEvent::Move");
+    };
+    update.current.buttons = PointerButtons::new();
+    update.current.pressure = 0.0;
+    laid.dispatch_pointer_event(&event);
+}
+
+fn offset(x: f32, y: f32) -> Offset {
+    Offset::new(px(x), px(y))
+}
+
+// ── hitTestBehavior ──────────────────────────────────────────────────────────
+
+/// A childless `DeferToChild` region never registers a hit at all (no child
+/// to defer to); switching the SAME region to the default `Opaque` behavior
+/// makes it self-register unconditionally within its own bounds.
+///
+/// Flutter parity: `'hitTestBehavior test - HitTestBehavior.deferToChild/opaque'`
+/// — `MouseRegion(hitTestBehavior: deferToChild)` under a stationary pointer
+/// never fires `onEnter`; rebuilding to the default `MouseRegion(onEnter:
+/// ...)` (opaque) does. Adapted: upstream observes the second leg's `onEnter`
+/// from the *stationary* pointer alone (Flutter's implicit postframe
+/// recheck); this harness has no equivalent (see the module doc), so the
+/// second leg re-dispatches an explicit hover at the same point instead —
+/// still a genuine, fresh hit test the same device performs on receiving a
+/// real event, not a synthesized pass.
+#[test]
+fn hit_test_behavior_defer_to_child_then_opaque_toggles_enter() {
+    let entered = Rc::new(Cell::new(false));
+    let on_enter = Rc::clone(&entered);
+
+    let mut laid = harness::pump_widget(
+        MouseRegion::new()
+            .behavior(HitTestBehavior::DeferToChild)
+            .on_enter(move |_device, _position| on_enter.set(true)),
+        harness::screen_of(50.0, 50.0),
+    );
+    laid.dispatch_pointer_hover(25.0, 25.0);
+    assert!(
+        !entered.get(),
+        "a childless DeferToChild region has no child to defer to and must never register a hit"
+    );
+
+    let on_enter = Rc::clone(&entered);
+    laid.pump_widget(MouseRegion::new().on_enter(move |_device, _position| on_enter.set(true)));
+    laid.dispatch_pointer_hover(25.0, 25.0);
+    assert!(
+        entered.get(),
+        "the default Opaque behavior must self-register a hit even with no child"
+    );
+}
+
+/// A `deferToChild`, non-opaque region with a real hit-testable child does
+/// not block the sibling MouseRegion stacked below it.
+///
+/// Flutter parity: `'hitTestBehavior test - HitTestBehavior.deferToChild and
+/// non-opaque'` — two overlapping `MouseRegion`s in a `Stack`; the top one
+/// (`opaque: false`, `deferToChild`, with a real child) still lets the
+/// bottom one see the pointer.
+#[test]
+fn hit_test_behavior_defer_to_child_non_opaque_does_not_block_the_region_below() {
+    let region1_entered = Rc::new(Cell::new(false));
+    let region2_entered = Rc::new(Cell::new(false));
+    let on_enter1 = Rc::clone(&region1_entered);
+    let on_enter2 = Rc::clone(&region2_entered);
+
+    let laid = harness::pump_widget(
+        Stack::new(vec![
+            SizedBox::new(50.0, 50.0)
+                .child(MouseRegion::new().on_enter(move |_d, _p| on_enter1.set(true)))
+                .boxed(),
+            SizedBox::new(50.0, 50.0)
+                .child(
+                    MouseRegion::new()
+                        .opaque(false)
+                        .behavior(HitTestBehavior::DeferToChild)
+                        .on_enter(move |_d, _p| on_enter2.set(true))
+                        .child(
+                            ColoredBox::new(Color::rgb(255, 16, 25))
+                                .child(SizedBox::new(50.0, 50.0)),
+                        ),
+                )
+                .boxed(),
+        ]),
+        harness::screen_of(50.0, 50.0),
+    );
+
+    laid.dispatch_pointer_hover(10.0, 10.0);
+
+    assert!(
+        region2_entered.get(),
+        "the top, deferToChild region has a hit-testable child and must self-register"
+    );
+    assert!(
+        region1_entered.get(),
+        "opaque(false) on the top region must let the bottom sibling see the pointer too"
+    );
+}
+
+/// A childless `translucent` region self-registers (unlike `deferToChild`)
+/// and, being non-opaque by construction, does not block the sibling below.
+///
+/// Flutter parity: `'hitTestBehavior test - HitTestBehavior.translucent'`.
+#[test]
+fn hit_test_behavior_translucent_does_not_block_the_region_below() {
+    let region1_entered = Rc::new(Cell::new(false));
+    let region2_entered = Rc::new(Cell::new(false));
+    let on_enter1 = Rc::clone(&region1_entered);
+    let on_enter2 = Rc::clone(&region2_entered);
+
+    let laid = harness::pump_widget(
+        Stack::new(vec![
+            SizedBox::new(50.0, 50.0)
+                .child(MouseRegion::new().on_enter(move |_d, _p| on_enter1.set(true)))
+                .boxed(),
+            SizedBox::new(50.0, 50.0)
+                .child(
+                    MouseRegion::new()
+                        .behavior(HitTestBehavior::Translucent)
+                        .on_enter(move |_d, _p| on_enter2.set(true)),
+                )
+                .boxed(),
+        ]),
+        harness::screen_of(50.0, 50.0),
+    );
+
+    laid.dispatch_pointer_hover(10.0, 10.0);
+
+    assert!(
+        region2_entered.get(),
+        "a childless translucent region must self-register even with nothing to defer to"
+    );
+    assert!(
+        region1_entered.get(),
+        "translucent must not block the sibling below"
+    );
+}
+
+// ── Enter / hover / exit ─────────────────────────────────────────────────────
+
+/// Enter and exit still fire while a mouse button is held (a `Move` inside an
+/// active Down-to-Up sequence, not a bare `Hover`).
+///
+/// Flutter parity: `'onEnter and onExit can be triggered with mouse buttons
+/// pressed'`. See the module doc for why only `.position` (not
+/// `.localPosition`) is checked.
+#[test]
+fn enter_and_exit_fire_while_a_mouse_button_is_held() {
+    let enters: Rc<RefCell<Vec<Offset>>> = Rc::new(RefCell::new(Vec::new()));
+    let exits: Rc<RefCell<Vec<Offset>>> = Rc::new(RefCell::new(Vec::new()));
+    let on_enter = Rc::clone(&enters);
+    let on_exit = Rc::clone(&exits);
+
+    let laid = harness::pump_widget(
+        Align::new(Alignment::CENTER).child(
+            MouseRegion::new()
+                .on_enter(move |_device, position| on_enter.borrow_mut().push(position))
+                .on_exit(move |_device, position| on_exit.borrow_mut().push(position))
+                .child(SizedBox::new(100.0, 100.0)),
+        ),
+        harness::screen_of(300.0, 300.0),
+    );
+
+    // Press the button outside the centered 100x100 box (spans (100,100)-(200,200)).
+    laid.dispatch_pointer_down(10.0, 10.0);
+    assert!(enters.borrow().is_empty());
+
+    laid.dispatch_pointer_move(150.0, 150.0);
+    assert_eq!(
+        enters.borrow().as_slice(),
+        &[offset(150.0, 150.0)],
+        "a pressed move into the region must still fire onEnter"
+    );
+    assert!(exits.borrow().is_empty());
+
+    laid.dispatch_pointer_move(10.0, 10.0);
+    assert_eq!(
+        exits.borrow().as_slice(),
+        &[offset(10.0, 10.0)],
+        "a pressed move back out must still fire onExit"
+    );
+
+    laid.dispatch_pointer_up(10.0, 10.0);
+}
+
+/// A hover into a region fires `enter` then `hover`, in that order, with no
+/// `exit`.
+///
+/// Flutter parity: `'detects pointer enter'`.
+#[test]
+fn detects_pointer_enter() {
+    let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+    let (on_enter, on_hover, on_exit) = (Rc::clone(&log), Rc::clone(&log), Rc::clone(&log));
+
+    let laid = harness::pump_widget(
+        Align::new(Alignment::CENTER).child(
+            MouseRegion::new()
+                .on_enter(move |_d, _p| on_enter.borrow_mut().push("enter"))
+                .on_hover(move |_d, _p| on_hover.borrow_mut().push("hover"))
+                .on_exit(move |_d, _p| on_exit.borrow_mut().push("exit"))
+                .child(SizedBox::new(100.0, 100.0)),
+        ),
+        harness::screen_of(300.0, 300.0),
+    );
+
+    laid.dispatch_pointer_hover(150.0, 150.0);
+
+    assert_eq!(log.borrow().as_slice(), &["enter", "hover"]);
+}
+
+/// A hover that leaves a region fires only `exit`.
+///
+/// Flutter parity: `'detects pointer exiting'`.
+#[test]
+fn detects_pointer_exiting() {
+    let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+    let (on_enter, on_hover, on_exit) = (Rc::clone(&log), Rc::clone(&log), Rc::clone(&log));
+
+    let laid = harness::pump_widget(
+        Align::new(Alignment::CENTER).child(
+            MouseRegion::new()
+                .on_enter(move |_d, _p| on_enter.borrow_mut().push("enter"))
+                .on_hover(move |_d, _p| on_hover.borrow_mut().push("hover"))
+                .on_exit(move |_d, _p| on_exit.borrow_mut().push("exit"))
+                .child(SizedBox::new(100.0, 100.0)),
+        ),
+        harness::screen_of(300.0, 300.0),
+    );
+
+    laid.dispatch_pointer_hover(150.0, 150.0);
+    log.borrow_mut().clear();
+
+    laid.dispatch_pointer_hover(10.0, 10.0);
+
+    assert_eq!(log.borrow().as_slice(), &["exit"]);
+}
+
+/// Removing an actively-hovered region (a `pump_widget` root-swap, no new
+/// pointer dispatch) fires no spurious `exit` — the unmount path
+/// unregisters the mouse-tracker annotation silently.
+///
+/// Flutter parity: `"doesn't trigger pointer exit when widget disappears"`.
+#[test]
+fn removing_a_hovered_region_does_not_synthesize_an_exit() {
+    let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+    let (on_enter, on_hover, on_exit) = (Rc::clone(&log), Rc::clone(&log), Rc::clone(&log));
+
+    let mut laid = harness::pump_widget(
+        Align::new(Alignment::CENTER).child(
+            MouseRegion::new()
+                .on_enter(move |_d, _p| on_enter.borrow_mut().push("enter"))
+                .on_hover(move |_d, _p| on_hover.borrow_mut().push("hover"))
+                .on_exit(move |_d, _p| on_exit.borrow_mut().push("exit"))
+                .child(SizedBox::new(100.0, 100.0)),
+        ),
+        harness::screen_of(300.0, 300.0),
+    );
+
+    laid.dispatch_pointer_hover(150.0, 150.0);
+    log.borrow_mut().clear();
+
+    laid.pump_widget(SizedBox::new(100.0, 100.0));
+
+    assert!(
+        log.borrow().is_empty(),
+        "removing a hovered region with no new pointer dispatch must not synthesize an exit"
+    );
+}
+
+/// A pointer over a nested region fires enter/hover on both the inner and
+/// outer regions; moving to a point still within the outer region but
+/// outside the inner one exits only the inner region (the outer keeps
+/// hovering, no re-enter, no exit).
+///
+/// Flutter parity: `'Hover works with nested listeners'` — outer
+/// `MouseRegion(200x200, padding 50)` wrapping an inner `MouseRegion`
+/// (fills the padded 100x100 remainder).
+#[test]
+fn hover_works_with_nested_regions() {
+    let outer_log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+    let inner_log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+    let (outer_enter, outer_hover, outer_exit) = (
+        Rc::clone(&outer_log),
+        Rc::clone(&outer_log),
+        Rc::clone(&outer_log),
+    );
+    let (inner_enter, inner_hover, inner_exit) = (
+        Rc::clone(&inner_log),
+        Rc::clone(&inner_log),
+        Rc::clone(&inner_log),
+    );
+
+    let laid = harness::pump_widget(
+        MouseRegion::new()
+            .on_enter(move |_d, _p| outer_enter.borrow_mut().push("enter"))
+            .on_hover(move |_d, _p| outer_hover.borrow_mut().push("hover"))
+            .on_exit(move |_d, _p| outer_exit.borrow_mut().push("exit"))
+            .child(
+                Container::new().padding(EdgeInsets::all(px(50.0))).child(
+                    MouseRegion::new()
+                        .on_enter(move |_d, _p| inner_enter.borrow_mut().push("enter"))
+                        .on_hover(move |_d, _p| inner_hover.borrow_mut().push("hover"))
+                        .on_exit(move |_d, _p| inner_exit.borrow_mut().push("exit")),
+                ),
+            ),
+        harness::screen_of(200.0, 200.0),
+    );
+
+    // Inner region spans (50,50)-(150,150); center (100,100).
+    laid.dispatch_pointer_hover(100.0, 100.0);
+    assert_eq!(inner_log.borrow().as_slice(), &["enter", "hover"]);
+    assert_eq!(outer_log.borrow().as_slice(), &["enter", "hover"]);
+    inner_log.borrow_mut().clear();
+    outer_log.borrow_mut().clear();
+
+    // Still within the outer 200x200 box, outside the inner 100x100 one.
+    laid.dispatch_pointer_hover(25.0, 100.0);
+    assert_eq!(
+        inner_log.borrow().as_slice(),
+        &["exit"],
+        "leaving the inner region only exits the inner region"
+    );
+    assert_eq!(
+        outer_log.borrow().as_slice(),
+        &["hover"],
+        "the outer region keeps hovering, with no re-enter or exit"
+    );
+}
+
+/// Hover transfers cleanly between two sibling regions: entering the second
+/// exits the first, and moving off both exits whichever was last active.
+/// Unmounting afterward (no new dispatch) fires nothing further.
+///
+/// Flutter parity: `'Hover transfers between two listeners'`.
+#[test]
+fn hover_transfers_between_two_regions() {
+    let log1: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+    let log2: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+    let (e1, h1, x1) = (Rc::clone(&log1), Rc::clone(&log1), Rc::clone(&log1));
+    let (e2, h2, x2) = (Rc::clone(&log2), Rc::clone(&log2), Rc::clone(&log2));
+
+    let mut laid = harness::pump_widget(
+        Column::new(vec![
+            MouseRegion::new()
+                .on_enter(move |_d, _p| e1.borrow_mut().push("enter"))
+                .on_hover(move |_d, _p| h1.borrow_mut().push("hover"))
+                .on_exit(move |_d, _p| x1.borrow_mut().push("exit"))
+                .child(SizedBox::new(100.0, 100.0))
+                .boxed(),
+            MouseRegion::new()
+                .on_enter(move |_d, _p| e2.borrow_mut().push("enter"))
+                .on_hover(move |_d, _p| h2.borrow_mut().push("hover"))
+                .on_exit(move |_d, _p| x2.borrow_mut().push("exit"))
+                .child(SizedBox::new(100.0, 100.0))
+                .boxed(),
+        ]),
+        harness::screen_of(100.0, 200.0),
+    );
+
+    // Region 1 spans y in [0,100), region 2 spans y in [100,200).
+    laid.dispatch_pointer_hover(50.0, 50.0);
+    assert_eq!(log1.borrow().as_slice(), &["enter", "hover"]);
+    assert!(log2.borrow().is_empty());
+    log1.borrow_mut().clear();
+
+    laid.dispatch_pointer_hover(50.0, 150.0);
+    assert_eq!(log1.borrow().as_slice(), &["exit"]);
+    assert_eq!(log2.borrow().as_slice(), &["enter", "hover"]);
+    log1.borrow_mut().clear();
+    log2.borrow_mut().clear();
+
+    // Outside the 200-tall screen entirely -- outside both regions.
+    laid.dispatch_pointer_hover(50.0, 205.0);
+    assert!(log1.borrow().is_empty());
+    assert_eq!(log2.borrow().as_slice(), &["exit"]);
+    log2.borrow_mut().clear();
+
+    laid.pump_widget(SizedBox::new(1.0, 1.0));
+    assert!(log1.borrow().is_empty());
+    assert!(
+        log2.borrow().is_empty(),
+        "removing both regions with no new dispatch must not synthesize an exit"
+    );
+}
+
+/// Rebuilding a region with NEW callbacks routes subsequent enter/hover/exit
+/// to the new closures, never the stale ones from mount.
+///
+/// Flutter parity: `'MouseRegion uses updated callbacks'`.
+#[test]
+fn mouse_region_uses_updated_callbacks() {
+    fn region(
+        log: &Rc<RefCell<Vec<&'static str>>>,
+        enter: &'static str,
+        hover: &'static str,
+        exit: &'static str,
+    ) -> Align {
+        let (e, h, x) = (Rc::clone(log), Rc::clone(log), Rc::clone(log));
+        Align::new(Alignment::TOP_LEFT).child(
+            MouseRegion::new()
+                .on_enter(move |_d, _p| e.borrow_mut().push(enter))
+                .on_hover(move |_d, _p| h.borrow_mut().push(hover))
+                .on_exit(move |_d, _p| x.borrow_mut().push(exit))
+                .child(SizedBox::new(100.0, 100.0)),
+        )
+    }
+
+    let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+
+    let mut laid = harness::pump_widget(
+        region(&log, "enter1", "hover1", "exit1"),
+        harness::screen_of(300.0, 300.0),
+    );
+
+    laid.dispatch_pointer_hover(150.0, 150.0);
+    assert!(
+        log.borrow().is_empty(),
+        "the pointer starts and stays outside the top-left 100x100 box"
+    );
+
+    laid.dispatch_pointer_hover(50.0, 50.0);
+    laid.dispatch_pointer_hover(150.0, 150.0);
+    assert_eq!(log.borrow().as_slice(), &["enter1", "hover1", "exit1"]);
+    log.borrow_mut().clear();
+
+    laid.pump_widget(region(&log, "enter2", "hover2", "exit2"));
+    laid.dispatch_pointer_hover(50.0, 50.0);
+    laid.dispatch_pointer_hover(150.0, 150.0);
+    assert_eq!(
+        log.borrow().as_slice(),
+        &["enter2", "hover2", "exit2"],
+        "rebuilt callbacks must be used, not the stale closures captured at mount"
+    );
+}
+
+// ── Transform ─────────────────────────────────────────────────────────────
+
+/// A `MouseRegion` scaled 2x by an ancestor `Transform` hit-tests correctly
+/// against its SCALED bounds, not its unscaled layout bounds — proving the
+/// hit-test-transform-composition fixes land correctly through the widget →
+/// render-object wiring `MouseRegion` uses.
+///
+/// Geometry: the unscaled child (`SizedBox(150, 100)`) lays out at local
+/// `(0,0)-(150,100)`; `Transform::scale` defaults to `Alignment::CENTER`
+/// (matching Flutter's `Transform.scale` factory), pivoting on the child's
+/// own center `(75, 50)`. The scaled absolute span is therefore `x:
+/// [75-150, 75+150] = [-75, 225]`, `y: [50-100, 50+100] = [-50, 150]`.
+///
+/// Flutter parity: `'works with transform'` — the `delta`-field assertion
+/// has no port (see the module doc); the equally strong substitute checks
+/// the delivered `Offset` against the dispatched global position directly.
+#[test]
+fn hit_test_transitions_correctly_through_a_2x_transform_scale() {
+    let events: Rc<RefCell<Vec<(&'static str, Offset)>>> = Rc::new(RefCell::new(Vec::new()));
+    let (on_enter, on_hover, on_exit) =
+        (Rc::clone(&events), Rc::clone(&events), Rc::clone(&events));
+
+    let laid = harness::pump_widget(
+        Transform::scale(2.0, 2.0).child(
+            MouseRegion::new()
+                .on_enter(move |_d, p| on_enter.borrow_mut().push(("enter", p)))
+                .on_hover(move |_d, p| on_hover.borrow_mut().push(("hover", p)))
+                .on_exit(move |_d, p| on_exit.borrow_mut().push(("exit", p)))
+                .child(SizedBox::new(150.0, 100.0)),
+        ),
+        crate::common::loose(400.0),
+    );
+
+    // Just outside the scaled span's top-left corner (-75, -50).
+    laid.dispatch_pointer_hover(-76.0, -51.0);
+    assert!(events.borrow().is_empty());
+
+    // Just inside the same corner.
+    laid.dispatch_pointer_hover(-74.0, -49.0);
+    assert_eq!(
+        events.borrow().as_slice(),
+        &[
+            ("enter", offset(-74.0, -49.0)),
+            ("hover", offset(-74.0, -49.0)),
+        ]
+    );
+    events.borrow_mut().clear();
+
+    // Just inside the scaled span's bottom-left corner (-75, 150).
+    laid.dispatch_pointer_hover(-74.0, 149.0);
+    assert_eq!(
+        events.borrow().as_slice(),
+        &[("hover", offset(-74.0, 149.0))]
+    );
+    events.borrow_mut().clear();
+
+    // Just outside the same corner.
+    laid.dispatch_pointer_hover(-74.0, 151.0);
+    assert_eq!(
+        events.borrow().as_slice(),
+        &[("exit", offset(-74.0, 151.0))]
+    );
+}
+
+// ── Build/rebuild safety ──────────────────────────────────────────────────
+
+/// Rebuilding an already-hovered (or already-exited) region — with no new
+/// pointer dispatch between the rebuild and the prior one — must not refire
+/// `on_enter`/`on_exit`.
+///
+/// Flutter parity: `"Callbacks aren't called during build"`, adapted — see
+/// the module doc for why this drives the rebuild directly instead of
+/// through a `StatefulView`'s internal `setState`.
+#[test]
+fn rebuilding_an_active_region_does_not_refire_enter_or_exit() {
+    let enters = Rc::new(Cell::new(0u32));
+    let exits = Rc::new(Cell::new(0u32));
+
+    fn region(enters: &Rc<Cell<u32>>, exits: &Rc<Cell<u32>>) -> MouseRegion {
+        let (e, x) = (Rc::clone(enters), Rc::clone(exits));
+        MouseRegion::new()
+            .on_enter(move |_d, _p| e.set(e.get() + 1))
+            .on_exit(move |_d, _p| x.set(x.get() + 1))
+            .child(SizedBox::new(100.0, 100.0))
+    }
+
+    let mut laid = harness::pump_widget(region(&enters, &exits), harness::screen_of(100.0, 100.0));
+
+    laid.dispatch_pointer_hover(50.0, 50.0);
+    assert_eq!(enters.get(), 1);
+
+    laid.pump_widget(region(&enters, &exits));
+    assert_eq!(
+        enters.get(),
+        1,
+        "a rebuild alone, with no new pointer event, must not refire enter"
+    );
+    assert_eq!(exits.get(), 0);
+
+    laid.dispatch_pointer_hover(500.0, 500.0);
+    assert_eq!(exits.get(), 1);
+
+    laid.pump_widget(region(&enters, &exits));
+    assert_eq!(
+        exits.get(),
+        1,
+        "a rebuild after exit must not refire exit either"
+    );
+    assert_eq!(enters.get(), 1);
+}
+
+// ── Opacity ───────────────────────────────────────────────────────────────
+
+/// Three overlapping regions (A wraps B and C; C sits on top of B and is
+/// opaque by default): hitting the B/C overlap area fires A and C only (C
+/// blocks B); moving out exits C then A.
+///
+/// Flutter parity: `group('MouseRegion respects opacity:', ...)` →
+/// `'opaque should default to true'`.
+#[test]
+fn opaque_defaults_to_true_and_blocks_the_region_below() {
+    let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+    let (ea, ha, xa) = (Rc::clone(&log), Rc::clone(&log), Rc::clone(&log));
+    let (ec, hc, xc) = (Rc::clone(&log), Rc::clone(&log), Rc::clone(&log));
+
+    let laid = harness::pump_widget(
+        Align::new(Alignment::TOP_LEFT).child(
+            MouseRegion::new()
+                .on_enter(move |_d, _p| ea.borrow_mut().push("enterA"))
+                .on_hover(move |_d, _p| ha.borrow_mut().push("hoverA"))
+                .on_exit(move |_d, _p| xa.borrow_mut().push("exitA"))
+                .child(SizedBox::new(150.0, 150.0).child(Stack::new(vec![
+                        Positioned::new(MouseRegion::new())
+                            .left(20.0)
+                            .top(20.0)
+                            .width(80.0)
+                            .height(80.0)
+                            .boxed(),
+                        Positioned::new(
+                            MouseRegion::new()
+                                .on_enter(move |_d, _p| ec.borrow_mut().push("enterC"))
+                                .on_hover(move |_d, _p| hc.borrow_mut().push("hoverC"))
+                                .on_exit(move |_d, _p| xc.borrow_mut().push("exitC")),
+                        )
+                        .left(50.0)
+                        .top(50.0)
+                        .width(80.0)
+                        .height(80.0)
+                        .boxed(),
+                    ]))),
+        ),
+        harness::screen_of(200.0, 200.0),
+    );
+
+    // (75,75) is inside A, B ([20,100]x[20,100]), and C ([50,130]x[50,130]);
+    // C is stacked on top of B and opaque by default, so B never fires.
+    laid.dispatch_pointer_hover(75.0, 75.0);
+    assert_eq!(
+        log.borrow().as_slice(),
+        &["enterA", "enterC", "hoverC", "hoverA"],
+        "C, opaque by default, must block B underneath"
+    );
+    log.borrow_mut().clear();
+
+    laid.dispatch_pointer_hover(160.0, 160.0);
+    assert_eq!(log.borrow().as_slice(), &["exitC", "exitA"]);
+}
+
+/// A childless, opaque (default) `MouseRegion` stacked on top of a smaller
+/// hit-testable region blocks the pointer everywhere across the whole
+/// stack's area — including inside the smaller region's own bounds — because
+/// a childless `MouseRegion` sizes to `constraints.biggest()`, not zero.
+///
+/// Flutter parity: `'an empty opaque MouseRegion is effective'`.
+///
+/// Red-check: a broken childless-layout branch (returning `Size::ZERO`
+/// instead of `constraints.biggest()`) would make this test fail — mutation-
+/// run and confirmed (see the build report).
+#[test]
+fn a_childless_opaque_mouse_region_still_blocks_everything_beneath_it() {
+    let bottom_region_hovered = Rc::new(Cell::new(false));
+    let (e, h, x) = (
+        Rc::clone(&bottom_region_hovered),
+        Rc::clone(&bottom_region_hovered),
+        Rc::clone(&bottom_region_hovered),
+    );
+
+    let laid = harness::pump_widget(
+        Stack::new(vec![
+            Align::new(Alignment::TOP_LEFT)
+                .child(
+                    MouseRegion::new()
+                        .on_enter(move |_d, _p| e.set(true))
+                        .on_hover(move |_d, _p| h.set(true))
+                        .on_exit(move |_d, _p| x.set(true))
+                        .child(SizedBox::new(10.0, 10.0)),
+                )
+                .boxed(),
+            MouseRegion::new().boxed(),
+        ]),
+        harness::screen_of(200.0, 200.0),
+    );
+
+    // Squarely inside the bottom region's own 10x10 box.
+    laid.dispatch_pointer_hover(5.0, 5.0);
+    laid.dispatch_pointer_hover(20.0, 20.0);
+
+    assert!(
+        !bottom_region_hovered.get(),
+        "the empty opaque region on top must swallow the pointer everywhere in the \
+         stack, including inside the bottom region's own bounds"
+    );
+}
+
+// ── Device kind ──────────────────────────────────────────────────────────
+
+/// A stylus (pen) hover delivers enter/hover/exit exactly like a mouse hover
+/// — `MouseTracker::update_with_motion` gates on `Mouse | Pen`
+/// (`mouse_tracker.rs:220-222`), matching Flutter's own
+/// `mouse`/`stylus`-only gate for enter/exit (`mouse_tracker.dart:302`).
+///
+/// Flutter parity: `'stylus input works'`.
+#[test]
+fn stylus_hover_delivers_enter_hover_exit_like_a_mouse() {
+    let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+    let (on_enter, on_hover, on_exit) = (Rc::clone(&log), Rc::clone(&log), Rc::clone(&log));
+
+    let laid = harness::pump_widget(
+        Align::new(Alignment::TOP_LEFT).child(
+            MouseRegion::new()
+                .on_enter(move |_d, _p| on_enter.borrow_mut().push("enter"))
+                .on_hover(move |_d, _p| on_hover.borrow_mut().push("hover"))
+                .on_exit(move |_d, _p| on_exit.borrow_mut().push("exit"))
+                .child(SizedBox::new(10.0, 10.0)),
+        ),
+        harness::screen_of(20.0, 20.0),
+    );
+
+    dispatch_pen_hover(&laid, 20.0, 20.0);
+    assert!(log.borrow().is_empty(), "starts outside the 10x10 box");
+
+    dispatch_pen_hover(&laid, 5.0, 5.0);
+    assert_eq!(log.borrow().as_slice(), &["enter", "hover"]);
+    log.borrow_mut().clear();
+
+    dispatch_pen_hover(&laid, 20.0, 20.0);
+    assert_eq!(log.borrow().as_slice(), &["exit"]);
+}

--- a/crates/flui-widgets/tests/parity/mouse_region_test.rs
+++ b/crates/flui-widgets/tests/parity/mouse_region_test.rs
@@ -35,11 +35,12 @@
 //!   pointer ⇒ automatic enter/exit" contract correctly — the mechanism
 //!   exists and is wired at that layer — but this widget-level harness
 //!   cannot observe or prove it.
-//! - **`dispatch_pointer_hover` hardcodes `PointerType::Mouse`.** There is no
-//!   `LaidOut` method for a non-mouse hover device. This file adds a local
-//!   `dispatch_pen_hover` helper (same construction as
-//!   `LaidOut::dispatch_pointer_hover`, `PointerType::Pen` instead) to reach
-//!   the one case that needs it — see [`stylus_hover_delivers_enter_hover_exit_like_a_mouse`].
+//! - **`dispatch_pointer_hover` hardcoded `PointerType::Mouse`.** There was no
+//!   `LaidOut` method for a non-mouse hover device, so this file's harness
+//!   change adds `LaidOut::dispatch_pointer_hover_with_kind` (device-kind
+//!   parameter; `dispatch_pointer_hover` now just calls it with `Mouse`) to
+//!   reach the one case that needs it — see
+//!   [`stylus_hover_delivers_enter_hover_exit_like_a_mouse`].
 //! - **No paint-count, compositing-layer, cursor, or `hasScheduledFrame`
 //!   introspection.** Same category of gap `transform_test.rs` and
 //!   `clip_test.rs` already document for `TransformLayer`/`paints()`
@@ -97,11 +98,13 @@
 //!   equally strong direct check that the delivered `Offset` matches the
 //!   dispatched global position) —
 //!   [`hit_test_transitions_correctly_through_a_2x_transform_scale`]. This is
-//!   the highest-value port in this file: it proves the delivered hit-test
-//!   position under a `Transform::scale` is now correct end-to-end through
-//!   `MouseRegion`, the exact class of bug three hit-test-transform-
-//!   composition fixes just landed for (`b1bb4905`, and the PRs
-//!   `pointer_hit_test_test.rs`/`pointer_local_position_test.rs` cite).
+//!   the highest-value port in this file: the hit-test transform stack
+//!   composes global→local as the walk descends, so the position a region
+//!   receives must be local to it, not an ancestor's untransformed global
+//!   position. `pointer_local_position_test.rs` proves that invariant at the
+//!   lower-level hit-test/dispatch plumbing directly (`Listener` under
+//!   scaled/rotated ancestors); this case proves it holds end-to-end through
+//!   `MouseRegion`'s widget → render-object wiring too.
 //! - `"Callbacks aren't called during build"` (adapted: Flutter's oracle
 //!   drives the rebuild through an internal `setState` inside the
 //!   `HoverClient`/`HoverFeedback` `StatefulWidget`s that own the callbacks;
@@ -118,7 +121,8 @@
 //!   [`opaque_defaults_to_true_and_blocks_the_region_below`].
 //! - `'an empty opaque MouseRegion is effective'` —
 //!   [`a_childless_opaque_mouse_region_still_blocks_everything_beneath_it`].
-//! - `'stylus input works'` (via the local `dispatch_pen_hover` helper —
+//! - `'stylus input works'` (via
+//!   `LaidOut::dispatch_pointer_hover_with_kind(.., PointerType::Pen)` —
 //!   see the harness-capabilities note above) —
 //!   [`stylus_hover_delivers_enter_hover_exit_like_a_mouse`].
 //!
@@ -241,31 +245,12 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
-use flui_interaction::PointerId;
-use flui_interaction::events::{PointerButtons, PointerType, make_move_event_for_id};
+use flui_interaction::events::PointerType;
 use flui_types::{Alignment, Offset};
 use flui_view::ViewExt;
 use flui_widgets::prelude::*;
 
-use crate::common::LaidOut;
 use crate::harness;
-
-/// Dispatches a stylus/pen-kind hover move — the same construction
-/// [`LaidOut::dispatch_pointer_hover`] uses internally, but with
-/// `PointerType::Pen` in place of the hardcoded `PointerType::Mouse`. There is
-/// no harness method for a non-mouse hover device (see the module doc); this
-/// is test-local rather than a `common/mod.rs` addition because
-/// [`stylus_hover_delivers_enter_hover_exit_like_a_mouse`] is the only case
-/// that needs it.
-fn dispatch_pen_hover(laid: &LaidOut, x: f32, y: f32) {
-    let mut event = make_move_event_for_id(PointerId::PRIMARY, offset(x, y), PointerType::Pen);
-    let flui_interaction::events::PointerEvent::Move(update) = &mut event else {
-        unreachable!("make_move_event_for_id must produce PointerEvent::Move");
-    };
-    update.current.buttons = PointerButtons::new();
-    update.current.pressure = 0.0;
-    laid.dispatch_pointer_event(&event);
-}
 
 fn offset(x: f32, y: f32) -> Offset {
     Offset::new(px(x), px(y))
@@ -810,7 +795,8 @@ fn rebuilding_an_active_region_does_not_refire_enter_or_exit() {
 
 /// Three overlapping regions (A wraps B and C; C sits on top of B and is
 /// opaque by default): hitting the B/C overlap area fires A and C only (C
-/// blocks B); moving out exits C then A.
+/// blocks B, whose own callbacks must never fire); moving out exits C then
+/// A.
 ///
 /// Flutter parity: `group('MouseRegion respects opacity:', ...)` →
 /// `'opaque should default to true'`.
@@ -818,6 +804,7 @@ fn rebuilding_an_active_region_does_not_refire_enter_or_exit() {
 fn opaque_defaults_to_true_and_blocks_the_region_below() {
     let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
     let (ea, ha, xa) = (Rc::clone(&log), Rc::clone(&log), Rc::clone(&log));
+    let (eb, hb, xb) = (Rc::clone(&log), Rc::clone(&log), Rc::clone(&log));
     let (ec, hc, xc) = (Rc::clone(&log), Rc::clone(&log), Rc::clone(&log));
 
     let laid = harness::pump_widget(
@@ -827,12 +814,17 @@ fn opaque_defaults_to_true_and_blocks_the_region_below() {
                 .on_hover(move |_d, _p| ha.borrow_mut().push("hoverA"))
                 .on_exit(move |_d, _p| xa.borrow_mut().push("exitA"))
                 .child(SizedBox::new(150.0, 150.0).child(Stack::new(vec![
-                        Positioned::new(MouseRegion::new())
-                            .left(20.0)
-                            .top(20.0)
-                            .width(80.0)
-                            .height(80.0)
-                            .boxed(),
+                        Positioned::new(
+                            MouseRegion::new()
+                                .on_enter(move |_d, _p| eb.borrow_mut().push("enterB"))
+                                .on_hover(move |_d, _p| hb.borrow_mut().push("hoverB"))
+                                .on_exit(move |_d, _p| xb.borrow_mut().push("exitB")),
+                        )
+                        .left(20.0)
+                        .top(20.0)
+                        .width(80.0)
+                        .height(80.0)
+                        .boxed(),
                         Positioned::new(
                             MouseRegion::new()
                                 .on_enter(move |_d, _p| ec.borrow_mut().push("enterC"))
@@ -850,12 +842,16 @@ fn opaque_defaults_to_true_and_blocks_the_region_below() {
     );
 
     // (75,75) is inside A, B ([20,100]x[20,100]), and C ([50,130]x[50,130]);
-    // C is stacked on top of B and opaque by default, so B never fires.
+    // C is stacked on top of B and opaque by default, so B never fires. B now
+    // carries its own enter/hover/exit callbacks writing distinct labels into
+    // the same log, so if C stopped blocking, "enterB"/"hoverB" would show up
+    // here — this assertion is not satisfied merely by B staying silent for
+    // lack of a callback to fire.
     laid.dispatch_pointer_hover(75.0, 75.0);
     assert_eq!(
         log.borrow().as_slice(),
         &["enterA", "enterC", "hoverC", "hoverA"],
-        "C, opaque by default, must block B underneath"
+        "C, opaque by default, must block B underneath — enterB/hoverB must not appear"
     );
     log.borrow_mut().clear();
 
@@ -933,13 +929,13 @@ fn stylus_hover_delivers_enter_hover_exit_like_a_mouse() {
         harness::screen_of(20.0, 20.0),
     );
 
-    dispatch_pen_hover(&laid, 20.0, 20.0);
+    laid.dispatch_pointer_hover_with_kind(20.0, 20.0, PointerType::Pen);
     assert!(log.borrow().is_empty(), "starts outside the 10x10 box");
 
-    dispatch_pen_hover(&laid, 5.0, 5.0);
+    laid.dispatch_pointer_hover_with_kind(5.0, 5.0, PointerType::Pen);
     assert_eq!(log.borrow().as_slice(), &["enter", "hover"]);
     log.borrow_mut().clear();
 
-    dispatch_pen_hover(&laid, 20.0, 20.0);
+    laid.dispatch_pointer_hover_with_kind(20.0, 20.0, PointerType::Pen);
     assert_eq!(log.borrow().as_slice(), &["exit"]);
 }


### PR DESCRIPTION
Closes the last input-family widget without a parity file — `Listener`, `AbsorbPointer` and `IgnorePointer` landed in #460.

## Ported: 15 of 43

`mouse_region_test.dart` at tag `3.44.0`. The three `hitTestBehavior` variants, enter/exit with a button held, enter/exit detection, nested regions, hover transfer between two regions, updated callbacks, opaque defaults (including a childless opaque region), stylus hover, no-refire on rebuild, and **`'works with transform'`**.

That last one is the flagship: it exercises the hit-test transform composition repaired across #460, #462 and #464. Mutation-run to prove it is load-bearing — reverting `RenderTransform::hit_test` to feed the untransformed position makes it fail.

## Not ported: 28 of 43

Named individually with reasons, grouped so the arithmetic stays checkable (15 + 28 = 43):

| reason | n |
|---|---:|
| no device connect/disconnect primitive | 3 |
| no stationary-device postframe recheck reachable from this harness — `MouseTracker::update_all_devices` is called only from `flui-app`'s frame path, never from `HeadlessBinding::pump_frame` | 5 |
| no `hasScheduledFrame` equivalent | 2 |
| no paint-count introspection on `LaidOut` | 6 |
| no compositing-layer introspection | 2 |
| no cursor introspection | 1 |
| diagnostics-string formatting (`debugFillProperties`) | 2 |
| rebuild-handle-in-callback plumbing, deferred | 2 |
| `GlobalKey` reparent doesn't preserve render-object identity (matches an already-documented divergence) | 1 |
| disproportionate `Draggable` regression setup | 1 |
| deliberate scope cut — two opacity transition-matrix cases whose 2-leg contract is already proven | 2 |
| **genuine divergence, see below** | 1 |

## A real divergence, reported not papered over

`'detects hover from touch devices'` is not a harness gap. Flutter's `RenderMouseRegion.handleEvent` fires `onHover` for **any** `PointerHoverEvent` with no device-kind check (`rendering/proxy_box.dart`, verified at the tag). FLUI routes `on_hover` through `MouseTracker::update_with_motion`, gated to `Mouse | Pen`, so a touch-originated hover delivers nothing.

Left as a finding rather than ported around or "fixed" by adjusting the test.

## Red-checks were run, not asserted

Each non-obvious case was mutation-run. **One came back negative and is recorded as such:** forcing `MouseRegion`'s target cell to unregister and re-register does *not* make `rebuilding_an_active_region_does_not_refire_enter_or_exit` fail, because region continuity is keyed by `RenderId` rather than target identity. The test does catch the defect it exists for — a rebuild that helpfully re-notifies current state — but not target churn. Stated rather than left implied.

## Gates

parity **446 → 461** · workspace **8146** · clippy · fmt · inventory-check · port-check · doc-strict — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117t1jX2FFcCzP3YBLoQB94
