### PR TITLE
feat(painting)!: record Save/Restore so a clip can be undone

### DIFF
--- a/crates/flui-engine/src/commands.rs
+++ b/crates/flui-engine/src/commands.rs
@@ -337,6 +337,12 @@ pub fn dispatch_command<R: CommandRenderer + ?Sized>(command: &DrawCommand, rend
         DrawCommand::RestoreLayer { transform } => {
             renderer.restore_layer(transform);
         }
+        DrawCommand::Save { .. } => {
+            renderer.save_state();
+        }
+        DrawCommand::Restore { .. } => {
+            renderer.restore_state();
+        }
         // `DrawCommand` is `#[non_exhaustive]` so downstream crates
         // (this one) must handle the open-set shape. When a new
         // variant lands in flui-painting before flui-engine grows the

--- a/crates/flui-engine/src/traits.rs
+++ b/crates/flui-engine/src/traits.rs
@@ -344,6 +344,22 @@ pub trait CommandRenderer {
     /// Restore canvas state and composite the saved layer
     fn restore_layer(&mut self, transform: &Matrix4);
 
+    // ===== Plain State Scope =====
+
+    /// Push the current transform + clip state.
+    ///
+    /// The plain-state sibling of [`Self::save_layer`]: no offscreen target,
+    /// no compositing. A backend that narrows its clip on `clip_*` needs this
+    /// marker to know which narrowings to undo, and [`Self::restore_state`] to
+    /// undo them.
+    fn save_state(&mut self);
+
+    /// Pop the state pushed by the matching [`Self::save_state`].
+    ///
+    /// Unbalanced pops are a recording bug, not a rendering one — a backend
+    /// should report and ignore rather than corrupt its stack.
+    fn restore_state(&mut self);
+
     // ===== Performance Overlay =====
 
     /// Add a performance overlay to the scene

--- a/crates/flui-engine/src/wgpu/backend.rs
+++ b/crates/flui-engine/src/wgpu/backend.rs
@@ -1330,10 +1330,22 @@ impl CommandRenderer for Backend<'_> {
     }
 
     fn save_state(&mut self) {
+        // Both of these push/pop the SAME painter stack the lazy
+        // `active_transform` save uses, so the deferred save has to be settled
+        // before the scope moves the stack under it. Otherwise a later
+        // `flush_active_transform` pops whichever save happens to be on top —
+        // the scope's, not its own — and the absolute matrix lands on the wrong
+        // CTM while the scope silently never closes.
+        self.flush_active_transform();
         self.painter.save();
     }
 
     fn restore_state(&mut self) {
+        // Symmetric, and the ordering matters in the other direction: the lazy
+        // save was pushed *inside* this scope, so it must come off first or the
+        // pop below takes it and leaves `active_transform` pointing at a save
+        // that is already gone.
+        self.flush_active_transform();
         self.painter.restore();
     }
 

--- a/crates/flui-engine/src/wgpu/backend.rs
+++ b/crates/flui-engine/src/wgpu/backend.rs
@@ -1329,6 +1329,14 @@ impl CommandRenderer for Backend<'_> {
         self.painter.restore_layer();
     }
 
+    fn save_state(&mut self) {
+        self.painter.save();
+    }
+
+    fn restore_state(&mut self) {
+        self.painter.restore();
+    }
+
     // ===== Layer Tree Operations split out =====
     //
     // push_clip_* / push_offset / push_transform / push_opacity /

--- a/crates/flui-engine/src/wgpu/debug.rs
+++ b/crates/flui-engine/src/wgpu/debug.rs
@@ -368,6 +368,14 @@ impl CommandRenderer for DebugBackend {
         self.log_command("restore_layer", "");
     }
 
+    fn save_state(&mut self) {
+        self.log_command("save_state", "");
+    }
+
+    fn restore_state(&mut self) {
+        self.log_command("restore_state", "");
+    }
+
     // The layer-tree push/pop methods live in
     // `impl LayerStateStack for DebugBackend` below, not here — see the
     // `LayerStateStack` trait doc comment in `traits.rs` for why they are

