### PR TITLE
feat(app): multi-realm AppRuntime host with exit policy and deferred realm mutations (#555)

### DIFF
--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -30,7 +30,7 @@ use flui_scheduler::AppLifecycleState;
 )]
 use super::runtime::ExitPolicy;
 #[cfg(not(target_os = "ios"))]
-use super::runtime::{AppRuntime, RealmMapMutation, RealmSlot};
+use super::runtime::{AppRuntime, RealmSlot};
 
 /// A fresh clone of the loop-scoped platform wake capability — see
 /// `AppRuntime::frame_wake_callback`'s doc. `APP_RUNTIME` must not be
@@ -396,8 +396,9 @@ enum RealmDispatchError {
     /// and sequential, so a nested dispatch that targets a realm other than
     /// the one already checked out is always a bug, never a legitimate
     /// concurrent-realm scenario — reachable only if something bypasses the
-    /// defer-to-idle discipline [`super::runtime::AppRuntime::request_realm_mutation`]
-    /// exists to make unnecessary. A `debug_assert!` at the same call site
+    /// defer-to-idle discipline
+    /// [`super::runtime::AppRuntime::request_realm_install`]/[`super::runtime::AppRuntime::request_realm_uninstall`]
+    /// exist to make unnecessary. A `debug_assert!` at the same call site
     /// makes this loud in debug builds; this variant is the release-mode
     /// fallback that still refuses instead of silently nesting.
     NestedCrossRealmDispatchRejected,
@@ -1282,12 +1283,22 @@ fn install_platform_realm(
 
 /// Installs `realm` ALONGSIDE whatever is already hosted, never displacing a
 /// sibling — the multi-realm counterpart to [`install_platform_realm`]'s
-/// legacy single-primary-realm replace semantics. Registers `window` the
-/// same way, then requests the registry insertion through
-/// [`super::runtime::AppRuntime::request_realm_mutation`], so an install
-/// requested while another realm is checked out for dispatch (a frame
-/// callback opening a second window) defers to loop idle instead of
-/// installing mid-dispatch.
+/// legacy single-primary-realm replace semantics. Requests window
+/// registration and the registry insertion TOGETHER, through
+/// [`super::runtime::AppRuntime::request_realm_install`] (never registers
+/// the window separately/eagerly — see that method's own doc for the gap a
+/// two-step sequence would leave open), so an install requested while
+/// another realm is checked out for dispatch (a frame callback opening a
+/// second window) defers to loop idle instead of installing mid-dispatch.
+///
+/// `Err(RegistryError::WindowAlreadyMapped)` only when applied immediately
+/// (no dispatch/visit in flight) and `window`'s id already maps to a live
+/// entry — refused, never silently re-routed onto whichever sibling realm
+/// already owns that id (`WindowRegistry::register_window`'s replace
+/// semantics is exactly the wrong tool for two realms meant to coexist). A
+/// deferred install that later collides is traced and dropped instead (see
+/// `AppRuntime::drain_pending_realm_mutations`), since the caller has
+/// already returned by the time a deferred mutation applies.
 ///
 /// No production embedder call site yet: today's bootstrap
 /// (`run_desktop`/`run_android`/`run_web`) still only ever opens one window
@@ -1307,44 +1318,41 @@ fn install_platform_realm(
 fn install_realm_alongside(
     realm: super::ui_realm::UiRealm,
     window: &std::sync::Arc<dyn flui_platform::traits::PlatformWindow>,
-) -> RealmDispatcher {
+) -> Result<RealmDispatcher, super::window_registry::RegistryError> {
     let owner_thread = std::thread::current().id();
     let address = flui_foundation::PresentationAddress {
         realm_id: realm.realm_id(),
         presentation_id: realm.presentation_id(),
     };
+    let window = std::sync::Arc::clone(window);
     APP_RUNTIME.with(|slot| {
         let mut state = slot.borrow_mut();
-        state.registry.register_window(window, address);
         state.owner_thread.get_or_insert(owner_thread);
         let _ = state.ensure_services();
-        let displaced = state.request_realm_mutation(RealmMapMutation::Install(
+        state.request_realm_install(
             address.realm_id,
-            Box::new(RealmSlot {
+            RealmSlot {
                 realm: Some(realm),
                 queue: VecDeque::new(),
                 draining: false,
                 address,
                 surface_applier: None,
-            }),
-        ));
-        debug_assert!(
-            displaced.is_none(),
-            "BUG: an Install mutation can never itself return a displaced slot"
-        );
-    });
-    RealmDispatcher {
+            },
+            window,
+        )
+    })?;
+    Ok(RealmDispatcher {
         owner_thread,
         address,
-    }
+    })
 }
 
 /// Uninstalls exactly one realm — a single window closing while siblings
 /// stay open — without disturbing any other hosted realm. Requests the
-/// removal through [`super::runtime::AppRuntime::request_realm_mutation`],
-/// so a request arriving mid-dispatch or mid-hot-restart-visit defers to
-/// loop idle instead of mutating the registry another operation is still
-/// walking.
+/// removal through
+/// [`super::runtime::AppRuntime::request_realm_uninstall`], so a request
+/// arriving mid-dispatch or mid-hot-restart-visit defers to loop idle
+/// instead of mutating the registry another operation is still walking.
 ///
 /// No production embedder call site yet — no backend currently detects a
 /// single window closing among several (that needs the hop-1/hop-2 routing
@@ -1360,10 +1368,7 @@ fn install_realm_alongside(
     )
 )]
 fn uninstall_platform_realm(realm_id: RealmId) {
-    let removed = APP_RUNTIME.with(|slot| {
-        slot.borrow_mut()
-            .request_realm_mutation(RealmMapMutation::Uninstall(realm_id))
-    });
+    let removed = APP_RUNTIME.with(|slot| slot.borrow_mut().request_realm_uninstall(realm_id));
     // Destructors may re-enter platform/framework code — drop only after the
     // TLS borrow above has released.
     drop(removed);
@@ -1419,8 +1424,9 @@ fn dispatch_platform_realm(
         // out just above), so a `dispatched_realm_id` naming a DIFFERENT
         // realm can only mean a nested dispatch was attempted while that
         // other realm's task is still running on this same thread — the one
-        // case `request_realm_mutation`'s defer-to-idle discipline exists to
-        // make structurally unreachable in production. Caught loudly in
+        // case `request_realm_install`/`request_realm_uninstall`'s
+        // defer-to-idle discipline exists to make structurally unreachable
+        // in production. Caught loudly in
         // debug builds; release builds still refuse rather than nest.
         if let Some(dispatched_realm_id) = state.dispatched_realm_id {
             debug_assert!(
@@ -1519,9 +1525,27 @@ fn dispatch_platform_realm(
 /// safely call back into any `APP_RUNTIME`-touching function, including a
 /// realm-map install/uninstall request. Such a request, arriving while this
 /// visit is still in progress, defers rather than applies immediately
-/// ([`super::runtime::AppRuntime::request_realm_mutation`]'s own doc),
+/// ([`super::runtime::AppRuntime::request_realm_install`]'s own doc),
 /// applied only once every realm has been visited — so the set of realms
 /// visited never shifts mid-iteration.
+///
+/// Each visited realm is ALSO stashed into `dispatched_scheduler`/
+/// `dispatched_realm_id` for the duration of its own call to `f` — the same
+/// fields `dispatch_platform_realm` stashes for a dispatched task — so
+/// `with_owner_platform`'s fence (c) stays able to see the visited realm's
+/// own scheduler phase for the whole time it sits checked out of `realms`,
+/// exactly as it does for a real dispatch.
+///
+/// A panic inside `f` is caught, not propagated past this function's own
+/// cleanup: the visited realm is restored to its slot, `iterating_all_realms`
+/// is cleared, and any mutation deferred during the visit (including one
+/// requested by the very call that panicked) is drained, all BEFORE the
+/// panic resumes. Skipping any of that on a panicking visit would strand the
+/// visited realm's slot at `realm: None` forever and wedge
+/// `iterating_all_realms` at `true` forever — which, after
+/// `drain_pending_realm_mutations`'s own guard against draining while a
+/// visit is nominally still in flight, would silently defer every future
+/// realm-map mutation for the rest of the process.
 ///
 /// No production driver calls this yet — hot-restart's real trigger (the
 /// `flui-hot-reload` file-watcher path) still only ever polls the single
@@ -1548,12 +1572,20 @@ fn for_each_installed_realm(mut f: impl FnMut(&super::ui_realm::UiRealm)) {
         state.realms.keys()
     });
 
+    let mut panic_payload = None;
     for id in ids {
         let realm = APP_RUNTIME.with(|slot| {
-            slot.borrow_mut()
+            let mut state = slot.borrow_mut();
+            let realm = state
                 .realms
                 .get_mut(&id)
-                .and_then(|realm_slot| realm_slot.realm.take())
+                .and_then(|realm_slot| realm_slot.realm.take())?;
+            // Mirrors `dispatch_platform_realm`'s own checkout stash: while
+            // `realm` sits outside `realms` for the extent of `f` below,
+            // fence (c) must still be able to read ITS phase, not go blind.
+            state.dispatched_scheduler = Some(realm.scheduler().clone());
+            state.dispatched_realm_id = Some(id);
+            Some(realm)
         });
         let Some(realm) = realm else {
             // Removed by an earlier realm's own visit before this iteration
@@ -1563,12 +1595,26 @@ fn for_each_installed_realm(mut f: impl FnMut(&super::ui_realm::UiRealm)) {
             // `expect`.
             continue;
         };
-        f(&realm);
+
+        // Never hold the TLS RefCell borrow across `f` -- the same
+        // discipline `dispatch_platform_realm` follows for a dispatched
+        // task. Catch only to restore the checked-out realm and this
+        // visit's own bookkeeping; the original panic resumes once every
+        // realm has been handled (visited, or left untouched after a
+        // panic stops the walk).
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&realm)));
         APP_RUNTIME.with(|slot| {
-            if let Some(realm_slot) = slot.borrow_mut().realms.get_mut(&id) {
+            let mut state = slot.borrow_mut();
+            if let Some(realm_slot) = state.realms.get_mut(&id) {
                 realm_slot.realm = Some(realm);
             }
+            state.dispatched_scheduler = None;
+            state.dispatched_realm_id = None;
         });
+        if let Err(payload) = result {
+            panic_payload = Some(payload);
+            break;
+        }
     }
 
     let removed = APP_RUNTIME.with(|slot| {
@@ -1577,6 +1623,10 @@ fn for_each_installed_realm(mut f: impl FnMut(&super::ui_realm::UiRealm)) {
         state.drain_pending_realm_mutations()
     });
     drop(removed);
+
+    if let Some(payload) = panic_payload {
+        std::panic::resume_unwind(payload);
+    }
 }
 
 /// Drains the per-frame owner-inbox commands and reports whether the drain
@@ -2630,7 +2680,8 @@ mod realm_dispatch_tests {
         let dispatcher_a =
             install_platform_realm(super::super::ui_realm::UiRealm::for_test(), &window_a);
         let dispatcher_b =
-            install_realm_alongside(super::super::ui_realm::UiRealm::for_test(), &window_b);
+            install_realm_alongside(super::super::ui_realm::UiRealm::for_test(), &window_b)
+                .expect("realm B installs alongside realm A cleanly");
         (dispatcher_a, dispatcher_b)
     }
 
@@ -2732,7 +2783,7 @@ mod realm_dispatch_tests {
         .expect("B's attach dispatches");
 
         // Realm A tears itself down from WITHIN its own dispatched task. The
-        // defer-to-idle discipline (`AppRuntime::request_realm_mutation`)
+        // defer-to-idle discipline (`AppRuntime::request_realm_uninstall`)
         // means this queues rather than nests -- applied once this task's
         // own dispatch restores below.
         dispatch_platform_realm(
@@ -2762,6 +2813,46 @@ mod realm_dispatch_tests {
             *presented.borrow(),
             "realm B must still produce (and present) a frame after a sibling realm tore \
              itself down mid-dispatch"
+        );
+
+        teardown_platform_realm();
+    }
+
+    /// `install_realm_alongside` must REFUSE a window-id collision, not
+    /// silently re-route the colliding window's mapping onto the new realm
+    /// (`WindowRegistry::register_window`'s replace semantics would do
+    /// exactly that -- the wrong tool for two realms meant to coexist, and
+    /// the exact failure mode this crate's own `HeadlessPlatform`
+    /// window-id-aliasing gotcha produced during development).
+    #[test]
+    fn install_realm_alongside_refuses_a_colliding_window_id_instead_of_silently_rerouting() {
+        let platform = flui_platform::headless_platform();
+        let window = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create a test window");
+        let dispatcher_a =
+            install_platform_realm(super::super::ui_realm::UiRealm::for_test(), &window);
+
+        let result = install_realm_alongside(super::super::ui_realm::UiRealm::for_test(), &window);
+        match result {
+            Err(super::super::window_registry::RegistryError::WindowAlreadyMapped { existing }) => {
+                assert_eq!(
+                    existing, dispatcher_a.address,
+                    "the refusal must report realm A's own address as the existing mapping"
+                );
+            }
+            other => panic!(
+                "a colliding window id must be refused as WindowAlreadyMapped, got {other:?}"
+            ),
+        }
+
+        assert!(
+            APP_RUNTIME.with(|slot| slot
+                .borrow()
+                .realms
+                .get(&dispatcher_a.address.realm_id)
+                .is_some()),
+            "realm A's own registration must be untouched by the refused collision"
         );
 
         teardown_platform_realm();
@@ -2799,57 +2890,67 @@ mod realm_dispatch_tests {
         teardown_platform_realm();
     }
 
-    /// The drain-before-decide rule: a queued "open the main
-    /// window" install must veto exit even though the splash realm's own
-    /// uninstall is queued in the very same batch -- `should_exit` must
-    /// apply every deferred mutation BEFORE checking whether the registry
-    /// is empty, not race it.
+    /// The drain-before-decide rule: closing the splash realm and installing
+    /// the main realm in the very same batch must never exit the loop --
+    /// the surviving main realm keeps it alive. Drives the deferral through
+    /// the REAL seam, `for_each_installed_realm`'s visit (hot-restart's own
+    /// primitive), rather than hand-poking `iterating_all_realms` -- a
+    /// splash's own dispose callback requesting the main window mid-visit is
+    /// exactly this shape.
     #[test]
     fn close_splash_then_open_main_does_not_exit() {
         let splash = install_test_realm();
         let splash_id = splash.address.realm_id;
 
+        let platform = flui_platform::headless_platform();
+        let main_window = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create the main window");
         let main_realm = super::super::ui_realm::UiRealm::for_test();
-        let main_address = flui_foundation::PresentationAddress {
-            realm_id: main_realm.realm_id(),
-            presentation_id: main_realm.presentation_id(),
-        };
-        let main_window = test_window();
-        // Stand in for "a dispatch/visit is in flight": both requests below
-        // must defer rather than apply immediately -- exactly the state a
-        // splash-close dispose callback queuing a main-window open would
-        // leave behind mid-frame.
-        APP_RUNTIME.with(|slot| {
-            let mut state = slot.borrow_mut();
-            // Register the main window's mapping the same way a real install
-            // path would -- required for `teardown_platform_realm`'s own
-            // read-back assertion to hold once this realm tears down below.
-            state.registry.register_window(&main_window, main_address);
-            state.iterating_all_realms = true;
-            let deferred_uninstall =
-                state.request_realm_mutation(RealmMapMutation::Uninstall(splash_id));
-            assert!(
-                deferred_uninstall.is_none(),
-                "an Uninstall requested while a visit is in flight must defer, not apply \
-                 immediately"
+        let main_id = main_realm.realm_id();
+        let mut main_realm = Some(main_realm);
+
+        for_each_installed_realm(|realm| {
+            assert_eq!(
+                realm.realm_id(),
+                splash_id,
+                "only the splash realm is resident at visit time"
             );
-            let deferred_install = state.request_realm_mutation(RealmMapMutation::Install(
-                main_address.realm_id,
-                Box::new(RealmSlot {
-                    realm: Some(main_realm),
-                    queue: VecDeque::new(),
-                    draining: false,
-                    address: main_address,
-                    surface_applier: None,
-                }),
-            ));
-            assert!(
-                deferred_install.is_none(),
-                "an Install requested while a visit is in flight must defer, not apply \
-                 immediately"
+            uninstall_platform_realm(splash_id);
+            let installed = install_realm_alongside(
+                main_realm.take().expect("visited exactly once"),
+                &main_window,
             );
-            state.iterating_all_realms = false;
+            assert!(
+                installed.is_ok(),
+                "install_realm_alongside must defer mid-visit, not fail"
+            );
+
+            // Mid-visit: both requests just made are still queued (deferred
+            // by `iterating_all_realms`), so the splash realm's own slot is
+            // still resident (only marked for pending removal) and
+            // `should_exit` must not report exit.
+            let (exit, removed) = APP_RUNTIME.with(|slot| {
+                slot.borrow_mut()
+                    .should_exit(ExitPolicy::OnLastWindowClosed)
+            });
+            drop(removed);
+            assert!(
+                !exit,
+                "should_exit must not report exit while this visit is still in flight"
+            );
         });
+
+        // Both deferred mutations land once the whole visit completes (its
+        // own tail drain).
+        assert!(
+            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&splash_id).is_none()),
+            "the deferred splash uninstall must have applied once the visit completed"
+        );
+        assert!(
+            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&main_id).is_some()),
+            "the deferred main-window install must have applied once the visit completed"
+        );
 
         let should_exit = APP_RUNTIME.with(|slot| {
             let (exit, removed) = slot
@@ -2860,16 +2961,8 @@ mod realm_dispatch_tests {
         });
         assert!(
             !should_exit,
-            "the drain-before-decide rule: a queued open-main install must veto exit \
-             even though the splash realm's own uninstall is queued in the same batch"
-        );
-        assert!(
-            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&main_address.realm_id).is_some()),
-            "should_exit must have applied the queued install before deciding"
-        );
-        assert!(
-            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&splash_id).is_none()),
-            "should_exit must also have applied the queued splash uninstall"
+            "the drain-before-decide rule: closing the splash and installing the main realm in \
+             the same pass must never exit the loop -- the surviving main realm keeps it alive"
         );
 
         teardown_platform_realm();
@@ -2892,51 +2985,26 @@ mod realm_dispatch_tests {
             install_platform_realm(super::super::ui_realm::UiRealm::for_test(), &window_a);
 
         let second_realm = super::super::ui_realm::UiRealm::for_test();
-        let second_address = flui_foundation::PresentationAddress {
-            realm_id: second_realm.realm_id(),
-            presentation_id: second_realm.presentation_id(),
-        };
-        let second_slot = RealmSlot {
-            realm: Some(second_realm),
-            queue: VecDeque::new(),
-            draining: false,
-            address: second_address,
-            surface_applier: None,
-        };
-        // Register the second window's mapping the same way a real install
-        // path would -- required for `teardown_platform_realm`'s own
-        // read-back assertion to hold once this realm tears down at the end
-        // of this test.
+        let second_realm_id = second_realm.realm_id();
         let second_window = platform
             .open_window(flui_platform::WindowOptions::default())
             .expect("headless platform should create the second window");
-        APP_RUNTIME.with(|slot| {
-            slot.borrow_mut()
-                .registry
-                .register_window(&second_window, second_address);
-        });
+        let mut second_realm = Some(second_realm);
 
         dispatch_platform_realm(
             dispatcher_a,
             RealmTask::Frame(Box::new(move |_realm| {
-                let deferred = APP_RUNTIME.with(|slot| {
-                    slot.borrow_mut()
-                        .request_realm_mutation(RealmMapMutation::Install(
-                            second_address.realm_id,
-                            Box::new(second_slot),
-                        ))
-                });
-                assert!(
-                    deferred.is_none(),
-                    "an Install requested mid-dispatch must defer (return None), never apply \
-                     immediately"
+                let installed = install_realm_alongside(
+                    second_realm.take().expect("dispatched exactly once"),
+                    &second_window,
                 );
                 assert!(
-                    APP_RUNTIME.with(|slot| slot
-                        .borrow()
-                        .realms
-                        .get(&second_address.realm_id)
-                        .is_none()),
+                    installed.is_ok(),
+                    "install_realm_alongside must defer mid-dispatch (Ok, not yet visible), \
+                     never fail"
+                );
+                assert!(
+                    APP_RUNTIME.with(|slot| slot.borrow().realms.get(&second_realm_id).is_none()),
                     "the second realm must not be visible in the registry while realm A is \
                      still checked out for dispatch"
                 );
@@ -2945,7 +3013,7 @@ mod realm_dispatch_tests {
         .expect("A's frame callback dispatches");
 
         assert!(
-            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&second_address.realm_id).is_some()),
+            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&second_realm_id).is_some()),
             "the deferred install must land once realm A's own dispatch restores"
         );
 
@@ -2994,6 +3062,88 @@ mod realm_dispatch_tests {
         teardown_platform_realm();
     }
 
+    /// `should_exit` called from mid-visit must not drain a mutation the
+    /// SAME visit just deferred. Before this guard existed,
+    /// `drain_pending_realm_mutations` drained unconditionally, so this call
+    /// would have applied the visited realm's own queued self-uninstall
+    /// immediately -- removing its slot from the registry while its
+    /// `UiRealm` is still checked out here, held by `for_each_installed_realm`'s
+    /// loop, about to be restored into a slot that would no longer exist.
+    #[test]
+    fn should_exit_mid_visit_does_not_prematurely_drain_the_visited_realms_own_pending_uninstall() {
+        let dispatcher = install_test_realm();
+        let realm_id = dispatcher.address.realm_id;
+
+        for_each_installed_realm(|realm| {
+            assert_eq!(
+                realm.realm_id(),
+                realm_id,
+                "the sole installed realm is the one visited"
+            );
+            uninstall_platform_realm(realm_id);
+
+            let (exit, removed) = APP_RUNTIME.with(|slot| {
+                slot.borrow_mut()
+                    .should_exit(ExitPolicy::OnLastWindowClosed)
+            });
+            drop(removed);
+            assert!(
+                !exit,
+                "the registry is not empty: this realm's slot is still resident here, only its \
+                 checked-out UiRealm is held externally by this visit"
+            );
+            assert!(
+                APP_RUNTIME.with(|slot| slot.borrow().realms.get(&realm_id).is_some()),
+                "should_exit called mid-visit must not drain a mutation the SAME visit just \
+                 deferred -- draining it now would remove this realm's slot while its UiRealm \
+                 is still checked out here, and the visit's own restore step would then \
+                 silently drop it instead of the queued uninstall ever running its own \
+                 registry cleanup"
+            );
+        });
+
+        assert!(
+            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&realm_id).is_none()),
+            "the deferred uninstall must still apply once the whole visit completes"
+        );
+
+        teardown_platform_realm();
+    }
+
+    /// A panicking visitor (e.g. hot-restart's reassemble running arbitrary
+    /// user build code) must not permanently strand the checked-out realm
+    /// at `realm: None`, nor wedge `iterating_all_realms` at `true` forever
+    /// -- both of which would (after the fix above) silently defer every
+    /// future realm-map mutation request for the rest of the process.
+    #[test]
+    fn panicking_visit_restores_the_checked_out_realm_and_clears_iterating_all_realms() {
+        let dispatcher = install_test_realm();
+
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            for_each_installed_realm(|_realm| {
+                panic!("simulated visitor panic");
+            });
+        }));
+        assert!(
+            panic.is_err(),
+            "the visitor's panic must propagate out of for_each_installed_realm, not be \
+             swallowed"
+        );
+
+        assert!(
+            APP_RUNTIME.with(|slot| !slot.borrow().iterating_all_realms),
+            "a panicking visit must clear iterating_all_realms before its own panic resumes -- \
+             otherwise every future realm-map mutation request would defer forever"
+        );
+
+        dispatch_platform_realm(dispatcher, RealmTask::Frame(Box::new(|_| {}))).expect(
+            "the realm must still be dispatchable after a panicking visit -- its slot \
+                     was restored, not permanently stranded at realm: None",
+        );
+
+        teardown_platform_realm();
+    }
+
     /// Fence-(c) two-realm probe: with realm A mid-frame-transaction and a
     /// SECOND, fully idle realm B also resident, `with_owner_platform`'s
     /// debug_assert must still trip. A two-realm registry is not an "OR of
@@ -3017,18 +3167,30 @@ mod realm_dispatch_tests {
         // silently displace realm A's window mapping the moment realm B's
         // window registers.
         let platform = headless_platform();
-        let window_a = platform
-            .open_window(flui_platform::WindowOptions::default())
-            .expect("headless platform should create window a");
-        let dispatcher_a =
-            install_platform_realm(super::super::ui_realm::UiRealm::for_test(), &window_a);
+        // The IDLE sibling installs FIRST (`install_platform_realm`, this
+        // test's legacy-primary slot), the mid-transaction realm SECOND
+        // (`install_realm_alongside`) -- deliberately the opposite of mount
+        // order elsewhere in this file. `installed_realm_phase` falls back to
+        // `phases.first()` when nothing scans as forbidden; installing the
+        // idle realm first means that fallback alone would return `Idle` and
+        // this test would pass FALSELY (the debug_assert would never trip,
+        // failing `#[should_panic]`) if the `.find(is_frame_transaction_phase)`
+        // scan were ever deleted. Only the real scan, checking every
+        // resident slot rather than assuming the first one is representative,
+        // makes this test kill that mutant.
         let window_b = platform
             .open_window(flui_platform::WindowOptions::default())
             .expect("headless platform should create window b");
         // Realm B is installed and then never touched again for the rest of
         // this test -- it stays resident and Idle throughout.
         let _dispatcher_b =
-            install_realm_alongside(super::super::ui_realm::UiRealm::for_test(), &window_b);
+            install_platform_realm(super::super::ui_realm::UiRealm::for_test(), &window_b);
+        let window_a = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window a");
+        let dispatcher_a =
+            install_realm_alongside(super::super::ui_realm::UiRealm::for_test(), &window_a)
+                .expect("realm A installs alongside the idle realm B cleanly");
 
         let scheduler_a = APP_RUNTIME.with(|slot| {
             slot.borrow()

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -8,15 +8,29 @@ use flui_view::{StatelessView, View};
 use super::AppConfig;
 
 #[cfg(not(target_os = "ios"))]
+use std::collections::VecDeque;
+#[cfg(not(target_os = "ios"))]
 use std::sync::Arc;
 #[cfg(not(target_os = "ios"))]
 use std::sync::atomic::AtomicBool;
 
 #[cfg(not(target_os = "ios"))]
+use flui_foundation::RealmId;
+#[cfg(not(target_os = "ios"))]
 use flui_scheduler::AppLifecycleState;
 
 #[cfg(not(target_os = "ios"))]
-use super::runtime::AppRuntime;
+#[cfg_attr(
+    not(test),
+    expect(
+        unused_imports,
+        reason = "ExitPolicy is exercised by this module's own tests only until a future \
+                  embedder wires it through AppConfig (issue #555's native-lifecycle slice)"
+    )
+)]
+use super::runtime::ExitPolicy;
+#[cfg(not(target_os = "ios"))]
+use super::runtime::{AppRuntime, RealmMapMutation, RealmSlot};
 
 /// A fresh clone of the loop-scoped platform wake capability — see
 /// `AppRuntime::frame_wake_callback`'s doc. `APP_RUNTIME` must not be
@@ -301,30 +315,38 @@ impl Drop for OwnerHostClearGuard {
 }
 
 /// A registration-lifetime renderer-surface applier: `FnMut(size,
-/// scale_factor)`. Named so [`AppRuntime`]'s `surface_applier` field
+/// scale_factor)`. Named so [`RealmSlot`]'s `surface_applier` field
 /// declaration reads plainly instead of spelling out the boxed closure type
-/// inline. `pub(super)` (rather than private) so [`AppRuntime`]'s struct
+/// inline. `pub(super)` (rather than private) so [`RealmSlot`]'s struct
 /// definition in the sibling `runtime` module can name this type.
 #[cfg(not(target_os = "ios"))]
 pub(super) type SurfaceApplier =
     Box<dyn FnMut(flui_types::Size<flui_types::geometry::Pixels>, f32)>;
 
-/// Restores a taken [`SurfaceApplier`] back into [`APP_RUNTIME`]'s slot when
-/// dropped — including during an unwinding drop, so a panic inside the
-/// applier's own call (caught by `dispatch_platform_realm`'s outer
-/// `catch_unwind`) cannot permanently strand resizing. Without this, the
-/// applier taken out before the call is simply never restored once the call
-/// panics, and every later `Resized` event finds the slot empty forever,
-/// silently coalescing at the `None` arm's trace instead of ever applying
-/// again.
+/// Restores a taken [`SurfaceApplier`] back into its realm's slot in
+/// [`APP_RUNTIME`]'s registry when dropped — including during an unwinding
+/// drop, so a panic inside the applier's own call (caught by
+/// `dispatch_platform_realm`'s outer `catch_unwind`) cannot permanently
+/// strand resizing. Without this, the applier taken out before the call is
+/// simply never restored once the call panics, and every later `Resized`
+/// event for that realm finds the slot empty forever, silently coalescing at
+/// the `None` arm's trace instead of ever applying again.
+///
+/// Addressed by [`RealmId`] (not the old bare `Option`): if the realm was
+/// torn down while the applier's own call was still running, restoring into
+/// a now-missing slot is a silent no-op, matching this file's existing "the
+/// realm may be gone by the time a destructor runs" discipline.
 #[cfg(not(target_os = "ios"))]
 #[must_use = "dropping this immediately restores the applier with no call in between"]
-struct SurfaceApplierRestoreGuard(Option<SurfaceApplier>);
+struct SurfaceApplierRestoreGuard {
+    realm_id: RealmId,
+    applier: Option<SurfaceApplier>,
+}
 
 #[cfg(not(target_os = "ios"))]
 impl SurfaceApplierRestoreGuard {
     fn call(&mut self, size: flui_types::Size<flui_types::geometry::Pixels>, scale_factor: f32) {
-        if let Some(applier) = self.0.as_mut() {
+        if let Some(applier) = self.applier.as_mut() {
             applier(size, scale_factor);
         }
     }
@@ -333,9 +355,12 @@ impl SurfaceApplierRestoreGuard {
 #[cfg(not(target_os = "ios"))]
 impl Drop for SurfaceApplierRestoreGuard {
     fn drop(&mut self) {
-        if let Some(applier) = self.0.take() {
+        if let Some(applier) = self.applier.take() {
+            let realm_id = self.realm_id;
             APP_RUNTIME.with(|slot| {
-                slot.borrow_mut().surface_applier = Some(applier);
+                if let Some(realm_slot) = slot.borrow_mut().realms.get_mut(&realm_id) {
+                    realm_slot.surface_applier = Some(applier);
+                }
             });
         }
     }
@@ -366,6 +391,16 @@ enum RealmDispatchError {
     /// variant now: the design-for-N contract, not dead code.
     StalePresentation,
     RealmUnavailable,
+    /// Rejected because a DIFFERENT realm is currently checked out for
+    /// dispatch on this thread (issue #555): dispatch is single-threaded
+    /// and sequential, so a nested dispatch that targets a realm other than
+    /// the one already checked out is always a bug, never a legitimate
+    /// concurrent-realm scenario — reachable only if something bypasses the
+    /// defer-to-idle discipline [`super::runtime::AppRuntime::request_realm_mutation`]
+    /// exists to make unnecessary. A `debug_assert!` at the same call site
+    /// makes this loud in debug builds; this variant is the release-mode
+    /// fallback that still refuses instead of silently nesting.
+    NestedCrossRealmDispatchRejected,
 }
 
 /// Typed, closed cross-thread payload (ADR-0037 §3): every routable
@@ -439,16 +474,22 @@ impl PlatformToUi {
         match self {
             Self::Input(input) => realm.handle_input_entered(input),
             Self::Resized { size, scale_factor } => {
-                // Take the applier out of the TLS slot, release the borrow,
-                // call it, then restore it — never call through a live
-                // borrow, so a reentrant TLS access from inside the applier
-                // (e.g. a nested dispatch enqueuing further work) cannot hit
-                // an already-mutably-borrowed `RefCell` panic. If the slot is
-                // ever found empty here (no applier installed yet, or
-                // already cleared by teardown) this skips with a trace
-                // instead of unwrapping/panicking; surface application then
-                // coalesces onto the next real applier install.
-                let applier = APP_RUNTIME.with(|slot| slot.borrow_mut().surface_applier.take());
+                // Take the applier out of THIS realm's slot, release the
+                // borrow, call it, then restore it — never call through a
+                // live borrow, so a reentrant TLS access from inside the
+                // applier (e.g. a nested dispatch enqueuing further work)
+                // cannot hit an already-mutably-borrowed `RefCell` panic. If
+                // the slot is ever found empty here (no applier installed
+                // yet, or already cleared by teardown) this skips with a
+                // trace instead of unwrapping/panicking; surface application
+                // then coalesces onto the next real applier install.
+                let realm_id = realm.realm_id();
+                let applier = APP_RUNTIME.with(|slot| {
+                    slot.borrow_mut()
+                        .realms
+                        .get_mut(&realm_id)
+                        .and_then(|realm_slot| realm_slot.surface_applier.take())
+                });
                 match applier {
                     Some(applier) => {
                         // The guard restores the applier on drop
@@ -456,7 +497,10 @@ impl PlatformToUi {
                         // panics and the drop runs during unwind — so a
                         // caught panic in the applier never permanently
                         // strands resizing.
-                        let mut guard = SurfaceApplierRestoreGuard(Some(applier));
+                        let mut guard = SurfaceApplierRestoreGuard {
+                            realm_id,
+                            applier: Some(applier),
+                        };
                         guard.call(size, scale_factor);
                     }
                     None => {
@@ -495,17 +539,20 @@ impl PlatformToUi {
     }
 }
 
-/// Installs `applier` as the registration-lifetime renderer-surface
-/// applier for the current realm host, replacing (never stacking) any
-/// previously-installed one. Call once per realm install, alongside
-/// [`install_platform_realm`], from each backend's bootstrap — never from
-/// inside a frame/event dispatch.
+/// Installs `applier` as `realm_id`'s registration-lifetime renderer-surface
+/// applier, replacing (never stacking) any previously-installed one for that
+/// SAME realm — a sibling realm's own applier is untouched. Call once per
+/// realm install, alongside [`install_platform_realm`], from each backend's
+/// bootstrap — never from inside a frame/event dispatch.
 #[cfg(not(target_os = "ios"))]
 fn install_surface_applier(
+    realm_id: RealmId,
     applier: impl FnMut(flui_types::Size<flui_types::geometry::Pixels>, f32) + 'static,
 ) {
     APP_RUNTIME.with(|slot| {
-        slot.borrow_mut().surface_applier = Some(Box::new(applier));
+        if let Some(realm_slot) = slot.borrow_mut().realms.get_mut(&realm_id) {
+            realm_slot.surface_applier = Some(Box::new(applier));
+        }
     });
 }
 
@@ -1132,11 +1179,21 @@ mod lifecycle_derivation_tests {
     }
 }
 
-/// Installs `realm`, minting its dispatcher's address by registering
-/// `window` in the single [`super::window_registry::WindowRegistry`]
-/// authority — the registry is the sole mint path for a routable
-/// [`flui_foundation::PresentationAddress`]; no caller of this function ever
-/// names the platform-internal native-handle key type itself.
+/// Installs `realm` as the SOLE hosted realm on this thread, minting its
+/// dispatcher's address by registering `window` in the single
+/// [`super::window_registry::WindowRegistry`] authority — the registry is
+/// the sole mint path for a routable [`flui_foundation::PresentationAddress`];
+/// no caller of this function ever names the platform-internal native-handle
+/// key type itself.
+///
+/// This is the legacy single-primary-realm entry point every backend's
+/// bootstrap still calls exactly once: it clears the ENTIRE realm registry
+/// (every hosted realm, not only one) before inserting the fresh one —
+/// exactly the behavior the single `Option<UiRealm>` slot this registry
+/// replaces used to have, since that slot could only ever hold one realm at
+/// all. A second, non-displacing realm (a genuinely independent window
+/// alongside this one) is installed through
+/// [`install_realm_alongside`] instead.
 #[cfg(not(target_os = "ios"))]
 fn install_platform_realm(
     realm: super::ui_realm::UiRealm,
@@ -1147,54 +1204,53 @@ fn install_platform_realm(
         realm_id: realm.realm_id(),
         presentation_id: realm.presentation_id(),
     };
-    let (displaced_realm, displaced_queue, displaced_applier) = APP_RUNTIME.with(|slot| {
+    let displaced = APP_RUNTIME.with(|slot| {
         let mut state = slot.borrow_mut();
-        // A realm may already be installed here — a reinstall without an
-        // intervening `teardown_platform_realm` (the panic-recovery path: a
-        // mid-`on_ready` failure leaves the old realm/queue/applier/registry
-        // mappings in place, and bootstrap tries again on the same thread).
-        // Remove every registry mapping addressed to the DISPLACED realm —
-        // not just the window being installed now — in this same borrow,
-        // before registering the new window: otherwise the displaced
-        // realm's own window(s) survive as dead entries no later teardown
-        // ever reaches (teardown only ever removes the realm that is
-        // *currently* installed).
-        let previous_address = state.address;
+        // Every realm hosted here may already be installed — a reinstall
+        // without an intervening `teardown_platform_realm` (the
+        // panic-recovery path: a mid-`on_ready` failure leaves the old
+        // registry/queue/applier/window-registry mappings in place, and
+        // bootstrap tries again on the same thread). Remove every registry
+        // mapping addressed to EACH displaced realm — not just the window
+        // being installed now — in this same borrow, before registering the
+        // new window: otherwise a displaced realm's own window(s) survive as
+        // dead entries no later teardown ever reaches (this legacy entry
+        // point is the only one that clears the whole registry at once).
         let mut removed_window_mappings = 0;
-        if let Some(previous_address) = previous_address {
-            removed_window_mappings = state.registry.remove_realm(previous_address.realm_id).len();
+        let displaced = state.realms.clear();
+        for (displaced_id, _) in &displaced {
+            removed_window_mappings += state.registry.remove_realm(*displaced_id).len();
         }
         state.registry.register_window(window, address);
 
-        // Mirror `teardown_platform_realm`'s discipline exactly: `mem::take`
-        // the displaced realm, its queue, and its surface applier out from
-        // under this borrow — never let an assignment drop them while the
-        // borrow is still live, and never leave stale-incarnation events
-        // sitting in the queue to be delivered FIFO-first into the new
-        // realm on its first dispatch.
-        let displaced_realm = state.realm.take();
-        let displaced_queue = std::mem::take(&mut state.queue);
-        let displaced_applier = state.surface_applier.take();
-        if displaced_realm.is_some() {
+        if !displaced.is_empty() {
             tracing::warn!(
-                previous_address = ?previous_address,
+                displaced_realms = displaced.len(),
                 new_address = ?address,
-                queued_events_discarded = displaced_queue.len(),
                 removed_window_mappings,
-                "install_platform_realm: replacing a realm that was never torn down"
+                "install_platform_realm: replacing realm(s) that were never torn down"
             );
         }
-        state.realm = Some(realm);
+        state.realms.insert(
+            address.realm_id,
+            RealmSlot {
+                realm: Some(realm),
+                queue: VecDeque::new(),
+                draining: false,
+                address,
+                surface_applier: None,
+            },
+        );
         state.owner_thread = Some(owner_thread);
-        state.address = Some(address);
-        state.draining = false;
         // Defensive: a reinstall-without-teardown only reaches this path
-        // when the displaced incarnation's own dispatch never restored
-        // `realm` (the panic-recovery scenario this function's doc already
-        // documents) — `dispatched_scheduler`, if the displaced incarnation
-        // left one stashed, belongs to that dead incarnation and must not
-        // leak into the fresh one's fence-(c) reads.
+        // when the displaced incarnation's own dispatch never restored its
+        // slot's `realm` (the panic-recovery scenario this function's doc
+        // already documents) — `dispatched_scheduler`/`dispatched_realm_id`,
+        // if the displaced incarnation left either stashed, belong to that
+        // dead incarnation and must not leak into the fresh one's fence-(c)
+        // reads.
         state.dispatched_scheduler = None;
+        state.dispatched_realm_id = None;
         // A second realm installed on this thread (hot-restart, or a
         // sequential test realm) must not inherit whatever `(visible,
         // focused)` the PREVIOUS realm's window last reported — every
@@ -1212,18 +1268,105 @@ fn install_platform_realm(
         // it does not matter whether a prior realm on this thread already
         // triggered it.
         let _ = state.ensure_services();
-        (displaced_realm, displaced_queue, displaced_applier)
+        displaced
     });
     // Destructors may re-enter platform/framework code (the same invariant
     // `teardown_platform_realm` honors) — drop only after the TLS borrow
     // above has released.
-    drop(displaced_queue);
-    drop(displaced_realm);
-    drop(displaced_applier);
+    drop(displaced);
     RealmDispatcher {
         owner_thread,
         address,
     }
+}
+
+/// Installs `realm` ALONGSIDE whatever is already hosted, never displacing a
+/// sibling — the multi-realm counterpart to [`install_platform_realm`]'s
+/// legacy single-primary-realm replace semantics. Registers `window` the
+/// same way, then requests the registry insertion through
+/// [`super::runtime::AppRuntime::request_realm_mutation`], so an install
+/// requested while another realm is checked out for dispatch (a frame
+/// callback opening a second window) defers to loop idle instead of
+/// installing mid-dispatch.
+///
+/// No production embedder call site yet: today's bootstrap
+/// (`run_desktop`/`run_android`/`run_web`) still only ever opens one window
+/// through `install_platform_realm`. This is the multi-realm mechanism
+/// (issue #555); wiring a real second-window embedder entry point
+/// through it is a follow-up (tracked as this issue's native-lifecycle
+/// slice). Exercised directly by this module's own tests in the meantime.
+#[cfg(not(target_os = "ios"))]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "design-for-N install path; no production embedder entry point opens a \
+                  second window yet -- exercised by this module's own tests"
+    )
+)]
+fn install_realm_alongside(
+    realm: super::ui_realm::UiRealm,
+    window: &std::sync::Arc<dyn flui_platform::traits::PlatformWindow>,
+) -> RealmDispatcher {
+    let owner_thread = std::thread::current().id();
+    let address = flui_foundation::PresentationAddress {
+        realm_id: realm.realm_id(),
+        presentation_id: realm.presentation_id(),
+    };
+    APP_RUNTIME.with(|slot| {
+        let mut state = slot.borrow_mut();
+        state.registry.register_window(window, address);
+        state.owner_thread.get_or_insert(owner_thread);
+        let _ = state.ensure_services();
+        let displaced = state.request_realm_mutation(RealmMapMutation::Install(
+            address.realm_id,
+            Box::new(RealmSlot {
+                realm: Some(realm),
+                queue: VecDeque::new(),
+                draining: false,
+                address,
+                surface_applier: None,
+            }),
+        ));
+        debug_assert!(
+            displaced.is_none(),
+            "BUG: an Install mutation can never itself return a displaced slot"
+        );
+    });
+    RealmDispatcher {
+        owner_thread,
+        address,
+    }
+}
+
+/// Uninstalls exactly one realm — a single window closing while siblings
+/// stay open — without disturbing any other hosted realm. Requests the
+/// removal through [`super::runtime::AppRuntime::request_realm_mutation`],
+/// so a request arriving mid-dispatch or mid-hot-restart-visit defers to
+/// loop idle instead of mutating the registry another operation is still
+/// walking.
+///
+/// No production embedder call site yet — no backend currently detects a
+/// single window closing among several (that needs the hop-1/hop-2 routing
+/// this issue's later slices add); exercised directly by this module's own
+/// tests in the meantime.
+#[cfg(not(target_os = "ios"))]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "design-for-N uninstall path; no production embedder call site detects a \
+                  single window closing among several yet -- exercised by this module's own tests"
+    )
+)]
+fn uninstall_platform_realm(realm_id: RealmId) {
+    let removed = APP_RUNTIME.with(|slot| {
+        slot.borrow_mut()
+            .request_realm_mutation(RealmMapMutation::Uninstall(realm_id))
+    });
+    // Destructors may re-enter platform/framework code — drop only after the
+    // TLS borrow above has released.
+    drop(removed);
 }
 
 #[cfg(not(target_os = "ios"))]
@@ -1235,7 +1378,8 @@ fn dispatch_platform_realm(
         tracing::error!(?dispatcher, "rejecting realm callback on non-owner thread");
         return Err(RealmDispatchError::WrongThread);
     }
-    let realm = APP_RUNTIME.with(|slot| {
+    let realm_id = dispatcher.address.realm_id;
+    let checked_out = APP_RUNTIME.with(|slot| {
         let mut state = slot.borrow_mut();
         // Normative compare order (ADR-0037): realm first, then
         // presentation. `realm_id`/`presentation_id` mint from one shared
@@ -1244,55 +1388,79 @@ fn dispatch_platform_realm(
         // reachable only when the realm half matches but the presentation
         // half does not (a forged/mixed address today; real presentation
         // replacement within a live realm once a forest exists).
-        match state.address {
-            None => {
-                tracing::debug!(
-                    ?dispatcher,
-                    "dropping realm callback: no realm installed (not yet ready, or already torn down)"
-                );
-                return Err(RealmDispatchError::RealmUnavailable);
-            }
-            Some(current) if current.realm_id != dispatcher.address.realm_id => {
-                tracing::debug!(
-                    ?dispatcher,
-                    current_realm_id = ?current.realm_id,
-                    "dropping realm callback: a newer realm replaced the one it was dispatched for"
-                );
-                return Err(RealmDispatchError::StaleRealm);
-            }
-            Some(current) if current.presentation_id != dispatcher.address.presentation_id => {
-                tracing::debug!(
-                    ?dispatcher,
-                    current_address = ?current,
-                    "dropping realm callback: presentation incarnation mismatch within the live realm"
-                );
-                return Err(RealmDispatchError::StalePresentation);
-            }
-            Some(_) => {}
+        if state.realms.is_empty() {
+            tracing::debug!(
+                ?dispatcher,
+                "dropping realm callback: no realm installed (not yet ready, or already torn down)"
+            );
+            return Err(RealmDispatchError::RealmUnavailable);
         }
-        state.queue.push_back(event);
-        if state.draining || state.realm.is_none() {
+        let Some(realm_slot) = state.realms.get_mut(&realm_id) else {
+            tracing::debug!(
+                ?dispatcher,
+                "dropping realm callback: a newer realm replaced the one it was dispatched for"
+            );
+            return Err(RealmDispatchError::StaleRealm);
+        };
+        if realm_slot.address.presentation_id != dispatcher.address.presentation_id {
+            tracing::debug!(
+                ?dispatcher,
+                current_address = ?realm_slot.address,
+                "dropping realm callback: presentation incarnation mismatch within the live realm"
+            );
+            return Err(RealmDispatchError::StalePresentation);
+        }
+        realm_slot.queue.push_back(event);
+        if realm_slot.draining || realm_slot.realm.is_none() {
             return Ok(None);
         }
-        let first = state
+        // Nested cross-realm dispatch guard (issue #555): reaching here
+        // means THIS realm is neither draining nor checked out (both ruled
+        // out just above), so a `dispatched_realm_id` naming a DIFFERENT
+        // realm can only mean a nested dispatch was attempted while that
+        // other realm's task is still running on this same thread — the one
+        // case `request_realm_mutation`'s defer-to-idle discipline exists to
+        // make structurally unreachable in production. Caught loudly in
+        // debug builds; release builds still refuse rather than nest.
+        if let Some(dispatched_realm_id) = state.dispatched_realm_id {
+            debug_assert!(
+                false,
+                "BUG: nested cross-realm dispatch: realm {realm_id:?} dispatched while realm \
+                 {dispatched_realm_id:?} is still checked out on this thread -- installs/\
+                 uninstalls must defer to loop idle instead of nesting"
+            );
+            tracing::error!(
+                ?realm_id,
+                ?dispatched_realm_id,
+                "rejecting nested cross-realm dispatch"
+            );
+            return Err(RealmDispatchError::NestedCrossRealmDispatchRejected);
+        }
+        let realm_slot = state
+            .realms
+            .get_mut(&realm_id)
+            .expect("BUG: presence checked above");
+        let first = realm_slot
             .queue
             .pop_front()
             .expect("BUG: event was enqueued before starting realm dispatch");
-        state.draining = true;
-        let realm = state.realm.take();
-        // Stash a clone of the checked-out realm's scheduler BEFORE it leaves
-        // this slot: `installed_realm_phase` (with_owner_platform's fence
-        // (c)) reads `dispatched_scheduler` as its fallback whenever `realm`
-        // itself is empty, which is exactly the state this call is about to
-        // create for the entire duration of the dispatched task below —
-        // otherwise the fence goes blind for every real production frame,
-        // not merely when no realm is installed at all. `Scheduler::clone`
-        // is one `Arc::clone` (see `flui-scheduler`'s single-`Arc` handle
-        // shape), not a second scheduler.
+        realm_slot.draining = true;
+        let realm = realm_slot.realm.take();
+        // Stash a clone of the checked-out realm's scheduler (and its
+        // identity) BEFORE it leaves this slot: `installed_realm_phase`
+        // (with_owner_platform's fence (c)) reads `dispatched_scheduler` as
+        // its fallback whenever no OTHER realm's dispatch is in flight, which
+        // is exactly the state this call is about to create for the entire
+        // duration of the dispatched task below — otherwise the fence goes
+        // blind for every real production frame, not merely when no realm is
+        // installed at all. `Scheduler::clone` is one `Arc::clone` (see
+        // `flui-scheduler`'s single-`Arc` handle shape), not a second
+        // scheduler.
         state.dispatched_scheduler = realm.as_ref().map(|realm| realm.scheduler().clone());
+        state.dispatched_realm_id = Some(realm_id);
         Ok(realm.map(|realm| (realm, first)))
     })?;
-    let Some((realm, first)) = realm else {
+    let Some((realm, first)) = checked_out else {
         return Ok(());
     };
 
@@ -1302,24 +1470,113 @@ fn dispatch_platform_realm(
         let mut next = Some(first);
         while let Some(event) = next {
             realm.enter(|realm| event.run(realm));
-            next = APP_RUNTIME.with(|slot| slot.borrow_mut().queue.pop_front());
+            next = APP_RUNTIME.with(|slot| {
+                slot.borrow_mut()
+                    .realms
+                    .get_mut(&realm_id)
+                    .and_then(|realm_slot| realm_slot.queue.pop_front())
+            });
         }
     }));
-    APP_RUNTIME.with(|slot| {
+    let removed = APP_RUNTIME.with(|slot| {
         let mut state = slot.borrow_mut();
-        state.realm = Some(realm);
-        state.draining = false;
+        // The slot may be gone entirely if a NESTED, non-dispatch teardown
+        // (e.g. `teardown_platform_realm`'s full-registry clear, called
+        // reentrantly from inside the just-run task) already removed it —
+        // that dropped this realm's queue/applier already, so there is
+        // nothing left to restore; just let `realm` fall out of scope below.
+        if let Some(realm_slot) = state.realms.get_mut(&realm_id) {
+            realm_slot.realm = Some(realm);
+            realm_slot.draining = false;
+        }
         // Cleared unconditionally in this same restore block, which runs
         // whether or not the dispatched task above panicked (the panic, if
         // any, is only resumed after this restore completes below) — the
         // fence-(c) fallback must not survive past the dispatch it was
         // stashed for.
         state.dispatched_scheduler = None;
+        state.dispatched_realm_id = None;
+        // Applies any realm-map mutation this realm's own task requested
+        // (e.g. a dispose callback uninstalling itself, or a frame callback
+        // installing a second realm) — deferred above precisely because
+        // `dispatched_realm_id` was `Some` for the whole task, and safe to
+        // apply now that it is cleared.
+        state.drain_pending_realm_mutations()
     });
+    // Destructors may re-enter platform/framework code — drop only after the
+    // TLS borrow above has released.
+    drop(removed);
     if let Err(payload) = result {
         std::panic::resume_unwind(payload);
     }
     Ok(())
+}
+
+/// Hot-restart's own iteration primitive (issue #555): visits every
+/// currently-installed realm, in mount order, running `f` against each one
+/// OUTSIDE the `APP_RUNTIME` borrow — the same checkout/restore discipline
+/// [`dispatch_platform_realm`] uses for a single addressed realm — so `f` may
+/// safely call back into any `APP_RUNTIME`-touching function, including a
+/// realm-map install/uninstall request. Such a request, arriving while this
+/// visit is still in progress, defers rather than applies immediately
+/// ([`super::runtime::AppRuntime::request_realm_mutation`]'s own doc),
+/// applied only once every realm has been visited — so the set of realms
+/// visited never shifts mid-iteration.
+///
+/// No production driver calls this yet — hot-restart's real trigger (the
+/// `flui-hot-reload` file-watcher path) still only ever polls the single
+/// dispatched realm through its own frame callback; a driver that visits
+/// every hosted realm is this issue's follow-up. Exercised directly by this
+/// module's own tests in the meantime.
+#[cfg(not(target_os = "ios"))]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "design-for-N hot-restart iteration primitive; no production driver visits \
+                  every hosted realm yet -- exercised by this module's own tests"
+    )
+)]
+fn for_each_installed_realm(mut f: impl FnMut(&super::ui_realm::UiRealm)) {
+    let ids = APP_RUNTIME.with(|slot| {
+        let mut state = slot.borrow_mut();
+        debug_assert!(
+            !state.iterating_all_realms,
+            "BUG: reentrant for_each_installed_realm"
+        );
+        state.iterating_all_realms = true;
+        state.realms.keys()
+    });
+
+    for id in ids {
+        let realm = APP_RUNTIME.with(|slot| {
+            slot.borrow_mut()
+                .realms
+                .get_mut(&id)
+                .and_then(|realm_slot| realm_slot.realm.take())
+        });
+        let Some(realm) = realm else {
+            // Removed by an earlier realm's own visit before this iteration
+            // reached it -- unreachable under the defer-to-idle discipline
+            // (a mutation requested mid-visit only applies AFTER the whole
+            // visit completes), kept as a defensive skip rather than an
+            // `expect`.
+            continue;
+        };
+        f(&realm);
+        APP_RUNTIME.with(|slot| {
+            if let Some(realm_slot) = slot.borrow_mut().realms.get_mut(&id) {
+                realm_slot.realm = Some(realm);
+            }
+        });
+    }
+
+    let removed = APP_RUNTIME.with(|slot| {
+        let mut state = slot.borrow_mut();
+        state.iterating_all_realms = false;
+        state.drain_pending_realm_mutations()
+    });
+    drop(removed);
 }
 
 /// Drains the per-frame owner-inbox commands and reports whether the drain
@@ -1345,37 +1602,44 @@ fn drain_owner_inbox(realm: &super::ui_realm::UiRealm) -> bool {
 
 #[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
 fn teardown_platform_realm() {
-    let (realm, queued) = APP_RUNTIME.with(|slot| {
+    let realms = APP_RUNTIME.with(|slot| {
         let mut state = slot.borrow_mut();
         // Registry removal first (ADR-0037 §2): stop new routing before the
         // queued old-generation events below are dropped, and before the
-        // realm/address cache is cleared. The teardown real read: assert
-        // the removed entries include the address this realm installed —
-        // `remove_realm` removes every window mapped to this realm, not
-        // just the first, so a future one-realm-many-windows install still
-        // leaves nothing behind.
-        if let Some(address) = state.address {
-            let removed = state.registry.remove_realm(address.realm_id);
+        // registry is cleared. The teardown real read: assert the removed
+        // entries include the address EACH realm installed — `remove_realm`
+        // removes every window mapped to that realm, not just the first, so
+        // a one-realm-many-windows install still leaves nothing behind.
+        //
+        // Every hosted realm tears down here, not just one: this runs from
+        // `run_desktop`/`run_android` after their respective
+        // `platform.run(...)` returns, i.e. the WHOLE loop is exiting, so
+        // every realm this thread ever hosted goes with it.
+        let realms = state.realms.clear();
+        for (id, realm_slot) in &realms {
+            let removed = state.registry.remove_realm(*id);
             debug_assert!(
                 removed
                     .iter()
-                    .any(|(_, removed_address)| *removed_address == address),
+                    .any(|(_, removed_address)| *removed_address == realm_slot.address),
                 "BUG: window_registry teardown read did not include the installed address"
             );
         }
-        let realm = state.realm.take();
-        let queued = std::mem::take(&mut state.queue);
-        state.draining = false;
         state.owner_thread = None;
-        state.address = None;
-        state.surface_applier = None;
         state.dispatched_scheduler = None;
-        (realm, queued)
+        state.dispatched_realm_id = None;
+        state.iterating_all_realms = false;
+        debug_assert!(
+            !state.has_pending_realm_mutations(),
+            "BUG: realm-map mutations still pending at full loop-exit teardown -- \
+             dispatch_platform_realm and for_each_installed_realm must drain \
+             unconditionally in their own tails"
+        );
+        realms
     });
     // Destructors may re-enter platform/framework code. Drop only after the
     // TLS borrow and incarnation identity have been released.
-    drop(queued);
-    drop(realm);
+    drop(realms);
 
     // ADR-0034's install/teardown symmetry: the event loop has exited (this
     // runs from both `run_desktop` and `run_android`, after their respective
@@ -1512,13 +1776,19 @@ mod realm_dispatch_tests {
         // a realm that was mid-drain when the panic hit.
         APP_RUNTIME.with(|slot| {
             let mut state = slot.borrow_mut();
-            state.queue.push_back(RealmTask::Frame(Box::new(move |_| {
-                *delivered_in_event.borrow_mut() = true;
-            })));
-            state
+            let realm_slot = state
+                .realms
+                .get_mut(&dispatcher_a.address.realm_id)
+                .expect("dispatcher_a's realm is installed above");
+            realm_slot
+                .queue
+                .push_back(RealmTask::Frame(Box::new(move |_| {
+                    *delivered_in_event.borrow_mut() = true;
+                })));
+            realm_slot
                 .queue
                 .push_back(RealmTask::Frame(Box::new(move |_| drop(probe))));
-            state.draining = true;
+            realm_slot.draining = true;
         });
 
         // The panic-recovery reinstall itself: no teardown in between.
@@ -1724,14 +1994,9 @@ mod realm_dispatch_tests {
     #[test]
     fn late_event_never_crosses_realm_incarnations() {
         let stale = install_test_realm();
-        APP_RUNTIME.with(|slot| {
-            let mut state = slot.borrow_mut();
-            let realm = state.realm.take();
-            state.queue.clear();
-            state.address = None;
-            drop(state);
-            drop(realm);
-        });
+        let removed =
+            APP_RUNTIME.with(|slot| slot.borrow_mut().realms.remove(&stale.address.realm_id));
+        drop(removed);
         assert_eq!(
             dispatch_platform_realm(stale, RealmTask::Frame(Box::new(|_| {}))),
             Err(RealmDispatchError::RealmUnavailable)
@@ -1824,21 +2089,27 @@ mod realm_dispatch_tests {
     /// dropping it, and both assertions below fail.
     #[test]
     fn queued_events_for_a_removed_presentation_never_deliver() {
-        let _dispatcher = install_test_realm();
+        let dispatcher = install_test_realm();
         let delivered = Rc::new(RefCell::new(false));
         let delivered_in_event = Rc::clone(&delivered);
         let applier_invoked = Rc::new(RefCell::new(false));
         let applier_invoked_in_closure = Rc::clone(&applier_invoked);
-        install_surface_applier(move |_size, _scale_factor| {
+        install_surface_applier(dispatcher.address.realm_id, move |_size, _scale_factor| {
             *applier_invoked_in_closure.borrow_mut() = true;
         });
 
         APP_RUNTIME.with(|slot| {
             let mut state = slot.borrow_mut();
-            state.queue.push_back(RealmTask::Frame(Box::new(move |_| {
-                *delivered_in_event.borrow_mut() = true;
-            })));
-            state
+            let realm_slot = state
+                .realms
+                .get_mut(&dispatcher.address.realm_id)
+                .expect("just installed above");
+            realm_slot
+                .queue
+                .push_back(RealmTask::Frame(Box::new(move |_| {
+                    *delivered_in_event.borrow_mut() = true;
+                })));
+            realm_slot
                 .queue
                 .push_back(RealmTask::Event(PlatformToUi::Resized {
                     size: flui_types::Size::new(
@@ -1943,7 +2214,7 @@ mod realm_dispatch_tests {
         let dispatcher = install_test_realm();
         let calls = Rc::new(RefCell::new(0));
         let calls_in_closure = Rc::clone(&calls);
-        install_surface_applier(move |_size, _scale_factor| {
+        install_surface_applier(dispatcher.address.realm_id, move |_size, _scale_factor| {
             *calls_in_closure.borrow_mut() += 1;
             assert_ne!(
                 *calls_in_closure.borrow(),
@@ -1999,7 +2270,7 @@ mod realm_dispatch_tests {
         let order = Rc::new(RefCell::new(Vec::new()));
         let outer = Rc::clone(&order);
         let applier_calls = Rc::clone(&order);
-        install_surface_applier(move |_size, _scale_factor| {
+        install_surface_applier(dispatcher.address.realm_id, move |_size, _scale_factor| {
             applier_calls.borrow_mut().push(3);
         });
         dispatch_platform_realm(
@@ -2057,6 +2328,9 @@ mod realm_dispatch_tests {
         };
         APP_RUNTIME.with(|slot| {
             slot.borrow_mut()
+                .realms
+                .get_mut(&dispatcher.address.realm_id)
+                .expect("just installed above")
                 .queue
                 .push_back(RealmTask::Frame(Box::new(move |_| drop(probe))));
         });
@@ -2320,6 +2594,455 @@ mod realm_dispatch_tests {
         );
 
         teardown_platform_realm();
+    }
+
+    // ========================================================================
+    // Issue #555 red exploits: multi-realm `AppRuntime` hosting,
+    // separate-realms policy, exit policy, hot-restart.
+    //
+    // Every test below was structurally impossible to even set up before this
+    // change: `AppRuntime` had exactly one `Option<UiRealm>` slot, so a
+    // second `install_platform_realm`/`install_realm_alongside` call always
+    // displaced the first rather than coexisting with it. There was no red
+    // run to capture (the code to call did not exist), so "red" here means
+    // "would not compile / had no second-realm install path to call" rather
+    // than "compiled and failed an assertion" -- stated rather than
+    // fabricated.
+    // ========================================================================
+
+    /// Installs two coexisting realms, A (through the legacy displacing
+    /// `install_platform_realm`) and B (through `install_realm_alongside`,
+    /// non-displacing). Both windows come from ONE shared headless platform
+    /// instance, not two separate `test_window()` calls: `HeadlessPlatform`
+    /// mints window ids from an instance-local counter, so two windows from
+    /// two SEPARATE `headless_platform()` calls can alias the same id —
+    /// fatal for two realms meant to coexist, since `WindowRegistry::
+    /// register_window` REPLACES on a matching id, silently dropping realm
+    /// A's window mapping the moment realm B's aliased-id window installs.
+    fn install_two_test_realms() -> (RealmDispatcher, RealmDispatcher) {
+        let platform = flui_platform::headless_platform();
+        let window_a = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window a");
+        let window_b = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window b");
+        let dispatcher_a =
+            install_platform_realm(super::super::ui_realm::UiRealm::for_test(), &window_a);
+        let dispatcher_b =
+            install_realm_alongside(super::super::ui_realm::UiRealm::for_test(), &window_b);
+        (dispatcher_a, dispatcher_b)
+    }
+
+    /// Two realms hosted by the SAME `AppRuntime` share no gesture-arena
+    /// state: a pointer dispatched only to realm A must leave realm B's
+    /// arena completely untouched. Both realms are reached only through
+    /// `install_platform_realm`/`install_realm_alongside` and
+    /// `dispatch_platform_realm` here -- never a directly-held `UiRealm`
+    /// handle -- so this is the "through `AppRuntime`" half of the
+    /// end-state invariant; `ui_realm.rs`'s `two_realms_coexist_same_thread`
+    /// family already proves the same disjointness at the `UiRealm`
+    /// construction level.
+    #[test]
+    fn two_window_realms_share_no_ui_state_through_app_runtime() {
+        let (dispatcher_a, dispatcher_b) = install_two_test_realms();
+
+        assert_ne!(
+            dispatcher_a.address.realm_id, dispatcher_b.address.realm_id,
+            "AppRuntime must never host two live realms under the same identity"
+        );
+
+        dispatch_platform_realm(
+            dispatcher_a,
+            RealmTask::Frame(Box::new(|realm| {
+                let down = down_input(4.0);
+                if let PlatformInput::Pointer(event) = down {
+                    realm
+                        .gestures()
+                        .handle_pointer_event(&event, |_| HitTestResult::new());
+                }
+                assert_eq!(
+                    realm.gestures().active_pointer_count(),
+                    1,
+                    "realm A observes its own pointer"
+                );
+            })),
+        )
+        .expect("A dispatches");
+
+        dispatch_platform_realm(
+            dispatcher_b,
+            RealmTask::Frame(Box::new(|realm| {
+                assert_eq!(
+                    realm.gestures().active_pointer_count(),
+                    0,
+                    "realm B's gesture arena must be untouched by a pointer dispatched only \
+                     to realm A -- AppRuntime shares no mutable UI state between hosted realms"
+                );
+            })),
+        )
+        .expect("B dispatches independently of A");
+
+        teardown_platform_realm();
+    }
+
+    /// Realm A tearing itself down from WITHIN its own dispatched task must
+    /// not disturb sibling realm B's ability to keep dispatching and
+    /// producing (presenting) frames.
+    #[test]
+    fn teardown_realm_a_mid_dispatch_leaves_realm_b_frame_producing() {
+        use flui_widgets::SizedBox;
+
+        struct AlwaysPresentsBackend;
+        impl flui_engine::RasterBackend for AlwaysPresentsBackend {
+            fn render_scene(
+                &mut self,
+                _scene: &flui_layer::Scene,
+            ) -> Result<bool, flui_engine::EngineError> {
+                Ok(true)
+            }
+            fn resize(&mut self, _width: u32, _height: u32) {}
+            fn is_device_lost(&self) -> bool {
+                false
+            }
+            fn mark_dirty(&mut self, _rect: flui_types::Rect<flui_types::geometry::Pixels>) {}
+            fn mark_full_repaint(&mut self) {}
+            fn has_damage(&self) -> bool {
+                true
+            }
+            fn size(&self) -> (u32, u32) {
+                (64, 64)
+            }
+            fn reconfigure_surface(&mut self) -> Result<(), flui_engine::EngineError> {
+                Ok(())
+            }
+        }
+
+        let (dispatcher_a, dispatcher_b) = install_two_test_realms();
+        let realm_a_id = dispatcher_a.address.realm_id;
+
+        dispatch_platform_realm(
+            dispatcher_b,
+            RealmTask::Frame(Box::new(|realm| {
+                realm
+                    .attach_root_widget_with_size(&SizedBox::new(20.0, 20.0), 20.0, 20.0)
+                    .expect("B mounts its own root");
+            })),
+        )
+        .expect("B's attach dispatches");
+
+        // Realm A tears itself down from WITHIN its own dispatched task. The
+        // defer-to-idle discipline (`AppRuntime::request_realm_mutation`)
+        // means this queues rather than nests -- applied once this task's
+        // own dispatch restores below.
+        dispatch_platform_realm(
+            dispatcher_a,
+            RealmTask::Frame(Box::new(move |_realm| {
+                uninstall_platform_realm(realm_a_id);
+            })),
+        )
+        .expect("A's own mid-dispatch teardown task runs");
+
+        assert!(
+            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&realm_a_id).is_none()),
+            "realm A must be gone once its own mid-dispatch uninstall request has applied"
+        );
+
+        let presented = Rc::new(RefCell::new(false));
+        let presented_in_frame = Rc::clone(&presented);
+        dispatch_platform_realm(
+            dispatcher_b,
+            RealmTask::Frame(Box::new(move |realm| {
+                let mut backend = AlwaysPresentsBackend;
+                *presented_in_frame.borrow_mut() = realm.render_frame_entered(&mut backend);
+            })),
+        )
+        .expect("realm B still dispatches after realm A's mid-dispatch teardown");
+        assert!(
+            *presented.borrow(),
+            "realm B must still produce (and present) a frame after a sibling realm tore \
+             itself down mid-dispatch"
+        );
+
+        teardown_platform_realm();
+    }
+
+    /// Closing one of two hosted windows must not exit the loop while a
+    /// sibling realm is still hosted (the default `ExitPolicy::OnLastWindowClosed`).
+    #[test]
+    fn closing_one_of_two_windows_does_not_exit_the_loop() {
+        let (dispatcher_a, dispatcher_b) = install_two_test_realms();
+
+        uninstall_platform_realm(dispatcher_a.address.realm_id);
+
+        let should_exit = APP_RUNTIME.with(|slot| {
+            let (exit, removed) = slot
+                .borrow_mut()
+                .should_exit(ExitPolicy::OnLastWindowClosed);
+            drop(removed);
+            exit
+        });
+        assert!(
+            !should_exit,
+            "closing one of two windows must not exit the loop while a sibling realm is \
+             still hosted"
+        );
+        assert!(
+            APP_RUNTIME.with(|slot| slot
+                .borrow()
+                .realms
+                .get(&dispatcher_b.address.realm_id)
+                .is_some()),
+            "the surviving realm B must still be hosted"
+        );
+
+        teardown_platform_realm();
+    }
+
+    /// The drain-before-decide rule: a queued "open the main
+    /// window" install must veto exit even though the splash realm's own
+    /// uninstall is queued in the very same batch -- `should_exit` must
+    /// apply every deferred mutation BEFORE checking whether the registry
+    /// is empty, not race it.
+    #[test]
+    fn close_splash_then_open_main_does_not_exit() {
+        let splash = install_test_realm();
+        let splash_id = splash.address.realm_id;
+
+        let main_realm = super::super::ui_realm::UiRealm::for_test();
+        let main_address = flui_foundation::PresentationAddress {
+            realm_id: main_realm.realm_id(),
+            presentation_id: main_realm.presentation_id(),
+        };
+        let main_window = test_window();
+        // Stand in for "a dispatch/visit is in flight": both requests below
+        // must defer rather than apply immediately -- exactly the state a
+        // splash-close dispose callback queuing a main-window open would
+        // leave behind mid-frame.
+        APP_RUNTIME.with(|slot| {
+            let mut state = slot.borrow_mut();
+            // Register the main window's mapping the same way a real install
+            // path would -- required for `teardown_platform_realm`'s own
+            // read-back assertion to hold once this realm tears down below.
+            state.registry.register_window(&main_window, main_address);
+            state.iterating_all_realms = true;
+            let deferred_uninstall =
+                state.request_realm_mutation(RealmMapMutation::Uninstall(splash_id));
+            assert!(
+                deferred_uninstall.is_none(),
+                "an Uninstall requested while a visit is in flight must defer, not apply \
+                 immediately"
+            );
+            let deferred_install = state.request_realm_mutation(RealmMapMutation::Install(
+                main_address.realm_id,
+                Box::new(RealmSlot {
+                    realm: Some(main_realm),
+                    queue: VecDeque::new(),
+                    draining: false,
+                    address: main_address,
+                    surface_applier: None,
+                }),
+            ));
+            assert!(
+                deferred_install.is_none(),
+                "an Install requested while a visit is in flight must defer, not apply \
+                 immediately"
+            );
+            state.iterating_all_realms = false;
+        });
+
+        let should_exit = APP_RUNTIME.with(|slot| {
+            let (exit, removed) = slot
+                .borrow_mut()
+                .should_exit(ExitPolicy::OnLastWindowClosed);
+            drop(removed);
+            exit
+        });
+        assert!(
+            !should_exit,
+            "the drain-before-decide rule: a queued open-main install must veto exit \
+             even though the splash realm's own uninstall is queued in the same batch"
+        );
+        assert!(
+            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&main_address.realm_id).is_some()),
+            "should_exit must have applied the queued install before deciding"
+        );
+        assert!(
+            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&splash_id).is_none()),
+            "should_exit must also have applied the queued splash uninstall"
+        );
+
+        teardown_platform_realm();
+    }
+
+    /// A frame callback that decides to open a second window must install
+    /// the second realm without ever attempting a nested dispatch: the
+    /// install is invisible in the registry until realm A's own dispatch
+    /// restores, at which point it lands.
+    #[test]
+    fn frame_callback_opening_a_window_installs_second_realm_without_nested_dispatch() {
+        // Both windows from ONE shared platform instance -- see
+        // `install_two_test_realms`'s doc for why two separate
+        // `test_window()` calls would risk an aliased id here.
+        let platform = flui_platform::headless_platform();
+        let window_a = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window a");
+        let dispatcher_a =
+            install_platform_realm(super::super::ui_realm::UiRealm::for_test(), &window_a);
+
+        let second_realm = super::super::ui_realm::UiRealm::for_test();
+        let second_address = flui_foundation::PresentationAddress {
+            realm_id: second_realm.realm_id(),
+            presentation_id: second_realm.presentation_id(),
+        };
+        let second_slot = RealmSlot {
+            realm: Some(second_realm),
+            queue: VecDeque::new(),
+            draining: false,
+            address: second_address,
+            surface_applier: None,
+        };
+        // Register the second window's mapping the same way a real install
+        // path would -- required for `teardown_platform_realm`'s own
+        // read-back assertion to hold once this realm tears down at the end
+        // of this test.
+        let second_window = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create the second window");
+        APP_RUNTIME.with(|slot| {
+            slot.borrow_mut()
+                .registry
+                .register_window(&second_window, second_address);
+        });
+
+        dispatch_platform_realm(
+            dispatcher_a,
+            RealmTask::Frame(Box::new(move |_realm| {
+                let deferred = APP_RUNTIME.with(|slot| {
+                    slot.borrow_mut()
+                        .request_realm_mutation(RealmMapMutation::Install(
+                            second_address.realm_id,
+                            Box::new(second_slot),
+                        ))
+                });
+                assert!(
+                    deferred.is_none(),
+                    "an Install requested mid-dispatch must defer (return None), never apply \
+                     immediately"
+                );
+                assert!(
+                    APP_RUNTIME.with(|slot| slot
+                        .borrow()
+                        .realms
+                        .get(&second_address.realm_id)
+                        .is_none()),
+                    "the second realm must not be visible in the registry while realm A is \
+                     still checked out for dispatch"
+                );
+            })),
+        )
+        .expect("A's frame callback dispatches");
+
+        assert!(
+            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&second_address.realm_id).is_some()),
+            "the deferred install must land once realm A's own dispatch restores"
+        );
+
+        teardown_platform_realm();
+    }
+
+    /// Hot-restart's `for_each_installed_realm` visits every hosted realm in
+    /// mount order; a realm-map mutation a visited realm's own callback
+    /// requests must defer until the WHOLE visit completes, never change the
+    /// set of realms still being walked.
+    #[test]
+    fn hot_restart_while_callback_mutates_realm_map_defers_mutation() {
+        let (dispatcher_a, dispatcher_b) = install_two_test_realms();
+        let realm_a_id = dispatcher_a.address.realm_id;
+        let realm_b_id = dispatcher_b.address.realm_id;
+
+        let visited = Rc::new(RefCell::new(Vec::new()));
+        let visited_in_closure = Rc::clone(&visited);
+
+        for_each_installed_realm(move |realm| {
+            visited_in_closure.borrow_mut().push(realm.realm_id());
+            if realm.realm_id() == realm_a_id {
+                uninstall_platform_realm(realm_a_id);
+                assert!(
+                    APP_RUNTIME.with(|slot| slot.borrow().realms.get(&realm_a_id).is_some()),
+                    "a mutation requested mid-visit must defer, not remove the realm immediately"
+                );
+            }
+        });
+
+        assert_eq!(
+            *visited.borrow(),
+            vec![realm_a_id, realm_b_id],
+            "the visit must walk every realm in mount order, unaffected by the mid-visit \
+             mutation request"
+        );
+        assert!(
+            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&realm_a_id).is_none()),
+            "the deferred uninstall must apply once the whole visit completes"
+        );
+        assert!(
+            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&realm_b_id).is_some()),
+            "realm B must be untouched by realm A's own deferred mutation"
+        );
+
+        teardown_platform_realm();
+    }
+
+    /// Fence-(c) two-realm probe: with realm A mid-frame-transaction and a
+    /// SECOND, fully idle realm B also resident, `with_owner_platform`'s
+    /// debug_assert must still trip. A two-realm registry is not an "OR of
+    /// all Idle" check that a lone idle sibling could vacuously satisfy —
+    /// this must actually catch the realm that IS mid-transaction.
+    #[test]
+    #[should_panic(
+        expected = "with_owner_platform called while the installed realm's scheduler is inside"
+    )]
+    #[cfg_attr(
+        not(debug_assertions),
+        ignore = "the fence is a debug_assert!; release builds don't panic"
+    )]
+    fn owner_platform_accessor_fences_correctly_with_a_second_idle_realm_present() {
+        use flui_platform::headless_platform;
+
+        let _clear_guard = OwnerHostClearGuard::arm();
+        // Both windows from ONE shared platform instance: `HeadlessPlatform`
+        // mints window ids from an instance-local counter, so two separate
+        // `headless_platform()` calls could alias the same id, which would
+        // silently displace realm A's window mapping the moment realm B's
+        // window registers.
+        let platform = headless_platform();
+        let window_a = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window a");
+        let dispatcher_a =
+            install_platform_realm(super::super::ui_realm::UiRealm::for_test(), &window_a);
+        let window_b = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create window b");
+        // Realm B is installed and then never touched again for the rest of
+        // this test -- it stays resident and Idle throughout.
+        let _dispatcher_b =
+            install_realm_alongside(super::super::ui_realm::UiRealm::for_test(), &window_b);
+
+        let scheduler_a = APP_RUNTIME.with(|slot| {
+            slot.borrow()
+                .realms
+                .get(&dispatcher_a.address.realm_id)
+                .and_then(|realm_slot| realm_slot.realm.as_ref())
+                .expect("realm A installed above")
+                .scheduler()
+                .clone()
+        });
+
+        scheduler_a.drive_frame(web_time::Instant::now(), || {
+            let _ = with_owner_platform(|_owner| ());
+        });
     }
 }
 
@@ -2947,11 +3670,14 @@ where
         // renderer inside the event payload itself.
         {
             let renderer_resize = Arc::clone(&renderer);
-            install_surface_applier(move |size, scale_factor| {
-                let w = (size.width.0 * scale_factor) as u32;
-                let h = (size.height.0 * scale_factor) as u32;
-                renderer_resize.lock().resize(w, h);
-            });
+            install_surface_applier(
+                realm_dispatch.address.realm_id,
+                move |size, scale_factor| {
+                    let w = (size.width.0 * scale_factor) as u32;
+                    let h = (size.height.0 * scale_factor) as u32;
+                    renderer_resize.lock().resize(w, h);
+                },
+            );
         }
 
         // 5. Register input callback -> entered realm input dispatch
@@ -3427,11 +4153,14 @@ where
         // matching comment for the take/call/restore protocol this feeds.
         {
             let renderer_resize = Arc::clone(&renderer);
-            install_surface_applier(move |size, scale_factor| {
-                let w = (size.width.0 * scale_factor) as u32;
-                let h = (size.height.0 * scale_factor) as u32;
-                renderer_resize.lock().resize(w, h);
-            });
+            install_surface_applier(
+                realm_dispatch.address.realm_id,
+                move |size, scale_factor| {
+                    let w = (size.width.0 * scale_factor) as u32;
+                    let h = (size.height.0 * scale_factor) as u32;
+                    renderer_resize.lock().resize(w, h);
+                },
+            );
         }
 
         // 5. Register input callback -> entered realm input dispatch
@@ -3786,13 +4515,16 @@ where
         // matching comment for the take/call/restore protocol this feeds.
         {
             let renderer_resize = Arc::clone(&renderer);
-            install_surface_applier(move |size, scale_factor| {
-                if let Some(renderer) = renderer_resize.lock().as_mut() {
-                    let width = (size.width.0 * scale_factor) as u32;
-                    let height = (size.height.0 * scale_factor) as u32;
-                    renderer.resize(width, height);
-                }
-            });
+            install_surface_applier(
+                realm_dispatch.address.realm_id,
+                move |size, scale_factor| {
+                    if let Some(renderer) = renderer_resize.lock().as_mut() {
+                        let width = (size.width.0 * scale_factor) as u32;
+                        let height = (size.height.0 * scale_factor) as u32;
+                        renderer.resize(width, height);
+                    }
+                },
+            );
         }
 
         // 4. Register input callback
@@ -4294,20 +5026,22 @@ mod tests {
         let window = headless_platform()
             .open_window(flui_platform::WindowOptions::default())
             .expect("headless platform should create a test window");
-        install_platform_realm(super::super::ui_realm::UiRealm::for_test(), &window);
+        let dispatcher =
+            install_platform_realm(super::super::ui_realm::UiRealm::for_test(), &window);
 
         // A clone of the installed realm's OWN scheduler -- same underlying
         // `SchedulerInner` fence (c) reads through `installed_realm_phase`.
-        // Driven directly here, with the realm still resident in `realm`
+        // Driven directly here, with the realm still resident in its slot
         // (not checked out via `dispatch_platform_realm`) -- the sibling
         // test right below this one, `..._through_dispatch`, pins the other
         // half: the realm checked OUT for a dispatched task, where
         // `installed_realm_phase` must fall back to `dispatched_scheduler`
-        // instead of reading `realm` directly.
+        // instead of reading the resident slot directly.
         let scheduler = APP_RUNTIME.with(|slot| {
             slot.borrow()
-                .realm
-                .as_ref()
+                .realms
+                .get(&dispatcher.address.realm_id)
+                .and_then(|realm_slot| realm_slot.realm.as_ref())
                 .expect("just installed above")
                 .scheduler()
                 .clone()
@@ -4330,10 +5064,11 @@ mod tests {
     /// active.
     ///
     /// Red before the `dispatched_scheduler` fallback existed:
-    /// `dispatch_platform_realm` checks the realm OUT of `AppRuntime.realm`
+    /// `dispatch_platform_realm` checks the realm's `UiRealm` OUT of its slot
     /// for the entire extent of the dispatched task (see its own doc), so
-    /// `installed_realm_phase` reading only `realm` would observe `None` for
-    /// this call, not `PersistentCallbacks` -- vacuously "not mid-frame",
+    /// `installed_realm_phase` reading only resident slots would observe
+    /// `None` for this call, not `PersistentCallbacks` -- vacuously "not
+    /// mid-frame",
     /// the debug_assert would pass, and this test would fail its
     /// `#[should_panic]` expectation. Green now because
     /// `dispatch_platform_realm` stashes a clone of the checked-out realm's
@@ -4360,7 +5095,7 @@ mod tests {
 
         // Unlike the sibling test above, this drives the frame from INSIDE a
         // `RealmTask::Frame` dispatched through `dispatch_platform_realm` --
-        // the realm is checked out of `AppRuntime.realm` for the whole
+        // the realm is checked out of its registry slot for the whole
         // closure below, exactly the window `dispatched_scheduler` exists to
         // cover. `drive_frame`'s `PersistentCallbacks` phase is active while
         // `with_owner_platform` is called, so the fence must trip here

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -545,6 +545,13 @@ impl PlatformToUi {
 /// SAME realm — a sibling realm's own applier is untouched. Call once per
 /// realm install, alongside [`install_platform_realm`], from each backend's
 /// bootstrap — never from inside a frame/event dispatch.
+///
+/// `realm_id` not being resident here is always a caller bug, never a
+/// legitimate race: this is called synchronously, immediately alongside the
+/// realm's own install, so the slot must already exist. Loud rather than a
+/// silent no-op, because the failure mode otherwise is silent forever — that
+/// realm's `Resized` events would coalesce onto a `None` applier for its
+/// entire lifetime with nothing ever pointing at why.
 #[cfg(not(target_os = "ios"))]
 fn install_surface_applier(
     realm_id: RealmId,
@@ -553,6 +560,18 @@ fn install_surface_applier(
     APP_RUNTIME.with(|slot| {
         if let Some(realm_slot) = slot.borrow_mut().realms.get_mut(&realm_id) {
             realm_slot.surface_applier = Some(Box::new(applier));
+        } else {
+            debug_assert!(
+                false,
+                "BUG: install_surface_applier called for realm {realm_id:?}, which is not \
+                 resident in the registry -- call this once, synchronously, immediately \
+                 alongside install_platform_realm/install_realm_alongside, never after"
+            );
+            tracing::error!(
+                ?realm_id,
+                "install_surface_applier: realm not found in the registry -- this realm's \
+                 resize handling is silently lost for its whole lifetime"
+            );
         }
     });
 }
@@ -1425,19 +1444,30 @@ fn dispatch_platform_realm(
             );
             return Err(RealmDispatchError::StalePresentation);
         }
-        realm_slot.queue.push_back(event);
+        // Same-realm reentrancy: this realm is already draining (mid its
+        // own drain loop below) or checked out (by its own dispatch, or by
+        // a `for_each_installed_realm` visit) -- always safe to enqueue and
+        // return early; the ongoing drain loop, or the next legitimate
+        // dispatch once the realm is restored, picks the event up.
         if realm_slot.draining || realm_slot.realm.is_none() {
+            realm_slot.queue.push_back(event);
             return Ok(None);
         }
-        // Nested cross-realm dispatch guard (issue #555): reaching here
-        // means THIS realm is neither draining nor checked out (both ruled
-        // out just above), so a `dispatched_realm_id` naming a DIFFERENT
-        // realm can only mean a nested dispatch was attempted while that
-        // other realm's task is still running on this same thread — the one
-        // case `request_realm_install`/`request_realm_uninstall`'s
-        // defer-to-idle discipline exists to make structurally unreachable
-        // in production. Caught loudly in
-        // debug builds; release builds still refuse rather than nest.
+        // Nested cross-realm dispatch guard (issue #555), checked BEFORE
+        // enqueuing `event` anywhere: reaching here means THIS realm is
+        // neither draining nor checked out (both ruled out just above), so
+        // a `dispatched_realm_id` naming a DIFFERENT realm can only mean a
+        // nested dispatch was attempted while that other realm's task is
+        // still running on this same thread — the one case
+        // `request_realm_install`/`request_realm_uninstall`'s defer-to-idle
+        // discipline exists to make structurally unreachable in production.
+        // Checking this BEFORE the enqueue below is load-bearing, not
+        // cosmetic: enqueuing `event` first and rejecting after would leave
+        // it stuck in this realm's queue forever (nothing else ever removes
+        // a rejected event), silently delivered to the next LEGITIMATE
+        // dispatch instead of the genuine rejection this error reports.
+        // Caught loudly in debug builds; release builds still refuse rather
+        // than nest.
         if let Some(dispatched_realm_id) = state.dispatched_realm_id {
             debug_assert!(
                 false,
@@ -1456,6 +1486,7 @@ fn dispatch_platform_realm(
             .realms
             .get_mut(&realm_id)
             .expect("BUG: presence checked above");
+        realm_slot.queue.push_back(event);
         let first = realm_slot
             .queue
             .pop_front()
@@ -2759,6 +2790,63 @@ mod realm_dispatch_tests {
             })),
         )
         .expect("B dispatches independently of A");
+
+        teardown_platform_realm();
+    }
+
+    /// A rejected nested cross-realm dispatch must never smuggle its task
+    /// into the target realm's queue: the task must not run during the
+    /// rejected attempt, AND must not be silently delivered by the NEXT
+    /// legitimate dispatch to that same realm either. Before the ordering
+    /// fix, the event was pushed into realm B's queue BEFORE the
+    /// nested-dispatch guard ran, so nothing ever removed a rejected
+    /// event — the very next legitimate dispatch to B would pop and run it.
+    #[test]
+    #[cfg_attr(
+        not(debug_assertions),
+        ignore = "the nested-dispatch guard fires via debug_assert!(false, ...) in this build; \
+                  release builds return Err without panicking, so realm A's own outer dispatch \
+                  never unwinds and this test's catch_unwind expectation does not apply"
+    )]
+    fn rejected_nested_dispatch_never_delivers_its_task_on_the_next_legitimate_dispatch() {
+        let (dispatcher_a, dispatcher_b) = install_two_test_realms();
+
+        let rejected_ran = Rc::new(Cell::new(false));
+        let rejected_ran_in_task = Rc::clone(&rejected_ran);
+
+        // From inside realm A's own dispatched task, attempt a NESTED
+        // dispatch to realm B -- a DIFFERENT, resident-and-idle realm --
+        // which the nested-cross-realm-dispatch guard must reject before
+        // ever touching B's queue. The guard's debug_assert! panics in this
+        // build; the panic unwinds through A's own dispatch, which this
+        // catch_unwind survives.
+        let attempt = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            dispatch_platform_realm(
+                dispatcher_a,
+                RealmTask::Frame(Box::new(move |_realm| {
+                    let _ = dispatch_platform_realm(
+                        dispatcher_b,
+                        RealmTask::Frame(Box::new(move |_| {
+                            rejected_ran_in_task.set(true);
+                        })),
+                    );
+                })),
+            )
+        }));
+        assert!(
+            attempt.is_err(),
+            "the nested cross-realm dispatch attempt must panic via the guard's debug_assert!"
+        );
+
+        // A LEGITIMATE, top-level dispatch to realm B, driven afterward.
+        dispatch_platform_realm(dispatcher_b, RealmTask::Frame(Box::new(|_| {})))
+            .expect("realm B still dispatches normally after the rejected nested attempt");
+
+        assert!(
+            !rejected_ran.get(),
+            "the REJECTED task must never run -- not during the rejected attempt, and not \
+             smuggled into realm B's queue for a later legitimate dispatch to deliver"
+        );
 
         teardown_platform_realm();
     }

--- a/crates/flui-app/src/app/runner.rs
+++ b/crates/flui-app/src/app/runner.rs
@@ -1325,7 +1325,7 @@ fn install_realm_alongside(
         presentation_id: realm.presentation_id(),
     };
     let window = std::sync::Arc::clone(window);
-    APP_RUNTIME.with(|slot| {
+    let result = APP_RUNTIME.with(|slot| {
         let mut state = slot.borrow_mut();
         state.owner_thread.get_or_insert(owner_thread);
         let _ = state.ensure_services();
@@ -1340,11 +1340,21 @@ fn install_realm_alongside(
             },
             window,
         )
-    })?;
-    Ok(RealmDispatcher {
-        owner_thread,
-        address,
-    })
+    });
+    // On a refused collision, `result` carries the rejected `RealmSlot` (and
+    // the `UiRealm` it owns) back out of the TLS borrow above -- dropped
+    // only here, after that borrow has released, never inside it (see
+    // `AppRuntime::apply_install`'s own doc for why).
+    match result {
+        Ok(()) => Ok(RealmDispatcher {
+            owner_thread,
+            address,
+        }),
+        Err((error, rejected_slot)) => {
+            drop(rejected_slot);
+            Err(error)
+        }
+    }
 }
 
 /// Uninstalls exactly one realm — a single window closing while siblings
@@ -1521,20 +1531,33 @@ fn dispatch_platform_realm(
 /// Hot-restart's own iteration primitive (issue #555): visits every
 /// currently-installed realm, in mount order, running `f` against each one
 /// OUTSIDE the `APP_RUNTIME` borrow — the same checkout/restore discipline
-/// [`dispatch_platform_realm`] uses for a single addressed realm — so `f` may
-/// safely call back into any `APP_RUNTIME`-touching function, including a
-/// realm-map install/uninstall request. Such a request, arriving while this
-/// visit is still in progress, defers rather than applies immediately
-/// ([`super::runtime::AppRuntime::request_realm_install`]'s own doc),
-/// applied only once every realm has been visited — so the set of realms
-/// visited never shifts mid-iteration.
+/// [`dispatch_platform_realm`] uses for a single addressed realm.
+///
+/// What `f` may safely do, precisely (not "any `APP_RUNTIME`-touching
+/// function" — the visited realm counts as dispatched, see below, so the
+/// same restrictions a dispatched task's own closure has apply here too):
+/// dispatch back to the SAME realm being visited (enqueues via the ordinary
+/// same-realm reentrant path, never recurses); request a realm-map
+/// install/uninstall (defers rather than applies immediately — see
+/// [`super::runtime::AppRuntime::request_realm_install`]'s own doc — applied
+/// only once every realm has been visited, so the set of realms visited
+/// never shifts mid-iteration); or call [`super::runtime::AppRuntime::should_exit`]
+/// (also defers its own drain while this visit is in flight, for the same
+/// reason). Dispatching to a DIFFERENT, sibling realm is NOT safe: it now
+/// trips `dispatch_platform_realm`'s nested-cross-realm-dispatch guard (see
+/// the next paragraph), a deliberate behavior change, not an oversight.
 ///
 /// Each visited realm is ALSO stashed into `dispatched_scheduler`/
 /// `dispatched_realm_id` for the duration of its own call to `f` — the same
 /// fields `dispatch_platform_realm` stashes for a dispatched task — so
 /// `with_owner_platform`'s fence (c) stays able to see the visited realm's
 /// own scheduler phase for the whole time it sits checked out of `realms`,
-/// exactly as it does for a real dispatch.
+/// exactly as it does for a real dispatch. A side effect of that stash is
+/// exactly the restriction stated above: `dispatch_platform_realm` treats a
+/// visited realm as "checked out" indistinguishably from a dispatched one,
+/// so a nested dispatch to a sibling realm from inside `f` is rejected by
+/// the same nested-cross-realm-dispatch guard a nested dispatch from inside
+/// another dispatch would be.
 ///
 /// A panic inside `f` is caught, not propagated past this function's own
 /// cleanup: the visited realm is restored to its slot, `iterating_all_realms`
@@ -1713,7 +1736,10 @@ fn teardown_platform_realm() {
     not(target_arch = "wasm32")
 ))]
 mod realm_dispatch_tests {
-    use std::{cell::RefCell, rc::Rc};
+    use std::{
+        cell::{Cell, RefCell},
+        rc::Rc,
+    };
 
     use flui_interaction::{
         HitTestResult,
@@ -2858,6 +2884,77 @@ mod realm_dispatch_tests {
         teardown_platform_realm();
     }
 
+    /// The DEFERRED half of the collision-refusal path:
+    /// `drain_pending_realm_mutations`'s own `Install` arm, reached only
+    /// when a collision is requested mid-visit/mid-dispatch rather than at
+    /// idle. Must behave identically to the immediate path above -- refuse,
+    /// leave realm A's own registration untouched, and never corrupt the
+    /// registry -- and must do so without ever dropping the rejected
+    /// `RealmSlot` (and the `UiRealm` it owns) while this visit's own
+    /// `APP_RUNTIME` borrow is live: `apply_install`/
+    /// `drain_pending_realm_mutations` route a rejected slot through
+    /// `removed` instead, the same bucket a removed `Uninstall` slot uses,
+    /// dropped only once the caller's borrow has released.
+    #[test]
+    fn deferred_install_collision_is_refused_without_corrupting_the_registry() {
+        let platform = flui_platform::headless_platform();
+        let window = platform
+            .open_window(flui_platform::WindowOptions::default())
+            .expect("headless platform should create a test window");
+        let dispatcher_a =
+            install_platform_realm(super::super::ui_realm::UiRealm::for_test(), &window);
+        let realm_a_id = dispatcher_a.address.realm_id;
+
+        let colliding_realm = super::super::ui_realm::UiRealm::for_test();
+        let colliding_address = flui_foundation::PresentationAddress {
+            realm_id: colliding_realm.realm_id(),
+            presentation_id: colliding_realm.presentation_id(),
+        };
+        let mut colliding_realm = Some(colliding_realm);
+
+        for_each_installed_realm(|realm| {
+            assert_eq!(
+                realm.realm_id(),
+                realm_a_id,
+                "the sole installed realm is realm A"
+            );
+            let deferred = APP_RUNTIME.with(|slot| {
+                slot.borrow_mut().request_realm_install(
+                    colliding_address.realm_id,
+                    RealmSlot {
+                        realm: colliding_realm.take(),
+                        queue: VecDeque::new(),
+                        draining: false,
+                        address: colliding_address,
+                        surface_applier: None,
+                    },
+                    std::sync::Arc::clone(&window),
+                )
+            });
+            assert!(
+                deferred.is_ok(),
+                "an Install requested mid-visit must defer (Ok), not fail synchronously -- \
+                 the collision is only discovered once the deferred drain applies it"
+            );
+        });
+
+        assert!(
+            APP_RUNTIME.with(|slot| slot
+                .borrow()
+                .realms
+                .get(&colliding_address.realm_id)
+                .is_none()),
+            "the colliding realm must never enter the registry -- its window id collided with \
+             realm A's own mapping when the deferred drain applied it"
+        );
+        assert!(
+            APP_RUNTIME.with(|slot| slot.borrow().realms.get(&realm_a_id).is_some()),
+            "realm A's own registration must survive the sibling's refused, deferred collision"
+        );
+
+        teardown_platform_realm();
+    }
+
     /// Closing one of two hosted windows must not exit the loop while a
     /// sibling realm is still hosted (the default `ExitPolicy::OnLastWindowClosed`).
     #[test]
@@ -3136,9 +3233,30 @@ mod realm_dispatch_tests {
              otherwise every future realm-map mutation request would defer forever"
         );
 
-        dispatch_platform_realm(dispatcher, RealmTask::Frame(Box::new(|_| {}))).expect(
-            "the realm must still be dispatchable after a panicking visit -- its slot \
-                     was restored, not permanently stranded at realm: None",
+        // A bare `.expect(Ok(()))` on the dispatch below is NOT sufficient
+        // evidence the realm's slot was actually restored: if `realm: None`
+        // were left stranded, `dispatch_platform_realm` would take its
+        // enqueue-only early-return path (`realm_slot.realm.is_none()`) and
+        // still return `Ok(())` — successfully queuing the task forever
+        // without ever running it, indistinguishable from success at the
+        // `Result` level alone. Give the task an observable side effect
+        // instead: it only runs SYNCHRONOUSLY, inside this same call, if the
+        // slot's `realm` was genuinely `Some(..)` at call time.
+        let ran = Rc::new(Cell::new(false));
+        let ran_in_task = Rc::clone(&ran);
+        dispatch_platform_realm(
+            dispatcher,
+            RealmTask::Frame(Box::new(move |_| {
+                ran_in_task.set(true);
+            })),
+        )
+        .expect("dispatch must return cleanly after a panicking visit");
+        assert!(
+            ran.get(),
+            "the dispatched task must actually RUN, not merely enqueue forever -- it only runs \
+             if the visit's cleanup genuinely restored realm: Some(..) into this realm's slot; \
+             a stranded realm: None slot would still return Ok(()) from the enqueue-only path \
+             above without ever executing this closure"
         );
 
         teardown_platform_realm();

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -300,6 +300,16 @@ impl RealmRegistry {
         self.slots.is_empty()
     }
 
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "shared-reference lookup; every production call site so far checks a slot \
+                      out via get_mut (the checkout-based dispatch/visit pattern) -- exercised \
+                      by this crate's own tests, which only need to read a slot back, never \
+                      mutate it"
+        )
+    )]
     pub(super) fn get(&self, id: &RealmId) -> Option<&RealmSlot> {
         self.slots
             .iter()
@@ -490,10 +500,10 @@ impl FrameWakeHandle {
 ///
 /// # Design-for-N
 ///
-/// The realm-facing API is `RealmId`-keyed ([`AppRuntime::realm`]);
-/// *storage* is [`RealmRegistry`], an insertion-ordered map of any number of
-/// hosted realms (issue #555) — `next_identity` above already mints from a
-/// shape that never needed to change for this to land.
+/// The realm-facing API is `RealmId`-keyed: `realms` is [`RealmRegistry`],
+/// an insertion-ordered map of any number of hosted realms (issue #555) —
+/// `next_identity` above already mints from a shape that never needed to
+/// change for this to land.
 #[cfg(not(target_os = "ios"))]
 pub(crate) struct AppRuntime {
     /// Every hosted realm, keyed by `RealmId`, in mount (insertion) order.
@@ -685,23 +695,6 @@ impl AppRuntime {
         self.services.get().is_some()
     }
 
-    /// `RealmId`-keyed lookup: `Some` only when `id` names a currently
-    /// hosted (resident, not checked-out) realm. Storage is
-    /// [`RealmRegistry`], so this scales to however many realms are
-    /// actually installed rather than a single degenerate slot.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "design-for-N accessor; the single production caller \
-                      (per-realm dispatch) still addresses the TLS slot \
-                      directly"
-        )
-    )]
-    pub(crate) fn realm(&self, id: RealmId) -> Option<&UiRealm> {
-        self.realms.get(&id).and_then(|slot| slot.realm.as_ref())
-    }
-
     /// True if `phase` is one of the phases `with_owner_platform`'s fence (c)
     /// forbids: a frame transaction genuinely in flight, as opposed to
     /// `Idle`/`PostFrameCallbacks`, both of which are legitimate times to
@@ -732,32 +725,43 @@ impl AppRuntime {
     /// exact for that case, not merely a fallback. Only once nothing is
     /// checked out does this fall through to scanning `realms` itself, so an
     /// addressed probe (this dispatch's own realm) and the aggregate fence
-    /// both stay correct without duplicating the forbidden-phase list. Reads
-    /// `Some(Idle)` (not `None`) when every resident realm is quiescent,
-    /// matching this function's pre-registry single-slot behavior exactly
-    /// for the common one-realm case.
+    /// both stay correct without duplicating the forbidden-phase list.
+    /// Single-pass, no intermediate allocation: returns the first FORBIDDEN
+    /// phase found, short-circuiting the scan; if none is forbidden, returns
+    /// the first realm's OBSERVED phase honestly (never claimed to be
+    /// specifically `Idle` — a fully quiescent realm can legitimately sit in
+    /// `PostFrameCallbacks` just as validly, and this reads back whichever
+    /// one it actually is) rather than `None`, matching this function's
+    /// pre-registry single-slot behavior for the common one-realm case (a
+    /// realm being installed reads back its own real phase, not a
+    /// vacuous "nothing installed" `None`).
     pub(super) fn installed_realm_phase(&self) -> Option<flui_scheduler::SchedulerPhase> {
         if let Some(scheduler) = self.dispatched_scheduler.as_ref() {
             return Some(scheduler.phase());
         }
-        let phases: Vec<_> = self
-            .realms
-            .iter()
-            .filter_map(|(_, slot)| slot.realm.as_ref())
-            .map(|realm| realm.scheduler().phase())
-            .collect();
-        phases
-            .iter()
-            .copied()
-            .find(|phase| Self::is_frame_transaction_phase(*phase))
-            .or_else(|| phases.first().copied())
+        let mut first_observed = None;
+        for (_, slot) in self.realms.iter() {
+            let Some(realm) = slot.realm.as_ref() else {
+                continue;
+            };
+            let phase = realm.scheduler().phase();
+            if Self::is_frame_transaction_phase(phase) {
+                return Some(phase);
+            }
+            first_observed.get_or_insert(phase);
+        }
+        first_observed
     }
 
     /// The un-deferred application of an `Install` mutation: registers
-    /// `window`'s id in the `WindowRegistry` FIRST, strictly (never
-    /// replacing an existing mapping — an id collision is refused, not
-    /// silently re-routed onto a sibling realm's window), and only inserts
-    /// `slot` into `realms` once that registration succeeds.
+    /// `window` in the `WindowRegistry` FIRST, strictly (never replacing an
+    /// existing mapping — an id collision is refused, not silently
+    /// re-routed onto a sibling realm's window), and only inserts `slot`
+    /// into `realms` once that registration succeeds. Hands `window` to
+    /// [`super::window_registry::WindowRegistry::try_register_window`]
+    /// rather than deriving its id here: `WindowId` is the registry's own
+    /// single-authority concern (ADR-0037 §2) — `AppRuntime` never names or
+    /// touches it directly.
     ///
     /// On `Err`, hands `slot` BACK rather than dropping it here: this method
     /// is always called while some caller's `APP_RUNTIME` `RefCell` borrow is
@@ -774,7 +778,7 @@ impl AppRuntime {
         slot: RealmSlot,
         window: &Arc<dyn PlatformWindow>,
     ) -> Result<(), (RegistryError, Box<RealmSlot>)> {
-        if let Err(error) = self.registry.try_register(window.id(), slot.address) {
+        if let Err(error) = self.registry.try_register_window(window, slot.address) {
             return Err((error, Box::new(slot)));
         }
         self.realms.insert(id, slot);
@@ -942,6 +946,14 @@ impl AppRuntime {
     /// completed. `teardown_platform_realm` asserts this rather than
     /// silently dropping a still-pending mutation (and the `UiRealm` an
     /// `Install` mutation might still be holding) unnoticed.
+    ///
+    /// `cfg`-gated to match that one caller exactly: `teardown_platform_realm`
+    /// is `#[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]`
+    /// (the web host never tears down at all — see that function's own
+    /// module doc), so on wasm32 this method has no caller at all and must
+    /// not compile there either, or it is dead code under `wasm-check`'s
+    /// deny-warnings build.
+    #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn has_pending_realm_mutations(&self) -> bool {
         !self.pending_realm_mutations.is_empty()
     }
@@ -1201,9 +1213,10 @@ mod app_runtime_tests {
         );
         assert!(
             runtime
-                .realm(RealmId::new_gen(0, NonZeroU32::new(1).unwrap()))
+                .realms
+                .get(&RealmId::new_gen(0, NonZeroU32::new(1).unwrap()))
                 .is_none(),
-            "the RealmId-keyed accessor must return None when no realm is installed"
+            "the RealmId-keyed registry must return None when no realm is installed"
         );
     }
 

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -757,16 +757,26 @@ impl AppRuntime {
     /// `window`'s id in the `WindowRegistry` FIRST, strictly (never
     /// replacing an existing mapping — an id collision is refused, not
     /// silently re-routed onto a sibling realm's window), and only inserts
-    /// `slot` into `realms` once that registration succeeds. On
-    /// `Err`, `slot` (and the `UiRealm` it owns) is dropped by the caller;
-    /// this method itself never touches `realms` in that case.
+    /// `slot` into `realms` once that registration succeeds.
+    ///
+    /// On `Err`, hands `slot` BACK rather than dropping it here: this method
+    /// is always called while some caller's `APP_RUNTIME` `RefCell` borrow is
+    /// still live, and `slot` owns a whole `UiRealm` whose destructors may
+    /// re-enter platform/framework code — the same reason
+    /// `install_platform_realm`/`teardown_platform_realm` never drop a
+    /// realm-owning value while their own TLS borrow is held. Every caller of
+    /// this method routes the returned slot through its own `removed`-style
+    /// return value instead, so the actual drop happens only once that
+    /// borrow has released.
     fn apply_install(
         &mut self,
         id: RealmId,
         slot: RealmSlot,
         window: &Arc<dyn PlatformWindow>,
-    ) -> Result<(), RegistryError> {
-        self.registry.try_register(window.id(), slot.address)?;
+    ) -> Result<(), (RegistryError, Box<RealmSlot>)> {
+        if let Err(error) = self.registry.try_register(window.id(), slot.address) {
+            return Err((error, Box::new(slot)));
+        }
         self.realms.insert(id, slot);
         Ok(())
     }
@@ -806,7 +816,11 @@ impl AppRuntime {
     /// to a live entry — deferred installs cannot fail synchronously (the
     /// caller has already returned by the time they apply); see
     /// [`Self::drain_pending_realm_mutations`] for how that case is handled
-    /// instead (traced and dropped, never silently re-routed).
+    /// instead (traced and dropped, never silently re-routed). On that
+    /// immediate `Err`, hands `slot` back inside the error (see
+    /// [`Self::apply_install`]'s own doc for why) — the caller (always
+    /// itself inside a live `APP_RUNTIME` borrow) must drop it only after
+    /// that borrow releases.
     #[cfg_attr(
         not(test),
         expect(
@@ -820,7 +834,7 @@ impl AppRuntime {
         id: RealmId,
         slot: RealmSlot,
         window: Arc<dyn PlatformWindow>,
-    ) -> Result<(), RegistryError> {
+    ) -> Result<(), (RegistryError, Box<RealmSlot>)> {
         if self.dispatched_realm_id.is_some() || self.iterating_all_realms {
             self.pending_realm_mutations.push(RealmMapMutation::Install(
                 id,
@@ -879,10 +893,13 @@ impl AppRuntime {
     /// caller, never the outer operation whose completion is supposed to
     /// trigger the drain.
     ///
-    /// Returns every removed [`RealmSlot`] (from a deferred `Uninstall`), for
-    /// the caller to drop outside the live `APP_RUNTIME` borrow — see
-    /// [`Self::request_realm_install`]'s doc for why that discipline matters
-    /// here.
+    /// Returns every removed [`RealmSlot`] — both from a deferred
+    /// `Uninstall`, AND from a deferred `Install` that collided on its
+    /// window id — for the caller to drop outside the live `APP_RUNTIME`
+    /// borrow — see [`Self::apply_install`]'s own doc for why that
+    /// discipline matters here: this method runs inside every one of its
+    /// three callers' live `RefCell` borrow, so it must never drop a
+    /// realm-owning value itself.
     pub(super) fn drain_pending_realm_mutations(&mut self) -> Vec<RealmSlot> {
         if self.dispatched_realm_id.is_some() || self.iterating_all_realms {
             return Vec::new();
@@ -892,18 +909,18 @@ impl AppRuntime {
         for mutation in pending {
             match mutation {
                 RealmMapMutation::Install(id, slot, window) => {
-                    if let Err(error) = self.apply_install(id, *slot, &window) {
-                        // The realm this Install carried is dropped here,
-                        // with `slot` (and the `UiRealm` it owned) falling
-                        // out of scope at the end of this match arm --
-                        // never silently re-routed onto whichever sibling
-                        // realm already owns this window id.
+                    if let Err((error, slot)) = self.apply_install(id, *slot, &window) {
+                        // The collided slot is routed through `removed`, the
+                        // SAME bucket a rejected/removed `Uninstall` slot
+                        // uses below -- never dropped here, inside this
+                        // method's live borrow.
                         tracing::error!(
                             ?id,
                             ?error,
                             "dropping a deferred realm install: its window id collided with an \
                              already-registered mapping"
                         );
+                        removed.push(*slot);
                     }
                 }
                 RealmMapMutation::Uninstall(id) => {

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -74,7 +74,7 @@ use super::runner::{RealmTask, SurfaceApplier};
 #[cfg(not(target_os = "ios"))]
 use super::ui_realm::UiRealm;
 #[cfg(not(target_os = "ios"))]
-use super::window_registry::WindowRegistry;
+use super::window_registry::{RegistryError, WindowRegistry};
 
 /// Process-level engine services, each resolved **once** per owner thread in
 /// [`SharedEngineServices::resolve`] — never re-resolved on every access, and
@@ -371,17 +371,23 @@ impl RealmRegistry {
 
 /// A realm-registry install/uninstall requested while a mutation must defer
 /// (a dispatch or an all-realms iteration is in flight on this thread — see
-/// [`AppRuntime::request_realm_mutation`]). Applied in request order once
-/// the deferring condition clears.
+/// [`AppRuntime::request_realm_install`]/[`AppRuntime::request_realm_uninstall`]).
+/// Applied in request order once the deferring condition clears. Private:
+/// external callers (`super::runner`) go through the typed
+/// `request_realm_install`/`request_realm_uninstall` methods, never
+/// construct this enum directly — keeping the window-registration step
+/// (see [`AppRuntime::apply_install`]) bundled with the registry insert
+/// atomically, instead of requiring every call site to remember both.
 #[cfg(not(target_os = "ios"))]
-pub(super) enum RealmMapMutation {
+enum RealmMapMutation {
     /// Add a newly-constructed realm to the registry (never displaces a
-    /// sibling — see `install_realm_alongside` in `super::runner`). Boxed:
-    /// `RealmSlot` owns a whole `UiRealm`, over a kilobyte, next to
-    /// `Uninstall`'s bare `RealmId` -- boxing keeps this enum (and every
-    /// `Vec<RealmMapMutation>` queueing it) from paying that size for every
-    /// entry regardless of variant.
-    Install(RealmId, Box<RealmSlot>),
+    /// sibling — see `install_realm_alongside` in `super::runner`), plus the
+    /// window whose id mints its `WindowRegistry` mapping. Boxed: `RealmSlot`
+    /// owns a whole `UiRealm`, over a kilobyte, next to `Uninstall`'s bare
+    /// `RealmId` -- boxing keeps this enum (and every `Vec<RealmMapMutation>`
+    /// queueing it) from paying that size for every entry regardless of
+    /// variant.
+    Install(RealmId, Box<RealmSlot>, Arc<dyn PlatformWindow>),
     /// Remove one realm from the registry (a window closing while siblings
     /// stay open — see `uninstall_platform_realm` in `super::runner`).
     Uninstall(RealmId),
@@ -552,16 +558,22 @@ pub(crate) struct AppRuntime {
     /// is currently checked out, so a nested dispatch attempt targeting a
     /// DIFFERENT realm can be told apart from a legitimate same-realm
     /// reentrant call (already handled by each slot's own `draining` flag).
+    /// Also set (alongside `dispatched_scheduler`) for the realm
+    /// `for_each_installed_realm` currently has checked out of the registry
+    /// mid-visit — from fence (c)'s perspective a visited realm IS
+    /// dispatched: its own scheduler phase must still be observable, not
+    /// blind, for the whole time it sits outside `realms`.
     pub(super) dispatched_realm_id: Option<RealmId>,
     /// Set for the duration of `for_each_installed_realm`'s (`runner.rs`)
     /// hot-restart-shaped visit over every hosted realm. A realm-map
     /// mutation requested while this is `true` defers exactly like one
     /// requested while `dispatched_realm_id` is `Some` — see
-    /// [`Self::request_realm_mutation`] — so a mutation triggered by a
-    /// callback running mid-visit never changes the set of realms that same
-    /// visit is still walking.
+    /// [`Self::request_realm_install`]/[`Self::request_realm_uninstall`] —
+    /// so a mutation triggered by a callback running mid-visit never
+    /// changes the set of realms that same visit is still walking.
     pub(super) iterating_all_realms: bool,
-    /// Realm-map mutations requested while [`Self::request_realm_mutation`]
+    /// Realm-map mutations requested while
+    /// [`Self::request_realm_install`]/[`Self::request_realm_uninstall`]
     /// decided they must defer. Applied, in request order, by
     /// [`Self::drain_pending_realm_mutations`].
     pending_realm_mutations: Vec<RealmMapMutation>,
@@ -741,7 +753,44 @@ impl AppRuntime {
             .or_else(|| phases.first().copied())
     }
 
-    /// Requests a realm-registry install/uninstall.
+    /// The un-deferred application of an `Install` mutation: registers
+    /// `window`'s id in the `WindowRegistry` FIRST, strictly (never
+    /// replacing an existing mapping — an id collision is refused, not
+    /// silently re-routed onto a sibling realm's window), and only inserts
+    /// `slot` into `realms` once that registration succeeds. On
+    /// `Err`, `slot` (and the `UiRealm` it owns) is dropped by the caller;
+    /// this method itself never touches `realms` in that case.
+    fn apply_install(
+        &mut self,
+        id: RealmId,
+        slot: RealmSlot,
+        window: &Arc<dyn PlatformWindow>,
+    ) -> Result<(), RegistryError> {
+        self.registry.try_register(window.id(), slot.address)?;
+        self.realms.insert(id, slot);
+        Ok(())
+    }
+
+    /// The un-deferred application of an `Uninstall` mutation.
+    fn apply_uninstall(&mut self, id: RealmId) -> Option<RealmSlot> {
+        let removed = self.realms.remove(&id);
+        if removed.is_some() {
+            self.registry.remove_realm(id);
+        }
+        removed
+    }
+
+    /// Requests installing a newly-constructed realm, registering `window`'s
+    /// id and inserting `slot` into the registry TOGETHER, atomically from
+    /// every caller's perspective: either both happen now, or both are
+    /// queued as one [`RealmMapMutation::Install`] entry and both happen
+    /// together once the queue drains. This closes the gap a two-step
+    /// "register the window now, defer the realm insert" sequence would
+    /// otherwise leave open — a platform event addressed to the new
+    /// window's id arriving in that gap would find a `WindowRegistry` entry
+    /// but no matching `realms` entry, and `dispatch_platform_realm` would
+    /// misreport it as `StaleRealm` ("a newer realm replaced the one it was
+    /// dispatched for") instead of "this realm's install has not landed yet".
     ///
     /// Applied immediately unless a dispatch (`dispatched_realm_id` is
     /// `Some`) or an all-realms iteration (`iterating_all_realms`) is
@@ -753,7 +802,41 @@ impl AppRuntime {
     /// mid-hot-restart-visit never changes the set of realms
     /// `for_each_installed_realm` is still walking (its own tail).
     ///
-    /// Returns any [`RealmSlot`] an IMMEDIATE `Uninstall` removed, so the
+    /// `Err` only when applied immediately AND the window's id already maps
+    /// to a live entry — deferred installs cannot fail synchronously (the
+    /// caller has already returned by the time they apply); see
+    /// [`Self::drain_pending_realm_mutations`] for how that case is handled
+    /// instead (traced and dropped, never silently re-routed).
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "install_realm_alongside is design-for-N mechanism with no production \
+                      embedder call site yet -- exercised by this crate's own tests"
+        )
+    )]
+    pub(super) fn request_realm_install(
+        &mut self,
+        id: RealmId,
+        slot: RealmSlot,
+        window: Arc<dyn PlatformWindow>,
+    ) -> Result<(), RegistryError> {
+        if self.dispatched_realm_id.is_some() || self.iterating_all_realms {
+            self.pending_realm_mutations.push(RealmMapMutation::Install(
+                id,
+                Box::new(slot),
+                window,
+            ));
+            return Ok(());
+        }
+        self.apply_install(id, slot, &window)
+    }
+
+    /// Requests uninstalling one realm — a single window closing while
+    /// siblings stay open. Same defer-to-idle discipline as
+    /// [`Self::request_realm_install`]; see that method's doc for why.
+    ///
+    /// Returns any [`RealmSlot`] an IMMEDIATE uninstall removed, so the
     /// caller can drop it (and the `UiRealm` it owns) only after releasing
     /// whatever `APP_RUNTIME` borrow is live — the same discipline
     /// `install_platform_realm`/`teardown_platform_realm` already follow for
@@ -762,32 +845,17 @@ impl AppRuntime {
         not(test),
         expect(
             dead_code,
-            reason = "both production call sites (install_realm_alongside, \
-                      uninstall_platform_realm) are themselves design-for-N mechanism with \
-                      no production embedder call site yet -- exercised by this crate's own tests"
+            reason = "uninstall_platform_realm is design-for-N mechanism with no production \
+                      embedder call site yet -- exercised by this crate's own tests"
         )
     )]
-    pub(super) fn request_realm_mutation(
-        &mut self,
-        mutation: RealmMapMutation,
-    ) -> Option<RealmSlot> {
+    pub(super) fn request_realm_uninstall(&mut self, id: RealmId) -> Option<RealmSlot> {
         if self.dispatched_realm_id.is_some() || self.iterating_all_realms {
-            self.pending_realm_mutations.push(mutation);
+            self.pending_realm_mutations
+                .push(RealmMapMutation::Uninstall(id));
             return None;
         }
-        match mutation {
-            RealmMapMutation::Install(id, slot) => {
-                self.realms.insert(id, *slot);
-                None
-            }
-            RealmMapMutation::Uninstall(id) => {
-                let removed = self.realms.remove(&id);
-                if removed.is_some() {
-                    self.registry.remove_realm(id);
-                }
-                removed
-            }
-        }
+        self.apply_uninstall(id)
     }
 
     /// Applies every realm-map mutation deferred while a dispatch or an
@@ -796,21 +864,50 @@ impl AppRuntime {
     /// the tail of `for_each_installed_realm` (both `runner.rs`), and
     /// [`Self::should_exit`] (the drain-before-decide rule).
     ///
+    /// **Early-returns (drains nothing) while `dispatched_realm_id.is_some()
+    /// || iterating_all_realms` is still true** — a NESTED call reached
+    /// through one of those three call sites (e.g. a dispatch run from
+    /// inside a `for_each_installed_realm` visit, which that function's own
+    /// doc says is safe to attempt) must not apply a mutation an OUTER,
+    /// still-in-flight operation deferred: draining it early would remove a
+    /// realm's slot while that realm might still be the one checked out for
+    /// the outer visit, and the outer visit's own restore step
+    /// (`realm_slot.realm = Some(realm)` finding no slot to write into)
+    /// would then silently drop a live, un-torn-down `UiRealm` instead of
+    /// restoring it. All three legitimate call sites clear their OWN flag
+    /// before calling this, so the guard only ever blocks a genuinely nested
+    /// caller, never the outer operation whose completion is supposed to
+    /// trigger the drain.
+    ///
     /// Returns every removed [`RealmSlot`] (from a deferred `Uninstall`), for
     /// the caller to drop outside the live `APP_RUNTIME` borrow — see
-    /// [`Self::request_realm_mutation`]'s doc for why that discipline
-    /// matters here.
+    /// [`Self::request_realm_install`]'s doc for why that discipline matters
+    /// here.
     pub(super) fn drain_pending_realm_mutations(&mut self) -> Vec<RealmSlot> {
+        if self.dispatched_realm_id.is_some() || self.iterating_all_realms {
+            return Vec::new();
+        }
         let pending = std::mem::take(&mut self.pending_realm_mutations);
         let mut removed = Vec::new();
         for mutation in pending {
             match mutation {
-                RealmMapMutation::Install(id, slot) => {
-                    self.realms.insert(id, *slot);
+                RealmMapMutation::Install(id, slot, window) => {
+                    if let Err(error) = self.apply_install(id, *slot, &window) {
+                        // The realm this Install carried is dropped here,
+                        // with `slot` (and the `UiRealm` it owned) falling
+                        // out of scope at the end of this match arm --
+                        // never silently re-routed onto whichever sibling
+                        // realm already owns this window id.
+                        tracing::error!(
+                            ?id,
+                            ?error,
+                            "dropping a deferred realm install: its window id collided with an \
+                             already-registered mapping"
+                        );
+                    }
                 }
                 RealmMapMutation::Uninstall(id) => {
-                    if let Some(slot) = self.realms.remove(&id) {
-                        self.registry.remove_realm(id);
+                    if let Some(slot) = self.apply_uninstall(id) {
                         removed.push(slot);
                     }
                 }

--- a/crates/flui-app/src/app/runtime.rs
+++ b/crates/flui-app/src/app/runtime.rs
@@ -232,6 +232,205 @@ pub(crate) fn next_identity() -> (RealmId, PresentationId) {
     )
 }
 
+// ============================================================================
+// Multi-realm hosting (issue #555)
+// ============================================================================
+
+/// One realm's dispatch-adjacent state, keyed by [`RealmId`] in
+/// [`AppRuntime`]'s [`RealmRegistry`]. Bundles exactly what the single-slot
+/// design this replaces used to keep as flat `AppRuntime` fields (`realm`,
+/// `queue`, `draining`, `address`, `surface_applier`): each hosted realm now
+/// owns its own copy of all five, so a second realm's dispatch, resize
+/// routing, and reentrancy guard are independent of the first's — the
+/// concrete mechanism behind the end-state invariant that two windows share
+/// no mutable UI tree through `AppRuntime` (sharing happens only through
+/// explicit `SharedEngineServices`/app-model injection, never through this
+/// registry).
+#[cfg(not(target_os = "ios"))]
+pub(super) struct RealmSlot {
+    /// `None` while this realm is checked OUT of the registry for
+    /// [`dispatch_platform_realm`](super::runner) — the other four fields
+    /// stay in place throughout that checkout (never removed alongside
+    /// `realm`), so a nested same-realm dispatch still finds its target and
+    /// enqueues into `queue`, instead of reading back `StaleRealm`.
+    pub(super) realm: Option<UiRealm>,
+    /// This realm's own owner-thread work queue — never shared with a
+    /// sibling realm's queue, so draining one realm's events can never pop a
+    /// task meant for another.
+    pub(super) queue: VecDeque<RealmTask>,
+    /// Set while a queued task for THIS realm is running, so a reentrant
+    /// same-realm dispatch enqueues instead of recursing into `realm.take()`.
+    pub(super) draining: bool,
+    /// This realm's routable address — the per-slot replacement for the
+    /// single `AppRuntime.address: Option<PresentationAddress>` this type
+    /// used to be.
+    pub(super) address: PresentationAddress,
+    /// This realm's own registration-lifetime renderer-surface applier for a
+    /// `Resized` event — never shared with a sibling realm's applier, so a
+    /// resize addressed to one window can never resize another's surface.
+    pub(super) surface_applier: Option<SurfaceApplier>,
+}
+
+/// The [`RealmId`]-keyed, insertion-ordered realm registry `AppRuntime` hosts
+/// — the multi-realm replacement for the single `Option<UiRealm>` slot (plus
+/// its four sibling flat fields) this type used to be.
+///
+/// Insertion order matters: hot-restart's [`super::runner`]
+/// `for_each_installed_realm` and the exit-policy drain both visit realms in
+/// the order they were installed, i.e. mount order.
+///
+/// Storage is a linear-scan `Vec`, not a hash map: the number of live realms
+/// is the number of open top-level windows, small enough that O(n) lookup is
+/// not a real cost, and a `Vec` gives insertion order for free with no extra
+/// bookkeeping — the same reasoning `WindowRegistry` already applies to its
+/// own `Vec<(WindowId, PresentationAddress)>` storage.
+#[cfg(not(target_os = "ios"))]
+#[derive(Default)]
+pub(super) struct RealmRegistry {
+    slots: Vec<(RealmId, RealmSlot)>,
+}
+
+#[cfg(not(target_os = "ios"))]
+impl RealmRegistry {
+    pub(super) const fn new() -> Self {
+        Self { slots: Vec::new() }
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.slots.is_empty()
+    }
+
+    pub(super) fn get(&self, id: &RealmId) -> Option<&RealmSlot> {
+        self.slots
+            .iter()
+            .find(|(slot_id, _)| slot_id == id)
+            .map(|(_, slot)| slot)
+    }
+
+    pub(super) fn get_mut(&mut self, id: &RealmId) -> Option<&mut RealmSlot> {
+        self.slots
+            .iter_mut()
+            .find(|(slot_id, _)| slot_id == id)
+            .map(|(_, slot)| slot)
+    }
+
+    pub(super) fn contains_key(&self, id: &RealmId) -> bool {
+        self.slots.iter().any(|(slot_id, _)| slot_id == id)
+    }
+
+    /// Inserts `slot` at `id`, appending at the end of insertion order.
+    ///
+    /// `id` must not already be present: `next_identity` never repeats a
+    /// `RealmId`, and every removal path (`remove`/`clear`) drops the old
+    /// entry before a replacement is ever inserted, so a collision here
+    /// means a stale id was reused — a bug this debug_assert catches instead
+    /// of silently shadowing a live realm.
+    pub(super) fn insert(&mut self, id: RealmId, slot: RealmSlot) {
+        debug_assert!(
+            !self.contains_key(&id),
+            "BUG: RealmRegistry::insert called for an id already present -- \
+             next_identity never repeats a RealmId, so this means a stale id was reused"
+        );
+        self.slots.push((id, slot));
+    }
+
+    /// Removes and returns the slot at `id`, if present.
+    pub(super) fn remove(&mut self, id: &RealmId) -> Option<RealmSlot> {
+        let index = self.slots.iter().position(|(slot_id, _)| slot_id == id)?;
+        Some(self.slots.remove(index).1)
+    }
+
+    /// Removes and returns every slot, in insertion order — the
+    /// multi-realm generalization of `mem::take`-ing the old single
+    /// `Option` slot (`install_platform_realm`'s reinstall-without-teardown
+    /// path, and `teardown_platform_realm`'s full loop-exit teardown, both
+    /// use this).
+    pub(super) fn clear(&mut self) -> Vec<(RealmId, RealmSlot)> {
+        std::mem::take(&mut self.slots)
+    }
+
+    pub(super) fn iter(&self) -> impl Iterator<Item = &(RealmId, RealmSlot)> {
+        self.slots.iter()
+    }
+
+    /// Every installed `RealmId`, in insertion (mount) order — the read
+    /// `for_each_installed_realm` (`super::runner`) snapshots before it
+    /// starts checking realms out one at a time.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "for_each_installed_realm's only production driver is a follow-up; \
+                      exercised by this module's own tests via that function"
+        )
+    )]
+    pub(super) fn keys(&self) -> Vec<RealmId> {
+        self.slots.iter().map(|(id, _)| *id).collect()
+    }
+}
+
+/// A realm-registry install/uninstall requested while a mutation must defer
+/// (a dispatch or an all-realms iteration is in flight on this thread — see
+/// [`AppRuntime::request_realm_mutation`]). Applied in request order once
+/// the deferring condition clears.
+#[cfg(not(target_os = "ios"))]
+pub(super) enum RealmMapMutation {
+    /// Add a newly-constructed realm to the registry (never displaces a
+    /// sibling — see `install_realm_alongside` in `super::runner`). Boxed:
+    /// `RealmSlot` owns a whole `UiRealm`, over a kilobyte, next to
+    /// `Uninstall`'s bare `RealmId` -- boxing keeps this enum (and every
+    /// `Vec<RealmMapMutation>` queueing it) from paying that size for every
+    /// entry regardless of variant.
+    Install(RealmId, Box<RealmSlot>),
+    /// Remove one realm from the registry (a window closing while siblings
+    /// stay open — see `uninstall_platform_realm` in `super::runner`).
+    Uninstall(RealmId),
+}
+
+/// Governs when the platform loop should exit once every hosted realm's
+/// window has closed — the embedder-facing policy knob for the "new
+/// independent desktop window ⇒ new realm" production policy (ADR-0027 step
+/// 5's multi-window follow-up, issue #555).
+///
+/// Consulted through [`AppRuntime::should_exit`], which drains any deferred
+/// realm-map mutation FIRST (the drain-before-decide rule): a
+/// queued "open another window" install — e.g. a splash screen's dispose
+/// callback requesting the main window — is applied before the
+/// empty-registry check, so it vetoes exit instead of racing it. Without
+/// that ordering, a splash-close and a main-window-open landing in the same
+/// idle tick could observe "no realms installed" and exit before the queued
+/// install ever lands.
+///
+/// `#[non_exhaustive]`: a future variant (e.g. "never exit automatically;
+/// the embedder calls `quit()` itself") must not be a breaking change for a
+/// caller that already matches exhaustively — the same precedent
+/// `AttachError` set (`binding.rs`).
+///
+/// Not yet wired into a live platform loop: `run_desktop`/`run_android`/
+/// `run_web` still let each backend's own window-close handling
+/// (`flui-platform`'s per-backend `CloseRequested`/`on_should_close`
+/// handling) decide exit unconditionally. This type and
+/// `AppRuntime::should_exit` are the decision *mechanism* — the policy shape
+/// is the deliverable now, wiring a real winit multi-window loop through it
+/// is a follow-up (tracked as this issue's native-lifecycle slice).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the exit-policy mechanism has no production embedder call site yet -- \
+                  wiring a real winit multi-window loop through it is this issue's \
+                  native-lifecycle follow-up; exercised by this crate's own tests"
+    )
+)]
+pub enum ExitPolicy {
+    /// Exit once every hosted realm has closed and none is queued to open.
+    /// The default policy.
+    #[default]
+    OnLastWindowClosed,
+}
+
 /// Cross-thread wake capability for the platform event loop.
 ///
 /// Setting `needs_redraw` and poking a live window are two independent
@@ -286,36 +485,36 @@ impl FrameWakeHandle {
 /// # Design-for-N
 ///
 /// The realm-facing API is `RealmId`-keyed ([`AppRuntime::realm`]);
-/// *storage* is a single `Option<UiRealm>` slot until the element forest
-/// lets a realm host multiple presentations and this grows a real
-/// multi-realm registry. `next_identity` above already mints from a shape
-/// that does not need to change when that lands.
+/// *storage* is [`RealmRegistry`], an insertion-ordered map of any number of
+/// hosted realms (issue #555) — `next_identity` above already mints from a
+/// shape that never needed to change for this to land.
 #[cfg(not(target_os = "ios"))]
 pub(crate) struct AppRuntime {
-    /// The single hosted realm, when one is installed.
-    pub(super) realm: Option<UiRealm>,
-    /// Queued owner-thread work: cross-thread platform events plus the
-    /// co-located frame pump (see `runner.rs`'s `RealmTask`).
-    pub(super) queue: VecDeque<RealmTask>,
-    /// Set while a queued task is running, so a reentrant dispatch enqueues
-    /// instead of recursing into `realm.take()`.
-    pub(super) draining: bool,
-    /// The thread that installed the current realm; every dispatch checks
-    /// against this before touching the slot.
+    /// Every hosted realm, keyed by `RealmId`, in mount (insertion) order.
+    /// Replaces the single `Option<UiRealm>` slot (plus its four sibling
+    /// flat fields `queue`/`draining`/`address`/`surface_applier`) this
+    /// struct used to carry — see [`RealmSlot`]'s doc for why those four
+    /// moved inside the per-realm entry instead of staying flat.
+    pub(super) realms: RealmRegistry,
+    /// The thread that installed the first realm hosted here; every dispatch
+    /// checks against this before touching the registry. Loop-scoped, not
+    /// per-realm: every realm this `AppRuntime` ever hosts lives on the same
+    /// owner thread (`APP_RUNTIME` is thread-local), so one shared value is
+    /// exact, not an approximation of a per-realm concept.
     pub(super) owner_thread: Option<ThreadId>,
-    /// This realm incarnation's routable address — a derived cache of
-    /// `registry` below, not a second source of truth (see
-    /// `window_registry`'s module doc for the write-ordering invariant).
-    pub(super) address: Option<PresentationAddress>,
     /// The sole native-window-to-presentation mapping authority (ADR-0037
-    /// §2). A future multi-window `AppRuntime` lifts this unchanged — the
-    /// type itself has no TLS assumption baked in.
+    /// §2), already `RealmId`-keyed and multi-window-shaped — see its own
+    /// module doc.
     pub(super) registry: WindowRegistry,
-    /// The registration-lifetime renderer-surface applier for a `Resized`
-    /// event; installed once at realm install, cleared at teardown.
-    pub(super) surface_applier: Option<SurfaceApplier>,
     /// Single-window `(visible, focused)` tracking for the
     /// `AppLifecycleState` derivation (ADR-0035). Both default `true`.
+    ///
+    /// **Known limitation, stated rather than silently overclaimed:** this
+    /// pair is still loop-scoped, not per-realm — with more than one
+    /// hosted realm, a focus/visibility change on any one window's OS
+    /// signal drives the SAME derivation for the whole loop. Per-realm
+    /// lifecycle derivation is `FocusCoordinator` territory (a later, exact-routing
+    /// slice of issue #555), out of this change's scope.
     pub(super) visible: bool,
     pub(super) focused: bool,
     /// The loop-scoped owner-thread platform capability (ADR-0039 §6).
@@ -323,24 +522,49 @@ pub(crate) struct AppRuntime {
     /// another realm before it exits (hot-restart does exactly this).
     pub(super) owner_platform: Option<OwnerPlatform>,
     /// A clone of the currently-dispatched realm's scheduler, held ONLY
-    /// while `dispatch_platform_realm` (in `runner.rs`) has taken that realm
-    /// out of `realm` above for the duration of a queued task. Without this,
-    /// [`Self::installed_realm_phase`] (`with_owner_platform`'s fence (c))
-    /// reads `None` for the realm's entire dispatched extent — not just when
-    /// no realm is installed at all — because `dispatch_platform_realm`
-    /// checks the realm OUT of this struct before running any task,
-    /// including the frame pump that drives the scheduler through
-    /// `PersistentCallbacks`. That makes the fence blind exactly when a
-    /// frame phase is actually running, which is the one case trigger #22
-    /// exists to catch. `Scheduler` is a single-`Arc` handle (see
+    /// while `dispatch_platform_realm` (in `runner.rs`) has taken that
+    /// realm's slot out of `realms` above for the duration of a queued task.
+    /// Without this, [`Self::installed_realm_phase`] (`with_owner_platform`'s
+    /// fence (c)) reads `None` for the realm's entire dispatched extent —
+    /// not just when no realm is installed at all — because
+    /// `dispatch_platform_realm` checks the realm's `UiRealm` OUT of its slot
+    /// before running any task, including the frame pump that drives the
+    /// scheduler through `PersistentCallbacks`. That makes the fence blind
+    /// exactly when a frame phase is actually running, which is the one case
+    /// trigger #22 exists to catch. `Scheduler` is a single-`Arc` handle (see
     /// `flui-scheduler`'s `Scheduler`/`SchedulerInner` split), so cloning it
     /// here to survive the checkout is cheap — an `Arc::clone`, not a new
     /// scheduler. Set at checkout, cleared at restore
     /// (`dispatch_platform_realm`), in both cases inside the same
-    /// `catch_unwind`-guarded block that restores `realm` itself, so an
-    /// unwinding dispatched task leaves this `None` exactly as reliably as
-    /// it leaves `realm` restored.
+    /// `catch_unwind`-guarded block that restores the realm's slot itself, so
+    /// an unwinding dispatched task leaves this `None` exactly as reliably as
+    /// it leaves the slot restored.
+    ///
+    /// Stays single-slot on purpose: dispatch is
+    /// single-threaded and sequential, so at most one realm is EVER checked
+    /// out on this thread at a given instant — [`RealmMapMutation`]'s
+    /// defer-to-idle discipline exists precisely so no second, nested
+    /// dispatch for a DIFFERENT realm is ever attempted while this is
+    /// `Some`; `dispatch_platform_realm` debug-asserts that invariant at its
+    /// one checkout site.
     pub(super) dispatched_scheduler: Option<Scheduler>,
+    /// The identity companion to `dispatched_scheduler` above: which realm
+    /// is currently checked out, so a nested dispatch attempt targeting a
+    /// DIFFERENT realm can be told apart from a legitimate same-realm
+    /// reentrant call (already handled by each slot's own `draining` flag).
+    pub(super) dispatched_realm_id: Option<RealmId>,
+    /// Set for the duration of `for_each_installed_realm`'s (`runner.rs`)
+    /// hot-restart-shaped visit over every hosted realm. A realm-map
+    /// mutation requested while this is `true` defers exactly like one
+    /// requested while `dispatched_realm_id` is `Some` — see
+    /// [`Self::request_realm_mutation`] — so a mutation triggered by a
+    /// callback running mid-visit never changes the set of realms that same
+    /// visit is still walking.
+    pub(super) iterating_all_realms: bool,
+    /// Realm-map mutations requested while [`Self::request_realm_mutation`]
+    /// decided they must defer. Applied, in request order, by
+    /// [`Self::drain_pending_realm_mutations`].
+    pending_realm_mutations: Vec<RealmMapMutation>,
     /// Process-level engine services. Deliberately **not** resolved in
     /// [`AppRuntime::new`] -- see [`AppRuntime::ensure_services`] for why.
     services: OnceCell<SharedEngineServices>,
@@ -396,17 +620,16 @@ impl AppRuntime {
     /// and this change does not touch it.
     pub(super) fn new() -> Self {
         Self {
-            realm: None,
-            queue: VecDeque::new(),
-            draining: false,
+            realms: RealmRegistry::new(),
             owner_thread: None,
-            address: None,
             registry: WindowRegistry::new(),
-            surface_applier: None,
             visible: true,
             focused: true,
             owner_platform: None,
             dispatched_scheduler: None,
+            dispatched_realm_id: None,
+            iterating_all_realms: false,
+            pending_realm_mutations: Vec::new(),
             services: OnceCell::new(),
             needs_redraw: Arc::new(AtomicBool::new(false)),
             redraw_window: Arc::new(Mutex::new(None)),
@@ -450,25 +673,34 @@ impl AppRuntime {
         self.services.get().is_some()
     }
 
-    /// `RealmId`-keyed lookup: `Some` only when `id` matches the single
-    /// installed realm's identity. Storage is one slot until the element
-    /// forest lets a realm host multiple presentations and `AppRuntime`
-    /// grows a real multi-realm registry — the keyed shape is the
-    /// deliverable now, so that growth does not have to reshape this
-    /// method's callers, only its body.
+    /// `RealmId`-keyed lookup: `Some` only when `id` names a currently
+    /// hosted (resident, not checked-out) realm. Storage is
+    /// [`RealmRegistry`], so this scales to however many realms are
+    /// actually installed rather than a single degenerate slot.
     #[cfg_attr(
         not(test),
         expect(
             dead_code,
             reason = "design-for-N accessor; the single production caller \
                       (per-realm dispatch) still addresses the TLS slot \
-                      directly until the element forest lets a realm host \
-                      multiple presentations and this grows a real \
-                      multi-realm registry"
+                      directly"
         )
     )]
     pub(crate) fn realm(&self, id: RealmId) -> Option<&UiRealm> {
-        self.realm.as_ref().filter(|realm| realm.realm_id() == id)
+        self.realms.get(&id).and_then(|slot| slot.realm.as_ref())
+    }
+
+    /// True if `phase` is one of the phases `with_owner_platform`'s fence (c)
+    /// forbids: a frame transaction genuinely in flight, as opposed to
+    /// `Idle`/`PostFrameCallbacks`, both of which are legitimate times to
+    /// acquire owner-platform capability (ADR-0021-style post-frame work).
+    fn is_frame_transaction_phase(phase: flui_scheduler::SchedulerPhase) -> bool {
+        matches!(
+            phase,
+            flui_scheduler::SchedulerPhase::TransientCallbacks
+                | flui_scheduler::SchedulerPhase::MidFrameMicrotasks
+                | flui_scheduler::SchedulerPhase::PersistentCallbacks
+        )
     }
 
     /// The installed realm's scheduler phase, or `None` if no realm is
@@ -476,22 +708,156 @@ impl AppRuntime {
     /// dispatch either — the replacement for `with_owner_platform`'s fence
     /// (c), formerly a bare `Scheduler::instance().phase()` read.
     ///
-    /// Falls back to [`Self::dispatched_scheduler`] when `realm` itself is
-    /// empty: `dispatch_platform_realm` takes the realm OUT of `realm` for
-    /// the entire extent of a queued task (including the frame pump that
-    /// drives `PersistentCallbacks`), so reading only `realm` here would
-    /// make this probe blind for every production frame, not merely when no
-    /// realm is installed at all. `None` (truly no realm, and none
-    /// dispatched) is vacuous-but-truthful: no realm means no frame
-    /// transaction can be in flight on this thread, so the caller's
-    /// "not mid-frame" assertion holds trivially. Storage is the single slot
-    /// until the element forest lets a realm host multiple presentations; a
-    /// future multi-realm `AppRuntime` iterates its slot set here instead.
+    /// **Design-for-N (issue #555): iterates every resident slot in
+    /// `realms`**, rather than assuming a single slot is "the" realm that
+    /// matters — but checks [`Self::dispatched_scheduler`] FIRST: dispatch is
+    /// single-threaded and sequential, so whenever a realm is checked out for
+    /// `dispatch_platform_realm` (the entire extent of a queued task,
+    /// including the frame pump that drives `PersistentCallbacks`), every
+    /// OTHER resident realm is necessarily `Idle`/`PostFrameCallbacks` (no
+    /// two realms ever run their frame pump concurrently on one thread) —
+    /// reading `dispatched_scheduler` first is therefore both sufficient and
+    /// exact for that case, not merely a fallback. Only once nothing is
+    /// checked out does this fall through to scanning `realms` itself, so an
+    /// addressed probe (this dispatch's own realm) and the aggregate fence
+    /// both stay correct without duplicating the forbidden-phase list. Reads
+    /// `Some(Idle)` (not `None`) when every resident realm is quiescent,
+    /// matching this function's pre-registry single-slot behavior exactly
+    /// for the common one-realm case.
     pub(super) fn installed_realm_phase(&self) -> Option<flui_scheduler::SchedulerPhase> {
-        self.realm
-            .as_ref()
+        if let Some(scheduler) = self.dispatched_scheduler.as_ref() {
+            return Some(scheduler.phase());
+        }
+        let phases: Vec<_> = self
+            .realms
+            .iter()
+            .filter_map(|(_, slot)| slot.realm.as_ref())
             .map(|realm| realm.scheduler().phase())
-            .or_else(|| self.dispatched_scheduler.as_ref().map(Scheduler::phase))
+            .collect();
+        phases
+            .iter()
+            .copied()
+            .find(|phase| Self::is_frame_transaction_phase(*phase))
+            .or_else(|| phases.first().copied())
+    }
+
+    /// Requests a realm-registry install/uninstall.
+    ///
+    /// Applied immediately unless a dispatch (`dispatched_realm_id` is
+    /// `Some`) or an all-realms iteration (`iterating_all_realms`) is
+    /// currently in flight on this thread, in which case it queues instead —
+    /// the mechanism behind two contracts: an install requested from inside a
+    /// dispatched frame callback never nests into a second, concurrent
+    /// dispatch (it lands once the outer dispatch's restore completes,
+    /// `dispatch_platform_realm`'s tail), and a mutation requested
+    /// mid-hot-restart-visit never changes the set of realms
+    /// `for_each_installed_realm` is still walking (its own tail).
+    ///
+    /// Returns any [`RealmSlot`] an IMMEDIATE `Uninstall` removed, so the
+    /// caller can drop it (and the `UiRealm` it owns) only after releasing
+    /// whatever `APP_RUNTIME` borrow is live — the same discipline
+    /// `install_platform_realm`/`teardown_platform_realm` already follow for
+    /// every other realm-owning drop in this module.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "both production call sites (install_realm_alongside, \
+                      uninstall_platform_realm) are themselves design-for-N mechanism with \
+                      no production embedder call site yet -- exercised by this crate's own tests"
+        )
+    )]
+    pub(super) fn request_realm_mutation(
+        &mut self,
+        mutation: RealmMapMutation,
+    ) -> Option<RealmSlot> {
+        if self.dispatched_realm_id.is_some() || self.iterating_all_realms {
+            self.pending_realm_mutations.push(mutation);
+            return None;
+        }
+        match mutation {
+            RealmMapMutation::Install(id, slot) => {
+                self.realms.insert(id, *slot);
+                None
+            }
+            RealmMapMutation::Uninstall(id) => {
+                let removed = self.realms.remove(&id);
+                if removed.is_some() {
+                    self.registry.remove_realm(id);
+                }
+                removed
+            }
+        }
+    }
+
+    /// Applies every realm-map mutation deferred while a dispatch or an
+    /// all-realms iteration was in flight, in request order. Called once the
+    /// deferring condition clears: the tail of `dispatch_platform_realm` and
+    /// the tail of `for_each_installed_realm` (both `runner.rs`), and
+    /// [`Self::should_exit`] (the drain-before-decide rule).
+    ///
+    /// Returns every removed [`RealmSlot`] (from a deferred `Uninstall`), for
+    /// the caller to drop outside the live `APP_RUNTIME` borrow — see
+    /// [`Self::request_realm_mutation`]'s doc for why that discipline
+    /// matters here.
+    pub(super) fn drain_pending_realm_mutations(&mut self) -> Vec<RealmSlot> {
+        let pending = std::mem::take(&mut self.pending_realm_mutations);
+        let mut removed = Vec::new();
+        for mutation in pending {
+            match mutation {
+                RealmMapMutation::Install(id, slot) => {
+                    self.realms.insert(id, *slot);
+                }
+                RealmMapMutation::Uninstall(id) => {
+                    if let Some(slot) = self.realms.remove(&id) {
+                        self.registry.remove_realm(id);
+                        removed.push(slot);
+                    }
+                }
+            }
+        }
+        removed
+    }
+
+    /// Teardown-only introspection: whether any realm-map mutation is still
+    /// waiting to be applied. Should always be `false` by the time
+    /// `teardown_platform_realm` (full loop-exit teardown) runs: both
+    /// `dispatch_platform_realm` and `for_each_installed_realm` drain
+    /// unconditionally in their own tails (panic or not), so nothing should
+    /// ever still be queued once every in-flight dispatch/iteration has
+    /// completed. `teardown_platform_realm` asserts this rather than
+    /// silently dropping a still-pending mutation (and the `UiRealm` an
+    /// `Install` mutation might still be holding) unnoticed.
+    pub(super) fn has_pending_realm_mutations(&self) -> bool {
+        !self.pending_realm_mutations.is_empty()
+    }
+
+    /// Whether the loop should exit under `policy`, given the realms
+    /// currently hosted, plus any [`RealmSlot`]s a deferred mutation just
+    /// removed (drop these outside the `APP_RUNTIME` borrow, same as every
+    /// other realm-owning drop in this module).
+    ///
+    /// **Drain-before-decide:** calls
+    /// [`Self::drain_pending_realm_mutations`] BEFORE checking `policy` — a
+    /// queued install (e.g. a splash screen's dispose callback requesting the
+    /// main window) is applied first, so it vetoes exit instead of racing the
+    /// empty-registry check. Without that ordering, a splash-close and a
+    /// main-window-open landing in the same idle tick could observe "no
+    /// realms installed" and exit before the queued install ever lands.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the exit-policy mechanism has no production embedder call site yet -- \
+                      exercised by this crate's own tests"
+        )
+    )]
+    pub(super) fn should_exit(&mut self, policy: ExitPolicy) -> (bool, Vec<RealmSlot>) {
+        let removed = self.drain_pending_realm_mutations();
+        let exit = match policy {
+            ExitPolicy::OnLastWindowClosed => self.realms.is_empty(),
+        };
+        (exit, removed)
     }
 
     // ========================================================================
@@ -706,7 +1072,7 @@ mod app_runtime_tests {
         let runtime = AppRuntime::new();
 
         assert!(
-            runtime.realm.is_none(),
+            runtime.realms.is_empty(),
             "a freshly constructed AppRuntime hosts no realm yet"
         );
         assert!(

--- a/crates/flui-app/src/app/window_registry.rs
+++ b/crates/flui-app/src/app/window_registry.rs
@@ -27,18 +27,12 @@ use flui_foundation::{PresentationAddress, RealmId};
 use flui_platform::traits::{PlatformWindow, WindowId};
 
 /// Errors from [`WindowRegistry::try_register`].
-// The strict path has no production call site yet (today's single-window
-// install always uses the replace semantics of `register_window`); it is
-// reserved for a future multi-window install path that chooses
-// strict-vs-replace per call site, and is exercised by this module's own
-// tests in the meantime.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "reserved for a future multi-window install path; exercised by this module's tests"
-    )
-)]
+///
+/// Reached from `AppRuntime::apply_install`
+/// (`crates/flui-app/src/app/runtime.rs`): the strict, refuse-on-collision
+/// path `install_realm_alongside`'s non-displacing install uses, so a
+/// second realm's window id colliding with an already-registered one is
+/// refused rather than silently re-routed onto the sibling's mapping.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum RegistryError {
@@ -127,19 +121,9 @@ impl WindowRegistry {
         displaced
     }
 
-    /// The strict, design-for-N alternative to [`Self::register_window`]:
-    /// refuses instead of replacing when `id` is already mapped.
-    ///
-    /// Not dead code despite zero production call sites today — exercised
-    /// by this module's own tests, and reserved for a future multi-window
-    /// install path that chooses strict-vs-replace per call site.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "reserved for a future multi-window install path; exercised by this module's tests"
-        )
-    )]
+    /// The strict alternative to [`Self::register_window`]: refuses instead
+    /// of replacing when `id` is already mapped. See [`RegistryError`]'s doc
+    /// for its one production caller.
     pub(crate) fn try_register(
         &mut self,
         id: WindowId,

--- a/crates/flui-app/src/app/window_registry.rs
+++ b/crates/flui-app/src/app/window_registry.rs
@@ -5,28 +5,36 @@
 //! registry, or a platform callback. This module is that authority's home.
 //! `WindowId` (the platform-internal native-handle key) is confined to this
 //! file within `flui-app` — every other module addresses a presentation
-//! through [`PresentationAddress`] only, minted here. The mechanical
-//! `forbidden_pattern` scan in `docs/runtime-contract.toml` confines the
-//! `WindowId` token itself to this one file within `crates/flui-app/src`.
+//! through [`PresentationAddress`] only, minted here. Every write path
+//! (`register_window`, `try_register_window`) takes a `&Arc<dyn
+//! PlatformWindow>` and derives the id itself; no caller outside this file
+//! ever names or passes a bare `WindowId`. The mechanical `forbidden_pattern`
+//! scan in `docs/runtime-contract.toml` confines the `WindowId` token itself
+//! to this one file within `crates/flui-app/src`.
 //!
 //! # Derived-cache invariant
 //!
-//! `AppRuntime.address: Option<PresentationAddress>` (`app/runtime.rs`) is a
-//! **derived cache** of this registry, not a second source of truth. Both
-//! are written only by `install_platform_realm`/`teardown_platform_realm`,
-//! inside the same TLS borrow, in that order: on install, the registry is
-//! written first (which also removes every mapping of a realm displaced by
-//! a panic-recovery reinstall — never just the new window), then the
-//! cache; on teardown, the registry entries are removed first — so map
-//! removal stops new routing before the queued old-generation events still
-//! sitting in the host's queue are dropped (ADR-0037 §2).
+//! Each hosted realm's own `RealmSlot.address: PresentationAddress`
+//! (`app/runtime.rs`'s `RealmRegistry`) is a **derived cache** of this
+//! registry, not a second source of truth. Both are written together, in
+//! the same TLS borrow: `install_platform_realm`/`teardown_platform_realm`
+//! for the legacy single-primary-realm path, and `AppRuntime::apply_install`/
+//! `apply_uninstall` for the multi-realm registry/uninstall path (issue
+//! #555) — in each case the registry write and the `RealmSlot` write happen
+//! inside the same borrow, in the order ADR-0037 §2 requires: on install,
+//! the registry is written first (which also removes every mapping of a
+//! realm displaced by a panic-recovery reinstall — never just the new
+//! window), then the realm entry; on uninstall/teardown, the registry
+//! entries are removed first — so map removal stops new routing before the
+//! queued old-generation events still sitting in the host's queue are
+//! dropped.
 
 use std::sync::Arc;
 
 use flui_foundation::{PresentationAddress, RealmId};
 use flui_platform::traits::{PlatformWindow, WindowId};
 
-/// Errors from [`WindowRegistry::try_register`].
+/// Errors from [`WindowRegistry::try_register_window`].
 ///
 /// Reached from `AppRuntime::apply_install`
 /// (`crates/flui-app/src/app/runtime.rs`): the strict, refuse-on-collision
@@ -36,7 +44,7 @@ use flui_platform::traits::{PlatformWindow, WindowId};
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum RegistryError {
-    /// The window already has a mapped address; `try_register` never
+    /// The window already has a mapped address; `try_register_window` never
     /// replaces (use [`WindowRegistry::register_window`] for replace
     /// semantics).
     #[error("window is already mapped to {existing:?}")]
@@ -76,8 +84,8 @@ impl WindowRegistry {
     /// registry lives alongside, and the web host never tears down at all — a hard error here
     /// would brick reinstall on either path. A replacement is traced at
     /// `warn` with both addresses so a genuine double-install bug is still
-    /// visible; [`Self::try_register`] is the strict alternative for a
-    /// caller that wants a hard error instead.
+    /// visible; [`Self::try_register_window`] is the strict alternative for
+    /// a caller that wants a hard error instead.
     ///
     /// This only replaces the mapping for the exact same `WindowId` — it
     /// does **not** remove any *other* window mapped to a realm this
@@ -122,9 +130,33 @@ impl WindowRegistry {
     }
 
     /// The strict alternative to [`Self::register_window`]: refuses instead
-    /// of replacing when `id` is already mapped. See [`RegistryError`]'s doc
-    /// for its one production caller.
-    pub(crate) fn try_register(
+    /// of replacing when `window`'s id is already mapped. See
+    /// [`RegistryError`]'s doc for its one production caller.
+    ///
+    /// Calls `window.id()` internally, exactly like [`Self::register_window`]
+    /// does — so a caller outside this file (`AppRuntime::apply_install`,
+    /// specifically) derives and pairs a window's id with an address without
+    /// ever naming [`WindowId`] itself. Before this method existed,
+    /// `apply_install` called `window.id()` directly and passed the raw
+    /// `WindowId` across the module boundary to [`Self::try_register`] (the
+    /// bare, id-taking primitive below) — a second native-window-lookup path
+    /// this module's own single-authority contract (ADR-0037 §2) forbids.
+    pub(crate) fn try_register_window(
+        &mut self,
+        window: &Arc<dyn PlatformWindow>,
+        address: PresentationAddress,
+    ) -> Result<(), RegistryError> {
+        self.try_register(window.id(), address)
+    }
+
+    /// The bare, `WindowId`-taking primitive [`Self::try_register_window`]
+    /// wraps. Private: only this module's own test submodule (which
+    /// constructs a `WindowId` directly to probe collision handling without
+    /// needing a real `PlatformWindow`) can reach it, since a nested `mod
+    /// tests` sees its parent module's private items. Every OTHER caller, in
+    /// or out of this file, goes through `try_register_window` instead,
+    /// never naming `WindowId` itself.
+    fn try_register(
         &mut self,
         id: WindowId,
         address: PresentationAddress,

--- a/docs/runtime-contract.toml
+++ b/docs/runtime-contract.toml
@@ -275,66 +275,118 @@ evidence = [
 key = "app-runtime-composition-host"
 statement = """
 `AppRuntime`, a loop-scoped composition root, now exists: it owns platform \
-event-loop demux, the single realm slot, `SharedEngineServices` \
-(painting/semantics -- the scheduler moved to a per-realm owned field, see \
-`idle-only-commit-points` and the deleted `SchedulerRef` seam), the \
-loop-scoped frame-wake mechanism, and the platform clipboard, \
-resolved/installed once, when a realm is actually installed. The \
-transitional process-service host (`AppBinding`) it used to coexist with is \
-retired: its fields dissolved into `AppRuntime` (loop-scoped: wake, \
-clipboard) and `UiRealm`/`PresentationState` (realm/presentation-scoped: \
-renderer, scheduler, vsync, frame accounting, haptics). It is not yet the \
-target statement in full: it is one TLS-scoped instance per owner thread \
-(`APP_RUNTIME` in `runner.rs`), not one per process; and its realm storage \
-is a single slot behind a `RealmId`-keyed accessor, not real 1..N hosting -- \
-that needs the element forest to let a realm host multiple presentations.
+event-loop demux, `SharedEngineServices` (painting/semantics -- the \
+scheduler moved to a per-realm owned field, see `idle-only-commit-points` \
+and the deleted `SchedulerRef` seam), the loop-scoped frame-wake mechanism, \
+and the platform clipboard, resolved/installed once, when a realm is \
+actually installed. The transitional process-service host (`AppBinding`) it \
+used to coexist with is retired: its fields dissolved into `AppRuntime` \
+(loop-scoped: wake, clipboard) and `UiRealm`/`PresentationState` \
+(realm/presentation-scoped: renderer, scheduler, vsync, frame accounting, \
+haptics).
+
+**The single-slot caveat this contract used to carry is now cleared:** \
+`AppRuntime`'s realm storage is `RealmRegistry`, a `RealmId`-keyed, \
+insertion-ordered registry of any number of simultaneously hosted realms \
+(`crates/flui-app/src/app/runtime.rs`), not a single `Option<UiRealm>` slot. \
+Each hosted realm's dispatch-adjacent state (`RealmSlot`: its `UiRealm`, its \
+own owner-thread queue, its own reentrancy-guard flag, its own routable \
+address, its own resize applier) is bundled per entry, so two realms hosted \
+by the SAME `AppRuntime` share none of it -- proven THROUGH `AppRuntime` \
+itself (not merely via directly-held `UiRealm` values) by \
+`two_window_realms_share_no_ui_state_through_app_runtime`. A realm tearing \
+itself down mid-dispatch leaves a sibling realm fully able to keep \
+dispatching and presenting frames \
+(`teardown_realm_a_mid_dispatch_leaves_realm_b_frame_producing`). \
+`#[non_exhaustive] pub enum ExitPolicy` (default `OnLastWindowClosed`) plus \
+`AppRuntime::should_exit` decide loop exit only after draining any realm-map \
+mutation deferred while a dispatch or an all-realms visit was in flight (the \
+drain-before-decide rule) -- a queued "open the main window" install vetoes \
+exit even in the same batch as the closing realm's own uninstall \
+(`close_splash_then_open_main_does_not_exit`), and closing one of several \
+hosted realms never exits the loop while a sibling survives \
+(`closing_one_of_two_windows_does_not_exit_the_loop`). A realm-map mutation \
+requested from inside a dispatched frame callback, or from inside \
+`for_each_installed_realm`'s (hot-restart's own primitive) visit over every \
+hosted realm, always defers to loop idle rather than nesting into a second, \
+concurrent dispatch or shifting the set of realms still being walked \
+(`frame_callback_opening_a_window_installs_second_realm_without_nested_dispatch`, \
+`hot_restart_while_callback_mutates_realm_map_defers_mutation`) -- backed by \
+a `dispatch_platform_realm` debug_assert against nested cross-realm \
+dispatch, which the registry's defer-to-idle discipline makes structurally \
+unreachable in production.
+
+It is still not yet the target statement in full, for reasons unrelated to \
+the single-slot caveat: it remains one TLS-scoped instance per owner thread \
+(`APP_RUNTIME` in `runner.rs`), not one per process; no production embedder \
+call site opens a genuinely second native window through \
+`install_realm_alongside`/`uninstall_platform_realm` yet (today's \
+`run_desktop`/`run_android`/`run_web` bootstraps still each open exactly \
+one, through the legacy displacing `install_platform_realm`) -- that native \
+wiring, plus `ExitPolicy` actually gating a live winit loop's exit instead \
+of the platform backend's own unconditional "last window closed" signal, is \
+this issue's native-lifecycle follow-up; and a REALM hosting more than one \
+PRESENTATION (the element forest) is a separate, still-unstarted claim this \
+contract does not yet make.
 
 `with_owner_platform`'s fence (c) (ADR-0039 §6, trigger #22's runtime \
 backstop) re-points onto this struct: `AppRuntime::installed_realm_phase` \
-reads the resident realm's own scheduler phase instead of the retired \
+reads every resident realm's own scheduler phase instead of the retired \
 `Scheduler::instance().phase()`. Its `None` case is truthfully vacuous only \
 for "no realm installed" -- bootstrap paths (`run_direct`, and any owner \
 thread before its first realm) never install one, so the fence holds \
 trivially there, which is a strict improvement over the singleton-era probe \
 (that one *constructed* a full `Scheduler` singleton just to read `Idle`). \
-But `dispatch_platform_realm` also checks the resident realm OUT of \
-`AppRuntime.realm` for the entire duration of every dispatched task \
+But `dispatch_platform_realm` also checks the dispatched realm's `UiRealm` \
+OUT of its registry slot for the entire duration of every dispatched task \
 (including the frame pump that drives `PersistentCallbacks`), which would \
 make `installed_realm_phase` read `None` -- and the fence pass vacuously -- \
-for every real production frame, not merely at bootstrap. The dispatched-frame \
-marker closes that gap: `dispatch_platform_realm` stashes a clone of the \
-checked-out realm's scheduler into `AppRuntime.dispatched_scheduler` \
-(`Scheduler` is a single-`Arc` handle, so this is one cheap `Arc::clone`, \
-not a second scheduler) before running the queued task, and \
-`installed_realm_phase` falls back to it whenever `realm` itself is empty; \
-both the ordinary return path and the `catch_unwind`-guarded restore on an \
-unwinding dispatched task clear the field, so it never survives past the \
-dispatch it was stashed for.
+for every real production frame, not merely at bootstrap. The \
+dispatched-frame marker closes that gap: `dispatch_platform_realm` stashes \
+a clone of the checked-out realm's scheduler into \
+`AppRuntime.dispatched_scheduler` (`Scheduler` is a single-`Arc` handle, so \
+this is one cheap `Arc::clone`, not a second scheduler) before running the \
+queued task, and `installed_realm_phase` falls back to it whenever nothing \
+resident matches; both the ordinary return path and the \
+`catch_unwind`-guarded restore on an unwinding dispatched task clear the \
+field, so it never survives past the dispatch it was stashed for. A \
+two-realm fence probe -- one realm mid-`PersistentCallbacks`, a fully idle \
+sibling also resident -- proves this is not an "OR of all Idle" check a lone \
+idle sibling could vacuously satisfy \
+(`owner_platform_accessor_fences_correctly_with_a_second_idle_realm_present`).
 
-Singleton retirement itself is now COMPLETE (issue #553's own scope): the \
-transitional `REALM_CLAIMED` at-most-one guard and `UiRealmError::AlreadyExists` \
-are deleted, `flui_foundation::{BindingBase, HasInstance, impl_binding_singleton!}` \
-no longer exist at all, and `two_realms_coexist_same_thread` / \
+Singleton retirement itself is COMPLETE (issue #553's own scope, now \
+closed): the transitional `REALM_CLAIMED` at-most-one guard and \
+`UiRealmError::AlreadyExists` are deleted, \
+`flui_foundation::{BindingBase, HasInstance, impl_binding_singleton!}` no \
+longer exist at all, and `two_realms_coexist_same_thread` / \
 `two_realms_two_threads_no_shared_state` / `dropping_realm_a_cannot_wake_realm_b` / \
 `cross_realm_duplicate_global_key_mounts_succeed_in_both` prove two \
 directly-constructed `UiRealm`s share no widget/focus/gesture-arena/scheduler \
 state, on one thread or two. This state stays "partial", not "implemented", \
-because the earlier single-slot/single-TLS-instance caveat in this \
-statement is still true and is a SEPARATE claim from singleton retirement: \
-the coexistence tests construct realms directly, never through an \
-`AppRuntime` hosting two of them at once (that needs the element forest, \
-tracked under #555) -- marking this contract fully "implemented" would \
-overclaim exactly the gap issue #555 exists to close.\
+because the remaining gaps stated above (native second-window wiring, a \
+realm hosting more than one presentation) are real and unclosed -- marking \
+this contract fully "implemented" would overclaim past what has actually \
+landed.\
 """
 state = "partial"
 domain = "application"
-owner_issue = 553
+owner_issue = 555
 mechanical = true
 mechanism = "symbol/test existence pinned here; later changes advance disposition further"
 evidence = [
     { kind = "symbol", file = "crates/flui-app/src/app/runtime.rs", contains = "pub(crate) struct AppRuntime" },
-    { kind = "test", file = "crates/flui-app/src/app/runtime.rs", contains = "fn app_runtime_owns_registry_and_realm_slot" },
+    { kind = "symbol", file = "crates/flui-app/src/app/runtime.rs", contains = "pub(super) struct RealmRegistry" },
+    { kind = "symbol", file = "crates/flui-app/src/app/runtime.rs", contains = "pub(super) struct RealmSlot" },
+    { kind = "symbol", file = "crates/flui-app/src/app/runtime.rs", contains = "pub enum ExitPolicy" },
     { kind = "symbol", file = "crates/flui-app/src/app/runtime.rs", contains = "dispatched_scheduler: Option<Scheduler>" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn two_window_realms_share_no_ui_state_through_app_runtime" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn teardown_realm_a_mid_dispatch_leaves_realm_b_frame_producing" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn closing_one_of_two_windows_does_not_exit_the_loop" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn close_splash_then_open_main_does_not_exit" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn frame_callback_opening_a_window_installs_second_realm_without_nested_dispatch" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn hot_restart_while_callback_mutates_realm_map_defers_mutation" },
+    { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn owner_platform_accessor_fences_correctly_with_a_second_idle_realm_present" },
     { kind = "test", file = "crates/flui-app/src/app/runner.rs", contains = "fn owner_platform_accessor_fences_the_installed_realms_frame_transaction_through_dispatch" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn two_realms_coexist_same_thread" },
     { kind = "test", file = "crates/flui-app/src/app/ui_realm.rs", contains = "fn two_realms_two_threads_no_shared_state" },


### PR DESCRIPTION
Slice 1 of #555 (independent of the GlobalKeyScope slice #604; the presentation forest lands next on top of both).

## What

- **`AppRuntime`'s realm storage generalized** from a single slot to `RealmRegistry` — a `RealmId`-keyed, insertion-ordered map. The frame-boundary fence iterates resident slots with the addressed-probe fast path via `dispatched_scheduler` (plus a debug-assert against nested cross-realm dispatch); a visited realm counts as dispatched for fence purposes, so the fence is never blind during iteration.
- **`#[non_exhaustive] pub enum ExitPolicy`**, default `OnLastWindowClosed`, with the drain-before-decide rule documented on the enum and implemented in `AppRuntime::should_exit`: the exit decision is taken only after draining the realm inbox, so a queued open-window command vetoes exit (pinned by the close-splash-then-open-main exploit driven through the real visit seam). Live winit wiring is deliberately deferred to the native-lifecycle slice per the plan ladder — no production caller exists yet and the registry contract says so honestly (`app-runtime-composition-host` stays `partial`).
- **Deferred realm-map mutation protocol**: install/uninstall requests arriving while a realm is checked out or iteration is in flight defer to loop idle (`drain_pending_realm_mutations` guards on both), with panic-safe iteration (`for_each_installed_realm` uses the same catch_unwind + restore + flag-clear + drain + resume_unwind bracket as dispatch — a panicking visit cannot strand a realm or wedge the iteration flag). Atomic alongside-install: the window registration rides inside `RealmMapMutation::Install`, so no event can route to a not-yet-installed realm; window-id collisions are refused via `try_register` and surfaced as `RegistryError::WindowAlreadyMapped`, with the rejected slot dropped only after the TLS borrow releases (destructors may re-enter framework code).
- **End-state invariant** documented and test-pinned: two windows share no mutable UI tree through `AppRuntime`; sharing only via explicit engine-service/app-model injection.

## Evidence

- 7 planned red-exploits + 5 review-driven regression tests, several mutant-verified by the reviewer independently: the fence probe fails when the phase scan is deleted; the panic-restore test fails when the restore line is deleted (strengthened after the first version was proven vacuous — an `Ok(())` from dispatch is no evidence a slot is live).
- `cargo nextest run -p flui-app` 191/191; workspace clippy `-D warnings` clean; `just ci` exit 0; conformance + port-check + rustdoc `-D warnings` + taplo + typos clean.
- Three review rounds: full two-stage review, then two narrow re-verifications with empirical mutant runs — final verdict CLEAN at 8f0dc9aa.
- Follow-up filed: #605 (HeadlessPlatform instance-local window-id minting).

Part of #555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du3J3bDcsRaSU3tKgYKvni