### PR TITLE
docs+cli: honesty sweep from the 2026-08-04 audit — devtools truth, ADR-0016 amendment, doc drift, CHANGELOG catch-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,9 +167,12 @@ jobs:
         run: cargo clippy -p flui-engine --all-targets --locked --features enable-wgpu-tests -- -D warnings
 
   # ─────────────────────────────────────────────────────────────────────────
-  # test — workspace build + nextest. Matrix: Linux + Windows.
-  # Gated on `checks`. macOS deferred until the workspace AppKit code is
-  # re-enabled (see CLAUDE.md: many high-level crates disabled in workspace).
+  # test — workspace build + nextest. Matrix: Linux only today (see the
+  # Windows note on `os:` below for why it was dropped; macOS was never
+  # added here). All 28 crates are active — nothing is workspace-disabled.
+  # `cross-typecheck` is the only job touching the AppKit/Win32 backends,
+  # and it only type-checks them (no link, no tests) — see AGENTS.md's CI
+  # Pipeline notes for what that gate does and does not prove.
   # ─────────────────────────────────────────────────────────────────────────
   test:
     name: test (${{ matrix.os }})
@@ -244,13 +247,20 @@ jobs:
 
       # Runs BOTH unit (--lib) and integration (tests/) targets — the
       # integration dirs carry the Core.0/Core.2 exit-gate suites
-      # (flui-rendering 37 files, flui-widgets 51, flui-view 26) and were
-      # previously never executed in CI (the invocation was `--lib` only).
-      # Runs fully parallel: nextest gives each test its own process, so the
-      # flui-app process-global singletons cannot leak across tests, and the
-      # in-process AppBinding/Scheduler races under plain `cargo test` are
-      # serialized by `SINGLETON_WINDOW_TEST_LOCK`/`SCHEDULER_PHASE_TEST_LOCK`
-      # in flui-app. flui-platform tests are excluded until the spawned
+      # (flui-rendering 39 files, flui-widgets 63, flui-view 27 as of
+      # 2026-08-04 — recount if this drifts) and were previously never
+      # executed in CI (the invocation was `--lib` only).
+      # Runs fully parallel: nextest gives each test its own process. The
+      # old process-global singletons (`AppBinding`, singleton `Scheduler`)
+      # this used to guard are fully retired — there is no more shared
+      # binding/scheduler state to race on, and the locks that once
+      # serialized it (`SINGLETON_WINDOW_TEST_LOCK`, `SCHEDULER_PHASE_TEST_LOCK`,
+      # `SEMANTICS_TEST_LOCK`) are deleted along with it; each is a
+      # forbidden-pattern ratchet in docs/runtime-contract.toml now, so a
+      # PR cannot reintroduce the pattern by reintroducing the name. Any
+      # genuinely process-global resource that remains (see AGENTS.md's
+      # Testing Quirks) needs its own explicit test-local lock instead.
+      # flui-platform tests are excluded until the spawned
       # STATUS_HEAP_CORRUPTION investigation lands a fix.
       - name: cargo nextest run (lib + integration)
         run: >
@@ -659,9 +669,10 @@ jobs:
   # painting_demo are workspace members but were only ever compiled for the
   # host target; this checks the wasm-capable set under the real
   # wasm32-unknown-unknown target. The set was verified crate-by-crate before
