### PR TITLE
fix(platform,ci): lint the Windows and macOS backends; cross-typecheck runs clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -666,16 +666,19 @@ jobs:
         run: cargo check --workspace --locked --target wasm32-unknown-unknown ${{ env.NO_WASM_PKGS }}
 
   # ─────────────────────────────────────────────────────────────────────────
-  # cross-typecheck — flui-platform's per-OS backends, TYPE-CHECKED from Linux.
-  # `cargo check` does not link, so the Win32 and AppKit backends compile from
-  # any host. Before this job they were only ever built by whoever happened to
-  # develop on that OS: the Windows backend had a hard `missing_docs` error
-  # (`pub mod win32`) and both backends had missing Debug impls that the Linux
-  # and wasm gates structurally could not see.
+  # cross-typecheck — flui-platform's per-OS backends, LINTED from Linux.
+  # `cargo clippy` does not link, so the Win32 and AppKit backends compile
+  # from any host. Before this job they were only ever built by whoever
+  # happened to develop on that OS: the Windows backend had a hard
+  # `missing_docs` error (`pub mod win32`) and both backends had missing
+  # Debug impls that the Linux and wasm gates structurally could not see.
   #
-  # Named `typecheck`, not `check`, on purpose: it does NOT link and runs NO
-  # tests, and flui-platform is excluded from the `test` job entirely, so this
-  # is the only gate touching those backends. Green means "compiles".
+  # clippy, not plain check, on purpose: `cfg(windows)`/`cfg(macos)` code is
+  # invisible to every other lint gate, and running only `cargo check` here
+  # let ~80 deny-level lint violations accumulate unseen (found the day this
+  # switched). It still does NOT link and runs NO tests, and flui-platform is
+  # excluded from the `test` job entirely, so this is the only gate touching
+  # those backends. Green means "compiles clean under the workspace lints".
   # Triples are the shipped ones — MSVC (what `gpu-test` uses) and aarch64
   # macOS — with `--all-targets` so per-OS test targets compile too.
   # ─────────────────────────────────────────────────────────────────────────
@@ -707,11 +710,11 @@ jobs:
       - name: Add cross targets to the pinned toolchain
         run: rustup target add x86_64-pc-windows-msvc aarch64-apple-darwin
 
-      - name: cargo check (windows backend)
-        run: cargo check -p flui-platform --locked --all-targets --target x86_64-pc-windows-msvc
+      - name: cargo clippy (windows backend)
+        run: cargo clippy -p flui-platform --locked --all-targets --target x86_64-pc-windows-msvc -- -D warnings
 
-      - name: cargo check (macos backend)
-        run: cargo check -p flui-platform --locked --all-targets --target aarch64-apple-darwin
+      - name: cargo clippy (macos backend)
+        run: cargo clippy -p flui-platform --locked --all-targets --target aarch64-apple-darwin -- -D warnings
 
   # ─────────────────────────────────────────────────────────────────────────
   # ci — aggregator over every job above (tokio pattern). Branch protection

