### PR TITLE
perf(objects): paint a pure-translation Transform without a compositing layer

### DIFF
--- a/crates/flui-geometry/src/matrix4.rs
+++ b/crates/flui-geometry/src/matrix4.rs
@@ -356,6 +356,41 @@ impl Matrix4 {
         true
     }
 
+    /// This matrix as a pure 2D translation `(dx, dy)`, or `None` if it is
+    /// anything else.
+    ///
+    /// The port of Flutter's `MatrixUtils.getAsTranslation`
+    /// (`painting/matrix_utils.dart`), and deliberately **exact** rather than
+    /// epsilon-tolerant, unlike [`is_translation_only`](Self::is_translation_only):
+    /// the caller's next move is to drop the matrix entirely and shift the
+    /// child by `(dx, dy)` instead, so a matrix that is merely *near* a
+    /// translation must take the general path. Accepting it would silently
+    /// discard the residual scale or skew.
+    ///
+    /// A translation along z also returns `None` — the result is a 2D offset,
+    /// and there is no honest way to express a z component in one.
+    #[must_use]
+    pub fn as_translation(&self) -> Option<(f32, f32)> {
+        // Column-major: columns 0..2 must be the identity basis, the
+        // perspective row zero, and the translation column's z entry zero.
+        let is_identity_basis = self.m[0] == 1.0
+            && self.m[1] == 0.0
+            && self.m[2] == 0.0
+            && self.m[3] == 0.0
+            && self.m[4] == 0.0
+            && self.m[5] == 1.0
+            && self.m[6] == 0.0
+            && self.m[7] == 0.0
+            && self.m[8] == 0.0
+            && self.m[9] == 0.0
+            && self.m[10] == 1.0
+            && self.m[11] == 0.0
+            && self.m[14] == 0.0
+            && self.m[15] == 1.0;
+
+        is_identity_basis.then(|| (self.m[12], self.m[13]))
+    }
+
     /// Returns whether this matrix represents only a translation, using
     /// `f32::EPSILON` as the comparison tolerance.
     #[inline]

--- a/crates/flui-objects/src/layout/transform.rs
+++ b/crates/flui-objects/src/layout/transform.rs
@@ -1,6 +1,7 @@
 //! RenderTransform - applies a transformation matrix to a single child.
 
 use flui_tree::Single;
