### PR TITLE
fix(atomics): relax bare-flag SeqCst sites and state each ordering contract

### DIFF
--- a/crates/flui-platform/src/platforms/android/mod.rs
+++ b/crates/flui-platform/src/platforms/android/mod.rs
@@ -174,10 +174,14 @@ impl Platform for AndroidPlatform {
 
         let mut on_ready = Some(on_ready);
         let mut resumed = false;
-        self.running.store(true, Ordering::SeqCst);
+        // Relaxed everywhere on `running`: it is a bare stop-signal with no
+        // data published through it. The loop re-reads it every iteration,
+        // the Destroy store happens on the loop thread itself, and a
+        // cross-thread `quit()` only needs eventual visibility.
+        self.running.store(true, Ordering::Relaxed);
 
         loop {
-            if !self.running.load(Ordering::SeqCst) {
+            if !self.running.load(Ordering::Relaxed) {
                 break;
             }
 
@@ -230,7 +234,7 @@ impl Platform for AndroidPlatform {
                                 w.callbacks().dispatch_close();
                             }
 
-                            self.running.store(false, Ordering::SeqCst);
+                            self.running.store(false, Ordering::Relaxed);
                         }
                         MainEvent::WindowResized { .. } => {
                             tracing::info!("Android: Window resized");
@@ -292,7 +296,7 @@ impl Platform for AndroidPlatform {
 
     fn quit(&self) {
         tracing::info!("Android: quit requested");
-        self.running.store(false, Ordering::SeqCst);
+        self.running.store(false, Ordering::Relaxed);
     }
 
     fn open_window(&self, _options: WindowOptions) -> Result<Arc<dyn PlatformWindow>> {

--- a/crates/flui-rendering/src/storage/flags.rs
+++ b/crates/flui-rendering/src/storage/flags.rs
@@ -33,6 +33,13 @@
 //! This is sufficient because flags are simple presence indicators with no
 //! dependent data co-located in the atomic.
 //!
+//! No cross-thread reader of these flags exists today — the pipeline is
+//! single-threaded by contract (see `storage/state`), and dirty-marking
+//! flows through `PipelineOwner` on the UI thread. The Acquire/Release
+//! scheme is deliberately conservative so that a future off-thread reader
+//! (e.g. a raster or semantics worker) inherits correct publication
+//! ordering without a re-audit of every call site.
+//!
 //! # Performance
 //!
 //! Atomic flag operations are extremely fast:

--- a/crates/flui-scheduler/src/scheduler.rs
+++ b/crates/flui-scheduler/src/scheduler.rs
@@ -90,6 +90,8 @@ use crate::{
 
 fn next_scheduler_identity() -> u64 {
     static NEXT_IDENTITY: AtomicU64 = AtomicU64::new(1);
+    // Relaxed: pure ID allocation — uniqueness comes from the RMW's own
+    // atomicity; no data is published through this counter.
     NEXT_IDENTITY
         .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |next| {
             next.checked_add(1)

--- a/crates/flui-semantics/src/binding.rs
+++ b/crates/flui-semantics/src/binding.rs
@@ -105,21 +105,26 @@ pub struct SemanticsHandle {
 impl SemanticsHandle {
     /// Creates a new semantics handle.
     fn new(counter: Arc<AtomicUsize>) -> Self {
-        counter.fetch_add(1, Ordering::SeqCst);
+        // Relaxed: bare presence counter. The RMW is atomic on its own, and
+        // no data is published through it — readers only gate whether the
+        // semantics phase runs, and re-check every frame.
+        counter.fetch_add(1, Ordering::Relaxed);
         Self { counter }
     }
 }
 
 impl Drop for SemanticsHandle {
     fn drop(&mut self) {
-        self.counter.fetch_sub(1, Ordering::SeqCst);
+        // Relaxed: nothing is freed or torn down when the count reaches
+        // zero; collection stopping one frame late is acceptable.
+        self.counter.fetch_sub(1, Ordering::Relaxed);
     }
 }
 
 impl std::fmt::Debug for SemanticsHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SemanticsHandle")
-            .field("active_handles", &self.counter.load(Ordering::SeqCst))
+            .field("active_handles", &self.counter.load(Ordering::Relaxed))
             .finish()
     }
 }
@@ -185,13 +190,17 @@ impl SemanticsBinding {
     /// - The platform has requested semantics
     /// - There are outstanding `SemanticsHandle`s
     pub fn semantics_enabled(&self) -> bool {
-        self.platform_semantics_enabled.load(Ordering::SeqCst)
-            || self.handle_count.load(Ordering::SeqCst) > 0
+        // Relaxed: this flag/counter pair only gates whether semantics
+        // collection runs. No semantics data is published through these
+        // atomics (the tree lives behind its own locks), and the frame loop
+        // re-reads them every frame, so eventual visibility is enough.
+        self.platform_semantics_enabled.load(Ordering::Relaxed)
+            || self.handle_count.load(Ordering::Relaxed) > 0
     }
 
     /// Returns the number of outstanding semantics handles.
     pub fn outstanding_handles(&self) -> usize {
-        self.handle_count.load(Ordering::SeqCst)
+        self.handle_count.load(Ordering::Relaxed)
     }
 
     /// Creates a new `SemanticsHandle` and enables semantics collection.
@@ -206,13 +215,14 @@ impl SemanticsBinding {
     /// This is typically called by the platform embedder when accessibility
     /// services are activated or deactivated.
     pub fn set_platform_semantics_enabled(&self, enabled: bool) {
+        // Relaxed: the flag carries no payload — see `semantics_enabled`.
         self.platform_semantics_enabled
-            .store(enabled, Ordering::SeqCst);
+            .store(enabled, Ordering::Relaxed);
     }
 
     /// Returns whether the platform has requested semantics.
     pub fn platform_semantics_enabled(&self) -> bool {
-        self.platform_semantics_enabled.load(Ordering::SeqCst)
+        self.platform_semantics_enabled.load(Ordering::Relaxed)
     }
 
     // ========== Accessibility Features ==========

--- a/crates/flui-widgets/src/interaction/dismissible.rs
+++ b/crates/flui-widgets/src/interaction/dismissible.rs
@@ -502,6 +502,14 @@ struct DragState {
     /// Bumped by `move_controller`'s status listener on every transition to
     /// `Completed`. `Send + Sync` (an atomic), so the listener may touch it
     /// directly; `build()` diffs it against `delivered_move_completions`.
+    ///
+    /// All atomics in this struct use `Relaxed`: they carry bare counts, not
+    /// data publication. Every consumer runs in `build()` after the
+    /// listener's `RebuildHandle::schedule` call, whose queue
+    /// synchronization already orders the listener-side bump before the
+    /// rebuild that reads it; a load racing a concurrent tick can at worst
+    /// miss an increment that the tick's own scheduled rebuild then
+    /// delivers.
     move_completed_runs: Arc<AtomicU64>,
     delivered_move_completions: Cell<u64>,
 
@@ -587,7 +595,7 @@ impl ViewState<Dismissible> for DismissibleState {
         self.move_status_listener_id = Some(self.move_controller.add_status_listener(Arc::new(
             move |status| {
                 if status == AnimationStatus::Completed {
-                    move_completed_runs.fetch_add(1, Ordering::SeqCst);
+                    move_completed_runs.fetch_add(1, Ordering::Relaxed);
                     rebuild_for_status.schedule(flui_view::RebuildReason::AnimationTick);
                 }
             },
@@ -958,7 +966,7 @@ fn ensure_move_controller_registered(
 /// `_handleDragEnd` bypass, which likewise never consults the status
 /// listener for that case.
 fn discard_transient_move_completion(drag: &DragState) {
-    let completed_runs = drag.move_completed_runs.load(Ordering::SeqCst);
+    let completed_runs = drag.move_completed_runs.load(Ordering::Relaxed);
     drag.delivered_move_completions.set(completed_runs);
 }
 
@@ -1170,7 +1178,7 @@ fn deliver_move_completion(
     rebuild: &RebuildHandle,
     constraints: BoxConstraints,
 ) {
-    let completed_runs = drag.move_completed_runs.load(Ordering::SeqCst);
+    let completed_runs = drag.move_completed_runs.load(Ordering::Relaxed);
     if completed_runs <= drag.delivered_move_completions.get() {
         return;
     }
@@ -1202,9 +1210,9 @@ fn start_resize_animation(
     let rebuild_for_resize = rebuild.clone();
     let listener_id = resize_controller.add_listener(Arc::new(move || {
         if resize_ref.is_completed() {
-            completed_flag.store(true, Ordering::SeqCst);
+            completed_flag.store(true, Ordering::Relaxed);
         } else {
-            progress_ticks.fetch_add(1, Ordering::SeqCst);
+            progress_ticks.fetch_add(1, Ordering::Relaxed);
         }
         rebuild_for_resize.schedule(flui_view::RebuildReason::AnimationTick);
     }));
@@ -1223,7 +1231,7 @@ fn start_resize_animation(
 /// fires `on_resize` for every delivered progress tick, or `on_dismissed`
 /// once when the resize controller completes.
 fn deliver_resize_progress(drag: &Rc<DragState>, resolved: &Rc<ResolvedConfig>) {
-    if drag.resize_completed.load(Ordering::SeqCst) {
+    if drag.resize_completed.load(Ordering::Relaxed) {
         if !drag.delivered_resize_dismissal.get() {
             drag.delivered_resize_dismissal.set(true);
             let direction = extent_to_direction(
@@ -1237,7 +1245,7 @@ fn deliver_resize_progress(drag: &Rc<DragState>, resolved: &Rc<ResolvedConfig>) 
         }
         return;
     }
-    let ticks = drag.resize_progress_ticks.load(Ordering::SeqCst);
+    let ticks = drag.resize_progress_ticks.load(Ordering::Relaxed);
     let delivered = drag.delivered_resize_ticks.get();
     if ticks > delivered {
         drag.delivered_resize_ticks.set(ticks);


### PR DESCRIPTION
Closes the atomic-ordering finding of the 2026-07-25 upgrade-pack audit (§17): production `SeqCst` sites carried no written justification.

Verification against HEAD before fixing showed the audit's list was partly stale: `flui-app/runner.rs` and `flui-binding/lib.rs` only ever had SeqCst in test/doctest code, and `AtomicRenderFlags` already ran a documented Acquire/Release/AcqRel scheme. The genuinely open remainder was 19 sites in three files, all bare counters/flags with no co-located data publication:

- **flui-semantics `binding.rs` (8)** — handle counter + platform flag gate whether the semantics phase runs and are re-read every frame → `Relaxed`, contract stated at each accessor.
- **flui-widgets `dismissible.rs` (7)** — listener-side tick/completion counters; the consuming rebuild is ordered after the bump by the `RebuildHandle` queue's own synchronization → `Relaxed`, policy documented once on `DragState`.
- **flui-platform `android/mod.rs` (4)** — `running` stop-signal; loop re-reads every iteration, `Destroy` store is on the loop thread, cross-thread `quit()` needs only eventual visibility → `Relaxed`.

Plus: rationale comment on the scheduler's already-`Relaxed` `NEXT_IDENTITY`, and a note in `flags.rs` that no cross-thread flag reader exists today (scheme kept deliberately conservative for future off-thread readers).

Gates: `just ci` green locally (fmt, inventory, port-check, clippy, tests incl. doc). The audit's flake-context test `resize_collapse_starts_at_full_size_then_runs_to_completion` passes. Android sites are cfg'd off local builds — the edit there is a pure `Ordering` swap + comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)