### PR TITLE
test(rendering): walk real NodePtrs under miri; fix the reconcile-capture flake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,9 +167,11 @@ workflow file does *not* tell you, and what you will misjudge without it:
   not link — no link, no tests, and `flui-platform` is excluded from the `test` job. Green means
   "compiles", nothing more. Before this job existed those backends were only ever compiled by
   whoever happened to develop on that OS, and the Windows one did not compile at all.
-- **miri is far narrower than its name suggests.** It covers `pipeline::owner::subtree_arena` only,
-  and the five tests it runs never enter `layout_subtree_borrowed_impl` nor dereference a real
-  `NodePtr` — so it is *not* coverage of the layout-walk reborrows. Advisory while stabilizing.
+- **miri covers `pipeline::owner::subtree_arena` only** — but that now includes two real-`NodePtr`
+  walks driving `layout_dirty_root` through every reborrow phase of `layout_subtree_borrowed_impl`
+  (one straight pass, one cyclic edge exercising the baseline callback's in-flight gate — removing
+  that gate fails miri). Sliver walks and intrinsics queries are still not interpreted. Advisory
+  while stabilizing.
 - **feature-matrix exists because workspace feature unification hides broken per-crate wiring.** A
   crate whose features only resolve thanks to a sibling's dependency passes a normal build and
   fails here.

--- a/crates/flui-rendering/src/pipeline/owner/subtree_arena.rs
+++ b/crates/flui-rendering/src/pipeline/owner/subtree_arena.rs
@@ -2136,4 +2136,220 @@ mod tests {
         let bands2 = arena.take_pending_retain_bands();
         assert!(bands2.is_empty(), "second retain-band drain must be empty");
     }
