### PR TITLE
ci: close three audited gate gaps — feature pairs, bench numbers, wasm import surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,11 @@ name: CI
 # Job graph (every job is gated on the fast `checks` source gate):
 #   checks         — fmt + taplo + typos + inventory + port-check + actionlint + zizmor (seconds, no compile)
 #   clippy         — workspace lint with -D warnings
-#   feature-matrix — cargo-hack per-feature clippy (--each-feature --optional-deps), xilem-style
-#   wasm-check     — cargo check --target wasm32-unknown-unknown for the wasm-capable crates
-#   cross-typecheck — cargo check (no link, no tests) of flui-platform's windows + macos backends
+#   feature-matrix — cargo-hack per-feature clippy (--each-feature --optional-deps), xilem-style,
+#                    plus a bounded backend-feature-pair powerset for flui-engine
+#   wasm-check     — cargo check for the wasm-capable crates + real cdylib link of the two web
+#                    demos + import-surface check against scripts/wasm-import-allowlist.txt
+#   cross-typecheck — cargo clippy (no link, no tests) of flui-platform's windows + macos backends
 #   test           — build + nextest (lib + integration), ubuntu
 #   gpu-test       — full enable-wgpu-tests readback suite on windows/WARP (merge-blocking)
 #   bench-compile  — criterion benches compile + link
@@ -613,6 +615,16 @@ jobs:
       - name: cargo hack clippy (tests/benches/examples, per feature)
         run: cargo hack clippy --workspace --locked --each-feature --optional-deps --keep-going --tests --benches --examples -- -D warnings
 
+      # --each-feature can never see a defect that only appears when two
+      # features combine. flui-engine is the one crate where combinations
+      # matter (its backend features are ADDITIVE by design — enabling two
+      # compiles both wgpu backends), so pairwise coverage there is bounded
+      # and meaningful: depth 2 over the six backend-adjacent features is ~22
+      # configurations, minutes not hours. The full workspace powerset stays
+      # deliberately out (2^N explosion for no known failure mode).
+      - name: cargo hack check flui-engine (backend-feature pairs)
+        run: cargo hack check -p flui-engine --locked --feature-powerset --include-features vulkan,metal,dx12,webgpu,gles,wgpu-backend --depth 2
+
   # ─────────────────────────────────────────────────────────────────────────
   # wasm-check — the web platform claim, machine-checked. web_demo /
   # painting_demo are workspace members but were only ever compiled for the
@@ -664,6 +676,26 @@ jobs:
 
       - name: cargo check (wasm32)
         run: cargo check --workspace --locked --target wasm32-unknown-unknown ${{ env.NO_WASM_PKGS }}
+
+      # `cargo check` does not link. rust-lld resolves a wasm cdylib for
+      # real — and on wasm32 an undefined symbol does not even fail the link
+      # (it becomes an import), so linking alone is still not the full claim.
+      - name: cargo build (wasm cdylibs — real link)
+        run: cargo build --locked --target wasm32-unknown-unknown -p flui-web-demo -p flui-painting-demo
+
+      - name: Install wasm-tools
+        uses: taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7 # v2.85.0
+        with:
+          tool: wasm-tools@1
+
+      # ...which is why the import surface is a committed, reviewed artifact:
+      # any module outside scripts/wasm-import-allowlist.txt (most notably
+      # `env`, the catch-all for accidental native externs) fails here.
+      - name: Check wasm import surface against the allowlist
+        run: >-
+          bash scripts/check-wasm-imports.sh
+          target/wasm32-unknown-unknown/debug/flui_web_demo.wasm
+          target/wasm32-unknown-unknown/debug/flui_painting_demo.wasm
 
   # ─────────────────────────────────────────────────────────────────────────
   # cross-typecheck — flui-platform's per-OS backends, LINTED from Linux.

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -6,6 +6,11 @@ name: Weekly
 #   latest-deps — upstream semver breakage: fresh `cargo update` + full build
 #                 and test run, so a breaking dependency release surfaces here
 #                 before it lands in someone's PR
+#   bench       — executes the criterion benches and uploads the numbers as
+#                 an artifact. TREND DATA ONLY, never a gate: shared runners
+#                 are noisy, so the numbers support "did this drift over
+#                 weeks", not "did this PR regress" — real A/B comparisons
+#                 happen locally via `just bench-save` / `just bench-compare`.
 # Runs Monday ~05:17 UTC (off the :00/:30 herd marks). Not a merge gate;
 # failures surface in the Actions tab.
 
