### PR TITLE
fix(interaction): deliver MouseRegion hover off the device-gated path

### DIFF
--- a/crates/flui-interaction/src/binding.rs
+++ b/crates/flui-interaction/src/binding.rs
@@ -688,20 +688,20 @@ impl GestureBinding {
                     }
                 }
                 PendingMove::Hover { event, hit_test } => {
-                    let delivered = self.dispatch_ephemeral(&event, &hit_test);
-                    RoutePanic::preserve_first(&mut first_panic, delivered, "coalesced hover move");
                     // `MouseRegion::on_hover` has no device-kind gate (Flutter
                     // parity: `RenderMouseRegion.handleEvent`, unlike
                     // `MouseTracker.updateWithEvent`'s mouse/stylus-only gate)
                     // and rides the same coalesced dispatch cadence as the
-                    // ordinary hit-test targets above, not the immediate
-                    // per-raw-event enter/exit update.
-                    let hover_delivered = self.mouse_tracker.dispatch_hover(&event, &hit_test);
-                    RoutePanic::preserve_first(
-                        &mut first_panic,
-                        hover_delivered,
-                        "coalesced mouse hover dispatch",
-                    );
+                    // ordinary hit-test targets, not the immediate
+                    // per-raw-event enter/exit update. It interleaves with
+                    // those ordinary targets in ONE per-entry, leaf-first
+                    // walk (`dispatch_ephemeral_with_hover_interleaved`) so a
+                    // `Listener` and a nested `MouseRegion` fire in hit-test
+                    // order relative to each other, not as two separate full
+                    // passes.
+                    let delivered =
+                        self.dispatch_ephemeral_with_hover_interleaved(&event, &hit_test);
+                    RoutePanic::preserve_first(&mut first_panic, delivered, "coalesced hover move");
                     count += 1;
                 }
             }