--- a/crates/flui-engine/src/wgpu/layer_render.rs
+++ b/crates/flui-engine/src/wgpu/layer_render.rs
@@ -714,6 +714,14 @@ mod tests {
             self.calls.push("restore_layer".to_string());
         }
 
+        fn save_state(&mut self) {
+            self.calls.push("save_state".to_string());
+        }
+
+        fn restore_state(&mut self) {
+            self.calls.push("restore_state".to_string());
+        }
+
         // The push/pop methods live in `impl LayerStateStack` below, not here.
 
         // ===== Performance Overlay (recorded) =====

--- a/crates/flui-painting/src/canvas/state.rs
+++ b/crates/flui-painting/src/canvas/state.rs
@@ -70,6 +70,13 @@ impl Canvas {
             clip_depth: self.clip_stack.len(),
             is_layer: false,
         });
+        // The backend needs the scope marker too, not just this stack: a clip
+        // recorded after this point narrows the backend's state, and only a
+        // matching `Restore` tells it when to stop. Without the pair, the
+        // clip_stack below would unwind on the CPU while the GPU kept clipping.
+        self.display_list.push(DrawCommand::Save {
+            transform: self.transform,
+        });
     }
 
     /// Restores the most recently saved state.
@@ -83,8 +90,16 @@ impl Canvas {
     #[inline]
     pub fn restore(&mut self) {
         if let Some(state) = self.save_stack.pop() {
+            // Exactly one closing command per opening one: `save_layer`
+            // recorded a `SaveLayer` and is closed by `RestoreLayer`, which
+            // composites the offscreen target and unwinds its own state; a
+            // plain `save` recorded a `Save` and is closed by `Restore`.
             if state.is_layer {
                 self.display_list.push(DrawCommand::RestoreLayer {
+                    transform: self.transform,
+                });
+            } else {
+                self.display_list.push(DrawCommand::Restore {
                     transform: self.transform,
                 });
             }

--- a/crates/flui-painting/src/display_list/command.rs
+++ b/crates/flui-painting/src/display_list/command.rs
@@ -447,6 +447,39 @@ pub enum DrawCommand {
         /// Transform at recording time (for consistency).
         transform: Matrix4,
     },
+
+    /// Push the backend's transform + clip state.
+    ///
+    /// The counterpart to [`DrawCommand::Restore`], and the plain-state
+    /// sibling of [`DrawCommand::SaveLayer`] — no offscreen target, no
+    /// compositing, just a scope marker.
+    ///
+    /// It exists because a clip has to be *undoable*. `ClipRect`/`ClipRRect`
+    /// and friends narrow the backend's current clip, and without a marker
+    /// saying when that narrowing ends, a clip applied for one subtree keeps
+    /// applying to every command recorded after it — including siblings that
+    /// never asked to be clipped.
+    ///
+    /// Carries the recording-time transform like every other variant, per this
+    /// enum's stated invariant — the backend's own stack is what actually
+    /// holds the saved state, so this field is for consistency and for
+    /// `transform()`/`transform_mut()`, not a second source of truth.
+    Save {
+        /// Transform at recording time (for consistency).
+        transform: Matrix4,
+    },
+
+    /// Pop the transform + clip state pushed by the matching
+    /// [`DrawCommand::Save`].
+    ///
+    /// Emitted by `Canvas::restore` for a plain `save()`. A `save_layer()` is
+    /// closed by [`DrawCommand::RestoreLayer`] instead — that path composites
+    /// an offscreen target and manages its own state — so exactly one of the
+    /// two is recorded per balanced pair, never both.
+    Restore {
+        /// Transform at recording time (for consistency).
+        transform: Matrix4,
+    },
 }
 
 /// Categories of drawing commands.
@@ -492,7 +525,7 @@ mod contract_freeze {
 
     /// Frozen count of `DrawCommand` variants. Bump only via the change
     /// protocol in the module comment above.
-    const FROZEN_DRAWCOMMAND_VARIANT_COUNT: usize = 31;
+    const FROZEN_DRAWCOMMAND_VARIANT_COUNT: usize = 33;
 
     /// Exhaustive — NO wildcard arm. This is the compile-time freeze guard:
     /// the function only exists to force the exhaustiveness check; the
@@ -530,6 +563,8 @@ mod contract_freeze {
             DrawCommand::DrawAtlas { .. } => "DrawAtlas",
             DrawCommand::SaveLayer { .. } => "SaveLayer",
             DrawCommand::RestoreLayer { .. } => "RestoreLayer",
+            DrawCommand::Save { .. } => "Save",
+            DrawCommand::Restore { .. } => "Restore",
         }
     }
 
@@ -540,7 +575,7 @@ mod contract_freeze {
         // pins the count as a second, human-readable signal and keeps the
         // helper from being dead code.
         assert_eq!(
-            FROZEN_DRAWCOMMAND_VARIANT_COUNT, 31,
+            FROZEN_DRAWCOMMAND_VARIANT_COUNT, 33,
             "DrawCommand contract count changed — follow the change protocol in \
              the module comment + docs/designs/2026-06-30-scene-drawcommand-contract.md"
         );

--- a/crates/flui-painting/src/display_list/command_ops.rs
+++ b/crates/flui-painting/src/display_list/command_ops.rs
@@ -91,7 +91,9 @@ impl DrawCommand {
             | Self::DrawTextSpan { .. }
             | Self::DrawGradient { .. }
             | Self::DrawGradientRRect { .. }
-            | Self::RestoreLayer { .. } => self.clone(),
+            | Self::RestoreLayer { .. }
+            | Self::Save { .. }
+            | Self::Restore { .. } => self.clone(),
 
             // Paint commands: Apply opacity to paint field
             //
@@ -613,7 +615,10 @@ impl DrawCommand {
             DrawCommand::SaveLayer {
                 bounds, transform, ..
             } => bounds.map(|b| transform.transform_rect(&b)),
-            DrawCommand::RestoreLayer { .. } => None,
+            // Scope markers draw nothing, so they contribute no bounds.
+            DrawCommand::RestoreLayer { .. }
+            | DrawCommand::Save { .. }
+            | DrawCommand::Restore { .. } => None,
         }
     }
 
@@ -743,7 +748,9 @@ impl DrawCommand {
             | DrawCommand::DrawPaint { transform, .. }
             | DrawCommand::DrawAtlas { transform, .. }
             | DrawCommand::SaveLayer { transform, .. }
-            | DrawCommand::RestoreLayer { transform, .. } => *transform,
+            | DrawCommand::RestoreLayer { transform, .. }
+            | DrawCommand::Save { transform, .. }
+            | DrawCommand::Restore { transform, .. } => *transform,
         }
     }
 
@@ -821,7 +828,9 @@ impl DrawCommand {
             | DrawCommand::DrawPaint { transform, .. }
             | DrawCommand::DrawAtlas { transform, .. }
             | DrawCommand::SaveLayer { transform, .. }
-            | DrawCommand::RestoreLayer { transform, .. } => transform,
+            | DrawCommand::RestoreLayer { transform, .. }
+            | DrawCommand::Save { transform, .. }
+            | DrawCommand::Restore { transform, .. } => transform,
         }
     }
 

--- a/crates/flui-painting/src/display_list/command_ops.rs
+++ b/crates/flui-painting/src/display_list/command_ops.rs
@@ -633,7 +633,15 @@ impl DrawCommand {
             | DrawCommand::ClipRSuperellipse { .. }
             | DrawCommand::ClipPath { .. } => CommandKind::Clip,
 
-            DrawCommand::SaveLayer { .. } | DrawCommand::RestoreLayer { .. } => CommandKind::Layer,
+            // The scope markers are `Layer` too: they are the plain-state
+            // siblings of `SaveLayer`/`RestoreLayer`, and the `_ => Draw`
+            // fallback below would otherwise make `is_draw()` true for a
+            // command that draws nothing — skewing `draw_commands()` and
+            // `count_by_kind()` for every recording that uses a scope.
+            DrawCommand::SaveLayer { .. }
+            | DrawCommand::RestoreLayer { .. }
+            | DrawCommand::Save { .. }
+            | DrawCommand::Restore { .. } => CommandKind::Layer,
 
             DrawCommand::ShaderMask { .. } | DrawCommand::BackdropFilter { .. } => {
                 CommandKind::Effect

--- a/crates/flui-painting/tests/canvas_scoped.rs
+++ b/crates/flui-painting/tests/canvas_scoped.rs
@@ -326,3 +326,42 @@ fn a_scoped_clip_is_closed_before_later_drawing() {
          follows is what bounds it",
     );
 }
+
+/// A scope marker is not a draw.
+///
+/// `kind()` has a `_ => Draw` fallback, so a new variant that is not listed
+/// explicitly silently becomes a drawing command — which would make
+/// `is_draw()` true for `Save`/`Restore` and inflate every draw count and
+/// filter over a recording that uses a scope.
+#[test]
+fn scope_markers_are_classified_as_layer_not_draw() {
+    let mut canvas = Canvas::new();
+    canvas.with_save(|c| {
+        c.draw_rect(
+            Rect::from_xywh(px(0.0), px(0.0), px(10.0), px(10.0)),
+            &Paint::fill(Color::RED),
+        );
+    });
+
+    let draws = canvas
+        .display_list()
+        .iter()
+        .filter(|command| command.is_draw())
+        .count();
+    assert_eq!(
+        draws, 1,
+        "only the rect is a draw; the Save/Restore bracket is not",
+    );
+
+    for command in canvas.display_list() {
+        if matches!(
+            command,
+            DrawCommand::Save { .. } | DrawCommand::Restore { .. }
+        ) {
+            assert_eq!(
+                command.kind(),
+                flui_painting::display_list::CommandKind::Layer
+            );
+        }
+    }
+}

--- a/crates/flui-painting/tests/canvas_scoped.rs
+++ b/crates/flui-painting/tests/canvas_scoped.rs
@@ -9,6 +9,37 @@ use flui_types::{
     styling::Color,
 };
 
+/// Marks each recorded command as the scope bracket or as body content.
+///
+/// Every scoped helper brackets its body with `Save`/`Restore`. That bracket is
+/// not bookkeeping: `Save` is what makes a later `Clip*` undoable, and without
+/// the pair a clip applied inside the closure keeps applying to everything
+/// recorded after it. Asserting the bracket is asserting the scope exists in
+/// the recording at all.
+fn scope_shape(canvas: &Canvas) -> Vec<&'static str> {
+    canvas
+        .display_list()
+        .iter()
+        .map(|command| match command {
+            DrawCommand::Save { .. } => "Save",
+            DrawCommand::Restore { .. } => "Restore",
+            _ => "body",
+        })
+        .collect()
+}
+
+/// Asserts the recording is exactly one scope wrapping `body_len` commands.
+fn assert_scope_wraps(canvas: &Canvas, body_len: usize) {
+    let shape = scope_shape(canvas);
+    let mut expected = vec!["Save"];
+    expected.extend(std::iter::repeat_n("body", body_len));
+    expected.push("Restore");
+    assert_eq!(
+        shape, expected,
+        "a scoped helper must record its Save/Restore bracket around the body",
+    );
+}
+
 #[test]
 fn test_with_save_restores_transform() {
     let mut canvas = Canvas::new();
@@ -49,7 +80,7 @@ fn test_with_translate() {
     });
 
     // Should have 1 command
-    assert_eq!(canvas.len(), 1);
+    assert_scope_wraps(&canvas, 1);
 
     // Transform should be restored
     assert_eq!(canvas.transform_matrix(), Matrix4::identity());
@@ -67,7 +98,7 @@ fn test_with_rotate() {
         );
     });
 
