### PR TITLE
fix(interaction,widgets): timestamp drag velocity samples off the arena clock

### DIFF
--- a/crates/flui-cupertino/tests/common/mod.rs
+++ b/crates/flui-cupertino/tests/common/mod.rs
@@ -33,6 +33,16 @@ pub struct LaidOut {
     root_element_id: ElementId,
 }
 
+/// Spacing between the synthetic pointer samples that record a velocity
+/// sample — i.e. contact Moves, and only those.
+///
+/// 8ms is a ~120Hz pointer-report interval: faster than a 60Hz display, as a
+/// high-report-rate pointer genuinely is, and comfortably inside the velocity
+/// tracker's 100ms fit horizon so a short synthetic drag yields several usable
+/// samples. Matches `flui-widgets`' harness so a gesture behaves identically
+/// whichever crate's tests drive it.
+const POINTER_SAMPLE_INTERVAL: Duration = Duration::from_millis(8);
+
 /// Loose constraints from `0` up to `max × max` on both axes.
 pub fn loose(max: f32) -> BoxConstraints {
     BoxConstraints::loose(Size::new(px(max), px(max)))
@@ -232,8 +242,19 @@ impl LaidOut {
         self.route_event(&event);
     }
 
-    /// A pointer-move to `(x, y)` — drives hover enter/exit.
+    /// A pointer-move to `(x, y)` — drives hover enter/exit and drag.
+    ///
+    /// Advances the binding's virtual clock by [`POINTER_SAMPLE_INTERVAL`]
+    /// first. `DragGestureRecognizer` timestamps its velocity samples from
+    /// `RecognizerBase::now()`, which reads the clock bound to the very
+    /// `GestureArena` this harness hands the tree (`binding.arena()` — see
+    /// `lay_out`); without this, consecutive moves would all land on the same
+    /// instant, the velocity tracker's zero-span guard would report zero
+    /// velocity, and any drag-release this harness drives would silently take
+    /// the position-snap branch instead of the fling branch it was written to
+    /// exercise.
     pub fn dispatch_pointer_move(&self, x: f32, y: f32) {
+        self.binding.clock().advance(POINTER_SAMPLE_INTERVAL);
         let position = Offset::new(px(x), px(y));
         let event = make_move_event(position, PointerType::Mouse);
         self.route_event(&event);

--- a/crates/flui-interaction/src/recognizers/drag.rs
+++ b/crates/flui-interaction/src/recognizers/drag.rs
@@ -359,17 +359,22 @@ impl DragGestureRecognizer {
 
     /// Handle pointer down - start tracking
     fn handle_down(&self, position: Offset<Pixels>, kind: PointerType) {
+        // Read the arena's clock, not the OS clock directly: production binds
+        // it to `SystemClock` (so this is `Instant::now()` either way), but a
+        // headless frame driver binds it to a `ManualClock` it advances
+        // explicitly — the same mechanism `LongPressGestureRecognizer` and
+        // `DoubleTapGestureRecognizer` already use — so a test controls
+        // velocity-sample spacing instead of inheriting the wall clock.
+        let now = self.state.now();
         let mut state = self.drag_state.lock();
         state.state = DragPhase::Possible;
-        state.start_time = Some(Instant::now());
+        state.start_time = Some(now);
         state.start_position = None;
         state.last_position = Some(position);
-        state.last_time = Some(Instant::now());
+        state.last_time = Some(now);
         state.device_kind = Some(kind);
         state.velocity_tracker.reset();
-        state
-            .velocity_tracker
-            .add_position(Instant::now(), position);
+        state.velocity_tracker.add_position(now, position);
         drop(state); // Release lock before callback
 
         // Call on_down callback (pointer contact before drag starts)
@@ -393,7 +398,7 @@ impl DragGestureRecognizer {
                     return;
                 };
                 let distance = self.calculate_primary_delta(position - initial_pos);
-                let now = Instant::now();
+                let now = self.state.now();
                 state.last_position = Some(position);
                 state.last_time = Some(now);
                 state.device_kind = Some(kind);
@@ -411,12 +416,11 @@ impl DragGestureRecognizer {
             DragPhase::Started => {
                 // Update drag
                 if let Some(last_pos) = state.last_position {
+                    let now = self.state.now();
                     let delta = self.project_delta(position - last_pos);
                     state.last_position = Some(position);
-                    state.last_time = Some(Instant::now());
-                    state
-                        .velocity_tracker
-                        .add_position(Instant::now(), position);
+                    state.last_time = Some(now);
+                    state.velocity_tracker.add_position(now, position);
 
                     // Per-event, matching `delta` above — not accumulated
                     // across the whole drag. Flutter's `primaryDelta` reports
@@ -463,7 +467,7 @@ impl DragGestureRecognizer {
                 DragStartBehavior::Down => initial,
                 DragStartBehavior::Start => accepted_position,
             };
-            let timestamp = state.last_time.unwrap_or_else(Instant::now);
+            let timestamp = state.last_time.unwrap_or_else(|| self.state.now());
             let kind = state.device_kind.unwrap_or(PointerType::Touch);
             state.state = DragPhase::Started;
             state.start_position = Some(start_position);

--- a/crates/flui-material/tests/common/mod.rs
+++ b/crates/flui-material/tests/common/mod.rs
@@ -36,6 +36,16 @@ pub struct LaidOut {
     root_element_id: ElementId,
 }
 
+/// Spacing between the synthetic pointer samples that record a velocity
+/// sample — i.e. contact Moves, and only those.
+///
+/// 8ms is a ~120Hz pointer-report interval: faster than a 60Hz display, as a
+/// high-report-rate pointer genuinely is, and comfortably inside the velocity
+/// tracker's 100ms fit horizon so a short synthetic drag yields several usable
+/// samples. Matches `flui-widgets`' harness so a gesture behaves identically
+/// whichever crate's tests drive it.
+const POINTER_SAMPLE_INTERVAL: Duration = Duration::from_millis(8);
+
 /// Loose constraints from `0` up to `max × max` on both axes.
 pub fn loose(max: f32) -> BoxConstraints {
     BoxConstraints::loose(Size::new(px(max), px(max)))
@@ -246,8 +256,19 @@ impl LaidOut {
             .dispatch_pointer(&event, |position| self.hit_test(position));
     }
 
-    /// A pointer-move to `(x, y)` — drives hover enter/exit.
+    /// A pointer-move to `(x, y)` — drives hover enter/exit and drag.
+    ///
+    /// Advances the binding's virtual clock by [`POINTER_SAMPLE_INTERVAL`]
+    /// first. `DragGestureRecognizer` timestamps its velocity samples from
+    /// `RecognizerBase::now()`, which reads the clock bound to the very
+    /// `GestureArena` this harness hands the tree (`binding.arena()` — see
+    /// `lay_out`); without this, consecutive moves would all land on the same
+    /// instant, the velocity tracker's zero-span guard would report zero
+    /// velocity, and any drag-release this harness drives would silently take
+    /// the position-snap branch instead of the fling branch it was written to
+    /// exercise.
     pub fn dispatch_pointer_move(&self, x: f32, y: f32) {
+        self.binding.clock().advance(POINTER_SAMPLE_INTERVAL);
         let position = Offset::new(px(x), px(y));
         let event = make_move_event(position, PointerType::Mouse);
         self.binding

--- a/crates/flui-material/tests/drawer.rs
+++ b/crates/flui-material/tests/drawer.rs
@@ -570,6 +570,76 @@ fn drag_open_then_close_round_trip_updates_the_handles_tracked_state() {
     );
 }
 
+/// `_settle`'s two branches disagree here, which is the whole point: the drag
+/// is released **below** the halfway mark, so the position branch would close
+/// the drawer, while a qualifying opening velocity flings it open. Flutter's
+/// `_settle` checks velocity first (`drawer.dart`), so open is the correct
+/// outcome — and observing it proves the release velocity this harness feeds
+/// the recognizer is real.
+///
+/// Every other drag test in this file deliberately releases *past* 0.5, where
+/// both branches agree and the measured velocity is unobservable — see
+/// `scrim_mounts_when_open_and_a_tap_closes_the_drawer`, whose comment says so
+/// outright. That is why the harness could feed degenerate sample timestamps
+/// for as long as it did without a single test noticing.
+///
+/// Red-check: drop the `clock().advance(POINTER_SAMPLE_INTERVAL)` from
+/// `tests/common::LaidOut::dispatch_pointer_move`. Every velocity sample then
+/// lands on the same instant, the tracker's zero-span guard reports zero
+/// velocity, `_settle` falls through to the position branch, and the drawer
+/// closes instead — failing the assertion below.
+#[test]
+fn a_fast_release_below_halfway_flings_the_drawer_open_rather_than_snapping_shut() {
+    let vsync = Vsync::new();
+    let handle_slot: Rc<RefCell<Option<DrawerHandle>>> = Rc::new(RefCell::new(None));
+    let probe = HandleProbe {
+        slot: Rc::clone(&handle_slot),
+        on_tap: Rc::new(|_handle: &DrawerHandle| {}),
+    };
+
+    let mut laid = lay_out_animated(
+        themed_animated(
+            Scaffold::new()
+                .drawer(Drawer::new())
+                // Widened so the whole drag path stays within the strip's own
+                // hit-test bounds — see the module docs' "harness limitation"
+                // note (no pointer capture in this harness).
+                .drawer_edge_drag_width(400.0)
+                .body(probe),
+            &vsync,
+        ),
+        tight(400.0, 800.0),
+        vsync,
+    );
+    let handle = handle_slot
+        .borrow()
+        .clone()
+        .expect("HandleProbe captures the handle on its first build");
+
+    // Three moves so the least-squares fit gets its `MIN_SAMPLE_SIZE` (3)
+    // samples; the first also spends the recognizer's slop. The last lands at
+    // x=100, i.e. value ~= 100/304 ~= 0.33 — comfortably below the 0.5 the
+    // position branch snaps on. At the harness's 8ms sample spacing the
+    // release velocity is on the order of 10^4 px/s, far above the drawer's
+    // 365 px/s `_kMinFlingVelocity`.
+    laid.dispatch_pointer_down(5.0, 400.0);
+    laid.dispatch_pointer_move(40.0, 400.0);
+    laid.dispatch_pointer_move(70.0, 400.0);
+    laid.dispatch_pointer_move(100.0, 400.0);
+    laid.dispatch_pointer_up(100.0, 400.0);
+
+    for _ in 0..FLING_SETTLE_PUMPS {
+        laid.pump_for(FRAME);
+    }
+
+    assert!(
+        handle.is_drawer_open(),
+        "a fast opening release must fling the drawer open even though it was \
+         let go below halfway; reporting closed means the release velocity \
+         reaching `_settle` was zero"
+    );
+}
+
 // ============================================================================
 // 5. on_drawer_changed: the app author's callback forwards through Scaffold.
 // ============================================================================

--- a/crates/flui-widgets/src/scroll/page_view.rs
+++ b/crates/flui-widgets/src/scroll/page_view.rs
@@ -732,11 +732,12 @@ impl ViewState<PageView> for PageViewState {
 // `PageScrollPhysics::create_ballistic_simulation` is tested here at the pure
 // function level (metrics + velocity in, a `Simulation` out) rather than only
 // through a gesture-driven `PageView` in the `parity` integration corpus.
-// Reason: this crate's headless test harness dispatches pointer events with
-// real `Instant::now()` timestamps advanced by only a minimal OS-timer tick
-// (`advance_gesture_clock`), so a synthetic drag's *measured* release
-// velocity is enormous — `Scrollable::on_pan_end` clamps it to Flutter's
-// `kMaxFlingVelocity` (±8,000 px/s), still far above
+// Reason: this crate's headless test harness timestamps synthetic pointer
+// samples off the binding's own virtual clock, advanced by a fixed
+// `POINTER_SAMPLE_INTERVAL` per sample rather than any position input the
+// test chose deliberately — so a synthetic drag's *measured* release
+// velocity is whatever falls out of the pixel deltas a test happened to
+// pick, not a value chosen to land on either side of
 // `PageScrollPhysics::velocity_tolerance_px_per_sec` (20.0). A gesture-driven
 // settle test therefore can't isolate "distance-only rounding" from
 // "velocity-biased" behavior deterministically — exactly the halfway-vs-fling

--- a/crates/flui-widgets/src/test_harness.rs
+++ b/crates/flui-widgets/src/test_harness.rs
@@ -10,7 +10,7 @@ use std::any::TypeId;
 use std::cell::Cell;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use flui_binding::HeadlessBinding;
 use flui_foundation::ElementId;
@@ -211,11 +211,24 @@ impl Harness {
         self.binding.enter_owner_scope(callback)
     }
 
-    fn advance_gesture_clock() {
-        let t0 = Instant::now();
-        while Instant::now() == t0 {
-            std::hint::spin_loop();
-        }
+    /// Advance the binding's virtual clock by a fixed, deterministic sample
+    /// interval before a synthetic Move that records a new velocity sample —
+    /// the same mechanism (and same 8ms rationale) as
+    /// `tests/common::LaidOut::advance_pointer_clock`. `DragGestureRecognizer`
+    /// timestamps its velocity samples from `RecognizerBase::now()`, which
+    /// reads this SAME clock-bound `GestureArena` via `binding.arena()`
+    /// above, so a spin-wait on the real clock (which made sample spacing
+    /// depend on however much wall-clock time the test process happened to
+    /// be scheduled between dispatch calls) is neither necessary nor correct.
+    ///
+    /// Only a Move calls this: `DragGestureRecognizer::handle_down` always
+    /// resets the velocity tracker before recording its own sample, so a Down
+    /// has no predecessor sample to space apart from, and advancing the clock
+    /// there would only cost deadline-timing tests virtual time they did not
+    /// ask to spend.
+    fn advance_pointer_clock(&self) {
+        const POINTER_SAMPLE_INTERVAL: Duration = Duration::from_millis(8);
+        self.binding.clock().advance(POINTER_SAMPLE_INTERVAL);
     }
 
     fn begin_contact(&self) -> PointerId {
@@ -246,7 +259,6 @@ impl Harness {
     }
 
     pub(crate) fn dispatch_pointer_down(&self, x: f32, y: f32) {
-        Self::advance_gesture_clock();
         let event = make_down_event_for_id(
             self.begin_contact(),
             Offset::new(px(x), px(y)),
@@ -257,7 +269,7 @@ impl Harness {
     }
 
     pub(crate) fn dispatch_pointer_move(&self, x: f32, y: f32) {
-        Self::advance_gesture_clock();
+        self.advance_pointer_clock();
         let event = make_move_event_for_id(
             self.current_contact(),
             Offset::new(px(x), px(y)),

--- a/crates/flui-widgets/tests/common/mod.rs
+++ b/crates/flui-widgets/tests/common/mod.rs
@@ -14,7 +14,7 @@ use std::cell::Cell;
 use std::collections::HashSet;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use flui_animation::{AnimationController, Vsync};
 use flui_binding::HeadlessBinding;
@@ -63,6 +63,16 @@ pub struct LaidOut {
     /// Pointer id of the in-flight contact, shared by its Move/Up/Cancel.
     current_pointer: Cell<u64>,
 }
+
+/// Default spacing between synthetic pointer samples that record a new
+/// velocity sample (Down, Move, hover-Move, secondary Down) — a plausible
+/// high-frequency pointer-report interval, matching the 8ms sampling period
+/// already assumed elsewhere in the interaction stack (e.g.
+/// `flui_interaction::processing::sampling_clock`). Advancing the binding's
+/// virtual clock by this fixed amount before each such dispatch means the
+/// spacing the velocity tracker records never depends on how much real time
+/// the test process happened to be scheduled between calls.
+const POINTER_SAMPLE_INTERVAL: Duration = Duration::from_millis(8);
 
 /// Loose constraints from `0` up to `max × max` on both axes.
 pub fn loose(max: f32) -> BoxConstraints {
@@ -797,12 +807,28 @@ impl LaidOut {
             .dispatch_pointer(event, |position| self.hit_test_pointer(position));
     }
 
-    /// Ensure consecutive velocity samples receive distinct timestamps.
-    fn advance_gesture_clock() {
-        let t0 = Instant::now();
-        while Instant::now() == t0 {
-            std::hint::spin_loop();
-        }
+    /// Advance the binding's virtual clock by `dt` before a synthetic Move
+    /// that records a new velocity sample.
+    ///
+    /// `DragGestureRecognizer` timestamps its velocity samples from
+    /// `RecognizerBase::now()`, which reads the SAME clock-bound
+    /// `GestureArena` this harness hands the tree via `GestureArenaScope`
+    /// (`binding.arena()` — see `lay_out`). Advancing that clock explicitly,
+    /// instead of spin-waiting on `Instant::now()` to tick, means consecutive
+    /// samples get a fixed, deterministic spacing no matter how much real
+    /// wall-clock time the test process happens to be scheduled between
+    /// dispatch calls — the previous spin-wait's spacing was exactly that
+    /// real, unscheduled gap, which a loaded CI runner could stretch far
+    /// past a plausible pointer-report interval and corrupt the fling
+    /// velocity's least-squares fit.
+    ///
+    /// Only a Move needs this: `DragGestureRecognizer::handle_down` always
+    /// resets the velocity tracker before recording its own sample, so a Down
+    /// has no predecessor sample to space apart from, and advancing the clock
+    /// there would only cost deadline-timing tests (long-press/double-tap
+    /// window boundaries) virtual time they did not ask to spend.
+    fn advance_pointer_clock(&self, dt: Duration) {
+        self.binding.clock().advance(dt);
     }
 
     /// Allocate a fresh pointer id for a new contact and remember it.
@@ -828,9 +854,9 @@ impl LaidOut {
     /// the `Listener` test to assert its callback fires.
     ///
     /// See [`hit_test_pointer`](Self::hit_test_pointer) for why hit-testing runs inside
-    /// the lane scope alongside dispatch.
+    /// the lane scope alongside dispatch. Spends no virtual clock time — see
+    /// [`advance_pointer_clock`](Self::advance_pointer_clock).
     pub fn dispatch_pointer_down(&self, x: f32, y: f32) {
-        Self::advance_gesture_clock();
         let event = make_down_event_for_id(self.begin_contact(), offset(x, y), PointerType::Mouse);
         self.binding
             .dispatch_pointer(&event, |position| self.hit_test_pointer(position));
@@ -844,9 +870,22 @@ impl LaidOut {
             .dispatch_pointer(&event, |position| self.hit_test_pointer(position));
     }
 
-    /// A contact move to `(x, y)` — to drive slop / drag handling.
+    /// A contact move to `(x, y)` — to drive slop / drag handling. Advances
+    /// the virtual clock by the default [`POINTER_SAMPLE_INTERVAL`] first; use
+    /// [`dispatch_pointer_move_after`](Self::dispatch_pointer_move_after) when
+    /// a test needs to assert against an explicit sample spacing instead.
     pub fn dispatch_pointer_move(&self, x: f32, y: f32) {
-        Self::advance_gesture_clock();
+        self.dispatch_pointer_move_after(x, y, POINTER_SAMPLE_INTERVAL);
+    }
+
+    /// As [`dispatch_pointer_move`](Self::dispatch_pointer_move), but advances
+    /// the virtual clock by a caller-chosen `dt` instead of the default
+    /// sample interval — for a test that builds velocity and needs to say
+    /// explicitly how far apart its samples are (mirrors Flutter's
+    /// `WidgetController.timedDrag`/`flingFrom`, which stamp each synthetic
+    /// move with an explicit `timeStamp` rather than the wall clock).
+    pub fn dispatch_pointer_move_after(&self, x: f32, y: f32, dt: Duration) {
+        self.advance_pointer_clock(dt);
         let event =
             make_move_event_for_id(self.current_contact(), offset(x, y), PointerType::Mouse);
         self.binding
@@ -861,8 +900,10 @@ impl LaidOut {
     /// As [`dispatch_pointer_hover`](Self::dispatch_pointer_hover), but for a
     /// caller-chosen device kind (e.g. `PointerType::Pen` for stylus tests) —
     /// the same construction, parameterised instead of hardcoded to `Mouse`.
+    /// A hover has no tracked contact, so it never reaches
+    /// `DragGestureRecognizer::handle_move`'s velocity sampling and spends no
+    /// virtual clock time.
     pub fn dispatch_pointer_hover_with_kind(&self, x: f32, y: f32, kind: PointerType) {
-        Self::advance_gesture_clock();
         let mut event = make_move_event_for_id(PointerId::PRIMARY, offset(x, y), kind);
         let PointerEvent::Move(update) = &mut event else {
             unreachable!("the test move constructor must produce PointerEvent::Move");
@@ -882,10 +923,11 @@ impl LaidOut {
     /// (right-click) pointer-down event — the headless analogue of a right-mouse
     /// button press reaching the framework. Used by `GestureDetector` tests to
     /// assert `on_secondary_tap` fires on right-click.
+    /// Spends no virtual clock time — see
+    /// [`advance_pointer_clock`](Self::advance_pointer_clock).
     pub fn dispatch_secondary_down(&self, x: f32, y: f32) {
         use flui_interaction::events::pointer::PointerButton;
 
-        Self::advance_gesture_clock();
         let event = make_down_event_for_id_with_button(
             self.begin_contact(),
             offset(x, y),

--- a/crates/flui-widgets/tests/common/mod.rs
+++ b/crates/flui-widgets/tests/common/mod.rs
@@ -64,14 +64,23 @@ pub struct LaidOut {
     current_pointer: Cell<u64>,
 }
 
-/// Default spacing between synthetic pointer samples that record a new
-/// velocity sample (Down, Move, hover-Move, secondary Down) — a plausible
-/// high-frequency pointer-report interval, matching the 8ms sampling period
-/// already assumed elsewhere in the interaction stack (e.g.
-/// `flui_interaction::processing::sampling_clock`). Advancing the binding's
-/// virtual clock by this fixed amount before each such dispatch means the
-/// spacing the velocity tracker records never depends on how much real time
-/// the test process happened to be scheduled between calls.
+/// Default spacing between the synthetic pointer samples that record a
+/// velocity sample — i.e. contact Moves, and only those (see
+/// [`LaidOut::advance_pointer_clock`]).
+///
+/// 8ms is a ~120Hz pointer-report interval: faster than a 60Hz display, which
+/// is what a high-report-rate pointer actually does, and comfortably inside
+/// the velocity tracker's 100ms fit horizon so a short synthetic drag yields
+/// several usable samples. It is deliberately NOT
+/// `flui_interaction::processing::sampling_clock::DEFAULT_SAMPLE_PERIOD`
+/// (16.667ms) — that constant is the *resampling* cadence, the rate at which
+/// coalesced input is replayed toward the frame, a different quantity from
+/// how far apart a test spaces the raw samples it feeds in.
+///
+/// Advancing the binding's virtual clock by this fixed amount before each
+/// such dispatch means the spacing the velocity tracker records never depends
+/// on how much real time the test process happened to be scheduled between
+/// calls.
 const POINTER_SAMPLE_INTERVAL: Duration = Duration::from_millis(8);
 
 /// Loose constraints from `0` up to `max × max` on both axes.

--- a/crates/flui-widgets/tests/parity/dismissible_test.rs
+++ b/crates/flui-widgets/tests/parity/dismissible_test.rs
@@ -46,37 +46,38 @@
 //! - **Fling-velocity cases** (`'Horizontal fling triggers dismiss...'` and
 //!   every other `'fling-*'` case, `'... fling item before/after
 //!   movementDuration'`, `'Horizontal/Vertical fling less than threshold'`) —
+//!   still not ported here. At the time this file was written,
 //!   `DragGestureRecognizer::handle_move` (`crates/flui-interaction/src/recognizers/drag.rs`)
-//!   timestamps velocity samples with the real OS clock (`Instant::now()`),
-//!   not the deterministic virtual clock `LaidOut::pump_for` advances for
-//!   gesture *timing* (long-press/double-tap deadlines — see
-//!   `gesture_timing_test.rs`'s module doc). A scripted
-//!   `dispatch_pointer_move` sequence therefore produces a *real* velocity of
-//!   *non-reproducible magnitude* — confirmed empirically while building this
-//!   file: identical test code measured anywhere from ~1.6M to ~4.3M px/s for
-//!   the same 120px drag, run to run. Unlike Flutter's own `WidgetTester`
-//!   (whose synthetic test binding feeds fake timestamps into pointer events
-//!   for exactly this reason), no case here can assert a *specific* fling
-//!   velocity or a bounded settle time — a dedicated virtual-clock seam for
-//!   pointer-velocity sampling would need to land in the shared harness
-//!   first, out of this task's scope.
+//!   timestamped velocity samples with the real OS clock (`Instant::now()`)
+//!   rather than the arena's clock, so a scripted `dispatch_pointer_move`
+//!   sequence produced a *real* velocity of *non-reproducible magnitude* —
+//!   confirmed empirically while building this file: identical test code
+//!   measured anywhere from ~1.6M to ~4.3M px/s for the same 120px drag, run
+//!   to run. That blocker is gone: `DragGestureRecognizer` now reads
+//!   `RecognizerBase::now()`, which resolves to the SAME clock-bound
+//!   `GestureArena` this harness's `HeadlessBinding` owns, and
+//!   `LaidOut::dispatch_pointer_move` advances that clock by a fixed,
+//!   explicit interval per sample — so a scripted drag's release velocity is
+//!   now deterministic and reproducible run to run, the same seam Flutter's
+//!   own `WidgetTester` gets from feeding explicit `timeStamp`s into its
+//!   synthetic pointer events. Porting the fling-velocity cases above is
+//!   newly *possible*, not yet *done* — no case here asserts a specific
+//!   fling velocity or bounded settle time; adding that coverage is
+//!   unstarted follow-up work, out of the scope that landed the clock fix.
 //!
 //!   Every drag-then-release case below neutralizes the *classification*
-//!   instead (it cannot neutralize the magnitude): the release lands at a
-//!   position offset on the CROSS axis by the exact same signed pixel amount
-//!   as the reported primary-axis delta. Whatever the recognizer's opaque
-//!   velocity estimator computes, it is applying the *same* function to two
-//!   proportional (here, identical) position/time series, so the estimated
-//!   `|primary_velocity|` and `|cross_velocity|` come out equal regardless of
-//!   the actual (unpredictable) magnitude — `describe_fling_gesture`'s
-//!   `primary.abs() - cross.abs() < kMinFlingVelocityDelta` gate is satisfied
-//!   unconditionally, so it resolves to `FlingGestureKind::None` and the
-//!   release falls through to the plain threshold-vs-`.forward()`/`.reverse()`
-//!   path this port actually targets. (An earlier attempt — repeating the
-//!   final position 2-3 times before releasing, hoping to drive the estimate
-//!   toward zero — measurably failed: it still produced million-px/s
-//!   estimates, and even flipped the classified *direction* run to run,
-//!   confirming the estimator is not a simple last-sample delta.)
+//!   instead, and still does so deliberately even though the magnitude is no
+//!   longer unpredictable: the release lands at a position offset on the
+//!   CROSS axis by the exact same signed pixel amount as the reported
+//!   primary-axis delta. Whatever the recognizer's velocity estimator
+//!   computes, it is applying the *same* function to two proportional (here,
+//!   identical) position/time series, so the estimated `|primary_velocity|`
+//!   and `|cross_velocity|` come out equal regardless of the magnitude —
+//!   `describe_fling_gesture`'s `primary.abs() - cross.abs() <
+//!   kMinFlingVelocityDelta` gate is satisfied unconditionally, so it
+//!   resolves to `FlingGestureKind::None` and the release falls through to
+//!   the plain threshold-vs-`.forward()`/`.reverse()` path this port actually
+//!   targets.
 //!
 //!   Every test that relies on this lays its `Dismissible` out in a box whose
 //!   CROSS axis has enough headroom for that offset (`horizontal_extent`/

--- a/crates/flui-widgets/tests/parity/page_view_test.rs
+++ b/crates/flui-widgets/tests/parity/page_view_test.rs
@@ -95,11 +95,12 @@
 //! `fling_velocity_beyond_tolerance_advances_regardless_of_distance`,
 //! `backward_fling_velocity_beyond_tolerance_retreats_regardless_of_distance`)
 //! — not duplicated here as gesture-driven release+settle assertions. Reason:
-//! this crate's headless harness dispatches pointer events with real
-//! `Instant::now()` timestamps advanced by only a minimal OS-timer tick
-//! (`advance_gesture_clock`, `tests/common/mod.rs`), so a synthetic drag's
-//! *measured* release velocity is enormous — `Scrollable::on_pan_end` clamps
-//! it to Flutter's `kMaxFlingVelocity` (±8,000 px/s), still far above
+//! this crate's headless harness timestamps synthetic pointer samples off the
+//! binding's own virtual clock, advanced by a fixed
+//! `POINTER_SAMPLE_INTERVAL` per sample (`tests/common/mod.rs`) rather than
+//! any position input the test chose deliberately — so a synthetic drag's
+//! *measured* release velocity is whatever falls out of the pixel deltas a
+//! test happened to pick, not a value chosen to land on either side of
 //! `PageScrollPhysics::velocity_tolerance_px_per_sec` (20.0). A gesture-driven
 //! settle test can't isolate "distance-only rounding" from "velocity-biased"
 //! behavior deterministically that way — precisely the distinction those four

--- a/crates/flui-widgets/tests/scroll.rs
+++ b/crates/flui-widgets/tests/scroll.rs
@@ -1042,6 +1042,62 @@ fn scrollable_fling_advances_offset_past_release() {
     );
 }
 
+/// Same gesture as [`scrollable_fling_advances_offset_past_release`], but with
+/// deliberately irregular REAL delays inserted between the dispatch calls —
+/// standing in for the scheduler jitter a loaded CI runner introduces between
+/// one Rust statement and the next. The sleeps are adversarial input, not
+/// synchronization: nothing about this test's outcome should depend on how
+/// long they actually took.
+///
+/// A pointer's own velocity samples must come from the binding's virtual
+/// clock, never from wall time — so however long the real gaps between
+/// `dispatch_pointer_*` calls turn out to be, the recorded sample spacing
+/// (and therefore the fling velocity) is unaffected. This is the deterministic
+/// reproduction of the flake `scrollable_fling_advances_offset_past_release`
+/// hit intermittently under load: that test's own real dispatch gaps were
+/// implicitly whatever the machine happened to schedule; this test makes the
+/// worst case explicit and asserts it still doesn't corrupt the fling.
+#[test]
+fn scrollable_fling_survives_irregular_real_dispatch_timing() {
+    let controller = ScrollController::new();
+    controller.update_dimensions(300.0, 0.0, 4700.0);
+
+    let vsync = Vsync::new();
+    let widget = Scrollable::new()
+        .controller(controller.clone())
+        .child(SizedBox::new(300.0, 5000.0));
+
+    let mut scoped = fling_scoped(widget, vsync, tight(300.0, 300.0));
+
+    scoped.dispatch_pointer_down(150.0, 250.0);
+    // Wildly uneven real gaps — nothing a genuine pointer's report rate would
+    // ever produce, chosen to make the corruption obvious if wall time leaks
+    // into the recorded sample timestamps.
+    std::thread::sleep(Duration::from_millis(2));
+    scoped.dispatch_pointer_move(150.0, 180.0); // 70 px upward: slop-crossing
+    std::thread::sleep(Duration::from_millis(41));
+    scoped.dispatch_pointer_move(150.0, 150.0); // 30 px more: on_pan_update
+    scoped.dispatch_pointer_up(150.0, 150.0);
+
+    let pixels_at_release = controller.pixels();
+    assert!(
+        pixels_at_release > 0.0,
+        "pan drag must advance the offset before release regardless of real \
+         dispatch timing; got {pixels_at_release}"
+    );
+
+    scoped.pump_for(Duration::from_millis(16));
+    scoped.pump_for(Duration::from_millis(16));
+
+    assert!(
+        controller.pixels() > pixels_at_release,
+        "the fling must keep advancing past the release position no matter how \
+         irregular the real time between dispatch calls was; \
+         release={pixels_at_release:.1}, now={:.1}",
+        controller.pixels()
+    );
+}
+
 /// Clamping physics must never allow the fling to carry the scroll position
 /// past `max_scroll_extent` regardless of the initial fling velocity.
 ///


### PR DESCRIPTION
## The bug

`DragGestureRecognizer` stamped every velocity sample with `Instant::now()`, while its sibling recognizers (`LongPress`, `DoubleTap`) already read the gesture arena's injected clock. In production both resolve to the same `SystemClock`, so this was invisible there — but under a headless binding, whose arena is bound to a `ManualClock`, the drag recognizer alone kept reading wall time.

Both test harnesses papered over that by spinning until the OS clock ticked:

```rust
fn advance_gesture_clock() {
    let t0 = Instant::now();
    while Instant::now() == t0 { std::hint::spin_loop(); }
}
```

That only guaranteed *distinct* timestamps, never a plausible spacing. The interval the velocity tracker actually recorded was whatever real time the test process happened to be scheduled between two dispatch calls — so on a loaded runner a synthetic drag's least-squares velocity fit could collapse and the fling resolve to nothing.

Two tests flaked on exactly this: `scrollable_fling_advances_offset_past_release` and `scrollable_reinstalls_the_stop_hook_after_a_controller_swap`. Measured: **1 failure in 15 runs** under load, **0 in 30** idle. They tripped CI three separate times in one session while the full workspace passed locally on every attempt.

## The fix

- **`drag.rs`** reads `self.state.now()` — the same arena clock the other recognizers use. Plumbing only; no behavior change on the production path.
- **Both harnesses** advance the binding's virtual clock by an explicit `POINTER_SAMPLE_INTERVAL` (8ms) before each Move that records a sample. Down / hover / secondary-down spend no virtual time: a Down resets the tracker so it has no predecessor to space apart from, and charging it virtual time would eat into long-press / double-tap deadline windows.
- **`dispatch_pointer_move_after(x, y, dt)`** lets a test state its sample spacing explicitly — mirroring Flutter's `WidgetController.timedDrag` / `flingFrom`, which stamp each synthetic move with an explicit `timeStamp` rather than the wall clock.
- **`page_view.rs`** is comment-only: its prose explained a deferral in terms of the spin-wait's enormous measured velocities, a premise the fix falsifies.

## Red first — and deterministically

The new `scrollable_fling_survives_irregular_real_dispatch_timing` inserts uneven **real** sleeps (2ms, 41ms) between dispatch calls as *adversarial input*, standing in for scheduler jitter. Nothing about its outcome should depend on how long they took. With `drag.rs` reverted to the wall clock it fails on the first run:

```
FAIL [0.047s] scroll::scrollable_fling_survives_irregular_real_dispatch_timing
```

Previously this failure class was only reachable statistically.

## Verification

| gate | result |
|---|---|
| `nextest --workspace --exclude flui-platform` | **8156 passed** |
| doctests | **630 passed** |
| clippy / fmt / inventory-check / port-check / doc-strict | clean |
| the two former flakes, 20 repetitions | **0 / 20 failures** |

Only production change is the `drag.rs` clock read; `test_harness.rs` is `#[cfg(test)]`-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117t1jX2FFcCzP3YBLoQB94