@@ -1394,6 +1394,31 @@ impl GestureBinding {
         result: &HitTestResult,
     ) -> Option<RoutePanic> {
         let mut first_panic = result.dispatch_capturing_panic(event);
+        let router_panic = self.pointer_router.route_capturing_panics(event);
+        RoutePanic::preserve_first(&mut first_panic, router_panic, "pointer router");
+        first_panic
+    }
+
+    /// As [`dispatch_ephemeral`](Self::dispatch_ephemeral), but every
+    /// ordinary pointer target AND every mouse-hover region on `result`'s
+    /// path deliver together, leaf-first, in one per-entry pass instead of
+    /// [`dispatch_ephemeral`](Self::dispatch_ephemeral)'s ordinary-targets-only
+    /// walk followed by a separate full pass over mouse regions.
+    ///
+    /// Used only for the coalesced hover-move arm of
+    /// [`flush_pending_moves_kernel`](Self::flush_pending_moves_kernel): a
+    /// hover move never has a cached Down route, so this — like
+    /// [`dispatch_ephemeral`](Self::dispatch_ephemeral) — resolves and
+    /// releases everything within this one call, then still runs the root
+    /// pointer router after the walk (Flutter parity: `GestureBinding`'s own
+    /// `handleEvent`, the path's least-specific entry, calls
+    /// `pointerRouter.route(event)` last).
+    fn dispatch_ephemeral_with_hover_interleaved(
+        &self,
+        event: &PointerEvent,
+        result: &HitTestResult,
+    ) -> Option<RoutePanic> {
+        let mut first_panic = result.dispatch_hover_interleaved_capturing_panic(event);
         let router_panic = self.pointer_router.route_capturing_panics(event);
         RoutePanic::preserve_first(&mut first_panic, router_panic, "pointer router");
         first_panic

--- a/crates/flui-interaction/src/binding.rs
+++ b/crates/flui-interaction/src/binding.rs
@@ -690,6 +690,18 @@ impl GestureBinding {
                 PendingMove::Hover { event, hit_test } => {
                     let delivered = self.dispatch_ephemeral(&event, &hit_test);
                     RoutePanic::preserve_first(&mut first_panic, delivered, "coalesced hover move");
+                    // `MouseRegion::on_hover` has no device-kind gate (Flutter
+                    // parity: `RenderMouseRegion.handleEvent`, unlike
+                    // `MouseTracker.updateWithEvent`'s mouse/stylus-only gate)
+                    // and rides the same coalesced dispatch cadence as the
+                    // ordinary hit-test targets above, not the immediate
+                    // per-raw-event enter/exit update.
+                    let hover_delivered = self.mouse_tracker.dispatch_hover(&event, &hit_test);
+                    RoutePanic::preserve_first(
+                        &mut first_panic,
+                        hover_delivered,
+                        "coalesced mouse hover dispatch",
+                    );
                     count += 1;
                 }
             }

--- a/crates/flui-interaction/src/routing/hit_test.rs
+++ b/crates/flui-interaction/src/routing/hit_test.rs
@@ -585,6 +585,51 @@ impl HitTestResult {
         first_panic
     }
 
+    /// Dispatch a pointer event to every ordinary pointer target AND every
+    /// mouse-hover region on this path together, leaf-first, in a single
+    /// per-entry pass — the interleaved counterpart to
+    /// [`dispatch_capturing_panic`](Self::dispatch_capturing_panic), which
+    /// only knows about ordinary pointer targets.
+    ///
+    /// A `Listener` and a nested `MouseRegion` sharing this path must fire in
+    /// hit-test order relative to EACH OTHER (Flutter's single per-entry
+    /// `entry.target.handleEvent` loop, `gestures/binding.dart:496`); calling
+    /// [`dispatch_capturing_panic`](Self::dispatch_capturing_panic) and
+    /// [`MouseTracker::dispatch_hover`](super::mouse_tracker::MouseTracker::dispatch_hover)
+    /// as two separate full passes always delivers every ordinary target
+    /// before every region, regardless of which is actually the leaf.
+    ///
+    /// Used only by the coalesced ephemeral hover-move dispatch path (see
+    /// [`InteractionDispatchHandle::dispatch_hover_interleaved`](super::interaction_lane::InteractionDispatchHandle::dispatch_hover_interleaved)
+    /// for the resolve/invoke detail); every other event kind keeps
+    /// dispatching through
+    /// [`dispatch_capturing_panic`](Self::dispatch_capturing_panic)
+    /// unchanged.
+    pub(crate) fn dispatch_hover_interleaved_capturing_panic(
+        &self,
+        event: &PointerEvent,
+    ) -> Option<RoutePanic> {
+        if !self
+            .path
+            .iter()
+            .any(|e| e.pointer_target.is_some() || e.mouse_annotation.is_some())
+        {
+            return None;
+        }
+        let handle = match active_dispatch_handle() {
+            Ok(handle) => handle,
+            Err(error) => {
+                tracing::error!(
+                    ?error,
+                    "hover-interleaved dispatch outside an active interaction lane; \
+                     event not delivered"
+                );
+                return None;
+            }
+        };
+        handle.dispatch_hover_interleaved(&self.path, event)
+    }
+
     /// Dispatches a scroll event to all entries.
     pub fn dispatch_scroll(&self, event: &ScrollEventData) -> bool {
         let handle = match active_dispatch_handle() {

--- a/crates/flui-interaction/src/routing/interaction_lane.rs
+++ b/crates/flui-interaction/src/routing/interaction_lane.rs
@@ -21,7 +21,7 @@ use flui_types::painting::{Path, Shader};
 use flui_types::{Offset, Pixels, Rect, Size};
 
 use super::hit_test::{EventPropagation, HitTestEntry, transform_pointer_event};
-use crate::events::{DeviceId, PointerEvent, ScrollEventData};
+use crate::events::{DeviceId, PointerEvent, PointerEventExt, ScrollEventData};
 
 static NEXT_LANE_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -476,6 +476,24 @@ impl ResolvedHitRoute {
         }
         first_panic
     }
+}
+
+/// One hit-path entry resolved for
+/// [`InteractionDispatchHandle::dispatch_hover_interleaved`]: whichever of a
+/// pointer-target handler and a mouse-hover callback that entry carries,
+/// captured together so a single per-entry invocation pass can deliver both
+/// in the SAME step rather than as two independent full passes.
+///
+/// Distinct from [`ResolvedHitEntry`]/[`ResolvedHitRoute`] (the batched
+/// pointer-only route Down, cached contact moves, Up, and Cancel dispatch
+/// through): those resolve and invoke pointer targets as their own complete
+/// pass, with no mouse-hover awareness at all, and are cached under a
+/// [`ResolvedRouteToken`] for reuse across a whole pointer sequence. A hover
+/// move never has a cached Down route to reuse, so this type is resolved and
+/// invoked once, inline, with nothing stored in `lane.routes`.
+struct ResolvedHoverInterleavedEntry {
+    pointer: Option<(Rc<HandlerCell>, LocalEventTransform)>,
+    hover_callback: Option<MouseHoverCallback>,
 }
 
 /// The first panic captured while invoking a resolved pointer route.
@@ -1139,6 +1157,159 @@ impl InteractionDispatchHandle {
             .ok_or(InteractionDispatchError::StaleRoute)?;
         drop(removed);
         Ok(())
+    }
+
+    /// Resolve and invoke a hit path's pointer targets and mouse-hover
+    /// regions together, leaf-first, in a single per-entry pass — so a
+    /// `Listener` and a nested `MouseRegion` on the same path fire in
+    /// hit-test order relative to EACH OTHER, matching Flutter's single
+    /// per-entry `entry.target.handleEvent` loop (`gestures/binding.dart:496`,
+    /// `HitTestResult.path` ordered leaf-first per
+    /// `gestures/hit_test.dart:131-132`) instead of two independent full
+    /// passes over the path.
+    ///
+    /// Used only by the coalesced ephemeral hover-move dispatch
+    /// (`GestureBinding::flush_pending_moves_kernel`'s `PendingMove::Hover`
+    /// arm). A hover move never has a cached Down route, so unlike
+    /// [`resolve_pointer_route`](Self::resolve_pointer_route)/
+    /// [`invoke_pointer_route`](Self::invoke_pointer_route) (shared by Down,
+    /// cached contact moves, Up, and Cancel), nothing here is stored in
+    /// `lane.routes` for later reuse or release — resolution and invocation
+    /// both happen in this one call, and every OTHER event kind keeps
+    /// dispatching exactly as before.
+    ///
+    /// Every pointer-target entry is resolved upfront, before any callback
+    /// runs — matching the batched route's re-entrancy guarantee: a callback
+    /// that unregisters a LATER entry's target mid-walk does not suppress
+    /// that later entry, because its handler cell was already captured. A
+    /// foreign-lane pointer target aborts the whole dispatch (matching
+    /// `resolve_pointer_route`'s `?`-propagated validation); a foreign-lane
+    /// or since-unregistered mouse-hover target is skipped and traced
+    /// per-entry instead (matching [`resolve_mouse_region`](Self::resolve_mouse_region)'s
+    /// existing per-annotation behavior), so one absent region does not drop
+    /// its neighbors.
+    pub(super) fn dispatch_hover_interleaved(
+        &self,
+        path: &[HitTestEntry],
+        event: &PointerEvent,
+    ) -> Option<RoutePanic> {
+        if !path
+            .iter()
+            .any(|entry| entry.pointer_target.is_some() || entry.mouse_annotation.is_some())
+        {
+            return None;
+        }
+        let lane = match self.active_lane() {
+            Ok(lane) => lane,
+            Err(error) => {
+                tracing::error!(
+                    ?error,
+                    "hover-interleaved dispatch outside an active interaction lane; \
+                     event not delivered"
+                );
+                return None;
+            }
+        };
+        for target in path.iter().filter_map(|entry| entry.pointer_target) {
+            if let Err(error) = self.validate_lane(target.lane_id) {
+                tracing::error!(
+                    ?error,
+                    "pointer target from a foreign lane during interleaved hover dispatch; \
+                     event not delivered"
+                );
+                return None;
+            }
+        }
+
+        // Mirrors `MouseTracker::dispatch_hover`'s own gate: only a
+        // buttons-empty `Move` carries hover semantics (Flutter's
+        // `PointerHoverEvent` vs `PointerMoveEvent` split at the event-class
+        // level). Gating resolution (not just invocation) means a
+        // non-hover-shaped event never resolves mouse-region callbacks at
+        // all.
+        let hover_qualifies = matches!(
+            event,
+            PointerEvent::Move(update) if update.current.buttons.is_empty()
+        );
+
+        let resolved: Vec<ResolvedHoverInterleavedEntry> = {
+            let targets = lane.targets.borrow();
+            path.iter()
+                .filter_map(|entry| {
+                    let pointer = entry.pointer_target.and_then(|target| {
+                        targets
+                            .get(&target.target_id)
+                            .cloned()
+                            .map(|cell| (cell, LocalEventTransform::capture(entry.transform)))
+                    });
+                    let hover_callback = hover_qualifies
+                        .then_some(entry.mouse_annotation)
+                        .flatten()
+                        .and_then(|annotation| {
+                            match self.resolve_mouse_region(annotation.target) {
+                                Ok(cell) => cell.snapshot().on_hover,
+                                Err(error) => {
+                                    tracing::debug!(
+                                        ?error,
+                                        "mouse-hover target unavailable during interleaved dispatch"
+                                    );
+                                    None
+                                }
+                            }
+                        });
+                    (pointer.is_some() || hover_callback.is_some()).then_some(
+                        ResolvedHoverInterleavedEntry {
+                            pointer,
+                            hover_callback,
+                        },
+                    )
+                })
+                .collect()
+        };
+
+        let device_id = event.device_id();
+        let position = event.position();
+        let mut first_panic = None;
+        for entry in resolved {
+            if let Some((cell, transform)) = entry.pointer {
+                let local_event = match &transform {
+                    LocalEventTransform::Local(local) => {
+                        Some(transform_pointer_event(event, local))
+                    }
+                    LocalEventTransform::Global | LocalEventTransform::NonInvertible => None,
+                };
+                if !matches!(transform, LocalEventTransform::NonInvertible) {
+                    let handler = cell.snapshot();
+                    let delivered = RoutePanic::capture(|| {
+                        handler(local_event.as_ref().unwrap_or(event));
+                    });
+                    RoutePanic::preserve_first(
+                        &mut first_panic,
+                        delivered,
+                        "pointer target (hover-interleaved)",
+                    );
+                    // Same re-entrancy care as `ResolvedHitRoute::invoke`: keep
+                    // the snapshot's destructor inside this transaction rather
+                    // than unwinding before later entries and the caller's
+                    // mandatory cleanup run.
+                    let snapshot_cleanup = RoutePanic::capture(|| drop(handler));
+                    RoutePanic::preserve_first(
+                        &mut first_panic,
+                        snapshot_cleanup,
+                        "pointer target snapshot cleanup (hover-interleaved)",
+                    );
+                }
+            }
+            if let Some(callback) = entry.hover_callback {
+                let delivered = RoutePanic::capture(|| callback(device_id, position));
+                RoutePanic::preserve_first(
+                    &mut first_panic,
+                    delivered,
+                    "mouse hover callback (hover-interleaved)",
+                );
+            }
+        }
+        first_panic
     }
 }
 

