### PR TITLE
fix(widgets): ListBody resolves AxisDirection from ambient Directionality

### DIFF
--- a/crates/flui-widgets/src/layout/list_body.rs
+++ b/crates/flui-widgets/src/layout/list_body.rs
@@ -117,7 +117,8 @@ where
 }
 
 /// The actual `RenderListBody`-backed render-object widget. Its
-/// `AxisDirection` is already resolved by [`ListBody::build`] — kept private
+/// `AxisDirection` is already resolved by [`ListBody`]'s `StatelessView::build`
+/// — kept private
 /// so `Directionality` is only ever read at the `BuildContext` seam that can
 /// see it, never assumed to be reachable from a bare `RenderView`.
 #[derive(Clone)]

--- a/crates/flui-widgets/src/layout/list_body.rs
+++ b/crates/flui-widgets/src/layout/list_body.rs
@@ -5,9 +5,11 @@ use std::fmt;
 use flui_objects::RenderListBody;
 use flui_rendering::protocol::BoxProtocol;
 use flui_types::layout::{Axis, AxisDirection};
+use flui_types::typography::TextDirection;
 use flui_view::BoxedView;
 use flui_view::seq::ViewSeq;
 
+use crate::localization::Directionality;
 use crate::support::generic_render_view_element;
 
 /// Lays children out sequentially along one axis, stretching them in the cross
@@ -16,6 +18,22 @@ use crate::support::generic_render_view_element;
 /// Flutter parity: `widgets/basic.dart` `ListBody` over `RenderListBody`.
 /// `ListBody` expects its parent to provide unbounded space along the main axis
 /// and a bounded cross axis, typically inside a matching scrollable.
+///
+/// Resolves its `AxisDirection` the way Flutter's
+/// `getAxisDirectionFromAxisReverseAndDirectionality` does (`widgets/
+/// basic.dart`): a horizontal `ListBody` reads the ambient [`Directionality`]
+/// and picks `LeftToRight`/`RightToLeft` accordingly (defaulting to `Ltr` with
+/// no ancestor, matching every other FLUI widget that consults
+/// `Directionality`), then `reverse` flips the result to its opposite. A
+/// vertical `ListBody` never consults `Directionality` — `reverse` alone
+/// decides `TopToBottom` vs. `BottomToTop`, mirroring `_getDirection`'s own
+/// `Axis.vertical` arm. That ambient read only exists inside a
+/// `BuildContext`, so `ListBody` is a composing widget: `build` resolves the
+/// direction once and hands the *already-resolved* `AxisDirection` to a
+/// private render-object widget — `flui_view::RenderObjectContext` (the only
+/// context `RenderView::create_render_object`/`update_render_object` ever
+/// receive) carries no ambient-lookup capability, so a bare `RenderView` can
+/// never read `Directionality` itself.
 #[derive(Clone)]
 pub struct ListBody<C = Vec<BoxedView>> {
     main_axis: Axis,
@@ -47,8 +65,22 @@ impl<C> ListBody<C> {
         self
     }
 
-    fn axis_direction(&self) -> AxisDirection {
-        AxisDirection::from_axis(self.main_axis, self.reverse)
+    /// Resolve the render object's `AxisDirection`: Flutter's
+    /// `getAxisDirectionFromAxisReverseAndDirectionality` (`widgets/
+    /// basic.dart`) — only `Axis::Horizontal` consults `text_direction`;
+    /// `reverse` flips either axis's base direction to its opposite.
+    fn resolve_axis_direction(&self, text_direction: TextDirection) -> AxisDirection {
+        match self.main_axis {
+            Axis::Horizontal => {
+                let base = if text_direction.is_rtl() {
+                    AxisDirection::RightToLeft
+                } else {
+                    AxisDirection::LeftToRight
+                };
+                if self.reverse { base.opposite() } else { base }
+            }
+            Axis::Vertical => AxisDirection::from_axis(Axis::Vertical, self.reverse),
+        }
     }
 }
 
@@ -62,7 +94,39 @@ impl<C: ViewSeq> fmt::Debug for ListBody<C> {
     }
 }
 
