### PR TITLE
fix(widgets): resolve scroll-view AxisDirection from ambient Directionality

### DIFF
--- a/crates/flui-widgets/src/localization/directionality.rs
+++ b/crates/flui-widgets/src/localization/directionality.rs
@@ -2,6 +2,7 @@
 //!
 //! Flutter parity: `widgets/directionality.dart` `Directionality`.
 
+use flui_types::layout::{Axis, AxisDirection};
 use flui_types::typography::TextDirection;
 use flui_view::prelude::*;
 use flui_view::{BoxedView, InheritedView, impl_inherited_view};
@@ -90,6 +91,54 @@ impl InheritedView for Directionality {
 
 impl_inherited_view!(Directionality);
 
+/// Resolves an [`AxisDirection`] from a layout/scroll `axis`, its `reverse`
+/// flag, and the ambient [`Directionality`] — Flutter's
+/// `getAxisDirectionFromAxisReverseAndDirectionality` (`widgets/basic.dart`).
+/// Only `Axis::Horizontal` consults `Directionality` (defaulting to `Ltr`
+/// with no ancestor, matching every other FLUI widget that reads it) — a
+/// vertical caller never registers a dependency on it, so a `Directionality`
+/// change never forces an unrelated rebuild. `Axis::Vertical` picks
+/// `TopToBottom`/`BottomToTop` from `reverse` alone. `reverse` flips either
+/// axis's base direction to its opposite.
+///
+/// Shared by every FLUI scroll view that needs this exact rule:
+/// [`CustomScrollView`](crate::CustomScrollView), [`GridView`](crate::GridView),
+/// [`ListView`](crate::ListView), [`PageView`](crate::PageView), and
+/// [`SingleChildScrollView`](crate::SingleChildScrollView). [`ListBody`](crate::ListBody)
+/// implements the identical rule inline (its own `resolve_axis_direction`)
+/// rather than depending on this function, since it resolves through a
+/// private render-object widget this module has no reason to know about.
+#[must_use]
+pub(crate) fn axis_direction_from_axis_reverse_and_directionality(
+    ctx: &dyn BuildContext,
+    axis: Axis,
+    reverse: bool,
+) -> AxisDirection {
+    match axis {
+        Axis::Horizontal => {
+            let text_direction = Directionality::maybe_of(ctx).unwrap_or(TextDirection::Ltr);
+            resolve_horizontal_axis_direction(text_direction, reverse)
+        }
+        Axis::Vertical => AxisDirection::from_axis(Axis::Vertical, reverse),
+    }
+}
+
+/// The pure `text_direction` + `reverse` -> `AxisDirection` rule for the
+/// horizontal branch of [`axis_direction_from_axis_reverse_and_directionality`],
+/// split out so it is unit-testable without a [`BuildContext`].
+#[must_use]
+fn resolve_horizontal_axis_direction(
+    text_direction: TextDirection,
+    reverse: bool,
+) -> AxisDirection {
+    let base = if text_direction.is_rtl() {
+        AxisDirection::RightToLeft
+    } else {
+        AxisDirection::LeftToRight
+    };
+    if reverse { base.opposite() } else { base }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -123,5 +172,71 @@ mod tests {
         let a = Directionality::new(TextDirection::Rtl, SizedBox::shrink());
         let b = Directionality::new(TextDirection::Ltr, SizedBox::shrink());
         assert!(a.update_should_notify(&b));
+    }
+
+    // ------------------------------------------------------------------
+    // `resolve_horizontal_axis_direction` — the pure half of
+    // `axis_direction_from_axis_reverse_and_directionality`'s Flutter parity
+    // rule. Every FLUI scroll view sharing this helper relies on these four
+    // combinations resolving correctly, including the `reverse` flip on both
+    // the LTR and RTL base cases.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn resolve_horizontal_axis_direction_ltr_is_left_to_right() {
+        assert_eq!(
+            resolve_horizontal_axis_direction(TextDirection::Ltr, false),
+            AxisDirection::LeftToRight
+        );
+    }
+
+    #[test]
+    fn resolve_horizontal_axis_direction_rtl_is_right_to_left() {
+        assert_eq!(
+            resolve_horizontal_axis_direction(TextDirection::Rtl, false),
+            AxisDirection::RightToLeft,
+            "a horizontal axis under RTL Directionality must resolve to RightToLeft"
+        );
+    }
+
+    #[test]
+    fn resolve_horizontal_axis_direction_ltr_reverse_is_right_to_left() {
+        assert_eq!(
+            resolve_horizontal_axis_direction(TextDirection::Ltr, true),
+            AxisDirection::RightToLeft
+        );
+    }
+
+    /// `reverse` flips the RTL base direction too: RTL + reverse ends up back
+    /// at `LeftToRight`, matching `flipAxisDirection(AxisDirection.left)`.
+    #[test]
+    fn resolve_horizontal_axis_direction_rtl_reverse_is_left_to_right() {
+        assert_eq!(
+            resolve_horizontal_axis_direction(TextDirection::Rtl, true),
+            AxisDirection::LeftToRight
+        );
+    }
+
+    /// The vertical axis never consults `text_direction` — mirrors the
+    /// oracle's `Axis.vertical` arm, which never touches `Directionality` at
+    /// all. `axis_direction_from_axis_reverse_and_directionality`'s vertical
+    /// branch delegates straight to `AxisDirection::from_axis`, already
+    /// covered at the unit level in `crates/flui-types/src/layout/axis.rs`;
+    /// these two pin the specific `Axis::Vertical` outputs this module's
+    /// callers rely on.
+    #[test]
+    fn axis_direction_from_axis_reverse_and_directionality_vertical_false_is_top_to_bottom() {
+        assert_eq!(
+            AxisDirection::from_axis(Axis::Vertical, false),
+            AxisDirection::TopToBottom
+        );
+    }
+
+    #[test]
+    fn axis_direction_from_axis_reverse_and_directionality_vertical_reverse_is_bottom_to_top() {
+        assert_eq!(
+            AxisDirection::from_axis(Axis::Vertical, true),
+            AxisDirection::BottomToTop
+        );
     }
 }

--- a/crates/flui-widgets/src/localization/mod.rs
+++ b/crates/flui-widgets/src/localization/mod.rs
@@ -11,6 +11,7 @@ mod localizations;
 mod widgets_localizations;
 
 pub use directionality::Directionality;
