### PR TITLE
feat(widgets): give AnimatedAlign animated width/height factors

### DIFF
--- a/crates/flui-widgets/src/animated/animated_align.rs
+++ b/crates/flui-widgets/src/animated/animated_align.rs
@@ -2,13 +2,15 @@
 
 use std::time::Duration;
 
+use flui_animation::Animation;
 use flui_animation::curve::{ArcCurve, Curve};
-use flui_animation::{Animatable, Animation};
 use flui_types::Alignment;
 use flui_view::prelude::{BuildContext, StatefulView};
 use flui_view::{BoxedView, BuildContextExt, IntoView, ViewExt, ViewState};
 
-use crate::animated::implicitly_animated::{DEFAULT_DURATION, ImplicitAnimation, default_curve};
+use crate::animated::implicitly_animated::{
+    DEFAULT_DURATION, ImplicitController, OptTween, default_curve,
+};
 use crate::animated::vsync_scope::VsyncScope;
 use crate::{Align, AnimatedBuilder};
 
@@ -22,17 +24,43 @@ use crate::{Align, AnimatedBuilder};
 #[derive(Clone, StatefulView)]
 pub struct AnimatedAlign {
     alignment: Alignment,
+    width_factor: Option<f32>,
+    height_factor: Option<f32>,
     duration: Duration,
     curve: ArcCurve,
     child: BoxedView,
 }
 
 impl AnimatedAlign {
+    /// Size the box to `factor` x the child's width, animating the factor when
+    /// it changes.
+    ///
+    /// The oracle tweens this alongside the alignment
+    /// (`_AnimatedAlignState._widthFactorTween`), so a changed factor
+    /// interpolates rather than snapping. Leaving it unset is not the same as
+    /// setting `1.0`: an unset factor makes the box fill its constraints on
+    /// that axis, which is what `'AnimatedAlign null widthFactor'` pins.
+    #[must_use]
+    pub fn width_factor(mut self, factor: f32) -> Self {
+        self.width_factor = Some(factor);
+        self
+    }
+
+    /// Size the box to `factor` x the child's height, animating the factor when
+    /// it changes. See [`width_factor`](Self::width_factor).
+    #[must_use]
+    pub fn height_factor(mut self, factor: f32) -> Self {
+        self.height_factor = Some(factor);
+        self
+    }
+
     /// Animate `child` toward `alignment`, with the 200 ms default duration and
     /// an ease-in-out curve.
     pub fn new(alignment: Alignment, child: impl IntoView) -> Self {
         Self {
             alignment,
+            width_factor: None,
+            height_factor: None,
             duration: DEFAULT_DURATION,
             curve: default_curve(),
             child: child.into_view().boxed(),
@@ -67,7 +95,10 @@ impl std::fmt::Debug for AnimatedAlign {
 /// State for [`AnimatedAlign`] — owns the persistent alignment animation.
 #[derive(Debug)]
 pub struct AnimatedAlignState {
-    animation: ImplicitAnimation<Alignment>,
+    controller: ImplicitController,
+    alignment: OptTween<Alignment>,
+    width_factor: OptTween<f32>,
+    height_factor: OptTween<f32>,
     child: BoxedView,
 }
 
@@ -76,7 +107,12 @@ impl StatefulView for AnimatedAlign {
 
     fn create_state(&self) -> Self::State {
         AnimatedAlignState {
-            animation: ImplicitAnimation::new(self.alignment, self.duration, self.curve.clone()),
+            controller: ImplicitController::new(self.duration, self.curve.clone()),
+            // Always set, unlike the two factors — `AnimatedAlign` has no
+            // alignment-less state.
+            alignment: OptTween::at_rest(Some(self.alignment)),
+            width_factor: OptTween::at_rest(self.width_factor),
+            height_factor: OptTween::at_rest(self.height_factor),
             child: self.child.clone(),
         }
     }
@@ -85,33 +121,57 @@ impl StatefulView for AnimatedAlign {
 impl ViewState<AnimatedAlign> for AnimatedAlignState {
     fn init_state(&mut self, ctx: &dyn BuildContext) {
         if let Some(vsync) = ctx.get::<VsyncScope, _>(|scope| scope.vsync().clone()) {
-            self.animation.register(vsync);
+            self.controller.register(vsync);
         }
     }
 
     fn build(&self, _view: &AnimatedAlign, _ctx: &dyn BuildContext) -> impl IntoView {
-        let curved = self.animation.curved();
-        let tween = self.animation.tween();
+        let curved = self.controller.curved();
+        let alignment = self.alignment.clone();
+        let width_factor = self.width_factor.clone();
+        let height_factor = self.height_factor.clone();
         let child = self.child.clone();
-        AnimatedBuilder::new(self.animation.listenable(), move || {
-            Align::new(tween.transform(curved.value())).child(child.clone())
+        AnimatedBuilder::new(self.controller.listenable(), move || {
+            let t = curved.value();
+            // An unset factor must reach `Align` as unset, not as `1.0`: the
+            // oracle's `build` passes `_widthFactorTween?.evaluate(animation)`,
+            // so a null factor stays null and the axis fills its constraints.
+            let mut align = Align::new(
+                alignment
+                    .current(t)
+                    .expect("BUG: AnimatedAlign always has an alignment tween"),
+            );
+            if let Some(factor) = width_factor.current(t) {
+                align = align.width_factor(factor);
+            }
+            if let Some(factor) = height_factor.current(t) {
+                align = align.height_factor(factor);
+            }
+            align.child(child.clone())
         })
     }
 
     fn did_update_view(&mut self, _old_view: &AnimatedAlign, new_view: &AnimatedAlign) {
         self.child = new_view.child.clone();
-        // `build()` re-captures `curved()`/`tween()` fresh on every genuine
-        // reconfigure (this widget rebuilds via `AnimatedBuilder`, unlike
-        // `AnimatedOpacity`), so there is no downstream recompute to gate —
-        // the changed/unchanged report is intentionally discarded here.
-        let _ = self.animation.retarget(
-            new_view.alignment,
-            new_view.duration,
-            new_view.curve.clone(),
-        );
+        self.controller.set_duration(new_view.duration);
+        // Swap the curve before sampling `t`, so a target change anchors
+        // against the already-updated curve — same ordering as
+        // `AnimatedContainer`, which carries the oracle citations for it.
+        self.controller.set_curve(new_view.curve.clone());
+        let t = self.controller.value();
+
+        // `|=`, not `||`: every property must be re-anchored at this same
+        // instant even once an earlier one has already reported a change.
+        let mut any_target_changed = false;
+        any_target_changed |= self.alignment.retarget(Some(new_view.alignment), t);
+        any_target_changed |= self.width_factor.retarget(new_view.width_factor, t);
+        any_target_changed |= self.height_factor.retarget(new_view.height_factor, t);
+        if any_target_changed {
+            self.controller.restart_from_zero();
+        }
     }
 
     fn dispose(&mut self) {
-        self.animation.dispose();
+        self.controller.dispose();
     }
 }

--- a/crates/flui-widgets/tests/parity/animated_align_test.rs
+++ b/crates/flui-widgets/tests/parity/animated_align_test.rs
@@ -18,8 +18,7 @@
 //!   `implicit_animations_test.rs` documents for `AnimatedContainer`'s
 //!   lockstep guarantee.
 //!
-//! Out of scope: 6 of 7 — a genuine, worth-flagging capability gap, not a
-//! judgment call per case:
+//! Out of scope: 2 of 7 —
 //! - `'AnimatedAlign.debugFillProperties'` — no Debug-format parity contract
 //!   in this harness (also true of every other `debugFillProperties` case in
 //!   this family).
@@ -27,21 +26,25 @@
 //!   `AnimatedAlign::alignment` is a plain `Alignment`, never
 //!   `AlignmentGeometry`; there is no `Directionality`-resolved path to
 //!   exercise (same family-wide gap as `AnimatedContainer`/`AnimatedPadding`).
-//! - `'AnimatedAlign widthFactor'`, `'AnimatedAlign heightFactor'`,
-//!   `'AnimatedAlign null height factor'`, `'AnimatedAlign null widthFactor'`
-//!   — **`AnimatedAlign` does not expose `width_factor`/`height_factor` at
-//!   all**, unlike the plain (non-animated) `Align` widget, which does
-//!   (`crates/flui-widgets/src/layout/align.rs`:
-//!   `Align::width_factor`/`Align::height_factor`). This is a real,
-//!   `AnimatedAlign`-specific capability gap versus its own non-animated
-//!   sibling, not shared by the rest of the family — flagged here rather than
-//!   silently skipped.
+//!
+//! The four size-factor cases were listed here as blocked on
+//! `AnimatedAlign` not exposing `width_factor`/`height_factor` at all. It
+//! exposes both now, animated through `OptTween<f32>` the way the rest of the
+//! implicitly-animated family carries its optional properties, so they are
+//! ported below:
+//! - `'AnimatedAlign widthFactor'` — [`animated_align_width_factor`].
+//! - `'AnimatedAlign heightFactor'` — [`animated_align_height_factor`].
+//! - `'AnimatedAlign null height factor'`, `'AnimatedAlign null widthFactor'` —
+//!   [`animated_align_leaves_an_unset_factor_filling_its_axis`], which covers
+//!   both: each upstream case sets neither factor and asserts a 100x100
+//!   result, differing only in which enclosing box supplies the unbounded
+//!   axis.
 
 use flui_animation::Vsync;
 use flui_types::Alignment;
 use flui_view::prelude::{BuildContext, StatefulView};
 use flui_view::{IntoView, ViewState};
-use flui_widgets::{AnimatedAlign, SizedBox, VsyncScope};
+use flui_widgets::{AnimatedAlign, Column, Row, SizedBox, VsyncScope, column, row};
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
@@ -163,5 +166,166 @@ fn animated_align_animates_child_offset_over_duration() {
         child_offset(&laid),
         (80.0, 80.0),
         "the run must end exactly at the new alignment's offset"
+    );
+}
+
+/// Flutter parity: `animated_align_test.dart` `'AnimatedAlign widthFactor'`
+/// (3.44.0) — a `width_factor` of `0.5` over a 100-wide child sizes the box to
+/// 50.
+///
+/// The `Row` is load-bearing, not scenery: it hands the `AnimatedAlign`
+/// unbounded width. Under the harness's tight screen constraints the factor is
+/// unobservable, because `RenderPositionedBox` shrink-wraps and then
+/// `constrain`s — `constrain(50)` against a tight 800 is 800. The same trap the
+/// plain `Align` port documents.
+#[test]
+fn animated_align_width_factor() {
+    let laid = lay_out(
+        Row::new(row![
+            AnimatedAlign::new(Alignment::CENTER, SizedBox::new(100.0, 100.0))
+                .width_factor(0.5)
+                .duration(RUN)
+        ]),
+        tight(800.0, 600.0),
+    );
+
+    let align = laid.find_by_render_type("RenderAlign");
+    assert_eq!(laid.size(align).width.get(), 50.0);
+}
+
+/// Flutter parity: `animated_align_test.dart` `'AnimatedAlign heightFactor'`
+/// (3.44.0) — the transposed case, with a `Column` supplying the unbounded
+/// axis.
+#[test]
+fn animated_align_height_factor() {
+    let laid = lay_out(
+        Column::new(column![
+            AnimatedAlign::new(Alignment::CENTER, SizedBox::new(100.0, 100.0))
+                .height_factor(0.5)
+                .duration(RUN)
+        ]),
+        tight(800.0, 600.0),
+    );
+
+    let align = laid.find_by_render_type("RenderAlign");
+    assert_eq!(laid.size(align).height.get(), 50.0);
+}
+
+/// Flutter parity: `animated_align_test.dart` `'AnimatedAlign null height
+/// factor'` and `'AnimatedAlign null widthFactor'` (3.44.0), both covered here.
+///
+/// The two upstream cases are the same assertion from opposite axes: neither
+/// sets a factor, both expect the box to measure exactly the child (100x100),
+/// and they differ only in which enclosing widget supplies the unbounded axis.
+///
+/// An unset factor must reach `Align` as *unset*, not as `1.0`. The two are
+/// indistinguishable here — `1.0 x 100` is also 100 — so this test alone cannot
+/// tell them apart, and says so rather than implying otherwise. What separates
+/// them is the *bounded* axis: with no factor the box fills its constraint
+/// there, which is asserted below and which a blanket `1.0` default would
+/// break.
+#[test]
+fn animated_align_leaves_an_unset_factor_filling_its_axis() {
+    let laid = lay_out(
+        Row::new(row![
+            AnimatedAlign::new(Alignment::CENTER, SizedBox::new(100.0, 100.0)).duration(RUN)
+        ]),
+        tight(800.0, 600.0),
+    );
+
+    let align = laid.find_by_render_type("RenderAlign");
+    assert_eq!(
+        laid.size(align),
+        common::size(100.0, 600.0),
+        "unbounded width shrink-wraps to the child (the oracle's 100); the \
+         bounded height has no factor and therefore fills, which is what \
+         distinguishes an unset factor from a 1.0 one"
+    );
+}
+
+#[derive(Clone, StatefulView)]
+struct FactorProbe {
+    vsync: Vsync,
+    factor: Arc<Mutex<f32>>,
+}
+
+struct FactorProbeState {
+    vsync: Vsync,
+    factor: Arc<Mutex<f32>>,
+}
+
+impl StatefulView for FactorProbe {
+    type State = FactorProbeState;
+
+    fn create_state(&self) -> Self::State {
+        FactorProbeState {
+            vsync: self.vsync.clone(),
+            factor: Arc::clone(&self.factor),
+        }
+    }
+}
+
+impl ViewState<FactorProbe> for FactorProbeState {
+    fn build(&self, _view: &FactorProbe, _ctx: &dyn BuildContext) -> impl IntoView {
+        let factor = *self.factor.lock();
+        VsyncScope::new(
+            self.vsync.clone(),
+            Row::new(row![
+                AnimatedAlign::new(Alignment::CENTER, SizedBox::new(100.0, 100.0))
+                    .width_factor(factor)
+                    .duration(RUN)
+            ]),
+        )
+    }
+}
+
+/// A changed size factor **animates**; it does not snap.
+///
+/// This is the case that separates a faithful port from a pass-through. The
+/// three static factor cases above each lay out once, so a `width_factor` that
+/// merely forwarded its value to `Align` would satisfy all of them. The oracle
+/// tweens the factor alongside the alignment
+/// (`_AnimatedAlignState._widthFactorTween`, `implicit_animations.dart`), and
+/// only a mid-run sample can tell the two apart.
+///
+/// Red-check: make `AnimatedAlign` forward `width_factor` straight to `Align`
+/// instead of holding it in an `OptTween` — the halfway assertion then reads
+/// the target width 100 instead of a value strictly between 50 and 100.
+#[test]
+fn animated_align_animates_a_changed_size_factor() {
+    let vsync = Vsync::new();
+    let factor = Arc::new(Mutex::new(0.5));
+    let probe = FactorProbe {
+        vsync: vsync.clone(),
+        factor: Arc::clone(&factor),
+    };
+    let mut laid = lay_out_animated(probe, tight(800.0, 600.0), vsync);
+
+    let width = |laid: &common::LaidOut| -> f32 {
+        laid.size(laid.find_by_render_type("RenderAlign"))
+            .width
+            .get()
+    };
+
+    assert_eq!(width(&laid), 50.0, "first build sits at the initial factor");
+
+    *factor.lock() = 1.0;
+    laid.pump();
+    laid.pump_for(Duration::ZERO); // detection frame: anchors the fresh run
+    laid.pump_for(RUN / 2);
+
+    let mid = width(&laid);
+    assert!(
+        mid > 51.0 && mid < 99.0,
+        "halfway through the run the box must be strictly between the old and \
+         new factor widths; got {mid} — a value of 100 means the factor snapped \
+         rather than animating"
+    );
+
+    laid.pump_for(RUN / 2);
+    assert_eq!(
+        width(&laid),
+        100.0,
+        "the run ends exactly at the new factor"
     );
 }


### PR DESCRIPTION
## What

`AnimatedAlign` exposed **no size factors at all**, unlike its own non-animated sibling `Align`, which has both. Its parity file flagged that as a real capability gap and listed four upstream cases as blocked on it.

## Done as a faithful port, not a pass-through

The state moves from the single-property `ImplicitAnimation<Alignment>` to the multi-property shape `AnimatedContainer` already uses: one shared `ImplicitController` plus an `OptTween` per property. `OptTween` exists for exactly this and already documents the Some/None edge — no new convention invented.

Two details the oracle forces:

- **An unset factor must reach `Align` as unset, not as `1.0`.** Upstream's build passes `_widthFactorTween?.evaluate(animation)`, so a null factor stays null and that axis *fills* its constraints instead of shrink-wrapping.
- **The factors are tweened, not forwarded** (`_widthFactorTween`), so a changed factor interpolates.

## The second point is what the ported cases cannot see

Each of the four upstream cases lays out **once**, so a `width_factor` that merely forwarded its value to `Align` would satisfy all four. `animated_align_animates_a_changed_size_factor` is the case that discriminates, and it is red-checked — sampling the tween at `t = 1.0` instead of the curve's `t`:

```
halfway through the run the box must be strictly between the old and new factor
widths; got 100 — a value of 100 means the factor snapped rather than animating
```

## Two upstream cases, one Rust test

`'AnimatedAlign null height factor'` and `'AnimatedAlign null widthFactor'` are the same assertion from opposite axes, differing only in which enclosing box supplies the unbounded one.

Its doc states plainly **what it cannot prove**: an unset factor and a `1.0` factor both yield 100 on the unbounded axis, so they are indistinguishable there. The *bounded* axis is what separates them — with no factor the box fills — and that is what is asserted.

Also worth noting for reviewers: the harness's tight screen constraints make a factor unobservable (`RenderPositionedBox` shrink-wraps then `constrain`s, so `constrain(50)` against a tight 800 is 800). Every factor case is therefore posed inside a `Row`/`Column`.

Out of scope for this file drops from **6 of 7 to 2 of 7**.

## Verification

| gate | result |
|---|---|
| `nextest --workspace --exclude flui-platform` | **8174 passed** |
| doctests | **630 passed** |
| clippy / fmt / doc-strict / port-check | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117t1jX2FFcCzP3YBLoQB94