### PR TITLE
feat(foundation,platform): land the ADR-0039 slice-1 owner-affinity backstop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,6 +1780,7 @@ dependencies = [
  "crossbeam-channel",
  "cursor-icon",
  "dpi",
+ "flui-foundation",
  "flui-types",
  "keyboard-types",
  "libc",

--- a/crates/flui-foundation/src/affinity.rs
+++ b/crates/flui-foundation/src/affinity.rs
@@ -1,0 +1,191 @@
+//! Owner-thread affinity — the runtime floor under ADR-0039's capability model.
+//!
+//! Native platform backends (`AppKit`, Win32) own an event loop whose OS
+//! objects are thread-affine, yet the `Platform` trait is `Send + Sync` with
+//! `&self` methods — nothing stops a worker thread from calling `open_window`
+//! on macOS, which is undefined-behavior-class misuse of `AppKit`. The full fix is
+//! the `!Send` `OwnerPlatform` capability (ADR-0039 slices 2–3); this module
+//! is slice 1: a recordable owner identity plus a debug assertion backends
+//! place at the entry of their affine operations.
+//!
+//! It lives in `flui-foundation` — not `flui-platform` — so its behavior is
+//! exercised by a test suite CI actually runs (`flui-platform`'s suite is
+//! excluded from the CI gate; see AGENTS.md). The backend wiring is
+//! compile-checked by cross-typecheck and verified locally on the native OS.
+
+use std::sync::OnceLock;
+use std::thread::{self, ThreadId};
+
+/// Records which thread owns a platform event loop and lets affine
+/// operations assert they run there.
+///
+/// Lifecycle: constructed unbound (`const`-initializable, so it can sit in a
+/// backend struct or a `static`); bound once via [`bind_current`] at the
+/// backend's loop-entry point (`Platform::run`, or the constructor where the
+/// backend documents a main-thread requirement); consulted via
+/// [`debug_assert_owner`] at each affine operation's entry.
+///
+/// Before binding, [`debug_assert_owner`] is deliberately a no-op: pre-run
+/// flows (e.g. Win32 examples opening a window before `run()`) are legal
+/// until ADR-0039 slice 2 migrates them into `on_ready`, and an unbound
+/// affinity has no owner to check against.
+///
+/// [`bind_current`]: Self::bind_current
+/// [`debug_assert_owner`]: Self::debug_assert_owner
+#[derive(Debug)]
+pub struct OwnerAffinity {
+    owner: OnceLock<ThreadId>,
+}
+
+impl OwnerAffinity {
+    /// An unbound affinity. `const`, so backends can hold one without an
+    /// `Option` dance.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            owner: OnceLock::new(),
+        }
+    }
+
+    /// Binds the calling thread as the owner.
+    ///
+    /// Idempotent from the owner thread (re-entering `run`-adjacent setup is
+    /// harmless). Binding from a *different* thread after an owner exists is
+    /// a bug — the loop cannot move threads — and trips a `debug_assert!`;
+    /// in release the original owner is kept and the attempt is traced.
+    pub fn bind_current(&self) {
+        let current = thread::current().id();
+        let bound = *self.owner.get_or_init(|| current);
+        if bound != current {
+            debug_assert!(
+                false,
+                "BUG: OwnerAffinity re-bind from {current:?}, but the owner \
+                 is {bound:?} — an event loop cannot change threads"
+            );
+            tracing::error!(
+                ?bound,
+                ?current,
+                "OwnerAffinity re-bind from a foreign thread ignored"
+            );
+        }
+    }
+
+    /// The bound owner thread, if any.
+    #[must_use]
+    pub fn owner(&self) -> Option<ThreadId> {
+        self.owner.get().copied()
+    }
+
+    /// Whether the calling thread is the bound owner. `false` when unbound.
+    #[must_use]
+    pub fn is_owner(&self) -> bool {
+        self.owner() == Some(thread::current().id())
+    }
+
+    /// `debug_assert!` that the caller is the bound owner; a no-op when no
+    /// owner is bound yet (see the type docs for why).
+    ///
+    /// `op` names the violated operation in the panic message and trace.
+    pub fn debug_assert_owner(&self, op: &'static str) {
+        let Some(bound) = self.owner() else {
+            return;
+        };
+        let current = thread::current().id();
+        if bound != current {
+            tracing::error!(
+                op,
+                ?bound,
+                ?current,
+                "thread-affine platform operation called off the owner thread"
+            );
+            debug_assert!(
+                false,
+                "BUG: `{op}` called from {current:?}, but the platform event \
+                 loop is owned by {bound:?} — thread-affine OS APIs must be \
+                 reached through the owner thread (ADR-0039)"
+            );
+        }
+    }
+}
+
+impl Default for OwnerAffinity {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unbound_assert_is_a_no_op_and_reports_no_owner() {
+        let affinity = OwnerAffinity::new();
+        assert_eq!(affinity.owner(), None);
+        assert!(!affinity.is_owner());
+        // Must not panic even in debug: pre-run flows are legal until an
+        // owner exists.
+        affinity.debug_assert_owner("pre_run_op");
+    }
+
+    #[test]
+    fn bind_records_the_calling_thread_and_assert_passes_on_it() {
+        let affinity = OwnerAffinity::new();
+        affinity.bind_current();
+        assert_eq!(affinity.owner(), Some(std::thread::current().id()));
+        assert!(affinity.is_owner());
+        affinity.debug_assert_owner("owner_op");
+        // Re-bind from the owner thread is idempotent.
+        affinity.bind_current();
+        assert!(affinity.is_owner());
+    }
+
+    #[test]
+    #[cfg_attr(
+        not(debug_assertions),
+        ignore = "the violation is a debug_assert; release keeps the owner and only traces"
+    )]
+    fn cross_thread_assert_is_caught() {
+        let affinity = std::sync::Arc::new(OwnerAffinity::new());
+        affinity.bind_current();
+        let worker_view = std::sync::Arc::clone(&affinity);
+        let panicked = std::thread::spawn(move || {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                worker_view.debug_assert_owner("cross_thread_op");
+            }))
+            .is_err()
+        })
+        .join()
+        .expect("worker thread must complete");
+        assert!(
+            panicked,
+            "debug_assert_owner must panic on a foreign thread in debug builds",
+        );
+    }
+
+    #[test]
+    #[cfg_attr(
+        not(debug_assertions),
+        ignore = "the violation is a debug_assert; release keeps the owner and only traces"
+    )]
+    fn foreign_rebind_is_rejected_and_original_owner_kept() {
+        let affinity = std::sync::Arc::new(OwnerAffinity::new());
+        affinity.bind_current();
+        let original = affinity.owner();
+        let foreign_view = std::sync::Arc::clone(&affinity);
+        let panicked = std::thread::spawn(move || {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                foreign_view.bind_current();
+            }))
+            .is_err()
+        })
+        .join()
+        .expect("worker thread must complete");
+        assert!(panicked, "foreign re-bind must trip the debug assertion");
+        assert_eq!(
+            affinity.owner(),
+            original,
+            "the original owner must survive a rejected re-bind",
+        );
+    }
+}

