### PR TITLE
feat(conformance): Runtime.1 conformance matrix and public-API freeze gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 # Job graph (every job is gated on the fast `checks` source gate):
-#   checks         — fmt + taplo + typos + inventory + port-check + actionlint + zizmor (seconds, no compile)
+#   checks         — fmt + taplo + typos + inventory + runtime-conformance + port-check + actionlint + zizmor (seconds, no compile)
 #   clippy         — workspace lint with -D warnings
 #   feature-matrix — cargo-hack per-feature clippy (--each-feature --optional-deps), xilem-style,
 #                    plus a bounded backend-feature-pair powerset for flui-engine, plus every
@@ -57,14 +57,15 @@ env:
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────
-  # checks — fast source gate. fmt + port-check + typos + Taplo + the workflow
+  # checks — fast source gate. fmt + inventory + runtime-conformance +
+  # port-check + typos + Taplo + the workflow
   # linters (actionlint semantics, zizmor security audit). No compile. Every
   # downstream job (clippy, test, doc, bench-compile) depends on this, so a
   # malformed PR fails in seconds before any workspace build starts.
   # Ubuntu only — pure source analysis. clippy lives in its own parallel job.
   # ─────────────────────────────────────────────────────────────────────────
   checks:
-    name: checks (fmt, port-check, typos, taplo, actionlint, zizmor)
+    name: checks (fmt, conformance, port-check, typos, taplo, actionlint, zizmor)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -114,6 +115,9 @@ jobs:
 
       - name: workspace inventory + layer topology drift check
         run: bash scripts/check-workspace-inventory.sh
+
+      - name: Runtime.1 conformance registry check
+        run: bash scripts/check-runtime-conformance.sh
 
       - name: scripts/port-check.sh (22 refusal triggers + FR-033)
         run: bash scripts/port-check.sh -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       - name: workspace inventory + layer topology drift check
         run: bash scripts/check-workspace-inventory.sh
 
-      - name: Runtime.1 conformance registry check
+      - name: Runtime contract registry check
         run: bash scripts/check-runtime-conformance.sh
 
       - name: scripts/port-check.sh (22 refusal triggers + FR-033)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,8 +92,8 @@ run `just --list` for the full recipe set — every recipe is categorised and do
 don't look for a duplicate list here.
 
 **`just ci` is the gate to run before any commit.** It chains `fmt-check` → `inventory-check` →
-`port-check` → `clippy` → `test` → `test-doc`; running the pieces individually is for narrowing a
-failure, not a substitute.
+`runtime-conformance-check` → `port-check` → `clippy` → `test` → `test-doc`; running the pieces
+individually is for narrowing a failure, not a substitute.
 
 Two invocations `just --list` won't teach you:
 
@@ -149,6 +149,7 @@ When changing render-tree, sliver, layout, paint, hit-test, semantics, schedulin
 | **Crates map** | `docs/crates.md` | Per-layer crate inventory |
 | **Testing** | `docs/testing.md` | Build/test/coverage commands |
 | **Panic policy** | `docs/PANIC-POLICY.md` | When `expect("BUG: …")` is allowed vs. `Result`; `clippy::unwrap_used` gate |
+| **Runtime.1 conformance registry** | `docs/runtime-conformance.toml` | Which runtime ADR clauses are implemented vs planned, and every public runtime surface's stability classification — shipped behavior vs target architecture. Checked by `just runtime-conformance-check`; touching runtime/platform/scheduler/raster public API means updating it |
 | **Render harness** | `crates/flui-rendering/docs/TESTING.md` | RenderTester API, catalog rules |
 | **Logging ownership** | `crates/flui-log/AGENTS.md` | Subscriber policies, native sinks, who may depend on the backend |
 | **Crate ARCHITECTURE.md** | `crates/flui-{foundation,rendering,engine,layer,painting}/ARCHITECTURE.md` | Per-crate deep architecture |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ When changing render-tree, sliver, layout, paint, hit-test, semantics, schedulin
 | **Crates map** | `docs/crates.md` | Per-layer crate inventory |
 | **Testing** | `docs/testing.md` | Build/test/coverage commands |
 | **Panic policy** | `docs/PANIC-POLICY.md` | When `expect("BUG: …")` is allowed vs. `Result`; `clippy::unwrap_used` gate |
-| **Runtime.1 conformance registry** | `docs/runtime-conformance.toml` | Which runtime ADR clauses are implemented vs planned, and every public runtime surface's stability classification — shipped behavior vs target architecture. Checked by `just runtime-conformance-check`; touching runtime/platform/scheduler/raster public API means updating it |
+| **Runtime contract registry** | `docs/runtime-contract.toml` | Public shipped/planned runtime contracts, classified boundary families, and the checked root-export manifest. It deliberately does not depend on internal design records. Checked by `just runtime-conformance-check`; touching a monitored runtime export means updating it deliberately |
 | **Render harness** | `crates/flui-rendering/docs/TESTING.md` | RenderTester API, catalog rules |
 | **Logging ownership** | `crates/flui-log/AGENTS.md` | Subscriber policies, native sinks, who may depend on the backend |
 | **Crate ARCHITECTURE.md** | `crates/flui-{foundation,rendering,engine,layer,painting}/ARCHITECTURE.md` | Per-crate deep architecture |

