### PR TITLE
feat(app): generational presentation addressing across platform, UI, semantics, and raster

### DIFF
--- a/crates/flui-app/src/app/binding.rs
+++ b/crates/flui-app/src/app/binding.rs
@@ -1415,6 +1415,38 @@ impl AppBinding {
         realm: &super::ui_realm::UiRealm,
         input: PlatformInput,
     ) {
+        // Lifecycle gate at the physical owner (ADR-0037 §9). `Closing`/
+        // `Closed` is a hard gate: no input of any kind is dispatched.
+        // `Suspended` drops pointer input only (gesture-arena protection);
+        // keyboard and IME keep flowing so a flaky or absent occlusion
+        // signal (the web backend wires none) never becomes a keystroke
+        // blackout. `Created` has no arm of its own: it is
+        // constructor-internal and production-unreachable (see
+        // `PresentationState::new`), so it falls through with
+        // `SurfaceAttached` rather than pretending to be a tested case.
+        use super::presentation::PresentationLifecycle;
+        match realm.presentation_lifecycle() {
+            PresentationLifecycle::Closing | PresentationLifecycle::Closed => {
+                tracing::debug!(
+                    { flui_foundation::diagnostics::PRESENTATION_ID } =
+                        realm.presentation_id().as_u64(),
+                    ?input,
+                    "dropping input: presentation is closing or closed"
+                );
+                return;
+            }
+            PresentationLifecycle::Suspended => {
+                if matches!(input, PlatformInput::Pointer(_)) {
+                    tracing::debug!(
+                        { flui_foundation::diagnostics::PRESENTATION_ID } =
+                            realm.presentation_id().as_u64(),
+                        "dropping pointer input while the presentation is suspended"
+                    );
+                    return;
+                }
+            }
+            PresentationLifecycle::Created | PresentationLifecycle::SurfaceAttached => {}
+        }
         match input {
             PlatformInput::Ime(ime_event) => {
                 realm.text_input().dispatch(&ime_event);
@@ -1749,7 +1781,7 @@ mod tests {
             )),
         );
 
-        // Production input arrives inside the realm (runner.rs's RealmEvent
+        // Production input arrives inside the realm (runner.rs's PlatformToUi
         // dispatch enters it before calling handle_input), so the synthetic
         // tap does the same.
         let position = flui_types::Offset::new(px(50.0), px(50.0));
@@ -1775,6 +1807,113 @@ mod tests {
             "the outer tap recognizer shares the arena and must be rejected — \
              if both fire, each detector built its own private arena (no shell \
              GestureArenaScope above the root)",
+        );
+    }
+
+    /// Coordinator ruling (ADR-0037 §9): `Suspended` drops pointer input only
+    /// — gesture-arena protection — while keyboard/IME continue to flow. A
+    /// flaky or absent occlusion signal (the web backend wires none) must
+    /// never become a keystroke blackout.
+    ///
+    /// Red-check: remove the `Suspended` pointer-only arm from
+    /// `handle_input_entered` and the pointer assertions below fail (the
+    /// arena receives the down and `needs_redraw` is armed even though the
+    /// presentation is suspended).
+    #[test]
+    fn pointer_input_is_dropped_while_suspended_but_keyboard_flows() {
+        use flui_interaction::events::{PointerType, make_down_event};
+
+        let app = AppBinding::new();
+        let realm = test_realm(&app);
+        realm.handle_presentation_lifecycle(AppLifecycleState::Hidden);
+
+        let position = flui_types::Offset::new(px(50.0), px(50.0));
+        realm.enter(|realm| {
+            app.handle_input_entered(
+                realm,
+                PlatformInput::Pointer(make_down_event(position, PointerType::Mouse)),
+            );
+        });
+        assert_eq!(
+            realm.gestures().active_pointer_count(),
+            0,
+            "a pointer down while suspended must never reach the gesture arena"
+        );
+        assert!(
+            !app.needs_redraw(),
+            "a dropped pointer event must never arm a redraw"
+        );
+
+        // Keyboard/IME keep flowing while suspended: falling through to the
+        // ordinary dispatch path is observable because that path (unlike the
+        // pointer early-return above) always requests a redraw.
+        realm.enter(|realm| {
+            app.handle_input_entered(
+                realm,
+                PlatformInput::Ime(flui_types::ImeEvent::Commit("suspended-ime".to_string())),
+            );
+        });
+        assert!(
+            app.needs_redraw(),
+            "IME input must keep flowing while the presentation is only suspended"
+        );
+
+        // Resume: pointer flows again.
+        app.mark_rendered();
+        realm.handle_presentation_lifecycle(AppLifecycleState::Resumed);
+        realm.enter(|realm| {
+            app.handle_input_entered(
+                realm,
+                PlatformInput::Pointer(make_down_event(position, PointerType::Mouse)),
+            );
+        });
+        assert_eq!(
+            realm.gestures().active_pointer_count(),
+            1,
+            "pointer input must reach the arena again once resumed"
+        );
+    }
+
+    /// Coordinator ruling (ADR-0037 §9): `Closing`/`Closed` is a hard gate —
+    /// every input kind is dropped, not just pointer.
+    ///
+    /// Red-check: remove the `Closing | Closed` hard-gate arm from
+    /// `handle_input_entered` and the IME assertion below fails (a "closed"
+    /// presentation still dispatches and arms a redraw).
+    #[test]
+    fn all_input_dropped_after_close() {
+        use flui_interaction::events::{PointerType, make_down_event};
+
+        let app = AppBinding::new();
+        let realm = test_realm(&app);
+        realm.handle_presentation_lifecycle(AppLifecycleState::Detached);
+
+        let position = flui_types::Offset::new(px(50.0), px(50.0));
+        realm.enter(|realm| {
+            app.handle_input_entered(
+                realm,
+                PlatformInput::Pointer(make_down_event(position, PointerType::Mouse)),
+            );
+        });
+        assert_eq!(
+            realm.gestures().active_pointer_count(),
+            0,
+            "pointer input must never reach the arena once closed"
+        );
+        assert!(
+            !app.needs_redraw(),
+            "no input at all may reach dispatch once closed"
+        );
+
+        realm.enter(|realm| {
+            app.handle_input_entered(
+                realm,
+                PlatformInput::Ime(flui_types::ImeEvent::Commit("closed-ime".to_string())),
+            );
+        });
+        assert!(
+            !app.needs_redraw(),
+            "IME input must also be dropped once closed — the hard gate covers every kind"
         );
     }
 

--- a/crates/flui-app/src/app/binding.rs
+++ b/crates/flui-app/src/app/binding.rs
@@ -41,7 +41,7 @@ use flui_animation::Vsync;
 use flui_engine::{EngineError, RasterBackend};
 use flui_foundation::HasInstance;
 use flui_layer::{Layer, LayerTree, PerformanceOverlayLayer, PerformanceStats, Scene};
-use flui_platform::traits::{Clipboard, PlatformInput, PlatformWindow};
+use flui_platform::traits::{Clipboard, DragDropEvent, PlatformInput, PlatformWindow};
 use flui_rendering::binding::RendererBinding;
 use flui_rendering::constraints::BoxConstraints;
 use flui_scheduler::{AppLifecycleState, Scheduler};
@@ -1415,37 +1415,18 @@ impl AppBinding {
         realm: &super::ui_realm::UiRealm,
         input: PlatformInput,
     ) {
-        // Lifecycle gate at the physical owner (ADR-0037 §9). `Closing`/
-        // `Closed` is a hard gate: no input of any kind is dispatched.
-        // `Suspended` drops pointer input only (gesture-arena protection);
-        // keyboard and IME keep flowing so a flaky or absent occlusion
-        // signal (the web backend wires none) never becomes a keystroke
-        // blackout. `Created` has no arm of its own: it is
-        // constructor-internal and production-unreachable (see
-        // `PresentationState::new`), so it falls through with
-        // `SurfaceAttached` rather than pretending to be a tested case.
-        use super::presentation::PresentationLifecycle;
-        match realm.presentation_lifecycle() {
-            PresentationLifecycle::Closing | PresentationLifecycle::Closed => {
-                tracing::debug!(
-                    { flui_foundation::diagnostics::PRESENTATION_ID } =
-                        realm.presentation_id().as_u64(),
-                    ?input,
-                    "dropping input: presentation is closing or closed"
-                );
-                return;
-            }
-            PresentationLifecycle::Suspended => {
-                if matches!(input, PlatformInput::Pointer(_)) {
-                    tracing::debug!(
-                        { flui_foundation::diagnostics::PRESENTATION_ID } =
-                            realm.presentation_id().as_u64(),
-                        "dropping pointer input while the presentation is suspended"
-                    );
-                    return;
-                }
-            }
-            PresentationLifecycle::Created | PresentationLifecycle::SurfaceAttached => {}
+        // Lifecycle gate at the physical owner (ADR-0037 §9), decided by an
+        // explicit, exhaustive policy over (lifecycle, input kind) — see
+        // `input_dropped_by_lifecycle` for the policy itself and why each
+        // arm is what it is.
+        if input_dropped_by_lifecycle(realm.presentation_lifecycle(), &input) {
+            tracing::debug!(
+                { flui_foundation::diagnostics::PRESENTATION_ID } = realm.presentation_id().as_u64(),
+                lifecycle = ?realm.presentation_lifecycle(),
+                input_kind = input_kind(&input),
+                "dropping input due to presentation lifecycle"
+            );
+            return;
         }
         match input {
             PlatformInput::Ime(ime_event) => {
@@ -1500,12 +1481,83 @@ impl AppBinding {
                 // the realm-side routing — drop-target resolution and the
                 // DropFeedback loop — does not exist yet, so the event is
                 // deliberately logged and dropped rather than half-routed.
+                // Only the session-stage discriminator is logged, never the
+                // event itself: it carries the transfer offer (STYLE.md
+                // forbids logging drag-and-drop payloads, same as text-input
+                // content).
                 tracing::debug!(
-                    event = ?drag_drop_event,
+                    drag_drop_kind = drag_drop_kind(&drag_drop_event),
                     "drag-and-drop input received; realm routing not implemented yet (ADR-0038), dropping"
                 );
             }
         }
+    }
+}
+
+/// Whether [`AppBinding::handle_input_entered`] must drop `input` outright,
+/// before ever reaching the per-kind dispatch above, given the
+/// presentation's current lifecycle (ADR-0037 §9).
+///
+/// Explicit and exhaustive over **both** axes — lifecycle and input kind —
+/// with no wildcard on the input axis: adding a `PlatformInput` variant
+/// breaks this match at compile time instead of silently falling through a
+/// `_` arm. (`PlatformInput` is not `#[non_exhaustive]` today; if it becomes
+/// one, this match needs an explicit arm per existing variant plus a
+/// deny-by-default final arm that drops and traces at `warn`, so an unknown
+/// future variant fails safe instead of silently flowing through.)
+///
+/// - `Created`: constructor-internal and production-unreachable post-
+///   construction (`PresentationState::new` self-attaches its surface), but
+///   it must never silently allow input if it were ever reached — no
+///   surface is attached yet.
+/// - `Closing`/`Closed`: teardown has started or finished; no input of any
+///   kind.
+/// - `Suspended`: pointer and drag-drop are dropped (gesture-arena /
+///   no-surface-to-react-to protection); keyboard and IME keep flowing —
+///   the standing web-occlusion rationale: the web backend wires no
+///   occlusion signal at all, so a hard gate here would silently blackout
+///   keystrokes on that backend the moment focus/visibility looks
+///   ambiguous.
+/// - `SurfaceAttached`: nothing is dropped here.
+fn input_dropped_by_lifecycle(
+    lifecycle: super::presentation::PresentationLifecycle,
+    input: &PlatformInput,
+) -> bool {
+    use super::presentation::PresentationLifecycle;
+    match lifecycle {
+        PresentationLifecycle::Created
+        | PresentationLifecycle::Closing
+        | PresentationLifecycle::Closed => true,
+        PresentationLifecycle::Suspended => match input {
+            PlatformInput::Pointer(_) | PlatformInput::DragDrop(_) => true,
+            PlatformInput::Keyboard(_) | PlatformInput::Ime(_) => false,
+        },
+        PresentationLifecycle::SurfaceAttached => false,
+    }
+}
+
+/// A safe, content-free discriminator for a [`PlatformInput`] — never the
+/// payload itself. STYLE.md forbids logging text-input/IME and drag-and-drop
+/// payloads (composition text, keystrokes, dragged offer contents); this is
+/// the only thing about an input event that may reach a trace/log line.
+/// Exhaustive for the same reason as [`input_dropped_by_lifecycle`].
+fn input_kind(input: &PlatformInput) -> &'static str {
+    match input {
+        PlatformInput::Pointer(_) => "pointer",
+        PlatformInput::Keyboard(_) => "keyboard",
+        PlatformInput::Ime(_) => "ime",
+        PlatformInput::DragDrop(_) => "drag_drop",
+    }
+}
+
+/// A safe, content-free discriminator for a [`DragDropEvent`] — never the
+/// carried offer/payload (STYLE.md forbids logging drag-and-drop payloads).
+fn drag_drop_kind(event: &DragDropEvent) -> &'static str {
+    match event {
+        DragDropEvent::Entered { .. } => "entered",
+        DragDropEvent::Moved { .. } => "moved",
+        DragDropEvent::Dropped { .. } => "dropped",
+        DragDropEvent::Exited { .. } => "exited",
     }
 }
 
@@ -1810,12 +1862,12 @@ mod tests {
         );
     }
 
-    /// Coordinator ruling (ADR-0037 §9): `Suspended` drops pointer input only
-    /// — gesture-arena protection — while keyboard/IME continue to flow. A
-    /// flaky or absent occlusion signal (the web backend wires none) must
-    /// never become a keystroke blackout.
+    /// `Suspended` drops pointer input only — gesture-arena protection —
+    /// while keyboard/IME continue to flow (ADR-0037 §9). A flaky or absent
+    /// occlusion signal (the web backend wires none) must never become a
+    /// keystroke blackout.
     ///
-    /// Red-check: remove the `Suspended` pointer-only arm from
+    /// If reverted: remove the `Suspended` pointer-only arm from
     /// `handle_input_entered` and the pointer assertions below fail (the
     /// arena receives the down and `needs_redraw` is armed even though the
     /// presentation is suspended).
@@ -1874,10 +1926,10 @@ mod tests {
         );
     }
 
-    /// Coordinator ruling (ADR-0037 §9): `Closing`/`Closed` is a hard gate —
-    /// every input kind is dropped, not just pointer.
+    /// `Closing`/`Closed` is a hard gate (ADR-0037 §9): every input kind is
+    /// dropped, not just pointer.
     ///
-    /// Red-check: remove the `Closing | Closed` hard-gate arm from
+    /// If reverted: remove the `Closing | Closed` hard-gate arm from
     /// `handle_input_entered` and the IME assertion below fails (a "closed"
     /// presentation still dispatches and arms a redraw).
     #[test]
@@ -1915,6 +1967,75 @@ mod tests {
             !app.needs_redraw(),
             "IME input must also be dropped once closed — the hard gate covers every kind"
         );
+    }
+
+    /// Exhaustively pins `input_dropped_by_lifecycle`'s policy over every
+    /// `(lifecycle, input kind)` pair, including `DragDrop` — previously
+    /// only `Pointer` was checked against a `matches!`, so a `DragDrop` event
+    /// silently flowed through a `Suspended` presentation instead of being
+    /// dropped alongside pointer input for the same no-surface-to-react-to
+    /// reason.
+    ///
+    /// If reverted: restore the old `matches!(input, PlatformInput::Pointer(_))`
+    /// check in place of the exhaustive match and the `Suspended` +
+    /// `DragDrop` case fails (`assert!` sees `false` instead of `true`).
+    #[test]
+    fn input_lifecycle_gate_is_exhaustive_and_explicit() {
+        use flui_interaction::events::{PointerType, make_down_event};
+        use flui_interaction::testing::input::KeyEventBuilder;
+        use flui_platform::traits::DragDropEvent;
+
+        use super::super::presentation::PresentationLifecycle;
+
+        let pointer = PlatformInput::Pointer(make_down_event(
+            flui_types::Offset::new(px(0.0), px(0.0)),
+            PointerType::Mouse,
+        ));
+        let keyboard = PlatformInput::Keyboard(
+            KeyEventBuilder::new(flui_interaction::events::Code::KeyA).build(),
+        );
+        let ime = PlatformInput::Ime(flui_types::ImeEvent::Commit("x".to_string()));
+        let drag_drop = PlatformInput::DragDrop(DragDropEvent::Exited {
+            id: flui_foundation::DataTransferId::new(1),
+        });
+        let every_kind = [&pointer, &keyboard, &ime, &drag_drop];
+
+        for lifecycle in [
+            PresentationLifecycle::Created,
+            PresentationLifecycle::Closing,
+            PresentationLifecycle::Closed,
+        ] {
+            for input in every_kind {
+                assert!(
+                    input_dropped_by_lifecycle(lifecycle, input),
+                    "{lifecycle:?} must reject every input kind, including {input:?}"
+                );
+            }
+        }
+
+        assert!(input_dropped_by_lifecycle(
+            PresentationLifecycle::Suspended,
+            &pointer
+        ));
+        assert!(
+            input_dropped_by_lifecycle(PresentationLifecycle::Suspended, &drag_drop),
+            "DragDrop must be dropped while suspended, the same as Pointer"
+        );
+        assert!(!input_dropped_by_lifecycle(
+            PresentationLifecycle::Suspended,
+            &keyboard
+        ));
+        assert!(!input_dropped_by_lifecycle(
+            PresentationLifecycle::Suspended,
+            &ime
+        ));
+
+        for input in every_kind {
+            assert!(!input_dropped_by_lifecycle(
+                PresentationLifecycle::SurfaceAttached,
+                input
+            ));
+        }
     }
 
     /// Deadline keep-alive regression: a long-press armed by a pointer down
