### PR TITLE
feat(platform,app): land ADR-0038 slice 1 — data-transfer transport + winit file drops

### DIFF
--- a/crates/flui-app/src/app/binding.rs
+++ b/crates/flui-app/src/app/binding.rs
@@ -1462,6 +1462,16 @@ impl AppBinding {
                 realm.focus_manager().dispatch_key_event(&keyboard_event);
                 self.request_redraw();
             }
+            PlatformInput::DragDrop(drag_drop_event) => {
+                // The transport delivers DnD sessions here (ADR-0038), but
+                // the realm-side routing — drop-target resolution and the
+                // DropFeedback loop — does not exist yet, so the event is
+                // deliberately logged and dropped rather than half-routed.
+                tracing::debug!(
+                    event = ?drag_drop_event,
+                    "drag-and-drop input received; realm routing not implemented yet (ADR-0038), dropping"
+                );
+            }
         }
     }
 }

--- a/crates/flui-app/tests/data_transfer_transport.rs
+++ b/crates/flui-app/tests/data_transfer_transport.rs
@@ -1,0 +1,497 @@
+//! Gate-visible tests for the data-transfer transport (ADR-0038).
+//!
+//! These live in flui-app rather than next to the code because
+//! flui-platform's tests are excluded from the CI test job — a transport
+//! test there would be green-by-vacuity at the merge gate. flui-app is
+//! CI-covered and already depends on flui-platform and flui-scheduler, so
+//! the `OfferTable`, `TransferRequest`/`TransferCompleter`, and
+//! mock-source-through-`AsyncDriver` evidence runs here until the exclusion
+//! lifts.
+
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll, Waker};
+
+use flui_foundation::DataTransferId;
+use flui_platform::data_transfer::{
+    DataTransferOffer, DataTransferSource, DropFeedback, OfferRecord, OfferTable,
+    RepresentationDescriptor, RepresentationIndex, TransferActions, TransferCompleter,
+    TransferError, TransferFormat, TransferLimits, TransferPayload, TransferRequest, TransferUri,
+};
+use flui_scheduler::AsyncDriver;
+use parking_lot::Mutex;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn text_representations() -> Arc<[RepresentationDescriptor]> {
+    Arc::from([RepresentationDescriptor {
+        format: TransferFormat::Text,
+        declared_len: None,
+    }])
+}
+
+fn poll_once(
+    request: &mut std::pin::Pin<&mut TransferRequest>,
+) -> Poll<Result<TransferPayload, TransferError>> {
+    request
+        .as_mut()
+        .poll(&mut Context::from_waker(Waker::noop()))
+}
+
+// ============================================================================
+// OfferTable semantics
+// ============================================================================
+
+#[test]
+fn offer_table_mints_lookups_and_retires() {
+    let mut table = OfferTable::new();
+    assert!(table.is_empty());
+
+    let id = table.mint(OfferRecord::new(text_representations()));
+    assert_eq!(table.len(), 1);
+    assert!(table.get(id).is_some(), "a live id resolves its record");
+
+    let record = table.retire(id).expect("retiring a live offer yields it");
+    assert_eq!(record.representations().len(), 1);
+    assert!(table.is_empty());
+    assert!(table.get(id).is_none(), "a retired id no longer resolves");
+    assert!(
+        table.retire(id).is_none(),
+        "retire is idempotent — the second call is a stale no-op"
+    );
+}
+
+#[test]
+fn offer_table_bumps_the_generation_on_retire() {
+    let mut table = OfferTable::new();
+    let first = table.mint(OfferRecord::new(text_representations()));
+    table.retire(first);
+
+    // The freed slot is reused, so the new id shares the slot index but
+    // must carry a bumped generation.
+    let second = table.mint(OfferRecord::new(text_representations()));
+    assert_eq!(
+        first.index(),
+        second.index(),
+        "the slot is expected to be reused for this test to be meaningful"
+    );
+    assert!(
+        second.generation() > first.generation(),
+        "reused slot must mint under a bumped generation"
+    );
+    assert_ne!(first, second);
+
+    // Cross-generation lookup fails: the stale id addresses nothing even
+    // though its slot is occupied again.
+    assert!(table.get(first).is_none());
+    assert!(table.get(second).is_some());
+}
+
+#[test]
+fn stale_offer_request_fails_with_stale_offer() {
+    let source = MockSource::new();
+    let offer = source.mint_text_offer("hello");
+    source.retire(offer.id());
+
+    let request = source.request(
+        offer.id(),
+        RepresentationIndex(0),
+        TransferLimits::default(),
+    );
+    let mut request = pin!(request);
+    let Poll::Ready(Err(TransferError::StaleOffer(stale))) = poll_once(&mut request) else {
+        panic!("a retired offer must fail the generation check");
+    };
+    assert_eq!(stale, offer.id());
+}
+
+// ============================================================================
+// TransferRequest / TransferCompleter state machine
+// ============================================================================
+
+#[test]
+fn completer_resolves_the_request() {
+    let (request, completer) = TransferRequest::channel();
+    let mut request = pin!(request);
+    assert!(poll_once(&mut request).is_pending());
+
+    completer.complete(Ok(TransferPayload::Text("delivered".into())));
+
+    let Poll::Ready(Ok(TransferPayload::Text(text))) = poll_once(&mut request) else {
+        panic!("completed request must resolve with the payload");
+    };
+    assert_eq!(text, "delivered");
+}
+
+#[test]
+fn dropping_the_completer_resolves_source_gone() {
+    let (request, completer) = TransferRequest::channel();
+    let mut request = pin!(request);
+    assert!(poll_once(&mut request).is_pending());
+
+    drop(completer);
+
+    assert!(matches!(
+        poll_once(&mut request),
+        Poll::Ready(Err(TransferError::SourceGone))
+    ));
+}
+
+#[test]
+fn dropping_the_request_is_observable_as_cancellation() {
+    let (request, completer) = TransferRequest::channel();
+    assert!(!completer.is_cancelled());
+
+    drop(request);
+
+    assert!(
+        completer.is_cancelled(),
+        "the producer must observe consumer-side cancellation"
+    );
+    // Completing after cancellation is a silent no-op (must not panic).
+    completer.complete(Ok(TransferPayload::Text("too late".into())));
+}
+
+#[test]
+fn ready_request_resolves_immediately() {
+    let request = TransferRequest::ready(Ok(TransferPayload::UriList(vec![TransferUri::Path(
+        PathBuf::from("/tmp/ready.txt"),
+    )])));
+    let mut request = pin!(request);
+    let Poll::Ready(Ok(TransferPayload::UriList(uris))) = poll_once(&mut request) else {
+        panic!("ready request must resolve on the first poll");
+    };
+    assert_eq!(uris.len(), 1);
+}
+
+#[test]
+fn completion_wakes_the_stored_waker() {
+    // A real Waker (the AsyncDriver's) must fire on complete(); the noop
+    // waker above cannot show that, so drive one task through the driver.
+    let driver = AsyncDriver::new();
+    let frames = Arc::new(AtomicUsize::new(0));
+    let frames_for_hook = Arc::clone(&frames);
+    driver.set_request_frame(move || {
+        frames_for_hook.fetch_add(1, Ordering::Relaxed);
+    });
+
+    let (request, completer) = TransferRequest::channel();
+    let outcome: Arc<Mutex<Option<Result<TransferPayload, TransferError>>>> =
+        Arc::new(Mutex::new(None));
+    let outcome_for_task = Arc::clone(&outcome);
+    let _token = driver.spawn_local(Box::pin(async move {
+        *outcome_for_task.lock() = Some(request.await);
+    }));
+
+    assert_eq!(driver.poll_ready(), 1, "first poll parks the request");
+    assert!(outcome.lock().is_none());
+    let frames_before = frames.load(Ordering::Relaxed);
+
+    completer.complete(Ok(TransferPayload::Text("woken".into())));
+    assert!(
+        frames.load(Ordering::Relaxed) > frames_before,
+        "completion must wake the driver's frame-request hook"
+    );
+
+    assert_eq!(driver.poll_ready(), 1, "the wake re-arms exactly this task");
+    let delivered = outcome.lock().take().expect("task observed the payload");
+    assert!(matches!(delivered, Ok(TransferPayload::Text(text)) if text == "woken"));
+}
+
+// ============================================================================
+// Mock source: the seven stages over a real AsyncDriver
+// ============================================================================
+
+/// A `DataTransferSource` with the same shape a native backend has: one
+/// `OfferTable`, lazy delivery through parked completers, and a feedback
+/// cache — enough to drive every transport stage from a test.
+struct MockSource {
+    state: Mutex<MockState>,
+}
+
+struct MockState {
+    table: OfferTable,
+    /// Text payload per live offer, delivered when the test releases it.
+    payloads: Vec<(DataTransferId, String)>,
+    /// Deliveries parked until `deliver_all` (the "async backend" half).
+    parked: Vec<(DataTransferId, TransferCompleter, TransferLimits)>,
+    /// Latest stage-2 feedback per offer, as a backend would cache it.
+    feedback: Vec<(DataTransferId, DropFeedback)>,
+    /// Offers retired through stage-6 conclusion.
+    concluded: Vec<DataTransferId>,
+}
+
+impl MockSource {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(MockState {
+                table: OfferTable::new(),
+                payloads: Vec::new(),
+                parked: Vec::new(),
+                feedback: Vec::new(),
+                concluded: Vec::new(),
+            }),
+        }
+    }
+
+    /// Stage 1: announce an offer whose text payload the mock will deliver.
+    fn mint_text_offer(&self, text: &str) -> DataTransferOffer {
+        let representations = text_representations();
+        let mut state = self.state.lock();
+        let id = state
+            .table
+            .mint(OfferRecord::new(Arc::clone(&representations)));
+        state.payloads.push((id, text.to_string()));
+        DataTransferOffer::new(id, representations)
+    }
+
+    /// Producer half: resolve every parked delivery from "the backend".
+    fn deliver_all(&self) {
+        let (parked, payloads) = {
+            let mut state = self.state.lock();
+            let parked = std::mem::take(&mut state.parked);
+            (parked, state.payloads.clone())
+        };
+        // Completions run outside the lock, like a real backend thread.
+        for (id, completer, limits) in parked {
+            let payload = payloads
+                .iter()
+                .find(|(payload_id, _)| *payload_id == id)
+                .map(|(_, text)| TransferPayload::Text(text.clone()));
+            let result = match payload {
+                Some(payload) if payload.byte_len() > limits.max_bytes => {
+                    Err(TransferError::TooLarge {
+                        actual: payload.byte_len(),
+                        limit: limits.max_bytes,
+                    })
+                }
+                Some(payload) => Ok(payload),
+                None => Err(TransferError::SourceGone),
+            };
+            completer.complete(result);
+        }
+    }
+
+    fn retire(&self, id: DataTransferId) {
+        self.state.lock().table.retire(id);
+    }
+
+    fn cached_feedback(&self, id: DataTransferId) -> Option<DropFeedback> {
+        self.state
+            .lock()
+            .feedback
+            .iter()
+            .rev()
+            .find(|(feedback_id, _)| *feedback_id == id)
+            .map(|(_, feedback)| *feedback)
+    }
+
+    fn concluded(&self) -> Vec<DataTransferId> {
+        self.state.lock().concluded.clone()
+    }
+
+    fn parked_count(&self) -> usize {
+        self.state.lock().parked.len()
+    }
+
+    fn parked_completer_cancelled(&self, id: DataTransferId) -> Option<bool> {
+        self.state
+            .lock()
+            .parked
+            .iter()
+            .find(|(parked_id, _, _)| *parked_id == id)
+            .map(|(_, completer, _)| completer.is_cancelled())
+    }
+}
+
+impl DataTransferSource for MockSource {
+    fn clipboard_offer(&self) -> Option<DataTransferOffer> {
+        None
+    }
+
+    fn request(
+        &self,
+        id: DataTransferId,
+        representation: RepresentationIndex,
+        limits: TransferLimits,
+    ) -> TransferRequest {
+        let mut state = self.state.lock();
+        let Some(record) = state.table.get(id) else {
+            return TransferRequest::ready(Err(TransferError::StaleOffer(id)));
+        };
+        if usize::from(representation.0) >= record.representations().len() {
+            return TransferRequest::ready(Err(TransferError::UnknownRepresentation {
+                id,
+                index: representation,
+            }));
+        }
+        let (request, completer) = TransferRequest::channel();
+        state.parked.push((id, completer, limits));
+        request
+    }
+
+    fn update_drop_feedback(&self, id: DataTransferId, feedback: DropFeedback) {
+        let mut state = self.state.lock();
+        if state.table.get(id).is_none() {
+            return; // stale ids are a no-op per the trait contract
+        }
+        state.feedback.push((id, feedback));
+    }
+
+    fn conclude_drop(&self, id: DataTransferId) {
+        let mut state = self.state.lock();
+        if state.table.retire(id).is_some() {
+            state.concluded.push(id);
+        }
+    }
+}
+
+/// All seven stages, end to end, with delivery polled by a real
+/// `AsyncDriver` — the exact contour a widget-facing consumer will use.
+#[test]
+fn mock_source_drives_all_seven_stages_through_the_async_driver() {
+    let source = Arc::new(MockSource::new());
+    let driver = AsyncDriver::new();
+    let frames = Arc::new(AtomicUsize::new(0));
+    let frames_for_hook = Arc::clone(&frames);
+    driver.set_request_frame(move || {
+        frames_for_hook.fetch_add(1, Ordering::Relaxed);
+    });
+
+    // Stage 1 — offer: metadata only, no payload.
+    let offer = source.mint_text_offer("pasted text");
+    assert_eq!(offer.representations().len(), 1);
+
+    // Stage 2 — negotiation: the consumer picks a representation and (drag
+    // facade) replies with feedback the source caches.
+    let index = offer
+        .find(&TransferFormat::Text)
+        .expect("the announced Text representation is findable");
+    source.update_drop_feedback(
+        offer.id(),
+        DropFeedback {
+            accept: Some(TransferActions::COPY),
+        },
+    );
+    assert_eq!(
+        source.cached_feedback(offer.id()),
+        Some(DropFeedback {
+            accept: Some(TransferActions::COPY),
+        })
+    );
+
+    // Stage 3 — request: returns immediately with a pollable value.
+    let request = source.request(offer.id(), index, TransferLimits::default());
+
+    // Stage 4 — async delivery: the request rides a BoxedTask on the house
+    // driver; nothing resolves until the producer completes.
+    let outcome: Arc<Mutex<Option<Result<TransferPayload, TransferError>>>> =
+        Arc::new(Mutex::new(None));
+    let outcome_for_task = Arc::clone(&outcome);
+    let token = driver.spawn_local(Box::pin(async move {
+        *outcome_for_task.lock() = Some(request.await);
+    }));
+    assert_eq!(driver.poll_ready(), 1);
+    assert!(outcome.lock().is_none(), "no delivery before the producer");
+
+    source.deliver_all();
+    assert_eq!(driver.poll_ready(), 1, "completion woke the task");
+
+    // Stage 5 — decoding: the payload arrives typed.
+    let delivered = outcome.lock().take().expect("delivery observed");
+    let Ok(TransferPayload::Text(text)) = delivered else {
+        panic!("expected the typed Text payload, got {delivered:?}");
+    };
+    assert_eq!(text, "pasted text");
+
+    // Stage 6 — drop action/conclusion: the consumer is done; the source
+    // releases the offer.
+    source.conclude_drop(offer.id());
+    assert_eq!(source.concluded(), vec![offer.id()]);
+
+    // Stage 7 — completion: the offer is now stale for everyone.
+    let stale = source.request(offer.id(), index, TransferLimits::default());
+    let mut stale = pin!(stale);
+    assert!(matches!(
+        poll_once(&mut stale),
+        Poll::Ready(Err(TransferError::StaleOffer(_)))
+    ));
+    drop(token);
+}
+
+/// Stage-7 cancellation composes through the driver: dropping the
+/// `TaskToken` drops the task's future, which drops the `TransferRequest`,
+/// which the producer observes via `TransferCompleter::is_cancelled`.
+#[test]
+fn dropping_the_task_token_cancels_the_in_flight_delivery() {
+    let source = Arc::new(MockSource::new());
+    let driver = AsyncDriver::new();
+
+    let offer = source.mint_text_offer("never delivered");
+    let request = source.request(
+        offer.id(),
+        RepresentationIndex(0),
+        TransferLimits::default(),
+    );
+
+    let outcome: Arc<Mutex<Option<Result<TransferPayload, TransferError>>>> =
+        Arc::new(Mutex::new(None));
+    let outcome_for_task = Arc::clone(&outcome);
+    let token = driver.spawn_local(Box::pin(async move {
+        *outcome_for_task.lock() = Some(request.await);
+    }));
+    assert_eq!(driver.poll_ready(), 1);
+    assert_eq!(
+        source.parked_completer_cancelled(offer.id()),
+        Some(false),
+        "delivery is live while the token is held"
+    );
+
+    drop(token);
+
+    assert_eq!(
+        source.parked_completer_cancelled(offer.id()),
+        Some(true),
+        "TaskToken drop → future drop → TransferRequest drop → cancelled"
+    );
+
+    // Producer-side completion after cancellation is a silent no-op.
+    source.deliver_all();
+    assert_eq!(source.parked_count(), 0);
+    assert!(
+        outcome.lock().is_none(),
+        "nothing is delivered after cancel"
+    );
+    assert_eq!(
+        driver.poll_ready(),
+        0,
+        "the cancelled task never runs again"
+    );
+}
+
+/// Byte limits are enforced at delivery against actual accumulated size.
+#[test]
+fn limits_are_enforced_at_delivery() {
+    let source = Arc::new(MockSource::new());
+    let offer = source.mint_text_offer("this payload is longer than four bytes");
+
+    let request = source.request(
+        offer.id(),
+        RepresentationIndex(0),
+        TransferLimits::default().with_max_bytes(4),
+    );
+    let mut request = pin!(request);
+    assert!(poll_once(&mut request).is_pending());
+
+    source.deliver_all();
+
+    assert!(matches!(
+        poll_once(&mut request),
+        Poll::Ready(Err(TransferError::TooLarge { limit: 4, .. }))
+    ));
+}

