### PR TITLE
feat(app): AppRuntime composition root and injection seams (singleton retirement 1/6)

### DIFF
--- a/crates/flui-app/src/app/mod.rs
+++ b/crates/flui-app/src/app/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod hot_reload;
 pub(crate) mod logging;
 pub(crate) mod presentation;
 pub mod runner;
+pub(crate) mod runtime;
 pub(crate) mod ui_realm;
 pub(crate) mod window_registry;
 

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -103,8 +103,8 @@ thread_local! {
     /// `OwnerHostClearGuard::drop` firing during an unwind on a thread that
     /// never reached platform init -- can never itself trigger singleton
     /// construction or full system-font enumeration. Real service
-    /// resolution happens only via the explicit `ensure_services` calls in
-    /// `install_owner_platform`/`install_platform_realm` below.
+    /// resolution happens only via the explicit `ensure_services` call in
+    /// `install_platform_realm` below, when a realm is actually installed.
     static APP_RUNTIME: std::cell::RefCell<AppRuntime> =
         const { std::cell::RefCell::new(AppRuntime::new()) };
 }
@@ -113,15 +113,18 @@ thread_local! {
 /// backend's `on_ready` callback (ADR-0039 §6) — every `run_*` entry point
 /// in this module does so immediately after minting/receiving its
 /// `OwnerPlatform`.
+///
+/// Deliberately does NOT resolve `SharedEngineServices`: `run_direct`
+/// installs an owner platform and opens a window but never installs a
+/// `UiRealm` (no widget tree, no painting/semantics/scheduler singleton
+/// reach at all), so resolving here would pay for singleton construction
+/// and full system-font enumeration on a path that can never consume
+/// either. `install_platform_realm` is the one call site that resolves —
+/// every realm-hosting backend goes through it, `run_direct` never does.
 #[cfg(not(target_os = "ios"))]
 pub(crate) fn install_owner_platform(owner: flui_platform::OwnerPlatform) {
     APP_RUNTIME.with(|slot| {
-        let mut state = slot.borrow_mut();
-        state.owner_platform = Some(owner);
-        // Explicit, known-point resolution -- not a TLS-initializer side
-        // effect. Idempotent (`ensure_services` caches), so it does not
-        // matter that `install_platform_realm` below also calls it.
-        let _ = state.ensure_services();
+        slot.borrow_mut().owner_platform = Some(owner);
     });
 }
 
@@ -1126,10 +1129,13 @@ fn install_platform_realm(
         // stale `Hidden`/`Inactive` left behind by the last one.
         state.visible = true;
         state.focused = true;
-        // Explicit, known-point resolution (idempotent with the call in
-        // `install_owner_platform`) -- test call sites that install a realm
-        // directly, without going through `install_owner_platform` first
-        // (e.g. `install_test_realm` below), still get services resolved.
+        // Explicit, known-point resolution: a realm is actually being
+        // installed, so this thread genuinely needs `SharedEngineServices`
+        // -- unlike `install_owner_platform`, which every backend calls
+        // (including `run_direct`, which never installs a realm and never
+        // needs these services). Idempotent (`ensure_services` caches), so
+        // it does not matter whether a prior realm on this thread already
+        // triggered it.
         let _ = state.ensure_services();
         (displaced_realm, displaced_queue, displaced_applier)
     });
@@ -3905,6 +3911,30 @@ mod tests {
             with_owner_platform(|_| ()).is_none(),
             "the clear guard must remove the host once its scope ends"
         );
+    }
+
+    /// `install_owner_platform` alone -- the exact path `run_direct` takes,
+    /// which opens a window but never installs a `UiRealm` -- must NOT
+    /// resolve `SharedEngineServices`. Only `install_platform_realm`
+    /// (exercised by the realm-install tests elsewhere in this file) does
+    /// that, so a backend that never hosts a realm never pays for
+    /// painting/semantics/scheduler singleton construction or full
+    /// system-font enumeration it cannot use.
+    #[test]
+    fn install_owner_platform_alone_does_not_resolve_services() {
+        use flui_platform::headless_platform;
+
+        let _clear_guard = OwnerHostClearGuard::arm();
+        let platform = headless_platform();
+        let result = platform.run(Box::new(|owner| {
+            install_owner_platform(owner);
+            assert!(
+                !APP_RUNTIME.with(|slot| slot.borrow().services_resolved()),
+                "install_owner_platform alone must not resolve SharedEngineServices"
+            );
+            Ok(())
+        }));
+        assert!(result.is_ok(), "on_ready returns Ok here");
     }
 
     #[test]

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -80,13 +80,13 @@ where
 }
 
 // ============================================================================
-// Loop-scoped composition root (ADR-0027, ADR-0039 §6; issue #553)
+// Loop-scoped composition root (ADR-0027, ADR-0039 §6)
 // ============================================================================
 
 #[cfg(not(target_os = "ios"))]
 thread_local! {
     /// The one loop-scoped composition root, shared by desktop, Android, and
-    /// wasm. Absorbs what were, until issue #553's `AppRuntime` skeleton, two
+    /// wasm. Absorbs what were, before the `AppRuntime` skeleton existed, two
     /// separate thread-locals: the transitional realm host (realm slot, queue,
     /// draining, owner thread, address cache, window registry, surface
     /// applier, visible/focused) and the loop-scoped `OwnerPlatform` host —
@@ -179,9 +179,9 @@ pub(crate) fn install_owner_platform(owner: flui_platform::OwnerPlatform) {
 ///
 /// `f` runs while this function holds an immutable `APP_RUNTIME.borrow()`.
 /// Since `AppRuntime` folded the realm-facing state and `owner_platform`
-/// into ONE thread-local `RefCell` (issue #553's `AppRuntime` skeleton —
-/// they were two disjoint cells before), `f` must never call back into any
-/// function that touches this same cell: `dispatch_platform_realm`,
+/// into ONE thread-local `RefCell` (they were two disjoint cells before), `f`
+/// must never call back into any function that touches this same cell:
+/// `dispatch_platform_realm`,
 /// `install_platform_realm`, `teardown_platform_realm`,
 /// `install_surface_applier`, or `install_owner_platform` itself. Any of
 /// those does `slot.borrow_mut()` while this borrow is still live, which is
@@ -3989,7 +3989,7 @@ mod tests {
         });
     }
 
-    /// Hot-restart survival (ADR-0039 §6; issue #553): `owner_platform`
+    /// Hot-restart survival (ADR-0039 §6): `owner_platform`
     /// is a loop-scoped `AppRuntime` field, deliberately not cleared by
     /// `teardown_platform_realm` alongside the realm-facing fields it DOES
     /// clear (`realm`, `queue`, `owner_thread`, `address`,

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -12,6 +12,9 @@ use flui_foundation::HasInstance;
 #[cfg(not(target_os = "ios"))]
 use flui_scheduler::{AppLifecycleState, Scheduler};
 
+#[cfg(not(target_os = "ios"))]
+use super::runtime::AppRuntime;
+
 /// Run a FLUI application with default configuration.
 ///
 /// This is the internal implementation called by `run_app()`.
@@ -77,38 +80,24 @@ where
 }
 
 // ============================================================================
-// Platform-neutral owner-thread realm host (ADR-0027)
+// Loop-scoped composition root (ADR-0027, ADR-0039 §6; issue #553)
 // ============================================================================
 
 #[cfg(not(target_os = "ios"))]
 thread_local! {
-    /// Transitional owner-thread host shared by desktop, Android, and wasm.
-    /// The platform callback surface still requires `Send`, so the `!Send`
-    /// realm remains in owner TLS until that seam is retired. Access is only
-    /// through the stamped FIFO dispatcher below.
-    static PLATFORM_REALM_HOST: std::cell::RefCell<RealmHost> =
-        const { std::cell::RefCell::new(RealmHost::new()) };
-}
-
-// ============================================================================
-// Loop-scoped owner-platform host (ADR-0039 §6)
-// ============================================================================
-
-#[cfg(not(target_os = "ios"))]
-thread_local! {
-    /// Loop-scoped host for the owner-thread platform capability
-    /// (ADR-0039), *separate from* [`PLATFORM_REALM_HOST`]: a realm's
-    /// teardown must not strand the loop's capability, because the loop may
-    /// host another realm before it exits (hot-restart does exactly this
-    /// today, `install_platform_realm`). Deliberately not cleared by
-    /// `teardown_platform_realm`.
-    ///
-    /// `OwnerPlatform` is not `Clone` (ADR-0039 slice-2 decision record), so
-    /// the only sanctioned way to read this slot is the borrow-style
-    /// [`with_owner_platform`] accessor below — there is no path to a
-    /// durable owned copy that outlives one access.
-    static OWNER_PLATFORM_HOST: std::cell::RefCell<Option<flui_platform::OwnerPlatform>> =
-        const { std::cell::RefCell::new(None) };
+    /// The one loop-scoped composition root, shared by desktop, Android, and
+    /// wasm. Absorbs what were, until issue #553's `AppRuntime` skeleton, two
+    /// separate thread-locals: the transitional realm host (realm slot, queue,
+    /// draining, owner thread, address cache, window registry, surface
+    /// applier, visible/focused) and the loop-scoped `OwnerPlatform` host —
+    /// see [`AppRuntime`]'s own module doc for why one struct correctly
+    /// carries both invariants. The platform callback surface still
+    /// requires `Send`, so the `!Send` realm this holds remains in owner TLS
+    /// until that seam is retired (ADR-0027 follow-up 5); access is only
+    /// through the stamped FIFO dispatcher below and the fenced
+    /// `with_owner_platform` accessor.
+    static APP_RUNTIME: std::cell::RefCell<AppRuntime> =
+        std::cell::RefCell::new(AppRuntime::new());
 }
 
 /// Installs `owner` in the loop-scoped host. Call once, at the top of each