@@ -2631,7 +2752,7 @@ mod tests {
     /// still reaches `AppBinding::instance()` (the real singleton) rather
     /// than the throwaway.
     ///
-    /// Red-check: move the `set_on_frame_scheduled` install back into
+    /// If reverted: move the `set_on_frame_scheduled` install back into
     /// `AppBinding::new()` using a per-construction `wake_handle.into_callback()`
     /// (the original bug this test was written for) and this fails — the
     /// throwaway binding's construction below steals the hook, so the real
@@ -2690,7 +2811,7 @@ mod tests {
     /// spawned OS thread — exactly how a completed async task's waker fires
     /// in production.
     ///
-    /// Red-check: change the hook installed in `instance()` back to
+    /// If reverted: change the hook installed in `instance()` back to
     /// resolving `AppBinding::instance()` inside the closure (fire-time
     /// resolution) and this fails — the spawned thread constructs its own
     /// windowless binding and wakes it instead of `real`.
@@ -3488,7 +3609,7 @@ mod tests {
             realm
         }
 
-        /// Red-check: replace the `retry_needed` branch with an unconditional
+        /// If reverted: replace the `retry_needed` branch with an unconditional
         /// `self.mark_rendered()` (the pre-fix shape) and this fails —
         /// `needs_redraw` comes back `false` after a dropped `SurfaceLost`
         /// frame, so nothing would ever re-drive a static UI back to life.
@@ -3647,7 +3768,7 @@ mod tests {
             realm
         }
 
-        /// Red-check: remove the `send_to_engine` consult in
+        /// If reverted: remove the `send_to_engine` consult in
         /// `render_frame_entered` (fall through to the unconditional present
         /// branch as before this fix) and this fails — `render_scene` gets
         /// called despite the deferral.
@@ -3677,7 +3798,7 @@ mod tests {
             );
         }
 
-        /// Red-check: comment out `allow_first_frame`'s `RepaintHandle`
+        /// If reverted: comment out `allow_first_frame`'s `RepaintHandle`
         /// re-mark (the wake+redirty block) and this fails — `presented`
         /// comes back `false` because the woken frame finds a clean
         /// pipeline (the deferred pass already consumed the dirty work)
@@ -3727,7 +3848,7 @@ mod tests {
         /// `AppBinding::instance()`'s bootstrap installs the real listener
         /// against.
         ///
-        /// Red-check: comment out the redirty call inside
+        /// If reverted: comment out the redirty call inside
         /// `install_frames_reenable_redirty_listener`'s body (leave only
         /// `wake()`) and the final assertion fails — the woken frame finds
         /// a clean pipeline and presents `false` (`FramePaintOutcome::Idle`)
@@ -3793,7 +3914,7 @@ mod tests {
             assert_eq!(backend.render_scene_calls, 2);
         }
 
-        /// Red-check: replace `first_frame_deferred_count.fetch_sub`'s
+        /// If reverted: replace `first_frame_deferred_count.fetch_sub`'s
         /// underflow-checked decrement with an unconditional "count == 0
         /// means open" read that ignores nesting depth, and this fails —
         /// the frame after the FIRST `allow_first_frame()` would present
@@ -3842,7 +3963,7 @@ mod tests {
         /// `allow_first_frame` pair, since `send_frames_to_engine`
         /// short-circuits `true` once sent.
         ///
-        /// Red-check: drop the `!errored` guard around `mark_first_frame_sent`
+        /// If reverted: drop the `!errored` guard around `mark_first_frame_sent`
         /// in `render_frame_entered` and this fails — the errored frame
         /// latches, and the later `defer_first_frame` cannot close the gate.
         #[test]
@@ -4211,7 +4332,7 @@ mod tests {
         /// Real-path proof: `perform_haptic_feedback` reads the binding's
         /// active window and calls through to its `PlatformHaptics`.
         ///
-        /// Red-check: turning `perform_haptic_feedback` into a no-op
+        /// If reverted: turning `perform_haptic_feedback` into a no-op
         /// (dropping the `with_window`/`perform` call) makes this fail —
         /// `fake.calls()` would stay empty.
         #[test]
@@ -4281,7 +4402,7 @@ mod tests {
             (tree, root)
         }
 
-        /// Red-check: this fails if `attach_performance_overlay` stops
+        /// If reverted: this fails if `attach_performance_overlay` stops
         /// honouring the `None` slot and appends unconditionally.
         #[test]
         fn overlay_off_leaves_the_layer_tree_untouched() {
@@ -4297,7 +4418,7 @@ mod tests {
             );
         }
 
-        /// Red-check: this fails if the layer is inserted without being
+        /// If reverted: this fails if the layer is inserted without being
         /// linked to the root — the tree would still grow, but the child and
         /// parent assertions catch the orphan.
         ///
@@ -4391,7 +4512,7 @@ mod tests {
         /// reachable through `AppBinding::clipboard()`, and a write/read
         /// round-trips through the SAME clipboard instance.
         ///
-        /// Red-check: turning `set_platform_clipboard` into a no-op (dropping
+        /// If reverted: turning `set_platform_clipboard` into a no-op (dropping
         /// its `*self.platform_clipboard.lock() = Some(clipboard)` write)
         /// makes this fail — `binding.clipboard()` stays `None` and the
         /// `.expect()` below panics.

--- a/crates/flui-app/src/app/binding.rs
+++ b/crates/flui-app/src/app/binding.rs
@@ -1992,6 +1992,10 @@ mod tests {
         }
 
         impl PlatformWindow for CountingWindow {
+            fn id(&self) -> flui_platform::traits::WindowId {
+                flui_platform::traits::WindowId(1)
+            }
+
             fn physical_size(&self) -> Size<DevicePixels> {
                 Size::new(device_px(800), device_px(600))
             }
@@ -4029,6 +4033,10 @@ mod tests {
         struct BareWindow;
 
         impl PlatformWindow for BareWindow {
+            fn id(&self) -> flui_platform::traits::WindowId {
+                flui_platform::traits::WindowId(1)
+            }
+
             fn physical_size(
                 &self,
             ) -> flui_types::geometry::Size<flui_types::geometry::DevicePixels> {

--- a/crates/flui-app/src/app/mod.rs
+++ b/crates/flui-app/src/app/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod logging;
 pub(crate) mod presentation;
 pub mod runner;
 pub(crate) mod ui_realm;
+pub(crate) mod window_registry;
 
 pub use binding::AppBinding;
 pub use config::{AppConfig, DiagnosticsProfile};

--- a/crates/flui-app/src/app/presentation.rs
+++ b/crates/flui-app/src/app/presentation.rs
@@ -81,6 +81,11 @@ impl PlatformWindow for TestPresentationWindow {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PresentationLifecycle {
     /// Identity exists, but no render surface is attached yet.
+    ///
+    /// Constructor-internal and production-unreachable once construction
+    /// returns: `PresentationState::new` self-attaches its surface before
+    /// handing the value back to its caller, so no arm dispatching on this
+    /// state ever observes `Created` outside that constructor.
     Created,
     /// The presentation accepts input and produces frames.
     SurfaceAttached,

--- a/crates/flui-app/src/app/presentation.rs
+++ b/crates/flui-app/src/app/presentation.rs
@@ -41,6 +41,10 @@ impl TestPresentationWindow {
 
 #[cfg(test)]
 impl PlatformWindow for TestPresentationWindow {
+    fn id(&self) -> flui_platform::traits::WindowId {
+        flui_platform::traits::WindowId(1)
+    }
+
     fn physical_size(&self) -> flui_types::geometry::Size<flui_types::geometry::DevicePixels> {
         flui_types::geometry::Size::default()
     }

--- a/crates/flui-app/src/app/presentation.rs
+++ b/crates/flui-app/src/app/presentation.rs
@@ -181,7 +181,6 @@ impl PresentationState {
     }
 
     #[must_use]
-    #[cfg(test)]
     pub(crate) fn lifecycle(&self) -> PresentationLifecycle {
         self.lifecycle.get()
     }
@@ -236,6 +235,12 @@ impl PresentationState {
         &self,
         request: SemanticsActionRequest,
     ) -> Result<(), SemanticsActionError> {
+        if matches!(
+            self.lifecycle.get(),
+            PresentationLifecycle::Closing | PresentationLifecycle::Closed
+        ) {
+            return Err(SemanticsActionError::PresentationClosed);
+        }
         let invocation = {
             let pipeline = self.pipeline.read();
             pipeline.resolve_semantics_action(request)?
@@ -361,6 +366,27 @@ mod tests {
         presentation.close();
         presentation.close();
         assert_eq!(presentation.lifecycle(), PresentationLifecycle::Closed);
+    }
+
+    /// Red-check: remove the lifecycle check from `dispatch_semantics_action`
+    /// and this fails with `Ok(())` instead (the request would resolve
+    /// against a node id that happens not to exist, which is a different,
+    /// pre-existing refusal path — `PresentationClosed` must fire first).
+    #[test]
+    fn semantics_action_after_close_is_refused() {
+        use flui_semantics::{AccessibilityNodeId, SemanticsAction};
+
+        let presentation = presentation();
+        presentation.close();
+
+        let request = SemanticsActionRequest::new(
+            AccessibilityNodeId::from(flui_foundation::RenderId::new(1)),
+            SemanticsAction::Tap,
+        );
+        assert_eq!(
+            presentation.dispatch_semantics_action(request),
+            Err(SemanticsActionError::PresentationClosed)
+        );
     }
 
     #[test]

--- a/crates/flui-app/src/app/presentation.rs
+++ b/crates/flui-app/src/app/presentation.rs
@@ -373,7 +373,7 @@ mod tests {
         assert_eq!(presentation.lifecycle(), PresentationLifecycle::Closed);
     }
 
-    /// Red-check: remove the lifecycle check from `dispatch_semantics_action`
+    /// If reverted: remove the lifecycle check from `dispatch_semantics_action`
     /// and this fails with `Ok(())` instead (the request would resolve
     /// against a node id that happens not to exist, which is a different,
     /// pre-existing refusal path — `PresentationClosed` must fire first).

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -234,6 +234,38 @@ impl Drop for OwnerHostClearGuard {
 #[cfg(not(target_os = "ios"))]
 type SurfaceApplier = Box<dyn FnMut(flui_types::Size<flui_types::geometry::Pixels>, f32)>;
 
+/// Restores a taken [`SurfaceApplier`] back into [`PLATFORM_REALM_HOST`]'s
+/// slot when dropped — including during an unwinding drop, so a panic
+/// inside the applier's own call (caught by `dispatch_platform_realm`'s
+/// outer `catch_unwind`) cannot permanently strand resizing. Without this,
+/// the applier taken out before the call is simply never restored once the
+/// call panics, and every later `Resized` event finds the slot empty
+/// forever, silently coalescing at the `None` arm's trace instead of ever
+/// applying again.
+#[cfg(not(target_os = "ios"))]
+#[must_use = "dropping this immediately restores the applier with no call in between"]
+struct SurfaceApplierRestoreGuard(Option<SurfaceApplier>);
+
+#[cfg(not(target_os = "ios"))]
+impl SurfaceApplierRestoreGuard {
+    fn call(&mut self, size: flui_types::Size<flui_types::geometry::Pixels>, scale_factor: f32) {
+        if let Some(applier) = self.0.as_mut() {
+            applier(size, scale_factor);
+        }
+    }
+}
+
+#[cfg(not(target_os = "ios"))]
+impl Drop for SurfaceApplierRestoreGuard {
+    fn drop(&mut self) {
+        if let Some(applier) = self.0.take() {
+            PLATFORM_REALM_HOST.with(|slot| {
+                slot.borrow_mut().surface_applier = Some(applier);
+            });
+        }
+    }
+}
+
 #[cfg(not(target_os = "ios"))]
 struct RealmHost {
     realm: Option<super::ui_realm::UiRealm>,
@@ -392,11 +424,14 @@ impl PlatformToUi {
                 let applier =
                     PLATFORM_REALM_HOST.with(|slot| slot.borrow_mut().surface_applier.take());
                 match applier {
-                    Some(mut applier) => {
-                        applier(size, scale_factor);
-                        PLATFORM_REALM_HOST.with(|slot| {
-                            slot.borrow_mut().surface_applier = Some(applier);
-                        });
+                    Some(applier) => {
+                        // The guard restores the applier on drop
+                        // unconditionally — including if `call` below
+                        // panics and the drop runs during unwind — so a
+                        // caught panic in the applier never permanently
+                        // strands resizing.
+                        let mut guard = SurfaceApplierRestoreGuard(Some(applier));
+                        guard.call(size, scale_factor);
                     }
                     None => {
                         tracing::debug!(
@@ -1052,12 +1087,34 @@ fn install_platform_realm(
         realm_id: realm.realm_id(),
         presentation_id: realm.presentation_id(),
     };
-    PLATFORM_REALM_HOST.with(|slot| {
+    let (displaced_realm, displaced_queue, displaced_applier) = PLATFORM_REALM_HOST.with(|slot| {
         let mut state = slot.borrow_mut();
         state.registry.register_window(window, address);
+        // A realm may already be installed here — a reinstall without an
+        // intervening `teardown_platform_realm` (the panic-recovery path: a
+        // mid-`on_ready` failure leaves the old realm/queue/applier in
+        // place, and bootstrap tries again on the same thread). Mirror
+        // `teardown_platform_realm`'s discipline exactly: `mem::take` the
+        // displaced realm, its queue, and its surface applier out from
+        // under this borrow — never let an assignment drop them while the
+        // borrow is still live, and never leave stale-incarnation events
+        // sitting in the queue to be delivered FIFO-first into the new
+        // realm on its first dispatch.
+        let displaced_realm = state.realm.take();
+        let displaced_queue = std::mem::take(&mut state.queue);
+        let displaced_applier = state.surface_applier.take();
+        if displaced_realm.is_some() {
+            tracing::warn!(
+                previous_address = ?state.address,
+                new_address = ?address,
+                queued_events_discarded = displaced_queue.len(),
+                "install_platform_realm: replacing a realm that was never torn down"
+            );
+        }
         state.realm = Some(realm);
         state.owner_thread = Some(owner_thread);
         state.address = Some(address);
+        state.draining = false;
         // A second realm installed on this thread (hot-restart, or a
         // sequential test realm) must not inherit whatever `(visible,
         // focused)` the PREVIOUS realm's window last reported — every
@@ -1067,7 +1124,14 @@ fn install_platform_realm(
         // stale `Hidden`/`Inactive` left behind by the last one.
         state.visible = true;
         state.focused = true;
+        (displaced_realm, displaced_queue, displaced_applier)
     });
+    // Destructors may re-enter platform/framework code (the same invariant
+    // `teardown_platform_realm` honors) — drop only after the TLS borrow
+    // above has released.
+    drop(displaced_queue);
+    drop(displaced_realm);
+    drop(displaced_applier);
     RealmDispatcher {
         owner_thread,
         address,
@@ -1286,6 +1350,94 @@ mod realm_dispatch_tests {
                  value from a prior realm"
             );
         });
+        teardown_platform_realm();
+    }
+
+    /// Panic-recovery reinstall: `install_platform_realm` called again while
+    /// a realm from a prior incarnation is still installed (a mid-`on_ready`
+    /// failure that never reached `teardown_platform_realm`). The displaced
+    /// realm's queue must never leak stale-incarnation events into the new
+    /// realm, the displaced realm/queue/applier must drop only after the TLS
+    /// borrow releases (a reentrant dispatch triggered by that drop must see
+    /// a clean, already-released borrow — never a double-borrow panic), and
+    /// `draining` must not be left stuck from whatever state the displaced
+    /// realm was in.
+    ///
+    /// Red-check: without `mem::take`-ing the queue before overwriting
+    /// `state.realm`, the pre-existing stale event is delivered to the NEW
+    /// realm FIFO-first and this fails on the `delivered` assertion.
+    #[test]
+    fn reinstall_without_teardown_drops_the_displaced_realm_and_queue_outside_the_borrow() {
+        struct ReenterOnDrop {
+            dispatcher: RealmDispatcher,
+            result: Rc<RefCell<Option<Result<(), RealmDispatchError>>>>,
+        }
+
+        impl Drop for ReenterOnDrop {
+            fn drop(&mut self) {
+                let result =
+                    dispatch_platform_realm(self.dispatcher, RealmTask::Frame(Box::new(|_| {})));
+                *self.result.borrow_mut() = Some(result);
+            }
+        }
+
+        let dispatcher_a = install_test_realm();
+        let reentry_result = Rc::new(RefCell::new(None));
+        let reentry_result_in_probe = Rc::clone(&reentry_result);
+        let probe = ReenterOnDrop {
+            dispatcher: dispatcher_a,
+            result: reentry_result_in_probe,
+        };
+
+        let delivered = Rc::new(RefCell::new(false));
+        let delivered_in_event = Rc::clone(&delivered);
+
+        // Enqueue directly (not through `dispatch_platform_realm`, which
+        // would drain immediately) — this is the stale-incarnation queue
+        // state a mid-`on_ready` panic can leave behind before bootstrap
+        // retries `install_platform_realm` without ever calling
+        // `teardown_platform_realm`. Also force `draining = true`, matching
+        // a realm that was mid-drain when the panic hit.
+        PLATFORM_REALM_HOST.with(|slot| {
+            let mut state = slot.borrow_mut();
+            state.queue.push_back(RealmTask::Frame(Box::new(move |_| {
+                *delivered_in_event.borrow_mut() = true;
+            })));
+            state
+                .queue
+                .push_back(RealmTask::Frame(Box::new(move |_| drop(probe))));
+            state.draining = true;
+        });
+
+        // The panic-recovery reinstall itself: no teardown in between.
+        let dispatcher_b = install_test_realm();
+
+        assert!(
+            !*delivered.borrow(),
+            "a queued event from the displaced incarnation must never reach the new realm"
+        );
+        assert_eq!(
+            *reentry_result.borrow(),
+            Some(Err(RealmDispatchError::StaleRealm)),
+            "the displaced realm/queue must drop only after install_platform_realm's TLS \
+             borrow releases — a drop still inside that borrow would panic this reentrant \
+             dispatch with a double-borrow instead of returning a clean Err"
+        );
+
+        let new_realm_ran = Rc::new(RefCell::new(false));
+        let new_realm_ran_in_event = Rc::clone(&new_realm_ran);
+        dispatch_platform_realm(
+            dispatcher_b,
+            RealmTask::Frame(Box::new(move |_| {
+                *new_realm_ran_in_event.borrow_mut() = true;
+            })),
+        )
+        .expect("the new realm dispatches normally");
+        assert!(
+            *new_realm_ran.borrow(),
+            "draining must not be left stuck from the displaced incarnation — the new \
+             realm must actually drain, not just enqueue forever"
+        );
         teardown_platform_realm();
     }
 
@@ -1564,6 +1716,59 @@ mod realm_dispatch_tests {
         )
         .expect("host restored");
         assert!(*ran.borrow());
+    }
+
+    /// A panic inside the surface applier's own call (caught by
+    /// `dispatch_platform_realm`'s outer `catch_unwind`, same as any other
+    /// panicking event) must not permanently strand resizing: the
+    /// `SurfaceApplierRestoreGuard` restores the applier into the TLS slot
+    /// during the unwinding drop, so the next `Resized` still reaches it.
+    ///
+    /// Red-check: revert to restoring the applier only after a successful
+    /// call (no drop guard) and this fails — the second `Resized` silently
+    /// coalesces at the `None` arm instead of calling the applier again.
+    #[test]
+    fn surface_applier_panic_is_caught_and_the_applier_still_applies_next_time() {
+        let dispatcher = install_test_realm();
+        let calls = Rc::new(RefCell::new(0));
+        let calls_in_closure = Rc::clone(&calls);
+        install_surface_applier(move |_size, _scale_factor| {
+            *calls_in_closure.borrow_mut() += 1;
+            assert_ne!(
+                *calls_in_closure.borrow(),
+                1,
+                "surface applier panics on its first call (simulated backend failure)"
+            );
+        });
+
+        let resize_event = |side: f32| {
+            RealmTask::Event(PlatformToUi::Resized {
+                size: flui_types::Size::new(
+                    flui_types::geometry::px(side),
+                    flui_types::geometry::px(side),
+                ),
+                scale_factor: 1.0,
+            })
+        };
+
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = dispatch_platform_realm(dispatcher, resize_event(20.0));
+        }));
+        assert!(
+            panic.is_err(),
+            "the first Resized's applier call must panic"
+        );
+
+        dispatch_platform_realm(dispatcher, resize_event(30.0))
+            .expect("dispatch after the caught panic still succeeds");
+
+        assert_eq!(
+            *calls.borrow(),
+            2,
+            "the second Resized must still reach the applier — a panic on the first call \
+             must not permanently strand resizing"
+        );
+        teardown_platform_realm();
     }
 
     #[test]

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -1229,6 +1229,8 @@ mod realm_dispatch_tests {
 
     use super::*;
 
+    static_assertions::assert_impl_all!(PlatformToUi: Send);
+
     fn down_input(offset: f32) -> PlatformInput {
         PlatformInput::Pointer(make_down_event(
             Offset::new(Pixels(offset), Pixels(offset)),

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -316,7 +316,8 @@ enum RealmDispatchError {
 
 /// Typed, closed cross-thread payload (ADR-0037 §3): every routable
 /// platform-to-UI event. Compile-time evidence that this is a real `Send`
-/// boundary: [`assert_impl_all!`] is checked below. If `PlatformInput` ever
+/// boundary: `static_assertions::assert_impl_all!` is checked in this
+/// module's own tests. If `PlatformInput` ever
 /// stopped being `Send`, that must be fixed in `flui-platform` itself,
 /// never worked around here.
 #[cfg(not(target_os = "ios"))]

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -227,16 +227,41 @@ impl Drop for OwnerHostClearGuard {
     }
 }
 
+/// A registration-lifetime renderer-surface applier: `FnMut(size,
+/// scale_factor)`. Named so [`RealmHost::surface_applier`]'s field
+/// declaration reads plainly instead of spelling out the boxed closure type
+/// inline.
+#[cfg(not(target_os = "ios"))]
+type SurfaceApplier = Box<dyn FnMut(flui_types::Size<flui_types::geometry::Pixels>, f32)>;
+
 #[cfg(not(target_os = "ios"))]
 struct RealmHost {
     realm: Option<super::ui_realm::UiRealm>,
-    queue: std::collections::VecDeque<RealmEvent>,
+    queue: std::collections::VecDeque<RealmTask>,
     draining: bool,
     owner_thread: Option<std::thread::ThreadId>,
-    realm_id: Option<flui_foundation::RealmId>,
+    /// This realm incarnation's routable address. A **derived cache** of
+    /// [`super::window_registry::WindowRegistry`] below, not a second
+    /// source of truth — both are written only by
+    /// [`install_platform_realm`]/[`teardown_platform_realm`], inside this
+    /// same TLS borrow, in that order (see `window_registry`'s module doc
+    /// for the full invariant).
+    address: Option<super::window_registry::UiAddress>,
+    /// The sole native-window-to-presentation mapping authority (ADR-0037
+    /// §2). Lives here, inside the same thread-local as the realm it
+    /// addresses, rather than as a second free-standing static — a future
+    /// multi-window `AppRuntime` lifts it out unchanged (the type itself
+    /// has no TLS assumption baked in).
+    registry: super::window_registry::WindowRegistry,
+    /// The registration-lifetime renderer-surface applier for a
+    /// [`PlatformToUi::Resized`] event, installed once at realm install by
+    /// [`install_surface_applier`] and cleared at teardown. `take`n out of
+    /// this slot before it is called and restored after (never called
+    /// through a live borrow) — see [`PlatformToUi::run`]'s `Resized` arm.
+    surface_applier: Option<SurfaceApplier>,
 
     /// Single-window `(visible, focused)` tracking for the
-    /// `AppLifecycleState` derivation (see `ADR-0035`) — `RealmEvent::
+    /// `AppLifecycleState` derivation (see `ADR-0035`) — `PlatformToUi::
     /// WindowFocus`/`WindowVisibility` each update one half of this pair and
     /// re-derive. Both default `true`: a window is assumed visible and
     /// focused until a platform callback says otherwise (matches every
@@ -253,7 +278,9 @@ impl RealmHost {
             queue: std::collections::VecDeque::new(),
             draining: false,
             owner_thread: None,
-            realm_id: None,
+            address: None,
+            registry: super::window_registry::WindowRegistry::new(),
+            surface_applier: None,
             visible: true,
             focused: true,
         }
@@ -264,24 +291,40 @@ impl RealmHost {
 #[cfg(not(target_os = "ios"))]
 struct RealmDispatcher {
     owner_thread: std::thread::ThreadId,
-    realm_id: flui_foundation::RealmId,
+    address: super::window_registry::UiAddress,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg(not(target_os = "ios"))]
 enum RealmDispatchError {
     WrongThread,
+    /// The realm incarnation this dispatcher was minted for is gone — the
+    /// common path: `realm_id`/`presentation_id` mint from one shared
+    /// counter, so teardown+reinstall always changes both, and this check
+    /// (realm first) catches it before the presentation half is even
+    /// compared.
     StaleRealm,
+    /// The realm is live and matches, but the presentation incarnation does
+    /// not — reachable today only via a forged/mixed address (a dispatcher
+    /// whose presentation half was swapped for another incarnation's), and,
+    /// once one realm can host more than one presentation, via real
+    /// presentation replacement within a live realm. Kept as its own
+    /// variant now: the design-for-N contract, not dead code.
+    StalePresentation,
     RealmUnavailable,
 }
 
+/// Typed, closed cross-thread payload (ADR-0037 §3): every routable
+/// platform-to-UI event. Compile-time evidence that this is a real `Send`
+/// boundary: [`assert_impl_all!`] is checked below. If `PlatformInput` ever
+/// stopped being `Send`, that must be fixed in `flui-platform` itself,
+/// never worked around here.
 #[cfg(not(target_os = "ios"))]
-enum RealmEvent {
+enum PlatformToUi {
     Input(flui_platform::traits::PlatformInput),
-    Resize {
+    Resized {
         size: flui_types::Size<flui_types::geometry::Pixels>,
         scale_factor: f32,
-        apply_surface: Box<dyn FnOnce()>,
     },
     /// Window focus changed (winit's `WindowEvent::Focused`, or the
     /// equivalent per-backend signal; same source as the deleted `Active`
@@ -302,21 +345,65 @@ enum RealmEvent {
     WindowVisibility(bool),
     /// Drive a lifecycle target that requires owner-local realm cleanup (most
     /// notably Detached during platform shutdown).
-    LifecycleTarget(AppLifecycleState),
+    Lifecycle(AppLifecycleState),
+}
+
+/// One queued unit of owner-thread work: either a typed cross-thread
+/// [`PlatformToUi`] event, or the co-located frame pump. `Frame` is
+/// deliberately NOT part of the cross-thread vocabulary above — it is
+/// same-thread by construction (the `WrongThread` guard in
+/// [`dispatch_platform_realm`] rejects it from anywhere else) and carries an
+/// owner-local closure, which a cross-thread payload must never do
+/// (ADR-0037 §3 forbids `Box<dyn FnOnce()>` on that boundary). The `Send`
+/// assertion above applies to `PlatformToUi` only; splitting the two types
+/// is what makes that assertion non-vacuous.
+#[cfg(not(target_os = "ios"))]
+enum RealmTask {
+    Event(PlatformToUi),
     Frame(Box<dyn FnOnce(&super::ui_realm::UiRealm)>),
 }
 
 #[cfg(not(target_os = "ios"))]
-impl RealmEvent {
+impl RealmTask {
+    fn run(self, realm: &super::ui_realm::UiRealm) {
+        match self {
+            Self::Event(event) => event.run(realm),
+            Self::Frame(run) => run(realm),
+        }
+    }
+}
+
+#[cfg(not(target_os = "ios"))]
+impl PlatformToUi {
     fn run(self, realm: &super::ui_realm::UiRealm) {
         match self {
             Self::Input(input) => AppBinding::instance().handle_input_entered(realm, input),
-            Self::Resize {
-                size,
-                scale_factor,
-                apply_surface,
-            } => {
-                apply_surface();
+            Self::Resized { size, scale_factor } => {
+                // Take the applier out of the TLS slot, release the borrow,
+                // call it, then restore it — never call through a live
+                // borrow, so a reentrant TLS access from inside the applier
+                // (e.g. a nested dispatch enqueuing further work) cannot hit
+                // an already-mutably-borrowed `RefCell` panic. If the slot is
+                // ever found empty here (no applier installed yet, or
+                // already cleared by teardown) this skips with a trace
+                // instead of unwrapping/panicking; surface application then
+                // coalesces onto the next real applier install.
+                let applier =
+                    PLATFORM_REALM_HOST.with(|slot| slot.borrow_mut().surface_applier.take());
+                match applier {
+                    Some(mut applier) => {
+                        applier(size, scale_factor);
+                        PLATFORM_REALM_HOST.with(|slot| {
+                            slot.borrow_mut().surface_applier = Some(applier);
+                        });
+                    }
+                    None => {
+                        tracing::debug!(
+                            "realm resize: surface applier slot is empty; surface application \
+                             coalesces onto the next real applier install"
+                        );
+                    }
+                }
                 AppBinding::instance()
                     .render_pipeline_mut()
                     .set_device_pixel_ratio(scale_factor);
@@ -341,12 +428,25 @@ impl RealmEvent {
                 });
                 emit_lifecycle_transition(realm, old, new);
             }
-            Self::LifecycleTarget(new) => {
+            Self::Lifecycle(new) => {
                 emit_lifecycle_transition(realm, Scheduler::instance().lifecycle_state(), new);
             }
-            Self::Frame(run) => run(realm),
         }
     }
+}
+
+/// Installs `applier` as the registration-lifetime renderer-surface
+/// applier for the current realm host, replacing (never stacking) any
+/// previously-installed one. Call once per realm install, alongside
+/// [`install_platform_realm`], from each backend's bootstrap — never from
+/// inside a frame/event dispatch.
+#[cfg(not(target_os = "ios"))]
+fn install_surface_applier(
+    applier: impl FnMut(flui_types::Size<flui_types::geometry::Pixels>, f32) + 'static,
+) {
+    PLATFORM_REALM_HOST.with(|slot| {
+        slot.borrow_mut().surface_applier = Some(Box::new(applier));
+    });
 }
 
 // ============================================================================
@@ -442,12 +542,12 @@ fn lifecycle_ladder(old: AppLifecycleState, new: AppLifecycleState) -> Vec<AppLi
 /// stream driving both `SchedulerBinding` and `WidgetsBinding` from the same
 /// synthesized sequence of states.
 ///
-/// Installed as a direct call in the same `RealmEvent` handler (never a
+/// Installed as a direct call in the same `PlatformToUi` handler (never a
 /// `Scheduler`-listener closure): a listener captured at bootstrap time would
 /// have to resolve `realm`/`WidgetsBinding` lazily at fire time, which is
 /// exactly the thread-local-resolution/Send-capture trap
 /// `AppBinding::instance()`'s own installer avoids elsewhere in this crate.
-/// `realm` is already in scope here (`RealmEvent::run`'s parameter), so no
+/// `realm` is already in scope here (`PlatformToUi::run`'s parameter), so no
 /// such resolution is needed.
 #[cfg(not(target_os = "ios"))]
 fn emit_lifecycle_transition(
@@ -936,15 +1036,27 @@ mod lifecycle_derivation_tests {
     }
 }
 
+/// Installs `realm`, minting its dispatcher's address by registering
+/// `window` in the single [`super::window_registry::WindowRegistry`]
+/// authority — the registry is the sole mint path for a routable
+/// [`super::window_registry::UiAddress`]; no caller of this function ever
+/// names the platform-internal native-handle key type itself.
 #[cfg(not(target_os = "ios"))]
-fn install_platform_realm(realm: super::ui_realm::UiRealm) -> RealmDispatcher {
+fn install_platform_realm(
+    realm: super::ui_realm::UiRealm,
+    window: &std::sync::Arc<dyn flui_platform::traits::PlatformWindow>,
+) -> RealmDispatcher {
     let owner_thread = std::thread::current().id();
-    let realm_id = realm.realm_id();
+    let address = super::window_registry::UiAddress {
+        realm_id: realm.realm_id(),
+        presentation_id: realm.presentation_id(),
+    };
     PLATFORM_REALM_HOST.with(|slot| {
         let mut state = slot.borrow_mut();
+        state.registry.register_window(window, address);
         state.realm = Some(realm);
         state.owner_thread = Some(owner_thread);
-        state.realm_id = Some(realm_id);
+        state.address = Some(address);
         // A second realm installed on this thread (hot-restart, or a
         // sequential test realm) must not inherit whatever `(visible,
         // focused)` the PREVIOUS realm's window last reported — every
@@ -957,14 +1069,14 @@ fn install_platform_realm(realm: super::ui_realm::UiRealm) -> RealmDispatcher {
     });
     RealmDispatcher {
         owner_thread,
-        realm_id,
+        address,
     }
 }
 
 #[cfg(not(target_os = "ios"))]
 fn dispatch_platform_realm(
     dispatcher: RealmDispatcher,
-    event: RealmEvent,
+    event: RealmTask,
 ) -> Result<(), RealmDispatchError> {
     if std::thread::current().id() != dispatcher.owner_thread {
         tracing::error!(?dispatcher, "rejecting realm callback on non-owner thread");
@@ -972,21 +1084,38 @@ fn dispatch_platform_realm(
     }
     let realm = PLATFORM_REALM_HOST.with(|slot| {
         let mut state = slot.borrow_mut();
-        if state.realm_id != Some(dispatcher.realm_id) {
-            return Err(if state.realm_id.is_some() {
-                tracing::debug!(
-                    ?dispatcher,
-                    current_realm_id = ?state.realm_id,
-                    "dropping realm callback: a newer realm replaced the one it was dispatched for"
-                );
-                RealmDispatchError::StaleRealm
-            } else {
+        // Normative compare order (ADR-0037): realm first, then
+        // presentation. `realm_id`/`presentation_id` mint from one shared
+        // counter, so teardown+reinstall always changes both and the realm
+        // check fires first on the common path; `StalePresentation` is
+        // reachable only when the realm half matches but the presentation
+        // half does not (a forged/mixed address today; real presentation
+        // replacement within a live realm once a forest exists).
+        match state.address {
+            None => {
                 tracing::debug!(
                     ?dispatcher,
                     "dropping realm callback: no realm installed (not yet ready, or already torn down)"
                 );
-                RealmDispatchError::RealmUnavailable
-            });
+                return Err(RealmDispatchError::RealmUnavailable);
+            }
+            Some(current) if current.realm_id != dispatcher.address.realm_id => {
+                tracing::debug!(
+                    ?dispatcher,
+                    current_realm_id = ?current.realm_id,
+                    "dropping realm callback: a newer realm replaced the one it was dispatched for"
+                );
+                return Err(RealmDispatchError::StaleRealm);
+            }
+            Some(current) if current.presentation_id != dispatcher.address.presentation_id => {
+                tracing::debug!(
+                    ?dispatcher,
+                    current_address = ?current,
+                    "dropping realm callback: presentation incarnation mismatch within the live realm"
+                );
+                return Err(RealmDispatchError::StalePresentation);
+            }
+            Some(_) => {}
         }
         state.queue.push_back(event);
         if state.draining || state.realm.is_none() {
@@ -1048,11 +1177,24 @@ fn drain_owner_inbox(realm: &super::ui_realm::UiRealm) -> bool {
 fn teardown_platform_realm() {
     let (realm, queued) = PLATFORM_REALM_HOST.with(|slot| {
         let mut state = slot.borrow_mut();
+        // Registry removal first (ADR-0037 §2): stop new routing before the
+        // queued old-generation events below are dropped, and before the
+        // realm/address cache is cleared. The teardown real read: assert
+        // the removed entry matches the address this realm installed.
+        if let Some(address) = state.address {
+            let removed = state.registry.remove_realm(address.realm_id);
+            debug_assert_eq!(
+                removed.map(|(_, removed_address)| removed_address),
+                Some(address),
+                "BUG: window_registry teardown read did not match the installed address"
+            );
+        }
         let realm = state.realm.take();
         let queued = std::mem::take(&mut state.queue);
         state.draining = false;
         state.owner_thread = None;
-        state.realm_id = None;
+        state.address = None;
+        state.surface_applier = None;
         (realm, queued)
     });
     // Destructors may re-enter platform/framework code. Drop only after the
@@ -1082,13 +1224,30 @@ mod realm_dispatch_tests {
         HitTestResult,
         events::{PointerType, make_down_event},
     };
+    use flui_platform::traits::PlatformInput;
     use flui_types::geometry::{Offset, Pixels};
 
     use super::*;
 
+    fn down_input(offset: f32) -> PlatformInput {
+        PlatformInput::Pointer(make_down_event(
+            Offset::new(Pixels(offset), Pixels(offset)),
+            PointerType::Mouse,
+        ))
+    }
+
+    fn test_window() -> std::sync::Arc<dyn flui_platform::traits::PlatformWindow> {
+        flui_platform::headless_platform()
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create a test window")
+    }
+
     fn install_test_realm() -> RealmDispatcher {
         let app = AppBinding::instance();
-        install_platform_realm(super::super::ui_realm::UiRealm::for_test(app))
+        install_platform_realm(
+            super::super::ui_realm::UiRealm::for_test(app),
+            &test_window(),
+        )
     }
 
     /// A second realm installed on the same thread (hot-restart; sequential
@@ -1132,12 +1291,12 @@ mod realm_dispatch_tests {
         let dispatcher = install_test_realm();
         dispatch_platform_realm(
             dispatcher,
-            RealmEvent::LifecycleTarget(AppLifecycleState::Resumed),
+            RealmTask::Event(PlatformToUi::Lifecycle(AppLifecycleState::Resumed)),
         )
         .expect("test realm resumes");
         dispatch_platform_realm(
             dispatcher,
-            RealmEvent::Frame(Box::new(|realm| {
+            RealmTask::Frame(Box::new(|realm| {
                 let down =
                     make_down_event(Offset::new(Pixels(4.0), Pixels(6.0)), PointerType::Touch);
                 realm
@@ -1150,12 +1309,12 @@ mod realm_dispatch_tests {
 
         dispatch_platform_realm(
             dispatcher,
-            RealmEvent::LifecycleTarget(AppLifecycleState::Detached),
+            RealmTask::Event(PlatformToUi::Lifecycle(AppLifecycleState::Detached)),
         )
         .expect("Detached lifecycle dispatches through the realm");
         dispatch_platform_realm(
             dispatcher,
-            RealmEvent::Frame(Box::new(|realm| {
+            RealmTask::Frame(Box::new(|realm| {
                 assert_eq!(realm.gestures().active_pointer_count(), 0);
                 assert_eq!(realm.gestures().active_resampler_count(), 0);
                 assert_eq!(realm.gestures().pending_move_count(), 0);
@@ -1166,7 +1325,7 @@ mod realm_dispatch_tests {
 
         dispatch_platform_realm(
             dispatcher,
-            RealmEvent::LifecycleTarget(AppLifecycleState::Resumed),
+            RealmTask::Event(PlatformToUi::Lifecycle(AppLifecycleState::Resumed)),
         )
         .expect("test realm lifecycle restores");
         teardown_platform_realm();
@@ -1179,12 +1338,12 @@ mod realm_dispatch_tests {
         let outer = Rc::clone(&order);
         dispatch_platform_realm(
             dispatcher,
-            RealmEvent::Frame(Box::new(move |_| {
+            RealmTask::Frame(Box::new(move |_| {
                 outer.borrow_mut().push(1);
                 let nested = Rc::clone(&outer);
                 dispatch_platform_realm(
                     dispatcher,
-                    RealmEvent::Frame(Box::new(move |_| {
+                    RealmTask::Frame(Box::new(move |_| {
                         nested.borrow_mut().push(3);
                     })),
                 )
@@ -1203,22 +1362,182 @@ mod realm_dispatch_tests {
             let mut state = slot.borrow_mut();
             let realm = state.realm.take();
             state.queue.clear();
-            state.realm_id = None;
+            state.address = None;
             drop(state);
             drop(realm);
         });
         assert_eq!(
-            dispatch_platform_realm(stale, RealmEvent::Frame(Box::new(|_| {}))),
+            dispatch_platform_realm(stale, RealmTask::Frame(Box::new(|_| {}))),
             Err(RealmDispatchError::RealmUnavailable)
         );
 
         let current = install_test_realm();
         assert_eq!(
-            dispatch_platform_realm(stale, RealmEvent::Frame(Box::new(|_| {}))),
+            dispatch_platform_realm(stale, RealmTask::Frame(Box::new(|_| {}))),
             Err(RealmDispatchError::StaleRealm)
         );
-        dispatch_platform_realm(current, RealmEvent::Frame(Box::new(|_| {})))
+        dispatch_platform_realm(current, RealmTask::Frame(Box::new(|_| {})))
             .expect("current incarnation dispatches");
+    }
+
+    /// The common path (ADR-0037 compare order, realm first): teardown +
+    /// reinstall mints both a fresh `RealmId` and a fresh `PresentationId`
+    /// from the same shared counter, so a stale dispatcher's realm half
+    /// never matches — the presentation half is never even compared.
+    ///
+    /// Red-check: remove the realm-id compare from `dispatch_platform_realm`
+    /// and this fails — the stale dispatcher's input reaches the new realm.
+    #[test]
+    fn stale_realm_dispatch_is_dropped() {
+        let stale = install_test_realm();
+        teardown_platform_realm();
+        let _current = install_test_realm();
+
+        assert_eq!(
+            dispatch_platform_realm(
+                stale,
+                RealmTask::Event(PlatformToUi::Input(down_input(1.0))),
+            ),
+            Err(RealmDispatchError::StaleRealm)
+        );
+        teardown_platform_realm();
+    }
+
+    /// The design-for-N path (reachable today only via a forged/mixed
+    /// address, since realm/presentation generations always advance
+    /// together): a dispatcher whose realm half matches the live realm but
+    /// whose presentation half names a different incarnation must be
+    /// dropped as `StalePresentation`, and the live realm's own gesture
+    /// state must be completely untouched by the attempt.
+    ///
+    /// Red-check: remove the presentation-id compare from
+    /// `dispatch_platform_realm` and this fails — the forged dispatcher's
+    /// input reaches the live realm's arena.
+    #[test]
+    fn stale_presentation_with_live_realm_is_dropped() {
+        let live = install_test_realm();
+        let live_generation = live.address.presentation_id.generation();
+        let forged_generation = std::num::NonZeroU32::new(live_generation.get() + 1)
+            .expect("live_generation + 1 is nonzero");
+        let forged = RealmDispatcher {
+            owner_thread: live.owner_thread,
+            address: super::super::window_registry::UiAddress {
+                realm_id: live.address.realm_id,
+                presentation_id: flui_foundation::PresentationId::new_gen(0, forged_generation),
+            },
+        };
+
+        assert_eq!(
+            dispatch_platform_realm(
+                forged,
+                RealmTask::Event(PlatformToUi::Input(down_input(1.0))),
+            ),
+            Err(RealmDispatchError::StalePresentation)
+        );
+
+        dispatch_platform_realm(
+            live,
+            RealmTask::Frame(Box::new(|realm| {
+                assert_eq!(
+                    realm.gestures().active_pointer_count(),
+                    0,
+                    "the live realm's gesture state must be untouched by a dropped forged dispatch"
+                );
+            })),
+        )
+        .expect("the live dispatcher still dispatches");
+        teardown_platform_realm();
+    }
+
+    /// The AC-named teardown test: events queued before teardown for a
+    /// removed presentation must never deliver, and the surface applier
+    /// (cleared at the same teardown point) must not fire for a queued
+    /// resize either.
+    ///
+    /// Red-check: have `teardown_platform_realm` run the queue instead of
+    /// dropping it, and both assertions below fail.
+    #[test]
+    fn queued_events_for_a_removed_presentation_never_deliver() {
+        let _dispatcher = install_test_realm();
+        let delivered = Rc::new(RefCell::new(false));
+        let delivered_in_event = Rc::clone(&delivered);
+        let applier_invoked = Rc::new(RefCell::new(false));
+        let applier_invoked_in_closure = Rc::clone(&applier_invoked);
+        install_surface_applier(move |_size, _scale_factor| {
+            *applier_invoked_in_closure.borrow_mut() = true;
+        });
+
+        PLATFORM_REALM_HOST.with(|slot| {
+            let mut state = slot.borrow_mut();
+            state.queue.push_back(RealmTask::Frame(Box::new(move |_| {
+                *delivered_in_event.borrow_mut() = true;
+            })));
+            state
+                .queue
+                .push_back(RealmTask::Event(PlatformToUi::Resized {
+                    size: flui_types::Size::new(
+                        flui_types::geometry::px(100.0),
+                        flui_types::geometry::px(100.0),
+                    ),
+                    scale_factor: 1.0,
+                }));
+        });
+
+        teardown_platform_realm();
+        let _new_realm = install_test_realm();
+
+        assert!(
+            !*delivered.borrow(),
+            "a queued event for a removed presentation must never deliver"
+        );
+        assert!(
+            !*applier_invoked.borrow(),
+            "the surface applier must not fire for a queued resize after teardown"
+        );
+        teardown_platform_realm();
+    }
+
+    /// Borrow-discipline test: a `Resized` event dispatched while the
+    /// registration-lifetime applier slot is empty (no applier installed
+    /// yet, or already torn down) must skip with a trace rather than
+    /// unwrap/panic — the take/call/restore protocol's `None` arm.
+    ///
+    /// A genuinely *nested* re-entrant call (the applier's own call
+    /// triggering another `Resized` dispatch before it returns) cannot
+    /// observe an empty slot here: `dispatch_platform_realm` always defers a
+    /// call made while `draining` to the FIFO queue rather than running it
+    /// synchronously, and by the time that queued event is drained the
+    /// outer call has already restored the slot. The `None` arm exists for
+    /// the case this test exercises directly: a `Resized` event reaching
+    /// [`PlatformToUi::run`] before [`install_surface_applier`] has run (or
+    /// after it has been cleared), never for synchronous reentrancy.
+    ///
+    /// Red-check: replace the `None` arm's trace-and-skip with
+    /// `.expect("applier installed")` and this panics instead of returning
+    /// `Ok`.
+    #[test]
+    fn resized_with_no_applier_installed_skips_instead_of_panicking() {
+        let dispatcher = install_test_realm();
+        // Deliberately no `install_surface_applier` call: the slot starts
+        // (and stays) empty.
+
+        let result = dispatch_platform_realm(
+            dispatcher,
+            RealmTask::Event(PlatformToUi::Resized {
+                size: flui_types::Size::new(
+                    flui_types::geometry::px(20.0),
+                    flui_types::geometry::px(20.0),
+                ),
+                scale_factor: 1.0,
+            }),
+        );
+
+        assert!(
+            result.is_ok(),
+            "a Resized event with no applier installed must not panic; it \
+             coalesces onto the next real applier install instead"
+        );
+        teardown_platform_realm();
     }
 
     #[test]
@@ -1227,7 +1546,7 @@ mod realm_dispatch_tests {
         let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _ = dispatch_platform_realm(
                 dispatcher,
-                RealmEvent::Frame(Box::new(|_| panic!("test panic"))),
+                RealmTask::Frame(Box::new(|_| panic!("test panic"))),
             );
         }));
         assert!(panic.is_err());
@@ -1236,7 +1555,7 @@ mod realm_dispatch_tests {
         let ran_in_event = Rc::clone(&ran);
         dispatch_platform_realm(
             dispatcher,
-            RealmEvent::Frame(Box::new(move |_| {
+            RealmTask::Frame(Box::new(move |_| {
                 *ran_in_event.borrow_mut() = true;
             })),
         )
@@ -1248,7 +1567,7 @@ mod realm_dispatch_tests {
     fn callback_on_wrong_thread_is_rejected() {
         let dispatcher = install_test_realm();
         let result = std::thread::spawn(move || {
-            dispatch_platform_realm(dispatcher, RealmEvent::Frame(Box::new(|_| {})))
+            dispatch_platform_realm(dispatcher, RealmTask::Frame(Box::new(|_| {})))
         })
         .join()
         .expect("worker test thread");
@@ -1260,30 +1579,35 @@ mod realm_dispatch_tests {
         let dispatcher = install_test_realm();
         let order = Rc::new(RefCell::new(Vec::new()));
         let outer = Rc::clone(&order);
+        let applier_calls = Rc::clone(&order);
+        install_surface_applier(move |_size, _scale_factor| {
+            applier_calls.borrow_mut().push(3);
+        });
         dispatch_platform_realm(
             dispatcher,
-            RealmEvent::Frame(Box::new(move |_| {
+            RealmTask::Frame(Box::new(move |_| {
                 outer.borrow_mut().push(1);
-                dispatch_platform_realm(dispatcher, RealmEvent::WindowFocus(true))
-                    .expect("window focus queues");
-                let resize = Rc::clone(&outer);
                 dispatch_platform_realm(
                     dispatcher,
-                    RealmEvent::Resize {
+                    RealmTask::Event(PlatformToUi::WindowFocus(true)),
+                )
+                .expect("window focus queues");
+                dispatch_platform_realm(
+                    dispatcher,
+                    RealmTask::Event(PlatformToUi::Resized {
                         size: flui_types::Size::new(
                             flui_types::geometry::px(640.0),
                             flui_types::geometry::px(480.0),
                         ),
                         scale_factor: 2.0,
-                        apply_surface: Box::new(move || resize.borrow_mut().push(3)),
-                    },
+                    }),
                 )
                 .expect("resize queues");
                 outer.borrow_mut().push(2);
             })),
         )
         .expect("frame dispatches");
-        // Two different `RealmEvent` variants nested inside a `Frame` still
+        // Two different `PlatformToUi` variants nested inside a `Frame` still
         // queue FIFO rather than running immediately — the property
         // `reentrant_frame_event_is_queued_fifo` proves for same-variant
         // nesting, this proves it holds across variant types too.
@@ -1300,7 +1624,7 @@ mod realm_dispatch_tests {
         impl Drop for ReenterOnDrop {
             fn drop(&mut self) {
                 let result =
-                    dispatch_platform_realm(self.dispatcher, RealmEvent::Frame(Box::new(|_| {})));
+                    dispatch_platform_realm(self.dispatcher, RealmTask::Frame(Box::new(|_| {})));
                 assert_eq!(result, Err(RealmDispatchError::RealmUnavailable));
                 *self.dropped.borrow_mut() = true;
             }
@@ -1315,7 +1639,7 @@ mod realm_dispatch_tests {
         PLATFORM_REALM_HOST.with(|slot| {
             slot.borrow_mut()
                 .queue
-                .push_back(RealmEvent::Frame(Box::new(move |_| drop(probe))));
+                .push_back(RealmTask::Frame(Box::new(move |_| drop(probe))));
         });
         teardown_platform_realm();
         assert!(*dropped.borrow());
@@ -1332,12 +1656,12 @@ mod realm_dispatch_tests {
         let sender_a = runtime_a.command_sender();
         let old_a_hook = queued_hot_reload_hook(sender_a.clone());
         let registration_a = register_request_rebuild(queued_hot_reload_hook(sender_a));
-        let _realm_a = install_platform_realm(runtime_a);
+        let _realm_a = install_platform_realm(runtime_a, &test_window());
         teardown_platform_realm();
 
         let runtime_b = super::super::ui_realm::UiRealm::for_test(AppBinding::instance());
         let sender_b = runtime_b.command_sender();
-        let realm_b = install_platform_realm(runtime_b);
+        let realm_b = install_platform_realm(runtime_b, &test_window());
         let registration_b = register_request_rebuild(queued_hot_reload_hook(sender_b));
         drop(registration_a);
 
@@ -1346,7 +1670,7 @@ mod realm_dispatch_tests {
         let after_old_in_frame = Rc::clone(&after_old);
         dispatch_platform_realm(
             realm_b,
-            RealmEvent::Frame(Box::new(move |realm| {
+            RealmTask::Frame(Box::new(move |realm| {
                 *after_old_in_frame.borrow_mut() = Some(realm.drain_commands());
             })),
         )
@@ -1364,7 +1688,7 @@ mod realm_dispatch_tests {
         let after_current_in_frame = Rc::clone(&after_current);
         dispatch_platform_realm(
             realm_b,
-            RealmEvent::Frame(Box::new(move |realm| {
+            RealmTask::Frame(Box::new(move |realm| {
                 *after_current_in_frame.borrow_mut() = Some(realm.drain_commands());
             })),
         )
@@ -1388,13 +1712,13 @@ mod realm_dispatch_tests {
         realm
             .widgets()
             .with_build_owner_mut(|owner| owner.register_global_key(key.id(), element));
-        let dispatcher = install_platform_realm(realm);
+        let dispatcher = install_platform_realm(realm, &test_window());
         let key_after_frame = key.clone();
 
         assert_eq!(key.current_element(), None, "scope starts inactive");
         dispatch_platform_realm(
             dispatcher,
-            RealmEvent::Frame(Box::new(move |_| {
+            RealmTask::Frame(Box::new(move |_| {
                 assert_eq!(key.current_element(), Some(element));
             })),
         )
@@ -2021,16 +2345,33 @@ where
             "UiRealm constructed"
         );
         let hot_reload_sender = ui_realm.command_sender();
-        let realm_dispatch = install_platform_realm(ui_realm);
+        let realm_dispatch = install_platform_realm(ui_realm, &window);
         *rebuild_registration_slot.borrow_mut() =
             Some(worker_reload.register_rebuild_hook(hot_reload_sender));
 
         // 4. Wrap renderer for callback sharing
         let renderer = Arc::new(Mutex::new(renderer));
 
+        // Install the registration-lifetime surface applier alongside the
+        // realm (cleared together at teardown): a `Resized` event takes it
+        // out of the TLS slot, calls it, and restores it (see
+        // `PlatformToUi::run`'s `Resized` arm) rather than capturing the
+        // renderer inside the event payload itself.
+        {
+            let renderer_resize = Arc::clone(&renderer);
+            install_surface_applier(move |size, scale_factor| {
+                let w = (size.width.0 * scale_factor) as u32;
+                let h = (size.height.0 * scale_factor) as u32;
+                renderer_resize.lock().resize(w, h);
+            });
+        }
+
         // 5. Register input callback -> entered realm input dispatch
         window.on_input(Box::new(move |input: PlatformInput| {
-            let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::Input(input));
+            let _ = dispatch_platform_realm(
+                realm_dispatch,
+                RealmTask::Event(PlatformToUi::Input(input)),
+            );
             DispatchEventResult::resolved(false, true)
         }));
 
@@ -2040,7 +2381,7 @@ where
         window.on_request_frame(Box::new(move || {
         let renderer_frame = Arc::clone(&renderer_frame);
         let worker_reload_frame = worker_reload_frame.clone();
-        let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::Frame(Box::new(move |realm| {
+        let _ = dispatch_platform_realm(realm_dispatch, RealmTask::Frame(Box::new(move |realm| {
             worker_reload_frame.poll_and_apply(realm);
 
             let binding = AppBinding::instance();
@@ -2173,22 +2514,12 @@ where
         })));
     }));
 
-        // 7. Register resize callback -> renderer.resize()
-        let renderer_resize = Arc::clone(&renderer);
+        // 7. Register resize callback -> typed Resized event; the applier
+        // installed above (not this closure) actually touches the renderer.
         window.on_resize(Box::new(move |size, scale_factor| {
-            let apply_size = size;
-            let renderer_resize = Arc::clone(&renderer_resize);
             let _ = dispatch_platform_realm(
                 realm_dispatch,
-                RealmEvent::Resize {
-                    size,
-                    scale_factor,
-                    apply_surface: Box::new(move || {
-                        let w = (apply_size.width.0 * scale_factor) as u32;
-                        let h = (apply_size.height.0 * scale_factor) as u32;
-                        renderer_resize.lock().resize(w, h);
-                    }),
-                },
+                RealmTask::Event(PlatformToUi::Resized { size, scale_factor }),
             );
         }));
 
@@ -2209,7 +2540,7 @@ where
                 );
                 if let Err(error) = dispatch_platform_realm(
                     realm_dispatch,
-                    RealmEvent::LifecycleTarget(AppLifecycleState::Detached),
+                    RealmTask::Event(PlatformToUi::Lifecycle(AppLifecycleState::Detached)),
                 ) {
                     tracing::warn!(
                         ?error,
@@ -2240,10 +2571,16 @@ where
         // compositor never sends it, the window is treated as always
         // visible (the same as before this callback existed).
         window.on_active_status_change(Box::new(move |focused| {
-            let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::WindowFocus(focused));
+            let _ = dispatch_platform_realm(
+                realm_dispatch,
+                RealmTask::Event(PlatformToUi::WindowFocus(focused)),
+            );
         }));
         window.on_visibility_status_change(Box::new(move |visible| {
-            let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::WindowVisibility(visible));
+            let _ = dispatch_platform_realm(
+                realm_dispatch,
+                RealmTask::Event(PlatformToUi::WindowVisibility(visible)),
+            );
         }));
 
         // 9. Store window in AppBinding for runtime access — BEFORE
@@ -2482,14 +2819,29 @@ where
             tracing::error!("Root widget attach failed: {:?}", e);
             return Err(anyhow::anyhow!(e).context("Root widget attach failed"));
         }
-        let realm_dispatch = install_platform_realm(ui_realm);
+        let realm_dispatch = install_platform_realm(ui_realm, &window);
 
         // 4. Wrap renderer for callback sharing
         let renderer = Arc::new(Mutex::new(renderer));
 
+        // Install the registration-lifetime surface applier alongside the
+        // realm (cleared together at teardown) — see the desktop bootstrap's
+        // matching comment for the take/call/restore protocol this feeds.
+        {
+            let renderer_resize = Arc::clone(&renderer);
+            install_surface_applier(move |size, scale_factor| {
+                let w = (size.width.0 * scale_factor) as u32;
+                let h = (size.height.0 * scale_factor) as u32;
+                renderer_resize.lock().resize(w, h);
+            });
+        }
+
         // 5. Register input callback -> entered realm input dispatch
         window.on_input(Box::new(move |input: PlatformInput| {
-            let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::Input(input));
+            let _ = dispatch_platform_realm(
+                realm_dispatch,
+                RealmTask::Event(PlatformToUi::Input(input)),
+            );
             DispatchEventResult::resolved(false, true)
         }));
 
@@ -2501,7 +2853,7 @@ where
             let hot_reload_frame = hot_reload_frame.clone();
             let _ = dispatch_platform_realm(
                 realm_dispatch,
-                RealmEvent::Frame(Box::new(move |realm| {
+                RealmTask::Frame(Box::new(move |realm| {
                     // Owner-inbox drain: commands and worker results commit HERE,
                     // at the frame boundary while the scheduler phase is Idle —
                     // never inside the frame transaction below. Runs before
@@ -2577,22 +2929,12 @@ where
             );
         }));
 
-        // 7. Register resize callback -> renderer.resize()
-        let renderer_resize = Arc::clone(&renderer);
+        // 7. Register resize callback -> typed Resized event; the applier
+        // installed above (not this closure) actually touches the renderer.
         window.on_resize(Box::new(move |size, scale_factor| {
-            let apply_size = size;
-            let renderer_resize = Arc::clone(&renderer_resize);
             let _ = dispatch_platform_realm(
                 realm_dispatch,
-                RealmEvent::Resize {
-                    size,
-                    scale_factor,
-                    apply_surface: Box::new(move || {
-                        let w = (apply_size.width.0 * scale_factor) as u32;
-                        let h = (apply_size.height.0 * scale_factor) as u32;
-                        renderer_resize.lock().resize(w, h);
-                    }),
-                },
+                RealmTask::Event(PlatformToUi::Resized { size, scale_factor }),
             );
         }));
 
@@ -2612,7 +2954,7 @@ where
                 );
                 if let Err(error) = dispatch_platform_realm(
                     realm_dispatch,
-                    RealmEvent::LifecycleTarget(AppLifecycleState::Detached),
+                    RealmTask::Event(PlatformToUi::Lifecycle(AppLifecycleState::Detached)),
                 ) {
                     tracing::warn!(
                         ?error,
@@ -2649,7 +2991,7 @@ where
             };
             let _ = dispatch_platform_realm(
                 realm_dispatch,
-                RealmEvent::Frame(Box::new(move |realm| {
+                RealmTask::Frame(Box::new(move |realm| {
                     let old = Scheduler::instance().lifecycle_state();
                     emit_lifecycle_transition(realm, old, target);
                 })),
@@ -2832,11 +3174,28 @@ where
             tracing::error!("Root widget attach failed: {:?}", e);
             return Err(anyhow::anyhow!(e).context("Root widget attach failed"));
         }
-        let realm_dispatch = install_platform_realm(ui_realm);
+        let realm_dispatch = install_platform_realm(ui_realm, &window);
+
+        // Install the registration-lifetime surface applier alongside the
+        // realm (cleared together at teardown) — see the desktop bootstrap's
+        // matching comment for the take/call/restore protocol this feeds.
+        {
+            let renderer_resize = Arc::clone(&renderer);
+            install_surface_applier(move |size, scale_factor| {
+                if let Some(renderer) = renderer_resize.lock().as_mut() {
+                    let width = (size.width.0 * scale_factor) as u32;
+                    let height = (size.height.0 * scale_factor) as u32;
+                    renderer.resize(width, height);
+                }
+            });
+        }
 
         // 4. Register input callback
         window.on_input(Box::new(move |input: PlatformInput| {
-            let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::Input(input));
+            let _ = dispatch_platform_realm(
+                realm_dispatch,
+                RealmTask::Event(PlatformToUi::Input(input)),
+            );
             DispatchEventResult::resolved(false, true)
         }));
 
@@ -2846,7 +3205,7 @@ where
             let renderer_frame = Arc::clone(&renderer_frame);
             let _ = dispatch_platform_realm(
                 realm_dispatch,
-                RealmEvent::Frame(Box::new(move |realm| {
+                RealmTask::Frame(Box::new(move |realm| {
                     // Owner-inbox drain: commands and worker results commit HERE,
                     // at the frame boundary while the scheduler phase is Idle —
                     // never inside the frame transaction below. Runs before the
@@ -2927,23 +3286,10 @@ where
             );
         }));
 
-        let renderer_resize = Arc::clone(&renderer);
         window.on_resize(Box::new(move |size, scale_factor| {
-            let apply_size = size;
-            let renderer_resize = Arc::clone(&renderer_resize);
             let _ = dispatch_platform_realm(
                 realm_dispatch,
-                RealmEvent::Resize {
-                    size,
-                    scale_factor,
-                    apply_surface: Box::new(move || {
-                        if let Some(renderer) = renderer_resize.lock().as_mut() {
-                            let width = (apply_size.width.0 * scale_factor) as u32;
-                            let height = (apply_size.height.0 * scale_factor) as u32;
-                            renderer.resize(width, height);
-                        }
-                    }),
-                },
+                RealmTask::Event(PlatformToUi::Resized { size, scale_factor }),
             );
         }));
 
@@ -2961,7 +3307,7 @@ where
                 );
                 if let Err(error) = dispatch_platform_realm(
                     realm_dispatch,
-                    RealmEvent::LifecycleTarget(AppLifecycleState::Detached),
+                    RealmTask::Event(PlatformToUi::Lifecycle(AppLifecycleState::Detached)),
                 ) {
                     tracing::warn!(
                         ?error,
@@ -2983,7 +3329,10 @@ where
         // `Occluded` is desktop-only) — a DOM `visibilitychange` listener is a
         // future follow-up, not this PR's scope.
         window.on_active_status_change(Box::new(move |focused| {
-            let _ = dispatch_platform_realm(realm_dispatch, RealmEvent::WindowFocus(focused));
+            let _ = dispatch_platform_realm(
+                realm_dispatch,
+                RealmTask::Event(PlatformToUi::WindowFocus(focused)),
+            );
         }));
 
         // 7. Store window — BEFORE marking the lifecycle Resumed, which can

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -278,7 +278,7 @@ struct RealmHost {
     /// [`install_platform_realm`]/[`teardown_platform_realm`], inside this
     /// same TLS borrow, in that order (see `window_registry`'s module doc
     /// for the full invariant).
-    address: Option<super::window_registry::UiAddress>,
+    address: Option<flui_foundation::PresentationAddress>,
     /// The sole native-window-to-presentation mapping authority (ADR-0037
     /// §2). Lives here, inside the same thread-local as the realm it
     /// addresses, rather than as a second free-standing static — a future
@@ -323,7 +323,7 @@ impl RealmHost {
 #[cfg(not(target_os = "ios"))]
 struct RealmDispatcher {
     owner_thread: std::thread::ThreadId,
-    address: super::window_registry::UiAddress,
+    address: flui_foundation::PresentationAddress,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1075,7 +1075,7 @@ mod lifecycle_derivation_tests {
 /// Installs `realm`, minting its dispatcher's address by registering
 /// `window` in the single [`super::window_registry::WindowRegistry`]
 /// authority — the registry is the sole mint path for a routable
-/// [`super::window_registry::UiAddress`]; no caller of this function ever
+/// [`flui_foundation::PresentationAddress`]; no caller of this function ever
 /// names the platform-internal native-handle key type itself.
 #[cfg(not(target_os = "ios"))]
 fn install_platform_realm(
@@ -1083,19 +1083,31 @@ fn install_platform_realm(
     window: &std::sync::Arc<dyn flui_platform::traits::PlatformWindow>,
 ) -> RealmDispatcher {
     let owner_thread = std::thread::current().id();
-    let address = super::window_registry::UiAddress {
+    let address = flui_foundation::PresentationAddress {
         realm_id: realm.realm_id(),
         presentation_id: realm.presentation_id(),
     };
     let (displaced_realm, displaced_queue, displaced_applier) = PLATFORM_REALM_HOST.with(|slot| {
         let mut state = slot.borrow_mut();
-        state.registry.register_window(window, address);
         // A realm may already be installed here — a reinstall without an
         // intervening `teardown_platform_realm` (the panic-recovery path: a
-        // mid-`on_ready` failure leaves the old realm/queue/applier in
-        // place, and bootstrap tries again on the same thread). Mirror
-        // `teardown_platform_realm`'s discipline exactly: `mem::take` the
-        // displaced realm, its queue, and its surface applier out from
+        // mid-`on_ready` failure leaves the old realm/queue/applier/registry
+        // mappings in place, and bootstrap tries again on the same thread).
+        // Remove every registry mapping addressed to the DISPLACED realm —
+        // not just the window being installed now — in this same borrow,
+        // before registering the new window: otherwise the displaced
+        // realm's own window(s) survive as dead entries no later teardown
+        // ever reaches (teardown only ever removes the realm that is
+        // *currently* installed).
+        let previous_address = state.address;
+        let mut removed_window_mappings = 0;
+        if let Some(previous_address) = previous_address {
+            removed_window_mappings = state.registry.remove_realm(previous_address.realm_id).len();
+        }
+        state.registry.register_window(window, address);
+
+        // Mirror `teardown_platform_realm`'s discipline exactly: `mem::take`
+        // the displaced realm, its queue, and its surface applier out from
         // under this borrow — never let an assignment drop them while the
         // borrow is still live, and never leave stale-incarnation events
         // sitting in the queue to be delivered FIFO-first into the new
@@ -1105,9 +1117,10 @@ fn install_platform_realm(
         let displaced_applier = state.surface_applier.take();
         if displaced_realm.is_some() {
             tracing::warn!(
-                previous_address = ?state.address,
+                previous_address = ?previous_address,
                 new_address = ?address,
                 queued_events_discarded = displaced_queue.len(),
+                removed_window_mappings,
                 "install_platform_realm: replacing a realm that was never torn down"
             );
         }
@@ -1245,13 +1258,17 @@ fn teardown_platform_realm() {
         // Registry removal first (ADR-0037 §2): stop new routing before the
         // queued old-generation events below are dropped, and before the
         // realm/address cache is cleared. The teardown real read: assert
-        // the removed entry matches the address this realm installed.
+        // the removed entries include the address this realm installed —
+        // `remove_realm` removes every window mapped to this realm, not
+        // just the first, so a future one-realm-many-windows install still
+        // leaves nothing behind.
         if let Some(address) = state.address {
             let removed = state.registry.remove_realm(address.realm_id);
-            debug_assert_eq!(
-                removed.map(|(_, removed_address)| removed_address),
-                Some(address),
-                "BUG: window_registry teardown read did not match the installed address"
+            debug_assert!(
+                removed
+                    .iter()
+                    .any(|(_, removed_address)| *removed_address == address),
+                "BUG: window_registry teardown read did not include the installed address"
             );
         }
         let realm = state.realm.take();
@@ -1323,7 +1340,7 @@ mod realm_dispatch_tests {
     /// focused, so a fresh realm's derivation must start from that same
     /// baseline.
     ///
-    /// Red-check: remove the `state.visible = true; state.focused = true;`
+    /// If reverted: remove the `state.visible = true; state.focused = true;`
     /// reset from `install_platform_realm` and this fails — the second
     /// realm reads `visible == false` left behind by the first.
     #[test]
@@ -1363,7 +1380,7 @@ mod realm_dispatch_tests {
     /// `draining` must not be left stuck from whatever state the displaced
     /// realm was in.
     ///
-    /// Red-check: without `mem::take`-ing the queue before overwriting
+    /// If reverted: without `mem::take`-ing the queue before overwriting
     /// `state.realm`, the pre-existing stale event is delivered to the NEW
     /// realm FIFO-first and this fails on the `delivered` assertion.
     #[test]
@@ -1438,6 +1455,67 @@ mod realm_dispatch_tests {
             "draining must not be left stuck from the displaced incarnation — the new \
              realm must actually drain, not just enqueue forever"
         );
+        teardown_platform_realm();
+    }
+
+    /// A panic-recovery reinstall under a DIFFERENT native window must
+    /// remove the displaced realm's own window mapping from the registry —
+    /// not just leave it behind alongside the new one.
+    ///
+    /// Both windows are opened from the *same* headless platform instance:
+    /// `HeadlessPlatform` mints window ids from its own instance-local
+    /// counter, so two windows from two separate `headless_platform()` calls
+    /// would alias the same id instead of differing — one instance, two
+    /// `open_window` calls, is what actually produces two distinct windows.
+    ///
+    /// If reverted: skip the registry cleanup for the displaced realm in
+    /// `install_platform_realm` and this fails — the first window still
+    /// resolves, and the registry holds two entries instead of one.
+    #[test]
+    fn reinstall_with_a_different_window_removes_the_old_windows_registry_mapping() {
+        let platform = flui_platform::headless_platform();
+        let first_window = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create the first test window");
+        let second_window = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create the second test window");
+        let first_window_id = first_window.id();
+        let second_window_id = second_window.id();
+        assert_ne!(
+            first_window_id, second_window_id,
+            "the two windows must have distinct ids for this test to mean anything"
+        );
+
+        let app = AppBinding::instance();
+        let _first_dispatcher = install_platform_realm(
+            super::super::ui_realm::UiRealm::for_test(app),
+            &first_window,
+        );
+        // The panic-recovery reinstall itself, under the second window: no
+        // teardown in between.
+        let _second_dispatcher = install_platform_realm(
+            super::super::ui_realm::UiRealm::for_test(app),
+            &second_window,
+        );
+
+        PLATFORM_REALM_HOST.with(|slot| {
+            let state = slot.borrow();
+            assert_eq!(
+                state.registry.resolve(first_window_id),
+                None,
+                "the displaced realm's old window mapping must be removed on reinstall"
+            );
+            assert!(
+                state.registry.resolve(second_window_id).is_some(),
+                "the new window must resolve to the new realm's address"
+            );
+            assert_eq!(
+                state.registry.len(),
+                1,
+                "only the new window's mapping may remain after the reinstall"
+            );
+        });
         teardown_platform_realm();
     }
 
@@ -1540,7 +1618,7 @@ mod realm_dispatch_tests {
     /// from the same shared counter, so a stale dispatcher's realm half
     /// never matches — the presentation half is never even compared.
     ///
-    /// Red-check: remove the realm-id compare from `dispatch_platform_realm`
+    /// If reverted: remove the realm-id compare from `dispatch_platform_realm`
     /// and this fails — the stale dispatcher's input reaches the new realm.
     #[test]
     fn stale_realm_dispatch_is_dropped() {
@@ -1565,7 +1643,7 @@ mod realm_dispatch_tests {
     /// dropped as `StalePresentation`, and the live realm's own gesture
     /// state must be completely untouched by the attempt.
     ///
-    /// Red-check: remove the presentation-id compare from
+    /// If reverted: remove the presentation-id compare from
     /// `dispatch_platform_realm` and this fails — the forged dispatcher's
     /// input reaches the live realm's arena.
     #[test]
@@ -1576,7 +1654,7 @@ mod realm_dispatch_tests {
             .expect("live_generation + 1 is nonzero");
         let forged = RealmDispatcher {
             owner_thread: live.owner_thread,
-            address: super::super::window_registry::UiAddress {
+            address: flui_foundation::PresentationAddress {
                 realm_id: live.address.realm_id,
                 presentation_id: flui_foundation::PresentationId::new_gen(0, forged_generation),
             },
@@ -1609,7 +1687,7 @@ mod realm_dispatch_tests {
     /// (cleared at the same teardown point) must not fire for a queued
     /// resize either.
     ///
-    /// Red-check: have `teardown_platform_realm` run the queue instead of
+    /// If reverted: have `teardown_platform_realm` run the queue instead of
     /// dropping it, and both assertions below fail.
     #[test]
     fn queued_events_for_a_removed_presentation_never_deliver() {
@@ -1667,7 +1745,7 @@ mod realm_dispatch_tests {
     /// [`PlatformToUi::run`] before [`install_surface_applier`] has run (or
     /// after it has been cleared), never for synchronous reentrancy.
     ///
-    /// Red-check: replace the `None` arm's trace-and-skip with
+    /// If reverted: replace the `None` arm's trace-and-skip with
     /// `.expect("applier installed")` and this panics instead of returning
     /// `Ok`.
     #[test]
@@ -1724,7 +1802,7 @@ mod realm_dispatch_tests {
     /// `SurfaceApplierRestoreGuard` restores the applier into the TLS slot
     /// during the unwinding drop, so the next `Resized` still reaches it.
     ///
-    /// Red-check: revert to restoring the applier only after a successful
+    /// If reverted: revert to restoring the applier only after a successful
     /// call (no drop guard) and this fails — the second `Resized` silently
     /// coalesces at the `None` arm instead of calling the applier again.
     #[test]
@@ -2160,7 +2238,7 @@ mod desktop_pacing_tests {
     /// mirrors what `run_desktop`'s frame callback does on a `PumpAsync`
     /// wake, without needing a live window/event loop.
     ///
-    /// Red-check: gate the pump too (only call `drive_async_tasks` when
+    /// If reverted: gate the pump too (only call `drive_async_tasks` when
     /// `wake_action` returns `Render` — a mistaken "no work while
     /// backgrounded" fix) and this fails: the future never completes (RUN
     /// IT — see the test module doc for how this is verified).
@@ -3681,7 +3759,7 @@ mod tests {
     /// on the singleton — only THIS test's window, with THIS test's
     /// unmistakable marker size, proves `set_window` ran before the callback.
     ///
-    /// Red-check: swap the order of the two `AppBinding::instance()` calls
+    /// If reverted: swap the order of the two `AppBinding::instance()` calls
     /// below (request the redraw, then store the window — the pre-fix shape)
     /// and this fails: `wake_frame` finds no active window yet, never calls
     /// `request_redraw` on it, and the callback never fires at all.

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -130,7 +130,7 @@ impl CommandSendError {
 ///   presentation incarnation within it (the eventual element-forest case)
 ///   and a sender may have been vended for a presentation that no longer
 ///   owns this realm's inbox.
-/// - **Realm-scoped** commands ([`Self::HotReload`], [`Self::Navigation`])
+/// - **Realm-scoped** commands (`HotReload`, [`Self::Navigation`])
 ///   carry no stamp of their own and stay bound by channel identity alone:
 ///   a recreated realm mints new channels, and a sender into the dead realm
 ///   already gets `OwnerGone` at send — re-stamping realm identity on top of

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -530,15 +530,15 @@ impl UiRealm {
 
     /// Current presentation incarnation.
     #[must_use]
-    #[cfg_attr(
-        target_arch = "wasm32",
-        expect(
-            dead_code,
-            reason = "consumed only by the desktop runner and tests, neither in the wasm lib check"
-        )
-    )]
     pub fn presentation_id(&self) -> PresentationId {
         self.presentation.id()
+    }
+
+    /// The current presentation's lifecycle state, for the input-gate
+    /// checks at the physical owner (`AppBinding::handle_input_entered`).
+    #[must_use]
+    pub(crate) fn presentation_lifecycle(&self) -> super::presentation::PresentationLifecycle {
+        self.presentation.lifecycle()
     }
 
     /// A new cross-thread sender into this runtime's inbox.

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -121,6 +121,20 @@ impl CommandSendError {
 // ---------------------------------------------------------------------------
 
 /// A command enqueued for the owner thread.
+///
+/// Two addressing classes, by design, not oversight:
+///
+/// - **Presentation-scoped** commands ([`Self::SemanticsAction`]) carry an
+///   explicit `presentation_id` stamp and are validated against the live
+///   presentation at drain time, because the realm's inbox outlives any one
+///   presentation incarnation within it (the eventual element-forest case)
+///   and a sender may have been vended for a presentation that no longer
+///   owns this realm's inbox.
+/// - **Realm-scoped** commands ([`Self::HotReload`], [`Self::Navigation`])
+///   carry no stamp of their own and stay bound by channel identity alone:
+///   a recreated realm mints new channels, and a sender into the dead realm
+///   already gets `OwnerGone` at send — re-stamping realm identity on top of
+///   that would duplicate a structural fact the channel already enforces.
 pub(crate) enum UiCommand {
     /// Apply a hot-reload reassemble on the owner at the next Idle drain.
     // Only constructed by `request_hot_reload`, whose consumer is the
@@ -134,8 +148,15 @@ pub(crate) enum UiCommand {
         )
     )]
     HotReload(flui_hot_reload::HotReloadTier),
-    /// Resolve and invoke an accessibility action on the owner thread.
-    SemanticsAction(SemanticsActionRequest),
+    /// Resolve and invoke an accessibility action on the owner thread,
+    /// addressed to the exact presentation that was live when the sender
+    /// stamped it.
+    SemanticsAction {
+        /// The presentation this action was stamped for.
+        presentation_id: PresentationId,
+        /// The stable node identity and action to resolve.
+        request: SemanticsActionRequest,
+    },
     /// Apply a typed navigator mutation on the owner thread.
     Navigation(NavigatorCommand),
 }
@@ -147,9 +168,13 @@ impl std::fmt::Debug for UiCommand {
             UiCommand::HotReload(tier) => {
                 f.debug_tuple("UiCommand::HotReload").field(tier).finish()
             }
-            UiCommand::SemanticsAction(request) => f
-                .debug_tuple("UiCommand::SemanticsAction")
-                .field(request)
+            UiCommand::SemanticsAction {
+                presentation_id,
+                request,
+            } => f
+                .debug_struct("UiCommand::SemanticsAction")
+                .field("presentation_id", presentation_id)
+                .field("request", request)
                 .finish(),
             UiCommand::Navigation(command) => f
                 .debug_tuple("UiCommand::Navigation")
@@ -185,6 +210,12 @@ pub(crate) struct UiCommandSender {
     tx: Sender<UiCommand>,
     capacity: usize,
     redraw_pending: Arc<AtomicBool>,
+    /// The presentation this sender stamps onto every presentation-scoped
+    /// command it sends (set once, at [`UiRealm::construct`]). For the
+    /// eventual element forest, senders become vended per-presentation with
+    /// different stamps into the same realm inbox — this field is already
+    /// the right shape; only the vending point changes.
+    presentation_id: PresentationId,
     /// Fired after every successful state change so an idle event loop
     /// produces the drain that observes it — the enqueue-then-wake contract,
     /// same as `PipelineOwnerHandle`'s notifier.
@@ -195,6 +226,7 @@ impl std::fmt::Debug for UiCommandSender {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UiCommandSender")
             .field("capacity", &self.capacity)
+            .field("presentation_id", &self.presentation_id)
             .field("pending", &self.tx.len())
             .field(
                 "redraw_pending",
@@ -249,7 +281,10 @@ impl UiCommandSender {
         &self,
         request: SemanticsActionRequest,
     ) -> Result<(), CommandSendError> {
-        self.send(UiCommand::SemanticsAction(request))
+        self.send(UiCommand::SemanticsAction {
+            presentation_id: self.presentation_id,
+            request,
+        })
     }
 
     /// Enqueue a typed navigation command for owner-thread application.
@@ -454,6 +489,7 @@ impl UiRealm {
     ) -> Result<Self, UiRealmError> {
         let (tx, rx) = bounded(capacity);
         let redraw_pending = Arc::new(AtomicBool::new(false));
+        let presentation_id = presentation.id();
         let local_post_frame = Scheduler::instance().local_post_frame_lane();
         let interaction_lane = InteractionLane::try_new()?;
         let widgets = WidgetsBinding::with_focus_manager(presentation.focus_manager());
@@ -475,6 +511,7 @@ impl UiRealm {
                 tx,
                 capacity,
                 redraw_pending: Arc::clone(&redraw_pending),
+                presentation_id,
                 wake,
             },
             redraw_pending,
@@ -667,7 +704,20 @@ impl UiRealm {
                     }
                     report.invoked += 1;
                 }
-                UiCommand::SemanticsAction(request) => {
+                UiCommand::SemanticsAction {
+                    presentation_id,
+                    request,
+                } => {
+                    if presentation_id != self.presentation.id() {
+                        tracing::trace!(
+                            { flui_foundation::diagnostics::PRESENTATION_ID } =
+                                self.presentation.id().as_u64(),
+                            stamped_presentation_id = presentation_id.as_u64(),
+                            "dropping semantics action stamped for a stale presentation incarnation"
+                        );
+                        report.dropped_stale += 1;
+                        continue;
+                    }
                     match self.presentation.dispatch_semantics_action(request) {
                         Ok(()) => {
                             report.invoked += 1;
@@ -715,6 +765,7 @@ impl Drop for UiRealm {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
     use std::sync::atomic::{AtomicBool, AtomicUsize};
 
     use flui_foundation::RenderId;
@@ -946,6 +997,67 @@ mod tests {
         let report = realm.drain_commands();
         assert_eq!(report.invoked, 0);
         assert_eq!(report.dropped_stale, 1);
+    }
+
+    /// Distinct from `stale_semantics_action_is_gracefully_dropped` above:
+    /// that test forges a stale *node* id against a live presentation; this
+    /// one forges a stale *presentation* stamp against a request whose node
+    /// would otherwise resolve — proving the stamp check runs first and
+    /// never lets the request reach `dispatch_semantics_action` (no
+    /// pipeline borrow at all).
+    ///
+    /// Red-check: remove the `presentation_id` comparison from
+    /// `drain_commands` and this fails (`invoked == 1` instead of
+    /// `dropped_stale == 1`).
+    #[test]
+    fn semantics_action_with_stale_presentation_stamp_is_dropped() {
+        let app = super::super::binding::AppBinding::new();
+        let realm = UiRealm::for_test(&app);
+        let render_id = RenderId::new(1);
+        let invoked = Arc::new(AtomicUsize::new(0));
+        let invoked_in_handler = Arc::clone(&invoked);
+        let mut node = SemanticsNode::new().with_source_render_id(render_id);
+        // The action handler is real and would succeed: this test's stamp
+        // check must be what drops the request, not an unrelated resolution
+        // failure (e.g. a node with no registered action at all, which
+        // would drop for the wrong reason and pass even with the stamp
+        // check deleted).
+        node.config_mut().add_action(
+            SemanticsAction::Tap,
+            Arc::new(move |_action, _arguments| {
+                invoked_in_handler.fetch_add(1, Ordering::SeqCst);
+            }),
+        );
+        let mut semantics_owner = SemanticsOwner::new(Arc::new(|_| {}));
+        let root = semantics_owner.insert(node);
+        semantics_owner.set_root(Some(root));
+        app.render_pipeline_mut()
+            .set_semantics_owner(Some(semantics_owner));
+
+        let live = realm.presentation_id();
+        let forged = PresentationId::new_gen(
+            live.index(),
+            NonZeroU32::new(live.generation().get() + 1).expect("nonzero"),
+        );
+        realm
+            .command_sender()
+            .send(UiCommand::SemanticsAction {
+                presentation_id: forged,
+                request: SemanticsActionRequest::new(
+                    AccessibilityNodeId::from(render_id),
+                    SemanticsAction::Tap,
+                ),
+            })
+            .expect("realm inbox has room");
+
+        let report = realm.drain_commands();
+        assert_eq!(report.invoked, 0);
+        assert_eq!(report.dropped_stale, 1);
+        assert_eq!(
+            invoked.load(Ordering::SeqCst),
+            0,
+            "a stale-stamped action must never reach the handler at all"
+        );
     }
 
     #[test]

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -1006,7 +1006,7 @@ mod tests {
     /// never lets the request reach `dispatch_semantics_action` (no
     /// pipeline borrow at all).
     ///
-    /// Red-check: remove the `presentation_id` comparison from
+    /// If reverted: remove the `presentation_id` comparison from
     /// `drain_commands` and this fails (`invoked == 1` instead of
     /// `dropped_stale == 1`).
     #[test]

--- a/crates/flui-app/src/app/window_registry.rs
+++ b/crates/flui-app/src/app/window_registry.rs
@@ -40,6 +40,18 @@ pub(crate) struct UiAddress {
 }
 
 /// Errors from [`WindowRegistry::try_register`].
+// The strict path has no production call site yet (today's single-window
+// install always uses the replace semantics of `register_window`); it is
+// reserved for a future multi-window install path that chooses
+// strict-vs-replace per call site, and is exercised by this module's own
+// tests in the meantime.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "reserved for a future multi-window install path; exercised by this module's tests"
+    )
+)]
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum RegistryError {
@@ -127,6 +139,13 @@ impl WindowRegistry {
     /// Not dead code despite zero production call sites today — exercised
     /// by this module's own tests, and reserved for a future multi-window
     /// install path that chooses strict-vs-replace per call site.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "reserved for a future multi-window install path; exercised by this module's tests"
+        )
+    )]
     pub(crate) fn try_register(
         &mut self,
         id: WindowId,
@@ -152,6 +171,16 @@ impl WindowRegistry {
     /// This is the teardown real read: the caller asserts the returned
     /// entry against the address it installed, proving the registry tracked
     /// the same window/address pair for this realm's whole lifetime.
+    // `teardown_platform_realm` (runner.rs) is the only production caller,
+    // and it does not exist on wasm32 — the web host never tears down (see
+    // its own module doc) — so the wasm lib check sees this as dead.
+    #[cfg_attr(
+        target_arch = "wasm32",
+        expect(
+            dead_code,
+            reason = "consumed only by teardown_platform_realm, which does not exist on wasm32, and by this module's tests"
+        )
+    )]
     pub(crate) fn remove_realm(&mut self, realm_id: RealmId) -> Option<(WindowId, UiAddress)> {
         let position = self
             .entries

--- a/crates/flui-app/src/app/window_registry.rs
+++ b/crates/flui-app/src/app/window_registry.rs
@@ -1,0 +1,47 @@
+//! The single `WindowId -> UiAddress` mapping authority.
+//!
+//! ADR-0037 §2 names one authority for the native-window-to-presentation
+//! map; no second one may live in `AppBinding`, `UiRealm`, an input
+//! registry, or a platform callback. This module is that authority's home.
+//! `WindowId` (the platform-internal native-handle key) is confined to this
+//! file within `flui-app` — every other module addresses a presentation
+//! through [`UiAddress`] only, minted here.
+
+use flui_foundation::{PresentationId, RealmId};
+
+/// One presentation's routable address: which realm incarnation owns it,
+/// and which presentation incarnation within that realm.
+///
+/// Field names match the `RealmDispatcher.realm_id` precedent
+/// (`runner.rs`) and ADR-0037 §7's literal `SemanticsCommand` fields —
+/// `realm_id`/`presentation_id`, not a bare tuple or abbreviated names.
+///
+/// Deliberately `flui-app`-private: it graduates to `flui-foundation` only
+/// when a second crate needs it (rule of three).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct UiAddress {
+    pub(crate) realm_id: RealmId,
+    pub(crate) presentation_id: PresentationId,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use super::*;
+
+    static_assertions::assert_impl_all!(UiAddress: Send, Sync, Copy);
+
+    #[test]
+    fn addresses_compare_by_both_fields() {
+        let one = UiAddress {
+            realm_id: RealmId::new_gen(0, NonZeroU32::MIN),
+            presentation_id: PresentationId::new_gen(0, NonZeroU32::MIN),
+        };
+        let same_realm_different_presentation = UiAddress {
+            realm_id: one.realm_id,
+            presentation_id: PresentationId::new_gen(0, NonZeroU32::new(2).unwrap()),
+        };
+        assert_ne!(one, same_realm_different_presentation);
+    }
+}

--- a/crates/flui-app/src/app/window_registry.rs
+++ b/crates/flui-app/src/app/window_registry.rs
@@ -5,9 +5,24 @@
 //! registry, or a platform callback. This module is that authority's home.
 //! `WindowId` (the platform-internal native-handle key) is confined to this
 //! file within `flui-app` — every other module addresses a presentation
-//! through [`UiAddress`] only, minted here.
+//! through [`UiAddress`] only, minted here. The mechanical
+//! `forbidden_pattern` scan in `docs/runtime-contract.toml` confines the
+//! `WindowId` token itself to this one file within `crates/flui-app/src`.
+//!
+//! # Derived-cache invariant
+//!
+//! `RealmHost.address: Option<UiAddress>` (`runner.rs`) is a **derived
+//! cache** of this registry, not a second source of truth. Both are written
+//! only by `install_platform_realm`/`teardown_platform_realm`, inside the
+//! same TLS borrow, in that order: on install, the registry is written
+//! first, then the cache; on teardown, the registry entry is removed first
+//! — so map removal stops new routing before the queued old-generation
+//! events still sitting in the host's queue are dropped (ADR-0037 §2).
+
+use std::sync::Arc;
 
 use flui_foundation::{PresentationId, RealmId};
+use flui_platform::traits::{PlatformWindow, WindowId};
 
 /// One presentation's routable address: which realm incarnation owns it,
 /// and which presentation incarnation within that realm.
@@ -22,6 +37,128 @@ use flui_foundation::{PresentationId, RealmId};
 pub(crate) struct UiAddress {
     pub(crate) realm_id: RealmId,
     pub(crate) presentation_id: PresentationId,
+}
+
+/// Errors from [`WindowRegistry::try_register`].
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum RegistryError {
+    /// The window already has a mapped address; `try_register` never
+    /// replaces (use [`WindowRegistry::register_window`] for replace
+    /// semantics).
+    #[error("window is already mapped to {existing:?}")]
+    WindowAlreadyMapped {
+        /// The address the window was already mapped to.
+        existing: UiAddress,
+    },
+}
+
+/// The sole `WindowId -> UiAddress` mint/lookup authority.
+///
+/// API designed for N windows, instantiated for exactly one today: storage
+/// is a plain linear-scan `Vec` with no TLS assumption inside the type
+/// itself — a future multi-window `AppRuntime` lifts this struct unchanged.
+/// `WindowId` never crosses this module's boundary except through the
+/// methods below, which take an already-known window/id and hand back an
+/// address; callers outside this file never construct or hold a `WindowId`.
+#[derive(Debug, Default)]
+pub(crate) struct WindowRegistry {
+    entries: Vec<(WindowId, UiAddress)>,
+}
+
+impl WindowRegistry {
+    pub(crate) const fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    /// Registers `window` at `address`, **replacing** any existing mapping
+    /// for the same window and returning the displaced address.
+    ///
+    /// Replacement (not a hard error) keeps install recoverable after a
+    /// mid-`on_ready` panic: `OwnerHostClearGuard` only clears
+    /// `OWNER_PLATFORM_HOST`, not the realm host this registry lives
+    /// inside, and the web host never tears down at all — a hard error here
+    /// would brick reinstall on either path. A replacement is traced at
+    /// `warn` with both addresses so a genuine double-install bug is still
+    /// visible; [`Self::try_register`] is the strict alternative for a
+    /// caller that wants a hard error instead.
+    ///
+    /// Calls `window.id()` internally so callers never need to name
+    /// [`WindowId`] themselves. Performs the install-time self-check read
+    /// immediately after inserting: the very next [`Self::resolve`] must
+    /// see exactly what was just written.
+    pub(crate) fn register_window(
+        &mut self,
+        window: &Arc<dyn PlatformWindow>,
+        address: UiAddress,
+    ) -> Option<UiAddress> {
+        let id = window.id();
+        let displaced = if let Some(entry) = self
+            .entries
+            .iter_mut()
+            .find(|(existing, _)| *existing == id)
+        {
+            Some(std::mem::replace(&mut entry.1, address))
+        } else {
+            self.entries.push((id, address));
+            None
+        };
+        if let Some(displaced) = displaced {
+            tracing::warn!(
+                ?id,
+                new_address = ?address,
+                displaced_address = ?displaced,
+                "window_registry: replacing an existing window mapping"
+            );
+        }
+        debug_assert_eq!(
+            self.resolve(id),
+            Some(address),
+            "BUG: window_registry install-time self-check failed immediately after insert"
+        );
+        displaced
+    }
+
+    /// The strict, design-for-N alternative to [`Self::register_window`]:
+    /// refuses instead of replacing when `id` is already mapped.
+    ///
+    /// Not dead code despite zero production call sites today — exercised
+    /// by this module's own tests, and reserved for a future multi-window
+    /// install path that chooses strict-vs-replace per call site.
+    pub(crate) fn try_register(
+        &mut self,
+        id: WindowId,
+        address: UiAddress,
+    ) -> Result<(), RegistryError> {
+        if let Some(existing) = self.resolve(id) {
+            return Err(RegistryError::WindowAlreadyMapped { existing });
+        }
+        self.entries.push((id, address));
+        Ok(())
+    }
+
+    /// Looks up the address currently mapped to `id`, if any.
+    pub(crate) fn resolve(&self, id: WindowId) -> Option<UiAddress> {
+        self.entries
+            .iter()
+            .find(|(existing, _)| *existing == id)
+            .map(|(_, address)| *address)
+    }
+
+    /// Removes and returns the sole entry for `realm_id`, if one exists.
+    ///
+    /// This is the teardown real read: the caller asserts the returned
+    /// entry against the address it installed, proving the registry tracked
+    /// the same window/address pair for this realm's whole lifetime.
+    pub(crate) fn remove_realm(&mut self, realm_id: RealmId) -> Option<(WindowId, UiAddress)> {
+        let position = self
+            .entries
+            .iter()
+            .position(|(_, address)| address.realm_id == realm_id)?;
+        Some(self.entries.remove(position))
+    }
 }
 
 #[cfg(test)]
@@ -43,5 +180,129 @@ mod tests {
             presentation_id: PresentationId::new_gen(0, NonZeroU32::new(2).unwrap()),
         };
         assert_ne!(one, same_realm_different_presentation);
+    }
+
+    fn address(slot: u32) -> UiAddress {
+        UiAddress {
+            realm_id: RealmId::new_gen(slot, NonZeroU32::MIN),
+            presentation_id: PresentationId::new_gen(slot, NonZeroU32::MIN),
+        }
+    }
+
+    struct StubWindow(WindowId);
+
+    impl PlatformWindow for StubWindow {
+        fn id(&self) -> WindowId {
+            self.0
+        }
+
+        fn physical_size(&self) -> flui_types::geometry::Size<flui_types::geometry::DevicePixels> {
+            flui_types::geometry::Size::default()
+        }
+
+        fn logical_size(&self) -> flui_types::geometry::Size<flui_types::Pixels> {
+            flui_types::geometry::Size::default()
+        }
+
+        fn scale_factor(&self) -> f64 {
+            1.0
+        }
+
+        fn request_redraw(&self) {}
+
+        fn is_focused(&self) -> bool {
+            false
+        }
+
+        fn is_visible(&self) -> bool {
+            true
+        }
+
+        fn set_cursor(
+            &self,
+            _cursor: flui_platform::CursorIcon,
+        ) -> Result<(), flui_platform::CursorError> {
+            Ok(())
+        }
+    }
+
+    fn stub_window(id: u64) -> Arc<dyn PlatformWindow> {
+        Arc::new(StubWindow(WindowId(id)))
+    }
+
+    #[test]
+    fn register_window_replaces_same_window_with_trace() {
+        let mut registry = WindowRegistry::new();
+        let window = stub_window(1);
+        let first = address(0);
+        let second = address(1);
+
+        assert_eq!(registry.register_window(&window, first), None);
+        let displaced = registry.register_window(&window, second);
+        assert_eq!(
+            displaced,
+            Some(first),
+            "re-registering the same window must return the displaced address"
+        );
+        assert_eq!(registry.resolve(window.id()), Some(second));
+    }
+
+    #[test]
+    fn try_register_rejects_duplicate_window() {
+        let mut registry = WindowRegistry::new();
+        let id = WindowId(7);
+        let first = address(0);
+
+        registry
+            .try_register(id, first)
+            .expect("first registration succeeds");
+        let error = registry
+            .try_register(id, address(1))
+            .expect_err("duplicate window must be refused, not replaced");
+        assert_eq!(
+            error,
+            RegistryError::WindowAlreadyMapped { existing: first }
+        );
+        assert_eq!(
+            registry.resolve(id),
+            Some(first),
+            "a refused try_register must not change the existing mapping"
+        );
+    }
+
+    #[test]
+    fn remove_realm_returns_the_installed_entry() {
+        let mut registry = WindowRegistry::new();
+        let window = stub_window(3);
+        let installed = address(0);
+        registry.register_window(&window, installed);
+
+        let removed = registry.remove_realm(installed.realm_id);
+        assert_eq!(
+            removed,
+            Some((window.id(), installed)),
+            "teardown must return exactly the entry that was installed"
+        );
+        assert_eq!(
+            registry.resolve(window.id()),
+            None,
+            "the entry must be gone after removal"
+        );
+    }
+
+    #[test]
+    fn two_windows_get_two_distinct_addresses() {
+        let mut registry = WindowRegistry::new();
+        let window_a = stub_window(10);
+        let window_b = stub_window(20);
+        let address_a = address(0);
+        let address_b = address(1);
+
+        registry.register_window(&window_a, address_a);
+        registry.register_window(&window_b, address_b);
+
+        assert_eq!(registry.resolve(window_a.id()), Some(address_a));
+        assert_eq!(registry.resolve(window_b.id()), Some(address_b));
+        assert_ne!(address_a, address_b);
     }
 }

--- a/crates/flui-app/src/app/window_registry.rs
+++ b/crates/flui-app/src/app/window_registry.rs
@@ -1,43 +1,30 @@
-//! The single `WindowId -> UiAddress` mapping authority.
+//! The single `WindowId -> PresentationAddress` mapping authority.
 //!
 //! ADR-0037 §2 names one authority for the native-window-to-presentation
 //! map; no second one may live in `AppBinding`, `UiRealm`, an input
 //! registry, or a platform callback. This module is that authority's home.
 //! `WindowId` (the platform-internal native-handle key) is confined to this
 //! file within `flui-app` — every other module addresses a presentation
-//! through [`UiAddress`] only, minted here. The mechanical
+//! through [`PresentationAddress`] only, minted here. The mechanical
 //! `forbidden_pattern` scan in `docs/runtime-contract.toml` confines the
 //! `WindowId` token itself to this one file within `crates/flui-app/src`.
 //!
 //! # Derived-cache invariant
 //!
-//! `RealmHost.address: Option<UiAddress>` (`runner.rs`) is a **derived
-//! cache** of this registry, not a second source of truth. Both are written
-//! only by `install_platform_realm`/`teardown_platform_realm`, inside the
-//! same TLS borrow, in that order: on install, the registry is written
-//! first, then the cache; on teardown, the registry entry is removed first
-//! — so map removal stops new routing before the queued old-generation
-//! events still sitting in the host's queue are dropped (ADR-0037 §2).
+//! `RealmHost.address: Option<PresentationAddress>` (`runner.rs`) is a
+//! **derived cache** of this registry, not a second source of truth. Both
+//! are written only by `install_platform_realm`/`teardown_platform_realm`,
+//! inside the same TLS borrow, in that order: on install, the registry is
+//! written first (which also removes every mapping of a realm displaced by
+//! a panic-recovery reinstall — never just the new window), then the
+//! cache; on teardown, the registry entries are removed first — so map
+//! removal stops new routing before the queued old-generation events still
+//! sitting in the host's queue are dropped (ADR-0037 §2).
 
 use std::sync::Arc;
 
-use flui_foundation::{PresentationId, RealmId};
+use flui_foundation::{PresentationAddress, RealmId};
 use flui_platform::traits::{PlatformWindow, WindowId};
-
-/// One presentation's routable address: which realm incarnation owns it,
-/// and which presentation incarnation within that realm.
-///
-/// Field names match the `RealmDispatcher.realm_id` precedent
-/// (`runner.rs`) and ADR-0037 §7's literal `SemanticsCommand` fields —
-/// `realm_id`/`presentation_id`, not a bare tuple or abbreviated names.
-///
-/// Deliberately `flui-app`-private: it graduates to `flui-foundation` only
-/// when a second crate needs it (rule of three).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct UiAddress {
-    pub(crate) realm_id: RealmId,
-    pub(crate) presentation_id: PresentationId,
-}
 
 /// Errors from [`WindowRegistry::try_register`].
 // The strict path has no production call site yet (today's single-window
@@ -61,21 +48,22 @@ pub(crate) enum RegistryError {
     #[error("window is already mapped to {existing:?}")]
     WindowAlreadyMapped {
         /// The address the window was already mapped to.
-        existing: UiAddress,
+        existing: PresentationAddress,
     },
 }
 
-/// The sole `WindowId -> UiAddress` mint/lookup authority.
+/// The sole `WindowId -> PresentationAddress` mint/lookup authority.
 ///
-/// API designed for N windows, instantiated for exactly one today: storage
-/// is a plain linear-scan `Vec` with no TLS assumption inside the type
-/// itself — a future multi-window `AppRuntime` lifts this struct unchanged.
-/// `WindowId` never crosses this module's boundary except through the
-/// methods below, which take an already-known window/id and hand back an
-/// address; callers outside this file never construct or hold a `WindowId`.
+/// API designed for N windows per realm, instantiated for exactly one
+/// window today: storage is a plain linear-scan `Vec` with no TLS
+/// assumption inside the type itself — a future multi-window `AppRuntime`
+/// lifts this struct unchanged. `WindowId` never crosses this module's
+/// boundary except through the methods below, which take an already-known
+/// window/id and hand back an address; callers outside this file never
+/// construct or hold a `WindowId`.
 #[derive(Debug, Default)]
 pub(crate) struct WindowRegistry {
-    entries: Vec<(WindowId, UiAddress)>,
+    entries: Vec<(WindowId, PresentationAddress)>,
 }
 
 impl WindowRegistry {
@@ -97,6 +85,12 @@ impl WindowRegistry {
     /// visible; [`Self::try_register`] is the strict alternative for a
     /// caller that wants a hard error instead.
     ///
+    /// This only replaces the mapping for the exact same `WindowId` — it
+    /// does **not** remove any *other* window mapped to a realm this
+    /// address's realm is displacing. A caller reinstalling an entire realm
+    /// under a fresh window must call [`Self::remove_realm`] for the
+    /// displaced realm first (see `install_platform_realm`'s use of both).
+    ///
     /// Calls `window.id()` internally so callers never need to name
     /// [`WindowId`] themselves. Performs the install-time self-check read
     /// immediately after inserting: the very next [`Self::resolve`] must
@@ -104,8 +98,8 @@ impl WindowRegistry {
     pub(crate) fn register_window(
         &mut self,
         window: &Arc<dyn PlatformWindow>,
-        address: UiAddress,
-    ) -> Option<UiAddress> {
+        address: PresentationAddress,
+    ) -> Option<PresentationAddress> {
         let id = window.id();
         let displaced = if let Some(entry) = self
             .entries
@@ -149,7 +143,7 @@ impl WindowRegistry {
     pub(crate) fn try_register(
         &mut self,
         id: WindowId,
-        address: UiAddress,
+        address: PresentationAddress,
     ) -> Result<(), RegistryError> {
         if let Some(existing) = self.resolve(id) {
             return Err(RegistryError::WindowAlreadyMapped { existing });
@@ -159,34 +153,57 @@ impl WindowRegistry {
     }
 
     /// Looks up the address currently mapped to `id`, if any.
-    pub(crate) fn resolve(&self, id: WindowId) -> Option<UiAddress> {
+    pub(crate) fn resolve(&self, id: WindowId) -> Option<PresentationAddress> {
         self.entries
             .iter()
             .find(|(existing, _)| *existing == id)
             .map(|(_, address)| *address)
     }
 
-    /// Removes and returns the sole entry for `realm_id`, if one exists.
+    /// Removes and returns **every** entry addressed to `realm_id`.
     ///
-    /// This is the teardown real read: the caller asserts the returned
-    /// entry against the address it installed, proving the registry tracked
-    /// the same window/address pair for this realm's whole lifetime.
-    // `teardown_platform_realm` (runner.rs) is the only production caller,
-    // and it does not exist on wasm32 — the web host never tears down (see
-    // its own module doc) — so the wasm lib check sees this as dead.
-    #[cfg_attr(
-        target_arch = "wasm32",
-        expect(
-            dead_code,
-            reason = "consumed only by teardown_platform_realm, which does not exist on wasm32, and by this module's tests"
-        )
-    )]
-    pub(crate) fn remove_realm(&mut self, realm_id: RealmId) -> Option<(WindowId, UiAddress)> {
-        let position = self
-            .entries
-            .iter()
-            .position(|(_, address)| address.realm_id == realm_id)?;
-        Some(self.entries.remove(position))
+    /// The target model is one realm owning any number of windows, so a
+    /// realm's teardown (or its displacement by a panic-recovery reinstall)
+    /// must not leave a second, third, ... window's mapping behind just
+    /// because only the first one happened to be removed. This is the
+    /// teardown real read: the caller asserts the returned entries against
+    /// the address(es) it installed, proving the registry tracked the same
+    /// window/address pairs for this realm's whole lifetime.
+    // `teardown_platform_realm` and `install_platform_realm` (runner.rs) are
+    // the only production callers, and `teardown_platform_realm` does not
+    // exist on wasm32 — the web host never tears down (see its own module
+    // doc) — so the wasm lib check would see this as dead if
+    // `install_platform_realm`'s reinstall-cleanup call did not also reach
+    // it; kept unconditional since that second call site is not wasm-gated.
+    pub(crate) fn remove_realm(
+        &mut self,
+        realm_id: RealmId,
+    ) -> Vec<(WindowId, PresentationAddress)> {
+        let mut removed = Vec::new();
+        self.entries.retain(|(id, address)| {
+            if address.realm_id == realm_id {
+                removed.push((*id, *address));
+                false
+            } else {
+                true
+            }
+        });
+        removed
+    }
+
+    /// The number of window mappings currently held. Test/introspection
+    /// only — production code never needs to enumerate the registry, only
+    /// resolve or remove by identity.
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Companion to [`Self::len`] (clippy's `len_without_is_empty`); also
+    /// exercised directly by this module's own tests.
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
     }
 }
 
@@ -196,25 +213,28 @@ mod tests {
 
     use super::*;
 
-    static_assertions::assert_impl_all!(UiAddress: Send, Sync, Copy);
+    static_assertions::assert_impl_all!(PresentationAddress: Send, Sync, Copy);
 
     #[test]
     fn addresses_compare_by_both_fields() {
-        let one = UiAddress {
+        let one = PresentationAddress {
             realm_id: RealmId::new_gen(0, NonZeroU32::MIN),
-            presentation_id: PresentationId::new_gen(0, NonZeroU32::MIN),
+            presentation_id: flui_foundation::PresentationId::new_gen(0, NonZeroU32::MIN),
         };
-        let same_realm_different_presentation = UiAddress {
+        let same_realm_different_presentation = PresentationAddress {
             realm_id: one.realm_id,
-            presentation_id: PresentationId::new_gen(0, NonZeroU32::new(2).unwrap()),
+            presentation_id: flui_foundation::PresentationId::new_gen(
+                0,
+                NonZeroU32::new(2).unwrap(),
+            ),
         };
         assert_ne!(one, same_realm_different_presentation);
     }
 
-    fn address(slot: u32) -> UiAddress {
-        UiAddress {
+    fn address(slot: u32) -> PresentationAddress {
+        PresentationAddress {
             realm_id: RealmId::new_gen(slot, NonZeroU32::MIN),
-            presentation_id: PresentationId::new_gen(slot, NonZeroU32::MIN),
+            presentation_id: flui_foundation::PresentationId::new_gen(slot, NonZeroU32::MIN),
         }
     }
 
@@ -309,14 +329,54 @@ mod tests {
         let removed = registry.remove_realm(installed.realm_id);
         assert_eq!(
             removed,
-            Some((window.id(), installed)),
-            "teardown must return exactly the entry that was installed"
+            vec![(window.id(), installed)],
+            "teardown must return exactly the entries that were installed"
         );
         assert_eq!(
             registry.resolve(window.id()),
             None,
             "the entry must be gone after removal"
         );
+        assert!(registry.is_empty());
+    }
+
+    /// The target model is one realm owning any number of windows:
+    /// `remove_realm` must remove every mapping addressed to that realm,
+    /// not just the first one found.
+    ///
+    /// If reverted: use `position` + single `remove` instead of `retain` and
+    /// this fails — only the first-registered window's mapping is removed,
+    /// the second survives as a dead entry.
+    #[test]
+    fn remove_realm_removes_every_mapping_for_that_realm_not_just_the_first() {
+        let mut registry = WindowRegistry::new();
+        let realm_address = address(0);
+        let same_realm_second_window = PresentationAddress {
+            realm_id: realm_address.realm_id,
+            presentation_id: flui_foundation::PresentationId::new_gen(1, NonZeroU32::MIN),
+        };
+        let other_realm_address = address(1);
+
+        let window_a = stub_window(100);
+        let window_b = stub_window(101);
+        let window_c = stub_window(102);
+        registry.register_window(&window_a, realm_address);
+        registry.register_window(&window_b, same_realm_second_window);
+        registry.register_window(&window_c, other_realm_address);
+
+        let removed = registry.remove_realm(realm_address.realm_id);
+        assert_eq!(removed.len(), 2, "both same-realm windows must be removed");
+        assert!(removed.contains(&(window_a.id(), realm_address)));
+        assert!(removed.contains(&(window_b.id(), same_realm_second_window)));
+
+        assert_eq!(registry.resolve(window_a.id()), None);
+        assert_eq!(registry.resolve(window_b.id()), None);
+        assert_eq!(
+            registry.resolve(window_c.id()),
+            Some(other_realm_address),
+            "an unrelated realm's window mapping must survive"
+        );
+        assert_eq!(registry.len(), 1);
     }
 
     #[test]

--- a/crates/flui-engine/src/lib.rs
+++ b/crates/flui-engine/src/lib.rs
@@ -148,6 +148,7 @@ pub use raster::RasterBackend;
 // Raster mailbox + dedicated ack channel boundary.
 pub use raster_owner::{
     FrameDropReason, PumpOutcome, RasterAck, RasterHandle, RasterOwner, RasterSubmitError,
+    SurfaceState,
 };
 #[cfg(all(feature = "wgpu-backend", debug_assertions))]
 pub use wgpu::DebugBackend;

--- a/crates/flui-engine/src/raster_owner.rs
+++ b/crates/flui-engine/src/raster_owner.rs
@@ -38,7 +38,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crossbeam_channel::{Receiver, Sender, TrySendError, bounded};
-use flui_foundation::{FrameEpoch, SurfaceGeneration};
+use flui_foundation::{FrameEpoch, PresentationId, SurfaceGeneration};
 use flui_layer::SceneSnapshot;
 use parking_lot::{Condvar, Mutex};
 
@@ -136,18 +136,34 @@ impl RasterMailbox {
 /// load-bearing for correctness — see the module docs for why shutdown
 /// completion rides a separate, guaranteed channel instead of a variant
 /// here.
+///
+/// Every variant carries the submitting frame's `presentation_id`: the owner
+/// **echoes** the stamp the frame arrived with, it never mints one. This is
+/// the deterministic drop predicate a consumer applies once presentations
+/// are addressed: `ack.presentation_id != live_presentation` means the ack
+/// is stale and must be dropped. The predicate is about the ack's *content*,
+/// not its *delivery* — this channel is lossy telemetry (see the module
+/// docs), so an ack for a live presentation can still simply never arrive.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RasterAck {
     /// The frame with this epoch rendered and presented.
+    #[non_exhaustive]
     Presented {
         /// The presented frame's epoch.
         epoch: FrameEpoch,
+        /// The presented frame's presentation, echoed from the submitted
+        /// [`SceneSnapshot`].
+        presentation_id: PresentationId,
     },
     /// The frame with this epoch was dropped without presenting.
+    #[non_exhaustive]
     Dropped {
         /// The dropped frame's epoch.
         epoch: FrameEpoch,
+        /// The dropped frame's presentation, echoed from the submitted
+        /// [`SceneSnapshot`].
+        presentation_id: PresentationId,
         /// Why it was dropped.
         reason: FrameDropReason,
     },
@@ -156,9 +172,13 @@ pub enum RasterAck {
     /// before ever reaching the backend (the frame's stamped generation is
     /// older than the owner's current one, or reported by the
     /// backend itself during render.
+    #[non_exhaustive]
     SurfaceOutdated {
         /// The rejected frame's epoch.
         epoch: FrameEpoch,
+        /// The rejected frame's presentation, echoed from the submitted
+        /// [`SceneSnapshot`].
+        presentation_id: PresentationId,
         /// The generation the rejected frame was stamped with.
         stale: SurfaceGeneration,
         /// The owner's current surface generation — the value the consumer
@@ -173,9 +193,13 @@ pub enum RasterAck {
     /// [`RasterAck::Dropped`] for the same frame would double-report one
     /// condition (one ack per condition). Recovery is the
     /// consumer's job, off-thread, never inline under a lock.
+    #[non_exhaustive]
     DeviceLost {
         /// The frame that was being rendered when the device was lost.
         epoch: FrameEpoch,
+        /// The frame's presentation, echoed from the submitted
+        /// [`SceneSnapshot`].
+        presentation_id: PresentationId,
     },
 }
 
@@ -289,6 +313,7 @@ impl RasterHandle {
                 // does block, `ShutdownComplete`, is never sent from here).
                 self.mailbox.send_ack(RasterAck::Dropped {
                     epoch: superseded.epoch,
+                    presentation_id: superseded.presentation_id,
                     reason: FrameDropReason::Superseded,
                 });
             }
@@ -331,6 +356,9 @@ impl RasterHandle {
 // ---------------------------------------------------------------------------
 
 /// What one [`RasterOwner::pump`] pass did.
+///
+/// Every variant carrying a frame identity echoes the pending frame's
+/// `presentation_id`, mirroring [`RasterAck`]'s echo-never-mint contract.
 #[non_exhaustive]
 #[must_use]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -339,27 +367,49 @@ pub enum PumpOutcome {
     /// to the backend.
     Idle,
     /// The pending frame rendered and presented.
-    Presented(FrameEpoch),
+    #[non_exhaustive]
+    Presented {
+        /// The presented frame's epoch.
+        epoch: FrameEpoch,
+        /// The presented frame's presentation, echoed from the submitted
+        /// [`SceneSnapshot`].
+        presentation_id: PresentationId,
+    },
     /// The pending frame was dropped without presenting.
+    #[non_exhaustive]
     Dropped {
         /// The dropped frame's epoch.
         epoch: FrameEpoch,
+        /// The dropped frame's presentation, echoed from the submitted
+        /// [`SceneSnapshot`].
+        presentation_id: PresentationId,
         /// Why it was dropped.
         reason: FrameDropReason,
     },
     /// The pending frame's surface generation no longer matched the
     /// owner's current one; the frame was dropped without rendering.
     /// Mirrors [`RasterAck::SurfaceOutdated`] — see its field docs.
+    #[non_exhaustive]
     SurfaceOutdated {
         /// The rejected frame's epoch.
         epoch: FrameEpoch,
+        /// The rejected frame's presentation, echoed from the submitted
+        /// [`SceneSnapshot`].
+        presentation_id: PresentationId,
         /// The generation the rejected frame was stamped with.
         stale: SurfaceGeneration,
         /// The owner's current surface generation.
         current: SurfaceGeneration,
     },
     /// The GPU device was lost while rendering this frame.
-    DeviceLost(FrameEpoch),
+    #[non_exhaustive]
+    DeviceLost {
+        /// The frame that was being rendered when the device was lost.
+        epoch: FrameEpoch,
+        /// The frame's presentation, echoed from the submitted
+        /// [`SceneSnapshot`].
+        presentation_id: PresentationId,
+    },
     /// The mailbox was empty and shutdown had been requested: the
     /// shutdown-completion one-shot channel ([`RasterOwner::new`]) was
     /// signaled and no further pumps are expected to observe work.
@@ -502,11 +552,13 @@ impl<B: RasterBackend> RasterOwner<B> {
             );
             self.mailbox.send_ack(RasterAck::SurfaceOutdated {
                 epoch: frame.epoch,
+                presentation_id: frame.presentation_id,
                 stale,
                 current,
             });
             return PumpOutcome::SurfaceOutdated {
                 epoch: frame.epoch,
+                presentation_id: frame.presentation_id,
                 stale,
                 current,
             };
@@ -530,11 +582,21 @@ impl<B: RasterBackend> RasterOwner<B> {
             // yet a consumer of any pacing model. Any `Ok` still completes
             // the render attempt with a `Presented` ack.
             Ok(_presented) => {
-                self.mailbox
-                    .send_ack(RasterAck::Presented { epoch: frame.epoch });
-                PumpOutcome::Presented(frame.epoch)
+                self.mailbox.send_ack(RasterAck::Presented {
+                    epoch: frame.epoch,
+                    presentation_id: frame.presentation_id,
+                });
+                PumpOutcome::Presented {
+                    epoch: frame.epoch,
+                    presentation_id: frame.presentation_id,
+                }
             }
-            Err(error) => self.handle_render_failure(frame.epoch, frame.surface_generation, error),
+            Err(error) => self.handle_render_failure(
+                frame.epoch,
+                frame.presentation_id,
+                frame.surface_generation,
+                error,
+            ),
         }
     }
 
@@ -567,14 +629,21 @@ impl<B: RasterBackend> RasterOwner<B> {
     fn handle_render_failure(
         &mut self,
         epoch: FrameEpoch,
+        presentation_id: PresentationId,
         stale: SurfaceGeneration,
         error: EngineError,
     ) -> PumpOutcome {
         match error {
             EngineError::DeviceLost => {
                 tracing::warn!(?epoch, "raster owner: GPU device lost");
-                self.mailbox.send_ack(RasterAck::DeviceLost { epoch });
-                PumpOutcome::DeviceLost(epoch)
+                self.mailbox.send_ack(RasterAck::DeviceLost {
+                    epoch,
+                    presentation_id,
+                });
+                PumpOutcome::DeviceLost {
+                    epoch,
+                    presentation_id,
+                }
             }
             EngineError::SurfaceLost | EngineError::SurfaceValidation => {
                 // The backend itself detected the surface is gone — a
@@ -593,11 +662,13 @@ impl<B: RasterBackend> RasterOwner<B> {
                 );
                 self.mailbox.send_ack(RasterAck::SurfaceOutdated {
                     epoch,
+                    presentation_id,
                     stale,
                     current,
                 });
                 PumpOutcome::SurfaceOutdated {
                     epoch,
+                    presentation_id,
                     stale,
                     current,
                 }
@@ -606,10 +677,12 @@ impl<B: RasterBackend> RasterOwner<B> {
                 tracing::error!(?epoch, error = %other, "raster owner: frame render failed");
                 self.mailbox.send_ack(RasterAck::Dropped {
                     epoch,
+                    presentation_id,
                     reason: FrameDropReason::RenderFailed,
                 });
                 PumpOutcome::Dropped {
                     epoch,
+                    presentation_id,
                     reason: FrameDropReason::RenderFailed,
                 }
             }
@@ -630,6 +703,7 @@ impl<B: RasterBackend> Drop for RasterOwner<B> {
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
+    use std::num::NonZeroU32;
     use std::sync::Barrier;
     use std::thread;
 
@@ -696,9 +770,24 @@ mod tests {
         }
     }
 
+    /// The presentation every test uses unless it is specifically exercising
+    /// more than one incarnation (tests 8/9 below).
+    fn test_presentation_id() -> PresentationId {
+        PresentationId::new(1)
+    }
+
     fn test_frame(epoch: FrameEpoch, surface_generation: SurfaceGeneration) -> SceneSnapshot {
+        test_frame_for(epoch, test_presentation_id(), surface_generation)
+    }
+
+    fn test_frame_for(
+        epoch: FrameEpoch,
+        presentation_id: PresentationId,
+        surface_generation: SurfaceGeneration,
+    ) -> SceneSnapshot {
         SceneSnapshot::new(
             RealmId::new(1),
+            presentation_id,
             epoch,
             surface_generation,
             DamageRegion::Full,
@@ -754,9 +843,13 @@ mod tests {
             vec![
                 RasterAck::Dropped {
                     epoch: epoch1,
+                    presentation_id: test_presentation_id(),
                     reason: FrameDropReason::Superseded,
                 },
-                RasterAck::Presented { epoch: epoch2 },
+                RasterAck::Presented {
+                    epoch: epoch2,
+                    presentation_id: test_presentation_id(),
+                },
             ]
         );
         assert_eq!(
@@ -825,12 +918,13 @@ mod tests {
                 RasterAck::Dropped {
                 epoch,
                 reason: FrameDropReason::Superseded,
+                ..
                 } if *epoch == epoch1
                 )
             });
-            let presented_epoch2_index = acks
-                .iter()
-                .position(|ack| matches!(ack, RasterAck::Presented { epoch } if *epoch == epoch2));
+            let presented_epoch2_index = acks.iter().position(
+                |ack| matches!(ack, RasterAck::Presented { epoch, .. } if *epoch == epoch2),
+            );
 
             // Two legal outcomes depending on who won the race for epoch1
             // itself: either the owner already took and presented epoch1
@@ -866,16 +960,31 @@ mod tests {
             handle
                 .submit(test_frame(epoch, SurfaceGeneration::ZERO))
                 .expect("submit");
-            assert_eq!(owner.pump(), PumpOutcome::Presented(epoch));
+            assert_eq!(
+                owner.pump(),
+                PumpOutcome::Presented {
+                    epoch,
+                    presentation_id: test_presentation_id(),
+                }
+            );
         }
 
         let acks: Vec<RasterAck> = ack_rx.try_iter().collect();
         assert_eq!(
             acks,
             vec![
-                RasterAck::Presented { epoch: epoch1 },
-                RasterAck::Presented { epoch: epoch2 },
-                RasterAck::Presented { epoch: epoch3 },
+                RasterAck::Presented {
+                    epoch: epoch1,
+                    presentation_id: test_presentation_id(),
+                },
+                RasterAck::Presented {
+                    epoch: epoch2,
+                    presentation_id: test_presentation_id(),
+                },
+                RasterAck::Presented {
+                    epoch: epoch3,
+                    presentation_id: test_presentation_id(),
+                },
             ]
         );
     }
@@ -954,6 +1063,7 @@ mod tests {
             outcome,
             PumpOutcome::Dropped {
                 epoch,
+                presentation_id: test_presentation_id(),
                 reason: FrameDropReason::RenderFailed,
             }
         );
@@ -961,6 +1071,7 @@ mod tests {
             ack_rx.try_recv().unwrap(),
             RasterAck::Dropped {
                 epoch,
+                presentation_id: test_presentation_id(),
                 reason: FrameDropReason::RenderFailed,
             }
         );
@@ -987,7 +1098,13 @@ mod tests {
             .expect("submit");
         let outcome = owner.pump();
 
-        assert_eq!(outcome, PumpOutcome::Presented(epoch));
+        assert_eq!(
+            outcome,
+            PumpOutcome::Presented {
+                epoch,
+                presentation_id: test_presentation_id(),
+            }
+        );
         owner.with_backend(|backend| {
             assert_eq!(
                 backend.resize_calls,
@@ -1012,8 +1129,20 @@ mod tests {
             .expect("submit");
 
         let outcome = owner.pump();
-        assert_eq!(outcome, PumpOutcome::DeviceLost(epoch));
-        assert_eq!(ack_rx.try_recv().unwrap(), RasterAck::DeviceLost { epoch });
+        assert_eq!(
+            outcome,
+            PumpOutcome::DeviceLost {
+                epoch,
+                presentation_id: test_presentation_id(),
+            }
+        );
+        assert_eq!(
+            ack_rx.try_recv().unwrap(),
+            RasterAck::DeviceLost {
+                epoch,
+                presentation_id: test_presentation_id(),
+            }
+        );
         // Exactly one ack: DeviceLost does not also emit a Dropped ack for
         // the same frame (one ack per condition).
         assert!(ack_rx.try_recv().is_err());
@@ -1043,6 +1172,7 @@ mod tests {
             outcome,
             PumpOutcome::SurfaceOutdated {
                 epoch,
+                presentation_id: test_presentation_id(),
                 stale,
                 current,
             }
@@ -1051,6 +1181,7 @@ mod tests {
             ack_rx.try_recv().unwrap(),
             RasterAck::SurfaceOutdated {
                 epoch,
+                presentation_id: test_presentation_id(),
                 stale,
                 current,
             }
@@ -1089,6 +1220,7 @@ mod tests {
             outcome,
             PumpOutcome::SurfaceOutdated {
                 epoch,
+                presentation_id: test_presentation_id(),
                 stale,
                 current,
             }
@@ -1097,6 +1229,7 @@ mod tests {
             ack_rx.try_recv().unwrap(),
             RasterAck::SurfaceOutdated {
                 epoch,
+                presentation_id: test_presentation_id(),
                 stale,
                 current,
             }
@@ -1144,6 +1277,157 @@ mod tests {
         assert!(
             ack_rx.try_iter().next().is_none(),
             "no telemetry ack is produced by the shutdown-complete path"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Every ack echoes the submitting frame's presentation identity rather
+    // than minting one of its own.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn acks_echo_the_submitted_frames_presentation_id() {
+        let stamp = PresentationId::new_gen(3, NonZeroU32::new(9).expect("nonzero"));
+
+        // Presented
+        {
+            let (mut owner, handle, ack_rx, _shutdown_complete_rx) =
+                RasterOwner::new(FakeBackend::default());
+            let epoch = FrameEpoch::ZERO.next();
+            handle
+                .submit(test_frame_for(epoch, stamp, SurfaceGeneration::ZERO))
+                .expect("submit");
+            assert_eq!(
+                owner.pump(),
+                PumpOutcome::Presented {
+                    epoch,
+                    presentation_id: stamp,
+                }
+            );
+            assert_eq!(
+                ack_rx.try_recv().unwrap(),
+                RasterAck::Presented {
+                    epoch,
+                    presentation_id: stamp,
+                }
+            );
+        }
+
+        // Dropped (Superseded)
+        {
+            let (owner, handle, ack_rx, _shutdown_complete_rx) =
+                RasterOwner::new(FakeBackend::default());
+            let epoch1 = FrameEpoch::ZERO.next();
+            let epoch2 = epoch1.next();
+            handle
+                .submit(test_frame_for(epoch1, stamp, SurfaceGeneration::ZERO))
+                .expect("first submit");
+            handle
+                .submit(test_frame_for(epoch2, stamp, SurfaceGeneration::ZERO))
+                .expect("second submit supersedes the first");
+            assert_eq!(
+                ack_rx.try_recv().unwrap(),
+                RasterAck::Dropped {
+                    epoch: epoch1,
+                    presentation_id: stamp,
+                    reason: FrameDropReason::Superseded,
+                }
+            );
+            drop(owner);
+        }
+
+        // SurfaceOutdated
+        {
+            let (mut owner, handle, ack_rx, _shutdown_complete_rx) =
+                RasterOwner::new(FakeBackend::default());
+            handle.resize(100, 100);
+            let epoch = FrameEpoch::ZERO.next();
+            handle
+                .submit(test_frame_for(epoch, stamp, SurfaceGeneration::ZERO))
+                .expect("submit");
+            let outcome = owner.pump();
+            let PumpOutcome::SurfaceOutdated {
+                presentation_id, ..
+            } = outcome
+            else {
+                panic!("expected SurfaceOutdated, got {outcome:?}");
+            };
+            assert_eq!(presentation_id, stamp);
+            let ack = ack_rx.try_recv().unwrap();
+            let RasterAck::SurfaceOutdated {
+                presentation_id, ..
+            } = ack
+            else {
+                panic!("expected a SurfaceOutdated ack, got {ack:?}");
+            };
+            assert_eq!(presentation_id, stamp);
+        }
+
+        // DeviceLost
+        {
+            let backend = FakeBackend::with_planned([Err(EngineError::DeviceLost)]);
+            let (mut owner, handle, ack_rx, _shutdown_complete_rx) = RasterOwner::new(backend);
+            let epoch = FrameEpoch::ZERO.next();
+            handle
+                .submit(test_frame_for(epoch, stamp, SurfaceGeneration::ZERO))
+                .expect("submit");
+            assert_eq!(
+                owner.pump(),
+                PumpOutcome::DeviceLost {
+                    epoch,
+                    presentation_id: stamp,
+                }
+            );
+            assert_eq!(
+                ack_rx.try_recv().unwrap(),
+                RasterAck::DeviceLost {
+                    epoch,
+                    presentation_id: stamp,
+                }
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // A late ack fails the address predicate a consumer applies once its
+    // presentation has been torn down and recreated: same slot, new
+    // generation, never equal.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn late_ack_after_presentation_recreation_fails_the_address_predicate() {
+        let incarnation_one = PresentationId::new_gen(0, NonZeroU32::new(1).expect("nonzero"));
+        let (mut owner, handle, ack_rx, _shutdown_complete_rx) =
+            RasterOwner::new(FakeBackend::default());
+        let epoch = FrameEpoch::ZERO.next();
+        handle
+            .submit(test_frame_for(
+                epoch,
+                incarnation_one,
+                SurfaceGeneration::ZERO,
+            ))
+            .expect("submit");
+        assert_eq!(
+            owner.pump(),
+            PumpOutcome::Presented {
+                epoch,
+                presentation_id: incarnation_one,
+            }
+        );
+        let ack = ack_rx.try_recv().expect("presented ack arrives");
+        let RasterAck::Presented {
+            presentation_id, ..
+        } = ack
+        else {
+            panic!("expected a Presented ack, got {ack:?}");
+        };
+
+        // The consumer's presentation was torn down and reinstalled while
+        // this ack was in flight: same slot, next generation.
+        let live_incarnation = PresentationId::new_gen(0, NonZeroU32::new(2).expect("nonzero"));
+        assert_ne!(
+            presentation_id, live_incarnation,
+            "a late ack's stamp must compare unequal to a recreated live presentation"
         );
     }
 }

--- a/crates/flui-engine/src/raster_owner.rs
+++ b/crates/flui-engine/src/raster_owner.rs
@@ -7,16 +7,27 @@
 //! is acknowledged [`FrameDropReason::Superseded`] immediately, synchronously,
 //! at submit time.
 //!
-//! Two structurally separate channels carry outcomes off this module, never
-//! the owner's general inbox (riding the inbox would deadlock
+//! Three structurally separate mechanisms carry outcomes off this module,
+//! never the owner's general inbox (riding the inbox would deadlock
 //! shutdown, since the inbox flips to drain-and-refuse before an outcome is
 //! ready to send):
 //!
 //! - A **lossy telemetry ack** channel ([`RasterAck`]: presented, dropped,
-//! surface-outdated, device-lost) — useful for diagnostics and
-//! surface-generation feedback, never load-bearing for correctness. A full
-//! channel drops the newest ack and logs it rather than ever blocking the
-//! pump loop.
+//! surface-outdated, device-lost) — useful for diagnostics, never
+//! load-bearing for correctness. A full channel drops the newest ack and
+//! logs it rather than ever blocking the pump loop.
+//! - A **reliable, coalesced [`SurfaceState`] slot** ([`RasterHandle::surface_state`]),
+//! read directly rather than delivered over a channel. `SurfaceOutdated` and
+//! `DeviceLost` are recovery-critical — the generation the consumer's next
+//! frame must be stamped with, and the device-lost recovery trigger — so
+//! they may NOT depend on the lossy ack lane ever actually delivering: a
+//! full ack channel must never leave a consumer stamping frames against a
+//! stale generation, or never learning its device was lost, forever. The
+//! corresponding `RasterAck` variants still exist and still ride the ack
+//! lane too (existing ack-only consumers keep working unchanged), but this
+//! slot is the one a consumer MUST poll to observe these two conditions
+//! reliably. `Presented`/`Dropped` stay lossy-telemetry-only — they carry no
+//! state a consumer cannot simply infer from submitting again.
 //! - A **load-bearing one-shot shutdown-completion** channel, returned
 //! separately from [`RasterOwner::new`]. Kept structurally apart from the
 //! telemetry channel so no volume of lossy acks (e.g. a frame superseded a
@@ -38,7 +49,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crossbeam_channel::{Receiver, Sender, TrySendError, bounded};
-use flui_foundation::{FrameEpoch, PresentationId, SurfaceGeneration};
+use flui_foundation::{FrameEpoch, PresentationAddress, SurfaceGeneration};
 use flui_layer::SceneSnapshot;
 use parking_lot::{Condvar, Mutex};
 
@@ -65,6 +76,31 @@ const ACK_CHANNEL_CAPACITY: usize = 16;
 /// channel) is the point of this design — an unbounded flood of telemetry
 /// acks can never block or displace it.
 const SHUTDOWN_COMPLETE_CHANNEL_CAPACITY: usize = 1;
+
+// ---------------------------------------------------------------------------
+// Reliable, coalesced surface state
+// ---------------------------------------------------------------------------
+
+/// Reliable, coalesced surface state — read directly via
+/// [`RasterHandle::surface_state`], never delivered over the lossy
+/// telemetry ack lane. See the module docs for why `SurfaceOutdated` and
+/// `DeviceLost` need this and `Presented`/`Dropped` do not.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SurfaceState {
+    /// The surface generation the owner currently considers valid — the
+    /// value a consumer's next `SceneSnapshot` must be stamped with.
+    /// Updated every time the owner reconfigures the surface (a coalesced
+    /// resize, or the backend itself reporting the surface outdated),
+    /// unconditionally, regardless of whether the corresponding
+    /// [`RasterAck::SurfaceOutdated`] ever reaches the ack lane.
+    pub required_generation: SurfaceGeneration,
+    /// Whether the owner's GPU device is currently considered lost. Set the
+    /// moment [`RasterAck::DeviceLost`] would fire, cleared the next time a
+    /// frame presents successfully — recovery is the consumer's job, this
+    /// flag only reports the condition reliably.
+    pub device_lost: bool,
+}
 
 // ---------------------------------------------------------------------------
 // Mailbox (private)
@@ -96,6 +132,13 @@ struct MailboxState {
 /// from the ack channel so no volume of telemetry can ever
 /// block or displace the completion signal.
 struct RasterMailbox {
+    /// The exact presentation this owner was bound to at construction
+    /// (ADR-0037). Two different realm incarnations can mint an identical
+    /// `PresentationId`, so this is the full `(realm_id, presentation_id)`
+    /// pair, never `PresentationId` alone — [`RasterHandle::submit`]
+    /// validates every frame against it and rejects a mismatch instead of
+    /// silently accepting a frame addressed to a different presentation.
+    address: PresentationAddress,
     state: Mutex<MailboxState>,
     condvar: Condvar,
     /// Flipped to `false` when the owning [`RasterOwner`] drops, including a
@@ -108,6 +151,9 @@ struct RasterMailbox {
     /// observed empty and shutting down. `try_send`-only, same as
     /// [`Self::send_ack`] — no send in this module ever blocks.
     shutdown_complete_tx: Sender<()>,
+    /// The reliable, coalesced counterpart to the lossy `SurfaceOutdated`/
+    /// `DeviceLost` acks — see the module docs and [`SurfaceState`].
+    surface_state: Mutex<SurfaceState>,
 }
 
 impl RasterMailbox {
@@ -125,6 +171,23 @@ impl RasterMailbox {
             tracing::warn!(?dropped, "raster ack channel full; dropping ack");
         }
     }
+
+    /// Updates the reliable [`SurfaceState`] slot's required generation.
+    /// Called unconditionally alongside every
+    /// `send_ack(RasterAck::SurfaceOutdated { .. })` and every coalesced
+    /// resize — never only on the lossy ack path — so the slot is correct
+    /// regardless of whether that ack lands on the (possibly full) channel.
+    fn set_required_generation(&self, required_generation: SurfaceGeneration) {
+        self.surface_state.lock().required_generation = required_generation;
+    }
+
+    /// Updates the reliable [`SurfaceState`] slot's device-lost flag. Called
+    /// unconditionally alongside every `send_ack(RasterAck::DeviceLost { .. })`
+    /// and on every successful present (which clears it) — never only on
+    /// the lossy ack path.
+    fn set_device_lost(&self, device_lost: bool) {
+        self.surface_state.lock().device_lost = device_lost;
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -137,10 +200,12 @@ impl RasterMailbox {
 /// completion rides a separate, guaranteed channel instead of a variant
 /// here.
 ///
-/// Every variant carries the submitting frame's `presentation_id`: the owner
-/// **echoes** the stamp the frame arrived with, it never mints one. This is
-/// the deterministic drop predicate a consumer applies once presentations
-/// are addressed: `ack.presentation_id != live_presentation` means the ack
+/// Every variant carries the submitting frame's full `address` (never bare
+/// `PresentationId` — two different realms can mint an identical
+/// `PresentationId`, so only the full pair is safely distinguishable): the
+/// owner **echoes** the stamp the frame arrived with, it never mints one.
+/// This is the deterministic drop predicate a consumer applies once
+/// presentations are addressed: `ack.address != live_address` means the ack
 /// is stale and must be dropped. The predicate is about the ack's *content*,
 /// not its *delivery* — this channel is lossy telemetry (see the module
 /// docs), so an ack for a live presentation can still simply never arrive.
@@ -152,18 +217,18 @@ pub enum RasterAck {
     Presented {
         /// The presented frame's epoch.
         epoch: FrameEpoch,
-        /// The presented frame's presentation, echoed from the submitted
+        /// The presented frame's address, echoed from the submitted
         /// [`SceneSnapshot`].
-        presentation_id: PresentationId,
+        address: PresentationAddress,
     },
     /// The frame with this epoch was dropped without presenting.
     #[non_exhaustive]
     Dropped {
         /// The dropped frame's epoch.
         epoch: FrameEpoch,
-        /// The dropped frame's presentation, echoed from the submitted
+        /// The dropped frame's address, echoed from the submitted
         /// [`SceneSnapshot`].
-        presentation_id: PresentationId,
+        address: PresentationAddress,
         /// Why it was dropped.
         reason: FrameDropReason,
     },
@@ -176,9 +241,9 @@ pub enum RasterAck {
     SurfaceOutdated {
         /// The rejected frame's epoch.
         epoch: FrameEpoch,
-        /// The rejected frame's presentation, echoed from the submitted
+        /// The rejected frame's address, echoed from the submitted
         /// [`SceneSnapshot`].
-        presentation_id: PresentationId,
+        address: PresentationAddress,
         /// The generation the rejected frame was stamped with.
         stale: SurfaceGeneration,
         /// The owner's current surface generation — the value the consumer
@@ -197,9 +262,9 @@ pub enum RasterAck {
     DeviceLost {
         /// The frame that was being rendered when the device was lost.
         epoch: FrameEpoch,
-        /// The frame's presentation, echoed from the submitted
+        /// The frame's address, echoed from the submitted
         /// [`SceneSnapshot`].
-        presentation_id: PresentationId,
+        address: PresentationAddress,
     },
 }
 
@@ -242,6 +307,19 @@ pub enum RasterSubmitError {
     /// permanently inert.
     #[error("raster owner dropped; frame submit refused")]
     OwnerGone,
+    /// The submitted frame's address does not match the address this owner
+    /// was bound to at construction (ADR-0037). Two different realm
+    /// incarnations can mint an identical `PresentationId` at the same slot,
+    /// so a frame addressed to any other presentation — even one that
+    /// happens to share this owner's `presentation_id` but not its
+    /// `realm_id` — is never silently accepted.
+    #[error("frame address {got:?} does not match this raster owner's bound address {expected:?}")]
+    AddressMismatch {
+        /// The address this owner was constructed with.
+        expected: PresentationAddress,
+        /// The address stamped on the rejected frame.
+        got: PresentationAddress,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -282,10 +360,19 @@ impl RasterHandle {
     ///
     /// # Errors
     ///
-    /// [`RasterSubmitError::ShuttingDown`] once [`Self::shutdown`] has been
-    /// called; [`RasterSubmitError::OwnerGone`] once the owning
-    /// [`RasterOwner`] has dropped.
+    /// [`RasterSubmitError::AddressMismatch`] if `frame.address` does not
+    /// match the address this owner was constructed with — checked first,
+    /// regardless of lifecycle state, since it is a protocol violation, not
+    /// a backpressure/lifecycle condition; [`RasterSubmitError::ShuttingDown`]
+    /// once [`Self::shutdown`] has been called; [`RasterSubmitError::OwnerGone`]
+    /// once the owning [`RasterOwner`] has dropped.
     pub fn submit(&self, frame: SceneSnapshot) -> Result<(), RasterSubmitError> {
+        if frame.address != self.mailbox.address {
+            return Err(RasterSubmitError::AddressMismatch {
+                expected: self.mailbox.address,
+                got: frame.address,
+            });
+        }
         {
             let mut state = self.mailbox.state.lock();
             if state.shutting_down {
@@ -313,7 +400,7 @@ impl RasterHandle {
                 // does block, `ShutdownComplete`, is never sent from here).
                 self.mailbox.send_ack(RasterAck::Dropped {
                     epoch: superseded.epoch,
-                    presentation_id: superseded.presentation_id,
+                    address: superseded.address,
                     reason: FrameDropReason::Superseded,
                 });
             }
@@ -349,6 +436,16 @@ impl RasterHandle {
         drop(state);
         self.mailbox.condvar.notify_all();
     }
+
+    /// The current reliable, coalesced [`SurfaceState`] — the required
+    /// surface generation and device-lost flag, always up to date
+    /// regardless of the lossy ack lane's capacity. See the module docs for
+    /// why `SurfaceOutdated`/`DeviceLost` need this instead of only riding
+    /// [`RasterOwner::new`]'s ack `Receiver`.
+    #[must_use]
+    pub fn surface_state(&self) -> SurfaceState {
+        *self.mailbox.surface_state.lock()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -357,8 +454,8 @@ impl RasterHandle {
 
 /// What one [`RasterOwner::pump`] pass did.
 ///
-/// Every variant carrying a frame identity echoes the pending frame's
-/// `presentation_id`, mirroring [`RasterAck`]'s echo-never-mint contract.
+/// Every variant carrying a frame identity echoes the pending frame's full
+/// `address`, mirroring [`RasterAck`]'s echo-never-mint contract.
 #[non_exhaustive]
 #[must_use]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -371,18 +468,18 @@ pub enum PumpOutcome {
     Presented {
         /// The presented frame's epoch.
         epoch: FrameEpoch,
-        /// The presented frame's presentation, echoed from the submitted
+        /// The presented frame's address, echoed from the submitted
         /// [`SceneSnapshot`].
-        presentation_id: PresentationId,
+        address: PresentationAddress,
     },
     /// The pending frame was dropped without presenting.
     #[non_exhaustive]
     Dropped {
         /// The dropped frame's epoch.
         epoch: FrameEpoch,
-        /// The dropped frame's presentation, echoed from the submitted
+        /// The dropped frame's address, echoed from the submitted
         /// [`SceneSnapshot`].
-        presentation_id: PresentationId,
+        address: PresentationAddress,
         /// Why it was dropped.
         reason: FrameDropReason,
     },
@@ -393,9 +490,9 @@ pub enum PumpOutcome {
     SurfaceOutdated {
         /// The rejected frame's epoch.
         epoch: FrameEpoch,
-        /// The rejected frame's presentation, echoed from the submitted
+        /// The rejected frame's address, echoed from the submitted
         /// [`SceneSnapshot`].
-        presentation_id: PresentationId,
+        address: PresentationAddress,
         /// The generation the rejected frame was stamped with.
         stale: SurfaceGeneration,
         /// The owner's current surface generation.
@@ -406,9 +503,9 @@ pub enum PumpOutcome {
     DeviceLost {
         /// The frame that was being rendered when the device was lost.
         epoch: FrameEpoch,
-        /// The frame's presentation, echoed from the submitted
+        /// The frame's address, echoed from the submitted
         /// [`SceneSnapshot`].
-        presentation_id: PresentationId,
+        address: PresentationAddress,
     },
     /// The mailbox was empty and shutdown had been requested: the
     /// shutdown-completion one-shot channel ([`RasterOwner::new`]) was
@@ -457,17 +554,31 @@ impl<B: RasterBackend> RasterOwner<B> {
     ///   displace it.
     ///
     /// Neither channel rides the mailbox or any other inbox.
+    ///
+    /// `address` binds this owner to the exact presentation it serves
+    /// (ADR-0037): every [`RasterHandle::submit`] validates its frame
+    /// against it and rejects a mismatch with
+    /// [`RasterSubmitError::AddressMismatch`] instead of silently accepting
+    /// a frame addressed to a different presentation.
     #[must_use]
-    pub fn new(backend: B) -> (Self, RasterHandle, Receiver<RasterAck>, Receiver<()>) {
+    pub fn new(
+        backend: B,
+        address: PresentationAddress,
+    ) -> (Self, RasterHandle, Receiver<RasterAck>, Receiver<()>) {
         let (ack_tx, ack_rx) = bounded(ACK_CHANNEL_CAPACITY);
         let (shutdown_complete_tx, shutdown_complete_rx) =
             bounded(SHUTDOWN_COMPLETE_CHANNEL_CAPACITY);
         let mailbox = Arc::new(RasterMailbox {
+            address,
             state: Mutex::new(MailboxState::default()),
             condvar: Condvar::new(),
             owner_alive: AtomicBool::new(true),
             ack_tx,
             shutdown_complete_tx,
+            surface_state: Mutex::new(SurfaceState {
+                required_generation: SurfaceGeneration::ZERO,
+                device_lost: false,
+            }),
         });
         let owner = Self {
             backend,
@@ -513,6 +624,11 @@ impl<B: RasterBackend> RasterOwner<B> {
             // against the pre-resize surface is rejected below rather than
             // rendered into a torn-down swapchain.
             self.current_surface_generation = self.current_surface_generation.next();
+            // Reliable, not just the (possibly-full) ack lane: a resize is
+            // exactly the kind of surface-(re)configure event a consumer
+            // must never miss.
+            self.mailbox
+                .set_required_generation(self.current_surface_generation);
             tracing::debug!(
             surface_generation = ?self.current_surface_generation,
             "raster owner: surface reconfigured by resize"
@@ -552,13 +668,13 @@ impl<B: RasterBackend> RasterOwner<B> {
             );
             self.mailbox.send_ack(RasterAck::SurfaceOutdated {
                 epoch: frame.epoch,
-                presentation_id: frame.presentation_id,
+                address: frame.address,
                 stale,
                 current,
             });
             return PumpOutcome::SurfaceOutdated {
                 epoch: frame.epoch,
-                presentation_id: frame.presentation_id,
+                address: frame.address,
                 stale,
                 current,
             };
@@ -582,18 +698,22 @@ impl<B: RasterBackend> RasterOwner<B> {
             // yet a consumer of any pacing model. Any `Ok` still completes
             // the render attempt with a `Presented` ack.
             Ok(_presented) => {
+                // A successful present is the recovery signal: whatever
+                // device-lost state the reliable slot was carrying no
+                // longer applies.
+                self.mailbox.set_device_lost(false);
                 self.mailbox.send_ack(RasterAck::Presented {
                     epoch: frame.epoch,
-                    presentation_id: frame.presentation_id,
+                    address: frame.address,
                 });
                 PumpOutcome::Presented {
                     epoch: frame.epoch,
-                    presentation_id: frame.presentation_id,
+                    address: frame.address,
                 }
             }
             Err(error) => self.handle_render_failure(
                 frame.epoch,
-                frame.presentation_id,
+                frame.address,
                 frame.surface_generation,
                 error,
             ),
@@ -629,21 +749,20 @@ impl<B: RasterBackend> RasterOwner<B> {
     fn handle_render_failure(
         &mut self,
         epoch: FrameEpoch,
-        presentation_id: PresentationId,
+        address: PresentationAddress,
         stale: SurfaceGeneration,
         error: EngineError,
     ) -> PumpOutcome {
         match error {
             EngineError::DeviceLost => {
                 tracing::warn!(?epoch, "raster owner: GPU device lost");
-                self.mailbox.send_ack(RasterAck::DeviceLost {
-                    epoch,
-                    presentation_id,
-                });
-                PumpOutcome::DeviceLost {
-                    epoch,
-                    presentation_id,
-                }
+                // Reliable, not just the (possibly-full) ack lane: device
+                // loss is exactly the kind of recovery-critical state a
+                // consumer must never miss.
+                self.mailbox.set_device_lost(true);
+                self.mailbox
+                    .send_ack(RasterAck::DeviceLost { epoch, address });
+                PumpOutcome::DeviceLost { epoch, address }
             }
             EngineError::SurfaceLost | EngineError::SurfaceValidation => {
                 // The backend itself detected the surface is gone — a
@@ -654,6 +773,10 @@ impl<B: RasterBackend> RasterOwner<B> {
                 // proactive check in `pump` until the consumer catches up.
                 self.current_surface_generation = self.current_surface_generation.next();
                 let current = self.current_surface_generation;
+                // Same reliability requirement as the resize path above:
+                // the required generation must reach the consumer even if
+                // the ack lane is momentarily full.
+                self.mailbox.set_required_generation(current);
                 tracing::warn!(
                     ?epoch,
                     ?stale,
@@ -662,13 +785,13 @@ impl<B: RasterBackend> RasterOwner<B> {
                 );
                 self.mailbox.send_ack(RasterAck::SurfaceOutdated {
                     epoch,
-                    presentation_id,
+                    address,
                     stale,
                     current,
                 });
                 PumpOutcome::SurfaceOutdated {
                     epoch,
-                    presentation_id,
+                    address,
                     stale,
                     current,
                 }
@@ -677,12 +800,12 @@ impl<B: RasterBackend> RasterOwner<B> {
                 tracing::error!(?epoch, error = %other, "raster owner: frame render failed");
                 self.mailbox.send_ack(RasterAck::Dropped {
                     epoch,
-                    presentation_id,
+                    address,
                     reason: FrameDropReason::RenderFailed,
                 });
                 PumpOutcome::Dropped {
                     epoch,
-                    presentation_id,
+                    address,
                     reason: FrameDropReason::RenderFailed,
                 }
             }
@@ -707,7 +830,7 @@ mod tests {
     use std::sync::Barrier;
     use std::thread;
 
-    use flui_foundation::RealmId;
+    use flui_foundation::{PresentationId, RealmId};
     use flui_layer::{CanvasLayer, DamageRegion, Layer, Scene};
     use flui_types::Size;
     use flui_types::geometry::{Pixels, Rect};
@@ -770,24 +893,41 @@ mod tests {
         }
     }
 
-    /// The presentation every test uses unless it is specifically exercising
-    /// more than one incarnation (tests 8/9 below).
-    fn test_presentation_id() -> PresentationId {
-        PresentationId::new(1)
+    /// The address every test uses unless it is specifically exercising more
+    /// than one incarnation or a mismatched address (see the address tests
+    /// below).
+    fn test_address() -> PresentationAddress {
+        PresentationAddress {
+            realm_id: RealmId::new(1),
+            presentation_id: PresentationId::new(1),
+        }
+    }
+
+    /// Builds an owner bound to [`test_address`] — the address every
+    /// `test_frame`/`test_frame_for` frame carries unless told otherwise, so
+    /// ordinary tests never have to spell the binding out themselves.
+    fn new_owner(
+        backend: FakeBackend,
+    ) -> (
+        RasterOwner<FakeBackend>,
+        RasterHandle,
+        Receiver<RasterAck>,
+        Receiver<()>,
+    ) {
+        RasterOwner::new(backend, test_address())
     }
 
     fn test_frame(epoch: FrameEpoch, surface_generation: SurfaceGeneration) -> SceneSnapshot {
-        test_frame_for(epoch, test_presentation_id(), surface_generation)
+        test_frame_for(epoch, test_address(), surface_generation)
     }
 
     fn test_frame_for(
         epoch: FrameEpoch,
-        presentation_id: PresentationId,
+        address: PresentationAddress,
         surface_generation: SurfaceGeneration,
     ) -> SceneSnapshot {
         SceneSnapshot::new(
-            RealmId::new(1),
-            presentation_id,
+            address,
             epoch,
             surface_generation,
             DamageRegion::Full,
@@ -814,8 +954,7 @@ mod tests {
 
     #[test]
     fn latest_frame_wins_supersedes_pending() {
-        let (owner, handle, ack_rx, shutdown_complete_rx) =
-            RasterOwner::new(FakeBackend::default());
+        let (owner, handle, ack_rx, shutdown_complete_rx) = new_owner(FakeBackend::default());
         let start = Barrier::new(2);
         let epoch1 = FrameEpoch::ZERO.next();
         let epoch2 = epoch1.next();
@@ -843,12 +982,12 @@ mod tests {
             vec![
                 RasterAck::Dropped {
                     epoch: epoch1,
-                    presentation_id: test_presentation_id(),
+                    address: test_address(),
                     reason: FrameDropReason::Superseded,
                 },
                 RasterAck::Presented {
                     epoch: epoch2,
-                    presentation_id: test_presentation_id(),
+                    address: test_address(),
                 },
             ]
         );
@@ -889,8 +1028,7 @@ mod tests {
         // give a regression a real chance of being scheduled into the
         // interesting interleaving.
         for _ in 0..200 {
-            let (owner, handle, ack_rx, shutdown_complete_rx) =
-                RasterOwner::new(FakeBackend::default());
+            let (owner, handle, ack_rx, shutdown_complete_rx) = new_owner(FakeBackend::default());
             let epoch1 = FrameEpoch::ZERO.next();
             let epoch2 = epoch1.next();
 
@@ -950,8 +1088,7 @@ mod tests {
 
     #[test]
     fn presented_acks_arrive_in_submission_order() {
-        let (mut owner, handle, ack_rx, _shutdown_complete_rx) =
-            RasterOwner::new(FakeBackend::default());
+        let (mut owner, handle, ack_rx, _shutdown_complete_rx) = new_owner(FakeBackend::default());
         let epoch1 = FrameEpoch::ZERO.next();
         let epoch2 = epoch1.next();
         let epoch3 = epoch2.next();
@@ -964,7 +1101,7 @@ mod tests {
                 owner.pump(),
                 PumpOutcome::Presented {
                     epoch,
-                    presentation_id: test_presentation_id(),
+                    address: test_address(),
                 }
             );
         }
@@ -975,15 +1112,15 @@ mod tests {
             vec![
                 RasterAck::Presented {
                     epoch: epoch1,
-                    presentation_id: test_presentation_id(),
+                    address: test_address(),
                 },
                 RasterAck::Presented {
                     epoch: epoch2,
-                    presentation_id: test_presentation_id(),
+                    address: test_address(),
                 },
                 RasterAck::Presented {
                     epoch: epoch3,
-                    presentation_id: test_presentation_id(),
+                    address: test_address(),
                 },
             ]
         );
@@ -995,8 +1132,7 @@ mod tests {
 
     #[test]
     fn shutdown_handshake_completes_and_thread_joins() {
-        let (owner, handle, _ack_rx, shutdown_complete_rx) =
-            RasterOwner::new(FakeBackend::default());
+        let (owner, handle, _ack_rx, shutdown_complete_rx) = new_owner(FakeBackend::default());
         let start = Barrier::new(2);
 
         thread::scope(|scope| {
@@ -1025,8 +1161,7 @@ mod tests {
 
     #[test]
     fn submit_after_shutdown_fails_typed() {
-        let (_owner, handle, _ack_rx, _shutdown_complete_rx) =
-            RasterOwner::new(FakeBackend::default());
+        let (_owner, handle, _ack_rx, _shutdown_complete_rx) = new_owner(FakeBackend::default());
         handle.shutdown();
         let err = handle
             .submit(test_frame(FrameEpoch::ZERO.next(), SurfaceGeneration::ZERO))
@@ -1036,8 +1171,7 @@ mod tests {
 
     #[test]
     fn submit_after_owner_dropped_fails_typed() {
-        let (owner, handle, _ack_rx, _shutdown_complete_rx) =
-            RasterOwner::new(FakeBackend::default());
+        let (owner, handle, _ack_rx, _shutdown_complete_rx) = new_owner(FakeBackend::default());
         drop(owner);
         let err = handle
             .submit(test_frame(FrameEpoch::ZERO.next(), SurfaceGeneration::ZERO))
@@ -1052,7 +1186,7 @@ mod tests {
     #[test]
     fn render_failure_acks_dropped_render_failed() {
         let backend = FakeBackend::with_planned([Err(EngineError::NotInitialized)]);
-        let (mut owner, handle, ack_rx, _shutdown_complete_rx) = RasterOwner::new(backend);
+        let (mut owner, handle, ack_rx, _shutdown_complete_rx) = new_owner(backend);
         let epoch = FrameEpoch::ZERO.next();
         handle
             .submit(test_frame(epoch, SurfaceGeneration::ZERO))
@@ -1063,7 +1197,7 @@ mod tests {
             outcome,
             PumpOutcome::Dropped {
                 epoch,
-                presentation_id: test_presentation_id(),
+                address: test_address(),
                 reason: FrameDropReason::RenderFailed,
             }
         );
@@ -1071,7 +1205,7 @@ mod tests {
             ack_rx.try_recv().unwrap(),
             RasterAck::Dropped {
                 epoch,
-                presentation_id: test_presentation_id(),
+                address: test_address(),
                 reason: FrameDropReason::RenderFailed,
             }
         );
@@ -1083,8 +1217,7 @@ mod tests {
 
     #[test]
     fn resize_coalesces_latest_wins() {
-        let (mut owner, handle, _ack_rx, _shutdown_complete_rx) =
-            RasterOwner::new(FakeBackend::default());
+        let (mut owner, handle, _ack_rx, _shutdown_complete_rx) = new_owner(FakeBackend::default());
         handle.resize(100, 100);
         handle.resize(200, 150);
         handle.resize(320, 240);
@@ -1102,7 +1235,7 @@ mod tests {
             outcome,
             PumpOutcome::Presented {
                 epoch,
-                presentation_id: test_presentation_id(),
+                address: test_address(),
             }
         );
         owner.with_backend(|backend| {
@@ -1122,7 +1255,7 @@ mod tests {
     #[test]
     fn device_lost_maps_to_device_lost_ack() {
         let backend = FakeBackend::with_planned([Err(EngineError::DeviceLost)]);
-        let (mut owner, handle, ack_rx, _shutdown_complete_rx) = RasterOwner::new(backend);
+        let (mut owner, handle, ack_rx, _shutdown_complete_rx) = new_owner(backend);
         let epoch = FrameEpoch::ZERO.next();
         handle
             .submit(test_frame(epoch, SurfaceGeneration::ZERO))
@@ -1133,14 +1266,14 @@ mod tests {
             outcome,
             PumpOutcome::DeviceLost {
                 epoch,
-                presentation_id: test_presentation_id(),
+                address: test_address(),
             }
         );
         assert_eq!(
             ack_rx.try_recv().unwrap(),
             RasterAck::DeviceLost {
                 epoch,
-                presentation_id: test_presentation_id(),
+                address: test_address(),
             }
         );
         // Exactly one ack: DeviceLost does not also emit a Dropped ack for
@@ -1155,7 +1288,7 @@ mod tests {
     #[test]
     fn surface_validation_error_maps_to_surface_outdated_ack() {
         let backend = FakeBackend::with_planned([Err(EngineError::SurfaceValidation)]);
-        let (mut owner, handle, ack_rx, _shutdown_complete_rx) = RasterOwner::new(backend);
+        let (mut owner, handle, ack_rx, _shutdown_complete_rx) = new_owner(backend);
         let epoch = FrameEpoch::ZERO.next();
         handle
             .submit(test_frame(epoch, SurfaceGeneration::ZERO))
@@ -1172,7 +1305,7 @@ mod tests {
             outcome,
             PumpOutcome::SurfaceOutdated {
                 epoch,
-                presentation_id: test_presentation_id(),
+                address: test_address(),
                 stale,
                 current,
             }
@@ -1181,7 +1314,7 @@ mod tests {
             ack_rx.try_recv().unwrap(),
             RasterAck::SurfaceOutdated {
                 epoch,
-                presentation_id: test_presentation_id(),
+                address: test_address(),
                 stale,
                 current,
             }
@@ -1191,7 +1324,7 @@ mod tests {
     #[test]
     fn pump_with_empty_mailbox_returns_idle() {
         let (mut owner, _handle, _ack_rx, _shutdown_complete_rx) =
-            RasterOwner::new(FakeBackend::default());
+            new_owner(FakeBackend::default());
         assert_eq!(owner.pump(), PumpOutcome::Idle);
     }
 
@@ -1201,8 +1334,7 @@ mod tests {
 
     #[test]
     fn stale_surface_generation_is_rejected_before_render() {
-        let (mut owner, handle, ack_rx, _shutdown_complete_rx) =
-            RasterOwner::new(FakeBackend::default());
+        let (mut owner, handle, ack_rx, _shutdown_complete_rx) = new_owner(FakeBackend::default());
         handle.resize(800, 600);
         // Stamped against the pre-resize generation (ZERO): the coalesced
         // resize applied inside the same pump bumps the owner's current
@@ -1220,7 +1352,7 @@ mod tests {
             outcome,
             PumpOutcome::SurfaceOutdated {
                 epoch,
-                presentation_id: test_presentation_id(),
+                address: test_address(),
                 stale,
                 current,
             }
@@ -1229,7 +1361,7 @@ mod tests {
             ack_rx.try_recv().unwrap(),
             RasterAck::SurfaceOutdated {
                 epoch,
-                presentation_id: test_presentation_id(),
+                address: test_address(),
                 stale,
                 current,
             }
@@ -1259,8 +1391,7 @@ mod tests {
 
     #[test]
     fn pump_after_shutdown_complete_does_not_resignal() {
-        let (mut owner, handle, ack_rx, shutdown_complete_rx) =
-            RasterOwner::new(FakeBackend::default());
+        let (mut owner, handle, ack_rx, shutdown_complete_rx) = new_owner(FakeBackend::default());
         handle.shutdown();
         assert_eq!(owner.pump(), PumpOutcome::ShutdownComplete);
         assert_eq!(owner.pump(), PumpOutcome::ShutdownComplete);
@@ -1281,18 +1412,21 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Every ack echoes the submitting frame's presentation identity rather
-    // than minting one of its own.
+    // Every ack echoes the submitting frame's full address rather than
+    // minting one of its own.
     // -----------------------------------------------------------------------
 
     #[test]
-    fn acks_echo_the_submitted_frames_presentation_id() {
-        let stamp = PresentationId::new_gen(3, NonZeroU32::new(9).expect("nonzero"));
+    fn acks_echo_the_submitted_frames_address() {
+        let stamp = PresentationAddress {
+            realm_id: RealmId::new(1),
+            presentation_id: PresentationId::new_gen(3, NonZeroU32::new(9).expect("nonzero")),
+        };
 
         // Presented
         {
             let (mut owner, handle, ack_rx, _shutdown_complete_rx) =
-                RasterOwner::new(FakeBackend::default());
+                RasterOwner::new(FakeBackend::default(), stamp);
             let epoch = FrameEpoch::ZERO.next();
             handle
                 .submit(test_frame_for(epoch, stamp, SurfaceGeneration::ZERO))
@@ -1301,14 +1435,14 @@ mod tests {
                 owner.pump(),
                 PumpOutcome::Presented {
                     epoch,
-                    presentation_id: stamp,
+                    address: stamp
                 }
             );
             assert_eq!(
                 ack_rx.try_recv().unwrap(),
                 RasterAck::Presented {
                     epoch,
-                    presentation_id: stamp,
+                    address: stamp
                 }
             );
         }
@@ -1316,7 +1450,7 @@ mod tests {
         // Dropped (Superseded)
         {
             let (owner, handle, ack_rx, _shutdown_complete_rx) =
-                RasterOwner::new(FakeBackend::default());
+                RasterOwner::new(FakeBackend::default(), stamp);
             let epoch1 = FrameEpoch::ZERO.next();
             let epoch2 = epoch1.next();
             handle
@@ -1329,7 +1463,7 @@ mod tests {
                 ack_rx.try_recv().unwrap(),
                 RasterAck::Dropped {
                     epoch: epoch1,
-                    presentation_id: stamp,
+                    address: stamp,
                     reason: FrameDropReason::Superseded,
                 }
             );
@@ -1339,34 +1473,29 @@ mod tests {
         // SurfaceOutdated
         {
             let (mut owner, handle, ack_rx, _shutdown_complete_rx) =
-                RasterOwner::new(FakeBackend::default());
+                RasterOwner::new(FakeBackend::default(), stamp);
             handle.resize(100, 100);
             let epoch = FrameEpoch::ZERO.next();
             handle
                 .submit(test_frame_for(epoch, stamp, SurfaceGeneration::ZERO))
                 .expect("submit");
             let outcome = owner.pump();
-            let PumpOutcome::SurfaceOutdated {
-                presentation_id, ..
-            } = outcome
-            else {
+            let PumpOutcome::SurfaceOutdated { address, .. } = outcome else {
                 panic!("expected SurfaceOutdated, got {outcome:?}");
             };
-            assert_eq!(presentation_id, stamp);
+            assert_eq!(address, stamp);
             let ack = ack_rx.try_recv().unwrap();
-            let RasterAck::SurfaceOutdated {
-                presentation_id, ..
-            } = ack
-            else {
+            let RasterAck::SurfaceOutdated { address, .. } = ack else {
                 panic!("expected a SurfaceOutdated ack, got {ack:?}");
             };
-            assert_eq!(presentation_id, stamp);
+            assert_eq!(address, stamp);
         }
 
         // DeviceLost
         {
             let backend = FakeBackend::with_planned([Err(EngineError::DeviceLost)]);
-            let (mut owner, handle, ack_rx, _shutdown_complete_rx) = RasterOwner::new(backend);
+            let (mut owner, handle, ack_rx, _shutdown_complete_rx) =
+                RasterOwner::new(backend, stamp);
             let epoch = FrameEpoch::ZERO.next();
             handle
                 .submit(test_frame_for(epoch, stamp, SurfaceGeneration::ZERO))
@@ -1375,14 +1504,14 @@ mod tests {
                 owner.pump(),
                 PumpOutcome::DeviceLost {
                     epoch,
-                    presentation_id: stamp,
+                    address: stamp
                 }
             );
             assert_eq!(
                 ack_rx.try_recv().unwrap(),
                 RasterAck::DeviceLost {
                     epoch,
-                    presentation_id: stamp,
+                    address: stamp
                 }
             );
         }
@@ -1396,9 +1525,13 @@ mod tests {
 
     #[test]
     fn late_ack_after_presentation_recreation_fails_the_address_predicate() {
-        let incarnation_one = PresentationId::new_gen(0, NonZeroU32::new(1).expect("nonzero"));
+        let realm_id = RealmId::new(1);
+        let incarnation_one = PresentationAddress {
+            realm_id,
+            presentation_id: PresentationId::new_gen(0, NonZeroU32::new(1).expect("nonzero")),
+        };
         let (mut owner, handle, ack_rx, _shutdown_complete_rx) =
-            RasterOwner::new(FakeBackend::default());
+            RasterOwner::new(FakeBackend::default(), incarnation_one);
         let epoch = FrameEpoch::ZERO.next();
         handle
             .submit(test_frame_for(
@@ -1411,23 +1544,138 @@ mod tests {
             owner.pump(),
             PumpOutcome::Presented {
                 epoch,
-                presentation_id: incarnation_one,
+                address: incarnation_one,
             }
         );
         let ack = ack_rx.try_recv().expect("presented ack arrives");
-        let RasterAck::Presented {
-            presentation_id, ..
-        } = ack
-        else {
+        let RasterAck::Presented { address, .. } = ack else {
             panic!("expected a Presented ack, got {ack:?}");
         };
 
         // The consumer's presentation was torn down and reinstalled while
         // this ack was in flight: same slot, next generation.
-        let live_incarnation = PresentationId::new_gen(0, NonZeroU32::new(2).expect("nonzero"));
+        let live_incarnation = PresentationAddress {
+            realm_id,
+            presentation_id: PresentationId::new_gen(0, NonZeroU32::new(2).expect("nonzero")),
+        };
         assert_ne!(
-            presentation_id, live_incarnation,
+            address, live_incarnation,
             "a late ack's stamp must compare unequal to a recreated live presentation"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // ADR-0037: two different realm incarnations can mint an identical
+    // PresentationId, so RasterOwner must reject a submit whose realm_id
+    // does not match, even when presentation_id happens to agree.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn submit_with_mismatched_realm_id_is_rejected_even_with_matching_presentation_id() {
+        let owner_address = test_address();
+        let (_owner, handle, _ack_rx, _shutdown_complete_rx) = new_owner(FakeBackend::default());
+
+        let mismatched_realm = PresentationAddress {
+            realm_id: RealmId::new(2),
+            presentation_id: owner_address.presentation_id,
+        };
+        let frame = test_frame_for(
+            FrameEpoch::ZERO.next(),
+            mismatched_realm,
+            SurfaceGeneration::ZERO,
+        );
+
+        let error = handle.submit(frame).unwrap_err();
+        assert_eq!(
+            error,
+            RasterSubmitError::AddressMismatch {
+                expected: owner_address,
+                got: mismatched_realm,
+            }
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // The reliable SurfaceState slot must reflect a surface reconfigure even
+    // when the lossy ack lane is full and silently drops the corresponding
+    // SurfaceOutdated ack.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn surface_state_slot_survives_a_full_ack_lane() {
+        let (mut owner, handle, ack_rx, _shutdown_complete_rx) = new_owner(FakeBackend::default());
+
+        // Saturate the lossy ack channel with unrelated Presented acks,
+        // never draining `ack_rx` — exactly the "consumer fell behind"
+        // condition the reliable slot exists for.
+        for _ in 0..ACK_CHANNEL_CAPACITY {
+            let epoch = FrameEpoch::ZERO.next();
+            handle
+                .submit(test_frame(epoch, SurfaceGeneration::ZERO))
+                .expect("submit");
+            assert_eq!(
+                owner.pump(),
+                PumpOutcome::Presented {
+                    epoch,
+                    address: test_address(),
+                }
+            );
+        }
+
+        // The channel is now exactly full of undrained Presented acks.
+        assert_eq!(ack_rx.len(), ACK_CHANNEL_CAPACITY);
+        assert_eq!(
+            handle.surface_state(),
+            SurfaceState {
+                required_generation: SurfaceGeneration::ZERO,
+                device_lost: false,
+            },
+            "no reconfigure has happened yet"
+        );
+
+        // Force a SurfaceOutdated outcome: a resize bumps the generation,
+        // then a frame stamped against the pre-resize generation is
+        // proactively rejected. The channel is still full, so this ack is
+        // the one that gets silently dropped by `send_ack`.
+        handle.resize(800, 600);
+        let epoch = FrameEpoch::ZERO.next();
+        handle
+            .submit(test_frame(epoch, SurfaceGeneration::ZERO))
+            .expect("submit");
+        let current = SurfaceGeneration::ZERO.next();
+        assert_eq!(
+            owner.pump(),
+            PumpOutcome::SurfaceOutdated {
+                epoch,
+                address: test_address(),
+                stale: SurfaceGeneration::ZERO,
+                current,
+            }
+        );
+
+        // The ack itself never landed — the channel was already full and
+        // every slot still holds one of the earlier Presented acks.
+        assert_eq!(ack_rx.len(), ACK_CHANNEL_CAPACITY);
+        assert_eq!(
+            ack_rx
+                .try_recv()
+                .expect("channel still holds Presented acks"),
+            RasterAck::Presented {
+                epoch: FrameEpoch::ZERO.next(),
+                address: test_address(),
+            }
+        );
+
+        // But the reliable slot reflects the reconfigure regardless of
+        // whether its ack was ever delivered.
+        assert_eq!(
+            handle.surface_state(),
+            SurfaceState {
+                required_generation: current,
+                device_lost: false,
+            },
+            "the reliable slot must reflect the reconfigure even though its \
+             ack was dropped by the full lossy channel"
         );
     }
 }

--- a/crates/flui-foundation/src/id.rs
+++ b/crates/flui-foundation/src/id.rs
@@ -1065,6 +1065,42 @@ impl TreeId for PresentationId {
 }
 
 // =========================================================================
+// PresentationAddress — the full routable identity of one presentation
+// =========================================================================
+
+/// The full routable identity of one presentation: which realm incarnation
+/// owns it, and which presentation incarnation within that realm.
+///
+/// `RealmId` and `PresentationId` are each independently generational, but
+/// neither alone is a safe cross-thread address: two different realm
+/// incarnations can mint an identical `PresentationId` (same slot, same
+/// generation) if their presentation counters happen to align, so a
+/// protocol that carries only `PresentationId` cannot distinguish "the
+/// right presentation in realm A" from "a same-numbered presentation in
+/// unrelated realm B." Every protocol that crosses a thread or owner
+/// boundary and needs to address one exact presentation — the raster
+/// mailbox, the platform-to-realm dispatch table, the single native-window
+/// map — carries this full pair, never `PresentationId` alone.
+///
+/// Promoted here (rule of three): `flui-app`, `flui-layer`, and
+/// `flui-engine` each need this exact pair, so it lives in `flui-foundation`
+/// alongside the ids it pairs rather than as a private duplicate in any one
+/// of them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PresentationAddress {
+    /// Which `UiRealm` incarnation owns this presentation.
+    pub realm_id: RealmId,
+    /// Which presentation incarnation, within that realm, this address
+    /// names.
+    pub presentation_id: PresentationId,
+}
+
+const _: () = {
+    const fn assert_send_sync_copy<T: Send + Sync + Copy>() {}
+    assert_send_sync_copy::<PresentationAddress>();
+};
+
+// =========================================================================
 // ElementId — generational arena key for the element tree
 // =========================================================================
 

--- a/crates/flui-foundation/src/lib.rs
+++ b/crates/flui-foundation/src/lib.rs
@@ -227,6 +227,8 @@ pub use id::{
     ListenerId,
     Marker,
     ObserverId,
+    // The full (RealmId, PresentationId) routable address of one presentation
+    PresentationAddress,
     // Presentation identity — one presentation-runtime incarnation
     PresentationId,
     RawId,
@@ -298,6 +300,7 @@ pub mod prelude {
         // Observer IDs
         ObserverId,
         Predicate,
+        PresentationAddress,
         PresentationId,
         RELEASE_MODE,
         RealmId,

--- a/crates/flui-layer/src/scene_snapshot.rs
+++ b/crates/flui-layer/src/scene_snapshot.rs
@@ -4,7 +4,7 @@
 //! seam a `UiRealm` hands to a raster owner (Flutter parity:
 //! `RenderView.compositeFrame` → `FlutterView.render` → dispose).
 
-use flui_foundation::{FrameEpoch, PresentationId, RealmId, SurfaceGeneration};
+use flui_foundation::{FrameEpoch, PresentationAddress, SurfaceGeneration};
 
 use crate::scene::Scene;
 
@@ -34,10 +34,13 @@ pub enum DamageRegion {
 ///
 /// # Frame identity
 ///
-/// A frame's full identity is `(realm_id, presentation_id, epoch)`.
+/// A frame's full identity is `(address, epoch)`, where `address` is the
+/// full `(realm_id, presentation_id)` pair — never `presentation_id` alone,
+/// since two different realm incarnations can mint an identical
+/// `PresentationId` and only the full pair safely distinguishes them.
 /// [`FrameEpoch`] is per-*realm* monotonic, so two presentations belonging to
-/// the same realm's forest may composite in the same epoch —
-/// `presentation_id` disambiguates them; it is not redundant with `epoch`.
+/// the same realm's forest may composite in the same epoch — `address`
+/// disambiguates them; it is not redundant with `epoch`.
 /// `surface_generation` is a separate axis, scoped *per presentation*: it is
 /// minted by that presentation's own raster seam (ADR-0037 §8), never by the
 /// realm or by frame counting.
@@ -48,20 +51,18 @@ pub enum DamageRegion {
 /// *matching* on this struct additive when a field is added later. It does
 /// **not** make *construction* additive: [`SceneSnapshot::new`] is a
 /// positional constructor, so every field this type gains breaks every
-/// external call site — exactly the case the `presentation_id` field added
-/// here demonstrates. Before this type leaves `experimental`, the growing
-/// positional constructor should become a builder or an identity-group value
-/// (`realm_id`/`presentation_id`/`epoch`/`surface_generation` bundled
-/// together) so a future field addition is actually additive.
+/// external call site. Before this type leaves `experimental`, the growing
+/// positional constructor should become a builder or a fuller identity-group
+/// value (`address`/`epoch`/`surface_generation` bundled together) so a
+/// future field addition is actually additive.
 #[non_exhaustive]
 #[derive(Debug)]
 pub struct SceneSnapshot {
-    /// Identifies which `UiRealm` incarnation produced this frame.
-    pub realm_id: RealmId,
-    /// Identifies which presentation incarnation, within that realm,
-    /// composited this frame. Disambiguates same-epoch frames from sibling
-    /// presentations in a realm's forest (see the type docs above).
-    pub presentation_id: PresentationId,
+    /// The full realm+presentation address that composited this frame.
+    /// Disambiguates same-epoch frames from sibling presentations in a
+    /// realm's forest, and from same-numbered presentations in an unrelated
+    /// realm (see the type docs above).
+    pub address: PresentationAddress,
     /// The runtime's per-frame counter at the time this frame was composited.
     pub epoch: FrameEpoch,
     /// The raster surface generation this frame was produced against.
@@ -77,16 +78,14 @@ impl SceneSnapshot {
     /// the raster boundary needs to accept, reject, or reconcile it.
     #[must_use]
     pub fn new(
-        realm_id: RealmId,
-        presentation_id: PresentationId,
+        address: PresentationAddress,
         epoch: FrameEpoch,
         surface_generation: SurfaceGeneration,
         damage: DamageRegion,
         scene: Scene,
     ) -> Self {
         Self {
-            realm_id,
-            presentation_id,
+            address,
             epoch,
             surface_generation,
             damage,
@@ -104,23 +103,23 @@ mod tests {
 
     #[test]
     fn new_packages_all_fields() {
-        let realm_id = RealmId::new(1);
-        let presentation_id = flui_foundation::PresentationId::new(1);
+        let address = flui_foundation::PresentationAddress {
+            realm_id: flui_foundation::RealmId::new(1),
+            presentation_id: flui_foundation::PresentationId::new(1),
+        };
         let epoch = FrameEpoch::ZERO.next();
         let surface_generation = SurfaceGeneration::ZERO;
         let scene = Scene::from_layer(Size::ZERO, crate::Layer::from(CanvasLayer::new()), 0);
 
         let frame = SceneSnapshot::new(
-            realm_id,
-            presentation_id,
+            address,
             epoch,
             surface_generation,
             DamageRegion::Full,
             scene,
         );
 
-        assert_eq!(frame.realm_id, realm_id);
-        assert_eq!(frame.presentation_id, presentation_id);
+        assert_eq!(frame.address, address);
         assert_eq!(frame.epoch, epoch);
         assert_eq!(frame.surface_generation, surface_generation);
         assert_eq!(frame.damage, DamageRegion::Full);

--- a/crates/flui-layer/src/scene_snapshot.rs
+++ b/crates/flui-layer/src/scene_snapshot.rs
@@ -4,7 +4,7 @@
 //! seam a `UiRealm` hands to a raster owner (Flutter parity:
 //! `RenderView.compositeFrame` → `FlutterView.render` → dispose).
 
-use flui_foundation::{FrameEpoch, RealmId, SurfaceGeneration};
+use flui_foundation::{FrameEpoch, PresentationId, RealmId, SurfaceGeneration};
 
 use crate::scene::Scene;
 
@@ -32,14 +32,36 @@ pub enum DamageRegion {
 /// window per frame, mirroring Flutter's `RenderView.compositeFrame` →
 /// `FlutterView.render` → dispose sequence.
 ///
-/// `#[non_exhaustive]`: fields are `pub` for direct read/match access, but
-/// external construction goes through [`SceneSnapshot::new`] so a future field
-/// (e.g. presentation timing) is additive, not breaking.
+/// # Frame identity
+///
+/// A frame's full identity is `(realm_id, presentation_id, epoch)`.
+/// [`FrameEpoch`] is per-*realm* monotonic, so two presentations belonging to
+/// the same realm's forest may composite in the same epoch —
+/// `presentation_id` disambiguates them; it is not redundant with `epoch`.
+/// `surface_generation` is a separate axis, scoped *per presentation*: it is
+/// minted by that presentation's own raster seam (ADR-0037 §8), never by the
+/// realm or by frame counting.
+///
+/// # `#[non_exhaustive]` does not make the constructor additive
+///
+/// Fields are `pub` for direct read/match access; `#[non_exhaustive]` makes
+/// *matching* on this struct additive when a field is added later. It does
+/// **not** make *construction* additive: [`SceneSnapshot::new`] is a
+/// positional constructor, so every field this type gains breaks every
+/// external call site — exactly the case the `presentation_id` field added
+/// here demonstrates. Before this type leaves `experimental`, the growing
+/// positional constructor should become a builder or an identity-group value
+/// (`realm_id`/`presentation_id`/`epoch`/`surface_generation` bundled
+/// together) so a future field addition is actually additive.
 #[non_exhaustive]
 #[derive(Debug)]
 pub struct SceneSnapshot {
     /// Identifies which `UiRealm` incarnation produced this frame.
     pub realm_id: RealmId,
+    /// Identifies which presentation incarnation, within that realm,
+    /// composited this frame. Disambiguates same-epoch frames from sibling
+    /// presentations in a realm's forest (see the type docs above).
+    pub presentation_id: PresentationId,
     /// The runtime's per-frame counter at the time this frame was composited.
     pub epoch: FrameEpoch,
     /// The raster surface generation this frame was produced against.
@@ -56,6 +78,7 @@ impl SceneSnapshot {
     #[must_use]
     pub fn new(
         realm_id: RealmId,
+        presentation_id: PresentationId,
         epoch: FrameEpoch,
         surface_generation: SurfaceGeneration,
         damage: DamageRegion,
@@ -63,6 +86,7 @@ impl SceneSnapshot {
     ) -> Self {
         Self {
             realm_id,
+            presentation_id,
             epoch,
             surface_generation,
             damage,
@@ -81,12 +105,14 @@ mod tests {
     #[test]
     fn new_packages_all_fields() {
         let realm_id = RealmId::new(1);
+        let presentation_id = flui_foundation::PresentationId::new(1);
         let epoch = FrameEpoch::ZERO.next();
         let surface_generation = SurfaceGeneration::ZERO;
         let scene = Scene::from_layer(Size::ZERO, crate::Layer::from(CanvasLayer::new()), 0);
 
         let frame = SceneSnapshot::new(
             realm_id,
+            presentation_id,
             epoch,
             surface_generation,
             DamageRegion::Full,
@@ -94,6 +120,7 @@ mod tests {
         );
 
         assert_eq!(frame.realm_id, realm_id);
+        assert_eq!(frame.presentation_id, presentation_id);
         assert_eq!(frame.epoch, epoch);
         assert_eq!(frame.surface_generation, surface_generation);
         assert_eq!(frame.damage, DamageRegion::Full);

--- a/crates/flui-platform/src/platforms/android/window.rs
+++ b/crates/flui-platform/src/platforms/android/window.rs
@@ -64,6 +64,15 @@ impl AndroidWindow {
 }
 
 impl PlatformWindow for AndroidWindow {
+    // Android hosts exactly one `AndroidApp` surface for the process's
+    // lifetime (see the struct docs above) — there is no second native
+    // window this identity could ever collide with, so a fixed constant is
+    // this backend's honest identity, not a stand-in for missing
+    // information.
+    fn id(&self) -> WindowId {
+        WindowId(1)
+    }
+
     fn physical_size(&self) -> Size<DevicePixels> {
         let (w, h) = self.native_size();
         Size::new(device_px(w), device_px(h))

--- a/crates/flui-platform/src/platforms/headless/platform.rs
+++ b/crates/flui-platform/src/platforms/headless/platform.rs
@@ -361,6 +361,10 @@ impl MockWindow {
 }
 
 impl crate::traits::PlatformWindow for MockWindow {
+    fn id(&self) -> WindowId {
+        self.id
+    }
+
     fn physical_size(&self) -> Size<DevicePixels> {
         use flui_types::geometry::device_px;
 

--- a/crates/flui-platform/src/platforms/macos/window.rs
+++ b/crates/flui-platform/src/platforms/macos/window.rs
@@ -27,7 +27,9 @@ use super::view;
 use crate::{
     config::WindowConfiguration,
     shared::WindowCallbacks,
-    traits::{CursorError, DispatchEventResult, PlatformInput, PlatformWindow, WindowOptions},
+    traits::{
+        CursorError, DispatchEventResult, PlatformInput, PlatformWindow, WindowId, WindowOptions,
+    },
 };
 
 /// macOS window wrapper around NSWindow
@@ -215,6 +217,10 @@ impl MacOSWindow {
 }
 
 impl PlatformWindow for MacOSWindow {
+    fn id(&self) -> WindowId {
+        WindowId(self.ns_window as u64)
+    }
+
     fn physical_size(&self) -> Size<DevicePixels> {
         let state = self.state.lock();
         let logical = state.bounds.size;

--- a/crates/flui-platform/src/platforms/web/window.rs
+++ b/crates/flui-platform/src/platforms/web/window.rs
@@ -19,9 +19,6 @@ use super::display::WebDisplay;
 
 /// Web window wrapping a `<canvas>` element
 pub struct WebWindow {
-    // Retained for the multi-window path: the web backend creates a single
-    // canvas today, and `PlatformWindow` exposes no `id()` accessor.
-    #[allow(dead_code)]
     id: WindowId,
     canvas: web_sys::HtmlCanvasElement,
     state: Arc<Mutex<WebWindowState>>,
@@ -139,6 +136,10 @@ impl WebWindow {
 }
 
 impl PlatformWindow for WebWindow {
+    fn id(&self) -> WindowId {
+        self.id
+    }
+
     fn physical_size(&self) -> Size<DevicePixels> {
         let state = self.state.lock();
         Size::new(

--- a/crates/flui-platform/src/platforms/windows/window.rs
+++ b/crates/flui-platform/src/platforms/windows/window.rs
@@ -543,6 +543,10 @@ impl WindowsWindow {
 }
 
 impl PlatformWindow for WindowsWindow {
+    fn id(&self) -> WindowId {
+        WindowId(self.hwnd.0 as u64)
+    }
+
     fn physical_size(&self) -> Size<DevicePixels> {
         let state = self.state.lock();
         let logical = state.bounds.size;

--- a/crates/flui-platform/src/platforms/winit/control.rs
+++ b/crates/flui-platform/src/platforms/winit/control.rs
@@ -307,6 +307,10 @@ mod tests {
     struct StubWindow;
 
     impl crate::traits::PlatformWindow for StubWindow {
+        fn id(&self) -> crate::traits::WindowId {
+            crate::traits::WindowId(1)
+        }
+
         fn physical_size(&self) -> flui_types::geometry::Size<flui_types::geometry::DevicePixels> {
             flui_types::geometry::Size::default()
         }

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -429,12 +429,14 @@ impl WinitPlatform {
 
         let raw_window = Arc::new(event_loop.create_window(attributes)?);
         let winit_id = raw_window.id();
-        let winit_window = Arc::new(WinitWindow::new(raw_window));
+        // Allocate the platform identity before constructing the wrapper so
+        // `WinitWindow` can carry its own `id()` from the start, rather than
+        // being registered under an identity it cannot itself report.
+        let platform_id = self.with_state(WinitPlatformState::allocate_window_id);
+        let winit_window = Arc::new(WinitWindow::new(platform_id, raw_window));
 
-        let platform_id = self.with_state(|state| {
-            let id = state.allocate_window_id();
-            state.register_window(winit_id, id, winit_window.clone());
-            id
+        self.with_state(|state| {
+            state.register_window(winit_id, platform_id, winit_window.clone());
         });
 
         tracing::info!(?platform_id, "Created window");

--- a/crates/flui-platform/src/traits/window.rs
+++ b/crates/flui-platform/src/traits/window.rs
@@ -13,6 +13,7 @@ use super::{
     display::PlatformDisplay,
     haptics::PlatformHaptics,
     input::{DispatchEventResult, Modifiers, PlatformInput},
+    platform::WindowId,
     text_input::PlatformTextInput,
 };
 
@@ -90,6 +91,16 @@ use winit::window::Window;
 /// notifications share one causal FIFO across event kinds; see
 /// [`crate::WindowCallbacks`] for nested input return semantics.
 pub trait PlatformWindow: Send + Sync {
+    /// This window's platform-internal identity.
+    ///
+    /// A window that cannot state its identity cannot be demultiplexed
+    /// (ADR-0037 §2): the identity is what lets the demux boundary look up
+    /// which `(RealmId, PresentationId)` a native event belongs to. Every
+    /// implementor must return a real, stable-for-the-window's-lifetime
+    /// value — never a shared sentinel that would make two different
+    /// windows compare equal.
+    fn id(&self) -> WindowId;
+
     /// Get the window size in physical pixels (device pixels)
     fn physical_size(&self) -> Size<DevicePixels>;
 
@@ -389,6 +400,7 @@ impl HasDisplayHandle for dyn PlatformWindow + '_ {
 /// Includes per-window callbacks for event delivery using the causal FIFO
 /// dispatch pattern for reentrancy safety.
 pub struct WinitWindow {
+    id: WindowId,
     window: Arc<Window>,
     is_focused: parking_lot::Mutex<bool>,
     is_visible: parking_lot::Mutex<bool>,
@@ -437,9 +449,11 @@ impl std::fmt::Debug for WinitWindow {
 
 #[cfg(feature = "winit-backend")]
 impl WinitWindow {
-    /// Create a new WinitWindow wrapper
-    pub fn new(window: Arc<Window>) -> Self {
+    /// Create a new WinitWindow wrapper, addressed by the platform-minted
+    /// `id` the caller already allocated for it.
+    pub fn new(id: WindowId, window: Arc<Window>) -> Self {
         Self {
+            id,
             window,
             is_focused: parking_lot::Mutex::new(true),
             is_visible: parking_lot::Mutex::new(true),
@@ -470,6 +484,10 @@ impl WinitWindow {
 
 #[cfg(feature = "winit-backend")]
 impl PlatformWindow for WinitWindow {
+    fn id(&self) -> WindowId {
+        self.id
+    }
+
     fn physical_size(&self) -> Size<DevicePixels> {
         use flui_types::geometry::device_px;
 
@@ -627,6 +645,10 @@ mod tests {
     }
 
     impl PlatformWindow for MockWindow {
+        fn id(&self) -> WindowId {
+            WindowId(1)
+        }
+
         fn physical_size(&self) -> Size<DevicePixels> {
             use flui_types::geometry::device_px;
 

--- a/crates/flui-platform/src/window.rs
+++ b/crates/flui-platform/src/window.rs
@@ -203,9 +203,11 @@ pub trait Window {
 /// Unique identifier for a window.
 ///
 /// This ID is unique within the application and persists for the window's
-/// lifetime.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct WindowId(pub u64); // PORT-CHECK-OK-SP3: pre-existing parallel definition; consolidation tracked
+/// lifetime. Consolidated onto the canonical definition
+/// (`traits::platform::WindowId`, the one `PlatformWindowEvent::Created`/
+/// `PlatformWindow::id()` use) rather than a second parallel newtype — this
+/// module used to define its own identical `(pub u64)` wrapper.
+pub use crate::traits::WindowId;
 
 impl WindowId {
     /// Create a new window ID.

--- a/crates/flui-semantics/src/owner.rs
+++ b/crates/flui-semantics/src/owner.rs
@@ -69,6 +69,11 @@ pub enum SemanticsActionError {
         /// Action absent from the node's effective action mask.
         action: SemanticsAction,
     },
+
+    /// The owning presentation has begun or completed teardown; actions are
+    /// refused regardless of whether the node itself still resolves.
+    #[error("presentation is closing or closed; accessibility action refused")]
+    PresentationClosed,
 }
 
 /// A resolved action whose handler has been cloned out of the semantics tree.

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -1783,6 +1783,31 @@ scope = "crates/flui-platform/src/platforms/macos/clipboard.rs"
 why = "the clipboard ownership contract: clipboard operations are documented off-main-safe; an affinity assert would panic legitimate existing cross-thread callers"
 allow_files = []
 
+[[forbidden_pattern]]
+pattern = "WindowId"
+scope = "crates/flui-app/src"
+why = """
+the single-authority window map contract: WindowId is the platform-internal \
+native-handle key; every routing/business-logic path in flui-app addresses \
+a presentation through UiAddress only, minted by window_registry.rs's \
+register_window/remove_realm (which take a window or a realm id, never a \
+bare WindowId, so runner.rs and friends never name the type). Proxy-gate \
+disclaimer: `let id = window.id();` with an inferred local type defeats a \
+substring scan on its own -- the manual backstop is that no flui-app \
+routing API outside window_registry.rs accepts or returns WindowId. \
+binding.rs and presentation.rs are allow-listed only for their test-only \
+PlatformWindow mock implementations, which must restate the trait's \
+required `fn id(&self) -> WindowId` signature to implement it at all; \
+that is a structural trait-conformance fact, not a routing-logic \
+exception, and neither file's production code may accept or return the \
+type.\
+"""
+allow_files = [
+    "crates/flui-app/src/app/window_registry.rs",
+    "crates/flui-app/src/app/binding.rs",
+    "crates/flui-app/src/app/presentation.rs",
+]
+
 [[forbidden_path]]
 path = "crates/flui-presentation"
 why = "the presentation composition contract: no flui-presentation crate; flui-app privately composes the three owners"

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -610,10 +610,14 @@ evidence = [
 [[contract]]
 key = "presentation-identity-generational"
 statement = """
-Generational `PresentationId` exists and `AppRuntime` is the only \
-`WindowId → (RealmId, PresentationId)` authority. The ID type is real and \
-stamped on `PresentationState`; the single-authority window map does not \
-exist and `SceneSnapshot` still lacks a `PresentationId` field.\
+Generational `PresentationId` exists, is stamped on `PresentationState`, \
+`SceneSnapshot`, and every `RasterAck`/`PumpOutcome` variant, and \
+`flui-app`'s private `WindowRegistry` (`window_registry.rs`) is the sole \
+`WindowId -> UiAddress` mint authority, read at install (a self-check) and \
+teardown (`remove_realm`). Remainder: the registry is not yet the routing \
+demux — platform callbacks still deliver through captured addresses rather \
+than a `resolve` lookup — and it is not yet lifted into a public \
+multi-window `AppRuntime`.\
 """
 state = "partial"
 domain = "application"
@@ -621,6 +625,8 @@ owner_issue = 552
 mechanical = false
 evidence = [
     { kind = "symbol", file = "crates/flui-foundation/src/id.rs", contains = "pub struct PresentationId" },
+    { kind = "symbol", file = "crates/flui-app/src/app/window_registry.rs", contains = "pub(crate) struct WindowRegistry" },
+    { kind = "test", file = "crates/flui-app/src/app/window_registry.rs", contains = "fn register_window_replaces_same_window_with_trace" },
 ]
 
 [[contract]]
@@ -628,9 +634,16 @@ key = "closed-cross-thread-vocabulary"
 statement = """
 Cross-lane traffic is closed, presentation-addressed enums — never `dyn \
 Any`, opaque windows, or `Box<dyn FnOnce()>` payloads. The realm inbox \
-(`UiCommand`) is a closed vocabulary today; the full \
-`PlatformToUi`/`UiToPlatform`/`UiToRaster`/`RasterToUi` families with \
-presentation addressing do not exist yet.\
+(`UiCommand`) stamps its presentation-scoped commands with `PresentationId`; \
+the platform-to-realm boundary is the closed, `Send`-asserted `PlatformToUi` \
+family (`Input`/`Resized`/`WindowFocus`/`WindowVisibility`/`Lifecycle`), \
+dispatched only after a realm-then-presentation address compare. The \
+co-located frame pump is deliberately excluded from that typed family (it is \
+same-thread by construction, never a cross-thread payload). \
+`UiToRaster`/`RasterToUi` are deliberately not minted as parallel enums — \
+`RasterHandle`'s methods and `RasterAck` already are that protocol, and \
+`RasterHandle::resize`/`shutdown` are presentation-bound by channel identity \
+the same way a realm's `UiCommand` channel is.\
 """
 state = "partial"
 domain = "platform"
@@ -638,6 +651,10 @@ owner_issue = 552
 mechanical = false
 evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "enum UiCommand" },
+    { kind = "symbol", file = "crates/flui-app/src/app/runner.rs", contains = "enum PlatformToUi" },
+    { kind = "compile-time", file = "crates/flui-app/src/app/runner.rs", contains = "assert_impl_all!(PlatformToUi: Send)" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn stale_realm_dispatch_is_dropped" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn stale_presentation_with_live_realm_is_dropped" },
 ]
 
 [[contract]]
@@ -733,9 +750,17 @@ evidence = [
 key = "presentation-lifecycle-monotonic"
 statement = """
 Each presentation has the explicit Created → SurfaceAttached → Suspended → \
-Closing → Closed lifecycle with typed transitions and idempotent close. \
-Gap: resume claims `SurfaceAttached` without awaiting a raster surface ack, \
-because the shipping path has no raster acks to await.\
+Closing → Closed lifecycle with typed transitions and idempotent close, now \
+enforced at the platform input gate: `Closing`/`Closed` refuses all input \
+and accessibility-action dispatch deterministically; `Suspended` drops \
+pointer input only (gesture-arena protection) while keyboard/IME keep \
+flowing, so a flaky or absent occlusion signal never becomes a keystroke \
+blackout; `Created` is constructor-internal and production-unreachable \
+(documented, not given a dead arm pretending to be tested). Gap: resume \
+claims `SurfaceAttached` without awaiting a raster surface ack, because the \
+shipping path has no raster acks to await — and when that gap closes, the \
+ack it awaits must ride a guaranteed lane, never the lossy telemetry \
+channel `RasterAck` already rides.\
 """
 state = "partial"
 domain = "presentation"
@@ -744,6 +769,38 @@ mechanical = false
 evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "enum PresentationLifecycle" },
     { kind = "test", file = "crates/flui-app/src/app/presentation.rs", contains = "fn lifecycle_transitions_are_typed_and_close_is_idempotent" },
+    { kind = "test", file = "crates/flui-app/src/app/binding.rs", contains = "fn pointer_input_is_dropped_while_suspended_but_keyboard_flows" },
+    { kind = "test", file = "crates/flui-app/src/app/binding.rs", contains = "fn all_input_dropped_after_close" },
+    { kind = "test", file = "crates/flui-app/src/app/presentation.rs", contains = "fn semantics_action_after_close_is_refused" },
+]
+
+[[contract]]
+key = "single-native-window-map-authority"
+statement = """
+There is exactly one native-window-to-presentation map in `flui-app`: \
+`WindowRegistry` (`window_registry.rs`), which mints every dispatcher \
+address via `register_window`/`try_register` and is read at install (a \
+self-check) and teardown (`remove_realm`, the teardown real read). \
+`RealmHost.address` is a derived cache of this registry, not a second \
+source of truth — both are written only by `install_platform_realm`/ \
+`teardown_platform_realm`, inside the same TLS borrow, in that order: \
+registry first on install, registry removal first on teardown (so map \
+removal stops new routing before queued old-generation events drop). \
+Remainder: the registry mints and is read at install/teardown, but it is \
+not yet the routing demux — platform callbacks still deliver through \
+per-window closures with captured addresses rather than a `resolve` \
+lookup — and it has not been lifted into a public multi-window \
+`AppRuntime`.\
+"""
+state = "partial"
+domain = "application"
+owner_issue = 552
+mechanical = true
+mechanism = "forbidden_pattern scoped scan confines the WindowId token to window_registry.rs (plus two test-only PlatformWindow-mock allow-listed files) within crates/flui-app/src"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/window_registry.rs", contains = "pub(crate) struct WindowRegistry" },
+    { kind = "test", file = "crates/flui-app/src/app/window_registry.rs", contains = "fn remove_realm_returns_the_installed_entry" },
+    { kind = "test", file = "crates/flui-app/src/app/window_registry.rs", contains = "fn try_register_rejects_duplicate_window" },
 ]
 
 [[contract]]
@@ -1357,10 +1414,15 @@ declared_in = "crates/flui-platform/src/traits/platform.rs"
 contains = "pub struct WindowId"
 classification = "transitional"
 thread_affinity = "PlatformWindow: Send + Sync; per-window callbacks deliver on the owner thread"
-owner = "platform-internal native window key and handle — WindowId must never become realm-facing identity"
+owner = "platform-internal native window key and handle — WindowId must never become realm-facing identity; canonical definition (this one) is the only one PlatformWindow::id() returns"
 failure_semantics = "callback installation is install-only today (no cancellation ownership)"
-consumers = ["runner", "presentation state (weak)", "examples"]
+consumers = [
+    "flui-app's window_registry (sole caller of id())",
+    "presentation state (weak)",
+    "examples",
+]
 owner_issue = 552
+notes = "PlatformWindow gained a required id() -> WindowId accessor across all 11 implementors. traits/platform.rs:139 is canonical; src/window.rs's identical parallel definition now re-exports it (`pub use crate::traits::WindowId;`); platforms/macos/window_manager.rs:257 is left as recorded consolidation debt (its own PORT-CHECK-OK-SP3 marker), not touched by this change."
 
 [[surface]]
 path = "flui_platform::{WindowCallbacks, PlatformHandlers}"
@@ -1511,6 +1573,7 @@ owner = "the the raster mailbox contract mailbox protocol — implemented and th
 failure_semantics = "typed RasterSubmitError {MailboxClosed, ...}; acks carry frame identity; shutdown is a one-shot handshake"
 consumers = ["threaded protocol tests only"]
 owner_issue = 559
+notes = "Every RasterAck/PumpOutcome variant now carries presentation_id, echoed from the submitted SceneSnapshot's own stamp (the owner mints epoch/surface-generation feedback, never a presentation identity). Per-variant #[non_exhaustive] added to both enums (enum-level non_exhaustive alone does not block exact-field destructuring); the two former tuple variants (Presented, DeviceLost) became named-field variants since non_exhaustive cannot apply to a tuple/unit variant."
 
 [[surface]]
 path = "flui_layer::{SceneSnapshot, DamageRegion}"
@@ -1524,7 +1587,7 @@ owner = "per-presentation per-frame raster package — non_exhaustive, explicitl
 failure_semantics = "identity fields let receivers reject stale frames"
 consumers = ["RasterOwner protocol", "threaded tests"]
 owner_issue = 552
-notes = "Missing the PresentationId field the presentation-identity contract requires; adding it is additive under non_exhaustive."
+notes = "Now carries presentation_id (realm_id, presentation_id, epoch is the full frame identity — FrameEpoch is only per-realm monotonic, so presentation_id disambiguates same-epoch frames from sibling presentations). The prior note calling this addition additive under non_exhaustive was itself the overclaim corrected here: non_exhaustive makes matching additive, not construction through a positional new() — every field this type gains breaks the positional constructor, which is exactly what happened. Recorded pre-graduation gate: replace the growing positional new() with a builder or an identity-group value before this type leaves experimental."
 
 [[surface]]
 path = "flui_foundation::{RealmId, PresentationId, FrameEpoch, SurfaceGeneration, ResourceGeneration, GenerationGate}"

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -185,7 +185,7 @@ declarations = [
     "pub use flui_painting::Paint;",
     "pub use traits::{CommandRenderer, LayerStateStack};",
     "pub use raster::RasterBackend;",
-    "pub use raster_owner::{ FrameDropReason, PumpOutcome, RasterAck, RasterHandle, RasterOwner, RasterSubmitError, };",
+    "pub use raster_owner::{ FrameDropReason, PumpOutcome, RasterAck, RasterHandle, RasterOwner, RasterSubmitError, SurfaceState, };",
     "pub use wgpu::DebugBackend;",
     "pub use wgpu::{Backend, FontLoader, LayerRender, WgpuPainter};",
 ]
@@ -220,7 +220,7 @@ declarations = [
     "pub use consts::{DEBUG_MODE, EPSILON, EPSILON_F32, IS_DESKTOP, IS_MOBILE, IS_WEB, RELEASE_MODE};",
     "pub use epoch::{FrameEpoch, GenerationGate, ResourceGeneration, SurfaceGeneration};",
     "pub use debug::{ DebugPaintConfig, DiagnosticLevel, Diagnosticable, DiagnosticsBuilder, DiagnosticsNode, DiagnosticsProperty, DiagnosticsPropertyKind, DiagnosticsTreeStyle, };",
-    "pub use id::{ DataTransferId, ElementId, FrameCallbackId, FrameId, Id, Identifier, LayerId, ListenerId, Marker, ObserverId, PresentationId, RawId, RealmId, RenderId, SemanticsId, TaskId, TickerId, TreeId, ViewId, markers, };",
+    "pub use id::{ DataTransferId, ElementId, FrameCallbackId, FrameId, Id, Identifier, LayerId, ListenerId, Marker, ObserverId, PresentationAddress, PresentationId, RawId, RealmId, RenderId, SemanticsId, TaskId, TickerId, TreeId, ViewId, markers, };",
     "pub use key::{Key, KeyRef, Keyed, UniqueKey, ValueKey, ViewKey, WithKey};",
     "pub use notifier::{ChangeNotifier, Listenable, ListenerCallback, ValueListenable, ValueNotifier};",
     "pub use rebuild_reason::{RebuildReason, RebuildReasons};",
@@ -613,7 +613,7 @@ statement = """
 Generational `PresentationId` exists, is stamped on `PresentationState`, \
 `SceneSnapshot`, and every `RasterAck`/`PumpOutcome` variant, and \
 `flui-app`'s private `WindowRegistry` (`window_registry.rs`) is the sole \
-`WindowId -> UiAddress` mint authority, read at install (a self-check) and \
+`WindowId -> PresentationAddress` mint authority, read at install (a self-check) and \
 teardown (`remove_realm`). Remainder: the registry is not yet the routing \
 demux — platform callbacks still deliver through captured addresses rather \
 than a `resolve` lookup — and it is not yet lifted into a public \
@@ -1573,7 +1573,7 @@ owner = "the the raster mailbox contract mailbox protocol — implemented and th
 failure_semantics = "typed RasterSubmitError {MailboxClosed, ...}; acks carry frame identity; shutdown is a one-shot handshake"
 consumers = ["threaded protocol tests only"]
 owner_issue = 559
-notes = "Every RasterAck/PumpOutcome variant now carries presentation_id, echoed from the submitted SceneSnapshot's own stamp (the owner mints epoch/surface-generation feedback, never a presentation identity). Per-variant #[non_exhaustive] added to both enums (enum-level non_exhaustive alone does not block exact-field destructuring); the two former tuple variants (Presented, DeviceLost) became named-field variants since non_exhaustive cannot apply to a tuple/unit variant."
+notes = "Every RasterAck/PumpOutcome variant now carries address: flui_foundation::PresentationAddress (the full realm_id + presentation_id pair, replacing a bare presentation_id field), echoed from the submitted SceneSnapshot's own stamp (the owner mints epoch/surface-generation feedback, never a presentation identity). Two different realm incarnations can mint an identical PresentationId, so the owner is bound to its expected PresentationAddress at construction and RasterHandle::submit validates every frame against it, rejecting a mismatch as RasterSubmitError::AddressMismatch rather than accepting it. Per-variant #[non_exhaustive] added to both enums (enum-level non_exhaustive alone does not block exact-field destructuring); the two former tuple variants (Presented, DeviceLost) became named-field variants since non_exhaustive cannot apply to a tuple/unit variant."
 
 [[surface]]
 path = "flui_layer::{SceneSnapshot, DamageRegion}"
@@ -1587,10 +1587,10 @@ owner = "per-presentation per-frame raster package — non_exhaustive, explicitl
 failure_semantics = "identity fields let receivers reject stale frames"
 consumers = ["RasterOwner protocol", "threaded tests"]
 owner_issue = 552
-notes = "Now carries presentation_id (realm_id, presentation_id, epoch is the full frame identity — FrameEpoch is only per-realm monotonic, so presentation_id disambiguates same-epoch frames from sibling presentations). The prior note calling this addition additive under non_exhaustive was itself the overclaim corrected here: non_exhaustive makes matching additive, not construction through a positional new() — every field this type gains breaks the positional constructor, which is exactly what happened. Recorded pre-graduation gate: replace the growing positional new() with a builder or an identity-group value before this type leaves experimental."
+notes = "Now carries address: flui_foundation::PresentationAddress in place of the former bare realm_id/presentation_id fields (address, epoch is the full frame identity — FrameEpoch is only per-realm monotonic, so address disambiguates same-epoch frames from sibling presentations, and two different realm incarnations can mint an identical PresentationId so the full pair is required, not presentation_id alone). The prior note calling this addition additive under non_exhaustive was itself the overclaim corrected here: non_exhaustive makes matching additive, not construction through a positional new() — every field this type gains breaks the positional constructor, which is exactly what happened. Recorded pre-graduation gate: replace the growing positional new() with a builder or an identity-group value before this type leaves experimental."
 
 [[surface]]
-path = "flui_foundation::{RealmId, PresentationId, FrameEpoch, SurfaceGeneration, ResourceGeneration, GenerationGate}"
+path = "flui_foundation::{RealmId, PresentationId, PresentationAddress, FrameEpoch, SurfaceGeneration, ResourceGeneration, GenerationGate}"
 crate = "flui-foundation"
 kind = "type"
 declared_in = "crates/flui-foundation/src/id.rs"
@@ -1601,6 +1601,7 @@ owner = "generational protocol identity vocabulary"
 failure_semantics = "generation mismatch compares unequal; GenerationGate rejects stale commits"
 consumers = ["UiRealm", "PresentationState", "SceneSnapshot", "RasterOwner"]
 owner_issue = 552
+notes = "PresentationAddress { realm_id, presentation_id } is a new additive public type: the full pair a `RasterOwner` binds to and validates every SceneSnapshot against (ADR-0037) — two different realm incarnations can mint an identical PresentationId, so the bare id alone never safely disambiguates them. Promoted here from flui-app's now-deleted private UiAddress once app/layer/engine all needed the same pair."
 
 [[surface]]
 path = "flui_testing::HeadlessBinding"
@@ -1852,7 +1853,7 @@ scope = "crates/flui-app/src"
 why = """
 the single-authority window map contract: WindowId is the platform-internal \
 native-handle key; every routing/business-logic path in flui-app addresses \
-a presentation through UiAddress only, minted by window_registry.rs's \
+a presentation through PresentationAddress only, minted by window_registry.rs's \
 register_window/remove_realm (which take a window or a realm id, never a \
 bare WindowId, so runner.rs and friends never name the type). Proxy-gate \
 disclaimer: `let id = window.id();` with an inferred local type defeats a \


### PR DESCRIPTION
Implements issue #552 — generational presentation addressing across platform, UI, semantics, and raster (ADR-0037, ADR-0027 §6). Every cross-boundary route now carries or is structurally bound to a `(RealmId, PresentationId)` incarnation, and every physical owner rejects stale identities deterministically.

## ⚠️ One policy decision to veto or confirm

**`Suspended` drops pointer input only; keyboard/IME continue to flow.** Hard drop applies to `Closing | Closed` (unambiguous). Rationale: the web backend wires no occlusion signal at all, so a hard "suspended = no input" gate would silently blackout typing the moment visibility derivation is wrong; a stray pointer event mutating a suspended presentation's gesture arena is the hazard actually worth closing now. ADR-0037 §9 leaves this to policy. The stricter alternative is one `match` arm away in `AppBinding::handle_input_entered` — say the word.

## What lands (7 + 1 commits)

- **`PlatformWindow::id() -> WindowId`** — required method, all 11 implementors; the canonical `WindowId` is `traits/platform.rs`'s (the `src/window.rs` duplicate collapsed to a `pub use`; the macOS `window_manager.rs` one recorded as consolidation debt).
- **`WindowRegistry` (flui-app-private)** — the sole `WindowId → UiAddress{realm_id, presentation_id}` authority, shaped for #553's `AppRuntime` to absorb as a field. Replace-with-trace install semantics (panic-recovery reinstall stays sound), install-time self-check read, teardown removal by realm. Mechanical gate: a `forbidden_pattern` keeps `WindowId` out of all flui-app routing logic (allow-list = registry + two test-double files, with the inference-exploit honestly named as the gate's limit). `RealmHost.address` is documented as a derived cache written only by install/teardown inside the same TLS borrow. The `single-native-window-map-authority` contract is recorded **partial** — full `WindowEvent` demux through the registry arrives with #553.
- **`SceneSnapshot.presentation_id`** (mandatory field; frame identity = realm_id + presentation_id + epoch, rustdoc'd) and **presentation-stamped `RasterAck`/`PumpOutcome`** — the raster owner echoes the submitted frame's stamp, never mints. Per-variant `#[non_exhaustive]` added now (free today, breaking after #559 brings real consumers). The ack criterion is deliberately worded as a stale-**predicate**: the ack lane is lossy `try_send` telemetry; #559's consumer wiring owns delivery.
- **`PlatformToUi`** — the closed, `Send`-asserted platform→UI vocabulary (Input / Resized / WindowFocus / WindowVisibility / Lifecycle), split from the co-located `RealmTask::Frame` pump so the Send assert is honest. The `Resize` closure-in-message is gone — typed `Resized {size, scale_factor}` + a registration-lifetime surface applier with a take/call/restore protocol and a panic-restore RAII guard.
- **Dispatch checks realm first, then presentation** (`StaleRealm` / new `StalePresentation`), upstream of the payload match — covering every variant, not just input. Note for reviewers: realm and presentation ids mint from one counter today, so realm-vs-presentation staleness is production-indistinguishable until #555's forest; the `StalePresentation` test forges a mixed address (live realm + stale presentation) to pin the compare order.
- **`UiCommand::SemanticsAction { presentation_id, .. }`** — stamped and validated in `drain_commands` before any pipeline borrow; `dispatch_semantics_action` refuses `Closing|Closed` with a new (additive, `#[non_exhaustive]`) `SemanticsActionError::PresentationClosed`. Realm-scoped commands stay bound by channel identity (re-stamping a structural fact was deliberately rejected).
- **Input lifecycle gate** at the physical owner; teardown removes the registry entry before dropping queue+realm outside the TLS borrow — and `install_platform_realm`'s replace path now mirrors the same hygiene (displaced realm + queue + applier dropped outside the borrow; proven by a dispatch-from-inside-`Drop` probe test).
- **Registry delta**: 3 contracts advance with rewritten honest statements (all stay `partial` with named remainders), 1 new mechanical contract, surface notes updated.

## Acceptance criteria — honest map

| AC | Status |
|---|---|
| Recreated presentations never compare equal | ✅ (foundation GenId tests + routing-level stale-drop tests) |
| Late input / semantics / worker / raster-ack dropped deterministically | ✅ input, ✅ semantics, ✅ raster **at protocol level** (shipping ack consumer is #559's); worker results stay covered by ADR-0027 §6 generation gates — presentation-scoped worker classes arrive with #555 |
| SceneSnapshot presentation-addressed | ✅ (construction sites are protocol tests only until #559) |
| No second native-window mapping authority | ✅ for current topology (mechanical gate; contract `partial` until #553 rehome + demux) |
| Co-located and cross-thread delivery share typed messages | ✅ for everything that is a message today; `RasterHandle`+`RasterAck` *are* the raster protocol (no parallel enum family — one fact, one place); the co-located `Frame` pump is documented as not-a-message, retired by #553 |
| Teardown tests cover queued events after identity removal | ✅ (non-delivery + applier non-invocation + reinstall-without-teardown recovery path) |

## Review process

Plan → two adversarial reviews (15 findings folded, incl. the one-counter minting insight that reshaped the test strategy, the vacuous-authority objection that added real registry reads, and per-variant `#[non_exhaustive]` before consumers exist) → build (red→green for 19 tests, each with a stated red condition) → spec-compliance review (PASS; 3 minors) → quality review with red-exploit (7 exploit attempts against the stale-drop guarantee — **holds** on all shipping orderings; the one recovery-path hole found was fixed and probe-tested) → all findings closed.

## Verification

- `just ci` exit 0 (8546+ tests); clippy `-D warnings` across the four touched crates; `just runtime-conformance-check` (47 contracts) and `just port-check-verbose` clean.
- Cross-targets: wasm32 check, cross-typecheck (Win32/AppKit compile the new `id()` impls), `aarch64-linux-android` check (unblocked by #584) — all green.
- `cargo public-api` delta captured for flui-platform / flui-layer / flui-engine (+ additive flui-semantics variant): matches the declared breaking set exactly.
- **Semver: this is a 0.3.0 breaking change** (`PlatformWindow::id()` required method; `SceneSnapshot::new` arity; `RasterAck`/`PumpOutcome` field additions).

## Honest gaps

- Raster-ack **delivery** is not deterministic (lossy lane) and has no shipping consumer — the stamped protocol + drop predicate land here; consumption is #559.
- Multi-presentation isolation beyond the structural at-most-one gate is #555's; realm/presentation staleness is indistinguishable in production until then (one mint counter).
- Win32/AppKit `id()` impls are compile-checked only (no CI execution for those backends); web host never tears down (page-lifetime), so teardown tests are native-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