@@ -84,3 +89,34 @@ jobs:
 
       - name: cargo nextest run (lib + integration)
         run: cargo nextest run --workspace --exclude flui-platform --no-fail-fast
+
+  bench:
+    name: bench (criterion numbers, trend artifact)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    # Advisory by design: a noisy-runner outlier must not page anyone.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      # The script enumerates the real [[bench]] targets (plain `cargo bench`
+      # also selects libtest-harness targets, which reject criterion flags)
+      # and skips the feature-gated GPU benches. --noplot keeps the artifact
+      # to the raw estimates.json files, which is what comparisons consume.
+      - name: Run criterion benches (save weekly baseline)
+        run: bash scripts/bench-collect.sh weekly
+
+      - name: Upload criterion numbers
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: criterion-weekly-${{ github.run_id }}
+          path: target/criterion
+          retention-days: 90

--- a/crates/flui-engine/ARCHITECTURE.md
+++ b/crates/flui-engine/ARCHITECTURE.md
@@ -35,6 +35,39 @@ The relevant external APIs the crate consumes:
 
 ---
 
+## Supported backend/feature combinations
+
+The GPU-API features (`vulkan`, `metal`, `dx12`, `webgpu`, `gles`) are
+**additive pass-throughs to wgpu's own backend features — not mutually
+exclusive selectors**. Enabling two of them compiles both wgpu backends;
+which one actually runs is decided at runtime-init by
+`Renderer::select_backend()` per `target_os`. No source code in this crate
+cfg-gates on these features, and no `compile_error!` guards a pair — pairs
+are valid by design.
+
+Nobody normally enables them by hand: the per-target dependency entries in
+[`Cargo.toml`](Cargo.toml) feature-unify the right wgpu backend into every
+build automatically.
+
+| Target | Default backend (per-target dep) | Named extras that make sense |
+|---|---|---|
+| Windows | `dx12` | `vulkan` (e.g. for renderdoc), `gles` |
+| macOS / iOS | `metal` | — (MoltenVK via `vulkan` is unsupported) |
+| Linux / Android | `vulkan` | `gles` (older drivers) |
+| wasm32 | `webgpu` + `gles` + `fragile-send-sync-non-atomic-wasm` | — (fixed set; the fragile flag is sound only while the wasm build has no threads) |
+
+The two `compile_error!` guards in [`src/lib.rs`](src/lib.rs) protect exactly
+the combinations that are *not* valid: wasm32 with atomics while the
+fragile-send-sync flag is on, and wasm32 with `gpu-profiler`.
+
+CI coverage: the `feature-matrix` job runs every feature singly
+(`--each-feature`) for the whole workspace, plus a bounded pairwise powerset
+(`--depth 2` over the six backend-adjacent features) for this crate — the one
+place combinations matter. A full powerset is deliberately not run (2^13
+configurations for no known failure mode).
+
+---
+
 ## Mapping decisions
 
 This section records places where the Rust shape diverges from the patterns the GPU APIs themselves suggest, or where the original `flui-engine` code shape diverged from the Mythos-cleaned shape. Each entry follows the "Accepted trade-offs" format established by [`docs/plans/2026-03-31-custom-render-callback-design.md`](../../docs/plans/2026-03-31-custom-render-callback-design.md).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -98,6 +98,21 @@ cargo bench -p flui-engine
 
 Benchmark results are written under `target/criterion/` as HTML reports.
 
+Compiling benches (`bench-compile` in CI) proves they build; it does not
+detect a regression — numbers have to be collected and compared. The
+workflow for that:
+
+- **Local A/B (the authoritative comparison).** Run on a quiet machine:
+  `just bench-save before` on the baseline commit, apply the change, then
+  `just bench-save after` and `just bench-compare before after` (needs
+  `critcmp`, e.g. `cargo binstall critcmp`). Criterion also prints its own
+  change estimate against the last run of the same bench.
+- **Weekly trend (advisory).** The `bench` job in `weekly.yml` executes the
+  full suite and uploads `target/criterion` as a 90-day artifact. Shared
+  runners are noisy, so this is drift-over-weeks data — it never gates a
+  merge and a single outlier means nothing. GPU benches self-exclude via
+  their `required-features` gate.
+
 Performance targets defined by the constitution:
 
 - Widget rebuild: < 1 ms for 1000 widgets.