-impl<C> flui_view::RenderView for ListBody<C>
+impl<C> flui_view::View for ListBody<C>
+where
+    C: ViewSeq + Clone + 'static,
+{
+    fn create_element(&self) -> flui_view::element::ElementKind {
+        flui_view::element::ElementKind::stateless(self)
+    }
+}
+
+impl<C> flui_view::StatelessView for ListBody<C>
+where
+    C: ViewSeq + Clone + 'static,
+{
+    fn build(&self, ctx: &dyn flui_view::BuildContext) -> impl flui_view::IntoView {
+        let text_direction = Directionality::maybe_of(ctx).unwrap_or(TextDirection::Ltr);
+        ListBodyRenderView {
+            axis_direction: self.resolve_axis_direction(text_direction),
+            children: self.children.clone(),
+        }
+    }
+}
+
+/// The actual `RenderListBody`-backed render-object widget. Its
+/// `AxisDirection` is already resolved by [`ListBody::build`] — kept private
+/// so `Directionality` is only ever read at the `BuildContext` seam that can
+/// see it, never assumed to be reachable from a bare `RenderView`.
+#[derive(Clone)]
+struct ListBodyRenderView<C> {
+    axis_direction: AxisDirection,
+    children: C,
+}
+
+impl<C> flui_view::RenderView for ListBodyRenderView<C>
 where
     C: ViewSeq + Clone + 'static,
 {
@@ -70,7 +134,7 @@ where
     type RenderObject = RenderListBody;
 
     fn create_render_object(&self, _ctx: &flui_view::RenderObjectContext<'_>) -> RenderListBody {
-        RenderListBody::with_axis_direction(self.axis_direction())
+        RenderListBody::with_axis_direction(self.axis_direction)
     }
 
     fn update_render_object(
@@ -78,7 +142,7 @@ where
         _ctx: &flui_view::RenderObjectContext<'_>,
         render_object: &mut RenderListBody,
     ) {
-        render_object.set_axis_direction(self.axis_direction());
+        render_object.set_axis_direction(self.axis_direction);
     }
 
     fn has_children(&self) -> bool {
@@ -90,7 +154,7 @@ where
     }
 }
 
