### PR TITLE
feat(painting): add BoxDecoration.shape with BoxShape::Circle

### DIFF
--- a/crates/flui-geometry/src/rect.rs
+++ b/crates/flui-geometry/src/rect.rs
@@ -319,6 +319,27 @@ where
     pub fn size(&self) -> Size<T> {
         Size::new(self.width(), self.height())
     }
+
+    /// The lesser of the magnitudes of [`Self::width`] and
+    /// [`Self::height`] (Flutter parity: `Rect.shortestSide`,
+    /// `math.min(width.abs(), height.abs())`).
+    ///
+    /// Uses the absolute value so an inverted rectangle (`min > max` on
+    /// either axis) still yields a non-negative side length.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use flui_geometry::{Rect, px};
+    ///
+    /// let rect = Rect::from_xywh(px(0.0), px(0.0), px(200.0), px(100.0));
+    /// assert_eq!(rect.shortest_side(), px(100.0));
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn shortest_side(&self) -> T {
+        self.width().abs().min(self.height().abs())
+    }
 }
 
 impl<T: NumericUnit> Rect<T>

--- a/crates/flui-objects/tests/render_object_harness.rs
+++ b/crates/flui-objects/tests/render_object_harness.rs
@@ -3709,6 +3709,36 @@ fn harness_decorated_box_wraps_child() {
 }
 
 #[test]
+fn harness_decorated_box_circle_shape_hit_test_misses_the_corner() {
+    // BoxShape::Circle inscribes the circle in the shorter side (here: the
+    // full 100x100 square, r=50, centered at (50,50)). (4,4) is inside the
+    // 100x100 bounding rect but far outside the inscribed circle
+    // (distance from center ~= 65 > 50), so it must MISS -- there is no
+    // child to fall back to, so a hit at (4,4) means the decoration's own
+    // shape (a plain rect fallback) wrongly claimed the corner.
+    let run = RenderTester::mount(box_node(RenderDecoratedBox::new(
+        BoxDecoration::with_color(Color::RED).set_shape(BoxShape::Circle),
+    )))
+    .with_size(Size::new(px(100.0), px(100.0)))
+    .run_frame();
+
+    assert_eq!(
+        run.hit_first(4.0, 4.0),
+        None,
+        "a BoxShape::Circle decoration must not claim its corners as hits"
+    );
+
+    // Paired positive assertion: without this, `hit_test_self` returning
+    // `false` unconditionally (never testing the circle at all, just
+    // rejecting everything) would also make the corner-miss assertion
+    // above pass.
+    assert!(
+        run.hit_first(50.0, 50.0).is_some(),
+        "the center of a BoxShape::Circle decoration must still hit"
+    );
+}
+
+#[test]
 fn harness_decorated_box_hit_tests_child_before_decoration_shape() {
     // Flutter tests the child before hitTestSelf: a rounded decoration excludes
     // the rect's corners from its own shape, but a child hittable in a cut

--- a/crates/flui-painting/src/decoration.rs
+++ b/crates/flui-painting/src/decoration.rs
@@ -12,13 +12,95 @@
 //! display list, never rasterized — the same contract as the rest of
 //! the fragment paint model.
 
+use std::sync::Once;
+
 use flui_types::{
     Color, Offset, Pixels, Point, RRect, Rect,
+    geometry::Circle,
     painting::{Paint, Path, Shader},
     styling::{BoxDecoration, BoxShadow, Gradient},
 };
 
 use crate::canvas::Canvas;
+
+/// One-shot gate for the "`border_radius` ignored on `BoxShape::Circle`"
+/// warning (see `resolve_silhouette` below).
+///
+/// `resolve_silhouette` runs from `paint_box_decoration` on every frame AND
+/// from `box_decoration_hit_test` on every pointer event, so an ungated
+/// `tracing::warn!` here would spam at frame-and-input rate for any
+/// decoration that keeps a mismatched `border_radius` set across rebuilds
+/// (e.g. an `AnimatedContainer` interpolating other fields). This is a
+/// static-misconfiguration notice, not a per-event diagnostic — Flutter's
+/// own `debugAssertIsValid` only ever fires once, at construction — so a
+/// process-lifetime `Once` gate is the right frequency, matching the
+/// precedent at `flui_rendering::delegates::custom_painter::WARN_ONCE`.
+static WARN_CIRCLE_BORDER_RADIUS: Once = Once::new();
+
+/// One-shot gate for the "non-uniform border on a circle is unimplemented"
+/// warning (see `paint_circle_border` below) — same per-frame-spam
+/// rationale as [`WARN_CIRCLE_BORDER_RADIUS`].
+static WARN_CIRCLE_NON_UNIFORM_BORDER: Once = Once::new();
+
+/// One-shot gate for the "decoration image on a circle paints unclipped"
+/// warning (see the image step of `paint_box_decoration` below) — same
+/// per-frame-spam rationale as [`WARN_CIRCLE_BORDER_RADIUS`].
+static WARN_CIRCLE_IMAGE_UNCLIPPED: Once = Once::new();
+
+/// The decoration's resolved silhouette: the one shape used for the
+/// background fill, the shadow cast, the image clip, the border, and
+/// hit testing.
+///
+/// Resolved once per paint/hit-test call (`resolve_silhouette`) rather
+/// than re-derived at each of the five paint sites. Resolving once is
+/// what keeps the five sites from disagreeing about the shape, and it
+/// also means the `border_radius`-on-circle conflict is detected in one
+/// place rather than at every site that would have re-derived it (the
+/// warning itself fires at most once per process — see
+/// [`WARN_CIRCLE_BORDER_RADIUS`]).
+enum Silhouette {
+    /// `BoxShape::Rectangle`, no border radius. Carries no payload: the
+    /// plain paint rect is already in scope as the outer `rect`
+    /// parameter at every call site that matches on this variant.
+    Rect,
+    /// `BoxShape::Rectangle` with a border radius.
+    RRect(RRect),
+    /// `BoxShape::Circle`, inscribed in the rect's shorter side.
+    Circle(Circle<Pixels>),
+}
+
+/// Resolves `decoration`'s silhouette against `rect`.
+///
+/// `BoxShape::Circle` wins over `border_radius` unconditionally —
+/// Flutter treats the combination as invalid
+/// (`box_decoration.dart:134-137`'s `debugAssertIsValid`, a debug-only
+/// assert). A `debug_assert!` here would make "the circle wins in
+/// release" an untestable claim in every build profile that runs with
+/// assertions on (this crate's own test suite included), so this warns
+/// via `tracing` instead — testable in every profile — and paints the
+/// circle regardless. The warn fires at most once per process
+/// ([`WARN_CIRCLE_BORDER_RADIUS`]): this function is called from both
+/// `paint_box_decoration` (every frame) and `box_decoration_hit_test`
+/// (every pointer event), and an ungated warn would spam at that rate.
+fn resolve_silhouette(rect: Rect<Pixels>, decoration: &BoxDecoration<Pixels>) -> Silhouette {
+    if decoration.shape.is_circle() {
+        if decoration.border_radius.is_some() {
+            WARN_CIRCLE_BORDER_RADIUS.call_once(|| {
+                tracing::warn!(
+                    "BoxDecoration: `border_radius` is ignored when `shape` is \
+                     `BoxShape::Circle`; the circle wins (this warn fires once \
+                     per process)"
+                );
+            });
+        }
+        let radius = rect.shortest_side() / 2.0;
+        return Silhouette::Circle(Circle::new(rect.center(), radius));
+    }
+    match decoration_rrect(rect, decoration) {
+        Some(rrect) => Silhouette::RRect(rrect),
+        None => Silhouette::Rect,
+    }
+}
 
 /// Paints `decoration` into `rect` on `canvas` in Flutter's order:
 /// shadows, then background color/gradient, then the decoration image,
@@ -28,7 +110,7 @@ pub fn paint_box_decoration(
     rect: Rect<Pixels>,
     decoration: &BoxDecoration<Pixels>,
 ) {
-    let rrect = decoration_rrect(rect, decoration);
+    let silhouette = resolve_silhouette(rect, decoration);
 
     // 1. Shadows (behind everything). Inset shadows are an inner-glow
     //    effect drawn INSIDE the shape above the background — a
@@ -41,7 +123,11 @@ pub fn paint_box_decoration(
                 tracing::warn!(?shadow.color, "inset box shadows are not painted yet");
                 continue;
             }
-            paint_shadow(canvas, rect, rrect, shadow);
+            match &silhouette {
+                Silhouette::Circle(circle) => paint_circle_shadow(canvas, *circle, shadow),
+                Silhouette::RRect(rrect) => paint_shadow(canvas, rect, Some(*rrect), shadow),
+                Silhouette::Rect => paint_shadow(canvas, rect, None, shadow),
+            }
         }
     }
 
