### PR TITLE
feat(binding,widgets): keep the composited layer tree a headless frame produces

### DIFF
--- a/crates/flui-binding/src/lib.rs
+++ b/crates/flui-binding/src/lib.rs
@@ -97,6 +97,9 @@ use flui_interaction::{
     GestureBinding, HitTestResult, InteractionDispatchError, InteractionDispatchHandle,
     InteractionLane, PointerEvent,
 };
+// `flui-rendering` re-exports `flui-layer` wholesale, so naming the composited
+// tree costs no extra dependency edge.
+use flui_rendering::layer::LayerTree;
 use flui_rendering::pipeline::PipelineOwner;
 use flui_scheduler::{BoxedTask, LocalPostFrameLane, Scheduler, TaskToken};
 use flui_types::geometry::{Offset, Pixels};
@@ -183,6 +186,21 @@ pub struct HeadlessBinding {
     local_post_frame: LocalPostFrameLane,
     /// Owner-affine interaction callback storage, active across every owner entry.
     interaction_lane: InteractionLane,
+    /// The composited [`LayerTree`] the most recent [`pump_frame`](Self::pump_frame)
+    /// produced, retained rather than dropped.
+    ///
+    /// On screen this value is the frame's whole point — `AppBinding::draw_frame`
+    /// hands it to the compositor. Headlessly there is nothing downstream to hand
+    /// it to, so the pipeline's return value used to be discarded, leaving no way
+    /// to ask what a frame actually composited. Keeping it makes the headless
+    /// frame observable in the same terms as the on-screen one; see
+    /// [`layer_tree`](Self::layer_tree).
+    ///
+    /// `None` before the first frame, and for a gesture-only binding with no
+    /// mounted tree. A frame over a tree with nothing dirty repaints nothing and
+    /// composites nothing, so it also leaves `None` — the field reports what the
+    /// last frame produced, not a cached last-known-good tree.
+    last_layer_tree: Option<LayerTree>,
 }
 
 impl HeadlessBinding {
@@ -218,6 +236,7 @@ impl HeadlessBinding {
             scheduler,
             local_post_frame,
             interaction_lane,
+            last_layer_tree: None,
         })
     }
 
@@ -434,6 +453,24 @@ impl HeadlessBinding {
         self.gestures.mouse_tracker()
     }
 
+    /// The composited layer tree the most recent [`pump_frame`](Self::pump_frame)
+    /// produced, or `None` if that frame composited nothing.
+    ///
+    /// This is the headless counterpart of the value `AppBinding::draw_frame`
+    /// hands the compositor — the same tree, from the same pipeline step, simply
+    /// kept instead of dropped. It answers "what did this frame actually
+    /// composite", which the render tree alone cannot: layers are created by
+    /// *paint*, so a widget that forces a clip, a transform, or an opacity layer
+    /// is visible here and nowhere else.
+    ///
+    /// A frame over a tree with nothing dirty repaints nothing and therefore
+    /// composites nothing, leaving `None` — this reports the last frame's
+    /// output, not the last non-empty output. Mount, then pump, then read.
+    #[must_use]
+    pub fn layer_tree(&self) -> Option<&LayerTree> {
+        self.last_layer_tree.as_ref()
+    }
+
     /// The virtual clock this binding advances each frame.
     ///
     /// Exposed for inspection (`now()` / `elapsed()`). Prefer
