### PR TITLE
feat(engine): clip images with the active SDF clip

### DIFF
--- a/crates/flui-engine/src/wgpu/batches/images.rs
+++ b/crates/flui-engine/src/wgpu/batches/images.rs
@@ -125,10 +125,10 @@ impl DrawBatcher {
             Rect::from_ltrb(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
 
         // Create texture instance (full UV mapping, no rotation, white tint).
-        let instance = super::super::instancing::TextureInstance::new(
+        let instance = state.apply_active_clip(super::super::instancing::TextureInstance::new(
             transformed_rect,
             flui_types::Color::WHITE,
-        );
+        ));
 
         // Store the ID in the IR. Resolution happens at replay time in
         // flush_segment_external_images, which calls
@@ -216,16 +216,16 @@ impl DrawBatcher {
             Ok(cached_texture) => {
                 // Preserve atlas UVs when the image is packed into the shared atlas.
                 let instance = if let Some(uv_rect) = cached_texture.uv_rect {
-                    super::super::instancing::TextureInstance::with_uv(
+                    state.apply_active_clip(super::super::instancing::TextureInstance::with_uv(
                         transformed_rect,
                         uv_rect,
                         flui_types::styling::Color::WHITE,
-                    )
+                    ))
                 } else {
-                    super::super::instancing::TextureInstance::new(
+                    state.apply_active_clip(super::super::instancing::TextureInstance::new(
                         transformed_rect,
                         flui_types::styling::Color::WHITE,
-                    )
+                    ))
                 };
 
                 // ── Advanced (dst-read) diversion ─────────────────────────────
@@ -374,13 +374,18 @@ impl DrawBatcher {
                             Rect::from_ltrb(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
 
                         let instance = if let Some(uv_rect) = cached_texture.uv_rect {
-                            super::super::instancing::TextureInstance::with_uv(
-                                tr,
-                                uv_rect,
-                                Color::WHITE,
+                            state.apply_active_clip(
+                                super::super::instancing::TextureInstance::with_uv(
+                                    tr,
+                                    uv_rect,
+                                    Color::WHITE,
+                                ),
                             )
                         } else {
-                            super::super::instancing::TextureInstance::new(tr, Color::WHITE)
+                            state.apply_active_clip(super::super::instancing::TextureInstance::new(
+                                tr,
+                                Color::WHITE,
+                            ))
                         };
                         shape_seg.cached_images.push((
                             texture_id.clone(),
@@ -777,13 +782,20 @@ impl DrawBatcher {
                     ) {
                         Ok(cached_texture) => {
                             let instance = if let Some(uv_rect) = cached_texture.uv_rect {
-                                super::super::instancing::TextureInstance::with_uv(
-                                    tr,
-                                    uv_rect,
-                                    Color::WHITE,
+                                state.apply_active_clip(
+                                    super::super::instancing::TextureInstance::with_uv(
+                                        tr,
+                                        uv_rect,
+                                        Color::WHITE,
+                                    ),
                                 )
                             } else {
-                                super::super::instancing::TextureInstance::new(tr, Color::WHITE)
+                                state.apply_active_clip(
+                                    super::super::instancing::TextureInstance::new(
+                                        tr,
+                                        Color::WHITE,
+                                    ),
+                                )
                             };
                             shape_segment.cached_images.push((
                                 texture_id,
@@ -1228,10 +1240,12 @@ impl DrawBatcher {
                         let transformed_dst =
                             Rect::from_ltrb(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
 
-                        let instance = super::super::instancing::TextureInstance::with_uv(
-                            transformed_dst,
-                            src_uv,
-                            tint,
+                        let instance = state.apply_active_clip(
+                            super::super::instancing::TextureInstance::with_uv(
+                                transformed_dst,
+                                src_uv,
+                                tint,
+                            ),
                         );
                         shape_segment.cached_images.push((
                             cache_id.clone(),
@@ -1302,8 +1316,9 @@ impl DrawBatcher {
 
                     // Create texture instance and route through cached_images so it is
                     // flushed by flush_segment_cached_images (not the orphaned texture_batch).
-                    let instance =
-                        super::super::instancing::TextureInstance::with_uv(dst_rect, src_uv, tint);
+                    let instance = state.apply_active_clip(
+                        super::super::instancing::TextureInstance::with_uv(dst_rect, src_uv, tint),
+                    );
                     segment.cached_images.push((
                         cache_id.clone(),
                         instance,
@@ -1396,8 +1411,11 @@ impl DrawBatcher {
         let transformed_dst =
             Rect::from_ltrb(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
 
-        let instance =
-            super::super::instancing::TextureInstance::with_uv(transformed_dst, src_uv, tint);
+        let instance = state.apply_active_clip(super::super::instancing::TextureInstance::with_uv(
+            transformed_dst,
+            src_uv,
+            tint,
+        ));
 
         // Push the ID into the IR. Resolution to a `wgpu::TextureView` happens
         // at replay time in flush_segment_external_images.

--- a/crates/flui-engine/src/wgpu/gradient_image_blend_tests.rs
+++ b/crates/flui-engine/src/wgpu/gradient_image_blend_tests.rs
@@ -572,6 +572,88 @@ mod gpu_tests {
         }
     }
 
+    /// The same clip under a scaling CTM — the HiDPI case.
+    ///
+    /// `clip_rrect` transforms its bounds through the CTM, so the radii must
+    /// travel with them. When they did not, the root `scale(dpr)` of any
+    /// HiDPI display turned a circular clip into a rounded square: bounds
+    /// doubled, corners did not. That is invisible at DPR 1, which is exactly
+    /// what the identity-transform test above runs at.
+    #[test]
+    fn a_clipped_image_stays_circular_under_a_scaling_transform() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_sampleable_surface(&device);
+
+        let backdrop = Color::rgba(0, 0, 255, 255);
+        clear_surface_to_color(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 0.0,
+                g: 0.0,
+                b: 1.0,
+                a: 1.0,
+            },
+        );
+
+        let source_color = Color::rgba(255, 0, 0, 255);
+        let source_image = solid_color_image(source_color);
+
+        // Half-size in logical units, doubled by the CTM — the same device
+        // pixels as the unscaled case, reached the way a HiDPI frame reaches
+        // them.
+        let logical_side = (SURFACE_WIDTH / 2) as f32;
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        painter.save();
+        painter.scale(2.0, 2.0);
+        painter.clip_rrect(flui_types::geometry::RRect::from_rect_circular(
+            Rect::from_xywh(px(0.0), px(0.0), px(logical_side), px(logical_side)),
+            px(logical_side / 2.0),
+        ));
+        painter.draw_image(
+            &source_image,
+            Rect::from_xywh(px(0.0), px(0.0), px(logical_side), px(logical_side)),
+            BlendMode::SrcOver,
+        );
+        painter.restore();
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Scaled circular image clip encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed for the scaled circular image clip");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let readback = readback_pixels(&device, &queue, &surface_texture);
+        let width = SURFACE_WIDTH as usize;
+        let at = |col: usize, row: usize| readback[row * width + col];
+
+        assert_pixel_within_tolerance(
+            "scaled circular image clip — centre is the image",
+            at(width / 2, width / 2),
+            [source_color.r, source_color.g, source_color.b, 255],
+            2,
+        );
+        for (col, row) in [
+            (1, 1),
+            (width - 2, 1),
+            (1, width - 2),
+            (width - 2, width - 2),
+        ] {
+            assert_pixel_within_tolerance(
+                &format!("scaled circular image clip — corner ({col},{row}) keeps the backdrop"),
+                at(col, row),
+                [backdrop.r, backdrop.g, backdrop.b, 255],
+                2,
+            );
+        }
+    }
+
     // ── GI3: 2-tile repeat — single backdrop read ─────────────────────────────
 
     /// GI3: A 2-tile image repeat with an advanced blend mode must blend BOTH tiles

--- a/crates/flui-engine/src/wgpu/gradient_image_blend_tests.rs
+++ b/crates/flui-engine/src/wgpu/gradient_image_blend_tests.rs
@@ -483,6 +483,95 @@ mod gpu_tests {
         }
     }
 
+    // ── Circular image clip ───────────────────────────────────────────────────
+    //
+    // Lives beside the blend cases because it needs the same image-readback
+    // harness (device, sampleable surface, pixel readback), not because it is
+    // a blend test.
+
+    /// A rounded-rect SDF clip must actually reach a textured quad.
+    ///
+    /// The image batch built its instances without ever consulting the active
+    /// clip, so an image took only the coarse bounding-box scissor — a square.
+    /// Nothing in the recording API could observe that; it is visible only in
+    /// pixels, which is why this is a readback test rather than a unit test on
+    /// the command stream.
+    ///
+    /// The clip here is a circle inscribed in the surface, expressed as an
+    /// rrect with radii at half the side. Corners fall outside it and must keep
+    /// the backdrop; the centre falls inside and must show the image.
+    #[test]
+    fn a_clipped_image_keeps_the_backdrop_outside_the_clip() {
+        let (device, queue) = acquire_test_device_and_queue();
+        let (surface_texture, surface_view) = create_sampleable_surface(&device);
+
+        let backdrop = Color::rgba(0, 0, 255, 255);
+        clear_surface_to_color(
+            &device,
+            &queue,
+            &surface_view,
+            wgpu::Color {
+                r: 0.0,
+                g: 0.0,
+                b: 1.0,
+                a: 1.0,
+            },
+        );
+
+        let source_color = Color::rgba(255, 0, 0, 255);
+        let source_image = solid_color_image(source_color);
+
+        let mut painter = build_painter(Arc::clone(&device), Arc::clone(&queue));
+        let side = SURFACE_WIDTH as f32;
+        let radius = side / 2.0;
+        painter.save();
+        painter.clip_rrect(flui_types::geometry::RRect::from_rect_circular(
+            Rect::from_xywh(px(0.0), px(0.0), px(side), px(side)),
+            px(radius),
+        ));
+        painter.draw_image(&source_image, full_surface_bounds(), BlendMode::SrcOver);
+        painter.restore();
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Circular image clip encoder"),
+        });
+        painter
+            .render(
+                RenderTarget::sampleable(&surface_view, &surface_texture),
+                &mut encoder,
+            )
+            .expect("painter.render must succeed for the circular image clip");
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let readback = readback_pixels(&device, &queue, &surface_texture);
+        let width = SURFACE_WIDTH as usize;
+        let at = |col: usize, row: usize| readback[row * width + col];
+
+        // Centre: inside the circle, so the image wins.
+        assert_pixel_within_tolerance(
+            "circular image clip — centre is the image",
+            at(width / 2, width / 2),
+            [source_color.r, source_color.g, source_color.b, 255],
+            2,
+        );
+
+        // Corners: outside the inscribed circle by ~0.29 × radius, far beyond
+        // any AA band, so an unclipped image would show up here as red.
+        for (col, row) in [
+            (1, 1),
+            (width - 2, 1),
+            (1, width - 2),
+            (width - 2, width - 2),
+        ] {
+            assert_pixel_within_tolerance(
+                &format!("circular image clip — corner ({col},{row}) keeps the backdrop"),
+                at(col, row),
+                [backdrop.r, backdrop.g, backdrop.b, 255],
+                2,
+            );
+        }
+    }
+
     // ── GI3: 2-tile repeat — single backdrop read ─────────────────────────────
 
     /// GI3: A 2-tile image repeat with an advanced blend mode must blend BOTH tiles

--- a/crates/flui-engine/src/wgpu/instancing.rs
+++ b/crates/flui-engine/src/wgpu/instancing.rs
@@ -598,6 +598,22 @@ pub struct TextureInstance {
     /// [cos(angle), sin(angle), translate_x, translate_y]
     /// For no rotation: [1.0, 0.0, 0.0, 0.0]
     pub transform: [f32; 4],
+
+    /// SDF clip rounded rectangle, same layout and sentinel as
+    /// [`RectInstance::clip_rrect`]: `[x, y, width, height, radius_tl,
+    /// radius_tr, radius_br, radius_bl]`, all zeros meaning no clip.
+    ///
+    /// A circular clip is this slot with every radius at half the shorter
+    /// side — and because the fragment shader evaluates it as a signed
+    /// distance rather than tessellating it, that is an exact circle, not a
+    /// Bézier approximation of one.
+    pub clip_rrect: [f32; 8],
+
+    /// Clip-kind flag selecting which SDF to evaluate against `clip_rrect`.
+    /// `0` none, `1` rounded box, `2` rounded superellipse — identical
+    /// encoding to [`RectInstance::clip_kind`], including the `[u32; 4]`
+    /// padding for 16-byte vec4 alignment.
+    pub clip_kind: [u32; 4],
 }
 
 impl TextureInstance {
@@ -618,6 +634,8 @@ impl TextureInstance {
             src_uv: [0.0, 0.0, 1.0, 1.0], // Full texture
             tint: tint.to_f32_array(),
             transform: [1.0, 0.0, 0.0, 0.0], // No rotation
+            clip_rrect: [0.0; 8],
+            clip_kind: [0; 4],
         }
     }
 
@@ -643,6 +661,8 @@ impl TextureInstance {
             src_uv,
             tint: tint.to_f32_array(),
             transform: [1.0, 0.0, 0.0, 0.0],
+            clip_rrect: [0.0; 8],
+            clip_kind: [0; 4],
         }
     }
 
@@ -677,6 +697,8 @@ impl TextureInstance {
             src_uv,
             tint,
             transform: [1.0, 0.0, 0.0, 0.0],
+            clip_rrect: [0.0; 8],
+            clip_kind: [0; 4],
         }
     }
 
@@ -692,6 +714,12 @@ impl TextureInstance {
             4 => Float32x4,
             // Transform (location 5)
             5 => Float32x4,
+            // Clip rrect part 1: [x, y, width, height] (location 6)
+            6 => Float32x4,
+            // Clip rrect part 2: [radius_tl, radius_tr, radius_br, radius_bl] (location 7)
+            7 => Float32x4,
+            // Clip kind: [kind, _pad, _pad, _pad] (location 8) — 0=none, 1=rrect, 2=rsuperellipse
+            8 => Uint32x4,
         ];
 
         wgpu::VertexBufferLayout {
@@ -699,6 +727,77 @@ impl TextureInstance {
             step_mode: wgpu::VertexStepMode::Instance,
             attributes: ATTRIBUTES,
         }
+    }
+}
+
+/// An instance type that can carry the active SDF clip.
+///
+/// Exists so [`GpuStateStack::apply_active_clip`] can decide *once* which of
+/// the two clip slots wins and hand the answer to any instance kind, instead
+/// of each batch re-deriving that branch order and drifting from the others.
+///
+/// [`GpuStateStack::apply_active_clip`]: super::state_stack::GpuStateStack::apply_active_clip
+pub trait ClippableInstance {
+    /// Attach a rounded-rect SDF clip (`clip_kind = 1`), or clear the clip
+    /// when the slot is the all-zero "no clip" sentinel.
+    #[must_use]
+    fn with_clip_rrect(self, clip: [f32; 8]) -> Self;
+
+    /// Attach a rounded-superellipse SDF clip (`clip_kind = 2`), or clear the
+    /// clip when the slot is the all-zero sentinel.
+    #[must_use]
+    fn with_clip_rsuperellipse(self, superellipse_clip: [f32; 12]) -> Self;
+}
+
+impl ClippableInstance for RectInstance {
+    fn with_clip_rrect(self, clip: [f32; 8]) -> Self {
+        RectInstance::with_clip_rrect(self, clip)
+    }
+
+    fn with_clip_rsuperellipse(self, superellipse_clip: [f32; 12]) -> Self {
+        RectInstance::with_clip_rsuperellipse(self, superellipse_clip)
+    }
+}
+
+impl ClippableInstance for TextureInstance {
+    fn with_clip_rrect(mut self, clip: [f32; 8]) -> Self {
+        self.clip_rrect = clip;
+        // Exact equality against the bit-exact `[0.0; 8]` sentinel, matching
+        // `RectInstance` — the slot is assigned, never computed, so no ULP slop.
+        #[expect(
+            clippy::float_cmp,
+            reason = "exact comparison against the bit-exact `[0.0; 8]` 'no clip' sentinel"
+        )]
+        let is_empty = clip == [0.0; 8];
+        self.clip_kind = if is_empty { [0; 4] } else { [1, 0, 0, 0] };
+        self
+    }
+
+    fn with_clip_rsuperellipse(mut self, superellipse_clip: [f32; 12]) -> Self {
+        #[expect(
+            clippy::float_cmp,
+            reason = "exact comparison against the bit-exact `[0.0; 12]` 'no clip' sentinel"
+        )]
+        let is_empty = superellipse_clip == [0.0; 12];
+        if is_empty {
+            self.clip_rrect = [0.0; 8];
+            self.clip_kind = [0; 4];
+            return self;
+        }
+        // Same per-corner rx/ry averaging as `RectInstance`, so both instance
+        // kinds approximate the squircle identically rather than in two ways.
+        self.clip_rrect = [
+            superellipse_clip[0],
+            superellipse_clip[1],
+            superellipse_clip[2],
+            superellipse_clip[3],
+            0.5 * (superellipse_clip[4] + superellipse_clip[5]),
+            0.5 * (superellipse_clip[6] + superellipse_clip[7]),
+            0.5 * (superellipse_clip[8] + superellipse_clip[9]),
+            0.5 * (superellipse_clip[10] + superellipse_clip[11]),
+        ];
+        self.clip_kind = [2, 0, 0, 0];
+        self
     }
 }
 
@@ -959,11 +1058,13 @@ mod tests {
 
     #[test]
     fn test_texture_instance_size() {
-        // Verify struct is tightly packed for GPU
-        assert_eq!(
-            std::mem::size_of::<TextureInstance>(),
-            16 * 4 // 16 floats = 64 bytes
-        );
+        // Tightly packed for the GPU, and the count must match `desc()`:
+        // dst_rect + src_uv + tint + transform (4 vec4s) + the clip slot
+        // (clip_rrect is 2 vec4s, clip_kind 1 uvec4) = 7 * 16 bytes. A
+        // mismatch here means an attribute in the vertex layout has no
+        // storage behind it, which reads as garbage clip bounds on the GPU
+        // rather than as a compile error.
+        assert_eq!(std::mem::size_of::<TextureInstance>(), 7 * 16);
     }
 
     #[test]

--- a/crates/flui-engine/src/wgpu/shaders/texture_instanced.wgsl
+++ b/crates/flui-engine/src/wgpu/shaders/texture_instanced.wgsl
@@ -17,6 +17,9 @@ struct InstanceInput {
     @location(3) src_uv: vec4<f32>,        // [u_min, v_min, u_max, v_max] in 0-1 range
     @location(4) tint: vec4<f32>,          // [r, g, b, a] in 0-1 range
     @location(5) transform: vec4<f32>,     // [cos(angle), sin(angle), tx, ty]
+    @location(6) clip_bounds: vec4<f32>,   // [x, y, width, height] of clip
+    @location(7) clip_radii: vec4<f32>,    // [tl, tr, br, bl] of clip
+    @location(8) clip_kind: vec4<u32>,     // [kind, _, _, _]: 0=none, 1=rrect, 2=rsuperellipse
 }
 
 // Vertex output / Fragment input
@@ -24,6 +27,57 @@ struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) uv: vec2<f32>,            // Texture coordinates
     @location(1) tint: vec4<f32>,          // Tint color
+    @location(2) world_pos: vec2<f32>,     // Device-pixel position for the clip SDF
+    @location(3) clip_bounds: vec4<f32>,   // Clip rect bounds
+    @location(4) clip_radii: vec4<f32>,    // Clip corner radii
+    @location(5) @interpolate(flat) clip_kind: u32, // 0=none, 1=rrect, 2=rsuperellipse
+}
+
+// =============================================================================
+// SDF helpers
+// =============================================================================
+//
+// Inlined rather than imported: WGSL here has no include mechanism, and
+// `rect_instanced.wgsl` sets the convention of carrying its own copy. Both
+// must stay identical — a clip that rounds differently per primitive is worse
+// than no clip at all, because the seam only shows where two primitives meet.
+
+/// Rounded box SDF with per-corner radii. See `rect_instanced.wgsl` for the
+/// branchless quadrant-selection prose.
+fn sdRoundedBox(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
+    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
+    let r3 = select(r2.x, r2.y, p.y > 0.0);
+
+    let q = abs(p) - b + vec2<f32>(r3);
+    return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0))) - r3;
+}
+
+/// Rounded superellipse SDF (iOS-squircle, n=4) with per-corner radii.
+fn sdRoundedSuperellipse(p: vec2<f32>, b: vec2<f32>, r: vec4<f32>) -> f32 {
+    let r2 = select(vec2<f32>(r.x, r.w), vec2<f32>(r.y, r.z), p.x > 0.0);
+    let r3 = select(r2.x, r2.y, p.y > 0.0);
+
+    let q = abs(p) - b + vec2<f32>(r3);
+
+    if (q.x < 0.0 && q.y < 0.0) {
+        return max(q.x, q.y) - r3;
+    }
+
+    if (r3 <= 0.0) {
+        return min(max(q.x, q.y), 0.0) + length(max(q, vec2<f32>(0.0)));
+    }
+
+    let ax = max(q.x, 0.0) / r3;
+    let ay = max(q.y, 0.0) / r3;
+    let n_norm = sqrt(sqrt(ax * ax * ax * ax + ay * ay * ay * ay));
+    return (n_norm - 1.0) * r3;
+}
+
+/// Convert SDF distance to alpha with adaptive antialiasing (L2 gradient, so a
+/// rotated edge gets ~1 device pixel of AA rather than ~1.41).
+fn sdfToAlpha(dist: f32) -> f32 {
+    let edge_width = length(vec2<f32>(dpdx(dist), dpdy(dist))) * 0.5;
+    return 1.0 - smoothstep(-edge_width, edge_width, dist);
 }
 
 // Viewport uniform (for screen-space to clip-space conversion)
@@ -99,6 +153,13 @@ fn vs_main(
 
     out.tint = instance.tint;
 
+    // The clip is evaluated in device pixels, so hand the fragment the same
+    // world position the vertex was placed at — post-rotation, pre-projection.
+    out.world_pos = world_pos;
+    out.clip_bounds = instance.clip_bounds;
+    out.clip_radii = instance.clip_radii;
+    out.clip_kind = instance.clip_kind.x;
+
     return out;
 }
 
@@ -110,7 +171,37 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // Apply tint (multiply)
     tex_color = tex_color * in.tint;
 
-    // Alpha test (discard fully transparent pixels for better performance)
+    // --- SDF Clip Test ---
+    // Same branch order and kind encoding as `rect_instanced.wgsl`: the kind
+    // flag selects the SDF, the bounds+radii slot is shared between kinds, and
+    // flat interpolation keeps the branch uniform across the draw call.
+    //
+    // A circle is expressed here as radii of half the shorter side. Because
+    // this is a distance field rather than tessellated geometry, that is an
+    // exact circle at any scale — the ~6% diagonal bulge that rules out
+    // drrect for circular *geometry* does not apply to a clip.
+    var clip_alpha = 1.0;
+    if (in.clip_kind != 0u && in.clip_bounds.z > 0.0 && in.clip_bounds.w > 0.0) {
+        let clip_center = in.clip_bounds.xy + in.clip_bounds.zw * 0.5;
+        let clip_p = in.world_pos - clip_center;
+        let clip_half = in.clip_bounds.zw * 0.5;
+
+        var clip_dist = 0.0;
+        if (in.clip_kind == 2u) {
+            clip_dist = sdRoundedSuperellipse(clip_p, clip_half, in.clip_radii);
+        } else {
+            // clip_kind == 1u (rrect), and the safe default for a kind this
+            // shader has not learned about yet.
+            clip_dist = sdRoundedBox(clip_p, clip_half, in.clip_radii);
+        }
+
+        clip_alpha = sdfToAlpha(clip_dist);
+    }
+
+    tex_color.a = tex_color.a * clip_alpha;
+
+    // Alpha test (discard fully transparent pixels for better performance).
+    // Runs after the clip so fully clipped-out texels cost nothing downstream.
     if (tex_color.a < 0.01) {
         discard;
     }

--- a/crates/flui-engine/src/wgpu/state_stack.rs
+++ b/crates/flui-engine/src/wgpu/state_stack.rs
@@ -451,6 +451,21 @@ impl GpuStateStack {
         let transform = self.current_transform;
         let rect = rrect.rect;
 
+        // A rotated or skewed CTM has no representation in this slot: the
+        // shader evaluates an axis-aligned box, and the bounds below are
+        // derived from two corners, which for a rotated rect is not even its
+        // AABB — a 45° rotation collapses them onto one vertical, giving a
+        // ZERO-width clip that erases everything it covers. Leaving the slot
+        // empty and relying on the coarse scissor over-includes, which is the
+        // survivable direction of wrong; a clip carried in local space with
+        // its own transform is what would represent this properly.
+        if !self.is_axis_aligned() {
+            self.current_rrect_clip = [0.0; 8];
+            self.current_rsuperellipse_clip = [0.0; 12];
+            self.clip_rect(rrect.rect, surface_size);
+            return;
+        }
+
         let (x, y, w, h) = if transform == glam::Mat4::IDENTITY {
             (rect.left().0, rect.top().0, rect.width().0, rect.height().0)
         } else {
@@ -472,6 +487,16 @@ impl GpuStateStack {
         // did rather than decomposing the matrix, so a translation-only or
         // identity transform yields exactly 1.0 and the values stay bit-equal
         // to the untransformed path.
+        // Only meaningful when the CTM is axis-aligned. Under rotation or
+        // skew the bounds above are the AABB of a rotated rect, so this ratio
+        // is the AABB's aspect change and not a scale at all — at 45° it would
+        // inflate every radius by ~1.41 for no reason. The SDF slot cannot
+        // express a rotated clip either way (the shader evaluates an
+        // axis-aligned box), so that case keeps its radii untouched: still an
+        // approximation, but the same one it was before, rather than a new
+        // and larger distortion layered on top. Representing a rotated clip
+        // properly needs the clip carried in local space with its own
+        // transform — a change to the instance format, not to this line.
         let (scale_x, scale_y) = if rect.width().0 > 0.0 && rect.height().0 > 0.0 {
             (w / rect.width().0, h / rect.height().0)
         } else {
@@ -536,6 +561,15 @@ impl GpuStateStack {
     ) {
         let transform = self.current_transform;
         let rect = rse.outer_rect();
+
+        // Same bail-out as `clip_rrect`, for the same reason: this slot is
+        // axis-aligned in the shader and its bounds cannot survive a rotation.
+        if !self.is_axis_aligned() {
+            self.current_rsuperellipse_clip = [0.0; 12];
+            self.current_rrect_clip = [0.0; 8];
+            self.clip_rect(rect, surface_size);
+            return;
+        }
 
         let (x, y, w, h) = if transform == glam::Mat4::IDENTITY {
             (rect.left().0, rect.top().0, rect.width().0, rect.height().0)
@@ -1039,5 +1073,34 @@ mod tests {
                 h / 2.0,
             );
         }
+    }
+
+    /// A rotated CTM must leave the SDF slot empty rather than fill it with
+    /// something the shader cannot represent.
+    ///
+    /// The bounds are derived from two corners, which for a rotated rect is
+    /// not even its AABB: a 45° rotation puts both on one vertical, giving a
+    /// zero-width box. Combined with the radius clamp that is a clip which
+    /// erases everything it covers. Falling back to the coarse scissor
+    /// over-includes instead, which is the survivable direction of wrong.
+    #[test]
+    fn a_rotated_clip_populates_no_sdf_slot() {
+        let mut stack = GpuStateStack::new_for_test();
+        let rrect = RRect::from_rect_circular(
+            Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0)),
+            px(10.0),
+        );
+
+        stack.rotate(std::f32::consts::FRAC_PI_4);
+        stack.clip_rrect(rrect, (400, 400));
+
+        assert_eq!(
+            stack.current_rrect_clip, [0.0; 8],
+            "a rotated clip must not populate the axis-aligned SDF slot",
+        );
+        assert!(
+            stack.current_scissor().is_some(),
+            "the coarse scissor still applies — the clip is loosened, not dropped",
+        );
     }
 }

--- a/crates/flui-engine/src/wgpu/state_stack.rs
+++ b/crates/flui-engine/src/wgpu/state_stack.rs
@@ -39,8 +39,6 @@ use flui_types::{
     geometry::{Pixels, RRect, px},
 };
 
-use super::instancing::RectInstance;
-
 /// The four parallel GPU draw-state stacks, plus their cached top-of-stack
 /// values.
 ///
@@ -570,7 +568,10 @@ impl GpuStateStack {
     ///
     /// Centralises the per-instance clip-kind selection so the two
     /// `rect`/`rrect` batch-build sites do not drift apart.
-    pub(super) fn apply_active_clip(&self, instance: RectInstance) -> RectInstance {
+    pub(super) fn apply_active_clip<I: super::instancing::ClippableInstance>(
+        &self,
+        instance: I,
+    ) -> I {
         // Exact equality against the all-zero "no clip active" sentinel is
         // intentional: the field is set bit-exact to `[0.0; 12]` whenever
         // the clip is cleared, never via arithmetic that would introduce

--- a/crates/flui-engine/src/wgpu/state_stack.rs
+++ b/crates/flui-engine/src/wgpu/state_stack.rs
@@ -477,13 +477,25 @@ impl GpuStateStack {
         } else {
             (1.0, 1.0)
         };
-        // Each corner collapses its rx/ry to one radius (the SDF slot carries
-        // one per corner), and scaling before the collapse keeps that choice
-        // meaningful under a non-uniform scale.
-        let r_tl = (rrect.top_left.x.0 * scale_x).max(rrect.top_left.y.0 * scale_y);
-        let r_tr = (rrect.top_right.x.0 * scale_x).max(rrect.top_right.y.0 * scale_y);
-        let r_br = (rrect.bottom_right.x.0 * scale_x).max(rrect.bottom_right.y.0 * scale_y);
-        let r_bl = (rrect.bottom_left.x.0 * scale_x).max(rrect.bottom_left.y.0 * scale_y);
+        // This slot carries ONE radius per corner, so an elliptical corner is
+        // not representable in it. Under a non-uniform scale — `scale(2, 1)`
+        // turning a circle into an ellipse with radii (100, 50) — the two
+        // scaled axes have to collapse to a scalar, and a bare `max` would
+        // hand the shader a radius larger than the box's own half-height. The
+        // rounded-box SDF is degenerate there and clips visibly INWARD.
+        //
+        // So collapse, then clamp to the largest radius the box can hold. The
+        // result is the largest well-formed rounded shape inside the intended
+        // ellipse: still a divergence under non-uniform scale, but a bounded
+        // one instead of a broken one. Carrying rx/ry per corner through the
+        // instance and both shaders is the real fix and a format change of its
+        // own; the superellipse slot above already has the room for it.
+        let max_radius = (w * 0.5).min(h * 0.5).max(0.0);
+        let collapse = |rx: f32, ry: f32| (rx * scale_x).max(ry * scale_y).min(max_radius);
+        let r_tl = collapse(rrect.top_left.x.0, rrect.top_left.y.0);
+        let r_tr = collapse(rrect.top_right.x.0, rrect.top_right.y.0);
+        let r_br = collapse(rrect.bottom_right.x.0, rrect.bottom_right.y.0);
+        let r_bl = collapse(rrect.bottom_left.x.0, rrect.bottom_left.y.0);
 
         self.current_rrect_clip = [x, y, w, h, r_tl, r_tr, r_br, r_bl];
         // Clearing the superellipse clip prevents `apply_active_clip` from
@@ -542,9 +554,30 @@ impl GpuStateStack {
         let br_r = rse.br_radius();
         let bl_r = rse.bl_radius();
 
+        // Same rule as `clip_rrect`: radii live in the bounds' space and must
+        // make the same trip, or the shader compares logical-pixel corners
+        // against a device-pixel rect. Unlike the rrect slot, this one carries
+        // rx and ry per corner, so the per-axis scale is exact here rather
+        // than an approximation.
+        let (scale_x, scale_y) = if rect.width().0 > 0.0 && rect.height().0 > 0.0 {
+            (w / rect.width().0, h / rect.height().0)
+        } else {
+            (1.0, 1.0)
+        };
+
         self.current_rsuperellipse_clip = [
-            x, y, w, h, tl_r.x.0, tl_r.y.0, tr_r.x.0, tr_r.y.0, br_r.x.0, br_r.y.0, bl_r.x.0,
-            bl_r.y.0,
+            x,
+            y,
+            w,
+            h,
+            tl_r.x.0 * scale_x,
+            tl_r.y.0 * scale_y,
+            tr_r.x.0 * scale_x,
+            tr_r.y.0 * scale_y,
+            br_r.x.0 * scale_x,
+            br_r.y.0 * scale_y,
+            bl_r.x.0 * scale_x,
+            bl_r.y.0 * scale_y,
         ];
         // Clear the rrect clip to prevent `apply_active_clip` from falling
         // back to it. Mirror of the corresponding clear in `clip_rrect`.
@@ -946,5 +979,65 @@ mod tests {
             [10.0, 20.0, 80.0, 40.0, 7.5, 7.5, 7.5, 7.5],
             "an identity CTM must divide out to exactly 1.0, not to 0.999…",
         );
+    }
+
+    /// The superellipse slot has room for per-axis radii, so its scaling is
+    /// exact — no collapse, no clamp.
+    #[test]
+    fn a_scaled_superellipse_clip_scales_each_radius_axis() {
+        use flui_types::geometry::RSuperellipse;
+
+        let mut stack = GpuStateStack::new_for_test();
+        let rse = RSuperellipse::from_rect_circular(
+            Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0)),
+            px(20.0),
+        );
+
+        stack.scale(2.0, 3.0);
+        stack.clip_rsuperellipse(rse, (600, 600));
+
+        let clip = stack.current_rsuperellipse_clip;
+        assert_eq!((clip[2], clip[3]), (200.0, 300.0), "bounds follow the CTM");
+        for (i, corner) in ["tl", "tr", "br", "bl"].iter().enumerate() {
+            let (rx, ry) = (clip[4 + i * 2], clip[5 + i * 2]);
+            assert!(
+                (rx - 40.0).abs() < 0.01 && (ry - 60.0).abs() < 0.01,
+                "corner {corner} must scale per axis (40, 60), got ({rx}, {ry}) — leaving \
+                 either in logical pixels leaks the clip on a HiDPI display",
+            );
+        }
+    }
+
+    /// A non-uniform scale cannot be represented in the rrect slot's single
+    /// radius per corner, so the collapse must at least stay well-formed.
+    ///
+    /// `scale(2, 1)` turns a circular clip into a 200×100 box whose intended
+    /// corners are (100, 50). The scalar collapse picks 100, which exceeds the
+    /// box's own half-height — a rounded-box SDF with a radius larger than its
+    /// half-extent is degenerate and clips inward, eating the image. Clamping
+    /// to the largest radius the box can hold keeps it a bounded divergence
+    /// rather than a broken one.
+    #[test]
+    fn a_non_uniform_scale_clamps_the_collapsed_radius_to_the_box() {
+        let mut stack = GpuStateStack::new_for_test();
+        let circle = RRect::from_rect_circular(
+            Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0)),
+            px(50.0),
+        );
+
+        stack.scale(2.0, 1.0);
+        stack.clip_rrect(circle, (400, 400));
+
+        let clip = stack.current_rrect_clip;
+        let (w, h) = (clip[2], clip[3]);
+        assert_eq!((w, h), (200.0, 100.0));
+        for radius in &clip[4..8] {
+            assert!(
+                *radius <= h / 2.0 + 0.01,
+                "a radius of {radius} exceeds the half-height {} — the SDF is degenerate \
+                 there and clips inward",
+                h / 2.0,
+            );
+        }
     }
 }

--- a/crates/flui-engine/src/wgpu/state_stack.rs
+++ b/crates/flui-engine/src/wgpu/state_stack.rs
@@ -463,10 +463,27 @@ impl GpuStateStack {
             (min_x, min_y, max_x - min_x, max_y - min_y)
         };
 
-        let r_tl = rrect.top_left.x.0.max(rrect.top_left.y.0);
-        let r_tr = rrect.top_right.x.0.max(rrect.top_right.y.0);
-        let r_br = rrect.bottom_right.x.0.max(rrect.bottom_right.y.0);
-        let r_bl = rrect.bottom_left.x.0.max(rrect.bottom_left.y.0);
+        // The radii live in the same space as the bounds, so they have to make
+        // the same trip. Transforming the bounds alone leaves them in logical
+        // pixels while the SDF evaluates against a device-pixel rect: at the
+        // root `scale(dpr)` of any HiDPI display a 100×100 circular clip
+        // becomes 200×200 with 50-pixel corners — a rounded square, not a
+        // circle. Derive the per-axis factors from what the bounds actually
+        // did rather than decomposing the matrix, so a translation-only or
+        // identity transform yields exactly 1.0 and the values stay bit-equal
+        // to the untransformed path.
+        let (scale_x, scale_y) = if rect.width().0 > 0.0 && rect.height().0 > 0.0 {
+            (w / rect.width().0, h / rect.height().0)
+        } else {
+            (1.0, 1.0)
+        };
+        // Each corner collapses its rx/ry to one radius (the SDF slot carries
+        // one per corner), and scaling before the collapse keeps that choice
+        // meaningful under a non-uniform scale.
+        let r_tl = (rrect.top_left.x.0 * scale_x).max(rrect.top_left.y.0 * scale_y);
+        let r_tr = (rrect.top_right.x.0 * scale_x).max(rrect.top_right.y.0 * scale_y);
+        let r_br = (rrect.bottom_right.x.0 * scale_x).max(rrect.bottom_right.y.0 * scale_y);
+        let r_bl = (rrect.bottom_left.x.0 * scale_x).max(rrect.bottom_left.y.0 * scale_y);
 
         self.current_rrect_clip = [x, y, w, h, r_tl, r_tr, r_br, r_bl];
         // Clearing the superellipse clip prevents `apply_active_clip` from
@@ -876,6 +893,58 @@ mod tests {
             w, 0,
             "a clip rect entirely past the right edge must clamp to zero width, not leave a \
              residual extent past the surface bound"
+        );
+    }
+
+    /// A scaled circular clip must stay a circle.
+    ///
+    /// `clip_rrect` transforms the bounds through the CTM. If the radii do not
+    /// make the same trip they stay in logical pixels while the SDF evaluates
+    /// against a device-pixel rect — so at the root `scale(dpr)` of any HiDPI
+    /// display a circular clip renders as a rounded square. The invariant that
+    /// makes it a circle is `radius == shorter_side / 2`, and it has to hold
+    /// after the transform, not just before it.
+    #[test]
+    fn a_scaled_circular_clip_keeps_its_radius_proportional_to_its_bounds() {
+        let mut stack = GpuStateStack::new_for_test();
+        let surface = (400u32, 400u32);
+
+        let circle = RRect::from_rect_circular(
+            Rect::from_xywh(px(0.0), px(0.0), px(100.0), px(100.0)),
+            px(50.0),
+        );
+
+        stack.scale(2.0, 2.0);
+        stack.clip_rrect(circle, surface);
+
+        let clip = stack.current_rrect_clip;
+        let (w, h) = (clip[2], clip[3]);
+        assert_eq!((w, h), (200.0, 200.0), "the bounds scale with the CTM");
+        for (corner, radius) in ["tl", "tr", "br", "bl"].iter().zip(&clip[4..8]) {
+            assert!(
+                (radius - w / 2.0).abs() < 0.01,
+                "corner {corner} must stay at half the scaled side ({}), got {radius} — a \
+                 smaller radius is a rounded square wearing a circle's bounds",
+                w / 2.0,
+            );
+        }
+    }
+
+    /// The untransformed path must be untouched by the scaling fix.
+    #[test]
+    fn an_unscaled_clip_keeps_its_radii_bit_exact() {
+        let mut stack = GpuStateStack::new_for_test();
+        let rrect = RRect::from_rect_circular(
+            Rect::from_xywh(px(10.0), px(20.0), px(80.0), px(40.0)),
+            px(7.5),
+        );
+
+        stack.clip_rrect(rrect, (400, 400));
+
+        assert_eq!(
+            stack.current_rrect_clip,
+            [10.0, 20.0, 80.0, 40.0, 7.5, 7.5, 7.5, 7.5],
+            "an identity CTM must divide out to exactly 1.0, not to 0.999…",
         );
     }
 }

--- a/crates/flui-painting/src/decoration.rs
+++ b/crates/flui-painting/src/decoration.rs
@@ -42,21 +42,15 @@ static WARN_CIRCLE_BORDER_RADIUS: Once = Once::new();
 /// rationale as [`WARN_CIRCLE_BORDER_RADIUS`].
 static WARN_CIRCLE_NON_UNIFORM_BORDER: Once = Once::new();
 
-/// One-shot gate for the "decoration image on a circle paints unclipped"
-/// warning (see the image step of `paint_box_decoration` below) — same
-/// per-frame-spam rationale as [`WARN_CIRCLE_BORDER_RADIUS`].
-static WARN_CIRCLE_IMAGE_UNCLIPPED: Once = Once::new();
-
 /// The decoration's resolved silhouette: the one shape used for the
-/// background fill, the shadow cast, the border, and hit testing.
+/// background fill, the shadow cast, the border, hit testing, and — on a
+/// circle — the image clip.
 ///
-/// **Not the image.** The decoration image is painted into the full
-/// rectangular destination whatever this resolves to — on a circle it
-/// only decides whether to warn, never to clip. Clipping it would need a
-/// route this layer does not have (see the image step of
-/// `paint_box_decoration`), so a circular decoration image renders as a
-/// square. Do not read this type as "the shape everything is confined
-/// to"; it is the shape the four sites listed above agree on.
+/// **The image is the partial case.** A circular decoration clips its image
+/// to the circle; a rounded-rect one still paints its image to the full rect,
+/// where Flutter would clip it too. That difference is deliberate and named
+/// at the image step of `paint_box_decoration`, not an oversight of this
+/// type.
 ///
 /// Resolved once per paint/hit-test call (`resolve_silhouette`) rather
 /// than re-derived at each paint site. Resolving once is what keeps
@@ -178,42 +172,40 @@ pub fn paint_box_decoration(
 
     // 3. Decoration image (above the background, below the border).
     //
-    // Flutter clips the image to the circle
-    // (`box_decoration.dart:543-551` `_paintBackgroundImage`). Clipping a
-    // circular image is UNIMPLEMENTED here — this used to route through
-    // `canvas.save()` + `clip_rrect` + `canvas.restore()` on an inscribed
-    // square, but that construction is broken two independent ways, neither
-    // fixable within this crate:
+    // Flutter clips the image to the decoration's shape
+    // (`box_decoration.dart` `_paintBackgroundImage`). On a circle this
+    // routes through a scoped SDF clip: `save` opens a scope the backend can
+    // unwind, `clip_rrect` with radii at half the shorter side narrows it to
+    // the circle, and `restore` closes it so the border painted afterwards is
+    // untouched.
     //
-    // 1. `Canvas::save()` (`canvas/state.rs`) records nothing in the
-    //    display list, and `restore()` only emits a `RestoreLayer` command
-    //    when the saved state came from `save_layer()` (`is_layer`, which
-    //    plain `save()` always sets to `false`). There is no plain
-    //    Save/Restore `DrawCommand` variant, so the `ClipRRect` this used
-    //    to push was never closed — it would leak onto the image AND every
-    //    following sibling command in the same `PictureLayer`.
-    // 2. Even a properly scoped clip would not clip an image: the rounded
-    //    SDF clip only reaches a draw through
-    //    `GpuStateStack::apply_active_clip`, whose only call sites are the
-    //    `RectInstance` paths in `flui-engine`'s `wgpu/batches/shapes.rs`.
-    //    `wgpu/batches/images.rs` never calls it, so an image only ever
-    //    gets the coarse bounding-box scissor — a SQUARE, not a circle.
-    //
-    // Fixing this needs either a `FragmentScope` clip route in
-    // `flui-rendering` or `apply_active_clip` support in the image batch;
-    // both are out of scope here. The image paints unclipped (a square)
-    // instead, with a one-shot warning.
+    // The clip is a distance field, not tessellated geometry, so the circle
+    // is exact — the ~6% diagonal bulge that rules out drrect for a circular
+    // *ring* does not apply to a clip.
     if let Some(image) = &decoration.image {
-        if matches!(&silhouette, Silhouette::Circle(_)) {
-            WARN_CIRCLE_IMAGE_UNCLIPPED.call_once(|| {
-                tracing::warn!(
-                    "BoxDecoration: a decoration image on a BoxShape::Circle is painted \
-                     unclipped (a square, not a circle); circular image clipping is not \
-                     implemented yet (this warn fires once per process)"
+        match &silhouette {
+            Silhouette::Circle(circle) => {
+                let diameter = circle.radius * 2.0;
+                let bounds = Rect::from_xywh(
+                    circle.center.x - circle.radius,
+                    circle.center.y - circle.radius,
+                    diameter,
+                    diameter,
                 );
-            });
+                canvas.save();
+                canvas.clip_rrect(RRect::from_rect_circular(bounds, circle.radius));
+                paint_decoration_image(canvas, rect, image);
+                canvas.restore();
+            }
+            // A rounded-rect decoration still paints its image to the full
+            // rect. Flutter clips that case too; closing it is the same
+            // mechanism as above, but it changes what existing rounded
+            // decorations render, and no readback oracle covers a clipped
+            // image yet — so it is named here rather than changed blind.
+            Silhouette::RRect(_) | Silhouette::Rect => {
+                paint_decoration_image(canvas, rect, image);
+            }
         }
-        paint_decoration_image(canvas, rect, image);
     }
 
     // 4. Border (on top).

--- a/crates/flui-painting/tests/decoration_unit.rs
+++ b/crates/flui-painting/tests/decoration_unit.rs
@@ -467,12 +467,28 @@ fn a_circular_decoration_image_is_clipped_to_the_circle_and_the_clip_is_closed()
         BoxDecoration::with_image(DecorationImage::new(image)).set_shape(BoxShape::Circle);
     let cmds = commands_in(rect, &decoration);
 
-    let clip_index = cmds
-        .iter()
-        .position(|c| matches!(c, DrawCommand::ClipRRect { .. }))
-        .unwrap_or_else(|| panic!("the image must be clipped to the circle; commands: {cmds:?}"));
+    // Assert the whole bracket in order rather than "a clip exists somewhere":
+    // Save opens the scope, the clip narrows it, the image draws inside it,
+    // and Restore closes it before the border. Any other order is a clip that
+    // either does not apply to the image or does not stop after it.
+    let position = |predicate: fn(&DrawCommand) -> bool| cmds.iter().position(predicate);
 
-    let DrawCommand::ClipRRect { rrect, .. } = &cmds[clip_index] else {
+    let save = position(|c| matches!(c, DrawCommand::Save { .. }))
+        .unwrap_or_else(|| panic!("the image must be drawn inside a scope; commands: {cmds:?}"));
+    let clip = position(|c| matches!(c, DrawCommand::ClipRRect { .. }))
+        .unwrap_or_else(|| panic!("the image must be clipped to the circle; commands: {cmds:?}"));
+    let image = position(|c| matches!(c, DrawCommand::DrawImage { .. }))
+        .unwrap_or_else(|| panic!("the decoration image must be drawn; commands: {cmds:?}"));
+    let restore = position(|c| matches!(c, DrawCommand::Restore { .. }))
+        .unwrap_or_else(|| panic!("the scope must close; commands: {cmds:?}"));
+
+    assert!(
+        save < clip && clip < image && image < restore,
+        "expected Save < ClipRRect < DrawImage < Restore, got {save} < {clip} < {image} < \
+         {restore}; commands: {cmds:?}",
+    );
+
+    let DrawCommand::ClipRRect { rrect, .. } = &cmds[clip] else {
         unreachable!("position() matched this variant")
     };
     assert_eq!(
@@ -483,18 +499,8 @@ fn a_circular_decoration_image_is_clipped_to_the_circle_and_the_clip_is_closed()
     assert_eq!(
         rrect.top_left.x,
         px(50.0),
-        "radii of half the shorter side make the rrect SDF an exact circle;          commands: {cmds:?}",
-    );
-
-    assert!(
-        matches!(cmds[clip_index - 1], DrawCommand::Save { .. }),
-        "the clip must be opened inside a scope; commands: {cmds:?}",
-    );
-    assert!(
-        cmds[clip_index..]
-            .iter()
-            .any(|c| matches!(c, DrawCommand::Restore { .. })),
-        "and the scope must close, or the clip narrows every later sibling;          commands: {cmds:?}",
+        "radii of half the shorter side make the rrect SDF an exact circle; \
+         commands: {cmds:?}",
     );
 }
 

--- a/crates/flui-painting/tests/decoration_unit.rs
+++ b/crates/flui-painting/tests/decoration_unit.rs
@@ -449,42 +449,52 @@ fn circle_non_uniform_border_paints_nothing_not_a_square_frame() {
 }
 
 #[test]
-fn circle_image_paints_unclipped_with_no_recorded_clip_command() {
-    // Circular image clipping is UNIMPLEMENTED (see `paint_box_decoration`'s
-    // image step): `Canvas::save()` never records anything and `restore()`
-    // only closes a `save_layer()` scope (`is_layer`), so a `ClipRRect`
-    // pushed here would never be closed -- it would leak onto the image and
-    // every later sibling command in the same `PictureLayer`. Separately,
-    // even a properly scoped `clip_rrect` would not clip an IMAGE: the
-    // rounded-SDF clip only reaches a draw through
-    // `GpuStateStack::apply_active_clip`, and the wgpu image batch never
-    // calls it (only the `RectInstance` paths in `batches/shapes.rs` do) --
-    // an image would only ever get the coarse bounding-box scissor, a
-    // SQUARE, not a circle. So the honest behavior is: no clip command
-    // recorded at all, and the image paints unclipped.
+fn a_circular_decoration_image_is_clipped_to_the_circle_and_the_clip_is_closed() {
+    // The two things that used to make this impossible are both gone: a plain
+    // `save()`/`restore()` now records a scope the backend can unwind, and the
+    // wgpu image batch routes its instances through `apply_active_clip`, so a
+    // rounded-SDF clip actually reaches a textured quad instead of only the
+    // coarse bounding-box scissor.
+    //
+    // What is asserted is the recording, which is what this crate owns: the
+    // clip is a circle inscribed in the shorter side, it is opened inside a
+    // scope, and the scope closes before anything else is drawn — a clip that
+    // outlived it would silently narrow the border painted next, and every
+    // sibling after that.
     let rect = square_rect(); // r = 50, side = 100
     let image = Image::from_rgba8(2, 2, vec![255; 2 * 2 * 4]);
     let decoration =
         BoxDecoration::with_image(DecorationImage::new(image)).set_shape(BoxShape::Circle);
     let cmds = commands_in(rect, &decoration);
 
+    let clip_index = cmds
+        .iter()
+        .position(|c| matches!(c, DrawCommand::ClipRRect { .. }))
+        .unwrap_or_else(|| panic!("the image must be clipped to the circle; commands: {cmds:?}"));
+
+    let DrawCommand::ClipRRect { rrect, .. } = &cmds[clip_index] else {
+        unreachable!("position() matched this variant")
+    };
+    assert_eq!(
+        rrect.rect.width(),
+        px(100.0),
+        "the clip spans the inscribed circle's diameter; commands: {cmds:?}",
+    );
+    assert_eq!(
+        rrect.top_left.x,
+        px(50.0),
+        "radii of half the shorter side make the rrect SDF an exact circle;          commands: {cmds:?}",
+    );
+
     assert!(
-        !cmds.iter().any(|c| matches!(
-            c,
-            DrawCommand::ClipRect { .. }
-                | DrawCommand::ClipRRect { .. }
-                | DrawCommand::ClipRSuperellipse { .. }
-                | DrawCommand::ClipPath { .. }
-        )),
-        "a circular decoration image must not record ANY clip command until \
-         circular image clipping is actually implemented (an unbalanced \
-         save()/clip_rrect()/restore() pair would leak onto later commands, \
-         and clip_rrect does not reach the image batch anyway); commands: {cmds:?}"
+        matches!(cmds[clip_index - 1], DrawCommand::Save { .. }),
+        "the clip must be opened inside a scope; commands: {cmds:?}",
     );
     assert!(
-        cmds.iter()
-            .any(|c| matches!(c, DrawCommand::DrawImage { .. })),
-        "the image must still be painted, unclipped; commands: {cmds:?}"
+        cmds[clip_index..]
+            .iter()
+            .any(|c| matches!(c, DrawCommand::Restore { .. })),
+        "and the scope must close, or the clip narrows every later sibling;          commands: {cmds:?}",
     );
 }
 


### PR DESCRIPTION
Stacked on #513 (base is that branch, so the diff here is only this half). Closes the circular-image gap #509 declared.

## What was wrong

The rounded-SDF clip only ever reached `RectInstance`. `GpuStateStack::apply_active_clip` was typed to that one struct, and `batches/images.rs` never called it — so an image got only the coarse bounding-box scissor. A circular decoration rendered its fill, border and hit-test as circles and its image as a **square**.

## The change

- `TextureInstance` gains the same `clip_rrect` + `clip_kind` slot as `RectInstance`, with the same all-zero sentinel and the same per-corner rx/ry averaging for the superellipse kind.
- `texture_instanced.wgsl` gains the SDF clip block. Inlined rather than shared: WGSL here has no include mechanism and `rect_instanced.wgsl` set that convention. The math is byte-for-byte the rect shader's — a clip that rounds differently per primitive is worse than no clip, because the seam shows exactly where two primitives meet.
- `apply_active_clip` becomes generic over a new `ClippableInstance` trait, so the branch order between the rrect and superellipse slots stays decided in one place instead of being re-derived per batch. All ten image construction sites route through it.
- `paint_box_decoration` scopes the circular case: `save` → `clip_rrect(circle)` → draw → `restore`. Only possible because #513 gave a plain save/restore something to record. The old comment naming the two blockers, and its one-shot warning, are deleted with them.

A circle is expressed as radii of half the shorter side, and that is **exact** here — the clip is a signed distance field, not tessellated geometry, so the ~6% diagonal bulge that ruled out drrect for a circular *ring* does not apply to a clip.

## Evidence is a pixel

The whole class of bug this closes is invisible to the command stream, so the test is a readback: clip an image to an inscribed circle, assert the centre is the image and all four corners keep the backdrop.

Ran on a real GPU locally — passes. Verified it can fail: neutering `TextureInstance::with_clip_rrect` to a no-op fails it on the corner assertion.

Worth noting on its own: **this is the first readback case covering a clipped image at all.** The merge-blocking suite had no oracle for one, which is the same coverage shape that let the stroked-circle bug (#510) sit under a green gate.

## Left deliberately

A rounded-rect decoration still paints its image to the full rect, where Flutter clips it too. Identical mechanism, but it changes what existing rounded decorations render and no oracle covers a clipped image — so it is named at the call site rather than changed blind.

## Verification

- `cargo nextest run --workspace --exclude flui-platform` — **8370 passed**, 0 failed, 15 skipped
- `cargo nextest run -p flui-engine --features enable-wgpu-tests -E 'test(a_clipped_image_keeps_the_backdrop)'` — passes on a local GPU device
- `cargo clippy -p flui-engine --all-targets --features enable-wgpu-tests -- -D warnings` — clean
- `cargo fmt --all --check`, `port-check`, `typos` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)