@@ -49,32 +135,95 @@ pub fn paint_box_decoration(
     //    "if gradient is specified, color has no effect").
     if let Some(gradient) = &decoration.gradient {
         let shader = resolve_gradient(gradient, rect);
-        match &rrect {
-            Some(rrect) => canvas.draw_gradient_rrect(*rrect, shader),
-            None => canvas.draw_gradient(rect, shader),
+        match &silhouette {
+            Silhouette::Circle(circle) => {
+                // No dedicated `DrawGradientCircle` command exists (unlike
+                // `DrawGradientRRect`); route through `draw_circle`'s
+                // existing shader-paint dispatch instead, which the wgpu
+                // backend already renders as an exact circle (`circle()`'s
+                // `paint.has_shader()` branch calls `dispatch_shader_rect`
+                // with `[radius; 4]` corners — an exact circle through the
+                // same `sdRoundedBox` identity `DrawGradientRRect` uses).
+                // The fill color is unreachable except as the fallback for
+                // a stopless shader (`dispatch_shader_rect` returning
+                // `false` when the gradient has no color stops —
+                // `Gradient::new` does not validate that, so this is
+                // reachable from safe input). `Color::TRANSPARENT` keeps
+                // that fallback consistent with the rect/rrect gradient
+                // paths: `render_gradient`/`render_gradient_rrect`
+                // early-return and paint NOTHING on an empty color list
+                // (`wgpu/backend.rs`); a solid fallback color here would
+                // make the circle the only gradient-silhouette that paints
+                // something visible from a stopless shader.
+                let paint = Paint::fill(Color::TRANSPARENT).with_shader(shader);
+                canvas.draw_circle(circle.center, circle.radius, &paint);
+            }
+            Silhouette::RRect(rrect) => canvas.draw_gradient_rrect(*rrect, shader),
+            Silhouette::Rect => canvas.draw_gradient(rect, shader),
         }
     } else if let Some(color) = decoration.color {
         let paint = Paint::fill(color);
-        match &rrect {
-            Some(rrect) => canvas.draw_rrect(*rrect, &paint),
-            None => canvas.draw_rect(rect, &paint),
+        match &silhouette {
+            Silhouette::Circle(circle) => canvas.draw_circle(circle.center, circle.radius, &paint),
+            Silhouette::RRect(rrect) => canvas.draw_rrect(*rrect, &paint),
+            Silhouette::Rect => canvas.draw_rect(rect, &paint),
         }
     }
 
     // 3. Decoration image (above the background, below the border).
+    //
+    // Flutter clips the image to the circle
+    // (`box_decoration.dart:543-551` `_paintBackgroundImage`). Clipping a
+    // circular image is UNIMPLEMENTED here — this used to route through
+    // `canvas.save()` + `clip_rrect` + `canvas.restore()` on an inscribed
+    // square, but that construction is broken two independent ways, neither
+    // fixable within this crate:
+    //
+    // 1. `Canvas::save()` (`canvas/state.rs`) records nothing in the
+    //    display list, and `restore()` only emits a `RestoreLayer` command
+    //    when the saved state came from `save_layer()` (`is_layer`, which
+    //    plain `save()` always sets to `false`). There is no plain
+    //    Save/Restore `DrawCommand` variant, so the `ClipRRect` this used
+    //    to push was never closed — it would leak onto the image AND every
+    //    following sibling command in the same `PictureLayer`.
+    // 2. Even a properly scoped clip would not clip an image: the rounded
+    //    SDF clip only reaches a draw through
+    //    `GpuStateStack::apply_active_clip`, whose only call sites are the
+    //    `RectInstance` paths in `flui-engine`'s `wgpu/batches/shapes.rs`.
+    //    `wgpu/batches/images.rs` never calls it, so an image only ever
+    //    gets the coarse bounding-box scissor — a SQUARE, not a circle.
+    //
+    // Fixing this needs either a `FragmentScope` clip route in
+    // `flui-rendering` or `apply_active_clip` support in the image batch;
+    // both are out of scope here. The image paints unclipped (a square)
+    // instead, with a one-shot warning.
     if let Some(image) = &decoration.image {
+        if matches!(&silhouette, Silhouette::Circle(_)) {
+            WARN_CIRCLE_IMAGE_UNCLIPPED.call_once(|| {
+                tracing::warn!(
+                    "BoxDecoration: a decoration image on a BoxShape::Circle is painted \
+                     unclipped (a square, not a circle); circular image clipping is not \
+                     implemented yet (this warn fires once per process)"
+                );
+            });
+        }
         paint_decoration_image(canvas, rect, image);
     }
 
     // 4. Border (on top).
     if let Some(border) = &decoration.border {
-        paint_border(canvas, rect, rrect, border);
+        match &silhouette {
+            Silhouette::Circle(circle) => paint_circle_border(canvas, *circle, border),
+            Silhouette::RRect(rrect) => paint_border(canvas, rect, Some(*rrect), border),
+            Silhouette::Rect => paint_border(canvas, rect, None, border),
+        }
     }
 }
 
-/// Hit test against the decoration's geometry: inside the rounded
-/// rect when a border radius is set, inside the plain rect otherwise
-/// (Flutter `BoxDecoration.hitTest`).
+/// Hit test against the decoration's geometry: inside the circle when
+/// `shape` is `BoxShape::Circle`, inside the rounded rect when a
+/// border radius is set, inside the plain rect otherwise (Flutter
+/// `BoxDecoration.hitTest`).
 #[must_use]
 pub fn box_decoration_hit_test(
     rect: Rect<Pixels>,
@@ -85,9 +234,10 @@ pub fn box_decoration_hit_test(
     if !rect.contains(point) {
         return false;
     }
-    match decoration_rrect(rect, decoration) {
-        Some(rrect) => rrect_contains(&rrect, point),
-        None => true,
+    match resolve_silhouette(rect, decoration) {
+        Silhouette::Circle(circle) => circle.contains(point),
+        Silhouette::RRect(rrect) => rrect_contains(&rrect, point),
+        Silhouette::Rect => true,
     }
 }
 
@@ -102,6 +252,119 @@ fn decoration_rrect(rect: Rect<Pixels>, decoration: &BoxDecoration<Pixels>) -> O
             radius.bottom_left,
         )
     })
+}
+
+/// The circle-shape shadow silhouette: the fill circle's radius
+/// inflated by the spread radius and its center displaced by the
+/// shadow offset — Flutter re-derives `rect.shortestSide / 2` from
+/// `rect.shift(offset).inflate(spread)` (`box_decoration.dart:448-462`
+/// `_paintShadows` -> `_paintBox`), which is equivalent to inflating
+/// the radius directly for a square rect. `Circle::inflate` clamps the
+/// radius at 0, so a spread large enough to invert the circle degrades
+/// to a zero-radius point rather than panicking in `Canvas::draw_shadow`.
+///
+/// **Documented divergence from Flutter:** for a spread radius large
+/// enough to invert the rect (e.g. a 100×100 rect with
+/// `spread_radius = -1000`), Flutter's re-derivation inflates the RECT
+/// first — `rect.inflate(-1000)` yields `LTRB(1000, 1000, -900, -900)` —
+/// and only then takes `shortestSide / 2` of that inverted rect, landing
+/// on radius **950** (`math.min((-900 - 1000).abs(), (-900 - 1000).abs())
+/// / 2`). FLUI instead clamps `Circle::inflate`'s radius at 0, yielding
+/// radius **0** for the same input — a deliberate choice, not a missed
+/// case: Flutter's 950-radius shadow for a -1000 spread on a 100px box is
+/// arguably the more surprising number, and FLUI's own rect/rrect shadow
+/// path (`paint_shadow` below) does not clamp its `RRect::inflate` at all,
+/// so the two silhouettes already disagree on this edge case independent
+/// of this function. Clamping the circle path does not introduce a new
+/// inconsistency; it just avoids a shadow radius nearly an order of
+/// magnitude larger than the box it decorates.
+fn paint_circle_shadow(canvas: &mut Canvas, circle: Circle<Pixels>, shadow: &BoxShadow<Pixels>) {
+    let silhouette = circle
+        .inflate(shadow.spread_radius)
+        .translate(shadow.offset.into());
+    canvas.draw_shadow(
+        &Path::circle(silhouette.center, silhouette.radius.get()),
+        shadow.color,
+        shadow.blur_radius.get(),
+    );
+}
+
+/// Paints a uniform border on a circle as a STROKED circle (Flutter
+/// `box_border.dart:346-350` `_paintUniformBorderWithCircle`,
+/// `drawCircle(center, (shortestSide + strokeOffset) / 2, side.toPaint())`),
+/// NOT `draw_drrect` on an inscribed rounded rect: `tessellate_drrect`
+/// approximates each 90-degree corner with a single quadratic Bezier,
+/// which bulges the ring outward by about 6% on the diagonals relative
+/// to `draw_circle`'s exact SDF fill, so the two shapes would visibly
+/// disagree.
+///
+/// The stroke is centered so its OUTER edge lands exactly on the fill
+/// radius, matching the inside-stroke convention `paint_border` above
+/// already uses for the rect/rrect path (a filled outer/inner pair via
+/// `draw_drrect`) rather than Flutter's `strokeAlign`, which FLUI's
+/// `BorderSide` does not thread through this call. A width *exactly* at
+/// the diameter still satisfies that invariant — the stroke centers at
+/// radius 0 and spans `±radius`, so it paints a full disc in the border
+/// color. Only a width that *exceeds* the diameter is unsatisfiable
+/// (it would need a negative stroke-center radius), and that case is
+/// skipped rather than clamped, since clamping paints a disc **outside**
+/// the fill instead of a ring inside it (see the guard below).
+///
+/// A non-uniform border on a circle is UNIMPLEMENTED. Flutter defines
+/// it for the single-visible-side case
+/// (`box_border.dart:301-343`), but that is deferred to a follow-up
+/// task; this warns (at most once per process,
+/// [`WARN_CIRCLE_NON_UNIFORM_BORDER`]) and paints nothing rather than
+/// falling through to the per-side strip painter below, which would draw
+/// a square frame around a circular fill.
+fn paint_circle_border(
+    canvas: &mut Canvas,
+    circle: Circle<Pixels>,
+    border: &flui_types::styling::Border<Pixels>,
+) {
+    if !border.is_uniform() {
+        WARN_CIRCLE_NON_UNIFORM_BORDER.call_once(|| {
+            tracing::warn!(
+                "non-uniform border on a BoxShape::Circle is not painted \
+                 (unimplemented; this warn fires once per process)"
+            );
+        });
+        return;
+    }
+    let Some(side) = border.top else {
+        return;
+    };
+    let width = side.width.get();
+    if width <= 0.0 {
+        return;
+    }
+    let diameter = circle.radius.get() * 2.0;
+    if width > diameter {
+        // Past the diameter the invariant is unsatisfiable: the stroke
+        // center would need a negative radius, and pinning it at 0 while
+        // keeping the full `width` puts the stroke's outer edge at
+        // `width / 2 > radius` -- a disc bulging OUTSIDE the fill rather
+        // than a ring inside it. Skip instead of painting that.
+        //
+        // Exactly AT the diameter is not this case and must not be folded
+        // into it: `radius - width / 2` is 0, and a stroke of width
+        // `2 * radius` centered there spans `±radius`, landing its outer
+        // edge exactly on the fill radius. That is a full disc in the
+        // border color, which is the correct rendering of a border as
+        // thick as the shape -- skipping it would silently drop the
+        // border color instead.
+        //
+        // Divergence from Flutter, deliberate: Flutter's
+        // `_paintUniformBorderWithCircle` (`box_border.dart:346-350`) has
+        // no such guard and `BorderSide` only asserts `width >= 0`, so an
+        // over-wide border there reaches `drawCircle` with a zero-or-
+        // negative radius. FLUI declines to paint rather than depend on a
+        // backend's handling of a degenerate radius.
+        return;
+    }
+    let stroke_radius = circle.radius.get() - width / 2.0;
+    let paint = Paint::stroke(side.color, width);
+    canvas.draw_circle(circle.center, Pixels(stroke_radius), &paint);
 }
 
 /// One box shadow: the casting silhouette is the decoration's shape

