### PR TITLE
fix(foundation,interaction): make the clock stack wasm-safe via web-time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,6 +1614,7 @@ dependencies = [
  "tracing-oslog",
  "tracing-subscriber",
  "tracing-wasm",
+ "web-time",
 ]
 
 [[package]]
@@ -1665,6 +1666,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ui-events",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,11 @@ dashmap = "6.1"
 # owner inbox — bounded queues with typed backpressure only)
 crossbeam-channel = "0.5"
 
+# TIME - std::time re-export on native; performance.now()-backed Instant on
+# wasm32 (std Instant::now() panics there). Single source so every crate's
+# Instant is the same type per target.
+web-time = "1.1"
+
 # COLLECTIONS - Used by multiple crates
 smallvec = { version = "1.13", features = ["serde", "union", "const_generics"] }
 

--- a/crates/flui-app/Cargo.toml
+++ b/crates/flui-app/Cargo.toml
@@ -58,7 +58,7 @@ crossbeam-channel.workspace = true
 anyhow.workspace = true
 raw-window-handle.workspace = true
 pollster = "0.4"
-web-time = "1.1"
+web-time = { workspace = true }
 
 # Web/WASM platform (runner spawns the frame loop via spawn_local)
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/flui-devtools/Cargo.toml
+++ b/crates/flui-devtools/Cargo.toml
@@ -11,7 +11,7 @@ description = "Developer tools for FLUI - profiling, debugging, hot reload, and 
 [dependencies]
 
 # Timing and performance (web-time is the maintained replacement for instant)
-web-time = "1.1"
+web-time = { workspace = true }
 
 # Serialization (for devtools protocol)
 serde = { workspace = true }

--- a/crates/flui-foundation/Cargo.toml
+++ b/crates/flui-foundation/Cargo.toml
@@ -17,6 +17,10 @@ workspace = true
 
 [dependencies]
 parking_lot = { workspace = true }
+# `MonotonicClock`'s Instant: std::time on native, performance.now() on
+# wasm32 — std::time::Instant::now() panics on wasm32-unknown-unknown,
+# and this clock is the default the gesture arena runs on (see clock.rs).
+web-time = { workspace = true }
 # `SmallVec` for stack-allocated listener-callback snapshots in
 # `ChangeNotifier::notify_listeners` (audit I-4). Inline capacity 4
 # covers the common case of one or two listeners per notifier;

--- a/crates/flui-foundation/src/clock.rs
+++ b/crates/flui-foundation/src/clock.rs
@@ -16,9 +16,12 @@
 
 use std::fmt;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
+// `std::time::{Duration, Instant}` on native targets; on wasm32 an
+// `Instant` backed by `performance.now()` — the std one panics there,
+// and this clock is what the gesture arena reads on every pointer event.
+use web_time::{Duration, Instant};
 
 /// A monotonic time source — the single authority a deadline- or frame-driven
 /// subsystem reads `now()` from.

--- a/crates/flui-interaction/Cargo.toml
+++ b/crates/flui-interaction/Cargo.toml
@@ -13,6 +13,9 @@ keywords = ["gui", "ui", "events", "gestures", "interaction"]
 # Flui dependencies
 flui-types = { path = "../flui-types", version = "0.2.0" }
 flui-foundation = { path = "../flui-foundation", version = "0.2.0" }
+# Instant that works on wasm32 (std's panics there). Must be the same type
+# the foundation clock returns, so timestamps interoperate.
+web-time = { workspace = true }
 # Presentation-owned IME state holds the exact platform capability directly.
 # This removes the former app-layer Any/downcast + closure-bridge path.
 flui-platform = { path = "../flui-platform", version = "0.2.0" }

--- a/crates/flui-interaction/src/arena/mod.rs
+++ b/crates/flui-interaction/src/arena/mod.rs
@@ -59,13 +59,13 @@ use std::{
         Arc, Weak,
         atomic::{AtomicU64, Ordering},
     },
-    time::Instant,
 };
 
 use dashmap::DashMap;
 use parking_lot::Mutex;
 use smallvec::SmallVec;
 use tracing::instrument;
+use web_time::Instant;
 
 use crate::ids::PointerId;
 use flui_foundation::{MonotonicClock, SystemClock};

