### PR TITLE
feat(painting): retire the PaintingBinding singleton; per-family icon fonts; injected TextRenderer font system (singleton retirement 2/6)

### DIFF
--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -9,12 +9,12 @@
 //! Other ambient reaches (`renderer_binding.rs`, `binding.rs`,
 //! `hot_reload.rs`, `config.rs`) are untouched — they remain until the
 //! change that retires each singleton they reach for.
-//! `flui-engine/src/wgpu/text.rs`'s ambient reach for painting closed in
-//! singleton retirement PR-2 (#553): `TextRenderer::new` takes an injected
-//! `SharedFontSystem` parameter instead of calling
-//! `PaintingBinding::instance()` itself. This is not a forwarding shim: no
-//! old API is preserved-but-deprecated here, and no ambient access point
-//! this change does not touch is claimed as closed.
+//! `flui-engine/src/wgpu/text.rs`'s ambient reach for painting has since
+//! closed: `TextRenderer::new` takes an injected `SharedFontSystem`
+//! parameter instead of calling `PaintingBinding::instance()` itself. This
+//! is not a forwarding shim: no old API is preserved-but-deprecated here,
+//! and no ambient access point this change does not touch is claimed as
+//! closed.
 //!
 //! # What lives here vs. in `runner.rs`
 //!
@@ -146,12 +146,12 @@ use super::window_registry::WindowRegistry;
 /// [`SharedEngineServices::resolve`] — never re-resolved on every access, and
 /// never reached ambiently from inside `UiRealm`.
 ///
-/// `painting` is an OWNED [`PaintingBinding`] value: PR-2 of singleton
-/// retirement (#553) deleted `PaintingBinding`'s singleton-macro
-/// invocation, so this is the first field here to complete its flip from a
-/// `'static`
-/// singleton reference to a plain owned value — the same "flip-containment"
-/// shape `PaintingBinding::font_system` already proved possible (it returns
+/// `painting` is an OWNED [`PaintingBinding`] value: `PaintingBinding`'s
+/// singleton-macro invocation was deleted as the remaining singletons here
+/// move behind explicit owners one at a time, so this is the first field
+/// here to complete its flip from a `'static` singleton reference to a
+/// plain owned value — the same "flip-containment" shape
+/// `PaintingBinding::font_system` already proved possible (it returns
 /// `SharedFontSystem` by value, so consumers never observed the `'static`
 /// lifetime in the first place). `semantics` and `scheduler` are still the
 /// process-global singleton underneath (`SemanticsBinding::instance()` and

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -7,10 +7,14 @@
 //! honest claim: `UiRealm` performs zero `::instance()` calls; the services
 //! it consumes are resolved once, here, in [`SharedEngineServices::resolve`].
 //! Other ambient reaches (`renderer_binding.rs`, `binding.rs`,
-//! `hot_reload.rs`, `config.rs`, `text.rs`) are untouched — they remain
-//! until the change that retires each singleton they reach for. This is not
-//! a forwarding shim: no old API is preserved-but-deprecated here, and no
-//! ambient access point this change does not touch is claimed as closed.
+//! `hot_reload.rs`, `config.rs`) are untouched — they remain until the
+//! change that retires each singleton they reach for.
+//! `flui-engine/src/wgpu/text.rs`'s ambient reach for painting closed in
+//! singleton retirement PR-2 (#553): `TextRenderer::new` takes an injected
+//! `SharedFontSystem` parameter instead of calling
+//! `PaintingBinding::instance()` itself. This is not a forwarding shim: no
+//! old API is preserved-but-deprecated here, and no ambient access point
+//! this change does not touch is claimed as closed.
 //!
 //! # What lives here vs. in `runner.rs`
 //!
@@ -142,14 +146,21 @@ use super::window_registry::WindowRegistry;
 /// [`SharedEngineServices::resolve`] — never re-resolved on every access, and
 /// never reached ambiently from inside `UiRealm`.
 ///
-/// Every field here is transitional: the type each names is still the
-/// process-global singleton underneath (`PaintingBinding::instance()` and
-/// friends) — only the *resolution point* moves to this one constructor.
-/// Each field's `'static` reference is expected to flip to an owned value
-/// once the change that retires that singleton lands (painting, semantics,
-/// and the scheduler each have their own separate follow-up); until then
-/// these fields are `pub(super)`, not part of any public surface (ADR-0027
-/// §9: transitional runtime types stay `pub(crate)` at most).
+/// `painting` is an OWNED [`PaintingBinding`] value: PR-2 of singleton
+/// retirement (#553) deleted `PaintingBinding`'s singleton-macro
+/// invocation, so this is the first field here to complete its flip from a
+/// `'static`
+/// singleton reference to a plain owned value — the same "flip-containment"
+/// shape `PaintingBinding::font_system` already proved possible (it returns
+/// `SharedFontSystem` by value, so consumers never observed the `'static`
+/// lifetime in the first place). `semantics` and `scheduler` are still the
+/// process-global singleton underneath (`SemanticsBinding::instance()` and
+/// `Scheduler::instance()`) — only the *resolution point* moves to this one
+/// constructor; each flips to an owned value once the change that retires
+/// that singleton lands (semantics and the scheduler each have their own
+/// separate follow-up). Until then these fields are `pub(super)`, not part
+/// of any public surface (ADR-0027 §9: transitional runtime types stay
+/// `pub(crate)` at most).
 #[cfg(not(target_os = "ios"))]
 pub(crate) struct SharedEngineServices {
     #[cfg_attr(
@@ -160,7 +171,7 @@ pub(crate) struct SharedEngineServices {
                       change wires the first real consumer"
         )
     )]