--- a/crates/flui-painting/src/decoration.rs
+++ b/crates/flui-painting/src/decoration.rs
@@ -48,16 +48,22 @@ static WARN_CIRCLE_NON_UNIFORM_BORDER: Once = Once::new();
 static WARN_CIRCLE_IMAGE_UNCLIPPED: Once = Once::new();
 
 /// The decoration's resolved silhouette: the one shape used for the
-/// background fill, the shadow cast, the image clip, the border, and
-/// hit testing.
+/// background fill, the shadow cast, the border, and hit testing.
+///
+/// **Not the image.** The decoration image is painted into the full
+/// rectangular destination whatever this resolves to — on a circle it
+/// only decides whether to warn, never to clip. Clipping it would need a
+/// route this layer does not have (see the image step of
+/// `paint_box_decoration`), so a circular decoration image renders as a
+/// square. Do not read this type as "the shape everything is confined
+/// to"; it is the shape the four sites listed above agree on.
 ///
 /// Resolved once per paint/hit-test call (`resolve_silhouette`) rather
-/// than re-derived at each of the five paint sites. Resolving once is
-/// what keeps the five sites from disagreeing about the shape, and it
-/// also means the `border_radius`-on-circle conflict is detected in one
-/// place rather than at every site that would have re-derived it (the
-/// warning itself fires at most once per process — see
-/// [`WARN_CIRCLE_BORDER_RADIUS`]).
+/// than re-derived at each paint site. Resolving once is what keeps
+/// those sites from disagreeing about the shape, and it also means the
+/// `border_radius`-on-circle conflict is detected in one place rather
+/// than at every site that would have re-derived it (the warning itself
+/// fires at most once per process — see [`WARN_CIRCLE_BORDER_RADIUS`]).
 enum Silhouette {
     /// `BoxShape::Rectangle`, no border radius. Carries no payload: the
     /// plain paint rect is already in scope as the outer `rect`
@@ -310,13 +316,28 @@ fn paint_circle_shadow(canvas: &mut Canvas, circle: Circle<Pixels>, shadow: &Box
 /// skipped rather than clamped, since clamping paints a disc **outside**
 /// the fill instead of a ring inside it (see the guard below).
 ///
-/// A non-uniform border on a circle is UNIMPLEMENTED. Flutter defines
-/// it for the single-visible-side case
-/// (`box_border.dart:301-343`), but that is deferred to a follow-up
-/// task; this warns (at most once per process,
-/// [`WARN_CIRCLE_NON_UNIFORM_BORDER`]) and paints nothing rather than
-/// falling through to the per-side strip painter below, which would draw
-/// a square frame around a circular fill.
+/// A non-uniform border on a circle is UNIMPLEMENTED, and the blocker is
+/// a missing primitive rather than missing work here.
+///
+/// Flutter paints a subset of these: `Border.paint` accepts a
+/// non-uniform border on a circle when exactly one distinct *visible*
+/// colour is present and no side is a hairline, and routes it to
+/// `BoxBorder.paintNonUniformBorder` (`box_border.dart`, tag `3.44.0`).
+/// That function does not walk the sides as arcs — it builds an `RRect`
+/// from the circle's bounding rect, deflates and inflates it by each
+/// side's stroke inset/outset, and emits a single `drawDRRect`. So a
+/// border visible on one side only comes out as a crescent of varying
+/// thickness, not as a constant-width arc.
+///
+/// Reproducing that here would mean a `draw_drrect` whose corners are a
+/// true circle. FLUI's tessellates each 90° corner with one quadratic
+/// Bézier, which bulges roughly 6% on the diagonals — the same reason
+/// the uniform path above strokes a circle instead of inscribing a
+/// rounded rect. Emitting it anyway would put a visibly non-circular
+/// ring around a circular fill, so this warns (at most once per process,
+/// [`WARN_CIRCLE_NON_UNIFORM_BORDER`]) and paints nothing. Falling
+/// through to the per-side strip painter below is not an option either:
+/// that draws a square frame around a circular fill.
 fn paint_circle_border(
     canvas: &mut Canvas,
     circle: Circle<Pixels>,
@@ -325,8 +346,11 @@ fn paint_circle_border(
     if !border.is_uniform() {
         WARN_CIRCLE_NON_UNIFORM_BORDER.call_once(|| {
             tracing::warn!(
-                "non-uniform border on a BoxShape::Circle is not painted \
-                 (unimplemented; this warn fires once per process)"
+                "non-uniform border on a BoxShape::Circle is not painted; \
+                 Flutter renders the single-visible-colour form of it via \
+                 drawDRRect, which needs a drrect whose corners are a true \
+                 circle -- ours approximates each corner with one quadratic \
+                 Bezier (this warn fires once per process)"
             );
         });
         return;

--- a/crates/flui-painting/tests/decoration_unit.rs
+++ b/crates/flui-painting/tests/decoration_unit.rs
@@ -10,12 +10,13 @@ use flui_painting::{
     resolve_gradient,
 };
 use flui_types::{
-    Offset, Pixels,
+    Offset, Pixels, Point,
     geometry::{Rect, px},
-    painting::Shader,
+    layout::BoxShape,
+    painting::{Image, PaintStyle, PathCommand, Shader},
     styling::{
         Border, BorderRadius, BorderRadiusExt, BorderSide, BorderStyle, BoxDecoration, BoxShadow,
-        Color, Gradient, LinearGradient,
+        Color, DecorationImage, Gradient, LinearGradient,
     },
 };
 
@@ -24,8 +25,16 @@ fn rect100() -> Rect<Pixels> {
 }
 
 fn commands(decoration: &BoxDecoration<Pixels>) -> Vec<DrawCommand> {
+    commands_in(rect100(), decoration)
+}
+
+/// Like [`commands`], but against a caller-supplied rect rather than the
+/// fixed 100x50 `rect100()` — needed for the `BoxShape::Circle` cases,
+/// which care about the rect's aspect ratio (the inscribed circle) and
+/// about non-degenerate vs. degenerate sizes.
+fn commands_in(rect: Rect<Pixels>, decoration: &BoxDecoration<Pixels>) -> Vec<DrawCommand> {
     let mut canvas = Canvas::new();
-    paint_box_decoration(&mut canvas, rect100(), decoration);
+    paint_box_decoration(&mut canvas, rect, decoration);
     canvas.finish().commands().cloned().collect()
 }
 
@@ -147,4 +156,477 @@ fn hit_test_respects_rounded_corners() {
         &decoration,
         Offset::new(px(150.0), px(25.0))
     ));
+}
+
+// ============================================================================
+// `BoxShape::Circle`
+// ============================================================================
+
+/// A square rect (100x100) so the inscribed circle has a clean radius
+/// (50) and center (50, 50).
+fn square_rect() -> Rect<Pixels> {
+    Rect::from_ltrb(px(0.0), px(0.0), px(100.0), px(100.0))
+}
+
+#[test]
+fn circle_hit_test_center_inside_boundary_and_outside() {
+    let decoration = BoxDecoration::with_color(Color::RED).set_shape(BoxShape::Circle);
+    let rect = square_rect();
+
+    // Center: inside.
+    assert!(box_decoration_hit_test(
+        rect,
+        &decoration,
+        Offset::new(px(50.0), px(50.0))
+    ));
+
+    // center + (30, 40): a 30-40-50 Pythagorean triple, so this point sits
+    // EXACTLY on the r=50 boundary. Circle::contains is inclusive (`<=`),
+    // matching Flutter's `distance <= radius`.
+    assert!(box_decoration_hit_test(
+        rect,
+        &decoration,
+        Offset::new(px(80.0), px(90.0))
+    ));
+
+    // center + (29, 40): distance = sqrt(29^2 + 40^2) ~= 49.4 < 50 -- just
+    // inside the circle.
+    assert!(box_decoration_hit_test(
+        rect,
+        &decoration,
+        Offset::new(px(79.0), px(90.0))
+    ));
+
+    // center + (31, 40): distance = sqrt(31^2 + 40^2) ~= 50.6 > 50 -- just
+    // outside the circle, but still well within the 100x100 bounding rect,
+    // so this exercises the circle branch itself, not the outer
+    // `rect.contains` guard.
+    assert!(!box_decoration_hit_test(
+        rect,
+        &decoration,
+        Offset::new(px(81.0), px(90.0))
+    ));
+}
+
+#[test]
+fn circle_inscribes_in_the_shorter_side_and_centers() {
+    // 200x100: shortest side is the height (100), so r=50, centered at
+    // (100, 50) -- NOT an ellipse fit to both dimensions.
+    let rect = Rect::from_ltrb(px(0.0), px(0.0), px(200.0), px(100.0));
+    let decoration = BoxDecoration::with_color(Color::RED).set_shape(BoxShape::Circle);
+    let cmds = commands_in(rect, &decoration);
+
+    assert_eq!(cmds.len(), 1);
+    match &cmds[0] {
+        DrawCommand::DrawCircle { center, radius, .. } => {
+            assert_eq!(*center, Point::new(px(100.0), px(50.0)));
+            assert_eq!(*radius, px(50.0));
+        }
+        other => panic!("expected DrawCircle, got {other:?}"),
+    }
+}
+
+#[test]
+fn circle_color_paints_a_circle_command_not_rect_or_rrect() {
+    let decoration = BoxDecoration::with_color(Color::RED).set_shape(BoxShape::Circle);
+    let cmds = commands(&decoration);
+    assert_eq!(cmds.len(), 1);
+    match &cmds[0] {
+        DrawCommand::DrawCircle { paint, .. } => {
+            assert_eq!(paint.color, Color::RED);
+        }
+        other => panic!("expected DrawCircle, got {other:?}"),
+    }
+}
+
+#[test]
+fn circle_gradient_paints_a_circle_carrying_the_shader_and_stops() {
+    let gradient = Gradient::Linear(LinearGradient::new(
+        flui_types::Alignment::CENTER_LEFT,
+        flui_types::Alignment::CENTER_RIGHT,
+        vec![Color::RED, Color::BLUE],
+        Some(vec![0.0, 1.0]),
+        flui_types::painting::TileMode::Clamp,
+    ));
+    // `color` is set too, to prove the gradient (not the color) wins, same
+    // as the rect-path `gradient_wins_over_color_and_resolves_alignment`.
+    let decoration = BoxDecoration::with_color(Color::WHITE)
+        .set_gradient(Some(gradient))
+        .set_shape(BoxShape::Circle);
+    let cmds = commands(&decoration);
+
+    assert_eq!(cmds.len(), 1);
+    match &cmds[0] {
+        DrawCommand::DrawCircle {
+            center,
+            radius,
+            paint,
+            ..
+        } => {
+            // rect100() is 100x50: shortest side 50, so r=25 centered at
+            // (50, 25) -- catches a shape regression the shader match below
+            // cannot.
+            assert_eq!(*center, Point::new(px(50.0), px(25.0)));
+            assert_eq!(*radius, px(25.0));
+            // The wgpu shader dispatch (`dispatch_shader_rect`) is only
+            // called when `paint.style == Fill`; a stroke paint carrying
+            // the same shader would silently never reach it, so this must
+            // be pinned alongside the shader/stops assertions below.
+            assert_eq!(paint.style, PaintStyle::Fill);
+            let shader = paint
+                .shader
+                .as_ref()
+                .expect("a gradient circle must carry a shader, not just a flat color");
+            match shader {
+                Shader::LinearGradient { colors, stops, .. } => {
+                    assert_eq!(colors, &vec![Color::RED, Color::BLUE]);
+                    assert_eq!(stops, &Some(vec![0.0, 1.0]));
+                }
+                other => panic!("expected a LinearGradient shader, got {other:?}"),
+            }
+        }
+        other => panic!("expected DrawCircle, got {other:?}"),
+    }
+}
+
+#[test]
+fn circle_gradient_without_stops_falls_back_to_transparent_like_the_rect_path() {
+    // `LinearGradient::new` does not validate `colors`; an empty list
+    // constructs fine and makes the wgpu backend's `dispatch_shader_rect`
+    // return `false` (`gradients.rs`: `stops.is_empty()`), falling through
+    // to a solid `paint.color` fill. The rect/rrect gradient paths
+    // (`render_gradient` / `render_gradient_rrect`) early-return and paint
+    // NOTHING for an empty color list, so the circle's fallback color must
+    // be `Color::TRANSPARENT` to match -- `Color::BLACK` would make the
+    // circle silently paint a solid black disc where its siblings paint
+    // nothing.
+    let gradient = Gradient::Linear(LinearGradient::new(
+        flui_types::Alignment::CENTER_LEFT,
+        flui_types::Alignment::CENTER_RIGHT,
+        vec![],
+        None,
+        flui_types::painting::TileMode::Clamp,
+    ));
+    let decoration = BoxDecoration::with_color(Color::RED) // must not show through either
+        .set_gradient(Some(gradient))
+        .set_shape(BoxShape::Circle);
+    let cmds = commands(&decoration);
+
+    assert_eq!(cmds.len(), 1);
+    match &cmds[0] {
+        DrawCommand::DrawCircle { paint, .. } => {
+            assert_eq!(paint.color, Color::TRANSPARENT);
+        }
+        other => panic!("expected DrawCircle, got {other:?}"),
+    }
+}
+
+#[test]
+fn circle_uniform_border_is_a_stroked_circle_not_a_drrect() {
+    let rect = square_rect(); // r = 50
+    let decoration = BoxDecoration::with_color(Color::WHITE)
+        .set_shape(BoxShape::Circle)
+        .set_border(Some(Border::all(BorderSide::new(
+            Color::BLACK,
+            px(4.0),
+            BorderStyle::Solid,
+        ))));
+    let cmds = commands_in(rect, &decoration);
+
+    assert_eq!(cmds.len(), 2, "background fill + stroked border");
+    assert!(
+        !cmds
+            .iter()
+            .any(|c| matches!(c, DrawCommand::DrawDRRect { .. })),
+        "a circular border must stroke a circle, not fill a drrect ring \
+         (tessellate_drrect bulges ~6% on the diagonals relative to the \
+         exact circle fill); commands: {cmds:?}"
+    );
+    match &cmds[1] {
+        DrawCommand::DrawCircle {
+            center,
+            radius,
+            paint,
+            ..
+        } => {
+            assert_eq!(*center, Point::new(px(50.0), px(50.0)));
+            // Inside-stroke convention (matching the rect/rrect
+            // draw_drrect(outer, outer.inflate(-width)) path): the
+            // stroke's OUTER edge lands on the fill radius (50), so the
+            // stroke is centered at 50 - 4/2 = 48.
+            assert_eq!(*radius, px(48.0));
+            assert_eq!(paint.style, PaintStyle::Stroke);
+            assert_eq!(paint.stroke_width, 4.0);
+            assert_eq!(paint.color, Color::BLACK);
+        }
+        other => panic!("expected a stroked DrawCircle border, got {other:?}"),
+    }
+}
+
+#[test]
+fn circle_border_exactly_at_the_diameter_still_paints_a_full_disc() {
+    let rect = square_rect(); // r = 50, diameter = 100
+
+    // A width equal to the diameter is the boundary case, and it IS
+    // satisfiable: the stroke centers at `radius - width / 2 == 0` and a
+    // stroke of width 100 there spans ±50, landing its outer edge exactly
+    // on the r=50 fill. That renders a full disc in the border color --
+    // the right answer for a border as thick as the shape. Skipping it
+    // would silently drop the border color instead.
+    let decoration = BoxDecoration::with_color(Color::WHITE)
+        .set_shape(BoxShape::Circle)
+        .set_border(Some(Border::all(BorderSide::new(
+            Color::BLACK,
+            px(100.0),
+            BorderStyle::Solid,
+        ))));
+    let cmds = commands_in(rect, &decoration);
+
+    assert_eq!(
+        cmds.len(),
+        2,
+        "background fill plus the border stroke; commands: {cmds:?}"
+    );
+    let DrawCommand::DrawCircle {
+        center,
+        radius,
+        paint,
+        ..
+    } = &cmds[1]
+    else {
+        panic!("border must be a stroked circle, got {:?}", cmds[1]);
+    };
+    assert_eq!(*center, Point::new(px(50.0), px(50.0)));
+    assert_eq!(radius.get(), 0.0, "stroke centers at radius - width / 2");
+    assert_eq!(paint.stroke_width, 100.0, "full width is retained");
+    assert_eq!(paint.color, Color::BLACK);
+}
+
+#[test]
+fn circle_border_past_the_diameter_skips_instead_of_bulging_past_the_fill() {
+    let rect = square_rect(); // r = 50, diameter = 100
+
+    // Beyond the diameter the invariant is unsatisfiable: the stroke center
+    // would need a negative radius, and pinning it at 0 while keeping the
+    // full width puts the outer edge at `width / 2 > 50` -- a disc bulging
+    // OUTSIDE the r=50 fill. Declining to paint beats painting that.
+    let decoration = BoxDecoration::with_color(Color::WHITE)
+        .set_shape(BoxShape::Circle)
+        .set_border(Some(Border::all(BorderSide::new(
+            Color::BLACK,
+            px(200.0),
+            BorderStyle::Solid,
+        ))));
+    let cmds = commands_in(rect, &decoration);
+
+    assert_eq!(
+        cmds.len(),
+        1,
+        "only the background fill, no border stroke; commands: {cmds:?}"
+    );
+    assert!(matches!(cmds[0], DrawCommand::DrawCircle { .. }));
+}
+
+#[test]
+fn circle_non_uniform_border_paints_nothing_not_a_square_frame() {
+    let rect = square_rect();
+    let decoration = BoxDecoration::with_color(Color::WHITE)
+        .set_shape(BoxShape::Circle)
+        .set_border(Some(Border {
+            top: Some(BorderSide::new(Color::RED, px(2.0), BorderStyle::Solid)),
+            right: None,
+            bottom: Some(BorderSide::new(Color::BLUE, px(4.0), BorderStyle::Solid)),
+            left: None,
+        }));
+    let cmds = commands_in(rect, &decoration);
+
+    // Background fill only -- the non-uniform border on a circle is
+    // unimplemented (warns, paints nothing) and must NOT fall through to
+    // the rect/rrect per-side strip painter, which would draw a square
+    // frame around the circular fill.
+    assert_eq!(cmds.len(), 1, "commands: {cmds:?}");
+    assert!(matches!(cmds[0], DrawCommand::DrawCircle { .. }));
+}
+
+#[test]
+fn circle_image_paints_unclipped_with_no_recorded_clip_command() {
+    // Circular image clipping is UNIMPLEMENTED (see `paint_box_decoration`'s
+    // image step): `Canvas::save()` never records anything and `restore()`
+    // only closes a `save_layer()` scope (`is_layer`), so a `ClipRRect`
+    // pushed here would never be closed -- it would leak onto the image and
+    // every later sibling command in the same `PictureLayer`. Separately,
+    // even a properly scoped `clip_rrect` would not clip an IMAGE: the
+    // rounded-SDF clip only reaches a draw through
+    // `GpuStateStack::apply_active_clip`, and the wgpu image batch never
+    // calls it (only the `RectInstance` paths in `batches/shapes.rs` do) --
+    // an image would only ever get the coarse bounding-box scissor, a
+    // SQUARE, not a circle. So the honest behavior is: no clip command
+    // recorded at all, and the image paints unclipped.
+    let rect = square_rect(); // r = 50, side = 100
+    let image = Image::from_rgba8(2, 2, vec![255; 2 * 2 * 4]);
+    let decoration =
+        BoxDecoration::with_image(DecorationImage::new(image)).set_shape(BoxShape::Circle);
+    let cmds = commands_in(rect, &decoration);
+
+    assert!(
+        !cmds.iter().any(|c| matches!(
+            c,
+            DrawCommand::ClipRect { .. }
+                | DrawCommand::ClipRRect { .. }
+                | DrawCommand::ClipRSuperellipse { .. }
+                | DrawCommand::ClipPath { .. }
+        )),
+        "a circular decoration image must not record ANY clip command until \
+         circular image clipping is actually implemented (an unbalanced \
+         save()/clip_rrect()/restore() pair would leak onto later commands, \
+         and clip_rrect does not reach the image batch anyway); commands: {cmds:?}"
+    );
+    assert!(
+        cmds.iter()
+            .any(|c| matches!(c, DrawCommand::DrawImage { .. })),
+        "the image must still be painted, unclipped; commands: {cmds:?}"
+    );
+}
+
+#[test]
+fn circle_shadow_spread_inflates_the_radius_translates_the_center_and_clamps_at_zero() {
+    let rect = square_rect(); // r = 50, center (50, 50)
+    // A non-zero offset: with `Offset::ZERO` (the previous fixture),
+    // `Circle::translate` could be deleted from `paint_circle_shadow` and
+    // this test would stay green, since the un-translated center is
+    // identical.
+    let decoration = BoxDecoration::with_color(Color::RED)
+        .set_shape(BoxShape::Circle)
+        .set_box_shadow(Some(vec![BoxShadow {
+            color: Color::BLACK,
+            offset: Offset::new(px(5.0), px(-3.0)),
+            blur_radius: px(4.0),
+            spread_radius: px(10.0),
+            inset: false,
+        }]));
+    let cmds = commands_in(rect, &decoration);
+
+    let DrawCommand::DrawShadow {
+        path, elevation, ..
+    } = &cmds[0]
+    else {
+        panic!("expected DrawShadow first (shadows paint behind everything); commands: {cmds:?}");
+    };
+    assert_eq!(
+        *elevation, 4.0,
+        "blur_radius must ride as the shadow's elevation input"
+    );
+    match path.commands() {
+        [PathCommand::AddOval(oval)] => {
+            // r + spread = 50 + 10 = 60 -> bounding square side 120,
+            // centered at (50 + 5, 50 - 3) = (55, 47) after the offset
+            // translate.
+            assert_eq!(
+                *oval,
+                Rect::from_ltrb(px(-5.0), px(-13.0), px(115.0), px(107.0))
+            );
+        }
+        other => panic!("expected a single AddOval command, got {other:?}"),
+    }
+
+    // A spread radius that would drive the radius negative clamps to 0
+    // (`Circle::inflate`'s clamp) instead of panicking in
+    // `Canvas::draw_shadow` / `Canvas::draw_circle`.
+    let inverting = BoxDecoration::with_color(Color::RED)
+        .set_shape(BoxShape::Circle)
+        .set_box_shadow(Some(vec![BoxShadow {
+            color: Color::BLACK,
+            offset: Offset::new(px(0.0), px(0.0)),
+            blur_radius: px(4.0),
+            spread_radius: px(-1000.0),
+            inset: false,
+        }]));
+    let cmds = commands_in(rect, &inverting); // must not panic
+    let DrawCommand::DrawShadow { path, .. } = &cmds[0] else {
+        panic!("expected DrawShadow first; commands: {cmds:?}");
+    };
+    match path.commands() {
+        [PathCommand::AddOval(oval)] => {
+            assert_eq!(
+                *oval,
+                Rect::from_ltrb(px(50.0), px(50.0), px(50.0), px(50.0)),
+                "radius clamped to 0: a zero-size oval centered on the circle's own center"
+            );
+        }
+        other => panic!("expected a single AddOval command, got {other:?}"),
+    }
+}
+
+#[test]
+fn circle_ignores_border_radius_and_still_paints_the_circle() {
+    let rect = square_rect();
+    let decoration = BoxDecoration::with_color(Color::RED)
+        .set_shape(BoxShape::Circle)
+        .set_border_radius(Some(BorderRadius::circular(px(20.0))));
+    let cmds = commands_in(rect, &decoration);
+
+    assert_eq!(cmds.len(), 1);
+    match &cmds[0] {
+        DrawCommand::DrawCircle { center, radius, .. } => {
+            // The plain inscribed circle (r=50, centered) -- completely
+            // unaffected by the ignored `border_radius: 20`. A variant-only
+            // check would also pass if the radius silently changed.
+            assert_eq!(*center, Point::new(px(50.0), px(50.0)));
+            assert_eq!(*radius, px(50.0));
+        }
+        other => panic!("expected DrawCircle, got {other:?}"),
+    }
+}
+
+#[test]
+fn circle_zero_size_and_negative_area_rects_do_not_panic() {
+    let decoration = BoxDecoration::with_color(Color::RED).set_shape(BoxShape::Circle);
+
+    // (rect, expected center, expected radius). Pinning the resolved
+    // geometry (not just "did not panic") is what actually exercises
+    // `shortest_side`'s `.abs()` branch -- an assertion-free version of
+    // this test would pass even if the degenerate cases silently produced
+    // a negative radius or NaN center.
+    let cases = [
+        (
+            Rect::from_ltrb(px(0.0), px(0.0), px(0.0), px(0.0)),
+            Point::new(px(0.0), px(0.0)),
+            px(0.0),
+        ),
+        (
+            // Zero height: shortest_side is 0 regardless of the 100-wide side.
+            Rect::from_ltrb(px(0.0), px(0.0), px(100.0), px(0.0)),
+            Point::new(px(50.0), px(0.0)),
+            px(0.0),
+        ),
+        (
+            // Zero width: symmetric to the above.
+            Rect::from_ltrb(px(0.0), px(0.0), px(0.0), px(100.0)),
+            Point::new(px(0.0), px(50.0)),
+            px(0.0),
+        ),
+        (
+            // Inverted (min > max on both axes): `width()`/`height()`
+            // (`max - min`) are both -100, so this is the ONLY case here
+            // that exercises `shortest_side`'s `.abs()` branch -- without
+            // it this would resolve to a negative radius instead of the
+            // r=50 an upright 100x100 rect produces.
+            Rect::from_ltrb(px(100.0), px(100.0), px(0.0), px(0.0)),
+            Point::new(px(50.0), px(50.0)),
+            px(50.0),
+        ),
+    ];
+
+    for (rect, expected_center, expected_radius) in cases {
+        let cmds = commands_in(rect, &decoration); // must not panic
+        match cmds.as_slice() {
+            [DrawCommand::DrawCircle { center, radius, .. }] => {
+                assert_eq!(*center, expected_center, "rect: {rect:?}");
+                assert_eq!(*radius, expected_radius, "rect: {rect:?}");
+            }
+            other => panic!("expected a single DrawCircle, got {other:?}; rect: {rect:?}"),
+        }
+        // Must not panic on the hit-test path either.
+        let _ = box_decoration_hit_test(rect, &decoration, Offset::new(px(0.0), px(0.0)));
+    }
 }

--- a/crates/flui-types/src/styling/decoration.rs
+++ b/crates/flui-types/src/styling/decoration.rs
@@ -172,6 +172,13 @@ pub struct BoxDecoration<T: Unit> {
     ///
     /// The shape cannot be interpolated: `lerp` switches discretely at
     /// `t == 0.5` (Flutter parity, `box_decoration.dart:209-211,314`).
+    ///
+    /// `serde(default)` is load-bearing, not decoration: this field was
+    /// added after the type was already serializable, so a payload
+    /// written without it would otherwise fail to deserialize with a
+    /// missing-field error. Deriving `Default` on [`BoxShape`] does not
+    /// give serde that behaviour on its own.
+    #[cfg_attr(feature = "serde", serde(default))]
     pub shape: BoxShape,
 }
 
@@ -405,5 +412,26 @@ mod tests {
         assert_eq!(BoxDecoration::lerp(&b, &a, 0.0).shape, BoxShape::Circle);
         assert_eq!(BoxDecoration::lerp(&b, &a, 0.5).shape, BoxShape::Rectangle);
         assert_eq!(BoxDecoration::lerp(&b, &a, 1.0).shape, BoxShape::Rectangle);
+    }
+
+    /// A payload written before `shape` existed must still load, as the
+    /// rectangle it was. Without `serde(default)` on the field, serde
+    /// rejects it outright — `BoxShape: Default` does not reach the
+    /// derive on its own.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn a_decoration_serialized_before_shape_existed_still_deserializes() {
+        let legacy = r#"{
+            "color": null,
+            "image": null,
+            "border": null,
+            "border_radius": null,
+            "box_shadow": null,
+            "gradient": null
+        }"#;
+
+        let decoration: BoxDecoration<crate::geometry::Pixels> =
+            serde_json::from_str(legacy).expect("a pre-shape payload must still deserialize");
+        assert_eq!(decoration.shape, BoxShape::Rectangle);
     }
 }

