### PR TITLE
fix(hot-reload): prune the worker registry, keep scene memory plugin-owned, handshake the ABI

### DIFF
--- a/crates/flui-hot-reload/build.rs
+++ b/crates/flui-hot-reload/build.rs
@@ -1,0 +1,34 @@
+//! Captures the exact compiler identity for the plugin ABI handshake.
+//!
+//! `Scene` is `repr(Rust)`: its layout is a private contract between one
+//! compiler invocation and itself. The host and a plugin are separate
+//! compilations, so before any `Scene` crosses the dlopen boundary both sides
+//! must prove they were produced by the same compiler from the same crate
+//! revision — see `abi::abi_token`, which folds this string in.
+
+use std::process::Command;
+
+fn main() {
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
+    // A silent fallback here would be unsafe in the wrong direction: if both
+    // sides failed to capture the compiler identity, two different toolchains
+    // could produce EQUAL tokens. Fail the build instead.
+    let output = Command::new(&rustc)
+        .arg("-vV")
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run `{rustc} -vV` for the ABI handshake: {e}"));
+    assert!(
+        output.status.success(),
+        "`{rustc} -vV` exited with {}: the ABI handshake needs the compiler identity",
+        output.status
+    );
+    let verbose_version = String::from_utf8_lossy(&output.stdout).into_owned();
+
+    // Single line so the env var survives cargo's metadata handling.
+    let compact = verbose_version
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    println!("cargo:rustc-env=FLUI_HOT_RELOAD_RUSTC_VERSION={compact}");
+    println!("cargo:rerun-if-env-changed=RUSTC");
+}

--- a/crates/flui-hot-reload/src/abi.rs
+++ b/crates/flui-hot-reload/src/abi.rs
@@ -1,0 +1,57 @@
+//! Host/plugin ABI-compatibility handshake.
+//!
+//! `Scene` is `repr(Rust)` and crosses the dlopen boundary by raw pointer, so
+//! the ONLY thing that makes the transfer sound is that the host and the
+//! plugin are the same compiler's view of the same source. That premise used
+//! to be assumed; now it is checked: every plugin macro exports an
+//! `flui_*_abi_token` symbol returning [`abi_token`] as computed inside the
+//! plugin's compilation, and each loader compares it against the host's own
+//! value before accepting the library.
+//!
+//! The token folds in:
+//!
+//! - the exact `rustc -vV` identity (captured by this crate's build script) —
+//!   `repr(Rust)` layout may legally change between compiler versions;
+//! - this crate's version — the plugin ABI itself (symbol set, calling
+//!   conventions) is versioned with the crate;
+//! - `size_of`/`align_of` of [`Scene`] and [`LayerTree`] — a direct tripwire
+//!   for layout drift of the payload types actually transferred.
+//!
+//! Equal tokens do not *prove* layout equality (same size/align can hide a
+//! field reorder within one compiler version if the sources diverged), but
+//! with the toolchain pinned and both artifacts built from one worktree —
+//! the only supported dev-loop — a mismatch reliably means "rebuild the other
+//! half", and a match restores the premise the transfer was designed around.
+
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+use flui_layer::{LayerTree, Scene};
+
+/// The ABI-compatibility token for THIS compilation of the plugin boundary.
+///
+/// Host and plugin each compute their own; the loaders refuse a library whose
+/// token differs. See the module docs for what it folds in and what a match
+/// does (and does not) guarantee.
+#[must_use]
+pub fn abi_token() -> u64 {
+    let mut hasher = DefaultHasher::new();
+    env!("FLUI_HOT_RELOAD_RUSTC_VERSION").hash(&mut hasher);
+    env!("CARGO_PKG_VERSION").hash(&mut hasher);
+    core::mem::size_of::<Scene>().hash(&mut hasher);
+    core::mem::align_of::<Scene>().hash(&mut hasher);
+    core::mem::size_of::<LayerTree>().hash(&mut hasher);
+    core::mem::align_of::<LayerTree>().hash(&mut hasher);
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn abi_token_is_stable_within_one_compilation() {
+        // The loaders rely on the token being a pure function of the build,
+        // not of call order or time.
+        assert_eq!(abi_token(), abi_token());
+    }
+}

--- a/crates/flui-hot-reload/src/host.rs
+++ b/crates/flui-hot-reload/src/host.rs
@@ -30,6 +30,20 @@ type SceneVersionFn = extern "C" fn() -> u32;
 /// Function pointer: `flui_scene_drop(ptr)`
 type SceneDropFn = unsafe extern "C" fn(*mut std::ffi::c_void);
 
+/// Function pointer: `flui_scene_free(ptr)` — deallocate without dropping.
+type SceneFreeFn = unsafe extern "C" fn(*mut std::ffi::c_void);
+
+/// Function pointer: `flui_scene_abi_token() -> u64`
+type AbiTokenFn = extern "C" fn() -> u64;
+
+/// One resolved symbol family (`flui_app_*` or `flui_scene_*`), token-checked.
+struct ResolvedSceneFamily {
+    build_fn: BuildSceneFn,
+    free_fn: SceneFreeFn,
+    drop_fn: Option<SceneDropFn>,
+    version: u32,
+}
+
 /// Which symbol convention the loaded plugin uses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PluginKind {