--- a/docs/runtime-conformance.toml
+++ b/docs/runtime-conformance.toml
@@ -1,0 +1,1505 @@
+# Runtime.1 conformance registry.
+#
+# This file is the *authoritative*, machine-readable inventory of (a) every
+# normative requirement in the runtime ADRs — ADR-0027, ADR-0037, ADR-0029,
+# ADR-0039 — with its verified implementation state, and (b) every public
+# runtime/platform/scheduler/raster surface with its stability classification.
+# It is validated by `scripts/check-runtime-conformance.sh`
+# (`just runtime-conformance-check`, part of `just ci` and the CI `checks`
+# job). Markdown is deliberately NOT the source of truth here; prose in the
+# ADRs describes the target architecture, and this file records what is
+# actually true of the tree, cross-checked against the source.
+#
+# What the checker verifies mechanically (and, honestly, what it cannot):
+#
+#   - Every evidence/surface citation names a real file containing the cited
+#     string. It CANNOT verify behavior — a `contains` match proves the symbol
+#     or test still exists, not that it is correct. Behavior lives in the
+#     cited tests, which `just test` runs.
+#   - `state = "implemented"` requires at least one `symbol` citation plus at
+#     least one `test`/`compile-time`/`source-gate` citation, and rejects
+#     `.md` files as evidence — documentation is never implementation
+#     evidence.
+#   - `partial`/`planned` entries require exactly one owning issue in
+#     #551–#565.
+#   - Forbidden patterns/paths (retired intermediaries, a public generic UI
+#     executor, an `unsafe impl Sync for Renderer`, a `flui-presentation`
+#     crate) stay absent from `crates/**/*.rs`.
+#   - New ambient singletons and public lock-shaped surfaces in the runtime
+#     crates are caught by scanning for `impl_binding_singleton!(`,
+#     `fn instance() -> &'static`, and `PORT-CHECK-OK-SP6` markers, and
+#     requiring every hit to be registered below with an owning issue. This
+#     net sees exactly what those textual markers see: a singleton built
+#     without the macro/idiom, or a lock surface that never needed an SP-6
+#     marker (because port-check trigger #12's grammar missed it), is invisible
+#     to it. Full Rust-surface analysis is not claimed.
+#
+# States:
+#   implemented           — verified against current code, with evidence below
+#   partial               — some of the clause is real; the gap has one owner
+#   planned               — nothing usable landed; the work has one owner
+#   documented-divergence — FLUI deliberately diverges; the divergence is
+#                           documented at the cited location
+#
+# Classifications (public surfaces):
+#   stable-candidate — expected to survive Runtime.1 in roughly this shape;
+#                      still pre-1.0, still breakable, but not scheduled for
+#                      replacement
+#   experimental     — real, usable, explicitly unstable; may change without
+#                      migration support
+#   transitional     — exists only to bridge to the Runtime.1 ownership model;
+#                      will be reshaped or replaced by its owning issue
+#   removal-target   — scheduled for deletion by its owning issue; do not add
+#                      consumers
+#
+# Ownership domains follow ADR-0027/ADR-0037:
+#   application | realm | presentation | raster | platform | shared-engine
+
+[registry]
+milestone = "Runtime.1"
+adr_scope = ["ADR-0027", "ADR-0037", "ADR-0029", "ADR-0039"]
+
+# =============================================================================
+# ADR-0027 — Owner-affine UI realms
+# =============================================================================
+
+[[requirement]]
+key = "realm-owns-ui-session-owner-affine"
+adr = "ADR-0027"
+section = "§1–§2 ownership model / thread-affinity"
+statement = """
+Mutable UI state is scoped to a `UiRealm` — a single-owner UI session that is \
+structurally `!Send + !Sync` — never to the process or the native window.\
+"""
+state = "implemented"
+domain = "realm"
+mechanical = true
+mechanism = "compile-time assert_not_impl_any + symbol/test existence checks here"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "_owner_affine: PhantomData<*const ()>" },
+    { kind = "compile-time", file = "crates/flui-app/src/app/ui_realm.rs", contains = "assert_not_impl_any!(UiRealm: Send, Sync)" },
+]
+
+[[requirement]]
+key = "app-runtime-composition-host"
+adr = "ADR-0027"
+section = "§1 ownership model (AppRuntime / SharedEngineServices)"
+statement = """
+One `AppRuntime` per process owns platform event-loop demux, explicit \
+constructor-injected `SharedEngineServices`, and 1..N realms. No such type \
+exists; `AppBinding` remains the transitional process-service host.\
+"""
+state = "planned"
+domain = "application"
+owner_issue = 553
+mechanical = false
+
+[[requirement]]
+key = "scheduling-splits-by-level"
+adr = "ADR-0027"
+section = "§1 (scheduling split); execution plan frame-clock item"
+statement = """
+Logical update scheduling (realm `UpdateScheduler`), physical pacing \
+(presentation `FrameClock`), and raster backpressure are separate owners. \
+Today one process-global `Scheduler` singleton combines all three concerns.\
+"""
+state = "planned"
+domain = "realm"
+owner_issue = 556
+mechanical = false
+
+[[requirement]]
+key = "transitional-realm-guard-at-most-one"
+adr = "ADR-0027"
+section = "Consequences (at-most-one instance guard)"
+statement = """
+Until singleton retirement, constructing a second `UiRealm` fails with a \
+typed error — a per-realm API over process-global internals would be a lying \
+API. `REALM_CLAIMED` and `UiRealmError::AlreadyExists` retire with the \
+singletons under the owning issue.\
+"""
+state = "implemented"
+domain = "realm"
+owner_issue = 553
+mechanical = true
+mechanism = "process_global_guard entry below pins the guard; its deletion fails this gate until the registry is updated"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "static REALM_CLAIMED" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn at_most_one_runtime_second_construction_fails_typed" },
+]
+
+[[requirement]]
+key = "idle-only-commit-points"
+adr = "ADR-0027"
+section = "§3 message flow and commit points"
+statement = """
+Cross-thread commands and worker results commit only while the realm's \
+scheduler phase is Idle — never inside the frame transaction.\
+"""
+state = "implemented"
+domain = "realm"
+mechanical = true
+mechanism = "drain_commands asserts/gates on SchedulerPhase::Idle; owner-thread commit pinned by test"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "SchedulerPhase::Idle" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn cross_thread_navigation_command_drains_on_owner_thread" },
+]
+
+[[requirement]]
+key = "reentrancy-fifo-ordered-dispatch"
+adr = "ADR-0027"
+section = "§3 reentrancy gate"
+statement = """
+A platform callback that re-enters while the realm is mid-transaction is \
+queued into a realm-local ordered FIFO and applied at the next permitted \
+anchor; the frame transaction is uninterruptible by construction.\
+"""
+state = "implemented"
+domain = "realm"
+mechanical = true
+mechanism = "test existence pinned here; behavior verified by the cited tests"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/runner.rs", contains = "draining: bool" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn reentrant_frame_event_is_queued_fifo" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn nested_resize_and_window_focus_wait_until_frame_returns" },
+]
+
+[[requirement]]
+key = "wake-contract-enqueue-then-wake"
+adr = "ADR-0027"
+section = "§3 wake contract / §4 coalesced invalidations"
+statement = """
+Enqueue-then-wake is one operation from the sender's perspective; redraw \
+requests coalesce to one flag and one wake; a realm never goes idle with a \
+dirty tree.\
+"""
+state = "implemented"
+domain = "realm"
+mechanical = true
+mechanism = "test existence pinned here"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn command_sender" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn every_send_wakes_the_owner" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn redraw_requests_coalesce_to_one_flag_and_one_wake" },
+]
+
+[[requirement]]
+key = "bounded-lanes-typed-backpressure"
+adr = "ADR-0027"
+section = "§4 queues by reliability class"
+statement = """
+No unbounded channels on runtime paths. The owner inbox is bounded; a full \
+lane returns a typed `ChannelFull` carrying the rejected command; a dropped \
+owner returns typed `OwnerGone`.\
+"""
+state = "implemented"
+domain = "realm"
+mechanical = true
+mechanism = "test existence pinned here"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "ChannelFull {" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn inbox_reports_backpressure_at_capacity" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn channel_full_retry_preserves_the_rejected_payload" },
+]
+
+[[requirement]]
+key = "raster-mailbox-protocol-threaded"
+adr = "ADR-0027"
+section = "§5 SceneSnapshot and the raster boundary"
+statement = """
+The raster seam is a capacity-one latest-frame-wins mailbox with identity-\
+stamped acks, stale-`SurfaceGeneration` rejection before render, a lossy \
+telemetry ack lane, and a dedicated one-shot shutdown handshake — exercised \
+by a threaded protocol harness so the protocol is not vacuously green under \
+the synchronous baseline.\
+"""
+state = "implemented"
+domain = "raster"
+mechanical = true
+mechanism = "threaded protocol tests pinned here"
+evidence = [
+    { kind = "symbol", file = "crates/flui-engine/src/raster_owner.rs", contains = "pub struct RasterOwner" },
+    { kind = "test", file = "crates/flui-engine/src/raster_owner.rs", contains = "fn latest_frame_wins_supersedes_pending" },
+    { kind = "test", file = "crates/flui-engine/src/raster_owner.rs", contains = "fn stale_surface_generation_is_rejected_before_render" },
+    { kind = "test", file = "crates/flui-engine/src/raster_owner.rs", contains = "fn shutdown_handshake_completes_and_thread_joins" },
+]
+
+[[requirement]]
+key = "raster-owner-in-shipping-path"
+adr = "ADR-0027"
+section = "§5 (shipping baseline behind the mailbox seam)"
+statement = """
+The shipping runners must drive frames through the raster-owner mailbox seam \
+with the raster owner as sole `Renderer` owner. Today the desktop/Android \
+runners call `Renderer::render_scene` directly and the web runner shares an \
+`Arc<Mutex<Option<Renderer>>>`; `RasterOwner` has zero production consumers.\
+"""
+state = "partial"
+domain = "raster"
+owner_issue = 559
+mechanical = false
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/runner.rs", contains = "Arc<Mutex<Option<Renderer>>>" },
+]
+
+[[requirement]]
+key = "freshness-by-work-class"
+adr = "ADR-0027"
+section = "§6 identity, versioning, cancellation"
+statement = """
+Commit-time freshness is per work class (`ResourceGeneration`/\
+`GenerationGate` for assets, `FrameEpoch` + `SurfaceGeneration` for raster, \
+channel identity for lifetime). The foundation primitives exist and are \
+tested; adoption across decode/worker paths has not started.\
+"""
+state = "partial"
+domain = "shared-engine"
+owner_issue = 557
+mechanical = false
+evidence = [
+    { kind = "symbol", file = "crates/flui-foundation/src/epoch.rs", contains = "pub struct ResourceGeneration" },
+]
+
+[[requirement]]
+key = "channel-identity-lifetime-boundary"
+adr = "ADR-0027"
+section = "§6 channel identity"
+statement = """
+A realm's channels are created with the realm and die with it; a recreated \
+realm mints a fresh generational `RealmId`, and senders into the dead realm \
+get `OwnerGone` at send.\
+"""
+state = "implemented"
+domain = "realm"
+mechanical = true
+mechanism = "test existence pinned here"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "static NEXT_INCARNATION" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn recreated_runtime_gets_fresh_realm_id" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn dropped_runtime_yields_owner_gone" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn late_event_never_crosses_realm_incarnations" },
+]
+
+[[requirement]]
+key = "shutdown-protocol-per-realm"
+adr = "ADR-0027"
+section = "§7 shutdown protocol"
+statement = """
+Per-realm teardown follows detach → refuse → cancel → mailbox close + \
+one-shot completion → renderer teardown → drop. The ADR itself records this \
+as the target protocol: desktop/Android detach their transitional host after \
+loop exit, web cannot detach at all, and full orchestration is unlanded.\
+"""
+state = "partial"
+domain = "application"
+owner_issue = 558
+mechanical = false
+evidence = [
+    { kind = "symbol", file = "crates/flui-engine/src/raster_owner.rs", contains = "fn shutdown" },
+]
+
+[[requirement]]
+key = "globalkey-realm-scoped"
+adr = "ADR-0027"
+section = "§8 focus, GlobalKey, multi-realm semantics"
+statement = """
+GlobalKey identity is realm-scoped through a realm-entry activation stack, \
+not a process-global active registry. Deliberate divergence from Flutter's \
+process-global registry, sanctioned by the leapfrog-zone governance.\
+"""
+state = "implemented"
+domain = "realm"
+mechanical = true
+mechanism = "test existence pinned here"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn realm_id" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn realm_entry_activates_its_global_key_registry" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn whole_frame_event_keeps_realm_global_key_scope_active" },
+]
+
+[[requirement]]
+key = "focus-coordination-per-realm"
+adr = "ADR-0027"
+section = "§8 FocusCoordinator"
+statement = """
+One `FocusTree` per presentation with realm-level active-presentation \
+arbitration. The per-presentation `FocusManager` is real (owned by \
+`PresentationState`); the multi-presentation `FocusCoordinator` arbitration \
+cannot exist before the element forest.\
+"""
+state = "partial"
+domain = "presentation"
+owner_issue = 555
+mechanical = false
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "fn focus_manager" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn presentation_and_widget_tree_share_the_exact_focus_owner" },
+]
+
+[[requirement]]
+key = "ui-types-lose-send-sync"
+adr = "ADR-0027"
+section = "§9 public API consequences (bound drop)"
+statement = """
+`View`, `BuildContext`, `ViewState`, and the owner-authored callback aliases \
+carry no `Send + Sync` bounds; the data plane keeps its bounds per the \
+ADR-0002 table.\
+"""
+state = "implemented"
+domain = "realm"
+mechanical = true
+mechanism = "exact trait-bound string pinned by source-gate; widening the bound changes the string"
+evidence = [
+    { kind = "symbol", file = "crates/flui-view/src/view/view.rs", contains = "pub trait View: Downcast + DynClone + 'static" },
+    { kind = "compile-time", file = "crates/flui-view/src/context/element_build_context.rs", contains = "assert_not_impl_any!(ElementBuildContext: Send, Sync)" },
+]
+
+[[requirement]]
+key = "no-public-generic-ui-executor"
+adr = "ADR-0027"
+section = "§9 closed command vocabulary"
+statement = """
+No public run-a-closure executor targets the owner thread; the cross-thread \
+surface is a closed command vocabulary. The former public \
+`ForegroundExecutor` stays deleted.\
+"""
+state = "implemented"
+domain = "platform"
+mechanical = true
+mechanism = "forbidden_pattern scan below keeps ForegroundExecutor out of crates/**/*.rs"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "enum UiCommand" },
+    { kind = "source-gate", file = "crates/flui-platform/src/lib.rs", contains = "pub use executor::BackgroundExecutor" },
+]
+
+[[requirement]]
+key = "transitional-realm-types-not-public"
+adr = "ADR-0027"
+section = "§9 current stability posture"
+statement = """
+The transitional `UiRealm`, its dispatcher, command sender, and \
+command/error protocol are `pub(crate)` implementation details of \
+`flui-app`, not an embedder API. A future public realm capability surface is \
+designed after ownership extraction, not by publishing these types.\
+"""
+state = "implemented"
+domain = "application"
+mechanical = true
+mechanism = "source-gate pins the pub(crate) module declarations"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/mod.rs", contains = "pub(crate) mod ui_realm" },
+    { kind = "source-gate", file = "crates/flui-app/src/app/mod.rs", contains = "pub(crate) mod presentation" },
+]
+
+[[requirement]]
+key = "parallel-layout-gated"
+adr = "ADR-0027"
+section = "§10 absorbed G1–G4 gates"
+statement = """
+Parallel layout (repaint-boundary subtrees) stays gated behind G1–G4 with a \
+deterministic serial oracle; no parallelization of the control plane, \
+element/build tree, or display list.\
+"""
+state = "planned"
+domain = "realm"
+owner_issue = 562
+mechanical = false
+
+# =============================================================================
+# ADR-0037 — Presentation ownership domains
+# =============================================================================
+
+[[requirement]]
+key = "three-owner-presentation-shape"
+adr = "ADR-0037"
+section = "§1 one logical presentation, three physical owners"
+statement = """
+A presentation is coordinated by exactly three physical owners — event-loop \
+`WindowHost`, realm-owned `PresentationState`, engine `RasterOwner` — with no \
+fourth mediation object. `PresentationState` exists (crate-private, owner-\
+local); `WindowHost` does not exist as an owner (the runner's TLS host and \
+per-window callbacks stand in), and `RasterOwner` is not in the shipping \
+composition.\
+"""
+state = "partial"
+domain = "application"
+owner_issue = 553
+mechanical = false
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "pub(crate) struct PresentationState" },
+]
+
+[[requirement]]
+key = "presentation-identity-generational"
+adr = "ADR-0037"
+section = "§2 presentation identity"
+statement = """
+Generational `PresentationId` exists and `AppRuntime` is the only \
+`WindowId → (RealmId, PresentationId)` authority. The ID type is real and \
+stamped on `PresentationState`; the single-authority window map does not \
+exist and `SceneSnapshot` still lacks a `PresentationId` field.\
+"""
+state = "partial"
+domain = "application"
+owner_issue = 552
+mechanical = false
+evidence = [
+    { kind = "symbol", file = "crates/flui-foundation/src/id.rs", contains = "pub struct PresentationId" },
+]
+
+[[requirement]]
+key = "closed-cross-thread-vocabulary"
+adr = "ADR-0037"
+section = "§3 cross-thread traffic"
+statement = """
+Cross-lane traffic is closed, presentation-addressed enums — never `dyn \
+Any`, opaque windows, or `Box<dyn FnOnce()>` payloads. The realm inbox \
+(`UiCommand`) is a closed vocabulary today; the full \
+`PlatformToUi`/`UiToPlatform`/`UiToRaster`/`RasterToUi` families with \
+presentation addressing do not exist yet.\
+"""
+state = "partial"
+domain = "platform"
+owner_issue = 552
+mechanical = false
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "enum UiCommand" },
+]
+
+[[requirement]]
+key = "presentation-state-owner-nucleus"
+adr = "ADR-0037"
+section = "§4 PresentationState"
+statement = """
+`PresentationState` is private to `flui-app`, stored inside `UiRealm`, \
+structurally `!Send + !Sync`, owning one presentation's pipeline, focus, \
+gestures, mouse tracking, text-input session, and semantics dispatch. \
+Missing from the ADR's field list: frame clock/pacing state, redraw \
+coalescing, element-forest root entry, and cached raster acks.\
+"""
+state = "partial"
+domain = "presentation"
+owner_issue = 553
+mechanical = true
+mechanism = "compile-time assert pinned here"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "pub(crate) struct PresentationState" },
+    { kind = "compile-time", file = "crates/flui-app/src/app/presentation.rs", contains = "assert_not_impl_any!(PresentationState: Send, Sync)" },
+]
+
+[[requirement]]
+key = "text-input-direct-ownership"
+adr = "ADR-0037"
+section = "§5 text input"
+statement = """
+Text input is a presentation-owned `TextInputOwner` with a weak-capability \
+`TextInputHandle`; one active client per presentation, token-checked detach, \
+typed `OwnerGone`/`Closed`. The `ImeBackend`/`TextInputPlatformBridge`/\
+`OpaqueWindowHandle`/global-registry/downcast path is deleted and stays \
+deleted.\
+"""
+state = "implemented"
+domain = "presentation"
+mechanical = true
+mechanism = "forbidden_pattern scan keeps the deleted intermediaries out of crates/**/*.rs"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "text_input: Rc<TextInputOwner>" },
+    { kind = "test", file = "crates/flui-app/src/app/presentation.rs", contains = "fn text_input_handle_is_bound_to_the_owned_text_input_state" },
+]
+
+[[requirement]]
+key = "input-domain-per-presentation"
+adr = "ADR-0037"
+section = "§6 focus, gestures, mouse, keyboard"
+statement = """
+Each presentation owns one complete input domain (gesture arena, mouse \
+tracker, focus tree, cursor to the exact window; a closed window drops the \
+update). Implemented for the single presentation that can exist today; the \
+cross-presentation isolation clauses are untestable until the element forest \
+allows a second presentation.\
+"""
+state = "partial"
+domain = "presentation"
+owner_issue = 555
+mechanical = false
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "gestures: GestureBinding" },
+    { kind = "test", file = "crates/flui-app/src/app/presentation.rs", contains = "fn mouse_tracker_applies_cursor_to_the_exact_owned_window" },
+]
+
+[[requirement]]
+key = "semantics-two-phase-borrow"
+adr = "ADR-0037"
+section = "§7 semantics command routing"
+statement = """
+Accessibility actions are closed, identity-stamped commands resolved through \
+the presentation's exact pipeline owner in two borrow phases — no action \
+invocation runs while the render tree is borrowed; stale identities are \
+rejected and traced.\
+"""
+state = "implemented"
+domain = "presentation"
+mechanical = true
+mechanism = "test existence pinned here"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "fn dispatch_semantics_action" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn semantics_action_commits_on_the_owner_after_releasing_the_pipeline_lock" },
+    { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn stale_semantics_action_is_gracefully_dropped" },
+]
+
+[[requirement]]
+key = "surface-generation-single-authority"
+adr = "ADR-0037"
+section = "§8 RasterOwner mints SurfaceGeneration"
+statement = """
+Only `RasterOwner` mints `SurfaceGeneration`, in the ordered command stream \
+that reconfigures the surface; stale frames are rejected before render. True \
+at protocol level in `flui-engine` (with threaded tests); not true of the \
+shipping path, which bypasses the raster owner entirely.\
+"""
+state = "partial"
+domain = "raster"
+owner_issue = 559
+mechanical = false
+evidence = [
+    { kind = "test", file = "crates/flui-engine/src/raster_owner.rs", contains = "fn resize_coalesces_latest_wins" },
+]
+
+[[requirement]]
+key = "presentation-lifecycle-monotonic"
+adr = "ADR-0037"
+section = "§9 lifecycle"
+statement = """
+Each presentation has the explicit Created → SurfaceAttached → Suspended → \
+Closing → Closed lifecycle with typed transitions and idempotent close. \
+Gap: resume claims `SurfaceAttached` without awaiting a raster surface ack, \
+because the shipping path has no raster acks to await.\
+"""
+state = "partial"
+domain = "presentation"
+owner_issue = 552
+mechanical = false
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "enum PresentationLifecycle" },
+    { kind = "test", file = "crates/flui-app/src/app/presentation.rs", contains = "fn lifecycle_transitions_are_typed_and_close_is_idempotent" },
+]
+
+[[requirement]]
+key = "cancellable-platform-callbacks"
+adr = "ADR-0037"
+section = "§10 platform callback lifetime"
+statement = """
+Install-only callbacks are forbidden: delivery is event-loop-owned or \
+registration returns a cancellation token owned by `WindowHost`. Today \
+`PlatformHandlers` stores process-lifetime `Mutex<Option<Box<dyn FnMut>>>` \
+handlers with no cancellation ownership.\
+"""
+state = "partial"
+domain = "platform"
+owner_issue = 551
+mechanical = false
+evidence = [
+    { kind = "symbol", file = "crates/flui-platform/src/shared/handlers.rs", contains = "pub on_input: Mutex<Option<Box<dyn FnMut(PlatformInput)" },
+]
+
+[[requirement]]
+key = "multi-presentation-forest-gate"
+adr = "ADR-0037"
+section = "§11 one realm / N presentations gate"
+statement = """
+One-realm/multi-presentation support is gated on a verified element forest; \
+until then a realm holds at most one live `PresentationState`. The gate \
+holds structurally today — `UiRealm` stores exactly one `PresentationState` \
+by value, so a second attachment is unrepresentable. The forest itself is \
+future work.\
+"""
+state = "partial"
+domain = "realm"
+owner_issue = 555
+mechanical = true
+mechanism = "single-field storage pinned by symbol check; a second slot or Vec would change the string"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "presentation: PresentationState" },
+]
+
+[[requirement]]
+key = "no-flui-presentation-crate"
+adr = "ADR-0037"
+section = "§12 no new crate"
+statement = """
+A `flui-presentation` crate is rejected; `flui-app` privately composes the \
+three owners. Extraction needs its own ADR with two production consumers.\
+"""
+state = "implemented"
+domain = "application"
+mechanical = true
+mechanism = "forbidden_path check below; ADR-0041 topology contract also gates new crates"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "pub(crate) struct PresentationState" },
+    { kind = "source-gate", file = "docs/workspace-layers.toml", contains = "flui-app" },
+]
+
+# =============================================================================
+# ADR-0029 — Frame pacing
+# =============================================================================
+
+[[requirement]]
+key = "fifo-default-present-mode"
+adr = "ADR-0029"
+section = "Decision 1 (select_present_mode)"
+statement = """
+`select_present_mode` defaults to Fifo; the blocking `present()` under Fifo \
+is the steady-state pacing mechanism. Mailbox is a documented future opt-in, \
+unreachable from `flui-app`. No unit test pins the selection — the evidence \
+is the source plus the measured-cadence record in the ADR.\
+"""
+state = "implemented"
+domain = "raster"
+mechanical = true
+mechanism = "source-gate pins the Fifo selection expectation string"
+evidence = [
+    { kind = "symbol", file = "crates/flui-engine/src/wgpu/renderer.rs", contains = "fn select_present_mode" },
+    { kind = "source-gate", file = "crates/flui-engine/src/wgpu/renderer.rs", contains = "BUG: wgpu guarantees Fifo is always a supported present mode" },
+]
+
+[[requirement]]
+key = "control-flow-wait-pinned"
+adr = "ADR-0029"
+section = "Decision 2 (ControlFlow::Wait)"
+statement = """
+`WinitApp::about_to_wait` sets `ControlFlow::Wait` explicitly every \
+iteration as a defensive pin against a future winit default change. No \
+executing test covers this (flui-platform tests are excluded from CI); the \
+pin is source-level only.\
+"""
+state = "implemented"
+domain = "platform"
+mechanical = true
+mechanism = "source-gate pins the set_control_flow call"
+evidence = [
+    { kind = "symbol", file = "crates/flui-platform/src/platforms/winit/platform.rs", contains = "set_control_flow(winit::event_loop::ControlFlow::Wait)" },
+    { kind = "source-gate", file = "crates/flui-platform/src/platforms/winit/platform.rs", contains = "set_control_flow(winit::event_loop::ControlFlow::Wait)" },
+]
+
+[[requirement]]
+key = "no-present-fallback-throttle"
+adr = "ADR-0029"
+section = "Decision 3 (fallback throttle)"
+statement = """
+The fixed frame-budget sleep is deleted; a coarse fallback throttle applies \
+only when a frame did not present AND a ticker keeps the gate open. The \
+decision functions are pure and unit-tested because `run_desktop` cannot run \
+headlessly.\
+"""
+state = "implemented"
+domain = "application"
+mechanical = true
+mechanism = "decision-function tests pinned here"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/runner.rs", contains = "fn no_present_fallback_pace" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn no_present_fallback_bounds_repeating_no_present_wakes" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn no_present_fallback_pace_requires_both_no_present_and_an_open_gate" },
+]
+
+[[requirement]]
+key = "idle-renders-zero-frames"
+adr = "ADR-0029"
+section = "Evidence (idle invariant)"
+statement = """
+A wake with frames enabled, nothing dirty, and no scheduled ticker renders \
+zero frames; the redraw gate closes when a controller settles.\
+"""
+state = "implemented"
+domain = "application"
+mechanical = true
+mechanism = "gate tests pinned here"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/runner.rs", contains = "fn keeps_frame_gate_open" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn idle_wake_with_no_dirty_work_and_no_scheduled_frame_skips" },
+    { kind = "test", file = "crates/flui-app/src/app/binding.rs", contains = "fn vsync_continuation_keeps_gate_open_while_running_and_closes_on_settle" },
+]
+
+[[requirement]]
+key = "target-fps-advisory-documented"
+adr = "ADR-0029"
+section = "Decision 4 (target_fps audit)"
+statement = """
+`AppConfig::target_fps` is documented as advisory with a full consumer \
+audit, and `AppConfig::vsync` is documented as not controlling the present \
+mode. Neither field governs the pacing model; the config_field gate below \
+prevents either from being classified as working stable configuration.\
+"""
+state = "implemented"
+domain = "application"
+mechanical = true
+mechanism = "config_field entries below; the checker hard-requires vsync/target_fps to be registered as not-stable"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/config.rs", contains = "Advisory target frame rate (FPS)" },
+    { kind = "source-gate", file = "crates/flui-app/src/app/runner.rs", contains = "target_fps_advisory" },
+]
+
+[[requirement]]
+key = "appconfig-effective-or-removed"
+adr = "ADR-0029"
+section = "Decision 4 + execution-plan frame-clock item"
+statement = """
+Every misleading `AppConfig` field is wired end to end or removed; public \
+configuration is fully effective and tested. `vsync`, `fullscreen`, and \
+`debug_paint` are unwired; `target_fps` is advisory; \
+`show_performance_overlay` ignores its option mask.\
+"""
+state = "planned"
+domain = "application"
+owner_issue = 556
+mechanical = true
+mechanism = "config_field entries below pin each field's non-stable classification"
+
+[[requirement]]
+key = "timer-service-for-frozen-tickers"
+adr = "ADR-0029"
+section = "Occlusion semantics"
+statement = """
+Time-based UX (timeout-shaped animations) must not silently freeze with the \
+frame gate; a wall-clock timer service independent of the frame tick is the \
+named correctness seam. Explicitly not solved by ADR-0029.\
+"""
+state = "planned"
+domain = "application"
+owner_issue = 556
+mechanical = false
+
+# =============================================================================
+# ADR-0039 — Event-loop affinity capability (Proposed)
+# =============================================================================
+
+[[requirement]]
+key = "adr-0039-stays-proposed-until-validated"
+adr = "ADR-0039"
+section = "Status"
+statement = """
+ADR-0039 remains Proposed; its acceptance and implementation (trait split, \
+capability, proxy) belong to the owning issue. The checker fails if the \
+ADR's status line changes without going through that issue.\
+"""
+state = "planned"
+domain = "platform"
+owner_issue = 551
+mechanical = true
+mechanism = "the checker asserts the ADR file still carries the Proposed status line"
+
+[[requirement]]
+key = "owner-affinity-runtime-backstop"
+adr = "ADR-0039"
+section = "Slice 1"
+statement = """
+`OwnerAffinity` (bind-once owner thread, debug-assert on owner-affine \
+entry points) lives in `flui-foundation` with CI-run unit tests; macOS and \
+Windows backends assert on `open_window`/`quit`/`active_window` (+ displays \
+on macOS). Honest scope: the backend wiring is verified by cross-typecheck \
+only — no CI job executes flui-platform tests.\
+"""
+state = "implemented"
+domain = "platform"
+mechanical = true
+mechanism = "foundation unit tests pinned here; backend wiring pinned by symbol checks only"
+evidence = [
+    { kind = "symbol", file = "crates/flui-foundation/src/affinity.rs", contains = "pub struct OwnerAffinity" },
+    { kind = "test", file = "crates/flui-foundation/src/affinity.rs", contains = "fn bind_records_the_calling_thread_and_assert_passes_on_it" },
+    { kind = "symbol", file = "crates/flui-platform/src/platforms/macos/platform.rs", contains = "debug_assert_owner(\"MacOSPlatform::open_window\")" },
+    { kind = "symbol", file = "crates/flui-platform/src/platforms/windows/platform.rs", contains = "debug_assert_owner(\"WindowsPlatform::quit\")" },
+]
+
+[[requirement]]
+key = "owner-platform-capability"
+adr = "ADR-0039"
+section = "§1–§2 (slices 2–3)"
+statement = """
+Owner-thread-only platform operations move off the `Send + Sync` `Platform` \
+trait onto a `!Send + !Sync` `OwnerPlatform` capability handed to \
+`on_ready`; post-bootstrap owner-thread window creation is deferred through \
+the owner lane, never direct. Nothing of slices 2–3 exists in the tree.\
+"""
+state = "planned"
+domain = "platform"
+owner_issue = 551
+mechanical = false
+
+[[requirement]]
+key = "platform-proxy-claim-slot"
+adr = "ADR-0039"
+section = "§3–§4 (PlatformProxy, PendingWindow, DrainGate)"
+statement = """
+Workers reach the owner through a typed, bounded `PlatformProxy` with \
+claim-slot at-most-once replies and per-backend drain-anchor gates. The \
+winit-internal `ControlSender` lane exists (bounded, typed \
+`Full`/`OwnerGone`, wake, admission gate) but is backend-private and keeps \
+the weaker buffered one-shot reply.\
+"""
+state = "partial"
+domain = "platform"
+owner_issue = 551
+mechanical = false
+evidence = [
+    { kind = "symbol", file = "crates/flui-platform/src/platforms/winit/control.rs", contains = "enum ControlSendError" },
+]
+
+[[requirement]]
+key = "clipboard-stays-thread-safe"
+adr = "ADR-0039"
+section = "§5 clipboard position"
+statement = """
+`Clipboard` keeps `Send + Sync` and gets no owner-affinity asserts anywhere \
+— plain-text pasteboard operations are documented off-main-safe, and \
+asserting them would panic legitimate ADR-0034 callers. Supersedes \
+ADR-0034's suggested `MacOSClipboard` debug-assert.\
+"""
+state = "implemented"
+domain = "platform"
+mechanical = true
+mechanism = "forbidden_pattern below keeps affinity asserts out of the macOS clipboard implementation"
+evidence = [
+    { kind = "symbol", file = "crates/flui-platform/src/traits/platform.rs", contains = "pub trait Platform: Send + Sync + 'static" },
+    { kind = "source-gate", file = "crates/flui-platform/src/platforms/macos/clipboard.rs", contains = "Clipboard" },
+]
+
+[[requirement]]
+key = "pre-run-flows-migrate-to-on-ready"
+adr = "ADR-0039"
+section = "Slice 2 (pre-run bootstrap migrations)"
+statement = """
+Window creation before `Platform::run` (run_direct, Android bootstrap, web \
+bootstrap, Win32 examples) migrates inside `on_ready`, where every backend \
+guarantees synchronous owner-thread creation. `run_direct` remains broken on \
+the winit backend until this lands and is marked experimental for exactly \
+this reason.\
+"""
+state = "planned"
+domain = "platform"
+owner_issue = 551
+mechanical = true
+mechanism = "the checker pins run_direct's experimental marking and classification"
+
+# =============================================================================
+# Public runtime surface classification
+# =============================================================================
+#
+# `declared_in` + `contains` are existence pins: if the cited declaration
+# moves or is deleted, this gate fails until the registry is updated — a
+# surface cannot silently disappear from (or be renamed out of) the
+# inventory. Classification semantics are documented at the top of the file.
+
+[[surface]]
+path = "flui_app::run_app"
+crate = "flui-app"
+kind = "function"
+declared_in = "crates/flui-app/src/app/runner.rs"
+contains = "pub fn run_app_impl"
+classification = "stable-candidate"
+thread_affinity = "call on the process main thread; blocks until the event loop exits (never returns on macOS)"
+owner = "application composition root (runner)"
+failure_semantics = "returns unit; bootstrap failures are logged and the loop exits — no Result surface today"
+consumers = ["flui facade re-export", "examples"]
+
+[[surface]]
+path = "flui_app::run_app_with_config"
+crate = "flui-app"
+kind = "function"
+declared_in = "crates/flui-app/src/app/runner.rs"
+contains = "pub fn run_app_with_config_impl"
+classification = "stable-candidate"
+thread_affinity = "call on the process main thread; blocks until the event loop exits"
+owner = "application composition root (runner)"
+failure_semantics = "returns unit; bootstrap failures are logged and the loop exits — no Result surface today"
+consumers = ["flui facade re-export", "examples"]
+
+[[surface]]
+path = "flui_app::run_direct"
+crate = "flui-app"
+kind = "function"
+declared_in = "crates/flui-app/src/app/direct.rs"
+contains = "pub fn run_direct"
+classification = "experimental"
+thread_affinity = "process main thread; opens the window before run(), so it fails fast on the winit backend"
+owner = "application composition root (direct-engine escape hatch)"
+failure_semantics = "anyhow::Result; typed fast-fail before any window opens on winit (Linux)"
+consumers = ["examples/direct_render.rs", "examples/aa_showcase.rs"]
+owner_issue = 551
+notes = "Event-loop repair (on_ready reorder) is ADR-0039 slice 2. The checker pins the experimental marking."
+
+[[surface]]
+path = "flui_app::run_app_android / run_app_android_with_config"
+crate = "flui-app"
+kind = "function"
+declared_in = "crates/flui-app/src/app/runner.rs"
+contains = "pub fn run_app_android"
+classification = "experimental"
+thread_affinity = "android_main thread; pre-run bootstrap creates the window/GPU before the loop, contra ADR-0039 slice 2"
+owner = "application composition root (Android runner)"
+failure_semantics = "returns unit; bootstrap failures are logged"
+consumers = ["examples/android_demo (via its own bootstrap)"]
+owner_issue = 551
+
+[[surface]]
+path = "flui_app::AppBinding"
+crate = "flui-app"
+kind = "type"
+declared_in = "crates/flui-app/src/app/binding.rs"
+contains = "pub struct AppBinding"
+classification = "transitional"
+thread_affinity = "owner-thread only; thread-local instance(); structurally !Send + !Sync via PhantomData marker"
+owner = "transitional process-service host — dissolves into AppRuntime + realm construction"
+failure_semantics = "instance() lazily constructs per thread; wrong-thread use creates a second windowless binding rather than erroring"
+consumers = ["runner", "hot reload", "flui facade via app module"]
+owner_issue = 553
+
+[[surface]]
+path = "flui_app::WidgetsFlutterBinding"
+crate = "flui-app"
+kind = "type-alias"
+declared_in = "crates/flui-app/src/app/mod.rs"
+contains = "pub type WidgetsFlutterBinding = AppBinding"
+classification = "removal-target"
+thread_affinity = "same as AppBinding"
+owner = "legacy alias for the transitional host"
+failure_semantics = "same as AppBinding"
+consumers = ["prelude re-export only"]
+owner_issue = 553
+
+[[surface]]
+path = "flui_app::AppConfig"
+crate = "flui-app"
+kind = "type"
+declared_in = "crates/flui-app/src/app/config.rs"
+contains = "pub struct AppConfig"
+classification = "transitional"
+thread_affinity = "plain data; Send + Sync"
+owner = "application configuration"
+failure_semantics = "infallible builder; several fields are unwired or advisory (see [[config_field]])"
+consumers = ["run_app_with_config", "run_direct", "examples"]
+owner_issue = 556
+notes = "The type survives; its field set must become fully effective or shrink (ADR-0029 decision 4)."
+
+[[surface]]
+path = "flui_app::bindings re-export bundle (Scheduler, PipelineOwner, GestureBinding, WidgetsBinding, SemanticsBinding, PaintingBinding, RenderingFlutterBinding)"
+crate = "flui-app"
+kind = "re-export"
+declared_in = "crates/flui-app/src/bindings/mod.rs"
+contains = "pub use flui_rendering::{binding::RendererBinding, pipeline::PipelineOwner}"
+classification = "transitional"
+thread_affinity = "mixed; the singleton graph is owner-thread-local via HasInstance"
+owner = "transitional singleton service graph"
+failure_semantics = "singleton accessors construct lazily per thread; no typed errors"
+consumers = ["flui-app prelude", "flui facade via app module"]
+owner_issue = 553
+
+[[surface]]
+path = "flui_app::embedder"
+crate = "flui-app"
+kind = "module"
+declared_in = "crates/flui-app/src/lib.rs"
+contains = "pub mod embedder"
+classification = "experimental"
+thread_affinity = "embedder-driven; window-handle + GPU-surface adapters"
+owner = "platform embedder adapters"
+failure_semantics = "per-adapter Results"
+consumers = ["external embedders (none in-tree)"]
+owner_issue = 560
+
+[[surface]]
+path = "flui_platform::Platform (trait)"
+crate = "flui-platform"
+kind = "trait"
+declared_in = "crates/flui-platform/src/traits/platform.rs"
+contains = "pub trait Platform: Send + Sync + 'static"
+classification = "transitional"
+thread_affinity = "declared Send + Sync, but open_window/quit/activate/displays/window_appearance are owner-thread-only on real OSes — the ADR-0039 defect"
+owner = "platform backend (one per process; consumed by run())"
+failure_semantics = "anyhow surface; owner-affinity violations are debug_assert-only (slice 1 backstop)"
+consumers = ["runner bootstrap", "run_direct", "examples"]
+owner_issue = 551
+
+[[surface]]
+path = "flui_platform::PlatformReadyCallback"
+crate = "flui-platform"
+kind = "type-alias"
+declared_in = "crates/flui-platform/src/traits/platform.rs"
+contains = "pub type PlatformReadyCallback"
+classification = "transitional"
+thread_affinity = "invoked on the event-loop owner thread by every backend"
+owner = "backend run() contract"
+failure_semantics = "infallible callback"
+consumers = ["all six backends", "runner"]
+owner_issue = 551
+notes = "ADR-0039 slice 2 flips this signature to carry OwnerPlatform by value — a breaking change across all backends."
+
+[[surface]]
+path = "flui_platform::current_platform"
+crate = "flui-platform"
+kind = "function"
+declared_in = "crates/flui-platform/src/lib.rs"
+contains = "pub fn current_platform"
+classification = "transitional"
+thread_affinity = "callable anywhere; the returned Box<dyn Platform> carries the trait's misdeclared affinity"
+owner = "platform selection"
+failure_semantics = "anyhow::Result"
+consumers = ["runner", "run_direct", "examples"]
+owner_issue = 551
+
+[[surface]]
+path = "flui_platform backend types (WinitPlatform, WindowsPlatform, MacOSPlatform, HeadlessPlatform, WebPlatform, AndroidPlatform, ...)"
+crate = "flui-platform"
+kind = "type"
+declared_in = "crates/flui-platform/src/lib.rs"
+contains = "pub use platforms::{FakeHaptics, FakeTextInput, HeadlessPlatform}"
+classification = "transitional"
+thread_affinity = "construct and run on the thread that owns (or will own) the event loop; MacOSPlatform carries unsafe impl Send/Sync by AppKit convention"
+owner = "per-OS event-loop backends"
+failure_semantics = "per-backend anyhow/typed mixes; winit returns typed OpenWindowStateError including OwnerWouldBlock"
+consumers = ["current_platform", "native examples"]
+owner_issue = 551
+
+[[surface]]
+path = "flui_platform::{BackgroundExecutor, PlatformExecutor}"
+crate = "flui-platform"
+kind = "type"
+declared_in = "crates/flui-platform/src/lib.rs"
+contains = "pub use executor::BackgroundExecutor"
+classification = "removal-target"
+thread_affinity = "Send + Sync thread-pool handles"
+owner = "per-platform executor construction — moves to host-injected runtime execution"
+failure_semantics = "spawn-shaped; no admission control or cancellation contract"
+consumers = ["flui-assets decode path", "prompt marshaling (Windows)"]
+owner_issue = 557
+notes = "workspace-layers.toml disposition 'narrow' for flui-platform names exactly this loss."
+
+[[surface]]
+path = "flui_platform::Task"
+crate = "flui-platform"
+kind = "type"
+declared_in = "crates/flui-platform/src/task.rs"
+contains = "pub struct Task<T>"
+classification = "removal-target"
+thread_affinity = "Send future wrapper"
+owner = "flagged parallel async definition; TaskToken (flui-scheduler) is the framework's one async mechanism"
+failure_semantics = "drop does not cancel — the defect ADR-0039 §2 refuses to entrench"
+consumers = ["prompt_for_paths (Windows)"]
+owner_issue = 557
+
+[[surface]]
+path = "flui_platform::{PlatformWindow, WindowOptions, WindowId}"
+crate = "flui-platform"
+kind = "trait"
+declared_in = "crates/flui-platform/src/traits/platform.rs"
+contains = "pub struct WindowId"
+classification = "transitional"
+thread_affinity = "PlatformWindow: Send + Sync; per-window callbacks deliver on the owner thread"
+owner = "platform-internal native window key and handle — WindowId must never become realm-facing identity"
+failure_semantics = "callback installation is install-only today (no cancellation ownership)"
+consumers = ["runner", "presentation state (weak)", "examples"]
+owner_issue = 552
+
+[[surface]]
+path = "flui_platform::{WindowCallbacks, PlatformHandlers}"
+crate = "flui-platform"
+kind = "type"
+declared_in = "crates/flui-platform/src/lib.rs"
+contains = "pub use shared::{PlatformHandlers, WindowCallbacks}"
+classification = "transitional"
+thread_affinity = "callback storage behind mutexes; delivery on the owner thread"
+owner = "per-window / per-platform callback registries"
+failure_semantics = "install-only registration; ADR-0037 §10 requires cancellable registrations"
+consumers = ["all backends", "runner"]
+owner_issue = 551
+
+[[surface]]
+path = "flui_foundation::OwnerAffinity"
+crate = "flui-foundation"
+kind = "type"
+declared_in = "crates/flui-foundation/src/affinity.rs"
+contains = "pub struct OwnerAffinity"
+classification = "experimental"
+thread_affinity = "Send + Sync value; binds one owner ThreadId once, debug-asserts elsewhere"
+owner = "ADR-0039 slice-1 runtime backstop — scaffolding under the future capability type, not the end state"
+failure_semantics = "debug_assert on violation; release builds are unchecked"
+consumers = ["MacOSPlatform", "WindowsPlatform"]
+owner_issue = 551
+
+[[surface]]
+path = "flui_scheduler::Scheduler"
+crate = "flui-scheduler"
+kind = "type"
+declared_in = "crates/flui-scheduler/src/scheduler.rs"
+contains = "pub struct Scheduler"
+classification = "transitional"
+thread_affinity = "thread-local HasInstance singleton; cross-thread wake via Send + Sync callbacks"
+owner = "process-global (per-thread) scheduling authority — splits into realm UpdateScheduler + presentation FrameClock"
+failure_semantics = "singleton accessor constructs lazily; phase machine asserts on misuse"
+consumers = ["AppBinding", "UiRealm", "flui-animation tickers", "flui-view"]
+owner_issue = 556
+
+[[surface]]
+path = "flui_scheduler::Scheduler::budget (MutexGuard accessor)"
+crate = "flui-scheduler"
+kind = "function"
+declared_in = "crates/flui-scheduler/src/scheduler.rs"
+contains = "pub fn budget(&self) -> parking_lot::MutexGuard<'_, FrameBudget>"
+classification = "removal-target"
+thread_affinity = "returns a live lock guard to the caller"
+owner = "SP-6-exempted lock-shaped accessor (PORT-CHECK-OK-SP6)"
+failure_semantics = "caller holds the scheduler's budget lock; re-entrancy is the caller's problem"
+consumers = ["stats/diagnostics call sites"]
+owner_issue = 556
+
+[[surface]]
+path = "flui_scheduler::{VsyncScheduler, VsyncMode, VsyncStats, VsyncCallback}"
+crate = "flui-scheduler"
+kind = "type"
+declared_in = "crates/flui-scheduler/src/vsync.rs"
+contains = "pub struct VsyncScheduler"
+classification = "removal-target"
+thread_affinity = "Send + Sync"
+owner = "fixed-rate vsync simulator — not display-derived pacing, and no production runner wires it"
+failure_semantics = "typed construction error on zero refresh rate"
+consumers = ["none in production (tests and re-exports only)"]
+owner_issue = 556
+notes = "ADR-0029 moved real pacing to the blocking Fifo present; a fixed-rate simulator on the public surface misleads."
+
+[[surface]]
+path = "flui_scheduler::{FrameBudget, SharedBudget, BudgetPolicy}"
+crate = "flui-scheduler"
+kind = "type"
+declared_in = "crates/flui-scheduler/src/budget.rs"
+contains = "pub struct FrameBudget"
+classification = "transitional"
+thread_affinity = "plain data behind the scheduler's mutex"
+owner = "60-FPS-default frame budget — the global default contract ADR-0027's split retires"
+failure_semantics = "infallible; budget overruns are advisory statistics"
+consumers = ["Scheduler", "diagnostics"]
+owner_issue = 556
+
+[[surface]]
+path = "flui_scheduler::{Ticker, TickerProvider, TickerGroup}"
+crate = "flui-scheduler"
+kind = "type"
+declared_in = "crates/flui-scheduler/src/ticker.rs"
+contains = "pub struct Ticker"
+classification = "transitional"
+thread_affinity = "registered against the thread-local Scheduler singleton; flui-animation holds a scoped Send + Sync exception"
+owner = "animation tick registration — re-homes to the realm's UpdateScheduler"
+failure_semantics = "TickerCanceled futures on cancellation"
+consumers = ["flui-animation controllers", "flui-widgets implicit animations"]
+owner_issue = 556
+
+[[surface]]
+path = "flui_scheduler::{PostFrameHandle, LocalPostFrameLane}"
+crate = "flui-scheduler"
+kind = "type"
+declared_in = "crates/flui-scheduler/src/post_frame.rs"
+contains = "pub struct PostFrameHandle"
+classification = "transitional"
+thread_affinity = "handle is Clone + Send + Sync; local lane is owner-affine; schedule_local accepts non-Send captures only in the active owner scope"
+owner = "post-frame callback lanes (ADR-0021 / ADR-0027 step 2a); the weak TLS ticket registry retires when the Scheduler becomes realm-owned"
+failure_semantics = "typed LocalPostFrameScheduleError outside the owner scope"
+consumers = ["flui-view", "flui-widgets", "UiRealm"]
+owner_issue = 556
+
+[[surface]]
+path = "flui_foundation::{HasInstance, BindingBase} (+ flui_scheduler re-export)"
+crate = "flui-foundation"
+kind = "trait"
+declared_in = "crates/flui-foundation/src/binding.rs"
+contains = "pub trait HasInstance: BindingBase"
+classification = "removal-target"
+thread_affinity = "thread-local singleton storage per implementor"
+owner = "the ambient singleton pattern itself — deleted from runtime paths under the owning issue"
+failure_semantics = "lazily constructs a per-thread instance; cannot fail, which is the problem"
+consumers = [
+    "Scheduler",
+    "RenderingFlutterBinding",
+    "PaintingBinding",
+    "SemanticsBinding",
+    "AppBinding (manual)",
+]
+owner_issue = 553
+
+[[surface]]
+path = "flui_engine::wgpu::Renderer"
+crate = "flui-engine"
+kind = "type"
+declared_in = "crates/flui-engine/src/wgpu/renderer.rs"
+contains = "pub struct Renderer"
+classification = "transitional"
+thread_affinity = "Send + !Sync (unsafe impl Send, no Sync) — movable to a raster owner, single mutator by convention"
+owner = "GPU surface/device/queue owner; moves behind the raster-owner lane"
+failure_semantics = "typed EngineError with Recoverability; device loss recovered via recover()"
+consumers = ["runner frame callbacks", "run_direct", "HeadlessRenderer path"]
+owner_issue = 559
+
+[[surface]]
+path = "flui_engine::{RasterOwner, RasterHandle, RasterAck, FrameDropReason, RasterSubmitError, PumpOutcome}"
+crate = "flui-engine"
+kind = "type"
+declared_in = "crates/flui-engine/src/raster_owner.rs"
+contains = "pub struct RasterHandle"
+classification = "experimental"
+thread_affinity = "RasterHandle is Send + Sync; RasterOwner is the single-threaded owner end"
+owner = "the ADR-0027 §5 mailbox protocol — implemented and threaded-tested, but with zero production consumers until the raster lane lands"
+failure_semantics = "typed RasterSubmitError {MailboxClosed, ...}; acks carry frame identity; shutdown is a one-shot handshake"
+consumers = ["threaded protocol tests only"]
+owner_issue = 559
+
+[[surface]]
+path = "flui_layer::{SceneSnapshot, DamageRegion}"
+crate = "flui-layer"
+kind = "type"
+declared_in = "crates/flui-layer/src/scene_snapshot.rs"
+contains = "pub struct SceneSnapshot"
+classification = "experimental"
+thread_affinity = "Send; moves by value into the raster mailbox"
+owner = "per-presentation per-frame raster package — non_exhaustive, explicitly unstable"
+failure_semantics = "identity fields let receivers reject stale frames"
+consumers = ["RasterOwner protocol", "threaded tests"]
+owner_issue = 552
+notes = "Missing the PresentationId field ADR-0037 §2 requires; adding it is additive under non_exhaustive."
+
+[[surface]]
+path = "flui_foundation::{RealmId, PresentationId, FrameEpoch, SurfaceGeneration, ResourceGeneration, GenerationGate}"
+crate = "flui-foundation"
+kind = "type"
+declared_in = "crates/flui-foundation/src/id.rs"
+contains = "pub struct PresentationId"
+classification = "experimental"
+thread_affinity = "plain Copy value types; Send + Sync"
+owner = "generational protocol identity vocabulary"
+failure_semantics = "generation mismatch compares unequal; GenerationGate rejects stale commits"
+consumers = ["UiRealm", "PresentationState", "SceneSnapshot", "RasterOwner"]
+owner_issue = 552
+
+[[surface]]
+path = "flui_testing::HeadlessBinding"
+crate = "flui-testing"
+kind = "type"
+declared_in = "crates/flui-testing/src/lib.rs"
+contains = "pub struct HeadlessBinding"
+classification = "experimental"
+thread_affinity = "owner-thread create/use/drop; !Send + !Sync per ADR-0027's intentional break"
+owner = "deterministic headless frame driver for tests"
+failure_semantics = "panics on misuse (test driver)"
+consumers = ["crate tests across the workspace", "screenshot example"]
+owner_issue = 563
+
+[[surface]]
+path = "flui::run_app (facade re-export)"
+crate = "flui"
+kind = "re-export"
+declared_in = "src/lib.rs"
+contains = "pub use flui_app::run_app"
+classification = "stable-candidate"
+thread_affinity = "same as flui_app::run_app"
+owner = "facade"
+failure_semantics = "same as flui_app::run_app"
+consumers = ["applications", "examples"]
+
+[[surface]]
+path = "flui::app (facade module re-export of the whole flui-app surface)"
+crate = "flui"
+kind = "re-export"
+declared_in = "src/lib.rs"
+contains = "pub use flui_app as app"
+classification = "transitional"
+thread_affinity = "mixed — re-exposes AppBinding and the singleton graph from the facade"
+owner = "facade"
+failure_semantics = "same as the underlying flui-app items"
+consumers = ["applications reaching transitional types through the facade"]
+owner_issue = 553
+
+# =============================================================================
+# Known advisory / unwired public configuration
+# =============================================================================
+#
+# The checker hard-requires `vsync` and `target_fps` to be present here and
+# to carry a non-stable classification — they must never be presented as
+# working stable configuration (ADR-0029 decision 4).
+
+[[config_field]]
+name = "vsync"
+path = "flui_app::AppConfig::vsync"
+file = "crates/flui-app/src/app/config.rs"
+contains = "pub vsync: bool"
+status = "unwired"
+classification = "transitional"
+owner_issue = 556
+notes = "Dropped by From<&AppConfig> for WindowOptions; select_present_mode always chooses Fifo. AppBinding::vsync()/VsyncScope is an unrelated animation registry."
+
+[[config_field]]
+name = "target_fps"
+path = "flui_app::AppConfig::target_fps"
+file = "crates/flui-app/src/app/config.rs"
+contains = "pub target_fps: u32"
+status = "advisory"
+classification = "transitional"
+owner_issue = 556
+notes = "Logged at startup only; pacing comes from the blocking Fifo present. The no-present fallback is a fixed constant, deliberately not derived from this field."
+
+[[config_field]]
+name = "fullscreen"
+path = "flui_app::AppConfig::fullscreen"
+file = "crates/flui-app/src/app/config.rs"
+contains = "pub fullscreen: bool"
+status = "unwired"
+classification = "transitional"
+owner_issue = 565
+notes = "WindowOptions has no fullscreen field and nothing calls toggle_fullscreen at startup."
+
+[[config_field]]
+name = "debug_paint"
+path = "flui_app::AppConfig::debug_paint"
+file = "crates/flui-app/src/app/config.rs"
+contains = "pub debug_paint: bool"
+status = "unwired"
+classification = "transitional"
+owner_issue = 565
+notes = "No paint-phase debug visualization reads it."
+
+[[config_field]]
+name = "show_performance_overlay"
+path = "flui_app::AppConfig::show_performance_overlay"
+file = "crates/flui-app/src/app/config.rs"
+contains = "pub show_performance_overlay: bool"
+status = "partially-wired"
+classification = "transitional"
+owner_issue = 565
+notes = "Overlay renders, but the renderer ignores the frame counter and the PerformanceOverlayOption mask."
+
+# =============================================================================
+# Ambient singleton allowlist
+# =============================================================================
+#
+# The checker scans the runtime crates for `impl_binding_singleton!(` and
+# `fn instance() -> &'static`; every hit must be listed here. A new ambient
+# singleton therefore cannot land without an owning issue. (The macro's
+# defining file, crates/flui-foundation/src/binding.rs, is exempt: it holds
+# the definition, doc examples, and cfg(test) invocations.)
+
+[[singleton_exemption]]
+symbol = "AppBinding::instance (manual thread-local singleton)"
+file = "crates/flui-app/src/app/binding.rs"
+contains = "pub fn instance() -> &'static Self"
+owner_issue = 553
+
+[[singleton_exemption]]
+symbol = "impl_binding_singleton!(RenderingFlutterBinding)"
+file = "crates/flui-app/src/bindings/renderer_binding.rs"
+contains = "impl_binding_singleton!(RenderingFlutterBinding)"
+owner_issue = 553
+
+[[singleton_exemption]]
+symbol = "impl_binding_singleton!(Scheduler)"
+file = "crates/flui-scheduler/src/scheduler.rs"
+contains = "impl_binding_singleton!(Scheduler)"
+owner_issue = 553
+
+[[singleton_exemption]]
+symbol = "impl_binding_singleton!(PaintingBinding)"
+file = "crates/flui-painting/src/binding.rs"
+contains = "impl_binding_singleton!(PaintingBinding)"
+owner_issue = 553
+
+[[singleton_exemption]]
+symbol = "impl_binding_singleton!(SemanticsBinding)"
+file = "crates/flui-semantics/src/binding.rs"
+contains = "impl_binding_singleton!(SemanticsBinding)"
+owner_issue = 553
+
+# =============================================================================
+# Public lock-shaped surface allowlist (runtime crates)
+# =============================================================================
+#
+# The checker scans flui-app, flui-scheduler, flui-platform, and flui-engine
+# for `PORT-CHECK-OK-SP6` markers (port-check trigger #12's exemption
+# grammar); every file containing one must be listed here with an owning
+# issue. This sees exactly what the SP-6 marker sees — a lock-shaped public
+# surface that trigger #12's grammar misses is invisible to both gates.
+
+[[lock_exemption]]
+file = "crates/flui-app/src/app/binding.rs"
+reason = "AppBinding renderer/renderer_mut guards and render_pipeline_arc accessor"
+owner_issue = 553
+
+[[lock_exemption]]
+file = "crates/flui-scheduler/src/scheduler.rs"
+reason = "Scheduler::budget() returns a MutexGuard"
+owner_issue = 556
+
+[[lock_exemption]]
+file = "crates/flui-platform/src/platforms/windows/platform.rs"
+reason = "WindowsPlatform public handlers Arc<Mutex<PlatformHandlers>> field"
+owner_issue = 551
+
+[[lock_exemption]]
+file = "crates/flui-platform/src/shared/handlers.rs"
+reason = "PlatformHandlers public Mutex<Option<Box<dyn FnMut>>> callback storage"
+owner_issue = 551
+
+# =============================================================================
+# Process-global guards (transitional; retire with the singletons)
+# =============================================================================
+#
+# Existence-pinned: deleting a guard without updating the registry fails the
+# gate, so retirement (the owning issue's deliverable) must update this file
+# in the same change — which is exactly when the entry should disappear.
+
+[[process_global_guard]]
+symbol = "REALM_CLAIMED"
+file = "crates/flui-app/src/app/ui_realm.rs"
+contains = "static REALM_CLAIMED"
+owner_issue = 553
+
+[[process_global_guard]]
+symbol = "SEMANTICS_TEST_LOCK"
+file = "crates/flui-app/src/bindings/renderer_binding.rs"
+contains = "static SEMANTICS_TEST_LOCK"
+owner_issue = 553
+
+# =============================================================================
+# Forbidden patterns and paths
+# =============================================================================
+#
+# Substring scans over crates/**/*.rs (comments included — the strings below
+# are retired identifiers that must not reappear even in prose). `allow_files`
+# lists exact files permitted to contain the pattern.
+
+[[forbidden_pattern]]
+pattern = "ForegroundExecutor"
+why = "ADR-0027 §9: the public generic UI-thread executor was deleted; the closed command vocabulary replaces it"
+allow_files = []
+
+[[forbidden_pattern]]
+pattern = "TextInputPlatformBridge"
+why = "ADR-0037 §5: the IME intermediary object was deleted in favor of direct presentation ownership"
+allow_files = []
+
+[[forbidden_pattern]]
+pattern = "OpaqueWindowHandle"
+why = "ADR-0037 §5: opaque-window storage plus downcast was deleted"
+allow_files = []
+
+[[forbidden_pattern]]
+pattern = "TextInputRegistry"
+why = "ADR-0037 §5: the process-global text-input registry was deleted"
+allow_files = []
+
+[[forbidden_pattern]]
+pattern = "unsafe impl Sync for Renderer"
+why = "ADR-0027 §2: Renderer is Send + !Sync — a single mutator, never shared"
+allow_files = []
+
+[[forbidden_pattern]]
+pattern = "debug_assert_owner"
+scope = "crates/flui-platform/src/platforms/macos/clipboard.rs"
+why = "ADR-0039 §5: clipboard operations are documented off-main-safe; an affinity assert would panic legitimate ADR-0034 callers"
+allow_files = []
+
+[[forbidden_path]]
+path = "crates/flui-presentation"
+why = "ADR-0037 §12: no flui-presentation crate; flui-app privately composes the three owners"

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -1,14 +1,12 @@
-# Runtime.1 conformance registry.
+# Runtime.1 public contract registry.
 #
