### PR TITLE
feat(gates): mechanical panic-policy expect-message gate + top-file burn-down

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 # Job graph (every job is gated on the fast `checks` source gate):
-#   checks         — fmt + taplo + typos + inventory + runtime-conformance + port-check + actionlint + zizmor (seconds, no compile)
+#   checks         — fmt + taplo + typos + inventory + runtime-conformance + panic-policy + port-check + actionlint + zizmor (seconds, no compile)
 #   clippy         — workspace lint with -D warnings
 #   feature-matrix — cargo-hack per-feature clippy (--each-feature --optional-deps), xilem-style,
 #                    plus a bounded backend-feature-pair powerset for flui-engine, plus every
@@ -59,7 +59,7 @@ env:
 jobs:
   # ─────────────────────────────────────────────────────────────────────────
   # checks — fast source gate. fmt + inventory + runtime-conformance +
-  # port-check + typos + Taplo + the workflow
+  # panic-policy + port-check + typos + Taplo + the workflow
   # linters (actionlint semantics, zizmor security audit). No compile. Every
   # downstream job (clippy, test, doc, bench-compile) depends on this, so a
   # malformed PR fails in seconds before any workspace build starts.
@@ -119,6 +119,9 @@ jobs:
 
       - name: Runtime contract registry check
         run: bash scripts/check-runtime-conformance.sh
+
+      - name: panic-policy expect("BUG: …") convention gate
+        run: bash scripts/check-panic-policy.sh
 
       - name: scripts/port-check.sh (22 refusal triggers + FR-033)
         run: bash scripts/port-check.sh -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Runtime contract registry check
         run: bash scripts/check-runtime-conformance.sh
 
-      - name: panic-policy expect("BUG: …") convention gate
+      - name: 'panic-policy expect-message convention gate'
         run: bash scripts/check-panic-policy.sh
 
       - name: scripts/port-check.sh (22 refusal triggers + FR-033)

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -3673,7 +3673,17 @@ where
 
     tracing::info!("Starting web platform via flui-platform");
 
-    let platform = flui_platform::current_platform().expect("Failed to initialize web platform");
+    // Platform init is an environment failure (unsupported browser, missing
+    // wasm feature, driver problem), not a `BUG:` invariant — see the
+    // matching comment in `run_desktop` above for why this is a `match` +
+    // `panic!` with a full error log instead of a bare `.expect()`.
+    let platform = match flui_platform::current_platform() {
+        Ok(platform) => platform,
+        Err(error) => {
+            tracing::error!(%error, "Failed to initialize platform");
+            panic!("web bootstrap failed: platform initialization error: {error:?}");
+        }
+    };
 
     /// The actual web bootstrap: canvas window, renderer, realm, and
     /// callback wiring. Runs once, synchronously, inside `on_ready` —