@@ -65,6 +79,15 @@ pub enum PluginKind {
 pub struct ScenePlugin {
     lib: DynLib,
     build_fn: BuildSceneFn,
+    /// The deallocate-only entry (`flui_*_free`): releases the box a build
+    /// call returned after the host has moved the `Scene` value out, so the
+    /// memory is freed by the image that allocated it. Mandatory — `load`
+    /// refuses a plugin without it.
+    free_fn: SceneFreeFn,
+    /// The drop-and-deallocate entry (`flui_*_drop`), for a scene the host
+    /// decides not to consume. Currently every host path consumes, so this is
+    /// resolved-but-idle; kept because it is the correct disposal for an
+    /// unconsumed pointer.
     #[allow(dead_code)]
     drop_fn: Option<SceneDropFn>,
     kind: PluginKind,
@@ -91,44 +114,39 @@ impl ScenePlugin {
         #[allow(unsafe_code)]
         unsafe {
             // Try app_plugin! symbols first (flui_app_build)
-            if let Some(result) =
-                Self::try_resolve(&lib, "flui_app_build", "flui_app_version", "flui_app_drop")
-            {
+            if let Some(resolved) = Self::try_resolve(&lib, "flui_app") {
                 let mtime = dynlib::file_mtime(lib_path);
                 tracing::info!(
                     "App plugin loaded (version {}) from {}",
-                    result.2,
+                    resolved.version,
                     lib_path.display()
                 );
                 return Some(ScenePlugin {
                     lib,
-                    build_fn: result.0,
-                    drop_fn: result.1,
+                    build_fn: resolved.build_fn,
+                    free_fn: resolved.free_fn,
+                    drop_fn: resolved.drop_fn,
                     kind: PluginKind::App,
-                    version: result.2,
+                    version: resolved.version,
                     mtime,
                 });
             }
 
             // Fall back to scene_plugin! symbols (flui_scene_build)
-            if let Some(result) = Self::try_resolve(
-                &lib,
-                "flui_scene_build",
-                "flui_scene_version",
-                "flui_scene_drop",
-            ) {
+            if let Some(resolved) = Self::try_resolve(&lib, "flui_scene") {
                 let mtime = dynlib::file_mtime(lib_path);
                 tracing::info!(
                     "Scene plugin loaded (version {}) from {}",
-                    result.2,
+                    resolved.version,
                     lib_path.display()
                 );
                 return Some(ScenePlugin {
                     lib,
-                    build_fn: result.0,
-                    drop_fn: result.1,
+                    build_fn: resolved.build_fn,
+                    free_fn: resolved.free_fn,
+                    drop_fn: resolved.drop_fn,
                     kind: PluginKind::Scene,
-                    version: result.2,
+                    version: resolved.version,
                     mtime,
                 });
             }
@@ -138,102 +156,128 @@ impl ScenePlugin {
         }
     }
 
-    /// Try to resolve a set of build/version/drop symbols from the library.
+    /// Try to resolve one symbol family (`flui_app` / `flui_scene`) from the
+    /// library, enforcing the ABI handshake.
     ///
-    /// Returns `(build_fn, drop_fn, version)` if the build symbol is found.
+    /// Refuses (returns `None`, with a log) when the family's `_free` or
+    /// `_abi_token` symbol is missing — a library that predates them cannot
+    /// discharge the ownership contract — or when the plugin's token differs
+    /// from the host's (different compiler, source revision, or crate
+    /// version: `repr(Rust)` layout agreement is then unestablished).
     ///
     /// # Safety
     ///
     /// Caller must ensure `lib` is a valid loaded library.
     #[allow(unsafe_code)]
-    unsafe fn try_resolve(
-        lib: &DynLib,
-        build_sym: &str,
-        version_sym: &str,
-        drop_sym: &str,
-    ) -> Option<(BuildSceneFn, Option<SceneDropFn>, u32)> {
+    unsafe fn try_resolve(lib: &DynLib, family: &str) -> Option<ResolvedSceneFamily> {
         // SAFETY: edition 2024 makes unsafe-fn bodies safe by default, so the
         // calls still need their own block. The caller guarantees `lib` is a
         // live library, and each symbol/type pair is the ABI this crate
         // declares for that name.
         //
-        // On null: only `build_ptr` is checked at its use site. `drop_fn` and
-        // `version` transmute straight out of `lib.symbol(..)` — sound because
+        // On null: only `build_ptr` is checked at its use site. The other
+        // transmutes come straight out of `lib.symbol(..)` — sound because
         // `get_symbol` maps a null `dlsym` result to `None`, so a `Some` is
-        // already non-null. The earlier wording claimed a site-level check
-        // that is not there.
+        // already non-null.
         unsafe {
-            let build_ptr = lib.symbol(build_sym)?;
+            let build_ptr = lib.symbol(&format!("{family}_build"))?;
             if build_ptr.is_null() {
                 return None;
             }
             let build_fn: BuildSceneFn = std::mem::transmute(build_ptr);
 
-            let drop_fn: Option<SceneDropFn> =
-                lib.symbol(drop_sym).map(|ptr| std::mem::transmute(ptr));
+            // ABI handshake FIRST: nothing else about the library may be
+            // trusted (not even calling its version fn is interesting) until
+            // the layout premise is established.
+            let Some(token_ptr) = lib.symbol(&format!("{family}_abi_token")) else {
+                tracing::error!(
+                    family,
+                    path = %lib.path().display(),
+                    "plugin refused: no ABI-token symbol — rebuild it against \
+                     this tree (the ownership-safe plugin ABI requires it)"
+                );
+                return None;
+            };
+            let token_fn: AbiTokenFn = std::mem::transmute(token_ptr);
+            let plugin_token = token_fn();
+            let host_token = crate::abi_token();
+            if plugin_token != host_token {
+                tracing::error!(
+                    family,
+                    plugin_token,
+                    host_token,
+                    path = %lib.path().display(),
+                    "plugin refused: ABI token mismatch — host and plugin \
+                     were built by different compilers or source revisions; \
+                     rebuild both from one worktree with one toolchain"
+                );
+                return None;
+            }
 
-            let version = lib.symbol(version_sym).map_or(0, |ptr| {
+            let Some(free_ptr) = lib.symbol(&format!("{family}_free")) else {
+                tracing::error!(
+                    family,
+                    path = %lib.path().display(),
+                    "plugin refused: no deallocate-only symbol — rebuild it \
+                     against this tree"
+                );
+                return None;
+            };
+            let free_fn: SceneFreeFn = std::mem::transmute(free_ptr);
+
+            let drop_fn: Option<SceneDropFn> = lib
+                .symbol(&format!("{family}_drop"))
+                .map(|ptr| std::mem::transmute::<*mut std::ffi::c_void, SceneDropFn>(ptr));
+
+            let version = lib.symbol(&format!("{family}_version")).map_or(0, |ptr| {
                 let version_fn: SceneVersionFn = std::mem::transmute(ptr);
                 version_fn()
             });
 
-            Some((build_fn, drop_fn, version))
+            Some(ResolvedSceneFamily {
+                build_fn,
+                free_fn,
+                drop_fn,
+                version,
+            })
         }
     }
 
     /// Build a scene by calling the plugin's `flui_scene_build` function.
     ///
-    /// The plugin allocates a `Box<Scene>` and returns it as a raw pointer.
-    /// This method takes ownership back via `Box::from_raw`.
+    /// The plugin allocates a `Box<Scene>` and returns it raw; this method
+    /// moves the `Scene` value out with `ptr::read` and hands the emptied box
+    /// back to the plugin's `flui_*_free`, so allocation and deallocation
+    /// both happen inside the plugin image. Layout agreement between the two
+    /// `repr(Rust)` compilations is established at `load` by the ABI-token
+    /// handshake (same compiler, same crate revision — see [`crate::abi_token`]).
     ///
     /// # Safety
     ///
-    /// This cannot be a safe function. It reclaims, with the HOST's drop glue
-    /// and allocator, a `Box<Scene>` that the PLUGIN allocated — and `Scene` is
-    /// `repr(Rust)`, so nothing guarantees the two compilations agree on its
-    /// layout. The caller must establish, out of band, that:
-    ///
-    /// * host and plugin were built by the same compiler from the same source
-    ///   revision with the same features (nothing here checks it — the plugin's
-    ///   `flui_*_version` symbol is resolved and never compared);
-    /// * neither side installs a `#[global_allocator]`, so both `__rust_alloc`
-    ///   implementations bottom out in the same `malloc`;
-    /// * the returned `Scene` is dropped BEFORE the library is unloaded — it
-    ///   holds `Box<dyn FnOnce>` and `Arc<dyn Any>` whose vtables live in the
-    ///   plugin image, so dropping it after `dlclose` is a use-after-free of
-    ///   code. No lifetime ties the two.
-    ///
-    /// The plugin exports `flui_scene_drop`, which is the deallocator that
-    /// *would* discharge the first two obligations; this path bypasses it.
-    /// Treat hot-reload as a development-only path until that is redesigned.
+    /// One obligation remains with the caller, and it is why this stays an
+    /// `unsafe fn`: the returned `Scene` holds `Box<dyn FnOnce>` and
+    /// `Arc<dyn Any>` whose vtables live in the plugin image, so the caller
+    /// must drop it BEFORE the library is unloaded. No lifetime ties the
+    /// scene to the [`DynLib`]; dropping it after `dlclose` is a
+    /// use-after-free of code. Development-only tooling either way.
     #[allow(unsafe_code)]
     pub unsafe fn build_scene(&self, width: f32, height: f32) -> Scene {
-        // SAFETY, to the extent it can be claimed: `build_fn` was resolved from
-        // the `DynLib` this struct owns and which outlives the call, and
-        // `scene_plugin!` really does return `Box::into_raw(Box::new(scene))`,
-        // so exactly one `Box::from_raw` is correct arity. Null is rejected
-        // first.
-        //
-        // This is NOT sufficient, and saying otherwise would be dishonest. The
-        // load-bearing premises are unestablished:
-        //   * `Scene` is `repr(Rust)`. Nothing guarantees the host and the
-        //     plugin — separate compilations, each with its own copy of
-        //     flui-layer, loaded `RTLD_LOCAL` — agree on its layout.
-        //   * the `Box` is allocated by the plugin and freed here, by the
-        //     host's drop glue and `__rust_dealloc`. That works only because
-        //     neither side installs a `#[global_allocator]` and both bottom
-        //     out in the one shared libc `malloc`.
-        //   * `Scene` holds `Box<dyn FnOnce>` and `Arc<dyn Any>` whose vtables
-        //     live in the plugin image, so dropping it after `unload` is a
-        //     use-after-free of code. No lifetime ties the two.
-        // The plugin exports `flui_scene_drop` — the deallocator that would be
-        // correct — and this path bypasses it. Redesign tracked; treat
-        // hot-reload as a development-only path until then.
+        // SAFETY: `build_fn`/`free_fn` were resolved from the `DynLib` this
+        // struct owns, which outlives the call. The plugin macro returns
+        // `Box::into_raw(Box::new(scene))`, so `ptr` addresses one live,
+        // initialized `Scene`; the load-time token handshake establishes that
+        // both compilations agree on `Scene`'s layout, making the `ptr::read`
+        // a valid move. After the read the box's contents are logically moved
+        // out, and `free_fn` deallocates without dropping (it reads the slot
+        // as `MaybeUninit<Scene>`), in the image that allocated it — no
+        // cross-image allocator or drop-glue mismatch remains.
         #[allow(unsafe_code)]
         unsafe {
             let ptr = (self.build_fn)(width, height);
             assert!(!ptr.is_null(), "flui_scene_build returned null");
-            *Box::from_raw(ptr.cast::<Scene>())
+            let scene = std::ptr::read(ptr.cast::<Scene>());
+            (self.free_fn)(ptr);
+            scene
         }
     }
 

--- a/crates/flui-hot-reload/src/lib.rs
+++ b/crates/flui-hot-reload/src/lib.rs
@@ -4,25 +4,29 @@
 //!
 //! ## Development-only
 //!
-//! **Do not ship an application that reaches this crate at runtime.** The plugin
-//! boundary is unsound by construction, not by omission:
+//! **Do not ship an application that reaches this crate at runtime.** The
+//! boundary contracts are enforced as far as a dlopen design allows, and the
+//! remaining exposure is documented rather than hidden:
 //!
-//! * [`ScenePlugin::build_scene`] reclaims, with the host's drop glue and
-//!   allocator, a `Box<Scene>` the plugin allocated. `Scene` is `repr(Rust)`, so
-//!   nothing guarantees the two compilations agree on its layout, and it works
-//!   today only because neither side installs a `#[global_allocator]`. It is an
-//!   `unsafe fn` whose contract the caller cannot fully discharge.
-//! * A returned `Scene` holds `Box<dyn FnOnce>` and `Arc<dyn Any>` whose vtables
-//!   live in the plugin image, and no lifetime ties it to [`dynlib::DynLib`]'s
-//!   `dlclose`.
-//! * [`worker::get_worker_build_ptr`] hands out a code address that dangles after
-//!   [`worker::WorkerPlugin::unload`] — the registry is never pruned.
-//! * The plugin's `flui_*_version` symbol is resolved and never compared against
-//!   a host-expected value, and `flui_scene_drop` — the deallocator that would
-//!   be correct — is resolved and never called.
-//!
-//! Making this sound needs an opaque-handle C ABI, or never unloading the
-//! library, or process isolation. Tracked; until then this is a dev-loop tool.
+//! * Layout agreement for the `repr(Rust)` payloads is established by an
+//!   ABI-token handshake ([`abi_token`]): every plugin macro exports
+//!   `flui_*_abi_token`, and each loader refuses a library whose token
+//!   (compiler identity + crate version + payload size/align) differs from
+//!   the host's. Same-token builds from one worktree are the only supported
+//!   configuration.
+//! * Scene memory is allocated AND deallocated inside the plugin image: the
+//!   host moves the value out with `ptr::read` and returns the emptied box
+//!   through `flui_*_free`, so no cross-image allocator or drop-glue pairing
+//!   is assumed.
+//! * The worker build registry is pruned by [`worker::WorkerPlugin`]'s `Drop`
+//!   BEFORE its image unmaps, so [`worker::get_worker_build_ptr`] returning
+//!   `Some` implies a live image; `None` means "worker unavailable".
+//! * What remains, and why this stays a dev-loop tool: a returned `Scene`
+//!   holds `Box<dyn FnOnce>` and `Arc<dyn Any>` whose vtables live in the
+//!   plugin image, and no lifetime ties it to [`dynlib::DynLib`]'s `dlclose`
+//!   — the caller must drop the scene before unloading
+//!   ([`ScenePlugin::build_scene`] stays `unsafe` for exactly this), and the
+//!   token handshake is a strong tripwire, not a proof of layout equality.
 //!
 //! ## Two-Layer Architecture
 //!
@@ -47,8 +51,11 @@
 //!
 //! The plugin builds a real [`flui_layer::Scene`] using normal FLUI APIs.
 //! The macro wraps it with `extern "C"` functions that pass an opaque pointer
-//! (`Box::into_raw`) across the FFI boundary. The host takes ownership back
-//! via `Box::from_raw`. No serialization, no `#[repr(C)]` types needed.
+//! (`Box::into_raw`) across the FFI boundary. The host moves the value out
+//! with `ptr::read` and hands the emptied box back to the plugin's
+//! `flui_*_free`, after the load-time ABI-token handshake has established
+//! that both sides agree on the layout. No serialization, no `#[repr(C)]`
+//! types needed.
 //!
 //! ## Cross-Platform
 //!
@@ -118,6 +125,9 @@ pub mod strategy;
 pub mod dev;
 
 pub mod engine;
+
+mod abi;
+pub use abi::abi_token;
 
 #[cfg(feature = "app-plugin")]
 mod pipeline;

--- a/crates/flui-hot-reload/src/plugin.rs
+++ b/crates/flui-hot-reload/src/plugin.rs
@@ -21,6 +21,11 @@
 ///   detection)
 /// - `flui_scene_drop(ptr)` — drops a Scene previously returned by
 ///   `flui_scene_build`
+/// - `flui_scene_free(ptr)` — deallocates the box WITHOUT dropping the Scene
+///   (the host moves the value out with `ptr::read` first, so allocation and
+///   deallocation both happen inside the plugin image)
+/// - `flui_scene_abi_token() -> u64` — the plugin-side
+///   [`abi_token`](crate::abi_token); the host refuses to load on mismatch
 ///
 /// # Example
 ///
@@ -84,6 +89,37 @@ macro_rules! scene_plugin {
                 }
             }
         }
+
+        /// Deallocate the box behind `ptr` WITHOUT dropping the `Scene` inside.
+        ///
+        /// The host consumes the scene with `ptr::read` and then hands the
+        /// now-logically-empty box back here, so the memory is released by the
+        /// same image (and the same allocator/layout knowledge) that allocated
+        /// it.
+        ///
+        /// # Safety
+        ///
+        /// `ptr` must come from `flui_scene_build`, and the host must have
+        /// already moved the `Scene` value out — after this call the pointee
+        /// is gone. Passing null is safe (no-op).
+        #[unsafe(no_mangle)]
+        pub extern "C" fn flui_scene_free(ptr: *mut ::std::ffi::c_void) {
+            if !ptr.is_null() {
+                #[allow(unsafe_code)]
+                unsafe {
+                    drop(::std::boxed::Box::from_raw(
+                        ptr as *mut ::std::mem::MaybeUninit<::flui_layer::Scene>,
+                    ));
+                }
+            }
+        }
+
+        /// Plugin-side ABI-compatibility token; the host refuses to load this
+        /// library unless it equals the host's own token.
+        #[unsafe(no_mangle)]
+        pub extern "C" fn flui_scene_abi_token() -> u64 {
+            $crate::abi_token()
+        }
     };
 }
 
@@ -127,6 +163,13 @@ macro_rules! hot_reload_worker {
         pub extern "C" fn flui_worker_fingerprint() -> u64 {
             $fp
         }
+
+        /// Worker-side ABI-compatibility token; the host refuses to load this
+        /// library unless it equals the host's own token.
+        #[unsafe(no_mangle)]
+        pub extern "C" fn flui_worker_abi_token() -> u64 {
+            $crate::abi_token()
+        }
     };
 }
 
@@ -150,6 +193,10 @@ macro_rules! hot_reload_worker {
 ///   detection)
 /// - `flui_app_drop(ptr)` — drops a Scene previously returned by
 ///   `flui_app_build`
+/// - `flui_app_free(ptr)` — deallocates the box WITHOUT dropping the Scene
+///   (host moves the value out first; see `scene_plugin!`)
+/// - `flui_app_abi_token() -> u64` — plugin-side
+///   [`abi_token`](crate::abi_token); the host refuses to load on mismatch
 ///
 /// # Example
 ///
@@ -225,6 +272,32 @@ macro_rules! app_plugin {
                     drop(::std::boxed::Box::from_raw(ptr as *mut ::flui_layer::Scene));
                 }
             }
+        }
+
+        /// Deallocate the box behind `ptr` WITHOUT dropping the `Scene` inside.
+        ///
+        /// # Safety
+        ///
+        /// `ptr` must come from `flui_app_build`, and the host must have
+        /// already moved the `Scene` value out — after this call the pointee
+        /// is gone. Passing null is safe (no-op).
+        #[no_mangle]
+        pub extern "C" fn flui_app_free(ptr: *mut ::std::ffi::c_void) {
+            if !ptr.is_null() {
+                #[allow(unsafe_code)]
+                unsafe {
+                    drop(::std::boxed::Box::from_raw(
+                        ptr as *mut ::std::mem::MaybeUninit<::flui_layer::Scene>,
+                    ));
+                }
+            }
+        }
+
+        /// Plugin-side ABI-compatibility token; the host refuses to load this
+        /// library unless it equals the host's own token.
+        #[no_mangle]
+        pub extern "C" fn flui_app_abi_token() -> u64 {
+            $crate::abi_token()
         }
     };
 }