-  # wiring (27 of 34 packages green); the excluded seven genuinely cannot
-  # target wasm today — see NO_WASM_PKGS. A crate that gains wasm support is
-  # REMOVED from the exclude list, never worked around.
+  # wiring (29 of 36 packages green, as of 2026-08-04 — `cargo metadata
+  # --no-deps` counts packages, recount if this drifts); the excluded seven
+  # genuinely cannot target wasm today — see NO_WASM_PKGS. A crate that
+  # gains wasm support is REMOVED from the exclude list, never worked around.
   # ─────────────────────────────────────────────────────────────────────────
   wasm-check:
     name: wasm-check (wasm32-unknown-unknown)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ them there. What the manifest can't tell you:
 - **Platform:** native Win32, AppKit, and headless backends, with `winit` only as a fallback
 - **Diagnostics:** `tracing` only — **no `println!`, `eprintln!`, or `dbg!` in shipped code** (CI enforces this in foundation/tree/macros crates via port-check trigger #15). *Emitting* is universal; *installing a subscriber* is a composition-root decision that lives in `flui-log` and never in a library
 - **Errors:** `thiserror` (libraries), `anyhow` (applications); panics only per [`docs/PANIC-POLICY.md`](docs/PANIC-POLICY.md) — `expect("BUG: <invariant>")` for internal invariants, never bare `unwrap()` on production paths (`clippy::unwrap_used` gates this)
-Of the crate roots, `crates/flui-rendering/src/lib.rs` is by far the densest — budget accordingly.
+`crates/flui-rendering/src/lib.rs` itself is a thin 220-line root — density lives deeper in the tree: `pipeline/owner/subtree_arena.rs` (~2.5k lines), `protocol/sliver_protocol.rs` (~1.9k), `storage/tree.rs` (~1.8k), and `protocol/box_protocol.rs` (~1.8k) are the densest files; budget accordingly.
 
 ## Build & Development Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,75 @@ file records the repo-consumer-visible summary.
 
 ### Added
 
+- **Runtime.1 conformance registry and public-API freeze gate** (#576):
+  `docs/runtime-conformance.toml` is the machine-readable inventory of every
+  normative ADR-0027/0037/0029/0039 clause (state verified against current
+  code, evidence or an owning issue) and of every public runtime/platform/
+  scheduler/raster surface, with a stability classification (stable-candidate
+  / experimental / transitional / removal-target), thread affinity, actual
+  owner, and failure semantics. `scripts/check-runtime-conformance.sh`
+  validates citation existence, evidence rules (documentation is never
+  implementation evidence), forbidden retired identifiers, and registration
+  nets for ambient singletons and SP-6 lock exemptions. Wired as
+  `just runtime-conformance-check`, into `just ci`, and into CI's `checks`
+  gate.
+- **Generational presentation addressing** (#585): every frame is now
+  addressed by `PresentationAddress` (`realm_id` + `presentation_id`,
+  promoted to `flui-foundation`) instead of a bare `presentation_id`, since
+  two different `UiRealm` incarnations can mint an identical `PresentationId`
+  and only the full pair disambiguates a frame's owner. `PlatformWindow::id()`
+  gives every window a stable identity; `SceneSnapshot` and every
+  `RasterAck`/`PumpOutcome` variant (now individually `#[non_exhaustive]`)
+  carry the full address; `RasterOwner` rejects a submit whose address
+  doesn't match (`RasterSubmitError::AddressMismatch`) instead of accepting
+  it on a partial (`presentation_id`-only) match. `WindowRegistry` is
+  flui-app's sole native-window-to-presentation map. A new coalesced
+  `SurfaceState` slot carries `SurfaceOutdated`/`DeviceLost` outside the
+  lossy telemetry ack channel, since both are recovery-critical.
+- **`OwnerPlatform` capability and typed owner-lane proxy** (#577, ADR-0039
+  slice 2): `OwnerPlatform` (a `!Send + !Sync` owner-thread capability,
+  minted only by a backend) and `PlatformProxy` (a `Clone + Send + Sync`
+  cross-thread request capability) replace the ambient `&dyn Platform` every
+  backend's `on_ready` used to hand out — the old shape stayed fully
+  `Send + Sync` until a later trait split, so safe code on another thread
+  could call an owner-affine method through it. `flui-foundation`'s new
+  `ClaimSlot<T>`/`ClaimHandle<T>` (`Pending` → `Delivered` → `Claimed`, plus
+  an `OwnerGone` terminal state and a `Future` impl) back `PendingWindow`'s
+  at-most-once open-window reply, closing a window-leak-on-drop gap in the
+  winit owner lane. `Platform::run` and its `on_ready` callback are now
+  fallible (`anyhow::Result<()>`), so a bootstrap failure (window creation,
+  GPU init, root-widget attach) stops the loop on every backend instead of
+  running with no UI. `SharedPlatform` is the `Clone + Send + Sync`-safe
+  residual of `Platform` a proxy can actually hold across threads.
+- **Feature-selective facade, Material-first** (#574): `flui-material`
+  (default), `flui-cupertino`, and the newly exposed `flui-localizations` are
+  optional dependencies behind their own facade features; a module whose
+  feature is off is absent from the graph, not an empty stub. `flui-hot-reload`
+  leaves the production graph — optional in `flui-app` behind `hot-reload`,
+  asserted absent from `flui-app`'s default `cargo tree` rather than assumed.
+  `flui-binding` is renamed to `flui-testing` (directory moved with history;
+  `HeadlessBinding` keeps its name). `flui-app::theme` (`AppTheme`/
+  `AppColorScheme`) is deleted outright per ADR-0042 — theming belongs to the
+  design system (`ThemeMode` on `flui-material`'s `MaterialApp`), not the app
+  framework. `just facade-combos` compiles each supported facade combination
+  in isolation against `flui` alone, since a `--workspace` build proves
+  nothing about the facade surface (feature unification would turn a broken
+  combination green).
+- **`flui-log` restored as a standalone, composition-only logging backend**
+  (#571): `flui-foundation` no longer installs a process-global tracing
+  subscriber (libraries emit through `tracing` only); `flui-log`'s
+  three-outcome `SubscriberOwnership` (`Inherit`/`Auto`/`Install`) makes
+  ownership explicit and never panics on an already-owned slot, replacing an
+  `init()` that used to panic the moment a host process already owned one.
+  Fixes three real defects found while restoring it: a stray `LevelFilter`
+  ceiling that silently discarded events `RUST_LOG` had just selected, an
+  illegal Apple subsystem identifier synthesized from an arbitrary app
+  display name, and a logcat field-renderer separator that never fired when
+  the message arrived first — untested because its tests lived inside a
+  `cfg(target_os = "android")` island that never compiled anywhere.
+  `docs/workspace-layers.toml` gains `allowed_dependents`, so a normal edge
+  into `flui-log` from anything but `flui-app`, `flui-cli`, or the facade now
+  fails `just inventory-check`.
 - **`cargo-deny` CI job** (merge-blocking): the in-repo `deny.toml` was never
   executed in CI; the first wired run surfaced four real advisories —
   `anyhow` 1.0.102 unsound `downcast_mut` (RUSTSEC-2026-0190),
@@ -37,6 +106,20 @@ file records the repo-consumer-visible summary.
 
 ### Changed
 
+- **Four miri-confirmed UB paths closed in the Android page-aligned
+  allocator** (#584): `Drop` recomputed the dealloc layout as
+  `capacity * size_of::<T>()`, which undershoots the real page-rounded
+  allocation whenever `size_of::<T>()` doesn't evenly divide it — now stores
+  the allocated byte size verbatim and reuses it. Zero-capacity construction
+  and zero-sized `T` both reached the global allocator with a zero-size
+  `Layout` (the former now uses a non-null dangling pointer instead of
+  allocating; the latter is now a compile-time assertion). Separately,
+  `alloc_page_aligned`'s rounding arithmetic could wrap to zero under
+  release's `overflow-checks = false`, reaching the allocator with a
+  zero-size `Layout` for a large enough request — now checked, returning
+  `Err` instead of wrapping. All four verified by replicating the auditor's
+  scratch-crate `cargo +nightly miri test` harness: reproduces the original
+  UB before the fix, clean after.
 - **Toolchain 1.96.1 → 1.97.1, MSRV 1.96 → 1.97.** `rust-toolchain.toml` no
   longer mirrors the MSRV: it is now explicitly the *development* toolchain
   (a pin at the floor hides new lints and codegen changes from the developer
@@ -130,6 +213,44 @@ file records the repo-consumer-visible summary.
   by a new drift guard in `scripts/check-workspace-inventory.sh`.
 - `flui-assets` restored to `[workspace] members` — it is built and tested by
   CI again.
+
+### Removed
+
+- **Singleton retirement, completed in six PRs (#586–#593).** `flui-app`'s
+  process-global service host — `AppBinding`, plus its `WidgetsFlutterBinding`
+  alias — is deleted outright, not deprecated, along with
+  `flui-foundation`'s `impl_binding_singleton!` macro and the
+  `HasInstance`/`BindingBase` trait pair, `SemanticsBinding`, and the
+  `PaintingBinding`/`Scheduler` singleton `::instance()` accessors. Ownership
+  moves to where it should have lived all along: `AppRuntime` (loop-scoped:
+  wake, clipboard), `UiRealm`/`PresentationState` (realm/presentation-scoped:
+  renderer, vsync, frame counters, haptics, and semantics fan-out through a
+  new per-presentation `SemanticsHost`), and a `WeakScheduler`-backed
+  `Scheduler` owned fresh per realm — the weak handle breaks the
+  `scheduler → transient queue → ticker closure → scheduler` `Arc` cycle
+  that used to leak every active ticker for the scheduler's whole lifetime.
+  `UiRealm`'s transitional at-most-one-construction guard
+  (`REALM_CLAIMED`, `UiRealmError::AlreadyExists`) — which existed only
+  because `UiRealm` used to front that process-global state — is deleted
+  too; four new tests prove actual realm coexistence (independent mounts,
+  scheduler phases, and gesture arenas, including across two threads and
+  across a `GlobalKey` collision in two different realms) rather than
+  merely the absence of the deleted guard. The test locks this family
+  needed — `SINGLETON_WINDOW_TEST_LOCK`, `SCHEDULER_PHASE_TEST_LOCK`,
+  `SEMANTICS_TEST_LOCK` — are gone along with the state they serialized;
+  each is now a `forbidden_pattern` ratchet in `docs/runtime-contract.toml`
+  so a PR cannot reintroduce the pattern by reintroducing the name.
+
+  **Breaking (pre-1.0, sanctioned):** `flui_app::{AppBinding,
+  WidgetsFlutterBinding}` and the `flui::app` facade re-export of both are
+  gone; `crates/flui-foundation/src/binding.rs` (`BindingBase`,
+  `HasInstance`, `impl_binding_singleton!`) is deleted wholesale;
+  `SemanticsBinding` is deleted, not slimmed. `run_app`/
+  `run_app_with_config`/`run_direct` signatures are unchanged — this is an
+  internal-ownership change, not a public entry-point break. Recorded here
+  as the semver trigger for a `0.2.0` → `0.3.0` bump once this workspace is
+  published; no git tag is cut by this entry (release-lead's call, separate
+  from this changelog sweep).
 
 ### Pre-changelog milestones
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,8 @@ file records the repo-consumer-visible summary.
   feature is off is absent from the graph, not an empty stub. `flui-hot-reload`
   leaves the production graph — optional in `flui-app` behind `hot-reload`,
   asserted absent from `flui-app`'s default `cargo tree` rather than assumed.
-  `flui-binding` is renamed to `flui-testing` (directory moved with history;
-  `HeadlessBinding` keeps its name). `flui-app::theme` (`AppTheme`/
+  The workspace's test-support crate is renamed to `flui-testing` (directory
+  moved with history; `HeadlessBinding` keeps its name). `flui-app::theme` (`AppTheme`/
   `AppColorScheme`) is deleted outright per ADR-0042 — theming belongs to the
   design system (`ThemeMode` on `flui-material`'s `MaterialApp`), not the app
   framework. `just facade-combos` compiles each supported facade combination

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ file records the repo-consumer-visible summary.
 ### Added
 
 - **Runtime.1 conformance registry and public-API freeze gate** (#576):
-  `docs/runtime-conformance.toml` is the machine-readable inventory of every
+  `docs/runtime-contract.toml` is the machine-readable inventory of every
   normative ADR-0027/0037/0029/0039 clause (state verified against current
   code, evidence or an owning issue) and of every public runtime/platform/
   scheduler/raster surface, with a stability classification (stable-candidate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,7 +254,7 @@ regex = "1"
 # - lyon (tessellation)
 # - guillotiere (texture atlas)
 
-# CACHING - Used by flui_core and flui-assets
+# CACHING - Used by flui-assets
 moka = { version = "0.12", features = ["future"] }
 
 # NETWORKING - Used by flui-assets

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ driver.
 - **GPU-first rendering.** `wgpu` 29.x backend with `lyon` tessellation and `cosmic-text` / `glyphon` for high-quality text.
 - **Cross-platform.** Native Win32 and AppKit backends, headless mode for CI, Android NDK target, WASM/WebGPU, plus a `winit` fallback.
 - **Hot-reload scenes.** `dlopen`-based plugin host (`flui-hot-reload`) for desktop iteration without process restarts.
-- **Strict architecture.** Layered crate DAG with no upward edges. `unsafe` is confined to `flui-platform`, `flui-painting`, `flui-engine`. Constitution-mandated and reviewed at the workspace level.
+- **Strict architecture.** Layered crate DAG with no upward edges. `unsafe` is *not* confined to a fixed crate list — it concentrates wherever a crate touches an FFI or ABI boundary. By unsafe-site count in `src/` (`rg -c '\bunsafe\s+(fn|impl|trait|extern)\b|\bunsafe\s*\{'`, measured 2026-08-04): `flui-platform` (Win32/AppKit/Android FFI) dominates by a wide margin, followed by `flui-rendering` (a miri-audited arena, `subtree_arena.rs`), `flui-hot-reload` (the `dlopen` ABI boundary), and `flui-engine` (wgpu/raw-window-handle FFI); smaller counts exist in `flui-layer`, `flui-foundation`, `flui-types`, `flui-log`, `flui-view`, and `flui-app`. `flui-painting` carries zero unsafe code today. Reviewed at the workspace level — see `docs/PANIC-POLICY.md` and each crate's `ARCHITECTURE.md`.
 
 ## Hello World
 

--- a/crates/flui-animation/src/vsync.rs
+++ b/crates/flui-animation/src/vsync.rs
@@ -210,7 +210,7 @@ impl Vsync {
 
     /// Whether at least one registered controller is currently running.
     ///
-    /// Used by a production frame driver (e.g. `AppBinding`) to decide whether
+    /// Used by a production frame driver (e.g. `flui-app`'s `UiRealm`) to decide whether
     /// to request the next frame: call this after [`tick_all`](Self::tick_all)
     /// and, if `true`, schedule a wake so the frame loop keeps going. Once the
     /// last running controller completes, `has_running()` returns `false` and

--- a/crates/flui-app/Cargo.toml
+++ b/crates/flui-app/Cargo.toml
@@ -16,6 +16,16 @@ crate-type = ["rlib"]
 default = ["desktop"]
 
 # === Platform Features ===
+# Honest note (verified 2026-08-04): these four are no-op selectors today —
+# `rg 'feature\s*=\s*"(desktop|android|ios|web)"' crates/flui-app/src` has
+# zero hits. Platform dispatch in this crate is `#[cfg(target_os = "...")]`
+# on the actual target, not one of these flags; enabling or disabling any of
+# them changes nothing observable. They exist as forward-compatible names for
+# downstream `Cargo.toml`s to opt into (e.g. `default-features = false,
+# features = ["desktop"]`) if/when this crate grows real per-platform gating,
+# and `desktop` staying default keeps that future migration additive. Do not
+# assume enabling one of these turns on platform-specific code — check the
+# actual `#[cfg(target_os = ...)]` gates for that.
 desktop = []
 android = []
 ios = []
@@ -32,6 +42,14 @@ web = []
 hot-reload = ["dep:flui-hot-reload"]
 
 # === Debug Features ===
+# Honest note (verified 2026-08-04): also no-op selectors — zero
+# `feature = "debug-overlay"` / `feature = "performance-overlay"` references
+# in this crate's src. There is one runtime toggle for this, not two:
+# `AppConfig::show_performance_overlay` (`app/config.rs`), which `runner.rs`
+# also calls "the debug overlay" in comments — it is the same overlay under
+# both names, controlled entirely at runtime, not by either compile-time
+# feature. Kept for the same forward-compatible-name reason as the platform
+# features above.
 debug-overlay = []
 performance-overlay = []
 

--- a/crates/flui-app/src/embedder/mod.rs
+++ b/crates/flui-app/src/embedder/mod.rs
@@ -3,11 +3,11 @@
 //! # Architecture
 //!
 //! ```text
-//! Platform callbacks → entered UiRealm + transitional AppBinding
+//! Platform callbacks → entered UiRealm
 //!   ├── UiRealm::GestureBinding (pointer events + hit testing)
 //!   ├── UiRealm::FocusManager (keyboard events)
 //!   ├── UiRealm::WidgetsBinding (build phase)
-//!   ├── AppBinding::RenderPipelineOwner (layout/paint)
+//!   ├── PresentationState::PipelineOwner (layout/paint)
 //!   └── Renderer (GPU rendering, owned by runner callback)
 //! ```
 //!

--- a/crates/flui-assets/README.md
+++ b/crates/flui-assets/README.md
@@ -283,6 +283,5 @@ at your option.
 
 ## Related Crates
 
-- [`flui_types`](../flui_types) - Core types for FLUI
-- [`flui_core`](../flui_core) - FLUI framework core
-- [`flui_painting`](../flui_painting) - 2D graphics API
+- [`flui-types`](../flui-types) - Core types for FLUI
+- [`flui-painting`](../flui-painting) - 2D graphics API

--- a/crates/flui-cli/Cargo.toml
+++ b/crates/flui-cli/Cargo.toml
@@ -23,9 +23,10 @@ path = "src/main.rs"
 flui-build = { path = "../flui-build", version = "0.2.0" }
 flui-hot-reload = { path = "../flui-hot-reload", version = "0.2.0", features = ["source-watch"] }
 
-# Async runtime — `run` blocks on the async build/push pipeline via a
-# multi-thread `Runtime`; `signal` backs the devtools server's Ctrl+C wait.
-tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
+# Async runtime — `run` blocks on the async Android build/push pipeline via
+# a multi-thread `Runtime`. There is no `devtools` server (see
+# commands/devtools.rs), so no `signal` feature is needed here.
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 # Logging backend. The CLI chooses and installs its own subscriber policy and
 # reuses flui-log's backend construction; it is a composition root, so this

--- a/crates/flui-cli/src/commands/devtools.rs
+++ b/crates/flui-cli/src/commands/devtools.rs
@@ -4,7 +4,7 @@
 //! one, regardless of the `devtools` feature. Both paths below say so
 //! honestly and name what `flui-devtools` actually offers as a library
 //! today: `InspectorCounters` (mount/rebuild/unmount tallies over the
-//! ADR-0040 observation seam) plus opt-in `profiler`/`timeline`/`hot_reload`
+//! framework's observation seam) plus opt-in `profiler`/`timeline`/`hot_reload`
 //! modules an embedder wires up manually. See `crates/flui-devtools/FEATURES.md`.
 
 #[cfg(feature = "devtools")]
@@ -46,7 +46,7 @@ fn report_not_implemented(port: u16) -> CliResult<()> {
         "`flui-devtools` exists as a library with feature-gated subsystems \
          the CLI does not wire up:",
         "- inspector: InspectorCounters — mount/rebuild/unmount tallies \
-         over the ADR-0040 observation seam",
+         over the framework observation seam",
         "- profiling: Profiler — frame/phase timing, jank detection",
         "- timeline: Timeline — Chrome-trace event export",
         "- hot-reload: HotReloader — file-watch callbacks",
@@ -77,10 +77,11 @@ fn show_unavailable_message(_port: u16) -> CliResult<()> {
     let instructions = format!(
         "{}\n\n  {}\n\n{}",
         "To use `flui-devtools`' library subsystems (inspector counters, \
-         profiler, timeline, hot-reload), rebuild flui-cli with the \
-         devtools feature — note this does not add a DevTools server:",
-        style("cargo install flui-cli --features devtools").cyan(),
-        style("DevTools requires the flui-devtools crate.").dim(),
+         profiler, timeline, hot-reload), add the crate to your app and \
+         wire the subsystems you need — the CLI's `devtools` feature only \
+         links the library and adds no server or wiring:",
+        style("cargo add flui-devtools --features profiling,timeline").cyan(),
+        style("See crates/flui-devtools/FEATURES.md for the real API.").dim(),
     );
 
     cliclack::note("Setup Instructions", instructions)?;

--- a/crates/flui-cli/src/commands/devtools.rs
+++ b/crates/flui-cli/src/commands/devtools.rs
@@ -1,69 +1,82 @@
-//! `DevTools` command for launching the FLUI development tools.
+//! `DevTools` command for the FLUI development tools.
 //!
-//! When the `devtools` feature is enabled, launches the `DevTools` server.
-//! When disabled, displays instructions on how to enable it.
+//! There is no `DevTools` server to launch — this command has never started
+//! one, regardless of the `devtools` feature. Both paths below say so
+//! honestly and name what `flui-devtools` actually offers as a library
+//! today: `InspectorCounters` (mount/rebuild/unmount tallies over the
+//! ADR-0040 observation seam) plus opt-in `profiler`/`timeline`/`hot_reload`
+//! modules an embedder wires up manually. See `crates/flui-devtools/FEATURES.md`.
 
-use crate::error::CliResult;
+use crate::error::{CliError, CliResult};
 use console::style;
 
 /// Execute the devtools command.
 ///
-/// Behavior depends on whether the `devtools` feature is compiled in:
-/// - **Enabled**: Launches the `DevTools` server on the specified port.
-/// - **Disabled**: Displays instructions for enabling the feature.
+/// Neither build reaches a running server: with the `devtools` feature
+/// compiled in this reports what `flui-devtools` provides as a library and
+/// returns [`CliError::NotImplemented`] (nonzero exit); without it, this
+/// shows the same message plus the build instruction.
 pub fn execute(port: u16) -> CliResult<()> {
     cliclack::intro(style(" flui devtools ").on_green().black())?;
 
     #[cfg(feature = "devtools")]
     {
-        launch_devtools_server(port)?;
+        report_not_implemented(port)
     }
 
     #[cfg(not(feature = "devtools"))]
     {
-        show_unavailable_message(port)?;
+        show_unavailable_message(port)
     }
-
-    Ok(())
 }
 
-/// Launch the DevTools server (only compiled when devtools feature is enabled).
+/// Report honestly that no DevTools server exists, and name what
+/// `flui-devtools` actually provides as a library (only compiled when the
+/// `devtools` feature is available).
 #[cfg(feature = "devtools")]
-fn launch_devtools_server(port: u16) -> CliResult<()> {
-    // Check if port is already in use.
-    check_port_available(port)?;
-
-    cliclack::log::info(format!(
-        "DevTools server started on {}",
-        style(format!("http://localhost:{port}"))
-            .cyan()
-            .underlined()
+fn report_not_implemented(port: u16) -> CliResult<()> {
+    cliclack::log::warning(format!(
+        "DevTools server is not implemented — no listener opens on port {port}."
     ))?;
-    cliclack::log::info("Press Ctrl+C to stop")?;
 
-    // TODO: Call flui_devtools::start_server(port) when the crate API is available.
-    // For now, block until Ctrl+C.
-    tracing::info!(port, "DevTools server listening");
+    let available = format!(
+        "{}\n\n  {}\n  {}\n  {}\n  {}\n\n{}",
+        "`flui-devtools` exists as a library with feature-gated subsystems \
+         the CLI does not wire up:",
+        "- inspector: InspectorCounters — mount/rebuild/unmount tallies \
+         over the ADR-0040 observation seam",
+        "- profiling: Profiler — frame/phase timing, jank detection",
+        "- timeline: Timeline — Chrome-trace event export",
+        "- hot-reload: HotReloader — file-watch callbacks",
+        style(
+            "An embedder wires these in directly today; there is no \
+             CLI-launched server. See crates/flui-devtools/FEATURES.md."
+        )
+        .dim(),
+    );
+    cliclack::note("What actually exists", available)?;
+    cliclack::outro(style("DevTools server not implemented").red())?;
 
-    // Block on Ctrl+C via tokio's signal driver (same runtime idiom as `run`).
-    let rt = tokio::runtime::Runtime::new()?;
-    rt.block_on(async {
-        if let Err(e) = tokio::signal::ctrl_c().await {
-            tracing::warn!("Failed to listen for Ctrl+C: {e}");
-        }
-    });
-    cliclack::outro("DevTools server stopped")?;
-    Ok(())
+    tracing::info!(port, "flui devtools: no server implementation to launch");
+
+    Err(CliError::not_implemented("flui devtools server"))
 }
 
-/// Show a message when devtools feature is not available.
+/// Show a message when the `devtools` feature is not compiled in.
+///
+/// Note: enabling the feature does not change the outcome — see
+/// [`report_not_implemented`], which this build does not compile. There is
+/// no server to gain access to; this only unlocks `flui-devtools` as a
+/// library dependency.
 #[cfg(not(feature = "devtools"))]
 fn show_unavailable_message(_port: u16) -> CliResult<()> {
     cliclack::log::warning("DevTools is not available in this build.")?;
 
     let instructions = format!(
         "{}\n\n  {}\n\n{}",
-        "To enable DevTools, rebuild flui-cli with the devtools feature:",
+        "To use `flui-devtools`' library subsystems (inspector counters, \
+         profiler, timeline, hot-reload), rebuild flui-cli with the \
+         devtools feature — note this does not add a DevTools server:",
         style("cargo install flui-cli --features devtools").cyan(),
         style("DevTools requires the flui-devtools crate.").dim(),
     );
@@ -72,23 +85,4 @@ fn show_unavailable_message(_port: u16) -> CliResult<()> {
     cliclack::outro(style("DevTools not enabled").dim())?;
 
     Ok(())
-}
-
-/// Check if a TCP port is available for binding.
-#[cfg(feature = "devtools")]
-fn check_port_available(port: u16) -> CliResult<()> {
-    use std::net::TcpListener;
-
-    if let Ok(_listener) = TcpListener::bind(("127.0.0.1", port)) {
-        // Port is available — the listener is dropped here, freeing the port.
-        Ok(())
-    } else {
-        cliclack::log::error(format!(
-            "Port {port} is already in use. Try a different port with --port <PORT>"
-        ))?;
-        Err(crate::error::CliError::build_failed(
-            "devtools",
-            format!("Port {port} is already in use"),
-        ))
-    }
 }

--- a/crates/flui-cli/src/commands/devtools.rs
+++ b/crates/flui-cli/src/commands/devtools.rs
@@ -16,7 +16,7 @@ use console::style;
 ///
 /// Neither build reaches a running server: with the `devtools` feature
 /// compiled in this reports what `flui-devtools` provides as a library and
-/// returns [`CliError::NotImplemented`] (nonzero exit); without it, this
+/// returns `CliError::NotImplemented` (nonzero exit); without it, this
 /// shows the same message plus the build instruction.
 pub fn execute(port: u16) -> CliResult<()> {
     cliclack::intro(style(" flui devtools ").on_green().black())?;
@@ -67,7 +67,7 @@ fn report_not_implemented(port: u16) -> CliResult<()> {
 /// Show a message when the `devtools` feature is not compiled in.
 ///
 /// Note: enabling the feature does not change the outcome — see
-/// [`report_not_implemented`], which this build does not compile. There is
+/// `report_not_implemented`, which this build does not compile. There is
 /// no server to gain access to; this only unlocks `flui-devtools` as a
 /// library dependency.
 #[cfg(not(feature = "devtools"))]

--- a/crates/flui-cli/src/commands/devtools.rs
+++ b/crates/flui-cli/src/commands/devtools.rs
@@ -7,7 +7,9 @@
 //! ADR-0040 observation seam) plus opt-in `profiler`/`timeline`/`hot_reload`
 //! modules an embedder wires up manually. See `crates/flui-devtools/FEATURES.md`.
 
-use crate::error::{CliError, CliResult};
+#[cfg(feature = "devtools")]
+use crate::error::CliError;
+use crate::error::CliResult;
 use console::style;
 
 /// Execute the devtools command.

--- a/crates/flui-devtools/FEATURES.md
+++ b/crates/flui-devtools/FEATURES.md
@@ -4,7 +4,7 @@
 
 ### 1. 🎯 Performance Profiler
 **Status**: ✅ Complete  
-**File**: `src/profiler.rs` (543 lines)
+**File**: `src/profiler.rs` (614 lines)
 
 **Capabilities**:
 - Frame-level performance tracking
@@ -31,35 +31,46 @@ let stats = profiler.frame_stats();
 
 ---
 
-### 2. 🔍 Widget Inspector  
-**Status**: ✅ Complete  
-**File**: `src/inspector.rs` (437 lines)
+### 2. 🔎 Inspector Counters
+**Status**: ✅ Complete — but not a tree inspector (see below)
+**File**: `src/inspector.rs` (181 lines)
+**Feature Flag**: `inspector`
+
+This is a counting/logging [`TreeObserver`] over the ADR-0040 observation
+seam, not a widget-tree inspector. It has no access to the widget, element,
+or render trees — only `flui-foundation` on its dependency list (dependency
+inversion) — and cannot select, highlight, or walk widgets.
 
 **Capabilities**:
-- Widget tree inspection
-- Element information extraction
-- Tree visualization (`WidgetTreeNode`)
-- Widget highlighting for debugging
-- Type-based widget search
-- Root-to-widget path calculation
-- Thread-safe with `Arc<RwLock<>>`
+- Tallies element mounts, moves, rebuilds (per [`RebuildReason`](https://docs.rs/flui-foundation) cause), and unmounts as a running realm mutates
+- Point-in-time [`InspectorSnapshot`] with per-counter monotonicity (no cross-counter consistency guarantee)
+- Detects stream end (`detached()`) so a snapshot can report whether the observation stream is final
+- Thread-safe via private atomics — no lock in the public surface (SP-6)
 
 **API**:
 ```rust
-let inspector = Inspector::new();
-inspector.attach_to_tree(tree);
-let info = inspector.select_widget(id);
-let tree = inspector.get_widget_tree();
-inspector.highlight_widget(id);
+use flui_devtools::inspector::InspectorCounters;
+
+let counters = InspectorCounters::new();
+// Install via WidgetsBinding::install_tree_observer(Arc::new(counters.clone()))
+// or hold `&counters` as a `&dyn TreeObserver` for direct dispatch.
+let snapshot = counters.snapshot();
+println!("mounts: {}, rebuilds: {}", snapshot.mounts, snapshot.rebuilds);
 ```
 
-**Tests**: 4 tests for creation, attachment, highlighting
+**Tests**: 1 test covering mount/move/rebuild/unmount tallying, per-reason
+counts, and the detached flag.
+
+**What this is NOT**: there is no `WidgetTreeNode`, no `select_widget`,
+`get_widget_tree`, `highlight_widget`, or `find_widgets_by_type` — those
+APIs never existed. Pull-shaped inspection (walking a live tree) waits on a
+future seam; see `src/lib.rs`'s crate-level docs for the current boundary.
 
 ---
 
 ### 3. ⏱️ Timeline View
 **Status**: ✅ Complete  
-**File**: `src/timeline.rs` (496 lines)
+**File**: `src/timeline.rs` (619 lines)
 
 **Capabilities**:
 - Timeline event recording
@@ -82,13 +93,13 @@ let json = timeline.export_chrome_trace();
 
 **Chrome Trace Format**: Compatible with `chrome://tracing` for visualization
 
-**Tests**: 7 tests for recording, categories, exports, thread safety
+**Tests**: 11 tests for recording, categories, exports, thread safety
 
 ---
 
 ### 4. 🔥 Hot Reload
 **Status**: ✅ Complete  
-**File**: `src/hot_reload.rs` (315 lines)  
+**File**: `src/hot_reload.rs` (202 lines)  
 **Feature Flag**: `hot-reload`
 
 **Capabilities**:
@@ -109,7 +120,7 @@ reloader.on_change(|path| {
 let _handle = reloader.watch_async();
 ```
 
-**Tests**: 5 tests for creation, watching, callbacks, async/blocking
+**Tests**: 4 tests for creation, watching, callbacks, stop
 
 ---
 
@@ -118,66 +129,27 @@ let _handle = reloader.watch_async();
 | Module | Lines of Code | Tests | Status |
 |--------|--------------|-------|--------|
 | **common.rs** | 91 | - | ✅ |
-| **profiler.rs** | 543 | 7 | ✅ |
-| **inspector.rs** | 437 | 4 | ✅ |
-| **timeline.rs** | 496 | 7 | ✅ |
-| **hot_reload.rs** | 315 | 5 | ✅ |
-| **lib.rs** | 182 | 1 | ✅ |
-| **Total** | **2,064 LOC** | **24 tests** | ✅ |
+| **profiler.rs** | 614 | 7 | ✅ |
+| **inspector.rs** | 181 | 1 | ✅ |
+| **timeline.rs** | 619 | 11 | ✅ |
+| **hot_reload.rs** | 202 | 4 | ✅ |
+| **lib.rs** | 139 | 1 | ✅ |
+| **Total** | **1,846 LOC** | **24 tests** | ✅ |
+
+Counted directly from `src/*.rs` (`wc -l`, `rg -c '#\[test\]'`) — re-run
+those if this table drifts again; nothing enforces it mechanically.
 
 ---
 
-## 🚀 Future Features (TODO)
+## 🚫 Not Implemented
 
-### 5. 🌐 Network Monitor
-**Feature Flag**: `network-monitor`  
-**Status**: TODO
-
-Planned capabilities:
-- HTTP request/response tracking
-- Request timing (DNS, Connect, TLS, Transfer)
-- Response size analysis
-- Header inspection
-- WebSocket monitoring
-
----
-
-### 6. 💾 Memory Profiler
-**Feature Flag**: `memory-profiler`  
-**Status**: TODO
-
-Planned capabilities:
-- Heap allocation tracking (using `dhat`)
-- Memory usage over time
-- Leak detection
-- Allocation flamegraphs
-- Widget memory footprint
-
----
-
-### 7. 🔌 Remote Debug Server
-**Feature Flag**: `remote-debug`  
-**Status**: TODO
-
-Planned capabilities:
-- WebSocket-based debugging protocol
-- Browser DevTools integration
-- Remote widget inspection
-- Live profiling data streaming
-- Command execution (rebuild, clear cache, etc.)
-
----
-
-### 8. 📝 Tracing Support
-**Feature Flag**: `tracing-support`  
-**Status**: TODO
-
-Planned capabilities:
-- Integration with `tracing` crate
-- Structured logging
-- Span-based profiling
-- Log level filtering
-- Custom subscribers
+Earlier revisions of this document (and the crate README) advertised a
+network monitor, memory profiler, remote-debug server, and a
+`tracing-support` feature. **None of these were ever implemented** — there
+is no corresponding module, no `Cargo.toml` feature flag, and no such
+capability behind `full`. `src/lib.rs`'s crate-level docs are the current
+source of truth for what exists; treat any capability not listed there as
+fictional until it has a module and a feature flag to match.
 
 ---
 
@@ -193,8 +165,11 @@ Planned capabilities:
    - No data races
 
 3. **Feature Gated**: Optional features don't bloat the binary
-   - Default features: `profiling`, `inspector`
-   - Optional: `timeline`, `hot-reload`, etc.
+   - Default features: none (`default = []`) — a release build with no
+     features enabled compiles zero devtools code, opens no port, and runs
+     no background work
+   - Opt in per-feature: `profiling`, `timeline`, `hot-reload`, `inspector`;
+     `full` enables all four
 
 4. **Ergonomic API**: Easy to use, hard to misuse
    - RAII guards (PhaseGuard, EventGuard, WatchHandle)
@@ -209,18 +184,21 @@ Planned capabilities:
 
 ## 📦 Dependencies
 
-### Core Dependencies
-- `flui_core` - Integration with FLUI framework
-- `instant` - Cross-platform timing
-- `serde`, `serde_json` - Serialization
-- `parking_lot` - Fast locks
-- `dashmap` - Concurrent HashMap
+Read straight from `Cargo.toml` — no fictional entries.
 
-### Feature Dependencies
-- `notify` - File watching (hot-reload)
-- `tokio`, `tokio-tungstenite` - Async runtime (network-monitor, remote-debug)
-- `dhat` - Memory profiling (memory-profiler)
-- `tracing`, `tracing-subscriber` - Logging (tracing-support)
+### Unconditional
+- `web-time` - Cross-platform timing (the maintained replacement for `instant`)
+- `serde`, `serde_json` - Serialization (devtools protocol payloads)
+- `parking_lot` - Fast locks
+- `windows-sys` (Windows only) - process/memory info
+
+### Feature-gated
+- `flui-hot-reload` (feature `hot-reload`, via its `source-watch` feature) - underlying file watcher (`SourceWatcher`)
+- `flui-foundation` + `tracing` (feature `inspector`) - `TreeObserver`/`RebuildReason` types and debug-level event logging
+
+There is no `flui_core` (that crate has never existed in this workspace —
+see `docs/crates.md`), no `dashmap`, and no `dhat`/`tokio-tungstenite`
+pulled in for features that were never built.
 
 ---
 
@@ -234,8 +212,8 @@ All modules have comprehensive test coverage:
 
 Run tests:
 ```bash
-cargo test -p flui_devtools
-cargo test -p flui_devtools --all-features
+cargo test -p flui-devtools
+cargo test -p flui-devtools --all-features
 ```
 
 ---
@@ -254,13 +232,14 @@ cargo test -p flui_devtools --all-features
 | Feature | Flutter DevTools | FLUI DevTools | Status |
 |---------|-----------------|---------------|--------|
 | Performance Profiler | ✅ | ✅ | Complete |
-| Widget Inspector | ✅ | ✅ | Complete |
+| Widget Inspector (tree walk/select/highlight) | ✅ | ❌ | Not implemented |
+| Inspector counters (mount/rebuild/unmount tallies) | — | ✅ | Complete |
 | Timeline View | ✅ | ✅ | Complete |
-| Memory Profiler | ✅ | ⏳ | TODO |
-| Network Monitor | ✅ | ⏳ | TODO |
-| Debugger | ✅ | ⏳ | TODO |
-| Logging | ✅ | ⏳ | TODO |
-| Hot Reload | ✅ | ✅ | Complete |
+| Memory Profiler | ✅ | ❌ | Not implemented, not planned |
+| Network Monitor | ✅ | ❌ | Not implemented, not planned |
+| Debugger | ✅ | ❌ | Not implemented, not planned |
+| Logging | ✅ | ❌ | Not implemented, not planned |
+| Hot Reload | ✅ | ✅ | Complete (file-watch only; no state preservation) |
 
 ---
 
@@ -277,11 +256,11 @@ cargo test -p flui_devtools --all-features
 ## 💡 Usage Examples
 
 See `examples/` directory:
-- `profiler_demo.rs` - Frame profiling
-- `inspector_demo.rs` - Widget inspection (TODO)
-- `timeline_demo.rs` - Timeline recording (TODO)
-- `hot_reload_demo.rs` - Hot reload setup (TODO)
+- `profiler_demo.rs` - Frame profiling (requires `--features profiling`)
+
+That is the only example in the crate today. There is no
+`inspector_demo.rs`, `timeline_demo.rs`, or `hot_reload_demo.rs`.
 
 ---
 
-Generated: 2025-10-27
+Last verified against `src/*.rs` and `Cargo.toml`: 2026-08-04.

--- a/crates/flui-hot-reload/src/pipeline.rs
+++ b/crates/flui-hot-reload/src/pipeline.rs
@@ -4,9 +4,9 @@
 //! Render) inside a plugin, producing a [`Scene`] that can be passed back to
 //! the host via the `app_plugin!` macro.
 //!
-//! This is intentionally independent of `AppBinding` — the plugin owns its own
-//! `WidgetsBinding` and `PipelineOwner`, avoiding singleton conflicts with the
-//! host.
+//! This is intentionally independent of the host's realm — the plugin owns its
+//! own `WidgetsBinding` and `PipelineOwner`, so it never shares mutable UI
+//! state with the host's `UiRealm`.
 
 use std::sync::Arc;
 
@@ -69,8 +69,8 @@ impl PluginPipeline {
     /// Mount a root widget and create the rendering pipeline.
     ///
     /// This mirrors the `mount_root()` logic in `flui-app`'s runner,
-    /// but uses a standalone `WidgetsBinding` instead of the global
-    /// `AppBinding`.
+    /// but uses a standalone `WidgetsBinding` instead of the host realm's
+    /// widget machinery.
     pub fn mount<V>(root: V, width: f32, height: f32) -> Self
     where
         V: View + StatelessView + Clone + Send + Sync + 'static,
@@ -153,9 +153,10 @@ impl PluginPipeline {
 
             // Phase 2: Run the full frame through the typestate-driven
             // pipeline. Force-mark the root dirty first so we always produce
-            // a fresh LayerTree -- unlike AppBinding (which skips frames when
-            // nothing is dirty and the previous frame is still on-screen),
-            // the plugin must return a Scene every time it's called: the
+            // a fresh LayerTree -- unlike the host realm's frame loop (which
+            // skips frames when nothing is dirty and the previous frame is
+            // still on-screen), the plugin must return a Scene every time
+            // it's called: the
             // host expects a new opaque pointer.
             //
             // `run_frame` returns

--- a/crates/flui-objects/src/lib.rs
+++ b/crates/flui-objects/src/lib.rs
@@ -3,8 +3,12 @@
 //! This crate contains all ready-to-use render objects, organized into domain
 //! families. It sits directly above the [`flui_rendering`] engine crate (which
 //! owns traits, pipeline, arena, protocol, and contexts) and validates that the
-//! engine's custom-object-authoring API is complete — 76 real objects compiling
+//! engine's custom-object-authoring API is complete — 81 real objects compiling
 //! from outside the engine crate proves the authoring surface needs no additions.
+//! (Counted from `RENDER_OBJECT_TYPES` in
+//! `tests/render_object_harness.rs`, mechanically kept in sync with this
+//! crate's exports by `catalog_covers_every_render_object_name`; re-run that
+//! count if this comment drifts again.)
 //!
 //! # Organization
 //!
@@ -19,7 +23,7 @@
 //!
 //! # Flat public surface
 //!
-//! All 76 render-object types are re-exported flat from this crate root so the consumer
+//! All 81 render-object types are re-exported flat from this crate root so the consumer
 //! import path is simply `flui_objects::RenderPadding` — identical depth to the
 //! old `flui_rendering::objects::RenderPadding`.
 //!

--- a/crates/flui-platform/Cargo.toml
+++ b/crates/flui-platform/Cargo.toml
@@ -150,6 +150,13 @@ desktop = ["dep:winit"]
 winit-backend = ["dep:winit", "dep:arboard", "dep:crossbeam-channel"]
 
 # Web platform
+# Honest note (verified 2026-08-04): no-op selector — zero
+# `feature = "web"` references in this crate's src. `platforms::web` is
+# gated by `#[cfg(target_arch = "wasm32")]` on the actual compile target
+# (`src/platforms/mod.rs`), not by this flag; enabling or disabling it
+# changes nothing observable. Kept as a forward-compatible name for
+# downstream `Cargo.toml`s, mirroring `desktop` (which — unlike this one —
+# really does gate `dep:winit`).
 web = []
 
 # Linux display server protocols

--- a/crates/flui-platform/src/platforms/headless/platform.rs
+++ b/crates/flui-platform/src/platforms/headless/platform.rs
@@ -625,9 +625,9 @@ impl PlatformTextInput for FakeTextInput {
 ///
 /// Every `perform` call is appended to an in-memory history so a test can
 /// assert exactly which feedback kinds the haptics bridge
-/// (`flui-app`'s `AppBinding::perform_haptic_feedback`) told the platform
-/// to perform, in delivery order, rather than only that the call didn't
-/// panic.
+/// (`flui-app`'s `UiRealm::perform_haptic_feedback`, forwarded through
+/// `PresentationState`) told the platform to perform, in delivery order,
+/// rather than only that the call didn't panic.
 #[derive(Default)]
 pub struct FakeHaptics {
     calls: Mutex<Vec<HapticFeedback>>,

--- a/crates/flui-platform/src/platforms/winit/platform.rs
+++ b/crates/flui-platform/src/platforms/winit/platform.rs
@@ -35,7 +35,7 @@
 //! `ControlFlow::Wait` explicitly every iteration, even though `Wait` is
 //! winit's documented default when nothing sets it. This is deliberate,
 //! not decorative: `flui-app`'s frame loop is wake-driven (a redraw is
-//! requested only from `AppBinding::wake_frame`/`request_redraw`, never
+//! requested only from `UiRealm::wake_frame`/`request_redraw`, never
 //! polled), and steady-state pacing for a frame that DOES present comes
 //! entirely from the GPU-side blocking Fifo present in `flui-engine`'s
 //! `Renderer::render_scene` (see the frame-pacing ADR). If a future winit

--- a/crates/flui-platform/src/traits/haptics.rs
+++ b/crates/flui-platform/src/traits/haptics.rs
@@ -41,12 +41,14 @@
 //!    a device-global service — of FLUI's eventual backend targets, Android
 //!    is the one with the most granular haptics contract, and per-window is
 //!    the FLUI shape closest to that reality.
-//! 3. **It is the only scope `flui-app` can reach today.** `AppBinding`
-//!    retains `active_window` as its one live platform handle —
-//!    `Platform`/`Box<dyn Platform>` is consumed by `run()` and not kept
-//!    around — so a device-global accessor on `Platform` would be unreachable
-//!    from the one production bridge this capability needs
-//!    (`AppBinding::perform_haptic_feedback`).
+//! 3. **It is the only scope `flui-app` can reach today.** `flui-app`'s
+//!    `PresentationState` retains the active window as its one live
+//!    platform handle (`with_window`, the retired `AppBinding::with_window`'s
+//!    replacement) — `Platform`/`Box<dyn Platform>` is consumed by `run()`
+//!    and not kept around — so a device-global accessor on `Platform` would
+//!    be unreachable from the one production bridge this capability needs
+//!    (`UiRealm::perform_haptic_feedback`, forwarded through
+//!    `PresentationState`).
 //!
 //! Desktop backends with a single device-global haptics engine (if one ever
 //! exists) can trivially satisfy this by returning the same `Arc` from every

--- a/crates/flui-rendering/src/binding/mod.rs
+++ b/crates/flui-rendering/src/binding/mod.rs
@@ -83,7 +83,8 @@ use crate::{
 /// gating step 6 on [`send_frames_to_engine`](Self::send_frames_to_engine)
 /// is the implementer's job, not a trait default — see that method's
 /// doc for why. The production incarnation is
-/// `AppBinding::render_frame_entered` (`flui-app`), which consults
+/// `UiRealm::render_frame_entered` (`flui-app`; there is no `AppBinding`
+/// any more — that type was retired), which consults
 /// `RenderingFlutterBinding::send_frames_to_engine` before presenting.
 pub trait RendererBinding {
     // ========================================================================

--- a/crates/flui-scheduler/README.md
+++ b/crates/flui-scheduler/README.md
@@ -239,12 +239,19 @@ Tasks execute in strict priority order:
 
 ## Integration with FLUI
 
-### In flui_core Pipeline
+### In flui-rendering's `PipelineOwner`
 
-```rust
+`flui-rendering::pipeline::owner::PipelineOwner` is the real consumer —
+there is no `flui_core` crate in this workspace. The sketch below is
+illustrative shape, not the real struct (the actual `PipelineOwner` is
+typestate-generic over its pipeline phase and carries a `DirtyTracker`,
+not a bare `Scheduler` field — see `flui-rendering`'s own docs for the
+real definition):
+
+```rust,ignore
 use flui_scheduler::{Scheduler, FramePhase};
 
-pub struct PipelineOwner {
+struct PipelineOwner {
     scheduler: Scheduler,
 }
 

--- a/crates/flui-scheduler/src/scheduler.rs
+++ b/crates/flui-scheduler/src/scheduler.rs
@@ -1203,8 +1203,8 @@ impl Scheduler {
         self.inner.async_driver.spawn_local_eager(future)
     }
 
-    /// **The** async-driver step of a frame — the single call site both bindings
-    /// use (`HeadlessBinding::pump_frame` and `AppBinding::draw_frame`).
+    /// **The** async-driver step of a frame — the single call site both frame
+    /// drivers use (`HeadlessBinding::pump_frame` and `UiRealm::draw_frame`).
     ///
     /// Polls every task whose waker fired, on the calling thread. A future
     /// completing here calls `RebuildHandle::schedule()`, whose id the *same*

--- a/crates/flui-widgets/src/app/safe_area.rs
+++ b/crates/flui-widgets/src/app/safe_area.rs
@@ -33,11 +33,10 @@ use crate::layout::Padding;
 ///
 /// # Panics
 ///
-/// Panics in `build` if there is no [`MediaQuery`] ancestor. Place a
-/// `MediaQuery` near the root — construct it directly with
-/// `flui_widgets::MediaQueryData` (there is no `AppBinding` that installs
-/// one automatically; that type was retired in the singleton-binding
-/// removal).
+/// Panics in `build` if there is no [`MediaQuery`] ancestor. Wrap the
+/// subtree in a [`MediaQuery`] near the root —
+/// `MediaQuery::new(MediaQueryData { .. }, child)` — since nothing installs
+/// one automatically.
 // Four independent per-edge toggle bools mirror Flutter's `SafeArea` API
 // (left/top/right/bottom as separate constructor params). There is no semantic
 // grouping that warrants a state machine or enum — each edge is truly

--- a/crates/flui-widgets/src/app/safe_area.rs
+++ b/crates/flui-widgets/src/app/safe_area.rs
@@ -34,7 +34,10 @@ use crate::layout::Padding;
 /// # Panics
 ///
 /// Panics in `build` if there is no [`MediaQuery`] ancestor. Place a
-/// `MediaQuery` near the root (e.g. from `flui_app::AppBinding`).
+/// `MediaQuery` near the root — construct it directly with
+/// `flui_widgets::MediaQueryData` (there is no `AppBinding` that installs
+/// one automatically; that type was retired in the singleton-binding
+/// removal).
 // Four independent per-edge toggle bools mirror Flutter's `SafeArea` API
 // (left/top/right/bottom as separate constructor params). There is no semantic
 // grouping that warrants a state machine or enum — each edge is truly

--- a/crates/flui-widgets/src/interaction/visibility.rs
+++ b/crates/flui-widgets/src/interaction/visibility.rs
@@ -37,9 +37,11 @@ use crate::layout::SizedBox;
 ///
 /// **Divergences from Flutter:**
 /// - `maintainAnimation` controls descendants registered through an ambient
-///   `VsyncScope`, as production `AppBinding` roots provide. Without an ambient
-///   scope, FLUI's `TickerMode` intentionally passes its child through so an
-///   undriven nested registry cannot swallow wall-clock fallback animations.
+///   `VsyncScope`, as a production `UiRealm` root provides (it auto-wraps the
+///   attached root view in one — see `flui_app`'s realm attach path). Without
+///   an ambient scope, FLUI's `TickerMode` intentionally passes its child
+///   through so an undriven nested registry cannot swallow wall-clock
+///   fallback animations.
 /// - `maintainSize` (requires `maintainAnimation`) — deferred.
 /// - `maintainInteractivity` (requires `maintainSize` in Flutter) — accepted
 ///   but currently a no-op beyond `maintain_state`; full semantics deferred
@@ -100,7 +102,8 @@ impl Visibility {
     /// remount the child, and lose its state.
     ///
     /// Animation muting applies to descendants registered through an ambient
-    /// `VsyncScope`; production `AppBinding` roots provide that scope.
+    /// `VsyncScope`; a production `UiRealm` root provides that scope
+    /// automatically (there is no `AppBinding` — that type was retired).
     #[must_use]
     pub fn maintain_animation(mut self, maintain_animation: bool) -> Self {
         self.maintain_animation = maintain_animation;

--- a/crates/flui-widgets/src/scroll/list_view.rs
+++ b/crates/flui-widgets/src/scroll/list_view.rs
@@ -37,7 +37,7 @@ enum OffsetSource {
 /// - **Lazy** ([`ListView::builder`]): children built on demand from a
 ///   closure, only for the viewport-visible + cache band. Backed by
 ///   [`SliverList`] (variable-height, element-owned). Wired into both
-///   `HeadlessBinding::pump_frame` and the production `AppBinding::draw_frame`,
+///   `HeadlessBinding::pump_frame` and the production `UiRealm::draw_frame`,
 ///   where the child-manager wiring and its test coverage converge.
 ///
 ///   **First-frame settling (Flutter divergence):** lazy children are built

--- a/docs/FOUNDATIONS.md
+++ b/docs/FOUNDATIONS.md
@@ -320,7 +320,7 @@ This document is the **architecture contract** for the port. Its relationship to
 - **`FOUNDATIONS.md`** (this document) — *what* (the target architecture, the locked contracts, the crate graph).
 - [`PORT.md`](PORT.md) — *how* (the port methodology, refusal triggers, mapping rules).
 - [`ROADMAP.md`](ROADMAP.md) — *when / in what order* (the dependency-ordered construction phases).
-- [`.specify/memory/constitution.md`](../.specify/memory/constitution.md) — the ratified rules. **It requires amendment** (MINOR bump): the layer table must be replaced with Part IV's, and the edition/Rust-version line corrected to 2024 / 1.95.
+- [`AGENTS.md`](../AGENTS.md) — the cross-tool ratified rules living in this checkout today. (There is no `.specify/memory/constitution.md` here — that path, and the amendment it once needed, are stale; `AGENTS.md` is kept current directly instead.)
 
 **Amendment.** A change to a locked contract (Part III) or the target crate graph (Part IV) requires: documented rationale, a corresponding `STRATEGY.md`/`PORT.md`/constitution sync if affected, and — once construction has begun — an explicit migration assessment, because a contract change after Phase 1 has catalog-wide blast radius. The contracts are locked precisely so that they are *not* casually amended.
 

--- a/docs/PORT.md
+++ b/docs/PORT.md
@@ -14,7 +14,7 @@ PORT.md sits inside a four-document governance set:
 3. **`PORT.md` (this page)** — governance + operational translation manual.
 4. [`ROADMAP.md`](ROADMAP.md) — the construction plan (dependency-ordered phases from current to target).
 
-For the rule-by-rule architectural guide (workspace layers, anti-pattern code examples, dependency DAG), read [`.ai-factory/ARCHITECTURE.md`](../.ai-factory/ARCHITECTURE.md). This page does not restate the strategy or contract layers; it is the operational layer that hangs off them.
+For the rule-by-rule architectural guide (workspace layers, anti-pattern code examples, dependency DAG), read [`FOUNDATIONS.md`](FOUNDATIONS.md) (`.ai-factory/ARCHITECTURE.md` does not exist in this checkout). This page does not restate the strategy or contract layers; it is the operational layer that hangs off them.
 
 The translation manual draws inspiration from Bun's [oven-sh/bun#PORTING.md](https://github.com/oven-sh/bun/blob/main/docs/PORTING.md), with one principled inversion: **flui actively embraces the Rust ecosystem**. Where Bun bans `tokio`/`rayon`/`hyper`/`futures` and rolls its own primitives, flui adopts mature ecosystem crates (`parking_lot`, `dashmap`, `smallvec`, `ambassador`, `bon`, `thiserror`, `tracing`, `wgpu`, `moka`, `tokio` LTS). See [§Ecosystem-first principle](#ecosystem-first-principle) for the adoption table and the version policy.
 
@@ -51,7 +51,7 @@ Triggers are seeded from observed friction in the workspace. Forward-looking tri
 
 **Why:** the render hot path is strictly synchronous (see [`STRATEGY.md`](../STRATEGY.md) clause "sync hot path, async на краях"). A lock on a per-node storage type held across `perform_layout` or `paint` serialises the pipeline against itself and removes the "many readers OR one writer" guarantee the hot path depends on. Shared infrastructure locks (`PipelineOwner`, `WidgetsBinding`, route plumbing) are different — they sit one level above per-node mutation and are covered in [Lock decisions](#lock-decisions).
 
-**Back-references:** [`.specify/memory/constitution.md`](../.specify/memory/constitution.md) v2.2.0 Anti-Patterns ("`Arc<Mutex<>>` for tree structures"); [`STRATEGY.md`](../STRATEGY.md) "sync hot path".
+**Back-references:** the project constitution's v2.2.0 Anti-Patterns entry ("`Arc<Mutex<>>` for tree structures") — historical citation; `.specify/memory/constitution.md` no longer exists in this checkout, see [`AGENTS.md`](../AGENTS.md) for the current rule; [`STRATEGY.md`](../STRATEGY.md) "sync hot path".
 
 **Regex (used by `just port-check`):** `RwLock<\s*Box<\s*dyn\s+(RenderObject|Layer\b|ContainerLayer)` (storage-shaped violations). Scope extended in Mythos Step 13 of the `flui-layer` chain to cover `crates/flui-layer/src/` and to match `dyn Layer` / `dyn ContainerLayer` shapes as well. Re-confirmed in Mythos Step 13 of the `flui-painting` chain to cover the post-split `crates/flui-painting/src/` subdirectories (`canvas/`, `display_list/`, `text_layout/`, `text_painter/`) as a forward-looking guard.
 
@@ -63,7 +63,7 @@ Trigger 1 catches the specific `RwLock` variant. Trigger 2 catches any other int
 
 The *funnel* signatures (`tree.rs::insert_box`, view → render `From` impls) accept `Box<dyn RenderObject<_>>` as a transient parameter type and are not the target — the violation is the stored-and-wrapped shape.
 
-**Back-references:** [`.ai-factory/ARCHITECTURE.md`](../.ai-factory/ARCHITECTURE.md) example "`RenderBad { children: Vec<Box<dyn RenderObject>> }` — forbidden"; [`.specify/memory/constitution.md`](../.specify/memory/constitution.md) Principle IV.
+**Back-references:** historical `.ai-factory/ARCHITECTURE.md` example "`RenderBad { children: Vec<Box<dyn RenderObject>> }` — forbidden" and constitution Principle IV — neither file exists in this checkout; see [`FOUNDATIONS.md`](FOUNDATIONS.md) and [`AGENTS.md`](../AGENTS.md) for the current rule.
 
 **Regex:** `(RwLock|Mutex|RefCell|Cell|UnsafeCell)<\s*Box<\s*dyn\s+(RenderObject|Layer\b|ContainerLayer)` constrained to render-storage modules, `crates/flui-layer/src/`, and `crates/flui-painting/src/`. Scope and trait-name set extended in Mythos Step 13 of the `flui-layer` chain; re-confirmed for the post-split `flui-painting` subdirectories in Mythos Step 13 of the `flui-painting` chain.
 
@@ -97,7 +97,7 @@ The *funnel* signatures (`tree.rs::insert_box`, view → render `From` impls) ac
 
 **Why:** the unified element reconciler is built around generic dispatch (`Element<V, A, B>`); storing user-defined `Box<dyn View>` in child storage forces a runtime-typed boundary into the reconciliation hot path. Funnel parameters that accept `Box<dyn View>` at the boundary are acceptable; storing them as children is not.
 
-**Back-references:** [`.specify/memory/constitution.md`](../.specify/memory/constitution.md) Principle IV ("Prefer generics and enum dispatch over `dyn` trait objects").
+**Back-references:** constitution Principle IV ("Prefer generics and enum dispatch over `dyn` trait objects") — historical citation; `.specify/memory/constitution.md` no longer exists in this checkout, see [`AGENTS.md`](../AGENTS.md) for the current rule.
 
 **Regex:** `:\s*Vec<\s*Box<\s*dyn\s+View|:\s*Box<\s*dyn\s+View` constrained to `crates/flui-view/src/element/child_storage.rs` and storage struct definitions in `crates/flui-view/src/element/**`.
 
@@ -1095,8 +1095,8 @@ Authoritative workspace state lives in [`AGENTS.md`](../AGENTS.md) and [`docs/cr
 
 External references this methodology builds on:
 
-- [`.specify/memory/constitution.md`](../.specify/memory/constitution.md) — v2.2.0 anti-patterns and architectural rules.
-- [`.ai-factory/ARCHITECTURE.md`](../.ai-factory/ARCHITECTURE.md) — full anti-pattern list with code examples.
+- [`AGENTS.md`](../AGENTS.md) — current anti-patterns and architectural rules. (`.specify/memory/constitution.md` v2.2.0 and `.ai-factory/ARCHITECTURE.md` were the historical originals; neither exists in this checkout.)
+- [`FOUNDATIONS.md`](FOUNDATIONS.md) — full anti-pattern list with code examples.
 - [`STRATEGY.md`](../STRATEGY.md) — port rationale, Bun precedent, three architectural clauses.
 - [`docs/plans/2026-03-31-core-crates-hardening.md`](plans/2026-03-31-core-crates-hardening.md) — `Weak<RwLock<PipelineOwner>>` precedent.
 - [`docs/plans/2026-03-31-platform-roadmap.md`](plans/2026-03-31-platform-roadmap.md) — `PlatformTextSystem` deletion precedent (source of the binding-deletion carve-out).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ This roadmap sits on top of [`FOUNDATIONS.md`](FOUNDATIONS.md) — the architect
 |---|---|
 | Core.0 — spine to spec | ✅ **Complete.** Pipeline phases wired and tested, keyed reconciliation production-wired, contracts locked, gate green. |
 | Core.1 — vertical slice | ✅ Slice widgets, contract validation, combined demo app + acceptance tests, parity ports, frame evidence, drag-to-scroll — all delivered. |
-| Core.2 — render-object catalog | ✅ **79 of ~80** objects built with harness tests in `crates/flui-objects`, incl. `RenderAnimatedOpacity`/`RenderSliverAnimatedOpacity`; exit verification (scrolling test, intrinsics audit, coverage ≥80%) met. |
+| Core.2 — render-object catalog | ✅ **81** objects built with harness tests in `crates/flui-objects` (exceeds the original ~80 estimate), incl. `RenderAnimatedOpacity`/`RenderSliverAnimatedOpacity`; exit verification (scrolling test, intrinsics audit, coverage ≥80%) met. |
 | Business.1 — widget catalog | ◐ Every named catalog widget implemented and integration-tested; named `Hero` gaps are closed (cross-navigator flights + user-gesture flights, `ROADMAP-TRACKER.md` B1.4; `push_replacement` was checked and needs no fix — it already flies heroes with no dedicated wiring). **Fidelity** (ported parity corpus) is the only Business.1 residue remaining. |
 | Catalog.1 — Material ∥ Cupertino | ◐ `flui-localizations` created; `flui-material` underway (theming + per-component themes, the button family, `Scaffold`/`AppBar`/secondary tabs, `Card`, `Dialog`, `TextField`/`InputDecorator` (filled), `ListTile`/`Divider`, `Drawer`, `SnackBar`/`ScaffoldMessenger`, `NavigationBar`, selection controls, `Chip`/`FilterChip`, `DataTable`) — still owed ink ripple, bottom sheets, sorting/pagination, primary-style tabs, floating `SnackBar`; against the 210.8k LOC oracle. `flui-cupertino` underway (theming foundation, `CupertinoButton`, `cupertino_page_route`, `CupertinoNavigationBar`, `CupertinoPageScaffold`, `CupertinoTabScaffold`+`CupertinoTabBar`) — still early against the 48.3k LOC oracle. |
 | App.1 — application integration | ◐ `run_app`, both bindings, the vsync-paced frame loop ([ADR-0029](adr/ADR-0029-frame-pacing-swapchain-block-with-fallback-throttle.md)), the facade crate, the full IME pipeline incl. `EditableText` adoption, caret-following cursor area, and composing-region rendering ([ADR-0030](adr/ADR-0030-platform-text-input-ime-capability.md)…[ADR-0033](adr/ADR-0033-composing-region-rendering.md)), `PlatformHaptics` + clipboard reachability ([ADR-0031](adr/ADR-0031-platform-haptics-capability-and-system-chrome-deferral.md), [ADR-0034](adr/ADR-0034-clipboard-reachability-without-a-platform-handle.md)), lifecycle/framesEnabled ([ADR-0035](adr/ADR-0035-lifecycle-consolidation-and-frames-enabled.md)), and a completed full-crate audit-and-repair pass all landed. Remains: real-IME manual verification and native-backend pacing evidence (Cross.P). |
@@ -36,7 +36,7 @@ The target is **full parity with released Flutter** — every framework package,
 | `semantics` | 7.9k | ~70% | Cross.H |
 | `animation` | 5.3k | ~85% | Core.1 (active workspace member) |
 | `painting` | 24.9k | ~60% | Core.0 → Core.2 |
-| `rendering` | 52.1k | machine ~90%; catalog **79/~80 harness-tested** (`crates/flui-objects`) | Core.2 ✅ |
+| `rendering` | 52.1k | machine ~90%; catalog **81 harness-tested** (exceeds the original ~80 estimate) (`crates/flui-objects`) | Core.2 ✅ |
 | `widgets` | 157.4k | catalog built, **89.72% line coverage measured 2026-07-15** (bar ≥85% met), **fidelity partial** | Business.1 (fidelity) |
 | `services` | 30.2k | ~40% | App.1 + Cross.P (dissolved into `flui-platform`) |
 | `material` | 210.8k | ~3% — theming foundation (`ColorScheme`/`TextTheme`/`ThemeData`/`Theme`), `Material`/`InkWell`, the M3 button family, `Scaffold`/`AppBar` | Catalog.1 |
@@ -197,7 +197,7 @@ Each phase states: **Goal**, **Status**, what was **Delivered** (for closed work
 - **Composited-layer pipeline gap** (no `updateCompositedLayer`/retained-layer alpha-blend-without-repaint path) — tracked under Cross.H below; it is a `flui-rendering` machine capability, not specific to the opacity pair, and would benefit any future retained-layer effect.
 - **`AnimatedOpacity` widget rewiring** — delivered 2026-07-15: the widget now builds `RenderAnimatedOpacity` directly through an injected, hot-swappable `ProxyAnimation<f32>` (retarget = widget-side `set_parent`, the render object never sees controller or curve), and a probe test pins that animation ticks no longer rebuild the child subtree. Surfaced pre-existing gap, now named under Business.1: `ImplicitAnimation` ignores a changed `curve` on rebuild across all implicit widgets (Flutter re-creates the `CurvedAnimation`).
 
-**Parity delta.** `rendering` catalog → ~95% coverage (mechanical count 79/~80); `painting` advanced correspondingly.
+**Parity delta.** `rendering` catalog → ~95% coverage (mechanical count 81, exceeding the original ~80 estimate); `painting` advanced correspondingly.
 
 ---
 
@@ -337,8 +337,8 @@ Bundled into Core.0 because they were cheap-now / catalog-wide-later: the `flui-
 ```
 MAIN VERTICAL (sequential — Core → Business → Catalog → App):
   Core.0 ✅ ── Core.1 ✅ ── Core.2 ✅ ── Business.1 ◐ ── Catalog.1 ◐ ── App.1 ◐
-                            (79/~80      (built;        (Material ∥     (partial:
-                             objects;     fidelity       Cupertino —     vsync, IME,
+                            (81 objects; (built;        (Material ∥     (partial:
+                             ~80 est.     fidelity       Cupertino —     vsync, IME,
                              exit met)    open)          not started)    facade left)
 
 CROSS layer — continuous, with cross-track gates marked:
@@ -365,7 +365,7 @@ Within phases: Core.2's render-object families parallelize (box / sliver / paint
 | # | Risk | Mitigation |
 |---|---|---|
 | R1 | Widget catalog built on a spine not yet at target spec — defects compound across ~80 widgets, silently | **Realized as designed:** Core.0 was a hard gate with objective exit tests and is met; Core.1's vertical slice re-proved the spine under live load before breadth |
-| R2 | Render-object catalog under-scoped — Business.1 stalls mid-widget on a missing render object | The widget → render-object checklist ([`research/widget-renderobject-map.md`](research/widget-renderobject-map.md)) was built before the catalog; Core.2 is complete — 79/~80 objects exist with harness tests |
+| R2 | Render-object catalog under-scoped — Business.1 stalls mid-widget on a missing render object | The widget → render-object checklist ([`research/widget-renderobject-map.md`](research/widget-renderobject-map.md)) was built before the catalog; Core.2 is complete — 81 objects exist with harness tests (exceeds the original ~80 estimate) |
 | R3 | A contract flaw discovered inside `flui-material` (210k LOC) = catastrophic rework | Core.1's slice exercised every contract on live code; Catalog.1 starts only after the contract-validation report ([`research/2026-06-30-phase1-contract-validation.md`](research/2026-06-30-phase1-contract-validation.md)) is clean and Core.1's residues close |
 | R4 | `flui-material` is one monolithic terminal phase | Phased internally by component family (theming → buttons → inputs → navigation → data); ships in increments; runs ∥ `flui-cupertino` |
 | R5 | `Scene`/`DrawCommand` contract drift breaks the parallel engine track | The contract is frozen with a documented change protocol (`docs/designs/2026-06-30-scene-drawcommand-contract.md`); any later change is a coordinated cross-track change |

--- a/docs/adr/ADR-0016-unified-font-system-registration.md
+++ b/docs/adr/ADR-0016-unified-font-system-registration.md
@@ -4,11 +4,58 @@
 
 ---
 
-- **Status:** Accepted (chief-architect ARCH-GATE: **ACCEPTABLE** — infra decision only. The `Icon` glyph-rendering slice, the engine `TextRenderer` migration, and the bundled-font wiring are separate DEV tasks, each DoD-cross-checked against `.flutter/`.)
+- **Status:** Accepted; **Superseded/Amended 2026-08-04** — the decision to unify the two `FontSystem`s stands and shipped (Slices 1–2 below), but the *mechanism* this doc specifies (`PaintingBinding::instance().font_system()`, an ambient singleton accessor) no longer exists: the painting-singleton retirement removed `PaintingBinding::instance()` entirely. See "Amendment (2026-08-04)" below for the real current shape. (chief-architect ARCH-GATE: **ACCEPTABLE** — infra decision only. The `Icon` glyph-rendering slice, the engine `TextRenderer` migration, and the bundled-font wiring are separate DEV tasks, each DoD-cross-checked against `.flutter/`.)
 - **Date:** 2026-07-02
 - **Deciders:** chief-architect; consult api-design-lead (the new `PaintingBinding::register_font` / `font_system()` public surface + the `flui_painting::FontSystem` re-export that pins the shared type), async-systems/scheduler owner (confirming the shared-lock stays off the async path and layout/paint phases are disjoint), systems-perf-lead (lock-contention and multi-window font-DB sharing), qa-lead (the type-identity failsafe test + the register→measure→paint consistency tests)
 - **Relates to:** **Unblocks the deferred glyph-rendering half of the `Icon` widget** (`docs/research/2026-07-02-icon-widget-plan.md` §"THE GAP", B1.1 — the widget-layer slice shipped honestly with glyph rendering NO-GO pending this ADR). Sibling in spirit to ADR-0011/0012/0013: close a gap by making the correct state *structural* (one source of truth) rather than bolting on a parallel channel that must be kept consistent.
 - **Gate:** ARCH-GATE (this doc) → then per-slice DEV-GATEs (painting API, engine migration, bundled-font wiring, Icon glyph assertion).
+
+---
+
+## Amendment (2026-08-04)
+
+**What changed:** a later, unrelated change (the painting-singleton
+retirement) deleted `PaintingBinding::instance()` and the rest of the
+`BindingBase`/`HasInstance`/`impl_binding_singleton!` ambient-singleton
+machinery workspace-wide. This ADR's Decision and Implementation-progress
+sections (below, left as originally written — this is an amendment note,
+not a rewrite) describe the shared `FontSystem` as reached through
+`PaintingBinding::instance().font_system()`. That accessor path is gone;
+`PaintingBinding` is now a plain value type constructed with
+`PaintingBinding::new()` wherever a caller needs one (`crates/flui-painting/src/binding.rs:382`).
+
+**What did NOT change:** the one-`FontSystem` decision itself. There is
+still exactly one process-wide `FontSystem`, and a font registered anywhere
+is still visible to both layout and every engine instance — the property
+this ADR exists to guarantee.
+
+**The real current shape:**
+
+- A free-standing `static FONT_SYSTEM: OnceLock<Arc<Mutex<FontSystem>>>` in
+  `crates/flui-painting/src/text_layout/layout.rs:48`, behind the
+  crate-private `font_system_arc()` accessor.
+- `PaintingBinding::font_system()` and `PaintingBinding::register_font()`
+  are ordinary instance methods on a value-constructed `PaintingBinding`
+  that delegate straight to that process-global (`crate::text_layout::shared_font_system()`)
+  — they are not the ownership boundary the original Decision text implies.
+- Construction ownership: `SharedEngineServices::resolve()` (invoked from
+  `AppRuntime::ensure_services()` at realm install) is the constructing
+  owner — it calls `PaintingBinding::font_system()` explicitly at realm
+  install, eagerly initializing the process-wide `FontSystem` rather than
+  leaving it to whichever text-measurement call happens to run first.
+- The **read** path stays ambient on layout hot paths — this is a named,
+  bounded, and accepted hazard (cross-realm `register_font` staleness
+  mid-layout is a staleness window, not a data race, because the shared
+  state is `Mutex<FontSystem>`), tracked as a documented ratchet exclusion
+  in `docs/runtime-contract.toml:1779` rather than closed. Closing it (an
+  owner-local-access or font-sharding design) is an ADR-0027 follow-up, not
+  done here.
+
+This amendment does not change any of the Decision, Consequences,
+Alternatives, or Test-plan sections below — they document the original
+call and remain historically accurate for what was decided and why. Read
+them as "why we unified the two `FontSystem`s"; read this section as "how
+that unification is actually wired today."
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 
 FLUI combines two patterns: a **Layered Modular Workspace** (workspace structure) and a **Three-Tree Pipeline** (runtime data flow). The first tells you *what may depend on what*; the second tells you *how a frame is built, laid out, and painted*.
 
-For the deep, rule-by-rule guide (anti-patterns, code examples, dependency rules), read [`.ai-factory/ARCHITECTURE.md`](../.ai-factory/ARCHITECTURE.md). This page is the high-level orientation.
+For the deep, rule-by-rule guide (anti-patterns, code examples, dependency rules), read [`FOUNDATIONS.md`](FOUNDATIONS.md) (`.ai-factory/ARCHITECTURE.md` does not exist in this checkout). This page is the high-level orientation.
 
 ## Layered Modular Workspace
 
@@ -172,9 +172,8 @@ See [Hot Reload](hot-reload.md) for workflows, `ReloadStrategy`, and integration
 ## See Also
 
 - [Hot Reload](hot-reload.md) — two-layer dev model, plugin workflows
-- [`.ai-factory/ARCHITECTURE.md`](../.ai-factory/ARCHITECTURE.md) — full architectural rules and anti-patterns
-- [`.specify/memory/constitution.md`](../.specify/memory/constitution.md) — constitution v2.3.0
-- [Foundations](FOUNDATIONS.md) — architecture contract, target crate graph
+- [Foundations](FOUNDATIONS.md) — architecture contract, target crate graph, full anti-pattern list
+- [`AGENTS.md`](../AGENTS.md) — the current cross-tool rules (`.ai-factory/ARCHITECTURE.md` and `.specify/memory/constitution.md` were the historical originals; neither exists in this checkout)
 - [Roadmap](ROADMAP.md) — construction phases from current to target
 - [Crates Map](crates.md) — per-layer crate inventory
 - [Contributing](contributing.md) — workflow and conventions

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -15,11 +15,9 @@ Before opening a PR or even a planning issue, read:
 3. [`docs/ROADMAP.md`](ROADMAP.md) — **construction plan**: dependency-ordered phases that move the workspace from current state to the target.
 4. [`STRATEGY.md`](../STRATEGY.md) — product strategy and the three port rules ("behavior loyal, structure Rust-native").
 5. [`docs/PORT.md`](PORT.md) — port methodology, refusal triggers, per-crate `ARCHITECTURE.md` template.
-6. [`.specify/memory/constitution.md`](../.specify/memory/constitution.md) — the project constitution (v2.3.0). Non-negotiable rules: layered DAG, `unsafe` boundaries, no `unwrap()` / `println!`, on-demand rendering, etc.
-7. [`.ai-factory/ARCHITECTURE.md`](../.ai-factory/ARCHITECTURE.md) — full architectural rules and anti-patterns.
-8. [`.ai-factory/rules/base.md`](../.ai-factory/rules/base.md) — project base rules (naming, modules, errors, logging, testing, unsafe).
-9. [`CLAUDE.md`](../CLAUDE.md) — Claude Code-specific guidance for this repo (build commands, troubleshooting).
-10. [Architecture overview](architecture.md) and [Crates Map](crates.md) — high-level orientation (current-state).
+6. [`AGENTS.md`](../AGENTS.md) — the cross-tool agent guide and this workspace's non-negotiable rules: layered DAG, `unsafe` boundaries, no `unwrap()` / `println!`, on-demand rendering, etc. `docs/FOUNDATIONS.md` (item 2 above) is the full architectural-rules-and-anti-patterns reference. Neither `.specify/memory/constitution.md`, `.ai-factory/ARCHITECTURE.md`, nor `.ai-factory/rules/base.md` exists in this checkout — those are stale paths this repo no longer carries.
+7. [`CLAUDE.md`](../CLAUDE.md) — Claude Code-specific guidance for this repo (build commands, troubleshooting).
+8. [Architecture overview](architecture.md) and [Crates Map](crates.md) — high-level orientation (current-state).
 
 ## Quality Gates
 
@@ -109,7 +107,7 @@ parts of that contract. Do not copy a subset into a crate and let it drift.
 - **No `wgpu` types in widget or layout code.** GPU access flows through `flui-painting`'s abstract canvas API.
 - **No polling render loops.** Use `ControlFlow::Wait`. Constitution-mandated.
 
-For the full anti-pattern list see [`.ai-factory/ARCHITECTURE.md`](../.ai-factory/ARCHITECTURE.md).
+For the full anti-pattern list see [`docs/FOUNDATIONS.md`](FOUNDATIONS.md) (`.ai-factory/ARCHITECTURE.md` does not exist in this checkout).
 
 ## Reviewing a Change
 

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -4,7 +4,7 @@
 
 > **Scope.** This page describes the **current** workspace as it is built today. `flui-localizations`, `flui-material`, and `flui-cupertino` (Catalog.1) have landed; the remaining target crate decomposition — the formal `flui` facade — is defined in [`FOUNDATIONS.md` Part IV](FOUNDATIONS.md); the migration is sequenced in [`ROADMAP.md`](ROADMAP.md).
 
-The FLUI workspace contains 20+ crates organized into a strict layered DAG. This page is the canonical inventory: what each crate does, what layer it sits in, and whether it is currently active.
+The FLUI workspace contains 28 crates plus the `flui` facade, organized into a strict layered DAG. This page is the canonical inventory: what each crate does, what layer it sits in, and whether it is currently active.
 
 > **Layer assignments here mirror [`workspace-layers.toml`](workspace-layers.toml), which is the authoritative policy.** `scripts/check-workspace-inventory.sh` (`just inventory-check`) validates every **normal** Cargo dependency edge against that file: strictly downward, with an ordered-pair allowlist for same-layer edges, named forbidden pairs, and an acyclicity check that includes projected future edges. See [ADR-0041](adr/ADR-0041-workspace-topology-contract.md) for the contract and [`FOUNDATIONS.md` Part IV](FOUNDATIONS.md) for the target graph. Dev-dependencies are deliberately out of scope — they cross layers freely and Cargo permits cycles among them.
 
@@ -23,7 +23,7 @@ A crate marked **DISABLED** is commented out in `Cargo.toml` `[workspace.members
 
 | Crate | Status | Purpose |
 |-------|--------|---------|
-| `flui-foundation` | ✅ ACTIVE | Framework primitives: `ChangeNotifier` / `Listenable`, `Id` system, `BindingBase`, `Key`, the shared structured-field vocabulary in `diagnostics`, error helpers. Emits `tracing` events; owns no subscriber. |
+| `flui-foundation` | ✅ ACTIVE | Framework primitives: `ChangeNotifier` / `Listenable`, `Id` system, `Key`, the `observe` tree-observer seam (ADR-0040) + `RebuildReason`, the shared structured-field vocabulary in `diagnostics`, error helpers. There is no `BindingBase` — the ambient-singleton machinery it backed was retired workspace-wide. Emits `tracing` events; owns no subscriber. |
 | `flui-macros` | ✅ ACTIVE | Proc-macro crate for framework derives and generated boilerplate |
 
 ## Layer 2 — Substrate
@@ -138,7 +138,7 @@ A new crate is a topology change, so it starts with the contract, not the direct
 3. Add a `[[member]]` entry to `workspace-layers.toml` with its layer and disposition (`keep` / `rename` / `narrow` / `optionalize` / `deferred-extraction`).
 4. Add the directory under `crates/<flui-name>/` with a standard layout (`Cargo.toml`, `src/lib.rs`, `src/error.rs`).
 5. Add the path to `[workspace.members]` in the root `Cargo.toml`; add it to `default-members` unless the crate is intentionally excluded from default local builds.
-6. Update the constitution layer table in `.specify/memory/constitution.md` if it represents a new responsibility.
+6. Update the layer table in [`AGENTS.md`](../AGENTS.md) if it represents a new responsibility. (There is no `.specify/memory/constitution.md` in this checkout — `AGENTS.md` is where that table lives now.)
 7. Update this page (`docs/crates.md`), [`FOUNDATIONS.md` Part IV](FOUNDATIONS.md), and the `active_crates` / `build-layered` inventories in the `justfile`.
 
 ## See Also
@@ -149,5 +149,4 @@ A new crate is a topology change, so it starts with the contract, not the direct
 - [Roadmap](ROADMAP.md) — construction phases from current to target
 - [Architecture](architecture.md) — three-tree pipeline + layered DAG (current state)
 - [Getting Started](getting-started.md) — build and run instructions
-- [`.ai-factory/ARCHITECTURE.md`](../.ai-factory/ARCHITECTURE.md) — full architectural rules
-- [`.specify/memory/constitution.md`](../.specify/memory/constitution.md) — constitution v2.3.0
+- [`AGENTS.md`](../AGENTS.md) — current cross-tool rules (`.ai-factory/ARCHITECTURE.md` and `.specify/memory/constitution.md` were the historical originals; neither exists in this checkout)

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -138,7 +138,7 @@ A new crate is a topology change, so it starts with the contract, not the direct
 3. Add a `[[member]]` entry to `workspace-layers.toml` with its layer and disposition (`keep` / `rename` / `narrow` / `optionalize` / `deferred-extraction`).
 4. Add the directory under `crates/<flui-name>/` with a standard layout (`Cargo.toml`, `src/lib.rs`, `src/error.rs`).
 5. Add the path to `[workspace.members]` in the root `Cargo.toml`; add it to `default-members` unless the crate is intentionally excluded from default local builds.
-6. Update the layer table in [`AGENTS.md`](../AGENTS.md) if it represents a new responsibility. (There is no `.specify/memory/constitution.md` in this checkout — `AGENTS.md` is where that table lives now.)
+6. There is no separate layer table to maintain: the checked authority is the `[[member]]` entry from step 3 (`workspace-layers.toml`), and the human-readable graph is [`FOUNDATIONS.md` Part IV](FOUNDATIONS.md), updated in step 7. If the crate changes what an agent should read first, extend the decision tables in [`AGENTS.md`](../AGENTS.md).
 7. Update this page (`docs/crates.md`), [`FOUNDATIONS.md` Part IV](FOUNDATIONS.md), and the `active_crates` / `build-layered` inventories in the `justfile`.
 
 ## See Also

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,14 +12,17 @@ The local pre-review gate is:
 just ci
 ```
 
-Expanded, that currently runs:
+Expanded (see `ci:` in the `justfile` for the authoritative recipe list), that currently runs:
 
 ```bash
-cargo fmt --all -- --check          # formatter gate (rustfmt.toml is authoritative)
-bash scripts/check-workspace-inventory.sh # crate inventory drift guard
-bash scripts/port-check.sh           # architecture refusal triggers
-cargo clippy --workspace --all-targets -- -D warnings # lint gate — zero warnings
-cargo test --workspace               # full test suite
+cargo fmt --all -- --check                                # fmt-check: formatter gate (rustfmt.toml is authoritative)
+bash scripts/check-workspace-inventory.sh                  # inventory-check: crate inventory + layer-policy drift guard
+bash scripts/check-runtime-conformance.sh                  # runtime-conformance-check: docs/runtime-contract.toml vs. source tree
+bash scripts/port-check.sh                                 # port-check: architecture refusal triggers
+cargo clippy --workspace --all-targets -- -D warnings      # clippy: lint gate — zero warnings
+cargo nextest run --workspace --exclude flui-platform --locked --no-fail-fast  # test-ci (flui-platform is excluded — see CI Expectations below)
+cargo test --workspace --exclude flui-platform --doc       # test-doc: doc-tests, same exclusion
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked --document-private-items  # doc-strict
 ```
 
 ## Build
@@ -156,7 +159,7 @@ The constitution requires `///` doc comments on every public item and `//!` over
 - **Unit tests** live in the same file under `#[cfg(test)] mod tests { ... }`.
 - **Integration tests** live in `tests/` per crate. Cross-crate pipelines are tested in `flui-engine`.
 - **Property-based tests** use [`proptest`](https://docs.rs/proptest) for layout algorithms and geometric operations.
-- **Visual regression tests** (planned) will use snapshot-based comparison against the headless backend.
+- **Visual regression tests** exist: `tests/golden_screenshots.rs` (209 lines) renders each demo headless and compares against 6 committed PNGs in `tests/goldens/`. Needs a GPU; run with `just golden` (`--features golden`); regenerate with `UPDATE_GOLDENS=1`.
 - **No mocking frameworks.** Use trait-based test doubles. The `HeadlessPlatform` backend is the canonical test surface for platform-dependent code.
 
 ## Test Harnesses (`testing` feature)
@@ -206,16 +209,18 @@ cargo test -p flui-rendering --test render_object_harness
 
 ### Render-object harness catalog
 
-`crates/flui-rendering/tests/render_object_harness.rs` is the CI-facing
+`crates/flui-objects/tests/render_object_harness.rs` is the CI-facing
 catalog: every concrete `RenderBox` / `RenderSliver` type is mounted
 through `RenderTester`, laid out (or painted when hit-test / layer
 structure matters), and asserted via `Probe` + structured diagnostics
 queries. The file header lists a per-type coverage map; `RENDER_OBJECT_TYPES`
-is the manifest of all 37 exported render types; and
+is the manifest of all 81 exported render types (count it yourself —
+`RENDER_OBJECT_TYPES` in that file — if this drifts again); and
 `catalog_covers_every_render_object_name` fails CI if any type is missing
-from the harness file. Add a harness test when landing a new render object
-so layout, hit-test, and config/runtime diagnostics stay pinned without
-visual inspection.
+from the harness file, and `render_object_types_match_exports` fails CI if
+the catalog and this crate's `pub use` exports diverge. Add a harness test
+when landing a new render object so layout, hit-test, and config/runtime
+diagnostics stay pinned without visual inspection.
 
 Parent metadata that widgets normally write before layout (stack
 positioning, flex factors, future animation parent slots) can be expressed
@@ -272,8 +277,12 @@ RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-it
 cargo nextest run --workspace --exclude flui-platform --locked --no-fail-fast
 cargo test --workspace --exclude flui-platform --locked --doc
 cargo check --workspace --all-targets --locked                # repeated on Rust 1.97 (MSRV job)
-cargo miri test -p flui-rendering --lib pipeline::owner::subtree_arena  # advisory; NARROW — 5 unit tests,
-                                                              # none enters the layout walk or derefs a real NodePtr
+cargo +nightly miri test -p flui-rendering --lib pipeline::owner::subtree_arena  # advisory (continue-on-error); NARROW —
+                                                              # covers two real-NodePtr walks driving layout_dirty_root
+                                                              # through every reborrow phase of layout_subtree_borrowed_impl
+                                                              # (one straight pass, one cyclic edge exercising the
+                                                              # baseline callback's in-flight gate). Sliver walks and
+                                                              # intrinsics queries are not interpreted.
 ```
 
 The `gpu-test` job additionally runs the full `enable-wgpu-tests` readback
@@ -293,4 +302,4 @@ A change cannot be merged if any of these fail. If you encounter a flaky test, f
 
 - [Getting Started](getting-started.md) — toolchain setup and first build
 - [Contributing](contributing.md) — workflow, commits, speckit
-- [`.specify/memory/constitution.md`](../.specify/memory/constitution.md) — constitutional performance and testing requirements
+- [`AGENTS.md`](../AGENTS.md) — current performance and testing requirements (`.specify/memory/constitution.md` does not exist in this checkout)


### PR DESCRIPTION
Implements the quick-win tier of the 2026-08-04 audit (`docs/audits/2026-08-04-full-audit.md` §2.3/§2.6/§3.4/§3.6/§3.9/§5) — truthfulness fixes across the shipped surface:

- **`flui devtools` no longer lies**: instead of printing "DevTools server started" while starting nothing, it states plainly that no server exists yet, names what IS available (the `InspectorCounters`/profiling observation seam), and exits nonzero via a typed not-implemented error. `FEATURES.md` rewritten to describe the real crate (real line/test counts, real default features, no fictional inspector API); every `flui_core` ghost-crate reference corrected.
- **ADR-0016 amended** (dated, history preserved): its `PaintingBinding::instance()` mechanism died in the painting-singleton retirement; the real shape (constructor-owned `FONT_SYSTEM` `OnceLock` + the registry-named ambient-read exclusion) is now stated.
- **Dead features annotated honestly** (flui-app `desktop`/`android`/`ios`/`web`/overlays, flui-platform `web`): zero `cfg(feature)` consumers, zero external selectors — kept as documented no-op selectors rather than deleted (verified against facade/examples/CI matrix; `facade-combos` green).
- **README's unsafe-boundary claim corrected to measured reality** (platform/rendering/hot-reload/engine; the previously-credited flui-painting has zero).
- **Doc-drift sweep**: `testing.md` (real `just ci` chain + the CI-only taplo/typos gates, correct harness path, real miri description, goldens exist), `crates.md` (dead links, counts, and — caught in review — a false layer-table pointer this very sweep almost introduced), `ci.yml` comment-only corrections (YAML-equality verified), the three divergent render-object counts unified at the counted **81**, ~11 stale `AppBinding`-as-live references reworded across six crates.
- **CHANGELOG catches up 112 commits** in one structured block (the singleton-retirement series #586–#593 with its full breaking list, #585, #577, #584, #576, #574, #571). Git tags deliberately left as a release-lead decision (noted).

Out of scope by design (later queue items): port-check whitelists, `expect("BUG:")` burn-down, the `.flutter/` oracle policy, lockfile dedup, flui-platform CI re-entry.

Review trail: independent recount of every numeric claim (render objects, unsafe counts, FEATURES.md table, CHANGELOG symbol list vs recorded public-api deltas), devtools traced through both feature configs, ci.yml parsed for functional equality. One reviewer-caught blocker (the false layer-table pointer) fixed; one reviewer nit withdrawn after recount.

Gates: `just ci` green (8568+31), facade-combos, conformance, port-check, taplo, typos, zizmor. `actionlint` unavailable locally (comment-only ci.yml edits; zizmor clean) — flagged, not skipped silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)