-    assert_eq!(canvas.len(), 1);
+    assert_scope_wraps(&canvas, 1);
     assert_eq!(canvas.transform_matrix(), Matrix4::identity());
 }
 
@@ -83,7 +114,7 @@ fn test_with_rotate_around() {
         );
     });
 
-    assert_eq!(canvas.len(), 1);
+    assert_scope_wraps(&canvas, 1);
     assert_eq!(canvas.transform_matrix(), Matrix4::identity());
 }
 
@@ -99,7 +130,7 @@ fn test_with_scale() {
         );
     });
 
-    assert_eq!(canvas.len(), 1);
+    assert_scope_wraps(&canvas, 1);
     assert_eq!(canvas.transform_matrix(), Matrix4::identity());
 }
 
@@ -112,7 +143,7 @@ fn test_with_scale_xy() {
         c.draw_circle(Point::new(px(50.0), px(50.0)), px(25.0), &paint);
     });
 
-    assert_eq!(canvas.len(), 1);
+    assert_scope_wraps(&canvas, 1);
 }
 
 #[test]
@@ -129,7 +160,7 @@ fn test_with_transform() {
         );
     });
 
-    assert_eq!(canvas.len(), 1);
+    assert_scope_wraps(&canvas, 1);
     assert_eq!(canvas.transform_matrix(), Matrix4::identity());
 }
 