--- a/crates/flui-hot-reload/src/worker.rs
+++ b/crates/flui-hot-reload/src/worker.rs
@@ -25,8 +25,16 @@ fn worker_builds() -> &'static Mutex<HashMap<u64, BuildPtr>> {
     WORKER_BUILDS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// While a [`WorkerPlugin`] init call is in flight, collects the
+/// `(fingerprint, ptr)` pairs it registers, so the plugin can prune exactly
+/// those entries when it unloads. `None` outside an init call — a registration
+/// arriving then still lands in the map but belongs to no plugin (and is
+/// logged), so it can never be pruned; workers must register from
+/// `flui_worker_init` only.
+static REGISTRATION_SESSION: Mutex<Option<Vec<(u64, BuildPtr)>>> = Mutex::new(None);
+
 /// Type-erased function pointer — safe to store in a `Sync` static.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 struct BuildPtr(*const ());
 
 // SAFETY: a code address is a `Copy` integer as far as these auto traits are
@@ -39,11 +47,11 @@ struct BuildPtr(*const ());
 // nothing enforces a calling thread — `get_worker_build_ptr` is public and
 // takes no thread context.
 //
-// The real hazard is lifetime, not threading, and these impls do not address
-// it: `WORKER_BUILDS` is a `'static` map that is never pruned, so after
-// `WorkerPlugin::unload` unmaps the image the stored address dangles and
-// calling it jumps into unmapped memory. Tracked with the plugin-boundary
-// redesign; see the module docs.
+// Lifetime: the address is only as live as the worker image it points into.
+// [`WorkerPlugin`]'s `Drop` prunes this plugin's entries from `WORKER_BUILDS`
+// BEFORE `DynLib::drop` unmaps the image, so a map hit implies the image is
+// still mapped (single-threaded host loop; a caller racing an unload from
+// another thread is outside the supported dev-loop).
 #[allow(unsafe_code)]
 unsafe impl Send for BuildPtr {}
 #[allow(unsafe_code)]