@@ -603,6 +640,7 @@ impl HeadlessBinding {
             scheduler,
             local_post_frame,
             interaction_lane,
+            last_layer_tree,
         } = self;
         local_post_frame.enter(|| {
             interaction_lane.enter(|| {
@@ -648,7 +686,7 @@ impl HeadlessBinding {
                 let scheduler = scheduler.clone();
                 let vsync_time = flui_scheduler::Instant::now();
                 scheduler.drive_frame(vsync_time, || {
-                    Self::run_pipeline(tree);
+                    *last_layer_tree = Self::run_pipeline(tree);
 
                     // 7. Re-hit-test every stationary device against the
                     //    tree layout/paint that just committed above,
@@ -690,10 +728,13 @@ impl HeadlessBinding {
     /// The pipeline step: build → layout (with the build-during-layout fixpoint)
     /// → paint, plus the lazy-sliver service pass. Runs inside
     /// [`Scheduler::drive_frame`]'s persistent slot.
-    fn run_pipeline(tree: &mut Option<TreeBinding>) {
-        let Some(tree_binding) = tree.as_mut() else {
-            return;
-        };
+    ///
+    /// Returns the composited [`LayerTree`] this frame produced — `None` for a
+    /// gesture-only binding, and `None` when nothing was dirty enough to
+    /// repaint. `pump_frame` stores it in
+    /// [`last_layer_tree`](Self::last_layer_tree).
+    fn run_pipeline(tree: &mut Option<TreeBinding>) -> Option<LayerTree> {
+        let tree_binding = tree.as_mut()?;
 
         // Drain the build inbox, filled by the vsync tick and the async-driver
         // poll that ran before this closure.
@@ -716,7 +757,7 @@ impl HeadlessBinding {
         // A headless frame over an already-mounted, rooted tree must succeed;
         // a pipeline error here is a regression, surfaced loudly (the harness
         // and production frame path expect the same).
-        result.expect("headless pump_frame: pipeline run_frame should succeed");
+        let layer_tree = result.expect("headless pump_frame: pipeline run_frame should succeed");
 
         // Service lazy-sliver child requests. Layout may have emitted build
         // requests for absent children and retain-band signals for eviction.
@@ -727,6 +768,8 @@ impl HeadlessBinding {
         tree_binding
             .build_owner
             .service_child_requests(&mut tree_binding.tree, &tree_binding.pipeline_owner);
+
+        layer_tree
     }
 }
 

--- a/crates/flui-widgets/tests/common/mod.rs
+++ b/crates/flui-widgets/tests/common/mod.rs
@@ -711,6 +711,30 @@ impl LaidOut {
     /// itself exactly that), but a caller querying "by render type" wants
     /// the base name regardless of which generic argument a render object
     /// happens to be monomorphized over.
+    pub fn find_all_by_render_type(&self, render_type_name: &str) -> Vec<RenderId> {
+        let logical_root = self.current_root();
+        let owner = self.pipeline_owner.read();
+        let render_tree = owner.render_tree();
+        let mut logical_ids = HashSet::new();
+        let mut pending = vec![logical_root];
+        while let Some(id) = pending.pop() {
+            logical_ids.insert(id);
+            pending.extend(render_tree.children(id).iter().copied());
+        }
+
+        let queried = base_type_name(render_type_name);
+        render_tree
+            .iter()
+            .filter_map(|(id, _node)| {
+                if !logical_ids.contains(&id) {
+                    return None;
+                }
+                let diagnostics = owner.debug_node_diagnostics(id)?;
+                (diagnostics.name().map(base_type_name) == Some(queried)).then_some(id)
+            })
+            .collect()
+    }
+
     /// The composited layer tree from the most recent pumped frame.
     ///
     /// The structural form of [`layer_kinds`](Self::layer_kinds), for the cases
@@ -764,30 +788,6 @@ impl LaidOut {
             }
         }
         kinds
-    }
-
-    pub fn find_all_by_render_type(&self, render_type_name: &str) -> Vec<RenderId> {
-        let logical_root = self.current_root();
-        let owner = self.pipeline_owner.read();
-        let render_tree = owner.render_tree();
-        let mut logical_ids = HashSet::new();
-        let mut pending = vec![logical_root];
-        while let Some(id) = pending.pop() {
-            logical_ids.insert(id);
-            pending.extend(render_tree.children(id).iter().copied());
-        }
-
-        let queried = base_type_name(render_type_name);
-        render_tree
-            .iter()
-            .filter_map(|(id, _node)| {
-                if !logical_ids.contains(&id) {
-                    return None;
-                }
-                let diagnostics = owner.debug_node_diagnostics(id)?;
-                (diagnostics.name().map(base_type_name) == Some(queried)).then_some(id)
-            })
-            .collect()
     }
 
     /// The unique render node whose short type name equals `render_type_name`.

--- a/crates/flui-widgets/tests/common/mod.rs
+++ b/crates/flui-widgets/tests/common/mod.rs
@@ -711,6 +711,61 @@ impl LaidOut {
     /// itself exactly that), but a caller querying "by render type" wants
     /// the base name regardless of which generic argument a render object
     /// happens to be monomorphized over.
+    /// The composited layer tree from the most recent pumped frame.
+    ///
+    /// The structural form of [`layer_kinds`](Self::layer_kinds), for the cases
+    /// that need parent/child shape rather than a flat list — upstream's
+    /// `fitted_box_test.dart` walks a single-child *container chain* and asserts
+    /// `firstChild == lastChild` at every step, which a flattened list cannot
+    /// express. Same "a frame must have been pumped" precondition.
+    pub fn layer_tree(&self) -> Option<&flui_rendering::layer::LayerTree> {
+        self.binding.layer_tree()
+    }
+
+    /// The kinds of every layer the most recent pumped frame composited, in
+    /// depth-first pre-order from the root — FLUI's answer to Flutter's
+    /// `tester.layers`.
+    ///
+    /// Layers exist only as a product of **paint**, so this answers questions
+    /// the render tree structurally cannot: whether a widget forced a clip, a
+    /// transform, or an opacity layer into the composited output, and how many.
+    /// `find_all_by_render_type` reports what was *built*; this reports what was
+    /// *composited*, and the two deliberately disagree — a `Transform` whose
+    /// matrix collapses to identity has a render object and no
+    /// `TransformLayer`.
+    ///
+    /// **A frame must have been pumped.** `lay_out` drives the mount frame
+    /// through the pipeline directly and discards its output, and a frame over a
+    /// tree with nothing dirty composites nothing at all — so call
+    /// [`pump`](Self::pump) (or any other pump) before reading, and expect an
+    /// empty vec otherwise. This is stricter than Flutter, where `pumpWidget`
+    /// itself is the frame; the extra call is the honest price of not having the
+    /// mount path retain a tree nothing downstream consumes.
+    pub fn layer_kinds(&self) -> Vec<&'static str> {
+        let Some(tree) = self.binding.layer_tree() else {
+            return Vec::new();
+        };
+        let Some(root) = tree.root() else {
+            return Vec::new();
+        };
+
+        let mut kinds = Vec::with_capacity(tree.len());
+        // Explicit stack rather than recursion: a deep composited tree is
+        // ordinary, and the harness must not be the thing that overflows.
+        let mut stack = vec![root];
+        while let Some(id) = stack.pop() {
+            let Some(layer) = tree.get_layer(id) else {
+                continue;
+            };
+            kinds.push(layer.kind_name());
+            if let Some(children) = tree.children(id) {
+                // Push reversed so siblings pop back in paint order.
+                stack.extend(children.iter().rev().copied());
+            }
+        }
+        kinds
+    }
+
     pub fn find_all_by_render_type(&self, render_type_name: &str) -> Vec<RenderId> {
         let logical_root = self.current_root();
         let owner = self.pipeline_owner.read();

--- a/crates/flui-widgets/tests/layer_inspection.rs
+++ b/crates/flui-widgets/tests/layer_inspection.rs
@@ -1,0 +1,159 @@
+//! The headless harness can report what a frame actually **composited**, not
+//! just what it built.
+//!
+//! Layers are produced by *paint*, so they answer questions the render tree
+//! structurally cannot: whether a widget forced a clip, a transform, or an
+//! opacity layer into the output, and how many. Upstream's widget tests lean on
+//! this constantly (`tester.layers`, and the `getLayers()` container-chain walk
+//! `fitted_box_test.dart` defines locally); five files in
+//! `tests/parity/` currently list cases as out of scope naming the absence of
+//! exactly this capability.
+//!
+//! The pipeline always produced the tree — `HeadlessBinding::pump_frame` simply
+//! dropped it on the floor, because headlessly there is no compositor to hand it
+//! to. These tests pin that it is kept and reachable.
+
+use std::time::Duration;
+
+use crate::common::{lay_out, tight};
+use flui_geometry::Matrix4;
+use flui_types::Color;
+use flui_widgets::{ColoredBox, Opacity, SizedBox, Transform};
+
+/// The baseline: a pumped frame reports the layers it composited.
+///
+/// Asserts the *content*, not merely that the vec is non-empty — a stub
+/// returning `vec!["Picture"]` would pass an is-empty check. A painted tree
+/// bottoms out in a `Picture` leaf beneath an `Offset` root, and both must be
+/// named.
+///
+/// Red-check: revert `pump_frame` to discarding `run_pipeline`'s return value.
+/// `layer_kinds` then reports an empty vec and both assertions fail.
+#[test]
+fn a_pumped_frame_reports_the_layers_it_composited() {
+    let mut laid = lay_out(
+        SizedBox::new(50.0, 50.0).child(ColoredBox::new(Color::rgb(10, 20, 30))),
+        tight(200.0, 200.0),
+    );
+    laid.pump();
+
+    let kinds = laid.layer_kinds();
+    assert!(
+        kinds.contains(&"Picture"),
+        "a painted tree must composite a Picture leaf; got {kinds:?}"
+    );
+    assert!(
+        kinds.contains(&"Offset"),
+        "the composited root must be an Offset layer; got {kinds:?}"
+    );
+}
+
+/// Layers reflect **paint**, so a widget that forces one into the output is
+/// visible here and nowhere else in the harness.
+///
+/// `Opacity` is the clearest case: it adds no render-tree geometry a
+/// `find_all_by_render_type` sweep could distinguish from its child alone, but
+/// it must composite an `Opacity` layer. This is the capability's whole reason
+/// for existing — asserting on composited output rather than built structure.
+#[test]
+fn a_widget_that_forces_a_compositing_layer_shows_up_in_the_composited_output() {
+    let mut without = lay_out(
+        SizedBox::new(50.0, 50.0).child(ColoredBox::new(Color::rgb(10, 20, 30))),
+        tight(200.0, 200.0),
+    );
+    without.pump();
+    assert!(
+        !without.layer_kinds().contains(&"Opacity"),
+        "the control tree must not composite an Opacity layer; got {:?}",
+        without.layer_kinds()
+    );
+
+    let mut with = lay_out(
+        Opacity::new(0.5)
+            .child(SizedBox::new(50.0, 50.0).child(ColoredBox::new(Color::rgb(10, 20, 30)))),
+        tight(200.0, 200.0),
+    );
+    with.pump();
+    assert!(
+        with.layer_kinds().contains(&"Opacity"),
+        "a half-opaque subtree must composite an Opacity layer; got {:?}",
+        with.layer_kinds()
+    );
+}
+
+/// The structural form: [`LaidOut::layer_tree`] exposes parent/child shape, not
+/// just a flat list.
+///
+/// Upstream's `fitted_box_test.dart` needs exactly this — its local
+/// `getLayers()` walks a single-child *container chain* from the root and
+/// asserts `firstChild == lastChild` at every step, which a flattened list
+/// cannot express. This pins that the shape is reachable, so that helper is
+/// portable when the features it exercises land.
+#[test]
+fn the_composited_tree_exposes_parent_child_shape_not_just_a_flat_list() {
+    let mut laid = lay_out(
+        Transform::new(Matrix4::scaling(2.0, 2.0, 1.0))
+            .child(SizedBox::new(50.0, 50.0).child(ColoredBox::new(Color::rgb(10, 20, 30)))),
+        tight(200.0, 200.0),
+    );
+    laid.pump();
+
+    let tree = laid.layer_tree().expect("a pumped frame composites a tree");
+    let root = tree.root().expect("the composited tree has a root");
+    assert!(
+        tree.len() > 1,
+        "this tree composites more than the root alone; got {} layer(s)",
+        tree.len()
+    );
+    assert_eq!(
+        tree.parent(root),
+        None,
+        "the root layer must have no parent"
+    );
+
+    let children = tree
+        .children(root)
+        .expect("the root of a multi-layer tree has children");
+    assert!(
+        !children.is_empty(),
+        "the root must actually parent the layers below it — a flat list of the \
+         right length would not prove the tree is linked"
+    );
+    for &child in children {
+        assert_eq!(
+            tree.parent(child),
+            Some(root),
+            "every child's parent link must point back at the root"
+        );
+    }
+}
+
+/// Composited output is the *last frame's* output, not a cached
+/// last-known-good tree.
+///
+/// A frame over a tree with nothing dirty repaints nothing and therefore
+/// composites nothing. Reporting a stale tree there would be the more
+/// convenient lie — and would silently answer "yes, this widget composited a
+/// clip" about a frame that never ran. Pinning the honest behavior keeps a
+/// future caller from building on the convenient one.
+#[test]
+fn a_frame_that_repaints_nothing_composites_nothing() {
+    let mut laid = lay_out(
+        SizedBox::new(50.0, 50.0).child(ColoredBox::new(Color::rgb(10, 20, 30))),
+        tight(200.0, 200.0),
+    );
+    laid.pump();
+    assert!(
+        !laid.layer_kinds().is_empty(),
+        "the dirty frame must composite something to make this test meaningful"
+    );
+
+    // `pump_for` advances virtual time without dirtying the tree.
+    laid.pump_for(Duration::from_millis(16));
+    assert!(
+        laid.layer_kinds().is_empty(),
+        "a frame that repainted nothing must report no composited layers rather \
+         than the previous frame's; got {:?}",
+        laid.layer_kinds()
+    );
+}

--- a/crates/flui-widgets/tests/main.rs
+++ b/crates/flui-widgets/tests/main.rs
@@ -62,6 +62,8 @@ mod indexed_stack;
 mod inherited_app;
 #[path = "intrinsic_and_overflow.rs"]
 mod intrinsic_and_overflow;
+#[path = "layer_inspection.rs"]
+mod layer_inspection;
 #[path = "layout.rs"]
 mod layout;
 #[path = "layout_builder.rs"]

--- a/crates/flui-widgets/tests/parity/fitted_box_test.rs
+++ b/crates/flui-widgets/tests/parity/fitted_box_test.rs
@@ -39,8 +39,21 @@
 //! Out of scope (4 cases): `'FittedBox layers - contain'`, `'FittedBox
 //! layers - cover - horizontal'`, `'FittedBox layers - cover - vertical'`,
 //! `'FittedBox layers - none - clip'` — all four assert `getLayers()`
-//! (`TransformLayer`/`ClipRectLayer`/`OffsetLayer` composition-layer
-//! counts); FLUI's headless harness has no compositing-layer-tree capture.
+//! (`TransformLayer`/`ClipRectLayer`/`OffsetLayer` composition-layer counts).
+//!
+//! The harness reason these once carried is gone: `LaidOut::layer_kinds` /
+//! `LaidOut::layer_tree` now report exactly what a frame composited (see
+//! `tests/layer_inspection.rs`). What blocks them is one layer down and
+//! larger — **`RenderFittedBox` does not clip at all.** Its own module doc
+//! (`crates/flui-objects/src/layout/fitted_box.rs`) says so: `clip_behavior`
+//! is stored and dumped in diagnostics, but "active clipping awaits the
+//! layer-level clip integration". Measured against the four upstream trees,
+//! FLUI composites the identical chain for every one of them — including
+//! `BoxFit::Cover` with `Clip::HardEdge` over an overflowing child, where the
+//! oracle expects a `ClipRectLayer`. Three of the four cases assert a clip
+//! layer that FLUI cannot yet produce, so porting them would pin behavior
+//! that does not exist. They unblock with the clip integration, not with a
+//! test-harness change.
 //!
 //! Framework gap (1 leg, not a full case — folded into the ported
 //! `'Child can be aligned multiple ways in a row'` above rather than double

--- a/crates/flui-widgets/tests/parity/fitted_box_test.rs
+++ b/crates/flui-widgets/tests/parity/fitted_box_test.rs
@@ -4,9 +4,12 @@
 //! `3.44.0`, 15 cases).
 //!
 //! Ported cases (11 upstream names, 11 Rust tests — every geometry, clip-
-//! storage, and hit-test case; FLUI has no golden-file/compositing-layer
-//! harness, so every `getLayers()` layer-count assertion is dropped, same
-//! reason `clip_test.rs`/`transform_test.rs` drop paint-pattern assertions):
+//! storage, and hit-test case. The `getLayers()` layer-count assertions are
+//! dropped, but no longer for want of a harness: `LaidOut::layer_kinds` /
+//! `LaidOut::layer_tree` report composited output now, and what actually
+//! blocks those four cases is `RenderFittedBox`'s missing clip — see "Out of
+//! scope" below. FLUI still has no golden-file harness, the separate reason
+//! `clip_test.rs` drops paint-pattern assertions):
 //! - `'Can size according to aspect ratio'` — [`can_size_according_to_aspect_ratio`].
 //! - `'Can contain child'` — [`can_contain_child`].
 //! - `'Child can cover'` — [`child_can_cover`]. This case exercises

--- a/crates/flui-widgets/tests/parity/transform_test.rs
+++ b/crates/flui-widgets/tests/parity/transform_test.rs
@@ -74,6 +74,25 @@
 //!   [`transform_scale_zero_hit_test_misses_the_non_invertible_transform`],
 //!   [`transform_scale_x_zero_hit_test_misses_the_non_invertible_transform`],
 //!   [`transform_scale_y_zero_hit_test_misses_the_non_invertible_transform`].
+//!
+//!   **The layer half of that case is now measurable, and FLUI fails it.**
+//!   `LaidOut::layer_kinds` (see `tests/layer_inspection.rs`) reports the
+//!   composited output, and for all four upstream legs FLUI composites the
+//!   *identical* chain — the child's layers are painted under `scale: 0.0`
+//!   exactly as under `scale: 0.01`. The oracle requires the opposite:
+//!   `RenderTransform.paint` (`rendering/proxy_box.dart`, 3.44.0) computes
+//!   `transform.determinant()` and, when it is `0` or non-finite, clears its
+//!   layer and returns without painting — "if the matrix is singular the
+//!   children would be compressed to a line or single point, instead
+//!   short-circuit and paint nothing." So FLUI paints a subtree that can
+//!   never be visible.
+//!
+//!   Note the asymmetry this leaves: hit-testing already honours the singular
+//!   case (the three ported cases above pass precisely because `try_inverse`
+//!   returns `None`), while painting does not. The fix is not a test change —
+//!   FLUI centralises the transform push in the paint walk rather than in
+//!   `RenderTransform`, so where the determinant guard belongs is a real
+//!   design call, tracked separately from this port.
 //! - `'Transform.scale'`'s scale-factor assertion (the `m[0][0]` delta only —
 //!   the full composited-layer matrix, including the CENTER-alignment pivot's
 //!   translation component, is a `TransformLayer` assertion, out of scope) —

--- a/crates/flui-widgets/tests/parity/transform_test.rs
+++ b/crates/flui-widgets/tests/parity/transform_test.rs
@@ -7,10 +7,15 @@
 //!
 //! Ported cases (7 upstream names, 9 Rust tests — hit-testing under
 //! translation/scale/composition and the alignment+origin combination the
-//! render object's `compute_origin` fix addresses are the portable core; FLUI
-//! has no golden-file/compositing-layer harness, so every `TransformLayer`
-//! matrix/count assertion is dropped, same reason `clip_test.rs` drops
-//! `paints..save()..clipRect()` assertions). Every case below that taps a
+//! render object's `compute_origin` fix addresses are the portable core. The
+//! `TransformLayer` assertions are still dropped, but the reason has split in
+//! two: `LaidOut::layer_kinds` / `LaidOut::layer_tree` now report composited
+//! output, so layer *counts* are measurable — and measuring them exposed a
+//! real paint bug, recorded under the zero-determinant case below. What
+//! remains out of reach is the layer *matrix*: nothing surfaces a composited
+//! layer's own transform, and FLUI has no golden-file harness either, the
+//! separate reason `clip_test.rs` drops `paints..save()..clipRect()`
+//! assertions). Every case below that taps a
 //! target starts from a fresh `AtomicBool::new(false)`, so upstream's pre-tap
 //! `expect(didReceiveTap`/`pointerDown, isFalse)` — asserting only that the
 //! flag is still at its default before any interaction, not a behavior — is
@@ -89,10 +94,19 @@
 //!
 //!   Note the asymmetry this leaves: hit-testing already honours the singular
 //!   case (the three ported cases above pass precisely because `try_inverse`
-//!   returns `None`), while painting does not. The fix is not a test change —
-//!   FLUI centralises the transform push in the paint walk rather than in
-//!   `RenderTransform`, so where the determinant guard belongs is a real
-//!   design call, tracked separately from this port.
+//!   returns `None`), while painting does not.
+//!
+//!   The fix is not a test change, and it belongs on the render object, not in
+//!   the paint walk: `RenderObject::skip_paint` is the existing node-local
+//!   "suppress this subtree entirely" hook, and `RenderOpacity` already uses it
+//!   to express the very same Flutter shape (`if (_alpha == 0) return;`). Two
+//!   details make it exact rather than approximate — `effective_transform`
+//!   wraps the matrix in pure origin translations, which cannot change a
+//!   determinant, so the guard needs no laid-out size; and it must spell out
+//!   `det == 0 || !det.is_finite()` rather than reuse
+//!   `Matrix4::is_invertible`, whose epsilon test answers *true* for an
+//!   infinite scale and would let exactly the non-finite cases below through.
+//!   Tracked separately from this port so the harness change stays reviewable.
 //! - `'Transform.scale'`'s scale-factor assertion (the `m[0][0]` delta only —
 //!   the full composited-layer matrix, including the CENTER-alignment pivot's
 //!   translation component, is a `TransformLayer` assertion, out of scope) —
@@ -149,15 +163,29 @@
 //!   `'Transform.translate/scale/rotate with FilterQuality produces filter
 //!   layer'` (4 cases), `'Transform layers update to match child and
 //!   filterQuality'`, `'Transform layers with filterQuality golden'` — all
-//!   `TransformLayer`/`ImageFilterLayer`/`matchesGoldenFile` assertions; FLUI's
-//!   headless harness has no compositing-layer introspection or golden-image
-//!   capture.
+//!   `TransformLayer`/`ImageFilterLayer`/`matchesGoldenFile` assertions.
+//!
+//!   Layer *counts* among these are no longer harness-blocked
+//!   (`LaidOut::layer_kinds`); what still blocks each is its own missing
+//!   feature or surface: `Transform` has no `filterQuality` at all, so the
+//!   five `ImageFilterLayer` cases have nothing to assert against; the
+//!   layer-matrix halves need a composited layer's own transform, which
+//!   nothing surfaces; and `matchesGoldenFile` needs golden-image capture,
+//!   which does not exist. `'Transform.scale with 0.0 does not paint child
+//!   layers'` is the one case whose blocker is now *measured* rather than
+//!   assumed — see the zero-determinant entry in the Delta ports section
+//!   above, which records the paint bug the measurement exposed.
 //! - `'Transform with nan/inf/-inf value short-circuits rendering'` (3 cases)
-//!   — Flutter's `Transform._computeRotation`/paint path short-circuits to a
-//!   single (root) layer when the matrix carries a non-finite entry; whether
-//!   `RenderTransform` has an equivalent guard is unverified (no layer count
-//!   to assert against either way), and probing it would require the same
-//!   missing layer-count harness.
+//!   — Flutter's paint path short-circuits to a single (root) layer when the
+//!   matrix carries a non-finite entry. This was previously recorded here as
+//!   *unverified* for want of a layer count; it is now measured, and the
+//!   answer is that **`RenderTransform` has no such guard**. A `NAN`, `INFINITY`
+//!   or `NEG_INFINITY` scale composites the identical chain a finite `2.0`
+//!   scale does — the child subtree is painted in full. Same defect, same
+//!   `det == 0 || !det.isFinite` branch of `RenderTransform.paint`
+//!   (`rendering/proxy_box.dart`, 3.44.0), as the zero-determinant case above,
+//!   and blocked on the same design call about where the guard belongs. These
+//!   three cases become portable with that fix, not with a harness change.
 //! - `"Transform.scale() does not accept all three ... to be non-null"`,
 //!   `"Transform.scale() needs at least one of ... to be non-null"` —
 //!   Dart-specific `assert()`-throws tests guarding `Transform.scale`'s


### PR DESCRIPTION
## What

`HeadlessBinding::pump_frame` ran the pipeline, received the frame's `LayerTree`, and **dropped it** — headlessly there is no compositor to hand it to, so the return value went on the floor. On screen that same value is the frame's whole point (`AppBinding::draw_frame` gives it to the compositor). This keeps it.

Layers exist only as a product of *paint*, so they answer what the render tree structurally cannot: whether a widget forced a clip, a transform, or an opacity layer into the output, and how many. **Five files** under `tests/parity/` list cases as out of scope naming the absence of exactly this capability.

- `HeadlessBinding::layer_tree()` — the tree the last `pump_frame` produced. No new dependency: `flui-rendering` already re-exports `flui-layer`.
- `LaidOut::layer_kinds()` (flat, depth-first — the `tester.layers` analogue) and `LaidOut::layer_tree()` (structural). Both are needed: upstream's `fitted_box_test.dart` walks a single-child *container chain* asserting `firstChild == lastChild` at each step, which a flat list cannot express.

It reports **the last frame's output, not a cached last-known-good tree**. A frame over a tree with nothing dirty repaints nothing and composites nothing, and says so — measured, not assumed. `a_frame_that_repaints_nothing_composites_nothing` pins it, because the convenient lie would silently answer "yes, this widget composited a clip" about a frame that never ran.

Red-checked: reverting `pump_frame` to discard the value fails all four tests.

## What it immediately caught

Two parity module docs are corrected here — the capability falsified their stated reasons, and a stale reason is worse than none.

**`transform_test.rs` — a real bug, oracle-confirmed.** The layer half of `'Transform.scale with 0.0 does not paint child layers'` is now measurable, and FLUI fails it. All four upstream legs composite the *identical* chain — the child is painted under `scale: 0.0` exactly as under `scale: 0.01`:

```
scale 0.0   -> ["Offset", "Transform", "Offset", "Picture"]
scaleX 0.0  -> ["Offset", "Transform", "Offset", "Picture"]
scaleY 0.0  -> ["Offset", "Transform", "Offset", "Picture"]
scale 0.01  -> ["Offset", "Transform", "Offset", "Picture"]
```

`RenderTransform.paint` (`rendering/proxy_box.dart`, 3.44.0) instead computes `transform.determinant()` and, when it is `0` or non-finite, clears its layer and returns without painting — *"if the matrix is singular the children would be compressed to a line or single point, instead short-circuit and paint nothing."* So FLUI paints a subtree that can never be visible.

Note the asymmetry: the **hit-test** path already honours the singular case (three ported cases pass precisely because `try_inverse` returns `None`); only paint does not.

**Not fixed here, deliberately.** FLUI centralises the transform push in the paint walk rather than in `RenderTransform`, so where the determinant guard belongs is a design call affecting every `paint_transform` provider — not a one-liner to bolt onto a harness PR.

**`fitted_box_test.rs` — the stated reason was only half true.** It blamed the harness for its four `getLayers()` cases. The real blocker is one layer down and larger: `RenderFittedBox` **does not clip at all** — its own module doc says active clipping "awaits the layer-level clip integration". Measured against all four upstream trees, FLUI composites an identical chain for every one, including `BoxFit::Cover` + `Clip::HardEdge` over an overflowing child where the oracle expects a `ClipRectLayer`. Those cases unblock with the clip integration, not with a test-harness change.

## Verification

| gate | result |
|---|---|
| `nextest --workspace --exclude flui-platform` | **8161 passed** (+4) |
| doctests | **630 passed** |
| clippy / fmt / inventory-check / port-check | clean |
| red-check (revert retention) | 4 / 4 fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117t1jX2FFcCzP3YBLoQB94