@@ -144,7 +175,7 @@ fn test_with_clip_rect() {
     });
 
     // Should have clip command + circle command
-    assert_eq!(canvas.len(), 2);
+    assert_scope_wraps(&canvas, 2);
 }
 
 #[test]
@@ -163,7 +194,7 @@ fn test_with_clip_rrect() {
         );
     });
 
-    assert_eq!(canvas.len(), 2);
+    assert_scope_wraps(&canvas, 2);
 }
 
 #[test]
@@ -179,7 +210,7 @@ fn test_with_clip_path() {
         );
     });
 
-    assert_eq!(canvas.len(), 2);
+    assert_scope_wraps(&canvas, 2);
 }
 
 #[test]
@@ -198,7 +229,15 @@ fn test_nested_with_operations() {
         });
     });
 
-    assert_eq!(canvas.len(), 1);
+    // Three nested scopes around one rect: the brackets nest rather than
+    // collapsing, so the inner clip/transform of each level can be undone
+    // independently.
+    assert_eq!(
+        scope_shape(&canvas),
+        [
+            "Save", "Save", "Save", "body", "Restore", "Restore", "Restore"
+        ],
+    );
     assert_eq!(canvas.transform_matrix(), Matrix4::identity());
 }
 
@@ -238,6 +277,52 @@ fn test_chained_operations() {
         });
     }
 