-generic_render_view_element!(ListBody);
+generic_render_view_element!(ListBodyRenderView);
 
 #[cfg(test)]
 mod tests {
@@ -101,50 +165,119 @@ mod tests {
     use super::*;
     use crate::SizedBox;
 
+    // ------------------------------------------------------------------
+    // `resolve_axis_direction` — the Flutter parity rule under test. Covers
+    // every (axis, reverse, text_direction) combination `getAxisDirectionFrom
+    // AxisReverseAndDirectionality` handles, including the RTL cases a
+    // vertical-only `AxisDirection::from_axis` call could never reach.
+    // ------------------------------------------------------------------
+
     #[test]
-    fn create_render_object_defaults_to_top_to_bottom() {
+    fn resolve_axis_direction_vertical_defaults_to_top_to_bottom() {
         let list_body: ListBody = ListBody::new(Vec::new());
-        let render_object =
-            list_body.create_render_object(&flui_view::RenderObjectContext::detached());
-        assert_eq!(render_object.axis_direction(), AxisDirection::TopToBottom);
+        assert_eq!(
+            list_body.resolve_axis_direction(TextDirection::Ltr),
+            AxisDirection::TopToBottom
+        );
     }
 
     #[test]
-    fn create_render_object_reverse_vertical_is_bottom_to_top() {
+    fn resolve_axis_direction_vertical_reverse_is_bottom_to_top() {
         let list_body: ListBody = ListBody::new(Vec::new()).reverse(true);
-        let render_object =
-            list_body.create_render_object(&flui_view::RenderObjectContext::detached());
-        assert_eq!(render_object.axis_direction(), AxisDirection::BottomToTop);
+        assert_eq!(
+            list_body.resolve_axis_direction(TextDirection::Ltr),
+            AxisDirection::BottomToTop
+        );
+    }
+
+    /// The vertical axis never consults `text_direction` — Flutter's
+    /// `_getDirection`'s `Axis.vertical` arm ignores it too.
+    #[test]
+    fn resolve_axis_direction_vertical_ignores_text_direction() {
+        let list_body: ListBody = ListBody::new(Vec::new()).reverse(true);
+        assert_eq!(
+            list_body.resolve_axis_direction(TextDirection::Rtl),
+            AxisDirection::BottomToTop,
+            "an RTL ambient direction must not change a vertical ListBody's axis direction"
+        );
     }
 
     #[test]
-    fn create_render_object_horizontal_is_left_to_right() {
+    fn resolve_axis_direction_horizontal_ltr_is_left_to_right() {
         let list_body: ListBody = ListBody::new(Vec::new()).main_axis(Axis::Horizontal);
-        let render_object =
-            list_body.create_render_object(&flui_view::RenderObjectContext::detached());
-        assert_eq!(render_object.axis_direction(), AxisDirection::LeftToRight);
+        assert_eq!(
+            list_body.resolve_axis_direction(TextDirection::Ltr),
+            AxisDirection::LeftToRight
+        );
     }
 
     #[test]
-    fn create_render_object_horizontal_reverse_is_right_to_left() {
+    fn resolve_axis_direction_horizontal_rtl_is_right_to_left() {
+        let list_body: ListBody = ListBody::new(Vec::new()).main_axis(Axis::Horizontal);
+        assert_eq!(
+            list_body.resolve_axis_direction(TextDirection::Rtl),
+            AxisDirection::RightToLeft,
+            "a horizontal ListBody under RTL Directionality must lay out right to left"
+        );
+    }
+
+    #[test]
+    fn resolve_axis_direction_horizontal_ltr_reverse_is_right_to_left() {
         let list_body: ListBody = ListBody::new(Vec::new())
             .main_axis(Axis::Horizontal)
             .reverse(true);
+        assert_eq!(
+            list_body.resolve_axis_direction(TextDirection::Ltr),
+            AxisDirection::RightToLeft
+        );
+    }
+
+    /// `reverse` flips the RTL base direction too: RTL + reverse ends up back
+    /// at `LeftToRight`, matching `flipAxisDirection(AxisDirection.left)`.
+    #[test]
+    fn resolve_axis_direction_horizontal_rtl_reverse_is_left_to_right() {
+        let list_body: ListBody = ListBody::new(Vec::new())
+            .main_axis(Axis::Horizontal)
+            .reverse(true);
+        assert_eq!(
+            list_body.resolve_axis_direction(TextDirection::Rtl),
+            AxisDirection::LeftToRight
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // `ListBodyRenderView` — the private render-object widget `ListBody::
+    // build` delegates to once the direction is resolved. Verifies the
+    // resolved `AxisDirection` (and children) actually reach `RenderListBody`
+    // and can be updated, independent of the ambient-direction resolution
+    // above.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn render_view_create_render_object_uses_the_resolved_direction() {
+        let render_view = ListBodyRenderView {
+            axis_direction: AxisDirection::RightToLeft,
+            children: Vec::<BoxedView>::new(),
+        };
         let render_object =
-            list_body.create_render_object(&flui_view::RenderObjectContext::detached());
+            render_view.create_render_object(&flui_view::RenderObjectContext::detached());
         assert_eq!(render_object.axis_direction(), AxisDirection::RightToLeft);
     }
 
     #[test]
-    fn update_render_object_applies_a_changed_axis_direction() {
-        let list_body: ListBody = ListBody::new(Vec::new());
+    fn render_view_update_render_object_applies_a_changed_direction() {
+        let render_view = ListBodyRenderView {
+            axis_direction: AxisDirection::TopToBottom,
+            children: Vec::<BoxedView>::new(),
+        };
         let mut render_object =
-            list_body.create_render_object(&flui_view::RenderObjectContext::detached());
+            render_view.create_render_object(&flui_view::RenderObjectContext::detached());
         assert_eq!(render_object.axis_direction(), AxisDirection::TopToBottom);
 
-        let updated: ListBody = ListBody::new(Vec::new())
-            .main_axis(Axis::Horizontal)
-            .reverse(true);
+        let updated = ListBodyRenderView {
+            axis_direction: AxisDirection::RightToLeft,
+            children: Vec::<BoxedView>::new(),
+        };
         updated.update_render_object(
             &flui_view::RenderObjectContext::detached(),
             &mut render_object,
@@ -154,11 +287,17 @@ mod tests {
     }
 
     #[test]
-    fn has_children_reflects_an_empty_child_list() {
-        let empty: ListBody = ListBody::new(Vec::new());
+    fn render_view_has_children_reflects_an_empty_child_list() {
+        let empty = ListBodyRenderView {
+            axis_direction: AxisDirection::TopToBottom,
+            children: Vec::<BoxedView>::new(),
+        };
         assert!(!empty.has_children());
 
-        let non_empty = ListBody::new(vec![SizedBox::shrink().boxed()]);
+        let non_empty = ListBodyRenderView {
+            axis_direction: AxisDirection::TopToBottom,
+            children: vec![SizedBox::shrink().boxed()],
+        };
         assert!(non_empty.has_children());
     }
 
@@ -189,16 +328,22 @@ mod tests {
     }
 
     #[test]
-    fn visit_child_views_invokes_the_visitor_once_per_child() {
-        let list_body = ListBody::new(vec![SizedBox::shrink().boxed(), SizedBox::shrink().boxed()]);
+    fn render_view_visit_child_views_invokes_the_visitor_once_per_child() {
+        let render_view = ListBodyRenderView {
+            axis_direction: AxisDirection::TopToBottom,
+            children: vec![SizedBox::shrink().boxed(), SizedBox::shrink().boxed()],
+        };
         let mut visited = 0;
-        list_body.visit_child_views(&mut |_| visited += 1);
+        render_view.visit_child_views(&mut |_| visited += 1);
         assert_eq!(visited, 2, "visitor must run once per child");
     }
 
     #[test]
-    fn visit_child_views_does_not_invoke_the_visitor_without_children() {
-        let empty: ListBody = ListBody::new(Vec::new());
+    fn render_view_visit_child_views_does_not_invoke_the_visitor_without_children() {
+        let empty = ListBodyRenderView {
+            axis_direction: AxisDirection::TopToBottom,
+            children: Vec::<BoxedView>::new(),
+        };
         let mut visited = 0;
         empty.visit_child_views(&mut |_| visited += 1);
         assert_eq!(visited, 0, "no children -> visitor must not run");

--- a/crates/flui-widgets/tests/parity/list_body_test.rs
+++ b/crates/flui-widgets/tests/parity/list_body_test.rs
@@ -27,12 +27,13 @@
 //!    [`list_body_up_lays_out_bottom_to_top_stretched_to_parent_width`].
 //! 3. `'ListBody right'` — ported, real green:
 //!    [`list_body_right_lays_out_left_to_right_stretched_to_parent_height`].
-//!    LTR ambient direction, non-reverse; see "Divergence found by this
-//!    port" below for why this case passing does not, on its own, prove FLUI
-//!    resolves ambient direction at all.
-//! 4. `'ListBody left'` — **divergence pin**, asserting the oracle:
-//!    [`list_body_left_lays_out_right_to_left_pin`]. See "Divergence found by
-//!    this port" below.
+//!    LTR ambient direction, non-reverse; on its own this case cannot
+//!    distinguish "reads Directionality and got LTR" from "ignores
+//!    Directionality and defaults to LTR" — see "Divergence found by this
+//!    port" below for why case 4 is the one that actually proves the read.
+//! 4. `'ListBody left'` — ported, real green:
+//!    [`list_body_left_lays_out_right_to_left`]. See "Divergence found by
+//!    this port" below for the bug this case catches.
 //! 5. `'Limited space along main axis error'` — ported, real green, but via
 //!    an observable that needed empirical discovery, not the mechanism the
 //!    module doc originally assumed — see "The layout-poisoning gap found by
@@ -89,10 +90,10 @@
 //! `PipelineOwner` query? a diagnostics counter?), which is a `flui-rendering`
 //! design question this test file has no standing to answer.
 //!
-//! ## Divergence found by this port
+//! ## Divergence found by this port — fixed
 //!
 //! `ListBody::axis_direction` (`crates/flui-widgets/src/layout/list_body.rs`)
-//! computes its `AxisDirection` from `main_axis` and `reverse` alone:
+//! used to compute its `AxisDirection` from `main_axis` and `reverse` alone:
 //!
 //! ```text
 //! fn axis_direction(&self) -> AxisDirection {
@@ -105,38 +106,53 @@
 //! reverse)` (`widgets/basic.dart`), which for `Axis.horizontal` reads
 //! `Directionality.of(context)` and flips the resulting `AxisDirection`
 //! between `left`/`right` depending on the ambient `TextDirection`. FLUI's
-//! version never looks at `Directionality` at all: for `Axis::Horizontal`
-//! with `reverse: false` it is unconditionally `AxisDirection::LeftToRight`,
-//! regardless of what `Directionality` ancestor is in scope.
+//! old version never looked at `Directionality` at all: for
+//! `Axis::Horizontal` with `reverse: false` it was unconditionally
+//! `AxisDirection::LeftToRight`, regardless of what `Directionality`
+//! ancestor was in scope.
 //!
-//! The root cause is structural, not a one-line oversight:
+//! The root cause was structural, not a one-line oversight:
 //! `flui_view::RenderObjectContext` (`crates/flui-view/src/view/render.rs`)
 //! — the only context `RenderView::create_render_object`/
 //! `update_render_object` ever receive — carries nothing but an optional
 //! interaction-dispatch handle. There is no ambient inherited-data lookup
 //! capability at that call site at all, so no leaf `RenderView` in
 //! `flui-widgets` can consult `Directionality` while building its render
-//! object. This is not `ListBody`-specific: `Flex`/`Row`/`Column`
+//! object.
+//!
+//! The fix does not widen `RenderObjectContext` — every other FLUI widget
+//! that needs ambient inherited data (`Text` reading `DefaultTextStyle` and
+//! delegating to `RichText`, `Dismissible` reading `Directionality` in its
+//! own `build`) resolves it the same way: at the `BuildContext` seam
+//! (`build`), not at the render-object seam. `ListBody`
+//! (`crates/flui-widgets/src/layout/list_body.rs`) is now a composing
+//! `StatelessView`: its `build` resolves `Directionality::maybe_of(ctx)`
+//! (defaulting to `Ltr` with no ancestor, matching every other FLUI widget
+//! that reads `Directionality`) through `resolve_axis_direction` — the exact
+//! `getAxisDirectionFromAxisReverseAndDirectionality` rule, including the
+//! `reverse` flip on both the LTR and RTL base cases — and hands the
+//! already-resolved `AxisDirection` to a private `ListBodyRenderView`, the
+//! actual `RenderListBody`-backed `RenderView`. The render object itself
+//! needed no change: its `AxisDirection::RightToLeft` branch was already
+//! correct (`harness_list_body_horizontal_right_to_left_stretches_height`,
+//! `crates/flui-objects/tests/render_object_harness.rs`); the widget layer
+//! simply never selected it before.
+//!
+//! Effect before the fix: a horizontal `ListBody` with `reverse: false` under
+//! an RTL `Directionality` ancestor laid out its children left-to-right
+//! instead of Flutter's right-to-left — a real content-mirroring defect for
+//! RTL locales, not a cosmetic one. Case 3 above (`'ListBody right'`) passed
+//! even before this fix, but only because its ambient direction is LTR,
+//! which coincided with FLUI's old hardcoded default; it never exercised, and
+//! could not have caught, this gap. Case 4 (RTL ambient) is the one that
+//! actually proves the read, and now passes for real.
+//!
+//! Not fixed here: `Flex`/`Row`/`Column`
 //! (`crates/flui-widgets/src/flex/flex.rs`) share the identical gap —
 //! grepping that file for `text_direction`/`Directionality`/`TextDirection`
-//! returns zero hits, confirming FLUI's flex family has no RTL-aware
-//! `textDirection` concept at all yet either.
-//!
-//! Effect: a horizontal `ListBody` with `reverse: false` under an RTL
-//! `Directionality` ancestor lays out its children left-to-right instead of
-//! Flutter's right-to-left — a real content-mirroring defect for RTL
-//! locales, not a cosmetic one. Case 3 above (`'ListBody right'`) passes
-//! today, but only because its ambient direction is LTR, which coincides
-//! with FLUI's hardcoded default; it does not exercise, and cannot catch,
-//! this gap. Only case 4 (RTL ambient) does, which is why it is pinned
-//! rather than silently folded into "already covered by case 3".
-//!
-//! Not fixed here: closing this gap means widening `RenderObjectContext`
-//! with an ambient-lookup capability — a `flui-view` architecture change
-//! spanning every `RenderView` impl that would need it (`ListBody` today,
-//! `Flex`/`Row`/`Column` eventually) — not a `flui-widgets`-local, test-only
-//! fix. Reported for `flui-view`/`flui-widgets` maintainers to design
-//! against, not patched silently here.
+//! returns zero hits, confirming FLUI's flex family still has no RTL-aware
+//! `textDirection` concept. Reported for `flui-widgets` maintainers to port
+//! next using the same `build`-seam pattern; out of scope for this change.
 
 use flui_foundation::RenderId;
 use flui_types::layout::Axis;
@@ -315,40 +331,35 @@ fn list_body_right_lays_out_left_to_right_stretched_to_parent_height() {
 }
 
 // ============================================================================
-// Case 4 (divergence pin) — 'ListBody left'
+// Case 4 — 'ListBody left'
 // ============================================================================
 
 /// Flutter parity: `list_body_test.dart` `'ListBody left'` (tag `3.44.0`).
 ///
-/// **`#[ignore]`d divergence pin, verified failing.** Asserts the oracle's
-/// behaviour: a horizontal, non-reversed `ListBody` under an RTL
-/// `Directionality` lays its children out right to left — the first child
-/// (`children[0]`) ends up rightmost, at `x = 600`, and the last ends up
-/// leftmost, at `x = 0`.
+/// Asserts the oracle's behaviour: a horizontal, non-reversed `ListBody`
+/// under an RTL `Directionality` lays its children out right to left — the
+/// first child (`children[0]`) ends up rightmost, at `x = 600`, and the last
+/// ends up leftmost, at `x = 0`.
 ///
-/// FLUI's `ListBody::axis_direction` ignores `Directionality` entirely (see
-/// the module doc's "Divergence found by this port"), so it resolves
+/// Before the fix (see the module doc's "Divergence found by this port"),
+/// FLUI's `ListBody` ignored `Directionality` entirely and resolved
 /// `Axis::Horizontal` + `reverse: false` to `AxisDirection::LeftToRight`
 /// unconditionally — identical to case 3's LTR scene above, even though this
 /// scene's ambient direction is RTL. The render object's own
-/// `AxisDirection::RightToLeft` branch is correct and is exercised — by
+/// `AxisDirection::RightToLeft` branch was already correct and already
+/// exercised — by
 /// `harness_list_body_horizontal_right_to_left_stretches_height`
 /// (`crates/flui-objects/tests/render_object_harness.rs`), which drives the
-/// render object directly. Note what that means: the render object handles
-/// RTL, and nothing in the widget layer ever asks it to. The defect is
-/// entirely in `axis_direction` never selecting that branch from ambient
-/// direction.
+/// render object directly. Only the widget layer never selected that branch.
 ///
-/// Captured failure (this pin run once un-ignored, verbatim from the
-/// harness): the first assertion fails with
-/// `left: (0.0, 0.0, 200.0, 600.0), right: (600.0, 0.0, 200.0, 600.0)` —
-/// FLUI places `children[0]` at the LTR position `x = 0` instead of the
-/// oracle's RTL position `x = 600`.
+/// Captured failure before the fix (this test run with the old
+/// `AxisDirection::from_axis(self.main_axis, self.reverse)` body, verbatim
+/// from the harness): the first assertion failed with `left: (0.0, 0.0,
+/// 200.0, 600.0), right: (600.0, 0.0, 200.0, 600.0)` — FLUI placed
+/// `children[0]` at the LTR position `x = 0` instead of the oracle's RTL
+/// position `x = 600`.
 #[test]
-#[ignore = "divergence pin: ListBody::axis_direction never consults ambient \
-            Directionality (RenderObjectContext has no inherited-data lookup \
-            capability) — see the module doc's 'Divergence found by this port'"]
-fn list_body_left_lays_out_right_to_left_pin() {
+fn list_body_left_lays_out_right_to_left() {
     let laid = harness::pump_widget(
         Row::new(row![Directionality::new(
             TextDirection::Rtl,


### PR DESCRIPTION
Closes the bug the `ListBody` parity port found (#517), and turns its quarantined pin into ordinary coverage.

## The bug

`ListBody::axis_direction` was `AxisDirection::from_axis(self.main_axis, self.reverse)` — ambient `Directionality` was never consulted. A horizontal, non-reversed `ListBody` under RTL laid out **left to right**.

The render object was never at fault: its `RightToLeft` branch is correct and is exercised by `harness_list_body_horizontal_right_to_left_stretches_height`. The widget layer simply never selected it.

## Flutter's rule, ported rather than invented

`getAxisDirectionFromAxisReverseAndDirectionality` (`basic.dart`, tag `3.44.0`):

- **horizontal** — read `Directionality`, map Ltr→right / Rtl→left, then flip if `reverse`.
- **vertical** — `reverse ? up : down`; text direction is never consulted.

That asymmetry is the part worth getting right, and it is now covered across all six (axis, reverse, direction) combinations that matter.

## The structural consequence, stated plainly

`RenderObjectContext` — the only context `create_render_object` / `update_render_object` receive — carries no ambient lookup, and I told the agent not to invent one. It didn't. Instead `ListBody` follows the pattern FLUI already uses for exactly this (`Text` reading `DefaultTextStyle` and delegating to `RichText`): it is now a composing `StatelessView` that resolves direction at the `BuildContext` seam and hands an already-resolved `AxisDirection` to a private `ListBodyRenderView`.

**Public surface is unchanged** — `ListBody` is still exported and still a `View`; only the internal `RenderView` role moved to a private type. Crate-internal unit tests that called `create_render_object` directly on `ListBody` moved to the new type, same assertions.

## Falsification — re-run independently

Forcing `resolve_axis_direction` back to ignoring its `text_direction` argument fails the (now un-ignored) case:

```
left:  (0.0, 0.0, 200.0, 600.0)
right: (600.0, 0.0, 200.0, 600.0)
```

Restored, green again.

## Same defect elsewhere — found, deliberately not fixed here

Reported so it is visible rather than silently inherited:

- `Flex` / `Row` / `Column` (`flex/flex.rs`) — no `Directionality` reference at all.
- `custom_scroll_view.rs`, `grid_view.rs`, `list_view.rs`, `page_view.rs` — each hardcodes `Axis::Horizontal => AxisDirection::LeftToRight`.
- `single_child_scroll_view.rs` — same, and already self-documented as an LTR-only divergence.

Each is its own change; bundling them here would make one reviewable fix into an unreviewable sweep.

## Verification

- `cargo nextest run --workspace --exclude flui-platform` — **8401 passed**, 18 skipped (one fewer skip: the pin is now real coverage)
- `cargo nextest run -p flui-objects` — 867 passed (layout resolution touched, harness must stay green)
- `cargo clippy -p flui-widgets --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, `port-check`, `typos` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)