@@ -59,10 +67,24 @@ extern "C" fn host_register_worker_build(fingerprint: u64, build: *const ()) {
         );
         return;
     }
+    let ptr = BuildPtr(build);
     worker_builds()
         .lock()
         .expect("worker build registry poisoned")
-        .insert(fingerprint, BuildPtr(build));
+        .insert(fingerprint, ptr);
+    if let Some(session) = &mut *REGISTRATION_SESSION
+        .lock()
+        .expect("worker registration session poisoned")
+    {
+        session.push((fingerprint, ptr));
+    } else {
+        tracing::warn!(
+            fingerprint,
+            "worker build registered outside flui_worker_init — the entry \
+             cannot be pruned on unload and will dangle after the image is \
+             unmapped"
+        );
+    }
     tracing::debug!(fingerprint, "worker build registered in host");
 }
 
@@ -74,19 +96,17 @@ pub fn host_register_fn() -> RegisterWorkerBuildFn {
 
 /// Look up a worker-registered build function by layout fingerprint.
 ///
-/// # Safety of the returned pointer
+/// Returns `None` when no live worker has registered this fingerprint —
+/// including after an unload or a failed reload: [`WorkerPlugin`]'s `Drop`
+/// prunes its own registrations from the registry BEFORE the image is
+/// unmapped, so a `Some` here points into a still-mapped image. Treat `None`
+/// as "worker unavailable" and fall back (or fail loudly), never cache a
+/// previously returned pointer across frames.
 ///
-/// This function is safe — it only reads a map — but the address it returns is
-/// **not guaranteed to be live**. It points into the worker dylib, and
-/// [`WorkerPlugin::unload`] unmaps that image WITHOUT removing the entry (the
-/// registry is a `'static` map that is never pruned). After an unload, or after
-/// a failed reload that already dropped the old library, transmuting and calling
-/// this pointer jumps into unmapped memory.
-///
-/// A caller must therefore establish out of band that no unload has happened
-/// since registration. Fixing this properly means pruning the registry in
-/// `unload` and treating a missing entry as "worker unavailable"; tracked with
-/// the plugin-boundary redesign.
+/// The one unpruned case: a registration made outside `flui_worker_init`
+/// (logged as a warning at registration time) belongs to no plugin and WILL
+/// dangle after that image unloads — workers must register from their init
+/// hook only.
 #[must_use]
 pub fn get_worker_build_ptr(fingerprint: u64) -> Option<*const ()> {
     worker_builds()
@@ -99,6 +119,7 @@ pub fn get_worker_build_ptr(fingerprint: u64) -> Option<*const ()> {
 type WorkerInitFn = extern "C" fn(RegisterWorkerBuildFn);
 type WorkerVersionFn = extern "C" fn() -> u32;
 type WorkerFingerprintFn = extern "C" fn() -> u64;
+type WorkerAbiTokenFn = extern "C" fn() -> u64;
 
 /// A loaded hot-reload worker dylib (`my_app_logic.dll`).
 #[allow(missing_debug_implementations)]
@@ -108,12 +129,17 @@ pub struct WorkerPlugin {
     fingerprint_fn: Option<WorkerFingerprintFn>,
     version: u32,
     mtime: u64,
+    /// The `(fingerprint, ptr)` pairs this plugin's init hook registered in
+    /// `WORKER_BUILDS` — pruned by `Drop` before the image is unmapped.
+    registered: Mutex<Vec<(u64, BuildPtr)>>,
 }
 
 impl WorkerPlugin {
     /// Load a worker from `lib_path` and call its `flui_worker_init` hook.
     ///
-    /// Returns `None` when the file is missing, unloadable, or lacks worker symbols.
+    /// Returns `None` when the file is missing, unloadable, lacks worker
+    /// symbols, or fails the ABI-token handshake (built by a different
+    /// compiler or source revision than this host — see [`crate::abi_token`]).
     pub fn load(lib_path: impl AsRef<Path>) -> Option<Self> {
         let lib_path = lib_path.as_ref();
         let lib = DynLib::open(lib_path)?;
@@ -129,6 +155,33 @@ impl WorkerPlugin {
                 return None;
             }
             let init_fn: WorkerInitFn = std::mem::transmute(init_ptr);
+
+            // ABI handshake before calling anything else in the image: build
+            // pointers registered by init are transmuted to typed fn pointers
+            // whose argument types are `repr(Rust)`, so layout agreement must
+            // be established first.
+            let Some(token_ptr) = lib.symbol("flui_worker_abi_token") else {
+                tracing::error!(
+                    path = %lib_path.display(),
+                    "worker refused: no ABI-token symbol — rebuild it against \
+                     this tree (the ownership-safe worker ABI requires it)"
+                );
+                return None;
+            };
+            let token_fn: WorkerAbiTokenFn = std::mem::transmute(token_ptr);
+            let worker_token = token_fn();
+            let host_token = crate::abi_token();
+            if worker_token != host_token {
+                tracing::error!(
+                    worker_token,
+                    host_token,
+                    path = %lib_path.display(),
+                    "worker refused: ABI token mismatch — host and worker were \
+                     built by different compilers or source revisions; rebuild \
+                     both from one worktree with one toolchain"
+                );
+                return None;
+            }
 
             let version = lib.symbol("flui_worker_version").map_or(0, |ptr| {
                 let version_fn: WorkerVersionFn = std::mem::transmute(ptr);
@@ -146,6 +199,7 @@ impl WorkerPlugin {
                 fingerprint_fn,
                 version,
                 mtime,
+                registered: Mutex::new(Vec::new()),
             };
             plugin.init();
             tracing::info!(
@@ -157,9 +211,25 @@ impl WorkerPlugin {
         }
     }
 
-    /// Re-run the worker's registration hook (`flui_worker_init`).
+    /// Re-run the worker's registration hook (`flui_worker_init`), recording
+    /// what it registers so `Drop` can prune exactly those entries.
     pub fn init(&self) {
+        {
+            let mut session = REGISTRATION_SESSION
+                .lock()
+                .expect("worker registration session poisoned");
+            *session = Some(Vec::new());
+        }
         (self.init_fn)(host_register_fn());
+        let registered_now = REGISTRATION_SESSION
+            .lock()
+            .expect("worker registration session poisoned")
+            .take()
+            .unwrap_or_default();
+        self.registered
+            .lock()
+            .expect("worker registration list poisoned")
+            .extend(registered_now);
     }
 
     /// Type-layout fingerprint exported by the worker (0 when absent).
@@ -175,6 +245,7 @@ impl WorkerPlugin {
     /// Unload the worker library.
     pub fn unload(self) {
         tracing::info!(version = self.version, "Worker plugin unloaded");
+        // Drop prunes this plugin's registry entries, then DynLib unmaps.
     }
 
     /// Path this worker was loaded from.
@@ -188,6 +259,36 @@ impl WorkerPlugin {
     }
 }
 
+impl Drop for WorkerPlugin {
+    fn drop(&mut self) {
+        // Prune this plugin's registrations BEFORE `self.lib` drops (fields
+        // drop in declaration order; `lib` is declared first but `Drop::drop`
+        // runs before ANY field drops), so `get_worker_build_ptr` can never
+        // observe an address into an unmapped image. An entry is removed only
+        // while it still holds the pointer this plugin registered — a newer
+        // plugin that re-registered the same fingerprint keeps its (live)
+        // entry.
+        let registered = std::mem::take(
+            &mut *self
+                .registered
+                .lock()
+                .expect("worker registration list poisoned"),
+        );
+        if registered.is_empty() {
+            return;
+        }
+        let mut builds = worker_builds()
+            .lock()
+            .expect("worker build registry poisoned");
+        for (fingerprint, ptr) in registered {
+            if builds.get(&fingerprint) == Some(&ptr) {
+                builds.remove(&fingerprint);
+                tracing::debug!(fingerprint, "worker build pruned on unload");
+            }
+        }
+    }
+}
+
 /// Result of polling a [`WorkerReloadDriver`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WorkerPollOutcome {
@@ -198,6 +299,21 @@ pub enum WorkerPollOutcome {
     Reloaded {
         /// How many reloads since the driver was created (includes the first load).
         reload_count: u32,
+    },
+
+    /// The dylib reloaded, but its layout fingerprint changed: the shared
+    /// `types` crate's layout no longer matches what the host was compiled
+    /// against, so the host must NOT call the newly registered build fns with
+    /// its old-layout state. Lookups keyed by the host's compiled-in
+    /// fingerprint miss the new registrations, degrading to "worker
+    /// unavailable" (this is the producer of the degradation
+    /// [`crate::HotReloadOutcome::Degraded`] names). Restart the host to pick
+    /// up the new layout.
+    Degraded {
+        /// Fingerprint the previous worker reported.
+        old_fingerprint: u64,
+        /// Fingerprint the reloaded worker reports.
+        new_fingerprint: u64,
     },
 
     /// An update was detected but reload failed (file locked / missing symbols).
@@ -317,7 +433,30 @@ impl WorkerReloadDriver {
             if let Some(ref plugin) = self.plugin {
                 self.loaded_path = load_path;
                 self.reload_count += 1;
+                let old_fingerprint = self.last_fingerprint;
                 self.last_fingerprint = plugin.fingerprint();
+                // A changed fingerprint means the shared `types` layout moved
+                // under the host: surface the degradation instead of
+                // reporting a healthy reload. (The old worker's registry
+                // entries were pruned on its unload, and the host's
+                // fingerprint-keyed lookups miss the new ones, so builds
+                // degrade to "worker unavailable" rather than calling across
+                // an incompatible layout.)
+                if old_fingerprint != DEFAULT_FINGERPRINT
+                    && self.last_fingerprint != old_fingerprint
+                {
+                    tracing::warn!(
+                        old_fingerprint,
+                        new_fingerprint = self.last_fingerprint,
+                        "WorkerReloadDriver: worker layout fingerprint changed \
+                         — degraded to worker-unavailable; restart the host to \
+                         adopt the new layout"
+                    );
+                    return WorkerPollOutcome::Degraded {
+                        old_fingerprint,
+                        new_fingerprint: self.last_fingerprint,
+                    };
+                }
                 tracing::info!(
                     reload = self.reload_count,
                     fingerprint = self.last_fingerprint,
@@ -350,5 +489,97 @@ impl WorkerReloadDriver {
         }
 
         WorkerPollOutcome::NoChange
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The registry mutex plus the session mutex are process-global; tests
+    /// that touch them must not interleave.
+    static REGISTRY_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Runs `body` with a fresh registration session, returning what it
+    /// registered — the same bracket `WorkerPlugin::init` uses.
+    fn with_session<R>(body: impl FnOnce() -> R) -> (R, Vec<(u64, BuildPtr)>) {
+        *REGISTRATION_SESSION.lock().unwrap() = Some(Vec::new());
+        let out = body();
+        let session = REGISTRATION_SESSION
+            .lock()
+            .unwrap()
+            .take()
+            .unwrap_or_default();
+        (out, session)
+    }
+
+    /// Mirrors `WorkerPlugin::drop`'s prune loop without needing a dylib.
+    fn prune(registered: Vec<(u64, BuildPtr)>) {
+        let mut builds = worker_builds().lock().unwrap();
+        for (fingerprint, ptr) in registered {
+            if builds.get(&fingerprint) == Some(&ptr) {
+                builds.remove(&fingerprint);
+            }
+        }
+    }
+
+    #[test]
+    fn unload_prunes_exactly_the_sessions_registrations() {
+        let _guard = REGISTRY_TEST_LOCK.lock().unwrap();
+        let fp_a = 0xA11C_E001;
+        let fp_b = 0xA11C_E002;
+        let addr_one = 0x1000 as *const ();
+        let addr_two = 0x2000 as *const ();
+
+        let ((), session) = with_session(|| {
+            host_register_worker_build(fp_a, addr_one);
+            host_register_worker_build(fp_b, addr_two);
+        });
+        assert_eq!(session.len(), 2, "both registrations recorded");
+        assert_eq!(get_worker_build_ptr(fp_a), Some(addr_one));
+        assert_eq!(get_worker_build_ptr(fp_b), Some(addr_two));
+
+        prune(session);
+        assert_eq!(
+            get_worker_build_ptr(fp_a),
+            None,
+            "a pruned fingerprint must read as worker-unavailable",
+        );
+        assert_eq!(get_worker_build_ptr(fp_b), None);
+    }
+
+    #[test]
+    fn prune_keeps_a_fingerprint_a_newer_session_re_registered() {
+        let _guard = REGISTRY_TEST_LOCK.lock().unwrap();
+        let fp = 0xA11C_E003;
+        let old_addr = 0x3000 as *const ();
+        let new_addr = 0x4000 as *const ();
+
+        let ((), old_session) = with_session(|| host_register_worker_build(fp, old_addr));
+        // Reload: the new worker re-registers the same fingerprint before the
+        // old plugin's entries are pruned (out-of-order drop).
+        let ((), _new_session) = with_session(|| host_register_worker_build(fp, new_addr));
+
+        prune(old_session);
+        assert_eq!(
+            get_worker_build_ptr(fp),
+            Some(new_addr),
+            "the newer registration must survive the older session's prune",
+        );
+
+        // Cleanup so other tests see an empty registry.
+        worker_builds().lock().unwrap().remove(&fp);
+    }
+
+    #[test]
+    fn null_registration_is_rejected_and_not_recorded() {
+        let _guard = REGISTRY_TEST_LOCK.lock().unwrap();
+        let fp = 0xA11C_E004;
+        let ((), session) = with_session(|| host_register_worker_build(fp, std::ptr::null()));
+        assert!(
+            session.is_empty(),
+            "null pointer must not enter the session"
+        );
+        assert_eq!(get_worker_build_ptr(fp), None);
     }
 }

--- a/examples/hot_reload_counter/types/src/lib.rs
+++ b/examples/hot_reload_counter/types/src/lib.rs
@@ -19,8 +19,15 @@ type CounterBuildFn = fn(WorkerBuildEnv<'_>, &CounterAppState, &CounterApp) -> B
 
 #[allow(unsafe_code)]
 fn get_counter_build() -> CounterBuildFn {
-    let ptr = flui_hot_reload::get_worker_build_ptr(TYPE_FINGERPRINT)
-        .expect("counter worker not loaded — build the logic crate and set FLUI_WORKER_PLUGIN");
+    // `None` is now a clean "worker unavailable" signal (the registry is
+    // pruned before an image unmaps, and a layout-fingerprint change after a
+    // reload registers under a different key), so this panic is a loud but
+    // safe failure — never a jump into unmapped code.
+    let ptr = flui_hot_reload::get_worker_build_ptr(TYPE_FINGERPRINT).expect(
+        "counter worker unavailable — build the logic crate, set \
+         FLUI_WORKER_PLUGIN, and restart the host if the shared types layout \
+         changed (fingerprint mismatch)",
+    );
     // SAFETY: the worker registers this pointer via host-owned storage in
     // `flui_worker_init` with the same `CounterBuildFn` signature.
     unsafe { std::mem::transmute(ptr) }


### PR DESCRIPTION
Closes the three hot-reload boundary defects recorded in the 2026-07-25 upgrade-pack audit (status notes + U16 §28). Verification against HEAD confirmed all three were candidly documented in SAFETY comments but behaviorally unrepaired.

**1. Dangling worker registry.** `WORKER_BUILDS` was never pruned; after `WorkerPlugin::unload` unmapped the image, `get_worker_build_ptr` returned an address into unmapped code. Now: registrations are recorded per `flui_worker_init` session, and `WorkerPlugin::Drop` prunes exactly its own `(fingerprint, ptr)` pairs before `DynLib` unmaps — `Some` implies a live image, `None` means "worker unavailable". A fingerprint re-registered by a newer worker survives the older worker's prune (pointer-matched removal). A registration made outside the init hook is warned about at registration time (unprunable by design).

**2. Cross-image Box ownership.** The host reclaimed a plugin-allocated `Box<Scene>` with its own drop glue/allocator; `flui_scene_drop` was resolved and never called. Now the host `ptr::read`s the value out and returns the emptied box via new `flui_scene_free`/`flui_app_free` exports (dealloc-without-drop through `MaybeUninit<Scene>`), so allocation and deallocation both happen inside the plugin image. `build_scene` remains `unsafe` for the one untypeable obligation: drop the scene before unload (its dyn vtables live in the plugin image).

**3. No ABI handshake (U16).** `Scene` is `repr(Rust)`; the transfer was sound only under an unchecked same-compiler-same-source premise. Every plugin macro now exports `flui_*_abi_token` — a hash of the exact `rustc -vV` identity (captured by a new build script that fails loudly if it can't run rustc), the crate version, and `Scene`/`LayerTree` size+align — and both loaders refuse a mismatching or token-less library before calling anything else in it. Equal tokens are a strong tripwire, not a proof; the doc says so explicitly.

**Degraded is finally produced:** `WorkerReloadDriver::poll` returns a new `WorkerPollOutcome::Degraded { old_fingerprint, new_fingerprint }` when a reload changes the worker's layout fingerprint (the flui-app call site uses `matches!(… Reloaded …)`, so it correctly does NOT treat a degraded reload as healthy). This is the producer `HotReloadOutcome::Degraded` promised and never had.

Tests: registry prune semantics ×3 + token stability; crate suite 14/14; full `just ci` green; taplo green. **Not covered:** a real dlopen round-trip (needs a built artifact — loader tests cover refusal paths; the example crates compile the macro expansions, so symbol generation is machine-checked).

Compatibility note: plugins built before this PR no longer load (missing token/free symbols, by design) — rebuild from the same tree, which is the only supported dev-loop anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)