--- a/crates/flui-interaction/src/routing/mouse_tracker.rs
+++ b/crates/flui-interaction/src/routing/mouse_tracker.rs
@@ -1,9 +1,16 @@
 //! Mouse tracking for hover, enter, and exit events.
 //!
-//! The tracker owns per-device hover state. Executable region callbacks do not
-//! live in render objects or hit-test entries: hit testing contributes a
-//! data-only [`MouseRegionTarget`], and the tracker resolves it through the
-//! active owner-local [`InteractionLane`](super::InteractionLane).
+//! The tracker owns per-device enter/exit/cursor state, gated to
+//! `Mouse | Pen` (Flutter's own `MouseTracker.updateWithEvent` gate,
+//! `rendering/mouse_tracker.dart:302`). `MouseRegion::on_hover` is deliberately
+//! **not** part of that device state machine: it is invoked by
+//! [`MouseTracker::dispatch_hover`], with no device-kind gate, mirroring
+//! `RenderMouseRegion.handleEvent` (`rendering/proxy_box.dart`) firing
+//! `onHover` for any `PointerHoverEvent` reaching a hit-test target. Executable
+//! region callbacks do not live in render objects or hit-test entries either
+//! way: hit testing contributes a data-only [`MouseRegionTarget`], and both
+//! methods resolve it through the active owner-local
+//! [`InteractionLane`](super::InteractionLane).
 
 use std::{
     cell::RefCell,
@@ -18,7 +25,7 @@ use smallvec::SmallVec;
 pub use super::interaction_lane::{
     MouseEnterCallback, MouseExitCallback, MouseHoverCallback, MouseRegionTarget,
 };
-use super::{HitTestResult, active_dispatch_handle};
+use super::{HitTestResult, RoutePanic, active_dispatch_handle};
 use crate::{
     events::{CursorIcon, PointerEvent, PointerEventExt, PointerType},
     ids::RegionId,
@@ -31,8 +38,10 @@ pub use crate::events::DeviceId;
 /// How a pointer move participates in the mouse-region protocol.
 ///
 /// Both variants refresh enter/exit/cursor state from a fresh hit test.
-/// Only `Hover` invokes `MouseRegion::on_hover`; contact motion continues to
-/// the gesture route captured at Down.
+/// Neither invokes `MouseRegion::on_hover` — see
+/// [`MouseTracker::dispatch_hover`] for that, which does not take a `kind`
+/// because it derives the hover/contact distinction from the event itself
+/// (an empty-buttons `Move`, Flutter's `PointerHoverEvent` shape).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PointerMotionKind {
     /// Motion without an active Down sequence.
@@ -222,6 +231,11 @@ impl MouseTracker {
         }
         let device_id = event.device_id();
         let position = event.position();
+        tracing::trace!(
+            device_id,
+            ?kind,
+            "mouse tracker updating enter/exit/cursor state"
+        );
 
         let resolved = resolve_hit_test_annotations(hit_test_result);
         let new_regions: HashSet<RegionId> = resolved.order.iter().copied().collect();
@@ -279,21 +293,6 @@ impl MouseTracker {
                         .and_then(|ann| ann.cell.snapshot().on_exit)
                 })
                 .collect();
-            let hover_callbacks: SmallVec<[MouseHoverCallback; 4]> =
-                if kind == PointerMotionKind::Hover {
-                    resolved
-                        .order
-                        .iter()
-                        .filter_map(|id| {
-                            inner
-                                .annotations
-                                .get(id)
-                                .and_then(|ann| ann.cell.snapshot().on_hover)
-                        })
-                        .collect()
-                } else {
-                    SmallVec::new()
-                };
             for id in exited {
                 inner.annotations.remove(&id);
             }
@@ -311,13 +310,67 @@ impl MouseTracker {
                 position,
                 enter_callbacks,
                 exit_callbacks,
-                hover_callbacks,
                 cursor_callback,
                 new_cursor,
             }
         };
 
         work.invoke();
