### PR TITLE
docs(platform): Windows-backend SAFETY burn-down — true invariants, traced Win32 failures, scoped unsafe allows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,12 +329,20 @@ unwrap_used = "warn"
 # `undocumented_unsafe_blocks` is deliberately NOT enabled. It was tried and
 # reverted, for two reasons worth recording so it is not re-adopted casually:
 #
-#   * It can only see what the Linux clippy job compiles. The `cfg(windows)` and
-#     `cfg(target_os = "macos")` backends in flui-platform carry ~91 further
-#     undocumented sites that no gate here reaches, so a green workspace run
-#     would license the claim "every unsafe site is documented" while that is
-#     false for two of three desktop targets. Enabling it is only meaningful
-#     once the cross-target job runs `clippy`, not `cargo check`.
+#   * It can only see what the Linux clippy job compiles. `cfg(windows)`'s
+#     flui-platform backend (Win32 window/platform FFI) is now fully
+#     SAFETY-documented — every unsafe block there carries an invariant
+#     comment, verified via `cargo clippy --target x86_64-pc-windows-msvc`.
+#     `cfg(target_os = "macos")` and the Android/`wasm32` backends are not:
+#     as of the last full audit (docs/audits/2026-08-04-full-audit.md §2.1),
+#     macOS carried ~11 undocumented sites, Android ~14 (mostly outside the
+#     now-scoped `platforms::android::memory` FFI island), web ~9 — none of
+#     which the Linux clippy job reaches. A green workspace run would still
+#     license the claim "every unsafe site is documented" while that remains
+#     false for two of three desktop targets plus mobile/web. Enabling it is
+#     only meaningful once the cross-target jobs run `clippy`, not `cargo
+#     check` (today `cross-typecheck` type-checks msvc/darwin without
+#     linting, and there is no Android/wasm clippy job at all).
 #   * Turning it on first and writing comments to satisfy it produces prose, not
 #     review. That is how several comments in flui-hot-reload came to state
 #     invariants the code does not establish. Document unsafe because the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -330,9 +330,11 @@ unwrap_used = "warn"
 # reverted, for two reasons worth recording so it is not re-adopted casually:
 #
 #   * It can only see what the Linux clippy job compiles. `cfg(windows)`'s
-#     flui-platform backend (Win32 window/platform FFI) is now fully
-#     SAFETY-documented — every unsafe block there carries an invariant
-#     comment, verified via `cargo clippy --target x86_64-pc-windows-msvc`.
+#     flui-platform backend — every file under `platforms::windows`
+#     (`window.rs`, `platform.rs`, `clipboard.rs`, `display.rs`, `events.rs`,
+#     `util.rs`) — is now fully SAFETY-documented: every unsafe block carries
+#     an invariant comment (or, for `unsafe fn`, a `# Safety` rustdoc
+#     section), verified via `cargo clippy --target x86_64-pc-windows-msvc`.
 #     `cfg(target_os = "macos")` and the Android/`wasm32` backends are not:
 #     as of the last full audit (docs/audits/2026-08-04-full-audit.md §2.1),
 #     macOS carried ~11 undocumented sites, Android ~14 (mostly outside the

--- a/crates/flui-app/src/app/presentation.rs
+++ b/crates/flui-app/src/app/presentation.rs
@@ -79,6 +79,10 @@ impl PlatformWindow for TestPresentationWindow {
         *self.cursor.lock() = cursor;
         Ok(())
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 /// Lifecycle of the owner-thread half of a presentation.
@@ -657,9 +661,9 @@ mod tests {
                 .expect("the headless backend's PlatformHaptics is a FakeHaptics")
         }
 
-        /// A minimal `PlatformWindow` implementing only the trait's
-        /// non-default methods, so `haptics()` falls through to the trait
-        /// default (`None`).
+        /// A minimal `PlatformWindow` implementing only the trait's required
+        /// methods (`as_any` has no default; everything else here does), so
+        /// `haptics()` falls through to the trait default (`None`).
         struct BareWindow;
 
         impl PlatformWindow for BareWindow {
@@ -696,6 +700,10 @@ mod tests {
                 _cursor: flui_platform::CursorIcon,
             ) -> Result<(), flui_platform::CursorError> {
                 Ok(())
+            }
+
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
             }
         }
 

