### PR TITLE
test(widgets): port the ListBody parity cases, and pin an ambient-Directionality bug

### DIFF
--- a/crates/flui-widgets/tests/parity/list_body_test.rs
+++ b/crates/flui-widgets/tests/parity/list_body_test.rs
@@ -331,12 +331,13 @@ fn list_body_right_lays_out_left_to_right_stretched_to_parent_height() {
 /// `Axis::Horizontal` + `reverse: false` to `AxisDirection::LeftToRight`
 /// unconditionally — identical to case 3's LTR scene above, even though this
 /// scene's ambient direction is RTL. The render object's own
-/// `AxisDirection::RightToLeft` branch is correct (it is exercised, and
-/// passes, by the `main_axis(Axis::Horizontal)` + `.reverse(true)` case in
-/// the non-parity `crates/flui-widgets/tests/list_body.rs` suite's sibling
-/// coverage and by this port's own render-object-level construction tests);
-/// the defect is entirely in the widget layer never selecting that branch
-/// from ambient RTL.
+/// `AxisDirection::RightToLeft` branch is correct and is exercised — by
+/// `harness_list_body_horizontal_right_to_left_stretches_height`
+/// (`crates/flui-objects/tests/render_object_harness.rs`), which drives the
+/// render object directly. Note what that means: the render object handles
+/// RTL, and nothing in the widget layer ever asks it to. The defect is
+/// entirely in `axis_direction` never selecting that branch from ambient
+/// direction.
 ///
 /// Captured failure (this pin run once un-ignored, verbatim from the
 /// harness): the first assertion fails with

--- a/crates/flui-widgets/tests/parity/list_body_test.rs
+++ b/crates/flui-widgets/tests/parity/list_body_test.rs
@@ -1,0 +1,473 @@
+//! ## Test parity notes
+//!
+//! Flutter source:
+//! - Widget: `packages/flutter/lib/src/widgets/basic.dart` `ListBody` over
+//!   `RenderListBody` (`packages/flutter/lib/src/rendering/list_body.dart`).
+//! - Tests: `packages/flutter/test/widgets/list_body_test.dart` (tag
+//!   `3.44.0`), all six cases.
+//!
+//! `RenderListBody`'s contract (`rendering/list_body.dart`,
+//! `performLayout`/`computeDryLayout`): children are laid out sequentially
+//! along the main axis at their own intrinsic main-axis extent — the render
+//! object hands each child `BoxConstraints.tightFor(<cross axis>: <its own
+//! cross extent>)`, leaving the main axis of that per-child constraint fully
+//! open (`0..∞`) — while forcing every child's cross axis tight to the box's
+//! own cross extent. The box's own main-axis extent is the sum of its
+//! children's main-axis extents; its cross extent is whatever the parent
+//! constrains it to. It never clips or resizes a child's main-axis extent to
+//! fit, and it asserts (`_debugCheckConstraints`) that its own incoming
+//! constraints give it unlimited main-axis space and a bounded cross axis —
+//! the two error cases below.
+//!
+//! ## Case ledger
+//!
+//! 1. `'ListBody down'` — ported, real green:
+//!    [`list_body_down_lays_out_top_to_bottom_stretched_to_parent_width`].
+//! 2. `'ListBody up'` — ported, real green:
+//!    [`list_body_up_lays_out_bottom_to_top_stretched_to_parent_width`].
+//! 3. `'ListBody right'` — ported, real green:
+//!    [`list_body_right_lays_out_left_to_right_stretched_to_parent_height`].
+//!    LTR ambient direction, non-reverse; see "Divergence found by this
+//!    port" below for why this case passing does not, on its own, prove FLUI
+//!    resolves ambient direction at all.
+//! 4. `'ListBody left'` — **divergence pin**, asserting the oracle:
+//!    [`list_body_left_lays_out_right_to_left_pin`]. See "Divergence found by
+//!    this port" below.
+//! 5. `'Limited space along main axis error'` — ported, real green, but via
+//!    an observable that needed empirical discovery, not the mechanism the
+//!    module doc originally assumed — see "The layout-poisoning gap found by
+//!    this port" below:
+//!    [`horizontal_list_body_without_unlimited_main_axis_panics`].
+//! 6. `'Nested ListBody unbounded cross axis error'` — ported, real green,
+//!    same gap:
+//!    [`nested_list_body_with_unbounded_cross_axis_panics`].
+//!
+//! ## The layout-poisoning gap found by this port (cases 5 and 6)
+//!
+//! Both error cases trip a real `debug_assert!` in
+//! `RenderListBody::debug_check_constraints`
+//! (`crates/flui-objects/src/layout/list_body.rs`) — confirmed by the
+//! `thread '...' panicked at .../list_body.rs:84:17: RenderListBody must
+//! have unlimited space along its main axis` line that prints to stderr on
+//! every run. But that panic never reaches `harness::pump_widget`'s caller:
+//! `flui-rendering`'s layout walk
+//! (`crates/flui-rendering/src/pipeline/owner/subtree_arena.rs`) wraps
+//! `perform_layout_raw` in `catch_unwind` for BOTH the leaf and non-leaf
+//! paths (not only the sliver child-manager build path
+//! `error_widget_test.rs`'s module doc describes — this is a separate,
+//! more general net), converts the panic to
+//! `RenderError::Poisoned { render_object, phase: "layout" }`, and the
+//! walk's caller swallows that `Err` entirely: the offending node is left
+//! with NO committed geometry, its ancestors still complete their own
+//! layout and the whole frame finishes as if nothing failed. `pump_widget`
+//! itself never panics or errors — confirmed by writing this test first as
+//! a bare `#[should_panic]` around the `pump_widget` call alone (no
+//! `expected` string) and observing it fail with "test did not panic as
+//! expected".
+//!
+//! The only place the failure becomes observable at all is the poisoned
+//! node's own geometry: `LaidOut::size` (`crates/flui-widgets/tests/
+//! common/mod.rs:322`) asserts the render node has committed box geometry,
+//! and panics with `"render node should have box geometry after layout"`
+//! when it does not — an unrelated-sounding message, not the original
+//! assert text, because by the time a test can query it, the pipeline has
+//! already discarded the original panic payload into a `tracing::error!`
+//! log event instead of any queryable `Result`. Both tests below assert
+//! that specific, real, reproducible symptom.
+//!
+//! This is a materially different (and arguably worse) divergence from
+//! Flutter than the `debug_assert!`-vs-`FlutterError` mechanism gap
+//! `table_test.rs`/`flow_test.rs` already document: Flutter's
+//! `FlutterError` is caught by the framework and reported through
+//! `FlutterError.onError`/`tester.takeException()` — a documented, typed,
+//! application-observable channel. FLUI's equivalent invariant violation is
+//! caught too, but the only trace left behind is a `tracing::error!` log
+//! line and a node with permanently-missing geometry; nothing in the
+//! `PipelineOwner`/`pump_widget` public surface reports that the frame
+//! contains a poisoned node at all. Reported here, not fixed: closing it
+//! means deciding where a poisoned-node signal should surface (a
+//! `PipelineOwner` query? a diagnostics counter?), which is a `flui-rendering`
+//! design question this test file has no standing to answer.
+//!
+//! ## Divergence found by this port
+//!
+//! `ListBody::axis_direction` (`crates/flui-widgets/src/layout/list_body.rs`)
+//! computes its `AxisDirection` from `main_axis` and `reverse` alone:
+//!
+//! ```text
+//! fn axis_direction(&self) -> AxisDirection {
+//!     AxisDirection::from_axis(self.main_axis, self.reverse)
+//! }
+//! ```
+//!
+//! Flutter's `ListBody._getDirection(BuildContext context)` instead calls
+//! `getAxisDirectionFromAxisReverseAndDirectionality(context, mainAxis,
+//! reverse)` (`widgets/basic.dart`), which for `Axis.horizontal` reads
+//! `Directionality.of(context)` and flips the resulting `AxisDirection`
+//! between `left`/`right` depending on the ambient `TextDirection`. FLUI's
+//! version never looks at `Directionality` at all: for `Axis::Horizontal`
+//! with `reverse: false` it is unconditionally `AxisDirection::LeftToRight`,
+//! regardless of what `Directionality` ancestor is in scope.
+//!
+//! The root cause is structural, not a one-line oversight:
+//! `flui_view::RenderObjectContext` (`crates/flui-view/src/view/render.rs`)
+//! — the only context `RenderView::create_render_object`/
+//! `update_render_object` ever receive — carries nothing but an optional
+//! interaction-dispatch handle. There is no ambient inherited-data lookup
+//! capability at that call site at all, so no leaf `RenderView` in
+//! `flui-widgets` can consult `Directionality` while building its render
+//! object. This is not `ListBody`-specific: `Flex`/`Row`/`Column`
+//! (`crates/flui-widgets/src/flex/flex.rs`) share the identical gap —
+//! grepping that file for `text_direction`/`Directionality`/`TextDirection`
+//! returns zero hits, confirming FLUI's flex family has no RTL-aware
+//! `textDirection` concept at all yet either.
+//!
+//! Effect: a horizontal `ListBody` with `reverse: false` under an RTL
+//! `Directionality` ancestor lays out its children left-to-right instead of
+//! Flutter's right-to-left — a real content-mirroring defect for RTL
+//! locales, not a cosmetic one. Case 3 above (`'ListBody right'`) passes
+//! today, but only because its ambient direction is LTR, which coincides
+//! with FLUI's hardcoded default; it does not exercise, and cannot catch,
+//! this gap. Only case 4 (RTL ambient) does, which is why it is pinned
+//! rather than silently folded into "already covered by case 3".
+//!
+//! Not fixed here: closing this gap means widening `RenderObjectContext`
+//! with an ambient-lookup capability — a `flui-view` architecture change
+//! spanning every `RenderView` impl that would need it (`ListBody` today,
+//! `Flex`/`Row`/`Column` eventually) — not a `flui-widgets`-local, test-only
+//! fix. Reported for `flui-view`/`flui-widgets` maintainers to design
+//! against, not patched silently here.
+
+use flui_foundation::RenderId;
+use flui_types::layout::Axis;
+use flui_types::typography::TextDirection;
+use flui_widgets::{Column, Directionality, ListBody, Row, SizedBox, row};
+
+use crate::harness;
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const ITEM_WIDTH: f32 = 200.0;
+const ITEM_HEIGHT: f32 = 150.0;
+
+/// The oracle's shared `children` constant: four identically-sized boxes.
+fn oracle_children() -> (SizedBox, SizedBox, SizedBox, SizedBox) {
+    (
+        SizedBox::new(ITEM_WIDTH, ITEM_HEIGHT),
+        SizedBox::new(ITEM_WIDTH, ITEM_HEIGHT),
+        SizedBox::new(ITEM_WIDTH, ITEM_HEIGHT),
+        SizedBox::new(ITEM_WIDTH, ITEM_HEIGHT),
+    )
+}
+
+// ============================================================================
+// Case 1 — 'ListBody down'
+// ============================================================================
+
+/// Flutter parity: `list_body_test.dart` `'ListBody down'` (tag `3.44.0`).
+///
+/// A vertical `ListBody` nested in a vertical `Flex` (`Column`, which gives
+/// it unlimited height and a bounded, 800px-wide cross axis) stacks its four
+/// 200×150 children top to bottom, each stretched to the full 800px width.
+///
+/// Mutation-checked: temporarily changing child 2's expected `dy` from
+/// `300.0` to `301.0` flips this red — captured verbatim:
+/// `assertion `left == right` failed: child 2's absolute (x, y, width,
+/// height) must match the oracle's Rect.fromLTWH left: (0.0, 300.0, 800.0,
+/// 150.0) right: (0.0, 301.0, 800.0, 150.0)` — reverted after confirming.
+#[test]
+fn list_body_down_lays_out_top_to_bottom_stretched_to_parent_width() {
+    let laid = harness::pump_widget(
+        Column::new(row![ListBody::new(oracle_children())]),
+        harness::screen(),
+    );
+
+    let list_body = laid.find_by_render_type("RenderListBody");
+    let rect = |id: RenderId| {
+        let offset = laid.absolute_offset(id);
+        let size = laid.size(id);
+        (
+            offset.dx.get(),
+            offset.dy.get(),
+            size.width.get(),
+            size.height.get(),
+        )
+    };
+
+    let expected = [
+        (0.0, 0.0, 800.0, 150.0),
+        (0.0, 150.0, 800.0, 150.0),
+        (0.0, 300.0, 800.0, 150.0),
+        (0.0, 450.0, 800.0, 150.0),
+    ];
+    for (i, expected_rect) in expected.into_iter().enumerate() {
+        let child = laid.child(list_body, i);
+        assert_eq!(
+            rect(child),
+            expected_rect,
+            "child {i}'s absolute (x, y, width, height) must match the \
+             oracle's Rect.fromLTWH"
+        );
+    }
+}
+
+// ============================================================================
+// Case 2 — 'ListBody up'
+// ============================================================================
+
+/// Flutter parity: `list_body_test.dart` `'ListBody up'` (tag `3.44.0`).
+///
+/// `reverse: true` on a vertical `ListBody` flips the main axis to
+/// bottom-to-top: the first child ends up lowest on screen, the last child
+/// highest — without changing any child's own size.
+#[test]
+fn list_body_up_lays_out_bottom_to_top_stretched_to_parent_width() {
+    let laid = harness::pump_widget(
+        Column::new(row![ListBody::new(oracle_children()).reverse(true)]),
+        harness::screen(),
+    );
+
+    let list_body = laid.find_by_render_type("RenderListBody");
+    let rect = |id: RenderId| {
+        let offset = laid.absolute_offset(id);
+        let size = laid.size(id);
+        (
+            offset.dx.get(),
+            offset.dy.get(),
+            size.width.get(),
+            size.height.get(),
+        )
+    };
+
+    let expected = [
+        (0.0, 450.0, 800.0, 150.0),
+        (0.0, 300.0, 800.0, 150.0),
+        (0.0, 150.0, 800.0, 150.0),
+        (0.0, 0.0, 800.0, 150.0),
+    ];
+    for (i, expected_rect) in expected.into_iter().enumerate() {
+        let child = laid.child(list_body, i);
+        assert_eq!(
+            rect(child),
+            expected_rect,
+            "child {i}'s absolute (x, y, width, height) must match the \
+             oracle's Rect.fromLTWH"
+        );
+    }
+}
+
+// ============================================================================
+// Case 3 — 'ListBody right'
+// ============================================================================
+
+/// Flutter parity: `list_body_test.dart` `'ListBody right'` (tag `3.44.0`).
+///
+/// A horizontal `ListBody` under an LTR `Directionality`, nested in a
+/// horizontal `Flex` (`Row`, which gives it unlimited width and a bounded,
+/// 600px-tall cross axis), places its four 200×150 children left to right,
+/// each stretched to the full 600px height.
+///
+/// This passes today even though FLUI's `ListBody` ignores ambient
+/// `Directionality` entirely (see the module doc's divergence note): LTR is
+/// also FLUI's hardcoded default for `Axis::Horizontal` + `reverse: false`,
+/// so this scene cannot distinguish "reads Directionality and got LTR" from
+/// "ignores Directionality and defaults to LTR". Case 4 below is the one
+/// that actually exercises ambient direction.
+#[test]
+fn list_body_right_lays_out_left_to_right_stretched_to_parent_height() {
+    let laid = harness::pump_widget(
+        Row::new(row![Directionality::new(
+            TextDirection::Ltr,
+            ListBody::new(oracle_children()).main_axis(Axis::Horizontal),
+        )]),
+        harness::screen(),
+    );
+
+    let list_body = laid.find_by_render_type("RenderListBody");
+    let rect = |id: RenderId| {
+        let offset = laid.absolute_offset(id);
+        let size = laid.size(id);
+        (
+            offset.dx.get(),
+            offset.dy.get(),
+            size.width.get(),
+            size.height.get(),
+        )
+    };
+
+    let expected = [
+        (0.0, 0.0, 200.0, 600.0),
+        (200.0, 0.0, 200.0, 600.0),
+        (400.0, 0.0, 200.0, 600.0),
+        (600.0, 0.0, 200.0, 600.0),
+    ];
+    for (i, expected_rect) in expected.into_iter().enumerate() {
+        let child = laid.child(list_body, i);
+        assert_eq!(
+            rect(child),
+            expected_rect,
+            "child {i}'s absolute (x, y, width, height) must match the \
+             oracle's Rect.fromLTWH"
+        );
+    }
+}
+
+// ============================================================================
+// Case 4 (divergence pin) — 'ListBody left'
+// ============================================================================
+
+/// Flutter parity: `list_body_test.dart` `'ListBody left'` (tag `3.44.0`).
+///
+/// **`#[ignore]`d divergence pin, verified failing.** Asserts the oracle's
+/// behaviour: a horizontal, non-reversed `ListBody` under an RTL
+/// `Directionality` lays its children out right to left — the first child
+/// (`children[0]`) ends up rightmost, at `x = 600`, and the last ends up
+/// leftmost, at `x = 0`.
+///
+/// FLUI's `ListBody::axis_direction` ignores `Directionality` entirely (see
+/// the module doc's "Divergence found by this port"), so it resolves
+/// `Axis::Horizontal` + `reverse: false` to `AxisDirection::LeftToRight`
+/// unconditionally — identical to case 3's LTR scene above, even though this
+/// scene's ambient direction is RTL. The render object's own
+/// `AxisDirection::RightToLeft` branch is correct (it is exercised, and
+/// passes, by the `main_axis(Axis::Horizontal)` + `.reverse(true)` case in
+/// the non-parity `crates/flui-widgets/tests/list_body.rs` suite's sibling
+/// coverage and by this port's own render-object-level construction tests);
+/// the defect is entirely in the widget layer never selecting that branch
+/// from ambient RTL.
+///
+/// Captured failure (this pin run once un-ignored, verbatim from the
+/// harness): the first assertion fails with
+/// `left: (0.0, 0.0, 200.0, 600.0), right: (600.0, 0.0, 200.0, 600.0)` —
+/// FLUI places `children[0]` at the LTR position `x = 0` instead of the
+/// oracle's RTL position `x = 600`.
+#[test]
+#[ignore = "divergence pin: ListBody::axis_direction never consults ambient \
+            Directionality (RenderObjectContext has no inherited-data lookup \
+            capability) — see the module doc's 'Divergence found by this port'"]
+fn list_body_left_lays_out_right_to_left_pin() {
+    let laid = harness::pump_widget(
+        Row::new(row![Directionality::new(
+            TextDirection::Rtl,
+            ListBody::new(oracle_children()).main_axis(Axis::Horizontal),
+        )]),
+        harness::screen(),
+    );
+
+    let list_body = laid.find_by_render_type("RenderListBody");
+    let rect = |id: RenderId| {
+        let offset = laid.absolute_offset(id);
+        let size = laid.size(id);
+        (
+            offset.dx.get(),
+            offset.dy.get(),
+            size.width.get(),
+            size.height.get(),
+        )
+    };
+
+    let expected = [
+        (600.0, 0.0, 200.0, 600.0),
+        (400.0, 0.0, 200.0, 600.0),
+        (200.0, 0.0, 200.0, 600.0),
+        (0.0, 0.0, 200.0, 600.0),
+    ];
+    for (i, expected_rect) in expected.into_iter().enumerate() {
+        let child = laid.child(list_body, i);
+        assert_eq!(
+            rect(child),
+            expected_rect,
+            "child {i}'s absolute (x, y, width, height) must match the \
+             oracle's Rect.fromLTWH under RTL"
+        );
+    }
+}
+
+// ============================================================================
+// Case 5 — 'Limited space along main axis error'
+// ============================================================================
+
+/// Flutter parity: `list_body_test.dart` `'Limited space along main axis
+/// error'` (tag `3.44.0`).
+///
+/// The oracle wraps a horizontal `ListBody` directly in a `SizedBox.square`
+/// (no `Flex` ancestor to relax the main axis to infinity), so the box's own
+/// incoming main-axis (width) constraint stays finite/tight, and
+/// `RenderListBody._debugCheckConstraints` throws.
+///
+/// FLUI's `RenderListBody::debug_check_constraints`
+/// (`crates/flui-objects/src/layout/list_body.rs`) enforces the identical
+/// invariant with a `debug_assert!`, but the layout pipeline catches and
+/// swallows that panic (`RenderError::Poisoned`) rather than surfacing it to
+/// `pump_widget`'s caller at all — see the module doc's "layout-poisoning
+/// gap" section. The only observable symptom at this test's level is that
+/// the poisoned `ListBody` node never receives committed geometry, so
+/// querying its size panics with the harness's own
+/// `"render node should have box geometry after layout"` message — that is
+/// what this test actually pins, not the original assert text.
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "render node should have box geometry after layout")]
+fn horizontal_list_body_without_unlimited_main_axis_panics() {
+    let laid = harness::pump_widget(
+        SizedBox::square(100.0).child(Directionality::new(
+            TextDirection::Rtl,
+            ListBody::new(oracle_children()).main_axis(Axis::Horizontal),
+        )),
+        harness::screen(),
+    );
+    let list_body = laid.find_by_render_type("RenderListBody");
+    let _ = laid.size(list_body);
+}
+
+// ============================================================================
+// Case 6 — 'Nested ListBody unbounded cross axis error'
+// ============================================================================
+
+/// Flutter parity: `list_body_test.dart` `'Nested ListBody unbounded cross
+/// axis error'` (tag `3.44.0`).
+///
+/// The outer horizontal `ListBody` is correctly nested in a horizontal
+/// `Flex` (`Row`), so its own main axis is fine. Its single child is a
+/// vertical `Flex` (`Column`) wrapping an inner, default (vertical)
+/// `ListBody`. The outer `ListBody` hands its `Column` child an unconstrained
+/// width (main-axis passthrough for a horizontal `ListBody`'s child); the
+/// `Column`'s own non-stretch `CrossAxisAlignment::Center` default loosens
+/// its own child's cross axis (width) to that SAME unbounded max — so the
+/// inner `ListBody`'s cross axis (width, since its main axis is vertical)
+/// arrives unbounded, and `RenderListBody._debugCheckConstraints` throws.
+///
+/// Same mechanism divergence as case 5 (see that test's doc comment): the
+/// `debug_assert!` fires, gets caught by the layout pipeline's
+/// `catch_unwind`, and is swallowed as a `RenderError::Poisoned` — invisible
+/// to `pump_widget`'s caller. Querying the poisoned inner `ListBody`'s own
+/// geometry is what surfaces it.
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "render node should have box geometry after layout")]
+fn nested_list_body_with_unbounded_cross_axis_panics() {
+    let laid = harness::pump_widget(
+        Row::new(row![Directionality::new(
+            TextDirection::Ltr,
+            ListBody::new(row![Column::new(row![Directionality::new(
+                TextDirection::Ltr,
+                ListBody::new(oracle_children()),
+            )])])
+            .main_axis(Axis::Horizontal),
+        )]),
+        harness::screen(),
+    );
+
+    // Two `RenderListBody` nodes exist (outer + inner), so
+    // `find_by_render_type` is ambiguous here. The outer one laid out fine
+    // (its own constraints were valid) — walk down from the root
+    // (`Row` -> outer `ListBody` -> `Column` -> inner `ListBody`;
+    // `Directionality` is transparent, no render node of its own) to reach
+    // the poisoned inner one.
+    let outer_list_body = laid.only_child(laid.root());
+    let column = laid.only_child(outer_list_body);
+    let inner_list_body = laid.only_child(column);
+    let _ = laid.size(inner_list_body);
+}