+
+    // ========================================================================
+    // Real-NodePtr walks — the tests the miri gate actually needs
+    // ========================================================================
+    //
+    // The five tests above never dereference a real `NodePtr` (the one they
+    // construct is deliberately dangling), so on their own they give miri
+    // nothing to check about the layout walk's reborrow discipline.  The two
+    // tests below drive `PipelineOwner::layout_dirty_root` over heap-real
+    // nodes so miri interprets the full Phase 1 / 1b / 2+3 / 4 sequence,
+    // including the in-flight gate on the baseline callback (whose absence
+    // is provenance-only UB — invisible to a hardware test run).
+
+    use std::sync::Arc;
+
+    use flui_foundation::Diagnosticable;
+    use flui_tree::{Leaf, Single};
+    use flui_types::{Size, geometry::px};
+
+    use crate::{
+        context::{BoxHitTestContext, BoxLayoutContext},
+        hit_testing::HitTestBehavior,
+        parent_data::BoxParentData,
+        pipeline::PipelineOwner,
+        traits::{RenderBox, TextBaseline},
+    };
+
+    /// Probe cell the test widgets record their baseline query into:
+    /// `None` = the query never ran; `Some(inner)` = it ran and returned
+    /// `inner`.
+    type BaselineProbe = Arc<Mutex<Option<Option<f32>>>>;
+
+    /// Leaf that reports a fixed size and a known baseline.
+    #[derive(Debug)]
+    struct BaselineLeaf;
+
+    impl Diagnosticable for BaselineLeaf {}
+
+    impl RenderBox for BaselineLeaf {
+        type Arity = Leaf;
+        type ParentData = BoxParentData;
+
+        fn perform_layout(&mut self, _ctx: &mut BoxLayoutContext<'_, Leaf, BoxParentData>) -> Size {
+            Size::new(px(10.0), px(10.0))
+        }
+
+        fn compute_distance_to_actual_baseline(&self, _baseline: TextBaseline) -> Option<f32> {
+            Some(7.5)
+        }
+
+        fn hit_test(&self, _ctx: &mut BoxHitTestContext<'_, Leaf, BoxParentData>) -> bool {
+            false
+        }
+        fn hit_test_behavior(&self) -> HitTestBehavior {
+            HitTestBehavior::Opaque
+        }
+    }
+
+    /// Single-child parent that lays out its child and then queries the
+    /// child's actual baseline through the erased ctx — the path that
+    /// invokes `baseline_cb_owned`.
+    #[derive(Debug)]
+    struct BaselineReader {
+        probe: BaselineProbe,
+    }
+
+    impl Diagnosticable for BaselineReader {}
+
+    impl RenderBox for BaselineReader {
+        type Arity = Single;
+        type ParentData = BoxParentData;
+
+        fn perform_layout(
+            &mut self,
+            ctx: &mut BoxLayoutContext<'_, Single, BoxParentData>,
+        ) -> Size {
+            let constraints = *ctx.constraints();
+            let child_size = ctx.layout_child(0, constraints);
+            *self.probe.lock() =
+                Some(ctx.child_distance_to_actual_baseline(0, TextBaseline::Alphabetic));
+            child_size
+        }
+
+        fn hit_test(&self, _ctx: &mut BoxHitTestContext<'_, Single, BoxParentData>) -> bool {
+            false
+        }
+        fn hit_test_behavior(&self) -> HitTestBehavior {
+            HitTestBehavior::Opaque
+        }
+    }
+
+    /// Walks a real two-node tree (parent → leaf) through
+    /// `layout_dirty_root`, so every reborrow phase of
+    /// `layout_subtree_borrowed_impl` runs against heap-real `NodePtr`s
+    /// under miri — and asserts the walk's observable outputs: the child's
+    /// size propagates to the returned geometry, the child's geometry
+    /// commits, and the post-layout baseline query reaches the leaf.
+    #[test]
+    fn real_node_ptr_walk_commits_geometry_and_answers_baseline() {
+        let probe: BaselineProbe = Arc::new(Mutex::new(None));
+        let mut pipeline = PipelineOwner::new().into_layout();
+        let parent = pipeline
+            .render_tree_mut()
+            .insert_box(Box::new(BaselineReader {
+                probe: Arc::clone(&probe),
+            }));
+        let leaf = pipeline
+            .render_tree_mut()
+            .insert_box_child(parent, Box::new(BaselineLeaf))
+            .expect("leaf insert");
+
+        let constraints = BoxConstraints::loose(Size::new(px(100.0), px(100.0)));
+        let size = pipeline
+            .layout_dirty_root(parent, constraints)
+            .expect("two-node walk over real NodePtrs must lay out");
+
+        assert_eq!(
+            size,
+            Size::new(px(10.0), px(10.0)),
+            "parent returns the child's laid-out size",
+        );
+        assert_eq!(
+            pipeline
+                .render_tree()
+                .get(leaf)
+                .expect("leaf in tree")
+                .geometry_box(),
+            Some(Size::new(px(10.0), px(10.0))),
+            "child geometry must be committed by the walk",
+        );
+        assert_eq!(
+            *probe.lock(),
+            Some(Some(7.5)),
+            "baseline query after layout_child must reach the laid-out leaf",
+        );
+    }
+
+    /// Single-child parent whose perform_layout ONLY queries the child's
+    /// baseline — used with a cyclic `children()` edge naming the walk
+    /// root, so the query targets a slot whose `&mut` is live on an
+    /// ancestor frame.
+    #[derive(Debug)]
+    struct CyclicBaselineProbe {
+        probe: BaselineProbe,
+    }
+
+    impl Diagnosticable for CyclicBaselineProbe {}
+
+    impl RenderBox for CyclicBaselineProbe {
+        type Arity = Single;
+        type ParentData = BoxParentData;
+
+        fn perform_layout(
+            &mut self,
+            ctx: &mut BoxLayoutContext<'_, Single, BoxParentData>,
+        ) -> Size {
+            *self.probe.lock() =
+                Some(ctx.child_distance_to_actual_baseline(0, TextBaseline::Alphabetic));
+            Size::new(px(5.0), px(5.0))
+        }
+
+        fn hit_test(&self, _ctx: &mut BoxHitTestContext<'_, Single, BoxParentData>) -> bool {
+            false
+        }
+        fn hit_test_behavior(&self) -> HitTestBehavior {
+            HitTestBehavior::Opaque
+        }
+    }
+
+    /// Regression guard for the in-flight gate in `baseline_cb_owned`:
+    /// P1 → P2 where P2's `children()` cyclically names P1, and P2's
+    /// perform_layout queries child 0's baseline while P1's `&mut` is live
+    /// on the ancestor frame.  With the gate, the query answers `None`;
+    /// with the gate removed, the callback derefs a slot with a live
+    /// Unique tag — a foreign read miri rejects (hardware runs pass
+    /// either way, which is why this test must be in the miri filter).
+    #[test]
+    fn baseline_query_on_cyclic_in_flight_edge_answers_none() {
+        let probe: BaselineProbe = Arc::new(Mutex::new(None));
+        let mut pipeline = PipelineOwner::new().into_layout();
+        let p1 = pipeline
+            .render_tree_mut()
+            .insert_box(Box::new(BaselineReader {
+                probe: Arc::new(Mutex::new(None)),
+            }));
+        let p2 = pipeline
+            .render_tree_mut()
+            .insert_box_child(
+                p1,
+                Box::new(CyclicBaselineProbe {
+                    probe: Arc::clone(&probe),
+                }),
+            )
+            .expect("p2 insert");
+        // Cyclic edge: P2's children list now names the in-flight walk root.
+        pipeline
+            .render_tree_mut()
+            .get_mut(p2)
+            .expect("p2 in tree")
+            .add_child(p1);
+
+        let constraints = BoxConstraints::loose(Size::new(px(100.0), px(100.0)));
+        let result = pipeline.layout_dirty_root(p1, constraints);
+
+        assert!(
+            result.is_ok(),
+            "a baseline query on a cyclic edge must degrade, not fail the \
+             walk; got {result:?}",
+        );
+        assert_eq!(
+            *probe.lock(),
+            Some(None),
+            "the baseline query must run and answer None for the in-flight \
+             slot (its &mut is live on the ancestor frame)",
+        );
+    }
 }