--- a/justfile
+++ b/justfile
@@ -84,6 +84,17 @@ wasm-check:
       --exclude flui-web-server --exclude hot-reload-counter-host \
       --exclude hot-reload-counter-logic --exclude hot-reload-counter-types
 
+# `cargo check` does not link, and on wasm32 even a link does not fail on an
+# undefined symbol (rust-lld turns it into an import) — hence the committed
+# import allowlist. Requires wasm-tools (cargo binstall wasm-tools).
+[group("build")]
+[doc("Really link the two wasm cdylibs and check their import surface (mirrors the CI wasm-check link steps)")]
+wasm-link-check:
+    cargo build --locked --target wasm32-unknown-unknown -p flui-web-demo -p flui-painting-demo
+    bash scripts/check-wasm-imports.sh \
+      target/wasm32-unknown-unknown/debug/flui_web_demo.wasm \
+      target/wasm32-unknown-unknown/debug/flui_painting_demo.wasm
+
 # `cargo check` does not link, so the per-OS backends in flui-platform can be
 # type-checked from any host. Without this they are only ever compiled by
 # whoever happens to develop on that OS — which is how the Windows backend
@@ -279,6 +290,21 @@ bench crate:
 [doc("Run benchmarks across the workspace")]
 bench-all:
     cargo bench --workspace
+
+# Criterion writes baselines under target/criterion; this quiet dev box is
+# where real A/B comparisons belong (CI runners are noisy — the weekly job
+# only uploads trend artifacts, it never compares or gates). The script
+# enumerates the real [[bench]] targets because plain `cargo bench` also
+# selects libtest-harness targets, which reject criterion CLI flags.
+[group("bench")]
+[doc("Run every criterion bench and save the numbers under a named baseline (e.g. just bench-save before-fix)")]
+bench-save name:
+    bash scripts/bench-collect.sh {{name}}
+
+[group("bench")]
+[doc("Compare two saved baselines (requires critcmp: cargo binstall critcmp)")]
+bench-compare old new:
+    critcmp {{old}} {{new}}
 
 # =============================================================================
 # Examples

