### PR TITLE
fix(view,binding): unmount subtrees bottom-up; recheck stationary devices

### DIFF
--- a/crates/flui-binding/src/lib.rs
+++ b/crates/flui-binding/src/lib.rs
@@ -560,16 +560,24 @@ impl HeadlessBinding {
     ///    `MouseTracker.updateAllDevices` postframe recheck
     ///    (`rendering/mouse_tracker.dart`, called from
     ///    `RendererBinding._handlePersistentFrameCallback`'s
-    ///    `_scheduleMouseTrackerUpdate`). This is what lets a region that
-    ///    appears, moves, or disappears under a **motionless** pointer emit
-    ///    enter/exit with no new pointer motion: the mechanism production
-    ///    already wires (`AppBinding::draw_frame`,
-    ///    `crates/flui-app/src/app/binding.rs`) right after layout/paint,
-    ///    mirrored here against this binding's own tree-bound
-    ///    `PipelineOwner` rather than a caller-supplied hit-test closure —
-    ///    `pump_frame`'s tree-bound branch already owns the same
-    ///    `Arc<RwLock<PipelineOwner>>` production's `hit_test_in_view` wraps,
-    ///    so no new parameter is needed on this already-widely-called method.
+    ///    `_scheduleMouseTrackerUpdate`, still inside the persistent phase,
+    ///    ahead of the post-frame callback queue). This is what lets a
+    ///    region that appears, moves, or disappears under a **motionless**
+    ///    pointer emit enter/exit with no new pointer motion: the mechanism
+    ///    production already wires
+    ///    (`AppBinding::render_frame_entered`,
+    ///    `crates/flui-app/src/app/binding.rs`, driven from inside
+    ///    `Scheduler::drive_frame`'s own pipeline closure —
+    ///    `crates/flui-app/src/app/runner.rs`) right after layout/paint and
+    ///    still inside that same closure, mirrored here against this
+    ///    binding's own tree-bound `PipelineOwner` rather than a
+    ///    caller-supplied hit-test closure — `pump_frame`'s tree-bound
+    ///    branch already owns the same `Arc<RwLock<PipelineOwner>>`
+    ///    production's `hit_test_in_view` wraps, so no new parameter is
+    ///    needed on this already-widely-called method. Step 7 therefore
+    ///    runs inside the same `drive_frame` pipeline closure as step 6,
+    ///    not after it returns — see the inline comment at the call site
+    ///    for why that placement is load-bearing, not cosmetic.
     ///
     /// # The load-bearing invariant
     ///
@@ -639,23 +647,42 @@ impl HeadlessBinding {
                 // the borrow on `self` for the pipeline closure.
                 let scheduler = scheduler.clone();
                 let vsync_time = flui_scheduler::Instant::now();
-                scheduler.drive_frame(vsync_time, || Self::run_pipeline(tree));
+                scheduler.drive_frame(vsync_time, || {
+                    Self::run_pipeline(tree);
 
-                // 9. Re-hit-test every stationary device against the tree
-                //    layout/paint above just committed. Unconditional and
-                //    every frame, matching both the oracle
-                //    (`_scheduleMouseTrackerUpdate`, always posted) and
-                //    production (`AppBinding::draw_frame`, no gate). A
-                //    gesture-only binding has no tree to hit-test, so this
-                //    is a no-op there.
-                if let Some(tree_binding) = tree.as_ref() {
-                    let pipeline_owner = &tree_binding.pipeline_owner;
-                    gestures.mouse_tracker().update_all_devices(|position| {
-                        let mut result = HitTestResult::new();
-                        pipeline_owner.read().hit_test(position, &mut result);
-                        result
-                    });
-                }
+                    // 7. Re-hit-test every stationary device against the
+                    //    tree layout/paint that just committed above,
+                    //    still inside this closure's `PersistentCallbacks`
+                    //    slot — i.e. BEFORE `end_frame` drains post-frame
+                    //    callbacks below, not after `drive_frame` returns.
+                    //    Placement matters: production
+                    //    (`AppBinding::render_frame_entered`,
+                    //    `crates/flui-app/src/app/binding.rs`, invoked from
+                    //    `crates/flui-app/src/app/runner.rs`) calls
+                    //    `update_all_devices` from inside the SAME
+                    //    `drive_frame` pipeline closure it runs its own
+                    //    layout/paint step in, so any post-frame work an
+                    //    enter/exit callback queues (e.g. a rebuild
+                    //    handle) lands in THIS frame's post-frame phase —
+                    //    matching the oracle, where
+                    //    `_scheduleMouseTrackerUpdate` posts
+                    //    `updateAllDevices` from
+                    //    `_handlePersistentFrameCallback`, still inside
+                    //    the persistent phase, ahead of the post-frame
+                    //    queue. Running this after `drive_frame` returns
+                    //    would defer that queued work to a LATER pump
+                    //    instead. Unconditional and every frame; a
+                    //    gesture-only binding has no tree to hit-test, so
+                    //    this is a no-op there.
+                    if let Some(tree_binding) = tree.as_ref() {
+                        let pipeline_owner = &tree_binding.pipeline_owner;
+                        gestures.mouse_tracker().update_all_devices(|position| {
+                            let mut result = HitTestResult::new();
+                            pipeline_owner.read().hit_test(position, &mut result);
+                            result
+                        });
+                    }
+                });
             });
         });
     }

--- a/crates/flui-binding/src/lib.rs
+++ b/crates/flui-binding/src/lib.rs
@@ -555,6 +555,21 @@ impl HeadlessBinding {
     ///    that inbox at its start and reconciles.
     /// 6. **Run the pipeline frame** (tree-bound only): `PipelineOwner::run_frame`
     ///    lays out, paints, and composites.
+    /// 7. **Re-hit-test every stationary pointing device** (tree-bound only)
+    ///    against the tree this frame just laid out — Flutter's implicit
+    ///    `MouseTracker.updateAllDevices` postframe recheck
+    ///    (`rendering/mouse_tracker.dart`, called from
+    ///    `RendererBinding._handlePersistentFrameCallback`'s
+    ///    `_scheduleMouseTrackerUpdate`). This is what lets a region that
+    ///    appears, moves, or disappears under a **motionless** pointer emit
+    ///    enter/exit with no new pointer motion: the mechanism production
+    ///    already wires (`AppBinding::draw_frame`,
+    ///    `crates/flui-app/src/app/binding.rs`) right after layout/paint,
+    ///    mirrored here against this binding's own tree-bound
+    ///    `PipelineOwner` rather than a caller-supplied hit-test closure —
+    ///    `pump_frame`'s tree-bound branch already owns the same
+    ///    `Arc<RwLock<PipelineOwner>>` production's `hit_test_in_view` wraps,
+    ///    so no new parameter is needed on this already-widely-called method.
     ///
     /// # The load-bearing invariant
     ///
@@ -568,7 +583,7 @@ impl HeadlessBinding {
     /// next frame — a one-frame animation lag. The order is what makes an
     /// animation visible **same-frame**.
     ///
-    /// Steps 5–6 run only when the binding is tree-bound
+    /// Steps 5–7 run only when the binding is tree-bound
     /// ([`with_tree`](Self::with_tree)); a gesture-only binding stops after step 4,
     /// so a bare controller can still be driven deterministically.
     pub fn pump_frame(&mut self, dt: Duration) {
@@ -625,6 +640,22 @@ impl HeadlessBinding {
                 let scheduler = scheduler.clone();
                 let vsync_time = flui_scheduler::Instant::now();
                 scheduler.drive_frame(vsync_time, || Self::run_pipeline(tree));
+
+                // 9. Re-hit-test every stationary device against the tree
+                //    layout/paint above just committed. Unconditional and
+                //    every frame, matching both the oracle
+                //    (`_scheduleMouseTrackerUpdate`, always posted) and
+                //    production (`AppBinding::draw_frame`, no gate). A
+                //    gesture-only binding has no tree to hit-test, so this
+                //    is a no-op there.
+                if let Some(tree_binding) = tree.as_ref() {
+                    let pipeline_owner = &tree_binding.pipeline_owner;
+                    gestures.mouse_tracker().update_all_devices(|position| {
+                        let mut result = HitTestResult::new();
+                        pipeline_owner.read().hit_test(position, &mut result);
+                        result
+                    });
+                }
             });
         });
     }

--- a/crates/flui-interaction/src/routing/interaction_lane.rs
+++ b/crates/flui-interaction/src/routing/interaction_lane.rs
@@ -825,21 +825,29 @@ impl InteractionDispatchHandle {
         Ok(())
     }
 
-    /// Remove a mouse-region target from future annotation resolution.
+    /// Remove a mouse-region target from future annotation resolution,
+    /// without touching the target's shared cell contents.
     ///