--- a/crates/flui-view/tests/global_key_reparent.rs
+++ b/crates/flui-view/tests/global_key_reparent.rs
@@ -26,15 +26,11 @@ use flui_foundation::ViewKey;
 use flui_view::{
     BuildContext, BuildOwner, ElementTree, GlobalKey, IntoView, StatefulView, View, ViewExt,
     ViewState,
-    tree::{
-        ReconcileEventKind,
-        test_utils::{CollectedEvent, ReconcileEventCollector},
-    },
+    tree::{ReconcileEventKind, test_utils::CollectedEvent},
 };
 use parking_lot::RwLock;
-use tracing::dispatcher::Dispatch;
-use tracing_subscriber::Registry;
-use tracing_subscriber::layer::SubscriberExt;
+
+use crate::reconcile_capture::capture;
 
 // ============================================================================
 // Fixtures — a stateful keyed counter widget so state survival is
@@ -121,13 +117,6 @@ fn fresh_tree() -> (Arc<RwLock<ElementTree>>, Arc<RwLock<BuildOwner>>) {
     let owner = Arc::new(RwLock::new(BuildOwner::new()));
     flui_view::test_only_set_global_key_registry(&tree, &owner);
     (tree, owner)
-}
-
-fn capture<F: FnOnce()>(body: F) -> Vec<CollectedEvent> {
-    let collector = ReconcileEventCollector::new();
-    let subscriber = Registry::default().with(collector.layer());
-    tracing::dispatcher::with_default(&Dispatch::new(subscriber), body);
-    collector.events()
 }
 
 fn direct_children_in_slot_order(

--- a/crates/flui-view/tests/main.rs
+++ b/crates/flui-view/tests/main.rs
@@ -49,6 +49,8 @@ mod lifecycle_tests;
 mod notifications;
 #[path = "production_reconcile_emits.rs"]
 mod production_reconcile_emits;
+#[path = "reconcile_capture.rs"]
+mod reconcile_capture;
 #[path = "stateless_stateful_tests.rs"]
 mod stateless_stateful_tests;
 #[path = "trybuild_ui.rs"]

--- a/crates/flui-view/tests/production_reconcile_emits.rs
+++ b/crates/flui-view/tests/production_reconcile_emits.rs
@@ -18,38 +18,19 @@
 
 #![cfg(feature = "test-utils")]
 
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use flui_foundation::{ElementId, ValueKey, ViewKey};
 use flui_objects::RenderSizedBox;
 use flui_rendering::pipeline::PipelineOwner;
 use flui_rendering::protocol::BoxProtocol;
 use flui_view::{
-    BuildOwner, ElementTree, GlobalKey, RenderView, View, ViewExt,
-    tree::ReconcileEventKind,
-    tree::test_utils::{CollectedEvent, ReconcileEventCollector},
+    BuildOwner, ElementTree, GlobalKey, RenderView, View, ViewExt, tree::ReconcileEventKind,
 };
 use parking_lot::RwLock;
 use serial_test::serial;
-use tracing::dispatcher::Dispatch;
-use tracing_subscriber::Registry;
-use tracing_subscriber::layer::SubscriberExt;
 
-static GLOBAL_SUBSCRIBER: OnceLock<()> = OnceLock::new();
-
-fn ensure_global_subscriber() {
-    GLOBAL_SUBSCRIBER.get_or_init(|| {
-        let _ = tracing::subscriber::set_global_default(Registry::default());
-    });
-}
-
-fn capture<F: FnOnce()>(body: F) -> Vec<CollectedEvent> {
-    ensure_global_subscriber();
-    let collector = ReconcileEventCollector::new();
-    let subscriber = Registry::default().with(collector.layer());
-    tracing::dispatcher::with_default(&Dispatch::new(subscriber), body);
-    collector.events()
-}
+use crate::reconcile_capture::capture;
 
 #[derive(Clone)]
 struct KeyedLeafBox {

--- a/crates/flui-view/tests/reconcile_capture.rs
+++ b/crates/flui-view/tests/reconcile_capture.rs
@@ -1,0 +1,41 @@
+//! Shared tracing-capture fixture for reconcile-event tests.
+//!
+//! Every test that observes the `flui::reconcile` trace stream must capture
+//! through this module — not by building its own scoped dispatcher — because
+//! of a `tracing` callsite-interest race under parallel test threads:
+//!
+//! `tracing` caches per-callsite interest globally. While no interested
+//! subscriber exists, a callsite is cached as `never`, and every
+//! registration/drop of a dispatcher (including the scoped `with_default`
+//! ones this fixture creates) rebuilds that cache. An event emitted on one
+//! thread in the window where another thread's rebuild has the callsite at
+//! `never` is skipped before the emitting thread's own dispatcher is even
+//! consulted — the capture comes back empty. Installing one process-global,
+//! always-enabled, no-op subscriber keeps every callsite's computed interest
+//! non-`never` for the life of the process, so scoped capture dispatchers
+//! always see their thread's events.
+#![cfg(feature = "test-utils")]
+
+use std::sync::OnceLock;
+
+use flui_view::tree::test_utils::{CollectedEvent, ReconcileEventCollector};
+use tracing::dispatcher::Dispatch;
+use tracing_subscriber::{Registry, layer::SubscriberExt};
+
+static GLOBAL_SUBSCRIBER: OnceLock<()> = OnceLock::new();
+
+fn ensure_global_subscriber() {
+    GLOBAL_SUBSCRIBER.get_or_init(|| {
+        let _ = tracing::subscriber::set_global_default(Registry::default());
+    });
+}
+
+/// Runs `body` with a scoped reconcile-event collector installed as this
+/// thread's dispatcher and returns the events captured during the call.
+pub fn capture<F: FnOnce()>(body: F) -> Vec<CollectedEvent> {
+    ensure_global_subscriber();
+    let collector = ReconcileEventCollector::new();
+    let subscriber = Registry::default().with(collector.layer());
+    tracing::dispatcher::with_default(&Dispatch::new(subscriber), body);
+    collector.events()
+}

--- a/justfile
+++ b/justfile
@@ -176,12 +176,15 @@ test-assets:
 deny:
     cargo deny check
 
-# SCOPE: this runs five `subtree_arena` unit tests, none of which enters
-# `layout_subtree_borrowed_impl` or dereferences a real `NodePtr` (the arena
-# tests use `NonNull::dangling()` deliberately). It is NOT coverage of the
-# layout-walk reborrows — treat "miri green" accordingly.
+# SCOPE: the `subtree_arena` unit tests include two real-NodePtr walks that
+# drive `layout_dirty_root` through every reborrow phase of
+# `layout_subtree_borrowed_impl` — one straight parent→leaf pass, one cyclic
+# `children()` edge that exercises the in-flight gate on the baseline
+# callback (removing that gate makes miri fail this suite). Still narrow:
+# only this module, only box layout — sliver walks and intrinsics queries
+# are not interpreted here.
 [group("test")]
-[doc("Run miri on flui-rendering's subtree-arena unit tests (NOT the layout walk; requires nightly + miri)")]
+[doc("Run miri on flui-rendering's subtree-arena tests, incl. real layout walks (requires nightly + miri)")]
 miri:
     cargo +nightly miri test -p flui-rendering --lib pipeline::owner::subtree_arena
 


### PR DESCRIPTION
Closes the miri-coverage half of the arena finding from the 2026-07-25 upgrade-pack audit status notes (the `baseline_cb_owned` in-flight gate itself landed in e2d81942; this PR makes its absence detectable).

**Commit 1 — reconcile-capture flake (found while gating this session's work).** `global_key_reparent::active_to_active_reparent_emits_from_parent_and_preserves_state` intermittently captured zero events under full-workspace load (2 of 3 local `just ci` runs). Root cause is tracing's global per-callsite interest cache: with no interested subscriber a callsite caches as `never`, and every scoped `with_default` dispatcher register/drop on any thread rebuilds the cache — events emitted in a `never` window are skipped before the thread-local dispatcher is consulted. `production_reconcile_emits` already carried the antidote (a permanent global always-enabled no-op `Registry`) but only for itself and only if its tests ran first. The fixture is now a shared module both files use. Validated: 12 consecutive full `view_it` runs green + full `just ci`.

**Commit 2 — real-NodePtr miri coverage.** The miri gate's five tests never dereferenced a real `NodePtr` (justfile admitted this in a comment). Added two tests the existing filter picks up unchanged:
- a heap-real parent→leaf `layout_dirty_root` walk, so miri interprets every reborrow phase, asserting committed geometry + a working post-layout baseline query;
- a cyclic-edge variant querying the in-flight walk root's baseline — answers `None` with the gate, and **fails miri with the gate removed** ("would remove [Unique] which is strongly protected"; verified locally by disabling the gate).

Stale scope comments in `justfile` and `AGENTS.md` updated to describe the widened coverage and what is still not interpreted (sliver walks, intrinsics queries).

Gates: `just ci` green, `just miri` 7/7 green (3.9s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)