### PR TITLE
docs(devtools): stop advertising subsystems that do not exist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ members = [
     "crates/flui-animation", # Animation system (ACTIVE)
 
     # === DX tooling ===
-    "crates/flui-devtools", # Profiler / inspector / hot-reload protocol
+    "crates/flui-devtools", # Profiler / timeline / file-watch (no tree inspector yet — see the crate docs)
     "crates/flui-build",    # Build orchestration (android / cross)
     "crates/flui-cli",      # `flui` CLI (run / build / devtools / templates)
     # NOTE: there is deliberately NO signals crate. flui-reactivity (a signals/
@@ -441,33 +441,15 @@ default = []
 golden = []
 
 # === Core Features ===
-# Serialization support across all crates
-serde = [
-    # "flui_core/serde",  # Temporarily disabled
-    "flui-types/serde",
-    # "flui-rendering/serde",  # Temporarily disabled
-]
+# Serialization support (flui-types only today; other crates' serde features
+# are opted into per-crate, not through the facade)
+serde = ["flui-types/serde"]
 
-# === Performance Features ===
-# Multi-threaded parallel processing (temporarily disabled)
-# parallel = ["flui_core/parallel"]
-
-# === Profiling & Debug Features ===
-# TODO: Fix puffin dependencies before enabling
-# profiling = ["puffin", "puffin_http", "flui_core/profiling"]
-# tracy = ["tracing-tracy"]
-# full-profiling = ["profiling", "tracy"]
-
-# === DevTools Features ===
-# Developer tools integration (temporarily disabled)
-# devtools = ["flui-engine/devtools"]
-
-# TODO: Re-enable when memory-profiler dependencies are fixed
-# memory-profiler = ["devtools", "flui-engine/memory-profiler"]
-
-# === Convenience Features ===
-# Enable all stable features (temporarily disabled)
-# full = ["serde", "parallel", "devtools"]
+# The facade declares no other features. Earlier revisions carried commented
+# blocks for parallel / profiling / tracy / devtools / memory-profiler /
+# full — all referencing crates or features that do not exist (`flui_core`,
+# `flui-engine/devtools`). A capability that does not exist gets no feature
+# stub here; add the feature in the same change that implements it.
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Build Profiles

--- a/crates/flui-devtools/Cargo.toml
+++ b/crates/flui-devtools/Cargo.toml
@@ -46,23 +46,11 @@ timeline = []
 # Hot code reload for development
 hot-reload = ["dep:flui-hot-reload"]
 
-# TODO: Add dependencies for these features:
-# network-monitor = ["tokio", "tokio-tungstenite"]
-# memory-profiler = ["dhat"]
-# remote-debug = ["tokio", "tokio-tungstenite"]
-# tracing-support = ["tracing-subscriber"]
-
 # === Convenience Features ===
-# Enable all features
-full = [
-    "profiling",
-    "timeline",
-    "hot-reload",
-    # "network-monitor",
-    # "memory-profiler",
-    # "remote-debug",
-    # "tracing-support",
-]
+# Enable all features. This list is the crate's honest capability inventory —
+# a subsystem that does not exist (inspector, network monitor, memory
+# profiler, remote debug) has no feature here, commented or otherwise.
+full = ["profiling", "timeline", "hot-reload"]
 
 [dev-dependencies]
 

--- a/crates/flui-devtools/src/lib.rs
+++ b/crates/flui-devtools/src/lib.rs
@@ -1,41 +1,35 @@
 //! FLUI DevTools - Developer tools for FLUI framework
 //!
-//! This crate provides a comprehensive suite of developer tools for debugging,
-//! profiling, and inspecting FLUI applications. Inspired by Flutter DevTools
-//! and React DevTools, it offers:
+//! What this crate actually contains today — three small, feature-gated
+//! subsystems, all standalone (no view/element/render-tree access):
 //!
 //! # Features
 //!
 //! ## 🎯 Performance Profiler (feature: profiling)
 //! - Frame timing and jank detection
-//! - Build/layout/paint phase profiling
-//! - CPU usage tracking
+//! - Build/layout/paint phase profiling, fed manually by the caller
 //! - Performance timeline with markers
 //!
-//! ## ⏱️ Timeline View
+//! ## ⏱️ Timeline View (feature: timeline)
 //! - Event timeline visualization
 //! - Frame boundaries
 //! - Custom trace events
 //!
 //! ## 🔥 Hot Reload (feature: hot-reload)
-//! - Watch file changes
-//! - Trigger rebuilds automatically
-//! - State preservation
+//! - Watch file changes and report them to a callback
+//! - That is all: rebuild triggering and state preservation live in
+//!   `flui-hot-reload` (worker/host split), not here
 //!
-//! ## 🌐 Network Monitor (feature: network-monitor)
-//! - HTTP request tracking
-//! - Response inspection
-//! - Performance metrics
+//! # What this crate is NOT (yet)
 //!
-//! ## 💾 Memory Profiler (feature: memory-profiler)
-//! - Heap allocation tracking
-//! - Memory usage over time
-//! - Leak detection
-//!
-//! ## 🔌 Remote Debug (feature: remote-debug)
-//! - WebSocket-based debugging protocol
-//! - Connect from browser DevTools
-//! - Remote widget inspection
+//! It is not an inspector: it has no dependency on any flui tree crate, so
+//! it cannot observe widgets, elements, render objects, or semantics. Wiring
+//! that up requires an observation seam in the core (dependency inversion —
+//! the core publishes tree events through a narrow trait the devtools can
+//! subscribe to; see the 2026-07-25 audit §26). There is likewise no network
+//! monitor, no memory profiler, and no remote-debug protocol — earlier
+//! versions of this documentation advertised those as features; they were
+//! never implemented.
 //!
 //! # Usage
 //!
@@ -83,15 +77,12 @@
 //! - `default`: no features enabled; opt in via `profiling`, `timeline`, or `hot-reload`
 //! - `profiling`: Performance profiling tools (no external dependencies)
 //! - `timeline`: Timeline view for events
-//! - `hot-reload`: File watching and hot reload
-//! - `network-monitor`: HTTP request monitoring
-//! - `memory-profiler`: Memory usage tracking
-//! - `remote-debug`: WebSocket debugging server
-//! - `tracing-support`: Integration with `tracing` crate
-//! - `full`: All features enabled
+//! - `hot-reload`: File watching (reports changes; nothing more)
+//! - `full`: all of the above
 //!
-//! **Note**: This crate has NO dependency on `flui_core` to avoid circular
-//! dependencies. Widget inspection is available through separate tools.
+//! No other feature exists. The `default = []` boundary is what keeps a
+//! release build at zero devtools overhead: nothing here is compiled, no
+//! port is opened, no background work runs.
 
 // Ship bar (wave 4): every public item is documented; keep it that way.
 #![deny(missing_docs)]
@@ -99,21 +90,10 @@
 mod common;
 #[cfg(feature = "hot-reload")]
 pub mod hot_reload;
-// TODO: Add memory profiler module
-// #[cfg(feature = "memory-profiler")]
-// pub mod memory;
-// TODO: Add network monitor module
-// #[cfg(feature = "network-monitor")]
-// pub mod network;
-// TODO: Add remote debug module
-// #[cfg(feature = "remote-debug")]
-// pub mod remote;
 #[cfg(feature = "profiling")]
 pub mod profiler;
 #[cfg(feature = "timeline")]
 pub mod timeline;
-
-// Feature-gated modules
 
 // Re-exports
 pub use common::*;
@@ -135,10 +115,6 @@ pub mod prelude {
     pub use crate::profiler::{FramePhase, FrameStats, Profiler};
     #[cfg(feature = "timeline")]
     pub use crate::timeline::{Timeline, TimelineEvent};
-
-    // TODO: Add memory profiler re-exports
-    // #[cfg(feature = "memory-profiler")]
-    // pub use crate::memory::{MemoryProfiler, MemorySnapshot};
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes the false-advertising half of U3 from the 2026-07-25 upgrade-pack audit (§26), plus the §29 finding about the facade's phantom feature blocks.

- `flui-devtools/src/lib.rs`: the 🌐 Network Monitor / 💾 Memory Profiler / 🔌 Remote Debug sections are gone (verified byte-identical to the audit's citation before removal); the "State preservation" hot-reload bullet is replaced with the truth (file watching only — rebuild triggering and state live in `flui-hot-reload`); a "What this crate is NOT (yet)" section states that this is not an inspector and names the missing piece (an observation seam in the core, dependency inversion per the audit's recommendation).
- `flui-devtools/Cargo.toml`: the commented feature stubs are deleted; `full` lists exactly the three real features.
- Facade `Cargo.toml`: the six commented feature blocks (`parallel`, `profiling`, `tracy`, `full-profiling`, `devtools`, `memory-profiler`, `full`) referenced crates and features that do not exist (`flui_core`, `flui-engine/devtools`) — deleted, with the rule recorded that a feature stub lands in the change that implements the capability.

The observation-seam half of U3 (TreeObserver dependency inversion) is design work, handled with the audit's other design items — this PR only makes the surface honest so no reader builds on the fiction meanwhile.

No behavior change. Gates: clippy `--all-features`, rustdoc, taplo, full `just ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)