--- a/crates/flui-foundation/src/lib.rs
+++ b/crates/flui-foundation/src/lib.rs
@@ -146,6 +146,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Core modules - fundamental types with minimal dependencies
+pub mod affinity;
 pub mod async_snapshot;
 pub mod binding;
 pub mod callbacks;
@@ -178,6 +179,7 @@ pub mod debug;
 
 // Core types - IDs for all tree levels
 // Binding infrastructure
+pub use affinity::OwnerAffinity;
 pub use async_snapshot::{AsyncSnapshot, ConnectionState};
 pub use binding::{BindingBase, HasInstance, check_instance};
 // Callbacks

--- a/crates/flui-platform/Cargo.toml
+++ b/crates/flui-platform/Cargo.toml
@@ -15,6 +15,10 @@ autotests = false
 
 [dependencies]
 flui-types = { path = "../flui-types", version = "0.2.0" }
+# OwnerAffinity: the ADR-0039 slice-1 owner-thread backstop. Layer-legal
+# (foundation sits below platform in the DAG) and deliberately hosted there
+# so its tests run in CI, which flui-platform's own suite does not.
+flui-foundation = { path = "../flui-foundation", version = "0.2.0" }
 
 # UI Events - W3C compliant event types
 ui-events = { workspace = true }

--- a/crates/flui-platform/src/platforms/macos/platform.rs
+++ b/crates/flui-platform/src/platforms/macos/platform.rs
@@ -7,6 +7,7 @@ use cocoa::{
     appkit::{NSApp, NSApplication, NSApplicationActivationPolicyRegular},
     base::{YES, id, nil},
 };
+use flui_foundation::OwnerAffinity;
 use objc::{class, msg_send, sel, sel_impl};
 use parking_lot::Mutex;
 