--- a/crates/flui-types/src/styling/decoration.rs
+++ b/crates/flui-types/src/styling/decoration.rs
@@ -4,7 +4,7 @@
 pub use crate::painting::{BlendMode, BoxFit, ColorFilter, ImageRepeat};
 use crate::{
     geometry::traits::{NumericUnit, Unit},
-    layout::Alignment,
+    layout::{Alignment, BoxShape},
     painting::Image,
     styling::{Border, BorderRadius, BorderRadiusExt, BoxShadow, Color, Gradient},
 };
@@ -159,6 +159,20 @@ pub struct BoxDecoration<T: Unit> {
     ///
     /// If this is specified, `color` has no effect.
     pub gradient: Option<Gradient>,
+
+    /// The shape to fill the background, gradient, and image into, and
+    /// to cast as the box shadow.
+    ///
+    /// If this is [`BoxShape::Circle`], `border_radius` is ignored (a
+    /// warning is logged — at most once per process, since resolving the
+    /// silhouette runs on every paint and every hit test — rather than
+    /// asserting, so the fallback is observable in every build profile).
+    /// The circle is inscribed in the shorter of the paint rect's two
+    /// sides.
+    ///
+    /// The shape cannot be interpolated: `lerp` switches discretely at
+    /// `t == 0.5` (Flutter parity, `box_decoration.dart:209-211,314`).
+    pub shape: BoxShape,
 }
 
 impl<T: Unit> BoxDecoration<T> {
@@ -172,6 +186,7 @@ impl<T: Unit> BoxDecoration<T> {
             border_radius: None,
             box_shadow: None,
             gradient: None,
+            shape: BoxShape::Rectangle,
         }
     }
 