--- a/crates/flui-platform/src/platforms/macos/display.rs
+++ b/crates/flui-platform/src/platforms/macos/display.rs
@@ -74,7 +74,7 @@ impl MacOSDisplay {
 
             Self {
                 id: DisplayId(display_id),
-                name: format!("Display {}", display_id),
+                name: format!("Display {display_id}"),
                 bounds,
                 usable_bounds,
                 scale_factor: scale,

--- a/crates/flui-platform/src/platforms/macos/events.rs
+++ b/crates/flui-platform/src/platforms/macos/events.rs
@@ -37,7 +37,7 @@ use ui_events::{
     keyboard::{Code, KeyState, KeyboardEvent, Location},
     pointer::{
         PointerButton, PointerButtonEvent, PointerButtons, PointerEvent, PointerId, PointerInfo,
-        PointerScrollEvent, PointerState, PointerType, PointerUpdate,
+        PointerOrientation, PointerScrollEvent, PointerState, PointerType, PointerUpdate,
     },
 };
 
@@ -120,64 +120,66 @@ pub unsafe fn convert_ns_event(
             }
 
             // Mouse button events
-            NSEventType::NSLeftMouseDown => convert_mouse_button(
+            NSEventType::NSLeftMouseDown => Some(convert_mouse_button(
                 ns_event,
                 scale_factor,
                 view_height,
                 PointerButton::Primary,
                 true,
-            ),
+            )),
 
-            NSEventType::NSLeftMouseUp => convert_mouse_button(
+            NSEventType::NSLeftMouseUp => Some(convert_mouse_button(
                 ns_event,
                 scale_factor,
                 view_height,
                 PointerButton::Primary,
                 false,
-            ),
+            )),
 
-            NSEventType::NSRightMouseDown => convert_mouse_button(
+            NSEventType::NSRightMouseDown => Some(convert_mouse_button(
                 ns_event,
                 scale_factor,
                 view_height,
                 PointerButton::Secondary,
                 true,
-            ),
+            )),
 
-            NSEventType::NSRightMouseUp => convert_mouse_button(
+            NSEventType::NSRightMouseUp => Some(convert_mouse_button(
                 ns_event,
                 scale_factor,
                 view_height,
                 PointerButton::Secondary,
                 false,
-            ),
+            )),
 
-            NSEventType::NSOtherMouseDown => convert_mouse_button(
+            NSEventType::NSOtherMouseDown => Some(convert_mouse_button(
                 ns_event,
                 scale_factor,
                 view_height,
                 PointerButton::Auxiliary,
                 true,
-            ),
+            )),
 
-            NSEventType::NSOtherMouseUp => convert_mouse_button(
+            NSEventType::NSOtherMouseUp => Some(convert_mouse_button(
                 ns_event,
                 scale_factor,
                 view_height,
                 PointerButton::Auxiliary,
                 false,
-            ),
+            )),
 
             // Mouse movement events
             NSEventType::NSMouseMoved
             | NSEventType::NSLeftMouseDragged
             | NSEventType::NSRightMouseDragged
             | NSEventType::NSOtherMouseDragged => {
-                convert_mouse_move(ns_event, scale_factor, view_height)
+                Some(convert_mouse_move(ns_event, scale_factor, view_height))
             }
 
             // Scroll events
-            NSEventType::NSScrollWheel => convert_scroll_event(ns_event, scale_factor, view_height),
+            NSEventType::NSScrollWheel => {
+                Some(convert_scroll_event(ns_event, scale_factor, view_height))
+            }
 
             // Mouse enter/exit carry no useful position payload in the W3C
             // model — Enter/Leave only identify the pointer.
@@ -229,7 +231,7 @@ unsafe fn extract_key(ns_event: id) -> Key {
             return Key::Named(NamedKey::Unidentified);
         }
 
-        let chars_str = std::ffi::CStr::from_ptr(chars_ptr as *const _)
+        let chars_str = std::ffi::CStr::from_ptr(chars_ptr.cast())
             .to_str()
             .unwrap_or("");
 
@@ -342,7 +344,7 @@ unsafe fn pointer_state(ns_event: id, scale_factor: f64, view_height: f64) -> Po
             modifiers,
             count: 1,
             contact_geometry: PhysicalSize::new(1.0, 1.0),
-            orientation: Default::default(),
+            orientation: PointerOrientation::default(),
             pressure: 0.0,
             tangential_pressure: 0.0,
             scale_factor,
@@ -361,7 +363,7 @@ unsafe fn convert_mouse_button(
     view_height: f64,
     button: PointerButton,
     is_down: bool,
-) -> Option<PlatformInput> {
+) -> PlatformInput {
     // SAFETY: caller guarantees `ns_event` validity; forwarded to
     // `pointer_state` under the same contract.
     unsafe {
@@ -380,7 +382,7 @@ unsafe fn convert_mouse_button(
             PointerEvent::Up(button_event)
         };
 
-        Some(PlatformInput::Pointer(event))
+        PlatformInput::Pointer(event)
     }
 }
 
@@ -389,22 +391,18 @@ unsafe fn convert_mouse_button(
 /// # Safety
 ///
 /// `ns_event` must be a valid, live `NSEvent*` of a mouse-move event.
-unsafe fn convert_mouse_move(
-    ns_event: id,
-    scale_factor: f64,
-    view_height: f64,
-) -> Option<PlatformInput> {
+unsafe fn convert_mouse_move(ns_event: id, scale_factor: f64, view_height: f64) -> PlatformInput {
     // SAFETY: caller guarantees `ns_event` validity; forwarded to
     // `pointer_state` under the same contract.
     unsafe {
         let state = pointer_state(ns_event, scale_factor, view_height);
 
-        Some(PlatformInput::Pointer(PointerEvent::Move(PointerUpdate {
+        PlatformInput::Pointer(PointerEvent::Move(PointerUpdate {
             pointer: primary_mouse_info(),
             current: state,
             coalesced: Vec::new(),
             predicted: Vec::new(),
-        })))
+        }))
     }
 }
 
@@ -413,11 +411,7 @@ unsafe fn convert_mouse_move(
 /// # Safety
 ///
 /// `ns_event` must be a valid, live `NSEvent*` of a scroll-wheel event.
-unsafe fn convert_scroll_event(
-    ns_event: id,
-    scale_factor: f64,
-    view_height: f64,
-) -> Option<PlatformInput> {
+unsafe fn convert_scroll_event(ns_event: id, scale_factor: f64, view_height: f64) -> PlatformInput {
     // SAFETY: caller guarantees `ns_event` validity; `scrollingDeltaX/Y` and
     // `hasPreciseScrollingDeltas` are documented NSEvent getters.
     unsafe {
@@ -438,13 +432,11 @@ unsafe fn convert_scroll_event(
             ScrollDelta::LineDelta(delta_x as f32, delta_y as f32)
         };
 
-        Some(PlatformInput::Pointer(PointerEvent::Scroll(
-            PointerScrollEvent {
-                pointer: primary_mouse_info(),
-                state,
-                delta,
-            },
-        )))
+        PlatformInput::Pointer(PointerEvent::Scroll(PointerScrollEvent {
+            pointer: primary_mouse_info(),
+            state,
+            delta,
+        }))
     }
 }
 

--- a/crates/flui-platform/src/platforms/macos/liquid_glass.rs
+++ b/crates/flui-platform/src/platforms/macos/liquid_glass.rs
@@ -62,11 +62,10 @@ impl LiquidGlassMaterial {
     /// These values are calibrated to match Apple's design guidelines.
     pub fn default_blur_radius(self) -> f32 {
         match self {
-            LiquidGlassMaterial::Standard => 30.0,
+            LiquidGlassMaterial::Standard | LiquidGlassMaterial::Popover => 30.0,
             LiquidGlassMaterial::Prominent => 20.0,
             LiquidGlassMaterial::Sidebar => 40.0,
             LiquidGlassMaterial::Menu => 25.0,
-            LiquidGlassMaterial::Popover => 30.0,
             LiquidGlassMaterial::ControlCenter => 35.0,
         }
     }
@@ -95,12 +94,12 @@ impl LiquidGlassMaterial {
     /// is exposed; macOS Tahoe 26 will provide dedicated materials.
     pub(crate) fn to_ns_visual_effect_material(self) -> usize {
         match self {
-            LiquidGlassMaterial::Standard => 18,      // contentBackground
-            LiquidGlassMaterial::Prominent => 13,     // hudWindow
-            LiquidGlassMaterial::Sidebar => 7,        // sidebar
-            LiquidGlassMaterial::Menu => 5,           // menu
-            LiquidGlassMaterial::Popover => 6,        // popover
-            LiquidGlassMaterial::ControlCenter => 13, // hudWindow
+            LiquidGlassMaterial::Standard => 18, // contentBackground
+            // hudWindow
+            LiquidGlassMaterial::Prominent | LiquidGlassMaterial::ControlCenter => 13,
+            LiquidGlassMaterial::Sidebar => 7, // sidebar
+            LiquidGlassMaterial::Menu => 5,    // menu
+            LiquidGlassMaterial::Popover => 6, // popover
         }
     }
 

--- a/crates/flui-platform/src/platforms/macos/platform.rs
+++ b/crates/flui-platform/src/platforms/macos/platform.rs
@@ -158,11 +158,11 @@ impl Platform for MacOSPlatform {
         // returns nil or a live NSWindow whose pointer value is used as an id.
         unsafe {
             let key_window: id = msg_send![self.app, keyWindow];
-            if key_window != nil {
+            if key_window == nil {
+                None
+            } else {
                 let ptr = key_window as u64;
                 Some(WindowId(ptr))
-            } else {
-                None
             }
         }
     }

--- a/crates/flui-platform/src/platforms/macos/view.rs
+++ b/crates/flui-platform/src/platforms/macos/view.rs
@@ -63,7 +63,8 @@ pub fn create_content_view(
         let context = Box::into_raw(Box::new(ViewContext {
             scale_factor,
             callbacks,
-        })) as *mut std::ffi::c_void;
+        }))
+        .cast::<std::ffi::c_void>();
         (*view).set_ivar("context_ptr", context);
 
         view
@@ -197,7 +198,7 @@ fn get_or_create_view_class() -> &'static Class {
             unsafe {
                 let context_ptr: *mut std::ffi::c_void = *this.get_ivar("context_ptr");
                 if !context_ptr.is_null() {
-                    drop(Box::from_raw(context_ptr as *mut ViewContext));
+                    drop(Box::from_raw(context_ptr.cast::<ViewContext>()));
                 }
 
                 let superclass = class!(NSView);
@@ -385,7 +386,7 @@ pub fn update_view_scale_factor(view: id, new_scale_factor: f64) {
     unsafe {
         let context_ptr: *mut std::ffi::c_void = *(*view).get_ivar("context_ptr");
         if !context_ptr.is_null() {
-            let context = &mut *(context_ptr as *mut ViewContext);
+            let context = &mut *context_ptr.cast::<ViewContext>();
             context.scale_factor = new_scale_factor;
             tracing::debug!("Updated view scale factor to {}", new_scale_factor);
         }

--- a/crates/flui-platform/src/platforms/macos/window.rs
+++ b/crates/flui-platform/src/platforms/macos/window.rs
@@ -45,7 +45,7 @@ pub struct MacOSWindow {
     callbacks: Arc<WindowCallbacks>,
 
     /// Window configuration
-    _config: WindowConfiguration,
+    config: WindowConfiguration,
 }
 
 // SAFETY: the NSWindow pointer is only messaged from the main thread (AppKit
@@ -169,7 +169,7 @@ impl MacOSWindow {
                 })),
                 windows_map: Arc::clone(&windows_map),
                 callbacks,
-                _config: config,
+                config,
             });
 
             // Create content view for input events
@@ -500,7 +500,7 @@ impl HasWindowHandle for MacOSWindow {
         // SAFETY: `ns_window` is alive for the lifetime of `self`; the
         // returned handle borrows `self`, so the view outlives it.
         let content_view: id = unsafe { msg_send![self.ns_window, contentView] };
-        let ns_view = NonNull::new(content_view as *mut std::ffi::c_void)
+        let ns_view = NonNull::new(content_view.cast::<std::ffi::c_void>())
             .ok_or(raw_window_handle::HandleError::Unavailable)?;
         let handle = AppKitWindowHandle::new(ns_view);
 
@@ -529,7 +529,7 @@ impl Clone for MacOSWindow {
             state: Arc::clone(&self.state),
             windows_map: Arc::clone(&self.windows_map),
             callbacks: Arc::clone(&self.callbacks),
-            _config: self._config.clone(),
+            config: self.config.clone(),
         }
     }
 }
@@ -572,7 +572,7 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn set_title(&mut self, title: &str) {
-        PlatformWindow::set_title(self, title)
+        PlatformWindow::set_title(self, title);
     }
 
     fn position(&self) -> Point<Pixels> {
@@ -602,7 +602,7 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn set_size(&mut self, size: Size<Pixels>) {
-        PlatformWindow::resize(self, size)
+        PlatformWindow::resize(self, size);
     }
 
     fn state(&self) -> WindowState {
@@ -757,7 +757,7 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn focus(&mut self) {
-        PlatformWindow::activate(self)
+        PlatformWindow::activate(self);
     }
 
     fn is_focused(&self) -> bool {
@@ -765,11 +765,11 @@ impl WindowTrait for MacOSWindow {
     }
 
     fn close(&mut self) {
-        PlatformWindow::close(self)
+        PlatformWindow::close(self);
     }
 
     fn request_redraw(&mut self) {
-        PlatformWindow::request_redraw(self)
+        PlatformWindow::request_redraw(self);
     }
 
     fn set_min_size(&mut self, size: Option<Size<Pixels>>) {
@@ -813,8 +813,8 @@ impl WindowTrait for MacOSWindow {
         unsafe {
             let content_view: id = msg_send![self.ns_window, contentView];
             CrossRawWindowHandle::MacOS {
-                ns_view: content_view as *mut std::ffi::c_void,
-                ns_window: self.ns_window as *mut std::ffi::c_void,
+                ns_view: content_view.cast::<std::ffi::c_void>(),
+                ns_window: self.ns_window.cast::<std::ffi::c_void>(),
             }
         }
     }
@@ -962,11 +962,11 @@ impl MacOSWindowExtTrait for MacOSWindow {
             // Window ids are NSWindow pointers (see `WindowTrait::id`)
             let other_ns_window = other_window_id as *mut Object;
 
-            if other_ns_window != nil {
+            if other_ns_window == nil {
+                tracing::warn!("Cannot add tab: window {:?} not found", other_window_id);
+            } else {
                 let _: () = msg_send![self.ns_window, addTabbedWindow:other_ns_window ordered:0]; // NSWindowAbove
                 tracing::debug!("Added tab to window {:p}", other_ns_window);
-            } else {
-                tracing::warn!("Cannot add tab: window {:?} not found", other_window_id);
             }
         }
     }
@@ -1066,7 +1066,7 @@ fn create_window_delegate(window: Weak<MacOSWindow>) -> id {
         let delegate: id = msg_send![delegate, init];
 
         // Store weak pointer to window
-        let window_ptr = Box::into_raw(Box::new(window)) as *mut std::ffi::c_void;
+        let window_ptr = Box::into_raw(Box::new(window)).cast::<std::ffi::c_void>();
         (*delegate).set_ivar("window_ptr", window_ptr);
 
         delegate
@@ -1169,7 +1169,7 @@ fn get_or_create_delegate_class() -> &'static Class {
             unsafe {
                 let window_ptr: *mut std::ffi::c_void = *this.get_ivar("window_ptr");
                 if !window_ptr.is_null() {
-                    drop(Box::from_raw(window_ptr as *mut Weak<MacOSWindow>));
+                    drop(Box::from_raw(window_ptr.cast::<Weak<MacOSWindow>>()));
                 }
                 let superclass = class!(NSObject);
                 let _: () = msg_send![super(this, superclass), dealloc];
@@ -1237,7 +1237,7 @@ unsafe fn get_window_from_delegate(delegate: &Object) -> Option<Arc<MacOSWindow>
     // Box<Weak<MacOSWindow>> pointer owned by the delegate.
     unsafe {
         let window_ptr: *mut std::ffi::c_void = *delegate.get_ivar("window_ptr");
-        let weak_ptr = window_ptr as *mut Weak<MacOSWindow>;
+        let weak_ptr = window_ptr.cast::<Weak<MacOSWindow>>();
         if weak_ptr.is_null() {
             return None;
         }

--- a/crates/flui-platform/src/platforms/macos/window_ext.rs
+++ b/crates/flui-platform/src/platforms/macos/window_ext.rs
@@ -212,8 +212,7 @@ impl MacOSWindowLevel {
     pub fn to_ns_value(self) -> isize {
         match self {
             MacOSWindowLevel::Normal => 0,
-            MacOSWindowLevel::Floating => 3,
-            MacOSWindowLevel::TornOffMenu => 3,
+            MacOSWindowLevel::Floating | MacOSWindowLevel::TornOffMenu => 3,
             MacOSWindowLevel::ModalPanel => 8,
             MacOSWindowLevel::MainMenu => 24,
             MacOSWindowLevel::Status => 25,

--- a/crates/flui-platform/src/platforms/macos/window_manager.rs
+++ b/crates/flui-platform/src/platforms/macos/window_manager.rs
@@ -207,7 +207,7 @@ impl WindowManager {
 
     /// Get windows in a group.
     pub fn get_group(&self, group_id: GroupId) -> Option<&[WindowId]> {
-        self.groups.get(&group_id).map(|v| v.as_slice())
+        self.groups.get(&group_id).map(std::vec::Vec::as_slice)
     }
 
     /// Remove window from its group.

--- a/crates/flui-platform/src/platforms/windows/clipboard.rs
+++ b/crates/flui-platform/src/platforms/windows/clipboard.rs
@@ -25,9 +25,9 @@ use crate::traits::Clipboard;
 /// applications.
 #[derive(Debug)]
 pub struct WindowsClipboard {
-    /// Dummy HWND for clipboard operations (we use None which means current
-    /// thread) Mutex is used to ensure thread-safe access
-    _lock: Mutex<()>,
+    /// Serializes clipboard operations on this instance — the Win32
+    /// clipboard is a global resource opened per operation.
+    lock: Mutex<()>,
 }
 
 impl WindowsClipboard {
@@ -35,7 +35,7 @@ impl WindowsClipboard {
     pub fn new() -> Self {
         tracing::debug!("Created Windows clipboard");
         Self {
-            _lock: Mutex::new(()),
+            lock: Mutex::new(()),
         }
     }
 }
@@ -48,7 +48,7 @@ impl Default for WindowsClipboard {
 
 impl Clipboard for WindowsClipboard {
     fn read_text(&self) -> Option<String> {
-        let _guard = self._lock.lock();
+        let _guard = self.lock.lock();
 
         unsafe {
             // Open clipboard (None = current thread's window)
@@ -67,12 +67,13 @@ impl Clipboard for WindowsClipboard {
             }
 
             // Get clipboard data - returns HANDLE which we convert to HGLOBAL
-            let handle_result = GetClipboardData(CF_UNICODETEXT.0 as u32);
-            if let Err(e) = handle_result {
-                tracing::warn!(?e, "Failed to get clipboard data");
-                return None;
-            }
-            let handle = handle_result.unwrap();
+            let handle = match GetClipboardData(CF_UNICODETEXT.0 as u32) {
+                Ok(handle) => handle,
+                Err(e) => {
+                    tracing::warn!(?e, "Failed to get clipboard data");
+                    return None;
+                }
+            };
 
             if handle.is_invalid() {
                 tracing::debug!("Clipboard handle is invalid");
@@ -91,7 +92,10 @@ impl Clipboard for WindowsClipboard {
 
             // Convert wide string to Rust String
             let wide_ptr = ptr as *const u16;
-            let len = (0..).take_while(|&i| *wide_ptr.offset(i) != 0).count();
+            let mut len: usize = 0;
+            while *wide_ptr.add(len) != 0 {
+                len += 1;
+            }
             let wide_slice = std::slice::from_raw_parts(wide_ptr, len);
             let rust_string = String::from_utf16_lossy(wide_slice);
 
@@ -104,7 +108,7 @@ impl Clipboard for WindowsClipboard {
     }
 
     fn write_text(&self, text: String) {
-        let _guard = self._lock.lock();
+        let _guard = self.lock.lock();
 
         unsafe {
             // Open clipboard
@@ -143,7 +147,7 @@ impl Clipboard for WindowsClipboard {
                 return;
             }
 
-            std::ptr::copy_nonoverlapping(wide.as_ptr() as *const u8, ptr as *mut u8, size);
+            std::ptr::copy_nonoverlapping(wide.as_ptr().cast::<u8>(), ptr.cast::<u8>(), size);
 
             let _ = GlobalUnlock(global);
 
@@ -193,7 +197,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Flaky: clipboard can be modified by other processes
+    #[ignore = "flaky: the clipboard can be modified by other processes"]
     fn test_clipboard_roundtrip() {
         // Note: This test requires clipboard access and may fail in CI
         let clipboard = WindowsClipboard::new();

--- a/crates/flui-platform/src/platforms/windows/display.rs
+++ b/crates/flui-platform/src/platforms/windows/display.rs
@@ -3,7 +3,11 @@
 use std::sync::Arc;
 
 use flui_types::geometry::{Bounds, DevicePixels, Point, Size};
-use windows::Win32::{Foundation::*, Graphics::Gdi::*, UI::HiDpi::*};
+use windows::Win32::{
+    Foundation::{LPARAM, RECT, TRUE},
+    Graphics::Gdi::{EnumDisplayMonitors, GetMonitorInfoW, HDC, HMONITOR, MONITORINFOEXW},
+    UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI},
+};
 // BOOL moved from Win32::Foundation to windows_core in windows 0.62
 use windows::core::BOOL;
 
@@ -40,7 +44,7 @@ impl WindowsDisplay {
             // Get DPI for this monitor
             let mut dpi_x = 96u32;
             let mut dpi_y = 96u32;
-            let _ = GetDpiForMonitor(hmonitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
+            let _ = GetDpiForMonitor(hmonitor, MDT_EFFECTIVE_DPI, &raw mut dpi_x, &raw mut dpi_y);
             let scale_factor = dpi_x as f64 / 96.0;
 
             // Convert device name from wide string

--- a/crates/flui-platform/src/platforms/windows/events.rs
+++ b/crates/flui-platform/src/platforms/windows/events.rs
@@ -15,13 +15,24 @@ use keyboard_types::Modifiers as KeyboardModifiers;
 use ui_events::{
     keyboard::{Code, KeyState, KeyboardEvent, Location},
     pointer::{
-        PointerButton, PointerButtonEvent, PointerEvent, PointerId, PointerInfo, PointerState,
-        PointerType, PointerUpdate,
+        PointerButton, PointerButtonEvent, PointerButtons, PointerEvent, PointerId, PointerInfo,
+        PointerOrientation, PointerState, PointerType, PointerUpdate,
     },
 };
-use windows::Win32::{Foundation::*, UI::Input::KeyboardAndMouse::*};
+use windows::Win32::{
+    Foundation::{LPARAM, WPARAM},
+    UI::Input::KeyboardAndMouse::{
+        VIRTUAL_KEY, VK_0, VK_1, VK_2, VK_3, VK_4, VK_5, VK_6, VK_7, VK_8, VK_9, VK_A, VK_B,
+        VK_BACK, VK_C, VK_CONTROL, VK_D, VK_DELETE, VK_DOWN, VK_E, VK_END, VK_ESCAPE, VK_F, VK_F1,
+        VK_F2, VK_F3, VK_F4, VK_F5, VK_F6, VK_F7, VK_F8, VK_F9, VK_F10, VK_F11, VK_F12, VK_G, VK_H,
+        VK_HOME, VK_I, VK_INSERT, VK_J, VK_K, VK_L, VK_LCONTROL, VK_LEFT, VK_LMENU, VK_LSHIFT,
+        VK_LWIN, VK_M, VK_MENU, VK_N, VK_NEXT, VK_O, VK_P, VK_PRIOR, VK_Q, VK_R, VK_RCONTROL,
+        VK_RETURN, VK_RIGHT, VK_RMENU, VK_RSHIFT, VK_RWIN, VK_S, VK_SHIFT, VK_SPACE, VK_T, VK_TAB,
+        VK_U, VK_UP, VK_V, VK_W, VK_X, VK_Y, VK_Z,
+    },
+};
 
-use super::util::*;
+use super::util::{get_x_lparam, get_y_lparam, is_key_pressed};
 use crate::traits::{Key, PlatformInput, ScrollDelta, device_to_logical};
 
 /// Process-start epoch for monotonic event timestamps.
@@ -176,11 +187,11 @@ fn pointer_state(
     let state = PointerState {
         time: event_timestamp_ms(),
         position: PhysicalPosition::new(logical_x as f64, logical_y as f64),
-        buttons: Default::default(),
+        buttons: PointerButtons::default(),
         modifiers,
         count: 1,
         contact_geometry: PhysicalSize::new(1.0, 1.0),
-        orientation: Default::default(),
+        orientation: PointerOrientation::default(),
         pressure,
         tangential_pressure: 0.0,
         scale_factor: scale_factor as f64,
@@ -311,7 +322,7 @@ mod tests {
 
     #[test]
     fn test_mouse_button_down() {
-        let lparam = LPARAM(((200 << 16) | 100) as isize);
+        let lparam = LPARAM(((0xC8 << 16) | 0x64) as isize); // y=200, x=100
         let event = mouse_button_event(PointerButton::Primary, true, lparam, 1.0);
 
         if let PlatformInput::Pointer(PointerEvent::Down(down_event)) = event {
@@ -325,7 +336,7 @@ mod tests {
 
     #[test]
     fn test_mouse_move() {
-        let lparam = LPARAM(((200 << 16) | 100) as isize);
+        let lparam = LPARAM(((0xC8 << 16) | 0x64) as isize); // y=200, x=100
         let event = mouse_move_event(lparam, 1.0);
 
         if let PlatformInput::Pointer(PointerEvent::Move(move_event)) = event {

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -8,24 +8,43 @@ use flui_types::geometry::{Bounds, DevicePixels, Point, Size};
 use parking_lot::Mutex;
 use windows::{
     Win32::{
-        Foundation::*,
-        Graphics::Gdi::*,
-        System::LibraryLoader::*,
+        Foundation::{ERROR_CANCELLED, HWND, LPARAM, LRESULT, RECT, WPARAM},
+        Graphics::Gdi::{BeginPaint, EndPaint, HBRUSH, PAINTSTRUCT},
+        System::LibraryLoader::{GetModuleFileNameW, GetModuleHandleW},
         UI::{
-            HiDpi::*,
+            HiDpi::{DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, SetProcessDpiAwarenessContext},
             Input::KeyboardAndMouse::{TME_LEAVE, TRACKMOUSEEVENT, TrackMouseEvent},
-            WindowsAndMessaging::*,
+            WindowsAndMessaging::{
+                CS_HREDRAW, CS_OWNDC, CS_VREDRAW, CreateWindowExW, DefWindowProcW, DestroyWindow,
+                DispatchMessageW, GWLP_USERDATA, GetForegroundWindow, GetMessageW,
+                GetWindowLongPtrW, HICON, HTCLIENT, HWND_MESSAGE, IDC_ARROW, MSG, PostQuitMessage,
+                RegisterClassW, SW_SHOWNORMAL, SWP_NOACTIVATE, SWP_NOZORDER, SetForegroundWindow,
+                SetWindowLongPtrW, SetWindowPos, TranslateMessage, WINDOW_EX_STYLE, WINDOW_STYLE,
+                WM_CHAR, WM_CLOSE, WM_CREATE, WM_DESTROY, WM_DPICHANGED, WM_ERASEBKGND,
+                WM_INPUTLANGCHANGE, WM_KEYDOWN, WM_KEYUP, WM_KILLFOCUS, WM_LBUTTONDOWN,
+                WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_MOVE,
+                WM_PAINT, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SETCURSOR, WM_SETFOCUS,
+                WM_SETTINGCHANGE, WM_SIZE, WM_SYSKEYDOWN, WM_SYSKEYUP, WNDCLASSW,
+            },
         },
     },
     core::{PCWSTR, w},
 };
 
-use super::{display::enumerate_displays, util::*, window::WindowsWindow};
+use super::{
+    display::enumerate_displays,
+    util::{WINDOW_CLASS_NAME, get_x_lparam, get_y_lparam, hiword, load_cursor_style},
+    window::WindowsWindow,
+};
 use crate::{
     config::WindowConfiguration,
     executor::BackgroundExecutor,
     shared::{PlatformHandlers, WindowCallbacks},
-    traits::*,
+    traits::{
+        Clipboard, DesktopCapabilities, Platform, PlatformCapabilities, PlatformDisplay,
+        PlatformExecutor, PlatformWindow, WindowAppearance, WindowEvent, WindowId, WindowMode,
+        WindowOptions,
+    },
 };
 
 /// Ensures window class is registered exactly once (sound replacement for
@@ -172,7 +191,7 @@ impl WindowsPlatform {
             use windows::Win32::System::Com::{COINIT_APARTMENTTHREADED, CoInitializeEx};
             let hr = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
             if hr.is_err() {
-                return Err(anyhow::anyhow!("Failed to initialize COM: {:?}", hr));
+                return Err(anyhow::anyhow!("Failed to initialize COM: {hr:?}"));
             }
         }
 
@@ -190,7 +209,7 @@ impl WindowsPlatform {
         // Create message-only window for platform messages
         let message_window = unsafe {
             let hinstance = GetModuleHandleW(None)
-                .map_err(|e| anyhow::anyhow!("Failed to get module handle: {:?}", e))?;
+                .map_err(|e| anyhow::anyhow!("Failed to get module handle: {e:?}"))?;
 
             CreateWindowExW(
                 WINDOW_EX_STYLE(0),
@@ -206,7 +225,7 @@ impl WindowsPlatform {
                 Some(hinstance.into()),
                 None,
             )
-            .map_err(|e| anyhow::anyhow!("Failed to create message window: {:?}", e))?
+            .map_err(|e| anyhow::anyhow!("Failed to create message window: {e:?}"))?
         };
 
         // Create executors
@@ -246,7 +265,7 @@ impl WindowsPlatform {
                         lpszClassName: WINDOW_CLASS_NAME,
                     };
 
-                    let atom = RegisterClassW(&wc);
+                    let atom = RegisterClassW(&raw const wc);
                     if atom == 0 {
                         return Err(windows::core::Error::from_thread().into());
                     }
@@ -274,10 +293,10 @@ impl WindowsPlatform {
         unsafe {
             // Get window context from GWLP_USERDATA
             let ctx_ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut WindowContext;
-            let ctx = if !ctx_ptr.is_null() {
-                Some(&*ctx_ptr)
-            } else {
+            let ctx = if ctx_ptr.is_null() {
                 None
+            } else {
+                Some(&*ctx_ptr)
             };
 
             match msg {
@@ -336,11 +355,13 @@ impl WindowsPlatform {
 
                 WM_PAINT => {
                     let mut ps = PAINTSTRUCT::default();
-                    let hdc = BeginPaint(hwnd, &mut ps);
+                    let hdc = BeginPaint(hwnd, &raw mut ps);
                     if !hdc.is_invalid() {
                         // Skip rendering for minimized windows to save CPU/GPU resources
                         let should_skip = WindowsWindow::should_skip_render(hwnd);
-                        if !should_skip {
+                        if should_skip {
+                            tracing::trace!("Skipping render for minimized window");
+                        } else {
                             // No GDI painting here. This HWND carries a D3D12 flip-model
                             // swapchain (wgpu-on-DX12 is always flip-model). Per Microsoft,
                             // GDI and flip model cannot share an HWND: after the first
@@ -358,10 +379,8 @@ impl WindowsPlatform {
                                     window_id: ctx.window_id,
                                 });
                             }
-                        } else {
-                            tracing::trace!("Skipping render for minimized window");
                         }
-                        let _ = EndPaint(hwnd, &ps);
+                        let _ = EndPaint(hwnd, &raw const ps);
                     }
                     LRESULT(0)
                 }
@@ -389,13 +408,7 @@ impl WindowsPlatform {
                                         size: ctx.last_size.get(),
                                     },
                                 };
-                                if !prev_mode.can_transition_to(&candidate) {
-                                    tracing::warn!(
-                                        "⚠️  Invalid state transition: {:?} -> Minimized (transition ignored)",
-                                        prev_mode
-                                    );
-                                    (prev_mode, None)
-                                } else {
+                                if prev_mode.can_transition_to(&candidate) {
                                     // Save current size before minimizing
                                     if !prev_mode.is_minimized() {
                                         ctx.last_size.set(size);
@@ -406,6 +419,12 @@ impl WindowsPlatform {
                                             window_id: ctx.window_id,
                                         }),
                                     )
+                                } else {
+                                    tracing::warn!(
+                                        "⚠️  Invalid state transition: {:?} -> Minimized (transition ignored)",
+                                        prev_mode
+                                    );
+                                    (prev_mode, None)
                                 }
                             }
                             SIZE_MAXIMIZED => {
@@ -417,13 +436,7 @@ impl WindowsPlatform {
                                         size: ctx.last_size.get(),
                                     },
                                 };
-                                if !prev_mode.can_transition_to(&candidate) {
-                                    tracing::warn!(
-                                        "⚠️  Invalid state transition: {:?} -> Maximized (transition ignored)",
-                                        prev_mode
-                                    );
-                                    (prev_mode, None)
-                                } else {
+                                if prev_mode.can_transition_to(&candidate) {
                                     ctx.last_size.set(size);
                                     (
                                         candidate,
@@ -432,6 +445,12 @@ impl WindowsPlatform {
                                             size,
                                         }),
                                     )
+                                } else {
+                                    tracing::warn!(
+                                        "⚠️  Invalid state transition: {:?} -> Maximized (transition ignored)",
+                                        prev_mode
+                                    );
+                                    (prev_mode, None)
                                 }
                             }
                             SIZE_RESTORED => {
@@ -592,7 +611,7 @@ impl WindowsPlatform {
                             hwndTrack: hwnd,
                             dwHoverTime: 0,
                         };
-                        let _ = TrackMouseEvent(&mut tme);
+                        let _ = TrackMouseEvent(&raw mut tme);
 
                         // Track hover state (T034)
                         ctx.is_hovered.set(true);
@@ -849,21 +868,19 @@ impl WindowsPlatform {
     }
 
     /// Run the Windows message loop (internal implementation)
-    fn run_message_loop(&self) -> Result<()> {
+    fn run_message_loop() {
         tracing::info!("Starting Windows message loop");
 
         unsafe {
             let mut msg = MSG::default();
 
-            while GetMessageW(&mut msg, None, 0, 0).as_bool() {
-                let _ = TranslateMessage(&msg);
-                DispatchMessageW(&msg);
+            while GetMessageW(&raw mut msg, None, 0, 0).as_bool() {
+                let _ = TranslateMessage(&raw const msg);
+                DispatchMessageW(&raw const msg);
             }
 
             tracing::info!("Message loop exited with code: {}", msg.wParam.0);
         }
-
-        Ok(())
     }
 }
 
@@ -882,10 +899,7 @@ impl Platform for WindowsPlatform {
         // Call ready callback
         on_ready(&*self);
 
-        // Run message loop
-        if let Err(e) = self.run_message_loop() {
-            tracing::error!("Message loop error: {:?}", e);
-        }
+        Self::run_message_loop();
     }
 
     fn quit(&self) {
@@ -982,7 +996,9 @@ impl Platform for WindowsPlatform {
 
     fn window_appearance(&self) -> WindowAppearance {
         // Read system theme from registry: AppsUseLightTheme
-        use windows::Win32::System::Registry::*;
+        use windows::Win32::System::Registry::{
+            HKEY, HKEY_CURRENT_USER, KEY_READ, RegCloseKey, RegOpenKeyExW, RegQueryValueExW,
+        };
         unsafe {
             let mut hkey = HKEY::default();
             let subkey: Vec<u16> =
@@ -996,7 +1012,7 @@ impl Platform for WindowsPlatform {
                 PCWSTR(subkey.as_ptr()),
                 Some(0),
                 KEY_READ,
-                &mut hkey,
+                &raw mut hkey,
             );
             if status.is_err() {
                 return WindowAppearance::Light;
@@ -1010,7 +1026,7 @@ impl Platform for WindowsPlatform {
                 None,
                 None,
                 Some((&raw mut data).cast::<u8>()),
-                Some(&mut data_size),
+                Some(&raw mut data_size),
             );
             let _ = RegCloseKey(hkey);
 
@@ -1047,7 +1063,7 @@ impl Platform for WindowsPlatform {
         use windows::Win32::UI::Shell::ShellExecuteW;
         // Use "explorer /select,<path>" to reveal in Explorer
         let path_str = path.to_string_lossy();
-        let arg = format!("/select,{}", path_str);
+        let arg = format!("/select,{path_str}");
         let wide_arg: Vec<u16> = arg.encode_utf16().chain(std::iter::once(0)).collect();
         let explorer: Vec<u16> = "explorer\0".encode_utf16().collect();
         unsafe {
@@ -1092,7 +1108,16 @@ impl Platform for WindowsPlatform {
             // COM file dialogs must run on an STA thread
             let result = std::thread::spawn(move || -> Result<Option<Vec<std::path::PathBuf>>> {
                 unsafe {
-                    use windows::Win32::{System::Com::*, UI::Shell::*};
+                    use windows::Win32::{
+                        System::Com::{
+                            CLSCTX_ALL, COINIT_APARTMENTTHREADED, CoCreateInstance, CoInitializeEx,
+                            CoTaskMemFree,
+                        },
+                        UI::Shell::{
+                            FOS_ALLOWMULTISELECT, FOS_FORCEFILESYSTEM, FOS_PATHMUSTEXIST,
+                            FOS_PICKFOLDERS, FileOpenDialog, IFileOpenDialog, SIGDN_FILESYSPATH,
+                        },
+                    };
 
                     let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
 
@@ -1144,12 +1169,22 @@ impl Platform for WindowsPlatform {
         suggested_name: Option<&str>,
     ) -> crate::task::Task<Result<Option<std::path::PathBuf>>> {
         let dir = directory.to_path_buf();
-        let name = suggested_name.map(|s| s.to_string());
+        let name = suggested_name.map(std::string::ToString::to_string);
         let executor = self.background_executor.clone();
         executor.spawn(async move {
             let result = std::thread::spawn(move || -> Result<Option<std::path::PathBuf>> {
                 unsafe {
-                    use windows::Win32::{System::Com::*, UI::Shell::*};
+                    use windows::Win32::{
+                        System::Com::{
+                            CLSCTX_ALL, COINIT_APARTMENTTHREADED, CoCreateInstance, CoInitializeEx,
+                            CoTaskMemFree,
+                        },
+                        UI::Shell::{
+                            FOS_FORCEFILESYSTEM, FOS_OVERWRITEPROMPT, FOS_PATHMUSTEXIST,
+                            FileSaveDialog, IFileSaveDialog, IShellItem,
+                            SHCreateItemFromParsingName, SIGDN_FILESYSPATH,
+                        },
+                    };
 
                     let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
 

--- a/crates/flui-platform/src/platforms/windows/util.rs
+++ b/crates/flui-platform/src/platforms/windows/util.rs
@@ -4,13 +4,13 @@
 use anyhow::{Result, anyhow};
 use flui_types::geometry::{DevicePixels, Pixels, Point, Size, device_px, px};
 use windows::{
-    Win32::{Foundation::*, UI::Input::KeyboardAndMouse::GetAsyncKeyState},
+    Win32::{Foundation::LPARAM, UI::Input::KeyboardAndMouse::GetAsyncKeyState},
     core::{PCWSTR, w},
 };
 
 /// Windows platform window class name (shared across platform.rs and window.rs)
 pub const WINDOW_CLASS_NAME: PCWSTR = w!("FluiWindowClass");
-use windows::Win32::UI::WindowsAndMessaging::*;
+use windows::Win32::UI::WindowsAndMessaging::{HCURSOR, LoadCursorW};
 
 /// Convert LPARAM to X coordinate
 #[inline]
@@ -80,7 +80,7 @@ pub fn to_wide(s: &str) -> Vec<u16> {
 
 /// Load a cursor by style
 pub unsafe fn load_cursor_style(style: PCWSTR) -> Result<HCURSOR> {
-    unsafe { LoadCursorW(None, style).map_err(|e| anyhow!("Failed to load cursor: {}", e)) }
+    unsafe { LoadCursorW(None, style).map_err(|e| anyhow!("Failed to load cursor: {e}")) }
 }
 
 /// Check if a key is pressed
@@ -106,7 +106,7 @@ mod tests {
     #[test]
     fn test_lparam_coordinates() {
         // X=100, Y=200 packed into LPARAM
-        let lparam = LPARAM(((200 << 16) | 100) as isize);
+        let lparam = LPARAM(((0xC8 << 16) | 0x64) as isize); // y=200, x=100
 
         assert_eq!(get_x_lparam(lparam), 100);
         assert_eq!(get_y_lparam(lparam), 200);

--- a/crates/flui-platform/src/platforms/windows/window.rs
+++ b/crates/flui-platform/src/platforms/windows/window.rs
@@ -12,10 +12,27 @@ use raw_window_handle::{
 };
 use windows::{
     Win32::{
-        Foundation::*,
-        Graphics::Gdi::*,
-        System::LibraryLoader::*,
-        UI::{HiDpi::*, WindowsAndMessaging::*},
+        Foundation::{FALSE, HWND, POINT, RECT, TRUE},
+        Graphics::Gdi::{
+            HRGN, InvalidateRect, MONITOR_DEFAULTTOPRIMARY, MonitorFromWindow, ScreenToClient,
+            UpdateWindow,
+        },
+        System::LibraryLoader::GetModuleHandleW,
+        UI::{
+            HiDpi::{GetDpiForSystem, GetDpiForWindow},
+            WindowsAndMessaging::{
+                CW_USEDEFAULT, CreateWindowExW, DestroyWindow, GCLP_HBRBACKGROUND, GWL_STYLE,
+                GWLP_USERDATA, GetClientRect, GetCursorPos, GetForegroundWindow, GetWindowLongPtrW,
+                GetWindowPlacement, IDC_APPSTARTING, IDC_ARROW, IDC_CROSS, IDC_HAND, IDC_IBEAM,
+                IDC_NO, IDC_SIZEALL, IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE, IDC_WAIT,
+                IsZoomed, LoadCursorW, SW_HIDE, SW_MAXIMIZE, SW_MINIMIZE, SW_RESTORE, SW_SHOW,
+                SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER,
+                SetClassLongPtrW, SetCursor, SetForegroundWindow, SetWindowLongPtrW, SetWindowPos,
+                SetWindowTextW, ShowWindow, WINDOWPLACEMENT, WS_EX_APPWINDOW, WS_MAXIMIZEBOX,
+                WS_MINIMIZEBOX, WS_OVERLAPPEDWINDOW, WS_POPUP, WS_SYSMENU, WS_THICKFRAME,
+                WS_VISIBLE,
+            },
+        },
     },
     core::HSTRING,
 };
@@ -23,7 +40,11 @@ use windows::{
 use super::util::{USER_DEFAULT_SCREEN_DPI, WINDOW_CLASS_NAME, logical_to_device};
 use crate::{
     shared::{PlatformHandlers, WindowCallbacks},
-    traits::*,
+    traits::{
+        CursorError, DispatchEventResult, PlatformDisplay, PlatformInput, PlatformWindow,
+        WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowId, WindowMode,
+        WindowOptions,
+    },
 };
 
 /// Windows window wrapper
@@ -227,7 +248,7 @@ impl WindowsWindow {
                 cyTopHeight: -1,
                 cyBottomHeight: -1,
             };
-            let _ = DwmExtendFrameIntoClientArea(hwnd, &margins);
+            let _ = DwmExtendFrameIntoClientArea(hwnd, &raw const margins);
 
             // 2. Enable Mica backdrop (Windows 11+)
             let mica_value: i32 = 2; // DWMSBT_MAINWINDOW
@@ -308,7 +329,16 @@ impl WindowsWindow {
     /// WindowsWindow::toggle_fullscreen_for_hwnd(hwnd);
     /// ```
     pub fn toggle_fullscreen_for_hwnd(hwnd: HWND) {
-        use windows::Win32::{Graphics::Gdi::*, UI::WindowsAndMessaging::*};
+        use windows::Win32::{
+            Graphics::Gdi::{
+                GetMonitorInfoW, MONITOR_DEFAULTTOPRIMARY, MONITORINFO, MonitorFromWindow,
+            },
+            UI::WindowsAndMessaging::{
+                GWL_STYLE, GWLP_USERDATA, GetWindowLongPtrW, GetWindowRect, HWND_TOP,
+                SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOZORDER, SetWindowLongPtrW, SetWindowPos,
+                WS_POPUP, WS_VISIBLE,
+            },
+        };
 
         unsafe {
             // Get WindowContext from GWLP_USERDATA
@@ -322,120 +352,117 @@ impl WindowsWindow {
 
             let current_mode = ctx.mode.get();
 
-            match current_mode {
-                WindowMode::Fullscreen { restore_bounds } => {
-                    // Exit fullscreen - restore previous style and bounds
-                    tracing::info!("Exiting fullscreen mode");
+            if let WindowMode::Fullscreen { restore_bounds } = current_mode {
+                // Exit fullscreen - restore previous style and bounds
+                tracing::info!("Exiting fullscreen mode");
 
-                    // Validate transition
-                    let candidate = WindowMode::Normal;
-                    if !current_mode.can_transition_to(&candidate) {
-                        tracing::warn!("Cannot exit fullscreen: invalid state transition");
-                        return;
-                    }
-
-                    // Restore window style from WindowContext
-                    let restore_style = ctx.restore_style.get();
-                    SetWindowLongPtrW(hwnd, GWL_STYLE, restore_style as isize);
-
-                    // Restore window position and size
-                    SetWindowPos(
-                        hwnd,
-                        None,
-                        restore_bounds.origin.x.0,
-                        restore_bounds.origin.y.0,
-                        restore_bounds.size.width.0,
-                        restore_bounds.size.height.0,
-                        SWP_FRAMECHANGED | SWP_NOZORDER | SWP_NOACTIVATE,
-                    )
-                    .ok();
-
-                    // Update state
-                    ctx.mode.set(WindowMode::Normal);
-
-                    // Dispatch ExitFullscreen event
-                    ctx.dispatch_event(crate::traits::WindowEvent::ExitFullscreen {
-                        window_id: ctx.window_id,
-                        size: restore_bounds.size,
-                    });
+                // Validate transition
+                let candidate = WindowMode::Normal;
+                if !current_mode.can_transition_to(&candidate) {
+                    tracing::warn!("Cannot exit fullscreen: invalid state transition");
+                    return;
                 }
-                _ => {
-                    // Enter fullscreen - save current state and go borderless on monitor
-                    tracing::info!("Entering fullscreen mode");
 
-                    // Get current window rect
-                    let mut rect = RECT::default();
-                    GetWindowRect(hwnd, &mut rect).ok();
+                // Restore window style from WindowContext
+                let restore_style = ctx.restore_style.get();
+                SetWindowLongPtrW(hwnd, GWL_STYLE, restore_style as isize);
 
-                    // Save current style to WindowContext
-                    let current_style = GetWindowLongPtrW(hwnd, GWL_STYLE) as u32;
-                    ctx.restore_style.set(current_style);
+                // Restore window position and size
+                SetWindowPos(
+                    hwnd,
+                    None,
+                    restore_bounds.origin.x.0,
+                    restore_bounds.origin.y.0,
+                    restore_bounds.size.width.0,
+                    restore_bounds.size.height.0,
+                    SWP_FRAMECHANGED | SWP_NOZORDER | SWP_NOACTIVATE,
+                )
+                .ok();
 
-                    // Save current bounds
-                    let restore_bounds = Bounds {
-                        origin: Point::new(DevicePixels(rect.left), DevicePixels(rect.top)),
-                        size: Size::new(
-                            DevicePixels(rect.right - rect.left),
-                            DevicePixels(rect.bottom - rect.top),
-                        ),
-                    };
+                // Update state
+                ctx.mode.set(WindowMode::Normal);
 
-                    // Validate transition
-                    let candidate = WindowMode::Fullscreen { restore_bounds };
-                    if !current_mode.can_transition_to(&candidate) {
-                        tracing::warn!(
-                            "Cannot enter fullscreen: invalid state transition from {:?}",
-                            current_mode
-                        );
-                        return;
-                    }
+                // Dispatch ExitFullscreen event
+                ctx.dispatch_event(crate::traits::WindowEvent::ExitFullscreen {
+                    window_id: ctx.window_id,
+                    size: restore_bounds.size,
+                });
+            } else {
+                // Enter fullscreen - save current state and go borderless on monitor
+                tracing::info!("Entering fullscreen mode");
 
-                    // Get monitor containing this window
-                    let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTOPRIMARY);
-                    let mut monitor_info = MONITORINFO {
-                        cbSize: std::mem::size_of::<MONITORINFO>() as u32,
-                        ..Default::default()
-                    };
-                    let _ = GetMonitorInfoW(monitor, &mut monitor_info);
+                // Get current window rect
+                let mut rect = RECT::default();
+                GetWindowRect(hwnd, &raw mut rect).ok();
 
-                    let monitor_rect = monitor_info.rcMonitor;
+                // Save current style to WindowContext
+                let current_style = GetWindowLongPtrW(hwnd, GWL_STYLE) as u32;
+                ctx.restore_style.set(current_style);
 
-                    // Set borderless style
-                    let fullscreen_style = WS_POPUP | WS_VISIBLE;
-                    SetWindowLongPtrW(hwnd, GWL_STYLE, fullscreen_style.0 as isize);
+                // Save current bounds
+                let restore_bounds = Bounds {
+                    origin: Point::new(DevicePixels(rect.left), DevicePixels(rect.top)),
+                    size: Size::new(
+                        DevicePixels(rect.right - rect.left),
+                        DevicePixels(rect.bottom - rect.top),
+                    ),
+                };
 
-                    // Position window to cover entire monitor
-                    SetWindowPos(
-                        hwnd,
-                        Some(HWND_TOP),
-                        monitor_rect.left,
-                        monitor_rect.top,
-                        monitor_rect.right - monitor_rect.left,
-                        monitor_rect.bottom - monitor_rect.top,
-                        SWP_FRAMECHANGED | SWP_NOACTIVATE,
-                    )
-                    .ok();
-
-                    // Update state
-                    ctx.mode.set(candidate);
-
-                    // Dispatch Fullscreen event
-                    let size = Size::new(
-                        flui_types::geometry::DevicePixels(monitor_rect.right - monitor_rect.left),
-                        flui_types::geometry::DevicePixels(monitor_rect.bottom - monitor_rect.top),
+                // Validate transition
+                let candidate = WindowMode::Fullscreen { restore_bounds };
+                if !current_mode.can_transition_to(&candidate) {
+                    tracing::warn!(
+                        "Cannot enter fullscreen: invalid state transition from {:?}",
+                        current_mode
                     );
-                    ctx.dispatch_event(crate::traits::WindowEvent::Fullscreen {
-                        window_id: ctx.window_id,
-                        size,
-                    });
+                    return;
                 }
+
+                // Get monitor containing this window
+                let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTOPRIMARY);
+                let mut monitor_info = MONITORINFO {
+                    cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+                    ..Default::default()
+                };
+                let _ = GetMonitorInfoW(monitor, &raw mut monitor_info);
+
+                let monitor_rect = monitor_info.rcMonitor;
+
+                // Set borderless style
+                let fullscreen_style = WS_POPUP | WS_VISIBLE;
+                SetWindowLongPtrW(hwnd, GWL_STYLE, fullscreen_style.0 as isize);
+
+                // Position window to cover entire monitor
+                SetWindowPos(
+                    hwnd,
+                    Some(HWND_TOP),
+                    monitor_rect.left,
+                    monitor_rect.top,
+                    monitor_rect.right - monitor_rect.left,
+                    monitor_rect.bottom - monitor_rect.top,
+                    SWP_FRAMECHANGED | SWP_NOACTIVATE,
+                )
+                .ok();
+
+                // Update state
+                ctx.mode.set(candidate);
+
+                // Dispatch Fullscreen event
+                let size = Size::new(
+                    flui_types::geometry::DevicePixels(monitor_rect.right - monitor_rect.left),
+                    flui_types::geometry::DevicePixels(monitor_rect.bottom - monitor_rect.top),
+                );
+                ctx.dispatch_event(crate::traits::WindowEvent::Fullscreen {
+                    window_id: ctx.window_id,
+                    size,
+                });
             }
         }
     }
 
     /// Toggle fullscreen mode for this window
     pub fn toggle_fullscreen(&self) {
-        Self::toggle_fullscreen_for_hwnd(self.hwnd)
+        Self::toggle_fullscreen_for_hwnd(self.hwnd);
     }
 
     /// Check if the window is currently in fullscreen mode
@@ -501,13 +528,8 @@ impl WindowsWindow {
             | CursorIcon::RowResize => IDC_SIZENS,
             CursorIcon::NeResize | CursorIcon::SwResize | CursorIcon::NeswResize => IDC_SIZENESW,
             CursorIcon::NwResize | CursorIcon::SeResize | CursorIcon::NwseResize => IDC_SIZENWSE,
-            CursorIcon::Default
-            | CursorIcon::ContextMenu
-            | CursorIcon::Help
-            | CursorIcon::Alias
-            | CursorIcon::ZoomIn
-            | CursorIcon::ZoomOut
-            | CursorIcon::DndAsk => IDC_ARROW,
+            // Default, ContextMenu, Help, Alias, ZoomIn, ZoomOut, DndAsk and
+            // every future variant fall back to the arrow cursor.
             _ => IDC_ARROW,
         };
 
@@ -577,7 +599,7 @@ impl PlatformWindow for WindowsWindow {
     fn content_size(&self) -> Size<Pixels> {
         unsafe {
             let mut rect = RECT::default();
-            if GetClientRect(self.hwnd, &mut rect).is_ok() {
+            if GetClientRect(self.hwnd, &raw mut rect).is_ok() {
                 let scale = self.state.lock().scale_factor;
                 Size::new(
                     px((rect.right - rect.left) as f32 / scale),
@@ -635,8 +657,8 @@ impl PlatformWindow for WindowsWindow {
     fn mouse_position(&self) -> Point<Pixels> {
         unsafe {
             let mut cursor_pos = POINT::default();
-            if GetCursorPos(&mut cursor_pos).is_ok()
-                && ScreenToClient(self.hwnd, &mut cursor_pos).as_bool()
+            if GetCursorPos(&raw mut cursor_pos).is_ok()
+                && ScreenToClient(self.hwnd, &raw mut cursor_pos).as_bool()
             {
                 let scale = self.state.lock().scale_factor;
                 Point::new(
@@ -739,7 +761,7 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn toggle_fullscreen(&self) {
-        WindowsWindow::toggle_fullscreen(self)
+        WindowsWindow::toggle_fullscreen(self);
     }
 
     fn resize(&self, size: Size<Pixels>) {
@@ -773,9 +795,10 @@ impl PlatformWindow for WindowsWindow {
             use windows::Win32::Graphics::Dwm::{DWMWINDOWATTRIBUTE, DwmSetWindowAttribute};
 
             let backdrop_value: i32 = match appearance {
-                WindowBackgroundAppearance::Opaque => 1,       // DWMSBT_NONE
-                WindowBackgroundAppearance::Transparent => 1,  // No native transparent, use NONE
-                WindowBackgroundAppearance::Blurred => 3,      // DWMSBT_TRANSIENTWINDOW (Acrylic)
+                // DWMSBT_NONE — Windows has no native transparent backdrop,
+                // so Transparent also maps to NONE.
+                WindowBackgroundAppearance::Opaque | WindowBackgroundAppearance::Transparent => 1,
+                WindowBackgroundAppearance::Blurred => 3, // DWMSBT_TRANSIENTWINDOW (Acrylic)
                 WindowBackgroundAppearance::MicaBackdrop => 2, // DWMSBT_MAINWINDOW (Mica)
                 WindowBackgroundAppearance::MicaAltBackdrop => 4, // DWMSBT_TABBEDWINDOW (Mica Alt)
             };
@@ -1150,7 +1173,8 @@ impl WindowTrait for WindowsWindow {
 
     fn raw_window_handle(&self) -> CrossRawWindowHandle {
         unsafe {
-            let hinstance = GetModuleHandleW(None).unwrap();
+            let hinstance = GetModuleHandleW(None)
+                .expect("BUG: GetModuleHandleW(None) cannot fail for the current process image");
             CrossRawWindowHandle::Windows {
                 hwnd: self.hwnd.0,
                 hinstance: hinstance.0,
@@ -1167,7 +1191,7 @@ impl WindowsWindow {
                 length: std::mem::size_of::<WINDOWPLACEMENT>() as u32,
                 ..Default::default()
             };
-            GetWindowPlacement(self.hwnd, &mut placement).ok();
+            GetWindowPlacement(self.hwnd, &raw mut placement).ok();
             placement
         }
     }
@@ -1180,7 +1204,7 @@ impl WindowsWindow {
             DwmSetWindowAttribute(
                 self.hwnd,
                 DWMWINDOWATTRIBUTE(attribute),
-                value as *const T as *const std::ffi::c_void,
+                std::ptr::from_ref::<T>(value).cast::<std::ffi::c_void>(),
                 std::mem::size_of::<T>() as u32,
             )
         }
@@ -1233,7 +1257,7 @@ impl WindowsWindowExtTrait for WindowsWindow {
     fn backdrop(&self) -> WindowsBackdrop {
         unsafe {
             match self.get_dwm_attribute::<i32>(dwm_attributes::DWMWA_SYSTEMBACKDROP_TYPE) {
-                Ok(1) => WindowsBackdrop::None,
+                // Ok(1) is DWMSBT_NONE — covered by the fallback arm.
                 Ok(2) => WindowsBackdrop::Mica,
                 Ok(3) => WindowsBackdrop::Acrylic,
                 Ok(4) => WindowsBackdrop::MicaAlt,
@@ -1310,7 +1334,7 @@ impl WindowsWindowExtTrait for WindowsWindow {
     fn corner_preference(&self) -> WindowCornerPreference {
         unsafe {
             match self.get_dwm_attribute::<i32>(dwm_attributes::DWMWA_WINDOW_CORNER_PREFERENCE) {
-                Ok(0) => WindowCornerPreference::Default,
+                // Ok(0) is DWMCP_DEFAULT — covered by the fallback arm.
                 Ok(1) => WindowCornerPreference::DoNotRound,
                 Ok(2) => WindowCornerPreference::Round,
                 Ok(3) => WindowCornerPreference::RoundSmall,
@@ -1332,7 +1356,7 @@ impl WindowsWindowExtTrait for WindowsWindow {
                 fTransitionOnMaximized: FALSE,
             };
 
-            if let Err(e) = DwmEnableBlurBehindWindow(self.hwnd, &bb) {
+            if let Err(e) = DwmEnableBlurBehindWindow(self.hwnd, &raw const bb) {
                 tracing::warn!("Failed to enable blur behind: {:?}", e);
             } else {
                 tracing::debug!("Blur behind: {}", enable);
@@ -1358,7 +1382,7 @@ impl WindowsWindowExtTrait for WindowsWindow {
 
     fn set_dark_mode(&mut self, dark_mode: bool) {
         unsafe {
-            let dark_mode_value: i32 = if dark_mode { 1 } else { 0 };
+            let dark_mode_value: i32 = i32::from(dark_mode);
             if let Err(e) = self.set_dwm_attribute(
                 dwm_attributes::DWMWA_USE_IMMERSIVE_DARK_MODE,
                 &dark_mode_value,
@@ -1418,7 +1442,7 @@ impl WindowsWindowExtTrait for WindowsWindow {
                 }
             } else {
                 // Reset to default (0xFFFFFFFF means use default)
-                let default_color: u32 = 0xFFFFFFFF;
+                let default_color: u32 = 0xFFFF_FFFF;
                 self.set_dwm_attribute(dwm_attributes::DWMWA_CAPTION_COLOR, &default_color)
                     .ok();
             }
@@ -1478,7 +1502,7 @@ mod tests {
     use super::*;
 
     #[test]
-    #[ignore] // Requires WindowsPlatform to register window class
+    #[ignore = "requires WindowsPlatform to register the window class"]
     fn test_window_creation() {
         let options = WindowOptions {
             title: "Test Window".to_string(),

--- a/crates/flui-platform/src/platforms/windows/window_ext.rs
+++ b/crates/flui-platform/src/platforms/windows/window_ext.rs
@@ -221,11 +221,11 @@ impl WindowsBackdrop {
     /// values.
     pub fn to_dwm_value(self) -> i32 {
         match self {
-            WindowsBackdrop::None => 1,    // DWMSBT_NONE
-            WindowsBackdrop::Mica => 2,    // DWMSBT_MAINWINDOW (Mica)
-            WindowsBackdrop::MicaAlt => 4, // DWMSBT_TABBEDWINDOW (Mica Alt)
+            WindowsBackdrop::None => 1, // DWMSBT_NONE
+            WindowsBackdrop::Mica => 2, // DWMSBT_MAINWINDOW (Mica)
+            // DWMSBT_TABBEDWINDOW backs both Mica Alt and Tabbed.
+            WindowsBackdrop::MicaAlt | WindowsBackdrop::Tabbed => 4,
             WindowsBackdrop::Acrylic => 3, // DWMSBT_TRANSIENTWINDOW (Acrylic)
-            WindowsBackdrop::Tabbed => 4,  // DWMSBT_TABBEDWINDOW
         }
     }
 

--- a/crates/flui-platform/tests/display_enumeration.rs
+++ b/crates/flui-platform/tests/display_enumeration.rs
@@ -312,7 +312,7 @@ fn test_windows_enum_display_monitors() {
     );
 
     // Verify each display has Windows-specific properties correct
-    for disp in displays.iter() {
+    for disp in &displays {
         let bounds = disp.bounds();
 
         tracing::info!(
@@ -368,7 +368,7 @@ fn test_macos_nsscreen_enumeration() {
     );
 
     // Verify macOS-specific properties
-    for disp in displays.iter() {
+    for disp in &displays {
         let bounds = disp.bounds();
         let scale = disp.scale_factor();
 

--- a/crates/flui-platform/tests/window_modes.rs
+++ b/crates/flui-platform/tests/window_modes.rs
@@ -98,7 +98,7 @@ fn test_windows_mode_transitions() {
             tracing::info!("✓ T017 PASS: Windows mode transitions verified");
         }
         Err(e) => {
-            panic!("Windows platform should support window creation: {}", e);
+            panic!("Windows platform should support window creation: {e}");
         }
     }
 }
@@ -143,7 +143,7 @@ fn test_macos_mode_transitions() {
             tracing::info!("✓ T018 PASS: macOS mode transitions verified");
         }
         Err(e) => {
-            panic!("macOS platform should support window creation: {}", e);
+            panic!("macOS platform should support window creation: {e}");
         }
     }
 }

--- a/justfile
+++ b/justfile
@@ -95,14 +95,17 @@ wasm-check:
 # per-OS test targets are compiled too — omitting it is what made live code
 # look dead on wasm32.
 #
-# TYPE-CHECK ONLY: it does not link and runs no tests, and flui-platform is
-# excluded from the test job entirely. Green here means "compiles", nothing more.
+# LINT, NO LINK: clippy (not plain check) because cfg(windows)/cfg(macos)
+# code is invisible to every other lint gate — check-only let ~80 deny-level
+# violations accumulate unseen. It still does not link and runs no tests, and
+# flui-platform is excluded from the test job entirely. Green here means
+# "compiles clean under the workspace lints", nothing more.
 # Requires: rustup target add x86_64-pc-windows-msvc aarch64-apple-darwin
 [group("build")]
-[doc("Type-check flui-platform's Windows and macOS backends from this host (mirrors the CI cross-typecheck job)")]
+[doc("Clippy flui-platform's Windows and macOS backends from this host (mirrors the CI cross-typecheck job)")]
 cross-typecheck:
-    cargo check -p flui-platform --locked --all-targets --target x86_64-pc-windows-msvc
-    cargo check -p flui-platform --locked --all-targets --target aarch64-apple-darwin
+    cargo clippy -p flui-platform --locked --all-targets --target x86_64-pc-windows-msvc -- -D warnings
+    cargo clippy -p flui-platform --locked --all-targets --target aarch64-apple-darwin -- -D warnings
 
 # =============================================================================
 # Testing


### PR DESCRIPTION
Closes the U19 remainder from the 2026-07-25 upgrade-pack audit (§20): the cross-target job ran `cargo check`, so `cfg(windows)`/`cfg(macos)` code had never been seen by the workspace's deny-level clippy set — and the recorded precondition for ever re-evaluating `undocumented_unsafe_blocks` was exactly "make the cross-target job run clippy first".

Switching the CI job and `just cross-typecheck` to `cargo clippy -- -D warnings` surfaced ~90 violations across the two backends. All are fixed, none suppressed; the риск-classes worth review:

- **check-then-unwrap on `GetClipboardData`** → proper match (the unwrap was reachable only after an explicit `if let Err` return, but the shape violated `unwrap_used` and the panic policy).
- **Unbounded `(0..).take_while(...)` NUL scan** in the clipboard reader → plain `while *ptr.add(len) != 0` loop (same semantics, no `maybe_infinite_iter`).
- **Two glob-expanded Win32 import monsters** (the `--fix` expansion listed dozens of unused `*_Impl` traits) → minimal explicit lists.
- **`run_message_loop(&self) -> Result<()>`** — used neither self nor fallibility → associated fn returning `()`; the caller's dead error branch is gone.
- **Three macOS event converters returning `Option` with no `None` path** → infallible signatures, `Some(...)` moved to the dispatch match.
- Mechanical: duplicate match arms folded (cursor map, DWMSBT, window levels, materials), `_lock`/`_config` renamed (they are used), `#[ignore]` reasons, literal/format lints.

The job comment and justfile doc now state honestly what green means: "compiles clean under the workspace lints" — still no link, no tests for these backends.

Gates: clippy clean on `x86_64-pc-windows-msvc`, `aarch64-apple-darwin`, and the host; full `just ci` green. Note: there is still no runtime test coverage on these OSes, so behavioral review of the match-arm folds is the one thing CI cannot vouch for — each fold was value-identical by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)