--- a/scripts/bench-collect.sh
+++ b/scripts/bench-collect.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Runs every criterion bench target in the workspace and saves the numbers
+# under a named baseline (target/criterion/<bench>/<baseline>).
+#
+# Why not plain `cargo bench --workspace -- --save-baseline X`: cargo's bench
+# target selection includes every lib/test target whose default `bench = true`
+# flag is set, and those run under libtest's harness, which rejects criterion
+# CLI flags ("Unrecognized option: 'save-baseline'"). Enumerating the real
+# `[[bench]]` targets (harness = false, criterion) sidesteps that without
+# sprinkling `bench = false` across two dozen manifests.
+#
+# Targets with `required-features` (the GPU readback benches) are skipped:
+# explicitly selecting such a target without its features is a hard cargo
+# error, and this script runs in GPU-less environments.
+#
+# Usage: scripts/bench-collect.sh <baseline-name>
+set -euo pipefail
+
+baseline="${1:?usage: bench-collect.sh <baseline-name>}"
+
+targets=$(cargo metadata --no-deps --format-version 1 \
+    | jq -r '.packages[] | .name as $p | .targets[]
+             | select((.kind | index("bench")) and ((.["required-features"] // []) | length == 0))
+             | "\($p) \(.name)"')
+
+if [[ -z "$targets" ]]; then
+    echo "error: no bench targets found" >&2
+    exit 1
+fi
+
+skipped=$(cargo metadata --no-deps --format-version 1 \
+    | jq -r '.packages[] | .name as $p | .targets[]
+             | select((.kind | index("bench")) and ((.["required-features"] // []) | length > 0))
+             | "\($p) \(.name) (required-features)"')
+if [[ -n "$skipped" ]]; then
+    echo "skipping feature-gated bench targets:"
+    echo "$skipped" | sed 's/^/  /'
+fi
+
+while read -r pkg bench; do
+    echo "== $pkg / $bench"
+    cargo bench -p "$pkg" --bench "$bench" --locked -- --noplot --save-baseline "$baseline"
+done <<< "$targets"
+
+echo "baseline '$baseline' saved under target/criterion/"

--- a/scripts/check-wasm-imports.sh
+++ b/scripts/check-wasm-imports.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Verifies that the linked wasm cdylibs import ONLY from the expected host
+# modules. An undefined symbol on wasm32 does not fail the link — rust-lld
+# turns it into an import — so "it linked" proves nothing about the import
+# surface. This check makes the import list an intentional, reviewed artifact:
+# a new module (most notably `env`, the catch-all for accidental native
+# externs) fails CI until it is added to the committed allowlist.
+#
+# Requires: wasm-tools (https://github.com/bytecodealliance/wasm-tools)
+# Usage: scripts/check-wasm-imports.sh <wasm-file>...
+set -euo pipefail
+
+allowlist="$(dirname "$0")/wasm-import-allowlist.txt"
+if [[ ! -f "$allowlist" ]]; then
+    echo "error: allowlist not found at $allowlist" >&2
+    exit 2
+fi
+
+status=0
+for wasm in "$@"; do
+    if [[ ! -f "$wasm" ]]; then
+        echo "error: $wasm does not exist (was the cdylib built?)" >&2
+        status=1
+        continue
+    fi
+    # Import entries look like: (import "module" "name" ...)
+    modules=$(wasm-tools print "$wasm" \
+        | grep -oE '\(import "[^"]+"' \
+        | sed -E 's/\(import "([^"]+)"/\1/' \
+        | sort -u)
+    unexpected=$(comm -23 <(printf '%s\n' "$modules") <(sort -u "$allowlist"))
+    if [[ -n "$unexpected" ]]; then
+        echo "error: $wasm imports from modules not in $allowlist:" >&2
+        echo "$unexpected" | sed 's/^/  /' >&2
+        echo "If intentional, add the module to the allowlist with a comment in the PR." >&2
+        status=1
+    else
+        echo "ok: $wasm imports only from allowed modules:"
+        echo "$modules" | sed 's/^/  /'
+    fi
+done
+exit "$status"

--- a/scripts/wasm-import-allowlist.txt
+++ b/scripts/wasm-import-allowlist.txt
@@ -1,0 +1,2 @@
+__wbindgen_externref_xform__
+__wbindgen_placeholder__


### PR DESCRIPTION
Closes U17 (§29), U20 (§30), and the U11 remainder (§19) of the 2026-07-25 upgrade-pack audit.

**U17 — feature combinations.** `--each-feature` structurally cannot catch a defect that needs two features enabled. The feature-matrix job now also runs a bounded pairwise powerset for flui-engine (`--depth 2` over `vulkan,metal,dx12,webgpu,gles,wgpu-backend` — ~22 configs, ~1 min locally). One audit correction, recorded in a new "Supported backend/feature combinations" section of `flui-engine/ARCHITECTURE.md`: the premise "взаимоисключающие backend-features" was wrong — they are additive pass-throughs to wgpu's own features (runtime selection via `select_backend()` by `target_os`; zero cfg sites on them in src; the only invalid combos already have `compile_error!` guards). So the deliverable is the documented matrix + pairwise check, not a mutual-exclusion guard that would break the additive contract.

**U20 — bench numbers.** `bench-compile` proves compilation only. Now: `scripts/bench-collect.sh` enumerates the real `[[bench]]` targets via cargo metadata — necessary because plain `cargo bench -- --save-baseline` also selects libtest-harness lib/test targets which hard-fail on criterion flags (reproduced before writing the script) — and skips the feature-gated GPU benches (explicit selection without features is a cargo error). Local A/B: `just bench-save <name>` + `just bench-compare <a> <b>` (critcmp). CI: an advisory `bench` job in weekly.yml uploads `target/criterion` as a 90-day artifact. Trend data only, never a merge gate — shared runners are noisy and this repo already has a load-sensitive flake on record. docs/testing.md states the split.

**U11 — real wasm linking + import surface.** wasm-check now `cargo build`s the two cdylib demos (real rust-lld link) — and because wasm32 turns undefined symbols into *imports* instead of link errors, the job then diffs the import-module surface against a committed allowlist (`scripts/wasm-import-allowlist.txt`, currently the two wasm-bindgen modules). An accidental `env` import — the audit's exact concern — fails CI with the offending module named. Locally: `just wasm-link-check`.

Verified: powerset green ~76s; one criterion target smoke-run with the exact weekly flags; link+import check green on both demos; full `just ci` green; workflow YAML parses. Not verified: a full weekly bench wall-clock on a GH runner (timeout set to 120 min, `continue-on-error: true` so an overrun cannot page anyone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)