@@ -185,6 +200,7 @@ impl<T: Unit> BoxDecoration<T> {
             border_radius: None,
             box_shadow: None,
             gradient: None,
+            shape: BoxShape::Rectangle,
         }
     }
 
@@ -198,6 +214,7 @@ impl<T: Unit> BoxDecoration<T> {
             border_radius: None,
             box_shadow: None,
             gradient: Some(gradient),
+            shape: BoxShape::Rectangle,
         }
     }
 
@@ -211,6 +228,7 @@ impl<T: Unit> BoxDecoration<T> {
             border_radius: None,
             box_shadow: None,
             gradient: None,
+            shape: BoxShape::Rectangle,
         }
     }
 
@@ -246,6 +264,13 @@ impl<T: Unit> BoxDecoration<T> {
     #[inline]
     pub fn set_gradient(mut self, gradient: Option<Gradient>) -> Self {
         self.gradient = gradient;
+        self
+    }
+
+    /// Creates a copy of this decoration with the given shape.
+    #[inline]
+    pub const fn set_shape(mut self, shape: BoxShape) -> Self {
+        self.shape = shape;
         self
     }
 }
@@ -306,6 +331,10 @@ where
             b.image.clone()
         };
 
+        // Not interpolatable (Flutter parity, box_decoration.dart:209-211):
+        // discrete switch at the midpoint, same as the image crossfade above.
+        let shape = if t < 0.5 { a.shape } else { b.shape };
+
         Self {
             color,
             image,
@@ -313,6 +342,7 @@ where
             border_radius,
             box_shadow,
             gradient,
+            shape,
         }
     }
 }