--- a/crates/flui-interaction/src/binding.rs
+++ b/crates/flui-interaction/src/binding.rs
@@ -590,8 +590,8 @@ impl GestureBinding {
     /// `next_sample_time <= sample_time`.
     pub fn flush_pending_moves_at(
         &self,
-        sample_time: std::time::Instant,
-        next_sample_time: std::time::Instant,
+        sample_time: web_time::Instant,
+        next_sample_time: web_time::Instant,
     ) -> Result<usize, InvalidSamplingWindow> {
         if next_sample_time <= sample_time {
             return Err(InvalidSamplingWindow);
@@ -601,7 +601,7 @@ impl GestureBinding {
 
     fn flush_pending_moves_kernel(
         &self,
-        sample_window: Option<(std::time::Instant, std::time::Instant)>,
+        sample_window: Option<(web_time::Instant, web_time::Instant)>,
     ) -> usize {
         if self.tearing_down_all_pointers.get() || !self.tearing_down_pointers.borrow().is_empty() {
             return 0;

--- a/crates/flui-interaction/src/processing/one_euro.rs
+++ b/crates/flui-interaction/src/processing/one_euro.rs
@@ -26,7 +26,7 @@
 //! Defaults here (`min_cutoff = 1.0 Hz`, `beta = 0.007`, `d_cutoff = 1.0 Hz`)
 //! are the paper's recommended starting point for 60–120 Hz pointer input.
 
-use std::time::Instant;
+use web_time::Instant;
 
 use flui_types::geometry::{Offset, Pixels};
 

--- a/crates/flui-interaction/src/processing/prediction.rs
+++ b/crates/flui-interaction/src/processing/prediction.rs
@@ -31,7 +31,7 @@
 //! - Medium accuracy: 16-32ms (one to two frames)
 //! - Low accuracy: 32-50ms (use with caution)
 
-use std::time::{Duration, Instant};
+use web_time::{Duration, Instant};
 
 use flui_types::geometry::{Offset, Pixels};
 

--- a/crates/flui-interaction/src/processing/raw_input.rs
+++ b/crates/flui-interaction/src/processing/raw_input.rs
@@ -39,8 +39,9 @@ use std::{
     cell::{Cell, RefCell},
     collections::HashMap,
     rc::Rc,
-    time::Instant,
 };
+
+use web_time::Instant;
 
 use flui_types::geometry::{Offset, PixelDelta, Pixels, px};
 

--- a/crates/flui-interaction/src/processing/resampler.rs
+++ b/crates/flui-interaction/src/processing/resampler.rs
@@ -44,11 +44,9 @@
 //! let _has_pending = resampler.has_pending_events();
 //! ```
 
-use std::{
-    collections::VecDeque,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{collections::VecDeque, sync::Arc};
+
+use web_time::{Duration, Instant};
 
 use flui_types::geometry::{Offset, Pixels};
 use parking_lot::Mutex;

--- a/crates/flui-interaction/src/processing/sampling_clock.rs
+++ b/crates/flui-interaction/src/processing/sampling_clock.rs
@@ -40,7 +40,7 @@
 //! Flutter reference: `gestures/resampler.dart` (caller-paced sampling
 //! loop) and `scheduler/ticker.dart` (frame-tick clock).
 
-use std::time::{Duration, Instant};
+use web_time::{Duration, Instant};
 
 /// Default sampling period: 60 Hz (Flutter's `kDefaultSamplePeriod`).
 ///

--- a/crates/flui-interaction/src/processing/velocity.rs
+++ b/crates/flui-interaction/src/processing/velocity.rs
@@ -31,7 +31,7 @@
 //! # Example
 //!
 //! ```rust
-//! use std::time::{Duration, Instant};
+//! use web_time::{Duration, Instant};
 //!
 //! use flui_interaction::processing::VelocityTracker;
 //! use flui_types::geometry::{Offset, Pixels};
@@ -54,7 +54,7 @@
 //! let _fling = tracker.get_fling_velocity(false);
 //! ```
 
-use std::time::{Duration, Instant};
+use web_time::{Duration, Instant};
 
 use flui_types::geometry::{Offset, Pixels};
 pub use flui_types::gestures::{PointerDeviceKind, Velocity, VelocityEstimate};

--- a/crates/flui-interaction/src/recognizers/double_tap.rs
+++ b/crates/flui-interaction/src/recognizers/double_tap.rs
@@ -10,12 +10,9 @@
 //!
 //! Flutter reference: <https://api.flutter.dev/flutter/gestures/DoubleTapGestureRecognizer-class.html>
 
-use std::{
-    cell::RefCell,
-    rc::Rc,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{cell::RefCell, rc::Rc, sync::Arc};
+
+use web_time::{Duration, Instant};
 
 use flui_types::{Offset, geometry::Pixels};
 use parking_lot::Mutex;

--- a/crates/flui-interaction/src/recognizers/drag.rs
+++ b/crates/flui-interaction/src/recognizers/drag.rs
@@ -9,7 +9,9 @@
 //!
 //! Flutter reference: <https://api.flutter.dev/flutter/gestures/DragGestureRecognizer-class.html>
 
-use std::{cell::RefCell, rc::Rc, sync::Arc, time::Instant};
+use std::{cell::RefCell, rc::Rc, sync::Arc};
+
+use web_time::Instant;
 
 use flui_types::{
     Offset,

--- a/crates/flui-interaction/src/recognizers/long_press.rs
+++ b/crates/flui-interaction/src/recognizers/long_press.rs
@@ -11,12 +11,9 @@
 //!
 //! Flutter reference: <https://api.flutter.dev/flutter/gestures/LongPressGestureRecognizer-class.html>
 
-use std::{
-    cell::RefCell,
-    rc::Rc,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{cell::RefCell, rc::Rc, sync::Arc};
+
+use web_time::{Duration, Instant};
 
 use flui_types::{Offset, geometry::Pixels};
 use parking_lot::Mutex;

--- a/crates/flui-interaction/src/recognizers/multi_tap.rs
+++ b/crates/flui-interaction/src/recognizers/multi_tap.rs
@@ -9,13 +9,9 @@
 //!
 //! Flutter reference: <https://api.flutter.dev/flutter/gestures/MultiTapGestureRecognizer-class.html>
 
-use std::{
-    cell::RefCell,
-    collections::HashMap,
-    rc::Rc,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc};
+
+use web_time::{Duration, Instant};
 
 use flui_types::{Offset, geometry::Pixels};
 use parking_lot::Mutex;

--- a/crates/flui-interaction/src/recognizers/multidrag.rs
+++ b/crates/flui-interaction/src/recognizers/multidrag.rs
@@ -56,7 +56,9 @@
 //! | Arena entries | one | one per pointer |
 //! | Tap → drag use case | yes | no (use [`TapAndDragGestureRecognizer`](crate::recognizers::TapAndDragGestureRecognizer)) |
 
-use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc, time::Instant};
+use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc};
+
+use web_time::Instant;
 
 use flui_types::{
     Offset,

--- a/crates/flui-interaction/src/recognizers/recognizer.rs
+++ b/crates/flui-interaction/src/recognizers/recognizer.rs
@@ -115,7 +115,7 @@ impl RecognizerBase {
     /// production; a headless frame driver's virtual clock in tests, so a
     /// deadline elapses deterministically without a wall-clock sleep.
     #[inline]
-    pub fn now(&self) -> std::time::Instant {
+    pub fn now(&self) -> web_time::Instant {
         self.arena.now()
     }
 

--- a/crates/flui-interaction/src/recognizers/scale.rs
+++ b/crates/flui-interaction/src/recognizers/scale.rs
@@ -9,7 +9,9 @@
 //!
 //! Flutter reference: <https://api.flutter.dev/flutter/gestures/ScaleGestureRecognizer-class.html>
 
-use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc, time::Instant};
+use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc};
+
+use web_time::Instant;
 
 use flui_types::{Offset, geometry::Pixels};
 use parking_lot::Mutex;

--- a/crates/flui-interaction/src/recognizers/tap_and_drag.rs
+++ b/crates/flui-interaction/src/recognizers/tap_and_drag.rs
@@ -373,7 +373,7 @@ impl GestureRecognizer for TapAndDragGestureRecognizer {
             ds.tap_viable = true;
             ds.velocity_tracker.reset();
             ds.velocity_tracker
-                .add_position(std::time::Instant::now(), position);
+                .add_position(web_time::Instant::now(), position);
         }
         *self.phase.lock() = Phase::Down;
     }
@@ -479,7 +479,7 @@ impl TapAndDragGestureRecognizer {
                         ds.last = Some(position);
                         ds.velocity_tracker.reset();
                         ds.velocity_tracker
-                            .add_position(std::time::Instant::now(), position);
+                            .add_position(web_time::Instant::now(), position);
                     }
 
                     let start_cb = self.callbacks.borrow().on_drag_start.clone();
@@ -523,7 +523,7 @@ impl TapAndDragGestureRecognizer {
                     let mut ds = self.drag_state.lock();
                     ds.last = Some(position);
                     ds.velocity_tracker
-                        .add_position(std::time::Instant::now(), position);
+                        .add_position(web_time::Instant::now(), position);
                 }
                 let cb = self.callbacks.borrow().on_drag_update.clone();
                 if let Some(cb) = cb {

--- a/crates/flui-interaction/src/testing/recording.rs
+++ b/crates/flui-interaction/src/testing/recording.rs
@@ -25,7 +25,7 @@
 //! }
 //! ```
 
-use std::time::{Duration, Instant};
+use web_time::{Duration, Instant};
 
 use flui_types::{Offset, geometry::Pixels};
 use ui_events::pointer::{PointerButton, PointerButtons};

--- a/crates/flui-interaction/src/timer.rs
+++ b/crates/flui-interaction/src/timer.rs
@@ -61,13 +61,12 @@
 //! timer.cancel();
 //! ```
 
-use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicBool, AtomicU64, Ordering},
-    },
-    time::{Duration, Instant},
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicU64, Ordering},
 };
+
+use web_time::{Duration, Instant};
 
 use parking_lot::Mutex;
 use smallvec::SmallVec;

--- a/crates/flui-layer/Cargo.toml
+++ b/crates/flui-layer/Cargo.toml
@@ -29,7 +29,7 @@ testing = []
 [dependencies]
 # Cross-platform clock: std::time::Instant panics on wasm32, and
 # `PerformanceStats` is reached from the frame path.
-web-time = "1.1"
+web-time = { workspace = true }
 
 # Foundation - canonical ID types
 flui-foundation = { path = "../flui-foundation", version = "0.2.0" }

--- a/crates/flui-scheduler/Cargo.toml
+++ b/crates/flui-scheduler/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["gui", "game-development", "rendering"]
 flui-foundation = { path = "../flui-foundation", version = "0.2.0" }
 
 # Cross-platform time (web-time is the maintained replacement for instant)
-web-time = "1.1"
+web-time = { workspace = true }
 
 # Thread-safe synchronization
 parking_lot.workspace = true


### PR DESCRIPTION
Closes the wasm-clock defect recorded in the 2026-07-25 upgrade-pack audit status notes ("wasm: гейт зелёный ≠ wasm работает").

**Defect.** `SystemClock::now()` was `std::time::Instant::now()`, which panics on `wasm32-unknown-unknown` — and it is the default clock of `GestureArena`/`GestureBinding`. The live chain `run_web → UiRealm → PresentationState → GestureBinding::new()` wires it on web, so the first pointer event or deadline poll panicked. Beyond the clock, 13 direct `Instant::now()` call sites sat on the pointer path (timer wheel, sampling clock, velocity tracker, resampler, double-tap/long-press/multi-tap/multidrag/scale/tap-and-drag recognizers). `cargo check` can't see any of this — it never executes.

**Fix.** Source `Instant`/`Duration` from `web-time` (the mechanism flui-layer/flui-scheduler already used): a `std::time` re-export on native targets, so every native consumer keeps the exact same types, and a `performance.now()`-backed `Instant` on wasm32. `web-time` is hoisted to `[workspace.dependencies]`; the four crates that declared it locally now inherit it. The type distinction on wasm is what makes the sweep compiler-verified: any missed site fails the existing `wasm-check` gate.

Two audit details corrected along the way: `draggable.rs`/`back_gesture.rs` `Instant::now()` sites are test-only at HEAD (not wasm hazards), and the audit-era claim "no wasm-bindgen in workspace" is stale (web_demo/painting_demo are cdylib+wasm-bindgen members).

Gates: `just ci` green, `just wasm-check` green, `taplo fmt --check` green, flui-interaction 489/489.

Non-goal, recorded for follow-up: several recognizers still read wall-clock directly instead of the injected arena clock — works, but bypasses deterministic-clock testing; that's a determinism cleanup, not a wasm defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)