--- a/crates/flui-app/src/app/window_registry.rs
+++ b/crates/flui-app/src/app/window_registry.rs
@@ -273,6 +273,10 @@ mod tests {
         ) -> Result<(), flui_platform::CursorError> {
             Ok(())
         }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
     }
 
     fn stub_window(id: u64) -> Arc<dyn PlatformWindow> {

--- a/crates/flui-platform/src/lib.rs
+++ b/crates/flui-platform/src/lib.rs
@@ -148,9 +148,17 @@
 //! ```
 
 // Platform FFI is the sanctioned `unsafe` boundary of the workspace (Win32 /
-// AppKit / headless backends); every block carries a `// SAFETY:` comment.
-// Permanent, unlike the tracked debt below.
-#![allow(unsafe_code)]
+// AppKit / Android NDK / wasm-bindgen backends — `headless` has none). The
+// crate no longer opts the whole tree out of `unsafe_code = "warn"`: each
+// FFI island (`platforms::windows`, `platforms::macos`, `platforms::web`,
+// `platforms::winit`, `platforms::android::memory`) carries its own
+// module-level `#![allow(unsafe_code)]` where it is declared, and the two
+// small marker-trait impls in `window.rs`/`task.rs` carry item-level allows.
+// Every `unsafe` block anywhere in this crate still carries a `// SAFETY:`
+// comment stating the invariant that makes it sound — the workspace lint is
+// scoped per-crate, not proof that every site is documented; see the
+// per-crate documentation coverage tracked in the root `Cargo.toml`'s
+// `undocumented_unsafe_blocks` note.
 // Ship bar (wave 4): every public item is documented; keep it that way.
 #![deny(missing_docs)]
 

--- a/crates/flui-platform/src/lib.rs
+++ b/crates/flui-platform/src/lib.rs
@@ -154,11 +154,14 @@
 // `platforms::winit`, `platforms::android::memory`) carries its own
 // module-level `#![allow(unsafe_code)]` where it is declared, and the two
 // small marker-trait impls in `window.rs`/`task.rs` carry item-level allows.
-// Every `unsafe` block anywhere in this crate still carries a `// SAFETY:`
-// comment stating the invariant that makes it sound — the workspace lint is
-// scoped per-crate, not proof that every site is documented; see the
+// `platforms::windows` (every file: `window.rs`, `platform.rs`, `clipboard.rs`,
+// `display.rs`, `events.rs`, `util.rs`) is fully SAFETY-documented — every
+// `unsafe` block there carries a `// SAFETY:` comment (or, for `unsafe fn`,
+// a `# Safety` rustdoc section) stating the invariant that makes it sound.
+// `platforms::macos`/`android`/`web` are NOT yet at that bar; see the
 // per-crate documentation coverage tracked in the root `Cargo.toml`'s
-// `undocumented_unsafe_blocks` note.
+// `undocumented_unsafe_blocks` note — do not restate "every block" as a
+// crate-wide claim until that note says so too.
 // Ship bar (wave 4): every public item is documented; keep it that way.
 #![deny(missing_docs)]
 

--- a/crates/flui-platform/src/platforms/android/memory.rs
+++ b/crates/flui-platform/src/platforms/android/memory.rs
@@ -21,6 +21,12 @@
 //! assert_eq!(buffer.as_ptr() as usize % get_page_size(), 0);
 //! ```
 
+// This module is one of the workspace's sanctioned `unsafe` FFI islands —
+// raw page-aligned allocation has no safe wrapper. The workspace lint
+// `unsafe_code = "warn"` is opted out here, at the module boundary, rather
+// than for the whole crate (see `lib.rs`).
+#![allow(unsafe_code)]
+
 use std::{
     alloc::{Layout, alloc, dealloc},
     fmt,
@@ -58,10 +64,7 @@ pub fn get_page_size() -> usize {
     {
         // SAFETY: sysconf is a standard POSIX function
         // _SC_PAGESIZE always returns a valid value on Android
-        #[allow(unsafe_code)]
-        unsafe {
-            libc::sysconf(libc::_SC_PAGESIZE) as usize
-        }
+        unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize }
     }
 
     #[cfg(not(target_os = "android"))]

--- a/crates/flui-platform/src/platforms/android/window.rs
+++ b/crates/flui-platform/src/platforms/android/window.rs
@@ -198,4 +198,8 @@ impl PlatformWindow for AndroidWindow {
     fn mouse_position(&self) -> Point<Pixels> {
         Point::default()
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }

--- a/crates/flui-platform/src/platforms/headless/platform.rs
+++ b/crates/flui-platform/src/platforms/headless/platform.rs
@@ -554,6 +554,10 @@ impl crate::traits::PlatformWindow for MockWindow {
     fn on_appearance_changed(&self, callback: Box<dyn FnMut() + Send>) {
         *self.callbacks.on_appearance_changed.lock() = Some(callback);
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 /// Recording fake for [`PlatformTextInput`], backing the headless backend's

--- a/crates/flui-platform/src/platforms/macos/mod.rs
+++ b/crates/flui-platform/src/platforms/macos/mod.rs
@@ -64,4 +64,6 @@ pub use window_ext::{MacOSCollectionBehavior, MacOSWindowExt, MacOSWindowLevel};
 pub use window_manager::{
     GroupId, SharedWindowManager, WindowId, WindowInfo, WindowLevel, WindowManager, WindowOptions,
 };
-pub use window_tiling::{TilePosition, TilingConfiguration, TilingLayout, TilingState};
+pub use window_tiling::{
+    TilePosition, TilingConfiguration, TilingError, TilingLayout, TilingState,
+};

--- a/crates/flui-platform/src/platforms/macos/mod.rs
+++ b/crates/flui-platform/src/platforms/macos/mod.rs
@@ -37,6 +37,11 @@
 // this backend deliberately stays on the single cocoa/objc stack until a
 // dedicated objc2 migration replaces it wholesale.
 #![allow(deprecated)]
+// This module (and its submodules) is one of the workspace's sanctioned
+// `unsafe` FFI islands — direct AppKit/Cocoa objc calls have no safe
+// wrapper. The workspace lint `unsafe_code = "warn"` is opted out here, at
+// the module boundary, rather than for the whole crate (see `lib.rs`).
+#![allow(unsafe_code)]
 
 mod clipboard;
 mod display;

--- a/crates/flui-platform/src/platforms/macos/window_tiling.rs
+++ b/crates/flui-platform/src/platforms/macos/window_tiling.rs
@@ -27,6 +27,17 @@ use flui_types::{
     geometry::{Rect, Size},
 };
 
+/// A [`TilingConfiguration`] combined a [`TilePosition`] and [`TilingLayout`]
+/// that are not compatible with each other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("{position:?} is not a valid primary position for {layout:?}")]
+pub struct TilingError {
+    /// The incompatible position that was set.
+    pub position: TilePosition,
+    /// The layout it was paired with.
+    pub layout: TilingLayout,
+}
+
 // ============================================================================
 // Tiling Configuration
 // ============================================================================
@@ -108,16 +119,34 @@ impl TilingConfiguration {
 
     /// Calculate tile rectangles for the given screen size.
     ///
-    /// Returns (primary_rect, secondary_rect).
-    pub fn calculate_tiles(&self, screen_size: Size<Pixels>) -> (Rect<Pixels>, Rect<Pixels>) {
+    /// Returns `(primary_rect, secondary_rect)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TilingError`] if `self.primary_position` is not one of the
+    /// positions [`TilePosition::is_valid_for_layout`] accepts for
+    /// `self.layout` (e.g. `TopLeft` with a `SideBySide` layout) — the
+    /// builder methods that set `layout`/`primary_position` independently do
+    /// not cross-validate them, so this can only be caught here.
+    pub fn calculate_tiles(
+        &self,
+        screen_size: Size<Pixels>,
+    ) -> Result<(Rect<Pixels>, Rect<Pixels>), TilingError> {
+        if !self.primary_position.is_valid_for_layout(self.layout) {
+            return Err(TilingError {
+                position: self.primary_position,
+                layout: self.layout,
+            });
+        }
+
         let width = screen_size.width;
         let height = screen_size.height;
 
-        match self.layout {
+        let tiles = match self.layout {
             TilingLayout::SideBySide => {
                 let split_x = width * self.split_ratio;
 
-                let (primary, secondary) = match self.primary_position {
+                match self.primary_position {
                     TilePosition::Left => (
                         Rect::from_origin_size(
                             flui_types::geometry::Point::new(Pixels(0.0), Pixels(0.0)),
@@ -138,16 +167,18 @@ impl TilingConfiguration {
                             Size::new(width - split_x, height),
                         ),
                     ),
-                    _ => panic!("Invalid position for SideBySide layout"),
-                };
-
-                (primary, secondary)
+                    // Every other `TilePosition` was already rejected by the
+                    // `is_valid_for_layout` guard above.
+                    _ => unreachable!(
+                        "BUG: is_valid_for_layout guard above did not match calculate_tiles's own SideBySide arm"
+                    ),
+                }
             }
 
             TilingLayout::TopBottom => {
                 let split_y = height * self.split_ratio;
 
-                let (primary, secondary) = match self.primary_position {
+                match self.primary_position {
                     TilePosition::Top => (
                         Rect::from_origin_size(
                             flui_types::geometry::Point::new(Pixels(0.0), Pixels(0.0)),
@@ -168,10 +199,10 @@ impl TilingConfiguration {
                             Size::new(width, height - split_y),
                         ),
                     ),
-                    _ => panic!("Invalid position for TopBottom layout"),
-                };
-
-                (primary, secondary)
+                    _ => unreachable!(
+                        "BUG: is_valid_for_layout guard above did not match calculate_tiles's own TopBottom arm"
+                    ),
+                }
             }
 
             TilingLayout::Quarters => {
@@ -196,7 +227,9 @@ impl TilingConfiguration {
                         flui_types::geometry::Point::new(half_width, half_height),
                         Size::new(half_width, half_height),
                     ),
-                    _ => panic!("Invalid position for Quarters layout"),
+                    _ => unreachable!(
+                        "BUG: is_valid_for_layout guard above did not match calculate_tiles's own Quarters arm"
+                    ),
                 };
 
                 // Secondary takes the rest (3 quadrants)
@@ -207,7 +240,9 @@ impl TilingConfiguration {
 
                 (primary, secondary)
             }
-        }
+        };
+
+        Ok(tiles)
     }
 
     /// Check if tiling is available on this macOS version.
@@ -409,7 +444,7 @@ mod tests {
             .with_split_ratio(0.5);
 
         let screen = Size::new(Pixels(1920.0), Pixels(1080.0));
-        let (primary, secondary) = config.calculate_tiles(screen);
+        let (primary, secondary) = config.calculate_tiles(screen).unwrap();
 
         assert_eq!(primary.width(), Pixels(960.0));
         assert_eq!(secondary.width(), Pixels(960.0));
@@ -425,10 +460,30 @@ mod tests {
             .with_split_ratio(0.6);
 
         let screen = Size::new(Pixels(1920.0), Pixels(1080.0));
-        let (primary, secondary) = config.calculate_tiles(screen);
+        let (primary, secondary) = config.calculate_tiles(screen).unwrap();
 
         assert_eq!(primary.height(), Pixels(648.0)); // 60% of 1080
         assert_eq!(secondary.height(), Pixels(432.0)); // 40% of 1080
+    }
+
+    #[test]
+    fn test_calculate_tiles_rejects_mismatched_position() {
+        // `with_layout`/`with_primary_position` don't cross-validate each
+        // other, so this combination — a Quarters position paired with a
+        // SideBySide layout — only surfaces as an error here.
+        let config = TilingConfiguration::new()
+            .with_layout(TilingLayout::SideBySide)
+            .with_primary_position(TilePosition::TopLeft);
+
+        let screen = Size::new(Pixels(1920.0), Pixels(1080.0));
+        let err = config.calculate_tiles(screen).unwrap_err();
+        assert_eq!(
+            err,
+            TilingError {
+                position: TilePosition::TopLeft,
+                layout: TilingLayout::SideBySide,
+            }
+        );
     }
 
     #[test]

--- a/crates/flui-platform/src/platforms/macos/window_tiling.rs
+++ b/crates/flui-platform/src/platforms/macos/window_tiling.rs
@@ -27,7 +27,7 @@ use flui_types::{
     geometry::{Rect, Size},
 };
 
-/// A [`TilingConfiguration`] combined a [`TilePosition`] and [`TilingLayout`]
+/// A [`TilingConfiguration`] combines a [`TilePosition`] and [`TilingLayout`]
 /// that are not compatible with each other.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[error("{position:?} is not a valid primary position for {layout:?}")]

--- a/crates/flui-platform/src/platforms/web/mod.rs
+++ b/crates/flui-platform/src/platforms/web/mod.rs
@@ -3,6 +3,12 @@
 //! Implements the Platform trait for web browsers via WebAssembly using
 //! wasm-bindgen and web-sys for browser API access.
 
+// This module (and its submodules) is one of the workspace's sanctioned
+// `unsafe` FFI islands — `wasm-bindgen`'s JS interop requires it. The
+// workspace lint `unsafe_code = "warn"` is opted out here, at the module
+// boundary, rather than for the whole crate (see `lib.rs`).
+#![allow(unsafe_code)]
+
 mod clipboard;
 mod display;
 mod events;

--- a/crates/flui-platform/src/platforms/web/window.rs
+++ b/crates/flui-platform/src/platforms/web/window.rs
@@ -325,4 +325,8 @@ impl PlatformWindow for WebWindow {
         // SAFETY: Web display handle is always valid
         Ok(unsafe { DisplayHandle::borrow_raw(raw) })
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }

--- a/crates/flui-platform/src/platforms/windows/clipboard.rs
+++ b/crates/flui-platform/src/platforms/windows/clipboard.rs
@@ -5,13 +5,13 @@
 
 use parking_lot::Mutex;
 use windows::Win32::{
-    Foundation::{HANDLE, HGLOBAL},
+    Foundation::{GlobalFree, HANDLE, HGLOBAL},
     System::{
         DataExchange::{
             CloseClipboard, EmptyClipboard, GetClipboardData, IsClipboardFormatAvailable,
             OpenClipboard, SetClipboardData,
         },
-        Memory::{GMEM_MOVEABLE, GlobalAlloc, GlobalLock, GlobalUnlock},
+        Memory::{GMEM_MOVEABLE, GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock},
         Ole::CF_UNICODETEXT,
     },
 };
@@ -56,19 +56,19 @@ impl Clipboard for WindowsClipboard {
         // step runs (`is_err()`/`is_invalid()`), so `handle` is only
         // converted to `HGLOBAL` once known valid. `GlobalLock` returning
         // non-null is checked before `ptr` is dereferenced at all. The
-        // `while *wide_ptr.add(len) != 0` scan trusts that data placed
-        // under `CF_UNICODETEXT` is a NUL-terminated UTF-16 string, per the
-        // documented Win32 clipboard-format contract — this code does not
-        // itself bound `len` against the allocation size, so a clipboard
-        // owner that violates that format contract (places unterminated
-        // data under this format) would walk past the allocation; that is
-        // a trust boundary on external/OS-mediated data, not something this
-        // function can verify from its own inputs. `GlobalUnlock`'s result
-        // is discarded deliberately: its return value cannot distinguish
-        // "already unlocked, success" from "failed" without a further
-        // `GetLastError` check, and there is nothing actionable left to do
-        // with the lock at this point regardless — the string was already
-        // copied out of the locked memory before this call.
+        // clipboard is owned by another, untrusted process — CF_UNICODETEXT's
+        // documented "NUL-terminated UTF-16" contract is not something this
+        // code can rely on that other process to honor, so the NUL scan
+        // below is hard-bounded by `GlobalSize(hglobal)` (the allocation's
+        // actual byte length, halved for `u16` units): the scan never reads
+        // past `wide_ptr.add(max_len - 1)`, and a missing terminator within
+        // that bound is treated as malformed data (`None`), not walked past.
+        // `GlobalUnlock`'s result is discarded deliberately on every path:
+        // its return value cannot distinguish "already unlocked, success"
+        // from "failed" without a further `GetLastError` check, and there is
+        // nothing actionable left to do with the lock at this point
+        // regardless — the string (or the decision to abandon it) is
+        // already finalized before this call.
         unsafe {
             // Open clipboard (None = current thread's window)
             if OpenClipboard(None).is_err() {
@@ -109,12 +109,28 @@ impl Clipboard for WindowsClipboard {
                 return None;
             }
 
+            // Bound the NUL scan by the allocation's actual size — never
+            // trust that a CF_UNICODETEXT payload from another process is
+            // properly terminated within the memory it was given.
+            let byte_size = GlobalSize(hglobal);
+            let max_len = byte_size / std::mem::size_of::<u16>();
+
             // Convert wide string to Rust String
             let wide_ptr = ptr as *const u16;
             let mut len: usize = 0;
-            while *wide_ptr.add(len) != 0 {
+            while len < max_len && *wide_ptr.add(len) != 0 {
                 len += 1;
             }
+
+            if len == max_len {
+                tracing::warn!(
+                    byte_size,
+                    "Clipboard CF_UNICODETEXT data has no NUL terminator within its allocated size"
+                );
+                let _ = GlobalUnlock(hglobal);
+                return None;
+            }
+
             let wide_slice = std::slice::from_raw_parts(wide_ptr, len);
             let rust_string = String::from_utf16_lossy(wide_slice);
 
@@ -141,13 +157,15 @@ impl Clipboard for WindowsClipboard {
         // as in `read_text` (ambiguous success/fail without `GetLastError`,
         // nothing actionable to do about it here). Ownership of `global`
         // transfers to the clipboard only after `SetClipboardData` reports
-        // success — checked before `let _ = global;` is reached, so this
-        // code never frees memory the clipboard already owns, and every
-        // earlier `return` (failed alloc/lock/`SetClipboardData`) leaves
-        // `global` to be dropped normally, which is safe precisely because
-        // `HGLOBAL` has no automatic-free `Drop` impl of its own — an
-        // unconsumed allocation here is a leak on the failure paths, not a
-        // double-free.
+        // success. Every failure path between the successful `GlobalAlloc`
+        // and that point (`GlobalLock` failing, `SetClipboardData` failing)
+        // still owns `global` outright — nothing else has a handle to it or
+        // has started using it — so calling `GlobalFree` there is sound and
+        // this code does so explicitly rather than leaking (`HGLOBAL` has no
+        // automatic-free `Drop` impl of its own, so a bare early `return`
+        // would otherwise leak the allocation). Once `SetClipboardData`
+        // succeeds, `global` is no longer freed by this function at all —
+        // the clipboard owns it from that point on.
         unsafe {
             // Open clipboard
             if OpenClipboard(None).is_err() {
@@ -181,9 +199,16 @@ impl Clipboard for WindowsClipboard {
             let ptr = GlobalLock(global);
             if ptr.is_null() {
                 tracing::error!("Failed to lock global memory");
-                // The allocation leaks here: windows-rs HGLOBAL has no Drop
-                // (see the SAFETY block above) — a rare, bounded leak on a
-                // failure path, preferred over a double-free hazard.
+                // Ownership never transferred to the clipboard, so freeing
+                // `global` here is sound (see the SAFETY block above).
+                // Discarding the `Result`: raw `GlobalFree` documents NULL
+                // as its success return, but `windows::Win32::Foundation::HGLOBAL::is_invalid`
+                // treats a null/`-1` handle as invalid and this wrapper maps
+                // "invalid result" to `Err` — so a genuinely successful free
+                // surfaces here as `Err`, not `Ok`. Not reliable enough to
+                // log a success/failure claim from; the free is issued
+                // either way, which is the part that matters.
+                let _ = GlobalFree(Some(global));
                 return;
             }
 
@@ -195,8 +220,12 @@ impl Clipboard for WindowsClipboard {
             // After successful SetClipboardData, we must NOT free the memory
             if SetClipboardData(CF_UNICODETEXT.0 as u32, Some(HANDLE(global.0))).is_err() {
                 tracing::error!("Failed to set clipboard data");
-                // The allocation leaks here (HGLOBAL has no Drop) — bounded
-                // failure-path leak, never a double-free.
+                // The clipboard never took ownership on this path, so
+                // `global` is still ours to free — see the SetClipboardData
+                // SAFETY note above and the GlobalFree Result-polarity note
+                // on the GlobalLock failure path above for why the result is
+                // discarded rather than logged as success/failure.
+                let _ = GlobalFree(Some(global));
                 return;
             }
 

--- a/crates/flui-platform/src/platforms/windows/clipboard.rs
+++ b/crates/flui-platform/src/platforms/windows/clipboard.rs
@@ -50,6 +50,25 @@ impl Clipboard for WindowsClipboard {
     fn read_text(&self) -> Option<String> {
         let _guard = self.lock.lock();
 
+        // SAFETY: `OpenClipboard`/`IsClipboardFormatAvailable`/
+        // `GetClipboardData` are plain FFI calls with no pointer arguments
+        // of ours; every one of their results is checked before the next
+        // step runs (`is_err()`/`is_invalid()`), so `handle` is only
+        // converted to `HGLOBAL` once known valid. `GlobalLock` returning
+        // non-null is checked before `ptr` is dereferenced at all. The
+        // `while *wide_ptr.add(len) != 0` scan trusts that data placed
+        // under `CF_UNICODETEXT` is a NUL-terminated UTF-16 string, per the
+        // documented Win32 clipboard-format contract — this code does not
+        // itself bound `len` against the allocation size, so a clipboard
+        // owner that violates that format contract (places unterminated
+        // data under this format) would walk past the allocation; that is
+        // a trust boundary on external/OS-mediated data, not something this
+        // function can verify from its own inputs. `GlobalUnlock`'s result
+        // is discarded deliberately: its return value cannot distinguish
+        // "already unlocked, success" from "failed" without a further
+        // `GetLastError` check, and there is nothing actionable left to do
+        // with the lock at this point regardless — the string was already
+        // copied out of the locked memory before this call.
         unsafe {
             // Open clipboard (None = current thread's window)
             if OpenClipboard(None).is_err() {
@@ -110,6 +129,25 @@ impl Clipboard for WindowsClipboard {
     fn write_text(&self, text: String) {
         let _guard = self.lock.lock();
 
+        // SAFETY: `OpenClipboard`/`EmptyClipboard`/`GlobalAlloc` results are
+        // all checked before the next step runs. `size` is computed as
+        // `wide.len() * size_of::<u16>()`, the exact byte length of `wide`
+        // (a `Vec<u16>`, so `wide.as_ptr()` is valid for reads of `size`
+        // bytes) — the same `size` is passed to `GlobalAlloc`, so `ptr` from
+        // the matching `GlobalLock` is valid for writes of `size` bytes too;
+        // `copy_nonoverlapping` copies between two distinct allocations
+        // (the `Vec` and the newly allocated `HGLOBAL`), never the same
+        // memory. `GlobalUnlock`'s result is discarded for the same reason
+        // as in `read_text` (ambiguous success/fail without `GetLastError`,
+        // nothing actionable to do about it here). Ownership of `global`
+        // transfers to the clipboard only after `SetClipboardData` reports
+        // success — checked before `let _ = global;` is reached, so this
+        // code never frees memory the clipboard already owns, and every
+        // earlier `return` (failed alloc/lock/`SetClipboardData`) leaves
+        // `global` to be dropped normally, which is safe precisely because
+        // `HGLOBAL` has no automatic-free `Drop` impl of its own — an
+        // unconsumed allocation here is a leak on the failure paths, not a
+        // double-free.
         unsafe {
             // Open clipboard
             if OpenClipboard(None).is_err() {
@@ -167,6 +205,10 @@ impl Clipboard for WindowsClipboard {
     }
 
     fn has_text(&self) -> bool {
+        // SAFETY: `IsClipboardFormatAvailable` takes a plain format-id
+        // integer, no pointer arguments, and (per its own documented
+        // contract) is one of the few clipboard queries safe to call
+        // without an open/close pair around it.
         unsafe {
             // Check if Unicode text format is available without opening clipboard
             // IsClipboardFormatAvailable returns Result<()> in windows-rs 0.59
@@ -180,6 +222,13 @@ struct CloseClipboardGuard;
 
 impl Drop for CloseClipboardGuard {
     fn drop(&mut self) {
+        // SAFETY: `CloseClipboard` takes no arguments; every caller of this
+        // guard only constructs it after a successful `OpenClipboard`, so
+        // this always closes a clipboard this thread actually holds open.
+        // The result is discarded because `Drop::drop` cannot return a
+        // `Result` and there is no recovery action available regardless —
+        // an unbalanced close would surface as the *next* `OpenClipboard`
+        // failing, not as memory unsafety here.
         unsafe {
             let _ = CloseClipboard();
         }

--- a/crates/flui-platform/src/platforms/windows/clipboard.rs
+++ b/crates/flui-platform/src/platforms/windows/clipboard.rs
@@ -181,7 +181,9 @@ impl Clipboard for WindowsClipboard {
             let ptr = GlobalLock(global);
             if ptr.is_null() {
                 tracing::error!("Failed to lock global memory");
-                // Note: memory will be freed when global goes out of scope
+                // The allocation leaks here: windows-rs HGLOBAL has no Drop
+                // (see the SAFETY block above) — a rare, bounded leak on a
+                // failure path, preferred over a double-free hazard.
                 return;
             }
 
@@ -193,12 +195,14 @@ impl Clipboard for WindowsClipboard {
             // After successful SetClipboardData, we must NOT free the memory
             if SetClipboardData(CF_UNICODETEXT.0 as u32, Some(HANDLE(global.0))).is_err() {
                 tracing::error!("Failed to set clipboard data");
-                // On error, memory will be freed when global goes out of scope
+                // The allocation leaks here (HGLOBAL has no Drop) — bounded
+                // failure-path leak, never a double-free.
                 return;
             }
 
-            // Success - clipboard now owns the memory
-            // Prevent HGLOBAL from being freed by forgetting it
+            // Success — the clipboard owns the memory from here on; the
+            // local HGLOBAL is a plain handle newtype with no Drop, so
+            // letting it fall out of scope frees nothing.
             let _ = global;
             tracing::debug!(len = text.len(), "Wrote text to clipboard");
         }

--- a/crates/flui-platform/src/platforms/windows/events.rs
+++ b/crates/flui-platform/src/platforms/windows/events.rs
@@ -146,7 +146,15 @@ fn vk_to_key(vk: VIRTUAL_KEY, _scan_code: u16) -> Key {
 }
 
 /// Get current modifiers state
+///
+/// # Safety
+///
+/// None, in the memory-safety sense — this only calls `is_key_pressed`
+/// (see its own `# Safety` section in `util.rs`) with the fixed, in-range
+/// virtual-key constants below. `unsafe fn` purely because it calls an
+/// `unsafe fn`, not because this function itself has a precondition.
 unsafe fn get_modifiers() -> KeyboardModifiers {
+    // SAFETY: see the `# Safety` section above.
     unsafe {
         let mut mods = KeyboardModifiers::empty();
 
@@ -180,6 +188,8 @@ fn pointer_state(
 ) -> (PointerState, KeyboardModifiers) {
     let x = get_x_lparam(lparam);
     let y = get_y_lparam(lparam);
+    // SAFETY: see `get_modifiers`'s own `# Safety` section — no
+    // precondition to discharge here.
     let modifiers = unsafe { get_modifiers() };
     let logical_x = device_to_logical(x as f32, scale_factor);
     let logical_y = device_to_logical(y as f32, scale_factor);
@@ -269,6 +279,7 @@ pub fn key_down_event(wparam: WPARAM, lparam: LPARAM) -> PlatformInput {
     let scan_code = ((lparam.0 >> 16) & 0xFF) as u16;
     let is_repeat = (lparam.0 & (1 << 30)) != 0;
 
+    // SAFETY: see `pointer_state` above — same call, no precondition.
     let modifiers = unsafe { get_modifiers() };
     let key = vk_to_key(vk, scan_code);
 
@@ -288,6 +299,7 @@ pub fn key_up_event(wparam: WPARAM, lparam: LPARAM) -> PlatformInput {
     let vk = VIRTUAL_KEY(wparam.0 as u16);
     let scan_code = ((lparam.0 >> 16) & 0xFF) as u16;
 
+    // SAFETY: see `pointer_state` above — same call, no precondition.
     let modifiers = unsafe { get_modifiers() };
     let key = vk_to_key(vk, scan_code);
 

--- a/crates/flui-platform/src/platforms/windows/mod.rs
+++ b/crates/flui-platform/src/platforms/windows/mod.rs
@@ -3,6 +3,14 @@
 //! This module provides native Windows support without winit,
 //! using direct Win32 API calls for maximum control and performance.
 
+// This module (and its submodules) is one of the workspace's sanctioned
+// `unsafe` FFI islands — direct Win32 calls have no safe wrapper. The
+// workspace lint `unsafe_code = "warn"` is opted out here, at the module
+// boundary, rather than for the whole crate (see `lib.rs`); every `unsafe`
+// block still carries its own `// SAFETY:` comment stating the invariant
+// that makes it sound.
+#![allow(unsafe_code)]
+
 mod clipboard;
 mod display;
 mod events;

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -1168,8 +1168,14 @@ impl Platform for WindowsPlatform {
         unsafe {
             // Bring the foreground window to front
             let hwnd = GetForegroundWindow();
-            if !hwnd.is_invalid() {
-                let _ = SetForegroundWindow(hwnd);
+            if !hwnd.is_invalid()
+                && let Err(error) = SetForegroundWindow(hwnd).ok()
+            {
+                tracing::warn!(
+                    ?hwnd,
+                    ?error,
+                    "SetForegroundWindow failed in Platform::activate"
+                );
             }
         }
     }

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -61,8 +61,15 @@ pub(super) struct WindowContext {
     pub handlers: Arc<Mutex<PlatformHandlers>>, // PORT-CHECK-OK-SP6: WindowsPlatform handlers Arc<Mutex<>>; mirrors PlatformHandlers callback storage; pre-existing SP-6
     /// Per-window callbacks for event delivery
     pub callbacks: Arc<WindowCallbacks>,
-    /// Scale factor for coordinate conversion
-    pub scale_factor: f32,
+    /// Scale factor for coordinate conversion.
+    ///
+    /// `Cell`, not a plain `f32`: `window_proc` only ever holds a shared
+    /// `&WindowContext` (see its `# Safety` section), and `WM_DPICHANGED` is
+    /// the one message that updates this field — `Cell::set` lets it do so
+    /// through that shared reference instead of forging a second, aliasing
+    /// `&mut WindowContext` from the raw `GWLP_USERDATA` pointer while the
+    /// shared one is still live.
+    pub scale_factor: std::cell::Cell<f32>,
     /// Current window mode (replaces display_state + saved bounds)
     pub mode: std::cell::Cell<WindowMode>,
     /// Last known size (before minimization) for restore detection
@@ -195,6 +202,12 @@ impl WindowsPlatform {
     /// let platform = WindowsPlatform::with_config(config)?;
     /// ```
     pub fn with_config(config: WindowConfiguration) -> Result<Self> {
+        // SAFETY: `CoInitializeEx` takes no pointer arguments (`None` for
+        // the reserved parameter) and its `HRESULT` is checked before
+        // anything downstream assumes COM is initialized on this thread —
+        // this call establishes the calling thread as an STA, which is also
+        // the thread this platform's `affinity` binds to a few lines below.
+        //
         // Initialize COM for drag-and-drop, clipboard, etc.
         unsafe {
             use windows::Win32::System::Com::{COINIT_APARTMENTTHREADED, CoInitializeEx};
@@ -204,17 +217,33 @@ impl WindowsPlatform {
             }
         }
 
+        // SAFETY: `SetProcessDpiAwarenessContext` takes a constant by value,
+        // no pointer arguments; failure (already set, or an OS predating
+        // per-monitor-v2 awareness) is expected and non-fatal, hence the
+        // discarded result.
+        //
         // Set DPI awareness to per-monitor v2 (best quality)
         // Ignore errors - this can fail if already set or on older Windows
         unsafe {
             let _ = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
         }
 
+        // SAFETY: `register_window_class`'s own `# Safety` contract (below)
+        // is discharged by `REGISTER_WINDOW_CLASS: Once` making the call
+        // race-free and idempotent regardless of caller thread.
+        //
         // Register window class
         unsafe {
             Self::register_window_class()?;
         }
 
+        // SAFETY: `GetModuleHandleW(None)` queries the current process
+        // image, no pointer arguments. `CreateWindowExW` here creates the
+        // message-only window with `HWND_MESSAGE` as parent and constant
+        // Win32 arguments (no caller-supplied buffers); its class was just
+        // registered above on this same thread, satisfying the ordering
+        // Win32 requires (register-before-create).
+        //
         // Create message-only window for platform messages
         let message_window = unsafe {
             let hinstance = GetModuleHandleW(None)
@@ -260,7 +289,26 @@ impl WindowsPlatform {
     }
 
     /// Register the window class for all FLUI windows (idempotent via `Once`).
+    ///
+    /// # Safety
+    ///
+    /// `Self::window_proc` is registered as the class's `WNDPROC` — its
+    /// `extern "system" fn(HWND, u32, WPARAM, LPARAM) -> LRESULT` signature
+    /// must exactly match what Win32 calls through that slot, or every
+    /// dispatch to a window of this class is an ABI-mismatched call. The
+    /// caller must not register a different, incompatible callback under
+    /// the same `WINDOW_CLASS_NAME` afterward — `REGISTER_WINDOW_CLASS: Once`
+    /// enforces that this body runs at most once per process, so subsequent
+    /// calls are no-ops rather than a re-registration race.
     unsafe fn register_window_class() -> Result<()> {
+        // SAFETY: per the `# Safety` contract above, `Self::window_proc`'s
+        // signature matches `WNDPROC`. `GetModuleHandleW(None)` takes no
+        // pointer arguments. `wc.lpszClassName`/`wc.hCursor` reference
+        // process-lifetime statics (`WINDOW_CLASS_NAME`, the loaded cursor
+        // resource); `&raw const wc` gives `RegisterClassW` a valid pointer
+        // to the fully-initialized, stack-local `WNDCLASSW`. `call_once`
+        // guarantees this body executes at most once, so there is no
+        // concurrent registration to race.
         unsafe {
             let mut result: Result<()> = Ok(());
 
@@ -301,12 +349,43 @@ impl WindowsPlatform {
     }
 
     /// Main window procedure for all FLUI windows
+    ///
+    /// # Safety
+    ///
+    /// Called by Win32 as a `WNDPROC` for windows of `WINDOW_CLASS_NAME`,
+    /// registered as this exact function in `register_window_class`. Win32
+    /// guarantees `hwnd`/`msg`/`wparam`/`lparam` are well-formed for the
+    /// message being delivered, and always dispatches on the thread that
+    /// owns the window's message queue — the `GWLP_USERDATA` read below does
+    /// not race `WM_DESTROY`'s clear+free precisely because both run here,
+    /// serialized by that same-thread dispatch guarantee.
+    ///
+    /// Known gap (not fixed by this comment, not UB — flagged for the
+    /// audit): none of the callback dispatches below (`ctx.callbacks.*`,
+    /// `ctx.dispatch_event`) are wrapped in `catch_unwind`. A panic inside a
+    /// framework-supplied callback unwinds into this `extern "system"`
+    /// frame; stable Rust aborts the process rather than invoking UB when
+    /// that happens (FFI boundaries are implicitly `nounwind`), but that is
+    /// still whole-process termination from a single window's callback,
+    /// unlike the `winit` backend's `window_proc`-equivalent path, which
+    /// does guard its callback boundary with `catch_unwind`.
     unsafe extern "system" fn window_proc(
         hwnd: HWND,
         msg: u32,
         wparam: WPARAM,
         lparam: LPARAM,
     ) -> LRESULT {
+        // SAFETY: see the `# Safety` section above for the `GWLP_USERDATA`
+        // contract this read relies on. The rest of this single `unsafe`
+        // block covers every Win32 call in the `match` below: `GetWindowLongPtrW`/
+        // `SetWindowLongPtrW` take `hwnd` and plain integers, no pointers;
+        // `TrackMouseEvent` (`WM_MOUSEMOVE`) and `BeginPaint`/`EndPaint`
+        // (`WM_PAINT`, its own SAFETY note below) take `&raw` pointers to
+        // stack-local, correctly-sized structs; `DestroyWindow` calls are
+        // individually commented where they appear; `Box::from_raw(ctx_ptr)`
+        // (`WM_DESTROY`) has its own SAFETY note where it appears;
+        // `DefWindowProcW` forwards unhandled messages verbatim with no
+        // pointer arguments of its own.
         unsafe {
             // Get window context from GWLP_USERDATA
             let ctx_ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut WindowContext;
@@ -334,11 +413,17 @@ impl WindowsPlatform {
                             ctx.dispatch_event(WindowEvent::CloseRequested {
                                 window_id: ctx.window_id,
                             });
-                            DestroyWindow(hwnd).ok();
+                            if let Err(error) = DestroyWindow(hwnd) {
+                                tracing::warn!(?hwnd, ?error, "DestroyWindow failed on WM_CLOSE");
+                            }
                         }
                         // If !should_close, the close is vetoed
-                    } else {
-                        DestroyWindow(hwnd).ok();
+                    } else if let Err(error) = DestroyWindow(hwnd) {
+                        tracing::warn!(
+                            ?hwnd,
+                            ?error,
+                            "DestroyWindow failed on WM_CLOSE (no WindowContext)"
+                        );
                     }
 
                     LRESULT(0)
@@ -356,6 +441,20 @@ impl WindowsPlatform {
 
                         // Clean up context - IMPORTANT: Clear pointer BEFORE dropping to avoid
                         // dangling pointer
+                        //
+                        // SAFETY: `ctx_ptr` is the same pointer `WindowsWindow::new`
+                        // produced via `Box::into_raw` and stored in this HWND's
+                        // `GWLP_USERDATA` — `ctx` (the shared reference used just
+                        // above) is derived from that same allocation, and its
+                        // last use is the `dispatch_event` call above, so no
+                        // reference into the box outlives this reclaim. The slot
+                        // is zeroed with `SetWindowLongPtrW` *before* `Box::from_raw`
+                        // runs, so if `dispatch_close`/`dispatch_event` above had
+                        // re-entrantly queried `GWLP_USERDATA` (they don't), they
+                        // would see null rather than a pointer about to be freed.
+                        // `window_proc` never runs concurrently with itself for
+                        // the same `hwnd` (Win32 serializes message dispatch per
+                        // queue), so this is the only path that can free `ctx_ptr`.
                         SetWindowLongPtrW(hwnd, GWLP_USERDATA, 0);
                         drop(Box::from_raw(ctx_ptr));
                     }
@@ -371,6 +470,13 @@ impl WindowsPlatform {
                 }
 
                 WM_PAINT => {
+                    // SAFETY: `ps` is a stack-local `PAINTSTRUCT`; `&raw mut
+                    // ps` gives `BeginPaint` a valid, correctly-sized
+                    // out-parameter, and `&raw const ps` below hands the
+                    // same (by now filled-in) struct back to the matching
+                    // `EndPaint` — every `WM_PAINT` arm here calls
+                    // `BeginPaint`/`EndPaint` exactly once, satisfying
+                    // Win32's required pairing.
                     let mut ps = PAINTSTRUCT::default();
                     let hdc = BeginPaint(hwnd, &raw mut ps);
                     if !hdc.is_invalid() {
@@ -519,15 +625,15 @@ impl WindowsPlatform {
                             let logical_size = Size::new(
                                 flui_types::geometry::px(super::util::device_to_logical(
                                     width,
-                                    ctx.scale_factor,
+                                    ctx.scale_factor.get(),
                                 )),
                                 flui_types::geometry::px(super::util::device_to_logical(
                                     height,
-                                    ctx.scale_factor,
+                                    ctx.scale_factor.get(),
                                 )),
                             );
                             ctx.callbacks
-                                .dispatch_resize(logical_size, ctx.scale_factor);
+                                .dispatch_resize(logical_size, ctx.scale_factor.get());
                         }
 
                         // Dispatch event to global handlers if any
@@ -570,8 +676,8 @@ impl WindowsPlatform {
                         // Dispatch Moved event to global handlers
                         use flui_types::geometry::{Point, px};
                         let position = Point::new(
-                            px(x as f32 / ctx.scale_factor),
-                            px(y as f32 / ctx.scale_factor),
+                            px(x as f32 / ctx.scale_factor.get()),
+                            px(y as f32 / ctx.scale_factor.get()),
                         );
                         ctx.dispatch_event(WindowEvent::Moved {
                             window_id: ctx.window_id,
@@ -595,15 +701,25 @@ impl WindowsPlatform {
                             scale_factor: new_scale as f64,
                         });
 
-                        // Update context scale factor
-                        let ctx_mut = &mut *(ctx_ptr);
-                        ctx_mut.scale_factor = new_scale;
+                        // Update context scale factor through the shared
+                        // reference already held above — see the field doc
+                        // on `WindowContext::scale_factor` for why this must
+                        // not go through a second `&mut` reborrow of
+                        // `ctx_ptr`.
+                        ctx.scale_factor.set(new_scale);
 
                         // Suggested rect for new DPI
+                        //
+                        // SAFETY: `lparam` carries a pointer to a `RECT`
+                        // supplied by Win32 for `WM_DPICHANGED` specifically
+                        // (documented behavior of this message); the
+                        // null-check guards a caller that violates that
+                        // documented contract, and `rect` is copied out
+                        // (`RECT: Copy`) rather than referenced further.
                         let suggested_rect = lparam.0 as *const RECT;
                         if !suggested_rect.is_null() {
                             let rect = *suggested_rect;
-                            SetWindowPos(
+                            if let Err(error) = SetWindowPos(
                                 hwnd,
                                 None,
                                 rect.left,
@@ -611,8 +727,13 @@ impl WindowsPlatform {
                                 rect.right - rect.left,
                                 rect.bottom - rect.top,
                                 SWP_NOZORDER | SWP_NOACTIVATE,
-                            )
-                            .ok();
+                            ) {
+                                tracing::warn!(
+                                    ?hwnd,
+                                    ?error,
+                                    "SetWindowPos (DPI-change suggested rect) failed"
+                                );
+                            }
                         }
                     }
 
@@ -637,7 +758,7 @@ impl WindowsPlatform {
                         ctx.callbacks.dispatch_hover_status_change(true);
 
                         use super::events::mouse_move_event;
-                        let event = mouse_move_event(lparam, ctx.scale_factor);
+                        let event = mouse_move_event(lparam, ctx.scale_factor.get());
                         ctx.callbacks.dispatch_input(event);
                     }
                     LRESULT(0)
@@ -670,7 +791,7 @@ impl WindowsPlatform {
                             PointerButton::Primary,
                             true,
                             lparam,
-                            ctx.scale_factor,
+                            ctx.scale_factor.get(),
                         );
                         ctx.callbacks.dispatch_input(event);
                     }
@@ -686,7 +807,7 @@ impl WindowsPlatform {
                             PointerButton::Secondary,
                             true,
                             lparam,
-                            ctx.scale_factor,
+                            ctx.scale_factor.get(),
                         );
                         ctx.callbacks.dispatch_input(event);
                     }
@@ -702,7 +823,7 @@ impl WindowsPlatform {
                             PointerButton::Auxiliary,
                             true,
                             lparam,
-                            ctx.scale_factor,
+                            ctx.scale_factor.get(),
                         );
                         ctx.callbacks.dispatch_input(event);
                     }
@@ -718,7 +839,7 @@ impl WindowsPlatform {
                             PointerButton::Primary,
                             false,
                             lparam,
-                            ctx.scale_factor,
+                            ctx.scale_factor.get(),
                         );
                         ctx.callbacks.dispatch_input(event);
                     }
@@ -734,7 +855,7 @@ impl WindowsPlatform {
                             PointerButton::Secondary,
                             false,
                             lparam,
-                            ctx.scale_factor,
+                            ctx.scale_factor.get(),
                         );
                         ctx.callbacks.dispatch_input(event);
                     }
@@ -750,7 +871,7 @@ impl WindowsPlatform {
                             PointerButton::Auxiliary,
                             false,
                             lparam,
-                            ctx.scale_factor,
+                            ctx.scale_factor.get(),
                         );
                         ctx.callbacks.dispatch_input(event);
                     }
@@ -760,7 +881,7 @@ impl WindowsPlatform {
                 WM_MOUSEWHEEL => {
                     if let Some(ctx) = ctx {
                         use super::events::mouse_wheel_event;
-                        let event = mouse_wheel_event(wparam, lparam, ctx.scale_factor);
+                        let event = mouse_wheel_event(wparam, lparam, ctx.scale_factor.get());
                         ctx.callbacks.dispatch_input(event);
                     }
                     LRESULT(0)
@@ -888,6 +1009,12 @@ impl WindowsPlatform {
     fn run_message_loop() {
         tracing::info!("Starting Windows message loop");
 
+        // SAFETY: `msg` is a stack-local `MSG`; `&raw mut msg`/`&raw const
+        // msg` give `GetMessageW`/`TranslateMessage`/`DispatchMessageW`
+        // valid, correctly-sized pointers to it, and `GetMessageW` only
+        // returns `TRUE` after filling `msg` in, so it is never read
+        // uninitialized. `DispatchMessageW` is what invokes `window_proc`
+        // (registered per-class in `register_window_class`) on this thread.
         unsafe {
             let mut msg = MSG::default();
 
@@ -938,6 +1065,11 @@ impl Platform for WindowsPlatform {
         // the owner thread it silently quits nothing (ADR-0039).
         self.affinity.debug_assert_owner("WindowsPlatform::quit");
         tracing::info!("Quitting Windows platform");
+        // SAFETY: `PostQuitMessage` takes a plain `i32` exit code, no
+        // pointer arguments; the `debug_assert_owner` above documents (in
+        // debug builds) that this runs on the thread whose queue it posts
+        // to — posting from elsewhere is a logic bug (silently posts to the
+        // wrong queue), not memory-unsafety.
         unsafe {
             PostQuitMessage(0);
         }
@@ -948,6 +1080,8 @@ impl Platform for WindowsPlatform {
     fn active_window(&self) -> Option<WindowId> {
         self.affinity
             .debug_assert_owner("WindowsPlatform::active_window");
+        // SAFETY: `GetForegroundWindow` takes no arguments; `hwnd` is just
+        // an opaque value compared/wrapped, never dereferenced.
         unsafe {
             let hwnd = GetForegroundWindow();
             if hwnd.is_invalid() {
@@ -1029,6 +1163,8 @@ impl Platform for WindowsPlatform {
     // ==================== App Activation (US3 T038) ====================
 
     fn activate(&self, _ignoring_other_apps: bool) {
+        // SAFETY: `GetForegroundWindow`/`SetForegroundWindow` take no
+        // pointer arguments — `hwnd` is an opaque value, never dereferenced.
         unsafe {
             // Bring the foreground window to front
             let hwnd = GetForegroundWindow();
@@ -1045,6 +1181,17 @@ impl Platform for WindowsPlatform {
         use windows::Win32::System::Registry::{
             HKEY, HKEY_CURRENT_USER, KEY_READ, RegCloseKey, RegOpenKeyExW, RegQueryValueExW,
         };
+        // SAFETY: `subkey`/`value_name` are `Vec<u16>` explicitly
+        // NUL-terminated (`"...\0".encode_utf16()`), matching what
+        // `PCWSTR` requires, and kept alive across the calls that borrow
+        // their pointers. `hkey` is a stack-local `HKEY` written through
+        // `&raw mut hkey`; `RegQueryValueExW` only reads through
+        // `&raw mut data` after `status.is_err()` returned early on
+        // failure to open the key, and `data_size` is seeded to
+        // `size_of::<u32>()` so the registry API cannot write past `data`.
+        // `RegCloseKey` runs unconditionally once `hkey` was successfully
+        // opened, on every return path below (both the early `is_err()`
+        // return and the final value).
         unsafe {
             let mut hkey = HKEY::default();
             let subkey: Vec<u16> =
@@ -1093,6 +1240,10 @@ impl Platform for WindowsPlatform {
     fn open_url(&self, url: &str) {
         use windows::Win32::UI::Shell::ShellExecuteW;
         let wide_url: Vec<u16> = url.encode_utf16().chain(std::iter::once(0)).collect();
+        // SAFETY: `wide_url` is explicitly NUL-terminated
+        // (`.chain(std::iter::once(0))`), matching what `PCWSTR` requires,
+        // and stays alive for the duration of this call (it is not dropped
+        // or reallocated between `.as_ptr()` and the call).
         unsafe {
             ShellExecuteW(
                 None,
@@ -1112,6 +1263,8 @@ impl Platform for WindowsPlatform {
         let arg = format!("/select,{path_str}");
         let wide_arg: Vec<u16> = arg.encode_utf16().chain(std::iter::once(0)).collect();
         let explorer: Vec<u16> = "explorer\0".encode_utf16().collect();
+        // SAFETY: see `open_url` above — both `wide_arg` and `explorer` are
+        // explicitly NUL-terminated and kept alive across the call.
         unsafe {
             ShellExecuteW(
                 None,
@@ -1131,6 +1284,8 @@ impl Platform for WindowsPlatform {
             .encode_utf16()
             .chain(std::iter::once(0))
             .collect();
+        // SAFETY: see `open_url` above — `wide_path` is explicitly
+        // NUL-terminated and kept alive across the call.
         unsafe {
             ShellExecuteW(
                 None,
@@ -1153,6 +1308,18 @@ impl Platform for WindowsPlatform {
         executor.spawn(async move {
             // COM file dialogs must run on an STA thread
             let result = std::thread::spawn(move || -> Result<Option<Vec<std::path::PathBuf>>> {
+                // SAFETY: this whole body runs on the freshly `std::thread::spawn`ed
+                // thread, which owns no other window state — `CoInitializeEx`
+                // makes it an STA for the `IFileOpenDialog` COM object, as
+                // that interface requires. Every `windows-rs` COM call
+                // (`CoCreateInstance`, `dialog.Show`/`SetOptions`, `results.*`,
+                // `item.GetDisplayName`) is a checked, typed FFI wrapper with
+                // no raw pointer of ours to validate. `CoTaskMemFree` below
+                // frees the `PWSTR` `name` owns from COM — it is only used
+                // (via `name.to_string()`, which copies the string out) before
+                // this free, and each loop iteration gets its own `name` from
+                // `GetDisplayName`, so there is no double-free or use-after-free
+                // across iterations.
                 unsafe {
                     use windows::Win32::{
                         System::Com::{
@@ -1219,6 +1386,14 @@ impl Platform for WindowsPlatform {
         let executor = self.background_executor.clone();
         executor.spawn(async move {
             let result = std::thread::spawn(move || -> Result<Option<std::path::PathBuf>> {
+                // SAFETY: see `prompt_for_paths` above — same
+                // dedicated-STA-thread, checked-COM-wrapper reasoning.
+                // `dir_wide` is explicitly NUL-terminated and outlives the
+                // `SHCreateItemFromParsingName` call that borrows its
+                // pointer; the single `CoTaskMemFree` below frees the one
+                // `name` this function's single `IFileSaveDialog::GetResult`
+                // path produces, after `name.to_string()` has already copied
+                // the string out.
                 unsafe {
                     use windows::Win32::{
                         System::Com::{
@@ -1289,6 +1464,10 @@ impl Platform for WindowsPlatform {
 
     fn keyboard_layout(&self) -> String {
         use windows::Win32::UI::Input::KeyboardAndMouse::GetKeyboardLayoutNameW;
+        // SAFETY: `buffer` is a stack-local, zero-initialized `[u16; 9]`
+        // sized to `KL_NAMELENGTH`, the exact size this API requires;
+        // `&mut buffer` gives it a valid, correctly-sized out-parameter, and
+        // it is only read (`is_ok()` branch) after the call reports success.
         unsafe {
             let mut buffer = [0u16; 9]; // KL_NAMELENGTH = 9
             if GetKeyboardLayoutNameW(&mut buffer).is_ok() {
@@ -1304,6 +1483,10 @@ impl Platform for WindowsPlatform {
     // ==================== File System Integration ====================
 
     fn app_path(&self) -> Result<std::path::PathBuf> {
+        // SAFETY: `buffer` is a stack-local `[u16; MAX_PATH]`; `&mut buffer`
+        // gives `GetModuleFileNameW` a valid, correctly-sized out-parameter,
+        // and only the first `len` code units it reports writing are read
+        // below — a `len == 0` failure returns before any read.
         unsafe {
             let mut buffer = [0u16; 260]; // MAX_PATH, stack-allocated
             let len = GetModuleFileNameW(None, &mut buffer);
@@ -1322,12 +1505,29 @@ impl Drop for WindowsPlatform {
         tracing::debug!("Dropping WindowsPlatform");
 
         // Destroy message window
+        //
+        // SAFETY: `DestroyWindow` takes `self.message_window` by value; the
+        // `is_invalid()` guard skips the call for a handle that was never
+        // successfully created. This window carries no `GWLP_USERDATA`
+        // context (it is message-only and never routed through
+        // `WindowsWindow::new`), so there is no allocation to reclaim here.
         if !self.message_window.is_invalid() {
             unsafe {
-                DestroyWindow(self.message_window).ok();
+                if let Err(error) = DestroyWindow(self.message_window) {
+                    tracing::warn!(
+                        hwnd = ?self.message_window,
+                        ?error,
+                        "DestroyWindow failed for the message-only window"
+                    );
+                }
             }
         }
 
+        // SAFETY: `CoUninitialize` takes no arguments; it pairs with the
+        // `CoInitializeEx` call in `with_config` on the same thread — COM's
+        // own reference counting (not memory safety) governs whether this
+        // is the initializing call's matching uninitialize.
+        //
         // Uninitialize COM
         unsafe {
             use windows::Win32::System::Com::CoUninitialize;
@@ -1346,6 +1546,9 @@ fn current_modifiers() -> keyboard_types::Modifiers {
         GetKeyState, VK_CONTROL, VK_LWIN, VK_MENU, VK_RWIN, VK_SHIFT,
     };
 
+    // SAFETY: `GetKeyState` takes a plain `i32` virtual-key code and returns
+    // a plain `i16`/`u16` bit pattern — no pointer arguments, no invariant
+    // beyond the ordinary FFI call.
     unsafe {
         let mut mods = keyboard_types::Modifiers::empty();
         if (GetKeyState(VK_SHIFT.0 as i32) as u16 & 0x8000) != 0 {

--- a/crates/flui-platform/src/platforms/windows/platform.rs
+++ b/crates/flui-platform/src/platforms/windows/platform.rs
@@ -1529,10 +1529,21 @@ impl Drop for WindowsPlatform {
             }
         }
 
-        // SAFETY: `CoUninitialize` takes no arguments; it pairs with the
-        // `CoInitializeEx` call in `with_config` on the same thread — COM's
-        // own reference counting (not memory safety) governs whether this
-        // is the initializing call's matching uninitialize.
+        // SAFETY: `CoUninitialize` takes no arguments, so this call itself
+        // cannot be memory-unsafe regardless of which thread runs it.
+        //
+        // NOT established: that this runs on the same thread that called
+        // `CoInitializeEx` in `with_config`. COM's apartment state is
+        // per-thread, and `CoUninitialize` is only the matching call for
+        // the thread that initialized it — but `WindowsPlatform` is `Send`
+        // (see its impl above), so nothing stops this value being moved to
+        // and dropped on a different thread than the one that constructed
+        // it. If that happens, this does not uninitialize the constructing
+        // thread's COM apartment at all; at worst it leaves that thread's
+        // COM reference count unbalanced (permanently initialized) and/or
+        // calls `CoUninitialize` on a thread whose own apartment state this
+        // struct never tracked — an accounting/leak concern, not memory
+        // unsafety, and not fixed by this comment.
         //
         // Uninitialize COM
         unsafe {

--- a/crates/flui-platform/src/platforms/windows/util.rs
+++ b/crates/flui-platform/src/platforms/windows/util.rs
@@ -79,13 +79,35 @@ pub fn to_wide(s: &str) -> Vec<u16> {
 }
 
 /// Load a cursor by style
+///
+/// # Safety
+///
+/// `style` must be a value `LoadCursorW` accepts as its resource-name
+/// argument: either one of the predefined `IDC_*` constants (an integer
+/// resource ordinal packed into a pointer-sized value via
+/// `MAKEINTRESOURCEW`, which must never be dereferenced as an actual
+/// pointer) or a genuine NUL-terminated UTF-16 string pointer that stays
+/// valid for the duration of this call. Every call site in this crate
+/// passes a predefined `IDC_*` constant.
 pub unsafe fn load_cursor_style(style: PCWSTR) -> Result<HCURSOR> {
+    // SAFETY: per the `# Safety` contract above; `None` for `hinstance` is
+    // required and documented for loading a predefined `IDC_*` cursor.
     unsafe { LoadCursorW(None, style).map_err(|e| anyhow!("Failed to load cursor: {e}")) }
 }
 
 /// Check if a key is pressed
+///
+/// # Safety
+///
+/// None, in the memory-safety sense: `GetAsyncKeyState` takes a plain `i32`
+/// virtual-key code and returns a bit-packed `SHORT` — an out-of-range
+/// `vkey` is documented to return an unspecified-but-defined value, not UB.
+/// This is `unsafe fn` for FFI-boundary consistency with the call it wraps,
+/// not because a caller must uphold an invariant to avoid unsoundness.
 #[inline]
 pub unsafe fn is_key_pressed(vkey: i32) -> bool {
+    // SAFETY: see the `# Safety` section above — no precondition to
+    // discharge beyond the ordinary FFI call.
     unsafe { (GetAsyncKeyState(vkey) as i32 & 0x8000) != 0 }
 }
 

--- a/crates/flui-platform/src/platforms/windows/window.rs
+++ b/crates/flui-platform/src/platforms/windows/window.rs
@@ -231,7 +231,7 @@ impl WindowsWindow {
                 window_id,
                 handlers: handlers.clone(),
                 callbacks,
-                scale_factor,
+                scale_factor: std::cell::Cell::new(scale_factor),
                 mode: std::cell::Cell::new(WindowMode::Normal),
                 last_size: std::cell::Cell::new(initial_size),
                 config,

--- a/crates/flui-platform/src/platforms/windows/window.rs
+++ b/crates/flui-platform/src/platforms/windows/window.rs
@@ -1085,17 +1085,19 @@ impl HasWindowHandle for WindowsWindow {
 
         // SAFETY: `raw_window_handle::WindowHandle::borrow_raw`'s contract
         // requires the wrapped handle to stay valid for the returned
-        // `WindowHandle`'s lifetime, which `'_` ties to `&self` — as long as
-        // this `&WindowsWindow` borrow is live, `self.hwnd` has not been
-        // destroyed by `Drop` (which requires exclusive access to drop the
-        // last `Arc`). `window_proc`-driven destruction (e.g. the user
-        // closing the window) is not fenced by that borrow, so a caller that
-        // holds this handle across such an external `DestroyWindow` still
-        // ends up with a stale-but-not-dereferenced HWND value — the
-        // wgpu/raw-window-handle contract only requires the *value* be
-        // meaningful for calls made while the handle is alive, not that the
-        // OS object outlive it, so this is within the trait's contract as
-        // documented, not a soundness gap.
+        // `WindowHandle`'s lifetime. The `'_` this function returns only
+        // ties to `&self` — i.e. to the `Arc<WindowsWindow>` staying alive —
+        // not to the underlying native HWND staying valid. Those are NOT
+        // the same lifetime: `PlatformWindow::close()` (or the user closing
+        // the window, which reaches `DestroyWindow` through `window_proc`
+        // regardless of which thread requested it) can destroy the native
+        // window while an `Arc<WindowsWindow>`, and therefore a
+        // `WindowHandle` borrowed from it, is still held and used elsewhere
+        // (e.g. by wgpu to (re)create a surface). This is the same
+        // undischarged-HWND-lifetime class as the documented cross-thread
+        // `GWLP_USERDATA` race on this type's `Send`/`Sync` impls above —
+        // a real gap this comment does not close, not a validity claim
+        // this code has actually established.
         Ok(unsafe { raw_window_handle::WindowHandle::borrow_raw(RawWindowHandle::Win32(handle)) })
     }
 }

--- a/crates/flui-platform/src/platforms/windows/window.rs
+++ b/crates/flui-platform/src/platforms/windows/window.rs
@@ -62,8 +62,22 @@ pub struct WindowsWindow {
     windows_map: Arc<Mutex<HashMap<isize, Arc<WindowsWindow>>>>,
 }
 
-// SAFETY: HWND is just an integer handle and is safe to send/share between
-// threads. Windows API handles are thread-safe by design.
+// SAFETY, per field: `state` and `callbacks` are `Arc<Mutex<..>>`/`Arc<..>`
+// with their own synchronization; `windows_map` is likewise an
+// `Arc<Mutex<..>>`. The only non-`Sync` member is `hwnd: HWND`, a bare
+// address — sending or sharing the address itself aliases nothing, so `Send`
+// and `Sync` are sound for the struct.
+//
+// NOT claimed — an HWND is thread-AFFINE, not "thread-safe by design": its
+// message queue belongs to the thread that created it, and Win32 requires
+// several of the calls below (`DestroyWindow`, `SetWindowLongPtrW` on
+// `GWLP_USERDATA`, anything touching the `WindowContext` stashed there) to
+// run on that owning thread to stay race-free against `window_proc`'s
+// `WM_DESTROY` handler freeing the same context. These impls only make it
+// legal to move/share the `Arc<WindowsWindow>` across threads; they do not
+// themselves discharge that thread-affinity obligation — see the per-call
+// SAFETY comments below and the same gap already documented on
+// `WindowsPlatform`'s `Send`/`Sync` impls in `platform.rs`.
 unsafe impl Send for WindowsWindow {}
 unsafe impl Sync for WindowsWindow {}
 
@@ -103,6 +117,23 @@ impl WindowsWindow {
         handlers: Arc<Mutex<PlatformHandlers>>,
         config: crate::config::WindowConfiguration,
     ) -> Result<Arc<Self>> {
+        // SAFETY: `GetModuleHandleW(None)` queries the current process image
+        // and takes no pointer arguments — always sound. `GetDpiForSystem`
+        // reads global state, no preconditions. `CreateWindowExW` requires
+        // `WINDOW_CLASS_NAME` to already be registered, which
+        // `WindowsPlatform::with_config` guarantees before any `open_window`
+        // call can reach here; `&title` is a live `HSTRING` owned by this
+        // frame. `hwnd.is_invalid()` is checked immediately after, so every
+        // Win32 call below it only runs against a handle the OS just
+        // returned as valid. `SetClassLongPtrW` and `apply_windows_features`
+        // operate on that same freshly created, still-valid `hwnd`.
+        // `Box::into_raw(context)` intentionally leaks the allocation into
+        // the `GWLP_USERDATA` slot — ownership transfers to the window and is
+        // reclaimed by `WindowsPlatform::window_proc`'s `WM_DESTROY` arm
+        // (`platform.rs`, `Box::from_raw`); a window destroyed by any path
+        // that skips `WM_DESTROY` (process-exit teardown) leaks the
+        // allocation rather than double-frees or dangles it. `ShowWindow`/
+        // `UpdateWindow` again only need a valid `hwnd`, which holds here.
         unsafe {
             let hinstance = GetModuleHandleW(None).context("Failed to get module handle")?;
 
@@ -231,6 +262,18 @@ impl WindowsWindow {
     /// - Rounded window corners
     /// - DWM frame extension for proper backdrop rendering
     fn apply_windows_features(hwnd: HWND) {
+        // SAFETY: every call here (`DwmExtendFrameIntoClientArea`,
+        // `DwmSetWindowAttribute` x3) takes `hwnd` and a pointer to a
+        // stack-local value whose `size_of` matches the `u32` byte-count
+        // argument passed alongside it (`MARGINS` by-reference for the first
+        // call; `&raw const <i32>` cast to `c_void` for the rest, each with
+        // `size_of::<i32>()`). Callers of this function (`WindowsWindow::new`)
+        // pass the `hwnd` just returned by `CreateWindowExW`, so it is valid
+        // for the duration of this call. All three `DwmSetWindowAttribute`
+        // results are discarded (`let _ =`) because every attribute here is a
+        // Windows-11-only cosmetic feature — failure on older Windows is
+        // expected and non-fatal, not evidence swallowed silently for an
+        // operation the caller depends on.
         unsafe {
             use windows::Win32::{
                 Graphics::Dwm::{
@@ -340,6 +383,26 @@ impl WindowsWindow {
             },
         };
 
+        // SAFETY: `ctx_ptr` is whatever `isize` is currently stored in
+        // `hwnd`'s `GWLP_USERDATA` slot. A non-null value was written by
+        // `WindowsWindow::new` (`Box::into_raw`) and is only cleared+freed by
+        // `WindowsPlatform::window_proc`'s `WM_DESTROY` arm, on this window's
+        // owning thread. The null check covers a window not yet initialized
+        // or already destroyed by the time this call reads the slot.
+        //
+        // Known gap (not fixed by this comment): this function is reachable
+        // both from `window_proc` (always on the owning thread, per the
+        // `# Thread Safety` doc above) and from `WindowsWindow::toggle_fullscreen`
+        // on `&self`, which carries no thread-affinity check — a caller on a
+        // different thread than the one servicing this HWND's message queue
+        // races the `WM_DESTROY` free with no synchronization discharging
+        // that race. `GetWindowRect`/`GetWindowLongPtrW`/`SetWindowLongPtrW`/
+        // `SetWindowPos`/`MonitorFromWindow`/`GetMonitorInfoW` below all take
+        // `hwnd` or a `&raw mut` to a stack-local out-parameter whose size
+        // matches what each call expects, and are otherwise ordinary Win32
+        // calls with no additional invariant beyond `hwnd` naming a live
+        // window, which the OS itself would report via a failed return
+        // rather than UB if it did not.
         unsafe {
             // Get WindowContext from GWLP_USERDATA
             let ctx_ptr =
@@ -368,7 +431,7 @@ impl WindowsWindow {
                 SetWindowLongPtrW(hwnd, GWL_STYLE, restore_style as isize);
 
                 // Restore window position and size
-                SetWindowPos(
+                if let Err(error) = SetWindowPos(
                     hwnd,
                     None,
                     restore_bounds.origin.x.0,
@@ -376,8 +439,9 @@ impl WindowsWindow {
                     restore_bounds.size.width.0,
                     restore_bounds.size.height.0,
                     SWP_FRAMECHANGED | SWP_NOZORDER | SWP_NOACTIVATE,
-                )
-                .ok();
+                ) {
+                    tracing::warn!(?hwnd, ?error, "SetWindowPos (exit fullscreen restore) failed");
+                }
 
                 // Update state
                 ctx.mode.set(WindowMode::Normal);
@@ -393,7 +457,13 @@ impl WindowsWindow {
 
                 // Get current window rect
                 let mut rect = RECT::default();
-                GetWindowRect(hwnd, &raw mut rect).ok();
+                if let Err(error) = GetWindowRect(hwnd, &raw mut rect) {
+                    tracing::warn!(
+                        ?hwnd,
+                        ?error,
+                        "GetWindowRect failed entering fullscreen; restore bounds will be zeroed"
+                    );
+                }
 
                 // Save current style to WindowContext
                 let current_style = GetWindowLongPtrW(hwnd, GWL_STYLE) as u32;
@@ -433,7 +503,7 @@ impl WindowsWindow {
                 SetWindowLongPtrW(hwnd, GWL_STYLE, fullscreen_style.0 as isize);
 
                 // Position window to cover entire monitor
-                SetWindowPos(
+                if let Err(error) = SetWindowPos(
                     hwnd,
                     Some(HWND_TOP),
                     monitor_rect.left,
@@ -441,8 +511,9 @@ impl WindowsWindow {
                     monitor_rect.right - monitor_rect.left,
                     monitor_rect.bottom - monitor_rect.top,
                     SWP_FRAMECHANGED | SWP_NOACTIVATE,
-                )
-                .ok();
+                ) {
+                    tracing::warn!(?hwnd, ?error, "SetWindowPos (enter fullscreen) failed");
+                }
 
                 // Update state
                 ctx.mode.set(candidate);
@@ -467,6 +538,11 @@ impl WindowsWindow {
 
     /// Check if the window is currently in fullscreen mode
     pub fn is_fullscreen(&self) -> bool {
+        // SAFETY: same `GWLP_USERDATA` contract as
+        // `toggle_fullscreen_for_hwnd` above — non-null implies `new`
+        // populated it and `WM_DESTROY` (owning thread only) hasn't cleared
+        // it yet; the same cross-thread race is a known, undischarged gap
+        // when this is called off that thread.
         unsafe {
             let ctx_ptr =
                 GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
@@ -496,6 +572,11 @@ impl WindowsWindow {
     /// Returns true if the window is minimized, as rendering minimized windows
     /// wastes CPU/GPU resources without any visible output.
     pub fn should_skip_render(hwnd: HWND) -> bool {
+        // SAFETY: same `GWLP_USERDATA` contract as `toggle_fullscreen_for_hwnd`
+        // above. Every current call site (`platform.rs`'s `WM_PAINT` arm)
+        // runs on the owning thread, so the race noted there does not apply
+        // here today — but the function itself does not enforce that, since
+        // it takes a bare `HWND` from any caller.
         unsafe {
             let ctx_ptr =
                 GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
@@ -533,6 +614,12 @@ impl WindowsWindow {
             _ => IDC_ARROW,
         };
 
+        // SAFETY: `LoadCursorW(None, resource)` loads a built-in system
+        // cursor by atom/ordinal (`resource` is always one of the `IDC_*`
+        // constants from the match above, never a caller-supplied pointer),
+        // and returns a handle owned by the system — no allocation to free.
+        // `SetCursor` takes that handle by value; passing `None` on error is
+        // not reachable here since `?` returns before it.
         unsafe {
             let handle = LoadCursorW(None, resource)
                 .map_err(|error| CursorError::Backend(error.to_string()))?;
@@ -566,6 +653,11 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn request_redraw(&self) {
+        // SAFETY: `InvalidateRect` takes `self.hwnd` and `None` for the
+        // rect (invalidate the whole client area) — no pointer to validate.
+        // Failure just means nothing was invalidated (e.g. the window is
+        // already gone); requesting a redraw is inherently best-effort, so
+        // discarding the result keeps this fire-and-forget by design.
         unsafe {
             let _ = InvalidateRect(Some(self.hwnd), None, false);
         }
@@ -580,6 +672,11 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn set_cursor(&self, cursor: CursorIcon) -> Result<(), CursorError> {
+        // SAFETY: same `GWLP_USERDATA` contract as `toggle_fullscreen_for_hwnd`
+        // above; `.as_ref()` turns the possibly-null raw pointer into
+        // `Option<&WindowContext>` without dereferencing a null pointer, and
+        // the cross-thread `WM_DESTROY` race documented there applies
+        // equally here.
         unsafe {
             let ctx_ptr =
                 GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
@@ -601,6 +698,10 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn content_size(&self) -> Size<Pixels> {
+        // SAFETY: `rect` is a stack-local `RECT` and `&raw mut rect` gives
+        // `GetClientRect` a valid, correctly-sized out-parameter; the `Err`
+        // path (stale/destroyed `hwnd`) is handled by falling back to the
+        // last-known cached bounds rather than reading `rect` uninitialized.
         unsafe {
             let mut rect = RECT::default();
             if GetClientRect(self.hwnd, &raw mut rect).is_ok() {
@@ -617,6 +718,8 @@ impl PlatformWindow for WindowsWindow {
 
     fn window_bounds(&self) -> WindowBounds {
         let bounds = self.bounds();
+        // SAFETY: same `GWLP_USERDATA` contract as `toggle_fullscreen_for_hwnd`
+        // above, including the same undischarged cross-thread race.
         unsafe {
             let ctx_ptr =
                 GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
@@ -635,6 +738,9 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn is_maximized(&self) -> bool {
+        // SAFETY: `IsZoomed` takes `self.hwnd` by value and returns a
+        // `BOOL` — no pointer arguments, no invariant beyond an ordinary
+        // FFI call.
         unsafe { IsZoomed(self.hwnd).as_bool() }
     }
 
@@ -644,10 +750,14 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn is_active(&self) -> bool {
+        // SAFETY: `GetForegroundWindow` takes no arguments; comparing its
+        // result to `self.hwnd` is a plain integer/handle comparison.
         unsafe { GetForegroundWindow() == self.hwnd }
     }
 
     fn is_hovered(&self) -> bool {
+        // SAFETY: same `GWLP_USERDATA` contract as `toggle_fullscreen_for_hwnd`
+        // above, including the same undischarged cross-thread race.
         unsafe {
             let ctx_ptr =
                 GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
@@ -659,6 +769,11 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn mouse_position(&self) -> Point<Pixels> {
+        // SAFETY: `cursor_pos` is a stack-local `POINT`; `&raw mut
+        // cursor_pos` gives both `GetCursorPos` and `ScreenToClient` a
+        // valid, correctly-sized out-parameter. The `is_ok()`/`as_bool()`
+        // short-circuit means `cursor_pos` is only read after both calls
+        // reported success, so it is never read uninitialized.
         unsafe {
             let mut cursor_pos = POINT::default();
             if GetCursorPos(&raw mut cursor_pos).is_ok()
@@ -676,6 +791,8 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn modifiers(&self) -> keyboard_types::Modifiers {
+        // SAFETY: same `GWLP_USERDATA` contract as `toggle_fullscreen_for_hwnd`
+        // above, including the same undischarged cross-thread race.
         unsafe {
             let ctx_ptr =
                 GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
@@ -687,6 +804,11 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn appearance(&self) -> WindowAppearance {
+        // SAFETY: the `GWLP_USERDATA` read shares the contract documented on
+        // `toggle_fullscreen_for_hwnd` above. `DwmGetWindowAttribute` below
+        // writes through `&raw mut dark_mode` cast to `c_void`, sized via
+        // `size_of::<i32>()` to match the stack-local `i32` it points at;
+        // `dark_mode` is only read after checking `result.is_ok()`.
         unsafe {
             let ctx_ptr =
                 GetWindowLongPtrW(self.hwnd, GWLP_USERDATA) as *mut super::platform::WindowContext;
@@ -711,6 +833,11 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn display(&self) -> Option<Arc<dyn PlatformDisplay>> {
+        // SAFETY: `MonitorFromWindow` takes `self.hwnd` by value and a flag;
+        // `MONITOR_DEFAULTTOPRIMARY` guarantees a non-null `HMONITOR` even
+        // for an invalid `hwnd`, so the `is_invalid()` check below is
+        // defensive rather than load-bearing for memory safety — no pointer
+        // is dereferenced here.
         unsafe {
             let monitor = MonitorFromWindow(self.hwnd, MONITOR_DEFAULTTOPRIMARY);
             if monitor.is_invalid() {
@@ -733,6 +860,9 @@ impl PlatformWindow for WindowsWindow {
     // ==================== Control Methods (US2) ====================
 
     fn set_title(&self, title: &str) {
+        // SAFETY: `title_str` is a live, locally-owned `HSTRING` for the
+        // duration of the call; `SetWindowTextW` reads it by reference and
+        // does not retain the pointer past the call.
         unsafe {
             let title_str = HSTRING::from(title);
             let _ = SetWindowTextW(self.hwnd, &title_str);
@@ -741,24 +871,30 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn activate(&self) {
+        // SAFETY: `SetForegroundWindow` takes `self.hwnd` by value, no
+        // pointer arguments.
         unsafe {
             let _ = SetForegroundWindow(self.hwnd);
         }
     }
 
     fn minimize(&self) {
+        // SAFETY: `ShowWindow` takes `self.hwnd` and a command constant by
+        // value, no pointer arguments.
         unsafe {
             let _ = ShowWindow(self.hwnd, SW_MINIMIZE);
         }
     }
 
     fn maximize(&self) {
+        // SAFETY: see `minimize` above — same call shape.
         unsafe {
             let _ = ShowWindow(self.hwnd, SW_MAXIMIZE);
         }
     }
 
     fn restore(&self) {
+        // SAFETY: see `minimize` above — same call shape.
         unsafe {
             let _ = ShowWindow(self.hwnd, SW_RESTORE);
         }
@@ -769,6 +905,9 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn resize(&self, size: Size<Pixels>) {
+        // SAFETY: `SetWindowPos` takes `self.hwnd` and plain integer/flag
+        // arguments; `None` for the z-order handle is a documented no-op
+        // value, not a null pointer.
         unsafe {
             let scale = self.state.lock().scale_factor;
             let width = logical_to_device(size.width.0, scale);
@@ -789,12 +928,20 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn close(&self) {
+        // SAFETY: `DestroyWindow` takes `self.hwnd` by value; `WM_DESTROY`
+        // (handled in `platform.rs`) reclaims the `GWLP_USERDATA` allocation
+        // synchronously within this same call before it returns, on this
+        // thread — Win32 dispatches `WM_DESTROY` to the window procedure
+        // before `DestroyWindow` returns.
         unsafe {
             let _ = DestroyWindow(self.hwnd);
         }
     }
 
     fn set_background_appearance(&self, appearance: WindowBackgroundAppearance) {
+        // SAFETY: `backdrop_value` is a stack-local `i32`; `DwmSetWindowAttribute`
+        // receives it via `&raw const` cast to `c_void`, sized with
+        // `size_of::<i32>()` matching the value pointed at.
         unsafe {
             use windows::Win32::Graphics::Dwm::{DWMWINDOWATTRIBUTE, DwmSetWindowAttribute};
 
@@ -887,6 +1034,8 @@ impl HasWindowHandle for WindowsWindow {
             NonZeroIsize::new(hwnd_value).ok_or(raw_window_handle::HandleError::Unavailable)?,
         );
 
+        // SAFETY: `GetModuleHandleW(None)` queries the current process
+        // image, no pointer arguments — always sound.
         unsafe {
             let hinstance =
                 GetModuleHandleW(None).map_err(|_| raw_window_handle::HandleError::Unavailable)?;
@@ -894,6 +1043,19 @@ impl HasWindowHandle for WindowsWindow {
             handle.hinstance = NonZeroIsize::new(hinstance_value);
         }
 
+        // SAFETY: `raw_window_handle::WindowHandle::borrow_raw`'s contract
+        // requires the wrapped handle to stay valid for the returned
+        // `WindowHandle`'s lifetime, which `'_` ties to `&self` — as long as
+        // this `&WindowsWindow` borrow is live, `self.hwnd` has not been
+        // destroyed by `Drop` (which requires exclusive access to drop the
+        // last `Arc`). `window_proc`-driven destruction (e.g. the user
+        // closing the window) is not fenced by that borrow, so a caller that
+        // holds this handle across such an external `DestroyWindow` still
+        // ends up with a stale-but-not-dereferenced HWND value — the
+        // wgpu/raw-window-handle contract only requires the *value* be
+        // meaningful for calls made while the handle is alive, not that the
+        // OS object outlive it, so this is within the trait's contract as
+        // documented, not a soundness gap.
         Ok(unsafe { raw_window_handle::WindowHandle::borrow_raw(RawWindowHandle::Win32(handle)) })
     }
 }
@@ -906,6 +1068,10 @@ impl HasDisplayHandle for WindowsWindow {
         // WindowsDisplayHandle::new() creates a valid default for Windows Display enumeration.
         // This helps wgpu locate the correct adapter/surface for the window's monitor.
         let handle = WindowsDisplayHandle::new();
+        // SAFETY: `WindowsDisplayHandle` carries no fields (Windows has no
+        // per-display native handle in this API) — there is nothing for
+        // `borrow_raw` to invalidate; the call only exists to satisfy the
+        // `raw-window-handle` trait's `unsafe fn` signature.
         Ok(unsafe {
             raw_window_handle::DisplayHandle::borrow_raw(RawDisplayHandle::Windows(handle))
         })
@@ -942,9 +1108,13 @@ impl WindowTrait for WindowsWindow {
     }
 
     fn set_title(&mut self, title: &str) {
+        // SAFETY: see `PlatformWindow::set_title` above — same
+        // locally-owned `HSTRING` and call shape.
         unsafe {
             let title_str = HSTRING::from(title);
-            SetWindowTextW(self.hwnd, &title_str).ok();
+            if let Err(error) = SetWindowTextW(self.hwnd, &title_str) {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "SetWindowTextW failed");
+            }
             self.state.lock().title = title.to_string();
         }
     }
@@ -954,12 +1124,15 @@ impl WindowTrait for WindowsWindow {
     }
 
     fn set_position(&mut self, position: Point<Pixels>) {
+        // SAFETY: `SetWindowPos` takes `self.hwnd` and plain integer/flag
+        // arguments; `None` for the z-order handle is a documented no-op
+        // value, not a null pointer.
         unsafe {
             let scale = self.state.lock().scale_factor;
             let x = logical_to_device(position.x.0, scale);
             let y = logical_to_device(position.y.0, scale);
 
-            SetWindowPos(
+            if let Err(error) = SetWindowPos(
                 self.hwnd,
                 None,
                 x,
@@ -967,8 +1140,9 @@ impl WindowTrait for WindowsWindow {
                 0,
                 0,
                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
-            )
-            .ok();
+            ) {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "SetWindowPos (move) failed");
+            }
 
             self.state.lock().bounds.origin = position;
         }
@@ -979,12 +1153,13 @@ impl WindowTrait for WindowsWindow {
     }
 
     fn set_size(&mut self, size: Size<Pixels>) {
+        // SAFETY: see `set_position` above — same call shape.
         unsafe {
             let scale = self.state.lock().scale_factor;
             let width = logical_to_device(size.width.0, scale);
             let height = logical_to_device(size.height.0, scale);
 
-            SetWindowPos(
+            if let Err(error) = SetWindowPos(
                 self.hwnd,
                 None,
                 0,
@@ -992,8 +1167,9 @@ impl WindowTrait for WindowsWindow {
                 width,
                 height,
                 SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE,
-            )
-            .ok();
+            ) {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "SetWindowPos (resize) failed");
+            }
 
             self.state.lock().bounds.size = size;
         }
@@ -1014,6 +1190,9 @@ impl WindowTrait for WindowsWindow {
     }
 
     fn set_state(&mut self, state: CrossWindowState) {
+        // SAFETY: `ShowWindow` takes `self.hwnd` and a command constant by
+        // value, no pointer arguments; `self.set_fullscreen`/`self.is_fullscreen`
+        // carry their own SAFETY contracts documented where they're defined.
         unsafe {
             match state {
                 CrossWindowState::Normal => {
@@ -1043,6 +1222,8 @@ impl WindowTrait for WindowsWindow {
     }
 
     fn set_visible(&mut self, visible: bool) {
+        // SAFETY: `ShowWindow` takes `self.hwnd` and a command constant by
+        // value, no pointer arguments.
         unsafe {
             let cmd = if visible { SW_SHOW } else { SW_HIDE };
             let _ = ShowWindow(self.hwnd, cmd);
@@ -1051,6 +1232,9 @@ impl WindowTrait for WindowsWindow {
     }
 
     fn is_resizable(&self) -> bool {
+        // SAFETY: `GetWindowLongPtrW` takes `self.hwnd` and an index
+        // constant, returning a plain `isize` bit pattern — no pointer
+        // arguments, no invariant beyond the ordinary FFI call.
         unsafe {
             let style = GetWindowLongPtrW(self.hwnd, GWL_STYLE) as u32;
             (style & WS_THICKFRAME.0) != 0
@@ -1058,6 +1242,11 @@ impl WindowTrait for WindowsWindow {
     }
 
     fn set_resizable(&mut self, resizable: bool) {
+        // SAFETY: see `is_resizable` above for `GetWindowLongPtrW`;
+        // `SetWindowLongPtrW` is the same shape in reverse (writes a plain
+        // bit pattern, not a pointer); `SetWindowPos` here only re-applies
+        // frame metrics (`SWP_FRAMECHANGED`) with no move/resize, same call
+        // shape as `set_position` above.
         unsafe {
             let mut style = GetWindowLongPtrW(self.hwnd, GWL_STYLE) as u32;
             if resizable {
@@ -1066,7 +1255,7 @@ impl WindowTrait for WindowsWindow {
                 style &= !WS_THICKFRAME.0;
             }
             SetWindowLongPtrW(self.hwnd, GWL_STYLE, style as isize);
-            SetWindowPos(
+            if let Err(error) = SetWindowPos(
                 self.hwnd,
                 None,
                 0,
@@ -1074,12 +1263,14 @@ impl WindowTrait for WindowsWindow {
                 0,
                 0,
                 SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
-            )
-            .ok();
+            ) {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "SetWindowPos (resizable style refresh) failed");
+            }
         }
     }
 
     fn is_minimizable(&self) -> bool {
+        // SAFETY: see `is_resizable` above — same call shape.
         unsafe {
             let style = GetWindowLongPtrW(self.hwnd, GWL_STYLE) as u32;
             (style & WS_MINIMIZEBOX.0) != 0
@@ -1087,6 +1278,7 @@ impl WindowTrait for WindowsWindow {
     }
 
     fn set_minimizable(&mut self, minimizable: bool) {
+        // SAFETY: see `set_resizable` above — same call shape.
         unsafe {
             let mut style = GetWindowLongPtrW(self.hwnd, GWL_STYLE) as u32;
             if minimizable {
@@ -1095,7 +1287,7 @@ impl WindowTrait for WindowsWindow {
                 style &= !WS_MINIMIZEBOX.0;
             }
             SetWindowLongPtrW(self.hwnd, GWL_STYLE, style as isize);
-            SetWindowPos(
+            if let Err(error) = SetWindowPos(
                 self.hwnd,
                 None,
                 0,
@@ -1103,12 +1295,14 @@ impl WindowTrait for WindowsWindow {
                 0,
                 0,
                 SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
-            )
-            .ok();
+            ) {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "SetWindowPos (minimizable style refresh) failed");
+            }
         }
     }
 
     fn is_closable(&self) -> bool {
+        // SAFETY: see `is_resizable` above — same call shape.
         unsafe {
             let style = GetWindowLongPtrW(self.hwnd, GWL_STYLE) as u32;
             (style & WS_SYSMENU.0) != 0
@@ -1116,6 +1310,7 @@ impl WindowTrait for WindowsWindow {
     }
 
     fn set_closable(&mut self, closable: bool) {
+        // SAFETY: see `set_resizable` above — same call shape.
         unsafe {
             let mut style = GetWindowLongPtrW(self.hwnd, GWL_STYLE) as u32;
             if closable {
@@ -1124,7 +1319,7 @@ impl WindowTrait for WindowsWindow {
                 style &= !WS_SYSMENU.0;
             }
             SetWindowLongPtrW(self.hwnd, GWL_STYLE, style as isize);
-            SetWindowPos(
+            if let Err(error) = SetWindowPos(
                 self.hwnd,
                 None,
                 0,
@@ -1132,12 +1327,15 @@ impl WindowTrait for WindowsWindow {
                 0,
                 0,
                 SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
-            )
-            .ok();
+            ) {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "SetWindowPos (closable style refresh) failed");
+            }
         }
     }
 
     fn focus(&mut self) {
+        // SAFETY: `SetForegroundWindow` takes `self.hwnd` by value, no
+        // pointer arguments.
         unsafe {
             let _ = SetForegroundWindow(self.hwnd);
         }
@@ -1148,8 +1346,11 @@ impl WindowTrait for WindowsWindow {
     }
 
     fn close(&mut self) {
+        // SAFETY: see `PlatformWindow::close` above — same call shape.
         unsafe {
-            DestroyWindow(self.hwnd).ok();
+            if let Err(error) = DestroyWindow(self.hwnd) {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "DestroyWindow failed");
+            }
         }
     }
 
@@ -1176,6 +1377,8 @@ impl WindowTrait for WindowsWindow {
     }
 
     fn raw_window_handle(&self) -> CrossRawWindowHandle {
+        // SAFETY: `GetModuleHandleW(None)` queries the current process
+        // image, no pointer arguments — always sound.
         unsafe {
             let hinstance = GetModuleHandleW(None)
                 .expect("BUG: GetModuleHandleW(None) cannot fail for the current process image");
@@ -1190,18 +1393,41 @@ impl WindowTrait for WindowsWindow {
 impl WindowsWindow {
     /// Helper to get window placement
     fn get_window_placement(&self) -> WINDOWPLACEMENT {
+        // SAFETY: `placement` is a stack-local `WINDOWPLACEMENT` with
+        // `length` pre-filled to its own `size_of` as the API requires;
+        // `&raw mut placement` gives `GetWindowPlacement` a valid,
+        // correctly-sized out-parameter regardless of whether the call
+        // succeeds, so returning `placement` on `Err` is safe (it holds the
+        // `Default` values this function seeded, not uninitialized memory) —
+        // callers just get a placement that will not match SW_MINIMIZE or
+        // SW_MAXIMIZE, i.e. a normal-state placement.
         unsafe {
             let mut placement = WINDOWPLACEMENT {
                 length: std::mem::size_of::<WINDOWPLACEMENT>() as u32,
                 ..Default::default()
             };
-            GetWindowPlacement(self.hwnd, &raw mut placement).ok();
+            if let Err(error) = GetWindowPlacement(self.hwnd, &raw mut placement) {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "GetWindowPlacement failed");
+            }
             placement
         }
     }
 
     /// Set DWM window attribute
+    ///
+    /// # Safety
+    ///
+    /// `value` must be a valid, initialized `T` whose size and layout match
+    /// what `attribute` (a `DWMWINDOWATTRIBUTE` ordinal) expects DWM to read
+    /// — the byte count passed to `DwmSetWindowAttribute` is derived from
+    /// `size_of::<T>()`, so calling this with the wrong `T` for a given
+    /// `attribute` has DWM read past `value`'s bytes.
     unsafe fn set_dwm_attribute<T>(&self, attribute: i32, value: &T) -> windows::core::Result<()> {
+        // SAFETY: per the `# Safety` contract above, the caller guarantees
+        // `T` matches `attribute`'s expected layout; `value` is a live `&T`
+        // for the duration of this call, and `size_of::<T>()` is the
+        // correct byte count for the pointer `std::ptr::from_ref` produces
+        // from it.
         unsafe {
             use windows::Win32::Graphics::Dwm::{DWMWINDOWATTRIBUTE, DwmSetWindowAttribute};
 
@@ -1215,7 +1441,19 @@ impl WindowsWindow {
     }
 
     /// Get DWM window attribute
+    ///
+    /// # Safety
+    ///
+    /// `T` must match the layout DWM writes for `attribute` (a
+    /// `DWMWINDOWATTRIBUTE` ordinal) — `size_of::<T>()` is the byte count
+    /// passed to `DwmGetWindowAttribute`, so the wrong `T` for a given
+    /// `attribute` has DWM write past `value`'s bytes.
     unsafe fn get_dwm_attribute<T: Default>(&self, attribute: i32) -> windows::core::Result<T> {
+        // SAFETY: per the `# Safety` contract above, `T::default()` seeds a
+        // valid, fully-initialized `value` before `&raw mut value` is handed
+        // to DWM, so even if the call fails without writing anything, `value`
+        // is never read uninitialized; the caller guarantees `T` matches
+        // `attribute`'s expected layout and `size_of::<T>()`.
         unsafe {
             use windows::Win32::Graphics::Dwm::{DWMWINDOWATTRIBUTE, DwmGetWindowAttribute};
 
@@ -1242,6 +1480,8 @@ use super::window_ext::{
 
 impl WindowsWindowExtTrait for WindowsWindow {
     fn set_backdrop(&mut self, backdrop: WindowsBackdrop) {
+        // SAFETY: `backdrop_value` is `i32`, matching `DWMWA_SYSTEMBACKDROP_TYPE`'s
+        // expected layout, satisfying `set_dwm_attribute`'s `# Safety` contract.
         unsafe {
             let backdrop_value = backdrop.to_dwm_value();
             if let Err(e) =
@@ -1259,6 +1499,8 @@ impl WindowsWindowExtTrait for WindowsWindow {
     }
 
     fn backdrop(&self) -> WindowsBackdrop {
+        // SAFETY: `i32` matches `DWMWA_SYSTEMBACKDROP_TYPE`'s expected
+        // layout, satisfying `get_dwm_attribute`'s `# Safety` contract.
         unsafe {
             match self.get_dwm_attribute::<i32>(dwm_attributes::DWMWA_SYSTEMBACKDROP_TYPE) {
                 // Ok(1) is DWMSBT_NONE — covered by the fallback arm.
@@ -1274,11 +1516,14 @@ impl WindowsWindowExtTrait for WindowsWindow {
         // Snap Layouts are automatically enabled on Windows 11 if the window has
         // a standard maximize button. No explicit API call needed.
         // We just need to ensure WS_MAXIMIZEBOX is set
+        //
+        // SAFETY: see `PlatformWindow::is_resizable`/`set_resizable` above —
+        // same `GetWindowLongPtrW`/`SetWindowLongPtrW`/`SetWindowPos` shape.
         unsafe {
             let mut style = GetWindowLongPtrW(self.hwnd, GWL_STYLE) as u32;
             style |= WS_MAXIMIZEBOX.0;
             SetWindowLongPtrW(self.hwnd, GWL_STYLE, style as isize);
-            SetWindowPos(
+            if let Err(error) = SetWindowPos(
                 self.hwnd,
                 None,
                 0,
@@ -1286,8 +1531,9 @@ impl WindowsWindowExtTrait for WindowsWindow {
                 0,
                 0,
                 SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
-            )
-            .ok();
+            ) {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "SetWindowPos (enable snap layouts style refresh) failed");
+            }
 
             tracing::debug!("Snap Layouts enabled (via WS_MAXIMIZEBOX)");
         }
@@ -1295,11 +1541,13 @@ impl WindowsWindowExtTrait for WindowsWindow {
 
     fn disable_snap_layouts(&mut self) {
         // Disable by removing WS_MAXIMIZEBOX
+        //
+        // SAFETY: see `enable_snap_layouts` above — same call shape.
         unsafe {
             let mut style = GetWindowLongPtrW(self.hwnd, GWL_STYLE) as u32;
             style &= !WS_MAXIMIZEBOX.0;
             SetWindowLongPtrW(self.hwnd, GWL_STYLE, style as isize);
-            SetWindowPos(
+            if let Err(error) = SetWindowPos(
                 self.hwnd,
                 None,
                 0,
@@ -1307,14 +1555,16 @@ impl WindowsWindowExtTrait for WindowsWindow {
                 0,
                 0,
                 SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
-            )
-            .ok();
+            ) {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "SetWindowPos (disable snap layouts style refresh) failed");
+            }
 
             tracing::debug!("Snap Layouts disabled");
         }
     }
 
     fn is_snap_layouts_enabled(&self) -> bool {
+        // SAFETY: see `PlatformWindow::is_resizable` above — same call shape.
         unsafe {
             let style = GetWindowLongPtrW(self.hwnd, GWL_STYLE) as u32;
             (style & WS_MAXIMIZEBOX.0) != 0
@@ -1322,6 +1572,9 @@ impl WindowsWindowExtTrait for WindowsWindow {
     }
 
     fn set_corner_preference(&mut self, preference: WindowCornerPreference) {
+        // SAFETY: `corner_value` is `i32`, matching
+        // `DWMWA_WINDOW_CORNER_PREFERENCE`'s expected layout, satisfying
+        // `set_dwm_attribute`'s `# Safety` contract.
         unsafe {
             let corner_value = preference.to_dwm_value();
             if let Err(e) = self.set_dwm_attribute(
@@ -1336,6 +1589,8 @@ impl WindowsWindowExtTrait for WindowsWindow {
     }
 
     fn corner_preference(&self) -> WindowCornerPreference {
+        // SAFETY: `i32` matches `DWMWA_WINDOW_CORNER_PREFERENCE`'s expected
+        // layout, satisfying `get_dwm_attribute`'s `# Safety` contract.
         unsafe {
             match self.get_dwm_attribute::<i32>(dwm_attributes::DWMWA_WINDOW_CORNER_PREFERENCE) {
                 // Ok(0) is DWMCP_DEFAULT — covered by the fallback arm.
@@ -1352,6 +1607,11 @@ impl WindowsWindowExtTrait for WindowsWindow {
             DWM_BB_ENABLE, DWM_BLURBEHIND, DwmEnableBlurBehindWindow,
         };
 
+        // SAFETY: `bb` is a stack-local `DWM_BLURBEHIND`, fully initialized
+        // above; `&raw const bb` gives `DwmEnableBlurBehindWindow` a valid
+        // pointer to it — the API takes a typed struct pointer, not a
+        // `(pointer, size)` pair, so there is no separate size argument to
+        // get wrong.
         unsafe {
             let bb = DWM_BLURBEHIND {
                 dwFlags: DWM_BB_ENABLE,
@@ -1385,6 +1645,9 @@ impl WindowsWindowExtTrait for WindowsWindow {
     }
 
     fn set_dark_mode(&mut self, dark_mode: bool) {
+        // SAFETY: `dark_mode_value` is `i32`, matching
+        // `DWMWA_USE_IMMERSIVE_DARK_MODE`'s expected layout, satisfying
+        // `set_dwm_attribute`'s `# Safety` contract.
         unsafe {
             let dark_mode_value: i32 = i32::from(dark_mode);
             if let Err(e) = self.set_dwm_attribute(
@@ -1399,6 +1662,8 @@ impl WindowsWindowExtTrait for WindowsWindow {
     }
 
     fn is_dark_mode(&self) -> bool {
+        // SAFETY: `i32` matches `DWMWA_USE_IMMERSIVE_DARK_MODE`'s expected
+        // layout, satisfying `get_dwm_attribute`'s `# Safety` contract.
         unsafe {
             self.get_dwm_attribute::<i32>(dwm_attributes::DWMWA_USE_IMMERSIVE_DARK_MODE)
                 .unwrap_or(0)
@@ -1432,6 +1697,9 @@ impl WindowsWindowExtTrait for WindowsWindow {
     }
 
     fn set_title_bar_color(&mut self, color: Option<(u8, u8, u8)>) {
+        // SAFETY: both `colorref` and `default_color` are `u32`, matching
+        // `DWMWA_CAPTION_COLOR`'s expected `COLORREF` layout, satisfying
+        // `set_dwm_attribute`'s `# Safety` contract.
         unsafe {
             if let Some((r, g, b)) = color {
                 // Windows expects COLORREF format: 0x00BBGGRR
@@ -1447,8 +1715,15 @@ impl WindowsWindowExtTrait for WindowsWindow {
             } else {
                 // Reset to default (0xFFFFFFFF means use default)
                 let default_color: u32 = 0xFFFF_FFFF;
-                self.set_dwm_attribute(dwm_attributes::DWMWA_CAPTION_COLOR, &default_color)
-                    .ok();
+                if let Err(error) =
+                    self.set_dwm_attribute(dwm_attributes::DWMWA_CAPTION_COLOR, &default_color)
+                {
+                    tracing::warn!(
+                        hwnd = ?self.hwnd,
+                        ?error,
+                        "failed to reset title bar color to default"
+                    );
+                }
             }
         }
     }
@@ -1465,6 +1740,9 @@ impl WindowsWindowExtTrait for WindowsWindow {
     }
 
     fn dpi(&self) -> u32 {
+        // SAFETY: `GetDpiForWindow` takes `self.hwnd` by value, no pointer
+        // arguments; an invalid `hwnd` yields a documented fallback DPI, not
+        // UB.
         unsafe { GetDpiForWindow(self.hwnd) }
     }
 
@@ -1488,9 +1766,16 @@ impl Drop for WindowsWindow {
         if Arc::strong_count(&self.state) == 1 {
             tracing::debug!("Destroying window HWND {:?}", self.hwnd);
 
+            // SAFETY: `DestroyWindow` takes `self.hwnd` by value; the
+            // `is_invalid()` guard skips the call for a handle that was
+            // never successfully created, and `WM_DESTROY` (handled in
+            // `platform.rs`) reclaims the `GWLP_USERDATA` allocation
+            // synchronously within this call.
             unsafe {
-                if !self.hwnd.is_invalid() {
-                    DestroyWindow(self.hwnd).ok();
+                if !self.hwnd.is_invalid()
+                    && let Err(error) = DestroyWindow(self.hwnd)
+                {
+                    tracing::warn!(hwnd = ?self.hwnd, ?error, "DestroyWindow failed in Drop");
                 }
             }
 

--- a/crates/flui-platform/src/platforms/windows/window.rs
+++ b/crates/flui-platform/src/platforms/windows/window.rs
@@ -245,8 +245,16 @@ impl WindowsWindow {
 
             // Show window if requested
             if options.visible {
-                let _ = ShowWindow(hwnd, SW_SHOW);
-                let _ = UpdateWindow(hwnd);
+                if let Err(error) = ShowWindow(hwnd, SW_SHOW).ok() {
+                    tracing::warn!(
+                        ?hwnd,
+                        ?error,
+                        "ShowWindow(SW_SHOW) failed in WindowsWindow::new"
+                    );
+                }
+                if let Err(error) = UpdateWindow(hwnd).ok() {
+                    tracing::warn!(?hwnd, ?error, "UpdateWindow failed in WindowsWindow::new");
+                }
                 window.state.lock().visible = true;
             }
 
@@ -498,7 +506,13 @@ impl WindowsWindow {
                     cbSize: std::mem::size_of::<MONITORINFO>() as u32,
                     ..Default::default()
                 };
-                let _ = GetMonitorInfoW(monitor, &raw mut monitor_info);
+                if let Err(error) = GetMonitorInfoW(monitor, &raw mut monitor_info).ok() {
+                    tracing::warn!(
+                        ?hwnd,
+                        ?error,
+                        "GetMonitorInfoW failed entering fullscreen; monitor rect will be zeroed"
+                    );
+                }
 
                 let monitor_rect = monitor_info.rcMonitor;
 
@@ -869,7 +883,9 @@ impl PlatformWindow for WindowsWindow {
         // does not retain the pointer past the call.
         unsafe {
             let title_str = HSTRING::from(title);
-            let _ = SetWindowTextW(self.hwnd, &title_str);
+            if let Err(error) = SetWindowTextW(self.hwnd, &title_str) {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "SetWindowTextW failed");
+            }
             self.state.lock().title = title.to_string();
         }
     }
@@ -878,7 +894,9 @@ impl PlatformWindow for WindowsWindow {
         // SAFETY: `SetForegroundWindow` takes `self.hwnd` by value, no
         // pointer arguments.
         unsafe {
-            let _ = SetForegroundWindow(self.hwnd);
+            if let Err(error) = SetForegroundWindow(self.hwnd).ok() {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "SetForegroundWindow failed");
+            }
         }
     }
 
@@ -886,21 +904,27 @@ impl PlatformWindow for WindowsWindow {
         // SAFETY: `ShowWindow` takes `self.hwnd` and a command constant by
         // value, no pointer arguments.
         unsafe {
-            let _ = ShowWindow(self.hwnd, SW_MINIMIZE);
+            if let Err(error) = ShowWindow(self.hwnd, SW_MINIMIZE).ok() {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "ShowWindow(SW_MINIMIZE) failed");
+            }
         }
     }
 
     fn maximize(&self) {
         // SAFETY: see `minimize` above — same call shape.
         unsafe {
-            let _ = ShowWindow(self.hwnd, SW_MAXIMIZE);
+            if let Err(error) = ShowWindow(self.hwnd, SW_MAXIMIZE).ok() {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "ShowWindow(SW_MAXIMIZE) failed");
+            }
         }
     }
 
     fn restore(&self) {
         // SAFETY: see `minimize` above — same call shape.
         unsafe {
-            let _ = ShowWindow(self.hwnd, SW_RESTORE);
+            if let Err(error) = ShowWindow(self.hwnd, SW_RESTORE).ok() {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "ShowWindow(SW_RESTORE) failed");
+            }
         }
     }
 
@@ -917,7 +941,7 @@ impl PlatformWindow for WindowsWindow {
             let width = logical_to_device(size.width.0, scale);
             let height = logical_to_device(size.height.0, scale);
 
-            let _ = SetWindowPos(
+            if let Err(error) = SetWindowPos(
                 self.hwnd,
                 None,
                 0,
@@ -925,7 +949,9 @@ impl PlatformWindow for WindowsWindow {
                 width,
                 height,
                 SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE,
-            );
+            ) {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "SetWindowPos (PlatformWindow::resize) failed");
+            }
 
             self.state.lock().bounds.size = size;
         }
@@ -938,7 +964,9 @@ impl PlatformWindow for WindowsWindow {
         // thread — Win32 dispatches `WM_DESTROY` to the window procedure
         // before `DestroyWindow` returns.
         unsafe {
-            let _ = DestroyWindow(self.hwnd);
+            if let Err(error) = DestroyWindow(self.hwnd) {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "DestroyWindow (PlatformWindow::close) failed");
+            }
         }
     }
 
@@ -958,12 +986,19 @@ impl PlatformWindow for WindowsWindow {
                 WindowBackgroundAppearance::MicaAltBackdrop => 4, // DWMSBT_TABBEDWINDOW (Mica Alt)
             };
 
-            let _ = DwmSetWindowAttribute(
+            if let Err(error) = DwmSetWindowAttribute(
                 self.hwnd,
                 DWMWINDOWATTRIBUTE(38), // DWMWA_SYSTEMBACKDROP_TYPE
                 (&raw const backdrop_value).cast::<std::ffi::c_void>(),
                 std::mem::size_of::<i32>() as u32,
-            );
+            ) {
+                tracing::warn!(
+                    hwnd = ?self.hwnd,
+                    ?error,
+                    ?appearance,
+                    "DwmSetWindowAttribute(DWMWA_SYSTEMBACKDROP_TYPE) failed"
+                );
+            }
         }
     }
 
@@ -1203,16 +1238,22 @@ impl WindowTrait for WindowsWindow {
                     if self.is_fullscreen() {
                         self.set_fullscreen(false);
                     }
-                    let _ = ShowWindow(self.hwnd, SW_RESTORE);
+                    if let Err(error) = ShowWindow(self.hwnd, SW_RESTORE).ok() {
+                        tracing::warn!(hwnd = ?self.hwnd, ?error, "ShowWindow(SW_RESTORE) failed in set_state(Normal)");
+                    }
                 }
                 CrossWindowState::Minimized => {
-                    let _ = ShowWindow(self.hwnd, SW_MINIMIZE);
+                    if let Err(error) = ShowWindow(self.hwnd, SW_MINIMIZE).ok() {
+                        tracing::warn!(hwnd = ?self.hwnd, ?error, "ShowWindow(SW_MINIMIZE) failed in set_state(Minimized)");
+                    }
                 }
                 CrossWindowState::Maximized => {
                     if self.is_fullscreen() {
                         self.set_fullscreen(false);
                     }
-                    let _ = ShowWindow(self.hwnd, SW_MAXIMIZE);
+                    if let Err(error) = ShowWindow(self.hwnd, SW_MAXIMIZE).ok() {
+                        tracing::warn!(hwnd = ?self.hwnd, ?error, "ShowWindow(SW_MAXIMIZE) failed in set_state(Maximized)");
+                    }
                 }
                 CrossWindowState::Fullscreen => {
                     self.set_fullscreen(true);
@@ -1230,7 +1271,9 @@ impl WindowTrait for WindowsWindow {
         // value, no pointer arguments.
         unsafe {
             let cmd = if visible { SW_SHOW } else { SW_HIDE };
-            let _ = ShowWindow(self.hwnd, cmd);
+            if let Err(error) = ShowWindow(self.hwnd, cmd).ok() {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, visible, "ShowWindow failed in set_visible");
+            }
             self.state.lock().visible = visible;
         }
     }
@@ -1341,7 +1384,9 @@ impl WindowTrait for WindowsWindow {
         // SAFETY: `SetForegroundWindow` takes `self.hwnd` by value, no
         // pointer arguments.
         unsafe {
-            let _ = SetForegroundWindow(self.hwnd);
+            if let Err(error) = SetForegroundWindow(self.hwnd).ok() {
+                tracing::warn!(hwnd = ?self.hwnd, ?error, "SetForegroundWindow failed in focus");
+            }
         }
     }
 

--- a/crates/flui-platform/src/platforms/windows/window.rs
+++ b/crates/flui-platform/src/platforms/windows/window.rs
@@ -245,13 +245,14 @@ impl WindowsWindow {
 
             // Show window if requested
             if options.visible {
-                if let Err(error) = ShowWindow(hwnd, SW_SHOW).ok() {
-                    tracing::warn!(
-                        ?hwnd,
-                        ?error,
-                        "ShowWindow(SW_SHOW) failed in WindowsWindow::new"
-                    );
-                }
+                // ShowWindow's return value reports the window's PREVIOUS
+                // visibility state (nonzero if it was already visible), not
+                // success/failure -- a freshly created window is always
+                // previously-hidden, so treating the BOOL as a Result would
+                // warn on every visible window creation. Nothing meaningful
+                // to check here; UpdateWindow below does return a genuine
+                // success/failure BOOL.
+                let _ = ShowWindow(hwnd, SW_SHOW);
                 if let Err(error) = UpdateWindow(hwnd).ok() {
                     tracing::warn!(?hwnd, ?error, "UpdateWindow failed in WindowsWindow::new");
                 }
@@ -903,28 +904,28 @@ impl PlatformWindow for WindowsWindow {
     fn minimize(&self) {
         // SAFETY: `ShowWindow` takes `self.hwnd` and a command constant by
         // value, no pointer arguments.
+        //
+        // Return value is the window's PREVIOUS visibility state (nonzero
+        // if it was already visible before this call), not success/failure
+        // — nothing meaningful to check or warn on.
         unsafe {
-            if let Err(error) = ShowWindow(self.hwnd, SW_MINIMIZE).ok() {
-                tracing::warn!(hwnd = ?self.hwnd, ?error, "ShowWindow(SW_MINIMIZE) failed");
-            }
+            let _ = ShowWindow(self.hwnd, SW_MINIMIZE);
         }
     }
 
     fn maximize(&self) {
-        // SAFETY: see `minimize` above — same call shape.
+        // SAFETY: see `minimize` above — same call shape and return-value
+        // semantics (previous visibility, not success/failure).
         unsafe {
-            if let Err(error) = ShowWindow(self.hwnd, SW_MAXIMIZE).ok() {
-                tracing::warn!(hwnd = ?self.hwnd, ?error, "ShowWindow(SW_MAXIMIZE) failed");
-            }
+            let _ = ShowWindow(self.hwnd, SW_MAXIMIZE);
         }
     }
 
     fn restore(&self) {
-        // SAFETY: see `minimize` above — same call shape.
+        // SAFETY: see `minimize` above — same call shape and return-value
+        // semantics (previous visibility, not success/failure).
         unsafe {
-            if let Err(error) = ShowWindow(self.hwnd, SW_RESTORE).ok() {
-                tracing::warn!(hwnd = ?self.hwnd, ?error, "ShowWindow(SW_RESTORE) failed");
-            }
+            let _ = ShowWindow(self.hwnd, SW_RESTORE);
         }
     }
 
@@ -1232,28 +1233,27 @@ impl WindowTrait for WindowsWindow {
         // SAFETY: `ShowWindow` takes `self.hwnd` and a command constant by
         // value, no pointer arguments; `self.set_fullscreen`/`self.is_fullscreen`
         // carry their own SAFETY contracts documented where they're defined.
+        //
+        // Every `ShowWindow` return value below is the window's PREVIOUS
+        // visibility state (nonzero if it was already visible before this
+        // call), not success/failure — nothing meaningful to check or warn
+        // on.
         unsafe {
             match state {
                 CrossWindowState::Normal => {
                     if self.is_fullscreen() {
                         self.set_fullscreen(false);
                     }
-                    if let Err(error) = ShowWindow(self.hwnd, SW_RESTORE).ok() {
-                        tracing::warn!(hwnd = ?self.hwnd, ?error, "ShowWindow(SW_RESTORE) failed in set_state(Normal)");
-                    }
+                    let _ = ShowWindow(self.hwnd, SW_RESTORE);
                 }
                 CrossWindowState::Minimized => {
-                    if let Err(error) = ShowWindow(self.hwnd, SW_MINIMIZE).ok() {
-                        tracing::warn!(hwnd = ?self.hwnd, ?error, "ShowWindow(SW_MINIMIZE) failed in set_state(Minimized)");
-                    }
+                    let _ = ShowWindow(self.hwnd, SW_MINIMIZE);
                 }
                 CrossWindowState::Maximized => {
                     if self.is_fullscreen() {
                         self.set_fullscreen(false);
                     }
-                    if let Err(error) = ShowWindow(self.hwnd, SW_MAXIMIZE).ok() {
-                        tracing::warn!(hwnd = ?self.hwnd, ?error, "ShowWindow(SW_MAXIMIZE) failed in set_state(Maximized)");
-                    }
+                    let _ = ShowWindow(self.hwnd, SW_MAXIMIZE);
                 }
                 CrossWindowState::Fullscreen => {
                     self.set_fullscreen(true);
@@ -1268,12 +1268,13 @@ impl WindowTrait for WindowsWindow {
 
     fn set_visible(&mut self, visible: bool) {
         // SAFETY: `ShowWindow` takes `self.hwnd` and a command constant by
-        // value, no pointer arguments.
+        // value, no pointer arguments. Return value is the window's
+        // PREVIOUS visibility state (nonzero if it was already visible
+        // before this call), not success/failure — nothing meaningful to
+        // check or warn on.
         unsafe {
             let cmd = if visible { SW_SHOW } else { SW_HIDE };
-            if let Err(error) = ShowWindow(self.hwnd, cmd).ok() {
-                tracing::warn!(hwnd = ?self.hwnd, ?error, visible, "ShowWindow failed in set_visible");
-            }
+            let _ = ShowWindow(self.hwnd, cmd);
             self.state.lock().visible = visible;
         }
     }
@@ -1790,8 +1791,14 @@ impl WindowsWindowExtTrait for WindowsWindow {
 
     fn dpi(&self) -> u32 {
         // SAFETY: `GetDpiForWindow` takes `self.hwnd` by value, no pointer
-        // arguments; an invalid `hwnd` yields a documented fallback DPI, not
-        // UB.
+        // arguments — a stale or invalid `hwnd` cannot cause UB here, it is
+        // just an ordinary FFI call either way. NOT a "safe fallback",
+        // though: per its documented contract, an invalid `hwnd` makes this
+        // return a literal `0`, not some usable default DPI — a caller that
+        // divides by this result (e.g. computing a scale factor) would get
+        // infinity or NaN, not graceful degradation. No current caller in
+        // this crate divides by `dpi()`'s result, but a future one should
+        // not assume `0` means "use 96 instead".
         unsafe { GetDpiForWindow(self.hwnd) }
     }
 

--- a/crates/flui-platform/src/platforms/windows/window.rs
+++ b/crates/flui-platform/src/platforms/windows/window.rs
@@ -440,7 +440,11 @@ impl WindowsWindow {
                     restore_bounds.size.height.0,
                     SWP_FRAMECHANGED | SWP_NOZORDER | SWP_NOACTIVATE,
                 ) {
-                    tracing::warn!(?hwnd, ?error, "SetWindowPos (exit fullscreen restore) failed");
+                    tracing::warn!(
+                        ?hwnd,
+                        ?error,
+                        "SetWindowPos (exit fullscreen restore) failed"
+                    );
                 }
 
                 // Update state

--- a/crates/flui-platform/src/platforms/winit/control.rs
+++ b/crates/flui-platform/src/platforms/winit/control.rs
@@ -333,6 +333,9 @@ mod tests {
         ) -> Result<(), crate::traits::CursorError> {
             Ok(())
         }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
     }
 
     #[test]

--- a/crates/flui-platform/src/platforms/winit/mod.rs
+++ b/crates/flui-platform/src/platforms/winit/mod.rs
@@ -1,5 +1,11 @@
 //! Winit-based platform implementation
 
+// `platform.rs` needs a small `unsafe` FFI island (documented at each site);
+// the workspace lint `unsafe_code = "warn"` is opted out here, at the module
+// boundary, rather than for the whole crate (see `lib.rs`). The other
+// submodules in this backend have no `unsafe` of their own.
+#![allow(unsafe_code)]
+
 mod clipboard;
 mod control;
 mod data_transfer;

--- a/crates/flui-platform/src/task.rs
+++ b/crates/flui-platform/src/task.rs
@@ -111,34 +111,22 @@ impl<T> Task<T> {
     }
 }
 
-impl<T: Send + 'static> Future for Task<T> {
+impl<T: Send + Unpin + 'static> Future for Task<T> {
     type Output = T;
 
-    // `unsafe` here is Pin-projection boilerplate (see the two `// SAFETY:`
-    // comments below), not FFI — item-level rather than a module- or
-    // crate-level allow, since this is the only unsafe in the file.
-    #[allow(unsafe_code)]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         // `TaskState::Spawned` — the only arm that consults the waker — does not
         // exist on wasm32, where every Task is already `Ready`.
         #[cfg(target_arch = "wasm32")]
         let _ = cx;
 
-        // SAFETY: `get_unchecked_mut` requires that moving the pointee after
-        // this call cannot violate a pinning invariant `Task<T>` depends on.
-        // `Task<T>` never establishes one: it has no `PhantomPinned` field,
-        // does not pin-project any field (no `pin_project`/manual projection
-        // anywhere in this type), and neither `TaskState` variant is
-        // self-referential — `TaskState::Ready` holds a plain `Option<T>`
-        // that this function freely moves out of via `.take()` below, and
-        // `TaskState::Spawned` holds a `tokio::task::JoinHandle<T>`, which
-        // has an unconditional `Unpin` impl (true regardless of `T`: the
-        // handle is a plain index into the runtime, not a borrow into this
-        // struct or into `T`). `Pin<&mut Self>` is only present here because
-        // it is `Future::poll`'s mandated signature, not because `Task<T>`
-        // itself needs any address to stay fixed — so unwrapping it via
-        // `get_unchecked_mut` gives up nothing this type was relying on.
-        let this = unsafe { self.get_unchecked_mut() };
+        // No unsafe pin-projection needed: `Task<T>` never establishes a
+        // pinning invariant (no `PhantomPinned`, no self-referential field,
+        // nothing here treats an address as fixed) — the `T: Unpin` bound
+        // above just makes that already-true fact provable to the compiler,
+        // so `Pin::get_mut` (safe) replaces what used to be a justified
+        // `get_unchecked_mut`.
+        let this = self.get_mut();
         match &mut this.0 {
             TaskState::Ready(val) => {
                 let val = val.take().expect("Task::Ready polled after completion");
@@ -146,13 +134,13 @@ impl<T: Send + 'static> Future for Task<T> {
             }
             #[cfg(not(target_arch = "wasm32"))]
             TaskState::Spawned(handle) => {
-                // SAFETY: `tokio::task::JoinHandle<T>` implements `Unpin`
-                // unconditionally (it holds no self-referential data — just
-                // a handle into the runtime), so pinning it via
-                // `new_unchecked` imposes no obligation this code must
-                // uphold; an `Unpin` type can be soundly pinned and unpinned
-                // at will.
-                let handle = unsafe { Pin::new_unchecked(handle) };
+                // `tokio::task::JoinHandle<T>` carries an unconditional
+                // `impl<T> Unpin for JoinHandle<T> {}` (tokio 1.53.0,
+                // src/runtime/task/join.rs) — true regardless of `T`, since
+                // the handle holds a `RawTask` plus `PhantomData<T>`, never
+                // a borrow into `T` itself. `Pin::new` (safe) replaces what
+                // used to be a justified `Pin::new_unchecked`.
+                let handle = Pin::new(handle);
                 match handle.poll(cx) {
                     Poll::Ready(Ok(val)) => Poll::Ready(val),
                     Poll::Ready(Err(join_error)) => {

--- a/crates/flui-platform/src/task.rs
+++ b/crates/flui-platform/src/task.rs
@@ -114,14 +114,25 @@ impl<T> Task<T> {
 impl<T: Send + 'static> Future for Task<T> {
     type Output = T;
 
+    // `unsafe` here is Pin-projection boilerplate (see the two `// SAFETY:`
+    // comments below), not FFI — item-level rather than a module- or
+    // crate-level allow, since this is the only unsafe in the file.
+    #[allow(unsafe_code)]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         // `TaskState::Spawned` — the only arm that consults the waker — does not
         // exist on wasm32, where every Task is already `Ready`.
         #[cfg(target_arch = "wasm32")]
         let _ = cx;
 
-        // SAFETY: We only access the inner state through the pin, and TaskState
-        // variants are safe to move when accessed through Pin projection.
+        // SAFETY: `get_unchecked_mut` requires that moving the pointee after
+        // this call cannot violate a pinning invariant `Task<T>` depends on.
+        // `Task<T>` has no `PhantomPinned` field and neither `TaskState`
+        // variant is self-referential: `Option<T>` and `tokio::task::JoinHandle<T>`
+        // are themselves `Unpin` regardless of `T` (the handle is a plain
+        // index into the runtime, not a borrow into this struct), so nothing
+        // here actually needs to stay pinned — this projection cannot
+        // produce a dangling self-reference because there is no
+        // self-reference to begin with.
         let this = unsafe { self.get_unchecked_mut() };
         match &mut this.0 {
             TaskState::Ready(val) => {
@@ -130,7 +141,12 @@ impl<T: Send + 'static> Future for Task<T> {
             }
             #[cfg(not(target_arch = "wasm32"))]
             TaskState::Spawned(handle) => {
-                // SAFETY: JoinHandle is Unpin, so pinning is safe
+                // SAFETY: `tokio::task::JoinHandle<T>` implements `Unpin`
+                // unconditionally (it holds no self-referential data — just
+                // a handle into the runtime), so pinning it via
+                // `new_unchecked` imposes no obligation this code must
+                // uphold; an `Unpin` type can be soundly pinned and unpinned
+                // at will.
                 let handle = unsafe { Pin::new_unchecked(handle) };
                 match handle.poll(cx) {
                     Poll::Ready(Ok(val)) => Poll::Ready(val),
@@ -139,8 +155,22 @@ impl<T: Send + 'static> Future for Task<T> {
                         if join_error.is_panic() {
                             std::panic::resume_unwind(join_error.into_panic());
                         }
-                        // Task was cancelled — this shouldn't happen since we hold the handle
-                        panic!("Task was unexpectedly cancelled");
+                        // Cancellation without an explicit `abort()` call (not exposed by
+                        // this API) means the tokio runtime itself was dropped/shut down
+                        // while this handle was still being polled — holding the
+                        // `JoinHandle` does NOT prevent that. `Task<T>: Future<Output = T>`
+                        // has no error channel to report it through, so this is a genuine
+                        // invariant violation of "the runtime outlives tasks still being
+                        // polled", not a scenario that can be handled by returning a value.
+                        // Converting this to a typed error would mean `Output = Result<T, _>`
+                        // for every `Task<T>` in the crate, touching every await site —
+                        // a breaking change that needs its own dedicated review and test
+                        // pass, not a drive-by edit alongside unrelated work.
+                        panic!(
+                            "BUG: Task was cancelled while its JoinHandle was still held — \
+                             the tokio runtime was dropped/shut down while this task was \
+                             still being polled"
+                        );
                     }
                     Poll::Pending => Poll::Pending,
                 }

--- a/crates/flui-platform/src/task.rs
+++ b/crates/flui-platform/src/task.rs
@@ -126,13 +126,18 @@ impl<T: Send + 'static> Future for Task<T> {
 
         // SAFETY: `get_unchecked_mut` requires that moving the pointee after
         // this call cannot violate a pinning invariant `Task<T>` depends on.
-        // `Task<T>` has no `PhantomPinned` field and neither `TaskState`
-        // variant is self-referential: `Option<T>` and `tokio::task::JoinHandle<T>`
-        // are themselves `Unpin` regardless of `T` (the handle is a plain
-        // index into the runtime, not a borrow into this struct), so nothing
-        // here actually needs to stay pinned — this projection cannot
-        // produce a dangling self-reference because there is no
-        // self-reference to begin with.
+        // `Task<T>` never establishes one: it has no `PhantomPinned` field,
+        // does not pin-project any field (no `pin_project`/manual projection
+        // anywhere in this type), and neither `TaskState` variant is
+        // self-referential — `TaskState::Ready` holds a plain `Option<T>`
+        // that this function freely moves out of via `.take()` below, and
+        // `TaskState::Spawned` holds a `tokio::task::JoinHandle<T>`, which
+        // has an unconditional `Unpin` impl (true regardless of `T`: the
+        // handle is a plain index into the runtime, not a borrow into this
+        // struct or into `T`). `Pin<&mut Self>` is only present here because
+        // it is `Future::poll`'s mandated signature, not because `Task<T>`
+        // itself needs any address to stay fixed — so unwrapping it via
+        // `get_unchecked_mut` gives up nothing this type was relying on.
         let this = unsafe { self.get_unchecked_mut() };
         match &mut this.0 {
             TaskState::Ready(val) => {

--- a/crates/flui-platform/src/traits/window.rs
+++ b/crates/flui-platform/src/traits/window.rs
@@ -376,7 +376,7 @@ pub trait PlatformWindow: Send + Sync {
     /// No default body: a panicking default here would only be discovered
     /// the first time some caller downcasts a backend that forgot to
     /// override it — every implementor must supply its own (invariably
-    /// `{ self }`), the same shape [`PlatformHaptics::as_any`](super::PlatformHaptics::as_any)
+    /// `{ self }`), the same shape [`super::PlatformHaptics::as_any`]
     /// already requires.
     fn as_any(&self) -> &dyn Any;
 }

--- a/crates/flui-platform/src/traits/window.rs
+++ b/crates/flui-platform/src/traits/window.rs
@@ -371,10 +371,14 @@ pub trait PlatformWindow: Send + Sync {
         None
     }
 
-    /// Downcast to concrete type
-    fn as_any(&self) -> &dyn Any {
-        panic!("as_any not implemented")
-    }
+    /// Downcast to concrete type.
+    ///
+    /// No default body: a panicking default here would only be discovered
+    /// the first time some caller downcasts a backend that forgot to
+    /// override it — every implementor must supply its own (invariably
+    /// `{ self }`), the same shape [`PlatformHaptics::as_any`](super::PlatformHaptics::as_any)
+    /// already requires.
+    fn as_any(&self) -> &dyn Any;
 }
 
 impl HasWindowHandle for dyn PlatformWindow + '_ {
@@ -627,6 +631,10 @@ impl PlatformWindow for WinitWindow {
         }))
     }
 
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     // No `haptics()` override: desktop winit targets have no haptic
     // hardware to drive, so the `PlatformWindow` trait default (`None`) is
     // the permanent correct answer here, not a stub awaiting a backend.
@@ -680,6 +688,10 @@ mod tests {
 
         fn set_cursor(&self, _cursor: CursorIcon) -> Result<(), CursorError> {
             Ok(())
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
         }
     }
 

--- a/crates/flui-platform/src/window.rs
+++ b/crates/flui-platform/src/window.rs
@@ -314,10 +314,21 @@ pub enum RawWindowHandle {
     },
 }
 
-// SAFETY: Raw window handles are just pointers and can be sent between threads
+// SAFETY: every field across every variant is a raw pointer or plain integer
+// (`*mut c_void`, `u64`, `u32`) that this type never dereferences — it only
+// carries the bit pattern for a caller (e.g. `raw-window-handle` / wgpu
+// surface creation) to interpret. Moving or sharing the enum moves/shares
+// those addresses, not access to whatever they point at, so this is sound
+// regardless of what the pointee's own thread-affinity requirements are —
+// same reasoning as the platform-specific `HWND`/`NSView` wrapper types this
+// crate defines elsewhere (see their own SAFETY comments for the caveat that
+// *using* the pointee, as opposed to holding its address, still owes
+// whatever thread-affinity the native handle requires).
+#[allow(unsafe_code)] // small, cross-platform marker impl — not an FFI island
 unsafe impl Send for RawWindowHandle {}
 // SAFETY: as for `Send` above — the handle is an opaque address that is never
 // dereferenced here, so sharing it across threads adds no aliasing.
+#[allow(unsafe_code)] // small, cross-platform marker impl — not an FFI island
 unsafe impl Sync for RawWindowHandle {}
 
 // ============================================================================


### PR DESCRIPTION
Implements the audit's unsafe-discipline tier for the Windows backend (the workspace's densest unsafe zone had ~104 sites against 6 SAFETY comments; ~19 Win32 results swallowed silently; a crate-level `#![allow(unsafe_code)]` with a false coverage claim).

## What lands

- **Every unsafe block in `platforms/windows/{window,platform,display,clipboard,events,util}.rs` now carries a SAFETY comment stating the real invariant** — hard-verified by the unsafe audit across 20+ sampled sites (HWND validity chains, buffer-length math, GWLP_USERDATA round-trips, COM dialog-thread memory). Where an invariant is NOT dischargeable from the code, the comment says so honestly instead of wishing: the two genuine soundness gaps this pass surfaced are tracked as **#597** (GWLP_USERDATA cross-thread race — CRITICAL, pre-existing, needs an affinity/guarded-slot design) and **#598** (`window_proc` panic boundary — MEDIUM: abort-not-UB on stable, winit already guards its equivalent).
- **Win32 failures stop disappearing**: genuine success-BOOLs (`UpdateWindow`, `SetWindowPos`, `GetMonitorInfoW`, …) now trace on failure with operation+hwnd context; the eight `ShowWindow` sites deliberately stay discards with comments — its BOOL is the *previous visibility*, not success (an audit catch: the first version logged a false failure on every visible-window creation).
- **`#![allow(unsafe_code)]` scoped down** from crate-level to the actual FFI islands; the workspace `unsafe_code = "warn"` lint now bites everywhere else (clippy `-D warnings` proven on msvc + darwin + Linux targets). The false "every block carries SAFETY" prose replaced by a truthful per-file statement.
- **macOS reachable panics → typed errors**: the three window-tiling `panic!`s become a `TilingError` taxonomy (invariant `unreachable!`s proven against the layout match arms); `as_any()`'s panicking default method becomes a required method (matches the haptics precedent). One real aliasing bug found and fixed along the way (`WM_DPICHANGED` writing through a stale reference — now a `Cell` through the live shared ref).
- One deliberate deferral recorded (task.rs cancellation panic), plus a clipboard NUL-scan hardening follow-up noted by the audit.

## Verification honesty

These paths cannot execute on this host (cfg(windows) FFI; miri cannot interpret foreign OS calls) — this is a **source-audit discipline pass**, compile-proven per batch on `x86_64-pc-windows-msvc` and `aarch64-apple-darwin` with clippy `-D warnings`, plus the full Linux ladder (`just ci`, flui-platform's Linux suite unchanged at its known set). SAFETY-GATE: auditor half **signed** after a two-round audit (blockers: the ShowWindow misread and an overstated coverage claim — both fixed with evidence), carrying #597 as the tracked accepted-risk deferral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)