-    /// Existing tracker state may still retain a strong owner-local clone of
-    /// this target's cell long enough to emit the matching exit callback for
-    /// a previously active annotation — e.g. a rebuild that empties a still-
-    /// mounted region's callback set
-    /// (`sync_mouse_region_target`'s `(false, Some(target))` branch,
-    /// `crates/flui-widgets/src/interaction/mouse_region.rs`) wants a pointer
-    /// that later leaves the region's (still hit-testable) bounds to still
-    /// resolve *some* delivery against the callback set active when it was
-    /// entered. Use [`detach_mouse_region`](Self::detach_mouse_region)
-    /// instead when the region's render object is being permanently removed
-    /// from the tree (unmounted) — there, the softer contract this method
-    /// keeps would let a stationary device's postframe recheck fire a
-    /// spurious exit for a region that no longer exists.
+    /// This is a lane-level primitive, not the still-mounted-region case: a
+    /// render object that is merely rebuilt with an empty callback set stays
+    /// registered (see `MouseRegion::sync_mouse_region_target`,
+    /// `crates/flui-widgets/src/interaction/mouse_region.rs`, which calls
+    /// [`replace_mouse_region`](Self::replace_mouse_region) with the empty
+    /// set instead of this method — Flutter's `RenderMouseRegion` has no
+    /// "unregister while attached" concept either, its callback fields are
+    /// just nulled in place). What remains for this method is releasing a
+    /// target this lane no longer wants to resolve fresh annotations
+    /// against. Because it only drops the *lane's* map entry, an existing
+    /// strong `Rc` clone held elsewhere — e.g.
+    /// [`MouseTracker`](super::MouseTracker)'s own per-region cache,
+    /// populated the last time this target was resolved from a hit test —
+    /// keeps observing whatever the cell's contents happen to be until that
+    /// clone is itself dropped, which is how a target already mid-resolution
+    /// can still deliver one last, correctly-scoped callback. Use
+    /// [`detach_mouse_region`](Self::detach_mouse_region) instead when the
+    /// goal is to guarantee no further delivery at all, including from an
+    /// already-cached clone — that is what a permanently unmounted render
+    /// object needs.
     pub fn unregister_mouse_region(
         &self,
         target: MouseRegionTarget,
@@ -850,10 +858,10 @@ impl InteractionDispatchHandle {
 
     /// Remove a mouse-region target AND immediately invalidate its cell's
     /// callbacks in place, for a region whose render object is being
-    /// permanently detached (unmounted) rather than merely rebuilt with an
-    /// empty callback set — see
-    /// [`unregister_mouse_region`](Self::unregister_mouse_region) for that
-    /// softer, still-mounted case and why the two must differ.
+    /// permanently detached (unmounted) — see
+    /// [`unregister_mouse_region`](Self::unregister_mouse_region) for the
+    /// softer lane-level primitive and why a still-mounted, rebuilt-with-no-
+    /// callbacks region uses neither of these two methods at all.
     ///
     /// [`MouseTracker`](super::MouseTracker) caches an `Rc` clone of this
     /// same cell across frames (its `annotations` map, keyed by region id)

--- a/crates/flui-interaction/src/routing/interaction_lane.rs
+++ b/crates/flui-interaction/src/routing/interaction_lane.rs
@@ -826,19 +826,72 @@ impl InteractionDispatchHandle {
     }
 
     /// Remove a mouse-region target from future annotation resolution.
+    ///
+    /// Existing tracker state may still retain a strong owner-local clone of
+    /// this target's cell long enough to emit the matching exit callback for
+    /// a previously active annotation — e.g. a rebuild that empties a still-
+    /// mounted region's callback set
+    /// (`sync_mouse_region_target`'s `(false, Some(target))` branch,
+    /// `crates/flui-widgets/src/interaction/mouse_region.rs`) wants a pointer
+    /// that later leaves the region's (still hit-testable) bounds to still
+    /// resolve *some* delivery against the callback set active when it was
+    /// entered. Use [`detach_mouse_region`](Self::detach_mouse_region)
+    /// instead when the region's render object is being permanently removed
+    /// from the tree (unmounted) — there, the softer contract this method
+    /// keeps would let a stationary device's postframe recheck fire a
+    /// spurious exit for a region that no longer exists.
     pub fn unregister_mouse_region(
         &self,
         target: MouseRegionTarget,
     ) -> Result<(), InteractionDispatchError> {
+        drop(self.take_mouse_region_cell(target)?);
+        Ok(())
+    }
+
+    /// Remove a mouse-region target AND immediately invalidate its cell's
+    /// callbacks in place, for a region whose render object is being
+    /// permanently detached (unmounted) rather than merely rebuilt with an
+    /// empty callback set — see
+    /// [`unregister_mouse_region`](Self::unregister_mouse_region) for that
+    /// softer, still-mounted case and why the two must differ.
+    ///
+    /// [`MouseTracker`](super::MouseTracker) caches an `Rc` clone of this
+    /// same cell across frames (its `annotations` map, keyed by region id)
+    /// so it can resolve an exit callback for a region that no longer
+    /// appears in a fresh hit test. Removing only this lane's own map entry
+    /// leaves that cached clone's callbacks intact, so a stationary
+    /// device's next postframe recheck
+    /// ([`MouseTracker::update_all_devices`](super::MouseTracker::update_all_devices))
+    /// would still invoke the unmounted region's `on_exit` — the spurious
+    /// exit Flutter's `validForMouseTracker` flag
+    /// (`rendering/proxy_box.dart` `RenderMouseRegion.detach`) exists to
+    /// prevent. Overwriting the shared cell's contents here is FLUI's
+    /// equivalent invalidation: every remaining holder of the `Rc`,
+    /// including that cached clone, observes empty callbacks on its next
+    /// `snapshot()`.
+    pub fn detach_mouse_region(
+        &self,
+        target: MouseRegionTarget,
+    ) -> Result<(), InteractionDispatchError> {
+        let cell = self.take_mouse_region_cell(target)?;
+        drop(cell.replace(MouseRegionCallbacks::default()));
+        Ok(())
+    }
+
+    /// Shared removal step for [`unregister_mouse_region`](Self::unregister_mouse_region)
+    /// and [`detach_mouse_region`](Self::detach_mouse_region): take this
+    /// lane's own map entry, leaving the caller to decide whether the
+    /// returned cell's callbacks should also be invalidated in place.
+    fn take_mouse_region_cell(
+        &self,
+        target: MouseRegionTarget,
+    ) -> Result<Rc<MouseRegionCell>, InteractionDispatchError> {
         let lane = self.active_lane()?;
         self.validate_lane(target.lane_id)?;
-        let removed = lane
-            .mouse_targets
+        lane.mouse_targets
             .borrow_mut()
             .remove(&target.target_id)
-            .ok_or(InteractionDispatchError::TargetGone)?;
-        drop(removed);
-        Ok(())
+            .ok_or(InteractionDispatchError::TargetGone)
     }
 
     pub(super) fn resolve_mouse_region(

--- a/crates/flui-interaction/src/routing/mouse_tracker.rs
+++ b/crates/flui-interaction/src/routing/mouse_tracker.rs
@@ -709,6 +709,26 @@ mod tests {
         assert_eq!(tracker.current_cursor(), CursorIcon::Default);
     }
 
+    /// Exercises [`InteractionDispatchHandle::unregister_mouse_region`]
+    /// directly, at the lane level — not through
+    /// `MouseRegion`/`RenderMouseRegion`. The `outside_event` fed to the
+    /// second [`MouseTracker::update_with_motion`] call is a genuine change
+    /// of circumstance independent of the unregister: an empty
+    /// `HitTestResult` standing in for the pointer having actually moved off
+    /// the region. That combination — a target unregistered from the lane,
+    /// *and* a fresh hit test that separately no longer finds it — is
+    /// distinct from a still-mounted region rebuilt with an empty callback
+    /// set at a stationary pointer position, which is what
+    /// `rebuilding_a_hovered_region_down_to_no_callbacks_fires_nothing`
+    /// (`crates/flui-widgets/tests/parity/mouse_region_test.rs`) pins:
+    /// `MouseRegion`'s widget-level sync no longer calls
+    /// `unregister_mouse_region` for that case at all (it keeps the target
+    /// registered and replaces its callbacks via `replace_mouse_region`
+    /// instead), so this test's contract — a target already mid-resolution
+    /// can still deliver one last callback against the state that was
+    /// active when it was unregistered — remains correct for what it
+    /// actually tests: the lane-level `unregister_mouse_region` primitive,
+    /// not `MouseRegion`'s rebuild behavior.
     #[test]
     fn enter_exit_callbacks_are_owner_local_and_exit_uses_previous_annotation() {
         let lane = InteractionLane::try_new().expect("lane");

--- a/crates/flui-view/src/tree/element_tree.rs
+++ b/crates/flui-view/src/tree/element_tree.rs
@@ -1253,12 +1253,19 @@ impl ElementTree {
     ///
     /// The algorithm mirrors `id_reconcile::remove_child` / `collect_subtree_preorder`:
     ///
-    /// 1. Snapshot the subtree in pre-order (parent before children) while all
-    ///    `child_ids` lists are intact.
-    /// 2. For an un-keyed root, free descendants deepest-first via
-    ///    `remove_finalized` BEFORE the root's own removal (step 3). Each
-    ///    element's own `unmount` — e.g. `RenderView::did_unmount_render_object`
-    ///    for `MouseRegion`/`ClipPath`/`Listener`, which unregisters from the
+    /// 1. Peek whether the root is keyed (`registered_global_key_hash`),
+    ///    side-effect-free, before touching anything. A keyed root
+    ///    soft-removes via `remove` and returns immediately — descendants
+    ///    stay untouched, parked for `finalize_tree`'s deferred drain in
+    ///    case the root is reclaimed same-frame via `GlobalKey` — so the
+    ///    subtree snapshot below is never needed for this branch and would
+    ///    be pure wasted work if taken first.
+    /// 2. For an un-keyed root, snapshot the subtree in pre-order (parent
+    ///    before children) while all `child_ids` lists are intact.
+    /// 3. Free descendants deepest-first via `remove_finalized` BEFORE the
+    ///    root's own removal (step 4). Each element's own `unmount` — e.g.
+    ///    `RenderView::did_unmount_render_object` for
+    ///    `MouseRegion`/`ClipPath`/`Listener`, which unregisters from the
     ///    owner-local interaction lane — needs its OWN render object still
     ///    reachable in the render tree to fire at all
     ///    (`RenderBehavior::on_unmount` looks it up by id and silently skips
@@ -1270,17 +1277,30 @@ impl ElementTree {
     ///    orphaning its interaction-lane registration for the life of the
     ///    owner. Processing descendants first makes each one's own render
     ///    removal a no-op by the time the root's cascade reaches it.
-    /// 3. Remove the root via `remove` (soft-removes keyed elements; for a
-    ///    keyed root, descendants are left untouched — parked for
-    ///    `finalize_tree`'s deferred drain in case the root is reclaimed
-    ///    same-frame via `GlobalKey`, exactly as before this function
-    ///    reordered steps 2–3).
+    /// 4. Remove the root via `remove`.
     ///
     /// Complexity: O(n) time + O(n) peak heap for the work-stack (n = subtree
-    /// size), O(h) call-stack for the constant-stack iterative walk.
+    /// size), O(h) call-stack for the constant-stack iterative walk — paid
+    /// only for an un-keyed root; a keyed root is O(1).
     pub(crate) fn remove_subtree(&mut self, id: ElementId, owner: &mut crate::ElementOwner<'_>) {
-        // Snapshot subtree pre-order (parent before children) before touching
-        // any node, while every `child_ids` list is still intact.
+        // A keyed root soft-removes into the inactive queue instead of
+        // freeing outright (`remove`'s own branch, keyed on
+        // `registered_global_key_hash`); descendants stay untouched. Check
+        // this FIRST: it needs no subtree walk, and a keyed root never uses
+        // the snapshot below, so paying for that walk before checking would
+        // be wasted work for every keyed-root removal.
+        let root_is_keyed = self
+            .get(id)
+            .is_some_and(|node| node.registered_global_key_hash().is_some());
+
+        if root_is_keyed {
+            self.remove(id, owner);
+            return;
+        }
+
+        // Un-keyed root: snapshot the subtree pre-order (parent before
+        // children) before touching any node, while every `child_ids` list
+        // is still intact.
         let mut subtree: Vec<ElementId> = Vec::new();
         {
             let mut work_stack: Vec<ElementId> = vec![id];
@@ -1294,26 +1314,11 @@ impl ElementTree {
             }
         }
 
-        // A keyed root soft-removes into the inactive queue instead of
-        // freeing outright (`remove`'s own branch, keyed on
-        // `registered_global_key_hash`); descendants stay untouched exactly
-        // as before this reorder. Peeking the flag here, before touching
-        // anything, is side-effect-free and lets us pick the descendants-
-        // first-or-not branch up front instead of after the fact.
-        let root_is_keyed = self
-            .get(id)
-            .is_some_and(|node| node.registered_global_key_hash().is_some());
-
-        if root_is_keyed {
-            self.remove(id, owner);
-            return;
-        }
-
-        // Un-keyed root: free descendants deepest-first -- `subtree[0]` is
-        // the root itself (removed below, last); iterating the rest in
-        // reverse visits each descendant after all of ITS OWN descendants,
-        // so a nested unmount hook (e.g. a `MouseRegion` two levels down)
-        // always still finds its own render object present.
+        // Free descendants deepest-first -- `subtree[0]` is the root itself
+        // (removed below, last); iterating the rest in reverse visits each
+        // descendant after all of ITS OWN descendants, so a nested unmount
+        // hook (e.g. a `MouseRegion` two levels down) always still finds its
+        // own render object present.
         for &descendant in subtree[1..].iter().rev() {
             self.remove_finalized(descendant, owner);
         }

--- a/crates/flui-view/src/tree/element_tree.rs
+++ b/crates/flui-view/src/tree/element_tree.rs
@@ -1246,15 +1246,35 @@ impl ElementTree {
     /// evict a lazy sliver child together with all of its own descendant
     /// elements and render nodes (e.g. a `Container(Padding(Text))` child
     /// produces three elements; a single-node `remove` would leak the inner
-    /// two).
+    /// two). Also the removal path a rebuild takes for any un-keyed child
+    /// whose element type changed (`ElementTree::update`'s can't-reuse
+    /// branch) — e.g. `LaidOut::pump_widget`'s root-swap in the headless
+    /// harness.
     ///
     /// The algorithm mirrors `id_reconcile::remove_child` / `collect_subtree_preorder`:
     ///
     /// 1. Snapshot the subtree in pre-order (parent before children) while all
     ///    `child_ids` lists are intact.
-    /// 2. Remove the root via `remove` (soft-removes keyed elements).
-    /// 3. If the root was eagerly removed (un-keyed), free its descendants
-    ///    deepest-first via `remove_finalized`.
+    /// 2. For an un-keyed root, free descendants deepest-first via
+    ///    `remove_finalized` BEFORE the root's own removal (step 3). Each
+    ///    element's own `unmount` — e.g. `RenderView::did_unmount_render_object`
+    ///    for `MouseRegion`/`ClipPath`/`Listener`, which unregisters from the
+    ///    owner-local interaction lane — needs its OWN render object still
+    ///    reachable in the render tree to fire at all
+    ///    (`RenderBehavior::on_unmount` looks it up by id and silently skips
+    ///    the view-level hook when the lookup misses). Removing the root
+    ///    first would cascade-delete every descendant render node in one
+    ///    shot (`PipelineOwner::remove_render_object` recurses), so a
+    ///    descendant unmounted afterward would find its render object
+    ///    already gone and its own unmount hook would silently never run —
+    ///    orphaning its interaction-lane registration for the life of the
+    ///    owner. Processing descendants first makes each one's own render
+    ///    removal a no-op by the time the root's cascade reaches it.
+    /// 3. Remove the root via `remove` (soft-removes keyed elements; for a
+    ///    keyed root, descendants are left untouched — parked for
+    ///    `finalize_tree`'s deferred drain in case the root is reclaimed
+    ///    same-frame via `GlobalKey`, exactly as before this function
+    ///    reordered steps 2–3).
     ///
     /// Complexity: O(n) time + O(n) peak heap for the work-stack (n = subtree
     /// size), O(h) call-stack for the constant-stack iterative walk.
@@ -1274,18 +1294,30 @@ impl ElementTree {
             }
         }
 
-        // Remove the root; `Some` ⇒ eagerly freed (un-keyed), `None` ⇒
-        // soft-removed (keyed) and parked for `finalize_tree`.
-        let root_removed_eagerly = self.remove(id, owner).is_some();
+        // A keyed root soft-removes into the inactive queue instead of
+        // freeing outright (`remove`'s own branch, keyed on
+        // `registered_global_key_hash`); descendants stay untouched exactly
+        // as before this reorder. Peeking the flag here, before touching
+        // anything, is side-effect-free and lets us pick the descendants-
+        // first-or-not branch up front instead of after the fact.
+        let root_is_keyed = self
+            .get(id)
+            .is_some_and(|node| node.registered_global_key_hash().is_some());
 
-        if root_removed_eagerly {
-            // Free orphaned descendants deepest-first.  `subtree[0]` is the
-            // root (already freed above); iterating in reverse visits each
-            // child after all of its own descendants.
-            for &descendant in subtree[1..].iter().rev() {
-                self.remove_finalized(descendant, owner);
-            }
+        if root_is_keyed {
+            self.remove(id, owner);
+            return;
         }
+
+        // Un-keyed root: free descendants deepest-first -- `subtree[0]` is
+        // the root itself (removed below, last); iterating the rest in
+        // reverse visits each descendant after all of ITS OWN descendants,
+        // so a nested unmount hook (e.g. a `MouseRegion` two levels down)
+        // always still finds its own render object present.
+        for &descendant in subtree[1..].iter().rev() {
+            self.remove_finalized(descendant, owner);
+        }
+        self.remove(id, owner);
     }
 
     /// Fully remove an element that has already been unmounted (e.g.

--- a/crates/flui-view/src/tree/id_reconcile.rs
+++ b/crates/flui-view/src/tree/id_reconcile.rs
@@ -528,6 +528,20 @@ fn update_child(
 /// active and registered; E3's contract here is that every descendant unmounts
 /// exactly once.
 ///
+/// Order for an unkeyed top: descendants unmount deepest-first BEFORE the
+/// top, not after. An element's own `unmount` (`RenderBehavior::on_unmount`)
+/// looks up its render object by id and calls the view-level
+/// `did_unmount_render_object` hook ONLY if that lookup still succeeds —
+/// which is how `MouseRegion`/`ClipPath`/`Listener` unregister from the
+/// owner-local interaction lane on unmount. The top's own render-object
+/// removal cascades (`PipelineOwner::remove_render_object` recurses over
+/// descendants), so unmounting the top first would delete every descendant's
+/// render object before that descendant's own `unmount` ever ran — silently
+/// skipping its view-level hook and orphaning its interaction-lane
+/// registration for the life of the owner. Freeing descendants first makes
+/// each one's own render-object removal (part of its own `unmount`) a no-op
+/// by the time the top's cascade would otherwise have reached it.
+///
 /// Stale / absent ids are a no-op inside `remove` / `remove_finalized`.
 fn remove_child(tree: &mut ElementTree, id: ElementId, owner: &mut crate::ElementOwner<'_>) {
     // Snapshot the subtree pre-order (parent before children) BEFORE
@@ -537,18 +551,26 @@ fn remove_child(tree: &mut ElementTree, id: ElementId, owner: &mut crate::Elemen
     let mut subtree = Vec::new();
     collect_subtree_preorder(tree, id, &mut subtree);
 
-    // Remove the top. `Some` ⇒ eager (unkeyed) free; `None` ⇒ soft-removed
-    // (keyed) and parked for `finalize_tree`.
-    let removed_eagerly = tree.remove(id, owner).is_some();
-
-    if removed_eagerly {
-        // Free the orphaned descendants deepest-first. `subtree[0]` is the
-        // top (already removed); reverse of pre-order visits every parent
-        // after all of its descendants.
-        for &descendant in subtree[1..].iter().rev() {
-            tree.remove_finalized(descendant, owner);
-        }
+    // A keyed top soft-removes into the inactive queue instead of freeing
+    // outright, leaving descendants untouched for `finalize_tree`'s deferred
+    // drain (same-frame GlobalKey retake window) — peeking the flag before
+    // touching anything lets us pick the descendants-first-or-not branch up
+    // front rather than after the fact.
+    if tree
+        .get(id)
+        .is_some_and(|node| node.registered_global_key_hash().is_some())
+    {
+        tree.remove(id, owner);
+        return;
     }
+
+    // Unkeyed top: free the descendants deepest-first — `subtree[0]` is the
+    // top itself (removed last, below); reverse of pre-order visits every
+    // parent after all of its descendants.
+    for &descendant in subtree[1..].iter().rev() {
+        tree.remove_finalized(descendant, owner);
+    }
+    tree.remove(id, owner);
 }
 
 /// Collect `id` and its whole subtree in pre-order (parent before

--- a/crates/flui-view/src/tree/id_reconcile.rs
+++ b/crates/flui-view/src/tree/id_reconcile.rs
@@ -509,18 +509,20 @@ fn update_child(
 /// deregistration, dependent cleanup, render-object detach) never run and
 /// its `parent` edge left dangling at a freed slot.
 ///
-/// Two cases, branched on the top node's keyed-ness via `remove`'s return:
-/// - **Keyed top** → `remove` soft-removes it into the inactive queue and
-///   leaves the subtree intact in the slab.
+/// Two cases, branched on the top node's keyed-ness, peeked via
+/// `registered_global_key_hash` BEFORE touching anything:
+/// - **Keyed top** → soft-removes via `remove` into the inactive queue and
+///   returns immediately, leaving the subtree intact in the slab.
 ///   [`BuildOwner::finalize_tree`](crate::BuildOwner::finalize_tree) later
 ///   re-collects that subtree and tears it down deepest-first, preserving
-///   the same-frame GlobalKey retake window. Nothing more to do here.
-/// - **Unkeyed top** → `remove` eager-unmounts + frees only the top,
-///   returning the node. Its descendants are now orphaned, so they are
-///   freed here deepest-first via
-///   [`ElementTree::remove_finalized`](crate::tree::ElementTree::remove_finalized),
-///   mirroring `finalize_tree`'s reverse-pre-order drain so no parent slot
-///   is freed before its children.
+///   the same-frame GlobalKey retake window. The subtree snapshot below is
+///   never needed for this branch, so checking keyed-ness first avoids
+///   paying for that walk on every keyed-top removal.
+/// - **Unkeyed top** → its descendants are freed here deepest-first via
+///   [`ElementTree::remove_finalized`](crate::tree::ElementTree::remove_finalized)
+///   BEFORE the top's own `remove`, mirroring `finalize_tree`'s
+///   reverse-pre-order drain so no parent slot is freed before its
+///   children — see the ordering rationale below.
 ///
 /// A keyed *descendant* of an unkeyed top is freed (not soft-removed) — it
 /// loses its retake window because its ancestor is already gone. The active
@@ -544,18 +546,12 @@ fn update_child(
 ///
 /// Stale / absent ids are a no-op inside `remove` / `remove_finalized`.
 fn remove_child(tree: &mut ElementTree, id: ElementId, owner: &mut crate::ElementOwner<'_>) {
-    // Snapshot the subtree pre-order (parent before children) BEFORE
-    // touching the top, while every `child_ids` list is still intact.
-    // Owned `Vec` → no slab borrow is held across the removals
-    // (extract-then-apply).
-    let mut subtree = Vec::new();
-    collect_subtree_preorder(tree, id, &mut subtree);
-
     // A keyed top soft-removes into the inactive queue instead of freeing
     // outright, leaving descendants untouched for `finalize_tree`'s deferred
-    // drain (same-frame GlobalKey retake window) — peeking the flag before
-    // touching anything lets us pick the descendants-first-or-not branch up
-    // front rather than after the fact.
+    // drain (same-frame GlobalKey retake window). Check this FIRST: it needs
+    // no subtree walk, and a keyed top never uses the snapshot below, so
+    // collecting it before checking would be wasted work for every keyed-top
+    // removal.
     if tree
         .get(id)
         .is_some_and(|node| node.registered_global_key_hash().is_some())
@@ -564,9 +560,16 @@ fn remove_child(tree: &mut ElementTree, id: ElementId, owner: &mut crate::Elemen
         return;
     }
 
-    // Unkeyed top: free the descendants deepest-first — `subtree[0]` is the
-    // top itself (removed last, below); reverse of pre-order visits every
-    // parent after all of its descendants.
+    // Unkeyed top: snapshot the subtree pre-order (parent before children)
+    // BEFORE touching the top, while every `child_ids` list is still
+    // intact. Owned `Vec` → no slab borrow is held across the removals
+    // (extract-then-apply).
+    let mut subtree = Vec::new();
+    collect_subtree_preorder(tree, id, &mut subtree);
+
+    // Free the descendants deepest-first — `subtree[0]` is the top itself
+    // (removed last, below); reverse of pre-order visits every parent
+    // after all of its descendants.
     for &descendant in subtree[1..].iter().rev() {
         tree.remove_finalized(descendant, owner);
     }

--- a/crates/flui-view/src/view/render.rs
+++ b/crates/flui-view/src/view/render.rs
@@ -136,14 +136,25 @@ impl<'a> RenderObjectContext<'a> {
             .replace_mouse_region(target, callbacks)?)
     }
 
-    /// Remove a mouse-region target from future annotation resolution.
+    /// Remove a mouse-region target from future annotation resolution,
+    /// without invalidating its shared cell's current contents.
     ///
-    /// Existing tracker state may still retain a strong owner-local cell long
-    /// enough to emit the matching exit callback for a previously active
-    /// annotation. Use
-    /// [`detach_mouse_region`](Self::detach_mouse_region) instead when the
-    /// region's render object is being permanently removed from the tree
-    /// (unmounted) rather than merely rebuilt with an empty callback set.
+    /// A still-mounted region rebuilt with an empty callback set does NOT
+    /// call this — `MouseRegion`'s widget-level sync
+    /// (`crates/flui-widgets/src/interaction/mouse_region.rs`) keeps
+    /// the target registered and calls
+    /// [`replace_mouse_region`](Self::replace_mouse_region) with the empty
+    /// set instead, matching Flutter's `RenderMouseRegion`, which stays a
+    /// valid annotation with null callback fields until `detach()`
+    /// (`rendering/proxy_box.dart`). This method is the lower-level lane
+    /// primitive underneath it: existing tracker state may still retain a
+    /// strong owner-local cell clone long enough to emit a matching exit
+    /// callback for an annotation that was already resolved before this
+    /// call. Use [`detach_mouse_region`](Self::detach_mouse_region) instead
+    /// when the region's render object is being permanently removed from
+    /// the tree (unmounted) — there, the softer contract this method keeps
+    /// would let a stationary device's postframe recheck fire a spurious
+    /// exit for a region that no longer exists.
     ///
     /// # Errors
     ///
@@ -162,8 +173,8 @@ impl<'a> RenderObjectContext<'a> {
     /// [`RenderView::did_unmount_render_object`]
     /// rather than [`unregister_mouse_region`](Self::unregister_mouse_region)
     /// — that method's softer contract (a pending exit may still fire
-    /// against a just-unregistered target) is for a still-mounted region
-    /// rebuilt with an empty callback set, and would let a stationary
+    /// against a just-unregistered target) is for a lower-level lane caller,
+    /// not for this widget-lifecycle case, and would let a stationary
     /// device's postframe recheck fire a spurious exit for a region that no
     /// longer exists.
     ///

--- a/crates/flui-view/src/view/render.rs
+++ b/crates/flui-view/src/view/render.rs
@@ -140,7 +140,10 @@ impl<'a> RenderObjectContext<'a> {
     ///
     /// Existing tracker state may still retain a strong owner-local cell long
     /// enough to emit the matching exit callback for a previously active
-    /// annotation.
+    /// annotation. Use
+    /// [`detach_mouse_region`](Self::detach_mouse_region) instead when the
+    /// region's render object is being permanently removed from the tree
+    /// (unmounted) rather than merely rebuilt with an empty callback set.
     ///
     /// # Errors
     ///
@@ -151,6 +154,28 @@ impl<'a> RenderObjectContext<'a> {
         target: flui_interaction::routing::MouseRegionTarget,
     ) -> Result<(), RenderObjectContextError> {
         Ok(self.dispatch_handle()?.unregister_mouse_region(target)?)
+    }
+
+    /// Remove a mouse-region target AND immediately invalidate its
+    /// callbacks, for a region whose render object is being permanently
+    /// detached (unmounted). Call this from
+    /// [`RenderView::did_unmount_render_object`]
+    /// rather than [`unregister_mouse_region`](Self::unregister_mouse_region)
+    /// — that method's softer contract (a pending exit may still fire
+    /// against a just-unregistered target) is for a still-mounted region
+    /// rebuilt with an empty callback set, and would let a stationary
+    /// device's postframe recheck fire a spurious exit for a region that no
+    /// longer exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns the lane's typed dispatch error for wrong/detached owner state
+    /// or for a target already removed from the active owner lane.
+    pub fn detach_mouse_region(
+        &self,
+        target: flui_interaction::routing::MouseRegionTarget,
+    ) -> Result<(), RenderObjectContextError> {
+        Ok(self.dispatch_handle()?.detach_mouse_region(target)?)
     }
 
     /// Register a path clipper in the active owner lane.

--- a/crates/flui-widgets/src/interaction/mouse_region.rs
+++ b/crates/flui-widgets/src/interaction/mouse_region.rs
@@ -185,8 +185,14 @@ impl RenderView for MouseRegion {
         render_object: &mut Self::RenderObject,
     ) {
         if let Some(target) = render_object.mouse_region_target() {
-            if let Err(error) = ctx.unregister_mouse_region(target) {
-                tracing::debug!(?error, "MouseRegion target unregistration failed");
+            // `detach_mouse_region`, not `unregister_mouse_region`: this
+            // render object is being permanently removed from the tree, so
+            // any pending exit a stationary device's postframe recheck might
+            // otherwise resolve against it must not fire. See
+            // `RenderObjectContext::detach_mouse_region`'s doc for why the
+            // two calls differ.
+            if let Err(error) = ctx.detach_mouse_region(target) {
+                tracing::debug!(?error, "MouseRegion target detach failed");
             }
             render_object.set_mouse_region_target(None);
         }

--- a/crates/flui-widgets/src/interaction/mouse_region.rs
+++ b/crates/flui-widgets/src/interaction/mouse_region.rs
@@ -129,18 +129,39 @@ impl MouseRegion {
 
     /// Keep the render object's one mouse-region target in sync with the
     /// complete enter/hover/exit callback set.
+    ///
+    /// A target, once registered, stays registered for as long as the render
+    /// object stays mounted — including across a rebuild that empties the
+    /// callback set down to none. This mirrors Flutter's `RenderMouseRegion`,
+    /// which stays a valid `MouseTrackerAnnotation` with null `onEnter`/
+    /// `onHover`/`onExit` fields for as long as it is attached; there is no
+    /// "unregister while still attached" concept to port
+    /// (`rendering/proxy_box.dart`: `onEnter`/`onHover`/`onExit` are plain
+    /// nullable fields, and `validForMouseTracker` only flips false from
+    /// `detach()`). Dropping the lane registration here instead would make
+    /// `RenderMouseRegion::mouse_tracker_annotation`
+    /// (`crates/flui-objects/src/interaction/mouse_region.rs`) stop
+    /// contributing an annotation to hit-test results the moment callbacks
+    /// are emptied (it requires `Some(target)`), which a stationary
+    /// device's postframe recheck reads as "the region departed" and
+    /// resolves a stale exit against the callback set that was active
+    /// before the rebuild — see
+    /// [`did_unmount_render_object`](Self::did_unmount_render_object) below
+    /// for the call that DOES need to end registration, because there the
+    /// render object is truly leaving the tree.
     fn sync_mouse_region_target(
         &self,
         ctx: &flui_view::RenderObjectContext<'_>,
         render_object: &mut RenderMouseRegion,
     ) {
-        match (self.has_callbacks(), render_object.mouse_region_target()) {
-            (true, Some(target)) => {
+        match render_object.mouse_region_target() {
+            Some(target) => {
                 if let Err(error) = ctx.replace_mouse_region(target, self.mouse_callbacks()) {
                     tracing::warn!(?error, "MouseRegion callback replacement failed");
                 }
             }
-            (true, None) => match ctx.register_mouse_region(self.mouse_callbacks()) {
+            None if self.has_callbacks() => match ctx.register_mouse_region(self.mouse_callbacks())
+            {
                 Ok(target) => render_object.set_mouse_region_target(Some(target)),
                 Err(error) => tracing::debug!(
                     ?error,
@@ -148,13 +169,7 @@ impl MouseRegion {
                      enter/exit events will not be delivered"
                 ),
             },
-            (false, Some(target)) => {
-                if let Err(error) = ctx.unregister_mouse_region(target) {
-                    tracing::debug!(?error, "MouseRegion target unregistration failed");
-                }
-                render_object.set_mouse_region_target(None);
-            }
-            (false, None) => {}
+            None => {}
         }
     }
 }

--- a/crates/flui-widgets/tests/common/mod.rs
+++ b/crates/flui-widgets/tests/common/mod.rs
@@ -217,6 +217,17 @@ impl LaidOut {
         Rc::clone(&self.focus_manager)
     }
 
+    /// This binding's own scheduler, for a probe that must observe frame
+    /// ordering directly (e.g. whether a callback fired from inside
+    /// [`LaidOut::pump_widget`]'s postframe recheck lands in the SAME
+    /// frame's post-frame phase or a later one). `Scheduler` is `Arc`-backed
+    /// and `Clone`, so cloning it merely shares a handle to the same
+    /// binding-local callback queues [`HeadlessBinding::scheduler`] already
+    /// owns.
+    pub fn scheduler(&self) -> flui_scheduler::Scheduler {
+        self.binding.scheduler().clone()
+    }
+
     /// Run an owner-side action under the headless binding's local runtime scope.
     pub fn enter_owner_scope<R>(&self, callback: impl FnOnce() -> R) -> R {
         self.binding.enter_owner_scope(callback)

--- a/crates/flui-widgets/tests/parity/mouse_region_test.rs
+++ b/crates/flui-widgets/tests/parity/mouse_region_test.rs
@@ -22,19 +22,6 @@
 //!   `#[cfg(test)]` unit tests inside `mouse_tracker.rs` itself. A "mouse
 //!   connects/disconnects" event cannot be synthesized through
 //!   [`LaidOut`](crate::common::LaidOut)'s public dispatch surface.
-//! - **No stationary-device postframe recheck reachable from the widget-test
-//!   harness.** `MouseTracker::update_all_devices` — the mechanism that
-//!   re-hit-tests every tracked device after a frame that changed the tree
-//!   shape, with no new pointer motion (Flutter's implicit
-//!   `MouseTracker.schedulePostFrameCheck`) — is called exactly once in the
-//!   whole workspace: `crates/flui-app/src/app/binding.rs:1257`, inside
-//!   `Presentation::render_frame_entered`. `flui-binding`'s
-//!   `HeadlessBinding::pump_frame` (what `LaidOut::pump_widget`/`pump` drive)
-//!   never calls it. A production FLUI app running through `flui-app`'s real
-//!   frame loop reproduces Flutter's "widget moves under a stationary
-//!   pointer ⇒ automatic enter/exit" contract correctly — the mechanism
-//!   exists and is wired at that layer — but this widget-level harness
-//!   cannot observe or prove it.
 //! - **`dispatch_pointer_hover` hardcoded `PointerType::Mouse`.** There was no
 //!   `LaidOut` method for a non-mouse hover device, so this file's harness
 //!   change adds `LaidOut::dispatch_pointer_hover_with_kind` (device-kind
@@ -90,7 +77,75 @@
 //! the self-contained, directly testable form of the same resolve-and-invoke
 //! step.
 //!
-//! ### Ported (16 of 43)
+//! ### Stationary-device postframe recheck, now wired into the headless
+//! frame path
+//!
+//! `MouseTracker::update_all_devices` — the mechanism that re-hit-tests
+//! every tracked device after a frame that changed the tree shape, with no
+//! new pointer motion (Flutter's implicit `MouseTracker.updateAllDevices`
+//! postframe recheck, `rendering/mouse_tracker.dart:366`) — used to be
+//! called exactly once in the whole workspace:
+//! `crates/flui-app/src/app/binding.rs`, inside the production frame path.
+//! `flui-binding`'s `HeadlessBinding::pump_frame` (what
+//! `LaidOut::pump_widget`/`pump`/`tick` drive) never called it, so this
+//! widget-test harness could not observe or prove Flutter's "widget moves
+//! under a stationary pointer ⇒ automatic enter/exit" contract even though
+//! production reproduced it correctly. `pump_frame` now runs the same
+//! recheck, every frame, unconditionally, for a tree-bound binding —
+//! against its own `PipelineOwner` directly (the tree-bound branch already
+//! owns the same `Arc<RwLock<PipelineOwner>>` production's
+//! `hit_test_in_view` wraps, so no caller-supplied hit-test closure needed
+//! adding to `pump_frame`'s signature). See the doc on
+//! [`HeadlessBinding::pump_frame`](flui_binding::HeadlessBinding::pump_frame)
+//! for the full ordering.
+//!
+//! Wiring the recheck surfaced a real, pre-existing bug, independent of this
+//! file's own scope but directly exposed by exercising the recheck for the
+//! first time: [`removing_a_hovered_region_does_not_synthesize_an_exit`]
+//! (already ported, previously passing only because nothing rechecked a
+//! stationary device) started failing — a removed, still-hovered region's
+//! stale `on_exit` fired spuriously. The root cause was two independent
+//! copies of the same ordering bug, in `ElementTree::remove_subtree`
+//! (`crates/flui-view/src/tree/element_tree.rs`) and `id_reconcile::remove_child`
+//! (`crates/flui-view/src/tree/id_reconcile.rs`, the path an ordinary
+//! `pump_widget` root-swap actually takes): both unmounted the root of a
+//! removed subtree *before* its descendants, and the root's own
+//! render-object removal cascades (`PipelineOwner::remove_render_object`
+//! recurses over descendants), deleting every descendant's render object
+//! before that descendant's own `unmount` — and therefore its
+//! `RenderView::did_unmount_render_object` hook, which is how
+//! `MouseRegion`/`ClipPath`/`Listener` unregister from the owner-local
+//! interaction lane — ever ran. The hook was silently skipped for any
+//! interaction-lane-registering widget nested under a removed ancestor, not
+//! just `MouseRegion`: a permanent registration leak, not merely a
+//! mouse-tracker quirk. Both functions now unmount descendants deepest-first
+//! *before* the (unkeyed) root, mirroring Flutter's own bottom-up
+//! `RenderObject.detach()` walk; a keyed root's existing soft-remove
+//! (parked for `finalize_tree`, descendants untouched) is unchanged.
+//!
+//! A second, narrower fix was needed on top of the reorder:
+//! `MouseTracker` caches a strong `Rc` clone of a mouse-region target's
+//! callback cell (its `annotations` map, keyed by region id) across frames,
+//! so it can resolve an exit callback for a region no longer present in a
+//! fresh hit test. A pre-existing unit test,
+//! `enter_exit_callbacks_are_owner_local_and_exit_uses_previous_annotation`
+//! (`crates/flui-interaction/src/routing/mouse_tracker.rs`), deliberately
+//! asserts that this cached clone must still be able to fire a pending exit
+//! *after* `unregister_mouse_region` — the contract a still-mounted region
+//! rebuilt with an emptied callback set relies on. Reusing that same call
+//! for a genuinely unmounted region would therefore have kept firing the
+//! stale exit even with the reorder fix in place (confirmed empirically:
+//! reverting just this second fix reintroduced the failure). The two cases
+//! needed to diverge, so `InteractionDispatchHandle`/`RenderObjectContext`
+//! gained a second, narrower call —
+//! `detach_mouse_region` — that also invalidates the shared cell's callbacks
+//! in place; `RenderView::did_unmount_render_object` for `MouseRegion` now
+//! calls it instead of the softer `unregister_mouse_region`. This is FLUI's
+//! structural equivalent of Flutter's `validForMouseTracker` flag
+//! (`rendering/proxy_box.dart` `RenderMouseRegion.detach`), which exists for
+//! exactly this reason.
+//!
+//! ### Ported (19 of 43)
 //! - `'hitTestBehavior test - HitTestBehavior.deferToChild/opaque'` —
 //!   [`hit_test_behavior_defer_to_child_then_opaque_toggles_enter`].
 //! - `'hitTestBehavior test - HitTestBehavior.deferToChild and non-opaque'` —
@@ -154,9 +209,20 @@
 //!   `LaidOut::dispatch_pointer_hover_with_kind(.., PointerType::Touch)`) —
 //!   the divergence fix above made this portable; see the section on it —
 //!   [`detects_hover_from_touch_devices`].
+//! - `'triggers pointer enter when widget appears'` — now reachable via the
+//!   postframe-recheck wiring above —
+//!   [`stationary_pointer_over_a_newly_appeared_region_triggers_enter_next_frame`].
+//! - `'triggers pointer enter when widget moves in'` —
+//!   [`stationary_pointer_over_a_region_that_moves_in_triggers_enter_next_frame`].
+//! - `'triggers pointer exit when widget moves out'` (its initial "enter"
+//!   leg, which upstream reaches by connecting a fresh mouse device, is
+//!   replaced by an ordinary dispatched hover — no device connect/disconnect
+//!   primitive exists in this harness, per the capability note above; the
+//!   "moves out while stationary" leg under test is unaffected) —
+//!   [`stationary_pointer_over_a_region_that_moves_out_triggers_exit_next_frame`].
 //!
-//! ### Not ported (27 of 43) {#not-ported}
-//! Grouped by shared reason so the arithmetic stays checkable (16 + 27 = 43)
+//! ### Not ported (24 of 43) {#not-ported}
+//! Grouped by shared reason so the arithmetic stays checkable (19 + 24 = 43)
 //! without repeating each explanation 43 times:
 //!
 //! **No device connect/disconnect primitive** (3): `'triggers pointer enter
@@ -164,18 +230,9 @@
 //! disconnected'`, `'Exit event when unplugging mouse should have a
 //! position'`.
 //!
-//! **No stationary-device postframe recheck reachable from this harness**
-//! (5): `'triggers pointer enter when widget appears'`, `'triggers pointer
-//! enter when widget moves in'`, `'triggers pointer exit when widget moves
-//! out'` (its initial "enter" leg is also an implicit-connect, the first
-//! reason above), `'A MouseRegion mounted under the pointer should take
-//! effect in the next postframe'`, `'A MouseRegion moved into the mouse
-//! should take effect in the next postframe'`.
-//!
-//! **`hasScheduledFrame` has no harness equivalent** (2, one overlapping the
-//! postframe-recheck group above): `'A MouseRegion unmounted under the
-//! pointer should not trigger state change'`, `'No new frames are scheduled
-//! when mouse moves without triggering callbacks'`.
+//! **`hasScheduledFrame` has no harness equivalent** (2): `'A MouseRegion
+//! unmounted under the pointer should not trigger state change'`, `'No new
+//! frames are scheduled when mouse moves without triggering callbacks'`.
 //!
 //! **No cursor introspection surfaced by `LaidOut`** (1) —
 //! `MouseTracker::device_cursor` exists (`mouse_tracker.rs:450`) but nothing
@@ -203,16 +260,34 @@
 //! debugFillProperties when default"`, `"RenderMouseRegion's
 //! debugFillProperties when full"`.
 //!
-//! **`StatefulView`-rebuild-handle-in-callback plumbing, deferred** (2) —
+//! **`StatefulView`-rebuild-handle-in-callback plumbing, deferred** (4) —
 //! same real-but-disproportionate cost as the one case adapted around above
 //! ([`rebuilding_an_active_region_does_not_refire_enter_or_exit`]), but these
-//! two don't clear the "worth the substitution" bar the way that one does:
+//! four don't clear the "worth the substitution" bar the way that one does:
 //! `'MouseRegion activate/deactivate don't duplicate annotations'` (also
 //! needs `GlobalKey`-based deactivate/reactivate), `'detects pointer enter
 //! with closure arguments'` (tests no `MouseRegion` contract beyond
 //! [`detects_pointer_enter`]/[`detects_pointer_exiting`]/
 //! [`removing_a_hovered_region_does_not_synthesize_an_exit`] once the
-//! `StatefulWidget` indirection is stripped away).
+//! `StatefulWidget` indirection is stripped away), and two cases the
+//! postframe-recheck wiring above made only *partially* reachable —
+//! `'A MouseRegion mounted under the pointer should take effect in the next
+//! postframe'` and `'A MouseRegion moved into the mouse should take effect
+//! in the next postframe'`. Upstream drives both through `HoverClient`, a
+//! `StatefulWidget` whose `onHover` callback calls `setState`, so the
+//! specific thing under test — that the state change (and its dependent
+//! text) lands on the *next* frame, not the one that mounted/moved the
+//! region, with no further frame scheduled — needs a real rebuild triggered
+//! *from inside* the enter callback. A bare `Cell`/`RefCell` counter (as
+//! [`stationary_pointer_over_a_newly_appeared_region_triggers_enter_next_frame`]
+//! and
+//! [`stationary_pointer_over_a_region_that_moves_in_triggers_enter_next_frame`]
+//! use) only proves the callback fired on the right frame, which those two
+//! cases already cover; it cannot prove the callback-driven second rebuild
+//! landed on ITS OWN next frame rather than immediately, since a headless
+//! `pump_widget` call would drive both in the same call regardless. Also
+//! still blocked on `hasScheduledFrame`, above, which both cases assert on
+//! directly.
 //!
 //! **`GlobalKey` reparent does not preserve render-object identity in
 //! FLUI** (1) — `'Does not trigger side effects during a reparent'` depends
@@ -249,11 +324,11 @@
 //! disproportionate additional scope for this pass.
 //!
 //! Count check, one primary reason per case, no case counted twice: 3
-//! (connect/disconnect) + 5 (postframe recheck) + 2 (`hasScheduledFrame`) + 1
-//! (cursor introspection) + 2 (compositing) + 6 (paint-count) + 2
-//! (`debugFillProperties`) + 2 (`StatefulView` plumbing) + 1 (`GlobalKey`
-//! reparent) + 1 (`Draggable` regression) + 2 (opacity transition matrix) =
-//! 27 not ported. 16 ported + 27 not ported = 43.
+//! (connect/disconnect) + 2 (`hasScheduledFrame`) + 1 (cursor introspection) +
+//! 2 (compositing) + 6 (paint-count) + 2 (`debugFillProperties`) + 4
+//! (`StatefulView` plumbing) + 1 (`GlobalKey` reparent) + 1 (`Draggable`
+//! regression) + 2 (opacity transition matrix) =
+//! 24 not ported. 19 ported + 24 not ported = 43.
 //!
 //! Widget → render-object mapping:
 //! - `MouseRegion` → `RenderMouseRegion`
@@ -927,6 +1002,145 @@ fn a_childless_opaque_mouse_region_still_blocks_everything_beneath_it() {
         !bottom_region_hovered.get(),
         "the empty opaque region on top must swallow the pointer everywhere in the \
          stack, including inside the bottom region's own bounds"
+    );
+}
+
+// ── Stationary-device postframe recheck ─────────────────────────────────────
+
+/// A region that appears where a stationary pointer already sits is entered
+/// on the very next frame, with no new pointer dispatch — Flutter's implicit
+/// `MouseTracker.updateAllDevices` postframe recheck
+/// (`rendering/mouse_tracker.dart:366`), wired into
+/// [`HeadlessBinding::pump_frame`] (`crates/flui-binding/src/lib.rs`) to
+/// match the production frame path
+/// (`crates/flui-app/src/app/binding.rs`). Enter only, never hover: Flutter's
+/// own `_handleDeviceUpdateMouseEvents` (`mouse_tracker.dart:399-430`), the
+/// handler this recheck drives, synthesizes only enter/exit events — never a
+/// hover — and the upstream oracle test itself asserts `move` (hover) stays
+/// null; `MouseRegion.on_hover` fires only from an actual pointer motion.
+///
+/// Flutter parity: `'triggers pointer enter when widget appears'`.
+#[test]
+fn stationary_pointer_over_a_newly_appeared_region_triggers_enter_next_frame() {
+    let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+    let (on_enter, on_hover, on_exit) = (Rc::clone(&log), Rc::clone(&log), Rc::clone(&log));
+
+    let mut laid = harness::pump_widget(
+        Align::new(Alignment::CENTER).child(SizedBox::new(100.0, 100.0)),
+        harness::screen_of(300.0, 300.0),
+    );
+
+    // Register the stationary device at the region's future center -- no
+    // region is mounted yet, so nothing fires.
+    laid.dispatch_pointer_hover(150.0, 150.0);
+    assert!(
+        log.borrow().is_empty(),
+        "no region is mounted yet, so the hover must find nothing"
+    );
+
+    laid.pump_widget(
+        Align::new(Alignment::CENTER).child(
+            MouseRegion::new()
+                .on_enter(move |_d, _p| on_enter.borrow_mut().push("enter"))
+                .on_hover(move |_d, _p| on_hover.borrow_mut().push("hover"))
+                .on_exit(move |_d, _p| on_exit.borrow_mut().push("exit"))
+                .child(SizedBox::new(100.0, 100.0)),
+        ),
+    );
+
+    assert_eq!(
+        log.borrow().as_slice(),
+        &["enter"],
+        "a region mounted under a stationary pointer must be entered on the \
+         very next frame, with no new pointer dispatch -- the frame that \
+         mounts it must itself re-hit-test every stationary device; the \
+         postframe recheck synthesizes enter/exit only, never hover"
+    );
+}
+
+/// A region that moves under a stationary pointer (its bounds change via a
+/// rebuild, not a new pointer event) is entered on the very next frame.
+///
+/// Flutter parity: `'triggers pointer enter when widget moves in'`.
+#[test]
+fn stationary_pointer_over_a_region_that_moves_in_triggers_enter_next_frame() {
+    let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+
+    fn region(log: &Rc<RefCell<Vec<&'static str>>>) -> MouseRegion {
+        let (e, h, x) = (Rc::clone(log), Rc::clone(log), Rc::clone(log));
+        MouseRegion::new()
+            .on_enter(move |_d, _p| e.borrow_mut().push("enter"))
+            .on_hover(move |_d, _p| h.borrow_mut().push("hover"))
+            .on_exit(move |_d, _p| x.borrow_mut().push("exit"))
+            .child(SizedBox::new(100.0, 100.0))
+    }
+
+    // Region spans (0,0)-(100,100) at top-left of a 300x300 screen.
+    let mut laid = harness::pump_widget(
+        Align::new(Alignment::TOP_LEFT).child(region(&log)),
+        harness::screen_of(300.0, 300.0),
+    );
+
+    // The screen's center, where the region will move to below -- outside
+    // the top-left region today, so nothing fires yet.
+    laid.dispatch_pointer_hover(150.0, 150.0);
+    assert!(
+        log.borrow().is_empty(),
+        "the stationary point starts outside the top-left region"
+    );
+
+    // Same region, moved to center via a rebuild -- no new pointer dispatch.
+    laid.pump_widget(Align::new(Alignment::CENTER).child(region(&log)));
+
+    assert_eq!(
+        log.borrow().as_slice(),
+        &["enter"],
+        "a region that moves under a stationary pointer must be entered on \
+         the very next frame, enter/exit only, never hover"
+    );
+}
+
+/// A region that moves out from under a stationary pointer (its bounds
+/// change via a rebuild, not a new pointer event) is exited on the very next
+/// frame.
+///
+/// Flutter parity: `'triggers pointer exit when widget moves out'`.
+#[test]
+fn stationary_pointer_over_a_region_that_moves_out_triggers_exit_next_frame() {
+    let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+
+    fn region(log: &Rc<RefCell<Vec<&'static str>>>) -> MouseRegion {
+        let (e, h, x) = (Rc::clone(log), Rc::clone(log), Rc::clone(log));
+        MouseRegion::new()
+            .on_enter(move |_d, _p| e.borrow_mut().push("enter"))
+            .on_hover(move |_d, _p| h.borrow_mut().push("hover"))
+            .on_exit(move |_d, _p| x.borrow_mut().push("exit"))
+            .child(SizedBox::new(100.0, 100.0))
+    }
+
+    // Region spans (100,100)-(200,200), centered in a 300x300 screen.
+    let mut laid = harness::pump_widget(
+        Align::new(Alignment::CENTER).child(region(&log)),
+        harness::screen_of(300.0, 300.0),
+    );
+
+    laid.dispatch_pointer_hover(150.0, 150.0);
+    assert_eq!(
+        log.borrow().as_slice(),
+        &["enter", "hover"],
+        "an ordinary dispatched hover still fires enter then hover"
+    );
+    log.borrow_mut().clear();
+
+    // Same region, moved to top-left via a rebuild -- no new pointer
+    // dispatch. The stationary pointer at (150,150) is now outside it.
+    laid.pump_widget(Align::new(Alignment::TOP_LEFT).child(region(&log)));
+
+    assert_eq!(
+        log.borrow().as_slice(),
+        &["exit"],
+        "a region that moves out from under a stationary pointer must be \
+         exited on the very next frame, with no new pointer dispatch"
     );
 }
 

--- a/crates/flui-widgets/tests/parity/mouse_region_test.rs
+++ b/crates/flui-widgets/tests/parity/mouse_region_test.rs
@@ -123,27 +123,46 @@
 //! `RenderObject.detach()` walk; a keyed root's existing soft-remove
 //! (parked for `finalize_tree`, descendants untouched) is unchanged.
 //!
-//! A second, narrower fix was needed on top of the reorder:
-//! `MouseTracker` caches a strong `Rc` clone of a mouse-region target's
-//! callback cell (its `annotations` map, keyed by region id) across frames,
-//! so it can resolve an exit callback for a region no longer present in a
-//! fresh hit test. A pre-existing unit test,
-//! `enter_exit_callbacks_are_owner_local_and_exit_uses_previous_annotation`
-//! (`crates/flui-interaction/src/routing/mouse_tracker.rs`), deliberately
-//! asserts that this cached clone must still be able to fire a pending exit
-//! *after* `unregister_mouse_region` — the contract a still-mounted region
-//! rebuilt with an emptied callback set relies on. Reusing that same call
-//! for a genuinely unmounted region would therefore have kept firing the
-//! stale exit even with the reorder fix in place (confirmed empirically:
-//! reverting just this second fix reintroduced the failure). The two cases
-//! needed to diverge, so `InteractionDispatchHandle`/`RenderObjectContext`
-//! gained a second, narrower call —
-//! `detach_mouse_region` — that also invalidates the shared cell's callbacks
-//! in place; `RenderView::did_unmount_render_object` for `MouseRegion` now
-//! calls it instead of the softer `unregister_mouse_region`. This is FLUI's
-//! structural equivalent of Flutter's `validForMouseTracker` flag
-//! (`rendering/proxy_box.dart` `RenderMouseRegion.detach`), which exists for
-//! exactly this reason.
+//! A second, narrower fix was needed on top of the reorder: `MouseTracker`
+//! caches a strong `Rc` clone of a mouse-region target's callback cell (its
+//! `annotations` map, keyed by region id) across frames, so it can resolve
+//! an exit callback for a region no longer present in a fresh hit test. A
+//! permanently unmounted region's render object is gone from the tree for
+//! good, so that cached clone must never fire again once unmount runs —
+//! `InteractionDispatchHandle`/`RenderObjectContext` gained a narrower call,
+//! `detach_mouse_region`, that invalidates the shared cell's callbacks in
+//! place (not just drops the lane's own map entry, which the general-purpose
+//! `unregister_mouse_region` does); `RenderView::did_unmount_render_object`
+//! for `MouseRegion` calls it. This is FLUI's structural equivalent of
+//! Flutter's `validForMouseTracker` flag (`rendering/proxy_box.dart`
+//! `RenderMouseRegion.detach`), which exists for exactly this reason.
+//!
+//! A THIRD bug surfaced once the recheck ran against a still-mounted
+//! region, found by measuring the pointer state across an empty-callback
+//! rebuild rather than assuming the unmount-order fix above was the whole
+//! story: `MouseRegion::sync_mouse_region_target`'s original zero-callbacks
+//! branch called the general-purpose `unregister_mouse_region` — which
+//! drops the lane's own map entry but leaves the shared cell's contents
+//! untouched — and cleared the render object's own `mouse_region_target`.
+//! With no target, `RenderMouseRegion::mouse_tracker_annotation`
+//! (`crates/flui-objects/src/interaction/mouse_region.rs`) stops
+//! contributing an annotation at all, so the very next postframe recheck's
+//! hit test simply does not find the region — indistinguishable, from the
+//! tracker's point of view, from the region having moved away or been
+//! removed. The tracker resolved its still callback-intact cached cell and
+//! fired a stale `on_exit`, even though the region was never removed from
+//! the tree and the pointer never moved. Flutter has no such failure mode:
+//! `RenderMouseRegion.onEnter`/`onHover`/`onExit` are plain nullable fields
+//! on a render object that stays a valid `MouseTrackerAnnotation` for as
+//! long as it is attached (`rendering/proxy_box.dart`) — there is no
+//! "unregister while still attached" step to get wrong. The fix ports that
+//! shape: a still-mounted region now keeps its lane target for its whole
+//! mounted lifetime and replaces its callbacks with the empty set instead
+//! of dropping the registration — see
+//! [`rebuilding_a_hovered_region_down_to_no_callbacks_fires_nothing`],
+//! which pins the corrected behavior (confirmed empirically: reverting only
+//! the widget-level fix, with the recheck and the unmount-order fix both
+//! still in place, reintroduces the stale exit).
 //!
 //! ### Ported (19 of 43)
 //! - `'hitTestBehavior test - HitTestBehavior.deferToChild/opaque'` —
@@ -1141,6 +1160,134 @@ fn stationary_pointer_over_a_region_that_moves_out_triggers_exit_next_frame() {
         &["exit"],
         "a region that moves out from under a stationary pointer must be \
          exited on the very next frame, with no new pointer dispatch"
+    );
+}
+
+/// A still-mounted, still-hit-testable region rebuilt with an empty callback
+/// set must not synthesize a stale exit against the callback set that was
+/// active before the rebuild.
+///
+/// Pins a regression the postframe-recheck wiring above introduced and that
+/// the model, not just the recheck, had to correct: the first version of
+/// `MouseRegion::sync_mouse_region_target` unregistered the lane target the
+/// moment its callback set went empty, which made
+/// `RenderMouseRegion::mouse_tracker_annotation`
+/// (`crates/flui-objects/src/interaction/mouse_region.rs`) stop contributing
+/// an annotation to the very next hit test — the recheck then read that as
+/// "the region departed" and fired the OLD `on_exit`, even though the
+/// region was never removed from the tree and the pointer never moved.
+/// Flutter has no such failure mode: `RenderMouseRegion.onEnter`/`onHover`/
+/// `onExit` are plain nullable fields on a render object that stays a valid
+/// `MouseTrackerAnnotation` for as long as it is attached
+/// (`rendering/proxy_box.dart`) — nulling a field never deregisters
+/// anything. `sync_mouse_region_target` now keeps the lane target
+/// registered across the rebuild and replaces its callbacks with the empty
+/// set instead, matching that.
+///
+/// No Flutter parity id: no `mouse_region_test.dart` case rebuilds a hovered
+/// region down to zero callbacks under a stationary pointer.
+#[test]
+fn rebuilding_a_hovered_region_down_to_no_callbacks_fires_nothing() {
+    let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+    let (on_enter, on_exit) = (Rc::clone(&log), Rc::clone(&log));
+
+    let mut laid = harness::pump_widget(
+        Align::new(Alignment::CENTER).child(
+            MouseRegion::new()
+                .on_enter(move |_d, _p| on_enter.borrow_mut().push("enter"))
+                .on_exit(move |_d, _p| on_exit.borrow_mut().push("exit"))
+                .child(SizedBox::new(100.0, 100.0)),
+        ),
+        harness::screen_of(300.0, 300.0),
+    );
+
+    laid.dispatch_pointer_hover(150.0, 150.0);
+    assert_eq!(
+        log.borrow().as_slice(),
+        &["enter"],
+        "an ordinary dispatched hover over the mounted region fires enter"
+    );
+    log.borrow_mut().clear();
+
+    // Same region, same position, rebuilt with every callback removed --
+    // still mounted, still hit-testable, at the SAME stationary pointer
+    // position. No new pointer dispatch.
+    laid.pump_widget(
+        Align::new(Alignment::CENTER).child(MouseRegion::new().child(SizedBox::new(100.0, 100.0))),
+    );
+
+    assert_eq!(
+        log.borrow().len(),
+        0,
+        "a still-mounted, still-hit-testable region rebuilt down to no \
+         callbacks must not fire a stale exit against the callback set that \
+         was active before the rebuild; got {:?}",
+        log.borrow()
+    );
+}
+
+/// The postframe recheck runs INSIDE [`HeadlessBinding::pump_frame`]'s own
+/// `Scheduler::drive_frame` pipeline closure, in the same
+/// `PersistentCallbacks` slot as layout/paint — not after `drive_frame`
+/// returns. A post-frame callback an enter/exit callback queues must
+/// therefore land in the SAME frame's post-frame phase, matching production
+/// (`AppBinding::render_frame_entered`, `crates/flui-app/src/app/
+/// binding.rs`, which calls `MouseTracker::update_all_devices` from inside
+/// the same `drive_frame` closure it runs its own layout/paint step in —
+/// see `crates/flui-app/src/app/runner.rs`) and the oracle
+/// (`_scheduleMouseTrackerUpdate` posts `updateAllDevices` from
+/// `_handlePersistentFrameCallback`, still inside the persistent phase,
+/// ahead of the post-frame queue). Running the recheck after `drive_frame`
+/// returns instead — as an earlier version of
+/// [`HeadlessBinding::pump_frame`] did — would defer that queued callback
+/// to a LATER pump.
+///
+/// Goes around [`flui_scheduler::Scheduler::add_post_frame_callback`]
+/// directly rather than through a `StatefulView` rebuild handle: driving
+/// this same ordering question end-to-end through a real widget rebuild is
+/// exactly the "next postframe" cases' missing
+/// `StatefulView`-rebuild-handle-in-callback plumbing (see the not-ported
+/// section below) — disproportionate cost for this one placement check,
+/// which the lower-level scheduler call proves directly.
+#[test]
+fn stationary_enter_queues_a_post_frame_callback_for_the_same_frame() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    let mut laid = harness::pump_widget(
+        Align::new(Alignment::CENTER).child(SizedBox::new(100.0, 100.0)),
+        harness::screen_of(300.0, 300.0),
+    );
+    laid.dispatch_pointer_hover(150.0, 150.0);
+
+    let scheduler = laid.scheduler();
+    let post_frame_fires: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
+    let post_frame_fires_for_enter = Arc::clone(&post_frame_fires);
+
+    // Region mounted under the stationary pointer above -- entered by the
+    // postframe recheck, not by a new pointer dispatch. Its `on_enter`
+    // queues a post-frame callback the same way a widget's rebuild handle
+    // would from inside a real `setState`.
+    laid.pump_widget(
+        Align::new(Alignment::CENTER).child(
+            MouseRegion::new()
+                .on_enter(move |_d, _p| {
+                    let post_frame_fires = Arc::clone(&post_frame_fires_for_enter);
+                    scheduler.add_post_frame_callback(Box::new(move |_timing| {
+                        post_frame_fires.fetch_add(1, Ordering::SeqCst);
+                    }));
+                })
+                .child(SizedBox::new(100.0, 100.0)),
+        ),
+    );
+
+    assert_eq!(
+        post_frame_fires.load(Ordering::SeqCst),
+        1,
+        "a post-frame callback queued from the postframe recheck's enter \
+         callback must fire exactly once, in the SAME pump_widget call that \
+         mounted the region -- not zero times (deferred to a later pump) \
+         and not more than once"
     );
 }
 


### PR DESCRIPTION
Two defects, found together because the second **hid** the first.

## 1. Unmount order (core tree)

`ElementTree::remove_subtree` and `id_reconcile::remove_child` unmounted a removed subtree's **root before its descendants**. Removing the root's render object cascades, so by the time a descendant's `unmount` ran its render object was already gone and `RenderView::did_unmount_render_object` was silently skipped — the hook `MouseRegion`, `ClipPath` and `Listener` use to unregister from the interaction lane. The registration was orphaned **permanently**, not just for one stray event.

Flutter unmounts depth-first, children before self — `_InactiveElements._unmount` recurses through `visitChildren` and only then calls `element.unmount()` (`widgets/framework.dart`, verified at tag `3.44.0`). Both functions now match. Keyed-root soft-remove semantics unchanged.

Blast radius is every subtree removal in the framework, so: full workspace **8153/8153**, doctests 630, and the fix independently mutation-verified — reverting only these two files makes `removing_a_hovered_region_does_not_synthesize_an_exit` fail.

## 2. Stationary-device recheck (test-harness fidelity)

Production re-hit-tests every stationary pointing device after layout each frame, matching the oracle (`_handlePersistentFrameCallback` runs `drawFrame()` then schedules a post-frame `MouseTracker.updateAllDevices()`). `HeadlessBinding::pump_frame` never did.

So no widget test could observe enter/exit caused by the tree changing under a motionless pointer — **which is exactly how the unmount bug above survived**. The gap was not just missing coverage; it was a blind spot that made a real defect untestable.

The recheck now runs every frame, unconditionally, hit-testing through the pipeline owner `pump_frame` already holds rather than threading a closure through its signature and all four call sites.

A second, narrower fix was needed once it ran: `MouseTracker` caches a strong clone of a region's callback cell across frames, and an existing test deliberately requires that a *rebuild-emptied* unregister still lets a pending exit fire. Unmount therefore calls a distinct `detach_mouse_region` that also invalidates the cell — FLUI's equivalent of Flutter's `validForMouseTracker`.

## A corrected expectation, not corrected code

The recheck synthesizes enter/exit only, **never hover**: Flutter's `_handleDeviceUpdateMouseEvents` has no hover branch and the upstream case asserts the move stays null. A first draft of the new test expected hover and was simply wrong — the expectation was fixed, not the implementation.

## Parity

Ports `'triggers pointer enter when widget appears'`, `'… moves in'`, `'… moves out'` — denominator **19 + 24 = 43**.

The two `'… take effect in the next postframe'` cases stay unported: the postframe mechanism is now reachable, but they additionally need rebuild-handle-in-callback plumbing and `hasScheduledFrame`, neither of which exists here. Their reason is **updated** rather than left stale.

## Gates

parity **467** · workspace **8153** · doctests 630 · clippy · fmt · inventory-check · port-check · doc-strict — all clean. The one wall-clock scroll flake that appeared mid-run was re-run 10× in isolation with 0 failures and the full workspace re-run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117t1jX2FFcCzP3YBLoQB94
