### PR TITLE
test(widgets): port 'Composited transform offset' under FLUI's layer convention

### DIFF
--- a/crates/flui-widgets/tests/parity/transform_test.rs
+++ b/crates/flui-widgets/tests/parity/transform_test.rs
@@ -5,16 +5,16 @@
 //! - `packages/flutter/test/widgets/basic_test.dart` (tag `3.44.0`), the
 //!   `'FractionalTranslation'` group (4 cases).
 //!
-//! Ported cases (8 upstream names, 10 Rust tests — hit-testing under
+//! Ported cases (9 upstream names, 11 Rust tests — hit-testing under
 //! translation/scale/composition and the alignment+origin combination the
-//! render object's `compute_origin` fix addresses are the portable core. The
-//! `TransformLayer` assertions are still dropped, but the reason has split in
-//! two: `LaidOut::layer_kinds` / `LaidOut::layer_tree` now report composited
-//! output, so layer *counts* are measurable — and measuring them exposed a
-//! real paint bug, recorded under the zero-determinant case below. What
-//! remains out of reach is the layer *matrix*: nothing surfaces a composited
-//! layer's own transform, and FLUI has no golden-file harness either, the
-//! separate reason `clip_test.rs` drops `paints..save()..clipRect()`
+//! render object's `compute_origin` fix addresses are the portable core.
+//! Composited output is fully reachable now: `LaidOut::layer_kinds` reports
+//! layer *counts* — and measuring them exposed a real paint bug, recorded
+//! under the zero-determinant case below — while `LaidOut::layer_tree`
+//! reaches `TransformLayer::transform` for layer *matrices*. The
+//! `TransformLayer` assertions that remain dropped are dropped for their own
+//! reasons, named in "Out of scope"; FLUI still has no golden-file harness,
+//! the separate reason `clip_test.rs` drops `paints..save()..clipRect()`
 //! assertions). Every case below that taps a
 //! target starts from a fresh `AtomicBool::new(false)`, so upstream's pre-tap
 //! `expect(didReceiveTap`/`pointerDown, isFalse)` — asserting only that the
@@ -54,6 +54,13 @@
 //!   [`fractional_translation_hit_test_entirely_inside_the_bounding_box`],
 //!   [`fractional_translation_hit_test_partially_inside_the_bounding_box`],
 //!   [`fractional_translation_hit_test_completely_outside_the_bounding_box`].
+//! - `'Composited transform offset'` — the composited transform layer's matrix
+//!   folds in the alignment pivot, not just the raw scale. Upstream's raw
+//!   translation does not port (its layers are parent-relative where FLUI's
+//!   carry global geometry); the expectation is re-derived from the widget
+//!   geometry instead, and the test's doc records the measurement and the
+//!   arithmetic that pin the difference —
+//!   [`the_composited_transform_layer_folds_in_the_alignment_pivot`].
 //! - `'Transform with nan/inf/-inf value short-circuits rendering'` (3 upstream
 //!   cases, one Rust test covering all three matrix shapes) — a non-finite
 //!   determinant must short-circuit painting. Previously listed out of scope,
@@ -1042,9 +1049,12 @@ fn the_composited_transform_layer_folds_in_the_alignment_pivot() {
         matrix.m[12],
         matrix.m[13],
     );
+    // Both axes: the widget asks for a uniform scale, and asserting only `m[0]`
+    // would accept a matrix that scaled x correctly and y not at all.
     assert!(
-        (matrix.m[0] - SCALE).abs() < TOLERANCE,
-        "and still carry the scale itself; got {}",
-        matrix.m[0]
+        (matrix.m[0] - SCALE).abs() < TOLERANCE && (matrix.m[5] - SCALE).abs() < TOLERANCE,
+        "and still carry the uniform scale itself; got ({}, {})",
+        matrix.m[0],
+        matrix.m[5],
     );
 }

--- a/crates/flui-widgets/tests/parity/transform_test.rs
+++ b/crates/flui-widgets/tests/parity/transform_test.rs
@@ -144,7 +144,7 @@
 //!   (no `AlignmentDirectional`/`TextDirection` resolution path exists on
 //!   `Transform` at all — its `alignment` field is a bare `Alignment`, never
 //!   an `AlignmentGeometry`).
-//! - `'Composited transform offset'`, `'Transform.rotate'` (the layer-matrix
+//! - `'Transform.rotate'` (the layer-matrix
 //!   half), `'applyPaintTransform of Transform in Padding'`, `'Transform.translate'`
 //!   (the layer-avoidance-optimization half), `'3D transform renders the same
 //!   with or without needsCompositing'`, `'Transform.rotate does not remove
@@ -155,11 +155,26 @@
 //!   filterQuality'`, `'Transform layers with filterQuality golden'` — all
 //!   `TransformLayer`/`ImageFilterLayer`/`matchesGoldenFile` assertions.
 //!
