### PR TITLE
feat(widgets): add the PhysicalModel and PhysicalShape widgets

### DIFF
--- a/crates/flui-objects/src/proxy/physical_model.rs
+++ b/crates/flui-objects/src/proxy/physical_model.rs
@@ -921,13 +921,13 @@ mod tests {
     // test: `set_path_clip_target` now compares the full
     // `Option<PathClipTarget>`, not just its `is_some()` presence.
     //
-    // FLUI has no `RenderPhysicalShape`-consuming widget wired up yet (no
-    // `PhysicalShape` view exists in `flui-widgets`), so this cannot be
-    // ported at the oracle's own fidelity (`debugNeedsPaint` after a real
-    // `layout()`/`pumpFrame()`) — there is no `mark_needs_paint()` consumer
-    // of this setter's return value to observe yet. This tests the setter's
-    // own change-detection contract instead, the precondition any future
-    // widget-diff layer will rely on.
+    // The `PhysicalShape` view (`flui-widgets`) ignores this setter's
+    // returned change flag — its repaint comes from the element layer's
+    // unconditional needs-layout/paint mark after `update_render_object` —
+    // so the oracle's own observable (`debugNeedsPaint` flipped by the
+    // setter) still has no consumer to port against. This tests the
+    // setter's own change-detection contract instead, the precondition a
+    // flag-consuming diff layer would rely on.
     #[test]
     fn set_path_clip_target_detects_target_swap_not_just_presence() {
         let lane = InteractionLane::try_new().expect("lane");

--- a/crates/flui-widgets/src/lib.rs
+++ b/crates/flui-widgets/src/lib.rs
@@ -99,6 +99,7 @@ pub mod navigator;
 // resolve its intra-doc links in the crate root.)
 mod overlay;
 pub mod paint;
+pub mod physical_model;
 pub mod scroll;
 pub mod semantics;
 pub mod stack;
@@ -198,6 +199,7 @@ pub use navigator::{
 // the crate — `Navigator` and `Draggable`'s feedback layer are its callers.
 pub use overlay::{Overlay, OverlayEntry, OverlayEntryId, OverlayHandle};
 pub use paint::{ColoredBox, CustomPaint, DecoratedBox, Opacity, RepaintBoundary};
+pub use physical_model::{PhysicalModel, PhysicalShape};
 pub use scroll::{
     BouncingScrollPhysics, ClampingScrollPhysics, CustomScrollView, GridView, ListView,
     PageController, PageScrollPhysics, PageView, PageViewState, RefreshController,
@@ -304,9 +306,9 @@ pub mod prelude {
         MediaQueryData, MergeSemantics, MouseRegion, Navigator, NavigatorHandle, NextFocusAction,
         NextFocusIntent, Offstage, Opacity, OverflowBox, OverflowBoxFit, Overlay, OverlayEntry,
         OverlayEntryId, OverlayHandle, Padding, PageController, PageRoute, PageScrollPhysics,
-        PageView, PopScope, PopupRoute, Positioned, PreferredSize, PreferredSizeView,
-        PreviousFocusAction, PreviousFocusIntent, RepaintBoundary, RichText, RotatedBox, Row,
-        SafeArea, ScrollController, Scrollable, Scrollbar, Semantics, Shortcuts,
+        PageView, PhysicalModel, PhysicalShape, PopScope, PopupRoute, Positioned, PreferredSize,
+        PreferredSizeView, PreviousFocusAction, PreviousFocusIntent, RepaintBoundary, RichText,
+        RotatedBox, Row, SafeArea, ScrollController, Scrollable, Scrollbar, Semantics, Shortcuts,
         ShrinkWrappingViewport, SimpleRoute, SingleActivator, SingleChildScrollView, SizedBox,
         SizedOverflowBox, SliverChildBuilderDelegate, SliverFillRemaining,
         SliverFillRemainingAndOverscroll, SliverFillRemainingWithScrollable, SliverFillViewport,

--- a/crates/flui-widgets/src/physical_model/mod.rs
+++ b/crates/flui-widgets/src/physical_model/mod.rs
@@ -1,0 +1,11 @@
+//! Physical-layer widgets — a clipped, shadow-casting, filled surface around
+//! a single child, over `flui-objects`' `RenderPhysicalModelBase<C>` family.
+//! Layout is a pass-through; only painting is affected. [`PhysicalModel`]
+//! clips to a [`flui_types::layout::BoxShape`] (optionally rounded);
+//! [`PhysicalShape`] clips to an arbitrary user-supplied `Path`.
+
+mod physical_model;
+mod physical_shape;
+
+pub use physical_model::PhysicalModel;
+pub use physical_shape::PhysicalShape;

--- a/crates/flui-widgets/src/physical_model/physical_model.rs
+++ b/crates/flui-widgets/src/physical_model/physical_model.rs
@@ -1,0 +1,240 @@
+//! [`PhysicalModel`] — a shadow-casting, filled, `BoxShape`-clipped surface
+//! around a single child.
+
+use flui_objects::RenderPhysicalModel;
+use flui_rendering::protocol::BoxProtocol;
+use flui_types::Color;
+use flui_types::layout::BoxShape;
+use flui_types::painting::Clip;
+use flui_types::styling::BorderRadius;
+use flui_view::{Child, IntoView, RenderView, View, impl_render_view};
+
+/// A physical layer that clips its child to a [`BoxShape`] (optionally
+/// rounded via `border_radius` when the shape is
+/// [`BoxShape::Rectangle`]), casts a drop shadow at `elevation`, and fills
+/// the shape with `color`.
+///
+/// Flutter parity: `widgets/basic.dart` `PhysicalModel` (tag `3.44.0`) over
+/// [`RenderPhysicalModel`] (`RenderPhysicalModelBase<RectangleClip>`,
+/// `crates/flui-objects/src/proxy/physical_model.rs`) — the render object
+/// already implements clip + `Canvas::draw_shadow` + fill; this widget is a
+/// thin configuration wrapper over it. `create_render_object` /
+/// `update_render_object` push every field, mirroring the oracle's own
+/// `createRenderObject`/`updateRenderObject` (both `..`-cascade every
+/// property on every call).
+///
+/// `clip_behavior` defaults to [`Clip::None`] — physical-model surfaces
+/// don't clip by default (oracle `proxy_box.dart:2071`, inherited unchanged
+/// by [`RenderPhysicalModel`]'s own default).
+#[derive(Clone, Debug)]
+pub struct PhysicalModel {
+    shape: BoxShape,
+    clip_behavior: Clip,
+    border_radius: Option<BorderRadius>,
+    elevation: f32,
+    color: Color,
+    shadow_color: Color,
+    child: Child,
+}
+
+impl PhysicalModel {
+    /// A flat (`elevation: 0`), unrounded (`border_radius: None`),
+    /// rectangular, unclipped (`Clip::None`) surface filled with `color`
+    /// and an opaque-black shadow color — Flutter's
+    /// `PhysicalModel(color: color)` with every other parameter left at its
+    /// oracle default.
+    #[must_use]
+    pub fn new(color: Color) -> Self {
+        Self {
+            shape: BoxShape::Rectangle,
+            clip_behavior: Clip::None,
+            border_radius: None,
+            elevation: 0.0,
+            color,
+            shadow_color: Color::BLACK,
+            child: Child::empty(),
+        }
+    }
+
+    /// Sets the box shape (`Rectangle` or `Circle`).
+    #[must_use]
+    pub fn shape(mut self, shape: BoxShape) -> Self {
+        self.shape = shape;
+        self
+    }
+
+    /// Sets the clip behavior (anti-aliasing / save-layer policy).
+    #[must_use]
+    pub fn clip_behavior(mut self, clip_behavior: Clip) -> Self {
+        self.clip_behavior = clip_behavior;
+        self
+    }
+
+    /// Sets the corner radius. Ignored unless `shape` is
+    /// [`BoxShape::Rectangle`]. Unset behaves like `BorderRadius::ZERO`
+    /// (oracle default: `borderRadius: null`).
+    #[must_use]
+    pub fn border_radius(mut self, border_radius: BorderRadius) -> Self {
+        self.border_radius = Some(border_radius);
+        self
+    }
+
+    /// Sets the elevation. Must be non-negative — the underlying render
+    /// object debug-asserts this (oracle: `assert(elevation >= 0.0)`).
+    #[must_use]
+    pub fn elevation(mut self, elevation: f32) -> Self {
+        self.elevation = elevation;
+        self
+    }
+
+    /// Sets the fill color.
+    #[must_use]
+    pub fn color(mut self, color: Color) -> Self {
+        self.color = color;
+        self
+    }
+
+    /// Sets the drop-shadow color, used only when `elevation != 0.0`.
+    #[must_use]
+    pub fn shadow_color(mut self, shadow_color: Color) -> Self {
+        self.shadow_color = shadow_color;
+        self
+    }
+
+    /// Sets the child painted on top of the surface.
+    #[must_use]
+    pub fn child(mut self, child: impl IntoView) -> Self {
+        self.child = Child::some(child.into_view());
+        self
+    }
+}
+
+impl RenderView for PhysicalModel {
+    type Protocol = BoxProtocol;
+    type RenderObject = RenderPhysicalModel;
+
+    fn create_render_object(
+        &self,
+        _ctx: &flui_view::RenderObjectContext<'_>,
+    ) -> Self::RenderObject {
+        let mut render_object = RenderPhysicalModel::new(self.color)
+            .with_shape(self.shape)
+            .with_clip_behavior(self.clip_behavior)
+            .with_elevation(self.elevation)
+            .with_shadow_color(self.shadow_color);
+        render_object.set_border_radius(self.border_radius);
+        render_object
+    }
+
+    fn update_render_object(
+        &self,
+        _ctx: &flui_view::RenderObjectContext<'_>,
+        render_object: &mut Self::RenderObject,
+    ) {
+        render_object.set_shape(self.shape);
+        render_object.set_clip_behavior(self.clip_behavior);
+        render_object.set_border_radius(self.border_radius);
+        render_object.set_elevation(self.elevation);
+        render_object.set_color(self.color);
+        render_object.set_shadow_color(self.shadow_color);
+    }
+
+    fn has_children(&self) -> bool {
+        self.child.is_some()
+    }
+
+    fn visit_child_views(&self, visitor: &mut dyn FnMut(&dyn View)) {
+        if let Some(child) = self.child.as_ref() {
+            visitor(child);
+        }
+    }
+}
+
+impl_render_view!(PhysicalModel);
+
+#[cfg(test)]
+mod tests {
+    use flui_types::styling::BorderRadiusExt;
+    use flui_view::RenderView;
+
+    use super::*;
+    use crate::SizedBox;
+
+    fn detached() -> flui_view::RenderObjectContext<'static> {
+        flui_view::RenderObjectContext::detached()
+    }
+
+    #[test]
+    fn create_render_object_applies_oracle_defaults() {
+        let render_object = PhysicalModel::new(Color::RED).create_render_object(&detached());
+        assert_eq!(render_object.shape(), BoxShape::Rectangle);
+        assert_eq!(render_object.clip_behavior(), Clip::None);
+        assert_eq!(render_object.border_radius(), None);
+        assert_eq!(render_object.elevation(), 0.0);
+        assert_eq!(render_object.color(), Color::RED);
+        assert_eq!(render_object.shadow_color(), Color::BLACK);
+    }
+
+    #[test]
+    fn create_render_object_applies_every_configured_field() {
+        let br = BorderRadius::circular(flui_types::geometry::px(4.0));
+        let render_object = PhysicalModel::new(Color::RED)
+            .shape(BoxShape::Circle)
+            .clip_behavior(Clip::AntiAlias)
+            .border_radius(br)
+            .elevation(6.0)
+            .color(Color::BLUE)
+            .shadow_color(Color::GREEN)
+            .create_render_object(&detached());
+
+        assert_eq!(render_object.shape(), BoxShape::Circle);
+        assert_eq!(render_object.clip_behavior(), Clip::AntiAlias);
+        assert_eq!(render_object.border_radius(), Some(br));
+        assert_eq!(render_object.elevation(), 6.0);
+        assert_eq!(render_object.color(), Color::BLUE);
+        assert_eq!(render_object.shadow_color(), Color::GREEN);
+    }
+
+    #[test]
+    fn update_render_object_pushes_every_field() {
+        let mut render_object = PhysicalModel::new(Color::RED).create_render_object(&detached());
+
+        let br = BorderRadius::circular(flui_types::geometry::px(8.0));
+        PhysicalModel::new(Color::BLUE)
+            .shape(BoxShape::Circle)
+            .clip_behavior(Clip::HardEdge)
+            .border_radius(br)
+            .elevation(3.0)
+            .shadow_color(Color::GREEN)
+            .update_render_object(&detached(), &mut render_object);
+
+        assert_eq!(render_object.shape(), BoxShape::Circle);
+        assert_eq!(render_object.clip_behavior(), Clip::HardEdge);
+        assert_eq!(render_object.border_radius(), Some(br));
+        assert_eq!(render_object.elevation(), 3.0);
+        assert_eq!(render_object.color(), Color::BLUE);
+        assert_eq!(render_object.shadow_color(), Color::GREEN);
+    }
+
+    #[test]
+    fn update_render_object_clears_a_previously_set_border_radius() {
+        let br = BorderRadius::circular(flui_types::geometry::px(8.0));
+        let mut render_object = PhysicalModel::new(Color::RED)
+            .border_radius(br)
+            .create_render_object(&detached());
+        assert_eq!(render_object.border_radius(), Some(br));
+
+        PhysicalModel::new(Color::RED).update_render_object(&detached(), &mut render_object);
+        assert_eq!(render_object.border_radius(), None);
+    }
+
+    #[test]
+    fn has_children_reflects_whether_a_child_was_set() {
+        assert!(!PhysicalModel::new(Color::RED).has_children());
+        assert!(
+            PhysicalModel::new(Color::RED)
+                .child(SizedBox::shrink())
+                .has_children()
+        );
+    }
+}

--- a/crates/flui-widgets/src/physical_model/physical_shape.rs
+++ b/crates/flui-widgets/src/physical_model/physical_shape.rs
@@ -1,0 +1,276 @@
+//! [`PhysicalShape`] — a shadow-casting, filled, arbitrary-path-clipped
+//! surface around a single child.
+
+use std::rc::Rc;
+
+use flui_objects::RenderPhysicalShape;
+use flui_rendering::protocol::BoxProtocol;
+use flui_types::Color;
+use flui_types::Size;
+use flui_types::painting::{Clip, Path};
+use flui_view::{Child, IntoView, RenderView, View, impl_render_view};
+
+/// The user-supplied clip-shape function: maps the laid-out box size to the
+/// [`Path`] to clip against — Flutter's `CustomClipper<Path>` (`clipper`).
+/// Owner-local under ADR-0027; render storage receives only a data-plane
+/// target token, the same convention [`ClipPath`](crate::ClipPath) uses for
+/// its own `Fn(Size) -> Path` clipper.
+type PathClipper = Rc<dyn Fn(Size) -> Path>;
+
+/// A physical layer that clips its child to an arbitrary [`Path`] computed
+/// from the child's laid-out size, casts a drop shadow at `elevation`, and
+/// fills the shape with `color`.
+///
+/// Flutter parity: `widgets/basic.dart` `PhysicalShape` (tag `3.44.0`) over
+/// [`RenderPhysicalShape`] (`RenderPhysicalModelBase<PathClip>`,
+/// `crates/flui-objects/src/proxy/physical_model.rs`) — the render object
+/// already implements clip + `Canvas::draw_shadow` + fill; this widget is a
+/// thin configuration wrapper over it. `create_render_object` /
+/// `update_render_object` push every field, mirroring the oracle's own
+/// `createRenderObject`/`updateRenderObject` (both `..`-cascade every
+/// property on every call).
+///
+/// `clip_behavior` defaults to [`Clip::None`] — physical-model surfaces
+/// don't clip by default (oracle `proxy_box.dart:2071`, inherited unchanged
+/// by [`RenderPhysicalShape`]'s own default).
+#[derive(Clone)]
+pub struct PhysicalShape {
+    clipper: PathClipper,
+    clip_behavior: Clip,
+    elevation: f32,
+    color: Color,
+    shadow_color: Color,
+    child: Child,
+}
+
+impl PhysicalShape {
+    /// Clips to the path returned by `clipper` for the laid-out size, filled
+    /// with `color`, at Flutter's defaults: `elevation: 0`,
+    /// `clip_behavior: Clip::None`, opaque-black `shadow_color`.
+    #[must_use]
+    pub fn new(clipper: impl Fn(Size) -> Path + 'static, color: Color) -> Self {
+        Self {
+            clipper: Rc::new(clipper),
+            clip_behavior: Clip::None,
+            elevation: 0.0,
+            color,
+            shadow_color: Color::BLACK,
+            child: Child::empty(),
+        }
+    }
+
+    /// Sets the clip behavior (anti-aliasing / save-layer policy).
+    #[must_use]
+    pub fn clip_behavior(mut self, clip_behavior: Clip) -> Self {
+        self.clip_behavior = clip_behavior;
+        self
+    }
+
+    /// Sets the elevation. Must be non-negative — the underlying render
+    /// object debug-asserts this (oracle: `assert(elevation >= 0.0)`).
+    #[must_use]
+    pub fn elevation(mut self, elevation: f32) -> Self {
+        self.elevation = elevation;
+        self
+    }
+
+    /// Sets the fill color.
+    #[must_use]
+    pub fn color(mut self, color: Color) -> Self {
+        self.color = color;
+        self
+    }
+
+    /// Sets the drop-shadow color, used only when `elevation != 0.0`.
+    #[must_use]
+    pub fn shadow_color(mut self, shadow_color: Color) -> Self {
+        self.shadow_color = shadow_color;
+        self
+    }
+
+    /// Sets the child painted on top of the surface.
+    #[must_use]
+    pub fn child(mut self, child: impl IntoView) -> Self {
+        self.child = Child::some(child.into_view());
+        self
+    }
+
+    fn sync_path_clip_target(
+        &self,
+        ctx: &flui_view::RenderObjectContext<'_>,
+        render_object: &mut RenderPhysicalShape,
+    ) {
+        let clipper = Rc::clone(&self.clipper);
+        match render_object.path_clip_target() {
+            Some(target) => {
+                if let Err(error) = ctx.replace_path_clipper(target, move |size| clipper(size)) {
+                    tracing::warn!(?error, "PhysicalShape clipper replacement failed");
+                }
+            }
+            None => match ctx.register_path_clipper(move |size| clipper(size)) {
+                Ok(target) => {
+                    render_object.set_path_clip_target(Some(target));
+                }
+                Err(error) => tracing::debug!(
+                    ?error,
+                    "PhysicalShape mounted without an active interaction lane; \
+                     custom path clipper will not be resolved"
+                ),
+            },
+        }
+    }
+}
+
+impl std::fmt::Debug for PhysicalShape {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PhysicalShape")
+            .field("clip_behavior", &self.clip_behavior)
+            .field("elevation", &self.elevation)
+            .field("color", &self.color)
+            .field("shadow_color", &self.shadow_color)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RenderView for PhysicalShape {
+    type Protocol = BoxProtocol;
+    type RenderObject = RenderPhysicalShape;
+
+    fn create_render_object(&self, ctx: &flui_view::RenderObjectContext<'_>) -> Self::RenderObject {
+        let mut render_object = RenderPhysicalShape::new(self.color)
+            .with_clip_behavior(self.clip_behavior)
+            .with_elevation(self.elevation)
+            .with_shadow_color(self.shadow_color);
+        self.sync_path_clip_target(ctx, &mut render_object);
+        render_object
+    }
+
+    fn update_render_object(
+        &self,
+        ctx: &flui_view::RenderObjectContext<'_>,
+        render_object: &mut Self::RenderObject,
+    ) {
+        render_object.set_clip_behavior(self.clip_behavior);
+        render_object.set_elevation(self.elevation);
+        render_object.set_color(self.color);
+        render_object.set_shadow_color(self.shadow_color);
+        self.sync_path_clip_target(ctx, render_object);
+    }
+
+    fn did_unmount_render_object(
+        &self,
+        ctx: &flui_view::RenderObjectContext<'_>,
+        render_object: &mut Self::RenderObject,
+    ) {
+        if let Some(target) = render_object.path_clip_target() {
+            if let Err(error) = ctx.unregister_path_clipper(target) {
+                tracing::debug!(?error, "PhysicalShape clipper unregistration failed");
+            }
+            render_object.set_path_clip_target(None);
+        }
+    }
+
+    fn has_children(&self) -> bool {
+        self.child.is_some()
+    }
+
+    fn visit_child_views(&self, visitor: &mut dyn FnMut(&dyn View)) {
+        if let Some(child) = self.child.as_ref() {
+            visitor(child);
+        }
+    }
+}
+
+impl_render_view!(PhysicalShape);
+
+#[cfg(test)]
+mod tests {
+    use flui_view::RenderView;
+
+    use super::*;
+    use crate::SizedBox;
+
+    fn detached() -> flui_view::RenderObjectContext<'static> {
+        flui_view::RenderObjectContext::detached()
+    }
+
+    fn whole_box_clipper() -> impl Fn(Size) -> Path + 'static {
+        |size: Size| {
+            let mut path = Path::new();
+            path.add_rect(flui_types::Rect::from_origin_size(
+                flui_types::Point::ZERO,
+                size,
+            ));
+            path
+        }
+    }
+
+    fn physical_shape() -> PhysicalShape {
+        PhysicalShape::new(whole_box_clipper(), Color::RED)
+    }
+
+    #[test]
+    fn create_render_object_applies_oracle_defaults() {
+        let render_object = physical_shape().create_render_object(&detached());
+        assert_eq!(render_object.clip_behavior(), Clip::None);
+        assert_eq!(render_object.elevation(), 0.0);
+        assert_eq!(render_object.color(), Color::RED);
+        assert_eq!(render_object.shadow_color(), Color::BLACK);
+    }
+
+    #[test]
+    fn create_render_object_applies_every_configured_field() {
+        let render_object = physical_shape()
+            .clip_behavior(Clip::AntiAlias)
+            .elevation(6.0)
+            .color(Color::BLUE)
+            .shadow_color(Color::GREEN)
+            .create_render_object(&detached());
+
+        assert_eq!(render_object.clip_behavior(), Clip::AntiAlias);
+        assert_eq!(render_object.elevation(), 6.0);
+        assert_eq!(render_object.color(), Color::BLUE);
+        assert_eq!(render_object.shadow_color(), Color::GREEN);
+    }
+
+    #[test]
+    fn update_render_object_pushes_every_field() {
+        let mut render_object = physical_shape().create_render_object(&detached());
+
+        physical_shape()
+            .clip_behavior(Clip::HardEdge)
+            .elevation(3.0)
+            .color(Color::BLUE)
+            .shadow_color(Color::GREEN)
+            .update_render_object(&detached(), &mut render_object);
+
+        assert_eq!(render_object.clip_behavior(), Clip::HardEdge);
+        assert_eq!(render_object.elevation(), 3.0);
+        assert_eq!(render_object.color(), Color::BLUE);
+        assert_eq!(render_object.shadow_color(), Color::GREEN);
+    }
+
+    #[test]
+    fn detached_creation_does_not_install_a_path_clipper() {
+        let render_object = physical_shape().create_render_object(&detached());
+        assert!(!render_object.has_custom_clipper());
+    }
+
+    #[test]
+    fn has_children_reflects_whether_a_child_was_set() {
+        assert!(!physical_shape().has_children());
+        assert!(physical_shape().child(SizedBox::shrink()).has_children());
+    }
+
+    #[test]
+    fn debug_reports_configured_fields() {
+        let debug = format!(
+            "{:?}",
+            physical_shape().clip_behavior(Clip::None).elevation(2.0)
+        );
+        assert!(
+            debug.contains("clip_behavior: None") && debug.contains("elevation: 2.0"),
+            "Debug output must include clip_behavior and elevation, got: {debug}",
+        );
+    }
+}

--- a/crates/flui-widgets/src/physical_model/physical_shape.rs
+++ b/crates/flui-widgets/src/physical_model/physical_shape.rs
@@ -12,9 +12,10 @@ use flui_view::{Child, IntoView, RenderView, View, impl_render_view};
 
 /// The user-supplied clip-shape function: maps the laid-out box size to the
 /// [`Path`] to clip against — Flutter's `CustomClipper<Path>` (`clipper`).
-/// Owner-local under ADR-0027; render storage receives only a data-plane
-/// target token, the same convention [`ClipPath`](crate::ClipPath) uses for
-/// its own `Fn(Size) -> Path` clipper.
+/// The closure stays owner-local (UI-realm affine, never sent across
+/// threads); render storage receives only a data-plane target token — the
+/// same convention [`ClipPath`](crate::ClipPath) uses for its own
+/// `Fn(Size) -> Path` clipper.
 type PathClipper = Rc<dyn Fn(Size) -> Path>;
 
 /// A physical layer that clips its child to an arbitrary [`Path`] computed

--- a/crates/flui-widgets/tests/common/mod.rs
+++ b/crates/flui-widgets/tests/common/mod.rs
@@ -28,8 +28,8 @@ use flui_interaction::events::{
 };
 use flui_objects::{
     RenderAnimatedOpacity, RenderClipOval, RenderClipPath, RenderClipRRect, RenderClipRect,
-    RenderFittedBox, RenderImage, RenderOpacity, RenderParagraph, RenderSliverOpacity,
-    RenderTransform,
+    RenderFittedBox, RenderImage, RenderOpacity, RenderParagraph, RenderPhysicalModel,
+    RenderPhysicalShape, RenderSliverOpacity, RenderTransform,
 };
 use flui_rendering::constraints::{BoxConstraints, SliverGeometry};
 use flui_rendering::pipeline::PipelineOwner;
@@ -537,10 +537,11 @@ impl LaidOut {
     }
 
     /// The [`Clip`] behavior of a clip-family render node (`RenderClipRect`,
-    /// `RenderClipRRect`, `RenderClipOval`, `RenderClipPath`) or a
+    /// `RenderClipRRect`, `RenderClipOval`, `RenderClipPath`), a
     /// [`RenderFittedBox`] (which stores `clip_behavior` today even though
-    /// active clip-painting is still pending — see its module doc). Panics
-    /// if `id` is none of the five.
+    /// active clip-painting is still pending — see its module doc), or a
+    /// physical-model render node (`RenderPhysicalModel`,
+    /// `RenderPhysicalShape`). Panics if `id` is none of the seven.
     pub fn clip_behavior(&self, id: RenderId) -> Clip {
         let mut owner = self.pipeline_owner.write();
         let node = owner
@@ -562,8 +563,15 @@ impl LaidOut {
         if let Some(render) = node.downcast_render_object_mut::<RenderFittedBox>() {
             return render.clip_behavior();
         }
+        if let Some(render) = node.downcast_render_object_mut::<RenderPhysicalModel>() {
+            return render.clip_behavior();
+        }
+        if let Some(render) = node.downcast_render_object_mut::<RenderPhysicalShape>() {
+            return render.clip_behavior();
+        }
         panic!(
-            "render node should be a clip-family render object (Rect/RRect/Oval/Path) or a RenderFittedBox"
+            "render node should be a clip-family render object (Rect/RRect/Oval/Path), a \
+             RenderFittedBox, or a physical-model render object (Model/Shape)"
         );
     }
 

--- a/crates/flui-widgets/tests/parity/main.rs
+++ b/crates/flui-widgets/tests/parity/main.rs
@@ -173,5 +173,5 @@ mod sliver_list_correction_test;
 mod error_widget_test;
 mod sliver_opacity_test;
 
-// ── Business.1 fidelity front — PhysicalModel / PhysicalShape parity ───────
+// ── Physical-layer widgets — PhysicalModel / PhysicalShape parity ──────────
 mod physical_model_test;

--- a/crates/flui-widgets/tests/parity/main.rs
+++ b/crates/flui-widgets/tests/parity/main.rs
@@ -172,3 +172,6 @@ mod sliver_list_correction_test;
 //    override contract + the SliverOpacity 'painting & semantics' subject) ─
 mod error_widget_test;
 mod sliver_opacity_test;
+
+// ── Business.1 fidelity front — PhysicalModel / PhysicalShape parity ───────
+mod physical_model_test;

--- a/crates/flui-widgets/tests/parity/physical_model_test.rs
+++ b/crates/flui-widgets/tests/parity/physical_model_test.rs
@@ -1,0 +1,123 @@
+//! ## Test parity notes
+//!
+//! Flutter source: `packages/flutter/test/widgets/physical_model_test.dart`
+//! (tag `3.44.0`, 3 `testWidgets` cases).
+//!
+//! Widget → render-object mapping:
+//! - `PhysicalModel` → [`flui_objects::RenderPhysicalModel`]
+//!   (`RenderPhysicalModelBase<RectangleClip>`)
+//! - `PhysicalShape` → [`flui_objects::RenderPhysicalShape`]
+//!   (`RenderPhysicalModelBase<PathClip>`)
+//!   both in `crates/flui-objects/src/proxy/physical_model.rs`. The widget
+//!   wrappers live in `crates/flui-widgets/src/physical_model/`.
+//!
+//! Ported cases (2 of 3):
+//! - `'PhysicalModel updates clipBehavior in updateRenderObject'` —
+//!   [`physical_model_update_render_object_transitions_clip_behavior_to_anti_alias`].
+//! - `'PhysicalShape updates clipBehavior in updateRenderObject'` —
+//!   [`physical_shape_update_render_object_transitions_clip_behavior_to_anti_alias`].
+//!
+//! Both oracle cases assert exactly one observable — `clipBehavior` — across
+//! a `Clip.none -> Clip.antiAlias` `updateRenderObject` transition on the
+//! same live render object; the ports below assert that single observable
+//! faithfully, no more and no less (nothing else is asserted upstream to
+//! port). The remaining VALUE fields each widget's `updateRenderObject`
+//! also pushes (`shape`/`borderRadius`/`elevation`/`color`/`shadowColor`
+//! for `PhysicalModel`; `elevation`/`color`/`shadowColor` for
+//! `PhysicalShape`) are covered by the widget's own unit tests
+//! (`crates/flui-widgets/src/physical_model/physical_model.rs::tests::update_render_object_pushes_every_field`
+//! and the sibling test in `physical_shape.rs`). `PhysicalShape`'s
+//! `clipper` push is the one write those unit tests can NOT assert: they
+//! run against a detached `RenderObjectContext`, where
+//! `sync_path_clip_target` short-circuits (no owner lane), and the parity
+//! pumps exercise the registration live but assert only `clip_behavior` —
+//! the path-clip RESOLUTION itself is pinned at render level by the
+//! `harness_physical_shape_*` tests — not just the one this oracle file
+//! happens to exercise end-to-end.
+//!
+//! Out of scope (1 of 3):
+//! - `'PhysicalModel - clips when overflows and elevation is 0'` — two
+//!   independent blockers, either one alone would already exclude it:
+//!   1. The case's actual subject is a `RenderFlex` overflow: four
+//!      `PhysicalModel`-wrapped `Text` children in a `Row` with no `Expanded`
+//!      force an overflow, and the assertion is on the resulting
+//!      `FlutterError`'s diagnostics (`'A RenderFlex overflowed by '`) — a
+//!      `RenderErrorBox`-style overflow-diagnostics machinery FLUI's
+//!      `RenderFlex` (`crates/flui-objects/src/layout/flex.rs`) does not
+//!      implement at all (no overflow detection, no error diagnostics, no
+//!      analog of `RenderErrorBox`). `PhysicalModel` itself is incidental to
+//!      what's actually being tested here.
+//!   2. Even with that machinery, the case's closing assertion is
+//!      `matchesGoldenFile('physical_model_overflow.png')` — FLUI has no
+//!      golden-file harness (standing gap, cited throughout this directory,
+//!      e.g. `clip_test.rs`'s module doc).
+//!
+//! **Total: 3 oracle cases = 2 ported (both real green, full-fidelity: the
+//! sole assertion each makes) + 1 out of scope (named, both blockers cited)
+//! — no narrowing.**
+
+use flui_types::Color;
+use flui_types::Point;
+use flui_types::Rect;
+use flui_types::Size;
+use flui_types::painting::{Clip, Path};
+use flui_widgets::{PhysicalModel, PhysicalShape};
+
+use crate::harness::{pump_widget, screen};
+
+/// A whole-box rectangle clipper — `PhysicalShape::clipper`'s shape is
+/// incidental to this test (only `clipBehavior` is observed), so the
+/// simplest faithful `Fn(Size) -> Path` stands in for the oracle's
+/// `ShapeBorderClipper(shape: CircleBorder())`.
+fn whole_box_clipper(size: Size) -> Path {
+    let mut path = Path::new();
+    path.add_rect(Rect::from_origin_size(Point::ZERO, size));
+    path
+}
+
+/// `PhysicalModel`'s `clip_behavior` starts at Flutter's default
+/// (`Clip::None`), then follows the render object through a live
+/// `update_render_object` call to `Clip::AntiAlias`.
+///
+/// Flutter parity: `physical_model_test.dart` `'PhysicalModel updates
+/// clipBehavior in updateRenderObject'` (3.44.0).
+#[test]
+fn physical_model_update_render_object_transitions_clip_behavior_to_anti_alias() {
+    let mut laid = pump_widget(PhysicalModel::new(Color::BLACK), screen());
+    let id = laid.find_by_render_type("RenderPhysicalModel");
+    assert_eq!(
+        laid.clip_behavior(id),
+        Clip::None,
+        "PhysicalModel's default clip_behavior must be Clip::None"
+    );
+
+    laid.pump_widget(PhysicalModel::new(Color::BLACK).clip_behavior(Clip::AntiAlias));
+    assert_eq!(laid.clip_behavior(id), Clip::AntiAlias);
+}
+
+/// `PhysicalShape`'s `clip_behavior` starts at Flutter's default
+/// (`Clip::None`), then follows the render object through a live
+/// `update_render_object` call to `Clip::AntiAlias` — the `PhysicalShape`
+/// sibling of
+/// [`physical_model_update_render_object_transitions_clip_behavior_to_anti_alias`].
+///
+/// Flutter parity: `physical_model_test.dart` `'PhysicalShape updates
+/// clipBehavior in updateRenderObject'` (3.44.0).
+#[test]
+fn physical_shape_update_render_object_transitions_clip_behavior_to_anti_alias() {
+    let mut laid = pump_widget(
+        PhysicalShape::new(whole_box_clipper, Color::BLACK),
+        screen(),
+    );
+    let id = laid.find_by_render_type("RenderPhysicalShape");
+    assert_eq!(
+        laid.clip_behavior(id),
+        Clip::None,
+        "PhysicalShape's default clip_behavior must be Clip::None"
+    );
+
+    laid.pump_widget(
+        PhysicalShape::new(whole_box_clipper, Color::BLACK).clip_behavior(Clip::AntiAlias),
+    );
+    assert_eq!(laid.clip_behavior(id), Clip::AntiAlias);
+}

--- a/crates/flui-widgets/tests/parity/physical_model_test.rs
+++ b/crates/flui-widgets/tests/parity/physical_model_test.rs
@@ -56,12 +56,16 @@
 //! sole assertion each makes) + 1 out of scope (named, both blockers cited)
 //! — no narrowing.**
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
 use flui_types::Color;
 use flui_types::Point;
 use flui_types::Rect;
 use flui_types::Size;
+use flui_types::geometry::px;
 use flui_types::painting::{Clip, Path};
-use flui_widgets::{PhysicalModel, PhysicalShape};
+use flui_widgets::{GestureDetector, HitTestBehavior, PhysicalModel, PhysicalShape, SizedBox};
 
 use crate::harness::{pump_widget, screen};
 
@@ -120,4 +124,93 @@ fn physical_shape_update_render_object_transitions_clip_behavior_to_anti_alias()
         PhysicalShape::new(whole_box_clipper, Color::BLACK).clip_behavior(Clip::AntiAlias),
     );
     assert_eq!(laid.clip_behavior(id), Clip::AntiAlias);
+}
+
+/// FLUI-added (no oracle counterpart in `physical_model_test.dart`): the
+/// proxy layout half the two `updateRenderObject` cases never touch — a
+/// `PhysicalModel` with a child must mount the child and adopt its size
+/// (a wrapper that silently dropped or mis-parented its child would pass
+/// the childless configuration tests above).
+#[test]
+fn physical_model_lays_out_its_child_as_a_proxy() {
+    let laid = pump_widget(
+        PhysicalModel::new(Color::BLACK).child(SizedBox::new(42.0, 42.0)),
+        crate::common::loose(800.0),
+    );
+    let id = laid.find_by_render_type("RenderPhysicalModel");
+    assert_eq!(
+        laid.size(id),
+        Size::new(px(42.0), px(42.0)),
+        "PhysicalModel must adopt its child's size (proxy layout)"
+    );
+}
+
+/// FLUI-added: the `PhysicalShape` sibling of
+/// [`physical_model_lays_out_its_child_as_a_proxy`].
+#[test]
+fn physical_shape_lays_out_its_child_as_a_proxy() {
+    let laid = pump_widget(
+        PhysicalShape::new(whole_box_clipper, Color::BLACK).child(SizedBox::new(42.0, 42.0)),
+        crate::common::loose(800.0),
+    );
+    let id = laid.find_by_render_type("RenderPhysicalShape");
+    assert_eq!(
+        laid.size(id),
+        Size::new(px(42.0), px(42.0)),
+        "PhysicalShape must adopt its child's size (proxy layout)"
+    );
+}
+
+/// FLUI-added: proves the custom clipper genuinely REACHES the render
+/// object through the live owner-lane registration — a registration or
+/// replacement failure leaves `RenderPhysicalShape` on its whole-box
+/// fallback, which this test distinguishes: hit-testing honors the shape
+/// (the render object always tests its path, matching Flutter's
+/// `RenderPhysicalModelBase.hitTest`), so a tap outside the custom
+/// sub-rect must MISS while a tap inside HITS — under the fallback both
+/// taps would fire. Same pattern as `clip_test.rs`'s `'ClipPath'`
+/// hit-test ports.
+#[test]
+fn physical_shape_custom_clipper_registers_live_and_clips_hit_tests() {
+    let did_tap = Arc::new(AtomicBool::new(false));
+    let clip_evaluations = Arc::new(AtomicU32::new(0));
+    let (tap_cb, eval_cb) = (Arc::clone(&did_tap), Arc::clone(&clip_evaluations));
+
+    let laid = pump_widget(
+        PhysicalShape::new(
+            move |_size: Size| {
+                eval_cb.fetch_add(1, Ordering::SeqCst);
+                let mut path = Path::new();
+                path.add_rect(Rect::from_ltwh(px(50.0), px(50.0), px(100.0), px(100.0)));
+                path
+            },
+            Color::BLACK,
+        )
+        .child(
+            GestureDetector::new()
+                .behavior(HitTestBehavior::Opaque)
+                .on_tap(move || tap_cb.store(true, Ordering::SeqCst)),
+        ),
+        screen(),
+    );
+
+    laid.dispatch_pointer_down(10.0, 10.0);
+    laid.dispatch_pointer_up(10.0, 10.0);
+    assert!(
+        !did_tap.load(Ordering::SeqCst),
+        "a tap outside the custom clip rect (50,50,100,100) must not reach \
+         the child — firing here means the whole-box fallback is in effect \
+         and the live clipper registration silently failed"
+    );
+    assert!(
+        clip_evaluations.load(Ordering::SeqCst) > 0,
+        "hit-testing must actually evaluate the registered custom clipper"
+    );
+
+    laid.dispatch_pointer_down(100.0, 100.0);
+    laid.dispatch_pointer_up(100.0, 100.0);
+    assert!(
+        did_tap.load(Ordering::SeqCst),
+        "a tap inside the custom clip rect must reach the child"
+    );
 }


### PR DESCRIPTION
Business.1 fidelity: adds the **`PhysicalModel` and `PhysicalShape` widgets** — the render objects (`RenderPhysicalModel`/`RenderPhysicalShape`) have existed with 11 harness tests since the layer-widget round, but no widget wrapper did, leaving `physical_model_test.dart` implementation-gated. This unit unblocks that backlog item.

## The widgets
Thin single-child wrappers in `crates/flui-widgets/src/physical_model/`, mirroring Flutter's surface at tag `3.44.0` field-for-field (verified param-by-param against `widgets/basic.dart` in review):
- `PhysicalModel`: `shape` (default rectangle), `border_radius` (optional, clearing round-trips), `elevation` (default 0, non-negativity asserted by the render object — panic surface documented on the widget), `color` (required, positional), `shadow_color` (default black), `clip_behavior` (default `Clip::None`).
- `PhysicalShape`: clipper closure + required `color` positionally (the `Material` precedent — Flutter's `required this.color` forbids a color-less instance by construction), rest as above. The owner-lane path-clipper lifecycle (register at create / replace on update / unregister at unmount) is reused verbatim from `ClipPath` — this is the **second** copy; review noted a third consumer must extract a shared helper rather than paste again.
- `create_render_object`/`update_render_object` push every field, matching the Dart cascades; each widget carries an `update_render_object_pushes_every_field` unit test over the value fields (the `clipper` push is the one write those tests cannot assert — detached context, no owner lane — stated explicitly in the ledger; path-clip resolution itself is pinned by the `harness_physical_shape_*` render tests).

## The port — `physical_model_test.dart` @3.44.0 (3 cases)
1. `'PhysicalModel updates clipBehavior in updateRenderObject'` → ported green.
2. `'PhysicalShape updates clipBehavior in updateRenderObject'` → ported green.
3. `'PhysicalModel - clips when overflows and elevation is 0'` → out of scope on two independent blockers: the case's actual subject is a `RenderFlex` overflow error (FLUI's flex has no overflow-detection/error-box machinery) and it closes with `matchesGoldenFile` (no golden harness). Either alone excludes it.

Both ported cases mirror the oracle's exact `Clip.none → Clip.antiAlias` transition and read the render object's state (not widget state) via the shared `clip_behavior()` accessor, which gains the two new downcasts.

## Review
Full new-public-API bar: every param/default cross-checked against the Dart source at the tag; the PathClipTarget lifecycle diffed against `ClipPath`'s (identical except log strings); the #447 swap-detection precedent confirmed (full `Option<PathClipTarget>` equality + unconditional post-update mark makes closure swaps repaint correctly); the red-check independently re-run by the reviewer (byte-identical restore, sha-verified). Verdict NEEDS-WORK on two doc-accuracy items — an overstated coverage claim (the ledger said the unit tests assert the clipper push; they can't) and a comment in `flui-objects` made stale by this very diff — both fixed.

## Verification
- `just ci` green; `typos` + `taplo fmt --check` green
- `cargo nextest run -p flui-widgets`: 1629 passed; parity suite 505 passed, 7 skipped
- `cargo nextest run -p flui-objects --test render_object_harness`: 348/348 (catalog untouched — render objects pre-existed)
- `cargo doc -p flui-widgets --no-deps` clean
- Red-checks: dropping the `set_clip_behavior` push fails both the unit and parity tests at the exact assertion, for each widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)