-# This file is the *authoritative*, machine-readable inventory of (a) every
-# normative requirement in the runtime ADRs — ADR-0027, ADR-0037, ADR-0029,
-# ADR-0039 — with its verified implementation state, and (b) every public
-# runtime/platform/scheduler/raster surface with its stability classification.
+# This file is the authoritative, machine-readable inventory of the runtime
+# contracts contributors and CI must preserve, together with the public
+# boundary families whose stability must be reviewed before they grow.
 # It is validated by `scripts/check-runtime-conformance.sh`
 # (`just runtime-conformance-check`, part of `just ci` and the CI `checks`
-# job). Markdown is deliberately NOT the source of truth here; prose in the
-# ADRs describes the target architecture, and this file records what is
-# actually true of the tree, cross-checked against the source.
+# job). It deliberately does not depend on internal design records, their
+# numbering, status, or continued presence in this repository.
 #
 # What the checker verifies mechanically (and, honestly, what it cannot):
 #
@@ -20,7 +18,7 @@
 #     least one `test`/`compile-time`/`source-gate` citation, and rejects
 #     `.md` files as evidence — documentation is never implementation
 #     evidence.
-#   - `partial`/`planned` entries require exactly one owning issue in
+#   - `partial`/`planned` contracts require exactly one owning issue in
 #     #551–#565.
 #   - Forbidden patterns/paths (retired intermediaries, a public generic UI
 #     executor, an `unsafe impl Sync for Renderer`, a `flui-presentation`