-//!   Layer *counts* are no longer harness-blocked (`LaidOut::layer_kinds`), so
-//!   what remains is named per case rather than blamed on the harness:
-//!   `Transform` has no `filterQuality` at all, so the five `ImageFilterLayer`
-//!   cases have nothing to assert against; the layer-matrix halves need a
-//!   composited layer's own transform, which nothing surfaces; and
+//!   Neither layer *counts* nor layer *matrices* are harness-blocked any
+//!   more — `LaidOut::layer_kinds` reports the former and `LaidOut::layer_tree`
+//!   reaches `TransformLayer::transform` for the latter, which is how
+//!   [`the_composited_transform_layer_folds_in_the_alignment_pivot`] ports
+//!   `'Composited transform offset'`. What remains is named per case:
+//!
+//!   The five `ImageFilterLayer` cases need more than a widget field.
+//!   `Transform` has no `filterQuality`, but the deeper gap is that
+//!   `flui_types::painting::ImageFilter` has no *geometric* matrix variant at
+//!   all (its `Matrix` variant is a 5×4 **colour** matrix); the oracle needs
+//!   `ui.ImageFilter.matrix(m, filterQuality)`, i.e. resampling through a
+//!   transform. Adding the field alone would emit a layer the engine cannot
+//!   honour — a stub that satisfies a layer-shape assertion and changes
+//!   nothing on screen.
+//!
+//!   The remaining layer-matrix halves state upstream's raw values, which are
+//!   parent-relative; FLUI's layers carry global geometry (measured — see the
+//!   ported case above). Porting each means re-deriving its expectation under
+//!   FLUI's convention, case by case, rather than copying a number.
+//!
 //!   `matchesGoldenFile` needs golden-image capture, which does not exist.
 //! - `"Transform.scale() does not accept all three ... to be non-null"`,
 //!   `"Transform.scale() needs at least one of ... to be non-null"` —
@@ -197,12 +212,13 @@
 
 use flui_geometry::Matrix4;
 use flui_rendering::hit_testing::HitTestBehavior;
+use flui_rendering::layer::Layer;
 use flui_types::geometry::px;
 use flui_types::{Alignment, Color, Offset};
 use flui_view::ViewExt;
 use flui_widgets::{
-    Center, ColoredBox, FractionalTranslation, GestureDetector, Positioned, SizedBox, Stack,
-    Transform,
+    Center, ClipRect, ColoredBox, FractionalTranslation, GestureDetector, Positioned,
+    RepaintBoundary, SizedBox, Stack, Transform,
 };
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -936,5 +952,99 @@ fn a_pure_translation_composites_no_transform_layer() {
         "a scale cannot be expressed as an offset and must still composite a \
          transform layer; got {:?}",
         scaled.layer_kinds()
+    );
+}
+
+/// The composited transform layer's matrix folds in the alignment pivot, not
+/// just the raw scale.
+///
+/// Flutter parity: `transform_test.dart` `'Composited transform offset'`
+/// (3.44.0). Upstream retains the `TransformLayer`s, expects two (the first
+/// being the render view's), and asserts the second carries translation
+/// `(100, 75)` — a `Matrix4.diagonal3Values(0.5, 0.5, 1)` over a 400×300 box
+/// under the default `CENTER` alignment.
+///
+/// **The number does not port, and the reason is a layer-space convention, not
+/// a defect.** Measured on this exact tree, FLUI's layers carry *global*
+/// geometry: the `ClipRect` layer's rect is `(200,150)..(600,450)` and the
+/// inner offset layer holds `(200,150)`, both absolute. Upstream's are
+/// parent-relative, so its `ClipRectLayer` absorbs the placement and the
+/// transform beneath it sees a zero paint offset — leaving only the pivot's
+/// contribution, `(100, 75)`. FLUI conjugates about the *global* pivot
+/// instead, so the same widget yields `(200, 150)`. Both compose to the same
+/// thing on screen; only the split between layers differs.
+///
+/// So this asserts the contract with an expectation derived from the widget
+/// geometry rather than copied from the oracle: the box sits at global
+/// `(200, 150)` and is 400×300, so its `CENTER` pivot is global `(400, 300)`,
+/// and a scale of `0.5` about that pivot translates by
+/// `pivot * (1 - scale) = (200, 150)`. Asserting the raw `0.5` scale alone
+/// would pass on a matrix that ignored the pivot entirely, which is the
+/// mistake this case exists to catch.
+///
+/// The red check makes the convention difference exact rather than argued:
+/// dropping the pivot from `RenderTransform::compute_origin` yields
+/// **`(100, 75)`** — upstream's own expected value. The two frameworks differ
+/// by precisely the global-origin conjugation term, which is what the layer
+/// geometry measured above says and what this arithmetic confirms
+/// independently.
+#[test]
+fn the_composited_transform_layer_folds_in_the_alignment_pivot() {
+    const SCALE: f32 = 0.5;
+
+    let mut laid =
+        pump_widget(
+            Center::new().child(SizedBox::new(400.0, 300.0).child(
+                ClipRect::new().child(
+                    Transform::new(Matrix4::scaling(SCALE, SCALE, 1.0)).child(
+                        RepaintBoundary::new().child(ColoredBox::new(Color::rgb(0, 255, 0))),
+                    ),
+                ),
+            )),
+            screen(),
+        );
+    laid.pump();
+
+    let tree = laid.layer_tree().expect("the frame composites a tree");
+    let mut matrices = Vec::new();
+    let mut stack = vec![tree.root().expect("composited root")];
+    while let Some(id) = stack.pop() {
+        if let Some(Layer::Transform(t)) = tree.get_layer(id) {
+            matrices.push(*t.transform());
+        }
+        if let Some(children) = tree.children(id) {
+            stack.extend(children.iter().copied());
+        }
+    }
+
+    assert_eq!(
+        matrices.len(),
+        1,
+        "exactly one transform layer — FLUI's composited root is an Offset \
+         layer, so unlike upstream there is no render-view transform to skip"
+    );
+    let matrix = matrices[0];
+
+    // Derived from the widget geometry, not read back from the render object:
+    // an 800×600 screen centres a 400×300 box at (200, 150), whose CENTER
+    // pivot is therefore global (400, 300).
+    let pivot_x = 200.0 + 400.0 / 2.0;
+    let pivot_y = 150.0 + 300.0 / 2.0;
+    let expected_x = pivot_x * (1.0 - SCALE);
+    let expected_y = pivot_y * (1.0 - SCALE);
+
+    const TOLERANCE: f32 = 1e-3;
+    assert!(
+        (matrix.m[12] - expected_x).abs() < TOLERANCE
+            && (matrix.m[13] - expected_y).abs() < TOLERANCE,
+        "the composited matrix must translate by pivot * (1 - scale) = \
+         ({expected_x}, {expected_y}); got ({}, {})",
+        matrix.m[12],
+        matrix.m[13],
+    );
+    assert!(
+        (matrix.m[0] - SCALE).abs() < TOLERANCE,
+        "and still carry the scale itself; got {}",
+        matrix.m[0]
     );
 }


