### PR TITLE
fix(objects): reject negative insets on RenderPadding and RenderSliverPadding

### DIFF
--- a/crates/flui-geometry/src/edges.rs
+++ b/crates/flui-geometry/src/edges.rs
@@ -311,12 +311,14 @@ impl Edges<super::units::Pixels> {
     /// ```
     #[must_use]
     #[inline]
-    pub fn is_non_negative(&self) -> bool {
-        use super::units::px;
-        self.left >= px(0.0)
-            && self.top >= px(0.0)
-            && self.right >= px(0.0)
-            && self.bottom >= px(0.0)
+    pub const fn is_non_negative(&self) -> bool {
+        // Compared as raw `f32` rather than through `PartialOrd` on `Pixels`,
+        // because a trait-method call is not permitted in a `const fn` — and
+        // being const lets `const fn` constructors assert this invariant.
+        self.left.get() >= 0.0
+            && self.top.get() >= 0.0
+            && self.right.get() >= 0.0
+            && self.bottom.get() >= 0.0
     }
 
     /// Clamp all edge values to be non-negative.

--- a/crates/flui-objects/src/layout/padding.rs
+++ b/crates/flui-objects/src/layout/padding.rs
@@ -31,7 +31,22 @@ pub struct RenderPadding {
 
 impl RenderPadding {
     /// Creates a new padding render object.
+    ///
+    /// # Panics
+    ///
+    /// Debug builds panic if any inset is negative. Layout deflates the
+    /// incoming constraints by these insets and then re-inflates the child's
+    /// size by them, so a negative inset would hand the child constraints
+    /// larger than its parent's and report a size that does not contain it —
+    /// the guard rejects that at the point the value enters, not later where
+    /// the geometry is already wrong. Mirrors the Dart
+    /// `assert(padding.isNonNegative)`, and like it is stripped from a release
+    /// build, where the negative inset is applied as given.
     pub fn new(padding: EdgeInsets) -> Self {
+        debug_assert!(
+            padding.is_non_negative(),
+            "RenderPadding insets must be non-negative, got {padding:?}"
+        );
         Self {
             padding,
             has_child: false,
@@ -55,7 +70,16 @@ impl RenderPadding {
     }
 
     /// Sets the padding.
+    ///
+    /// # Panics
+    ///
+    /// Debug builds panic if any inset is negative, for the reason given on
+    /// [`RenderPadding::new`].
     pub fn set_padding(&mut self, padding: EdgeInsets) {
+        debug_assert!(
+            padding.is_non_negative(),
+            "RenderPadding insets must be non-negative, got {padding:?}"
+        );
         self.padding = padding;
     }
 
@@ -247,5 +271,32 @@ mod tests {
         // symmetric(vertical=10.0, horizontal=20.0)
         assert_eq!(insets.horizontal_total(), px(40.0)); // left + right = 20.0 + 20.0
         assert_eq!(insets.vertical_total(), px(20.0)); // top + bottom = 10.0 + 10.0
+    }
+
+    #[test]
+    fn zero_padding_is_accepted() {
+        // The invariant is non-*negative*, not positive: zero on every side is
+        // the identity padding and must not trip the guard.
+        let mut p = RenderPadding::new(EdgeInsets::all(px(0.0)));
+        p.set_padding(EdgeInsets::all(px(0.0)));
+        assert_eq!(p.padding(), EdgeInsets::all(px(0.0)));
+    }
+
+    // The negative-inset guard is a `debug_assert!`, mirroring the Dart
+    // `assert(padding.isNonNegative)` that is likewise stripped from a release
+    // build — so these only have a panic to observe under `debug_assertions`.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "non-negative")]
+    fn new_rejects_a_negative_inset() {
+        let _ = RenderPadding::new(EdgeInsets::new(px(0.0), px(-1.0), px(0.0), px(0.0)));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "non-negative")]
+    fn set_padding_rejects_a_negative_inset() {
+        let mut p = RenderPadding::all(4.0);
+        p.set_padding(EdgeInsets::new(px(0.0), px(0.0), px(-3.0), px(0.0)));
     }
 }

--- a/crates/flui-objects/src/sliver/sliver_padding.rs
+++ b/crates/flui-objects/src/sliver/sliver_padding.rs
@@ -64,8 +64,24 @@ pub struct RenderSliverPadding {
 
 impl RenderSliverPadding {
     /// Creates a sliver-padding render object with the given insets.
+    ///
+    /// # Panics
+    ///
+    /// Debug builds panic if any inset is negative: the padded geometry adds
+    /// these insets to the child's scroll extent and offsets the child by the
+    /// leading one, so a negative inset would place the child ahead of its own
+    /// paint origin and shrink the sliver below the extent it actually
+    /// occupies. Mirrors the Dart `assert(padding.isNonNegative)`, and like it
+    /// is stripped from a release build.
+    ///
+    /// The message carries no inset values because a `const fn` may only panic
+    /// with a literal — formatting is not available in a const context.
     #[must_use]
     pub const fn new(padding: EdgeInsets) -> Self {
+        debug_assert!(
+            padding.is_non_negative(),
+            "RenderSliverPadding insets must be non-negative"
+        );
         Self { padding }
     }
 
@@ -94,7 +110,26 @@ impl RenderSliverPadding {
     }
 
     /// Updates the padding; returns `true` iff the value changed.
+    ///
+    /// # Panics
+    ///
+    /// Debug builds panic if any *incoming* inset is negative, for the reason
+    /// given on [`RenderSliverPadding::new`].
+    ///
+    /// **Documented divergence.** Dart's `RenderSliverPadding` setter asserts
+    /// `padding.isNonNegative` — the getter, i.e. the value already stored —
+    /// so upstream the check inspects the outgoing value and a negative one
+    /// assigned to a previously-valid object passes unnoticed. Its box
+    /// counterpart in `shifted_box.dart` asserts `value.isNonNegative`, which
+    /// is the check both were meant to be. FLUI asserts the incoming value in
+    /// both: the invariant being protected is a property of what gets stored,
+    /// and a guard that can only fire on a value it is too late to reject is
+    /// not one worth porting.
     pub fn set_padding(&mut self, padding: EdgeInsets) -> bool {
+        debug_assert!(
+            padding.is_non_negative(),
+            "RenderSliverPadding insets must be non-negative, got {padding:?}"
+        );
         if self.padding == padding {
             return false;
         }
@@ -504,6 +539,33 @@ mod tests {
         assert!(!p.set_padding(EdgeInsets::all(px(4.0)))); // no-op
         assert!(p.set_padding(EdgeInsets::all(px(5.0))));
         assert_eq!(p.padding(), EdgeInsets::all(px(5.0)));
+    }
+
+    #[test]
+    fn zero_padding_is_accepted() {
+        // The invariant is non-*negative*, not positive: zero on every side is
+        // the identity padding and must not trip the guard.
+        let mut p = RenderSliverPadding::new(EdgeInsets::all(px(0.0)));
+        assert!(p.set_padding(EdgeInsets::all(px(1.0))));
+        assert!(p.set_padding(EdgeInsets::all(px(0.0))));
+    }
+
+    // The negative-inset guard is a `debug_assert!`, mirroring the Dart
+    // `assert(padding.isNonNegative)` that is likewise stripped from a release
+    // build — so these only have a panic to observe under `debug_assertions`.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "non-negative")]
+    fn new_rejects_a_negative_inset() {
+        let _ = RenderSliverPadding::new(EdgeInsets::new(px(-1.0), px(0.0), px(0.0), px(0.0)));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "non-negative")]
+    fn set_padding_rejects_a_negative_inset() {
+        let mut p = RenderSliverPadding::all(4.0);
+        let _ = p.set_padding(EdgeInsets::new(px(0.0), px(0.0), px(0.0), px(-2.0)));
     }
 
     // ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
`RenderPadding` and `RenderSliverPadding` took `EdgeInsets` unchecked. Dart guards each of the four entry points with `assert(padding.isNonNegative)`; FLUI guarded none.

## Why a negative inset is not just "less padding"

It produces geometry that contradicts itself, and it surfaces far from the call that caused it.

- `RenderPadding` deflates the child's constraints by the insets and re-inflates the child's size by them. A negative inset hands the child constraints *looser* than its own parent's, then reports a size that does not contain the child it just laid out.
- `RenderSliverPadding` adds the insets to the child's scroll extent and offsets the child by the leading one. A negative inset places the child ahead of its own paint origin and shrinks the sliver below the extent it actually occupies.

## The change

`debug_assert!` on the incoming value at `RenderPadding::{new, set_padding}` and `RenderSliverPadding::{new, set_padding}`. The `all` / `symmetric` constructors of both types funnel through `new`, so four points cover the whole surface. Like the Dart asserts they mirror, these are stripped from a release build, where the value is applied as given.

`EdgeInsets::is_non_negative` becomes a `const fn` — not cosmetics: `RenderSliverPadding::new` is already `pub const fn`, and the guard could not go in otherwise. It compares the raw `f32` rather than going through `PartialOrd` on `Pixels`, because a trait method is not callable in a const context. The NaN verdict is unchanged (`NaN >= 0.0` is false either way), so a NaN inset now trips the guard too. The sliver `new` message carries no values because a `const fn` may only panic with a literal.

## One deliberate divergence

Verified verbatim against `flutter/flutter` tag `3.44.0`:

- `shifted_box.dart` L134 (constructor), L158 — `assert(value.isNonNegative)`
- `sliver_padding.dart` L313 (constructor), L343 — `assert(padding.isNonNegative)`

L343 asserts the *getter* — the value already stored — so upstream the sliver setter inspects the outgoing value and lets a negative incoming one through unnoticed. Its box counterpart asserts `value`. FLUI asserts the incoming value in both, documented at the call site: the invariant being protected is a property of what gets stored, and a guard that can only fire on a value it is too late to reject is not one worth porting.

## Verification

- `cargo nextest run --workspace --exclude flui-platform` — **8364 passed**, 0 failed, 15 skipped
- `cargo nextest run -p flui-objects -p flui-geometry` — 1107 passed, 1 skipped
- `cargo clippy -p flui-objects -p flui-geometry --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, `port-check` (22 triggers), `typos`, `RUSTDOCFLAGS=-D warnings cargo doc`, `cargo test --doc` — all clean
- The four `{new,set_padding}_rejects_a_negative_inset` tests failed before this change and pass after — red→green against a real guard, not a relaxed assertion. `zero_padding_is_accepted` pins that the invariant is non-*negative*, not positive.
- No existing call site in the workspace passes a negative inset: negative literals appear only in the guard tests, and the full suite confirms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)