--- a/crates/flui-foundation/src/id.rs
+++ b/crates/flui-foundation/src/id.rs
@@ -738,6 +738,19 @@ ids! {
         /// platform-internal native handle key — the two are not
         /// interchangeable and neither converts implicitly to the other.
         pub type RealmId Realm;
+
+        /// Data-transfer ID - **generational** key identifying one live
+        /// transfer offer: a clipboard snapshot or an in-progress system
+        /// drag session (ADR-0038).
+        ///
+        /// Generational ([`GenId`]): offers are short-lived and their slots
+        /// are reused; a stale id held by a widget across a drag-cancel or a
+        /// clipboard change must fail the generation check instead of
+        /// silently addressing the next offer (ABA). Minted exclusively by
+        /// the one offer table inside a platform's single
+        /// `DataTransferSource` instance, so every observable id is
+        /// redeemable at the place it was minted.
+        pub type DataTransferId DataTransfer;
     }
 }
 
@@ -1444,6 +1457,27 @@ mod tests {
     #[should_panic(expected = "GenId::new requires n >= 1")]
     fn gen_id_new_zero_panics() {
         let _ = RenderId::new(0);
+    }
+
+    /// `DataTransferId` is a full `GenId` domain: pack/unpack round-trip,
+    /// ABA distinctness across generations, and the niche optimisation.
+    #[test]
+    fn data_transfer_id_is_generational_with_niche() {
+        let generation = NonZeroU32::new(3).unwrap();
+        let id = DataTransferId::new_gen(9, generation);
+        assert_eq!(id.index(), 9);
+        assert_eq!(id.generation(), generation);
+
+        let stale = DataTransferId::new_gen(9, NonZeroU32::new(2).unwrap());
+        assert_ne!(
+            stale, id,
+            "a stale DataTransferId must never compare equal to the slot's live id"
+        );
+
+        assert_eq!(
+            size_of::<DataTransferId>(),
+            size_of::<Option<DataTransferId>>()
+        );
     }
 
     /// `GenId` satisfies `TreeId` without `Identifier` (no `.get()`;

--- a/crates/flui-foundation/src/lib.rs
+++ b/crates/flui-foundation/src/lib.rs
@@ -205,6 +205,8 @@ pub use debug::{
     DiagnosticsProperty, DiagnosticsPropertyKind, DiagnosticsTreeStyle,
 };
 pub use id::{
+    // Data-transfer offer identity (ADR-0038)
+    DataTransferId,
     // Core tree IDs (5-tree architecture)
     ElementId,
     // Scheduler IDs (consumed by flui-scheduler)

--- a/crates/flui-platform/Cargo.toml
+++ b/crates/flui-platform/Cargo.toml
@@ -15,9 +15,10 @@ autotests = false
 
 [dependencies]
 flui-types = { path = "../flui-types", version = "0.2.0" }
-# OwnerAffinity: the ADR-0039 slice-1 owner-thread backstop. Layer-legal
-# (foundation sits below platform in the DAG) and deliberately hosted there
-# so its tests run in CI, which flui-platform's own suite does not.
+# Layer-legal downward edge (foundation sits below platform in the DAG),
+# carrying two seams: OwnerAffinity — the ADR-0039 owner-thread backstop,
+# hosted in foundation so its tests run in CI (flui-platform's suite does
+# not) — and the generational DataTransferId for the ADR-0038 transport.
 flui-foundation = { path = "../flui-foundation", version = "0.2.0" }
 
 # UI Events - W3C compliant event types

--- a/crates/flui-platform/src/data_transfer.rs
+++ b/crates/flui-platform/src/data_transfer.rs
@@ -1,0 +1,772 @@
+//! Data-transfer transport vocabulary (ADR-0038).
+//!
+//! Clipboard reads and system drag-and-drop share one seven-stage transport:
+//! offer → negotiation → request → async delivery → decoding → drop action →
+//! completion/cancellation. This module defines the stage artifacts:
+//!
+//! - [`DataTransferOffer`] — stage 1, metadata only, never bytes;
+//! - [`RepresentationDescriptor`] / [`TransferFormat`] / [`Mime`] — stage 2
+//!   negotiation vocabulary, plus [`DropFeedback`], the DnD reply half;
+//! - [`TransferLimits`] — stage-3 resource bounds;
+//! - [`TransferRequest`] / [`TransferCompleter`] — stage 4, a hand-rolled
+//!   oneshot future/completer pair polled on the frame-driven `AsyncDriver`
+//!   (no second async mechanism, no runtime dependency);
+//! - [`TransferPayload`] / [`TransferError`] — stage 5 outcomes;
+//! - [`DataTransferSource`] — the platform-side trait tying the stages
+//!   together, with [`NullDataTransferSource`] as the honest inert
+//!   implementation for backends that have no transport yet.
+//!
+//! [`OfferTable`] is the single minting authority for [`DataTransferId`]s:
+//! each platform instance owns exactly one table inside its one
+//! [`DataTransferSource`], so every id the app can observe is redeemable at
+//! `Platform::data_transfer()` and stale ids fail the generation check
+//! instead of aliasing a later offer.
+
+use std::num::NonZeroU32;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::task::Waker;
+
+use flui_foundation::DataTransferId;
+use parking_lot::Mutex;
+
+// ============================================================================
+// MIME + formats
+// ============================================================================
+
+/// A MIME type. Construction normalizes the type/subtype and parameter
+/// *attribute names* to ASCII-lowercase; parameter *values* are preserved
+/// byte-for-byte (RFC 2045 — e.g. `boundary` values are case-sensitive).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Mime(Arc<str>);
+
+impl Mime {
+    /// Normalize `s` into a canonical MIME string.
+    ///
+    /// `type/subtype` and every parameter attribute name are lowercased and
+    /// trimmed of surrounding whitespace; everything after a parameter's `=`
+    /// is kept exactly as written.
+    #[must_use]
+    pub fn new(s: &str) -> Self {
+        let mut out = String::with_capacity(s.len());
+        let mut parts = s.split(';');
+        if let Some(essence) = parts.next() {
+            out.push_str(&essence.trim().to_ascii_lowercase());
+        }
+        for parameter in parts {
+            out.push(';');
+            match parameter.split_once('=') {
+                Some((attribute, value)) => {
+                    out.push_str(&attribute.trim().to_ascii_lowercase());
+                    out.push('=');
+                    out.push_str(value);
+                }
+                None => out.push_str(&parameter.trim().to_ascii_lowercase()),
+            }
+        }
+        Self(Arc::from(out))
+    }
+
+    /// The normalized MIME string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for Mime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The typed format of one representation a source offers.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TransferFormat {
+    /// Plain UTF-8 text (`text/plain`).
+    Text,
+    /// HTML markup (`text/html`). Delivered raw; sanitization is the
+    /// consumer's duty.
+    Html,
+    /// URIs / file paths (`text/uri-list`).
+    UriList,
+    /// An encoded image in the container named by `mime` (e.g. `image/png`).
+    Image {
+        /// Container format of the encoded bytes.
+        mime: Mime,
+    },
+    /// Any other MIME type, delivered as raw bytes.
+    Custom {
+        /// The exact MIME type the source declared.
+        mime: Mime,
+    },
+}
+
+/// Stage-1/2 descriptor of one representation: format + size hint, no
+/// payload.
+#[derive(Debug, Clone)]
+pub struct RepresentationDescriptor {
+    /// Typed format of this representation.
+    pub format: TransferFormat,
+    /// Size in bytes if the source declared it; `None` = unknown until
+    /// delivery.
+    pub declared_len: Option<u64>,
+}
+
+/// Index of a representation within one offer, assigned by the source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RepresentationIndex(pub u16);
+
+// ============================================================================
+// Actions + feedback
+// ============================================================================
+
+/// Drop effects a DnD source permits / a target accepts. Plain `u8` bitset —
+/// no external bitflags dependency.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TransferActions(u8);
+
+impl TransferActions {
+    /// No action — a target replying with this refuses the drop.
+    pub const NONE: Self = Self(0);
+    /// Copy the data; the source keeps its copy.
+    pub const COPY: Self = Self(1 << 0);
+    /// Move the data; the source is expected to remove its copy.
+    pub const MOVE: Self = Self(1 << 1);
+    /// Link to the data rather than transferring it.
+    pub const LINK: Self = Self(1 << 2);
+
+    /// Whether every action in `other` is present in `self`.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    /// The set union of the two action sets.
+    #[must_use]
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    /// Whether the set is empty (no permitted/accepted action).
+    #[must_use]
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl std::ops::BitOr for TransferActions {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self {
+        self.union(rhs)
+    }
+}
+
+impl std::ops::BitOrAssign for TransferActions {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = self.union(rhs);
+    }
+}
+
+/// Stage-2 reply half (DnD): the target's current answer to "what would you
+/// do if the user dropped now". Sent via
+/// [`DataTransferSource::update_drop_feedback`]; the backend caches the
+/// latest value per session and answers the OS's synchronous hover queries
+/// from that cache. `accept: None` (the default) means reject.
+///
+/// `accept` should name a single action; the backend intersects it with the
+/// source's permitted set and maps it to the protocol's single effect value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct DropFeedback {
+    /// The action the target would take on a drop right now, or `None` to
+    /// reject.
+    pub accept: Option<TransferActions>,
+}
+
+// ============================================================================
+// Offer
+// ============================================================================
+
+/// Stage-1 artifact: what a source announces. Metadata only. Cheap to clone
+/// (`Arc`-backed), immutable after mint.
+#[derive(Debug, Clone)]
+pub struct DataTransferOffer {
+    id: DataTransferId,
+    representations: Arc<[RepresentationDescriptor]>,
+}
+
+impl DataTransferOffer {
+    /// Assemble an offer from its minted id and announced representations.
+    ///
+    /// Backends call this right after [`OfferTable::mint`]; the offer shares
+    /// the record's representation slice, so the two can never disagree.
+    #[must_use]
+    pub fn new(id: DataTransferId, representations: Arc<[RepresentationDescriptor]>) -> Self {
+        Self {
+            id,
+            representations,
+        }
+    }
+
+    /// The generational id redeemable at the minting source.
+    #[must_use]
+    pub fn id(&self) -> DataTransferId {
+        self.id
+    }
+
+    /// Representations in the source's declared order, which every platform
+    /// convention (X11 TARGETS, Wayland offer order, NSPasteboard types)
+    /// treats as the source's preference ranking — index 0 is what the
+    /// source considers its best fidelity.
+    #[must_use]
+    pub fn representations(&self) -> &[RepresentationDescriptor] {
+        &self.representations
+    }
+
+    /// First representation matching `format` in source-preference order.
+    /// A consumer with its own cross-format ranking (e.g. prefer any `Image`
+    /// over `Html`) iterates [`Self::representations`] itself.
+    #[must_use]
+    pub fn find(&self, format: &TransferFormat) -> Option<RepresentationIndex> {
+        self.representations
+            .iter()
+            .position(|descriptor| descriptor.format == *format)
+            .map(|index| {
+                RepresentationIndex(
+                    u16::try_from(index)
+                        .expect("BUG: offer holds more than u16::MAX representations"),
+                )
+            })
+    }
+}
+
+// ============================================================================
+// Payload
+// ============================================================================
+
+/// One entry of a `text/uri-list` payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransferUri {
+    /// A local filesystem path (`file://` URIs and platform-native drops).
+    Path(PathBuf),
+    /// Any other scheme, unparsed.
+    Uri(String),
+}
+
+/// An encoded image payload. The transport hands over *encoded* bytes; pixel
+/// decoding belongs to the consumer (flui-assets' decoders), not the
+/// transport.
+///
+/// Declared as part of the frozen vocabulary, but **no backend delivers it
+/// yet**: image representations arrive with the native transports (ADR-0038
+/// §5 protocol mapping). Until then no source ever announces
+/// [`TransferFormat::Image`], so a request for one cannot arise — there is
+/// deliberately no stub that fabricates success.
+#[derive(Debug, Clone)]
+pub struct TransferImage {
+    /// Container format of `bytes` (e.g. `image/png`).
+    pub mime: Mime,
+    /// The encoded image bytes, exactly as the source provided them.
+    pub bytes: Arc<[u8]>,
+}
+
+/// Stage-5 artifact: a decoded, typed payload.
+#[derive(Debug, Clone)]
+pub enum TransferPayload {
+    /// Plain UTF-8 text.
+    Text(String),
+    /// Raw HTML markup (unsanitized — the consumer's duty).
+    Html(String),
+    /// Entries of a `text/uri-list` representation.
+    UriList(Vec<TransferUri>),
+    /// An encoded image (see [`TransferImage`] for delivery status).
+    Image(TransferImage),
+    /// Raw bytes of any other MIME type.
+    Custom {
+        /// The exact MIME type the source declared.
+        mime: Mime,
+        /// The undecoded payload bytes.
+        bytes: Arc<[u8]>,
+    },
+}
+
+impl TransferPayload {
+    /// Actual in-memory payload size in bytes, for limit enforcement against
+    /// already-materialized data ([`TransferLimits::max_bytes`]).
+    #[must_use]
+    pub fn byte_len(&self) -> u64 {
+        match self {
+            Self::Text(text) | Self::Html(text) => text.len() as u64,
+            Self::UriList(uris) => uris
+                .iter()
+                .map(|uri| match uri {
+                    TransferUri::Path(path) => path.as_os_str().len() as u64,
+                    TransferUri::Uri(uri) => uri.len() as u64,
+                })
+                .sum(),
+            Self::Image(image) => image.bytes.len() as u64,
+            Self::Custom { bytes, .. } => bytes.len() as u64,
+        }
+    }
+}
+
+// ============================================================================
+// Limits + errors
+// ============================================================================
+
+/// Stage-3 resource bounds, enforced by the transport before and during
+/// delivery. `#[non_exhaustive]`: deferred timeout work may add a field;
+/// construct via `Default` + `with_*`.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct TransferLimits {
+    /// Deliveries larger than this fail with [`TransferError::TooLarge`].
+    /// Checked against [`RepresentationDescriptor::declared_len`] at request
+    /// time when known, and against actual accumulated bytes during delivery
+    /// regardless.
+    pub max_bytes: u64,
+}
+
+impl TransferLimits {
+    /// Replace the byte ceiling.
+    #[must_use]
+    pub fn with_max_bytes(mut self, max_bytes: u64) -> Self {
+        self.max_bytes = max_bytes;
+        self
+    }
+}
+
+impl Default for TransferLimits {
+    /// 16 MiB — generous for text/uri-list, deliberately small for images;
+    /// consumers expecting large payloads must opt in explicitly.
+    fn default() -> Self {
+        Self {
+            max_bytes: 16 * 1024 * 1024,
+        }
+    }
+}
+
+/// Transport-stage failure. `#[non_exhaustive]`: deferred timeout/streaming
+/// work implies new variants.
+#[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
+pub enum TransferError {
+    /// The offer id does not name a live offer (superseded, completed, or
+    /// cancelled).
+    #[error("offer {0} is stale (superseded, completed, or cancelled)")]
+    StaleOffer(DataTransferId),
+    /// The representation index is out of range for the offer.
+    #[error("representation {index:?} out of range for offer {id}")]
+    UnknownRepresentation {
+        /// The offer that was addressed.
+        id: DataTransferId,
+        /// The out-of-range representation index.
+        index: RepresentationIndex,
+    },
+    /// The payload exceeds the requested [`TransferLimits::max_bytes`].
+    #[error("payload exceeds limit: {actual} > {limit} bytes")]
+    TooLarge {
+        /// Declared or accumulated payload size in bytes.
+        actual: u64,
+        /// The limit the request set.
+        limit: u64,
+    },
+    /// The payload bytes failed to decode as the announced format.
+    #[error("payload failed to decode as {format:?}")]
+    Decode {
+        /// The format the representation announced.
+        format: TransferFormat,
+    },
+    /// The producing side vanished mid-transfer (window closed, client
+    /// exited, completer dropped without completing).
+    #[error("source vanished mid-transfer (window closed, client exited)")]
+    SourceGone,
+    /// The transfer was cancelled by the consumer.
+    #[error("transfer cancelled")]
+    Cancelled,
+}
+
+// ============================================================================
+// OfferTable — the single minting authority
+// ============================================================================
+
+/// Source-side state for one live offer: the announced representations plus
+/// the payload once (and if) the source has it in memory.
+#[derive(Debug, Clone)]
+pub struct OfferRecord {
+    representations: Arc<[RepresentationDescriptor]>,
+    payload: Option<TransferPayload>,
+}
+
+impl OfferRecord {
+    /// A record announcing `representations`, with no payload yet.
+    #[must_use]
+    pub fn new(representations: Arc<[RepresentationDescriptor]>) -> Self {
+        Self {
+            representations,
+            payload: None,
+        }
+    }
+
+    /// The announced representations, in source-preference order.
+    #[must_use]
+    pub fn representations(&self) -> &Arc<[RepresentationDescriptor]> {
+        &self.representations
+    }
+
+    /// The in-memory payload, if the source has materialized one.
+    #[must_use]
+    pub fn payload(&self) -> Option<&TransferPayload> {
+        self.payload.as_ref()
+    }
+
+    /// Store the materialized payload (e.g. a frozen file-drop list).
+    pub fn set_payload(&mut self, payload: TransferPayload) {
+        self.payload = Some(payload);
+    }
+}
+
+/// One slot of the offer slab. The generation survives the record: retiring
+/// bumps it, so the next occupant of the slot mints a different id.
+#[derive(Debug)]
+struct OfferSlot {
+    generation: NonZeroU32,
+    record: Option<OfferRecord>,
+}
+
+/// Slab of live offers with generation-checked lookup. One per platform
+/// instance, private inside its [`DataTransferSource`]. Not a public-API
+/// lock: backends hold it behind their existing state lock (SP-6 — no guard
+/// escapes a public signature).
+///
+/// This is the **single minting authority** for [`DataTransferId`]s
+/// (ADR-0038 §2): a generational check is only a defense within one table,
+/// so a platform instance must never operate two of these.
+#[derive(Debug, Default)]
+pub struct OfferTable {
+    slots: Vec<OfferSlot>,
+    free: Vec<u32>,
+}
+
+impl OfferTable {
+    /// An empty table.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mint a live offer, returning its generational id
+    /// (`new_gen(slot, generation)`).
+    pub fn mint(&mut self, record: OfferRecord) -> DataTransferId {
+        if let Some(index) = self.free.pop() {
+            let slot = &mut self.slots[index as usize];
+            debug_assert!(slot.record.is_none(), "free list held an occupied slot");
+            slot.record = Some(record);
+            return DataTransferId::new_gen(index, slot.generation);
+        }
+
+        let index =
+            u32::try_from(self.slots.len()).expect("BUG: offer table exceeds u32::MAX slots");
+        let generation = NonZeroU32::MIN;
+        self.slots.push(OfferSlot {
+            generation,
+            record: Some(record),
+        });
+        DataTransferId::new_gen(index, generation)
+    }
+
+    /// Generation-checked lookup: slot **and** generation must match, so a
+    /// retired id never addresses the slot's next occupant.
+    #[must_use]
+    pub fn get(&self, id: DataTransferId) -> Option<&OfferRecord> {
+        self.slot(id).and_then(|slot| slot.record.as_ref())
+    }
+
+    /// Generation-checked mutable lookup (same rules as [`Self::get`]).
+    pub fn get_mut(&mut self, id: DataTransferId) -> Option<&mut OfferRecord> {
+        let slot_index = id.index() as usize;
+        let slot = self.slots.get_mut(slot_index)?;
+        if slot.generation != id.generation() {
+            return None;
+        }
+        slot.record.as_mut()
+    }
+
+    /// Retire a live offer: free the slot and bump its generation so the id
+    /// is permanently stale. Returns the record, or `None` if `id` was
+    /// already stale (idempotent).
+    ///
+    /// A slot whose generation would overflow is never reused — it is
+    /// dropped from circulation rather than allowed to recycle generation 1.
+    pub fn retire(&mut self, id: DataTransferId) -> Option<OfferRecord> {
+        let slot_index = id.index() as usize;
+        let slot = self.slots.get_mut(slot_index)?;
+        if slot.generation != id.generation() || slot.record.is_none() {
+            return None;
+        }
+        let record = slot.record.take();
+        if let Some(next) = slot.generation.checked_add(1) {
+            slot.generation = next;
+            self.free.push(id.index());
+        }
+        // else: generation space exhausted for this slot — leave it out of
+        // the free list forever rather than risk ABA reuse.
+        record
+    }
+
+    /// Number of live offers.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.slots
+            .iter()
+            .filter(|slot| slot.record.is_some())
+            .count()
+    }
+
+    /// Whether the table holds no live offer.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn slot(&self, id: DataTransferId) -> Option<&OfferSlot> {
+        let slot = self.slots.get(id.index() as usize)?;
+        (slot.generation == id.generation()).then_some(slot)
+    }
+}
+
+// ============================================================================
+// TransferRequest / TransferCompleter — the stage-4 oneshot pair
+// ============================================================================
+
+/// Shared oneshot state between a [`TransferRequest`] and its
+/// [`TransferCompleter`]. Private; no guard ever escapes (SP-6).
+#[derive(Debug)]
+struct TransferShared {
+    slot: Mutex<TransferSlot>,
+}
+
+#[derive(Debug)]
+struct TransferSlot {
+    /// The delivery outcome, present between completion and the consumer
+    /// taking it in `poll`.
+    outcome: Option<Result<TransferPayload, TransferError>>,
+    /// Waker of the last poll, woken on completion.
+    waker: Option<Waker>,
+    /// Consumer dropped its half (stage-7 cancellation).
+    cancelled: bool,
+    /// Producer finished — `complete` ran or the completer was dropped.
+    settled: bool,
+    /// The consumer already took the outcome out of the slot.
+    delivered: bool,
+}
+
+/// Stage-4 artifact, consumer half: one in-flight delivery. A `Send` future
+/// so it can ride `BoxedTask` (`Pin<Box<dyn Future<Output = ()> + Send>>`,
+/// flui-scheduler's `AsyncDriver` contour) after being wrapped by the
+/// consumer. Dropping it before completion is stage-7 cancellation: the
+/// shared state is marked cancelled, which the producer observes via
+/// [`TransferCompleter::is_cancelled`].
+#[must_use = "dropping a TransferRequest cancels the delivery"]
+#[derive(Debug)]
+pub struct TransferRequest {
+    shared: Arc<TransferShared>,
+}
+
+impl TransferRequest {
+    /// A connected pair: the backend keeps the completer and returns the
+    /// request from [`DataTransferSource::request`].
+    #[must_use = "dropping the pair immediately resolves it as cancelled"]
+    pub fn channel() -> (TransferRequest, TransferCompleter) {
+        let shared = Arc::new(TransferShared {
+            slot: Mutex::new(TransferSlot {
+                outcome: None,
+                waker: None,
+                cancelled: false,
+                settled: false,
+                delivered: false,
+            }),
+        });
+        (
+            TransferRequest {
+                shared: Arc::clone(&shared),
+            },
+            TransferCompleter { shared },
+        )
+    }
+
+    /// An already-resolved request, for data that is genuinely in memory.
+    pub fn ready(result: Result<TransferPayload, TransferError>) -> Self {
+        Self {
+            shared: Arc::new(TransferShared {
+                slot: Mutex::new(TransferSlot {
+                    outcome: Some(result),
+                    waker: None,
+                    cancelled: false,
+                    settled: true,
+                    delivered: false,
+                }),
+            }),
+        }
+    }
+}
+
+impl std::future::Future for TransferRequest {
+    type Output = Result<TransferPayload, TransferError>;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let mut slot = self.shared.slot.lock();
+        if let Some(outcome) = slot.outcome.take() {
+            slot.delivered = true;
+            slot.waker = None;
+            return std::task::Poll::Ready(outcome);
+        }
+        assert!(
+            !slot.delivered,
+            "BUG: TransferRequest polled again after it resolved"
+        );
+        slot.waker = Some(cx.waker().clone());
+        std::task::Poll::Pending
+    }
+}
+
+impl Drop for TransferRequest {
+    fn drop(&mut self) {
+        let mut slot = self.shared.slot.lock();
+        slot.cancelled = true;
+        // Free the payload and waker eagerly; the producer only reads flags.
+        slot.outcome = None;
+        slot.waker = None;
+    }
+}
+
+/// Stage-4 artifact, producer half, held by the backend. `Send` — complete
+/// from any thread. Completing after the consumer dropped the request is a
+/// silent no-op; dropping the completer without completing resolves the
+/// request with [`TransferError::SourceGone`], so a crashed producer can
+/// never leave a consumer pending forever.
+#[derive(Debug)]
+pub struct TransferCompleter {
+    shared: Arc<TransferShared>,
+}
+
+impl TransferCompleter {
+    /// Resolve the paired request. A no-op if the consumer already cancelled
+    /// (dropped its half).
+    pub fn complete(self, result: Result<TransferPayload, TransferError>) {
+        let waker = {
+            let mut slot = self.shared.slot.lock();
+            slot.settled = true;
+            if slot.cancelled {
+                None
+            } else {
+                slot.outcome = Some(result);
+                slot.waker.take()
+            }
+        };
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+    }
+
+    /// True once the consumer cancelled (dropped its half). A long-running
+    /// producer polls this to abandon work early. Note: a blocking read
+    /// already in progress (arboard) is *not* interruptible — cancellation
+    /// then means the result is discarded, not that the thread unblocks.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.shared.slot.lock().cancelled
+    }
+}
+
+impl Drop for TransferCompleter {
+    fn drop(&mut self) {
+        let waker = {
+            let mut slot = self.shared.slot.lock();
+            if slot.settled {
+                None
+            } else {
+                slot.settled = true;
+                if slot.cancelled {
+                    None
+                } else {
+                    slot.outcome = Some(Err(TransferError::SourceGone));
+                    slot.waker.take()
+                }
+            }
+        };
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+    }
+}
+
+// ============================================================================
+// DataTransferSource
+// ============================================================================
+
+/// The platform-side transport: stages 1, 2 (reply half), 3, 6 in one
+/// object-safe trait. Exactly one instance per platform instance (ADR-0038
+/// §2, §6). No method blocks; no method is `async fn` — the sync-pipeline
+/// rule is honored by returning a pollable value instead.
+pub trait DataTransferSource: Send + Sync {
+    /// Stage 1, clipboard flavor: advertise the current clipboard offer.
+    /// Stable id per observed clipboard state (ADR-0038 §2 lifecycle). DnD
+    /// offers arrive by event (`DragDropEvent::Entered`) instead — pushed by
+    /// the OS, not polled.
+    fn clipboard_offer(&self) -> Option<DataTransferOffer>;
+
+    /// Stage 3: request one representation of a live offer. Returns
+    /// immediately; delivery completes through the returned future. A
+    /// backend whose data is already in memory returns
+    /// [`TransferRequest::ready`].
+    fn request(
+        &self,
+        id: DataTransferId,
+        representation: RepresentationIndex,
+        limits: TransferLimits,
+    ) -> TransferRequest;
+
+    /// Stage 2, reply half (DnD only): the target's current hover answer.
+    /// The backend caches the latest value per session and answers the OS's
+    /// synchronous hover queries from the cache. Stale ids are a no-op.
+    fn update_drop_feedback(&self, id: DataTransferId, feedback: DropFeedback);
+
+    /// Stage 6 (DnD only): the target has fetched what it needs; release
+    /// protocol resources (Wayland `wl_data_offer.finish`, Win32 IDataObject
+    /// release) and retire the offer. Idempotent; stale ids are a no-op.
+    fn conclude_drop(&self, id: DataTransferId);
+}
+
+/// The inert source: [`clipboard_offer`](DataTransferSource::clipboard_offer)
+/// → `None`; [`request`](DataTransferSource::request) →
+/// `TransferRequest::ready(Err(TransferError::StaleOffer(id)))`; feedback and
+/// conclusion are no-ops. For backends with no transport yet — honest
+/// absence, not fake success.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NullDataTransferSource;
+
+impl DataTransferSource for NullDataTransferSource {
+    fn clipboard_offer(&self) -> Option<DataTransferOffer> {
+        None
+    }
+
+    fn request(
+        &self,
+        id: DataTransferId,
+        _representation: RepresentationIndex,
+        _limits: TransferLimits,
+    ) -> TransferRequest {
+        // This source mints no offers, so every id presented to it is by
+        // definition not one of ours — stale, honestly.
+        TransferRequest::ready(Err(TransferError::StaleOffer(id)))
+    }
+
+    fn update_drop_feedback(&self, _id: DataTransferId, _feedback: DropFeedback) {}
+
+    fn conclude_drop(&self, _id: DataTransferId) {}
+}