+    }
+
+    /// Invokes `MouseRegion::on_hover` for every region under a hover-shaped
+    /// pointer move, with no device-kind gate.
+    ///
+    /// Flutter parity: `RenderMouseRegion.handleEvent`
+    /// (`rendering/proxy_box.dart`) fires `onHover` for any
+    /// `PointerHoverEvent` reaching a hit-test target, regardless of device
+    /// kind — unlike `MouseTracker.updateWithEvent`
+    /// (`rendering/mouse_tracker.dart`), which gates enter/exit to
+    /// mouse/stylus only. [`update_with_motion`](Self::update_with_motion)
+    /// keeps that gate for enter/exit; this method carries the ungated hover
+    /// half of the contract, called from the ordinary coalesced-move
+    /// dispatch path rather than the enter/exit device-state machine.
+    ///
+    /// A non-`Move` event, or a `Move` with any button held (a contact drag,
+    /// not a hover), is a no-op — mirroring Flutter's `PointerHoverEvent` vs
+    /// `PointerMoveEvent` split at the event-class level.
+    ///
+    /// Per-target panics are isolated the same way the render tree isolates
+    /// resolved pointer-route dispatch: the first is returned for the caller
+    /// to resume after its own mandatory cleanup, later ones are traced.
+    #[must_use = "a captured hover-callback panic must be resumed after dispatch cleanup"]
+    pub fn dispatch_hover(
+        &self,
+        event: &PointerEvent,
+        hit_test_result: &HitTestResult,
+    ) -> Option<RoutePanic> {
+        let PointerEvent::Move(update) = event else {
+            return None;
+        };
+        if !update.current.buttons.is_empty() {
+            return None;
+        }
+        let device_id = event.device_id();
+        let position = event.position();
+
+        let resolved = resolve_hit_test_annotations(hit_test_result);
+        let hover_callbacks: SmallVec<[MouseHoverCallback; 4]> = resolved
+            .order
+            .iter()
+            .filter_map(|id| {
+                resolved
+                    .annotations
+                    .get(id)
+                    .and_then(|ann| ann.cell.snapshot().on_hover)
+            })
+            .collect();
+
+        let mut first_panic = None;
+        for callback in hover_callbacks {
+            let delivered = RoutePanic::capture(|| callback(device_id, position));
+            RoutePanic::preserve_first(&mut first_panic, delivered, "mouse hover callback");
+        }
+        first_panic
     }
 
     /// Re-runs hit testing for every tracked mouse device at its last known
@@ -404,7 +457,6 @@ impl MouseTracker {
                     position,
                     enter_callbacks,
                     exit_callbacks,
-                    hover_callbacks: SmallVec::new(),
                     cursor_callback,
                     new_cursor,
                 }
@@ -534,7 +586,6 @@ struct DeviceWork {
     position: Offset<Pixels>,
     enter_callbacks: SmallVec<[MouseEnterCallback; 4]>,
     exit_callbacks: SmallVec<[MouseExitCallback; 4]>,
-    hover_callbacks: SmallVec<[MouseHoverCallback; 4]>,
     cursor_callback: Option<CursorChangeCallback>,
     new_cursor: CursorIcon,
 }
@@ -587,22 +638,6 @@ impl DeviceWork {
                 }
             }
         }
-        for callback in self.hover_callbacks {
-            let delivered = catch_unwind(AssertUnwindSafe(|| {
-                callback(self.device_id, self.position);
-            }));
-            if let Err(payload) = delivered {
-                if first_panic.is_none() {
-                    first_panic = Some(payload);
-                } else {
-                    tracing::error!(
-                        "mouse hover callback panicked after an earlier mouse callback already \
-                         panicked; only the first panic is resumed"
-                    );
-                }
-            }
-        }
-
         if let Some(payload) = first_panic {
             resume_unwind(payload);
         }
@@ -752,8 +787,18 @@ mod tests {
         assert!(!active.contains(&ordinary_id));
     }
 
+    /// `update_with_motion` used to be the one place that invoked `on_hover`,
+    /// gated by `kind == PointerMotionKind::Hover`. That behavior moved to
+    /// [`MouseTracker::dispatch_hover`] (Flutter parity: `on_hover` is
+    /// `RenderMouseRegion.handleEvent`'s concern, not `MouseTracker`'s — see
+    /// this module's doc). This test used to assert the old in-tracker
+    /// gating; it now asserts the complementary invariant that motivated the
+    /// move — `update_with_motion` invokes `on_hover` zero times under
+    /// either kind, while still sharing region-tracking state across them.
+    /// See `dispatch_hover_invokes_on_hover_for_a_buttons_empty_move_only`
+    /// below for the relocated behavior.
     #[test]