+pub(crate) use directionality::axis_direction_from_axis_reverse_and_directionality;
 pub use locale_resolution::basic_locale_list_resolution;
 pub use localizations::{
     BoxedLocalizationsDelegate, BoxedWidgetsLocalizations, DefaultWidgetsLocalizationsDelegate,

--- a/crates/flui-widgets/src/scroll/custom_scroll_view.rs
+++ b/crates/flui-widgets/src/scroll/custom_scroll_view.rs
@@ -3,11 +3,12 @@
 
 use std::fmt;
 
-use flui_types::layout::{Axis, AxisDirection};
+use flui_types::layout::Axis;
 use flui_view::prelude::StatelessView;
 use flui_view::seq::ViewSeq;
 use flui_view::{BoxedView, BuildContext, IntoView, ViewExt};
 
+use crate::localization::axis_direction_from_axis_reverse_and_directionality;
 use crate::scroll::{ShrinkWrappingViewport, Viewport};
 
 /// A scrollable area whose scroll body is composed from an arbitrary list of
@@ -26,8 +27,16 @@ use crate::scroll::{ShrinkWrappingViewport, Viewport};
 /// Set [`CustomScrollView::shrink_wrap`] when the scroll view is placed under
 /// unbounded constraints in the scroll axis.
 ///
+/// A horizontal `scroll_direction` resolves its `AxisDirection` from the
+/// ambient [`Directionality`] (`RightToLeft` under an RTL ancestor), matching
+/// `ScrollView.getDirection` (`widgets/scroll_view.dart`); the vertical axis
+/// never consults it. `CustomScrollView` has no `reverse` flag yet, unlike
+/// [`SingleChildScrollView`].
+///
 /// Flutter parity: `widgets/scroll_view.dart` `CustomScrollView`.
 ///
+/// [`Directionality`]: crate::Directionality
+/// [`SingleChildScrollView`]: crate::SingleChildScrollView
 /// [`ListView`]: crate::ListView
 /// [`GridView`]: crate::GridView
 /// [`SliverToBoxAdapter`]: crate::SliverToBoxAdapter
@@ -92,11 +101,14 @@ impl fmt::Debug for CustomScrollView {
 }
 
 impl StatelessView for CustomScrollView {
-    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
-        let axis_direction = match self.scroll_direction {
-            Axis::Vertical => AxisDirection::TopToBottom,
-            Axis::Horizontal => AxisDirection::LeftToRight,
-        };
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        // `reverse` isn't modeled on `CustomScrollView` yet (unlike
+        // `SingleChildScrollView`), so it's always `false` here — the
+        // resolution still consults ambient `Directionality` for a
+        // horizontal `scroll_direction`, matching `ScrollView.getDirection`
+        // (`widgets/scroll_view.dart`).
+        let axis_direction =
+            axis_direction_from_axis_reverse_and_directionality(ctx, self.scroll_direction, false);
         if self.shrink_wrap {
             ShrinkWrappingViewport::new(self.slivers.clone())
                 .axis_direction(axis_direction)

--- a/crates/flui-widgets/src/scroll/grid_view.rs
+++ b/crates/flui-widgets/src/scroll/grid_view.rs
@@ -9,11 +9,12 @@ use flui_rendering::delegates::{
     SliverGridDelegateWithMaxCrossAxisExtent,
 };
 use flui_rendering::view::ScrollPosition;
-use flui_types::layout::{Axis, AxisDirection};
+use flui_types::layout::Axis;
 use flui_view::prelude::StatelessView;
 use flui_view::seq::ViewSeq;
 use flui_view::{BoxedView, BuildContext, IntoView, ViewExt};
 
+use crate::localization::axis_direction_from_axis_reverse_and_directionality;
 use crate::scroll::{
     ShrinkWrappingViewport, SliverChildBuilderDelegate, SliverGrid, SliverGridLazy, Viewport,
 };
@@ -54,6 +55,12 @@ enum OffsetSource {
 /// gesture-driven scrolling is provided by [`Scrollable`](crate::Scrollable).
 /// Set [`GridView::shrink_wrap`] when the grid is placed under unbounded
 /// constraints in the scroll axis.
+///
+/// A horizontal `scroll_direction` resolves its `AxisDirection` from the
+/// ambient [`Directionality`](crate::Directionality) (`RightToLeft` under an
+/// RTL ancestor), matching `ScrollView.getDirection`
+/// (`widgets/scroll_view.dart`); the vertical axis never consults it.
+/// `GridView` has no `reverse` flag yet.
 ///
 /// Flutter parity: `widgets/scroll_view.dart` `GridView.count`,
 /// `GridView.extent`, and `GridView.builder`.
@@ -196,11 +203,13 @@ impl fmt::Debug for GridView {
 }
 
 impl StatelessView for GridView {
-    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
-        let axis_direction = match self.scroll_direction {
-            Axis::Vertical => AxisDirection::TopToBottom,
-            Axis::Horizontal => AxisDirection::LeftToRight,
-        };
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        // `reverse` isn't modeled on `GridView` yet, so it's always `false`
+        // here — the resolution still consults ambient `Directionality` for
+        // a horizontal `scroll_direction`, matching `ScrollView.getDirection`
+        // (`widgets/scroll_view.dart`).
+        let axis_direction =
+            axis_direction_from_axis_reverse_and_directionality(ctx, self.scroll_direction, false);
 
         let sliver: BoxedView = if let Some(ref delegate) = self.builder_source {
             // Lazy variant: wire SliverGridLazy (element-owned request strategy).

--- a/crates/flui-widgets/src/scroll/list_view.rs
+++ b/crates/flui-widgets/src/scroll/list_view.rs
@@ -4,11 +4,12 @@ use std::fmt;
 use std::rc::Rc;
 
 use flui_rendering::view::ScrollPosition;
-use flui_types::layout::{Axis, AxisDirection};
+use flui_types::layout::Axis;
 use flui_view::prelude::StatelessView;
 use flui_view::seq::ViewSeq;
 use flui_view::{BoxedView, BuildContext, IntoView, ViewExt};
 
+use crate::localization::axis_direction_from_axis_reverse_and_directionality;
 use crate::scroll::{
     ShrinkWrappingViewport, SliverChildBuilderDelegate, SliverFixedExtentList, SliverList, Viewport,
 };
@@ -50,6 +51,12 @@ enum OffsetSource {
 /// Both modes compose a [`Viewport`] over their respective sliver, or a
 /// [`ShrinkWrappingViewport`] when [`ListView::shrink_wrap`] is enabled.
 /// `offset` is a programmatic scroll position in logical pixels.
+///
+/// A horizontal `scroll_direction` resolves its `AxisDirection` from the
+/// ambient [`Directionality`](crate::Directionality) (`RightToLeft` under an
+/// RTL ancestor), matching `ScrollView.getDirection`
+/// (`widgets/scroll_view.dart`); the vertical axis never consults it.
+/// `ListView` has no `reverse` flag yet.
 ///
 /// Flutter parity: `widgets/scroll_view.dart` `ListView` and
 /// `ListView.builder`.
@@ -179,11 +186,13 @@ impl fmt::Debug for ListView {
 }
 
 impl StatelessView for ListView {
-    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
-        let axis_direction = match self.scroll_direction {
-            Axis::Vertical => AxisDirection::TopToBottom,
-            Axis::Horizontal => AxisDirection::LeftToRight,
-        };
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        // `reverse` isn't modeled on `ListView` yet, so it's always `false`
+        // here — the resolution still consults ambient `Directionality` for
+        // a horizontal `scroll_direction`, matching `ScrollView.getDirection`
+        // (`widgets/scroll_view.dart`).
+        let axis_direction =
+            axis_direction_from_axis_reverse_and_directionality(ctx, self.scroll_direction, false);
         // Both arms produce `Viewport<(BoxedView,)>` by boxing the sliver so
         // the opaque return type is the same concrete type in both branches.
         //

--- a/crates/flui-widgets/src/scroll/page_view.rs
+++ b/crates/flui-widgets/src/scroll/page_view.rs
@@ -47,11 +47,12 @@ use flui_foundation::{Listenable, ListenerId};
 use flui_rendering::view::{
     CacheExtentStyle, DimensionChangePolicy, ScrollPosition, ViewportOffset,
 };
-use flui_types::layout::{Axis, AxisDirection};
+use flui_types::layout::Axis;
 use flui_view::prelude::StatefulView;
 use flui_view::seq::ViewSeq;
 use flui_view::{BoxedView, BuildContext, IntoView, ViewExt, ViewState};
 
+use crate::localization::axis_direction_from_axis_reverse_and_directionality;
 use crate::scroll::{
     ClampingScrollPhysics, ScrollController, ScrollMetrics, ScrollPhysics, Scrollable,
     SharedScrollPhysics, SliverFillViewport, Viewport,
@@ -427,7 +428,11 @@ type OnPageChanged = Arc<dyn Fn(usize) + Send + Sync>;
 /// Each child fills [`PageController::viewport_fraction`] of the viewport
 /// along [`PageView::scroll_direction`]. `PageView` is pure composition over
 /// [`Scrollable`] + [`PageScrollPhysics`] + [`Viewport`] +
-/// [`SliverFillViewport`] — no new render objects.
+/// [`SliverFillViewport`] — no new render objects. A horizontal
+/// `scroll_direction` resolves its `AxisDirection` from the ambient
+/// [`Directionality`](crate::Directionality) (`RightToLeft` under an RTL
+/// ancestor), matching `ScrollView.getDirection` (`widgets/scroll_view.dart`);
+/// the vertical axis never consults it.
 ///
 /// # Flutter parity
 ///
@@ -646,14 +651,17 @@ impl ViewState<PageView> for PageViewState {
         self.register_page_listener();
     }
 
-    fn build(&self, view: &PageView, _ctx: &dyn BuildContext) -> impl IntoView {
+    fn build(&self, view: &PageView, ctx: &dyn BuildContext) -> impl IntoView {
         let controller = self.controller.clone();
         let viewport_fraction = controller.viewport_fraction();
         let scroll_direction = view.scroll_direction;
-        let axis_direction = match scroll_direction {
-            Axis::Horizontal => AxisDirection::LeftToRight,
-            Axis::Vertical => AxisDirection::TopToBottom,
-        };
+        // `reverse` isn't modeled on `PageView` yet (see the module docs'
+        // deferred-divergences list), so it's always `false` here — the
+        // resolution still consults ambient `Directionality` for a
+        // horizontal `scroll_direction`, matching `ScrollView.getDirection`
+        // (`widgets/scroll_view.dart`).
+        let axis_direction =
+            axis_direction_from_axis_reverse_and_directionality(ctx, scroll_direction, false);
         let children = view.children.clone();
         let cache_extent = view.cache_extent;
         let physics: SharedScrollPhysics = Arc::new(PageScrollPhysics::new(viewport_fraction));

--- a/crates/flui-widgets/src/scroll/page_view.rs
+++ b/crates/flui-widgets/src/scroll/page_view.rs
@@ -670,6 +670,13 @@ impl ViewState<PageView> for PageViewState {
             .controller(controller.scroll_controller())
             .physics(physics)
             .scroll_direction(scroll_direction)
+            // The inner `Viewport` below is built with this SAME
+            // `axis_direction` — handing it to `Scrollable` too keeps drag
+            // and fling gesture orientation in sync with what actually
+            // paints under RTL `Directionality` (see `Scrollable::
+            // axis_direction`'s docs; `Scrollable` cannot see into an
+            // arbitrary `viewport_builder`'s content to derive this itself).
+            .axis_direction(axis_direction)
             .viewport_builder(Rc::new(move |position: ScrollPosition| {
                 let sliver = SliverFillViewport::new(viewport_fraction, children.clone());
                 let mut viewport = Viewport::new((sliver,))

--- a/crates/flui-widgets/src/scroll/page_view.rs
+++ b/crates/flui-widgets/src/scroll/page_view.rs
@@ -671,11 +671,21 @@ impl ViewState<PageView> for PageViewState {
             .physics(physics)
             .scroll_direction(scroll_direction)
             // The inner `Viewport` below is built with this SAME
-            // `axis_direction` — handing it to `Scrollable` too keeps drag
-            // and fling gesture orientation in sync with what actually
-            // paints under RTL `Directionality` (see `Scrollable::
-            // axis_direction`'s docs; `Scrollable` cannot see into an
-            // arbitrary `viewport_builder`'s content to derive this itself).
+            // `axis_direction`. Handing it to `Scrollable` explicitly (rather
+            // than relying on `Scrollable`'s own ambient-`Directionality`
+            // fallback, which currently resolves to the identical value here
+            // — same helper, same `ctx`-visible `Directionality` ancestor,
+            // same `reverse: false`, verified by deleting this line: every
+            // test still passes) keeps this composition correct BY
+            // CONSTRUCTION rather than by that coincidence: `PageView`'s own
+            // module docs list `reverse` as a deferred feature, and once
+            // added, this explicit value (not the fallback's hardcoded
+            // `reverse: false`) is what must reach `Scrollable`'s gesture
+            // code. `Scrollable::axis_direction`'s docs cover the general
+            // case: any `.viewport_builder` composing content whose
+            // `AxisDirection` doesn't reduce to "ambient `Directionality` +
+            // this `scroll_direction` + `reverse: false`" needs this to stay
+            // correct.
             .axis_direction(axis_direction)
             .viewport_builder(Rc::new(move |position: ScrollPosition| {
                 let sliver = SliverFillViewport::new(viewport_fraction, children.clone());

--- a/crates/flui-widgets/src/scroll/scrollable.rs
+++ b/crates/flui-widgets/src/scroll/scrollable.rs
@@ -20,6 +20,16 @@
 //! `on_pan_start` halts any in-flight fling via `stop()`, so grabbing a
 //! scrolling list feels physically correct.
 //!
+//! # Gesture orientation
+//!
+//! `on_pan_update`/`on_pan_end` orient the drag delta and fling velocity by
+//! the resolved [`AxisDirection`] (see [`Scrollable::axis_direction`]), not
+//! the bare [`Axis`] alone: a horizontal `Scrollable` under an RTL ambient
+//! `Directionality` resolves `RightToLeft` and flips the sign relative to
+//! the default `LeftToRight` case, matching `axisDirectionIsReversed`
+//! (`painting/basic_types.dart`) and `ScrollDragController.update`/`.end`
+//! (`widgets/scroll_activity.dart`).
+//!
 //! # `animate_to` servicing (ADR-0037)
 //!
 //! [`ScrollController::animate_to`]/[`jump_to`](ScrollController::jump_to)
@@ -46,11 +56,12 @@ use flui_animation::{Animation, AnimationController, Scheduler, Vsync, VsyncRegi
 use flui_foundation::{Listenable, ListenerId};
 use flui_rendering::hit_testing::HitTestBehavior;
 use flui_rendering::view::ScrollPosition;
-use flui_types::layout::Axis;
+use flui_types::layout::{Axis, AxisDirection};
 use flui_view::prelude::StatefulView;
 use flui_view::{BoxedView, BuildContext, BuildContextExt, Child, IntoView, ViewExt, ViewState};
 
 use crate::animated::VsyncScope;
+use crate::localization::axis_direction_from_axis_reverse_and_directionality;
 use crate::scroll::{ClampingScrollPhysics, ScrollController, ScrollMetrics, SharedScrollPhysics};
 use crate::{AnimatedBuilder, GestureDetector, SingleChildScrollView};
 
@@ -108,6 +119,18 @@ pub struct Scrollable {
     physics: SharedScrollPhysics,
     /// The axis along which the child scrolls.
     scroll_direction: Axis,
+    /// Overrides the resolved [`AxisDirection`] used to orient gesture
+    /// deltas/velocity, bypassing this widget's own ambient-`Directionality`
+    /// resolution. `None` (the default) means: resolve it the same way the
+    /// `.child()` fast path's internally-composed [`SingleChildScrollView`]
+    /// does — [`axis_direction_from_axis_reverse_and_directionality`] against
+    /// `scroll_direction` with `reverse: false`. Set this explicitly when
+    /// composing a [`Scrollable::viewport_builder`] whose content already
+    /// resolved its own `AxisDirection` (e.g. [`PageView`](crate::PageView)):
+    /// passing that SAME value here keeps gesture orientation in sync with
+    /// what the composed content actually paints, instead of `Scrollable`
+    /// re-deriving a value that has no visibility into the builder's content.
+    axis_direction: Option<AxisDirection>,
     /// The content to make scrollable.
     child: Child,
     /// Overrides the scrollable content's composition entirely; `None`
@@ -120,6 +143,7 @@ impl std::fmt::Debug for Scrollable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Scrollable")
             .field("scroll_direction", &self.scroll_direction)
+            .field("axis_direction", &self.axis_direction)
             .field("controller", &self.controller)
             .field("physics", &self.physics)
             .field("has_viewport_builder", &self.viewport_builder.is_some())
@@ -133,6 +157,7 @@ impl Default for Scrollable {
             controller: ScrollController::new(),
             physics: Arc::new(ClampingScrollPhysics::new()),
             scroll_direction: Axis::Vertical,
+            axis_direction: None,
             child: Child::empty(),
             viewport_builder: None,
         }
@@ -168,6 +193,19 @@ impl Scrollable {
     #[must_use]
     pub fn scroll_direction(mut self, axis: Axis) -> Self {
         self.scroll_direction = axis;
+        self
+    }
+
+    /// Override the resolved [`AxisDirection`] gestures are oriented by
+    /// (default: `None`, resolved from ambient `Directionality` — see the
+    /// field docs). Pass the exact `AxisDirection` a
+    /// [`Scrollable::viewport_builder`]'s composed content resolved for
+    /// itself, so a drag in a given physical direction moves the offset the
+    /// way that content actually paints (Flutter parity:
+    /// `axisDirectionIsReversed`, `painting/basic_types.dart`).
+    #[must_use]
+    pub fn axis_direction(mut self, direction: AxisDirection) -> Self {
+        self.axis_direction = Some(direction);
         self
     }
 
@@ -361,10 +399,19 @@ impl ViewState<Scrollable> for ScrollableState {
         self.install_flush_handle(ctx);
     }
 
-    fn build(&self, view: &Scrollable, _ctx: &dyn BuildContext) -> impl IntoView {
+    fn build(&self, view: &Scrollable, ctx: &dyn BuildContext) -> impl IntoView {
         let scroll_controller = view.controller.clone();
         let physics = view.physics.clone();
         let scroll_direction = view.scroll_direction;
+        // No explicit override: resolve the same way the `.child()` fast
+        // path's internally-composed `SingleChildScrollView` resolves its
+        // own `AxisDirection` — same helper, same ambient `Directionality`
+        // ancestor, same `reverse: false` — so the two stay in agreement
+        // without `Scrollable` needing to see what `SingleChildScrollView`
+        // computed. See `axis_direction`'s field docs for the override case.
+        let axis_direction = view.axis_direction.unwrap_or_else(|| {
+            axis_direction_from_axis_reverse_and_directionality(ctx, scroll_direction, false)
+        });
         let child = view.child.clone();
         let viewport_builder = view.viewport_builder.clone();
         let fling_controller = self.fling_controller.clone();
@@ -419,9 +466,15 @@ impl ViewState<Scrollable> for ScrollableState {
                     let _ = fling_stop.stop();
                 })
                 .on_pan_update(move |details| {
-                    // Flutter convention: a downward finger drag (positive delta
-                    // on the scroll axis) moves the viewport toward the START of
-                    // the content, so the offset DECREASES.
+                    // Flutter convention: a downward/rightward finger drag
+                    // (positive delta on the scroll axis) moves the viewport
+                    // toward the axis's START, so the offset DECREASES — but
+                    // only for a NOT-reversed `AxisDirection` (`down`/`right`).
+                    // For a reversed one (`up`/`left`, e.g. `RightToLeft`
+                    // under RTL `Directionality`) the sign flips, mirroring
+                    // `ScrollDragController.update`'s `if (_reversed) { offset
+                    // = -offset; }` (`widgets/scroll_activity.dart`) ahead of
+                    // `ScrollPosition.applyUserOffset`'s `pixels - delta`.
                     //
                     // `apply_boundary_conditions` enforces the physics limits
                     // (hard clamp or spring resistance) before committing.
@@ -429,18 +482,33 @@ impl ViewState<Scrollable> for ScrollableState {
                         Axis::Vertical => details.delta.dy.get(),
                         Axis::Horizontal => details.delta.dx.get(),
                     };
-                    let proposed = ctrl_update.pixels() - raw_delta;
+                    let signed_delta = if axis_direction.is_reversed() {
+                        -raw_delta
+                    } else {
+                        raw_delta
+                    };
+                    let proposed = ctrl_update.pixels() - signed_delta;
                     let metrics = ScrollMetrics::from(&ctrl_update.position());
                     let clamped = phys_update.apply_boundary_conditions(&metrics, proposed);
                     ctrl_update.set_pixels(clamped);
                 })
                 .on_pan_end(move |details| {
-                    // Pointer velocity is in "screen coordinates": positive dy =
-                    // finger moving down. Scroll offset increases when the finger
-                    // moves UP, so we negate to convert to scroll velocity.
-                    let fling_velocity_px_per_sec = match scroll_direction {
-                        Axis::Vertical => -details.velocity.pixels_per_second.dy.get(),
-                        Axis::Horizontal => -details.velocity.pixels_per_second.dx.get(),
+                    // Pointer velocity is in "screen coordinates": positive dy/dx
+                    // = finger moving down/right. For a NOT-reversed axis
+                    // direction the scroll offset increases when the finger
+                    // moves the opposite way, so we negate; for a reversed one
+                    // (`up`/`left`) the two negations cancel — mirroring
+                    // `ScrollDragController.end`'s `double velocity =
+                    // -details.primaryVelocity!; if (_reversed) { velocity =
+                    // -velocity; }` (`widgets/scroll_activity.dart`).
+                    let raw_velocity = match scroll_direction {
+                        Axis::Vertical => details.velocity.pixels_per_second.dy.get(),
+                        Axis::Horizontal => details.velocity.pixels_per_second.dx.get(),
+                    };
+                    let fling_velocity_px_per_sec = if axis_direction.is_reversed() {
+                        raw_velocity
+                    } else {
+                        -raw_velocity
                     };
                     // Cap at Flutter's `kMaxFlingVelocity` (8 000 px/s). The LSQ
                     // velocity tracker can produce astronomically large velocities

--- a/crates/flui-widgets/src/scroll/single_child_scroll_view.rs
+++ b/crates/flui-widgets/src/scroll/single_child_scroll_view.rs
@@ -1,10 +1,11 @@
 //! [`SingleChildScrollView`] — makes a single child scrollable along one axis.
 
 use flui_rendering::view::ScrollPosition;
-use flui_types::layout::{Axis, AxisDirection};
+use flui_types::layout::Axis;
 use flui_view::prelude::StatelessView;
 use flui_view::{BuildContext, Child, IntoView};
 
+use crate::localization::axis_direction_from_axis_reverse_and_directionality;
 use crate::scroll::{SliverToBoxAdapter, Viewport};
 
 /// Where the composed [`Viewport`] gets its scroll offset from — mirrors
@@ -27,10 +28,13 @@ enum OffsetSource {
 /// `scroll_direction` defaults to [`Axis::Vertical`]. `offset` is a programmatic
 /// scroll position; gesture-driven scrolling arrives with the
 /// `Scrollable`/`ScrollController` layer. `reverse` flips which edge scroll
-/// position `0.0` anchors to (Flutter parity:
-/// `getAxisDirectionFromAxisReverseAndDirectionality`, `LTR`-only here — no
-/// `Directionality` lookup, matching this widget's existing left-to-right-only
-/// horizontal support).
+/// position `0.0` anchors to. `AxisDirection` is resolved the way
+/// `getAxisDirectionFromAxisReverseAndDirectionality` (`widgets/basic.dart`)
+/// does: a horizontal `scroll_direction` reads the ambient
+/// [`Directionality`](crate::Directionality) (`RightToLeft` under an RTL
+/// ancestor, defaulting to `LeftToRight` with no ancestor), and `reverse`
+/// flips whichever base direction that resolves to — including the vertical
+/// axis, which never consults `Directionality` itself.
 #[derive(Clone, Debug, StatelessView)]
 pub struct SingleChildScrollView {
     scroll_direction: Axis,
@@ -103,13 +107,12 @@ impl SingleChildScrollView {
 }
 
 impl StatelessView for SingleChildScrollView {
-    fn build(&self, _ctx: &dyn BuildContext) -> impl IntoView {
-        let axis_direction = match (self.scroll_direction, self.reverse) {
-            (Axis::Vertical, false) => AxisDirection::TopToBottom,
-            (Axis::Vertical, true) => AxisDirection::BottomToTop,
-            (Axis::Horizontal, false) => AxisDirection::LeftToRight,
-            (Axis::Horizontal, true) => AxisDirection::RightToLeft,
-        };
+    fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
+        let axis_direction = axis_direction_from_axis_reverse_and_directionality(
+            ctx,
+            self.scroll_direction,
+            self.reverse,
+        );
         let adapter = match self.child.clone().into_inner() {
             Some(boxed) => SliverToBoxAdapter::new().child(boxed),
             None => SliverToBoxAdapter::new(),

--- a/crates/flui-widgets/tests/parity/custom_scroll_view_test.rs
+++ b/crates/flui-widgets/tests/parity/custom_scroll_view_test.rs
@@ -10,8 +10,6 @@
 //! - Each sliver child is wired directly into the viewport as a sliver child.
 //!
 //! Divergence:
-//! - Flutter wraps `CustomScrollView` in a `Directionality`; FLUI's layout
-//!   pipeline has no text-direction concept at this level.
 //! - Flutter tests cover keyboard scroll, focus, and overscroll physics; those
 //!   require `ScrollController` integration not yet exercised in this harness.
 //!   Geometry/structure assertions are used here (Phase-2 scope).

--- a/crates/flui-widgets/tests/parity/grid_view_test.rs
+++ b/crates/flui-widgets/tests/parity/grid_view_test.rs
@@ -16,7 +16,11 @@
 //! - Flutter asserts via `tester.renderObjectList<RenderBox>(find.byType(DecoratedBox))`;
 //!   FLUI uses `find_all_by_render_type("RenderSliverGrid")` and
 //!   `render_node_count()` since the type-finder operates on render objects.
-//! - FLUI omits `Directionality` (not required by the layout machinery).
+//! - These node-count cases place no `Directionality` ancestor; `GridView`
+//!   now resolves a horizontal `scroll_direction` from it (defaulting to
+//!   `Ltr` with none), same as `ListView`/`CustomScrollView`/`PageView`/
+//!   `SingleChildScrollView` — see `crates/flui-widgets/tests/parity/
+//!   list_view_test.rs` for the RTL geometry oracle this family shares.
 //!
 //! Geometry cross-check:
 //! `SliverGridDelegateWithMaxCrossAxisExtent(max=100)` on a 200-wide viewport:

--- a/crates/flui-widgets/tests/parity/list_view_test.rs
+++ b/crates/flui-widgets/tests/parity/list_view_test.rs
@@ -24,15 +24,27 @@
 //!   (`crates/flui-objects/src/sliver/sliver_list.rs`), so this instead
 //!   asserts the property upstream's exact log is really checking: a large
 //!   jump does not force-build every index it skipped over.
+//!
+//! Divergence found and fixed by this port: `ListView::build`
+//! (`crates/flui-widgets/src/scroll/list_view.rs`) hardcoded
+//! `AxisDirection::LeftToRight` for `Axis::Horizontal`, ignoring the ambient
+//! `Directionality` entirely — a horizontal `ListView` under an RTL ancestor
+//! laid its items out left-to-right instead of Flutter's right-to-left
+//! (`ScrollView.getDirection`, `widgets/scroll_view.dart`, delegating to
+//! `getAxisDirectionFromAxisReverseAndDirectionality`,
+//! `widgets/basic.dart:4513-4527`). See
+//! [`horizontal_under_rtl_directionality_lays_the_first_item_out_at_the_right_edge`]
+//! for the oracle and the falsifying geometry.
 
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
 
 use crate::common::{lay_out, tight};
+use flui_types::typography::TextDirection;
 use flui_view::ViewExt;
 use flui_widgets::prelude::Axis;
-use flui_widgets::{ListView, ScrollController, SizedBox};
+use flui_widgets::{Directionality, ListView, ScrollController, SizedBox};
 
 /// A `ListView.builder` over 3 items that all fit in the viewport builds
 /// all 3 items after the two-tick lazy-settle sequence.
@@ -176,4 +188,56 @@ fn large_scroll_jump_settles_the_new_window_without_materializing_the_skipped_ba
         "a large jump must build items in the new visible window (around index 20); \
          built indices: {built:?}"
     );
+}
+
+/// A horizontal, non-reversed `ListView` under an RTL `Directionality`
+/// resolves its `AxisDirection` to `RightToLeft`: the first item
+/// (`children[0]`) paints at the viewport's TRAILING (right) edge, and each
+/// later item sits progressively further LEFT — the mirror image of the LTR
+/// case, not just "the same layout with a flipped default."
+///
+/// Flutter parity: `ScrollView.getDirection` (`widgets/scroll_view.dart`)
+/// delegates to `getAxisDirectionFromAxisReverseAndDirectionality`
+/// (`widgets/basic.dart:4513-4527`), which for `Axis.horizontal` reads
+/// `Directionality.of(context)` and maps RTL to `AxisDirection.left`.
+///
+/// Oracle: `RenderSliverFixedExtentList` positions each child through the
+/// same shared per-child paint-offset rule every sliver uses —
+/// `crates/flui-rendering/src/constraints/sliver_layout.rs`'s
+/// `child_paint_offset` (ported from `RenderSliverMultiBoxAdaptorMixin`'s
+/// child-positioning contract): for a not-right-way-up sliver (RTL, forward
+/// growth), `main_axis_delta = paint_extent - child_main_extent -
+/// child_main_axis_position`, where `child_main_axis_position = layout_offset
+/// - scroll_offset`. Three 100px-wide items in an exactly-filled 300px-wide
+/// viewport (`scroll_offset = 0`, `paint_extent = 300`):
+/// - item 0: `layout_offset = 0` → `300 - 100 - 0 = 200`
+/// - item 1: `layout_offset = 100` → `300 - 100 - 100 = 100`
+/// - item 2: `layout_offset = 200` → `300 - 100 - 200 = 0`
+///
+/// Before the fix, `ListView::build` hardcoded `AxisDirection::LeftToRight`
+/// for `Axis::Horizontal`, so this test failed with item 0 at `x = 0.0`
+/// (the LTR position) instead of the RTL oracle's `x = 200.0` — see the
+/// module doc's "Divergence found and fixed by this port".
+#[test]
+fn horizontal_under_rtl_directionality_lays_the_first_item_out_at_the_right_edge() {
+    let items: Vec<flui_view::BoxedView> =
+        (0..3).map(|_| SizedBox::new(100.0, 50.0).boxed()).collect();
+    let laid = lay_out(
+        Directionality::new(
+            TextDirection::Rtl,
+            ListView::new(100.0, items).scroll_direction(Axis::Horizontal),
+        ),
+        tight(300.0, 50.0),
+    );
+
+    let list_sliver = laid.find_by_render_type("RenderSliverFixedExtentList");
+    let expected_x = [200.0, 100.0, 0.0];
+    for (index, expected_x) in expected_x.into_iter().enumerate() {
+        let item = laid.child(list_sliver, index);
+        assert_eq!(
+            laid.offset(item).dx.get(),
+            expected_x,
+            "item {index}'s local x offset within the sliver must match the RTL oracle"
+        );
+    }
 }

--- a/crates/flui-widgets/tests/parity/page_view_test.rs
+++ b/crates/flui-widgets/tests/parity/page_view_test.rs
@@ -9,7 +9,7 @@
 //! `crates/flui-widgets/src/scroll/page_view.rs`'s module docs record the
 //! exact V1 boundary (eager children, listener-based `on_page_changed`, no
 //! `pageSnapping: false`/`reverse`/`padEnds`/`allowImplicitScrolling`/
-//! `PageStorage`/`viewport_fraction > 1.0` centering). **15
+//! `PageStorage`/`viewport_fraction > 1.0` centering). **17
 //! tests ported below**, covering the portable core:
 //!
 //! - `initial_page_lands_on_first_layout` — `initialPage` seeding on the very
@@ -72,6 +72,16 @@
 //!   coverage (the horizontal axis dominates the rest of this file, but
 //!   `PageView::scroll_direction` is not axis-agnostic-by-construction — a
 //!   `dy`-vs-`dx` mixup would only show up in a real vertical drag).
+//! - `horizontal_page_view_drag_under_rtl_directionality_crosses_to_the_next_page_on_the_opposite_physical_drag`
+//!   and `horizontal_page_view_fling_under_rtl_directionality_continues_the_opposite_way_of_ltr`
+//!   — RTL `Directionality` coverage for both gesture halves. `PageView`
+//!   composes `Scrollable` (`crates/flui-widgets/src/scroll/page_view.rs`),
+//!   handing it the SAME resolved `AxisDirection` its own inner `Viewport`
+//!   uses, so a real drag/fling through `PageView` itself — not just a bare
+//!   `Scrollable` — must orient the same way under RTL. Not Flutter ports
+//!   (no corresponding upstream `testWidgets` case); regression coverage for
+//!   the `axisDirectionIsReversed` gesture-orientation fix, read through
+//!   `PageController` the same way the halfway-threshold tests above do.
 //! - `animate_to_page_lands_on_the_page` (ADR-0037) — page → pixels
 //!   through the guarded formula, then a real curve/duration animation
 //!   pumped to completion. Cross-checked against `'PageController control
@@ -120,9 +130,10 @@ use std::time::Duration;
 
 use flui_animation::{Curves, Vsync};
 use flui_types::layout::Axis;
+use flui_types::typography::TextDirection;
 use flui_view::prelude::StatelessView;
 use flui_view::{BuildContext, IntoView, ViewExt};
-use flui_widgets::{PageController, PageView, SizedBox, VsyncScope};
+use flui_widgets::{Directionality, PageController, PageView, SizedBox, VsyncScope};
 
 use crate::common::{LaidOut, lay_out, loose, tight};
 
@@ -336,6 +347,188 @@ fn on_page_changed_fires_exactly_once_per_crossing() {
     );
 
     scoped.dispatch_pointer_up(20.0, 100.0);
+}
+
+// ============================================================================
+// Gesture orientation under RTL Directionality
+// ============================================================================
+//
+// `PageView` composes `Scrollable` (`crates/flui-widgets/src/scroll/page_view.rs`,
+// `PageViewState::build`), handing it the SAME `axis_direction` its own
+// inner `Viewport` uses. The two tests below drive an actual `PageView`
+// (not a bare `Scrollable`) through both gesture halves under RTL
+// `Directionality`, so a regression in that wiring — not just in
+// `Scrollable`'s own `on_pan_update`/`on_pan_end` sign math, already covered
+// generically by `scrollable_test.rs`'s
+// `horizontal_drag_under_rtl_directionality_moves_the_offset_opposite_of_ltr`/
+// `horizontal_fling_under_rtl_directionality_continues_the_opposite_way_of_ltr`
+// — would be caught here too: e.g. `PageView` passing a `scroll_direction`
+// to `Scrollable` that disagrees with the `axis_direction` it separately
+// resolved, or the reverse.
+//
+// Both start `PageController::with_params(2, 1.0)` at the middle page (2 of
+// 0..=4, pixels 600) rather than page 0, so a drag toward EITHER
+// neighbor is a plain in-bounds move — no boundary clamp can mask a
+// wrong-signed drag/fling the way starting at the 0 minimum would.
+
+/// The drag-delta half. Same 160px, past-the-160px-halfway-mark distance
+/// (viewport_fraction 1.0 -> half a 300px page = 150px) that
+/// `dragging_past_half_reads_the_next_page_dragging_below_half_reads_the_current_page`
+/// uses under (default) LTR — reused here as this test's own LTR control,
+/// since the drag distance/assertion shape needs no change to be reused
+/// starting from page 2 instead of page 0 (`2 + 160/300`, not `0 +
+/// 160/300`).
+///
+/// Oracle: `axisDirectionIsReversed` (`painting/basic_types.dart`) +
+/// `ScrollDragController.update` (`widgets/scroll_activity.dart`) — a
+/// horizontal, non-reversed (`LeftToRight`) `PageView` and one under RTL
+/// `Directionality` (`RightToLeft`, reversed) must move the SAME physical
+/// drag toward OPPOSITE pages.
+#[test]
+fn horizontal_page_view_drag_under_rtl_directionality_crosses_to_the_next_page_on_the_opposite_physical_drag()
+ {
+    fn page_after_drag(directionality: Option<TextDirection>, total_delta_x: f32) -> f32 {
+        let controller = PageController::with_params(2, 1.0);
+        let page_view = PageView::new(pages(5)).controller(controller.clone());
+        let scoped = match directionality {
+            Some(direction) => lay_out(
+                Directionality::new(direction, page_view),
+                tight(300.0, 300.0),
+            ),
+            None => lay_out(page_view, tight(300.0, 300.0)),
+        };
+        drag_horizontal_by(&scoped, total_delta_x, 100.0);
+        controller
+            .page()
+            .expect("page() must be Some once laid out")
+    }
+
+    // LTR control: a 160px LEFTWARD drag (dx = -160), the exact distance
+    // `dragging_past_half_reads_the_next_page_dragging_below_half_reads_the_current_page`
+    // uses, must read page 2.533 (2 + 160/300) — advancing toward page 3.
+    let ltr_page = page_after_drag(None, -160.0);
+    assert!(
+        (ltr_page - (2.0 + 160.0 / 300.0)).abs() < 1e-4,
+        "LTR control: a 160px leftward drag from page 2 must read page 2.533, advancing \
+         toward page 3; got {ltr_page}"
+    );
+
+    // SAME leftward drag under RTL Directionality: PageView resolves
+    // RightToLeft (reversed), so the fixed Scrollable now DECREASES pixels
+    // on a leftward drag instead of increasing them — page 1.467 (2 -
+    // 160/300), retreating toward page 1 instead of advancing toward page 3.
+    let rtl_same_direction_page = page_after_drag(Some(TextDirection::Rtl), -160.0);
+    assert!(
+        (rtl_same_direction_page - (2.0 - 160.0 / 300.0)).abs() < 1e-4,
+        "under RTL Directionality the SAME leftward drag must retreat toward page 1 \
+         (page 1.467), the opposite of the LTR control's advance toward page 3; \
+         got {rtl_same_direction_page}"
+    );
+
+    // The RTL-correct direction — a 160px RIGHTWARD drag, the mirror image
+    // of the LTR control's leftward drag — is what advances toward page 3
+    // under RTL, landing on the SAME page value as the LTR control.
+    let rtl_opposite_direction_page = page_after_drag(Some(TextDirection::Rtl), 160.0);
+    assert!(
+        (rtl_opposite_direction_page - (2.0 + 160.0 / 300.0)).abs() < 1e-4,
+        "under RTL Directionality a 160px RIGHTWARD drag (the mirror image of the LTR \
+         control's leftward drag) must read page 2.533, matching the LTR control's \
+         advance toward page 3; got {rtl_opposite_direction_page}"
+    );
+}
+
+/// The fling-velocity half. `PageScrollPhysics::create_ballistic_simulation`
+/// (this file's own physics-unit tests, `crates/flui-widgets/src/scroll/page_view.rs`)
+/// takes the fling velocity `Scrollable::on_pan_end` computes — the SAME
+/// axis-direction-aware sign this fix applies — so a released `PageView`
+/// drag must keep moving in the direction the drag itself established,
+/// mirrored under RTL the same way
+/// `horizontal_fling_under_rtl_directionality_continues_the_opposite_way_of_ltr`
+/// (`scrollable_test.rs`) pins for a bare `Scrollable`. This drives it
+/// through an actual `PageView` to exercise `PageView`'s own `Scrollable`
+/// wiring, not just the shared `Scrollable` code path.
+///
+/// This does NOT assert which page the fling settles on — this file's own
+/// module doc ("Why 'past half'/'below half'/'fling velocity' aren't ALSO
+/// gesture-driven release+settle tests") explains why this harness's
+/// synthetic drags can't be steered to land a *measured* release velocity on
+/// a chosen side of `PageScrollPhysics::velocity_tolerance_px_per_sec`
+/// deterministically; that distinction stays pinned at the physics-unit
+/// level (`fling_velocity_beyond_tolerance_advances_regardless_of_distance`
+/// and its backward sibling). This test only needs the fully deterministic
+/// half: live pixels keep moving consistently after release, and that
+/// direction flips between LTR and RTL for the identical physical drag.
+#[test]
+fn horizontal_page_view_fling_under_rtl_directionality_continues_the_opposite_way_of_ltr() {
+    fn fling_pixels(directionality: Option<TextDirection>) -> (f32, f32, f32) {
+        let controller = PageController::with_params(2, 1.0);
+        let page_view = PageView::new(pages(5)).controller(controller.clone());
+        let vsync = Vsync::new();
+        let wrapped = VsyncScope::new(vsync.clone(), page_view);
+        let mut scoped = match directionality {
+            Some(direction) => {
+                lay_out(Directionality::new(direction, wrapped), tight(300.0, 300.0))
+            }
+            None => lay_out(wrapped, tight(300.0, 300.0)),
+        };
+        scoped.adopt_vsync(vsync);
+
+        let start_pixels = controller.scroll_controller().pixels();
+
+        // Leftward drag well past the 18px slop, mirroring
+        // `horizontal_fling_under_rtl_directionality_continues_the_opposite_way_of_ltr`
+        // (`scrollable_test.rs`).
+        scoped.dispatch_pointer_down(250.0, 100.0);
+        scoped.dispatch_pointer_move(150.0, 100.0); // 100px leftward: slop-crossing
+        scoped.dispatch_pointer_move(100.0, 100.0); // 50px more: on_pan_update
+        scoped.dispatch_pointer_up(100.0, 100.0);
+
+        let pixels_at_release = controller.scroll_controller().pixels();
+
+        // Same two-pump settle window as the `Scrollable`-level fling test.
+        scoped.pump_for(Duration::from_millis(16));
+        scoped.pump_for(Duration::from_millis(16));
+
+        (
+            start_pixels,
+            pixels_at_release,
+            controller.scroll_controller().pixels(),
+        )
+    }
+
+    let (ltr_start, ltr_at_release, ltr_after_pump) = fling_pixels(None);
+    assert_eq!(
+        ltr_start, 600.0,
+        "sanity: PageController::with_params(2, 1.0) must land on page 2 (pixels 600) \
+         on the first layout, same as initial_page_lands_on_first_layout pins"
+    );
+    assert!(
+        ltr_at_release > ltr_start,
+        "LTR control: a leftward drag on a horizontal PageView must increase pixels \
+         before release ({ltr_start} -> {ltr_at_release})"
+    );
+    assert!(
+        ltr_after_pump > ltr_at_release,
+        "LTR control: the fling must keep advancing (increasing) past the release point \
+         after two animation frames; release={ltr_at_release:.1}, after_pump={ltr_after_pump:.1}"
+    );
+
+    let (rtl_start, rtl_at_release, rtl_after_pump) = fling_pixels(Some(TextDirection::Rtl));
+    assert_eq!(
+        rtl_start, 600.0,
+        "sanity: same initial-page seeding under RTL"
+    );
+    assert!(
+        rtl_at_release < rtl_start,
+        "under RTL Directionality the SAME leftward drag must DECREASE pixels before \
+         release ({rtl_start} -> {rtl_at_release}), the opposite of the LTR control"
+    );
+    assert!(
+        rtl_after_pump < rtl_at_release,
+        "under RTL Directionality the fling must keep advancing (decreasing) past the \
+         release point after two animation frames — the opposite of the LTR control's \
+         continued increase; release={rtl_at_release:.1}, after_pump={rtl_after_pump:.1}"
+    );
 }
 
 // ============================================================================

--- a/crates/flui-widgets/tests/parity/scrollable_test.rs
+++ b/crates/flui-widgets/tests/parity/scrollable_test.rs
@@ -47,8 +47,10 @@ use std::time::Duration;
 
 use flui_animation::Vsync;
 use flui_rendering::constraints::BoxConstraints;
+use flui_types::typography::TextDirection;
+use flui_widgets::prelude::Axis;
 use flui_widgets::{
-    BouncingScrollPhysics, ClampingScrollPhysics, ScrollController, Scrollable,
+    BouncingScrollPhysics, ClampingScrollPhysics, Directionality, ScrollController, Scrollable,
     SharedScrollPhysics, SizedBox, VsyncScope,
 };
 
@@ -157,5 +159,168 @@ fn bouncing_physics_top_overscroll_springs_back_to_min_extent() {
         (-1.0..=1.0).contains(&final_pixels),
         "bouncing spring-back must return scroll to within 1 px of the minimum (0); \
          got {final_pixels:.3}"
+    );
+}
+
+// ============================================================================
+// Gesture orientation under RTL Directionality
+// ============================================================================
+//
+// A horizontal scroll view's *layout* now resolves its `AxisDirection` from
+// ambient `Directionality` (RTL -> `RightToLeft`), but `Scrollable`'s gesture
+// code oriented drags/flings by the bare `Axis` alone, unconditionally
+// negating as if the axis were always non-reversed (`LeftToRight`/
+// `TopToBottom`). Under RTL that leaves content moving AGAINST the finger.
+//
+// Oracle: `axisDirectionIsReversed` (`painting/basic_types.dart`) — `up` and
+// `left` are reversed, `down` and `right` are not — feeding
+// `ScrollDragController.update`'s `if (_reversed) { offset = -offset; }` and
+// `.end`'s `double velocity = -details.primaryVelocity!; if (_reversed) {
+// velocity = -velocity; }` (`widgets/scroll_activity.dart`), both ahead of
+// `ScrollPosition.applyUserOffset`'s `pixels - delta`. FLUI's
+// `AxisDirection::is_reversed` (`crates/flui-types/src/layout/axis.rs`)
+// already implements the identical `RightToLeft | BottomToTop => true`
+// rule, so `Scrollable` only needed to consult it.
+
+/// The drag-delta half of the defect (`on_pan_update`). Builds a horizontal
+/// `Scrollable` with (LTR, the default) and without (RTL) an ambient
+/// `Directionality`, drags the SAME physical distance in both, and asserts
+/// the offset moves in OPPOSITE directions.
+///
+/// LTR resolves `LeftToRight` (not reversed): `pixels -= raw_delta`, so a
+/// 50px LEFTWARD drag (`raw_delta = -50`) increases the offset by 50 — the
+/// same "drag toward the axis start increases the offset" convention
+/// `scrollable_drag_up_increases_scroll_offset` (`tests/scroll.rs`) pins for
+/// the vertical (`TopToBottom`, also not reversed) case.
+///
+/// RTL resolves `RightToLeft` (reversed): `pixels += raw_delta`, so the
+/// SAME 50px leftward drag DECREASES the offset by 50 instead — the mirror
+/// image, not a smaller/larger version of the LTR case.
+#[test]
+fn horizontal_drag_under_rtl_directionality_moves_the_offset_opposite_of_ltr() {
+    fn dragged_pixels(directionality: Option<TextDirection>) -> f32 {
+        let controller = ScrollController::new();
+        controller.update_dimensions(300.0, 0.0, 500.0);
+        // Midpoint start: a ±50px move from here never clips against either
+        // boundary, so a difference between the LTR and RTL runs can only
+        // come from the sign the gesture code applies, not from clamping.
+        controller.set_pixels(250.0);
+
+        let scrollable = Scrollable::new()
+            .controller(controller.clone())
+            .scroll_direction(Axis::Horizontal)
+            .child(SizedBox::new(800.0, 300.0));
+
+        let scoped = match directionality {
+            Some(direction) => lay_out(
+                Directionality::new(direction, scrollable),
+                tight(300.0, 300.0),
+            ),
+            None => lay_out(scrollable, tight(300.0, 300.0)),
+        };
+
+        // A single 50px leftward drag: with no competing recognizer the
+        // arena awards the drag after Down, so this first move is delivered
+        // in full — same pattern as `scrollable_drag_up_increases_scroll_offset`
+        // (`tests/scroll.rs`).
+        scoped.dispatch_pointer_down(200.0, 150.0);
+        scoped.dispatch_pointer_move(150.0, 150.0);
+        scoped.dispatch_pointer_up(150.0, 150.0);
+
+        controller.pixels()
+    }
+
+    let ltr_pixels = dragged_pixels(None);
+    assert_eq!(
+        ltr_pixels, 300.0,
+        "LTR control: a 50px leftward drag on a non-reversed (LeftToRight) horizontal \
+         Scrollable must increase the offset by 50 (250 -> 300); got {ltr_pixels:.1}"
+    );
+
+    let rtl_pixels = dragged_pixels(Some(TextDirection::Rtl));
+    assert_eq!(
+        rtl_pixels, 200.0,
+        "under RTL Directionality the SAME physical leftward drag must move the offset \
+         the OPPOSITE way (250 -> 200), not the LTR-control direction; got {rtl_pixels:.1}"
+    );
+}
+
+/// The independent fling/velocity half of the same defect (`on_pan_end`) —
+/// the sign bug in `on_pan_update` and the sign bug in `on_pan_end` are two
+/// separate `match scroll_direction` arms in `Scrollable::build`
+/// (`crates/flui-widgets/src/scroll/scrollable.rs`), so a fix that only
+/// covers the drag-delta test above would leave this half uncovered.
+///
+/// A fast horizontal drag released mid-gesture must keep advancing the
+/// offset in the SAME direction the drag itself established: LTR continues
+/// increasing past the release point (mirroring
+/// `scrollable_fling_advances_offset_past_release` in `tests/scroll.rs`);
+/// RTL continues DECREASING past its (already-decreasing) release point —
+/// the mirror image, not a fling that reverses direction on release.
+#[test]
+fn horizontal_fling_under_rtl_directionality_continues_the_opposite_way_of_ltr() {
+    fn fling_pixels(directionality: Option<TextDirection>) -> (f32, f32, f32) {
+        let controller = ScrollController::new();
+        // Large extent keeps the fling well clear of either boundary so
+        // clamping physics never masks a wrong-signed velocity.
+        controller.update_dimensions(300.0, 0.0, 4700.0);
+        let start_pixels = 2000.0;
+        controller.set_pixels(start_pixels);
+
+        let scrollable = Scrollable::new()
+            .controller(controller.clone())
+            .scroll_direction(Axis::Horizontal)
+            .child(SizedBox::new(5000.0, 300.0));
+
+        let vsync = Vsync::new();
+        let wrapped = VsyncScope::new(vsync.clone(), scrollable);
+        let mut scoped = match directionality {
+            Some(direction) => {
+                lay_out(Directionality::new(direction, wrapped), tight(300.0, 300.0))
+            }
+            None => lay_out(wrapped, tight(300.0, 300.0)),
+        };
+        scoped.adopt_vsync(vsync);
+
+        // Leftward drag well past the 18px slop, mirroring
+        // `scrollable_fling_advances_offset_past_release`'s magnitude: first
+        // move crosses slop (on_pan_start), second fires on_pan_update.
+        scoped.dispatch_pointer_down(250.0, 150.0);
+        scoped.dispatch_pointer_move(150.0, 150.0); // 100px leftward: slop-crossing
+        scoped.dispatch_pointer_move(100.0, 150.0); // 50px more: on_pan_update
+        scoped.dispatch_pointer_up(100.0, 150.0);
+
+        let pixels_at_release = controller.pixels();
+
+        // Same two-pump settle window as `scrollable_fling_advances_offset_past_release`.
+        scoped.pump_for(Duration::from_millis(16));
+        scoped.pump_for(Duration::from_millis(16));
+
+        (start_pixels, pixels_at_release, controller.pixels())
+    }
+
+    let (ltr_start, ltr_at_release, ltr_after_pump) = fling_pixels(None);
+    assert!(
+        ltr_at_release > ltr_start,
+        "LTR control: a leftward drag on a non-reversed horizontal Scrollable must \
+         increase the offset before release ({ltr_start} -> {ltr_at_release})"
+    );
+    assert!(
+        ltr_after_pump > ltr_at_release,
+        "LTR control: the fling must keep advancing (increasing) past the release point \
+         after two animation frames; release={ltr_at_release:.1}, after_pump={ltr_after_pump:.1}"
+    );
+
+    let (rtl_start, rtl_at_release, rtl_after_pump) = fling_pixels(Some(TextDirection::Rtl));
+    assert!(
+        rtl_at_release < rtl_start,
+        "under RTL Directionality the SAME leftward drag must DECREASE the offset before \
+         release ({rtl_start} -> {rtl_at_release}), the opposite of the LTR control"
+    );
+    assert!(
+        rtl_after_pump < rtl_at_release,
+        "under RTL Directionality the fling must keep advancing (decreasing) past the \
+         release point after two animation frames — the opposite of the LTR control's \
+         continued increase; release={rtl_at_release:.1}, after_pump={rtl_after_pump:.1}"
     );
 }

--- a/crates/flui-widgets/tests/parity/scrollable_test.rs
+++ b/crates/flui-widgets/tests/parity/scrollable_test.rs
@@ -48,10 +48,11 @@ use std::time::Duration;
 use flui_animation::Vsync;
 use flui_rendering::constraints::BoxConstraints;
 use flui_types::typography::TextDirection;
-use flui_widgets::prelude::Axis;
+use flui_view::ViewExt;
+use flui_widgets::prelude::{Axis, AxisDirection};
 use flui_widgets::{
     BouncingScrollPhysics, ClampingScrollPhysics, Directionality, ScrollController, Scrollable,
-    SharedScrollPhysics, SizedBox, VsyncScope,
+    SharedScrollPhysics, SizedBox, SliverFixedExtentList, Viewport, VsyncScope,
 };
 
 use crate::common::{LaidOut, lay_out, tight};
@@ -322,5 +323,197 @@ fn horizontal_fling_under_rtl_directionality_continues_the_opposite_way_of_ltr()
         "under RTL Directionality the fling must keep advancing (decreasing) past the \
          release point after two animation frames — the opposite of the LTR control's \
          continued increase; release={rtl_at_release:.1}, after_pump={rtl_after_pump:.1}"
+    );
+}
+
+// ============================================================================
+// Explicit axis_direction override
+// ============================================================================
+//
+// `Scrollable::axis_direction` lets a `.viewport_builder` composition hand
+// `Scrollable` a pre-resolved `AxisDirection` directly, bypassing ambient
+// `Directionality` resolution entirely — the one case
+// `Scrollable::build`'s own fallback (`view.axis_direction.unwrap_or_else`,
+// which only ever consults `Directionality`) structurally cannot serve:
+// composed content whose `AxisDirection` doesn't reduce to "ambient
+// Directionality + scroll_direction + reverse: false". Both tests below set
+// the override to a value CONTRADICTING what ambient resolution would
+// produce in that same scene, so a silent fallback to ambient (dropping
+// `view.axis_direction`) flips the sign and fails with the OTHER case's
+// expected value — verified by that exact falsification on both tests
+// before this comment was written.
+
+/// The drag-delta half. `.axis_direction(LeftToRight)` under an RTL
+/// `Directionality` ancestor (ambient alone would resolve `RightToLeft`)
+/// must still orient by `LeftToRight` (not reversed). `.axis_direction(
+/// RightToLeft)` with NO `Directionality` ancestor at all (ambient would
+/// default to `LeftToRight`) must still orient by `RightToLeft` (reversed).
+/// Composed via `.viewport_builder`, `Scrollable::axis_direction`'s actual
+/// reason to exist, over the same `Viewport`-over-`SliverFixedExtentList`
+/// fixture `scrollable_viewport_builder_composes_a_custom_viewport_with_working_drag_and_feedback`
+/// (`tests/scroll.rs`) uses, oriented horizontally instead of vertically.
+///
+/// Falsified by replacing `Scrollable::build`'s `view.axis_direction
+/// .unwrap_or_else(...)` with the unconditional ambient resolution (i.e.
+/// dropping `view.axis_direction`): the RTL-ambient case (override
+/// `LeftToRight`) landed on 100.0 — the ambient-derived `RightToLeft`
+/// value — instead of 200.0, and the no-ambient case (override
+/// `RightToLeft`) landed on 200.0 — the ambient-derived `LeftToRight` value
+/// — instead of 100.0. Each run produced exactly the OTHER case's expected
+/// value, confirming both assertions exercise the override, not the
+/// fallback. Restored byte-identically; both green again.
+#[test]
+fn scrollable_axis_direction_override_governs_the_drag_delta_not_ambient_directionality() {
+    fn dragged_pixels(explicit: AxisDirection, ambient: Option<TextDirection>) -> f32 {
+        let controller = ScrollController::new();
+        controller.update_dimensions(300.0, 0.0, 300.0);
+        controller.set_pixels(150.0);
+
+        let scrollable = Scrollable::new()
+            .controller(controller.clone())
+            .scroll_direction(Axis::Horizontal)
+            .axis_direction(explicit)
+            .viewport_builder(std::rc::Rc::new(move |position| {
+                let cols: Vec<_> = (0..12)
+                    .map(|_| SizedBox::new(50.0, 300.0).boxed())
+                    .collect();
+                Viewport::new((SliverFixedExtentList::new(50.0, cols),))
+                    .axis_direction(explicit)
+                    .position(position)
+                    .boxed()
+            }));
+
+        let scoped = match ambient {
+            Some(direction) => lay_out(
+                Directionality::new(direction, scrollable),
+                tight(300.0, 300.0),
+            ),
+            None => lay_out(scrollable, tight(300.0, 300.0)),
+        };
+
+        // Single 50px leftward drag: no competing recognizer, delivered in
+        // full — same pattern used throughout this file.
+        scoped.dispatch_pointer_down(200.0, 150.0);
+        scoped.dispatch_pointer_move(150.0, 150.0);
+        scoped.dispatch_pointer_up(150.0, 150.0);
+
+        controller.pixels()
+    }
+
+    // Override LeftToRight; ambient Directionality is RTL (would resolve
+    // RightToLeft if the override were ignored). A 50px leftward drag under
+    // (not reversed) LeftToRight increases pixels: 150 -> 200.
+    let ltr_override_under_rtl_ambient =
+        dragged_pixels(AxisDirection::LeftToRight, Some(TextDirection::Rtl));
+    assert_eq!(
+        ltr_override_under_rtl_ambient, 200.0,
+        "an explicit LeftToRight override under an RTL Directionality ancestor must orient \
+         by LeftToRight (not reversed), not the ambient RightToLeft; got \
+         {ltr_override_under_rtl_ambient:.1}"
+    );
+
+    // Override RightToLeft; no Directionality ancestor at all (ambient
+    // would default to LeftToRight if the override were ignored). The SAME
+    // 50px leftward drag under (reversed) RightToLeft decreases pixels:
+    // 150 -> 100.
+    let rtl_override_under_no_ambient = dragged_pixels(AxisDirection::RightToLeft, None);
+    assert_eq!(
+        rtl_override_under_no_ambient, 100.0,
+        "an explicit RightToLeft override with no Directionality ancestor must orient by \
+         RightToLeft (reversed), not the ambient default LeftToRight; got \
+         {rtl_override_under_no_ambient:.1}"
+    );
+}
+
+/// The fling-velocity half, same override-vs-ambient-contradiction shape as
+/// the drag test above. Composed over a longer strip (100 columns, 5000px
+/// content, 4700px `max_scroll_extent`) so a two-frame fling settle window
+/// never approaches either boundary.
+///
+/// Falsified the same way as the drag test: dropping `view.axis_direction`
+/// from `Scrollable::build` made the RTL-ambient case (override
+/// `LeftToRight`) DECREASE after release instead of increase, and the
+/// no-ambient case (override `RightToLeft`) INCREASE instead of decrease —
+/// each flipping to the other case's expected direction. Restored
+/// byte-identically; both green again.
+#[test]
+fn scrollable_axis_direction_override_governs_the_fling_velocity_not_ambient_directionality() {
+    fn fling_pixels(explicit: AxisDirection, ambient: Option<TextDirection>) -> (f32, f32, f32) {
+        let controller = ScrollController::new();
+        controller.update_dimensions(300.0, 0.0, 4700.0);
+        controller.set_pixels(2000.0);
+
+        let vsync = Vsync::new();
+        let scrollable = Scrollable::new()
+            .controller(controller.clone())
+            .scroll_direction(Axis::Horizontal)
+            .axis_direction(explicit)
+            .viewport_builder(std::rc::Rc::new(move |position| {
+                let cols: Vec<_> = (0..100)
+                    .map(|_| SizedBox::new(50.0, 300.0).boxed())
+                    .collect();
+                Viewport::new((SliverFixedExtentList::new(50.0, cols),))
+                    .axis_direction(explicit)
+                    .position(position)
+                    .boxed()
+            }));
+        let wrapped = VsyncScope::new(vsync.clone(), scrollable);
+
+        let mut scoped = match ambient {
+            Some(direction) => {
+                lay_out(Directionality::new(direction, wrapped), tight(300.0, 300.0))
+            }
+            None => lay_out(wrapped, tight(300.0, 300.0)),
+        };
+        scoped.adopt_vsync(vsync);
+
+        let start_pixels = controller.pixels();
+
+        // Leftward drag well past the 18px slop, same magnitude as the
+        // ambient-Directionality fling test above.
+        scoped.dispatch_pointer_down(250.0, 150.0);
+        scoped.dispatch_pointer_move(150.0, 150.0); // 100px leftward: slop-crossing
+        scoped.dispatch_pointer_move(100.0, 150.0); // 50px more: on_pan_update
+        scoped.dispatch_pointer_up(100.0, 150.0);
+
+        let pixels_at_release = controller.pixels();
+
+        scoped.pump_for(Duration::from_millis(16));
+        scoped.pump_for(Duration::from_millis(16));
+
+        (start_pixels, pixels_at_release, controller.pixels())
+    }
+
+    // Override LeftToRight under an RTL ambient: must behave as the
+    // non-reversed control (increase, then keep increasing).
+    let (ltr_start, ltr_at_release, ltr_after_pump) =
+        fling_pixels(AxisDirection::LeftToRight, Some(TextDirection::Rtl));
+    assert!(
+        ltr_at_release > ltr_start,
+        "an explicit LeftToRight override under an RTL Directionality ancestor must \
+         increase pixels before release, not decrease like the ambient RightToLeft would \
+         ({ltr_start} -> {ltr_at_release})"
+    );
+    assert!(
+        ltr_after_pump > ltr_at_release,
+        "the LeftToRight override's fling must keep advancing (increasing) past release; \
+         release={ltr_at_release:.1}, after_pump={ltr_after_pump:.1}"
+    );
+
+    // Override RightToLeft with no Directionality ancestor: must behave as
+    // the reversed control (decrease, then keep decreasing), not the
+    // ambient default LeftToRight.
+    let (rtl_start, rtl_at_release, rtl_after_pump) =
+        fling_pixels(AxisDirection::RightToLeft, None);
+    assert!(
+        rtl_at_release < rtl_start,
+        "an explicit RightToLeft override with no Directionality ancestor must decrease \
+         pixels before release, not increase like the ambient default LeftToRight would \
+         ({rtl_start} -> {rtl_at_release})"
+    );
+    assert!(
+        rtl_after_pump < rtl_at_release,
+        "the RightToLeft override's fling must keep advancing (decreasing) past release; \
+         release={rtl_at_release:.1}, after_pump={rtl_after_pump:.1}"
     );
 }

--- a/crates/flui-widgets/tests/parity/single_child_scroll_view_test.rs
+++ b/crates/flui-widgets/tests/parity/single_child_scroll_view_test.rs
@@ -44,6 +44,18 @@
 //! `AxisDirection` values, so no `flui-objects`/`flui-rendering` change was
 //! needed (tripwire not crossed).
 //!
+//! Second divergence found and fixed by this port: that `(scroll_direction,
+//! reverse)` mapping ignored the ambient `Directionality` entirely, always
+//! resolving `Axis::Horizontal` + `reverse: false` to
+//! `AxisDirection::LeftToRight` — a horizontal, non-reversed
+//! `SingleChildScrollView` under an RTL ancestor scrolled left-to-right
+//! instead of Flutter's right-to-left
+//! (`getAxisDirectionFromAxisReverseAndDirectionality`,
+//! `widgets/basic.dart:4513-4527`). See
+//! [`horizontal_under_rtl_directionality_lays_out_right_to_left`] and
+//! [`horizontal_reverse_under_rtl_directionality_cancels_back_to_left_to_right`]
+//! for the oracle and the `reverse`/`Directionality` interaction.
+//!
 //! Overlap: `tests/scroll.rs`
 //! `single_child_scroll_view_lays_child_out_unbounded_on_scroll_axis` and
 //! `_horizontal_lays_child_unbounded_on_width` already cover "child sized
@@ -52,8 +64,9 @@
 //! that case and instead cites the upstream test on those two functions.
 
 use crate::common::{lay_out, offset, size, tight};
+use flui_types::typography::TextDirection;
 use flui_widgets::prelude::Axis;
-use flui_widgets::{SingleChildScrollView, SizedBox};
+use flui_widgets::{Directionality, SingleChildScrollView, SizedBox};
 
 /// An offset far past `max_scroll_extent` clamps to the maximum; an offset
 /// below `min_scroll_extent` (0) clamps to zero. Read indirectly through the
@@ -168,6 +181,86 @@ fn reverse_horizontal_flips_to_right_to_left_not_bottom_to_top() {
         laid.offset(child),
         offset(-300.0, 0.0),
         "horizontal reverse must shift on the X axis (RightToLeft), not the Y axis"
+    );
+}
+
+/// A horizontal, non-reversed `SingleChildScrollView` under an RTL
+/// `Directionality` resolves to the SAME `AxisDirection::RightToLeft` as
+/// `reverse_horizontal_flips_to_right_to_left_not_bottom_to_top` above gets
+/// from `reverse(true)` under the (default) LTR ancestor — RTL alone, with no
+/// `reverse`, already flips the content.
+///
+/// Flutter parity: `getAxisDirectionFromAxisReverseAndDirectionality`
+/// (`widgets/basic.dart:4513-4527`) maps `scrollDirection: Axis.horizontal,
+/// reverse: false` under an RTL `Directionality` to `AxisDirection.left` —
+/// the identical `AxisDirection` the sibling test reaches via `reverse: true`
+/// under LTR instead. Same child-offset math as that test:
+/// `main_axis_delta = paint_extent - child_main_extent -
+/// child_main_axis_position` = `300 - 600 - 0 = -300`.
+///
+/// Before the fix, `SingleChildScrollView::build` never consulted
+/// `Directionality` — this scene resolved to the default
+/// `AxisDirection::LeftToRight` regardless of the RTL ancestor, so this test
+/// failed with the child at `offset(0.0, 0.0)` (the LTR position) instead of
+/// the oracle's `offset(-300.0, 0.0)` — see the module doc's second
+/// "divergence found and fixed by this port".
+#[test]
+fn horizontal_under_rtl_directionality_lays_out_right_to_left() {
+    let laid = lay_out(
+        Directionality::new(
+            TextDirection::Rtl,
+            SingleChildScrollView::new()
+                .scroll_direction(Axis::Horizontal)
+                .child(SizedBox::new(600.0, 200.0)),
+        ),
+        tight(300.0, 200.0),
+    );
+    let child = laid.only_child(laid.only_child(laid.root()));
+    assert_eq!(
+        laid.offset(child),
+        offset(-300.0, 0.0),
+        "a horizontal SingleChildScrollView under RTL Directionality (no reverse) must \
+         resolve to AxisDirection::RightToLeft, same as reverse(true) under LTR"
+    );
+}
+
+/// `reverse(true)` under an RTL `Directionality` cancels the RTL base
+/// direction back to `AxisDirection::LeftToRight` — the double-flip case: two
+/// direction-reversing inputs (an RTL ambient direction AND an explicit
+/// `reverse`) compose back to the ORIGINAL forward direction, not to a
+/// doubled or unchanged reversal.
+///
+/// Flutter parity: `getAxisDirectionFromAxisReverseAndDirectionality`
+/// (`widgets/basic.dart:4513-4527`) computes the RTL base direction
+/// (`AxisDirection.left`) first, THEN applies `flipAxisDirection` because
+/// `reverse` is true — `flipAxisDirection(AxisDirection.left) ==
+/// AxisDirection.right`, i.e. `AxisDirection.right` in Flutter's own naming
+/// (`AxisDirection::LeftToRight` in FLUI's). Same child-offset math as
+/// `reverse_flips_which_edge_the_child_anchors_to`'s forward case:
+/// `main_axis_delta = child_main_axis_position = 0 - 0 = 0`.
+///
+/// This is the case most likely to get the flip order wrong: computing
+/// `reverse` first and RTL second (or applying `reverse` twice) would land on
+/// `AxisDirection::RightToLeft` again instead of cancelling back to
+/// `LeftToRight`.
+#[test]
+fn horizontal_reverse_under_rtl_directionality_cancels_back_to_left_to_right() {
+    let laid = lay_out(
+        Directionality::new(
+            TextDirection::Rtl,
+            SingleChildScrollView::new()
+                .scroll_direction(Axis::Horizontal)
+                .reverse(true)
+                .child(SizedBox::new(600.0, 200.0)),
+        ),
+        tight(300.0, 200.0),
+    );
+    let child = laid.only_child(laid.only_child(laid.root()));
+    assert_eq!(
+        laid.offset(child),
+        offset(0.0, 0.0),
+        "reverse(true) under RTL Directionality must cancel back to \
+         AxisDirection::LeftToRight, matching the plain forward/LTR rest position"
     );
 }
 


### PR DESCRIPTION
Five scroll views mapped a horizontal axis to `AxisDirection::LeftToRight` unconditionally, so **every horizontal scroll view laid out and scrolled the wrong way under RTL** — first item at the left edge instead of the right. Found while fixing the same defect in `ListBody` (#521).

## Flutter's rule, ported from three sources

`ScrollView.getDirection` delegates to `getAxisDirectionFromAxisReverseAndDirectionality` (`widgets/basic.dart`); `PageView._getDirection` inlines the identical switch; `SingleChildScrollView` calls the same helper. All three were read directly rather than inferred from one.

The asymmetry that matters: **only `Axis.horizontal` consults `Directionality`** — vertical never does — and `reverse` flips whatever base direction results.

## One helper, not five copies

`axis_direction_from_axis_reverse_and_directionality` lives in `crates/flui-widgets/src/localization/directionality.rs`, beside `Directionality` rather than under `scroll/`, mirroring where Flutter puts it (`basic.dart`, shared with `ListBody`, not `scroll_view.dart`).

Only the horizontal branch calls `Directionality::maybe_of`, so a **vertical** scroll view never registers an inherited dependency and cannot be forced to rebuild by a direction change. The pure `text_direction` + `reverse` math is split into a private function so it is unit-testable without a `BuildContext`.

All five were fixable. Four have no `reverse` field and pass `false`; `SingleChildScrollView` is the only one with a real `reverse`, and its doc comment — which previously self-documented the gap as "LTR-only, no Directionality lookup" — now describes the fixed behaviour.

## Two stale doc claims removed

`custom_scroll_view_test.rs` asserted in prose that *"FLUI's layout pipeline has no text-direction concept at this level"* — a statement about FLUI's own limitation, not Flutter's behaviour, and now false. `grid_view_test.rs` carried the same claim. Both updated. No test assertion was weakened: the affected tests check render-node counts, not direction, and stayed green throughout.

`grid_view_interaction_test.rs`'s separate finding about **cross**-axis direction in `Viewport::default_cross_axis_direction` is a distinct gap and is deliberately untouched.

## Falsification — re-run independently against production

Making the helper ignore its context and always resolve LTR:

```
FAIL list_view_test::horizontal_under_rtl_directionality_lays_the_first_item_out_at_the_right_edge
  left: 0.0     right: 200.0
FAIL single_child_scroll_view_test::horizontal_reverse_under_rtl_directionality_cancels_back_to_left_to_right
```

Note the second case: `reverse` and RTL **compose** back to left-to-right. That double flip is the likeliest place to get this wrong, so it is asserted explicitly rather than left implied.

Restored byte-identically, green again.

## Verification

- `cargo nextest run --workspace --exclude flui-platform` — **8423 passed**, 19 skipped
- `cargo nextest run -p flui-objects` — 867 passed
- `cargo clippy -p flui-widgets --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`, `port-check`, `typos` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)