### PR TITLE
fix(deps): bump event-listener to 5.4.2 for RUSTSEC-2026-0221

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,11 +1300,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
A new unsound advisory landed against `event-listener` 5.4.1 and now fails `cargo deny check advisories`. **This blocks every open PR in the repo** — it is not caused by any of them, and it will hit `main` on its next scheduled run too.

## The advisory

[RUSTSEC-2026-0221](https://rustsec.org/advisories/RUSTSEC-2026-0221) — affected versions unconditionally implement `Send`, so a `!Send` tag can cross a thread boundary via `StackSlot`. Solution named by the advisory: `>=5.4.2`.

It reaches the tree through `async-lock`, `event-listener-strategy`, `moka`, and `flui-scheduler`'s dev-dependencies — no direct dependency of ours, which is why nothing in the workspace source needs to change.

## The change

Lockfile only: `event-listener 5.4.1 → 5.4.2`, via `cargo update -p event-listener` so nothing else moves. `cargo deny check advisories` goes from the failure above to `advisories ok`.

## How this surfaced, and the lesson attached

It appeared as a `deny` failure on a **test-only** parity PR, alongside a `doc` failure on the same run. The `doc` one turned out to be an infrastructure flake — `couldn't generate documentation: I/O error`, with the same SHA passing on a re-run elsewhere. Two red checks on one PR, one real and one noise.

That is the argument for reading the job log before reacting: treating the red as "my PR broke something" would have produced a fix for a defect that does not exist, while leaving the advisory — the one that actually blocks the queue — undiagnosed.

## Verification

- `cargo deny check advisories` — `advisories ok`
- `cargo nextest run --workspace --exclude flui-platform` — **8400 passed**, 19 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)