-    fn hover_and_contact_share_tracking_but_only_hover_invokes_on_hover() {
+    fn update_with_motion_shares_tracking_across_kinds_but_never_invokes_on_hover() {
         let lane = InteractionLane::try_new().expect("lane");
         let handle = lane.dispatch_handle();
         let tracker = MouseTracker::new();
@@ -783,8 +828,78 @@ mod tests {
             tracker.update_with_motion(&event, PointerMotionKind::Contact, &result);
         });
 
-        assert_eq!(hovers.get(), 1);
+        assert_eq!(
+            hovers.get(),
+            0,
+            "update_with_motion must never invoke on_hover -- that moved to dispatch_hover"
+        );
         assert!(tracker.device_active_regions(0).contains(&region_id));
+    }
+
+    /// The relocated half of the split covered above: `dispatch_hover` fires
+    /// `on_hover` for a buttons-empty `Move` (Flutter's `PointerHoverEvent`
+    /// shape) and is a no-op for a `Move` with a button held (a contact
+    /// drag, Flutter's `PointerMoveEvent` shape) -- with no device-kind gate
+    /// and no dependency on prior `update_with_motion` tracking state.
+    #[test]
+    fn dispatch_hover_invokes_on_hover_for_a_buttons_empty_move_only() {
+        use crate::events::PointerButtons;
+
+        let lane = InteractionLane::try_new().expect("lane");
+        let handle = lane.dispatch_handle();
+        let tracker = MouseTracker::new();
+        let hovers = Rc::new(Cell::new(0));
+        let callback_hovers = Rc::clone(&hovers);
+        let target = lane.enter(|| {
+            handle
+                .register_mouse_region(MouseRegionCallbacks {
+                    on_hover: Some(Rc::new(move |_device, _position| {
+                        callback_hovers.set(callback_hovers.get() + 1);
+                    })),
+                    ..MouseRegionCallbacks::default()
+                })
+                .expect("register mouse region")
+        });
+        let region_id = RenderId::new(1);
+        let position = Offset::new(Pixels(10.0), Pixels(10.0));
+        // `make_move_event` defaults `buttons` to `Primary` held (it is meant
+        // for contact-motion tests); a genuine hover-shaped move must clear
+        // it explicitly, matching Flutter's `PointerHoverEvent` (no buttons)
+        // vs `PointerMoveEvent` (buttons held) split.
+        let mut hover_event = make_move_event(position, PointerType::Mouse);
+        let contact_event = make_move_event(position, PointerType::Mouse);
+        let PointerEvent::Move(update) = &mut hover_event else {
+            unreachable!("make_move_event always returns PointerEvent::Move")
+        };
+        update.current.buttons = PointerButtons::new();
+        let mut result = HitTestResult::new();
+        result.add(
+            HitTestEntry::new(region_id)
+                .mouse_annotation(MouseTrackerAnnotation::new(region_id, target)),
+        );
+
+        lane.enter(|| {
+            assert!(tracker.dispatch_hover(&contact_event, &result).is_none());
+        });
+        assert_eq!(
+            hovers.get(),
+            0,
+            "a Move with a button held is a contact drag, not a hover -- no on_hover"
+        );
+
+        lane.enter(|| {
+            assert!(tracker.dispatch_hover(&hover_event, &result).is_none());
+        });
+        assert_eq!(hovers.get(), 1, "a buttons-empty Move is a genuine hover");
+
+        lane.enter(|| {
+            assert!(tracker.dispatch_hover(&hover_event, &result).is_none());
+        });
+        assert_eq!(
+            hovers.get(),
+            2,
+            "dispatch_hover has no device-kind or tracker-state gate -- it fires every call"
+        );
     }
 
     #[test]

--- a/crates/flui-interaction/src/routing/mouse_tracker.rs
+++ b/crates/flui-interaction/src/routing/mouse_tracker.rs
@@ -3,14 +3,30 @@
 //! The tracker owns per-device enter/exit/cursor state, gated to
 //! `Mouse | Pen` (Flutter's own `MouseTracker.updateWithEvent` gate,
 //! `rendering/mouse_tracker.dart:302`). `MouseRegion::on_hover` is deliberately
-//! **not** part of that device state machine: it is invoked by
-//! [`MouseTracker::dispatch_hover`], with no device-kind gate, mirroring
-//! `RenderMouseRegion.handleEvent` (`rendering/proxy_box.dart`) firing
-//! `onHover` for any `PointerHoverEvent` reaching a hit-test target. Executable
-//! region callbacks do not live in render objects or hit-test entries either
-//! way: hit testing contributes a data-only [`MouseRegionTarget`], and both
-//! methods resolve it through the active owner-local
+//! **not** part of that device state machine, and has no device-kind gate,
+//! mirroring `RenderMouseRegion.handleEvent` (`rendering/proxy_box.dart`)
+//! firing `onHover` for any `PointerHoverEvent` reaching a hit-test target.
+//! Executable region callbacks do not live in render objects or hit-test
+//! entries either way: hit testing contributes a data-only
+//! [`MouseRegionTarget`], resolved through the active owner-local
 //! [`InteractionLane`](super::InteractionLane).