--- a/crates/flui-widgets/tests/parity/main.rs
+++ b/crates/flui-widgets/tests/parity/main.rs
@@ -194,3 +194,6 @@ mod colored_box_test;
 // ── Business.1 fidelity — UnconstrainedBox parity (basic_test.dart
 //    UnconstrainedBox group) ───────────────────────────────────────────────
 mod unconstrained_box_test;
+
+// ── Business.1 fidelity — ListBody parity (list_body_test.dart) ────────────
+mod list_body_test;


### PR DESCRIPTION
Business.1 fidelity. Ports all 6 cases of `list_body_test.dart` (tag `3.44.0`). Four real green, one `#[ignore]`d divergence pin, and the port turned up **two production findings** — neither fixed here, both documented.

## Finding 1 — `ListBody` ignores ambient `Directionality` (pinned)

`ListBody::axis_direction` (`crates/flui-widgets/src/layout/list_body.rs`) is:

```rust
AxisDirection::from_axis(self.main_axis, self.reverse)
```

No `Directionality` anywhere. So a horizontal, non-reversed `ListBody` under an RTL ambient direction lays out **left to right** — identical to the LTR scene — where the oracle lays it right to left.

The render object is not at fault: its `AxisDirection::RightToLeft` branch is correct and is exercised. The defect is the widget layer never selecting that branch from ambient direction.