@@ -52,21 +50,211 @@
 #   removal-target   — scheduled for deletion by its owning issue; do not add
 #                      consumers
 #
-# Ownership domains follow ADR-0027/ADR-0037:
+# Ownership domains:
 #   application | realm | presentation | raster | platform | shared-engine
 
 [registry]
 milestone = "Runtime.1"
-adr_scope = ["ADR-0027", "ADR-0037", "ADR-0029", "ADR-0039"]
+schema = 1
 
-# =============================================================================
-# ADR-0027 — Owner-affine UI realms
-# =============================================================================
+# Root export manifest
+#
+# These declarations are the stable-toolchain boundary of the API gate. The
+# checker compares every column-zero public declaration in each listed crate
+# root. Public modules are classified as boundary families below; this does not
+# pretend to replace compiler-level rustdoc JSON, which is unavailable on the
+# pinned stable toolchain.
 
-[[requirement]]
+[[export_root]]
+file = "src/lib.rs"
+declarations = [
+    "pub use flui_animation as animation;",
+    "pub use flui_app as app;",
+    "pub use flui_cupertino as cupertino;",
+    "pub use flui_foundation as foundation;",
+    "pub use flui_geometry as geometry;",
+    "pub use flui_localizations as localizations;",
+    "pub use flui_material as material;",
+    "pub use flui_types as types;",
+    "pub use flui_view as view;",
+    "pub use flui_widgets as widgets;",
+    "pub use flui_app::run_app;",
+    "pub mod prelude {",
+]
+
+[[export_root]]
+file = "crates/flui-app/src/lib.rs"
+declarations = [
+    "pub mod app;",
+    "pub mod bindings;",
+    "pub mod embedder;",
+    "pub use app::{ AppBinding, AppConfig, DiagnosticsProfile, RootRenderElement, RootRenderView, WidgetsFlutterBinding, run_app, run_app_with_config, run_direct, };",
+    "pub use app::{run_app_android, run_app_android_with_config};",
+    "pub use bindings::{ GestureBinding, PaintingBinding, PipelineOwner, RenderingFlutterBinding, Scheduler, SemanticsBinding, WidgetsBinding, };",
+    "pub use flui_log::{AppIdentity, AppleBundleId};",
+    "pub use flui_view::{ BuildContext, BuildContextExt, BuildOwner, ElementBase, ElementTree, StatefulView, StatelessElement, StatelessView, View, };",
+    "pub mod prelude {",
+]
+
+[[export_root]]
+file = "crates/flui-app/src/app/mod.rs"
+declarations = [
+    "pub mod direct;",
+    "pub mod runner;",
+    "pub use binding::AppBinding;",
+    "pub use config::{AppConfig, DiagnosticsProfile};",
+    "pub use direct::run_direct;",
+    "pub use runner::{run_app_android, run_app_android_with_config};",
+    "pub use runner::{run_app_impl as run_app, run_app_with_config_impl as run_app_with_config};",
+    "pub type WidgetsFlutterBinding = AppBinding;",
+    "pub use flui_view::{RootRenderElement, RootRenderView};",
+]
+
+[[export_root]]
+file = "crates/flui-platform/src/lib.rs"
+declarations = [
+    "pub mod config;",
+    "pub mod data_transfer;",
+    "pub mod executor;",
+    "pub mod platforms;",
+    "pub mod shared;",
+    "pub mod task;",
+    "pub mod traits;",
+    "pub mod window;",
+    "pub use config::{FullscreenMonitor, WindowConfiguration};",
+    "pub use data_transfer::{DataTransferOffer, DataTransferSource, NullDataTransferSource};",
+    "pub use cursor_icon::CursorIcon;",
+    "pub use executor::BackgroundExecutor;",
+    "pub use platforms::AndroidPlatform;",
+    "pub use platforms::IOSPlatform;",
+    "pub use platforms::LinuxPlatform;",
+    "pub use platforms::MacOSPlatform;",
+    "pub use platforms::{FakeHaptics, FakeTextInput, HeadlessPlatform};",
+    "pub use platforms::WebPlatform;",
+    "pub use platforms::WindowsPlatform;",
+    "pub use platforms::WinitPlatform;",
+    "pub use shared::{PlatformHandlers, WindowCallbacks};",
+    "pub use task::{Priority, Task, TaskLabel};",
+    "pub use traits::{ Clipboard, ClipboardItem, CursorError, DesktopCapabilities, DispatchEventResult, DisplayId, MobileCapabilities, PathPromptOptions, Platform, PlatformCapabilities, PlatformDisplay, PlatformEmbedder, PlatformExecutor, PlatformHaptics, PlatformReadyCallback, PlatformTextInput, PlatformWindow, WebCapabilities, WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowEvent, WindowId, WindowMode, WindowOptions, };",
+    "pub fn current_platform() -> anyhow::Result<Box<dyn Platform>> {",
+    "pub fn headless_platform() -> Box<dyn Platform> {",
+]
+
+[[export_root]]
+file = "crates/flui-scheduler/src/lib.rs"
+declarations = [
+    "pub mod budget;",
+    "pub mod config;",
+    "pub mod frame;",
+    "pub mod scheduler;",
+    "pub mod task;",
+    "pub mod ticker;",
+    "pub mod vsync;",
+    "pub mod async_driver;",
+    "pub mod duration;",
+    "pub mod id;",
+    "pub use async_driver::{AsyncDriver, BoxedTask, TaskToken};",
+    "pub use budget::{ AllPhaseStats, BudgetPolicy, FrameBudget, FrameBudgetBuilder, PhaseStats, SharedBudget, };",
+    "pub use config::{ PerformanceMode, PerformanceModeRequestHandle, SERVICE_EXT_TIME_DILATION, SchedulingStrategy, TimingsCallback, default_scheduling_strategy, set_time_dilation, time_dilation, };",
+    "pub use post_frame::{LocalPostFrameLane, LocalPostFrameScheduleError, PostFrameHandle};",
+    "pub use web_time::Instant;",
+    "pub use duration::{FrameDuration, Microseconds, Milliseconds, Percentage, Seconds};",
+    "pub use flui_foundation::{BindingBase, HasInstance};",
+    "pub use frame::{ AppLifecycleState, FrameCallback, FrameId, FramePhase, FrameTiming, FrameTimingBuilder, LifecycleStateCallback, OneShotFrameCallback, PostFrameCallback, RecurringFrameCallback, SchedulerPhase, };",
+    "pub use id::{CallbackId, Id, IdGenerator, Marker, markers};",
+    "pub use scheduler::{FrameCompletionFuture, FrameSkipPolicy, Scheduler, SchedulerBuilder};",
+    "pub use task::{Priority, PriorityCount, Task, TaskId, TaskQueue};",
+    "pub use ticker::{ Ticker, TickerCallback, TickerCanceled, TickerFuture, TickerFutureOrCancel, TickerGroup, TickerId, TickerProvider, TickerState, };",
+    "pub use vsync::{VsyncCallback, VsyncMode, VsyncScheduler, VsyncStats};",
+    "pub mod prelude {",
+]
+
+[[export_root]]
+file = "crates/flui-engine/src/lib.rs"
+declarations = [
+    "pub mod error;",
+    "pub mod traits;",
+    "pub mod commands;",
+    "pub mod raster;",
+    "pub mod raster_owner;",
+    "pub mod wgpu;",
+    "pub use commands::{dispatch_command, dispatch_commands};",
+    "pub use error::{EngineError, EngineResult, Recoverability};",
+    "pub use flui_layer::{ CanvasLayer, DamageRegion, Layer, LayerId, LayerTree, LinkRegistry, Scene, SceneBuilder, SceneCompositor, SceneSnapshot, ShaderMaskLayer, };",
+    "pub use flui_painting::Paint;",
+    "pub use traits::{CommandRenderer, LayerStateStack};",
+    "pub use raster::RasterBackend;",
+    "pub use raster_owner::{ FrameDropReason, PumpOutcome, RasterAck, RasterHandle, RasterOwner, RasterSubmitError, };",
+    "pub use wgpu::DebugBackend;",
+    "pub use wgpu::{Backend, FontLoader, LayerRender, WgpuPainter};",
+]
+
+[[export_root]]
+file = "crates/flui-foundation/src/lib.rs"
+declarations = [
+    "pub mod affinity;",
+    "pub mod async_snapshot;",
+    "pub mod binding;",
+    "pub mod callbacks;",
+    "pub mod clock;",
+    "pub mod consts;",
+    "pub mod epoch;",
+    "pub mod id;",
+    "pub mod key;",
+    "pub mod wasm;",
+    "pub mod diagnostics;",
+    "pub mod observe;",
+    "pub mod rebuild_reason;",
+    "pub mod notifier;",
+    "pub mod listener_registry;",
+    "pub mod notifier_generic;",
+    "pub mod debug;",
+    "pub use affinity::OwnerAffinity;",
+    "pub use async_snapshot::{AsyncSnapshot, ConnectionState};",
+    "pub use binding::{BindingBase, HasInstance, check_instance};",
+    "pub use callbacks::{ FallibleCallback, Predicate, ValueChanged, ValueGetter, ValueSetter, ValueTransformer, VoidCallback, };",
+    "pub use clock::{ManualClock, MonotonicClock, SystemClock};",
+    "pub use consts::{DEBUG_MODE, EPSILON, EPSILON_F32, IS_DESKTOP, IS_MOBILE, IS_WEB, RELEASE_MODE};",
+    "pub use epoch::{FrameEpoch, GenerationGate, ResourceGeneration, SurfaceGeneration};",
+    "pub use debug::{ DebugPaintConfig, DiagnosticLevel, Diagnosticable, DiagnosticsBuilder, DiagnosticsNode, DiagnosticsProperty, DiagnosticsPropertyKind, DiagnosticsTreeStyle, };",
+    "pub use id::{ DataTransferId, ElementId, FrameCallbackId, FrameId, Id, Identifier, LayerId, ListenerId, Marker, ObserverId, PresentationId, RawId, RealmId, RenderId, SemanticsId, TaskId, TickerId, TreeId, ViewId, markers, };",
+    "pub use key::{Key, KeyRef, Keyed, UniqueKey, ValueKey, ViewKey, WithKey};",
+    "pub use notifier::{ChangeNotifier, Listenable, ListenerCallback, ValueListenable, ValueNotifier};",
+    "pub use rebuild_reason::{RebuildReason, RebuildReasons};",
+    "pub use listener_registry::{ListenerRegistry, ListenerSubscription};",
+    "pub use notifier_generic::{ArgCallback, Notifier};",
+    "pub use wasm::WasmNotSendSync;",
+    "pub mod prelude {",
+]
+
+[[export_root]]
+file = "crates/flui-layer/src/lib.rs"
+declarations = [
+    "pub mod damage;",
+    "pub mod layer;",
+    "pub mod testing;",
+    "pub mod tree;",
+    "pub use error::{LayerError, LayerResult};",
+    "pub use compositor::{CompositorStats, SceneBuilder, SceneCompositor};",
+    "pub use flui_foundation::LayerId;",
+    "pub use layer::annotation::{AnnotationEntry, AnnotationResult, AnnotationSearchOptions};",
+    "pub use layer::{ AnnotatedRegionLayer, AnnotationValue, BackdropFilterLayer, CanvasLayer, ClipPathLayer, ClipRRectLayer, ClipRectLayer, ClipSuperellipseLayer, ColorFilterLayer, FollowerLayer, ImageFilterLayer, Layer, LayerBounds, LayerLink, LeaderLayer, OffsetLayer, OpacityLayer, PerformanceOverlayLayer, PerformanceOverlayOption, PerformanceStats, PictureLayer, PlatformViewHitTestBehavior, PlatformViewId, PlatformViewLayer, SemanticLabel, ShaderMaskLayer, SystemUiOverlayStyle, TextureLayer, TransformLayer, };",
+    "pub use link_registry::{LeaderInfo, LinkRegistry, resolve_follower_offset};",
+    "pub use scene::{CompositionCallback, Scene};",
+    "pub use scene_snapshot::{DamageRegion, SceneSnapshot};",
+    "pub use tree::{LayerNode, LayerTree};",
+    "pub mod prelude {",
+    "pub const VERSION: &str = env!(\"CARGO_PKG_VERSION\");",
+]
+
+[[export_root]]
+file = "crates/flui-testing/src/lib.rs"
+declarations = ["pub struct HeadlessBinding {"]
+
+# Owner-affine UI realms
+
+[[contract]]
 key = "realm-owns-ui-session-owner-affine"
-adr = "ADR-0027"
-section = "§1–§2 ownership model / thread-affinity"
 statement = """
 Mutable UI state is scoped to a `UiRealm` — a single-owner UI session that is \
 structurally `!Send + !Sync` — never to the process or the native window.\
@@ -80,10 +268,8 @@ evidence = [
     { kind = "compile-time", file = "crates/flui-app/src/app/ui_realm.rs", contains = "assert_not_impl_any!(UiRealm: Send, Sync)" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "app-runtime-composition-host"
-adr = "ADR-0027"
-section = "§1 ownership model (AppRuntime / SharedEngineServices)"
 statement = """
 One `AppRuntime` per process owns platform event-loop demux, explicit \
 constructor-injected `SharedEngineServices`, and 1..N realms. No such type \
@@ -94,10 +280,8 @@ domain = "application"
 owner_issue = 553
 mechanical = false
 
-[[requirement]]
+[[contract]]
 key = "scheduling-splits-by-level"
-adr = "ADR-0027"
-section = "§1 (scheduling split); execution plan frame-clock item"
 statement = """
 Logical update scheduling (realm `UpdateScheduler`), physical pacing \
 (presentation `FrameClock`), and raster backpressure are separate owners. \
@@ -108,10 +292,8 @@ domain = "realm"
 owner_issue = 556
 mechanical = false
 
-[[requirement]]
+[[contract]]
 key = "transitional-realm-guard-at-most-one"
-adr = "ADR-0027"
-section = "Consequences (at-most-one instance guard)"
 statement = """
 Until singleton retirement, constructing a second `UiRealm` fails with a \
 typed error — a per-realm API over process-global internals would be a lying \
@@ -128,10 +310,8 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn at_most_one_runtime_second_construction_fails_typed" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "idle-only-commit-points"
-adr = "ADR-0027"
-section = "§3 message flow and commit points"
 statement = """
 Cross-thread commands and worker results commit only while the realm's \
 scheduler phase is Idle — never inside the frame transaction.\
@@ -145,14 +325,13 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn cross_thread_navigation_command_drains_on_owner_thread" },
 ]
 
-[[requirement]]
-key = "reentrancy-fifo-ordered-dispatch"
-adr = "ADR-0027"
-section = "§3 reentrancy gate"
+[[contract]]
+key = "input-and-reentrancy-fifo-ordered-dispatch"
 statement = """
