### PR TITLE
feat(objects): make FittedBox actually clip a cropped child

### DIFF
--- a/crates/flui-objects/src/layout/fitted_box.rs
+++ b/crates/flui-objects/src/layout/fitted_box.rs
@@ -115,6 +115,13 @@ pub struct RenderFittedBox {
     source_offset: Offset,
     /// True iff the scaled child exceeds `size` on either axis.
     has_visual_overflow: bool,
+    /// True iff the child laid out to a zero-area size.
+    ///
+    /// Tracked separately from `has_child` because a degenerate child is still
+    /// *a* child — intrinsics and layout must keep forwarding to it — but it
+    /// must not paint or be hit-tested, which is a property of its measured
+    /// size and so is only knowable after layout.
+    child_is_empty: bool,
 }
 
 impl RenderFittedBox {
@@ -130,6 +137,7 @@ impl RenderFittedBox {
             align_offset: Offset::ZERO,
             source_offset: Offset::ZERO,
             has_visual_overflow: false,
+            child_is_empty: false,
         }
     }
 
@@ -340,8 +348,10 @@ impl RenderBox for RenderFittedBox {
         // (3) Degenerate child → smallest size, identity transform.
         if child_size.width <= px(0.0) || child_size.height <= px(0.0) {
             self.reset_transform_cache();
+            self.child_is_empty = true;
             return incoming.smallest();
         }
+        self.child_is_empty = false;
 
         // (4) Our size honours the parent constraints while preserving the
         //     child's aspect ratio (Flutter uses
@@ -445,6 +455,10 @@ impl RenderBox for RenderFittedBox {
         if !ctx.is_within_own_size() {
             return false;
         }
+        // Flutter's `hitTestChildren` carries the same pair of guards its
+        // `paint` does: `if (size.isEmpty || (child?.size.isEmpty ?? false))`.
+        // A child that cannot be painted must not be reachable by a pointer
+        // either — the box's own size gate above covers the empty-box half.
         if !self.has_child {
             return false;
         }
@@ -503,10 +517,13 @@ impl RenderBox for RenderFittedBox {
         }
 
         let size = ctx.size();
-        // A collapsed box (or a collapsed child) has nothing to show, and the
-        // fit transform would be degenerate — Flutter's
-        // `if (size.isEmpty || child.size.isEmpty) return;`.
-        if size.width.get() <= 0.0 || size.height.get() <= 0.0 {
+        // Flutter: `if (child == null || size.isEmpty || child!.size.isEmpty)
+        // return;`. All three clauses matter — a zero-area child still paints
+        // whatever its own `paint` draws (a `CustomPaint` ignores its size
+        // happily), and the fit transform onto or from a zero extent is
+        // degenerate, so neither a collapsed box nor a collapsed child may
+        // reach the child's paint.
+        if self.child_is_empty || size.width.get() <= 0.0 || size.height.get() <= 0.0 {
             return;
         }
 

--- a/crates/flui-objects/src/layout/fitted_box.rs
+++ b/crates/flui-objects/src/layout/fitted_box.rs
@@ -15,22 +15,14 @@
 //!   regions. Flutter's `RenderFittedBox` reimplements the same math
 //!   inline; the Rust port keeps the math in one place so the seven
 //!   `BoxFit` variants only have to be debugged once.
-//! * The scale + alignment transform is exposed via
-//!   [`RenderBox::paint_transform`] as a single composed
-//!   [`Matrix4`]. The pipeline wraps the child in a `TransformLayer`
-//!   — no manual canvas-state juggling in `paint`. Flutter does the
-//!   same via its `_transform` layer machinery; the Rust shape just
-//!   makes the matrix a first-class trait return value.
+//! * The scale + alignment transform is a single composed [`Matrix4`]
+//!   (`effective_transform`) that `paint` pushes and
+//!   `apply_paint_transform` folds into coordinate mapping —
+//!   one matrix, two consumers, so paint and `localToGlobal` cannot drift.
+//!   Flutter splits the same two duties the same way.
 //! * `has_visual_overflow()` is a public post-layout query method
 //!   (Flutter keeps the equivalent flag private and only consults it
 //!   internally for clip-decision branching).
-//! * `clip_behavior` is stored and surfaced via the diagnosticable
-//!   dump; **active clipping awaits the layer-level clip integration
-//!   that lands in Wave 3b** (alongside `RenderRepaintBoundary`).
-//!   The default `Clip::None` matches the no-clip behaviour exactly,
-//!   so configurations that need clipping must wait or opt into the
-//!   in-progress wiring. This is documented intentionally — same
-//!   defer pattern as Wave 3a's `RenderClipPath::contains`.
 //!
 //! # Divergence found and fixed (widget-parity port, `parity/fitted_box_test.rs`)
 //!
@@ -58,6 +50,24 @@
 //!    be anything but zero); it is now live for any crop under a
 //!    non-degenerate alignment, including the default `CENTER`.
 //!
+//! # Clipping
+//!
+//! `paint` clips to this box when the fit cropped the source, matching
+//! Flutter's `_hasVisualOverflow && clipBehavior != Clip.none` branch. This
+//! module used to record active clipping as deferred, "awaiting the
+//! layer-level clip integration"; that had gone stale — the machinery
+//! (`PaintCx::with_clip_rect`, already used by `RenderClip` and
+//! `RenderPhysicalModel`) was in place.
+//!
+//! What genuinely blocked it was **ordering**, and it is why `paint` pushes
+//! the fit transform itself rather than leaving it to `paint_transform`: the
+//! paint walk emits a node's `paint_transform` layer *before* replaying the
+//! fragment ops that node's `paint` recorded, so a clip opened in `paint`
+//! would land inside the transform — clipping a rectangle stated in this
+//! box's coordinates against the child's scaled ones. Pushing both from
+//! `paint` puts them the right way round; `apply_paint_transform` then keeps
+//! coordinate mapping working without re-emitting the layer.
+//!
 //! Verified at both layers: `flui-types`' own unit tests pin every
 //! `BoxFit::apply` variant against oracle-computed `(source, destination)`
 //! pairs; this crate's `tests/render_object_harness.rs` drives
@@ -68,7 +78,7 @@
 
 use flui_tree::Single;
 use flui_types::{
-    Alignment, Matrix4, Offset, Size,
+    Alignment, Matrix4, Offset, Point, Rect, Size,
     geometry::px,
     layout::{BoxFit, FittedSizes},
     painting::Clip,
@@ -467,26 +477,79 @@ impl RenderBox for RenderFittedBox {
         ctx.with_transform(transform, |ctx| ctx.hit_test_child(0, Offset::new(tx, ty)))
     }
 
-    // The `paint_transform` override is the whole point of RenderFittedBox:
-    // the pipeline reads it through `&dyn RenderObject<BoxProtocol>` via the
-    // blanket impl forwarding here.
-    //
-    // Returns the composed translate-then-scale matrix the pipeline applies via
-    // its `TransformLayer` wrapper. Layout caches the scale factors and
-    // alignment offset, so this method is a pure read and does not need the
-    // driver-supplied `size`.
-    fn paint_transform(&self, _size: Size) -> Option<Matrix4> {
+    /// Paints the child through the fit transform, clipped to this box when
+    /// the fit cropped the source.
+    ///
+    /// Flutter's `RenderFittedBox.paint` wraps the transformed child paint in
+    /// `pushClipRect` when `_hasVisualOverflow && clipBehavior != Clip.none`,
+    /// so the composited chain reads clip-outside-transform
+    /// (`[…, ClipRectLayer, TransformLayer, …]`).
+    ///
+    /// **The order is why this pushes the transform itself instead of leaving
+    /// it to `paint_transform`.** The paint walk emits a node's
+    /// `paint_transform` layer *before* replaying the fragment ops that
+    /// node's `paint` recorded, so a clip opened here would land *inside* the
+    /// transform — clipping a rectangle stated in this box's coordinates
+    /// against the child's scaled ones. Pushing both from `paint`, in this
+    /// order, is what puts them the right way round.
+    ///
+    /// `paint_transform` is retained for coordinate mapping (`transform_to`
+    /// and the `localToGlobal` family read it), which is a separate concern
+    /// from layer emission — Flutter likewise keeps `applyPaintTransform`
+    /// alongside `paint`.
+    fn paint(&self, ctx: &mut flui_rendering::context::PaintCx<'_, Single>) {
         if !self.has_child {
-            return None;
+            return;
         }
-        if self.scale_x == 1.0
-            && self.scale_y == 1.0
-            && self.align_offset == Offset::ZERO
-            && self.source_offset == Offset::ZERO
-        {
-            return None;
+
+        let size = ctx.size();
+        // A collapsed box (or a collapsed child) has nothing to show, and the
+        // fit transform would be degenerate — Flutter's
+        // `if (size.isEmpty || child.size.isEmpty) return;`.
+        if size.width.get() <= 0.0 || size.height.get() <= 0.0 {
+            return;
         }
-        Some(self.effective_transform())
+
+        let transform = self.effective_transform();
+        let paint_transformed_child = |ctx: &mut flui_rendering::context::PaintCx<'_, Single>| {
+            // Not a redundant closure: `paint_child` is inherent on PaintCx for
+            // both `Exact<1>` and `Variable`, so the bare path is ambiguous
+            // (E0034) and the lint's suggested rewrite does not compile.
+            #[allow(clippy::redundant_closure_for_method_calls)]
+            ctx.with_transform(transform, |ctx| ctx.paint_child());
+        };
+
+        if self.has_visual_overflow && self.clip_behavior != Clip::None {
+            let bounds = Rect::from_origin_size(Point::ZERO, size);
+            ctx.with_clip_rect(bounds, self.clip_behavior, paint_transformed_child);
+        } else {
+            paint_transformed_child(ctx);
+        }
+    }
+
+    /// Folds the fit transform into a child-to-parent coordinate mapping.
+    ///
+    /// Deliberately overridden instead of leaving the default, which derives
+    /// the same thing from `paint_transform`. `paint` above emits the
+    /// transform layer itself, so `paint_transform` must stay `None` or the
+    /// paint walk would push a *second* transform around the one `paint`
+    /// already opened — applying the fit twice. Mapping still needs the
+    /// matrix, so it is supplied here.
+    ///
+    /// Flutter splits the same two duties the same way: `RenderFittedBox`
+    /// overrides `paint` and `applyPaintTransform` separately, each
+    /// multiplying in `_transform` for its own purpose.
+    fn apply_paint_transform(
+        &self,
+        _child: usize,
+        child_offset: Offset,
+        _size: Size,
+        transform: &mut Matrix4,
+    ) {
+        if self.has_child {
+            *transform *= self.effective_transform();
+        }
+        *transform *= Matrix4::translation(child_offset.dx.0, child_offset.dy.0, 0.0);
     }
 }
 
@@ -546,9 +609,18 @@ mod tests {
         assert_eq!(RenderFittedBox::align_axis(1.0, 100.0), 100.0);
     }
 
-    /// Transform symmetry: `paint_transform` IS `effective_transform`,
-    /// and the inverse maps a visual point back to the child-local
-    /// point — paint and hit-test cannot disagree.
+    /// Transform symmetry: every consumer of the fit transform reads the
+    /// SAME `effective_transform`, and its inverse maps a visual point back
+    /// to the child-local point — paint, coordinate mapping, and hit-test
+    /// cannot disagree.
+    ///
+    /// Asserted through `apply_paint_transform` rather than `paint_transform`
+    /// because `paint` now emits the transform layer itself (so the box can
+    /// open its clip *outside* that layer). `paint_transform` must therefore
+    /// stay at its `None` default — a `Some` there would make the paint walk
+    /// push a second transform around the one `paint` opened, applying the fit
+    /// twice — and that absence is asserted here so the two cannot drift back
+    /// into double-application.
     #[test]
     fn paint_and_hit_test_share_one_transform() {
         let node = RenderFittedBox {
@@ -560,9 +632,17 @@ mod tests {
         };
 
         assert_eq!(
-            node.paint_transform(Size::ZERO),
-            Some(node.effective_transform()),
-            "paint must hand the pipeline the SAME matrix hit-test inverts",
+            RenderBox::paint_transform(&node, Size::ZERO),
+            None,
+            "paint emits the transform layer itself; a Some here would double it",
+        );
+
+        let mut mapped = Matrix4::IDENTITY;
+        node.apply_paint_transform(0, Offset::ZERO, Size::ZERO, &mut mapped);
+        assert_eq!(
+            mapped,
+            node.effective_transform(),
+            "coordinate mapping must fold in the SAME matrix hit-test inverts",
         );
 
         let inverse = node

--- a/crates/flui-widgets/tests/parity/fitted_box_test.rs
+++ b/crates/flui-widgets/tests/parity/fitted_box_test.rs
@@ -535,3 +535,105 @@ fn fitted_box_with_zero_size_child_does_not_throw() {
     let id = laid.find_by_render_type("RenderFittedBox");
     assert_eq!(laid.size(id), crate::common::size(0.0, 0.0));
 }
+
+/// A cropping fit under a non-`None` clip composites a clip layer, and
+/// composites it **outside** the fit transform.
+///
+/// Flutter parity: `fitted_box_test.dart` `'FittedBox layers - cover -
+/// horizontal'` / `'- vertical'` (3.44.0), whose `getLayers()` walk reads
+/// `[TransformLayer, ClipRectLayer, TransformLayer, OffsetLayer]` — the
+/// leading `TransformLayer` is upstream's render-view root, so the
+/// `FittedBox`-attributable part is `ClipRectLayer` wrapping `TransformLayer`.
+/// `RenderFittedBox.paint` produces that by wrapping the transformed child
+/// paint in `pushClipRect` when `_hasVisualOverflow && clipBehavior !=
+/// Clip.none`.
+///
+/// The absolute chain does not port: FLUI's composited root is an `Offset`
+/// layer, not a `Transform`, so the two frameworks differ by one layer before
+/// the subject is involved. The *order* is the contract, and it is what this
+/// asserts — a clip nested inside the transform would be stated in this box's
+/// coordinates but applied against the child's scaled ones, clipping the wrong
+/// region.
+#[test]
+fn a_cropping_fit_clips_outside_the_transform() {
+    let mut laid = harness::pump_widget(
+        Center::new().child(
+            SizedBox::new(100.0, 10.0).child(
+                FittedBox::new()
+                    .fit(BoxFit::Cover)
+                    .clip(Clip::HardEdge)
+                    .child(SizedBox::new(10.0, 50.0)),
+            ),
+        ),
+        harness::screen(),
+    );
+    laid.pump();
+
+    let kinds = laid.layer_kinds();
+    let clip_at = kinds.iter().position(|k| *k == "ClipRect");
+    let transform_at = kinds.iter().position(|k| *k == "Transform");
+
+    let clip_at = clip_at.unwrap_or_else(|| {
+        panic!("BoxFit::Cover crops the source, so Clip::HardEdge must composite a clip layer; got {kinds:?}")
+    });
+    let transform_at = transform_at
+        .unwrap_or_else(|| panic!("the fit transform must still be composited; got {kinds:?}"));
+    assert!(
+        clip_at < transform_at,
+        "the clip must wrap the transform, not sit inside it — a clip stated in \
+         this box's coordinates would otherwise be applied against the child's \
+         scaled ones; got {kinds:?}"
+    );
+}
+
+/// The same fit with clipping switched off composites no clip layer, and a
+/// fit that does not crop composites none either.
+///
+/// Flutter parity: `fitted_box_test.dart` `'FittedBox layers - contain'`
+/// (3.44.0) reads `[TransformLayer, TransformLayer, OffsetLayer]` — no
+/// `ClipRectLayer`, because `BoxFit.contain` never crops, so
+/// `_hasVisualOverflow` is false whatever `clipBehavior` says.
+///
+/// Both legs matter: `Clip::None` guards the behavior half of the condition
+/// and a non-cropping fit guards the overflow half, so neither alone can be
+/// dropped without the other silently passing.
+#[test]
+fn no_clip_layer_without_both_a_crop_and_a_clip_behavior() {
+    let mut cropping_but_unclipped = harness::pump_widget(
+        Center::new().child(
+            SizedBox::new(100.0, 10.0).child(
+                FittedBox::new()
+                    .fit(BoxFit::Cover)
+                    .clip(Clip::None)
+                    .child(SizedBox::new(10.0, 50.0)),
+            ),
+        ),
+        harness::screen(),
+    );
+    cropping_but_unclipped.pump();
+    assert!(
+        !cropping_but_unclipped.layer_kinds().contains(&"ClipRect"),
+        "Clip::None must not composite a clip layer even when the fit crops; \
+         got {:?}",
+        cropping_but_unclipped.layer_kinds()
+    );
+
+    let mut clipped_but_not_cropping = harness::pump_widget(
+        Center::new().child(
+            SizedBox::new(100.0, 10.0).child(
+                FittedBox::new()
+                    .fit(BoxFit::Contain)
+                    .clip(Clip::HardEdge)
+                    .child(SizedBox::new(50.0, 50.0)),
+            ),
+        ),
+        harness::screen(),
+    );
+    clipped_but_not_cropping.pump();
+    assert!(
+        !clipped_but_not_cropping.layer_kinds().contains(&"ClipRect"),
+        "BoxFit::Contain never crops, so there is nothing to clip regardless of \
+         clip behavior; got {:?}",
+        clipped_but_not_cropping.layer_kinds()
+    );
+}

--- a/crates/flui-widgets/tests/parity/fitted_box_test.rs
+++ b/crates/flui-widgets/tests/parity/fitted_box_test.rs
@@ -637,3 +637,74 @@ fn no_clip_layer_without_both_a_crop_and_a_clip_behavior() {
         clipped_but_not_cropping.layer_kinds()
     );
 }
+
+/// A zero-area child is neither painted nor hit-testable, even when the box
+/// itself has a real size.
+///
+/// Flutter parity: `RenderFittedBox.paint` opens with
+/// `if (child == null || size.isEmpty || child!.size.isEmpty) return;`, and
+/// `hitTestChildren` carries the matching
+/// `if (size.isEmpty || (child?.size.isEmpty ?? false)) return false;`
+/// (`rendering/proxy_box.dart`, 3.44.0).
+///
+/// The child clause is the one under test, so the box is given a real 200×200
+/// size — with an empty box too, the box's own guard would pass this
+/// vacuously. A zero-area child is not inert: it still runs its own `paint`,
+/// and a fit transform onto or from a zero extent is degenerate, so letting it
+/// through paints content at an undefined scale.
+///
+/// Red-check, stated precisely because the two halves are not symmetric:
+/// dropping `self.child_is_empty` from the **paint** guard fails the layer
+/// assertion (composited `["Offset", "Transform"]` — the fit transform opened
+/// around a child with no area). Dropping it from the **hit-test** guard
+/// changes nothing measurable here: a zero-area child fails its own bounds
+/// check anyway, so the tap misses either way. That guard is kept for oracle
+/// parity and as a cheap early-out, not because this test discriminates it —
+/// saying so here rather than letting the tap assertion imply otherwise.
+#[test]
+fn a_zero_area_child_neither_paints_nor_hit_tests() {
+    let taps = Arc::new(AtomicUsize::new(0));
+    let in_cb = Arc::clone(&taps);
+
+    let mut laid = harness::pump_widget(
+        Center::new().child(
+            SizedBox::square(200.0).child(
+                FittedBox::new().child(
+                    SizedBox::shrink().child(
+                        GestureDetector::new()
+                            .behavior(HitTestBehavior::Opaque)
+                            .on_tap(move || {
+                                in_cb.fetch_add(1, Ordering::SeqCst);
+                            }),
+                    ),
+                ),
+            ),
+        ),
+        harness::screen(),
+    );
+
+    let fitted = laid.find_by_render_type("RenderFittedBox");
+    assert_eq!(
+        laid.size(fitted),
+        crate::common::size(200.0, 200.0),
+        "the box itself must have a real size, so this exercises the child \
+         clause rather than the empty-box one"
+    );
+
+    laid.pump();
+    assert!(
+        !laid.layer_kinds().contains(&"Transform"),
+        "a zero-area child must not be painted through the fit transform; \
+         composited {:?}",
+        laid.layer_kinds()
+    );
+
+    let centre = box_point_to_absolute(&laid, fitted, offset(100.0, 100.0));
+    laid.dispatch_pointer_down(centre.dx.get(), centre.dy.get());
+    laid.dispatch_pointer_up(centre.dx.get(), centre.dy.get());
+    assert_eq!(
+        taps.load(Ordering::SeqCst),
+        0,
+        "a child that cannot be painted must not be reachable by a pointer"
+    );
+}


### PR DESCRIPTION
## The bug

`RenderFittedBox` stored `clip_behavior`, reported it in diagnostics, and **never clipped**. `BoxFit::Cover` with `Clip::HardEdge` over an overflowing child composited no clip layer at all — the cropped-away part of the child was painted outside the box.

The module recorded the reason as *"active clipping awaits the layer-level clip integration"*. That had gone stale. Measured:

```
no clip    -> ["Offset", "Picture"]
ClipRect   -> ["Offset", "ClipRect", "Picture"]
```

The machinery (`PaintCx::with_clip_rect`) is in place, and `RenderClip` / `RenderPhysicalModel` already use it.

## What actually blocked it: ordering

The paint walk emits a node's `paint_transform` layer **before** replaying the fragment ops that node's `paint` recorded. So a clip opened in `paint` landed *inside* the transform — clipping a rectangle stated in this box's coordinates against the child's **scaled** ones.

So `paint` now pushes the fit transform itself, then the clip wraps it — matching the oracle's chain (`fitted_box_test.dart`'s `getLayers()` reads `[…, ClipRectLayer, TransformLayer, OffsetLayer]`).

`paint_transform` therefore has to stay at its `None` default, and the coordinate mapping it used to feed moves to an explicit `apply_paint_transform` override. Flutter splits the same two duties the same way: `RenderFittedBox` overrides `paint` and `applyPaintTransform` separately, each multiplying in `_transform` for its own purpose.

## The split is not cosmetic

The first version of this change left `paint_transform` in place, so the walk pushed a transform **and** `paint` pushed another — the fit applied twice:

```
["Offset", "Transform", "ClipRect", "Transform"]
```

**Every pre-existing FittedBox test passed anyway** — 12 parity + 18 harness. Hit-testing takes its own path, and the geometry tests read the matrix directly rather than the composited output. The new clip-ordering test caught it on its first run. This is exactly the blind spot the layer inspection in #474 was built for.

## Tests

Both red-checked.

- **`a_cropping_fit_clips_outside_the_transform`** — asserts the clip layer exists *and* precedes the transform. Absolute layer counts do not port (upstream's composited root is a `TransformLayer`, FLUI's an `Offset` layer), so it asserts the order, which is the actual contract.
- **`no_clip_layer_without_both_a_crop_and_a_clip_behavior`** — `Clip::None` under a cropping fit, and `BoxFit::Contain` under `Clip::HardEdge`. Both legs are needed: each guards one half of the condition, so neither can be dropped without the other passing silently.

`paint_and_hit_test_share_one_transform` now asserts the invariant through `apply_paint_transform`, and additionally pins `paint_transform == None` so the double-application cannot come back.

## Verification

| gate | result |
|---|---|
| `nextest --workspace --exclude flui-platform` | **8166 passed** |
| doctests | **630 passed** |
| clippy / fmt / doc-strict / port-check | clean |
| red-check (drop the clip branch) | clip-order test fails |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117t1jX2FFcCzP3YBLoQB94