+//!
+//! [`MouseTracker::dispatch_hover`] is the self-contained, directly testable
+//! form of that resolve-and-invoke step and remains public for exactly that.
+//! Production `GestureBinding` delivery does NOT call it: a `Listener` and a
+//! nested `MouseRegion` must fire in hit-test order relative to each other
+//! (Flutter's single per-entry `entry.target.handleEvent` loop,
+//! `gestures/binding.dart:496`), so the binding instead resolves and invokes
+//! pointer targets and mouse-hover regions together in one per-entry walk
+//! (`InteractionDispatchHandle::dispatch_hover_interleaved`,
+//! `routing/interaction_lane.rs`) — calling `dispatch_hover` as its own
+//! separate full pass would deliver every ordinary pointer target before
+//! every region regardless of which is actually the hit path's leaf. Both
+//! paths apply the identical gate (a buttons-empty `Move`) and read the same
+//! lane state; they exist because Rust's ownership boundary makes "resolve
+//! once, deliver in one interleaved order" and "a small function that just
+//! does hover" different call shapes, not because the underlying contract
+//! differs.
 
 use std::{
     cell::RefCell,

--- a/crates/flui-objects/tests/render_object_harness.rs
+++ b/crates/flui-objects/tests/render_object_harness.rs
@@ -1080,23 +1080,53 @@ fn harness_mouse_region_uses_one_tracker_target_for_hover_enter_and_exit() {
         flui_interaction::events::PointerType::Mouse,
         Offset::ZERO,
     );
-    let inside_event = flui_interaction::events::make_move_event(
+
+    // `update_with_motion` (enter/exit/cursor tracking) and `dispatch_hover`
+    // (on_hover) are two independent dispatch paths that both resolve the
+    // SAME `MouseRegionTarget` -- one tracker target really does serve all
+    // three callbacks, just not through one call. `make_move_event` defaults
+    // `buttons` to a button held (it targets contact-motion tests), so a
+    // genuine hover-shaped move needs buttons cleared explicitly.
+    let mut hover_event = flui_interaction::events::make_move_event(
         inside_position,
         flui_interaction::events::PointerType::Mouse,
     );
-    lane.enter(|| {
-        tracker.update_with_motion(&inside_event, PointerMotionKind::Hover, &inside);
-    });
-    assert_eq!(enters.get(), 1, "first tracker update enters the region");
-    assert_eq!(hovers.get(), 1, "the same target receives hover");
+    let flui_interaction::events::PointerEvent::Move(hover_update) = &mut hover_event else {
+        unreachable!("make_move_event always returns PointerEvent::Move")
+    };
+    hover_update.current.buttons = flui_interaction::events::PointerButtons::new();
 
     lane.enter(|| {
-        tracker.update_with_motion(&inside_event, PointerMotionKind::Contact, &inside);
+        tracker.update_with_motion(&hover_event, PointerMotionKind::Hover, &inside);
+    });
+    assert_eq!(enters.get(), 1, "first tracker update enters the region");
+    assert_eq!(
+        hovers.get(),
+        0,
+        "on_hover is dispatch_hover's concern, not update_with_motion's",
+    );
+
+    lane.enter(|| {
+        assert!(tracker.dispatch_hover(&hover_event, &inside).is_none());
     });
     assert_eq!(
         hovers.get(),
         1,
-        "contact motion refreshes tracking but must not invoke on_hover",
+        "dispatch_hover resolves the same tracker target enter/exit used",
+    );
+
+    let contact_event = flui_interaction::events::make_move_event(
+        inside_position,
+        flui_interaction::events::PointerType::Mouse,
+    );
+    lane.enter(|| {
+        tracker.update_with_motion(&contact_event, PointerMotionKind::Contact, &inside);
+        assert!(tracker.dispatch_hover(&contact_event, &inside).is_none());
+    });
+    assert_eq!(
+        hovers.get(),
+        1,
+        "a buttons-held move refreshes tracking but must not invoke on_hover",
     );
 
     let mut outside = HitTestResult::new();

--- a/crates/flui-widgets/tests/parity/mouse_region_test.rs
+++ b/crates/flui-widgets/tests/parity/mouse_region_test.rs
@@ -66,14 +66,29 @@
 //! hover delivered `on_hover` in Flutter and nothing at all in FLUI.
 //!
 //! The fix relocates `on_hover` delivery out of the device-state machine
-//! entirely, into `MouseTracker::dispatch_hover` (`mouse_tracker.rs`), called
-//! from the ordinary coalesced pointer-move dispatch path with no
-//! device-kind gate — mirroring `handleEvent` exactly.
+//! entirely, with no device-kind gate — mirroring `handleEvent` exactly —
+//! and rides the ordinary coalesced pointer-move dispatch path rather than
+//! the immediate per-raw-event enter/exit update.
 //! `MouseTracker::update_with_motion` keeps its `Mouse | Pen` gate, now
 //! scoped to enter/exit/cursor only, matching
 //! `MouseTracker.updateWithEvent`'s real scope in Flutter. See
 //! [`detects_hover_from_touch_devices`], now ported below instead of listed
 //! as a divergence.
+//!
+//! Production delivery resolves `on_hover` together with ordinary pointer
+//! targets in one leaf-first pass
+//! (`InteractionDispatchHandle::dispatch_hover_interleaved`,
+//! `crates/flui-interaction/src/routing/interaction_lane.rs`) rather than
+//! calling `MouseTracker::dispatch_hover` as a separate full pass — a
+//! `Listener` and a nested `MouseRegion` must fire in hit-test order
+//! relative to each other, and two independent passes always deliver every
+//! ordinary target before every region regardless of which is actually the
+//! leaf. See
+//! [`hover_fires_leaf_first_through_a_listener_wrapping_a_mouse_region`] and
+//! [`hover_fires_leaf_first_through_a_mouse_region_wrapping_a_listener`].
+//! `MouseTracker::dispatch_hover` itself is unchanged and stays public as
+//! the self-contained, directly testable form of the same resolve-and-invoke
+//! step.
 //!
 //! ### Ported (16 of 43)
 //! - `'hitTestBehavior test - HitTestBehavior.deferToChild/opaque'` —
@@ -256,7 +271,7 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use flui_interaction::events::PointerType;
-use flui_types::{Alignment, Offset};
+use flui_types::{Alignment, Color, Offset};
 use flui_view::ViewExt;
 use flui_widgets::prelude::*;
 
@@ -1002,5 +1017,83 @@ fn detects_hover_from_touch_devices() {
     assert!(
         exits.borrow().is_empty(),
         "on_exit stays gated to Mouse | Pen -- touch must not trigger it"
+    );
+}
+
+// ── Interleaving with other hit-path targets ────────────────────────────────
+
+/// A `Listener`'s `on_pointer_hover` and a nested `MouseRegion`'s `on_hover`
+/// must fire in hit-path order relative to EACH OTHER, not as two separate
+/// full passes over the path (every ordinary pointer target, then every
+/// mouse region). Flutter delivers both through the SAME single per-entry
+/// loop -- `GestureBinding.dispatchEvent`'s `for (final HitTestEntry entry in
+/// hitTestResult.path) { entry.target.handleEvent(...); }`
+/// (`gestures/binding.dart:496`) -- and `HitTestResult.path` is ordered
+/// leaf-first, "the most specific first" (`gestures/hit_test.dart:131-132`).
+/// For `Listener(outer) > MouseRegion(inner)` the inner region is the more
+/// specific target, so its `on_hover` must run before the outer listener's
+/// `on_pointer_hover`.
+///
+/// Not a Flutter-oracle port (no single upstream test isolates this
+/// interleaving); a regression test for FLUI's own two-pass dispatch
+/// (all ordinary targets, then all mouse regions) losing that relative order.
+///
+/// The leaf is a `ColoredBox`, not a bare `SizedBox`: an unpainted `SizedBox`
+/// has no `hitTestSelf` override and no child of its own, so it is correctly
+/// never part of the hit path (matching Flutter) -- a `DeferToChild` listener
+/// wrapping one would never register, which would make this test vacuous
+/// rather than red for the right reason.
+#[test]
+fn hover_fires_leaf_first_through_a_listener_wrapping_a_mouse_region() {
+    let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+    let (listener_log, region_log) = (Rc::clone(&log), Rc::clone(&log));
+
+    let laid = harness::pump_widget(
+        Listener::new()
+            .on_pointer_hover(move |_event| listener_log.borrow_mut().push("listener"))
+            .child(
+                MouseRegion::new()
+                    .on_hover(move |_device, _position| region_log.borrow_mut().push("region"))
+                    .child(ColoredBox::new(Color::rgb(10, 20, 30))),
+            ),
+        harness::screen_of(20.0, 20.0),
+    );
+
+    laid.dispatch_pointer_hover(10.0, 10.0);
+
+    assert_eq!(
+        log.borrow().as_slice(),
+        &["region", "listener"],
+        "the innermost MouseRegion is the leaf of the hit path and must \
+         receive on_hover before the outer Listener's on_pointer_hover"
+    );
+}
+
+/// As above with the nesting reversed -- pins "leaf-first", not "MouseRegion
+/// always fires first". `MouseRegion(outer) > Listener(inner)`: the inner
+/// `Listener` is now the more specific target and must fire first.
+#[test]
+fn hover_fires_leaf_first_through_a_mouse_region_wrapping_a_listener() {
+    let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+    let (region_log, listener_log) = (Rc::clone(&log), Rc::clone(&log));
+
+    let laid = harness::pump_widget(
+        MouseRegion::new()
+            .on_hover(move |_device, _position| region_log.borrow_mut().push("region"))
+            .child(
+                Listener::new()
+                    .on_pointer_hover(move |_event| listener_log.borrow_mut().push("listener"))
+                    .child(ColoredBox::new(Color::rgb(10, 20, 30))),
+            ),
+        harness::screen_of(20.0, 20.0),
+    );
+
+    laid.dispatch_pointer_hover(10.0, 10.0);
+
+    assert_eq!(
+        log.borrow().as_slice(),
+        &["listener", "region"],
+        "the innermost Listener is the leaf of the hit path and must receive \
+         on_pointer_hover before the outer MouseRegion's on_hover"
     );
 }

--- a/crates/flui-widgets/tests/parity/mouse_region_test.rs
+++ b/crates/flui-widgets/tests/parity/mouse_region_test.rs
@@ -49,23 +49,33 @@
 //!   (exists but not surfaced — the `binding` field is private), or a
 //!   scheduled-frame flag.
 //!
-//! ### A genuine FLUI/Flutter divergence found while classifying, not fixed
-//! here — reported per this file's honesty bar, not silently ported around:
-//! Flutter's `RenderMouseRegion.handleEvent` (`rendering/proxy_box.dart`
-//! 3.44.0, lines 3344-3349) fires `onHover` for **any** `PointerHoverEvent`
-//! reaching it as an ordinary `HitTestTarget`, regardless of device kind —
-//! independent of `MouseTracker`, which separately gates enter/exit to
-//! `mouse`/`stylus` only (`rendering/mouse_tracker.dart:302`). FLUI's
-//! `RenderMouseRegion` (`crates/flui-objects/src/interaction/mouse_region.rs`)
-//! has no such generic hit-test-event handler at all — it contributes only a
-//! [`MouseTrackerAnnotation`], so `on_hover` fires **exclusively** through
-//! `MouseTracker::update_with_motion`, which is gated to `Mouse | Pen`
-//! (`mouse_tracker.rs:220-222`) — the same gate Flutter uses for enter/exit,
-//! but Flutter does not apply it to hover. A touch-kind hover therefore
-//! delivers `on_hover` in Flutter and delivers nothing at all in FLUI. See
-//! [`'detects hover from touch devices'`](#not-ported) below.
+//! ### A genuine FLUI/Flutter divergence found while classifying, and fixed
+//! in this file's own change — reported per this file's honesty bar, not
+//! silently ported around: Flutter's `RenderMouseRegion.handleEvent`
+//! (`rendering/proxy_box.dart` 3.44.0) fires `onHover` for **any**
+//! `PointerHoverEvent` reaching it as an ordinary `HitTestTarget`, regardless
+//! of device kind — independent of `MouseTracker`, which separately gates
+//! enter/exit to `mouse`/`stylus` only (`rendering/mouse_tracker.dart:302`).
+//! FLUI's `RenderMouseRegion`
+//! (`crates/flui-objects/src/interaction/mouse_region.rs`) has no generic
+//! hit-test-event handler at all — it contributes only a
+//! [`MouseTrackerAnnotation`]. `on_hover` used to fire **exclusively**
+//! through `MouseTracker::update_with_motion`, which is gated to
+//! `Mouse | Pen` (`mouse_tracker.rs:220-222`) — the same gate Flutter uses
+//! for enter/exit, but Flutter does not apply it to hover — so a touch-kind
+//! hover delivered `on_hover` in Flutter and nothing at all in FLUI.
 //!
-//! ### Ported (15 of 43)
+//! The fix relocates `on_hover` delivery out of the device-state machine
+//! entirely, into `MouseTracker::dispatch_hover` (`mouse_tracker.rs`), called
+//! from the ordinary coalesced pointer-move dispatch path with no
+//! device-kind gate — mirroring `handleEvent` exactly.
+//! `MouseTracker::update_with_motion` keeps its `Mouse | Pen` gate, now
+//! scoped to enter/exit/cursor only, matching
+//! `MouseTracker.updateWithEvent`'s real scope in Flutter. See
+//! [`detects_hover_from_touch_devices`], now ported below instead of listed
+//! as a divergence.
+//!
+//! ### Ported (16 of 43)
 //! - `'hitTestBehavior test - HitTestBehavior.deferToChild/opaque'` —
 //!   [`hit_test_behavior_defer_to_child_then_opaque_toggles_enter`].
 //! - `'hitTestBehavior test - HitTestBehavior.deferToChild and non-opaque'` —
@@ -125,9 +135,13 @@
 //!   `LaidOut::dispatch_pointer_hover_with_kind(.., PointerType::Pen)` —
 //!   see the harness-capabilities note above) —
 //!   [`stylus_hover_delivers_enter_hover_exit_like_a_mouse`].
+//! - `'detects hover from touch devices'` (via
+//!   `LaidOut::dispatch_pointer_hover_with_kind(.., PointerType::Touch)`) —
+//!   the divergence fix above made this portable; see the section on it —
+//!   [`detects_hover_from_touch_devices`].
 //!
-//! ### Not ported (28 of 43) {#not-ported}
-//! Grouped by shared reason so the arithmetic stays checkable (15 + 28 = 43)
+//! ### Not ported (27 of 43) {#not-ported}
+//! Grouped by shared reason so the arithmetic stays checkable (16 + 27 = 43)
 //! without repeating each explanation 43 times:
 //!
 //! **No device connect/disconnect primitive** (3): `'triggers pointer enter
@@ -147,10 +161,6 @@
 //! postframe-recheck group above): `'A MouseRegion unmounted under the
 //! pointer should not trigger state change'`, `'No new frames are scheduled
 //! when mouse moves without triggering callbacks'`.
-//!
-//! **Touch-kind hover is a genuine FLUI/Flutter divergence, not just a
-//! harness gap** (1) — see the section above: `'detects hover from touch
-//! devices'`.
 //!
 //! **No cursor introspection surfaced by `LaidOut`** (1) —
 //! `MouseTracker::device_cursor` exists (`mouse_tracker.rs:450`) but nothing
@@ -225,10 +235,10 @@
 //!
 //! Count check, one primary reason per case, no case counted twice: 3
 //! (connect/disconnect) + 5 (postframe recheck) + 2 (`hasScheduledFrame`) + 1
-//! (touch hover) + 1 (cursor introspection) + 2 (compositing) + 6
-//! (paint-count) + 2 (`debugFillProperties`) + 2 (`StatefulView` plumbing) +
-//! 1 (`GlobalKey` reparent) + 1 (`Draggable` regression) + 2 (opacity
-//! transition matrix) = 28 not ported. 15 ported + 28 not ported = 43.
+//! (cursor introspection) + 2 (compositing) + 6 (paint-count) + 2
+//! (`debugFillProperties`) + 2 (`StatefulView` plumbing) + 1 (`GlobalKey`
+//! reparent) + 1 (`Draggable` regression) + 2 (opacity transition matrix) =
+//! 27 not ported. 16 ported + 27 not ported = 43.
 //!
 //! Widget → render-object mapping:
 //! - `MouseRegion` → `RenderMouseRegion`
@@ -938,4 +948,59 @@ fn stylus_hover_delivers_enter_hover_exit_like_a_mouse() {
 
     laid.dispatch_pointer_hover_with_kind(20.0, 20.0, PointerType::Pen);
     assert_eq!(log.borrow().as_slice(), &["exit"]);
+}
+
+/// A touch-originated hover reaches `on_hover` — exactly once — while
+/// `on_enter`/`on_exit` correctly do not fire for touch at all.
+///
+/// `on_enter`/`on_exit` stay gated to `Mouse | Pen`
+/// (`MouseTracker::update_with_motion`, `mouse_tracker.rs:220-222`), matching
+/// Flutter's own `MouseTracker.updateWithEvent` gate (`mouse_tracker.dart:302`).
+/// `on_hover` has no such gate: it is `RenderMouseRegion.handleEvent`'s
+/// concern (`proxy_box.dart`), not the tracker's, and fires for any
+/// `PointerHoverEvent` reaching the hit-test target regardless of device
+/// kind.
+///
+/// Flutter parity: `'detects hover from touch devices'`.
+#[test]
+fn detects_hover_from_touch_devices() {
+    let hover_count = Rc::new(Cell::new(0u32));
+    let last_hover_position = Rc::new(Cell::new(Offset::ZERO));
+    let enters: Rc<RefCell<Vec<Offset>>> = Rc::new(RefCell::new(Vec::new()));
+    let exits: Rc<RefCell<Vec<Offset>>> = Rc::new(RefCell::new(Vec::new()));
+    let (hover_counter, hover_position) =
+        (Rc::clone(&hover_count), Rc::clone(&last_hover_position));
+    let on_enter = Rc::clone(&enters);
+    let on_exit = Rc::clone(&exits);
+
+    let laid = harness::pump_widget(
+        Align::new(Alignment::CENTER).child(
+            MouseRegion::new()
+                .on_enter(move |_d, p| on_enter.borrow_mut().push(p))
+                .on_hover(move |_d, p| {
+                    hover_counter.set(hover_counter.get() + 1);
+                    hover_position.set(p);
+                })
+                .on_exit(move |_d, p| on_exit.borrow_mut().push(p))
+                .child(SizedBox::new(100.0, 100.0)),
+        ),
+        harness::screen_of(300.0, 300.0),
+    );
+
+    laid.dispatch_pointer_hover_with_kind(150.0, 150.0, PointerType::Touch);
+
+    assert_eq!(
+        hover_count.get(),
+        1,
+        "a touch-originated hover must reach on_hover exactly once"
+    );
+    assert_eq!(last_hover_position.get(), offset(150.0, 150.0));
+    assert!(
+        enters.borrow().is_empty(),
+        "on_enter stays gated to Mouse | Pen -- touch must not trigger it"
+    );
+    assert!(
+        exits.borrow().is_empty(),
+        "on_exit stays gated to Mouse | Pen -- touch must not trigger it"
+    );
 }


### PR DESCRIPTION
A touch-originated hover reached `MouseRegion::on_hover` **nowhere**. Found while porting the `MouseRegion` parity corpus (#465), where it was recorded as a divergence rather than papered over.

## The diagnosis is not the obvious one

FLUI fired hover from inside `MouseTracker::update_with_motion`, which gates on `Mouse | Pen`. The tempting read — "FLUI gates by device kind, Flutter doesn't" — is **wrong**:

- Flutter's `MouseTracker.updateWithEvent` has the identical gate: it returns early for any kind that is neither `mouse` nor `stylus`. FLUI's gate is correct parity.
- Flutter's tracker invokes **only** `onEnter` and `onExit` — those are the sole annotation callbacks in the whole file.
- `onHover` comes from `RenderMouseRegion.handleEvent`, on the ordinary per-target dispatch loop, with no device-kind check at all.

So the divergence is *where* hover is dispatched from, not whether a gate exists. Widening the gate would have turned the touch-hover test green **while introducing a new divergence** — enter/exit firing for touch, which Flutter does not do.

## The fix

Hover now dispatches from `MouseTracker::dispatch_hover`, called from the coalesced move-flush beside the existing ephemeral dispatch that already drives listener-style targets, resolving the same mouse annotations the render object already contributes. It filters only for a buttons-empty `Move` — Flutter's `PointerHoverEvent`/`PointerMoveEvent` split expressed on the event, since FLUI has one `Move` variant.

`update_with_motion` keeps its gate and is now enter/exit/cursor only. The hover collection and its invoke loop are **removed** from that path rather than left dead, so hover has exactly one dispatch site and structurally cannot double-fire.

Ordering is unchanged and matches the oracle: `RendererBinding.dispatchEvent` calls `updateWithEvent` before `super.dispatchEvent`, so enter precedes hover — the order FLUI's existing tests already encode.

## Evidence

Red reproduced by disabling the new dispatch call: `detects_hover_from_touch_devices` fails with *"a touch-originated hover must reach on_hover exactly once"*. Single-fire is asserted with integer counters, not booleans, and the pre-existing mouse-hover smoke test still asserts exactly 1.

Two existing tests encoded the old placement and were **adapted, not deleted**: the tracker unit test now asserts the complementary invariant (`update_with_motion` never invokes hover), and the harness test exercises the two calls as the independent paths they became.

## Parity

`'detects hover from touch devices'` moves from not-ported to ported — denominator now **16 + 27 = 43**. The tracker's module doc and `PointerMotionKind`'s doc both claimed hover was tracker-owned; corrected.

## Gates

parity **462** · workspace **8148** · clippy · fmt · inventory-check · port-check · doc-strict — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117t1jX2FFcCzP3YBLoQB94