-A platform callback that re-enters while the realm is mid-transaction is \
-queued into a realm-local ordered FIFO and applied at the next permitted \
-anchor; the frame transaction is uninterruptible by construction.\
+Platform input is delivered in causal order and never coalesced. A callback \
+that re-enters while the realm is mid-transaction is queued into a realm-local \
+ordered FIFO and applied at the next permitted anchor; the frame transaction \
+is uninterruptible by construction.\
 """
 state = "implemented"
 domain = "realm"
@@ -164,10 +343,8 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn nested_resize_and_window_focus_wait_until_frame_returns" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "wake-contract-enqueue-then-wake"
-adr = "ADR-0027"
-section = "§3 wake contract / §4 coalesced invalidations"
 statement = """
 Enqueue-then-wake is one operation from the sender's perspective; redraw \
 requests coalesce to one flag and one wake; a realm never goes idle with a \
@@ -183,14 +360,11 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn redraw_requests_coalesce_to_one_flag_and_one_wake" },
 ]
 
-[[requirement]]
-key = "bounded-lanes-typed-backpressure"
-adr = "ADR-0027"
-section = "§4 queues by reliability class"
+[[contract]]
+key = "owner-inbox-bounded-typed-backpressure"
 statement = """
-No unbounded channels on runtime paths. The owner inbox is bounded; a full \
-lane returns a typed `ChannelFull` carrying the rejected command; a dropped \
-owner returns typed `OwnerGone`.\
+The owner inbox is bounded. A full lane returns a typed `ChannelFull` carrying \
+the rejected command; a dropped owner returns typed `OwnerGone`.\
 """
 state = "implemented"
 domain = "realm"
@@ -202,10 +376,24 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn channel_full_retry_preserves_the_rejected_payload" },
 ]
 
-[[requirement]]
+[[contract]]
+key = "owner-inbox-drain-is-bounded-snapshot"
+statement = """
+One owner-inbox drain processes at most the pre-read queue length. Commands \
+arriving during a drain remain for the next deterministic batch, so a producer \
+cannot extend one owner pass indefinitely.\
+"""
+state = "implemented"
+domain = "realm"
+mechanical = true
+mechanism = "source gate pins the pre-read length and bounded loop"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "let pending = self.rx.len();" },
+    { kind = "source-gate", file = "crates/flui-app/src/app/ui_realm.rs", contains = "for _ in 0..pending" },
+]
+
+[[contract]]
 key = "raster-mailbox-protocol-threaded"
-adr = "ADR-0027"
-section = "§5 SceneSnapshot and the raster boundary"
 statement = """
 The raster seam is a capacity-one latest-frame-wins mailbox with identity-\
 stamped acks, stale-`SurfaceGeneration` rejection before render, a lossy \
@@ -224,10 +412,8 @@ evidence = [
     { kind = "test", file = "crates/flui-engine/src/raster_owner.rs", contains = "fn shutdown_handshake_completes_and_thread_joins" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "raster-owner-in-shipping-path"
-adr = "ADR-0027"
-section = "§5 (shipping baseline behind the mailbox seam)"
 statement = """
 The shipping runners must drive frames through the raster-owner mailbox seam \
 with the raster owner as sole `Renderer` owner. Today the desktop/Android \
@@ -242,10 +428,8 @@ evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/runner.rs", contains = "Arc<Mutex<Option<Renderer>>>" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "freshness-by-work-class"
-adr = "ADR-0027"
-section = "§6 identity, versioning, cancellation"
 statement = """
 Commit-time freshness is per work class (`ResourceGeneration`/\
 `GenerationGate` for assets, `FrameEpoch` + `SurfaceGeneration` for raster, \
@@ -260,10 +444,21 @@ evidence = [
     { kind = "symbol", file = "crates/flui-foundation/src/epoch.rs", contains = "pub struct ResourceGeneration" },
 ]
 
-[[requirement]]
+[[contract]]
+key = "worker-jobs-cancel-with-owner-lifetime"
+statement = """
+Every runtime worker job carries cancellation owned by the realm or service \
+that requested it. Dropping an owner cancels outstanding work, and racing \
+results meet a dead channel or a work-class freshness check rather than \
+mutating replacement state. This has not been adopted across runtime workers.\
+"""
+state = "planned"
+domain = "shared-engine"
+owner_issue = 557
+mechanical = false
+
+[[contract]]
 key = "channel-identity-lifetime-boundary"
-adr = "ADR-0027"
-section = "§6 channel identity"
 statement = """
 A realm's channels are created with the realm and die with it; a recreated \
 realm mints a fresh generational `RealmId`, and senders into the dead realm \
@@ -280,14 +475,12 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn late_event_never_crosses_realm_incarnations" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "shutdown-protocol-per-realm"
-adr = "ADR-0027"
-section = "§7 shutdown protocol"
 statement = """
 Per-realm teardown follows detach → refuse → cancel → mailbox close + \
-one-shot completion → renderer teardown → drop. The ADR itself records this \
-as the target protocol: desktop/Android detach their transitional host after \
+one-shot completion → renderer teardown → drop. Today desktop/Android detach \
+their transitional host after \
 loop exit, web cannot detach at all, and full orchestration is unlanded.\
 """
 state = "partial"