-    pub(super) painting: &'static PaintingBinding,
+    pub(super) painting: PaintingBinding,
     #[cfg_attr(
         not(test),
         expect(
@@ -184,7 +195,7 @@ pub(crate) struct SharedEngineServices {
 #[cfg(not(target_os = "ios"))]
 impl SharedEngineServices {
     fn resolve() -> Self {
-        let painting = PaintingBinding::instance();
+        let painting = PaintingBinding::new();
 
         // `SharedEngineServices::resolve()` -- reached only through
         // `AppRuntime::ensure_services()`, at the realm-install point -- is

--- a/crates/flui-app/src/bindings/renderer_binding.rs
+++ b/crates/flui-app/src/bindings/renderer_binding.rs
@@ -495,15 +495,18 @@ impl RenderingFlutterBinding {
 
     /// Attempts to handle memory pressure by clearing the image cache.
     ///
-    /// **Currently inert** — see [`Self::painting`]'s doc comment. This
-    /// clears the throwaway `PaintingBinding`'s own, always-empty
-    /// `ImageCache`, not whatever cache the application is actually using;
-    /// it becomes meaningful again once `RenderingFlutterBinding` is
-    /// re-homed to receive its painting service from the owning runtime.
-    /// Traced at `trace`, not `info`, so this does not read as a real
-    /// memory-pressure response in a production log.
+    /// **Currently inert** — see [`Self::painting`]'s doc comment. Deliberately
+    /// does NOT call `Self::painting().handle_memory_pressure()`: that inner
+    /// method's own `tracing::info!("Memory pressure: clearing image cache")`
+    /// is legitimate for a real, owned `PaintingBinding` value, but firing it
+    /// here — against a throwaway value whose `ImageCache` starts and ends
+    /// empty — would be exactly the false "it worked" signal this method is
+    /// trying not to emit. This becomes meaningful again once
+    /// `RenderingFlutterBinding` is re-homed to receive its painting service
+    /// from the owning runtime. Traced at `trace`, not `info`, so the no-op
+    /// itself does not read as a real memory-pressure response in a
+    /// production log.
     pub fn handle_memory_pressure(&self) {
-        Self::painting().handle_memory_pressure();
         tracing::trace!(
             "RenderingFlutterBinding::handle_memory_pressure: inert no-op on a \
              throwaway PaintingBinding -- see the doc comment on this method \

--- a/crates/flui-app/src/bindings/renderer_binding.rs
+++ b/crates/flui-app/src/bindings/renderer_binding.rs
@@ -466,7 +466,9 @@ impl RenderingFlutterBinding {
         SemanticsBinding::instance()
     }
 
-    /// Returns a throwaway, unshared [`PaintingBinding`] value.
+    /// Returns a fresh [`PaintingBinding`] value; its `ImageCache` is
+    /// throwaway, but `font_system()` still reaches shared state (see
+    /// below).
     ///
     /// **Inert by construction, not just as a compile-preserving stopgap.**
     /// `PaintingBinding` left the ambient-singleton graph as the remaining
@@ -480,11 +482,23 @@ impl RenderingFlutterBinding {
     /// which is the opposite of what retiring these singletons is for.
     /// Until `RenderingFlutterBinding` is re-homed to receive its painting
     /// service from the owning runtime instead of constructing its own,
-    /// every call to this method returns a brand new, empty
-    /// `PaintingBinding` — its `ImageCache` starts and ends empty, and
-    /// nothing else in the process observes whatever you do with it.
-    /// Do not use this to configure or read the "real" image cache; there
-    /// isn't one reachable from here today.
+    /// every call to this method returns a brand new `PaintingBinding` whose
+    /// `ImageCache` and `SystemFontsNotifier` start and end empty/unused —
+    /// nothing else in the process observes whatever you do to THOSE two
+    /// fields through this handle. Do not use this to configure or read the
+    /// "real" image cache; there isn't one reachable from here today.
+    ///
+    /// **`font_system()` is the one exception.** Unlike the image cache,
+    /// `PaintingBinding::font_system()` does not read this struct's own
+    /// fields at all — it reaches the process-wide shared `FONT_SYSTEM`
+    /// (`flui-painting`'s `text_layout/layout.rs`), the exact same one every
+    /// other `PaintingBinding` value (including the real one on
+    /// `AppRuntime`) resolves to. So `Self::painting().font_system()...` or
+    /// `Self::painting().register_font(...)` through this "throwaway" value
+    /// DOES mutate real, shared, process-wide font state, visible to every
+    /// other consumer — the isolation this doc comment describes is
+    /// specific to the image cache and font-change notifier, not to
+    /// everything reachable through the returned value.
     pub fn painting() -> PaintingBinding {
         PaintingBinding::new()
     }
@@ -493,19 +507,19 @@ impl RenderingFlutterBinding {
     // Memory Management
     // ========================================================================
 
-    /// Attempts to handle memory pressure by clearing the image cache.
+    /// Currently a no-op: does NOT clear any real image cache.
     ///
-    /// **Currently inert** — see [`Self::painting`]'s doc comment. Deliberately
-    /// does NOT call `Self::painting().handle_memory_pressure()`: that inner
-    /// method's own `tracing::info!("Memory pressure: clearing image cache")`
-    /// is legitimate for a real, owned `PaintingBinding` value, but firing it
-    /// here — against a throwaway value whose `ImageCache` starts and ends
-    /// empty — would be exactly the false "it worked" signal this method is
-    /// trying not to emit. This becomes meaningful again once
-    /// `RenderingFlutterBinding` is re-homed to receive its painting service
-    /// from the owning runtime. Traced at `trace`, not `info`, so the no-op
-    /// itself does not read as a real memory-pressure response in a
-    /// production log.
+    /// See [`Self::painting`]'s doc comment for why. This method
+    /// deliberately does NOT call `Self::painting().handle_memory_pressure()`:
+    /// that inner method's own `tracing::info!("Memory pressure: clearing
+    /// image cache")` is legitimate for a real, owned `PaintingBinding`
+    /// value, but firing it here — against a throwaway value whose
+    /// `ImageCache` starts and ends empty — would be exactly the false "it
+    /// worked" signal this method is trying not to emit. This becomes
+    /// meaningful again once `RenderingFlutterBinding` is re-homed to
+    /// receive its painting service from the owning runtime. Traced at
+    /// `trace`, not `info`, so the no-op itself does not read as a real
+    /// memory-pressure response in a production log.
     pub fn handle_memory_pressure(&self) {
         tracing::trace!(
             "RenderingFlutterBinding::handle_memory_pressure: inert no-op on a \

--- a/crates/flui-app/src/bindings/renderer_binding.rs
+++ b/crates/flui-app/src/bindings/renderer_binding.rs
@@ -466,17 +466,25 @@ impl RenderingFlutterBinding {
         SemanticsBinding::instance()
     }
 
-    /// Returns a fresh [`PaintingBinding`] value.
+    /// Returns a throwaway, unshared [`PaintingBinding`] value.
     ///
-    /// Forced ripple from singleton retirement PR-2 (#553):
-    /// `PaintingBinding`'s singleton-macro invocation is deleted, so
-    /// `PaintingBinding::instance()` no longer exists to return here. This
-    /// is a minimal, compile-preserving fix, not a `RenderingFlutterBinding`
-    /// redesign (PR-3's territory) — every other field/method on this type
-    /// is untouched. `PaintingBinding::new()` is cheap (an `ImageCache` plus
-    /// a `SystemFontsNotifier`, no heavy construction), and the only
-    /// caller, [`Self::handle_memory_pressure`], only needs `&self` access
-    /// for the duration of one call.
+    /// **Inert by construction, not just as a compile-preserving stopgap.**
+    /// `PaintingBinding` left the ambient-singleton graph as the remaining
+    /// singletons here move behind explicit owners: its real, long-lived
+    /// value now lives on `AppRuntime`'s `SharedEngineServices`
+    /// (`app/runtime.rs`), constructed once at realm install.
+    /// `RenderingFlutterBinding` has no field or accessor reaching that
+    /// runtime-owned value — it is itself still a process-wide singleton,
+    /// structurally unrelated to `AppRuntime` — and adding one here would
+    /// mean inventing a *new* ambient path from one singleton into another,
+    /// which is the opposite of what retiring these singletons is for.
+    /// Until `RenderingFlutterBinding` is re-homed to receive its painting
+    /// service from the owning runtime instead of constructing its own,
+    /// every call to this method returns a brand new, empty
+    /// `PaintingBinding` — its `ImageCache` starts and ends empty, and
+    /// nothing else in the process observes whatever you do with it.
+    /// Do not use this to configure or read the "real" image cache; there
+    /// isn't one reachable from here today.
     pub fn painting() -> PaintingBinding {
         PaintingBinding::new()
     }
@@ -485,12 +493,22 @@ impl RenderingFlutterBinding {
     // Memory Management
     // ========================================================================
 
-    /// Handles memory pressure by clearing caches.
+    /// Attempts to handle memory pressure by clearing the image cache.
     ///
-    /// Delegates to PaintingBinding to clear the image cache.
+    /// **Currently inert** — see [`Self::painting`]'s doc comment. This
+    /// clears the throwaway `PaintingBinding`'s own, always-empty
+    /// `ImageCache`, not whatever cache the application is actually using;
+    /// it becomes meaningful again once `RenderingFlutterBinding` is
+    /// re-homed to receive its painting service from the owning runtime.
+    /// Traced at `trace`, not `info`, so this does not read as a real
+    /// memory-pressure response in a production log.
     pub fn handle_memory_pressure(&self) {
         Self::painting().handle_memory_pressure();
-        tracing::info!("RenderingFlutterBinding: handled memory pressure");
+        tracing::trace!(
+            "RenderingFlutterBinding::handle_memory_pressure: inert no-op on a \
+             throwaway PaintingBinding -- see the doc comment on this method \
+             and on Self::painting"
+        );
     }
 }
 
@@ -514,10 +532,12 @@ impl BindingBase for RenderingFlutterBinding {
         tracing::debug!("SemanticsBinding initialized via RenderingFlutterBinding");
 
         // Painting no longer has a process-wide binding to eagerly
-        // initialize here: `PaintingBinding` stopped being a singleton in
-        // singleton retirement PR-2 (#553) — its owned value now lives on
-        // `AppRuntime`'s `SharedEngineServices`, constructed at realm
-        // install (`app/runtime.rs`).
+        // initialize here: `PaintingBinding` stopped being a singleton as
+        // the remaining singletons move behind explicit owners -- its owned
+        // value now lives on `AppRuntime`'s `SharedEngineServices`,
+        // constructed at realm install (`app/runtime.rs`). See
+        // `Self::painting`'s doc comment for why `RenderingFlutterBinding`
+        // cannot simply reach that value instead.
 
         tracing::info!("RenderingFlutterBinding initialized");
     }

--- a/crates/flui-app/src/bindings/renderer_binding.rs
+++ b/crates/flui-app/src/bindings/renderer_binding.rs
@@ -466,11 +466,19 @@ impl RenderingFlutterBinding {
         SemanticsBinding::instance()
     }
 
-    /// Get the PaintingBinding singleton.
+    /// Returns a fresh [`PaintingBinding`] value.
     ///
-    /// Equivalent to Flutter's `PaintingBinding.instance`.
-    pub fn painting() -> &'static PaintingBinding {
-        PaintingBinding::instance()
+    /// Forced ripple from singleton retirement PR-2 (#553):
+    /// `PaintingBinding`'s singleton-macro invocation is deleted, so
+    /// `PaintingBinding::instance()` no longer exists to return here. This
+    /// is a minimal, compile-preserving fix, not a `RenderingFlutterBinding`
+    /// redesign (PR-3's territory) — every other field/method on this type
+    /// is untouched. `PaintingBinding::new()` is cheap (an `ImageCache` plus
+    /// a `SystemFontsNotifier`, no heavy construction), and the only
+    /// caller, [`Self::handle_memory_pressure`], only needs `&self` access
+    /// for the duration of one call.
+    pub fn painting() -> PaintingBinding {
+        PaintingBinding::new()
     }
 
     // ========================================================================
@@ -505,9 +513,11 @@ impl BindingBase for RenderingFlutterBinding {
         let _ = SemanticsBinding::instance();
         tracing::debug!("SemanticsBinding initialized via RenderingFlutterBinding");
 
-        // Initialize painting binding (image cache, shader warm-up)
-        let _ = PaintingBinding::instance();
-        tracing::debug!("PaintingBinding initialized via RenderingFlutterBinding");
+        // Painting no longer has a process-wide binding to eagerly
+        // initialize here: `PaintingBinding` stopped being a singleton in
+        // singleton retirement PR-2 (#553) — its owned value now lives on
+        // `AppRuntime`'s `SharedEngineServices`, constructed at realm
+        // install (`app/runtime.rs`).
 
         tracing::info!("RenderingFlutterBinding initialized");
     }

--- a/crates/flui-engine/src/wgpu/painter/mod.rs
+++ b/crates/flui-engine/src/wgpu/painter/mod.rs
@@ -10,6 +10,8 @@
 
 use std::sync::Arc;
 
+use flui_painting::PaintingBinding;
+
 use super::{
     command_ir::{DrawItem, DrawSegment, ImageFilterPass, PendingOffscreenTexture, ScissorRect},
     layer_compositor::LayerCompositor,
@@ -146,7 +148,18 @@ impl WgpuPainter {
         let replay = GpuReplay::new(&device, &pipelines, size.0, size.1);
 
         // ===== Text renderer =====
-        let text_renderer = TextRenderer::new(&device, &queue, surface_format);
+        //
+        // `PaintingBinding::new()` here is a cheap, transient value used only
+        // to reach `font_system()` -- that accessor reads the process-wide
+        // `FONT_SYSTEM` (flui-painting's `text_layout/layout.rs`) regardless
+        // of which `PaintingBinding` calls it, so this is the injection
+        // point: `TextRenderer` receives the handle explicitly rather than
+        // resolving `PaintingBinding::instance()` itself, which used to
+        // stand up a second, leaked, thread-local binding on whichever
+        // thread constructed the painter (the raster thread, in the
+        // shipping path).
+        let font_system = PaintingBinding::new().font_system();
+        let text_renderer = TextRenderer::new(&device, &queue, surface_format, font_system);
 
         // ===== Resource managers =====
         let resources = GpuResources::new(Arc::clone(&device), Arc::clone(&queue));

--- a/crates/flui-engine/src/wgpu/text.rs
+++ b/crates/flui-engine/src/wgpu/text.rs
@@ -348,7 +348,7 @@ enum BatchEntry {
 ///
 /// # Example
 /// ```ignore
-/// let mut text_renderer = TextRenderer::new(&device, &queue, surface_format, font_system)?;
+/// let mut text_renderer = TextRenderer::new(&device, &queue, surface_format, font_system);
 ///
 /// // Add plain text during frame
 /// text_renderer.add_text("Hello, World!", Point::new(10.0, 10.0), 16.0, Color::BLACK);

--- a/crates/flui-engine/src/wgpu/text.rs
+++ b/crates/flui-engine/src/wgpu/text.rs
@@ -445,25 +445,47 @@ impl TextRenderer {
         // instance: idempotent on a repeat call against the SAME
         // `FontSystem` (the family is already there), and always loads for a
         // genuinely different one.
-        const MATERIAL_ICONS_FAMILY: &str = "Material Icons";
-        let icon_fonts_present = font_system.db().faces().any(|face| {
-            face.families
-                .iter()
-                .any(|(name, _)| name == MATERIAL_ICONS_FAMILY)
-        });
-        if !icon_fonts_present {
-            const MATERIAL_ICONS: &[u8] =
-                include_bytes!("../../assets/fonts/MaterialIcons-Regular.ttf");
-            const CUPERTINO_ICONS: &[u8] = include_bytes!("../../assets/fonts/CupertinoIcons.ttf");
-            font_system.db_mut().load_font_data(MATERIAL_ICONS.to_vec());
-            font_system
-                .db_mut()
-                .load_font_data(CUPERTINO_ICONS.to_vec());
-            tracing::info!(
-                count = font_system.db().faces().count(),
-                "loaded embedded Material Icons + Cupertino Icons fonts"
-            );
+        //
+        // The two embedded fonts are probed and loaded INDEPENDENTLY, each
+        // keyed by its own family name, rather than gating both on a single
+        // "Material Icons present?" check. A single shared gate is wrong the
+        // moment the two faces can appear separately: a system-installed or
+        // previously `register_font`-ed "Material Icons" face (this is a
+        // real family name, not exclusive to the embedded TTF) would make
+        // the combined check see the family as present and skip loading
+        // BOTH fonts -- silently dropping the embedded Material Icons face
+        // update *and* Cupertino Icons entirely, even though nothing ever
+        // provided Cupertino Icons. Each font's presence is real evidence
+        // only for that font.
+        Self::ensure_embedded_font_loaded(
+            font_system,
+            "Material Icons",
+            include_bytes!("../../assets/fonts/MaterialIcons-Regular.ttf"),
+        );
+        Self::ensure_embedded_font_loaded(
+            font_system,
+            "CupertinoIcons",
+            include_bytes!("../../assets/fonts/CupertinoIcons.ttf"),
+        );
+    }
+
+    /// Loads `font_data` into `font_system`'s database unless a face already
+    /// carries `family` — the per-font idempotency check
+    /// [`Self::ensure_fonts_available`]'s doc comment explains.
+    fn ensure_embedded_font_loaded(font_system: &mut FontSystem, family: &str, font_data: &[u8]) {
+        let already_present = font_system
+            .db()
+            .faces()
+            .any(|face| face.families.iter().any(|(name, _)| name == family));
+        if already_present {
+            return;
         }
+        font_system.db_mut().load_font_data(font_data.to_vec());
+        tracing::info!(
+            family,
+            count = font_system.db().faces().count(),
+            "loaded embedded icon font"
+        );
     }
 
     /// Creates a new `TextRenderer` bound to the given wgpu `device`/`queue`,
@@ -944,6 +966,8 @@ fn build_text_areas<'cache>(
 
 #[cfg(test)]
 mod tests {
+    use glyphon::fontdb;
+
     use super::{FontSystem, TextRenderer, collect_styled_spans};
     use flui_types::typography::{FontWeight, InlineSpan, TextSpan, TextStyle};
 
@@ -1188,6 +1212,25 @@ mod tests {
         assert_eq!(key(None), key(None), "None must be stable");
     }
 
+    /// Constructs a genuinely empty, hermetic `FontSystem`: an empty
+    /// `fontdb::Database` and no system-font scan. `FontSystem::new()` would
+    /// make icon-font assertions vacuous on any machine that happens to
+    /// have a system-installed "Material Icons"/"CupertinoIcons" font (or
+    /// on a machine where a previous test in the same process already
+    /// registered one into a SHARED font system) -- this constructor
+    /// guarantees the test starts from zero faces every time, on every
+    /// machine.
+    fn empty_font_system() -> FontSystem {
+        FontSystem::new_with_locale_and_db("en-US".to_string(), fontdb::Database::new())
+    }
+
+    fn has_family(font_system: &FontSystem, family: &str) -> bool {
+        font_system
+            .db()
+            .faces()
+            .any(|face| face.families.iter().any(|(name, _)| name == family))
+    }
+
     /// Regression test for the process-global `ICON_FONTS_LOADED` bug: icon
     /// fonts must load into EVERY independently constructed `FontSystem`, not
     /// just the first one `ensure_fonts_available` ever sees.
@@ -1195,35 +1238,81 @@ mod tests {
     /// Red before the per-instance fix: a single process-wide
     /// `AtomicBool::swap` flipped true on the FIRST call below and stayed
     /// true for the rest of the process, so the second, independent
-    /// `FontSystem` never got its icon fonts loaded and `has_material_icons`
-    /// on `fs_b` would fail.
+    /// `FontSystem` never got its icon fonts loaded and both assertions on
+    /// `fs_b` would fail.
     #[test]
-    fn ensure_fonts_available_loads_icon_fonts_into_every_independent_font_system() {
-        fn has_material_icons(font_system: &FontSystem) -> bool {
-            font_system.db().faces().any(|face| {
-                face.families
-                    .iter()
-                    .any(|(name, _)| name == "Material Icons")
-            })
-        }
-
-        let mut fs_a = FontSystem::new();
+    fn ensure_fonts_available_loads_both_icon_fonts_into_every_independent_font_system() {
+        let mut fs_a = empty_font_system();
         TextRenderer::ensure_fonts_available(&mut fs_a);
         assert!(
-            has_material_icons(&fs_a),
+            has_family(&fs_a, "Material Icons"),
             "the first FontSystem must resolve the Material Icons glyph after \
+             ensure_fonts_available"
+        );
+        assert!(
+            has_family(&fs_a, "CupertinoIcons"),
+            "the first FontSystem must resolve the Cupertino Icons glyph after \
              ensure_fonts_available"
         );
 
         // A SECOND, independently constructed FontSystem must ALSO receive
-        // the icon fonts -- this is the case the process-global flag broke.
-        let mut fs_b = FontSystem::new();
+        // BOTH icon fonts -- this is the case the process-global flag broke.
+        let mut fs_b = empty_font_system();
         TextRenderer::ensure_fonts_available(&mut fs_b);
         assert!(
-            has_material_icons(&fs_b),
+            has_family(&fs_b, "Material Icons"),
             "a second, independent FontSystem must also resolve the Material Icons \
              glyph -- regression test for the process-global ICON_FONTS_LOADED flag \
              that silently skipped icon-font loading for every FontSystem after the first"
+        );
+        assert!(
+            has_family(&fs_b, "CupertinoIcons"),
+            "a second, independent FontSystem must also resolve the Cupertino Icons glyph"
+        );
+    }
+
+    /// Regression test for the single-probe bug: the guard used to check
+    /// ONLY "Material Icons" presence but gated LOADING BOTH embedded fonts
+    /// on that one check. A `FontSystem` that already carries a "Material
+    /// Icons" face -- a real family name that can come from the OS or a
+    /// prior `register_font` call, not exclusively from this crate's
+    /// embedded TTF -- made the combined check see the family as present and
+    /// skip loading Cupertino Icons entirely, even though nothing had ever
+    /// provided it.
+    ///
+    /// Red under the single-probe bug: seeding a "Material Icons" face
+    /// (without touching Cupertino Icons) makes the old combined check
+    /// true, so `ensure_fonts_available` would return early and the
+    /// Cupertino assertion below would fail.
+    #[test]
+    fn ensure_fonts_available_loads_cupertino_icons_even_when_material_icons_already_present() {
+        let mut fs = empty_font_system();
+        // Seed a "Material Icons" face WITHOUT going through
+        // `ensure_fonts_available` -- simulates a system-installed or
+        // previously registered face with that family name, independent of
+        // the fix under test. Reusing the embedded Material Icons TTF here
+        // is just a convenient real, loadable font with that exact family
+        // name; nothing about this test depends on it being THE canonical
+        // embedded copy.
+        fs.db_mut().load_font_data(
+            include_bytes!("../../assets/fonts/MaterialIcons-Regular.ttf").to_vec(),
+        );
+        assert!(
+            has_family(&fs, "Material Icons"),
+            "test setup must have seeded a Material Icons face"
+        );
+        assert!(
+            !has_family(&fs, "CupertinoIcons"),
+            "test setup must not have seeded a Cupertino Icons face"
+        );
+
+        TextRenderer::ensure_fonts_available(&mut fs);
+
+        assert!(
+            has_family(&fs, "CupertinoIcons"),
+            "CupertinoIcons must load even when Material Icons is already present -- \
+             regression test for the single combined-gate bug where checking ONLY \
+             'Material Icons' presence silently skipped loading BOTH fonts"
         );
     }
 }

--- a/crates/flui-engine/src/wgpu/text.rs
+++ b/crates/flui-engine/src/wgpu/text.rs
@@ -14,8 +14,7 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::hash::{Hash, Hasher};
 
-use flui_foundation::HasInstance;
-use flui_painting::{PaintingBinding, SharedFontSystem};
+use flui_painting::SharedFontSystem;
 use flui_types::{
     geometry::{Pixels, Point},
     styling::Color,
@@ -349,7 +348,7 @@ enum BatchEntry {
 ///
 /// # Example
 /// ```ignore
-/// let mut text_renderer = TextRenderer::new(&device, &queue, surface_format)?;
+/// let mut text_renderer = TextRenderer::new(&device, &queue, surface_format, font_system)?;
 ///
 /// // Add plain text during frame
 /// text_renderer.add_text("Hello, World!", Point::new(10.0, 10.0), 16.0, Color::BLACK);
@@ -358,12 +357,18 @@ enum BatchEntry {
 /// text_renderer.render(&device, &queue, &view, &mut encoder, (800, 600))?;
 /// ```
 pub struct TextRenderer {
-    /// The framework's single shared font system (ADR-0016).
+    /// The framework's single shared font system (ADR-0016), injected by the
+    /// caller rather than resolved ambiently.
     ///
     /// This is a clone of the handle owned by `flui-painting`, so glyphs are
     /// shaped here against the exact same faces that text *measurement* uses:
     /// a font registered via `PaintingBinding::register_font` is visible to
-    /// both paths, with no second database to keep in sync.
+    /// both paths, with no second database to keep in sync. Taking this as a
+    /// constructor parameter (rather than reaching for
+    /// `PaintingBinding::instance()` internally) means constructing a
+    /// `TextRenderer` on a non-owner thread (the raster thread) never has to
+    /// stand up a second, disconnected binding of its own — the caller
+    /// decides which font system this renderer shapes against.
     font_system: SharedFontSystem,
 
     /// Swash cache (rasterizes glyphs)
@@ -426,10 +431,27 @@ impl TextRenderer {
         // Icon fonts: always present, independent of the text-font count above.
         // Neither the OS text fonts nor Roboto carry the private-use glyphs that
         // Material / Cupertino icons resolve to, so `Icon` renders tofu without
-        // these. Loaded exactly once into the process-wide shared DB.
-        static ICON_FONTS_LOADED: std::sync::atomic::AtomicBool =
-            std::sync::atomic::AtomicBool::new(false);
-        if !ICON_FONTS_LOADED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        // these.
+        //
+        // Idempotency is checked per FontSystem INSTANCE (by family-name
+        // presence in `font_system`'s own db), not via a process-global flag.
+        // A process-global `AtomicBool` (the previous shape) is wrong here:
+        // it flips true the first time any `FontSystem` loads the icon
+        // fonts, and every OTHER `FontSystem` afterwards -- including one
+        // constructed independently on a non-owner thread -- reads that
+        // flag as already-satisfied and silently skips loading into its OWN
+        // (empty) db, so `Icon` renders tofu on that instance forever.
+        // Checking this instance's own faces makes the guard correct per
+        // instance: idempotent on a repeat call against the SAME
+        // `FontSystem` (the family is already there), and always loads for a
+        // genuinely different one.
+        const MATERIAL_ICONS_FAMILY: &str = "Material Icons";
+        let icon_fonts_present = font_system.db().faces().any(|face| {
+            face.families
+                .iter()
+                .any(|(name, _)| name == MATERIAL_ICONS_FAMILY)
+        });
+        if !icon_fonts_present {
             const MATERIAL_ICONS: &[u8] =
                 include_bytes!("../../assets/fonts/MaterialIcons-Regular.ttf");
             const CUPERTINO_ICONS: &[u8] = include_bytes!("../../assets/fonts/CupertinoIcons.ttf");
@@ -444,11 +466,22 @@ impl TextRenderer {
         }
     }
 
-    /// Creates a new `TextRenderer` bound to the given wgpu `device`/`queue`.
-    pub fn new(device: &wgpu::Device, queue: &wgpu::Queue, format: wgpu::TextureFormat) -> Self {
+    /// Creates a new `TextRenderer` bound to the given wgpu `device`/`queue`,
+    /// shaping against the injected `font_system`.
+    ///
+    /// `font_system` is a caller-supplied [`SharedFontSystem`] handle rather
+    /// than an ambient lookup: the caller decides which font database this
+    /// renderer shapes against, so constructing a `TextRenderer` on a
+    /// non-owner thread (the raster thread) never has to stand up a second,
+    /// disconnected binding of its own just to reach the font DB.
+    pub fn new(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        format: wgpu::TextureFormat,
+        font_system: SharedFontSystem,
+    ) -> Self {
         tracing::trace!(format = ?format, "TextRenderer::new");
 
-        let font_system = PaintingBinding::instance().font_system();
         font_system.with_mut(Self::ensure_fonts_available);
         let swash_cache = SwashCache::new();
         let cache = Cache::new(device);
@@ -911,7 +944,7 @@ fn build_text_areas<'cache>(
 
 #[cfg(test)]
 mod tests {
-    use super::collect_styled_spans;
+    use super::{FontSystem, TextRenderer, collect_styled_spans};
     use flui_types::typography::{FontWeight, InlineSpan, TextSpan, TextStyle};
 
     /// A bold child of a sized parent must carry both bold weight and the
@@ -1154,12 +1187,52 @@ mod tests {
         );
         assert_eq!(key(None), key(None), "None must be stable");
     }
+
+    /// Regression test for the process-global `ICON_FONTS_LOADED` bug: icon
+    /// fonts must load into EVERY independently constructed `FontSystem`, not
+    /// just the first one `ensure_fonts_available` ever sees.
+    ///
+    /// Red before the per-instance fix: a single process-wide
+    /// `AtomicBool::swap` flipped true on the FIRST call below and stayed
+    /// true for the rest of the process, so the second, independent
+    /// `FontSystem` never got its icon fonts loaded and `has_material_icons`
+    /// on `fs_b` would fail.
+    #[test]
+    fn ensure_fonts_available_loads_icon_fonts_into_every_independent_font_system() {
+        fn has_material_icons(font_system: &FontSystem) -> bool {
+            font_system.db().faces().any(|face| {
+                face.families
+                    .iter()
+                    .any(|(name, _)| name == "Material Icons")
+            })
+        }
+
+        let mut fs_a = FontSystem::new();
+        TextRenderer::ensure_fonts_available(&mut fs_a);
+        assert!(
+            has_material_icons(&fs_a),
+            "the first FontSystem must resolve the Material Icons glyph after \
+             ensure_fonts_available"
+        );
+
+        // A SECOND, independently constructed FontSystem must ALSO receive
+        // the icon fonts -- this is the case the process-global flag broke.
+        let mut fs_b = FontSystem::new();
+        TextRenderer::ensure_fonts_available(&mut fs_b);
+        assert!(
+            has_material_icons(&fs_b),
+            "a second, independent FontSystem must also resolve the Material Icons \
+             glyph -- regression test for the process-global ICON_FONTS_LOADED flag \
+             that silently skipped icon-font loading for every FontSystem after the first"
+        );
+    }
 }
 
 #[cfg(all(test, feature = "enable-wgpu-tests"))]
 mod gpu_tests {
     use std::sync::Arc;
 
+    use flui_painting::PaintingBinding;
     use flui_types::{geometry::Pixels, geometry::Point, styling::Color};
 
     use super::TextRenderer;
@@ -1317,7 +1390,8 @@ mod gpu_tests {
     fn atlas_trim_each_frame_keeps_text_rendering() {
         let (device, queue) = device_queue();
         let (target, view) = make_target(&device);
-        let mut tr = TextRenderer::new(&device, &queue, FORMAT);
+        let font_system = PaintingBinding::new().font_system();
+        let mut tr = TextRenderer::new(&device, &queue, FORMAT, font_system);
         let white = Color::rgba(255, 255, 255, 255);
 
         // Churn: every frame draws DISTINCT glyphs (varying text + size) and

--- a/crates/flui-painting/src/binding.rs
+++ b/crates/flui-painting/src/binding.rs
@@ -25,7 +25,6 @@ use std::{
     },
 };
 
-use flui_foundation::BindingBase;
 use flui_types::{Size, geometry::Pixels};
 use parking_lot::RwLock;
 
@@ -382,13 +381,18 @@ impl Default for PaintingBinding {
 
 impl PaintingBinding {
     /// Creates a new painting binding.
+    ///
+    /// This is a plain value constructor, not a singleton bootstrap: since
+    /// `PaintingBinding` left the ambient-singleton graph, callers construct
+    /// one whenever they need one (once per owner thread in
+    /// `SharedEngineServices`, but also transiently wherever an accessor
+    /// only needs to reach through to `font_system()`) — there is no
+    /// process-wide "the first construction matters" moment left to log.
     pub fn new() -> Self {
-        let mut binding = Self {
+        Self {
             image_cache: ImageCache::new(),
             system_fonts: SystemFontsNotifier::new(),
-        };
-        binding.init_instances();
-        binding
+        }
     }
 
     /// Returns the image cache.
@@ -478,12 +482,6 @@ impl PaintingBinding {
             tracing::debug!("System fonts changed");
             self.system_fonts.notify_listeners();
         }
-    }
-}
-
-impl BindingBase for PaintingBinding {
-    fn init_instances(&mut self) {
-        tracing::info!("PaintingBinding initialized");
     }
 }
 

--- a/crates/flui-painting/src/binding.rs
+++ b/crates/flui-painting/src/binding.rs
@@ -25,7 +25,7 @@ use std::{
     },
 };
 
-use flui_foundation::{BindingBase, HasInstance, impl_binding_singleton};
+use flui_foundation::BindingBase;
 use flui_types::{Size, geometry::Pixels};
 use parking_lot::RwLock;
 
@@ -487,21 +487,6 @@ impl BindingBase for PaintingBinding {
     }
 }
 
-// Singleton pattern
-impl_binding_singleton!(PaintingBinding);
-
-// ============================================================================
-// Convenience function
-// ============================================================================
-
-/// Returns the global image cache.
-///
-/// This is a convenience function equivalent to
-/// `PaintingBinding.instance.imageCache`.
-pub fn image_cache() -> &'static ImageCache {
-    PaintingBinding::instance().image_cache()
-}
-
 // ============================================================================
 // Tests
 // ============================================================================
@@ -621,15 +606,8 @@ mod tests {
     }
 
     #[test]
-    fn test_painting_binding_singleton() {
-        let binding1 = PaintingBinding::instance();
-        let binding2 = PaintingBinding::instance();
-        assert!(std::ptr::eq(binding1, binding2));
-    }
-
-    #[test]
     fn register_font_rejects_data_with_no_loadable_faces() {
-        let binding = PaintingBinding::instance();
+        let binding = PaintingBinding::new();
         let err = binding
             .register_font(b"this is plainly not a font file")
             .unwrap_err();
@@ -645,16 +623,21 @@ mod tests {
         // input, not an API/layering coupling — flui-engine still depends on
         // flui-painting, never the reverse).
         const ROBOTO: &[u8] = include_bytes!("../../flui-engine/assets/fonts/Roboto-Regular.ttf");
-        let binding = PaintingBinding::instance();
+        let binding = PaintingBinding::new();
 
         binding
             .register_font(ROBOTO)
             .expect("Roboto-Regular.ttf is a valid TTF with at least one face");
 
-        // A *separately obtained* handle sees the face — proving the ADR-0016
-        // contract that `font_system()` shares one instance rather than
-        // handing out isolated copies.
-        let visible = binding.font_system().with_mut(|font_system| {
+        // A handle obtained from a SEPARATELY CONSTRUCTED `PaintingBinding`
+        // still sees the face — proving the ADR-0016 contract that
+        // `font_system()` shares one process-wide font database keyed off
+        // `FONT_SYSTEM` (`text_layout/layout.rs`), not off `PaintingBinding`
+        // instance identity. `PaintingBinding` itself is a plain owned value
+        // now (no singleton behind it); the sharing invariant this test
+        // pins lives entirely in `shared_font_system()`.
+        let other_binding = PaintingBinding::new();
+        let visible = other_binding.font_system().with_mut(|font_system| {
             font_system.db().faces().any(|face| {
                 face.families
                     .iter()
@@ -663,7 +646,8 @@ mod tests {
         });
         assert!(
             visible,
-            "a registered face must be visible through any font_system() handle"
+            "a registered face must be visible through any font_system() handle, \
+             including one obtained from an entirely different PaintingBinding value"
         );
     }
 }

--- a/crates/flui-painting/src/lib.rs
+++ b/crates/flui-painting/src/lib.rs
@@ -191,7 +191,7 @@ pub mod testing;
 // flui_painting::canvas::Canvas`.
 
 // Binding
-pub use binding::{CachedImage, ImageCache, ImageHandle, PaintingBinding, image_cache};
+pub use binding::{CachedImage, ImageCache, ImageHandle, PaintingBinding};
 // Primary API types
 pub use canvas::Canvas;
 pub use clip_context::ClipContext;

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -1937,11 +1937,19 @@ allow_files = []
 pattern = "PR-2"
 why = """
 See the `PR-1` entry above for the shared rationale and the substring-scan \
-caveat. Pre-existing debt on `main` from an earlier (pre-singleton-retirement) \
-blend-mode-routing migration that used the same `PR-N` slice-marker convention \
-in its own comments -- out of scope to fix in the singleton-retirement PR that \
-added this gate, so those files are allowlisted here as named debt rather than \
-silently exempted.\
+caveat. Pre-existing debt on `main` from TWO unrelated earlier migrations \
+that each used the same `PR-N` slice-marker convention in their own \
+comments -- out of scope to fix in the singleton-retirement PR that added \
+this gate, so those files are allowlisted here as named debt rather than \
+silently exempted. `aa_oracle_tests.rs`, `advanced_blend/mod.rs`, \
+`batches/shapes.rs`, `instancing.rs`, and `flui-types/src/styling/color.rs` \
+(the WGSL-port CPU oracle cross-referenced from the shared `Color` type) are \
+the pre-singleton-retirement blend-mode-routing/GPU-port migration in \
+`flui-engine`'s wgpu backend. `flui-view/src/tree/element_tree.rs` is NOT \
+part of that migration -- its `PR-2` marks a separate, unrelated `flui-view` \
+inherited-scope migration (the per-node `inherited` map for `depend_on` \
+resolution); it happens to share the same slice number by coincidence, not \
+by relation.\
 """
 allow_files = [
     "crates/flui-engine/src/wgpu/aa_oracle_tests.rs",

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -1257,7 +1257,7 @@ contains = "pub use flui_rendering::{binding::RendererBinding, pipeline::Pipelin
 classification = "transitional"
 thread_affinity = "mixed; the singleton graph is owner-thread-local via HasInstance"
 owner = "transitional singleton service graph"
-failure_semantics = "singleton accessors construct lazily per thread; no typed errors (PaintingBinding excepted: it left the singleton graph in PR-2 and is now a plain constructible value, still re-exported here as a type)"
+failure_semantics = "singleton accessors construct lazily per thread; no typed errors (PaintingBinding excepted: it left the singleton graph and is now a plain constructible value, still re-exported here as a type)"
 consumers = ["flui-app prelude", "flui facade via app module"]
 owner_issue = 553
 
@@ -1560,7 +1560,7 @@ owner = "the ambient singleton pattern itself — deleted from runtime paths und
 failure_semantics = "lazily constructs a per-thread instance; cannot fail, which is the problem"
 consumers = ["Scheduler", "RenderingFlutterBinding", "SemanticsBinding", "AppBinding (manual)"]
 owner_issue = 553
-notes = "PaintingBinding stopped implementing HasInstance in singleton retirement PR-2 -- impl_binding_singleton!(PaintingBinding) is deleted; the type is now a plain owned value (SharedEngineServices.painting on AppRuntime)."
+notes = "PaintingBinding no longer implements HasInstance -- its singleton-macro invocation is deleted; the type is now a plain owned value (SharedEngineServices.painting on AppRuntime)."
 
 [[surface]]
 path = "flui_engine::wgpu::Renderer"
@@ -1789,7 +1789,7 @@ note = "single AppBinding::instance() reach; re-routed through the runtime once 
 file = "crates/flui-app/src/app/runtime.rs"
 grammar = "instance-call"
 owner_issue = 553
-note = "the deliberate resolution seam this file creates: SemanticsBinding::instance()/Scheduler::instance() are called exactly once each, in SharedEngineServices::resolve() and RealmServices::resolve() -- this is the ONE file allowed to still reach for these singletons directly so every other constructor (including UiRealm's) does not have to. PaintingBinding::instance() completed its flip in singleton retirement PR-2: SharedEngineServices.painting is now an owned PaintingBinding value, constructed via PaintingBinding::new(). Each of the remaining two flips to an owned/injected value as the singleton it names is retired (semantics, then the scheduler), at which point this entry shrinks accordingly."
+note = "the deliberate resolution seam this file creates: SemanticsBinding::instance()/Scheduler::instance() are called exactly once each, in SharedEngineServices::resolve() and RealmServices::resolve() -- this is the ONE file allowed to still reach for these singletons directly so every other constructor (including UiRealm's) does not have to. PaintingBinding::instance() already completed its flip: SharedEngineServices.painting is now an owned PaintingBinding value, constructed via PaintingBinding::new(). Each of the remaining two flips to an owned/injected value as the singleton it names is retired (semantics, then the scheduler), at which point this entry shrinks accordingly."
 
 [[ambient_reach]]
 file = "crates/flui-app/src/app/runner.rs"
@@ -1831,7 +1831,7 @@ note = "AssetRegistry::global(): named residual, out of this migration's scope e
 file = "crates/flui-painting/src/text_layout/layout.rs"
 grammar = "ambient-static"
 owner_issue = 553
-note = "shared_font_system()/FONT_SYSTEM: SharedEngineServices::resolve() (invoked from AppRuntime::ensure_services() at realm install) is the CONSTRUCTING owner -- it calls PaintingBinding::font_system() explicitly, eagerly installing the process-wide FontSystem instead of leaving it to whichever text-measurement call happens to run first. The READ path stays ambient on layout hot paths -- cross-realm register_font staleness mid-layout is a named, bounded hazard (Mutex<FontSystem> makes it staleness not a data race), not closed until fonts get their own owner-local-access/sharding follow-up (ADR-0027 follow-up 6). Singleton retirement PR-2 additionally re-scoped ICON_FONTS_LOADED (flui-engine/src/wgpu/text.rs) from a process-global flag to a per-FontSystem family-presence check, and gave TextRenderer::new an injected SharedFontSystem parameter instead of an ambient PaintingBinding::instance() reach -- neither changes this entry's hazard, which is specifically about concurrent register_font mutation, not construction-time ownership."
+note = "shared_font_system()/FONT_SYSTEM: SharedEngineServices::resolve() (invoked from AppRuntime::ensure_services() at realm install) is the CONSTRUCTING owner -- it calls PaintingBinding::font_system() explicitly, eagerly installing the process-wide FontSystem instead of leaving it to whichever text-measurement call happens to run first. The READ path stays ambient on layout hot paths -- cross-realm register_font staleness mid-layout is a named, bounded hazard (Mutex<FontSystem> makes it staleness not a data race), not closed until fonts get their own owner-local-access/sharding follow-up (ADR-0027 follow-up 6). This migration additionally re-scoped ICON_FONTS_LOADED (flui-engine/src/wgpu/text.rs) from a process-global flag to a per-font, per-FontSystem-instance family-presence check (each embedded icon font probed and loaded independently, so one already-present family never gates the other), and gave TextRenderer::new an injected SharedFontSystem parameter instead of an ambient PaintingBinding::instance() reach -- neither changes this entry's hazard, which is specifically about concurrent register_font mutation, not construction-time ownership."
 
 # =============================================================================
 # Public lock-shaped surface allowlist (runtime crates)
@@ -1909,6 +1909,111 @@ owner_issue = 553
 # Substring scans over crates/**/*.rs (comments included — the strings below
 # are retired identifiers that must not reappear even in prose). `allow_files`
 # lists exact files permitted to contain the pattern.
+
+[[forbidden_pattern]]
+pattern = "PR-1"
+why = """
+plan-slice markers (a private review/planning-history identifier like `PR-N` \
+naming one slice of a multi-PR migration plan) are banned from source comments \
+by AGENTS.md's "no internal process-ID markers" rule -- state the invariant or \
+rationale in plain English instead, since a reader should not need a planning \
+doc that may not outlive the project to understand why the code is shaped this \
+way. This recurred three times across review rounds on the font/paint-ownership \
+slice of singleton retirement before becoming this mechanical gate. The checker \
+(`check-runtime-conformance.sh`) \
+does a plain substring scan, not a regex, so `PR-[0-9]` is enforced as one \
+literal-digit entry per digit (`PR-1` through `PR-6`, matching this migration's \
+six-PR structure) rather than a single character-class pattern; a bare `PR-` \
+prefix was rejected because it collides with the unrelated `DPR-only`/\
+`DPR-scale-only` (device-pixel-ratio) domain term already in the tree. `PR-1` \
+itself has no pre-existing hits (the five sibling entries for the higher \
+digits carry the pre-existing allowlists instead), so this entry is enforced \
+with an empty allowlist from the day it lands -- any future `PR-1` marker is \
+a fresh violation, not inherited debt.\
+"""
+allow_files = []
+
+[[forbidden_pattern]]
+pattern = "PR-2"
+why = """
+See the `PR-1` entry above for the shared rationale and the substring-scan \
+caveat. Pre-existing debt on `main` from an earlier (pre-singleton-retirement) \
+blend-mode-routing migration that used the same `PR-N` slice-marker convention \
+in its own comments -- out of scope to fix in the singleton-retirement PR that \
+added this gate, so those files are allowlisted here as named debt rather than \
+silently exempted.\
+"""
+allow_files = [
+    "crates/flui-engine/src/wgpu/aa_oracle_tests.rs",
+    "crates/flui-engine/src/wgpu/advanced_blend/mod.rs",
+    "crates/flui-engine/src/wgpu/batches/shapes.rs",
+    "crates/flui-engine/src/wgpu/instancing.rs",
+    "crates/flui-types/src/styling/color.rs",
+    "crates/flui-view/src/tree/element_tree.rs",
+]
+
+[[forbidden_pattern]]
+pattern = "PR-3"
+why = "See the `PR-1` entry above for the shared rationale. Pre-existing debt from the same earlier blend-mode-routing migration; out of scope to fix here."
+allow_files = [
+    "crates/flui-engine/src/wgpu/aa_oracle_tests.rs",
+    "crates/flui-engine/src/wgpu/advanced_blend/mod.rs",
+    "crates/flui-engine/src/wgpu/batches/paths.rs",
+    "crates/flui-engine/src/wgpu/batches/shapes.rs",
+    "crates/flui-engine/src/wgpu/layer_blend_tests.rs",
+    "crates/flui-engine/src/wgpu/mod.rs",
+    "crates/flui-engine/src/wgpu/pipeline.rs",
+    "crates/flui-engine/src/wgpu/replay/mod.rs",
+    "crates/flui-engine/src/wgpu/ssaa.rs",
+]
+
+[[forbidden_pattern]]
+pattern = "PR-4"
+why = "See the `PR-1` entry above for the shared rationale. Pre-existing debt from the same earlier blend-mode-routing migration; out of scope to fix here."
+allow_files = [
+    "crates/flui-engine/src/wgpu/aa_oracle_tests.rs",
+    "crates/flui-engine/src/wgpu/batches/paths.rs",
+    "crates/flui-engine/src/wgpu/batches/shapes.rs",
+    "crates/flui-engine/src/wgpu/mod.rs",
+    "crates/flui-engine/src/wgpu/pipeline.rs",
+    "crates/flui-engine/src/wgpu/replay/mod.rs",
+    "crates/flui-engine/src/wgpu/shape_blend_tests.rs",
+    "crates/flui-engine/src/wgpu/ssaa.rs",
+]
+
+[[forbidden_pattern]]
+pattern = "PR-5"
+why = "See the `PR-1` entry above for the shared rationale. Pre-existing debt from the same earlier blend-mode-routing migration; out of scope to fix here."
+allow_files = [
+    "crates/flui-engine/src/wgpu/backend.rs",
+    "crates/flui-engine/src/wgpu/batches/gradients.rs",
+    "crates/flui-engine/src/wgpu/batches/images.rs",
+    "crates/flui-engine/src/wgpu/batches/mod.rs",
+    "crates/flui-engine/src/wgpu/batches/shapes.rs",
+    "crates/flui-engine/src/wgpu/gradient_image_blend_tests.rs",
+    "crates/flui-engine/src/wgpu/mod.rs",
+    "crates/flui-engine/src/wgpu/painter/draw.rs",
+    "crates/flui-engine/src/wgpu/pipeline.rs",
+]
+
+[[forbidden_pattern]]
+pattern = "PR-6"
+why = "See the `PR-1` entry above for the shared rationale. Pre-existing debt from the same earlier blend-mode-routing migration; out of scope to fix here."
+allow_files = ["crates/flui-engine/src/wgpu/renderer.rs"]
+
+[[forbidden_pattern]]
+pattern = "WU-"
+why = """
+Companion ban to the `PR-N` entries above: `WU-N` (work-unit) is the other \
+plan-slice marker shape banned by AGENTS.md's "no internal process-ID markers" \
+rule. Unlike `PR-`, no bare-prefix collision exists anywhere in the tree today \
+(no `xWU-`-shaped domain term), so this is enforced as a single prefix pattern \
+rather than one entry per digit -- it also catches double-digit work units \
+(`WU-10`+) that a `WU-[0-9]`-per-digit approach would miss. Zero pre-existing \
+hits at the time this gate landed, so the allowlist starts empty; any future \
+`WU-N` marker is a fresh violation, not inherited debt.\
+"""
+allow_files = []
 
 [[forbidden_pattern]]
 pattern = "ForegroundExecutor"

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -1257,7 +1257,7 @@ contains = "pub use flui_rendering::{binding::RendererBinding, pipeline::Pipelin
 classification = "transitional"
 thread_affinity = "mixed; the singleton graph is owner-thread-local via HasInstance"
 owner = "transitional singleton service graph"
-failure_semantics = "singleton accessors construct lazily per thread; no typed errors"
+failure_semantics = "singleton accessors construct lazily per thread; no typed errors (PaintingBinding excepted: it left the singleton graph in PR-2 and is now a plain constructible value, still re-exported here as a type)"
 consumers = ["flui-app prelude", "flui facade via app module"]
 owner_issue = 553
 
@@ -1558,14 +1558,9 @@ classification = "removal-target"
 thread_affinity = "thread-local singleton storage per implementor"
 owner = "the ambient singleton pattern itself — deleted from runtime paths under the owning issue"
 failure_semantics = "lazily constructs a per-thread instance; cannot fail, which is the problem"
-consumers = [
-    "Scheduler",
-    "RenderingFlutterBinding",
-    "PaintingBinding",
-    "SemanticsBinding",
-    "AppBinding (manual)",
-]
+consumers = ["Scheduler", "RenderingFlutterBinding", "SemanticsBinding", "AppBinding (manual)"]
 owner_issue = 553
+notes = "PaintingBinding stopped implementing HasInstance in singleton retirement PR-2 -- impl_binding_singleton!(PaintingBinding) is deleted; the type is now a plain owned value (SharedEngineServices.painting on AppRuntime)."
 
 [[surface]]
 path = "flui_engine::wgpu::Renderer"
@@ -1747,12 +1742,6 @@ contains = "impl_binding_singleton!(Scheduler)"
 owner_issue = 553
 
 [[singleton_exemption]]
-symbol = "impl_binding_singleton!(PaintingBinding)"
-file = "crates/flui-painting/src/binding.rs"
-contains = "impl_binding_singleton!(PaintingBinding)"
-owner_issue = 553
-
-[[singleton_exemption]]
 symbol = "impl_binding_singleton!(SemanticsBinding)"
 file = "crates/flui-semantics/src/binding.rs"
 contains = "impl_binding_singleton!(SemanticsBinding)"
@@ -1800,7 +1789,7 @@ note = "single AppBinding::instance() reach; re-routed through the runtime once 
 file = "crates/flui-app/src/app/runtime.rs"
 grammar = "instance-call"
 owner_issue = 553
-note = "the deliberate resolution seam this file creates: PaintingBinding::instance()/SemanticsBinding::instance()/Scheduler::instance() are called exactly once each, in SharedEngineServices::resolve() and RealmServices::resolve() -- this is the ONE file allowed to still reach for these singletons directly so every other constructor (including UiRealm's) does not have to. Each flips to an owned/injected value as the singleton it names is retired, at which point this entry shrinks accordingly."
+note = "the deliberate resolution seam this file creates: SemanticsBinding::instance()/Scheduler::instance() are called exactly once each, in SharedEngineServices::resolve() and RealmServices::resolve() -- this is the ONE file allowed to still reach for these singletons directly so every other constructor (including UiRealm's) does not have to. PaintingBinding::instance() completed its flip in singleton retirement PR-2: SharedEngineServices.painting is now an owned PaintingBinding value, constructed via PaintingBinding::new(). Each of the remaining two flips to an owned/injected value as the singleton it names is retired (semantics, then the scheduler), at which point this entry shrinks accordingly."
 
 [[ambient_reach]]
 file = "crates/flui-app/src/app/runner.rs"
@@ -1813,18 +1802,6 @@ file = "crates/flui-app/src/bindings/renderer_binding.rs"
 grammar = "instance-call"
 owner_issue = 553
 note = "RenderingFlutterBinding::instance()/AppBinding::instance()/Scheduler::instance() reaches; retired alongside RenderingFlutterBinding, AppBinding, and the Scheduler singleton respectively"
-
-[[ambient_reach]]
-file = "crates/flui-engine/src/wgpu/text.rs"
-grammar = "instance-call"
-owner_issue = 553
-note = "TextRenderer::new constructs a thread-local PaintingBinding via PaintingBinding::instance() to reach the font DB; a SharedFontSystem injection point retires this"
-
-[[ambient_reach]]
-file = "crates/flui-painting/src/binding.rs"
-grammar = "instance-call"
-owner_issue = 553
-note = "PaintingBinding's own instance()-based image_cache() free fn and its tests; retired together with impl_binding_singleton!(PaintingBinding)"
 
 [[ambient_reach]]
 file = "crates/flui-scheduler/src/config.rs"
@@ -1854,7 +1831,7 @@ note = "AssetRegistry::global(): named residual, out of this migration's scope e
 file = "crates/flui-painting/src/text_layout/layout.rs"
 grammar = "ambient-static"
 owner_issue = 553
-note = "shared_font_system()/FONT_SYSTEM: AppRuntime::new() becomes the CONSTRUCTING owner (explicit eager init), but the READ path stays ambient on layout hot paths -- cross-realm register_font staleness mid-layout is a named, bounded hazard (Mutex<FontSystem> makes it staleness not a data race), not closed until fonts get their own owner-local-access/sharding follow-up (ADR-0027 follow-up 6)"
+note = "shared_font_system()/FONT_SYSTEM: SharedEngineServices::resolve() (invoked from AppRuntime::ensure_services() at realm install) is the CONSTRUCTING owner -- it calls PaintingBinding::font_system() explicitly, eagerly installing the process-wide FontSystem instead of leaving it to whichever text-measurement call happens to run first. The READ path stays ambient on layout hot paths -- cross-realm register_font staleness mid-layout is a named, bounded hazard (Mutex<FontSystem> makes it staleness not a data race), not closed until fonts get their own owner-local-access/sharding follow-up (ADR-0027 follow-up 6). Singleton retirement PR-2 additionally re-scoped ICON_FONTS_LOADED (flui-engine/src/wgpu/text.rs) from a process-global flag to a per-FontSystem family-presence check, and gave TextRenderer::new an injected SharedFontSystem parameter instead of an ambient PaintingBinding::instance() reach -- neither changes this entry's hazard, which is specifically about concurrent register_font mutation, not construction-time ownership."
 
 # =============================================================================
 # Public lock-shaped surface allowlist (runtime crates)


### PR DESCRIPTION
Second of six slices for #553 (singleton retirement). This one makes **font/paint state ownership real, not nominal**: the previous slice made service resolution the constructing owner of the font system; this slice removes the painting singleton itself and fixes two latent bugs the ambient model was hiding.

## What lands

- **`impl_binding_singleton!(PaintingBinding)` and the ambient `image_cache()` free fn are deleted** (facade-visible via `flui::app` — breaking, 0.3.0 record). `PaintingBinding` is now a plain value owned by `SharedEngineServices`; its `BindingBase` impl (and the misleading per-construction "initialized" log) is gone. `ImageCache`/`FontSystem` remain deliberately shared across realms — data-plane caches, recorded in the registry.
- **`TextRenderer::new` takes an injected `SharedFontSystem`** (the existing painting type — no new handle invented). This kills a real latent bug: constructing a `TextRenderer` on a raster thread used to silently create a *second thread-local `PaintingBinding`* with a separate font DB. Now closed by construction — `PaintingBinding::instance()` no longer exists anywhere.
- **Icon-font loading is per-family, not single-gated**: the old process-global `ICON_FONTS_LOADED` flag guarded *both* embedded fonts behind one "Material Icons" presence check — a system-installed or user-registered Material face silently skipped CupertinoIcons (tofu). Each embedded font is now probed and loaded independently, under the `FontSystem` mutex (no double-load race), with hermetic regression tests (empty `fontdb`, both families asserted — vacuous-on-CI risk eliminated).
- **`handle_memory_pressure()`/`painting()` on the rendering binding are explicitly inert** — they used to clear a freshly constructed empty cache and log success at INFO. Routing to the runtime-owned painting was rejected because it would mint a new ambient singleton-to-singleton path; the honest no-op (documented, `trace!`) holds until the rendering binding itself is realm-owned (next slices).
- **The ambient-reach ratchet shrinks** (painting entries removed; the bidirectional check enforces it), and a **new mechanical gate bans plan-slice markers** (`PR-1`..`PR-6`, `WU-`) in source comments — with 110 pre-existing occurrences from two old migrations inventoried as named debt in the allowlist (cleanup is a separate trivial PR).

## Verification

- `just ci` green (8562 + 31 tests); clippy `-D warnings` (painting/engine/app); conformance 47 contracts with the new gates active; port-check 22/22; wasm-check; cross-typecheck.
- **Screenshot harness sha256-identical to main** — the font pipeline change is pixel-neutral.
- Red→green live-verified for: the combined-gate icon bug (seeded-face test fails under old shape), the wrong-thread injection, the marker gate (planted/removed), the ratchet shrink (stale-entry failure).
- `cargo public-api` delta recorded in review notes: deletions in flui-painting (`instance`, `image_cache`, `BindingBase` impl), signature change in flui-engine (`TextRenderer::new`), small ripple in flui-app (`RenderingFlutterBinding::painting()` returns owned).

Review trail: combined spec+quality review (found the two correctness bugs above pre-merge) → fix round → narrow re-verification (all items CLOSED, including a spot-check that the marker-gate allowlist is exact to the file and the debt attribution honest).

Next slices: semantics + rendering leaves → AppBinding dissolution → Scheduler realm-ownership (design-note gated) → guard/macro deletion with the two-realm coexistence proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
