### PR TITLE
feat(types)!: close BoxDecoration to struct-literal construction

### DIFF
--- a/crates/flui-cupertino/src/button.rs
+++ b/crates/flui-cupertino/src/button.rs
@@ -553,14 +553,12 @@ impl ViewState<CupertinoButton> for CupertinoButtonState {
             Some(_) if !enabled => Some(view.disabled_color.resolve(ctx)),
             other => other,
         };
-        let decoration = BoxDecoration::<Pixels> {
-            color: fill_color,
-            border_radius: Some(
+        let decoration = BoxDecoration::<Pixels>::new()
+            .set_color(fill_color)
+            .set_border_radius(Some(
                 view.border_radius
                     .unwrap_or_else(|| size_border_radius(view.size_style)),
-            ),
-            ..BoxDecoration::new()
-        };
+            ));
 
         // An explicit `minimum_size` (including `(0.0, 0.0)`, which
         // genuinely removes the floor) passes straight through unmodified —

--- a/crates/flui-types/src/styling/decoration.rs
+++ b/crates/flui-types/src/styling/decoration.rs
@@ -117,6 +117,16 @@ pub trait Decoration: std::fmt::Debug {
 ///
 /// Generic over unit type `T` for full type safety.
 ///
+/// # Construction
+///
+/// This type is `#[non_exhaustive]`: build it with [`BoxDecoration::new`] (or
+/// one of the `with_*` constructors) and the `set_*` chain, never with a
+/// struct literal. Flutter's `BoxDecoration` has grown fields steadily —
+/// `shape`, `backgroundBlendMode`, `image` all arrived after the type
+/// existed — and each one would otherwise be a source-breaking change for
+/// every caller that spelled out the braces. Closing the literal now costs
+/// two call sites; leaving it open costs every future field.
+///
 /// # Examples
 ///
 /// ```
@@ -139,6 +149,7 @@ pub trait Decoration: std::fmt::Debug {
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub struct BoxDecoration<T: Unit> {
     /// The color to fill the box with.
     pub color: Option<Color>,

--- a/crates/flui-types/src/styling/decoration.rs
+++ b/crates/flui-types/src/styling/decoration.rs
@@ -124,8 +124,8 @@ pub trait Decoration: std::fmt::Debug {
 /// struct literal. Flutter's `BoxDecoration` has grown fields steadily —
 /// `shape`, `backgroundBlendMode`, `image` all arrived after the type
 /// existed — and each one would otherwise be a source-breaking change for
-/// every caller that spelled out the braces. Closing the literal now costs
-/// two call sites; leaving it open costs every future field.
+/// every caller that spelled out the braces. Keeping construction on the
+/// constructors is what lets a new field be additive.
 ///
 /// # Examples
 ///

--- a/crates/flui-types/tests/compile_fail/box_decoration_struct_literal.rs
+++ b/crates/flui-types/tests/compile_fail/box_decoration_struct_literal.rs
@@ -1,0 +1,29 @@
+//! Compile-fail test: `BoxDecoration` is `#[non_exhaustive]`, so a downstream
+//! crate cannot construct it with a struct literal.
+//!
+//! This is what lets the type grow a field without breaking callers — the
+//! reason `shape` was a source-breaking change before the attribute landed.
+//! The functional-update form (`..Default::default()`) is rejected too, which
+//! is the part that is easy to assume still works.
+
+use flui_types::geometry::Pixels;
+use flui_types::styling::{BoxDecoration, Color};
+
+fn main() {
+    // Spelling out every field: rejected outright.
+    let _explicit = BoxDecoration::<Pixels> {
+        color: Some(Color::RED),
+        image: None,
+        border: None,
+        border_radius: None,
+        box_shadow: None,
+        gradient: None,
+        shape: Default::default(),
+    };
+
+    // Functional update from a legally-built value: also rejected.
+    let _updated = BoxDecoration::<Pixels> {
+        color: Some(Color::RED),
+        ..BoxDecoration::new()
+    };
+}

--- a/crates/flui-types/tests/compile_fail/box_decoration_struct_literal.rs
+++ b/crates/flui-types/tests/compile_fail/box_decoration_struct_literal.rs
@@ -3,8 +3,9 @@
 //!
 //! This is what lets the type grow a field without breaking callers — the
 //! reason `shape` was a source-breaking change before the attribute landed.
-//! The functional-update form (`..Default::default()`) is rejected too, which
-//! is the part that is easy to assume still works.
+//! The functional-update form (`..BoxDecoration::new()` below, and equally
+//! `..Default::default()`) is rejected too, which is the part that is easy to
+//! assume still works.
 
 use flui_types::geometry::Pixels;
 use flui_types::styling::{BoxDecoration, Color};

--- a/crates/flui-types/tests/compile_fail/box_decoration_struct_literal.stderr
+++ b/crates/flui-types/tests/compile_fail/box_decoration_struct_literal.stderr
@@ -1,0 +1,22 @@
+error[E0639]: cannot create non-exhaustive struct using struct expression
+  --> tests/compile_fail/box_decoration_struct_literal.rs:14:21
+   |
+14 |       let _explicit = BoxDecoration::<Pixels> {
+   |  _____________________^
+15 | |         color: Some(Color::RED),
+16 | |         image: None,
+17 | |         border: None,
+...  |
+21 | |         shape: Default::default(),
+22 | |     };
+   | |_____^
+
+error[E0639]: cannot create non-exhaustive struct using struct expression
+  --> tests/compile_fail/box_decoration_struct_literal.rs:25:20
+   |
+25 |       let _updated = BoxDecoration::<Pixels> {
+   |  ____________________^
+26 | |         color: Some(Color::RED),
+27 | |         ..BoxDecoration::new()
+28 | |     };
+   | |_____^

--- a/crates/flui-types/tests/compile_fail/box_decoration_struct_literal.stderr
+++ b/crates/flui-types/tests/compile_fail/box_decoration_struct_literal.stderr
@@ -1,22 +1,22 @@
 error[E0639]: cannot create non-exhaustive struct using struct expression
-  --> tests/compile_fail/box_decoration_struct_literal.rs:14:21
+  --> tests/compile_fail/box_decoration_struct_literal.rs:15:21
    |
-14 |       let _explicit = BoxDecoration::<Pixels> {
+15 |       let _explicit = BoxDecoration::<Pixels> {
    |  _____________________^
-15 | |         color: Some(Color::RED),
-16 | |         image: None,
-17 | |         border: None,
+16 | |         color: Some(Color::RED),
+17 | |         image: None,
+18 | |         border: None,
 ...  |
-21 | |         shape: Default::default(),
-22 | |     };
+22 | |         shape: Default::default(),
+23 | |     };
    | |_____^
 
 error[E0639]: cannot create non-exhaustive struct using struct expression
-  --> tests/compile_fail/box_decoration_struct_literal.rs:25:20
+  --> tests/compile_fail/box_decoration_struct_literal.rs:26:20
    |
-25 |       let _updated = BoxDecoration::<Pixels> {
+26 |       let _updated = BoxDecoration::<Pixels> {
    |  ____________________^
-26 | |         color: Some(Color::RED),
-27 | |         ..BoxDecoration::new()
-28 | |     };
+27 | |         color: Some(Color::RED),
+28 | |         ..BoxDecoration::new()
+29 | |     };
    | |_____^

--- a/crates/flui-widgets/tests/parity/grid_view_interaction_test.rs
+++ b/crates/flui-widgets/tests/parity/grid_view_interaction_test.rs
@@ -966,10 +966,7 @@ fn grid_view_one_line_paints_only_onstage_tiles() {
     let green = Color::rgb(0, 255, 0);
     let make_tile = || {
         Container::new()
-            .decoration(BoxDecoration {
-                color: Some(green),
-                ..Default::default()
-            })
+            .decoration(BoxDecoration::with_color(green))
             .boxed()
     };
     let children: Vec<BoxedView> = vec![make_tile(), make_tile(), make_tile(), make_tile()];


### PR DESCRIPTION
Follow-up to the review of #509, where Copilot pointed out that adding `shape` as a `pub` field was a source-breaking change for anyone constructing `BoxDecoration` with a struct literal. It was — and it will not be the last field. Flutter's own `BoxDecoration` grew `shape`, `backgroundBlendMode` and `image` after the type existed.

**BREAKING CHANGE:** `BoxDecoration` is now `#[non_exhaustive]`. Outside `flui-types`, build it with `new()` / `with_*` and the `set_*` chain. Struct literals no longer compile — and neither does the functional-update form, which is the part that looks like it should still work:

```rust
// both rejected from another crate, E0639
let d = BoxDecoration::<Pixels> { color: Some(RED), image: None, /* ... */ };
let d = BoxDecoration::<Pixels> { color: Some(RED), ..BoxDecoration::new() };
```

Closing the literal costs two call sites today and nothing per field afterwards; leaving it open charges every future field to every consumer. That trade only gets worse, which is why it is worth doing before the crate has external users — the Prime Directive's "breaking changes are cheap today and ossify once consumers exist".

## Call sites moved

- `flui-cupertino`'s button — fill colour + border radius, now a `new().set_color().set_border_radius()` chain.
- A `flui-widgets` GridView parity test — a coloured tile, which collapses to `BoxDecoration::with_color(green)`.

Both were using `..Default::default()` / `..BoxDecoration::new()`, so both would have broken; converting them is the proof that the attribute bites across a crate boundary.

## Pinned by a test, not by prose

A trybuild compile-fail case covers both rejected forms and their `E0639` diagnostics. Removing `#[non_exhaustive]` fails it — `1 of 4 tests failed` — so the case pins the guarantee rather than the spelling of the attribute.

## Verification

- `cargo nextest run --workspace --exclude flui-platform` — **8368 passed**, 0 failed, 15 skipped
- `cargo nextest run -p flui-types --features serde` — 645 passed (the trybuild suite included)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check`, `port-check` (22 triggers), `typos`, `cargo test --doc -p flui-types` (118 passed) — clean
- `cargo check --workspace --all-targets` after the conversion — clean, which is what confirms no third call site was missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)