### PR TITLE
feat(platform): OwnerPlatform capability and typed owner-lane proxy (ADR-0039 slice 2)

### DIFF
--- a/crates/flui-app/AGENTS.md
+++ b/crates/flui-app/AGENTS.md
@@ -9,7 +9,7 @@ process services while ADR-0027 extracts the remaining global bindings.
 - **AppBinding / AppConfig** — transitional process host for renderer, lifecycle, focus, and scheduler services; it does not own widget or gesture state
 - **RootRenderElement / RootRenderView** — root of the render/element tree
 - **run_app / run_app_with_config** — the supported entry points for starting the app
-- **run_direct** — experimental direct-engine escape hatch (no widget tree, no input, broken on the winit backend pending ADR-0039's `on_ready` reorder); do not describe it as a supported cross-platform path
+- **run_direct** — experimental direct-engine escape hatch (no widget tree, no input); its bootstrap (window, GPU renderer, callback wiring) now runs inside `on_ready` (ADR-0039 slice 2), so it works on the winit backend too — still `experimental` by policy, not a supported cross-platform application entry point
 - **embedder / overlay** — app-level subsystems (PORT-CHECK-OK-SP4 marked)
 - **Re-exports** — `GestureBinding`, `PaintingBinding`, `PipelineOwner`, `RenderingFlutterBinding`, `Scheduler`, `SemanticsBinding`, `WidgetsBinding` from constituent crates
 

--- a/crates/flui-app/src/app/direct.rs
+++ b/crates/flui-app/src/app/direct.rs
@@ -107,25 +107,21 @@ pub fn run_direct(
 
     let platform = flui_platform::current_platform()?;
 
-    // `on_ready` has no return path back to this function's caller (it runs
-    // synchronously inside `Platform::run`, which returns `()`) — bootstrap
-    // failures thread out through this cell instead, same pattern
-    // `run_desktop`'s `bootstrap_error_slot` uses.
-    let bootstrap_error: std::rc::Rc<std::cell::RefCell<Option<anyhow::Error>>> =
-        std::rc::Rc::new(std::cell::RefCell::new(None));
-    let bootstrap_error_slot = std::rc::Rc::clone(&bootstrap_error);
-
     /// The actual direct-mode bootstrap: window, GPU renderer, and callback
     /// wiring. Runs once, synchronously, inside `on_ready` (ADR-0039 slice
     /// 2) — the winit backend can only create a window from inside a
     /// running event loop, so this can no longer run before `run()` starts
     /// it (which is what made this function fail fast on that backend
     /// before this migration).
-    fn bootstrap_direct<F>(
-        config: AppConfig,
-        render_fn: F,
-        bootstrap_error_slot: std::rc::Rc<std::cell::RefCell<Option<anyhow::Error>>>,
-    ) where
+    ///
+    /// Returns `Err` on bootstrap failure — `on_ready` itself is fallible
+    /// now, so this propagates straight out of `Platform::run` instead of
+    /// threading the failure out through a
+    /// `Rc<RefCell<Option<anyhow::Error>>>` side channel (the old
+    /// `bootstrap_error_slot` pattern, now redundant and removed: this
+    /// function's own `Result` return is `run_direct`'s answer).
+    fn bootstrap_direct<F>(config: AppConfig, render_fn: F) -> anyhow::Result<()>
+    where
         F: FnMut(&mut SceneBuilder<'_>, f32, f32) + Send + 'static,
     {
         fn owner_platform_installed<R>(f: impl FnOnce(&flui_platform::OwnerPlatform) -> R) -> R {
@@ -142,10 +138,7 @@ pub fn run_direct(
             Ok(window) => window,
             Err(error) => {
                 tracing::error!(%error, "Window creation failed");
-                *bootstrap_error_slot.borrow_mut() =
-                    Some(anyhow::Error::from(error).context("Failed to create window"));
-                owner_platform_installed(flui_platform::OwnerPlatform::quit);
-                return;
+                return Err(anyhow::Error::from(error).context("Failed to create window"));
             }
         };
 
@@ -156,10 +149,7 @@ pub fn run_direct(
             Ok(r) => r,
             Err(e) => {
                 tracing::error!("GPU init failed: {:?}", e);
-                *bootstrap_error_slot.borrow_mut() =
-                    Some(anyhow::anyhow!(e).context("GPU initialization failed"));
-                owner_platform_installed(flui_platform::OwnerPlatform::quit);
-                return;
+                return Err(anyhow::anyhow!(e).context("GPU initialization failed"));
             }
         };
         renderer.resize(phys_size.width.0 as u32, phys_size.height.0 as u32);
@@ -266,6 +256,7 @@ pub fn run_direct(
         window.request_redraw();
 
         tracing::info!("Direct render mode initialized, entering event loop");
+        Ok(())
     }
 
     // Owner-host clear guard armed BEFORE `run(...)`, not inside `on_ready`
@@ -273,13 +264,8 @@ pub fn run_direct(
     let _owner_host_clear_guard = crate::app::runner::OwnerHostClearGuard::arm();
     platform.run(Box::new(move |owner| {
         crate::app::runner::install_owner_platform(owner);
-        bootstrap_direct(config, render_fn, bootstrap_error_slot);
+        bootstrap_direct(config, render_fn)?;
         tracing::info!("FLUI direct render mode ready");
-    }));
-
-    if let Some(error) = bootstrap_error.borrow_mut().take() {
-        return Err(error);
-    }
-
-    Ok(())
+        Ok(())
+    }))
 }

--- a/crates/flui-app/src/app/direct.rs
+++ b/crates/flui-app/src/app/direct.rs
@@ -6,26 +6,20 @@
 //!
 //! This is **not** a supported cross-platform application entry point, and it
 //! is not a smaller `run_app`. It is a direct-engine escape hatch for scene
-//! and shader work, with three standing limitations:
+//! and shader work, with two standing limitations:
 //!
-//! - **It does not run on the winit backend**, which is what Linux uses today.
-//!   [`run_direct`] opens its window before starting the event loop, and winit
-//!   cannot create a window outside a running loop — so the call fails fast
-//!   with an error instead of opening anything. The fix is the same
-//!   `on_ready`-driven reorder `run_desktop` already received, required by
-//!   [ADR-0039](https://github.com/vanyastaff/flui/blob/main/docs/adr/ADR-0039-event-loop-affinity-capability.md)'s
-//!   slice 2 ("pre-run flows migrate into `on_ready`", which names this
-//!   function). It is deliberately not attempted here: an event-loop
-//!   architecture change does not belong in a package-surface cleanup.
 //! - **There is no input handling.** The input callback is a no-op stub; a
 //!   caller that needs input drives it from inside `render_fn` via its own
 //!   state.
 //! - **There is no damage tracking**, no widget tree, no layout, no hit test,
 //!   and no semantics — every frame is a full repaint of a caller-built scene.
 //!
-//! Native (non-winit) Windows and macOS backends are unaffected by the first
-//! limitation, and `examples/direct_render.rs` and `examples/aa_showcase.rs`
-//! run there.
+//! Window creation, GPU renderer init, and callback wiring all run inside
+//! `on_ready` (ADR-0039 slice 2), the same reorder `run_desktop` already
+//! received — this function used to open its window *before* starting the
+//! event loop, which failed fast on the winit backend (Linux) instead of
+//! opening anything (winit cannot create a window outside a running loop).
+//! It now runs on every backend, including winit.
 //!
 //! # Example
 //!
@@ -70,9 +64,9 @@ use super::AppConfig;
 /// tree machinery (flui-view, flui-rendering) for direct engine access.
 ///
 /// **Experimental / direct-engine only.** This is not a supported
-/// cross-platform application entry point — see the module docs for the three
-/// standing limitations, including that it does not work on the winit backend.
-/// Use [`run_app`](crate::run_app) for applications.
+/// cross-platform application entry point — see the module docs for the two
+/// standing limitations (no input handling, no damage tracking). Use
+/// [`run_app`](crate::run_app) for applications.
 ///
 /// # Arguments
 ///
@@ -88,10 +82,13 @@ use super::AppConfig;
 ///
 /// # Platform Support
 ///
-/// Dead on arrival on the winit backend (Linux) — see the "Open window" note
-/// in the body for why, and the module docs for the tracked fix. Native
-/// (non-winit) Windows/macOS backends are unaffected. Uses
-/// `flui_platform::current_platform()` for platform selection.
+/// Runs on every backend, including winit (Linux) — bootstrap moved inside
+/// `on_ready` (ADR-0039 slice 2), so the winit backend's requirement of a
+/// running event loop before window creation is satisfied on every target.
+/// Uses `flui_platform::current_platform()` for platform selection.
+///
+/// **Experimental**: this is a direct-engine escape hatch, not a supported
+/// application entry point — see the module docs.
 pub fn run_direct(
     config: AppConfig,
     render_fn: impl FnMut(&mut SceneBuilder<'_>, f32, f32) + Send + 'static,
@@ -110,140 +107,179 @@ pub fn run_direct(
 
     let platform = flui_platform::current_platform()?;
 
-    // 1. Open window
-    //
-    // NOTE: like the pre-fix `run_desktop`, this opens the window before
-    // `run()` starts the event loop. On the winit backend (Linux) that no
-    // longer hangs — `WinitPlatform::open_window` now fails fast with a
-    // clear error when called before the event loop is running — but it
-    // still can't work: this `?` will bubble that error out of `run_direct`
-    // immediately, before any window ever opens. The fix is the on_ready-driven
-    // reorder `run_desktop` already received (see `runner.rs`'s
-    // `bootstrap_desktop`), which ADR-0039's slice 2 requires for exactly this
-    // function. Not attempted here — an event-loop architecture change is not
-    // part of a package-surface cleanup.
-    let options: WindowOptions = (&config).into();
-    let window = platform
-        .open_window(options)
-        .map_err(|e| anyhow::anyhow!("Failed to create window: {e}"))?;
+    // `on_ready` has no return path back to this function's caller (it runs
+    // synchronously inside `Platform::run`, which returns `()`) — bootstrap
+    // failures thread out through this cell instead, same pattern
+    // `run_desktop`'s `bootstrap_error_slot` uses.
+    let bootstrap_error: std::rc::Rc<std::cell::RefCell<Option<anyhow::Error>>> =
+        std::rc::Rc::new(std::cell::RefCell::new(None));
+    let bootstrap_error_slot = std::rc::Rc::clone(&bootstrap_error);
 
-    // 2. Create GPU renderer
-    let phys_size = window.physical_size();
-    let renderer = pollster::block_on(Renderer::new(window.as_ref()));
-    let mut renderer = match renderer {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::error!("GPU init failed: {:?}", e);
-            return Err(anyhow::anyhow!("GPU initialization failed: {e}"));
-        }
-    };
-    renderer.resize(phys_size.width.0 as u32, phys_size.height.0 as u32);
-
-    tracing::info!(
-        gpu = %renderer.capabilities().adapter_name,
-        backend = ?renderer.capabilities().backend,
-        "GPU renderer initialized"
-    );
-
-    // 3. Wrap renderer and render_fn for callback sharing
-    let renderer = Arc::new(Mutex::new(renderer));
-    let render_fn = Arc::new(Mutex::new(render_fn));
-    let frame_counter = Arc::new(std::sync::atomic::AtomicU64::new(0));
-
-    // 4. Register frame callback
-    let renderer_frame = Arc::clone(&renderer);
-    let render_fn_frame = Arc::clone(&render_fn);
-    let frame_counter_frame = Arc::clone(&frame_counter);
-    window.on_request_frame(Box::new(move || {
-        let mut r = renderer_frame.lock();
-        let (w, h) = r.size();
-
-        if w == 0 || h == 0 {
-            return;
+    /// The actual direct-mode bootstrap: window, GPU renderer, and callback
+    /// wiring. Runs once, synchronously, inside `on_ready` (ADR-0039 slice
+    /// 2) — the winit backend can only create a window from inside a
+    /// running event loop, so this can no longer run before `run()` starts
+    /// it (which is what made this function fail fast on that backend
+    /// before this migration).
+    fn bootstrap_direct<F>(
+        config: AppConfig,
+        render_fn: F,
+        bootstrap_error_slot: std::rc::Rc<std::cell::RefCell<Option<anyhow::Error>>>,
+    ) where
+        F: FnMut(&mut SceneBuilder<'_>, f32, f32) + Send + 'static,
+    {
+        fn owner_platform_installed<R>(f: impl FnOnce(&flui_platform::OwnerPlatform) -> R) -> R {
+            crate::app::runner::with_owner_platform(f)
+                .expect("BUG: bootstrap_direct runs only after install_owner_platform")
         }
 
-        // Mark full repaint every frame in direct mode (no damage tracking)
-        r.mark_full_repaint();
-
-        // Build scene via user closure
-        let mut tree = LayerTree::new();
+        // 1. Open window. `Ready` is guaranteed inside `on_ready`
+        // (ADR-0039 §1).
+        let options: WindowOptions = (&config).into();
+        let window = match owner_platform_installed(|owner| owner.open_window(options))
+            .and_then(flui_platform::WindowOpen::try_ready)
         {
-            let mut builder = SceneBuilder::new(&mut tree);
-            let mut rfn = render_fn_frame.lock();
-            rfn(&mut builder, w as f32, h as f32);
-            // builder dropped here, releasing borrow on tree
-        }
-
-        let root = tree.root();
-        let frame = frame_counter_frame.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let scene = Scene::new(Size::new(px(w as f32), px(h as f32)), tree, root, frame);
-
-        if let Err(e) = r.render_scene(&scene) {
-            if e.recoverability() == Recoverability::Recoverable {
-                tracing::warn!("Recoverable render error (will retry): {}", e);
-            } else {
-                // Covers both Fatal (renderer must be recreated) and
-                // Unrecoverable (surface misconfig / resource I/O / text error:
-                // drop this frame, no blind retry). Neither auto-retries.
-                tracing::error!(error = ?e, "Non-recoverable render error");
+            Ok(window) => window,
+            Err(error) => {
+                tracing::error!(%error, "Window creation failed");
+                *bootstrap_error_slot.borrow_mut() =
+                    Some(anyhow::Error::from(error).context("Failed to create window"));
+                owner_platform_installed(flui_platform::OwnerPlatform::quit);
+                return;
             }
-        }
+        };
 
-        // GPU device-loss recovery: same logic as runner.rs frame callbacks.
-        if r.is_device_lost() {
-            match pollster::block_on(r.recover()) {
-                Ok(()) => {
-                    tracing::warn!("GPU device lost — recovered successfully");
-                }
-                Err(e) => {
-                    tracing::error!(error = ?e, "GPU device recovery failed; will retry next frame");
+        // 2. Create GPU renderer
+        let phys_size = window.physical_size();
+        let renderer = pollster::block_on(Renderer::new(window.as_ref()));
+        let mut renderer = match renderer {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!("GPU init failed: {:?}", e);
+                *bootstrap_error_slot.borrow_mut() =
+                    Some(anyhow::anyhow!(e).context("GPU initialization failed"));
+                owner_platform_installed(flui_platform::OwnerPlatform::quit);
+                return;
+            }
+        };
+        renderer.resize(phys_size.width.0 as u32, phys_size.height.0 as u32);
+
+        tracing::info!(
+            gpu = %renderer.capabilities().adapter_name,
+            backend = ?renderer.capabilities().backend,
+            "GPU renderer initialized"
+        );
+
+        // 3. Wrap renderer and render_fn for callback sharing
+        let renderer = Arc::new(Mutex::new(renderer));
+        let render_fn = Arc::new(Mutex::new(render_fn));
+        let frame_counter = Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+        // 4. Register frame callback
+        let renderer_frame = Arc::clone(&renderer);
+        let render_fn_frame = Arc::clone(&render_fn);
+        let frame_counter_frame = Arc::clone(&frame_counter);
+        window.on_request_frame(Box::new(move || {
+            let mut r = renderer_frame.lock();
+            let (w, h) = r.size();
+
+            if w == 0 || h == 0 {
+                return;
+            }
+
+            // Mark full repaint every frame in direct mode (no damage tracking)
+            r.mark_full_repaint();
+
+            // Build scene via user closure
+            let mut tree = LayerTree::new();
+            {
+                let mut builder = SceneBuilder::new(&mut tree);
+                let mut rfn = render_fn_frame.lock();
+                rfn(&mut builder, w as f32, h as f32);
+                // builder dropped here, releasing borrow on tree
+            }
+
+            let root = tree.root();
+            let frame = frame_counter_frame.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let scene = Scene::new(Size::new(px(w as f32), px(h as f32)), tree, root, frame);
+
+            if let Err(e) = r.render_scene(&scene) {
+                if e.recoverability() == Recoverability::Recoverable {
+                    tracing::warn!("Recoverable render error (will retry): {}", e);
+                } else {
+                    // Covers both Fatal (renderer must be recreated) and
+                    // Unrecoverable (surface misconfig / resource I/O / text error:
+                    // drop this frame, no blind retry). Neither auto-retries.
+                    tracing::error!(error = ?e, "Non-recoverable render error");
                 }
             }
-        }
-    }));
 
-    // 5. Register resize callback
-    let renderer_resize = Arc::clone(&renderer);
-    window.on_resize(Box::new(move |size, scale_factor| {
-        let w = (size.width.0 * scale_factor) as u32;
-        let h = (size.height.0 * scale_factor) as u32;
-        if w > 0 && h > 0 {
-            renderer_resize.lock().resize(w, h);
-            tracing::debug!("Window resized to {}x{} (scale: {})", w, h, scale_factor);
-        }
-    }));
+            // GPU device-loss recovery: same logic as runner.rs frame callbacks.
+            if r.is_device_lost() {
+                match pollster::block_on(r.recover()) {
+                    Ok(()) => {
+                        tracing::warn!("GPU device lost — recovered successfully");
+                    }
+                    Err(e) => {
+                        tracing::error!(error = ?e, "GPU device recovery failed; will retry next frame");
+                    }
+                }
+            }
+        }));
 
-    // 6. Register input callback. This is a no-op stub: it neither inspects
-    // the input nor requests a redraw (`resolved(false, false)`). Direct mode
-    // has no widget tree to dispatch input into; a caller who needs input
-    // handling drives it from inside `render_fn` via its own state.
-    window.on_input(Box::new(move |_input: PlatformInput| {
-        DispatchEventResult::resolved(false, false)
-    }));
+        // 5. Register resize callback
+        let renderer_resize = Arc::clone(&renderer);
+        window.on_resize(Box::new(move |size, scale_factor| {
+            let w = (size.width.0 * scale_factor) as u32;
+            let h = (size.height.0 * scale_factor) as u32;
+            if w > 0 && h > 0 {
+                renderer_resize.lock().resize(w, h);
+                tracing::debug!("Window resized to {}x{} (scale: {})", w, h, scale_factor);
+            }
+        }));
 
-    // 7. Lifecycle callbacks
-    window.on_close(Box::new(|| {
-        tracing::info!("Window closed");
-    }));
+        // 6. Register input callback. This is a no-op stub: it neither inspects
+        // the input nor requests a redraw (`resolved(false, false)`). Direct mode
+        // has no widget tree to dispatch input into; a caller who needs input
+        // handling drives it from inside `render_fn` via its own state.
+        window.on_input(Box::new(move |_input: PlatformInput| {
+            DispatchEventResult::resolved(false, false)
+        }));
 
-    window.on_should_close(Box::new(|| {
-        tracing::debug!("Window close requested, allowing");
-        true
-    }));
+        // 7. Lifecycle callbacks
+        window.on_close(Box::new(|| {
+            tracing::info!("Window closed");
+        }));
 
-    platform.on_quit(Box::new(|| {
-        tracing::info!("Platform quit");
-    }));
+        window.on_should_close(Box::new(|| {
+            tracing::debug!("Window close requested, allowing");
+            true
+        }));
 
-    // 8. Request initial redraw
-    window.request_redraw();
+        owner_platform_installed(|owner| {
+            owner.shared().on_quit(Box::new(|| {
+                tracing::info!("Platform quit");
+            }));
+        });
 
-    tracing::info!("Direct render mode initialized, entering event loop");
+        // 8. Request initial redraw
+        window.request_redraw();
 
-    // 9. Run event loop (takes ownership of platform)
-    platform.run(Box::new(|_platform| {
+        tracing::info!("Direct render mode initialized, entering event loop");
+    }
+
+    // Owner-host clear guard armed BEFORE `run(...)`, not inside `on_ready`
+    // (ADR-0039 §6/§7, U7) — see `run_desktop`'s matching comment.
+    let _owner_host_clear_guard = crate::app::runner::OwnerHostClearGuard::arm();
+    platform.run(Box::new(move |owner| {
+        crate::app::runner::install_owner_platform(owner);
+        bootstrap_direct(config, render_fn, bootstrap_error_slot);
         tracing::info!("FLUI direct render mode ready");
     }));
+
+    if let Some(error) = bootstrap_error.borrow_mut().take() {
+        return Err(error);
+    }
 
     Ok(())
 }

--- a/crates/flui-app/src/app/direct.rs
+++ b/crates/flui-app/src/app/direct.rs
@@ -269,7 +269,7 @@ pub fn run_direct(
     }
 
     // Owner-host clear guard armed BEFORE `run(...)`, not inside `on_ready`
-    // (ADR-0039 §6/§7, U7) — see `run_desktop`'s matching comment.
+    // (ADR-0039 §6/§7) — see `run_desktop`'s matching comment.
     let _owner_host_clear_guard = crate::app::runner::OwnerHostClearGuard::arm();
     platform.run(Box::new(move |owner| {
         crate::app::runner::install_owner_platform(owner);

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -3226,4 +3226,51 @@ mod tests {
             let _ = with_owner_platform(|_owner| ());
         });
     }
+
+    /// Hot-restart survival (ADR-0039 §6): `OWNER_PLATFORM_HOST` is
+    /// loop-scoped, deliberately separate from `PLATFORM_REALM_HOST` --
+    /// tearing down a realm on the owner thread must not strand the loop's
+    /// capability, because the loop may host a fresh realm next without
+    /// ever calling `Platform::run` again (hot-restart does exactly this
+    /// today, `install_platform_realm`). `teardown_platform_realm` must
+    /// therefore leave `OWNER_PLATFORM_HOST` untouched.
+    #[test]
+    fn owner_platform_host_survives_teardown_platform_realm() {
+        use flui_platform::headless_platform;
+
+        // `Rc<Cell<_>>`, not a bare local: the `on_ready` closure below is
+        // `Box<dyn FnOnce(OwnerPlatform) + 'static>`, so it cannot borrow a
+        // stack local -- see the sibling install/clear test's identical
+        // note. `(bool, bool)` is `Copy`, so `Cell` suffices.
+        let observed = Rc::new(Cell::new((false, false)));
+        let observed_for_closure = Rc::clone(&observed);
+
+        let _clear_guard = OwnerHostClearGuard::arm();
+        let platform = headless_platform();
+        platform.run(Box::new(move |owner| {
+            install_owner_platform(owner);
+            let before_teardown = with_owner_platform(|_owner| true) == Some(true);
+
+            // Simulate hot-restart: a realm's teardown runs on this owner
+            // thread while the loop keeps running (headless `run` returns
+            // immediately either way, but the TLS host's contract does not
+            // depend on that -- it is exercised identically whether the
+            // loop is about to return or about to host another realm).
+            teardown_platform_realm();
+
+            let after_teardown = with_owner_platform(|_owner| true) == Some(true);
+            observed_for_closure.set((before_teardown, after_teardown));
+        }));
+
+        let (before_teardown, after_teardown) = observed.get();
+        assert!(
+            before_teardown,
+            "the host must be installed before teardown runs"
+        );
+        assert!(
+            after_teardown,
+            "teardown_platform_realm must not clear OWNER_PLATFORM_HOST -- \
+             the loop may host another realm before it exits (hot-restart)"
+        );
+    }
 }

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -1830,13 +1830,6 @@ where
     let rebuild_registration: Rc<RefCell<Option<RebuildHookGuard>>> = Rc::new(RefCell::new(None));
     let rebuild_registration_slot = Rc::clone(&rebuild_registration);
 
-    // Bootstrap can fail fatally (GPU init, `UiRealm` construction, root
-    // widget attach) from inside `on_ready`, which has no return path back
-    // to this function's caller — thread the failure out through this cell
-    // instead, same pattern as `rebuild_registration`.
-    let bootstrap_error: Rc<RefCell<Option<anyhow::Error>>> = Rc::new(RefCell::new(None));
-    let bootstrap_error_slot = Rc::clone(&bootstrap_error);
-
     /// The actual desktop bootstrap: opens the window, initializes the GPU
     /// renderer, mounts the widget tree, and wires every platform/window
     /// callback. Runs exactly once, synchronously, inside `on_ready` (see
@@ -1844,6 +1837,16 @@ where
     /// only create a window from inside a running event loop
     /// (`ActiveEventLoop` is unreachable beforehand, and `open_window` fails
     /// fast rather than deadlock if called too early).
+    ///
+    /// Returns `Err` on any bootstrap failure (GPU init, `UiRealm`
+    /// construction, root widget attach); `on_ready` itself is now fallible,
+    /// so this propagates straight out of `Platform::run` instead of
+    /// threading the failure out through a
+    /// `Rc<RefCell<Option<anyhow::Error>>>` side channel — that pattern is
+    /// now redundant here and has been removed. Every backend stops
+    /// entering (or promptly exits) its loop on this `Err`, so there is no
+    /// need to call `owner.quit()` explicitly on any of the error paths
+    /// below.
     ///
     /// Pulled out of the `on_ready` closure into a named fn so rustfmt
     /// actually formats it — rustfmt does not reliably reformat very large
@@ -1853,8 +1856,8 @@ where
         config: AppConfig,
         worker_reload: WorkerReload,
         rebuild_registration_slot: Rc<RefCell<Option<RebuildHookGuard>>>,
-        bootstrap_error_slot: Rc<RefCell<Option<anyhow::Error>>>,
-    ) where
+    ) -> anyhow::Result<()>
+    where
         V: View + StatelessView + Clone + 'static,
     {
         tracing::info!("Platform ready");
@@ -1883,11 +1886,11 @@ where
         // 1. Open window now that the event loop is running. Window creation is
         // an environment failure (display server hiccup, resource exhaustion),
         // not a `BUG:` invariant, and — unlike platform init above — this DOES
-        // run inside `on_ready` with a live owner capability and
-        // `bootstrap_error_slot` available, so it gets the same
-        // deferred-panic-after-teardown handling as the GPU/realm/attach
-        // failures below instead of an immediate bare `.expect()` panic
-        // mid-`on_ready`. `Ready` is guaranteed here (ADR-0039 §1).
+        // run inside `on_ready` with a live owner capability, so a failure here
+        // gets the same `Err`-propagates-out-of-`run` handling as the
+        // GPU/realm/attach failures below instead of an immediate bare
+        // `.expect()` panic mid-`on_ready`. `Ready` is guaranteed here
+        // (ADR-0039 §1).
         let options: WindowOptions = (&config).into();
         let window = match owner_platform_installed(|owner| owner.open_window(options))
             .and_then(flui_platform::WindowOpen::try_ready)
@@ -1895,10 +1898,7 @@ where
             Ok(window) => window,
             Err(error) => {
                 tracing::error!(%error, "Window creation failed");
-                *bootstrap_error_slot.borrow_mut() =
-                    Some(anyhow::Error::from(error).context("Window creation failed"));
-                owner_platform_installed(flui_platform::OwnerPlatform::quit);
-                return;
+                return Err(anyhow::Error::from(error).context("Window creation failed"));
             }
         };
 
@@ -1909,10 +1909,7 @@ where
             Ok(r) => r,
             Err(e) => {
                 tracing::error!("GPU init failed: {:?}", e);
-                *bootstrap_error_slot.borrow_mut() =
-                    Some(anyhow::anyhow!(e).context("GPU init failed"));
-                owner_platform_installed(flui_platform::OwnerPlatform::quit);
-                return;
+                return Err(anyhow::anyhow!(e).context("GPU init failed"));
             }
         };
         renderer.resize(phys_size.width.0 as u32, phys_size.height.0 as u32);
@@ -1933,10 +1930,7 @@ where
             Ok(realm) => realm,
             Err(e) => {
                 tracing::error!(error = %e, "UiRealm construction failed");
-                *bootstrap_error_slot.borrow_mut() =
-                    Some(anyhow::anyhow!(e).context("UiRealm construction failed"));
-                owner_platform_installed(flui_platform::OwnerPlatform::quit);
-                return;
+                return Err(anyhow::anyhow!(e).context("UiRealm construction failed"));
             }
         };
         let logical = window.logical_size();
@@ -1950,10 +1944,7 @@ where
         });
         if let Err(e) = attach {
             tracing::error!("Root widget attach failed: {:?}", e);
-            *bootstrap_error_slot.borrow_mut() =
-                Some(anyhow::anyhow!(e).context("Root widget attach failed"));
-            owner_platform_installed(flui_platform::OwnerPlatform::quit);
-            return;
+            return Err(anyhow::anyhow!(e).context("Root widget attach failed"));
         }
 
         // 3b. Wire the wake chain (E0a).
@@ -2257,6 +2248,7 @@ where
         AppBinding::instance().wake_frame();
 
         tracing::info!("Desktop platform initialized with callbacks");
+        Ok(())
     }
 
     // Window creation, GPU/renderer setup, and callback wiring all run
@@ -2272,15 +2264,9 @@ where
     // guard and cannot leak the host onto this thread past this call
     // (ADR-0039 §6).
     let _owner_host_clear_guard = OwnerHostClearGuard::arm();
-    platform.run(Box::new(move |owner| {
+    let result = platform.run(Box::new(move |owner| {
         install_owner_platform(owner);
-        bootstrap_desktop(
-            root,
-            config,
-            worker_reload,
-            rebuild_registration_slot,
-            bootstrap_error_slot,
-        );
+        bootstrap_desktop(root, config, worker_reload, rebuild_registration_slot)
     }));
 
     // Event loop exited: drop the runtime now (releases the at-most-one
@@ -2290,11 +2276,10 @@ where
     teardown_platform_realm();
 
     // Surface a fatal bootstrap failure (GPU init, `UiRealm` construction,
-    // root widget attach) now that the event loop has exited — those
-    // failures happen inside `on_ready`, with no return path back here
-    // except through `bootstrap_error`, and quitting the platform on them
-    // (see `bootstrap_desktop`) must not look like a clean exit.
-    if let Some(err) = bootstrap_error.borrow_mut().take() {
+    // root widget attach, or window creation) now that the event loop has
+    // exited — `on_ready`'s `Err` propagates straight out of `Platform::run`;
+    // no side-channel cell is needed to thread it out anymore.
+    if let Err(err) = result {
         panic!("desktop bootstrap failed: {err:?}");
     }
 }
@@ -2391,7 +2376,16 @@ where
     /// code untouched by this migration. **Unvalidated on-device**: no
     /// device and no CI compile target for `target_os = "android"` verify
     /// this; stated here and in the registry rather than assumed.
-    fn bootstrap_android<V>(root: V, config: AppConfig, hot_reload: ScenePlugin)
+    ///
+    /// Returns `Err` on bootstrap failure — `on_ready` itself is fallible
+    /// now, so the Android backend's `run` loop stops (and propagates the
+    /// error out) instead of continuing to pump input/frame
+    /// dispatch for an app that never finished bootstrapping.
+    fn bootstrap_android<V>(
+        root: V,
+        config: AppConfig,
+        hot_reload: ScenePlugin,
+    ) -> anyhow::Result<()>
     where
         V: View + StatelessView + Clone + 'static,
     {
@@ -2411,9 +2405,15 @@ where
         // 1. Open window (wraps the existing ANativeWindow). `Ready` is
         // guaranteed inside `on_ready` (ADR-0039 §1).
         let options: WindowOptions = (&config).into();
-        let window = owner_platform_installed(|owner| owner.open_window(options))
+        let window = match owner_platform_installed(|owner| owner.open_window(options))
             .and_then(flui_platform::WindowOpen::try_ready)
-            .expect("Failed to create Android window");
+        {
+            Ok(window) => window,
+            Err(error) => {
+                tracing::error!(%error, "Failed to create Android window");
+                return Err(anyhow::Error::from(error).context("Failed to create Android window"));
+            }
+        };
 
         // 2. Create GPU renderer (Vulkan backend on Android)
         let phys_size = window.physical_size();
@@ -2422,7 +2422,7 @@ where
             Ok(r) => r,
             Err(e) => {
                 tracing::error!("GPU init failed: {:?}", e);
-                return;
+                return Err(anyhow::anyhow!(e).context("GPU init failed"));
             }
         };
         renderer.resize(phys_size.width.0 as u32, phys_size.height.0 as u32);
@@ -2441,7 +2441,7 @@ where
             Ok(realm) => realm,
             Err(error) => {
                 tracing::error!(%error, "UiRealm construction failed");
-                return;
+                return Err(anyhow::anyhow!(error).context("UiRealm construction failed"));
             }
         };
         let logical = window.logical_size();
@@ -2455,7 +2455,7 @@ where
         });
         if let Err(e) = attach {
             tracing::error!("Root widget attach failed: {:?}", e);
-            return;
+            return Err(anyhow::anyhow!(e).context("Root widget attach failed"));
         }
         let realm_dispatch = install_platform_realm(ui_realm);
 
@@ -2658,16 +2658,24 @@ where
         AppBinding::instance().wake_frame();
 
         tracing::info!("Android platform initialized with callbacks (hot-reload enabled)");
+        Ok(())
     }
 
     // Owner-host clear guard armed BEFORE `run(...)`, not inside `on_ready`
     // (ADR-0039 §6) — see `run_desktop`'s matching comment.
     let _owner_host_clear_guard = OwnerHostClearGuard::arm();
-    platform.run(Box::new(move |owner| {
+    let result = platform.run(Box::new(move |owner| {
         install_owner_platform(owner);
-        bootstrap_android(root, config, hot_reload);
+        bootstrap_android(root, config, hot_reload)
     }));
     teardown_platform_realm();
+
+    // `on_ready`'s `Err` propagates straight out of `Platform::run`; surface
+    // it the same way `run_desktop` does now that the event loop has
+    // exited.
+    if let Err(err) = result {
+        panic!("android bootstrap failed: {err:?}");
+    }
 }
 
 // ============================================================================
@@ -2710,7 +2718,11 @@ where
     /// `WebPlatform::run` invokes it before starting the RAF loop
     /// (ADR-0039 slice 2 migration; behavior-preserving, since `on_ready`
     /// already runs synchronously on this thread before `run` returns).
-    fn bootstrap_web<V>(root: V, config: AppConfig)
+    ///
+    /// Returns `Err` on bootstrap failure — `on_ready` itself is fallible
+    /// now, so `WebPlatform::run` does not install the RAF loop over a
+    /// half-built page.
+    fn bootstrap_web<V>(root: V, config: AppConfig) -> anyhow::Result<()>
     where
         V: View + StatelessView + Clone + 'static,
     {
@@ -2730,9 +2742,15 @@ where
         // 1. Open window (creates canvas). `Ready` is guaranteed inside
         // `on_ready` (ADR-0039 §1).
         let options: WindowOptions = (&config).into();
-        let window = owner_platform_installed(|owner| owner.open_window(options))
+        let window = match owner_platform_installed(|owner| owner.open_window(options))
             .and_then(flui_platform::WindowOpen::try_ready)
-            .expect("Failed to create canvas window");
+        {
+            Ok(window) => window,
+            Err(error) => {
+                tracing::error!(%error, "Failed to create canvas window");
+                return Err(anyhow::Error::from(error).context("Failed to create canvas window"));
+            }
+        };
 
         // 2. Shared renderer slot — starts as None, filled async once the WebGPU
         //    adapter is available. `Option` lets the frame callback skip frames that
@@ -2773,7 +2791,7 @@ where
             Ok(realm) => realm,
             Err(error) => {
                 tracing::error!(%error, "UiRealm construction failed");
-                return;
+                return Err(anyhow::anyhow!(error).context("UiRealm construction failed"));
             }
         };
         let logical = window.logical_size();
@@ -2787,7 +2805,7 @@ where
         });
         if let Err(e) = attach {
             tracing::error!("Root widget attach failed: {:?}", e);
-            return;
+            return Err(anyhow::anyhow!(e).context("Root widget attach failed"));
         }
         let realm_dispatch = install_platform_realm(ui_realm);
 
@@ -2958,6 +2976,7 @@ where
         Scheduler::instance().handle_app_lifecycle_state_change(AppLifecycleState::Resumed);
 
         tracing::info!("Web platform initialized with callbacks");
+        Ok(())
     }
 
     // Run the event loop (takes ownership of the platform). No
@@ -2968,11 +2987,19 @@ where
     // (ADR-0039 §6/§7 "wasm posture"). An explicit web detach/quit
     // ownership hook is deferred until the platform exposes a callback
     // whose lifetime encloses the RAF registration.
-    platform.run(Box::new(move |owner| {
+    let result = platform.run(Box::new(move |owner| {
         install_owner_platform(owner);
-        bootstrap_web(root, config);
+        bootstrap_web(root, config)?;
         tracing::info!("Web platform ready");
+        Ok(())
     }));
+
+    // `on_ready`'s `Err` propagates straight out of `Platform::run`:
+    // `WebPlatform::run` does not install the RAF loop over a half-built
+    // page in that case.
+    if let Err(err) = result {
+        panic!("web bootstrap failed: {err:?}");
+    }
 }
 
 #[cfg(test)]
@@ -3164,11 +3191,13 @@ mod tests {
         {
             let _clear_guard = OwnerHostClearGuard::arm();
             let platform = headless_platform();
-            platform.run(Box::new(move |owner| {
+            let result = platform.run(Box::new(move |owner| {
                 install_owner_platform(owner);
                 let observed = with_owner_platform(|_owner| true);
                 seen_while_installed_for_closure.set(observed == Some(true));
+                Ok(())
             }));
+            assert!(result.is_ok(), "on_ready returns Ok here");
         } // `_clear_guard` drops here.
 
         assert!(
@@ -3188,7 +3217,7 @@ mod tests {
         let unwind = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _clear_guard = OwnerHostClearGuard::arm();
             let platform = headless_platform();
-            platform.run(Box::new(|owner| {
+            let _ = platform.run(Box::new(|owner| {
                 install_owner_platform(owner);
                 panic!("exercise on_ready panic cleanup");
             }));
@@ -3200,6 +3229,42 @@ mod tests {
             "a panic inside on_ready must still unwind through the clear guard \
              (armed before Platform::run, not inside on_ready) rather than \
              leaking the host onto this thread"
+        );
+    }
+
+    /// `on_ready` returning `Err` must propagate all the way out of
+    /// `Platform::run` — not be swallowed into
+    /// a bare log while the loop keeps running a half-built app — AND the
+    /// `OWNER_PLATFORM_HOST` TLS clear guard (armed before `run`, per the
+    /// existing unwind-safety contract) must still fire on this ordinary
+    /// `Err` return, exactly as it does on a panic.
+    #[test]
+    fn owner_platform_host_on_ready_error_propagates_and_still_clears() {
+        use flui_platform::headless_platform;
+
+        let result = {
+            let _clear_guard = OwnerHostClearGuard::arm();
+            let platform = headless_platform();
+            platform.run(Box::new(|owner| {
+                install_owner_platform(owner);
+                assert!(
+                    with_owner_platform(|_| ()).is_some(),
+                    "the host is installed while on_ready runs, even on the \
+                     path that is about to fail"
+                );
+                Err(anyhow::anyhow!("simulated bootstrap failure"))
+            }))
+        }; // `_clear_guard` drops here -- before the assertions below.
+
+        assert!(
+            result.is_err(),
+            "on_ready's Err must propagate out of Platform::run, not be \
+             swallowed"
+        );
+        assert!(
+            with_owner_platform(|_| ()).is_none(),
+            "the clear guard must still remove the host on the Err path, \
+             the same as it does on a panic"
         );
     }
 
@@ -3222,7 +3287,7 @@ mod tests {
         // test's own `#[should_panic]` unwind leaves the singleton clean
         // for whatever runs on it next -- no hand-rolled restore guard
         // needed on top of `drive_frame`'s own recovery path.
-        Scheduler::instance().drive_frame(std::time::Instant::now(), || {
+        Scheduler::instance().drive_frame(web_time::Instant::now(), || {
             let _ = with_owner_platform(|_owner| ());
         });
     }
@@ -3247,7 +3312,7 @@ mod tests {
 
         let _clear_guard = OwnerHostClearGuard::arm();
         let platform = headless_platform();
-        platform.run(Box::new(move |owner| {
+        let result = platform.run(Box::new(move |owner| {
             install_owner_platform(owner);
             let before_teardown = with_owner_platform(|_owner| true) == Some(true);
 
@@ -3260,7 +3325,9 @@ mod tests {
 
             let after_teardown = with_owner_platform(|_owner| true) == Some(true);
             observed_for_closure.set((before_teardown, after_teardown));
+            Ok(())
         }));
+        assert!(result.is_ok(), "on_ready returns Ok here");
 
         let (before_teardown, after_teardown) = observed.get();
         assert!(

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -2270,7 +2270,7 @@ where
     // inside `on_ready` — so a panic anywhere inside `on_ready` (or later,
     // on backends where `run` keeps running after it) unwinds through the
     // guard and cannot leak the host onto this thread past this call
-    // (ADR-0039 §6, U7).
+    // (ADR-0039 §6).
     let _owner_host_clear_guard = OwnerHostClearGuard::arm();
     platform.run(Box::new(move |owner| {
         install_owner_platform(owner);
@@ -2661,7 +2661,7 @@ where
     }
 
     // Owner-host clear guard armed BEFORE `run(...)`, not inside `on_ready`
-    // (ADR-0039 §6, U7) — see `run_desktop`'s matching comment.
+    // (ADR-0039 §6) — see `run_desktop`'s matching comment.
     let _owner_host_clear_guard = OwnerHostClearGuard::arm();
     platform.run(Box::new(move |owner| {
         install_owner_platform(owner);
@@ -3134,7 +3134,7 @@ mod tests {
     }
 
     // ========================================================================
-    // Owner-platform host tests (ADR-0039 §6, U7)
+    // Owner-platform host tests (ADR-0039 §6)
     // ========================================================================
 
     /// Serializes tests that mutate `Scheduler::instance()`'s process-global

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -146,6 +146,31 @@ pub(crate) fn install_owner_platform(owner: flui_platform::OwnerPlatform) {
 ///     drive their own binding-local `Scheduler`, never the
 ///     `Scheduler::instance()` singleton this checks, so fences (a) and (b)
 ///     are the load-bearing ones there — stated here, not hidden.
+///
+/// # `owner.shared()`'s method list is a compile-time fence too
+///
+/// Code reached through this accessor that isn't owner-thread-affine goes
+/// through [`OwnerPlatform::shared`](flui_platform::OwnerPlatform::shared),
+/// which returns `SharedPlatform` — a type whose method list IS the fence
+/// (no owner-affine method, e.g. `open_window`, is ever added to it; see
+/// its own rustdoc). This
+/// `compile_fail` doctest is CI-run evidence for that fence: `flui-app`
+/// dev/normal-depends on `flui-platform` and its own doc tests DO run under
+/// `just test-doc`, unlike the equivalent illustration inside
+/// `flui-platform` itself (excluded from that gate, `justfile:177`).
+///
+/// ```compile_fail,E0599
+/// use flui_platform::headless_platform;
+///
+/// let _ = headless_platform().run(Box::new(|owner| {
+///     let shared = owner.shared();
+///     // `SharedPlatform` has no `open_window` — it stays owner-affine on
+///     // `OwnerPlatform` only. Fails with "no method named `open_window`
+///     // found for struct `SharedPlatform`" (E0599).
+///     let _ = shared.open_window(Default::default());
+///     Ok(())
+/// }));
+/// ```
 #[cfg(not(target_os = "ios"))]
 pub(crate) fn with_owner_platform<R>(
     f: impl FnOnce(&flui_platform::OwnerPlatform) -> R,

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -90,6 +90,118 @@ thread_local! {
         const { std::cell::RefCell::new(RealmHost::new()) };
 }
 
+// ============================================================================
+// Loop-scoped owner-platform host (ADR-0039 §6)
+// ============================================================================
+
+#[cfg(not(target_os = "ios"))]
+thread_local! {
+    /// Loop-scoped host for the owner-thread platform capability
+    /// (ADR-0039), *separate from* [`PLATFORM_REALM_HOST`]: a realm's
+    /// teardown must not strand the loop's capability, because the loop may
+    /// host another realm before it exits (hot-restart does exactly this
+    /// today, `install_platform_realm`). Deliberately not cleared by
+    /// `teardown_platform_realm`.
+    ///
+    /// `OwnerPlatform` is not `Clone` (ADR-0039 slice-2 decision record), so
+    /// the only sanctioned way to read this slot is the borrow-style
+    /// [`with_owner_platform`] accessor below — there is no path to a
+    /// durable owned copy that outlives one access.
+    static OWNER_PLATFORM_HOST: std::cell::RefCell<Option<flui_platform::OwnerPlatform>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Installs `owner` in the loop-scoped host. Call once, at the top of each
+/// backend's `on_ready` callback (ADR-0039 §6) — every `run_*` entry point
+/// in this module does so immediately after minting/receiving its
+/// `OwnerPlatform`.
+#[cfg(not(target_os = "ios"))]
+pub(crate) fn install_owner_platform(owner: flui_platform::OwnerPlatform) {
+    OWNER_PLATFORM_HOST.with(|slot| {
+        *slot.borrow_mut() = Some(owner);
+    });
+}
+
+/// Borrow-style access to the loop-scoped owner-platform capability.
+/// `None` if no `OwnerPlatform` is currently installed on this thread
+/// (before `on_ready`, or after the host was cleared).
+///
+/// Three fences (ADR-0039 §6), all landing in this one accessor:
+///
+/// (a) **Borrow, not clone.** `pub(crate)` to `flui-app`'s `app` module,
+///     never re-exported; `OwnerPlatform` isn't `Clone`, so there is no way
+///     to escape this closure with a durable owned copy — every access
+///     re-crosses the fence.
+/// (b) **Static scan.** This function's name carries the scanner token
+///     `owner_platform`, so `scripts/check-frame-capability-scope.sh`
+///     (trigger #22) mechanically rejects any call from inside
+///     `build`/`perform_layout`/`paint`/composite bodies, across every
+///     crate the scanner sweeps.
+/// (c) **Runtime backstop.** `debug_assert!`s the process-global scheduler
+///     is not inside the frame transaction. "Not inside a frame phase" per
+///     the ADR means `TransientCallbacks`/`MidFrameMicrotasks`/
+///     `PersistentCallbacks` are forbidden; `Idle` and `PostFrameCallbacks`
+///     are allowed (legitimate ADR-0021-style post-frame work). This fence
+///     is **vacuous on binding-local frame paths**: headless/test bindings
+///     drive their own binding-local `Scheduler`, never the
+///     `Scheduler::instance()` singleton this checks, so fences (a) and (b)
+///     are the load-bearing ones there — stated here, not hidden.
+#[cfg(not(target_os = "ios"))]
+pub(crate) fn with_owner_platform<R>(
+    f: impl FnOnce(&flui_platform::OwnerPlatform) -> R,
+) -> Option<R> {
+    #[cfg(debug_assertions)]
+    {
+        let phase = Scheduler::instance().phase();
+        debug_assert!(
+            !matches!(
+                phase,
+                flui_scheduler::SchedulerPhase::TransientCallbacks
+                    | flui_scheduler::SchedulerPhase::MidFrameMicrotasks
+                    | flui_scheduler::SchedulerPhase::PersistentCallbacks
+            ),
+            "BUG: with_owner_platform called while the scheduler is inside \
+             the frame transaction (phase {phase:?}) -- owner_platform must \
+             not be acquired from build/layout/paint (ADR-0039 §6, trigger #22)"
+        );
+    }
+    OWNER_PLATFORM_HOST.with(|slot| slot.borrow().as_ref().map(f))
+}
+
+/// Unwind-safe TLS clearing. Arm this guard *before* calling
+/// `Platform::run(...)` on any backend whose `run` returns (winit,
+/// headless, Android) — not inside `on_ready` — so a panic anywhere inside
+/// `on_ready` or later in `run` unwinds through the guard's `Drop` and
+/// cannot leak the host into whatever runs on this thread next (notably,
+/// the next test). Clearing an already-empty slot is a no-op.
+///
+/// Web deliberately arms no guard: the host stays resident for the page's
+/// lifetime (see the web runner's own comment on this). macOS is moot:
+/// `run` never returns there (`terminate:` exits the process).
+#[cfg(not(target_os = "ios"))]
+#[must_use = "the guard must stay alive across the Platform::run(...) call it \
+              guards, or the TLS host clears immediately instead of at loop exit"]
+pub(crate) struct OwnerHostClearGuard {
+    _private: (),
+}
+
+#[cfg(not(target_os = "ios"))]
+impl OwnerHostClearGuard {
+    /// Arms the guard. Call immediately before `Platform::run(...)`.
+    pub(crate) fn arm() -> Self {
+        Self { _private: () }
+    }
+}
+
+#[cfg(not(target_os = "ios"))]
+impl Drop for OwnerHostClearGuard {
+    fn drop(&mut self) {
+        OWNER_PLATFORM_HOST.with(|slot| {
+            slot.borrow_mut().take();
+        });
+    }
+}
+
 #[cfg(not(target_os = "ios"))]
 struct RealmHost {
     realm: Option<super::ui_realm::UiRealm>,
@@ -1682,7 +1794,7 @@ where
 
     use flui_engine::wgpu::Renderer;
     use flui_platform::{
-        Platform, WindowOptions,
+        WindowOptions,
         traits::{DispatchEventResult, PlatformInput},
     };
     use parking_lot::Mutex;
@@ -1737,7 +1849,6 @@ where
     /// actually formats it — rustfmt does not reliably reformat very large
     /// closure literals passed as call arguments.
     fn bootstrap_desktop<V>(
-        platform: &dyn Platform,
         root: V,
         config: AppConfig,
         worker_reload: WorkerReload,
@@ -1748,13 +1859,22 @@ where
     {
         tracing::info!("Platform ready");
 
+        // No `owner: OwnerPlatform` parameter: the caller already installed
+        // it in the loop-scoped host (ADR-0039 §6) before calling this
+        // function, so every owner-thread touch below re-crosses the fenced
+        // `with_owner_platform` accessor instead of holding a private copy
+        // (`OwnerPlatform` isn't `Clone` by design — there is exactly one
+        // instance, and the TLS host is its one sanctioned home for the
+        // rest of the loop's life).
+        fn owner_platform_installed<R>(f: impl FnOnce(&flui_platform::OwnerPlatform) -> R) -> R {
+            with_owner_platform(f)
+                .expect("BUG: bootstrap_desktop runs only after install_owner_platform")
+        }
+
         // 0. Wire the platform clipboard (ADR-0034) before anything else can
-        // observe `AppBinding::clipboard()`. `platform` is `&dyn Platform`
-        // here, still fully intact — `on_ready` runs before `Platform::run`
-        // returns, so this is not the pre-`run()` extraction Android/web
-        // need, just an early call on a reference that stays valid for the
-        // rest of this function.
-        AppBinding::instance().set_platform_clipboard(platform.clipboard());
+        // observe `AppBinding::clipboard()`.
+        let clipboard = owner_platform_installed(|owner| owner.shared().clipboard());
+        AppBinding::instance().set_platform_clipboard(clipboard);
 
         // Debug overlay: `Some` stats IS the enable flag, so this is the
         // single point that turns the frame path's overlay work on.
@@ -1763,17 +1883,21 @@ where
         // 1. Open window now that the event loop is running. Window creation is
         // an environment failure (display server hiccup, resource exhaustion),
         // not a `BUG:` invariant, and — unlike platform init above — this DOES
-        // run inside `on_ready` with a live `platform` and `bootstrap_error_slot`
-        // available, so it gets the same deferred-panic-after-teardown handling
-        // as the GPU/realm/attach failures below instead of an immediate bare
-        // `.expect()` panic mid-`on_ready`.
+        // run inside `on_ready` with a live owner capability and
+        // `bootstrap_error_slot` available, so it gets the same
+        // deferred-panic-after-teardown handling as the GPU/realm/attach
+        // failures below instead of an immediate bare `.expect()` panic
+        // mid-`on_ready`. `Ready` is guaranteed here (ADR-0039 §1).
         let options: WindowOptions = (&config).into();
-        let window = match platform.open_window(options) {
+        let window = match owner_platform_installed(|owner| owner.open_window(options))
+            .and_then(flui_platform::WindowOpen::try_ready)
+        {
             Ok(window) => window,
             Err(error) => {
                 tracing::error!(%error, "Window creation failed");
-                *bootstrap_error_slot.borrow_mut() = Some(error.context("Window creation failed"));
-                platform.quit();
+                *bootstrap_error_slot.borrow_mut() =
+                    Some(anyhow::Error::from(error).context("Window creation failed"));
+                owner_platform_installed(flui_platform::OwnerPlatform::quit);
                 return;
             }
         };
@@ -1787,7 +1911,7 @@ where
                 tracing::error!("GPU init failed: {:?}", e);
                 *bootstrap_error_slot.borrow_mut() =
                     Some(anyhow::anyhow!(e).context("GPU init failed"));
-                platform.quit();
+                owner_platform_installed(flui_platform::OwnerPlatform::quit);
                 return;
             }
         };
@@ -1811,7 +1935,7 @@ where
                 tracing::error!(error = %e, "UiRealm construction failed");
                 *bootstrap_error_slot.borrow_mut() =
                     Some(anyhow::anyhow!(e).context("UiRealm construction failed"));
-                platform.quit();
+                owner_platform_installed(flui_platform::OwnerPlatform::quit);
                 return;
             }
         };
@@ -1828,7 +1952,7 @@ where
             tracing::error!("Root widget attach failed: {:?}", e);
             *bootstrap_error_slot.borrow_mut() =
                 Some(anyhow::anyhow!(e).context("Root widget attach failed"));
-            platform.quit();
+            owner_platform_installed(flui_platform::OwnerPlatform::quit);
             return;
         }
 
@@ -2059,25 +2183,27 @@ where
         // arrive before lifecycle observers run.
 
         // Platform quit -> Detached (frames disabled, listeners notified).
-        platform.on_quit(Box::new(move || {
-            tracing::info!("Platform quit");
-            debug_assert_eq!(
-                std::thread::current().id(),
-                realm_dispatch.owner_thread,
-                "platform on_quit must fire on the realm's owner thread"
-            );
-            if let Err(error) = dispatch_platform_realm(
-                realm_dispatch,
-                RealmEvent::LifecycleTarget(AppLifecycleState::Detached),
-            ) {
-                tracing::warn!(
-                    ?error,
-                    "realm unavailable during Detached lifecycle dispatch"
+        owner_platform_installed(|owner| {
+            owner.shared().on_quit(Box::new(move || {
+                tracing::info!("Platform quit");
+                debug_assert_eq!(
+                    std::thread::current().id(),
+                    realm_dispatch.owner_thread,
+                    "platform on_quit must fire on the realm's owner thread"
                 );
-                Scheduler::instance()
-                    .handle_app_lifecycle_state_change(AppLifecycleState::Detached);
-            }
-        }));
+                if let Err(error) = dispatch_platform_realm(
+                    realm_dispatch,
+                    RealmEvent::LifecycleTarget(AppLifecycleState::Detached),
+                ) {
+                    tracing::warn!(
+                        ?error,
+                        "realm unavailable during Detached lifecycle dispatch"
+                    );
+                    Scheduler::instance()
+                        .handle_app_lifecycle_state_change(AppLifecycleState::Detached);
+                }
+            }));
+        });
 
         // Window close -> log and let the platform handle quit
         // (Windows window proc already calls PostQuitMessage on WM_DESTROY)
@@ -2139,9 +2265,16 @@ where
     // is unreachable beforehand); opening it earlier would deadlock forever
     // waiting for a pump that never started. `on_ready` runs exactly once,
     // synchronously, on this same thread — see `Platform::run`'s doc.
-    platform.run(Box::new(move |platform: &dyn Platform| {
+    //
+    // The owner-host clear guard is armed HERE, before `run(...)`, not
+    // inside `on_ready` — so a panic anywhere inside `on_ready` (or later,
+    // on backends where `run` keeps running after it) unwinds through the
+    // guard and cannot leak the host onto this thread past this call
+    // (ADR-0039 §6, U7).
+    let _owner_host_clear_guard = OwnerHostClearGuard::arm();
+    platform.run(Box::new(move |owner| {
+        install_owner_platform(owner);
         bootstrap_desktop(
-            platform,
             root,
             config,
             worker_reload,
@@ -2246,267 +2379,293 @@ where
 
     let platform: Box<dyn Platform> = Box::new(AndroidPlatform::new(app));
 
-    // 0. Wire the platform clipboard (ADR-0034). Extracted from the `Box`
-    // now, while `platform` is still intact: `platform.run(...)` below takes
-    // `self: Box<Self>` by value, and the `on_ready` closure it invokes
-    // discards its `platform` parameter, so there is no later point at which
-    // this platform's `clipboard()` is reachable at all.
-    AppBinding::instance().set_platform_clipboard(platform.clipboard());
+    /// The actual Android bootstrap: window, GPU, realm, and callback
+    /// wiring. Runs once, synchronously, inside `on_ready` — which this
+    /// backend delivers at the first `Resume` (module doc,
+    /// `platforms/android/mod.rs:13`: "Resumed -> on_ready() -> create
+    /// surface"). Migrated here from before `run()` (ADR-0039 slice 2):
+    /// `on_ready` is `FnOnce` and fires exactly once, matching today's
+    /// once-only pre-run bootstrap semantics exactly — no behavior change
+    /// is intended or made on the subsequent-Resume/surface-recreation
+    /// path, which flows through the backend's existing window/surface
+    /// code untouched by this migration. **Unvalidated on-device**: no
+    /// device and no CI compile target for `target_os = "android"` verify
+    /// this; stated here and in the registry rather than assumed.
+    fn bootstrap_android<V>(root: V, config: AppConfig, hot_reload: ScenePlugin)
+    where
+        V: View + StatelessView + Clone + 'static,
+    {
+        fn owner_platform_installed<R>(f: impl FnOnce(&flui_platform::OwnerPlatform) -> R) -> R {
+            with_owner_platform(f)
+                .expect("BUG: bootstrap_android runs only after install_owner_platform")
+        }
 
-    // Debug overlay: `Some` stats IS the enable flag, so this is the
-    // single point that turns the frame path's overlay work on.
-    AppBinding::instance().set_performance_overlay(config.show_performance_overlay);
+        // 0. Wire the platform clipboard (ADR-0034).
+        let clipboard = owner_platform_installed(|owner| owner.shared().clipboard());
+        AppBinding::instance().set_platform_clipboard(clipboard);
 
-    // 1. Open window (wraps the existing ANativeWindow) before run()
-    let options: WindowOptions = (&config).into();
-    let window = platform
-        .open_window(options)
-        .expect("Failed to create Android window");
+        // Debug overlay: `Some` stats IS the enable flag, so this is the
+        // single point that turns the frame path's overlay work on.
+        AppBinding::instance().set_performance_overlay(config.show_performance_overlay);
 
-    // 2. Create GPU renderer (Vulkan backend on Android)
-    let phys_size = window.physical_size();
-    let renderer = pollster::block_on(Renderer::new(window.as_ref()));
-    let mut renderer = match renderer {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::error!("GPU init failed: {:?}", e);
+        // 1. Open window (wraps the existing ANativeWindow). `Ready` is
+        // guaranteed inside `on_ready` (ADR-0039 §1).
+        let options: WindowOptions = (&config).into();
+        let window = owner_platform_installed(|owner| owner.open_window(options))
+            .and_then(flui_platform::WindowOpen::try_ready)
+            .expect("Failed to create Android window");
+
+        // 2. Create GPU renderer (Vulkan backend on Android)
+        let phys_size = window.physical_size();
+        let renderer = pollster::block_on(Renderer::new(window.as_ref()));
+        let mut renderer = match renderer {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!("GPU init failed: {:?}", e);
+                return;
+            }
+        };
+        renderer.resize(phys_size.width.0 as u32, phys_size.height.0 as u32);
+
+        // 3. Mount root widget (used when no plugin is active) at the
+        // LOGICAL size; the paint root's DPR transform maps to physical.
+        let scale_factor = window.scale_factor() as f32;
+        AppBinding::instance()
+            .render_pipeline_mut()
+            .set_device_pixel_ratio(scale_factor);
+        let ui_realm = match super::ui_realm::UiRealm::new(
+            AppBinding::instance(),
+            AppBinding::instance().frame_wake_callback(),
+            Arc::clone(&window),
+        ) {
+            Ok(realm) => realm,
+            Err(error) => {
+                tracing::error!(%error, "UiRealm construction failed");
+                return;
+            }
+        };
+        let logical = window.logical_size();
+        let attach = ui_realm.enter(|realm| {
+            AppBinding::instance().attach_root_widget_with_size(
+                realm,
+                &root,
+                logical.width.0 as f32,
+                logical.height.0 as f32,
+            )
+        });
+        if let Err(e) = attach {
+            tracing::error!("Root widget attach failed: {:?}", e);
             return;
         }
-    };
-    renderer.resize(phys_size.width.0 as u32, phys_size.height.0 as u32);
+        let realm_dispatch = install_platform_realm(ui_realm);
 
-    // 3. Mount root widget (used when no plugin is active) at the
-    // LOGICAL size; the paint root's DPR transform maps to physical.
-    let scale_factor = window.scale_factor() as f32;
-    AppBinding::instance()
-        .render_pipeline_mut()
-        .set_device_pixel_ratio(scale_factor);
-    let ui_realm = match super::ui_realm::UiRealm::new(
-        AppBinding::instance(),
-        AppBinding::instance().frame_wake_callback(),
-        Arc::clone(&window),
-    ) {
-        Ok(realm) => realm,
-        Err(error) => {
-            tracing::error!(%error, "UiRealm construction failed");
-            return;
-        }
-    };
-    let logical = window.logical_size();
-    let attach = ui_realm.enter(|realm| {
-        AppBinding::instance().attach_root_widget_with_size(
-            realm,
-            &root,
-            logical.width.0 as f32,
-            logical.height.0 as f32,
-        )
-    });
-    if let Err(e) = attach {
-        tracing::error!("Root widget attach failed: {:?}", e);
-        return;
-    }
-    let realm_dispatch = install_platform_realm(ui_realm);
+        // 4. Wrap renderer for callback sharing
+        let renderer = Arc::new(Mutex::new(renderer));
 
-    // 4. Wrap renderer for callback sharing
-    let renderer = Arc::new(Mutex::new(renderer));
+        // 5. Register input callback -> entered realm input dispatch
+        window.on_input(Box::new(move |input: PlatformInput| {
+            let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::Input(input));
+            DispatchEventResult::resolved(false, true)
+        }));
 
-    // 5. Register input callback -> entered realm input dispatch
-    window.on_input(Box::new(move |input: PlatformInput| {
-        let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::Input(input));
-        DispatchEventResult::resolved(false, true)
-    }));
+        // 6. Register frame callback -- with hot-reload plugin override
+        let renderer_frame = Arc::clone(&renderer);
+        let hot_reload_frame = hot_reload.clone();
+        window.on_request_frame(Box::new(move || {
+            let renderer_frame = Arc::clone(&renderer_frame);
+            let hot_reload_frame = hot_reload_frame.clone();
+            let _ = dispatch_platform_realm(
+                realm_dispatch,
+                RealmEvent::Frame(Box::new(move |realm| {
+                    // Owner-inbox drain: commands and worker results commit HERE,
+                    // at the frame boundary while the scheduler phase is Idle —
+                    // never inside the frame transaction below. Runs before
+                    // everything else in this callback, including the hot-reload
+                    // plugin scene fast path below, so a command-driven redraw
+                    // request is observed by the very frame its wake produced
+                    // regardless of which rendering path this frame takes.
+                    let inbox_redraw = drain_owner_inbox(realm);
 
-    // 6. Register frame callback -- with hot-reload plugin override
-    let renderer_frame = Arc::clone(&renderer);
-    let hot_reload_frame = hot_reload.clone();
-    window.on_request_frame(Box::new(move || {
-        let renderer_frame = Arc::clone(&renderer_frame);
-        let hot_reload_frame = hot_reload_frame.clone();
-        let _ = dispatch_platform_realm(
-            realm_dispatch,
-            RealmEvent::Frame(Box::new(move |realm| {
-                // Owner-inbox drain: commands and worker results commit HERE,
-                // at the frame boundary while the scheduler phase is Idle —
-                // never inside the frame transaction below. Runs before
-                // everything else in this callback, including the hot-reload
-                // plugin scene fast path below, so a command-driven redraw
-                // request is observed by the very frame its wake produced
-                // regardless of which rendering path this frame takes.
-                let inbox_redraw = drain_owner_inbox(realm);
+                    let mut r = renderer_frame.lock();
+                    let (w, h) = r.size();
 
-                let mut r = renderer_frame.lock();
-                let (w, h) = r.size();
-
-                // If a scene plugin is live it owns this presentation frame,
-                // but the callback still executes inside the realm entry
-                // scope. Always `false` in a build without the `hot-reload`
-                // feature.
-                if hot_reload_frame.try_render_frame(&mut *r, w as f32, h as f32) {
-                    return;
-                }
-                drop(r);
-
-                let binding = AppBinding::instance();
-                let has_pending = binding.has_pending_work(realm);
-                let dirty = inbox_redraw || binding.needs_redraw() || has_pending;
-                let scheduler = Scheduler::instance();
-                match wake_action(scheduler.frames_enabled(), dirty, scheduler.is_frame_scheduled())
-                {
-                    WakeAction::Skip => return,
-                    WakeAction::PumpAsync => {
-                        // Frames disabled: pump only the async driver — no
-                        // begin/draw frame, no tickers, no pipeline, no
-                        // present. See `wake_action`'s doc for why this is
-                        // the only thing keeping a spawned future
-                        // progressing while backgrounded.
-                        //
-                        // `finish_async_pump` MUST run first, not after —
-                        // see `Scheduler::finish_async_pump`'s doc for the
-                        // starvation hazard this ordering avoids.
-                        scheduler.finish_async_pump();
-                        scheduler.drive_async_tasks();
-                        // Unconditional throttle: a self-re-arming task has
-                        // no vsync/present call to bound it here either, and
-                        // this arm has no gate-open signal to make the pace
-                        // conditional the way desktop's does — see
-                        // `NO_PRESENT_FALLBACK_PACE`'s doc.
-                        std::thread::sleep(NO_PRESENT_FALLBACK_PACE);
+                    // If a scene plugin is live it owns this presentation frame,
+                    // but the callback still executes inside the realm entry
+                    // scope. Always `false` in a build without the `hot-reload`
+                    // feature.
+                    if hot_reload_frame.try_render_frame(&mut *r, w as f32, h as f32) {
                         return;
                     }
-                    WakeAction::Render => {}
-                }
+                    drop(r);
 
-                let now = web_time::Instant::now();
-                // Scheduler callbacks and rendering share ONE `UiRealm::enter`
-                // dynamic extent; callbacks may legally resolve realm-local
-                // capabilities throughout the complete frame transaction.
-                scheduler.drive_frame(now, || {
-                    let mut r = renderer_frame.lock();
-                    binding.render_frame_entered(realm, &mut *r);
+                    let binding = AppBinding::instance();
+                    let has_pending = binding.has_pending_work(realm);
+                    let dirty = inbox_redraw || binding.needs_redraw() || has_pending;
+                    let scheduler = Scheduler::instance();
+                    match wake_action(scheduler.frames_enabled(), dirty, scheduler.is_frame_scheduled())
+                    {
+                        WakeAction::Skip => return,
+                        WakeAction::PumpAsync => {
+                            // Frames disabled: pump only the async driver — no
+                            // begin/draw frame, no tickers, no pipeline, no
+                            // present. See `wake_action`'s doc for why this is
+                            // the only thing keeping a spawned future
+                            // progressing while backgrounded.
+                            //
+                            // `finish_async_pump` MUST run first, not after —
+                            // see `Scheduler::finish_async_pump`'s doc for the
+                            // starvation hazard this ordering avoids.
+                            scheduler.finish_async_pump();
+                            scheduler.drive_async_tasks();
+                            // Unconditional throttle: a self-re-arming task has
+                            // no vsync/present call to bound it here either, and
+                            // this arm has no gate-open signal to make the pace
+                            // conditional the way desktop's does — see
+                            // `NO_PRESENT_FALLBACK_PACE`'s doc.
+                            std::thread::sleep(NO_PRESENT_FALLBACK_PACE);
+                            return;
+                        }
+                        WakeAction::Render => {}
+                    }
 
-                    if r.is_device_lost() {
-                        match pollster::block_on(r.recover()) {
-                            Ok(()) => {
-                                tracing::warn!("GPU device lost — recovered successfully");
-                                AppBinding::instance().wake_frame();
-                            }
-                            Err(e) => {
-                                tracing::error!(error = ?e, "GPU device recovery failed; will retry next frame");
+                    let now = web_time::Instant::now();
+                    // Scheduler callbacks and rendering share ONE `UiRealm::enter`
+                    // dynamic extent; callbacks may legally resolve realm-local
+                    // capabilities throughout the complete frame transaction.
+                    scheduler.drive_frame(now, || {
+                        let mut r = renderer_frame.lock();
+                        binding.render_frame_entered(realm, &mut *r);
+
+                        if r.is_device_lost() {
+                            match pollster::block_on(r.recover()) {
+                                Ok(()) => {
+                                    tracing::warn!("GPU device lost — recovered successfully");
+                                    AppBinding::instance().wake_frame();
+                                }
+                                Err(e) => {
+                                    tracing::error!(error = ?e, "GPU device recovery failed; will retry next frame");
+                                }
                             }
                         }
-                    }
-                });
-            })),
-        );
-    }));
+                    });
+                })),
+            );
+        }));
 
-    // 7. Register resize callback -> renderer.resize()
-    let renderer_resize = Arc::clone(&renderer);
-    window.on_resize(Box::new(move |size, scale_factor| {
-        let apply_size = size;
-        let renderer_resize = Arc::clone(&renderer_resize);
-        let _ = dispatch_platform_realm(
-            realm_dispatch,
-            RealmEvent::Resize {
-                size,
-                scale_factor,
-                apply_surface: Box::new(move || {
-                    let w = (apply_size.width.0 * scale_factor) as u32;
-                    let h = (apply_size.height.0 * scale_factor) as u32;
-                    renderer_resize.lock().resize(w, h);
-                }),
-            },
-        );
-    }));
+        // 7. Register resize callback -> renderer.resize()
+        let renderer_resize = Arc::clone(&renderer);
+        window.on_resize(Box::new(move |size, scale_factor| {
+            let apply_size = size;
+            let renderer_resize = Arc::clone(&renderer_resize);
+            let _ = dispatch_platform_realm(
+                realm_dispatch,
+                RealmEvent::Resize {
+                    size,
+                    scale_factor,
+                    apply_surface: Box::new(move || {
+                        let w = (apply_size.width.0 * scale_factor) as u32;
+                        let h = (apply_size.height.0 * scale_factor) as u32;
+                        renderer_resize.lock().resize(w, h);
+                    }),
+                },
+            );
+        }));
 
-    // 8. Lifecycle callbacks
-    //
-    // Detached is realm-dispatched so interrupted gesture state is drained
-    // before lifecycle observers run.
+        // 8. Lifecycle callbacks
+        //
+        // Detached is realm-dispatched so interrupted gesture state is drained
+        // before lifecycle observers run.
 
-    // Platform quit -> Detached (frames disabled, listeners notified).
-    platform.on_quit(Box::new(move || {
-        tracing::info!("Platform quit");
+        // Platform quit -> Detached (frames disabled, listeners notified).
+        owner_platform_installed(|owner| {
+            owner.shared().on_quit(Box::new(move || {
+                tracing::info!("Platform quit");
+                debug_assert_eq!(
+                    std::thread::current().id(),
+                    realm_dispatch.owner_thread,
+                    "platform on_quit must fire on the realm's owner thread"
+                );
+                if let Err(error) = dispatch_platform_realm(
+                    realm_dispatch,
+                    RealmEvent::LifecycleTarget(AppLifecycleState::Detached),
+                ) {
+                    tracing::warn!(
+                        ?error,
+                        "realm unavailable during Detached lifecycle dispatch"
+                    );
+                    Scheduler::instance()
+                        .handle_app_lifecycle_state_change(AppLifecycleState::Detached);
+                }
+            }));
+        });
+
+        // Window close (fired by Android Destroy event)
+        window.on_close(Box::new(move || {
+            tracing::info!("Window closed");
+        }));
+
+        // Window active status. On Android this one callback conflates real
+        // window focus (`MainEvent::GainedFocus`/`LostFocus`) with the app's
+        // actual pause/resume signal (`MainEvent::Resume`/`Pause` currently fire
+        // the identical `dispatch_active_status_change` — see
+        // `flui-platform`'s `platforms/android/mod.rs`); a dedicated
+        // `MainEvent` -> lifecycle callback that tells them apart is a named
+        // follow-up (ADR-0035), not this PR. Until that split lands, this keeps
+        // the existing transport but fixes the mapping: `false` ladders all the
+        // way to `Paused` and `true` back to `Resumed` — Android's
+        // backgrounding signal needs the deeper ladder the desktop/web
+        // `(visible, focused)` derivation (which only ever reaches
+        // `Inactive`/`Hidden`) does not produce.
+        window.on_active_status_change(Box::new(move |resumed| {
+            let target = if resumed {
+                AppLifecycleState::Resumed
+            } else {
+                AppLifecycleState::Paused
+            };
+            let _ = dispatch_platform_realm(
+                realm_dispatch,
+                RealmEvent::Frame(Box::new(move |realm| {
+                    let old = Scheduler::instance().lifecycle_state();
+                    emit_lifecycle_transition(realm, old, target);
+                })),
+            );
+        }));
+
+        // 9. Store window in AppBinding for runtime access — BEFORE marking the
+        // lifecycle Resumed or requesting the initial redraw. Both of those can
+        // synchronously run the first frame through `dispatch_platform_realm`;
+        // if `active_window` were still `None` at that point, anything
+        // resolving it during that frame (an autofocus `EditableText`
+        // attaching its IME client, for instance) would silently no-op instead
+        // of attaching.
+        AppBinding::instance().set_window(window);
+
+        // Mark lifecycle as started (Resumed).
         debug_assert_eq!(
             std::thread::current().id(),
             realm_dispatch.owner_thread,
-            "platform on_quit must fire on the realm's owner thread"
+            "android bootstrap must run on the realm's owner thread"
         );
-        if let Err(error) = dispatch_platform_realm(
-            realm_dispatch,
-            RealmEvent::LifecycleTarget(AppLifecycleState::Detached),
-        ) {
-            tracing::warn!(
-                ?error,
-                "realm unavailable during Detached lifecycle dispatch"
-            );
-            Scheduler::instance().handle_app_lifecycle_state_change(AppLifecycleState::Detached);
-        }
-    }));
+        Scheduler::instance().handle_app_lifecycle_state_change(AppLifecycleState::Resumed);
 
-    // Window close (fired by Android Destroy event)
-    window.on_close(Box::new(move || {
-        tracing::info!("Window closed");
-    }));
+        // 10. Request initial redraw, now that the window is stored.
+        // `wake_frame` (not `with_window(|w| w.request_redraw())`): it clones
+        // the window out from under `active_window`'s lock before calling
+        // through, so a backend whose `request_redraw` re-enters `AppBinding`
+        // synchronously (headless, in this crate's own tests) cannot deadlock
+        // on that same lock — the same clone-then-call discipline used by
+        // direct platform capabilities.
+        AppBinding::instance().wake_frame();
 
-    // Window active status. On Android this one callback conflates real
-    // window focus (`MainEvent::GainedFocus`/`LostFocus`) with the app's
-    // actual pause/resume signal (`MainEvent::Resume`/`Pause` currently fire
-    // the identical `dispatch_active_status_change` — see
-    // `flui-platform`'s `platforms/android/mod.rs`); a dedicated
-    // `MainEvent` -> lifecycle callback that tells them apart is a named
-    // follow-up (ADR-0035), not this PR. Until that split lands, this keeps
-    // the existing transport but fixes the mapping: `false` ladders all the
-    // way to `Paused` and `true` back to `Resumed` — Android's
-    // backgrounding signal needs the deeper ladder the desktop/web
-    // `(visible, focused)` derivation (which only ever reaches
-    // `Inactive`/`Hidden`) does not produce.
-    window.on_active_status_change(Box::new(move |resumed| {
-        let target = if resumed {
-            AppLifecycleState::Resumed
-        } else {
-            AppLifecycleState::Paused
-        };
-        let _ = dispatch_platform_realm(
-            realm_dispatch,
-            RealmEvent::Frame(Box::new(move |realm| {
-                let old = Scheduler::instance().lifecycle_state();
-                emit_lifecycle_transition(realm, old, target);
-            })),
-        );
-    }));
+        tracing::info!("Android platform initialized with callbacks (hot-reload enabled)");
+    }
 
-    // 9. Store window in AppBinding for runtime access — BEFORE marking the
-    // lifecycle Resumed or requesting the initial redraw. Both of those can
-    // synchronously run the first frame through `dispatch_platform_realm`;
-    // if `active_window` were still `None` at that point, anything
-    // resolving it during that frame (an autofocus `EditableText`
-    // attaching its IME client, for instance) would silently no-op instead
-    // of attaching.
-    AppBinding::instance().set_window(window);
-
-    // Mark lifecycle as started (Resumed).
-    debug_assert_eq!(
-        std::thread::current().id(),
-        realm_dispatch.owner_thread,
-        "android bootstrap must run on the realm's owner thread"
-    );
-    Scheduler::instance().handle_app_lifecycle_state_change(AppLifecycleState::Resumed);
-
-    // 10. Request initial redraw, now that the window is stored.
-    // `wake_frame` (not `with_window(|w| w.request_redraw())`): it clones
-    // the window out from under `active_window`'s lock before calling
-    // through, so a backend whose `request_redraw` re-enters `AppBinding`
-    // synchronously (headless, in this crate's own tests) cannot deadlock
-    // on that same lock — the same clone-then-call discipline used by
-    // direct platform capabilities.
-    AppBinding::instance().wake_frame();
-
-    tracing::info!("Android platform initialized with callbacks (hot-reload enabled)");
-
-    // Run the event loop (takes ownership of the platform)
-    platform.run(Box::new(|_platform| {
-        tracing::info!("Android platform ready");
+    // Owner-host clear guard armed BEFORE `run(...)`, not inside `on_ready`
+    // (ADR-0039 §6, U7) — see `run_desktop`'s matching comment.
+    let _owner_host_clear_guard = OwnerHostClearGuard::arm();
+    platform.run(Box::new(move |owner| {
+        install_owner_platform(owner);
+        bootstrap_android(root, config, hot_reload);
     }));
     teardown_platform_realm();
 }
@@ -2546,253 +2705,274 @@ where
 
     let platform = flui_platform::current_platform().expect("Failed to initialize web platform");
 
-    // 0. Wire the platform clipboard (ADR-0034). Extracted from the `Box`
-    // now, while `platform` is still intact — see `run_android`'s identical
-    // comment for why there is no later point at which this platform's
-    // `clipboard()` is reachable.
-    AppBinding::instance().set_platform_clipboard(platform.clipboard());
+    /// The actual web bootstrap: canvas window, renderer, realm, and
+    /// callback wiring. Runs once, synchronously, inside `on_ready` —
+    /// `WebPlatform::run` invokes it before starting the RAF loop
+    /// (ADR-0039 slice 2 migration; behavior-preserving, since `on_ready`
+    /// already runs synchronously on this thread before `run` returns).
+    fn bootstrap_web<V>(root: V, config: AppConfig)
+    where
+        V: View + StatelessView + Clone + 'static,
+    {
+        fn owner_platform_installed<R>(f: impl FnOnce(&flui_platform::OwnerPlatform) -> R) -> R {
+            with_owner_platform(f)
+                .expect("BUG: bootstrap_web runs only after install_owner_platform")
+        }
 
-    // Debug overlay: `Some` stats IS the enable flag, so this is the
-    // single point that turns the frame path's overlay work on.
-    AppBinding::instance().set_performance_overlay(config.show_performance_overlay);
+        // 0. Wire the platform clipboard (ADR-0034).
+        let clipboard = owner_platform_installed(|owner| owner.shared().clipboard());
+        AppBinding::instance().set_platform_clipboard(clipboard);
 
-    // 1. Open window (creates canvas) before run() since run() takes ownership
-    let options: WindowOptions = (&config).into();
-    let window = platform
-        .open_window(options)
-        .expect("Failed to create canvas window");
+        // Debug overlay: `Some` stats IS the enable flag, so this is the
+        // single point that turns the frame path's overlay work on.
+        AppBinding::instance().set_performance_overlay(config.show_performance_overlay);
 
-    // 2. Shared renderer slot — starts as None, filled async once the WebGPU
-    //    adapter is available. `Option` lets the frame callback skip frames that
-    //    arrive before the renderer is ready.
-    let renderer: Arc<Mutex<Option<Renderer>>> = Arc::new(Mutex::new(None));
+        // 1. Open window (creates canvas). `Ready` is guaranteed inside
+        // `on_ready` (ADR-0039 §1).
+        let options: WindowOptions = (&config).into();
+        let window = owner_platform_installed(|owner| owner.open_window(options))
+            .and_then(flui_platform::WindowOpen::try_ready)
+            .expect("Failed to create canvas window");
 
-    let phys_size = window.physical_size();
-    let renderer_init = Arc::clone(&renderer);
-    let renderer_window = Arc::clone(&window);
+        // 2. Shared renderer slot — starts as None, filled async once the WebGPU
+        //    adapter is available. `Option` lets the frame callback skip frames that
+        //    arrive before the renderer is ready.
+        let renderer: Arc<Mutex<Option<Renderer>>> = Arc::new(Mutex::new(None));
 
-    // The future owns a strong window reference. This is required because the
-    // browser platform installs RAF and returns immediately, and startup can
-    // also return early before the window reaches AppBinding.
-    wasm_bindgen_futures::spawn_local(async move {
-        let mut r = match Renderer::new(renderer_window.as_ref()).await {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::error!("GPU init failed: {:?}", e);
+        let phys_size = window.physical_size();
+        let renderer_init = Arc::clone(&renderer);
+        let renderer_window = Arc::clone(&window);
+
+        // The future owns a strong window reference. This is required because the
+        // browser platform installs RAF and returns immediately, and startup can
+        // also return early before the window reaches AppBinding.
+        wasm_bindgen_futures::spawn_local(async move {
+            let mut r = match Renderer::new(renderer_window.as_ref()).await {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::error!("GPU init failed: {:?}", e);
+                    return;
+                }
+            };
+            r.resize(phys_size.width.0 as u32, phys_size.height.0 as u32);
+            tracing::info!("WebGPU renderer initialized");
+            *renderer_init.lock() = Some(r);
+        });
+
+        // 3. Mount root widget at the LOGICAL size; the paint root's DPR
+        // transform maps to the physical canvas.
+        let scale_factor = window.scale_factor() as f32;
+        AppBinding::instance()
+            .render_pipeline_mut()
+            .set_device_pixel_ratio(scale_factor);
+        let ui_realm = match super::ui_realm::UiRealm::new(
+            AppBinding::instance(),
+            AppBinding::instance().frame_wake_callback(),
+            Arc::clone(&window),
+        ) {
+            Ok(realm) => realm,
+            Err(error) => {
+                tracing::error!(%error, "UiRealm construction failed");
                 return;
             }
         };
-        r.resize(phys_size.width.0 as u32, phys_size.height.0 as u32);
-        tracing::info!("WebGPU renderer initialized");
-        *renderer_init.lock() = Some(r);
-    });
-
-    // 3. Mount root widget at the LOGICAL size; the paint root's DPR
-    // transform maps to the physical canvas.
-    let scale_factor = window.scale_factor() as f32;
-    AppBinding::instance()
-        .render_pipeline_mut()
-        .set_device_pixel_ratio(scale_factor);
-    let ui_realm = match super::ui_realm::UiRealm::new(
-        AppBinding::instance(),
-        AppBinding::instance().frame_wake_callback(),
-        Arc::clone(&window),
-    ) {
-        Ok(realm) => realm,
-        Err(error) => {
-            tracing::error!(%error, "UiRealm construction failed");
+        let logical = window.logical_size();
+        let attach = ui_realm.enter(|realm| {
+            AppBinding::instance().attach_root_widget_with_size(
+                realm,
+                &root,
+                logical.width.0 as f32,
+                logical.height.0 as f32,
+            )
+        });
+        if let Err(e) = attach {
+            tracing::error!("Root widget attach failed: {:?}", e);
             return;
         }
-    };
-    let logical = window.logical_size();
-    let attach = ui_realm.enter(|realm| {
-        AppBinding::instance().attach_root_widget_with_size(
-            realm,
-            &root,
-            logical.width.0 as f32,
-            logical.height.0 as f32,
-        )
-    });
-    if let Err(e) = attach {
-        tracing::error!("Root widget attach failed: {:?}", e);
-        return;
-    }
-    let realm_dispatch = install_platform_realm(ui_realm);
+        let realm_dispatch = install_platform_realm(ui_realm);
 
-    // 4. Register input callback
-    window.on_input(Box::new(move |input: PlatformInput| {
-        let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::Input(input));
-        DispatchEventResult::resolved(false, true)
-    }));
+        // 4. Register input callback
+        window.on_input(Box::new(move |input: PlatformInput| {
+            let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::Input(input));
+            DispatchEventResult::resolved(false, true)
+        }));
 
-    // 5. Register frame callback
-    let renderer_frame = Arc::clone(&renderer);
-    window.on_request_frame(Box::new(move || {
-        let renderer_frame = Arc::clone(&renderer_frame);
-        let _ = dispatch_platform_realm(
-            realm_dispatch,
-            RealmEvent::Frame(Box::new(move |realm| {
-                // Owner-inbox drain: commands and worker results commit HERE,
-                // at the frame boundary while the scheduler phase is Idle —
-                // never inside the frame transaction below. Runs before the
-                // dirty gate so a command-driven redraw request is observed
-                // by the very frame its wake produced.
-                let inbox_redraw = drain_owner_inbox(realm);
+        // 5. Register frame callback
+        let renderer_frame = Arc::clone(&renderer);
+        window.on_request_frame(Box::new(move || {
+            let renderer_frame = Arc::clone(&renderer_frame);
+            let _ = dispatch_platform_realm(
+                realm_dispatch,
+                RealmEvent::Frame(Box::new(move |realm| {
+                    // Owner-inbox drain: commands and worker results commit HERE,
+                    // at the frame boundary while the scheduler phase is Idle —
+                    // never inside the frame transaction below. Runs before the
+                    // dirty gate so a command-driven redraw request is observed
+                    // by the very frame its wake produced.
+                    let inbox_redraw = drain_owner_inbox(realm);
 
-                let binding = AppBinding::instance();
-                let has_pending = binding.has_pending_work(realm);
-                let dirty = inbox_redraw || binding.needs_redraw() || has_pending;
-                let scheduler = Scheduler::instance();
-                match wake_action(scheduler.frames_enabled(), dirty, scheduler.is_frame_scheduled())
-                {
-                    WakeAction::Skip => return,
-                    WakeAction::PumpAsync => {
-                        // Frames disabled: pump only the async driver — see
-                        // `wake_action`'s doc for why this is the only thing
-                        // keeping a spawned future progressing while
-                        // backgrounded.
-                        //
-                        // `finish_async_pump` MUST run first, not after —
-                        // see `Scheduler::finish_async_pump`'s doc for the
-                        // starvation hazard this ordering avoids.
-                        //
-                        // No `NO_PRESENT_FALLBACK_PACE` sleep here, unlike
-                        // desktop/Android: this callback is driven by the
-                        // browser's `requestAnimationFrame` loop
-                        // (`start_raf_loop`, `flui-platform`'s web backend),
-                        // which fires unconditionally once per animation
-                        // frame regardless of whether a redraw was
-                        // requested — the browser's own vsync-paced RAF
-                        // cadence already bounds this arm's re-wake rate, so
-                        // an additional sleep would be redundant. It would
-                        // also be unsound here: `wasm32-unknown-unknown` has
-                        // no real OS threads, and blocking the single JS
-                        // thread with `std::thread::sleep` would hang the
-                        // page rather than pace it.
-                        scheduler.finish_async_pump();
-                        scheduler.drive_async_tasks();
-                        return;
+                    let binding = AppBinding::instance();
+                    let has_pending = binding.has_pending_work(realm);
+                    let dirty = inbox_redraw || binding.needs_redraw() || has_pending;
+                    let scheduler = Scheduler::instance();
+                    match wake_action(scheduler.frames_enabled(), dirty, scheduler.is_frame_scheduled())
+                    {
+                        WakeAction::Skip => return,
+                        WakeAction::PumpAsync => {
+                            // Frames disabled: pump only the async driver — see
+                            // `wake_action`'s doc for why this is the only thing
+                            // keeping a spawned future progressing while
+                            // backgrounded.
+                            //
+                            // `finish_async_pump` MUST run first, not after —
+                            // see `Scheduler::finish_async_pump`'s doc for the
+                            // starvation hazard this ordering avoids.
+                            //
+                            // No `NO_PRESENT_FALLBACK_PACE` sleep here, unlike
+                            // desktop/Android: this callback is driven by the
+                            // browser's `requestAnimationFrame` loop
+                            // (`start_raf_loop`, `flui-platform`'s web backend),
+                            // which fires unconditionally once per animation
+                            // frame regardless of whether a redraw was
+                            // requested — the browser's own vsync-paced RAF
+                            // cadence already bounds this arm's re-wake rate, so
+                            // an additional sleep would be redundant. It would
+                            // also be unsound here: `wasm32-unknown-unknown` has
+                            // no real OS threads, and blocking the single JS
+                            // thread with `std::thread::sleep` would hang the
+                            // page rather than pace it.
+                            scheduler.finish_async_pump();
+                            scheduler.drive_async_tasks();
+                            return;
+                        }
+                        WakeAction::Render => {}
                     }
-                    WakeAction::Render => {}
+
+                    let now = web_time::Instant::now();
+                    // Scheduler callbacks and rendering share one realm entry.
+                    scheduler.drive_frame(now, || {
+                        let mut slot = renderer_frame.lock();
+                        let Some(r) = slot.as_mut() else {
+                            return;
+                        };
+
+                        binding.render_frame_entered(realm, r);
+
+                        if r.is_device_lost() {
+                            drop(slot);
+                            let renderer_recover = Arc::clone(&renderer_frame);
+                            wasm_bindgen_futures::spawn_local(async move {
+                                // Never hold the renderer mutex across `.await`.
+                                let Some(mut renderer) = renderer_recover.lock().take() else {
+                                    return;
+                                };
+                                let result = renderer.recover().await;
+                                *renderer_recover.lock() = Some(renderer);
+                                match result {
+                                    Ok(()) => {
+                                        tracing::warn!("GPU device lost — recovered successfully");
+                                        AppBinding::instance().wake_frame();
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(error = ?e, "GPU device recovery failed; will retry next frame");
+                                    }
+                                }
+                            });
+                        }
+                    });
+                })),
+            );
+        }));
+
+        let renderer_resize = Arc::clone(&renderer);
+        window.on_resize(Box::new(move |size, scale_factor| {
+            let apply_size = size;
+            let renderer_resize = Arc::clone(&renderer_resize);
+            let _ = dispatch_platform_realm(
+                realm_dispatch,
+                RealmEvent::Resize {
+                    size,
+                    scale_factor,
+                    apply_surface: Box::new(move || {
+                        if let Some(renderer) = renderer_resize.lock().as_mut() {
+                            let width = (apply_size.width.0 * scale_factor) as u32;
+                            let height = (apply_size.height.0 * scale_factor) as u32;
+                            renderer.resize(width, height);
+                        }
+                    }),
+                },
+            );
+        }));
+
+        // 6. Lifecycle callbacks
+        //
+        // Detached is realm-dispatched so interrupted gesture state is drained
+        // before lifecycle observers run.
+        owner_platform_installed(|owner| {
+            owner.shared().on_quit(Box::new(move || {
+                tracing::info!("Web platform quit");
+                debug_assert_eq!(
+                    std::thread::current().id(),
+                    realm_dispatch.owner_thread,
+                    "platform on_quit must fire on the realm's owner thread"
+                );
+                if let Err(error) = dispatch_platform_realm(
+                    realm_dispatch,
+                    RealmEvent::LifecycleTarget(AppLifecycleState::Detached),
+                ) {
+                    tracing::warn!(
+                        ?error,
+                        "realm unavailable during Detached lifecycle dispatch"
+                    );
+                    Scheduler::instance()
+                        .handle_app_lifecycle_state_change(AppLifecycleState::Detached);
                 }
+            }));
+        });
 
-                let now = web_time::Instant::now();
-                // Scheduler callbacks and rendering share one realm entry.
-                scheduler.drive_frame(now, || {
-                    let mut slot = renderer_frame.lock();
-                    let Some(r) = slot.as_mut() else {
-                        return;
-                    };
+        window.on_close(Box::new(move || {
+            tracing::info!("Canvas window closed");
+            // On web, no explicit quit mechanism needed
+        }));
 
-                    binding.render_frame_entered(realm, r);
+        // No `on_visibility_status_change` registration on web (yet): there is
+        // no occlusion signal wired for this backend in this PR (winit's
+        // `Occluded` is desktop-only) — a DOM `visibilitychange` listener is a
+        // future follow-up, not this PR's scope.
+        window.on_active_status_change(Box::new(move |focused| {
+            let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::WindowFocus(focused));
+        }));
 
-                    if r.is_device_lost() {
-                        drop(slot);
-                        let renderer_recover = Arc::clone(&renderer_frame);
-                        wasm_bindgen_futures::spawn_local(async move {
-                            // Never hold the renderer mutex across `.await`.
-                            let Some(mut renderer) = renderer_recover.lock().take() else {
-                                return;
-                            };
-                            let result = renderer.recover().await;
-                            *renderer_recover.lock() = Some(renderer);
-                            match result {
-                                Ok(()) => {
-                                    tracing::warn!("GPU device lost — recovered successfully");
-                                    AppBinding::instance().wake_frame();
-                                }
-                                Err(e) => {
-                                    tracing::error!(error = ?e, "GPU device recovery failed; will retry next frame");
-                                }
-                            }
-                        });
-                    }
-                });
-            })),
-        );
-    }));
+        // 7. Store window — BEFORE marking the lifecycle Resumed, which can
+        // synchronously run the first frame through `dispatch_platform_realm`;
+        // anything resolving `active_window` during that frame (an autofocus
+        // `EditableText` attaching its IME client, for instance) must not see
+        // `None`.
+        AppBinding::instance().set_window(window);
 
-    let renderer_resize = Arc::clone(&renderer);
-    window.on_resize(Box::new(move |size, scale_factor| {
-        let apply_size = size;
-        let renderer_resize = Arc::clone(&renderer_resize);
-        let _ = dispatch_platform_realm(
-            realm_dispatch,
-            RealmEvent::Resize {
-                size,
-                scale_factor,
-                apply_surface: Box::new(move || {
-                    if let Some(renderer) = renderer_resize.lock().as_mut() {
-                        let width = (apply_size.width.0 * scale_factor) as u32;
-                        let height = (apply_size.height.0 * scale_factor) as u32;
-                        renderer.resize(width, height);
-                    }
-                }),
-            },
-        );
-    }));
-
-    // 6. Lifecycle callbacks
-    //
-    // Detached is realm-dispatched so interrupted gesture state is drained
-    // before lifecycle observers run.
-    platform.on_quit(Box::new(move || {
-        tracing::info!("Web platform quit");
         debug_assert_eq!(
             std::thread::current().id(),
             realm_dispatch.owner_thread,
-            "platform on_quit must fire on the realm's owner thread"
+            "web bootstrap must run on the realm's owner thread"
         );
-        if let Err(error) = dispatch_platform_realm(
-            realm_dispatch,
-            RealmEvent::LifecycleTarget(AppLifecycleState::Detached),
-        ) {
-            tracing::warn!(
-                ?error,
-                "realm unavailable during Detached lifecycle dispatch"
-            );
-            Scheduler::instance().handle_app_lifecycle_state_change(AppLifecycleState::Detached);
-        }
-    }));
+        Scheduler::instance().handle_app_lifecycle_state_change(AppLifecycleState::Resumed);
 
-    window.on_close(Box::new(move || {
-        tracing::info!("Canvas window closed");
-        // On web, no explicit quit mechanism needed
-    }));
+        tracing::info!("Web platform initialized with callbacks");
+    }
 
-    // No `on_visibility_status_change` registration on web (yet): there is
-    // no occlusion signal wired for this backend in this PR (winit's
-    // `Occluded` is desktop-only) — a DOM `visibilitychange` listener is a
-    // future follow-up, not this PR's scope.
-    window.on_active_status_change(Box::new(move |focused| {
-        let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::WindowFocus(focused));
-    }));
-
-    // 7. Store window — BEFORE marking the lifecycle Resumed, which can
-    // synchronously run the first frame through `dispatch_platform_realm`;
-    // anything resolving `active_window` during that frame (an autofocus
-    // `EditableText` attaching its IME client, for instance) must not see
-    // `None`.
-    AppBinding::instance().set_window(window);
-
-    debug_assert_eq!(
-        std::thread::current().id(),
-        realm_dispatch.owner_thread,
-        "web bootstrap must run on the realm's owner thread"
-    );
-    Scheduler::instance().handle_app_lifecycle_state_change(AppLifecycleState::Resumed);
-
-    tracing::info!("Web platform initialized with callbacks");
-
-    // Run the event loop (takes ownership of the platform)
-    platform.run(Box::new(|_platform| {
+    // Run the event loop (takes ownership of the platform). No
+    // `OwnerHostClearGuard` here — deliberately: `WebPlatform::run` installs
+    // the RAF callback and returns immediately, and tearing down the realm
+    // (or the owner host) at that point would destroy it before the first
+    // frame. The host stays owner-TLS resident for the page's lifetime
+    // (ADR-0039 §6/§7 "wasm posture"). An explicit web detach/quit
+    // ownership hook is deferred until the platform exposes a callback
+    // whose lifetime encloses the RAF registration.
+    platform.run(Box::new(move |owner| {
+        install_owner_platform(owner);
+        bootstrap_web(root, config);
         tracing::info!("Web platform ready");
     }));
-    // `WebPlatform::run` installs the RAF callback and returns immediately;
-    // tearing down here would destroy the realm before the first frame. The
-    // host therefore remains owner-TLS resident for the page lifetime. An
-    // explicit web detach/quit ownership hook is deferred until the platform
-    // exposes a callback whose lifetime encloses the RAF registration.
 }
 
 #[cfg(test)]
@@ -2951,5 +3131,99 @@ mod tests {
             "set_window must have taken effect before the initial redraw fires \
              the frame callback that could read active_window",
         );
+    }
+
+    // ========================================================================
+    // Owner-platform host tests (ADR-0039 §6, U7)
+    // ========================================================================
+
+    /// Serializes tests that mutate `Scheduler::instance()`'s process-global
+    /// phase (the repo rule for shared binding/scheduler state — AGENTS.md
+    /// "Testing quirks"). `OWNER_PLATFORM_HOST` itself is `thread_local!`, so
+    /// the install/clear tests below need no lock (the standard library
+    /// test harness runs each `#[test]` on its own thread by default); this
+    /// lock exists only for the one test that drives the process-global
+    /// `Scheduler::instance()` singleton through a real frame.
+    static SCHEDULER_PHASE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn owner_platform_host_installs_and_clears_around_run() {
+        use flui_platform::headless_platform;
+
+        assert!(
+            with_owner_platform(|_| ()).is_none(),
+            "no host installed before any on_ready has run on this thread"
+        );
+
+        // `PlatformReadyCallback` is `Box<dyn FnOnce(OwnerPlatform) + 'static>`,
+        // so the closure below cannot borrow a stack-local `Cell` — `Rc`
+        // gives it an owned handle instead (single-threaded: headless `run`
+        // invokes `on_ready` synchronously, on this same thread).
+        let seen_while_installed = Rc::new(Cell::new(false));
+        let seen_while_installed_for_closure = Rc::clone(&seen_while_installed);
+        {
+            let _clear_guard = OwnerHostClearGuard::arm();
+            let platform = headless_platform();
+            platform.run(Box::new(move |owner| {
+                install_owner_platform(owner);
+                let observed = with_owner_platform(|_owner| true);
+                seen_while_installed_for_closure.set(observed == Some(true));
+            }));
+        } // `_clear_guard` drops here.
+
+        assert!(
+            seen_while_installed.get(),
+            "the accessor must yield Some(_) while a host is installed"
+        );
+        assert!(
+            with_owner_platform(|_| ()).is_none(),
+            "the clear guard must remove the host once its scope ends"
+        );
+    }
+
+    #[test]
+    fn owner_platform_host_panic_in_on_ready_still_clears() {
+        use flui_platform::headless_platform;
+
+        let unwind = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _clear_guard = OwnerHostClearGuard::arm();
+            let platform = headless_platform();
+            platform.run(Box::new(|owner| {
+                install_owner_platform(owner);
+                panic!("exercise on_ready panic cleanup");
+            }));
+        }));
+
+        assert!(unwind.is_err(), "on_ready's panic must propagate");
+        assert!(
+            with_owner_platform(|_| ()).is_none(),
+            "a panic inside on_ready must still unwind through the clear guard \
+             (armed before Platform::run, not inside on_ready) rather than \
+             leaking the host onto this thread"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "with_owner_platform called while the scheduler is inside")]
+    #[cfg_attr(
+        not(debug_assertions),
+        ignore = "the fence is a debug_assert!; release builds don't panic"
+    )]
+    fn owner_platform_accessor_fences_the_frame_transaction() {
+        let _serialized = SCHEDULER_PHASE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // `drive_frame` leaves the *production* `Scheduler::instance()`
+        // singleton in `PersistentCallbacks` for the duration of its
+        // `pipeline` closure -- a forbidden phase per fence (c). A
+        // panicking pipeline is caught internally and resolved back to
+        // `Idle` via `abort_frame()` before the panic resumes, so this
+        // test's own `#[should_panic]` unwind leaves the singleton clean
+        // for whatever runs on it next -- no hand-rolled restore guard
+        // needed on top of `drive_frame`'s own recovery path.
+        Scheduler::instance().drive_frame(std::time::Instant::now(), || {
+            let _ = with_owner_platform(|_owner| ());
+        });
     }
 }

--- a/crates/flui-foundation/src/claim_slot.rs
+++ b/crates/flui-foundation/src/claim_slot.rs
@@ -1,0 +1,485 @@
+//! `ClaimSlot<T>` — a generic at-most-once request/reply primitive.
+//!
+//! ADR-0039 §3 needs a reply protocol strictly stronger than a buffered
+//! one-shot channel: today's winit owner lane hands back a
+//! `sync_channel(1)` whose send always succeeds once the receiver exists,
+//! even if the receiver is later dropped without ever reading it — so a
+//! requester that abandons a request *after* the owner replies leaks
+//! whatever the reply carries (a created window, on the winit lane). A
+//! claim slot closes that gap: the requester side and the owner side share
+//! one small state machine, and every transition is linearized under the
+//! slot's own private lock (SP-6: this module exposes no lock guard or
+//! channel endpoint in any public signature).
+//!
+//! ```text
+//! Pending   ──(owner delivers)──────────▶  Delivered(T)
+//! Pending   ──(requester drops)─────────▶  Abandoned(None)
+//! Delivered ──(requester claims)────────▶  Claimed
+//! Delivered ──(requester drops)─────────▶  Abandoned(Some(T))
+//! ```
+//!
+//! The owner side ([`ClaimSlot<T>`]) is kept alive by the caller *past*
+//! `deliver` — an owner-side in-flight registry (ADR-0039 §3; the winit
+//! lane, U4) holds it so it can later notice a `Delivered -> Abandoned`
+//! transition (the requester dropped without claiming) and reclaim the
+//! payload via [`ClaimSlot::take_abandoned`] to unwind it. `deliver` is
+//! therefore `&self`, not consuming; at-most-once delivery is a runtime
+//! contract on the owner (exactly one `deliver` call per request — the
+//! winit lane has exactly one call site), enforced by a `BUG:` panic on
+//! violation rather than by the type system. Abandonment (whichever side
+//! notices it first) fires an injected wake callback exactly once, so an
+//! owner parked on its own event loop learns promptly that it must unwind
+//! rather than relying on a fallible reply send it never observes failing.
+//!
+//! This primitive is deliberately generic and carries no `flui-platform`
+//! vocabulary (no `WindowId`, no `OpenWindowError`) — the ADR places its
+//! tests in the winit lane, which CI does not execute; landing the tested
+//! core here means the state-machine behavior is CI-verified even though
+//! its winit composition is not (the same rationale `OwnerAffinity`
+//! already established for the runtime-backstop half of ADR-0039).
+
+use std::fmt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use parking_lot::{Condvar, Mutex};
+
+/// Fired at most once, when a request transitions into `Abandoned` — either
+/// because the requester dropped its [`ClaimHandle`] or because the owner's
+/// [`ClaimSlot::deliver`] discovers the slot was abandoned first.
+type WakeOwner = Arc<dyn Fn() + Send + Sync>;
+
+enum SlotState<T> {
+    Pending,
+    Delivered(T),
+    Claimed,
+    Abandoned(Option<T>),
+}
+
+struct Inner<T> {
+    state: Mutex<SlotState<T>>,
+    delivered: Condvar,
+    wake: WakeOwner,
+    wake_fired: AtomicBool,
+}
+
+impl<T> Inner<T> {
+    /// Fires the wake callback outside the state lock (never call this
+    /// while `state` is held — the callback is arbitrary owner code and
+    /// must not be able to deadlock by re-entering the slot) and only on
+    /// the first abandonment transition this slot ever sees.
+    fn notify_abandoned(&self) {
+        if !self.wake_fired.swap(true, Ordering::AcqRel) {
+            (self.wake)();
+        }
+    }
+}
+
+/// Owner-side handle: produces the request's result and, after delivery,
+/// can be polled for a late abandonment to unwind.
+pub struct ClaimSlot<T> {
+    inner: Arc<Inner<T>>,
+}
+
+impl<T> fmt::Debug for ClaimSlot<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = match &*self.inner.state.lock() {
+            SlotState::Pending => "Pending",
+            SlotState::Delivered(_) => "Delivered",
+            SlotState::Claimed => "Claimed",
+            SlotState::Abandoned(_) => "Abandoned",
+        };
+        f.debug_struct("ClaimSlot").field("state", &state).finish()
+    }
+}
+
+impl<T> ClaimSlot<T> {
+    /// True once the slot is `Abandoned`, regardless of whether it still
+    /// carries a reclaimable payload. Before delivery this is the "should I
+    /// even bother producing `T`?" check (U4: skip creation entirely);
+    /// after delivery it is the "does the sweep need to reclaim this?"
+    /// check (paired with [`take_abandoned`](Self::take_abandoned)).
+    #[must_use]
+    pub fn is_abandoned(&self) -> bool {
+        matches!(*self.inner.state.lock(), SlotState::Abandoned(_))
+    }
+
+    /// True once the request is fully resolved — `Claimed`, or `Abandoned`
+    /// with its payload already reclaimed via
+    /// [`take_abandoned`](Self::take_abandoned). An owner-side in-flight
+    /// registry sweeps entries where this is `true`.
+    #[must_use]
+    pub fn is_settled(&self) -> bool {
+        matches!(
+            *self.inner.state.lock(),
+            SlotState::Claimed | SlotState::Abandoned(None)
+        )
+    }
+
+    /// Delivers the completed value, `Pending -> Delivered`.
+    ///
+    /// If the requester abandoned the slot before this call, the value is
+    /// handed back via `Err` so the owner can unwind whatever it just
+    /// produced immediately. If the requester abandons *after* a
+    /// successful delivery, the transition happens on the requester's side
+    /// (`Delivered -> Abandoned(Some(value))`) and the owner reclaims it
+    /// later via [`take_abandoned`](Self::take_abandoned) — `deliver`
+    /// itself only ever observes the pre-delivery race.
+    ///
+    /// # Errors
+    /// Returns `Err(value)` when the requester already abandoned the slot
+    /// before this call — the caller must unwind `value` instead of handing
+    /// it to anyone.
+    ///
+    /// # Panics
+    /// Calling `deliver` a second time on the same slot is an owner-side
+    /// contract violation (this primitive supports exactly one delivery
+    /// per request); it panics rather than silently double-delivering.
+    pub fn deliver(&self, value: T) -> Result<(), T> {
+        let mut state = self.inner.state.lock();
+        match &*state {
+            SlotState::Pending => {
+                *state = SlotState::Delivered(value);
+                drop(state);
+                self.inner.delivered.notify_one();
+                Ok(())
+            }
+            SlotState::Abandoned(None) => {
+                *state = SlotState::Abandoned(None);
+                drop(state);
+                Err(value)
+            }
+            SlotState::Delivered(_) | SlotState::Claimed | SlotState::Abandoned(Some(_)) => {
+                unreachable!(
+                    "BUG: ClaimSlot::deliver called a second time on the same \
+                     request — exactly one deliver call per request is the \
+                     owner-side contract this primitive assumes"
+                )
+            }
+        }
+    }
+
+    /// Reclaims the payload of a `Delivered -> Abandoned` transition (the
+    /// requester claimed delivery, then dropped its handle without ever
+    /// calling `try_take`/`wait`). `None` if the slot never delivered, was
+    /// abandoned before delivery (already returned via `deliver`'s `Err`),
+    /// or was already reclaimed. Idempotent past the first successful call.
+    #[must_use]
+    pub fn take_abandoned(&self) -> Option<T> {
+        let mut state = self.inner.state.lock();
+        match &mut *state {
+            SlotState::Abandoned(payload) => payload.take(),
+            SlotState::Pending | SlotState::Delivered(_) | SlotState::Claimed => None,
+        }
+    }
+}
+
+/// Requester-side handle: claims the delivered value, or abandons the
+/// request on drop.
+///
+/// Dropping a `ClaimHandle` before claiming its value is the deliberate
+/// cancellation path (a dying realm, a finished worker) — it is not an
+/// error, but it does transition the slot to `Abandoned` and wake the
+/// owner so the owner can unwind promptly rather than leak.
+#[must_use = "dropping a ClaimHandle before claiming abandons the request; \
+              see `ClaimSlot` module docs for the unwind contract"]
+pub struct ClaimHandle<T> {
+    inner: Arc<Inner<T>>,
+}
+
+impl<T> fmt::Debug for ClaimHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ClaimHandle").finish_non_exhaustive()
+    }
+}
+
+impl<T> ClaimHandle<T> {
+    /// Non-blocking poll. Returns `Some(T)` exactly once — the first call
+    /// observing `Delivered` claims it (`Delivered -> Claimed`) and every
+    /// later call (on this handle, or after the request is otherwise
+    /// resolved) returns `None`. Safe on any thread, including the owner.
+    pub fn try_take(&mut self) -> Option<T> {
+        let mut state = self.inner.state.lock();
+        let current = std::mem::replace(&mut *state, SlotState::Claimed);
+        match current {
+            SlotState::Delivered(value) => Some(value),
+            other @ (SlotState::Pending | SlotState::Claimed | SlotState::Abandoned(_)) => {
+                *state = other;
+                None
+            }
+        }
+    }
+
+    /// Blocks the calling thread until the owner delivers, then claims the
+    /// value.
+    ///
+    /// This primitive does not itself refuse the owner thread — callers
+    /// that must not block their own owner (e.g. `flui-platform`'s
+    /// `PendingWindow::wait`, which drains the very lane this would block
+    /// on) are responsible for checking thread identity *before* calling
+    /// `wait` and taking the non-blocking `try_take` path instead.
+    #[must_use]
+    pub fn wait(self) -> T {
+        let mut state = self.inner.state.lock();
+        loop {
+            match &*state {
+                SlotState::Delivered(_) => {
+                    let SlotState::Delivered(value) =
+                        std::mem::replace(&mut *state, SlotState::Claimed)
+                    else {
+                        unreachable!("BUG: match on &*state just confirmed Delivered")
+                    };
+                    return value;
+                }
+                SlotState::Pending => {
+                    self.inner.delivered.wait(&mut state);
+                }
+                SlotState::Claimed | SlotState::Abandoned(_) => unreachable!(
+                    "BUG: ClaimHandle::wait observed a resolved state while \
+                     still holding the sole handle — only this handle's own \
+                     consuming methods or its Drop can resolve the slot"
+                ),
+            }
+        }
+    }
+}
+
+impl<T> Drop for ClaimHandle<T> {
+    fn drop(&mut self) {
+        let became_abandoned = {
+            let mut state = self.inner.state.lock();
+            match std::mem::replace(&mut *state, SlotState::Claimed) {
+                SlotState::Pending => {
+                    *state = SlotState::Abandoned(None);
+                    true
+                }
+                SlotState::Delivered(value) => {
+                    *state = SlotState::Abandoned(Some(value));
+                    true
+                }
+                already_resolved @ (SlotState::Claimed | SlotState::Abandoned(_)) => {
+                    *state = already_resolved;
+                    false
+                }
+            }
+        }; // lock released here — notify_abandoned must never run under it.
+        if became_abandoned {
+            self.inner.notify_abandoned();
+        }
+    }
+}
+
+/// Creates a linked owner/requester pair for one request.
+///
+/// `wake` fires at most once, exactly when the request transitions into
+/// `Abandoned` (see the module docs' state diagram) — never on delivery or
+/// claim. On the winit lane this is the coalesced owner wake that already
+/// exists for enqueue (`control.rs`'s `wake_owner`); a generic caller with
+/// no wake-worthy event loop may pass `Arc::new(|| {})`.
+#[must_use = "dropping both halves immediately abandons the request for no reason"]
+pub fn claim_slot<T>(wake: WakeOwner) -> (ClaimSlot<T>, ClaimHandle<T>) {
+    let inner = Arc::new(Inner {
+        state: Mutex::new(SlotState::Pending),
+        delivered: Condvar::new(),
+        wake,
+        wake_fired: AtomicBool::new(false),
+    });
+    (
+        ClaimSlot {
+            inner: Arc::clone(&inner),
+        },
+        ClaimHandle { inner },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    use super::claim_slot;
+
+    fn counting_wake() -> (Arc<dyn Fn() + Send + Sync>, Arc<AtomicUsize>) {
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_for_wake = Arc::clone(&count);
+        let wake: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+            count_for_wake.fetch_add(1, Ordering::AcqRel);
+        });
+        (wake, count)
+    }
+
+    #[test]
+    fn dropped_before_delivery_abandons_with_no_payload() {
+        let (wake, wake_count) = counting_wake();
+        let (slot, handle) = claim_slot::<u32>(wake);
+        drop(handle);
+
+        assert!(slot.is_abandoned(), "requester dropped before delivery");
+        assert_eq!(wake_count.load(Ordering::Acquire), 1);
+
+        let delivered = slot.deliver(7);
+        assert_eq!(
+            delivered,
+            Err(7),
+            "owner must get the value back to unwind it"
+        );
+        assert!(
+            slot.is_settled(),
+            "after the owner reclaims via deliver's Err, nothing is left to sweep"
+        );
+    }
+
+    #[test]
+    fn dropped_after_delivery_abandons_with_recoverable_payload() {
+        let (wake, wake_count) = counting_wake();
+        let (slot, handle) = claim_slot::<String>(wake);
+
+        slot.deliver("payload".to_string())
+            .expect("slot is still Pending");
+        assert_eq!(
+            wake_count.load(Ordering::Acquire),
+            0,
+            "delivery alone must not fire the abandonment wake"
+        );
+
+        // Requester claims delivery happened (so a real `PendingWindow`
+        // would now be holding the value) is NOT what we're testing here —
+        // this test is the "claimed delivery but then dropped without
+        // reading it" path, so drop the handle without calling try_take.
+        assert!(!slot.is_settled(), "not yet abandoned or claimed");
+        drop(handle);
+
+        assert_eq!(
+            wake_count.load(Ordering::Acquire),
+            1,
+            "abandonment after delivery must still wake the owner"
+        );
+        assert!(slot.is_abandoned());
+        assert_eq!(
+            slot.take_abandoned(),
+            Some("payload".to_string()),
+            "the owner must be able to reclaim the payload to unwind it"
+        );
+        assert_eq!(
+            slot.take_abandoned(),
+            None,
+            "reclaiming is idempotent — a second sweep must not double-unwind"
+        );
+        assert!(slot.is_settled());
+    }
+
+    #[test]
+    fn claimed_then_dropped_keeps_the_value_with_the_requester() {
+        let (wake, wake_count) = counting_wake();
+        let (slot, mut handle) = claim_slot::<u32>(wake);
+
+        slot.deliver(42).expect("slot is still Pending");
+        let claimed = handle.try_take();
+        assert_eq!(claimed, Some(42));
+
+        drop(handle);
+        assert_eq!(
+            wake_count.load(Ordering::Acquire),
+            0,
+            "a claimed-then-dropped handle must not abandon or wake"
+        );
+        assert!(slot.is_settled());
+        assert_eq!(slot.take_abandoned(), None);
+    }
+
+    #[test]
+    fn double_take_after_claim_returns_none() {
+        let (wake, _wake_count) = counting_wake();
+        let (slot, mut handle) = claim_slot::<u32>(wake);
+        slot.deliver(1).expect("slot is still Pending");
+
+        assert_eq!(handle.try_take(), Some(1));
+        assert_eq!(
+            handle.try_take(),
+            None,
+            "a second claim on an already-Claimed slot must not repeat the value"
+        );
+    }
+
+    #[test]
+    fn try_take_before_delivery_is_none_and_does_not_abandon() {
+        let (wake, wake_count) = counting_wake();
+        let (_slot, mut handle) = claim_slot::<u32>(wake);
+        assert_eq!(handle.try_take(), None);
+        assert_eq!(wake_count.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn abandonment_wake_fires_exactly_once() {
+        let (wake, wake_count) = counting_wake();
+        let (_slot, handle) = claim_slot::<u32>(wake);
+        drop(handle);
+        assert_eq!(wake_count.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn concurrent_abandon_and_deliver_race_wakes_exactly_once() {
+        // Stress the race the module doc calls out: the owner may call
+        // `deliver` concurrently with the requester dropping its handle.
+        // Whichever side observes the transition first, the wake must
+        // still fire exactly once and the owner must get its payload back
+        // whenever abandonment preceded (or tied with) delivery.
+        for _ in 0..64 {
+            let (wake, wake_count) = counting_wake();
+            let (slot, handle) = claim_slot::<u32>(wake);
+
+            let deliverer = thread::spawn(move || slot.deliver(99));
+            drop(handle);
+            let result = deliverer.join().expect("owner thread does not panic");
+
+            assert_eq!(wake_count.load(Ordering::Acquire), 1);
+            if let Err(rejected) = result {
+                assert_eq!(rejected, 99);
+            }
+        }
+    }
+
+    #[test]
+    fn wait_blocks_until_delivery_then_returns_the_value() {
+        let (wake, _wake_count) = counting_wake();
+        let (slot, handle) = claim_slot::<u32>(wake);
+
+        let waiter = thread::spawn(move || handle.wait());
+        // Give the waiter a chance to reach the condvar; not required for
+        // correctness (deliver would still be observed), only to exercise
+        // the blocking path rather than the immediate one.
+        thread::sleep(Duration::from_millis(20));
+        slot.deliver(123).expect("slot is still Pending");
+
+        assert_eq!(waiter.join().expect("waiter thread does not panic"), 123);
+    }
+
+    #[test]
+    fn panic_during_owner_work_before_delivery_leaves_the_slot_claimable_or_abandoned() {
+        // Simulates the owner panicking while producing `T`, *before* ever
+        // calling `deliver` — the hazard this test rules out is a wedged
+        // Mutex from a poisoned lock. `parking_lot::Mutex` does not
+        // poison, so a panicking owner thread that never touches the slot
+        // again still leaves it in a state the requester can act on.
+        let (wake, wake_count) = counting_wake();
+        let (slot, handle) = claim_slot::<u32>(wake);
+
+        let owner = thread::spawn(move || {
+            let _slot_kept_alive_until_panic = &slot;
+            panic!("owner failed to produce the value");
+        });
+        assert!(owner.join().is_err(), "owner thread panics as designed");
+
+        // The slot was dropped when the panicking thread unwound, so the
+        // requester's abandonment path — not the owner's — resolves this
+        // request the moment the handle itself is dropped.
+        drop(handle);
+        assert_eq!(
+            wake_count.load(Ordering::Acquire),
+            1,
+            "slot is not wedged: abandonment still completes and wakes exactly once"
+        );
+    }
+}

--- a/crates/flui-foundation/src/claim_slot.rs
+++ b/crates/flui-foundation/src/claim_slot.rs
@@ -14,6 +14,7 @@
 //! ```text
 //! Pending   ──(owner delivers)──────────▶  Delivered(T)
 //! Pending   ──(requester drops)─────────▶  Abandoned(None)
+//! Pending   ──(owner drops)─────────────▶  OwnerGone
 //! Delivered ──(requester claims)────────▶  Claimed
 //! Delivered ──(requester drops)─────────▶  Abandoned(Some(T))
 //! ```
@@ -32,6 +33,18 @@
 //! that it must unwind rather than relying on a fallible reply send it
 //! never observes failing.
 //!
+//! `ClaimSlot`'s own `Drop` additionally covers owner disconnection: if the
+//! owner side is dropped while the request is still `Pending` (the owner
+//! died, or unwound, without ever calling `deliver`), the slot transitions
+//! to the terminal `OwnerGone` state and wakes whichever consumer-side
+//! primitive is parked on it — a blocked [`ClaimHandle::wait`] and any
+//! registered [`Waker`] both resolve immediately instead
+//! of hanging forever on the owner's `deliver` discipline. This is on top
+//! of (not a replacement for) that discipline: a well-behaved owner still
+//! always calls `deliver` via a panic-safe guard; `OwnerGone` is the
+//! consumer-side backstop for the case where something upstream of that
+//! guard didn't hold up its end.
+//!
 //! This primitive is deliberately generic and carries no `flui-platform`
 //! vocabulary (no `WindowId`, no `OpenWindowError`) — the ADR places its
 //! tests in the winit lane, which CI does not execute; landing the tested
@@ -40,8 +53,11 @@
 //! already established for the runtime-backstop half of ADR-0039).
 
 use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll, Waker};
 
 use parking_lot::{Condvar, Mutex};
 
@@ -59,6 +75,10 @@ enum SlotState<T> {
     Delivered(T),
     Claimed,
     Abandoned(Option<T>),
+    /// The owner side ([`ClaimSlot<T>`]) was dropped while this request was
+    /// still `Pending` — it never called [`ClaimSlot::deliver`]. Reachable
+    /// only from `Pending` (see `ClaimSlot`'s `Drop` impl); terminal.
+    OwnerGone,
 }
 
 struct Inner<T> {
@@ -71,6 +91,12 @@ struct Inner<T> {
     // is redundant against today's single caller. Kept so a future call
     // site added to this type could not silently double-fire the wake.
     wake_fired: AtomicBool,
+    /// The waker of whichever task last polled this handle via the `Future`
+    /// impl (or registered through it), if any. Separate lock from `state`
+    /// so waking a task never happens while `state` is held (the same
+    /// outside-the-lock discipline `notify_abandoned` already follows for
+    /// `wake`) — the woken task may re-enter this module synchronously.
+    waker: Mutex<Option<Waker>>,
 }
 
 impl<T> Inner<T> {
@@ -81,6 +107,17 @@ impl<T> Inner<T> {
     fn notify_abandoned(&self) {
         if !self.wake_fired.swap(true, Ordering::AcqRel) {
             (self.wake)();
+        }
+    }
+
+    /// Wakes whichever task last polled this handle via `Future::poll`, if
+    /// any — called outside `state`'s lock (same discipline as
+    /// `notify_abandoned`) from every transition that changes what a poll
+    /// would observe: delivery, requester abandonment, and owner
+    /// disconnection.
+    fn wake_task(&self) {
+        if let Some(waker) = self.waker.lock().take() {
+            waker.wake();
         }
     }
 }
@@ -98,6 +135,7 @@ impl<T> fmt::Debug for ClaimSlot<T> {
             SlotState::Delivered(_) => "Delivered",
             SlotState::Claimed => "Claimed",
             SlotState::Abandoned(_) => "Abandoned",
+            SlotState::OwnerGone => "OwnerGone",
         };
         f.debug_struct("ClaimSlot").field("state", &state).finish()
     }
@@ -109,6 +147,10 @@ impl<T> ClaimSlot<T> {
     /// even bother producing `T`?" check (the owner lane skips creation
     /// entirely); after delivery it is the "does the sweep need to reclaim
     /// this?" check (paired with [`take_abandoned`](Self::take_abandoned)).
+    ///
+    /// Does not report `OwnerGone` — that transition is this slot's own
+    /// `Drop`, so by the time any code could observe it through this method
+    /// the `ClaimSlot` value is already gone.
     #[must_use]
     pub fn is_abandoned(&self) -> bool {
         matches!(*self.inner.state.lock(), SlotState::Abandoned(_))
@@ -145,6 +187,9 @@ impl<T> ClaimSlot<T> {
     /// Calling `deliver` a second time on the same slot is an owner-side
     /// contract violation (this primitive supports exactly one delivery
     /// per request); it panics rather than silently double-delivering.
+    /// `OwnerGone` is likewise unreachable here — that transition is this
+    /// same `ClaimSlot` value's own `Drop`, so no further method call on it
+    /// can observe it.
     pub fn deliver(&self, value: T) -> Result<(), T> {
         let mut state = self.inner.state.lock();
         match &*state {
@@ -152,6 +197,7 @@ impl<T> ClaimSlot<T> {
                 *state = SlotState::Delivered(value);
                 drop(state);
                 self.inner.delivered.notify_one();
+                self.inner.wake_task();
                 Ok(())
             }
             SlotState::Abandoned(None) => {
@@ -161,7 +207,10 @@ impl<T> ClaimSlot<T> {
                 drop(state);
                 Err(value)
             }
-            SlotState::Delivered(_) | SlotState::Claimed | SlotState::Abandoned(Some(_)) => {
+            SlotState::Delivered(_)
+            | SlotState::Claimed
+            | SlotState::Abandoned(Some(_))
+            | SlotState::OwnerGone => {
                 unreachable!(
                     "BUG: ClaimSlot::deliver called a second time on the same \
                      request — exactly one deliver call per request is the \
@@ -181,7 +230,38 @@ impl<T> ClaimSlot<T> {
         let mut state = self.inner.state.lock();
         match &mut *state {
             SlotState::Abandoned(payload) => payload.take(),
-            SlotState::Pending | SlotState::Delivered(_) | SlotState::Claimed => None,
+            SlotState::Pending
+            | SlotState::Delivered(_)
+            | SlotState::Claimed
+            | SlotState::OwnerGone => None,
+        }
+    }
+}
+
+impl<T> Drop for ClaimSlot<T> {
+    /// Owner-disconnect transition (ADR-0039 §3/slice-2 amendment):
+    /// `Pending -> OwnerGone` if the owner drops this handle without ever
+    /// calling [`deliver`](Self::deliver) — the owner died mid-request, or
+    /// unwound before reaching its `deliver` guard. Wakes both consumer-side
+    /// waiting primitives: a blocked [`ClaimHandle::wait`] (via the
+    /// condvar) and a parked `Future` poll (via the registered
+    /// [`Waker`]), so neither hangs forever on discipline the owner itself
+    /// failed to uphold. A no-op past `Pending` — the request already has a
+    /// resolution (delivered, or already abandoned by the requester) that
+    /// this transition must not clobber.
+    fn drop(&mut self) {
+        let became_owner_gone = {
+            let mut state = self.inner.state.lock();
+            if matches!(*state, SlotState::Pending) {
+                *state = SlotState::OwnerGone;
+                true
+            } else {
+                false
+            }
+        }; // lock released here — notify/wake must never run under it.
+        if became_owner_gone {
+            self.inner.delivered.notify_all();
+            self.inner.wake_task();
         }
     }
 }
@@ -205,55 +285,121 @@ impl<T> fmt::Debug for ClaimHandle<T> {
     }
 }
 
+/// Outcome of resolving a [`ClaimHandle`] — returned by
+/// [`ClaimHandle::wait`] and, wrapped in [`Poll`], by its `Future` impl.
+/// `Delivered`/`AlreadyClaimed`/`OwnerGone` mirror three of the state
+/// diagram's terminal destinations; the fourth, `Abandoned`, is never
+/// reachable through this type (see the `Abandoned` note below).
+#[derive(Debug, PartialEq, Eq)]
+pub enum ClaimOutcome<T> {
+    /// The owner delivered a value; this call/poll claims it.
+    Delivered(T),
+    /// Already claimed by an earlier [`try_take`](ClaimHandle::try_take) (or
+    /// a previous resolution of the same `Future`) on this same handle —
+    /// nothing is left to hand back. A caller-sequencing fact, not a
+    /// slot-invariant violation.
+    AlreadyClaimed,
+    /// The owner side ([`ClaimSlot`]) was dropped before ever delivering.
+    OwnerGone,
+}
+
 impl<T> ClaimHandle<T> {
+    /// Registers `waker` to be woken exactly once, the next time this
+    /// request's outcome changes (delivery, or the owner disconnecting).
+    /// Replaces any previously registered waker — the most recent `poll`
+    /// wins, per the `Future` contract. Called before re-checking `state`
+    /// (not after) so a transition landing between an unguarded check and
+    /// registration can never go unobserved: either the transition already
+    /// happened and the immediate re-check below sees it, or it happens
+    /// later and wakes the now-registered waker.
+    fn register_waker(&self, waker: &Waker) {
+        let mut slot = self.inner.waker.lock();
+        match &*slot {
+            Some(existing) if existing.will_wake(waker) => {}
+            _ => *slot = Some(waker.clone()),
+        }
+    }
+
+    /// The shared non-blocking check behind [`try_take`](Self::try_take) and
+    /// the `Future` impl. `waker` is `Some` only from the `Future` path —
+    /// `try_take` itself never parks anything.
+    fn poll_claim(&mut self, waker: Option<&Waker>) -> Poll<ClaimOutcome<T>> {
+        if let Some(waker) = waker {
+            self.register_waker(waker);
+        }
+        let mut state = self.inner.state.lock();
+        match std::mem::replace(&mut *state, SlotState::Claimed) {
+            SlotState::Delivered(value) => Poll::Ready(ClaimOutcome::Delivered(value)),
+            SlotState::Pending => {
+                *state = SlotState::Pending;
+                Poll::Pending
+            }
+            SlotState::Claimed => {
+                *state = SlotState::Claimed;
+                Poll::Ready(ClaimOutcome::AlreadyClaimed)
+            }
+            SlotState::OwnerGone => {
+                *state = SlotState::OwnerGone;
+                Poll::Ready(ClaimOutcome::OwnerGone)
+            }
+            SlotState::Abandoned(_) => unreachable!(
+                "BUG: ClaimHandle observed Abandoned while still holding the \
+                 sole handle — only this handle's own Drop can abandon it, \
+                 and Drop cannot have run while `self` is alive here"
+            ),
+        }
+    }
+
     /// Non-blocking poll. Returns `Some(T)` exactly once — the first call
     /// observing `Delivered` claims it (`Delivered -> Claimed`) and every
     /// later call (on this handle, or after the request is otherwise
-    /// resolved) returns `None`. Safe on any thread, including the owner.
+    /// resolved, including `OwnerGone`) returns `None`. Safe on any thread,
+    /// including the owner. Callers that need to distinguish "nothing yet"
+    /// from "the owner is gone" should poll the `Future` impl instead (or
+    /// use [`wait`](Self::wait), off the owner thread).
     #[must_use = "discarding Some(value) strands whatever the owner delivered"]
     pub fn try_take(&mut self) -> Option<T> {
-        let mut state = self.inner.state.lock();
-        let current = std::mem::replace(&mut *state, SlotState::Claimed);
-        match current {
-            SlotState::Delivered(value) => Some(value),
-            other @ (SlotState::Pending | SlotState::Claimed | SlotState::Abandoned(_)) => {
-                *state = other;
+        match self.poll_claim(None) {
+            Poll::Ready(ClaimOutcome::Delivered(value)) => Some(value),
+            Poll::Ready(ClaimOutcome::AlreadyClaimed | ClaimOutcome::OwnerGone) | Poll::Pending => {
                 None
             }
         }
     }
 
-    /// Blocks the calling thread until the owner delivers, then claims the
-    /// value.
+    /// Blocks the calling thread until the request resolves — delivery, or
+    /// the owner disconnecting — then claims the outcome.
     ///
-    /// Returns `None` if this handle was already claimed by an earlier
-    /// [`try_take`](Self::try_take) call — `try_take` takes `&mut self`, so
-    /// nothing in the type system stops a caller from following a
-    /// successful `try_take` with a `wait` on the same still-alive handle;
-    /// that is a caller-sequencing fact (there is nothing left to wait
-    /// for), not a slot-invariant violation, so it is reported through the
-    /// return value rather than a panic. Callers that hand this outcome
-    /// to a typed error (e.g. `flui-platform`'s `PendingWindow::wait`) map
-    /// `None` onto their own `#[non_exhaustive]` error enum.
+    /// Returns [`ClaimOutcome::AlreadyClaimed`] if this handle was already
+    /// claimed by an earlier [`try_take`](Self::try_take) call — `try_take`
+    /// takes `&mut self`, so nothing in the type system stops a caller from
+    /// following a successful `try_take` with a `wait` on the same
+    /// still-alive handle; that is a caller-sequencing fact (there is
+    /// nothing left to wait for), not a slot-invariant violation. Callers
+    /// that hand this outcome to a typed error (e.g. `flui-platform`'s
+    /// `PendingWindow::wait`) map each `ClaimOutcome` variant onto their own
+    /// `#[non_exhaustive]` error enum.
     ///
     /// This primitive does not itself refuse the owner thread — callers
     /// that must not block their own owner (e.g. `flui-platform`'s
     /// `PendingWindow::wait`, which drains the very lane this would block
     /// on) are responsible for checking thread identity *before* calling
-    /// `wait` and taking the non-blocking `try_take` path instead.
+    /// `wait` and taking the non-blocking `try_take` path (or the `Future`
+    /// impl, which is always non-blocking) instead.
     ///
     /// # Owner obligation
-    /// `wait` has no "owner disconnected" transition to wake it early —
-    /// unlike a channel's `Receiver`, dropping the owner-side [`ClaimSlot`]
-    /// without ever calling [`deliver`](ClaimSlot::deliver) sends no signal
-    /// here, so a caller blocked in `wait` would block forever. The owner
-    /// must guarantee it always eventually calls `deliver`, typically via a
-    /// panic-safe guard that calls it unconditionally on drop if not
-    /// already called explicitly (`flui-platform`'s `OpenWindowReplyGuard`
-    /// is exactly this guard for the winit lane) — never a bare, fallible
-    /// call site with no fallback.
-    #[must_use = "discarding Some(value) strands whatever the owner delivered"]
-    pub fn wait(self) -> Option<T> {
+    /// The owner must still guarantee it always eventually calls `deliver`,
+    /// typically via a panic-safe guard that calls it unconditionally on
+    /// drop if not already called explicitly (`flui-platform`'s
+    /// `OpenWindowReplyGuard` is exactly this guard for the winit lane).
+    /// `ClaimSlot`'s `Drop` is the backstop for when that discipline is
+    /// broken upstream of the guard (the owner died or unwound before
+    /// `deliver` even had a guard protecting it): a blocked `wait` now
+    /// resolves to [`ClaimOutcome::OwnerGone`] instead of hanging forever —
+    /// the guard is still the primary mechanism, not something this
+    /// backstop makes optional.
+    #[must_use = "discarding a Delivered outcome strands whatever the owner delivered"]
+    pub fn wait(self) -> ClaimOutcome<T> {
         let mut state = self.inner.state.lock();
         loop {
             match &*state {
@@ -263,7 +409,7 @@ impl<T> ClaimHandle<T> {
                     else {
                         unreachable!("BUG: match on &*state just confirmed Delivered")
                     };
-                    return Some(value);
+                    return ClaimOutcome::Delivered(value);
                 }
                 SlotState::Pending => {
                     self.inner.delivered.wait(&mut state);
@@ -271,7 +417,12 @@ impl<T> ClaimHandle<T> {
                 // Already resolved by an earlier `try_take` on this same
                 // handle -- a caller-sequencing fact, not a bug: nothing
                 // left to wait for.
-                SlotState::Claimed => return None,
+                SlotState::Claimed => return ClaimOutcome::AlreadyClaimed,
+                // The owner side dropped without ever delivering (its own
+                // `Drop` set this and woke this condvar) -- resolve rather
+                // than loop forever waiting for a `deliver` that will now
+                // never come.
+                SlotState::OwnerGone => return ClaimOutcome::OwnerGone,
                 SlotState::Abandoned(_) => unreachable!(
                     "BUG: ClaimHandle::wait observed Abandoned while still \
                      holding the sole handle — only this handle's own Drop \
@@ -280,6 +431,20 @@ impl<T> ClaimHandle<T> {
                 ),
             }
         }
+    }
+}
+
+impl<T> Future for ClaimHandle<T> {
+    type Output = ClaimOutcome<T>;
+
+    /// Non-blocking poll; safe on any thread, including the owner (unlike
+    /// [`wait`](Self::wait), which refuses there because it would block on
+    /// the very lane the owner itself drains). Resolves on delivery, on
+    /// owner disconnection ([`ClaimOutcome::OwnerGone`], woken by
+    /// `ClaimSlot`'s `Drop`), or immediately if this handle was already
+    /// claimed by an earlier [`try_take`](Self::try_take).
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.poll_claim(Some(cx.waker()))
     }
 }
 
@@ -296,7 +461,9 @@ impl<T> Drop for ClaimHandle<T> {
                     *state = SlotState::Abandoned(Some(value));
                     true
                 }
-                already_resolved @ (SlotState::Claimed | SlotState::Abandoned(_)) => {
+                already_resolved @ (SlotState::Claimed
+                | SlotState::Abandoned(_)
+                | SlotState::OwnerGone) => {
                     *state = already_resolved;
                     false
                 }
@@ -304,6 +471,12 @@ impl<T> Drop for ClaimHandle<T> {
         }; // lock released here — notify_abandoned must never run under it.
         if became_abandoned {
             self.inner.notify_abandoned();
+            // No task can still be parked on this same handle's `Future`
+            // once the handle itself is being dropped, so this is a no-op
+            // in practice — fired anyway for symmetry with `deliver` and
+            // `ClaimSlot`'s `Drop`, which both wake unconditionally on
+            // their own state-changing transitions.
+            self.inner.wake_task();
         }
     }
 }
@@ -322,6 +495,7 @@ pub fn claim_slot<T>(wake: WakeOwner) -> (ClaimSlot<T>, ClaimHandle<T>) {
         delivered: Condvar::new(),
         wake,
         wake_fired: AtomicBool::new(false),
+        waker: Mutex::new(None),
     });
     (
         ClaimSlot {
@@ -333,12 +507,15 @@ pub fn claim_slot<T>(wake: WakeOwner) -> (ClaimSlot<T>, ClaimHandle<T>) {
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Context, Poll, Waker};
     use std::thread;
     use std::time::Duration;
 
-    use super::claim_slot;
+    use super::{ClaimOutcome, claim_slot};
 
     fn counting_wake() -> (Arc<dyn Fn() + Send + Sync>, Arc<AtomicUsize>) {
         let count = Arc::new(AtomicUsize::new(0));
@@ -494,18 +671,18 @@ mod tests {
 
         assert_eq!(
             waiter.join().expect("waiter thread does not panic"),
-            Some(123)
+            ClaimOutcome::Delivered(123)
         );
     }
 
     #[test]
-    fn wait_after_a_successful_try_take_on_the_same_handle_returns_none_not_a_panic() {
-        // Regression test (spec-compliance review MAJOR-1): `try_take` takes
-        // `&mut self`, so nothing in the type system stops a caller from
+    fn wait_after_a_successful_try_take_on_the_same_handle_returns_already_claimed_not_a_panic() {
+        // Regression test (foundation claim-slot compliance review): `try_take`
+        // takes `&mut self`, so nothing in the type system stops a caller from
         // following a successful `try_take` with a `wait` on the same
         // still-alive handle. That used to hit an `unreachable!("BUG: ...")`
         // panic through entirely safe public API; `wait` must instead
-        // report "nothing left to wait for" via `None`.
+        // report "nothing left to wait for" via `AlreadyClaimed`.
         let (wake, wake_count) = counting_wake();
         let (slot, mut handle) = claim_slot::<u32>(wake);
 
@@ -514,8 +691,8 @@ mod tests {
 
         assert_eq!(
             handle.wait(),
-            None,
-            "wait on an already-claimed handle must report None, not panic"
+            ClaimOutcome::AlreadyClaimed,
+            "wait on an already-claimed handle must report AlreadyClaimed, not panic"
         );
         assert_eq!(
             wake_count.load(Ordering::Acquire),
@@ -524,13 +701,179 @@ mod tests {
         );
     }
 
+    /// Real second thread, bounded via `recv_timeout`: a `wait()` blocked on
+    /// a request the owner never delivers must not hang forever once the
+    /// owner side (`ClaimSlot`) is dropped — it must unblock with
+    /// `ClaimOutcome::OwnerGone` (ADR-0039 §3/slice-2 amendment). A test
+    /// that used a bare `.join()` would itself hang the test suite if this
+    /// regressed; `recv_timeout` turns that failure mode into a normal
+    /// assertion failure instead.
+    #[test]
+    fn blocked_waiter_unblocks_on_owner_drop() {
+        let (wake, _wake_count) = counting_wake();
+        let (slot, handle) = claim_slot::<u32>(wake);
+        let (result_tx, result_rx) = std::sync::mpsc::channel();
+
+        let waiter = thread::spawn(move || {
+            let outcome = handle.wait();
+            // A join-based test could hang forever if `wait` regressed to
+            // blocking indefinitely; sending through a channel lets the
+            // main thread bound how long it waits instead.
+            let _ = result_tx.send(outcome);
+        });
+
+        // Give the waiter a chance to reach the condvar before the owner
+        // disconnects; not required for correctness (dropping `slot` first
+        // would still resolve `wait` correctly), only to exercise the
+        // blocking path rather than the immediate one.
+        thread::sleep(Duration::from_millis(20));
+        drop(slot);
+
+        let outcome = result_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("wait() must unblock promptly once the owner side drops");
+        assert_eq!(outcome, ClaimOutcome::OwnerGone);
+        waiter.join().expect("waiter thread does not panic");
+    }
+
+    #[test]
+    fn future_resolves_on_deliver() {
+        let (wake, _wake_count) = counting_wake();
+        let (slot, mut handle) = claim_slot::<u32>(wake);
+
+        let (waker, _wake_count_task) = test_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert_eq!(
+            Pin::new(&mut handle).poll(&mut cx),
+            Poll::Pending,
+            "nothing delivered yet"
+        );
+
+        slot.deliver(42).expect("slot is still Pending");
+
+        assert_eq!(
+            Pin::new(&mut handle).poll(&mut cx),
+            Poll::Ready(ClaimOutcome::Delivered(42)),
+            "a re-poll after delivery must resolve, not just the woken task"
+        );
+    }
+
+    /// Distinguishes "the value eventually resolves" from "the registered
+    /// `Waker` actually fires" — a `Future` that only ever resolved on the
+    /// next unconditional re-poll (never truly parking) would still pass a
+    /// resolves-on-deliver test but stall forever under a real executor
+    /// that only re-polls after a wake.
+    #[test]
+    fn future_wakes_not_just_resolves_after_waker_registration() {
+        let (wake, _wake_count) = counting_wake();
+        let (slot, mut handle) = claim_slot::<u32>(wake);
+
+        let (waker, wake_count) = test_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert_eq!(Pin::new(&mut handle).poll(&mut cx), Poll::Pending);
+        assert_eq!(
+            wake_count.count(),
+            0,
+            "registering must not itself count as a wake"
+        );
+
+        slot.deliver(7).expect("slot is still Pending");
+
+        assert_eq!(
+            wake_count.count(),
+            1,
+            "delivery must wake the registered waker directly, not merely \
+             become observable on a hypothetical future poll"
+        );
+        assert_eq!(
+            Pin::new(&mut handle).poll(&mut cx),
+            Poll::Ready(ClaimOutcome::Delivered(7))
+        );
+    }
+
+    #[test]
+    fn future_wakes_on_owner_drop() {
+        let (wake, _wake_count) = counting_wake();
+        let (slot, mut handle) = claim_slot::<u32>(wake);
+
+        let (waker, wake_count) = test_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert_eq!(Pin::new(&mut handle).poll(&mut cx), Poll::Pending);
+
+        drop(slot);
+
+        assert_eq!(
+            wake_count.count(),
+            1,
+            "owner disconnection must wake a parked poll, not just resolve a later one"
+        );
+        assert_eq!(
+            Pin::new(&mut handle).poll(&mut cx),
+            Poll::Ready(ClaimOutcome::OwnerGone)
+        );
+    }
+
+    /// The owner thread is also a legal thread to poll from — unlike
+    /// `wait()`, which must refuse there (callers building on top, e.g.
+    /// `flui-platform`'s `PendingWindow`, check thread identity themselves;
+    /// this primitive's `Future` impl has no such refusal because polling
+    /// never blocks in the first place).
+    #[test]
+    fn owner_thread_poll_never_blocks() {
+        let (wake, _wake_count) = counting_wake();
+        let (_slot, mut handle) = claim_slot::<u32>(wake);
+
+        let (waker, _wake_count_task) = test_waker();
+        let mut cx = Context::from_waker(&waker);
+        // Same thread as the (still-live) owner side `_slot` -- a blocking
+        // `wait()` here would be the exact hazard `PendingWindow::wait`
+        // refuses; `poll` must return immediately regardless.
+        assert_eq!(Pin::new(&mut handle).poll(&mut cx), Poll::Pending);
+    }
+
+    /// Counting `Wake` implementation for tests: no executor, `futures`
+    /// dependency, or hand-rolled `RawWaker`/`unsafe` needed just to prove a
+    /// wake fired — `std::task::Wake` builds a real `Waker` from a safe
+    /// `Arc<impl Wake>` (stable since 1.51).
+    struct CountingWake(AtomicUsize);
+
+    impl CountingWake {
+        fn count(&self) -> usize {
+            self.0.load(Ordering::Acquire)
+        }
+    }
+
+    impl std::task::Wake for CountingWake {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    fn test_waker() -> (Waker, Arc<CountingWake>) {
+        let inner = Arc::new(CountingWake(AtomicUsize::new(0)));
+        (Waker::from(Arc::clone(&inner)), inner)
+    }
+
     #[test]
     fn panic_during_owner_work_before_delivery_leaves_the_slot_claimable_or_abandoned() {
         // Simulates the owner panicking while producing `T`, *before* ever
         // calling `deliver` — the hazard this test rules out is a wedged
-        // Mutex from a poisoned lock. `parking_lot::Mutex` does not
-        // poison, so a panicking owner thread that never touches the slot
-        // again still leaves it in a state the requester can act on.
+        // `Mutex` from a poisoned lock (`parking_lot::Mutex` does not
+        // poison) AND, since `ClaimSlot`'s own `Drop` now covers owner
+        // disconnection (ADR-0039 §3 slice-2 amendment), a handle left
+        // waiting forever for a `deliver` call that will now never come.
+        //
+        // The panicking thread's `slot` unwinds through `ClaimSlot::drop`
+        // right there, on the owner thread — it observes `Pending` and
+        // transitions straight to `OwnerGone` before this test ever touches
+        // `handle`, so the injected `WakeOwner` callback (`counting_wake`)
+        // correctly never fires here: that callback wakes the *owner*'s
+        // event loop when the *requester* abandons, which is not what
+        // happened in this scenario (the owner is what disconnected).
         let (wake, wake_count) = counting_wake();
         let (slot, handle) = claim_slot::<u32>(wake);
 
@@ -540,14 +883,18 @@ mod tests {
         });
         assert!(owner.join().is_err(), "owner thread panics as designed");
 
-        // The slot was dropped when the panicking thread unwound, so the
-        // requester's abandonment path — not the owner's — resolves this
-        // request the moment the handle itself is dropped.
-        drop(handle);
+        assert_eq!(
+            handle.wait(),
+            ClaimOutcome::OwnerGone,
+            "slot is not wedged: the handle resolves to OwnerGone instead of \
+             blocking forever on a deliver call that will never come"
+        );
         assert_eq!(
             wake_count.load(Ordering::Acquire),
-            1,
-            "slot is not wedged: abandonment still completes and wakes exactly once"
+            0,
+            "the requester never abandoned anything here -- the owner did -- \
+             so the WakeOwner callback (which wakes the owner on requester \
+             abandonment) must not fire"
         );
     }
 }

--- a/crates/flui-foundation/src/claim_slot.rs
+++ b/crates/flui-foundation/src/claim_slot.rs
@@ -20,16 +20,17 @@
 //!
 //! The owner side ([`ClaimSlot<T>`]) is kept alive by the caller *past*
 //! `deliver` — an owner-side in-flight registry (ADR-0039 §3; the winit
-//! lane, U4) holds it so it can later notice a `Delivered -> Abandoned`
-//! transition (the requester dropped without claiming) and reclaim the
-//! payload via [`ClaimSlot::take_abandoned`] to unwind it. `deliver` is
-//! therefore `&self`, not consuming; at-most-once delivery is a runtime
-//! contract on the owner (exactly one `deliver` call per request — the
-//! winit lane has exactly one call site), enforced by a `BUG:` panic on
-//! violation rather than by the type system. Abandonment (whichever side
-//! notices it first) fires an injected wake callback exactly once, so an
-//! owner parked on its own event loop learns promptly that it must unwind
-//! rather than relying on a fallible reply send it never observes failing.
+//! lane's drain-and-sweep loop) holds it so it can later notice a
+//! `Delivered -> Abandoned` transition (the requester dropped without
+//! claiming) and reclaim the payload via [`ClaimSlot::take_abandoned`] to
+//! unwind it. `deliver` is therefore `&self`, not consuming; at-most-once
+//! delivery is a runtime contract on the owner (exactly one `deliver` call
+//! per request — the winit lane has exactly one call site), enforced by a
+//! `BUG:` panic on violation rather than by the type system. Abandonment
+//! (whichever side notices it first) fires an injected wake callback
+//! exactly once, so an owner parked on its own event loop learns promptly
+//! that it must unwind rather than relying on a fallible reply send it
+//! never observes failing.
 //!
 //! This primitive is deliberately generic and carries no `flui-platform`
 //! vocabulary (no `WindowId`, no `OpenWindowError`) — the ADR places its
@@ -44,9 +45,13 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use parking_lot::{Condvar, Mutex};
 
-/// Fired at most once, when a request transitions into `Abandoned` — either
-/// because the requester dropped its [`ClaimHandle`] or because the owner's
-/// [`ClaimSlot::deliver`] discovers the slot was abandoned first.
+/// Fired exactly once, the moment a request transitions into `Abandoned` —
+/// always from [`ClaimHandle`]'s `Drop`, the only place that transition
+/// happens. `ClaimSlot::deliver` never fires it: when `deliver` observes an
+/// already-`Abandoned` slot (the pre-delivery race), the wake already fired
+/// when that abandonment happened, on the requester's side, before
+/// `deliver` was even called — `deliver` only ever *reads* the outcome, via
+/// its `Err` return, and correctly does not re-fire the wake for it.
 type WakeOwner = Arc<dyn Fn() + Send + Sync>;
 
 enum SlotState<T> {
@@ -60,6 +65,11 @@ struct Inner<T> {
     state: Mutex<SlotState<T>>,
     delivered: Condvar,
     wake: WakeOwner,
+    // Belt-and-braces, not currently load-bearing: `notify_abandoned` has
+    // exactly one call site (`ClaimHandle`'s `Drop`), and `Drop::drop` runs
+    // at most once per value by Rust's own ownership rules, so this guard
+    // is redundant against today's single caller. Kept so a future call
+    // site added to this type could not silently double-fire the wake.
     wake_fired: AtomicBool,
 }
 
@@ -96,9 +106,9 @@ impl<T> fmt::Debug for ClaimSlot<T> {
 impl<T> ClaimSlot<T> {
     /// True once the slot is `Abandoned`, regardless of whether it still
     /// carries a reclaimable payload. Before delivery this is the "should I
-    /// even bother producing `T`?" check (U4: skip creation entirely);
-    /// after delivery it is the "does the sweep need to reclaim this?"
-    /// check (paired with [`take_abandoned`](Self::take_abandoned)).
+    /// even bother producing `T`?" check (the owner lane skips creation
+    /// entirely); after delivery it is the "does the sweep need to reclaim
+    /// this?" check (paired with [`take_abandoned`](Self::take_abandoned)).
     #[must_use]
     pub fn is_abandoned(&self) -> bool {
         matches!(*self.inner.state.lock(), SlotState::Abandoned(_))
@@ -145,7 +155,9 @@ impl<T> ClaimSlot<T> {
                 Ok(())
             }
             SlotState::Abandoned(None) => {
-                *state = SlotState::Abandoned(None);
+                // No write-back needed: the state is already exactly
+                // `Abandoned(None)` (confirmed by the match arm above), so
+                // there is nothing to update before handing `value` back.
                 drop(state);
                 Err(value)
             }
@@ -198,6 +210,7 @@ impl<T> ClaimHandle<T> {
     /// observing `Delivered` claims it (`Delivered -> Claimed`) and every
     /// later call (on this handle, or after the request is otherwise
     /// resolved) returns `None`. Safe on any thread, including the owner.
+    #[must_use = "discarding Some(value) strands whatever the owner delivered"]
     pub fn try_take(&mut self) -> Option<T> {
         let mut state = self.inner.state.lock();
         let current = std::mem::replace(&mut *state, SlotState::Claimed);
@@ -213,13 +226,34 @@ impl<T> ClaimHandle<T> {
     /// Blocks the calling thread until the owner delivers, then claims the
     /// value.
     ///
+    /// Returns `None` if this handle was already claimed by an earlier
+    /// [`try_take`](Self::try_take) call — `try_take` takes `&mut self`, so
+    /// nothing in the type system stops a caller from following a
+    /// successful `try_take` with a `wait` on the same still-alive handle;
+    /// that is a caller-sequencing fact (there is nothing left to wait
+    /// for), not a slot-invariant violation, so it is reported through the
+    /// return value rather than a panic. Callers that hand this outcome
+    /// to a typed error (e.g. `flui-platform`'s `PendingWindow::wait`) map
+    /// `None` onto their own `#[non_exhaustive]` error enum.
+    ///
     /// This primitive does not itself refuse the owner thread — callers
     /// that must not block their own owner (e.g. `flui-platform`'s
     /// `PendingWindow::wait`, which drains the very lane this would block
     /// on) are responsible for checking thread identity *before* calling
     /// `wait` and taking the non-blocking `try_take` path instead.
-    #[must_use]
-    pub fn wait(self) -> T {
+    ///
+    /// # Owner obligation
+    /// `wait` has no "owner disconnected" transition to wake it early —
+    /// unlike a channel's `Receiver`, dropping the owner-side [`ClaimSlot`]
+    /// without ever calling [`deliver`](ClaimSlot::deliver) sends no signal
+    /// here, so a caller blocked in `wait` would block forever. The owner
+    /// must guarantee it always eventually calls `deliver`, typically via a
+    /// panic-safe guard that calls it unconditionally on drop if not
+    /// already called explicitly (`flui-platform`'s `OpenWindowReplyGuard`
+    /// is exactly this guard for the winit lane) — never a bare, fallible
+    /// call site with no fallback.
+    #[must_use = "discarding Some(value) strands whatever the owner delivered"]
+    pub fn wait(self) -> Option<T> {
         let mut state = self.inner.state.lock();
         loop {
             match &*state {
@@ -229,15 +263,20 @@ impl<T> ClaimHandle<T> {
                     else {
                         unreachable!("BUG: match on &*state just confirmed Delivered")
                     };
-                    return value;
+                    return Some(value);
                 }
                 SlotState::Pending => {
                     self.inner.delivered.wait(&mut state);
                 }
-                SlotState::Claimed | SlotState::Abandoned(_) => unreachable!(
-                    "BUG: ClaimHandle::wait observed a resolved state while \
-                     still holding the sole handle — only this handle's own \
-                     consuming methods or its Drop can resolve the slot"
+                // Already resolved by an earlier `try_take` on this same
+                // handle -- a caller-sequencing fact, not a bug: nothing
+                // left to wait for.
+                SlotState::Claimed => return None,
+                SlotState::Abandoned(_) => unreachable!(
+                    "BUG: ClaimHandle::wait observed Abandoned while still \
+                     holding the sole handle — only this handle's own Drop \
+                     can abandon it, and Drop cannot have run while `self` \
+                     is alive here"
                 ),
             }
         }
@@ -453,7 +492,36 @@ mod tests {
         thread::sleep(Duration::from_millis(20));
         slot.deliver(123).expect("slot is still Pending");
 
-        assert_eq!(waiter.join().expect("waiter thread does not panic"), 123);
+        assert_eq!(
+            waiter.join().expect("waiter thread does not panic"),
+            Some(123)
+        );
+    }
+
+    #[test]
+    fn wait_after_a_successful_try_take_on_the_same_handle_returns_none_not_a_panic() {
+        // Regression test (spec-compliance review MAJOR-1): `try_take` takes
+        // `&mut self`, so nothing in the type system stops a caller from
+        // following a successful `try_take` with a `wait` on the same
+        // still-alive handle. That used to hit an `unreachable!("BUG: ...")`
+        // panic through entirely safe public API; `wait` must instead
+        // report "nothing left to wait for" via `None`.
+        let (wake, wake_count) = counting_wake();
+        let (slot, mut handle) = claim_slot::<u32>(wake);
+
+        slot.deliver(7).expect("slot is still Pending");
+        assert_eq!(handle.try_take(), Some(7), "first claim succeeds normally");
+
+        assert_eq!(
+            handle.wait(),
+            None,
+            "wait on an already-claimed handle must report None, not panic"
+        );
+        assert_eq!(
+            wake_count.load(Ordering::Acquire),
+            0,
+            "a claimed handle's wait/drop must not abandon or wake"
+        );
     }
 
     #[test]

--- a/crates/flui-foundation/src/lib.rs
+++ b/crates/flui-foundation/src/lib.rs
@@ -150,6 +150,10 @@ pub mod affinity;
 pub mod async_snapshot;
 pub mod binding;
 pub mod callbacks;
+// Generic at-most-once request/reply primitive (ADR-0039 §3): the winit
+// owner lane's claim-slot reply protocol composes this; its state-machine
+// tests live here so CI actually runs them (same rationale as `affinity`).
+pub mod claim_slot;
 pub mod clock;
 pub mod consts;
 // Monotonic generation/version counters for the window-runtime protocol:
@@ -193,6 +197,8 @@ pub use callbacks::{
     FallibleCallback, Predicate, ValueChanged, ValueGetter, ValueSetter, ValueTransformer,
     VoidCallback,
 };
+// Claim-slot request/reply primitive (ADR-0039 §3)
+pub use claim_slot::{ClaimHandle, ClaimSlot, claim_slot};
 // Monotonic time source (OS / virtual clock) — foundational primitive injected
 // by deadline- and frame-driven subsystems (gesture arena, headless binding).
 pub use clock::{ManualClock, MonotonicClock, SystemClock};

--- a/crates/flui-foundation/src/lib.rs
+++ b/crates/flui-foundation/src/lib.rs
@@ -198,7 +198,7 @@ pub use callbacks::{
     VoidCallback,
 };
 // Claim-slot request/reply primitive (ADR-0039 §3)
-pub use claim_slot::{ClaimHandle, ClaimSlot, claim_slot};
+pub use claim_slot::{ClaimHandle, ClaimOutcome, ClaimSlot, claim_slot};
 // Monotonic time source (OS / virtual clock) — foundational primitive injected
 // by deadline- and frame-driven subsystems (gesture arena, headless binding).
 pub use clock::{ManualClock, MonotonicClock, SystemClock};

--- a/crates/flui-platform/AGENTS.md
+++ b/crates/flui-platform/AGENTS.md
@@ -14,6 +14,11 @@ Platform abstraction layer. Provides a unified `Platform` trait with concrete im
 ## Key constraints
 
 - **Tests excluded from CI** — STATUS_HEAP_CORRUPTION investigation in progress
+- The `winit/` module (including its owner-lane tests) only compiles under the
+  `winit-backend` feature, not `desktop` (default) — a bare
+  `cargo nextest run -p flui-platform` silently skips all of it; use
+  `cargo nextest run -p flui-platform --all-features` (or `--features winit-backend`)
+  to actually build and run it
 - `desktop` feature (default) enables `winit`; `web` feature for WASM
 - Native async deps (tokio) are `cfg(not(target_arch = "wasm32"))` only
 - `raw-window-handle` 0.6 for window handle abstraction

--- a/crates/flui-platform/Cargo.toml
+++ b/crates/flui-platform/Cargo.toml
@@ -50,6 +50,14 @@ raw-window-handle = "0.6"
 # Bitflags for platform-specific flags
 bitflags = "2.6"
 
+# Compile-time auto-trait fences for `OwnerPlatform`/`PlatformProxy`/
+# `PendingWindow` (ADR-0039 §6-8): item-position `assert_not_impl_any!`/
+# `assert_impl_all!` in `traits/owner.rs`, expanded unconditionally by every
+# `cargo check` (including cross-typecheck on win/mac) — not gated behind
+# `#[cfg(test)]` — so this must be a real dependency, not dev-only, or the
+# assertions never expand outside this crate's own test builds.
+static_assertions = { workspace = true }
+
 # Windows platform
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62", features = [
@@ -156,7 +164,6 @@ workspace = true
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }
-static_assertions = { workspace = true }
 
 [[test]]
 name = "platform_it"

--- a/crates/flui-platform/examples/simple_window.rs
+++ b/crates/flui-platform/examples/simple_window.rs
@@ -62,11 +62,14 @@ fn main() {
 
     // Run platform event loop (takes ownership)
     tracing::info!("Starting platform event loop...");
-    platform.run(Box::new(move |_platform| {
-        tracing::info!("Platform ready callback invoked");
-        // Window is already created; keep it alive via the closure capture
-        let _window = window;
-    }));
+    platform
+        .run(Box::new(move |_owner| {
+            tracing::info!("Platform ready callback invoked");
+            // Window is already created; keep it alive via the closure capture
+            let _window = window;
+            Ok(())
+        }))
+        .expect("platform event loop exited with an error");
 
     tracing::info!("Platform shut down successfully!");
 }

--- a/crates/flui-platform/src/lib.rs
+++ b/crates/flui-platform/src/lib.rs
@@ -46,9 +46,10 @@
 //! use flui_platform::current_platform;
 //!
 //! let platform = current_platform()?;
-//! platform.run(Box::new(|platform| {
-//!     println!("Platform ready: {}", platform.name());
-//! }));
+//! platform.run(Box::new(|owner| {
+//!     println!("Platform ready: {}", owner.shared().name());
+//!     Ok(())
+//! }))?;
 //! ```
 //!
 //! ## Testing with Headless Mode
@@ -211,8 +212,8 @@ pub use traits::{
 // The owner-thread capability (ADR-0039 slice 2): minted only by a backend,
 // handed to `on_ready`, never re-exported with a public minting seam.
 pub use traits::{
-    OpenWindowError, OwnerPlatform, PendingWindow, PlatformProxy, ProxySendError, WaitError,
-    WindowOpen,
+    OpenWindowError, OwnerPlatform, PendingWindow, PlatformProxy, ProxySendError, SharedPlatform,
+    WaitError, WindowOpen,
 };
 
 /// Get the current platform implementation
@@ -293,9 +294,10 @@ pub use traits::{
 /// let platform = current_platform()?;
 /// println!("Running on: {}", platform.name());
 ///
-/// platform.run(Box::new(|_platform| {
+/// platform.run(Box::new(|_owner| {
 ///     println!("Platform ready!");
-/// }));
+///     Ok(())
+/// }))?;
 /// ```
 ///
 /// ```rust,ignore

--- a/crates/flui-platform/src/lib.rs
+++ b/crates/flui-platform/src/lib.rs
@@ -208,6 +208,12 @@ pub use traits::{
     PlatformWindow, WebCapabilities, WindowAppearance, WindowBackgroundAppearance, WindowBounds,
     WindowEvent, WindowId, WindowMode, WindowOptions,
 };
+// The owner-thread capability (ADR-0039 slice 2): minted only by a backend,
+// handed to `on_ready`, never re-exported with a public minting seam.
+pub use traits::{
+    OpenWindowError, OwnerPlatform, PendingWindow, PlatformProxy, ProxySendError, WaitError,
+    WindowOpen,
+};
 
 /// Get the current platform implementation
 ///

--- a/crates/flui-platform/src/platforms/android/mod.rs
+++ b/crates/flui-platform/src/platforms/android/mod.rs
@@ -64,9 +64,10 @@ use crate::{
 /// #[no_mangle]
 /// fn android_main(app: AndroidApp) {
 ///     let platform = AndroidPlatform::new(app);
-///     platform.run(Box::new(|owner| {
+///     let _ = platform.run(Box::new(|owner| {
 ///         // Platform ready (first Resume) — create window and renderer
 ///         let _ = owner;
+///         Ok(())
 ///     }));
 /// }
 /// ```
@@ -176,7 +177,7 @@ impl Platform for AndroidPlatform {
         self.background_executor.clone()
     }
 
-    fn run(self: Box<Self>, on_ready: PlatformReadyCallback) {
+    fn run(self: Box<Self>, on_ready: PlatformReadyCallback) -> anyhow::Result<()> {
         tracing::info!("Starting Android platform event loop");
 
         // Converted once, up front: `on_ready` needs an `Arc<dyn Platform>`
@@ -187,6 +188,13 @@ impl Platform for AndroidPlatform {
 
         let mut on_ready = Some(on_ready);
         let mut resumed = false;
+        // Set when `on_ready` returns `Err`: a fallible bootstrap
+        // failure (window creation, GPU init, root-widget attach) has no
+        // other return path back to `run`'s caller. Stopping `running` and
+        // `continue`-ing to the loop's top-of-iteration check exits
+        // promptly instead of continuing to pump input/frame dispatch for
+        // an app that never finished bootstrapping.
+        let mut bootstrap_error: Option<anyhow::Error> = None;
         // Relaxed everywhere on `running`: it is a bare stop-signal with no
         // data published through it. The loop re-reads it every iteration,
         // the Destroy store happens on the loop thread itself, and a
@@ -295,7 +303,18 @@ impl Platform for AndroidPlatform {
                     let owner_platform = Arc::clone(&platform) as Arc<dyn Platform>;
                     let hooks: Arc<dyn OwnerHooks> =
                         Arc::new(DirectOwnerHooks::new(Arc::clone(&owner_platform)));
-                    ready(OwnerPlatform::new(owner_platform, hooks));
+                    if let Err(error) = ready(OwnerPlatform::new(owner_platform, hooks)) {
+                        tracing::error!(
+                            %error,
+                            "on_ready bootstrap failed; stopping the event loop"
+                        );
+                        bootstrap_error = Some(error);
+                        platform.running.store(false, Ordering::Relaxed);
+                        // Skip input/frame dispatch below for this
+                        // iteration -- the top-of-loop check exits on the
+                        // next pass.
+                        continue;
+                    }
                 }
             }
 
@@ -315,6 +334,11 @@ impl Platform for AndroidPlatform {
         // Invoke quit handlers
         platform.handlers.lock().invoke_quit();
         tracing::info!("Android platform event loop finished");
+
+        if let Some(error) = bootstrap_error {
+            return Err(error);
+        }
+        Ok(())
     }
 
     fn quit(&self) {

--- a/crates/flui-platform/src/platforms/android/mod.rs
+++ b/crates/flui-platform/src/platforms/android/mod.rs
@@ -292,7 +292,7 @@ impl Platform for AndroidPlatform {
             // always `Ready`.
             if should_call_ready {
                 if let Some(ready) = on_ready.take() {
-                    let owner_platform: Arc<dyn Platform> = Arc::clone(&platform);
+                    let owner_platform = Arc::clone(&platform) as Arc<dyn Platform>;
                     let hooks: Arc<dyn OwnerHooks> =
                         Arc::new(DirectOwnerHooks::new(Arc::clone(&owner_platform)));
                     ready(OwnerPlatform::new(owner_platform, hooks));

--- a/crates/flui-platform/src/platforms/android/mod.rs
+++ b/crates/flui-platform/src/platforms/android/mod.rs
@@ -47,7 +47,10 @@ pub use window::AndroidWindow;
 use crate::{
     data_transfer::{DataTransferSource, NullDataTransferSource},
     shared::PlatformHandlers,
-    traits::*,
+    traits::{
+        owner::{DirectOwnerHooks, OwnerHooks},
+        *,
+    },
 };
 
 /// Android platform implementation using `android-activity`
@@ -61,9 +64,9 @@ use crate::{
 /// #[no_mangle]
 /// fn android_main(app: AndroidApp) {
 ///     let platform = AndroidPlatform::new(app);
-///     platform.run(Box::new(|platform| {
-///         // Platform ready — create window and renderer
-///         let _ = platform;
+///     platform.run(Box::new(|owner| {
+///         // Platform ready (first Resume) — create window and renderer
+///         let _ = owner;
 ///     }));
 /// }
 /// ```
@@ -173,8 +176,14 @@ impl Platform for AndroidPlatform {
         self.background_executor.clone()
     }
 
-    fn run(self: Box<Self>, on_ready: Box<dyn FnOnce(&dyn Platform)>) {
+    fn run(self: Box<Self>, on_ready: PlatformReadyCallback) {
         tracing::info!("Starting Android platform event loop");
+
+        // Converted once, up front: `on_ready` needs an `Arc<dyn Platform>`
+        // to mint `OwnerPlatform` from (ADR-0039 slice 2), and the rest of
+        // this loop reads through the same `Arc` for its whole lifetime
+        // instead of the original `Box`.
+        let platform = Arc::new(*self);
 
         let mut on_ready = Some(on_ready);
         let mut resumed = false;
@@ -182,15 +191,15 @@ impl Platform for AndroidPlatform {
         // data published through it. The loop re-reads it every iteration,
         // the Destroy store happens on the loop thread itself, and a
         // cross-thread `quit()` only needs eventual visibility.
-        self.running.store(true, Ordering::Relaxed);
+        platform.running.store(true, Ordering::Relaxed);
 
         loop {
-            if !self.running.load(Ordering::Relaxed) {
+            if !platform.running.load(Ordering::Relaxed) {
                 break;
             }
 
             // Check if we should render before polling
-            let should_render = self
+            let should_render = platform
                 .window
                 .lock()
                 .as_ref()
@@ -204,7 +213,7 @@ impl Platform for AndroidPlatform {
 
             let mut should_call_ready = false;
 
-            self.app.poll_events(Some(timeout), |event| {
+            platform.app.poll_events(Some(timeout), |event| {
                 match event {
                     PollEvent::Main(main_event) => match main_event {
                         MainEvent::Resume { .. } => {
@@ -216,7 +225,7 @@ impl Platform for AndroidPlatform {
                             }
 
                             // Notify window of activation
-                            if let Some(ref w) = *self.window.lock() {
+                            if let Some(ref w) = *platform.window.lock() {
                                 w.callbacks().dispatch_active_status_change(true);
                                 w.request_redraw();
                             }
@@ -226,7 +235,7 @@ impl Platform for AndroidPlatform {
                             resumed = false;
 
                             // Notify window of deactivation
-                            if let Some(ref w) = *self.window.lock() {
+                            if let Some(ref w) = *platform.window.lock() {
                                 w.callbacks().dispatch_active_status_change(false);
                             }
                         }
@@ -234,15 +243,15 @@ impl Platform for AndroidPlatform {
                             tracing::info!("Android: Destroy — shutting down");
 
                             // Dispatch close before stopping
-                            if let Some(ref w) = *self.window.lock() {
+                            if let Some(ref w) = *platform.window.lock() {
                                 w.callbacks().dispatch_close();
                             }
 
-                            self.running.store(false, Ordering::Relaxed);
+                            platform.running.store(false, Ordering::Relaxed);
                         }
                         MainEvent::WindowResized { .. } => {
                             tracing::info!("Android: Window resized");
-                            if let Some(ref w) = *self.window.lock() {
+                            if let Some(ref w) = *platform.window.lock() {
                                 let size = w.logical_size();
                                 let scale = w.scale_factor() as f32;
                                 w.callbacks().dispatch_resize(size, scale);
@@ -251,13 +260,13 @@ impl Platform for AndroidPlatform {
                         }
                         MainEvent::GainedFocus => {
                             tracing::debug!("Android: Gained focus");
-                            if let Some(ref w) = *self.window.lock() {
+                            if let Some(ref w) = *platform.window.lock() {
                                 w.callbacks().dispatch_active_status_change(true);
                             }
                         }
                         MainEvent::LostFocus => {
                             tracing::debug!("Android: Lost focus");
-                            if let Some(ref w) = *self.window.lock() {
+                            if let Some(ref w) = *platform.window.lock() {
                                 w.callbacks().dispatch_active_status_change(false);
                             }
                         }
@@ -273,28 +282,38 @@ impl Platform for AndroidPlatform {
                 }
             });
 
-            // Call on_ready outside of poll_events (FnOnce can't be called in closure)
+            // Call on_ready outside of poll_events (FnOnce can't be called in
+            // closure). Fires once, at the first `Resume` — the module doc's
+            // `Resumed -> on_ready() -> create surface` sequence (ADR-0039
+            // slice 2: the pre-run bootstrap that used to run before this
+            // loop started now runs from here, in `flui-app`'s `on_ready`
+            // migration). No owner lane on this backend: every
+            // `OwnerPlatform::open_window` call creates directly and is
+            // always `Ready`.
             if should_call_ready {
                 if let Some(ready) = on_ready.take() {
-                    ready(&*self);
+                    let owner_platform: Arc<dyn Platform> = Arc::clone(&platform);
+                    let hooks: Arc<dyn OwnerHooks> =
+                        Arc::new(DirectOwnerHooks::new(Arc::clone(&owner_platform)));
+                    ready(OwnerPlatform::new(owner_platform, hooks));
                 }
             }
 
             // Process input events (touch, key) and dispatch through callbacks
             if resumed {
-                self.process_input_events();
+                platform.process_input_events();
             }
 
             // Dispatch frame rendering if resumed and redraw was requested
             if resumed && should_render {
-                if let Some(ref w) = *self.window.lock() {
+                if let Some(ref w) = *platform.window.lock() {
                     w.callbacks().dispatch_request_frame();
                 }
             }
         }
 
         // Invoke quit handlers
-        self.handlers.lock().invoke_quit();
+        platform.handlers.lock().invoke_quit();
         tracing::info!("Android platform event loop finished");
     }
 

--- a/crates/flui-platform/src/platforms/headless/platform.rs
+++ b/crates/flui-platform/src/platforms/headless/platform.rs
@@ -17,10 +17,12 @@ use crate::{
     data_transfer::{DataTransferSource, NullDataTransferSource},
     shared::{PlatformHandlers, WindowCallbacks},
     traits::{
-        Clipboard, ClipboardItem, CursorError, DesktopCapabilities, DispatchEventResult, Platform,
-        PlatformCapabilities, PlatformDisplay, PlatformExecutor, PlatformHaptics, PlatformInput,
-        PlatformReadyCallback, PlatformTextInput, PlatformWindow, WindowAppearance,
-        WindowBackgroundAppearance, WindowBounds, WindowEvent, WindowId, WindowOptions,
+        Clipboard, ClipboardItem, CursorError, DesktopCapabilities, DispatchEventResult,
+        OwnerPlatform, Platform, PlatformCapabilities, PlatformDisplay, PlatformExecutor,
+        PlatformHaptics, PlatformInput, PlatformReadyCallback, PlatformTextInput, PlatformWindow,
+        WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowEvent, WindowId,
+        WindowOptions,
+        owner::{DirectOwnerHooks, OwnerHooks},
     },
 };
 
@@ -102,8 +104,16 @@ impl Platform for HeadlessPlatform {
             state.is_running = true;
         });
 
-        // In headless mode, just call on_ready and return immediately
-        on_ready(&*self);
+        // No owner lane on this backend: every `OwnerPlatform::open_window`
+        // call creates directly and is always `Ready` (ADR-0039 slice 2).
+        // "For the loop's life" means "until the value is dropped" here,
+        // since `run` returns immediately (ADR-0039 §1) -- there is no
+        // later point on this thread to defer to.
+        let platform: Arc<dyn Platform> = Arc::new(*self);
+        let hooks: Arc<dyn OwnerHooks> = Arc::new(DirectOwnerHooks::new(Arc::clone(&platform)));
+
+        // In headless mode, just call on_ready and return immediately.
+        on_ready(OwnerPlatform::new(platform, hooks));
 
         tracing::info!("Headless platform ready");
     }

--- a/crates/flui-platform/src/platforms/headless/platform.rs
+++ b/crates/flui-platform/src/platforms/headless/platform.rs
@@ -97,7 +97,7 @@ impl Platform for HeadlessPlatform {
         self.with_state(|state| state.background_executor.clone())
     }
 
-    fn run(self: Box<Self>, on_ready: PlatformReadyCallback) {
+    fn run(self: Box<Self>, on_ready: PlatformReadyCallback) -> anyhow::Result<()> {
         tracing::info!("Starting headless platform (no event loop)");
 
         self.with_state(|state| {
@@ -112,10 +112,14 @@ impl Platform for HeadlessPlatform {
         let platform: Arc<dyn Platform> = Arc::new(*self);
         let hooks: Arc<dyn OwnerHooks> = Arc::new(DirectOwnerHooks::new(Arc::clone(&platform)));
 
-        // In headless mode, just call on_ready and return immediately.
-        on_ready(OwnerPlatform::new(platform, hooks));
+        // In headless mode, just call on_ready and return immediately. A
+        // fallible bootstrap has nowhere else to go on this backend since
+        // there is no loop to keep running with a half-built app --
+        // propagate straight out of `run`.
+        on_ready(OwnerPlatform::new(platform, hooks))?;
 
         tracing::info!("Headless platform ready");
+        Ok(())
     }
 
     fn quit(&self) {

--- a/crates/flui-platform/src/platforms/ios/mod.rs
+++ b/crates/flui-platform/src/platforms/ios/mod.rs
@@ -177,7 +177,12 @@ impl Platform for IOSPlatform {
         unimplemented!("iOS GCD executor not implemented")
     }
 
-    fn run(self: Box<Self>, _on_finish_launching: Box<dyn FnOnce()>) {
+    fn run(self: Box<Self>, _on_finish_launching: PlatformReadyCallback) {
+        // Pre-existing signature mismatch fixed by the callback flip
+        // (ADR-0039 slice 2): this stub never compiled under any CI target
+        // before (`target_os = "ios"` has no CI compile job) and still
+        // returns `unimplemented!()` -- platform-init stub exemption
+        // (AGENTS.md).
         unimplemented!("iOS UIApplicationMain run loop not implemented")
     }
 

--- a/crates/flui-platform/src/platforms/ios/mod.rs
+++ b/crates/flui-platform/src/platforms/ios/mod.rs
@@ -177,12 +177,14 @@ impl Platform for IOSPlatform {
         unimplemented!("iOS GCD executor not implemented")
     }
 
-    fn run(self: Box<Self>, _on_finish_launching: PlatformReadyCallback) {
+    fn run(self: Box<Self>, _on_finish_launching: PlatformReadyCallback) -> anyhow::Result<()> {
         // Pre-existing signature mismatch fixed by the callback flip
         // (ADR-0039 slice 2): this stub never compiled under any CI target
         // before (`target_os = "ios"` has no CI compile job) and still
         // returns `unimplemented!()` -- platform-init stub exemption
-        // (AGENTS.md).
+        // (AGENTS.md). The later fallible `on_ready`/`run` flip is likewise
+        // trivial propagation here — `unimplemented!()` unifies with any
+        // return type.
         unimplemented!("iOS UIApplicationMain run loop not implemented")
     }
 

--- a/crates/flui-platform/src/platforms/linux/mod.rs
+++ b/crates/flui-platform/src/platforms/linux/mod.rs
@@ -139,7 +139,7 @@ impl Platform for LinuxPlatform {
         unimplemented!("Linux Tokio executor integration not implemented")
     }
 
-    fn run(self: Box<Self>, _on_finish_launching: PlatformReadyCallback) {
+    fn run(self: Box<Self>, _on_finish_launching: PlatformReadyCallback) -> anyhow::Result<()> {
         unimplemented!("Linux event loop (Wayland/X11) not implemented")
     }
 

--- a/crates/flui-platform/src/platforms/macos/mod.rs
+++ b/crates/flui-platform/src/platforms/macos/mod.rs
@@ -27,9 +27,10 @@
 //! use flui_platform::MacOSPlatform;
 //!
 //! let platform = MacOSPlatform::new()?;
-//! platform.run(Box::new(|_platform| {
+//! platform.run(Box::new(|_owner| {
 //!     println!("macOS platform ready!");
-//! }));
+//!     Ok(())
+//! }))?;
 //! ```
 
 // cocoa 0.26 deprecates its entire API surface in favor of the objc2 family;

--- a/crates/flui-platform/src/platforms/macos/platform.rs
+++ b/crates/flui-platform/src/platforms/macos/platform.rs
@@ -159,7 +159,7 @@ impl Platform for MacOSPlatform {
         Arc::clone(&self.background_executor) as Arc<dyn PlatformExecutor>
     }
 
-    fn run(self: Box<Self>, on_finish_launching: PlatformReadyCallback) {
+    fn run(self: Box<Self>, on_finish_launching: PlatformReadyCallback) -> anyhow::Result<()> {
         // Idempotent when `with_config` already bound on this thread; trips
         // a debug assertion if `run` somehow migrated threads (ADR-0039).
         self.affinity.bind_current();
@@ -177,9 +177,12 @@ impl Platform for MacOSPlatform {
         // Call the launch callback. This is an ordinary (safe) call — keep
         // it outside the `unsafe` block below rather than widening that
         // block's scope to cover code that needs no unsafe justification.
+        // `on_finish_launching` runs before `app.run()` starts: on `Err`,
+        // return without ever starting the NSApplication event loop rather
+        // than launching over a half-built app.
         let platform: Arc<dyn Platform> = Arc::new(*self);
         let hooks: Arc<dyn OwnerHooks> = Arc::new(DirectOwnerHooks::new(Arc::clone(&platform)));
-        on_finish_launching(OwnerPlatform::new(platform, hooks));
+        on_finish_launching(OwnerPlatform::new(platform, hooks))?;
 
         // SAFETY: runs on the main thread; `app` is the live NSApplication
         // singleton.
@@ -193,6 +196,11 @@ impl Platform for MacOSPlatform {
             tracing::info!("Starting NSApplication event loop");
             app.run();
         }
+
+        // Unreachable in practice: `app.run()` never returns on macOS
+        // (`terminate:` exits the process) — this satisfies the trait's
+        // `Result` return type for the compiler, not a real code path.
+        Ok(())
     }
 
     fn quit(&self) {

--- a/crates/flui-platform/src/platforms/macos/platform.rs
+++ b/crates/flui-platform/src/platforms/macos/platform.rs
@@ -18,9 +18,10 @@ use crate::{
     executor::BackgroundExecutor,
     shared::PlatformHandlers,
     traits::{
-        Clipboard, DesktopCapabilities, Platform, PlatformCapabilities, PlatformDisplay,
-        PlatformExecutor, PlatformReadyCallback, PlatformWindow, WindowEvent, WindowId,
-        WindowOptions,
+        Clipboard, DesktopCapabilities, OwnerPlatform, Platform, PlatformCapabilities,
+        PlatformDisplay, PlatformExecutor, PlatformReadyCallback, PlatformWindow, WindowEvent,
+        WindowId, WindowOptions,
+        owner::{DirectOwnerHooks, OwnerHooks},
     },
 };
 
@@ -164,22 +165,33 @@ impl Platform for MacOSPlatform {
         self.affinity.bind_current();
         debug_assert_appkit_main_thread("MacOSPlatform::run");
 
-        // Call the launch callback. This is an ordinary (safe) call — keep it
-        // outside the `unsafe` block below rather than widening that block's
-        // scope to cover code that needs no unsafe justification.
-        on_finish_launching(&*self);
+        // `app` is a Copy Objective-C object pointer: captured before `self`
+        // moves into the `Arc<dyn Platform>` the capability needs.
+        let app = self.app;
 
-        // SAFETY: runs on the main thread; `self.app` is the live
-        // NSApplication singleton.
+        // No owner lane on this backend: every `OwnerPlatform::open_window`
+        // call creates directly and is always `Ready` (ADR-0039 slice 2).
+        // `run` never returns on macOS (`terminate:` exits the process), so
+        // there is no loop-scoped TLS host to clear here either.
+        //
+        // Call the launch callback. This is an ordinary (safe) call — keep
+        // it outside the `unsafe` block below rather than widening that
+        // block's scope to cover code that needs no unsafe justification.
+        let platform: Arc<dyn Platform> = Arc::new(*self);
+        let hooks: Arc<dyn OwnerHooks> = Arc::new(DirectOwnerHooks::new(Arc::clone(&platform)));
+        on_finish_launching(OwnerPlatform::new(platform, hooks));
+
+        // SAFETY: runs on the main thread; `app` is the live NSApplication
+        // singleton.
         unsafe {
             // Activate the app (bring to foreground)
-            self.app.activateIgnoringOtherApps_(YES);
+            app.activateIgnoringOtherApps_(YES);
 
             // Run the NSApplication event loop. Window lifecycle events are
             // delivered via NSWindowDelegate; input events via the content
             // view's NSResponder chain.
             tracing::info!("Starting NSApplication event loop");
-            self.app.run();
+            app.run();
         }
     }
 

--- a/crates/flui-platform/src/platforms/web/platform.rs
+++ b/crates/flui-platform/src/platforms/web/platform.rs
@@ -12,7 +12,10 @@ use wasm_bindgen::prelude::*;
 use crate::{
     data_transfer::{DataTransferSource, NullDataTransferSource},
     shared::{PlatformHandlers, WindowCallbacks},
-    traits::*,
+    traits::{
+        owner::{DirectOwnerHooks, OwnerHooks},
+        *,
+    },
 };
 
 use super::{
@@ -122,16 +125,30 @@ impl Platform for WebPlatform {
         self.with_state(|s| s.background_executor.clone())
     }
 
-    fn run(self: Box<Self>, on_ready: Box<dyn FnOnce(&dyn Platform)>) {
+    fn run(self: Box<Self>, on_ready: PlatformReadyCallback) {
         tracing::info!("Starting web platform");
 
         self.with_state(|s| s.is_running = true);
 
-        // Call on_ready synchronously — browser event loop is already running
-        on_ready(&*self);
+        let platform = Arc::new(*self);
+
+        // No owner lane on this backend: every `OwnerPlatform::open_window`
+        // call creates directly and is always `Ready` (ADR-0039 slice 2).
+        // wasm is single-threaded, so `PlatformProxy` staying inert here is
+        // moot rather than a real limitation (ADR-0039 "wasm posture").
+        let hooks: Arc<dyn OwnerHooks> = Arc::new(DirectOwnerHooks::new(
+            Arc::clone(&platform) as Arc<dyn Platform>
+        ));
+
+        // Call on_ready synchronously — browser event loop is already
+        // running.
+        on_ready(OwnerPlatform::new(
+            Arc::clone(&platform) as Arc<dyn Platform>,
+            hooks,
+        ));
 
         // Start the RAF loop
-        self.start_raf_loop();
+        platform.start_raf_loop();
 
         tracing::info!("Web platform ready");
     }

--- a/crates/flui-platform/src/platforms/web/platform.rs
+++ b/crates/flui-platform/src/platforms/web/platform.rs
@@ -125,7 +125,7 @@ impl Platform for WebPlatform {
         self.with_state(|s| s.background_executor.clone())
     }
 
-    fn run(self: Box<Self>, on_ready: PlatformReadyCallback) {
+    fn run(self: Box<Self>, on_ready: PlatformReadyCallback) -> anyhow::Result<()> {
         tracing::info!("Starting web platform");
 
         self.with_state(|s| s.is_running = true);
@@ -141,16 +141,18 @@ impl Platform for WebPlatform {
         ));
 
         // Call on_ready synchronously — browser event loop is already
-        // running.
+        // running. On `Err`, do NOT install the RAF loop over a half-built
+        // page — return the failure instead.
         on_ready(OwnerPlatform::new(
             Arc::clone(&platform) as Arc<dyn Platform>,
             hooks,
-        ));
+        ))?;
 
         // Start the RAF loop
         platform.start_raf_loop();
 
         tracing::info!("Web platform ready");
+        Ok(())
     }
 
     fn quit(&self) {

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -42,9 +42,10 @@ use crate::{
     executor::BackgroundExecutor,
     shared::{PlatformHandlers, WindowCallbacks},
     traits::{
-        Clipboard, DesktopCapabilities, Platform, PlatformCapabilities, PlatformDisplay,
-        PlatformExecutor, PlatformWindow, WindowAppearance, WindowEvent, WindowId, WindowMode,
-        WindowOptions,
+        Clipboard, DesktopCapabilities, OwnerPlatform, Platform, PlatformCapabilities,
+        PlatformDisplay, PlatformExecutor, PlatformReadyCallback, PlatformWindow, WindowAppearance,
+        WindowEvent, WindowId, WindowMode, WindowOptions,
+        owner::{DirectOwnerHooks, OwnerHooks},
     },
 };
 
@@ -909,7 +910,7 @@ impl Platform for WindowsPlatform {
 
     // ==================== Lifecycle ====================
 
-    fn run(self: Box<Self>, on_ready: Box<dyn FnOnce(&dyn Platform)>) {
+    fn run(self: Box<Self>, on_ready: PlatformReadyCallback) {
         tracing::info!("Running Windows platform");
 
         // Idempotent from the constructing thread; a `run` migrated to a
@@ -917,8 +918,13 @@ impl Platform for WindowsPlatform {
         // message-only window's queue is bound to the constructing thread).
         self.affinity.bind_current();
 
-        // Call ready callback
-        on_ready(&*self);
+        // No owner lane on this backend: every `OwnerPlatform::open_window`
+        // call creates directly and is always `Ready` (ADR-0039 slice 2).
+        // `PlatformProxy` is permanently `OwnerGone` until slice 3 adopts a
+        // lane here.
+        let platform: Arc<dyn Platform> = Arc::new(*self);
+        let hooks: Arc<dyn OwnerHooks> = Arc::new(DirectOwnerHooks::new(Arc::clone(&platform)));
+        on_ready(OwnerPlatform::new(platform, hooks));
 
         Self::run_message_loop();
     }

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -910,7 +910,7 @@ impl Platform for WindowsPlatform {
 
     // ==================== Lifecycle ====================
 
-    fn run(self: Box<Self>, on_ready: PlatformReadyCallback) {
+    fn run(self: Box<Self>, on_ready: PlatformReadyCallback) -> anyhow::Result<()> {
         tracing::info!("Running Windows platform");
 
         // Idempotent from the constructing thread; a `run` migrated to a
@@ -920,13 +920,17 @@ impl Platform for WindowsPlatform {
 
         // No owner lane on this backend: every `OwnerPlatform::open_window`
         // call creates directly and is always `Ready` (ADR-0039 slice 2).
-        // `PlatformProxy` is permanently `OwnerGone` until slice 3 adopts a
+        // `PlatformProxy` is permanently unsupported until slice 3 adopts a
         // lane here.
         let platform: Arc<dyn Platform> = Arc::new(*self);
         let hooks: Arc<dyn OwnerHooks> = Arc::new(DirectOwnerHooks::new(Arc::clone(&platform)));
-        on_ready(OwnerPlatform::new(platform, hooks));
+        // `on_ready` runs before the message pump starts: on `Err`, skip
+        // the pump entirely and return rather than servicing messages for a
+        // half-built app.
+        on_ready(OwnerPlatform::new(platform, hooks))?;
 
         Self::run_message_loop();
+        Ok(())
     }
 
     fn quit(&self) {

--- a/crates/flui-platform/src/platforms/winit/control.rs
+++ b/crates/flui-platform/src/platforms/winit/control.rs
@@ -220,10 +220,15 @@ impl ControlCommand {
         match self {
             Self::OpenWindow { options, reply } => {
                 // No owner ever saw this request (the enqueue itself
-                // failed); dropping `reply` here is silent (`ClaimSlot` has
-                // no `Drop` side effect -- only the paired `ClaimHandle`'s
-                // drop fires the abandonment wake, and that already
-                // happened at the call site).
+                // failed): the paired `ClaimHandle` (`request_open_window_
+                // after_admission`'s local `handle`) already dropped when
+                // that function returned `Err`, transitioning the slot
+                // `Pending -> Abandoned(None)` and firing the abandonment
+                // wake, before this `reply: ClaimSlot` is ever dropped here.
+                // `ClaimSlot`'s own `Drop` (ADR-0039 §3 slice-2 amendment:
+                // owner-disconnect -> `OwnerGone`) only fires on a slot
+                // still `Pending`, so dropping `reply` here is a no-op --
+                // the request is already resolved.
                 drop(reply);
                 options
             }
@@ -278,6 +283,7 @@ mod tests {
         time::Duration,
     };
 
+    use flui_foundation::ClaimOutcome;
     use flui_types::geometry::{Size, px};
     use static_assertions::{assert_impl_all, assert_not_impl_any};
 
@@ -395,11 +401,13 @@ mod tests {
             reply.deliver(Ok(Arc::new(StubWindow))).is_ok(),
             "slot is still Pending"
         );
-        let window = worker
-            .join()
-            .expect("worker exits")
-            .expect("this handle is never polled by another caller before wait")
-            .expect("window opens");
+        let window = match worker.join().expect("worker exits") {
+            ClaimOutcome::Delivered(result) => result.expect("window opens"),
+            ClaimOutcome::AlreadyClaimed => {
+                panic!("this handle is never polled by another caller before wait")
+            }
+            ClaimOutcome::OwnerGone => panic!("the owner never disconnects in this test"),
+        };
         assert!(window.is_visible());
     }
 
@@ -556,12 +564,13 @@ mod tests {
                 .is_ok(),
             "slot is still Pending"
         );
-        assert!(
-            handle
-                .wait()
-                .expect("this handle is never polled by another caller before wait")
-                .is_err()
-        );
+        match handle.wait() {
+            ClaimOutcome::Delivered(result) => assert!(result.is_err()),
+            ClaimOutcome::AlreadyClaimed => {
+                panic!("this handle is never polled by another caller before wait")
+            }
+            ClaimOutcome::OwnerGone => panic!("the owner never disconnects in this test"),
+        }
     }
 
     #[test]

--- a/crates/flui-platform/src/platforms/winit/control.rs
+++ b/crates/flui-platform/src/platforms/winit/control.rs
@@ -4,24 +4,37 @@ use std::{
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
-        mpsc::{Receiver as ResponseReceiver, SyncSender as ResponseSender, sync_channel},
     },
 };
 
 use crossbeam_channel::{Receiver, Sender, TrySendError, bounded};
+use flui_foundation::{ClaimHandle, ClaimSlot, claim_slot};
 use parking_lot::Mutex;
 
-use crate::traits::{WindowId, WindowOptions};
+use crate::traits::{PlatformWindow, WindowOptions, owner::OpenWindowError};
 
 pub(super) const CONTROL_CAPACITY: usize = 256;
 
 type WakeOwner = Arc<dyn Fn() + Send + Sync>;
-type OpenWindowResult = anyhow::Result<WindowId>;
+
+/// The lane's reply payload: the fully resolved window handle, or a typed
+/// failure — exactly `OwnerPlatform`/`PlatformProxy`'s `PendingWindow`
+/// payload (ADR-0039 §3). The owner resolves `WindowId -> Arc<dyn
+/// PlatformWindow>` before delivering, so no caller needs a second lookup.
+pub(super) type OpenWindowResult = Result<Arc<dyn PlatformWindow>, OpenWindowError>;
 
 pub(super) enum ControlCommand {
     OpenWindow {
         options: WindowOptions,
-        response: ResponseSender<OpenWindowResult>,
+        /// The owner-side half of the claim-slot reply protocol
+        /// (`flui-foundation`'s `ClaimSlot`, ADR-0039 §3). Replaces the
+        /// buffered `sync_channel(1)` one-shot: a requester that abandons
+        /// the request *after* the owner delivers no longer leaks the
+        /// created window, because the abandonment transition is visible
+        /// to the owner (see `WinitApp::sweep_settled_replies`) instead of
+        /// riding a reply send that always "succeeds" whether or not
+        /// anyone ever reads it.
+        reply: ClaimSlot<OpenWindowResult>,
     },
 }
 
@@ -36,6 +49,11 @@ impl std::fmt::Debug for ControlCommand {
     }
 }
 
+/// Failure to enqueue a request on the owner lane. Unchanged vocabulary
+/// (registry evidence pin `runtime-contract.toml`): this is the *admission*
+/// failure (lane full, or the owner is already gone at send time) — a
+/// distinct, narrower concern from the claim-slot reply protocol, which
+/// governs what happens after a request is admitted.
 #[derive(Debug)]
 pub(super) enum ControlSendError {
     Full {
@@ -108,7 +126,7 @@ impl ControlSender {
     pub(super) fn request_open_window(
         &self,
         options: WindowOptions,
-    ) -> Result<ResponseReceiver<OpenWindowResult>, ControlSendError> {
+    ) -> Result<ClaimHandle<OpenWindowResult>, ControlSendError> {
         self.request_open_window_after_admission(options, || {})
     }
 
@@ -116,14 +134,23 @@ impl ControlSender {
         &self,
         options: WindowOptions,
         after_admission: impl FnOnce(),
-    ) -> Result<ResponseReceiver<OpenWindowResult>, ControlSendError> {
+    ) -> Result<ClaimHandle<OpenWindowResult>, ControlSendError> {
         let admission = self.admission.lock();
         if !*admission {
             return Err(ControlSendError::OwnerGone { rejected: options });
         }
 
-        let (response, receiver) = sync_channel(1);
-        let command = ControlCommand::OpenWindow { options, response };
+        // The claim slot's wake fires only on abandonment (never on
+        // delivery/claim), reusing the exact same coalesced owner wake as a
+        // successful enqueue -- an abandoned-before-drain request wakes the
+        // owner promptly so it can skip creating a window nobody wants.
+        let sender_for_wake = self.clone();
+        let (slot, handle): (ClaimSlot<OpenWindowResult>, ClaimHandle<OpenWindowResult>) =
+            claim_slot(Arc::new(move || sender_for_wake.wake_owner()));
+        let command = ControlCommand::OpenWindow {
+            options,
+            reply: slot,
+        };
         after_admission();
         // `try_send` cannot block while the shutdown boundary waits for this
         // critical section. Once it returns, the command is either wholly
@@ -134,12 +161,19 @@ impl ControlSender {
         match send_result {
             Ok(()) => {
                 self.wake_owner();
-                Ok(receiver)
+                Ok(handle)
             }
-            Err(TrySendError::Full(rejected)) => Err(ControlSendError::Full {
-                capacity: CONTROL_CAPACITY,
-                rejected: rejected.into_options(),
-            }),
+            Err(TrySendError::Full(rejected)) => {
+                // `handle`'s Drop fires an extra (harmless, self-correcting)
+                // abandonment wake here: no owner ever saw this request, so
+                // the wake is spurious but not incorrect -- the coalescing
+                // flag this call itself never set stays consistent for the
+                // next real enqueue.
+                Err(ControlSendError::Full {
+                    capacity: CONTROL_CAPACITY,
+                    rejected: rejected.into_options(),
+                })
+            }
             Err(TrySendError::Disconnected(rejected)) => Err(ControlSendError::OwnerGone {
                 rejected: rejected.into_options(),
             }),
@@ -168,7 +202,15 @@ impl ControlSender {
 impl ControlCommand {
     fn into_options(self) -> WindowOptions {
         match self {
-            Self::OpenWindow { options, .. } => options,
+            Self::OpenWindow { options, reply } => {
+                // No owner ever saw this request (the enqueue itself
+                // failed); dropping `reply` here is silent (`ClaimSlot` has
+                // no `Drop` side effect -- only the paired `ClaimHandle`'s
+                // drop fires the abandonment wake, and that already
+                // happened at the call site).
+                drop(reply);
+                options
+            }
         }
     }
 }
@@ -224,7 +266,7 @@ mod tests {
     use static_assertions::{assert_impl_all, assert_not_impl_any};
 
     use super::{CONTROL_CAPACITY, ControlCommand, ControlSendError, control_lane};
-    use crate::traits::{WindowId, WindowOptions};
+    use crate::traits::{WindowOptions, owner::OpenWindowError};
 
     assert_impl_all!(super::ControlSender: Clone, Send, Sync);
     assert_not_impl_any!(super::ControlReceiver: Send, Sync);
@@ -234,6 +276,36 @@ mod tests {
             title: title.into(),
             size: Size::new(px(800.0), px(600.0)),
             ..WindowOptions::default()
+        }
+    }
+
+    /// A tiny stand-in `PlatformWindow` so tests can build an
+    /// `Arc<dyn PlatformWindow>` reply payload without depending on a real
+    /// winit window.
+    struct StubWindow;
+
+    impl crate::traits::PlatformWindow for StubWindow {
+        fn physical_size(&self) -> flui_types::geometry::Size<flui_types::geometry::DevicePixels> {
+            flui_types::geometry::Size::default()
+        }
+        fn logical_size(&self) -> flui_types::geometry::Size<flui_types::geometry::Pixels> {
+            flui_types::geometry::Size::default()
+        }
+        fn scale_factor(&self) -> f64 {
+            1.0
+        }
+        fn request_redraw(&self) {}
+        fn is_focused(&self) -> bool {
+            false
+        }
+        fn is_visible(&self) -> bool {
+            true
+        }
+        fn set_cursor(
+            &self,
+            _cursor: cursor_icon::CursorIcon,
+        ) -> Result<(), crate::traits::CursorError> {
+            Ok(())
         }
     }
 
@@ -255,26 +327,28 @@ mod tests {
             .recv_timeout(Duration::from_secs(1))
             .expect("successful enqueue wakes the owner");
         assert_eq!(receiver.begin_drain(), 1, "the command precedes its wake");
-        let ControlCommand::OpenWindow { options, response } =
+        let ControlCommand::OpenWindow { options, reply } =
             receiver.try_recv().expect("queued window request");
         assert_eq!(options.title, "ordered");
         owner_ack_tx
             .send(())
             .expect("release the sending worker after inspection");
-        response
-            .send(Ok(WindowId(7)))
-            .expect("requester keeps its one-shot receiver");
+        assert!(
+            reply.deliver(Ok(Arc::new(StubWindow))).is_ok(),
+            "slot is still Pending"
+        );
 
-        let reply = worker
+        let mut handle = worker
             .join()
             .expect("sending worker does not panic")
             .expect("request is accepted");
+        let window = handle
+            .try_take()
+            .expect("owner already delivered")
+            .expect("window opens");
         assert_eq!(
-            reply
-                .recv()
-                .expect("owner completes the one-shot")
-                .expect("window opens"),
-            WindowId(7)
+            window.physical_size(),
+            flui_types::geometry::Size::default()
         );
     }
 
@@ -288,10 +362,10 @@ mod tests {
         let (sender, receiver) = control_lane(wake);
 
         let worker = thread::spawn(move || {
-            let reply = sender
+            let handle = sender
                 .request_open_window(options("cross-thread"))
                 .expect("owner lane accepts request");
-            reply.recv().expect("owner returns a result")
+            handle.wait()
         });
 
         wake_rx
@@ -299,15 +373,14 @@ mod tests {
             .expect("worker request wakes owner");
         assert_eq!(receiver.begin_drain(), 1);
         assert_eq!(thread::current().id(), owner_thread);
-        let ControlCommand::OpenWindow { response, .. } =
+        let ControlCommand::OpenWindow { reply, .. } =
             receiver.try_recv().expect("owner receives request");
-        response
-            .send(Ok(WindowId(11)))
-            .expect("worker awaits response");
-        assert_eq!(
-            worker.join().expect("worker exits").expect("window opens"),
-            WindowId(11)
+        assert!(
+            reply.deliver(Ok(Arc::new(StubWindow))).is_ok(),
+            "slot is still Pending"
         );
+        let window = worker.join().expect("worker exits").expect("window opens");
+        assert!(window.is_visible());
     }
 
     #[test]
@@ -388,7 +461,8 @@ mod tests {
         assert_eq!(
             wake_count.load(Ordering::Relaxed),
             1,
-            "a rejected command cannot create a wake"
+            "a rejected command's abandonment wake still coalesces onto the \
+             already-pending flag from the queue-filling sends"
         );
     }
 
@@ -444,7 +518,7 @@ mod tests {
 
         receiver.stop_accepting();
         let shutdown_budget = receiver.begin_drain();
-        let reply = worker
+        let handle = worker
             .join()
             .expect("admitting worker does not panic")
             .expect("the request linearized before shutdown");
@@ -453,18 +527,16 @@ mod tests {
             "shutdown snapshot contains every request admitted before the stop boundary"
         );
 
-        let ControlCommand::OpenWindow { response, .. } = receiver
+        let ControlCommand::OpenWindow { reply, .. } = receiver
             .try_recv()
             .expect("the admitted command remains available for rejection");
-        response
-            .send(Err(anyhow::anyhow!("owner stopped")))
-            .expect("requester remains live");
         assert!(
             reply
-                .try_recv()
-                .expect("shutdown completes the response before receiver drop")
-                .is_err()
+                .deliver(Err(OpenWindowError::OwnerGone { rejected: None }))
+                .is_ok(),
+            "slot is still Pending"
         );
+        assert!(handle.wait().is_err());
     }
 
     #[test]
@@ -496,5 +568,45 @@ mod tests {
             !receiver.take_quit_requested(),
             "the owner consumes one quit transition exactly once"
         );
+    }
+
+    #[test]
+    fn winit_control_dropped_handle_before_delivery_abandons_the_slot() {
+        let (sender, receiver) = control_lane(Arc::new(|| {}));
+        let handle = sender
+            .request_open_window(options("abandon-me"))
+            .expect("request is admitted");
+        drop(handle);
+
+        assert_eq!(receiver.begin_drain(), 1);
+        let ControlCommand::OpenWindow { reply, .. } =
+            receiver.try_recv().expect("owner dequeues the request");
+        assert!(
+            reply.is_abandoned(),
+            "the owner must see the abandonment before creating anything"
+        );
+    }
+
+    #[test]
+    fn winit_control_dropped_handle_after_delivery_is_reclaimable() {
+        let (sender, receiver) = control_lane(Arc::new(|| {}));
+        let handle = sender
+            .request_open_window(options("late-abandon"))
+            .expect("request is admitted");
+
+        assert_eq!(receiver.begin_drain(), 1);
+        let ControlCommand::OpenWindow { reply, .. } =
+            receiver.try_recv().expect("owner dequeues the request");
+        assert!(
+            reply.deliver(Ok(Arc::new(StubWindow))).is_ok(),
+            "slot is still Pending"
+        );
+
+        drop(handle); // claimed delivery, never read -- late abandonment
+        let reclaimed = reply
+            .take_abandoned()
+            .expect("the owner must be able to reclaim the orphaned window")
+            .expect("a successful delivery was abandoned, not a Backend error");
+        assert!(reclaimed.is_visible());
     }
 }

--- a/crates/flui-platform/src/platforms/winit/control.rs
+++ b/crates/flui-platform/src/platforms/winit/control.rs
@@ -144,9 +144,25 @@ impl ControlSender {
         // delivery/claim), reusing the exact same coalesced owner wake as a
         // successful enqueue -- an abandoned-before-drain request wakes the
         // owner promptly so it can skip creating a window nobody wants.
-        let sender_for_wake = self.clone();
+        //
+        // Captures only `wake_pending` + `wake_owner` (both plain `Arc`s
+        // unrelated to the channel), mirroring `Self::wake_owner`'s body
+        // exactly, rather than cloning the whole `ControlSender` (which
+        // holds `commands: Sender<ControlCommand>`). This command is about
+        // to be enqueued into that very channel, so a wake closure that
+        // captured a full `ControlSender` clone would put a `Sender`
+        // reachable from inside its own queued message -- a message the
+        // channel's `Arc`-backed internal state keeps alive until dequeued,
+        // creating a self-reference cycle that a request left in the queue
+        // forever (owner gone, never drained) would leak.
+        let wake_pending_for_slot = Arc::clone(&self.wake_pending);
+        let wake_owner_for_slot = Arc::clone(&self.wake_owner);
         let (slot, handle): (ClaimSlot<OpenWindowResult>, ClaimHandle<OpenWindowResult>) =
-            claim_slot(Arc::new(move || sender_for_wake.wake_owner()));
+            claim_slot(Arc::new(move || {
+                if !wake_pending_for_slot.swap(true, Ordering::AcqRel) {
+                    (wake_owner_for_slot)();
+                }
+            }));
         let command = ControlCommand::OpenWindow {
             options,
             reply: slot,
@@ -379,7 +395,11 @@ mod tests {
             reply.deliver(Ok(Arc::new(StubWindow))).is_ok(),
             "slot is still Pending"
         );
-        let window = worker.join().expect("worker exits").expect("window opens");
+        let window = worker
+            .join()
+            .expect("worker exits")
+            .expect("this handle is never polled by another caller before wait")
+            .expect("window opens");
         assert!(window.is_visible());
     }
 
@@ -536,7 +556,12 @@ mod tests {
                 .is_ok(),
             "slot is still Pending"
         );
-        assert!(handle.wait().is_err());
+        assert!(
+            handle
+                .wait()
+                .expect("this handle is never polled by another caller before wait")
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -1539,11 +1539,23 @@ impl ProxyTransport for WinitProxyTransport {
 #[cfg(test)]
 mod tests {
     use std::{
-        panic::{AssertUnwindSafe, catch_unwind},
+        collections::HashSet,
+        panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
         sync::{
             Arc,
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
         },
+        thread,
+        time::{Duration, Instant},
+    };
+
+    use flui_types::geometry::{Size, px};
+    use parking_lot::Mutex;
+    use winit::{
+        application::ApplicationHandler,
+        event::WindowEvent as WinitWindowEvent,
+        event_loop::{ActiveEventLoop, EventLoop},
+        window::WindowId as WinitWindowId,
     };
 
     use super::{
@@ -1553,6 +1565,104 @@ mod tests {
         platforms::winit::control::{ControlCommand, control_lane},
         traits::{Platform, WindowOptions},
     };
+
+    fn options(title: impl Into<String>) -> WindowOptions {
+        WindowOptions {
+            title: title.into(),
+            size: Size::new(px(320.0), px(240.0)),
+            visible: false,
+            ..WindowOptions::default()
+        }
+    }
+
+    /// Polls (bounded, 2s) until the owner has reached `Running` — the point
+    /// at which `resumed()` has returned and the owner lane accepts
+    /// deferred, post-bootstrap requests. Real wall-clock, not simulated:
+    /// these lane tests drive an actual winit event loop.
+    fn wait_for_running(platform: &WinitPlatform) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !platform.with_state(|state| matches!(state.run_state, WinitRunState::Running { .. }))
+        {
+            assert!(
+                Instant::now() < deadline,
+                "owner never reached Running within 2s"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    /// Polls (bounded, 2s) until `window_id_map.len() == expected`. Used
+    /// both to detect that a deferred request actually landed (count goes
+    /// up) and that an unwind completed (count goes back down) — a
+    /// deterministic condition, not a blind sleep, even though the exact
+    /// wake-up latency is real wall-clock time.
+    fn wait_for_map_len(platform: &WinitPlatform, expected: usize, what: &str) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let actual = platform.with_state(|state| state.window_id_map.len());
+            if actual == expected {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for {what}: window_id_map.len() = {actual}, expected {expected}"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    /// Builds a real `EventLoop` for a test running on an ordinary test
+    /// thread, not the process's actual main thread. winit refuses this by
+    /// default (a real cross-platform hazard for production code); Linux
+    /// and Windows offer an explicit opt-out for exactly this situation
+    /// (test harnesses, embedding). AppKit has no such opt-out — main-thread
+    /// affinity there is enforced by the OS, not just winit's own guard —
+    /// so these lane tests are `#[ignore]`d on macOS (see the two callers).
+    ///
+    /// **Only one `EventLoop` may ever exist per process** (a separate,
+    /// permanent winit limitation, not the main-thread one above): a second
+    /// `build()` call anywhere in the same process fails with
+    /// `RecreationAttempt`, even sequentially, even after the first loop
+    /// exited. Every test that calls this must run in its own process —
+    /// `cargo nextest run` gives each test one by default; plain
+    /// `cargo test` runs the whole binary in one process and WILL fail
+    /// whichever of these tests happens to run second. Local-only per the
+    /// ADR-0039 slice-2 plan either way (`flui-platform`'s suite is
+    /// excluded from CI regardless).
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    fn build_test_event_loop() -> EventLoop<()> {
+        #[cfg(target_os = "linux")]
+        {
+            // `EventLoopBuilderExtWayland` adds a same-named, same-effect
+            // `with_any_thread` to this same shared `EventLoopBuilder` (the
+            // backend, X11 or Wayland, is a runtime choice, not this
+            // builder's) -- importing both traits makes the call
+            // ambiguous, so this sets the flag through X11's alone; it
+            // applies regardless of which backend is actually selected at
+            // runtime.
+            use winit::platform::x11::EventLoopBuilderExtX11;
+            let mut builder = EventLoop::builder();
+            EventLoopBuilderExtX11::with_any_thread(&mut builder, true);
+            builder
+                .build()
+                .expect("build a real winit event loop off the main thread")
+        }
+        #[cfg(target_os = "windows")]
+        {
+            use winit::platform::windows::EventLoopBuilderExtWindows;
+            EventLoop::builder()
+                .with_any_thread(true)
+                .build()
+                .expect("build a real winit event loop off the main thread")
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn build_test_event_loop() -> EventLoop<()> {
+        EventLoop::builder()
+            .build()
+            .expect("build a real winit event loop (main-thread only on macOS)")
+    }
 
     #[test]
     fn winit_owner_thread_open_outside_active_event_loop_is_rejected() {
@@ -1779,5 +1889,260 @@ mod tests {
                 .expect("reply guard returns explicit error instead of disconnect")
                 .is_err()
         );
+    }
+
+    /// Drives a REAL winit event loop (this sandbox has a live X11/Wayland
+    /// display) to exercise the actual owner-side path: `create_window_now`
+    /// needs a genuine `ActiveEventLoop`, so the drain/sweep/unwind sequence
+    /// (`process_control` -> `sweep_settled_replies` -> `unwind_orphan_window`)
+    /// cannot be exercised end-to-end with a hand-built `WinitApp` alone the
+    /// way the lower-level claim-slot tests in `control.rs` do.
+    ///
+    /// `on_ready: None` — this test bypasses `OwnerPlatform` entirely and
+    /// drives the lane directly through `ControlSender`, mirroring how a
+    /// deferred post-bootstrap request actually reaches it (`WinitOwnerHooks`/
+    /// `WinitProxyTransport` are thin wrappers over exactly this).
+    #[test]
+    #[cfg_attr(
+        target_os = "macos",
+        ignore = "winit requires AppKit's event loop on the real main thread; \
+                  the test harness runs this on an ordinary test thread"
+    )]
+    fn winit_lane_dropped_after_delivery_unwinds_and_leaves_the_window_gone() {
+        let platform = Arc::new(WinitPlatform::new());
+        let event_loop = build_test_event_loop();
+        let event_loop_proxy = event_loop.create_proxy();
+        let wake_owner: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+            let _ = event_loop_proxy.send_event(());
+        });
+        let (control, receiver) = control_lane(wake_owner);
+        let owner_thread = thread::current().id();
+        platform
+            .install_control_lane(owner_thread, control.clone())
+            .expect("first install succeeds");
+
+        let platform_for_worker = Arc::clone(&platform);
+        let control_for_worker = control.clone();
+        let worker = thread::spawn(move || {
+            // Catch a scenario panic (e.g. a bounded-poll timeout) so
+            // `request_quit()` always runs below -- otherwise a failing
+            // assertion leaves `run_app` parked forever waiting for a quit
+            // that never comes, and the test hangs until nextest's
+            // slow-test SIGKILL instead of failing fast.
+            let outcome = catch_unwind(AssertUnwindSafe(|| {
+                wait_for_running(&platform_for_worker);
+
+                let before = platform_for_worker.with_state(|state| state.window_id_map.len());
+
+                let handle = control_for_worker
+                    .request_open_window(options("orphan-after-delivery"))
+                    .expect("lane accepts the request");
+
+                // Bounded poll, not a blind sleep: the request must
+                // actually be created and delivered (the map grows) before
+                // we abandon it -- otherwise we would only be testing the
+                // already-covered dropped-*before*-delivery skip path.
+                wait_for_map_len(&platform_for_worker, before + 1, "window creation");
+
+                // Drop WITHOUT claiming: the claim-slot's
+                // `Delivered -> Abandoned` transition (ADR-0039 §3) -- the
+                // owner must unwind the window it already created for a
+                // requester that vanished before reading it.
+                drop(handle);
+
+                wait_for_map_len(&platform_for_worker, before, "orphan-window unwind");
+
+                let windows_len = platform_for_worker.with_state(|state| state.windows.len());
+                assert_eq!(
+                    windows_len, before,
+                    "unwind_orphan_window must also remove the windows-map entry, \
+                     not just window_id_map"
+                );
+            }));
+
+            control_for_worker.request_quit();
+            if let Err(payload) = outcome {
+                resume_unwind(payload);
+            }
+        });
+
+        let mut app = WinitApp {
+            platform: Arc::clone(&platform),
+            on_ready: None,
+            control: receiver,
+            quit_notified: false,
+            in_flight_replies: Vec::new(),
+        };
+        event_loop
+            .run_app(&mut app)
+            .expect("event loop runs to completion");
+        worker.join().expect("worker thread does not panic");
+    }
+
+    /// See the module doc on
+    /// [`winit_lane_dropped_after_delivery_unwinds_and_leaves_the_window_gone`]
+    /// for why this needs a real event loop. This test additionally proves
+    /// the winit `window_event` entry's existing unknown-id tolerance
+    /// (`tracing::warn!("Received event for unknown window"); return;`)
+    /// covers a straggler that names an id this lane itself just unwound —
+    /// not merely an id that was never registered at all.
+    #[test]
+    #[cfg_attr(
+        target_os = "macos",
+        ignore = "winit requires AppKit's event loop on the real main thread; \
+                  the test harness runs this on an ordinary test thread"
+    )]
+    fn winit_lane_post_unwind_straggler_event_is_tolerated() {
+        /// Wraps the real `WinitApp` to inject one synthetic `window_event`
+        /// call carrying a stale (already-unwound) `WinitWindowId`, reusing
+        /// the live `&ActiveEventLoop` the wrapping callback already has —
+        /// there is no other way to obtain one outside a running loop.
+        struct StragglerHarness {
+            inner: WinitApp,
+            stale_id: Arc<Mutex<Option<WinitWindowId>>>,
+            inject_now: Arc<AtomicBool>,
+            injected: AtomicBool,
+        }
+
+        impl ApplicationHandler for StragglerHarness {
+            fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+                self.inner.resumed(event_loop);
+            }
+
+            fn window_event(
+                &mut self,
+                event_loop: &ActiveEventLoop,
+                window_id: WinitWindowId,
+                event: WinitWindowEvent,
+            ) {
+                self.inner.window_event(event_loop, window_id, event);
+            }
+
+            fn user_event(&mut self, event_loop: &ActiveEventLoop, (): ()) {
+                self.inner.user_event(event_loop, ());
+                if self.inject_now.load(Ordering::Acquire)
+                    && !self.injected.swap(true, Ordering::AcqRel)
+                    && let Some(stale_id) = *self.stale_id.lock()
+                {
+                    // The straggler: an event for a window this app has
+                    // already fully unregistered. Must not panic -- if it
+                    // did, it would unwind through this real winit callback
+                    // and the test would fail loudly rather than silently.
+                    self.inner
+                        .window_event(event_loop, stale_id, WinitWindowEvent::Focused(true));
+                }
+            }
+
+            fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+                self.inner.about_to_wait(event_loop);
+            }
+
+            fn exiting(&mut self, event_loop: &ActiveEventLoop) {
+                self.inner.exiting(event_loop);
+            }
+        }
+
+        let platform = Arc::new(WinitPlatform::new());
+        let event_loop = build_test_event_loop();
+        let event_loop_proxy = event_loop.create_proxy();
+        let event_loop_proxy_for_inject = event_loop.create_proxy();
+        let wake_owner: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+            let _ = event_loop_proxy.send_event(());
+        });
+        let (control, receiver) = control_lane(wake_owner);
+        let owner_thread = thread::current().id();
+        platform
+            .install_control_lane(owner_thread, control.clone())
+            .expect("first install succeeds");
+
+        let stale_id: Arc<Mutex<Option<WinitWindowId>>> = Arc::new(Mutex::new(None));
+        let inject_now = Arc::new(AtomicBool::new(false));
+
+        let platform_for_worker = Arc::clone(&platform);
+        let control_for_worker = control.clone();
+        let stale_id_for_worker = Arc::clone(&stale_id);
+        let inject_now_for_worker = Arc::clone(&inject_now);
+        let worker = thread::spawn(move || {
+            // See the sibling test's identical comment: `request_quit()`
+            // must run even if a scenario assertion panics, or a failing
+            // poll leaves `run_app` parked forever instead of failing fast.
+            let outcome = catch_unwind(AssertUnwindSafe(|| {
+                wait_for_running(&platform_for_worker);
+
+                let keys_before: HashSet<_> = platform_for_worker
+                    .with_state(|state| state.window_id_map.keys().copied().collect());
+
+                let handle = control_for_worker
+                    .request_open_window(options("straggler-source"))
+                    .expect("lane accepts the request");
+
+                wait_for_map_len(
+                    &platform_for_worker,
+                    keys_before.len() + 1,
+                    "window creation",
+                );
+
+                let new_id = platform_for_worker
+                    .with_state(|state| {
+                        state
+                            .window_id_map
+                            .keys()
+                            .copied()
+                            .find(|id| !keys_before.contains(id))
+                    })
+                    .expect("a new winit id must have appeared");
+                *stale_id_for_worker.lock() = Some(new_id);
+
+                // Abandon without claiming -- same unwind path as the
+                // sibling test, so by the time the map shrinks back,
+                // `new_id` is a genuinely stale id: once valid, now
+                // unregistered.
+                drop(handle);
+                wait_for_map_len(
+                    &platform_for_worker,
+                    keys_before.len(),
+                    "orphan-window unwind",
+                );
+
+                // Arm the injection and wake the loop once more so the
+                // harness's `user_event` fires the straggler `window_event`.
+                inject_now_for_worker.store(true, Ordering::Release);
+                let _ = event_loop_proxy_for_inject.send_event(());
+
+                // If the injected call had panicked inside that callback,
+                // the real winit loop would have unwound through it and
+                // this request would never complete -- proving "no panic"
+                // by the process still being alive to finish a normal
+                // round trip, rather than asserting a negative directly.
+                let sentinel = control_for_worker
+                    .request_open_window(options("post-straggler-sentinel"))
+                    .expect("lane still accepts requests after the straggler event");
+                sentinel
+                    .wait()
+                    .expect("a normal request still completes after the straggler event");
+            }));
+
+            control_for_worker.request_quit();
+            if let Err(payload) = outcome {
+                resume_unwind(payload);
+            }
+        });
+
+        let mut app = StragglerHarness {
+            inner: WinitApp {
+                platform: Arc::clone(&platform),
+                on_ready: None,
+                control: receiver,
+                quit_notified: false,
+                in_flight_replies: Vec::new(),
+            },
+            stale_id,
+            inject_now,
+            injected: AtomicBool::new(false),
+        };
+        event_loop
+            .run_app(&mut app)
+            .expect("event loop runs to completion");
+        worker.join().expect("worker thread does not panic");
     }
 }

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -49,11 +49,12 @@ use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     ptr::NonNull,
-    sync::{Arc, mpsc::SyncSender},
+    sync::Arc,
     thread::{self, ThreadId},
 };
 
 use anyhow::Result;
+use flui_foundation::ClaimSlot;
 use keyboard_types::Modifiers as KeyboardModifiers;
 use parking_lot::Mutex;
 use winit::{
@@ -67,7 +68,10 @@ use flui_types::geometry::{Pixels, Point, px};
 
 use super::{
     clipboard::ArboardClipboard,
-    control::{ControlCommand, ControlReceiver, ControlSendError, ControlSender, control_lane},
+    control::{
+        ControlCommand, ControlReceiver, ControlSendError, ControlSender, OpenWindowResult,
+        control_lane,
+    },
     data_transfer::WinitDataTransfer,
     display::WinitDisplay,
     events as winit_events,
@@ -77,9 +81,11 @@ use crate::{
     executor::BackgroundExecutor,
     shared::PlatformHandlers,
     traits::{
-        Clipboard, DesktopCapabilities, Platform, PlatformCapabilities, PlatformDisplay,
-        PlatformExecutor, PlatformInput, PlatformReadyCallback, PlatformWindow, WindowEvent,
-        WindowId, WindowOptions, WinitWindow,
+        Clipboard, DesktopCapabilities, OpenWindowError, OwnerPlatform, PendingWindow, Platform,
+        PlatformCapabilities, PlatformDisplay, PlatformExecutor, PlatformInput,
+        PlatformReadyCallback, PlatformWindow, ProxySendError, WindowEvent, WindowId, WindowOpen,
+        WindowOptions, WinitWindow,
+        owner::{OwnerHooks, ProxyTransport},
     },
 };
 
@@ -146,10 +152,10 @@ impl WinitRunState {
 ///
 /// ```rust,ignore
 /// let platform = WinitPlatform::new();
-/// platform.run(Box::new(|platform| {
-///     // `open_window` is safe to call here — see the module-level doc on
-///     // same-thread window creation.
-///     let _window = platform.open_window(Default::default());
+/// platform.run(Box::new(|owner| {
+///     // `open_window` is guaranteed `Ready` here — see the module-level
+///     // doc on same-thread window creation.
+///     let _window = owner.open_window(Default::default())?.try_ready()?;
 /// }));
 /// ```
 pub struct WinitPlatform {
@@ -335,6 +341,7 @@ impl WinitPlatform {
             on_ready: Some(on_ready),
             control: receiver,
             quit_notified: false,
+            in_flight_replies: Vec::new(),
         };
         if quit_requested {
             control.request_quit();
@@ -444,6 +451,54 @@ impl WinitPlatform {
                 .map(|window| Arc::clone(window) as Arc<dyn PlatformWindow>)
         })
     }
+
+    /// Takes the global window-event handler out from under the state lock
+    /// so it can be invoked outside it (U6, ADR-0039). Before this hoist,
+    /// `invoke_window_event` ran while `with_state`'s lock was held, so a
+    /// handler that called an owner-thread platform method (e.g. a
+    /// deferred `OwnerPlatform::open_window`) would re-enter this same
+    /// non-reentrant lock and deadlock. Restores the handler on drop, only
+    /// if nothing fresher was registered meanwhile — the same take/invoke/
+    /// restore-if-none contract as `shared::handlers::CallbackLease`,
+    /// reimplemented here (not reused directly) because this handler lives
+    /// nested inside the platform's single big state `Mutex`, not its own
+    /// standalone `Mutex<Option<T>>`.
+    fn lease_window_event_handler(&self) -> WindowEventHandlerLease<'_> {
+        let handler = self.with_state(|state| state.handlers.window_event.take());
+        WindowEventHandlerLease {
+            platform: self,
+            handler,
+        }
+    }
+}
+
+/// See [`WinitPlatform::lease_window_event_handler`].
+struct WindowEventHandlerLease<'a> {
+    platform: &'a WinitPlatform,
+    handler: Option<Box<dyn FnMut(WindowEvent) + Send>>,
+}
+
+impl WindowEventHandlerLease<'_> {
+    /// Invokes the leased handler, if one is registered, outside the
+    /// platform state lock.
+    fn invoke(&mut self, event: WindowEvent) {
+        if let Some(handler) = self.handler.as_mut() {
+            handler(event);
+        }
+    }
+}
+
+impl Drop for WindowEventHandlerLease<'_> {
+    fn drop(&mut self) {
+        let Some(handler) = self.handler.take() else {
+            return;
+        };
+        self.platform.with_state(|state| {
+            if state.handlers.window_event.is_none() {
+                state.handlers.window_event = Some(handler);
+            }
+        });
+    }
 }
 
 thread_local! {
@@ -487,33 +542,52 @@ struct WinitApp {
     on_ready: Option<PlatformReadyCallback>,
     control: ControlReceiver,
     quit_notified: bool,
+    /// Claim slots whose delivery already landed (`Ok`), kept alive past
+    /// dequeue so a *later* abandonment (the requester claimed delivery,
+    /// then dropped without reading it) can still be swept and unwound —
+    /// see [`WinitApp::sweep_settled_replies`]. Bounded by lane capacity
+    /// for queued entries; a delivered-but-unclaimed entry persists here
+    /// until the requester claims or drops it (ADR-0039 §3's honest
+    /// registry-occupancy statement — not admission-time bounded).
+    in_flight_replies: Vec<(WindowId, ClaimSlot<OpenWindowResult>)>,
 }
 
-/// Completes a dequeued window request even if owner-side processing unwinds.
+/// Completes a dequeued window request even if owner-side processing
+/// unwinds. Wraps the claim-slot owner half (ADR-0039 §3) rather than the
+/// pre-ADR-0039 buffered `sync_channel(1)` one-shot.
 struct OpenWindowReplyGuard {
-    response: Option<SyncSender<anyhow::Result<WindowId>>>,
+    reply: Option<ClaimSlot<OpenWindowResult>>,
 }
 
 impl OpenWindowReplyGuard {
-    fn new(response: SyncSender<anyhow::Result<WindowId>>) -> Self {
-        Self {
-            response: Some(response),
-        }
+    fn new(reply: ClaimSlot<OpenWindowResult>) -> Self {
+        Self { reply: Some(reply) }
     }
 
-    fn complete(mut self, result: anyhow::Result<WindowId>) -> bool {
-        self.response
+    /// Delivers `result`. Returns the still-live `ClaimSlot` when delivery
+    /// landed on `Pending` (the owner should track it in
+    /// `in_flight_replies` for a possible later abandonment); `None` when
+    /// the requester had already abandoned the slot (the owner should
+    /// unwind instead of tracking).
+    fn complete(mut self, result: OpenWindowResult) -> Option<ClaimSlot<OpenWindowResult>> {
+        let reply = self
+            .reply
             .take()
-            .is_some_and(|response| response.send(result).is_ok())
+            .expect("BUG: complete called after this guard already completed once");
+        match reply.deliver(result) {
+            Ok(()) => Some(reply),
+            Err(_already_abandoned) => None,
+        }
     }
 }
 
 impl Drop for OpenWindowReplyGuard {
     fn drop(&mut self) {
-        if let Some(response) = self.response.take() {
-            let _ = response.send(Err(anyhow::anyhow!(
-                "winit event-loop owner stopped before completing the window request"
-            )));
+        if let Some(reply) = self.reply.take() {
+            let _ = reply.deliver(Err(OpenWindowError::Backend {
+                message: "winit event-loop owner stopped before completing the window request"
+                    .to_string(),
+            }));
         }
     }
 }
@@ -532,11 +606,20 @@ impl ApplicationHandler for WinitApp {
         // Call on_ready callback once. `ACTIVE_EVENT_LOOP` is published for
         // this exact nested call so `open_window` can create windows
         // directly instead of deadlocking on the cross-thread lane (see the
-        // module-level doc).
+        // module-level doc). Mint the owner-thread capability (ADR-0039)
+        // fresh for this call: `!Send + !Sync`, so it cannot outlive this
+        // stack frame except by `on_ready` stashing it itself (e.g.
+        // `flui-app`'s `OWNER_PLATFORM_HOST` TLS slot).
         if let Some(on_ready) = self.on_ready.take() {
             tracing::info!("Calling on_ready callback");
-            let platform = Arc::clone(&self.platform);
-            with_active_event_loop(event_loop, || on_ready(&*platform));
+            let owner_thread = thread::current().id();
+            let platform: Arc<dyn Platform> = Arc::clone(&self.platform) as Arc<dyn Platform>;
+            let hooks: Arc<dyn OwnerHooks> = Arc::new(WinitOwnerHooks {
+                platform: Arc::clone(&self.platform),
+                owner_thread,
+            });
+            let owner = OwnerPlatform::new(platform, hooks);
+            with_active_event_loop(event_loop, || on_ready(owner));
         }
 
         self.platform.mark_running();
@@ -576,14 +659,20 @@ impl ApplicationHandler for WinitApp {
                     win.callbacks().dispatch_close();
                 }
 
-                // Notify platform handler
-                let (should_exit, transfer) = self.platform.with_state(|state| {
-                    state
-                        .handlers
-                        .invoke_window_event(WindowEvent::CloseRequested {
-                            window_id: platform_id,
-                        });
+                // Lease-take the global handler and invoke it OUTSIDE the
+                // state lock (U6, ADR-0039): preserves today's observable
+                // ordering (handler invocation still precedes map
+                // removal/`should_exit`) while letting the handler call
+                // owner-thread platform methods (e.g. a deferred
+                // `OwnerPlatform::open_window`) without deadlocking on this
+                // non-reentrant lock.
+                let mut handler = self.platform.lease_window_event_handler();
+                handler.invoke(WindowEvent::CloseRequested {
+                    window_id: platform_id,
+                });
+                drop(handler);
 
+                let (should_exit, transfer) = self.platform.with_state(|state| {
                     // Remove window from tracking
                     state.window_id_map.retain(|_, v| *v != platform_id);
                     state.windows.remove(&platform_id);
@@ -620,13 +709,13 @@ impl ApplicationHandler for WinitApp {
                     win.callbacks().dispatch_resize(logical, scale);
                 }
 
-                // Notify platform handler
-                self.platform.with_state(|state| {
-                    state.handlers.invoke_window_event(WindowEvent::Resized {
+                // Notify platform handler (leased outside the state lock, U6).
+                self.platform
+                    .lease_window_event_handler()
+                    .invoke(WindowEvent::Resized {
                         window_id: platform_id,
                         size,
                     });
-                });
             }
             WinitWindowEvent::RedrawRequested => {
                 tracing::trace!(?platform_id, "Redraw requested");
@@ -636,14 +725,12 @@ impl ApplicationHandler for WinitApp {
                     win.callbacks().dispatch_request_frame();
                 }
 
-                // Notify platform handler
-                self.platform.with_state(|state| {
-                    state
-                        .handlers
-                        .invoke_window_event(WindowEvent::RedrawRequested {
-                            window_id: platform_id,
-                        });
-                });
+                // Notify platform handler (leased outside the state lock, U6).
+                self.platform
+                    .lease_window_event_handler()
+                    .invoke(WindowEvent::RedrawRequested {
+                        window_id: platform_id,
+                    });
             }
             WinitWindowEvent::Focused(focused) => {
                 tracing::debug!(?platform_id, ?focused, "Window focus changed");
@@ -654,33 +741,32 @@ impl ApplicationHandler for WinitApp {
                     win.callbacks().dispatch_active_status_change(focused);
                 }
 
-                // Update active window in platform state
+                // Active-window bookkeeping stays under the lock; only the
+                // handler invocation moves outside it (U6).
                 self.platform.with_state(|state| {
                     if focused {
                         state.active_window = Some(platform_id);
                     } else if state.active_window == Some(platform_id) {
                         state.active_window = None;
                     }
-
-                    state
-                        .handlers
-                        .invoke_window_event(WindowEvent::FocusChanged {
-                            window_id: platform_id,
-                            focused,
-                        });
                 });
+
+                self.platform
+                    .lease_window_event_handler()
+                    .invoke(WindowEvent::FocusChanged {
+                        window_id: platform_id,
+                        focused,
+                    });
             }
             WinitWindowEvent::ScaleFactorChanged { scale_factor, .. } => {
                 tracing::debug!(?platform_id, ?scale_factor, "Scale factor changed");
 
-                self.platform.with_state(|state| {
-                    state
-                        .handlers
-                        .invoke_window_event(WindowEvent::ScaleFactorChanged {
-                            window_id: platform_id,
-                            scale_factor,
-                        });
-                });
+                self.platform.lease_window_event_handler().invoke(
+                    WindowEvent::ScaleFactorChanged {
+                        window_id: platform_id,
+                        scale_factor,
+                    },
+                );
             }
             WinitWindowEvent::CursorMoved { position, .. } => {
                 let modifiers = self.platform.with_state(|state| {
@@ -939,20 +1025,100 @@ impl WinitApp {
                 break;
             };
             match command {
-                ControlCommand::OpenWindow { options, response } => {
-                    let reply = OpenWindowReplyGuard::new(response);
+                ControlCommand::OpenWindow { options, reply } => {
+                    // Claim-slot protocol (ADR-0039 §3): a request already
+                    // abandoned before the owner ever looked at it skips
+                    // creation entirely — never build a window nobody
+                    // wants.
+                    if reply.is_abandoned() {
+                        tracing::debug!("window requester abandoned before creation; skipping");
+                        continue;
+                    }
+
+                    let guard = OpenWindowReplyGuard::new(reply);
                     tracing::debug!("Processing window creation request");
-                    let result = self.platform.create_window_now(event_loop, options);
-                    if !reply.complete(result) {
-                        tracing::debug!("window requester was dropped before the response");
+                    match self.platform.create_window_now(event_loop, options) {
+                        Ok(window_id) => {
+                            let window = self
+                                .platform
+                                .window_by_id(window_id)
+                                .expect("BUG: just-created window must be registered");
+                            match guard.complete(Ok(window)) {
+                                Some(reply) => self.in_flight_replies.push((window_id, reply)),
+                                None => {
+                                    // The requester abandoned in the race
+                                    // between the `is_abandoned` check above
+                                    // and this delivery — unwind instead of
+                                    // leaking (ADR-0039 §3/§4).
+                                    self.unwind_orphan_window(window_id);
+                                }
+                            }
+                        }
+                        Err(backend_error) => {
+                            let _ = guard.complete(Err(OpenWindowError::Backend {
+                                message: backend_error.to_string(),
+                            }));
+                        }
                     }
                 }
             }
         }
 
+        // Sweep entries whose requester claimed delivery and then dropped
+        // its handle without ever reading it (late abandonment) — reclaim
+        // and unwind those, and drop fully-settled entries (claimed, or
+        // abandoned-and-reclaimed) from the registry. Runs at this
+        // `user_event` drain anchor every turn, per the claim-slot module
+        // docs' sweep contract.
+        self.sweep_settled_replies();
+
         if self.control.take_quit_requested() {
             self.request_exit(event_loop);
         }
+    }
+
+    /// Reclaims and unwinds any `in_flight_replies` entry whose requester
+    /// claimed delivery, then dropped its `PendingWindow` without reading
+    /// it — and drops fully-settled entries (claimed, or already
+    /// reclaimed) from the registry.
+    fn sweep_settled_replies(&mut self) {
+        // Take ownership of the whole registry first: `unwind_orphan_window`
+        // needs `&self`, which would otherwise conflict with an active
+        // `self.in_flight_replies.drain(..)` borrow for the loop's duration.
+        let drained = std::mem::take(&mut self.in_flight_replies);
+        let mut still_pending = Vec::with_capacity(drained.len());
+        for (window_id, reply) in drained {
+            if reply.take_abandoned().is_some() {
+                self.unwind_orphan_window(window_id);
+            }
+            if !reply.is_settled() {
+                still_pending.push((window_id, reply));
+            }
+        }
+        self.in_flight_replies = still_pending;
+    }
+
+    /// Unwinds a window the requester never claimed: hides it (a visible
+    /// flicker instead of a silent leak — the ADR's own framing), removes
+    /// it from platform state, and retires any in-flight drag session
+    /// addressed at it. No per-window user callbacks fire: the window was
+    /// never delivered to any caller, so nothing outside this module ever
+    /// registered one.
+    fn unwind_orphan_window(&self, window_id: WindowId) {
+        tracing::warn!(
+            ?window_id,
+            "orphaned window request (requester abandoned); unwinding"
+        );
+        let (window, data_transfer) = self.platform.with_state(|state| {
+            let window = state.windows.remove(&window_id);
+            state.window_id_map.retain(|_, v| *v != window_id);
+            state.cursor_positions.remove(&window_id);
+            (window, Arc::clone(&state.data_transfer))
+        });
+        if let Some(window) = window {
+            window.close();
+        }
+        data_transfer.forget_window(window_id);
     }
 
     fn request_exit(&mut self, event_loop: &ActiveEventLoop) {
@@ -977,10 +1143,9 @@ impl WinitApp {
         // draining to empty is finite and includes every accepted command.
         while let Some(command) = self.control.try_recv() {
             match command {
-                ControlCommand::OpenWindow { response, .. } => {
-                    let _ = OpenWindowReplyGuard::new(response).complete(Err(anyhow::anyhow!(
-                        "winit event-loop owner is shutting down"
-                    )));
+                ControlCommand::OpenWindow { reply, .. } => {
+                    let _ = OpenWindowReplyGuard::new(reply)
+                        .complete(Err(OpenWindowError::OwnerGone { rejected: None }));
                 }
             }
         }
@@ -1084,9 +1249,9 @@ impl Platform for WinitPlatform {
             })?;
 
         // The command crosses threads as data only. The owner creates the
-        // window and completes this one-shot without exposing winit's
-        // thread-affine event-loop capability.
-        let response_rx = control
+        // window and completes this claim-slot request (ADR-0039 §3)
+        // without exposing winit's thread-affine event-loop capability.
+        let handle = control
             .request_open_window(options)
             .map_err(|error| match error {
                 ControlSendError::Full { capacity, rejected } => {
@@ -1101,12 +1266,12 @@ impl Platform for WinitPlatform {
 
         tracing::debug!("Waiting for window creation response");
 
-        let window_id = response_rx
-            .recv()
-            .map_err(|_| anyhow::anyhow!("Failed to receive window creation response"))??;
+        let window = handle
+            .wait()
+            .map_err(|error| anyhow::anyhow!("winit window creation failed: {error}"))?;
 
-        tracing::info!(?window_id, "Window created successfully");
-        self.window_by_id(window_id)
+        tracing::info!("Window created successfully");
+        Ok(window)
     }
 
     fn active_window(&self) -> Option<WindowId> {
@@ -1252,6 +1417,125 @@ impl Platform for WinitPlatform {
     }
 }
 
+/// [`OwnerHooks`] for the winit backend (ADR-0039 §1, U4/U5). Inside
+/// `on_ready`, `ACTIVE_EVENT_LOOP` is published, so creation is direct and
+/// synchronous; afterwards, this defers through the owner lane instead of
+/// blocking or re-entering backend state — the load-bearing design choice
+/// that lets a call from arbitrary owner-thread callback context (a handler
+/// invoked by [`WinitApp::window_event`], now hoisted outside the state
+/// lock by U6) neither deadlock nor mutate the platform window map
+/// mid-frame.
+struct WinitOwnerHooks {
+    platform: Arc<WinitPlatform>,
+    owner_thread: ThreadId,
+}
+
+impl OwnerHooks for WinitOwnerHooks {
+    fn open_owner_window(&self, options: WindowOptions) -> Result<WindowOpen, OpenWindowError> {
+        if let Some(event_loop_ptr) = ACTIVE_EVENT_LOOP.with(Cell::get) {
+            // SAFETY: identical justification to `Platform::open_window`'s
+            // same-thread fast path above — this call is reached only from
+            // inside the same nested `on_ready` invocation that publishes
+            // `ACTIVE_EVENT_LOOP`.
+            let event_loop = unsafe { event_loop_ptr.as_ref() };
+            let window_id = self
+                .platform
+                .create_window_now(event_loop, options)
+                .map_err(|error| OpenWindowError::Backend {
+                    message: error.to_string(),
+                })?;
+            let window = self.platform.window_by_id(window_id).map_err(|error| {
+                OpenWindowError::Backend {
+                    message: error.to_string(),
+                }
+            })?;
+            return Ok(WindowOpen::Ready(window));
+        }
+
+        // Post-bootstrap: defer through the owner lane instead of creating
+        // directly (ADR-0039 §1) — a deferred `Pending` resolves at the
+        // next `user_event` drain anchor rather than risking re-entrance
+        // into backend state from arbitrary callback context.
+        let control = self.platform.with_state(|state| match &state.run_state {
+            WinitRunState::Running { control, .. } => Some(control.clone()),
+            _ => None,
+        });
+        let Some(control) = control else {
+            return Err(OpenWindowError::OwnerGone {
+                rejected: Some(options),
+            });
+        };
+        match control.request_open_window(options) {
+            Ok(handle) => Ok(WindowOpen::Pending(PendingWindow::new(
+                handle,
+                self.owner_thread,
+            ))),
+            Err(ControlSendError::Full { capacity, rejected }) => {
+                Err(OpenWindowError::LaneFull { capacity, rejected })
+            }
+            Err(ControlSendError::OwnerGone { rejected }) => Err(OpenWindowError::OwnerGone {
+                rejected: Some(rejected),
+            }),
+        }
+    }
+
+    fn transport(&self) -> Arc<dyn ProxyTransport> {
+        Arc::new(WinitProxyTransport {
+            platform: Arc::clone(&self.platform),
+            owner_thread: self.owner_thread,
+        })
+    }
+}
+
+/// [`ProxyTransport`] for the winit backend: worker threads reach the owner
+/// lane exactly as the pre-ADR-0039 cross-thread `Platform::open_window`
+/// path already did (U5) — enqueue-and-wake, claim-slot reply.
+struct WinitProxyTransport {
+    platform: Arc<WinitPlatform>,
+    owner_thread: ThreadId,
+}
+
+impl WinitProxyTransport {
+    fn control(&self) -> Option<ControlSender> {
+        self.platform.with_state(|state| match &state.run_state {
+            WinitRunState::Starting { control, .. } | WinitRunState::Running { control, .. } => {
+                Some(control.clone())
+            }
+            WinitRunState::New { .. } | WinitRunState::Stopped => None,
+        })
+    }
+}
+
+impl ProxyTransport for WinitProxyTransport {
+    fn open_window(
+        &self,
+        options: WindowOptions,
+    ) -> Result<PendingWindow, ProxySendError<WindowOptions>> {
+        let Some(control) = self.control() else {
+            return Err(ProxySendError::OwnerGone { rejected: options });
+        };
+        control
+            .request_open_window(options)
+            .map(|handle| PendingWindow::new(handle, self.owner_thread))
+            .map_err(|error| match error {
+                ControlSendError::Full { capacity, rejected } => {
+                    ProxySendError::Full { capacity, rejected }
+                }
+                ControlSendError::OwnerGone { rejected } => ProxySendError::OwnerGone { rejected },
+            })
+    }
+
+    fn request_quit(&self) {
+        if let Some(control) = self.control() {
+            control.request_quit();
+        }
+    }
+
+    fn owner_thread(&self) -> ThreadId {
+        self.owner_thread
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -1324,6 +1608,7 @@ mod tests {
             on_ready: None,
             control: receiver,
             quit_notified: false,
+            in_flight_replies: Vec::new(),
         };
 
         app.notify_quit_once();
@@ -1336,7 +1621,7 @@ mod tests {
     fn winit_shutdown_replies_to_admitted_requests_before_app_drop() {
         let platform = Arc::new(WinitPlatform::new());
         let (sender, receiver) = control_lane(Arc::new(|| {}));
-        let replies: Vec<_> = (0..3)
+        let mut replies: Vec<_> = (0..3)
             .map(|index| {
                 sender
                     .request_open_window(WindowOptions {
@@ -1351,14 +1636,15 @@ mod tests {
             on_ready: None,
             control: receiver,
             quit_notified: false,
+            in_flight_replies: Vec::new(),
         };
 
         app.finish_shutdown();
 
         assert_eq!(app.control.pending_count(), 0);
-        for reply in replies {
+        for reply in &mut replies {
             let result = reply
-                .try_recv()
+                .try_take()
                 .expect("shutdown responds while WinitApp is still alive");
             assert!(result.is_err());
         }
@@ -1374,7 +1660,7 @@ mod tests {
                 control: sender.clone(),
             };
         });
-        let replies: Vec<_> = (0..3)
+        let mut replies: Vec<_> = (0..3)
             .map(|index| {
                 sender
                     .request_open_window(WindowOptions {
@@ -1392,15 +1678,16 @@ mod tests {
                 on_ready: None,
                 control: receiver,
                 quit_notified: false,
+                in_flight_replies: Vec::new(),
             };
             panic!("exercise WinitApp unwind cleanup");
         }));
         assert!(unwind.is_err());
 
-        for reply in replies {
+        for reply in &mut replies {
             assert!(
                 reply
-                    .try_recv()
+                    .try_take()
                     .expect("owner unwind returns an explicit result, not disconnect")
                     .is_err()
             );
@@ -1424,7 +1711,7 @@ mod tests {
                 control: sender.clone(),
             };
         });
-        let replies: Vec<_> = (0..3)
+        let mut replies: Vec<_> = (0..3)
             .map(|index| {
                 sender
                     .request_open_window(WindowOptions {
@@ -1450,14 +1737,15 @@ mod tests {
             on_ready: None,
             control: receiver,
             quit_notified: false,
+            in_flight_replies: Vec::new(),
         };
 
         let first_finish = catch_unwind(AssertUnwindSafe(|| app.finish_shutdown()));
         assert!(first_finish.is_err(), "user callback panic must propagate");
-        for reply in replies {
+        for reply in &mut replies {
             assert!(
                 reply
-                    .try_recv()
+                    .try_take()
                     .expect("owner closes queued request before invoking user code")
                     .is_err()
             );
@@ -1473,21 +1761,21 @@ mod tests {
     #[test]
     fn winit_in_flight_reply_guard_returns_explicit_error_during_unwind() {
         let (sender, receiver) = control_lane(Arc::new(|| {}));
-        let reply = sender
+        let mut handle = sender
             .request_open_window(WindowOptions::default())
             .expect("request is admitted");
         assert_eq!(receiver.begin_drain(), 1);
-        let ControlCommand::OpenWindow { response, .. } =
+        let ControlCommand::OpenWindow { reply, .. } =
             receiver.try_recv().expect("owner dequeues request");
 
         let unwind = catch_unwind(AssertUnwindSafe(move || {
-            let _reply_guard = OpenWindowReplyGuard::new(response);
+            let _reply_guard = OpenWindowReplyGuard::new(reply);
             panic!("exercise in-flight reply unwind");
         }));
         assert!(unwind.is_err());
         assert!(
-            reply
-                .try_recv()
+            handle
+                .try_take()
                 .expect("reply guard returns explicit error instead of disconnect")
                 .is_err()
         );

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -54,7 +54,7 @@ use std::{
 };
 
 use anyhow::Result;
-use flui_foundation::ClaimSlot;
+use flui_foundation::{ClaimOutcome, ClaimSlot};
 use keyboard_types::Modifiers as KeyboardModifiers;
 use parking_lot::Mutex;
 use winit::{
@@ -156,7 +156,8 @@ impl WinitRunState {
 ///     // `open_window` is guaranteed `Ready` here — see the module-level
 ///     // doc on same-thread window creation.
 ///     let _window = owner.open_window(Default::default())?.try_ready()?;
-/// }));
+///     Ok(())
+/// }))?;
 /// ```
 pub struct WinitPlatform {
     /// Platform capabilities descriptor. `DesktopCapabilities` is a
@@ -342,14 +343,25 @@ impl WinitPlatform {
             control: receiver,
             quit_notified: false,
             in_flight_replies: Vec::new(),
+            bootstrap_error: None,
         };
         if quit_requested {
             control.request_quit();
         }
 
         let result = event_loop.run_app(&mut app);
+        // Taken before `finish_shutdown` only so the borrow shape stays
+        // simple — `finish_shutdown` does not touch this field.
+        let bootstrap_error = app.bootstrap_error.take();
         app.finish_shutdown();
         result?;
+
+        // Stashed by `resumed` when `on_ready` returned `Err`: propagate it
+        // now that the loop has actually unwound, rather than the bare
+        // `tracing::error!` a caller could not otherwise observe.
+        if let Some(error) = bootstrap_error {
+            return Err(error);
+        }
 
         Ok(())
     }
@@ -550,6 +562,13 @@ struct WinitApp {
     /// until the requester claims or drops it (ADR-0039 §3's honest
     /// registry-occupancy statement — not admission-time bounded).
     in_flight_replies: Vec<(WindowId, ClaimSlot<OpenWindowResult>)>,
+    /// Set when `on_ready` returns `Err` (a fallible bootstrap failure —
+    /// window creation, GPU init, root-widget attach — has no other return
+    /// path back to `Platform::run`'s caller). `resumed` stashes it
+    /// here and requests exit; `run_event_loop` propagates it out of `run`
+    /// once the loop has actually unwound, rather than swallowing it into a
+    /// bare `tracing::error!` while the loop keeps pumping a half-built app.
+    bootstrap_error: Option<anyhow::Error>,
 }
 
 /// Completes a dequeued window request even if owner-side processing
@@ -623,7 +642,19 @@ impl ApplicationHandler for WinitApp {
                 owner_thread,
             });
             let owner = OwnerPlatform::new(platform, hooks);
-            with_active_event_loop(event_loop, || on_ready(owner));
+            if let Err(error) = with_active_event_loop(event_loop, || on_ready(owner)) {
+                // A fallible bootstrap (window creation, GPU init,
+                // root-widget attach) failed with no return path back to
+                // `Platform::run`'s caller except through this stash and an
+                // immediate exit — never continue the loop with a
+                // half-built app. `finish_shutdown` (via `request_exit`)
+                // fires quit handlers and closes the owner lane exactly as
+                // any other shutdown path does.
+                tracing::error!(%error, "on_ready bootstrap failed; stopping the event loop");
+                self.bootstrap_error = Some(error);
+                self.request_exit(event_loop);
+                return;
+            }
         }
 
         self.platform.mark_running();
@@ -1181,12 +1212,12 @@ impl Platform for WinitPlatform {
         self.with_state(|state| state.background_executor.clone())
     }
 
-    fn run(self: Box<Self>, on_ready: PlatformReadyCallback) {
+    fn run(self: Box<Self>, on_ready: PlatformReadyCallback) -> anyhow::Result<()> {
         tracing::info!("Starting winit event loop via Platform::run()");
         let platform = Arc::new(*self);
-        if let Err(e) = platform.run_event_loop(on_ready) {
-            tracing::error!("Winit event loop error: {:?}", e);
-        }
+        platform.run_event_loop(on_ready).inspect_err(|error| {
+            tracing::error!("Winit event loop error: {:?}", error);
+        })
     }
 
     fn quit(&self) {
@@ -1272,12 +1303,23 @@ impl Platform for WinitPlatform {
 
         // This `handle` is freshly minted above and never offered to any
         // other caller, so `try_take` cannot have claimed it already —
-        // `None` here would mean this fast path itself raced a second
-        // claim attempt, which the code above never performs.
-        let window = handle
-            .wait()
-            .expect("BUG: this handle is never polled by another caller before wait")
-            .map_err(|error| anyhow::anyhow!("winit window creation failed: {error}"))?;
+        // `AlreadyClaimed` here would mean this fast path itself raced a
+        // second claim attempt, which the code above never performs.
+        // `OwnerGone` is real, though: the event-loop owner can disconnect
+        // (quit, panic-unwind) while this request is in flight on the lane.
+        let window = match handle.wait() {
+            ClaimOutcome::Delivered(result) => {
+                result.map_err(|error| anyhow::anyhow!("winit window creation failed: {error}"))?
+            }
+            ClaimOutcome::AlreadyClaimed => {
+                unreachable!("BUG: this handle is never polled by another caller before wait")
+            }
+            ClaimOutcome::OwnerGone => {
+                return Err(anyhow::anyhow!(
+                    "winit event-loop owner disconnected before delivering the window"
+                ));
+            }
+        };
 
         tracing::info!("Window created successfully");
         Ok(window)
@@ -1533,9 +1575,17 @@ impl ProxyTransport for WinitProxyTransport {
             })
     }
 
-    fn request_quit(&self) {
-        if let Some(control) = self.control() {
-            control.request_quit();
+    fn request_quit(&self) -> Result<(), ProxySendError<()>> {
+        match self.control() {
+            Some(control) => {
+                control.request_quit();
+                Ok(())
+            }
+            // A lane existed (winit always has one) but the loop already
+            // stopped -- `OwnerGone`, not `Unsupported`: this backend does
+            // support cross-thread quit requests in general, this
+            // particular loop instance is just gone.
+            None => Err(ProxySendError::OwnerGone { rejected: () }),
         }
     }
 
@@ -1558,6 +1608,7 @@ mod tests {
         time::{Duration, Instant},
     };
 
+    use flui_foundation::ClaimOutcome;
     use flui_types::geometry::{Size, px};
     use parking_lot::Mutex;
     use winit::{
@@ -1728,6 +1779,7 @@ mod tests {
             control: receiver,
             quit_notified: false,
             in_flight_replies: Vec::new(),
+            bootstrap_error: None,
         };
 
         app.notify_quit_once();
@@ -1756,6 +1808,7 @@ mod tests {
             control: receiver,
             quit_notified: false,
             in_flight_replies: Vec::new(),
+            bootstrap_error: None,
         };
 
         app.finish_shutdown();
@@ -1798,6 +1851,7 @@ mod tests {
                 control: receiver,
                 quit_notified: false,
                 in_flight_replies: Vec::new(),
+                bootstrap_error: None,
             };
             panic!("exercise WinitApp unwind cleanup");
         }));
@@ -1857,6 +1911,7 @@ mod tests {
             control: receiver,
             quit_notified: false,
             in_flight_replies: Vec::new(),
+            bootstrap_error: None,
         };
 
         let first_finish = catch_unwind(AssertUnwindSafe(|| app.finish_shutdown()));
@@ -2031,6 +2086,7 @@ mod tests {
             control: receiver,
             quit_notified: false,
             in_flight_replies: Vec::new(),
+            bootstrap_error: None,
         };
         event_loop
             .run_app(&mut app)
@@ -2176,10 +2232,15 @@ mod tests {
                 let sentinel = control_for_worker
                     .request_open_window(options("post-straggler-sentinel"))
                     .expect("lane still accepts requests after the straggler event");
-                sentinel
-                    .wait()
-                    .expect("this handle is never polled by another caller before wait")
-                    .expect("a normal request still completes after the straggler event");
+                match sentinel.wait() {
+                    ClaimOutcome::Delivered(result) => {
+                        result.expect("a normal request still completes after the straggler event");
+                    }
+                    ClaimOutcome::AlreadyClaimed => {
+                        panic!("this handle is never polled by another caller before wait")
+                    }
+                    ClaimOutcome::OwnerGone => panic!("the owner never disconnects in this test"),
+                }
             }));
 
             control_for_worker.request_quit();
@@ -2195,6 +2256,7 @@ mod tests {
                 control: receiver,
                 quit_notified: false,
                 in_flight_replies: Vec::new(),
+                bootstrap_error: None,
             },
             stale_id,
             inject_now,

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -453,7 +453,7 @@ impl WinitPlatform {
     }
 
     /// Takes the global window-event handler out from under the state lock
-    /// so it can be invoked outside it (U6, ADR-0039). Before this hoist,
+    /// so it can be invoked outside it (ADR-0039). Before this hoist,
     /// `invoke_window_event` ran while `with_state`'s lock was held, so a
     /// handler that called an owner-thread platform method (e.g. a
     /// deferred `OwnerPlatform::open_window`) would re-enter this same
@@ -584,10 +584,14 @@ impl OpenWindowReplyGuard {
 impl Drop for OpenWindowReplyGuard {
     fn drop(&mut self) {
         if let Some(reply) = self.reply.take() {
-            let _ = reply.deliver(Err(OpenWindowError::Backend {
-                message: "winit event-loop owner stopped before completing the window request"
-                    .to_string(),
-            }));
+            // `OwnerGone`, not `Backend`: this guard fires when the owner
+            // stops (panics, or drops the guard) before ever completing the
+            // request -- consistent with `reject_pending_commands`'
+            // identical shutdown-path delivery and with `OwnerGone`'s own
+            // documented semantics ("the loop died after the request was
+            // already accepted"). `Backend` means the backend tried and
+            // failed to create the window; that never happened here.
+            let _ = reply.deliver(Err(OpenWindowError::OwnerGone { rejected: None }));
         }
     }
 }
@@ -660,7 +664,7 @@ impl ApplicationHandler for WinitApp {
                 }
 
                 // Lease-take the global handler and invoke it OUTSIDE the
-                // state lock (U6, ADR-0039): preserves today's observable
+                // state lock (ADR-0039): preserves today's observable
                 // ordering (handler invocation still precedes map
                 // removal/`should_exit`) while letting the handler call
                 // owner-thread platform methods (e.g. a deferred
@@ -709,7 +713,7 @@ impl ApplicationHandler for WinitApp {
                     win.callbacks().dispatch_resize(logical, scale);
                 }
 
-                // Notify platform handler (leased outside the state lock, U6).
+                // Notify platform handler (leased outside the state lock).
                 self.platform
                     .lease_window_event_handler()
                     .invoke(WindowEvent::Resized {
@@ -725,7 +729,7 @@ impl ApplicationHandler for WinitApp {
                     win.callbacks().dispatch_request_frame();
                 }
 
-                // Notify platform handler (leased outside the state lock, U6).
+                // Notify platform handler (leased outside the state lock).
                 self.platform
                     .lease_window_event_handler()
                     .invoke(WindowEvent::RedrawRequested {
@@ -742,7 +746,7 @@ impl ApplicationHandler for WinitApp {
                 }
 
                 // Active-window bookkeeping stays under the lock; only the
-                // handler invocation moves outside it (U6).
+                // handler invocation moves outside it.
                 self.platform.with_state(|state| {
                     if focused {
                         state.active_window = Some(platform_id);
@@ -1266,8 +1270,13 @@ impl Platform for WinitPlatform {
 
         tracing::debug!("Waiting for window creation response");
 
+        // This `handle` is freshly minted above and never offered to any
+        // other caller, so `try_take` cannot have claimed it already —
+        // `None` here would mean this fast path itself raced a second
+        // claim attempt, which the code above never performs.
         let window = handle
             .wait()
+            .expect("BUG: this handle is never polled by another caller before wait")
             .map_err(|error| anyhow::anyhow!("winit window creation failed: {error}"))?;
 
         tracing::info!("Window created successfully");
@@ -1417,14 +1426,13 @@ impl Platform for WinitPlatform {
     }
 }
 
-/// [`OwnerHooks`] for the winit backend (ADR-0039 §1, U4/U5). Inside
-/// `on_ready`, `ACTIVE_EVENT_LOOP` is published, so creation is direct and
-/// synchronous; afterwards, this defers through the owner lane instead of
-/// blocking or re-entering backend state — the load-bearing design choice
-/// that lets a call from arbitrary owner-thread callback context (a handler
-/// invoked by [`WinitApp::window_event`], now hoisted outside the state
-/// lock by U6) neither deadlock nor mutate the platform window map
-/// mid-frame.
+/// [`OwnerHooks`] for the winit backend (ADR-0039 §1). Inside `on_ready`,
+/// `ACTIVE_EVENT_LOOP` is published, so creation is direct and synchronous;
+/// afterwards, this defers through the owner lane instead of blocking or
+/// re-entering backend state — the load-bearing design choice that lets a
+/// call from arbitrary owner-thread callback context (a handler invoked by
+/// [`WinitApp::window_event`], now hoisted outside the state lock) neither
+/// deadlock nor mutate the platform window map mid-frame.
 struct WinitOwnerHooks {
     platform: Arc<WinitPlatform>,
     owner_thread: ThreadId,
@@ -1489,7 +1497,7 @@ impl OwnerHooks for WinitOwnerHooks {
 
 /// [`ProxyTransport`] for the winit backend: worker threads reach the owner
 /// lane exactly as the pre-ADR-0039 cross-thread `Platform::open_window`
-/// path already did (U5) — enqueue-and-wake, claim-slot reply.
+/// path already did — enqueue-and-wake, claim-slot reply.
 struct WinitProxyTransport {
     platform: Arc<WinitPlatform>,
     owner_thread: ThreadId,
@@ -1541,6 +1549,7 @@ mod tests {
     use std::{
         collections::HashSet,
         panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
+        path::PathBuf,
         sync::{
             Arc,
             atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -1932,7 +1941,8 @@ mod tests {
             let outcome = catch_unwind(AssertUnwindSafe(|| {
                 wait_for_running(&platform_for_worker);
 
-                let before = platform_for_worker.with_state(|state| state.window_id_map.len());
+                let keys_before: HashSet<_> = platform_for_worker
+                    .with_state(|state| state.window_id_map.keys().copied().collect());
 
                 let handle = control_for_worker
                     .request_open_window(options("orphan-after-delivery"))
@@ -1942,7 +1952,35 @@ mod tests {
                 // actually be created and delivered (the map grows) before
                 // we abandon it -- otherwise we would only be testing the
                 // already-covered dropped-*before*-delivery skip path.
-                wait_for_map_len(&platform_for_worker, before + 1, "window creation");
+                wait_for_map_len(
+                    &platform_for_worker,
+                    keys_before.len() + 1,
+                    "window creation",
+                );
+
+                // Capture the orphan's platform `WindowId` (not just its
+                // winit id) so we can seed and later check state keyed by
+                // it: `cursor_positions`, and a synthetic drag-drop session
+                // via `data_transfer.note_dropped_file`, proving
+                // `unwind_orphan_window` cleans up both, not just the two
+                // window-identity maps.
+                let (orphan_id, data_transfer) = platform_for_worker.with_state(|state| {
+                    let new_winit_id = *state
+                        .window_id_map
+                        .keys()
+                        .find(|id| !keys_before.contains(id))
+                        .expect("a new winit id must have appeared");
+                    let orphan_id = state.window_id_map[&new_winit_id];
+                    state
+                        .cursor_positions
+                        .insert(orphan_id, winit::dpi::PhysicalPosition::new(1.0, 2.0));
+                    (orphan_id, Arc::clone(&state.data_transfer))
+                });
+                data_transfer.note_dropped_file(orphan_id, PathBuf::from("test.txt"), None);
+                assert!(
+                    data_transfer.windows_awaiting_freeze().contains(&orphan_id),
+                    "the seeded drag session must be live before the unwind"
+                );
 
                 // Drop WITHOUT claiming: the claim-slot's
                 // `Delivered -> Abandoned` transition (ADR-0039 §3) -- the
@@ -1950,13 +1988,34 @@ mod tests {
                 // requester that vanished before reading it.
                 drop(handle);
 
-                wait_for_map_len(&platform_for_worker, before, "orphan-window unwind");
+                wait_for_map_len(
+                    &platform_for_worker,
+                    keys_before.len(),
+                    "orphan-window unwind",
+                );
 
-                let windows_len = platform_for_worker.with_state(|state| state.windows.len());
+                let (windows_len, cursor_positions_still_has_orphan) = platform_for_worker
+                    .with_state(|state| {
+                        (
+                            state.windows.len(),
+                            state.cursor_positions.contains_key(&orphan_id),
+                        )
+                    });
                 assert_eq!(
-                    windows_len, before,
+                    windows_len,
+                    keys_before.len(),
                     "unwind_orphan_window must also remove the windows-map entry, \
                      not just window_id_map"
+                );
+                assert!(
+                    !cursor_positions_still_has_orphan,
+                    "unwind_orphan_window must also remove the orphan's \
+                     cursor_positions entry"
+                );
+                assert!(
+                    !data_transfer.windows_awaiting_freeze().contains(&orphan_id),
+                    "unwind_orphan_window's data_transfer.forget_window call must \
+                     retire the orphan's in-flight drag session"
                 );
             }));
 
@@ -2119,6 +2178,7 @@ mod tests {
                     .expect("lane still accepts requests after the straggler event");
                 sentinel
                     .wait()
+                    .expect("this handle is never polled by another caller before wait")
                     .expect("a normal request still completes after the straggler event");
             }));
 

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -349,21 +349,13 @@ impl WinitPlatform {
             control.request_quit();
         }
 
-        let result = event_loop.run_app(&mut app);
+        let result = event_loop.run_app(&mut app).map_err(anyhow::Error::from);
         // Taken before `finish_shutdown` only so the borrow shape stays
         // simple — `finish_shutdown` does not touch this field.
         let bootstrap_error = app.bootstrap_error.take();
         app.finish_shutdown();
-        result?;
 
-        // Stashed by `resumed` when `on_ready` returned `Err`: propagate it
-        // now that the loop has actually unwound, rather than the bare
-        // `tracing::error!` a caller could not otherwise observe.
-        if let Some(error) = bootstrap_error {
-            return Err(error);
-        }
-
-        Ok(())
+        combine_shutdown_result(bootstrap_error, result)
     }
 
     fn install_control_lane(&self, owner_thread: ThreadId, control: ControlSender) -> Result<bool> {
@@ -513,6 +505,33 @@ impl Drop for WindowEventHandlerLease<'_> {
     }
 }
 
+/// Combines `event_loop.run_app`'s own result with a stashed `on_ready`
+/// bootstrap failure (`WinitApp::bootstrap_error`).
+///
+/// The bootstrap error is the root cause the whole fallible-`on_ready`
+/// design exists to surface — it is checked and returned FIRST, never
+/// shadowed by a loop-level error that arrives alongside it.
+/// Checking `result` first (the bug this function fixes) would silently
+/// drop the actual bootstrap failure exactly when
+/// [`WinitApp::request_exit`]'s own `event_loop.exit()` call produces a
+/// winit-level error of its own — the one scenario this whole design
+/// exists to get right. When both are present, the loop error is attached
+/// as `.context()` on top of the bootstrap error, so neither is lost: the
+/// bootstrap error's own chain is still reachable via `{:?}`/`.chain()` on
+/// the returned value.
+fn combine_shutdown_result(
+    bootstrap_error: Option<anyhow::Error>,
+    result: Result<()>,
+) -> Result<()> {
+    match bootstrap_error {
+        Some(error) => Err(match result {
+            Ok(()) => error,
+            Err(loop_error) => error.context(loop_error),
+        }),
+        None => result,
+    }
+}
+
 thread_local! {
     /// Published only while `on_ready` executes synchronously inside
     /// [`WinitApp::resumed`], on the winit event-loop thread. See the
@@ -650,7 +669,17 @@ impl ApplicationHandler for WinitApp {
                 // half-built app. `finish_shutdown` (via `request_exit`)
                 // fires quit handlers and closes the owner lane exactly as
                 // any other shutdown path does.
-                tracing::error!(%error, "on_ready bootstrap failed; stopping the event loop");
+                //
+                // Logged once, at `error` level, from `Platform::run`'s own
+                // `inspect_err` once `run_event_loop` has combined this with
+                // whatever `event_loop.run_app` itself returns -- not here,
+                // to avoid double-logging the same failure under two
+                // different (and, at the `run()` site, previously
+                // misleading) messages.
+                tracing::debug!(
+                    "on_ready bootstrap failed; requesting event-loop exit \
+                     (see Platform::run's propagated error for the failure)"
+                );
                 self.bootstrap_error = Some(error);
                 self.request_exit(event_loop);
                 return;
@@ -1215,8 +1244,14 @@ impl Platform for WinitPlatform {
     fn run(self: Box<Self>, on_ready: PlatformReadyCallback) -> anyhow::Result<()> {
         tracing::info!("Starting winit event loop via Platform::run()");
         let platform = Arc::new(*self);
+        // Generic wording, not "Winit event loop error": the propagated
+        // error may be a stashed `on_ready` bootstrap failure (window
+        // creation, GPU init, root-widget attach), a genuine winit-level
+        // error from `event_loop.run_app`, or both combined -- see
+        // `run_event_loop`'s `combine_shutdown_result`. This is the sole
+        // `error`-level log for whichever of those it turns out to be.
         platform.run_event_loop(on_ready).inspect_err(|error| {
-            tracing::error!("Winit event loop error: {:?}", error);
+            tracing::error!("winit Platform::run exited with an error: {:?}", error);
         })
     }
 
@@ -1619,11 +1654,12 @@ mod tests {
     };
 
     use super::{
-        OpenWindowReplyGuard, OpenWindowStateError, WinitApp, WinitPlatform, WinitRunState,
+        OpenWindowReplyGuard, OpenWindowStateError, WinitApp, WinitPlatform, WinitProxyTransport,
+        WinitRunState, combine_shutdown_result,
     };
     use crate::{
         platforms::winit::control::{ControlCommand, control_lane},
-        traits::{Platform, WindowOptions},
+        traits::{Platform, ProxySendError, WindowOptions, owner::ProxyTransport},
     };
 
     fn options(title: impl Into<String>) -> WindowOptions {
@@ -1633,6 +1669,58 @@ mod tests {
             visible: false,
             ..WindowOptions::default()
         }
+    }
+
+    // ========================================================================
+    // combine_shutdown_result
+    // ========================================================================
+    //
+    // Fast, deterministic, no event loop needed -- these pin the exact
+    // combining logic `run_event_loop` calls, independent of whether a real
+    // winit loop can also be driven to produce both error shapes at once
+    // (which it cannot, deterministically, in a test).
+
+    #[test]
+    fn combine_shutdown_result_is_ok_when_neither_side_errors() {
+        assert!(combine_shutdown_result(None, Ok(())).is_ok());
+    }
+
+    #[test]
+    fn combine_shutdown_result_surfaces_a_lone_bootstrap_error() {
+        let error = combine_shutdown_result(Some(anyhow::anyhow!("bootstrap failed")), Ok(()))
+            .expect_err("a stashed bootstrap error must be Err even when the loop exits cleanly");
+        assert_eq!(error.to_string(), "bootstrap failed");
+    }
+
+    #[test]
+    fn combine_shutdown_result_surfaces_a_lone_loop_error() {
+        let error = combine_shutdown_result(None, Err(anyhow::anyhow!("loop failed")))
+            .expect_err("a loop-level error with no bootstrap error must still be Err");
+        assert_eq!(error.to_string(), "loop failed");
+    }
+
+    /// The regression this whole function exists to fix: checking `result`
+    /// before `bootstrap_error` (the pre-fix ordering) would return only
+    /// `loop failed` here and silently drop `bootstrap failed` -- in
+    /// exactly the scenario the fallible-`on_ready` design exists to
+    /// surface. The bootstrap error must still be the primary `Err`
+    /// returned, with the loop error preserved (not lost) in its chain.
+    #[test]
+    fn combine_shutdown_result_keeps_the_bootstrap_error_as_root_cause_when_both_occur() {
+        let error = combine_shutdown_result(
+            Some(anyhow::anyhow!("bootstrap failed")),
+            Err(anyhow::anyhow!("loop failed")),
+        )
+        .expect_err("both a bootstrap and a loop error must still be Err");
+        let chain: Vec<String> = error.chain().map(ToString::to_string).collect();
+        assert!(
+            chain.iter().any(|link| link == "bootstrap failed"),
+            "the bootstrap error (root cause) must survive in the chain, got: {chain:?}"
+        );
+        assert!(
+            chain.iter().any(|link| link == "loop failed"),
+            "the loop error must be attached, not silently dropped, got: {chain:?}"
+        );
     }
 
     /// Polls (bounded, 2s) until the owner has reached `Running` — the point
@@ -2266,5 +2354,125 @@ mod tests {
             .run_app(&mut app)
             .expect("event loop runs to completion");
         worker.join().expect("worker thread does not panic");
+    }
+
+    /// `resumed`'s stashed `bootstrap_error` must survive all the way to the
+    /// value `run_event_loop` returns. This drives a REAL winit event loop
+    /// through the identical sequence `run_event_loop` performs --
+    /// `event_loop.run_app(&mut app)`, take `bootstrap_error`,
+    /// `finish_shutdown`, then `combine_shutdown_result` (the exact
+    /// function `run_event_loop` calls) -- rather than calling
+    /// `run_event_loop` itself, which builds its own `EventLoop` internally
+    /// via a builder with no `with_any_thread` opt-out and so cannot run on
+    /// this non-main test thread (see `build_test_event_loop`'s doc).
+    #[test]
+    #[cfg_attr(
+        target_os = "macos",
+        ignore = "winit requires AppKit's event loop on the real main thread; \
+                  the test harness runs this on an ordinary test thread"
+    )]
+    fn on_ready_failure_propagates_through_the_combined_shutdown_result() {
+        let platform = Arc::new(WinitPlatform::new());
+        let event_loop = build_test_event_loop();
+        let event_loop_proxy = event_loop.create_proxy();
+        let wake_owner: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+            let _ = event_loop_proxy.send_event(());
+        });
+        let (control, receiver) = control_lane(wake_owner);
+        let owner_thread = thread::current().id();
+        platform
+            .install_control_lane(owner_thread, control)
+            .expect("first install succeeds");
+
+        let mut app = WinitApp {
+            platform: Arc::clone(&platform),
+            on_ready: Some(Box::new(|_owner| {
+                Err(anyhow::anyhow!("simulated bootstrap failure"))
+            })),
+            control: receiver,
+            quit_notified: false,
+            in_flight_replies: Vec::new(),
+            bootstrap_error: None,
+        };
+
+        let result = event_loop.run_app(&mut app).map_err(anyhow::Error::from);
+        assert!(
+            result.is_ok(),
+            "on_ready's own Err requests a clean exit; the winit loop \
+             itself does not error in this scenario, got: {result:?}"
+        );
+
+        let bootstrap_error = app.bootstrap_error.take();
+        assert!(
+            bootstrap_error.is_some(),
+            "resumed() must stash on_ready's Err on WinitApp::bootstrap_error"
+        );
+
+        let combined = combine_shutdown_result(bootstrap_error, result);
+        let error = combined.expect_err("the bootstrap failure must propagate as Err");
+        assert!(
+            format!("{error:?}").contains("simulated bootstrap failure"),
+            "the root cause must be reachable from the combined error, got: {error:?}"
+        );
+    }
+
+    /// Nothing previously asserted that winit's REAL `ProxyTransport`
+    /// reports `OwnerGone` -- a lane existed and its loop died -- rather
+    /// than `Unsupported` (reserved for backends with no lane at all,
+    /// `ClosedTransport`) once its loop has actually stopped.
+    #[test]
+    #[cfg_attr(
+        target_os = "macos",
+        ignore = "winit requires AppKit's event loop on the real main thread; \
+                  the test harness runs this on an ordinary test thread"
+    )]
+    fn winit_proxy_reports_owner_gone_not_unsupported_after_loop_stop() {
+        let platform = Arc::new(WinitPlatform::new());
+        let event_loop = build_test_event_loop();
+        let event_loop_proxy = event_loop.create_proxy();
+        let wake_owner: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+            let _ = event_loop_proxy.send_event(());
+        });
+        let (control, receiver) = control_lane(wake_owner);
+        let owner_thread = thread::current().id();
+        platform
+            .install_control_lane(owner_thread, control.clone())
+            .expect("first install succeeds");
+
+        let platform_for_worker = Arc::clone(&platform);
+        let worker = thread::spawn(move || {
+            wait_for_running(&platform_for_worker);
+            control.request_quit();
+        });
+
+        let mut app = WinitApp {
+            platform: Arc::clone(&platform),
+            on_ready: None,
+            control: receiver,
+            quit_notified: false,
+            in_flight_replies: Vec::new(),
+            bootstrap_error: None,
+        };
+        event_loop
+            .run_app(&mut app)
+            .expect("event loop runs to completion");
+        worker.join().expect("worker thread does not panic");
+
+        // The loop has now actually stopped (`finish_shutdown` ->
+        // `close_owner_lane` -> `platform.mark_stopped()`, run_state ==
+        // `Stopped`). A lane existed here and is now gone -- distinct from
+        // a lane-less backend, which reports `Unsupported` instead.
+        let transport = WinitProxyTransport {
+            platform: Arc::clone(&platform),
+            owner_thread,
+        };
+        let error = transport
+            .open_window(options("post-shutdown"))
+            .expect_err("no lane behind a stopped winit loop");
+        assert!(
+            matches!(error, ProxySendError::OwnerGone { .. }),
+            "a stopped winit loop must report OwnerGone (a lane existed and \
+             died), not Unsupported (no lane ever existed here) -- got {error:?}"
+        );
     }
 }

--- a/crates/flui-platform/src/traits/mod.rs
+++ b/crates/flui-platform/src/traits/mod.rs
@@ -55,8 +55,8 @@ pub use input::{
 // Re-export keyboard-types for convenience
 pub use keyboard_types::NamedKey;
 pub use owner::{
-    OpenWindowError, OwnerPlatform, PendingWindow, PlatformProxy, ProxySendError, WaitError,
-    WindowOpen,
+    OpenWindowError, OwnerPlatform, PendingWindow, PlatformProxy, ProxySendError, SharedPlatform,
+    WaitError, WindowOpen,
 };
 pub use platform::{
     Clipboard, ClipboardItem, PathPromptOptions, Platform, PlatformExecutor, PlatformReadyCallback,

--- a/crates/flui-platform/src/traits/mod.rs
+++ b/crates/flui-platform/src/traits/mod.rs
@@ -9,6 +9,12 @@ mod display;
 mod embedder;
 mod haptics;
 mod input;
+// The owner-thread capability (ADR-0039): `OwnerPlatform`, `PlatformProxy`,
+// `PendingWindow`, and their typed errors. `pub(crate)` (not private): the
+// `pub(crate)` seams inside it — `OwnerHooks`, `ProxyTransport`,
+// `DirectOwnerHooks`, `ClosedTransport` — are wired up by every backend
+// module, not just this crate's own `traits` tree.
+pub(crate) mod owner;
 mod platform;
 mod text_input;
 mod window;
@@ -48,6 +54,10 @@ pub use input::{
 };
 // Re-export keyboard-types for convenience
 pub use keyboard_types::NamedKey;
+pub use owner::{
+    OpenWindowError, OwnerPlatform, PendingWindow, PlatformProxy, ProxySendError, WaitError,
+    WindowOpen,
+};
 pub use platform::{
     Clipboard, ClipboardItem, PathPromptOptions, Platform, PlatformExecutor, PlatformReadyCallback,
     WindowEvent, WindowId, WindowMode, WindowOptions,

--- a/crates/flui-platform/src/traits/owner.rs
+++ b/crates/flui-platform/src/traits/owner.rs
@@ -1,0 +1,575 @@
+//! The owner-thread platform capability (ADR-0039).
+//!
+//! [`OwnerPlatform`] carries every `Platform` operation that is owner-affine
+//! on at least one real OS: window creation, display queries, activation,
+//! appearance/keyboard queries, and quit. It is minted only by a backend, on
+//! the thread that owns — or, before the loop starts, will own — its event
+//! loop, and handed to [`super::PlatformReadyCallback`]. `!Send + !Sync` by
+//! phantom marker: possession proves the thread, so a wrong-thread call
+//! becomes a compile error instead of a runtime assert (the [`OwnerAffinity`]
+//! backstop `flui-foundation` carries).
+//!
+//! [`OwnerAffinity`]: flui_foundation::OwnerAffinity
+//!
+//! Not [`Clone`] (ADR-0039 slice-2 decision record): the sanctioned way to
+//! hold this across owner-thread callbacks is `flui-app`'s loop-scoped
+//! `OWNER_PLATFORM_HOST` TLS slot, read through its `with_owner_platform`
+//! borrow-style accessor — never a durable owned copy squirreled away
+//! outside that fenced accessor. [`PlatformProxy`] is how a *worker* thread
+//! reaches the owner; it is `Clone` by design, since it carries no
+//! thread-affine capability, only a bounded, typed, cross-thread request
+//! channel.
+//!
+//! `Platform` becomes de-facto crate-sealed by this module: minting an
+//! `OwnerPlatform` requires the `pub(crate)` constructor here, so an
+//! out-of-crate `impl Platform` cannot hand its own `run()` the capability
+//! `on_ready` needs. An external-embedder minting seam is design work
+//! tracked separately (#560); until then, backend implementations of
+//! `Platform` live in this crate.
+
+use std::fmt;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::thread::ThreadId;
+
+use flui_foundation::ClaimHandle;
+use static_assertions::{assert_impl_all, assert_not_impl_any};
+
+use super::{
+    Platform, PlatformDisplay, PlatformWindow, WindowId, WindowOptions, window::WindowAppearance,
+};
+
+// ============================================================================
+// OwnerPlatform
+// ============================================================================
+
+/// Owner-thread platform capability. See the module docs for the full
+/// contract.
+///
+/// ```compile_fail,E0277
+/// // Illustration only (ALT-2): NOT cited as registry evidence — the
+/// // item-position `assert_not_impl_any!` below is. This doctest is
+/// // excluded from every CI gate (`justfile:177` excludes flui-platform's
+/// // doc tests) and is run locally via `cargo test -p flui-platform --doc`.
+/// fn assert_send<T: Send>() {}
+/// assert_send::<flui_platform::OwnerPlatform>();
+/// ```
+pub struct OwnerPlatform {
+    platform: Arc<dyn Platform>,
+    hooks: Arc<dyn OwnerHooks>,
+    // Slice 3 shrinks `platform` to `Arc<dyn OwnerOps>`; both fields stay
+    // private regardless.
+    _owner_affine: PhantomData<*const ()>,
+}
+
+impl fmt::Debug for OwnerPlatform {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OwnerPlatform")
+            .field("platform", &self.platform.name())
+            .finish_non_exhaustive()
+    }
+}
+
+impl OwnerPlatform {
+    /// Minted only by a backend — at `on_ready`, or (on backends whose
+    /// owner thread may create directly outside callbacks) at any later
+    /// point on that same thread. `pub(crate)`: not part of the public
+    /// constructor surface (see the module docs' crate-seal note).
+    pub(crate) fn new(platform: Arc<dyn Platform>, hooks: Arc<dyn OwnerHooks>) -> Self {
+        Self {
+            platform,
+            hooks,
+            _owner_affine: PhantomData,
+        }
+    }
+
+    /// Open a window. `Ready` is guaranteed inside `on_ready`; afterwards
+    /// the backend may defer through its owner lane (where one exists),
+    /// returning `Pending`.
+    ///
+    /// # Errors
+    /// See [`OpenWindowError`].
+    pub fn open_window(&self, options: WindowOptions) -> Result<WindowOpen, OpenWindowError> {
+        self.hooks.open_owner_window(options)
+    }
+
+    /// The currently active (focused) window, if any.
+    #[must_use]
+    pub fn active_window(&self) -> Option<WindowId> {
+        self.platform.active_window()
+    }
+
+    /// All available displays (monitors).
+    #[must_use]
+    pub fn displays(&self) -> Vec<Arc<dyn PlatformDisplay>> {
+        self.platform.displays()
+    }
+
+    /// The primary display.
+    #[must_use]
+    pub fn primary_display(&self) -> Option<Arc<dyn PlatformDisplay>> {
+        self.platform.primary_display()
+    }
+
+    /// Activate the application (bring to front).
+    pub fn activate(&self, ignoring_other_apps: bool) {
+        self.platform.activate(ignoring_other_apps);
+    }
+
+    /// The system window appearance (light/dark theme).
+    #[must_use]
+    pub fn window_appearance(&self) -> WindowAppearance {
+        self.platform.window_appearance()
+    }
+
+    /// The current keyboard layout identifier.
+    #[must_use]
+    pub fn keyboard_layout(&self) -> String {
+        self.platform.keyboard_layout()
+    }
+
+    /// Request the application to quit.
+    pub fn quit(&self) {
+        self.platform.quit();
+    }
+
+    /// Escapes to the residual thread-safe surface (`Send + Sync` methods
+    /// that need no owner-thread proof: `background_executor`, `clipboard`,
+    /// callback registration, and the rest of §2's "stays on `Platform`"
+    /// list).
+    #[must_use]
+    pub fn shared(&self) -> &dyn Platform {
+        &*self.platform
+    }
+
+    /// Mints a cross-thread capability, handed to workers, realms, or
+    /// tasks that need to reach the owner from off-thread.
+    #[must_use]
+    pub fn proxy(&self) -> PlatformProxy {
+        PlatformProxy::new(self.hooks.transport())
+    }
+}
+
+// Sole registry evidence for the "wrong-thread owner ops are compile
+// errors" acceptance criterion (ALT-2) — expanded by every `cargo check`,
+// including cross-typecheck on win/mac, because `static_assertions` is a
+// real (non-dev) dependency (see Cargo.toml).
+assert_not_impl_any!(OwnerPlatform: Send, Sync);
+
+/// Result of an owner-thread window-open request.
+#[must_use = "a Pending window creation must be waited on or polled; \
+              dropping it abandons the request (the owner unwinds or skips)"]
+pub enum WindowOpen {
+    /// Created synchronously. Always the case inside `on_ready`, and on
+    /// backends whose owner thread may create directly outside callbacks.
+    Ready(Arc<dyn PlatformWindow>),
+    /// Enqueued on the owner lane; resolves at the loop's next drain
+    /// anchor.
+    Pending(PendingWindow),
+}
+
+impl fmt::Debug for WindowOpen {
+    // Manual impl: `PlatformWindow` carries no blanket `Debug`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Ready(_) => f
+                .debug_tuple("Ready")
+                .field(&"<dyn PlatformWindow>")
+                .finish(),
+            Self::Pending(pending) => f.debug_tuple("Pending").field(pending).finish(),
+        }
+    }
+}
+
+impl WindowOpen {
+    /// Bootstrap convenience: unwrap `Ready`; typed error otherwise.
+    /// Guaranteed to succeed inside `on_ready`.
+    ///
+    /// # Errors
+    /// [`OpenWindowError::NotReady`] if this call is deferred (never the
+    /// case inside `on_ready`).
+    pub fn try_ready(self) -> Result<Arc<dyn PlatformWindow>, OpenWindowError> {
+        match self {
+            Self::Ready(window) => Ok(window),
+            Self::Pending(pending) => Err(OpenWindowError::NotReady(pending)),
+        }
+    }
+}
+
+/// Failure to open a window through [`OwnerPlatform`] or [`PlatformProxy`].
+///
+/// `#[non_exhaustive]`: the ADR forecasts variant growth when slice 3's
+/// moved methods adopt this typed taxonomy in place of today's `anyhow`
+/// surface.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum OpenWindowError {
+    /// The owner lane is at capacity. `rejected` is returned so the
+    /// producer can retry without rebuilding the options.
+    #[error("owner lane is full (capacity {capacity})")]
+    LaneFull {
+        /// The lane's fixed capacity.
+        capacity: usize,
+        /// The options that could not be enqueued.
+        rejected: WindowOptions,
+    },
+    /// The event-loop owner is gone. `rejected` is `Some` when refusal
+    /// happens at enqueue (the producer can retry without rebuilding
+    /// options) and `None` when the loop died after the request was
+    /// already accepted.
+    #[error("event-loop owner is gone")]
+    OwnerGone {
+        /// The options that could not be delivered, if known at refusal.
+        rejected: Option<WindowOptions>,
+    },
+    /// The backend could not create the window.
+    #[error("the backend could not create the window: {message}")]
+    Backend {
+        /// The backend's own error message.
+        message: String,
+    },
+    /// Window creation was deferred; this call site requires `Ready`.
+    #[error("window creation was deferred; this call site requires Ready")]
+    NotReady(PendingWindow),
+}
+
+// ============================================================================
+// PlatformProxy
+// ============================================================================
+
+/// Cross-thread request capability. `Clone + Send + Sync`. Enqueue-and-wake
+/// with bounded backpressure; never blocks the sender; never carries
+/// closures (ADR-0037 §3 closed vocabulary).
+#[derive(Clone)]
+pub struct PlatformProxy {
+    transport: Arc<dyn ProxyTransport>,
+}
+
+impl fmt::Debug for PlatformProxy {
+    // Manual impl: `transport` carries wake/send plumbing with no blanket
+    // `Debug` (api-lead #9).
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PlatformProxy")
+            .field("is_owner_thread", &self.is_owner_thread())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PlatformProxy {
+    pub(crate) fn new(transport: Arc<dyn ProxyTransport>) -> Self {
+        Self { transport }
+    }
+
+    /// Enqueues a window-open request. Never blocks — on any thread,
+    /// including the owner (deferral replaces the old owner-side refusal;
+    /// the blocking hazard lives in [`PendingWindow::wait`], which is where
+    /// it is refused). Fails fast with the rejected options returned so the
+    /// producer can retry without rebuilding them.
+    ///
+    /// # Errors
+    /// See [`ProxySendError`].
+    pub fn open_window(
+        &self,
+        options: WindowOptions,
+    ) -> Result<PendingWindow, ProxySendError<WindowOptions>> {
+        self.transport.open_window(options)
+    }
+
+    /// Coalesced, non-starvable quit flag — bypasses queue capacity.
+    pub fn request_quit(&self) {
+        self.transport.request_quit();
+    }
+
+    /// True iff the calling thread is the event-loop owner. Diagnostic
+    /// only — correctness never depends on it (the types carry the
+    /// guarantee).
+    #[must_use]
+    pub fn is_owner_thread(&self) -> bool {
+        self.transport.owner_thread() == std::thread::current().id()
+    }
+}
+
+assert_impl_all!(PlatformProxy: Clone, Send, Sync);
+
+/// Failure to enqueue a cross-thread request through [`PlatformProxy`].
+///
+/// Exhaustive: a deliberately closed cross-thread vocabulary (ADR-0027 §4,
+/// ADR-0037 §3).
+#[derive(Debug, thiserror::Error)]
+pub enum ProxySendError<T: fmt::Debug> {
+    /// The owner lane is at capacity.
+    #[error("platform owner lane is full (capacity {capacity})")]
+    Full {
+        /// The lane's fixed capacity.
+        capacity: usize,
+        /// The value that could not be enqueued.
+        rejected: T,
+    },
+    /// The event-loop owner is gone.
+    ///
+    /// On backends without an owner lane (macOS/Win32 until slice 3 lane
+    /// adoption; any single-threaded backend), this variant is returned on
+    /// a *live* loop and is **permanent** there — not a transient condition
+    /// to retry. Do not retry; this is not a transient condition. Treat it
+    /// as a standing "cross-thread platform requests are unsupported on
+    /// this backend today" signal (ADR-0039 slice-2 amendment b); slice 3's
+    /// lane adoption is what makes it literally true everywhere.
+    #[error("event-loop owner is gone")]
+    OwnerGone {
+        /// The value that could not be delivered.
+        rejected: T,
+    },
+}
+
+// ============================================================================
+// PendingWindow
+// ============================================================================
+
+/// A deferred window-open request in flight on the owner lane.
+///
+/// Dropping a `PendingWindow` disclaims the request: the owner skips
+/// creation (if it has not started) or unwinds the created window (if
+/// delivery already landed) — see `flui-foundation`'s `ClaimSlot` module
+/// docs for the full state machine this wraps.
+#[must_use = "dropping a PendingWindow disclaims the request; the owner \
+              skips or unwinds the window"]
+pub struct PendingWindow {
+    handle: ClaimHandle<Result<Arc<dyn PlatformWindow>, OpenWindowError>>,
+    owner_thread: ThreadId,
+}
+
+impl fmt::Debug for PendingWindow {
+    // Manual impl: the wrapped `ClaimHandle` carries a wake callback with
+    // no blanket `Debug` (api-lead #9).
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PendingWindow").finish_non_exhaustive()
+    }
+}
+
+impl PendingWindow {
+    // Only the winit backend's deferred owner-lane path ever constructs a
+    // `PendingWindow` (`WinitOwnerHooks::open_owner_window` and
+    // `WinitProxyTransport::open_window`, `platforms/winit/platform.rs`) —
+    // every lane-less backend (`DirectOwnerHooks`) always resolves `Ready`.
+    // Building this crate without the `winit-backend` feature (e.g. the
+    // headless-only default) makes this constructor genuinely unused.
+    #[cfg_attr(not(feature = "winit-backend"), allow(dead_code))]
+    pub(crate) fn new(
+        handle: ClaimHandle<Result<Arc<dyn PlatformWindow>, OpenWindowError>>,
+        owner_thread: ThreadId,
+    ) -> Self {
+        Self {
+            handle,
+            owner_thread,
+        }
+    }
+
+    /// Blocking wait — worker threads only. On the owner thread this
+    /// returns [`WaitError::WouldBlockOwner`] instead of deadlocking on the
+    /// lane the caller itself drains.
+    ///
+    /// # Errors
+    /// See [`WaitError`].
+    pub fn wait(self) -> Result<Arc<dyn PlatformWindow>, WaitError> {
+        if self.owner_thread == std::thread::current().id() {
+            return Err(WaitError::WouldBlockOwner(self));
+        }
+        self.handle.wait().map_err(WaitError::Open)
+    }
+
+    /// Non-blocking poll; safe on any thread.
+    pub fn try_take(&mut self) -> Option<Result<Arc<dyn PlatformWindow>, OpenWindowError>> {
+        self.handle.try_take()
+    }
+}
+
+assert_impl_all!(PendingWindow: Send);
+
+/// Failure to wait on a [`PendingWindow`].
+///
+/// `#[non_exhaustive]`: growth pressure via the `#[from] OpenWindowError`
+/// arm and possible future wait modes.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum WaitError {
+    /// Waiting on the owner thread would deadlock the lane it drains. The
+    /// handle is returned so the caller can still poll with `try_take`.
+    #[error(
+        "waiting on the owner thread would deadlock the lane it drains; poll with try_take instead"
+    )]
+    WouldBlockOwner(PendingWindow),
+    /// The request itself failed.
+    #[error(transparent)]
+    Open(#[from] OpenWindowError),
+}
+
+// ============================================================================
+// pub(crate) seams: the slice-3 `OwnerOps` seed
+// ============================================================================
+
+/// Backend-specific window-open dispatch behind [`OwnerPlatform`]. The
+/// slice-3 `OwnerOps` seed (ADR-0039 §2/§8) — stays `pub(crate)` until then,
+/// alongside [`OwnerPlatform`]'s own third private field.
+pub(crate) trait OwnerHooks: Send + Sync {
+    /// Creates or enqueues a window from the owner thread. Backends with an
+    /// owner lane (winit) enqueue when called outside `on_ready`; every
+    /// other backend creates directly and always returns `Ready`.
+    fn open_owner_window(&self, options: WindowOptions) -> Result<WindowOpen, OpenWindowError>;
+
+    /// The cross-thread transport backing [`PlatformProxy`]. Backends
+    /// without an owner lane return [`ClosedTransport`] — permanently,
+    /// until slice 3 gives them one (ADR amendment b).
+    fn transport(&self) -> Arc<dyn ProxyTransport>;
+}
+
+/// Direct-creation [`OwnerHooks`] for backends without an owner lane
+/// (windows/macos/headless/web/android): every `open_owner_window` call
+/// creates synchronously via the wrapped [`Platform`] and is always
+/// `Ready` — there is no deferral without a lane to defer onto. The
+/// backend's own `anyhow` error maps onto the typed
+/// [`OpenWindowError::Backend`] arm; the trait method itself keeps its
+/// untyped `anyhow` signature until slice 3.
+pub(crate) struct DirectOwnerHooks {
+    platform: Arc<dyn Platform>,
+    owner_thread: ThreadId,
+}
+
+impl DirectOwnerHooks {
+    /// Captures the calling thread as the permanent owner — call this from
+    /// the backend's `on_ready` (or wherever it mints its `OwnerPlatform`).
+    pub(crate) fn new(platform: Arc<dyn Platform>) -> Self {
+        Self {
+            platform,
+            owner_thread: std::thread::current().id(),
+        }
+    }
+}
+
+impl OwnerHooks for DirectOwnerHooks {
+    fn open_owner_window(&self, options: WindowOptions) -> Result<WindowOpen, OpenWindowError> {
+        self.platform
+            .open_window(options)
+            .map(WindowOpen::Ready)
+            .map_err(|error| OpenWindowError::Backend {
+                message: error.to_string(),
+            })
+    }
+
+    fn transport(&self) -> Arc<dyn ProxyTransport> {
+        Arc::new(ClosedTransport::new(self.owner_thread))
+    }
+}
+
+/// Cross-thread transport behind [`PlatformProxy`]. Backends with an owner
+/// lane (winit) implement this over their lane; lane-less backends use
+/// [`ClosedTransport`].
+pub(crate) trait ProxyTransport: Send + Sync {
+    /// Enqueues a window-open request from a worker thread.
+    fn open_window(
+        &self,
+        options: WindowOptions,
+    ) -> Result<PendingWindow, ProxySendError<WindowOptions>>;
+
+    /// Requests application quit — coalesced, non-starvable.
+    fn request_quit(&self);
+
+    /// The thread identity of the event-loop owner (diagnostic only).
+    fn owner_thread(&self) -> ThreadId;
+}
+
+/// A transport with no lane behind it: every request is refused with the
+/// permanent `OwnerGone` posture (ADR-0039 slice-2 amendment b) until
+/// slice 3 gives the backend a real lane.
+pub(crate) struct ClosedTransport {
+    owner_thread: ThreadId,
+}
+
+impl ClosedTransport {
+    pub(crate) fn new(owner_thread: ThreadId) -> Self {
+        Self { owner_thread }
+    }
+}
+
+impl ProxyTransport for ClosedTransport {
+    fn open_window(
+        &self,
+        options: WindowOptions,
+    ) -> Result<PendingWindow, ProxySendError<WindowOptions>> {
+        tracing::warn!(
+            "PlatformProxy::open_window on a lane-less backend: permanently \
+             OwnerGone until slice 3 (ADR-0039 amendment b) — do not retry"
+        );
+        Err(ProxySendError::OwnerGone { rejected: options })
+    }
+
+    fn request_quit(&self) {
+        tracing::warn!(
+            "PlatformProxy::request_quit on a lane-less backend is a no-op \
+             until slice 3 (ADR-0039 amendment b)"
+        );
+    }
+
+    fn owner_thread(&self) -> ThreadId {
+        self.owner_thread
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::thread;
+
+    use flui_foundation::claim_slot;
+
+    use super::*;
+
+    #[test]
+    fn try_ready_on_pending_yields_not_ready() {
+        let (_slot, handle) =
+            claim_slot::<Result<Arc<dyn PlatformWindow>, OpenWindowError>>(Arc::new(|| {}));
+        let pending = PendingWindow::new(handle, thread::current().id());
+        let open = WindowOpen::Pending(pending);
+
+        match open.try_ready() {
+            Err(OpenWindowError::NotReady(_)) => {}
+            Err(other) => panic!("wrong error variant: {other:?}"),
+            Ok(_) => panic!("Pending must not resolve to Ready"),
+        }
+    }
+
+    #[test]
+    fn wait_on_owner_thread_refuses_with_the_handle_back() {
+        let (_slot, handle) =
+            claim_slot::<Result<Arc<dyn PlatformWindow>, OpenWindowError>>(Arc::new(|| {}));
+        let pending = PendingWindow::new(handle, thread::current().id());
+
+        match pending.wait() {
+            Err(WaitError::WouldBlockOwner(_returned)) => {}
+            Err(other) => panic!("wrong error variant: {other:?}"),
+            Ok(_) => panic!("owner-thread wait must not succeed"),
+        }
+    }
+
+    #[test]
+    fn closed_transport_open_window_is_permanently_owner_gone() {
+        let transport = ClosedTransport::new(thread::current().id());
+        let error = transport
+            .open_window(WindowOptions::default())
+            .expect_err("no lane behind a ClosedTransport");
+        assert!(matches!(error, ProxySendError::OwnerGone { .. }));
+    }
+
+    #[test]
+    fn proxy_is_owner_thread_reflects_the_calling_thread() {
+        let transport: Arc<dyn ProxyTransport> =
+            Arc::new(ClosedTransport::new(thread::current().id()));
+        let proxy = PlatformProxy::new(transport);
+        assert!(proxy.is_owner_thread());
+
+        let moved = proxy.clone();
+        let on_worker = thread::spawn(move || moved.is_owner_thread())
+            .join()
+            .expect("worker does not panic");
+        assert!(!on_worker, "a worker thread is never the owner");
+    }
+}

--- a/crates/flui-platform/src/traits/owner.rs
+++ b/crates/flui-platform/src/traits/owner.rs
@@ -399,6 +399,15 @@ pub enum OpenWindowError {
     /// Window creation was deferred; this call site requires `Ready`.
     #[error("window creation was deferred; this call site requires Ready")]
     NotReady(PendingWindow),
+    /// An earlier [`try_take`](PendingWindow::try_take) on this same
+    /// `PendingWindow` already claimed the result — there is nothing left
+    /// to hand back. Not a slot-invariant violation, just a
+    /// caller-sequencing fact (mirrors [`WaitError::AlreadyClaimed`]):
+    /// `try_take` takes `&mut self`, so nothing stops a caller from
+    /// following a successful `try_take` with a poll of the `Future` impl
+    /// on the same handle.
+    #[error("the pending window was already claimed by an earlier try_take call")]
+    AlreadyClaimed,
 }
 
 // ============================================================================
@@ -598,8 +607,10 @@ impl std::future::Future for PendingWindow {
     /// ([`OpenWindowError::OwnerGone`], woken by the underlying
     /// `flui-foundation` `ClaimSlot`'s `Drop`), or immediately if this
     /// `PendingWindow` was already resolved by an earlier
-    /// [`try_take`](Self::try_take) call (mapped onto
-    /// [`OpenWindowError::Backend`] — there is nothing left to hand back).
+    /// [`try_take`](Self::try_take) call
+    /// ([`OpenWindowError::AlreadyClaimed`] — a typed caller-sequencing
+    /// fact, not a fabricated backend failure: there is nothing left to
+    /// hand back, and this is not the backend's fault).
     fn poll(
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
@@ -612,11 +623,7 @@ impl std::future::Future for PendingWindow {
                 std::task::Poll::Ready(Err(OpenWindowError::OwnerGone { rejected: None }))
             }
             std::task::Poll::Ready(ClaimOutcome::AlreadyClaimed) => {
-                std::task::Poll::Ready(Err(OpenWindowError::Backend {
-                    message: "PendingWindow polled after an earlier try_take call already \
-                              claimed its result"
-                        .to_string(),
-                }))
+                std::task::Poll::Ready(Err(OpenWindowError::AlreadyClaimed))
             }
             std::task::Poll::Pending => std::task::Poll::Pending,
         }

--- a/crates/flui-platform/src/traits/owner.rs
+++ b/crates/flui-platform/src/traits/owner.rs
@@ -29,15 +29,20 @@
 
 use std::fmt;
 use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::thread::ThreadId;
 
-use flui_foundation::ClaimHandle;
+use flui_foundation::{ClaimHandle, ClaimOutcome};
 use static_assertions::{assert_impl_all, assert_not_impl_any};
 
 use super::{
-    Platform, PlatformDisplay, PlatformWindow, WindowId, WindowOptions, window::WindowAppearance,
+    Clipboard, ClipboardItem, PathPromptOptions, Platform, PlatformCapabilities, PlatformDisplay,
+    PlatformExecutor, PlatformWindow, WindowEvent, WindowId, WindowOptions,
+    window::WindowAppearance,
 };
+use crate::data_transfer::DataTransferSource;
+use crate::task::Task;
 
 // ============================================================================
 // OwnerPlatform
@@ -133,13 +138,16 @@ impl OwnerPlatform {
         self.platform.quit();
     }
 
-    /// Escapes to the residual thread-safe surface (`Send + Sync` methods
-    /// that need no owner-thread proof: `background_executor`, `clipboard`,
-    /// callback registration, and the rest of §2's "stays on `Platform`"
-    /// list).
+    /// Escapes to the residual thread-safe surface: `background_executor`,
+    /// `clipboard`, callback registration, and the rest of §2's "stays on
+    /// `Platform`" list, wrapped in a `Clone + Send + Sync` handle a
+    /// `std::thread::scope` worker can freely hold — see
+    /// [`SharedPlatform`]'s own doc for why this can no longer be
+    /// `&dyn Platform` (that type is still `Send + Sync` in full,
+    /// owner-affine methods included, until slice 3's trait split).
     #[must_use]
-    pub fn shared(&self) -> &dyn Platform {
-        &*self.platform
+    pub fn shared(&self) -> SharedPlatform {
+        SharedPlatform::new(Arc::clone(&self.platform))
     }
 
     /// Mints a cross-thread capability, handed to workers, realms, or
@@ -155,6 +163,166 @@ impl OwnerPlatform {
 // including cross-typecheck on win/mac, because `static_assertions` is a
 // real (non-dev) dependency (see Cargo.toml).
 assert_not_impl_any!(OwnerPlatform: Send, Sync);
+
+// ============================================================================
+// SharedPlatform
+// ============================================================================
+
+/// The thread-safe residual of [`Platform`] — every operation NOT gated on
+/// owner-thread affinity, per ADR-0039 §2's "what stays" table.
+///
+/// `Clone + Send + Sync`: unlike `&dyn Platform` (which is `Platform: Send +
+/// Sync` in full, `open_window`/`quit`/`activate`/`displays`/
+/// `primary_display`/`window_appearance`/`keyboard_layout`/`active_window`
+/// included), a `SharedPlatform` genuinely can cross a `std::thread::scope`
+/// boundary into safe code without smuggling an owner-affine call along
+/// with it — **the method list below IS the fence**: every method on this
+/// type is safe to call from any thread, and no owner-affine method is
+/// ever added to it. Minted only by [`OwnerPlatform::shared`].
+///
+/// The registry (`docs/runtime-contract.toml`) tracks this as the
+/// compile-time-checked half of the owner-platform-capability contract;
+/// `Platform` itself (the trait `dyn` object underneath) remains
+/// runtime-checked (`OwnerAffinity` debug-asserts) until slice 3 splits its
+/// owner-affine methods off entirely.
+#[derive(Clone)]
+pub struct SharedPlatform {
+    platform: Arc<dyn Platform>,
+}
+
+impl fmt::Debug for SharedPlatform {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SharedPlatform")
+            .field("platform", &self.platform.name())
+            .finish_non_exhaustive()
+    }
+}
+
+impl SharedPlatform {
+    pub(crate) fn new(platform: Arc<dyn Platform>) -> Self {
+        Self { platform }
+    }
+
+    /// The platform's background executor for async tasks.
+    #[must_use]
+    pub fn background_executor(&self) -> Arc<dyn PlatformExecutor> {
+        self.platform.background_executor()
+    }
+
+    /// The platform's capabilities descriptor.
+    #[must_use]
+    pub fn capabilities(&self) -> &dyn PlatformCapabilities {
+        self.platform.capabilities()
+    }
+
+    /// The platform's name for debugging/logging.
+    #[must_use]
+    pub fn name(&self) -> &'static str {
+        self.platform.name()
+    }
+
+    /// The compositor name (e.g., "DWM" on Windows).
+    #[must_use]
+    pub fn compositor_name(&self) -> &'static str {
+        self.platform.compositor_name()
+    }
+
+    /// The application's executable path.
+    ///
+    /// # Errors
+    /// Propagates the backend's own lookup failure.
+    pub fn app_path(&self) -> anyhow::Result<PathBuf> {
+        self.platform.app_path()
+    }
+
+    /// The platform's clipboard interface.
+    #[must_use]
+    pub fn clipboard(&self) -> Arc<dyn Clipboard> {
+        self.platform.clipboard()
+    }
+
+    /// The data-transfer transport (ADR-0038).
+    #[must_use]
+    pub fn data_transfer(&self) -> Arc<dyn DataTransferSource> {
+        self.platform.data_transfer()
+    }
+
+    /// Registers a callback for when the application should quit.
+    pub fn on_quit(&self, callback: Box<dyn FnMut() + Send>) {
+        self.platform.on_quit(callback);
+    }
+
+    /// Registers a callback for when the application is reopened (macOS).
+    pub fn on_reopen(&self, callback: Box<dyn FnMut() + Send>) {
+        self.platform.on_reopen(callback);
+    }
+
+    /// Registers a callback for window events.
+    pub fn on_window_event(&self, callback: Box<dyn FnMut(WindowEvent) + Send>) {
+        self.platform.on_window_event(callback);
+    }
+
+    /// Registers a callback for URLs opened by the system.
+    pub fn on_open_urls(&self, callback: Box<dyn FnMut(Vec<String>) + Send>) {
+        self.platform.on_open_urls(callback);
+    }
+
+    /// Registers a callback for keyboard layout changes.
+    pub fn on_keyboard_layout_change(&self, callback: Box<dyn FnMut() + Send>) {
+        self.platform.on_keyboard_layout_change(callback);
+    }
+
+    /// Opens a URL with the system's default handler.
+    pub fn open_url(&self, url: &str) {
+        self.platform.open_url(url);
+    }
+
+    /// Reveals a path in the platform's file manager.
+    pub fn reveal_path(&self, path: &Path) {
+        self.platform.reveal_path(path);
+    }
+
+    /// Opens a path with the system's default application.
+    pub fn open_path(&self, path: &Path) {
+        self.platform.open_path(path);
+    }
+
+    /// Shows a file/directory picker dialog. Returns selected paths, or
+    /// `None` if the user cancelled. Runs asynchronously on a background
+    /// thread.
+    pub fn prompt_for_paths(
+        &self,
+        options: PathPromptOptions,
+    ) -> Task<anyhow::Result<Option<Vec<PathBuf>>>> {
+        self.platform.prompt_for_paths(options)
+    }
+
+    /// Shows a "Save As" dialog for selecting a new file path. Returns the
+    /// selected path, or `None` if the user cancelled.
+    pub fn prompt_for_new_path(
+        &self,
+        directory: &Path,
+        suggested_name: Option<&str>,
+    ) -> Task<anyhow::Result<Option<PathBuf>>> {
+        self.platform.prompt_for_new_path(directory, suggested_name)
+    }
+
+    /// Writes a rich clipboard item (text + metadata).
+    pub fn write_to_clipboard(&self, item: ClipboardItem) {
+        self.platform.write_to_clipboard(item);
+    }
+
+    /// Reads a rich clipboard item.
+    #[must_use]
+    pub fn read_from_clipboard(&self) -> Option<ClipboardItem> {
+        self.platform.read_from_clipboard()
+    }
+}
+
+// Sole registry evidence that `SharedPlatform` genuinely is the thread-safe
+// escape hatch its doc promises — expanded by every `cargo check`, same
+// discipline as `OwnerPlatform`'s `assert_not_impl_any!` above.
+assert_impl_all!(SharedPlatform: Send, Sync, Clone);
 
 /// Result of an owner-thread window-open request.
 #[must_use = "a Pending window creation must be waited on or polled; \
@@ -246,8 +414,8 @@ pub struct PlatformProxy {
 }
 
 impl fmt::Debug for PlatformProxy {
-    // Manual impl: `transport` carries wake/send plumbing with no blanket
-    // `Debug` (api-lead #9).
+    // Manual impl: `transport` is `Arc<dyn ProxyTransport>`, and trait
+    // objects carry no blanket `Debug` impl.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PlatformProxy")
             .field("is_owner_thread", &self.is_owner_thread())
@@ -276,8 +444,19 @@ impl PlatformProxy {
     }
 
     /// Coalesced, non-starvable quit flag — bypasses queue capacity.
-    pub fn request_quit(&self) {
-        self.transport.request_quit();
+    ///
+    /// The `Result` return is already `#[must_use]` (clippy's
+    /// `double_must_use` rejects a redundant fn-level attribute on top of
+    /// it) — discarding it silently swallows exactly the
+    /// permanent-`Unsupported` signal below.
+    ///
+    /// # Errors
+    /// See [`ProxySendError`]. [`ProxySendError::Unsupported`] is
+    /// **permanent** on lane-less backends (windows/macos/web/android/
+    /// headless) until slice 3 lane adoption — not a transient condition;
+    /// do not retry.
+    pub fn request_quit(&self) -> Result<(), ProxySendError<()>> {
+        self.transport.request_quit()
     }
 
     /// True iff the calling thread is the event-loop owner. Diagnostic
@@ -294,7 +473,9 @@ assert_impl_all!(PlatformProxy: Clone, Send, Sync);
 /// Failure to enqueue a cross-thread request through [`PlatformProxy`].
 ///
 /// Exhaustive: a deliberately closed cross-thread vocabulary (ADR-0027 §4,
-/// ADR-0037 §3).
+/// ADR-0037 §3) — `Unsupported` completes it (ADR-0039 slice-2 amendment b
+/// revision) rather than reopening it; every lane-less backend today maps
+/// onto this one variant instead of overloading `OwnerGone`.
 #[derive(Debug, thiserror::Error)]
 pub enum ProxySendError<T: fmt::Debug> {
     /// The owner lane is at capacity.
@@ -305,18 +486,25 @@ pub enum ProxySendError<T: fmt::Debug> {
         /// The value that could not be enqueued.
         rejected: T,
     },
-    /// The event-loop owner is gone.
-    ///
-    /// On backends without an owner lane (macOS/Win32 until slice 3 lane
-    /// adoption; any single-threaded backend), this variant is returned on
-    /// a *live* loop and is **permanent** there — not a transient condition
-    /// to retry. Do not retry; this is not a transient condition. Treat it
-    /// as a standing "cross-thread platform requests are unsupported on
-    /// this backend today" signal (ADR-0039 slice-2 amendment b); slice 3's
-    /// lane adoption is what makes it literally true everywhere.
+    /// The event-loop owner is gone: a lane existed and its loop has since
+    /// died. Strictly transient-loop-death, never "no lane at all" — see
+    /// [`Unsupported`](Self::Unsupported) for that case.
     #[error("event-loop owner is gone")]
     OwnerGone {
         /// The value that could not be delivered.
+        rejected: T,
+    },
+    /// This backend has no owner lane behind [`PlatformProxy`] at all —
+    /// not "the queue is full", not "the loop died", but "cross-thread
+    /// platform requests are not implemented here". **Permanent** on
+    /// windows/macos/web/android/headless until slice 3 lane adoption (ADR-
+    /// 0039 slice-2 amendment b) — do not retry; this is not a transient
+    /// condition. Treat it as a standing capability signal, the same way a
+    /// missing OS feature would be reported, not a request to back off and
+    /// try again.
+    #[error("cross-thread platform requests are unsupported on this backend")]
+    Unsupported {
+        /// The value that could not be enqueued or delivered.
         rejected: T,
     },
 }
@@ -340,7 +528,7 @@ pub struct PendingWindow {
 
 impl fmt::Debug for PendingWindow {
     // Manual impl: the wrapped `ClaimHandle` carries a wake callback with
-    // no blanket `Debug` (api-lead #9).
+    // no blanket `Debug` impl.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PendingWindow").finish_non_exhaustive()
     }
@@ -379,8 +567,11 @@ impl PendingWindow {
             return Err(WaitError::WouldBlockOwner(self));
         }
         match self.handle.wait() {
-            Some(result) => result.map_err(WaitError::Open),
-            None => Err(WaitError::AlreadyClaimed),
+            ClaimOutcome::Delivered(result) => result.map_err(WaitError::Open),
+            ClaimOutcome::AlreadyClaimed => Err(WaitError::AlreadyClaimed),
+            ClaimOutcome::OwnerGone => Err(WaitError::Open(OpenWindowError::OwnerGone {
+                rejected: None,
+            })),
         }
     }
 
@@ -389,6 +580,46 @@ impl PendingWindow {
                   (a live window, or the typed error explaining why not)"]
     pub fn try_take(&mut self) -> Option<Result<Arc<dyn PlatformWindow>, OpenWindowError>> {
         self.handle.try_take()
+    }
+}
+
+impl std::future::Future for PendingWindow {
+    type Output = Result<Arc<dyn PlatformWindow>, OpenWindowError>;
+
+    /// Non-blocking poll — safe on any thread, including the owner (unlike
+    /// [`wait`](Self::wait), which refuses there because it would block on
+    /// the very lane the owner itself drains). Intended usage: poll from
+    /// `Idle` (or drive this future via the framework's async driver);
+    /// never from inside a pipeline hot path (build/layout/paint/
+    /// composite) — the same fence every other owner-thread capability in
+    /// this crate observes.
+    ///
+    /// Resolves on delivery, on owner disconnection
+    /// ([`OpenWindowError::OwnerGone`], woken by the underlying
+    /// `flui-foundation` `ClaimSlot`'s `Drop`), or immediately if this
+    /// `PendingWindow` was already resolved by an earlier
+    /// [`try_take`](Self::try_take) call (mapped onto
+    /// [`OpenWindowError::Backend`] — there is nothing left to hand back).
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        match std::future::Future::poll(std::pin::Pin::new(&mut self.handle), cx) {
+            std::task::Poll::Ready(ClaimOutcome::Delivered(result)) => {
+                std::task::Poll::Ready(result)
+            }
+            std::task::Poll::Ready(ClaimOutcome::OwnerGone) => {
+                std::task::Poll::Ready(Err(OpenWindowError::OwnerGone { rejected: None }))
+            }
+            std::task::Poll::Ready(ClaimOutcome::AlreadyClaimed) => {
+                std::task::Poll::Ready(Err(OpenWindowError::Backend {
+                    message: "PendingWindow polled after an earlier try_take call already \
+                              claimed its result"
+                        .to_string(),
+                }))
+            }
+            std::task::Poll::Pending => std::task::Poll::Pending,
+        }
     }
 }
 
@@ -487,15 +718,20 @@ pub(crate) trait ProxyTransport: Send + Sync {
     ) -> Result<PendingWindow, ProxySendError<WindowOptions>>;
 
     /// Requests application quit — coalesced, non-starvable.
-    fn request_quit(&self);
+    ///
+    /// # Errors
+    /// See [`ProxySendError`]. [`ProxySendError::Unsupported`] on a
+    /// lane-less backend is **permanent** — not a transient condition.
+    fn request_quit(&self) -> Result<(), ProxySendError<()>>;
 
     /// The thread identity of the event-loop owner (diagnostic only).
     fn owner_thread(&self) -> ThreadId;
 }
 
-/// A transport with no lane behind it: every request is refused with the
-/// permanent `OwnerGone` posture (ADR-0039 slice-2 amendment b) until
-/// slice 3 gives the backend a real lane.
+/// A transport with no lane behind it: every request is refused with
+/// [`ProxySendError::Unsupported`] (ADR-0039 slice-2 amendment b) until
+/// slice 3 gives the backend a real lane — permanently, not
+/// `OwnerGone`: no lane ever existed here to die.
 pub(crate) struct ClosedTransport {
     owner_thread: ThreadId,
 }
@@ -511,18 +747,25 @@ impl ProxyTransport for ClosedTransport {
         &self,
         options: WindowOptions,
     ) -> Result<PendingWindow, ProxySendError<WindowOptions>> {
-        tracing::warn!(
+        // `debug!`, not `warn!` (this backend's posture is permanent and
+        // known at compile time, not an anomaly worth surfacing by
+        // default) — a caller probing/retrying `PlatformProxy::open_window`
+        // on a lane-less backend would otherwise flood a `warn!` per
+        // attempt.
+        tracing::debug!(
             "PlatformProxy::open_window on a lane-less backend: permanently \
-             OwnerGone until slice 3 (ADR-0039 amendment b) — do not retry"
+             unsupported until slice 3 (ADR-0039 amendment b) — do not retry"
         );
-        Err(ProxySendError::OwnerGone { rejected: options })
+        Err(ProxySendError::Unsupported { rejected: options })
     }
 
-    fn request_quit(&self) {
-        tracing::warn!(
-            "PlatformProxy::request_quit on a lane-less backend is a no-op \
-             until slice 3 (ADR-0039 amendment b)"
+    fn request_quit(&self) -> Result<(), ProxySendError<()>> {
+        // See `open_window`'s identical `debug!`-not-`warn!` rationale.
+        tracing::debug!(
+            "PlatformProxy::request_quit on a lane-less backend: permanently \
+             unsupported until slice 3 (ADR-0039 amendment b)"
         );
+        Err(ProxySendError::Unsupported { rejected: () })
     }
 
     fn owner_thread(&self) -> ThreadId {
@@ -567,12 +810,35 @@ mod tests {
     }
 
     #[test]
-    fn closed_transport_open_window_is_permanently_owner_gone() {
+    fn closed_transport_open_window_is_permanently_unsupported() {
         let transport = ClosedTransport::new(thread::current().id());
         let error = transport
             .open_window(WindowOptions::default())
             .expect_err("no lane behind a ClosedTransport");
-        assert!(matches!(error, ProxySendError::OwnerGone { .. }));
+        assert!(matches!(error, ProxySendError::Unsupported { .. }));
+    }
+
+    #[test]
+    fn closed_transport_request_quit_is_permanently_unsupported() {
+        let transport = ClosedTransport::new(thread::current().id());
+        let error = transport
+            .request_quit()
+            .expect_err("no lane behind a ClosedTransport");
+        assert!(matches!(
+            error,
+            ProxySendError::Unsupported { rejected: () }
+        ));
+    }
+
+    #[test]
+    fn proxy_request_quit_surfaces_unsupported_on_a_lane_less_backend() {
+        let transport: Arc<dyn ProxyTransport> =
+            Arc::new(ClosedTransport::new(thread::current().id()));
+        let proxy = PlatformProxy::new(transport);
+        assert!(matches!(
+            proxy.request_quit(),
+            Err(ProxySendError::Unsupported { rejected: () })
+        ));
     }
 
     #[test]

--- a/crates/flui-platform/src/traits/owner.rs
+++ b/crates/flui-platform/src/traits/owner.rs
@@ -369,15 +369,24 @@ impl PendingWindow {
     /// lane the caller itself drains.
     ///
     /// # Errors
-    /// See [`WaitError`].
+    /// See [`WaitError`]. Notably [`WaitError::AlreadyClaimed`] if an
+    /// earlier [`try_take`](Self::try_take) on this same `PendingWindow`
+    /// already claimed the result — `try_take` takes `&mut self`, so
+    /// nothing stops a caller from following a successful `try_take` with a
+    /// `wait` on the same handle; there is nothing left to wait for.
     pub fn wait(self) -> Result<Arc<dyn PlatformWindow>, WaitError> {
         if self.owner_thread == std::thread::current().id() {
             return Err(WaitError::WouldBlockOwner(self));
         }
-        self.handle.wait().map_err(WaitError::Open)
+        match self.handle.wait() {
+            Some(result) => result.map_err(WaitError::Open),
+            None => Err(WaitError::AlreadyClaimed),
+        }
     }
 
     /// Non-blocking poll; safe on any thread.
+    #[must_use = "discarding Some(_) strands whatever the owner delivered \
+                  (a live window, or the typed error explaining why not)"]
     pub fn try_take(&mut self) -> Option<Result<Arc<dyn PlatformWindow>, OpenWindowError>> {
         self.handle.try_take()
     }
@@ -401,6 +410,13 @@ pub enum WaitError {
     /// The request itself failed.
     #[error(transparent)]
     Open(#[from] OpenWindowError),
+    /// An earlier `try_take` on this same `PendingWindow` already claimed
+    /// the result — there is nothing left for `wait` to return. Not a
+    /// slot-invariant violation, just a caller-sequencing fact: `try_take`
+    /// takes `&mut self`, so nothing stops a caller from following a
+    /// successful poll with a `wait` call on the same handle.
+    #[error("the pending window was already claimed by an earlier try_take call")]
+    AlreadyClaimed,
 }
 
 // ============================================================================

--- a/crates/flui-platform/src/traits/platform.rs
+++ b/crates/flui-platform/src/traits/platform.rs
@@ -140,14 +140,24 @@ pub struct WindowId(pub u64); // PORT-CHECK-OK-SP3: pre-existing parallel defini
 
 /// [`Platform::run`]'s ready callback: invoked once, synchronously, with the
 /// owner-thread capability (ADR-0039). Named to keep
-/// `Box<dyn FnOnce(OwnerPlatform)>` out of every call site's signature.
+/// `Box<dyn FnOnce(OwnerPlatform) -> anyhow::Result<()>>` out of every call
+/// site's signature.
 ///
 /// Replaces the pre-ADR-0039 `Box<dyn FnOnce(&dyn Platform)>` shape: the
 /// callback now receives [`OwnerPlatform`] by value instead of a borrowed
 /// `&dyn Platform`, so it may stash the capability in owner-thread state for
 /// the rest of the loop's life (e.g. `flui-app`'s `OWNER_PLATFORM_HOST` TLS
 /// slot) rather than being limited to the callback's own stack frame.
-pub type PlatformReadyCallback = Box<dyn FnOnce(OwnerPlatform)>;
+///
+/// Fallible (slice-2 maintainer fix): bootstrap run from inside `on_ready`
+/// (window creation, GPU init, root-widget attach) can fail, and a callback
+/// that swallowed that failure would leave the loop running with a broken
+/// app — Android would keep pumping with no UI, web would install its RAF
+/// loop over a half-built page. Returning `Err` here propagates out of
+/// [`Platform::run`] itself instead: every backend stops entering (or
+/// promptly exits) its loop on `Err` and hands the error back to `run`'s own
+/// caller.
+pub type PlatformReadyCallback = Box<dyn FnOnce(OwnerPlatform) -> anyhow::Result<()>>;
 
 /// Core platform abstraction trait
 ///
@@ -171,10 +181,14 @@ pub type PlatformReadyCallback = Box<dyn FnOnce(OwnerPlatform)>;
 /// ```rust,ignore
 /// use flui_platform::{Platform, current_platform};
 ///
-/// let platform = current_platform();
-/// platform.run(Box::new(|owner| {
-///     println!("Platform ready: {}", owner.shared().name());
-/// }));
+/// fn main() -> anyhow::Result<()> {
+///     let platform = current_platform()?;
+///     platform.run(Box::new(|owner| {
+///         println!("Platform ready: {}", owner.shared().name());
+///         Ok(())
+///     }))?;
+///     Ok(())
+/// }
 /// ```
 ///
 /// # De-facto crate seal (ADR-0039)
@@ -216,7 +230,16 @@ pub trait Platform: Send + Sync + 'static {
     /// This function only returns when the application quits (never, on
     /// backends whose native run loop does not return control — e.g. macOS,
     /// where `terminate:` exits the process).
-    fn run(self: Box<Self>, on_ready: PlatformReadyCallback);
+    ///
+    /// # Errors
+    /// Propagates `on_ready`'s own `Err` (a bootstrap failure — window
+    /// creation, GPU init, root-widget attach — has no other return path
+    /// back to `run`'s caller). Every backend stops entering, or promptly
+    /// exits, its loop on that `Err` rather than continuing with a broken
+    /// app: a returned error means the loop never ran a single iteration
+    /// with `on_ready`'s bootstrap incomplete. A backend may also return its
+    /// own `Err` for a platform-level failure unrelated to `on_ready`.
+    fn run(self: Box<Self>, on_ready: PlatformReadyCallback) -> anyhow::Result<()>;
 
     /// Request the application to quit
     ///

--- a/crates/flui-platform/src/traits/platform.rs
+++ b/crates/flui-platform/src/traits/platform.rs
@@ -12,7 +12,9 @@ use std::{
 use anyhow::Result;
 use flui_types::geometry::{Bounds, DevicePixels, Pixels, Point, Size};
 
-use super::{PlatformCapabilities, PlatformDisplay, PlatformWindow, window::WindowAppearance};
+use super::{
+    OwnerPlatform, PlatformCapabilities, PlatformDisplay, PlatformWindow, window::WindowAppearance,
+};
 use crate::{data_transfer::DataTransferSource, task::Task};
 
 /// Window creation options
@@ -136,10 +138,16 @@ impl WindowMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WindowId(pub u64); // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
 
-/// [`Platform::run`]'s ready callback: invoked once, synchronously, with a
-/// platform handle. Named to keep `Box<dyn FnOnce(&dyn Platform)>` out of
-/// every call site's signature.
-pub type PlatformReadyCallback = Box<dyn FnOnce(&dyn Platform)>;
+/// [`Platform::run`]'s ready callback: invoked once, synchronously, with the
+/// owner-thread capability (ADR-0039). Named to keep
+/// `Box<dyn FnOnce(OwnerPlatform)>` out of every call site's signature.
+///
+/// Replaces the pre-ADR-0039 `Box<dyn FnOnce(&dyn Platform)>` shape: the
+/// callback now receives [`OwnerPlatform`] by value instead of a borrowed
+/// `&dyn Platform`, so it may stash the capability in owner-thread state for
+/// the rest of the loop's life (e.g. `flui-app`'s `OWNER_PLATFORM_HOST` TLS
+/// slot) rather than being limited to the callback's own stack frame.
+pub type PlatformReadyCallback = Box<dyn FnOnce(OwnerPlatform)>;
 
 /// Core platform abstraction trait
 ///
@@ -164,10 +172,21 @@ pub type PlatformReadyCallback = Box<dyn FnOnce(&dyn Platform)>;
 /// use flui_platform::{Platform, current_platform};
 ///
 /// let platform = current_platform();
-/// platform.run(Box::new(|platform| {
-///     println!("Platform ready: {}", platform.name());
+/// platform.run(Box::new(|owner| {
+///     println!("Platform ready: {}", owner.shared().name());
 /// }));
 /// ```
+///
+/// # De-facto crate seal (ADR-0039)
+///
+/// `run`'s `on_ready` callback receives an [`OwnerPlatform`] — a capability
+/// minted only through a `pub(crate)` constructor in this crate. An
+/// out-of-crate `impl Platform` can implement `run` but cannot construct the
+/// `OwnerPlatform` it must hand to `on_ready`, so this trait is de-facto
+/// sealed to backends living inside `flui-platform` even though nothing
+/// marks it `sealed` in the type system. An external-embedder minting seam
+/// is design work tracked separately (#560, `flui-platform` issue tracker);
+/// until then, new backends land in this crate.
 pub trait Platform: Send + Sync + 'static {
     // ==================== Core System ====================
 
@@ -182,15 +201,21 @@ pub trait Platform: Send + Sync + 'static {
     ///
     /// This function takes ownership of the platform and the current thread,
     /// running the platform's event loop. The `on_ready` callback is invoked
-    /// once the platform is initialized and ready to create windows, and is
-    /// passed a platform handle so it can call `open_window`, `on_quit`, and
-    /// other `&self` methods — the outer `Box<dyn Platform>` binding is no
-    /// longer reachable once `run` has taken ownership of it.
+    /// once, synchronously, on the thread that owns (or will own) the event
+    /// loop, and is passed an [`OwnerPlatform`] — the owner-thread capability
+    /// (ADR-0039) — by value: it can call `open_window` and every other
+    /// owner-affine operation, and reach the residual `Send + Sync` surface
+    /// via [`OwnerPlatform::shared`]. `on_ready` may stash the capability in
+    /// owner-thread state for the rest of the loop's life; the outer
+    /// `Box<dyn Platform>` binding is no longer reachable once `run` has
+    /// taken ownership of it.
     ///
     /// Takes `self: Box<Self>` because some backends (e.g. winit) require
     /// ownership of the event loop to run it.
     ///
-    /// This function only returns when the application quits.
+    /// This function only returns when the application quits (never, on
+    /// backends whose native run loop does not return control — e.g. macOS,
+    /// where `terminate:` exits the process).
     fn run(self: Box<Self>, on_ready: PlatformReadyCallback);
 
     /// Request the application to quit

--- a/docs/adr/ADR-0039-event-loop-affinity-capability.md
+++ b/docs/adr/ADR-0039-event-loop-affinity-capability.md
@@ -4,12 +4,12 @@
 
 ---
 
-- **Status:** Proposed (2026-07-28)
+- **Status:** Accepted (2026-08-03)
 - **Date:** 2026-07-28
 - **Deciders:** @vanyastaff
-- **Scope:** `crates/flui-foundation/src` (new `OwnerAffinity` primitive — the slice-1 CI-tested deliverable), `crates/flui-platform/src/traits/platform.rs` (trait split), new `crates/flui-platform/src/traits/owner.rs` (`OwnerPlatform`, `PlatformProxy`, `PendingWindow`), `crates/flui-platform/src/platforms/winit/{platform,control}.rs` (lane generalization + handler-dispatch hoist), `crates/flui-platform/src/platforms/{macos,windows}/platform.rs` (slice-1 asserts), `crates/flui-app/src/app/{runner,direct}.rs` (bootstrap migrations + owner-TLS host), `examples/*` (on_ready migration)
+- **Scope:** `crates/flui-foundation/src` (new `OwnerAffinity` primitive — the slice-1 CI-tested deliverable — and, in slice 2, the `ClaimSlot`/`ClaimHandle` request/reply primitive), `crates/flui-platform/src/traits/platform.rs` (trait split), new `crates/flui-platform/src/traits/owner.rs` (`OwnerPlatform`, `PlatformProxy`, `PendingWindow`), `crates/flui-platform/src/platforms/winit/{platform,control}.rs` (lane generalization + handler-dispatch hoist), `crates/flui-platform/src/platforms/{macos,windows}/platform.rs` (slice-1 asserts), `crates/flui-app/src/app/{runner,direct}.rs` (bootstrap migrations + owner-TLS host), `examples/*` (on_ready migration)
 - **Related:** ADR-0027 (owner-affine UI realms — the sanctioned leapfrog zone this design lives in), ADR-0037 (presentation ownership domains — `PresentationId`, closed cross-thread vocabulary), ADR-0034 (clipboard reachability; named the macOS pasteboard-affinity hazard — §5 supersedes its suggested assert), audit 2026-07-25 §23 (U7)
-- **Numbering note:** `docs/adr/` ends at 0037 at HEAD; this number assumes the in-flight 0038 draft lands first. Renumber at landing if it does not.
+- **Numbering note (resolved):** ADR-0038 landed as 0038; no renumbering was needed.
 
 ---
 
@@ -320,6 +320,93 @@ Proxy verbs beyond `OpenWindow`/`Quit`; macOS monotonic `WindowId` mint; the pro
 **Costs.** `PlatformReadyCallback` is a breaking signature change that must touch all six backends and every embedder/example in one PR (pre-1.0, sanctioned by ADR-0027 §9's break-acknowledgement posture); slice 3 is a second, distinct break class — it removes 13 methods from the public `Platform` trait (8 moved, 5 deleted), breaking any external `Platform` implementor, not just callers; the lane generalization moves `control.rs` (≈500 lines incl. its tests) into shared code that macOS/Windows must wire wakes and drain gates for; the claim-slot protocol is a genuinely richer state machine than a buffered one-shot and carries its own test matrix; two platform-shaped types (`OwnerPlatform`, `PlatformProxy`) join the public API and must document their thread-affinity contracts per ADR-0027 §9.
 
 **Risks.** The Android bootstrap migration shifts GPU init from before the loop to the first `Resume` — behaviorally the backend's documented intent, but unvalidated until it runs on-device; slice 3 is explicitly gated on that validation. The winit handler-dispatch hoist changes what handlers may observe (they run after, not inside, the state update) — existing handler code must be re-audited in that PR. Post-bootstrap owner-thread `open_window` on winit resolves a turn later than the request (`Pending`), which callers must design for; bootstrap callers are unaffected (`Ready` guaranteed in `on_ready`). The orphan-window unwind changes observable behavior for a requester that drops its handle mid-flight (window may flicker open/closed instead of leaking); strictly better, but a release-notes item.
+
+## Amendments (slice 2)
+
+Recorded at acceptance (2026-08-03), alongside the status flip from Proposed:
+slice 2 shipped in one PR and diverges from this ADR's original sketch in
+the ways below. Each is a reconciled decision-record entry from that PR's
+adversarial review, not a silent drift — the Accepted canon this document
+now represents describes the tree slice 2 actually left, not the tree the
+Proposed draft imagined.
+
+(a) **The claim-slot primitive lives in `flui-foundation`, not the winit
+lane.** `ClaimSlot<T>`/`ClaimHandle<T>` (`crates/flui-foundation/src/claim_slot.rs`)
+carry the full Pending/Delivered/Claimed/Abandoned state machine and its
+tests; the winit lane (`platforms/winit/control.rs`) composes them rather
+than owning the machinery. Same rationale slice 1 already established for
+`OwnerAffinity`: the tests run in CI this way, since `flui-platform`'s own
+suite does not.
+
+(b) **Transitional proxy posture is sanctioned in writing, not left to a
+`tracing::warn!`.** On backends without an owner lane (macOS and Win32
+until slice 3; any genuinely single-threaded backend permanently),
+`PlatformProxy` methods return `ProxySendError::OwnerGone` on a *live*
+loop. This is not a lie about liveness — it is a standing, permanent
+contract for that backend today, stated in `ProxySendError::OwnerGone`'s
+own rustdoc ("do not retry; this is not a transient condition") and here:
+the closed `Full`/`OwnerGone` vocabulary is unchanged, and slice 3's lane
+adoption is what makes the posture literally (not just formally) accurate
+everywhere.
+
+(c) **`OwnerPlatform` is not `Clone`.** The loop-scoped TLS host
+(`flui-app`'s `OWNER_PLATFORM_HOST`) is the one sanctioned stash across
+owner-thread callbacks, reached only through the fenced, borrow-style
+`with_owner_platform` accessor — never a durable owned copy. A `Clone`
+impl would be sound (the `!Send` bound survives cloning) but would hollow
+the fences: one Idle-time acquisition could yield a copy that never
+re-crosses fence (b)/(c) again.
+
+(d) **`OwnerHooks`/`ProxyTransport` are the slice-3 `OwnerOps` seed.** Both
+are `pub(crate)` traits in `traits/owner.rs` — `OwnerHooks::open_owner_window`
+dispatches direct-create-vs-defer per backend; `ProxyTransport` backs
+`PlatformProxy`. `OwnerPlatform` carries a private `Arc<dyn OwnerHooks>`
+alongside its `Arc<dyn Platform>` today; slice 3 shrinks the latter to
+`Arc<dyn OwnerOps>` and these seams become that trait's public shape.
+
+(e) **§3's registry-bound statement is corrected.** "The registry is
+bounded by lane capacity" was imprecise: *queued* entries are bounded by
+lane capacity (256); *delivered-but-unclaimed* entries persist past
+dequeue until the requester claims or drops them — each pins one created
+window as the requester's liability, which is the claim-slot contract
+working as designed (a dropped `PendingWindow` unwinds it), not a leak.
+Total registry occupancy is therefore queue-plus-outstanding-deliveries,
+not queue alone. Counting registry occupancy at admission was considered
+and rejected for slice 2 (no consumer needs it, and it would change
+`Full`'s semantics).
+
+(f) **`WindowOpen::expect_ready` is named `try_ready`.** House `try_*`
+convention for a method that returns `Result` rather than panicking; the
+original sketch's `expect_ready` name implied a panic per this codebase's
+panic policy, which the method never does.
+
+(g) **`#[non_exhaustive]` decisions, recorded explicitly:** `OpenWindowError`
+and `WaitError` are `#[non_exhaustive]` (both forecast variant growth —
+`OpenWindowError` when slice 3's moved trait methods adopt this typed
+taxonomy, `WaitError` via its `#[from] OpenWindowError` arm and possible
+future wait modes). `WindowOpen` and `ProxySendError` are deliberately
+exhaustive: `WindowOpen`'s Ready/Pending pair is the load-bearing two-state
+deferral model (a third state is a redesign), and `ProxySendError` is the
+closed cross-thread vocabulary ADR-0027 §4/ADR-0037 §3 already established.
+
+(h) **Fence (c)'s "not inside a frame phase" is spelled out.** Forbidden:
+`SchedulerPhase::TransientCallbacks`, `MidFrameMicrotasks`,
+`PersistentCallbacks`. Allowed: `Idle`, `PostFrameCallbacks` (legitimate
+ADR-0021-style post-frame work must not trip the fence). The fence is
+acknowledged vacuous on binding-local frame paths — headless/test bindings
+drive their own binding-local `Scheduler`, never the `Scheduler::instance()`
+singleton this backstop checks — so fences (a) and (b) carry the load
+there; this is stated in `with_owner_platform`'s own rustdoc, not hidden.
+
+(i) **`Platform` is de-facto crate-sealed post-flip.** Minting an
+`OwnerPlatform` requires the `pub(crate)` constructor in `traits/owner.rs`,
+so an out-of-crate `impl Platform` cannot produce the value its own
+`run()` must hand to `on_ready`. This is recorded as policy (rustdoc on
+the trait, and the registry's surface entry), not enforced by a sealed-trait
+pattern in code. An external-embedder minting seam is design work tracked
+separately (#560); it is out of scope here because no external implementor
+exists yet, and a capability mint open to arbitrary code would gut the
+"minted only by a backend" guarantee this whole design rests on.
 
 ## Follow-ups
 

--- a/docs/adr/ADR-0039-event-loop-affinity-capability.md
+++ b/docs/adr/ADR-0039-event-loop-affinity-capability.md
@@ -7,7 +7,7 @@
 - **Status:** Accepted (2026-08-03)
 - **Date:** 2026-07-28
 - **Deciders:** @vanyastaff
-- **Scope:** `crates/flui-foundation/src` (new `OwnerAffinity` primitive — the slice-1 CI-tested deliverable — and, in slice 2, the `ClaimSlot`/`ClaimHandle` request/reply primitive), `crates/flui-platform/src/traits/platform.rs` (trait split), new `crates/flui-platform/src/traits/owner.rs` (`OwnerPlatform`, `PlatformProxy`, `PendingWindow`), `crates/flui-platform/src/platforms/winit/{platform,control}.rs` (lane generalization + handler-dispatch hoist), `crates/flui-platform/src/platforms/{macos,windows}/platform.rs` (slice-1 asserts), `crates/flui-app/src/app/{runner,direct}.rs` (bootstrap migrations + owner-TLS host), `examples/*` (on_ready migration)
+- **Scope:** `crates/flui-foundation/src` (new `OwnerAffinity` primitive — the slice-1 CI-tested deliverable — and, in slice 2, the `ClaimSlot`/`ClaimHandle` request/reply primitive, including its maintainer-fix-round `Future`/`ClaimOutcome`/owner-disconnect extensions), `crates/flui-platform/src/traits/platform.rs` (trait split; fallible `PlatformReadyCallback`), new `crates/flui-platform/src/traits/owner.rs` (`OwnerPlatform`, `SharedPlatform`, `PlatformProxy`, `PendingWindow`), `crates/flui-platform/src/platforms/winit/{platform,control}.rs` (lane generalization + handler-dispatch hoist), `crates/flui-platform/src/platforms/{macos,windows}/platform.rs` (slice-1 asserts), `crates/flui-app/src/app/{runner,direct}.rs` (bootstrap migrations + owner-TLS host), `examples/*` (on_ready migration)
 - **Related:** ADR-0027 (owner-affine UI realms — the sanctioned leapfrog zone this design lives in), ADR-0037 (presentation ownership domains — `PresentationId`, closed cross-thread vocabulary), ADR-0034 (clipboard reachability; named the macOS pasteboard-affinity hazard — §5 supersedes its suggested assert), audit 2026-07-25 §23 (U7)
 - **Numbering note (resolved):** ADR-0038 landed as 0038; no renumbering was needed.
 
@@ -339,15 +339,19 @@ than owning the machinery. Same rationale slice 1 already established for
 suite does not.
 
 (b) **Transitional proxy posture is sanctioned in writing, not left to a
-`tracing::warn!`.** On backends without an owner lane (macOS and Win32
-until slice 3; any genuinely single-threaded backend permanently),
-`PlatformProxy` methods return `ProxySendError::OwnerGone` on a *live*
-loop. This is not a lie about liveness — it is a standing, permanent
-contract for that backend today, stated in `ProxySendError::OwnerGone`'s
-own rustdoc ("do not retry; this is not a transient condition") and here:
-the closed `Full`/`OwnerGone` vocabulary is unchanged, and slice 3's lane
-adoption is what makes the posture literally (not just formally) accurate
-everywhere.
+`tracing::warn!` — superseded by the maintainer fix round's `Unsupported`
+variant (see "Amendments (slice 2, maintainer fix round)" below).** As
+originally recorded here, backends without an owner lane returned
+`ProxySendError::OwnerGone` on a *live* loop, standing in for "no lane
+exists" by overloading a variant whose name means "a lane existed and
+died". The fix round corrected this: `ProxySendError` gained a third,
+dedicated variant, `Unsupported`, and lane-less backends
+(macOS/Windows/web/Android/headless until slice 3) return that instead —
+`OwnerGone` is now reserved for its literal meaning (winit's lane, after
+the loop has actually stopped). The vocabulary is still closed (now
+`Full`/`OwnerGone`/`Unsupported`, not reopened), and slice 3's lane
+adoption is what eventually removes lane-less backends' need to return
+`Unsupported` at all.
 
 (c) **`OwnerPlatform` is not `Clone`.** The loop-scoped TLS host
 (`flui-app`'s `OWNER_PLATFORM_HOST`) is the one sanctioned stash across
@@ -407,6 +411,80 @@ pattern in code. An external-embedder minting seam is design work tracked
 separately (#560); it is out of scope here because no external implementor
 exists yet, and a capability mint open to arbitrary code would gut the
 "minted only by a backend" guarantee this whole design rests on.
+
+## Amendments (slice 2, maintainer fix round)
+
+Recorded after a maintainer Request Changes on the slice-2 PR found five
+load-bearing gaps the adversarial review above did not catch. Each is a
+correction to this document's own canon, not a new slice.
+
+(j) **`OwnerPlatform::shared()` returns `SharedPlatform`, not `&dyn
+Platform`.** The original design (§1's sketch, `pub fn shared(&self) -> &dyn
+Platform`) laundered the owner-only surface: `Platform` stays `Send + Sync`
+in full — including `open_window`/`quit`/`activate`/`displays`/
+`primary_display`/`window_appearance`/`keyboard_layout`/`active_window` —
+until slice 3's trait split, so a caller who threaded that `&dyn Platform`
+across a `std::thread::scope` boundary could call an owner-affine method
+off-thread in entirely safe code, defeating the compile-time guarantee
+capability holders otherwise get. `SharedPlatform` (`traits/owner.rs`) is a
+new `Clone + Send + Sync` struct wrapping `Arc<dyn Platform>` privately,
+exposing only §2's "what stays" table as delegating methods — no
+owner-affine method is ever added to it, and its own rustdoc states that
+the method list *is* the fence. `shared()` now returns it by value. The
+underlying `Platform` trait object is unchanged and still runtime-checked
+only (`OwnerAffinity` debug-asserts) — the registry's
+`owner-platform-capability` statement is corrected to say so explicitly:
+the compile-time guarantee is scoped to capability holders
+(`OwnerPlatform`, `SharedPlatform`), not to `Platform` itself.
+
+(k) **`PlatformReadyCallback` is fallible.** `Box<dyn FnOnce(OwnerPlatform)>`
+(§1) had no way to report a bootstrap failure (window creation, GPU init,
+root-widget attach) back to `Platform::run`'s caller — every backend either
+swallowed the failure into a bare log while continuing to run a half-built
+app (Android would keep pumping with no UI; web would install its RAF loop
+over a half-built page), or an embedder threaded the failure out through an
+ad hoc side channel (`flui-app`'s `bootstrap_error_slot` pattern, now
+removed). The signature is now `Box<dyn FnOnce(OwnerPlatform) ->
+anyhow::Result<()>>`, and `Platform::run` itself returns `anyhow::Result<()>`
+so `on_ready`'s `Err` propagates straight out of it. All eight backends
+(winit, windows, macos, web, android, headless, the linux stub, the ios
+stub) were updated in the same change: each stops entering, or promptly
+exits, its loop on `Err` rather than continuing. This is a second breaking
+change to the same signature slice 2 already broke once (§ "Costs"); it
+lands in the same pre-1.0 breaking-change posture (ADR-0027 §9).
+
+(l) **`ClaimHandle<T>` implements `Future<Output = ClaimOutcome<T>>` in
+`flui-foundation`, and `PendingWindow` wraps it.** §3's `PendingWindow` only
+offered a blocking `wait` (refused on the owner thread) and a manual
+`try_take` poll — there was no way for an owner-thread caller to await
+readiness without hand-rolling a poll loop. `flui-foundation`'s
+`claim_slot.rs` now stores a `Waker` alongside the existing state machine;
+`deliver`, requester abandonment, and owner disconnection (see (m)) all wake
+it outside the state lock, the same discipline the existing abandonment
+`WakeOwner` callback already followed. `PendingWindow`'s own `Future` impl
+(`Output = Result<Arc<dyn PlatformWindow>, OpenWindowError>`) delegates to
+the wrapped `ClaimHandle`'s poll and maps `ClaimOutcome::OwnerGone` onto
+`OpenWindowError::OwnerGone`. Polling never blocks on any thread, including
+the owner — the intended use is polling at `Idle` or driving the future
+through the framework's async driver, never from inside a pipeline hot path
+(build/layout/paint/composite), the same fence every other owner-thread
+capability in this design observes. No `async fn` is introduced on any hot
+path; only a `Future` impl on an existing value type.
+
+(m) **`ClaimSlot<T>`'s own `Drop` covers owner disconnection.** §3's state
+machine had no transition for "the owner side died before ever calling
+`deliver`" — a blocked `PendingWindow::wait` (or, before (l), a bare
+`ClaimHandle::wait`) had no way to learn the owner was gone and would block
+forever, relying entirely on the owner's own discipline (a panic-safe
+guard that always calls `deliver`) never being violated upstream of that
+guard. `ClaimSlot`'s `Drop` now transitions `Pending -> OwnerGone` (a new
+terminal state, distinct from the requester-initiated `Abandoned`) and
+wakes both consumer-side waiting primitives — the condvar `wait` blocks on,
+and the `Waker` (l) registers — so both resolve to a typed `OwnerGone`
+outcome instead of hanging. This is a backstop layered *on top of*, not a
+replacement for, the owner's `deliver` discipline; `PendingWindow::wait`'s
+"Owner obligation" rustdoc is updated to say the type now enforces what was
+previously only a documented convention.
 
 ## Follow-ups
 

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -956,10 +956,24 @@ stays" table -- no owner-affine method is ever added to it), not the \
 ambient `&dyn Platform`/`Arc<dyn Platform>` trait object, which remains \
 `Send + Sync` in full and runtime-checked only (the slice-1 `OwnerAffinity` \
 debug_assert backstop) until slice 3 actually splits the owner-affine \
-methods off the trait. Slice 2 lands `OwnerPlatform`/`SharedPlatform`/the \
-fallible callback flip/the flui-app TLS host across every backend; slice 3 \
-(the `OwnerOps` trait-surgery seam, macOS/Windows lane adoption) is not in \
-the tree.\
+methods off the trait. Two more routes of the SAME residual-hazard class, \
+named here rather than left implicit: `headless_platform() -> Box<dyn \
+Platform>` (a free constructor handing out the same full-`Send+Sync` \
+trait object, runtime-checked only, same as `current_platform()`); and the \
+publicly re-exported CONCRETE backend types themselves (`WinitPlatform`, \
+`MacOSPlatform`, `WindowsPlatform`, `WebPlatform`, `AndroidPlatform`, \
+`IOSPlatform`, `LinuxPlatform`, `HeadlessPlatform`) -- an `Arc<WinitPlatform>` \
+(for instance, `WinitPlatform::run_event_loop` is itself `pub` and takes \
+`self: Arc<Self>`) held across the loop lets a worker call `.quit()` (or \
+any other `Platform` method) directly on the concrete type with no `dyn \
+Platform` object involved at all, so the hazard is not merely a trait-object \
+one. All three routes close together, mechanically, only when slice 3 \
+actually moves the owner-affine methods off the `Platform` trait; until \
+then each is a debug_assert-guarded, not compile-error-guarded, misuse \
+surface. Slice 2 lands `OwnerPlatform`/`SharedPlatform`/the fallible \
+callback flip/the flui-app TLS host across every backend; slice 3 (the \
+`OwnerOps` trait-surgery seam, macOS/Windows lane adoption) is not in the \
+tree.\
 """
 state = "partial"
 domain = "platform"
@@ -1196,7 +1210,7 @@ owner = "platform backend (one per process; consumed by run())"
 failure_semantics = "anyhow surface; owner-affinity on the trait's own methods is still a runtime debug_assert (OwnerAffinity), not a compile-time property, until slice 3 moves them off. The compile-time guarantee this issue actually delivers lives on the capability holders: OwnerPlatform is !Send, and its shared() escape hatch returns the restricted SharedPlatform (Clone + Send + Sync, no owner-affine method) rather than this trait's own &dyn Platform."
 consumers = ["runner bootstrap", "run_direct", "examples"]
 owner_issue = 551
-notes = "De-facto crate-sealed post-flip: minting an OwnerPlatform requires the pub(crate) constructor in traits/owner.rs, so an out-of-crate impl Platform cannot supply what its own run() must hand to on_ready. An external-embedder minting seam is #560 design work, not this issue's scope."
+notes = "De-facto crate-sealed post-flip: minting an OwnerPlatform requires the pub(crate) constructor in traits/owner.rs, so an out-of-crate impl Platform cannot supply what its own run() must hand to on_ready. An external-embedder minting seam is #560 design work, not this issue's scope. Same residual class, named on the owner-platform-capability contract rather than repeated here: headless_platform()'s Box<dyn Platform> return, and the publicly re-exported concrete backend types (WinitPlatform et al., whose own pub methods -- e.g. WinitPlatform::run_event_loop -- need no dyn Platform object at all to reach an owner-affine method off-thread)."
 
 [[surface]]
 path = "flui_platform::PlatformReadyCallback"

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -136,6 +136,7 @@ declarations = [
     "pub use shared::{PlatformHandlers, WindowCallbacks};",
     "pub use task::{Priority, Task, TaskLabel};",
     "pub use traits::{ Clipboard, ClipboardItem, CursorError, DesktopCapabilities, DispatchEventResult, DisplayId, MobileCapabilities, PathPromptOptions, Platform, PlatformCapabilities, PlatformDisplay, PlatformEmbedder, PlatformExecutor, PlatformHaptics, PlatformReadyCallback, PlatformTextInput, PlatformWindow, WebCapabilities, WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowEvent, WindowId, WindowMode, WindowOptions, };",
+    "pub use traits::{ OpenWindowError, OwnerPlatform, PendingWindow, PlatformProxy, ProxySendError, WaitError, WindowOpen, };",
     "pub fn current_platform() -> anyhow::Result<Box<dyn Platform>> {",
     "pub fn headless_platform() -> Box<dyn Platform> {",
 ]
@@ -196,6 +197,7 @@ declarations = [
     "pub mod async_snapshot;",
     "pub mod binding;",
     "pub mod callbacks;",
+    "pub mod claim_slot;",
     "pub mod clock;",
     "pub mod consts;",
     "pub mod epoch;",
@@ -213,6 +215,7 @@ declarations = [
     "pub use async_snapshot::{AsyncSnapshot, ConnectionState};",
     "pub use binding::{BindingBase, HasInstance, check_instance};",
     "pub use callbacks::{ FallibleCallback, Predicate, ValueChanged, ValueGetter, ValueSetter, ValueTransformer, VoidCallback, };",
+    "pub use claim_slot::{ClaimHandle, ClaimSlot, claim_slot};",
     "pub use clock::{ManualClock, MonotonicClock, SystemClock};",
     "pub use consts::{DEBUG_MODE, EPSILON, EPSILON_F32, IS_DESKTOP, IS_MOBILE, IS_WEB, RELEASE_MODE};",
     "pub use epoch::{FrameEpoch, GenerationGate, ResourceGeneration, SurfaceGeneration};",
@@ -945,21 +948,36 @@ statement = """
 Owner-thread-only platform operations move off the `Send + Sync` `Platform` \
 trait onto a `!Send + !Sync` `OwnerPlatform` capability handed to \
 `on_ready`; post-bootstrap owner-thread window creation is deferred through \
-the owner lane, never direct. Nothing of slices 2–3 exists in the tree.\
+the owner lane, never direct. Slice 2 lands `OwnerPlatform`/the callback \
+flip/the flui-app TLS host across every backend; slice 3 (the `OwnerOps` \
+trait-surgery seam, macOS/Windows lane adoption) is not in the tree.\
 """
-state = "planned"
+state = "partial"
 domain = "platform"
 owner_issue = 551
-mechanical = false
+mechanical = true
+mechanism = "item-position auto-trait fences in owner.rs, real (non-dev) static_assertions dependency"
+evidence = [
+    { kind = "symbol", file = "crates/flui-platform/src/traits/owner.rs", contains = "pub struct OwnerPlatform" },
+    { kind = "symbol", file = "crates/flui-platform/src/traits/owner.rs", contains = "pub enum OpenWindowError" },
+    { kind = "compile-time", file = "crates/flui-platform/src/traits/owner.rs", contains = "assert_not_impl_any!(OwnerPlatform" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn owner_platform_host_installs_and_clears_around_run" },
+]
 
 [[contract]]
 key = "platform-proxy-claim-slot"
 statement = """
 Workers reach the owner through a typed, bounded `PlatformProxy` with \
-claim-slot at-most-once replies and per-backend drain-anchor gates. The \
-winit-internal `ControlSender` lane exists (bounded, typed \
-`Full`/`OwnerGone`, wake, admission gate) but is backend-private and keeps \
-the weaker buffered one-shot reply.\
+claim-slot at-most-once replies. The winit lane's `ControlSender` composes \
+`flui-foundation`'s `ClaimSlot`/`ClaimHandle` for its reply protocol \
+(bounded, typed `Full`/`OwnerGone` at enqueue; claimed-or-abandoned at \
+resolution) and is `PlatformProxy`'s public transport on that backend. \
+macOS/Windows transports are `ClosedTransport` (permanent `OwnerGone`) \
+until slice 3 gives them a lane; the drain-anchor gate contract (ADR-0039 \
+§4) is scoped to slice 3's lane generalization. Registry-occupancy bound \
+is honest, not admission-time: queued entries ≤ lane capacity (256); \
+delivered-but-unclaimed entries persist as the requester's pinned \
+liability until claim or drop.\
 """
 state = "partial"
 domain = "platform"
@@ -967,6 +985,10 @@ owner_issue = 551
 mechanical = false
 evidence = [
     { kind = "symbol", file = "crates/flui-platform/src/platforms/winit/control.rs", contains = "enum ControlSendError" },
+    { kind = "symbol", file = "crates/flui-foundation/src/claim_slot.rs", contains = "pub struct ClaimSlot" },
+    { kind = "symbol", file = "crates/flui-platform/src/traits/owner.rs", contains = "pub enum ProxySendError" },
+    { kind = "symbol", file = "crates/flui-platform/src/traits/owner.rs", contains = "pub enum WaitError" },
+    { kind = "test", file = "crates/flui-foundation/src/claim_slot.rs", contains = "fn dropped_after_delivery_abandons_with_recoverable_payload" },
 ]
 
 [[contract]]
@@ -991,11 +1013,18 @@ key = "pre-run-flows-migrate-to-on-ready"
 statement = """
 Window creation before `Platform::run` (run_direct, Android bootstrap, web \
 bootstrap, Win32 examples) migrates inside `on_ready`, where every backend \
-guarantees synchronous owner-thread creation. `run_direct` remains broken on \
-the winit backend until this lands and is marked experimental for exactly \
-this reason.\
+guarantees synchronous owner-thread creation. All four flows are migrated \
+in source: `run_direct` now works on the winit backend (previously dead on \
+arrival there) and keeps `experimental` classification pending broader \
+stabilization; Android's migration (window/GPU/realm mount move from \
+before `run()` to the first `Resume`) is behaviorally the backend's \
+documented intent but on-device-unvalidated (no device, no CI compile \
+target for `target_os = "android"`) and gates slice 3's trait-method \
+deletion on that validation. Once-only bootstrap semantics are preserved \
+on every backend (`on_ready` is `FnOnce`, matching today's once-only \
+pre-run bootstrap exactly).\
 """
-state = "planned"
+state = "partial"
 domain = "platform"
 owner_issue = 551
 mechanical = true
@@ -1041,12 +1070,12 @@ kind = "function"
 declared_in = "crates/flui-app/src/app/direct.rs"
 contains = "pub fn run_direct"
 classification = "experimental"
-thread_affinity = "process main thread; opens the window before run(), so it fails fast on the winit backend"
+thread_affinity = "process main thread; window/GPU/callback bootstrap runs inside on_ready, so it now works on the winit backend too"
 owner = "application composition root (direct-engine escape hatch)"
-failure_semantics = "anyhow::Result; typed fast-fail before any window opens on winit (Linux)"
+failure_semantics = "anyhow::Result; bootstrap failures thread out through a Rc<RefCell<Option<Error>>> checked after run() returns"
 consumers = ["examples/direct_render.rs", "examples/aa_showcase.rs"]
 owner_issue = 551
-notes = "Event-loop repair (on_ready reorder) is issue #551. The checker pins the experimental marking."
+notes = "Graduating out of experimental is a separate post-slice-3 decision; the checker pins the experimental marking and the word appearing in direct.rs regardless of what the marking describes."
 
 [[surface]]
 path = "flui_app::run_app_android / run_app_android_with_config"
@@ -1055,7 +1084,7 @@ kind = "function"
 declared_in = "crates/flui-app/src/app/runner.rs"
 contains = "pub fn run_app_android"
 classification = "experimental"
-thread_affinity = "android_main thread; pre-run bootstrap creates the window/GPU before the loop, contra issue #551"
+thread_affinity = "android_main thread; window/GPU/realm mount now run inside on_ready, firing at the first Resume (module doc: Resumed -> on_ready() -> create surface); on-device validation is outstanding (no device, no CI compile target)"
 owner = "application composition root (Android runner)"
 failure_semantics = "returns unit; bootstrap failures are logged"
 consumers = ["examples/android_demo (via its own bootstrap)"]
@@ -1134,11 +1163,12 @@ kind = "trait"
 declared_in = "crates/flui-platform/src/traits/platform.rs"
 contains = "pub trait Platform: Send + Sync + 'static"
 classification = "transitional"
-thread_affinity = "declared Send + Sync, but open_window/quit/activate/displays/window_appearance are owner-thread-only on real OSes — the owner-affinity defect"
+thread_affinity = "declared Send + Sync; the owner-affine subset (open_window/quit/activate/displays/window_appearance) moved onto OwnerPlatform in slice 2 — the residual trait keeps only genuinely thread-safe methods (background_executor, clipboard, callback registration)"
 owner = "platform backend (one per process; consumed by run())"
-failure_semantics = "anyhow surface; owner-affinity violations are debug_assert-only (slice 1 backstop)"
+failure_semantics = "anyhow surface on the residual methods; owner-affinity is now a compile-time property of OwnerPlatform, not a debug_assert, for the methods that moved"
 consumers = ["runner bootstrap", "run_direct", "examples"]
 owner_issue = 551
+notes = "De-facto crate-sealed post-flip: minting an OwnerPlatform requires the pub(crate) constructor in traits/owner.rs, so an out-of-crate impl Platform cannot supply what its own run() must hand to on_ready. An external-embedder minting seam is #560 design work, not this issue's scope."
 
 [[surface]]
 path = "flui_platform::PlatformReadyCallback"
@@ -1147,12 +1177,68 @@ kind = "type-alias"
 declared_in = "crates/flui-platform/src/traits/platform.rs"
 contains = "pub type PlatformReadyCallback"
 classification = "transitional"
-thread_affinity = "invoked on the event-loop owner thread by every backend"
+thread_affinity = "invoked once, synchronously, on the event-loop owner thread by every backend; carries OwnerPlatform by value"
 owner = "backend run() contract"
 failure_semantics = "infallible callback"
-consumers = ["all six backends", "runner"]
+consumers = [
+    "all eight backends (winit, windows, macos, web, android, headless, linux stub, ios stub)",
+    "runner",
+]
 owner_issue = 551
-notes = "issue #551 flips this signature to carry OwnerPlatform by value — a breaking change across all backends."
+notes = "Flipped in issue #551 to Box<dyn FnOnce(OwnerPlatform)> -- a breaking change landed across every backend in one PR (pre-1.0, ADR-0027 §9 break-acknowledgement posture)."
+
+[[surface]]
+path = "flui_platform::OwnerPlatform"
+crate = "flui-platform"
+kind = "type"
+declared_in = "crates/flui-platform/src/traits/owner.rs"
+contains = "pub struct OwnerPlatform"
+classification = "experimental"
+thread_affinity = "!Send + !Sync by phantom marker; minted only by a backend, on the thread that owns (or will own) its event loop, and handed to on_ready"
+owner = "backend run() contract; stashed loop-scoped in flui-app's OWNER_PLATFORM_HOST TLS"
+failure_semantics = "open_window returns a typed Result<WindowOpen, OpenWindowError>; other methods are infallible or delegate to the residual Platform surface via shared()"
+consumers = ["every backend's on_ready closure", "flui-app runner bootstrap"]
+owner_issue = 551
+notes = "Not Clone by design (ADR-0039 slice-2 decision record) -- the sanctioned way to hold it across callbacks is flui-app's with_owner_platform borrow accessor, never a durable owned copy."
+
+[[surface]]
+path = "flui_platform::PlatformProxy"
+crate = "flui-platform"
+kind = "type"
+declared_in = "crates/flui-platform/src/traits/owner.rs"
+contains = "pub struct PlatformProxy"
+classification = "experimental"
+thread_affinity = "Clone + Send + Sync; callable from any thread, including the owner (is_owner_thread() is diagnostic only)"
+owner = "OwnerPlatform::proxy() mint; carried by workers/realms/tasks that need to reach the owner"
+failure_semantics = "open_window returns Result<PendingWindow, ProxySendError<WindowOptions>>; OwnerGone is permanent on lane-less backends until slice 3"
+consumers = ["winit lane (real transport)", "windows/macos/headless/web/android (ClosedTransport)"]
+owner_issue = 551
+
+[[surface]]
+path = "flui_platform::PendingWindow"
+crate = "flui-platform"
+kind = "type"
+declared_in = "crates/flui-platform/src/traits/owner.rs"
+contains = "pub struct PendingWindow"
+classification = "experimental"
+thread_affinity = "Send (statically asserted); wait() type-refuses the owner thread via WaitError::WouldBlockOwner rather than deadlocking on the lane it drains"
+owner = "the requester that received it from OwnerPlatform::open_window or PlatformProxy::open_window"
+failure_semantics = "dropping it disclaims the request (guard-like): the owner skips creation (not yet delivered) or unwinds the created window (already delivered) -- see ClaimSlot's module docs"
+consumers = ["winit lane deferred-open path"]
+owner_issue = 551
+
+[[surface]]
+path = "flui_platform::WindowOpen"
+crate = "flui-platform"
+kind = "type"
+declared_in = "crates/flui-platform/src/traits/owner.rs"
+contains = "pub enum WindowOpen"
+classification = "experimental"
+thread_affinity = "returned by OwnerPlatform::open_window; Ready always holds inside on_ready"
+owner = "OwnerPlatform::open_window's caller"
+failure_semantics = "exhaustive by design (Ready/Pending is the load-bearing two-state deferral model; a third state is a redesign); try_ready() converts Pending into the typed OpenWindowError::NotReady"
+consumers = ["every bootstrap_* function", "examples"]
+owner_issue = 551
 
 [[surface]]
 path = "flui_platform::current_platform"

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -136,7 +136,7 @@ declarations = [
     "pub use shared::{PlatformHandlers, WindowCallbacks};",
     "pub use task::{Priority, Task, TaskLabel};",
     "pub use traits::{ Clipboard, ClipboardItem, CursorError, DesktopCapabilities, DispatchEventResult, DisplayId, MobileCapabilities, PathPromptOptions, Platform, PlatformCapabilities, PlatformDisplay, PlatformEmbedder, PlatformExecutor, PlatformHaptics, PlatformReadyCallback, PlatformTextInput, PlatformWindow, WebCapabilities, WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowEvent, WindowId, WindowMode, WindowOptions, };",
-    "pub use traits::{ OpenWindowError, OwnerPlatform, PendingWindow, PlatformProxy, ProxySendError, WaitError, WindowOpen, };",
+    "pub use traits::{ OpenWindowError, OwnerPlatform, PendingWindow, PlatformProxy, ProxySendError, SharedPlatform, WaitError, WindowOpen, };",
     "pub fn current_platform() -> anyhow::Result<Box<dyn Platform>> {",
     "pub fn headless_platform() -> Box<dyn Platform> {",
 ]
@@ -215,7 +215,7 @@ declarations = [
     "pub use async_snapshot::{AsyncSnapshot, ConnectionState};",
     "pub use binding::{BindingBase, HasInstance, check_instance};",
     "pub use callbacks::{ FallibleCallback, Predicate, ValueChanged, ValueGetter, ValueSetter, ValueTransformer, VoidCallback, };",
-    "pub use claim_slot::{ClaimHandle, ClaimSlot, claim_slot};",
+    "pub use claim_slot::{ClaimHandle, ClaimOutcome, ClaimSlot, claim_slot};",
     "pub use clock::{ManualClock, MonotonicClock, SystemClock};",
     "pub use consts::{DEBUG_MODE, EPSILON, EPSILON_F32, IS_DESKTOP, IS_MOBILE, IS_WEB, RELEASE_MODE};",
     "pub use epoch::{FrameEpoch, GenerationGate, ResourceGeneration, SurfaceGeneration};",
@@ -948,9 +948,18 @@ statement = """
 Owner-thread-only platform operations move off the `Send + Sync` `Platform` \
 trait onto a `!Send + !Sync` `OwnerPlatform` capability handed to \
 `on_ready`; post-bootstrap owner-thread window creation is deferred through \
-the owner lane, never direct. Slice 2 lands `OwnerPlatform`/the callback \
-flip/the flui-app TLS host across every backend; slice 3 (the `OwnerOps` \
-trait-surgery seam, macOS/Windows lane adoption) is not in the tree.\
+the owner lane, never direct. The compile-time "wrong-thread is a compile \
+error" guarantee holds for CAPABILITY HOLDERS: `OwnerPlatform` is `!Send`, \
+and its `shared()` escape hatch returns `SharedPlatform` (`Clone + Send + \
+Sync`, deliberately restricted to the thread-safe residual per §2's "what \
+stays" table -- no owner-affine method is ever added to it), not the \
+ambient `&dyn Platform`/`Arc<dyn Platform>` trait object, which remains \
+`Send + Sync` in full and runtime-checked only (the slice-1 `OwnerAffinity` \
+debug_assert backstop) until slice 3 actually splits the owner-affine \
+methods off the trait. Slice 2 lands `OwnerPlatform`/`SharedPlatform`/the \
+fallible callback flip/the flui-app TLS host across every backend; slice 3 \
+(the `OwnerOps` trait-surgery seam, macOS/Windows lane adoption) is not in \
+the tree.\
 """
 state = "partial"
 domain = "platform"
@@ -959,9 +968,12 @@ mechanical = true
 mechanism = "item-position auto-trait fences in owner.rs, real (non-dev) static_assertions dependency"
 evidence = [
     { kind = "symbol", file = "crates/flui-platform/src/traits/owner.rs", contains = "pub struct OwnerPlatform" },
+    { kind = "symbol", file = "crates/flui-platform/src/traits/owner.rs", contains = "pub struct SharedPlatform" },
     { kind = "symbol", file = "crates/flui-platform/src/traits/owner.rs", contains = "pub enum OpenWindowError" },
     { kind = "compile-time", file = "crates/flui-platform/src/traits/owner.rs", contains = "assert_not_impl_any!(OwnerPlatform" },
+    { kind = "compile-time", file = "crates/flui-platform/src/traits/owner.rs", contains = "assert_impl_all!(SharedPlatform" },
     { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn owner_platform_host_installs_and_clears_around_run" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn owner_platform_host_on_ready_error_propagates_and_still_clears" },
 ]
 
 [[contract]]
@@ -972,12 +984,25 @@ claim-slot at-most-once replies. The winit lane's `ControlSender` composes \
 `flui-foundation`'s `ClaimSlot`/`ClaimHandle` for its reply protocol \
 (bounded, typed `Full`/`OwnerGone` at enqueue; claimed-or-abandoned at \
 resolution) and is `PlatformProxy`'s public transport on that backend. \
-macOS/Windows transports are `ClosedTransport` (permanent `OwnerGone`) \
-until slice 3 gives them a lane; the drain-anchor gate contract (ADR-0039 \
-§4) is scoped to slice 3's lane generalization. Registry-occupancy bound \
-is honest, not admission-time: queued entries ≤ lane capacity (256); \
-delivered-but-unclaimed entries persist as the requester's pinned \
-liability until claim or drop.\
+macOS/Windows/web/Android/headless transports are `ClosedTransport`, which \
+returns `ProxySendError::Unsupported` (PERMANENTLY, until slice 3 gives \
+them a lane) for both `open_window` and `request_quit` -- a maintainer fix \
+round correction: the vocabulary originally overloaded `OwnerGone` for this \
+(a name that means "a lane existed and died"), which `Unsupported` now \
+replaces on every lane-less backend; `OwnerGone` is reserved for the winit \
+lane after its loop has actually stopped. `request_quit` itself is now \
+fallible (`Result<(), ProxySendError<()>>`, `#[must_use]`): winit returns \
+`Ok(())` (coalesced, as before) or `OwnerGone` if the loop already stopped; \
+lane-less backends return `Unsupported`. The drain-anchor gate contract \
+(ADR-0039 §4) is scoped to slice 3's lane generalization. \
+Registry-occupancy bound is honest, not admission-time: queued entries ≤ \
+lane capacity (256); delivered-but-unclaimed entries persist as the \
+requester's pinned liability until claim or drop. `ClaimHandle<T>` also \
+implements `Future<Output = ClaimOutcome<T>>` (flui-foundation, CI-run \
+tests), and `PendingWindow` wraps it as its own `Future` -- non-blocking on \
+any thread including the owner, resolving to a typed `OwnerGone` outcome if \
+the owner side (`ClaimSlot`) is dropped before ever delivering (that \
+transition is `ClaimSlot`'s own `Drop`, not just `ClaimHandle`'s).\
 """
 state = "partial"
 domain = "platform"
@@ -988,7 +1013,10 @@ evidence = [
     { kind = "symbol", file = "crates/flui-foundation/src/claim_slot.rs", contains = "pub struct ClaimSlot" },
     { kind = "symbol", file = "crates/flui-platform/src/traits/owner.rs", contains = "pub enum ProxySendError" },
     { kind = "symbol", file = "crates/flui-platform/src/traits/owner.rs", contains = "pub enum WaitError" },
+    { kind = "symbol", file = "crates/flui-foundation/src/claim_slot.rs", contains = "pub enum ClaimOutcome" },
     { kind = "test", file = "crates/flui-foundation/src/claim_slot.rs", contains = "fn dropped_after_delivery_abandons_with_recoverable_payload" },
+    { kind = "test", file = "crates/flui-foundation/src/claim_slot.rs", contains = "fn blocked_waiter_unblocks_on_owner_drop" },
+    { kind = "test", file = "crates/flui-foundation/src/claim_slot.rs", contains = "fn future_wakes_on_owner_drop" },
 ]
 
 [[contract]]
@@ -1072,7 +1100,7 @@ contains = "pub fn run_direct"
 classification = "experimental"
 thread_affinity = "process main thread; window/GPU/callback bootstrap runs inside on_ready, so it now works on the winit backend too"
 owner = "application composition root (direct-engine escape hatch)"
-failure_semantics = "anyhow::Result; bootstrap failures thread out through a Rc<RefCell<Option<Error>>> checked after run() returns"
+failure_semantics = "anyhow::Result, returned directly from Platform::run's own Result: on_ready is now fallible, so the old Rc<RefCell<Option<Error>>> bootstrap_error_slot side-channel is redundant and has been removed"
 consumers = ["examples/direct_render.rs", "examples/aa_showcase.rs"]
 owner_issue = 551
 notes = "Graduating out of experimental is a separate post-slice-3 decision; the checker pins the experimental marking and the word appearing in direct.rs regardless of what the marking describes."
@@ -1086,7 +1114,7 @@ contains = "pub fn run_app_android"
 classification = "experimental"
 thread_affinity = "android_main thread; window/GPU/realm mount now run inside on_ready, firing at the first Resume (module doc: Resumed -> on_ready() -> create surface); on-device validation is outstanding (no device, no CI compile target)"
 owner = "application composition root (Android runner)"
-failure_semantics = "returns unit; bootstrap failures are logged"
+failure_semantics = "returns unit; a bootstrap failure now propagates through Platform::run's Result and panics rather than the earlier behavior of logging and silently continuing to pump a windowless loop"
 consumers = ["examples/android_demo (via its own bootstrap)"]
 owner_issue = 551
 
@@ -1163,9 +1191,9 @@ kind = "trait"
 declared_in = "crates/flui-platform/src/traits/platform.rs"
 contains = "pub trait Platform: Send + Sync + 'static"
 classification = "transitional"
-thread_affinity = "declared Send + Sync; the owner-affine subset (open_window/quit/activate/displays/window_appearance) moved onto OwnerPlatform in slice 2 — the residual trait keeps only genuinely thread-safe methods (background_executor, clipboard, callback registration)"
+thread_affinity = "TRANSITIONAL, NOT thread-safe in full: the trait itself is still declared Send + Sync with every owner-affine method still on it (open_window/quit/activate/displays/primary_display/window_appearance/keyboard_layout/active_window) -- slice 2 narrowed only the CAPABILITY SURFACES built on top (OwnerPlatform's own methods, and SharedPlatform's deliberately restricted method list), not this trait. An owner-affine call through a raw &dyn Platform / Arc<dyn Platform> is still guarded only by the slice-1 OwnerAffinity debug_assert backstop, not a compile error, until slice 3 actually moves these methods off the trait. Do not read this entry (or OwnerPlatform's) as implying `dyn Platform` itself became thread-safe -- it did not."
 owner = "platform backend (one per process; consumed by run())"
-failure_semantics = "anyhow surface on the residual methods; owner-affinity is now a compile-time property of OwnerPlatform, not a debug_assert, for the methods that moved"
+failure_semantics = "anyhow surface; owner-affinity on the trait's own methods is still a runtime debug_assert (OwnerAffinity), not a compile-time property, until slice 3 moves them off. The compile-time guarantee this issue actually delivers lives on the capability holders: OwnerPlatform is !Send, and its shared() escape hatch returns the restricted SharedPlatform (Clone + Send + Sync, no owner-affine method) rather than this trait's own &dyn Platform."
 consumers = ["runner bootstrap", "run_direct", "examples"]
 owner_issue = 551
 notes = "De-facto crate-sealed post-flip: minting an OwnerPlatform requires the pub(crate) constructor in traits/owner.rs, so an out-of-crate impl Platform cannot supply what its own run() must hand to on_ready. An external-embedder minting seam is #560 design work, not this issue's scope."
@@ -1179,13 +1207,13 @@ contains = "pub type PlatformReadyCallback"
 classification = "transitional"
 thread_affinity = "invoked once, synchronously, on the event-loop owner thread by every backend; carries OwnerPlatform by value"
 owner = "backend run() contract"
-failure_semantics = "infallible callback"
+failure_semantics = "fallible: Box<dyn FnOnce(OwnerPlatform) -> anyhow::Result<()>>. Platform::run itself returns anyhow::Result<()> and propagates on_ready's Err out of it; every backend stops entering (or promptly exits) its loop on Err rather than continuing to run a half-built app."
 consumers = [
     "all eight backends (winit, windows, macos, web, android, headless, linux stub, ios stub)",
     "runner",
 ]
 owner_issue = 551
-notes = "Flipped in issue #551 to Box<dyn FnOnce(OwnerPlatform)> -- a breaking change landed across every backend in one PR (pre-1.0, ADR-0027 §9 break-acknowledgement posture)."
+notes = "Flipped in issue #551 to Box<dyn FnOnce(OwnerPlatform)> -- a breaking change landed across every backend in one PR (pre-1.0, ADR-0027 §9 break-acknowledgement posture). Flipped a second time, to Box<dyn FnOnce(OwnerPlatform) -> anyhow::Result<()>>, across the same eight backends -- a bootstrap failure (window creation, GPU init, root-widget attach) now propagates out of Platform::run instead of leaving the loop running with a broken app. flui-app's bootstrap_desktop/bootstrap_android/bootstrap_web/bootstrap_direct all return anyhow::Result<()>; the old bootstrap_error_slot Rc<RefCell<Option<anyhow::Error>>> side-channel pattern is now redundant everywhere it was used and has been removed."
 
 [[surface]]
 path = "flui_platform::OwnerPlatform"
@@ -1202,6 +1230,20 @@ owner_issue = 551
 notes = "Not Clone by design (ADR-0039 slice-2 decision record) -- the sanctioned way to hold it across callbacks is flui-app's with_owner_platform borrow accessor, never a durable owned copy."
 
 [[surface]]
+path = "flui_platform::SharedPlatform"
+crate = "flui-platform"
+kind = "type"
+declared_in = "crates/flui-platform/src/traits/owner.rs"
+contains = "pub struct SharedPlatform"
+classification = "experimental"
+thread_affinity = "Clone + Send + Sync; every method is safe to call from any thread, including a std::thread::scope worker -- the method list itself is the fence (no owner-affine method is ever added)"
+owner = "OwnerPlatform::shared() mint"
+failure_semantics = "delegates to the residual Platform surface (background_executor, capabilities, name, compositor_name, app_path, clipboard, data_transfer, the five on_* registrations, open_url/reveal_path/open_path, prompt_for_paths/prompt_for_new_path, write_to_clipboard/read_from_clipboard); each keeps its own Platform-trait failure semantics"
+consumers = ["flui-app runner/direct bootstrap (clipboard wiring, on_quit registration)"]
+owner_issue = 551
+notes = "OwnerPlatform::shared() used to return &dyn Platform, which is Send + Sync in full (including the owner-affine methods) until slice 3's trait split -- a worker thread could borrow it and call an owner-affine method off-thread in safe code. SharedPlatform closes that: it wraps Arc<dyn Platform> privately and exposes only the thread-safe residual."
+
+[[surface]]
 path = "flui_platform::PlatformProxy"
 crate = "flui-platform"
 kind = "type"
@@ -1210,7 +1252,7 @@ contains = "pub struct PlatformProxy"
 classification = "experimental"
 thread_affinity = "Clone + Send + Sync; callable from any thread, including the owner (is_owner_thread() is diagnostic only)"
 owner = "OwnerPlatform::proxy() mint; carried by workers/realms/tasks that need to reach the owner"
-failure_semantics = "open_window returns Result<PendingWindow, ProxySendError<WindowOptions>>; OwnerGone is permanent on lane-less backends until slice 3"
+failure_semantics = "open_window returns Result<PendingWindow, ProxySendError<WindowOptions>>; request_quit returns Result<(), ProxySendError<()>> (#[must_use]). ProxySendError::Unsupported is permanent on lane-less backends (windows/macos/web/android/headless) until slice 3; ProxySendError::OwnerGone is reserved for the winit lane after its loop has actually stopped."
 consumers = ["winit lane (real transport)", "windows/macos/headless/web/android (ClosedTransport)"]
 owner_issue = 551
 

--- a/examples/color_filter_demo.rs
+++ b/examples/color_filter_demo.rs
@@ -319,11 +319,14 @@ fn main() {
         "color filter demo ready — 5 columns: unfiltered | Mode/Multiply | LinearToSrgb | SrgbToLinear | Grayscale"
     );
 
-    platform.run(Box::new(move |_platform| {
-        // Keep resources alive through the event loop.
-        let _window = &window;
-        let _renderer = &renderer;
-    }));
+    platform
+        .run(Box::new(move |_owner| {
+            // Keep resources alive through the event loop.
+            let _window = &window;
+            let _renderer = &renderer;
+            Ok(())
+        }))
+        .expect("platform event loop exited with an error");
 
     tracing::info!("color filter demo finished");
 }

--- a/examples/filter_demo.rs
+++ b/examples/filter_demo.rs
@@ -245,11 +245,14 @@ fn main() {
 
     tracing::info!("filter demo ready — left=sharp, right=blurred (σ=8)");
 
-    platform.run(Box::new(move |_platform| {
-        // Keep resources alive through the event loop.
-        let _window = &window;
-        let _renderer = &renderer;
-    }));
+    platform
+        .run(Box::new(move |_owner| {
+            // Keep resources alive through the event loop.
+            let _window = &window;
+            let _renderer = &renderer;
+            Ok(())
+        }))
+        .expect("platform event loop exited with an error");
 
     tracing::info!("filter demo finished");
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -19,48 +19,51 @@ fn main() {
     // displays and create windows once its event loop is pumping (calling
     // either earlier would either report zero displays or hang forever
     // waiting for a loop that hasn't started).
-    platform.run(Box::new(|owner| {
-        let displays = owner.displays();
-        tracing::info!("Found {} display(s):", displays.len());
-        for (i, disp) in displays.iter().enumerate() {
-            tracing::info!(
-                "  Display {}: {} ({}x{} @ {:.1}x scale)",
-                i + 1,
-                disp.name(),
-                disp.bounds().size.width,
-                disp.bounds().size.height,
-                disp.scale_factor()
-            );
-        }
+    platform
+        .run(Box::new(|owner| {
+            let displays = owner.displays();
+            tracing::info!("Found {} display(s):", displays.len());
+            for (i, disp) in displays.iter().enumerate() {
+                tracing::info!(
+                    "  Display {}: {} ({}x{} @ {:.1}x scale)",
+                    i + 1,
+                    disp.name(),
+                    disp.bounds().size.width,
+                    disp.bounds().size.height,
+                    disp.scale_factor()
+                );
+            }
 
-        tracing::info!("Creating window...");
+            tracing::info!("Creating window...");
 
-        let window_options = WindowOptions {
-            title: "Hello FLUI!".to_string(),
-            size: Size::new(px(800.0), px(600.0)),
-            resizable: true,
-            visible: true,
-            decorated: true,
-            min_size: None,
-            max_size: None,
-        };
+            let window_options = WindowOptions {
+                title: "Hello FLUI!".to_string(),
+                size: Size::new(px(800.0), px(600.0)),
+                resizable: true,
+                visible: true,
+                decorated: true,
+                min_size: None,
+                max_size: None,
+            };
 
-        // `Ready` is guaranteed inside `on_ready` (ADR-0039 §1).
-        let window = owner
-            .open_window(window_options)
-            .expect("Failed to create window")
-            .try_ready()
-            .expect("window creation is always Ready inside on_ready");
-        tracing::info!("Window created successfully!");
-        tracing::info!("   Logical size: {:?}", window.logical_size());
-        tracing::info!("   Physical size: {:?}", window.physical_size());
-        tracing::info!("   Scale factor: {:.1}x", window.scale_factor());
+            // `Ready` is guaranteed inside `on_ready` (ADR-0039 §1).
+            let window = owner
+                .open_window(window_options)
+                .expect("Failed to create window")
+                .try_ready()
+                .expect("window creation is always Ready inside on_ready");
+            tracing::info!("Window created successfully!");
+            tracing::info!("   Logical size: {:?}", window.logical_size());
+            tracing::info!("   Physical size: {:?}", window.physical_size());
+            tracing::info!("   Scale factor: {:.1}x", window.scale_factor());
 
-        tracing::info!("Platform ready, window is open");
-        // The platform's own window registry — not this handle — keeps the
-        // OS window alive; dropping `window` here just releases this handle.
-        let _window = window;
-    }));
+            tracing::info!("Platform ready, window is open");
+            // The platform's own window registry — not this handle — keeps the
+            // OS window alive; dropping `window` here just releases this handle.
+            let _window = window;
+            Ok(())
+        }))
+        .expect("platform event loop exited with an error");
 
     tracing::info!("Application finished!");
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -19,8 +19,8 @@ fn main() {
     // displays and create windows once its event loop is pumping (calling
     // either earlier would either report zero displays or hang forever
     // waiting for a loop that hasn't started).
-    platform.run(Box::new(|platform| {
-        let displays = platform.displays();
+    platform.run(Box::new(|owner| {
+        let displays = owner.displays();
         tracing::info!("Found {} display(s):", displays.len());
         for (i, disp) in displays.iter().enumerate() {
             tracing::info!(
@@ -45,9 +45,12 @@ fn main() {
             max_size: None,
         };
 
-        let window = platform
+        // `Ready` is guaranteed inside `on_ready` (ADR-0039 §1).
+        let window = owner
             .open_window(window_options)
-            .expect("Failed to create window");
+            .expect("Failed to create window")
+            .try_ready()
+            .expect("window creation is always Ready inside on_ready");
         tracing::info!("Window created successfully!");
         tracing::info!("   Logical size: {:?}", window.logical_size());
         tracing::info!("   Physical size: {:?}", window.physical_size());

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -72,11 +72,14 @@ fn main() {
     tracing::info!("");
     tracing::info!("Waiting for input events...");
 
-    platform.run(Box::new(move |_platform| {
-        tracing::info!("Platform ready, window is open");
-        // Keep window alive via closure capture
-        let _window = window;
-    }));
+    platform
+        .run(Box::new(move |_owner| {
+            tracing::info!("Platform ready, window is open");
+            // Keep window alive via closure capture
+            let _window = window;
+            Ok(())
+        }))
+        .expect("platform event loop exited with an error");
 
     tracing::info!("Application finished!");
 }

--- a/examples/scene_render.rs
+++ b/examples/scene_render.rs
@@ -199,12 +199,15 @@ fn main() {
         tracing::info!("Scene render pipeline active — set FLUI_SCENE_PLUGIN for hot-reload");
     }
 
-    platform.run(Box::new(move |_platform| {
-        tracing::info!("Platform ready");
-        // Keep resources alive via closure capture
-        let _window = &window;
-        let _renderer = &renderer;
-    }));
+    platform
+        .run(Box::new(move |_owner| {
+            tracing::info!("Platform ready");
+            // Keep resources alive via closure capture
+            let _window = &window;
+            let _renderer = &renderer;
+            Ok(())
+        }))
+        .expect("platform event loop exited with an error");
 
     tracing::info!("Application finished");
 }

--- a/examples/test_background.rs
+++ b/examples/test_background.rs
@@ -22,27 +22,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let platform: Box<dyn flui_platform::Platform> = Box::new(WindowsPlatform::new()?);
 
-    let options = WindowOptions {
-        title: "Background Test - Should be BLACK not white".to_string(),
-        size: Size::new(px(800.0), px(600.0)),
-        resizable: true,
-        visible: true,
-        decorated: true,
-        min_size: None,
-        max_size: None,
-    };
+    // Window creation moves inside `on_ready` (ADR-0039 slice 2): `Ready` is
+    // guaranteed there, matching every other backend's contract.
+    platform.run(Box::new(move |owner| {
+        let options = WindowOptions {
+            title: "Background Test - Should be BLACK not white".to_string(),
+            size: Size::new(px(800.0), px(600.0)),
+            resizable: true,
+            visible: true,
+            decorated: true,
+            min_size: None,
+            max_size: None,
+        };
 
-    // Create window before running the event loop (run() takes ownership)
-    let window = platform.open_window(options)?;
+        let window = owner
+            .open_window(options)
+            .and_then(flui_platform::WindowOpen::try_ready)
+            .expect("window creation is always Ready inside on_ready");
 
-    println!("Window created");
-    println!();
-    println!("If background is:");
-    println!("  - WHITE = WM_ERASEBKGND not working (Windows default)");
-    println!("  - BLACK = WM_ERASEBKGND working! (no background drawn)");
-    println!();
+        println!("Window created");
+        println!();
+        println!("If background is:");
+        println!("  - WHITE = WM_ERASEBKGND not working (Windows default)");
+        println!("  - BLACK = WM_ERASEBKGND working! (no background drawn)");
+        println!();
 
-    platform.run(Box::new(move |_platform| {
         // Keep window alive via closure capture
         let _window = window;
     }));

--- a/examples/test_background.rs
+++ b/examples/test_background.rs
@@ -49,7 +49,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // Keep window alive via closure capture
         let _window = window;
-    }));
+        Ok(())
+    }))?;
 
     Ok(())
 }

--- a/examples/web_demo/src/lib.rs
+++ b/examples/web_demo/src/lib.rs
@@ -112,8 +112,11 @@ pub fn start() {
 
     web_sys::console::log_1(&"FLUI Web Demo ready! Try clicking and typing on the canvas.".into());
 
-    platform.run(Box::new(move |_platform| {
-        // Keep window alive via closure capture
-        let _window = window;
-    }));
+    platform
+        .run(Box::new(move |_owner| {
+            // Keep window alive via closure capture
+            let _window = window;
+            Ok(())
+        }))
+        .expect("platform event loop exited with an error");
 }

--- a/examples/wgpu_window.rs
+++ b/examples/wgpu_window.rs
@@ -218,12 +218,15 @@ fn main() {
 
     tracing::info!("Setup complete - starting event loop with wgpu rendering");
 
-    platform.run(Box::new(move |_platform| {
-        tracing::info!("Platform ready");
-        // Keep window and gpu alive via closure capture
-        let _window = &window;
-        let _gpu = &gpu;
-    }));
+    platform
+        .run(Box::new(move |_owner| {
+            tracing::info!("Platform ready");
+            // Keep window and gpu alive via closure capture
+            let _window = &window;
+            let _gpu = &gpu;
+            Ok(())
+        }))
+        .expect("platform event loop exited with an error");
 
     tracing::info!("Application finished");
 }

--- a/examples/window_features.rs
+++ b/examples/window_features.rs
@@ -72,7 +72,8 @@ fn main() -> anyhow::Result<()> {
         tracing::info!("Platform ready, window is open");
         // Keep window alive via closure capture
         let _window = window;
-    }));
+        Ok(())
+    }))?;
 
     tracing::info!("Demo finished!");
     Ok(())

--- a/examples/window_features.rs
+++ b/examples/window_features.rs
@@ -30,41 +30,45 @@ fn main() -> anyhow::Result<()> {
     tracing::info!("Platform: {}", platform.name());
     tracing::info!("OS: {}", std::env::consts::OS);
 
-    // Display information
-    let displays = platform.displays();
-    tracing::info!("Displays:");
-    for (i, disp) in displays.iter().enumerate() {
-        tracing::info!(
-            "  {}. {} - {}x{} @ {:.1}x",
-            i + 1,
-            disp.name(),
-            disp.bounds().size.width,
-            disp.bounds().size.height,
-            disp.scale_factor()
-        );
-    }
+    // Display enumeration and window creation both move inside `on_ready`
+    // (ADR-0039 slice 2): the winit backend can only enumerate real
+    // displays and create windows once its event loop is pumping.
+    platform.run(Box::new(move |owner| {
+        let displays = owner.displays();
+        tracing::info!("Displays:");
+        for (i, disp) in displays.iter().enumerate() {
+            tracing::info!(
+                "  {}. {} - {}x{} @ {:.1}x",
+                i + 1,
+                disp.name(),
+                disp.bounds().size.width,
+                disp.bounds().size.height,
+                disp.scale_factor()
+            );
+        }
 
-    // Create window before running the event loop
-    tracing::info!("Creating window...");
-    let window_options = WindowOptions {
-        title: "Window Features Demo".to_string(),
-        size: Size::new(px(1000.0), px(700.0)),
-        resizable: true,
-        visible: true,
-        decorated: true,
-        min_size: Some(Size::new(px(600.0), px(400.0))),
-        max_size: None,
-    };
+        tracing::info!("Creating window...");
+        let window_options = WindowOptions {
+            title: "Window Features Demo".to_string(),
+            size: Size::new(px(1000.0), px(700.0)),
+            resizable: true,
+            visible: true,
+            decorated: true,
+            min_size: Some(Size::new(px(600.0), px(400.0))),
+            max_size: None,
+        };
 
-    let window = platform.open_window(window_options)?;
-    tracing::info!("Window created!");
-    tracing::info!("  Logical size:  {:?}", window.logical_size());
-    tracing::info!("  Physical size: {:?}", window.physical_size());
-    tracing::info!("  Scale factor:  {:.1}x", window.scale_factor());
-    tracing::info!("  Visible:       {}", window.is_visible());
-    tracing::info!("  Focused:       {}", window.is_focused());
+        let window = owner
+            .open_window(window_options)
+            .and_then(flui_platform::WindowOpen::try_ready)
+            .expect("window creation is always Ready inside on_ready");
+        tracing::info!("Window created!");
+        tracing::info!("  Logical size:  {:?}", window.logical_size());
+        tracing::info!("  Physical size: {:?}", window.physical_size());
+        tracing::info!("  Scale factor:  {:.1}x", window.scale_factor());
+        tracing::info!("  Visible:       {}", window.is_visible());
+        tracing::info!("  Focused:       {}", window.is_focused());
 
-    platform.run(Box::new(move |_platform| {
         tracing::info!("Platform ready, window is open");
         // Keep window alive via closure capture
         let _window = window;

--- a/examples/windows11_demo.rs
+++ b/examples/windows11_demo.rs
@@ -40,35 +40,38 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create platform (Box<dyn Platform> - run() takes ownership)
     let platform: Box<dyn Platform> = Box::new(WindowsPlatform::new()?);
 
-    // Create window - Windows 11 features applied automatically!
-    let options = WindowOptions {
-        title: "Windows 11 Features Demo".to_string(),
-        size: Size::new(px(1000.0), px(700.0)),
-        resizable: true,
-        visible: true,
-        decorated: true,
-        min_size: Some(Size::new(px(600.0), px(400.0))),
-        max_size: None,
-    };
+    // Window creation moves inside `on_ready` (ADR-0039 slice 2): `Ready` is
+    // guaranteed there, matching every other backend's contract.
+    platform.run(Box::new(|owner| {
+        let options = WindowOptions {
+            title: "Windows 11 Features Demo".to_string(),
+            size: Size::new(px(1000.0), px(700.0)),
+            resizable: true,
+            visible: true,
+            decorated: true,
+            min_size: Some(Size::new(px(600.0), px(400.0))),
+            max_size: None,
+        };
 
-    let _window = platform.open_window(options)?;
+        let _window = owner
+            .open_window(options)
+            .and_then(flui_platform::WindowOpen::try_ready)
+            .expect("window creation is always Ready inside on_ready");
 
-    println!("✅ Window created successfully!");
-    println!();
-    println!("🎨 Windows 11 features applied automatically:");
-    println!("  ✓ Mica backdrop - translucent background with blur");
-    println!("  ✓ Dark mode title bar - matches your Windows theme");
-    println!("  ✓ Rounded corners - modern Windows 11 style");
-    println!("  ✓ Snap Layouts - hover over maximize button");
-    println!();
-    println!("💡 These features are built into the platform!");
-    println!("   No manual DWM API calls needed in your code.");
-    println!();
-    println!("Close the window to exit");
-    println!();
-
-    // Run the platform event loop
-    platform.run(Box::new(|_platform| {}));
+        println!("✅ Window created successfully!");
+        println!();
+        println!("🎨 Windows 11 features applied automatically:");
+        println!("  ✓ Mica backdrop - translucent background with blur");
+        println!("  ✓ Dark mode title bar - matches your Windows theme");
+        println!("  ✓ Rounded corners - modern Windows 11 style");
+        println!("  ✓ Snap Layouts - hover over maximize button");
+        println!();
+        println!("💡 These features are built into the platform!");
+        println!("   No manual DWM API calls needed in your code.");
+        println!();
+        println!("Close the window to exit");
+        println!();
+    }));
 
     Ok(())
 }

--- a/examples/windows11_demo.rs
+++ b/examples/windows11_demo.rs
@@ -71,7 +71,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!();
         println!("Close the window to exit");
         println!();
-    }));
+        Ok(())
+    }))?;
 
     Ok(())
 }

--- a/examples/windows11_features.rs
+++ b/examples/windows11_features.rs
@@ -138,7 +138,8 @@ fn main() -> anyhow::Result<()> {
 
         // Keep window alive via closure capture
         let _window = window;
-    }));
+        Ok(())
+    }))?;
 
     println!("Demo finished!");
     Ok(())

--- a/examples/windows11_features.rs
+++ b/examples/windows11_features.rs
@@ -63,75 +63,79 @@ fn main() -> anyhow::Result<()> {
     // Create platform (Box<dyn Platform> - run() takes ownership)
     let platform: Box<dyn flui_platform::Platform> = Box::new(WindowsPlatform::new()?);
 
-    // Create window before running the event loop (run() takes ownership)
-    let window_options = WindowOptions {
-        title: "Windows 11 Features Demo".to_string(),
-        size: Size::new(px(1000.0), px(700.0)),
-        resizable: true,
-        visible: true,
-        decorated: true,
-        min_size: Some(Size::new(px(600.0), px(400.0))),
-        max_size: None,
-    };
+    // Window creation moves inside `on_ready` (ADR-0039 slice 2): `Ready` is
+    // guaranteed there, matching every other backend's contract.
+    platform.run(Box::new(move |owner| {
+        let window_options = WindowOptions {
+            title: "Windows 11 Features Demo".to_string(),
+            size: Size::new(px(1000.0), px(700.0)),
+            resizable: true,
+            visible: true,
+            decorated: true,
+            min_size: Some(Size::new(px(600.0), px(400.0))),
+            max_size: None,
+        };
 
-    let window = platform.open_window(window_options)?;
+        let window = owner
+            .open_window(window_options)
+            .and_then(flui_platform::WindowOpen::try_ready)
+            .expect("window creation is always Ready inside on_ready");
 
-    println!("Window created successfully!");
-    println!("  Logical size: {:?}", window.logical_size());
-    println!("  Physical size: {:?}", window.physical_size());
-    println!("  Scale factor: {:.1}x", window.scale_factor());
-    println!();
+        println!("Window created successfully!");
+        println!("  Logical size: {:?}", window.logical_size());
+        println!("  Physical size: {:?}", window.physical_size());
+        println!("  Scale factor: {:.1}x", window.scale_factor());
+        println!();
 
-    // Show available Windows 11 features
-    println!("Applying Windows 11 features...");
+        // Show available Windows 11 features
+        println!("Applying Windows 11 features...");
 
-    // Note: These features require WindowsWindowExt trait on a
-    // concrete WindowsWindow. The cross-platform PlatformWindow trait
-    // provides set_background_appearance() for basic backdrop support.
-    println!("  Setting Mica backdrop (via set_background_appearance)");
-    println!("  Enabling dark mode");
-    println!("  Setting rounded corners");
-    println!("  Setting custom title bar color");
-    println!();
+        // Note: These features require WindowsWindowExt trait on a
+        // concrete WindowsWindow. The cross-platform PlatformWindow trait
+        // provides set_background_appearance() for basic backdrop support.
+        println!("  Setting Mica backdrop (via set_background_appearance)");
+        println!("  Enabling dark mode");
+        println!("  Setting rounded corners");
+        println!("  Setting custom title bar color");
+        println!();
 
-    // Show available types for reference
-    println!(
-        "Available backdrop types: {:?}",
-        [
-            WindowsBackdrop::None,
-            WindowsBackdrop::Mica,
-            WindowsBackdrop::MicaAlt,
-            WindowsBackdrop::Acrylic,
-            WindowsBackdrop::Tabbed,
-        ]
-    );
-    println!(
-        "Available corner preferences: {:?}",
-        [
-            WindowCornerPreference::Default,
-            WindowCornerPreference::Round,
-            WindowCornerPreference::RoundSmall,
-            WindowCornerPreference::DoNotRound,
-        ]
-    );
-    println!(
-        "Available themes: {:?}",
-        [
-            WindowsTheme::Light,
-            WindowsTheme::Dark,
-            WindowsTheme::System,
-        ]
-    );
-    println!();
+        // Show available types for reference
+        println!(
+            "Available backdrop types: {:?}",
+            [
+                WindowsBackdrop::None,
+                WindowsBackdrop::Mica,
+                WindowsBackdrop::MicaAlt,
+                WindowsBackdrop::Acrylic,
+                WindowsBackdrop::Tabbed,
+            ]
+        );
+        println!(
+            "Available corner preferences: {:?}",
+            [
+                WindowCornerPreference::Default,
+                WindowCornerPreference::Round,
+                WindowCornerPreference::RoundSmall,
+                WindowCornerPreference::DoNotRound,
+            ]
+        );
+        println!(
+            "Available themes: {:?}",
+            [
+                WindowsTheme::Light,
+                WindowsTheme::Dark,
+                WindowsTheme::System,
+            ]
+        );
+        println!();
 
-    println!("All features applied!");
-    println!();
-    println!("Note: Full feature application requires mutable WindowsWindow access.");
-    println!("This demo shows the API - full integration requires event loop.");
-    println!();
-    println!("Hover over the maximize button to see Snap Layouts!");
+        println!("All features applied!");
+        println!();
+        println!("Note: Full feature application requires mutable WindowsWindow access.");
+        println!("This demo shows the API - full integration requires event loop.");
+        println!();
+        println!("Hover over the maximize button to see Snap Layouts!");
 
-    platform.run(Box::new(move |_platform| {
         // Keep window alive via closure capture
         let _window = window;
     }));

--- a/scripts/check-frame-capability-scope.sh
+++ b/scripts/check-frame-capability-scope.sh
@@ -4,7 +4,7 @@
 # not be acquired from a build / layout / paint / composite body.
 #
 # A lifecycle-only capability lets code affect presentation state outside the
-# build/layout/paint transaction. Four are exposed through `BuildContext`:
+# build/layout/paint transaction. Five are guarded:
 #
 #   rebuild_handle()    ADR-0018 U1 — `RebuildHandle::schedule()` marks an element
 #                       dirty for the next frame.
@@ -17,9 +17,21 @@
 #   focus_manager()     ADR-0037 — returns the presentation's concrete focus
 #                       owner; imperative focus changes synchronously notify
 #                       listeners and may schedule rebuilds.
+#   owner_platform()    ADR-0039 §6 — `with_owner_platform` in flui-app's
+#                       runner reaches the loop-scoped `!Send` owner-thread
+#                       platform capability; acquiring it from `build`/
+#                       `layout`/`paint` would let presentation code enqueue
+#                       owner-lane platform work (e.g. `open_window`) mid-frame
+#                       transaction, ahead of trigger #22's other four via the
+#                       same ambient-authority hazard.
 #
-# All four must be acquired in `ViewState::init_state` / `did_change_dependencies`,
-# stored, and fired later from a callback.
+# The first four are exposed through `BuildContext`; `owner_platform` is a
+# free function in flui-app, not a `BuildContext` method — the scanner is a
+# textual token match, not a method-call parse, so it is caught the same way.
+# All five must be acquired in `ViewState::init_state` / `did_change_dependencies`
+# (the `BuildContext` four) or outside any guarded body entirely
+# (`owner_platform`, which is composition-root-only, `pub(crate)` to
+# `flui-app`'s app module), stored, and fired later from a callback.
 #
 # Acquiring one inside `build` and scheduling from it is an unbounded rebuild loop
 # (rebuild) or a callback that fires against the very frame that is still running
@@ -46,7 +58,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 guarded_fns='build|build_into_views|perform_layout|layout_node_with_children|paint|paint_raw|run_paint|run_layout|run_compositing|compose|composite'
 
 # The capabilities themselves. Adding one here is the whole cost of guarding it.
-capabilities='rebuild_handle|post_frame_handle|text_input_handle|focus_manager'
+capabilities='rebuild_handle|post_frame_handle|text_input_handle|focus_manager|owner_platform'
 
 scan() {
   awk -v guarded="${guarded_fns}" -v caps="${capabilities}" '
@@ -92,17 +104,17 @@ self_test() {
     scan "${fixtures}/rejected.rs.fixture" 2>/dev/null | sed 's/^/  /' || true
     local found
     found=$(scan "${fixtures}/rejected.rs.fixture" 2>/dev/null | wc -l || true)
-    if [[ "${found}" -ne 7 ]]; then
-      echo "  FAIL: expected 7 violations across all four lifecycle-only capability tokens, got ${found}"
+    if [[ "${found}" -ne 8 ]]; then
+      echo "  FAIL: expected 8 violations across all five lifecycle-only capability tokens, got ${found}"
       status=1
     else
-      echo "  ok: 7 violations reported"
+      echo "  ok: 8 violations reported"
     fi
     # Every capability token must actually be named — a scanner can otherwise
     # report the expected count while silently leaving a newer capability open.
     local reported
     reported=$(scan "${fixtures}/rejected.rs.fixture" 2>/dev/null || true)
-    for cap in rebuild_handle post_frame_handle text_input_handle focus_manager; do
+    for cap in rebuild_handle post_frame_handle text_input_handle focus_manager owner_platform; do
       if ! grep -q "${cap}()" <<<"${reported}"; then
         echo "  FAIL: scanner never reported a ${cap}() violation"
         status=1

--- a/scripts/fixtures/frame-capability/rejected.rs.fixture
+++ b/scripts/fixtures/frame-capability/rejected.rs.fixture
@@ -7,9 +7,9 @@
 // phase. Every guarded token appears, so adding a capability to the scanner
 // without adding a fixture cannot create a false sense of coverage.
 //
-// Prose mentioning rebuild_handle, post_frame_handle, text_input_handle, or
-// focus_manager in a comment must NOT count as a violation; this line proves
-// the comment filter works.
+// Prose mentioning rebuild_handle, post_frame_handle, text_input_handle,
+// focus_manager, or owner_platform in a comment must NOT count as a
+// violation; this line proves the comment filter works.
 
 impl StatelessView for Loop {
     fn build(&self, ctx: &dyn BuildContext) -> impl IntoView {
@@ -22,6 +22,9 @@ impl StatelessView for Loop {
         let text_input = ctx.text_input_handle();
         // Makes imperative focus mutation reachable from build.
         let focus = ctx.focus_manager();
+        // Ambient owner-thread platform access from mid-frame presentation
+        // code (ADR-0039 §6) — the same hazard trigger #22 exists to fence.
+        with_owner_platform(|owner| owner.quit());
         Text::new("boom")
     }
 }


### PR DESCRIPTION
Implements **ADR-0039 slice 2** for #551: owner-thread-only platform operations get their compile-time capability. `OwnerPlatform` (`!Send + !Sync`, minted only by a backend on the event-loop owner thread) is handed to `on_ready` by value; workers reach the owner through the typed, bounded `PlatformProxy`; the winit owner lane's buffered one-shot reply is replaced by an at-most-once **claim-slot** protocol with guaranteed orphan-window unwind. Slice 1 (`OwnerAffinity`) landed earlier; slice 3 (trait surgery, lane generalization to macOS/Win32) stays gated on Android on-device validation per the ADR.

## What lands

- **`flui_foundation::ClaimSlot<T>`/`ClaimHandle<T>`** — the at-most-once request/reply state machine (`Pending → Delivered → Claimed | Abandoned`), homed in flui-foundation so its tests run in CI (same rationale as slice 1's `OwnerAffinity`). 10 CI-run tests.
- **`flui_platform::{OwnerPlatform, WindowOpen, OpenWindowError, PlatformProxy, ProxySendError, PendingWindow, WaitError}`** (`traits/owner.rs`) — the ADR §1/§3 surface. `OwnerPlatform` is deliberately **not `Clone`** (acquisition discipline; the TLS host is the only stash). `#[non_exhaustive]` on `OpenWindowError`/`WaitError` (slice 3 grows them); `WindowOpen`/`ProxySendError` deliberately exhaustive. Item-position `static_assertions` fences (`static_assertions` promoted to a real dependency) are the load-bearing CI evidence that wrong-thread owner ops are compile errors — enforced by every `cargo check` including cross-typecheck.
- **`PlatformReadyCallback` flip** (breaking): `Box<dyn FnOnce(&dyn Platform)>` → `Box<dyn FnOnce(OwnerPlatform)>`, across all 8 backends in one PR (also fixes the pre-existing iOS `run` signature mismatch). `Platform` is now de-facto crate-sealed (out-of-crate implementors cannot mint the capability) — documented as policy; an external-embedder minting seam is #560 design work.
- **Winit claim-slot lane + handler-dispatch hoist**: post-bootstrap owner-thread `open_window` now *defers* (enqueue → `Pending`, resolved at the `user_event` drain anchor) instead of erroring `OwnerWouldBlock`; dropped requesters can no longer leak windows in any ordering (skip-before-creation / unwind-after-delivery, exercised by two real-event-loop tests). `invoke_window_event` handlers are invoked outside the state mutex via a panic-safe lease — the deadlock precondition ADR-0039 Alternative G names.
- **`OWNER_PLATFORM_HOST` TLS in flui-app** with three fences: `pub(crate)` borrow-style `with_owner_platform` accessor (never re-exported), the `owner_platform` token added to the trigger-#22 scanner (`check-frame-capability-scope.sh`, self-test extended), and a frame-phase `debug_assert` (forbidden during frame-transaction phases, allowed Idle/PostFrame). Unwind-safe clear guard; hot-restart survival tested.
- **Pre-run flows migrated into `on_ready`**: `bootstrap_desktop`, `run_direct` (its winit fast-fail is gone — stays `experimental` by policy), web bootstrap, Android bootstrap (now at first `Resume`, the backend's own documented intent), and the four Win32 examples.
- **ADR-0039 → Accepted (2026-08-03)** via revise-and-accept: nine amendments recording exactly what shipped (claim-slot home, permanent-`OwnerGone` posture on lane-less backends, no-Clone ruling, `try_ready` naming, non_exhaustive matrix, fence semantics, crate-seal, corrected registry-bound statement, `OwnerHooks` seam). Conformance registry updated: 2 contracts advance to `partial` with real evidence, 4 new `[[surface]]` entries (all `experimental`, owner #551), export-root pins updated — `just runtime-conformance-check` green.

## Breaking changes (pre-1.0, sanctioned by ADR-0027 §9)

1. `PlatformReadyCallback` signature — every `Platform::run` caller/implementor updated in this PR.
2. `run_direct`/`run_app_android`/web bootstrap open their windows inside `on_ready` now (pre-run `open_window` on those paths is gone).
3. Behavior notes: post-bootstrap owner-thread `open_window` on winit resolves a turn later (`Pending`); a requester that drops its `PendingWindow` mid-flight gets its window unwound (flicker instead of leak); winit `on_window_event` handlers now run *outside* the platform state lock.

## Review process

Plan (chief-architect, maintainer-grade verdict) → adversarial plan review (harsh-critic + api-design-lead: 20 findings, all folded or explicitly rejected with reasons; e.g. Clone dropped, `try_ready` rename, static_assertions dev-dep trap fixed) → build (11+6 commits, red→green evidence for claim-slot, TLS host, fence, unwind and regression tests) → spec-compliance review (1 blocker: two missing lane tests — added, driving a real winit event loop) → code-quality review (2 MAJOR + 11 more findings — all fixed, incl. a reachable `wait`-after-`try_take` panic replaced by typed `WaitError::AlreadyClaimed`).

## Verification

- `just ci` — exit 0 (fmt, inventory, conformance, port-check, clippy `-D warnings`, nextest, doctests)
- `cargo nextest run`: flui-foundation 220/220, flui-app 139/139, flui-platform `--all-features` 152 passed with the same 11 pre-existing display-server-dependent failures as `main` (stash-verified; crate is CI-excluded) — 0 regressions
- `just cross-typecheck` (Win32 + AppKit mirror of CI) — clean; wasm32 check — clean
- `check-frame-capability-scope.sh --self-test` — green (8 violations, 5 tokens)
- Screenshot harness (`--example screenshot -- material`) — PNG verified

## Honest gaps

- **Android**: migrated per the ADR's own documented `Resumed → on_ready() → create surface` sequence, but on-device validation (incl. surface recreation on later Resume/Pause) is impossible here — it remains the ADR's stated gate on slice 3. `cargo check --target aarch64-linux-android` is blocked by a **pre-existing** `unsafe-op-in-unsafe-fn` bug in `android/memory.rs` (identical on `main`; needs its own trivial PR). One genuine Arc-coercion bug this branch introduced on that path was caught by the Android cross-check and fixed.
- **Two public paths** to the new types exist (`flui_platform::OwnerPlatform` and `flui_platform::traits::OwnerPlatform`) — matches the crate's existing convention for platform types; the sealed `owner` module itself is `pub(crate)`. Collapsing to one path is a mechanical follow-up if wanted.
- The winit module (incl. the new lane tests) compiles only under `winit-backend` (not in default features) — noted in `crates/flui-platform/AGENTS.md`; use `--all-features` locally.
- No CI-executed test drives a real winit event loop (flui-platform is CI-excluded pending STATUS_HEAP_CORRUPTION); the two lane tests run locally and are part of the local gate.

Closes nothing by itself — #551 completes with slice 3 (macOS/Win32 lane adoption + drain gates + trait surgery), gated on Android validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