@@ -298,10 +491,8 @@ evidence = [
     { kind = "symbol", file = "crates/flui-engine/src/raster_owner.rs", contains = "fn shutdown" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "globalkey-realm-scoped"
-adr = "ADR-0027"
-section = "§8 focus, GlobalKey, multi-realm semantics"
 statement = """
 GlobalKey identity is realm-scoped through a realm-entry activation stack, \
 not a process-global active registry. Deliberate divergence from Flutter's \
@@ -317,10 +508,8 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn whole_frame_event_keeps_realm_global_key_scope_active" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "focus-coordination-per-realm"
-adr = "ADR-0027"
-section = "§8 FocusCoordinator"
 statement = """
 One `FocusTree` per presentation with realm-level active-presentation \
 arbitration. The per-presentation `FocusManager` is real (owned by \
@@ -336,14 +525,12 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn presentation_and_widget_tree_share_the_exact_focus_owner" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "ui-types-lose-send-sync"
-adr = "ADR-0027"
-section = "§9 public API consequences (bound drop)"
 statement = """
 `View`, `BuildContext`, `ViewState`, and the owner-authored callback aliases \
-carry no `Send + Sync` bounds; the data plane keeps its bounds per the \
-ADR-0002 table.\
+carry no `Send + Sync` bounds; the established data plane keeps its own \
+thread-safety bounds.\
 """
 state = "implemented"
 domain = "realm"
@@ -354,10 +541,8 @@ evidence = [
     { kind = "compile-time", file = "crates/flui-view/src/context/element_build_context.rs", contains = "assert_not_impl_any!(ElementBuildContext: Send, Sync)" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "no-public-generic-ui-executor"
-adr = "ADR-0027"
-section = "§9 closed command vocabulary"
 statement = """
 No public run-a-closure executor targets the owner thread; the cross-thread \
 surface is a closed command vocabulary. The former public \
@@ -372,10 +557,8 @@ evidence = [
     { kind = "source-gate", file = "crates/flui-platform/src/lib.rs", contains = "pub use executor::BackgroundExecutor" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "transitional-realm-types-not-public"
-adr = "ADR-0027"
-section = "§9 current stability posture"
 statement = """
 The transitional `UiRealm`, its dispatcher, command sender, and \
 command/error protocol are `pub(crate)` implementation details of \
@@ -391,10 +574,8 @@ evidence = [
     { kind = "source-gate", file = "crates/flui-app/src/app/mod.rs", contains = "pub(crate) mod presentation" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "parallel-layout-gated"
-adr = "ADR-0027"
-section = "§10 absorbed G1–G4 gates"
 statement = """
 Parallel layout (repaint-boundary subtrees) stays gated behind G1–G4 with a \
 deterministic serial oracle; no parallelization of the control plane, \
@@ -405,21 +586,15 @@ domain = "realm"
 owner_issue = 562
 mechanical = false
 
-# =============================================================================
-# ADR-0037 — Presentation ownership domains
-# =============================================================================
+# Presentation ownership domains
 
-[[requirement]]
-key = "three-owner-presentation-shape"
-adr = "ADR-0037"
-section = "§1 one logical presentation, three physical owners"
+[[contract]]
+key = "window-host-is-explicit-composition-owner"
 statement = """
-A presentation is coordinated by exactly three physical owners — event-loop \
-`WindowHost`, realm-owned `PresentationState`, engine `RasterOwner` — with no \
-fourth mediation object. `PresentationState` exists (crate-private, owner-\
-local); `WindowHost` does not exist as an owner (the runner's TLS host and \
-per-window callbacks stand in), and `RasterOwner` is not in the shipping \
-composition.\
+The event-loop side of a presentation has one explicit `WindowHost` owner for \
+the native window, callback registrations, platform-to-realm routing, and \
+cancellation. Today the runner's TLS host and per-window callbacks stand in; \
+there is no explicit owner object.\
 """
 state = "partial"
 domain = "application"
@@ -429,10 +604,8 @@ evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "pub(crate) struct PresentationState" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "presentation-identity-generational"
-adr = "ADR-0037"
-section = "§2 presentation identity"
 statement = """
 Generational `PresentationId` exists and `AppRuntime` is the only \
 `WindowId → (RealmId, PresentationId)` authority. The ID type is real and \
@@ -447,10 +620,8 @@ evidence = [
     { kind = "symbol", file = "crates/flui-foundation/src/id.rs", contains = "pub struct PresentationId" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "closed-cross-thread-vocabulary"
-adr = "ADR-0037"
-section = "§3 cross-thread traffic"
 statement = """
 Cross-lane traffic is closed, presentation-addressed enums — never `dyn \
 Any`, opaque windows, or `Box<dyn FnOnce()>` payloads. The realm inbox \
@@ -466,16 +637,14 @@ evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "enum UiCommand" },
 ]
 
-[[requirement]]
-key = "presentation-state-owner-nucleus"
-adr = "ADR-0037"
-section = "§4 PresentationState"
+[[contract]]
+key = "presentation-state-owner-nucleus-rehomes-from-binding"
 statement = """
 `PresentationState` is private to `flui-app`, stored inside `UiRealm`, \
 structurally `!Send + !Sync`, owning one presentation's pipeline, focus, \
-gestures, mouse tracking, text-input session, and semantics dispatch. \
-Missing from the ADR's field list: frame clock/pacing state, redraw \
-coalescing, element-forest root entry, and cached raster acks.\
+gestures, mouse tracking, text-input session, and semantics dispatch. The \
+remaining presentation-local services move out of the transitional singleton \
+graph when explicit runtime ownership lands.\
 """
 state = "partial"
 domain = "presentation"
@@ -487,10 +656,8 @@ evidence = [
     { kind = "compile-time", file = "crates/flui-app/src/app/presentation.rs", contains = "assert_not_impl_any!(PresentationState: Send, Sync)" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "text-input-direct-ownership"
-adr = "ADR-0037"
-section = "§5 text input"
 statement = """
 Text input is a presentation-owned `TextInputOwner` with a weak-capability \
 `TextInputHandle`; one active client per presentation, token-checked detach, \
@@ -507,10 +674,8 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/presentation.rs", contains = "fn text_input_handle_is_bound_to_the_owned_text_input_state" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "input-domain-per-presentation"
-adr = "ADR-0037"
-section = "§6 focus, gestures, mouse, keyboard"
 statement = """
 Each presentation owns one complete input domain (gesture arena, mouse \
 tracker, focus tree, cursor to the exact window; a closed window drops the \
@@ -527,10 +692,8 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/presentation.rs", contains = "fn mouse_tracker_applies_cursor_to_the_exact_owned_window" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "semantics-two-phase-borrow"
-adr = "ADR-0037"
-section = "§7 semantics command routing"
 statement = """
 Accessibility actions are closed, identity-stamped commands resolved through \
 the presentation's exact pipeline owner in two borrow phases — no action \
@@ -547,10 +710,8 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn stale_semantics_action_is_gracefully_dropped" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "surface-generation-single-authority"
-adr = "ADR-0037"
-section = "§8 RasterOwner mints SurfaceGeneration"
 statement = """
 Only `RasterOwner` mints `SurfaceGeneration`, in the ordered command stream \
 that reconfigures the surface; stale frames are rejected before render. True \
@@ -565,10 +726,8 @@ evidence = [
     { kind = "test", file = "crates/flui-engine/src/raster_owner.rs", contains = "fn resize_coalesces_latest_wins" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "presentation-lifecycle-monotonic"
-adr = "ADR-0037"
-section = "§9 lifecycle"
 statement = """
 Each presentation has the explicit Created → SurfaceAttached → Suspended → \
 Closing → Closed lifecycle with typed transitions and idempotent close. \
@@ -584,10 +743,8 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/presentation.rs", contains = "fn lifecycle_transitions_are_typed_and_close_is_idempotent" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "cancellable-platform-callbacks"
-adr = "ADR-0037"
-section = "§10 platform callback lifetime"
 statement = """
 Install-only callbacks are forbidden: delivery is event-loop-owned or \
 registration returns a cancellation token owned by `WindowHost`. Today \
@@ -602,10 +759,8 @@ evidence = [
     { kind = "symbol", file = "crates/flui-platform/src/shared/handlers.rs", contains = "pub on_input: Mutex<Option<Box<dyn FnMut(PlatformInput)" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "multi-presentation-forest-gate"
-adr = "ADR-0037"
-section = "§11 one realm / N presentations gate"
 statement = """
 One-realm/multi-presentation support is gated on a verified element forest; \
 until then a realm holds at most one live `PresentationState`. The gate \
@@ -622,31 +777,26 @@ evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "presentation: PresentationState" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "no-flui-presentation-crate"
-adr = "ADR-0037"
-section = "§12 no new crate"
 statement = """
 A `flui-presentation` crate is rejected; `flui-app` privately composes the \
-three owners. Extraction needs its own ADR with two production consumers.\
+three owners. Extraction needs a separately reviewed decision with two \
+production consumers.\
 """
 state = "implemented"
 domain = "application"
 mechanical = true
-mechanism = "forbidden_path check below; ADR-0041 topology contract also gates new crates"
+mechanism = "forbidden_path check below; the workspace topology policy also gates new crates"
 evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "pub(crate) struct PresentationState" },
     { kind = "source-gate", file = "docs/workspace-layers.toml", contains = "flui-app" },
 ]
 
-# =============================================================================
-# ADR-0029 — Frame pacing
-# =============================================================================
+# Frame pacing
 
-[[requirement]]
+[[contract]]
 key = "fifo-default-present-mode"
-adr = "ADR-0029"
-section = "Decision 1 (select_present_mode)"
 statement = """
 `select_present_mode` defaults to Fifo; the blocking `present()` under Fifo \
 is the steady-state pacing mechanism. Mailbox is a documented future opt-in, \
@@ -662,10 +812,8 @@ evidence = [
     { kind = "source-gate", file = "crates/flui-engine/src/wgpu/renderer.rs", contains = "BUG: wgpu guarantees Fifo is always a supported present mode" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "control-flow-wait-pinned"
-adr = "ADR-0029"
-section = "Decision 2 (ControlFlow::Wait)"
 statement = """
 `WinitApp::about_to_wait` sets `ControlFlow::Wait` explicitly every \
 iteration as a defensive pin against a future winit default change. No \
@@ -681,10 +829,8 @@ evidence = [
     { kind = "source-gate", file = "crates/flui-platform/src/platforms/winit/platform.rs", contains = "set_control_flow(winit::event_loop::ControlFlow::Wait)" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "no-present-fallback-throttle"
-adr = "ADR-0029"
-section = "Decision 3 (fallback throttle)"
 statement = """
 The fixed frame-budget sleep is deleted; a coarse fallback throttle applies \
 only when a frame did not present AND a ticker keeps the gate open. The \
@@ -701,10 +847,8 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn no_present_fallback_pace_requires_both_no_present_and_an_open_gate" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "idle-renders-zero-frames"
-adr = "ADR-0029"
-section = "Evidence (idle invariant)"
 statement = """
 A wake with frames enabled, nothing dirty, and no scheduled ticker renders \
 zero frames; the redraw gate closes when a controller settles.\
@@ -719,10 +863,8 @@ evidence = [
     { kind = "test", file = "crates/flui-app/src/app/binding.rs", contains = "fn vsync_continuation_keeps_gate_open_while_running_and_closes_on_settle" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "target-fps-advisory-documented"
-adr = "ADR-0029"
-section = "Decision 4 (target_fps audit)"
 statement = """
 `AppConfig::target_fps` is documented as advisory with a full consumer \
 audit, and `AppConfig::vsync` is documented as not controlling the present \
@@ -738,15 +880,11 @@ evidence = [
     { kind = "source-gate", file = "crates/flui-app/src/app/runner.rs", contains = "target_fps_advisory" },
 ]
 
-[[requirement]]
-key = "appconfig-effective-or-removed"
-adr = "ADR-0029"
-section = "Decision 4 + execution-plan frame-clock item"
+[[contract]]
+key = "frame-config-effective-or-removed"
 statement = """
-Every misleading `AppConfig` field is wired end to end or removed; public \
-configuration is fully effective and tested. `vsync`, `fullscreen`, and \
-`debug_paint` are unwired; `target_fps` is advisory; \
-`show_performance_overlay` ignores its option mask.\
+Public frame configuration is wired end to end or removed. `vsync` is unwired \
+and `target_fps` is advisory; neither governs the real presentation clock.\
 """
 state = "planned"
 domain = "application"
@@ -754,43 +892,35 @@ owner_issue = 556
 mechanical = true
 mechanism = "config_field entries below pin each field's non-stable classification"
 
-[[requirement]]
+[[contract]]
+key = "non-frame-app-config-effective-or-removed"
+statement = """
+Remaining public application configuration is effective and tested or removed. \
+`fullscreen` and `debug_paint` are unwired, while the performance overlay \
+ignores its option mask.\
+"""
+state = "planned"
+domain = "application"
+owner_issue = 565
+mechanical = true
+mechanism = "config_field entries below pin each field's non-stable classification"
+
+[[contract]]
 key = "timer-service-for-frozen-tickers"
-adr = "ADR-0029"
-section = "Occlusion semantics"
 statement = """
 Time-based UX (timeout-shaped animations) must not silently freeze with the \
 frame gate; a wall-clock timer service independent of the frame tick is the \
-named correctness seam. Explicitly not solved by ADR-0029.\
+named correctness seam. This is not solved by frame pacing.\
 """
 state = "planned"
 domain = "application"
 owner_issue = 556
 mechanical = false
 
-# =============================================================================
-# ADR-0039 — Event-loop affinity capability (Proposed)
-# =============================================================================
+# Event-loop affinity capability
 
-[[requirement]]
-key = "adr-0039-stays-proposed-until-validated"
-adr = "ADR-0039"
-section = "Status"
-statement = """
-ADR-0039 remains Proposed; its acceptance and implementation (trait split, \
-capability, proxy) belong to the owning issue. The checker fails if the \
-ADR's status line changes without going through that issue.\
-"""
-state = "planned"
-domain = "platform"
-owner_issue = 551
-mechanical = true
-mechanism = "the checker asserts the ADR file still carries the Proposed status line"
-
-[[requirement]]
+[[contract]]
 key = "owner-affinity-runtime-backstop"
-adr = "ADR-0039"
-section = "Slice 1"
 statement = """
 `OwnerAffinity` (bind-once owner thread, debug-assert on owner-affine \
 entry points) lives in `flui-foundation` with CI-run unit tests; macOS and \
@@ -809,10 +939,8 @@ evidence = [
     { kind = "symbol", file = "crates/flui-platform/src/platforms/windows/platform.rs", contains = "debug_assert_owner(\"WindowsPlatform::quit\")" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "owner-platform-capability"
-adr = "ADR-0039"
-section = "§1–§2 (slices 2–3)"
 statement = """
 Owner-thread-only platform operations move off the `Send + Sync` `Platform` \
 trait onto a `!Send + !Sync` `OwnerPlatform` capability handed to \
@@ -824,10 +952,8 @@ domain = "platform"
 owner_issue = 551
 mechanical = false
 
-[[requirement]]
+[[contract]]
 key = "platform-proxy-claim-slot"
-adr = "ADR-0039"
-section = "§3–§4 (PlatformProxy, PendingWindow, DrainGate)"
 statement = """
 Workers reach the owner through a typed, bounded `PlatformProxy` with \
 claim-slot at-most-once replies and per-backend drain-anchor gates. The \
@@ -843,15 +969,13 @@ evidence = [
     { kind = "symbol", file = "crates/flui-platform/src/platforms/winit/control.rs", contains = "enum ControlSendError" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "clipboard-stays-thread-safe"
-adr = "ADR-0039"
-section = "§5 clipboard position"
 statement = """
 `Clipboard` keeps `Send + Sync` and gets no owner-affinity asserts anywhere \
 — plain-text pasteboard operations are documented off-main-safe, and \
-asserting them would panic legitimate ADR-0034 callers. Supersedes \
-ADR-0034's suggested `MacOSClipboard` debug-assert.\
+asserting them would panic legitimate existing cross-thread callers. This \
+supersedes the earlier suggested `MacOSClipboard` debug assertion.\
 """
 state = "implemented"
 domain = "platform"
@@ -862,10 +986,8 @@ evidence = [
     { kind = "source-gate", file = "crates/flui-platform/src/platforms/macos/clipboard.rs", contains = "Clipboard" },
 ]
 
-[[requirement]]
+[[contract]]
 key = "pre-run-flows-migrate-to-on-ready"
-adr = "ADR-0039"
-section = "Slice 2 (pre-run bootstrap migrations)"
 statement = """
 Window creation before `Platform::run` (run_direct, Android bootstrap, web \
 bootstrap, Win32 examples) migrates inside `on_ready`, where every backend \
@@ -924,7 +1046,7 @@ owner = "application composition root (direct-engine escape hatch)"
 failure_semantics = "anyhow::Result; typed fast-fail before any window opens on winit (Linux)"
 consumers = ["examples/direct_render.rs", "examples/aa_showcase.rs"]
 owner_issue = 551
-notes = "Event-loop repair (on_ready reorder) is ADR-0039 slice 2. The checker pins the experimental marking."
+notes = "Event-loop repair (on_ready reorder) is issue #551. The checker pins the experimental marking."
 
 [[surface]]
 path = "flui_app::run_app_android / run_app_android_with_config"
@@ -933,7 +1055,7 @@ kind = "function"
 declared_in = "crates/flui-app/src/app/runner.rs"
 contains = "pub fn run_app_android"
 classification = "experimental"
-thread_affinity = "android_main thread; pre-run bootstrap creates the window/GPU before the loop, contra ADR-0039 slice 2"
+thread_affinity = "android_main thread; pre-run bootstrap creates the window/GPU before the loop, contra issue #551"
 owner = "application composition root (Android runner)"
 failure_semantics = "returns unit; bootstrap failures are logged"
 consumers = ["examples/android_demo (via its own bootstrap)"]
@@ -977,7 +1099,7 @@ owner = "application configuration"
 failure_semantics = "infallible builder; several fields are unwired or advisory (see [[config_field]])"
 consumers = ["run_app_with_config", "run_direct", "examples"]
 owner_issue = 556
-notes = "The type survives; its field set must become fully effective or shrink (ADR-0029 decision 4)."
+notes = "The type survives; its field set must become fully effective or shrink (the effective-configuration contract)."
 
 [[surface]]
 path = "flui_app::bindings re-export bundle (Scheduler, PipelineOwner, GestureBinding, WidgetsBinding, SemanticsBinding, PaintingBinding, RenderingFlutterBinding)"
@@ -1012,7 +1134,7 @@ kind = "trait"
 declared_in = "crates/flui-platform/src/traits/platform.rs"
 contains = "pub trait Platform: Send + Sync + 'static"
 classification = "transitional"
-thread_affinity = "declared Send + Sync, but open_window/quit/activate/displays/window_appearance are owner-thread-only on real OSes — the ADR-0039 defect"
+thread_affinity = "declared Send + Sync, but open_window/quit/activate/displays/window_appearance are owner-thread-only on real OSes — the owner-affinity defect"
 owner = "platform backend (one per process; consumed by run())"
 failure_semantics = "anyhow surface; owner-affinity violations are debug_assert-only (slice 1 backstop)"
 consumers = ["runner bootstrap", "run_direct", "examples"]
@@ -1030,7 +1152,7 @@ owner = "backend run() contract"
 failure_semantics = "infallible callback"
 consumers = ["all six backends", "runner"]
 owner_issue = 551
-notes = "ADR-0039 slice 2 flips this signature to carry OwnerPlatform by value — a breaking change across all backends."
+notes = "issue #551 flips this signature to carry OwnerPlatform by value — a breaking change across all backends."
 
 [[surface]]
 path = "flui_platform::current_platform"
@@ -1081,7 +1203,7 @@ contains = "pub struct Task<T>"
 classification = "removal-target"
 thread_affinity = "Send future wrapper"
 owner = "flagged parallel async definition; TaskToken (flui-scheduler) is the framework's one async mechanism"
-failure_semantics = "drop does not cancel — the defect ADR-0039 §2 refuses to entrench"
+failure_semantics = "drop does not cancel — the defect the owner-affinity contract refuses to entrench"
 consumers = ["prompt_for_paths (Windows)"]
 owner_issue = 557
 
@@ -1107,7 +1229,7 @@ contains = "pub use shared::{PlatformHandlers, WindowCallbacks}"
 classification = "transitional"
 thread_affinity = "callback storage behind mutexes; delivery on the owner thread"
 owner = "per-window / per-platform callback registries"
-failure_semantics = "install-only registration; ADR-0037 §10 requires cancellable registrations"
+failure_semantics = "install-only registration; the callback-lifetime contract requires cancellable registrations"
 consumers = ["all backends", "runner"]
 owner_issue = 551
 
@@ -1119,7 +1241,7 @@ declared_in = "crates/flui-foundation/src/affinity.rs"
 contains = "pub struct OwnerAffinity"
 classification = "experimental"
 thread_affinity = "Send + Sync value; binds one owner ThreadId once, debug-asserts elsewhere"
-owner = "ADR-0039 slice-1 runtime backstop — scaffolding under the future capability type, not the end state"
+owner = "runtime owner-affinity runtime backstop — scaffolding under the future capability type, not the end state"
 failure_semantics = "debug_assert on violation; release builds are unchecked"
 consumers = ["MacOSPlatform", "WindowsPlatform"]
 owner_issue = 551
@@ -1162,7 +1284,7 @@ owner = "fixed-rate vsync simulator — not display-derived pacing, and no produ
 failure_semantics = "typed construction error on zero refresh rate"
 consumers = ["none in production (tests and re-exports only)"]
 owner_issue = 556
-notes = "ADR-0029 moved real pacing to the blocking Fifo present; a fixed-rate simulator on the public surface misleads."
+notes = "the frame-pacing implementation moved real pacing to the blocking Fifo present; a fixed-rate simulator on the public surface misleads."
 
 [[surface]]
 path = "flui_scheduler::{FrameBudget, SharedBudget, BudgetPolicy}"
@@ -1172,7 +1294,7 @@ declared_in = "crates/flui-scheduler/src/budget.rs"
 contains = "pub struct FrameBudget"
 classification = "transitional"
 thread_affinity = "plain data behind the scheduler's mutex"
-owner = "60-FPS-default frame budget — the global default contract ADR-0027's split retires"
+owner = "60-FPS-default frame budget — the global default contract the runtime scheduling split retires"
 failure_semantics = "infallible; budget overruns are advisory statistics"
 consumers = ["Scheduler", "diagnostics"]
 owner_issue = 556
@@ -1198,7 +1320,7 @@ declared_in = "crates/flui-scheduler/src/post_frame.rs"
 contains = "pub struct PostFrameHandle"
 classification = "transitional"
 thread_affinity = "handle is Clone + Send + Sync; local lane is owner-affine; schedule_local accepts non-Send captures only in the active owner scope"
-owner = "post-frame callback lanes (ADR-0021 / ADR-0027 step 2a); the weak TLS ticket registry retires when the Scheduler becomes realm-owned"
+owner = "post-frame callback lanes; the weak TLS ticket registry retires when the Scheduler becomes realm-owned"
 failure_semantics = "typed LocalPostFrameScheduleError outside the owner scope"
 consumers = ["flui-view", "flui-widgets", "UiRealm"]
 owner_issue = 556
@@ -1243,7 +1365,7 @@ declared_in = "crates/flui-engine/src/raster_owner.rs"
 contains = "pub struct RasterHandle"
 classification = "experimental"
 thread_affinity = "RasterHandle is Send + Sync; RasterOwner is the single-threaded owner end"
-owner = "the ADR-0027 §5 mailbox protocol — implemented and threaded-tested, but with zero production consumers until the raster lane lands"
+owner = "the the raster mailbox contract mailbox protocol — implemented and threaded-tested, but with zero production consumers until the raster lane lands"
 failure_semantics = "typed RasterSubmitError {MailboxClosed, ...}; acks carry frame identity; shutdown is a one-shot handshake"
 consumers = ["threaded protocol tests only"]
 owner_issue = 559
@@ -1260,7 +1382,7 @@ owner = "per-presentation per-frame raster package — non_exhaustive, explicitl
 failure_semantics = "identity fields let receivers reject stale frames"
 consumers = ["RasterOwner protocol", "threaded tests"]
 owner_issue = 552
-notes = "Missing the PresentationId field ADR-0037 §2 requires; adding it is additive under non_exhaustive."
+notes = "Missing the PresentationId field the presentation-identity contract requires; adding it is additive under non_exhaustive."
 
 [[surface]]
 path = "flui_foundation::{RealmId, PresentationId, FrameEpoch, SurfaceGeneration, ResourceGeneration, GenerationGate}"
@@ -1282,7 +1404,7 @@ kind = "type"
 declared_in = "crates/flui-testing/src/lib.rs"
 contains = "pub struct HeadlessBinding"
 classification = "experimental"
-thread_affinity = "owner-thread create/use/drop; !Send + !Sync per ADR-0027's intentional break"
+thread_affinity = "owner-thread create/use/drop; !Send + !Sync per the owner-affinity contract"
 owner = "deterministic headless frame driver for tests"
 failure_semantics = "panics on misuse (test driver)"
 consumers = ["crate tests across the workspace", "screenshot example"]
@@ -1319,7 +1441,7 @@ owner_issue = 553
 #
 # The checker hard-requires `vsync` and `target_fps` to be present here and
 # to carry a non-stable classification — they must never be presented as
-# working stable configuration (ADR-0029 decision 4).
+# working stable configuration (the effective-configuration contract).
 
 [[config_field]]
 name = "vsync"
@@ -1425,21 +1547,40 @@ owner_issue = 553
 file = "crates/flui-app/src/app/binding.rs"
 reason = "AppBinding renderer/renderer_mut guards and render_pipeline_arc accessor"
 owner_issue = 553
+markers = [
+    "PORT-CHECK-OK-SP6: AppBinding renderer accessor",
+    "PORT-CHECK-OK-SP6: AppBinding renderer_mut accessor",
+    "PORT-CHECK-OK-SP6: AppBinding render_pipeline_arc accessor",
+]
 
 [[lock_exemption]]
 file = "crates/flui-scheduler/src/scheduler.rs"
 reason = "Scheduler::budget() returns a MutexGuard"
 owner_issue = 556
+markers = ["PORT-CHECK-OK-SP6: FrameBudget guard accessor"]
 
 [[lock_exemption]]
 file = "crates/flui-platform/src/platforms/windows/platform.rs"
 reason = "WindowsPlatform public handlers Arc<Mutex<PlatformHandlers>> field"
 owner_issue = 551
+markers = ["PORT-CHECK-OK-SP6: WindowsPlatform handlers"]
 
 [[lock_exemption]]
 file = "crates/flui-platform/src/shared/handlers.rs"
 reason = "PlatformHandlers public Mutex<Option<Box<dyn FnMut>>> callback storage"
 owner_issue = 551
+markers = [
+    "pub on_input: Mutex<Option<Box<dyn FnMut(PlatformInput)",
+    "pub on_request_frame: Mutex<Option<Box<dyn FnMut()",
+    "pub on_resize: Mutex<Option<Box<dyn FnMut(Size<Pixels>, f32)",
+    "pub on_moved: Mutex<Option<Box<dyn FnMut()",
+    "pub on_close: Mutex<Option<Box<dyn FnOnce()",
+    "pub on_should_close: Mutex<Option<Box<dyn FnMut() -> bool",
+    "pub on_active_status_change: Mutex<Option<Box<dyn FnMut(bool)",
+    "pub on_visibility_status_change: Mutex<Option<Box<dyn FnMut(bool)",
+    "pub on_hover_status_change: Mutex<Option<Box<dyn FnMut(bool)",
+    "pub on_appearance_changed: Mutex<Option<Box<dyn FnMut()",
+]
 
 # =============================================================================
 # Process-global guards (transitional; retire with the singletons)
@@ -1471,35 +1612,35 @@ owner_issue = 553
 
 [[forbidden_pattern]]
 pattern = "ForegroundExecutor"
-why = "ADR-0027 §9: the public generic UI-thread executor was deleted; the closed command vocabulary replaces it"
+why = "the closed-command contract: the public generic UI-thread executor was deleted; the closed command vocabulary replaces it"
 allow_files = []
 
 [[forbidden_pattern]]
 pattern = "TextInputPlatformBridge"
-why = "ADR-0037 §5: the IME intermediary object was deleted in favor of direct presentation ownership"
+why = "the presentation-owned text-input contract: the IME intermediary object was deleted in favor of direct presentation ownership"
 allow_files = []
 
 [[forbidden_pattern]]
 pattern = "OpaqueWindowHandle"
-why = "ADR-0037 §5: opaque-window storage plus downcast was deleted"
+why = "the presentation-owned text-input contract: opaque-window storage plus downcast was deleted"
 allow_files = []
 
 [[forbidden_pattern]]
 pattern = "TextInputRegistry"
-why = "ADR-0037 §5: the process-global text-input registry was deleted"
+why = "the presentation-owned text-input contract: the process-global text-input registry was deleted"
 allow_files = []
 
 [[forbidden_pattern]]
 pattern = "unsafe impl Sync for Renderer"
-why = "ADR-0027 §2: Renderer is Send + !Sync — a single mutator, never shared"
+why = "the renderer single-owner contract: Renderer is Send + !Sync — a single mutator, never shared"
 allow_files = []
 
 [[forbidden_pattern]]
 pattern = "debug_assert_owner"
 scope = "crates/flui-platform/src/platforms/macos/clipboard.rs"
-why = "ADR-0039 §5: clipboard operations are documented off-main-safe; an affinity assert would panic legitimate ADR-0034 callers"
+why = "the clipboard ownership contract: clipboard operations are documented off-main-safe; an affinity assert would panic legitimate existing cross-thread callers"
 allow_files = []
 
 [[forbidden_path]]
 path = "crates/flui-presentation"
-why = "ADR-0037 §12: no flui-presentation crate; flui-app privately composes the three owners"
+why = "the presentation composition contract: no flui-presentation crate; flui-app privately composes the three owners"

--- a/justfile
+++ b/justfile
@@ -314,6 +314,11 @@ doc-strict:
 inventory-check:
     bash scripts/check-workspace-inventory.sh
 
+[group("quality")]
+[doc("Validate the Runtime.1 conformance registry (docs/runtime-conformance.toml) against the source tree")]
+runtime-conformance-check:
+    bash scripts/check-runtime-conformance.sh
+
 # =============================================================================
 # Port methodology
 # =============================================================================
@@ -476,8 +481,8 @@ watch-test crate="":
 #   just deny             (advisories / bans / licenses / sources)
 #   just miri             (nightly UB check, narrow scope — see its comment)
 [group("ci")]
-[doc("Run local CI gates (fmt-check + inventory + port-check + clippy + test + doctests + rustdoc)")]
-ci: fmt-check inventory-check port-check clippy test-ci test-doc doc-strict
+[doc("Run local CI gates (fmt-check + inventory + runtime-conformance + port-check + clippy + test + doctests + rustdoc)")]
+ci: fmt-check inventory-check runtime-conformance-check port-check clippy test-ci test-doc doc-strict
 
 # =============================================================================
 # Maintenance

--- a/justfile
+++ b/justfile
@@ -315,7 +315,7 @@ inventory-check:
     bash scripts/check-workspace-inventory.sh
 
 [group("quality")]
-[doc("Validate the Runtime.1 conformance registry (docs/runtime-conformance.toml) against the source tree")]
+[doc("Validate the Runtime contract registry (docs/runtime-contract.toml) against the source tree")]
 runtime-conformance-check:
     bash scripts/check-runtime-conformance.sh
 

--- a/scripts/check-runtime-conformance.sh
+++ b/scripts/check-runtime-conformance.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Validate the Runtime.1 conformance registry (docs/runtime-conformance.toml)
+# Validate the Runtime contract registry (docs/runtime-contract.toml)
 # against the source tree.
 #
-# This is the executable half of the Runtime.1 conformance matrix: the
-# registry records what each runtime ADR clause's state actually is and how
-# every public runtime surface is classified; this script keeps those claims
-# honest. It follows the same shape as scripts/check-workspace-inventory.sh —
+# This is the executable half of the Runtime.1 public contract registry: it
+# records shipped invariants, planned ownership, and classified public runtime
+# boundary families without depending on internal design records. It follows
+# the same shape as scripts/check-workspace-inventory.sh —
 # a thin bash wrapper around an embedded python3 program using the stdlib
 # structural TOML parser (tomllib), never regexes-over-TOML.
 #
@@ -19,14 +19,11 @@
 #     string. A `contains` match proves the symbol/test still exists at that
 #     path — it does NOT prove behavior. Behavior lives in the cited tests,
 #     which `just test` executes.
-#   * Source gates: retired identifiers stay deleted, `run_direct` keeps its
-#     experimental marking, ADR-0039 stays Proposed, no `flui-presentation`
-#     crate appears, and new ambient singletons / public lock-shaped surfaces
-#     in the runtime crates must be registered with an owner. The singleton
-#     and lock nets are textual (`impl_binding_singleton!`, `fn instance() ->
-#     &'static`, `PORT-CHECK-OK-SP6`): a singleton built without those idioms,
-#     or a lock surface port-check trigger #12's grammar misses, is invisible
-#     to them. This is a targeted gate, not full Rust API analysis.
+#   * Source gates: root export declarations are compared with an explicit
+#     manifest; retired identifiers stay deleted; `run_direct` keeps its
+#     experimental marking; and ambient singletons / public lock exceptions
+#     are matched declaration-by-declaration. This is a targeted boundary
+#     gate, not a claim that source text is a Rust semantic API analyzer.
 
 set -euo pipefail
 
@@ -40,12 +37,13 @@ if ! command -v python3 >/dev/null 2>&1; then
 fi
 
 python3 - "${repo_root}" <<'PY'
+import re
 import sys
 import tomllib
 from pathlib import Path
 
 root = Path(sys.argv[1]).resolve()
-registry_path = root / "docs" / "runtime-conformance.toml"
+registry_path = root / "docs" / "runtime-contract.toml"
 registry_rel = registry_path.relative_to(root)
 
 errors: list[str] = []
@@ -63,27 +61,13 @@ except (OSError, tomllib.TOMLDecodeError) as error:
     sys.exit(1)
 
 # ---------------------------------------------------------------------------
-# Contract vocabulary. The registry's [registry] header must agree, so the
-# file and this script cannot drift apart silently.
+# Contract vocabulary.
 # ---------------------------------------------------------------------------
-ADR_SCOPE = ["ADR-0027", "ADR-0037", "ADR-0029", "ADR-0039"]
 VALID_STATES = {"implemented", "partial", "planned", "documented-divergence"}
 VALID_CLASSIFICATIONS = {"stable-candidate", "experimental", "transitional", "removal-target"}
 VALID_DOMAINS = {"application", "realm", "presentation", "raster", "platform", "shared-engine"}
 VALID_EVIDENCE_KINDS = {"symbol", "test", "compile-time", "source-gate"}
 OWNER_ISSUE_MIN, OWNER_ISSUE_MAX = 551, 565
-
-# Floors, not proof of completeness: deleting requirement entries below these
-# counts fails; whether every normative clause is represented remains an
-# editorial judgment recorded in the entries themselves.
-MIN_REQUIREMENTS_PER_ADR = {"ADR-0027": 19, "ADR-0037": 12, "ADR-0029": 7, "ADR-0039": 6}
-
-ADR_FILES = {
-    "ADR-0027": "docs/adr/ADR-0027-owner-affine-ui-realms.md",
-    "ADR-0037": "docs/adr/ADR-0037-presentation-ownership-domains.md",
-    "ADR-0029": "docs/adr/ADR-0029-frame-pacing-swapchain-block-with-fallback-throttle.md",
-    "ADR-0039": "docs/adr/ADR-0039-event-loop-affinity-capability.md",
-}
 
 # Runtime crates covered by the singleton and lock-surface nets.
 RUNTIME_CRATES = ["flui-app", "flui-scheduler", "flui-platform", "flui-engine"]
@@ -93,15 +77,25 @@ RUNTIME_CRATES = ["flui-app", "flui-scheduler", "flui-platform", "flui-engine"]
 SINGLETON_NET_EXEMPT = {Path("crates/flui-foundation/src/binding.rs")}
 
 header = registry.get("registry", {})
-if header.get("adr_scope") != ADR_SCOPE:
-    fail(
-        f"{registry_rel} [registry].adr_scope = {header.get('adr_scope')!r} does not match "
-        f"this script's contract {ADR_SCOPE!r} — update both together, deliberately"
-    )
+if not isinstance(header, dict):
+    fail(f"{registry_rel} [registry] must be a table")
+    header = {}
+if header.get("schema") != 1:
+    fail(f"{registry_rel} [registry].schema must be 1")
 
-for adr, rel in ADR_FILES.items():
-    if not (root / rel).is_file():
-        fail(f"{rel} is missing, but {adr} is in the conformance scope")
+
+def table_array(name: str) -> list[dict]:
+    value = registry.get(name, [])
+    if not isinstance(value, list):
+        fail(f"{registry_rel} `{name}` must be an array of tables (`[[{name}]]`)")
+        return []
+    result: list[dict] = []
+    for index, entry in enumerate(value):
+        if not isinstance(entry, dict):
+            fail(f"{registry_rel} {name}[{index}] must be a table")
+            continue
+        result.append(entry)
+    return result
 
 
 def check_owner_issue(entry: dict, label: str, required: bool) -> None:
@@ -110,7 +104,7 @@ def check_owner_issue(entry: dict, label: str, required: bool) -> None:
         if required:
             fail(f"{label} has no owning issue; partial/planned/transitional work needs exactly one owner in #{OWNER_ISSUE_MIN}-#{OWNER_ISSUE_MAX}")
         return
-    if not isinstance(issue, int) or not (OWNER_ISSUE_MIN <= issue <= OWNER_ISSUE_MAX):
+    if isinstance(issue, bool) or not isinstance(issue, int) or not (OWNER_ISSUE_MIN <= issue <= OWNER_ISSUE_MAX):
         fail(f"{label} declares owner_issue {issue!r}; expected an integer in {OWNER_ISSUE_MIN}-{OWNER_ISSUE_MAX}")
 
 
@@ -129,7 +123,10 @@ def check_citation(file_value: object, contains_value: object, label: str, *, fo
     if forbid_docs and file_value.endswith((".md", ".markdown")):
         fail(f"{label} cites documentation ({file_value}) — documentation is never implementation evidence")
         return
-    path = root / file_value
+    path = (root / file_value).resolve()
+    if not path.is_relative_to(root):
+        fail(f"{label} cites path outside the repository: {file_value}")
+        return
     if not path.is_file():
         fail(f"{label} cites {file_value}, which does not exist")
         return
@@ -143,43 +140,33 @@ def check_citation(file_value: object, contains_value: object, label: str, *, fo
 
 
 # ---------------------------------------------------------------------------
-# Requirements
+# Contracts
 # ---------------------------------------------------------------------------
-requirement_keys: set[str] = set()
-requirements_by_adr: dict[str, int] = {adr: 0 for adr in ADR_SCOPE}
-requirements = registry.get("requirement", [])
+contract_keys: set[str] = set()
+contracts_by_state: dict[str, int] = {state: 0 for state in VALID_STATES}
+contracts = table_array("contract")
 
 # Descriptive kebab-case keys only. Internal process-ID shapes (SC-NNN, U##,
 # T-N/R-N/E-N, P#) are banned by the repo's Agent Rules.
-import re
-
 KEY_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)+$")
 BANNED_KEY_RE = re.compile(r"(^|-)((sc|u|t|r|e|p)-?\d+)($|-)", re.IGNORECASE)
 
-for index, entry in enumerate(requirements):
+for index, entry in enumerate(contracts):
     key = entry.get("key")
-    label = f"{registry_rel} requirement[{index}]"
+    label = f"{registry_rel} contract[{index}]"
     if not isinstance(key, str) or not key:
         fail(f"{label} has an empty or missing key")
         continue
-    label = f"{registry_rel} requirement `{key}`"
-    if key in requirement_keys:
+    label = f"{registry_rel} contract `{key}`"
+    if key in contract_keys:
         fail(f"{label} is declared more than once")
         continue
-    requirement_keys.add(key)
+    contract_keys.add(key)
     if not KEY_RE.match(key):
         fail(f"{label}: keys are descriptive kebab-case (`focus-per-presentation`), got {key!r}")
     if BANNED_KEY_RE.search(key):
         fail(f"{label}: numbered process-ID keys are banned by the repo's Agent Rules; use a descriptive key")
 
-    adr = entry.get("adr")
-    if adr not in ADR_SCOPE:
-        fail(f"{label} names ADR {adr!r}, which is not in the conformance scope {ADR_SCOPE}")
-    else:
-        requirements_by_adr[adr] += 1
-
-    if not str(entry.get("section", "")).strip():
-        fail(f"{label} has no ADR section reference")
     if not str(entry.get("statement", "")).strip():
         fail(f"{label} has no normative statement")
 
@@ -187,6 +174,7 @@ for index, entry in enumerate(requirements):
     if state not in VALID_STATES:
         fail(f"{label} declares state {state!r}; expected one of {sorted(VALID_STATES)}")
         continue
+    contracts_by_state[state] += 1
 
     domain = entry.get("domain")
     if domain not in VALID_DOMAINS:
@@ -206,6 +194,9 @@ for index, entry in enumerate(requirements):
     kinds_seen: set[str] = set()
     for citation_index, citation in enumerate(evidence):
         citation_label = f"{label} evidence[{citation_index}]"
+        if not isinstance(citation, dict):
+            fail(f"{citation_label} must be a table")
+            continue
         kind = citation.get("kind")
         if kind not in VALID_EVIDENCE_KINDS:
             fail(f"{citation_label} declares kind {kind!r}; expected one of {sorted(VALID_EVIDENCE_KINDS)}")
@@ -222,22 +213,15 @@ for index, entry in enumerate(requirements):
     elif state in {"partial", "planned"}:
         check_owner_issue(entry, label, required=True)
     elif state == "documented-divergence":
-        if not str(entry.get("divergence", entry.get("statement", ""))).strip():
+        if not str(entry.get("divergence", "")).strip():
             fail(f"{label} is a documented divergence with no divergence description")
-
-for adr, minimum in MIN_REQUIREMENTS_PER_ADR.items():
-    if requirements_by_adr.get(adr, 0) < minimum:
-        fail(
-            f"{registry_rel} carries {requirements_by_adr.get(adr, 0)} requirements for {adr}, "
-            f"below the recorded floor of {minimum} — requirements may be reworded, not silently dropped"
-        )
 
 # ---------------------------------------------------------------------------
 # Public surfaces
 # ---------------------------------------------------------------------------
 surface_paths: set[str] = set()
 run_direct_surface: dict | None = None
-for index, entry in enumerate(registry.get("surface", [])):
+for index, entry in enumerate(table_array("surface")):
     path_value = entry.get("path")
     label = f"{registry_rel} surface[{index}]"
     if not isinstance(path_value, str) or not path_value:
@@ -267,6 +251,75 @@ for index, entry in enumerate(registry.get("surface", [])):
     if path_value == "flui_app::run_direct":
         run_direct_surface = entry
 
+# ---------------------------------------------------------------------------
+# Root export manifest
+# ---------------------------------------------------------------------------
+def root_public_declarations(path: Path) -> list[str]:
+    """Return normalized column-zero `pub` declarations from one crate root.
+
+    The manifest intentionally controls export roots, not every item reachable
+    through a public module. Full Rust semantic API extraction requires
+    unstable rustdoc JSON on the pinned toolchain; module families are
+    classified above and their root growth is kept review-visible here.
+    """
+    lines = path.read_text().splitlines()
+    declarations: list[str] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index].split("//", 1)[0].rstrip()
+        if not line.startswith("pub "):
+            index += 1
+            continue
+        parts = [line.strip()]
+        is_use = line.startswith("pub use ")
+        while True:
+            joined = " ".join(parts)
+            if ";" in joined or (not is_use and "{" in joined):
+                break
+            index += 1
+            if index >= len(lines):
+                break
+            continued = lines[index].split("//", 1)[0].strip()
+            if continued:
+                parts.append(continued)
+        declarations.append(" ".join(" ".join(parts).split()))
+        index += 1
+    return declarations
+
+
+export_root_files: set[Path] = set()
+for index, entry in enumerate(table_array("export_root")):
+    label = f"{registry_rel} export_root[{index}]"
+    file_value = entry.get("file")
+    expected = entry.get("declarations")
+    if not isinstance(file_value, str) or not file_value:
+        fail(f"{label} has no file path")
+        continue
+    rel = Path(file_value)
+    if rel in export_root_files:
+        fail(f"{label} duplicates export root {file_value}")
+        continue
+    export_root_files.add(rel)
+    path = root / rel
+    if not path.is_file():
+        fail(f"{label} names missing file {file_value}")
+        continue
+    if not isinstance(expected, list) or not all(isinstance(item, str) and item for item in expected):
+        fail(f"{label} declarations must be a list of non-empty strings")
+        continue
+    if len(expected) != len(set(expected)):
+        fail(f"{label} declarations contain duplicates")
+    actual = root_public_declarations(path)
+    missing = sorted(set(expected) - set(actual))
+    unregistered = sorted(set(actual) - set(expected))
+    for declaration in missing:
+        fail(f"{file_value} no longer exports registered root declaration {declaration!r}")
+    for declaration in unregistered:
+        fail(
+            f"{file_value} has unregistered root export {declaration!r} — classify its boundary family "
+            "and update the explicit export manifest"
+        )
+
 # run_direct must stay registered, experimental, and marked in its module docs.
 if run_direct_surface is None:
     fail(f"{registry_rel} no longer registers surface `flui_app::run_direct`")
@@ -280,15 +333,7 @@ direct_rs = root / "crates" / "flui-app" / "src" / "app" / "direct.rs"
 if not direct_rs.is_file():
     fail("crates/flui-app/src/app/direct.rs is gone; remove or update the run_direct gates deliberately")
 elif "experimental" not in direct_rs.read_text().lower():
-    fail("crates/flui-app/src/app/direct.rs no longer marks run_direct as experimental — ADR-0039 slice 2 owns its stabilization")
-
-# ADR-0039 acceptance belongs to its owning issue; the file must stay Proposed.
-adr_0039 = root / ADR_FILES["ADR-0039"]
-if adr_0039.is_file() and "**Status:** Proposed" not in adr_0039.read_text():
-    fail(
-        f"{ADR_FILES['ADR-0039']} no longer carries `**Status:** Proposed` — accepting/implementing "
-        "ADR-0039 belongs to its owning issue, and this gate plus the registry must be updated with it"
-    )
+    fail("crates/flui-app/src/app/direct.rs no longer marks run_direct as experimental — issue #551 owns its stabilization")
 
 # ---------------------------------------------------------------------------
 # Known advisory / unwired configuration must never look stable.
@@ -299,7 +344,7 @@ VALID_CONFIG_STATUSES = {"unwired", "advisory", "partially-wired"}
 REQUIRED_ADVISORY_FIELDS = {"vsync", "target_fps"}
 
 config_fields: dict[str, dict] = {}
-for index, entry in enumerate(registry.get("config_field", [])):
+for index, entry in enumerate(table_array("config_field")):
     name = entry.get("name")
     label = f"{registry_rel} config_field[{index}]"
     if not isinstance(name, str) or not name:
@@ -333,13 +378,15 @@ for required in sorted(REQUIRED_ADVISORY_FIELDS):
 # Ambient singleton net: every impl_binding_singleton!/manual instance() in
 # the runtime crates must be registered with an owning issue.
 # ---------------------------------------------------------------------------
-singleton_exemptions: dict[Path, dict] = {}
-for index, entry in enumerate(registry.get("singleton_exemption", [])):
+singleton_exemptions: dict[Path, list[str]] = {}
+for index, entry in enumerate(table_array("singleton_exemption")):
     label = f"{registry_rel} singleton_exemption[{index}] `{entry.get('symbol', '?')}`"
-    check_citation(entry.get("file"), entry.get("contains"), label)
+    file_value = entry.get("file")
+    contains = entry.get("contains")
+    check_citation(file_value, contains, label)
     check_owner_issue(entry, label, required=True)
-    if isinstance(entry.get("file"), str):
-        singleton_exemptions[Path(entry["file"])] = entry
+    if isinstance(file_value, str) and isinstance(contains, str):
+        singleton_exemptions.setdefault(Path(file_value), []).append(contains)
 
 SINGLETON_MARKERS = ("impl_binding_singleton!(", "fn instance() -> &'static")
 for crate in RUNTIME_CRATES + [
@@ -357,12 +404,20 @@ for crate in RUNTIME_CRATES + [
             text = rs_file.read_text()
         except (OSError, UnicodeDecodeError):
             continue
-        for marker in SINGLETON_MARKERS:
-            if marker in text and rel not in singleton_exemptions:
+        expected = singleton_exemptions.get(rel, [])
+        for contains in expected:
+            count = text.count(contains)
+            if count != 1:
+                fail(f"{rel} must contain registered singleton declaration {contains!r} exactly once; found {count}")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            marker = next((candidate for candidate in SINGLETON_MARKERS if candidate in line), None)
+            if marker is None:
+                continue
+            matches = [contains for contains in expected if contains in line]
+            if len(matches) != 1:
                 fail(
-                    f"{rel} contains `{marker}` but is not in the registry's singleton allowlist — "
-                    "a new ambient singleton cannot land without an owning issue "
-                    "(ADR-0027: singleton retirement)"
+                    f"{rel}:{line_number} contains singleton marker `{marker}` but matches "
+                    f"{len(matches)} registered declarations — every ambient singleton needs its own exact entry"
                 )
 
 # ---------------------------------------------------------------------------
@@ -371,8 +426,8 @@ for crate in RUNTIME_CRATES + [
 # scripts/port-check.sh forces the marker onto any public lock surface its
 # grammar can see; this gate forces the marker's file into the registry.)
 # ---------------------------------------------------------------------------
-lock_exempt_files = set()
-for index, entry in enumerate(registry.get("lock_exemption", [])):
+lock_exemptions: dict[Path, list[str]] = {}
+for index, entry in enumerate(table_array("lock_exemption")):
     label = f"{registry_rel} lock_exemption[{index}] `{entry.get('file', '?')}`"
     file_value = entry.get("file")
     if not isinstance(file_value, str) or not (root / file_value).is_file():
@@ -381,7 +436,11 @@ for index, entry in enumerate(registry.get("lock_exemption", [])):
     if not str(entry.get("reason", "")).strip():
         fail(f"{label} has no reason")
     check_owner_issue(entry, label, required=True)
-    lock_exempt_files.add(Path(file_value))
+    markers = entry.get("markers")
+    if not isinstance(markers, list) or not markers or not all(isinstance(marker, str) and marker for marker in markers):
+        fail(f"{label} must declare a non-empty string list `markers`")
+        continue
+    lock_exemptions.setdefault(Path(file_value), []).extend(markers)
 
 for crate in RUNTIME_CRATES:
     crate_src = root / "crates" / crate / "src"
@@ -393,16 +452,25 @@ for crate in RUNTIME_CRATES:
             text = rs_file.read_text()
         except (OSError, UnicodeDecodeError):
             continue
-        if "PORT-CHECK-OK-SP6" in text and rel not in lock_exempt_files:
-            fail(
-                f"{rel} carries a PORT-CHECK-OK-SP6 lock exemption but is not in the registry's "
-                "lock allowlist — a public lock-shaped runtime surface needs an owning issue (SP-6)"
-            )
+        expected = lock_exemptions.get(rel, [])
+        for marker in expected:
+            count = text.count(marker)
+            if count != 1:
+                fail(f"{rel} must contain registered lock marker {marker!r} exactly once; found {count}")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if "PORT-CHECK-OK-SP6" not in line:
+                continue
+            matches = [marker for marker in expected if marker in line]
+            if len(matches) != 1:
+                fail(
+                    f"{rel}:{line_number} carries a lock exemption but matches {len(matches)} registered markers — "
+                    "every public lock-shaped declaration needs its own exact entry"
+                )
 
 # ---------------------------------------------------------------------------
 # Process-global guards: existence-pinned so retirement updates the registry.
 # ---------------------------------------------------------------------------
-for index, entry in enumerate(registry.get("process_global_guard", [])):
+for index, entry in enumerate(table_array("process_global_guard")):
     label = f"{registry_rel} process_global_guard `{entry.get('symbol', '?')}`"
     check_citation(entry.get("file"), entry.get("contains"), label)
     check_owner_issue(entry, label, required=True)
@@ -416,7 +484,7 @@ all_rs_files: list[Path] = [
     p for p in sorted((root / "crates").rglob("*.rs")) if "target" not in p.relative_to(root).parts
 ]
 
-for index, entry in enumerate(registry.get("forbidden_pattern", [])):
+for index, entry in enumerate(table_array("forbidden_pattern")):
     pattern = entry.get("pattern")
     label = f"{registry_rel} forbidden_pattern[{index}]"
     if not isinstance(pattern, str) or not pattern:
@@ -442,7 +510,7 @@ for index, entry in enumerate(registry.get("forbidden_pattern", [])):
         if pattern in text:
             fail(f"{rel} contains forbidden pattern `{pattern}`: {' '.join(str(entry.get('why', '')).split())}")
 
-for index, entry in enumerate(registry.get("forbidden_path", [])):
+for index, entry in enumerate(table_array("forbidden_path")):
     path_value = entry.get("path")
     if not isinstance(path_value, str) or not path_value:
         fail(f"{registry_rel} forbidden_path[{index}] has an empty path")
@@ -460,11 +528,12 @@ if errors:
     sys.exit(1)
 
 surface_count = len(surface_paths)
-requirement_count = len(requirement_keys)
-by_adr = ", ".join(f"{adr} {count}" for adr, count in requirements_by_adr.items())
+contract_count = len(contract_keys)
+by_state = ", ".join(f"{state} {contracts_by_state[state]}" for state in sorted(contracts_by_state))
 print(
-    f"runtime-conformance: {requirement_count} requirements ({by_adr}); "
+    f"runtime-conformance: {contract_count} contracts ({by_state}); "
     f"{surface_count} classified surfaces; {len(config_fields)} config fields; "
-    f"{len(singleton_exemptions)} singleton + {len(lock_exempt_files)} lock exemptions verified"
+    f"{sum(map(len, singleton_exemptions.values()))} singleton + "
+    f"{sum(map(len, lock_exemptions.values()))} lock declarations verified"
 )
 PY

--- a/scripts/check-runtime-conformance.sh
+++ b/scripts/check-runtime-conformance.sh
@@ -1,0 +1,470 @@
+#!/usr/bin/env bash
+# Validate the Runtime.1 conformance registry (docs/runtime-conformance.toml)
+# against the source tree.
+#
+# This is the executable half of the Runtime.1 conformance matrix: the
+# registry records what each runtime ADR clause's state actually is and how
+# every public runtime surface is classified; this script keeps those claims
+# honest. It follows the same shape as scripts/check-workspace-inventory.sh —
+# a thin bash wrapper around an embedded python3 program using the stdlib
+# structural TOML parser (tomllib), never regexes-over-TOML.
+#
+# What it verifies — and, deliberately documented, what it cannot:
+#
+#   * Registry integrity: known states/classifications/domains, unique
+#     non-empty descriptive keys, evidence present for `implemented`, exactly
+#     one owning issue (#551-#565) for `partial`/`planned`, no documentation
+#     files cited as implementation evidence.
+#   * Citation existence: every cited file exists and contains the cited
+#     string. A `contains` match proves the symbol/test still exists at that
+#     path — it does NOT prove behavior. Behavior lives in the cited tests,
+#     which `just test` executes.
+#   * Source gates: retired identifiers stay deleted, `run_direct` keeps its
+#     experimental marking, ADR-0039 stays Proposed, no `flui-presentation`
+#     crate appears, and new ambient singletons / public lock-shaped surfaces
+#     in the runtime crates must be registered with an owner. The singleton
+#     and lock nets are textual (`impl_binding_singleton!`, `fn instance() ->
+#     &'static`, `PORT-CHECK-OK-SP6`): a singleton built without those idioms,
+#     or a lock surface port-check trigger #12's grammar misses, is invisible
+#     to them. This is a targeted gate, not full Rust API analysis.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+cd "${repo_root}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "runtime-conformance: python3 not found on PATH" >&2
+  exit 2
+fi
+
+python3 - "${repo_root}" <<'PY'
+import sys
+import tomllib
+from pathlib import Path
+
+root = Path(sys.argv[1]).resolve()
+registry_path = root / "docs" / "runtime-conformance.toml"
+registry_rel = registry_path.relative_to(root)
+
+errors: list[str] = []
+
+
+def fail(message: str) -> None:
+    errors.append(message)
+
+
+try:
+    registry = tomllib.loads(registry_path.read_text())
+except (OSError, tomllib.TOMLDecodeError) as error:
+    print("runtime-conformance: violations detected", file=sys.stderr)
+    print(f"  - cannot load {registry_rel}: {error}", file=sys.stderr)
+    sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# Contract vocabulary. The registry's [registry] header must agree, so the
+# file and this script cannot drift apart silently.
+# ---------------------------------------------------------------------------
+ADR_SCOPE = ["ADR-0027", "ADR-0037", "ADR-0029", "ADR-0039"]
+VALID_STATES = {"implemented", "partial", "planned", "documented-divergence"}
+VALID_CLASSIFICATIONS = {"stable-candidate", "experimental", "transitional", "removal-target"}
+VALID_DOMAINS = {"application", "realm", "presentation", "raster", "platform", "shared-engine"}
+VALID_EVIDENCE_KINDS = {"symbol", "test", "compile-time", "source-gate"}
+OWNER_ISSUE_MIN, OWNER_ISSUE_MAX = 551, 565
+
+# Floors, not proof of completeness: deleting requirement entries below these
+# counts fails; whether every normative clause is represented remains an
+# editorial judgment recorded in the entries themselves.
+MIN_REQUIREMENTS_PER_ADR = {"ADR-0027": 19, "ADR-0037": 12, "ADR-0029": 7, "ADR-0039": 6}
+
+ADR_FILES = {
+    "ADR-0027": "docs/adr/ADR-0027-owner-affine-ui-realms.md",
+    "ADR-0037": "docs/adr/ADR-0037-presentation-ownership-domains.md",
+    "ADR-0029": "docs/adr/ADR-0029-frame-pacing-swapchain-block-with-fallback-throttle.md",
+    "ADR-0039": "docs/adr/ADR-0039-event-loop-affinity-capability.md",
+}
+
+# Runtime crates covered by the singleton and lock-surface nets.
+RUNTIME_CRATES = ["flui-app", "flui-scheduler", "flui-platform", "flui-engine"]
+
+# The macro-defining file: holds the definition, doc examples, and cfg(test)
+# invocations of impl_binding_singleton!; exempt from the singleton net.
+SINGLETON_NET_EXEMPT = {Path("crates/flui-foundation/src/binding.rs")}
+
+header = registry.get("registry", {})
+if header.get("adr_scope") != ADR_SCOPE:
+    fail(
+        f"{registry_rel} [registry].adr_scope = {header.get('adr_scope')!r} does not match "
+        f"this script's contract {ADR_SCOPE!r} — update both together, deliberately"
+    )
+
+for adr, rel in ADR_FILES.items():
+    if not (root / rel).is_file():
+        fail(f"{rel} is missing, but {adr} is in the conformance scope")
+
+
+def check_owner_issue(entry: dict, label: str, required: bool) -> None:
+    issue = entry.get("owner_issue")
+    if issue is None:
+        if required:
+            fail(f"{label} has no owning issue; partial/planned/transitional work needs exactly one owner in #{OWNER_ISSUE_MIN}-#{OWNER_ISSUE_MAX}")
+        return
+    if not isinstance(issue, int) or not (OWNER_ISSUE_MIN <= issue <= OWNER_ISSUE_MAX):
+        fail(f"{label} declares owner_issue {issue!r}; expected an integer in {OWNER_ISSUE_MIN}-{OWNER_ISSUE_MAX}")
+
+
+def check_citation(file_value: object, contains_value: object, label: str, *, forbid_docs: bool = False) -> None:
+    """A citation names a real file containing the cited string.
+
+    Existence + substring only: this proves the cited symbol/test is still
+    there, not that it behaves as claimed.
+    """
+    if not isinstance(file_value, str) or not file_value:
+        fail(f"{label} has no file path")
+        return
+    if not isinstance(contains_value, str) or not contains_value:
+        fail(f"{label} has no `contains` string")
+        return
+    if forbid_docs and file_value.endswith((".md", ".markdown")):
+        fail(f"{label} cites documentation ({file_value}) — documentation is never implementation evidence")
+        return
+    path = root / file_value
+    if not path.is_file():
+        fail(f"{label} cites {file_value}, which does not exist")
+        return
+    try:
+        text = path.read_text()
+    except (OSError, UnicodeDecodeError) as error:
+        fail(f"{label} cites {file_value}, which cannot be read: {error}")
+        return
+    if contains_value not in text:
+        fail(f"{label}: {file_value} does not contain {contains_value!r} — the citation is stale or fabricated")
+
+
+# ---------------------------------------------------------------------------
+# Requirements
+# ---------------------------------------------------------------------------
+requirement_keys: set[str] = set()
+requirements_by_adr: dict[str, int] = {adr: 0 for adr in ADR_SCOPE}
+requirements = registry.get("requirement", [])
+
+# Descriptive kebab-case keys only. Internal process-ID shapes (SC-NNN, U##,
+# T-N/R-N/E-N, P#) are banned by the repo's Agent Rules.
+import re
+
+KEY_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)+$")
+BANNED_KEY_RE = re.compile(r"(^|-)((sc|u|t|r|e|p)-?\d+)($|-)", re.IGNORECASE)
+
+for index, entry in enumerate(requirements):
+    key = entry.get("key")
+    label = f"{registry_rel} requirement[{index}]"
+    if not isinstance(key, str) or not key:
+        fail(f"{label} has an empty or missing key")
+        continue
+    label = f"{registry_rel} requirement `{key}`"
+    if key in requirement_keys:
+        fail(f"{label} is declared more than once")
+        continue
+    requirement_keys.add(key)
+    if not KEY_RE.match(key):
+        fail(f"{label}: keys are descriptive kebab-case (`focus-per-presentation`), got {key!r}")
+    if BANNED_KEY_RE.search(key):
+        fail(f"{label}: numbered process-ID keys are banned by the repo's Agent Rules; use a descriptive key")
+
+    adr = entry.get("adr")
+    if adr not in ADR_SCOPE:
+        fail(f"{label} names ADR {adr!r}, which is not in the conformance scope {ADR_SCOPE}")
+    else:
+        requirements_by_adr[adr] += 1
+
+    if not str(entry.get("section", "")).strip():
+        fail(f"{label} has no ADR section reference")
+    if not str(entry.get("statement", "")).strip():
+        fail(f"{label} has no normative statement")
+
+    state = entry.get("state")
+    if state not in VALID_STATES:
+        fail(f"{label} declares state {state!r}; expected one of {sorted(VALID_STATES)}")
+        continue
+
+    domain = entry.get("domain")
+    if domain not in VALID_DOMAINS:
+        fail(f"{label} declares domain {domain!r}; expected one of {sorted(VALID_DOMAINS)}")
+
+    mechanical = entry.get("mechanical")
+    if not isinstance(mechanical, bool):
+        fail(f"{label} must declare `mechanical = true/false` (is the clause mechanically checkable?)")
+    elif mechanical and not str(entry.get("mechanism", "")).strip():
+        fail(f"{label} claims to be mechanically checkable but names no mechanism")
+
+    evidence = entry.get("evidence", [])
+    if not isinstance(evidence, list):
+        fail(f"{label} evidence must be a list of citations")
+        evidence = []
+
+    kinds_seen: set[str] = set()
+    for citation_index, citation in enumerate(evidence):
+        citation_label = f"{label} evidence[{citation_index}]"
+        kind = citation.get("kind")
+        if kind not in VALID_EVIDENCE_KINDS:
+            fail(f"{citation_label} declares kind {kind!r}; expected one of {sorted(VALID_EVIDENCE_KINDS)}")
+            continue
+        kinds_seen.add(kind)
+        check_citation(citation.get("file"), citation.get("contains"), citation_label, forbid_docs=(state == "implemented"))
+
+    if state == "implemented":
+        if "symbol" not in kinds_seen:
+            fail(f"{label} is `implemented` but cites no production symbol")
+        if not kinds_seen & {"test", "compile-time", "source-gate"}:
+            fail(f"{label} is `implemented` but cites no test/compile-time/source-gate evidence — an unverified claim is a hypothesis")
+        check_owner_issue(entry, label, required=False)
+    elif state in {"partial", "planned"}:
+        check_owner_issue(entry, label, required=True)
+    elif state == "documented-divergence":
+        if not str(entry.get("divergence", entry.get("statement", ""))).strip():
+            fail(f"{label} is a documented divergence with no divergence description")
+
+for adr, minimum in MIN_REQUIREMENTS_PER_ADR.items():
+    if requirements_by_adr.get(adr, 0) < minimum:
+        fail(
+            f"{registry_rel} carries {requirements_by_adr.get(adr, 0)} requirements for {adr}, "
+            f"below the recorded floor of {minimum} — requirements may be reworded, not silently dropped"
+        )
+
+# ---------------------------------------------------------------------------
+# Public surfaces
+# ---------------------------------------------------------------------------
+surface_paths: set[str] = set()
+run_direct_surface: dict | None = None
+for index, entry in enumerate(registry.get("surface", [])):
+    path_value = entry.get("path")
+    label = f"{registry_rel} surface[{index}]"
+    if not isinstance(path_value, str) or not path_value:
+        fail(f"{label} has an empty or missing `path`")
+        continue
+    label = f"{registry_rel} surface `{path_value}`"
+    if path_value in surface_paths:
+        fail(f"{label} is declared more than once")
+        continue
+    surface_paths.add(path_value)
+
+    for field in ("crate", "kind", "thread_affinity", "owner", "failure_semantics"):
+        if not str(entry.get(field, "")).strip():
+            fail(f"{label} is missing `{field}`")
+    consumers = entry.get("consumers")
+    if not isinstance(consumers, list):
+        fail(f"{label} must record `consumers` as a list (empty is allowed, absence is not)")
+
+    classification = entry.get("classification")
+    if classification not in VALID_CLASSIFICATIONS:
+        fail(f"{label} declares classification {classification!r}; expected one of {sorted(VALID_CLASSIFICATIONS)}")
+        continue
+
+    check_citation(entry.get("declared_in"), entry.get("contains"), f"{label} declaration pin")
+    check_owner_issue(entry, label, required=classification in {"transitional", "removal-target"})
+
+    if path_value == "flui_app::run_direct":
+        run_direct_surface = entry
+
+# run_direct must stay registered, experimental, and marked in its module docs.
+if run_direct_surface is None:
+    fail(f"{registry_rel} no longer registers surface `flui_app::run_direct`")
+else:
+    if run_direct_surface.get("classification") != "experimental":
+        fail(
+            f"{registry_rel} surface `flui_app::run_direct` lost its `experimental` classification "
+            f"(now {run_direct_surface.get('classification')!r}); graduating it belongs to its owning issue"
+        )
+direct_rs = root / "crates" / "flui-app" / "src" / "app" / "direct.rs"
+if not direct_rs.is_file():
+    fail("crates/flui-app/src/app/direct.rs is gone; remove or update the run_direct gates deliberately")
+elif "experimental" not in direct_rs.read_text().lower():
+    fail("crates/flui-app/src/app/direct.rs no longer marks run_direct as experimental — ADR-0039 slice 2 owns its stabilization")
+
+# ADR-0039 acceptance belongs to its owning issue; the file must stay Proposed.
+adr_0039 = root / ADR_FILES["ADR-0039"]
+if adr_0039.is_file() and "**Status:** Proposed" not in adr_0039.read_text():
+    fail(
+        f"{ADR_FILES['ADR-0039']} no longer carries `**Status:** Proposed` — accepting/implementing "
+        "ADR-0039 belongs to its owning issue, and this gate plus the registry must be updated with it"
+    )
+
+# ---------------------------------------------------------------------------
+# Known advisory / unwired configuration must never look stable.
+# ---------------------------------------------------------------------------
+VALID_CONFIG_STATUSES = {"unwired", "advisory", "partially-wired"}
+# vsync does not control the present mode; target_fps is advisory. These two
+# must be registered and must not be classified as working stable config.
+REQUIRED_ADVISORY_FIELDS = {"vsync", "target_fps"}
+
+config_fields: dict[str, dict] = {}
+for index, entry in enumerate(registry.get("config_field", [])):
+    name = entry.get("name")
+    label = f"{registry_rel} config_field[{index}]"
+    if not isinstance(name, str) or not name:
+        fail(f"{label} has an empty or missing `name`")
+        continue
+    label = f"{registry_rel} config_field `{name}`"
+    if name in config_fields:
+        fail(f"{label} is declared more than once")
+        continue
+    config_fields[name] = entry
+
+    status = entry.get("status")
+    if status not in VALID_CONFIG_STATUSES:
+        fail(f"{label} declares status {status!r}; expected one of {sorted(VALID_CONFIG_STATUSES)}")
+    classification = entry.get("classification")
+    if classification not in VALID_CLASSIFICATIONS:
+        fail(f"{label} declares classification {classification!r}; expected one of {sorted(VALID_CLASSIFICATIONS)}")
+    elif classification == "stable-candidate":
+        fail(f"{label} is {status!r} yet classified `stable-candidate` — configuration that does not govern behavior is never stable")
+    check_citation(entry.get("file"), entry.get("contains"), f"{label} field pin")
+    check_owner_issue(entry, label, required=True)
+
+for required in sorted(REQUIRED_ADVISORY_FIELDS):
+    if required not in config_fields:
+        fail(
+            f"{registry_rel} must register config_field `{required}` — it is a known advisory/unwired "
+            "field and removing its entry requires actually wiring or deleting the field first"
+        )
+
+# ---------------------------------------------------------------------------
+# Ambient singleton net: every impl_binding_singleton!/manual instance() in
+# the runtime crates must be registered with an owning issue.
+# ---------------------------------------------------------------------------
+singleton_exemptions: dict[Path, dict] = {}
+for index, entry in enumerate(registry.get("singleton_exemption", [])):
+    label = f"{registry_rel} singleton_exemption[{index}] `{entry.get('symbol', '?')}`"
+    check_citation(entry.get("file"), entry.get("contains"), label)
+    check_owner_issue(entry, label, required=True)
+    if isinstance(entry.get("file"), str):
+        singleton_exemptions[Path(entry["file"])] = entry
+
+SINGLETON_MARKERS = ("impl_binding_singleton!(", "fn instance() -> &'static")
+for crate in RUNTIME_CRATES + [
+    "flui-foundation", "flui-view", "flui-rendering", "flui-interaction",
+    "flui-semantics", "flui-painting",
+]:
+    crate_src = root / "crates" / crate / "src"
+    if not crate_src.is_dir():
+        continue
+    for rs_file in sorted(crate_src.rglob("*.rs")):
+        rel = rs_file.relative_to(root)
+        if rel in SINGLETON_NET_EXEMPT:
+            continue
+        try:
+            text = rs_file.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for marker in SINGLETON_MARKERS:
+            if marker in text and rel not in singleton_exemptions:
+                fail(
+                    f"{rel} contains `{marker}` but is not in the registry's singleton allowlist — "
+                    "a new ambient singleton cannot land without an owning issue "
+                    "(ADR-0027: singleton retirement)"
+                )
+
+# ---------------------------------------------------------------------------
+# Public lock-shaped surface net: every PORT-CHECK-OK-SP6 marker in the
+# runtime crates must come from a registered file. (Trigger #12 in
+# scripts/port-check.sh forces the marker onto any public lock surface its
+# grammar can see; this gate forces the marker's file into the registry.)
+# ---------------------------------------------------------------------------
+lock_exempt_files = set()
+for index, entry in enumerate(registry.get("lock_exemption", [])):
+    label = f"{registry_rel} lock_exemption[{index}] `{entry.get('file', '?')}`"
+    file_value = entry.get("file")
+    if not isinstance(file_value, str) or not (root / file_value).is_file():
+        fail(f"{label} names a missing file")
+        continue
+    if not str(entry.get("reason", "")).strip():
+        fail(f"{label} has no reason")
+    check_owner_issue(entry, label, required=True)
+    lock_exempt_files.add(Path(file_value))
+
+for crate in RUNTIME_CRATES:
+    crate_src = root / "crates" / crate / "src"
+    if not crate_src.is_dir():
+        continue
+    for rs_file in sorted(crate_src.rglob("*.rs")):
+        rel = rs_file.relative_to(root)
+        try:
+            text = rs_file.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        if "PORT-CHECK-OK-SP6" in text and rel not in lock_exempt_files:
+            fail(
+                f"{rel} carries a PORT-CHECK-OK-SP6 lock exemption but is not in the registry's "
+                "lock allowlist — a public lock-shaped runtime surface needs an owning issue (SP-6)"
+            )
+
+# ---------------------------------------------------------------------------
+# Process-global guards: existence-pinned so retirement updates the registry.
+# ---------------------------------------------------------------------------
+for index, entry in enumerate(registry.get("process_global_guard", [])):
+    label = f"{registry_rel} process_global_guard `{entry.get('symbol', '?')}`"
+    check_citation(entry.get("file"), entry.get("contains"), label)
+    check_owner_issue(entry, label, required=True)
+
+# ---------------------------------------------------------------------------
+# Forbidden patterns/paths. Substring scans over crates/**/*.rs (comments
+# included: these are retired identifiers that must not reappear even as
+# prose). `scope` narrows a pattern to one file or directory.
+# ---------------------------------------------------------------------------
+all_rs_files: list[Path] = [
+    p for p in sorted((root / "crates").rglob("*.rs")) if "target" not in p.relative_to(root).parts
+]
+
+for index, entry in enumerate(registry.get("forbidden_pattern", [])):
+    pattern = entry.get("pattern")
+    label = f"{registry_rel} forbidden_pattern[{index}]"
+    if not isinstance(pattern, str) or not pattern:
+        fail(f"{label} has an empty pattern")
+        continue
+    if not str(entry.get("why", "")).strip():
+        fail(f"{label} (`{pattern}`) has no `why`")
+    allow = {Path(a) for a in entry.get("allow_files", [])}
+    scope = entry.get("scope")
+    if scope:
+        scope_path = root / scope
+        candidates = [scope_path] if scope_path.is_file() else sorted(scope_path.rglob("*.rs"))
+    else:
+        candidates = all_rs_files
+    for rs_file in candidates:
+        rel = rs_file.relative_to(root)
+        if rel in allow:
+            continue
+        try:
+            text = rs_file.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        if pattern in text:
+            fail(f"{rel} contains forbidden pattern `{pattern}`: {' '.join(str(entry.get('why', '')).split())}")
+
+for index, entry in enumerate(registry.get("forbidden_path", [])):
+    path_value = entry.get("path")
+    if not isinstance(path_value, str) or not path_value:
+        fail(f"{registry_rel} forbidden_path[{index}] has an empty path")
+        continue
+    if (root / path_value).exists():
+        fail(f"{path_value} exists but is forbidden: {' '.join(str(entry.get('why', '')).split())}")
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+if errors:
+    print("runtime-conformance: violations detected", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    sys.exit(1)
+
+surface_count = len(surface_paths)
+requirement_count = len(requirement_keys)
+by_adr = ", ".join(f"{adr} {count}" for adr, count in requirements_by_adr.items())
+print(
+    f"runtime-conformance: {requirement_count} requirements ({by_adr}); "
+    f"{surface_count} classified surfaces; {len(config_fields)} config fields; "
+    f"{len(singleton_exemptions)} singleton + {len(lock_exempt_files)} lock exemptions verified"
+)
+PY


### PR DESCRIPTION
Closes #550.

## What changed

Runtime.1 now has an executable **public contract registry** rather than a CI dependency on internal design records.

### Public runtime contract

`docs/runtime-contract.toml` is the source of truth for:

- 46 shipped, partial, and planned runtime contracts;
- 32 classified public boundary families;
- 5 advisory or unwired `AppConfig` fields;
- 5 transitional singleton declarations;
- 15 public lock-shaped declarations;
- forbidden retired identifiers and speculative package boundaries.

The registry deliberately contains no ADR identifiers, sections, statuses, or file dependencies. Internal design records may move out of the public repository without weakening the contributor contract or CI.

Contracts use descriptive keys and record the actual ownership domain, shipped state, production evidence, and exactly one owning issue for incomplete work. Broad rows were split where the missing work belongs to different issues: window-host composition, presentation state, frame configuration, non-frame configuration, bounded inbox drains, and worker cancellation now have independent ownership.

### Checked root-export manifest

The stable Rust 1.97.1 toolchain cannot emit rustdoc JSON, so this PR does not claim compiler-semantic API extraction. Instead, the registry carries an explicit manifest for the monitored crate roots and the checker compares their normalized column-zero public declarations.

A new root `pub` function, type, module, or re-export now fails until its boundary family is reviewed and the manifest is updated. Public modules remain classified as families; the checker documents this exact boundary rather than presenting a textual scan as complete Rust API analysis.

### Hardened validator

`scripts/check-runtime-conformance.sh` now:

- structurally validates every TOML array/table before field access;
- rejects citations that escape the repository;
- reports wrong TOML shapes as normal violations rather than Python tracebacks;
- matches singleton exemptions to exact declarations, not entire files;
- matches every `PORT-CHECK-OK-SP6` occurrence to one registered marker;
- detects duplicate or missing registered declarations;
- keeps `run_direct` explicitly experimental;
- keeps advisory/unwired configuration from being called stable;
- has no dependency on ADR files or statuses.

The gate remains part of `just ci` and the existing merge-blocking `checks` job.

## Red-state verification

Each mutation was applied to an isolated copy and observed to fail:

1. An unregistered `pub fn unregistered_runtime_api() {}` in the `flui-app` crate root is rejected as an unclassified root export.
2. A second `impl_binding_singleton!(SneakyBinding)` beside the registered scheduler singleton is rejected as an unmatched declaration.
3. An additional `PORT-CHECK-OK-SP6` marker in an already registered file is rejected independently.
4. A valid TOML document with `forbidden_path` in the wrong shape reports a structured schema violation and no traceback.

## Verification

- `just runtime-conformance-check` — 46 contracts, 32 boundary families, 5 config fields, 5 singleton declarations, and 15 lock declarations verified.
- `just inventory-check`, `just port-check`, formatting, Taplo, and typos — pass.
- workspace clippy with `-D warnings` — pass.
- workspace nextest — 8509/8511 passed in the sandbox; the two generated-project compilation tests were blocked only by sandbox DNS and both passed when rerun with crates.io access.
- facade `cupertino,localizations` partition — 31 passed.
- doctests and strict rustdoc — pass.
- `cargo deny check` — advisories, bans, licenses, and sources pass.

## Scope

This PR records and enforces current boundaries. It does not implement `OwnerPlatform`, `AppRuntime`, presentation forests, pipeline ownership replacement, or raster threading; those remain owned by #551–#565.