@@ -41,6 +42,33 @@ pub struct MacOSPlatform {
 
     /// Window configuration
     config: WindowConfiguration,
+
+    /// ADR-0039 slice 1: records the event-loop owner thread so the
+    /// thread-affine AppKit operations below can `debug_assert` their caller.
+    affinity: OwnerAffinity,
+}
+
+/// Debug-only check that the caller is the OS main thread.
+///
+/// On AppKit the owner thread must *be* the process main thread —
+/// `ThreadId` equality against the binding thread cannot express that on
+/// its own (ADR-0039 slice 1), so this asks AppKit directly.
+fn debug_assert_appkit_main_thread(op: &'static str) {
+    #[cfg(debug_assertions)]
+    {
+        // SAFETY: `+[NSThread isMainThread]` is a documented thread-safe
+        // class method with no arguments and a BOOL return.
+        let is_main: objc::runtime::BOOL = unsafe { msg_send![class!(NSThread), isMainThread] };
+        debug_assert!(
+            is_main != objc::runtime::NO,
+            "BUG: `{op}` must run on the AppKit main thread — thread-affine \
+             AppKit APIs are reached through the owner thread (ADR-0039)"
+        );
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        let _ = op;
+    }
 }
 
 // SAFETY: the NSApplication pointer is a process-wide singleton only messaged
@@ -98,13 +126,19 @@ impl MacOSPlatform {
 
             tracing::info!("macOS platform initialized with AppKit");
 
-            Ok(Self {
+            let platform = Self {
                 app,
                 windows: Arc::new(Mutex::new(HashMap::new())),
                 handlers: Arc::new(Mutex::new(PlatformHandlers::default())),
                 background_executor,
                 config,
-            })
+                affinity: OwnerAffinity::new(),
+            };
+            // The constructor already documents a main-thread requirement
+            // (see the SAFETY note above), so the owner is known here — bind
+            // early so pre-`run` affine calls are covered too (ADR-0039).
+            platform.affinity.bind_current();
+            Ok(platform)
         }
     }
 