--- a/crates/flui-engine/src/wgpu/backend.rs
+++ b/crates/flui-engine/src/wgpu/backend.rs
@@ -399,7 +399,7 @@ impl<'frame> Backend<'frame> {
             let off = self
                 .offscreen
                 .as_deref_mut()
-                .expect("offscreen is_some checked above");
+                .expect("BUG: apply_backdrop_blur returned above when self.offscreen was None; nothing clears it before this borrow");
             (
                 Arc::clone(off.device()),
                 Arc::clone(off.queue()),
@@ -462,7 +462,7 @@ impl<'frame> Backend<'frame> {
         let blur_input = self
             .offscreen
             .as_deref_mut()
-            .expect("offscreen is_some checked above")
+            .expect("BUG: apply_backdrop_blur returned above when self.offscreen was None; nothing clears it before this borrow")
             .texture_pool()
             .acquire(w, h, format);
         flush_encoder.copy_texture_to_texture(
@@ -493,7 +493,7 @@ impl<'frame> Backend<'frame> {
         let blurred = self
             .offscreen
             .as_deref_mut()
-            .expect("offscreen is_some checked above")
+            .expect("BUG: apply_backdrop_blur returned above when self.offscreen was None; nothing clears it before this borrow")
             .render_blur(&blur_input, sigma);
         let clamped_composite_rect = Rect::from_xywh(
             Pixels(x as f32),
@@ -827,7 +827,7 @@ impl CommandRenderer for Backend<'_> {
                 let offscreen = self
                     .offscreen
                     .as_deref_mut()
-                    .expect("checked is_some above");
+                    .expect("BUG: self.offscreen.is_some() was checked above and nothing clears it before this borrow");
                 let device = Arc::clone(offscreen.device());
                 let queue = Arc::clone(offscreen.queue());
                 let format = offscreen.surface_format();
@@ -856,7 +856,7 @@ impl CommandRenderer for Backend<'_> {
                 let offscreen_painter = self
                     .offscreen_painter
                     .as_mut()
-                    .expect("offscreen_painter was just populated by get_or_create");
+                    .expect("BUG: get_or_create_offscreen_painter was just called above and always populates self.offscreen_painter");
                 // Reset per-frame clip/transform/opacity state before rendering
                 // into this painter.  Without this, a clip_rect command from a
                 // previous ShaderMask call in the same frame leaks
@@ -915,7 +915,7 @@ impl CommandRenderer for Backend<'_> {
             let offscreen_painter = self
                 .offscreen_painter
                 .as_mut()
-                .expect("offscreen_painter was populated in step 2 and not moved");
+                .expect("BUG: get_or_create_offscreen_painter populated self.offscreen_painter in step 2 above and nothing takes or clears it before this borrow");
             if let Err(e) = offscreen_painter.render(child_target, &mut encoder) {
                 tracing::error!("Failed to render shader mask child content: {}", e);
             }
@@ -929,7 +929,7 @@ impl CommandRenderer for Backend<'_> {
                 let offscreen = self
                     .offscreen
                     .as_deref_mut()
-                    .expect("checked is_some above");
+                    .expect("BUG: self.offscreen.is_some() was checked above and nothing clears it before this borrow");
                 let result = offscreen.render_masked(
                     bounds,
                     result_size,

--- a/crates/flui-foundation/src/id.rs
+++ b/crates/flui-foundation/src/id.rs
@@ -808,7 +808,7 @@ impl<T: Marker> GenId<T> {
         let packed = (u64::from(generation.get()) << 32) | u64::from(index);
         Self(
             core::num::NonZeroU64::new(packed)
-                .expect("generation >= 1 ensures packed value is non-zero"),
+                .expect("BUG: generation is typed NonZeroU32, so generation >= 1 always keeps the packed value's high bits non-zero"),
             PhantomData,
         )
     }
@@ -852,7 +852,7 @@ impl<T: Marker> GenId<T> {
     pub fn generation(self) -> core::num::NonZeroU32 {
         let generation = (self.0.get() >> 32) as u32;
         core::num::NonZeroU32::new(generation)
-            .expect("GenId generation is always >= 1; packed value invariant violated")
+            .expect("BUG: every GenId is built via new/new_gen, which only accept a NonZeroU32 generation, so the packed high bits are always non-zero")
     }
 
     /// The raw packed `NonZeroU64` value (tracing/logging).
@@ -1199,7 +1199,7 @@ impl ElementId {
         // packed value is always non-zero.
         Self(
             core::num::NonZeroU64::new(packed)
-                .expect("generation >= 1 ensures packed value is non-zero"),
+                .expect("BUG: generation is typed NonZeroU32, so generation >= 1 always keeps the packed value's high bits non-zero"),
         )
     }
 
@@ -1262,7 +1262,7 @@ impl ElementId {
         let generation = (self.0.get() >> 32) as u32;
         // Invariant: `new_gen` only accepts `NonZeroU32`, so generation is always >= 1.
         core::num::NonZeroU32::new(generation)
-            .expect("ElementId generation is always >= 1; packed value invariant violated")
+            .expect("BUG: every ElementId is built via new/new_gen, which only accept a NonZeroU32 generation, so the packed high bits are always non-zero")
     }
 
     /// The raw packed `NonZeroU64` value. Useful for tracing / logging.

--- a/crates/flui-foundation/src/id.rs
+++ b/crates/flui-foundation/src/id.rs
@@ -1248,11 +1248,13 @@ impl ElementId {
     ///
     /// # Panics
     ///
-    /// In practice this function cannot panic: any `ElementId` constructed via
-    /// `new` or `new_gen` has a non-zero generation in the high 32 bits. The
-    /// `.expect` is a proof guard that fires only if a zero-generation id was
-    /// somehow constructed outside the public API, which is prevented by the
-    /// `NonZeroU64` newtype wrapper.
+    /// In practice this function cannot panic: every `ElementId` construction
+    /// path keeps the high 32 bits non-zero — `new`/`new_gen` require a
+    /// `NonZeroU32` generation by their own typing, and `Deserialize` (the
+    /// only other path) explicitly rejects a zero generation field before
+    /// building the value. The `.expect` is a proof guard that fires only if
+    /// a zero-generation id was somehow constructed outside all of the above,
+    /// which the `NonZeroU64` newtype wrapper prevents.
     #[inline]
     #[must_use]
     pub fn generation(self) -> core::num::NonZeroU32 {
@@ -1260,9 +1262,10 @@ impl ElementId {
         // `new_gen` requires a `NonZeroU32` generation, and the minimum packed
         // value with generation=1 is `1 << 32` which has non-zero high bits.
         let generation = (self.0.get() >> 32) as u32;
-        // Invariant: `new_gen` only accepts `NonZeroU32`, so generation is always >= 1.
+        // Invariant: every construction path (new/new_gen's NonZeroU32 typing,
+        // Deserialize's explicit validation) keeps generation >= 1.
         core::num::NonZeroU32::new(generation)
-            .expect("BUG: every ElementId is built via new/new_gen, which only accept a NonZeroU32 generation, so the packed high bits are always non-zero")
+            .expect("BUG: the high 32 bits are a NonZeroU32 generation by construction (new/new_gen typing; Deserialize validation)")
     }
 
     /// The raw packed `NonZeroU64` value. Useful for tracing / logging.

--- a/crates/flui-hot-reload/src/worker.rs
+++ b/crates/flui-hot-reload/src/worker.rs
@@ -70,11 +70,11 @@ extern "C" fn host_register_worker_build(fingerprint: u64, build: *const ()) {
     let ptr = BuildPtr(build);
     worker_builds()
         .lock()
-        .expect("worker build registry poisoned")
+        .expect("BUG: WORKER_BUILDS mutex is never held across a panic; poisoning means a bug elsewhere already corrupted host state")
         .insert(fingerprint, ptr);
     if let Some(session) = &mut *REGISTRATION_SESSION
         .lock()
-        .expect("worker registration session poisoned")
+        .expect("BUG: REGISTRATION_SESSION mutex is never held across a panic; poisoning means a bug elsewhere already corrupted host state")
     {
         session.push((fingerprint, ptr));
     } else {
@@ -111,7 +111,7 @@ pub fn host_register_fn() -> RegisterWorkerBuildFn {
 pub fn get_worker_build_ptr(fingerprint: u64) -> Option<*const ()> {
     worker_builds()
         .lock()
-        .expect("worker build registry poisoned")
+        .expect("BUG: WORKER_BUILDS mutex is never held across a panic; poisoning means a bug elsewhere already corrupted host state")
         .get(&fingerprint)
         .map(|slot| slot.0)
 }
@@ -217,18 +217,18 @@ impl WorkerPlugin {
         {
             let mut session = REGISTRATION_SESSION
                 .lock()
-                .expect("worker registration session poisoned");
+                .expect("BUG: REGISTRATION_SESSION mutex is never held across a panic; poisoning means a bug elsewhere already corrupted host state");
             *session = Some(Vec::new());
         }
         (self.init_fn)(host_register_fn());
         let registered_now = REGISTRATION_SESSION
             .lock()
-            .expect("worker registration session poisoned")
+            .expect("BUG: REGISTRATION_SESSION mutex is never held across a panic; poisoning means a bug elsewhere already corrupted host state")
             .take()
             .unwrap_or_default();
         self.registered
             .lock()
-            .expect("worker registration list poisoned")
+            .expect("BUG: WorkerPlugin::registered mutex is never held across a panic; poisoning means a bug elsewhere already corrupted host state")
             .extend(registered_now);
     }
 
@@ -272,14 +272,14 @@ impl Drop for WorkerPlugin {
             &mut *self
                 .registered
                 .lock()
-                .expect("worker registration list poisoned"),
+                .expect("BUG: WorkerPlugin::registered mutex is never held across a panic; poisoning means a bug elsewhere already corrupted host state"),
         );
         if registered.is_empty() {
             return;
         }
         let mut builds = worker_builds()
             .lock()
-            .expect("worker build registry poisoned");
+            .expect("BUG: WORKER_BUILDS mutex is never held across a panic; poisoning means a bug elsewhere already corrupted host state");
         for (fingerprint, ptr) in registered {
             if builds.get(&fingerprint) == Some(&ptr) {
                 builds.remove(&fingerprint);
@@ -426,7 +426,10 @@ impl WorkerReloadDriver {
                 path = %load_path.display(),
                 "WorkerReloadDriver: worker dylib updated — reloading"
             );
-            let old = self.plugin.take().expect("plugin was Some");
+            let old = self
+                .plugin
+                .take()
+                .expect("BUG: self.plugin just matched Some above and nothing else can clear it before this take() runs");
             old.unload();
 
             self.plugin = WorkerPlugin::load(&load_path);

--- a/crates/flui-painting/src/text_painter/paint.rs
+++ b/crates/flui-painting/src/text_painter/paint.rs
@@ -30,7 +30,7 @@ impl TextPainter {
         let cache = self
             .layout_cache
             .as_mut()
-            .expect("layout() must be called before get_offset_for_caret()");
+            .expect("BUG: layout() must be called before get_offset_for_caret() — the paint pipeline runs perform_layout before paint");
 
         let offset = cache.layout.get_offset_for_caret(position);
 
@@ -49,7 +49,7 @@ impl TextPainter {
         let cache = self
             .layout_cache
             .as_ref()
-            .expect("layout() must be called before get_position_for_offset()");
+            .expect("BUG: layout() must be called before get_position_for_offset() — the paint pipeline runs perform_layout before paint");
 
         let adjusted = offset - cache.paint_offset;
         cache.layout.get_position_for_offset(adjusted)
@@ -67,7 +67,7 @@ impl TextPainter {
         let cache = self
             .layout_cache
             .as_ref()
-            .expect("layout() must be called before get_line_metrics()");
+            .expect("BUG: layout() must be called before get_line_metrics() — the paint pipeline runs perform_layout before paint");
 
         cache.layout.get_line_metrics()
     }
@@ -84,7 +84,7 @@ impl TextPainter {
         let cache = self
             .layout_cache
             .as_ref()
-            .expect("layout() must be called before get_boxes_for_selection()");
+            .expect("BUG: layout() must be called before get_boxes_for_selection() — the paint pipeline runs perform_layout before paint");
 
         let mut boxes = cache.layout.get_boxes_for_range(TextRange::new(start, end));
 
@@ -107,7 +107,7 @@ impl TextPainter {
         let cache = self
             .layout_cache
             .as_ref()
-            .expect("layout() must be called before get_word_boundary()");
+            .expect("BUG: layout() must be called before get_word_boundary() — the paint pipeline runs perform_layout before paint");
 
         cache.layout.get_word_boundary(position)
     }
@@ -129,12 +129,12 @@ impl TextPainter {
         let text = self
             .text
             .as_ref()
-            .expect("TextPainter.text must be set before paint");
+            .expect("BUG: TextPainter.text must be set before paint() — layout() requires text, and the paint pipeline runs layout before paint");
 
         let cache = self
             .layout_cache
             .as_ref()
-            .expect("layout() must be called before paint()");
+            .expect("BUG: layout() must be called before paint() — the paint pipeline runs perform_layout before paint");
 
         let paint_offset = offset + cache.paint_offset;
 

--- a/crates/flui-painting/src/text_painter/paint.rs
+++ b/crates/flui-painting/src/text_painter/paint.rs
@@ -30,7 +30,7 @@ impl TextPainter {
         let cache = self
             .layout_cache
             .as_mut()
-            .expect("BUG: layout() must be called before get_offset_for_caret() — the paint pipeline runs perform_layout before paint");
+            .expect("BUG: TextPainter::layout() must be called before get_offset_for_caret() — it reads the cached layout that layout() populates");
 
         let offset = cache.layout.get_offset_for_caret(position);
 
@@ -49,7 +49,7 @@ impl TextPainter {
         let cache = self
             .layout_cache
             .as_ref()
-            .expect("BUG: layout() must be called before get_position_for_offset() — the paint pipeline runs perform_layout before paint");
+            .expect("BUG: TextPainter::layout() must be called before get_position_for_offset() — it reads the cached layout that layout() populates");
 
         let adjusted = offset - cache.paint_offset;
         cache.layout.get_position_for_offset(adjusted)
@@ -67,7 +67,7 @@ impl TextPainter {
         let cache = self
             .layout_cache
             .as_ref()
-            .expect("BUG: layout() must be called before get_line_metrics() — the paint pipeline runs perform_layout before paint");
+            .expect("BUG: TextPainter::layout() must be called before get_line_metrics() — it reads the cached layout that layout() populates");
 
         cache.layout.get_line_metrics()
     }
@@ -84,7 +84,7 @@ impl TextPainter {
         let cache = self
             .layout_cache
             .as_ref()
-            .expect("BUG: layout() must be called before get_boxes_for_selection() — the paint pipeline runs perform_layout before paint");
+            .expect("BUG: TextPainter::layout() must be called before get_boxes_for_selection() — it reads the cached layout that layout() populates");
 
         let mut boxes = cache.layout.get_boxes_for_range(TextRange::new(start, end));
 
@@ -107,7 +107,7 @@ impl TextPainter {
         let cache = self
             .layout_cache
             .as_ref()
-            .expect("BUG: layout() must be called before get_word_boundary() — the paint pipeline runs perform_layout before paint");
+            .expect("BUG: TextPainter::layout() must be called before get_word_boundary() — it reads the cached layout that layout() populates");
 
         cache.layout.get_word_boundary(position)
     }
@@ -129,12 +129,12 @@ impl TextPainter {
         let text = self
             .text
             .as_ref()
-            .expect("BUG: TextPainter.text must be set before paint() — layout() requires text, and the paint pipeline runs layout before paint");
+            .expect("BUG: TextPainter.text must be set before paint() — TextPainter::layout() requires text to be set, and paint() requires layout() to have run first");
 
         let cache = self
             .layout_cache
             .as_ref()
-            .expect("BUG: layout() must be called before paint() — the paint pipeline runs perform_layout before paint");
+            .expect("BUG: TextPainter::layout() must be called before paint() — it reads the cached layout that layout() populates");
 
         let paint_offset = offset + cache.paint_offset;
 

--- a/crates/flui-widgets/src/scroll/refresh_indicator.rs
+++ b/crates/flui-widgets/src/scroll/refresh_indicator.rs
@@ -152,7 +152,7 @@ impl RefreshController {
             .inner
             .is_refreshing
             .lock()
-            .expect("refresh controller mutex poisoned: is_refreshing field corrupted")
+            .expect("BUG: RefreshController is_refreshing mutex is never held across a panic; poisoning means a bug elsewhere already corrupted controller state")
     }
 
     /// The current pull distance in logical pixels.
@@ -165,7 +165,7 @@ impl RefreshController {
             .inner
             .pull_distance_px
             .lock()
-            .expect("refresh controller mutex poisoned: pull_distance_px field corrupted")
+            .expect("BUG: RefreshController pull_distance_px mutex is never held across a panic; poisoning means a bug elsewhere already corrupted controller state")
     }
 
     /// Signal that the refresh operation is complete. Hides the spinner and
@@ -177,7 +177,7 @@ impl RefreshController {
             .inner
             .is_refreshing
             .lock()
-            .expect("refresh controller mutex poisoned: is_refreshing field corrupted");
+            .expect("BUG: RefreshController is_refreshing mutex is never held across a panic; poisoning means a bug elsewhere already corrupted controller state");
         *guard = false;
         drop(guard);
         self.inner.notifier.notify_listeners();
@@ -199,7 +199,7 @@ impl RefreshController {
             .inner
             .pull_distance_px
             .lock()
-            .expect("refresh controller mutex poisoned: pull_distance_px field corrupted") =
+            .expect("BUG: RefreshController pull_distance_px mutex is never held across a panic; poisoning means a bug elsewhere already corrupted controller state") =
             distance_px;
         self.inner.notifier.notify_listeners();
     }
@@ -210,12 +210,12 @@ impl RefreshController {
                 .inner
                 .is_refreshing
                 .lock()
-                .expect("refresh controller mutex poisoned: is_refreshing field corrupted");
+                .expect("BUG: RefreshController is_refreshing mutex is never held across a panic; poisoning means a bug elsewhere already corrupted controller state");
             let mut pull = self
                 .inner
                 .pull_distance_px
                 .lock()
-                .expect("refresh controller mutex poisoned: pull_distance_px field corrupted");
+                .expect("BUG: RefreshController pull_distance_px mutex is never held across a panic; poisoning means a bug elsewhere already corrupted controller state");
             *refreshing = true;
             *pull = 0.0;
         }
@@ -398,7 +398,7 @@ impl StatefulView for RefreshIndicator {
             f32::NEG_INFINITY,
             f32::INFINITY,
         )
-        .expect("NEG_INFINITY < INFINITY satisfies the bounds invariant");
+        .expect("BUG: NEG_INFINITY < INFINITY is a hardcoded literal pair, so without_ticker_bounds can never reject it");
 
         RefreshIndicatorState {
             scroll_controller: self.scroll_controller.clone(),

--- a/docs/PANIC-POLICY.md
+++ b/docs/PANIC-POLICY.md
@@ -72,3 +72,13 @@ the message, not the call. Audit them with:
 rg '\.expect\("(?!BUG: )' crates/*/src --pcre2   # expects missing the convention
 rg '\.unwrap\(\)' crates/*/src                   # should be test-only or allow-tracked
 ```
+
+**Mechanical gate.** `scripts/check-panic-policy.sh` (`just
+panic-policy-check`, wired into `just ci` and the CI `checks` job) enforces
+the `BUG:` prefix on every production `expect()` under `crates/*/src`,
+excluding `#[cfg(test)]`/`#[cfg(any(test, feature = "testing"))]`-gated
+modules, functions, and impls (test-support code is exempt, same as
+`tests/`/`benches/`/`examples/`). It is a per-file, shrink-only ratchet
+against `docs/panic-policy-allowlist.txt`: a file with a non-conforming site
+must be listed there, and a listed file that has been fully burned down must
+be delisted — the script fails either way it drifts.

--- a/docs/panic-policy-allowlist.txt
+++ b/docs/panic-policy-allowlist.txt
@@ -16,21 +16,18 @@
 # environmental failure to a typed `Result` per docs/PANIC-POLICY.md's table
 # -- never by blanket-prefixing without reading the site.
 #
-# Seeded 2026-08-04 from the audit's expect("BUG: …") burn-down item. The
-# worst-offender files the audit named are deliberately absent from this
-# list, having been burned down in the same change that seeded it:
-# flui-hot-reload/src/worker.rs, flui-engine/src/wgpu/backend.rs,
-# flui-painting/src/text_painter/paint.rs,
+# Seeded 2026-08-04 with the worst offenders already burned down in the same
+# change that seeded this list: flui-hot-reload/src/worker.rs,
+# flui-engine/src/wgpu/backend.rs, flui-painting/src/text_painter/paint.rs,
 # flui-widgets/src/scroll/refresh_indicator.rs (all fully conforming now),
 # and flui-app/src/app/runner.rs (its one site converted to match
 # run_desktop's environmental-failure pattern instead of reworded, since the
 # failure is a real platform-init error, not an invariant).
-# flui-rendering/src/testing/harness.rs -- the audit's sixth named file --
-# never belonged on this list at all: it lives under a
-# `#[cfg(any(test, feature = "testing"))]`-gated module (test-support,
-# compiled only for this crate's own tests or an opt-in consumer feature),
-# which check-panic-policy.sh's whole-module exclusion (mirroring
-# `tests/`/`benches/`/`examples/`) correctly never scans.
+# flui-rendering/src/testing/harness.rs never belonged on this list at all:
+# it lives under a `#[cfg(any(test, feature = "testing"))]`-gated module
+# (test-support, compiled only for this crate's own tests or an opt-in
+# consumer feature), which check-panic-policy.sh's whole-module exclusion
+# (mirroring `tests/`/`benches/`/`examples/`) correctly never scans.
 #
 # flui-foundation/src/id.rs keeps 3 of its original 7 sites here rather than
 # rewording them: `RawId::zip`, `GenId::new`, and `ElementId::new` all carry

--- a/docs/panic-policy-allowlist.txt
+++ b/docs/panic-policy-allowlist.txt
@@ -2,14 +2,22 @@
 # enforced by scripts/check-panic-policy.sh (wired into `just
 # panic-policy-check` and `just ci`).
 #
-# Each line below names a file under crates/*/src that still has at least
-# one production `expect()` call whose message does not start with `BUG: `.
-# This is a SHRINK-ONLY ratchet, not a permanent exemption list:
+# Format: `relative/path.rs <count>`, one entry per line. `<count>` is the
+# file's CURRENT number of production `expect()` sites whose message does
+# not start with `BUG: ` -- it is load-bearing, not a label: the checker
+# compares it against the file's actual count on every run. This is a
+# SHRINK-ONLY ratchet per file, not merely per file-set:
 #
 #   * a file with a non-conforming site that is NOT listed here fails the
 #     gate (new debt must be declared here, not introduced silently);
-#   * a file listed here that no longer has any non-conforming site ALSO
-#     fails the gate (a cleaned file must leave this list).
+#   * a file listed here whose actual count no longer matches the listed
+#     count fails in EITHER direction -- higher (new bare expect() calls
+#     landed in an already-listed file; staying "on the list" is not a free
+#     pass to keep adding debt) or lower (the file improved but the count
+#     was not updated down, which would let a later regression back up to
+#     the stale number go unnoticed);
+#   * a file listed here with zero actual sites left ALSO fails (a fully
+#     cleaned file must leave this list).
 #
 # Burn down by rewording a genuine internal invariant to
 # `expect("BUG: <invariant>")`, or converting a genuinely caller-triggerable/
@@ -40,68 +48,68 @@
 # Out of scope for an internal-only pass; recorded as a breaking-API item in
 # the panic-policy-gate PR notes instead of forced into either bucket.
 
-crates/flui-animation/src/controller.rs
-crates/flui-devtools/src/hot_reload.rs
-crates/flui-engine/src/wgpu/advanced_blend/pipeline.rs
-crates/flui-engine/src/wgpu/batches/images.rs
-crates/flui-engine/src/wgpu/headless.rs
-crates/flui-engine/src/wgpu/mode/pipeline.rs
-crates/flui-engine/src/wgpu/offscreen/blit.rs
-crates/flui-engine/src/wgpu/offscreen/blur.rs
-crates/flui-engine/src/wgpu/offscreen/mask.rs
-crates/flui-engine/src/wgpu/renderer.rs
-crates/flui-engine/src/wgpu/state_stack.rs
-crates/flui-engine/src/wgpu/texture_cache.rs
-crates/flui-engine/src/wgpu/texture_pool.rs
-crates/flui-foundation/src/id.rs
-crates/flui-foundation/src/key.rs
-crates/flui-hot-reload/src/dev/source_watch.rs
-crates/flui-hot-reload/src/driver.rs
-crates/flui-hot-reload/src/plugin.rs
-crates/flui-interaction/src/binding.rs
-crates/flui-interaction/src/ids.rs
-crates/flui-interaction/src/processing/resampler.rs
-crates/flui-interaction/src/processing/sampling_clock.rs
-crates/flui-interaction/src/processing/velocity.rs
-crates/flui-interaction/src/recognizers/multidrag.rs
-crates/flui-macros/src/derive_animatable.rs
-crates/flui-macros/src/derive_diagnosticable.rs
-crates/flui-material/src/ink_well.rs
-crates/flui-material/src/scaffold.rs
-crates/flui-material/src/scaffold_messenger.rs
-crates/flui-material/src/tab_bar_view.rs
-crates/flui-material/src/tab_controller.rs
-crates/flui-material/src/tabs.rs
-crates/flui-material/src/theme.rs
-crates/flui-painting/src/text_painter/measure.rs
-crates/flui-platform/src/executor.rs
-crates/flui-platform/src/platforms/android/memory.rs
-crates/flui-platform/src/platforms/macos/view.rs
-crates/flui-platform/src/platforms/macos/window.rs
-crates/flui-platform/src/platforms/web/display.rs
-crates/flui-platform/src/platforms/web/events.rs
-crates/flui-platform/src/platforms/web/platform.rs
-crates/flui-platform/src/platforms/web/window.rs
-crates/flui-platform/src/platforms/winit/clipboard.rs
-crates/flui-platform/src/task.rs
-crates/flui-rendering/src/pipeline/owner/paint.rs
-crates/flui-rendering/src/pipeline/scheduler.rs
-crates/flui-rendering/src/storage/node.rs
-crates/flui-rendering/src/storage/tree.rs
-crates/flui-rendering/src/view/render_view.rs
-crates/flui-rendering/src/virtualization/sumtree.rs
-crates/flui-scheduler/src/budget.rs
-crates/flui-scheduler/src/frame.rs
-crates/flui-scheduler/src/scheduler.rs
-crates/flui-scheduler/src/vsync.rs
-crates/flui-testing/src/lib.rs
-crates/flui-view/src/element/behavior.rs
-crates/flui-view/src/tree/element_tree.rs
-crates/flui-view/src/tree/id_reconcile.rs
-crates/flui-widgets/src/app/media_query.rs
-crates/flui-widgets/src/interaction/focus.rs
-crates/flui-widgets/src/interaction/gesture_detector.rs
-crates/flui-widgets/src/navigator/hero.rs
-crates/flui-widgets/src/navigator/transition_route.rs
-crates/flui-widgets/src/overlay/mod.rs
-crates/flui-widgets/src/scroll/scrollable.rs
+crates/flui-animation/src/controller.rs 4
+crates/flui-devtools/src/hot_reload.rs 1
+crates/flui-engine/src/wgpu/advanced_blend/pipeline.rs 1
+crates/flui-engine/src/wgpu/batches/images.rs 3
+crates/flui-engine/src/wgpu/headless.rs 1
+crates/flui-engine/src/wgpu/mode/pipeline.rs 1
+crates/flui-engine/src/wgpu/offscreen/blit.rs 1
+crates/flui-engine/src/wgpu/offscreen/blur.rs 3
+crates/flui-engine/src/wgpu/offscreen/mask.rs 2
+crates/flui-engine/src/wgpu/renderer.rs 2
+crates/flui-engine/src/wgpu/state_stack.rs 2
+crates/flui-engine/src/wgpu/texture_cache.rs 2
+crates/flui-engine/src/wgpu/texture_pool.rs 3
+crates/flui-foundation/src/id.rs 3
+crates/flui-foundation/src/key.rs 4
+crates/flui-hot-reload/src/dev/source_watch.rs 1
+crates/flui-hot-reload/src/driver.rs 1
+crates/flui-hot-reload/src/plugin.rs 1
+crates/flui-interaction/src/binding.rs 1
+crates/flui-interaction/src/ids.rs 2
+crates/flui-interaction/src/processing/resampler.rs 1
+crates/flui-interaction/src/processing/sampling_clock.rs 1
+crates/flui-interaction/src/processing/velocity.rs 2
+crates/flui-interaction/src/recognizers/multidrag.rs 1
+crates/flui-macros/src/derive_animatable.rs 1
+crates/flui-macros/src/derive_diagnosticable.rs 1
+crates/flui-material/src/ink_well.rs 2
+crates/flui-material/src/scaffold.rs 1
+crates/flui-material/src/scaffold_messenger.rs 1
+crates/flui-material/src/tab_bar_view.rs 2
+crates/flui-material/src/tab_controller.rs 1
+crates/flui-material/src/tabs.rs 5
+crates/flui-material/src/theme.rs 1
+crates/flui-painting/src/text_painter/measure.rs 5
+crates/flui-platform/src/executor.rs 1
+crates/flui-platform/src/platforms/android/memory.rs 2
+crates/flui-platform/src/platforms/macos/view.rs 2
+crates/flui-platform/src/platforms/macos/window.rs 2
+crates/flui-platform/src/platforms/web/display.rs 2
+crates/flui-platform/src/platforms/web/events.rs 1
+crates/flui-platform/src/platforms/web/platform.rs 1
+crates/flui-platform/src/platforms/web/window.rs 1
+crates/flui-platform/src/platforms/winit/clipboard.rs 1
+crates/flui-platform/src/task.rs 1
+crates/flui-rendering/src/pipeline/owner/paint.rs 2
+crates/flui-rendering/src/pipeline/scheduler.rs 2
+crates/flui-rendering/src/storage/node.rs 2
+crates/flui-rendering/src/storage/tree.rs 5
+crates/flui-rendering/src/view/render_view.rs 1
+crates/flui-rendering/src/virtualization/sumtree.rs 6
+crates/flui-scheduler/src/budget.rs 3
+crates/flui-scheduler/src/frame.rs 2
+crates/flui-scheduler/src/scheduler.rs 4
+crates/flui-scheduler/src/vsync.rs 1
+crates/flui-testing/src/lib.rs 3
+crates/flui-view/src/element/behavior.rs 2
+crates/flui-view/src/tree/element_tree.rs 5
+crates/flui-view/src/tree/id_reconcile.rs 2
+crates/flui-widgets/src/app/media_query.rs 1
+crates/flui-widgets/src/interaction/focus.rs 1
+crates/flui-widgets/src/interaction/gesture_detector.rs 1
+crates/flui-widgets/src/navigator/hero.rs 1
+crates/flui-widgets/src/navigator/transition_route.rs 1
+crates/flui-widgets/src/overlay/mod.rs 1
+crates/flui-widgets/src/scroll/scrollable.rs 1

--- a/docs/panic-policy-allowlist.txt
+++ b/docs/panic-policy-allowlist.txt
@@ -1,0 +1,110 @@
+# Per-file ratchet for docs/PANIC-POLICY.md's `expect("BUG: …")` convention,
+# enforced by scripts/check-panic-policy.sh (wired into `just
+# panic-policy-check` and `just ci`).
+#
+# Each line below names a file under crates/*/src that still has at least
+# one production `expect()` call whose message does not start with `BUG: `.
+# This is a SHRINK-ONLY ratchet, not a permanent exemption list:
+#
+#   * a file with a non-conforming site that is NOT listed here fails the
+#     gate (new debt must be declared here, not introduced silently);
+#   * a file listed here that no longer has any non-conforming site ALSO
+#     fails the gate (a cleaned file must leave this list).
+#
+# Burn down by rewording a genuine internal invariant to
+# `expect("BUG: <invariant>")`, or converting a genuinely caller-triggerable/
+# environmental failure to a typed `Result` per docs/PANIC-POLICY.md's table
+# -- never by blanket-prefixing without reading the site.
+#
+# Seeded 2026-08-04 from the audit's expect("BUG: …") burn-down item. The
+# worst-offender files the audit named are deliberately absent from this
+# list, having been burned down in the same change that seeded it:
+# flui-hot-reload/src/worker.rs, flui-engine/src/wgpu/backend.rs,
+# flui-painting/src/text_painter/paint.rs,
+# flui-widgets/src/scroll/refresh_indicator.rs (all fully conforming now),
+# and flui-app/src/app/runner.rs (its one site converted to match
+# run_desktop's environmental-failure pattern instead of reworded, since the
+# failure is a real platform-init error, not an invariant).
+# flui-rendering/src/testing/harness.rs -- the audit's sixth named file --
+# never belonged on this list at all: it lives under a
+# `#[cfg(any(test, feature = "testing"))]`-gated module (test-support,
+# compiled only for this crate's own tests or an opt-in consumer feature),
+# which check-panic-policy.sh's whole-module exclusion (mirroring
+# `tests/`/`benches/`/`examples/`) correctly never scans.
+#
+# flui-foundation/src/id.rs keeps 3 of its original 7 sites here rather than
+# rewording them: `RawId::zip`, `GenId::new`, and `ElementId::new` all carry
+# a documented `# Panics` section and are genuinely caller-triggerable (a
+# caller passes an index of 0, or one that overflows u32) rather than an
+# internal invariant this module maintains -- the strict PANIC-POLICY.md
+# reading calls for a `Result`, but `zip` is the ID offset pattern's public,
+# widely-used constructor (`AGENTS.md`'s "Insert: slab_index + 1"); making it
+# fallible would ripple across every ID type in every crate that mints one.
+# Out of scope for an internal-only pass; recorded as a breaking-API item in
+# the panic-policy-gate PR notes instead of forced into either bucket.
+
+crates/flui-animation/src/controller.rs
+crates/flui-devtools/src/hot_reload.rs
+crates/flui-engine/src/wgpu/advanced_blend/pipeline.rs
+crates/flui-engine/src/wgpu/batches/images.rs
+crates/flui-engine/src/wgpu/headless.rs
+crates/flui-engine/src/wgpu/mode/pipeline.rs
+crates/flui-engine/src/wgpu/offscreen/blit.rs
+crates/flui-engine/src/wgpu/offscreen/blur.rs
+crates/flui-engine/src/wgpu/offscreen/mask.rs
+crates/flui-engine/src/wgpu/renderer.rs
+crates/flui-engine/src/wgpu/state_stack.rs
+crates/flui-engine/src/wgpu/texture_cache.rs
+crates/flui-engine/src/wgpu/texture_pool.rs
+crates/flui-foundation/src/id.rs
+crates/flui-foundation/src/key.rs
+crates/flui-hot-reload/src/dev/source_watch.rs
+crates/flui-hot-reload/src/driver.rs
+crates/flui-hot-reload/src/plugin.rs
+crates/flui-interaction/src/binding.rs
+crates/flui-interaction/src/ids.rs
+crates/flui-interaction/src/processing/resampler.rs
+crates/flui-interaction/src/processing/sampling_clock.rs
+crates/flui-interaction/src/processing/velocity.rs
+crates/flui-interaction/src/recognizers/multidrag.rs
+crates/flui-macros/src/derive_animatable.rs
+crates/flui-macros/src/derive_diagnosticable.rs
+crates/flui-material/src/ink_well.rs
+crates/flui-material/src/scaffold.rs
+crates/flui-material/src/scaffold_messenger.rs
+crates/flui-material/src/tab_bar_view.rs
+crates/flui-material/src/tab_controller.rs
+crates/flui-material/src/tabs.rs
+crates/flui-material/src/theme.rs
+crates/flui-painting/src/text_painter/measure.rs
+crates/flui-platform/src/executor.rs
+crates/flui-platform/src/platforms/android/memory.rs
+crates/flui-platform/src/platforms/macos/view.rs
+crates/flui-platform/src/platforms/macos/window.rs
+crates/flui-platform/src/platforms/web/display.rs
+crates/flui-platform/src/platforms/web/events.rs
+crates/flui-platform/src/platforms/web/platform.rs
+crates/flui-platform/src/platforms/web/window.rs
+crates/flui-platform/src/platforms/winit/clipboard.rs
+crates/flui-platform/src/task.rs
+crates/flui-rendering/src/pipeline/owner/paint.rs
+crates/flui-rendering/src/pipeline/scheduler.rs
+crates/flui-rendering/src/storage/node.rs
+crates/flui-rendering/src/storage/tree.rs
+crates/flui-rendering/src/view/render_view.rs
+crates/flui-rendering/src/virtualization/sumtree.rs
+crates/flui-scheduler/src/budget.rs
+crates/flui-scheduler/src/frame.rs
+crates/flui-scheduler/src/scheduler.rs
+crates/flui-scheduler/src/vsync.rs
+crates/flui-testing/src/lib.rs
+crates/flui-view/src/element/behavior.rs
+crates/flui-view/src/tree/element_tree.rs
+crates/flui-view/src/tree/id_reconcile.rs
+crates/flui-widgets/src/app/media_query.rs
+crates/flui-widgets/src/interaction/focus.rs
+crates/flui-widgets/src/interaction/gesture_detector.rs
+crates/flui-widgets/src/navigator/hero.rs
+crates/flui-widgets/src/navigator/transition_route.rs
+crates/flui-widgets/src/overlay/mod.rs
+crates/flui-widgets/src/scroll/scrollable.rs

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -1199,15 +1199,15 @@ registry is the only one in the workspace that tracks a contract's \
 `mechanical`/`mechanism` pair. Enforcement is a per-file, shrink-only ratchet \
 (docs/panic-policy-allowlist.txt): a file with a non-conforming site must be \
 listed, and a listed file that has been fully burned down must be delisted. \
-Seeded 2026-08-04 at 65 listed files / 125 sites, down from the audit's 158 \
-after burning down the five worst-offender files it named (flui-hot-reload's \
-worker.rs, flui-engine's wgpu/backend.rs, flui-painting's \
+Seeded 2026-08-04 at 65 listed files / 125 sites, down from 158 non-conforming \
+sites at introduction after burning down the five worst-offender files \
+(flui-hot-reload's worker.rs, flui-engine's wgpu/backend.rs, flui-painting's \
 text_painter/paint.rs, flui-widgets' scroll/refresh_indicator.rs, and one \
-site in flui-app's runner.rs); flui-rendering's testing/harness.rs, the \
-audit's sixth named file, was never in scope -- it lives under a \
-`#[cfg(any(test, feature = "testing"))]`-gated module, which the checker's \
-whole-module test-support exclusion (mirroring tests/benches/examples) \
-correctly never scans.\
+site in flui-app's runner.rs). flui-rendering's testing/harness.rs was never \
+in scope -- it lives under a `#[cfg(any(test, feature = "testing"))]`-gated \
+module (test-support, cfg-gated), which the checker's whole-module \
+test-support exclusion (mirroring tests/benches/examples) correctly never \
+scans.\
 """
 state = "implemented"
 domain = "workspace"

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -52,6 +52,11 @@
 #
 # Ownership domains:
 #   application | realm | presentation | raster | platform | shared-engine
+#   workspace — deliberately not a Runtime.1 topology domain like the other
+#   six. Reserved for the rare cross-cutting engineering-discipline contract
+#   (not scoped to any single runtime domain) that has no other
+#   mechanically-checked registry to live in, e.g. the
+#   expect("BUG: …") panic-policy gate below. Narrow on purpose.
 
 [registry]
 milestone = "Runtime.1"
@@ -1180,6 +1185,39 @@ domain = "platform"
 owner_issue = 551
 mechanical = true
 mechanism = "the checker pins run_direct's experimental marking and classification"
+
+[[contract]]
+key = "panic-policy-bug-prefix-gated"
+statement = """
+Every production-path `expect()` under `crates/*/src` carries a message \
+prefixed `BUG: ` naming the internal invariant it asserts (docs/PANIC-POLICY.md), \
+distinguishing it from a caller-triggerable/environmental failure, which must \
+return a typed `Result` instead. This is not a Runtime.1 topology contract like \
+its six domain-scoped siblings above -- it is a workspace-wide coding \
+discipline with its own mechanical enforcement, recorded here because this \
+registry is the only one in the workspace that tracks a contract's \
+`mechanical`/`mechanism` pair. Enforcement is a per-file, shrink-only ratchet \
+(docs/panic-policy-allowlist.txt): a file with a non-conforming site must be \
+listed, and a listed file that has been fully burned down must be delisted. \
+Seeded 2026-08-04 at 65 listed files / 125 sites, down from the audit's 158 \
+after burning down the five worst-offender files it named (flui-hot-reload's \
+worker.rs, flui-engine's wgpu/backend.rs, flui-painting's \
+text_painter/paint.rs, flui-widgets' scroll/refresh_indicator.rs, and one \
+site in flui-app's runner.rs); flui-rendering's testing/harness.rs, the \
+audit's sixth named file, was never in scope -- it lives under a \
+`#[cfg(any(test, feature = "testing"))]`-gated module, which the checker's \
+whole-module test-support exclusion (mirroring tests/benches/examples) \
+correctly never scans.\
+"""
+state = "implemented"
+domain = "workspace"
+mechanical = true
+mechanism = "scripts/check-panic-policy.sh (just panic-policy-check, wired into just ci and the CI checks job)"
+evidence = [
+    { kind = "symbol", file = "scripts/check-panic-policy.sh", contains = "def nonconforming_sites" },
+    { kind = "test", file = "scripts/check-panic-policy.sh", contains = "def self_test" },
+    { kind = "source-gate", file = "justfile", contains = "panic-policy-check:" },
+]
 
 # =============================================================================
 # Public runtime surface classification

--- a/justfile
+++ b/justfile
@@ -339,6 +339,11 @@ inventory-check:
 runtime-conformance-check:
     bash scripts/check-runtime-conformance.sh
 
+[group("quality")]
+[doc("Gate the expect(\"BUG: …\") panic-policy convention (docs/PANIC-POLICY.md) via its per-file ratchet")]
+panic-policy-check:
+    bash scripts/check-panic-policy.sh
+
 # =============================================================================
 # Port methodology
 # =============================================================================
@@ -501,8 +506,8 @@ watch-test crate="":
 #   just deny             (advisories / bans / licenses / sources)
 #   just miri             (nightly UB check, narrow scope — see its comment)
 [group("ci")]
-[doc("Run local CI gates (fmt-check + inventory + runtime-conformance + port-check + clippy + test + doctests + rustdoc)")]
-ci: fmt-check inventory-check runtime-conformance-check port-check clippy test-ci test-doc doc-strict
+[doc("Run local CI gates (fmt-check + inventory + runtime-conformance + panic-policy + port-check + clippy + test + doctests + rustdoc)")]
+ci: fmt-check inventory-check runtime-conformance-check panic-policy-check port-check clippy test-ci test-doc doc-strict
 
 # =============================================================================
 # Maintenance

--- a/scripts/check-panic-policy.sh
+++ b/scripts/check-panic-policy.sh
@@ -645,6 +645,32 @@ def self_test() -> int:
             else:
                 print(f"  FAIL: expected zero errors, got: {errors}")
                 status = 1
+
+            print("self-test: whole-module exclusion excludes exactly the gated sibling")
+            wm_fixtures = fixtures / "whole_module_exclusion"
+            wm_crate_src = tmp_root / "crates" / "whole_module_crate" / "src"
+            wm_crate_src.mkdir(parents=True)
+            for f in wm_fixtures.glob("*.rs.fixture"):
+                shutil.copy(f, wm_crate_src / f.name.replace(".fixture", ""))
+
+            excluded = test_support_paths_for_crate(wm_crate_src)
+            expected_excluded = {Path(f"{rel_prefix.replace('fixture_crate', 'whole_module_crate')}/gated_testing_module.rs")}
+            if excluded == expected_excluded:
+                print("  ok: only the #[cfg(any(test, feature = \"testing\"))]-gated sibling is excluded")
+            else:
+                print(f"  FAIL: expected excluded == {expected_excluded}, got {excluded}")
+                status = 1
+
+            wm_errors, wm_counts = run_check(wm_crate_src.parent.parent, set())
+            wm_rel_prefix = "crates/whole_module_crate/src"
+            if (
+                any(f"{wm_rel_prefix}/ungated_sibling_module.rs" in e and "not on" in e for e in wm_errors)
+                and not any("gated_testing_module.rs" in e for e in wm_errors)
+            ):
+                print("  ok: the ungated sibling's violation is flagged; the gated file's is not scanned at all")
+            else:
+                print(f"  FAIL: expected only the ungated sibling flagged, got errors={wm_errors} counts={wm_counts}")
+                status = 1
         finally:
             root = real_root
 

--- a/scripts/check-panic-policy.sh
+++ b/scripts/check-panic-policy.sh
@@ -1,0 +1,671 @@
+#!/usr/bin/env bash
+# Mechanical gate for docs/PANIC-POLICY.md's `expect("BUG: …")` convention.
+#
+# Every production-path `expect()` call must carry a message prefixed with
+# "BUG: " that names the internal invariant it asserts (see PANIC-POLICY.md
+# for the caller-triggerable-vs-internal-invariant split this convention
+# encodes). Nothing enforced this before this script: `expect_used` is
+# deliberately not linted (the message is the review bar, not the call), so
+# a bare `.expect("failed to get node")` compiled clean forever.
+#
+# This is a RATCHET, not a ban, following the same shape as
+# scripts/check-runtime-conformance.sh's `ambient_reach` net: a per-file
+# allowlist (docs/panic-policy-allowlist.txt) records files that still carry
+# non-conforming production expect() sites. It shrinks only:
+#
+#   * a file with a non-conforming site that is NOT on the allowlist fails
+#     (new debt must be declared, not silently introduced);
+#   * a file ON the allowlist that no longer has any non-conforming site
+#     fails too (a cleaned file must leave the list -- the allowlist is
+#     "today's known debt", not a permanent exemption).
+#
+# Scope: `crates/*/src/**/*.rs`, minus:
+#   * a whole module gated `#[cfg(test)]` / `#[cfg(any(test, feature =
+#     "testing"))]` / etc. at its `mod NAME;` declaration (test-support
+#     libraries like flui-rendering's `testing`/`test_support` modules,
+#     compiled only under `cfg(test)` or an opt-in `testing` feature);
+#   * an individual `mod { ... }` / `fn(...) { ... }` / `impl ... { ... }`
+#     item gated the same way inline (`#[cfg(test)] mod tests { ... }`,
+#     `#[cfg(test)] fn for_test() { ... }`, `#[cfg(all(test, ...))] impl
+#     ... { ... }`);
+#   * doc comments and line comments (never code).
+#
+# `crates/*/tests/**`, `crates/*/benches/**`, `crates/*/examples/**` are
+# integration tests/benches/examples, not `src/`, and are outside this
+# script's glob entirely -- they get free `expect()`/`unwrap()` under
+# PANIC-POLICY.md's own "Test code, benches, examples" row.
+#
+# Lexer lineage: the literal-masking and line-comment-stripping passes below
+# are ported verbatim from check-runtime-conformance.sh's
+# `_mask_rust_literals` / `_strip_line_comments` (masking MUST run first --
+# see that script's docstring for the two failure-open shapes this ordering
+# closes: a same-line string containing "//", and a string containing an
+# unbalanced brace). This script EXTENDS that lexer in one direction that
+# script's own `_strip_top_level_test_modules` does not need to cover:
+#
+#   * `_strip_top_level_test_modules` only recognizes a single-line
+#     `#[cfg(test)]` / `#[cfg(all(test, ...))]` immediately above a `mod
+#     NAME { ... }` on the very next non-blank line. This workspace also
+#     gates individual `fn`/`impl` items (89 and 8 real sites), and gates
+#     some `mod`/`fn`/`impl` items with a `#[cfg(all(\n    test,\n    ...\n
+#     ))]` attribute spanning multiple physical lines (`runner.rs`'s
+#     `realm_dispatch_tests`/`desktop_pacing_tests`, missed by a single-line
+#     regex). `find_cfg_test_gated_items` below walks attributes generically
+#     (multi-line, stacked, any brace-delimited item kind) and evaluates the
+#     cfg predicate with a small `all`/`any`/`not` boolean evaluator instead
+#     of a regex, so `all(test, not(target_os = "ios"))` and `any(test,
+#     feature = "testing")` are both recognized as test-only regardless of
+#     line breaks.
+#
+# Usage:
+#   scripts/check-panic-policy.sh              # scan; exit 1 on violation
+#   scripts/check-panic-policy.sh --self-test  # verify the scanner itself
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+cd "${repo_root}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "check-panic-policy: python3 not found on PATH" >&2
+  exit 2
+fi
+
+mode="${1:-}"
+
+python3 - "${repo_root}" "${mode}" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1]).resolve()
+mode = sys.argv[2] if len(sys.argv) > 2 else ""
+ALLOWLIST_PATH = root / "docs" / "panic-policy-allowlist.txt"
+
+# =============================================================================
+# Lexer: literal masking + comment stripping (ported from
+# check-runtime-conformance.sh's _mask_rust_literals / _strip_line_comments).
+# =============================================================================
+
+
+def mask_rust_literals(text: str) -> str:
+    """Replace the contents of every string/char literal with spaces,
+    preserving every newline and the total character layout, so line numbers
+    and column positions -- and byte offsets into the ORIGINAL text -- stay
+    valid downstream. See check-runtime-conformance.sh's copy of this
+    function for the full rationale; this is a verbatim port."""
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in ("r", "b"):
+            j = i
+            if text[j] == "b" and j + 1 < n and text[j + 1] == "r":
+                j += 1
+            if j < n and text[j] == "r":
+                k = j + 1
+                hashes = 0
+                while k < n and text[k] == "#":
+                    hashes += 1
+                    k += 1
+                if k < n and text[k] == '"':
+                    prefix_end = k + 1
+                    out.append(text[i:prefix_end])
+                    closer = '"' + "#" * hashes
+                    end = text.find(closer, prefix_end)
+                    body_end = end if end != -1 else n
+                    body = text[prefix_end:body_end]
+                    out.append("".join("\n" if c == "\n" else " " for c in body))
+                    if end != -1:
+                        out.append(closer)
+                        i = end + len(closer)
+                    else:
+                        i = n
+                    continue
+        if ch == "'":
+            if i + 2 < n and text[i + 1] == "\\":
+                k = i + 2
+                limit = min(n, i + 2 + 12)
+                while k < limit and text[k] != "'":
+                    k += 1
+                if k < limit and text[k] == "'":
+                    out.append("'" + " " * (k - (i + 1)) + "'")
+                    i = k + 1
+                    continue
+            elif i + 2 < n and text[i + 2] == "'":
+                out.append("' '")
+                i += 3
+                continue
+            out.append(ch)
+            i += 1
+            continue
+        if ch == '"':
+            out.append('"')
+            i += 1
+            while i < n:
+                c = text[i]
+                if c == "\\" and i + 1 < n:
+                    out.append("\n" if text[i + 1] == "\n" else " ")
+                    out.append(" ")
+                    i += 2
+                    continue
+                if c == '"':
+                    out.append('"')
+                    i += 1
+                    break
+                out.append("\n" if c == "\n" else " ")
+                i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def strip_line_comments(text: str) -> str:
+    # split("\n"), NOT splitlines(): splitlines() drops a trailing empty
+    # element for text ending in "\n", which would desync this function's
+    # line count against the raw text this checker re-indexes into by line
+    # number below.
+    return "\n".join(line.split("//", 1)[0] for line in text.split("\n"))
+
+
+def split_top_level(text: str, sep: str = ",") -> list[str]:
+    """Split on `sep` at paren/bracket/brace depth 0."""
+    parts: list[str] = []
+    depth = 0
+    buf: list[str] = []
+    for ch in text:
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        if ch == sep and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    parts.append("".join(buf))
+    return [p.strip() for p in parts if p.strip()]
+
+
+def cfg_requires_test(predicate: str) -> bool:
+    """Does this cfg(...) predicate only ever hold under `test` or the
+    `testing` feature? Handles the grammar actually used in this workspace:
+    bare `test`, `all(...)`, `any(...)`, `not(...)`, `feature = "testing"`."""
+    expr = predicate.strip()
+    m = re.match(r"^(all|any|not)\((.*)\)$", expr, re.DOTALL)
+    if m:
+        kind, inner = m.group(1), m.group(2)
+        children = split_top_level(inner)
+        if kind == "all":
+            return any(cfg_requires_test(c) for c in children)
+        if kind == "any":
+            return bool(children) and all(cfg_requires_test(c) for c in children)
+        return False  # not(...) never *requires* test
+    if expr == "test":
+        return True
+    if re.match(r'^feature\s*=\s*"testing"$', expr):
+        return True
+    return False
+
+
+_ATTR_OPEN_RE = re.compile(r"^\s*#!?\[")
+_ITEM_RE = re.compile(
+    r"^\s*(?:pub(?:\([^)]*\))?\s+)?"
+    r"(?:default\s+)?(?:unsafe\s+)?(?:async\s+)?(?:const\s+)?"
+    r"(mod|fn|impl|trait)\b"
+)
+
+
+def _attr_span(lines: list[str], idx: int) -> int:
+    """`lines[idx]` opens an attribute (`#[...]`/`#![...]`), possibly
+    spanning multiple physical lines (bracket-depth tracked). Returns the
+    index one past its last line."""
+    depth = lines[idx].count("[") - lines[idx].count("]")
+    i = idx + 1
+    n = len(lines)
+    while depth > 0 and i < n:
+        depth += lines[i].count("[") - lines[i].count("]")
+        i += 1
+    return i
+
+
+def find_cfg_test_gated_items(lines: list[str]) -> list[tuple[int, int]]:
+    """Scan (masked, comment-stripped) `lines` for every brace-delimited item
+    (`mod`/`fn`/`impl`/`trait`) gated -- directly, or through a stack of
+    attributes -- by a cfg(...) predicate that only holds under test. Returns
+    (start_line_idx, end_line_idx_inclusive) spans to blank; start is the
+    first `#[cfg...]` line, so a `#[cfg(test)]` with no recognized item after
+    it is simply left alone (nothing to blank, not an error: it may gate a
+    struct/const/static this lexer does not open, none of which can contain
+    an `.expect(` call worth scanning)."""
+    spans: list[tuple[int, int]] = []
+    n = len(lines)
+    i = 0
+    while i < n:
+        if not _ATTR_OPEN_RE.match(lines[i]):
+            i += 1
+            continue
+        attr_start = i
+        requires_test = False
+        j = i
+        while j < n and _ATTR_OPEN_RE.match(lines[j]):
+            end = _attr_span(lines, j)
+            text = "\n".join(lines[j:end])
+            m = re.match(r"\s*#!?\[\s*cfg\(", text, re.DOTALL)
+            if m:
+                depth = 1
+                k = m.end()
+                start_pred = k
+                while depth > 0 and k < len(text):
+                    if text[k] == "(":
+                        depth += 1
+                    elif text[k] == ")":
+                        depth -= 1
+                    k += 1
+                predicate = text[start_pred : k - 1]
+                if cfg_requires_test(predicate):
+                    requires_test = True
+            j = end
+            while j < n and not lines[j].strip():
+                j += 1
+        if not requires_test:
+            i = attr_start + 1
+            continue
+        if j >= n or not _ITEM_RE.match(lines[j]):
+            i = attr_start + 1
+            continue
+        # Find the item's opening brace: the first '{' seen once paren depth
+        # returns to (or stays at) 0, scanning forward from the item line.
+        paren_depth = 0
+        brace_line = None
+        k = j
+        while k < n:
+            line = lines[k]
+            col = 0
+            found = False
+            while col < len(line):
+                c = line[col]
+                if c == "(":
+                    paren_depth += 1
+                elif c == ")":
+                    paren_depth -= 1
+                elif c == "{" and paren_depth <= 0:
+                    found = True
+                    break
+                col += 1
+            if found:
+                brace_line = k
+                break
+            k += 1
+        if brace_line is None:
+            i = attr_start + 1
+            continue
+        depth = 0
+        seen = False
+        m2 = brace_line
+        while m2 < n:
+            opens = lines[m2].count("{")
+            closes = lines[m2].count("}")
+            if opens:
+                seen = True
+            depth += opens - closes
+            m2 += 1
+            if seen and depth <= 0:
+                break
+        spans.append((attr_start, m2 - 1))
+        i = m2
+    return spans
+
+
+def strip_cfg_test_gated_items(text: str) -> str:
+    lines = text.split("\n")
+    out = list(lines)
+    for start, end in find_cfg_test_gated_items(lines):
+        for idx in range(start, end + 1):
+            out[idx] = ""
+    return "\n".join(out)
+
+
+def production_code(raw: str) -> str:
+    """The full pipeline: mask literals, strip line comments (safe now that
+    literals are masked), blank every cfg(test)-gated item."""
+    return strip_cfg_test_gated_items(strip_line_comments(mask_rust_literals(raw)))
+
+
+# =============================================================================
+# Whole-module test-support exclusion: a `mod NAME;` file declaration gated
+# by a test-requiring cfg (e.g. flui-rendering's `#[cfg(any(test, feature =
+# "testing"))] pub mod testing;`) excludes NAME's entire file/directory from
+# the scan, the same way `tests/`/`benches/`/`examples/` are out of scope by
+# not being under `src/` at all.
+# =============================================================================
+
+_MOD_DECL_RE = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?mod\s+(\w+)\s*;\s*$")
+_ATTR_LINE_RE = re.compile(r"^\s*#!?\[(.*)\]\s*$")
+_DOC_RE = re.compile(r"^\s*///.*$|^\s*//!.*$")
+
+
+def find_test_support_modules(rs_file: Path) -> list[str]:
+    try:
+        lines = rs_file.read_text().splitlines()
+    except (OSError, UnicodeDecodeError):
+        return []
+    names: list[str] = []
+    for idx, line in enumerate(lines):
+        m = _MOD_DECL_RE.match(line.split("//", 1)[0])
+        if not m:
+            continue
+        name = m.group(1)
+        j = idx - 1
+        attrs: list[str] = []
+        while j >= 0:
+            stripped = lines[j].strip()
+            if not stripped:
+                j -= 1
+                continue
+            if _DOC_RE.match(lines[j]):
+                j -= 1
+                continue
+            am = _ATTR_LINE_RE.match(lines[j])
+            if am:
+                attrs.append(am.group(1))
+                j -= 1
+                continue
+            break
+        gated = any(
+            cfg_requires_test(a.strip()[4:-1])
+            for a in attrs
+            if a.strip().startswith("cfg(") and a.strip().endswith(")")
+        )
+        if gated:
+            names.append(name)
+    return names
+
+
+def test_support_paths_for_crate(crate_src: Path) -> set[Path]:
+    excluded: set[Path] = set()
+    for rs_file in crate_src.rglob("*.rs"):
+        names = find_test_support_modules(rs_file)
+        if not names:
+            continue
+        decl_dir = rs_file.parent if rs_file.name in ("lib.rs", "mod.rs", "main.rs") else rs_file.parent / rs_file.stem
+        for name in names:
+            cand_file = decl_dir / f"{name}.rs"
+            cand_dir = decl_dir / name
+            if cand_dir.is_dir():
+                excluded.add(cand_dir.relative_to(root))
+            elif cand_file.is_file():
+                excluded.add(cand_file.relative_to(root))
+    return excluded
+
+
+def is_excluded(rel: Path, excluded: set[Path]) -> bool:
+    return any(rel == e or e in rel.parents for e in excluded)
+
+
+def production_files(crates_dir: Path) -> list[Path]:
+    files: list[Path] = []
+    for crate_dir in sorted(crates_dir.iterdir()):
+        src = crate_dir / "src"
+        if not src.is_dir():
+            continue
+        excluded = test_support_paths_for_crate(src)
+        for rs in sorted(src.rglob("*.rs")):
+            rel = rs.relative_to(root)
+            if not is_excluded(rel, excluded):
+                files.append(rs)
+    return files
+
+
+# =============================================================================
+# expect() site extraction: locate every `.expect(` call surviving the
+# production_code() pipeline (i.e. not in a comment, doc, or cfg(test)-gated
+# item), then read its message from the ORIGINAL (unmasked) text -- the mask
+# pass preserves line/column layout exactly, so a location found in the
+# masked text indexes validly into the raw text.
+# =============================================================================
+
+EXPECT_RE = re.compile(r"\.expect\(")
+_CONST_DEF_TMPL = r"const\s+{name}\s*:[^=]*=\s*"
+
+
+def extract_string_literal(raw: str, start: int) -> tuple[str, int] | None:
+    """`raw[start]` must open a string/raw-string literal. Returns
+    (content, end_idx) or None if it doesn't look like one."""
+    n = len(raw)
+    i = start
+    if raw[i] in ("r", "b"):
+        j = i
+        if raw[j] == "b" and j + 1 < n and raw[j + 1] == "r":
+            j += 1
+        if j < n and raw[j] == "r":
+            k = j + 1
+            hashes = 0
+            while k < n and raw[k] == "#":
+                hashes += 1
+                k += 1
+            if k < n and raw[k] == '"':
+                prefix_end = k + 1
+                closer = '"' + "#" * hashes
+                end = raw.find(closer, prefix_end)
+                if end == -1:
+                    return None
+                return raw[prefix_end:end], end + len(closer)
+        return None
+    if raw[i] != '"':
+        return None
+    i += 1
+    buf: list[str] = []
+    while i < n:
+        c = raw[i]
+        if c == "\\" and i + 1 < n:
+            buf.append(c)
+            buf.append(raw[i + 1])
+            i += 2
+            continue
+        if c == '"':
+            return "".join(buf), i + 1
+        buf.append(c)
+        i += 1
+    return None
+
+
+def nonconforming_sites(rs_file: Path) -> list[tuple[int, str]]:
+    """Returns (line_number, message-or-placeholder) for every production
+    `.expect(...)` site whose message does not start with `BUG: `."""
+    raw = rs_file.read_text()
+    prod = production_code(raw)
+    prod_lines = prod.split("\n")
+    raw_lines = raw.split("\n")
+    if len(prod_lines) != len(raw_lines):
+        # The pipeline above is line-count-preserving by construction; a
+        # mismatch means a bug in this script, not the scanned file.
+        raise AssertionError(f"{rs_file}: lexer line-count mismatch ({len(prod_lines)} vs {len(raw_lines)})")
+
+    sites: list[tuple[int, str]] = []
+    for li, pline in enumerate(prod_lines):
+        for m in EXPECT_RE.finditer(pline):
+            col = m.end()
+            content: str | None = None
+            search_line = li
+            search_col = col
+            hops = 0
+            while hops < 20:
+                cur_raw = raw_lines[search_line]
+                k = search_col
+                while k < len(cur_raw) and cur_raw[k] in " \t":
+                    k += 1
+                if k < len(cur_raw):
+                    ch = cur_raw[k]
+                    if ch == '"' or (ch in ("r", "b") and k + 1 < len(cur_raw)):
+                        joined = "\n".join(raw_lines[search_line : search_line + 25])
+                        res = extract_string_literal(joined, k)
+                        if res:
+                            content = res[0]
+                    else:
+                        rest = cur_raw[k:]
+                        idm = re.match(r"[A-Za-z_][A-Za-z0-9_:]*", rest)
+                        if idm:
+                            simple_name = idm.group(0).split("::")[-1]
+                            cm = re.search(_CONST_DEF_TMPL.format(name=re.escape(simple_name)), raw)
+                            if cm:
+                                res = extract_string_literal(raw, cm.end())
+                                if res:
+                                    content = res[0]
+                    break
+                search_line += 1
+                search_col = 0
+                hops += 1
+            if content is None or not content.startswith("BUG: "):
+                sites.append((li + 1, content if content is not None else "<dynamic, non-literal argument>"))
+    return sites
+
+
+# =============================================================================
+# Allowlist I/O: one relative path per line, `#`-comments and blank lines
+# ignored.
+# =============================================================================
+
+
+def load_allowlist(path: Path) -> set[str]:
+    if not path.is_file():
+        return set()
+    entries: set[str] = set()
+    for line in path.read_text().splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line:
+            entries.add(line)
+    return entries
+
+
+def run_check(crates_dir: Path, allowlist: set[str]) -> tuple[list[str], dict[str, int]]:
+    """Returns (errors, nonconforming_counts_by_relpath)."""
+    errors: list[str] = []
+    counts: dict[str, int] = {}
+    for rs_file in production_files(crates_dir):
+        rel = str(rs_file.relative_to(root))
+        sites = nonconforming_sites(rs_file)
+        if sites:
+            counts[rel] = len(sites)
+    unlisted = sorted(set(counts) - allowlist)
+    stale = sorted(allowlist - set(counts))
+    for rel in unlisted:
+        sites = nonconforming_sites(root / rel)
+        preview = "; ".join(f"{n}: {msg[:60]!r}" for n, msg in sites[:3])
+        more = f" (+{len(sites) - 3} more)" if len(sites) > 3 else ""
+        errors.append(
+            f"{rel} has {len(sites)} production expect() site(s) without the `BUG: ` prefix "
+            f"and is not on docs/panic-policy-allowlist.txt: {preview}{more}"
+        )
+    for rel in stale:
+        errors.append(
+            f"{rel} is on docs/panic-policy-allowlist.txt but no longer has any non-conforming "
+            "expect() site -- remove its entry (the allowlist is a shrink-only ratchet)"
+        )
+    return errors, counts
+
+
+# =============================================================================
+# Self-test: fixtures exercise both ratchet directions plus the lexer edge
+# cases (masking-before-comment-stripping, cfg(test) fn/impl/mod exclusion,
+# multi-line cfg attributes, const-resolved identifier arguments).
+# =============================================================================
+
+
+def self_test() -> int:
+    global root  # noqa: PLW0603 -- self-test only, restored before returning
+    import shutil
+    import tempfile
+
+    fixtures = root / "scripts" / "fixtures" / "panic-policy"
+    status = 0
+
+    def check(name: str, expect_sites: int) -> None:
+        nonlocal status
+        path = fixtures / name
+        sites = nonconforming_sites(path)
+        if len(sites) == expect_sites:
+            print(f"  ok: {name} -> {len(sites)} non-conforming site(s) as expected")
+        else:
+            print(
+                f"  FAIL: {name} -> expected {expect_sites} non-conforming site(s), got {len(sites)}: {sites}"
+            )
+            status = 1
+
+    print("self-test: lexer correctness (fixture files)")
+    check("conforming.rs.fixture", 0)
+    check("unlisted_violation.rs.fixture", 1)
+    check("stale_allowlist_candidate.rs.fixture", 0)
+
+    # Exercise the REAL run_check() pipeline end to end (not a hand-rolled
+    # re-check of the same set arithmetic): copy the fixtures into a
+    # throwaway `<tmp>/crates/fixture_crate/src/` so `production_files()`
+    # walks them exactly as it would a real crate, then run the gate against
+    # two synthetic allowlists that plant one violation in each direction.
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_root = Path(tmp)
+        crate_src = tmp_root / "crates" / "fixture_crate" / "src"
+        crate_src.mkdir(parents=True)
+        for f in fixtures.glob("*.rs.fixture"):
+            shutil.copy(f, crate_src / f.name.replace(".fixture", ""))
+
+        real_root = root
+        root = tmp_root
+        try:
+            rel_prefix = "crates/fixture_crate/src"
+
+            print("self-test: ratchet direction 1 -- unlisted violation must fail")
+            errors, _ = run_check(crate_src.parent.parent, {f"{rel_prefix}/stale_allowlist_candidate.rs"})
+            if any("unlisted_violation.rs" in e and "not on" in e for e in errors):
+                print("  ok: an unlisted file with a bare expect() is flagged")
+            else:
+                print(f"  FAIL: expected the unlisted violation to be flagged; errors were: {errors}")
+                status = 1
+
+            print("self-test: ratchet direction 2 -- cleaned file left on the allowlist must fail")
+            errors, _ = run_check(
+                crate_src.parent.parent,
+                {f"{rel_prefix}/unlisted_violation.rs", f"{rel_prefix}/stale_allowlist_candidate.rs"},
+            )
+            if any("stale_allowlist_candidate.rs" in e and "stale" in e.lower() for e in errors):
+                print("  ok: a listed-but-now-clean file is flagged as stale")
+            else:
+                print(f"  FAIL: expected the stale allowlist entry to be flagged; errors were: {errors}")
+                status = 1
+
+            print("self-test: fully reconciled allowlist passes clean")
+            errors, _ = run_check(
+                crate_src.parent.parent,
+                {f"{rel_prefix}/unlisted_violation.rs"},
+            )
+            if not errors:
+                print("  ok: no violations when the allowlist matches reality exactly")
+            else:
+                print(f"  FAIL: expected zero errors, got: {errors}")
+                status = 1
+        finally:
+            root = real_root
+
+    return status
+
+
+if mode == "--self-test":
+    sys.exit(self_test())
+
+allowlist = load_allowlist(ALLOWLIST_PATH)
+errors, counts = run_check(root / "crates", allowlist)
+
+if errors:
+    print("check-panic-policy: violations detected", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    sys.exit(1)
+
+total_sites = sum(counts.values())
+print(
+    f"check-panic-policy: {len(counts)} file(s) on the allowlist, "
+    f"{total_sites} tracked non-conforming expect() site(s); no unlisted or stale entries"
+)
+PY

--- a/scripts/check-panic-policy.sh
+++ b/scripts/check-panic-policy.sh
@@ -10,14 +10,25 @@
 #
 # This is a RATCHET, not a ban, following the same shape as
 # scripts/check-runtime-conformance.sh's `ambient_reach` net: a per-file
-# allowlist (docs/panic-policy-allowlist.txt) records files that still carry
-# non-conforming production expect() sites. It shrinks only:
+# allowlist (docs/panic-policy-allowlist.txt, `relative/path.rs <count>` per
+# line) records files that still carry non-conforming production expect()
+# sites, AND how many. The count is load-bearing, not a label: comparing
+# only file-set membership (an earlier version of this gate did) lets an
+# already-listed file silently accumulate new bare expect() calls forever,
+# since staying "on the list" said nothing about whether its debt grew. It
+# shrinks only, per file:
 #
 #   * a file with a non-conforming site that is NOT on the allowlist fails
 #     (new debt must be declared, not silently introduced);
-#   * a file ON the allowlist that no longer has any non-conforming site
-#     fails too (a cleaned file must leave the list -- the allowlist is
-#     "today's known debt", not a permanent exemption).
+#   * a file ON the allowlist whose actual count no longer matches the
+#     listed count fails in EITHER direction: higher (new debt landed in an
+#     already-listed file -- a regression, not a free pass) or lower (the
+#     file improved but the list was not updated down -- also not a free
+#     pass, since a future regression back up to the stale higher number
+#     would then go unnoticed);
+#   * a file ON the allowlist with zero actual sites left fails too (a fully
+#     cleaned file must leave the list -- the allowlist is "today's known
+#     debt", not a permanent exemption).
 #
 # Scope: `crates/*/src/**/*.rs`, minus:
 #   * a whole module gated `#[cfg(test)]` / `#[cfg(any(test, feature =
@@ -56,6 +67,18 @@
 #     of a regex, so `all(test, not(target_os = "ios"))` and `any(test,
 #     feature = "testing")` are both recognized as test-only regardless of
 #     line breaks.
+#   * An OUT-OF-LINE `#[cfg(test)] mod NAME;` declaration (no body of its
+#     own -- the real body lives in a sibling file, e.g.
+#     `flui-engine/src/wgpu/mod.rs`'s `mod aa_oracle_tests;`) has no `{` to
+#     find. `find_cfg_test_gated_items` stops at the terminating `;` and
+#     blanks nothing for it -- correct, because the separate whole-module
+#     mechanism below (`find_test_support_modules`/
+#     `test_support_paths_for_crate`) excludes the DECLARED file entirely.
+#     Scanning forward past the `;` for some LATER `{` (an earlier version
+#     of this script did) finds the next brace-delimited item in the file
+#     instead -- the next `mod NAME;`'s cfg attribute, or worse, a real
+#     production `fn` -- and blanks that unrelated span, silently
+#     swallowing whatever violations it contained.
 #
 # Usage:
 #   scripts/check-panic-policy.sh              # scan; exit 1 on violation
@@ -278,8 +301,22 @@ def find_cfg_test_gated_items(lines: list[str]) -> list[tuple[int, int]]:
             continue
         # Find the item's opening brace: the first '{' seen once paren depth
         # returns to (or stays at) 0, scanning forward from the item line.
+        # A ';' hit first at that same depth means this is a body-less
+        # DECLARATION (`mod tests;` out-of-line, or a trait method
+        # signature) -- there is no body to blank, and critically, we must
+        # NOT keep scanning past it: an out-of-line `mod NAME;` has no `{`
+        # of its own, so without this stop the scan would run into whatever
+        # brace-delimited item comes next in the file (the next `mod
+        # NAME;`, or a real production `fn`) and blank ITS body instead,
+        # silently swallowing real violations. Out-of-line `mod NAME;`
+        # declarations are excluded correctly by the separate whole-module
+        # mechanism below (`find_test_support_modules`/
+        # `test_support_paths_for_crate`), which excludes the DECLARED
+        # file, not a byte range of this one -- so skipping here (blanking
+        # nothing) is the right outcome, not a gap.
         paren_depth = 0
         brace_line = None
+        terminated_without_body = False
         k = j
         while k < n:
             line = lines[k]
@@ -294,12 +331,15 @@ def find_cfg_test_gated_items(lines: list[str]) -> list[tuple[int, int]]:
                 elif c == "{" and paren_depth <= 0:
                     found = True
                     break
+                elif c == ";" and paren_depth <= 0:
+                    terminated_without_body = True
+                    break
                 col += 1
-            if found:
-                brace_line = k
+            if found or terminated_without_body:
+                brace_line = k if found else None
                 break
             k += 1
-        if brace_line is None:
+        if terminated_without_body or brace_line is None:
             i = attr_start + 1
             continue
         depth = 0
@@ -524,24 +564,50 @@ def nonconforming_sites(rs_file: Path) -> list[tuple[int, str]]:
 
 
 # =============================================================================
-# Allowlist I/O: one relative path per line, `#`-comments and blank lines
-# ignored.
+# Allowlist I/O: `relative/path.rs <count>` per line (whitespace-separated),
+# `#`-comments and blank lines ignored. The count is load-bearing, not a
+# label: it is compared against the file's ACTUAL current non-conforming
+# site count on every run (see run_check below) so an allowlisted file
+# cannot silently gain new bare expect() calls -- set membership alone was
+# insufficient (a file staying "on the list" said nothing about whether its
+# debt had grown).
 # =============================================================================
 
+_ALLOWLIST_LINE_RE = re.compile(r"^(\S+)\s+(\d+)$")
 
-def load_allowlist(path: Path) -> set[str]:
+
+def load_allowlist(path: Path) -> dict[str, int]:
     if not path.is_file():
-        return set()
-    entries: set[str] = set()
-    for line in path.read_text().splitlines():
-        line = line.split("#", 1)[0].strip()
-        if line:
-            entries.add(line)
+        return {}
+    entries: dict[str, int] = {}
+    for line_number, raw_line in enumerate(path.read_text().splitlines(), start=1):
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        m = _ALLOWLIST_LINE_RE.match(line)
+        if not m:
+            raise ValueError(
+                f"{path}:{line_number}: expected `relative/path.rs <count>`, got {raw_line!r} "
+                "-- every allowlist entry must carry its current non-conforming site count"
+            )
+        entries[m.group(1)] = int(m.group(2))
     return entries
 
 
-def run_check(crates_dir: Path, allowlist: set[str]) -> tuple[list[str], dict[str, int]]:
-    """Returns (errors, nonconforming_counts_by_relpath)."""
+def run_check(crates_dir: Path, allowlist: dict[str, int]) -> tuple[list[str], dict[str, int]]:
+    """Returns (errors, nonconforming_counts_by_relpath).
+
+    Four outcomes per file, all of which must reconcile for a clean run:
+      * counted, not listed          -> new debt, must be declared (fail)
+      * listed, now zero sites       -> stale entry, must be removed (fail)
+      * listed count < actual count  -> REGRESSION: the file gained bare
+                                         expect() site(s) since it was listed
+                                         (fail) -- this is the ratchet's
+                                         whole point: a file does not stay
+                                         green just by staying on the list
+      * listed count > actual count  -> stale count: the file improved but
+                                         the list was not updated down (fail)
+    """
     errors: list[str] = []
     counts: dict[str, int] = {}
     for rs_file in production_files(crates_dir):
@@ -549,8 +615,11 @@ def run_check(crates_dir: Path, allowlist: set[str]) -> tuple[list[str], dict[st
         sites = nonconforming_sites(rs_file)
         if sites:
             counts[rel] = len(sites)
-    unlisted = sorted(set(counts) - allowlist)
-    stale = sorted(allowlist - set(counts))
+
+    unlisted = sorted(set(counts) - set(allowlist))
+    fully_stale = sorted(set(allowlist) - set(counts))
+    tracked = sorted(set(counts) & set(allowlist))
+
     for rel in unlisted:
         sites = nonconforming_sites(root / rel)
         preview = "; ".join(f"{n}: {msg[:60]!r}" for n, msg in sites[:3])
@@ -559,11 +628,28 @@ def run_check(crates_dir: Path, allowlist: set[str]) -> tuple[list[str], dict[st
             f"{rel} has {len(sites)} production expect() site(s) without the `BUG: ` prefix "
             f"and is not on docs/panic-policy-allowlist.txt: {preview}{more}"
         )
-    for rel in stale:
+    for rel in fully_stale:
         errors.append(
             f"{rel} is on docs/panic-policy-allowlist.txt but no longer has any non-conforming "
             "expect() site -- remove its entry (the allowlist is a shrink-only ratchet)"
         )
+    for rel in tracked:
+        actual = counts[rel]
+        listed = allowlist[rel]
+        if actual > listed:
+            sites = nonconforming_sites(root / rel)
+            preview = "; ".join(f"{n}: {msg[:60]!r}" for n, msg in sites[:3])
+            errors.append(
+                f"{rel} has {actual} non-conforming expect() site(s) now, but "
+                f"docs/panic-policy-allowlist.txt lists {listed} -- new debt was added to an "
+                f"already-listed file (fix the new site(s) or raise the listed count): {preview}"
+            )
+        elif actual < listed:
+            errors.append(
+                f"{rel} has {actual} non-conforming expect() site(s) now, but "
+                f"docs/panic-policy-allowlist.txt still lists {listed} -- lower the listed count "
+                "to match (the allowlist is a shrink-only ratchet per file, not just per file set)"
+            )
     return errors, counts
 
 
@@ -617,7 +703,7 @@ def self_test() -> int:
             rel_prefix = "crates/fixture_crate/src"
 
             print("self-test: ratchet direction 1 -- unlisted violation must fail")
-            errors, _ = run_check(crate_src.parent.parent, {f"{rel_prefix}/stale_allowlist_candidate.rs"})
+            errors, _ = run_check(crate_src.parent.parent, {f"{rel_prefix}/stale_allowlist_candidate.rs": 1})
             if any("unlisted_violation.rs" in e and "not on" in e for e in errors):
                 print("  ok: an unlisted file with a bare expect() is flagged")
             else:
@@ -627,7 +713,7 @@ def self_test() -> int:
             print("self-test: ratchet direction 2 -- cleaned file left on the allowlist must fail")
             errors, _ = run_check(
                 crate_src.parent.parent,
-                {f"{rel_prefix}/unlisted_violation.rs", f"{rel_prefix}/stale_allowlist_candidate.rs"},
+                {f"{rel_prefix}/unlisted_violation.rs": 1, f"{rel_prefix}/stale_allowlist_candidate.rs": 1},
             )
             if any("stale_allowlist_candidate.rs" in e and "stale" in e.lower() for e in errors):
                 print("  ok: a listed-but-now-clean file is flagged as stale")
@@ -638,12 +724,65 @@ def self_test() -> int:
             print("self-test: fully reconciled allowlist passes clean")
             errors, _ = run_check(
                 crate_src.parent.parent,
-                {f"{rel_prefix}/unlisted_violation.rs"},
+                {f"{rel_prefix}/unlisted_violation.rs": 1},
             )
             if not errors:
                 print("  ok: no violations when the allowlist matches reality exactly")
             else:
                 print(f"  FAIL: expected zero errors, got: {errors}")
+                status = 1
+
+            # -----------------------------------------------------------------
+            # Per-file COUNT ratchet (not just file-set membership): a listed
+            # file must fail when its actual site count diverges from the
+            # listed count in EITHER direction -- growing (a regression that
+            # must not stay green just because the file was already listed)
+            # or shrinking (a stale count that must be lowered). Lives under
+            # its own `regress_root/crates/`, NOT `tmp_root/crates/` --
+            # `production_files()` walks every crate dir under whatever
+            # `crates_dir` it is given, and `tmp_root/crates/` already holds
+            # `fixture_crate` (and, by the time this runs, `whole_module_
+            # crate`) from the checks above; sharing that directory would
+            # make THEIR violations count as "unlisted" against the
+            # narrower allowlist dict this block passes, which is a bug in
+            # the test, not the gate. Also uses its own throwaway copy so
+            # the mutation below cannot affect the checks above.
+            # -----------------------------------------------------------------
+            regress_root = tmp_root / "regress_root"
+            regress_crate_src = regress_root / "crates" / "regression_crate" / "src"
+            regress_crate_src.mkdir(parents=True)
+            regress_target = regress_crate_src / "unlisted_violation.rs"
+            shutil.copy(fixtures / "unlisted_violation.rs.fixture", regress_target)
+            regress_rel = "regress_root/crates/regression_crate/src/unlisted_violation.rs"
+
+            print("self-test: per-file count ratchet -- baseline (actual == listed) is clean")
+            errors, _ = run_check(regress_crate_src.parent.parent, {regress_rel: 1})
+            if not errors:
+                print("  ok: actual count matching the listed count passes clean")
+            else:
+                print(f"  FAIL: expected a clean baseline, got: {errors}")
+                status = 1
+
+            print("self-test: per-file count ratchet -- listed count too HIGH (stale) must fail")
+            errors, _ = run_check(regress_crate_src.parent.parent, {regress_rel: 3})
+            if any(regress_rel in e and "lower the listed count" in e for e in errors):
+                print("  ok: a listed count above the actual count is flagged as stale")
+            else:
+                print(f"  FAIL: expected a stale-count-too-high error; errors were: {errors}")
+                status = 1
+
+            print("self-test: per-file count ratchet -- new site in a listed file (regression) must fail")
+            regress_target.write_text(
+                regress_target.read_text()
+                + '\npub fn a_second_violation(x: Option<u32>) -> u32 {\n'
+                + '    x.expect("second bare expect landed without updating the allowlist count")\n'
+                + "}\n"
+            )
+            errors, _ = run_check(regress_crate_src.parent.parent, {regress_rel: 1})
+            if any(regress_rel in e and "new debt" in e for e in errors):
+                print("  ok: a listed file that gained a new bare expect() is flagged as a regression")
+            else:
+                print(f"  FAIL: expected a regression error; errors were: {errors}")
                 status = 1
 
             print("self-test: whole-module exclusion excludes exactly the gated sibling")
@@ -661,7 +800,7 @@ def self_test() -> int:
                 print(f"  FAIL: expected excluded == {expected_excluded}, got {excluded}")
                 status = 1
 
-            wm_errors, wm_counts = run_check(wm_crate_src.parent.parent, set())
+            wm_errors, wm_counts = run_check(wm_crate_src.parent.parent, {})
             wm_rel_prefix = "crates/whole_module_crate/src"
             if (
                 any(f"{wm_rel_prefix}/ungated_sibling_module.rs" in e and "not on" in e for e in wm_errors)
@@ -670,6 +809,34 @@ def self_test() -> int:
                 print("  ok: the ungated sibling's violation is flagged; the gated file's is not scanned at all")
             else:
                 print(f"  FAIL: expected only the ungated sibling flagged, got errors={wm_errors} counts={wm_counts}")
+                status = 1
+
+            print("self-test: out-of-line `#[cfg(test)] mod NAME;` does not swallow the next item")
+            ool_fixtures = fixtures / "out_of_line_test_mod"
+            ool_crate_src = tmp_root / "crates" / "out_of_line_crate" / "src"
+            ool_crate_src.mkdir(parents=True)
+            for f in ool_fixtures.glob("*.rs.fixture"):
+                shutil.copy(f, ool_crate_src / f.name.replace(".fixture", ""))
+            ool_rel_prefix = "crates/out_of_line_crate/src"
+
+            ool_excluded = test_support_paths_for_crate(ool_crate_src)
+            expected_ool_excluded = {Path(f"{ool_rel_prefix}/out_of_line_tests.rs")}
+            if ool_excluded == expected_ool_excluded:
+                print("  ok: the out-of-line-declared test module is excluded by the whole-module mechanism")
+            else:
+                print(f"  FAIL: expected excluded == {expected_ool_excluded}, got {ool_excluded}")
+                status = 1
+
+            ool_errors, ool_counts = run_check(ool_crate_src.parent.parent, {})
+            if any(
+                f"{ool_rel_prefix}/lib.rs" in e and "not on" in e for e in ool_errors
+            ) and not any("out_of_line_tests.rs" in e for e in ool_errors):
+                print(
+                    "  ok: the production fn after the out-of-line mod declaration is still "
+                    "scanned and flagged, not swallowed as if it were the mod's body"
+                )
+            else:
+                print(f"  FAIL: expected only lib.rs's violation flagged, got errors={ool_errors} counts={ool_counts}")
                 status = 1
         finally:
             root = real_root

--- a/scripts/check-runtime-conformance.sh
+++ b/scripts/check-runtime-conformance.sh
@@ -65,7 +65,12 @@ except (OSError, tomllib.TOMLDecodeError) as error:
 # ---------------------------------------------------------------------------
 VALID_STATES = {"implemented", "partial", "planned", "documented-divergence"}
 VALID_CLASSIFICATIONS = {"stable-candidate", "experimental", "transitional", "removal-target"}
-VALID_DOMAINS = {"application", "realm", "presentation", "raster", "platform", "shared-engine"}
+# "workspace" is deliberately not a Runtime.1 topology domain (the other six
+# are). It exists for the rare cross-cutting engineering-discipline contract
+# that has no other mechanically-checked registry to live in (e.g. the
+# expect("BUG: …") panic-policy gate) -- narrow on purpose, not a general
+# dumping ground for anything that lacks a home.
+VALID_DOMAINS = {"application", "realm", "presentation", "raster", "platform", "shared-engine", "workspace"}
 VALID_EVIDENCE_KINDS = {"symbol", "test", "compile-time", "source-gate"}
 OWNER_ISSUE_MIN, OWNER_ISSUE_MAX = 551, 565
 

--- a/scripts/fixtures/panic-policy/conforming.rs.fixture
+++ b/scripts/fixtures/panic-policy/conforming.rs.fixture
@@ -1,0 +1,63 @@
+//! Fixture: every production `.expect(` site here must be recognized as
+//! conforming (or excluded from the scan entirely). See
+//! check-panic-policy.sh's self-test for what each shape exercises.
+
+/// A commented-out call must never count: `foo.expect("not real")`.
+// let bare = foo.expect("also not real, this whole line is a comment");
+pub fn documented_urls() -> &'static str {
+    // A string containing "//" must not desync line-comment stripping (the
+    // masking pass runs first so this "//" is never mistaken for a comment
+    // marker) and the .expect(...) on the SAME line must still resolve.
+    let value = "see https://example.com/docs for details";
+    value
+}
+
+/// A genuine internal invariant, correctly prefixed.
+pub fn real_invariant(items: &[u32]) -> u32 {
+    *items
+        .first()
+        .expect("BUG: caller guarantees items is non-empty before calling real_invariant")
+}
+
+const REASON: &str = "BUG: identifier-resolved invariant message";
+
+/// An identifier argument (not a literal) that resolves to a `const` in this
+/// same file -- the checker must follow it rather than treat it as an
+/// unresolved dynamic argument.
+pub fn identifier_argument(slot: Option<u32>) -> u32 {
+    slot.expect(REASON)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn bare_expect_inside_a_test_mod_is_never_scanned() {
+        let value: Option<u32> = Some(1);
+        let _ = value.expect("test-only message, no BUG: prefix needed");
+    }
+}
+
+/// An individual `#[cfg(test)]`-gated function (not a whole `mod`) must also
+/// be excluded -- this workspace has ~90 real sites shaped exactly like
+/// this one.
+#[cfg(test)]
+fn for_test_helper() -> u32 {
+    let value: Option<u32> = Some(1);
+    value.expect("test-only helper, no BUG: prefix needed")
+}
+
+struct Thing;
+
+/// A multi-line `#[cfg(all(...))]` attribute gating an `impl` block must be
+/// recognized even though the `test` token is not on the same physical line
+/// as `#[cfg(`.
+#[cfg(all(
+    test,
+    not(target_os = "ios")
+))]
+impl Thing {
+    fn test_only_method(&self) -> u32 {
+        let value: Option<u32> = Some(1);
+        value.expect("gated impl block, no BUG: prefix needed")
+    }
+}

--- a/scripts/fixtures/panic-policy/out_of_line_test_mod/lib.rs.fixture
+++ b/scripts/fixtures/panic-policy/out_of_line_test_mod/lib.rs.fixture
@@ -1,0 +1,21 @@
+//! Fixture: exercises the OUT-OF-LINE `#[cfg(test)] mod NAME;` declaration
+//! shape (as opposed to the inline `#[cfg(test)] mod NAME { ... }` the
+//! `conforming.rs.fixture` fixture covers). This shape occurs in several
+//! real crate roots (`flui-engine/src/wgpu/mod.rs`,
+//! `flui-widgets/src/navigator/mod.rs`, and others) as a bare `mod NAME;`
+//! declaration with no body of its own -- the body lives in a sibling file.
+//!
+//! `find_cfg_test_gated_items`'s item scanner must stop at the terminating
+//! `;` and treat this as a body-less declaration (nothing to blank here;
+//! the whole-module mechanism excludes the sibling FILE instead). Before
+//! that fix, the scanner kept looking forward past the `;` for the next
+//! `{`, found the one opening `production_after_declaration` below, and
+//! blanked THAT function's body as though it were the mod's -- silently
+//! swallowing a real, unlisted violation.
+
+#[cfg(test)]
+mod out_of_line_tests;
+
+pub fn production_after_declaration(slot: Option<u32>) -> u32 {
+    slot.expect("must be flagged -- not swallowed by the mod declaration above")
+}

--- a/scripts/fixtures/panic-policy/out_of_line_test_mod/out_of_line_tests.rs.fixture
+++ b/scripts/fixtures/panic-policy/out_of_line_test_mod/out_of_line_tests.rs.fixture
@@ -1,0 +1,11 @@
+//! Fixture: the sibling file `lib.rs.fixture` declares out-of-line via
+//! `#[cfg(test)] mod out_of_line_tests;`. Its bare (non-`BUG:`) expect()
+//! must never be scanned -- the whole file is test-support, excluded by
+//! `test_support_paths_for_crate` (the same mechanism that excludes
+//! `flui-rendering/src/testing/`).
+
+#[test]
+fn some_test() {
+    let value: Option<u32> = Some(1);
+    let _ = value.expect("test-only, never scanned");
+}

--- a/scripts/fixtures/panic-policy/stale_allowlist_candidate.rs.fixture
+++ b/scripts/fixtures/panic-policy/stale_allowlist_candidate.rs.fixture
@@ -1,0 +1,9 @@
+//! Fixture: a fully conforming file, simulating one that used to carry
+//! non-conforming `expect()` sites and was burned down -- but whose entry
+//! was (hypothetically) left on the allowlist. check-panic-policy.sh's
+//! self-test asserts this combination is flagged as a stale entry: the
+//! ratchet shrinks only if a cleaned file also leaves the list.
+
+pub fn cleaned_up(slot: Option<u32>) -> u32 {
+    slot.expect("BUG: this file was burned down; every site here is conforming now")
+}

--- a/scripts/fixtures/panic-policy/unlisted_violation.rs.fixture
+++ b/scripts/fixtures/panic-policy/unlisted_violation.rs.fixture
@@ -1,0 +1,8 @@
+//! Fixture: a bare production `.expect()` with no `BUG: ` prefix, simulating
+//! a new site landing in a file the allowlist does not know about yet.
+//! check-panic-policy.sh's self-test asserts this file is flagged when it
+//! is not named in the (synthetic, in-test) allowlist.
+
+pub fn planted_violation(slot: Option<u32>) -> u32 {
+    slot.expect("no BUG: prefix here — this must fail the gate")
+}

--- a/scripts/fixtures/panic-policy/whole_module_exclusion/gated_testing_module.rs.fixture
+++ b/scripts/fixtures/panic-policy/whole_module_exclusion/gated_testing_module.rs.fixture
@@ -1,0 +1,7 @@
+//! Fixture: the file this crate's `lib.rs.fixture` declares behind
+//! `#[cfg(any(test, feature = "testing"))]`. Its bare (non-`BUG:`) expect()
+//! must never be scanned -- the whole file is test-support.
+
+pub fn only_ever_compiled_under_test(slot: Option<u32>) -> u32 {
+    slot.expect("test-support module, no BUG: prefix needed")
+}

--- a/scripts/fixtures/panic-policy/whole_module_exclusion/lib.rs.fixture
+++ b/scripts/fixtures/panic-policy/whole_module_exclusion/lib.rs.fixture
@@ -1,0 +1,22 @@
+//! Fixture: exercises the WHOLE-MODULE test-support exclusion path (as
+//! opposed to the inline `#[cfg(test)] mod X { ... }` / fn / impl exclusion
+//! the other fixtures cover). This file plays the role of a crate's
+//! `lib.rs`: one sibling module is gated the way flui-rendering/
+//! flui-interaction/flui-layer/flui-painting gate their real `testing`
+//! modules; the other is an ordinary, ungated production module.
+//!
+//! check-panic-policy.sh's self-test asserts that ONLY
+//! `gated_testing_module.rs` is excluded -- a regression that widens the
+//! exclusion (e.g. excludes every sibling regardless of its own cfg) would
+//! silently swallow `ungated_sibling_module.rs`'s real violation too, and a
+//! regression that narrows it (stops recognizing the gate at all) would
+//! wrongly flag `gated_testing_module.rs`'s test-only expect() as
+//! production debt. Both directions fail open (an exclusion bug is
+//! invisible until someone notices debt is missing or a test-only file is
+//! wrongly gating CI), so this is asserted directly against
+//! `test_support_paths_for_crate`, not just indirectly through site counts.
+
+#[cfg(any(test, feature = "testing"))]
+pub mod gated_testing_module;
+
+mod ungated_sibling_module;

--- a/scripts/fixtures/panic-policy/whole_module_exclusion/ungated_sibling_module.rs.fixture
+++ b/scripts/fixtures/panic-policy/whole_module_exclusion/ungated_sibling_module.rs.fixture
@@ -1,0 +1,9 @@
+//! Fixture: an ordinary, ungated production sibling of
+//! `gated_testing_module.rs.fixture`. Its bare (non-`BUG:`) expect() MUST be
+//! scanned and flagged -- proving the whole-module exclusion is scoped to
+//! the one gated declaration, not every module a gated file happens to sit
+//! next to.
+
+pub fn ordinary_production_code(slot: Option<u32>) -> u32 {
+    slot.expect("ungated sibling, this must be flagged")
+}


### PR DESCRIPTION
Implements the audit's §2.5-class finding: the `expect("BUG: …")` convention existed only as prose (243 production sites, ~35% compliant, zero enforcement).

## What lands

- **`scripts/check-panic-policy.sh`** — a bidirectional per-file ratchet (sibling of the conformance checker, reusing its literal-masking lexer, extended for multi-line `cfg` attributes and item-level `#[cfg(test)]` exclusion): production `expect()` messages must carry the `BUG:` prefix; an allowlist seeds today's 65 files / 125 deferred sites and can only shrink (stale entries fail; new bare expects in clean files fail). Self-test covers seven scenarios including the whole-module-exclusion path (fail-open regression guarded). Wired into `just ci` and the CI `checks` job.
- **Burn-down of the worst offenders** — 5 of the 6 audit-named files fully conforming, each message stating the *real* invariant verified by reading the code (mutex-poisoning privacy, same-scope `take`/`is_some` proofs, layout-before-paint contracts); the 6th (`flui-rendering` harness) confirmed test-support and correctly out of scope. `flui-foundation`'s three caller-triggerable ID panics stay honestly allowlisted (documented `# Panics`, fallible `try_zip` exists; the `Result`-conversion is a recorded deferred breaking candidate, not silently skipped). One genuine environmental failure (`run_web` bootstrap) converted to the sibling runner's match+panic pattern instead of being blessed with a false `BUG:`.
- Registry contract entry (`workspace` domain, mechanical) + PANIC-POLICY.md names the gate.

## Review trail

Independent review spot-read 10 reworded sites against their code (all invariants verified true), ran its own plant/revert red-tests both directions, probed the multi-line-cfg lexer against the hardest file, and caught two real defects pre-merge: an **unquoted `: ` in the new CI step name (invalid YAML that would have killed every workflow run — its own linters can't catch a file that never parses)**, and one invariant message overclaiming its constructor list (the serde path). Both fixed with repro-first evidence; YAML now validated by `yaml.safe_load` + `zizmor .github/`.

Gates: `just ci` exit 0 (now including the new gate), clippy `-D warnings`, taplo/typos, conformance, port-check; foundation 219/219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)