+use flui_types::geometry::px;
 use flui_types::{Alignment, Matrix4, Offset, Size};
 
 use flui_rendering::{
@@ -260,12 +261,54 @@ impl RenderBox for RenderTransform {
         determinant == 0.0 || !determinant.is_finite()
     }
 
-    // The whole point of RenderTransform: the pipeline reads these through
-    // `&dyn RenderObject<BoxProtocol>`; the blanket impl forwards here.
-    fn paint_transform(&self, size: Size) -> Option<Matrix4> {
-        // Return the effective transform so the paint walk can apply it.
-        // `size` is the laid-out size from RenderState (origin pivot).
-        Some(self.effective_transform(size))
+    /// Paints the child through the effective transform — or, when that
+    /// transform is a pure translation, at a plain offset with no layer at all.
+    ///
+    /// Flutter's `RenderTransform.paint` takes the same fork on
+    /// `MatrixUtils.getAsTranslation` (`rendering/proxy_box.dart`): a matrix
+    /// that only translates is applied as `super.paint(context, offset +
+    /// childOffset)`, and the node's layer is cleared. A compositing layer per
+    /// `Transform` is not free, and translation is the common case —
+    /// `Transform.translate`, and every `SlideTransition` built on it, paid for
+    /// one on every frame.
+    ///
+    /// The transform is pushed here rather than reported through
+    /// `paint_transform`, which must stay `None`: the paint walk emits a
+    /// node's `paint_transform` layer *before* replaying the fragments its
+    /// `paint` recorded, so reporting it as well would wrap this method's own
+    /// output in a second, identical transform. Coordinate mapping keeps the
+    /// matrix through `apply_paint_transform` below — the same split Flutter
+    /// makes between `paint` and `applyPaintTransform`.
+    fn paint(&self, ctx: &mut flui_rendering::context::PaintCx<'_, Single>) {
+        if !self.has_child {
+            return;
+        }
+
+        let transform = self.effective_transform(ctx.size());
+        if let Some((dx, dy)) = transform.as_translation() {
+            ctx.paint_child_at(Offset::new(px(dx), px(dy)));
+        } else {
+            // Not a redundant closure: `paint_child` is inherent on PaintCx for
+            // both `Exact<1>` and `Variable`, so the bare path is ambiguous
+            // (E0034) and the lint's suggested rewrite does not compile.
+            #[allow(clippy::redundant_closure_for_method_calls)]
+            ctx.with_transform(transform, |ctx| ctx.paint_child());
+        }
+    }
+
+    /// Folds the transform into a child-to-parent coordinate mapping.
+    ///
+    /// Overridden because the default derives this from `paint_transform`,
+    /// which `paint` above requires to stay `None`.
+    fn apply_paint_transform(
+        &self,
+        _child: usize,
+        child_offset: Offset,
+        size: Size,
+        transform: &mut Matrix4,
+    ) {
+        *transform *= self.effective_transform(size);
+        *transform *= Matrix4::translation(child_offset.dx.0, child_offset.dy.0, 0.0);
     }
 
     fn hit_test_transform(&self, size: Size) -> Option<Matrix4> {
@@ -300,19 +343,37 @@ mod tests {
         assert!(!RenderTransform::identity().skip_paint());
     }
 
-    /// Transform symmetry: `paint_transform` hands the pipeline the
-    /// SAME matrix hit-test inverts (`effective_transform` both ways),
-    /// and the inverse maps a visual point to the child-local point.
+    /// Transform symmetry: paint, coordinate mapping, and hit-test all read
+    /// the SAME `effective_transform`, and its inverse maps a visual point to
+    /// the child-local point.
+    ///
+    /// Asserted through `apply_paint_transform` rather than `paint_transform`
+    /// because `paint` emits the transform layer itself (so a pure translation
+    /// can skip the layer entirely). `paint_transform` must therefore stay at
+    /// its `None` default — a `Some` there would make the paint walk push a
+    /// second transform around the one `paint` already opened, applying it
+    /// twice — and that absence is pinned here so the two cannot drift back
+    /// into double-application.
     #[test]
     fn paint_and_hit_test_share_one_transform() {
         let mut node = RenderTransform::scale(2.0, 2.0);
         node.has_child = true;
         // size ZERO ⇒ CENTER-alignment origin is (0,0), so the effective
-        // matrix is the pure scale; both hooks return that same matrix.
+        // matrix is the pure scale.
         let size = Size::ZERO;
+
         assert_eq!(
-            node.paint_transform(size),
-            Some(node.effective_transform(size))
+            RenderBox::paint_transform(&node, size),
+            None,
+            "paint emits the transform layer itself; a Some here would double it",
+        );
+
+        let mut mapped = Matrix4::IDENTITY;
+        node.apply_paint_transform(0, Offset::ZERO, size, &mut mapped);
+        assert_eq!(
+            mapped,
+            node.effective_transform(size),
+            "coordinate mapping must fold in the SAME matrix hit-test inverts",
         );
 
         let inverse = node

--- a/crates/flui-rendering/tests/pipeline_scenarios.rs
+++ b/crates/flui-rendering/tests/pipeline_scenarios.rs
@@ -150,14 +150,26 @@ fn mixed_flex_padding_transform_clip_frame() {
     let tree = run.layer_tree().expect("frame paints");
     let owner = run.owner();
     let scaler_node = owner.render_tree().get(scaler).expect("scaler node");
-    // The production paint walk feeds the laid-out size (from RenderState)
-    // into paint_transform so the alignment origin resolves; mirror that
-    // here instead of reading a cached object field.
+    // The laid-out size (from RenderState) resolves the alignment origin, so
+    // feed it in rather than reading a cached object field.
+    //
+    // Read through `apply_paint_transform` rather than `paint_transform`:
+    // `RenderTransform` emits its layer from `paint` (so a pure translation can
+    // skip the layer entirely), which requires `paint_transform` to stay
+    // `None`. `apply_paint_transform` with a zero child offset yields exactly
+    // the same effective matrix — the one this test then expects to find
+    // conjugated in the composited layer.
     let scaler_size = scaler_node.size().unwrap_or(flui_types::Size::ZERO);
-    let local = scaler_node
-        .box_render_object()
-        .paint_transform(scaler_size)
-        .expect("scale(2,2) reports a paint transform");
+    let local = {
+        let mut m = Matrix4::IDENTITY;
+        scaler_node.box_render_object().apply_paint_transform(
+            0,
+            flui_types::Offset::ZERO,
+            scaler_size,
+            &mut m,
+        );
+        m
+    };
     let expected =
         Matrix4::translation(50.0, 0.0, 0.0) * local * Matrix4::translation(-50.0, 0.0, 0.0);
     assert_ne!(

--- a/crates/flui-widgets/tests/parity/transform_test.rs
+++ b/crates/flui-widgets/tests/parity/transform_test.rs
@@ -884,3 +884,57 @@ fn a_non_finite_transform_paints_no_child_content() {
         );
     }
 }
+
+/// A pure translation composites **no** transform layer — the child is painted
+/// at an offset instead.
+///
+/// Flutter parity: `RenderTransform.paint` forks on
+/// `MatrixUtils.getAsTranslation` (`rendering/proxy_box.dart`, 3.44.0): a
+/// matrix that only translates is applied as `super.paint(context, offset +
+/// childOffset)` with the node's layer cleared, so upstream's
+/// `'Transform.translate'` asserts `layers.length == 1` — the root alone.
+///
+/// A compositing layer per `Transform` is not free, and translation is the
+/// common case: `Transform.translate`, and every `SlideTransition` built on
+/// it, used to pay for one on every frame.
+///
+/// The scaled leg is what makes this discriminating — without it, a `paint`
+/// that never pushed a transform at all would pass.
+#[test]
+fn a_pure_translation_composites_no_transform_layer() {
+    for (label, matrix) in [
+        ("identity", Matrix4::IDENTITY),
+        ("translate(10, 20)", Matrix4::translation(10.0, 20.0, 0.0)),
+    ] {
+        let mut laid = pump_widget(
+            Transform::new(matrix)
+                .child(SizedBox::new(50.0, 50.0).child(ColoredBox::new(Color::rgb(10, 20, 30)))),
+            screen(),
+        );
+        laid.pump();
+
+        let kinds = laid.layer_kinds();
+        assert!(
+            !kinds.contains(&"Transform"),
+            "{label} only translates, so the child should be painted at an \
+             offset rather than through a compositing layer; got {kinds:?}"
+        );
+        assert!(
+            kinds.contains(&"Picture"),
+            "{label} must still paint its child; got {kinds:?}"
+        );
+    }
+
+    let mut scaled = pump_widget(
+        Transform::new(Matrix4::scaling(2.0, 2.0, 1.0))
+            .child(SizedBox::new(50.0, 50.0).child(ColoredBox::new(Color::rgb(10, 20, 30)))),
+        screen(),
+    );
+    scaled.pump();
+    assert!(
+        scaled.layer_kinds().contains(&"Transform"),
+        "a scale cannot be expressed as an offset and must still composite a \
+         transform layer; got {:?}",
+        scaled.layer_kinds()
+    );
+}


### PR DESCRIPTION
## What

`RenderTransform` composited a `TransformLayer` for **every** matrix — including the identity. Measured before this change:

```
identity            -> ["Offset", "Transform", "Picture"]
translate(10, 20)   -> ["Offset", "Transform", "Picture"]
scale(2, 2)         -> ["Offset", "Transform", "Picture"]
```

Flutter's `RenderTransform.paint` forks on `MatrixUtils.getAsTranslation` (`rendering/proxy_box.dart`, 3.44.0): a matrix that only translates is applied as `super.paint(context, offset + childOffset)` with the node's layer cleared — which is why upstream's `'Transform.translate'` asserts `layers.length == 1`.

A compositing layer per `Transform` is not free, and translation is the common case: `Transform.translate`, and every `SlideTransition` built on it, paid for one on every frame.

## `Matrix4::as_translation`

The port of `MatrixUtils.getAsTranslation`, and deliberately **exact** rather than epsilon-tolerant — unlike the neighbouring `is_translation_only`, which could not be reused:

- The caller's next move is to **discard the matrix** and shift the child instead, so a matrix that is merely *near* a translation must take the general path rather than silently drop the residual scale or skew.
- A z-translation returns `None`: the result is a 2D offset, and there is no honest way to express a z component in one. `is_translation_only` omits that check.

## The `paint_transform` split

Emitting the layer from `paint` means `paint_transform` must stay `None`, or the paint walk would wrap this method's output in a second identical transform. Coordinate mapping moves to an explicit `apply_paint_transform`. Same split Flutter makes between `paint` and `applyPaintTransform`, and the same one `RenderFittedBox` adopted in #476.

## Two tests changed — mechanism, not meaning

Neither was weakened; both read the transform through a path that no longer carries it:

- `paint_and_hit_test_share_one_transform` asserts the shared-matrix invariant through `apply_paint_transform`, and **additionally pins `paint_transform == None`** so double-application cannot come back.
- `pipeline_scenarios::mixed_flex_padding_transform_clip_frame` read the matrix it expects to find conjugated in the layer tree via `paint_transform`; it now reads the identical value via `apply_paint_transform` with a zero child offset.

## Verification

Red-checked: disabling the translation fork fails `a_pure_translation_composites_no_transform_layer`, reporting the composited `["Offset", "Transform", "Picture"]`. Its **scaled leg** is what makes it discriminating — without it, a `paint` that never pushed a transform at all would pass.

| gate | result |
|---|---|
| `nextest --workspace --exclude flui-platform` | **8168 passed** |
| doctests | **630 passed** |
| clippy / fmt / doc-strict / port-check | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117t1jX2FFcCzP3YBLoQB94