@@ -117,8 +106,8 @@ thread_local! {
 /// `OwnerPlatform`.
 #[cfg(not(target_os = "ios"))]
 pub(crate) fn install_owner_platform(owner: flui_platform::OwnerPlatform) {
-    OWNER_PLATFORM_HOST.with(|slot| {
-        *slot.borrow_mut() = Some(owner);
+    APP_RUNTIME.with(|slot| {
+        slot.borrow_mut().owner_platform = Some(owner);
     });
 }
 
@@ -190,7 +179,7 @@ pub(crate) fn with_owner_platform<R>(
              not be acquired from build/layout/paint (ADR-0039 §6, trigger #22)"
         );
     }
-    OWNER_PLATFORM_HOST.with(|slot| slot.borrow().as_ref().map(f))
+    APP_RUNTIME.with(|slot| slot.borrow().owner_platform.as_ref().map(f))
 }
 
 /// Unwind-safe TLS clearing. Arm this guard *before* calling
@@ -221,27 +210,29 @@ impl OwnerHostClearGuard {
 #[cfg(not(target_os = "ios"))]
 impl Drop for OwnerHostClearGuard {
     fn drop(&mut self) {
-        OWNER_PLATFORM_HOST.with(|slot| {
-            slot.borrow_mut().take();
+        APP_RUNTIME.with(|slot| {
+            slot.borrow_mut().owner_platform.take();
         });
     }
 }
 
 /// A registration-lifetime renderer-surface applier: `FnMut(size,
-/// scale_factor)`. Named so [`RealmHost::surface_applier`]'s field
+/// scale_factor)`. Named so [`AppRuntime`]'s `surface_applier` field
 /// declaration reads plainly instead of spelling out the boxed closure type
-/// inline.
+/// inline. `pub(super)` (rather than private) so [`AppRuntime`]'s struct
+/// definition in the sibling `runtime` module can name this type.
 #[cfg(not(target_os = "ios"))]
-type SurfaceApplier = Box<dyn FnMut(flui_types::Size<flui_types::geometry::Pixels>, f32)>;
+pub(super) type SurfaceApplier =
+    Box<dyn FnMut(flui_types::Size<flui_types::geometry::Pixels>, f32)>;
 
-/// Restores a taken [`SurfaceApplier`] back into [`PLATFORM_REALM_HOST`]'s
-/// slot when dropped — including during an unwinding drop, so a panic
-/// inside the applier's own call (caught by `dispatch_platform_realm`'s
-/// outer `catch_unwind`) cannot permanently strand resizing. Without this,
-/// the applier taken out before the call is simply never restored once the
-/// call panics, and every later `Resized` event finds the slot empty
-/// forever, silently coalescing at the `None` arm's trace instead of ever
-/// applying again.
+/// Restores a taken [`SurfaceApplier`] back into [`APP_RUNTIME`]'s slot when
+/// dropped — including during an unwinding drop, so a panic inside the
+/// applier's own call (caught by `dispatch_platform_realm`'s outer
+/// `catch_unwind`) cannot permanently strand resizing. Without this, the
+/// applier taken out before the call is simply never restored once the call
+/// panics, and every later `Resized` event finds the slot empty forever,
+/// silently coalescing at the `None` arm's trace instead of ever applying
+/// again.
 #[cfg(not(target_os = "ios"))]
 #[must_use = "dropping this immediately restores the applier with no call in between"]
 struct SurfaceApplierRestoreGuard(Option<SurfaceApplier>);
@@ -259,62 +250,9 @@ impl SurfaceApplierRestoreGuard {
 impl Drop for SurfaceApplierRestoreGuard {
     fn drop(&mut self) {
         if let Some(applier) = self.0.take() {
-            PLATFORM_REALM_HOST.with(|slot| {
+            APP_RUNTIME.with(|slot| {
                 slot.borrow_mut().surface_applier = Some(applier);
             });
-        }
-    }
-}
-
-#[cfg(not(target_os = "ios"))]
-struct RealmHost {
-    realm: Option<super::ui_realm::UiRealm>,
-    queue: std::collections::VecDeque<RealmTask>,
-    draining: bool,
-    owner_thread: Option<std::thread::ThreadId>,
-    /// This realm incarnation's routable address. A **derived cache** of
-    /// [`super::window_registry::WindowRegistry`] below, not a second
-    /// source of truth — both are written only by
-    /// [`install_platform_realm`]/[`teardown_platform_realm`], inside this
-    /// same TLS borrow, in that order (see `window_registry`'s module doc
-    /// for the full invariant).
-    address: Option<flui_foundation::PresentationAddress>,
-    /// The sole native-window-to-presentation mapping authority (ADR-0037
-    /// §2). Lives here, inside the same thread-local as the realm it
-    /// addresses, rather than as a second free-standing static — a future
-    /// multi-window `AppRuntime` lifts it out unchanged (the type itself
-    /// has no TLS assumption baked in).
-    registry: super::window_registry::WindowRegistry,
-    /// The registration-lifetime renderer-surface applier for a
-    /// [`PlatformToUi::Resized`] event, installed once at realm install by
-    /// [`install_surface_applier`] and cleared at teardown. `take`n out of
-    /// this slot before it is called and restored after (never called
-    /// through a live borrow) — see [`PlatformToUi::run`]'s `Resized` arm.
-    surface_applier: Option<SurfaceApplier>,
-
-    /// Single-window `(visible, focused)` tracking for the
-    /// `AppLifecycleState` derivation (see `ADR-0035`) — `PlatformToUi::
-    /// WindowFocus`/`WindowVisibility` each update one half of this pair and
-    /// re-derive. Both default `true`: a window is assumed visible and
-    /// focused until a platform callback says otherwise (matches every
-    /// backend's actual startup state).
-    visible: bool,
-    focused: bool,
-}
-
-#[cfg(not(target_os = "ios"))]
-impl RealmHost {
-    const fn new() -> Self {
-        Self {
-            realm: None,
-            queue: std::collections::VecDeque::new(),
-            draining: false,
-            owner_thread: None,
-            address: None,
-            registry: super::window_registry::WindowRegistry::new(),
-            surface_applier: None,
-            visible: true,
-            focused: true,
         }
     }
 }
@@ -352,8 +290,11 @@ enum RealmDispatchError {
 /// module's own tests. If `PlatformInput` ever
 /// stopped being `Send`, that must be fixed in `flui-platform` itself,
 /// never worked around here.
+// `pub(super)` because `RealmTask::Event` (also `pub(super)`, for
+// `AppRuntime`'s sake) carries this type in a field the compiler considers
+// reachable at that same visibility.
 #[cfg(not(target_os = "ios"))]
-enum PlatformToUi {
+pub(super) enum PlatformToUi {
     Input(flui_platform::traits::PlatformInput),
     Resized {
         size: flui_types::Size<flui_types::geometry::Pixels>,
@@ -390,8 +331,10 @@ enum PlatformToUi {
 /// (ADR-0037 §3 forbids `Box<dyn FnOnce()>` on that boundary). The `Send`
 /// assertion above applies to `PlatformToUi` only; splitting the two types
 /// is what makes that assertion non-vacuous.
+// `pub(super)` (rather than private) so `AppRuntime`'s `queue` field, defined
+// in the sibling `runtime` module, can name this type.
 #[cfg(not(target_os = "ios"))]
-enum RealmTask {
+pub(super) enum RealmTask {
     Event(PlatformToUi),
     Frame(Box<dyn FnOnce(&super::ui_realm::UiRealm)>),
 }
@@ -421,8 +364,7 @@ impl PlatformToUi {
                 // already cleared by teardown) this skips with a trace
                 // instead of unwrapping/panicking; surface application then
                 // coalesces onto the next real applier install.
-                let applier =
-                    PLATFORM_REALM_HOST.with(|slot| slot.borrow_mut().surface_applier.take());
+                let applier = APP_RUNTIME.with(|slot| slot.borrow_mut().surface_applier.take());
                 match applier {
                     Some(applier) => {
                         // The guard restores the applier on drop
@@ -447,7 +389,7 @@ impl PlatformToUi {
                 tracing::trace!(?size, scale_factor, "realm resize committed");
             }
             Self::WindowFocus(focused) => {
-                let (old, new) = PLATFORM_REALM_HOST.with(|slot| {
+                let (old, new) = APP_RUNTIME.with(|slot| {
                     let mut state = slot.borrow_mut();
                     let old = derive_lifecycle_state(state.visible, state.focused);
                     state.focused = focused;
@@ -456,7 +398,7 @@ impl PlatformToUi {
                 emit_lifecycle_transition(realm, old, new);
             }
             Self::WindowVisibility(visible) => {
-                let (old, new) = PLATFORM_REALM_HOST.with(|slot| {
+                let (old, new) = APP_RUNTIME.with(|slot| {
                     let mut state = slot.borrow_mut();
                     let old = derive_lifecycle_state(state.visible, state.focused);
                     state.visible = visible;
@@ -480,7 +422,7 @@ impl PlatformToUi {
 fn install_surface_applier(
     applier: impl FnMut(flui_types::Size<flui_types::geometry::Pixels>, f32) + 'static,
 ) {
-    PLATFORM_REALM_HOST.with(|slot| {
+    APP_RUNTIME.with(|slot| {
         slot.borrow_mut().surface_applier = Some(Box::new(applier));
     });
 }
@@ -769,7 +711,7 @@ mod lifecycle_derivation_tests {
     /// Occlusion-before-focus-loss and focus-loss-before-occlusion must
     /// converge to the same derived state — the derivation depends only on
     /// the final `(visible, focused)` pair, never on update order.
-    /// Mirrors `RealmHost`'s actual update pattern (mutate one signal,
+    /// Mirrors `AppRuntime`'s actual update pattern (mutate one signal,
     /// re-derive) so this test exercises real ordering, not just two calls
     /// to a pure function with identical arguments.
     struct WindowSignals {
@@ -1087,7 +1029,7 @@ fn install_platform_realm(
         realm_id: realm.realm_id(),
         presentation_id: realm.presentation_id(),
     };
-    let (displaced_realm, displaced_queue, displaced_applier) = PLATFORM_REALM_HOST.with(|slot| {
+    let (displaced_realm, displaced_queue, displaced_applier) = APP_RUNTIME.with(|slot| {
         let mut state = slot.borrow_mut();
         // A realm may already be installed here — a reinstall without an
         // intervening `teardown_platform_realm` (the panic-recovery path: a
@@ -1131,7 +1073,7 @@ fn install_platform_realm(
         // A second realm installed on this thread (hot-restart, or a
         // sequential test realm) must not inherit whatever `(visible,
         // focused)` the PREVIOUS realm's window last reported — every
-        // backend starts a window visible and focused (see `RealmHost::new`
+        // backend starts a window visible and focused (see `AppRuntime::new`
         // and each `MockWindow`/`WinitWindow` constructor), so a fresh
         // realm's derivation must start from that same baseline, not a
         // stale `Hidden`/`Inactive` left behind by the last one.
@@ -1160,7 +1102,7 @@ fn dispatch_platform_realm(
         tracing::error!(?dispatcher, "rejecting realm callback on non-owner thread");
         return Err(RealmDispatchError::WrongThread);
     }
-    let realm = PLATFORM_REALM_HOST.with(|slot| {
+    let realm = APP_RUNTIME.with(|slot| {
         let mut state = slot.borrow_mut();
         // Normative compare order (ADR-0037): realm first, then
         // presentation. `realm_id`/`presentation_id` mint from one shared
@@ -1216,10 +1158,10 @@ fn dispatch_platform_realm(
         let mut next = Some(first);
         while let Some(event) = next {
             realm.enter(|realm| event.run(realm));
-            next = PLATFORM_REALM_HOST.with(|slot| slot.borrow_mut().queue.pop_front());
+            next = APP_RUNTIME.with(|slot| slot.borrow_mut().queue.pop_front());
         }
     }));
-    PLATFORM_REALM_HOST.with(|slot| {
+    APP_RUNTIME.with(|slot| {
         let mut state = slot.borrow_mut();
         state.realm = Some(realm);
         state.draining = false;
@@ -1253,7 +1195,7 @@ fn drain_owner_inbox(realm: &super::ui_realm::UiRealm) -> bool {
 
 #[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
 fn teardown_platform_realm() {
-    let (realm, queued) = PLATFORM_REALM_HOST.with(|slot| {
+    let (realm, queued) = APP_RUNTIME.with(|slot| {
         let mut state = slot.borrow_mut();
         // Registry removal first (ADR-0037 §2): stop new routing before the
         // queued old-generation events below are dropped, and before the
@@ -1346,7 +1288,7 @@ mod realm_dispatch_tests {
     #[test]
     fn install_platform_realm_resets_stale_visible_focused_from_a_prior_realm() {
         install_test_realm();
-        PLATFORM_REALM_HOST.with(|slot| {
+        APP_RUNTIME.with(|slot| {
             let mut state = slot.borrow_mut();
             state.visible = false;
             state.focused = false;
@@ -1354,7 +1296,7 @@ mod realm_dispatch_tests {
         teardown_platform_realm();
 
         install_test_realm();
-        PLATFORM_REALM_HOST.with(|slot| {
+        APP_RUNTIME.with(|slot| {
             let state = slot.borrow();
             assert!(
                 state.visible,
@@ -1415,7 +1357,7 @@ mod realm_dispatch_tests {
         // retries `install_platform_realm` without ever calling
         // `teardown_platform_realm`. Also force `draining = true`, matching
         // a realm that was mid-drain when the panic hit.
-        PLATFORM_REALM_HOST.with(|slot| {
+        APP_RUNTIME.with(|slot| {
             let mut state = slot.borrow_mut();
             state.queue.push_back(RealmTask::Frame(Box::new(move |_| {
                 *delivered_in_event.borrow_mut() = true;
@@ -1499,7 +1441,7 @@ mod realm_dispatch_tests {
             &second_window,
         );
 
-        PLATFORM_REALM_HOST.with(|slot| {
+        APP_RUNTIME.with(|slot| {
             let state = slot.borrow();
             assert_eq!(
                 state.registry.resolve(first_window_id),
@@ -1591,7 +1533,7 @@ mod realm_dispatch_tests {
     #[test]
     fn late_event_never_crosses_realm_incarnations() {
         let stale = install_test_realm();
-        PLATFORM_REALM_HOST.with(|slot| {
+        APP_RUNTIME.with(|slot| {
             let mut state = slot.borrow_mut();
             let realm = state.realm.take();
             state.queue.clear();
@@ -1700,7 +1642,7 @@ mod realm_dispatch_tests {
             *applier_invoked_in_closure.borrow_mut() = true;
         });
 
-        PLATFORM_REALM_HOST.with(|slot| {
+        APP_RUNTIME.with(|slot| {
             let mut state = slot.borrow_mut();
             state.queue.push_back(RealmTask::Frame(Box::new(move |_| {
                 *delivered_in_event.borrow_mut() = true;
@@ -1922,7 +1864,7 @@ mod realm_dispatch_tests {
             dispatcher,
             dropped: Rc::clone(&dropped),
         };
-        PLATFORM_REALM_HOST.with(|slot| {
+        APP_RUNTIME.with(|slot| {
             slot.borrow_mut()
                 .queue
                 .push_back(RealmTask::Frame(Box::new(move |_| drop(probe))));
@@ -3826,7 +3768,7 @@ mod tests {
 
     /// Serializes tests that mutate `Scheduler::instance()`'s process-global
     /// phase (the repo rule for shared binding/scheduler state — AGENTS.md
-    /// "Testing quirks"). `OWNER_PLATFORM_HOST` itself is `thread_local!`, so
+    /// "Testing quirks"). `APP_RUNTIME` itself is `thread_local!`, so
     /// the install/clear tests below need no lock (the standard library
     /// test harness runs each `#[test]` on its own thread by default); this
     /// lock exists only for the one test that drives the process-global
@@ -3895,8 +3837,8 @@ mod tests {
     /// `on_ready` returning `Err` must propagate all the way out of
     /// `Platform::run` — not be swallowed into
     /// a bare log while the loop keeps running a half-built app — AND the
-    /// `OWNER_PLATFORM_HOST` TLS clear guard (armed before `run`, per the
-    /// existing unwind-safety contract) must still fire on this ordinary
+    /// `AppRuntime.owner_platform` TLS clear guard (armed before `run`, per
+    /// the existing unwind-safety contract) must still fire on this ordinary
     /// `Err` return, exactly as it does on a panic.
     #[test]
     fn owner_platform_host_on_ready_error_propagates_and_still_clears() {
@@ -3952,15 +3894,16 @@ mod tests {
         });
     }
 
-    /// Hot-restart survival (ADR-0039 §6): `OWNER_PLATFORM_HOST` is
-    /// loop-scoped, deliberately separate from `PLATFORM_REALM_HOST` --
-    /// tearing down a realm on the owner thread must not strand the loop's
-    /// capability, because the loop may host a fresh realm next without
-    /// ever calling `Platform::run` again (hot-restart does exactly this
-    /// today, `install_platform_realm`). `teardown_platform_realm` must
-    /// therefore leave `OWNER_PLATFORM_HOST` untouched.
+    /// Hot-restart survival (ADR-0039 §6; issue #553): `owner_platform`
+    /// is a loop-scoped `AppRuntime` field, deliberately not cleared by
+    /// `teardown_platform_realm` alongside the realm-facing fields it DOES
+    /// clear (`realm`, `queue`, `owner_thread`, `address`,
+    /// `surface_applier`) -- tearing down a realm on the owner thread must
+    /// not strand the loop's capability, because the loop may host a fresh
+    /// realm next without ever calling `Platform::run` again (hot-restart
+    /// does exactly this today, `install_platform_realm`).
     #[test]
-    fn owner_platform_host_survives_teardown_platform_realm() {
+    fn owner_platform_survives_realm_teardown() {
         use flui_platform::headless_platform;
 
         // `Rc<Cell<_>>`, not a bare local: the `on_ready` closure below is
@@ -3996,7 +3939,7 @@ mod tests {
         );
         assert!(
             after_teardown,
-            "teardown_platform_realm must not clear OWNER_PLATFORM_HOST -- \
+            "teardown_platform_realm must not clear AppRuntime.owner_platform -- \
              the loop may host another realm before it exits (hot-restart)"
         );
     }

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -4079,7 +4079,13 @@ mod tests {
     /// `teardown_platform_realm`, or `install_surface_applier` instead, for
     /// the identical reason (all of them `borrow_mut()` the same cell).
     #[test]
-    #[should_panic(expected = "already borrowed")]
+    // Substring match, not the full message: `RefCell`'s panic wording
+    // ("already borrowed: BorrowMutError" vs. "already mutably borrowed:
+    // BorrowError" depending on which side re-enters) has varied across
+    // Rust versions and could vary again; "borrow" is the one substring
+    // present in every variant, so this still fails on an unrelated panic
+    // while staying stable across toolchains.
+    #[should_panic(expected = "borrow")]
     fn with_owner_platform_reentering_dispatch_panics() {
         use flui_platform::headless_platform;
 

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -96,8 +96,17 @@ thread_local! {
     /// until that seam is retired (ADR-0027 follow-up 5); access is only
     /// through the stamped FIFO dispatcher below and the fenced
     /// `with_owner_platform` accessor.
+    ///
+    /// `AppRuntime::new()` is `const` and side-effect-free (no singleton
+    /// resolution) precisely so this `const` initializer stays true:
+    /// merely *touching* this thread-local -- for any reason, including
+    /// `OwnerHostClearGuard::drop` firing during an unwind on a thread that
+    /// never reached platform init -- can never itself trigger singleton
+    /// construction or full system-font enumeration. Real service
+    /// resolution happens only via the explicit `ensure_services` calls in
+    /// `install_owner_platform`/`install_platform_realm` below.
     static APP_RUNTIME: std::cell::RefCell<AppRuntime> =
-        std::cell::RefCell::new(AppRuntime::new());
+        const { std::cell::RefCell::new(AppRuntime::new()) };
 }
 
 /// Installs `owner` in the loop-scoped host. Call once, at the top of each
@@ -107,7 +116,12 @@ thread_local! {
 #[cfg(not(target_os = "ios"))]
 pub(crate) fn install_owner_platform(owner: flui_platform::OwnerPlatform) {
     APP_RUNTIME.with(|slot| {
-        slot.borrow_mut().owner_platform = Some(owner);
+        let mut state = slot.borrow_mut();
+        state.owner_platform = Some(owner);
+        // Explicit, known-point resolution -- not a TLS-initializer side
+        // effect. Idempotent (`ensure_services` caches), so it does not
+        // matter that `install_platform_realm` below also calls it.
+        let _ = state.ensure_services();
     });
 }
 
@@ -1079,6 +1093,11 @@ fn install_platform_realm(
         // stale `Hidden`/`Inactive` left behind by the last one.
         state.visible = true;
         state.focused = true;
+        // Explicit, known-point resolution (idempotent with the call in
+        // `install_owner_platform`) -- test call sites that install a realm
+        // directly, without going through `install_owner_platform` first
+        // (e.g. `install_test_realm` below), still get services resolved.
+        let _ = state.ensure_services();
         (displaced_realm, displaced_queue, displaced_applier)
     });
     // Destructors may re-enter platform/framework code (the same invariant

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -174,6 +174,23 @@ pub(crate) fn install_owner_platform(owner: flui_platform::OwnerPlatform) {
 ///     Ok(())
 /// }));
 /// ```
+///
+/// # No host re-entry
+///
+/// `f` runs while this function holds an immutable `APP_RUNTIME.borrow()`.
+/// Since `AppRuntime` folded the realm-facing state and `owner_platform`
+/// into ONE thread-local `RefCell` (issue #553's `AppRuntime` skeleton —
+/// they were two disjoint cells before), `f` must never call back into any
+/// function that touches this same cell: `dispatch_platform_realm`,
+/// `install_platform_realm`, `teardown_platform_realm`,
+/// `install_surface_applier`, or `install_owner_platform` itself. Any of
+/// those does `slot.borrow_mut()` while this borrow is still live, which is
+/// a guaranteed `BorrowMutError` panic — in every build, not only debug
+/// (`RefCell`'s borrow tracking is not a `debug_assert`). No production
+/// caller does this today (`f` closures only call owner-affine `Platform`
+/// methods), so this is a documented invariant with a regression pin
+/// (`with_owner_platform_reentering_dispatch_panics` below), not a runtime
+/// guard.
 #[cfg(not(target_os = "ios"))]
 pub(crate) fn with_owner_platform<R>(
     f: impl FnOnce(&flui_platform::OwnerPlatform) -> R,
@@ -206,6 +223,22 @@ pub(crate) fn with_owner_platform<R>(
 /// Web deliberately arms no guard: the host stays resident for the page's
 /// lifetime (see the web runner's own comment on this). macOS is moot:
 /// `run` never returns there (`terminate:` exits the process).
+///
+/// # No host re-entry, and no eager resolution
+///
+/// `Drop` touches only `owner_platform` (`self.owner_platform.take()`) —
+/// never `dispatch_platform_realm`/`install_platform_realm`/
+/// `teardown_platform_realm`/`install_surface_applier`, all of which would
+/// re-borrow the same `APP_RUNTIME` cell this drop already holds mutably
+/// (see `with_owner_platform`'s own "No host re-entry" doc for the general
+/// rule). Just as importantly, `AppRuntime::new()` is cheap and
+/// side-effect-free specifically so that a bare `.borrow_mut()` here — the
+/// *first* touch of `APP_RUNTIME` on a thread whose `on_ready` panicked
+/// before installing anything — can never trigger `SharedEngineServices`
+/// resolution (singleton construction plus full system-font enumeration)
+/// while already unwinding. A panic during that resolution, on top of the
+/// panic already unwinding, would abort the process instead of propagating
+/// the original failure.
 #[cfg(not(target_os = "ios"))]
 #[must_use = "the guard must stay alive across the Platform::run(...) call it \
               guards, or the TLS host clears immediately instead of at loop exit"]
@@ -1417,6 +1450,49 @@ mod realm_dispatch_tests {
              realm must actually drain, not just enqueue forever"
         );
         teardown_platform_realm();
+    }
+
+    /// `install_platform_realm` only ever touches the realm-facing fields
+    /// (`realm`, `queue`, `owner_thread`, `address`, `surface_applier`,
+    /// `visible`, `focused`) — `owner_platform` is a separate, loop-scoped
+    /// concern that must survive both branches: a fresh install, and a
+    /// replace-without-teardown reinstall that displaces a realm never torn
+    /// down (the same panic-recovery path
+    /// `reinstall_without_teardown_drops_the_displaced_realm_and_queue_outside_the_borrow`
+    /// exercises above).
+    #[test]
+    fn install_platform_realm_never_touches_owner_platform() {
+        use flui_platform::headless_platform;
+
+        let _clear_guard = OwnerHostClearGuard::arm();
+        let platform = headless_platform();
+        let result = platform.run(Box::new(|owner| {
+            install_owner_platform(owner);
+            assert!(
+                with_owner_platform(|_| ()).is_some(),
+                "owner_platform must be installed before the first realm install"
+            );
+
+            // Fresh-install branch.
+            install_test_realm();
+            assert!(
+                with_owner_platform(|_| ()).is_some(),
+                "a fresh realm install must not clear owner_platform"
+            );
+
+            // Replace-without-teardown branch: install a second realm while
+            // the first is still live, without an intervening
+            // `teardown_platform_realm` (the panic-recovery path).
+            install_test_realm();
+            assert!(
+                with_owner_platform(|_| ()).is_some(),
+                "a replace-without-teardown reinstall must not clear owner_platform"
+            );
+
+            teardown_platform_realm();
+            Ok(())
+        }));
+        assert!(result.is_ok(), "on_ready returns Ok here");
     }
 
     /// A panic-recovery reinstall under a DIFFERENT native window must
@@ -3961,5 +4037,48 @@ mod tests {
             "teardown_platform_realm must not clear AppRuntime.owner_platform -- \
              the loop may host another realm before it exits (hot-restart)"
         );
+    }
+
+    /// Regression pin for the "No host re-entry" rule on `with_owner_platform`'s
+    /// own rustdoc: since `AppRuntime` folded the realm-facing state and
+    /// `owner_platform` into one `RefCell`, a closure that calls back into
+    /// any function touching that same cell while `with_owner_platform`
+    /// still holds its immutable borrow is a guaranteed `BorrowMutError`
+    /// panic. `dispatch_platform_realm` is the stand-in host op here; the
+    /// same panic would fire for `install_platform_realm`,
+    /// `teardown_platform_realm`, or `install_surface_applier` instead, for
+    /// the identical reason (all of them `borrow_mut()` the same cell).
+    #[test]
+    #[should_panic(expected = "already borrowed")]
+    fn with_owner_platform_reentering_dispatch_panics() {
+        use flui_platform::headless_platform;
+
+        let _clear_guard = OwnerHostClearGuard::arm();
+        let platform = headless_platform();
+        let _ = platform.run(Box::new(|owner| {
+            install_owner_platform(owner);
+            with_owner_platform(|_owner| {
+                // Any host op re-entering here panics: `with_owner_platform`
+                // still holds `APP_RUNTIME.borrow()` for the duration of
+                // this closure, and `dispatch_platform_realm` immediately
+                // tries `slot.borrow_mut()` on the very first line of its
+                // own TLS access.
+                let dispatcher = RealmDispatcher {
+                    owner_thread: std::thread::current().id(),
+                    address: flui_foundation::PresentationAddress {
+                        realm_id: flui_foundation::RealmId::new_gen(
+                            0,
+                            std::num::NonZeroU32::new(1).unwrap(),
+                        ),
+                        presentation_id: flui_foundation::PresentationId::new_gen(
+                            0,
+                            std::num::NonZeroU32::new(1).unwrap(),
+                        ),
+                    },
+                };
+                let _ = dispatch_platform_realm(dispatcher, RealmTask::Frame(Box::new(|_| {})));
+            });
+            Ok(())
+        }));
     }
 }

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -1,4 +1,4 @@
-//! `AppRuntime` — the loop-scoped composition root (issue #553).
+//! `AppRuntime` — the loop-scoped composition root.
 //!
 //! # Thesis
 //!
@@ -186,16 +186,18 @@ impl SharedEngineServices {
     fn resolve() -> Self {
         let painting = PaintingBinding::instance();
 
-        // `AppRuntime::new()` is the CONSTRUCTING owner of the free-standing
-        // `FONT_SYSTEM` `OnceLock` slot (`flui-painting/src/text_layout/
-        // layout.rs`) -- initialize it explicitly, here, at a known point,
-        // rather than leaving it to whichever text-measurement call happens
-        // to run first on this thread. The read path stays ambient on
-        // layout hot paths: this is a named exclusion (see this crate's
+        // `SharedEngineServices::resolve()` -- reached only through
+        // `AppRuntime::ensure_services()`, at the realm-install point -- is
+        // the CONSTRUCTING owner of the free-standing `FONT_SYSTEM`
+        // `OnceLock` slot (`flui-painting/src/text_layout/layout.rs`):
+        // initialize it explicitly, here, at a known point, rather than
+        // leaving it to whichever text-measurement call happens to run
+        // first on this thread. The read path stays ambient on layout hot
+        // paths: this is a named exclusion (see this crate's
         // `ambient_reach` entry in `docs/runtime-contract.toml`), not closed
         // here -- injecting the font system into every `perform_layout`
-        // text-measurement call is a separate, larger follow-up (the icon-
-        // font-loading/sharding work tracked against issue #553).
+        // text-measurement call is a separate, larger follow-up (the
+        // icon-font-loading/sharding work).
         let _ = painting.font_system();
 
         Self {
@@ -251,8 +253,8 @@ static NEXT_INCARNATION: AtomicU32 = AtomicU32::new(1);
 
 /// Mints a fresh, process-unique `(RealmId, PresentationId)` pair. Slot 0 is
 /// the single-window slot; a real multi-window `AppRuntime` registry mints
-/// slots once it exists (#555) — the shape is the deliverable now,
-/// single-window the only instantiation.
+/// slots once the element forest lets a realm host multiple presentations —
+/// the shape is the deliverable now, single-window the only instantiation.
 pub(crate) fn next_identity() -> (RealmId, PresentationId) {
     let incarnation = NEXT_INCARNATION.fetch_add(1, Ordering::Relaxed);
     let generation = NonZeroU32::new(incarnation)
@@ -280,7 +282,8 @@ pub(crate) fn next_identity() -> (RealmId, PresentationId) {
 /// # Design-for-N
 ///
 /// The realm-facing API is `RealmId`-keyed ([`AppRuntime::realm`]);
-/// *storage* is a single `Option<UiRealm>` slot until #555 gives this a real
+/// *storage* is a single `Option<UiRealm>` slot until the element forest
+/// lets a realm host multiple presentations and this grows a real
 /// multi-realm registry. `next_identity` above already mints from a shape
 /// that does not need to change when that lands.
 #[cfg(not(target_os = "ios"))]

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -330,10 +330,13 @@ impl AppRuntime {
     /// (`runner.rs`), so simply *touching* the thread-local -- for any
     /// reason, on any thread -- can never itself run singleton construction
     /// or full system-font enumeration. Real service resolution happens
-    /// only via the explicit [`Self::ensure_services`] call, from
-    /// `install_owner_platform`/`install_platform_realm` -- the loop's own
-    /// bootstrap points, never from an incidental first touch such as
-    /// `OwnerHostClearGuard::drop` unwinding through a virgin thread.
+    /// only via the explicit [`Self::ensure_services`] call from
+    /// `install_platform_realm` -- when a realm is actually installed --
+    /// never from an incidental first touch such as
+    /// `OwnerHostClearGuard::drop` unwinding through a virgin thread, and
+    /// never from `install_owner_platform` either (every backend calls
+    /// that, including `run_direct`, which never installs a realm and
+    /// never needs these services).
     pub(super) const fn new() -> Self {
         Self {
             realm: None,
@@ -351,9 +354,14 @@ impl AppRuntime {
     }
 
     /// Resolves and caches [`SharedEngineServices`] on first call; returns
-    /// the cached value on every later call. Idempotent, so both
-    /// `install_owner_platform` and `install_platform_realm` can call this
-    /// unconditionally without needing to agree on which one runs first.
+    /// the cached value on every later call. Called only from
+    /// `install_platform_realm`, when a realm is actually about to be
+    /// installed on this thread -- `install_owner_platform` deliberately
+    /// does NOT call this (see its own doc): every backend calls that,
+    /// including `run_direct`, which opens a window but never installs a
+    /// realm and never consumes painting/semantics/scheduler services, so
+    /// resolving there would pay for singleton construction and full
+    /// system-font enumeration for nothing.
     ///
     /// This is the fix for a real hazard the previous shape had: when
     /// `AppRuntime::new()` itself resolved `SharedEngineServices` (singleton
@@ -371,18 +379,31 @@ impl AppRuntime {
         self.services.get_or_init(SharedEngineServices::resolve)
     }
 
+    /// Test-only introspection: whether `SharedEngineServices` has been
+    /// resolved yet. `services` itself is private to this module, and
+    /// `runner.rs`'s tests (a sibling module tree, with the real
+    /// `install_owner_platform`/`install_platform_realm` bootstrap) need to
+    /// assert on it without reaching into a private field directly.
+    #[cfg(test)]
+    pub(super) fn services_resolved(&self) -> bool {
+        self.services.get().is_some()
+    }
+
     /// `RealmId`-keyed lookup: `Some` only when `id` matches the single
-    /// installed realm's identity. Storage is one slot until #555 gives
-    /// `AppRuntime` a real multi-realm registry — the keyed shape is the
-    /// deliverable now, so #555 does not have to reshape this method's
-    /// callers, only its body.
+    /// installed realm's identity. Storage is one slot until the element
+    /// forest lets a realm host multiple presentations and `AppRuntime`
+    /// grows a real multi-realm registry — the keyed shape is the
+    /// deliverable now, so that growth does not have to reshape this
+    /// method's callers, only its body.
     #[cfg_attr(
         not(test),
         expect(
             dead_code,
             reason = "design-for-N accessor; the single production caller \
                       (per-realm dispatch) still addresses the TLS slot \
-                      directly until #555's multi-realm registry lands"
+                      directly until the element forest lets a realm host \
+                      multiple presentations and this grows a real \
+                      multi-realm registry"
         )
     )]
     pub(crate) fn realm(&self, id: RealmId) -> Option<&UiRealm> {

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -26,6 +26,7 @@
 //! *ownership* (one struct, one thread-local slot instead of two), not the
 //! dispatch/teardown semantics those functions implement.
 
+use std::marker::PhantomData;
 use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -50,29 +51,72 @@ use flui_scheduler::{AsyncDriver, LocalPostFrameLane, Scheduler, SchedulerPhase}
 /// `PaintingBinding::font_system` already proves for painting (it returns
 /// `SharedFontSystem` by value, so consumers never observe the `'static`
 /// lifetime).
+///
+/// # Thread affinity
+///
+/// `Scheduler::instance()` is itself thread-local — `impl_binding_singleton!`
+/// `Box::leak`s a *separate* instance per owner thread, so the `&'static`
+/// inside this newtype is only meaningful on the thread that resolved it. A
+/// bare `&'static Scheduler` field would make this struct auto-`Send +
+/// Sync` (a `&'static T` is `Send + Sync` whenever `T: Sync`, regardless of
+/// which thread produced the reference), which would let a `SchedulerRef`
+/// minted on thread A cross to thread B and silently read thread A's phase
+/// there instead of failing to compile or panicking. That is latent today
+/// only because every current holder (`UiRealm`, `AppRuntime`) is itself
+/// already `!Send` for unrelated reasons — it turns actively wrong the
+/// moment either type's ownership model changes to allow crossing threads
+/// while still carrying a `SchedulerRef`. The `PhantomData<*const ()>`
+/// field below is the same zero-cost thread-affinity marker `UiRealm` uses
+/// for itself (`_owner_affine`), and the item-position assertion after this
+/// impl block pins `!Send + !Sync` as a compile-time fact, not a comment.
 #[derive(Clone, Copy)]
-pub(crate) struct SchedulerRef(&'static Scheduler);
+pub(crate) struct SchedulerRef {
+    scheduler: &'static Scheduler,
+    _owner_affine: PhantomData<*const ()>,
+}
 
 impl SchedulerRef {
     fn resolve() -> Self {
-        Self(Scheduler::instance())
+        Self {
+            scheduler: Scheduler::instance(),
+            _owner_affine: PhantomData,
+        }
     }
 
     /// The current scheduler phase — the seam `UiRealm::drain_commands`
     /// reads for its idle-only commit-gate debug assertion, so `UiRealm`
     /// itself never has to call `Scheduler::instance()`.
     pub(crate) fn phase(&self) -> SchedulerPhase {
-        self.0.phase()
+        self.scheduler.phase()
     }
 
     /// Borrow the backing scheduler directly, for the handful of
     /// construction-time calls ([`RealmServices::resolve`]) that need more
-    /// than the phase probe.
+    /// than the phase probe. This is the one place that leaks the
+    /// `&'static` the newtype otherwise exists to contain -- it dies with
+    /// the scheduler-ownership flip: once `Scheduler` becomes an owned,
+    /// realm-local value instead of a `'static` singleton, this method
+    /// simply stops type-checking, which is the point.
     pub(crate) fn get(&self) -> &'static Scheduler {
-        self.0
+        self.scheduler
     }
 }
 
+#[cfg(test)]
+mod scheduler_ref_tests {
+    use super::*;
+
+    // Compile-time fence: a `SchedulerRef` minted on one thread must never
+    // be movable/shareable to another, because the `&'static Scheduler` it
+    // wraps is only meaningful on the thread that resolved it
+    // (`Scheduler::instance()` is thread-local underneath). Widening this
+    // bound is exactly the landmine described on `SchedulerRef`'s own
+    // rustdoc -- it would silently compile a cross-thread phase read.
+    static_assertions::assert_not_impl_any!(SchedulerRef: Send, Sync);
+}
+
+#[cfg(not(target_os = "ios"))]
+use std::cell::OnceCell;
 #[cfg(not(target_os = "ios"))]
 use std::collections::VecDeque;
 #[cfg(not(target_os = "ios"))]
@@ -271,27 +315,23 @@ pub(crate) struct AppRuntime {
     /// Deliberately *not* cleared by realm teardown — the loop may host
     /// another realm before it exits (hot-restart does exactly this).
     pub(super) owner_platform: Option<OwnerPlatform>,
-    /// Process-level engine services, resolved once at construction.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "this change only creates the resolution seam; nothing \
-                      yet reads this field back out (later changes wire \
-                      real consumers)"
-        )
-    )]
-    pub(super) services: SharedEngineServices,
+    /// Process-level engine services. Deliberately **not** resolved in
+    /// [`AppRuntime::new`] -- see [`AppRuntime::ensure_services`] for why.
+    services: OnceCell<SharedEngineServices>,
 }
 
 #[cfg(not(target_os = "ios"))]
 impl AppRuntime {
-    /// Construct the composition root. Called once per owner thread, lazily
-    /// on that thread's first touch of the `APP_RUNTIME` TLS slot — there is
-    /// no eager, process-wide bootstrap step yet. This is the seam this
-    /// change creates, not a compatibility layer: every service it
-    /// `resolve()`s from is still the same singleton it always was.
-    pub(super) fn new() -> Self {
+    /// Construct the composition root: cheap, side-effect-free, `const`.
+    /// Called as the `APP_RUNTIME` TLS slot's own `const` initializer
+    /// (`runner.rs`), so simply *touching* the thread-local -- for any
+    /// reason, on any thread -- can never itself run singleton construction
+    /// or full system-font enumeration. Real service resolution happens
+    /// only via the explicit [`Self::ensure_services`] call, from
+    /// `install_owner_platform`/`install_platform_realm` -- the loop's own
+    /// bootstrap points, never from an incidental first touch such as
+    /// `OwnerHostClearGuard::drop` unwinding through a virgin thread.
+    pub(super) const fn new() -> Self {
         Self {
             realm: None,
             queue: VecDeque::new(),
@@ -303,8 +343,29 @@ impl AppRuntime {
             visible: true,
             focused: true,
             owner_platform: None,
-            services: SharedEngineServices::resolve(),
+            services: OnceCell::new(),
         }
+    }
+
+    /// Resolves and caches [`SharedEngineServices`] on first call; returns
+    /// the cached value on every later call. Idempotent, so both
+    /// `install_owner_platform` and `install_platform_realm` can call this
+    /// unconditionally without needing to agree on which one runs first.
+    ///
+    /// This is the fix for a real hazard the previous shape had: when
+    /// `AppRuntime::new()` itself resolved `SharedEngineServices` (singleton
+    /// construction plus eager system-font enumeration), *any* first touch
+    /// of the TLS slot ran that work -- including
+    /// `OwnerHostClearGuard::drop` firing during an unwind on a thread that
+    /// never got past platform init. A panic inside that resolution path
+    /// would then be a second panic during an unwind already in progress,
+    /// i.e. an abort that masks the original panic. Making `AppRuntime::new`
+    /// infallible/side-effect-free and resolving services only from this
+    /// explicit call restores the old `RealmHost`-era guarantee that merely
+    /// touching the thread-local is always safe to do from within a
+    /// clear-guard drop.
+    pub(super) fn ensure_services(&mut self) -> &SharedEngineServices {
+        self.services.get_or_init(SharedEngineServices::resolve)
     }
 
     /// `RealmId`-keyed lookup: `Some` only when `id` matches the single
@@ -356,17 +417,63 @@ mod app_runtime_tests {
         );
     }
 
-    /// `SharedEngineServices::resolve` must actually populate all three
-    /// fields with live, usable handles -- reading each one here (rather
-    /// than only asserting the struct compiles) is what proves the
-    /// resolution seam works, not just that it type-checks.
+    /// `AppRuntime::new` must NOT resolve `SharedEngineServices` -- that is
+    /// the entire point of moving resolution behind `OnceCell` +
+    /// `ensure_services`. Red before the fix: `new()` used to call
+    /// `SharedEngineServices::resolve()` directly, so `services` was always
+    /// `Some` immediately after construction; this assertion would have
+    /// failed against that shape.
     #[test]
-    fn app_runtime_resolves_all_three_shared_engine_services() {
+    fn app_runtime_new_does_not_resolve_services() {
         let runtime = AppRuntime::new();
 
-        let _painting_image_cache = runtime.services.painting.image_cache();
-        let _semantics_features = runtime.services.semantics.accessibility_features();
-        let _phase = runtime.services.scheduler.phase();
+        assert!(
+            runtime.services.get().is_none(),
+            "AppRuntime::new must not resolve SharedEngineServices -- doing so \
+             makes every first touch of the TLS slot (including an \
+             OwnerHostClearGuard::drop during an unwind) run singleton \
+             construction and full system-font enumeration"
+        );
+    }
+
+    /// `ensure_services` must actually populate all three
+    /// `SharedEngineServices` fields with live, usable handles -- reading
+    /// each one here (rather than only asserting the struct compiles) is
+    /// what proves the resolution seam works, not just that it type-checks.
+    #[test]
+    fn ensure_services_resolves_all_three_and_caches_them() {
+        let mut runtime = AppRuntime::new();
+
+        let services = runtime.ensure_services();
+        let _painting_image_cache = services.painting.image_cache();
+        let _semantics_features = services.semantics.accessibility_features();
+        let _phase = services.scheduler.phase();
+
+        assert!(
+            runtime.services.get().is_some(),
+            "ensure_services must cache the resolved value, not re-resolve on \
+             every call"
+        );
+    }
+
+    /// A `OwnerHostClearGuard`-shaped operation that touches ONLY
+    /// `owner_platform` -- never `ensure_services` -- must leave `services`
+    /// unresolved. Mirrors `OwnerHostClearGuard::drop`'s actual field touch
+    /// (`runner.rs`) without depending on `runner.rs`'s platform machinery.
+    #[test]
+    fn guard_only_arm_and_drop_cycle_never_resolves_services() {
+        let mut runtime = AppRuntime::new();
+
+        // The clear-guard's drop body: `self.owner_platform.take();` and
+        // nothing else.
+        runtime.owner_platform.take();
+
+        assert!(
+            runtime.services.get().is_none(),
+            "a guard-only arm/drop cycle (owner_platform touch only) must \
+             never resolve SharedEngineServices -- that would reintroduce \
+             the double-panic-during-unwind hazard this shape closes"
+        );
     }
 }
 

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -1,0 +1,386 @@
+//! `AppRuntime` — the loop-scoped composition root (issue #553).
+//!
+//! # Thesis
+//!
+//! This module creates the composition root and the constructor-injection
+//! seams while every service it names is still singleton-*backed*. The
+//! honest claim: `UiRealm` performs zero `::instance()` calls; the services
+//! it consumes are resolved once, here, in [`SharedEngineServices::resolve`].
+//! Other ambient reaches (`renderer_binding.rs`, `binding.rs`,
+//! `hot_reload.rs`, `config.rs`, `text.rs`) are untouched — they remain
+//! until the change that retires each singleton they reach for. This is not
+//! a forwarding shim: no old API is preserved-but-deprecated here, and no
+//! ambient access point this change does not touch is claimed as closed.
+//!
+//! # What lives here vs. in `runner.rs`
+//!
+//! `AppRuntime` absorbs the transitional `RealmHost`'s fields (realm slot,
+//! queue, draining flag, owner thread, address cache, window registry,
+//! surface applier, visible/focused) plus the loop-scoped
+//! `OwnerPlatform` capability (formerly a second, separate thread-local) and
+//! [`SharedEngineServices`]. The single-threaded dispatch machinery that
+//! operates on this struct — `install_platform_realm`,
+//! `dispatch_platform_realm`, `teardown_platform_realm`,
+//! `install_owner_platform`, `with_owner_platform`, the TLS declaration
+//! itself — stays in `runner.rs`, unchanged in behavior: this change moves
+//! *ownership* (one struct, one thread-local slot instead of two), not the
+//! dispatch/teardown semantics those functions implement.
+
+use std::num::NonZeroU32;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use flui_foundation::{HasInstance, PresentationId, RealmId};
+use flui_scheduler::{AsyncDriver, LocalPostFrameLane, Scheduler, SchedulerPhase};
+
+// `SchedulerRef`, `RealmServices`, and `next_identity` below are used
+// unconditionally by `ui_realm.rs` (every `UiRealm` constructor resolves its
+// own `RealmServices` now, on every platform `UiRealm` itself compiles for,
+// including iOS's stub). `AppRuntime` and `SharedEngineServices` further
+// down are the loop-scoped composition root that only the non-iOS runners
+// (`runner.rs`'s desktop/android/web dispatch) instantiate, so they -- and
+// the imports only they need -- stay `#[cfg(not(target_os = "ios"))]`,
+// matching the cfg the absorbed `RealmHost`/`OWNER_PLATFORM_HOST` carried.
+
+/// Newtype over `&'static Scheduler`, resolved once in
+/// [`SharedEngineServices::resolve`] / [`RealmServices::resolve`].
+///
+/// Exists rather than a bare `&'static Scheduler` field so a future flip to
+/// a realm-owned `Scheduler` value changes one type's internals, not every
+/// call site's field-access syntax — the same "flip-containment" shape
+/// `PaintingBinding::font_system` already proves for painting (it returns
+/// `SharedFontSystem` by value, so consumers never observe the `'static`
+/// lifetime).
+#[derive(Clone, Copy)]
+pub(crate) struct SchedulerRef(&'static Scheduler);
+
+impl SchedulerRef {
+    fn resolve() -> Self {
+        Self(Scheduler::instance())
+    }
+
+    /// The current scheduler phase — the seam `UiRealm::drain_commands`
+    /// reads for its idle-only commit-gate debug assertion, so `UiRealm`
+    /// itself never has to call `Scheduler::instance()`.
+    pub(crate) fn phase(&self) -> SchedulerPhase {
+        self.0.phase()
+    }
+
+    /// Borrow the backing scheduler directly, for the handful of
+    /// construction-time calls ([`RealmServices::resolve`]) that need more
+    /// than the phase probe.
+    pub(crate) fn get(&self) -> &'static Scheduler {
+        self.0
+    }
+}
+
+#[cfg(not(target_os = "ios"))]
+use std::collections::VecDeque;
+#[cfg(not(target_os = "ios"))]
+use std::thread::ThreadId;
+
+#[cfg(not(target_os = "ios"))]
+use flui_foundation::PresentationAddress;
+#[cfg(not(target_os = "ios"))]
+use flui_painting::PaintingBinding;
+#[cfg(not(target_os = "ios"))]
+use flui_platform::OwnerPlatform;
+#[cfg(not(target_os = "ios"))]
+use flui_semantics::SemanticsBinding;
+
+#[cfg(not(target_os = "ios"))]
+use super::runner::{RealmTask, SurfaceApplier};
+#[cfg(not(target_os = "ios"))]
+use super::ui_realm::UiRealm;
+#[cfg(not(target_os = "ios"))]
+use super::window_registry::WindowRegistry;
+
+/// Process-level engine services, each resolved **once** per owner thread in
+/// [`SharedEngineServices::resolve`] — never re-resolved on every access, and
+/// never reached ambiently from inside `UiRealm`.
+///
+/// Every field here is transitional: the type each names is still the
+/// process-global singleton underneath (`PaintingBinding::instance()` and
+/// friends) — only the *resolution point* moves to this one constructor.
+/// Each field's `'static` reference is expected to flip to an owned value
+/// once the change that retires that singleton lands (painting, semantics,
+/// and the scheduler each have their own separate follow-up); until then
+/// these fields are `pub(super)`, not part of any public surface (ADR-0027
+/// §9: transitional runtime types stay `pub(crate)` at most).
+#[cfg(not(target_os = "ios"))]
+pub(crate) struct SharedEngineServices {
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "this change only creates the resolution seam; a later \
+                      change wires the first real consumer"
+        )
+    )]
+    pub(super) painting: &'static PaintingBinding,
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "this change only creates the resolution seam; a later \
+                      change wires the first real consumer"
+        )
+    )]
+    pub(super) semantics: &'static SemanticsBinding,
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "this change only creates the resolution seam; a later \
+                      change wires the first real consumer"
+        )
+    )]
+    pub(super) scheduler: SchedulerRef,
+}
+
+#[cfg(not(target_os = "ios"))]
+impl SharedEngineServices {
+    fn resolve() -> Self {
+        let painting = PaintingBinding::instance();
+
+        // `AppRuntime::new()` is the CONSTRUCTING owner of the free-standing
+        // `FONT_SYSTEM` `OnceLock` slot (`flui-painting/src/text_layout/
+        // layout.rs`) -- initialize it explicitly, here, at a known point,
+        // rather than leaving it to whichever text-measurement call happens
+        // to run first on this thread. The read path stays ambient on
+        // layout hot paths: this is a named exclusion (see this crate's
+        // `ambient_reach` entry in `docs/runtime-contract.toml`), not closed
+        // here -- injecting the font system into every `perform_layout`
+        // text-measurement call is a separate, larger follow-up (the icon-
+        // font-loading/sharding work tracked against issue #553).
+        let _ = painting.font_system();
+
+        Self {
+            painting,
+            semantics: SemanticsBinding::instance(),
+            scheduler: SchedulerRef::resolve(),
+        }
+    }
+}
+
+/// What [`UiRealm::construct`](super::ui_realm) needs from the scheduler at
+/// construction time: `local_post_frame_lane()` and `async_driver()`
+/// (formerly `Scheduler::instance()` calls inside `ui_realm.rs` itself),
+/// plus the [`SchedulerRef`] `UiRealm` retains for its idle-only commit-gate
+/// phase probe (formerly another `Scheduler::instance()` call in the same
+/// file). Resolved once, here — never inside `ui_realm.rs` itself, so
+/// `UiRealm`'s own source performs zero `::instance()` calls.
+pub(crate) struct RealmServices {
+    pub(crate) local_post_frame: LocalPostFrameLane,
+    pub(crate) async_driver: AsyncDriver,
+    pub(crate) scheduler: SchedulerRef,
+}
+
+impl RealmServices {
+    /// Resolves directly from the still-singleton-backed `Scheduler`.
+    /// Because `Scheduler::instance()` memoizes per owner thread, this
+    /// yields the exact same `&'static Scheduler` a live `AppRuntime`'s own
+    /// [`SharedEngineServices`] resolved on this thread — whether or not an
+    /// `AppRuntime` has actually been touched yet. That is what lets every
+    /// existing `UiRealm` constructor (`new`, `with_capacity`, `for_test`,
+    /// `for_test_with_text_input`) keep its exact current signature here:
+    /// each calls this instead of reaching for `Scheduler::instance()`
+    /// directly. Rewriting `for_test`/`for_test_with_text_input` onto
+    /// explicit `RealmServices` + `PresentationState` injection (dropping
+    /// `&AppBinding` entirely) is a separate, later change, not this one.
+    pub(crate) fn resolve() -> Self {
+        let scheduler = SchedulerRef::resolve();
+        let backing = scheduler.get();
+        Self {
+            local_post_frame: backing.local_post_frame_lane(),
+            async_driver: backing.async_driver().clone(),
+            scheduler,
+        }
+    }
+}
+
+/// Monotonic incarnation counter: every successfully constructed realm gets
+/// a fresh `RealmId` generation, so a recreated realm never compares equal
+/// to its predecessor. Moved here from `ui_realm.rs`: identity minting is an
+/// `AppRuntime` concern now, not a `UiRealm` one — a real multi-window
+/// `AppRuntime` registry mints slots from here once it exists.
+static NEXT_INCARNATION: AtomicU32 = AtomicU32::new(1);
+
+/// Mints a fresh, process-unique `(RealmId, PresentationId)` pair. Slot 0 is
+/// the single-window slot; a real multi-window `AppRuntime` registry mints
+/// slots once it exists (#555) — the shape is the deliverable now,
+/// single-window the only instantiation.
+pub(crate) fn next_identity() -> (RealmId, PresentationId) {
+    let incarnation = NEXT_INCARNATION.fetch_add(1, Ordering::Relaxed);
+    let generation = NonZeroU32::new(incarnation)
+        .expect("BUG: incarnation counter starts at 1 and only increments");
+    (
+        RealmId::new_gen(0, generation),
+        PresentationId::new_gen(0, generation),
+    )
+}
+
+/// The loop-scoped composition root: platform event-loop demux, the single
+/// realm slot, and the once-resolved [`SharedEngineServices`].
+///
+/// Absorbs the former `RealmHost` (realm slot, queue, draining flag, owner
+/// thread, address cache, window registry, surface applier, visible/focused)
+/// wholesale, plus the loop-scoped `OwnerPlatform` capability (formerly the
+/// separate `OWNER_PLATFORM_HOST` thread-local) and `services`. One struct,
+/// one thread-local slot (`runner.rs`'s `APP_RUNTIME`) — the same two
+/// invariants that justified two separate TLS cells before still hold as two
+/// fields on one struct: `teardown_platform_realm` clears the realm-facing
+/// fields and *never* `owner_platform` (hot-restart hosts a fresh realm on
+/// the same loop); `OwnerHostClearGuard` clears only `owner_platform` on
+/// unwind.
+///
+/// # Design-for-N
+///
+/// The realm-facing API is `RealmId`-keyed ([`AppRuntime::realm`]);
+/// *storage* is a single `Option<UiRealm>` slot until #555 gives this a real
+/// multi-realm registry. `next_identity` above already mints from a shape
+/// that does not need to change when that lands.
+#[cfg(not(target_os = "ios"))]
+pub(crate) struct AppRuntime {
+    /// The single hosted realm, when one is installed.
+    pub(super) realm: Option<UiRealm>,
+    /// Queued owner-thread work: cross-thread platform events plus the
+    /// co-located frame pump (see `runner.rs`'s `RealmTask`).
+    pub(super) queue: VecDeque<RealmTask>,
+    /// Set while a queued task is running, so a reentrant dispatch enqueues
+    /// instead of recursing into `realm.take()`.
+    pub(super) draining: bool,
+    /// The thread that installed the current realm; every dispatch checks
+    /// against this before touching the slot.
+    pub(super) owner_thread: Option<ThreadId>,
+    /// This realm incarnation's routable address — a derived cache of
+    /// `registry` below, not a second source of truth (see
+    /// `window_registry`'s module doc for the write-ordering invariant).
+    pub(super) address: Option<PresentationAddress>,
+    /// The sole native-window-to-presentation mapping authority (ADR-0037
+    /// §2). A future multi-window `AppRuntime` lifts this unchanged — the
+    /// type itself has no TLS assumption baked in.
+    pub(super) registry: WindowRegistry,
+    /// The registration-lifetime renderer-surface applier for a `Resized`
+    /// event; installed once at realm install, cleared at teardown.
+    pub(super) surface_applier: Option<SurfaceApplier>,
+    /// Single-window `(visible, focused)` tracking for the
+    /// `AppLifecycleState` derivation (ADR-0035). Both default `true`.
+    pub(super) visible: bool,
+    pub(super) focused: bool,
+    /// The loop-scoped owner-thread platform capability (ADR-0039 §6).
+    /// Deliberately *not* cleared by realm teardown — the loop may host
+    /// another realm before it exits (hot-restart does exactly this).
+    pub(super) owner_platform: Option<OwnerPlatform>,
+    /// Process-level engine services, resolved once at construction.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "this change only creates the resolution seam; nothing \
+                      yet reads this field back out (later changes wire \
+                      real consumers)"
+        )
+    )]
+    pub(super) services: SharedEngineServices,
+}
+
+#[cfg(not(target_os = "ios"))]
+impl AppRuntime {
+    /// Construct the composition root. Called once per owner thread, lazily
+    /// on that thread's first touch of the `APP_RUNTIME` TLS slot — there is
+    /// no eager, process-wide bootstrap step yet. This is the seam this
+    /// change creates, not a compatibility layer: every service it
+    /// `resolve()`s from is still the same singleton it always was.
+    pub(super) fn new() -> Self {
+        Self {
+            realm: None,
+            queue: VecDeque::new(),
+            draining: false,
+            owner_thread: None,
+            address: None,
+            registry: WindowRegistry::new(),
+            surface_applier: None,
+            visible: true,
+            focused: true,
+            owner_platform: None,
+            services: SharedEngineServices::resolve(),
+        }
+    }
+
+    /// `RealmId`-keyed lookup: `Some` only when `id` matches the single
+    /// installed realm's identity. Storage is one slot until #555 gives
+    /// `AppRuntime` a real multi-realm registry — the keyed shape is the
+    /// deliverable now, so #555 does not have to reshape this method's
+    /// callers, only its body.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "design-for-N accessor; the single production caller \
+                      (per-realm dispatch) still addresses the TLS slot \
+                      directly until #555's multi-realm registry lands"
+        )
+    )]
+    pub(crate) fn realm(&self, id: RealmId) -> Option<&UiRealm> {
+        self.realm.as_ref().filter(|realm| realm.realm_id() == id)
+    }
+}
+
+#[cfg(all(test, not(target_os = "ios")))]
+mod app_runtime_tests {
+    use super::*;
+
+    #[test]
+    fn app_runtime_owns_registry_and_realm_slot() {
+        let runtime = AppRuntime::new();
+
+        assert!(
+            runtime.realm.is_none(),
+            "a freshly constructed AppRuntime hosts no realm yet"
+        );
+        assert!(
+            runtime.owner_platform.is_none(),
+            "a freshly constructed AppRuntime hosts no owner platform yet"
+        );
+        assert!(runtime.visible, "a fresh runtime assumes a visible window");
+        assert!(runtime.focused, "a fresh runtime assumes a focused window");
+        assert!(
+            runtime.registry.is_empty(),
+            "AppRuntime owns the WindowRegistry directly -- a fresh one has no mappings"
+        );
+        assert!(
+            runtime
+                .realm(RealmId::new_gen(0, NonZeroU32::new(1).unwrap()))
+                .is_none(),
+            "the RealmId-keyed accessor must return None when no realm is installed"
+        );
+    }
+
+    /// `SharedEngineServices::resolve` must actually populate all three
+    /// fields with live, usable handles -- reading each one here (rather
+    /// than only asserting the struct compiles) is what proves the
+    /// resolution seam works, not just that it type-checks.
+    #[test]
+    fn app_runtime_resolves_all_three_shared_engine_services() {
+        let runtime = AppRuntime::new();
+
+        let _painting_image_cache = runtime.services.painting.image_cache();
+        let _semantics_features = runtime.services.semantics.accessibility_features();
+        let _phase = runtime.services.scheduler.phase();
+    }
+}
+
+#[cfg(test)]
+mod identity_tests {
+    use super::*;
+
+    #[test]
+    fn next_identity_mints_distinct_generations() {
+        let (realm_a, _) = next_identity();
+        let (realm_b, _) = next_identity();
+        assert_ne!(
+            realm_a, realm_b,
+            "every mint must produce a fresh generation, never repeating"
+        );
+    }
+}

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -409,7 +409,7 @@ pub(crate) struct UiRealm {
     /// the caller (see `RealmServices::resolve`) and retained only for the
     /// idle-only commit-gate phase probe in [`Self::drain_commands`] — the
     /// last remaining reach that used to be a bare `Scheduler::instance()`
-    /// call inside this type (issue #553).
+    /// call inside this type.
     scheduler: SchedulerRef,
     /// `*const ()` is `!Send + !Sync`; `PhantomData` of it makes the runtime
     /// so at zero cost (thread-affinity marker).
@@ -487,8 +487,7 @@ impl UiRealm {
     /// itself — the last two `Scheduler::instance()` calls this function
     /// used to make (`local_post_frame_lane()`, `async_driver()`) are now
     /// the caller's job (`RealmServices::resolve`, in `runtime.rs`), which
-    /// is what makes `UiRealm` perform zero `::instance()` calls (issue
-    /// #553).
+    /// is what makes `UiRealm` perform zero `::instance()` calls.
     fn construct(
         capacity: usize,
         wake: Arc<dyn Fn() + Send + Sync>,

--- a/crates/flui-app/src/app/ui_realm.rs
+++ b/crates/flui-app/src/app/ui_realm.rs
@@ -21,23 +21,23 @@
 //! droppable by identity, not by convention.
 
 use std::marker::PhantomData;
-use std::num::NonZeroU32;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crossbeam_channel::{Receiver, Sender, TrySendError, bounded};
-use flui_foundation::{HasInstance, PresentationId, RealmId};
+use flui_foundation::{PresentationId, RealmId};
 use flui_interaction::{FocusManager, GestureBinding, InteractionLane, TextInputOwner};
 #[cfg(test)]
 use flui_platform::traits::PlatformTextInput;
 use flui_platform::traits::PlatformWindow;
-use flui_scheduler::{AppLifecycleState, LocalPostFrameLane, Scheduler, SchedulerPhase};
+use flui_scheduler::{AppLifecycleState, LocalPostFrameLane, SchedulerPhase};
 use flui_semantics::SemanticsActionRequest;
 use flui_view::WidgetsBinding;
 use flui_widgets::NavigatorCommand;
 
 use super::presentation::PresentationState;
+use super::runtime::{RealmServices, SchedulerRef};
 
 /// Default bound of the owner inbox, matching the pipeline dirty-channel
 /// precedent (`DEFAULT_DIRTY_CHANNEL_CAPACITY`)). Observable at
@@ -46,11 +46,6 @@ const DEFAULT_COMMAND_CAPACITY: usize = 256;
 
 /// Claim flag for the at-most-one-instance transitional guard.
 static REALM_CLAIMED: AtomicBool = AtomicBool::new(false);
-
-/// Monotonic incarnation counter: every successfully constructed runtime
-/// gets a fresh `RealmId` generation, so a recreated realm never compares
-/// equal to its predecessor.
-static NEXT_INCARNATION: AtomicU32 = AtomicU32::new(1);
 
 // ---------------------------------------------------------------------------
 // Errors
@@ -410,6 +405,12 @@ pub(crate) struct UiRealm {
     redraw_pending: Arc<AtomicBool>,
     /// Whether this instance owns the transitional process-wide claim.
     claimed: bool,
+    /// The scheduler this realm was constructed against, resolved once by
+    /// the caller (see `RealmServices::resolve`) and retained only for the
+    /// idle-only commit-gate phase probe in [`Self::drain_commands`] — the
+    /// last remaining reach that used to be a bare `Scheduler::instance()`
+    /// call inside this type (issue #553).
+    scheduler: SchedulerRef,
     /// `*const ()` is `!Send + !Sync`; `PhantomData` of it makes the runtime
     /// so at zero cost (thread-affinity marker).
     _owner_affine: PhantomData<*const ()>,
@@ -468,10 +469,11 @@ impl UiRealm {
         if REALM_CLAIMED.swap(true, Ordering::AcqRel) {
             return Err(UiRealmError::AlreadyExists);
         }
-        let (realm_id, presentation_id) = Self::next_identity();
+        let (realm_id, presentation_id) = super::runtime::next_identity();
         let presentation =
             PresentationState::new(presentation_id, app.render_pipeline_arc(), window);
-        match Self::construct(capacity, wake, realm_id, presentation, true) {
+        let services = RealmServices::resolve();
+        match Self::construct(capacity, wake, realm_id, presentation, true, services) {
             Ok(realm) => Ok(realm),
             Err(error) => {
                 REALM_CLAIMED.store(false, Ordering::Release);
@@ -480,22 +482,34 @@ impl UiRealm {
         }
     }
 
+    /// Builds the realm from already-resolved pieces. Takes `services:
+    /// RealmServices` rather than reaching for `Scheduler::instance()`
+    /// itself — the last two `Scheduler::instance()` calls this function
+    /// used to make (`local_post_frame_lane()`, `async_driver()`) are now
+    /// the caller's job (`RealmServices::resolve`, in `runtime.rs`), which
+    /// is what makes `UiRealm` perform zero `::instance()` calls (issue
+    /// #553).
     fn construct(
         capacity: usize,
         wake: Arc<dyn Fn() + Send + Sync>,
         realm_id: RealmId,
         presentation: PresentationState,
         claimed: bool,
+        services: RealmServices,
     ) -> Result<Self, UiRealmError> {
         let (tx, rx) = bounded(capacity);
         let redraw_pending = Arc::new(AtomicBool::new(false));
         let presentation_id = presentation.id();
-        let local_post_frame = Scheduler::instance().local_post_frame_lane();
+        let RealmServices {
+            local_post_frame,
+            async_driver,
+            scheduler,
+        } = services;
         let interaction_lane = InteractionLane::try_new()?;
         let widgets = WidgetsBinding::with_focus_manager(presentation.focus_manager());
         widgets.set_pipeline_owner(Arc::clone(presentation.pipeline()));
         widgets.with_build_owner_mut(|owner| {
-            owner.set_async_driver(Scheduler::instance().async_driver().clone());
+            owner.set_async_driver(async_driver);
             owner.set_post_frame_handle(local_post_frame.post_frame_handle());
             owner.set_interaction_dispatch_handle(interaction_lane.dispatch_handle());
             owner.set_text_input_handle(presentation.text_input_handle());
@@ -516,21 +530,9 @@ impl UiRealm {
             },
             redraw_pending,
             claimed,
+            scheduler,
             _owner_affine: PhantomData,
         })
-    }
-
-    fn next_identity() -> (RealmId, PresentationId) {
-        let incarnation = NEXT_INCARNATION.fetch_add(1, Ordering::Relaxed);
-        let generation = NonZeroU32::new(incarnation)
-            .expect("BUG: incarnation counter starts at 1 and only increments");
-        // Slot 0 is the single-window slot; a real multi-window `AppRuntime`
-        // registry mints slots once it exists — the shape is the deliverable,
-        // single-window the only instantiation for now.
-        (
-            RealmId::new_gen(0, generation),
-            PresentationId::new_gen(0, generation),
-        )
     }
 
     #[cfg(test)]
@@ -543,7 +545,7 @@ impl UiRealm {
         app: &super::binding::AppBinding,
         platform_text_input: Option<Arc<dyn PlatformTextInput>>,
     ) -> Self {
-        let (realm_id, presentation_id) = Self::next_identity();
+        let (realm_id, presentation_id) = super::runtime::next_identity();
         let presentation = PresentationState::new_for_test(
             presentation_id,
             app.render_pipeline_arc(),
@@ -555,6 +557,7 @@ impl UiRealm {
             realm_id,
             presentation,
             false,
+            RealmServices::resolve(),
         )
         .expect("test UiRealm should create an interaction lane")
     }
@@ -679,7 +682,7 @@ impl UiRealm {
     /// (`UiRealm: !Send + !Sync`), not asserted.
     pub fn drain_commands(&self) -> DrainReport {
         debug_assert_eq!(
-            Scheduler::instance().phase(),
+            self.scheduler.phase(),
             SchedulerPhase::Idle,
             "UiRealm::drain_commands must run at a frame boundary (Idle), \
              never inside the frame transaction"

--- a/crates/flui-app/src/app/window_registry.rs
+++ b/crates/flui-app/src/app/window_registry.rs
@@ -11,7 +11,7 @@
 //!
 //! # Derived-cache invariant
 //!
-//! `RealmHost.address: Option<PresentationAddress>` (`runner.rs`) is a
+//! `AppRuntime.address: Option<PresentationAddress>` (`app/runtime.rs`) is a
 //! **derived cache** of this registry, not a second source of truth. Both
 //! are written only by `install_platform_realm`/`teardown_platform_realm`,
 //! inside the same TLS borrow, in that order: on install, the registry is
@@ -78,8 +78,8 @@ impl WindowRegistry {
     ///
     /// Replacement (not a hard error) keeps install recoverable after a
     /// mid-`on_ready` panic: `OwnerHostClearGuard` only clears
-    /// `OWNER_PLATFORM_HOST`, not the realm host this registry lives
-    /// inside, and the web host never tears down at all — a hard error here
+    /// `AppRuntime.owner_platform`, not the realm-facing fields this
+    /// registry lives alongside, and the web host never tears down at all — a hard error here
     /// would brick reinstall on either path. A replacement is traced at
     /// `warn` with both addresses so a genuine double-install bug is still
     /// visible; [`Self::try_register`] is the strict alternative for a

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -607,7 +607,7 @@ key = "window-host-is-explicit-composition-owner"
 statement = """
 The event-loop side of a presentation has one explicit `WindowHost` owner for \
 the native window, callback registrations, platform-to-realm routing, and \
-cancellation. Issue #553 gives the loop side an explicit owner object — \
+cancellation. The loop side now has an explicit owner object — \
 `AppRuntime` (`app/runtime.rs`) — replacing the anonymous TLS struct \
 (`RealmHost`) that used to sit directly in `runner.rs`; the runner's own \
 dispatch functions (`install_platform_realm`, `dispatch_platform_realm`, \
@@ -808,7 +808,8 @@ events drop). Remainder: the registry mints and is read at install/teardown, \
 but it is not yet the routing demux — platform callbacks still deliver \
 through per-window closures with captured addresses rather than a `resolve` \
 lookup — and `AppRuntime` hosts it as a single-slot owner, not yet the \
-public multi-window registry #555 gives it.\
+public multi-window registry it grows once the element forest lets a realm \
+host multiple presentations.\
 """
 state = "partial"
 domain = "application"
@@ -1758,7 +1759,7 @@ contains = "impl_binding_singleton!(SemanticsBinding)"
 owner_issue = 553
 
 # =============================================================================
-# Ambient-reach ratchet (issue #553)
+# Ambient-reach ratchet
 # =============================================================================
 #
 # Two grammars, each judged on code (comments and test-oracle mod blocks
@@ -1772,8 +1773,8 @@ owner_issue = 553
 #                    entry left behind after cleanup), the same as it fails
 #                    an unregistered file that newly matches.
 #   ambient-static — a named residual: a global()/OnceLock/LazyLock-backed
-#                    accessor issue #553 deliberately does not close. Carries
-#                    the hazard in its `note`, not silence.
+#                    accessor this migration deliberately does not close.
+#                    Carries the hazard in its `note`, not silence.
 #
 # `ui_realm.rs` is deliberately ABSENT from `instance-call`: the claim is
 # that `UiRealm::construct` (and every other constructor) stops calling
@@ -1841,13 +1842,13 @@ note = "SemanticsBinding's own instance()-based SemanticsService::* statics; ret
 file = "crates/flui-interaction/src/timer.rs"
 grammar = "ambient-static"
 owner_issue = 553
-note = "global_timer_service(): named residual, unresolved by issue #553 -- a pending-gesture-timer drop-isolation probe bounds its cross-realm blast radius, but the service itself stays process-global"
+note = "global_timer_service(): named residual, unresolved by this migration -- a pending-gesture-timer drop-isolation probe bounds its cross-realm blast radius, but the service itself stays process-global"
 
 [[ambient_reach]]
 file = "crates/flui-assets/src/registry/mod.rs"
 grammar = "ambient-static"
 owner_issue = 553
-note = "AssetRegistry::global(): named residual, out of issue #553's scope entirely -- no part of this migration touches flui-assets"
+note = "AssetRegistry::global(): named residual, out of this migration's scope entirely -- no part of this migration touches flui-assets"
 
 [[ambient_reach]]
 file = "crates/flui-painting/src/text_layout/layout.rs"

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -275,14 +275,14 @@ evidence = [
 key = "app-runtime-composition-host"
 statement = """
 `AppRuntime`, a loop-scoped composition root, now exists: it owns platform \
-event-loop demux, the single realm slot, and constructor-resolved \
-`SharedEngineServices` (painting/semantics/scheduler, each resolved once). \
-It is not yet the target statement in full: it is one TLS-scoped instance \
-per owner thread (`APP_RUNTIME` in `runner.rs`), not one per process; it \
+event-loop demux, the single realm slot, and `SharedEngineServices` \
+(painting/semantics/scheduler), resolved once, when a realm is actually \
+installed. It is not yet the target statement in full: it is one TLS-scoped \
+instance per owner thread (`APP_RUNTIME` in `runner.rs`), not one per process; it \
 still coexists with `AppBinding` as the transitional process-service host \
 (retiring `AppBinding` is separate follow-up work); and its realm storage is \
-a single slot behind a `RealmId`-keyed accessor, not real 1..N hosting \
-(#555).\
+a single slot behind a `RealmId`-keyed accessor, not real 1..N hosting -- \
+that needs the element forest to let a realm host multiple presentations.\
 """
 state = "partial"
 domain = "application"

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -274,14 +274,25 @@ evidence = [
 [[contract]]
 key = "app-runtime-composition-host"
 statement = """
-One `AppRuntime` per process owns platform event-loop demux, explicit \
-constructor-injected `SharedEngineServices`, and 1..N realms. No such type \
-exists; `AppBinding` remains the transitional process-service host.\
+`AppRuntime`, a loop-scoped composition root, now exists: it owns platform \
+event-loop demux, the single realm slot, and constructor-resolved \
+`SharedEngineServices` (painting/semantics/scheduler, each resolved once). \
+It is not yet the target statement in full: it is one TLS-scoped instance \
+per owner thread (`APP_RUNTIME` in `runner.rs`), not one per process; it \
+still coexists with `AppBinding` as the transitional process-service host \
+(retiring `AppBinding` is separate follow-up work); and its realm storage is \
+a single slot behind a `RealmId`-keyed accessor, not real 1..N hosting \
+(#555).\
 """
-state = "planned"
+state = "partial"
 domain = "application"
 owner_issue = 553
-mechanical = false
+mechanical = true
+mechanism = "symbol/test existence pinned here; later changes advance disposition further"
+evidence = [
+    { kind = "symbol", file = "crates/flui-app/src/app/runtime.rs", contains = "pub(crate) struct AppRuntime" },
+    { kind = "test", file = "crates/flui-app/src/app/runtime.rs", contains = "fn app_runtime_owns_registry_and_realm_slot" },
+]
 
 [[contract]]
 key = "scheduling-splits-by-level"
@@ -341,7 +352,7 @@ domain = "realm"
 mechanical = true
 mechanism = "test existence pinned here; behavior verified by the cited tests"
 evidence = [
-    { kind = "symbol", file = "crates/flui-app/src/app/runner.rs", contains = "draining: bool" },
+    { kind = "symbol", file = "crates/flui-app/src/app/runtime.rs", contains = "draining: bool" },
     { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn reentrant_frame_event_is_queued_fifo" },
     { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn nested_resize_and_window_focus_wait_until_frame_returns" },
 ]
@@ -472,7 +483,7 @@ domain = "realm"
 mechanical = true
 mechanism = "test existence pinned here"
 evidence = [
-    { kind = "symbol", file = "crates/flui-app/src/app/ui_realm.rs", contains = "static NEXT_INCARNATION" },
+    { kind = "symbol", file = "crates/flui-app/src/app/runtime.rs", contains = "static NEXT_INCARNATION" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn recreated_runtime_gets_fresh_realm_id" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn dropped_runtime_yields_owner_gone" },
     { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn late_event_never_crosses_realm_incarnations" },
@@ -596,8 +607,14 @@ key = "window-host-is-explicit-composition-owner"
 statement = """
 The event-loop side of a presentation has one explicit `WindowHost` owner for \
 the native window, callback registrations, platform-to-realm routing, and \
-cancellation. Today the runner's TLS host and per-window callbacks stand in; \
-there is no explicit owner object.\
+cancellation. Issue #553 gives the loop side an explicit owner object — \
+`AppRuntime` (`app/runtime.rs`) — replacing the anonymous TLS struct \
+(`RealmHost`) that used to sit directly in `runner.rs`; the runner's own \
+dispatch functions (`install_platform_realm`, `dispatch_platform_realm`, \
+`teardown_platform_realm`) and per-window callbacks still stand in for the \
+rest of `WindowHost`'s stated responsibilities (routing/cancellation as a \
+method surface on the owner object itself, not free functions closing over \
+its TLS slot) — that reshaping is not claimed here.\
 """
 state = "partial"
 domain = "application"
@@ -605,6 +622,7 @@ owner_issue = 553
 mechanical = false
 evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/presentation.rs", contains = "pub(crate) struct PresentationState" },
+    { kind = "symbol", file = "crates/flui-app/src/app/runtime.rs", contains = "pub(crate) struct AppRuntime" },
 ]
 
 [[contract]]
@@ -781,16 +799,16 @@ There is exactly one native-window-to-presentation map in `flui-app`: \
 `WindowRegistry` (`window_registry.rs`), which mints every dispatcher \
 address via `register_window`/`try_register` and is read at install (a \
 self-check) and teardown (`remove_realm`, the teardown real read). \
-`RealmHost.address` is a derived cache of this registry, not a second \
-source of truth — both are written only by `install_platform_realm`/ \
-`teardown_platform_realm`, inside the same TLS borrow, in that order: \
-registry first on install, registry removal first on teardown (so map \
-removal stops new routing before queued old-generation events drop). \
-Remainder: the registry mints and is read at install/teardown, but it is \
-not yet the routing demux — platform callbacks still deliver through \
-per-window closures with captured addresses rather than a `resolve` \
-lookup — and it has not been lifted into a public multi-window \
-`AppRuntime`.\
+`AppRuntime.address` (`app/runtime.rs`) is a derived cache of this registry, \
+not a second source of truth — both are written only by \
+`install_platform_realm`/`teardown_platform_realm`, inside the same TLS \
+borrow, in that order: registry first on install, registry removal first on \
+teardown (so map removal stops new routing before queued old-generation \
+events drop). Remainder: the registry mints and is read at install/teardown, \
+but it is not yet the routing demux — platform callbacks still deliver \
+through per-window closures with captured addresses rather than a `resolve` \
+lookup — and `AppRuntime` hosts it as a single-slot owner, not yet the \
+public multi-window registry #555 gives it.\
 """
 state = "partial"
 domain = "application"
@@ -1738,6 +1756,104 @@ symbol = "impl_binding_singleton!(SemanticsBinding)"
 file = "crates/flui-semantics/src/binding.rs"
 contains = "impl_binding_singleton!(SemanticsBinding)"
 owner_issue = 553
+
+# =============================================================================
+# Ambient-reach ratchet (issue #553)
+# =============================================================================
+#
+# Two grammars, each judged on code (comments and test-oracle mod blocks
+# stripped first — see `scripts/check-runtime-conformance.sh`):
+#
+#   instance-call  — a production `::instance()` call site. This class is a
+#                    RATCHET: it must shrink to empty as later changes retire
+#                    each remaining singleton (painting, semantics/rendering,
+#                    `AppBinding`, the scheduler), and the checker fails a
+#                    registered entry whose file no longer matches (a stale
+#                    entry left behind after cleanup), the same as it fails
+#                    an unregistered file that newly matches.
+#   ambient-static — a named residual: a global()/OnceLock/LazyLock-backed
+#                    accessor issue #553 deliberately does not close. Carries
+#                    the hazard in its `note`, not silence.
+#
+# `ui_realm.rs` is deliberately ABSENT from `instance-call`: the claim is
+# that `UiRealm::construct` (and every other constructor) stops calling
+# `Scheduler::instance()` — `RealmServices::resolve()` in `runtime.rs` does
+# that once, and `UiRealm`'s own source never does. This entry list is the
+# ratchet's mechanical proof of that claim: if a future change reintroduces
+# a real `::instance()` call in `ui_realm.rs`, the checker fails until it is
+# either fixed or explicitly registered here.
+
+[[ambient_reach]]
+file = "crates/flui-app/src/app/binding.rs"
+grammar = "instance-call"
+owner_issue = 553
+note = "AppBinding's own AppBinding::instance()/Scheduler::instance() reaches; retired when AppBinding itself is dissolved"
+
+[[ambient_reach]]
+file = "crates/flui-app/src/app/hot_reload.rs"
+grammar = "instance-call"
+owner_issue = 553
+note = "single AppBinding::instance() reach; re-routed through the runtime once AppBinding is dissolved"
+
+[[ambient_reach]]
+file = "crates/flui-app/src/app/runtime.rs"
+grammar = "instance-call"
+owner_issue = 553
+note = "the deliberate resolution seam this file creates: PaintingBinding::instance()/SemanticsBinding::instance()/Scheduler::instance() are called exactly once each, in SharedEngineServices::resolve() and RealmServices::resolve() -- this is the ONE file allowed to still reach for these singletons directly so every other constructor (including UiRealm's) does not have to. Each flips to an owned/injected value as the singleton it names is retired, at which point this entry shrinks accordingly."
+
+[[ambient_reach]]
+file = "crates/flui-app/src/app/runner.rs"
+grammar = "instance-call"
+owner_issue = 553
+note = "AppBinding::instance()/Scheduler::instance() in the platform dispatch/lifecycle-ladder machinery; the AppRuntime skeleton moves ownership (APP_RUNTIME), not these ambient reaches -- retiring AppBinding and the Scheduler singleton retires them"
+
+[[ambient_reach]]
+file = "crates/flui-app/src/bindings/renderer_binding.rs"
+grammar = "instance-call"
+owner_issue = 553
+note = "RenderingFlutterBinding::instance()/AppBinding::instance()/Scheduler::instance() reaches; retired alongside RenderingFlutterBinding, AppBinding, and the Scheduler singleton respectively"
+
+[[ambient_reach]]
+file = "crates/flui-engine/src/wgpu/text.rs"
+grammar = "instance-call"
+owner_issue = 553
+note = "TextRenderer::new constructs a thread-local PaintingBinding via PaintingBinding::instance() to reach the font DB; a SharedFontSystem injection point retires this"
+
+[[ambient_reach]]
+file = "crates/flui-painting/src/binding.rs"
+grammar = "instance-call"
+owner_issue = 553
+note = "PaintingBinding's own instance()-based image_cache() free fn and its tests; retired together with impl_binding_singleton!(PaintingBinding)"
+
+[[ambient_reach]]
+file = "crates/flui-scheduler/src/config.rs"
+grammar = "instance-call"
+owner_issue = 553
+note = "Scheduler::instance() reach in the time-dilation config path; retired together with impl_binding_singleton!(Scheduler)"
+
+[[ambient_reach]]
+file = "crates/flui-semantics/src/binding.rs"
+grammar = "instance-call"
+owner_issue = 553
+note = "SemanticsBinding's own instance()-based SemanticsService::* statics; retired together with the SemanticsBinding type itself"
+
+[[ambient_reach]]
+file = "crates/flui-interaction/src/timer.rs"
+grammar = "ambient-static"
+owner_issue = 553
+note = "global_timer_service(): named residual, unresolved by issue #553 -- a pending-gesture-timer drop-isolation probe bounds its cross-realm blast radius, but the service itself stays process-global"
+
+[[ambient_reach]]
+file = "crates/flui-assets/src/registry/mod.rs"
+grammar = "ambient-static"
+owner_issue = 553
+note = "AssetRegistry::global(): named residual, out of issue #553's scope entirely -- no part of this migration touches flui-assets"
+
+[[ambient_reach]]
+file = "crates/flui-painting/src/text_layout/layout.rs"
+grammar = "ambient-static"
+owner_issue = 553
+note = "shared_font_system()/FONT_SYSTEM: AppRuntime::new() becomes the CONSTRUCTING owner (explicit eager init), but the READ path stays ambient on layout hot paths -- cross-realm register_font staleness mid-layout is a named, bounded hazard (Mutex<FontSystem> makes it staleness not a data race), not closed until fonts get their own owner-local-access/sharding follow-up (ADR-0027 follow-up 6)"
 
 # =============================================================================
 # Public lock-shaped surface allowlist (runtime crates)

--- a/scripts/check-runtime-conformance.sh
+++ b/scripts/check-runtime-conformance.sh
@@ -421,6 +421,165 @@ for crate in RUNTIME_CRATES + [
                 )
 
 # ---------------------------------------------------------------------------
+# Ambient-reach ratchet (issue #553): every real (non-comment,
+# non-test-oracle) `::instance()` call site, and every
+# ambient global()/OnceLock/LazyLock-backed zero-arg accessor from a curated
+# marker list, must be named in `[[ambient_reach]]` with an owning issue.
+# Two grammars:
+#
+#   instance-call  -- the literal `::instance()` call syntax.
+#   ambient-static -- a curated marker list of known ambient accessor
+#                     signatures, distinct from the macro-generated `fn
+#                     instance() -> &'static` the singleton net above already
+#                     owns: `AssetRegistry::global()`, `global_timer_service()`,
+#                     `shared_font_system()`.
+#
+# This is a RATCHET, not a ban: `instance-call` is meant to shrink to empty
+# as #553's later slices retire each singleton (checked bidirectionally below
+# -- a registered file with no matching reach left is a stale entry, same as
+# an unregistered one is a missing entry); `ambient-static` carries named,
+# owner-tracked residuals #553 does not close.
+#
+# Both grammars are judged on CODE, not prose or test oracles: line comments
+# are stripped first, and top-level `#[cfg(test)]`/`#[cfg(all(test, ...))]`-
+# gated `mod { ... }` blocks are blanked out by brace depth -- a test that
+# calls `Foo::instance()` to prove NON-interference (this repo's divergence-
+# check idiom, e.g. `ui_realm.rs`'s hot-reload test asserting
+# `AppBinding::instance()` was untouched) is not a production ambient reach.
+# ---------------------------------------------------------------------------
+AMBIENT_REACH_EXEMPT = {Path("crates/flui-foundation/src/binding.rs")}
+AMBIENT_STATIC_MARKERS = (
+    "fn global() -> &'static",
+    "fn global_timer_service() -> &'static",
+    "fn shared_font_system(",
+)
+INSTANCE_CALL_MARKER = "::instance()"
+VALID_AMBIENT_GRAMMARS = {"instance-call", "ambient-static"}
+
+_TEST_CFG_RE = re.compile(r"^\s*#\[cfg\(\s*(test\b|all\(\s*test\b)")
+_TEST_MOD_RE = re.compile(r"^\s*(pub(\(crate\))?\s+)?mod\s+\w+\s*\{")
+
+
+def _strip_line_comments(text: str) -> str:
+    return "\n".join(line.split("//", 1)[0] for line in text.splitlines())
+
+
+def _strip_top_level_test_modules(text: str) -> str:
+    """Blank every `#[cfg(test)]`/`#[cfg(all(test, ...))]`-gated `mod { ... }`
+    block (brace-depth tracked, same technique as
+    check-frame-capability-scope.sh) so the ratchet judges production
+    reachability, not a test module that legitimately still calls a
+    singleton as its own oracle.
+    """
+    lines = text.split("\n")
+    out = list(lines)
+    i = 0
+    n = len(lines)
+    while i < n:
+        if _TEST_CFG_RE.match(lines[i]):
+            j = i + 1
+            while j < n and not lines[j].strip():
+                j += 1
+            if j < n and _TEST_MOD_RE.match(lines[j]):
+                depth = 0
+                seen = False
+                k = j
+                while k < n:
+                    opens = lines[k].count("{")
+                    closes = lines[k].count("}")
+                    if opens:
+                        seen = True
+                    depth += opens - closes
+                    k += 1
+                    if seen and depth <= 0:
+                        break
+                for idx in range(i, k):
+                    out[idx] = ""
+                i = k
+                continue
+        i += 1
+    return "\n".join(out)
+
+
+def _ambient_reach_code(path: Path) -> str | None:
+    try:
+        raw = path.read_text()
+    except (OSError, UnicodeDecodeError):
+        return None
+    return _strip_top_level_test_modules(_strip_line_comments(raw))
+
+
+ambient_reach_files: dict[str, set[Path]] = {"instance-call": set(), "ambient-static": set()}
+for index, entry in enumerate(table_array("ambient_reach")):
+    label = f"{registry_rel} ambient_reach[{index}]"
+    file_value = entry.get("file")
+    grammar = entry.get("grammar")
+    if not isinstance(file_value, str) or not file_value:
+        fail(f"{label} has no file path")
+        continue
+    label = f"{registry_rel} ambient_reach `{file_value}` (grammar {grammar!r})"
+    if grammar not in VALID_AMBIENT_GRAMMARS:
+        fail(f"{label}: expected grammar one of {sorted(VALID_AMBIENT_GRAMMARS)}")
+        continue
+    path = (root / file_value).resolve()
+    if not path.is_relative_to(root) or not path.is_file():
+        fail(f"{label} names a missing file")
+        continue
+    if not str(entry.get("note", "")).strip():
+        fail(f"{label} has no `note` explaining the residual")
+    check_owner_issue(entry, label, required=True)
+    rel = Path(file_value)
+    if rel in ambient_reach_files[grammar]:
+        fail(f"{label} is declared more than once for this grammar")
+    ambient_reach_files[grammar].add(rel)
+
+for crate_dir in sorted((root / "crates").iterdir()):
+    if not crate_dir.is_dir():
+        continue
+    crate_src = crate_dir / "src"
+    if not crate_src.is_dir():
+        continue
+    for rs_file in sorted(crate_src.rglob("*.rs")):
+        rel = rs_file.relative_to(root)
+        if rel in AMBIENT_REACH_EXEMPT:
+            continue
+        code = _ambient_reach_code(rs_file)
+        if code is None:
+            continue
+        if INSTANCE_CALL_MARKER in code and rel not in ambient_reach_files["instance-call"]:
+            fail(
+                f"{rel} contains a production `::instance()` call site with no "
+                "registered `[[ambient_reach]]` entry (grammar \"instance-call\") -- "
+                "every ambient singleton reach must be named with an owning issue"
+            )
+        if any(marker in code for marker in AMBIENT_STATIC_MARKERS) and rel not in ambient_reach_files["ambient-static"]:
+            fail(
+                f"{rel} contains an ambient global()/OnceLock/LazyLock-backed accessor "
+                "with no registered `[[ambient_reach]]` entry (grammar \"ambient-static\") "
+                "-- every named ambient residual must carry an owning issue"
+            )
+
+# Bidirectional: a registered entry whose file no longer contains a matching
+# reach is stale -- the ratchet's "shrinks to empty" claim only holds if
+# retiring the last call site in a file also requires removing its entry.
+for grammar, files in ambient_reach_files.items():
+    marker_check = (
+        (lambda code: INSTANCE_CALL_MARKER in code)
+        if grammar == "instance-call"
+        else (lambda code: any(marker in code for marker in AMBIENT_STATIC_MARKERS))
+    )
+    for rel in sorted(files):
+        path = root / rel
+        if not path.is_file():
+            continue  # already reported missing above
+        code = _ambient_reach_code(path)
+        if code is not None and not marker_check(code):
+            fail(
+                f"{registry_rel} ambient_reach `{rel}` (grammar {grammar!r}) is registered "
+                "but the file no longer contains a matching reach -- remove the stale entry"
+            )
+
+# ---------------------------------------------------------------------------
 # Public lock-shaped surface net: every PORT-CHECK-OK-SP6 marker in the
 # runtime crates must come from a registered file. (Trigger #12 in
 # scripts/port-check.sh forces the marker onto any public lock surface its

--- a/scripts/check-runtime-conformance.sh
+++ b/scripts/check-runtime-conformance.sh
@@ -421,7 +421,7 @@ for crate in RUNTIME_CRATES + [
                 )
 
 # ---------------------------------------------------------------------------
-# Ambient-reach ratchet (issue #553): every real (non-comment,
+# Ambient-reach ratchet: every real (non-comment,
 # non-test-oracle) `::instance()` call site, and every
 # ambient global()/OnceLock/LazyLock-backed zero-arg accessor from a curated
 # marker list, must be named in `[[ambient_reach]]` with an owning issue.
@@ -435,10 +435,10 @@ for crate in RUNTIME_CRATES + [
 #                     `shared_font_system()`.
 #
 # This is a RATCHET, not a ban: `instance-call` is meant to shrink to empty
-# as #553's later slices retire each singleton (checked bidirectionally below
-# -- a registered file with no matching reach left is a stale entry, same as
-# an unregistered one is a missing entry); `ambient-static` carries named,
-# owner-tracked residuals #553 does not close.
+# as later changes retire each remaining singleton (checked bidirectionally
+# below -- a registered file with no matching reach left is a stale entry,
+# same as an unregistered one is a missing entry); `ambient-static` carries
+# named, owner-tracked residuals this migration does not close.
 #
 # Both grammars are judged on CODE, not prose or test oracles: line comments
 # are stripped first, and top-level `#[cfg(test)]`/`#[cfg(all(test, ...))]`-

--- a/scripts/check-runtime-conformance.sh
+++ b/scripts/check-runtime-conformance.sh
@@ -460,6 +460,105 @@ _TEST_CFG_RE = re.compile(r"^\s*#\[cfg\(\s*(test\b|all\(\s*test\b)")
 _TEST_MOD_RE = re.compile(r"^\s*(pub(\(crate\))?\s+)?mod\s+\w+\s*\{")
 
 
+def _mask_rust_literals(text: str) -> str:
+    """Replace the contents of every string/char literal with spaces,
+    preserving every newline and the total character layout (so line
+    numbers and column positions stay meaningful downstream).
+
+    This MUST run before both `_strip_line_comments` (a naive
+    `split("//", 1)`) and `_strip_top_level_test_modules` (a naive
+    `{`/`}` count): neither knows about literals, so without this pass a
+    same-line string like `"https://example.com"` truncates everything
+    after it on that line -- including a real `::instance()` call sitting
+    right after the string -- and a string containing an unbalanced brace
+    (`"foo{bar"`) desyncs the brace-depth counter clean through to EOF,
+    blanking every later production reach in the file as a false negative.
+    Both are real, not hypothetical: this function exists because a
+    fixture exercising exactly these two shapes is red without it.
+
+    Handles: normal string literals with backslash escapes; char literals
+    (disambiguated from lifetimes -- `'a'` is masked, `'a` is left alone);
+    and raw (optionally byte-prefixed) strings `r"..."`/`br"..."` with any
+    number of `#` delimiters, including ones that span multiple lines.
+    Deliberately does not understand `/* */` block comments -- pre-existing
+    scope of this checker, unrelated to the literal-masking hazard fixed
+    here.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+
+        # Raw / byte-raw string: (b)?r(#*)"..."(#*matching), any # depth.
+        if ch in ("r", "b"):
+            j = i
+            if text[j] == "b" and j + 1 < n and text[j + 1] == "r":
+                j += 1
+            if j < n and text[j] == "r":
+                k = j + 1
+                hashes = 0
+                while k < n and text[k] == "#":
+                    hashes += 1
+                    k += 1
+                if k < n and text[k] == '"':
+                    prefix_end = k + 1
+                    out.append(text[i:prefix_end])
+                    closer = '"' + "#" * hashes
+                    end = text.find(closer, prefix_end)
+                    body_end = end if end != -1 else n
+                    body = text[prefix_end:body_end]
+                    out.append("".join("\n" if c == "\n" else " " for c in body))
+                    if end != -1:
+                        out.append(closer)
+                        i = end + len(closer)
+                    else:
+                        i = n
+                    continue
+
+        # Char literal ('c' or an escape like '\n'/'\u{1234}') vs. a
+        # lifetime ('a, 'static, ...), which has no closing quote at all.
+        if ch == "'":
+            if i + 2 < n and text[i + 1] == "\\":
+                k = i + 2
+                limit = min(n, i + 2 + 12)  # bounds \u{10FFFF}'
+                while k < limit and text[k] != "'":
+                    k += 1
+                if k < limit and text[k] == "'":
+                    out.append("'" + " " * (k - (i + 1)) + "'")
+                    i = k + 1
+                    continue
+            elif i + 2 < n and text[i + 2] == "'":
+                out.append("' '")
+                i += 3
+                continue
+            out.append(ch)
+            i += 1
+            continue
+
+        if ch == '"':
+            out.append('"')
+            i += 1
+            while i < n:
+                c = text[i]
+                if c == "\\" and i + 1 < n:
+                    out.append("\n" if text[i + 1] == "\n" else " ")
+                    out.append(" ")
+                    i += 2
+                    continue
+                if c == '"':
+                    out.append('"')
+                    i += 1
+                    break
+                out.append("\n" if c == "\n" else " ")
+                i += 1
+            continue
+
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 def _strip_line_comments(text: str) -> str:
     return "\n".join(line.split("//", 1)[0] for line in text.splitlines())
 
@@ -506,7 +605,9 @@ def _ambient_reach_code(path: Path) -> str | None:
         raw = path.read_text()
     except (OSError, UnicodeDecodeError):
         return None
-    return _strip_top_level_test_modules(_strip_line_comments(raw))
+    # Literal masking MUST run first -- see `_mask_rust_literals`'s own
+    # docstring for the two failure-open shapes this ordering closes.
+    return _strip_top_level_test_modules(_strip_line_comments(_mask_rust_literals(raw)))
 
 
 ambient_reach_files: dict[str, set[Path]] = {"instance-call": set(), "ambient-static": set()}


### PR DESCRIPTION
First of six PRs for #553 (retire AppBinding and framework singletons into explicit `AppRuntime` ownership). This slice creates the composition root and the constructor-injection seams while every service is still singleton-backed — **no singleton is deleted here**; the ambient access points die slice by slice in PR-2..6, each deletion final in its PR (no deprecated forwarding layer, per the issue's own criterion).

## What lands

- **`AppRuntime`** (`crates/flui-app/src/app/runtime.rs`, `pub(crate)`) — absorbs the former `RealmHost` wholesale (realm slot, task queue, drain state, `WindowRegistry` from #552, address cache, surface applier) **plus** `owner_platform` (the former second TLS slot) and `services`. The realm-facing API is `RealmId`-keyed (design for N; single-slot storage until #555). Identity minting (`next_identity`) moves behind it.
- **Injection seams**: `SharedEngineServices` (painting/semantics/scheduler, resolved **once, explicitly, at the install points** — behind a `OnceCell`, so the TLS initializer stays `const` and side-effect-free; a clear-guard drop during unwind can never construct services), `RealmServices` (what `UiRealm::construct` used to steal from `Scheduler::instance()`), and `SchedulerRef` — deliberately **`!Send + !Sync`** (phantom + static assert): the wrapped scheduler is a per-thread instance, and a ref crossing threads would silently alias the minting thread's phase machinery.
- **`UiRealm` performs zero `::instance()` calls** — mechanically enforced (see ratchet below), not just claimed. All existing public constructors keep their exact signatures.
- **One TLS slot**: `PLATFORM_REALM_HOST` + `OWNER_PLATFORM_HOST` collapse into `APP_RUNTIME`. `install_owner_platform`/`with_owner_platform` keep their names, borrow-only shape, and all three frame-capability fences (scanner self-test green). Teardown/hot-restart/web-resident/clear-guard semantics preserved verbatim — parity red-teamed across seven orderings (panic-between-installs, guard-vs-teardown order, reinstall-without-teardown hygiene from #552, double-install, web path, RefCell collisions). Two invariants the merge *created* are now encoded, not just true: the no-host-reentry rule on `with_owner_platform` (documented + `#[should_panic]` pin) and owner-platform-survives-install (both branches tested).
- **The ambient-reach ratchet** (`[[ambient_reach]]` in `docs/runtime-contract.toml`, enforced by `check-runtime-conformance.sh`): a bidirectional file allowlist of every `::instance()` call site and known `global()`-shaped ambient accessor, seeded with exactly today's reaches. Later PRs shrink it; a new ambient reach anywhere fails CI; a stale entry (file cleaned but still listed) also fails — the ratchet can only tighten. The lexer masks string/char literals before comment/brace analysis (both fail-open corners red-tested); an old-vs-new tree-wide diff of flagged sets is empty, so the seed hides nothing.
- **FONT_SYSTEM ruling made real**: `AppRuntime`'s service resolution is the *constructing* owner of the font-system `OnceLock`; the ambient read on layout hot paths is a **named exclusion** whose registry entry records the cross-realm `register_font` staleness hazard verbatim. Full injection through TextPainter/RenderParagraph is deliberately deferred (post-#553 owner-local-access work).

## Honest scope

- No singleton deleted, no test lock deleted, no public API change (facade untouched; everything new is `pub(crate)`).
- `AppRuntime` is one TLS-scoped instance per owner thread — not yet a per-process multi-realm host; the contract entry says exactly that.
- The ratchet's ambient-static grammar is a curated marker list (documented): a future ambient accessor under a novel name needs its marker added. A generic `OnceLock`/`LazyLock` accessor scan is scheduled for PR-6 (ratchet finalization).
- First `APP_RUNTIME` service resolution now happens at install time (explicit) instead of first ambient use — earlier, deterministic, and infallible on the unwind path.

## Review trail

Plan v3 (6-PR slicing) survived two adversarial reviews (18 findings folded — including the ones that reshaped this slice: `RenderingFlutterBinding` will be per-realm not runtime-owned; `SemanticsBinding`'s type dies rather than slims; the `flui-scheduler` re-export of `HasInstance` must die with the trait or the build breaks). This PR then passed spec-compliance (PASS) and a quality review whose red-team found three latent invariants the TLS merge created — all three now encoded in types/docs/tests (`SchedulerRef` `!Send`, no-host-reentry pin, const-init restoration).

Gates: `just ci` green (8556+ tests), flui-app 165/165, clippy `-D warnings`, conformance (47 contracts incl. the new ratchet, red-tested bidirectionally), frame-capability scanner self-test, wasm-check, cross-typecheck.

Next: PR-2 (font/paint state ownership), PR-3 (semantics + rendering leaves), PR-4 (AppBinding dissolution), PR-5 (Scheduler realm-ownership, gated on a design note), PR-6 (guard + macro deletion + two-realm coexistence proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