-    assert_eq!(canvas.len(), 5);
+    // Five scopes, each Save + one rect + Restore.
+    assert_eq!(canvas.len(), 15);
+    assert_eq!(
+        scope_shape(&canvas),
+        ["Save", "body", "Restore"].repeat(5),
+        "each iteration records its own bracket; they must not nest or merge",
+    );
     assert_eq!(canvas.transform_matrix(), Matrix4::identity());
+}
+
+/// The reason the bracket exists: a clip must not outlive its scope.
+///
+/// Before `Save`/`Restore` were recorded, a scoped clip put a `ClipRect` into
+/// the stream with nothing after it to undo the narrowing. The CPU-side clip
+/// stack unwound correctly, so the canvas *looked* right, while a backend
+/// replaying the commands kept clipping every later draw — including siblings
+/// that were never inside the closure.
+///
+/// This pins the shape that makes the difference: the command drawn after the
+/// scope is separated from the clip by a `Restore`.
+#[test]
+fn a_scoped_clip_is_closed_before_later_drawing() {
+    let mut canvas = Canvas::new();
+    let paint = Paint::fill(Color::RED);
+    let clip = Rect::from_xywh(px(0.0), px(0.0), px(10.0), px(10.0));
+
+    canvas.with_clip_rect(clip, |c| {
+        c.draw_rect(Rect::from_xywh(px(0.0), px(0.0), px(5.0), px(5.0)), &paint);
+    });
+    // Drawn outside the closure — it must not inherit the clip.
+    canvas.draw_rect(
+        Rect::from_xywh(px(100.0), px(100.0), px(5.0), px(5.0)),
+        &paint,
+    );
+
+    assert_eq!(
+        scope_shape(&canvas),
+        ["Save", "body", "body", "Restore", "body"],
+        "the clip and the rect inside it sit within the bracket; the later \
+         rect sits after the Restore that ends it",
+    );
+
+    let commands: Vec<_> = canvas.display_list().iter().collect();
+    assert!(
+        matches!(commands[1], DrawCommand::ClipRect { .. }),
+        "the first body command is the clip itself, so the Restore that \
+         follows is what bounds it",
+    );
 }