Pinned by `list_body_left_lays_out_right_to_left_pin`, which asserts the **oracle** and carries `#[ignore]`. Verified failing when un-ignored:

```
left: (0.0, 0.0, 200.0, 600.0), right: (600.0, 0.0, 200.0, 600.0)
```

Note the trap this creates for a reader: case 3 (LTR) passes, and its passing proves nothing about direction resolution — the ledger says so explicitly, because otherwise the green LTR case reads as evidence the feature works.

## Finding 2 — a failed layout assert leaves a poisoned node and no observable signal

Cases 5 and 6 trip a real `debug_assert!` in `RenderListBody::debug_check_constraints`. The layout walk's caller swallows the resulting `Err` entirely: the offending node ends with **no committed geometry**, its ancestors finish their own layout, and the frame completes as if nothing failed. `pump_widget` neither panics nor errors — established empirically by first writing the test as a bare `#[should_panic]` around `pump_widget` and watching it fail with *"test did not panic as expected"*.

The only trace is a `tracing::error!` line and a node with permanently-missing geometry. Nothing on the `PipelineOwner` / `pump_widget` surface reports that the frame contains a poisoned node.

That is a materially different divergence from the `debug_assert!`-vs-`FlutterError` mechanism gap already documented elsewhere: Flutter's error is a typed, application-observable channel (`FlutterError.onError` / `takeException`). Not fixed here — closing it means deciding *where* a poisoned-node signal should surface, which is a `flui-rendering` design question a test file has no standing to answer.

## Verification — run independently, not taken on report

- `cargo nextest run --workspace --exclude flui-platform` — **8385 passed**, 17 skipped (the extra skip is the new pin)
- Pin verified to fail under `--run-ignored all`, which is what makes it an honest quarantine rather than decoration
- Independently falsified a green case (not just the pin): perturbing the `'ListBody up'` expected offset fails with `left: (0.0, 450.0, 800.0, 150.0)`
- `cargo clippy -p flui-widgets --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, `port-check`, `typos` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)