@@ -336,5 +366,44 @@ where
     #[inline]
     fn lerp_decoration(a: &Self, b: &Self, t: f32) -> Option<Self> {
         Some(BoxDecoration::lerp(a, b, t))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geometry::Pixels;
+
+    /// `BoxDecoration::lerp`'s `shape` field is NOT interpolated (Flutter
+    /// parity, `box_decoration.dart:209-211,314`): it switches discretely
+    /// at the midpoint (`shape = if t < 0.5 { a.shape } else { b.shape }`
+    /// above). This branch had zero coverage before -- it could regress to
+    /// always picking `a`, always picking `b`, or an actual interpolation
+    /// without any test failing.
+    #[test]
+    fn lerp_shape_switches_discretely_at_the_midpoint() {
+        let a = BoxDecoration::<Pixels>::new().set_shape(BoxShape::Rectangle);
+        let b = BoxDecoration::<Pixels>::new().set_shape(BoxShape::Circle);
+
+        // t < 0.5: `a`'s shape.
+        assert_eq!(BoxDecoration::lerp(&a, &b, 0.0).shape, BoxShape::Rectangle);
+        assert_eq!(BoxDecoration::lerp(&a, &b, 0.25).shape, BoxShape::Rectangle);
+        assert_eq!(
+            BoxDecoration::lerp(&a, &b, 0.499).shape,
+            BoxShape::Rectangle
+        );
+
+        // t == 0.5 exactly: the switch already happened (`t < 0.5` is
+        // false at 0.5), so this lands on `b`'s shape, not `a`'s.
+        assert_eq!(BoxDecoration::lerp(&a, &b, 0.5).shape, BoxShape::Circle);
+
+        // t > 0.5: `b`'s shape.
+        assert_eq!(BoxDecoration::lerp(&a, &b, 0.75).shape, BoxShape::Circle);
+        assert_eq!(BoxDecoration::lerp(&a, &b, 1.0).shape, BoxShape::Circle);
+
+        // And the reverse direction, to catch an accidental `a`/`b` swap.
+        assert_eq!(BoxDecoration::lerp(&b, &a, 0.0).shape, BoxShape::Circle);
+        assert_eq!(BoxDecoration::lerp(&b, &a, 0.5).shape, BoxShape::Rectangle);
+        assert_eq!(BoxDecoration::lerp(&b, &a, 1.0).shape, BoxShape::Rectangle);
     }
 }