--- a/crates/flui-painting/tests/canvas_transform.rs
+++ b/crates/flui-painting/tests/canvas_transform.rs
@@ -115,7 +115,9 @@ fn test_transform_with_save_restore() {
     canvas.draw_rect(rect2, &paint);
 
     let display_list = canvas.finish();
-    assert_eq!(display_list.len(), 2);
+    // `Save`, the rect drawn under the rotation, `Restore`, then the rect
+    // drawn after it — the bracket is what keeps the rotation off the second.
+    assert_eq!(display_list.len(), 4);
 }
 
 #[test]

--- a/crates/flui-painting/tests/canvas_unit.rs
+++ b/crates/flui-painting/tests/canvas_unit.rs
@@ -127,7 +127,11 @@ fn test_canvas_finish_clean_after_balanced_save_restore() {
     canvas.translate(50.0, 50.0);
     canvas.restore();
     let display_list = canvas.finish();
-    assert_eq!(display_list.len(), 0);
+    // The pair records its scope bracket — `translate` mutates the canvas
+    // transform rather than emitting a command, so the two here are exactly
+    // `Save` and `Restore`. What this test is about is that the balance does
+    // not trip the imbalance assert in `finish`.
+    assert_eq!(display_list.len(), 2);
 }
 
 /// `Canvas::reset()` must clear commands, transform, clip stack, and
