### PR TITLE
fix(widgets): Row and Column resolve text direction from ambient Directionality

### DIFF
--- a/crates/flui-objects/src/layout/flex.rs
+++ b/crates/flui-objects/src/layout/flex.rs
@@ -709,15 +709,19 @@ impl RenderFlex {
         // measured in the same local (always-increasing-rightward) coordinate
         // space. `offsets` is written by real child index so the caller sees
         // one `Offset` per child regardless of visiting order.
+        // `step` counts placement positions along the main axis; `i` is the
+        // real child index occupying that position — the same sequence for
+        // both orders, derived rather than boxed behind `dyn Iterator` so
+        // this layout path stays allocation- and dispatch-free.
         let mut offsets = vec![Offset::ZERO; child_count];
-        let visiting_order: Box<dyn Iterator<Item = usize>> = if flip_main_axis {
-            Box::new((0..child_count).rev())
-        } else {
-            Box::new(0..child_count)
-        };
 
         let mut main_offset = leading_space;
-        for i in visiting_order {
+        for step in 0..child_count {
+            let i = if flip_main_axis {
+                child_count - 1 - step
+            } else {
+                step
+            };
             let child_size = flex_sizes.child_sizes[i].unwrap_or(Size::ZERO);
 
             let cross_offset = match effective_cross_axis_alignment {

--- a/crates/flui-objects/src/layout/flex.rs
+++ b/crates/flui-objects/src/layout/flex.rs
@@ -1,6 +1,7 @@
 //! RenderFlex - lays out children in a row or column.
 
 use flui_tree::Variable;
+use flui_types::typography::TextDirection;
 use flui_types::{Offset, Pixels, Size, geometry::px};
 
 use flui_rendering::{
@@ -121,6 +122,18 @@ pub struct RenderFlex {
     main_axis_size: MainAxisSize,
     /// Cross axis alignment.
     cross_axis_alignment: CrossAxisAlignment,
+    /// Resolves which physical edge `Start`/`End` mean, and which order
+    /// children are laid out in.
+    ///
+    /// A horizontal flex (`Row`) consults this for its **main** axis: under
+    /// `Rtl` children are laid out right-to-left (`RenderFlex._flipMainAxis`,
+    /// `rendering/flex.dart`). A vertical flex (`Column`) consults this for
+    /// its **cross** axis instead (`_flipCrossAxis`) — its main axis is
+    /// governed by `VerticalDirection`, which FLUI does not yet model, so a
+    /// `Column`'s main axis never flips. Defaults to `Ltr`, matching every
+    /// other FLUI render object that has no ambient `Directionality` to fall
+    /// back on.
+    text_direction: TextDirection,
     /// Baseline kind used when [`CrossAxisAlignment::Baseline`] is selected.
     text_baseline: TextBaseline,
     /// Spacing between children.
@@ -150,6 +163,7 @@ impl Default for RenderFlex {
             main_axis_alignment: MainAxisAlignment::Start,
             main_axis_size: MainAxisSize::Max,
             cross_axis_alignment: CrossAxisAlignment::Start,
+            text_direction: TextDirection::Ltr,
             text_baseline: TextBaseline::Alphabetic,
             spacing: 0.0,
             child_count: 0,
@@ -204,6 +218,15 @@ impl RenderFlex {
         self
     }
 
+    /// Sets the ambient text direction that resolves `Start`/`End` and child
+    /// order: a horizontal flex (`Row`) flips its main axis under `Rtl`; a
+    /// vertical flex (`Column`) flips its cross axis instead. Defaults to
+    /// `Ltr`.
+    pub fn with_text_direction(mut self, text_direction: TextDirection) -> Self {
+        self.text_direction = text_direction;
+        self
+    }
+
     /// Sets the spacing between children.
     ///
     /// Debug-asserts `spacing >= 0.0` — Flutter's `RenderFlex` asserts the
@@ -232,6 +255,31 @@ impl RenderFlex {
     /// Returns true if this is a vertical layout.
     pub fn is_vertical(&self) -> bool {
         self.direction == FlexDirection::Vertical
+    }
+
+    /// Returns the ambient text direction used to resolve `Start`/`End`.
+    pub fn text_direction(&self) -> TextDirection {
+        self.text_direction
+    }
+
+    /// Whether the main axis is laid out and iterated in reverse.
+    ///
+    /// Mirrors Flutter `RenderFlex._flipMainAxis` (`rendering/flex.dart`):
+    /// only a horizontal flex (`Row`) consults `text_direction` here — a
+    /// vertical flex's main axis is governed by `VerticalDirection`, which
+    /// FLUI does not model, so it never flips.
+    fn flip_main_axis(&self) -> bool {
+        self.direction == FlexDirection::Horizontal && self.text_direction.is_rtl()
+    }
+
+    /// Whether the cross axis's `Start`/`End` offsets are swapped.
+    ///
+    /// Mirrors Flutter `RenderFlex._flipCrossAxis`: only a vertical flex
+    /// (`Column`) consults `text_direction` here — a horizontal flex's cross
+    /// axis is governed by `VerticalDirection` instead, so a `Row` never
+    /// flips its cross axis from `text_direction` alone.
+    fn flip_cross_axis(&self) -> bool {
+        self.direction == FlexDirection::Vertical && self.text_direction.is_rtl()
     }
 
     /// Extracts main axis extent from a size.
@@ -597,7 +645,19 @@ impl RenderFlex {
         // do not shift children by negative offsets under End/Center/Space*.
         let free_space = (main_extent - flex_sizes.total_main).max(Pixels::ZERO);
 
-        let (mut main_offset, between_space) = match self.main_axis_alignment {
+        // Flutter flex.dart: `MainAxisAlignment._distributeSpace` derives `end`'s
+        // leading space from `start`'s formula with the flip inverted, which is
+        // equivalent to swapping Start/End up front and reusing one formula
+        // table below. Center/SpaceBetween/SpaceAround/SpaceEvenly are already
+        // symmetric, so flipping never changes their case.
+        let flip_main_axis = self.flip_main_axis();
+        let effective_main_axis_alignment = match (self.main_axis_alignment, flip_main_axis) {
+            (MainAxisAlignment::Start, true) => MainAxisAlignment::End,
+            (MainAxisAlignment::End, true) => MainAxisAlignment::Start,
+            (alignment, _) => alignment,
+        };
+
+        let (leading_space, between_space) = match effective_main_axis_alignment {
             MainAxisAlignment::Start => (Pixels::ZERO, Pixels::ZERO),
             MainAxisAlignment::End => (free_space, Pixels::ZERO),
             MainAxisAlignment::Center => (free_space / 2.0, Pixels::ZERO),
@@ -618,6 +678,16 @@ impl RenderFlex {
             }
         };
 
+        // Same Start/End swap for the cross axis (`_flipCrossAxis`); unlike
+        // the main axis this never reorders children, it only changes which
+        // physical edge each child's own offset is measured from.
+        let effective_cross_axis_alignment =
+            match (self.cross_axis_alignment, self.flip_cross_axis()) {
+                (CrossAxisAlignment::Start, true) => CrossAxisAlignment::End,
+                (CrossAxisAlignment::End, true) => CrossAxisAlignment::Start,
+                (alignment, _) => alignment,
+            };
+
         // Flutter flex.dart: baseline cross-axis alignment applies to rows only.
         // Find the maximum alignment-baseline distance — all children shift down
         // so their baselines land on the same horizontal level.
@@ -632,12 +702,25 @@ impl RenderFlex {
             None
         };
 
-        let mut offsets = Vec::with_capacity(child_count);
+        // Flutter flex.dart's offset loop walks from `topLeftChild` (last
+        // child, iterating `childBefore`) when `flipMainAxis`, instead of the
+        // usual first-child-forward order — the visual placement order
+        // reverses under RTL even though each child's own offset is still
+        // measured in the same local (always-increasing-rightward) coordinate
+        // space. `offsets` is written by real child index so the caller sees
+        // one `Offset` per child regardless of visiting order.
+        let mut offsets = vec![Offset::ZERO; child_count];
+        let visiting_order: Box<dyn Iterator<Item = usize>> = if flip_main_axis {
+            Box::new((0..child_count).rev())
+        } else {
+            Box::new(0..child_count)
+        };
 
-        for (i, slot) in flex_sizes.child_sizes.iter().enumerate() {
-            let child_size = slot.unwrap_or(Size::ZERO);
+        let mut main_offset = leading_space;
+        for i in visiting_order {
+            let child_size = flex_sizes.child_sizes[i].unwrap_or(Size::ZERO);
 
-            let cross_offset = match self.cross_axis_alignment {
+            let cross_offset = match effective_cross_axis_alignment {
                 CrossAxisAlignment::Start | CrossAxisAlignment::Stretch => Pixels::ZERO,
                 CrossAxisAlignment::End => cross_extent - self.cross_size(child_size),
                 CrossAxisAlignment::Center => (cross_extent - self.cross_size(child_size)) / 2.0,
@@ -650,7 +733,7 @@ impl RenderFlex {
                 }
             };
 
-            offsets.push(self.offset(main_offset, cross_offset));
+            offsets[i] = self.offset(main_offset, cross_offset);
             main_offset += self.main_size(child_size) + px(self.spacing) + between_space;
         }
 
@@ -679,6 +762,7 @@ impl flui_foundation::Diagnosticable for RenderFlex {
         if self.cross_axis_alignment == CrossAxisAlignment::Baseline {
             properties.add_enum("text_baseline", self.text_baseline);
         }
+        properties.add_default_enum("text_direction", self.text_direction, TextDirection::Ltr);
         properties.add_default_double("spacing", self.spacing, 0.0, Some("px"));
     }
 }

--- a/crates/flui-widgets/src/flex/flex.rs
+++ b/crates/flui-widgets/src/flex/flex.rs
@@ -7,9 +7,11 @@ use flui_objects::{
 };
 use flui_rendering::protocol::BoxProtocol;
 use flui_types::typography::TextBaseline;
+use flui_types::typography::TextDirection;
 use flui_view::BoxedView;
 use flui_view::seq::ViewSeq;
 
+use crate::localization::Directionality;
 use crate::support::generic_render_view_element;
 
 /// Shared main/cross-axis configuration for the flex family, with Flutter's
@@ -43,7 +45,10 @@ impl Default for FlexStyle {
 }
 
 impl FlexStyle {
-    fn build(self, direction: FlexDirection) -> RenderFlex {
+    /// `text_direction` is the already-resolved ambient direction — see
+    /// [`FlexRenderView`] for why it must be resolved before this call
+    /// rather than looked up here.
+    fn build(self, direction: FlexDirection, text_direction: TextDirection) -> RenderFlex {
         let base = match direction {
             FlexDirection::Horizontal => RenderFlex::row(),
             FlexDirection::Vertical => RenderFlex::column(),
@@ -53,6 +58,7 @@ impl FlexStyle {
             .with_main_axis_size(self.main_axis_size)
             .with_spacing(self.spacing)
             .with_text_baseline(self.text_baseline)
+            .with_text_direction(text_direction)
     }
 }
 
@@ -113,6 +119,20 @@ macro_rules! flex_style_builders {
 /// Generic over `C: ViewSeq`: a static `column!`/`row!` tuple keeps each child
 /// monomorphic (the contract-C2 fast path), while a `Vec<BoxedView>` carries a
 /// dynamic, runtime-sized child list.
+///
+/// Resolves the ambient [`Directionality`] the way Flutter's `RenderFlex`
+/// does (`rendering/flex.dart`): a horizontal flex (`Row`) consults it for
+/// its *main* axis (`Start`/`End` and child order flip under `Rtl`); a
+/// vertical flex (`Column`) consults it for its *cross* axis instead — its
+/// main axis is governed by `VerticalDirection`, which FLUI does not model.
+/// Defaults to [`TextDirection::Ltr`] with no ancestor, matching every other
+/// FLUI widget that consults `Directionality`. That ambient read only exists
+/// inside a `BuildContext`, so `Flex` is a composing widget: `build` resolves
+/// the direction once and hands the *already-resolved* [`TextDirection`] to a
+/// private render-object widget — `flui_view::RenderObjectContext` (the only
+/// context `RenderView::create_render_object`/`update_render_object` ever
+/// receive) carries no ambient-lookup capability, so a bare `RenderView` can
+/// never read `Directionality` itself.
 #[derive(Clone)]
 pub struct Flex<C = Vec<BoxedView>> {
     direction: FlexDirection,
@@ -143,38 +163,29 @@ impl<C: ViewSeq> fmt::Debug for Flex<C> {
     }
 }
 
-impl<C> flui_view::RenderView for Flex<C>
+impl<C> flui_view::View for Flex<C>
 where
     C: ViewSeq + Clone + 'static,
 {
-    type Protocol = BoxProtocol;
-    type RenderObject = RenderFlex;
-
-    fn create_render_object(
-        &self,
-        _ctx: &flui_view::RenderObjectContext<'_>,
-    ) -> Self::RenderObject {
-        self.style.build(self.direction)
-    }
-
-    fn update_render_object(
-        &self,
-        _ctx: &flui_view::RenderObjectContext<'_>,
-        render_object: &mut Self::RenderObject,
-    ) {
-        *render_object = self.style.build(self.direction);
-    }
-
-    fn has_children(&self) -> bool {
-        !self.children.is_empty()
-    }
-
-    fn visit_child_views(&self, visitor: &mut dyn FnMut(&dyn flui_view::View)) {
-        self.children.for_each(|_index, child| visitor(child));
+    fn create_element(&self) -> flui_view::element::ElementKind {
+        flui_view::element::ElementKind::stateless(self)
     }
 }
 
-generic_render_view_element!(Flex);
+impl<C> flui_view::StatelessView for Flex<C>
+where
+    C: ViewSeq + Clone + 'static,
+{
+    fn build(&self, ctx: &dyn flui_view::BuildContext) -> impl flui_view::IntoView {
+        let text_direction = Directionality::maybe_of(ctx).unwrap_or(TextDirection::Ltr);
+        FlexRenderView {
+            direction: self.direction,
+            style: self.style,
+            text_direction,
+            children: self.children.clone(),
+        }
+    }
+}
 
 /// Lays out children horizontally (Flutter's `Row`).
 #[derive(Clone)]
@@ -204,38 +215,29 @@ impl<C: ViewSeq> fmt::Debug for Row<C> {
     }
 }
 
-impl<C> flui_view::RenderView for Row<C>
+impl<C> flui_view::View for Row<C>
 where
     C: ViewSeq + Clone + 'static,
 {
-    type Protocol = BoxProtocol;
-    type RenderObject = RenderFlex;
-
-    fn create_render_object(
-        &self,
-        _ctx: &flui_view::RenderObjectContext<'_>,
-    ) -> Self::RenderObject {
-        self.style.build(FlexDirection::Horizontal)
-    }
-
-    fn update_render_object(
-        &self,
-        _ctx: &flui_view::RenderObjectContext<'_>,
-        render_object: &mut Self::RenderObject,
-    ) {
-        *render_object = self.style.build(FlexDirection::Horizontal);
-    }
-
-    fn has_children(&self) -> bool {
-        !self.children.is_empty()
-    }
-
-    fn visit_child_views(&self, visitor: &mut dyn FnMut(&dyn flui_view::View)) {
-        self.children.for_each(|_index, child| visitor(child));
+    fn create_element(&self) -> flui_view::element::ElementKind {
+        flui_view::element::ElementKind::stateless(self)
     }
 }
 
-generic_render_view_element!(Row);
+impl<C> flui_view::StatelessView for Row<C>
+where
+    C: ViewSeq + Clone + 'static,
+{
+    fn build(&self, ctx: &dyn flui_view::BuildContext) -> impl flui_view::IntoView {
+        let text_direction = Directionality::maybe_of(ctx).unwrap_or(TextDirection::Ltr);
+        FlexRenderView {
+            direction: FlexDirection::Horizontal,
+            style: self.style,
+            text_direction,
+            children: self.children.clone(),
+        }
+    }
+}
 
 /// Lays out children vertically (Flutter's `Column`).
 #[derive(Clone)]
@@ -265,7 +267,44 @@ impl<C: ViewSeq> fmt::Debug for Column<C> {
     }
 }
 
-impl<C> flui_view::RenderView for Column<C>
+impl<C> flui_view::View for Column<C>
+where
+    C: ViewSeq + Clone + 'static,
+{
+    fn create_element(&self) -> flui_view::element::ElementKind {
+        flui_view::element::ElementKind::stateless(self)
+    }
+}
+
+impl<C> flui_view::StatelessView for Column<C>
+where
+    C: ViewSeq + Clone + 'static,
+{
+    fn build(&self, ctx: &dyn flui_view::BuildContext) -> impl flui_view::IntoView {
+        let text_direction = Directionality::maybe_of(ctx).unwrap_or(TextDirection::Ltr);
+        FlexRenderView {
+            direction: FlexDirection::Vertical,
+            style: self.style,
+            text_direction,
+            children: self.children.clone(),
+        }
+    }
+}
+
+/// The actual `RenderFlex`-backed render-object widget shared by [`Flex`],
+/// [`Row`], and [`Column`]. Its [`TextDirection`] is already resolved by the
+/// composing widget's `StatelessView::build` — kept private so
+/// `Directionality` is only ever read at the `BuildContext` seam that can see
+/// it, never assumed to be reachable from a bare `RenderView`.
+#[derive(Clone)]
+struct FlexRenderView<C> {
+    direction: FlexDirection,
+    style: FlexStyle,
+    text_direction: TextDirection,
+    children: C,
+}
+
+impl<C> flui_view::RenderView for FlexRenderView<C>
 where
     C: ViewSeq + Clone + 'static,
 {
@@ -276,7 +315,7 @@ where
         &self,
         _ctx: &flui_view::RenderObjectContext<'_>,
     ) -> Self::RenderObject {
-        self.style.build(FlexDirection::Vertical)
+        self.style.build(self.direction, self.text_direction)
     }
 
     fn update_render_object(
@@ -284,7 +323,7 @@ where
         _ctx: &flui_view::RenderObjectContext<'_>,
         render_object: &mut Self::RenderObject,
     ) {
-        *render_object = self.style.build(FlexDirection::Vertical);
+        *render_object = self.style.build(self.direction, self.text_direction);
     }
 
     fn has_children(&self) -> bool {
@@ -296,22 +335,46 @@ where
     }
 }
 
-generic_render_view_element!(Column);
+generic_render_view_element!(FlexRenderView);
 
 #[cfg(test)]
 mod tests {
     //! `RenderFlex` exposes no public `spacing` getter, so wiring is verified
     //! through its derived `Debug` output — the same technique
     //! `crate::wrap::Wrap`'s own builder-wiring tests use for `RenderWrap`.
+    //!
+    //! `Row`/`Column` are composing `StatelessView`s (their `build` resolves
+    //! `Directionality` before delegating to `FlexRenderView`), so these tests
+    //! construct `FlexRenderView` directly with `TextDirection::Ltr` — the
+    //! same value `build` falls back to with no ambient `Directionality` —
+    //! rather than going through a `BuildContext`. `Directionality`
+    //! resolution itself is covered by the RTL parity tests in
+    //! `crates/flui-widgets/tests/parity/row_test.rs` and
+    //! `crates/flui-widgets/tests/parity/column_test.rs`.
 
     use flui_view::RenderView;
 
     use super::*;
 
+    fn as_render_view<C: ViewSeq + Clone + 'static>(
+        direction: FlexDirection,
+        style: FlexStyle,
+        children: C,
+    ) -> FlexRenderView<C> {
+        FlexRenderView {
+            direction,
+            style,
+            text_direction: TextDirection::Ltr,
+            children,
+        }
+    }
+
     #[test]
     fn row_spacing_defaults_to_zero() {
         let row: Row = Row::new(Vec::new());
-        let render_object = row.create_render_object(&flui_view::RenderObjectContext::detached());
+        let render_view = as_render_view(FlexDirection::Horizontal, row.style, row.children);
+        let render_object =
+            render_view.create_render_object(&flui_view::RenderObjectContext::detached());
         let debug = format!("{render_object:?}");
         assert!(
             debug.contains("spacing: 0.0"),
@@ -322,7 +385,9 @@ mod tests {
     #[test]
     fn row_spacing_builder_reaches_render_flex() {
         let row: Row = Row::new(Vec::new()).spacing(8.0);
-        let render_object = row.create_render_object(&flui_view::RenderObjectContext::detached());
+        let render_view = as_render_view(FlexDirection::Horizontal, row.style, row.children);
+        let render_object =
+            render_view.create_render_object(&flui_view::RenderObjectContext::detached());
         let debug = format!("{render_object:?}");
         assert!(
             debug.contains("spacing: 8.0"),
@@ -337,12 +402,16 @@ mod tests {
     #[test]
     fn row_update_render_object_pushes_updated_spacing() {
         let initial: Row = Row::new(Vec::new()).spacing(1.0);
+        let initial_view =
+            as_render_view(FlexDirection::Horizontal, initial.style, initial.children);
         let mut render_object =
-            initial.create_render_object(&flui_view::RenderObjectContext::detached());
+            initial_view.create_render_object(&flui_view::RenderObjectContext::detached());
         assert!(format!("{render_object:?}").contains("spacing: 1.0"));
 
         let updated: Row = Row::new(Vec::new()).spacing(9.0);
-        updated.update_render_object(
+        let updated_view =
+            as_render_view(FlexDirection::Horizontal, updated.style, updated.children);
+        updated_view.update_render_object(
             &flui_view::RenderObjectContext::detached(),
             &mut render_object,
         );
@@ -364,8 +433,9 @@ mod tests {
     #[test]
     fn column_spacing_builder_reaches_render_flex() {
         let column: Column = Column::new(Vec::new()).spacing(6.0);
+        let render_view = as_render_view(FlexDirection::Vertical, column.style, column.children);
         let render_object =
-            column.create_render_object(&flui_view::RenderObjectContext::detached());
+            render_view.create_render_object(&flui_view::RenderObjectContext::detached());
         assert!(
             format!("{render_object:?}").contains("spacing: 6.0"),
             "Column::spacing(6.0) must reach RenderFlex via the shared macro"

--- a/crates/flui-widgets/tests/parity/column_test.rs
+++ b/crates/flui-widgets/tests/parity/column_test.rs
@@ -1,0 +1,208 @@
+//! ## Test parity notes
+//!
+//! Flutter source: `packages/flutter/test/rendering/flex_test.dart`, tag
+//! `3.44.0`, the `'Flex RTL'` test — the section that sets `flex.direction =
+//! Axis.vertical` and drives `crossAxisAlignment` through `start`/`end`
+//! while `textDirection` is `rtl`. That test uses `RenderFlex` directly
+//! under a tight `800×600` test surface (Flutter's `rendering_tester.dart`
+//! `layout()` helper default); this port reproduces the same tight `800×600`
+//! constraint on the `Column` *widget* directly (no `Center` wrapper — a
+//! `Center` would hand `Column` loose constraints, and its cross axis
+//! (width) shrink-wraps to the widest child under a loose bound, collapsing
+//! the free space these cases exist to measure).
+//!
+//! Widget → render-object mapping: `Column` → `RenderFlex` (`direction:
+//! Vertical`); `SizedBox(w, h)` → `RenderConstrainedBox`.
+//!
+//! # Cross.H: flex text-direction gap (Column half)
+//!
+//! `Row`'s main-axis half of this gap (`RenderFlex._flipMainAxis`) is
+//! ported in `row_test.rs`. This file ports the other half:
+//! `RenderFlex._flipCrossAxis` only ever triggers for a **vertical** flex
+//! (`Column`), consulting the same ambient `Directionality` — a `Column`'s
+//! own **main** axis is governed by `VerticalDirection` instead, which FLUI
+//! does not model and this port does not touch. See `row_test.rs`'s Cross.H
+//! note for the shared root cause and the "no textDirection assertion"
+//! divergence, not repeated here.
+
+use flui_types::typography::TextDirection;
+use flui_view::ViewExt;
+use flui_widgets::prelude::*;
+
+use crate::common::{size, tight};
+use crate::harness;
+
+/// `CrossAxisAlignment::Start` under the default (no ambient
+/// `Directionality`) `Ltr` direction aligns every child flush to the left
+/// edge — `dx == 0`, regardless of how much free cross-axis space is
+/// available.
+///
+/// Flutter parity: `rendering/flex_test.dart` `'Flex RTL'`, the
+/// `flex.direction = Axis.vertical` / `crossAxisAlignment = start` /
+/// `textDirection = ltr` combination (reached later in the same test via
+/// `flex.textDirection = TextDirection.ltr` then `crossAxisAlignment =
+/// start`) — `box1`/`box2`/`box3` all land at `dx: 0.0`.
+#[test]
+fn column_cross_axis_alignment_start_ltr_aligns_children_to_the_left_edge() {
+    let laid = harness::pump_widget(
+        Column::new(vec![
+            SizedBox::new(100.0, 100.0).boxed(),
+            SizedBox::new(100.0, 100.0).boxed(),
+            SizedBox::new(100.0, 100.0).boxed(),
+        ])
+        .cross_axis_alignment(CrossAxisAlignment::Start),
+        tight(800.0, 600.0),
+    );
+
+    let flex_id = laid.find_by_render_type("RenderFlex");
+    assert_eq!(laid.size(flex_id), size(800.0, 600.0));
+    for i in 0..3 {
+        assert_eq!(laid.size(laid.child(flex_id, i)), size(100.0, 100.0));
+        assert_eq!(
+            laid.offset(laid.child(flex_id, i)).dx,
+            flui_types::geometry::px(0.0),
+            "child {i} must be flush against the left edge under Ltr"
+        );
+    }
+}
+
+/// `CrossAxisAlignment::End` under `Ltr` aligns every child flush to the
+/// **right** edge — the mirror image of `Start` above.
+///
+/// Flutter parity: `rendering/flex_test.dart` `'Flex RTL'`, the same
+/// vertical/`Ltr` block's `crossAxisAlignment = end` step —
+/// `box1`/`box2`/`box3` all land at `dx: 700.0` (`800 − 100`).
+#[test]
+fn column_cross_axis_alignment_end_ltr_aligns_children_to_the_right_edge() {
+    let laid = harness::pump_widget(
+        Column::new(vec![
+            SizedBox::new(100.0, 100.0).boxed(),
+            SizedBox::new(100.0, 100.0).boxed(),
+            SizedBox::new(100.0, 100.0).boxed(),
+        ])
+        .cross_axis_alignment(CrossAxisAlignment::End),
+        tight(800.0, 600.0),
+    );
+
+    let flex_id = laid.find_by_render_type("RenderFlex");
+    assert_eq!(laid.size(flex_id), size(800.0, 600.0));
+    for i in 0..3 {
+        assert_eq!(laid.size(laid.child(flex_id, i)), size(100.0, 100.0));
+        assert_eq!(
+            laid.offset(laid.child(flex_id, i)).dx,
+            flui_types::geometry::px(700.0),
+            "child {i} must be flush against the right edge under Ltr"
+        );
+    }
+}
+
+/// `CrossAxisAlignment::Start` under an **Rtl** `Directionality` flips a
+/// `Column`'s cross axis: `Start` now means the **right** edge, not the
+/// left. `RenderFlex._flipCrossAxis` only swaps which physical edge each
+/// child's own offset is measured from — it never reorders children (unlike
+/// `Row`'s main-axis flip), so every child still shifts by the same amount.
+///
+/// Flutter parity: `rendering/flex_test.dart` `'Flex RTL'` —
+/// `flex.direction = Axis.vertical; // and main=start, cross=start, up,
+/// rtl'` step: `box1`/`box2`/`box3` all land at `dx: 700.0`.
+#[test]
+fn column_cross_axis_alignment_start_rtl_aligns_children_to_the_right_edge() {
+    let laid = harness::pump_widget(
+        Directionality::new(
+            TextDirection::Rtl,
+            Column::new(vec![
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+            ])
+            .cross_axis_alignment(CrossAxisAlignment::Start),
+        ),
+        tight(800.0, 600.0),
+    );
+
+    let flex_id = laid.find_by_render_type("RenderFlex");
+    assert_eq!(laid.size(flex_id), size(800.0, 600.0));
+    for i in 0..3 {
+        assert_eq!(laid.size(laid.child(flex_id, i)), size(100.0, 100.0));
+        assert_eq!(
+            laid.offset(laid.child(flex_id, i)).dx,
+            flui_types::geometry::px(700.0),
+            "child {i} must flip to the right edge under CrossAxisAlignment::Start + Rtl"
+        );
+    }
+}
+
+/// `CrossAxisAlignment::End` under an **Rtl** `Directionality` flips to the
+/// **left** edge — the mirror of `Start` above, and the mirror of `End`'s
+/// own `Ltr` behavior.
+///
+/// Flutter parity: `rendering/flex_test.dart` `'Flex RTL'` — the
+/// `crossAxisAlignment = end` step immediately after: `box1`/`box2`/`box3`
+/// all land at `dx: 0.0`.
+#[test]
+fn column_cross_axis_alignment_end_rtl_aligns_children_to_the_left_edge() {
+    let laid = harness::pump_widget(
+        Directionality::new(
+            TextDirection::Rtl,
+            Column::new(vec![
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+            ])
+            .cross_axis_alignment(CrossAxisAlignment::End),
+        ),
+        tight(800.0, 600.0),
+    );
+
+    let flex_id = laid.find_by_render_type("RenderFlex");
+    assert_eq!(laid.size(flex_id), size(800.0, 600.0));
+    for i in 0..3 {
+        assert_eq!(laid.size(laid.child(flex_id, i)), size(100.0, 100.0));
+        assert_eq!(
+            laid.offset(laid.child(flex_id, i)).dx,
+            flui_types::geometry::px(0.0),
+            "child {i} must flip to the left edge under CrossAxisAlignment::End + Rtl"
+        );
+    }
+}
+
+/// A `Column`'s own **main** axis (vertical) never consults `Directionality`
+/// — only `VerticalDirection` (which FLUI does not model) governs it, per
+/// Flutter's `RenderFlex._flipMainAxis`. `MainAxisAlignment::Start` under
+/// `Rtl` must therefore position children exactly as it does with no
+/// ambient direction at all: sequentially from the top, in list order.
+///
+/// Flutter parity: `rendering/flex_test.dart` `'Flex RTL'`'s own `direction
+/// = Axis.vertical` block never varies main-axis child order by
+/// `textDirection` — only `verticalDirection` does (the `up`/`down` toggle
+/// later in the same test), which this port does not exercise.
+#[test]
+fn column_main_axis_alignment_start_rtl_does_not_flip_the_vertical_order() {
+    let laid = harness::pump_widget(
+        Directionality::new(
+            TextDirection::Rtl,
+            Column::new(vec![
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+            ]),
+        ),
+        tight(800.0, 600.0),
+    );
+
+    let flex_id = laid.find_by_render_type("RenderFlex");
+    // Only the main (vertical) axis is under test here — cross alignment
+    // stays at its `Center` default, so `dx` is not asserted.
+    assert_eq!(
+        laid.offset(laid.child(flex_id, 0)).dy,
+        flui_types::geometry::px(0.0)
+    );
+    assert_eq!(
+        laid.offset(laid.child(flex_id, 1)).dy,
+        flui_types::geometry::px(100.0)
+    );
+    assert_eq!(
+        laid.offset(laid.child(flex_id, 2)).dy,
+        flui_types::geometry::px(200.0)
+    );
+}

--- a/crates/flui-widgets/tests/parity/main.rs
+++ b/crates/flui-widgets/tests/parity/main.rs
@@ -187,6 +187,11 @@ mod physical_model_test;
 mod row_baseline_test;
 mod row_test;
 
+// ── Flex ambient-Directionality fix — Column cross-axis RTL (rendering/
+//    flex_test.dart's 'Flex RTL' case, the vertical-direction half of the
+//    same RenderFlex.textDirection gap row_test.rs's RTL cases close) ──────
+mod column_test;
+
 // ── Business.1 fidelity — GridView interaction parity (grid_view_test.dart,
 //    distinct oracle from grid_view_test.rs's grid_view_layout_test.dart) ──
 mod grid_view_interaction_test;

--- a/crates/flui-widgets/tests/parity/row_test.rs
+++ b/crates/flui-widgets/tests/parity/row_test.rs
@@ -22,17 +22,25 @@
 //!
 //! # Cross.H: flex text-direction gap
 //!
-//! `RenderFlex` (`crates/flui-objects/src/layout/flex.rs`) carries no
-//! `text_direction` field at all, and `Row`/`Column`/`Flex`
-//! (`crates/flui-widgets/src/flex/flex.rs`) lay out unconditionally as if
-//! `TextDirection.ltr`, with no ambient `Directionality` lookup and no
-//! "direction required" assertion. This blocks two whole axes of the
-//! oracle: the 8 `- RTL` cases (mirrored positions) and 8 of the 9 `- no
-//! textDirection` cases (a debug `AssertionError` (plain `assert`s in `flex.dart`, not a `FlutterError` construction), "has a null
-//! textDirection", from `RenderFlex._debugHasNecessaryDirections`,
-//! `rendering/flex.dart`, tag `3.44.0`). Filed as an extension of the
-//! existing shifted-box `AlignmentDirectional`/ambient-`Directionality` gap
-//! in `docs/ROADMAP.md`'s Cross.H section — see there for the shared root
+//! `RenderFlex` (`crates/flui-objects/src/layout/flex.rs`) now carries a
+//! `text_direction: TextDirection` field, and `Row`/`Column`/`Flex`
+//! (`crates/flui-widgets/src/flex/flex.rs`) resolve the ambient
+//! `Directionality` in `StatelessView::build` and hand the resolved value to
+//! a private `FlexRenderView` — the same composing-widget pattern
+//! `ListBody` uses (`crates/flui-widgets/src/layout/list_body.rs`). This
+//! unblocks the 8 `- RTL` cases below (mirrored positions).
+//!
+//! The 8 `- no textDirection` cases remain **out of scope**: they assert a
+//! debug `AssertionError` (plain `assert`s in `flex.dart`, not a
+//! `FlutterError` construction), "has a null textDirection", from
+//! `RenderFlex._debugHasNecessaryDirections` (`rendering/flex.dart`, tag
+//! `3.44.0`), fired when there is no `Directionality` ancestor at all. FLUI
+//! has no nullable `TextDirection` to assert against — every FLUI widget
+//! that consults `Directionality` defaults to `Ltr` with no ancestor instead
+//! of requiring one (the same divergence `ListBody`'s own parity port
+//! documents). Filed as an extension of the existing shifted-box
+//! `AlignmentDirectional`/ambient-`Directionality` gap in
+//! `docs/ROADMAP.md`'s Cross.H section — see there for the shared root
 //! cause, not repeated here.
 //!
 //! # Ledger (29 case names — every `testWidgets` in `row_test.dart` at tag
@@ -118,21 +126,22 @@
 //!     Also accounts for cases 9 and 27 (see their entries above/below).
 //!
 //! ## RTL (9)
-//! 19. `'Row with one Flexible child - RTL'` — **out of scope**, Cross.H
-//!     (mirrored positions require `RenderFlex` to resolve `TextDirection`).
-//! 20. `'Row with default main axis parameters - RTL'` — **out of scope**,
-//!     Cross.H.
-//! 21. `'Row with MainAxisAlignment.center - RTL'` — **out of scope**,
-//!     Cross.H.
-//! 22. `'Row with MainAxisAlignment.end - RTL'` — **out of scope**,
-//!     Cross.H.
-//! 23. `'Row with MainAxisAlignment.spaceBetween - RTL'` — **out of
-//!     scope**, Cross.H.
-//! 24. `'Row with MainAxisAlignment.spaceAround - RTL'` — **out of scope**,
-//!     Cross.H.
-//! 25. `'Row with MainAxisAlignment.spaceEvenly - RTL'` — **out of scope**,
-//!     Cross.H.
-//! 26. `'Row and MainAxisSize.min - RTL'` — **out of scope**, Cross.H.
+//! 19. `'Row with one Flexible child - RTL'` — **ported**:
+//!     [`row_with_one_flexible_child_rtl_packs_children_from_the_right`].
+//! 20. `'Row with default main axis parameters - RTL'` — **ported**:
+//!     [`row_default_main_axis_parameters_rtl_positions_children_from_the_right`].
+//! 21. `'Row with MainAxisAlignment.center - RTL'` — **ported**:
+//!     [`row_main_axis_alignment_center_rtl_centers_the_children_block`].
+//! 22. `'Row with MainAxisAlignment.end - RTL'` — **ported**:
+//!     [`row_main_axis_alignment_end_rtl_pushes_children_to_the_far_edge`].
+//! 23. `'Row with MainAxisAlignment.spaceBetween - RTL'` — **ported**:
+//!     [`row_main_axis_alignment_space_between_rtl_flushes_the_first_and_last_children_to_the_edges`].
+//! 24. `'Row with MainAxisAlignment.spaceAround - RTL'` — **ported**:
+//!     [`row_main_axis_alignment_space_around_rtl_gives_edge_children_half_gaps`].
+//! 25. `'Row with MainAxisAlignment.spaceEvenly - RTL'` — **ported**:
+//!     [`row_main_axis_alignment_space_evenly_rtl_distributes_free_space_symmetrically`].
+//! 26. `'Row and MainAxisSize.min - RTL'` — **ported**:
+//!     [`row_main_axis_size_min_rtl_shrink_wraps_and_positions_from_the_right`].
 //! 27. `'Row MainAxisSize.min layout at zero size - RTL'` — **duplicate,
 //!     not separately ported.** Like case 9, this checks only
 //!     `renderBox.size == Size(100, 0)` — `parentData.offset` (the one
@@ -146,11 +155,10 @@
 //! 29. `'Can update Row.spacing value'` — **ported**:
 //!     [`row_spacing_rebuild_changes_the_total_main_axis_extent`].
 //!
-//! **Total: 29 case names = 29 accounted for above** — 8 newly ported + 3
-//! cross-file duplicates against `flex_test.rs` (cases 10, 16, 17) + 2
-//! in-file duplicates folded into case 18 (cases 9, 27) + 16 out of scope
-//! under the Cross.H flex text-direction gap (8 `- no textDirection` error
-//! cases + 8 `- RTL` cases).
+//! **Total: 29 case names = 29 accounted for above** — 16 newly ported (8
+//! LTR + 8 RTL) + 3 cross-file duplicates against `flex_test.rs` (cases 10,
+//! 16, 17) + 2 in-file duplicates folded into case 18 (cases 9, 27) + 8 out
+//! of scope under the Cross.H "no textDirection assertion" divergence.
 //!
 //! # Implementation addition: `Row`/`Column`/`Flex::spacing`
 //!
@@ -172,6 +180,7 @@
 //! [`row_spacing_rebuild_changes_the_total_main_axis_extent`] below.
 
 use flui_rendering::testing::inspect::render_diagnostics;
+use flui_types::typography::TextDirection;
 use flui_view::ViewExt;
 use flui_widgets::prelude::*;
 
@@ -380,6 +389,263 @@ fn row_main_axis_size_min_layout_at_zero_size_collapses_the_child_to_zero_height
         "the child must keep its natural 100px width but collapse to 0px \
          height under the zero-sized ancestor's tight cross-axis constraint"
     );
+}
+
+// ------------------------------------------------------------------
+// RTL — an ambient `Directionality(TextDirection::Rtl)` flips a `Row`'s main
+// axis: `Start` packs children against the right edge instead of the left,
+// and the visual order reverses (the first child in list order ends up
+// right-most). Every case below is the exact LTR case above, mirrored, from
+// row_test.dart's `- RTL` variants (tag `3.44.0`).
+// ------------------------------------------------------------------
+
+/// `Flexible` (loose fit)/`Expanded` still take their natural/allocated
+/// width under RTL — only the main-axis *position* mirrors.
+///
+/// Flutter parity: row_test.dart `'Row with one Flexible child - RTL'` —
+/// `child0` (100px) ends up right-most at `dx` 700, the `Expanded` child
+/// (600px, filling the remaining space) at `dx` 100, and `child2` (100px)
+/// flush against the left edge at `dx` 0.
+#[test]
+fn row_with_one_flexible_child_rtl_packs_children_from_the_right() {
+    let laid = harness::pump_widget(
+        Center::new().child(Directionality::new(
+            TextDirection::Rtl,
+            Row::new(vec![
+                SizedBox::new(100.0, 100.0).boxed(),
+                Expanded::new(SizedBox::new(100.0, 100.0)).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+            ]),
+        )),
+        harness::screen(),
+    );
+
+    let flex_id = laid.find_by_render_type("RenderFlex");
+    assert_eq!(laid.size(flex_id), size(800.0, 100.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 0)), offset(700.0, 0.0));
+    assert_eq!(laid.size(laid.child(flex_id, 0)), size(100.0, 100.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 1)), offset(100.0, 0.0));
+    assert_eq!(laid.size(laid.child(flex_id, 1)), size(600.0, 100.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 2)), offset(0.0, 0.0));
+    assert_eq!(laid.size(laid.child(flex_id, 2)), size(100.0, 100.0));
+}
+
+/// Default `Row` (`MainAxisAlignment::Start`) under RTL packs children
+/// against the right edge, in list order — the mirror image of the LTR
+/// default case above.
+///
+/// Flutter parity: row_test.dart `'Row with default main axis parameters -
+/// RTL'` — three `SizedBox(100, 100)` children land at `dx` 700 / 600 / 500.
+#[test]
+fn row_default_main_axis_parameters_rtl_positions_children_from_the_right() {
+    let laid = harness::pump_widget(
+        Center::new().child(Directionality::new(
+            TextDirection::Rtl,
+            Row::new(vec![
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+            ]),
+        )),
+        harness::screen(),
+    );
+
+    let flex_id = laid.find_by_render_type("RenderFlex");
+    assert_eq!(laid.size(flex_id), size(800.0, 100.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 0)), offset(700.0, 0.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 1)), offset(600.0, 0.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 2)), offset(500.0, 0.0));
+    for i in 0..3 {
+        assert_eq!(laid.size(laid.child(flex_id, i)), size(100.0, 100.0));
+    }
+}
+
+/// `MainAxisAlignment::Center` is direction-symmetric — RTL centers the same
+/// block the LTR case does, just built with the RTL-visiting formula.
+///
+/// Flutter parity: row_test.dart `'Row with MainAxisAlignment.center - RTL'`
+/// — two `SizedBox(100, 100)` children land at `dx` 400 / 300 (mirrored from
+/// the LTR case's 300 / 400).
+#[test]
+fn row_main_axis_alignment_center_rtl_centers_the_children_block() {
+    let laid = harness::pump_widget(
+        Center::new().child(Directionality::new(
+            TextDirection::Rtl,
+            Row::new(vec![
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+            ])
+            .main_axis_alignment(MainAxisAlignment::Center),
+        )),
+        harness::screen(),
+    );
+
+    let flex_id = laid.find_by_render_type("RenderFlex");
+    assert_eq!(laid.size(flex_id), size(800.0, 100.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 0)), offset(400.0, 0.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 1)), offset(300.0, 0.0));
+    assert_eq!(laid.size(laid.child(flex_id, 0)), size(100.0, 100.0));
+    assert_eq!(laid.size(laid.child(flex_id, 1)), size(100.0, 100.0));
+}
+
+/// `MainAxisAlignment::End` under RTL packs children against the **left**
+/// edge — `End` and `Start` swap physical edges under RTL, and the LTR
+/// case's `End` (right edge) numbers become this case's `Start` numbers.
+///
+/// Flutter parity: row_test.dart `'Row with MainAxisAlignment.end - RTL'` —
+/// three `SizedBox(100, 100)` children land at `dx` 200 / 100 / 0.
+#[test]
+fn row_main_axis_alignment_end_rtl_pushes_children_to_the_far_edge() {
+    let laid = harness::pump_widget(
+        Center::new().child(Directionality::new(
+            TextDirection::Rtl,
+            Row::new(vec![
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+            ])
+            .main_axis_alignment(MainAxisAlignment::End),
+        )),
+        harness::screen(),
+    );
+
+    let flex_id = laid.find_by_render_type("RenderFlex");
+    assert_eq!(laid.size(flex_id), size(800.0, 100.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 0)), offset(200.0, 0.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 1)), offset(100.0, 0.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 2)), offset(0.0, 0.0));
+    assert_eq!(laid.size(laid.child(flex_id, 0)), size(100.0, 100.0));
+    assert_eq!(laid.size(laid.child(flex_id, 1)), size(100.0, 100.0));
+    assert_eq!(laid.size(laid.child(flex_id, 2)), size(100.0, 100.0));
+}
+
+/// `MainAxisAlignment::SpaceBetween` still flushes the first and last
+/// children to the row's own edges under RTL — but "first"/"last" now read
+/// right-to-left, so `child0` (list order) lands at the right edge instead
+/// of the left.
+///
+/// Flutter parity: row_test.dart `'Row with MainAxisAlignment.spaceBetween -
+/// RTL'` — three `SizedBox(100, 100)` children land at `dx` 700 / 350 / 0.
+#[test]
+fn row_main_axis_alignment_space_between_rtl_flushes_the_first_and_last_children_to_the_edges() {
+    let laid = harness::pump_widget(
+        Center::new().child(Directionality::new(
+            TextDirection::Rtl,
+            Row::new(vec![
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+            ])
+            .main_axis_alignment(MainAxisAlignment::SpaceBetween),
+        )),
+        harness::screen(),
+    );
+
+    let flex_id = laid.find_by_render_type("RenderFlex");
+    assert_eq!(laid.size(flex_id), size(800.0, 100.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 0)), offset(700.0, 0.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 1)), offset(350.0, 0.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 2)), offset(0.0, 0.0));
+    assert_eq!(laid.size(laid.child(flex_id, 0)), size(100.0, 100.0));
+    assert_eq!(laid.size(laid.child(flex_id, 1)), size(100.0, 100.0));
+    assert_eq!(laid.size(laid.child(flex_id, 2)), size(100.0, 100.0));
+}
+
+/// `MainAxisAlignment::SpaceAround`'s half-share edges swap sides under RTL,
+/// same as `SpaceBetween` above.
+///
+/// Flutter parity: row_test.dart `'Row with MainAxisAlignment.spaceAround -
+/// RTL'` — four `SizedBox(100, 100)` children land at `dx` 650 / 450 / 250 /
+/// 50.
+#[test]
+fn row_main_axis_alignment_space_around_rtl_gives_edge_children_half_gaps() {
+    let laid = harness::pump_widget(
+        Center::new().child(Directionality::new(
+            TextDirection::Rtl,
+            Row::new(vec![
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(100.0, 100.0).boxed(),
+            ])
+            .main_axis_alignment(MainAxisAlignment::SpaceAround),
+        )),
+        harness::screen(),
+    );
+
+    let flex_id = laid.find_by_render_type("RenderFlex");
+    assert_eq!(laid.size(flex_id), size(800.0, 100.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 0)), offset(650.0, 0.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 1)), offset(450.0, 0.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 2)), offset(250.0, 0.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 3)), offset(50.0, 0.0));
+    for i in 0..4 {
+        assert_eq!(laid.size(laid.child(flex_id, i)), size(100.0, 100.0));
+    }
+}
+
+/// `MainAxisAlignment::SpaceEvenly` is symmetric under RTL just like
+/// `Center` — the gap formula is unchanged, only the visiting order (and
+/// therefore which child sits in which gap) mirrors.
+///
+/// Flutter parity: row_test.dart `'Row with MainAxisAlignment.spaceEvenly -
+/// RTL'` — three `SizedBox(200, 100)` children land at `dx` 550 / 300 / 50.
+#[test]
+fn row_main_axis_alignment_space_evenly_rtl_distributes_free_space_symmetrically() {
+    let laid = harness::pump_widget(
+        Center::new().child(Directionality::new(
+            TextDirection::Rtl,
+            Row::new(vec![
+                SizedBox::new(200.0, 100.0).boxed(),
+                SizedBox::new(200.0, 100.0).boxed(),
+                SizedBox::new(200.0, 100.0).boxed(),
+            ])
+            .main_axis_alignment(MainAxisAlignment::SpaceEvenly),
+        )),
+        harness::screen(),
+    );
+
+    let flex_id = laid.find_by_render_type("RenderFlex");
+    assert_eq!(laid.size(flex_id), size(800.0, 100.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 0)), offset(550.0, 0.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 1)), offset(300.0, 0.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 2)), offset(50.0, 0.0));
+    for i in 0..3 {
+        assert_eq!(laid.size(laid.child(flex_id, i)), size(200.0, 100.0));
+    }
+}
+
+/// `MainAxisSize::Min` shrink-wraps the same way under RTL; with zero free
+/// space, `Start`/`End` agree — the only RTL-specific signal is the visiting
+/// order, which reverses which child sits at which end.
+///
+/// Flutter parity: row_test.dart `'Row and MainAxisSize.min - RTL'` — a
+/// 100px and a 150px child shrink-wrap to a 250px row, with `child0` (100px)
+/// right-most at `dx` 150 and `child1` (150px) flush left at `dx` 0.
+#[test]
+fn row_main_axis_size_min_rtl_shrink_wraps_and_positions_from_the_right() {
+    let laid = harness::pump_widget(
+        Center::new().child(Directionality::new(
+            TextDirection::Rtl,
+            Row::new(vec![
+                SizedBox::new(100.0, 100.0).boxed(),
+                SizedBox::new(150.0, 100.0).boxed(),
+            ])
+            .main_axis_size(MainAxisSize::Min),
+        )),
+        harness::screen(),
+    );
+
+    let flex_id = laid.find_by_render_type("RenderFlex");
+    assert_eq!(
+        laid.size(flex_id),
+        size(250.0, 100.0),
+        "MainAxisSize::Min must shrink-wrap to 100 + 150 = 250px regardless of direction"
+    );
+    assert_eq!(laid.offset(laid.child(flex_id, 0)), offset(150.0, 0.0));
+    assert_eq!(laid.size(laid.child(flex_id, 0)), size(100.0, 100.0));
+    assert_eq!(laid.offset(laid.child(flex_id, 1)), offset(0.0, 0.0));
+    assert_eq!(laid.size(laid.child(flex_id, 1)), size(150.0, 100.0));
 }
 
 /// A `Row` built with no explicit `.spacing()` call mounts a `RenderFlex`


### PR DESCRIPTION
`Flex`/`Row`/`Column` contained **zero** references to `Directionality` or `TextDirection`. Under RTL, a `Row` with `MainAxisAlignment.start` packed children to the left where Flutter packs them to the right — so every RTL layout built on the framework's most-used widgets was wrong. Found while fixing the same defect in `ListBody` (#521).

## Unlike `ListBody`, both layers were broken

`ListBody` turned out to be a widget-layer-only fix: its render object already accepted an `AxisDirection` and nobody handed it one. `RenderFlex` had no text-direction concept at all — no field, no flip logic — so this changes both:

- `RenderFlex` gains `text_direction`, `flip_main_axis` / `flip_cross_axis`, and a reworked offset computation.
- `Flex`/`Row`/`Column` become composing `StatelessView`s resolving `Directionality::maybe_of(ctx)` at the `BuildContext` seam, handing the value to a private render view — the `ListBody` pattern, with no new ambient-lookup capability invented in `flui-view`.

## The asymmetry that makes this easy to get wrong

Per `rendering/flex.dart` (tag `3.44.0`):

- **`_flipMainAxis`** — only a *horizontal* flex consults `textDirection`. A `Column`'s main axis is governed by `VerticalDirection` and never flips on text direction.
- **`_flipCrossAxis`** — the exact mirror: only a *vertical* flex consults it. A `Row`'s cross axis never does.

And the flip is not a `Start`⇄`End` swap: under `flipMainAxis` Flutter walks children **backward from `lastChild`**, so the first child in list order is positioned last. That is reproduced by reversing the visiting order and writing into a real-index-addressed offset vector, rather than reordering the children themselves.

## Falsification — re-run independently, both halves separately

Forcing `flip_main_axis` to `false` fails the Row RTL cases:

```
FAIL row_default_main_axis_parameters_rtl_positions_children_from_the_right
FAIL row_main_axis_size_min_rtl_shrink_wraps_and_positions_from_the_right
FAIL row_main_axis_alignment_space_between_rtl_flushes_the_first_and_last_children_to_the_edges
```

Forcing `flip_cross_axis` to `false` fails the Column ones, and **only** those:

```
FAIL column_cross_axis_alignment_end_rtl_aligns_children_to_the_left_edge
FAIL column_cross_axis_alignment_start_rtl_aligns_children_to_the_right_edge
```

The two disarmings hitting disjoint test sets is the evidence that the mirrored rule is implemented as two independent conditions rather than one shared flag — the failure mode a single `is_rtl()` check would have produced.

## No test was weakened

`row_test.rs` already carried a ledger marking all eight of Flutter's `- RTL` cases out of scope pending exactly this fix — it recorded FLUI's behaviour as a known gap rather than asserting LTR-only as correct. Those entries move to ported, with the oracle's own numbers, cross-checked against `rendering/flex_test.dart`'s `'Flex RTL'` case for the Column half.

## Deferred, and named

Flutter raises a debug assert when a horizontal flex has no `Directionality` ancestor; FLUI defaults to `Ltr`, matching every other ambient-direction fallback in the codebase, including the one `ListBody`'s port documents. `VerticalDirection` is still not modelled — correctly harmless here, since neither axis it governs is text-direction-driven.

## Verification

- `cargo nextest run --workspace --exclude flui-platform` — **8427 passed**, 19 skipped
- `cargo nextest run -p flui-objects` — 867 passed (core layout path touched; the render-object harness had to stay green)
- `cargo clippy -p flui-widgets -p flui-objects --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`, `port-check`, `typos` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)