@@ -120,6 +154,11 @@ impl Platform for MacOSPlatform {
     }
 
     fn run(self: Box<Self>, on_finish_launching: PlatformReadyCallback) {
+        // Idempotent when `with_config` already bound on this thread; trips
+        // a debug assertion if `run` somehow migrated threads (ADR-0039).
+        self.affinity.bind_current();
+        debug_assert_appkit_main_thread("MacOSPlatform::run");
+
         // Call the launch callback. This is an ordinary (safe) call — keep it
         // outside the `unsafe` block below rather than widening that block's
         // scope to cover code that needs no unsafe justification.
@@ -140,6 +179,8 @@ impl Platform for MacOSPlatform {
     }
 
     fn quit(&self) {
+        self.affinity.debug_assert_owner("MacOSPlatform::quit");
+        debug_assert_appkit_main_thread("MacOSPlatform::quit");
         // SAFETY: `self.app` is the live NSApplication singleton.
         unsafe {
             tracing::info!("Requesting application quit");
@@ -148,12 +189,18 @@ impl Platform for MacOSPlatform {
     }
 
     fn open_window(&self, options: WindowOptions) -> Result<Arc<dyn PlatformWindow>> {
+        self.affinity
+            .debug_assert_owner("MacOSPlatform::open_window");
+        debug_assert_appkit_main_thread("MacOSPlatform::open_window");
         let window = MacOSWindow::new(options, Arc::clone(&self.windows), self.config.clone())?;
 
         Ok(window)
     }
 
     fn active_window(&self) -> Option<WindowId> {
+        self.affinity
+            .debug_assert_owner("MacOSPlatform::active_window");
+        debug_assert_appkit_main_thread("MacOSPlatform::active_window");
         // SAFETY: `self.app` is the live NSApplication singleton; `keyWindow`
         // returns nil or a live NSWindow whose pointer value is used as an id.
         unsafe {
@@ -168,10 +215,15 @@ impl Platform for MacOSPlatform {
     }
 
     fn displays(&self) -> Vec<Arc<dyn PlatformDisplay>> {
+        self.affinity.debug_assert_owner("MacOSPlatform::displays");
+        debug_assert_appkit_main_thread("MacOSPlatform::displays");
         display::enumerate_displays()
     }
 
     fn primary_display(&self) -> Option<Arc<dyn PlatformDisplay>> {
+        self.affinity
+            .debug_assert_owner("MacOSPlatform::primary_display");
+        debug_assert_appkit_main_thread("MacOSPlatform::primary_display");
         display::enumerate_displays()
             .into_iter()
             .find(|d| d.is_primary())

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -117,6 +117,13 @@ pub struct WindowsPlatform {
 
     /// Window configuration (shared across all windows)
     config: WindowConfiguration,
+
+    /// ADR-0039 slice 1: records the message-loop owner thread so the
+    /// thread-affine Win32 operations below can `debug_assert` their caller.
+    /// Bound at `run` — pre-run window creation (the Win32 examples) is legal
+    /// until ADR-0039 slice 2 migrates it into `on_ready`, and the assert is
+    /// a no-op while unbound.
+    affinity: flui_foundation::OwnerAffinity,
 }
 
 // SAFETY, per field: `windows` and `handlers` are `Arc<Mutex<..>>`, the
@@ -239,6 +246,7 @@ impl WindowsPlatform {
             handlers: Arc::new(Mutex::new(PlatformHandlers::default())),
             background_executor,
             config,
+            affinity: flui_foundation::OwnerAffinity::new(),
         })
     }
 
@@ -896,6 +904,10 @@ impl Platform for WindowsPlatform {
     fn run(self: Box<Self>, on_ready: Box<dyn FnOnce(&dyn Platform)>) {
         tracing::info!("Running Windows platform");
 
+        // ADR-0039 slice 1: the thread that runs the message loop owns every
+        // window created from here on.
+        self.affinity.bind_current();
+
         // Call ready callback
         on_ready(&*self);
 
@@ -903,6 +915,9 @@ impl Platform for WindowsPlatform {
     }
 
     fn quit(&self) {
+        // PostQuitMessage posts to the CALLING thread's message queue — off
+        // the owner thread it silently quits nothing (ADR-0039).
+        self.affinity.debug_assert_owner("WindowsPlatform::quit");
         tracing::info!("Quitting Windows platform");
         unsafe {
             PostQuitMessage(0);
@@ -912,6 +927,8 @@ impl Platform for WindowsPlatform {
     // ==================== Window Management ====================
 
     fn active_window(&self) -> Option<WindowId> {
+        self.affinity
+            .debug_assert_owner("WindowsPlatform::active_window");
         unsafe {
             let hwnd = GetForegroundWindow();
             if hwnd.is_invalid() {
@@ -933,6 +950,10 @@ impl Platform for WindowsPlatform {
     }
 
     fn open_window(&self, options: WindowOptions) -> Result<Arc<dyn PlatformWindow>> {
+        // An HWND's message queue belongs to the creating thread; a window
+        // minted off the owner thread is silently mis-affined (ADR-0039).
+        self.affinity
+            .debug_assert_owner("WindowsPlatform::open_window");
         tracing::info!("Opening window: {:?}", options.title);
 
         let window = WindowsWindow::new(


### PR DESCRIPTION
First implementation slice of ADR-0039 (event-loop affinity), exactly as the ADR specifies it.

**`OwnerAffinity`** in `flui-foundation::affinity`: `const`-constructible, bound once at loop entry, `debug_assert_owner(op)` at affine operations. Design points the ADR fixed and this implements faithfully:
- **Unbound ⇒ no-op**: pre-run flows (Win32 examples opening windows before `run()`) remain legal until slice 2 migrates them into `on_ready`.
- **Foreign re-bind rejected**, original owner kept; release builds trace instead of panicking (panic policy: affinity violation is a BUG-class invariant, hence `debug_assert!`).
- Hosted in foundation **so its tests actually run in CI** — flui-platform's suite is CI-excluded; the honest-scope note from the ADR is restated in the module docs and commit.

**Wiring:** macOS binds in `with_config` + `run`, asserts on the five affine methods with a paired `NSThread.isMainThread` debug check (owner ≠ main-thread is expressible only by asking AppKit); clipboard gets **no** asserts per the ADR's §5 (which supersedes ADR-0034's suggestion). Windows binds in `run`, asserts on `open_window`/`quit`/`active_window`. winit/headless untouched.

Gates: foundation 204/204 (4 new affinity tests incl. cross-thread violation and foreign-rebind), cross-typecheck clippy green on both native triples, workspace clippy, taplo, full `just ci`. Honest limits: backend assert wiring is compile-checked only in CI (cross-typecheck runs nothing; flui-platform tests CI-excluded) — the ADR records this and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)