@@ -159,7 +163,8 @@ fn test_canvas_clear_commands_preserves_state() {
     canvas.translate(25.0, 25.0);
     let rect = Rect::from_ltrb(px(0.0), px(0.0), px(10.0), px(10.0));
     canvas.draw_rect(rect, &Paint::fill(Color::BLUE));
-    assert_eq!(canvas.display_list().len(), 1);
+    // `Save` from the outstanding save(), plus the rect.
+    assert_eq!(canvas.display_list().len(), 2);
     let before_count = canvas.save_count();
 
     canvas.clear_commands();
@@ -172,7 +177,14 @@ fn test_canvas_clear_commands_preserves_state() {
     // trip the unrestored-save debug_assert.
     canvas.restore();
     let dl = canvas.finish();
-    assert_eq!(dl.len(), 0);
+    // One command, and it is an unmatched `Restore`: `clear_commands` drops the
+    // recorded `Save` while deliberately preserving the save *stack*, so the
+    // pop that balances the CPU-side stack has no opening command left to
+    // close. A backend replaying this fragment alone sees a stack underflow
+    // (it warns and ignores). That is inherent to clearing a recording
+    // mid-scope, not a defect in the pair — callers who clear commands are
+    // expected to restart the recording, not splice it onto the old one.
+    assert_eq!(dl.len(), 1);
 }
 
 // ===== draw_polyline =====

--- a/docs/designs/2026-06-30-scene-drawcommand-contract.md
+++ b/docs/designs/2026-06-30-scene-drawcommand-contract.md
@@ -1,7 +1,7 @@
 ---
 title: "Scene / DrawCommand contract freeze"
 status: frozen
-contract_version: 1
+contract_version: 2
 date: 2026-06-30
 roadmap: Core.0 N11
 guards:
@@ -118,3 +118,4 @@ to be a major contract revision.
 | Contract version | Date | Change |
 |---|---|---|
 | 1 | 2026-06-30 | Initial freeze at 31 `DrawCommand` variants. Guard installed. |
+| 2 | 2026-07-30 | Added `Save` and `Restore` (33 variants). Additive, so downstream stays source-compatible via `#[non_exhaustive]`. The vocabulary had `SaveLayer`/`RestoreLayer` but no plain-state pair, so `Canvas::save`/`restore` recorded nothing: a `clip_*` narrowed the backend's state with no marker for when the narrowing ended, and the clip kept applying to every later command — including siblings. `CommandRenderer` grows `save_state`/`restore_state` accordingly. |


### PR DESCRIPTION
Groundwork for circular decoration-image clipping (#509's declared gap). Going after that feature turned up a prerequisite that is the more important bug, so it lands on its own.

## The defect

`DrawCommand` had `SaveLayer`/`RestoreLayer` but **no plain-state pair**. `Canvas::save`/`restore` maintained the CPU-side transform and clip stacks and recorded *nothing*. So a `clip_*` between them narrowed the backend's clip with no marker for when the narrowing ended — and the clip kept applying to every command recorded afterwards, including siblings that were never inside the scope.

The canvas looked correct, because its own clip stack unwound properly. Only the replayed command stream was wrong, which is why this survived: nothing in the recording API can observe it.

The engine could already scope it. `GpuStateStack::save`/`restore` push and pop the rrect and superellipse clip slots, and `WgpuPainter` exposes both as public methods. Nothing ever called them from a display list.

## The change

Follows the change protocol in `docs/designs/2026-06-30-scene-drawcommand-contract.md` verbatim:

1. Contract doc bumped to version 2 with a changelog line.
2. `Save` / `Restore` added (31 → 33 variants), freeze guard and count updated, `Canvas::save`/`restore` wired to emit them. Exactly one closing command per opening one — `save_layer` still closes with `RestoreLayer`.
3. `CommandRenderer::save_state` / `restore_state` added, dispatch arms wired, all three backends implemented (`Backend` → `painter.save()/restore()`, `DebugBackend`, `MockRenderer`).
4. Full gate re-run.

Additive, so `#[non_exhaustive]` keeps downstream crates source-compatible.

The four exhaustive matches in `command_ops` are answered by meaning rather than by a wildcard: a scope marker has no paint to scale and no bounds to contribute, and it carries the recording-time transform like every other variant — per the invariant stated in the enum's own doc comment, which is what made a payload-less variant the wrong first instinct.

## About the test churn

Fourteen tests asserted command counts derived from the missing pair. `test_with_clip_rect` is the clearest: it asserted `canvas.len() == 2` with the comment *"Should have clip command + circle command"* — that is precisely the recording that cannot be undone, written down as the expectation.

They are not renumbered. They now assert the **shape** of the scope (`["Save", "body", "body", "Restore"]`) so what they pin is the bracket rather than an arithmetic coincidence, and a new test pins the behaviour directly: a rect drawn after a scoped clip is separated from it by the `Restore`.

## One asymmetry, surfaced not smoothed

`clear_commands` drops the recorded `Save` while deliberately preserving the save *stack*, so a later `restore()` emits an unmatched `Restore`. That is inherent to clearing a recording mid-scope — the backend warns and ignores — and it is documented at the test that observes it rather than papered over.

## Verification

- `cargo nextest run --workspace --exclude flui-platform` — **8369 passed**, 0 failed, 15 skipped
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check`, `port-check` (22 triggers), `typos`, `cargo test --doc` — clean

## What is still missing for the circle-image feature

This makes a clip *scopeable*. Clipping an image additionally needs the clip fields on `TextureInstance` and the SDF block in `texture_instanced.wgsl`, which has none today (`rect_instanced.wgsl` has 39 clip references; the texture shader has zero). That is the next change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)