--- a/crates/flui-platform/src/lib.rs
+++ b/crates/flui-platform/src/lib.rs
@@ -154,6 +154,7 @@
 #![deny(missing_docs)]
 
 pub mod config;
+pub mod data_transfer;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod executor;
 pub mod platforms;
@@ -166,6 +167,9 @@ pub mod window; // PORT-CHECK-OK-SP4: window API surface; binding entry for plat
 // ==================== Platform Detection ====================
 
 pub use config::{FullscreenMonitor, WindowConfiguration};
+// Data-transfer transport (ADR-0038): one source per platform instance,
+// reachable via `Platform::data_transfer()`.
+pub use data_transfer::{DataTransferOffer, DataTransferSource, NullDataTransferSource};
 // One cursor vocabulary is shared by widgets, interaction, and platforms.
 pub use cursor_icon::CursorIcon;
 // Re-export executor types

--- a/crates/flui-platform/src/platforms/android/mod.rs
+++ b/crates/flui-platform/src/platforms/android/mod.rs
@@ -44,7 +44,11 @@ pub use memory::{
 use parking_lot::Mutex;
 pub use window::AndroidWindow;
 
-use crate::{shared::PlatformHandlers, traits::*};
+use crate::{
+    data_transfer::{DataTransferSource, NullDataTransferSource},
+    shared::PlatformHandlers,
+    traits::*,
+};
 
 /// Android platform implementation using `android-activity`
 ///
@@ -320,6 +324,11 @@ impl Platform for AndroidPlatform {
 
     fn clipboard(&self) -> Arc<dyn Clipboard> {
         self.clipboard.clone()
+    }
+
+    fn data_transfer(&self) -> Arc<dyn DataTransferSource> {
+        // No Android transport yet (ADR-0038): inert and honest.
+        Arc::new(NullDataTransferSource)
     }
 
     fn capabilities(&self) -> &dyn PlatformCapabilities {

--- a/crates/flui-platform/src/platforms/headless/platform.rs
+++ b/crates/flui-platform/src/platforms/headless/platform.rs
@@ -14,6 +14,7 @@ use flui_types::{
 use parking_lot::Mutex;
 
 use crate::{
+    data_transfer::{DataTransferSource, NullDataTransferSource},
     shared::{PlatformHandlers, WindowCallbacks},
     traits::{
         Clipboard, ClipboardItem, CursorError, DesktopCapabilities, DispatchEventResult, Platform,
@@ -154,6 +155,12 @@ impl Platform for HeadlessPlatform {
 
     fn clipboard(&self) -> Arc<dyn Clipboard> {
         self.with_state(|state| state.clipboard.clone())
+    }
+
+    fn data_transfer(&self) -> Arc<dyn DataTransferSource> {
+        // Headless gets a real test source with the clipboard transport
+        // (ADR-0038); until then it is inert and honest.
+        Arc::new(NullDataTransferSource)
     }
 
     fn capabilities(&self) -> &dyn PlatformCapabilities {

--- a/crates/flui-platform/src/platforms/ios/mod.rs
+++ b/crates/flui-platform/src/platforms/ios/mod.rs
@@ -123,6 +123,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 
+use crate::data_transfer::{DataTransferSource, NullDataTransferSource};
 use crate::traits::*;
 
 /// iOS platform implementation (stub)
@@ -202,6 +203,11 @@ impl Platform for IOSPlatform {
 
     fn clipboard(&self) -> Arc<dyn Clipboard> {
         unimplemented!("iOS UIPasteboard not implemented")
+    }
+
+    fn data_transfer(&self) -> Arc<dyn DataTransferSource> {
+        // No iOS transport yet (ADR-0038): inert and honest.
+        Arc::new(NullDataTransferSource)
     }
 
     fn capabilities(&self) -> &dyn PlatformCapabilities {

--- a/crates/flui-platform/src/platforms/linux/mod.rs
+++ b/crates/flui-platform/src/platforms/linux/mod.rs
@@ -79,6 +79,7 @@ use std::sync::Arc;
 use anyhow::Result;
 pub use window_ext::*;
 
+use crate::data_transfer::{DataTransferSource, NullDataTransferSource};
 use crate::traits::{
     Clipboard, Platform, PlatformCapabilities, PlatformDisplay, PlatformExecutor,
     PlatformReadyCallback, PlatformWindow, WindowEvent, WindowId, WindowOptions,
@@ -164,6 +165,11 @@ impl Platform for LinuxPlatform {
 
     fn clipboard(&self) -> Arc<dyn Clipboard> {
         unimplemented!("Linux clipboard (wayland-data-device/X11 CLIPBOARD) not implemented")
+    }
+
+    fn data_transfer(&self) -> Arc<dyn DataTransferSource> {
+        // No native Linux transport yet (ADR-0038): inert and honest.
+        Arc::new(NullDataTransferSource)
     }
 
     fn capabilities(&self) -> &dyn PlatformCapabilities {

--- a/crates/flui-platform/src/platforms/macos/platform.rs
+++ b/crates/flui-platform/src/platforms/macos/platform.rs
@@ -14,6 +14,7 @@ use parking_lot::Mutex;
 use super::{display, window::MacOSWindow};
 use crate::{
     config::WindowConfiguration,
+    data_transfer::{DataTransferSource, NullDataTransferSource},
     executor::BackgroundExecutor,
     shared::PlatformHandlers,
     traits::{
@@ -231,6 +232,12 @@ impl Platform for MacOSPlatform {
 
     fn clipboard(&self) -> Arc<dyn Clipboard> {
         Arc::new(super::MacOSClipboard::new())
+    }
+
+    fn data_transfer(&self) -> Arc<dyn DataTransferSource> {
+        // No AppKit transport yet (NSDraggingDestination/NSPasteboard land
+        // with the native slices of ADR-0038): inert and honest.
+        Arc::new(NullDataTransferSource)
     }
 
     fn capabilities(&self) -> &dyn PlatformCapabilities {

--- a/crates/flui-platform/src/platforms/web/platform.rs
+++ b/crates/flui-platform/src/platforms/web/platform.rs
@@ -10,6 +10,7 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 
 use crate::{
+    data_transfer::{DataTransferSource, NullDataTransferSource},
     shared::{PlatformHandlers, WindowCallbacks},
     traits::*,
 };
@@ -189,6 +190,13 @@ impl Platform for WebPlatform {
 
     fn clipboard(&self) -> Arc<dyn Clipboard> {
         self.with_state(|s| s.clipboard.clone())
+    }
+
+    fn data_transfer(&self) -> Arc<dyn DataTransferSource> {
+        // The web transport (navigator.clipboard, HTML5 DnD) needs its own
+        // design (ADR-0038 §8) — until then this is inert and honest, not a
+        // degraded fake over the write-cache clipboard.
+        Arc::new(NullDataTransferSource)
     }
 
     fn capabilities(&self) -> &dyn PlatformCapabilities {

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -38,6 +38,7 @@ use super::{
 };
 use crate::{
     config::WindowConfiguration,
+    data_transfer::{DataTransferSource, NullDataTransferSource},
     executor::BackgroundExecutor,
     shared::{PlatformHandlers, WindowCallbacks},
     traits::{
@@ -974,6 +975,12 @@ impl Platform for WindowsPlatform {
 
     fn clipboard(&self) -> Arc<dyn Clipboard> {
         Arc::new(super::WindowsClipboard::new())
+    }
+
+    fn data_transfer(&self) -> Arc<dyn DataTransferSource> {
+        // No Win32 transport yet (IDropTarget/IDataObject land with the
+        // native slices of ADR-0038): inert and honest.
+        Arc::new(NullDataTransferSource)
     }
 
     // ==================== Platform Capabilities ====================

--- a/crates/flui-platform/src/platforms/winit/data_transfer.rs
+++ b/crates/flui-platform/src/platforms/winit/data_transfer.rs
@@ -1,0 +1,659 @@
+//! Winit data-transfer source: system file drops as ADR-0038 offers.
+//!
+//! Owns the platform instance's **one** [`OfferTable`] — the single minting
+//! authority for every [`DataTransferId`] this backend can emit. The event
+//! pump reports winit's `HoveredFile` / `DroppedFile` / `HoveredFileCancelled`
+//! window events into the session state machine here and dispatches the
+//! [`DragDropEvent`]s it returns; all methods return events instead of
+//! dispatching so no handler ever runs under this source's lock (ADR-0038 §5
+//! lock discipline).
+//!
+//! # Approximation ceiling (documented, not hidden)
+//!
+//! winit exposes file drops only, with no negotiation channel and no
+//! end-of-burst marker, so this backend approximates the transport:
+//!
+//! - offers carry a single `text/uri-list` representation — files only;
+//! - `Dropped.action` is stamped [`TransferActions::COPY`], the file-manager
+//!   convention, because winit cannot report the real effect;
+//! - `update_drop_feedback` / `conclude_drop` are no-ops — winit has no API
+//!   to answer the OS's hover queries or release protocol resources;
+//! - the drop boundary is heuristic: winit delivers one `DroppedFile` per
+//!   file with no terminator, so the burst is frozen at the first
+//!   `about_to_wait` after at least one `DroppedFile`. A straggler
+//!   `DroppedFile` after that freeze mints a **new** defensive session, so a
+//!   pathological split burst surfaces as two complete drops, never one
+//!   truncated one.
+//!
+//! Native backends (Win32 `IDropTarget`, AppKit `NSDraggingDestination`,
+//! Wayland `wl_data_device`) remove every one of these ceilings — the trait
+//! and event surface already carry what they need (ADR-0038 §5).
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use flui_foundation::DataTransferId;
+use flui_types::geometry::{Pixels, Point};
+use parking_lot::Mutex;
+
+use crate::data_transfer::{
+    DataTransferOffer, DataTransferSource, DropFeedback, OfferRecord, OfferTable,
+    RepresentationDescriptor, RepresentationIndex, TransferActions, TransferCompleter,
+    TransferError, TransferFormat, TransferLimits, TransferPayload, TransferRequest, TransferUri,
+};
+use crate::traits::{DragDropEvent, WindowId};
+
+/// One drag session over one window (at most one live per window).
+#[derive(Debug)]
+struct DragSession {
+    /// The offer id minted for this session.
+    id: DataTransferId,
+    /// Paths accumulated from `HoveredFile` / `DroppedFile` events, drained
+    /// into the offer's `UriList` payload at the freeze.
+    paths: Vec<PathBuf>,
+    /// At least one `DroppedFile` arrived — the next `about_to_wait` freezes
+    /// the burst.
+    dropped: bool,
+    /// The burst was frozen: the payload is snapshot in the offer record and
+    /// the session no longer accepts accumulation.
+    frozen: bool,
+    /// Deliveries requested before the freeze; completed at the freeze or
+    /// dropped (→ `SourceGone`) when the session is torn down.
+    pending: Vec<(TransferCompleter, TransferLimits)>,
+}
+
+/// Interior state: the one offer table plus per-window sessions.
+#[derive(Debug, Default)]
+struct DragDropState {
+    table: OfferTable,
+    sessions: HashMap<WindowId, DragSession>,
+}
+
+/// The winit backend's single [`DataTransferSource`] (ADR-0038).
+///
+/// Constructed once at platform init, held in the backend's shared state,
+/// and returned by `Platform::data_transfer()` as clones of the same `Arc` —
+/// never reconstructed per call. DnD-capable within the winit approximation
+/// ceiling (see the module docs); `clipboard_offer` honestly returns `None`
+/// until the clipboard transport lands (ADR-0038 §6).
+#[derive(Debug, Default)]
+pub struct WinitDataTransfer {
+    /// Private lock; no guard escapes any signature (SP-6).
+    state: Mutex<DragDropState>,
+}
+
+impl WinitDataTransfer {
+    /// An empty source with no live sessions.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A `HoveredFile` event: accumulate into the live accepting session, or
+    /// mint a new session (retiring any predecessor) and return the
+    /// `Entered` event to dispatch.
+    pub(crate) fn note_hovered_file(
+        &self,
+        window: WindowId,
+        path: PathBuf,
+        position: Option<Point<Pixels>>,
+    ) -> Option<DragDropEvent> {
+        self.accumulate_or_begin(window, path, false, position)
+    }
+
+    /// A `DroppedFile` event: accumulate into the live accepting session and
+    /// arm the freeze, or — defensive minting — start a new session when
+    /// none is accepting (no prior `HoveredFile`, or a straggler after the
+    /// freeze), returning its `Entered` event.
+    pub(crate) fn note_dropped_file(
+        &self,
+        window: WindowId,
+        path: PathBuf,
+        position: Option<Point<Pixels>>,
+    ) -> Option<DragDropEvent> {
+        self.accumulate_or_begin(window, path, true, position)
+    }
+
+    /// A `HoveredFileCancelled` event: retire the accepting session (bumping
+    /// its generation, so the id goes stale) and return the `Exited` event.
+    /// A cancel after the freeze is ignored — the drop already completed and
+    /// its offer stays redeemable.
+    pub(crate) fn note_hover_cancelled(&self, window: WindowId) -> Option<DragDropEvent> {
+        let (event, stale_pending) = {
+            let mut state = self.state.lock();
+            match state.sessions.get(&window) {
+                None => return None,
+                Some(session) if session.frozen => {
+                    tracing::trace!(?window, "ignoring hover-cancel after the drop burst froze");
+                    return None;
+                }
+                Some(_) => {}
+            }
+            let session = state
+                .sessions
+                .remove(&window)
+                .expect("BUG: drag session vanished while the state lock was held");
+            state.table.retire(session.id);
+            (DragDropEvent::Exited { id: session.id }, session.pending)
+        };
+        // Parked completers resolve SourceGone from their Drop — outside the
+        // lock, so a waker can never re-enter this source under it.
+        drop(stale_pending);
+        Some(event)
+    }
+
+    /// Windows whose drop burst is complete-so-far and awaiting the freeze.
+    /// Cheap; empty in the steady state, so `about_to_wait` stays a no-op.
+    pub(crate) fn windows_awaiting_freeze(&self) -> Vec<WindowId> {
+        self.state
+            .lock()
+            .sessions
+            .iter()
+            .filter(|(_, session)| session.dropped && !session.frozen)
+            .map(|(window, _)| *window)
+            .collect()
+    }
+
+    /// Freeze every completed drop burst: snapshot the accumulated paths as
+    /// the offer's `UriList` payload, complete parked deliveries, and return
+    /// the `Dropped` events to dispatch. The action is stamped
+    /// [`TransferActions::COPY`] — winit cannot report the real effect
+    /// (documented approximation).
+    pub(crate) fn freeze_completed(
+        &self,
+        positions: &HashMap<WindowId, Point<Pixels>>,
+    ) -> Vec<(WindowId, DragDropEvent)> {
+        let mut events = Vec::new();
+        let mut completions: Vec<(TransferCompleter, Result<TransferPayload, TransferError>)> =
+            Vec::new();
+        {
+            let mut state = self.state.lock();
+            let DragDropState { table, sessions } = &mut *state;
+            for (window, session) in sessions.iter_mut() {
+                if !session.dropped || session.frozen {
+                    continue;
+                }
+                let uris: Vec<TransferUri> =
+                    session.paths.drain(..).map(TransferUri::Path).collect();
+                let payload = TransferPayload::UriList(uris);
+                let actual = payload.byte_len();
+                if let Some(record) = table.get_mut(session.id) {
+                    record.set_payload(payload.clone());
+                }
+                session.frozen = true;
+                for (completer, limits) in session.pending.drain(..) {
+                    let result = if actual > limits.max_bytes {
+                        Err(TransferError::TooLarge {
+                            actual,
+                            limit: limits.max_bytes,
+                        })
+                    } else {
+                        Ok(payload.clone())
+                    };
+                    completions.push((completer, result));
+                }
+                events.push((
+                    *window,
+                    DragDropEvent::Dropped {
+                        id: session.id,
+                        action: TransferActions::COPY,
+                        position: positions.get(window).copied(),
+                    },
+                ));
+            }
+        }
+        // Completions wake consumer wakers — strictly outside the lock.
+        for (completer, result) in completions {
+            completer.complete(result);
+        }
+        events
+    }
+
+    /// Tear down any session addressed at a closed window: retire the offer
+    /// and let parked deliveries resolve `SourceGone`.
+    pub(crate) fn forget_window(&self, window: WindowId) {
+        let stale_pending = {
+            let mut state = self.state.lock();
+            state.sessions.remove(&window).map(|session| {
+                state.table.retire(session.id);
+                session.pending
+            })
+        };
+        drop(stale_pending);
+    }
+
+    /// Shared body of the two path-bearing arms: accumulate into a live
+    /// accepting session, or begin a new one and return its `Entered` event.
+    fn accumulate_or_begin(
+        &self,
+        window: WindowId,
+        path: PathBuf,
+        dropped: bool,
+        position: Option<Point<Pixels>>,
+    ) -> Option<DragDropEvent> {
+        let (event, stale_pending) = {
+            let mut state = self.state.lock();
+            if let Some(session) = state.sessions.get_mut(&window)
+                && !session.frozen
+            {
+                session.paths.push(path);
+                session.dropped |= dropped;
+                return None;
+            }
+
+            // Mint a new session. One live session slot per window
+            // (ADR-0038 §2): the predecessor — frozen or not — is retired,
+            // so its id goes stale and its slot's generation bumps.
+            let mut stale_pending = Vec::new();
+            if let Some(previous) = state.sessions.remove(&window) {
+                state.table.retire(previous.id);
+                stale_pending = previous.pending;
+            }
+            let representations: Arc<[RepresentationDescriptor]> =
+                Arc::from([RepresentationDescriptor {
+                    format: TransferFormat::UriList,
+                    declared_len: None,
+                }]);
+            let id = state
+                .table
+                .mint(OfferRecord::new(Arc::clone(&representations)));
+            state.sessions.insert(
+                window,
+                DragSession {
+                    id,
+                    paths: vec![path],
+                    dropped,
+                    frozen: false,
+                    pending: Vec::new(),
+                },
+            );
+            (
+                DragDropEvent::Entered {
+                    offer: DataTransferOffer::new(id, representations),
+                    // winit reports no source-permitted set; COPY is the
+                    // file-manager convention (documented approximation).
+                    allowed: TransferActions::COPY,
+                    position,
+                },
+                stale_pending,
+            )
+        };
+        drop(stale_pending);
+        Some(event)
+    }
+}
+
+impl DataTransferSource for WinitDataTransfer {
+    fn clipboard_offer(&self) -> Option<DataTransferOffer> {
+        // The clipboard half of this source arrives with the clipboard
+        // transport (ADR-0038 §6). Until then there is honestly no offer —
+        // not a fabricated one over the sync `Clipboard` trait.
+        None
+    }
+
+    fn request(
+        &self,
+        id: DataTransferId,
+        representation: RepresentationIndex,
+        limits: TransferLimits,
+    ) -> TransferRequest {
+        let mut state = self.state.lock();
+        let DragDropState { table, sessions } = &mut *state;
+        let Some(record) = table.get(id) else {
+            return TransferRequest::ready(Err(TransferError::StaleOffer(id)));
+        };
+        if usize::from(representation.0) >= record.representations().len() {
+            return TransferRequest::ready(Err(TransferError::UnknownRepresentation {
+                id,
+                index: representation,
+            }));
+        }
+        if let Some(payload) = record.payload() {
+            // Frozen file offer: the path list is genuinely in memory, so
+            // the delivery resolves synchronously — not fake async.
+            let actual = payload.byte_len();
+            if actual > limits.max_bytes {
+                return TransferRequest::ready(Err(TransferError::TooLarge {
+                    actual,
+                    limit: limits.max_bytes,
+                }));
+            }
+            return TransferRequest::ready(Ok(payload.clone()));
+        }
+        // Live pre-drop session: park the completer; the drop-burst freeze
+        // completes it, and session teardown drops it (→ `SourceGone`).
+        if let Some(session) = sessions.values_mut().find(|session| session.id == id) {
+            let (request, completer) = TransferRequest::channel();
+            session.pending.push((completer, limits));
+            return request;
+        }
+        // A record without payload always belongs to a live session in this
+        // source; a miss means the producer side is gone.
+        TransferRequest::ready(Err(TransferError::SourceGone))
+    }
+
+    fn update_drop_feedback(&self, id: DataTransferId, feedback: DropFeedback) {
+        // Documented no-op: winit exposes no channel through which the OS's
+        // synchronous hover queries could be answered, so the drop can be
+        // neither rejected nor renegotiated here (ADR-0038 approximation
+        // ceiling; native backends implement the real feedback loop).
+        tracing::trace!(%id, ?feedback, "winit exposes no drop-feedback channel; ignoring");
+    }
+
+    fn conclude_drop(&self, id: DataTransferId) {
+        // Documented no-op: winit holds no protocol resources to release,
+        // and offer retirement stays with this source's own lifecycle (next
+        // session mint, hover cancel, window teardown) until the realm-side
+        // conclusion authority lands (ADR-0038 §7).
+        tracing::trace!(%id, "winit holds no drop resources; conclude_drop ignored");
+    }
+}
+
+// These are the winit arm-conversion tests referenced by ADR-0038. They are
+// valuable locally (`just test`), but they are explicitly NOT the CI gate
+// evidence for the transport: flui-platform's tests are excluded from the CI
+// test job, so the gate-visible transport tests live in
+// `crates/flui-app/tests/data_transfer_transport.rs`.
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::pin::pin;
+    use std::task::{Context, Poll, Waker};
+
+    use super::*;
+
+    const WINDOW: WindowId = WindowId(1);
+    const OTHER_WINDOW: WindowId = WindowId(2);
+
+    fn poll_now(request: TransferRequest) -> Poll<Result<TransferPayload, TransferError>> {
+        let mut request = pin!(request);
+        let waker = Waker::noop();
+        request.as_mut().poll(&mut Context::from_waker(waker))
+    }
+
+    fn entered_offer(event: DragDropEvent) -> DataTransferOffer {
+        match event {
+            DragDropEvent::Entered { offer, .. } => offer,
+            other => panic!("expected Entered, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hovered_file_mints_a_session_and_emits_entered_once() {
+        let source = WinitDataTransfer::new();
+
+        let entered = source
+            .note_hovered_file(WINDOW, PathBuf::from("/tmp/a.txt"), None)
+            .expect("first path mints the session");
+        let DragDropEvent::Entered {
+            offer,
+            allowed,
+            position,
+        } = entered
+        else {
+            panic!("first hovered path must emit Entered");
+        };
+        assert_eq!(allowed, TransferActions::COPY);
+        assert_eq!(position, None);
+        assert_eq!(offer.representations().len(), 1);
+        assert_eq!(
+            offer.find(&TransferFormat::UriList),
+            Some(RepresentationIndex(0))
+        );
+
+        // Subsequent paths accumulate silently into the same session.
+        assert!(
+            source
+                .note_hovered_file(WINDOW, PathBuf::from("/tmp/b.txt"), None)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn hover_cancel_emits_exited_and_makes_the_offer_stale() {
+        let source = WinitDataTransfer::new();
+        let offer = entered_offer(
+            source
+                .note_hovered_file(WINDOW, PathBuf::from("/tmp/a.txt"), None)
+                .expect("mint"),
+        );
+
+        let exited = source
+            .note_hover_cancelled(WINDOW)
+            .expect("live session cancels");
+        assert!(matches!(exited, DragDropEvent::Exited { id } if id == offer.id()));
+
+        // The retired id fails the generation check.
+        let outcome = poll_now(source.request(
+            offer.id(),
+            RepresentationIndex(0),
+            TransferLimits::default(),
+        ));
+        assert!(matches!(
+            outcome,
+            Poll::Ready(Err(TransferError::StaleOffer(id))) if id == offer.id()
+        ));
+
+        // Cancelling again is a no-op.
+        assert!(source.note_hover_cancelled(WINDOW).is_none());
+    }
+
+    #[test]
+    fn drop_burst_freezes_at_about_to_wait_and_serves_the_uri_list() {
+        let source = WinitDataTransfer::new();
+        let offer = entered_offer(
+            source
+                .note_hovered_file(WINDOW, PathBuf::from("/tmp/a.txt"), None)
+                .expect("mint"),
+        );
+        assert!(
+            source
+                .note_dropped_file(WINDOW, PathBuf::from("/tmp/b.txt"), None)
+                .is_none(),
+            "drop into a live session accumulates silently"
+        );
+
+        assert_eq!(source.windows_awaiting_freeze(), vec![WINDOW]);
+        let drops = source.freeze_completed(&HashMap::new());
+        assert_eq!(drops.len(), 1);
+        let (window, DragDropEvent::Dropped { id, action, .. }) = drops[0].clone() else {
+            panic!("freeze must emit Dropped");
+        };
+        assert_eq!(window, WINDOW);
+        assert_eq!(id, offer.id());
+        assert_eq!(action, TransferActions::COPY, "documented COPY stamp");
+        assert!(source.windows_awaiting_freeze().is_empty());
+
+        // A frozen offer resolves synchronously from memory.
+        let outcome = poll_now(source.request(
+            offer.id(),
+            RepresentationIndex(0),
+            TransferLimits::default(),
+        ));
+        let Poll::Ready(Ok(TransferPayload::UriList(uris))) = outcome else {
+            panic!("frozen offer must deliver its UriList, got {outcome:?}");
+        };
+        assert_eq!(
+            uris,
+            vec![
+                TransferUri::Path(PathBuf::from("/tmp/a.txt")),
+                TransferUri::Path(PathBuf::from("/tmp/b.txt")),
+            ]
+        );
+    }
+
+    #[test]
+    fn dropped_file_without_prior_hover_mints_defensively() {
+        let source = WinitDataTransfer::new();
+
+        let entered = source
+            .note_dropped_file(WINDOW, PathBuf::from("/tmp/only.txt"), None)
+            .expect("a drop with no prior hover mints its own session");
+        let offer = entered_offer(entered);
+
+        let drops = source.freeze_completed(&HashMap::new());
+        assert_eq!(drops.len(), 1);
+        assert!(matches!(&drops[0].1, DragDropEvent::Dropped { id, .. } if *id == offer.id()));
+    }
+
+    #[test]
+    fn straggler_after_freeze_becomes_a_second_complete_drop() {
+        let source = WinitDataTransfer::new();
+        let first = entered_offer(
+            source
+                .note_dropped_file(WINDOW, PathBuf::from("/tmp/first.txt"), None)
+                .expect("mint"),
+        );
+        assert_eq!(source.freeze_completed(&HashMap::new()).len(), 1);
+
+        // The straggler mints a NEW defensive session (two complete drops,
+        // never one truncated one) — and, per the one-live-session rule,
+        // retires the frozen predecessor.
+        let second = entered_offer(
+            source
+                .note_dropped_file(WINDOW, PathBuf::from("/tmp/straggler.txt"), None)
+                .expect("straggler mints a fresh session"),
+        );
+        assert_ne!(first.id(), second.id());
+
+        let drops = source.freeze_completed(&HashMap::new());
+        assert_eq!(drops.len(), 1);
+        assert!(matches!(&drops[0].1, DragDropEvent::Dropped { id, .. } if *id == second.id()));
+
+        let outcome = poll_now(source.request(
+            second.id(),
+            RepresentationIndex(0),
+            TransferLimits::default(),
+        ));
+        let Poll::Ready(Ok(TransferPayload::UriList(uris))) = outcome else {
+            panic!("second drop must be complete, got {outcome:?}");
+        };
+        assert_eq!(
+            uris,
+            vec![TransferUri::Path(PathBuf::from("/tmp/straggler.txt"))]
+        );
+
+        let stale = poll_now(source.request(
+            first.id(),
+            RepresentationIndex(0),
+            TransferLimits::default(),
+        ));
+        assert!(matches!(
+            stale,
+            Poll::Ready(Err(TransferError::StaleOffer(id))) if id == first.id()
+        ));
+    }
+
+    #[test]
+    fn pre_freeze_request_is_parked_and_completed_at_the_freeze() {
+        let source = WinitDataTransfer::new();
+        let offer = entered_offer(
+            source
+                .note_hovered_file(WINDOW, PathBuf::from("/tmp/early.txt"), None)
+                .expect("mint"),
+        );
+
+        let request = source.request(
+            offer.id(),
+            RepresentationIndex(0),
+            TransferLimits::default(),
+        );
+        let mut request = pin!(request);
+        let waker = Waker::noop();
+        assert!(
+            request
+                .as_mut()
+                .poll(&mut Context::from_waker(waker))
+                .is_pending(),
+            "no payload exists before the drop burst freezes"
+        );
+
+        source.note_dropped_file(WINDOW, PathBuf::from("/tmp/late.txt"), None);
+        source.freeze_completed(&HashMap::new());
+
+        let Poll::Ready(Ok(TransferPayload::UriList(uris))) =
+            request.as_mut().poll(&mut Context::from_waker(waker))
+        else {
+            panic!("the parked delivery must resolve at the freeze");
+        };
+        assert_eq!(uris.len(), 2);
+    }
+
+    #[test]
+    fn window_teardown_resolves_parked_deliveries_as_source_gone() {
+        let source = WinitDataTransfer::new();
+        let offer = entered_offer(
+            source
+                .note_hovered_file(WINDOW, PathBuf::from("/tmp/gone.txt"), None)
+                .expect("mint"),
+        );
+        let request = source.request(
+            offer.id(),
+            RepresentationIndex(0),
+            TransferLimits::default(),
+        );
+
+        source.forget_window(WINDOW);
+
+        assert!(matches!(
+            poll_now(request),
+            Poll::Ready(Err(TransferError::SourceGone))
+        ));
+    }
+
+    #[test]
+    fn unknown_representation_and_limits_are_enforced() {
+        let source = WinitDataTransfer::new();
+        let offer = entered_offer(
+            source
+                .note_dropped_file(WINDOW, PathBuf::from("/tmp/limited.txt"), None)
+                .expect("mint"),
+        );
+        source.freeze_completed(&HashMap::new());
+
+        assert!(matches!(
+            poll_now(source.request(
+                offer.id(),
+                RepresentationIndex(7),
+                TransferLimits::default(),
+            )),
+            Poll::Ready(Err(TransferError::UnknownRepresentation { index, .. }))
+                if index == RepresentationIndex(7)
+        ));
+
+        assert!(matches!(
+            poll_now(source.request(
+                offer.id(),
+                RepresentationIndex(0),
+                TransferLimits::default().with_max_bytes(1),
+            )),
+            Poll::Ready(Err(TransferError::TooLarge { limit: 1, .. }))
+        ));
+    }
+
+    #[test]
+    fn sessions_are_independent_per_window() {
+        let source = WinitDataTransfer::new();
+        let first = entered_offer(
+            source
+                .note_hovered_file(WINDOW, PathBuf::from("/tmp/one.txt"), None)
+                .expect("mint"),
+        );
+        let second = entered_offer(
+            source
+                .note_hovered_file(OTHER_WINDOW, PathBuf::from("/tmp/two.txt"), None)
+                .expect("independent window mints its own session"),
+        );
+        assert_ne!(first.id(), second.id());
+
+        // Cancelling one window's drag leaves the other live.
+        source.note_hover_cancelled(WINDOW);
+        assert!(
+            source
+                .note_dropped_file(OTHER_WINDOW, PathBuf::from("/tmp/more.txt"), None)
+                .is_none(),
+            "the other window's session still accumulates"
+        );
+    }
+}

--- a/crates/flui-platform/src/platforms/winit/data_transfer.rs
+++ b/crates/flui-platform/src/platforms/winit/data_transfer.rs
@@ -23,7 +23,12 @@
 //!   `about_to_wait` after at least one `DroppedFile`. A straggler
 //!   `DroppedFile` after that freeze mints a **new** defensive session, so a
 //!   pathological split burst surfaces as two complete drops, never one
-//!   truncated one.
+//!   truncated one.;
+//! - a LOST `HoveredFileCancelled` (known flaky on some X11 setups) leaves
+//!   the unfrozen session live, so the next drag's `HoveredFile` paths
+//!   accumulate into it — two distinct drags can merge into one offer with
+//!   no second `Entered`. Bounded per window; the session resolves at the
+//!   next freeze or teardown either way.
 //!
 //! Native backends (Win32 `IDropTarget`, AppKit `NSDraggingDestination`,
 //! Wayland `wl_data_device`) remove every one of these ceilings — the trait
@@ -342,11 +347,27 @@ impl DataTransferSource for WinitDataTransfer {
     }
 
     fn conclude_drop(&self, id: DataTransferId) {
-        // Documented no-op: winit holds no protocol resources to release,
-        // and offer retirement stays with this source's own lifecycle (next
-        // session mint, hover cancel, window teardown) until the realm-side
-        // conclusion authority lands (ADR-0038 §7).
-        tracing::trace!(%id, "winit holds no drop resources; conclude_drop ignored");
+        // winit holds no PROTOCOL resources to release — but table
+        // retirement is purely local, and the trait contract promises the
+        // offer goes stale after conclusion. Honor it here so the slice-3
+        // realm authority does not inherit a source that silently keeps
+        // concluded offers redeemable until the next mint.
+        let stale_pending = {
+            let mut state = self.state.lock();
+            state.table.retire(id);
+            // Drop any session still tracking this offer (a frozen session
+            // whose drop the consumer has now concluded).
+            let window = state
+                .sessions
+                .iter()
+                .find(|(_, session)| session.id == id)
+                .map(|(window, _)| *window);
+            window.and_then(|window| state.sessions.remove(&window))
+        };
+        // Parked completers (if any survived the freeze) resolve from their
+        // Drop — outside the lock, so a waker cannot re-enter this source.
+        drop(stale_pending);
+        tracing::trace!(%id, "drop concluded; offer retired");
     }
 }
 

--- a/crates/flui-platform/src/platforms/winit/mod.rs
+++ b/crates/flui-platform/src/platforms/winit/mod.rs
@@ -2,10 +2,12 @@
 
 mod clipboard;
 mod control;
+mod data_transfer;
 mod display;
 mod events;
 mod platform;
 
 pub use clipboard::ArboardClipboard;
+pub use data_transfer::WinitDataTransfer;
 pub use display::WinitDisplay;
 pub use platform::WinitPlatform;

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -63,21 +63,36 @@ use winit::{
     window::{WindowAttributes, WindowId as WinitWindowId},
 };
 
+use flui_types::geometry::{Pixels, Point, px};
+
 use super::{
     clipboard::ArboardClipboard,
     control::{ControlCommand, ControlReceiver, ControlSendError, ControlSender, control_lane},
+    data_transfer::WinitDataTransfer,
     display::WinitDisplay,
     events as winit_events,
 };
 use crate::{
+    data_transfer::DataTransferSource,
     executor::BackgroundExecutor,
     shared::PlatformHandlers,
     traits::{
         Clipboard, DesktopCapabilities, Platform, PlatformCapabilities, PlatformDisplay,
-        PlatformExecutor, PlatformReadyCallback, PlatformWindow, WindowEvent, WindowId,
-        WindowOptions, WinitWindow,
+        PlatformExecutor, PlatformInput, PlatformReadyCallback, PlatformWindow, WindowEvent,
+        WindowId, WindowOptions, WinitWindow,
     },
 };
+
+/// Convert a tracked physical cursor position to logical pixels.
+fn logical_cursor_point(
+    position: winit::dpi::PhysicalPosition<f64>,
+    scale_factor: f64,
+) -> Point<Pixels> {
+    Point::new(
+        px((position.x / scale_factor) as f32),
+        px((position.y / scale_factor) as f32),
+    )
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum OpenWindowStateError {
@@ -169,6 +184,12 @@ struct WinitPlatformState {
     /// Clipboard
     clipboard: Arc<ArboardClipboard>,
 
+    /// The one data-transfer source of this platform instance (ADR-0038):
+    /// constructed once here, cloned out by `Platform::data_transfer()`,
+    /// never reconstructed — it owns the single offer table, so ids stay
+    /// redeemable across every clone.
+    data_transfer: Arc<WinitDataTransfer>,
+
     /// Map of winit window IDs to platform window IDs
     window_id_map: HashMap<WinitWindowId, WindowId>,
 
@@ -209,6 +230,7 @@ impl WinitPlatformState {
             handlers: PlatformHandlers::new(),
             background_executor: Arc::new(BackgroundExecutor::new()),
             clipboard,
+            data_transfer: Arc::new(WinitDataTransfer::new()),
             window_id_map: HashMap::new(),
             windows: HashMap::new(),
             displays: Vec::new(),
@@ -555,7 +577,7 @@ impl ApplicationHandler for WinitApp {
                 }
 
                 // Notify platform handler
-                let should_exit = self.platform.with_state(|state| {
+                let (should_exit, transfer) = self.platform.with_state(|state| {
                     state
                         .handlers
                         .invoke_window_event(WindowEvent::CloseRequested {
@@ -567,8 +589,12 @@ impl ApplicationHandler for WinitApp {
                     state.windows.remove(&platform_id);
                     state.cursor_positions.remove(&platform_id);
 
-                    state.windows.is_empty()
+                    (state.windows.is_empty(), Arc::clone(&state.data_transfer))
                 });
+
+                // Retire any drag session addressed at this window; parked
+                // deliveries resolve SourceGone (ADR-0038 offer lifecycle).
+                transfer.forget_window(platform_id);
 
                 if should_exit {
                     self.request_exit(event_loop);
@@ -759,11 +785,38 @@ impl ApplicationHandler for WinitApp {
                     win.callbacks().dispatch_visibility_status_change(!occluded);
                 }
             }
+            WinitWindowEvent::HoveredFile(path) => {
+                self.handle_drag_drop_path(platform_id, window.as_ref(), path, DragPath::Hovered);
+            }
+            WinitWindowEvent::DroppedFile(path) => {
+                self.handle_drag_drop_path(platform_id, window.as_ref(), path, DragPath::Dropped);
+            }
+            WinitWindowEvent::HoveredFileCancelled => {
+                let transfer = self
+                    .platform
+                    .with_state(|state| Arc::clone(&state.data_transfer));
+                let event = transfer.note_hover_cancelled(platform_id);
+                // Lock discipline (ADR-0038 §5): both the platform-state and
+                // transfer locks are released before dispatch, mirroring the
+                // CursorMoved arm.
+                if let (Some(event), Some(win)) = (event, window.as_ref()) {
+                    win.callbacks()
+                        .dispatch_input(PlatformInput::DragDrop(event));
+                }
+            }
             _ => {}
         }
     }
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        // Drop-burst boundary (ADR-0038): winit delivers one `DroppedFile`
+        // per file with no end-of-burst marker, so the first `about_to_wait`
+        // after at least one `DroppedFile` freezes the accumulated list as
+        // the offer's payload and emits `Dropped`. A straggler after this
+        // point mints a new defensive session — two complete drops, never
+        // one truncated one (documented winit approximation ceiling).
+        self.freeze_completed_drops();
+
         // Explicit `Wait`, not a no-op: see the module doc's "Vsync pacing"
         // section. Re-asserted every iteration so an upstream winit default
         // change can't silently turn the wake-driven frame loop into a
@@ -780,8 +833,95 @@ impl ApplicationHandler for WinitApp {
     }
 }
 
+/// Which winit file-drag arm produced a path.
+#[derive(Debug, Clone, Copy)]
+enum DragPath {
+    /// `WindowEvent::HoveredFile` — the drag is still in flight.
+    Hovered,
+    /// `WindowEvent::DroppedFile` — the user released; arm the burst freeze.
+    Dropped,
+}
+
 // Helper methods for WinitApp
 impl WinitApp {
+    /// Shared body of the `HoveredFile`/`DroppedFile` arms: feed the path
+    /// into the drag-session state machine and dispatch any resulting event.
+    ///
+    /// Lock discipline (ADR-0038 §5): platform state is only locked to clone
+    /// out the transfer source and the tracked cursor position; both that
+    /// lock and the source's internal lock are released before
+    /// `dispatch_input` runs, mirroring the CursorMoved arm.
+    fn handle_drag_drop_path(
+        &self,
+        platform_id: WindowId,
+        window: Option<&Arc<WinitWindow>>,
+        path: PathBuf,
+        kind: DragPath,
+    ) {
+        let (transfer, cursor) = self.platform.with_state(|state| {
+            (
+                Arc::clone(&state.data_transfer),
+                state.cursor_positions.get(&platform_id).copied(),
+            )
+        });
+        // Last tracked cursor position, if any — possibly stale on Wayland,
+        // where an external drag grabs the cursor (documented limitation).
+        let position = window
+            .and_then(|win| cursor.map(|cursor| logical_cursor_point(cursor, win.scale_factor())));
+        let event = match kind {
+            DragPath::Hovered => transfer.note_hovered_file(platform_id, path, position),
+            DragPath::Dropped => transfer.note_dropped_file(platform_id, path, position),
+        };
+        if let (Some(event), Some(win)) = (event, window) {
+            win.callbacks()
+                .dispatch_input(PlatformInput::DragDrop(event));
+        }
+    }
+
+    /// Freeze completed drop bursts and dispatch their `Dropped` events.
+    /// Cheap in the steady state: one uncontended lock to observe that no
+    /// session is awaiting the freeze.
+    fn freeze_completed_drops(&self) {
+        let transfer = self
+            .platform
+            .with_state(|state| Arc::clone(&state.data_transfer));
+        let windows = transfer.windows_awaiting_freeze();
+        if windows.is_empty() {
+            return;
+        }
+
+        // Snapshot window handles and cursor positions first; the platform
+        // lock is released before scale-factor reads and dispatch.
+        let mut snapshots: Vec<(WindowId, Arc<WinitWindow>, Option<_>)> = Vec::new();
+        self.platform.with_state(|state| {
+            for window_id in &windows {
+                if let Some(win) = state.windows.get(window_id) {
+                    snapshots.push((
+                        *window_id,
+                        Arc::clone(win),
+                        state.cursor_positions.get(window_id).copied(),
+                    ));
+                }
+            }
+        });
+
+        let mut positions = HashMap::new();
+        let mut handles: HashMap<WindowId, Arc<WinitWindow>> = HashMap::new();
+        for (window_id, win, cursor) in snapshots {
+            if let Some(cursor) = cursor {
+                positions.insert(window_id, logical_cursor_point(cursor, win.scale_factor()));
+            }
+            handles.insert(window_id, win);
+        }
+
+        for (window_id, event) in transfer.freeze_completed(&positions) {
+            if let Some(win) = handles.get(&window_id) {
+                win.callbacks()
+                    .dispatch_input(PlatformInput::DragDrop(event));
+            }
+        }
+    }
+
     fn process_control(&mut self, event_loop: &ActiveEventLoop) {
         if self.control.take_quit_requested() {
             self.request_exit(event_loop);
@@ -1002,6 +1142,12 @@ impl Platform for WinitPlatform {
 
     fn clipboard(&self) -> Arc<dyn Clipboard> {
         self.with_state(|state| state.clipboard.clone())
+    }
+
+    fn data_transfer(&self) -> Arc<dyn DataTransferSource> {
+        // Clones of the ONE source constructed at platform init (ADR-0038
+        // §2): every id it mints stays redeemable at every clone.
+        self.with_state(|state| Arc::clone(&state.data_transfer) as Arc<dyn DataTransferSource>)
     }
 
     fn capabilities(&self) -> &dyn PlatformCapabilities {

--- a/crates/flui-platform/src/traits/input.rs
+++ b/crates/flui-platform/src/traits/input.rs
@@ -51,7 +51,8 @@
 use std::collections::VecDeque;
 use std::time::Instant;
 
-use flui_types::geometry::{Offset, PixelDelta, Pixels};
+use flui_foundation::DataTransferId;
+use flui_types::geometry::{Offset, PixelDelta, Pixels, Point};
 /// Re-export keyboard types from keyboard-types crate
 pub use keyboard_types::{Key, Modifiers};
 /// Re-export scroll events
@@ -128,6 +129,11 @@ pub enum PlatformInput {
     /// vocabulary and [`crate::traits::PlatformTextInput`] for the
     /// window-side capability this pairs with.
     Ime(flui_types::ImeEvent),
+
+    /// System drag-and-drop (ADR-0038). Deliberately NOT a pointer event:
+    /// during an external drag the OS owns the cursor, and the gesture-arena
+    /// semantics of the pointer pipeline (capture, velocity) do not apply.
+    DragDrop(DragDropEvent),
 }
 
 impl PlatformInput {
@@ -136,7 +142,7 @@ impl PlatformInput {
     pub fn as_pointer(&self) -> Option<&PointerEvent> {
         match self {
             PlatformInput::Pointer(event) => Some(event),
-            PlatformInput::Keyboard(_) | PlatformInput::Ime(_) => None,
+            PlatformInput::Keyboard(_) | PlatformInput::Ime(_) | PlatformInput::DragDrop(_) => None,
         }
     }
 
@@ -145,7 +151,7 @@ impl PlatformInput {
     pub fn as_keyboard(&self) -> Option<&KeyboardEvent> {
         match self {
             PlatformInput::Keyboard(event) => Some(event),
-            PlatformInput::Pointer(_) | PlatformInput::Ime(_) => None,
+            PlatformInput::Pointer(_) | PlatformInput::Ime(_) | PlatformInput::DragDrop(_) => None,
         }
     }
 
@@ -154,9 +160,70 @@ impl PlatformInput {
     pub fn as_ime(&self) -> Option<&flui_types::ImeEvent> {
         match self {
             PlatformInput::Ime(event) => Some(event),
-            PlatformInput::Pointer(_) | PlatformInput::Keyboard(_) => None,
+            PlatformInput::Pointer(_) | PlatformInput::Keyboard(_) | PlatformInput::DragDrop(_) => {
+                None
+            }
         }
     }
+
+    /// Extract the drag-and-drop event if this is a DnD input.
+    #[inline]
+    pub fn as_drag_drop(&self) -> Option<&DragDropEvent> {
+        match self {
+            PlatformInput::DragDrop(event) => Some(event),
+            PlatformInput::Pointer(_) | PlatformInput::Keyboard(_) | PlatformInput::Ime(_) => None,
+        }
+    }
+}
+
+/// The push half of the data-transfer transport (ADR-0038): stage-1 arrival
+/// and stage-2/6 progress for a drag session over one window. The target's
+/// reply half flows the other way, through
+/// [`crate::data_transfer::DataTransferSource::update_drop_feedback`].
+#[derive(Debug, Clone)]
+pub enum DragDropEvent {
+    /// A drag entered the window. Carries the full offer (stage 1) and the
+    /// actions the source currently permits.
+    Entered {
+        /// The stage-1 offer minted for this drag session.
+        offer: crate::data_transfer::DataTransferOffer,
+        /// Actions the source currently permits.
+        allowed: crate::data_transfer::TransferActions,
+        /// Logical-pixel position when the backend knows it. The winit
+        /// backend stamps the last tracked cursor position — `None` before
+        /// any cursor event, and possibly stale on Wayland where an external
+        /// drag grabs the cursor (documented backend limitation).
+        position: Option<Point<Pixels>>,
+    },
+    /// The drag moved while over the window. `allowed` is re-stamped on
+    /// every event: modifier-driven copy/move/link changes mid-drag arrive
+    /// here, and the target answers them with fresh `DropFeedback`.
+    Moved {
+        /// The live session's offer id.
+        id: DataTransferId,
+        /// Actions the source permits as of this event.
+        allowed: crate::data_transfer::TransferActions,
+        /// Logical-pixel hover position.
+        position: Point<Pixels>,
+    },
+    /// The user released and the backend resolved the drop from the cached
+    /// feedback. `action` is the effect reported to the OS. The payload is
+    /// NOT here — a stage-3 request fetches it lazily; the target calls
+    /// `conclude_drop` when done.
+    Dropped {
+        /// The dropped session's offer id, redeemable for the payload.
+        id: DataTransferId,
+        /// The drop effect resolved and reported to the OS.
+        action: crate::data_transfer::TransferActions,
+        /// Logical-pixel drop position when the backend knows it.
+        position: Option<Point<Pixels>>,
+    },
+    /// The drag left the window or the source cancelled; the offer is
+    /// retired.
+    Exited {
+        /// The retired session's offer id (now stale by construction).
+        id: DataTransferId,
+    },
 }
 
 // ============================================================================

--- a/crates/flui-platform/src/traits/mod.rs
+++ b/crates/flui-platform/src/traits/mod.rs
@@ -24,6 +24,8 @@ pub use input::{
     BasicVelocityTracker,
     // Event dispatch result
     DispatchEventResult,
+    // System drag-and-drop (ADR-0038)
+    DragDropEvent,
     // W3C event types (re-exported from ui-events)
     Key,
     KeyboardEvent,

--- a/crates/flui-platform/src/traits/platform.rs
+++ b/crates/flui-platform/src/traits/platform.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use flui_types::geometry::{Bounds, DevicePixels, Pixels, Point, Size};
 
 use super::{PlatformCapabilities, PlatformDisplay, PlatformWindow, window::WindowAppearance};
-use crate::task::Task;
+use crate::{data_transfer::DataTransferSource, task::Task};
 
 /// Window creation options
 #[derive(Debug, Clone)]
@@ -230,6 +230,18 @@ pub trait Platform: Send + Sync + 'static {
 
     /// Get the platform's clipboard interface
     fn clipboard(&self) -> Arc<dyn Clipboard>;
+
+    /// The data-transfer transport (ADR-0038). Contract: returns clones of
+    /// ONE source instance per platform instance — the source owns
+    /// connection-like state (the offer table), and per ADR-0034 §3 such
+    /// state must live behind an `Arc` the platform clones out, never be
+    /// reconstructed per call (two independently minted tables would split
+    /// the id space and let cross-table ids pass each other's generation
+    /// checks). Deliberately a required method with no default body so a
+    /// new backend must make that choice explicitly. Backends without a
+    /// transport return [`crate::data_transfer::NullDataTransferSource`]
+    /// (inert, honest — not fake success).
+    fn data_transfer(&self) -> Arc<dyn DataTransferSource>;
 
     // ==================== App Activation (US3) ====================
 

--- a/examples/web_demo/src/lib.rs
+++ b/examples/web_demo/src/lib.rs
@@ -85,6 +85,11 @@ pub fn start() {
             PlatformInput::Ime(ime_event) => {
                 web_sys::console::log_1(&format!("IME: {ime_event:?}").into());
             }
+            PlatformInput::DragDrop(drag_drop_event) => {
+                // The web backend has no data-transfer transport yet
+                // (ADR-0038 §8), so this arm can only log.
+                web_sys::console::log_1(&format!("DragDrop: {drag_drop_event:?}").into());
+            }
         }
         DispatchEventResult::resolved(false, true)
     }));


### PR DESCRIPTION
First implementation slice of ADR-0038 (data-transfer architecture), all 7 items of the ADR's slice-1 list. Built agent-assisted against the ADR as spec, then reviewed by a second agent (verdict: approve, 0 blocking); the two actionable review findings are fixed in the second commit.

**What lands:**
- `DataTransferId` in flui-foundation's generational `ids!` block (house ABA defense).
- `flui_platform::data_transfer`: the §3 vocabulary (Mime with RFC-2045 normalization, TransferFormat, representations, `TransferActions`, `DropFeedback`, `DataTransferOffer`, `TransferPayload`, `#[non_exhaustive]` limits/errors), `OfferTable` (single minting authority per platform instance; generation bump on retire → `StaleOffer`), the hand-rolled `TransferRequest`/`TransferCompleter` oneshot (Send future; cancel-on-drop; drop-completer → `SourceGone`; **no second async mechanism** — composes with `AsyncDriver`/`TaskToken`), `DataTransferSource` with the frozen feedback surface, `NullDataTransferSource`.
- `Platform::data_transfer()` **required** method wired at all 8 backends (winit = the real source; others = honest nulls); cross-typecheck green on both native triples.
- `PlatformInput::DragDrop(DragDropEvent)` + winit `HoveredFile`/`DroppedFile`/`HoveredFileCancelled` arms with the ADR's defensive-minting and freeze-at-first-`about_to_wait` burst boundary (stragglers mint a new complete session — never a truncated drop); §5 lock discipline (nothing dispatches under the state lock; completer drops fire wakers outside it). `Dropped.action` stamped COPY and `update_drop_feedback` no-op are **documented approximations** of the winit ceiling, listed in the module docs (now including the lost-`HoveredFileCancelled` merge case).
- flui-app realm dispatcher: `DragDrop` arm logs-and-drops (realm routing is slice 3, stated in the log).
- **Tests where CI runs them**: 11 transport tests in `crates/flui-app/tests/data_transfer_transport.rs` (OfferTable semantics incl. cross-generation misses; the full completer state machine; a mock source driving all seven stages through a real `AsyncDriver` incl. `TaskToken` cancel-on-drop) + 9 winit arm tests local to flui-platform (explicitly not gate evidence — that crate's suite is CI-excluded). **Integrity check performed:** disabling the generation bump fails exactly the generation test; restored.

**Review follow-ups fixed here:** winit `conclude_drop` now retires the offer locally per the trait contract (was a sanctioned no-op that slice 3 would have tripped over); lost-cancel ceiling documented. Deferred with rationale (pre-slice-4): `DataTransferOffer::find`'s `expect` becomes reachable only when native backends mint OS-supplied representation lists; `byte_len` counts raw bytes, not encoded `text/uri-list` form (consistently on both enforcement sites).

Gates (all run, all green): full `just ci`, workspace clippy `-D warnings`, both cross-typecheck triples, `just wasm-check` (incl. the web_demo exhaustive-match ripple the new variant forced), port-check, taplo, typos; flui-app 136/136, foundation + winit-local suites green. flui-platform's 11 pre-existing `platform_it` failures verified byte-identical on clean main (stash A/B) — the documented CI-exclusion reason, untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)