### PR DESCRIPTION
Flutter's `BoxDecoration.shape` had no analog here: `BoxShape` existed in flui-types but nothing consumed it, so `shape: circle` was inexpressible and a circular decoration hit-tested as its full bounding rectangle.

Adds the field — defaulting to `Rectangle`, so every existing call site is unaffected — and a resolved silhouette that the shadow, fill, gradient, image and border steps all branch on, rather than each re-deriving the shape. The rect/rrect paths are left byte-for-byte intact.

## Circle specifics, and why each primitive was chosen

- **Hit-test** inscribes the circle in the shorter side and compares squared distance, matching Flutter's `distance <= shortestSide / 2`.
- **Gradient** rides `Paint::shader` into `draw_circle`. The wgpu circle shim already dispatches a shader fill through an SDF that reduces to `length(p) - r`, so this is an exact circle with no engine change.
- **Uniform border** is a *stroked* circle, not `draw_drrect` on an inscribed rounded rect: drrect tessellation approximates each 90° corner with a single quadratic Bézier, which bulges roughly 6% on the diagonals and would leave the ring not matching the fill.
- **`lerp`** switches shape discretely at `t = 0.5`; shape is not an interpolatable property.
- **`border_radius` combined with a circle** warns once and the circle wins, rather than asserting, so the fallback is observable in every profile.

## Two documented divergences from Flutter

- A shadow spread that would invert the circle clamps the radius at 0. Flutter re-derives from the inverted rect and lands on a radius far larger than the box.
- A border wider than the diameter declines to paint. Flutter hands a negative radius to `drawCircle`.

## Two gaps declared rather than faked

Both warn-gated, neither papered over:

- A non-uniform border on a circle paints nothing.
- A circular decoration image is painted unclipped. This one cannot be fixed at this layer: `Canvas::save`/`restore` emit no display-list command, so a raw canvas clip leaks onto the child and later siblings, and the rounded-rect SDF clip never reaches image batches.

## Verification

Re-verified on current `main` after rebase:

- `cargo nextest run --workspace --exclude flui-platform` — **8358 passed**, 0 failed, 15 skipped
- `cargo nextest run -p flui-painting -p flui-types -p flui-geometry -p flui-objects` — 1952 passed, 5 skipped
- `cargo clippy` on those four crates, `--all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check`, `port-check` (22 triggers), `typos` — clean
- `RUSTDOCFLAGS=-D warnings cargo doc`, `cargo test --doc -p flui-painting -p flui-types` (120 passed) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)