### PR TITLE
fix: address automated review findings on the ADR slice-1 PRs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1801,6 +1801,7 @@ dependencies = [
  "ui-events",
  "wasm-bindgen",
  "web-sys",
+ "web-time",
  "windows",
  "winit",
 ]

--- a/crates/flui-binding/Cargo.toml
+++ b/crates/flui-binding/Cargo.toml
@@ -53,7 +53,7 @@ flui-interaction = { path = "../flui-interaction", version = "0.2.0", features =
 # of release builds.
 flui-view = { path = "../flui-view", version = "0.2.0", features = ["test-utils"] }
 flui-foundation = { path = "../flui-foundation", version = "0.2.0" }
-# ADR-0040 slice 1: the end-to-end observation-seam test drives a real tree
+# The end-to-end observation-seam test (ADR-0040) drives a real tree
 # against the devtools inspector — this crate is the one that links both
 # halves (acyclic: flui-devtools depends only on flui-foundation).
 flui-devtools = { path = "../flui-devtools", version = "0.2.0", features = ["inspector"] }

--- a/crates/flui-binding/benches/tree_observer_overhead.rs
+++ b/crates/flui-binding/benches/tree_observer_overhead.rs
@@ -1,12 +1,12 @@
-//! The audit-§30 "inspector overhead" benchmark, previously unwritable
-//! because no observation seam existed (ADR-0040 made it writable; slice 1
-//! ships it as the check on the zero-cost-when-off claim).
+//! Overhead check on ADR-0040's zero-cost-when-off claim: what does the
+//! tree-observation seam cost a frame with no observer installed, and what
+//! does a live one add?
 //!
 //! Three scenarios over the same rebuild-heavy drive (keyed rotation of 64
 //! render children through the production `build_scope` path each
 //! iteration): observer absent (the `Option` null-check off path), a no-op
 //! observer (emission + `catch_unwind` frame, empty body), and the
-//! devtools counting inspector (the real slice-1 consumer).
+//! devtools counting inspector (the first real consumer).
 
 // Bench binary: criterion's generated main has no docs (house precedent:
 // the flui-view benches carry the same allow).

--- a/crates/flui-devtools/src/inspector.rs
+++ b/crates/flui-devtools/src/inspector.rs
@@ -1,4 +1,5 @@
-//! Counting/logging tree inspector — the ADR-0040 slice-1 consumer.
+//! Counting/logging tree inspector — the first consumer of the ADR-0040
+//! observation seam.
 //!
 //! Proves the dependency-inverted observation seam end to end with only
 //! `flui-foundation` on the dependency list: install an
@@ -16,12 +17,13 @@ use flui_foundation::observe::{
 /// Number of [`RebuildReason`] variants tracked in the per-cause tallies.
 const REASON_COUNT: usize = 10;
 
-/// Counting/logging [`TreeObserver`] — the slice-1 inspector.
+/// Counting/logging [`TreeObserver`].
 ///
 /// Interior state is private atomics; nothing here exposes a lock (SP-6).
-/// All counter updates use `Relaxed`: bare tallies, no data is published
-/// through them, and the observation contract already serializes emissions
-/// per realm (owner-thread, synchronous).
+/// Counter updates use `Relaxed` (bare tallies; the observation contract
+/// serializes emissions per realm), while the end-of-stream flag is
+/// Release/Acquire so a snapshot that observes the stream end also
+/// observes every count that preceded it.
 #[derive(Debug, Default)]
 pub struct InspectorCounters {
     mounts: AtomicU64,
@@ -49,6 +51,12 @@ impl InspectorCounters {
     /// returns no guard (SP-6).
     #[must_use]
     pub fn snapshot(&self) -> InspectorSnapshot {
+        // Acquire on the final flag FIRST: it pairs with the Release store
+        // in `detached()`, so a snapshot observing `is_final() == true`
+        // also observes every count the emitting thread made before the
+        // stream ended. Counters themselves stay Relaxed — mid-stream
+        // snapshots promise per-counter monotonicity only.
+        let detached = self.detached.load(Ordering::Acquire);
         let mut per_reason = [0u64; REASON_COUNT];
         for (slot, counter) in per_reason.iter_mut().zip(&self.per_reason) {
             *slot = counter.load(Ordering::Relaxed);
@@ -59,7 +67,7 @@ impl InspectorCounters {
             rebuilds: self.rebuilds.load(Ordering::Relaxed),
             moves: self.moves.load(Ordering::Relaxed),
             per_reason,
-            detached: self.detached.load(Ordering::Relaxed),
+            detached,
         }
     }
 }
@@ -91,7 +99,9 @@ impl TreeObserver for InspectorCounters {
     }
 
     fn detached(&self) {
-        self.detached.store(true, Ordering::Relaxed);
+        // Release pairs with the Acquire in `snapshot()`: a reader that
+        // sees the final flag sees every count that preceded it.
+        self.detached.store(true, Ordering::Release);
         tracing::debug!("inspector: stream detached");
     }
 }

--- a/crates/flui-foundation/src/affinity.rs
+++ b/crates/flui-foundation/src/affinity.rs
@@ -3,10 +3,10 @@
 //! Native platform backends (`AppKit`, Win32) own an event loop whose OS
 //! objects are thread-affine, yet the `Platform` trait is `Send + Sync` with
 //! `&self` methods — nothing stops a worker thread from calling `open_window`
-//! on macOS, which is undefined-behavior-class misuse of `AppKit`. The full fix is
-//! the `!Send` `OwnerPlatform` capability (ADR-0039 slices 2–3); this module
-//! is slice 1: a recordable owner identity plus a debug assertion backends
-//! place at the entry of their affine operations.
+//! on macOS, which is undefined-behavior-class misuse of `AppKit`. The full
+//! fix is the `!Send` `OwnerPlatform` capability (ADR-0039); this module is
+//! the runtime backstop beneath it: a recordable owner identity plus a debug
+//! assertion backends place at the entry of their affine operations.
 //!
 //! It lives in `flui-foundation` — not `flui-platform` — so its behavior is
 //! exercised by a test suite CI actually runs (`flui-platform`'s suite is
@@ -26,9 +26,9 @@ use std::thread::{self, ThreadId};
 /// [`debug_assert_owner`] at each affine operation's entry.
 ///
 /// Before binding, [`debug_assert_owner`] is deliberately a no-op: pre-run
-/// flows (e.g. Win32 examples opening a window before `run()`) are legal
-/// until ADR-0039 slice 2 migrates them into `on_ready`, and an unbound
-/// affinity has no owner to check against.
+/// flows (e.g. Win32 examples opening a window before `run()`) stay legal
+/// until the `OwnerPlatform` capability moves them into `on_ready`
+/// (ADR-0039), and an unbound affinity has no owner to check against.
 ///
 /// [`bind_current`]: Self::bind_current
 /// [`debug_assert_owner`]: Self::debug_assert_owner

--- a/crates/flui-foundation/src/observe.rs
+++ b/crates/flui-foundation/src/observe.rs
@@ -1,4 +1,4 @@
-//! Dependency-inverted tree observation (ADR-0040; audit 2026-07-25 §26/U3).
+//! Dependency-inverted tree observation (ADR-0040).
 //!
 //! `flui-devtools` cannot depend on the tree crates (that would compile the
 //! whole framework into any app enabling inspection and invert nothing), so

--- a/crates/flui-platform/Cargo.toml
+++ b/crates/flui-platform/Cargo.toml
@@ -20,6 +20,8 @@ flui-types = { path = "../flui-types", version = "0.2.0" }
 # hosted in foundation so its tests run in CI (flui-platform's suite does
 # not) — and the generational DataTransferId for the ADR-0038 transport.
 flui-foundation = { path = "../flui-foundation", version = "0.2.0" }
+# Wasm-safe Instant for input timestamps (std re-export on native).
+web-time = { workspace = true }
 
 # UI Events - W3C compliant event types
 ui-events = { workspace = true }

--- a/crates/flui-platform/src/platforms/macos/platform.rs
+++ b/crates/flui-platform/src/platforms/macos/platform.rs
@@ -44,8 +44,8 @@ pub struct MacOSPlatform {
     /// Window configuration
     config: WindowConfiguration,
 
-    /// ADR-0039 slice 1: records the event-loop owner thread so the
-    /// thread-affine AppKit operations below can `debug_assert` their caller.
+    /// Records the event-loop owner thread so the thread-affine AppKit
+    /// operations below can `debug_assert` their caller (ADR-0039).
     affinity: OwnerAffinity,
 }
 
@@ -53,7 +53,7 @@ pub struct MacOSPlatform {
 ///
 /// On AppKit the owner thread must *be* the process main thread —
 /// `ThreadId` equality against the binding thread cannot express that on
-/// its own (ADR-0039 slice 1), so this asks AppKit directly.
+/// its own, so this asks AppKit directly.
 fn debug_assert_appkit_main_thread(op: &'static str) {
     #[cfg(debug_assertions)]
     {
@@ -109,6 +109,10 @@ impl MacOSPlatform {
 
     /// Create a new macOS platform with custom configuration
     pub fn with_config(config: WindowConfiguration) -> Result<Self> {
+        // AppKit is touched below (`NSApp()`, `setActivationPolicy_`), so
+        // the main-thread requirement starts HERE, not at `run` — check it
+        // before the first AppKit operation rather than after the fact.
+        debug_assert_appkit_main_thread("MacOSPlatform::with_config");
         // SAFETY: must run on the main thread (the platform owns the event
         // loop); `NSApp()` returns the shared application singleton which is
         // nil-checked before use.
@@ -135,9 +139,9 @@ impl MacOSPlatform {
                 config,
                 affinity: OwnerAffinity::new(),
             };
-            // The constructor already documents a main-thread requirement
-            // (see the SAFETY note above), so the owner is known here — bind
-            // early so pre-`run` affine calls are covered too (ADR-0039).
+            // The constructor requires the main thread (checked above), so
+            // the owner is known here — bind early so pre-`run` affine
+            // calls are covered too.
             platform.affinity.bind_current();
             Ok(platform)
         }

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -119,11 +119,11 @@ pub struct WindowsPlatform {
     /// Window configuration (shared across all windows)
     config: WindowConfiguration,
 
-    /// ADR-0039 slice 1: records the message-loop owner thread so the
-    /// thread-affine Win32 operations below can `debug_assert` their caller.
-    /// Bound at `run` — pre-run window creation (the Win32 examples) is legal
-    /// until ADR-0039 slice 2 migrates it into `on_ready`, and the assert is
-    /// a no-op while unbound.
+    /// Records the owner thread so the thread-affine Win32 operations below
+    /// can `debug_assert` their caller (ADR-0039). Bound at construction —
+    /// the message-only window's queue belongs to the constructing thread —
+    /// and re-asserted by `run`. Pre-run window creation on that same
+    /// thread (the Win32 examples) stays legal.
     affinity: flui_foundation::OwnerAffinity,
 }
 
@@ -241,14 +241,21 @@ impl WindowsPlatform {
 
         tracing::info!("Windows platform initialized with Tokio executors");
 
-        Ok(Self {
+        let platform = Self {
             message_window,
             windows: Arc::new(Mutex::new(HashMap::new())),
             handlers: Arc::new(Mutex::new(PlatformHandlers::default())),
             background_executor,
             config,
             affinity: flui_foundation::OwnerAffinity::new(),
-        })
+        };
+        // The message-only window above was just created on THIS thread, so
+        // its message queue already belongs here — the owner is decided at
+        // construction, not at `run`. A later `run` on another thread trips
+        // the foreign re-bind assertion instead of silently accepting a
+        // thread that cannot service the HWND.
+        platform.affinity.bind_current();
+        Ok(platform)
     }
 
     /// Register the window class for all FLUI windows (idempotent via `Once`).
@@ -905,8 +912,9 @@ impl Platform for WindowsPlatform {
     fn run(self: Box<Self>, on_ready: Box<dyn FnOnce(&dyn Platform)>) {
         tracing::info!("Running Windows platform");
 
-        // ADR-0039 slice 1: the thread that runs the message loop owns every
-        // window created from here on.
+        // Idempotent from the constructing thread; a `run` migrated to a
+        // different thread is a bug the re-bind assertion surfaces (the
+        // message-only window's queue is bound to the constructing thread).
         self.affinity.bind_current();
 
         // Call ready callback

--- a/crates/flui-platform/src/platforms/winit/data_transfer.rs
+++ b/crates/flui-platform/src/platforms/winit/data_transfer.rs
@@ -16,14 +16,16 @@
 //! - offers carry a single `text/uri-list` representation — files only;
 //! - `Dropped.action` is stamped [`TransferActions::COPY`], the file-manager
 //!   convention, because winit cannot report the real effect;
-//! - `update_drop_feedback` / `conclude_drop` are no-ops — winit has no API
-//!   to answer the OS's hover queries or release protocol resources;
+//! - `update_drop_feedback` is a no-op — winit has no API to answer the
+//!   OS's hover queries; `conclude_drop` has no protocol resources to
+//!   release but does retire the offer locally, so a concluded id goes
+//!   stale as the trait contract promises;
 //! - the drop boundary is heuristic: winit delivers one `DroppedFile` per
 //!   file with no terminator, so the burst is frozen at the first
 //!   `about_to_wait` after at least one `DroppedFile`. A straggler
 //!   `DroppedFile` after that freeze mints a **new** defensive session, so a
 //!   pathological split burst surfaces as two complete drops, never one
-//!   truncated one.;
+//!   truncated one;
 //! - a LOST `HoveredFileCancelled` (known flaky on some X11 setups) leaves
 //!   the unfrozen session live, so the next drag's `HoveredFile` paths
 //!   accumulate into it — two distinct drags can merge into one offer with
@@ -242,7 +244,15 @@ impl WinitDataTransfer {
             if let Some(session) = state.sessions.get_mut(&window)
                 && !session.frozen
             {
-                session.paths.push(path);
+                // winit re-reports every hovered path through the
+                // `DroppedFile` arm at the actual drop, so each file of one
+                // drag arrives twice. The session tracks the drag's file
+                // SET, not the event log — an already-known path only arms
+                // the drop flag. (Linear scan: a drag's file count is
+                // small; worst case O(n²) over the burst.)
+                if !session.paths.contains(&path) {
+                    session.paths.push(path);
+                }
                 session.dropped |= dropped;
                 return None;
             }
@@ -349,9 +359,9 @@ impl DataTransferSource for WinitDataTransfer {
     fn conclude_drop(&self, id: DataTransferId) {
         // winit holds no PROTOCOL resources to release — but table
         // retirement is purely local, and the trait contract promises the
-        // offer goes stale after conclusion. Honor it here so the slice-3
-        // realm authority does not inherit a source that silently keeps
-        // concluded offers redeemable until the next mint.
+        // offer goes stale after conclusion. Honor it here so downstream
+        // consumers never see a source that silently keeps concluded
+        // offers redeemable until the next mint.
         let stale_pending = {
             let mut state = self.state.lock();
             state.table.retire(id);
@@ -501,6 +511,51 @@ mod tests {
                 TransferUri::Path(PathBuf::from("/tmp/a.txt")),
                 TransferUri::Path(PathBuf::from("/tmp/b.txt")),
             ]
+        );
+    }
+
+    #[test]
+    fn hover_then_drop_of_the_same_files_yields_each_path_once() {
+        let source = WinitDataTransfer::new();
+        let offer = entered_offer(
+            source
+                .note_hovered_file(WINDOW, PathBuf::from("/tmp/a.txt"), None)
+                .expect("mint"),
+        );
+        assert!(
+            source
+                .note_hovered_file(WINDOW, PathBuf::from("/tmp/b.txt"), None)
+                .is_none()
+        );
+        // The actual drop re-reports both hovered paths (winit's contract):
+        // they must not double up in the frozen payload.
+        assert!(
+            source
+                .note_dropped_file(WINDOW, PathBuf::from("/tmp/a.txt"), None)
+                .is_none()
+        );
+        assert!(
+            source
+                .note_dropped_file(WINDOW, PathBuf::from("/tmp/b.txt"), None)
+                .is_none()
+        );
+
+        source.freeze_completed(&HashMap::new());
+        let outcome = poll_now(source.request(
+            offer.id(),
+            RepresentationIndex(0),
+            TransferLimits::default(),
+        ));
+        let Poll::Ready(Ok(TransferPayload::UriList(uris))) = outcome else {
+            panic!("frozen offer must deliver its UriList, got {outcome:?}");
+        };
+        assert_eq!(
+            uris,
+            vec![
+                TransferUri::Path(PathBuf::from("/tmp/a.txt")),
+                TransferUri::Path(PathBuf::from("/tmp/b.txt")),
+            ],
+            "each dragged file appears exactly once despite the hover+drop double report",
         );
     }
 

--- a/crates/flui-platform/src/traits/input.rs
+++ b/crates/flui-platform/src/traits/input.rs
@@ -49,7 +49,10 @@
 // Platform-specific utilities
 // ============================================================================
 use std::collections::VecDeque;
-use std::time::Instant;
+// web-time: std::time re-export on native; performance.now()-backed on
+// wasm32, where std::time::Instant::now() panics — this module is in the
+// wasm-check set and timestamps must be mintable there.
+use web_time::Instant;
 
 use flui_foundation::DataTransferId;
 use flui_types::geometry::{Offset, PixelDelta, Pixels, Point};
@@ -363,7 +366,7 @@ pub trait TimestampProvider {
     }
 }
 
-/// Default timestamp provider using std::time::Instant
+/// Default timestamp provider using the wasm-safe monotonic clock
 #[derive(Debug)]
 pub struct SystemTimestamp;
 

--- a/crates/flui-view/src/owner/build_owner.rs
+++ b/crates/flui-view/src/owner/build_owner.rs
@@ -577,7 +577,7 @@ impl BuildOwner {
     pub fn set_tree_observer(&mut self, observer: Arc<dyn flui_foundation::observe::TreeObserver>) {
         if let Some(previous) = self.tree_observer.replace(observer) {
             tracing::debug!("tree observer replaced; notifying the outgoing observer");
-            previous.detached();
+            notify_detached(&*previous);
         }
     }
 
@@ -585,7 +585,7 @@ impl BuildOwner {
     /// Fires `detached()` on the outgoing observer. Idempotent.
     pub fn clear_tree_observer(&mut self) {
         if let Some(previous) = self.tree_observer.take() {
-            previous.detached();
+            notify_detached(&*previous);
         }
     }
 
@@ -1376,6 +1376,15 @@ pub struct BuildScopeGuard<'a> {
 impl Drop for BuildScopeGuard<'_> {
     fn drop(&mut self) {
         self.owner.building = false;
+    }
+}
+
+/// `detached()` runs third-party observer code from realm setup/teardown —
+/// the same containment that guards event emission applies here: a panic is
+/// caught and logged, never unwound through the owner.
+fn notify_detached(observer: &dyn flui_foundation::observe::TreeObserver) {
+    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| observer.detached())).is_err() {
+        tracing::error!("TreeObserver::detached() panicked; ignored");
     }
 }
 


### PR DESCRIPTION
Follow-ups for the Codex/Copilot review findings that landed on the already-merged slice-1 PRs #492 (ADR-0039), #493 (ADR-0040), and #494 (ADR-0038). Every accepted finding maps to a fix below; nothing else changed.

## Accepted findings → fixes

**#492 — owner affinity**
- **Win32: bind at construction, not at `run`** (Codex P1). `WindowsPlatform::with_config` creates the message-only HWND on the constructing thread, so the owner is decided there. `bind_current()` now runs in the constructor; the idempotent re-bind in `run` stays, so a `run` migrated to another thread trips the foreign re-bind assertion instead of silently claiming a queue it cannot service.
- **AppKit: main-thread check before the first AppKit call** (Codex P1). `MacOSPlatform::with_config` now calls `debug_assert_appkit_main_thread` at the top — before `NSApp()` — rather than relying on the SAFETY comment alone.

**#493 — tree-observation seam**
- **`detached()` panics are contained** (Codex/Copilot P2). `set_tree_observer` / `clear_tree_observer` route the outgoing observer through a `catch_unwind` helper (`notify_detached`), matching the containment already applied to event emission.
- **`InspectorCounters` end-of-stream ordering** (Codex P2). `detached()` stores with `Release`; `snapshot()` loads the flag first with `Acquire`, so a snapshot observing `is_final() == true` also observes every count the emitting thread made before the stream ended. Counters stay `Relaxed` (per-counter monotonicity only), and the struct docs now say exactly that.

**#494 — data transfer**
- **Duplicate paths in one drag** (Codex P1). winit re-reports every hovered path through the `DroppedFile` arm at the actual drop, so hover-then-drop delivered each file twice into the session's path list. `accumulate_or_begin` now treats the list as the drag's file *set*; regression test `hover_then_drop_of_the_same_files_yields_each_path_once` fails without the fix.
- **`input.rs` wasm-unsafe clock** (Copilot). `crates/flui-platform/src/traits/input.rs` used `std::time::Instant`, and `TimestampProvider::now()` calls `Instant::now()` — a panic on wasm32, the same defect class as the #483 clock sweep (which missed flui-platform). Switched to `web_time::Instant` (std re-export on native) and added the `web-time` workspace dep.
- **Module-doc drift** (Copilot). The winit approximation-ceiling list still claimed `conclude_drop` is a no-op; it retires the offer locally since the post-review fix. The bullet now says so, and the stray `one.;` punctuation is gone.

**All three — marker sweep** (Copilot/Codex). Stripped banned process markers from the slice-1 files per the AGENTS.md rule: `audit 2026-07-25 §26/U3` (observe.rs), `audit-§30` (overhead bench), and `slice 1/2` phase language across affinity.rs, the macOS/Windows platform docs, the devtools inspector, and flui-binding's Cargo.toml. Plain `ADR-00xx` pointers stay — they reference in-repo docs.

## Explicitly deferred (with rationale)
- `DataTransferOffer::find` panics via `expect` if an offer ever holds more than `u16::MAX` representations — unreachable for the winit source (always 1); revisit when native backends mint OS-supplied representation lists.
- `TransferPayload::byte_len` counts raw path bytes, not the encoded `text/uri-list` wire form — the limit check is approximate by one encoding factor; revisit with the clipboard transport where payloads stop being path lists.

## Verification
- `just ci` green (fmt-check → inventory-check → port-check → clippy → test → test-doc), plus `taplo fmt --check` and `typos`
- Cross-typecheck green for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin` (`flui-platform --features winit-backend`)
- `just wasm-check` green (covers the `web_time` switch)
- winit data-transfer unit tests: 10/10 including the new dedup regression test (local run; flui-platform is excluded from the CI test job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
