### PR TITLE
feat: land the ADR-0040 slice-1 tree-observation seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,9 +1480,12 @@ dependencies = [
 name = "flui-binding"
 version = "0.2.0"
 dependencies = [
+ "criterion",
  "flui-animation",
+ "flui-devtools",
  "flui-foundation",
  "flui-interaction",
+ "flui-objects",
  "flui-rendering",
  "flui-scheduler",
  "flui-types",
@@ -1562,10 +1565,12 @@ dependencies = [
 name = "flui-devtools"
 version = "0.2.0"
 dependencies = [
+ "flui-foundation",
  "flui-hot-reload",
  "parking_lot",
  "serde",
  "serde_json",
+ "tracing",
  "web-time",
  "windows-sys 0.61.2",
 ]

--- a/crates/flui-binding/Cargo.toml
+++ b/crates/flui-binding/Cargo.toml
@@ -53,6 +53,12 @@ flui-interaction = { path = "../flui-interaction", version = "0.2.0", features =
 # of release builds.
 flui-view = { path = "../flui-view", version = "0.2.0", features = ["test-utils"] }
 flui-foundation = { path = "../flui-foundation", version = "0.2.0" }
+# ADR-0040 slice 1: the end-to-end observation-seam test drives a real tree
+# against the devtools inspector — this crate is the one that links both
+# halves (acyclic: flui-devtools depends only on flui-foundation).
+flui-devtools = { path = "../flui-devtools", version = "0.2.0", features = ["inspector"] }
+flui-objects = { workspace = true }
+criterion = { workspace = true }
 # The long-press deadline recognizer + settings exercised by the pump_frame test,
 # plus the geometry/offset types for the synthetic pointer-down. The `testing`
 # feature is NOT required: `add_pointer`/`poll_deadlines` are part of the release
@@ -62,3 +68,7 @@ flui-types = { path = "../flui-types", version = "0.2.0" }
 [[test]]
 name = "binding_it"
 path = "tests/main.rs"
+
+[[bench]]
+name = "tree_observer_overhead"
+harness = false

--- a/crates/flui-binding/benches/tree_observer_overhead.rs
+++ b/crates/flui-binding/benches/tree_observer_overhead.rs
@@ -1,0 +1,188 @@
+//! The audit-§30 "inspector overhead" benchmark, previously unwritable
+//! because no observation seam existed (ADR-0040 made it writable; slice 1
+//! ships it as the check on the zero-cost-when-off claim).
+//!
+//! Three scenarios over the same rebuild-heavy drive (keyed rotation of 64
+//! render children through the production `build_scope` path each
+//! iteration): observer absent (the `Option` null-check off path), a no-op
+//! observer (emission + `catch_unwind` frame, empty body), and the
+//! devtools counting inspector (the real slice-1 consumer).
+
+// Bench binary: criterion's generated main has no docs (house precedent:
+// the flui-view benches carry the same allow).
+#![allow(missing_docs)]
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use flui_devtools::inspector::InspectorCounters;
+use flui_foundation::observe::TreeObserver;
+use flui_foundation::{ElementId, ValueKey, ViewKey};
+use flui_objects::RenderSizedBox;
+use flui_view::{BuildOwner, ElementTree, RebuildReason, RenderView, View, ViewExt};
+
+#[derive(Clone)]
+struct KeyedLeafBox {
+    key: ValueKey<u32>,
+}
+
+impl KeyedLeafBox {
+    fn new(tag: u32) -> Self {
+        Self {
+            key: ValueKey::new(tag),
+        }
+    }
+}
+
+impl RenderView for KeyedLeafBox {
+    type Protocol = flui_rendering::protocol::BoxProtocol;
+    type RenderObject = RenderSizedBox;
+
+    fn create_render_object(
+        &self,
+        _ctx: &flui_view::RenderObjectContext<'_>,
+    ) -> Self::RenderObject {
+        RenderSizedBox::shrink()
+    }
+
+    fn update_render_object(
+        &self,
+        _ctx: &flui_view::RenderObjectContext<'_>,
+        _render_object: &mut Self::RenderObject,
+    ) {
+    }
+}
+
+impl View for KeyedLeafBox {
+    fn create_element(&self) -> flui_view::element::ElementKind {
+        flui_view::element::ElementKind::render_variable(self)
+    }
+
+    fn key(&self) -> Option<&dyn ViewKey> {
+        Some(&self.key)
+    }
+}
+
+#[derive(Clone)]
+struct MultiBox {
+    children: Vec<flui_view::BoxedView>,
+}
+
+impl MultiBox {
+    fn keyed(order: &[u32]) -> Self {
+        Self {
+            children: order
+                .iter()
+                .copied()
+                .map(|tag| KeyedLeafBox::new(tag).boxed())
+                .collect(),
+        }
+    }
+}
+
+impl RenderView for MultiBox {
+    type Protocol = flui_rendering::protocol::BoxProtocol;
+    type RenderObject = RenderSizedBox;
+
+    fn create_render_object(
+        &self,
+        _ctx: &flui_view::RenderObjectContext<'_>,
+    ) -> Self::RenderObject {
+        RenderSizedBox::shrink()
+    }
+
+    fn update_render_object(
+        &self,
+        _ctx: &flui_view::RenderObjectContext<'_>,
+        _render_object: &mut Self::RenderObject,
+    ) {
+    }
+
+    fn has_children(&self) -> bool {
+        !self.children.is_empty()
+    }
+
+    fn visit_child_views(&self, visitor: &mut dyn FnMut(&dyn View)) {
+        for child in &self.children {
+            visitor(child);
+        }
+    }
+}
+
+impl View for MultiBox {
+    fn create_element(&self) -> flui_view::element::ElementKind {
+        flui_view::element::ElementKind::render_variable(self)
+    }
+}
+
+struct NoOpObserver;
+impl TreeObserver for NoOpObserver {}
+
+/// One rebuild-heavy iteration: rotate the 64 keyed children and drain
+/// through `build_scope` (root rebuild + 64 keyed reconciles + reorders).
+fn drive_rotation(
+    owner: &mut BuildOwner,
+    tree: &mut ElementTree,
+    root: ElementId,
+    order: &mut [u32],
+) {
+    order.rotate_left(1);
+    tree.update(
+        root,
+        &MultiBox::keyed(order),
+        &mut owner.element_owner_mut(),
+    );
+    owner.schedule_build_for(root, 0, RebuildReason::ParentUpdate);
+    owner.build_scope(tree);
+}
+
+fn setup(
+    observer: Option<Arc<dyn TreeObserver>>,
+) -> (BuildOwner, ElementTree, ElementId, Vec<u32>) {
+    let mut owner = BuildOwner::new();
+    if let Some(observer) = observer {
+        owner.set_tree_observer(observer);
+    }
+    let mut tree = ElementTree::new();
+    let order: Vec<u32> = (0..64).collect();
+    let root = tree.mount_root(&MultiBox::keyed(&order), &mut owner.element_owner_mut());
+    owner.schedule_build_for(root, 0, RebuildReason::InitialMount);
+    owner.build_scope(&mut tree);
+    (owner, tree, root, order)
+}
+
+fn bench_observer_overhead(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tree_observer/rebuild_heavy_64_children");
+
+    group.bench_function("observer_absent", |b| {
+        let (mut owner, mut tree, root, mut order) = setup(None);
+        b.iter(|| {
+            drive_rotation(&mut owner, &mut tree, root, &mut order);
+            black_box(tree.len());
+        });
+    });
+
+    group.bench_function("noop_observer", |b| {
+        let (mut owner, mut tree, root, mut order) = setup(Some(Arc::new(NoOpObserver)));
+        b.iter(|| {
+            drive_rotation(&mut owner, &mut tree, root, &mut order);
+            black_box(tree.len());
+        });
+    });
+
+    group.bench_function("counting_inspector", |b| {
+        let counters = Arc::new(InspectorCounters::new());
+        let (mut owner, mut tree, root, mut order) =
+            setup(Some(Arc::clone(&counters) as Arc<dyn TreeObserver>));
+        b.iter(|| {
+            drive_rotation(&mut owner, &mut tree, root, &mut order);
+            black_box(counters.snapshot().rebuilds);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_observer_overhead);
+criterion_main!(benches);

--- a/crates/flui-binding/tests/main.rs
+++ b/crates/flui-binding/tests/main.rs
@@ -24,3 +24,5 @@ mod owner_scope;
 mod post_frame_after_layout;
 #[path = "self_rescheduling_local_post_frame.rs"]
 mod self_rescheduling_local_post_frame;
+#[path = "tree_observer_inspector.rs"]
+mod tree_observer_inspector;

--- a/crates/flui-binding/tests/tree_observer_inspector.rs
+++ b/crates/flui-binding/tests/tree_observer_inspector.rs
@@ -1,0 +1,295 @@
+//! End-to-end proof of the ADR-0040 tree-observation seam: a real tree
+//! driven through the production `build_scope` path against
+//! `flui-devtools`' `InspectorCounters` — the two halves the seam exists to
+//! connect, linked here because this crate is the one that can see both.
+//!
+//! The oracle is the ADR §4 invariant: `ElementUnmounted` fires exactly
+//! once per `Element::unmount`, `ElementMounted` exactly once per fresh
+//! mint — so mounts and unmounts balance against live-tree size.
+
+use std::sync::Arc;
+
+use flui_devtools::inspector::InspectorCounters;
+use flui_foundation::observe::TreeObserver;
+use flui_foundation::{ElementId, ValueKey, ViewKey};
+use flui_objects::RenderSizedBox;
+use flui_view::{BuildOwner, ElementTree, RebuildReason, RenderView, View, ViewExt};
+
+#[derive(Clone)]
+struct KeyedLeafBox {
+    key: ValueKey<u32>,
+}
+
+impl KeyedLeafBox {
+    fn new(tag: u32) -> Self {
+        Self {
+            key: ValueKey::new(tag),
+        }
+    }
+}
+
+impl RenderView for KeyedLeafBox {
+    type Protocol = flui_rendering::protocol::BoxProtocol;
+    type RenderObject = RenderSizedBox;
+
+    fn create_render_object(
+        &self,
+        _ctx: &flui_view::RenderObjectContext<'_>,
+    ) -> Self::RenderObject {
+        RenderSizedBox::shrink()
+    }
+
+    fn update_render_object(
+        &self,
+        _ctx: &flui_view::RenderObjectContext<'_>,
+        _render_object: &mut Self::RenderObject,
+    ) {
+    }
+}
+
+impl View for KeyedLeafBox {
+    fn create_element(&self) -> flui_view::element::ElementKind {
+        flui_view::element::ElementKind::render_variable(self)
+    }
+
+    fn key(&self) -> Option<&dyn ViewKey> {
+        Some(&self.key)
+    }
+}
+
+#[derive(Clone)]
+struct MultiBox {
+    children: Vec<flui_view::BoxedView>,
+}
+
+impl MultiBox {
+    fn keyed(order: &[u32]) -> Self {
+        Self {
+            children: order
+                .iter()
+                .copied()
+                .map(|tag| KeyedLeafBox::new(tag).boxed())
+                .collect(),
+        }
+    }
+}
+
+impl RenderView for MultiBox {
+    type Protocol = flui_rendering::protocol::BoxProtocol;
+    type RenderObject = RenderSizedBox;
+
+    fn create_render_object(
+        &self,
+        _ctx: &flui_view::RenderObjectContext<'_>,
+    ) -> Self::RenderObject {
+        RenderSizedBox::shrink()
+    }
+
+    fn update_render_object(
+        &self,
+        _ctx: &flui_view::RenderObjectContext<'_>,
+        _render_object: &mut Self::RenderObject,
+    ) {
+    }
+
+    fn has_children(&self) -> bool {
+        !self.children.is_empty()
+    }
+
+    fn visit_child_views(&self, visitor: &mut dyn FnMut(&dyn View)) {
+        for child in &self.children {
+            visitor(child);
+        }
+    }
+}
+
+impl View for MultiBox {
+    fn create_element(&self) -> flui_view::element::ElementKind {
+        flui_view::element::ElementKind::render_variable(self)
+    }
+}
+
+fn live_children(tree: &ElementTree, parent: ElementId) -> Vec<ElementId> {
+    let mut children: Vec<_> = tree
+        .iter_nodes()
+        .filter(|(_, node)| node.parent() == Some(parent))
+        .map(|(id, node)| (node.slot(), id))
+        .collect();
+    children.sort_by_key(|(slot, _)| *slot);
+    children.into_iter().map(|(_, id)| id).collect()
+}
+
+/// Drives mount → first builds → keyed reorder → shrink (eager unmounts) →
+/// clear, asserting exact counts at each step. Any emission site silently
+/// removed fails a specific assertion here (red→green verified during
+/// development by disabling sites).
+#[test]
+fn inspector_counts_mounts_moves_rebuilds_and_unmounts_exactly() {
+    let counters = Arc::new(InspectorCounters::new());
+    let mut owner = BuildOwner::new();
+    owner.set_tree_observer(Arc::clone(&counters) as Arc<dyn TreeObserver>);
+    let mut tree = ElementTree::new();
+
+    // Mount the root; its three keyed children mount during the first
+    // build_scope (phase-2 reconcile of the root's build output).
+    let root_id = tree.mount_root(&MultiBox::keyed(&[1, 2, 3]), &mut owner.element_owner_mut());
+    let after_root = counters.snapshot();
+    assert_eq!(
+        after_root.mounts, 1,
+        "root mint must emit exactly one mount"
+    );
+    assert_eq!(after_root.rebuilds, 0, "no build ran yet");
+
+    owner.schedule_build_for(root_id, 0, RebuildReason::InitialMount);
+    owner.build_scope(&mut tree);
+
+    let after_first_build = counters.snapshot();
+    assert_eq!(
+        after_first_build.mounts, 4,
+        "root + three children minted exactly once each",
+    );
+    assert!(
+        after_first_build.rebuilds >= 1,
+        "the root's first build must emit a rebuilt event",
+    );
+    assert_eq!(
+        after_first_build.rebuilds_for(RebuildReason::InitialMount),
+        after_first_build.rebuilds,
+        "every completed build so far was a first build",
+    );
+    assert_eq!(after_first_build.moves, 0);
+    assert_eq!(after_first_build.unmounts, 0);
+
+    // Keyed rotation: ids follow keys, three reorder moves, nothing
+    // mounts or unmounts.
+    let before = live_children(&tree, root_id);
+    assert_eq!(before.len(), 3);
+    tree.update(
+        root_id,
+        &MultiBox::keyed(&[3, 1, 2]),
+        &mut owner.element_owner_mut(),
+    );
+    owner.schedule_build_for(root_id, 0, RebuildReason::ParentUpdate);
+    owner.build_scope(&mut tree);
+
+    let after_reorder = counters.snapshot();
+    assert_eq!(
+        after_reorder.moves, 3,
+        "a full keyed rotation moves every child exactly once",
+    );
+    assert_eq!(after_reorder.mounts, 4, "reorder must not mount");
+    assert_eq!(after_reorder.unmounts, 0, "reorder must not unmount");
+    assert!(
+        after_reorder.rebuilds_for(RebuildReason::ParentUpdate) >= 1,
+        "the reorder build must carry the ParentUpdate cause",
+    );
+
+    // Shrink to one child: two un-keyed... (keyed, but not GlobalKey-keyed)
+    // children take the EAGER unmount path inside the reconcile — the
+    // majority path the finalize-only design would have missed.
+    tree.update(
+        root_id,
+        &MultiBox::keyed(&[3]),
+        &mut owner.element_owner_mut(),
+    );
+    owner.schedule_build_for(root_id, 0, RebuildReason::ParentUpdate);
+    owner.build_scope(&mut tree);
+    owner.finalize_tree(&mut tree);
+
+    let after_shrink = counters.snapshot();
+    assert_eq!(
+        after_shrink.unmounts, 2,
+        "each removed child unmounts exactly once (eager inline path)",
+    );
+
+    // Balance invariant (ADR-0040 §4): mounts − unmounts == live tree size
+    // once nothing is parked in the inactive queue.
+    assert_eq!(
+        after_shrink.mounts - after_shrink.unmounts,
+        tree.len() as u64,
+        "mounts and unmounts must balance against the live tree",
+    );
+
+    // Install/clear symmetry: the consumer gets its end-of-stream signal.
+    owner.clear_tree_observer();
+    assert!(
+        counters.snapshot().is_final(),
+        "clear_tree_observer must fire detached()",
+    );
+}
+
+/// A mid-run attach must start from an exact structural baseline: the
+/// seeded replay reports the live tree as synthetic mounts, and events
+/// after the install continue the same stream.
+#[test]
+fn seeded_replay_gives_a_mid_run_attach_an_exact_baseline() {
+    let mut owner = BuildOwner::new();
+    let mut tree = ElementTree::new();
+
+    // Build a 1+3 tree with NO observer installed.
+    let root_id = tree.mount_root(&MultiBox::keyed(&[1, 2, 3]), &mut owner.element_owner_mut());
+    owner.schedule_build_for(root_id, 0, RebuildReason::InitialMount);
+    owner.build_scope(&mut tree);
+
+    // Mid-run attach: replay-then-install (the WidgetsBinding helper does
+    // exactly this under one write guard; here the single thread IS the
+    // atomicity).
+    let counters = Arc::new(InspectorCounters::new());
+    tree.replay_mounts(&*counters);
+    owner.set_tree_observer(Arc::clone(&counters) as Arc<dyn TreeObserver>);
+
+    let baseline = counters.snapshot();
+    assert_eq!(
+        baseline.mounts,
+        tree.len() as u64,
+        "replay must report every live element exactly once",
+    );
+    assert_eq!(baseline.rebuilds, 0, "replay synthesizes mounts only");
+
+    // Post-attach events continue the stream: shrink and observe unmounts.
+    tree.update(
+        root_id,
+        &MultiBox::keyed(&[2]),
+        &mut owner.element_owner_mut(),
+    );
+    owner.schedule_build_for(root_id, 0, RebuildReason::ParentUpdate);
+    owner.build_scope(&mut tree);
+
+    let after = counters.snapshot();
+    assert_eq!(after.unmounts, 2, "post-attach unmounts arrive live");
+    assert_eq!(
+        after.mounts - after.unmounts,
+        tree.len() as u64,
+        "baseline + live stream keeps the balance invariant",
+    );
+}
+
+/// A panicking observer is detached and the frame survives; `detached()`
+/// is NOT called on the panicking observer.
+#[test]
+fn panicking_observer_is_detached_and_the_tree_survives() {
+    struct PanicOnMount;
+    impl TreeObserver for PanicOnMount {
+        fn element_mounted(&self, _event: &flui_foundation::observe::ElementMounted) {
+            panic!("observer bug");
+        }
+    }
+
+    let mut owner = BuildOwner::new();
+    owner.set_tree_observer(Arc::new(PanicOnMount));
+    let mut tree = ElementTree::new();
+
+    // The mount emission panics inside the observer; the emission helper
+    // contains it, detaches the observer, and the mount itself completes.
+    let root_id = tree.mount_root(&MultiBox::keyed(&[1]), &mut owner.element_owner_mut());
+    assert!(tree.get(root_id).is_some(), "the mount itself must survive");
+    assert!(
+        owner.tree_observer().is_none(),
+        "the panicking observer must be detached",
+    );
+
+    // The tree keeps working with no observer installed.
+    owner.schedule_build_for(root_id, 0, RebuildReason::InitialMount);
+    owner.build_scope(&mut tree);
+    assert_eq!(tree.len(), 2, "root + one child built normally");
+}

--- a/crates/flui-devtools/Cargo.toml
+++ b/crates/flui-devtools/Cargo.toml
@@ -21,6 +21,8 @@ serde_json = { workspace = true }
 flui-hot-reload = { path = "../flui-hot-reload", version = "0.2.0", optional = true, features = [
     "source-watch",
 ] }
+flui-foundation = { path = "../flui-foundation", version = "0.2.0", optional = true }
+tracing = { workspace = true, optional = true }
 
 # Data structures
 parking_lot = { workspace = true }
@@ -46,11 +48,16 @@ timeline = []
 # Hot code reload for development
 hot-reload = ["dep:flui-hot-reload"]
 
+# Counting/logging tree inspector over the ADR-0040 observation seam.
+# Depends ONLY on flui-foundation (dependency inversion) — still zero
+# access to the trees themselves.
+inspector = ["dep:flui-foundation", "dep:tracing"]
+
 # === Convenience Features ===
 # Enable all features. This list is the crate's honest capability inventory —
 # a subsystem that does not exist (inspector, network monitor, memory
 # profiler, remote debug) has no feature here, commented or otherwise.
-full = ["profiling", "timeline", "hot-reload"]
+full = ["profiling", "timeline", "hot-reload", "inspector"]
 
 [dev-dependencies]
 

--- a/crates/flui-devtools/src/inspector.rs
+++ b/crates/flui-devtools/src/inspector.rs
@@ -1,0 +1,171 @@
+//! Counting/logging tree inspector — the ADR-0040 slice-1 consumer.
+//!
+//! Proves the dependency-inverted observation seam end to end with only
+//! `flui-foundation` on the dependency list: install an
+//! [`InspectorCounters`] via `WidgetsBinding::install_tree_observer` and it
+//! tallies mounts, moves, rebuilds (with per-cause counts), and unmounts as
+//! the tree mutates. No tree access, no locks in the public surface.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use flui_foundation::RebuildReason;
+use flui_foundation::observe::{
+    ElementMounted, ElementMoved, ElementRebuilt, ElementUnmounted, TreeObserver,
+};
+
+/// Number of [`RebuildReason`] variants tracked in the per-cause tallies.
+const REASON_COUNT: usize = 10;
+
+/// Counting/logging [`TreeObserver`] — the slice-1 inspector.
+///
+/// Interior state is private atomics; nothing here exposes a lock (SP-6).
+/// All counter updates use `Relaxed`: bare tallies, no data is published
+/// through them, and the observation contract already serializes emissions
+/// per realm (owner-thread, synchronous).
+#[derive(Debug, Default)]
+pub struct InspectorCounters {
+    mounts: AtomicU64,
+    unmounts: AtomicU64,
+    rebuilds: AtomicU64,
+    moves: AtomicU64,
+    per_reason: [AtomicU64; REASON_COUNT],
+    detached: AtomicBool,
+}
+
+impl InspectorCounters {
+    /// Plain constructor — callers wrap in `Arc` themselves
+    /// (`Arc::new(InspectorCounters::new())`), consistent with the
+    /// `Default` derive rather than competing with it.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot for display. Each counter is individually monotonic, but
+    /// the snapshot reads independent atomics without a lock, so
+    /// cross-counter consistency is NOT guaranteed (a snapshot taken
+    /// mid-frame may show a mount whose paired rebuild is not yet counted).
+    /// Per-counter monotonicity is the only invariant. Clones values out,
+    /// returns no guard (SP-6).
+    #[must_use]
+    pub fn snapshot(&self) -> InspectorSnapshot {
+        let mut per_reason = [0u64; REASON_COUNT];
+        for (slot, counter) in per_reason.iter_mut().zip(&self.per_reason) {
+            *slot = counter.load(Ordering::Relaxed);
+        }
+        InspectorSnapshot {
+            mounts: self.mounts.load(Ordering::Relaxed),
+            unmounts: self.unmounts.load(Ordering::Relaxed),
+            rebuilds: self.rebuilds.load(Ordering::Relaxed),
+            moves: self.moves.load(Ordering::Relaxed),
+            per_reason,
+            detached: self.detached.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl TreeObserver for InspectorCounters {
+    fn element_mounted(&self, event: &ElementMounted) {
+        self.mounts.fetch_add(1, Ordering::Relaxed);
+        tracing::debug!(element = ?event.element, parent = ?event.parent, slot = event.slot, "inspector: mounted");
+    }
+
+    fn element_moved(&self, event: &ElementMoved) {
+        self.moves.fetch_add(1, Ordering::Relaxed);
+        tracing::debug!(element = ?event.element, parent = ?event.parent, slot = event.slot, "inspector: moved");
+    }
+
+    fn element_rebuilt(&self, event: &ElementRebuilt) {
+        self.rebuilds.fetch_add(1, Ordering::Relaxed);
+        for reason in event.reasons.iter() {
+            if let Some(counter) = self.per_reason.get(reason as u8 as usize) {
+                counter.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        tracing::debug!(element = ?event.element, reasons = %event.reasons, "inspector: rebuilt");
+    }
+
+    fn element_unmounted(&self, event: &ElementUnmounted) {
+        self.unmounts.fetch_add(1, Ordering::Relaxed);
+        tracing::debug!(element = ?event.element, "inspector: unmounted");
+    }
+
+    fn detached(&self) {
+        self.detached.store(true, Ordering::Relaxed);
+        tracing::debug!("inspector: stream detached");
+    }
+}
+
+/// Point-in-time counters. `#[non_exhaustive]` — fields append.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InspectorSnapshot {
+    /// Elements mounted since attach (including replay-seeded mounts).
+    pub mounts: u64,
+    /// Elements unmounted since attach.
+    pub unmounts: u64,
+    /// Completed builds since attach (first builds included — see
+    /// `ElementRebuilt`'s docs).
+    pub rebuilds: u64,
+    /// Moves (reparents + keyed reorders) since attach.
+    pub moves: u64,
+    /// Per-reason rebuild tallies; read via [`Self::rebuilds_for`].
+    per_reason: [u64; REASON_COUNT],
+    /// Whether the stream ended (`detached()` fired) before this snapshot.
+    detached: bool,
+}
+
+impl InspectorSnapshot {
+    /// Rebuilds whose cause set contained `reason`.
+    ///
+    /// A build accumulating several causes counts once per contained
+    /// cause, so per-reason tallies can sum to more than
+    /// [`rebuilds`](Self::rebuilds).
+    #[must_use]
+    pub fn rebuilds_for(&self, reason: RebuildReason) -> u64 {
+        self.per_reason
+            .get(reason as u8 as usize)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Whether the observation stream has ended (`detached()` fired).
+    #[must_use]
+    pub fn is_final(&self) -> bool {
+        self.detached
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::TypeId;
+
+    use flui_foundation::{ElementId, RebuildReasons};
+
+    use super::*;
+
+    #[test]
+    fn counters_tally_events_and_reasons() {
+        let counters = InspectorCounters::new();
+        let observer: &dyn TreeObserver = &counters;
+        let id = ElementId::new(1);
+
+        observer.element_mounted(&ElementMounted::new(id, None, 0, TypeId::of::<()>()));
+        let mut reasons = RebuildReasons::from_reason(RebuildReason::InitialMount);
+        reasons.insert(RebuildReason::StateChange);
+        observer.element_rebuilt(&ElementRebuilt::new(id, TypeId::of::<()>(), reasons));
+        observer.element_moved(&ElementMoved::new(id, id, 2));
+        observer.element_unmounted(&ElementUnmounted::new(id));
+        observer.detached();
+
+        let snapshot = counters.snapshot();
+        assert_eq!(snapshot.mounts, 1);
+        assert_eq!(snapshot.rebuilds, 1);
+        assert_eq!(snapshot.moves, 1);
+        assert_eq!(snapshot.unmounts, 1);
+        assert_eq!(snapshot.rebuilds_for(RebuildReason::InitialMount), 1);
+        assert_eq!(snapshot.rebuilds_for(RebuildReason::StateChange), 1);
+        assert_eq!(snapshot.rebuilds_for(RebuildReason::AnimationTick), 0);
+        assert!(snapshot.is_final());
+    }
+}

--- a/crates/flui-devtools/src/lib.rs
+++ b/crates/flui-devtools/src/lib.rs
@@ -20,16 +20,22 @@
 //! - That is all: rebuild triggering and state preservation live in
 //!   `flui-hot-reload` (worker/host split), not here
 //!
+//! ## 🔎 Inspector counters (feature: inspector)
+//! - A counting/logging `TreeObserver` (ADR-0040 seam) — tallies element
+//!   mounts, moves, rebuilds (per cause), and unmounts of a running realm
+//! - Depends only on `flui-foundation`; installed via
+//!   `WidgetsBinding::install_tree_observer` by the embedder
+//!
 //! # What this crate is NOT (yet)
 //!
-//! It is not an inspector: it has no dependency on any flui tree crate, so
-//! it cannot observe widgets, elements, render objects, or semantics. Wiring
-//! that up requires an observation seam in the core (dependency inversion —
-//! the core publishes tree events through a narrow trait the devtools can
-//! subscribe to; see the 2026-07-25 audit §26). There is likewise no network
-//! monitor, no memory profiler, and no remote-debug protocol — earlier
-//! versions of this documentation advertised those as features; they were
-//! never implemented.
+//! It is not a full inspector: it still has no dependency on any flui tree
+//! crate and cannot walk widgets, elements, render objects, or semantics.
+//! What exists (feature `inspector`) is the *event* half of ADR-0040's
+//! dependency-inverted seam — structural observations pushed by the core.
+//! Pull-shaped inspection (state versions, dependency edges, memory) waits
+//! on its own future seam. There is likewise no network monitor, no memory
+//! profiler, and no remote-debug protocol — earlier versions of this
+//! documentation advertised those as features; they were never implemented.
 //!
 //! # Usage
 //!
@@ -78,6 +84,7 @@
 //! - `profiling`: Performance profiling tools (no external dependencies)
 //! - `timeline`: Timeline view for events
 //! - `hot-reload`: File watching (reports changes; nothing more)
+//! - `inspector`: Counting/logging tree observer over the ADR-0040 seam
 //! - `full`: all of the above
 //!
 //! No other feature exists. The `default = []` boundary is what keeps a
@@ -90,6 +97,8 @@
 mod common;
 #[cfg(feature = "hot-reload")]
 pub mod hot_reload;
+#[cfg(feature = "inspector")]
+pub mod inspector;
 #[cfg(feature = "profiling")]
 pub mod profiler;
 #[cfg(feature = "timeline")]
@@ -111,6 +120,8 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub mod prelude {
     #[cfg(feature = "hot-reload")]
     pub use crate::hot_reload::HotReloader;
+    #[cfg(feature = "inspector")]
+    pub use crate::inspector::{InspectorCounters, InspectorSnapshot};
     #[cfg(feature = "profiling")]
     pub use crate::profiler::{FramePhase, FrameStats, Profiler};
     #[cfg(feature = "timeline")]

--- a/crates/flui-foundation/src/lib.rs
+++ b/crates/flui-foundation/src/lib.rs
@@ -162,6 +162,11 @@ pub mod wasm;
 // docs/plans/2026-05-23-001-feat-pipeline-wiring-d-block-plan.md).
 pub mod log;
 
+// Dependency-inverted tree observation (ADR-0040) + the typed rebuild
+// causes its events carry.
+pub mod observe;
+pub mod rebuild_reason;
+
 // Reactive programming - change notification and observables
 pub mod notifier;
 
@@ -229,6 +234,7 @@ pub use id::{
 pub use key::{Key, KeyRef, Keyed, UniqueKey, ValueKey, ViewKey, WithKey};
 // Change notification (Listenable pattern)
 pub use notifier::{ChangeNotifier, Listenable, ListenerCallback, ValueListenable, ValueNotifier};
+pub use rebuild_reason::{RebuildReason, RebuildReasons};
 // Generic typed channel + unified listener registry
 pub use listener_registry::{ListenerRegistry, ListenerSubscription};
 pub use notifier_generic::{ArgCallback, Notifier};

--- a/crates/flui-foundation/src/observe.rs
+++ b/crates/flui-foundation/src/observe.rs
@@ -1,0 +1,251 @@
+//! Dependency-inverted tree observation (ADR-0040; audit 2026-07-25 §26/U3).
+//!
+//! `flui-devtools` cannot depend on the tree crates (that would compile the
+//! whole framework into any app enabling inspection and invert nothing), so
+//! the core publishes observations *downward*: this module declares the
+//! narrow [`TreeObserver`] trait and its typed event structs, emitters
+//! (`BuildOwner` and the tree primitives it drives, in `flui-view`) call
+//! into an installed observer, and devtools implements the trait with only
+//! `flui-foundation` on its dependency list.
+//!
+//! The existing `flui::reconcile` tracing stream is deliberately NOT this
+//! seam (typed payloads degrade to strings there, its subscriber lifecycle
+//! is process-global, and it cannot be realm-scoped); it remains unchanged
+//! for trace tooling.
+
+use core::any::TypeId;
+
+use crate::{ElementId, RebuildReasons};
+
+/// A fresh element was created and mounted into the tree.
+///
+/// Emitted only when a new element is minted — a `GlobalKey` retake of an
+/// existing element emits [`ElementMoved`] instead, never a second mount.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ElementMounted {
+    /// The new element. Generational (index + generation), so a devtools
+    /// store keyed by the packed value can never confuse a recycled slab
+    /// slot — the house ABA defense.
+    pub element: ElementId,
+    /// `None` for the root element (`mount_root*`); `Some` for every child
+    /// minted by `ElementTree::insert`.
+    pub parent: Option<ElementId>,
+    /// Slot index under `parent` (0 for the root).
+    pub slot: usize,
+    /// `View::view_type_id()` of the configuring view — typed, not a Debug
+    /// string. This is the *logical* view type: `view_type_id` is
+    /// overridable and `BoxedView` forwards it to its inner view, so a
+    /// boxed child reports the inner type, not the wrapper. Devtools
+    /// grouping is therefore by logical type — the same identity the
+    /// reconciler matches on.
+    pub view_type_id: TypeId,
+}
+
+impl ElementMounted {
+    /// Constructor for in-workspace emitters.
+    ///
+    /// The struct is `#[non_exhaustive]`, which protects *matchers*, not
+    /// constructors: appending a field changes this signature. That is
+    /// acceptable because events are constructed only by in-workspace
+    /// emitters; out-of-workspace observers read events, never build them.
+    #[must_use]
+    pub fn new(
+        element: ElementId,
+        parent: Option<ElementId>,
+        slot: usize,
+        view_type_id: TypeId,
+    ) -> Self {
+        Self {
+            element,
+            parent,
+            slot,
+            view_type_id,
+        }
+    }
+}
+
+/// An existing element's position changed: a `GlobalKey` reparent (possibly
+/// across parents) or a keyed reorder under the same parent.
+///
+/// Consumers holding a mirror update the element's parent/slot edge; the
+/// element's state and identity survive.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ElementMoved {
+    /// The element that moved.
+    pub element: ElementId,
+    /// Its parent after the move (may equal the previous parent for a
+    /// same-parent reorder).
+    pub parent: ElementId,
+    /// Its slot under `parent` after the move.
+    pub slot: usize,
+}
+
+impl ElementMoved {
+    /// Constructor for in-workspace emitters (see [`ElementMounted::new`]).
+    #[must_use]
+    pub fn new(element: ElementId, parent: ElementId, slot: usize) -> Self {
+        Self {
+            element,
+            parent,
+            slot,
+        }
+    }
+}
+
+/// An element's build completed, with its accumulated causes.
+///
+/// Emitted only for builds that ran to completion (including builds
+/// recovered into an error view — those completed with substitute output).
+/// A build pass that unwinds emits nothing for that element. First builds
+/// are included: every mount is followed by a rebuilt event whose reasons
+/// contain [`crate::RebuildReason::InitialMount`], so `mounts + rebuilds`
+/// intentionally counts first builds in both — consumers wanting
+/// "re-builds only" filter on the reason set.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ElementRebuilt {
+    /// The rebuilt element.
+    pub element: ElementId,
+    /// Logical view type (same semantics as [`ElementMounted::view_type_id`]).
+    pub view_type_id: TypeId,
+    /// Every distinct cause accumulated since the last build — the same set
+    /// the build drain consumes.
+    pub reasons: RebuildReasons,
+}
+
+impl ElementRebuilt {
+    /// Constructor for in-workspace emitters (see [`ElementMounted::new`]).
+    #[must_use]
+    pub fn new(element: ElementId, view_type_id: TypeId, reasons: RebuildReasons) -> Self {
+        Self {
+            element,
+            view_type_id,
+            reasons,
+        }
+    }
+}
+
+/// An element was unmounted — its `unmount` ran and its slab slot was freed.
+///
+/// This is a fact, not a scheduling artifact: it fires for eager inline
+/// removals during reconcile, deferred keyed removals drained by
+/// `finalize_tree`, lazy-sliver evictions, and root detachment alike. A
+/// soft-removed keyed element parked in the inactive queue has NOT been
+/// unmounted and produces no event until it is either retaken
+/// ([`ElementMoved`]) or finalized (this event).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ElementUnmounted {
+    /// The unmounted element.
+    pub element: ElementId,
+}
+
+impl ElementUnmounted {
+    /// Constructor for in-workspace emitters (see [`ElementMounted::new`]).
+    #[must_use]
+    pub fn new(element: ElementId) -> Self {
+        Self { element }
+    }
+}
+
+/// Dependency-inverted tree observation (ADR-0040).
+///
+/// Implemented by consumers (devtools); emitted into by owners
+/// (`BuildOwner` and the tree primitives it drives). All methods default to
+/// no-ops so adding an observation kind is never a breaking change for
+/// implementors.
+///
+/// # Ordering contract
+///
+/// The stream is a **totally-ordered tree-mutation log**, emitted
+/// synchronously on the realm's owner thread in the exact order the
+/// mutations happen. Per element it is causal: `element_mounted` first,
+/// then any interleaving of `element_rebuilt` / `element_moved`, then
+/// `element_unmounted` last. **No phase bucketing is promised**: builds run
+/// mid-layout-settling and post-layout, eager unmounts happen inline during
+/// any reconcile, and finalization runs at several points per frame — so
+/// "mounts during build, unmounts at end of frame" would be false and is
+/// not the contract.
+///
+/// # Threading, re-entrancy, and deadlock
+///
+/// Callbacks run on the realm's owner thread, inside frame phases, while
+/// the realm's locks are held. The contract is absolute: an observer
+/// callback must not call **any** flui-view binding, realm, or owner API —
+/// the natural accessors take a non-reentrant read lock while the frame
+/// drive holds the write lock, which deadlocks the realm thread in release
+/// builds. A callback may touch only its own state (atomics, lock-free
+/// structures, `try_send` into a channel it owns) and must return promptly.
+/// Inspection-driven mutation must go through out-of-frame channels (a
+/// `RebuildHandle` used from *outside* the callback), never synchronously
+/// from an observer method.
+///
+/// # Panic policy
+///
+/// A panicking observer is detached: the emission wraps every call in
+/// `catch_unwind`; on unwind the observer is removed from its slot,
+/// [`detached`](Self::detached) is NOT called (the observer just proved it
+/// cannot be trusted to run), and the detachment is logged at error level.
+/// The frame survives.
+///
+/// # Teardown
+///
+/// The seam does not synthesize `element_unmounted` for elements alive at
+/// teardown. [`detached`](Self::detached) is the end-of-life signal — and
+/// it only fires if the embedder clears the observer (install/clear
+/// symmetry); an owner dropped without clearing emits nothing.
+pub trait TreeObserver: Send + Sync {
+    /// A fresh element was minted and mounted.
+    fn element_mounted(&self, event: &ElementMounted) {
+        let _ = event;
+    }
+    /// An existing element moved (`GlobalKey` reparent or keyed reorder).
+    fn element_moved(&self, event: &ElementMoved) {
+        let _ = event;
+    }
+    /// An element's build completed.
+    fn element_rebuilt(&self, event: &ElementRebuilt) {
+        let _ = event;
+    }
+    /// An element was unmounted and its slot freed.
+    fn element_unmounted(&self, event: &ElementUnmounted) {
+        let _ = event;
+    }
+    /// End of stream: the observer was replaced or explicitly cleared. No
+    /// further events will arrive from this owner. Consumers drop or
+    /// archive their mirror here — this, not mount/unmount balance, is the
+    /// end-of-life signal. Not called when the observer is detached after
+    /// a panic (see the trait docs).
+    fn detached(&self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Recorder(std::sync::Mutex<Vec<&'static str>>);
+
+    impl TreeObserver for Recorder {
+        fn element_mounted(&self, _event: &ElementMounted) {
+            self.0.lock().unwrap().push("mounted");
+        }
+        fn detached(&self) {
+            self.0.lock().unwrap().push("detached");
+        }
+    }
+
+    #[test]
+    fn defaulted_methods_are_no_ops_and_overrides_receive_events() {
+        let recorder = Recorder(std::sync::Mutex::new(Vec::new()));
+        let observer: &dyn TreeObserver = &recorder;
+        let id = ElementId::new(1);
+        observer.element_mounted(&ElementMounted::new(id, None, 0, TypeId::of::<()>()));
+        // Defaulted methods must be callable and silent.
+        observer.element_moved(&ElementMoved::new(id, id, 3));
+        observer.element_unmounted(&ElementUnmounted::new(id));
+        observer.detached();
+        assert_eq!(*recorder.0.lock().unwrap(), ["mounted", "detached"]);
+    }
+}

--- a/crates/flui-foundation/src/rebuild_reason.rs
+++ b/crates/flui-foundation/src/rebuild_reason.rs
@@ -39,6 +39,8 @@ pub enum RebuildReason {
 }
 
 impl RebuildReason {
+    /// Every variant in stable diagnostic order — the backing table for
+    /// [`RebuildReasons::iter`].
     pub(crate) const ALL: [Self; 10] = [
         Self::InitialMount,
         Self::ParentUpdate,
@@ -83,9 +85,9 @@ impl fmt::Display for RebuildReason {
 /// Compact set of causes accumulated for one pending element rebuild.
 ///
 /// Scheduling the same element several times still produces one build, but it
-/// does not erase causality: every distinct reason remains in this set. Values
-/// returned by [`BuildOwner::pending_rebuild_reasons`](super::BuildOwner::pending_rebuild_reasons)
-/// are snapshots and never expose the owner's internal queue or lock.
+/// does not erase causality: every distinct reason remains in this set. A
+/// value handed out by an owner is a snapshot — copying it out neither
+/// guards nor exposes the owner's internal queue or lock.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RebuildReasons(u16);
 
@@ -96,15 +98,14 @@ impl RebuildReasons {
         Self(reason.bit())
     }
 
-    pub(crate) const fn one(reason: RebuildReason) -> Self {
-        Self::from_reason(reason)
-    }
-
-    pub(crate) fn insert(&mut self, reason: RebuildReason) {
+    /// Add `reason` to the set. Value-semantic bitset union — there is no
+    /// invariant to protect, so this is public for out-of-crate emitters.
+    pub fn insert(&mut self, reason: RebuildReason) {
         self.0 |= reason.bit();
     }
 
-    pub(crate) fn merge(&mut self, other: Self) {
+    /// Union `other` into the set.
+    pub fn merge(&mut self, other: Self) {
         self.0 |= other.0;
     }
 
@@ -156,7 +157,7 @@ mod tests {
 
     #[test]
     fn accumulated_reasons_are_unique_and_stably_ordered() {
-        let mut reasons = RebuildReasons::one(RebuildReason::AnimationTick);
+        let mut reasons = RebuildReasons::from_reason(RebuildReason::AnimationTick);
         reasons.insert(RebuildReason::DependencyChange);
         reasons.insert(RebuildReason::AnimationTick);
 

--- a/crates/flui-view/src/binding.rs
+++ b/crates/flui-view/src/binding.rs
@@ -636,6 +636,40 @@ impl WidgetsBinding {
         f(&mut self.inner.write().build_owner)
     }
 
+    /// Atomic seeded observer install (ADR-0040 §3): under ONE `inner`
+    /// write guard, replay the current tree into `observer`
+    /// (`ElementTree::replay_mounts`), then install it as the realm's
+    /// observer. Every frame drive also holds the `inner` write lock, so no
+    /// tree mutation can interleave between replay and install — the
+    /// consumer's baseline is exact.
+    ///
+    /// A panic during replay aborts the install: nothing is registered and
+    /// the aborted install is logged (the observer proved untrustworthy
+    /// before it was ever installed).
+    pub fn install_tree_observer(
+        &self,
+        observer: std::sync::Arc<dyn flui_foundation::observe::TreeObserver>,
+    ) {
+        let mut inner = self.inner.write();
+        let replay_ok = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            inner.element_tree.replay_mounts(&*observer);
+        }))
+        .is_ok();
+        if replay_ok {
+            inner.build_owner.set_tree_observer(observer);
+        } else {
+            tracing::error!(
+                "TreeObserver panicked during seeded replay; install aborted, nothing registered"
+            );
+        }
+    }
+
+    /// Symmetric removal (install/clear symmetry); fires `detached()` on
+    /// the outgoing observer. Idempotent.
+    pub fn remove_tree_observer(&self) {
+        self.inner.write().build_owner.clear_tree_observer();
+    }
+
     // ========================================================================
     // Element Tree Access
     // ========================================================================

--- a/crates/flui-view/src/owner/build_owner.rs
+++ b/crates/flui-view/src/owner/build_owner.rs
@@ -13,7 +13,7 @@ use std::{
     sync::Arc,
 };
 
-use flui_foundation::{ElementId, RenderId};
+use flui_foundation::{ElementId, RebuildReasons, RenderId};
 use flui_interaction::FocusManager;
 use parking_lot::{Mutex, RwLock};
 
@@ -21,7 +21,7 @@ use crate::{
     element::child_manager::{ChildManager, ChildManagerRegistry},
     owner::{
         RebuildReason, inherited_dependencies::InheritedDependencies,
-        layout_builder::LayoutBuilderRegistry, rebuild_reason::RebuildReasons,
+        layout_builder::LayoutBuilderRegistry,
     },
     tree::ElementTree,
     view::View,
@@ -68,7 +68,7 @@ impl ExternalBuildScheduler {
             let mut inbox = self.inbox.lock();
             match inbox.entry(id) {
                 std::collections::hash_map::Entry::Vacant(entry) => {
-                    entry.insert(RebuildReasons::one(reason));
+                    entry.insert(RebuildReasons::from_reason(reason));
                     true
                 }
                 std::collections::hash_map::Entry::Occupied(mut entry) => {
@@ -223,6 +223,11 @@ pub struct BuildOwner {
     /// [`ElementNode`](crate::tree::ElementNode).
     pub(crate) inherited_dependencies: InheritedDependencies,
 
+    /// The realm's tree-observer slot (ADR-0040). `None` = observation off
+    /// (one branch per emission site). `pub(crate)` for the
+    /// [`ElementOwner`](super::ElementOwner) split-borrow.
+    pub(crate) tree_observer: Option<Arc<dyn flui_foundation::observe::TreeObserver>>,
+
     /// Whether we're currently in a build phase.
     #[cfg(debug_assertions)]
     building: bool,
@@ -361,6 +366,7 @@ impl BuildOwner {
             inactive_elements: Vec::new(),
             pending_dependency_changes: std::collections::HashSet::new(),
             inherited_dependencies: InheritedDependencies::default(),
+            tree_observer: None,
             #[cfg(debug_assertions)]
             building: false,
             #[cfg(debug_assertions)]
@@ -472,7 +478,7 @@ impl BuildOwner {
     pub fn schedule_build_for(&mut self, id: ElementId, depth: usize, reason: RebuildReason) {
         match self.dirty_reasons.entry(id) {
             std::collections::hash_map::Entry::Vacant(entry) => {
-                entry.insert(RebuildReasons::one(reason));
+                entry.insert(RebuildReasons::from_reason(reason));
                 self.dirty_elements
                     .push(Reverse(DirtyElement::new(id, depth)));
 
@@ -558,7 +564,36 @@ impl BuildOwner {
             post_frame_handle: &self.post_frame_handle,
             text_input_handle: &self.text_input_handle,
             interaction_dispatch: &self.interaction_dispatch,
+            tree_observer: &mut self.tree_observer,
         }
+    }
+
+    /// Install the realm's tree observer, replacing any previous one
+    /// (ADR-0040). A replaced observer receives `detached()` first, and the
+    /// replacement is logged so competing tools discover each other.
+    ///
+    /// Install at realm setup or via
+    /// `WidgetsBinding::install_tree_observer` — never from a frame phase.
+    pub fn set_tree_observer(&mut self, observer: Arc<dyn flui_foundation::observe::TreeObserver>) {
+        if let Some(previous) = self.tree_observer.replace(observer) {
+            tracing::debug!("tree observer replaced; notifying the outgoing observer");
+            previous.detached();
+        }
+    }
+
+    /// Remove the observer (realm teardown — install/clear symmetry).
+    /// Fires `detached()` on the outgoing observer. Idempotent.
+    pub fn clear_tree_observer(&mut self) {
+        if let Some(previous) = self.tree_observer.take() {
+            previous.detached();
+        }
+    }
+
+    /// The installed observer, if any. Clones the `Arc` out — no reference
+    /// into private state, no guard (SP-6).
+    #[must_use]
+    pub fn tree_observer(&self) -> Option<Arc<dyn flui_foundation::observe::TreeObserver>> {
+        self.tree_observer.clone()
     }
 
     /// Record the reverse half of an inherited dependency registration.
@@ -815,6 +850,7 @@ impl BuildOwner {
                     post_frame_handle: &self.post_frame_handle,
                     text_input_handle: &self.text_input_handle,
                     interaction_dispatch: &self.interaction_dispatch,
+                    tree_observer: &mut self.tree_observer,
                 };
                 if needs_did_change {
                     element
@@ -840,6 +876,23 @@ impl BuildOwner {
                 // dropped — the build did not complete.
                 Err(payload) => std::panic::resume_unwind(payload),
             };
+
+            // ADR-0040: the build ran to completion (the resume_unwind branch
+            // can no longer take it) and the slot is restored — safe window
+            // for third-party observer code, and a parent's rebuilt event
+            // precedes the child mutations its build produced (phase 2).
+            if self.tree_observer.is_some() {
+                let view_type_id = tree.get(id).map(|node| node.element().view_type_id());
+                if let Some(view_type_id) = view_type_id {
+                    super::emit_observation(&mut self.tree_observer, |o| {
+                        o.element_rebuilt(&flui_foundation::observe::ElementRebuilt::new(
+                            id,
+                            view_type_id,
+                            reasons,
+                        ));
+                    });
+                }
+            }
             for record in dep_sink.into_inner() {
                 let Some(node) = tree.get_mut(record.provider) else {
                     continue;
@@ -874,6 +927,7 @@ impl BuildOwner {
                 post_frame_handle: &self.post_frame_handle,
                 text_input_handle: &self.text_input_handle,
                 interaction_dispatch: &self.interaction_dispatch,
+                tree_observer: &mut self.tree_observer,
             };
             crate::tree::id_reconcile::reconcile_children_by_id(
                 tree,
@@ -1041,6 +1095,7 @@ impl BuildOwner {
                 post_frame_handle: &self.post_frame_handle,
                 text_input_handle: &self.text_input_handle,
                 interaction_dispatch: &self.interaction_dispatch,
+                tree_observer: &mut self.tree_observer,
             };
 
             let did_work = manager_arc.lock().service(
@@ -1170,6 +1225,7 @@ impl BuildOwner {
             post_frame_handle: &self.post_frame_handle,
             text_input_handle: &self.text_input_handle,
             interaction_dispatch: &self.interaction_dispatch,
+            tree_observer: &mut self.tree_observer,
         };
 
         // Finalize all elements (deepest first - already sorted by collect order).

--- a/crates/flui-view/src/owner/element_owner.rs
+++ b/crates/flui-view/src/owner/element_owner.rs
@@ -49,8 +49,8 @@ use super::RebuildReason;
 use super::build_owner::{DirtyElement, ExternalBuildScheduler, InactiveElement};
 use super::inherited_dependencies::{InheritedDependencies, ProviderIds};
 use super::layout_builder::{LayoutBuilderEntry, LayoutBuilderRegistry};
-use super::rebuild_reason::RebuildReasons;
 use crate::element::child_manager::{ChildManager, ChildManagerRegistry};
+use flui_foundation::RebuildReasons;
 
 /// Borrowed live-tree access carried by [`ElementOwner`] while a
 /// `build_scope` drain runs an element's `build()` (PR-K).
@@ -152,6 +152,12 @@ pub struct ElementOwner<'a> {
     /// callback to push onto from outside a frame.
     pub(crate) external_inbox: &'a Arc<Mutex<HashMap<ElementId, RebuildReasons>>>,
 
+    /// The realm's tree-observer slot (ADR-0040), threaded to the tree
+    /// primitives so mount/move/unmount facts are emitted at their funnels.
+    /// `&mut` is load-bearing: the panic-detach policy clears the slot from
+    /// inside the emission helper.
+    pub(crate) tree_observer: &'a mut Option<Arc<dyn flui_foundation::observe::TreeObserver>>,
+
     /// Reference to `BuildOwner::on_build_scheduled` as the shareable `Arc`
     /// (the [`Self::on_build_scheduled`] field above is the `&dyn Fn` view used
     /// for the in-frame fire). An [`ExternalBuildScheduler`] clones this so a
@@ -251,7 +257,7 @@ impl ElementOwner<'_> {
     pub fn schedule_build_for(&mut self, id: ElementId, depth: usize, reason: RebuildReason) {
         match self.dirty_reasons.entry(id) {
             std::collections::hash_map::Entry::Vacant(entry) => {
-                entry.insert(RebuildReasons::one(reason));
+                entry.insert(RebuildReasons::from_reason(reason));
                 self.dirty_elements
                     .push(Reverse(DirtyElement::new(id, depth)));
 

--- a/crates/flui-view/src/owner/mod.rs
+++ b/crates/flui-view/src/owner/mod.rs
@@ -12,11 +12,13 @@ mod element_owner;
 mod inherited_dependencies;
 mod layout_builder;
 mod rebuild_handle;
-mod rebuild_reason;
 
 pub use build_owner::BuildOwner;
 pub use rebuild_handle::RebuildHandle;
-pub use rebuild_reason::{RebuildReason, RebuildReasons};
+// Moved to flui-foundation (ADR-0040: observation events carry typed
+// causes, and foundation is the only crate below every emitter); re-exported
+// here so no call site changes.
+pub use flui_foundation::{RebuildReason, RebuildReasons};
 // Internal scheduling handle — `pub(crate)`: captured by `ElementCore` at mount,
 // no public consumer. See `ExternalBuildScheduler`.
 pub(crate) use build_owner::ExternalBuildScheduler;
@@ -24,3 +26,26 @@ pub use element_owner::ElementOwner;
 // Build-time live-tree handle carried on `ElementOwner` during a
 // `build_scope` drain (PR-K). Crate-internal.
 pub(crate) use element_owner::BuildHandle;
+
+/// Emit one tree observation through the realm's observer slot (ADR-0040).
+///
+/// Owns the two contract halves every emission site relies on:
+/// - **Laziness**: `f` (which constructs the payload) runs only when an
+///   observer is installed — the off path is one `Option` load + branch.
+/// - **Panic policy**: the observer call runs under `catch_unwind`; on
+///   unwind the observer is REMOVED from the slot (`detached()` is not
+///   called — the observer just proved it cannot be trusted to run) and the
+///   detachment is logged. The frame survives.
+pub(crate) fn emit_observation(
+    slot: &mut Option<std::sync::Arc<dyn flui_foundation::observe::TreeObserver>>,
+    f: impl FnOnce(&dyn flui_foundation::observe::TreeObserver),
+) {
+    if let Some(observer) = slot.as_deref()
+        && std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(observer))).is_err()
+    {
+        *slot = None;
+        tracing::error!(
+            "TreeObserver panicked during emission; observer detached (no detached() call)"
+        );
+    }
+}

--- a/crates/flui-view/src/tree/element_tree.rs
+++ b/crates/flui-view/src/tree/element_tree.rs
@@ -591,6 +591,16 @@ impl ElementTree {
             self.nodes[slab_index].registered_global_key_hash = Some(hash);
         }
 
+        // ADR-0040: a fresh root was minted and mounted.
+        crate::owner::emit_observation(owner.tree_observer, |o| {
+            o.element_mounted(&flui_foundation::observe::ElementMounted::new(
+                id,
+                None,
+                0,
+                view.view_type_id(),
+            ));
+        });
+
         self.root = Some(id);
         id
     }
@@ -705,6 +715,18 @@ impl ElementTree {
             view.view_type_id(),
             view.key().map(ViewKey::key_hash),
         ));
+
+        // ADR-0040: same single-mint funnel as the tracing Mount above — the
+        // GlobalKey-retake early-return can never reach this point, so a
+        // retake never double-fires as a mount.
+        crate::owner::emit_observation(owner.tree_observer, |o| {
+            o.element_mounted(&flui_foundation::observe::ElementMounted::new(
+                id,
+                Some(parent),
+                slot,
+                view.view_type_id(),
+            ));
+        });
 
         // A freshly-attached render child reads the parent-data its nearest
         // ancestor `ParentDataView` (`Expanded`, `Positioned`) contributes — the
@@ -1228,6 +1250,12 @@ impl ElementTree {
         self.unmount_inherited_dependencies(id, owner);
         self.nodes[index].element_mut().unmount(owner);
 
+        // ADR-0040: `Element::unmount` ran and the slot is about to free —
+        // one of the two primitives every unmount path bottoms out in.
+        crate::owner::emit_observation(owner.tree_observer, |o| {
+            o.element_unmounted(&flui_foundation::observe::ElementUnmounted::new(id));
+        });
+
         let node = self.nodes.remove(index);
         // Slot freed → bump its generation so any straggler id that still
         // names this slot can never resolve to its next occupant (ABA guard).
@@ -1353,6 +1381,12 @@ impl ElementTree {
         self.unmount_inherited_dependencies(id, owner);
         self.nodes[index].element_mut().unmount(owner);
 
+        // ADR-0040: the second of the two unmount primitives (finalize
+        // drains, subtree evictions, root detach all bottom out here).
+        crate::owner::emit_observation(owner.tree_observer, |o| {
+            o.element_unmounted(&flui_foundation::observe::ElementUnmounted::new(id));
+        });
+
         let node = self.nodes.remove(index);
         // Slot freed → bump its generation (ABA guard, see `remove`).
         self.bump_generation(index);
@@ -1362,6 +1396,34 @@ impl ElementTree {
         }
 
         Some(node)
+    }
+
+    /// Replay the live tree as synthetic `ElementMounted` events, in
+    /// pre-order (parent before children, `child_ids` slot order) — the
+    /// baseline for a mid-run observer attach (ADR-0040 §3).
+    ///
+    /// Walks from the root via `child_ids`, so soft-removed keyed elements
+    /// parked in the inactive queue are NOT replayed. The caller
+    /// (`WidgetsBinding::install_tree_observer`) holds the realm write lock
+    /// across replay + install, so no mutation can interleave.
+    pub fn replay_mounts(&self, observer: &dyn flui_foundation::observe::TreeObserver) {
+        let Some(root) = self.root else {
+            return;
+        };
+        let mut stack: Vec<ElementId> = vec![root];
+        while let Some(id) = stack.pop() {
+            let Some(node) = self.get(id) else {
+                continue;
+            };
+            observer.element_mounted(&flui_foundation::observe::ElementMounted::new(
+                id,
+                node.parent(),
+                node.slot(),
+                node.element().view_type_id(),
+            ));
+            // Reverse push keeps pre-order on a LIFO stack.
+            stack.extend(node.child_ids().iter().rev().copied());
+        }
     }
 
     /// Update an element with a new view.
@@ -1635,6 +1697,15 @@ fn retake_inactive_global_key(
         from_parent: None,
     });
 
+    // ADR-0040: identity and state survived — a move, never a second mount.
+    crate::owner::emit_observation(owner.tree_observer, |o| {
+        o.element_moved(&flui_foundation::observe::ElementMoved::new(
+            candidate_id,
+            new_parent,
+            new_slot,
+        ));
+    });
+
     Some(candidate_id)
 }
 
@@ -1726,6 +1797,15 @@ fn retake_active_global_key(
         view.view_type_id(),
         hash,
     ));
+
+    // ADR-0040: cross-parent move of a live element.
+    crate::owner::emit_observation(owner.tree_observer, |o| {
+        o.element_moved(&flui_foundation::observe::ElementMoved::new(
+            candidate_id,
+            new_parent,
+            new_slot,
+        ));
+    });
 
     Some(candidate_id)
 }

--- a/crates/flui-view/src/tree/id_reconcile.rs
+++ b/crates/flui-view/src/tree/id_reconcile.rs
@@ -270,6 +270,14 @@ pub(crate) fn reconcile_children_by_id(
             } else {
                 ReconcileEvent::reorder(parent_id, new_slot, view_type, key_hash)
             });
+            if !stayed {
+                // ADR-0040: a keyed match pulled the child across slots.
+                crate::owner::emit_observation(owner.tree_observer, |o| {
+                    o.element_moved(&flui_foundation::observe::ElementMoved::new(
+                        old_id, parent_id, new_slot,
+                    ));
+                });
+            }
             result.push(old_id);
         } else {
             // `ElementTree::insert` emits the disposition itself — `Mount`
@@ -305,6 +313,14 @@ pub(crate) fn reconcile_children_by_id(
         } else {
             ReconcileEvent::reorder(parent_id, new_idx, view_type, key_hash)
         });
+        if old_bottom != new_bottom {
+            // ADR-0040: the tail slice shifted because the middle resized.
+            crate::owner::emit_observation(owner.tree_observer, |o| {
+                o.element_moved(&flui_foundation::observe::ElementMoved::new(
+                    old_id, parent_id, new_idx,
+                ));
+            });
+        }
         result.push(old_id);
     }
 

--- a/scripts/port-check.sh
+++ b/scripts/port-check.sh
@@ -1162,6 +1162,9 @@ fi
 #   #5 error chains + observer/animation + owned callback storage:
 #      Error, std::error::Error, core::error::Error, Listenable,
 #      Animation, WidgetsBindingObserver, Fn, FnMut, FnOnce
+#   5. Observer patterns — TreeObserver (ADR-0040): dependency inversion
+#      REQUIRES type erasure here; the emitter crates cannot name the
+#      concrete devtools type below them in the DAG.
 #      (Fn/FnMut/FnOnce included via allowlist rather than per-site
 #      markers — see commit body of Phase 3.1 §U30 for the plan-time-
 #      vs-reality rationale; 96 owned-callback storage sites would have
@@ -1213,7 +1216,7 @@ fi
 #   `GlobalWidgetsLocalizations`) behind the trait every `Localizations::of`
 #   caller depends on — Flutter parity: `Localizations.of<WidgetsLocalizations>`
 #   is keyed by the abstract interface, never the concrete runtime class.
-fr036_allowed='dyn\s+(\$crate::|[a-zA-Z_][a-zA-Z0-9_]*::)*(View|ViewKey|BuildContext|ElementBase|ElementBehavior|StatelessElementBase|StatefulElementBase|ProxyElementBase|InheritedElementBase|RenderElementBase|RootElementBase|ErrorElementBase|InheritedElementAccess|RenderObjectTrait|RenderObject|Listenable|Notification|NotifiableElement|WidgetsBindingObserver|Animation|Animatable|BoxedView|ViewObject|Any|Error|GestureArenaMember|MonotonicClock|FocusTraversalPolicy|SliverGridDelegate|SingleChildLayoutDelegate|MultiChildLayoutDelegate|MultiChildLayoutContext|FlowDelegate|CustomPainter|ParentData|LogicalIndexParentData|CustomClipper|RendererBinding|HitTestable|Debug|Fn|FnMut|FnOnce|BoxLayoutCtxErased|SliverLayoutCtxErased|ChildManager|Future|Stream|ErasedRoute|NavigatorObserver|Simulation|ScrollPhysics|ImageProvider|ErasedLocalizationsDelegate|WidgetsLocalizations)\b'
+fr036_allowed='dyn\s+(\$crate::|[a-zA-Z_][a-zA-Z0-9_]*::)*(View|ViewKey|BuildContext|ElementBase|ElementBehavior|StatelessElementBase|StatefulElementBase|ProxyElementBase|InheritedElementBase|RenderElementBase|RootElementBase|ErrorElementBase|InheritedElementAccess|RenderObjectTrait|RenderObject|Listenable|Notification|NotifiableElement|WidgetsBindingObserver|TreeObserver|Animation|Animatable|BoxedView|ViewObject|Any|Error|GestureArenaMember|MonotonicClock|FocusTraversalPolicy|SliverGridDelegate|SingleChildLayoutDelegate|MultiChildLayoutDelegate|MultiChildLayoutContext|FlowDelegate|CustomPainter|ParentData|LogicalIndexParentData|CustomClipper|RendererBinding|HitTestable|Debug|Fn|FnMut|FnOnce|BoxLayoutCtxErased|SliverLayoutCtxErased|ChildManager|Future|Stream|ErasedRoute|NavigatorObserver|Simulation|ScrollPhysics|ImageProvider|ErasedLocalizationsDelegate|WidgetsLocalizations)\b'
 
 # Framework crates under enforcement.
 fr036_scope=(


### PR DESCRIPTION
Implements slice 1 of ADR-0040 exactly as committed: flui-devtools observes the widget tree with `flui-foundation` as its only framework dependency.

**The seam.** `flui_foundation::observe::TreeObserver` (five defaulted methods) + four `#[non_exhaustive]` typed events; `RebuildReason`/`RebuildReasons` move to foundation (old paths re-exported). One per-realm slot on `BuildOwner`; all emissions go through one helper owning laziness + `catch_unwind` + detach-on-panic. `Arc<dyn TreeObserver>` joins the FR-036 allowlist (category #5) in the same change.

**Emission sites are the corrected funnels** (the ADR's critique loop proved the naive set factually wrong): mounts at `insert`'s create path + `mount_root*` (retakes can't double-fire — early return); moves at both GlobalKey-retake paths and the two keyed-reorder branches; rebuilds at the `build_scope` drain **after `put_element` + Ok** (outside the unprotected extract window — covers frame builds, mid-layout settling, and post-layout servicing since all passes share the drain); unmounts at `ElementTree::remove`'s eager branch + `remove_finalized` — the only two primitives every unmount bottoms out in (un-keyed unmounts are eager/inline; a finalize-only design misses most of them). Soft-removes deliberately emit nothing. `replay_mounts` + `WidgetsBinding::install_tree_observer` seed a mid-run attach atomically under one write guard.

**Consumer + proof.** devtools `inspector` feature (`InspectorCounters`/`InspectorSnapshot`; wasm32-clean); flui-binding e2e suite drives a real render tree through `build_scope`: exact counts across mount → first builds → keyed rotation (moves=3) → eager shrink (unmounts=2), the §4 **mounts − unmounts == live-tree-size** oracle, seeded-replay exactness, panic-detach survival, install/clear `detached()` symmetry. **Red→green verified**: disabling the eager-unmount emission fails the suite (exercised during development).

**Benchmark** (audit §30's previously-unwritable inspector-overhead bench, 64-child keyed rotation per iteration): observer absent **19.18 µs**, no-op observer **21.45 µs** (+11.8%, ~34ns/event — the enabled path's `catch_unwind`+payload cost), counting inspector **23.51 µs** (+22.6%). Off-path cost remains bounded-by-construction; these numbers are the enabled path.

**Honest limits:** no dedicated `service_layout_builders` fixture (all build passes share the single drain emission site); render-phase observation, pull/query inspection, frame demarcation, and `flui::reconcile` consolidation stay out per the ADR's slicing; a `BuildOwner` dropped without `clear_tree_observer` emits no `detached()` (documented embedder obligation).

Gates: full `just ci`, `just wasm-check`, workspace clippy, taplo, port-check (new allowlist entry); e2e 3/3, devtools 24/24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)