### PR DESCRIPTION
## What

The layer-matrix half of `transform_test.dart` was recorded as out of scope because *"nothing surfaces a composited layer's own transform"*. That stopped being true when `LaidOut::layer_tree` landed (#474) — it reaches `TransformLayer::transform` directly. Another stale blocker.

## The number does not port, and that is a convention, not a defect

Upstream asserts the composited transform layer carries translation `(100, 75)` for a `0.5` scale over a 400×300 box. Measured on this exact tree, FLUI's layers carry **global** geometry:

```
cliprect    = (200,150)..(600,450)      ← absolute, not parent-relative
offsetlayer = (200,150)
transform translation = (200, 150)
```

Upstream's layers are parent-relative, so its `ClipRectLayer` absorbs the placement and the transform beneath it sees a **zero** paint offset — leaving only the pivot's contribution, `(100, 75)`. FLUI conjugates about the *global* pivot instead. Both compose to the same result on screen; only the split between layers differs.

So the test asserts the contract with an expectation **derived from the widget geometry** rather than copied from the oracle: an 800×600 screen centres the 400×300 box at `(200, 150)`, its `CENTER` pivot is global `(400, 300)`, and a `0.5` scale about that pivot translates by `pivot * (1 - scale)`.

## The red check settles it arithmetically

Dropping the pivot from `compute_origin` yields **`(100, 75)`** — upstream's own value:

```
the composited matrix must translate by pivot * (1 - scale) = (200, 150); got (100, 75)
```

The two frameworks differ by *precisely* the global-origin conjugation term. The measured layer geometry says it and this arithmetic confirms it independently.

Asserting the raw `0.5` scale alone would pass on a matrix that ignored the pivot entirely — which is the mistake this case exists to catch, so both are asserted.

## Out-of-scope list re-stated per case

No longer pointing at the harness. Notably, the five `ImageFilterLayer` cases need **more than the missing `Transform::filterQuality` field**: `flui_types::painting::ImageFilter` has no *geometric* matrix variant at all — its `Matrix` variant is a 5×4 **colour** matrix, while the oracle needs `ui.ImageFilter.matrix(m, filterQuality)`, i.e. resampling through a transform. Adding the field alone would emit a layer the engine cannot honour: a stub that satisfies a layer-shape assertion and changes nothing on screen.

## Verification

| gate | result |
|---|---|
| `nextest --workspace --exclude flui-platform` | **8170 passed** |
| clippy / fmt / doc-strict / port-check | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117t1jX2FFcCzP3YBLoQB94